### PR TITLE
Add PropertyReader and Filter to enumerator

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -6,6 +6,7 @@ namespace graphflow {
 namespace common {
 
 constexpr bool ENABLE_DEBUG = false;
+constexpr bool ENABLE_HASH_JOIN_ENUMERATION = true;
 
 // Size (in bytes) of the chunks to be read in GraphLoader.
 const uint64_t CSV_READING_BLOCK_SIZE = 1 << 23;

--- a/src/common/literal.cpp
+++ b/src/common/literal.cpp
@@ -22,5 +22,6 @@ string Literal::toString() const {
         throw std::invalid_argument("Unsupported data type " + DataTypeNames[type]);
     }
 }
+
 } // namespace common
 } // namespace graphflow

--- a/src/expression/include/logical/logical_expression.h
+++ b/src/expression/include/logical/logical_expression.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <unordered_set>
+
 #include "src/common/include/expression_type.h"
 #include "src/common/include/literal.h"
 #include "src/common/include/types.h"
@@ -15,12 +17,12 @@ class LogicalExpression {
 public:
     // creates a non-leaf logical binary expression.
     LogicalExpression(ExpressionType expressionType, DataType dataType,
-        unique_ptr<LogicalExpression> left, unique_ptr<LogicalExpression> right,
+        shared_ptr<LogicalExpression> left, shared_ptr<LogicalExpression> right,
         string rawExpression = string());
 
     // creates a non-leaf logical unary expression.
     LogicalExpression(ExpressionType expressionType, DataType dataType,
-        unique_ptr<LogicalExpression> child, string rawExpression = string());
+        shared_ptr<LogicalExpression> child, string rawExpression = string());
 
     // creates a leaf variable expression.
     LogicalExpression(ExpressionType expressionType, DataType dataType, const string& variableName,
@@ -42,16 +44,20 @@ public:
 
     inline const string& getRawExpression() const { return rawExpression; }
 
+    unordered_set<string> getIncludedVariables() const;
+
+    unordered_set<string> getIncludedProperties() const;
+
 protected:
     LogicalExpression(ExpressionType expressionType, DataType dataType)
         : expressionType{expressionType}, dataType{dataType} {}
 
-private:
+public:
     // variable name for leaf variable expressions.
     string variableName;
     // value used by leaf literal expressions.
     Literal literalValue;
-    vector<unique_ptr<LogicalExpression>> childrenExpr;
+    vector<shared_ptr<LogicalExpression>> childrenExpr;
     ExpressionType expressionType;
     DataType dataType;
     string rawExpression;

--- a/src/expression/logical/logical_expression.cpp
+++ b/src/expression/logical/logical_expression.cpp
@@ -4,17 +4,17 @@ namespace graphflow {
 namespace expression {
 
 LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dataType,
-    unique_ptr<LogicalExpression> left, unique_ptr<LogicalExpression> right, string rawExpression)
+    shared_ptr<LogicalExpression> left, shared_ptr<LogicalExpression> right, string rawExpression)
     : LogicalExpression(expressionType, dataType) {
-    childrenExpr.push_back(move(left));
-    childrenExpr.push_back(move(right));
+    childrenExpr.push_back(left);
+    childrenExpr.push_back(right);
     this->rawExpression = move(rawExpression);
 }
 
 LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dataType,
-    unique_ptr<LogicalExpression> child, string rawExpression)
+    shared_ptr<LogicalExpression> child, string rawExpression)
     : LogicalExpression(expressionType, dataType) {
-    childrenExpr.push_back(move(child));
+    childrenExpr.push_back(child);
     this->rawExpression = move(rawExpression);
 }
 
@@ -30,6 +30,42 @@ LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dat
     : LogicalExpression(expressionType, dataType) {
     this->literalValue = literalValue;
     this->rawExpression = move(rawExpression);
+}
+
+unordered_set<string> LogicalExpression::getIncludedVariables() const {
+    auto result = unordered_set<string>();
+    if (isExpressionLeafLiteral(expressionType)) {
+        return result;
+    }
+    if (VARIABLE == expressionType) {
+        result.insert(variableName);
+        return result;
+    }
+    if (PROPERTY == expressionType) {
+        result.insert(variableName.substr(0, variableName.find('.')));
+        return result;
+    }
+    for (auto& childExpr : childrenExpr) {
+        auto tmp = childExpr->getIncludedVariables();
+        result.insert(begin(tmp), end(tmp));
+    }
+    return result;
+}
+
+unordered_set<string> LogicalExpression::getIncludedProperties() const {
+    auto result = unordered_set<string>();
+    if (isExpressionLeafLiteral(expressionType) || VARIABLE == expressionType) {
+        return result;
+    }
+    if (PROPERTY == expressionType) {
+        result.insert(variableName);
+        return result;
+    }
+    for (auto& childExpr : childrenExpr) {
+        auto tmp = childExpr->getIncludedProperties();
+        result.insert(begin(tmp), end(tmp));
+    }
+    return result;
 }
 
 } // namespace expression

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -41,6 +41,7 @@ cc_library(
     name = "bound_statement",
     hdrs = [
         "include/bound_statements/bound_match_statement.h",
+        "include/bound_statements/bound_single_query.h",
     ],
 )
 
@@ -70,9 +71,11 @@ cc_library(
         "include/logical_plan/operator/property_reader/logical_node_property_reader.h",
         "include/logical_plan/operator/property_reader/logical_rel_property_reader.h",
         "include/logical_plan/operator/scan/logical_scan.h",
+        "include/logical_plan/schema.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "query_graph",
         "//src/common",
         "//src/expression",
     ],

--- a/src/planner/include/binder.h
+++ b/src/planner/include/binder.h
@@ -2,6 +2,7 @@
 
 #include "src/parser/include/single_query.h"
 #include "src/planner/include/bound_statements/bound_match_statement.h"
+#include "src/planner/include/bound_statements/bound_single_query.h"
 #include "src/planner/include/expression_binder.h"
 #include "src/storage/include/catalog.h"
 
@@ -16,7 +17,7 @@ class Binder {
 public:
     explicit Binder(const Catalog& catalog) : catalog{catalog} {}
 
-    vector<unique_ptr<BoundMatchStatement>> bindSingleQuery(const SingleQuery& singleQuery);
+    unique_ptr<BoundSingleQuery> bindSingleQuery(const SingleQuery& singleQuery);
 
 private:
     unique_ptr<BoundMatchStatement> bindStatement(const MatchStatement& matchStatement);

--- a/src/planner/include/bound_statements/bound_match_statement.h
+++ b/src/planner/include/bound_statements/bound_match_statement.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "src/expression/include/logical/logical_expression.h"
 #include "src/planner/include/query_graph/query_graph.h"
 
@@ -15,10 +17,8 @@ public:
         : queryGraph{move(queryGraph)} {}
 
     BoundMatchStatement(
-        unique_ptr<QueryGraph> queryGraph, unique_ptr<LogicalExpression> whereExpression)
+        unique_ptr<QueryGraph> queryGraph, shared_ptr<LogicalExpression> whereExpression)
         : queryGraph{move(queryGraph)}, whereExpression{move(whereExpression)} {}
-
-    QueryGraph& getQueryGraph() { return *queryGraph; }
 
     bool operator==(const BoundMatchStatement& other) const {
         return *queryGraph == *other.queryGraph;
@@ -26,7 +26,7 @@ public:
 
 public:
     unique_ptr<QueryGraph> queryGraph;
-    unique_ptr<LogicalExpression> whereExpression;
+    shared_ptr<LogicalExpression> whereExpression;
 };
 
 } // namespace planner

--- a/src/planner/include/bound_statements/bound_single_query.h
+++ b/src/planner/include/bound_statements/bound_single_query.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <utility>
+
+#include "src/expression/include/logical/logical_expression.h"
+#include "src/planner/include/query_graph/query_graph.h"
+
+using namespace graphflow::expression;
+
+namespace graphflow {
+namespace planner {
+
+class BoundSingleQuery {
+
+public:
+    BoundSingleQuery(unique_ptr<QueryGraph> queryGraph,
+        vector<shared_ptr<LogicalExpression>> whereExprsSplitByAND)
+        : queryGraph{move(queryGraph)}, whereExprsSplitByAND{move(whereExprsSplitByAND)} {}
+
+public:
+    unique_ptr<QueryGraph> queryGraph;
+    vector<shared_ptr<LogicalExpression>> whereExprsSplitByAND;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -1,9 +1,13 @@
 #pragma once
 
+#include "src/common/include/configs.h"
 #include "src/planner/include/binder.h"
 #include "src/planner/include/logical_plan/logical_plan.h"
 #include "src/planner/include/logical_plan/operator/extend/logical_extend.h"
+#include "src/planner/include/logical_plan/operator/filter/logical_filter.h"
 #include "src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h"
+#include "src/planner/include/logical_plan/operator/property_reader/logical_node_property_reader.h"
+#include "src/planner/include/logical_plan/operator/property_reader/logical_rel_property_reader.h"
 #include "src/planner/include/logical_plan/operator/scan/logical_scan.h"
 #include "src/planner/include/subgraph_plan_table.h"
 
@@ -13,14 +17,12 @@ namespace planner {
 class Enumerator {
 
 public:
-    explicit Enumerator(const QueryGraph& queryGraph) : queryGraph{queryGraph} {
-        subgraphPlanTable = make_unique<SubgraphPlanTable>(queryGraph.queryRels.size());
-    };
+    explicit Enumerator(const BoundSingleQuery& boundSingleQuery);
 
     vector<unique_ptr<LogicalPlan>> enumeratePlans();
 
 private:
-    void enumerateSingleQueryRel(uint32_t& numEnumeratedQueryRels);
+    void enumerateSingleQueryNode();
 
     void enumerateNextNumQueryRel(uint32_t& numEnumeratedQueryRels);
 
@@ -28,9 +30,27 @@ private:
 
     void enumerateExtend(uint32_t nextNumEnumeratedQueryRels);
 
+    void appendFiltersIfPossible(const SubqueryGraph& leftPrevSubgraph,
+        const SubqueryGraph& rightPrevSubgraph, const SubqueryGraph& subgraph, LogicalPlan& plan);
+
+    void appendFiltersIfPossible(
+        const SubqueryGraph& prevSubgraph, const SubqueryGraph& subgraph, LogicalPlan& plan);
+
+    void appendFilterAndNecessaryScans(shared_ptr<LogicalExpression> expr, LogicalPlan& plan);
+
+    void appendPropertyReader(const string& varAndPropertyName, LogicalPlan& plan);
+
+    void appendNodePropertyReader(
+        const string& nodeName, const string& propertyName, LogicalPlan& plan);
+
+    void appendRelPropertyReader(
+        const string& relName, const string& propertyName, LogicalPlan& plan);
+
 private:
     unique_ptr<SubgraphPlanTable> subgraphPlanTable; // cached subgraph plans
     const QueryGraph& queryGraph;
+    vector<pair<shared_ptr<LogicalExpression>, unordered_set<string>>>
+        expressionsAndIncludedVariables;
 };
 
 } // namespace planner

--- a/src/planner/include/expression_binder.h
+++ b/src/planner/include/expression_binder.h
@@ -20,35 +20,35 @@ public:
     explicit ExpressionBinder(const QueryGraph& queryGraph, const Catalog& catalog)
         : graphInScope{queryGraph}, catalog{catalog} {}
 
-    unique_ptr<LogicalExpression> bindExpression(const ParsedExpression& parsedExpression);
+    shared_ptr<LogicalExpression> bindExpression(const ParsedExpression& parsedExpression);
 
 private:
-    unique_ptr<LogicalExpression> bindBinaryBoolConnectionExpression(
+    shared_ptr<LogicalExpression> bindBinaryBoolConnectionExpression(
         const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindUnaryBoolConnectionExpression(
+    shared_ptr<LogicalExpression> bindUnaryBoolConnectionExpression(
         const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindComparisonExpression(
+    shared_ptr<LogicalExpression> bindComparisonExpression(
         const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindBinaryArithmeticExpression(
+    shared_ptr<LogicalExpression> bindBinaryArithmeticExpression(
         const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindUnaryArithmeticExpression(
+    shared_ptr<LogicalExpression> bindUnaryArithmeticExpression(
         const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindStringOperatorExpression(
+    shared_ptr<LogicalExpression> bindStringOperatorExpression(
         const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindNullComparisonOperatorExpression(
+    shared_ptr<LogicalExpression> bindNullComparisonOperatorExpression(
         const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindPropertyExpression(const ParsedExpression& parsedExpression);
+    shared_ptr<LogicalExpression> bindPropertyExpression(const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindLiteralExpression(const ParsedExpression& parsedExpression);
+    shared_ptr<LogicalExpression> bindLiteralExpression(const ParsedExpression& parsedExpression);
 
-    unique_ptr<LogicalExpression> bindVariableExpression(const ParsedExpression& parsedExpression);
+    shared_ptr<LogicalExpression> bindVariableExpression(const ParsedExpression& parsedExpression);
 
 private:
     const QueryGraph& graphInScope;

--- a/src/planner/include/logical_plan/logical_plan.h
+++ b/src/planner/include/logical_plan/logical_plan.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
+#include "src/planner/include/logical_plan/schema.h"
 
 namespace graphflow {
 namespace planner {
@@ -10,12 +11,16 @@ class LogicalPlan {
 public:
     LogicalPlan(shared_ptr<LogicalOperator> lastOperator) : lastOperator{lastOperator} {}
 
+    LogicalPlan(shared_ptr<LogicalOperator> lastOperator, unique_ptr<Schema> schema)
+        : lastOperator{lastOperator}, schema{move(schema)} {}
+
     LogicalPlan(const string& path);
 
     const LogicalOperator& getLastOperator() { return *lastOperator; }
 
-private:
+public:
     shared_ptr<LogicalOperator> lastOperator;
+    unique_ptr<Schema> schema;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/extend/logical_extend.h
+++ b/src/planner/include/logical_plan/operator/extend/logical_extend.h
@@ -4,6 +4,7 @@
 
 #include "src/common/include/types.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
+#include "src/planner/include/query_graph/query_rel.h"
 
 using namespace graphflow::common;
 using namespace std;
@@ -14,12 +15,22 @@ namespace planner {
 class LogicalExtend : public LogicalOperator {
 
 public:
-    LogicalExtend(const string& boundNodeVarName, label_t boundNodeVarLabel,
-        const string& nbrNodeVarName, label_t nbrNodeVarLabel, label_t relLabel,
-        const Direction& direction, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, boundNodeVarName{boundNodeVarName},
-          boundNodeVarLabel{boundNodeVarLabel}, nbrNodeVarName{nbrNodeVarName},
-          nbrNodeVarLabel{nbrNodeVarLabel}, relLabel{relLabel}, direction{direction} {}
+    LogicalExtend(const QueryRel& queryRel, const Direction& direction,
+        shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{prevOperator}, direction{direction} {
+        if (FWD == direction) {
+            boundNodeVarName = queryRel.getSrcNodeName();
+            boundNodeVarLabel = queryRel.srcNode->label;
+            nbrNodeVarName = queryRel.getDstNodeName();
+            nbrNodeVarLabel = queryRel.dstNode->label;
+        } else {
+            boundNodeVarName = queryRel.getDstNodeName();
+            boundNodeVarLabel = queryRel.dstNode->label;
+            nbrNodeVarName = queryRel.getSrcNodeName();
+            nbrNodeVarLabel = queryRel.srcNode->label;
+        }
+        relLabel = queryRel.label;
+    }
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_EXTEND;
@@ -30,12 +41,12 @@ public:
     }
 
 public:
-    const string boundNodeVarName;
-    const label_t boundNodeVarLabel;
-    const string nbrNodeVarName;
-    const label_t nbrNodeVarLabel;
-    const label_t relLabel;
-    const Direction direction;
+    string boundNodeVarName;
+    label_t boundNodeVarLabel;
+    string nbrNodeVarName;
+    label_t nbrNodeVarLabel;
+    label_t relLabel;
+    Direction direction;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/filter/logical_filter.h
+++ b/src/planner/include/logical_plan/operator/filter/logical_filter.h
@@ -14,8 +14,8 @@ namespace planner {
 class LogicalFilter : public LogicalOperator {
 
 public:
-    LogicalFilter(unique_ptr<LogicalExpression> rootExpr, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, rootExpr{move(rootExpr)} {}
+    LogicalFilter(shared_ptr<LogicalExpression> rootExpr, shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{prevOperator}, rootExpr{rootExpr} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_FILTER;
@@ -26,7 +26,7 @@ public:
     string getOperatorInformation() const override { return ""; }
 
 public:
-    unique_ptr<LogicalExpression> rootExpr;
+    shared_ptr<LogicalExpression> rootExpr;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/property_reader/logical_node_property_reader.h
+++ b/src/planner/include/logical_plan/operator/property_reader/logical_node_property_reader.h
@@ -12,7 +12,7 @@ namespace planner {
 class LogicalNodePropertyReader : public LogicalOperator {
 
 public:
-    LogicalNodePropertyReader(const string& nodeVarName, const string& nodeLabel,
+    LogicalNodePropertyReader(const string& nodeVarName, label_t nodeLabel,
         const string& propertyName, shared_ptr<LogicalOperator> prevOperator)
         : LogicalOperator{prevOperator}, nodeVarName{nodeVarName}, nodeLabel{nodeLabel},
           propertyName{propertyName} {}
@@ -25,7 +25,7 @@ public:
 
 public:
     const string nodeVarName;
-    const string nodeLabel;
+    label_t nodeLabel;
     const string propertyName;
 };
 

--- a/src/planner/include/logical_plan/operator/property_reader/logical_rel_property_reader.h
+++ b/src/planner/include/logical_plan/operator/property_reader/logical_rel_property_reader.h
@@ -4,6 +4,7 @@
 
 #include "src/common/include/types.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
+#include "src/planner/include/query_graph/query_rel.h"
 
 using namespace graphflow::common;
 using namespace std;
@@ -14,14 +15,23 @@ namespace planner {
 class LogicalRelPropertyReader : public LogicalOperator {
 
 public:
-    LogicalRelPropertyReader(const string& relName, const string& boundNodeVarName,
-        const string& boundNodeVarLabel, const string& nbrNodeVarName,
-        const string& nbrNodeVarLabel, const string& relLabel, Direction direction,
+    LogicalRelPropertyReader(const QueryRel& queryRel, Direction direction,
         const string& propertyName, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, relName{relName}, boundNodeVarName{boundNodeVarName},
-          boundNodeVarLabel{boundNodeVarLabel}, nbrNodeVarName{nbrNodeVarName},
-          nbrNodeVarLabel{nbrNodeVarLabel}, relLabel{relLabel}, direction{direction},
-          propertyName{propertyName} {}
+        : LogicalOperator{prevOperator}, direction{direction}, propertyName{propertyName} {
+        if (FWD == direction) {
+            boundNodeVarName = queryRel.getSrcNodeName();
+            boundNodeVarLabel = queryRel.srcNode->label;
+            nbrNodeVarName = queryRel.getDstNodeName();
+            nbrNodeVarLabel = queryRel.dstNode->label;
+        } else {
+            boundNodeVarName = queryRel.getDstNodeName();
+            boundNodeVarLabel = queryRel.dstNode->label;
+            nbrNodeVarName = queryRel.getSrcNodeName();
+            nbrNodeVarLabel = queryRel.srcNode->label;
+        }
+        relName = queryRel.name;
+        relLabel = queryRel.label;
+    }
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_REL_PROPERTY_READER;
@@ -30,14 +40,14 @@ public:
     string getOperatorInformation() const override { return relName + "." + propertyName; }
 
 public:
-    const string relName;
-    const string boundNodeVarName;
-    const string boundNodeVarLabel;
-    const string nbrNodeVarName;
-    const string nbrNodeVarLabel;
-    const string relLabel;
-    const Direction direction;
-    const string propertyName;
+    string boundNodeVarName;
+    label_t boundNodeVarLabel;
+    string nbrNodeVarName;
+    label_t nbrNodeVarLabel;
+    string relName;
+    label_t relLabel;
+    Direction direction;
+    string propertyName;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "src/planner/include/logical_plan/operator/logical_operator.h"
+
+namespace graphflow {
+namespace planner {
+
+class Schema {
+
+public:
+    void addOperator(const string& varName, LogicalOperator* logicalOperator) {
+        varNameOperatorMap.insert({varName, logicalOperator});
+    }
+
+    bool containsOperator(const string& varName) {
+        return end(varNameOperatorMap) != varNameOperatorMap.find(varName);
+    }
+
+    LogicalOperator* getOperator(const string& varName) { return varNameOperatorMap.at(varName); }
+
+    unique_ptr<Schema> copy() {
+        auto newSchema = make_unique<Schema>();
+        newSchema->varNameOperatorMap = varNameOperatorMap;
+        return newSchema;
+    }
+
+public:
+    unordered_map<string, LogicalOperator*> varNameOperatorMap;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/query_graph/query_graph.h
+++ b/src/planner/include/query_graph/query_graph.h
@@ -25,9 +25,13 @@ public:
         : queryGraph{other.queryGraph}, queryNodesSelector{other.queryNodesSelector},
           queryRelsSelector{other.queryRelsSelector} {}
 
-    void addQueryRel(uint32_t relIdx);
+    void addQueryNode(uint32_t nodePos);
+
+    void addQueryRel(uint32_t relPos);
 
     void addSubqueryGraph(const SubqueryGraph& other);
+
+    bool containAllVars(unordered_set<string>& vars) const;
 
     bool operator==(const SubqueryGraph& other) const;
 
@@ -50,13 +54,15 @@ public:
 
     QueryNode* getQueryNode(const string& queryNodeName) const;
 
-    uint32_t getQueryNodeIdx(const string& queryNodeName) const;
+    uint32_t getQueryNodePos(const string& queryNodeName) const;
 
     void addQueryNode(unique_ptr<QueryNode> queryNode);
 
     bool containsQueryRel(const string& queryRelName) const;
 
     QueryRel* getQueryRel(const string& queryRelName) const;
+
+    uint32_t getQueryRelPos(const string& queryRelName) const;
 
     void addQueryRel(unique_ptr<QueryRel> queryRel);
 
@@ -82,8 +88,8 @@ private:
         const pair<SubqueryGraph, uint32_t>& subgraphWithSingleJoinNode) const;
 
 public:
-    unordered_map<string, uint32_t> queryNodeNameToIdxMap;
-    unordered_map<string, uint32_t> queryRelNameToIdxMap;
+    unordered_map<string, uint32_t> queryNodeNameToPosMap;
+    unordered_map<string, uint32_t> queryRelNameToPosMap;
     vector<unique_ptr<QueryNode>> queryNodes;
     vector<unique_ptr<QueryRel>> queryRels;
 };

--- a/src/planner/include/subgraph_plan_table.h
+++ b/src/planner/include/subgraph_plan_table.h
@@ -5,14 +5,18 @@
 #include <unordered_set>
 #include <vector>
 
-#include "src/planner/include/logical_plan/operator/logical_operator.h"
+#include "src/planner/include/logical_plan/logical_plan.h"
 #include "src/planner/include/query_graph/query_graph.h"
 
 namespace graphflow {
 namespace planner {
 
+// hash on node bitset if subgraph has no rel
 struct SubqueryGraphHasher {
     std::size_t operator()(const SubqueryGraph& key) const {
+        if (0 == key.queryRelsSelector.count()) {
+            return hash<bitset<MAX_NUM_VARIABLES>>{}(key.queryNodesSelector);
+        }
         return hash<bitset<MAX_NUM_VARIABLES>>{}(key.queryRelsSelector);
     }
 };
@@ -22,13 +26,13 @@ class SubgraphPlanTable {
 public:
     explicit SubgraphPlanTable(uint32_t maxSubqueryGraphSize);
 
-    const vector<shared_ptr<LogicalOperator>>& getSubgraphPlans(
+    const vector<unique_ptr<LogicalPlan>>& getSubgraphPlans(
         const SubqueryGraph& subqueryGraph) const;
 
-    void addSubgraphPlan(const SubqueryGraph& subQueryGraph, shared_ptr<LogicalOperator> plan);
+    void addSubgraphPlan(const SubqueryGraph& subQueryGraph, unique_ptr<LogicalPlan> plan);
 
 public:
-    vector<unordered_map<SubqueryGraph, vector<shared_ptr<LogicalOperator>>, SubqueryGraphHasher>>
+    vector<unordered_map<SubqueryGraph, vector<unique_ptr<LogicalPlan>>, SubqueryGraphHasher>>
         subgraphPlans;
 };
 

--- a/src/planner/subgraph_plan_table.cpp
+++ b/src/planner/subgraph_plan_table.cpp
@@ -7,18 +7,18 @@ SubgraphPlanTable::SubgraphPlanTable(uint32_t maxSubqueryGraphSize) {
     subgraphPlans.resize(maxSubqueryGraphSize + 1);
 }
 
-const vector<shared_ptr<LogicalOperator>>& SubgraphPlanTable::getSubgraphPlans(
+const vector<unique_ptr<LogicalPlan>>& SubgraphPlanTable::getSubgraphPlans(
     const SubqueryGraph& subqueryGraph) const {
     return subgraphPlans.at(subqueryGraph.queryRelsSelector.count()).at(subqueryGraph);
 }
 
 void SubgraphPlanTable::addSubgraphPlan(
-    const SubqueryGraph& subQueryGraph, shared_ptr<LogicalOperator> plan) {
+    const SubqueryGraph& subQueryGraph, unique_ptr<LogicalPlan> plan) {
     auto& plansWithSameSize = subgraphPlans.at(subQueryGraph.queryRelsSelector.count());
     if (end(plansWithSameSize) == plansWithSameSize.find(subQueryGraph)) {
-        plansWithSameSize.emplace(subQueryGraph, vector<shared_ptr<LogicalOperator>>());
+        plansWithSameSize.emplace(subQueryGraph, vector<unique_ptr<LogicalPlan>>());
     }
-    plansWithSameSize.at(subQueryGraph).push_back(plan);
+    plansWithSameSize.at(subQueryGraph).push_back(move(plan));
 }
 
 } // namespace planner

--- a/src/processor/physical_plan/plan_mapper.cpp
+++ b/src/processor/physical_plan/plan_mapper.cpp
@@ -141,7 +141,7 @@ unique_ptr<PhysicalOperator> mapLogicalNodePropertyReaderToPhysical(
     auto dataChunkPos = physicalOperatorInfo.getDataChunkPos(propertyReader.nodeVarName);
     auto valueVectorPos = physicalOperatorInfo.getValueVectorPos(propertyReader.nodeVarName);
     auto& catalog = graph.getCatalog();
-    auto label = catalog.getNodeLabelFromString(propertyReader.nodeLabel.c_str());
+    auto label = propertyReader.nodeLabel;
     auto property = catalog.getNodePropertyKeyFromString(label, propertyReader.propertyName);
     auto& nodesStore = graph.getNodesStore();
     physicalOperatorInfo.appendAsNewValueVector(
@@ -160,8 +160,8 @@ unique_ptr<PhysicalOperator> mapLogicalRelPropertyReaderToPhysical(
     auto inValueVectorPos = physicalOperatorInfo.getValueVectorPos(propertyReader.boundNodeVarName);
     auto outDataChunkPos = physicalOperatorInfo.getDataChunkPos(propertyReader.nbrNodeVarName);
     auto& catalog = graph.getCatalog();
-    auto nodeLabel = catalog.getNodeLabelFromString(propertyReader.boundNodeVarLabel.c_str());
-    auto label = catalog.getRelLabelFromString(propertyReader.relLabel.c_str());
+    auto nodeLabel = propertyReader.boundNodeVarLabel;
+    auto label = propertyReader.relLabel;
     auto property = catalog.getRelPropertyKeyFromString(label, propertyReader.propertyName);
     auto& relsStore = graph.getRelsStore();
     physicalOperatorInfo.appendAsNewValueVector(

--- a/src/runner/server/embedded_server.cpp
+++ b/src/runner/server/embedded_server.cpp
@@ -15,8 +15,8 @@ vector<unique_ptr<LogicalPlan>> EmbeddedServer::enumerateLogicalPlans(const stri
     graphflow::parser::Parser parser;
     auto singleQuery = parser.parseQuery(query);
     Binder binder(graph->getCatalog());
-    auto boundStatements = binder.bindSingleQuery(*singleQuery);
-    Enumerator enumerator(boundStatements[0]->getQueryGraph());
+    auto boundSingleQuery = binder.bindSingleQuery(*singleQuery);
+    Enumerator enumerator(*boundSingleQuery);
     return enumerator.enumeratePlans();
 }
 


### PR DESCRIPTION
This PR adds propertyReader and filter into enumerator.

**BoundSingleQuery**
This class represents the output of binder and input of enumerator. It contains
- Single QueryGraph that is created by merging multiple input QueryGraphs
- Vector of expressions represents multiple where clause

**Predicate Enumeration**
- Split input WHERE clause by AND
- Apply predicate once a subplan (subgraph) contains all its dependent nodes and rels
  - append missing property readers
  - append filter

**Example**
`MATCH (a)->(b) WHERE a.age > 1 AND b.age > 3 AND a.age < b.age`
Plan1: `S(a) -> PR(a.age) -> Filter(a.age > 1) -> E(b) -> PR(b.age) -> Filter(b.age > 3) -> Filter(a.age < b.age)`
Plan2: `S(b) -> PR(b.age) -> Filter(b.age > 3) -> E(a) -> PR(a.age) -> Filter(a.age > 1) -> Filter(a.age < b.age)`
