### PR TITLE
replace elementSize with dataType for ValueVector creation

### DIFF
--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -53,7 +53,7 @@ DataType getBinaryExpressionResultDataType(
         if (leftOperandType == DOUBLE || rightOperandType == DOUBLE) {
             return DOUBLE;
         }
-        return INT;
+        return INT32;
     case POWER:
         return DOUBLE;
     default:

--- a/src/common/include/literal.h
+++ b/src/common/include/literal.h
@@ -18,7 +18,7 @@ public:
 
     explicit Literal(uint8_t value) : type(BOOL) { this->primitive.boolean = value; }
 
-    explicit Literal(int32_t value) : type(INT) { this->primitive.integer = value; }
+    explicit Literal(int32_t value) : type(INT32) { this->primitive.integer = value; }
 
     explicit Literal(double value) : type(DOUBLE) { this->primitive.double_ = value; }
 

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -75,7 +75,7 @@ struct overflow_value_t {
     uint8_t* value;
 };
 
-enum DataType { REL, NODE, LABEL, BOOL, INT, DOUBLE, STRING };
+enum DataType { REL, NODE, LABEL, BOOL, INT32, INT64, DOUBLE, STRING };
 const string DataTypeNames[] = {"REL", "NODE", "LABEL", "BOOL", "INT", "DOUBLE", "STRING"};
 
 class Property {

--- a/src/common/include/vector/node_vector.h
+++ b/src/common/include/vector/node_vector.h
@@ -53,11 +53,8 @@ protected:
 
     NodeIDVector(label_t commonLabel, const NodeIDCompressionScheme& nodeIDCompressionScheme,
         bool isSequence, uint64_t vectorCapacity)
-        : ValueVector{nodeIDCompressionScheme.getNumTotalBytes(), vectorCapacity},
-          commonLabel{commonLabel}, nodeIDCompressionScheme{nodeIDCompressionScheme},
-          isSequence{isSequence} {
-        dataType = NODE;
-    };
+        : ValueVector{NODE, vectorCapacity}, commonLabel{commonLabel},
+          nodeIDCompressionScheme{nodeIDCompressionScheme}, isSequence{isSequence} {};
 
 protected:
     label_t commonLabel;

--- a/src/common/include/vector/operations/executors/unary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/unary_operation_executor.h
@@ -20,9 +20,7 @@ struct UnaryOperationExecutor {
         } else {
             auto size = operand.size();
             for (uint64_t i = 0; i < size; i++) {
-                std::cout << "values[" << i << "] = " << values[i] << std::endl;
                 resultValues[i] = FUNC::operation(values[i]);
-                std::cout << "resultValues[" << i << "] = " << resultValues[i] << std::endl;
             }
         }
     }

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -16,20 +16,11 @@ public:
     static function<void(ValueVector&, ValueVector&, ValueVector&)> getBinaryOperation(
         ExpressionType type);
 
-    ValueVector(const uint64_t& elementSize, const uint64_t& vectorCapacity)
-        : capacity{elementSize * vectorCapacity},
-          buffer(make_unique<uint8_t[]>(capacity)), values{buffer.get()} {}
-
-    ValueVector(const uint64_t& elementSize) : ValueVector(elementSize, VECTOR_CAPACITY) {}
-
     ValueVector(const DataType& dataType, const uint64_t& vectorCapacity)
-        : ValueVector(getDataTypeSize(dataType), vectorCapacity) {
-        this->dataType = dataType;
-    }
+        : capacity{getDataTypeSize(dataType) * vectorCapacity},
+          buffer(make_unique<uint8_t[]>(capacity)), values{buffer.get()}, dataType{dataType} {}
 
-    ValueVector(const DataType& dataType) : ValueVector(getDataTypeSize(dataType)) {
-        this->dataType = dataType;
-    }
+    ValueVector(const DataType& dataType) : ValueVector(dataType, VECTOR_CAPACITY) {}
 
     inline DataType getDataType() const { return dataType; }
 

--- a/src/common/literal.cpp
+++ b/src/common/literal.cpp
@@ -9,7 +9,7 @@ string Literal::toString() const {
     switch (type) {
     case BOOL:
         return primitive.boolean ? "True" : "False";
-    case INT:
+    case INT32:
         return to_string(primitive.integer);
     case DOUBLE:
         return to_string(primitive.double_);

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -12,8 +12,10 @@ DataType getDataType(const std::string& dataTypeString) {
         return NODE;
     } else if (0 == dataTypeString.compare("REL")) {
         return REL;
-    } else if (0 == dataTypeString.compare("INT")) {
-        return INT;
+    } else if (0 == dataTypeString.compare("INT32")) {
+        return INT32;
+    } else if (0 == dataTypeString.compare("INT64")) {
+        return INT64;
     } else if (0 == dataTypeString.compare("DOUBLE")) {
         return DOUBLE;
     } else if (0 == dataTypeString.compare("BOOLEAN")) {
@@ -26,18 +28,20 @@ DataType getDataType(const std::string& dataTypeString) {
 
 size_t getDataTypeSize(DataType dataType) {
     switch (dataType) {
-    case INT:
+    case LABEL:
+        return sizeof(label_t);
+    case NODE:
+        return NUM_BYTES_PER_NODE_ID;
+    case INT32:
         return sizeof(int32_t);
+    case INT64:
+        return sizeof(int64_t);
     case DOUBLE:
         return sizeof(double_t);
     case BOOL:
         return sizeof(uint8_t);
     case STRING:
         return sizeof(gf_string_t);
-    case NODE:
-        return NUM_BYTES_PER_NODE_ID;
-    case LABEL:
-        return sizeof(label_t);
     default:
         throw invalid_argument("Cannot infer the size of dataType.");
     }

--- a/src/common/vector/operations/vector_arithmetic_operations.cpp
+++ b/src/common/vector/operations/vector_arithmetic_operations.cpp
@@ -14,9 +14,9 @@ public:
     template<class OP>
     static inline void execute(ValueVector& left, ValueVector& right, ValueVector& result) {
         switch (left.getDataType()) {
-        case INT:
+        case INT32:
             switch (right.getDataType()) {
-            case INT:
+            case INT32:
                 if (std::is_same<OP, operation::Power>::value) {
                     BinaryOperationExecutor::execute<int32_t, int32_t, double_t, OP>(
                         left, right, result);
@@ -36,7 +36,7 @@ public:
             break;
         case DOUBLE:
             switch (right.getDataType()) {
-            case INT:
+            case INT32:
                 BinaryOperationExecutor::execute<double_t, int32_t, int32_t, OP>(
                     left, right, result);
                 break;
@@ -58,7 +58,7 @@ public:
     template<class OP>
     static inline void execute(ValueVector& operand, ValueVector& result) {
         switch (operand.getDataType()) {
-        case INT:
+        case INT32:
             UnaryOperationExecutor::execute<int32_t, int32_t, OP>(operand, result);
             break;
         case DOUBLE:

--- a/src/common/vector/operations/vector_boolean_operations.cpp
+++ b/src/common/vector/operations/vector_boolean_operations.cpp
@@ -15,7 +15,7 @@ public:
         case BOOL:
             operate<uint8_t, OP>(operand, result);
             break;
-        case INT:
+        case INT32:
             operate<int32_t, OP>(operand, result);
             break;
         case DOUBLE:

--- a/src/common/vector/operations/vector_comparison_operations.cpp
+++ b/src/common/vector/operations/vector_comparison_operations.cpp
@@ -19,7 +19,7 @@ public:
         case BOOL:
             compare<uint8_t, OP>(left, right, result);
             break;
-        case INT:
+        case INT32:
             compare<int32_t, OP>(left, right, result);
             break;
         case DOUBLE:

--- a/src/loader/nodes_loader.cpp
+++ b/src/loader/nodes_loader.cpp
@@ -95,10 +95,10 @@ void NodesLoader::putPropsOfLineIntoBuffers(const vector<DataType>& propertyData
     auto propertyIdx = 0;
     while (reader.hasNextToken()) {
         switch (propertyDataTypes[propertyIdx]) {
-        case INT: {
+        case INT32: {
             auto intVal = reader.skipTokenIfNull() ? NULL_INT : reader.getInteger();
-            memcpy(buffers[propertyIdx].get() + (bufferOffset * getDataTypeSize(INT)), &intVal,
-                getDataTypeSize(INT));
+            memcpy(buffers[propertyIdx].get() + (bufferOffset * getDataTypeSize(INT32)), &intVal,
+                getDataTypeSize(INT32));
             break;
         }
         case DOUBLE: {

--- a/src/loader/rels_loader.cpp
+++ b/src/loader/rels_loader.cpp
@@ -177,10 +177,10 @@ void RelsLoader::putPropsOfLineIntoInMemPropertyColumns(const vector<DataType>& 
     auto propertyIdx = 0u;
     while (reader.hasNextToken()) {
         switch (propertyDataTypes[propertyIdx]) {
-        case INT: {
+        case INT32: {
             auto intVal = reader.skipTokenIfNull() ? NULL_INT : reader.getInteger();
             adjAndPropertyColumnsLoaderHelper->setProperty(
-                nodeID, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT);
+                nodeID, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT32);
             break;
         }
         case DOUBLE: {
@@ -217,10 +217,10 @@ void RelsLoader::putPropsOfLineIntoInMemRelPropLists(const vector<DataType>& pro
     auto propertyIdx = 0;
     while (reader.hasNextToken()) {
         switch (propertyDataTypes[propertyIdx]) {
-        case INT: {
+        case INT32: {
             auto intVal = reader.skipTokenIfNull() ? NULL_INT : reader.getInteger();
             adjAndPropertyListsLoaderHelper->setProperty(
-                pos, nodeIDs, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT);
+                pos, nodeIDs, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT32);
             break;
         }
         case DOUBLE: {

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -52,5 +52,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/common",
+        "//src/expression"
     ],
 )

--- a/src/planner/include/logical_plan/operator/logical_operator.h
+++ b/src/planner/include/logical_plan/operator/logical_operator.h
@@ -10,9 +10,10 @@ namespace planner {
 
 enum LogicalOperatorType {
     SCAN,
+    EXTEND,
+    FILTER,
     NODE_PROPERTY_READER,
     REL_PROPERTY_READER,
-    EXTEND,
 };
 
 class LogicalOperator {

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -49,7 +49,7 @@ unique_ptr<PhysicalExpression> mapLogicalLiteralExpressionToPhysical(
     auto valueVector = make_shared<ValueVector>(dataType, 1 /* capacity */);
     valueVector->setDataChunkOwner(dataChunkForLiteral);
     switch (dataType) {
-    case INT: {
+    case INT32: {
         valueVector->setValue(0, expression.getLiteralValue().primitive.integer);
     } break;
     case DOUBLE: {

--- a/src/processor/physical_plan/operator/column_reader/node_property_column_reader.cpp
+++ b/src/processor/physical_plan/operator/column_reader/node_property_column_reader.cpp
@@ -6,7 +6,7 @@ namespace processor {
 NodePropertyColumnReader::NodePropertyColumnReader(const uint64_t& dataChunkPos,
     const uint64_t& valueVectorPos, BaseColumn* column, unique_ptr<PhysicalOperator> prevOperator)
     : ColumnReader{dataChunkPos, valueVectorPos, column, move(prevOperator)} {
-    outValueVector = make_shared<ValueVector>(column->getElementSize());
+    outValueVector = make_shared<ValueVector>(column->getDataType());
     inDataChunk->append(outValueVector);
 }
 

--- a/src/processor/physical_plan/operator/column_reader/rel_property_column_reader.cpp
+++ b/src/processor/physical_plan/operator/column_reader/rel_property_column_reader.cpp
@@ -6,7 +6,7 @@ namespace processor {
 RelPropertyColumnReader::RelPropertyColumnReader(const uint64_t& dataChunkPos,
     const uint64_t& valueVectorPos, BaseColumn* column, unique_ptr<PhysicalOperator> prevOperator)
     : ColumnReader{dataChunkPos, valueVectorPos, column, move(prevOperator)} {
-    outValueVector = make_shared<ValueVector>(column->getElementSize());
+    outValueVector = make_shared<ValueVector>(column->getDataType());
     inDataChunk->append(outValueVector);
 }
 

--- a/src/processor/physical_plan/operator/hash_join/hash_table.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_table.cpp
@@ -25,7 +25,7 @@ static uint64_t nextPowerOfTwo(uint64_t v) {
 
 HashTable::HashTable(MemoryManager& memoryManager, vector<PayloadInfo>& payloadInfos)
     : memoryManager(memoryManager), numEntries(0), hashBitMask(0), htDirectory(nullptr),
-      hashVec(sizeof(uint64_t)), overflowBlocks(memoryManager) {
+      hashVec(INT64), overflowBlocks(memoryManager) {
     // key field (node_offset_t + label_t) + prev field (uint8_t*)
     numBytesForFixedTuplePart = sizeof(node_offset_t) + sizeof(label_t) + sizeof(uint8_t*);
     for (auto& payloadInfo : payloadInfos) {

--- a/src/processor/physical_plan/operator/list_reader/rel_property_list_reader.cpp
+++ b/src/processor/physical_plan/operator/list_reader/rel_property_list_reader.cpp
@@ -8,7 +8,7 @@ RelPropertyListReader::RelPropertyListReader(const uint64_t& inDataChunkPos,
     unique_ptr<PhysicalOperator> prevOperator)
     : ListReader{inDataChunkPos, inValueVectorPos, lists, move(prevOperator)},
       outDataChunkPos{outDataChunkPos} {
-    outValueVector = make_shared<ValueVector>(lists->getElementSize());
+    outValueVector = make_shared<ValueVector>(lists->getDataType());
     outDataChunk = dataChunks->getDataChunk(outDataChunkPos);
     handle->setListSyncState(dataChunks->getListSyncState(outDataChunkPos));
     outDataChunk->append(outValueVector);

--- a/src/processor/physical_plan/operator/tuple/data_chunks_iterator.cpp
+++ b/src/processor/physical_plan/operator/tuple/data_chunks_iterator.cpp
@@ -49,7 +49,7 @@ void DataChunksIterator::getNextTuple(Tuple& tuple) {
         auto tuplePosition = tuplePositions[i];
         for (auto& vector : dataChunk->valueVectors) {
             switch (vector->getDataType()) {
-            case INT: {
+            case INT32: {
                 tuple.getValue(valueInTupleIdx)->setInt(vector->getValue<int32_t>(tuplePosition));
                 break;
             }

--- a/src/storage/include/structures/column.h
+++ b/src/storage/include/structures/column.h
@@ -37,6 +37,8 @@ class Column : public BaseColumn {
 public:
     Column(const string& path, const uint64_t& numElements, BufferManager& bufferManager)
         : BaseColumn{path, sizeof(T), numElements, bufferManager} {};
+
+    DataType getDataType() override;
 };
 
 template<>
@@ -50,6 +52,8 @@ public:
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, const uint64_t& size,
         const unique_ptr<ColumnOrListsHandle>& handle) override;
+
+    DataType getDataType() override { return STRING; }
 
 private:
     void readStringsFromOverflowPages(
@@ -70,9 +74,20 @@ public:
 
     NodeIDCompressionScheme getCompressionScheme() const { return nodeIDCompressionScheme; }
 
+    DataType getDataType() override { return NODE; }
+
 private:
     NodeIDCompressionScheme nodeIDCompressionScheme;
 };
+
+template<>
+DataType Column<int32_t>::getDataType();
+
+template<>
+DataType Column<double_t>::getDataType();
+
+template<>
+DataType Column<uint8_t>::getDataType();
 
 typedef Column<int32_t> PropertyColumnInt;
 typedef Column<double_t> PropertyColumnDouble;

--- a/src/storage/include/structures/common.h
+++ b/src/storage/include/structures/common.h
@@ -106,7 +106,7 @@ class BaseColumnOrLists {
 public:
     void reclaim(const unique_ptr<ColumnOrListsHandle>& handle);
 
-    size_t getElementSize() { return elementSize; }
+    virtual DataType getDataType() = 0;
 
 protected:
     BaseColumnOrLists(const string& fname, const size_t& elementSize, BufferManager& bufferManager);

--- a/src/storage/include/structures/lists.h
+++ b/src/storage/include/structures/lists.h
@@ -43,6 +43,8 @@ class Lists : public BaseLists {
 public:
     Lists(const string& fname, shared_ptr<AdjListHeaders> headers, BufferManager& bufferManager)
         : BaseLists{fname, sizeof(T), headers, bufferManager} {};
+
+    DataType getDataType() override;
 };
 
 // Lists<nodeID_t> is the specialization of Lists<T> for lists of nodeIDs.
@@ -64,9 +66,23 @@ public:
 
     shared_ptr<AdjListHeaders> getHeaders() { return headers; };
 
+    DataType getDataType() override { return NODE; }
+
 private:
     NodeIDCompressionScheme nodeIDCompressionScheme;
 };
+
+template<>
+DataType Lists<int32_t>::getDataType();
+
+template<>
+DataType Lists<double_t>::getDataType();
+
+template<>
+DataType Lists<uint8_t>::getDataType();
+
+template<>
+DataType Lists<gf_string_t>::getDataType();
 
 typedef Lists<int32_t> RelPropertyListsInt;
 typedef Lists<double_t> RelPropertyListsDouble;

--- a/src/storage/stores/nodes_store.cpp
+++ b/src/storage/stores/nodes_store.cpp
@@ -16,11 +16,10 @@ NodesStore::NodesStore(const Catalog& catalog, const vector<uint64_t>& numNodesP
         for (auto property = propertyMap.begin(); property != propertyMap.end(); property++) {
             auto fname = getNodePropertyColumnFname(directory, nodeLabel, property->first);
             auto idx = property->second.idx;
-            logger->debug("nodeLabel {} propertyIdx {} "
-                          "type {} name `{}`",
-                nodeLabel, idx, property->second.dataType, property->first);
+            logger->debug("nodeLabel {} propertyIdx {} type {} name `{}`", nodeLabel, idx,
+                property->second.dataType, property->first);
             switch (property->second.dataType) {
-            case INT:
+            case INT32:
                 propertyColumns[nodeLabel][idx] = make_unique<PropertyColumnInt>(
                     fname, numNodesPerLabel[nodeLabel], bufferManager);
                 break;

--- a/src/storage/stores/rels_store.cpp
+++ b/src/storage/stores/rels_store.cpp
@@ -105,7 +105,7 @@ void RelsStore::initPropertyColumnsForRelLabel(const Catalog& catalog,
             logger->debug("DIR {} nodeLabel {} propertyIdx {} type {} name `{}`", dir, nodeLabel,
                 idx, property->second.dataType, property->first);
             switch (property->second.dataType) {
-            case INT:
+            case INT32:
                 propertyColumns[nodeLabel][relLabel][idx] = make_unique<PropertyColumnInt>(
                     fname, numNodesPerLabel[nodeLabel], bufferManager);
                 break;
@@ -145,7 +145,7 @@ void RelsStore::initPropertyListsForRelLabel(const Catalog& catalog,
                 logger->debug("DIR {} nodeLabel {} propertyIdx {} type {} name `{}`", dir,
                     nodeLabel, idx, property->second.dataType, property->first);
                 switch (property->second.dataType) {
-                case INT:
+                case INT32:
                     propertyLists[dir][nodeLabel][relLabel][idx] =
                         make_unique<RelPropertyListsInt>(fname, adjListsHeaders, bufferManager);
                     break;

--- a/src/storage/structures/column.cpp
+++ b/src/storage/structures/column.cpp
@@ -88,5 +88,20 @@ void Column<gf_string_t>::readStringsFromOverflowPages(
     }
 }
 
+template<>
+DataType Column<int32_t>::getDataType() {
+    return INT32;
+}
+
+template<>
+DataType Column<double_t>::getDataType() {
+    return DOUBLE;
+}
+
+template<>
+DataType Column<uint8_t>::getDataType() {
+    return BOOL;
+}
+
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/structures/lists.cpp
+++ b/src/storage/structures/lists.cpp
@@ -72,5 +72,25 @@ void Lists<nodeID_t>::readFromLargeList(const nodeID_t& nodeID,
     listSyncState->set(csrOffset, listLen);
 }
 
+template<>
+DataType Lists<int32_t>::getDataType() {
+    return INT32;
+}
+
+template<>
+DataType Lists<double_t>::getDataType() {
+    return DOUBLE;
+}
+
+template<>
+DataType Lists<uint8_t>::getDataType() {
+    return BOOL;
+}
+
+template<>
+DataType Lists<gf_string_t>::getDataType() {
+    return STRING;
+}
+
 } // namespace storage
 } // namespace graphflow

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -9,15 +9,15 @@ TEST(VectorArithTests, test) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->size = 100;
 
-    auto lVector = ValueVector(INT);
+    auto lVector = ValueVector(INT32);
     lVector.setDataChunkOwner(dataChunk);
     auto lData = (int32_t*)lVector.getValues();
 
-    auto rVector = ValueVector(INT);
+    auto rVector = ValueVector(INT32);
     rVector.setDataChunkOwner(dataChunk);
     auto rData = (int32_t*)rVector.getValues();
 
-    auto result = ValueVector(INT);
+    auto result = ValueVector(INT32);
     auto resultData = (int32_t*)result.getValues();
 
     // Fill values before the comparison.

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -12,11 +12,11 @@ TEST(VectorCmpTests, cmpInt) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->size = numTuples;
 
-    auto lVector = ValueVector(INT, numTuples);
+    auto lVector = ValueVector(INT32, numTuples);
     lVector.setDataChunkOwner(dataChunk);
     auto lData = (int32_t*)lVector.getValues();
 
-    auto rVector = ValueVector(INT, numTuples);
+    auto rVector = ValueVector(INT32, numTuples);
     rVector.setDataChunkOwner(dataChunk);
     auto rData = (int32_t*)rVector.getValues();
 

--- a/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
+++ b/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
@@ -15,7 +15,7 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
     nodeVector.setDataChunkOwner(dataChunk);
     auto nodeData = (uint64_t*)nodeVector.getValues();
 
-    auto result = ValueVector(sizeof(uint64_t));
+    auto result = ValueVector(INT64);
     auto resultData = (uint64_t*)result.getValues();
 
     // Fill values before the comparison.
@@ -41,11 +41,12 @@ TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->size = 1000;
 
-    auto nodeVector = NodeIDSequenceVector(100);
+    label_t commonLable = 100;
+    auto nodeVector = NodeIDSequenceVector(commonLable);
     nodeVector.setStartOffset(10);
     nodeVector.setDataChunkOwner(dataChunk);
 
-    auto result = ValueVector(sizeof(uint64_t));
+    auto result = ValueVector(INT64);
     auto resultData = (uint64_t*)result.getValues();
 
     auto hashNodeIDOp = ValueVector::getUnaryOperation(HASH_NODE_ID);

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -8,10 +8,10 @@ using namespace graphflow::expression;
 
 TEST(ExpressionTests, BinaryPhysicalExpressionTest) {
     auto propertyExpression =
-        make_unique<LogicalExpression>(ExpressionType::VARIABLE, DataType::INT, "a.prop");
+        make_unique<LogicalExpression>(ExpressionType::VARIABLE, DataType::INT32, "a.prop");
     auto literal = Literal(5);
     auto literalExpression =
-        make_unique<LogicalExpression>(ExpressionType::LITERAL_INT, DataType::INT, literal);
+        make_unique<LogicalExpression>(ExpressionType::LITERAL_INT, DataType::INT32, literal);
 
     auto addLogicalOperator = make_unique<LogicalExpression>(
             ExpressionType::ADD, move(propertyExpression), move(literalExpression));
@@ -20,7 +20,7 @@ TEST(ExpressionTests, BinaryPhysicalExpressionTest) {
     auto dataChunks = DataChunks();
     physicalOperatorInfo.put("a.prop", 0 /*dataChunkPos*/, 0 /*valueVectorPos*/);
 
-    auto valueVector = make_shared<ValueVector>(INT, 100);
+    auto valueVector = make_shared<ValueVector>(INT32, 100);
     auto values = (int32_t*)valueVector->getValues();
     for (auto i = 0u; i < 100; i++) {
         values[i] = i;
@@ -43,7 +43,7 @@ TEST(ExpressionTests, BinaryPhysicalExpressionTest) {
 
 TEST(ExpressionTests, UnaryPhysicalExpressionTest) {
     auto propertyExpression =
-        make_unique<LogicalExpression>(ExpressionType::VARIABLE, DataType::INT, "a.prop");
+        make_unique<LogicalExpression>(ExpressionType::VARIABLE, DataType::INT32, "a.prop");
     auto negateLogicalOperator =
         make_unique<LogicalExpression>(ExpressionType::NEGATE, move(propertyExpression));
 
@@ -51,7 +51,7 @@ TEST(ExpressionTests, UnaryPhysicalExpressionTest) {
     auto dataChunks = DataChunks();
     physicalOperatorInfo.put("a.prop", 0 /*dataChunkPos*/, 0 /*valueVectorPos*/);
 
-    auto valueVector = make_shared<ValueVector>(INT, 100);
+    auto valueVector = make_shared<ValueVector>(INT32, 100);
     auto values = (int32_t*)valueVector->getValues();
     for (auto i = 0u; i < 100; i++) {
         int32_t value = i;

--- a/test/processor/physical_plan/operator/hash_join/hash_table_test.cpp
+++ b/test/processor/physical_plan/operator/hash_join/hash_table_test.cpp
@@ -20,7 +20,7 @@ void generateSingleLabelDataChunks(
     shared_ptr<DataChunk> keyDataChunk, DataChunks& payloadDataChunks) {
     auto keyIdVec = make_shared<NodeIDSequenceVector>(8);
     keyIdVec->setStartOffset(0);
-    auto ageVec = make_shared<ValueVector>(INT);
+    auto ageVec = make_shared<ValueVector>(INT32);
     auto ageVecData = (int32_t*)ageVec->getValues();
     for (uint64_t i = 0; i < ValueVector::NODE_SEQUENCE_VECTOR_SIZE; i++) {
         ageVecData[i] = (i + 20) % 100;
@@ -35,7 +35,7 @@ void generateSingleLabelDataChunks(
     NodeIDCompressionScheme compressionScheme;
     auto payloadIdVector = make_shared<NodeIDVector>(compressionScheme);
     payloadIdVector->setCommonLabel(100);
-    auto payloadNumVector = make_shared<ValueVector>(INT);
+    auto payloadNumVector = make_shared<ValueVector>(INT32);
     auto payloadIdVectorPtr = (int64_t*)payloadIdVector->getValues();
     auto buildNumVectorPtr = (int32_t*)payloadNumVector->getValues();
     for (uint64_t i = 0; i < ValueVector::NODE_SEQUENCE_VECTOR_SIZE; i++) {

--- a/test/processor/physical_plan/operator/tuple/data_chunks_iterator_test.cpp
+++ b/test/processor/physical_plan/operator/tuple/data_chunks_iterator_test.cpp
@@ -14,7 +14,7 @@ public:
 
         NodeIDCompressionScheme compressionScheme;
         auto vectorA1 = make_shared<NodeIDVector>(18, compressionScheme);
-        auto vectorA2 = make_shared<ValueVector>(INT);
+        auto vectorA2 = make_shared<ValueVector>(INT32);
         auto vectorB1 = make_shared<NodeIDVector>(28, compressionScheme);
         auto vectorB2 = make_shared<ValueVector>(DOUBLE);
         auto vectorC1 = make_shared<NodeIDVector>(38, compressionScheme);


### PR DESCRIPTION
* remove the elementSize interface in ValueVector. A ValueVector only needs the dataType. Fixes #60.
* updates operators to initialize ValueVector with dataType.
* add a new getDataType interface to lists and columns.

This is a necessary step to add a PhysicalFilter operator as Expressions require the dataType field to be set in ValueVector.