### PR TITLE
update exception msg, add multi-part tests

### DIFF
--- a/src/expression/include/logical/logical_expression.h
+++ b/src/expression/include/logical/logical_expression.h
@@ -34,7 +34,9 @@ public:
 
     inline const LogicalExpression& getChildExpr(uint64_t pos) const { return *childrenExpr[pos]; }
 
-    inline const string getName() const { return alias.empty() ? rawExpression : alias; }
+    inline const string getAliasElseRawExpression() const {
+        return alias.empty() ? rawExpression : alias;
+    }
 
     unordered_set<string> getIncludedVariables() const;
 

--- a/src/planner/include/logical_plan/operator/projection/logical_projection.h
+++ b/src/planner/include/logical_plan/operator/projection/logical_projection.h
@@ -19,9 +19,9 @@ public:
     }
 
     string getOperatorInformation() const override {
-        auto result = expressionsToProject[0]->getName();
+        auto result = expressionsToProject[0]->getAliasElseRawExpression();
         for (auto i = 1u; i < expressionsToProject.size(); ++i) {
-            result += ", " + expressionsToProject[i]->getName();
+            result += ", " + expressionsToProject[i]->getAliasElseRawExpression();
         }
         return result;
     }

--- a/src/testing/include/test_helper.h
+++ b/src/testing/include/test_helper.h
@@ -18,11 +18,14 @@ struct TestSuiteConfig {
     vector<string> query;
     vector<uint64_t> expectedNumTuples;
     vector<vector<string>> expectedTuples;
+    vector<string> expectedErrorMsgs;
 };
 
 class TestHelper {
 public:
     static bool runTest(const string& path);
+
+    static bool runExceptionTest(const string& path);
 
 private:
     static TestSuiteConfig parseTestFile(const string& path);

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -22,6 +22,7 @@ cc_test(
 filegroup(
     name = "testfiles",
     srcs = [
+        "queries/exception/exception.test",
         "queries/filtered/nodes.test",
         "queries/filtered/paths.test",
         "queries/filtered/stars.test",

--- a/test/runner/end_to_end_test.cpp
+++ b/test/runner/end_to_end_test.cpp
@@ -4,6 +4,11 @@
 
 using namespace graphflow::testing;
 
+TEST(FrontEndTest, ExceptionQueries) {
+    TestHelper testHelper;
+    ASSERT_TRUE(testHelper.runExceptionTest("test/runner/queries/exception/exception.test"));
+}
+
 TEST(ProcessorTest, StructuralNodeQueries) {
     TestHelper testHelper;
     ASSERT_TRUE(testHelper.runTest("test/runner/queries/structural/nodes.test"));

--- a/test/runner/queries/exception/exception.test
+++ b/test/runner/queries/exception/exception.test
@@ -1,0 +1,69 @@
+# description: front-end exception
+
+-INPUT dataset/tinysnb/
+-OUTPUT test/unittest_temp/
+-PARALLELISM 1
+
+# Binder Exception Tests
+
+-NAME DisconnectedGraph
+-QUERY MATCH (a:person), (b:person) RETURN COUNT(*);
+-EXCEPTION Disconnect query graph is not supported.
+
+-NAME DisconnectedGraph2
+-QUERY MATCH (a:person) WITH * MATCH (b:person) RETURN COUNT(*);
+-EXCEPTION Disconnect query graph is not supported.
+
+-NAME NodeLabelNotExist
+-QUERY MATCH (a:PERSON) RETURN COUNT(*);
+-EXCEPTION Node label PERSON does not exist.
+
+-NAME RelLabelNotExist
+-QUERY MATCH (a:person)-[e1:KNOWS]->(b:person) RETURN COUNT(*);
+-EXCEPTION Rel label KNOWS does not exist.
+
+-NAME NodeRelNotConnect
+-QUERY MATCH (a:person)-[e1:workAt]->(b:person) RETURN COUNT(*);
+-EXCEPTION Node b doesn't connect to edge with same type as e1.
+
+-NAME RepeatedRelName
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)<-[e1:knows]-(:person) RETURN COUNT(*);
+-EXCEPTION Bind relationship e1 to relationship with same name is not supported.
+
+-NAME RepeatedReturnColumnName1
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN a.age AS b, b;
+-EXCEPTION Multiple result column with the same name b are not supported.
+
+-NAME RepeatedReturnColumnName2
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN *, e1;
+-EXCEPTION Multiple result column with the same name e1 are not supported.
+
+-NAME WITHExpressionAliased
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a.age RETURN *;
+-EXCEPTION Expression in WITH multi be aliased (use AS).
+
+-NAME BindToDifferentVariableType1
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH e1 AS a MATCH (a) RETURN *;
+-EXCEPTION a defined with conflicting type REL (expect NODE).
+
+-NAME BindToDifferentVariableType
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a.age + 1 AS a MATCH (a) RETURN *;
+-EXCEPTION a defined with conflicting type INT32 (expect NODE).
+
+# Expression Binder Exception Tests
+
+-NAME BindVariableNotInScope1
+-QUERY WITH a MATCH (a:person)-[e1:knows]->(b:person) RETURN *;
+-EXCEPTION Variable a not defined.
+
+-NAME BindVariableNotInScope2
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.age > foo RETURN *;
+-EXCEPTION Variable foo not defined.
+
+-NAME BindPropertyLookUpOnExpression
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN (a.age + 2).age;
+-EXCEPTION Type mismatch: expect NODE or REL, but a.age + 2 was INT32.
+
+-NAME BindPropertyNotExist
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) RETURN a.foo;
+-EXCEPTION Node a does not have property foo.

--- a/test/runner/queries/filtered/nodes.test
+++ b/test/runner/queries/filtered/nodes.test
@@ -4,8 +4,12 @@
 -OUTPUT test/unittest_temp/
 -PARALLELISM 1
 
--NAME PersonNodesAgeFilteredTest
+-NAME PersonNodesAgeFilteredTest1
 -QUERY MATCH (a:person) WHERE a.age <= 25 RETURN COUNT(*)
+---- 3
+
+-NAME PersonNodesAgeFilteredTest2
+-QUERY WITH 25 AS foo WITH foo AS age MATCH (a:person) WHERE a.age <= age RETURN COUNT(*)
 ---- 3
 
 -NAME PersonNodesIsWorkerFilteredTest
@@ -22,4 +26,8 @@
 
 -NAME PersonNodesGenderFilteredTest2
 -QUERY MATCH (a:person) WHERE (a.gender*3.5 = 7.0) RETURN COUNT(*)
+---- 4
+
+-NAME PersonNodesGenderFilteredTest3
+-QUERY WITH 3.5 AS threshold MATCH (a:person) WHERE (a.gender*threshold = 7.0) RETURN COUNT(*)
 ---- 4

--- a/test/runner/queries/filtered/paths.test
+++ b/test/runner/queries/filtered/paths.test
@@ -16,10 +16,22 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE (a.gender/2 <= 0.5) AND (b.gender*3.5 = 7.0) RETURN COUNT(*)
 ---- 6
 
+-NAME OneHopKnowsFilteredTest4
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE (a.gender/2 <= 0.5) WITH b WHERE b.gender*3.5 = 7.0 RETURN COUNT(*)
+---- 6
+
 -NAME TwoHopKnowsFilteredTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE a.age = c.age RETURN COUNT(*)
 ---- 12
 
--NAME TwoHopKnowsFilteredTwoQueryPartsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH * MATCH (b)-[e2:knows]->(c:person) WHERE a.age = c.age RETURN COUNT(*)
+-NAME TwoHopKnowsFilteredTest2
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b, a.age AS foo MATCH (b)-[e2:knows]->(c:person) WHERE foo = c.age RETURN COUNT(*)
+---- 12
+
+-NAME TwoHopKnowsFilteredTest3
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b AS d, a.age AS foo MATCH (d)-[e2:knows]->(a:person) WHERE foo = a.age RETURN COUNT(*)
+---- 12
+
+-NAME TwoHopKnowsFilteredTest4
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b AS d, a.age * 2.0 AS foo MATCH (d)-[e2:knows]->(a:person) WHERE foo = a.age * 2.0 RETURN COUNT(*)
 ---- 12

--- a/test/runner/queries/structural/paths.test
+++ b/test/runner/queries/structural/paths.test
@@ -20,7 +20,7 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) RETURN COUNT(*)
 ---- 36
 
--NAME TwoHopKnowsTwoQueryPartsTest
+-NAME TwoHopKnowsTest2
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b MATCH (b)-[e2:knows]->(c:person) RETURN COUNT(*)
 ---- 36
 
@@ -40,7 +40,7 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:studyAt]->(d:organisation) RETURN COUNT(*)
 ---- 18
 
--NAME ThreeHopTwoKnowsOneStudyAtTwoQueryPartsTest
+-NAME ThreeHopTwoKnowsOneStudyAtTest2
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH * MATCH (b)-[e2:knows]->(c:person)-[e3:studyAt]->(d:organisation) RETURN COUNT(*)
 ---- 18
 
@@ -48,6 +48,6 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:workAt]->(d:organisation) RETURN COUNT(*)
 ---- 18
 
--NAME ThreeHopTwoKnowsOneWorkAtTwoQueryPartsTest
+-NAME ThreeHopTwoKnowsOneWorkAtTest2
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WITH * MATCH (c)-[e3:workAt]->(d:organisation) RETURN COUNT(*)
 ---- 18

--- a/test/runner/queries/structural/stars.test
+++ b/test/runner/queries/structural/stars.test
@@ -44,6 +44,6 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person),(a:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
 ---- 324
 
--NAME OpenTwoHopWedgeKnowsThreeQueryPartsTest
+-NAME OpenTwoHopWedgeKnowsTest3
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH * MATCH (b)-[e2:knows]->(c:person) WITH * MATCH (a)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
 ---- 324


### PR DESCRIPTION
This PR add end to end tests for multi part queries and modify error message according to Neo4j,

Bug fix
- Avoid enumeration if first query part does not have a match statement
  - Example: `WITH 1 AS one MATCH ...` 
- Expression in with statement must have alias
  - Example `... WITH a.age + 2` is invalid
 
 