### PR TITLE
Enumerate load csv

### DIFF
--- a/dataset/tinysnb/params.csv
+++ b/dataset/tinysnb/params.csv
@@ -1,0 +1,3 @@
+age:INT32,name:STRING
+25,Xiyang
+30,Guodong

--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -27,7 +27,7 @@ unordered_set<string> Expression::getIncludedVariableNames() const {
         return result;
     }
     if (VARIABLE == expressionType) {
-        return getIncludedVariableNames();
+        return unordered_set<string>{variableName};
     }
     for (auto& childExpr : childrenExpr) {
         auto tmp = childExpr->getIncludedVariableNames();
@@ -36,17 +36,15 @@ unordered_set<string> Expression::getIncludedVariableNames() const {
     return result;
 }
 
-vector<const Expression*> Expression::getIncludedPropertyExpressions() const {
+vector<const Expression*> Expression::getIncludedExpressionsWithTypes(
+    const unordered_set<ExpressionType>& expressionTypes) const {
     auto result = vector<const Expression*>();
-    if (isExpressionLeafLiteral(expressionType) || VARIABLE == expressionType) {
-        return result;
-    }
-    if (PROPERTY == expressionType) {
+    if (expressionTypes.contains(expressionType)) {
         result.push_back(this);
         return result;
     }
     for (auto& childExpr : childrenExpr) {
-        auto tmp = childExpr->getIncludedPropertyExpressions();
+        auto tmp = childExpr->getIncludedExpressionsWithTypes(expressionTypes);
         result.insert(end(result), begin(tmp), end(tmp));
     }
     return result;

--- a/src/binder/include/bound_statements/bound_load_csv_statement.h
+++ b/src/binder/include/bound_statements/bound_load_csv_statement.h
@@ -15,17 +15,15 @@ namespace binder {
 class BoundLoadCSVStatement : public BoundReadingStatement {
 
 public:
-    BoundLoadCSVStatement(string filePath, char tokenSeparator,
-        vector<pair<string, DataType>> headerInfo, shared_ptr<Expression> csvLineVariable)
+    BoundLoadCSVStatement(
+        string filePath, char tokenSeparator, vector<shared_ptr<Expression>> csvColumnVariables)
         : BoundReadingStatement{LOAD_CSV_STATEMENT}, filePath{move(filePath)},
-          tokenSeparator(tokenSeparator), headerInfo{move(headerInfo)}, csvLineVariable{move(
-                                                                            csvLineVariable)} {}
+          tokenSeparator(tokenSeparator), csvColumnVariables{move(csvColumnVariables)} {}
 
 public:
     string filePath;
     char tokenSeparator;
-    vector<pair<string, DataType>> headerInfo;
-    shared_ptr<Expression> csvLineVariable;
+    vector<shared_ptr<Expression>> csvColumnVariables;
 };
 
 } // namespace binder

--- a/src/binder/include/expression/expression.h
+++ b/src/binder/include/expression/expression.h
@@ -40,13 +40,24 @@ public:
         return alias.empty() ? rawExpression : alias;
     }
 
-    virtual unordered_set<string> getIncludedVariableNames() const;
+    vector<const Expression*> getIncludedPropertyExpressions() const {
+        return getIncludedExpressionsWithTypes(unordered_set<ExpressionType>{PROPERTY});
+    }
 
-    vector<const Expression*> getIncludedPropertyExpressions() const;
+    vector<const Expression*> getIncludedLeafVariableExpressions() const {
+        return getIncludedExpressionsWithTypes(
+            unordered_set<ExpressionType>{PROPERTY, CSV_LINE_EXTRACT});
+    }
+
+    unordered_set<string> getIncludedVariableNames() const;
 
 protected:
     Expression(ExpressionType expressionType, DataType dataType)
         : expressionType{expressionType}, dataType{dataType} {}
+
+private:
+    vector<const Expression*> getIncludedExpressionsWithTypes(
+        const unordered_set<ExpressionType>& expressionTypes) const;
 
 public:
     // variable name for leaf variable expressions.

--- a/src/binder/include/expression/node_expression.h
+++ b/src/binder/include/expression/node_expression.h
@@ -15,10 +15,6 @@ public:
         variableName = nodeName;
     }
 
-    unordered_set<string> getIncludedVariableNames() const override {
-        return unordered_set<string>{variableName};
-    }
-
     string getIDProperty() { return variableName + "." + INTERNAL_ID; }
 
 public:

--- a/src/binder/include/expression/rel_expression.h
+++ b/src/binder/include/expression/rel_expression.h
@@ -17,10 +17,6 @@ public:
 
     inline string getDstNodeName() const { return dstNode->variableName; }
 
-    unordered_set<string> getIncludedVariableNames() const override {
-        return unordered_set<string>{variableName};
-    }
-
 public:
     label_t label;
     NodeExpression* srcNode;

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -33,8 +33,7 @@ private:
 
     shared_ptr<Expression> bindStringOperatorExpression(const ParsedExpression& parsedExpression);
 
-    shared_ptr<Expression> bindListExtractOperatorExpression(
-        const ParsedExpression& parsedExpression);
+    shared_ptr<Expression> bindCSVLineExtractExpression(const ParsedExpression& parsedExpression);
 
     shared_ptr<Expression> bindNullComparisonOperatorExpression(
         const ParsedExpression& parsedExpression);

--- a/src/binder/include/query_graph/query_graph.h
+++ b/src/binder/include/query_graph/query_graph.h
@@ -31,7 +31,7 @@ public:
 
     void addSubqueryGraph(const SubqueryGraph& other);
 
-    bool containAllVars(unordered_set<string>& vars) const;
+    bool containAllVariables(unordered_set<string>& variables) const;
 
     bool operator==(const SubqueryGraph& other) const;
 

--- a/src/binder/query_graph/query_graph.cpp
+++ b/src/binder/query_graph/query_graph.cpp
@@ -20,8 +20,8 @@ void SubqueryGraph::addSubqueryGraph(const SubqueryGraph& other) {
     queryNodesSelector |= other.queryNodesSelector;
 }
 
-bool SubqueryGraph::containAllVars(unordered_set<string>& vars) const {
-    for (auto& var : vars) {
+bool SubqueryGraph::containAllVariables(unordered_set<string>& variables) const {
+    for (auto& var : variables) {
         if (queryGraph.containsQueryNode(var) &&
             !queryNodesSelector[queryGraph.getQueryNodePos(var)]) {
             return false;

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -33,10 +33,6 @@ bool isExpressionStringOperator(ExpressionType type) {
     return STARTS_WITH == type || ENDS_WITH == type || CONTAINS == type;
 }
 
-bool isExpressionListExtractOperator(ExpressionType type) {
-    return LIST_EXTRACT == type;
-}
-
 bool isExpressionNullComparison(ExpressionType type) {
     return IS_NULL == type || IS_NOT_NULL == type;
 }
@@ -46,8 +42,12 @@ bool isExpressionLeafLiteral(ExpressionType type) {
            LITERAL_BOOLEAN == type || LITERAL_NULL == type;
 }
 
+/**
+ * Expression being leaf variable means it doesn't require evaluator and directly grabs value
+ * vector.
+ */
 bool isExpressionLeafVariable(ExpressionType type) {
-    return PROPERTY == type;
+    return PROPERTY == type || CSV_LINE_EXTRACT == type;
 }
 
 ExpressionType comparisonToIDComparison(ExpressionType type) {

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -60,9 +60,9 @@ enum ExpressionType : uint8_t {
     CONTAINS = 42,
 
     /**
-     * List Operator Expressions
+     * List Operator Expressions works only for CSV Line
      */
-    LIST_EXTRACT = 45,
+    CSV_LINE_EXTRACT = 45,
 
     /**
      * Null Operator Expressions
@@ -108,7 +108,6 @@ bool isExpressionBoolConnection(ExpressionType type);
 bool isExpressionComparison(ExpressionType type);
 bool isExpressionArithmetic(ExpressionType type);
 bool isExpressionStringOperator(ExpressionType type);
-bool isExpressionListExtractOperator(ExpressionType type);
 bool isExpressionNullComparison(ExpressionType type);
 bool isExpressionLeafLiteral(ExpressionType type);
 bool isExpressionLeafVariable(ExpressionType type);

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -48,13 +48,10 @@ enum DataType : uint8_t {
     STRING = 7,
     NODE_ID = 8,
     UNSTRUCTURED = 9,
-    // This is a temporary solution to bind LOAD CSV statement. This data type should be removed
-    // once we have a complete LIST implementation.
-    LIST_STRING = 10,
 };
 
 const string DataTypeNames[] = {"REL", "NODE", "LABEL", "BOOL", "INT32", "INT64", "DOUBLE",
-    "STRING", "NODE_ID", "UNSTRUCTURED", "LIST_STRING"};
+    "STRING", "NODE_ID", "UNSTRUCTURED"};
 
 int32_t convertToInt32(char* data);
 

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -411,7 +411,7 @@ unique_ptr<ParsedExpression> Transformer::transformListOperatorExpression(
     CypherParser::OC_ListOperatorExpressionContext& ctx,
     unique_ptr<ParsedExpression> propertyExpression) {
     auto rawExpression = propertyExpression->rawExpression + " " + ctx.getText();
-    auto expression = make_unique<ParsedExpression>(LIST_EXTRACT, string(), rawExpression);
+    auto expression = make_unique<ParsedExpression>(CSV_LINE_EXTRACT, string(), rawExpression);
     expression->children.push_back(move(propertyExpression));
     expression->children.push_back(transformExpression(*ctx.oC_Expression()));
     return expression;

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -26,6 +26,11 @@ public:
 private:
     void enumerateBoundQueryPart(BoundQueryPart& boundQueryPart);
 
+    void enumerateBoundReadingStatement(BoundReadingStatement& boundReadingStatement,
+        vector<shared_ptr<Expression>>& whereClauseSplitOnAND);
+
+    void enumerateBoundLoadCSVStatement(const BoundLoadCSVStatement& boundLoadCSVStatement);
+
     void updateQueryGraphAndWhereClause(BoundMatchStatement& boundMatchStatement,
         vector<shared_ptr<Expression>>& whereClauseSplitOnAND);
 
@@ -39,6 +44,8 @@ private:
     void enumerateHashJoin(const vector<shared_ptr<Expression>>& whereClauseSplitOnAND);
 
     void enumerateExtend(const vector<shared_ptr<Expression>>& whereClauseSplitOnAND);
+
+    void appendLoadCSV(const BoundLoadCSVStatement& boundLoadCSVStatement, LogicalPlan& plan);
 
     void appendLogicalScan(uint32_t queryNodePos, LogicalPlan& plan);
 

--- a/src/planner/include/logical_plan/operator/load_csv/logical_load_csv.h
+++ b/src/planner/include/logical_plan/operator/load_csv/logical_load_csv.h
@@ -9,11 +9,10 @@ namespace planner {
 class LogicalLoadCSV : public LogicalOperator {
 
 public:
-    LogicalLoadCSV(string path, char tokenSeparator,
-        vector<pair<string, DataType>> csvColumnVariableInfo,
-        shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, path{move(path)}, tokenSeparator{tokenSeparator},
-          csvColumnVariableInfo{move(csvColumnVariableInfo)} {}
+    LogicalLoadCSV(
+        string path, char tokenSeparator, vector<shared_ptr<Expression>> csvColumnVariables)
+        : path{move(path)}, tokenSeparator{tokenSeparator}, csvColumnVariables{
+                                                                move(csvColumnVariables)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_LOAD_CSV;
@@ -24,7 +23,7 @@ public:
 public:
     string path;
     char tokenSeparator;
-    vector<pair<string, DataType>> csvColumnVariableInfo;
+    vector<shared_ptr<Expression>> csvColumnVariables;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
+++ b/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
@@ -10,6 +10,9 @@ class LogicalScanNodeID : public LogicalOperator {
 public:
     LogicalScanNodeID(string nodeID, label_t label) : nodeID{move(nodeID)}, label{label} {}
 
+    LogicalScanNodeID(string nodeID, label_t label, shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{prevOperator}, nodeID{move(nodeID)}, label{label} {}
+
     LogicalOperatorType getLogicalOperatorType() const {
         return LogicalOperatorType::LOGICAL_SCAN_NODE_ID;
     }

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -34,6 +34,8 @@ public:
 class Schema {
 
 public:
+    Schema();
+
     void addMatchedAttribute(const string& attribute);
 
     void addQueryRelAndLogicalExtend(const string& queryRel, LogicalExtend* extend);
@@ -46,8 +48,6 @@ public:
     bool isVariableFlat(const string& variable) const;
 
     FactorizationGroup* getFactorizationGroup(const string& variable);
-
-    void initFlatFactorizationGroup(const string& variable, uint64_t cardinality);
 
     void addUnFlatFactorizationGroup(unordered_set<string> variables, uint64_t extensionRate);
 

--- a/src/planner/logical_plan/schema.cpp
+++ b/src/planner/logical_plan/schema.cpp
@@ -13,6 +13,10 @@ void FactorizationGroup::addVariables(unordered_set<string> variablesToAdd) {
     variables.insert(variablesToAdd.begin(), variablesToAdd.end());
 }
 
+Schema::Schema() {
+    flatGroup = make_unique<FactorizationGroup>(unordered_set<string>(), 1);
+}
+
 void Schema::addMatchedAttribute(const string& attribute) {
     matchedAttributes.insert(attribute);
 }
@@ -38,10 +42,6 @@ FactorizationGroup* Schema::getFactorizationGroup(const string& variable) {
         return flatGroup.get();
     }
     return unflatGroups[variableUnflatGroupPosMap.at(variable)].get();
-}
-
-void Schema::initFlatFactorizationGroup(const string& variable, uint64_t cardinality) {
-    flatGroup = make_unique<FactorizationGroup>(unordered_set<string>{variable}, cardinality);
 }
 
 void Schema::addUnFlatFactorizationGroup(unordered_set<string> variables, uint64_t extensionRate) {
@@ -84,7 +84,6 @@ unique_ptr<Schema> Schema::copy() {
 }
 
 void Schema::flattenFactorizationGroup(const FactorizationGroup& groupToFlatten) {
-    assert(!flatGroup->variables.empty());
     for (auto& variable : groupToFlatten.variables) {
         variableUnflatGroupPosMap.erase(variable);
     }

--- a/src/processor/include/physical_plan/operator/load_csv/load_csv.h
+++ b/src/processor/include/physical_plan/operator/load_csv/load_csv.h
@@ -8,6 +8,7 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace processor {
 
+template<bool IS_OUT_DATACHUNK_FILTERED>
 class LoadCSV : public PhysicalOperator {
 
 public:
@@ -15,7 +16,10 @@ public:
 
     void getNextTuples() override;
 
-    unique_ptr<PhysicalOperator> clone() override;
+    unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<LoadCSV<IS_OUT_DATACHUNK_FILTERED>>(
+            fname, tokenSeparator, csvColumnDataTypes);
+    }
 
 private:
     string fname;

--- a/src/processor/include/physical_plan/operator/scan_node_id/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id/scan_node_id.h
@@ -10,14 +10,18 @@ template<bool IS_OUT_DATACHUNK_FILTERED>
 class ScanNodeID : public PhysicalOperator {
 
 public:
-    ScanNodeID(shared_ptr<MorselsDesc>& morselDesc);
+    explicit ScanNodeID(shared_ptr<MorselsDesc>& morselDesc);
+
+    ScanNodeID(shared_ptr<MorselsDesc>& morselsDesc, unique_ptr<PhysicalOperator> prevOperator);
 
     void getNextTuples() override;
 
     shared_ptr<NodeIDVector>& getNodeVector() { return nodeIDVector; }
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ScanNodeID<IS_OUT_DATACHUNK_FILTERED>>(morsel);
+        return prevOperator ? make_unique<ScanNodeID<IS_OUT_DATACHUNK_FILTERED>>(
+                                  morsel, prevOperator->clone()) :
+                              make_unique<ScanNodeID<IS_OUT_DATACHUNK_FILTERED>>(morsel);
     }
 
 protected:

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -102,6 +102,7 @@ void QueryProcessor::decomposePlanIntoTasks(
         break;
     }
     case SCAN:
+    case LOAD_CSV:
         break;
     default:
         decomposePlanIntoTasks(op->prevOperator.get(), maxNumThreads, parentTask);

--- a/test/binder/binder_test_utils.cpp
+++ b/test/binder/binder_test_utils.cpp
@@ -3,14 +3,12 @@
 bool BinderTestUtils::equals(
     const BoundLoadCSVStatement& left, const BoundLoadCSVStatement& right) {
     auto result = left.filePath == right.filePath && left.tokenSeparator == right.tokenSeparator &&
-                  left.headerInfo.size() == right.headerInfo.size() &&
-                  equals(*left.csvLineVariable, *right.csvLineVariable);
+                  left.csvColumnVariables.size() == right.csvColumnVariables.size();
     if (!result) {
         return false;
     }
-    for (auto i = 0u; i < left.headerInfo.size(); ++i) {
-        if (left.headerInfo[i].first != right.headerInfo[i].first ||
-            left.headerInfo[i].second != right.headerInfo[i].second) {
+    for (auto i = 0u; i < left.csvColumnVariables.size(); ++i) {
+        if (!equals(*left.csvColumnVariables[i], *right.csvColumnVariables[i])) {
             return false;
         }
     }

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -100,7 +100,7 @@ TEST_F(ExpressionTest, FilterStringOperatorTest) {
 
 TEST_F(ExpressionTest, FilterLtOperatorTest) {
     auto aAge = makeAAgeExpression();
-    auto csvLine0 = make_unique<ParsedExpression>(LIST_EXTRACT, EMPTY, EMPTY);
+    auto csvLine0 = make_unique<ParsedExpression>(CSV_LINE_EXTRACT, EMPTY, EMPTY);
     csvLine0->children.emplace_back(make_unique<ParsedExpression>(VARIABLE, "csvLine", EMPTY));
     csvLine0->children.emplace_back(make_unique<ParsedExpression>(LITERAL_INT, "0", EMPTY));
     auto where = make_unique<ParsedExpression>(EQUALS, EMPTY, EMPTY, move(aAge), move(csvLine0));

--- a/test/planner/optimizer/BUILD.bazel
+++ b/test/planner/optimizer/BUILD.bazel
@@ -5,6 +5,9 @@ cc_test(
     srcs = [
         "optimizer_test.cpp",
     ],
+    data = [
+        "//dataset",
+    ],
     deps = [
         "//src/binder",
         "//src/parser",

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -23,6 +23,7 @@ filegroup(
     name = "testfiles",
     srcs = [
         "queries/filtered/id_comparison.test",
+        "queries/filtered/load_csv.test",
         "queries/filtered/nodes.test",
         "queries/filtered/paths.test",
         "queries/filtered/stars.test",

--- a/test/runner/end_to_end_test.cpp
+++ b/test/runner/end_to_end_test.cpp
@@ -64,3 +64,8 @@ TEST(ProcessorTest, FrontierQueries) {
     TestHelper testHelper;
     ASSERT_TRUE(testHelper.runTest("test/runner/queries/structural/frontier.test"));
 }
+
+TEST(ProcessorTest, LOADCSVQueries) {
+    TestHelper testHelper;
+    ASSERT_TRUE(testHelper.runTest("test/runner/queries/filtered/load_csv.test"));
+}

--- a/test/runner/queries/filtered/load_csv.test
+++ b/test/runner/queries/filtered/load_csv.test
@@ -1,0 +1,13 @@
+# description: load csv test
+
+-INPUT dataset/tinysnb/
+-OUTPUT test/unittest_temp/
+-PARALLELISM 1
+
+-NAME LOADCSVOneHopTest
+-QUERY LOAD CSV WITH HEADERS FROM "dataset/tinysnb/params.csv" AS csvLine MATCH (a:person)-[:knows]->(:person) WHERE a.age = csvLine[0] RETURN COUNT(*)
+---- 3
+
+-NAME LOADCSVSingleNodeTest
+-QUERY LOAD CSV WITH HEADERS FROM "dataset/tinysnb/params.csv" AS csvLine MATCH (a:person) WHERE a.age = csvLine[0] RETURN COUNT(*)
+---- 2


### PR DESCRIPTION
This PR add a hacky support to support LOAD CSV. Hacks are

- introduce CSV_LINE_EXTRACT expression type which represents csvLine[i]
- csvLine is binded as multiple CSV_LINE_EXTRACT expressions (euqals to number of columns)
- evaluation of CSV_LINE_EXTRACT is just grabbing valuevector (same as evaluating property expression)