### PR TITLE
refactor libraries in common and expression

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -1,40 +1,51 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
-    name = "common",
+    name = "data_chunk",
+    srcs = [
+        "data_chunk/data_chunk.cpp",
+    ],
+    hdrs = [
+        "include/data_chunk/data_chunk.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "vector",
+    ],
+)
+
+cc_library(
+    name = "vector",
     srcs = [
         "compression_scheme.cpp",
-        "data_chunk/data_chunk.cpp",
-        "data_chunk/data_chunk_state.cpp",
-        "expression_type.cpp",
-        "file_ser_deser_helper.cpp",
-        "string.cpp",
-        "types.cpp",
-        "value.cpp",
         "vector/node_vector.cpp",
+        "vector/value_vector.cpp",
+        "vector/vector_state.cpp"
+    ],
+    hdrs = [
+        "include/compression_scheme.h",
+        "include/vector/node_vector.h",
+        "include/vector/value_vector.h",
+        "include/vector/vector_state.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "types",
+        "expression_type",
+        "operations",
+    ],
+)
+
+cc_library(
+    name = "vector_operations",
+    srcs = [
         "vector/operations/vector_arithmetic_operations.cpp",
         "vector/operations/vector_boolean_operations.cpp",
         "vector/operations/vector_cast_operations.cpp",
         "vector/operations/vector_comparison_operations.cpp",
         "vector/operations/vector_node_id_operations.cpp",
-        "vector/value_vector.cpp",
     ],
     hdrs = [
-        "include/compression_scheme.h",
-        "include/configs.h",
-        "include/data_chunk/data_chunk.h",
-        "include/data_chunk/data_chunk_state.h",
-        "include/expression_type.h",
-        "include/file_ser_deser_helper.h",
-        "include/operations/arithmetic_operations.h",
-        "include/operations/boolean_operations.h",
-        "include/operations/comparison_operations.h",
-        "include/operations/decompress_operations.h",
-        "include/operations/hash_operations.h",
-        "include/string.h",
-        "include/types.h",
-        "include/value.h",
-        "include/vector/node_vector.h",
         "include/vector/operations/executors/binary_operation_executor.h",
         "include/vector/operations/executors/unary_operation_executor.h",
         "include/vector/operations/vector_arithmetic_operations.h",
@@ -42,11 +53,27 @@ cc_library(
         "include/vector/operations/vector_cast_operations.h",
         "include/vector/operations/vector_comparison_operations.h",
         "include/vector/operations/vector_node_id_operations.h",
-        "include/vector/value_vector.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "@martinus_robin_hood_hashing",
+        "operations",
+        "vector",
+    ],
+)
+
+cc_library(
+    name = "operations",
+    srcs = [],
+    hdrs = [
+        "include/operations/arithmetic_operations.h",
+        "include/operations/boolean_operations.h",
+        "include/operations/comparison_operations.h",
+        "include/operations/decompress_operations.h",
+        "include/operations/hash_operations.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "types",
     ],
 )
 
@@ -56,8 +83,72 @@ cc_library(
     hdrs = ["include/csv_reader/csv_reader.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "common",
+        "types",
+        "configs",
+        "utils",
     ],
+)
+
+cc_library(
+    name = "utils",
+    srcs = [],
+    hdrs = [
+        "include/utils.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@martinus_robin_hood_hashing",
+    ],
+)
+
+cc_library(
+    name = "types",
+    srcs = [
+        "types.cpp",
+        "value.cpp",
+        "string.cpp",
+    ],
+    hdrs = [
+        "include/types.h",
+        "include/value.h",
+        "include/string.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+cc_library(
+    name = "configs",
+    srcs = [],
+    hdrs = [
+        "include/configs.h"
+    ],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+cc_library(
+    name = "expression_type",
+    srcs = [
+        "expression_type.cpp",
+    ],
+    hdrs = [
+        "include/expression_type.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [],
+)
+
+cc_library(
+    name = "file_ser_deser_helper",
+    srcs = [
+        "file_ser_deser_helper.cpp",
+    ],
+    hdrs = [
+        "include/file_ser_deser_helper.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [],
 )
 
 cc_library(

--- a/src/common/csv_reader/csv_reader.cpp
+++ b/src/common/csv_reader/csv_reader.cpp
@@ -3,6 +3,7 @@
 #include <fstream>
 
 #include "src/common/include/configs.h"
+#include "src/common/include/utils.h"
 
 namespace graphflow {
 namespace common {

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -1,5 +1,7 @@
 #include "src/common/include/expression_type.h"
 
+#include <stdexcept>
+
 namespace graphflow {
 namespace common {
 

--- a/src/common/include/data_chunk/data_chunk.h
+++ b/src/common/include/data_chunk/data_chunk.h
@@ -3,9 +3,9 @@
 #include <memory>
 #include <vector>
 
-#include "src/common/include/data_chunk/data_chunk_state.h"
 #include "src/common/include/types.h"
 #include "src/common/include/vector/value_vector.h"
+#include "src/common/include/vector/vector_state.h"
 
 using namespace std;
 
@@ -28,7 +28,7 @@ public:
         : DataChunk(initializeSelectedValuesPos, MAX_VECTOR_SIZE) {}
 
     DataChunk(bool initializeSelectedValuesPos, uint64_t capacity) {
-        state = make_shared<DataChunkState>(initializeSelectedValuesPos, capacity);
+        state = make_shared<VectorState>(initializeSelectedValuesPos, capacity);
     }
 
     void append(shared_ptr<ValueVector> valueVector) {
@@ -44,7 +44,7 @@ public:
 
 public:
     vector<shared_ptr<ValueVector>> valueVectors;
-    shared_ptr<DataChunkState> state;
+    shared_ptr<VectorState> state;
 };
 
 } // namespace common

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -1,6 +1,9 @@
 #pragma once
 
-#include "src/common/include/types.h"
+#include <cstdint>
+#include <string>
+
+using namespace std;
 
 namespace graphflow {
 namespace common {

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <functional>
 
 #include "src/common/include/types.h"
 #include "src/common/include/value.h"

--- a/src/common/include/timer.h
+++ b/src/common/include/timer.h
@@ -5,9 +5,6 @@
 #include <string>
 #include <vector>
 
-#include <spdlog/sinks/stdout_sinks.h>
-#include <spdlog/spdlog.h>
-
 using namespace std;
 
 namespace graphflow {

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -3,11 +3,8 @@
 #include <cfloat>
 #include <cmath>
 #include <cstring>
+#include <string>
 #include <vector>
-
-#include "robin_hood.h"
-
-#include "src/common/include/string.h"
 
 using namespace std;
 
@@ -96,16 +93,6 @@ enum Direction : uint8_t { FWD = 0, BWD = 1 };
 const vector<Direction> DIRS = {FWD, BWD};
 
 Direction operator!(Direction& direction);
-
-// C-like string equalTo.
-struct charArrayEqualTo {
-    bool operator()(const char* lhs, const char* rhs) const { return strcmp(lhs, rhs) == 0; }
-};
-
-// C-like string hasher.
-struct charArrayHasher {
-    size_t operator()(const char* key) const { return robin_hood::hash_bytes(key, strlen(key)); }
-};
 
 } // namespace common
 } // namespace graphflow

--- a/src/common/include/utils.h
+++ b/src/common/include/utils.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "robin_hood.h"
+
+using namespace std;
+
+namespace graphflow {
+namespace common {
+
+// C-like string equalTo.
+struct charArrayEqualTo {
+    bool operator()(const char* lhs, const char* rhs) const { return strcmp(lhs, rhs) == 0; }
+};
+
+// C-like string hasher.
+struct charArrayHasher {
+    size_t operator()(const char* key) const { return robin_hood::hash_bytes(key, strlen(key)); }
+};
+
+} // namespace common
+} // namespace graphflow

--- a/src/common/include/value.h
+++ b/src/common/include/value.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 
+#include "src/common/include/string.h"
 #include "src/common/include/types.h"
 
 using namespace std;

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -1,8 +1,7 @@
 #pragma once
 
-#include "src/common/include/data_chunk/data_chunk_state.h"
-#include "src/common/include/expression_type.h"
 #include "src/common/include/types.h"
+#include "src/common/include/vector/vector_state.h"
 
 namespace graphflow {
 namespace common {
@@ -11,11 +10,6 @@ namespace common {
 class ValueVector {
 
 public:
-    static function<void(ValueVector&, ValueVector&)> getUnaryOperation(ExpressionType type);
-
-    static function<void(ValueVector&, ValueVector&, ValueVector&)> getBinaryOperation(
-        ExpressionType type);
-
     ValueVector(DataType dataType, uint64_t vectorCapacity)
         : ValueVector(vectorCapacity, getDataTypeSize(dataType), dataType) {}
 
@@ -57,7 +51,7 @@ public:
     DataType dataType;
     uint8_t* values;
     bool* nullMask;
-    shared_ptr<DataChunkState> state;
+    shared_ptr<VectorState> state;
 };
 
 } // namespace common

--- a/src/common/include/vector/vector_state.h
+++ b/src/common/include/vector/vector_state.h
@@ -1,21 +1,20 @@
 #pragma once
 
+#include <cstring>
 #include <memory>
 #include <vector>
-
-#include "src/common/include/types.h"
 
 using namespace std;
 
 namespace graphflow {
 namespace common {
 
-class DataChunkState {
+class VectorState {
 public:
     // returns a dataChunkState for vectors holding a single value.
-    static shared_ptr<DataChunkState> getSingleValueDataChunkState();
+    static shared_ptr<VectorState> getSingleValueDataChunkState();
 
-    DataChunkState(bool initializeSelectedValuesPos, uint64_t capacity);
+    VectorState(bool initializeSelectedValuesPos, uint64_t capacity);
 
     void initializeSelector() {
         for (auto i = 0u; i < numSelectedValues; i++) {
@@ -27,7 +26,7 @@ public:
 
     inline uint64_t getCurrSelectedValuesPos() { return selectedValuesPos[currPos]; }
 
-    shared_ptr<DataChunkState> clone();
+    shared_ptr<VectorState> clone();
 
 public:
     uint64_t size;

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -1,7 +1,9 @@
 #include "src/common/include/types.h"
 
 #include <cstdlib>
+#include <stdexcept>
 
+#include "src/common/include/string.h"
 #include "src/common/include/value.h"
 
 namespace graphflow {

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -1,92 +1,11 @@
 #include "src/common/include/vector/value_vector.h"
 
 #include "src/common/include/operations/comparison_operations.h"
-#include "src/common/include/vector/operations/vector_arithmetic_operations.h"
-#include "src/common/include/vector/operations/vector_boolean_operations.h"
-#include "src/common/include/vector/operations/vector_cast_operations.h"
-#include "src/common/include/vector/operations/vector_comparison_operations.h"
-#include "src/common/include/vector/operations/vector_node_id_operations.h"
 
 using namespace graphflow::common::operation;
 
 namespace graphflow {
 namespace common {
-
-std::function<void(ValueVector&, ValueVector&)> ValueVector::getUnaryOperation(
-    ExpressionType type) {
-    switch (type) {
-    case NOT:
-        return VectorBooleanOperations::Not;
-    case NEGATE:
-        return VectorArithmeticOperations::Negate;
-    case IS_NULL:
-        return VectorComparisonOperations::IsNull;
-    case IS_NOT_NULL:
-        return VectorComparisonOperations::IsNotNull;
-    case HASH_NODE_ID:
-        return VectorNodeIDOperations::Hash;
-    case DECOMPRESS_NODE_ID:
-        return VectorNodeIDOperations::Decompress;
-    case CAST_TO_STRING:
-        return VectorCastOperations::castStructuredToStringValue;
-    case CAST_TO_UNSTRUCTURED_VECTOR:
-        return VectorCastOperations::castStructuredToUnstructuredValue;
-    case CAST_UNSTRUCTURED_VECTOR_TO_BOOL_VECTOR:
-        return VectorCastOperations::castUnstructuredToBoolValue;
-    default:
-        assert(false);
-    }
-}
-
-std::function<void(ValueVector&, ValueVector&, ValueVector&)> ValueVector::getBinaryOperation(
-    ExpressionType type) {
-    switch (type) {
-    case AND:
-        return VectorBooleanOperations::And;
-    case OR:
-        return VectorBooleanOperations::Or;
-    case XOR:
-        return VectorBooleanOperations::Xor;
-    case EQUALS:
-        return VectorComparisonOperations::Equals;
-    case NOT_EQUALS:
-        return VectorComparisonOperations::NotEquals;
-    case GREATER_THAN:
-        return VectorComparisonOperations::GreaterThan;
-    case GREATER_THAN_EQUALS:
-        return VectorComparisonOperations::GreaterThanEquals;
-    case LESS_THAN:
-        return VectorComparisonOperations::LessThan;
-    case LESS_THAN_EQUALS:
-        return VectorComparisonOperations::LessThanEquals;
-    case EQUALS_NODE_ID:
-        return VectorNodeIDCompareOperations::Equals;
-    case NOT_EQUALS_NODE_ID:
-        return VectorNodeIDCompareOperations::NotEquals;
-    case GREATER_THAN_NODE_ID:
-        return VectorNodeIDCompareOperations::GreaterThan;
-    case GREATER_THAN_EQUALS_NODE_ID:
-        return VectorNodeIDCompareOperations::GreaterThanEquals;
-    case LESS_THAN_NODE_ID:
-        return VectorNodeIDCompareOperations::LessThan;
-    case LESS_THAN_EQUALS_NODE_ID:
-        return VectorNodeIDCompareOperations::LessThanEquals;
-    case ADD:
-        return VectorArithmeticOperations::Add;
-    case SUBTRACT:
-        return VectorArithmeticOperations::Subtract;
-    case MULTIPLY:
-        return VectorArithmeticOperations::Multiply;
-    case DIVIDE:
-        return VectorArithmeticOperations::Divide;
-    case MODULO:
-        return VectorArithmeticOperations::Modulo;
-    case POWER:
-        return VectorArithmeticOperations::Power;
-    default:
-        assert(false);
-    }
-}
 
 template<class T, class FUNC = std::function<uint8_t(T)>>
 static void fillOperandNullMask(ValueVector& operand) {

--- a/src/common/vector/vector_state.cpp
+++ b/src/common/vector/vector_state.cpp
@@ -1,9 +1,9 @@
-#include "src/common/include/data_chunk/data_chunk_state.h"
+#include "src/common/include/vector/vector_state.h"
 
 namespace graphflow {
 namespace common {
 
-DataChunkState::DataChunkState(bool initializeSelectedValuesPos, uint64_t capacity)
+VectorState::VectorState(bool initializeSelectedValuesPos, uint64_t capacity)
     : size{0}, currPos{-1}, numSelectedValues{0} {
     valuesPos = make_unique<uint64_t[]>(capacity);
     selectedValuesPos = valuesPos.get();
@@ -16,16 +16,16 @@ DataChunkState::DataChunkState(bool initializeSelectedValuesPos, uint64_t capaci
     }
 }
 
-shared_ptr<DataChunkState> DataChunkState::getSingleValueDataChunkState() {
-    auto state = make_shared<DataChunkState>(true /* init SelectedValuesPos */, 1);
+shared_ptr<VectorState> VectorState::getSingleValueDataChunkState() {
+    auto state = make_shared<VectorState>(true /* init SelectedValuesPos */, 1);
     state->size = 1;
     state->currPos = 0;
     return state;
 }
 
-shared_ptr<DataChunkState> DataChunkState::clone() {
+shared_ptr<VectorState> VectorState::clone() {
     auto capacity = sizeof(valuesPos.get()) / sizeof(uint64_t);
-    auto newState = make_shared<DataChunkState>(false /*initializeSelectedValuesPos*/, capacity);
+    auto newState = make_shared<VectorState>(false /*initializeSelectedValuesPos*/, capacity);
     newState->size = size;
     newState->currPos = currPos;
     newState->numSelectedValues = numSelectedValues;

--- a/src/expression/BUILD.bazel
+++ b/src/expression/BUILD.bazel
@@ -1,25 +1,40 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
+
 cc_library(
-    name = "expression",
+    name = "logical_expression",
     srcs = [
         "logical/logical_expression.cpp",
         "logical/logical_literal_expression.cpp",
-        "physical/physical_binary_expression.cpp",
-        "physical/physical_expression.cpp",
-        "physical/physical_unary_expression.cpp",
     ],
     hdrs = [
         "include/logical/logical_expression.h",
         "include/logical/logical_literal_expression.h",
         "include/logical/logical_node_expression.h",
         "include/logical/logical_rel_expression.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/common:expression_type",
+        "//src/common:types",
+    ],
+)
+
+cc_library(
+    name = "physical_expression",
+    srcs = [
+        "physical/physical_binary_expression.cpp",
+        "physical/physical_expression.cpp",
+        "physical/physical_unary_expression.cpp",
+    ],
+    hdrs = [
         "include/physical/physical_binary_expression.h",
         "include/physical/physical_expression.h",
         "include/physical/physical_unary_expression.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/common",
+        "//src/common:data_chunk",
+        "//src/common:vector_operations",
     ],
 )

--- a/src/expression/include/logical/logical_expression.h
+++ b/src/expression/include/logical/logical_expression.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <memory>
 #include <unordered_set>
 
 #include "src/common/include/expression_type.h"

--- a/src/expression/include/physical/physical_expression.h
+++ b/src/expression/include/physical/physical_expression.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <climits>
+#include <functional>
 
 #include "src/common/include/data_chunk/data_chunk.h"
+#include "src/common/include/expression_type.h"
 #include "src/common/include/value.h"
 #include "src/common/include/vector/value_vector.h"
 
@@ -14,6 +16,11 @@ namespace expression {
 class PhysicalExpression {
 
 public:
+    static function<void(ValueVector&, ValueVector&)> getUnaryOperation(ExpressionType type);
+
+    static function<void(ValueVector&, ValueVector&, ValueVector&)> getBinaryOperation(
+        ExpressionType type);
+
     // Creates a leaf literal as value vector physical expression.
     PhysicalExpression(shared_ptr<ValueVector> result, ExpressionType expressionType)
         : result{result}, valueVectorPos{UINT64_MAX}, expressionType{expressionType},

--- a/src/expression/physical/physical_binary_expression.cpp
+++ b/src/expression/physical/physical_binary_expression.cpp
@@ -9,7 +9,7 @@ PhysicalBinaryExpression::PhysicalBinaryExpression(unique_ptr<PhysicalExpression
     childrenExpr.push_back(move(rightExpr));
     this->expressionType = expressionType;
     this->dataType = dataType;
-    operation = ValueVector::getBinaryOperation(expressionType);
+    operation = getBinaryOperation(expressionType);
     result = createResultValueVector();
 }
 
@@ -24,7 +24,7 @@ shared_ptr<ValueVector> PhysicalBinaryExpression::createResultValueVector() {
     auto isLeftResultFlat = childrenExpr[0]->isResultFlat();
     auto isRightResultFlat = childrenExpr[1]->isResultFlat();
     if (isLeftResultFlat && isRightResultFlat) {
-        valueVector->state = DataChunkState::getSingleValueDataChunkState();
+        valueVector->state = VectorState::getSingleValueDataChunkState();
     } else {
         auto& unflatVector = !isLeftResultFlat ? childrenExpr[0]->result : childrenExpr[1]->result;
         valueVector->state = unflatVector->state;

--- a/src/expression/physical/physical_expression.cpp
+++ b/src/expression/physical/physical_expression.cpp
@@ -1,7 +1,89 @@
 #include "src/expression/include/physical/physical_expression.h"
 
+#include "src/common/include/vector/operations/vector_arithmetic_operations.h"
+#include "src/common/include/vector/operations/vector_boolean_operations.h"
+#include "src/common/include/vector/operations/vector_cast_operations.h"
+#include "src/common/include/vector/operations/vector_comparison_operations.h"
+#include "src/common/include/vector/operations/vector_node_id_operations.h"
+
 namespace graphflow {
 namespace expression {
+
+std::function<void(ValueVector&, ValueVector&)> PhysicalExpression::getUnaryOperation(
+    ExpressionType type) {
+    switch (type) {
+    case NOT:
+        return VectorBooleanOperations::Not;
+    case NEGATE:
+        return VectorArithmeticOperations::Negate;
+    case IS_NULL:
+        return VectorComparisonOperations::IsNull;
+    case IS_NOT_NULL:
+        return VectorComparisonOperations::IsNotNull;
+    case HASH_NODE_ID:
+        return VectorNodeIDOperations::Hash;
+    case DECOMPRESS_NODE_ID:
+        return VectorNodeIDOperations::Decompress;
+    case CAST_TO_STRING:
+        return VectorCastOperations::castStructuredToStringValue;
+    case CAST_TO_UNSTRUCTURED_VECTOR:
+        return VectorCastOperations::castStructuredToUnstructuredValue;
+    case CAST_UNSTRUCTURED_VECTOR_TO_BOOL_VECTOR:
+        return VectorCastOperations::castUnstructuredToBoolValue;
+    default:
+        assert(false);
+    }
+}
+
+std::function<void(ValueVector&, ValueVector&, ValueVector&)>
+PhysicalExpression::getBinaryOperation(ExpressionType type) {
+    switch (type) {
+    case AND:
+        return VectorBooleanOperations::And;
+    case OR:
+        return VectorBooleanOperations::Or;
+    case XOR:
+        return VectorBooleanOperations::Xor;
+    case EQUALS:
+        return VectorComparisonOperations::Equals;
+    case NOT_EQUALS:
+        return VectorComparisonOperations::NotEquals;
+    case GREATER_THAN:
+        return VectorComparisonOperations::GreaterThan;
+    case GREATER_THAN_EQUALS:
+        return VectorComparisonOperations::GreaterThanEquals;
+    case LESS_THAN:
+        return VectorComparisonOperations::LessThan;
+    case LESS_THAN_EQUALS:
+        return VectorComparisonOperations::LessThanEquals;
+    case EQUALS_NODE_ID:
+        return VectorNodeIDCompareOperations::Equals;
+    case NOT_EQUALS_NODE_ID:
+        return VectorNodeIDCompareOperations::NotEquals;
+    case GREATER_THAN_NODE_ID:
+        return VectorNodeIDCompareOperations::GreaterThan;
+    case GREATER_THAN_EQUALS_NODE_ID:
+        return VectorNodeIDCompareOperations::GreaterThanEquals;
+    case LESS_THAN_NODE_ID:
+        return VectorNodeIDCompareOperations::LessThan;
+    case LESS_THAN_EQUALS_NODE_ID:
+        return VectorNodeIDCompareOperations::LessThanEquals;
+    case ADD:
+        return VectorArithmeticOperations::Add;
+    case SUBTRACT:
+        return VectorArithmeticOperations::Subtract;
+    case MULTIPLY:
+        return VectorArithmeticOperations::Multiply;
+    case DIVIDE:
+        return VectorArithmeticOperations::Divide;
+    case MODULO:
+        return VectorArithmeticOperations::Modulo;
+    case POWER:
+        return VectorArithmeticOperations::Power;
+    default:
+        assert(false);
+    }
+}
 
 bool PhysicalExpression::isResultFlat() {
     if (childrenExpr.empty()) {

--- a/src/expression/physical/physical_unary_expression.cpp
+++ b/src/expression/physical/physical_unary_expression.cpp
@@ -8,7 +8,7 @@ PhysicalUnaryExpression::PhysicalUnaryExpression(
     childrenExpr.push_back(move(child));
     this->expressionType = expressionType;
     this->dataType = dataType;
-    operation = ValueVector::getUnaryOperation(expressionType);
+    operation = getUnaryOperation(expressionType);
     result = createResultValueVector();
 }
 

--- a/src/loader/BUILD.bazel
+++ b/src/loader/BUILD.bazel
@@ -33,12 +33,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "thread_pool",
-        "//src/common",
         "//src/common:csv_reader",
-        "//src/storage:catalog",
         "//src/storage:data_structure_utils",
         "//src/storage:graph",
-        "//src/storage:store",
         "@gabime_spdlog",
         "@martinus_robin_hood_hashing",
         "@nlohmann_json",

--- a/src/loader/include/in_mem_pages.h
+++ b/src/loader/include/in_mem_pages.h
@@ -5,6 +5,7 @@
 #include <mutex>
 
 #include "src/common/include/configs.h"
+#include "src/common/include/string.h"
 #include "src/common/include/types.h"
 #include "src/storage/include/data_structure/utils.h"
 

--- a/src/loader/include/utils.h
+++ b/src/loader/include/utils.h
@@ -8,6 +8,7 @@
 #include "src/common/include/compression_scheme.h"
 #include "src/common/include/configs.h"
 #include "src/common/include/types.h"
+#include "src/common/include/utils.h"
 #include "src/storage/include/data_structure/lists/list_headers.h"
 #include "src/storage/include/data_structure/lists/lists_metadata.h"
 #include "src/storage/include/data_structure/utils.h"

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -63,6 +63,6 @@ cc_library(
         "include/parsed_expression.h",
     ],
     deps = [
-        "//src/common",
+        "//src/common:expression_type",
     ],
 )

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -66,7 +66,7 @@ cc_library(
         "include/query_graph/query_graph.h",
     ],
     deps = [
-        "//src/expression",
+        "//src/expression:logical_expression",
     ],
 )
 
@@ -92,6 +92,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/expression",
+        "//src/expression:logical_expression",
+        "//src/common:file_ser_deser_helper",
     ],
 )

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -54,9 +54,9 @@ cc_library(
     deps = [
         "memory_manager",
         "result_set",
-        "//src/common",
         "//src/common:csv_reader",
-        "//src/expression",
+        "//src/expression:logical_expression",
+        "//src/expression:physical_expression",
         "//src/storage:graph",
         "//src/storage:lists_aux",
         "//src/transaction",
@@ -75,7 +75,7 @@ cc_library(
         "include/physical_plan/operator/result/tuple.h",
     ],
     deps = [
-        "//src/common",
+        "//src/common:data_chunk",
         "//src/storage:lists_aux",
     ],
 )
@@ -127,6 +127,5 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/common",
     ],
 )

--- a/src/processor/include/memory_manager.h
+++ b/src/processor/include/memory_manager.h
@@ -4,10 +4,7 @@
 #include <memory>
 #include <mutex>
 
-#include "src/common/include/types.h"
-
 using namespace std;
-using namespace graphflow::common;
 
 namespace graphflow {
 namespace processor {

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -65,9 +65,6 @@ public:
     shared_ptr<HashJoinSharedState> sharedState;
 
 private:
-    std::function<void(ValueVector&, ValueVector&)> vectorDecompressOp;
-    std::function<void(ValueVector&, ValueVector&)> vectorHashOp;
-
     uint64_t buildSideKeyDataChunkPos;
     uint64_t buildSideKeyVectorPos;
     vector<bool> buildSideDataChunkPosToIsFlat;

--- a/src/processor/include/task_system/morsel.h
+++ b/src/processor/include/task_system/morsel.h
@@ -3,8 +3,6 @@
 #include <cstdint>
 #include <mutex>
 
-#include "src/common/include/file_ser_deser_helper.h"
-
 using namespace std;
 using namespace graphflow::common;
 

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -64,7 +64,7 @@ unique_ptr<PhysicalExpression> mapLogicalLiteralExpressionToPhysical(
     auto vector = make_shared<ValueVector>(
         literalExpression.storeAsPrimitiveVector ? literalExpression.dataType : UNSTRUCTURED,
         1 /* capacity */);
-    vector->state = DataChunkState::getSingleValueDataChunkState();
+    vector->state = VectorState::getSingleValueDataChunkState();
     if (!literalExpression.storeAsPrimitiveVector) {
         ((Value*)vector->values)[0] = literalExpression.literal;
     } else {

--- a/src/processor/physical_plan/operator/load_csv/load_csv.cpp
+++ b/src/processor/physical_plan/operator/load_csv/load_csv.cpp
@@ -2,6 +2,8 @@
 
 #include <cassert>
 
+#include "src/common/include/string.h"
+
 using namespace graphflow::common;
 
 namespace graphflow {

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -8,7 +8,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/common",
+        "//src/common:configs",
         "@gabime_spdlog",
     ],
 )
@@ -20,8 +20,6 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "file_handle",
-        "//src/common",
-        "@gabime_spdlog",
         "@nlohmann_json",
     ],
 )
@@ -54,7 +52,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "data_structure_utils",
-        "//src/common",
+        "//src/common:types",
         "@gabime_spdlog",
     ],
 )
@@ -75,9 +73,8 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "buffer_manager",
-        "file_handle",
         "lists_aux",
-        "//src/common",
+        "//src/common:vector",
     ],
 )
 
@@ -93,10 +90,8 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "buffer_manager",
         "catalog",
         "data_structure",
-        "//src/common",
     ],
 )
 
@@ -106,7 +101,8 @@ cc_library(
     hdrs = ["include/catalog.h"],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/common",
+        "//src/common:types",
+        "//src/common:utils",
         "@fraillt_bitsery",
         "@gabime_spdlog",
         "@nlohmann_json",
@@ -116,19 +112,13 @@ cc_library(
 cc_library(
     name = "graph",
     srcs = [
-        "catalog.cpp",
         "graph.cpp",
     ],
     hdrs = [
-        "include/catalog.h",
         "include/graph.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "buffer_manager",
-        "catalog",
         "store",
-        "@fraillt_bitsery",
-        "@gabime_spdlog",
     ],
 )

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -10,6 +10,7 @@
 #include "spdlog/spdlog.h"
 
 #include "src/common/include/types.h"
+#include "src/common/include/utils.h"
 
 using namespace graphflow::common;
 using namespace std;

--- a/src/storage/include/data_structure/column.h
+++ b/src/storage/include/data_structure/column.h
@@ -2,6 +2,7 @@
 
 #include <string.h>
 
+#include "src/common/include/string.h"
 #include "src/common/include/types.h"
 #include "src/common/include/vector/node_vector.h"
 #include "src/storage/include/data_structure/data_structure.h"

--- a/src/storage/include/store/rels_store.h
+++ b/src/storage/include/store/rels_store.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "src/common/include/types.h"
 #include "src/storage/include/catalog.h"
 #include "src/storage/include/data_structure/column.h"
 #include "src/storage/include/data_structure/lists/lists.h"

--- a/src/transaction/BUILD.bazel
+++ b/src/transaction/BUILD.bazel
@@ -6,7 +6,9 @@ cc_library(
         "include/local_storage.h",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//src/common"],
+    deps = [
+        "//src/common:data_chunk",
+    ],
 )
 
 cc_library(

--- a/test/common/BUILD.bazel
+++ b/test/common/BUILD.bazel
@@ -12,7 +12,8 @@ cc_test(
         "-Iexternal/gtest/include",
     ],
     deps = [
-        "//src/common:common",
+        "//src/common:data_chunk",
+        "//src/common:vector_operations",
         "@gtest",
         "@gtest//:gtest_main",
     ],

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "src/common/include/data_chunk/data_chunk.h"
+#include "src/common/include/vector/operations/vector_arithmetic_operations.h"
 
 using namespace graphflow::common;
 using namespace std;
@@ -28,39 +29,33 @@ TEST(VectorArithTests, test) {
         rData[i] = 110 - i;
     }
 
-    auto negateOp = ValueVector::getUnaryOperation(ExpressionType::NEGATE);
-    negateOp(*lVector, *result);
+    VectorArithmeticOperations::Negate(*lVector, *result);
     for (int32_t i = 0; i < 100; i++) {
         ASSERT_EQ(resultData[i], -i);
     }
 
-    auto addOp = ValueVector::getBinaryOperation(ExpressionType::ADD);
-    addOp(*lVector, *rVector, *result);
+    VectorArithmeticOperations::Add(*lVector, *rVector, *result);
     for (int32_t i = 0; i < 100; i++) {
         ASSERT_EQ(resultData[i], 110);
     }
 
-    auto subtractOp = ValueVector::getBinaryOperation(ExpressionType::SUBTRACT);
-    subtractOp(*lVector, *rVector, *result);
+    VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
     for (int32_t i = 0; i < 100; i++) {
         ASSERT_EQ(resultData[i], 2 * i - 110);
     }
 
-    auto multiplyOp = ValueVector::getBinaryOperation(ExpressionType::MULTIPLY);
-    multiplyOp(*lVector, *rVector, *result);
+    VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
     for (int32_t i = 0; i < 100; i++) {
         ASSERT_EQ(resultData[i], i * (110 - i));
     }
 
-    auto divideOp = ValueVector::getBinaryOperation(ExpressionType::DIVIDE);
-    divideOp(*lVector, *rVector, *result);
+    VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
     for (int32_t i = 0; i < 100; i++) {
         ASSERT_EQ(resultData[i], i / (110 - i));
     }
 
     /* note rVector and lVector are flipped */
-    auto moduloOp = ValueVector::getBinaryOperation(ExpressionType::MODULO);
-    moduloOp(*rVector, *lVector, *result);
+    VectorArithmeticOperations::Modulo(*rVector, *lVector, *result);
     for (int32_t i = 0; i < 100; i++) {
         ASSERT_EQ(resultData[i], i % (110 - i));
     }
@@ -68,8 +63,7 @@ TEST(VectorArithTests, test) {
     result = make_shared<ValueVector>(DOUBLE);
     dataChunk->append(result);
     auto resultDataAsDoubleArr = (double_t*)result->values;
-    auto powerOp = ValueVector::getBinaryOperation(ExpressionType::POWER);
-    powerOp(*lVector, *rVector, *result);
+    VectorArithmeticOperations::Power(*lVector, *rVector, *result);
     for (int32_t i = 0; i < 100; i++) {
         ASSERT_EQ(resultDataAsDoubleArr[i], pow(i, 110 - i));
     }

--- a/test/common/vector/operations/vector_boolean_operations_test.cpp
+++ b/test/common/vector/operations/vector_boolean_operations_test.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 
 #include "src/common/include/data_chunk/data_chunk.h"
+#include "src/common/include/vector/operations/vector_boolean_operations.h"
 
 using namespace graphflow::common;
 using namespace std;
@@ -37,29 +38,25 @@ TEST(VectorBoolTests, test) {
     }
 
     uint8_t andExpectedResult[] = {FALSE, FALSE, FALSE, TRUE};
-    auto andOp = ValueVector::getBinaryOperation(ExpressionType::AND);
-    andOp(*lVector, *rVector, *result);
+    VectorBooleanOperations::And(*lVector, *rVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], andExpectedResult[i]);
     }
 
     uint8_t orExpectedResult[] = {FALSE, TRUE, TRUE, TRUE};
-    auto orOp = ValueVector::getBinaryOperation(ExpressionType::OR);
-    orOp(*lVector, *rVector, *result);
+    VectorBooleanOperations::Or(*lVector, *rVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], orExpectedResult[i]);
     }
 
     uint8_t xorExpectedResult[] = {FALSE, TRUE, TRUE, FALSE};
-    auto xorOp = ValueVector::getBinaryOperation(ExpressionType::XOR);
-    xorOp(*lVector, *rVector, *result);
+    VectorBooleanOperations::Xor(*lVector, *rVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], xorExpectedResult[i]);
     }
 
     uint8_t notExpectedResult[] = {TRUE, TRUE, FALSE, FALSE};
-    auto notOp = ValueVector::getUnaryOperation(ExpressionType::NOT);
-    notOp(*lVector, *result);
+    VectorBooleanOperations::Not(*lVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], notExpectedResult[i]);
     }

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -1,6 +1,8 @@
 #include "gtest/gtest.h"
 
 #include "src/common/include/data_chunk/data_chunk.h"
+#include "src/common/include/string.h"
+#include "src/common/include/vector/operations/vector_comparison_operations.h"
 
 using namespace graphflow::common;
 using namespace std;
@@ -30,38 +32,32 @@ TEST(VectorCmpTests, cmpInt) {
         rData[i] = 90 - i;
     }
 
-    auto equalsOp = ValueVector::getBinaryOperation(ExpressionType::EQUALS);
-    equalsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::Equals(*lVector, *rVector, *result);
     for (int32_t i = 0; i < numTuples; i++) {
         ASSERT_EQ(resultData[i], i == 45 ? TRUE : FALSE);
     }
 
-    auto notEqualsOp = ValueVector::getBinaryOperation(ExpressionType::NOT_EQUALS);
-    notEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::NotEquals(*lVector, *rVector, *result);
     for (int32_t i = 0; i < numTuples; i++) {
         ASSERT_EQ(resultData[i], i == 45 ? FALSE : TRUE);
     }
 
-    auto lessThanOp = ValueVector::getBinaryOperation(ExpressionType::LESS_THAN);
-    lessThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
     for (int32_t i = 0; i < numTuples; i++) {
         ASSERT_EQ(resultData[i], i < 45 ? TRUE : FALSE);
     }
 
-    auto lessThanEqualsOp = ValueVector::getBinaryOperation(ExpressionType::LESS_THAN_EQUALS);
-    lessThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
     for (int32_t i = 0; i < numTuples; i++) {
         ASSERT_EQ(resultData[i], i < 46 ? TRUE : FALSE);
     }
 
-    auto greaterThanOp = ValueVector::getBinaryOperation(ExpressionType::GREATER_THAN);
-    greaterThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
     for (int32_t i = 0; i < numTuples; i++) {
         ASSERT_EQ(resultData[i], i < 46 ? FALSE : TRUE);
     }
 
-    auto greaterThanEqualsOp = ValueVector::getBinaryOperation(ExpressionType::GREATER_THAN_EQUALS);
-    greaterThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
     for (int32_t i = 0; i < numTuples; i++) {
         ASSERT_EQ(resultData[i], i < 45 ? FALSE : TRUE);
     }
@@ -94,45 +90,39 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
     memcpy(lData[0].data, value + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
     memcpy(rData[0].data, value + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
 
-    auto equalsOp = ValueVector::getBinaryOperation(ExpressionType::EQUALS);
-    equalsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::Equals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
     rData[0].data[3] = 'i';
-    equalsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::Equals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    auto notEqualsOp = ValueVector::getBinaryOperation(ExpressionType::NOT_EQUALS);
-    notEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::NotEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    auto lessThanOp = ValueVector::getBinaryOperation(ExpressionType::LESS_THAN);
-    lessThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    auto lessThanEqualsOp = ValueVector::getBinaryOperation(ExpressionType::LESS_THAN_EQUALS);
-    lessThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    auto greaterThanOp = ValueVector::getBinaryOperation(ExpressionType::GREATER_THAN);
-    greaterThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    auto greaterThanEqualsOp = ValueVector::getBinaryOperation(ExpressionType::GREATER_THAN_EQUALS);
-    greaterThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
     rData[0].data[3] = 'a';
-    lessThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    lessThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    greaterThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    greaterThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 }
 
@@ -169,44 +159,38 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
     memcpy(rOverflow, value, overflowLen);
     rData->overflowPtr = reinterpret_cast<uintptr_t>(rOverflow);
 
-    auto equalsOp = ValueVector::getBinaryOperation(ExpressionType::EQUALS);
-    equalsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::Equals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
     rOverflow[overflowLen - 1] = 'z';
-    equalsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::Equals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    auto notEqualsOp = ValueVector::getBinaryOperation(ExpressionType::NOT_EQUALS);
-    notEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::NotEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    auto lessThanOp = ValueVector::getBinaryOperation(ExpressionType::LESS_THAN);
-    lessThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    auto lessThanEqualsOp = ValueVector::getBinaryOperation(ExpressionType::LESS_THAN_EQUALS);
-    lessThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    auto greaterThanOp = ValueVector::getBinaryOperation(ExpressionType::GREATER_THAN);
-    greaterThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    auto greaterThanEqualsOp = ValueVector::getBinaryOperation(ExpressionType::GREATER_THAN_EQUALS);
-    greaterThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
     rOverflow[overflowLen - 1] = 'a';
-    lessThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    lessThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], FALSE);
 
-    greaterThanOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 
-    greaterThanEqualsOp(*lVector, *rVector, *result);
+    VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
 }

--- a/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
+++ b/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
@@ -3,18 +3,18 @@
 #include "src/common/include/data_chunk/data_chunk.h"
 #include "src/common/include/operations/hash_operations.h"
 #include "src/common/include/vector/node_vector.h"
+#include "src/common/include/vector/operations/vector_node_id_operations.h"
 
 using namespace graphflow::common;
 using namespace std;
 
-/*
 TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 1000;
     dataChunk->state->numSelectedValues = 1000;
 
     NodeIDCompressionScheme compressionScheme;
-    auto nodeVector = make_shared<NodeIDVector>(100, compressionScheme);
+    auto nodeVector = make_shared<NodeIDVector>(100, compressionScheme, false);
     dataChunk->append(nodeVector);
     auto nodeData = (uint64_t*)nodeVector->values;
 
@@ -27,8 +27,7 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
         nodeData[i] = i * 10 + 1;
     }
 
-    auto hashNodeIDOp = ValueVector::getUnaryOperation(HASH_NODE_ID);
-    hashNodeIDOp(*nodeVector, *result);
+    VectorNodeIDOperations::Hash(*nodeVector, *result);
     for (int32_t i = 0; i < 1000; i++) {
         auto expected = operation::murmurhash64(i * 10 + 1) ^ operation::murmurhash64(100);
         ASSERT_EQ(resultData[i], expected);
@@ -36,7 +35,7 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
 
     // Set dataChunk to flat
     dataChunk->state->currPos = 8;
-    hashNodeIDOp(*nodeVector, *result);
+    VectorNodeIDOperations::Hash(*nodeVector, *result);
     auto expected = operation::murmurhash64(8 * 10 + 1) ^ operation::murmurhash64(100);
     auto pos = result->state->getCurrSelectedValuesPos();
     ASSERT_EQ(resultData[pos], expected);
@@ -48,7 +47,8 @@ TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
     dataChunk->state->numSelectedValues = 1000;
 
     label_t commonLabel = 100;
-    auto nodeVector = make_shared<NodeIDSequenceVector>(commonLabel);
+    NodeIDCompressionScheme compressionScheme;
+    auto nodeVector = make_shared<NodeIDVector>(commonLabel, compressionScheme, true);
     nodeVector->setStartOffset(10);
     dataChunk->append(nodeVector);
 
@@ -56,8 +56,7 @@ TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
     dataChunk->append(result);
     auto resultData = (uint64_t*)result->values;
 
-    auto hashNodeIDOp = ValueVector::getUnaryOperation(HASH_NODE_ID);
-    hashNodeIDOp(*nodeVector, *result);
+    VectorNodeIDOperations::Hash(*nodeVector, *result);
     for (int32_t i = 0; i < 1000; i++) {
         auto expected = operation::murmurhash64(10 + i) ^ operation::murmurhash64(100);
         ASSERT_EQ(resultData[i], expected);
@@ -65,8 +64,8 @@ TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
 
     // Set dataChunk to flat
     dataChunk->state->currPos = 8;
-    hashNodeIDOp(*nodeVector, *result);
+    VectorNodeIDOperations::Hash(*nodeVector, *result);
     auto expected = operation::murmurhash64(10 + 8) ^ operation::murmurhash64(100);
     auto pos = result->state->getCurrSelectedValuesPos();
     ASSERT_EQ(resultData[pos], expected);
-}*/
+}


### PR DESCRIPTION
This PR separates the single library under common into several ones, so each module that depends on common only needs to grab what it actually needs.
Also, expression is separated into logical and phyiscal.