### PR TITLE
Add ReturnCluase

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -19,7 +19,7 @@ oC_SingleQuery
     : oC_SinglePartQuery ;
 
 oC_SinglePartQuery 
-    : ( oC_ReadingClause SP? )* ;
+    : ( oC_ReadingClause SP? )* oC_Return ;
 
 oC_ReadingClause 
     : oC_Match ;
@@ -28,6 +28,28 @@ oC_Match
     : MATCH SP? oC_Pattern (SP? oC_Where)? ;
 
 MATCH : ( 'M' | 'm' ) ( 'A' | 'a' ) ( 'T' | 't' ) ( 'C' | 'c' ) ( 'H' | 'h' )  ;
+
+oC_Return
+    : RETURN oC_ProjectionBody ;
+
+RETURN : ( 'R' | 'r' ) ( 'E' | 'e' ) ( 'T' | 't' ) ( 'U' | 'u' ) ( 'R' | 'r' ) ( 'N' | 'n' ) ;
+
+oC_ProjectionBody
+    : SP oC_ProjectionItems ;
+
+oC_ProjectionItems
+    : ( STAR ( SP? ',' SP? oC_ProjectionItem )* )
+        | ( oC_ProjectionItem ( SP? ',' SP? oC_ProjectionItem )* )
+        ;
+
+STAR : '*' ;
+
+oC_ProjectionItem
+    : ( oC_Expression SP AS SP oC_Variable )
+        | oC_Expression
+        ;
+
+AS : ( 'A' | 'a' ) ( 'S' | 's' )  ;
 
 oC_Where
     : WHERE SP oC_Expression ;
@@ -145,9 +167,12 @@ oC_PropertyOrLabelsExpression
 oC_Atom
     : oC_Literal
         | oC_ParenthesizedExpression
+        | ( COUNT SP? '(' SP? '*' SP? ')' )
         | oC_FunctionInvocation
         | oC_Variable
         ;
+
+COUNT : ( 'C' | 'c' ) ( 'O' | 'o' ) ( 'U' | 'u' ) ( 'N' | 'n' ) ( 'T' | 't' )  ;
 
 oC_Literal
     : oC_NumberLiteral

--- a/src/expression/include/logical/logical_expression.h
+++ b/src/expression/include/logical/logical_expression.h
@@ -12,25 +12,26 @@ using namespace std;
 namespace graphflow {
 namespace expression {
 
+// replace this with function enum once we have multiple default functions
+const string COUNT_STAR = "COUNT_STAR";
+
 class LogicalExpression {
 
 public:
     // creates a non-leaf logical binary expression.
     LogicalExpression(ExpressionType expressionType, DataType dataType,
-        shared_ptr<LogicalExpression> left, shared_ptr<LogicalExpression> right,
-        string rawExpression = string());
+        shared_ptr<LogicalExpression> left, shared_ptr<LogicalExpression> right);
 
     // creates a non-leaf logical unary expression.
-    LogicalExpression(ExpressionType expressionType, DataType dataType,
-        shared_ptr<LogicalExpression> child, string rawExpression = string());
+    LogicalExpression(
+        ExpressionType expressionType, DataType dataType, shared_ptr<LogicalExpression> child);
 
     // creates a leaf variable expression.
-    LogicalExpression(ExpressionType expressionType, DataType dataType, const string& variableName,
-        string rawExpression = string());
+    LogicalExpression(ExpressionType expressionType, DataType dataType, const string& variableName);
 
     // creates a leaf literal expression.
-    LogicalExpression(ExpressionType expressionType, DataType dataType, const Literal& literalValue,
-        string rawExpression = string());
+    LogicalExpression(
+        ExpressionType expressionType, DataType dataType, const Literal& literalValue);
 
     inline const string& getVariableName() const { return variableName; }
 
@@ -60,6 +61,7 @@ public:
     vector<shared_ptr<LogicalExpression>> childrenExpr;
     ExpressionType expressionType;
     DataType dataType;
+    string alias;
     string rawExpression;
 };
 

--- a/src/expression/logical/logical_expression.cpp
+++ b/src/expression/logical/logical_expression.cpp
@@ -4,32 +4,28 @@ namespace graphflow {
 namespace expression {
 
 LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dataType,
-    shared_ptr<LogicalExpression> left, shared_ptr<LogicalExpression> right, string rawExpression)
+    shared_ptr<LogicalExpression> left, shared_ptr<LogicalExpression> right)
     : LogicalExpression(expressionType, dataType) {
     childrenExpr.push_back(left);
     childrenExpr.push_back(right);
-    this->rawExpression = move(rawExpression);
 }
 
-LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dataType,
-    shared_ptr<LogicalExpression> child, string rawExpression)
+LogicalExpression::LogicalExpression(
+    ExpressionType expressionType, DataType dataType, shared_ptr<LogicalExpression> child)
     : LogicalExpression(expressionType, dataType) {
     childrenExpr.push_back(child);
-    this->rawExpression = move(rawExpression);
 }
 
-LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dataType,
-    const string& variableName, string rawExpression)
+LogicalExpression::LogicalExpression(
+    ExpressionType expressionType, DataType dataType, const string& variableName)
     : LogicalExpression(expressionType, dataType) {
     this->variableName = variableName;
-    this->rawExpression = move(rawExpression);
 }
 
-LogicalExpression::LogicalExpression(ExpressionType expressionType, DataType dataType,
-    const Literal& literalValue, string rawExpression)
+LogicalExpression::LogicalExpression(
+    ExpressionType expressionType, DataType dataType, const Literal& literalValue)
     : LogicalExpression(expressionType, dataType) {
     this->literalValue = literalValue;
-    this->rawExpression = move(rawExpression);
 }
 
 unordered_set<string> LogicalExpression::getIncludedVariables() const {

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -22,6 +22,7 @@ cc_library(
     name = "statements",
     hdrs = [
         "include/statements/match_statement.h",
+        "include/statements/return_statement.h",
     ],
     deps = [
         "expressions",
@@ -36,7 +37,7 @@ cc_library(
         "include/patterns/pattern_element.h",
         "include/patterns/pattern_element_chain.h",
         "include/patterns/rel_pattern.h",
-    ]
+    ],
 )
 
 cc_library(

--- a/src/parser/include/parsed_expression.h
+++ b/src/parser/include/parsed_expression.h
@@ -25,9 +25,11 @@ public:
         children.push_back(move(right));
     }
 
+    string getName() const { return alias.empty() ? rawExpression : alias; }
+
     // no need to compare rawExpression
     bool operator==(const ParsedExpression& other) {
-        auto result = type == other.type && text == other.text;
+        auto result = type == other.type && text == other.text && alias == other.alias;
         for (auto i = 0ul; i < children.size(); ++i) {
             result &= *children[i] == *other.children[i];
         }
@@ -36,7 +38,9 @@ public:
 
 public:
     ExpressionType type;
+    // variableName, propertyName or functionName
     string text;
+    string alias;
     string rawExpression;
     vector<unique_ptr<ParsedExpression>> children;
 };

--- a/src/parser/include/single_query.h
+++ b/src/parser/include/single_query.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/parser/include/statements/match_statement.h"
+#include "src/parser/include/statements/return_statement.h"
 
 namespace graphflow {
 namespace parser {
@@ -9,15 +10,22 @@ class SingleQuery {
 
 public:
     bool operator==(const SingleQuery& other) {
-        auto result = true;
-        for (auto i = 0ul; i < statements.size(); ++i) {
-            result &= *statements[i] == *other.statements[i];
+        auto result = matchStatements.size() == other.matchStatements.size() &&
+                      *returnStatement == *other.returnStatement;
+        if (result) {
+            for (auto i = 0u; i < matchStatements.size(); ++i) {
+                if (!(*matchStatements[i] == *other.matchStatements[i])) {
+                    return false;
+                }
+            }
+            return true;
         }
-        return result;
+        return false;
     }
 
 public:
-    vector<unique_ptr<MatchStatement>> statements;
+    vector<unique_ptr<MatchStatement>> matchStatements;
+    unique_ptr<ReturnStatement> returnStatement;
 };
 
 } // namespace parser

--- a/src/parser/include/statements/return_statement.h
+++ b/src/parser/include/statements/return_statement.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "src/parser/include/parsed_expression.h"
+
+namespace graphflow {
+namespace parser {
+
+class ReturnStatement {
+
+public:
+    ReturnStatement(vector<unique_ptr<ParsedExpression>> expressions, bool containsStar)
+        : containsStar{containsStar}, expressions{move(expressions)} {}
+
+    bool operator==(const ReturnStatement& other) {
+        auto result =
+            containsStar == other.containsStar && expressions.size() == other.expressions.size();
+        for (auto i = 0u; i < expressions.size(); ++i) {
+            result &= *expressions[i] == *other.expressions[i];
+        }
+        return result;
+    }
+
+public:
+    bool containsStar;
+    vector<unique_ptr<ParsedExpression>> expressions;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/transformer.h
+++ b/src/parser/include/transformer.h
@@ -31,6 +31,11 @@ private:
 
     unique_ptr<MatchStatement> transformMatch(CypherParser::OC_MatchContext& ctx);
 
+    unique_ptr<ReturnStatement> transformReturn(CypherParser::OC_ReturnContext& ctx);
+
+    unique_ptr<ParsedExpression> transformProjectionItem(
+        CypherParser::OC_ProjectionItemContext& ctx);
+
     unique_ptr<ParsedExpression> transformWhere(CypherParser::OC_WhereContext& ctx);
 
     vector<unique_ptr<PatternElement>> transformPattern(CypherParser::OC_PatternContext& ctx);

--- a/src/planner/include/binder.h
+++ b/src/planner/include/binder.h
@@ -20,10 +20,12 @@ public:
     unique_ptr<BoundSingleQuery> bindSingleQuery(const SingleQuery& singleQuery);
 
 private:
-    unique_ptr<BoundMatchStatement> bindStatement(const MatchStatement& matchStatement);
+    unique_ptr<BoundMatchStatement> bindMatchStatement(const MatchStatement& matchStatement);
 
-    // Bind query graph
-    void bindQueryRels(const PatternElement& patternElement, QueryGraph& queryGraph);
+    unique_ptr<BoundReturnStatement> bindReturnStatement(
+        ReturnStatement& returnStatement, const QueryGraph& graphInScope);
+
+    unique_ptr<QueryGraph> bindQueryGraph(const vector<unique_ptr<PatternElement>>& graphPattern);
 
     QueryRel* bindQueryRel(const PatternElementChain& patternElementChain, QueryNode* leftNode,
         QueryGraph& queryGraph);
@@ -34,6 +36,7 @@ private:
 
     label_t bindNodeLabel(const string& parsed_label);
 
+    // set queryNode as src or dst for queryRel
     void bindNodeToRel(QueryRel* queryRel, QueryNode* queryNode, bool isSrcNode);
 
 private:

--- a/src/planner/include/bound_statements/bound_return_statement.h
+++ b/src/planner/include/bound_statements/bound_return_statement.h
@@ -10,7 +10,11 @@ namespace planner {
 class BoundReturnStatement {
 
 public:
-    vector<shared_ptr<LogicalExpression>> expressionsToReturn;
+    explicit BoundReturnStatement(vector<shared_ptr<LogicalExpression>> expressions)
+        : expressions{move(expressions)} {}
+
+public:
+    vector<shared_ptr<LogicalExpression>> expressions;
 };
 
 } // namespace planner

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -11,7 +11,7 @@ namespace planner {
 class Enumerator {
 
 public:
-    explicit Enumerator(const BoundSingleQuery& boundSingleQuery);
+    explicit Enumerator(const Catalog& catalog, const BoundSingleQuery& boundSingleQuery);
 
     vector<unique_ptr<LogicalPlan>> enumeratePlans();
 
@@ -45,6 +45,7 @@ private:
 
 private:
     unique_ptr<SubgraphPlanTable> subgraphPlanTable; // cached subgraph plans
+    const Catalog& catalog;
     const QueryGraph& queryGraph;
     vector<pair<shared_ptr<LogicalExpression>, unordered_set<string>>>
         whereClauseAndIncludedVariables;

--- a/src/planner/include/expression_binder.h
+++ b/src/planner/include/expression_binder.h
@@ -46,6 +46,8 @@ private:
 
     shared_ptr<LogicalExpression> bindPropertyExpression(const ParsedExpression& parsedExpression);
 
+    shared_ptr<LogicalExpression> bindFunctionExpression(const ParsedExpression& parsedExpression);
+
     shared_ptr<LogicalExpression> bindLiteralExpression(const ParsedExpression& parsedExpression);
 
     shared_ptr<LogicalExpression> bindVariableExpression(const ParsedExpression& parsedExpression);

--- a/src/planner/include/logical_plan/operator/logical_operator.h
+++ b/src/planner/include/logical_plan/operator/logical_operator.h
@@ -21,7 +21,7 @@ enum LogicalOperatorType : uint8_t {
 
 const string LogicalOperatorTypeNames[] = {"LOGICAL_NODE_ID_SCAN", "LOGICAL_EXTEND",
     "LOGICAL_FILTER", "LOGICAL_NODE_PROPERTY_SCAN", "LOGICAL_REL_PROPERTY_SCAN",
-    "LOGICAL_HASH_JOIN"};
+    "LOGICAL_HASH_JOIN", "LOGICAL_PROJECTION"};
 
 class LogicalOperator {
 public:

--- a/src/runner/server/embedded_server.cpp
+++ b/src/runner/server/embedded_server.cpp
@@ -27,7 +27,7 @@ vector<unique_ptr<LogicalPlan>> EmbeddedServer::enumerateLogicalPlans(const stri
     auto singleQuery = parser.parseQuery(query);
     Binder binder(graph->getCatalog());
     auto boundSingleQuery = binder.bindSingleQuery(*singleQuery);
-    Enumerator enumerator(*boundSingleQuery);
+    Enumerator enumerator(graph->getCatalog(), *boundSingleQuery);
     return enumerator.enumeratePlans();
 }
 

--- a/test/parser/graph_pattern_test.cpp
+++ b/test/parser/graph_pattern_test.cpp
@@ -36,75 +36,32 @@ TEST_F(GraphPatternTest, EmptyMatchTest) {
     expectedPatternElements.push_back(move(expectedPatternElement));
     auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
     auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
+    expectedSingleQuery->matchStatements.push_back(move(expectedMatchStatement));
+    auto returnStar = make_unique<ReturnStatement>(vector<unique_ptr<ParsedExpression>>(), true);
+    expectedSingleQuery->returnStatement = move(returnStar);
 
     graphflow::parser::Parser parser;
-    string input = "MATCH ();";
+    string input = "MATCH () RETURN *;";
     ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
 }
 
-TEST_F(GraphPatternTest, MATCHSingleElementSingleNodeNoLabelTest) {
-    auto expectedNode = makeNodePattern("a", string());
-    auto expectedPatternElement = makePatternElement(move(expectedNode));
-    vector<unique_ptr<PatternElement>> expectedPatternElements;
-    expectedPatternElements.push_back(move(expectedPatternElement));
-    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
-    auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
-
-    graphflow::parser::Parser parser;
-    string input = "MATCH (a);";
-    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
-}
-
-TEST_F(GraphPatternTest, MATCHSingleElementSingleNodeSingleLabelTest) {
+TEST_F(GraphPatternTest, MATCHSingleNodeTest) {
     auto expectedNode = makeNodePattern("a", "Person");
     auto expectedPatternElement = makePatternElement(move(expectedNode));
     vector<unique_ptr<PatternElement>> expectedPatternElements;
     expectedPatternElements.push_back(move(expectedPatternElement));
     auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
     auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
+    expectedSingleQuery->matchStatements.push_back(move(expectedMatchStatement));
+    auto returnStar = make_unique<ReturnStatement>(vector<unique_ptr<ParsedExpression>>(), true);
+    expectedSingleQuery->returnStatement = move(returnStar);
 
     graphflow::parser::Parser parser;
-    string input = "MATCH (a:Person);";
+    string input = "MATCH (a:Person) RETURN *;";
     ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
 }
 
-TEST_F(GraphPatternTest, MATCHSingleElementAnonymousNodeSingleLabelTest) {
-    auto expectedNode = makeNodePattern(string(), "Person");
-    auto expectedPatternElement = makePatternElement(move(expectedNode));
-    vector<unique_ptr<PatternElement>> expectedPatternElements;
-    expectedPatternElements.push_back(move(expectedPatternElement));
-    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
-    auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
-
-    graphflow::parser::Parser parser;
-    string input = "MATCH (:Person);";
-    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
-}
-
-TEST_F(GraphPatternTest, MATCHSingleElementSingleEdgeNoTypeTest) {
-    auto expectedNodeA = makeNodePattern("a", "Person");
-    auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge = makeRelPattern("e1", string(), RIGHT);
-    auto expectedPatternElementChain =
-        makePatternElementChain(move(expectedEdge), move(expectedNodeB));
-    auto expectedPatternElement = makePatternElement(move(expectedNodeA));
-    expectedPatternElement->patternElementChains.push_back(move(expectedPatternElementChain));
-    vector<unique_ptr<PatternElement>> expectedPatternElements;
-    expectedPatternElements.push_back(move(expectedPatternElement));
-    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
-    auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
-
-    graphflow::parser::Parser parser;
-    string input = "MATCH (a:Person)-[e1]->(b:Student);";
-    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
-}
-
-TEST_F(GraphPatternTest, MATCHSingleElementSingleEdgeSingleTypeTest) {
+TEST_F(GraphPatternTest, MATCHSingleEdgeTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
     auto expectedEdge = makeRelPattern("e1", "knows", RIGHT);
@@ -116,33 +73,16 @@ TEST_F(GraphPatternTest, MATCHSingleElementSingleEdgeSingleTypeTest) {
     expectedPatternElements.push_back(move(expectedPatternElement));
     auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
     auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
+    expectedSingleQuery->matchStatements.push_back(move(expectedMatchStatement));
+    auto returnStar = make_unique<ReturnStatement>(vector<unique_ptr<ParsedExpression>>(), true);
+    expectedSingleQuery->returnStatement = move(returnStar);
 
     graphflow::parser::Parser parser;
-    string input = "MATCH (a:Person)-[e1:knows]->(b:Student);";
+    string input = "MATCH (a:Person)-[e1:knows]->(b:Student) RETURN *;";
     ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
 }
 
-TEST_F(GraphPatternTest, MATCHSingleElementAnonymousEdgeMultiTypesTest) {
-    auto expectedNodeA = makeNodePattern("a", "Person");
-    auto expectedNodeB = makeNodePattern("b", "Student");
-    auto expectedEdge = makeRelPattern(string(), "knows", RIGHT);
-    auto expectedPatternElementChain =
-        makePatternElementChain(move(expectedEdge), move(expectedNodeB));
-    auto expectedPatternElement = makePatternElement(move(expectedNodeA));
-    expectedPatternElement->patternElementChains.push_back(move(expectedPatternElementChain));
-    vector<unique_ptr<PatternElement>> expectedPatternElements;
-    expectedPatternElements.push_back(move(expectedPatternElement));
-    auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
-    auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
-
-    graphflow::parser::Parser parser;
-    string input = "MATCH (a:Person)-[:knows]->(b:Student);";
-    ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
-}
-
-TEST_F(GraphPatternTest, MATCHSingleElementMultiEdgesTest) {
+TEST_F(GraphPatternTest, MATCHMultiEdgesTest) {
     auto expectedNodeA = makeNodePattern("a", "Person");
     auto expectedNodeB = makeNodePattern("b", "Student");
     auto expectedEdge1 = makeRelPattern(string(), "knows", RIGHT);
@@ -159,10 +99,12 @@ TEST_F(GraphPatternTest, MATCHSingleElementMultiEdgesTest) {
     expectedPatternElements.push_back(move(expectedPatternElement));
     auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
     auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
+    expectedSingleQuery->matchStatements.push_back(move(expectedMatchStatement));
+    auto returnStar = make_unique<ReturnStatement>(vector<unique_ptr<ParsedExpression>>(), true);
+    expectedSingleQuery->returnStatement = move(returnStar);
 
     graphflow::parser::Parser parser;
-    string input = "MATCH (a:Person)-[:knows]->(b:Student)<-[e2:likes]-(c:Student);";
+    string input = "MATCH (a:Person)-[:knows]->(b:Student)<-[e2:likes]-(c:Student) RETURN *;";
     ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
 }
 
@@ -188,10 +130,12 @@ TEST_F(GraphPatternTest, MATCHMultiElementsTest) {
     expectedPatternElements.push_back(move(expectedPatternElement2));
     auto expectedMatchStatement = make_unique<MatchStatement>(move(expectedPatternElements));
     auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement));
+    expectedSingleQuery->matchStatements.push_back(move(expectedMatchStatement));
+    auto returnStar = make_unique<ReturnStatement>(vector<unique_ptr<ParsedExpression>>(), true);
+    expectedSingleQuery->returnStatement = move(returnStar);
 
     graphflow::parser::Parser parser;
-    string input = "MATCH (a:Person)-[:knows]->(b:Student), (b)<-[e2:likes]-(c:Student);";
+    string input = "MATCH (a:Person)-[:knows]->(b:Student), (b)<-[e2:likes]-(c:Student) RETURN *;";
     ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
 }
 
@@ -219,10 +163,13 @@ TEST_F(GraphPatternTest, MultiMatchTest) {
     auto expectedMatchStatement2 = make_unique<MatchStatement>(move(expectedPatternElements2));
 
     auto expectedSingleQuery = make_unique<SingleQuery>();
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement1));
-    expectedSingleQuery->statements.push_back(move(expectedMatchStatement2));
+    expectedSingleQuery->matchStatements.push_back(move(expectedMatchStatement1));
+    expectedSingleQuery->matchStatements.push_back(move(expectedMatchStatement2));
+    auto returnStar = make_unique<ReturnStatement>(vector<unique_ptr<ParsedExpression>>(), true);
+    expectedSingleQuery->returnStatement = move(returnStar);
 
     graphflow::parser::Parser parser;
-    string input = "MATCH (a:Person)-[:knows]->(b:Student) MATCH (b)<-[e2:likes]-(c:Student);";
+    string input =
+        "MATCH (a:Person)-[:knows]->(b:Student) MATCH (b)<-[e2:likes]-(c:Student) RETURN *;";
     ASSERT_TRUE(*parser.parseQuery(input) == *expectedSingleQuery);
 }

--- a/test/runner/queries/filtered/nodes.test
+++ b/test/runner/queries/filtered/nodes.test
@@ -5,13 +5,13 @@
 -PARALLELISM 1
 
 -NAME PersonNodesAgeFilteredTest
--QUERY MATCH (a:person) WHERE a.age <= 25
+-QUERY MATCH (a:person) WHERE a.age <= 25 RETURN COUNT(*)
 ---- 3
 
 -NAME PersonNodesIsWorkerFilteredTest
--QUERY MATCH (a:person) WHERE a.isWorker = true
+-QUERY MATCH (a:person) WHERE a.isWorker = true RETURN COUNT(*)
 ---- 3
 
 -NAME OrganisationNodesIsWorkerFilteredTest
--QUERY MATCH (a:organisation) WHERE a.mark >= 3.7
+-QUERY MATCH (a:organisation) WHERE a.mark >= 3.7 RETURN COUNT(*)
 ---- 3

--- a/test/runner/queries/filtered/paths.test
+++ b/test/runner/queries/filtered/paths.test
@@ -4,10 +4,10 @@
 -OUTPUT test/unittest_temp/
 -PARALLELISM 1
 
--NAME OneHopKnowsFilteredTest1
--QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE a.gender = 1 AND b.gender = 2
+-NAME OneHopKnowsFilteredTest
+-QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE a.gender = 1 AND b.gender = 2 RETURN COUNT(*)
 ---- 6
 
 -NAME OneHopKnowsFilteredTest2
--QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE a.age > 22
+-QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE a.age > 22 RETURN COUNT(*)
 ---- 9

--- a/test/runner/queries/filtered/stars.test
+++ b/test/runner/queries/filtered/stars.test
@@ -5,5 +5,5 @@
 -PARALLELISM 1
 
 -NAME TwoHopKnowsFilteredTest
--MATCH (a:person)-[e1:knows]->(b:person), (a:person)-[e2:knows]->(c:person) WHERE e1.date = e2.date
+-MATCH (a:person)-[e1:knows]->(b:person), (a:person)-[e2:knows]->(c:person) WHERE e1.date = e2.date RETURN COUNT(*)
 ---- 24

--- a/test/runner/queries/structural/nodes.test
+++ b/test/runner/queries/structural/nodes.test
@@ -5,9 +5,9 @@
 -PARALLELISM 1
 
 -NAME PersonNodesTest
--QUERY MATCH (a:person)
+-QUERY MATCH (a:person) RETURN COUNT(*)
 ---- 7
 
 -NAME OrganizationNodesTest
--QUERY MATCH (a:organisation)
+-QUERY MATCH (a:organisation) RETURN COUNT(*)
 ---- 3

--- a/test/runner/queries/structural/paths.test
+++ b/test/runner/queries/structural/paths.test
@@ -5,37 +5,37 @@
 -PARALLELISM 1
 
 -NAME OneHopKnowsTest
--QUERY MATCH (a:person)-[e:knows]->(b:person)
+-QUERY MATCH (a:person)-[e:knows]->(b:person) RETURN COUNT(*)
 ---- 14
 
 -NAME OneHopStudyAtTest
--QUERY MATCH (a:person)-[e1:studyAt]->(b:organisation)
+-QUERY MATCH (a:person)-[e1:studyAt]->(b:organisation) RETURN COUNT(*)
 ---- 3
 
 -NAME OneHopWorkAtTest
--QUERY MATCH (a:person)-[e1:workAt]->(b:organisation)
+-QUERY MATCH (a:person)-[e1:workAt]->(b:organisation) RETURN COUNT(*)
 ---- 3
 
 -NAME TwoHopKnowsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) RETURN COUNT(*)
 ---- 36
 
 -NAME TwoHopKnowsStudyAtTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:studyAt]->(c:organisation)
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:studyAt]->(c:organisation) RETURN COUNT(*)
 ---- 7
 
 -NAME TwoHopKnowsWorkAtTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:workAt]->(c:organisation)
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:workAt]->(c:organisation) RETURN COUNT(*)
 ---- 6
 
 -NAME ThreeHopKnowsWorkAtKnowsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person)
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person) RETURN COUNT(*)
 ---- 108
 
 -NAME ThreeHopTwoKnowsOneStudyAtTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:studyAt]->(d:organisation)
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:studyAt]->(d:organisation) RETURN COUNT(*)
 ---- 18
 
 -NAME ThreeHopTwoKnowsOneWorkAtTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:workAt]->(d:organisation)
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:workAt]->(d:organisation) RETURN COUNT(*)
 ---- 18

--- a/test/runner/queries/structural/stars.test
+++ b/test/runner/queries/structural/stars.test
@@ -5,41 +5,41 @@
 -PARALLELISM 1
 
 -NAME OpenWedgeKnowsTest
--QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:knows]->(c:person)
+-QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:knows]->(c:person) RETURN COUNT(*)
 ---- 40
 
 -NAME OpenWedgeKnowsStudyAtTest
--QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:studyAt]->(c:organisation)
+-QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:studyAt]->(c:organisation) RETURN COUNT(*)
 ---- 6
 
 -NAME OpenWedgeKnowsWorkAtTest
--QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:workAt]->(c:organisation)
+-QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:workAt]->(c:organisation) RETURN COUNT(*)
 ---- 8
 
 -NAME OpenWedgeKnowsTest
--QUERY MATCH (b:person)-[e1:knows]->(a:person)<-[e2:knows]-(c:person)
+-QUERY MATCH (b:person)-[e1:knows]->(a:person)<-[e2:knows]-(c:person) RETURN COUNT(*)
 ---- 38
 
 -NAME OpenWedgeStudyAtTest
--QUERY MATCH (b:organisation)<-[e1:studyAt]-(a:person)-[e2:studyAt]->(c:organisation)
+-QUERY MATCH (b:organisation)<-[e1:studyAt]-(a:person)-[e2:studyAt]->(c:organisation) RETURN COUNT(*)
 ---- 3
 
 -NAME OpenWedgeWorkAtTest
--QUERY MATCH (b:organisation)<-[e1:workAt]-(a:person)-[e2:workAt]->(c:organisation)
+-QUERY MATCH (b:organisation)<-[e1:workAt]-(a:person)-[e2:workAt]->(c:organisation) RETURN COUNT(*)
 ---- 3
 
 -NAME OpenWedgeWorkAtTest
--QUERY MATCH (b:organisation)<-[e1:workAt]-(a:person)-[e2:studyAt]->(c:organisation)
+-QUERY MATCH (b:organisation)<-[e1:workAt]-(a:person)-[e2:studyAt]->(c:organisation) RETURN COUNT(*)
 ---- 0
 
 -NAME OpenWedgeKnowsTest
--QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:knows]->(c:person),(a)-[e3:knows]->(d:person)
+-QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:knows]->(c:person),(a)-[e3:knows]->(d:person) RETURN COUNT(*)
 ---- 116
 
 -NAME OpenWedgeKnowsTest
--QUERY MATCH (b:person)-[e1:knows]->(a:person)<-[e2:knows]-(c:person),(a)<-[e3:knows]-(d:person)
+-QUERY MATCH (b:person)-[e1:knows]->(a:person)<-[e2:knows]-(c:person),(a)<-[e3:knows]-(d:person) RETURN COUNT(*)
 ---- 110
 
 -NAME OpenTwoHopWedgeKnowsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person),(a:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person)
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person),(a:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
 ---- 324


### PR DESCRIPTION
This PR adds return clause parsing and binding

**ReturnStatement**
- contains a return star boolean flag
- contains `vector<ParsedExpression>`

**BoundReturnStatement**
- contains `vector<LogicalExpression>`
- First rewrite * as all variables in scope
  -  `MATCH (a)-[e1]->(b) RETURN * ` becomes `MATCH (a) RETURN a, e1, b`
- Validate no duplicate return column name
- Then rewrite variable as all properties associated with the variable
  -  `MATCH (a)-[e1]->(b) RETURN a` becomes  `MATCH (a) RETURN a.p1, a.p2, ...`