### PR TITLE
Add LogicalProjection

### DIFF
--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -41,6 +41,7 @@ cc_library(
     name = "bound_statement",
     hdrs = [
         "include/bound_statements/bound_match_statement.h",
+        "include/bound_statements/bound_return_statement.h",
         "include/bound_statements/bound_single_query.h",
     ],
 )
@@ -68,6 +69,7 @@ cc_library(
         "include/logical_plan/operator/filter/logical_filter.h",
         "include/logical_plan/operator/hash_join/logical_hash_join.h",
         "include/logical_plan/operator/logical_operator.h",
+        "include/logical_plan/operator/projection/logical_projection.h",
         "include/logical_plan/operator/scan_node_id/logical_scan_node_id.h",
         "include/logical_plan/operator/scan_property/logical_scan_node_property.h",
         "include/logical_plan/operator/scan_property/logical_scan_rel_property.h",

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -25,7 +25,8 @@ unique_ptr<BoundSingleQuery> Binder::bindSingleQuery(const SingleQuery& singleQu
             }
         }
     }
-    return make_unique<BoundSingleQuery>(move(mergedQueryGraph), move(whereExprsSplitOnAND));
+    return make_unique<BoundSingleQuery>(
+        move(mergedQueryGraph), move(whereExprsSplitOnAND), make_unique<BoundReturnStatement>());
 }
 
 unique_ptr<BoundMatchStatement> Binder::bindStatement(const MatchStatement& matchStatement) {

--- a/src/planner/include/bound_statements/bound_return_statement.h
+++ b/src/planner/include/bound_statements/bound_return_statement.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "src/expression/include/logical/logical_expression.h"
+
+using namespace graphflow::expression;
+
+namespace graphflow {
+namespace planner {
+
+class BoundReturnStatement {
+
+public:
+    vector<shared_ptr<LogicalExpression>> expressionsToReturn;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/bound_statements/bound_single_query.h
+++ b/src/planner/include/bound_statements/bound_single_query.h
@@ -3,6 +3,7 @@
 #include <utility>
 
 #include "src/expression/include/logical/logical_expression.h"
+#include "src/planner/include/bound_statements/bound_return_statement.h"
 #include "src/planner/include/query_graph/query_graph.h"
 
 using namespace graphflow::expression;
@@ -14,12 +15,15 @@ class BoundSingleQuery {
 
 public:
     BoundSingleQuery(unique_ptr<QueryGraph> queryGraph,
-        vector<shared_ptr<LogicalExpression>> whereExpressionsSplitOnAND)
-        : queryGraph{move(queryGraph)}, whereExpressionsSplitOnAND{whereExpressionsSplitOnAND} {}
+        vector<shared_ptr<LogicalExpression>> whereExpressionsSplitOnAND,
+        unique_ptr<BoundReturnStatement> boundReturnStatement)
+        : queryGraph{move(queryGraph)}, whereExpressionsSplitOnAND{whereExpressionsSplitOnAND},
+          boundReturnStatement{move(boundReturnStatement)} {}
 
 public:
     unique_ptr<QueryGraph> queryGraph;
     vector<shared_ptr<LogicalExpression>> whereExpressionsSplitOnAND;
+    unique_ptr<BoundReturnStatement> boundReturnStatement;
 };
 
 } // namespace planner

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -33,6 +33,10 @@ private:
 
     void appendFilter(shared_ptr<LogicalExpression> expression, LogicalPlan& plan);
 
+    void appendProjection(LogicalPlan& plan);
+
+    void appendNecessaryScans(shared_ptr<LogicalExpression> expression, LogicalPlan& plan);
+
     void appendScanNodeProperty(
         const string& nodeName, const string& propertyName, LogicalPlan& plan);
 
@@ -44,6 +48,7 @@ private:
     const QueryGraph& queryGraph;
     vector<pair<shared_ptr<LogicalExpression>, unordered_set<string>>>
         whereClauseAndIncludedVariables;
+    vector<shared_ptr<LogicalExpression>> returnClause;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/extend/logical_extend.h
+++ b/src/planner/include/logical_plan/operator/extend/logical_extend.h
@@ -18,17 +18,11 @@ public:
     LogicalExtend(const QueryRel& queryRel, const Direction& direction,
         shared_ptr<LogicalOperator> prevOperator)
         : LogicalOperator{prevOperator}, direction{direction} {
-        if (FWD == direction) {
-            boundNodeVarName = queryRel.getSrcNodeName();
-            boundNodeVarLabel = queryRel.srcNode->label;
-            nbrNodeVarName = queryRel.getDstNodeName();
-            nbrNodeVarLabel = queryRel.dstNode->label;
-        } else {
-            boundNodeVarName = queryRel.getDstNodeName();
-            boundNodeVarLabel = queryRel.dstNode->label;
-            nbrNodeVarName = queryRel.getSrcNodeName();
-            nbrNodeVarLabel = queryRel.srcNode->label;
-        }
+        auto isFwd = FWD == direction;
+        boundNodeVarName = isFwd ? queryRel.getSrcNodeName() : queryRel.getDstNodeName();
+        boundNodeVarLabel = isFwd ? queryRel.srcNode->label : queryRel.dstNode->label;
+        nbrNodeVarName = isFwd ? queryRel.getDstNodeName() : queryRel.getSrcNodeName();
+        nbrNodeVarLabel = isFwd ? queryRel.dstNode->label : queryRel.srcNode->label;
         relLabel = queryRel.label;
     }
 

--- a/src/planner/include/logical_plan/operator/logical_operator.h
+++ b/src/planner/include/logical_plan/operator/logical_operator.h
@@ -16,6 +16,7 @@ enum LogicalOperatorType : uint8_t {
     LOGICAL_SCAN_NODE_PROPERTY,
     LOGICAL_SCAN_REL_PROPERTY,
     LOGICAL_HASH_JOIN,
+    LOGICAL_PROJECTION,
 };
 
 const string LogicalOperatorTypeNames[] = {"LOGICAL_NODE_ID_SCAN", "LOGICAL_EXTEND",

--- a/src/planner/include/logical_plan/operator/projection/logical_projection.h
+++ b/src/planner/include/logical_plan/operator/projection/logical_projection.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "src/expression/include/logical/logical_expression.h"
+
+using namespace graphflow::expression;
+
+namespace graphflow {
+namespace planner {
+
+class LogicalProjection : public LogicalOperator {
+
+public:
+    explicit LogicalProjection(
+        vector<shared_ptr<LogicalExpression>> expressions, shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{prevOperator}, expressionsToProject{move(expressions)} {}
+
+    LogicalOperatorType getLogicalOperatorType() const override {
+        return LogicalOperatorType::LOGICAL_PROJECTION;
+    }
+
+    string getOperatorInformation() const override {
+        auto result = expressionsToProject[0]->getRawExpression();
+        for (auto i = 1u; i < expressionsToProject.size(); ++i) {
+            result += ", " + expressionsToProject[i]->getRawExpression();
+        }
+        return result;
+    }
+
+public:
+    vector<shared_ptr<LogicalExpression>> expressionsToProject;
+};
+
+} // namespace planner
+} // namespace graphflow


### PR DESCRIPTION
This PR adds LogicalProjection to enumerator

**LogicalProjection**
-  contains `vector<LogicalExpression> expressionsToProject`
- LogicalProjection is only appended before Sink
  -  Necessary LogicalScanProperty is appended before LogicalProjection 