### PR TITLE
Add the first version of testing framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 bazel-*
 .clwb
 .bazelrc
+
+test_temp/

--- a/dataset/BUILD.bazel
+++ b/dataset/BUILD.bazel
@@ -1,0 +1,5 @@
+filegroup(
+    name = "dataset",
+    srcs = glob(["tinysnb/**"]),
+    visibility = ["//visibility:public"],
+)

--- a/dataset/tinysnb/eKnows.csv
+++ b/dataset/tinysnb/eKnows.csv
@@ -1,0 +1,15 @@
+fromLabel:LABEL,from:NODE,toLabel:LABEL,to:NODE,date:INT32
+person,0,person,2,1234567890
+person,0,person,3,1234567890
+person,0,person,5,1234567890
+person,2,person,0,1234567890
+person,2,person,3,1234567892
+person,2,person,5,1234567892
+person,3,person,0,1234567890
+person,3,person,2,1234567892
+person,3,person,5,1234567893
+person,5,person,0,1234567890
+person,5,person,2,1234567892
+person,5,person,3,1234567893
+person,7,person,8,1234567897
+person,7,person,9,1234567897

--- a/dataset/tinysnb/eStudyAt.csv
+++ b/dataset/tinysnb/eStudyAt.csv
@@ -1,0 +1,4 @@
+fromLabel:LABEL,from:NODE,toLabel:LABEL,to:NODE,year:INT32
+person,0,organisation,1,2021
+person,2,organisation,1,2020
+person,8,organisation,1,2020

--- a/dataset/tinysnb/eWorkAt.csv
+++ b/dataset/tinysnb/eWorkAt.csv
@@ -1,0 +1,4 @@
+fromLabel:LABEL,from:NODE,toLabel:LABEL,to:NODE,year:INT32
+person,3,organisation,4,2015
+person,5,organisation,6,2010
+person,7,organisation,6,2015

--- a/dataset/tinysnb/metadata.json
+++ b/dataset/tinysnb/metadata.json
@@ -1,0 +1,39 @@
+{
+  "tokenSeparator": ",",
+  "nodeFileDescriptions": [
+    {
+      "filename": "vPerson.csv",
+      "label": "person"
+    },
+    {
+      "filename": "vOrganisation.csv",
+      "label": "organisation"
+    }
+  ],
+  "relFileDescriptions": [
+    {
+      "filename": "eKnows.csv",
+      "label": "knows",
+      "cardinality": "MANY_MANY",
+      "srcNodeLabels" : ["person"],
+      "dstNodeLabels" : ["person"],
+      "storeCompressed": [false, true]
+    },
+    {
+      "filename": "eStudyAt.csv",
+      "label": "studyAt",
+      "cardinality": "MANY_ONE",
+      "srcNodeLabels" : ["person"],
+      "dstNodeLabels" : ["organisation"],
+      "storeCompressed": [false, true]
+    },
+    {
+      "filename": "eWorkAt.csv",
+      "label": "workAt",
+      "cardinality": "MANY_ONE",
+      "srcNodeLabels" : ["person"],
+      "dstNodeLabels" : ["organisation"],
+      "storeCompressed": [false, true]
+    }
+  ]
+}

--- a/dataset/tinysnb/vOrganisation.csv
+++ b/dataset/tinysnb/vOrganisation.csv
@@ -1,0 +1,4 @@
+id:NODE,name:STRING,orgCode:INT32,mark:DOUBLE
+1,ABFsUni,325,3.7
+4,CsWork,934,4.1
+6,DEsWork,824,4.1

--- a/dataset/tinysnb/vPerson.csv
+++ b/dataset/tinysnb/vPerson.csv
@@ -1,0 +1,8 @@
+id:NODE,fName:STRING,gender:INT32,isStudent:BOOLEAN,isWorker:BOOLEAN,age:INT32,eyeSight:DOUBLE
+0,Alice,1,true,false,35,5.0
+2,Bob,2,true,false,30,5.1
+3,Carol,1,false,true,45,5.0
+5,Dan,2,false,true,20,4.8
+7,Elizabeth,1,false,true,20,4.7
+8,Farooq,2,true,false,25,4.5
+9,Greg,2,false,false,40,4.9

--- a/src/planner/include/logical_plan/operator/extend/logical_extend.h
+++ b/src/planner/include/logical_plan/operator/extend/logical_extend.h
@@ -21,8 +21,12 @@ public:
           boundNodeVarLabel{boundNodeVarLabel}, nbrNodeVarName{nbrNodeVarName},
           nbrNodeVarLabel{nbrNodeVarLabel}, relLabel{relLabel}, direction{direction} {}
 
-    LogicalOperatorType getLogicalOperatorType() const {
+    LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_EXTEND;
+    }
+
+    string getOperatorInformation() const override {
+        return boundNodeVarName + "->" + nbrNodeVarName;
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/filter/logical_filter.h
+++ b/src/planner/include/logical_plan/operator/filter/logical_filter.h
@@ -17,11 +17,13 @@ public:
     LogicalFilter(unique_ptr<LogicalExpression> rootExpr, shared_ptr<LogicalOperator> prevOperator)
         : LogicalOperator{prevOperator}, rootExpr{move(rootExpr)} {}
 
-    LogicalOperatorType getLogicalOperatorType() const {
+    LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_FILTER;
     }
 
     const LogicalExpression& getRootLogicalExpression() const { return *rootExpr; }
+
+    string getOperatorInformation() const override { return ""; }
 
 public:
     unique_ptr<LogicalExpression> rootExpr;

--- a/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
+++ b/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
@@ -24,6 +24,18 @@ public:
         return LogicalOperatorType::LOGICAL_HASH_JOIN;
     }
 
+    string toString(uint64_t depth = 0) const {
+        string result = LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
+                        getOperatorInformation() + "]";
+        result += "\nBUILD SIDE: \n";
+        result += buildSidePrevOperator->toString(depth + 1);
+        result += "\nPROBE SIDE: \n";
+        result += prevOperator->toString(depth + 1);
+        return result;
+    }
+
+    string getOperatorInformation() const override { return joinNodeVarName; }
+
 public:
     const string joinNodeVarName;
     const shared_ptr<LogicalOperator> buildSidePrevOperator;

--- a/src/planner/include/logical_plan/operator/logical_operator.h
+++ b/src/planner/include/logical_plan/operator/logical_operator.h
@@ -9,7 +9,7 @@ using namespace std;
 namespace graphflow {
 namespace planner {
 
-enum LogicalOperatorType {
+enum LogicalOperatorType : uint8_t {
     LOGICAL_SCAN,
     LOGICAL_EXTEND,
     LOGICAL_FILTER,
@@ -17,6 +17,9 @@ enum LogicalOperatorType {
     LOGICAL_REL_PROPERTY_READER,
     LOGICAL_HASH_JOIN,
 };
+
+const string LogicalOperatorTypeNames[] = {"LOGICAL_SCAN", "LOGICAL_EXTEND", "LOGICAL_FILTER",
+    "LOGICAL_NODE_PROPERTY_READER", "LOGICAL_REL_PROPERTY_READER", "LOGICAL_HASH_JOIN"};
 
 class LogicalOperator {
 public:
@@ -33,6 +36,19 @@ public:
     void setPrevOperator(shared_ptr<LogicalOperator> prevOperator) {
         this->prevOperator = prevOperator;
     }
+
+    virtual string toString(uint64_t depth = 0) const {
+        string result = string(depth * 4, ' ');
+        result += LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
+                  getOperatorInformation() + "]";
+        if (prevOperator) {
+            result += "\n";
+            result += prevOperator->toString(depth);
+        }
+        return result;
+    }
+
+    virtual string getOperatorInformation() const = 0;
 
 public:
     shared_ptr<LogicalOperator> prevOperator;

--- a/src/planner/include/logical_plan/operator/property_reader/logical_node_property_reader.h
+++ b/src/planner/include/logical_plan/operator/property_reader/logical_node_property_reader.h
@@ -17,9 +17,11 @@ public:
         : LogicalOperator{prevOperator}, nodeVarName{nodeVarName}, nodeLabel{nodeLabel},
           propertyName{propertyName} {}
 
-    LogicalOperatorType getLogicalOperatorType() const {
+    LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_NODE_PROPERTY_READER;
     }
+
+    string getOperatorInformation() const override { return nodeVarName + "." + propertyName; }
 
 public:
     const string nodeVarName;

--- a/src/planner/include/logical_plan/operator/property_reader/logical_rel_property_reader.h
+++ b/src/planner/include/logical_plan/operator/property_reader/logical_rel_property_reader.h
@@ -23,9 +23,11 @@ public:
           nbrNodeVarLabel{nbrNodeVarLabel}, relLabel{relLabel}, direction{direction},
           propertyName{propertyName} {}
 
-    LogicalOperatorType getLogicalOperatorType() const {
+    LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_REL_PROPERTY_READER;
     }
+
+    string getOperatorInformation() const override { return relName + "." + propertyName; }
 
 public:
     const string relName;

--- a/src/planner/include/logical_plan/operator/scan/logical_scan.h
+++ b/src/planner/include/logical_plan/operator/scan/logical_scan.h
@@ -18,6 +18,8 @@ public:
 
     LogicalOperatorType getLogicalOperatorType() const { return LogicalOperatorType::LOGICAL_SCAN; }
 
+    string getOperatorInformation() const override { return nodeVarName; }
+
 public:
     const string nodeVarName;
     const label_t label;

--- a/src/planner/query_graph/query_graph.cpp
+++ b/src/planner/query_graph/query_graph.cpp
@@ -79,7 +79,7 @@ QueryGraph::getSingleNodeJoiningSubgraph(
             auto tmp = extendSubgraphByOneQueryRel(matchedSubqueryGraph, subgraphAndJoinNodePair);
             nextSubgraphAndJoinNodePairs.insert(begin(tmp), end(tmp));
         }
-        subgraphAndJoinNodePairs = nextSubgraphAndJoinNodePairs;
+        subgraphAndJoinNodePairs = move(nextSubgraphAndJoinNodePairs);
     }
     return subgraphAndJoinNodePairs;
 }

--- a/src/runner/BUILD.bazel
+++ b/src/runner/BUILD.bazel
@@ -51,3 +51,22 @@ cc_binary(
         "@nlohmann_json",
     ],
 )
+
+cc_library(
+    name = "embedded_server",
+    srcs = [
+        "server/embedded_server.cpp"
+    ],
+    hdrs = [
+        "include/server/embedded_server.h"
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/processor",
+        "//src/storage:graph",
+        "//src/loader",
+        "//src/parser",
+        "//src/planner:binder",
+        "//src/planner:enumerator",
+    ],
+)

--- a/src/runner/include/server/embedded_server.h
+++ b/src/runner/include/server/embedded_server.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstdint>
+
+#include "src/loader/include/graph_loader.h"
+#include "src/planner/include/logical_plan/logical_plan.h"
+#include "src/processor/include/physical_plan/query_result.h"
+#include "src/processor/include/processor.h"
+#include "src/storage/include/graph.h"
+
+using namespace graphflow::processor;
+using namespace graphflow::storage;
+using namespace graphflow::loader;
+using namespace graphflow::planner;
+
+namespace graphflow {
+namespace runner {
+
+class EmbeddedServer {
+
+public:
+    EmbeddedServer(const string& inputGraphPath, const string& outputGraphPath,
+        uint64_t parallelism, uint64_t bufferPoolSize = DEFAULT_BUFFER_POOL_SIZE)
+        : parallelism(parallelism) {
+        GraphLoader graphLoader(inputGraphPath, outputGraphPath, parallelism);
+        graphLoader.loadGraph();
+        graph = make_unique<Graph>(outputGraphPath, bufferPoolSize);
+        processor = make_unique<QueryProcessor>(parallelism);
+    }
+
+    vector<unique_ptr<LogicalPlan>> enumerateLogicalPlans(const string& query);
+    unique_ptr<QueryResult> execute(unique_ptr<LogicalPlan> plan);
+
+private:
+    uint64_t parallelism;
+    unique_ptr<Graph> graph;
+    unique_ptr<QueryProcessor> processor;
+};
+
+} // namespace runner
+} // namespace graphflow

--- a/src/runner/server/embedded_server.cpp
+++ b/src/runner/server/embedded_server.cpp
@@ -1,0 +1,29 @@
+#include "src/runner/include/server/embedded_server.h"
+
+#include "src/parser/include/parser.h"
+#include "src/planner/include/binder.h"
+#include "src/planner/include/enumerator.h"
+#include "src/processor/include/physical_plan/plan_mapper.h"
+
+using namespace graphflow::processor;
+using namespace graphflow::planner;
+
+namespace graphflow {
+namespace runner {
+
+vector<unique_ptr<LogicalPlan>> EmbeddedServer::enumerateLogicalPlans(const string& query) {
+    graphflow::parser::Parser parser;
+    auto singleQuery = parser.parseQuery(query);
+    Binder binder(graph->getCatalog());
+    auto boundStatements = binder.bindSingleQuery(*singleQuery);
+    Enumerator enumerator(boundStatements[0]->getQueryGraph());
+    return enumerator.enumeratePlans();
+}
+
+unique_ptr<QueryResult> EmbeddedServer::execute(unique_ptr<LogicalPlan> plan) {
+    auto physicalPlan = PlanMapper::mapToPhysical(move(plan), *graph);
+    auto result = processor->execute(move(physicalPlan), parallelism);
+    return result;
+}
+} // namespace runner
+} // namespace graphflow

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -35,8 +35,8 @@ BufferManager::BufferManager(uint64_t maxSize)
     : logger{spdlog::stdout_logger_mt("buffer_manager")},
       bufferCache{maxSize / PAGE_SIZE}, clockHand{0}, numFrames{(uint32_t)(maxSize / PAGE_SIZE)} {
     logger->info("Initializing Buffer Manager.");
-    logger->info("BufferPool Size {}B, #4KB-pages {}.", maxSize, maxSize / PAGE_SIZE);
-    logger->info("Done.");
+    logger->debug("BufferPool Size {}B, #4KB-pages {}.", maxSize, maxSize / PAGE_SIZE);
+    logger->info("Done Initializing Buffer Manager.");
 }
 
 const uint8_t* BufferManager::get(FileHandle& fileHandle, uint32_t pageIdx) {

--- a/src/storage/include/buffer_manager.h
+++ b/src/storage/include/buffer_manager.h
@@ -50,6 +50,7 @@ class BufferManager {
 
 public:
     BufferManager(uint64_t maxSize);
+    ~BufferManager() { spdlog::drop("buffer_manager"); }
 
     // The function assumes that the requested page is already pinned.
     const uint8_t* get(FileHandle& fileHandle, uint32_t pageIdx);

--- a/src/storage/stores/nodes_store.cpp
+++ b/src/storage/stores/nodes_store.cpp
@@ -8,7 +8,7 @@ namespace storage {
 NodesStore::NodesStore(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
     const string& directory, BufferManager& bufferManager)
     : logger{spdlog::get("storage")} {
-    logger->info("Initializing NodesStore.");
+    logger->debug("Initializing NodesStore.");
     propertyColumns.resize(catalog.getNodeLabelsCount());
     for (auto nodeLabel = 0u; nodeLabel < catalog.getNodeLabelsCount(); nodeLabel++) {
         auto& propertyMap = catalog.getPropertyMapForNodeLabel(nodeLabel);
@@ -40,7 +40,7 @@ NodesStore::NodesStore(const Catalog& catalog, const vector<uint64_t>& numNodesP
             }
         }
     }
-    logger->info("Done.");
+    logger->debug("Done.");
 }
 
 } // namespace storage

--- a/src/storage/stores/rels_store.cpp
+++ b/src/storage/stores/rels_store.cpp
@@ -15,7 +15,7 @@ RelsStore::RelsStore(const Catalog& catalog, const vector<uint64_t>& numNodesPer
 
 void RelsStore::initAdjColumns(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
     const string& directory, BufferManager& bufferManager) {
-    logger->info("Initializing AdjColumns.");
+    logger->debug("Initializing AdjColumns.");
     for (auto dir : DIRS) {
         adjColumns[dir].resize(catalog.getNodeLabelsCount());
         for (auto nodeLabel = 0u; nodeLabel < catalog.getNodeLabelsCount(); nodeLabel++) {
@@ -35,12 +35,12 @@ void RelsStore::initAdjColumns(const Catalog& catalog, const vector<uint64_t>& n
             }
         }
     }
-    logger->info("Done.");
+    logger->debug("Done.");
 }
 
 void RelsStore::initAdjLists(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
     const string& directory, BufferManager& bufferManager) {
-    logger->info("Initializing AdjLists.");
+    logger->debug("Initializing AdjLists.");
     for (auto dir : DIRS) {
         adjLists[dir].resize(catalog.getNodeLabelsCount());
         for (auto nodeLabel = 0u; nodeLabel < catalog.getNodeLabelsCount(); nodeLabel++) {
@@ -60,13 +60,13 @@ void RelsStore::initAdjLists(const Catalog& catalog, const vector<uint64_t>& num
             }
         }
     }
-    logger->info("Done.");
+    logger->debug("Done.");
 }
 
 void RelsStore::initPropertyListsAndColumns(const Catalog& catalog,
     const vector<uint64_t>& numNodesPerLabel, const string& directory,
     BufferManager& bufferManager) {
-    logger->info("Initializing PropertyLists and PropertyColumns.");
+    logger->debug("Initializing PropertyLists and PropertyColumns.");
     propertyColumns.resize(catalog.getNodeLabelsCount());
     propertyLists[FWD].resize(catalog.getNodeLabelsCount());
     propertyLists[BWD].resize(catalog.getNodeLabelsCount());
@@ -89,7 +89,7 @@ void RelsStore::initPropertyListsAndColumns(const Catalog& catalog,
             }
         }
     }
-    logger->info("Done.");
+    logger->debug("Done.");
 }
 
 void RelsStore::initPropertyColumnsForRelLabel(const Catalog& catalog,

--- a/src/testing/BUILD.bazel
+++ b/src/testing/BUILD.bazel
@@ -1,0 +1,13 @@
+cc_library(
+    name = "test_helper",
+    srcs = [
+        "test_helper.cpp"
+    ],
+    hdrs = [
+        "include/test_helper.h"
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/runner:embedded_server",
+    ],
+)

--- a/src/testing/include/test_helper.h
+++ b/src/testing/include/test_helper.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+#include "src/runner/include/server/embedded_server.h"
+using namespace std;
+
+namespace graphflow {
+namespace testing {
+
+struct TestSuiteConfig {
+    string graphInputDir;
+    uint64_t numThreads = 1;
+    uint64_t bufferPoolSize = DEFAULT_BUFFER_POOL_SIZE;
+    vector<string> name;
+    vector<string> query;
+    vector<uint64_t> expectedNumTuples;
+};
+
+class TestHelper {
+public:
+    static bool runTest(const string& path);
+
+private:
+    static TestSuiteConfig parseTestFile(const string& path);
+};
+} // namespace testing
+} // namespace graphflow

--- a/src/testing/test_helper.cpp
+++ b/src/testing/test_helper.cpp
@@ -1,0 +1,84 @@
+#include "src/testing/include/test_helper.h"
+
+#include <filesystem>
+
+using namespace std;
+using namespace graphflow::runner;
+using namespace graphflow::planner;
+
+namespace graphflow {
+namespace testing {
+
+const string TEST_TEMP_DIR = "test_temp";
+
+bool TestHelper::runTest(const string& path) {
+    auto testConfig = parseTestFile(path);
+    filesystem::create_directory(TEST_TEMP_DIR);
+    auto server = make_unique<EmbeddedServer>(
+        testConfig.graphInputDir, TEST_TEMP_DIR, testConfig.numThreads, testConfig.bufferPoolSize);
+    auto numQueries = testConfig.query.size();
+    uint64_t numPassedQueries = 0;
+    vector<uint64_t> numPlansOfEachQuery(numQueries);
+    vector<uint64_t> numPassedPlansOfEachQuery(numQueries);
+    for (uint64_t i = 0; i < numQueries; i++) {
+        spdlog::info("TEST: {}", testConfig.name[i]);
+        spdlog::info("QUERY: {}", testConfig.query[i]);
+        auto plans = server->enumerateLogicalPlans(testConfig.query[i]);
+        auto numPlans = plans.size();
+        numPlansOfEachQuery[i] = numPlans;
+        uint64_t numPassedPlans = 0;
+        for (uint64_t j = 0; j < numPlans; j++) {
+            auto planStr = plans[j]->getLastOperator().toString();
+            auto result = server->execute(move(plans[j]));
+            if (result->numTuples != testConfig.expectedNumTuples[i]) {
+                spdlog::error("PLAN{} NOT PASSED. Result num tuples: {}, Expected num tuples: {}",
+                    j, result->numTuples, testConfig.expectedNumTuples[i]);
+                spdlog::info("PLAN: \n{}", planStr);
+            } else {
+                spdlog::info("PLAN{} PASSED", j);
+                spdlog::debug("PLAN: \n{}", planStr);
+                numPassedPlans++;
+            }
+        }
+        numPassedPlansOfEachQuery[i] = numPassedPlans;
+        spdlog::info("{}/{} plans passed in this query.", numPassedPlans, numPlans);
+    }
+    spdlog::info("SUMMARY:");
+    for (uint64_t i = 0; i < numQueries; i++) {
+        spdlog::info("{}: {}/{} PLANS PASSED", testConfig.name[i], numPassedPlansOfEachQuery[i],
+            numPlansOfEachQuery[i]);
+        numPassedQueries += (numPlansOfEachQuery[i] == numPassedPlansOfEachQuery[i]);
+    }
+    return numPassedQueries == numQueries;
+}
+
+TestSuiteConfig TestHelper::parseTestFile(const string& path) {
+    if (access(path.c_str(), 0) == 0) {
+        struct stat status;
+        stat(path.c_str(), &status);
+        if (!(status.st_mode & S_IFDIR)) {
+            ifstream ifs(path);
+            string line;
+            TestSuiteConfig config;
+            while (getline(ifs, line)) {
+                if (line.starts_with("-INPUT")) {
+                    config.graphInputDir = line.substr(7, line.length());
+                } else if (line.starts_with("-PARALLELISM")) {
+                    config.numThreads = stoi(line.substr(13, line.length()));
+                } else if (line.starts_with("-BUFFER_POOL_SIZE")) {
+                    config.bufferPoolSize = stoi(line.substr(18, line.length()));
+                } else if (line.starts_with("-NAME")) {
+                    config.name.push_back(line.substr(6, line.length()));
+                } else if (line.starts_with("-QUERY")) {
+                    config.query.push_back(line.substr(7, line.length()));
+                } else if (line.starts_with("----")) {
+                    config.expectedNumTuples.push_back(stoi(line.substr(5, line.length())));
+                }
+            }
+            return config;
+        }
+    }
+    throw invalid_argument("Test file not exists! [" + path + "].");
+}
+} // namespace testing
+} // namespace graphflow

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_test(
+    name = "basic_test",
+    srcs = [
+        "basic_test.cpp"
+    ],
+    copts = [
+        "-Iexternal/gtest/include",
+    ],
+    deps = [
+        "//src/testing:test_helper",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+    data = [
+        "//dataset",
+        "testfiles",
+    ]
+)
+
+filegroup(
+    name = "testfiles",
+    srcs = [
+        "basic_extend.test",
+        "basic_hash_join.test",
+        "basic_scan.test",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/test/runner/basic_extend.test
+++ b/test/runner/basic_extend.test
@@ -1,0 +1,13 @@
+# description: Basic extend test
+
+-INPUT dataset/tinysnb/
+-OUTPUT test/unittest_temp/
+-PARALLELISM 1
+
+-NAME ExtendTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)
+---- 14
+
+-NAME LongPathExtendTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person)
+---- 108

--- a/test/runner/basic_hash_join.test
+++ b/test/runner/basic_hash_join.test
@@ -1,0 +1,9 @@
+# description: Basic hash join test
+
+-INPUT dataset/tinysnb/
+-OUTPUT test/unittest_temp/
+-PARALLELISM 1
+
+-NAME HashJoinTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person)
+---- 108

--- a/test/runner/basic_scan.test
+++ b/test/runner/basic_scan.test
@@ -1,0 +1,8 @@
+# description: Basic scan test
+
+-INPUT dataset/tinysnb/
+-PARALLELISM 1
+
+-NAME SimpleMatchTest
+-QUERY MATCH (a:person)
+---- 7

--- a/test/runner/basic_test.cpp
+++ b/test/runner/basic_test.cpp
@@ -1,0 +1,10 @@
+#include "gtest/gtest.h"
+
+#include "src/testing/include/test_helper.h"
+
+using namespace graphflow::testing;
+
+TEST(BasicTest, BasicScan) {
+    TestHelper testHelper;
+    ASSERT_TRUE(testHelper.runTest("test/runner/basic_scan.test"));
+}


### PR DESCRIPTION
This PR makes the following changes:
1. Change some detailed log output from `info` to `debug`, so it hides detailed information from users.
2. Add a testing framework. **NOTICE**: currently, the parsing of test files is not robust enough, so the writing of test files better strictly stick to example files.

The usage of the testing framework requires a user to:
a) write a test file, an example can be found in `test/runner/basic_scan.test`.
```
# description: Basic scan test

-INPUT dataset/tinysnb/
-PARALLELISM 1

-NAME SimpleMatchTest
-QUERY MATCH (a:person)
---- 7

```
One test file is expected to hold a test suite, including a configuration of graph (csv files) input dir (`-INPUT`), parallelism of the processor (`-PARALLELISM`), and also one or multiple queries.
Each query consists of a name, `-NAME`, and the cypher `-QUERY`, followed by the number of tuples, e.g., `---- 1`.
Comparison on the query result is not supported for now (will be added in a later version).

b) add test file into the unittest's data dependency
```
filegroup(
    name = "testfiles",
    srcs = [
        "basic_extend.test",
        "basic_hash_join.test",
        "basic_scan.test",
    ],
    visibility = ["//visibility:public"],
)
```
To read these files in bazel test system, we need add them as data dependency, so they can be exposed and read in the bazel sandbox.

c) create a unittest
```
TEST(BasicTest, BasicScan) {
    TestHelper testHelper;
    ASSERT_TRUE(testHelper.runTest("test/runner/basic_scan.test"));
}
```
To use the test in unittest, we need add a unittest function to specify the path of the test file.
