### PR TITLE
Add Binder for Graph Pattern

### DIFF
--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -21,7 +21,7 @@ DataType getDataType(const std::string& dataTypeString) {
     } else if (0 == dataTypeString.compare("STRING")) {
         return STRING;
     }
-    throw invalid_argument("Cannot parse dataType.");
+    throw invalid_argument("Cannot parse dataType: " + dataTypeString);
 }
 
 size_t getDataTypeSize(DataType dataType) {

--- a/src/parser/include/patterns/node_pattern.h
+++ b/src/parser/include/patterns/node_pattern.h
@@ -14,6 +14,10 @@ namespace parser {
 class NodePattern {
 
 public:
+    string getName() const { return name; }
+
+    string getLabel() const { return label; }
+
     void setName(const string& name) { this->name = name; }
 
     void setLabel(const string& label) { this->label = label; }

--- a/src/parser/include/patterns/pattern_element.h
+++ b/src/parser/include/patterns/pattern_element.h
@@ -13,6 +13,14 @@ namespace parser {
 class PatternElement {
 
 public:
+    const NodePattern& getNodePattern() const { return *nodePattern; }
+
+    int getNumPatternElementChain() const { return patternElementChains.size(); }
+
+    const PatternElementChain& getPatternElementChain(int idx) const {
+        return *patternElementChains[idx];
+    }
+
     void setNodePattern(unique_ptr<NodePattern> nodePattern) {
         this->nodePattern = move(nodePattern);
     }

--- a/src/parser/include/patterns/pattern_element_chain.h
+++ b/src/parser/include/patterns/pattern_element_chain.h
@@ -11,6 +11,10 @@ namespace parser {
 class PatternElementChain {
 
 public:
+    const RelPattern& getRelPattern() const { return *relPattern; }
+
+    const NodePattern& getNodePattern() const { return *nodePattern; }
+
     void setRelPattern(unique_ptr<RelPattern> relPattern) { this->relPattern = move(relPattern); }
 
     void setNodePattern(unique_ptr<NodePattern> nodePattern) {

--- a/src/parser/include/patterns/rel_pattern.h
+++ b/src/parser/include/patterns/rel_pattern.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include "src/common/include/types.h"
 #include "src/parser/include/patterns/node_pattern.h"
-
-using namespace graphflow::common;
 
 namespace graphflow {
 namespace parser {
+
+enum ArrowDirection : uint8_t { LEFT = 0, RIGHT = 1 };
 
 /**
  * RelationshipPattern represents "-[relName:RelLabel]-"
@@ -14,22 +13,26 @@ namespace parser {
 class RelPattern {
 
 public:
+    string getName() const { return name; }
+
+    string getType() const { return type; }
+
+    ArrowDirection getDirection() const { return arrowDirection; }
+
     void setName(const string& name) { this->name = name; }
 
     void setType(const string& type) { this->type = type; }
 
-    void setDirection(Direction direction) { this->direction = direction; }
+    void setDirection(ArrowDirection arrowDirection) { this->arrowDirection = arrowDirection; }
 
     bool operator==(const RelPattern& other) {
-        return name == other.name && type == other.type && direction == other.direction;
+        return name == other.name && type == other.type && arrowDirection == other.arrowDirection;
     }
 
 private:
     string name;
-
     string type;
-
-    Direction direction;
+    ArrowDirection arrowDirection;
 };
 
 } // namespace parser

--- a/src/parser/include/single_query.h
+++ b/src/parser/include/single_query.h
@@ -8,6 +8,10 @@ namespace parser {
 class SingleQuery {
 
 public:
+    int getNumStatements() const { return statements.size(); }
+
+    const MatchStatement& getMatchStatement(int idx) const { return *statements[idx]; }
+
     void addMatchStatement(unique_ptr<MatchStatement> statement) {
         statements.push_back(move(statement));
     }

--- a/src/parser/include/statements/match_statement.h
+++ b/src/parser/include/statements/match_statement.h
@@ -12,6 +12,10 @@ public:
     explicit MatchStatement(vector<unique_ptr<PatternElement>> patternElements)
         : graphPattern{move(patternElements)} {}
 
+    int getNumPatternElement() const { return graphPattern.size(); }
+
+    const PatternElement& getPatternElement(int idx) const { return *graphPattern[idx]; }
+
     void setWhereClause(unique_ptr<ParsedExpression> whereClause) {
         this->whereClause = move(whereClause);
     }

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -111,7 +111,8 @@ unique_ptr<RelPattern> Transformer::transformRelationshipPattern(
     auto relPattern = ctx->oC_RelationshipDetail() ?
                           transformRelationshipDetail(ctx->oC_RelationshipDetail()) :
                           make_unique<RelPattern>();
-    relPattern->setDirection(ctx->oC_LeftArrowHead() ? BWD : FWD);
+    relPattern->setDirection(
+        ctx->oC_LeftArrowHead() ? ArrowDirection::LEFT : ArrowDirection::RIGHT);
     return relPattern;
 }
 

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+
+cc_library(
+    name = "binder",
+    srcs = [
+        "binder.cpp",
+    ],
+    hdrs = [
+        "include/binder.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "bound_statement",
+        "query_graph",
+        "//src/parser",
+        "//src/storage:catalog",
+    ],
+)
+
+cc_library(
+    name = "bound_statement",
+    hdrs = [
+        "include/bound_statements/bound_match_statement.h",
+    ],
+)
+
+cc_library(
+    name = "query_graph",
+    srcs = [
+        "query_graph/query_graph.cpp",
+    ],
+    hdrs = [
+        "include/query_graph/query_graph.h",
+        "include/query_graph/query_node.h",
+        "include/query_graph/query_rel.h",
+    ],
+    deps = [
+        "//src/common",
+    ],
+)

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -1,0 +1,115 @@
+#include "src/planner/include/binder.h"
+
+namespace graphflow {
+namespace planner {
+
+vector<unique_ptr<BoundMatchStatement>> Binder::bindSingleQuery(const SingleQuery& singleQuery) {
+    vector<unique_ptr<BoundMatchStatement>> boundStatements;
+    for (auto i = 0; i < singleQuery.getNumStatements(); ++i) {
+        boundStatements.push_back(bindStatement(singleQuery.getMatchStatement(i)));
+    }
+    return boundStatements;
+}
+
+unique_ptr<BoundMatchStatement> Binder::bindStatement(const MatchStatement& matchStatement) {
+    auto queryGraph = make_unique<QueryGraph>();
+    for (auto i = 0; i < matchStatement.getNumPatternElement(); ++i) {
+        bindQueryRels(matchStatement.getPatternElement(i), *queryGraph);
+    }
+    if (!queryGraph->isConnected()) {
+        throw invalid_argument("Disconnected query graph is not yet supported.");
+    }
+    return make_unique<BoundMatchStatement>(move(queryGraph));
+}
+
+void Binder::bindQueryRels(const PatternElement& patternElement, QueryGraph& queryGraph) {
+    QueryNode* leftNode = bindQueryNode(patternElement.getNodePattern(), queryGraph);
+    for (auto i = 0; i < patternElement.getNumPatternElementChain(); ++i) {
+        auto rel = bindQueryRel(patternElement.getPatternElementChain(i), leftNode, queryGraph);
+        leftNode = ArrowDirection::RIGHT ==
+                           patternElement.getPatternElementChain(i).getRelPattern().getDirection() ?
+                       rel->getDstNode() :
+                       rel->getSrcNode();
+    }
+}
+
+QueryRel* Binder::bindQueryRel(
+    const PatternElementChain& patternElementChain, QueryNode* leftNode, QueryGraph& queryGraph) {
+    auto parsedName = patternElementChain.getRelPattern().getName();
+    if (parsedName.empty()) {
+        parsedName = "_gfR_" + to_string(queryGraph.numQueryRels());
+    } else if (queryGraph.containsQueryRel(parsedName)) {
+        throw invalid_argument("Reuse name: " + parsedName + " for different relationships.");
+    } else if (queryGraph.containsQueryNode(parsedName)) {
+        throw invalid_argument("Reuse name: " + parsedName + " for node and relationship.");
+    }
+    auto queryRel = make_unique<QueryRel>(
+        parsedName, bindRelLabel(patternElementChain.getRelPattern().getType()));
+    auto leftNodeIsSrc =
+        ArrowDirection::RIGHT == patternElementChain.getRelPattern().getDirection();
+    bindNodeToRel(queryRel.get(), leftNode, leftNodeIsSrc);
+    bindNodeToRel(queryRel.get(), bindQueryNode(patternElementChain.getNodePattern(), queryGraph),
+        !leftNodeIsSrc);
+    queryGraph.addQueryRel(move(queryRel));
+    return queryGraph.getQueryRel(parsedName);
+}
+
+QueryNode* Binder::bindQueryNode(const NodePattern& nodePattern, QueryGraph& queryGraph) {
+    auto parsedName = nodePattern.getName();
+    if (parsedName.empty()) { // create anonymous node
+        parsedName = "_gfN_" + to_string(queryGraph.numQueryNodes());
+    } else if (queryGraph.containsQueryRel(parsedName)) {
+        throw invalid_argument("Reuse name: " + parsedName + " for node and relationship");
+    } else if (queryGraph.containsQueryNode(parsedName)) { // bind to previous bound node
+        auto label = bindNodeLabel(nodePattern.getLabel());
+        if (ANY_LABEL == label || queryGraph.getQueryNode(parsedName)->getLabel() == label) {
+            return queryGraph.getQueryNode(parsedName);
+        } else {
+            throw invalid_argument("Multi-label query nodes are not supported. " + parsedName +
+                                   " is given multiple labels");
+        }
+    }
+    auto queryNode = make_unique<QueryNode>(parsedName, bindNodeLabel(nodePattern.getLabel()));
+    queryGraph.addQueryNode(move(queryNode));
+    return queryGraph.getQueryNode(parsedName);
+}
+
+int Binder::bindRelLabel(const string& parsed_label) {
+    if (parsed_label.empty()) {
+        return ANY_LABEL;
+    }
+    if (!catalog.containRelLabel(parsed_label.c_str())) {
+        throw invalid_argument("Rel label: " + parsed_label + " does not exist.");
+    }
+    return catalog.getRelLabelFromString(parsed_label.c_str());
+}
+
+int Binder::bindNodeLabel(const string& parsed_label) {
+    if (parsed_label.empty()) {
+        return ANY_LABEL;
+    }
+    if (!catalog.containNodeLabel(parsed_label.c_str())) {
+        throw invalid_argument("Node label: " + parsed_label + " does not exist.");
+    }
+    return catalog.getNodeLabelFromString(parsed_label.c_str());
+}
+
+void Binder::bindNodeToRel(QueryRel* queryRel, QueryNode* queryNode, bool isSrcNode) {
+    if (ANY_LABEL != queryNode->getLabel() && ANY_LABEL != queryRel->getLabel()) {
+        auto relLabels =
+            catalog.getRelLabelsForNodeLabelDirection(queryNode->getLabel(), isSrcNode ? FWD : BWD);
+        for (auto it = begin(relLabels); it != end(relLabels); ++it) {
+            if (*it == queryRel->getLabel()) {
+                isSrcNode ? queryRel->setSrcNode(queryNode) : queryRel->setDstNode(queryNode);
+                return;
+            }
+        }
+        throw invalid_argument(
+            "Node: " + queryNode->getName() +
+            " doesn't connect to edge with same type as: " + queryRel->getName());
+    }
+    isSrcNode ? queryRel->setSrcNode(queryNode) : queryRel->setDstNode(queryNode);
+}
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/binder.h
+++ b/src/planner/include/binder.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "src/parser/include/single_query.h"
+#include "src/planner/include/bound_statements/bound_match_statement.h"
+#include "src/storage/include/catalog.h"
+
+using namespace graphflow::storage;
+using namespace graphflow::parser;
+
+namespace graphflow {
+namespace planner {
+
+class Binder {
+
+public:
+    explicit Binder(const Catalog& catalog) : catalog{catalog} {}
+
+    vector<unique_ptr<BoundMatchStatement>> bindSingleQuery(const SingleQuery& singleQuery);
+
+private:
+    unique_ptr<BoundMatchStatement> bindStatement(const MatchStatement& matchStatement);
+
+    void bindQueryRels(const PatternElement& patternElement, QueryGraph& queryGraph);
+
+    QueryRel* bindQueryRel(const PatternElementChain& patternElementChain, QueryNode* leftNode,
+        QueryGraph& queryGraph);
+
+    QueryNode* bindQueryNode(const NodePattern& nodePattern, QueryGraph& queryGraph);
+
+    int bindRelLabel(const string& parsed_label);
+
+    int bindNodeLabel(const string& parsed_label);
+
+    void bindNodeToRel(QueryRel* queryRel, QueryNode* queryNode, bool isSrcNode);
+
+private:
+    const Catalog& catalog;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/bound_statements/bound_match_statement.h
+++ b/src/planner/include/bound_statements/bound_match_statement.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "src/planner/include/query_graph/query_graph.h"
+
+namespace graphflow {
+namespace planner {
+
+class BoundMatchStatement {
+
+public:
+    explicit BoundMatchStatement(unique_ptr<QueryGraph> queryGraph)
+        : queryGraph{move(queryGraph)} {}
+
+    bool operator==(const BoundMatchStatement& other) const {
+        return *queryGraph == *other.queryGraph;
+    }
+
+private:
+    unique_ptr<QueryGraph> queryGraph;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/query_graph/query_graph.h
+++ b/src/planner/include/query_graph/query_graph.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <memory>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include "src/planner/include/query_graph/query_rel.h"
+
+namespace graphflow {
+namespace planner {
+
+class QueryGraph {
+
+public:
+    int numQueryNodes() const;
+
+    bool containsQueryNode(const string& nodeName) const;
+
+    QueryNode* getQueryNode(const string& nodeName) const;
+
+    void addQueryNode(unique_ptr<QueryNode> queryNode);
+
+    int numQueryRels() const;
+
+    bool containsQueryRel(const string& relName) const;
+
+    QueryRel* getQueryRel(const string& relName) const;
+
+    void addQueryRel(unique_ptr<QueryRel> queryRel);
+
+    bool isConnected() const;
+
+    bool operator==(const QueryGraph& other) const;
+
+private:
+    vector<QueryNode*> getNeighbourQueryNodes(const string& nodeName) const;
+
+private:
+    unordered_map<string, unique_ptr<QueryNode>> nameToQueryNodeMap;
+    unordered_map<string, unique_ptr<QueryRel>> nameToQueryRelMap;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/query_graph/query_node.h
+++ b/src/planner/include/query_graph/query_node.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+#include <utility>
+
+using namespace std;
+
+namespace graphflow {
+namespace planner {
+
+const int ANY_LABEL = -1;
+
+class QueryNode {
+
+public:
+    QueryNode(string name, int label) : name{move(name)}, label{label} {}
+
+    string getName() const { return name; }
+
+    int getLabel() const { return label; }
+
+    bool operator==(const QueryNode& other) const {
+        return name == other.name && label == other.label;
+    }
+
+private:
+    string name;
+    int label;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/query_graph/query_rel.h
+++ b/src/planner/include/query_graph/query_rel.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "src/planner/include/query_graph/query_node.h"
+
+namespace graphflow {
+namespace planner {
+
+class QueryRel {
+
+public:
+    QueryRel(string name, int label) : name{move(name)}, label{label} {}
+
+    string getName() const { return name; }
+
+    int getLabel() const { return label; }
+
+    QueryNode* getSrcNode() const { return srcNode; }
+
+    QueryNode* getDstNode() const { return dstNode; }
+
+    void setSrcNode(QueryNode* queryNode) { srcNode = queryNode; }
+
+    void setDstNode(QueryNode* queryNode) { dstNode = queryNode; }
+
+    bool operator==(const QueryRel& other) const {
+        auto result = name == other.name && label == other.label;
+        result &= *srcNode == *other.srcNode;
+        result &= *dstNode == *other.dstNode;
+        return result;
+    }
+
+private:
+    string name;
+    int label;
+    QueryNode* srcNode;
+    QueryNode* dstNode;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/query_graph/query_graph.cpp
+++ b/src/planner/query_graph/query_graph.cpp
@@ -1,0 +1,90 @@
+#include "src/planner/include/query_graph/query_graph.h"
+
+namespace graphflow {
+namespace planner {
+
+int QueryGraph::numQueryNodes() const {
+    return nameToQueryNodeMap.size();
+}
+
+bool QueryGraph::containsQueryNode(const string& nodeName) const {
+    return end(nameToQueryNodeMap) != nameToQueryNodeMap.find(nodeName);
+}
+
+QueryNode* QueryGraph::getQueryNode(const string& nodeName) const {
+    return nameToQueryNodeMap.find(nodeName)->second.get();
+}
+
+void QueryGraph::addQueryNode(unique_ptr<QueryNode> queryNode) {
+    nameToQueryNodeMap.insert({queryNode->getName(), move(queryNode)});
+}
+
+int QueryGraph::numQueryRels() const {
+    return nameToQueryRelMap.size();
+}
+
+bool QueryGraph::containsQueryRel(const string& relName) const {
+    return end(nameToQueryRelMap) != nameToQueryRelMap.find(relName);
+}
+
+QueryRel* QueryGraph::getQueryRel(const string& relName) const {
+    return nameToQueryRelMap.find(relName)->second.get();
+}
+
+void QueryGraph::addQueryRel(unique_ptr<QueryRel> queryRel) {
+    nameToQueryRelMap.insert({queryRel->getName(), move(queryRel)});
+}
+
+bool QueryGraph::isConnected() const {
+    auto visited = unordered_set<string>();
+    auto frontier = unordered_set<string>();
+    auto src = begin(nameToQueryNodeMap)->first;
+    frontier.insert(src);
+    while (!frontier.empty()) {
+        auto nextFrontier = unordered_set<string>();
+        for (auto frontierIt = begin(frontier); frontierIt != end(frontier); ++frontierIt) {
+            auto nbrs = getNeighbourQueryNodes(*frontierIt);
+            for (auto nbrIt = begin(nbrs); nbrIt != end(nbrs); ++nbrIt) {
+                if (end(visited) == visited.find((*nbrIt)->getName())) {
+                    visited.insert((*nbrIt)->getName());
+                    nextFrontier.insert((*nbrIt)->getName());
+                }
+            }
+        }
+        if (visited.size() == numQueryNodes()) {
+            return true;
+        }
+        frontier = nextFrontier;
+    }
+    return false;
+}
+
+bool QueryGraph::operator==(const QueryGraph& other) const {
+    auto result = true;
+    result &= nameToQueryNodeMap.size() == other.nameToQueryNodeMap.size();
+    for (auto it = begin(nameToQueryNodeMap); it != end(nameToQueryNodeMap); ++it) {
+        result &=
+            other.containsQueryNode(it->first) && *it->second == *other.getQueryNode(it->first);
+    }
+    result &= nameToQueryRelMap.size() == other.nameToQueryRelMap.size();
+    for (auto it = begin(nameToQueryRelMap); it != end(nameToQueryRelMap); ++it) {
+        result &= other.containsQueryRel(it->first) && *it->second == *other.getQueryRel(it->first);
+    }
+    return result;
+}
+
+vector<QueryNode*> QueryGraph::getNeighbourQueryNodes(const string& nodeName) const {
+    auto nbrs = vector<QueryNode*>();
+    for (auto it = begin(nameToQueryRelMap); it != end(nameToQueryRelMap); ++it) {
+        if (it->second->getSrcNode()->getName() == nodeName) {
+            nbrs.push_back(it->second->getDstNode());
+        }
+        if (it->second->getDstNode()->getName() == nodeName) {
+            nbrs.push_back(it->second->getSrcNode());
+        }
+    }
+    return nbrs;
+}
+
+} // namespace planner
+} // namespace graphflow

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -34,11 +34,32 @@ class Catalog {
 public:
     Catalog(const string& directory);
 
+    // This constructor is used for Binder unit tests
+    Catalog(stringToLabelMap_t stringToNodeLabelMap, stringToLabelMap_t stringToRelLabelMap,
+        vector<vector<label_t>> srcNodeLabelToRelLabel,
+        vector<vector<label_t>> dstNodeLabelToRelLabel,
+        vector<vector<label_t>> relLabelToSrcNodeLabels,
+        vector<vector<label_t>> relLabelToDstNodeLabels)
+        : stringToNodeLabelMap{move(stringToNodeLabelMap)}, stringToRelLabelMap{move(
+                                                                stringToRelLabelMap)},
+          relLabelToSrcNodeLabels{move(relLabelToSrcNodeLabels)}, relLabelToDstNodeLabels{move(
+                                                                      relLabelToDstNodeLabels)},
+          srcNodeLabelToRelLabel{move(srcNodeLabelToRelLabel)}, dstNodeLabelToRelLabel{
+                                                                    move(dstNodeLabelToRelLabel)} {}
+
     inline const uint32_t getNodeLabelsCount() const { return stringToNodeLabelMap.size(); }
     inline const uint32_t getRelLabelsCount() const { return stringToRelLabelMap.size(); }
 
+    inline const bool containNodeLabel(const char* label) const {
+        return end(stringToNodeLabelMap) != stringToNodeLabelMap.find(label);
+    }
+
     inline const label_t& getNodeLabelFromString(const char* label) const {
         return stringToNodeLabelMap.at(label);
+    }
+
+    inline const bool containRelLabel(const char* label) const {
+        return end(stringToRelLabelMap) != stringToRelLabelMap.find(label);
     }
 
     inline const label_t& getRelLabelFromString(const char* label) const {
@@ -67,6 +88,7 @@ public:
 
     const vector<label_t>& getRelLabelsForNodeLabelDirection(
         const label_t& nodeLabel, const Direction& dir) const;
+
     const vector<label_t>& getNodeLabelsForRelLabelDir(
         const label_t& relLabel, const Direction& dir) const;
 

--- a/test/parser/graph_pattern_test.cpp
+++ b/test/parser/graph_pattern_test.cpp
@@ -15,7 +15,7 @@ public:
         return node;
     }
 
-    unique_ptr<RelPattern> makeRelPattern(string name, string type, Direction direction) {
+    unique_ptr<RelPattern> makeRelPattern(string name, string type, ArrowDirection direction) {
         auto rel = make_unique<RelPattern>();
         rel->setName(name);
         rel->setType(type);
@@ -98,7 +98,7 @@ TEST_F(GraphPatternTest, MATCHSingleElementAnonymousNodeSingleLabelTest) {
 TEST_F(GraphPatternTest, MATCHSingleElementSingleEdgeNoTypeTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge = makeRelPattern("e1", string(), FWD);
+    auto expectedEdge = makeRelPattern("e1", string(), RIGHT);
     auto expectedPatternElementChain = makePatternElementChain(move(expectedEdge), move(expectedNodeB));
     auto expectedPatternElement = makePatternElement(move(expectedNodeA));
     expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain));
@@ -116,7 +116,7 @@ TEST_F(GraphPatternTest, MATCHSingleElementSingleEdgeNoTypeTest) {
 TEST_F(GraphPatternTest, MATCHSingleElementSingleEdgeSingleTypeTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge = makeRelPattern("e1", "knows", FWD);
+    auto expectedEdge = makeRelPattern("e1", "knows", RIGHT);
     auto expectedPatternElementChain = makePatternElementChain(move(expectedEdge), move(expectedNodeB));
     auto expectedPatternElement = makePatternElement(move(expectedNodeA));
     expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain));
@@ -134,7 +134,7 @@ TEST_F(GraphPatternTest, MATCHSingleElementSingleEdgeSingleTypeTest) {
 TEST_F(GraphPatternTest, MATCHSingleElementAnonymousEdgeMultiTypesTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge = makeRelPattern(string(), "knows", FWD);
+    auto expectedEdge = makeRelPattern(string(), "knows", RIGHT);
     auto expectedPatternElementChain = makePatternElementChain(move(expectedEdge), move(expectedNodeB));
     auto expectedPatternElement = makePatternElement(move(expectedNodeA));
     expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain));
@@ -152,10 +152,10 @@ TEST_F(GraphPatternTest, MATCHSingleElementAnonymousEdgeMultiTypesTest) {
 TEST_F(GraphPatternTest, MATCHSingleElementMultiEdgesTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge1 = makeRelPattern(string(), "knows", FWD);
+    auto expectedEdge1 = makeRelPattern(string(), "knows", RIGHT);
     auto expectedPatternElementChain1 = makePatternElementChain(move(expectedEdge1), move(expectedNodeB));
     auto expectedNodeC = makeNodePattern("c", "Student");
-    auto expectedEdge2 = makeRelPattern("e2", "likes", BWD);
+    auto expectedEdge2 = makeRelPattern("e2", "likes", LEFT);
     auto expectedPatternElementChain2 = makePatternElementChain(move(expectedEdge2), move(expectedNodeC));
     auto expectedPatternElement = makePatternElement(move(expectedNodeA));
     expectedPatternElement->addPatternElementChain(move(expectedPatternElementChain1));
@@ -174,14 +174,14 @@ TEST_F(GraphPatternTest, MATCHSingleElementMultiEdgesTest) {
 TEST_F(GraphPatternTest, MATCHMultiElementsTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge1 = makeRelPattern(string(), "knows", FWD);
+    auto expectedEdge1 = makeRelPattern(string(), "knows", RIGHT);
     auto expectedPatternElementChain1 = makePatternElementChain(move(expectedEdge1), move(expectedNodeB));
     auto expectedPatternElement1 = makePatternElement(move(expectedNodeA));
     expectedPatternElement1->addPatternElementChain(move(expectedPatternElementChain1));
 
     auto expectedNodeBDup = makeNodePattern("b", string());
     auto expectedNodeC = makeNodePattern("c", "Student");
-    auto expectedEdge2 = makeRelPattern("e2", "likes", BWD);
+    auto expectedEdge2 = makeRelPattern("e2", "likes", LEFT);
     auto expectedPatternElementChain2 = makePatternElementChain(move(expectedEdge2), move(expectedNodeC));
     auto expectedPatternElement2 = makePatternElement(move(expectedNodeBDup));
     expectedPatternElement2->addPatternElementChain(move(expectedPatternElementChain2));
@@ -201,7 +201,7 @@ TEST_F(GraphPatternTest, MATCHMultiElementsTest) {
 TEST_F(GraphPatternTest, MultiMatchTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge1 = makeRelPattern(string(), "knows", FWD);
+    auto expectedEdge1 = makeRelPattern(string(), "knows", RIGHT);
     auto expectedPatternElementChain1 = makePatternElementChain(move(expectedEdge1), move(expectedNodeB));
     auto expectedPatternElement1 = makePatternElement(move(expectedNodeA));
     expectedPatternElement1->addPatternElementChain(move(expectedPatternElementChain1));
@@ -211,7 +211,7 @@ TEST_F(GraphPatternTest, MultiMatchTest) {
 
     auto expectedNodeBDup = makeNodePattern("b", string());
     auto expectedNodeC = makeNodePattern("c", "Student");
-    auto expectedEdge2 = makeRelPattern("e2", "likes", BWD);
+    auto expectedEdge2 = makeRelPattern("e2", "likes", LEFT);
     auto expectedPatternElementChain2 = makePatternElementChain(move(expectedEdge2), move(expectedNodeC));
     auto expectedPatternElement2 = makePatternElement(move(expectedNodeBDup));
     expectedPatternElement2->addPatternElementChain(move(expectedPatternElementChain2));

--- a/test/planner/BUILD.bazel
+++ b/test/planner/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "binder_tests",
+    srcs = [
+        "query_graph_test.cpp"
+    ],
+    linkstatic = 1,
+    deps = [
+        "//src/planner:binder",
+        "//src/loader:loader",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/test/planner/query_graph_test.cpp
+++ b/test/planner/query_graph_test.cpp
@@ -1,0 +1,197 @@
+#include "gtest/gtest.h"
+
+#include "src/planner/include/binder.h"
+#include "src/loader/include/graph_loader.h"
+#include "src/parser/include/parser.h"
+
+using namespace graphflow::loader;
+using namespace graphflow::planner;
+
+class QueryGraphTest : public :: testing::Test {
+
+public:
+    void SetUp() override {
+        catalog = make_unique<Catalog>(createStringToNodeLabelMap(), createStringToRelLabelMap(),
+            createSrcNodeLabelToRelLabelsVector(), createDstNodeLabelToRelLabelsVector(),
+            createRelLabelToSrcNodeLabels(), createRelLabelToDstNodeLabels());
+    }
+
+private:
+    stringToLabelMap_t createStringToNodeLabelMap() {
+        stringToLabelMap_t map;
+        map.insert({"person", 0});
+        map.insert({"comment", 1});
+        return map;
+    }
+
+    stringToLabelMap_t createStringToRelLabelMap() {
+        stringToLabelMap_t map;
+        map.insert({"knows", 0});
+        map.insert({"likes", 1});
+        return map;
+    }
+
+    vector<vector<label_t>> createSrcNodeLabelToRelLabelsVector() {
+        vector<vector<label_t>> result;
+        vector<label_t> personToRelLabel = {0, 1};
+        vector<label_t> commentToRelLabel = {};
+        result.push_back(personToRelLabel);
+        result.push_back(commentToRelLabel);
+        return result;
+    }
+
+    vector<vector<label_t>> createDstNodeLabelToRelLabelsVector() {
+        vector<vector<label_t>> result;
+        vector<label_t> personToRelLabel = {0};
+        vector<label_t> commentToRelLabel = {1};
+        result.push_back(personToRelLabel);
+        result.push_back(commentToRelLabel);
+        return result;
+    }
+
+    vector<vector<label_t>> createRelLabelToSrcNodeLabels() {
+        vector<vector<label_t>> result;
+        result.resize(2);
+        vector<label_t> knowsToSrcLabels = {0};
+        vector<label_t> likesToSrcLabels = {0};
+        result.push_back(knowsToSrcLabels);
+        result.push_back(likesToSrcLabels);
+        return result;
+    }
+
+    vector<vector<label_t>> createRelLabelToDstNodeLabels() {
+        vector<vector<label_t>> result;
+        result.resize(2);
+        vector<label_t> knowsToDstLabels = {0};
+        vector<label_t> likesToDstLabels = {1};
+        result.push_back(knowsToDstLabels);
+        result.push_back(likesToDstLabels);
+        return result;
+    }
+
+public:
+    unique_ptr<Catalog> catalog;
+};
+
+TEST_F(QueryGraphTest, SingleEdgeTest) {
+    auto expectedQueryNodeA = make_unique<QueryNode>("a", catalog->getNodeLabelFromString("person"));
+    auto expectedQueryNodeB = make_unique<QueryNode>("b", catalog->getNodeLabelFromString("person"));
+    auto expectedQueryRel = make_unique<QueryRel>("e1", catalog->getRelLabelFromString("knows"));
+    expectedQueryRel->setSrcNode(expectedQueryNodeA.get());
+    expectedQueryRel->setDstNode(expectedQueryNodeB.get());
+    auto expectedQueryGraph = make_unique<QueryGraph>();
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeA));
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeB));
+    expectedQueryGraph->addQueryRel(move(expectedQueryRel));
+    auto expectedMatch = make_unique<BoundMatchStatement>(move(expectedQueryGraph));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:person)-[e1:knows]->(b:person);";
+
+    auto binder = make_unique<Binder>(*catalog);
+    auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+    ASSERT_TRUE(*boundStatements.at(0) == *expectedMatch);
+}
+
+TEST_F(QueryGraphTest, MultiEdgesTest) {
+    auto expectedQueryNodeA = make_unique<QueryNode>("a", catalog->getNodeLabelFromString("person"));
+    auto expectedQueryNodeB = make_unique<QueryNode>("_gfN_1", catalog->getNodeLabelFromString("person"));
+    auto expectedQueryRel1 = make_unique<QueryRel>("e1", catalog->getRelLabelFromString("knows"));
+    expectedQueryRel1->setSrcNode(expectedQueryNodeA.get());
+    expectedQueryRel1->setDstNode(expectedQueryNodeB.get());
+    auto expectedQueryNodeC = make_unique<QueryNode>("c", catalog->getNodeLabelFromString("comment"));
+    auto expectedQueryRel2 = make_unique<QueryRel>("e2", catalog->getRelLabelFromString("likes"));
+    expectedQueryRel2->setSrcNode(expectedQueryNodeB.get());
+    expectedQueryRel2->setDstNode(expectedQueryNodeC.get());
+    auto expectedQueryGraph = make_unique<QueryGraph>();
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeA));
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeB));
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeC));
+    expectedQueryGraph->addQueryRel(move(expectedQueryRel1));
+    expectedQueryGraph->addQueryRel(move(expectedQueryRel2));
+    auto expectedMatch = make_unique<BoundMatchStatement>(move(expectedQueryGraph));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:person)-[e1:knows]->(:person)-[e2:likes]->(c:comment);";
+
+    auto binder = make_unique<Binder>(*catalog);
+    auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+    ASSERT_TRUE(*boundStatements.at(0) == *expectedMatch);
+}
+
+TEST_F(QueryGraphTest, MultiPatternElementsTest) {
+    auto expectedQueryNodeA = make_unique<QueryNode>("a", catalog->getNodeLabelFromString("person"));
+    auto expectedQueryNodeB = make_unique<QueryNode>("_gfN_1", catalog->getNodeLabelFromString("person"));
+    auto expectedQueryRel1 = make_unique<QueryRel>("e1", catalog->getRelLabelFromString("knows"));
+    expectedQueryRel1->setSrcNode(expectedQueryNodeA.get());
+    expectedQueryRel1->setDstNode(expectedQueryNodeB.get());
+    auto expectedQueryNodeC = make_unique<QueryNode>("c", catalog->getNodeLabelFromString("comment"));
+    auto expectedQueryRel2 = make_unique<QueryRel>("e2", catalog->getRelLabelFromString("likes"));
+    expectedQueryRel2->setSrcNode(expectedQueryNodeB.get());
+    expectedQueryRel2->setDstNode(expectedQueryNodeC.get());
+    auto expectedQueryNodeD = make_unique<QueryNode>("d", catalog->getNodeLabelFromString("person"));
+    auto expectedQueryRel3 = make_unique<QueryRel>("_gfR_2", catalog->getRelLabelFromString("likes"));
+    expectedQueryRel3->setSrcNode(expectedQueryNodeD.get());
+    expectedQueryRel3->setDstNode(expectedQueryNodeC.get());
+    auto expectedQueryGraph = make_unique<QueryGraph>();
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeA));
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeB));
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeC));
+    expectedQueryGraph->addQueryNode(move(expectedQueryNodeD));
+    expectedQueryGraph->addQueryRel(move(expectedQueryRel1));
+    expectedQueryGraph->addQueryRel(move(expectedQueryRel2));
+    expectedQueryGraph->addQueryRel(move(expectedQueryRel3));
+    auto expectedMatch = make_unique<BoundMatchStatement>(move(expectedQueryGraph));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH (a:person)-[e1:knows]->(:person)-[e2:likes]->(c:comment), (c)<-[:likes]-(d:person);";
+
+    auto binder = make_unique<Binder>(*catalog);
+    auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+    ASSERT_TRUE(*boundStatements.at(0) == *expectedMatch);
+}
+
+TEST_F(QueryGraphTest, NonExistLabelTest) {
+    EXPECT_THROW({
+         graphflow::parser::Parser parser;
+         string input = "MATCH (a:dummy);";
+         auto binder = make_unique<Binder>(*catalog);
+         auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+    }, invalid_argument);
+}
+
+TEST_F(QueryGraphTest, RepeatedNameTest) {
+    EXPECT_THROW({
+         graphflow::parser::Parser parser;
+         string input = "MATCH (a:person)-[e1:knows]->(b:person)-[e1:knows]->(c:person);";
+         auto binder = make_unique<Binder>(*catalog);
+         auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+     }, invalid_argument);
+}
+
+TEST_F(QueryGraphTest, MultiLabelTest) {
+    EXPECT_THROW({
+         graphflow::parser::Parser parser;
+         string input = "MATCH (a:person)-[e1:knows]->(b:person), (b:comment);";
+         auto binder = make_unique<Binder>(*catalog);
+         auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+     }, invalid_argument);
+}
+
+TEST_F(QueryGraphTest, NoMatchedRelTest) {
+    EXPECT_THROW({
+         graphflow::parser::Parser parser;
+         string input = "MATCH (a:person)-[e1:likes]->(b:person);";
+         auto binder = make_unique<Binder>(*catalog);
+         auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+     }, invalid_argument);
+}
+
+TEST_F(QueryGraphTest, DisconnectGraphTest) {
+    EXPECT_THROW({
+         graphflow::parser::Parser parser;
+         string input = "MATCH (a:person)-[e1:likes]->(b:person), (c:comment);";
+         auto binder = make_unique<Binder>(*catalog);
+         auto boundStatements = binder->bindSingleQuery(*parser.parseQuery(input));
+     }, invalid_argument);
+}


### PR DESCRIPTION
This PR adds binder logic for parsed graph pattern.
### Binder
Binder validates and converts parsed graph pattern to query graph which will be used for planner.

**QueryGraph**
- Map nodeName->queryNode
- Map relName->queryRel

**QueryRel**
- name, label, srcNode, dstNode

**QueryNode**
- name, label

**Validation**
-  NodeLabel must exist in catalog
-  RelLabel must exist in catalog
-  Node and Rel cannot use the same name  
   - Rel and Rel cannot use the same name
   - If two node use the same name, then infer them as the same node e.g. `...->(b:Person), (b)-...`
- Node cannot have multi label e.g.  `...->(b:Person), (b:Student)-...`
- NodeLabel has outgoing/incoming relLabel as declared in the input
- Querygraph is connected