### PR TITLE
Add better error message for parser

### DIFF
--- a/src/antlr4/BUILD.bazel
+++ b/src/antlr4/BUILD.bazel
@@ -7,61 +7,37 @@ genrule(
         "@antlr4-complete//jar",
     ],
     outs = [
-        "CypherBaseListener.cpp",
-        "CypherBaseListener.h",
-        "CypherBaseVisitor.cpp",
-        "CypherBaseVisitor.h",
         "Cypher.interp",
         "CypherLexer.cpp",
         "CypherLexer.h",
         "CypherLexer.interp",
         "CypherLexer.tokens",
-        "CypherListener.cpp",
-        "CypherListener.h",
         "CypherParser.cpp",
         "CypherParser.h",
         "Cypher.tokens",
-        "CypherVisitor.cpp",
-        "CypherVisitor.h",
     ],
     cmd = """
-    java -jar $(location @antlr4-complete//jar) -Dlanguage=Cpp -visitor $(location Cypher.g4) -o $(RULEDIR) \
-        && mv $(RULEDIR)/src/antlr4/CypherBaseListener.cpp $(location CypherBaseListener.cpp) \
-        && mv $(RULEDIR)/src/antlr4/CypherBaseListener.h $(location CypherBaseListener.h) \
-        && mv $(RULEDIR)/src/antlr4/CypherBaseVisitor.cpp $(location CypherBaseVisitor.cpp) \
-        && mv $(RULEDIR)/src/antlr4/CypherBaseVisitor.h $(location CypherBaseVisitor.h) \
+    java -jar $(location @antlr4-complete//jar) -Dlanguage=Cpp -no-visitor -no-listener $(location Cypher.g4) -o $(RULEDIR) \
         && mv $(RULEDIR)/src/antlr4/Cypher.interp $(location Cypher.interp) \
         && mv $(RULEDIR)/src/antlr4/CypherLexer.cpp $(location CypherLexer.cpp) \
         && mv $(RULEDIR)/src/antlr4/CypherLexer.h $(location CypherLexer.h) \
         && mv $(RULEDIR)/src/antlr4/CypherLexer.interp $(location CypherLexer.interp) \
         && mv $(RULEDIR)/src/antlr4/CypherLexer.tokens $(location CypherLexer.tokens) \
-        && mv $(RULEDIR)/src/antlr4/CypherListener.cpp $(location CypherListener.cpp) \
-        && mv $(RULEDIR)/src/antlr4/CypherListener.h $(location CypherListener.h) \
         && mv $(RULEDIR)/src/antlr4/CypherParser.cpp $(location CypherParser.cpp) \
         && mv $(RULEDIR)/src/antlr4/CypherParser.h $(location CypherParser.h) \
         && mv $(RULEDIR)/src/antlr4/Cypher.tokens $(location Cypher.tokens) \
-        && mv $(RULEDIR)/src/antlr4/CypherVisitor.cpp $(location CypherVisitor.cpp) \
-        && mv $(RULEDIR)/src/antlr4/CypherVisitor.h $(location CypherVisitor.h) \
     """,
 )
 
 cc_library(
     name = "cypher_grammar_lib",
     srcs = [
-        "CypherBaseListener.cpp",
-        "CypherBaseVisitor.cpp",
         "CypherLexer.cpp",
-        "CypherListener.cpp",
         "CypherParser.cpp",
-        "CypherVisitor.cpp",
     ],
     hdrs = [
-        "CypherBaseListener.h",
-        "CypherBaseVisitor.h",
         "CypherLexer.h",
-        "CypherListener.h",
         "CypherParser.h",
-        "CypherVisitor.h",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -3,10 +3,16 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "parser",
     srcs = [
+        "antlr_parser/graphflow_cypher_parser.cpp",
+        "antlr_parser/parser_error_listener.cpp",
+        "antlr_parser/parser_error_strategy.cpp",
         "parser.cpp",
         "transformer.cpp",
     ],
     hdrs = [
+        "include/antlr_parser/graphflow_cypher_parser.h",
+        "include/antlr_parser/parser_error_listener.h",
+        "include/antlr_parser/parser_error_strategy.h",
         "include/parser.h",
         "include/transformer.h",
     ],

--- a/src/parser/antlr_parser/graphflow_cypher_parser.cpp
+++ b/src/parser/antlr_parser/graphflow_cypher_parser.cpp
@@ -1,0 +1,40 @@
+#include "src/parser/include/antlr_parser/graphflow_cypher_parser.h"
+
+#include <string>
+
+using namespace std;
+
+namespace graphflow {
+namespace parser {
+
+void GraphflowCypherParser::notifyQueryNotConcludeWithReturn(antlr4::Token* startToken) {
+    auto errorMsg = "Query must conclude with RETURN clause";
+    notifyErrorListeners(startToken, errorMsg, nullptr);
+}
+
+void GraphflowCypherParser::notifyNodePatternWithoutParentheses(
+    std::string nodeName, antlr4::Token* startToken) {
+    auto errorMsg =
+        "Parentheses are required to identify nodes in patterns, i.e. (" + nodeName + ")";
+    notifyErrorListeners(startToken, errorMsg, nullptr);
+}
+
+void GraphflowCypherParser::notifyInvalidNotEqualOperator(antlr4::Token* startToken) {
+    auto errorMsg = "Unknown operation '!=' (you probably meant to use '<>', which is the operator "
+                    "for inequality testing.)";
+    notifyErrorListeners(startToken, errorMsg, nullptr);
+}
+
+void GraphflowCypherParser::notifyEmptyToken(antlr4::Token* startToken) {
+    auto errorMsg =
+        "'' is not a valid token name. Token names cannot be empty or contain any null-bytes";
+    notifyErrorListeners(startToken, errorMsg, nullptr);
+}
+
+void GraphflowCypherParser::notifyReturnNotAtEnd(antlr4::Token* startToken) {
+    auto errorMsg = "RETURN can only be used at the end of the query";
+    notifyErrorListeners(startToken, errorMsg, nullptr);
+}
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/antlr_parser/parser_error_listener.cpp
+++ b/src/parser/antlr_parser/parser_error_listener.cpp
@@ -1,0 +1,45 @@
+#include "src/parser/include/antlr_parser/parser_error_listener.h"
+
+namespace graphflow {
+namespace parser {
+
+static vector<string> splitString(const string& str, const string& delimiter);
+
+void ParserErrorListener::syntaxError(Recognizer* recognizer, Token* offendingSymbol, size_t line,
+    size_t charPositionInLine, const std::string& msg, std::exception_ptr e) {
+    auto finalError = msg + " (line: " + to_string(line) +
+                      ", offset: " + to_string(charPositionInLine) + ")\n" +
+                      formatUnderLineError(*recognizer, *offendingSymbol, line, charPositionInLine);
+    throw invalid_argument(finalError);
+}
+
+string ParserErrorListener::formatUnderLineError(
+    Recognizer& recognizer, const Token& offendingToken, size_t line, size_t charPositionInLine) {
+    auto tokens = (CommonTokenStream*)recognizer.getInputStream();
+    auto input = tokens->getTokenSource()->getInputStream()->toString();
+    auto errorLine = splitString(input, "\n")[line - 1];
+    auto underLine = string(" ");
+    for (auto i = 0u; i < charPositionInLine; ++i) {
+        underLine += " ";
+    }
+    for (auto i = offendingToken.getStartIndex(); i <= offendingToken.getStopIndex(); ++i) {
+        underLine += "^";
+    }
+    return "\"" + errorLine + "\"\n" + underLine;
+}
+
+vector<string> splitString(const string& str, const string& delimiter) {
+    auto strings = vector<string>();
+    auto prevPos = 0u;
+    auto currentPos = str.find(delimiter, prevPos);
+    while (currentPos != string::npos) {
+        strings.push_back(str.substr(prevPos, currentPos - prevPos));
+        prevPos = currentPos + 1;
+        currentPos = str.find(delimiter, prevPos);
+    }
+    strings.push_back(str.substr(prevPos));
+    return strings;
+}
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/antlr_parser/parser_error_strategy.cpp
+++ b/src/parser/antlr_parser/parser_error_strategy.cpp
@@ -1,0 +1,21 @@
+#include "src/parser/include/antlr_parser/parser_error_strategy.h"
+
+namespace graphflow {
+namespace parser {
+
+void ParserErrorStrategy::reportNoViableAlternative(
+    Parser* recognizer, const NoViableAltException& e) {
+    auto tokens = recognizer->getTokenStream();
+    auto errorMsg =
+        tokens ?
+            Token::EOF == e.getStartToken()->getType() ?
+            "Unexpected end of input" :
+            "Invalid input <" + tokens->getText(e.getStartToken(), e.getOffendingToken()) + ">" :
+            "Unknown input";
+    auto expectedRuleName = recognizer->getRuleNames()[recognizer->getContext()->getRuleIndex()];
+    errorMsg += ": expected rule " + expectedRuleName;
+    recognizer->notifyErrorListeners(e.getOffendingToken(), errorMsg, make_exception_ptr(e));
+}
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/antlr_parser/graphflow_cypher_parser.h
+++ b/src/parser/include/antlr_parser/graphflow_cypher_parser.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "src/antlr4/CypherParser.h"
+
+namespace graphflow {
+namespace parser {
+
+class GraphflowCypherParser : public CypherParser {
+public:
+    explicit GraphflowCypherParser(antlr4::TokenStream* input) : CypherParser(input) {}
+
+    void notifyQueryNotConcludeWithReturn(antlr4::Token* startToken) override;
+
+    void notifyNodePatternWithoutParentheses(
+        std::string nodeName, antlr4::Token* startToken) override;
+
+    void notifyInvalidNotEqualOperator(antlr4::Token* startToken) override;
+
+    void notifyEmptyToken(antlr4::Token* startToken) override;
+
+    void notifyReturnNotAtEnd(antlr4::Token* startToken) override;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/antlr_parser/parser_error_listener.h
+++ b/src/parser/include/antlr_parser/parser_error_listener.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <string>
+
+#include "antlr4-runtime.h"
+
+using namespace std;
+using namespace antlr4;
+
+namespace graphflow {
+namespace parser {
+
+class ParserErrorListener : public BaseErrorListener {
+
+public:
+    void syntaxError(Recognizer* recognizer, Token* offendingSymbol, size_t line,
+        size_t charPositionInLine, const std::string& msg, std::exception_ptr e) override;
+
+private:
+    string formatUnderLineError(Recognizer& recognizer, const Token& offendingToken, size_t line,
+        size_t charPositionInLine);
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/antlr_parser/parser_error_strategy.h
+++ b/src/parser/include/antlr_parser/parser_error_strategy.h
@@ -1,0 +1,18 @@
+#include <string>
+
+#include "antlr4-runtime.h"
+
+using namespace antlr4;
+using namespace std;
+
+namespace graphflow {
+namespace parser {
+
+class ParserErrorStrategy : public DefaultErrorStrategy {
+
+protected:
+    virtual void reportNoViableAlternative(Parser* recognizer, const NoViableAltException& e);
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/parser.h
+++ b/src/parser/include/parser.h
@@ -1,10 +1,4 @@
-#include "antlr4-runtime.h"
-
-#include "src/antlr4/CypherLexer.h"
-#include "src/antlr4/CypherParser.h"
-#include "src/parser/include/transformer.h"
-
-using namespace antlr4;
+#include "src/parser/include/queries/single_query.h"
 
 namespace graphflow {
 namespace parser {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -1,17 +1,30 @@
 #include "src/parser/include/parser.h"
 
+#include "src/antlr4/CypherLexer.h"
+#include "src/parser/include/antlr_parser/graphflow_cypher_parser.h"
+#include "src/parser/include/antlr_parser/parser_error_listener.h"
+#include "src/parser/include/antlr_parser/parser_error_strategy.h"
+#include "src/parser/include/transformer.h"
+
+using namespace antlr4;
+
 namespace graphflow {
 namespace parser {
 
 unique_ptr<SingleQuery> Parser::parseQuery(string query) {
-    ANTLRInputStream inputStream(query);
-    CypherLexer cypherLexer(&inputStream);
-    CommonTokenStream tokens(&cypherLexer);
+    auto inputStream = ANTLRInputStream(query);
+    auto parserErrorListener = ParserErrorListener();
+
+    auto cypherLexer = CypherLexer(&inputStream);
+    cypherLexer.addErrorListener(&parserErrorListener);
+    auto tokens = CommonTokenStream(&cypherLexer);
     tokens.fill();
 
-    CypherParser cypherParser(&tokens);
+    auto graphflowCypherParser = GraphflowCypherParser(&tokens);
+    graphflowCypherParser.addErrorListener(&parserErrorListener);
+    graphflowCypherParser.setErrorHandler(make_shared<ParserErrorStrategy>());
 
-    Transformer transformer(*cypherParser.oC_Cypher());
+    Transformer transformer(*graphflowCypherParser.oC_Cypher());
     return transformer.transform();
 }
 

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -147,6 +147,10 @@ vector<shared_ptr<LogicalExpression>> Binder::bindProjectExpressions(
     auto expressionBinder = make_unique<ExpressionBinder>(variablesInScope, catalog);
     auto expressions = vector<shared_ptr<LogicalExpression>>();
     if (projectStar) {
+        if (variablesInScope.empty()) {
+            throw invalid_argument(
+                "RETURN or WITH * is not allowed when there are no variables in scope.");
+        }
         for (auto& [name, expression] : variablesInScope) {
             expressions.push_back(expression);
         }

--- a/src/testing/test_helper.cpp
+++ b/src/testing/test_helper.cpp
@@ -137,6 +137,9 @@ TestSuiteConfig TestHelper::parseTestFile(const string& path) {
                     config.query.push_back(line.substr(7, line.length()));
                 } else if (line.starts_with("-EXCEPTION")) {
                     config.expectedErrorMsgs.push_back(line.substr(11, line.length()));
+                } else if (line.starts_with("-CONTINUE_EXCEPTION")) {
+                    auto& errorMsg = config.expectedErrorMsgs[config.expectedErrorMsgs.size() - 1];
+                    errorMsg += "\n" + line.substr(20, line.length());
                 } else if (line.starts_with("----")) {
                     uint64_t numTuples = stoi(line.substr(5, line.length()));
                     config.expectedNumTuples.push_back(numTuples);

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
         "queries/filtered/unstructured_properties.test",
         "queries/malformed/binder.test",
         "queries/malformed/expression_binder.test",
+        "queries/malformed/syntax.test",
         "queries/structural/nodes.test",
         "queries/structural/paths.test",
         "queries/structural/stars.test",

--- a/test/runner/end_to_end_test.cpp
+++ b/test/runner/end_to_end_test.cpp
@@ -4,7 +4,12 @@
 
 using namespace graphflow::testing;
 
-TEST(FrontEndTest, BinderException) {
+TEST(FrontEndTest, SyntaxExceptionQueries) {
+    TestHelper testHelper;
+    ASSERT_TRUE(testHelper.runExceptionTest("test/runner/queries/malformed/syntax.test"));
+}
+
+TEST(FrontEndTest, ExceptionQueries) {
     TestHelper testHelper;
     ASSERT_TRUE(testHelper.runExceptionTest("test/runner/queries/malformed/binder.test"));
 }

--- a/test/runner/queries/malformed/binder.test
+++ b/test/runner/queries/malformed/binder.test
@@ -47,3 +47,7 @@
 -NAME BindToDifferentVariableType
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a.age + 1 AS a MATCH (a) RETURN *;
 -EXCEPTION a defined with conflicting type INT32 (expect NODE).
+
+-NAME BindEmptyStar
+-QUERY RETURN *;
+-EXCEPTION RETURN or WITH * is not allowed when there are no variables in scope.

--- a/test/runner/queries/malformed/syntax.test
+++ b/test/runner/queries/malformed/syntax.test
@@ -1,0 +1,53 @@
+# description: syntax exception
+
+-INPUT dataset/tinysnb/
+-OUTPUT test/unittest_temp/
+-PARALLELISM 1
+
+-NAME QueryNotConcludeWithReturn1
+-QUERY MATCH (a:person);
+-EXCEPTION Query must conclude with RETURN clause (line: 1, offset: 0)
+-CONTINUE_EXCEPTION "MATCH (a:person);"
+-CONTINUE_EXCEPTION  ^^^^^
+
+-NAME QueryNotConcludeWithReturn2
+-QUERY MATCH (a:person) WITH *;
+-EXCEPTION Query must conclude with RETURN clause (line: 1, offset: 23)
+-CONTINUE_EXCEPTION "MATCH (a:person) WITH *;"
+-CONTINUE_EXCEPTION                         ^
+
+-NAME QueryNotConcludeWithReturn3
+-QUERY MATCH (a:person) WITH a MATCH (a);
+-EXCEPTION Query must conclude with RETURN clause (line: 1, offset: 24)
+-CONTINUE_EXCEPTION "MATCH (a:person) WITH a MATCH (a);"
+-CONTINUE_EXCEPTION                          ^^^^^
+
+-NAME QueryNodeWithOutParentheses
+-QUERY MATCH a RETURN *;
+-EXCEPTION Parentheses are required to identify nodes in patterns, i.e. (a) (line: 1, offset: 6)
+-CONTINUE_EXCEPTION "MATCH a RETURN *;"
+-CONTINUE_EXCEPTION        ^
+
+-NAME InvalidNotEqualOperator
+-QUERY MATCH (a) WHERE a.age != 1 RETURN *;
+-EXCEPTION Unknown operation '!=' (you probably meant to use '<>', which is the operator for inequality testing.) (line: 1, offset: 22)
+-CONTINUE_EXCEPTION "MATCH (a) WHERE a.age != 1 RETURN *;"
+-CONTINUE_EXCEPTION                        ^^
+
+-NAME EmptyLabel
+-QUERY MATCH (a:``) RETURN *;
+-EXCEPTION '' is not a valid token name. Token names cannot be empty or contain any null-bytes (line: 1, offset: 9)
+-CONTINUE_EXCEPTION "MATCH (a:``) RETURN *;"
+-CONTINUE_EXCEPTION           ^^
+
+-NAME EmptyProperty
+-QUERY MATCH (a) WHERE a.`` != 1 RETURN *;
+-EXCEPTION '' is not a valid token name. Token names cannot be empty or contain any null-bytes (line: 1, offset: 18)
+-CONTINUE_EXCEPTION "MATCH (a) WHERE a.`` != 1 RETURN *;"
+-CONTINUE_EXCEPTION                    ^^
+
+-NAME ReturnNotAtEnd
+-QUERY RETURN a MATCH (a) RETURN a;
+-EXCEPTION RETURN can only be used at the end of the query (line: 1, offset: 0)
+-CONTINUE_EXCEPTION "RETURN a MATCH (a) RETURN a;"
+-CONTINUE_EXCEPTION  ^^^^^^


### PR DESCRIPTION
This PR adds error handling in parser.

For regular syntax error, we fall back to Antlr4 error message with Neo4j style of printing (with a second line indicating error part).

For common syntax error, we add ad-hoc error message. Common syntax errors are
- Query not conclude with RETURN
  -  `MATCH (a)` 
- Node is not parenthesed
  -  `MATCH a RETURN *`  
- Invalid not equal operator
  -  `a.age != 10` 
- Empty token
  -  `MATCH (a:``) RETURN *` 
- Return not at the end
  -  `RETURN 1 MATCH (a) RETURN *` 