### PR TITLE
Add id(a) support to front-end

### DIFF
--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -44,6 +44,25 @@ bool isExpressionLeafVariable(ExpressionType type) {
     return PROPERTY == type;
 }
 
+ExpressionType comparisonToIDComparison(ExpressionType type) {
+    switch (type) {
+    case EQUALS:
+        return EQUALS_NODE_ID;
+    case NOT_EQUALS:
+        return NOT_EQUALS_NODE_ID;
+    case GREATER_THAN:
+        return GREATER_THAN_NODE_ID;
+    case GREATER_THAN_EQUALS:
+        return GREATER_THAN_EQUALS_NODE_ID;
+    case LESS_THAN:
+        return LESS_THAN_NODE_ID;
+    case LESS_THAN_EQUALS:
+        return LESS_THAN_EQUALS_NODE_ID;
+    default:
+        throw invalid_argument("Cannot map " + expressionTypeToString(type) + " to ID comparison.");
+    }
+}
+
 string expressionTypeToString(ExpressionType type) {
     switch (type) {
     case OR:

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -104,6 +104,7 @@ bool isExpressionNullComparison(ExpressionType type);
 bool isExpressionLeafLiteral(ExpressionType type);
 bool isExpressionLeafVariable(ExpressionType type);
 
+ExpressionType comparisonToIDComparison(ExpressionType type);
 string expressionTypeToString(ExpressionType type);
 
 } // namespace common

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -185,7 +185,7 @@ inline uint8_t Equals::operation(const nodeID_t& left, const nodeID_t& right) {
 
 template<>
 inline uint8_t NotEquals::operation(const nodeID_t& left, const nodeID_t& right) {
-    return left.label != right.label && left.offset != right.offset;
+    return left.label != right.label || left.offset != right.offset;
 };
 
 /*******************************************************
@@ -324,7 +324,7 @@ inline uint8_t GreaterThan::operation(const nodeID_t& left, const nodeID_t& righ
 
 template<>
 inline uint8_t GreaterThanEquals::operation(const nodeID_t& left, const nodeID_t& right) {
-    return left.label >= right.label || (left.label == right.label && left.offset >= right.offset);
+    return left.label > right.label || (left.label == right.label && left.offset >= right.offset);
 };
 
 template<>
@@ -334,7 +334,7 @@ inline uint8_t LessThan::operation(const nodeID_t& left, const nodeID_t& right) 
 
 template<>
 inline uint8_t LessThanEquals::operation(const nodeID_t& left, const nodeID_t& right) {
-    return left.label <= right.label || (left.label == right.label && left.offset <= right.offset);
+    return left.label < right.label || (left.label == right.label && left.offset <= right.offset);
 };
 
 /********************************************

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -49,11 +49,12 @@ enum DataType : uint8_t {
     INT64 = 5,
     DOUBLE = 6,
     STRING = 7,
-    UNSTRUCTURED = 8
+    NODE_ID = 8,
+    UNSTRUCTURED = 9
 };
 
 const string DataTypeNames[] = {
-    "REL", "NODE", "LABEL", "BOOL", "INT32", "INT64", "DOUBLE", "STRING", "UNSTRUCTURED"};
+    "REL", "NODE", "LABEL", "BOOL", "INT32", "INT64", "DOUBLE", "STRING", "NODE_ID", "UNKNOWN"};
 
 int32_t convertToInt32(char* data);
 

--- a/src/expression/include/logical/logical_expression.h
+++ b/src/expression/include/logical/logical_expression.h
@@ -13,8 +13,9 @@ using namespace std;
 namespace graphflow {
 namespace expression {
 
-// replace this with function enum once we have multiple default functions
-const string COUNT_STAR = "COUNT_STAR";
+// replace this with function enum once we have more functions
+const string FUNCTION_COUNT_STAR = "COUNT_STAR";
+const string FUNCTION_ID = "ID";
 
 class LogicalExpression {
 
@@ -40,7 +41,7 @@ public:
         return alias.empty() ? rawExpression : alias;
     }
 
-    unordered_set<string> getIncludedVariables() const;
+    virtual unordered_set<string> getIncludedVariables() const;
 
     unordered_set<string> getIncludedProperties() const;
 

--- a/src/expression/include/logical/logical_node_expression.h
+++ b/src/expression/include/logical/logical_node_expression.h
@@ -11,6 +11,10 @@ public:
     LogicalNodeExpression(string name, label_t label)
         : LogicalExpression{VARIABLE, NODE}, name{move(name)}, label{label} {}
 
+    unordered_set<string> getIncludedVariables() const override {
+        return unordered_set<string>{name};
+    }
+
 public:
     string name;
     label_t label;

--- a/src/expression/include/logical/logical_rel_expression.h
+++ b/src/expression/include/logical/logical_rel_expression.h
@@ -15,6 +15,10 @@ public:
 
     inline string getDstNodeName() const { return dstNode->name; }
 
+    unordered_set<string> getIncludedVariables() const override {
+        return unordered_set<string>{name};
+    }
+
 public:
     string name;
     label_t label;

--- a/src/expression/logical/logical_expression.cpp
+++ b/src/expression/logical/logical_expression.cpp
@@ -28,8 +28,7 @@ unordered_set<string> LogicalExpression::getIncludedVariables() const {
         return result;
     }
     if (VARIABLE == expressionType) {
-        result.insert(variableName);
-        return result;
+        return getIncludedVariables();
     }
     if (PROPERTY == expressionType) {
         result.insert(variableName.substr(0, variableName.find('.')));

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -23,8 +23,8 @@ static void validateProjectionColumnNamesAreUnique(
 
 static void validateOnlyFunctionIsCountStar(vector<shared_ptr<LogicalExpression>>& expressions) {
     for (auto& expression : expressions) {
-        if (FUNCTION == expression->expressionType && COUNT_STAR == expression->variableName &&
-            1 != expressions.size()) {
+        if (FUNCTION == expression->expressionType &&
+            FUNCTION_COUNT_STAR == expression->variableName && expressions.size() != 1) {
             throw invalid_argument("The only function in the return clause should be COUNT(*).");
         }
     }

--- a/src/planner/include/logical_plan/operator/extend/logical_extend.h
+++ b/src/planner/include/logical_plan/operator/extend/logical_extend.h
@@ -1,14 +1,6 @@
 #pragma once
 
-#include <string>
-
-#include "src/common/include/types.h"
-#include "src/expression/include/logical/logical_rel_expression.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
-
-using namespace graphflow::expression;
-using namespace graphflow::common;
-using namespace std;
 
 namespace graphflow {
 namespace planner {
@@ -16,30 +8,26 @@ namespace planner {
 class LogicalExtend : public LogicalOperator {
 
 public:
-    LogicalExtend(const LogicalRelExpression& queryRel, const Direction& direction,
+    LogicalExtend(string boundNodeID, label_t boundNodeLabel, string nbrNodeID,
+        label_t nbrNodeLabel, label_t relLabel, Direction direction,
         shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, direction{direction} {
-        auto isFwd = FWD == direction;
-        boundNodeVarName = isFwd ? queryRel.getSrcNodeName() : queryRel.getDstNodeName();
-        boundNodeVarLabel = isFwd ? queryRel.srcNode->label : queryRel.dstNode->label;
-        nbrNodeVarName = isFwd ? queryRel.getDstNodeName() : queryRel.getSrcNodeName();
-        nbrNodeVarLabel = isFwd ? queryRel.dstNode->label : queryRel.srcNode->label;
-        relLabel = queryRel.label;
-    }
+        : LogicalOperator{prevOperator}, boundNodeID{move(boundNodeID)},
+          boundNodeLabel{boundNodeLabel}, nbrNodeID{move(nbrNodeID)},
+          nbrNodeLabel{nbrNodeLabel}, relLabel{relLabel}, direction{direction} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_EXTEND;
     }
 
     string getOperatorInformation() const override {
-        return boundNodeVarName + (direction == Direction::FWD ? "->" : "<-") + nbrNodeVarName;
+        return boundNodeID + (direction == Direction::FWD ? "->" : "<-") + nbrNodeID;
     }
 
 public:
-    string boundNodeVarName;
-    label_t boundNodeVarLabel;
-    string nbrNodeVarName;
-    label_t nbrNodeVarLabel;
+    string boundNodeID;
+    label_t boundNodeLabel;
+    string nbrNodeID;
+    label_t nbrNodeLabel;
     label_t relLabel;
     Direction direction;
 };

--- a/src/planner/include/logical_plan/operator/filter/logical_filter.h
+++ b/src/planner/include/logical_plan/operator/filter/logical_filter.h
@@ -1,12 +1,9 @@
 #pragma once
 
-#include "src/common/include/types.h"
 #include "src/expression/include/logical/logical_expression.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
 
 using namespace graphflow::expression;
-using namespace graphflow::common;
-using namespace std;
 
 namespace graphflow {
 namespace planner {

--- a/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
+++ b/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#include <string>
-#include <utility>
-
-#include "src/common/include/types.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
-
-using namespace graphflow::common;
-using namespace std;
 
 namespace graphflow {
 namespace planner {
@@ -15,9 +8,9 @@ namespace planner {
 class LogicalHashJoin : public LogicalOperator {
 
 public:
-    LogicalHashJoin(string joinNodeVarName, shared_ptr<LogicalOperator> buildSidePrevOperator,
+    LogicalHashJoin(string joinNodeID, shared_ptr<LogicalOperator> buildSidePrevOperator,
         shared_ptr<LogicalOperator> probeSidePrevOperator)
-        : LogicalOperator(move(probeSidePrevOperator)), joinNodeVarName(move(joinNodeVarName)),
+        : LogicalOperator(move(probeSidePrevOperator)), joinNodeID(move(joinNodeID)),
           buildSidePrevOperator(move(buildSidePrevOperator)) {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
@@ -34,10 +27,10 @@ public:
         return result;
     }
 
-    string getOperatorInformation() const override { return joinNodeVarName; }
+    string getOperatorInformation() const override { return joinNodeID; }
 
 public:
-    const string joinNodeVarName;
+    const string joinNodeID;
     const shared_ptr<LogicalOperator> buildSidePrevOperator;
 };
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
+++ b/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
@@ -1,11 +1,6 @@
 #pragma once
 
-#include <string>
-#include <vector>
-
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
-
-using namespace std;
 
 namespace graphflow {
 namespace planner {
@@ -13,17 +8,16 @@ namespace planner {
 class LogicalScanNodeID : public LogicalOperator {
 
 public:
-    LogicalScanNodeID(const string& variableName, label_t label)
-        : nodeVarName{variableName}, label{label} {}
+    LogicalScanNodeID(string nodeID, label_t label) : nodeID{move(nodeID)}, label{label} {}
 
     LogicalOperatorType getLogicalOperatorType() const {
         return LogicalOperatorType::LOGICAL_SCAN_NODE_ID;
     }
 
-    string getOperatorInformation() const override { return nodeVarName; }
+    string getOperatorInformation() const override { return nodeID; }
 
 public:
-    const string nodeVarName;
+    const string nodeID;
     const label_t label;
 };
 

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <string>
-
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
-
-using namespace std;
 
 namespace graphflow {
 namespace planner {
@@ -12,20 +8,21 @@ namespace planner {
 class LogicalScanNodeProperty : public LogicalOperator {
 
 public:
-    LogicalScanNodeProperty(const string& nodeVarName, label_t nodeLabel,
-        const string& propertyName, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, nodeVarName{nodeVarName}, nodeLabel{nodeLabel},
-          propertyName{propertyName} {}
+    LogicalScanNodeProperty(string nodeID, label_t nodeLabel, string nodeName, string propertyName,
+        shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{prevOperator}, nodeID{move(nodeID)}, nodeName{move(nodeName)},
+          nodeLabel{nodeLabel}, propertyName{move(propertyName)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_SCAN_NODE_PROPERTY;
     }
 
-    string getOperatorInformation() const override { return nodeVarName + "." + propertyName; }
+    string getOperatorInformation() const override { return nodeName + "." + propertyName; }
 
 public:
-    const string nodeVarName;
-    label_t nodeLabel;
+    const string nodeID;
+    const string nodeName;
+    const label_t nodeLabel;
     const string propertyName;
 };
 

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
@@ -1,14 +1,6 @@
 #pragma once
 
-#include <string>
-
-#include "src/common/include/types.h"
-#include "src/expression/include/logical/logical_rel_expression.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
-
-using namespace graphflow::expression;
-using namespace graphflow::common;
-using namespace std;
 
 namespace graphflow {
 namespace planner {
@@ -16,17 +8,13 @@ namespace planner {
 class LogicalScanRelProperty : public LogicalOperator {
 
 public:
-    LogicalScanRelProperty(const LogicalRelExpression& queryRel, Direction direction,
-        const string& propertyName, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, direction{direction}, propertyName{propertyName} {
-        auto isFwd = FWD == direction;
-        boundNodeVarName = isFwd ? queryRel.getSrcNodeName() : queryRel.getDstNodeName();
-        boundNodeVarLabel = isFwd ? queryRel.srcNode->label : queryRel.dstNode->label;
-        nbrNodeVarName = isFwd ? queryRel.getDstNodeName() : queryRel.getSrcNodeName();
-        nbrNodeVarLabel = isFwd ? queryRel.dstNode->label : queryRel.srcNode->label;
-        relName = queryRel.name;
-        relLabel = queryRel.label;
-    }
+    LogicalScanRelProperty(string boundNodeID, label_t boundNodeLabel, string nbrNodeID,
+        label_t nbrNodeLabel, string relName, label_t relLabel, Direction direction,
+        string propertyName, shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{prevOperator}, boundNodeID{move(boundNodeID)},
+          boundNodeLabel{boundNodeLabel}, nbrNodeID{move(nbrNodeID)}, nbrNodeLabel{nbrNodeLabel},
+          relName{move(relName)}, relLabel{relLabel}, direction{direction}, propertyName{move(
+                                                                                propertyName)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_SCAN_REL_PROPERTY;
@@ -35,10 +23,10 @@ public:
     string getOperatorInformation() const override { return relName + "." + propertyName; }
 
 public:
-    string boundNodeVarName;
-    label_t boundNodeVarLabel;
-    string nbrNodeVarName;
-    label_t nbrNodeVarLabel;
+    string boundNodeID;
+    label_t boundNodeLabel;
+    string nbrNodeID;
+    label_t nbrNodeLabel;
     string relName;
     label_t relLabel;
     Direction direction;

--- a/src/testing/test_helper.cpp
+++ b/src/testing/test_helper.cpp
@@ -95,7 +95,7 @@ bool TestHelper::runExceptionTest(const string& path) {
         try {
             auto plans = server->enumerateLogicalPlans(testConfig.query[i]);
             spdlog::error(
-                "QUERY: {} NOT PASSED. Expect exception to be thrown.", testConfig.query[i]);
+                "QUERY: {} NOT PASSED. Expect malformed to be thrown.", testConfig.query[i]);
         } catch (const invalid_argument& exception) {
             if (testConfig.expectedErrorMsgs[i] != exception.what()) {
                 spdlog::error("QUERY: {} NOT PASSED. Expect error message {} but get {}.",

--- a/test/parser/where_test.cpp
+++ b/test/parser/where_test.cpp
@@ -33,6 +33,21 @@ public:
     }
 };
 
+TEST_F(WhereTest, FilterIDComparisonTest) {
+    auto a = make_unique<ParsedExpression>(VARIABLE, "a", EMPTY);
+    auto aID = make_unique<ParsedExpression>(FUNCTION, "id", EMPTY);
+    aID->children.push_back(move(a));
+    auto b = make_unique<ParsedExpression>(VARIABLE, "b", EMPTY);
+    auto bID = make_unique<ParsedExpression>(FUNCTION, "id", EMPTY);
+    bID->children.push_back(move(b));
+    auto where = make_unique<ParsedExpression>(EQUALS, EMPTY, EMPTY, move(aID), move(bID));
+
+    graphflow::parser::Parser parser;
+    string input = "MATCH () WHERE id(a) = id(b) RETURN *;";
+    auto singleQuery = parser.parseQuery(input);
+    ASSERT_TRUE(ParserTestUtils::equals(*where, *singleQuery->matchStatements[0]->whereClause));
+}
+
 TEST_F(WhereTest, FilterBooleanConnectionTest) {
     auto aIsStudent = makeAIsStudentExpression();
     auto bIsMale = makeBIsMaleExpression();

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -22,12 +22,14 @@ cc_test(
 filegroup(
     name = "testfiles",
     srcs = [
-        "queries/exception/exception.test",
+        "queries/filtered/id_comparison.test",
         "queries/filtered/nodes.test",
         "queries/filtered/paths.test",
         "queries/filtered/stars.test",
         "queries/filtered/str_operations.test",
         "queries/filtered/unstructured_properties.test",
+        "queries/malformed/binder.test",
+        "queries/malformed/expression_binder.test",
         "queries/structural/nodes.test",
         "queries/structural/paths.test",
         "queries/structural/stars.test",

--- a/test/runner/end_to_end_test.cpp
+++ b/test/runner/end_to_end_test.cpp
@@ -4,9 +4,15 @@
 
 using namespace graphflow::testing;
 
-TEST(FrontEndTest, ExceptionQueries) {
+TEST(FrontEndTest, BinderException) {
     TestHelper testHelper;
-    ASSERT_TRUE(testHelper.runExceptionTest("test/runner/queries/exception/exception.test"));
+    ASSERT_TRUE(testHelper.runExceptionTest("test/runner/queries/malformed/binder.test"));
+}
+
+TEST(FrontEndTest, ExpressionBinderException) {
+    TestHelper testHelper;
+    ASSERT_TRUE(
+        testHelper.runExceptionTest("test/runner/queries/malformed/expression_binder.test"));
 }
 
 TEST(ProcessorTest, StructuralNodeQueries) {
@@ -47,4 +53,9 @@ TEST(ProcessorTest, StrOperations) {
 TEST(ProcessorTest, UnstructuredOperations) {
     TestHelper testHelper;
     ASSERT_TRUE(testHelper.runTest("test/runner/queries/filtered/unstructured_properties.test"));
+}
+
+TEST(ProcessorTest, IDComparisonQueries) {
+    TestHelper testHelper;
+    ASSERT_TRUE(testHelper.runTest("test/runner/queries/filtered/id_comparison.test"));
 }

--- a/test/runner/queries/filtered/id_comparison.test
+++ b/test/runner/queries/filtered/id_comparison.test
@@ -1,0 +1,29 @@
+# description: test node ID comparison
+
+-INPUT dataset/tinysnb/
+-OUTPUT test/unittest_temp/
+-PARALLELISM 1
+
+-NAME TwoHopKnowsIDEqualTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE id(a) = id(c) RETURN COUNT(*)
+---- 12
+
+-NAME TwoHopKnowsIDEqualTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE id(a) <> id(c) RETURN COUNT(*)
+---- 24
+
+-NAME TwoHopKnowsIDGreaterThanTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE id(a) > id(b) RETURN COUNT(*)
+---- 6
+
+-NAME TwoHopKnowsIDGreaterThanEqualsTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE id(a) >= id(c) RETURN COUNT(*)
+---- 24
+
+-NAME TwoHopKnowsIDLessThanTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE id(a) < id(b) RETURN COUNT(*)
+---- 8
+
+-NAME TwoHopKnowsIDLessThanEqualsTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE id(a) <= id(c) RETURN COUNT(*)
+---- 24

--- a/test/runner/queries/malformed/binder.test
+++ b/test/runner/queries/malformed/binder.test
@@ -1,10 +1,8 @@
-# description: front-end exception
+# description: binder exception
 
 -INPUT dataset/tinysnb/
 -OUTPUT test/unittest_temp/
 -PARALLELISM 1
-
-# Binder Exception Tests
 
 -NAME DisconnectedGraph
 -QUERY MATCH (a:person), (b:person) RETURN COUNT(*);
@@ -49,21 +47,3 @@
 -NAME BindToDifferentVariableType
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a.age + 1 AS a MATCH (a) RETURN *;
 -EXCEPTION a defined with conflicting type INT32 (expect NODE).
-
-# Expression Binder Exception Tests
-
--NAME BindVariableNotInScope1
--QUERY WITH a MATCH (a:person)-[e1:knows]->(b:person) RETURN *;
--EXCEPTION Variable a not defined.
-
--NAME BindVariableNotInScope2
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.age > foo RETURN *;
--EXCEPTION Variable foo not defined.
-
--NAME BindPropertyLookUpOnExpression
--QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN (a.age + 2).age;
--EXCEPTION Type mismatch: expect NODE or REL, but a.age + 2 was INT32.
-
--NAME BindPropertyNotExist
--QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN a.foo;
--EXCEPTION Node a does not have property foo.

--- a/test/runner/queries/malformed/expression_binder.test
+++ b/test/runner/queries/malformed/expression_binder.test
@@ -1,0 +1,25 @@
+# description: expression binder exception
+
+-INPUT dataset/tinysnb/
+-OUTPUT test/unittest_temp/
+-PARALLELISM 1
+
+-NAME BindVariableNotInScope1
+-QUERY WITH a MATCH (a:person)-[e1:knows]->(b:person) RETURN *;
+-EXCEPTION Variable a not defined.
+
+-NAME BindVariableNotInScope2
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.age > foo RETURN *;
+-EXCEPTION Variable foo not defined.
+
+-NAME BindPropertyLookUpOnExpression
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN (a.age + 2).age;
+-EXCEPTION Type mismatch: expect NODE or REL, but a.age + 2 was INT32.
+
+-NAME BindPropertyNotExist
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN a.foo;
+-EXCEPTION Node a does not have property foo.
+
+-NAME BindIDArithmetic
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE id(a) + 1 < id(b) RETURN *;
+-EXCEPTION id(a) has data type NODE_ID. A numerical data type was expected.


### PR DESCRIPTION
This PR add node id comparison support for front-end and should solve issue #102  and issue #127
Example `MATCH (a)->(b) WHERE id(a) = id(b) RETURN *`
- `id(a)` binds to a logical property expression `a._id`
- Change back-end node value vector name from `a` to `a._id`
  -  Scan(a) -> Scan(a._id)
  -  Extend(a to b) -> Extend(a._id to b._id) 
  -  ScanNodePR(a.name from a) -> ScanNodeProperty(a.name from a._id)
- Rewrite self loop edge `(a)->(a)` as `(a)->(anonymou) WHERE a._id = anonymous._id`

