### PR TITLE
Expression Binder

### DIFF
--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace common {
 
 bool isExpressionUnary(ExpressionType type) {
-    return NOT == type || NEGATE == type;
+    return NOT == type || NEGATE == type || IS_NULL == type || IS_NOT_NULL == type;
 }
 
 bool isExpressionBinary(ExpressionType type) {
@@ -58,6 +58,75 @@ DataType getBinaryExpressionResultDataType(
         return DOUBLE;
     default:
         throw std::invalid_argument("Invalid or unsupported binary operation.");
+    }
+}
+
+string expressionTypeToString(ExpressionType type) {
+    switch (type) {
+    case OR:
+        return "OR";
+    case XOR:
+        return "XOR";
+    case AND:
+        return "AND";
+    case NOT:
+        return "NOT";
+    case EQUALS:
+        return "EQUALS";
+    case NOT_EQUALS:
+        return "NOT_EQUALS";
+    case GREATER_THAN:
+        return "GREATER_THAN";
+    case GREATER_THAN_EQUALS:
+        return "GREATER_THAN_EQUALS";
+    case LESS_THAN:
+        return "LESS_THAN";
+    case LESS_THAN_EQUALS:
+        return "LESS_THAN_EQUALS";
+    case ADD:
+        return "ADD";
+    case SUBTRACT:
+        return "SUBTRACT";
+    case MULTIPLY:
+        return "MULTIPLY";
+    case DIVIDE:
+        return "DIVIDE";
+    case MODULO:
+        return "MODULO";
+    case POWER:
+        return "POWER";
+    case NEGATE:
+        return "NEGATE";
+    case HASH_NODE_ID:
+        return "HASH_NODE_ID";
+    case STARTS_WITH:
+        return "STARTS_WITH";
+    case ENDS_WITH:
+        return "ENDS_WITH";
+    case CONTAINS:
+        return "CONTAINS";
+    case IS_NULL:
+        return "IS_NULL";
+    case IS_NOT_NULL:
+        return "IS_NOT_NULL";
+    case PROPERTY:
+        return "PROPERTY";
+    case FUNCTION:
+        return "FUNCTION";
+    case LITERAL_INT:
+        return "LITERAL_INT";
+    case LITERAL_DOUBLE:
+        return "LITERAL_DOUBLE";
+    case LITERAL_STRING:
+        return "LITERAL_STRING";
+    case LITERAL_BOOLEAN:
+        return "LITERAL_BOOLEAN";
+    case LITERAL_NULL:
+        return "LITERAL_NULL";
+    case VARIABLE:
+        return "VARIABLE";
+    default:
+        throw invalid_argument("Should never happen. Cannot convert expression type to string");
     }
 }
 

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -7,10 +7,6 @@ namespace common {
 
 enum ExpressionType {
 
-    // -----------------------------------------
-    // Non Leaf Expression
-    // -----------------------------------------
-
     /**
      * Boolean Connection Expressions
      **/
@@ -73,10 +69,6 @@ enum ExpressionType {
      **/
     FUNCTION = 63,
 
-    // ------------------------------
-    // Leaf Expression
-    // ------------------------------
-
     /**
      * Literal Expressions
      **/
@@ -99,6 +91,8 @@ bool isExpressionLeafVariable(ExpressionType type);
 DataType getUnaryExpressionResultDataType(ExpressionType type, DataType operandType);
 DataType getBinaryExpressionResultDataType(
     ExpressionType type, DataType leftOperandType, DataType rightOperandType);
+
+string expressionTypeToString(ExpressionType type);
 
 } // namespace common
 } // namespace graphflow

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -95,6 +95,10 @@ size_t getDataTypeSize(DataType dataType);
 
 DataType getDataType(const std::string& dataTypeString);
 
+string dataTypeToString(DataType dataType);
+
+bool isNumericalType(DataType dataType);
+
 // Rel Label Cardinality
 enum Cardinality : uint8_t { MANY_MANY, MANY_ONE, ONE_MANY, ONE_ONE };
 const string CardinalityNames[] = {"MANY_MANY", "MANY_ONE", "ONE_MANY", "ONE_ONE"};

--- a/src/common/literal.cpp
+++ b/src/common/literal.cpp
@@ -10,6 +10,7 @@ string Literal::toString() const {
     case BOOL:
         return primitive.boolean ? "True" : "False";
     case INT32:
+    case INT64:
         return to_string(primitive.integer);
     case DOUBLE:
         return to_string(primitive.double_);

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -26,6 +26,21 @@ DataType getDataType(const std::string& dataTypeString) {
     throw invalid_argument("Cannot parse dataType: " + dataTypeString);
 }
 
+string dataTypeToString(DataType dataType) {
+    return DataTypeNames[dataType];
+}
+
+bool isNumericalType(DataType dataType) {
+    switch (dataType) {
+    case INT32:
+    case INT64:
+    case DOUBLE:
+        return true;
+    default:
+        return false;
+    }
+}
+
 size_t getDataTypeSize(DataType dataType) {
     switch (dataType) {
     case LABEL:

--- a/src/expression/include/logical/logical_expression.h
+++ b/src/expression/include/logical/logical_expression.h
@@ -14,11 +14,12 @@ class LogicalExpression {
 
 public:
     // creates a non-leaf logical binary expression.
-    LogicalExpression(ExpressionType expressionType, unique_ptr<LogicalExpression> left,
-        unique_ptr<LogicalExpression> right);
+    LogicalExpression(ExpressionType expressionType, DataType dataType,
+        unique_ptr<LogicalExpression> left, unique_ptr<LogicalExpression> right);
 
     // creates a non-leaf logical unary expression.
-    LogicalExpression(ExpressionType expressionType, unique_ptr<LogicalExpression> child);
+    LogicalExpression(
+        ExpressionType expressionType, DataType dataType, unique_ptr<LogicalExpression> child);
 
     // creates a leaf variable expression.
     LogicalExpression(ExpressionType expressionType, DataType dataType, const string& variableName);

--- a/src/expression/logical/logical_expression.cpp
+++ b/src/expression/logical/logical_expression.cpp
@@ -3,16 +3,18 @@
 namespace graphflow {
 namespace expression {
 
-LogicalExpression::LogicalExpression(ExpressionType expressionType,
+LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dataType,
     unique_ptr<LogicalExpression> left, unique_ptr<LogicalExpression> right) {
     childrenExpr.push_back(move(left));
     childrenExpr.push_back(move(right));
+    this->dataType = dataType;
     this->expressionType = expressionType;
 }
 
 LogicalExpression::LogicalExpression(
-    ExpressionType expressionType, unique_ptr<LogicalExpression> child) {
+    ExpressionType expressionType, DataType dataType, unique_ptr<LogicalExpression> child) {
     childrenExpr.push_back(move(child));
+    this->dataType = dataType;
     this->expressionType = expressionType;
 }
 

--- a/src/parser/include/parsed_expression.h
+++ b/src/parser/include/parsed_expression.h
@@ -26,6 +26,14 @@ public:
         children.push_back(move(right));
     }
 
+    ExpressionType getType() const { return type; }
+
+    string getText() const { return text; }
+
+    uint32_t getNumChildren() const { return children.size(); }
+
+    const ParsedExpression& getChildren(uint32_t idx) const { return *children.at(idx); }
+
     void addChild(unique_ptr<ParsedExpression> child) { children.push_back(move(child)); }
 
     bool operator==(const ParsedExpression& other) {

--- a/src/parser/include/statements/match_statement.h
+++ b/src/parser/include/statements/match_statement.h
@@ -16,6 +16,10 @@ public:
 
     const PatternElement& getPatternElement(int idx) const { return *graphPattern[idx]; }
 
+    bool hasWhereClause() const { return nullptr != whereClause; }
+
+    const ParsedExpression& getWhereClasue() const { return *whereClause; }
+
     void setWhereClause(unique_ptr<ParsedExpression> whereClause) {
         this->whereClause = move(whereClause);
     }

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -21,14 +21,17 @@ cc_library(
     name = "binder",
     srcs = [
         "binder.cpp",
+        "expression_binder.cpp",
     ],
     hdrs = [
         "include/binder.h",
+        "include/expression_binder.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
         "bound_statement",
         "query_graph",
+        "//src/expression",
         "//src/parser",
         "//src/storage:catalog",
     ],

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -1,0 +1,276 @@
+#include "src/planner/include/expression_binder.h"
+
+namespace graphflow {
+namespace planner {
+
+static void validateNoNullLiteralChildren(const ParsedExpression& parsedExpression);
+
+static void validateExpectedType(const LogicalExpression& logicalExpression, DataType expectedType);
+
+static void validateNumericalType(const LogicalExpression& logicalExpression);
+
+void validateNoNullLiteralChildren(const ParsedExpression& parsedExpression) {
+    for (auto i = 0ul; i < parsedExpression.getNumChildren(); ++i) {
+        if (LITERAL_NULL == parsedExpression.getChildren(i).getType()) {
+            throw invalid_argument(
+                "Expression of type: " + expressionTypeToString(parsedExpression.getType()) +
+                " cannot have null literal children");
+        }
+    }
+}
+
+void validateExpectedType(const LogicalExpression& logicalExpression, DataType expectedType) {
+    auto dataType = logicalExpression.getDataType();
+    if (expectedType != dataType) {
+        throw invalid_argument("LogicalExpression return data type: " + dataTypeToString(dataType) +
+                               " expect: " + dataTypeToString(expectedType));
+    }
+}
+
+void validateNumericalType(const LogicalExpression& logicalExpression) {
+    auto dataType = logicalExpression.getDataType();
+    if (!isNumericalType(dataType)) {
+        throw invalid_argument("LogicalExpression return data type: " + dataTypeToString(dataType) +
+                               " expect numerical type.");
+    }
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindExpression(
+    const ParsedExpression& parsedExpression) {
+    auto expressionType = parsedExpression.getType();
+    switch (expressionType) {
+    case OR:
+    case XOR:
+    case AND:
+    case NOT:
+        return bindBoolConnectionExpression(parsedExpression);
+    case EQUALS:
+    case NOT_EQUALS:
+    case GREATER_THAN:
+    case GREATER_THAN_EQUALS:
+    case LESS_THAN:
+    case LESS_THAN_EQUALS:
+        return bindComparisonExpression(parsedExpression);
+    case ADD:
+    case SUBTRACT:
+    case MULTIPLY:
+    case DIVIDE:
+    case MODULO:
+    case POWER:
+        return bindBinaryArithmeticExpression(parsedExpression);
+    case NEGATE:
+        return bindUnaryArithmeticExpression(parsedExpression);
+    case STARTS_WITH:
+    case ENDS_WITH:
+    case CONTAINS:
+        return bindStringOperatorExpression(parsedExpression);
+    case IS_NULL:
+    case IS_NOT_NULL:
+        return bindNullComparisonOperatorExpression(parsedExpression);
+    case PROPERTY:
+        return bindPropertyExpression(parsedExpression);
+    case FUNCTION:
+        throw invalid_argument("Bind expression with type FUNCTION is not yet implemented.");
+    case LITERAL_INT:
+    case LITERAL_DOUBLE:
+    case LITERAL_STRING:
+    case LITERAL_BOOLEAN:
+    case LITERAL_NULL:
+        return bindLiteralExpression(parsedExpression);
+    case VARIABLE:
+        return bindVariableExpression(parsedExpression);
+    default:
+        throw invalid_argument("Bind expression with type: " +
+                               expressionTypeToString(expressionType) + " should never happen.");
+    }
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindBoolConnectionExpression(
+    const ParsedExpression& parsedExpression) {
+    validateNoNullLiteralChildren(parsedExpression);
+    auto expressionType = parsedExpression.getType();
+    switch (expressionType) {
+    case OR:
+    case XOR:
+    case AND:
+        return buildBinaryASTForBoolConnectionExpression(parsedExpression, expressionType);
+    case NOT: {
+        auto child = bindExpression(parsedExpression.getChildren(0));
+        validateExpectedType(*child, BOOL);
+        return make_unique<LogicalExpression>(NOT, BOOL, move(child));
+    }
+    default:
+        throw invalid_argument("Should never happen. Cannot bind expression type of " +
+                               expressionTypeToString(expressionType) +
+                               " as bool connection expression.");
+    }
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::buildBinaryASTForBoolConnectionExpression(
+    const ParsedExpression& parsedExpression, ExpressionType expressionType) {
+    unique_ptr<LogicalExpression> logicalExpression;
+    for (auto i = 0ul; i < parsedExpression.getNumChildren(); ++i) {
+        auto next = bindExpression(parsedExpression.getChildren(i));
+        validateExpectedType(*next, BOOL);
+        logicalExpression = !logicalExpression ? move(next) :
+                                                 make_unique<LogicalExpression>(expressionType,
+                                                     BOOL, move(logicalExpression), move(next));
+    }
+    return logicalExpression;
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindComparisonExpression(
+    const ParsedExpression& parsedExpression) {
+    auto& parsedLeft = parsedExpression.getChildren(0);
+    auto& parsedRight = parsedExpression.getChildren(1);
+    if (LITERAL_NULL == parsedLeft.getType() || LITERAL_NULL == parsedRight.getType()) {
+        // rewrite == null as IS NULL
+        if (EQUALS == parsedExpression.getType()) {
+            return make_unique<LogicalExpression>(IS_NULL, BOOL,
+                LITERAL_NULL == parsedLeft.getType() ? bindExpression(parsedRight) :
+                                                       bindExpression(parsedLeft));
+        }
+        // rewrite <> null as IS NOT NULL
+        if (NOT_EQUALS == parsedExpression.getType()) {
+            return make_unique<LogicalExpression>(IS_NOT_NULL, BOOL,
+                LITERAL_NULL == parsedLeft.getType() ? bindExpression(parsedRight) :
+                                                       bindExpression(parsedLeft));
+        }
+    }
+    validateNoNullLiteralChildren(parsedExpression);
+    auto left = bindExpression(parsedLeft);
+    auto right = bindExpression(parsedRight);
+    isNumericalType(left->getDataType()) ? validateNumericalType(*right) :
+                                           validateExpectedType(*right, left->getDataType());
+    return make_unique<LogicalExpression>(
+        parsedExpression.getType(), BOOL, move(left), move(right));
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindBinaryArithmeticExpression(
+    const ParsedExpression& parsedExpression) {
+    validateNoNullLiteralChildren(parsedExpression);
+    auto left = bindExpression(parsedExpression.getChildren(0));
+    validateNumericalType(*left);
+    auto right = bindExpression(parsedExpression.getChildren(1));
+    validateNumericalType(*right);
+    DataType resultType;
+    if (DOUBLE == left->getDataType() || DOUBLE == right->getDataType()) {
+        resultType = DOUBLE;
+    } else if (INT64 == left->getDataType() || INT64 == right->getDataType()) {
+        resultType = INT64;
+    } else {
+        resultType = INT32;
+    }
+    auto type = parsedExpression.getType();
+    switch (type) {
+    case ADD:
+    case SUBTRACT:
+    case MULTIPLY:
+    case POWER:
+        return make_unique<LogicalExpression>(type, resultType, move(left), move(right));
+    case DIVIDE:
+        return make_unique<LogicalExpression>(DIVIDE, DOUBLE, move(left), move(right));
+    case MODULO:
+        return make_unique<LogicalExpression>(MODULO, INT32, move(left), move(right));
+    default:
+        throw invalid_argument("Should never happen. Cannot bind expression type of " +
+                               expressionTypeToString(type) + " as binary arithmetic expression.");
+    }
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindUnaryArithmeticExpression(
+    const ParsedExpression& parsedExpression) {
+    validateNoNullLiteralChildren(parsedExpression);
+    auto child = bindExpression(parsedExpression.getChildren(0));
+    validateNumericalType(*child);
+    return make_unique<LogicalExpression>(
+        parsedExpression.getType(), child->getDataType(), move(child));
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindStringOperatorExpression(
+    const ParsedExpression& parsedExpression) {
+    validateNoNullLiteralChildren(parsedExpression);
+    auto left = bindExpression(parsedExpression.getChildren(0));
+    validateExpectedType(*left, STRING);
+    auto right = bindExpression(parsedExpression.getChildren(1));
+    validateExpectedType(*right, STRING);
+    return make_unique<LogicalExpression>(
+        parsedExpression.getType(), BOOL, move(left), move(right));
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindNullComparisonOperatorExpression(
+    const ParsedExpression& parsedExpression) {
+    validateNoNullLiteralChildren(parsedExpression);
+    auto childExpression = bindExpression(parsedExpression.getChildren(0));
+    return make_unique<LogicalExpression>(parsedExpression.getType(), BOOL, move(childExpression));
+}
+
+// Note ParsedPropertyExpression is unary ,but LogicalPropertyExpression is leaf.
+// Bind property to node or rel. This should change for unstructured properties.
+unique_ptr<LogicalExpression> ExpressionBinder::bindPropertyExpression(
+    const ParsedExpression& parsedExpression) {
+    validateNoNullLiteralChildren(parsedExpression);
+    auto propertyName = parsedExpression.getText();
+    auto childExpression = bindExpression(parsedExpression.getChildren(0));
+    if (NODE == childExpression->getDataType()) {
+        auto nodeName = childExpression->getVariableName();
+        auto nodeLabel = graphInScope.getQueryNode(nodeName)->getLabel();
+        if (!catalog.containNodeProperty(nodeLabel, propertyName)) {
+            throw invalid_argument(
+                "Node: " + nodeName + " does not have property: " + propertyName);
+        }
+        return make_unique<LogicalExpression>(PROPERTY,
+            catalog.getNodePropertyTypeFromString(nodeLabel, propertyName),
+            nodeName + "." + propertyName);
+    }
+    if (REL == childExpression->getDataType()) {
+        auto relName = childExpression->getVariableName();
+        auto relLabel = graphInScope.getQueryRel(relName)->getLabel();
+        if (!catalog.containRelProperty(relLabel, propertyName)) {
+            throw invalid_argument("Rel: " + relName + " does not have property: " + propertyName);
+        }
+        return make_unique<LogicalExpression>(PROPERTY,
+            catalog.getRelPropertyTypeFromString(relLabel, propertyName),
+            relName + "." + propertyName);
+    }
+    throw invalid_argument(
+        "Property: " + parsedExpression.getText() + " is not associated with any node or rel.");
+}
+
+unique_ptr<LogicalExpression> ExpressionBinder::bindLiteralExpression(
+    const ParsedExpression& parsedExpression) {
+    auto literalVal = parsedExpression.getText();
+    auto literalType = parsedExpression.getType();
+    switch (literalType) {
+    case LITERAL_INT:
+        return make_unique<LogicalExpression>(LITERAL_INT, INT32, Literal(stoi(literalVal)));
+    case LITERAL_DOUBLE:
+        return make_unique<LogicalExpression>(LITERAL_DOUBLE, DOUBLE, Literal(stod(literalVal)));
+    case LITERAL_BOOLEAN:
+        return make_unique<LogicalExpression>(
+            LITERAL_BOOLEAN, BOOL, Literal((uint8_t)("true" == literalVal)));
+    case LITERAL_STRING:
+        return make_unique<LogicalExpression>(
+            LITERAL_STRING, STRING, Literal(literalVal.substr(1, literalVal.size() - 2)));
+    default:
+        throw invalid_argument("Cannot bind expression type of " +
+                               expressionTypeToString(literalType) + " as literal expression");
+    }
+}
+
+// Bind variable to either node or rel in the query graph
+// Should change once we have WITH statement
+unique_ptr<LogicalExpression> ExpressionBinder::bindVariableExpression(
+    const ParsedExpression& parsedExpression) {
+    auto varName = parsedExpression.getText();
+    if (graphInScope.containsQueryNode(varName)) {
+        return make_unique<LogicalExpression>(VARIABLE, NODE, varName);
+    }
+    if (graphInScope.containsQueryRel(varName)) {
+        return make_unique<LogicalExpression>(VARIABLE, REL, varName);
+    }
+    throw invalid_argument("Variable: " + varName + " is not in scope.");
+}
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/binder.h
+++ b/src/planner/include/binder.h
@@ -2,6 +2,7 @@
 
 #include "src/parser/include/single_query.h"
 #include "src/planner/include/bound_statements/bound_match_statement.h"
+#include "src/planner/include/expression_binder.h"
 #include "src/storage/include/catalog.h"
 
 using namespace graphflow::storage;
@@ -15,11 +16,12 @@ class Binder {
 public:
     explicit Binder(const Catalog& catalog) : catalog{catalog} {}
 
-    unique_ptr<QueryGraph> bindSingleQuery(const SingleQuery& singleQuery);
+    vector<unique_ptr<BoundMatchStatement>> bindSingleQuery(const SingleQuery& singleQuery);
 
 private:
     unique_ptr<BoundMatchStatement> bindStatement(const MatchStatement& matchStatement);
 
+    // Bind query graph
     void bindQueryRels(const PatternElement& patternElement, QueryGraph& queryGraph);
 
     QueryRel* bindQueryRel(const PatternElementChain& patternElementChain, QueryNode* leftNode,

--- a/src/planner/include/bound_statements/bound_match_statement.h
+++ b/src/planner/include/bound_statements/bound_match_statement.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include "src/expression/include/logical/logical_expression.h"
 #include "src/planner/include/query_graph/query_graph.h"
+
+using namespace graphflow::expression;
 
 namespace graphflow {
 namespace planner {
@@ -11,6 +14,10 @@ public:
     explicit BoundMatchStatement(unique_ptr<QueryGraph> queryGraph)
         : queryGraph{move(queryGraph)} {}
 
+    BoundMatchStatement(
+        unique_ptr<QueryGraph> queryGraph, unique_ptr<LogicalExpression> whereExpression)
+        : queryGraph{move(queryGraph)}, whereExpression{move(whereExpression)} {}
+
     QueryGraph& getQueryGraph() { return *queryGraph; }
 
     bool operator==(const BoundMatchStatement& other) const {
@@ -19,6 +26,7 @@ public:
 
 private:
     unique_ptr<QueryGraph> queryGraph;
+    unique_ptr<LogicalExpression> whereExpression;
 };
 
 } // namespace planner

--- a/src/planner/include/expression_binder.h
+++ b/src/planner/include/expression_binder.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <unordered_set>
+
+#include "src/expression/include/logical/logical_expression.h"
+#include "src/parser/include/parsed_expression.h"
+#include "src/planner/include/query_graph/query_graph.h"
+#include "src/storage/include/catalog.h"
+
+using namespace graphflow::parser;
+using namespace graphflow::expression;
+using namespace graphflow::storage;
+
+namespace graphflow {
+namespace planner {
+
+class ExpressionBinder {
+
+public:
+    explicit ExpressionBinder(const QueryGraph& queryGraph, const Catalog& catalog)
+        : graphInScope{queryGraph}, catalog{catalog} {}
+
+    unique_ptr<LogicalExpression> bindExpression(const ParsedExpression& parsedExpression);
+
+private:
+    unique_ptr<LogicalExpression> bindBoolConnectionExpression(
+        const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> buildBinaryASTForBoolConnectionExpression(
+        const ParsedExpression& parsedExpression, ExpressionType expressionType);
+
+    unique_ptr<LogicalExpression> bindComparisonExpression(
+        const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> bindBinaryArithmeticExpression(
+        const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> bindUnaryArithmeticExpression(
+        const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> bindStringOperatorExpression(
+        const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> bindNullComparisonOperatorExpression(
+        const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> bindPropertyExpression(const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> bindLiteralExpression(const ParsedExpression& parsedExpression);
+
+    unique_ptr<LogicalExpression> bindVariableExpression(const ParsedExpression& parsedExpression);
+
+private:
+    const QueryGraph& graphInScope;
+    const Catalog& catalog;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -34,23 +34,10 @@ class Catalog {
 public:
     Catalog(const string& directory);
 
-    // This constructor is used for Binder unit tests
-    Catalog(stringToLabelMap_t stringToNodeLabelMap, stringToLabelMap_t stringToRelLabelMap,
-        vector<vector<label_t>> srcNodeLabelToRelLabel,
-        vector<vector<label_t>> dstNodeLabelToRelLabel,
-        vector<vector<label_t>> relLabelToSrcNodeLabels,
-        vector<vector<label_t>> relLabelToDstNodeLabels)
-        : stringToNodeLabelMap{move(stringToNodeLabelMap)}, stringToRelLabelMap{move(
-                                                                stringToRelLabelMap)},
-          relLabelToSrcNodeLabels{move(relLabelToSrcNodeLabels)}, relLabelToDstNodeLabels{move(
-                                                                      relLabelToDstNodeLabels)},
-          srcNodeLabelToRelLabel{move(srcNodeLabelToRelLabel)}, dstNodeLabelToRelLabel{
-                                                                    move(dstNodeLabelToRelLabel)} {}
-
     inline const uint32_t getNodeLabelsCount() const { return stringToNodeLabelMap.size(); }
     inline const uint32_t getRelLabelsCount() const { return stringToRelLabelMap.size(); }
 
-    inline const bool containNodeLabel(const char* label) const {
+    inline bool containNodeLabel(const char* label) const {
         return end(stringToNodeLabelMap) != stringToNodeLabelMap.find(label);
     }
 
@@ -58,7 +45,7 @@ public:
         return stringToNodeLabelMap.at(label);
     }
 
-    inline const bool containRelLabel(const char* label) const {
+    inline bool containRelLabel(const char* label) const {
         return end(stringToRelLabelMap) != stringToRelLabelMap.find(label);
     }
 
@@ -75,10 +62,33 @@ public:
         return relPropertyMaps[relLabel];
     }
 
+    inline bool containNodeProperty(label_t nodeLabel, const string& propertyName) const {
+        auto& nodeProperties = getPropertyMapForNodeLabel(nodeLabel);
+        return end(nodeProperties) != nodeProperties.find(propertyName);
+    }
+
+    inline const DataType& getNodePropertyTypeFromString(
+        label_t nodeLabel, const string& propertyName) const {
+        auto& nodeProperties = getPropertyMapForNodeLabel(nodeLabel);
+        return nodeProperties.at(propertyName).dataType;
+    }
+
     inline const uint32_t& getNodePropertyKeyFromString(
         const label_t& nodeLabel, const string& name) const {
         return getPropertyMapForNodeLabel(nodeLabel).at(name).idx;
     }
+
+    inline bool containRelProperty(label_t relLabel, const string& propertyName) const {
+        auto relProperties = getPropertyMapForRelLabel(relLabel);
+        return end(relProperties) != relProperties.find(propertyName);
+    }
+
+    inline const DataType& getRelPropertyTypeFromString(
+        label_t relLabel, const string& propertyName) const {
+        auto& relProperties = getPropertyMapForRelLabel(relLabel);
+        return relProperties.at(propertyName).dataType;
+    }
+
     inline const uint32_t& getRelPropertyKeyFromString(
         const label_t& relLabel, const string& name) const {
         return getPropertyMapForRelLabel(relLabel).at(name).idx;

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -14,7 +14,7 @@ TEST(ExpressionTests, BinaryPhysicalExpressionTest) {
         make_unique<LogicalExpression>(ExpressionType::LITERAL_INT, DataType::INT32, literal);
 
     auto addLogicalOperator = make_unique<LogicalExpression>(
-            ExpressionType::ADD, move(propertyExpression), move(literalExpression));
+            ExpressionType::ADD, DataType::INT32, move(propertyExpression), move(literalExpression));
 
     auto physicalOperatorInfo = PhysicalOperatorsInfo();
     auto dataChunks = DataChunks();
@@ -45,7 +45,7 @@ TEST(ExpressionTests, UnaryPhysicalExpressionTest) {
     auto propertyExpression =
         make_unique<LogicalExpression>(ExpressionType::VARIABLE, DataType::INT32, "a.prop");
     auto negateLogicalOperator =
-        make_unique<LogicalExpression>(ExpressionType::NEGATE, move(propertyExpression));
+        make_unique<LogicalExpression>(ExpressionType::NEGATE, DataType::INT32, move(propertyExpression));
 
     auto physicalOperatorInfo = PhysicalOperatorsInfo();
     auto dataChunks = DataChunks();


### PR DESCRIPTION
This PR add expression binder and validates the following:
- Node/Rel variable is in scope
- Property variable exist in catalog. 
- StringOperator LHS and RHS is string type
- ArithmeticExpression LHS and RHS is arithmetic type (INT32, INT64, DOUBLE)
- ComparisonExpression LHS and RHS is of the same type
  -  different arithmetic types are considered as same 
- BoolConnectionExpression
  - take a flat parsedBoolConnectionExpression and build AST
  - validate LHS and RHS is bool type
