### PR TITLE
reading large adjlsits.

### DIFF
--- a/src/common/include/vector/node_vector.h
+++ b/src/common/include/vector/node_vector.h
@@ -17,9 +17,9 @@ public:
     NodeIDVector(const NodeIDCompressionScheme& nodeIDCompressionScheme)
         : ValueVector{nodeIDCompressionScheme.getNumTotalBytes()},
           nodeIDCompressionScheme(nodeIDCompressionScheme){};
-    NodeIDVector(const NodeIDCompressionScheme& compression, const bool& isSequence)
-        : ValueVector{compression.getNumTotalBytes()}, nodeIDCompressionScheme{compression},
-          isSequence{isSequence} {};
+    NodeIDVector(const NodeIDCompressionScheme& nodeIDCompressionScheme, const bool& isSequence)
+        : ValueVector{nodeIDCompressionScheme.getNumTotalBytes()},
+          nodeIDCompressionScheme{nodeIDCompressionScheme}, isSequence{isSequence} {};
 
     virtual ~NodeIDVector() = default;
 
@@ -59,8 +59,6 @@ protected:
           nodeIDCompressionScheme{nodeIDCompressionScheme}, isSequence(isSequence){};
 
 protected:
-    // The common label field is used with NodeIDcompressionScheme :
-    // LABEL_0_NODEOFFSET_{2/4/8}_BYTES.
     label_t commonLabel;
     NodeIDCompressionScheme nodeIDCompressionScheme;
     bool isSequence;

--- a/src/loader/adj_and_property_lists_loader_helper.cpp
+++ b/src/loader/adj_and_property_lists_loader_helper.cpp
@@ -287,15 +287,15 @@ void AdjAndPropertyListsLoaderHelper::calculatePageCursor(const uint32_t& header
     PageCursor& cursor, ListsMetadata& metadata) {
     auto numElementsInAPage = PAGE_SIZE / numBytesPerElement;
     if (AdjListHeaders::isALargeAdjList(header)) {
-        auto pos = metadata.largeListsPagesMap[header & 0x7fffffff][0] - reversePos;
+        auto lAdjListIdx = AdjListHeaders::getLargeAdjListIdx(header);
+        auto pos = metadata.largeListsPagesMap[lAdjListIdx][0] - reversePos;
         cursor.offset = numBytesPerElement * (pos % numElementsInAPage);
-        cursor.idx =
-            metadata.largeListsPagesMap[header & 0x7fffffff][1 + (pos / numElementsInAPage)];
+        cursor.idx = metadata.largeListsPagesMap[lAdjListIdx][1 + (pos / numElementsInAPage)];
         return;
     }
     auto chunkId = nodeOffset / BaseLists::LISTS_CHUNK_SIZE;
-    auto csrOffset = (header >> 11) & 0xfffff;
-    auto pos = (header & 0x7ff) - reversePos;
+    auto csrOffset = AdjListHeaders::getCSROffset(header);
+    auto pos = AdjListHeaders::getAdjListLen(header) - reversePos;
     cursor.idx = metadata.chunksPagesMap[chunkId][(csrOffset + pos) / numElementsInAPage];
     cursor.offset = numBytesPerElement * ((csrOffset + pos) % numElementsInAPage);
 }
@@ -323,7 +323,6 @@ void AdjAndPropertyListsLoaderHelper::calculateAdjListHeadersForIndexTask(Direct
                 csrOffset += relCount;
             }
             (*adjListHeaders).headers[nodeOffset] = header;
-
             nodeOffset++;
         }
     }

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -60,6 +60,7 @@ cc_library(
         "morsel",
         "//src/common",
         "//src/storage:graph",
+        "//src/storage:structures",
     ],
 )
 

--- a/src/processor/include/operator/logical/tuple/var_to_chunk_and_vector_idx_map.h
+++ b/src/processor/include/operator/logical/tuple/var_to_chunk_and_vector_idx_map.h
@@ -5,18 +5,27 @@
 #include <unordered_map>
 #include <utility>
 
+#include "src/storage/include/structures/common.h"
+
 using namespace std;
+using namespace graphflow::storage;
 
 namespace graphflow {
 namespace processor {
 
 class VarToChunkAndVectorIdxMap {
 
-    typedef unordered_map<string, pair<uint64_t, uint64_t>> variableToDataPosMap_t;
-
 public:
     void put(string variableName, uint64_t dataChunkPos, uint64_t valueVectorPos) {
         variableToDataPosMap.insert({variableName, make_pair(dataChunkPos, valueVectorPos)});
+    }
+
+    void putListSyncer(uint64_t dataChunkPos, shared_ptr<ListSyncer> listSyncer) {
+        listSyncerPerDataChunk.insert({dataChunkPos, listSyncer});
+    }
+
+    shared_ptr<ListSyncer> getListSyncer(uint64_t dataChunkPos) {
+        return listSyncerPerDataChunk[dataChunkPos];
     }
 
     uint64_t getDataChunkPos(string variableName) {
@@ -28,7 +37,8 @@ public:
     }
 
 private:
-    variableToDataPosMap_t variableToDataPosMap;
+    unordered_map<string, pair<uint64_t, uint64_t>> variableToDataPosMap;
+    unordered_map<uint64_t, shared_ptr<ListSyncer>> listSyncerPerDataChunk;
 };
 
 } // namespace processor

--- a/src/processor/include/operator/physical/column_reader/column_reader.h
+++ b/src/processor/include/operator/physical/column_reader/column_reader.h
@@ -16,9 +16,9 @@ public:
     ColumnReader(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos, BaseColumn* column,
         unique_ptr<Operator> prevOperator);
 
-    void getNextTuples() override;
+    ~ColumnReader() { column->reclaim(handle); }
 
-    void cleanup() override;
+    void getNextTuples() override;
 
 protected:
     uint64_t dataChunkPos;
@@ -28,7 +28,7 @@ protected:
     shared_ptr<ValueVector> outValueVector;
 
     BaseColumn* column;
-    unique_ptr<VectorFrameHandle> handle;
+    unique_ptr<ColumnOrListsHandle> handle;
 };
 
 } // namespace processor

--- a/src/processor/include/operator/physical/list_reader/adj_list_extend.h
+++ b/src/processor/include/operator/physical/list_reader/adj_list_extend.h
@@ -9,11 +9,7 @@ class AdjListExtend : public ListReader {
 
 public:
     AdjListExtend(const uint64_t& inDataChunkIdx, const uint64_t& inValueVectorIdx,
-        BaseLists* lists, unique_ptr<Operator> prevOperator);
-
-protected:
-    shared_ptr<DataChunk> outDataChunk;
-    shared_ptr<NodeIDVector> outNodeIDVector;
+        BaseLists* lists, shared_ptr<ListSyncer> listSyncer, unique_ptr<Operator> prevOperator);
 };
 
 } // namespace processor

--- a/src/processor/include/operator/physical/list_reader/extend/adj_list_flatten_and_extend.h
+++ b/src/processor/include/operator/physical/list_reader/extend/adj_list_flatten_and_extend.h
@@ -8,17 +8,17 @@ namespace processor {
 class AdjListFlattenAndExtend : public AdjListExtend {
 
 public:
-    AdjListFlattenAndExtend(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos,
-        BaseLists* lists, unique_ptr<Operator> prevOperator)
-        : AdjListExtend{dataChunkPos, valueVectorPos, lists, move(prevOperator)} {};
+    AdjListFlattenAndExtend(const uint64_t& inDataChunkPos, const uint64_t& inValueVectorPos,
+        BaseLists* lists, shared_ptr<ListSyncer> listSyncer, unique_ptr<Operator> prevOperator)
+        : AdjListExtend{inDataChunkPos, inValueVectorPos, lists, listSyncer, move(prevOperator)} {};
 
     bool hasNextMorsel() override;
 
     void getNextTuples() override;
 
     unique_ptr<Operator> clone() override {
-        return make_unique<AdjListFlattenAndExtend>(
-            dataChunkPos, valueVectorPos, lists, prevOperator->clone());
+        return make_unique<AdjListFlattenAndExtend>(inDataChunkPos, inValueVectorPos, lists,
+            handle->getListSyncer(), prevOperator->clone());
     }
 };
 

--- a/src/processor/include/operator/physical/list_reader/extend/adj_list_only_extend.h
+++ b/src/processor/include/operator/physical/list_reader/extend/adj_list_only_extend.h
@@ -8,15 +8,15 @@ namespace processor {
 class AdjListOnlyExtend : public AdjListExtend {
 
 public:
-    AdjListOnlyExtend(const uint64_t& inDataChunkIdx, const uint64_t& inValueVectorIdx,
-        BaseLists* lists, unique_ptr<Operator> prevOperator)
-        : AdjListExtend{inDataChunkIdx, inValueVectorIdx, lists, move(prevOperator)} {};
+    AdjListOnlyExtend(const uint64_t& inDataChunkPos, const uint64_t& inValueVectorPos,
+        BaseLists* lists, shared_ptr<ListSyncer> listSyncer, unique_ptr<Operator> prevOperator)
+        : AdjListExtend{inDataChunkPos, inValueVectorPos, lists, listSyncer, move(prevOperator)} {};
 
     void getNextTuples() override;
 
     unique_ptr<Operator> clone() override {
-        return make_unique<AdjListOnlyExtend>(
-            dataChunkPos, valueVectorPos, lists, prevOperator->clone());
+        return make_unique<AdjListOnlyExtend>(inDataChunkPos, inValueVectorPos, lists,
+            handle->getListSyncer(), prevOperator->clone());
     }
 };
 

--- a/src/processor/include/operator/physical/list_reader/list_reader.h
+++ b/src/processor/include/operator/physical/list_reader/list_reader.h
@@ -9,19 +9,26 @@ namespace processor {
 class ListReader : public Operator {
 
 public:
-    ListReader(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos, BaseLists* lists,
-        unique_ptr<Operator> prevOperator);
+    ListReader(const uint64_t& inDataChunkPos, const uint64_t& inValueVectorPos, BaseLists* lists,
+        shared_ptr<ListSyncer> ListSyncer, unique_ptr<Operator> prevOperator);
 
-    void cleanup() override;
+    ~ListReader() { lists->reclaim(handle); }
 
 protected:
-    uint64_t dataChunkPos;
-    uint64_t valueVectorPos;
+    void readValuesFromList();
+
+protected:
+    static constexpr uint32_t MAX_TO_READ = 512;
+
+    uint64_t inDataChunkPos;
+    uint64_t inValueVectorPos;
     shared_ptr<DataChunk> inDataChunk;
     shared_ptr<NodeIDVector> inNodeIDVector;
+    shared_ptr<DataChunk> outDataChunk;
+    shared_ptr<ValueVector> outValueVector;
 
     BaseLists* lists;
-    unique_ptr<VectorFrameHandle> handle;
+    unique_ptr<ColumnOrListsHandle> handle;
 };
 
 } // namespace processor

--- a/src/processor/include/operator/physical/list_reader/rel_property_list_reader.h
+++ b/src/processor/include/operator/physical/list_reader/rel_property_list_reader.h
@@ -9,19 +9,18 @@ class RelPropertyListReader : public ListReader {
 
 public:
     RelPropertyListReader(const uint64_t& inDataChunkPos, const uint64_t& inValueVectorPos,
-        const uint64_t& outDataChunkPos, BaseLists* lists, unique_ptr<Operator> prevOperator);
+        const uint64_t& outDataChunkPos, BaseLists* lists, shared_ptr<ListSyncer> listSyncer,
+        unique_ptr<Operator> prevOperator);
 
     void getNextTuples() override;
 
     unique_ptr<Operator> clone() override {
-        return make_unique<RelPropertyListReader>(
-            dataChunkPos, valueVectorPos, outDataChunkPos, lists, prevOperator->clone());
+        return make_unique<RelPropertyListReader>(inDataChunkPos, inValueVectorPos, outDataChunkPos,
+            lists, handle->getListSyncer(), prevOperator->clone());
     }
 
 private:
     uint64_t outDataChunkPos;
-    shared_ptr<DataChunk> outDataChunk;
-    shared_ptr<ValueVector> outValueVector;
 };
 
 } // namespace processor

--- a/src/processor/include/operator/physical/operator.h
+++ b/src/processor/include/operator/physical/operator.h
@@ -32,8 +32,6 @@ public:
 
     shared_ptr<DataChunks> getDataChunks() { return dataChunks; };
 
-    virtual void cleanup(){};
-
     virtual unique_ptr<Operator> clone() = 0;
 
 protected:

--- a/src/processor/include/operator/physical/sink/sink.h
+++ b/src/processor/include/operator/physical/sink/sink.h
@@ -12,8 +12,6 @@ public:
 
     void getNextTuples() override;
 
-    void cleanup() override { prevOperator->cleanup(); };
-
     unique_ptr<Operator> clone() override { return make_unique<Sink>(prevOperator->clone()); }
 
     uint64_t getNumTuples() { return numTuples; }

--- a/src/processor/include/operator/physical/tuple/data_chunk.h
+++ b/src/processor/include/operator/physical/tuple/data_chunk.h
@@ -9,14 +9,11 @@ using namespace std;
 namespace graphflow {
 namespace processor {
 
-//! A DataChunk represents tuples as a set of value vectors and a selector array.
-/*!
-    The data chunk represents a subset of a relation i.e., a set of tuples as
-   lists of the same length. Data chunks are passed as intermediate
-   representations between operators. A data chunk further contains a curr_idx
-   which is used when flatting and implies the value vector only contains the
-   elements at curr_idx of each value vector.
-*/
+//! A DataChunk represents tuples as a set of value vectors and a selector array. It represents a
+//! subset of a relation i.e., a set of tuples as lists of the same length. DataChunks are passed
+//! as intermediate representations between operators.A dataChunk further contains a curr_idx
+//! which is used when flatting and implies the value vector only contains the elements at curr_idx
+//! of each value vector.
 class DataChunk {
 
 public:

--- a/src/processor/operator/logical/property_reader/logical_rel_property_reader.cpp
+++ b/src/processor/operator/logical/property_reader/logical_rel_property_reader.cpp
@@ -32,8 +32,8 @@ unique_ptr<Operator> LogicalRelPropertyReader::mapToPhysical(
             inDataChunkPos, inValueVectorPos, column, move(prevOperator));
     } else {
         auto lists = relsStore.getRelPropertyLists(direction, nodeLabel, label, property);
-        return make_unique<RelPropertyListReader>(
-            inDataChunkPos, inValueVectorPos, outDataChunkPos, lists, move(prevOperator));
+        return make_unique<RelPropertyListReader>(inDataChunkPos, inValueVectorPos, outDataChunkPos,
+            lists, schema.getListSyncer(outDataChunkPos), move(prevOperator));
     }
 }
 

--- a/src/processor/operator/physical/column_reader/column_reader.cpp
+++ b/src/processor/operator/physical/column_reader/column_reader.cpp
@@ -10,12 +10,7 @@ ColumnReader::ColumnReader(const uint64_t& dataChunkPos, const uint64_t& valueVe
     dataChunks = this->prevOperator->getDataChunks();
     inDataChunk = dataChunks->getDataChunk(dataChunkPos);
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
-    handle = make_unique<VectorFrameHandle>();
-}
-
-void ColumnReader::cleanup() {
-    column->reclaim(handle);
-    prevOperator->cleanup();
+    handle = make_unique<ColumnOrListsHandle>();
 }
 
 void ColumnReader::getNextTuples() {

--- a/src/processor/operator/physical/list_reader/adj_list_extend.cpp
+++ b/src/processor/operator/physical/list_reader/adj_list_extend.cpp
@@ -4,14 +4,15 @@ namespace graphflow {
 namespace processor {
 
 AdjListExtend::AdjListExtend(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos,
-    BaseLists* lists, unique_ptr<Operator> prevOperator)
-    : ListReader{dataChunkPos, valueVectorPos, lists, move(prevOperator)} {
+    BaseLists* lists, shared_ptr<ListSyncer> listSyncer, unique_ptr<Operator> prevOperator)
+    : ListReader{dataChunkPos, valueVectorPos, lists, listSyncer, move(prevOperator)} {
     inDataChunk->setAsFlat();
-    outNodeIDVector =
+    outValueVector =
         make_shared<NodeIDVector>(((Lists<nodeID_t>*)lists)->getNodeIDCompressionScheme());
     outDataChunk = make_shared<DataChunk>();
-    outDataChunk->append(outNodeIDVector);
+    outDataChunk->append(outValueVector);
     dataChunks->append(outDataChunk);
+    handle->setIsAdjListHandle();
 }
 
 } // namespace processor

--- a/src/processor/operator/physical/list_reader/extend/adj_list_flatten_and_extend.cpp
+++ b/src/processor/operator/physical/list_reader/extend/adj_list_flatten_and_extend.cpp
@@ -9,6 +9,10 @@ bool AdjListFlattenAndExtend::hasNextMorsel() {
 }
 
 void AdjListFlattenAndExtend::getNextTuples() {
+    if (handle->hasMoreToRead()) {
+        readValuesFromList();
+        return;
+    }
     if (inDataChunk->size == 0 || inDataChunk->size == inDataChunk->curr_idx + 1) {
         inDataChunk->curr_idx = 0;
         prevOperator->getNextTuples();
@@ -16,10 +20,7 @@ void AdjListFlattenAndExtend::getNextTuples() {
         inDataChunk->curr_idx++;
     }
     if (inDataChunk->size > 0) {
-        nodeID_t nodeID;
-        inNodeIDVector->readValue(inDataChunk->curr_idx, nodeID);
-        lists->reclaim(handle);
-        lists->readValues(nodeID, outNodeIDVector, outDataChunk->size, handle);
+        readValuesFromList();
     } else {
         outDataChunk->size = 0;
     }

--- a/src/processor/operator/physical/list_reader/extend/adj_list_only_extend.cpp
+++ b/src/processor/operator/physical/list_reader/extend/adj_list_only_extend.cpp
@@ -4,12 +4,13 @@ namespace graphflow {
 namespace processor {
 
 void AdjListOnlyExtend::getNextTuples() {
-    lists->reclaim(handle);
+    if (handle->hasMoreToRead()) {
+        readValuesFromList();
+        return;
+    }
     prevOperator->getNextTuples();
     if (inDataChunk->size > 0) {
-        nodeID_t nodeID;
-        inNodeIDVector->readValue(inDataChunk->curr_idx, nodeID);
-        lists->readValues(nodeID, outNodeIDVector, outDataChunk->size, handle);
+        readValuesFromList();
     } else {
         outDataChunk->size = 0;
     }

--- a/src/processor/operator/physical/list_reader/list_reader.cpp
+++ b/src/processor/operator/physical/list_reader/list_reader.cpp
@@ -4,18 +4,20 @@ namespace graphflow {
 namespace processor {
 
 ListReader::ListReader(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos,
-    BaseLists* lists, unique_ptr<Operator> prevOperator)
-    : Operator{move(prevOperator)}, dataChunkPos{dataChunkPos},
-      valueVectorPos{valueVectorPos}, lists{lists} {
+    BaseLists* lists, shared_ptr<ListSyncer> listSyncer, unique_ptr<Operator> prevOperator)
+    : Operator{move(prevOperator)}, inDataChunkPos{dataChunkPos},
+      inValueVectorPos{valueVectorPos}, lists{lists} {
     dataChunks = this->prevOperator->getDataChunks();
     inDataChunk = dataChunks->getDataChunk(dataChunkPos);
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
-    handle = make_unique<VectorFrameHandle>();
+    handle = make_unique<ColumnOrListsHandle>();
+    handle->setListSyncer(listSyncer);
 }
 
-void ListReader::cleanup() {
-    lists->reclaim(handle);
-    prevOperator->cleanup();
+void ListReader::readValuesFromList() {
+    nodeID_t nodeID;
+    inNodeIDVector->readValue(inDataChunk->curr_idx, nodeID);
+    lists->readValues(nodeID, outValueVector, outDataChunk->size, handle, MAX_TO_READ);
 }
 
 } // namespace processor

--- a/src/processor/operator/physical/list_reader/rel_property_list_reader.cpp
+++ b/src/processor/operator/physical/list_reader/rel_property_list_reader.cpp
@@ -5,8 +5,8 @@ namespace processor {
 
 RelPropertyListReader::RelPropertyListReader(const uint64_t& inDataChunkPos,
     const uint64_t& inValueVectorPos, const uint64_t& outDataChunkPos, BaseLists* lists,
-    unique_ptr<Operator> prevOperator)
-    : ListReader{inDataChunkPos, inValueVectorPos, lists, move(prevOperator)},
+    shared_ptr<ListSyncer> listSyncer, unique_ptr<Operator> prevOperator)
+    : ListReader{inDataChunkPos, inValueVectorPos, lists, listSyncer, move(prevOperator)},
       outDataChunkPos{outDataChunkPos} {
     outValueVector = make_shared<ValueVector>(lists->getElementSize());
     outDataChunk = dataChunks->getDataChunk(outDataChunkPos);
@@ -15,11 +15,8 @@ RelPropertyListReader::RelPropertyListReader(const uint64_t& inDataChunkPos,
 
 void RelPropertyListReader::getNextTuples() {
     prevOperator->getNextTuples();
-    if (inDataChunk->size > 0) {
-        lists->reclaim(handle);
-        nodeID_t nodeID;
-        inNodeIDVector->readValue(inDataChunk->curr_idx, nodeID);
-        lists->readValues(nodeID, outValueVector, outDataChunk->size, handle);
+    if (handle->hasMoreToRead() || inDataChunk->size > 0) {
+        readValuesFromList();
     }
 }
 

--- a/src/processor/plan/physical/physical_plan.cpp
+++ b/src/processor/plan/physical/physical_plan.cpp
@@ -9,7 +9,6 @@ void PhysicalPlan::run() {
     while (lastOperator->hasNextMorsel()) {
         lastOperator->getNextTuples();
     }
-    lastOperator->cleanup();
 }
 
 } // namespace processor

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -28,7 +28,7 @@ FileHandle::FileHandle(const string& path) : logger{spdlog::get("storage")} {
     }
 }
 
-void FileHandle::readPage(char* frame, uint64_t pageIdx) {
+void FileHandle::readPage(uint8_t* frame, uint64_t pageIdx) {
     lseek(fileDescriptor, pageIdx * PAGE_SIZE, SEEK_SET);
     read(fileDescriptor, frame, PAGE_SIZE);
 }

--- a/src/storage/include/buffer_manager.h
+++ b/src/storage/include/buffer_manager.h
@@ -21,7 +21,7 @@ class Frame {
     friend class BufferManager;
 
 public:
-    unique_ptr<char[]> buffer;
+    unique_ptr<uint8_t[]> buffer;
 
 public:
     Frame();
@@ -39,7 +39,9 @@ class BufferManager {
 public:
     BufferManager(uint64_t maxSize);
 
-    const char* pin(FileHandle& fileHandle, uint32_t pageIdx);
+    const uint8_t* get(FileHandle& fileHandle, uint32_t pageIdx);
+
+    const uint8_t* pin(FileHandle& fileHandle, uint32_t pageIdx);
     void unpin(FileHandle& fileHandle, uint32_t pageIdx);
     unique_ptr<nlohmann::json> debugInfo();
 

--- a/src/storage/include/file_handle.h
+++ b/src/storage/include/file_handle.h
@@ -27,7 +27,7 @@ private:
     }
     inline void unswizzle(uint32_t pageIdx) { pageToFrameMap[pageIdx] = UINT64_MAX; }
 
-    void readPage(char* frame, uint64_t pageIdx);
+    void readPage(uint8_t* frame, uint64_t pageIdx);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/include/structures/column.h
+++ b/src/storage/include/structures/column.h
@@ -12,30 +12,23 @@ using namespace std;
 namespace graphflow {
 namespace storage {
 
-class BaseColumn : public BaseColumnOrList {
+class BaseColumn : public BaseColumnOrLists {
 
 public:
     virtual ~BaseColumn() = default;
 
     virtual void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, const uint64_t& size,
-        const unique_ptr<VectorFrameHandle>& handle);
+        const unique_ptr<ColumnOrListsHandle>& handle);
 
 protected:
     BaseColumn(const string& fname, const size_t& elementSize, const uint64_t& numElements,
         BufferManager& bufferManager)
-        : BaseColumnOrList{fname, elementSize, bufferManager} {};
+        : BaseColumnOrLists{fname, elementSize, bufferManager} {};
 
-    void readFromSeqNodeIDsBySettingFrame(const shared_ptr<ValueVector>& valueVector,
-        const unique_ptr<VectorFrameHandle>& handle, uint64_t pageIdx, uint64_t pageOffset);
-
-    void readFromSeqNodeIDsByCopying(const shared_ptr<ValueVector>& valueVector,
-        const unique_ptr<VectorFrameHandle>& handle, uint64_t sizeLeftToCopy, uint64_t pageIdx,
-        uint64_t pageOffset);
-
-    void readFromNonSeqNodeIDs(const shared_ptr<NodeIDVector>& nodeIDVector,
+    void readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, const uint64_t& size,
-        const unique_ptr<VectorFrameHandle>& handle);
+        const unique_ptr<ColumnOrListsHandle>& handle);
 };
 
 template<typename T>
@@ -56,7 +49,7 @@ public:
 
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, const uint64_t& size,
-        const unique_ptr<VectorFrameHandle>& handle) override;
+        const unique_ptr<ColumnOrListsHandle>& handle) override;
 
 private:
     void readStringsFromOverflowPages(

--- a/src/storage/include/structures/common.h
+++ b/src/storage/include/structures/common.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/common/include/configs.h"
+#include "src/common/include/vector/value_vector.h"
 #include "src/storage/include/buffer_manager.h"
 
 using namespace graphflow::common;
@@ -8,27 +9,120 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace storage {
 
-struct VectorFrameHandle {
-    uint32_t pageIdx;
-    bool isFrameBound;
-    VectorFrameHandle() : pageIdx(-1), isFrameBound(false){};
-};
-
-class BaseColumnOrList {
+//! ListSyncer holds the data that is required to synchronize reading from multiple Lists that have
+//! related data and hence share same AdjListHeaders. The Lists that share a single copy of
+//! AdjListHeaders are - a single-directional edges of a rel label and edges' properties. For the
+//! case of reading from a large list, we do not / cannot read the entire list in a single
+//! operation since it can be very big, hence we read in batches from a definite start point to an
+//! end point. List Sync holds this information and helps in co-ordinating all related lists so
+//! that all of them read the correct portion of data.
+class ListSyncer {
 
 public:
-    void reclaim(unique_ptr<VectorFrameHandle>& handle);
+    ListSyncer() { reset(); };
+
+    inline void init(uint64_t numElements) { this->numElements = numElements; }
+
+    inline void set(uint32_t startIdx, uint32_t size) {
+        this->startIdx = startIdx;
+        this->size = size;
+    }
+
+    uint32_t getStartIdx() { return startIdx; }
+    uint32_t getEndIdx() { return startIdx + size; }
+    uint32_t getSize() { return size; }
+
+    bool hasNewRangeToRead();
+    inline bool hasValidRangeToRead() { return -1u != startIdx; }
+
+private:
+    void reset();
+
+private:
+    uint32_t startIdx;
+    uint32_t size;
+    uint64_t numElements;
+};
+
+// ColumnOrListsHandle stores the state of reading a list or from a column across multiple calls to
+// the readValues() function. It holds three pieces information:
+// 1. pageIdx: reference of the page that is currently pinned by the Column/Lists to make the Frame
+// available to the readValues() caller.
+// 2. listSyncer: to synchronize reading of values between multiple lists that have related data so
+// that they end up reading the correct portion of the list.
+// 3. isAdjListsHandle: true, if the handle stores the state of anAdjLists, else false.
+class ColumnOrListsHandle {
+
+public:
+    ColumnOrListsHandle() : pageIdx{-1u}, isAdjListsHandle{false} {};
+
+    inline void setIsAdjListHandle() { isAdjListsHandle = true; }
+    inline bool getIsAdjListsHandle() { return isAdjListsHandle; }
+
+    inline void setListSyncer(shared_ptr<ListSyncer> listSyncer) { this->listSyncer = listSyncer; }
+    inline shared_ptr<ListSyncer> getListSyncer() { return listSyncer; }
+
+    inline bool hasPageIdx() { return -1u != pageIdx; }
+    inline uint32_t getPageIdx() { return pageIdx; }
+    inline void setPageIdx(uint32_t pageIdx) { this->pageIdx = pageIdx; }
+    inline void resetPageIdx() { pageIdx = -1u; }
+
+    bool hasMoreToRead();
+
+private:
+    uint32_t pageIdx;
+    shared_ptr<ListSyncer> listSyncer;
+    bool isAdjListsHandle;
+};
+
+// LogicalToPhysicalPageIDxMapper maps a logical pageIdx where a particular piece of data is located
+// to the actual sequential index of the page in the file. If the data to be read is a small list,
+// the logical pageIdx corresponds to the sequence of the page in a particular chunk while if the
+// data is being read from a large list, the logical page idx is one of the pages which stores the
+// complete large list. Note that pages of allocated to a chunk or a large list is not contiguously
+// arragened in the lists file. For the case of reading from a column, we do not need a mapper since
+// the logical page idx corresponds to the sequence in which pages are arranged in a column file.
+class LogicalToPhysicalPageIdxMapper {
+
+public:
+    LogicalToPhysicalPageIdxMapper(const vector<uint64_t>& map, uint32_t baseOffset)
+        : map{map}, baseOffset{baseOffset} {}
+
+    uint64_t getPageIdx(uint64_t pageIdx) { return map[pageIdx + baseOffset]; }
+
+private:
+    const vector<uint64_t>& map;
+    uint32_t baseOffset;
+};
+
+// Common class that is extended by both BaseColumn and BaseLists class. It abstracts the state and
+// functions that common in both column and lists, like, 1) layout info (size of a unit of element
+// and number of elements that can be accomodated in a page), 2) getting pageIdx and pageOffset of
+// an element and, 3) reading from pages.
+class BaseColumnOrLists {
+
+public:
+    void reclaim(const unique_ptr<ColumnOrListsHandle>& handle);
 
     size_t getElementSize() { return elementSize; }
 
 protected:
-    BaseColumnOrList(const string& fname, const size_t& elementSize, BufferManager& bufferManager);
+    BaseColumnOrLists(const string& fname, const size_t& elementSize, BufferManager& bufferManager);
+
+    virtual ~BaseColumnOrLists() = default;
 
     inline uint64_t getPageIdx(const uint64_t& offset) const { return offset / numElementsPerPage; }
 
     inline uint32_t getPageOffset(const uint64_t& nodeOffset) const {
         return (nodeOffset % numElementsPerPage) * elementSize;
     }
+
+    void readBySettingFrame(const shared_ptr<ValueVector>& valueVector,
+        const unique_ptr<ColumnOrListsHandle>& handle, uint64_t pageIdx, uint64_t pageOffset);
+
+    void readBySequentialCopy(const shared_ptr<ValueVector>& valueVector,
+        const unique_ptr<ColumnOrListsHandle>& handle, uint64_t sizeLeftToCopy, uint64_t pageIdx,
+        uint64_t pageOffset, unique_ptr<LogicalToPhysicalPageIdxMapper> mapper);
 
 protected:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/structures/column.cpp
+++ b/src/storage/structures/column.cpp
@@ -5,7 +5,7 @@ namespace storage {
 
 void BaseColumn::readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
     const shared_ptr<ValueVector>& valueVector, const uint64_t& size,
-    const unique_ptr<VectorFrameHandle>& handle) {
+    const unique_ptr<ColumnOrListsHandle>& handle) {
     if (nodeIDVector->getIsSequence()) {
         nodeID_t nodeID;
         nodeIDVector->readValue(0, nodeID);
@@ -14,45 +14,23 @@ void BaseColumn::readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
         auto pageOffset = getPageOffset(startOffset);
         auto sizeLeftToCopy = size * elementSize;
         if (pageOffset + sizeLeftToCopy <= PAGE_SIZE) {
-            readFromSeqNodeIDsBySettingFrame(valueVector, handle, pageIdx, pageOffset);
+            // Case when all the values are in a single page on disk.
+            readBySettingFrame(valueVector, handle, pageIdx, pageOffset);
         } else {
-            readFromSeqNodeIDsByCopying(valueVector, handle, sizeLeftToCopy, pageIdx, pageOffset);
+            // Case when the values are consecutive but not in a single page on disk.
+            readBySequentialCopy(valueVector, handle, sizeLeftToCopy, pageIdx, pageOffset,
+                nullptr /*no page mapping is required*/);
         }
         return;
     }
-    readFromNonSeqNodeIDs(nodeIDVector, valueVector, size, handle);
+    // Case when values are at non-sequential locations in a column.
+    readFromNonSequentialLocations(nodeIDVector, valueVector, size, handle);
 }
 
-void BaseColumn::readFromSeqNodeIDsBySettingFrame(const shared_ptr<ValueVector>& valueVector,
-    const unique_ptr<VectorFrameHandle>& handle, uint64_t pageIdx, uint64_t pageOffset) {
-    handle->pageIdx = pageIdx;
-    handle->isFrameBound = true;
-    auto frame = bufferManager.pin(fileHandle, handle->pageIdx);
-    valueVector->setValues((uint8_t*)frame + pageOffset);
-}
-
-void BaseColumn::readFromSeqNodeIDsByCopying(const shared_ptr<ValueVector>& valueVector,
-    const unique_ptr<VectorFrameHandle>& handle, uint64_t sizeLeftToCopy, uint64_t pageIdx,
-    uint64_t pageOffset) {
-    handle->isFrameBound = false;
-    valueVector->reset();
-    auto values = valueVector->getValues();
-    while (sizeLeftToCopy) {
-        auto sizeToCopyInPage = min(PAGE_SIZE - pageOffset, sizeLeftToCopy);
-        auto frame = bufferManager.pin(fileHandle, pageIdx);
-        memcpy(values, frame + pageOffset, sizeToCopyInPage);
-        bufferManager.unpin(fileHandle, pageIdx);
-        values += sizeToCopyInPage;
-        sizeLeftToCopy -= sizeToCopyInPage;
-        pageOffset = 0;
-        pageIdx++;
-    }
-}
-
-void BaseColumn::readFromNonSeqNodeIDs(const shared_ptr<NodeIDVector>& nodeIDVector,
+void BaseColumn::readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& nodeIDVector,
     const shared_ptr<ValueVector>& valueVector, const uint64_t& size,
-    const unique_ptr<VectorFrameHandle>& handle) {
-    handle->isFrameBound = false;
+    const unique_ptr<ColumnOrListsHandle>& handle) {
+    reclaim(handle);
     valueVector->reset();
     nodeID_t nodeID;
     auto values = valueVector->getValues();
@@ -69,7 +47,7 @@ void BaseColumn::readFromNonSeqNodeIDs(const shared_ptr<NodeIDVector>& nodeIDVec
 
 void Column<gf_string_t>::readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
     const shared_ptr<ValueVector>& valueVector, const uint64_t& size,
-    const unique_ptr<VectorFrameHandle>& handle) {
+    const unique_ptr<ColumnOrListsHandle>& handle) {
     if (nodeIDVector->getIsSequence()) {
         nodeID_t nodeID;
         nodeIDVector->readValue(0, nodeID);
@@ -77,9 +55,10 @@ void Column<gf_string_t>::readValues(const shared_ptr<NodeIDVector>& nodeIDVecto
         auto pageIdx = getPageIdx(startOffset);
         auto pageOffset = getPageOffset(startOffset);
         auto sizeLeftToCopy = size * elementSize;
-        readFromSeqNodeIDsByCopying(valueVector, handle, sizeLeftToCopy, pageIdx, pageOffset);
+        readBySequentialCopy(valueVector, handle, sizeLeftToCopy, pageIdx, pageOffset,
+            nullptr /*no page mapping is required*/);
     } else {
-        readFromNonSeqNodeIDs(nodeIDVector, valueVector, size, handle);
+        readFromNonSequentialLocations(nodeIDVector, valueVector, size, handle);
     }
     readStringsFromOverflowPages(valueVector, size);
 }

--- a/src/storage/structures/common.cpp
+++ b/src/storage/structures/common.cpp
@@ -3,15 +3,73 @@
 namespace graphflow {
 namespace storage {
 
-BaseColumnOrList::BaseColumnOrList(
+bool ListSyncer::hasNewRangeToRead() {
+    if (!hasValidRangeToRead()) {
+        return false;
+    }
+    if (startIdx + size == numElements) {
+        reset();
+        return false;
+    }
+    return true;
+}
+
+void ListSyncer::reset() {
+    startIdx = -1u;
+    size = -1u;
+    numElements = -1u;
+}
+
+bool ColumnOrListsHandle::hasMoreToRead() {
+    if (isAdjListsHandle) {
+        return listSyncer->hasNewRangeToRead();
+    } else {
+        return listSyncer->hasValidRangeToRead();
+    }
+}
+
+BaseColumnOrLists::BaseColumnOrLists(
     const string& fname, const size_t& elementSize, BufferManager& bufferManager)
     : logger{spdlog::get("storage")}, elementSize{elementSize},
       numElementsPerPage{(uint32_t)(PAGE_SIZE / elementSize)}, fileHandle{fname},
       bufferManager(bufferManager){};
 
-void BaseColumnOrList::reclaim(unique_ptr<VectorFrameHandle>& handle) {
-    if (handle->isFrameBound) {
-        bufferManager.unpin(fileHandle, handle->pageIdx);
+void BaseColumnOrLists::reclaim(const unique_ptr<ColumnOrListsHandle>& handle) {
+    if (handle->hasPageIdx()) {
+        bufferManager.unpin(fileHandle, handle->getPageIdx());
+        handle->resetPageIdx();
+    }
+}
+
+void BaseColumnOrLists::readBySettingFrame(const shared_ptr<ValueVector>& valueVector,
+    const unique_ptr<ColumnOrListsHandle>& handle, uint64_t pageIdx, uint64_t pageOffset) {
+    const uint8_t* frame;
+    if (handle->getPageIdx() != pageIdx) {
+        reclaim(handle);
+        handle->setPageIdx(pageIdx);
+        frame = bufferManager.pin(fileHandle, pageIdx);
+    } else {
+        frame = bufferManager.get(fileHandle, pageIdx);
+    }
+    valueVector->setValues((uint8_t*)frame + pageOffset);
+}
+
+void BaseColumnOrLists::readBySequentialCopy(const shared_ptr<ValueVector>& valueVector,
+    const unique_ptr<ColumnOrListsHandle>& handle, uint64_t sizeLeftToCopy, uint64_t pageIdx,
+    uint64_t pageOffset, unique_ptr<LogicalToPhysicalPageIdxMapper> mapper) {
+    reclaim(handle);
+    valueVector->reset();
+    auto values = valueVector->getValues();
+    while (sizeLeftToCopy) {
+        uint64_t physicalPageIdx = nullptr == mapper ? pageIdx : mapper->getPageIdx(pageIdx);
+        auto sizeToCopyInPage = min(PAGE_SIZE - pageOffset, sizeLeftToCopy);
+        auto frame = bufferManager.pin(fileHandle, physicalPageIdx);
+        memcpy(values, frame + pageOffset, sizeToCopyInPage);
+        bufferManager.unpin(fileHandle, physicalPageIdx);
+        values += sizeToCopyInPage;
+        sizeLeftToCopy -= sizeToCopyInPage;
+        pageOffset = 0;
+        pageIdx++;
     }
 }
 

--- a/src/storage/structures/lists.cpp
+++ b/src/storage/structures/lists.cpp
@@ -1,47 +1,75 @@
 #include "src/storage/include/structures/lists.h"
 
-#include <iostream>
-
 namespace graphflow {
 namespace storage {
 
 void BaseLists::readValues(const nodeID_t& nodeID, const shared_ptr<ValueVector>& valueVector,
-    uint64_t& adjListLen, const unique_ptr<VectorFrameHandle>& handle) {
+    uint64_t& listLen, const unique_ptr<ColumnOrListsHandle>& handle, uint32_t maxElementsToRead) {
     auto header = headers->getHeader(nodeID.offset);
-    if (!AdjListHeaders::isALargeAdjList(header)) {
-        adjListLen = AdjListHeaders::getAdjListLen(header);
-        auto csrOffset = AdjListHeaders::getCSROffset(header);
-        auto pageOffset = getPageOffset(csrOffset);
-        auto chunkIdx = nodeID.offset / LISTS_CHUNK_SIZE;
-        auto pageIdxInChunk = getPageIdx(csrOffset);
-        auto sizeLeftToCopy = adjListLen * elementSize;
-        if (pageOffset + sizeLeftToCopy > PAGE_SIZE) {
-            handle->isFrameBound = false;
-            valueVector->reset();
-            auto values = valueVector->getValues();
-            while (sizeLeftToCopy) {
-                auto pageIdx = metadata.getPageIdx(chunkIdx, pageIdxInChunk);
-                auto sizeToCopyInPage = min(PAGE_SIZE - pageOffset, sizeLeftToCopy);
-                auto frame = bufferManager.pin(fileHandle, pageIdx);
-                memcpy(values, frame + pageOffset, sizeToCopyInPage);
-                bufferManager.unpin(fileHandle, pageIdx);
-                values += sizeToCopyInPage;
-                sizeLeftToCopy -= sizeToCopyInPage;
-                pageOffset = 0;
-                pageIdxInChunk++;
-            }
-        } else {
-            handle->pageIdx = metadata.getPageIdx(chunkIdx, pageIdxInChunk);
-            handle->isFrameBound = true;
-            auto frame = bufferManager.pin(fileHandle, handle->pageIdx);
-            valueVector->setValues((uint8_t*)frame + pageOffset);
-        }
+    if (handle->hasMoreToRead() || AdjListHeaders::isALargeAdjList(header)) {
+        readFromLargeList(nodeID, valueVector, listLen, handle, header, maxElementsToRead);
     } else {
-        // TODO: Implement handling of large adjLists.
-        // for now we set the adjListLen to zero to ignore large adj lists.
-        adjListLen = 0;
-        handle->isFrameBound = false;
+        readSmallList(nodeID, valueVector, listLen, handle, header);
     }
+}
+
+void BaseLists::readSmallList(const nodeID_t& nodeID, const shared_ptr<ValueVector>& valueVector,
+    uint64_t& listLen, const unique_ptr<ColumnOrListsHandle>& handle, uint32_t header) {
+    if (handle->getIsAdjListsHandle()) {
+        listLen = AdjListHeaders::getAdjListLen(header);
+    }
+    auto csrOffset = AdjListHeaders::getCSROffset(header);
+    auto pageOffset = getPageOffset(csrOffset);
+    uint32_t chunkIdx = nodeID.offset / LISTS_CHUNK_SIZE;
+    auto pageIdx = getPageIdx(csrOffset);
+    auto sizeLeftToCopy = listLen * elementSize;
+    if (pageOffset + sizeLeftToCopy > PAGE_SIZE) {
+        readBySequentialCopy(valueVector, handle, sizeLeftToCopy, pageIdx, pageOffset,
+            metadata.getPageMapperForChunkIdx(chunkIdx));
+    } else {
+        auto physicalPageIdx = metadata.getPageIdxFromChunkPagesMap(chunkIdx, pageIdx);
+        readBySettingFrame(valueVector, handle, physicalPageIdx, pageOffset);
+    }
+}
+
+void BaseLists::readFromLargeList(const nodeID_t& nodeID,
+    const shared_ptr<ValueVector>& valueVector, uint64_t& listLen,
+    const unique_ptr<ColumnOrListsHandle>& handle, uint32_t header, uint32_t maxElementsToRead) {
+    auto largeListIdx = AdjListHeaders::getLargeAdjListIdx(header);
+    auto listSyncer = handle->getListSyncer();
+    auto csrOffset = listSyncer->getStartIdx();
+    auto pageIdx = getPageIdx(csrOffset);
+    auto pageOffset = getPageOffset(csrOffset);
+    auto sizeLeftToCopy = elementSize * listLen;
+    if (pageOffset + sizeLeftToCopy > PAGE_SIZE) {
+        readBySequentialCopy(valueVector, handle, sizeLeftToCopy, pageIdx, pageOffset,
+            metadata.getPageMapperForLargeListIdx(largeListIdx));
+    } else {
+        auto physicalPageIdx = metadata.getPageIdxFromLargeListPagesMap(largeListIdx, pageIdx);
+        readBySettingFrame(valueVector, handle, physicalPageIdx, pageOffset);
+    }
+}
+
+void Lists<nodeID_t>::readFromLargeList(const nodeID_t& nodeID,
+    const shared_ptr<ValueVector>& valueVector, uint64_t& listLen,
+    const unique_ptr<ColumnOrListsHandle>& handle, uint32_t header, uint32_t maxElementsToRead) {
+    auto largeListIdx = AdjListHeaders::getLargeAdjListIdx(header);
+    auto numElements = metadata.getNumElementsInLargeLists(largeListIdx);
+    auto listSyncer = handle->getListSyncer();
+    uint64_t csrOffset;
+    if (!handle->hasMoreToRead()) {
+        listSyncer->init(numElements);
+        csrOffset = 0;
+    } else {
+        csrOffset = listSyncer->getEndIdx();
+    }
+    auto pageIdx = getPageIdx(csrOffset);
+    auto pageOffset = getPageOffset(csrOffset);
+    listLen = min((uint32_t)(numElements - csrOffset),
+        min(numElementsPerPage - pageOffset, maxElementsToRead));
+    auto physicalPageIdx = metadata.getPageIdxFromLargeListPagesMap(largeListIdx, pageIdx);
+    readBySettingFrame(valueVector, handle, physicalPageIdx, pageOffset);
+    listSyncer->set(csrOffset, listLen);
 }
 
 } // namespace storage

--- a/src/storage/structures/lists_aux_structures.cpp
+++ b/src/storage/structures/lists_aux_structures.cpp
@@ -13,7 +13,7 @@ namespace storage {
 
 ListsMetadata::ListsMetadata(const string& path) : ListsMetadata() {
     readFromFile(path);
-    logger->trace("ListsMetadata: #Pages {}, #Chunks {}, #lAdjLists {}", numPages,
+    logger->trace("ListsMetadata: #Pages {}, #Chunks {}, #largeLists {}", numPages,
         chunksPagesMap.size(), largeListsPagesMap.size());
 };
 


### PR DESCRIPTION
- removes cleanup and instead cleans up in the destructor
- lazy reclaiming of handle.
- reader for large lists
    1. in the case of reading from an adjlists, reads a page at a time.
    2. in the case of property lists, read as many elements as there is in one page of corresponding adjlists.
    3. reading from the adjlist is always by setting the frame.
    4. reading from the property lists, can be by setting a frame, or by sequential copying if the data span pages.
- changes to VectorFrameHandle -> ColumnOrListHandle. stores the state of a column/lists across multiple calls to readValues().

PS: I can miss parts of the logic, want help with looking carefully at the sequence of statements in critical routines.

@amine have a look too