### PR TITLE
Adding graphDebugInfo support to the server

### DIFF
--- a/docs/gfdb_endpoints.http
+++ b/docs/gfdb_endpoints.http
@@ -1,15 +1,36 @@
 @prefix = http://localhost:3110
 
 @path_to_serialized_data = ...
+
 @path_to_serialized_query_plan = ...
 
-### Return a list of all API endpoints with description and usage.
+### Load the serialized graph data from the path.
 #   Method:
-#       GET
+#       POST
 #   URL:
-#       /help
+#       /load
+#   DataParams:
+#       <path_to_serialized_data>
 
-GET {{prefix}}/help
+POST {{prefix}}/load
+content-type: text/plain;charset=UTF-8
+
+{{path_to_serialized_data}}
+
+### Execute a query plan.
+#   Method:
+#       POST
+#   URL:
+#       /execute
+#   DataParams:
+#       <path_to_serialized_query_plan>
+#       <numThreads>
+
+POST {{prefix}}/execute
+content-type: text/plain;charset=UTF-8
+
+{{path_to_serialized_query_plan}}
+4
 
 ### Change the bufferPool size.
 #   Method: 
@@ -45,6 +66,24 @@ content-type: text/plain;charset=UTF-8
 
 4
 
+### Gets debug information about the database.
+#   Method:
+#       GET
+#   URL:
+#       /graphDebugInfo
+
+GET {{prefix}}/graphDebugInfo
+content-type: text/plain;charset=UTF-8
+
+
+### Return a list of all API endpoints with description and usage.
+#   Method:
+#       GET
+#   URL:
+#       /help
+
+GET {{prefix}}/help
+
 ### Gets the current state of session.
 #   Method:
 #       GET
@@ -52,19 +91,6 @@ content-type: text/plain;charset=UTF-8
 #       /session
 
 GET {{prefix}}/session
-
-### Load the serialized graph data from the path.
-#   Method:
-#       POST
-#   URL:
-#       /load
-#   DataParams:
-#       <path_to_serialized_data>
-
-POST {{prefix}}/load
-content-type: text/plain;charset=UTF-8
-
-{{path_to_serialized_data}}
 
 ### Print the query plan in a human-readable format.
 #   Method:
@@ -78,18 +104,3 @@ GET {{prefix}}/prettyPlan
 content-type: text/plain;charset=UTF-8
 
 {{path_to_serialized_query_plan}}
-
-### Execute a query plan.
-#   Method:
-#       POST
-#   URL:
-#       /execute
-#   DataParams:
-#       <path_to_serialized_query_plan>
-#       <numThreads>
-
-POST {{prefix}}/execute
-content-type: text/plain;charset=UTF-8
-
-{{path_to_serialized_query_plan}}
-3

--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -16,8 +16,8 @@ const uint64_t CSV_READING_BLOCK_SIZE = 1 << 23;
 // storing adjacency lists.
 const uint64_t PAGE_SIZE = 1 << 12;
 
-// The default amount of memory pre-allocated to the buffer pool (= 128GB).
-const uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 37;
+// The default amount of memory pre-allocated to the buffer pool (= 1GB).
+const uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 30;
 
 } // namespace common
 } // namespace graphflow

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -57,6 +57,7 @@ struct nodeID_t {
 };
 
 enum DataType { REL, NODE, LABEL, BOOL, INT, DOUBLE, STRING };
+const string DataTypeNames[] = {"REL", "NODE", "LABEL", "BOOL", "INT", "DOUBLE", "STRING"};
 
 class Property {
 
@@ -76,6 +77,7 @@ DataType getDataType(const std::string& dataTypeString);
 
 // Rel Label Cardinality
 enum Cardinality : uint8_t { MANY_MANY, MANY_ONE, ONE_MANY, ONE_ONE };
+const string CardinalityNames[] = {"MANY_MANY", "MANY_ONE", "ONE_MANY", "ONE_ONE"};
 
 Cardinality getCardinality(const string& cardinalityString);
 

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -26,6 +26,7 @@ unique_ptr<pair<PlanOutput, chrono::milliseconds>> QueryProcessor::execute(
     queue.push(task);
     while (!task->isComplete()) {
         /*busy wait*/
+        this_thread::sleep_for(chrono::milliseconds(10));
     }
     return task->getResult();
 }
@@ -37,7 +38,7 @@ void QueryProcessor::run() {
         }
         auto task = queue.getTask();
         if (!task) {
-            /*busy wait*/
+            this_thread::sleep_for(chrono::milliseconds(10));
             continue;
         }
         task->run();

--- a/src/runner/BUILD.bazel
+++ b/src/runner/BUILD.bazel
@@ -47,6 +47,7 @@ cc_binary(
     linkopts = ["-lpthread"],
     deps = [
         "server",
+        "@nlohmann_json",
         "@Taywee_args",
     ],
 )

--- a/src/runner/include/server/server.h
+++ b/src/runner/include/server/server.h
@@ -42,6 +42,9 @@ private:
     // endpoint: [POST] .../execute
     void registerPOSTExecute(unique_ptr<router_t>& router);
 
+    // endpoint: [GET] .../graphDebugInfo
+    void registerGETGraphDebugInfo(unique_ptr<router_t>& router);
+
 private:
     Session session;
     nlohmann::json helpCatalog;

--- a/src/runner/include/server/session.h
+++ b/src/runner/include/server/session.h
@@ -30,12 +30,16 @@ public:
 
     unique_ptr<nlohmann::json> execute(const string& path, const uint32_t& numThreads);
 
+    unique_ptr<nlohmann::json> getGraphDebugInfo();
+
+    void throwErrorIfGraphNotInitialized();
+    void throwErrorIfPathIsEmpty(const string& path);
+
 public:
     uint64_t bufferPoolSize = DEFAULT_BUFFER_POOL_SIZE;
     uint64_t numProcessorThreads = thread::hardware_concurrency();
     unique_ptr<Graph> graph;
-    unique_ptr<QueryProcessor> processor =
-        make_unique<QueryProcessor>(thread::hardware_concurrency());
+    unique_ptr<QueryProcessor> processor = make_unique<QueryProcessor>(1);
 };
 
 } // namespace runner

--- a/src/runner/server/server.cpp
+++ b/src/runner/server/server.cpp
@@ -16,6 +16,7 @@ void Server::run(const string& host, int port) {
     registerPOSTLoad(router);
     registerGETPrettyPlan(router);
     registerPOSTExecute(router);
+    registerGETGraphDebugInfo(router);
 
     try {
         using traits_t = restinio::traits_t<restinio::asio_timer_manager_t,
@@ -185,6 +186,22 @@ void Server::registerPOSTExecute(unique_ptr<router_t>& router) {
                 .set_body(session.execute(plan_path, numThreads)->dump())
                 .done();
         } catch (exception& ex) { createErrorResponse(req, ex); }
+        return restinio::request_accepted();
+    });
+}
+
+void Server::registerGETGraphDebugInfo(unique_ptr<router_t>& router) {
+    nlohmann::json json;
+    json["method"] = "GET";
+    json["url"] = "/graphDebugInfo";
+    json["desc"] = "Gets general information about the loaded graph database.";
+    helpCatalog["help"].push_back(json);
+    router->http_get("/graphDebugInfo", [&](request_handle_t req, auto) {
+        req->create_response()
+            .append_header(restinio::http_field::content_type, "text/plain; charset=utf-8")
+            .set_body(session.getGraphDebugInfo()->dump())
+            .done();
+
         return restinio::request_accepted();
     });
 }

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -22,6 +22,7 @@ cc_library(
         "file_handle",
         "//src/common",
         "@gabime_spdlog",
+        "@nlohmann_json",
     ],
 )
 
@@ -76,6 +77,7 @@ cc_library(
         "//src/common",
         "@fraillt_bitsery",
         "@gabime_spdlog",
+        "@nlohmann_json",
     ],
 )
 

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -97,5 +97,10 @@ void BufferManager::readNewPageIntoFrame(Frame* frame, FileHandle& fileHandle, u
     fileHandle.swizzle(pageIdx, reinterpret_cast<uint64_t>(frame));
 }
 
+unique_ptr<nlohmann::json> BufferManager::debugInfo() {
+    return make_unique<nlohmann::json>(
+        nlohmann::json{{"BufferManager", {{"maxPages", maxPages}, {"usedPages", usedPages}}}});
+}
+
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/include/buffer_manager.h
+++ b/src/storage/include/buffer_manager.h
@@ -4,6 +4,7 @@
 #include <mutex>
 #include <vector>
 
+#include "nlohmann/json.hpp"
 #include "spdlog/spdlog.h"
 
 #include "src/common/include/configs.h"
@@ -40,6 +41,7 @@ public:
 
     const char* pin(FileHandle& fileHandle, uint32_t pageIdx);
     void unpin(FileHandle& fileHandle, uint32_t pageIdx);
+    unique_ptr<nlohmann::json> debugInfo();
 
 private:
     uint64_t evict();

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "bitsery/bitsery.h"
+#include "nlohmann/json.hpp"
 #include "spdlog/sinks/stdout_sinks.h"
 #include "spdlog/spdlog.h"
 
@@ -39,6 +40,7 @@ public:
     inline const label_t& getNodeLabelFromString(const char* label) const {
         return stringToNodeLabelMap.at(label);
     }
+
     inline const label_t& getRelLabelFromString(const char* label) const {
         return stringToRelLabelMap.at(label);
     }
@@ -61,12 +63,16 @@ public:
         return getPropertyMapForRelLabel(relLabel).at(name).idx;
     }
 
+    const string getStringNodeLabel(const label_t label) const;
+
     const vector<label_t>& getRelLabelsForNodeLabelDirection(
         const label_t& nodeLabel, const Direction& dir) const;
     const vector<label_t>& getNodeLabelsForRelLabelDir(
         const label_t& relLabel, const Direction& dir) const;
 
     bool isSingleCaridinalityInDir(const label_t& relLabel, const Direction& dir) const;
+
+    unique_ptr<nlohmann::json> debugInfo();
 
 private:
     Catalog() : logger{spdlog::get("storage")} {};
@@ -79,6 +85,10 @@ private:
 
     void serializeStringToLabelMap(fstream& f, stringToLabelMap_t& map);
     void deserializeStringToLabelMap(fstream& f, stringToLabelMap_t& map);
+
+    string getNodeLabelsString(vector<label_t> nodeLabels);
+
+    unique_ptr<nlohmann::json> getPropertiesJson(const unordered_map<string, Property>& properties);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/include/graph.h
+++ b/src/storage/include/graph.h
@@ -46,6 +46,8 @@ public:
 
     inline const string& getPath() const { return path; }
 
+    unique_ptr<nlohmann::json> debugInfo();
+
 protected:
     Graph() : logger{spdlog::stdout_logger_st("storage")} {};
 


### PR DESCRIPTION
This PR is a warmup for me to add debug functionality to the server to print some information about the loaded database in the server. It adds debugInfo functions to Graph, Catalog, and BufferManager, which return jsons and returns graph.debugInfo() back to the client. 

I am submitting this with two known bugs that I didn't bother fixing yet because I think @g31pranjal will be in a better position to fix them.

Bug 1: If you do the following: 
1. /load
2. /bufferPoolSize twice you get this error:
>"error": "Cannot open file: /Users/semihsalihoglu/projects/vs-code-projects/graphflowdb/data/gf-db-files//n-7-url.col"
changing the bufferPoolSize resets the graph and recreates it. It may be that some file handle is not being released quickly enough.

Bug 2: If you do the above two steps and then do this:
3. /load again
Then you get this error: 

> logger with name 'storage' already exists

I am guessing this is because this code in bufferPoolSize (or in loadGraph) does not work properly, possibly because we are unable to delete the first graph appropriately, so maybe some component of the graph (e.g., BufferManager) is not being destroyed. The reason I'm guessing this might be the problem is that we have "logger{spdlog::get("storage")" line in many files under storage (e.g., buffer_manager.cpp or nodes_store.cpp). But I didn't debug this so this is just a guess.
`
graph.reset();
graph = make_unique<Graph>(path, bufferPoolSize);
` 