### PR TITLE
Add QueryProcessor with Sync Task System

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -3,8 +3,8 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "common",
     srcs = [
-        "types.cpp",
         "compression_scheme.cpp",
+        "types.cpp",
         "vector/node_vector.cpp",
     ],
     hdrs = [
@@ -18,4 +18,12 @@ cc_library(
     deps = [
         "@martinus_robin_hood_hashing",
     ],
+)
+
+cc_library(
+    name = "timer",
+    hdrs = [
+        "include/timer.h",
+    ],
+    visibility = ["//visibility:public"],
 )

--- a/src/common/include/timer.h
+++ b/src/common/include/timer.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <chrono>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <spdlog/sinks/stdout_sinks.h>
+#include <spdlog/spdlog.h>
+
+using namespace std;
+
+namespace graphflow {
+namespace common {
+
+class Timer {
+public:
+    Timer(const string& name)
+        : logger{spdlog::stdout_logger_st("timer")}, name{name},
+          start{chrono::high_resolution_clock::now()} {
+        Timer::logger->info("{} started.", name);
+    };
+
+    ~Timer() { spdlog::drop("timer"); }
+
+    void stop() {
+        checkpoint = chrono::high_resolution_clock::now();
+        stopped = true;
+    }
+
+    chrono::milliseconds getDuration() {
+        if (stopped) {
+            return duration_cast<chrono::milliseconds>(checkpoint - start);
+        }
+        throw new invalid_argument("Timer still running.");
+    }
+
+    void logCheckpoint(const string& checkpointName) {
+        auto currentCheckpoint = chrono::high_resolution_clock::now();
+        Timer::logger->info(
+            "Checkpoint:{}. Time since last checkpoint {} ms. Time since start {} ms.", name,
+            duration_cast<chrono::milliseconds>(currentCheckpoint - checkpoint).count(),
+            duration_cast<chrono::milliseconds>(currentCheckpoint - start).count());
+        checkpoint = currentCheckpoint;
+    }
+
+private:
+    shared_ptr<spdlog::logger> logger;
+    const string name;
+    bool stopped{false};
+    chrono::time_point<chrono::high_resolution_clock> start, checkpoint;
+};
+
+} // namespace common
+} // namespace graphflow

--- a/src/loader/utils.cpp
+++ b/src/loader/utils.cpp
@@ -2,6 +2,8 @@
 
 #include <string.h>
 
+#include <unordered_map>
+
 #include "src/common/include/configs.h"
 
 namespace graphflow {

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -1,7 +1,19 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
-    name = "processor",
+    name = "morsel",
+    hdrs = [
+        "include/task_system/morsel.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/common",
+        "//src/storage:graph",
+    ],
+)
+
+cc_library(
+    name = "operators",
     srcs = [
         "operator/column_reader/adj_column_extend.cpp",
         "operator/column_reader/column_reader.cpp",
@@ -10,7 +22,6 @@ cc_library(
         "operator/list_reader/adj_list_extend.cpp",
         "operator/list_reader/list_reader.cpp",
         "operator/list_reader/rel_property_list_reader.cpp",
-        "query_plan.cpp",
         "operator/scan/scan.cpp",
         "operator/sink/sink.cpp",
     ],
@@ -27,12 +38,50 @@ cc_library(
         "include/operator/sink/sink.h",
         "include/operator/tuple/data_chunk.h",
         "include/operator/tuple/data_chunks.h",
-        "include/query_plan.h",
-        "include/task_system/morsel.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "morsel",
         "//src/common",
+        "//src/storage:graph",
+    ],
+)
+
+cc_library(
+    name = "plan",
+    srcs = [
+        "plan/plan.cpp",
+    ],
+    hdrs = [
+        "include/plan/plan.h",
+        "include/plan/plan_output.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "operators",
+        "//src/common",
+        "//src/storage:graph",
+    ],
+)
+
+cc_library(
+    name = "processor",
+    srcs = [
+        "processor.cpp",
+        "task_system/task.cpp",
+        "task_system/task_queue.cpp",
+    ],
+    hdrs = [
+        "include/processor.h",
+        "include/task_system/morsel.h",
+        "include/task_system/task.h",
+        "include/task_system/task_queue.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "plan",
+        "//src/common",
+        "//src/common:timer",
         "//src/storage:graph",
     ],
 )

--- a/src/processor/include/plan/plan.h
+++ b/src/processor/include/plan/plan.h
@@ -5,6 +5,7 @@
 
 #include "src/processor/include/operator/operator.h"
 #include "src/processor/include/operator/sink/sink.h"
+#include "src/processor/include/plan/plan_output.h"
 
 namespace graphflow {
 namespace processor {
@@ -21,7 +22,9 @@ public:
 
     void run();
 
-    uint64_t getNumTuples() { return ((Sink*)lastOperator.get())->getNumTuples(); }
+    unique_ptr<PlanOutput> getPlanOutput() {
+        return make_unique<PlanOutput>(((Sink*)lastOperator.get())->getNumTuples());
+    }
 
 private:
     unique_ptr<Operator> lastOperator;

--- a/src/processor/include/plan/plan_output.h
+++ b/src/processor/include/plan/plan_output.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+
+namespace graphflow {
+namespace processor {
+
+class PlanOutput {
+
+public:
+    PlanOutput(const uint64_t& numOutputTuples) : numOutputTuples(numOutputTuples) {}
+    PlanOutput() : PlanOutput(0){};
+
+    uint64_t getNumOutputTuples() { return numOutputTuples; }
+
+    static void aggregate(vector<unique_ptr<PlanOutput>>& threadOutputs, PlanOutput& result) {
+        result.numOutputTuples = 0;
+        for (auto& threadOutput : threadOutputs) {
+            result.numOutputTuples += threadOutput->getNumOutputTuples();
+        }
+    }
+
+protected:
+    uint64_t numOutputTuples = 0;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/processor.h
+++ b/src/processor/include/processor.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <utility>
+
+#include "src/processor/include/task_system/task_queue.h"
+#include "src/storage/include/graph.h"
+
+using namespace graphflow::storage;
+
+namespace graphflow {
+namespace processor {
+
+class QueryProcessor {
+
+public:
+    QueryProcessor(Graph& graph, const uint64_t& numThreads);
+    ~QueryProcessor();
+
+    unique_ptr<pair<PlanOutput, chrono::milliseconds>> execute(
+        unique_ptr<QueryPlan>& plan, const uint64_t& maxNumThreads);
+
+    void run();
+
+private:
+    Graph& graph;
+    TaskQueue queue;
+    condition_variable ready;
+    bool stopThreads{false};
+    vector<thread> threads;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/task_system/morsel.h
+++ b/src/processor/include/task_system/morsel.h
@@ -3,6 +3,8 @@
 #include <cstdint>
 #include <mutex>
 
+#include "src/common/include/types.h"
+
 using namespace std;
 using namespace graphflow::common;
 

--- a/src/processor/include/task_system/task.h
+++ b/src/processor/include/task_system/task.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "src/common/include/timer.h"
+#include "src/processor/include/plan/plan.h"
+#include "src/processor/include/plan/plan_output.h"
+
+using namespace std;
+
+namespace graphflow {
+namespace processor {
+
+using lock_t = unique_lock<mutex>;
+
+class Task {
+
+public:
+    Task(QueryPlan* plan, Graph& graph, const uint64_t& maxNumThreads)
+        : plan{plan}, graph{graph}, maxNumThreads{maxNumThreads}, timer{"task-timer"} {}
+
+    void run();
+
+    inline bool isComplete() {
+        return numThreadsRegistered > 0 && numThreadsFinished == numThreadsRegistered;
+    }
+
+    inline bool canRegister() {
+        return 0 == numThreadsFinished && maxNumThreads > numThreadsRegistered;
+    }
+
+    unique_ptr<pair<PlanOutput, chrono::milliseconds>> getResult() { return move(result); };
+
+private:
+    bool registerThread();
+    void deregisterThread(unique_ptr<PlanOutput> planOutput);
+
+    void aggregatePlanOutputs();
+
+private:
+    mutex mtx;
+    QueryPlan* plan;
+    Graph& graph;
+    atomic_uint64_t maxNumThreads{0}, numThreadsFinished{0}, numThreadsRegistered{0};
+    Timer timer;
+    unique_ptr<pair<PlanOutput, chrono::milliseconds>> result;
+    vector<unique_ptr<PlanOutput>> threadOutputs;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/task_system/task_queue.h
+++ b/src/processor/include/task_system/task_queue.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "src/processor/include/task_system/task.h"
+
+namespace graphflow {
+namespace processor {
+
+// TaskQueue manages Tasks. At present, we have the invariant that there cannot be 2 tasks that
+// are running concurrently.
+class TaskQueue {
+
+public:
+    shared_ptr<Task> getTask();
+
+    void push(shared_ptr<Task> task);
+
+private:
+    mutex mtx;
+    deque<shared_ptr<Task>> taskQueue;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/plan/plan.cpp
+++ b/src/processor/plan/plan.cpp
@@ -1,4 +1,4 @@
-#include "src/processor/include/query_plan.h"
+#include "src/processor/include/plan/plan.h"
 
 namespace graphflow {
 namespace processor {

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -1,0 +1,48 @@
+#include "src/processor/include/processor.h"
+
+#include <iostream>
+
+namespace graphflow {
+namespace processor {
+
+QueryProcessor::QueryProcessor(Graph& graph, const uint64_t& numThreads) : graph{graph} {
+    for (auto n = 0u; n < numThreads; ++n) {
+        threads.emplace_back([&] { run(); });
+    }
+}
+
+QueryProcessor::~QueryProcessor() {
+    stopThreads = true;
+    for (auto& thread : threads) {
+        thread.join();
+    }
+}
+
+// This function is currently blocking. In the future, this should async and return the result
+// wrapped in Future for syncing with the runner.
+unique_ptr<pair<PlanOutput, chrono::milliseconds>> QueryProcessor::execute(
+    unique_ptr<QueryPlan>& plan, const uint64_t& maxNumThreads) {
+    auto task = make_shared<Task>(plan.get(), graph, maxNumThreads);
+    queue.push(task);
+    while (!task->isComplete()) {
+        /*busy wait*/
+    }
+    return task->getResult();
+}
+
+void QueryProcessor::run() {
+    while (true) {
+        if (stopThreads) {
+            break;
+        }
+        auto task = queue.getTask();
+        if (!task) {
+            /*busy wait*/
+            continue;
+        }
+        task->run();
+    }
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/task_system/task.cpp
+++ b/src/processor/task_system/task.cpp
@@ -1,0 +1,43 @@
+#include "src/processor/include/task_system/task.h"
+
+namespace graphflow {
+namespace processor {
+
+void Task::run() {
+    if (!registerThread()) {
+        return;
+    }
+    QueryPlan planCopy{*plan};
+    planCopy.initialize(&graph);
+    planCopy.run();
+    deregisterThread(planCopy.getPlanOutput());
+}
+
+bool Task::registerThread() {
+    lock_t lck{mtx};
+    if (canRegister()) {
+        numThreadsRegistered++;
+        return true;
+    }
+    return false;
+}
+
+void Task::deregisterThread(unique_ptr<PlanOutput> planOutput) {
+    lock_t lck{mtx};
+    threadOutputs.emplace_back(planOutput.release());
+    if (numThreadsFinished == numThreadsRegistered - 1) {
+        // last thread aggregates planOutputs from all threads.
+        timer.stop();
+        aggregatePlanOutputs();
+    }
+    ++numThreadsFinished;
+}
+
+void Task::aggregatePlanOutputs() {
+    result = make_unique<pair<PlanOutput, chrono::milliseconds>>();
+    PlanOutput::aggregate(threadOutputs, result->first);
+    result->second = timer.getDuration();
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/task_system/task_queue.cpp
+++ b/src/processor/task_system/task_queue.cpp
@@ -1,0 +1,24 @@
+#include "src/processor/include/task_system/task_queue.h"
+
+namespace graphflow {
+namespace processor {
+
+shared_ptr<Task> TaskQueue::getTask() {
+    lock_t lck{mtx};
+    if (taskQueue.empty()) {
+        return nullptr;
+    }
+    if (!taskQueue[0]->canRegister()) {
+        taskQueue.pop_front();
+        return nullptr;
+    }
+    return taskQueue[0];
+}
+
+void TaskQueue::push(shared_ptr<Task> task) {
+    lock_t lock{mtx};
+    taskQueue.push_back(task);
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/src/runner/create_plan.cpp
+++ b/src/runner/create_plan.cpp
@@ -2,7 +2,7 @@
 #include "src/processor/include/operator/list_reader/adj_list_extend.h"
 #include "src/processor/include/operator/scan/scan.h"
 #include "src/processor/include/operator/sink/sink.h"
-#include "src/processor/include/query_plan.h"
+#include "src/processor/include/plan/plan.h"
 
 using namespace graphflow::processor;
 

--- a/src/runner/data_loader.cpp
+++ b/src/runner/data_loader.cpp
@@ -4,7 +4,6 @@
 
 #include "args.hxx"
 #include "spdlog/spdlog.h"
-#include <bits/unique_ptr.h>
 
 #include "src/loader/include/graph_loader.h"
 

--- a/src/storage/include/structures/column.h
+++ b/src/storage/include/structures/column.h
@@ -2,8 +2,6 @@
 
 #include <string.h>
 
-#include <bits/unique_ptr.h>
-
 #include "src/common/include/types.h"
 #include "src/common/include/vector/node_vector.h"
 #include "src/storage/include/structures/common.h"

--- a/test/processor/BUILD.bazel
+++ b/test/processor/BUILD.bazel
@@ -5,6 +5,7 @@ cc_test(
     srcs = [
         "operator/property_reader/node_property_column_reader_test.cpp",
         "operator/scan/scan_test.cpp",
+        "processor_test.cpp"
     ],
     copts = [
         "-Iexternal/gtest/include",

--- a/test/processor/processor_test.cpp
+++ b/test/processor/processor_test.cpp
@@ -1,0 +1,29 @@
+#include "gtest/gtest.h"
+
+#include "src/processor/include/operator/scan/scan.h"
+#include "src/processor/include/processor.h"
+
+using namespace graphflow::processor;
+
+class ProcessorTest : public ::testing::Test {
+
+protected:
+    void SetUp() override {}
+
+    void TearDown() override { spdlog::shutdown(); }
+};
+
+class GraphStub : public Graph {
+
+public:
+    GraphStub() {}
+};
+
+TEST(ProcessorTests, MultiThreadedScanTest) {
+    unique_ptr<Graph> graph = make_unique<GraphStub>();
+    auto morsel = make_shared<MorselDescSingleLabelNodeIDs>(1, 1025012);
+    auto plan = make_unique<QueryPlan>(new Sink(new ScanSingleLabel("a", morsel)));
+    auto processor = make_unique<QueryProcessor>(*graph, 10);
+    auto result = processor->execute(plan, 3);
+    ASSERT_EQ(result->first.getNumOutputTuples(), 1025012 /* max_offset */ + 1);
+}


### PR DESCRIPTION
The PR adds a QueryProcessor acting as a Task system. The processor given a plan and a number of threads creates Task(s) which are pushed to a queue. Each thread is stealing from the Queue and once all threads executed and are done, a notifyAll done is called.

Currently this implementation is synchronous i.e., makes the main thread block using wait() till the queue is empty and all threads executed which would work fine for a CLI. I spent time exploring futures and async execution and made some plans to incorporate it in the future.