### PR TITLE
Make plan clone in Task::run() thread-safe

### DIFF
--- a/src/processor/include/task_system/task.h
+++ b/src/processor/include/task_system/task.h
@@ -30,7 +30,7 @@ public:
     }
 
 private:
-    bool registerThread();
+    unique_ptr<PhysicalOperator> registerThread();
     void deregisterThread(unique_ptr<PhysicalOperator> taskSinkOp);
 
 public:


### PR DESCRIPTION
This is a tiny PR, which moves the plan cloning into `registerThread` method to make sure that it is thread-safe.