### PR TITLE
map using char *

### DIFF
--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -3,6 +3,7 @@
 #include <cfloat>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 #include <string>
 #include <vector>
 
@@ -28,26 +29,16 @@ struct node_t {
 
 enum DataType { REL, NODE, LABEL, BOOL, INT, DOUBLE, STRING };
 
-struct Property {
+class Property {
 
 public:
     Property(){};
 
     Property(string name, DataType dataType) : name(name), dataType(dataType){};
 
-    bool operator==(const Property& o) const {
-        return dataType == o.dataType && name.compare(o.name) == 0;
-    }
-
 public:
     string name{};
     DataType dataType{};
-};
-
-struct hash_Property {
-    size_t operator()(Property const& property) const {
-        return (hash<string>{}(property.name) * 31) + property.dataType;
-    }
 };
 
 uint8_t getDataTypeSize(DataType dataType);
@@ -65,6 +56,16 @@ enum Direction : uint8_t { FWD = 0, BWD = 1 };
 const vector<Direction> DIRS = {FWD, BWD};
 
 Direction operator!(Direction& direction);
+
+// c-like string equalTo.
+struct charArrayEqualTo {
+    bool operator()(const char* lhs, const char* rhs) const { return strcmp(lhs, rhs) == 0; }
+};
+
+// c-like string hasher.
+struct charArrayHasher {
+    size_t operator()(const char* key) const { return std::_Hash_bytes(key, strlen(key), 31); }
+};
 
 } // namespace common
 } // namespace graphflow

--- a/src/loader/csv_reader.cpp
+++ b/src/loader/csv_reader.cpp
@@ -33,6 +33,7 @@ CSVReader::CSVReader(const string& fname, const char tokenSeparator, uint64_t bl
 }
 
 CSVReader::~CSVReader() {
+    fclose(f);
     delete[](line);
 }
 
@@ -53,7 +54,6 @@ bool CSVReader::hasNextLine() {
     };
     linePtrStart = linePtrEnd = -1;
     if (feof(f)) {
-        fclose(f);
         isEndOfBlock = false;
         return false;
     }
@@ -89,12 +89,8 @@ bool CSVReader::hasNextToken() {
     while (tokenSeparator != line[linePtrEnd] && '\n' != line[linePtrEnd]) {
         linePtrEnd++;
     }
-    line[linePtrEnd] = 10;
+    line[linePtrEnd] = 0;
     return true;
-}
-
-unique_ptr<string> CSVReader::getNodeID() {
-    return getString();
 }
 
 int32_t CSVReader::getInteger() {
@@ -121,10 +117,9 @@ uint8_t CSVReader::getBoolean() {
     throw invalid_argument("invalid boolean val.");
 }
 
-unique_ptr<string> CSVReader::getString() {
-    auto a = make_unique<string>(line + linePtrStart, linePtrEnd - linePtrStart);
+char* CSVReader::getString() {
     nextTokenIsNotProcessed = false;
-    return a;
+    return line + linePtrStart;
 }
 
 } // namespace loader

--- a/src/loader/include/adj_lists_loader_helper.h
+++ b/src/loader/include/adj_lists_loader_helper.h
@@ -4,6 +4,7 @@
 #include "spdlog/spdlog.h"
 
 #include "src/loader/include/in_mem_structures.h"
+#include "src/loader/include/thread_pool.h"
 #include "src/loader/include/utils.h"
 #include "src/storage/include/catalog.h"
 #include "src/storage/include/graph.h"
@@ -23,8 +24,9 @@ typedef vector<vector<vector<unique_ptr<InMemPropertyLists>>>> dirLabelPropertyI
 class AdjListsLoaderHelper {
 
 public:
-    AdjListsLoaderHelper(RelLabelDescription& description, const Graph& graph,
-        const Catalog& catalog, const string outputDirectory, shared_ptr<spdlog::logger> logger);
+    AdjListsLoaderHelper(RelLabelDescription& description, ThreadPool& threadPool,
+        const Graph& graph, const Catalog& catalog, const string outputDirectory,
+        shared_ptr<spdlog::logger> logger);
 
     inline AdjListHeaders& getAdjListHeaders(Direction dir, label_t nodeLabel) {
         return (*dirLabelAdjListHeaders)[dir][nodeLabel];
@@ -68,6 +70,7 @@ private:
 
     shared_ptr<spdlog::logger> logger;
     RelLabelDescription& description;
+    ThreadPool& threadPool;
     const Graph& graph;
     const Catalog& catalog;
     const string outputDirectory;

--- a/src/loader/include/adj_rels_loader_helper.h
+++ b/src/loader/include/adj_rels_loader_helper.h
@@ -4,6 +4,7 @@
 #include "spdlog/spdlog.h"
 
 #include "src/loader/include/in_mem_structures.h"
+#include "src/loader/include/thread_pool.h"
 #include "src/loader/include/utils.h"
 #include "src/storage/include/catalog.h"
 #include "src/storage/include/graph.h"
@@ -20,8 +21,9 @@ typedef vector<vector<unique_ptr<InMemAdjRels>>> dirLabelAdjRels_t;
 class AdjRelsLoaderHelper {
 
 public:
-    AdjRelsLoaderHelper(RelLabelDescription& description, const Graph& graph,
-        const Catalog& catalog, const string outputDirectory, shared_ptr<spdlog::logger> logger);
+    AdjRelsLoaderHelper(RelLabelDescription& description, ThreadPool& threadPool,
+        const Graph& graph, const Catalog& catalog, const string outputDirectory,
+        shared_ptr<spdlog::logger> logger);
 
     void saveToFile();
 
@@ -44,6 +46,7 @@ private:
 
     shared_ptr<spdlog::logger> logger;
     RelLabelDescription& description;
+    ThreadPool& threadPool;
     const Graph& graph;
     const Catalog& catalog;
     const string outputDirectory;

--- a/src/loader/include/csv_reader.h
+++ b/src/loader/include/csv_reader.h
@@ -29,11 +29,10 @@ public:
     bool skipTokenIfNull();
     void skipToken();
 
-    unique_ptr<string> getNodeID();
     int32_t getInteger();
     double_t getDouble();
     uint8_t getBoolean();
-    unique_ptr<string> getString();
+    char* getString();
 
 private:
     FILE* f;

--- a/src/loader/include/graph_loader.h
+++ b/src/loader/include/graph_loader.h
@@ -31,8 +31,7 @@ public:
 private:
     unique_ptr<nlohmann::json> readMetadata();
 
-    void assignLabels(
-        unordered_map<string, label_t>& stringToLabelMap, const nlohmann::json& fileDescriptions);
+    void assignLabels(stringToLabelMap_t& map, const nlohmann::json& fileDescriptions);
     void setCardinalities(Catalog& catalog, const nlohmann::json& metadata);
     void setSrcDstNodeLabelsForRelLabels(Catalog& catalog, const nlohmann::json& metadata);
 

--- a/src/loader/include/nodes_loader.h
+++ b/src/loader/include/nodes_loader.h
@@ -39,7 +39,7 @@ private:
 
     // Task Helpers
 
-    static unique_ptr<vector<uint8_t*>> getBuffersForWritingNodeProperties(
+    static unique_ptr<vector<unique_ptr<uint8_t[]>>> getBuffersForWritingNodeProperties(
         const vector<Property>& propertyMap, uint64_t numElements,
         shared_ptr<spdlog::logger> logger);
 

--- a/src/loader/include/rels_loader.h
+++ b/src/loader/include/rels_loader.h
@@ -8,7 +8,6 @@
 #include "src/loader/include/adj_rels_loader_helper.h"
 #include "src/loader/include/csv_reader.h"
 #include "src/loader/include/thread_pool.h"
-#include "src/storage/include/structures/lists.h"
 
 namespace graphflow {
 namespace loader {

--- a/src/loader/include/utils.h
+++ b/src/loader/include/utils.h
@@ -16,15 +16,16 @@ namespace loader {
 class NodeIDMap {
 
 public:
-    NodeIDMap(uint64_t size) : nodeIDToOffsetMapping{unordered_map<string, node_offset_t>(size)} {};
+    NodeIDMap(uint64_t size) : nodeIDToOffsetMapping{size} {};
+    ~NodeIDMap();
 
-    void setOffset(string nodeID, node_offset_t offset);
-    node_offset_t getOffset(string& nodeID);
-    bool hasNodeID(string& nodeID);
+    void setOffset(const char* nodeID, node_offset_t offset);
+    node_offset_t getOffset(const char* nodeID);
     void merge(NodeIDMap& localMap);
 
 private:
-    unordered_map<string, node_offset_t> nodeIDToOffsetMapping;
+    unordered_map<const char*, node_offset_t, charArrayHasher, charArrayEqualTo>
+        nodeIDToOffsetMapping;
 };
 
 // Holds information about a rel label that is needed to construct adjRels and adjLists indexes,

--- a/src/loader/utils.cpp
+++ b/src/loader/utils.cpp
@@ -7,16 +7,22 @@
 namespace graphflow {
 namespace loader {
 
-void NodeIDMap::setOffset(string nodeID, node_offset_t offset) {
-    nodeIDToOffsetMapping.insert(make_pair(nodeID, offset));
+NodeIDMap::~NodeIDMap() {
+    for (auto& a : nodeIDToOffsetMapping) {
+        delete[] a.first;
+    }
 }
 
-node_offset_t NodeIDMap::getOffset(string& nodeID) {
+void NodeIDMap::setOffset(const char* nodeID, node_offset_t offset) {
+    auto len = strlen(nodeID);
+    auto nodeIDcopy = new char[len + 1];
+    memcpy(nodeIDcopy, nodeID, len);
+    nodeIDcopy[len] = 0;
+    nodeIDToOffsetMapping.insert({{nodeIDcopy, offset}});
+}
+
+node_offset_t NodeIDMap::getOffset(const char* nodeID) {
     return nodeIDToOffsetMapping[nodeID];
-}
-
-bool NodeIDMap::hasNodeID(string& nodeID) {
-    return nodeIDToOffsetMapping.find(nodeID) != nodeIDToOffsetMapping.end();
 }
 
 void NodeIDMap::merge(NodeIDMap& localMap) {

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -22,6 +22,8 @@ class GraphLoader;
 namespace graphflow {
 namespace storage {
 
+typedef unordered_map<const char*, label_t, charArrayHasher, charArrayEqualTo> stringToLabelMap_t;
+
 class Catalog {
     friend class graphflow::loader::GraphLoader;
     friend class bitsery::Access;
@@ -32,10 +34,10 @@ public:
     inline uint32_t getNodeLabelsCount() const { return stringToNodeLabelMap.size(); }
     inline uint32_t getRelLabelsCount() const { return stringToRelLabelMap.size(); }
 
-    inline const label_t& getNodeLabelFromString(string& label) const {
+    inline const label_t& getNodeLabelFromString(const char* label) const {
         return stringToNodeLabelMap.at(label);
     }
-    inline const label_t& getRelLabelFromString(string& label) const {
+    inline const label_t& getRelLabelFromString(const char* label) const {
         return stringToRelLabelMap.at(label);
     }
 
@@ -68,9 +70,12 @@ private:
     void saveToFile(const string& directory);
     void readFromFile(const string& directory);
 
+    void serializeStringToLabelMap(fstream& f, stringToLabelMap_t& map);
+    void deserializeStringToLabelMap(fstream& f, stringToLabelMap_t& map);
+
 private:
-    unordered_map<string, label_t> stringToNodeLabelMap;
-    unordered_map<string, label_t> stringToRelLabelMap;
+    stringToLabelMap_t stringToNodeLabelMap;
+    stringToLabelMap_t stringToRelLabelMap;
     vector<vector<Property>> nodePropertyMaps;
     vector<vector<Property>> relPropertyMaps;
     vector<vector<label_t>> relLabelToSrcNodeLabels, relLabelToDstNodeLabels;


### PR DESCRIPTION
** changed NodeIdMap and StringToLabelMap (in catalog.h) to work with const char * keys. This improves the loading time by ~20%. 

As a consequence, we are not able to ser/de StringToLabelMap to file. I was using a plugin for serializing at whatever place we needed it, and didn't care about performance or completeness. This plugin doesn't directly support sterilizing char * - so I have commented the serializing part in this PR. I want to think about how we should go about serializing/deserializing - maybe writing our own simple serde is a good idea. 