### PR TITLE
Add parser for MatchClause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 .vscode
 bazel-*
 .clwb
-

--- a/WORKSPACE.bazel
+++ b/WORKSPACE.bazel
@@ -2,6 +2,7 @@ workspace(name = "graphflowdb")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_jar")
 
 # GTest
 git_repository(
@@ -79,7 +80,7 @@ http_archive(
     name = "fmtlib_fmt",
     build_file = "fmtlib_fmt.BUILD.bazel",
     sha256 = "50f2fd9f697f89726ae3c7efe84ae48c9e03158a2958eea496eeaa0fb190adb6",
-    strip_prefix = "fmt-7.1.3",  
+    strip_prefix = "fmt-7.1.3",
     url = "https://github.com/fmtlib/fmt/archive/7.1.3.zip",
 )
 
@@ -90,4 +91,20 @@ http_archive(
     sha256 = "2ed08bf521aeb2fba9c1966ead771c888b6c208392dbc3c94332f823e0f87d41",
     strip_prefix = "restinio-v.0.6.13/dev",
     url = "https://github.com/Stiffstream/restinio/archive/v.0.6.13.zip",
+)
+
+#antlr4_tools
+http_jar(
+    name = "antlr4-complete",
+    sha256 = "bd11b2464bc8aee5f51b119dff617101b77fa729540ee7f08241a6a672e6bc81",
+    url = "https://www.antlr.org/download/antlr-4.9-complete.jar",
+)
+
+# antlr4_runtimes
+http_archive(
+    name = "antlr4_runtimes",
+    build_file = "antlr4_runtimes.BUILD.bazel",
+    sha256 = "db170179917ce6fec7bc4ecf72edba36b97c9881e09e03af6ac0c901eba52a8f",
+    strip_prefix = "antlr4-4.9.1",
+    url = "https://github.com/antlr/antlr4/archive/4.9.1.tar.gz",
 )

--- a/external/antlr4_runtimes.BUILD.bazel
+++ b/external/antlr4_runtimes.BUILD.bazel
@@ -1,0 +1,9 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "antlr4_cpp",
+    srcs = glob(["runtime/Cpp/runtime/src/**/*.cpp"]),
+    hdrs = glob(["runtime/Cpp/runtime/src/**/*.h"]),
+    includes = ["runtime/Cpp/runtime/src"],
+    visibility = ["//visibility:public"],
+)

--- a/src/antlr4/BUILD.bazel
+++ b/src/antlr4/BUILD.bazel
@@ -1,0 +1,70 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+genrule(
+    name = "generate_grammar",
+    srcs = [
+        "Cypher.g4",
+        "@antlr4-complete//jar",
+    ],
+    outs = [
+        "CypherBaseListener.cpp",
+        "CypherBaseListener.h",
+        "CypherBaseVisitor.cpp",
+        "CypherBaseVisitor.h",
+        "Cypher.interp",
+        "CypherLexer.cpp",
+        "CypherLexer.h",
+        "CypherLexer.interp",
+        "CypherLexer.tokens",
+        "CypherListener.cpp",
+        "CypherListener.h",
+        "CypherParser.cpp",
+        "CypherParser.h",
+        "Cypher.tokens",
+        "CypherVisitor.cpp",
+        "CypherVisitor.h",
+    ],
+    cmd = """
+    java -jar $(location @antlr4-complete//jar) -Dlanguage=Cpp -visitor $(location Cypher.g4) -o $(RULEDIR) \
+        && mv $(RULEDIR)/src/antlr4/CypherBaseListener.cpp $(location CypherBaseListener.cpp) \
+        && mv $(RULEDIR)/src/antlr4/CypherBaseListener.h $(location CypherBaseListener.h) \
+        && mv $(RULEDIR)/src/antlr4/CypherBaseVisitor.cpp $(location CypherBaseVisitor.cpp) \
+        && mv $(RULEDIR)/src/antlr4/CypherBaseVisitor.h $(location CypherBaseVisitor.h) \
+        && mv $(RULEDIR)/src/antlr4/Cypher.interp $(location Cypher.interp) \
+        && mv $(RULEDIR)/src/antlr4/CypherLexer.cpp $(location CypherLexer.cpp) \
+        && mv $(RULEDIR)/src/antlr4/CypherLexer.h $(location CypherLexer.h) \
+        && mv $(RULEDIR)/src/antlr4/CypherLexer.interp $(location CypherLexer.interp) \
+        && mv $(RULEDIR)/src/antlr4/CypherLexer.tokens $(location CypherLexer.tokens) \
+        && mv $(RULEDIR)/src/antlr4/CypherListener.cpp $(location CypherListener.cpp) \
+        && mv $(RULEDIR)/src/antlr4/CypherListener.h $(location CypherListener.h) \
+        && mv $(RULEDIR)/src/antlr4/CypherParser.cpp $(location CypherParser.cpp) \
+        && mv $(RULEDIR)/src/antlr4/CypherParser.h $(location CypherParser.h) \
+        && mv $(RULEDIR)/src/antlr4/Cypher.tokens $(location Cypher.tokens) \
+        && mv $(RULEDIR)/src/antlr4/CypherVisitor.cpp $(location CypherVisitor.cpp) \
+        && mv $(RULEDIR)/src/antlr4/CypherVisitor.h $(location CypherVisitor.h) \
+    """,
+)
+
+cc_library(
+    name = "cypher_grammar_lib",
+    srcs = [
+        "CypherBaseListener.cpp",
+        "CypherBaseVisitor.cpp",
+        "CypherLexer.cpp",
+        "CypherListener.cpp",
+        "CypherParser.cpp",
+        "CypherVisitor.cpp",
+    ],
+    hdrs = [
+        "CypherBaseListener.h",
+        "CypherBaseVisitor.h",
+        "CypherLexer.h",
+        "CypherListener.h",
+        "CypherParser.h",
+        "CypherVisitor.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@antlr4_runtimes//:antlr4_cpp",
+    ],
+)

--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -1,0 +1,206 @@
+/*
+* OpenCypher grammar at "https://s3.amazonaws.com/artifacts.opencypher.org/Cypher.g4"
+*/
+grammar Cypher;
+
+oC_Cypher 
+    : SP ? oC_Statement ( SP? ';' )? SP? EOF ;
+
+oC_Statement 
+    : oC_Query ;
+
+oC_Query 
+    : oC_RegularQuery ;
+
+oC_RegularQuery
+    : oC_SingleQuery ;
+
+oC_SingleQuery 
+    : oC_SinglePartQuery ;
+
+oC_SinglePartQuery 
+    : ( oC_ReadingClause SP? )* ;
+
+oC_ReadingClause 
+    : oC_Match ;
+
+oC_Match 
+    : MATCH SP? oC_Pattern ;
+
+MATCH : ( 'M' | 'm' ) ( 'A' | 'a' ) ( 'T' | 't' ) ( 'C' | 'c' ) ( 'H' | 'h' )  ;
+
+oC_Pattern
+    : oC_PatternPart ( SP? ',' SP? oC_PatternPart )* ;
+
+oC_PatternPart
+    : oC_AnonymousPatternPart ;
+
+oC_AnonymousPatternPart
+    : oC_PatternElement ;
+
+oC_PatternElement
+    : ( oC_NodePattern ( SP? oC_PatternElementChain )* )
+        | ( '(' oC_PatternElement ')' )
+        ;
+
+oC_NodePattern
+    : '(' SP? ( oC_Variable SP? )? ( oC_NodeLabel SP? )? ')' ;
+
+oC_PatternElementChain
+    : oC_RelationshipPattern SP? oC_NodePattern ;
+
+oC_RelationshipPattern
+    : ( oC_LeftArrowHead SP? oC_Dash SP? oC_RelationshipDetail? SP? oC_Dash )
+        | ( oC_Dash SP? oC_RelationshipDetail? SP? oC_Dash SP? oC_RightArrowHead )
+        ;
+
+oC_RelationshipDetail
+    : '[' SP? ( oC_Variable SP? )? ( oC_RelTypeName SP? )? ']' ;
+
+oC_NodeLabel
+    : ':' SP? oC_LabelName ;
+
+oC_LabelName
+    : oC_SchemaName ;
+
+oC_RelTypeName
+    : ':' SP? oC_SchemaName ;
+
+oC_Variable
+    : oC_SymbolicName ;
+
+oC_SchemaName
+    : oC_SymbolicName ;
+
+oC_SymbolicName
+    : UnescapedSymbolicName
+        | EscapedSymbolicName
+        ;
+
+UnescapedSymbolicName
+    : IdentifierStart ( IdentifierPart )* ;
+
+IdentifierStart
+    : ID_Start
+        | Pc
+        ;
+
+IdentifierPart
+    :  ID_Continue
+        | Sc
+        ;
+
+EscapedSymbolicName
+    : ( '`' ( EscapedSymbolicName_0 )* '`' )+ ;
+
+SP
+  : ( WHITESPACE )+ ;
+
+WHITESPACE
+    :  SPACE
+        | TAB
+        | LF
+        | VT
+        | FF
+        | CR
+        | FS
+        | GS
+        | RS
+        | US
+        | '\u1680'
+        | '\u180e'
+        | '\u2000'
+        | '\u2001'
+        | '\u2002'
+        | '\u2003'
+        | '\u2004'
+        | '\u2005'
+        | '\u2006'
+        | '\u2008'
+        | '\u2009'
+        | '\u200a'
+        | '\u2028'
+        | '\u2029'
+        | '\u205f'
+        | '\u3000'
+        | '\u00a0'
+        | '\u2007'
+        | '\u202f'
+        | Comment
+        ;
+
+Comment
+    : ( '/*' ( Comment_1 | ( '*' Comment_2 ) )* '*/' )
+        | ( '//' ( Comment_3 )* CR? ( LF | EOF ) )
+        ;
+
+oC_LeftArrowHead
+    : '<'
+        | '\u27e8'
+        | '\u3008'
+        | '\ufe64'
+        | '\uff1c'
+        ;
+
+oC_RightArrowHead
+    : '>'
+        | '\u27e9'
+        | '\u3009'
+        | '\ufe65'
+        | '\uff1e'
+        ;
+
+oC_Dash
+    : '-'
+        | '\u00ad'
+        | '\u2010'
+        | '\u2011'
+        | '\u2012'
+        | '\u2013'
+        | '\u2014'
+        | '\u2015'
+        | '\u2212'
+        | '\ufe58'
+        | '\ufe63'
+        | '\uff0d'
+        ;
+
+fragment FF : [\f] ;
+
+fragment EscapedSymbolicName_0 : ~[`] ;
+
+fragment RS : [\u001E] ;
+
+fragment ID_Continue : [\p{ID_Continue}] ;
+
+fragment Comment_1 : ~[*] ;
+
+fragment StringLiteral_1 : ~['\\] ;
+
+fragment Comment_3 : ~[\n\r] ;
+
+fragment Comment_2 : ~[/] ;
+
+fragment GS : [\u001D] ;
+
+fragment FS : [\u001C] ;
+
+fragment CR : [\r] ;
+
+fragment Sc : [\p{Sc}] ;
+
+fragment SPACE : [ ] ;
+
+fragment Pc : [\p{Pc}] ;
+
+fragment TAB : [\t] ;
+
+fragment StringLiteral_0 : ~["\\] ;
+
+fragment LF : [\n] ;
+
+fragment VT : [\u000B] ;
+
+fragment US : [\u001F] ;
+
+fragment ID_Start : [\p{ID_Start}] ;

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_library(
+    name = "parser",
+    srcs = [
+        "parser.cpp",
+        "transformer.cpp",
+    ],
+    hdrs = [
+        "include/parser.h",
+        "include/single_query.h",
+        "include/transformer.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "statements",
+        "//src/antlr4:cypher_grammar_lib",
+    ],
+)
+
+cc_library(
+    name = "statements",
+    hdrs = [
+        "include/statements/match_statement.h",
+    ],
+    deps = ["patterns"],
+)
+
+cc_library(
+    name = "patterns",
+    hdrs = [
+        "include/patterns/node_pattern.h",
+        "include/patterns/pattern_element.h",
+        "include/patterns/pattern_element_chain.h",
+        "include/patterns/rel_pattern.h",
+    ],
+    deps = [
+        "//src/common",
+    ],
+)

--- a/src/parser/include/parser.h
+++ b/src/parser/include/parser.h
@@ -1,0 +1,19 @@
+#include "antlr4-runtime.h"
+
+#include "src/antlr4/CypherLexer.h"
+#include "src/antlr4/CypherParser.h"
+#include "src/parser/include/transformer.h"
+
+using namespace antlr4;
+
+namespace graphflow {
+namespace parser {
+
+class Parser {
+
+public:
+    unique_ptr<SingleQuery> parseQuery(string query);
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/patterns/node_pattern.h
+++ b/src/parser/include/patterns/node_pattern.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+using namespace std;
+
+namespace graphflow {
+namespace parser {
+
+/**
+ * NodePattern represents "(nodeName:NodeType)"
+ */
+class NodePattern {
+
+public:
+    void setName(const string& name) { this->name = name; }
+
+    void setLabel(const string& label) { this->label = label; }
+
+    bool operator==(const NodePattern& other) { return name == other.name && label == other.label; }
+
+private:
+    string name;
+    string label;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/patterns/pattern_element.h
+++ b/src/parser/include/patterns/pattern_element.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <vector>
+
+#include "src/parser/include/patterns/pattern_element_chain.h"
+
+namespace graphflow {
+namespace parser {
+
+/**
+ * PatternElement represents "NodePattern - PatternElementChain - ..."
+ */
+class PatternElement {
+
+public:
+    void setNodePattern(unique_ptr<NodePattern> nodePattern) {
+        this->nodePattern = move(nodePattern);
+    }
+
+    void addPatternElementChain(unique_ptr<PatternElementChain> patternElementChain) {
+        patternElementChains.push_back(move(patternElementChain));
+    }
+
+    bool operator==(const PatternElement& other) {
+        auto result = *nodePattern == *other.nodePattern;
+        for (auto i = 0; i < patternElementChains.size(); ++i) {
+            result &= *patternElementChains[i] == *other.patternElementChains[i];
+        }
+        return result;
+    }
+
+private:
+    unique_ptr<NodePattern> nodePattern;
+    vector<unique_ptr<PatternElementChain>> patternElementChains;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/patterns/pattern_element_chain.h
+++ b/src/parser/include/patterns/pattern_element_chain.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "src/parser/include/patterns/rel_pattern.h"
+
+namespace graphflow {
+namespace parser {
+
+/**
+ * PatternElementChain represents " - RelPattern - NodePattern"
+ */
+class PatternElementChain {
+
+public:
+    void setRelPattern(unique_ptr<RelPattern> relPattern) { this->relPattern = move(relPattern); }
+
+    void setNodePattern(unique_ptr<NodePattern> nodePattern) {
+        this->nodePattern = move(nodePattern);
+    }
+
+    bool operator==(const PatternElementChain& other) {
+        return *relPattern == *other.relPattern && *nodePattern == *other.nodePattern;
+    }
+
+private:
+    unique_ptr<RelPattern> relPattern;
+    unique_ptr<NodePattern> nodePattern;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/patterns/rel_pattern.h
+++ b/src/parser/include/patterns/rel_pattern.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "src/common/include/types.h"
+#include "src/parser/include/patterns/node_pattern.h"
+
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace parser {
+
+/**
+ * RelationshipPattern represents "-[relName:RelLabel]-"
+ */
+class RelPattern {
+
+public:
+    void setName(const string& name) { this->name = name; }
+
+    void setType(const string& type) { this->type = type; }
+
+    void setDirection(Direction direction) { this->direction = direction; }
+
+    bool operator==(const RelPattern& other) {
+        return name == other.name && type == other.type && direction == other.direction;
+    }
+
+private:
+    string name;
+
+    string type;
+
+    Direction direction;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/single_query.h
+++ b/src/parser/include/single_query.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "src/parser/include/statements/match_statement.h"
+
+namespace graphflow {
+namespace parser {
+
+class SingleQuery {
+
+public:
+    void addMatchStatement(unique_ptr<MatchStatement> statement) {
+        statements.push_back(move(statement));
+    }
+
+    bool operator==(const SingleQuery& other) {
+        auto result = true;
+        for (auto i = 0; i < statements.size(); ++i) {
+            result &= *statements[i] == *other.statements[i];
+        }
+        return result;
+    }
+
+private:
+    vector<unique_ptr<MatchStatement>> statements;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/statements/match_statement.h
+++ b/src/parser/include/statements/match_statement.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "src/parser/include/patterns/pattern_element.h"
+
+namespace graphflow {
+namespace parser {
+
+class MatchStatement {
+
+public:
+    explicit MatchStatement(vector<unique_ptr<PatternElement>> patternElements)
+        : patternElements{move(patternElements)} {}
+
+    bool operator==(const MatchStatement& other) {
+        auto result = true;
+        for (auto i = 0; i < patternElements.size(); ++i) {
+            result &= *patternElements[i] == *other.patternElements[i];
+        }
+        return result;
+    }
+
+private:
+    vector<unique_ptr<PatternElement>> patternElements;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/transformer.h
+++ b/src/parser/include/transformer.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "src/antlr4/CypherBaseVisitor.h"
+#include "src/parser/include/single_query.h"
+
+using namespace std;
+
+namespace graphflow {
+namespace parser {
+
+class Transformer {
+public:
+    unique_ptr<SingleQuery> transformParseTree(CypherParser::OC_CypherContext* ctx);
+
+private:
+    unique_ptr<SingleQuery> transformQuery(CypherParser::OC_QueryContext* ctx);
+
+    unique_ptr<SingleQuery> transformRegularQuery(CypherParser::OC_RegularQueryContext* ctx);
+
+    unique_ptr<SingleQuery> transformSingleQuery(CypherParser::OC_SingleQueryContext* ctx);
+
+    unique_ptr<SingleQuery> transformSinglePartQuery(CypherParser::OC_SinglePartQueryContext* ctx);
+
+    unique_ptr<MatchStatement> transformReadingClause(CypherParser::OC_ReadingClauseContext* ctx);
+
+    unique_ptr<MatchStatement> transformMatch(CypherParser::OC_MatchContext* ctx);
+
+    vector<unique_ptr<PatternElement>> transformPattern(CypherParser::OC_PatternContext* ctx);
+
+    unique_ptr<PatternElement> transformPatternPart(CypherParser::OC_PatternPartContext* ctx);
+
+    unique_ptr<PatternElement> transformAnonymousPatternPart(
+        CypherParser::OC_AnonymousPatternPartContext* ctx);
+
+    unique_ptr<PatternElement> transformPatternElement(CypherParser::OC_PatternElementContext* ctx);
+
+    unique_ptr<NodePattern> transformNodePattern(CypherParser::OC_NodePatternContext* ctx);
+
+    unique_ptr<PatternElementChain> transformPatternElementChain(
+        CypherParser::OC_PatternElementChainContext* ctx);
+
+    unique_ptr<RelPattern> transformRelationshipPattern(
+        CypherParser::OC_RelationshipPatternContext* ctx);
+
+    unique_ptr<RelPattern> transformRelationshipDetail(
+        CypherParser::OC_RelationshipDetailContext* ctx);
+
+    string transformNodeLabel(CypherParser::OC_NodeLabelContext* ctx);
+
+    string transformLabelName(CypherParser::OC_LabelNameContext* ctx);
+
+    string transformRelTypeName(CypherParser::OC_RelTypeNameContext* ctx);
+
+    string transformVariable(CypherParser::OC_VariableContext* ctx);
+
+    string transformSchemaName(CypherParser::OC_SchemaNameContext* ctx);
+
+    string transformSymbolicName(CypherParser::OC_SymbolicNameContext* ctx);
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -1,0 +1,20 @@
+#include "src/parser/include/parser.h"
+
+namespace graphflow {
+namespace parser {
+
+unique_ptr<SingleQuery> Parser::parseQuery(string query) {
+    ANTLRInputStream inputStream(query);
+    CypherLexer cypherLexer(&inputStream);
+    CommonTokenStream tokens(&cypherLexer);
+    tokens.fill();
+
+    CypherParser cypherParser(&tokens);
+    CypherParser::OC_CypherContext* tree = cypherParser.oC_Cypher();
+
+    Transformer transformer;
+    return transformer.transformParseTree(tree);
+}
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -1,0 +1,148 @@
+#include "src/parser/include/transformer.h"
+
+namespace graphflow {
+namespace parser {
+
+unique_ptr<SingleQuery> Transformer::transformParseTree(CypherParser::OC_CypherContext* ctx) {
+    return transformQuery(ctx->oC_Statement()->oC_Query());
+}
+
+unique_ptr<SingleQuery> Transformer::transformQuery(CypherParser::OC_QueryContext* ctx) {
+    return transformRegularQuery(ctx->oC_RegularQuery());
+}
+
+unique_ptr<SingleQuery> Transformer::transformRegularQuery(
+    CypherParser::OC_RegularQueryContext* ctx) {
+    return transformSingleQuery(ctx->oC_SingleQuery());
+}
+
+unique_ptr<SingleQuery> Transformer::transformSingleQuery(
+    CypherParser::OC_SingleQueryContext* ctx) {
+    return transformSinglePartQuery(ctx->oC_SinglePartQuery());
+}
+
+unique_ptr<SingleQuery> Transformer::transformSinglePartQuery(
+    CypherParser::OC_SinglePartQueryContext* ctx) {
+    auto singleQuery = make_unique<SingleQuery>();
+    auto readingClauses = ctx->oC_ReadingClause();
+    for (auto it = begin(readingClauses); it != end(readingClauses); ++it) {
+        singleQuery->addMatchStatement(move(transformReadingClause(*it)));
+    }
+    return singleQuery;
+}
+
+unique_ptr<MatchStatement> Transformer::transformReadingClause(
+    CypherParser::OC_ReadingClauseContext* ctx) {
+    return transformMatch(ctx->oC_Match());
+}
+
+unique_ptr<MatchStatement> Transformer::transformMatch(CypherParser::OC_MatchContext* ctx) {
+    return make_unique<MatchStatement>(move(transformPattern(ctx->oC_Pattern())));
+}
+
+vector<unique_ptr<PatternElement>> Transformer::transformPattern(
+    CypherParser::OC_PatternContext* ctx) {
+    vector<unique_ptr<PatternElement>> pattern;
+    auto patternPartContext = ctx->oC_PatternPart();
+    for (auto it = begin(patternPartContext); it != end(patternPartContext); ++it) {
+        pattern.push_back(move(transformPatternPart(*it)));
+    }
+    return pattern;
+}
+
+unique_ptr<PatternElement> Transformer::transformPatternPart(
+    CypherParser::OC_PatternPartContext* ctx) {
+    return transformAnonymousPatternPart(ctx->oC_AnonymousPatternPart());
+}
+
+unique_ptr<PatternElement> Transformer::transformAnonymousPatternPart(
+    CypherParser::OC_AnonymousPatternPartContext* ctx) {
+    return transformPatternElement(ctx->oC_PatternElement());
+}
+
+unique_ptr<PatternElement> Transformer::transformPatternElement(
+    CypherParser::OC_PatternElementContext* ctx) {
+    if (ctx->oC_PatternElement()) {
+        return transformPatternElement(ctx->oC_PatternElement());
+    }
+    auto patternElement = make_unique<PatternElement>();
+    patternElement->setNodePattern(move(transformNodePattern(ctx->oC_NodePattern())));
+    if (!ctx->oC_PatternElementChain().empty()) {
+        auto patternElementChainContext = ctx->oC_PatternElementChain();
+        for (auto it = begin(patternElementChainContext); it != end(patternElementChainContext);
+             ++it) {
+            patternElement->addPatternElementChain(move(transformPatternElementChain(*it)));
+        }
+    }
+    return patternElement;
+}
+
+unique_ptr<NodePattern> Transformer::transformNodePattern(
+    CypherParser::OC_NodePatternContext* ctx) {
+    auto nodePattern = make_unique<NodePattern>();
+    if (ctx->oC_Variable()) {
+        nodePattern->setName(transformSymbolicName(ctx->oC_Variable()->oC_SymbolicName()));
+    }
+    if (ctx->oC_NodeLabel()) {
+        nodePattern->setLabel(transformNodeLabel(ctx->oC_NodeLabel()));
+    }
+    return nodePattern;
+}
+
+unique_ptr<PatternElementChain> Transformer::transformPatternElementChain(
+    CypherParser::OC_PatternElementChainContext* ctx) {
+    auto patternElementChain = make_unique<PatternElementChain>();
+    patternElementChain->setRelPattern(
+        move(transformRelationshipPattern(ctx->oC_RelationshipPattern())));
+    patternElementChain->setNodePattern(move(transformNodePattern(ctx->oC_NodePattern())));
+    return patternElementChain;
+}
+
+unique_ptr<RelPattern> Transformer::transformRelationshipPattern(
+    CypherParser::OC_RelationshipPatternContext* ctx) {
+    auto relPattern = ctx->oC_RelationshipDetail() ?
+                          transformRelationshipDetail(ctx->oC_RelationshipDetail()) :
+                          make_unique<RelPattern>();
+    relPattern->setDirection(ctx->oC_LeftArrowHead() ? BWD : FWD);
+    return relPattern;
+}
+
+unique_ptr<RelPattern> Transformer::transformRelationshipDetail(
+    CypherParser::OC_RelationshipDetailContext* ctx) {
+    auto relPattern = make_unique<RelPattern>();
+    if (ctx->oC_Variable()) {
+        relPattern->setName(transformVariable(ctx->oC_Variable()));
+    }
+    if (ctx->oC_RelTypeName()) {
+        relPattern->setType(transformRelTypeName(ctx->oC_RelTypeName()));
+    }
+    return relPattern;
+}
+
+string Transformer::transformNodeLabel(CypherParser::OC_NodeLabelContext* ctx) {
+    return transformLabelName(ctx->oC_LabelName());
+}
+
+string Transformer::transformLabelName(CypherParser::OC_LabelNameContext* ctx) {
+    return transformSchemaName(ctx->oC_SchemaName());
+}
+
+string Transformer::transformRelTypeName(CypherParser::OC_RelTypeNameContext* ctx) {
+    return transformSchemaName(ctx->oC_SchemaName());
+}
+
+string Transformer::transformVariable(CypherParser::OC_VariableContext* ctx) {
+    return transformSymbolicName(ctx->oC_SymbolicName());
+}
+
+string Transformer::transformSchemaName(CypherParser::OC_SchemaNameContext* ctx) {
+    return transformSymbolicName(ctx->oC_SymbolicName());
+}
+
+string Transformer::transformSymbolicName(CypherParser::OC_SymbolicNameContext* ctx) {
+    return ctx->UnescapedSymbolicName() ? ctx->UnescapedSymbolicName()->getText() :
+                                          ctx->EscapedSymbolicName()->getText();
+}
+
+} // namespace parser
+} // namespace graphflow

--- a/test/parser/BUILD.bazel
+++ b/test/parser/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "parser_tests",
+    srcs = [
+        "parser_test.cpp",
+    ],
+    linkstatic = 1,
+    deps = [
+        "//src/parser",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/test/parser/parser_test.cpp
+++ b/test/parser/parser_test.cpp
@@ -1,0 +1,216 @@
+#include "gtest/gtest.h"
+
+#include "src/parser/include/parser.h"
+
+using namespace graphflow::parser;
+using namespace graphflow::common;
+
+class ParserTest : public :: testing::Test {
+
+public:
+
+    unique_ptr<NodePattern> makeNodePattern(string name, string label) {
+        auto node = make_unique<NodePattern>();
+        node->setName(name);
+        node->setLabel(label);
+        return node;
+    }
+
+    unique_ptr<RelPattern> makeRelPattern(string name, string type, Direction direction) {
+        auto rel = make_unique<RelPattern>();
+        rel->setName(name);
+        rel->setType(type);
+        rel->setDirection(direction);
+        return rel;
+    }
+
+    unique_ptr<PatternElementChain> makePatternElementChain(unique_ptr<RelPattern> rel,
+            unique_ptr<NodePattern> node) {
+        auto patternElementChain = make_unique<PatternElementChain>();
+        patternElementChain->setNodePattern(move(node));
+        patternElementChain->setRelPattern(move(rel));
+        return patternElementChain;
+    }
+
+    unique_ptr<PatternElement> makePatternElement(unique_ptr<NodePattern> nodePattern) {
+        auto patternElement = make_unique<PatternElement>();
+        patternElement->setNodePattern(move(nodePattern));
+        return patternElement;
+    }
+
+};
+
+TEST_F(ParserTest, MATCHSingleElementSingleNodeNoLabelTest) {
+    auto expectedNode = makeNodePattern("a", string());
+    auto expectedPatternElement = makePatternElement(move(expectedNode));
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MATCHSingleElementSingleNodeSingleLabelTest) {
+    auto expectedNode = makeNodePattern("a", "Person");
+    auto expectedPatternElement = makePatternElement(move(expectedNode));
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:Person);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MATCHSingleElementAnonymousNodeSingleLabelTest) {
+    auto expectedNode = makeNodePattern(string(), "Person");
+    auto expectedPatternElement = makePatternElement(move(expectedNode));
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (:Person);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MATCHSingleElementSingleEdgeNoTypeTest) {
+    auto expectedNodeA = makeNodePattern("a", "Person");
+    auto expectedNodeB = makeNodePattern("b", "Student");
+    auto expectedEdge = makeRelPattern("e1", string(), FWD);
+    auto expectedPatternElementChain = makePatternElementChain(move(expectedEdge), move(expectedNodeB));
+    auto expectedPatternElement = makePatternElement(move(expectedNodeA));
+    expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain));
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:Person)-[e1]->(b:Student);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MATCHSingleElementSingleEdgeSingleTypeTest) {
+    auto expectedNodeA = makeNodePattern("a", "Person");
+    auto expectedNodeB = makeNodePattern("b", "Student");
+    auto expectedEdge = makeRelPattern("e1", "knows", FWD);
+    auto expectedPatternElementChain = makePatternElementChain(move(expectedEdge), move(expectedNodeB));
+    auto expectedPatternElement = makePatternElement(move(expectedNodeA));
+    expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain));
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:Person)-[e1:knows]->(b:Student);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MATCHSingleElementAnonymousEdgeMultiTypesTest) {
+    auto expectedNodeA = makeNodePattern("a", "Person");
+    auto expectedNodeB = makeNodePattern("b", "Student");
+    auto expectedEdge = makeRelPattern(string(), "knows", FWD);
+    auto expectedPatternElementChain = makePatternElementChain(move(expectedEdge), move(expectedNodeB));
+    auto expectedPatternElement = makePatternElement(move(expectedNodeA));
+    expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain));
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:Person)-[:knows]->(b:Student);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MATCHSingleElementMultiEdgesTest) {
+    auto expectedNodeA = makeNodePattern("a", "Person");
+    auto expectedNodeB = makeNodePattern("b", "Student");
+    auto expectedEdge1 = makeRelPattern(string(), "knows", FWD);
+    auto expectedPatternElementChain1 = makePatternElementChain(move(expectedEdge1), move(expectedNodeB));
+    auto expectedNodeC = makeNodePattern("c", "Student");
+    auto expectedEdge2 = makeRelPattern("e2", "likes", BWD);
+    auto expectedPatternElementChain2 = makePatternElementChain(move(expectedEdge2), move(expectedNodeC));
+    auto expectedPatternElement = makePatternElement(move(expectedNodeA));
+    expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain1));
+    expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain2));
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:Person)-[:knows]->(b:Student)<-[e2:likes]-(c:Student);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MATCHMultiElementsTest) {
+    auto expectedNodeA = makeNodePattern("a", "Person");
+    auto expectedNodeB = makeNodePattern("b", "Student");
+    auto expectedEdge1 = makeRelPattern(string(), "knows", FWD);
+    auto expectedPatternElementChain1 = makePatternElementChain(move(expectedEdge1), move(expectedNodeB));
+    auto expectedPatternElement1 = makePatternElement(move(expectedNodeA));
+    expectedPatternElement1->addPatternElementChain(move(expectedPatternElementChain1));
+
+    auto expectedNodeBDup = makeNodePattern("b", string());
+    auto expectedNodeC = makeNodePattern("c", "Student");
+    auto expectedEdge2 = makeRelPattern("e2", "likes", BWD);
+    auto expectedPatternElementChain2 = makePatternElementChain(move(expectedEdge2), move(expectedNodeC));
+    auto expectedPatternElement2 = makePatternElement(move(expectedNodeBDup));
+    expectedPatternElement2->addPatternElementChain(move(expectedPatternElementChain2));
+
+    vector<unique_ptr<PatternElement>> expectedPatternElements;
+    expectedPatternElements.push_back(move(expectedPatternElement1));
+    expectedPatternElements.push_back(move(expectedPatternElement2));
+    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:Person)-[:knows]->(b:Student), (b)<-[e2:likes]-(c:Student);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}
+
+TEST_F(ParserTest, MultiMatchTest) {
+    auto expectedNodeA = makeNodePattern("a", "Person");
+    auto expectedNodeB = makeNodePattern("b", "Student");
+    auto expectedEdge1 = makeRelPattern(string(), "knows", FWD);
+    auto expectedPatternElementChain1 = makePatternElementChain(move(expectedEdge1), move(expectedNodeB));
+    auto expectedPatternElement1 = makePatternElement(move(expectedNodeA));
+    expectedPatternElement1->addPatternElementChain(move(expectedPatternElementChain1));
+    vector<unique_ptr<PatternElement>> expectedPatternElements1;
+    expectedPatternElements1.push_back(move(expectedPatternElement1));
+    auto expectedMatchStatement1 = make_unique<MatchStatement>(move(expectedPatternElements1));
+
+    auto expectedNodeBDup = makeNodePattern("b", string());
+    auto expectedNodeC = makeNodePattern("c", "Student");
+    auto expectedEdge2 = makeRelPattern("e2", "likes", BWD);
+    auto expectedPatternElementChain2 = makePatternElementChain(move(expectedEdge2), move(expectedNodeC));
+    auto expectedPatternElement2 = makePatternElement(move(expectedNodeBDup));
+    expectedPatternElement2->addPatternElementChain(move(expectedPatternElementChain2));
+    vector<unique_ptr<PatternElement>> expectedPatternElements2;
+    expectedPatternElements2.push_back(move(expectedPatternElement2));
+    auto expectedMatchStatement2 = make_unique<MatchStatement>(move(expectedPatternElements2));
+
+    auto expectedSingleQuery = make_unique<SingleQuery>();
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement1));
+    expectedSingleQuery->addMatchStatement(move(expectedMatchStatement2));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:Person)-[:knows]->(b:Student) MATCH (b)<-[e2:likes]-(c:Student);";
+    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
+}


### PR DESCRIPTION
This PR adds open cypher grammar and parser for MATCH clause.
### Grammar
We use the same grammar as [open cypher](https://s3.amazonaws.com/artifacts.opencypher.org/Cypher.g4) but remove features that are not yet supported. Eventually we should add these features back.
**Grammar Removed**
- Un-directed and bi-directed edge. E.g. `(a)-[e1]-(b),  (a)<-[e1]->(b)`
- Multi node labels. E.g. `(a:Person:Student)`
- Multi edge types. E.g. `[e1:knows|:likes]`

### Parser
Parser class structure closely follows open cypher grammar.
- NodePattern: `(a:Person)`
  - name, type 
- RelPattern: `-[e1:knows]->`
  - name, label, direction
- PatternElementChain: `-[e1:knows]->(b:Student)`
  - relPattern, nodePattern 
- PatternElement: `(a:Person) -[e1:knows]->(b:Student)  -[e2]->(c) `
  -  nodePattern, vector\<PatternElementChain\>
- MatchStatement: `MATCH ..., ...`
  - vector\<PatternElement\> 
- SingleQuery `MATCH ... MATCH ...`
  - vector\<MatchStatement\>