### PR TITLE
Rewrite variable in projection

### DIFF
--- a/src/expression/include/logical/logical_node_expression.h
+++ b/src/expression/include/logical/logical_node_expression.h
@@ -8,15 +8,14 @@ namespace expression {
 class LogicalNodeExpression : public LogicalExpression {
 
 public:
-    LogicalNodeExpression(string name, label_t label)
-        : LogicalExpression{VARIABLE, NODE}, name{move(name)}, label{label} {}
+    LogicalNodeExpression(const string& name, label_t label)
+        : LogicalExpression{VARIABLE, NODE, name}, label{label} {}
 
     unordered_set<string> getIncludedVariables() const override {
-        return unordered_set<string>{name};
+        return unordered_set<string>{variableName};
     }
 
 public:
-    string name;
     label_t label;
 };
 

--- a/src/expression/include/logical/logical_rel_expression.h
+++ b/src/expression/include/logical/logical_rel_expression.h
@@ -8,19 +8,18 @@ namespace expression {
 class LogicalRelExpression : public LogicalExpression {
 
 public:
-    LogicalRelExpression(string name, label_t label)
-        : LogicalExpression{VARIABLE, REL}, name{move(name)}, label{label} {}
+    LogicalRelExpression(const string& name, label_t label)
+        : LogicalExpression{VARIABLE, REL, name}, label{label} {}
 
-    inline string getSrcNodeName() const { return srcNode->name; }
+    inline string getSrcNodeName() const { return srcNode->variableName; }
 
-    inline string getDstNodeName() const { return dstNode->name; }
+    inline string getDstNodeName() const { return dstNode->variableName; }
 
     unordered_set<string> getIncludedVariables() const override {
-        return unordered_set<string>{name};
+        return unordered_set<string>{variableName};
     }
 
 public:
-    string name;
     label_t label;
     LogicalNodeExpression* srcNode;
     LogicalNodeExpression* dstNode;

--- a/src/planner/binder.cpp
+++ b/src/planner/binder.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace planner {
 
 static string makeUniqueVariableName(const string& name, uint32_t& idx) {
-    return name + "_gf" + to_string(idx++);
+    return "_gf" + to_string(idx++) + "_" + name;
 }
 
 static void validateProjectionColumnNamesAreUnique(
@@ -35,15 +35,15 @@ static void validateQueryGraphIsConnected(const QueryGraph& queryGraph,
     auto visited = unordered_set<string>();
     for (auto& [name, variable] : variablesInScope) {
         if (NODE == variable->dataType) {
-            visited.insert(static_pointer_cast<LogicalNodeExpression>(variable)->name);
+            visited.insert(variable->variableName);
         }
     }
     if (visited.empty()) {
-        visited.insert(queryGraph.queryNodes[0]->name);
+        visited.insert(queryGraph.queryNodes[0]->variableName);
     }
     auto target = visited;
     for (auto& queryNode : queryGraph.queryNodes) {
-        target.insert(queryNode->name);
+        target.insert(queryNode->variableName);
     }
     auto frontier = visited;
     while (!frontier.empty()) {

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -197,7 +197,8 @@ shared_ptr<LogicalExpression> ExpressionBinder::bindPropertyExpression(
         auto dataType = catalog.containNodeProperty(node->label, propertyName) ?
                             catalog.getNodePropertyTypeFromString(node->label, propertyName) :
                             UNSTRUCTURED;
-        return make_shared<LogicalExpression>(PROPERTY, dataType, node->name + "." + propertyName);
+        return make_shared<LogicalExpression>(
+            PROPERTY, dataType, node->variableName + "." + propertyName);
     }
     if (REL == childExpression->dataType) {
         auto rel = static_pointer_cast<LogicalRelExpression>(childExpression);
@@ -207,7 +208,7 @@ shared_ptr<LogicalExpression> ExpressionBinder::bindPropertyExpression(
         }
         return make_shared<LogicalExpression>(PROPERTY,
             catalog.getRelPropertyTypeFromString(rel->label, propertyName),
-            rel->name + "." + propertyName);
+            rel->variableName + "." + propertyName);
     }
     throw invalid_argument("Type mismatch: expect NODE or REL, but " +
                            childExpression->rawExpression + " was " +
@@ -230,8 +231,7 @@ shared_ptr<LogicalExpression> ExpressionBinder::bindFunctionExpression(
             throw invalid_argument("Expect " + child->rawExpression + " to be a node, but it was " +
                                    dataTypeToString(child->dataType));
         }
-        auto nodeName = static_pointer_cast<LogicalNodeExpression>(child)->name;
-        return make_shared<LogicalExpression>(PROPERTY, NODE_ID, nodeName + "._id");
+        return make_shared<LogicalExpression>(PROPERTY, NODE_ID, child->variableName + "._id");
     } else {
         throw invalid_argument(functionName + " is not supported.");
     }

--- a/src/planner/query_graph/query_graph.cpp
+++ b/src/planner/query_graph/query_graph.cpp
@@ -56,8 +56,8 @@ uint32_t QueryGraph::getQueryNodePos(const string& queryNodeName) const {
 }
 
 void QueryGraph::addQueryNodeIfNotExist(shared_ptr<LogicalNodeExpression> queryNode) {
-    if (!containsQueryNode(queryNode->name)) {
-        queryNodeNameToPosMap.insert({queryNode->name, queryNodes.size()});
+    if (!containsQueryNode(queryNode->variableName)) {
+        queryNodeNameToPosMap.insert({queryNode->variableName, queryNodes.size()});
         queryNodes.push_back(queryNode);
     }
 }
@@ -79,8 +79,8 @@ uint32_t QueryGraph::getQueryRelPos(const string& queryRelName) const {
 }
 
 void QueryGraph::addQueryRelIfNotExist(shared_ptr<LogicalRelExpression> queryRel) {
-    if (!containsQueryRel(queryRel->name)) {
-        queryRelNameToPosMap.insert({queryRel->name, queryRels.size()});
+    if (!containsQueryRel(queryRel->variableName)) {
+        queryRelNameToPosMap.insert({queryRel->variableName, queryRels.size()});
         queryRels.push_back(queryRel);
     }
 }


### PR DESCRIPTION
This PR 

- Remove name field in LogicalNodeExpression & LogicalRelExpression.
- Rewrite variable expression as all property expressions.
- Change internal variable representation from "a_gf0" to "_gf0_a"

