### PR TITLE
rewrite of projection operator and logical to physical mapping

### DIFF
--- a/src/common/include/data_chunk/data_chunk.h
+++ b/src/common/include/data_chunk/data_chunk.h
@@ -31,9 +31,11 @@ public:
         state = make_shared<DataChunkState>(initializeSelectedValuesPos, capacity);
     }
 
-    void append(shared_ptr<ValueVector> valueVector) {
+    void append(shared_ptr<ValueVector> valueVector) { valueVectors.push_back(valueVector); }
+
+    void appendAndSetVectorState(shared_ptr<ValueVector> valueVector) {
         valueVector->state = this->state;
-        valueVectors.push_back(valueVector);
+        append(valueVector);
     }
 
     inline shared_ptr<ValueVector> getValueVector(uint64_t valueVectorPos) {

--- a/src/processor/include/physical_plan/operator/projection/projection.h
+++ b/src/processor/include/physical_plan/operator/projection/projection.h
@@ -14,27 +14,20 @@ namespace processor {
 class Projection : public PhysicalOperator {
 
 public:
-    Projection(vector<unique_ptr<PhysicalExpression>> expressions,
-        vector<vector<uint64_t>>& expressionsPerDataChunk,
+    Projection(unique_ptr<vector<unique_ptr<PhysicalExpression>>> expressions,
+        vector<uint64_t> expressionPosToDataChunkPos, const vector<uint64_t>& discardedDataChunkPos,
         unique_ptr<PhysicalOperator> prevOperator);
 
     void getNextTuples() override;
 
-    unique_ptr<PhysicalOperator> clone() override {
-        vector<unique_ptr<PhysicalExpression>> clonedExpressions;
-        for (auto& expr : expressions) {
-            clonedExpressions.push_back(ExpressionMapper::clone(*expr, *dataChunks));
-        }
-        return make_unique<Projection>(
-            move(clonedExpressions), expressionsPerInDataChunk, prevOperator->clone());
-    }
+    unique_ptr<PhysicalOperator> clone() override;
 
 private:
-    vector<unique_ptr<PhysicalExpression>> expressions;
-    vector<vector<uint64_t>> expressionsPerInDataChunk;
-
-    shared_ptr<DataChunks> inDataChunks;
+    unique_ptr<vector<unique_ptr<PhysicalExpression>>> expressions;
+    vector<uint64_t> expressionPosToDataChunkPos;
+    vector<uint64_t> discardedDataChunkPos;
     shared_ptr<DataChunks> discardedDataChunks;
+    shared_ptr<DataChunks> inDataChunks;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/tuple/data_chunks.h
+++ b/src/processor/include/physical_plan/operator/tuple/data_chunks.h
@@ -40,9 +40,9 @@ public:
 
 public:
     uint64_t multiplicity;
+    vector<shared_ptr<DataChunk>> dataChunks;
 
 private:
-    vector<shared_ptr<DataChunk>> dataChunks;
     vector<shared_ptr<ListSyncState>> listSyncStatesPerDataChunk;
 };
 

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -66,7 +66,7 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeOutDataChunksAndVectorP
         } else {
             outVector = make_shared<ValueVector>(probeSideVector->dataType);
         }
-        outKeyDataChunk->append(outVector);
+        outKeyDataChunk->appendAndSetVectorState(outVector);
     }
     for (uint64_t i = 0; i < buildSideKeyDataChunk->valueVectors.size(); i++) {
         if (i == buildSideKeyVectorPos) {
@@ -81,7 +81,7 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeOutDataChunksAndVectorP
         } else {
             outVector = make_shared<ValueVector>(buildSideVector->dataType);
         }
-        outKeyDataChunk->append(outVector);
+        outKeyDataChunk->appendAndSetVectorState(outVector);
     }
 
     for (uint64_t i = 0; i < buildSideNonKeyDataChunks->getNumDataChunks(); i++) {
@@ -96,7 +96,7 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeOutDataChunksAndVectorP
                 } else {
                     outVector = make_shared<ValueVector>(vector->dataType);
                 }
-                outKeyDataChunk->append(outVector);
+                outKeyDataChunk->appendAndSetVectorState(outVector);
             }
         } else {
             auto unFlatOutDataChunk = make_shared<DataChunk>();
@@ -115,7 +115,7 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeOutDataChunksAndVectorP
                     buildSideVectorPtrs.size());
                 buildSideVectorInfos.push_back(vectorInfo);
                 buildSideVectorPtrs.push_back(move(vectorPtrs));
-                unFlatOutDataChunk->append(outVector);
+                unFlatOutDataChunk->appendAndSetVectorState(outVector);
             }
             dataChunks->append(unFlatOutDataChunk);
         }

--- a/src/processor/physical_plan/operator/projection/projection.cpp
+++ b/src/processor/physical_plan/operator/projection/projection.cpp
@@ -3,42 +3,57 @@
 namespace graphflow {
 namespace processor {
 
-Projection::Projection(vector<unique_ptr<PhysicalExpression>> expressions,
-    vector<vector<uint64_t>>& expressionsPerDataChunk, unique_ptr<PhysicalOperator> prevOperator)
-    : PhysicalOperator(move(prevOperator), PROJECTION), expressions(move(expressions)),
-      expressionsPerInDataChunk(expressionsPerDataChunk) {
-    /* inDataChunks = this->prevOperator->getDataChunks();
-    assert(expressionsPerDataChunk.size() == inDataChunks->getNumDataChunks());
+Projection::Projection(unique_ptr<vector<unique_ptr<PhysicalExpression>>> expressions,
+    vector<uint64_t> expressionPosToDataChunkPos, const vector<uint64_t>& discardedDataChunkPos,
+    unique_ptr<PhysicalOperator> prevOperator)
+    : PhysicalOperator(move(prevOperator), PROJECTION), expressions{move(expressions)},
+      expressionPosToDataChunkPos(expressionPosToDataChunkPos),
+      discardedDataChunkPos(discardedDataChunkPos) {
     dataChunks = make_shared<DataChunks>();
-    discardedDataChunks = make_shared<DataChunks>();
-    for (uint64_t i = 0; i < expressionsPerDataChunk.size(); i++) {
-        if (expressionsPerDataChunk[i].empty()) {
-            discardedDataChunks->append(inDataChunks->getDataChunk(i));
+    unordered_map<uint64_t, shared_ptr<DataChunk>> posToDataChunkMap;
+    for (auto exprPos = 0u; exprPos < expressionPosToDataChunkPos.size(); exprPos++) {
+        auto dataChunkPos = expressionPosToDataChunkPos[exprPos];
+        if (end(posToDataChunkMap) != posToDataChunkMap.find(dataChunkPos)) {
+            auto dataChunk = make_shared<DataChunk>();
+            auto exprResult = (*expressions)[exprPos]->result;
+            dataChunk->state = exprResult->state;
+            dataChunk->append(exprResult);
         } else {
-            auto outDataChunk = make_shared<DataChunk>(inDataChunks->getDataChunkState(i));
-            for (auto& expressionPos : expressionsPerDataChunk[i]) {
-
-                this->expressions[expressionPos]->setExpressionInputDataChunk(
-                    inDataChunks->getDataChunk(i));
-                this->expressions[expressionPos]->setExpressionResultOwnerState(
-                    outDataChunk->state);
-                outDataChunk->append(this->expressions[expressionPos]->result);
-
-            }
-            dataChunks->append(outDataChunk);
+            posToDataChunkMap.at(dataChunkPos)->append((*expressions)[exprPos]->result);
         }
-    }*/
+    }
+    inDataChunks = prevOperator->getDataChunks();
+    discardedDataChunks = make_shared<DataChunks>();
+    for (auto pos : discardedDataChunkPos) {
+        discardedDataChunks->append(inDataChunks->getDataChunk(pos));
+    }
 }
 
 void Projection::getNextTuples() {
     prevOperator->getNextTuples();
-    if (inDataChunks->getNumTuples() == 0) {
+    if (inDataChunks->getNumTuples() > 0) {
+        dataChunks->multiplicity = 0;
+        for (auto& dataChunk : dataChunks->dataChunks) {
+            dataChunk->state->size = 0;
+        }
         return;
     }
-    for (auto& expression : expressions) {
+    for (auto& expression : *expressions) {
         expression->evaluate();
     }
     dataChunks->multiplicity = discardedDataChunks->getNumTuples();
 }
+
+unique_ptr<PhysicalOperator> Projection::clone() {
+    auto prevOperatorClone = prevOperator->clone();
+    auto rootExpressionsCloned = make_unique<vector<unique_ptr<PhysicalExpression>>>();
+    for (auto& expr : *expressions) {
+        (*rootExpressionsCloned)
+            .push_back(ExpressionMapper::clone(*expr, *prevOperatorClone->getDataChunks()));
+    }
+    return make_unique<Projection>(move(rootExpressionsCloned), expressionPosToDataChunkPos,
+        discardedDataChunkPos, move(prevOperatorClone));
+}
+
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -9,7 +9,7 @@ AdjListExtend<IS_OUT_DATACHUNK_FILTERED>::AdjListExtend(uint64_t inDataChunkPos,
     : ReadList{inDataChunkPos, inValueVectorPos, lists, move(prevOperator)} {
     outValueVector = make_shared<NodeIDVector>(0, lists->getNodeIDCompressionScheme(), false);
     outDataChunk = make_shared<DataChunk>(true /* initializeSelectedValuesPos */);
-    outDataChunk->append(outValueVector);
+    outDataChunk->appendAndSetVectorState(outValueVector);
     auto listSyncState = make_shared<ListSyncState>();
     dataChunks->append(outDataChunk, listSyncState);
     handle->setListSyncState(listSyncState);

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -14,7 +14,7 @@ ReadRelPropertyList::ReadRelPropertyList(uint64_t inDataChunkPos, uint64_t inVal
     outValueVector = make_shared<ValueVector>(lists->getDataType());
     outDataChunk = dataChunks->getDataChunk(outDataChunkPos);
     handle->setListSyncState(dataChunks->getListSyncState(outDataChunkPos));
-    outDataChunk->append(outValueVector);
+    outDataChunk->appendAndSetVectorState(outValueVector);
 }
 
 void ReadRelPropertyList::getNextTuples() {

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -10,7 +10,7 @@ AdjColumnExtend::AdjColumnExtend(uint64_t dataChunkPos, uint64_t valueVectorPos,
     auto outNodeIDVector = make_shared<NodeIDVector>(
         0, ((AdjColumn*)column)->getCompressionScheme(), false /*inNodeIDVector->isSequence()*/);
     outValueVector = static_pointer_cast<ValueVector>(outNodeIDVector);
-    inDataChunk->append(outValueVector);
+    inDataChunk->appendAndSetVectorState(outValueVector);
 }
 
 void AdjColumnExtend::getNextTuples() {

--- a/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
@@ -9,7 +9,7 @@ ScanStructuredProperty::ScanStructuredProperty(uint64_t dataChunkPos, uint64_t v
     BaseColumn* column, unique_ptr<PhysicalOperator> prevOperator)
     : ScanStructuredColumn{dataChunkPos, valueVectorPos, column, move(prevOperator)} {
     outValueVector = make_shared<ValueVector>(column->getDataType());
-    inDataChunk->append(outValueVector);
+    inDataChunk->appendAndSetVectorState(outValueVector);
 }
 
 void ScanStructuredProperty::getNextTuples() {

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -14,7 +14,7 @@ ScanUnstructuredProperty::ScanUnstructuredProperty(uint64_t dataChunkPos, uint64
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
     handle = make_unique<ColumnOrListsHandle>();
     outValueVector = make_shared<ValueVector>(lists->getDataType());
-    inDataChunk->append(outValueVector);
+    inDataChunk->appendAndSetVectorState(outValueVector);
 }
 
 void ScanUnstructuredProperty::getNextTuples() {

--- a/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
@@ -10,7 +10,7 @@ ScanNodeID<IS_OUT_DATACHUNK_FILTERED>::ScanNodeID(shared_ptr<MorselsDesc>& morse
     nodeIDVector = make_shared<NodeIDVector>(morsel->label, NodeIDCompressionScheme(), true);
     outDataChunk =
         make_shared<DataChunk>(!IS_OUT_DATACHUNK_FILTERED /* initializeSelectedValuesPos */);
-    outDataChunk->append(nodeIDVector);
+    outDataChunk->appendAndSetVectorState(nodeIDVector);
     dataChunks->append(outDataChunk);
 }
 

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -11,15 +11,15 @@ TEST(VectorArithTests, test) {
     dataChunk->state->numSelectedValues = 100;
 
     auto lVector = make_shared<ValueVector>(INT32);
-    dataChunk->append(lVector);
+    dataChunk->appendAndSetVectorState(lVector);
     auto lData = (int32_t*)lVector->values;
 
     auto rVector = make_shared<ValueVector>(INT32);
-    dataChunk->append(rVector);
+    dataChunk->appendAndSetVectorState(rVector);
     auto rData = (int32_t*)rVector->values;
 
     auto result = make_shared<ValueVector>(INT32);
-    dataChunk->append(result);
+    dataChunk->appendAndSetVectorState(result);
     auto resultData = (int32_t*)result->values;
 
     // Fill values before the comparison.
@@ -66,7 +66,7 @@ TEST(VectorArithTests, test) {
     }
 
     result = make_shared<ValueVector>(DOUBLE);
-    dataChunk->append(result);
+    dataChunk->appendAndSetVectorState(result);
     auto resultDataAsDoubleArr = (double_t*)result->values;
     auto powerOp = ValueVector::getBinaryOperation(ExpressionType::POWER);
     powerOp(*lVector, *rVector, *result);

--- a/test/common/vector/operations/vector_boolean_operations_test.cpp
+++ b/test/common/vector/operations/vector_boolean_operations_test.cpp
@@ -12,15 +12,15 @@ TEST(VectorBoolTests, test) {
     dataChunk->state->numSelectedValues = VECTOR_SIZE;
 
     auto lVector = make_shared<ValueVector>(BOOL);
-    dataChunk->append(lVector);
+    dataChunk->appendAndSetVectorState(lVector);
     auto lData = (uint8_t*)lVector->values;
 
     auto rVector = make_shared<ValueVector>(BOOL);
-    dataChunk->append(rVector);
+    dataChunk->appendAndSetVectorState(rVector);
     auto rData = (uint8_t*)rVector->values;
 
     auto result = make_shared<ValueVector>(BOOL);
-    dataChunk->append(result);
+    dataChunk->appendAndSetVectorState(result);
     auto resultData = (uint8_t*)result->values;
 
     // Fill values before the comparison.

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -13,15 +13,15 @@ TEST(VectorCmpTests, cmpInt) {
     dataChunk->state->numSelectedValues = numTuples;
 
     auto lVector = make_shared<ValueVector>(INT32, numTuples);
-    dataChunk->append(lVector);
+    dataChunk->appendAndSetVectorState(lVector);
     auto lData = (int32_t*)lVector->values;
 
     auto rVector = make_shared<ValueVector>(INT32, numTuples);
-    dataChunk->append(rVector);
+    dataChunk->appendAndSetVectorState(rVector);
     auto rData = (int32_t*)rVector->values;
 
     auto result = make_shared<ValueVector>(BOOL, numTuples);
-    dataChunk->append(result);
+    dataChunk->appendAndSetVectorState(result);
     auto resultData = result->values;
 
     // Fill values before the comparison.
@@ -75,15 +75,15 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
     dataChunk->state->currPos = 0;
 
     auto lVector = make_shared<ValueVector>(STRING, numTuples);
-    dataChunk->append(lVector);
+    dataChunk->appendAndSetVectorState(lVector);
     auto lData = ((gf_string_t*)lVector->values);
 
     auto rVector = make_shared<ValueVector>(STRING, numTuples);
-    dataChunk->append(rVector);
+    dataChunk->appendAndSetVectorState(rVector);
     auto rData = ((gf_string_t*)rVector->values);
 
     auto result = make_shared<ValueVector>(BOOL, numTuples);
-    dataChunk->append(result);
+    dataChunk->appendAndSetVectorState(result);
     auto resultData = result->values;
 
     char* value = "abcdefgh";
@@ -145,15 +145,15 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
     dataChunk->state->currPos = 0;
 
     auto lVector = make_shared<ValueVector>(STRING, VECTOR_SIZE);
-    dataChunk->append(lVector);
+    dataChunk->appendAndSetVectorState(lVector);
     auto lData = ((gf_string_t*)lVector->values);
 
     auto rVector = make_shared<ValueVector>(STRING, VECTOR_SIZE);
-    dataChunk->append(rVector);
+    dataChunk->appendAndSetVectorState(rVector);
     auto rData = ((gf_string_t*)rVector->values);
 
     auto result = make_shared<ValueVector>(BOOL, VECTOR_SIZE);
-    dataChunk->append(result);
+    dataChunk->appendAndSetVectorState(result);
     auto resultData = result->values;
 
     char* value = "abcdefghijklmnopqrstuvwxy"; // 25.

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -24,7 +24,7 @@ TEST(ExpressionTests, BinaryPhysicalExpressionTest) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 100;
     dataChunk->state->numSelectedValues = 100;
-    dataChunk->append(valueVector);
+    dataChunk->appendAndSetVectorState(valueVector);
 
     auto physicalOperatorInfo = PhysicalOperatorsInfo();
     auto dataChunksExpr = DataChunks();
@@ -62,7 +62,7 @@ TEST(ExpressionTests, UnaryPhysicalExpressionTest) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 100;
     dataChunk->state->numSelectedValues = 100;
-    dataChunk->append(valueVector);
+    dataChunk->appendAndSetVectorState(valueVector);
 
     auto physicalOperatorInfo = PhysicalOperatorsInfo();
     auto dataChunksExpr = DataChunks();


### PR DESCRIPTION
This PR rewrites the projection operator and its mapping in PlanMapper.

A LogicalProjection contains m LogicalExpressions applied to the existing ValueVector(s) up to before the projection in the pipeline.
The projection operator creates a new DataChunks object and new DataChunks to hold the result(s) of the expression. We group the unflat vectors projected as done in prevDataChunks and we create a new DataChunk for flat vectors projected.

When mapping projection from a logical to physical operation. For each expression, we call `appendFlattenOperatorsIfNecessary` and collect a vector representing in its index the expressionPos and its value the dataChunkPos as before the projection. Finally, we clear the physicalOperatorInfo object and refill it with the new DataChunks with the positions normalized from 0 to m'. 