### PR TITLE
Add simple hash join operator for INNER join type

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -14,6 +14,7 @@ cc_library(
         "vector/operations/vector_boolean_operations.cpp",
         "vector/operations/vector_comparison_operations.cpp",
         "vector/operations/vector_hash_operations.cpp",
+        "vector/operations/vector_decompress_operations.cpp",
     ],
     hdrs = [
         "include/compression_scheme.h",
@@ -26,6 +27,7 @@ cc_library(
         "include/operations/boolean_operations.h",
         "include/operations/comparison_operations.h",
         "include/operations/hash_operations.h",
+        "include/operations/decompress_operations.h",
         "include/types.h",
         "include/vector/node_vector.h",
         "include/vector/value_vector.h",
@@ -35,6 +37,7 @@ cc_library(
         "include/vector/operations/vector_boolean_operations.h",
         "include/vector/operations/vector_comparison_operations.h",
         "include/vector/operations/vector_hash_operations.h",
+        "include/vector/operations/vector_decompress_operations.h",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/common/include/compression_scheme.h
+++ b/src/common/include/compression_scheme.h
@@ -1,7 +1,6 @@
 #pragma once
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <utility>
 #include <vector>
 
@@ -15,9 +14,10 @@ class NodeIDCompressionScheme {
 public:
     NodeIDCompressionScheme(const vector<label_t>& nbrNodeLabels,
         const vector<uint64_t>& numNodesPerLabel, const uint32_t& numNodeLabels);
-    NodeIDCompressionScheme()
-        : numBytesForLabel{0}, numBytesForOffset{8},
-          numTotalBytes(numBytesForLabel + numBytesForOffset){};
+    NodeIDCompressionScheme() : NodeIDCompressionScheme(0, 8){};
+    NodeIDCompressionScheme(uint32_t numBytesForLabel, uint32_t numBytesForOffset)
+        : numBytesForLabel(numBytesForLabel), numBytesForOffset(numBytesForOffset),
+          numTotalBytes(numBytesForLabel + numBytesForOffset) {}
 
     inline uint32_t getNumBytesForLabel() const { return numBytesForLabel; };
     inline uint32_t getNumBytesForOffset() const { return numBytesForOffset; };

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -46,6 +46,11 @@ enum ExpressionType {
     HASH_NODE_ID = 32,
 
     /**
+     * Decompress Expressions
+     * */
+    DECOMPRESS_NODE_ID = 33,
+
+    /**
      * String Operation Expressions
      **/
     STARTS_WITH = 37,

--- a/src/common/include/operations/decompress_operations.h
+++ b/src/common/include/operations/decompress_operations.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+#include "src/common/include/types.h"
+
+namespace graphflow {
+namespace common {
+namespace operation {
+
+struct DecompressNodeID {
+    static inline nodeID_t operation(nodeID_t nodeID) { return nodeID; }
+};
+
+} // namespace operation
+} // namespace common
+} // namespace graphflow

--- a/src/common/include/operations/hash_operations.h
+++ b/src/common/include/operations/hash_operations.h
@@ -34,6 +34,10 @@ inline uint64_t Hash::operation(const unordered_set<string>& key) {
     return result;
 }
 
+struct DecompressNodeID {
+    static inline nodeID_t operation(nodeID_t nodeID) { return nodeID; }
+};
+
 } // namespace operation
 } // namespace common
 } // namespace graphflow

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -76,7 +76,8 @@ struct overflow_value_t {
 };
 
 enum DataType { REL, NODE, LABEL, BOOL, INT32, INT64, DOUBLE, STRING };
-const string DataTypeNames[] = {"REL", "NODE", "LABEL", "BOOL", "INT", "DOUBLE", "STRING"};
+const string DataTypeNames[] = {
+    "REL", "NODE", "LABEL", "BOOL", "INT32", "INT64", "DOUBLE", "STRING"};
 
 class Property {
 

--- a/src/common/include/vector/node_vector.h
+++ b/src/common/include/vector/node_vector.h
@@ -26,7 +26,7 @@ public:
 
     NodeIDVector(label_t commonLabel, const NodeIDCompressionScheme& nodeIDCompressionScheme,
         bool isSequence)
-        : NodeIDVector{commonLabel, nodeIDCompressionScheme, isSequence, VECTOR_CAPACITY} {};
+        : NodeIDVector{commonLabel, nodeIDCompressionScheme, isSequence, MAX_VECTOR_SIZE} {};
 
     virtual ~NodeIDVector() = default;
 
@@ -41,7 +41,9 @@ public:
     inline bool getIsSequence() const { return isSequence; }
     inline void setIsSequence(bool storedSequentially) { this->isSequence = storedSequentially; }
 
-    inline int64_t getElementSize() override { return nodeIDCompressionScheme.getNumTotalBytes(); }
+    inline int64_t getNumBytesPerValue() override {
+        return nodeIDCompressionScheme.getNumTotalBytes();
+    }
 
     virtual void readNodeOffset(uint64_t pos, nodeID_t& nodeID);
     virtual void readNodeOffsetAndLabel(uint64_t pos, nodeID_t& nodeID);
@@ -53,8 +55,9 @@ protected:
 
     NodeIDVector(label_t commonLabel, const NodeIDCompressionScheme& nodeIDCompressionScheme,
         bool isSequence, uint64_t vectorCapacity)
-        : ValueVector{NODE, vectorCapacity}, commonLabel{commonLabel},
-          nodeIDCompressionScheme{nodeIDCompressionScheme}, isSequence{isSequence} {};
+        : ValueVector{vectorCapacity, nodeIDCompressionScheme.getNumTotalBytes(), NODE},
+          commonLabel{commonLabel}, nodeIDCompressionScheme{nodeIDCompressionScheme},
+          isSequence{isSequence} {};
 
 protected:
     label_t commonLabel;

--- a/src/common/include/vector/operations/vector_decompress_operations.h
+++ b/src/common/include/vector/operations/vector_decompress_operations.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "src/common/include/vector/value_vector.h"
+
+namespace graphflow {
+namespace common {
+
+struct VectorDecompressOperations {
+    // Only support NodeIDVector as operand in this function
+    static void DecompressNodeID(ValueVector& operand, ValueVector& result);
+};
+} // namespace common
+} // namespace graphflow

--- a/src/common/vector/node_vector.cpp
+++ b/src/common/vector/node_vector.cpp
@@ -12,9 +12,9 @@ void NodeIDVector::readNodeOffset(uint64_t pos, nodeID_t& nodeID) {
 
 void NodeIDVector::readNodeOffsetAndLabel(uint64_t pos, nodeID_t& nodeID) {
     auto readOffset = values + (pos * nodeIDCompressionScheme.getNumTotalBytes());
-    nodeID.offset = *(node_offset_t*)(readOffset + nodeIDCompressionScheme.getNumBytesForLabel());
     nodeID.label =
         nodeIDCompressionScheme.getNumBytesForLabel() == 0 ? commonLabel : *(label_t*)(readOffset);
+    nodeID.offset = *(node_offset_t*)(readOffset + nodeIDCompressionScheme.getNumBytesForLabel());
 }
 
 } // namespace common

--- a/src/common/vector/operations/vector_decompress_operations.cpp
+++ b/src/common/vector/operations/vector_decompress_operations.cpp
@@ -1,0 +1,41 @@
+#include "src/common/include/vector/operations/vector_decompress_operations.h"
+
+#include <stdexcept>
+
+#include "src/common/include/operations/decompress_operations.h"
+#include "src/common/include/vector/operations/executors/unary_operation_executor.h"
+
+namespace graphflow {
+namespace common {
+
+struct DecompressNodeIDOperationExecutor {
+public:
+    template<class OP>
+    static inline void execute(ValueVector& operand, ValueVector& result) {
+        auto& nodeIdOperand = dynamic_cast<NodeIDVector&>(operand);
+        switch (nodeIdOperand.getCompressionScheme().getNumBytesForOffset()) {
+        case 2:
+            UnaryOperationExecutor::executeOnNodeIDVector<uint16_t, nodeID_t, OP>(
+                nodeIdOperand, result);
+            break;
+        case 4:
+            UnaryOperationExecutor::executeOnNodeIDVector<uint32_t, nodeID_t, OP>(
+                nodeIdOperand, result);
+            break;
+        case 8:
+            UnaryOperationExecutor::executeOnNodeIDVector<uint64_t, nodeID_t, OP>(
+                nodeIdOperand, result);
+            break;
+        default:
+            throw std::invalid_argument(
+                "Invalid or unsupported operand type for decompress operation.");
+        }
+    }
+};
+
+void VectorDecompressOperations::DecompressNodeID(ValueVector& operand, ValueVector& result) {
+    DecompressNodeIDOperationExecutor::execute<operation::DecompressNodeID>(operand, result);
+}
+
+} // namespace common
+} // namespace graphflow

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -3,6 +3,7 @@
 #include "src/common/include/vector/operations/vector_arithmetic_operations.h"
 #include "src/common/include/vector/operations/vector_boolean_operations.h"
 #include "src/common/include/vector/operations/vector_comparison_operations.h"
+#include "src/common/include/vector/operations/vector_decompress_operations.h"
 #include "src/common/include/vector/operations/vector_hash_operations.h"
 
 namespace graphflow {
@@ -27,6 +28,8 @@ std::function<void(ValueVector&, ValueVector&)> ValueVector::getUnaryOperation(
         return VectorArithmeticOperations::Negate;
     case HASH_NODE_ID:
         return VectorHashOperations::HashNodeID;
+    case DECOMPRESS_NODE_ID:
+        return VectorDecompressOperations::DecompressNodeID;
     default:
         throw std::invalid_argument("Invalid or unsupported unary expression.");
     }

--- a/src/planner/include/query_graph/query_graph.h
+++ b/src/planner/include/query_graph/query_graph.h
@@ -14,7 +14,7 @@ class QueryGraph {
     friend void mergeQueryGraphs(QueryGraph& mergedQueryGraph, QueryGraph& otherQueryGraph);
 
 public:
-    uint numQueryNodes() const;
+    uint32_t numQueryNodes() const;
 
     bool containsQueryNode(const string& nodeName) const;
 
@@ -22,7 +22,7 @@ public:
 
     void addQueryNode(unique_ptr<QueryNode> queryNode);
 
-    uint numQueryRels() const;
+    uint32_t numQueryRels() const;
 
     bool containsQueryRel(const string& relName) const;
 

--- a/src/planner/query_graph/query_graph.cpp
+++ b/src/planner/query_graph/query_graph.cpp
@@ -3,7 +3,7 @@
 namespace graphflow {
 namespace planner {
 
-uint QueryGraph::numQueryNodes() const {
+uint32_t QueryGraph::numQueryNodes() const {
     return nameToQueryNodeMap.size();
 }
 
@@ -19,7 +19,7 @@ void QueryGraph::addQueryNode(unique_ptr<QueryNode> queryNode) {
     nameToQueryNodeMap.insert({queryNode->getName(), move(queryNode)});
 }
 
-uint QueryGraph::numQueryRels() const {
+uint32_t QueryGraph::numQueryRels() const {
     return nameToQueryRelMap.size();
 }
 

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -7,6 +7,7 @@ cc_library(
         "physical_plan/operator/column_reader/column_reader.cpp",
         "physical_plan/operator/column_reader/node_property_column_reader.cpp",
         "physical_plan/operator/column_reader/rel_property_column_reader.cpp",
+        "physical_plan/operator/hash_join/hash_join.cpp",
         "physical_plan/operator/list_reader/adj_list_extend.cpp",
         "physical_plan/operator/list_reader/extend/adj_list_flatten_and_extend.cpp",
         "physical_plan/operator/list_reader/extend/adj_list_only_extend.cpp",
@@ -14,8 +15,6 @@ cc_library(
         "physical_plan/operator/list_reader/rel_property_list_reader.cpp",
         "physical_plan/operator/scan/physical_scan.cpp",
         "physical_plan/operator/sink/sink.cpp",
-        "physical_plan/operator/tuple/data_chunks.cpp",
-        "physical_plan/operator/tuple/data_chunks_iterator.cpp",
     ],
     hdrs = [
         "include/task_system/morsel.h",
@@ -23,6 +22,7 @@ cc_library(
         "include/physical_plan/operator/column_reader/column_reader.h",
         "include/physical_plan/operator/column_reader/node_property_column_reader.h",
         "include/physical_plan/operator/column_reader/rel_property_column_reader.h",
+        "include/physical_plan/operator/hash_join/hash_join.h",
         "include/physical_plan/operator/list_reader/adj_list_extend.h",
         "include/physical_plan/operator/list_reader/extend/adj_list_flatten_and_extend.h",
         "include/physical_plan/operator/list_reader/extend/adj_list_only_extend.h",
@@ -31,16 +31,32 @@ cc_library(
         "include/physical_plan/operator/physical_operator.h",
         "include/physical_plan/operator/scan/physical_scan.h",
         "include/physical_plan/operator/sink/sink.h",
-        "include/physical_plan/operator/tuple/data_chunks.h",
-        "include/physical_plan/operator/tuple/data_chunks_iterator.h",
         "include/physical_plan/operator/tuple/tuple.h",
         "include/physical_plan/operator/tuple/physical_operator_info.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "hash_table",
         "//src/storage:graph",
         "//src/storage:structures",
         "//src/common",
+    ],
+)
+
+cc_library(
+    name = "data_chunks",
+    srcs = [
+        "physical_plan/operator/tuple/data_chunks.cpp",
+        "physical_plan/operator/tuple/data_chunks_iterator.cpp",
+    ],
+    hdrs = [
+        "include/physical_plan/operator/tuple/data_chunks.h",
+        "include/physical_plan/operator/tuple/tuple.h",
+        "include/physical_plan/operator/tuple/data_chunks_iterator.h",
+    ],
+    deps = [
+        "//src/common",
+        "//src/storage:structures",
     ],
 )
 
@@ -87,20 +103,32 @@ cc_library(
 )
 
 cc_library(
+    name = "memory_manager",
+    srcs = [
+        "memory_manager.cpp"
+    ],
+    hdrs = [
+        "include/memory_manager.h"
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/common"
+    ],
+)
+
+cc_library(
     name = "hash_table",
     srcs = [
         "physical_plan/operator/hash_join/hash_table.cpp",
         "physical_plan/operator/hash_join/overflow_blocks.cpp",
-        "memory_manager.cpp",
     ],
     hdrs = [
         "include/physical_plan/operator/hash_join/hash_table.h",
         "include/physical_plan/operator/hash_join/overflow_blocks.h",
-        "include/memory_manager.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "operators",
-        "//src/common",
+        "data_chunks",
+        "memory_manager"
     ],
 )

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join.h
@@ -1,0 +1,117 @@
+#pragma once
+
+#include "src/common/include/operations/hash_operations.h"
+#include "src/common/include/types.h"
+#include "src/common/include/vector/operations/vector_decompress_operations.h"
+#include "src/common/include/vector/operations/vector_hash_operations.h"
+#include "src/processor/include/physical_plan/operator/hash_join/hash_table.h"
+#include "src/processor/include/physical_plan/operator/physical_operator.h"
+#include "src/processor/include/physical_plan/operator/tuple/data_chunks.h"
+
+using namespace std;
+using namespace graphflow::common;
+using namespace graphflow::common::operation;
+
+namespace graphflow {
+namespace processor {
+
+struct ProbeState {
+    ProbeState(uint64_t pointersSize)
+        : probeKeyIndex(0), probedTuplesSize(0), matchedTuplesSize(0) {
+        probedTuples = make_unique<uint8_t*[]>(pointersSize);
+        matchedTuples = make_unique<uint8_t*[]>(pointersSize);
+        probeSelVector = make_unique<uint16_t[]>(pointersSize);
+    }
+    // Each key corresponds to a pointer with the same hash value from the ht directory.
+    unique_ptr<uint8_t*[]> probedTuples;
+    // Pointers to tuples in ht that actually matched.
+    unique_ptr<uint8_t*[]> matchedTuples;
+    // Selective index mapping each matched tuple to its probe side key.
+    unique_ptr<uint16_t[]> probeSelVector;
+    uint64_t probeKeyIndex;
+    uint64_t probedTuplesSize;
+    uint64_t matchedTuplesSize;
+};
+
+struct BuildSideVectorInfo {
+    BuildSideVectorInfo(uint32_t numBytesPerValue, uint32_t outDataChunkIdx, uint32_t outVectorIdx,
+        uint32_t vectorPtrsIdx)
+        : numBytesPerValue(numBytesPerValue), outDataChunkIdx(outDataChunkIdx),
+          outVectorIdx(outVectorIdx), vectorPtrsIdx(vectorPtrsIdx) {}
+
+    uint32_t numBytesPerValue;
+    uint32_t outDataChunkIdx;
+    uint32_t outVectorIdx;
+    uint32_t vectorPtrsIdx;
+};
+
+// WARN: The hash join only supports INNER join type for now
+// Key data structures:
+// 1) outKeyDataChunk. Join results for vectors from the probe side key data chunk, the build
+// side key data chunk (except for the build side key vector), and also build side flat non-key
+// data chunks will be populated into the outKeyDataChunk.
+// 2) buildSideVectorPtrs. Join results of vectors from build side unflat non-key data chunks
+// will first be read from ht as vector ptrs, and kept in buildSideVectorPtrs. Each vector
+// corresponds to an array of overflow_value_t structs.
+// 3) appended unflat output data chunks. for each build side unflat non-key data chunk, append a
+// new out data chunk in the output dataChunks.
+// 4) output dataChunks. outKeyDataChunk + probe side non-key data chunks + appended unflat output
+// data chunks.
+class HashJoin : public PhysicalOperator {
+public:
+    HashJoin(MemoryManager& memManager, uint64_t buildSideKeyDataChunkIdx,
+        uint64_t buildSideKeyVectorIdx, uint64_t probeSideKeyDataChunkIdx,
+        uint64_t probeSideKeyVectorIdx, unique_ptr<PhysicalOperator> buildSidePrevOp,
+        unique_ptr<PhysicalOperator> probeSidePrevOp);
+
+    void getNextTuples() override;
+
+    unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<HashJoin>(memManager, buildSideKeyDataChunkIdx, buildSideKeyVectorIdx,
+            probeSideKeyDataChunkIdx, probeSideKeyVectorIdx, prevOperator->clone(),
+            buildSidePrevOp->clone());
+    }
+
+private:
+    std::function<void(ValueVector&, ValueVector&)> vectorDecompressOp;
+
+    MemoryManager& memManager;
+    uint64_t buildSideKeyDataChunkIdx;
+    uint64_t buildSideKeyVectorIdx;
+    uint64_t probeSideKeyDataChunkIdx;
+    uint64_t probeSideKeyVectorIdx;
+    unique_ptr<PhysicalOperator> buildSidePrevOp;
+
+    shared_ptr<DataChunk> buildSideKeyDataChunk;
+    shared_ptr<DataChunks> buildSideNonKeyDataChunks;
+    shared_ptr<NodeIDVector> probeSideKeyVector;
+    shared_ptr<DataChunk> probeSideKeyDataChunk;
+    shared_ptr<DataChunks> probeSideNonKeyDataChunks;
+
+    vector<BuildSideVectorInfo> buildSideVectorInfos;
+    unique_ptr<ValueVector> decompressedProbeKeyVector;
+    unique_ptr<ProbeState> probeState;
+    shared_ptr<DataChunk> outKeyDataChunk;
+    vector<unique_ptr<overflow_value_t[]>> buildSideVectorPtrs;
+
+    unique_ptr<HashTable> hashTable;
+    bool isHTInitialized;
+
+    void initializeHashTable();
+    // This function initializes:
+    // 1) the outKeyDataChunk and appended unflat output data chunks, which are used to initialize
+    // the output dataChunks. 2) buildSideVectorPtrs for build side unflat non-key data chunks.
+    void initializeOutDataChunksAndVectorPtrs();
+
+    void getNextBatchOfMatchedTuples();
+    // This function reads matched tuples from ht and populates:
+    // 1) outKeyDataChunk with values from probe side key data chunk, build side key data chunk
+    // (except for build side keys), and also build side flat non-key data chunks. 2) populates
+    // vector ptrs with ptrs to probe side unflat non-key data chunks.
+    void populateOutKeyDataChunkAndVectorPtrs();
+    // This function updates appended unflat output data chunks based on vector ptrs and
+    // outKeyDataChunk.currPos.
+    void updateAppendedUnFlatOutDataChunks();
+};
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/physical_plan/operator/tuple/data_chunks_iterator.h
+++ b/src/processor/include/physical_plan/operator/tuple/data_chunks_iterator.h
@@ -11,7 +11,8 @@ namespace processor {
 
 class DataChunksIterator {
 public:
-    DataChunksIterator(DataChunks& dataChunks) : dataChunks(dataChunks), numIteratedTuples(0) {
+    explicit DataChunksIterator(DataChunks& dataChunks)
+        : dataChunks(dataChunks), numIteratedTuples(0) {
         initializeTuplePositions();
     }
 

--- a/src/processor/include/physical_plan/operator/tuple/tuple.h
+++ b/src/processor/include/physical_plan/operator/tuple/tuple.h
@@ -10,7 +10,7 @@ namespace processor {
 class Tuple {
 
 public:
-    Tuple(vector<DataType> valueTypes) {
+    explicit Tuple(const vector<DataType>& valueTypes) {
         for (auto& valueType : valueTypes) {
             auto value = make_unique<Literal>(valueType);
             values.push_back(move(value));

--- a/src/processor/physical_plan/operator/hash_join/hash_join.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join.cpp
@@ -1,0 +1,288 @@
+#include "src/processor/include/physical_plan/operator/hash_join/hash_join.h"
+
+namespace graphflow {
+namespace processor {
+
+HashJoin::HashJoin(MemoryManager& memManager, uint64_t buildSideKeyDataChunkIdx,
+    uint64_t buildSideKeyVectorIdx, uint64_t probeSideKeyDataChunkIdx,
+    uint64_t probeSideKeyVectorIdx, unique_ptr<PhysicalOperator> buildSidePrevOp,
+    unique_ptr<PhysicalOperator> probeSidePrevOp)
+    : PhysicalOperator(move(probeSidePrevOp)), memManager(memManager),
+      buildSideKeyDataChunkIdx(buildSideKeyDataChunkIdx),
+      buildSideKeyVectorIdx(buildSideKeyVectorIdx),
+      probeSideKeyDataChunkIdx(probeSideKeyDataChunkIdx),
+      probeSideKeyVectorIdx(probeSideKeyVectorIdx), buildSidePrevOp(move(buildSidePrevOp)),
+      isHTInitialized(false) {
+    auto buildSideDataChunks = this->buildSidePrevOp->getDataChunks();
+    buildSideKeyDataChunk = buildSideDataChunks->getDataChunk(buildSideKeyDataChunkIdx);
+    buildSideNonKeyDataChunks = make_shared<DataChunks>();
+    for (uint64_t i = 0; i < buildSideDataChunks->getNumDataChunks(); i++) {
+        if (i != buildSideKeyDataChunkIdx) {
+            buildSideNonKeyDataChunks->append(buildSideDataChunks->getDataChunk(i));
+        }
+    }
+
+    // The prevOperator is the probe side prev operator passed in to the PhysicalOperator
+    auto probeSideDataChunks = prevOperator->getDataChunks();
+    probeSideKeyDataChunk = probeSideDataChunks->getDataChunk(probeSideKeyDataChunkIdx);
+    probeSideKeyVector = static_pointer_cast<NodeIDVector>(
+        probeSideKeyDataChunk->getValueVector(probeSideKeyVectorIdx));
+    probeSideNonKeyDataChunks = make_shared<DataChunks>();
+    for (uint64_t i = 0; i < probeSideDataChunks->getNumDataChunks(); i++) {
+        if (i != probeSideKeyDataChunkIdx) {
+            probeSideNonKeyDataChunks->append(probeSideDataChunks->getDataChunk(i));
+        }
+    }
+
+    vectorDecompressOp = ValueVector::getUnaryOperation(DECOMPRESS_NODE_ID);
+    decompressedProbeKeyVector = make_unique<NodeIDVector>(NodeIDCompressionScheme(8, 8));
+
+    probeState = make_unique<ProbeState>(ValueVector::MAX_VECTOR_SIZE);
+
+    initializeHashTable();
+    initializeOutDataChunksAndVectorPtrs();
+}
+
+void HashJoin::initializeHashTable() {
+    vector<PayloadInfo> htPayloadInfos;
+    for (uint64_t i = 0; i < buildSideKeyDataChunk->getNumAttributes(); i++) {
+        if (i == buildSideKeyVectorIdx) {
+            continue;
+        }
+        PayloadInfo info(buildSideKeyDataChunk->getValueVector(i)->getNumBytesPerValue(), false);
+        htPayloadInfos.push_back(info);
+    }
+    for (uint64_t i = 0; i < buildSideNonKeyDataChunks->getNumDataChunks(); i++) {
+        auto dataChunk = buildSideNonKeyDataChunks->getDataChunk(i);
+        for (auto& vector : dataChunk->valueVectors) {
+            PayloadInfo info(
+                (dataChunk->isFlat() ? vector->getNumBytesPerValue() : sizeof(overflow_value_t)),
+                !dataChunk->isFlat());
+            htPayloadInfos.push_back(info);
+        }
+    }
+    hashTable = make_unique<HashTable>(memManager, htPayloadInfos);
+}
+
+void HashJoin::initializeOutDataChunksAndVectorPtrs() {
+    dataChunks = make_shared<DataChunks>();
+    outKeyDataChunk = make_unique<DataChunk>();
+    dataChunks->append(outKeyDataChunk);
+    for (uint64_t i = 0; i < probeSideNonKeyDataChunks->getNumDataChunks(); i++) {
+        dataChunks->append(probeSideNonKeyDataChunks->getDataChunk(i));
+    }
+
+    for (uint64_t i = 0; i < probeSideKeyDataChunk->getNumAttributes(); i++) {
+        auto probeSideVector = probeSideKeyDataChunk->getValueVector(i);
+        shared_ptr<ValueVector> outVector;
+        if (probeSideVector->getDataType() == NODE) {
+            auto probeSideNodeIDVector = static_pointer_cast<NodeIDVector>(probeSideVector);
+            outVector = make_shared<NodeIDVector>(probeSideNodeIDVector->getCommonLabel(),
+                probeSideNodeIDVector->getCompressionScheme());
+        } else {
+            outVector = make_shared<ValueVector>(probeSideVector->getDataType());
+        }
+        outKeyDataChunk->append(outVector);
+    }
+    for (uint64_t i = 0; i < buildSideKeyDataChunk->getNumAttributes(); i++) {
+        if (i == buildSideKeyVectorIdx) {
+            continue;
+        }
+        auto buildSideVector = buildSideKeyDataChunk->getValueVector(i);
+        shared_ptr<ValueVector> outVector;
+        if (buildSideVector->getDataType() == NODE) {
+            auto buildSideNodeIDVector = static_pointer_cast<NodeIDVector>(buildSideVector);
+            outVector = make_shared<NodeIDVector>(buildSideNodeIDVector->getCommonLabel(),
+                buildSideNodeIDVector->getCompressionScheme());
+        } else {
+            outVector = make_shared<ValueVector>(buildSideVector->getDataType());
+        }
+        outKeyDataChunk->append(outVector);
+    }
+
+    for (uint64_t i = 0; i < buildSideNonKeyDataChunks->getNumDataChunks(); i++) {
+        auto dataChunk = buildSideNonKeyDataChunks->getDataChunk(i);
+        if (dataChunk->isFlat()) {
+            for (auto& vector : dataChunk->valueVectors) {
+                shared_ptr<ValueVector> outVector;
+                if (vector->getDataType() == NODE) {
+                    auto nodeIDVector = static_pointer_cast<NodeIDVector>(vector);
+                    outVector = make_shared<NodeIDVector>(
+                        nodeIDVector->getCommonLabel(), nodeIDVector->getCompressionScheme());
+                } else {
+                    outVector = make_shared<ValueVector>(vector->getDataType());
+                }
+                outKeyDataChunk->append(outVector);
+            }
+        } else {
+            auto unFlatOutDataChunk = make_shared<DataChunk>();
+            for (auto& vector : dataChunk->valueVectors) {
+                shared_ptr<ValueVector> outVector;
+                if (vector->getDataType() == NODE) {
+                    auto nodeIDVector = static_pointer_cast<NodeIDVector>(vector);
+                    outVector = make_shared<NodeIDVector>(
+                        nodeIDVector->getCommonLabel(), nodeIDVector->getCompressionScheme());
+                } else {
+                    outVector = make_shared<ValueVector>(vector->getDataType());
+                }
+                auto vectorPtrs = make_unique<overflow_value_t[]>(ValueVector::DEFAULT_VECTOR_SIZE);
+                BuildSideVectorInfo vectorInfo(vector->getNumBytesPerValue(),
+                    dataChunks->getNumDataChunks(), unFlatOutDataChunk->getNumAttributes(),
+                    buildSideVectorPtrs.size());
+                buildSideVectorInfos.push_back(vectorInfo);
+                buildSideVectorPtrs.push_back(move(vectorPtrs));
+                unFlatOutDataChunk->append(outVector);
+            }
+            dataChunks->append(unFlatOutDataChunk);
+        }
+    }
+}
+
+void HashJoin::getNextBatchOfMatchedTuples() {
+    if (probeState->probedTuplesSize == 0 ||
+        probeState->probeKeyIndex == probeState->probedTuplesSize) {
+        if (!prevOperator->hasNextMorsel()) {
+            probeState->probedTuplesSize = 0;
+            return;
+        }
+        prevOperator->getNextTuples();
+        if (probeSideKeyDataChunk->size == 0) {
+            probeState->probedTuplesSize = 0;
+            return;
+        }
+        probeState->probedTuplesSize =
+            hashTable->probeDirectory(*probeSideKeyVector, probeState->probedTuples.get());
+        vectorDecompressOp(*probeSideKeyVector, *decompressedProbeKeyVector);
+        probeState->probeKeyIndex = 0;
+    }
+    nodeID_t nodeId;
+    auto decompressedProbeKeys = (nodeID_t*)decompressedProbeKeyVector->getValues();
+    for (uint64_t i = probeState->probeKeyIndex; i < probeState->probedTuplesSize; i++) {
+        while (probeState->probedTuples[i]) {
+            if (ValueVector::DEFAULT_VECTOR_SIZE == probeState->matchedTuplesSize) {
+                break;
+            }
+            memcpy(&nodeId, probeState->probedTuples[i], NUM_BYTES_PER_NODE_ID);
+            probeState->matchedTuples[probeState->matchedTuplesSize] = probeState->probedTuples[i];
+            probeState->probeSelVector[probeState->matchedTuplesSize] =
+                probeSideKeyDataChunk->isFlat() ? probeSideKeyDataChunk->currPos :
+                                                  probeState->probeKeyIndex;
+            probeState->matchedTuplesSize += (nodeId.label == decompressedProbeKeys[i].label &&
+                                              nodeId.offset == decompressedProbeKeys[i].offset);
+            probeState->probedTuples[i] =
+                *(uint8_t**)(probeState->probedTuples[i] + hashTable->numBytesForFixedTuplePart -
+                             sizeof(uint8_t*));
+        }
+        probeState->probeKeyIndex++;
+    }
+}
+
+void HashJoin::populateOutKeyDataChunkAndVectorPtrs() {
+    for (uint64_t i = 0; i < probeSideKeyDataChunk->getNumAttributes(); i++) {
+        auto probeVector = probeSideKeyDataChunk->getValueVector(i);
+        auto probeVectorValues = probeVector->getValues();
+        auto outKeyVector = outKeyDataChunk->getValueVector(i);
+        auto outKeyVectorValues = outKeyVector->getValues();
+        auto numBytesPerValue = outKeyVector->getNumBytesPerValue();
+        for (uint64_t j = 0; j < probeState->matchedTuplesSize; j++) {
+            memcpy(outKeyVectorValues + (j * numBytesPerValue),
+                probeVectorValues + (probeState->probeSelVector[j] * numBytesPerValue),
+                numBytesPerValue);
+        }
+    }
+    auto outKeyDataChunkVectorIdx = probeSideKeyDataChunk->getNumAttributes();
+    auto tupleReadOffset = NUM_BYTES_PER_NODE_ID;
+    for (uint64_t i = 0; i < buildSideKeyDataChunk->getNumAttributes(); i++) {
+        if (i == buildSideKeyVectorIdx) {
+            continue;
+        }
+        auto outVectorValues =
+            outKeyDataChunk->getValueVector(outKeyDataChunkVectorIdx)->getValues();
+        auto numBytesPerValue = buildSideKeyDataChunk->getValueVector(i)->getNumBytesPerValue();
+        for (uint64_t j = 0; j < probeState->matchedTuplesSize; j++) {
+            memcpy(outVectorValues + (j * numBytesPerValue),
+                probeState->matchedTuples[j] + tupleReadOffset, numBytesPerValue);
+        }
+        tupleReadOffset += numBytesPerValue;
+        outKeyDataChunkVectorIdx++;
+    }
+    auto buildSideVectorPtrsIdx = 0;
+    for (uint64_t i = 0; i < buildSideNonKeyDataChunks->getNumDataChunks(); i++) {
+        auto dataChunk = buildSideNonKeyDataChunks->getDataChunk(i);
+        if (dataChunk->isFlat()) {
+            for (auto& vector : dataChunk->valueVectors) {
+                auto outVectorValues =
+                    outKeyDataChunk->getValueVector(outKeyDataChunkVectorIdx)->getValues();
+                auto numBytesPerValue = vector->getNumBytesPerValue();
+                for (uint64_t j = 0; j < probeState->matchedTuplesSize; j++) {
+                    memcpy(outVectorValues + (j * numBytesPerValue),
+                        probeState->matchedTuples[j] + tupleReadOffset, numBytesPerValue);
+                }
+                tupleReadOffset += numBytesPerValue;
+                outKeyDataChunkVectorIdx++;
+            }
+        } else {
+            for (auto& vector : dataChunk->valueVectors) {
+                for (uint64_t j = 0; j < probeState->matchedTuplesSize; j++) {
+                    buildSideVectorPtrs[buildSideVectorPtrsIdx][j] =
+                        *(overflow_value_t*)(probeState->matchedTuples[j] + tupleReadOffset);
+                }
+                tupleReadOffset += sizeof(overflow_value_t);
+                buildSideVectorPtrsIdx++;
+            }
+        }
+    }
+
+    outKeyDataChunk->size = probeState->matchedTuplesSize;
+    probeState->matchedTuplesSize = 0;
+}
+
+void HashJoin::updateAppendedUnFlatOutDataChunks() {
+    for (auto& buildVectorInfo : buildSideVectorInfos) {
+        auto outDataChunk = dataChunks->getDataChunk(buildVectorInfo.outDataChunkIdx);
+        auto appendVectorData =
+            outDataChunk->getValueVector(buildVectorInfo.outVectorIdx)->getValues();
+        auto overflowVal =
+            buildSideVectorPtrs[buildVectorInfo.vectorPtrsIdx].operator[](outKeyDataChunk->currPos);
+        memcpy(appendVectorData, overflowVal.value, overflowVal.len);
+        outDataChunk->size = overflowVal.len / buildVectorInfo.numBytesPerValue;
+    }
+}
+
+// The general flow of a hash join:
+// 1) append all data chunks from the build side into ht.
+// 2) for probing, first find matched tuples of probe side keys from ht, then populate values from
+// matched tuples into outKeyDataChunk and buildSideVectorPtrs, finally, if build side doesn't
+// contain any unflat non-key data chunks, which means buildSideVectorPtrs is empty, directly unflat
+// outKeyDataChunk. else flat outKeyDataChunk and update currPos of outKeyDataChunk, and update
+// appended unflat data chunks based on buildSideVectorPtrs and outKeyDataChunk.currPos.
+void HashJoin::getNextTuples() {
+    if (!isHTInitialized) {
+        while (buildSidePrevOp->hasNextMorsel()) {
+            buildSidePrevOp->getNextTuples();
+            if (0 == buildSideKeyDataChunk->size) {
+                break;
+            }
+            hashTable->addDataChunks(
+                *buildSideKeyDataChunk, buildSideKeyVectorIdx, *buildSideNonKeyDataChunks);
+        }
+        hashTable->buildDirectory();
+        isHTInitialized = true;
+    }
+    if (!buildSideVectorPtrs.empty() && outKeyDataChunk->currPos < (outKeyDataChunk->size - 1)) {
+        outKeyDataChunk->currPos += 1;
+        updateAppendedUnFlatOutDataChunks();
+        return;
+    }
+    getNextBatchOfMatchedTuples();
+    populateOutKeyDataChunkAndVectorPtrs();
+    if (buildSideVectorPtrs.empty()) {
+        outKeyDataChunk->currPos = -1;
+    } else {
+        outKeyDataChunk->currPos = 0;
+        updateAppendedUnFlatOutDataChunks();
+    }
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/physical_plan/operator/scan/physical_scan.cpp
+++ b/src/processor/physical_plan/operator/scan/physical_scan.cpp
@@ -10,6 +10,7 @@ PhysicalScan::PhysicalScan(shared_ptr<MorselDesc>& morsel) : morsel{morsel} {
     nodeIDVector = make_shared<NodeIDSequenceVector>();
     outDataChunk = make_shared<DataChunk>();
     outDataChunk->append(nodeIDVector);
+    nodeIDVector->setDataChunkOwner(outDataChunk);
     dataChunks->append(outDataChunk);
 }
 
@@ -22,7 +23,7 @@ bool PhysicalScan::hasNextMorsel() {
         return false;
     } else {
         currentMorselStartOffset = morsel->currNodeOffset;
-        currentMorselSize = min((uint64_t)ValueVector::NODE_SEQUENCE_VECTOR_SIZE,
+        currentMorselSize = min((uint64_t)ValueVector::DEFAULT_VECTOR_SIZE,
             morsel->numNodes - currentMorselStartOffset);
         morsel->currNodeOffset += currentMorselSize;
         return true;

--- a/test/common/vector/node_vector_test.cpp
+++ b/test/common/vector/node_vector_test.cpp
@@ -8,7 +8,7 @@ TEST(ListTests, CreateSequenceNodeVectorTest) {
     auto vector = NodeIDSequenceVector();
     vector.setStartOffset(100);
     nodeID_t node;
-    for (uint64_t i = 0; i < ValueVector::NODE_SEQUENCE_VECTOR_SIZE; i++) {
+    for (uint64_t i = 0; i < ValueVector::DEFAULT_VECTOR_SIZE; i++) {
         vector.readNodeOffset(i, node);
         ASSERT_EQ(node.offset, 100 + i);
     }

--- a/test/processor/BUILD.bazel
+++ b/test/processor/BUILD.bazel
@@ -6,6 +6,7 @@ cc_test(
         "physical_plan/expression_mapper_test.cpp",
         "physical_plan/operator/scan/scan_test.cpp",
         "physical_plan/operator/hash_join/hash_table_test.cpp",
+        "physical_plan/operator/hash_join/hash_join_test.cpp",
         "physical_plan/operator/tuple/data_chunks_iterator_test.cpp",
         "processor_test.cpp",
         "memory_manager_test.cpp"
@@ -14,9 +15,22 @@ cc_test(
         "-Iexternal/gtest/include",
     ],
     deps = [
-        "//src/processor",
+        "mock_operators_for_hash_join",
         "//src/processor:hash_table",
         "@gtest",
         "@gtest//:gtest_main",
+    ],
+)
+
+cc_library(
+    name = "mock_operators_for_hash_join",
+    srcs = [
+        "physical_plan/operator/hash_join/data_chunks_mock_operator.cpp"
+    ],
+    hdrs = [
+        "physical_plan/operator/hash_join/data_chunks_mock_operator.h"
+    ],
+    deps = [
+        "//src/processor"
     ],
 )

--- a/test/processor/physical_plan/operator/hash_join/data_chunks_mock_operator.cpp
+++ b/test/processor/physical_plan/operator/hash_join/data_chunks_mock_operator.cpp
@@ -1,0 +1,116 @@
+#include "data_chunks_mock_operator.h"
+
+void ScanMockOp::getNextTuples() {
+    if (numTuples < 10) {
+        dataChunks->getDataChunk(1)->currPos = numTuples;
+        numTuples += 1;
+        return;
+    }
+    dataChunks->getDataChunk(0)->size = 0;
+    dataChunks->getDataChunk(1)->size = 0;
+    dataChunks->getDataChunk(2)->size = 0;
+}
+
+void ScanMockOp::generateDataChunks() {
+    auto dataChunkA = make_shared<DataChunk>();
+    auto dataChunkB = make_shared<DataChunk>();
+    auto dataChunkC = make_shared<DataChunk>();
+
+    NodeIDCompressionScheme compressionScheme;
+    auto vectorA1 = make_shared<NodeIDVector>(18, compressionScheme);
+    auto vectorA2 = make_shared<ValueVector>(INT32);
+    auto vectorB1 = make_shared<NodeIDVector>(28, compressionScheme);
+    auto vectorB2 = make_shared<ValueVector>(DOUBLE);
+    auto vectorC1 = make_shared<NodeIDVector>(38, compressionScheme);
+    auto vectorC2 = make_shared<ValueVector>(BOOL);
+
+    for (int32_t i = 0; i < 10; i++) {
+        vectorA1->setValue<uint64_t>(i, (uint64_t)i);
+        vectorA2->setValue<int32_t>(i, (int32_t)(i * 2));
+        vectorB1->setValue<uint64_t>(i, (uint64_t)i);
+        vectorB2->setValue(i, (double)(i / 2));
+        vectorC1->setValue<uint64_t>(i, (uint64_t)i);
+        vectorC2->setValue(i, (bool)((i / 2) == 1));
+    }
+    dataChunkA->append(vectorA1);
+    vectorA1->setDataChunkOwner(dataChunkA);
+    dataChunkA->append(vectorA2);
+    vectorA2->setDataChunkOwner(dataChunkA);
+    dataChunkB->append(vectorB1);
+    vectorB1->setDataChunkOwner(dataChunkB);
+    dataChunkB->append(vectorB2);
+    vectorB2->setDataChunkOwner(dataChunkB);
+    dataChunkC->append(vectorC1);
+    vectorC1->setDataChunkOwner(dataChunkC);
+    dataChunkC->append(vectorC2);
+    vectorC2->setDataChunkOwner(dataChunkC);
+
+    dataChunkA->size = 10;
+    dataChunkB->size = 10;
+    dataChunkC->size = 10;
+    dataChunkA->currPos = 0;
+    dataChunkB->currPos = 0;
+    dataChunkC->currPos = -1;
+    dataChunks->append(dataChunkA);
+    dataChunks->append(dataChunkB);
+    dataChunks->append(dataChunkC);
+}
+
+void ProbeScanMockOp::getNextTuples() {
+    if (numTuples < 4) {
+        dataChunks->getDataChunk(1)->currPos = numTuples;
+        numTuples += 1;
+        return;
+    }
+    dataChunks->getDataChunk(0)->size = 0;
+    dataChunks->getDataChunk(1)->size = 0;
+    dataChunks->getDataChunk(2)->size = 0;
+    dataChunks->getDataChunk(0)->size = 0;
+    dataChunks->getDataChunk(1)->size = 0;
+    dataChunks->getDataChunk(2)->size = 0;
+}
+
+void ProbeScanMockOp::generateDataChunks() {
+    auto dataChunkA = make_shared<DataChunk>();
+    auto dataChunkB = make_shared<DataChunk>();
+    auto dataChunkC = make_shared<DataChunk>();
+
+    NodeIDCompressionScheme compressionScheme;
+    auto vectorA1 = make_shared<NodeIDVector>(18, compressionScheme);
+    auto vectorA2 = make_shared<ValueVector>(INT32);
+    auto vectorB1 = make_shared<NodeIDVector>(28, compressionScheme);
+    auto vectorB2 = make_shared<ValueVector>(DOUBLE);
+    auto vectorC1 = make_shared<NodeIDVector>(38, compressionScheme);
+    auto vectorC2 = make_shared<ValueVector>(BOOL);
+
+    for (int32_t i = 0; i < 10; i++) {
+        vectorA1->setValue<uint64_t>(i, (uint64_t)i);
+        vectorA2->setValue<int32_t>(i, (int32_t)(i * 2));
+        vectorB1->setValue<uint64_t>(i, (uint64_t)i);
+        vectorB2->setValue(i, (double)(i / 2));
+        vectorC1->setValue<uint64_t>(i, (uint64_t)i);
+        vectorC2->setValue(i, (bool)((i / 2) == 1));
+    }
+    dataChunkA->append(vectorA1);
+    vectorA1->setDataChunkOwner(dataChunkA);
+    dataChunkA->append(vectorA2);
+    vectorA2->setDataChunkOwner(dataChunkA);
+    dataChunkB->append(vectorB1);
+    vectorB1->setDataChunkOwner(dataChunkB);
+    dataChunkB->append(vectorB2);
+    vectorB2->setDataChunkOwner(dataChunkB);
+    dataChunkC->append(vectorC1);
+    vectorC1->setDataChunkOwner(dataChunkC);
+    dataChunkC->append(vectorC2);
+    vectorC2->setDataChunkOwner(dataChunkC);
+
+    dataChunkA->size = 10;
+    dataChunkB->size = 10;
+    dataChunkC->size = 10;
+    dataChunkA->currPos = 0;
+    dataChunkB->currPos = 2;
+    dataChunkC->currPos = -1;
+    dataChunks->append(dataChunkA);
+    dataChunks->append(dataChunkB);
+    dataChunks->append(dataChunkC);
+}

--- a/test/processor/physical_plan/operator/hash_join/data_chunks_mock_operator.h
+++ b/test/processor/physical_plan/operator/hash_join/data_chunks_mock_operator.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "src/processor/include/physical_plan/operator/physical_operator.h"
+#include "src/processor/include/physical_plan/operator/tuple/data_chunks.h"
+
+using namespace graphflow::processor;
+
+namespace graphflow {
+namespace processor {
+
+class DataChunksMockOperator : public PhysicalOperator {
+public:
+    DataChunksMockOperator() { dataChunks = make_shared<DataChunks>(); }
+    DataChunksMockOperator(shared_ptr<DataChunks> mockDataChunks) { dataChunks = mockDataChunks; }
+
+    bool hasNextMorsel() override { return true; };
+    void getNextTuples() override {}
+    unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<DataChunksMockOperator>(dataChunks);
+    }
+};
+
+class ScanMockOp : public DataChunksMockOperator {
+public:
+    ScanMockOp() : numTuples(0) { generateDataChunks(); }
+
+    void getNextTuples() override;
+
+private:
+    void generateDataChunks();
+
+    uint64_t numTuples;
+};
+
+class ProbeScanMockOp : public DataChunksMockOperator {
+public:
+    ProbeScanMockOp() : numTuples(2) { generateDataChunks(); }
+
+    void getNextTuples() override;
+
+private:
+    void generateDataChunks();
+
+    uint64_t numTuples;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/test/processor/physical_plan/operator/hash_join/hash_join_test.cpp
+++ b/test/processor/physical_plan/operator/hash_join/hash_join_test.cpp
@@ -1,0 +1,178 @@
+#include "data_chunks_mock_operator.h"
+#include "gtest/gtest.h"
+
+#include "src/processor/include/memory_manager.h"
+#include "src/processor/include/physical_plan/operator/hash_join/hash_join.h"
+#include "src/processor/include/physical_plan/operator/tuple/data_chunks_iterator.h"
+#include "src/processor/include/physical_plan/operator/tuple/tuple.h"
+
+TEST(HashJoinTests, HashJoinTest1) {
+    MemoryManager memoryManager(1024 * 1024 * 1024);
+
+    auto buildOp = make_unique<ScanMockOp>();
+    auto probeOp = make_unique<ProbeScanMockOp>();
+
+    unique_ptr<HashJoin> hashJoin =
+        make_unique<HashJoin>(memoryManager, 0, 0, 0, 0, move(buildOp), move(probeOp));
+    uint64_t matchedNumTuples = 0;
+    while (true) {
+        hashJoin->getNextTuples();
+        auto result = hashJoin->getDataChunks();
+        matchedNumTuples += result->getNumTuples();
+        if (result->getNumTuples() == 0) {
+            break;
+        }
+        ASSERT_EQ(result->getNumTuples(), 100);
+        vector<DataType> types;
+        for (uint64_t i = 0; i < result->getNumDataChunks(); i++) {
+            for (auto& vector : result->getDataChunk(i)->valueVectors) {
+                types.push_back(vector->getDataType());
+            }
+        }
+        Tuple tuple(types);
+        DataChunksIterator dataChunksIterator(*result);
+        uint64_t tupleIndex = 0;
+        while (dataChunksIterator.hasNextTuple()) {
+            dataChunksIterator.getNextTuple(tuple);
+            ASSERT_EQ(tuple.getValue(0)->nodeID.label, 18);
+            ASSERT_EQ(tuple.getValue(0)->nodeID.offset, 0);
+            ASSERT_EQ(tuple.getValue(1)->primitive.integer, 0);
+            ASSERT_EQ(tuple.getValue(2)->primitive.integer, 0);
+            ASSERT_EQ(tuple.getValue(3)->nodeID.label, 28);
+            auto nodeOffset = 10 - (matchedNumTuples > 1000 ? (matchedNumTuples - 1000) / 100 :
+                                                              matchedNumTuples / 100);
+            ASSERT_EQ(tuple.getValue(3)->nodeID.offset, nodeOffset);
+            ASSERT_EQ(tuple.getValue(4)->primitive.double_, (double)(nodeOffset / 2));
+            ASSERT_EQ(tuple.getValue(5)->nodeID.label, 28);
+            ASSERT_EQ(tuple.getValue(5)->nodeID.offset, (matchedNumTuples > 1000 ? 3 : 2));
+            ASSERT_EQ(tuple.getValue(6)->primitive.double_,
+                (double)(tuple.getValue(5)->nodeID.offset / 2));
+            ASSERT_EQ(tuple.getValue(7)->nodeID.label, 38);
+            ASSERT_EQ(tuple.getValue(7)->nodeID.offset, tupleIndex / 10);
+            ASSERT_EQ(tuple.getValue(8)->primitive.boolean, ((tupleIndex / 10) / 2) == 1);
+            ASSERT_EQ(tuple.getValue(9)->nodeID.label, 38);
+            ASSERT_EQ(tuple.getValue(9)->nodeID.offset, (tupleIndex % 10));
+            ASSERT_EQ(tuple.getValue(10)->primitive.boolean, ((tupleIndex % 10) / 2) == 1);
+            tupleIndex++;
+        }
+    }
+    ASSERT_EQ(matchedNumTuples, 2000);
+}
+
+TEST(HashJoinTests, HashJoinTest2) {
+    MemoryManager memoryManager(1024 * 1024 * 1024);
+
+    auto buildOp = make_unique<ScanMockOp>();
+    auto probeOp = make_unique<ProbeScanMockOp>();
+    unique_ptr<HashJoin> hashJoin =
+        make_unique<HashJoin>(memoryManager, 2, 0, 2, 0, move(buildOp), move(probeOp));
+    uint64_t matchedNumTuples = 0;
+    while (true) {
+        hashJoin->getNextTuples();
+        auto result = hashJoin->getDataChunks();
+        matchedNumTuples += result->getNumTuples();
+        if (result->getNumTuples() == 0) {
+            break;
+        }
+        ASSERT_EQ(result->getNumTuples(), 100);
+        vector<DataType> types;
+        for (uint64_t i = 0; i < result->getNumDataChunks(); i++) {
+            for (auto& vector : result->getDataChunk(i)->valueVectors) {
+                types.push_back(vector->getDataType());
+            }
+        }
+        Tuple tuple(types);
+        DataChunksIterator dataChunksIterator(*result);
+        uint64_t tupleIndex = 0;
+        while (dataChunksIterator.hasNextTuple()) {
+            dataChunksIterator.getNextTuple(tuple);
+            ASSERT_EQ(tuple.getValue(0)->nodeID.label, 38);
+            ASSERT_EQ(tuple.getValue(0)->nodeID.offset, tupleIndex / 10);
+            ASSERT_EQ(tuple.getValue(1)->primitive.boolean, ((tupleIndex / 10) / 2) == 1);
+            ASSERT_EQ(tuple.getValue(2)->primitive.boolean, ((tupleIndex / 10) / 2) == 1);
+            ASSERT_EQ(tuple.getValue(3)->nodeID.label, 18);
+            ASSERT_EQ(tuple.getValue(3)->nodeID.offset, 0);
+            ASSERT_EQ(tuple.getValue(4)->primitive.integer, 0);
+            ASSERT_EQ(tuple.getValue(5)->nodeID.label, 28);
+            ASSERT_EQ(tuple.getValue(5)->nodeID.offset, (10 - ((tupleIndex % 10) + 1)));
+            ASSERT_EQ(
+                tuple.getValue(6)->primitive.double_, (double)((10 - ((tupleIndex % 10) + 1)) / 2));
+            ASSERT_EQ(tuple.getValue(7)->nodeID.label, 18);
+            ASSERT_EQ(tuple.getValue(7)->nodeID.offset, 0);
+            ASSERT_EQ(tuple.getValue(8)->primitive.integer, 0);
+            ASSERT_EQ(tuple.getValue(9)->nodeID.label, 28);
+            ASSERT_EQ(tuple.getValue(9)->nodeID.offset, (matchedNumTuples / 100) + 1);
+            ASSERT_EQ(tuple.getValue(10)->primitive.double_, (double)(tupleIndex / 100 + 1));
+            tupleIndex++;
+        }
+    }
+    ASSERT_EQ(matchedNumTuples, 200);
+}
+
+TEST(HashJoinTests, HashJoinTest3) {
+    MemoryManager memoryManager(1024 * 1024 * 1024);
+
+    auto buildOp = make_unique<ScanMockOp>();
+    auto probeOp = make_unique<ProbeScanMockOp>();
+    unique_ptr<HashJoin> hashJoin =
+        make_unique<HashJoin>(memoryManager, 1, 0, 1, 0, move(buildOp), move(probeOp));
+    uint64_t matchedNumTuples = 0;
+    while (true) {
+        hashJoin->getNextTuples();
+        auto result = hashJoin->getDataChunks();
+        matchedNumTuples += result->getNumTuples();
+        if (result->getNumTuples() == 0) {
+            break;
+        }
+        ASSERT_EQ(result->getNumTuples(), 100);
+        vector<DataType> types;
+        for (uint64_t i = 0; i < result->getNumDataChunks(); i++) {
+            for (auto& vector : result->getDataChunk(i)->valueVectors) {
+                types.push_back(vector->getDataType());
+            }
+        }
+        Tuple tuple(types);
+        DataChunksIterator dataChunksIterator(*result);
+        uint64_t tupleIndex = 0;
+        while (dataChunksIterator.hasNextTuple()) {
+            dataChunksIterator.getNextTuple(tuple);
+            ASSERT_EQ(tuple.getValue(0)->nodeID.label, 28);
+            ASSERT_EQ(tuple.getValue(0)->nodeID.offset, (matchedNumTuples / 100) + 1);
+            ASSERT_EQ(tuple.getValue(1)->primitive.double_, (double)(tupleIndex / 100 + 1));
+            ASSERT_EQ(tuple.getValue(2)->primitive.double_, (double)(tupleIndex / 100 + 1));
+            ASSERT_EQ(tuple.getValue(3)->nodeID.label, 18);
+            ASSERT_EQ(tuple.getValue(3)->nodeID.offset, 0);
+            ASSERT_EQ(tuple.getValue(4)->primitive.integer, 0);
+            ASSERT_EQ(tuple.getValue(5)->nodeID.label, 18);
+            ASSERT_EQ(tuple.getValue(5)->nodeID.offset, 0);
+            ASSERT_EQ(tuple.getValue(6)->primitive.integer, 0);
+            ASSERT_EQ(tuple.getValue(7)->nodeID.label, 38);
+            ASSERT_EQ(tuple.getValue(7)->nodeID.offset, tupleIndex / 10);
+            ASSERT_EQ(tuple.getValue(8)->primitive.boolean, ((tupleIndex / 10) / 2) == 1);
+            ASSERT_EQ(tuple.getValue(9)->nodeID.label, 38);
+            ASSERT_EQ(tuple.getValue(9)->nodeID.offset, (tupleIndex % 10));
+            ASSERT_EQ(tuple.getValue(10)->primitive.boolean, ((tupleIndex % 10) / 2) == 1);
+            tupleIndex++;
+        }
+    }
+    ASSERT_EQ(matchedNumTuples, 200);
+}
+
+TEST(HashJoinTests, HashJoinTest4) {
+    MemoryManager memoryManager(1024 * 1024 * 1024);
+
+    auto buildOp = make_unique<ScanMockOp>();
+    auto probeOp = make_unique<ProbeScanMockOp>();
+    unique_ptr<HashJoin> hashJoin =
+        make_unique<HashJoin>(memoryManager, 1, 0, 2, 0, move(buildOp), move(probeOp));
+    uint64_t matchedNumTuples = 0;
+    while (true) {
+        hashJoin->getNextTuples();
+        auto result = hashJoin->getDataChunks();
+        matchedNumTuples += result->getNumTuples();
+        if (result->getNumTuples() == 0) {
+            break;
+        }
+    }
+    ASSERT_EQ(matchedNumTuples, 0);
+}

--- a/test/processor/physical_plan/operator/scan/scan_test.cpp
+++ b/test/processor/physical_plan/operator/scan/scan_test.cpp
@@ -15,12 +15,12 @@ TEST(ScanTests, ScanTest) {
     auto nodeVector =
         static_pointer_cast<NodeIDVector>(dataChunks->getDataChunk(0)->getValueVector(0));
     node_offset_t currNodeOffset = 0;
-    uint64_t size = ValueVector::NODE_SEQUENCE_VECTOR_SIZE;
+    uint64_t size = ValueVector::DEFAULT_VECTOR_SIZE;
     while (morsel->getCurrNodeOffset() < 1025013) {
         ASSERT_EQ(scan->hasNextMorsel(), true);
         scan->getNextTuples();
         if (morsel->getCurrNodeOffset() >= 1025013) {
-            size = 1025013 % ValueVector::NODE_SEQUENCE_VECTOR_SIZE;
+            size = 1025013 % ValueVector::DEFAULT_VECTOR_SIZE;
         }
         ASSERT_EQ(dataChunk->size, size);
         nodeID_t node;
@@ -28,7 +28,7 @@ TEST(ScanTests, ScanTest) {
             nodeVector->readNodeOffset(i, node);
             ASSERT_EQ(node.offset, currNodeOffset + i);
         }
-        currNodeOffset += ValueVector::NODE_SEQUENCE_VECTOR_SIZE;
+        currNodeOffset += ValueVector::DEFAULT_VECTOR_SIZE;
     }
     ASSERT_EQ(morsel->getCurrNodeOffset(), 1025013);
     ASSERT_EQ(scan->hasNextMorsel(), false);


### PR DESCRIPTION
The hash join is based on the previously implemented #51 .

First, add all data chunks from the build side into the hash table.
Then, probe the hash table to find matched tuples.
Matched tuples are divided into several parts to be reconstructed as the final result dataChunks.

In the final result dataChunks, we keep data chunks from the probe side remain as they are except for the key data chunk.  
The probe side key data chunk will be replaced by (extended to) the `intermediateUnOverflowDataChunk`, which keeps all vectors in the probe side key data chunk, and also vectors from the build side that are not stored as overflow lists in the hash table.
Other overflow payloads in the hash table are read into the` intermediateOverflowDataChunk` as overflow struct values.

The two intermediate data chunks store at most 1024 tuples at a time, which will be flat in the final result dataChunks, and the overflow lists are copied into the result dataChunks as separate unflat data chunks.

