### PR TITLE
simplify VectorState size and getNextTuples()

### DIFF
--- a/src/common/include/vector/operations/executors/binary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/binary_operation_executor.h
@@ -27,7 +27,7 @@ struct BinaryOperationExecutor {
             auto lValue = lValues[lPos];
             auto isLeftNull = left.nullMask[lPos];
             // right and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < right.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < right.state->size; i++) {
                 auto pos = right.state->selectedValuesPos[i];
                 result.nullMask[pos] = isLeftNull || right.nullMask[pos];
                 if (!result.nullMask[pos]) {
@@ -39,7 +39,7 @@ struct BinaryOperationExecutor {
             auto rValue = rValues[rPos];
             auto isRightNull = right.nullMask[rPos];
             // left and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < left.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < left.state->size; i++) {
                 auto pos = left.state->selectedValuesPos[i];
                 result.nullMask[pos] = left.nullMask[pos] || isRightNull;
                 if (!result.nullMask[i]) {
@@ -48,7 +48,7 @@ struct BinaryOperationExecutor {
             }
         } else {
             // right, left, and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < result.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < result.state->size; i++) {
                 auto pos = result.state->selectedValuesPos[i];
                 result.nullMask[pos] = left.nullMask[pos] || right.nullMask[pos];
                 if (!result.nullMask[pos]) {
@@ -75,7 +75,7 @@ struct BinaryOperationExecutor {
             auto lValue = lValues[lPos];
             auto isLeftNull = left.nullMask[lPos];
             // right and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < right.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < right.state->size; i++) {
                 auto pos = right.state->selectedValuesPos[i];
                 result.nullMask[pos] = isLeftNull || right.nullMask[pos];
                 if (!result.nullMask[pos]) {
@@ -87,7 +87,7 @@ struct BinaryOperationExecutor {
             auto rValue = rValues[rPos];
             auto isRightNull = right.nullMask[rPos];
             // left and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < left.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < left.state->size; i++) {
                 auto pos = left.state->selectedValuesPos[i];
                 result.nullMask[pos] = left.nullMask[pos] || isRightNull;
                 if (!result.nullMask[i]) {
@@ -96,7 +96,7 @@ struct BinaryOperationExecutor {
             }
         } else {
             // right, left, and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < left.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < left.state->size; i++) {
                 auto pos = left.state->selectedValuesPos[i];
                 result.nullMask[pos] = left.nullMask[pos] || right.nullMask[pos];
                 if (!result.nullMask[pos]) {
@@ -122,7 +122,7 @@ struct BinaryOperationExecutor {
             auto flatValue = flatVector.values[pos];
             auto isFlatNull = flatVector.nullMask[flatVector.state->getCurrSelectedValuesPos()];
             // unflat and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < unflatVector.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < unflatVector.state->size; i++) {
                 pos = right.state->selectedValuesPos[i];
                 result.values[pos] = FUNC::operation(
                     flatValue, unflatVector.values[pos], isFlatNull, unflatVector.nullMask[pos]);
@@ -130,7 +130,7 @@ struct BinaryOperationExecutor {
             }
         } else {
             // right, left, and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < result.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < result.state->size; i++) {
                 auto pos = result.state->selectedValuesPos[i];
                 result.values[pos] = FUNC::operation(
                     left.values[pos], right.values[pos], left.nullMask[pos], right.nullMask[pos]);
@@ -160,7 +160,7 @@ struct BinaryOperationExecutor {
             auto isFlatNull = flatVector.nullMask[pos];
             flatVector.readNodeID(pos, nodeID);
             // unflat and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < unflatVector.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < unflatVector.state->size; i++) {
                 pos = unflatVector.state->selectedValuesPos[i];
                 unflatVector.readNodeID(pos, otherNodeID);
                 result.nullMask[i] = isFlatNull || unflatVector.nullMask[pos];
@@ -171,7 +171,7 @@ struct BinaryOperationExecutor {
             }
         } else {
             // right, left, and result vectors share the same selectedValuesPos.
-            for (uint64_t i = 0; i < left.state->numSelectedValues; i++) {
+            for (uint64_t i = 0; i < left.state->size; i++) {
                 auto pos = left.state->selectedValuesPos[i];
                 left.readNodeID(pos, nodeID);
                 right.readNodeID(pos, otherNodeID);

--- a/src/common/include/vector/operations/executors/unary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/unary_operation_executor.h
@@ -19,7 +19,7 @@ struct UnaryOperationExecutor {
                 FUNC::operation(inputValues[pos], resultValues[0]);
             }
         } else {
-            for (auto i = 0ul; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0ul; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 if (!operand.nullMask[pos]) {
                     FUNC::operation(inputValues[pos], resultValues[pos]);
@@ -38,7 +38,7 @@ struct UnaryOperationExecutor {
                 resultValues[pos] = FUNC::operation(inputValues[pos]);
             }
         } else {
-            for (auto i = 0ul; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0ul; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 if (!operand.nullMask[pos]) {
                     resultValues[pos] = FUNC::operation(inputValues[pos]);
@@ -58,7 +58,7 @@ struct UnaryOperationExecutor {
                 resultValues[pos] = FUNC::operation(nodeID);
             }
         } else {
-            for (auto i = 0ul; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0ul; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 operand.readNodeID(pos, nodeID);
                 if (!operand.nullMask[pos]) {
@@ -74,7 +74,7 @@ struct UnaryOperationExecutor {
             auto pos = operand.state->getCurrSelectedValuesPos();
             result.values[pos] = operand.nullMask[pos] == value;
         } else {
-            for (auto i = 0ul; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0ul; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 result.values[pos] = operand.nullMask[pos] == value;
             }

--- a/src/common/include/vector/vector_state.h
+++ b/src/common/include/vector/vector_state.h
@@ -19,7 +19,7 @@ public:
     VectorState(bool initializeSelectedValuesPos, uint64_t capacity);
 
     void initializeSelector() {
-        for (auto i = 0u; i < numSelectedValues; i++) {
+        for (auto i = 0u; i < size; i++) {
             valuesPos[i] = i;
         }
     }
@@ -38,10 +38,9 @@ public:
     shared_ptr<VectorState> clone();
 
 public:
-    uint64_t size;
     // The current position when vectors are flattened.
     int64_t currPos;
-    uint64_t numSelectedValues;
+    uint64_t size;
     uint64_t* selectedValuesPos;
     uint64_t* multiplicity;
 

--- a/src/common/vector/node_vector.cpp
+++ b/src/common/vector/node_vector.cpp
@@ -40,14 +40,14 @@ bool NodeIDVector::discardNulls() {
     if (state->currPos == -1) {
         auto selectedValuesPos = state->selectedValuesPos;
         auto selectedPos = 0u;
-        for (auto j = 0u; j < state->numSelectedValues; j++) {
+        for (auto j = 0u; j < state->size; j++) {
             nodeOffset = readNodeOffset(state->selectedValuesPos[j]);
             if (nodeOffset != nullOffset) {
                 selectedValuesPos[selectedPos++] = j;
             }
         }
-        state->numSelectedValues = selectedPos;
-        return state->numSelectedValues > 0;
+        state->size = selectedPos;
+        return state->size > 0;
     } else {
         nodeOffset = readNodeOffset(state->getCurrSelectedValuesPos());
         return nodeOffset != nullOffset;

--- a/src/common/vector/operations/vector_boolean_operations.cpp
+++ b/src/common/vector/operations/vector_boolean_operations.cpp
@@ -24,7 +24,7 @@ void VectorBooleanOperations::Not(ValueVector& operand, ValueVector& result) {
         auto pos = operand.state->getCurrSelectedValuesPos();
         result.values[pos] = operation::Not::operation(operand.values[pos], operand.nullMask[pos]);
     } else {
-        for (auto i = 0ul; i < operand.state->numSelectedValues; i++) {
+        for (auto i = 0ul; i < operand.state->size; i++) {
             auto pos = operand.state->selectedValuesPos[i];
             result.values[pos] =
                 operation::Not::operation(operand.values[pos], operand.nullMask[pos]);

--- a/src/common/vector/operations/vector_cast_operations.cpp
+++ b/src/common/vector/operations/vector_cast_operations.cpp
@@ -30,21 +30,21 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
     } else {
         switch (operand.dataType) {
         case BOOL: {
-            for (auto i = 0u; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 outValues[pos].primitive.booleanVal = operand.values[pos];
             }
         } break;
         case INT32: {
             auto intValues = (int32_t*)operand.values;
-            for (auto i = 0u; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 outValues[pos].primitive.int32Val = intValues[pos];
             }
         } break;
         case DOUBLE: {
             auto doubleValues = (double_t*)operand.values;
-            for (auto i = 0u; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 outValues[pos].primitive.doubleVal = doubleValues[pos];
             }
@@ -81,7 +81,7 @@ void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, Val
     } else {
         switch (operand.dataType) {
         case BOOL: {
-            for (auto i = 0u; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 outValues[pos].set(operand.values[pos] == TRUE ?
                                        "True" :
@@ -90,14 +90,14 @@ void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, Val
         } break;
         case INT32: {
             auto intValues = (int32_t*)operand.values;
-            for (auto i = 0u; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 outValues[pos].set(to_string(intValues[pos]));
             }
         } break;
         case DOUBLE: {
             auto doubleValues = (double_t*)operand.values;
-            for (auto i = 0u; i < operand.state->numSelectedValues; i++) {
+            for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 outValues[pos].set(to_string(doubleValues[pos]));
             }
@@ -112,7 +112,7 @@ void VectorCastOperations::castUnstructuredToBoolValue(ValueVector& operand, Val
     assert(operand.dataType == UNSTRUCTURED && result.dataType == BOOL);
     auto inValues = (Value*)result.values;
     if (!operand.state->isFlat()) {
-        for (auto i = 0u; i < operand.state->numSelectedValues; i++) {
+        for (auto i = 0u; i < operand.state->size; i++) {
             auto pos = operand.state->selectedValuesPos[i];
             if (inValues[pos].dataType != BOOL) {
                 throw std::invalid_argument("Don’t know how to treat that as a predicate: “" +

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -14,7 +14,7 @@ static void fillOperandNullMask(ValueVector& operand) {
         operand.nullMask[operand.state->getCurrSelectedValuesPos()] =
             IsNull::operation(values[operand.state->getCurrSelectedValuesPos()]);
     } else {
-        auto size = operand.state->numSelectedValues;
+        auto size = operand.state->size;
         for (uint64_t i = 0; i < size; i++) {
             operand.nullMask[i] = IsNull::operation(values[operand.state->selectedValuesPos[i]]);
         }

--- a/src/common/vector/vector_state.cpp
+++ b/src/common/vector/vector_state.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace common {
 
 VectorState::VectorState(bool initializeSelectedValuesPos, uint64_t capacity)
-    : size{0}, currPos{-1}, numSelectedValues{0} {
+    : currPos{-1}, size{0} {
     valuesPos = make_unique<uint64_t[]>(capacity);
     selectedValuesPos = valuesPos.get();
     if (initializeSelectedValuesPos) {
@@ -21,10 +21,10 @@ uint64_t VectorState::getNumSelectedValues() const {
     if (isFlat()) {
         return multiplicity == nullptr ? 1 : multiplicity[getCurrSelectedValuesPos()];
     } else if (multiplicity == nullptr) {
-        return numSelectedValues;
+        return size;
     } else {
         auto numSelectedValuesSum = 0u;
-        for (auto i = 0u; i < numSelectedValues; i++) {
+        for (auto i = 0u; i < size; i++) {
             numSelectedValuesSum += multiplicity[selectedValuesPos[i]];
         }
         return numSelectedValuesSum;
@@ -39,12 +39,11 @@ shared_ptr<VectorState> VectorState::getSingleValueDataChunkState() {
 }
 
 shared_ptr<VectorState> VectorState::clone() {
-    auto capacity = size == 1 ? 1 : DEFAULT_VECTOR_CAPACITY;
-    auto newState = make_shared<VectorState>(false /*initializeSelectedValuesPos*/, capacity);
-    newState->size = size;
+    auto newState =
+        make_shared<VectorState>(false /*initializeSelectedValuesPos*/, DEFAULT_VECTOR_CAPACITY);
     newState->currPos = currPos;
-    newState->numSelectedValues = numSelectedValues;
-    memcpy(newState->valuesPos.get(), valuesPos.get(), capacity * sizeof(uint64_t));
+    newState->size = size;
+    memcpy(newState->valuesPos.get(), valuesPos.get(), DEFAULT_VECTOR_CAPACITY * sizeof(uint64_t));
     return newState;
 }
 

--- a/src/processor/physical_plan/operator/crud/crud.cpp
+++ b/src/processor/physical_plan/operator/crud/crud.cpp
@@ -8,17 +8,17 @@ CRUDOperator::CRUDOperator(uint64_t dataChunkPos, Transaction* transactionPtr,
     : PhysicalOperator{move(prevOperator), type}, transactionPtr{transactionPtr}, graph{graph},
       dataChunkPos{dataChunkPos} {
     inDataChunk = resultSet->dataChunks[dataChunkPos];
-};
+}
 
 void CRUDOperator::getNextTuples() {
     while (true) {
         prevOperator->getNextTuples();
-        if (0 <= inDataChunk->state->size) {
+        if (inDataChunk->state->size == 0) {
             break;
         }
         transactionPtr->localStorage.addDataChunk(inDataChunk.get());
     }
-};
+}
 
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/flatten/flatten.cpp
+++ b/src/processor/physical_plan/operator/flatten/flatten.cpp
@@ -10,13 +10,10 @@ Flatten::Flatten(uint64_t dataChunkPos, unique_ptr<PhysicalOperator> prevOperato
 }
 
 void Flatten::getNextTuples() {
-    if (dataChunkToFlatten->state->numSelectedValues == 0ul ||
-        dataChunkToFlatten->state->numSelectedValues == dataChunkToFlatten->state->currPos + 1ul) {
-        do {
-            dataChunkToFlatten->state->currPos = -1;
-            prevOperator->getNextTuples();
-        } while (dataChunkToFlatten->state->size > 0 &&
-                 dataChunkToFlatten->state->numSelectedValues == 0);
+    if (dataChunkToFlatten->state->size == 0ul ||
+        dataChunkToFlatten->state->size == dataChunkToFlatten->state->currPos + 1ul) {
+        dataChunkToFlatten->state->currPos = -1;
+        prevOperator->getNextTuples();
         if (dataChunkToFlatten->state->size == 0) {
             return;
         }

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -96,7 +96,7 @@ void HashJoinBuild::appendPayloadVectorAsFixSizedValues(ValueVector& vector, uin
 
 overflow_value_t HashJoinBuild::addVectorInOverflowBlocks(ValueVector& vector) {
     auto numBytesPerValue = vector.getNumBytesPerValue();
-    auto valuesLength = vector.getNumBytesPerValue() * vector.state->numSelectedValues;
+    auto valuesLength = vector.getNumBytesPerValue() * vector.state->size;
     auto vectorValues = vector.values;
     auto vectorSelectedValuesPos = vector.state->selectedValuesPos;
     if (valuesLength > DEFAULT_OVERFLOW_BLOCK_SIZE) {
@@ -120,7 +120,7 @@ overflow_value_t HashJoinBuild::addVectorInOverflowBlocks(ValueVector& vector) {
         overflowBlocks.push_back(move(blockHandle));
     }
 
-    for (auto i = 0u; i < vector.state->numSelectedValues; i++) {
+    for (auto i = 0u; i < vector.state->size; i++) {
         memcpy(blockAppendPos + (i * numBytesPerValue),
             vectorValues + (vectorSelectedValuesPos[i] * numBytesPerValue), numBytesPerValue);
     }
@@ -201,13 +201,12 @@ void HashJoinBuild::allocateHTBlocks(
 }
 
 void HashJoinBuild::appendResultSet() {
-    if (keyDataChunk->state->numSelectedValues == 0) {
+    if (keyDataChunk->state->size == 0) {
         return;
     }
 
     // Allocate space for tuples
-    auto numTuplesToAppend =
-        keyDataChunk->state->isFlat() ? 1 : keyDataChunk->state->numSelectedValues;
+    auto numTuplesToAppend = keyDataChunk->state->isFlat() ? 1 : keyDataChunk->state->size;
     vector<BlockAppendInfo> blockAppendInfos;
     allocateHTBlocks(numTuplesToAppend, blockAppendInfos);
 
@@ -288,7 +287,6 @@ void HashJoinBuild::getNextTuples() {
     }
 
     keyDataChunk->state->size = 0;
-    keyDataChunk->state->numSelectedValues = 0;
 }
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/load_csv/load_csv.cpp
+++ b/src/processor/physical_plan/operator/load_csv/load_csv.cpp
@@ -72,7 +72,6 @@ void LoadCSV<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
         lineIdx++;
     }
     outDataChunk->state->size = lineIdx;
-    outDataChunk->state->numSelectedValues = lineIdx;
     if constexpr (IS_OUT_DATACHUNK_FILTERED) {
         for (auto i = 0u; i < outDataChunk->state->size; i++) {
             outDataChunk->state->selectedValuesPos[i] = i;

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -20,27 +20,23 @@ template<bool IS_OUT_DATACHUNK_FILTERED>
 void AdjListExtend<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
     if (handle->hasMoreToRead()) {
         readValuesFromList();
-        outDataChunk->state->numSelectedValues = outDataChunk->state->size;
         if constexpr (IS_OUT_DATACHUNK_FILTERED) {
             outDataChunk->state->initializeSelector();
         }
         return;
     }
     while (true) {
-        do {
-            prevOperator->getNextTuples();
-        } while (inDataChunk->state->size > 0 && inDataChunk->state->numSelectedValues == 0);
+        prevOperator->getNextTuples();
         if (inDataChunk->state->size > 0) {
             readValuesFromList();
             if (outDataChunk->state->size > 0) {
-                outDataChunk->state->numSelectedValues = outDataChunk->state->size;
                 if constexpr (IS_OUT_DATACHUNK_FILTERED) {
                     outDataChunk->state->initializeSelector();
                 }
                 return;
             }
         } else {
-            outDataChunk->state->size = outDataChunk->state->numSelectedValues = 0;
+            outDataChunk->state->size = 0;
             return;
         }
     }

--- a/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
@@ -51,8 +51,7 @@ void FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
     }
     do {
         prevOperator->getNextTuples();
-        if (inNodeIDVector->state->numSelectedValues == 0) {
-            outValueVector->state->size = outValueVector->state->numSelectedValues = 0;
+        if (inNodeIDVector->state->size == 0) {
             return;
         }
     } while (computeFrontiers());
@@ -163,7 +162,6 @@ void FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::produceOutputTuples() {
                             slot->multiplicity;
                         slot = slot->next;
                         if (outValueVector->state->size == DEFAULT_VECTOR_CAPACITY) {
-                            outValueVector->state->numSelectedValues = DEFAULT_VECTOR_CAPACITY;
                             currOutputPos.hasMoreTuplesToProduce = true;
                             if constexpr (IS_OUT_DATACHUNK_FILTERED) {
                                 outDataChunk->state->initializeSelector();
@@ -180,7 +178,6 @@ void FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::produceOutputTuples() {
         currOutputPos.blockIdx = 0u;
         currOutputPos.layer++;
     }
-    outValueVector->state->numSelectedValues = outValueVector->state->size;
     if constexpr (IS_OUT_DATACHUNK_FILTERED) {
         outDataChunk->state->initializeSelector();
     }

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -19,7 +19,7 @@ ReadRelPropertyList::ReadRelPropertyList(uint64_t inDataChunkPos, uint64_t inVal
 
 void ReadRelPropertyList::getNextTuples() {
     prevOperator->getNextTuples();
-    if (inDataChunk->state->numSelectedValues > 0) {
+    if (inDataChunk->state->size > 0) {
         readValuesFromList();
     }
     outValueVector->fillNullMask();

--- a/src/processor/physical_plan/operator/result/result_set_iterator.cpp
+++ b/src/processor/physical_plan/operator/result/result_set_iterator.cpp
@@ -26,7 +26,7 @@ bool ResultSetIterator::updateTuplePositions(int64_t chunkIdx) {
         return false;
     }
     tuplePositions[chunkIdx] = tuplePositions[chunkIdx] + 1;
-    if (tuplePositions[chunkIdx] == resultSet.dataChunks[chunkIdx]->state->numSelectedValues) {
+    if (tuplePositions[chunkIdx] == resultSet.dataChunks[chunkIdx]->state->size) {
         tuplePositions[chunkIdx] = 0;
         return false;
     }

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -16,9 +16,9 @@ AdjColumnExtend::AdjColumnExtend(uint64_t dataChunkPos, uint64_t valueVectorPos,
 void AdjColumnExtend::getNextTuples() {
     bool hasAtLeastOneNonNullValue;
     do {
-        inDataChunk->state->numSelectedValues = prevInNumSelectedValues;
+        inDataChunk->state->size = prevInNumSelectedValues;
         ScanColumn::getNextTuples();
-        prevInNumSelectedValues = inDataChunk->state->numSelectedValues;
+        prevInNumSelectedValues = inDataChunk->state->size;
         hasAtLeastOneNonNullValue =
             static_pointer_cast<NodeIDVector>(outValueVector)->discardNulls();
     } while (inDataChunk->state->size > 0 && !hasAtLeastOneNonNullValue);

--- a/src/processor/physical_plan/operator/scan_attribute/scan_column.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_column.cpp
@@ -4,9 +4,7 @@ namespace graphflow {
 namespace processor {
 
 void ScanColumn::getNextTuples() {
-    do {
-        prevOperator->getNextTuples();
-    } while (inDataChunk->state->size > 0 && inDataChunk->state->numSelectedValues == 0);
+    prevOperator->getNextTuples();
     if (inDataChunk->state->size > 0) {
         column->reclaim(handle);
         column->readValues(inNodeIDVector, outValueVector, handle);

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -18,9 +18,7 @@ ScanUnstructuredProperty::ScanUnstructuredProperty(uint64_t dataChunkPos, uint64
 }
 
 void ScanUnstructuredProperty::getNextTuples() {
-    do {
-        prevOperator->getNextTuples();
-    } while (inDataChunk->state->size > 0 && inDataChunk->state->numSelectedValues == 0);
+    prevOperator->getNextTuples();
     if (inDataChunk->state->size > 0) {
         lists->reclaim(handle);
         lists->readValues(inNodeIDVector, propertyKey, outValueVector, handle);

--- a/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
@@ -44,7 +44,6 @@ void ScanNodeID<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
             morsel->currNodeOffset += outDataChunk->state->size;
         }
     }
-    outDataChunk->state->numSelectedValues = outDataChunk->state->size;
     if constexpr (IS_OUT_DATACHUNK_FILTERED) {
         for (auto i = 0u; i < outDataChunk->state->size; i++) {
             outDataChunk->state->selectedValuesPos[i] = i;

--- a/src/storage/data_structure/column.cpp
+++ b/src/storage/data_structure/column.cpp
@@ -36,7 +36,7 @@ void BaseColumn::readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& 
         memcpy(values + pos * elementSize, frame + pageCursor.offset, elementSize);
         bufferManager.unpin(fileHandle, pageCursor.idx);
     } else {
-        for (auto i = 0ul; i < nodeIDVector->state->numSelectedValues; i++) {
+        for (auto i = 0ul; i < nodeIDVector->state->size; i++) {
             auto nodeOffset =
                 nodeIDVector->readNodeOffset(nodeIDVector->state->selectedValuesPos[i]);
             auto pageCursor = getPageCursorForOffset(nodeOffset);
@@ -64,7 +64,7 @@ void Column<STRING>::readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
 
 void Column<STRING>::readStringsFromOverflowPages(const shared_ptr<ValueVector>& valueVector) {
     PageCursor cursor;
-    for (auto i = 0u; i < valueVector->state->numSelectedValues; i++) {
+    for (auto i = 0u; i < valueVector->state->size; i++) {
         auto pos = valueVector->state->selectedValuesPos[i];
         auto& value = ((gf_string_t*)valueVector->values)[pos];
         if (value.len > gf_string_t::SHORT_STR_LENGTH) {

--- a/src/storage/data_structure/lists/lists.cpp
+++ b/src/storage/data_structure/lists/lists.cpp
@@ -95,7 +95,7 @@ void Lists<UNSTRUCTURED>::readValues(const shared_ptr<NodeIDVector>& nodeIDVecto
         readUnstrPropertyListOfNode(nodeOffset, propertyKeyIdxToRead, valueVector, pos, handle,
             headers->getHeader(nodeOffset));
     } else {
-        for (auto i = 0ul; i < valueVector->state->numSelectedValues; i++) {
+        for (auto i = 0ul; i < valueVector->state->size; i++) {
             auto pos = valueVector->state->selectedValuesPos[i];
             nodeOffset = nodeIDVector->readNodeOffset(pos);
             readUnstrPropertyListOfNode(nodeOffset, propertyKeyIdxToRead, valueVector, pos, handle,
@@ -209,7 +209,7 @@ void Lists<UNSTRUCTURED>::readOrSkipUnstrPropertyValue(uint64_t& physicalPageIdx
 void Lists<UNSTRUCTURED>::readStringsFromOverflowPages(const shared_ptr<ValueVector>& valueVector) {
     auto values = valueVector->values;
     PageCursor cursor;
-    for (auto i = 0u; i < valueVector->state->numSelectedValues; i++) {
+    for (auto i = 0u; i < valueVector->state->size; i++) {
         auto pos = valueVector->state->selectedValuesPos[i];
         if (!valueVector->nullMask[pos] && ((Value*)values)[pos].dataType == STRING) {
             auto& value = ((Value*)values)[pos].strVal;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -67,7 +67,7 @@ void HashIndex::lookup(ValueVector& keys, ValueVector& result) {
     hashes->state = keys.state;
     VectorHashOperations::Hash(keys, *hashes);
     auto offset = keys.state->isFlat() ? keys.state->getCurrSelectedValuesPos() : 0;
-    auto numKeys = keys.state->isFlat() ? 1 : keys.state->numSelectedValues;
+    auto numKeys = keys.state->isFlat() ? 1 : keys.state->size;
     auto slotIds = calculateSlotIdsForHashes(*hashes, offset, numKeys);
     auto numBytesPerKey = keys.getNumBytesPerValue();
     for (auto keyPos = 0u; keyPos < numKeys; keyPos++) {
@@ -143,7 +143,7 @@ void HashIndex::flush() {
 vector<bool> HashIndex::notExists(ValueVector& keys, ValueVector& hashes) {
     uint8_t* keyData = keys.values;
     auto offset = keys.state->isFlat() ? keys.state->getCurrSelectedValuesPos() : 0;
-    auto numKeys = keys.state->isFlat() ? 1 : keys.state->numSelectedValues;
+    auto numKeys = keys.state->isFlat() ? 1 : keys.state->size;
     if (indexHeader.currentNumEntries == 0) {
         // The index is empty, all keys not exist in the current index.
         vector<bool> keyNotExists(numKeys, true);
@@ -192,7 +192,7 @@ void HashIndex::insertInternal(
     auto numBytesPerKey = keys.getNumBytesPerValue();
     auto hashesData = (uint64_t*)hashes.values;
     auto offset = keys.state->isFlat() ? keys.state->getCurrSelectedValuesPos() : 0;
-    auto numKeys = keys.state->isFlat() ? 1 : keys.state->numSelectedValues;
+    auto numKeys = keys.state->isFlat() ? 1 : keys.state->size;
     vector<uint64_t> keyPositions(numKeys);
     uint64_t numEntriesToInsert = 0;
     for (auto pos = 0u; pos < numKeys; pos++) {

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -9,7 +9,6 @@ using namespace std;
 TEST(VectorArithTests, test) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 100;
-    dataChunk->state->numSelectedValues = 100;
 
     auto lVector = make_shared<ValueVector>(INT32);
     dataChunk->append(lVector);

--- a/test/common/vector/operations/vector_boolean_operations_test.cpp
+++ b/test/common/vector/operations/vector_boolean_operations_test.cpp
@@ -10,7 +10,6 @@ TEST(VectorBoolTests, test) {
     auto VECTOR_SIZE = 4;
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = VECTOR_SIZE;
-    dataChunk->state->numSelectedValues = VECTOR_SIZE;
 
     auto lVector = make_shared<ValueVector>(BOOL);
     dataChunk->append(lVector);

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -12,7 +12,6 @@ TEST(VectorCmpTests, cmpInt) {
 
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = numTuples;
-    dataChunk->state->numSelectedValues = numTuples;
 
     auto lVector = make_shared<ValueVector>(INT32);
     dataChunk->append(lVector);
@@ -131,7 +130,6 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
 
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = VECTOR_SIZE;
-    dataChunk->state->numSelectedValues = VECTOR_SIZE;
     dataChunk->state->currPos = 0;
 
     auto lVector = make_shared<ValueVector>(STRING);

--- a/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
+++ b/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
@@ -11,7 +11,6 @@ using namespace std;
 TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 1000;
-    dataChunk->state->numSelectedValues = 1000;
 
     NodeIDCompressionScheme compressionScheme;
     auto nodeVector = make_shared<NodeIDVector>(100, compressionScheme, false);
@@ -44,7 +43,6 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
 TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 1000;
-    dataChunk->state->numSelectedValues = 1000;
 
     label_t commonLabel = 100;
     NodeIDCompressionScheme compressionScheme;

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -23,7 +23,6 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
     }
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 100;
-    dataChunk->state->numSelectedValues = 100;
     dataChunk->append(valueVector);
 
     auto physicalOperatorInfo = PhysicalOperatorsInfo();
@@ -59,7 +58,6 @@ TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
     }
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 100;
-    dataChunk->state->numSelectedValues = 100;
     dataChunk->append(valueVector);
 
     auto physicalOperatorInfo = PhysicalOperatorsInfo();

--- a/test/processor/physical_plan/operator/frontier/frontier_test.cpp
+++ b/test/processor/physical_plan/operator/frontier/frontier_test.cpp
@@ -13,7 +13,7 @@ TEST(FrontierTests, frontierCreationTest) {
     NodeIDVector vector = NodeIDVector(0, compressionScheme, false);
     vector.state =
         make_shared<VectorState>(true /*initializeSelectedValuesPos*/, DEFAULT_VECTOR_CAPACITY);
-    vector.state->size = vector.state->numSelectedValues = DEFAULT_VECTOR_CAPACITY;
+    vector.state->size = DEFAULT_VECTOR_CAPACITY;
     for (auto i = 0u; i < vector.state->size; i++) {
         ((node_offset_t*)vector.values)[i] = i;
     }

--- a/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
+++ b/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
@@ -44,9 +44,6 @@ public:
         dataChunkA->state->size = 100;
         dataChunkB->state->size = 100;
         dataChunkC->state->size = 100;
-        dataChunkA->state->numSelectedValues = 100;
-        dataChunkB->state->numSelectedValues = 100;
-        dataChunkC->state->numSelectedValues = 100;
         resultSet.append(dataChunkA);
         resultSet.append(dataChunkB);
         resultSet.append(dataChunkC);

--- a/test/storage/hash_index_test.cpp
+++ b/test/storage/hash_index_test.cpp
@@ -26,7 +26,7 @@ public:
             TEMP_INDEX, 0, insertionMemoryManager, insertionBufferManager, ovfPagesManager, INT64);
         auto numEntries = 1000;
         auto state = make_shared<VectorState>(true, numEntries);
-        state->numSelectedValues = numEntries;
+        state->size = numEntries;
         ValueVector keys(INT64);
         keys.state = state;
         ValueVector values(INT64);
@@ -58,7 +58,7 @@ TEST_F(HashIndexTest, HashIndexInsertExists) {
     HashIndex hashIndex(TEMP_INDEX, 0, memoryManager, bufferManager, ovfPagesManager, INT64);
     auto numEntries = 10;
     auto state = make_shared<VectorState>(true, numEntries);
-    state->numSelectedValues = numEntries;
+    state->size = numEntries;
     ValueVector keys(INT64);
     keys.state = state;
     ValueVector values(INT64);
@@ -83,7 +83,7 @@ TEST_F(HashIndexTest, HashIndexSmallLookup) {
     HashIndex lookupHashIndex(TEMP_INDEX, 0, memoryManager, bufferManager, ovfPagesManager, INT64);
     auto numEntries = 10;
     auto state = make_shared<VectorState>(true, numEntries);
-    state->numSelectedValues = numEntries;
+    state->size = numEntries;
     ValueVector result(INT64);
     result.state = state;
     ValueVector keys(INT64);
@@ -106,7 +106,7 @@ TEST_F(HashIndexTest, HashIndexRandomLookup) {
     HashIndex lookupHashIndex(TEMP_INDEX, 0, memoryManager, bufferManager, ovfPagesManager, INT64);
     auto numEntries = 1000;
     auto state = make_shared<VectorState>(true, numEntries);
-    state->numSelectedValues = numEntries;
+    state->size = numEntries;
     ValueVector keys(INT64);
     keys.state = state;
     auto keysData = (uint64_t*)keys.values;


### PR DESCRIPTION
This PR simplifies size usage in VectorState, and loops and branches in operator `getNextTuples()`.
Before this PR, `size` field in VectorState records the number of values actually assigned in the vector, and `numSelectedValues` keeps the number of values actually selected to be processed.
This complicates the control logic in operator, that we need consider both fields.
This PR removes `size` field first, and then renames `numSelectedValues` to `size`. 
After the change, `size` now represents the number of selected values in a vector.