### PR TITLE
Indexing QueryNode & QueryRel in Enumerator

### DIFF
--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -190,7 +190,7 @@ unique_ptr<LogicalExpression> ExpressionBinder::bindPropertyExpression(
     auto childExpression = bindExpression(*parsedExpression.children.at(0));
     if (NODE == childExpression->getDataType()) {
         auto nodeName = childExpression->getVariableName();
-        auto nodeLabel = graphInScope.getQueryNode(nodeName)->getLabel();
+        auto nodeLabel = graphInScope.getQueryNode(nodeName)->label;
         if (!catalog.containNodeProperty(nodeLabel, propertyName)) {
             throw invalid_argument(
                 "Node: " + nodeName + " does not have property: " + propertyName);
@@ -201,7 +201,7 @@ unique_ptr<LogicalExpression> ExpressionBinder::bindPropertyExpression(
     }
     if (REL == childExpression->getDataType()) {
         auto relName = childExpression->getVariableName();
-        auto relLabel = graphInScope.getQueryRel(relName)->getLabel();
+        auto relLabel = graphInScope.getQueryRel(relName)->label;
         if (!catalog.containRelProperty(relLabel, propertyName)) {
             throw invalid_argument("Rel: " + relName + " does not have property: " + propertyName);
         }

--- a/src/planner/include/bound_statements/bound_match_statement.h
+++ b/src/planner/include/bound_statements/bound_match_statement.h
@@ -24,7 +24,7 @@ public:
         return *queryGraph == *other.queryGraph;
     }
 
-private:
+public:
     unique_ptr<QueryGraph> queryGraph;
     unique_ptr<LogicalExpression> whereExpression;
 };

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -14,7 +14,7 @@ class Enumerator {
 
 public:
     explicit Enumerator(const QueryGraph& queryGraph) : queryGraph{queryGraph} {
-        subgraphPlanTable = make_unique<SubgraphPlanTable>(queryGraph.numQueryRels());
+        subgraphPlanTable = make_unique<SubgraphPlanTable>(queryGraph.queryRels.size());
     };
 
     vector<unique_ptr<LogicalPlan>> enumeratePlans();

--- a/src/planner/include/query_graph/query_node.h
+++ b/src/planner/include/query_graph/query_node.h
@@ -18,17 +18,11 @@ class QueryNode {
 public:
     QueryNode(string name, label_t label) : name{move(name)}, label{label} {}
 
-    string getName() const { return name; }
-
-    label_t getLabel() const { return label; }
-
-    void setLabel(label_t label) { this->label = label; }
-
     bool operator==(const QueryNode& other) const {
         return name == other.name && label == other.label;
     }
 
-private:
+public:
     string name;
     label_t label;
 };

--- a/src/planner/include/query_graph/query_rel.h
+++ b/src/planner/include/query_graph/query_rel.h
@@ -10,17 +10,9 @@ class QueryRel {
 public:
     QueryRel(string name, label_t label) : name{move(name)}, label{label} {}
 
-    string getName() const { return name; }
+    inline string getSrcNodeName() const { return srcNode->name; }
 
-    label_t getLabel() const { return label; }
-
-    QueryNode* getSrcNode() const { return srcNode; }
-
-    QueryNode* getDstNode() const { return dstNode; }
-
-    void setSrcNode(QueryNode* queryNode) { srcNode = queryNode; }
-
-    void setDstNode(QueryNode* queryNode) { dstNode = queryNode; }
+    inline string getDstNodeName() const { return dstNode->name; }
 
     bool operator==(const QueryRel& other) const {
         auto result = name == other.name && label == other.label;
@@ -29,7 +21,7 @@ public:
         return result;
     }
 
-private:
+public:
     string name;
     label_t label;
     QueryNode* srcNode;

--- a/src/planner/include/subgraph_plan_table.h
+++ b/src/planner/include/subgraph_plan_table.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -10,32 +11,24 @@
 namespace graphflow {
 namespace planner {
 
-struct StringUnorderedSetHasher {
-    std::size_t operator()(const unordered_set<string>& key) const { return Hash::operation(key); }
+struct SubqueryGraphHasher {
+    std::size_t operator()(const SubqueryGraph& key) const {
+        return hash<bitset<MAX_NUM_VARIABLES>>{}(key.queryRelsSelector);
+    }
 };
 
 class SubgraphPlanTable {
 
 public:
-    explicit SubgraphPlanTable(uint32_t maxNumQueryRels);
-
-    const unordered_map<unordered_set<string>, vector<shared_ptr<LogicalOperator>>,
-        StringUnorderedSetHasher>&
-    getSubgraphPlans(uint32_t numQueryRels) const;
+    explicit SubgraphPlanTable(uint32_t maxSubqueryGraphSize);
 
     const vector<shared_ptr<LogicalOperator>>& getSubgraphPlans(
-        const unordered_set<string>& queryRels) const;
+        const SubqueryGraph& subqueryGraph) const;
 
-    void addSubgraphPlan(
-        const unordered_set<string>& matchedQueryRels, shared_ptr<LogicalOperator> plan);
+    void addSubgraphPlan(const SubqueryGraph& subQueryGraph, shared_ptr<LogicalOperator> plan);
 
-private:
-    void init(uint32_t maxNumQueryRels);
-
-private:
-    unordered_map<uint32_t /* num queryRels */,
-        unordered_map<unordered_set<string> /* queryRels */, vector<shared_ptr<LogicalOperator>>,
-            StringUnorderedSetHasher>>
+public:
+    vector<unordered_map<SubqueryGraph, vector<shared_ptr<LogicalOperator>>, SubqueryGraphHasher>>
         subgraphPlans;
 };
 

--- a/src/planner/subgraph_plan_table.cpp
+++ b/src/planner/subgraph_plan_table.cpp
@@ -3,36 +3,22 @@
 namespace graphflow {
 namespace planner {
 
-SubgraphPlanTable::SubgraphPlanTable(uint32_t maxNumQueryRels) {
-    init(maxNumQueryRels);
-}
-
-const unordered_map<unordered_set<string>, vector<shared_ptr<LogicalOperator>>,
-    StringUnorderedSetHasher>&
-SubgraphPlanTable::getSubgraphPlans(uint32_t numQueryRels) const {
-    return subgraphPlans.at(numQueryRels);
+SubgraphPlanTable::SubgraphPlanTable(uint32_t maxSubqueryGraphSize) {
+    subgraphPlans.resize(maxSubqueryGraphSize + 1);
 }
 
 const vector<shared_ptr<LogicalOperator>>& SubgraphPlanTable::getSubgraphPlans(
-    const unordered_set<string>& queryRels) const {
-    return subgraphPlans.at(queryRels.size()).at(queryRels);
+    const SubqueryGraph& subqueryGraph) const {
+    return subgraphPlans.at(subqueryGraph.queryRelsSelector.count()).at(subqueryGraph);
 }
 
 void SubgraphPlanTable::addSubgraphPlan(
-    const unordered_set<string>& matchedQueryRels, shared_ptr<LogicalOperator> plan) {
-    auto& subgraphPlansWithSameSize = subgraphPlans.at(matchedQueryRels.size());
-    if (end(subgraphPlansWithSameSize) == subgraphPlansWithSameSize.find(matchedQueryRels)) {
-        subgraphPlansWithSameSize.emplace(matchedQueryRels, vector<shared_ptr<LogicalOperator>>());
+    const SubqueryGraph& subQueryGraph, shared_ptr<LogicalOperator> plan) {
+    auto& plansWithSameSize = subgraphPlans.at(subQueryGraph.queryRelsSelector.count());
+    if (end(plansWithSameSize) == plansWithSameSize.find(subQueryGraph)) {
+        plansWithSameSize.emplace(subQueryGraph, vector<shared_ptr<LogicalOperator>>());
     }
-    subgraphPlansWithSameSize.at(matchedQueryRels).push_back(plan);
-}
-
-void SubgraphPlanTable::init(uint32_t maxPlanSize) {
-    for (auto i = 1u; i <= maxPlanSize; ++i) {
-        subgraphPlans.emplace(
-            i, unordered_map<unordered_set<string>, vector<shared_ptr<LogicalOperator>>,
-                   StringUnorderedSetHasher>());
-    }
+    plansWithSameSize.at(subQueryGraph).push_back(plan);
 }
 
 } // namespace planner


### PR DESCRIPTION
This PR refactor binder & enumerator
- Remove getter and setter for QueryNode, QueryRel & QueryGraph
- Indexing node and rel in QueryGraph
```
class QueryGraph:
    map<NodeName, NodePos>
    map<RelName, relPos>
    vector<Node>
    vector<Rel>
```
-  Subgraph is contains bitset selector of a QueryGraph
```
class Subgraph:
    QueryGraph&
    bitset nodeSelector
    bitset relSelector
```
SubgraphPlan is hashed on Subgraph relSelector (which is a bitset hash)
Subgraph merge is done by bitset OR operation