### PR TITLE
add buffer manager profiling

### DIFF
--- a/src/common/include/metric.h
+++ b/src/common/include/metric.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "src/common/include/timer.h"
 
 using namespace std;
@@ -7,6 +9,9 @@ using namespace std;
 namespace graphflow {
 namespace common {
 
+/**
+ * Note that all metrics are not thread safe
+ */
 class Metric {
 
 public:
@@ -36,6 +41,8 @@ public:
     explicit NumericMetric(bool enable);
 
     void increase(uint64_t value);
+
+    void incrementByOne();
 
 public:
     uint64_t accumulatedValue;

--- a/src/common/metric.cpp
+++ b/src/common/metric.cpp
@@ -40,5 +40,12 @@ void NumericMetric::increase(uint64_t value) {
     accumulatedValue += value;
 }
 
+void NumericMetric::incrementByOne() {
+    if (!enabled) {
+        return;
+    }
+    accumulatedValue++;
+}
+
 } // namespace common
 } // namespace graphflow

--- a/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
@@ -18,13 +18,7 @@ public:
 
     void setMemoryManager(MemoryManager* memMan) { this->memMan = memMan; }
 
-    unique_ptr<PhysicalOperator> clone() override {
-        auto cloneOp =
-            make_unique<FrontierExtend<IS_OUT_DATACHUNK_FILTERED>>(inDataChunkPos, inValueVectorPos,
-                (AdjLists*)lists, startLayer, endLayer, prevOperator->clone(), context, id);
-        cloneOp->memMan = this->memMan;
-        return cloneOp;
-    }
+    unique_ptr<PhysicalOperator> clone() override;
 
 private:
     bool computeFrontiers();

--- a/src/processor/include/physical_plan/operator/read_list/read_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_list.h
@@ -18,6 +18,8 @@ public:
 protected:
     void readValuesFromList();
 
+    nlohmann::json toJson(Profiler& profiler) override;
+
 protected:
     static constexpr uint32_t MAX_TO_READ = 512;
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
@@ -15,6 +15,9 @@ public:
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
 
 protected:
+    nlohmann::json toJson(Profiler& profiler) override;
+
+protected:
     uint64_t dataChunkPos;
     uint64_t valueVectorPos;
     shared_ptr<DataChunk> inDataChunk;

--- a/src/processor/physical_plan/operator/filter/filter.cpp
+++ b/src/processor/physical_plan/operator/filter/filter.cpp
@@ -21,7 +21,7 @@ Filter<IS_AFTER_FLATTEN>::Filter(unique_ptr<ExpressionEvaluator> rootExpr,
 
 template<bool IS_AFTER_FLATTEN>
 void Filter<IS_AFTER_FLATTEN>::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     bool hasAtLeastOneSelectedValue;
     do {
         if (IS_AFTER_FLATTEN) {
@@ -50,8 +50,8 @@ void Filter<IS_AFTER_FLATTEN>::getNextTuples() {
             hasAtLeastOneSelectedValue = resultPos > 0;
         }
     } while (!hasAtLeastOneSelectedValue);
-    executionTime->stop();
-    numOutputTuple->increase(dataChunkToSelect->state->size);
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(dataChunkToSelect->state->size);
 }
 
 template<bool IS_AFTER_FLATTEN>

--- a/src/processor/physical_plan/operator/flatten/flatten.cpp
+++ b/src/processor/physical_plan/operator/flatten/flatten.cpp
@@ -12,19 +12,19 @@ Flatten::Flatten(uint64_t dataChunkPos, unique_ptr<PhysicalOperator> prevOperato
 }
 
 void Flatten::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     if (dataChunkToFlatten->state->size == 0ul ||
         dataChunkToFlatten->state->size == dataChunkToFlatten->state->currPos + 1ul) {
         dataChunkToFlatten->state->currPos = -1;
         prevOperator->getNextTuples();
         if (dataChunkToFlatten->state->size == 0) {
-            executionTime->stop();
+            metrics->executionTime.stop();
             return;
         }
     }
     dataChunkToFlatten->state->currPos++;
-    executionTime->stop();
-    numOutputTuple->increase(1ul);
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.incrementByOne();
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -272,7 +272,7 @@ void HashJoinBuild::appendResultSet() {
 }
 
 void HashJoinBuild::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     // Append thread-local tuples
     do {
         prevOperator->getNextTuples();
@@ -289,7 +289,7 @@ void HashJoinBuild::getNextTuples() {
     }
 
     keyDataChunk->state->size = 0;
-    executionTime->stop();
+    metrics->executionTime.stop();
 }
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -276,7 +276,7 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::updateAppendedUnFlatOutResultSet(
 // outKeyDataChunk.currPos.
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     if (!buildSideVectorPtrs.empty() &&
         outKeyDataChunk->state->currPos < (int64_t)(outKeyDataChunk->state->size - 1)) {
         outKeyDataChunk->state->currPos += 1;
@@ -287,8 +287,8 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
                 resultSet->dataChunks[i]->state->initializeSelector();
             }
         }
-        executionTime->stop();
-        numOutputTuple->increase(resultSet->getNumTuples());
+        metrics->executionTime.stop();
+        metrics->numOutputTuple.increase(resultSet->getNumTuples());
         return;
     }
     getNextBatchOfMatchedTuples();
@@ -306,8 +306,8 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
             resultSet->dataChunks[i]->state->initializeSelector();
         }
     }
-    executionTime->stop();
-    numOutputTuple->increase(resultSet->getNumTuples());
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(resultSet->getNumTuples());
 }
 
 template class HashJoinProbe<true>;

--- a/src/processor/physical_plan/operator/load_csv/load_csv.cpp
+++ b/src/processor/physical_plan/operator/load_csv/load_csv.cpp
@@ -32,7 +32,7 @@ LoadCSV<IS_OUT_DATACHUNK_FILTERED>::LoadCSV(string fname, char tokenSeparator,
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void LoadCSV<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     auto lineIdx = 0ul;
     while (lineIdx < DEFAULT_VECTOR_CAPACITY && reader.hasNextLine()) {
         auto tokenIdx = 0ul;
@@ -78,8 +78,8 @@ void LoadCSV<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
             outDataChunk->state->selectedValuesPos[i] = i;
         }
     }
-    executionTime->stop();
-    numOutputTuple->increase(outDataChunk->state->size);
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(outDataChunk->state->size);
 }
 template class LoadCSV<true>;
 template class LoadCSV<false>;

--- a/src/processor/physical_plan/operator/projection/projection.cpp
+++ b/src/processor/physical_plan/operator/projection/projection.cpp
@@ -32,7 +32,7 @@ Projection::Projection(unique_ptr<vector<unique_ptr<ExpressionEvaluator>>> expre
 }
 
 void Projection::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     prevOperator->getNextTuples();
     if (inResultSet->getNumTuples() > 0) {
         resultSet->multiplicity = 0;
@@ -45,7 +45,7 @@ void Projection::getNextTuples() {
         expression->evaluate();
     }
     resultSet->multiplicity = discardedResultSet->getNumTuples();
-    executionTime->stop();
+    metrics->executionTime.stop();
 }
 
 unique_ptr<PhysicalOperator> Projection::clone() {

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -19,7 +19,7 @@ AdjListExtend<IS_OUT_DATACHUNK_FILTERED>::AdjListExtend(uint64_t inDataChunkPos,
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void AdjListExtend<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     if (handle->hasMoreToRead()) {
         readValuesFromList();
         if constexpr (IS_OUT_DATACHUNK_FILTERED) {
@@ -42,8 +42,8 @@ void AdjListExtend<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
             break;
         }
     }
-    executionTime->stop();
-    numOutputTuple->increase(outDataChunk->state->size);
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(outDataChunk->state->size);
 }
 
 template class AdjListExtend<true>;

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -17,7 +17,14 @@ void ReadList::readValuesFromList() {
     lists->reclaim(handle);
     auto nodeOffset =
         inNodeIDVector->readNodeOffset(inDataChunk->state->getCurrSelectedValuesPos());
-    lists->readValues(nodeOffset, outValueVector, outDataChunk->state->size, handle, MAX_TO_READ);
+    lists->readValues(nodeOffset, outValueVector, outDataChunk->state->size, handle, MAX_TO_READ,
+        *metrics->bufferManagerMetrics);
+}
+
+nlohmann::json ReadList::toJson(Profiler& profiler) {
+    auto json = PhysicalOperator::toJson(profiler);
+    flushBufferManagerMetrics(json, profiler);
+    return json;
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -15,13 +15,13 @@ ReadRelPropertyList::ReadRelPropertyList(uint64_t inDataChunkPos, uint64_t inVal
 }
 
 void ReadRelPropertyList::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     prevOperator->getNextTuples();
     if (inDataChunk->state->size > 0) {
         readValuesFromList();
     }
     outValueVector->fillNullMask();
-    executionTime->stop();
+    metrics->executionTime.stop();
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -14,7 +14,7 @@ AdjColumnExtend::AdjColumnExtend(uint64_t dataChunkPos, uint64_t valueVectorPos,
 }
 
 void AdjColumnExtend::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     bool hasAtLeastOneNonNullValue;
     do {
         inDataChunk->state->size = prevInNumSelectedValues;
@@ -23,8 +23,8 @@ void AdjColumnExtend::getNextTuples() {
         hasAtLeastOneNonNullValue =
             static_pointer_cast<NodeIDVector>(outValueVector)->discardNulls();
     } while (inDataChunk->state->size > 0 && !hasAtLeastOneNonNullValue);
-    executionTime->stop();
-    numOutputTuple->increase(inDataChunk->state->size);
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(inDataChunk->state->size);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
@@ -12,5 +12,11 @@ ScanAttribute::ScanAttribute(uint64_t dataChunkPos, uint64_t valueVectorPos,
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
 }
 
+nlohmann::json ScanAttribute::toJson(Profiler& profiler) {
+    auto json = PhysicalOperator::toJson(profiler);
+    flushBufferManagerMetrics(json, profiler);
+    return json;
+}
+
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/scan_attribute/scan_column.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_column.cpp
@@ -7,7 +7,7 @@ void ScanColumn::getNextTuples() {
     prevOperator->getNextTuples();
     if (inDataChunk->state->size > 0) {
         column->reclaim(handle);
-        column->readValues(inNodeIDVector, outValueVector, handle);
+        column->readValues(inNodeIDVector, outValueVector, handle, *metrics->bufferManagerMetrics);
     }
 }
 

--- a/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
@@ -14,10 +14,10 @@ ScanStructuredProperty::ScanStructuredProperty(uint64_t dataChunkPos, uint64_t v
 }
 
 void ScanStructuredProperty::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     ScanColumn::getNextTuples();
     outValueVector->fillNullMask();
-    executionTime->stop();
+    metrics->executionTime.stop();
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -19,13 +19,14 @@ ScanUnstructuredProperty::ScanUnstructuredProperty(uint64_t dataChunkPos, uint64
 }
 
 void ScanUnstructuredProperty::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     prevOperator->getNextTuples();
     if (inDataChunk->state->size > 0) {
         lists->reclaim(handle);
-        lists->readValues(inNodeIDVector, propertyKey, outValueVector, handle);
+        lists->readValues(
+            inNodeIDVector, propertyKey, outValueVector, handle, *metrics->bufferManagerMetrics);
     }
-    executionTime->stop();
+    metrics->executionTime.stop();
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
@@ -29,7 +29,7 @@ ScanNodeID<IS_OUT_DATACHUNK_FILTERED>::ScanNodeID(shared_ptr<MorselsDesc>& morse
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void ScanNodeID<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     if (prevOperator) {
         prevOperator->getNextTuples();
     }
@@ -51,8 +51,8 @@ void ScanNodeID<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
             outDataChunk->state->selectedValuesPos[i] = i;
         }
     }
-    executionTime->stop();
-    numOutputTuple->increase(outDataChunk->state->size);
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(outDataChunk->state->size);
 }
 
 template class ScanNodeID<true>;

--- a/src/processor/physical_plan/operator/sink/result_collector.cpp
+++ b/src/processor/physical_plan/operator/sink/result_collector.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace processor {
 
 void ResultCollector::getNextTuples() {
-    executionTime->start();
+    metrics->executionTime.start();
     prevOperator->getNextTuples();
     auto resultSet = prevOperator->getResultSet();
     queryResult->numTuples += resultSet->getNumTuples() * resultSet->multiplicity;
@@ -17,7 +17,7 @@ void ResultCollector::getNextTuples() {
             queryResult->tuples.push_back(move(tuple));
         }
     }
-    executionTime->stop();
+    metrics->executionTime.stop();
 }
 
 } // namespace processor

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -27,6 +27,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "file_handle",
+        "//src/common:profiler",
         "@nlohmann_json",
     ],
 )
@@ -94,6 +95,7 @@ cc_library(
         "buffer_manager",
         "lists_aux",
         "//src/common:vector",
+        "//src/common:profiler"
     ],
 )
 

--- a/src/storage/data_structure/column.cpp
+++ b/src/storage/data_structure/column.cpp
@@ -4,27 +4,29 @@ namespace graphflow {
 namespace storage {
 
 void BaseColumn::readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
-    const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle) {
+    const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+    BufferManagerMetrics& metrics) {
     if (nodeIDVector->isSequence()) {
         auto nodeOffset = nodeIDVector->readNodeOffset(0);
         auto pageCursor = getPageCursorForOffset(nodeOffset);
         auto sizeLeftToCopy = nodeIDVector->state->size * elementSize;
         if (pageCursor.offset + sizeLeftToCopy <= PAGE_SIZE) {
             // Case when all the values are in a single page on disk.
-            readBySettingFrame(valueVector, handle, pageCursor);
+            readBySettingFrame(valueVector, handle, pageCursor, metrics);
         } else {
             // Case when the values are consecutive but not in a single page on disk.
             readBySequentialCopy(valueVector, handle, sizeLeftToCopy, pageCursor,
-                nullptr /*no page mapping is required*/);
+                nullptr /*no page mapping is required*/, metrics);
         }
         return;
     }
     // Case when values are at non-sequential locations in a column.
-    readFromNonSequentialLocations(nodeIDVector, valueVector, handle);
+    readFromNonSequentialLocations(nodeIDVector, valueVector, handle, metrics);
 }
 
 void BaseColumn::readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& nodeIDVector,
-    const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle) {
+    const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+    BufferManagerMetrics& metrics) {
     reclaim(handle);
     valueVector->reset();
     auto values = valueVector->values;
@@ -32,7 +34,7 @@ void BaseColumn::readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& 
         auto pos = nodeIDVector->state->getCurrSelectedValuesPos();
         auto nodeOffset = nodeIDVector->readNodeOffset(pos);
         auto pageCursor = getPageCursorForOffset(nodeOffset);
-        auto frame = bufferManager.pin(fileHandle, pageCursor.idx);
+        auto frame = bufferManager.pin(fileHandle, pageCursor.idx, metrics);
         memcpy(values + pos * elementSize, frame + pageCursor.offset, elementSize);
         bufferManager.unpin(fileHandle, pageCursor.idx);
     } else {
@@ -40,7 +42,7 @@ void BaseColumn::readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& 
             auto nodeOffset =
                 nodeIDVector->readNodeOffset(nodeIDVector->state->selectedValuesPos[i]);
             auto pageCursor = getPageCursorForOffset(nodeOffset);
-            auto frame = bufferManager.pin(fileHandle, pageCursor.idx);
+            auto frame = bufferManager.pin(fileHandle, pageCursor.idx, metrics);
             memcpy(values + valueVector->state->selectedValuesPos[i] * elementSize,
                 frame + pageCursor.offset, elementSize);
             bufferManager.unpin(fileHandle, pageCursor.idx);
@@ -49,27 +51,29 @@ void BaseColumn::readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& 
 }
 
 void Column<STRING>::readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
-    const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle) {
+    const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+    BufferManagerMetrics& metrics) {
     if (nodeIDVector->isSequence()) {
         auto nodeOffset = nodeIDVector->readNodeOffset(0);
         auto pageCursor = getPageCursorForOffset(nodeOffset);
         auto sizeLeftToCopy = nodeIDVector->state->size * elementSize;
         readBySequentialCopy(valueVector, handle, sizeLeftToCopy, pageCursor,
-            nullptr /*no page mapping is required*/);
+            nullptr /*no page mapping is required*/, metrics);
     } else {
-        readFromNonSequentialLocations(nodeIDVector, valueVector, handle);
+        readFromNonSequentialLocations(nodeIDVector, valueVector, handle, metrics);
     }
-    readStringsFromOverflowPages(valueVector);
+    readStringsFromOverflowPages(valueVector, metrics);
 }
 
-void Column<STRING>::readStringsFromOverflowPages(const shared_ptr<ValueVector>& valueVector) {
+void Column<STRING>::readStringsFromOverflowPages(
+    const shared_ptr<ValueVector>& valueVector, BufferManagerMetrics& metrics) {
     PageCursor cursor;
     for (auto i = 0u; i < valueVector->state->size; i++) {
         auto pos = valueVector->state->selectedValuesPos[i];
         auto& value = ((gf_string_t*)valueVector->values)[pos];
         if (value.len > gf_string_t::SHORT_STR_LENGTH) {
             value.getOverflowPtrInfo(cursor.idx, cursor.offset);
-            auto frame = bufferManager.pin(overflowPagesFileHandle, cursor.idx);
+            auto frame = bufferManager.pin(overflowPagesFileHandle, cursor.idx, metrics);
             auto copyStr = new char[value.len];
             memcpy(copyStr, frame + cursor.offset, value.len);
             value.overflowPtr = reinterpret_cast<uintptr_t>(copyStr);

--- a/src/storage/include/data_structure/column.h
+++ b/src/storage/include/data_structure/column.h
@@ -19,7 +19,8 @@ public:
     virtual ~BaseColumn() = default;
 
     virtual void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
-        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle);
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        BufferManagerMetrics& metrics);
 
 protected:
     BaseColumn(const string& fname, const DataType& dataType, const size_t& elementSize,
@@ -27,7 +28,8 @@ protected:
         : DataStructure{fname, dataType, elementSize, bufferManager} {};
 
     void readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& nodeIDVector,
-        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle);
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        BufferManagerMetrics& metrics);
 };
 
 template<DataType D>
@@ -47,11 +49,12 @@ public:
           overflowPagesFileHandle{path + ".ovf", O_RDWR} {};
 
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
-        const shared_ptr<ValueVector>& valueVector,
-        const unique_ptr<DataStructureHandle>& handle) override;
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        BufferManagerMetrics& metrics) override;
 
 private:
-    void readStringsFromOverflowPages(const shared_ptr<ValueVector>& valueVector);
+    void readStringsFromOverflowPages(
+        const shared_ptr<ValueVector>& valueVector, BufferManagerMetrics& metrics);
 
 private:
     FileHandle overflowPagesFileHandle;

--- a/src/storage/include/data_structure/data_structure.h
+++ b/src/storage/include/data_structure/data_structure.h
@@ -37,11 +37,13 @@ protected:
     virtual ~DataStructure() = default;
 
     void readBySettingFrame(const shared_ptr<ValueVector>& valueVector,
-        const unique_ptr<DataStructureHandle>& handle, PageCursor& pageCursor);
+        const unique_ptr<DataStructureHandle>& handle, PageCursor& pageCursor,
+        BufferManagerMetrics& metrics);
 
     void readBySequentialCopy(const shared_ptr<ValueVector>& valueVector,
         const unique_ptr<DataStructureHandle>& handle, uint64_t sizeLeftToCopy,
-        PageCursor& pageCursor, unique_ptr<LogicalToPhysicalPageIdxMapper> mapper);
+        PageCursor& pageCursor, unique_ptr<LogicalToPhysicalPageIdxMapper> mapper,
+        BufferManagerMetrics& metrics);
 
 public:
     DataType dataType;

--- a/src/storage/include/data_structure/lists/lists.h
+++ b/src/storage/include/data_structure/lists/lists.h
@@ -16,7 +16,7 @@ class BaseLists : public DataStructure {
 public:
     void readValues(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
         uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle,
-        uint32_t maxElementsToRead);
+        uint32_t maxElementsToRead, BufferManagerMetrics& metrics);
 
     uint64_t getNumElementsInList(node_offset_t nodeOffset);
 
@@ -27,10 +27,12 @@ protected:
           headers(headers){};
 
     void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& listLen,
-        const unique_ptr<DataStructureHandle>& handle, uint32_t header, uint32_t maxElementsToRead);
+        const unique_ptr<DataStructureHandle>& handle, uint32_t header, uint32_t maxElementsToRead,
+        BufferManagerMetrics& metrics);
 
     void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle, uint32_t header);
+        uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle, uint32_t header,
+        BufferManagerMetrics& metrics);
 
 public:
     constexpr static uint16_t LISTS_CHUNK_SIZE = 512;
@@ -84,24 +86,28 @@ public:
 
     // readValues is overloaded. Lists<UNKNOWN> is not supposed to use the one defined in BaseLists.
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector, uint32_t propertyKeyIdxToRead,
-        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle);
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        BufferManagerMetrics& metrics);
 
 private:
     void readUnstrPropertyListOfNode(node_offset_t nodeOffset, uint32_t propertyKeyIdxToRead,
         const shared_ptr<ValueVector>& valueVector, uint64_t pos,
-        const unique_ptr<DataStructureHandle>& handle, uint32_t header);
+        const unique_ptr<DataStructureHandle>& handle, uint32_t header,
+        BufferManagerMetrics& metrics);
 
     void readUnstrPropertyKeyIdxAndDatatype(uint8_t* propertyKeyDataTypeCache,
         uint64_t& physicalPageIdx, const uint32_t*& propertyKeyIdxPtr,
         DataType& propertyKeyDataType, const unique_ptr<DataStructureHandle>& handle,
-        PageCursor& pageCursor, uint64_t& listLen, LogicalToPhysicalPageIdxMapper& mapper);
+        PageCursor& pageCursor, uint64_t& listLen, LogicalToPhysicalPageIdxMapper& mapper,
+        BufferManagerMetrics& metrics);
 
     void readOrSkipUnstrPropertyValue(uint64_t& physicalPageIdx, DataType& propertyDataType,
         const unique_ptr<DataStructureHandle>& handle, PageCursor& pageCursor, uint64_t& listLen,
         LogicalToPhysicalPageIdxMapper& mapper, const shared_ptr<ValueVector>& valueVector,
-        uint64_t pos, bool toRead);
+        uint64_t pos, bool toRead, BufferManagerMetrics& metrics);
 
-    void readStringsFromOverflowPages(const shared_ptr<ValueVector>& valueVector);
+    void readStringsFromOverflowPages(
+        const shared_ptr<ValueVector>& valueVector, BufferManagerMetrics& metrics);
 
 public:
     static constexpr uint8_t UNSTR_PROP_IDX_LEN = 4;

--- a/src/storage/include/index/hash_index.h
+++ b/src/storage/include/index/hash_index.h
@@ -126,7 +126,7 @@ public:
 
 public:
     vector<bool> insert(ValueVector& keys, ValueVector& values);
-    void lookup(ValueVector& keys, ValueVector& result);
+    void lookup(ValueVector& keys, ValueVector& result, BufferManagerMetrics& metrics);
     // Reserves space for at least the specified number of elements.
     void reserve(uint64_t numEntries);
     void flush();
@@ -145,8 +145,8 @@ private:
 
     uint8_t* findFreeOverflowSlot(SlotHeader& prevSlotHeader);
 
-    uint64_t lookupKeyInSlot(
-        uint8_t* key, uint64_t numBytesPerKey, uint64_t pageId, uint64_t slotIdInPage) const;
+    uint64_t lookupKeyInSlot(uint8_t* key, uint64_t numBytesPerKey, uint64_t pageId,
+        uint64_t slotIdInPage, BufferManagerMetrics& metrics) const;
     bool keyNotExistInSlot(
         uint8_t* key, uint64_t numBytesPerKey, uint64_t blockId, uint64_t slotIdInBlock);
 


### PR DESCRIPTION
This PR adds buffer manger profiling for operator

- Operator that might use buffer manager (i.e. readValues from column or list) keeps track of 3 additional metrics
  -  NumBufferHit, numBufferMiss and numDiskRead (each buffer miss may trigger multiple disk reads).
  -  Any call to buffer manager pin() should give these 3 additional metric.
  -  Frontier extend require metric to be thread safe.