### PR TITLE
refactor of value vector

### DIFF
--- a/src/common/include/data_chunk/data_chunk.h
+++ b/src/common/include/data_chunk/data_chunk.h
@@ -25,7 +25,7 @@ public:
     DataChunk() : DataChunk(true){};
 
     DataChunk(bool initializeSelectedValuesPos)
-        : state{new VectorState(initializeSelectedValuesPos, MAX_VECTOR_SIZE)} {};
+        : state{new VectorState(initializeSelectedValuesPos, DEFAULT_VECTOR_CAPACITY)} {};
 
     void append(shared_ptr<ValueVector> valueVector) {
         valueVector->state = this->state;

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -11,8 +11,8 @@ using namespace std;
 namespace graphflow {
 namespace common {
 
-constexpr uint64_t MAX_VECTOR_SIZE = 2048;
-constexpr uint64_t NODE_SEQUENCE_VECTOR_SIZE = 1024;
+constexpr uint64_t DEFAULT_VECTOR_CAPACITY = 2048;
+constexpr uint64_t NODE_SEQUENCE_VECTOR_CAPACITY = 1024;
 
 typedef uint32_t label_t;
 typedef uint64_t node_offset_t;

--- a/src/common/include/vector/node_vector.h
+++ b/src/common/include/vector/node_vector.h
@@ -27,10 +27,11 @@ class NodeIDVector : public ValueVector {
 public:
     NodeIDVector(label_t commonLabel, const NodeIDCompressionScheme& nodeIDCompressionScheme,
         bool isSequence)
-        : NodeIDVector{commonLabel, nodeIDCompressionScheme, isSequence, MAX_VECTOR_SIZE} {};
+        : NodeIDVector{
+              commonLabel, nodeIDCompressionScheme, isSequence, DEFAULT_VECTOR_CAPACITY} {};
 
-    void readNodeOffset(uint64_t pos, nodeID_t& nodeID) const override;
-    void readNodeOffsetAndLabel(uint64_t pos, nodeID_t& nodeID) const override;
+    node_offset_t readNodeOffset(uint64_t pos) const override;
+    void readNodeID(uint64_t pos, nodeID_t& nodeID) const override;
 
     inline void setStartOffset(node_offset_t node_offset) {
         assert(representation.isSequence);

--- a/src/common/include/vector/operations/executors/binary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/binary_operation_executor.h
@@ -144,9 +144,9 @@ struct BinaryOperationExecutor {
         nodeID_t nodeID, otherNodeID;
         if (left.state->isFlat() && right.state->isFlat()) {
             auto lPos = left.state->getCurrSelectedValuesPos();
-            left.readNodeOffsetAndLabel(lPos, nodeID);
+            left.readNodeID(lPos, nodeID);
             auto rPos = right.state->getCurrSelectedValuesPos();
-            right.readNodeOffsetAndLabel(rPos, otherNodeID);
+            right.readNodeID(rPos, otherNodeID);
             auto resPos = result.state->getCurrSelectedValuesPos();
             result.nullMask[resPos] = left.nullMask[lPos] || right.nullMask[rPos];
             if (!result.nullMask[resPos]) {
@@ -158,11 +158,11 @@ struct BinaryOperationExecutor {
             auto& unflatVector = !isLeftFlat ? left : right;
             auto pos = flatVector.state->getCurrSelectedValuesPos();
             auto isFlatNull = flatVector.nullMask[pos];
-            flatVector.readNodeOffsetAndLabel(pos, nodeID);
+            flatVector.readNodeID(pos, nodeID);
             // unflat and result vectors share the same selectedValuesPos.
             for (uint64_t i = 0; i < unflatVector.state->numSelectedValues; i++) {
                 pos = unflatVector.state->selectedValuesPos[i];
-                unflatVector.readNodeOffsetAndLabel(pos, otherNodeID);
+                unflatVector.readNodeID(pos, otherNodeID);
                 result.nullMask[i] = isFlatNull || unflatVector.nullMask[pos];
                 if (!result.nullMask[i]) {
                     result.values[i] = isLeftFlat ? FUNC::operation(nodeID, otherNodeID) :
@@ -173,8 +173,8 @@ struct BinaryOperationExecutor {
             // right, left, and result vectors share the same selectedValuesPos.
             for (uint64_t i = 0; i < left.state->numSelectedValues; i++) {
                 auto pos = left.state->selectedValuesPos[i];
-                left.readNodeOffsetAndLabel(pos, nodeID);
-                right.readNodeOffsetAndLabel(pos, otherNodeID);
+                left.readNodeID(pos, nodeID);
+                right.readNodeID(pos, otherNodeID);
                 result.nullMask[pos] = left.nullMask[pos] || right.nullMask[pos];
                 if (!result.nullMask[pos]) {
                     result.values[pos] = FUNC::operation(nodeID, otherNodeID);

--- a/src/common/include/vector/operations/executors/unary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/unary_operation_executor.h
@@ -53,14 +53,14 @@ struct UnaryOperationExecutor {
         nodeID_t nodeID;
         if (operand.state->isFlat()) {
             auto pos = operand.state->getCurrSelectedValuesPos();
-            operand.readNodeOffsetAndLabel(pos, nodeID);
+            operand.readNodeID(pos, nodeID);
             if (!operand.nullMask[pos]) {
                 resultValues[pos] = FUNC::operation(nodeID);
             }
         } else {
             for (auto i = 0ul; i < operand.state->numSelectedValues; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
-                operand.readNodeOffsetAndLabel(pos, nodeID);
+                operand.readNodeID(pos, nodeID);
                 if (!operand.nullMask[pos]) {
                     resultValues[pos] = FUNC::operation(nodeID);
                 }

--- a/src/common/include/vector/vector_state.h
+++ b/src/common/include/vector/vector_state.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <vector>
 
+#include "src/common/include/types.h"
+
 using namespace std;
 
 namespace graphflow {
@@ -23,7 +25,7 @@ public:
     }
 
     void initMultiplicity() {
-        multiplicityBuffer = make_unique<uint64_t[]>(2048 /* Max Vector Size */);
+        multiplicityBuffer = make_unique<uint64_t[]>(DEFAULT_VECTOR_CAPACITY);
         multiplicity = multiplicityBuffer.get();
     }
 
@@ -31,7 +33,7 @@ public:
 
     inline uint64_t getCurrSelectedValuesPos() const { return selectedValuesPos[currPos]; }
 
-    uint64_t getNumSelectedValues();
+    uint64_t getNumSelectedValues() const;
 
     shared_ptr<VectorState> clone();
 

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -42,15 +42,14 @@ void ValueVector::fillNullMask() {
 }
 
 shared_ptr<ValueVector> ValueVector::clone() {
-    auto vectorCapacity = capacity / getDataTypeSize(dataType);
     auto newVector = make_shared<ValueVector>(dataType, vectorCapacity);
     memcpy(newVector->nullMask, nullMask, vectorCapacity);
     if (STRING == dataType) {
-        for (auto i = 0; i < vectorCapacity; i++) {
+        for (auto i = 0u; i < vectorCapacity; i++) {
             ((gf_string_t*)newVector->values)[i] = ((gf_string_t*)values)[i];
         }
     } else {
-        memcpy(newVector->values, values, capacity);
+        memcpy(newVector->values, values, vectorCapacity * getNumBytesPerValue());
     }
     return newVector;
 }

--- a/src/common/vector/vector_state.cpp
+++ b/src/common/vector/vector_state.cpp
@@ -17,14 +17,14 @@ VectorState::VectorState(bool initializeSelectedValuesPos, uint64_t capacity)
     multiplicity = nullptr;
 }
 
-uint64_t VectorState::getNumSelectedValues() {
+uint64_t VectorState::getNumSelectedValues() const {
     if (isFlat()) {
         return multiplicity == nullptr ? 1 : multiplicity[getCurrSelectedValuesPos()];
     } else if (multiplicity == nullptr) {
         return numSelectedValues;
     } else {
         auto numSelectedValuesSum = 0u;
-        for (auto i = 0; i < numSelectedValues; i++) {
+        for (auto i = 0u; i < numSelectedValues; i++) {
             numSelectedValuesSum += multiplicity[selectedValuesPos[i]];
         }
         return numSelectedValuesSum;
@@ -39,7 +39,7 @@ shared_ptr<VectorState> VectorState::getSingleValueDataChunkState() {
 }
 
 shared_ptr<VectorState> VectorState::clone() {
-    auto capacity = sizeof(valuesPos.get()) / sizeof(uint64_t);
+    auto capacity = size == 1 ? 1 : DEFAULT_VECTOR_CAPACITY;
     auto newState = make_shared<VectorState>(false /*initializeSelectedValuesPos*/, capacity);
     newState->size = size;
     newState->currPos = currPos;

--- a/src/expression_evaluator/binary_expression_evaluator.cpp
+++ b/src/expression_evaluator/binary_expression_evaluator.cpp
@@ -20,7 +20,7 @@ void BinaryExpressionEvaluator::evaluate() {
 }
 
 shared_ptr<ValueVector> BinaryExpressionEvaluator::createResultValueVector() {
-    auto valueVector = make_shared<ValueVector>(dataType, MAX_VECTOR_SIZE);
+    auto valueVector = make_shared<ValueVector>(dataType);
     auto isLeftResultFlat = childrenExpr[0]->isResultFlat();
     auto isRightResultFlat = childrenExpr[1]->isResultFlat();
     if (isLeftResultFlat && isRightResultFlat) {

--- a/src/expression_evaluator/unary_expression_evaluator.cpp
+++ b/src/expression_evaluator/unary_expression_evaluator.cpp
@@ -18,10 +18,10 @@ void UnaryExpressionEvaluator::evaluate() {
 }
 
 shared_ptr<ValueVector> UnaryExpressionEvaluator::createResultValueVector() {
-    auto valueVector = make_shared<ValueVector>(dataType, MAX_VECTOR_SIZE);
+    auto valueVector = make_shared<ValueVector>(dataType);
     if (expressionType == CAST_TO_UNSTRUCTURED_VECTOR) {
         auto unstructuredValues = (Value*)valueVector->values;
-        for (auto i = 0u; i < MAX_VECTOR_SIZE; i++) {
+        for (auto i = 0u; i < DEFAULT_VECTOR_CAPACITY; i++) {
             unstructuredValues[i].dataType = childrenExpr[0]->dataType;
         }
     }

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -67,7 +67,7 @@ unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToPhysical(
     // We create an owner dataChunk which is flat and of size 1 to contain the literal.
     auto vector = make_shared<ValueVector>(
         literalExpression.storeAsPrimitiveVector ? literalExpression.dataType : UNSTRUCTURED,
-        1 /* capacity */);
+        true /* isSingleValue */);
     vector->state = VectorState::getSingleValueDataChunkState();
     if (!literalExpression.storeAsPrimitiveVector) {
         ((Value*)vector->values)[0] = literalExpression.literal;

--- a/src/processor/physical_plan/operator/filter/filter.cpp
+++ b/src/processor/physical_plan/operator/filter/filter.cpp
@@ -9,7 +9,7 @@ Filter<IS_AFTER_FLATTEN>::Filter(unique_ptr<ExpressionEvaluator> rootExpr,
     : PhysicalOperator{move(prevOperator), FILTER}, rootExpr{move(rootExpr)},
       dataChunkToSelectPos(dataChunkToSelectPos), prevInNumSelectedValues{0ul} {
     if (IS_AFTER_FLATTEN) {
-        prevInSelectedValuesPos = make_unique<uint64_t[]>(MAX_VECTOR_SIZE);
+        prevInSelectedValuesPos = make_unique<uint64_t[]>(DEFAULT_VECTOR_CAPACITY);
     }
     resultSet = this->prevOperator->getResultSet();
     dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -28,7 +28,7 @@ HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::HashJoinProbe(uint64_t buildSideKeyDat
     hashedProbeKeyVector = make_shared<ValueVector>(INT64);
     hashedProbeKeyVector->state = probeSideKeyVector->state;
 
-    probeState = make_unique<ProbeState>(MAX_VECTOR_SIZE);
+    probeState = make_unique<ProbeState>(DEFAULT_VECTOR_CAPACITY);
 
     initializeOutResultSetAndVectorPtrs();
 }
@@ -92,7 +92,7 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeOutResultSetAndVectorPt
             createVectorsFromExistingOnesAndAppend(
                 *dataChunk, *unFlatOutDataChunk, dataChunkVectorPositions);
             for (auto j = 0u; j < dataChunk->valueVectors.size(); j++) {
-                auto vectorPtrs = make_unique<overflow_value_t[]>(NODE_SEQUENCE_VECTOR_SIZE);
+                auto vectorPtrs = make_unique<overflow_value_t[]>(NODE_SEQUENCE_VECTOR_CAPACITY);
                 BuildSideVectorInfo vectorInfo(dataChunk->valueVectors[j]->getNumBytesPerValue(),
                     resultSet->dataChunks.size(), j, buildSideVectorPtrs.size());
                 buildSideVectorInfos.push_back(vectorInfo);
@@ -143,7 +143,7 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::getNextBatchOfMatchedTuples() {
         uint64_t decompressedProbeKeyPos, probeSelPos;
         for (uint64_t i = probeState->probeKeyPos; i < probeState->probedTuplesSize; i++) {
             while (probeState->probedTuples[i]) {
-                if (NODE_SEQUENCE_VECTOR_SIZE == probeState->matchedTuplesSize) {
+                if (NODE_SEQUENCE_VECTOR_CAPACITY == probeState->matchedTuplesSize) {
                     break;
                 }
                 memcpy(&nodeId, probeState->probedTuples[i], NUM_BYTES_PER_NODE_ID);

--- a/src/processor/physical_plan/operator/load_csv/load_csv.cpp
+++ b/src/processor/physical_plan/operator/load_csv/load_csv.cpp
@@ -33,7 +33,7 @@ LoadCSV<IS_OUT_DATACHUNK_FILTERED>::LoadCSV(
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void LoadCSV<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
     auto lineIdx = 0ul;
-    while (lineIdx < MAX_VECTOR_SIZE && reader.hasNextLine()) {
+    while (lineIdx < DEFAULT_VECTOR_CAPACITY && reader.hasNextLine()) {
         auto tokenIdx = 0ul;
         while (reader.hasNextToken()) {
             auto& vector = *outValueVectors[tokenIdx];

--- a/src/processor/physical_plan/operator/read_list/frontier/frontier_bag.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier/frontier_bag.cpp
@@ -24,16 +24,15 @@ NodeIDOverflow* FrontierBag::getOverflowPtr() {
 }
 
 void FrontierBag::append(const NodeIDVector& vector, uint64_t multiplicity) {
-    nodeID_t nodeID;
     for (auto i = 0u; i < vector.state->size; i++) {
-        vector.readNodeOffset(i, nodeID);
-        auto slot = nodeID.offset & moduloSlotBitMask;
+        auto nodeOffset = vector.readNodeOffset(i);
+        auto slot = nodeOffset & moduloSlotBitMask;
         if (hashTable[slot].size < NODE_IDS_PER_SLOT_FOR_BAG) {
-            hashTable[slot].nodeOffsets[hashTable[slot].size] = nodeID.offset;
+            hashTable[slot].nodeOffsets[hashTable[slot].size] = nodeOffset;
             hashTable[slot].multiplicity[hashTable[slot].size++] = multiplicity;
         } else {
             auto overflowPtr = getOverflowPtr();
-            overflowPtr->nodeOffset = nodeID.offset;
+            overflowPtr->nodeOffset = nodeOffset;
             overflowPtr->multiplicity = multiplicity;
             if (hashTable[slot].tail == nullptr) {
                 hashTable[slot].next = hashTable[slot].tail = overflowPtr;

--- a/src/processor/physical_plan/operator/read_list/frontier/frontier_set.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier/frontier_set.cpp
@@ -90,10 +90,9 @@ void FrontierSet::insert(node_offset_t nodeOffset, uint64_t multiplicity) {
 }
 
 void FrontierSet::insert(const NodeIDVector& vector) {
-    nodeID_t nodeID;
     for (auto pos = 0u; pos < vector.state->size; pos++) {
-        vector.readNodeOffset(pos, nodeID);
-        insert(nodeID.offset, 1 /* multiplicity */);
+        auto nodeOffset = vector.readNodeOffset(pos);
+        insert(nodeOffset, 1 /* multiplicity */);
     }
 }
 

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -15,9 +15,9 @@ ReadList::ReadList(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos,
 
 void ReadList::readValuesFromList() {
     lists->reclaim(handle);
-    nodeID_t nodeID;
-    inNodeIDVector->readNodeOffset(inDataChunk->state->getCurrSelectedValuesPos(), nodeID);
-    lists->readValues(nodeID, outValueVector, outDataChunk->state->size, handle, MAX_TO_READ);
+    auto nodeOffset =
+        inNodeIDVector->readNodeOffset(inDataChunk->state->getCurrSelectedValuesPos());
+    lists->readValues(nodeOffset, outValueVector, outDataChunk->state->size, handle, MAX_TO_READ);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/result/result_set_iterator.cpp
+++ b/src/processor/physical_plan/operator/result/result_set_iterator.cpp
@@ -79,7 +79,7 @@ void ResultSetIterator::getNextTuple(Tuple& tuple) {
             } break;
             case NODE: {
                 nodeID_t nodeID;
-                vector->readNodeOffsetAndLabel(selectedTuplePos, nodeID);
+                vector->readNodeID(selectedTuplePos, nodeID);
                 tuple.getValue(valueInTupleIdx)->nodeID = nodeID;
                 break;
             }

--- a/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
@@ -40,7 +40,7 @@ void ScanNodeID<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
         } else {
             nodeIDVector->setStartOffset(morsel->currNodeOffset);
             outDataChunk->state->size =
-                min(NODE_SEQUENCE_VECTOR_SIZE, morsel->numNodes - morsel->currNodeOffset);
+                min(NODE_SEQUENCE_VECTOR_CAPACITY, morsel->numNodes - morsel->currNodeOffset);
             morsel->currNodeOffset += outDataChunk->state->size;
         }
     }

--- a/src/storage/include/data_structure/lists/lists.h
+++ b/src/storage/include/data_structure/lists/lists.h
@@ -14,11 +14,11 @@ namespace storage {
 class BaseLists : public DataStructure {
 
 public:
-    void readValues(const nodeID_t& nodeID, const shared_ptr<ValueVector>& valueVector,
+    void readValues(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
         uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle,
         uint32_t maxElementsToRead);
 
-    uint64_t getNumElementsInList(const nodeID_t& nodeID);
+    uint64_t getNumElementsInList(node_offset_t nodeOffset);
 
 protected:
     BaseLists(const string& fname, const DataType& dataType, const size_t& elementSize,
@@ -26,11 +26,10 @@ protected:
         : DataStructure{fname, dataType, elementSize, bufferManager}, metadata{fname},
           headers(headers){};
 
-    void readFromLargeList(const nodeID_t& nodeID, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle, uint32_t header,
-        uint32_t maxElementsToRead);
+    void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& listLen,
+        const unique_ptr<DataStructureHandle>& handle, uint32_t header, uint32_t maxElementsToRead);
 
-    void readSmallList(const nodeID_t& nodeID, const shared_ptr<ValueVector>& valueVector,
+    void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
         uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle, uint32_t header);
 
 public:
@@ -88,7 +87,7 @@ public:
         const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle);
 
 private:
-    void readUnstrPropertyListOfNode(const nodeID_t& nodeID, uint32_t propertyKeyIdxToRead,
+    void readUnstrPropertyListOfNode(node_offset_t nodeOffset, uint32_t propertyKeyIdxToRead,
         const shared_ptr<ValueVector>& valueVector, uint64_t pos,
         const unique_ptr<DataStructureHandle>& handle, uint32_t header);
 

--- a/src/transaction/local_storage.cpp
+++ b/src/transaction/local_storage.cpp
@@ -174,10 +174,9 @@ void LocalStorage::updateNodePropertyColumn(uint32_t currPosInDataChunk,
     uint64_t numUpdatesInDataChunk, BaseColumn& column, uint8_t* nullValue,
     page_idx_to_dirty_page_map& dirtyPagesMap, ValueVector* propertyValueVector,
     NodeIDVector* nodeIDVector) {
-    nodeID_t nodeID;
     for (auto i = currPosInDataChunk; i < numUpdatesInDataChunk + currPosInDataChunk; i++) {
-        nodeIDVector->readNodeOffset(i, nodeID);
-        auto pageCursor = column.getPageCursorForOffset(nodeID.offset);
+        auto nodeOffset = nodeIDVector->readNodeOffset(i);
+        auto pageCursor = column.getPageCursorForOffset(nodeOffset);
         auto page =
             putPageInDirtyPagesMap(dirtyPagesMap, pageCursor.idx, column.getFileHandle(), true);
         memcpy(page + pageCursor.offset,
@@ -191,9 +190,8 @@ void LocalStorage::updateNodePropertyColumn(uint32_t currPosInDataChunk,
 void LocalStorage::appendToNodePropertyColumn(uint32_t& dataChunkIdx, uint32_t& currPosInDataChunk,
     BaseColumn& column, uint8_t* nullValue, page_idx_to_dirty_page_map& dirtyPagesMap,
     uint32_t dataChunkSize, ValueVector* propertyValueVector, NodeIDVector* nodeIDVector) {
-    nodeID_t nodeID;
-    nodeIDVector->readNodeOffset(currPosInDataChunk, nodeID);
-    auto pageCursor = column.getPageCursorForOffset(nodeID.offset);
+    auto nodeOffset = nodeIDVector->readNodeOffset(currPosInDataChunk);
+    auto pageCursor = column.getPageCursorForOffset(nodeOffset);
     auto page = putPageInDirtyPagesMap(dirtyPagesMap, pageCursor.idx, column.getFileHandle(), true);
     auto freePosInPage = (PAGE_SIZE - pageCursor.offset) / column.elementSize;
     auto elementsLeftInDataChunk = dataChunkSize - currPosInDataChunk;

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -14,15 +14,15 @@ TEST(VectorCmpTests, cmpInt) {
     dataChunk->state->size = numTuples;
     dataChunk->state->numSelectedValues = numTuples;
 
-    auto lVector = make_shared<ValueVector>(INT32, numTuples);
+    auto lVector = make_shared<ValueVector>(INT32);
     dataChunk->append(lVector);
     auto lData = (int32_t*)lVector->values;
 
-    auto rVector = make_shared<ValueVector>(INT32, numTuples);
+    auto rVector = make_shared<ValueVector>(INT32);
     dataChunk->append(rVector);
     auto rData = (int32_t*)rVector->values;
 
-    auto result = make_shared<ValueVector>(BOOL, numTuples);
+    auto result = make_shared<ValueVector>(BOOL);
     dataChunk->append(result);
     auto resultData = result->values;
 
@@ -70,15 +70,15 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
     dataChunk->state->size = numTuples;
     dataChunk->state->currPos = 0;
 
-    auto lVector = make_shared<ValueVector>(STRING, numTuples);
+    auto lVector = make_shared<ValueVector>(STRING);
     dataChunk->append(lVector);
     auto lData = ((gf_string_t*)lVector->values);
 
-    auto rVector = make_shared<ValueVector>(STRING, numTuples);
+    auto rVector = make_shared<ValueVector>(STRING);
     dataChunk->append(rVector);
     auto rData = ((gf_string_t*)rVector->values);
 
-    auto result = make_shared<ValueVector>(BOOL, numTuples);
+    auto result = make_shared<ValueVector>(BOOL);
     dataChunk->append(result);
     auto resultData = result->values;
 
@@ -134,15 +134,15 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
     dataChunk->state->numSelectedValues = VECTOR_SIZE;
     dataChunk->state->currPos = 0;
 
-    auto lVector = make_shared<ValueVector>(STRING, VECTOR_SIZE);
+    auto lVector = make_shared<ValueVector>(STRING);
     dataChunk->append(lVector);
     auto lData = ((gf_string_t*)lVector->values);
 
-    auto rVector = make_shared<ValueVector>(STRING, VECTOR_SIZE);
+    auto rVector = make_shared<ValueVector>(STRING);
     dataChunk->append(rVector);
     auto rData = ((gf_string_t*)rVector->values);
 
-    auto result = make_shared<ValueVector>(BOOL, VECTOR_SIZE);
+    auto result = make_shared<ValueVector>(BOOL);
     dataChunk->append(result);
     auto resultData = result->values;
 

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -16,7 +16,7 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
     auto addLogicalOperator = make_unique<Expression>(
         ExpressionType::ADD, DataType::INT32, move(propertyExpression), move(literalExpression));
 
-    auto valueVector = make_shared<ValueVector>(INT32, 100);
+    auto valueVector = make_shared<ValueVector>(INT32);
     auto values = (int32_t*)valueVector->values;
     for (auto i = 0u; i < 100; i++) {
         values[i] = i;
@@ -47,7 +47,7 @@ TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
     auto negateLogicalOperator =
         make_unique<Expression>(ExpressionType::NEGATE, DataType::INT32, move(propertyExpression));
 
-    auto valueVector = make_shared<ValueVector>(INT32, 100);
+    auto valueVector = make_shared<ValueVector>(INT32);
     auto values = (int32_t*)valueVector->values;
     for (auto i = 0u; i < 100; i++) {
         int32_t value = i;

--- a/test/processor/physical_plan/operator/frontier/frontier_test.cpp
+++ b/test/processor/physical_plan/operator/frontier/frontier_test.cpp
@@ -11,8 +11,9 @@ TEST(FrontierTests, frontierCreationTest) {
 
     NodeIDCompressionScheme compressionScheme;
     NodeIDVector vector = NodeIDVector(0, compressionScheme, false);
-    vector.state = make_shared<VectorState>(true /*initializeSelectedValuesPos*/, MAX_VECTOR_SIZE);
-    vector.state->size = vector.state->numSelectedValues = MAX_VECTOR_SIZE;
+    vector.state =
+        make_shared<VectorState>(true /*initializeSelectedValuesPos*/, DEFAULT_VECTOR_CAPACITY);
+    vector.state->size = vector.state->numSelectedValues = DEFAULT_VECTOR_CAPACITY;
     for (auto i = 0u; i < vector.state->size; i++) {
         ((node_offset_t*)vector.values)[i] = i;
     }
@@ -25,13 +26,13 @@ TEST(FrontierTests, frontierCreationTest) {
     for (auto i = 0u; i < 10; i++) {
         for (auto j = 0u; j < vector.state->size; j++) {
             ((node_offset_t*)vector.values)[j] =
-                ((node_offset_t*)vector.values)[j] + MAX_VECTOR_SIZE;
+                ((node_offset_t*)vector.values)[j] + DEFAULT_VECTOR_CAPACITY;
         }
         frontierBag.append(vector, FIXED_MULTIPLICITY_VALUE);
     }
-    ASSERT_EQ(frontierBag.size, MAX_VECTOR_SIZE * 11);
+    ASSERT_EQ(frontierBag.size, DEFAULT_VECTOR_CAPACITY * 11);
 
-    auto highestID = MAX_VECTOR_SIZE * 11;
+    auto highestID = DEFAULT_VECTOR_CAPACITY * 11;
     for (auto i = 0u; i < NUM_SLOTS_BAG; i++) {
         auto slot = frontierBag.hashTable[i];
         auto arrSize =

--- a/test/processor/physical_plan/operator/scan/scan_test.cpp
+++ b/test/processor/physical_plan/operator/scan/scan_test.cpp
@@ -11,19 +11,18 @@ TEST(ScanTests, ScanTest) {
     auto dataChunk = resultSet->dataChunks[0];
     auto nodeVector = static_pointer_cast<NodeIDVector>(dataChunk->getValueVector(0));
     node_offset_t currNodeOffset = 0;
-    auto size = NODE_SEQUENCE_VECTOR_SIZE;
+    auto size = NODE_SEQUENCE_VECTOR_CAPACITY;
     while (morsel->currNodeOffset < 1025013) {
         scan->getNextTuples();
         if (morsel->currNodeOffset >= 1025013) {
-            size = 1025013 % NODE_SEQUENCE_VECTOR_SIZE;
+            size = 1025013 % NODE_SEQUENCE_VECTOR_CAPACITY;
         }
         ASSERT_EQ(dataChunk->state->size, size);
-        nodeID_t node;
         for (uint64_t i = 0; i < dataChunk->state->size; i++) {
-            nodeVector->readNodeOffset(i, node);
-            ASSERT_EQ(node.offset, currNodeOffset + i);
+            auto nodeOffset = nodeVector->readNodeOffset(i);
+            ASSERT_EQ(nodeOffset, currNodeOffset + i);
         }
-        currNodeOffset += NODE_SEQUENCE_VECTOR_SIZE;
+        currNodeOffset += NODE_SEQUENCE_VECTOR_CAPACITY;
     }
     ASSERT_EQ(morsel->currNodeOffset, 1025013);
 }

--- a/test/storage/hash_index_test.cpp
+++ b/test/storage/hash_index_test.cpp
@@ -27,9 +27,9 @@ public:
         auto numEntries = 1000;
         auto state = make_shared<VectorState>(true, numEntries);
         state->numSelectedValues = numEntries;
-        ValueVector keys(INT64, numEntries);
+        ValueVector keys(INT64);
         keys.state = state;
-        ValueVector values(INT64, numEntries);
+        ValueVector values(INT64);
         values.state = state;
         auto keysData = (uint64_t*)keys.values;
         auto valuesData = (uint64_t*)values.values;
@@ -59,9 +59,9 @@ TEST_F(HashIndexTest, HashIndexInsertExists) {
     auto numEntries = 10;
     auto state = make_shared<VectorState>(true, numEntries);
     state->numSelectedValues = numEntries;
-    ValueVector keys(INT64, numEntries);
+    ValueVector keys(INT64);
     keys.state = state;
-    ValueVector values(INT64, numEntries);
+    ValueVector values(INT64);
     values.state = state;
     auto keysData = (uint64_t*)keys.values;
     auto valuesData = (uint64_t*)values.values;
@@ -84,9 +84,9 @@ TEST_F(HashIndexTest, HashIndexSmallLookup) {
     auto numEntries = 10;
     auto state = make_shared<VectorState>(true, numEntries);
     state->numSelectedValues = numEntries;
-    ValueVector result(INT64, numEntries);
+    ValueVector result(INT64);
     result.state = state;
-    ValueVector keys(INT64, numEntries);
+    ValueVector keys(INT64);
     keys.state = state;
     auto keysData = (uint64_t*)keys.values;
     for (auto i = 0; i < numEntries; i++) {
@@ -107,7 +107,7 @@ TEST_F(HashIndexTest, HashIndexRandomLookup) {
     auto numEntries = 1000;
     auto state = make_shared<VectorState>(true, numEntries);
     state->numSelectedValues = numEntries;
-    ValueVector keys(INT64, numEntries);
+    ValueVector keys(INT64);
     keys.state = state;
     auto keysData = (uint64_t*)keys.values;
 
@@ -125,7 +125,7 @@ TEST_F(HashIndexTest, HashIndexRandomLookup) {
     for (auto i = 0; i < numEntries; i++) {
         keysData[i] = distribution(gen);
     }
-    ValueVector result(INT64, numEntries);
+    ValueVector result(INT64);
     result.state = state;
     lookupHashIndex.lookup(keys, result);
     auto resultData = (uint64_t*)result.values;


### PR DESCRIPTION
This PR does following refactorings:
- rename: `MAX_VECTOR_SIZE` to `DEFAULT_VECTOR_CAPACITY`; `NODE_SEQUENCE_VECTOR_SIZE` to `NODE_SEQUENCE_VECTOR_CAPACITY`.
- change function `void readNodeOffset(uint64_t pos, nodeID_t& nodeID) const` to `node_offset_t readNodeOffset(uint64_t pos) const`, which removes unnecessary nodeID struct usage.
- rename function `readNodeOffsetAndLabel` to `readNodeID`.
- remove constructor `ValueVector(uint64_t numBytesPerValue, DataType dataType)`, which is no longer used.
- ValueVector now only has one public constructor `ValueVector(DataType dataType, bool isSingleValue = false)`, which allows only two kinds of capacity, either 1 or by default 2048.
- fix a bug in `VectorState::clone()` that calculate the capacity in a wrong way.