### PR TITLE
Add mock test for optimzier

### DIFF
--- a/src/expression/include/logical/logical_node_expression.h
+++ b/src/expression/include/logical/logical_node_expression.h
@@ -5,6 +5,8 @@
 namespace graphflow {
 namespace expression {
 
+const string INTERNAL_ID = "_id";
+
 class LogicalNodeExpression : public LogicalExpression {
 
 public:
@@ -14,6 +16,8 @@ public:
     unordered_set<string> getIncludedVariables() const override {
         return unordered_set<string>{variableName};
     }
+
+    string getIDProperty() { return variableName + "." + INTERNAL_ID; }
 
 public:
     label_t label;

--- a/src/planner/expression_binder.cpp
+++ b/src/planner/expression_binder.cpp
@@ -231,7 +231,8 @@ shared_ptr<LogicalExpression> ExpressionBinder::bindFunctionExpression(
             throw invalid_argument("Expect " + child->rawExpression + " to be a node, but it was " +
                                    dataTypeToString(child->dataType));
         }
-        return make_shared<LogicalExpression>(PROPERTY, NODE_ID, child->variableName + "._id");
+        return make_shared<LogicalExpression>(
+            PROPERTY, NODE_ID, static_pointer_cast<LogicalNodeExpression>(child)->getIDProperty());
     } else {
         throw invalid_argument(functionName + " is not supported.");
     }

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -35,22 +35,24 @@ public:
     Catalog(const string& directory);
     Catalog() : logger{spdlog::get("storage")} {};
 
+    virtual ~Catalog() = default;
+
     inline const uint32_t getNodeLabelsCount() const { return stringToNodeLabelMap.size(); }
     inline const uint32_t getRelLabelsCount() const { return stringToRelLabelMap.size(); }
 
-    inline bool containNodeLabel(const char* label) const {
+    virtual inline bool containNodeLabel(const char* label) const {
         return end(stringToNodeLabelMap) != stringToNodeLabelMap.find(label);
     }
 
-    inline label_t getNodeLabelFromString(const char* label) const {
+    virtual inline label_t getNodeLabelFromString(const char* label) const {
         return stringToNodeLabelMap.at(label);
     }
 
-    inline bool containRelLabel(const char* label) const {
+    virtual inline bool containRelLabel(const char* label) const {
         return end(stringToRelLabelMap) != stringToRelLabelMap.find(label);
     }
 
-    inline label_t getRelLabelFromString(const char* label) const {
+    virtual inline label_t getRelLabelFromString(const char* label) const {
         return stringToRelLabelMap.at(label);
     }
 
@@ -69,17 +71,18 @@ public:
         return relPropertyKeyMaps[relLabel];
     }
 
-    inline bool containNodeProperty(label_t nodeLabel, const string& propertyName) const {
+    virtual inline bool containNodeProperty(label_t nodeLabel, const string& propertyName) const {
         auto& nodeProperties = getPropertyKeyMapForNodeLabel(nodeLabel);
         return end(nodeProperties) != nodeProperties.find(propertyName);
     }
 
-    inline bool containUnstrNodeProperty(label_t nodeLabel, const string& propertyName) const {
+    virtual inline bool containUnstrNodeProperty(
+        label_t nodeLabel, const string& propertyName) const {
         auto& nodeProperties = getUnstrPropertyKeyMapForNodeLabel(nodeLabel);
         return end(nodeProperties) != nodeProperties.find(propertyName);
     }
 
-    inline DataType getNodePropertyTypeFromString(
+    virtual inline DataType getNodePropertyTypeFromString(
         label_t nodeLabel, const string& propertyName) const {
         auto& nodeProperties = getPropertyKeyMapForNodeLabel(nodeLabel);
         return nodeProperties.at(propertyName).dataType;
@@ -93,12 +96,12 @@ public:
         return getPropertyKeyMapForNodeLabel(nodeLabel).at(name).idx;
     }
 
-    inline bool containRelProperty(label_t relLabel, const string& propertyName) const {
+    virtual inline bool containRelProperty(label_t relLabel, const string& propertyName) const {
         auto relProperties = getPropertyKeyMapForRelLabel(relLabel);
         return end(relProperties) != relProperties.find(propertyName);
     }
 
-    inline DataType getRelPropertyTypeFromString(
+    virtual inline DataType getRelPropertyTypeFromString(
         label_t relLabel, const string& propertyName) const {
         auto& relProperties = getPropertyKeyMapForRelLabel(relLabel);
         return relProperties.at(propertyName).dataType;
@@ -110,12 +113,12 @@ public:
 
     const string getStringNodeLabel(label_t label) const;
 
-    const vector<label_t>& getRelLabelsForNodeLabelDirection(
+    virtual const vector<label_t>& getRelLabelsForNodeLabelDirection(
         label_t nodeLabel, Direction dir) const;
 
     const vector<label_t>& getNodeLabelsForRelLabelDir(label_t relLabel, Direction dir) const;
 
-    bool isSingleCaridinalityInDir(label_t relLabel, Direction dir) const;
+    virtual bool isSingleCaridinalityInDir(label_t relLabel, Direction dir) const;
 
     unique_ptr<nlohmann::json> debugInfo();
 

--- a/src/storage/include/graph.h
+++ b/src/storage/include/graph.h
@@ -34,7 +34,7 @@ public:
 
     virtual ~Graph() { spdlog::drop("storage"); };
 
-    inline const Catalog& getCatalog() const { return *catalog; }
+    virtual inline const Catalog& getCatalog() const { return *catalog; }
 
     inline const RelsStore& getRelsStore() const { return *relsStore; }
 
@@ -42,11 +42,9 @@ public:
 
     inline const vector<uint64_t>& getNumNodesPerLabel() const { return numNodesPerLabel; };
 
-    inline const uint64_t& getNumNodes(const label_t& label) const {
-        return numNodesPerLabel[label];
-    }
+    virtual inline uint64_t getNumNodes(label_t label) const { return numNodesPerLabel[label]; }
 
-    inline const uint64_t getNumRelsForDirBoundLabelRelLabel(
+    virtual inline uint64_t getNumRelsForDirBoundLabelRelLabel(
         Direction direction, label_t boundNodeLabel, label_t relLabel) const {
         return numRelsPerDirBoundLabelRelLabel[FWD == direction ? 0 : 1][boundNodeLabel][relLabel];
     }

--- a/test/planner/optimizer/BUILD.bazel
+++ b/test/planner/optimizer/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@rules_cc//cc:defs.bzl", "cc_test")
+
+cc_library(
+    name = "mock_objects",
+    hdrs = [
+        "mock_catalog.h",
+        "mock_graph.h",
+    ],
+    deps = [
+        "//src/storage:graph",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "optimizer_test",
+    srcs = [
+        "optimizer_test.cpp",
+    ],
+    deps = [
+        "mock_objects",
+        "//src/parser",
+        "//src/planner:enumerator",
+    ],
+)

--- a/test/planner/optimizer/mock_catalog.h
+++ b/test/planner/optimizer/mock_catalog.h
@@ -1,0 +1,28 @@
+#include "gmock/gmock.h"
+
+#include "src/storage/include/catalog.h"
+
+using namespace graphflow::storage;
+
+class MockCatalog : public Catalog {
+
+public:
+    MOCK_METHOD(bool, containNodeLabel, (const char* label), (const, override));
+    MOCK_METHOD(label_t, getNodeLabelFromString, (const char* label), (const, override));
+    MOCK_METHOD(bool, containRelLabel, (const char* label), (const, override));
+    MOCK_METHOD(label_t, getRelLabelFromString, (const char* label), (const, override));
+    MOCK_METHOD(const vector<label_t>&, getRelLabelsForNodeLabelDirection,
+        (label_t nodeLabel, Direction dir), (const, override));
+    MOCK_METHOD(bool, containNodeProperty, (label_t nodeLabel, const string& propertyName),
+        (const, override));
+    MOCK_METHOD(DataType, getNodePropertyTypeFromString,
+        (label_t nodeLabel, const string& propertyName), (const, override));
+    MOCK_METHOD(bool, containUnstrNodeProperty, (label_t nodeLabel, const string& propertyName),
+        (const, override));
+    MOCK_METHOD(bool, containRelProperty, (label_t relLabel, const string& propertyName),
+        (const, override));
+    MOCK_METHOD(DataType, getRelPropertyTypeFromString,
+        (label_t relLabel, const string& propertyName), (const, override));
+    MOCK_METHOD(
+        bool, isSingleCaridinalityInDir, (label_t relLabel, Direction dir), (const, override));
+};

--- a/test/planner/optimizer/mock_graph.h
+++ b/test/planner/optimizer/mock_graph.h
@@ -1,0 +1,14 @@
+#include "gmock/gmock.h"
+
+#include "src/storage/include/graph.h"
+
+using namespace graphflow::storage;
+
+class MockGraph : public Graph {
+
+public:
+    MOCK_METHOD(const Catalog&, getCatalog, (), (const, override));
+    MOCK_METHOD(uint64_t, getNumNodes, (label_t label), (const, override));
+    MOCK_METHOD(uint64_t, getNumRelsForDirBoundLabelRelLabel,
+        (Direction direction, label_t boundNodeLabel, label_t relLabel), (const, override));
+};

--- a/test/planner/optimizer/optimizer_test.cpp
+++ b/test/planner/optimizer/optimizer_test.cpp
@@ -1,0 +1,230 @@
+#include "gtest/gtest.h"
+#include "mock_catalog.h"
+#include "mock_graph.h"
+
+#include "src/parser/include/parser.h"
+#include "src/planner/include/binder.h"
+#include "src/planner/include/enumerator.h"
+#include "src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h"
+
+using ::testing::_;
+using ::testing::ElementsAre;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::ReturnRef;
+using ::testing::StrEq;
+using ::testing::Test;
+using ::testing::Throw;
+
+using namespace graphflow::planner;
+
+/**
+ * Mock person-knows-person catalog with 1 node label person
+ * and 1 rel label knows. Person has property age with type INT32.
+ * Knows has property description with type STRING.
+ */
+class PersonKnowsPersonCatalog : public MockCatalog {
+
+public:
+    void setUp() {
+        setSrcNodeLabelToRelLabels();
+        setDstNodeLabelToRelLabels();
+
+        setActionForContainNodeLabel();
+        setActionForGetNodeLabelFromString();
+        setActionForContainRelLabel();
+        setActionForGetRelLabelFromString();
+        setActionForGetRelLabelsForNodeLabelDirection();
+        setActionForContainNodeProperty();
+        setActionForGetNodePropertyTypeFromString();
+        setActionForContainUnstrNodeProperty();
+        setActionForContainRelProperty();
+        setActionForGetRelPropertyTypeFromString();
+        setActionForIsSingleCardinalityInDir();
+    }
+
+private:
+    void setActionForContainNodeLabel() {
+        ON_CALL(*this, containNodeLabel(_)).WillByDefault(Return(false));
+        ON_CALL(*this, containNodeLabel(StrEq("person"))).WillByDefault(Return(true));
+    }
+
+    void setActionForGetNodeLabelFromString() {
+        ON_CALL(*this, getNodeLabelFromString(StrEq("person"))).WillByDefault(Return(0));
+    }
+
+    void setActionForContainRelLabel() {
+        ON_CALL(*this, containRelLabel(_)).WillByDefault(Return(false));
+        ON_CALL(*this, containRelLabel(StrEq("knows"))).WillByDefault(Return(true));
+    }
+
+    void setActionForGetRelLabelFromString() {
+        ON_CALL(*this, getRelLabelFromString(StrEq("knows"))).WillByDefault(Return(0));
+    }
+
+    void setActionForGetRelLabelsForNodeLabelDirection() {
+        ON_CALL(*this, getRelLabelsForNodeLabelDirection(_, _))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, getRelLabelsForNodeLabelDirection(0, FWD))
+            .WillByDefault(ReturnRef(srcNodeLabelToRelLabels[0]));
+        ON_CALL(*this, getRelLabelsForNodeLabelDirection(0, BWD))
+            .WillByDefault(ReturnRef(dstNodeLabelToRelLabels[0]));
+    }
+
+    void setActionForContainNodeProperty() {
+        ON_CALL(*this, containNodeProperty(_, _))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, containNodeProperty(0, _)).WillByDefault(Return(false));
+        ON_CALL(*this, containNodeProperty(0, "age")).WillByDefault(Return(true));
+    }
+
+    void setActionForGetNodePropertyTypeFromString() {
+        ON_CALL(*this, getNodePropertyTypeFromString(0, "age")).WillByDefault(Return(INT32));
+    }
+
+    void setActionForContainUnstrNodeProperty() {
+        ON_CALL(*this, containUnstrNodeProperty(_, _))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, containUnstrNodeProperty(0, _)).WillByDefault(Return(false));
+    }
+
+    void setActionForContainRelProperty() {
+        ON_CALL(*this, containRelProperty(_, _))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, containRelProperty(0, _)).WillByDefault(Return(false));
+        ON_CALL(*this, containRelProperty(0, "description")).WillByDefault(Return(true));
+    }
+
+    void setActionForGetRelPropertyTypeFromString() {
+        ON_CALL(*this, getRelPropertyTypeFromString(0, "description"))
+            .WillByDefault(Return(STRING));
+    }
+
+    void setActionForIsSingleCardinalityInDir() {
+        ON_CALL(*this, isSingleCaridinalityInDir(_, _)).WillByDefault(Return(false));
+    }
+
+    void setSrcNodeLabelToRelLabels() {
+        vector<label_t> personToRelLabels = {0};
+        srcNodeLabelToRelLabels.push_back(move(personToRelLabels));
+    }
+
+    void setDstNodeLabelToRelLabels() {
+        vector<label_t> personToRelLabels = {0};
+        dstNodeLabelToRelLabels.push_back(move(personToRelLabels));
+    }
+
+    vector<vector<label_t>> srcNodeLabelToRelLabels, dstNodeLabelToRelLabels;
+};
+
+/**
+ * Mock person-knows-person graph with 10000 person nodes
+ * fwd average degree 10, bwd average degree 20
+ */
+class PersonKnowsPersonGraph : public MockGraph {
+
+public:
+    void setUp() {
+        numPersonNodes = 10000;
+        setCatalog();
+
+        setActionForGetCatalog();
+        setActionForGetNumNodes();
+        setActionForGetNumRelsForDirBoundLabelRelLabel();
+    }
+
+private:
+    void setActionForGetCatalog() { ON_CALL(*this, getCatalog).WillByDefault(ReturnRef(*catalog)); }
+
+    void setActionForGetNumNodes() {
+        ON_CALL(*this, getNumNodes(_))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, getNumNodes(0)).WillByDefault(Return(numPersonNodes));
+    }
+
+    void setActionForGetNumRelsForDirBoundLabelRelLabel() {
+        ON_CALL(*this, getNumRelsForDirBoundLabelRelLabel(_, _, _))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, getNumRelsForDirBoundLabelRelLabel(FWD, 0, 0))
+            .WillByDefault(Return(10 * numPersonNodes));
+        ON_CALL(*this, getNumRelsForDirBoundLabelRelLabel(BWD, 0, 0))
+            .WillByDefault(Return(20 * numPersonNodes));
+    }
+
+    void setCatalog() {
+        auto mockCatalog = make_unique<NiceMock<PersonKnowsPersonCatalog>>();
+        mockCatalog->setUp();
+        catalog = move(mockCatalog);
+    }
+
+    unique_ptr<Catalog> catalog;
+    uint64_t numPersonNodes;
+};
+
+class OptimizerTest : public Test {
+
+public:
+    static unique_ptr<LogicalPlan> getBestPlan(const string& query, const Graph& graph) {
+        auto parsedQuery = Parser::parseQuery(query);
+        auto boundQuery = Binder(graph.getCatalog()).bindSingleQuery(*parsedQuery);
+        return Enumerator(graph, *boundQuery).getBestPlan();
+    }
+
+    static bool containSubstr(const string& str, const string& substr) {
+        return str.find(substr) != string::npos;
+    }
+};
+
+TEST_F(OptimizerTest, OneHopSingleFilter) {
+    NiceMock<PersonKnowsPersonGraph> graph;
+    graph.setUp();
+
+    auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = 1 RETURN COUNT(*)";
+    auto plan = OptimizerTest::getBestPlan(query, graph);
+    auto& op1 = plan->getLastOperator();
+    ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID));
+    auto& op2 = *op1.prevOperator->prevOperator->prevOperator;
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2.getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op2).nodeID, "_a." + INTERNAL_ID));
+}
+
+TEST_F(OptimizerTest, OneHopMultiFilters) {
+    NiceMock<PersonKnowsPersonGraph> graph;
+    graph.setUp();
+
+    auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age > 10 AND a.age < 20 AND b.age "
+                 "= 45 RETURN COUNT(*)";
+    auto plan = OptimizerTest::getBestPlan(query, graph);
+    auto& op1 = *plan->getLastOperator().prevOperator->prevOperator;
+    ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID));
+    auto& op2 = *op1.prevOperator->prevOperator->prevOperator->prevOperator;
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2.getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op2).nodeID, "_a." + INTERNAL_ID));
+}
+
+TEST_F(OptimizerTest, TwoHop) {
+    NiceMock<PersonKnowsPersonGraph> graph;
+    graph.setUp();
+
+    auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN COUNT(*)";
+    auto plan = OptimizerTest::getBestPlan(query, graph);
+    auto& op1 = *plan->getLastOperator().prevOperator->prevOperator;
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID));
+}
+
+TEST_F(OptimizerTest, TwoHopMultiFilters) {
+    NiceMock<PersonKnowsPersonGraph> graph;
+    graph.setUp();
+
+    auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE a.age = 20 AND "
+                 "b.age = 35 RETURN COUNT(*)";
+    auto plan = OptimizerTest::getBestPlan(query, graph);
+    auto& op1 =
+        *plan->getLastOperator()
+             .prevOperator->prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID));
+}


### PR DESCRIPTION
This PR add mockCatalog and mockGraph and optimzier tests with mock objects.

Assume graph only contains person knows person relationship.
Optimizer tests includes following:
- MATCH (a)->(b) WHERE a.age = 20 
  -  QVO a,b
- MATCH (a)->(b) WHERE a.age > 20 AND a.age < 40 AND b.age = 35
  -  QVO a,b
- MATCH (a)->(b)->(c)
  - Scan(b) first
- MATCH (a)->(b)->(c) WHERE a.age = 20 AND b.age = 35
  - Scan(b) first   