### PR TITLE
Add EXPLAIN command and logical info print

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -16,7 +16,13 @@ oC_Cypher
     : SP ? oC_AnyCypherOption? SP? oC_Statement ( SP? ';' )? SP? EOF ;
 
 oC_AnyCypherOption
-    : oC_Profile ;
+    : oC_Explain
+        | oC_Profile ;
+
+oC_Explain
+    : EXPLAIN ;
+
+EXPLAIN : ( 'E' | 'e' ) ( 'X' | 'x' ) ( 'P' | 'p' ) ( 'L' | 'l' ) ( 'A' | 'a' ) ( 'I' | 'i' ) ( 'N' | 'n' ) ;
 
 oC_Profile
     : PROFILE ;

--- a/src/common/include/profiler.h
+++ b/src/common/include/profiler.h
@@ -19,7 +19,7 @@ public:
 
     uint64_t sumAllNumericMetricsWithKey(const string& key);
 
-    void reset();
+    void resetMetrics();
 
 private:
     void addMetric(const string& key, unique_ptr<Metric> metric);

--- a/src/common/profiler.cpp
+++ b/src/common/profiler.cpp
@@ -37,7 +37,7 @@ uint64_t Profiler::sumAllNumericMetricsWithKey(const string& key) {
     return sum;
 }
 
-void Profiler::reset() {
+void Profiler::resetMetrics() {
     metrics.clear();
 }
 

--- a/src/main/BUILD.bazel
+++ b/src/main/BUILD.bazel
@@ -2,12 +2,18 @@ load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
 
 cc_library(
     name = "session_context",
+    srcs = [
+        "plan_printer.cpp",
+    ],
     hdrs = [
         "include/session_context.h",
+        "include/plan_printer.h"
     ],
     deps = [
         "//src/transaction:transaction",
-        "//src/common:profiler"
+        "//src/common:profiler",
+        "//src/planner:logical_plan",
+        "//src/processor:physical_plan"
     ],
 )
 

--- a/src/main/include/plan_printer.h
+++ b/src/main/include/plan_printer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "src/common/include/profiler.h"
+#include "src/planner/include/logical_plan/logical_plan.h"
+#include "src/processor/include/physical_plan/physical_plan.h"
+
+using namespace graphflow::planner;
+using namespace graphflow::processor;
+
+namespace graphflow {
+namespace main {
+
+class PlanPrinter {
+
+public:
+    PlanPrinter(unordered_map<uint32_t, shared_ptr<LogicalOperator>> physicalToLogicalOperatorMap)
+        : physicalToLogicalOperatorMap{move(physicalToLogicalOperatorMap)} {}
+
+    nlohmann::json printPlanToJson(PhysicalPlan* physicalPlan, Profiler& profiler);
+
+private:
+    nlohmann::json toJson(PhysicalOperator* physicalOperator, Profiler& profiler);
+
+private:
+    unordered_map<uint32_t, shared_ptr<LogicalOperator>> physicalToLogicalOperatorMap;
+};
+
+} // namespace main
+} // namespace graphflow

--- a/src/main/include/session_context.h
+++ b/src/main/include/session_context.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/common/include/profiler.h"
+#include "src/main/include/plan_printer.h"
 #include "src/transaction/include/transaction.h"
 
 using namespace graphflow::common;
@@ -16,8 +17,10 @@ public:
 
 public:
     string query;
+    bool enable_explain = false;
     uint64_t numThreads = 1;
     unique_ptr<Profiler> profiler;
+    unique_ptr<PlanPrinter> planPrinter;
     Transaction* activeTransaction{nullptr};
 };
 

--- a/src/main/include/system.h
+++ b/src/main/include/system.h
@@ -14,24 +14,24 @@ using namespace graphflow::planner;
 namespace graphflow {
 namespace main {
 
-struct ExecutionResult {
-public:
-    ExecutionResult(unique_ptr<PhysicalPlan> physicalPlan, unique_ptr<QueryResult> queryResult)
-        : physicalPlan{move(physicalPlan)}, queryResult{move(queryResult)} {}
-    unique_ptr<PhysicalPlan> physicalPlan;
-    unique_ptr<QueryResult> queryResult;
-};
+const string BINDING_STAGE = "binding";
+const string PLANNING_STAGE = "planning";
+const string MAPPING_STAGE = "mapping";
+const string EXECUTING_STAGE = "executing";
 
 class System {
 
 public:
     explicit System(const string& path);
 
-    unique_ptr<ExecutionResult> executeQuery(SessionContext& sessionContext) const;
+    pair<unique_ptr<PhysicalPlan>, unique_ptr<ExecutionContext>> prepareQuery(
+        SessionContext& context) const;
+
+    unique_ptr<QueryResult> executePlan(PhysicalPlan* plan, SessionContext& context) const;
 
     // currently used in testing framework
     vector<unique_ptr<LogicalPlan>> enumerateAllPlans(SessionContext& sessionContext) const;
-    unique_ptr<ExecutionResult> executePlan(
+    unique_ptr<QueryResult> executePlan(
         unique_ptr<LogicalPlan> logicalPlan, SessionContext& sessionContext) const;
 
     unique_ptr<nlohmann::json> debugInfo() const;

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -1,0 +1,37 @@
+#include "src/main/include/plan_printer.h"
+
+#include "src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h"
+
+namespace graphflow {
+namespace main {
+
+nlohmann::json PlanPrinter::printPlanToJson(PhysicalPlan* physicalPlan, Profiler& profiler) {
+    return toJson(physicalPlan->lastOperator.get(), profiler);
+}
+
+nlohmann::json PlanPrinter::toJson(PhysicalOperator* physicalOperator, Profiler& profiler) {
+    auto json = nlohmann::json();
+    auto operatorType = physicalOperator->operatorType;
+    auto operatorID = physicalOperator->id;
+    // flatten, result collector do not have corresponding logical operator
+    auto operatorName = PhysicalOperatorTypeNames[operatorType];
+    if (physicalToLogicalOperatorMap.contains(operatorID)) {
+        operatorName +=
+            "(" + physicalToLogicalOperatorMap.at(operatorID)->getExpressionsForPrinting() + ")";
+    }
+    json["name"] = operatorName;
+    if (operatorType == HASH_JOIN_PROBE) {
+        json["buildChild"] =
+            toJson(((HashJoinProbe<true>*)physicalOperator)->buildSidePrevOp.get(), profiler);
+    }
+    if (physicalOperator->prevOperator) {
+        json["child"] = toJson(physicalOperator->prevOperator.get(), profiler);
+    }
+    if (profiler.enabled) {
+        physicalOperator->printMetricsToJson(json, profiler);
+    }
+    return json;
+}
+
+} // namespace main
+} // namespace graphflow

--- a/src/parser/include/queries/single_query.h
+++ b/src/parser/include/queries/single_query.h
@@ -14,6 +14,8 @@ public:
     vector<unique_ptr<QueryPart>> queryParts;
     vector<unique_ptr<ReadingStatement>> readingStatements;
     unique_ptr<ReturnStatement> returnStatement;
+    // If explain is enabled, we do not execute query but return physical plan only
+    bool enable_explain = false;
     bool enable_profile = false;
 };
 

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -8,9 +8,10 @@ namespace parser {
 
 unique_ptr<SingleQuery> Transformer::transform() {
     auto singleQuery = transformQuery(*root.oC_Statement()->oC_Query());
-    // Currently PROFILE is the only cypher option.
     if (root.oC_AnyCypherOption()) {
-        singleQuery->enable_profile = true;
+        auto cypherOption = root.oC_AnyCypherOption();
+        singleQuery->enable_explain = cypherOption->oC_Explain() != nullptr;
+        singleQuery->enable_profile = cypherOption->oC_Profile() != nullptr;
     }
     return singleQuery;
 }

--- a/src/planner/include/logical_plan/logical_plan.h
+++ b/src/planner/include/logical_plan/logical_plan.h
@@ -13,8 +13,6 @@ public:
 
     explicit LogicalPlan(unique_ptr<Schema> schema) : schema{move(schema)}, cost{0} {}
 
-    const LogicalOperator& getLastOperator();
-
     void appendOperator(shared_ptr<LogicalOperator> op);
 
     unique_ptr<LogicalPlan> copy() const;

--- a/src/planner/include/logical_plan/operator/crud/logical_crud_node.h
+++ b/src/planner/include/logical_plan/operator/crud/logical_crud_node.h
@@ -17,7 +17,7 @@ public:
 
     LogicalOperatorType getLogicalOperatorType() const override { return CRUDType; }
 
-    string getOperatorInformation() const override {
+    string getExpressionsForPrinting() const override {
         return LogicalOperatorTypeNames[CRUDType] + ": " + to_string(nodeLabel);
     }
 

--- a/src/planner/include/logical_plan/operator/extend/logical_extend.h
+++ b/src/planner/include/logical_plan/operator/extend/logical_extend.h
@@ -20,7 +20,7 @@ public:
         return LogicalOperatorType::LOGICAL_EXTEND;
     }
 
-    string getOperatorInformation() const override {
+    string getExpressionsForPrinting() const override {
         return boundNodeID + (direction == Direction::FWD ? "->" : "<-") + nbrNodeID;
     }
 

--- a/src/planner/include/logical_plan/operator/filter/logical_filter.h
+++ b/src/planner/include/logical_plan/operator/filter/logical_filter.h
@@ -20,7 +20,7 @@ public:
 
     const Expression& getRootExpression() const { return *rootExpr; }
 
-    string getOperatorInformation() const override { return rootExpr->rawExpression; }
+    string getExpressionsForPrinting() const override { return rootExpr->rawExpression; }
 
 public:
     shared_ptr<Expression> rootExpr;

--- a/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
+++ b/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
@@ -19,7 +19,7 @@ public:
 
     string toString(uint64_t depth = 0) const {
         string result = LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
-                        getOperatorInformation() + "]";
+                        getExpressionsForPrinting() + "]";
         result += "\nBUILD SIDE: \n";
         result += buildSidePrevOperator->toString(depth + 1);
         result += "\nPROBE SIDE: \n";
@@ -27,7 +27,7 @@ public:
         return result;
     }
 
-    string getOperatorInformation() const override { return joinNodeID; }
+    string getExpressionsForPrinting() const override { return joinNodeID; }
 
 public:
     const string joinNodeID;

--- a/src/planner/include/logical_plan/operator/load_csv/logical_load_csv.h
+++ b/src/planner/include/logical_plan/operator/load_csv/logical_load_csv.h
@@ -18,7 +18,7 @@ public:
         return LogicalOperatorType::LOGICAL_LOAD_CSV;
     }
 
-    string getOperatorInformation() const override { return path; }
+    string getExpressionsForPrinting() const override { return path; }
 
 public:
     string path;

--- a/src/planner/include/logical_plan/operator/logical_operator.h
+++ b/src/planner/include/logical_plan/operator/logical_operator.h
@@ -47,7 +47,7 @@ public:
     virtual string toString(uint64_t depth = 0) const {
         string result = string(depth * 4, ' ');
         result += LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
-                  getOperatorInformation() + "]";
+                  getExpressionsForPrinting() + "]";
         if (prevOperator) {
             result += "\n";
             result += prevOperator->toString(depth);
@@ -55,7 +55,7 @@ public:
         return result;
     }
 
-    virtual string getOperatorInformation() const = 0;
+    virtual string getExpressionsForPrinting() const = 0;
 
 public:
     shared_ptr<LogicalOperator> prevOperator;

--- a/src/planner/include/logical_plan/operator/projection/logical_projection.h
+++ b/src/planner/include/logical_plan/operator/projection/logical_projection.h
@@ -16,7 +16,7 @@ public:
         return LogicalOperatorType::LOGICAL_PROJECTION;
     }
 
-    string getOperatorInformation() const override {
+    string getExpressionsForPrinting() const override {
         auto result = expressionsToProject[0]->getAliasElseRawExpression();
         for (auto i = 1u; i < expressionsToProject.size(); ++i) {
             result += ", " + expressionsToProject[i]->getAliasElseRawExpression();

--- a/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
+++ b/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
@@ -17,7 +17,7 @@ public:
         return LogicalOperatorType::LOGICAL_SCAN_NODE_ID;
     }
 
-    string getOperatorInformation() const override { return nodeID; }
+    string getExpressionsForPrinting() const override { return nodeID; }
 
 public:
     const string nodeID;

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
@@ -18,7 +18,7 @@ public:
         return LogicalOperatorType::LOGICAL_SCAN_NODE_PROPERTY;
     }
 
-    string getOperatorInformation() const override { return propertyVariableName; }
+    string getExpressionsForPrinting() const override { return propertyVariableName; }
 
 public:
     const string nodeID;

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
@@ -20,7 +20,7 @@ public:
         return LogicalOperatorType::LOGICAL_SCAN_REL_PROPERTY;
     }
 
-    string getOperatorInformation() const override { return propertyVariableName; }
+    string getExpressionsForPrinting() const override { return propertyVariableName; }
 
 public:
     string boundNodeID;

--- a/src/planner/logical_plan/logical_plan.cpp
+++ b/src/planner/logical_plan/logical_plan.cpp
@@ -5,10 +5,6 @@
 namespace graphflow {
 namespace planner {
 
-const LogicalOperator& LogicalPlan::getLastOperator() {
-    return *lastOperator;
-}
-
 void LogicalPlan::appendOperator(shared_ptr<LogicalOperator> op) {
     lastOperator = move(op);
 }

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -60,12 +60,6 @@ public:
         return cloneOp;
     }
 
-    nlohmann::json toJson(Profiler& profiler) override {
-        auto json = PhysicalOperator::toJson(profiler);
-        json["buildSide"] = buildSidePrevOp->toJson(profiler);
-        return json;
-    }
-
 public:
     unique_ptr<PhysicalOperator> buildSidePrevOp;
     shared_ptr<HashJoinSharedState> sharedState;

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -67,7 +67,7 @@ public:
 
     virtual unique_ptr<PhysicalOperator> clone() = 0;
 
-    virtual nlohmann::json toJson(Profiler& profiler);
+    virtual void printMetricsToJson(nlohmann::json& json, Profiler& profiler);
 
 protected:
     string getTimeMetricKey() { return "time-" + to_string(id); }
@@ -78,8 +78,8 @@ protected:
 
     void registerProfilingMetrics();
 
-    void flushTimeAndNumOutputMetrics(nlohmann::json& json, Profiler& profiler);
-    void flushBufferManagerMetrics(nlohmann::json& json, Profiler& profiler);
+    void printTimeAndNumOutputMetrics(nlohmann::json& json, Profiler& profiler);
+    void printBufferManagerMetrics(nlohmann::json& json, Profiler& profiler);
 
 public:
     unique_ptr<PhysicalOperator> prevOperator;

--- a/src/processor/include/physical_plan/operator/read_list/read_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_list.h
@@ -15,10 +15,10 @@ public:
 
     ~ReadList() { lists->reclaim(handle); }
 
+    void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
+
 protected:
     void readValuesFromList();
-
-    nlohmann::json toJson(Profiler& profiler) override;
 
 protected:
     static constexpr uint32_t MAX_TO_READ = 512;

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
@@ -14,8 +14,7 @@ public:
     ScanAttribute(uint64_t dataChunkPos, uint64_t valueVectorPos,
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
 
-protected:
-    nlohmann::json toJson(Profiler& profiler) override;
+    void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
 
 protected:
     uint64_t dataChunkPos;

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -13,18 +13,17 @@ ReadList::ReadList(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos,
     handle = make_unique<DataStructureHandle>();
 }
 
+void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
+    PhysicalOperator::printTimeAndNumOutputMetrics(json, profiler);
+    printBufferManagerMetrics(json, profiler);
+}
+
 void ReadList::readValuesFromList() {
     lists->reclaim(handle);
     auto nodeOffset =
         inNodeIDVector->readNodeOffset(inDataChunk->state->getCurrSelectedValuesPos());
     lists->readValues(nodeOffset, outValueVector, outDataChunk->state->size, handle, MAX_TO_READ,
         *metrics->bufferManagerMetrics);
-}
-
-nlohmann::json ReadList::toJson(Profiler& profiler) {
-    auto json = PhysicalOperator::toJson(profiler);
-    flushBufferManagerMetrics(json, profiler);
-    return json;
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
@@ -12,10 +12,9 @@ ScanAttribute::ScanAttribute(uint64_t dataChunkPos, uint64_t valueVectorPos,
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
 }
 
-nlohmann::json ScanAttribute::toJson(Profiler& profiler) {
-    auto json = PhysicalOperator::toJson(profiler);
-    flushBufferManagerMetrics(json, profiler);
-    return json;
+void ScanAttribute::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
+    PhysicalOperator::printMetricsToJson(json, profiler);
+    printBufferManagerMetrics(json, profiler);
 }
 
 } // namespace processor

--- a/src/testing/test_helper.cpp
+++ b/src/testing/test_helper.cpp
@@ -27,8 +27,8 @@ bool TestHelper::runTest(const TestSuiteQueryConfig& testConfig, const System& s
         numPlansOfEachQuery[i] = numPlans;
         uint64_t numPassedPlans = 0;
         for (uint64_t j = 0; j < numPlans; j++) {
-            auto planStr = plans[j]->getLastOperator().toString();
-            auto result = move(system.executePlan(move(plans[j]), sessionContext)->queryResult);
+            auto planStr = plans[j]->lastOperator->toString();
+            auto result = system.executePlan(move(plans[j]), sessionContext);
             if (result->numTuples != testConfig.expectedNumTuples[i]) {
                 spdlog::error("PLAN{} NOT PASSED. Result num tuples: {}, Expected num tuples: {}",
                     j, result->numTuples, testConfig.expectedNumTuples[i]);

--- a/test/planner/optimizer/optimizer_test.cpp
+++ b/test/planner/optimizer/optimizer_test.cpp
@@ -31,7 +31,7 @@ TEST_F(OptimizerTest, OneHopSingleFilter) {
 
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = 1 RETURN COUNT(*)";
     auto plan = OptimizerTest::getBestPlan(query, graph);
-    auto& op1 = plan->getLastOperator();
+    auto& op1 = *plan->lastOperator;
     ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID));
     auto& op2 = *op1.prevOperator->prevOperator->prevOperator;
@@ -46,7 +46,7 @@ TEST_F(OptimizerTest, OneHopMultiFilters) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age > 10 AND a.age < 20 AND b.age "
                  "= 45 RETURN COUNT(*)";
     auto plan = OptimizerTest::getBestPlan(query, graph);
-    auto& op1 = *plan->getLastOperator().prevOperator->prevOperator;
+    auto& op1 = *plan->lastOperator->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID));
     auto& op2 = *op1.prevOperator->prevOperator->prevOperator->prevOperator;
@@ -60,7 +60,7 @@ TEST_F(OptimizerTest, TwoHop) {
 
     auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN COUNT(*)";
     auto plan = OptimizerTest::getBestPlan(query, graph);
-    auto& op1 = *plan->getLastOperator().prevOperator->prevOperator;
+    auto& op1 = *plan->lastOperator->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID));
 }
@@ -72,9 +72,8 @@ TEST_F(OptimizerTest, TwoHopMultiFilters) {
     auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE a.age = 20 AND "
                  "b.age = 35 RETURN COUNT(*)";
     auto plan = OptimizerTest::getBestPlan(query, graph);
-    auto& op1 =
-        *plan->getLastOperator()
-             .prevOperator->prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
+    auto& op1 = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator
+                     ->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID));
 }


### PR DESCRIPTION
This PR add supports to EXPLAIN command.

- EXPLAIN query will not trigger execution and return physical plan only
- Print physical plan together with logical plan
  -   Associate logical opertor info (e.g. which variable being scanned) when printing physical plan