### PR TITLE
add memory manager for string buffer

### DIFF
--- a/src/common/include/vector/node_vector.h
+++ b/src/common/include/vector/node_vector.h
@@ -51,7 +51,7 @@ public:
 protected:
     NodeIDVector(label_t commonLabel, const NodeIDCompressionScheme& nodeIDCompressionScheme,
         bool isSequence, uint64_t vectorCapacity)
-        : ValueVector{vectorCapacity, nodeIDCompressionScheme.getNumTotalBytes(), NODE},
+        : ValueVector{nullptr, vectorCapacity, nodeIDCompressionScheme.getNumTotalBytes(), NODE},
           representation{NodeIDRepresentation(isSequence, commonLabel, nodeIDCompressionScheme)} {};
 
 public:

--- a/src/common/include/vector/string_buffer.h
+++ b/src/common/include/vector/string_buffer.h
@@ -10,10 +10,8 @@ namespace common {
 
 struct BufferBlock {
 public:
-    explicit BufferBlock(uint64_t size) : size{size}, currentOffset{0} {
-        buffer = make_unique<uint8_t[]>(size);
-        data = buffer.get();
-    }
+    explicit BufferBlock(unique_ptr<MemoryBlock> block)
+        : size{block->size}, currentOffset{0}, data{block->data}, block{move(block)} {}
 
 public:
     uint64_t size;
@@ -21,19 +19,22 @@ public:
     uint8_t* data;
 
 private:
-    unique_ptr<uint8_t[]> buffer;
+    unique_ptr<MemoryBlock> block;
 };
 
 class StringBuffer {
     static constexpr uint64_t MIN_BUFFER_BLOCK_SIZE = 4096;
 
 public:
-    explicit StringBuffer() : currentBlock{nullptr} {};
+    explicit StringBuffer(MemoryManager& memoryManager)
+        : memoryManager{memoryManager}, currentBlock{nullptr} {};
 
 public:
     gf_string_t allocateLargeString(uint64_t len);
+    void appendBuffer(StringBuffer& other);
 
 private:
+    MemoryManager& memoryManager;
     BufferBlock* currentBlock;
     vector<unique_ptr<BufferBlock>> blocks;
 };

--- a/src/common/vector/string_buffer.cpp
+++ b/src/common/vector/string_buffer.cpp
@@ -1,7 +1,6 @@
 #include "src/common/include/vector/string_buffer.h"
 
 #include <cassert>
-#include <cstring>
 
 namespace graphflow {
 namespace common {
@@ -10,8 +9,8 @@ gf_string_t StringBuffer::allocateLargeString(uint64_t len) {
     assert(len > gf_string_t::SHORT_STR_LENGTH);
     if (currentBlock == nullptr || (currentBlock->currentOffset + len) > currentBlock->size) {
         auto blockSize = max(len, MIN_BUFFER_BLOCK_SIZE);
-        auto newBlock = make_unique<BufferBlock>(blockSize);
-        memset(newBlock->data, 0, blockSize);
+        auto newBlock = make_unique<BufferBlock>(
+            memoryManager.allocateBlock(blockSize, true /* initializeToZero */));
         currentBlock = newBlock.get();
         blocks.push_back(move(newBlock));
     }
@@ -21,6 +20,15 @@ gf_string_t StringBuffer::allocateLargeString(uint64_t len) {
         reinterpret_cast<uint64_t>(currentBlock->data + currentBlock->currentOffset);
     currentBlock->currentOffset += len;
     return result;
+}
+
+void StringBuffer::appendBuffer(StringBuffer& other) {
+    if (other.blocks.empty()) {
+        return;
+    }
+    blocks.insert(blocks.end(), make_move_iterator(other.blocks.begin()),
+        make_move_iterator(other.blocks.end()));
+    currentBlock = other.currentBlock;
 }
 } // namespace common
 } // namespace graphflow

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -42,7 +42,7 @@ void ValueVector::fillNullMask() {
 }
 
 shared_ptr<ValueVector> ValueVector::clone() {
-    auto newVector = make_shared<ValueVector>(dataType, vectorCapacity);
+    auto newVector = make_shared<ValueVector>(memoryManager, dataType, vectorCapacity);
     memcpy(newVector->nullMask, nullMask, vectorCapacity);
     if (STRING == dataType) {
         for (auto i = 0u; i < vectorCapacity; i++) {

--- a/src/expression_evaluator/binary_expression_evaluator.cpp
+++ b/src/expression_evaluator/binary_expression_evaluator.cpp
@@ -3,14 +3,15 @@
 namespace graphflow {
 namespace evaluator {
 
-BinaryExpressionEvaluator::BinaryExpressionEvaluator(unique_ptr<ExpressionEvaluator> leftExpr,
-    unique_ptr<ExpressionEvaluator> rightExpr, ExpressionType expressionType, DataType dataType) {
+BinaryExpressionEvaluator::BinaryExpressionEvaluator(MemoryManager& memoryManager,
+    unique_ptr<ExpressionEvaluator> leftExpr, unique_ptr<ExpressionEvaluator> rightExpr,
+    ExpressionType expressionType, DataType dataType) {
     childrenExpr.push_back(move(leftExpr));
     childrenExpr.push_back(move(rightExpr));
     this->expressionType = expressionType;
     this->dataType = dataType;
     operation = getBinaryOperation(expressionType);
-    result = createResultValueVector();
+    result = createResultValueVector(memoryManager);
 }
 
 void BinaryExpressionEvaluator::evaluate() {
@@ -19,8 +20,9 @@ void BinaryExpressionEvaluator::evaluate() {
     operation(*childrenExpr[0]->result, *childrenExpr[1]->result, *result);
 }
 
-shared_ptr<ValueVector> BinaryExpressionEvaluator::createResultValueVector() {
-    auto valueVector = make_shared<ValueVector>(dataType);
+shared_ptr<ValueVector> BinaryExpressionEvaluator::createResultValueVector(
+    MemoryManager& memoryManager) {
+    auto valueVector = make_shared<ValueVector>(&memoryManager, dataType);
     auto isLeftResultFlat = childrenExpr[0]->isResultFlat();
     auto isRightResultFlat = childrenExpr[1]->isResultFlat();
     if (isLeftResultFlat && isRightResultFlat) {

--- a/src/expression_evaluator/include/binary_expression_evaluator.h
+++ b/src/expression_evaluator/include/binary_expression_evaluator.h
@@ -11,13 +11,13 @@ namespace evaluator {
 class BinaryExpressionEvaluator : public ExpressionEvaluator {
 
 public:
-    BinaryExpressionEvaluator(unique_ptr<ExpressionEvaluator> leftExpr,
-        unique_ptr<ExpressionEvaluator> rightExpr, ExpressionType expressionType,
-        DataType dataType);
+    BinaryExpressionEvaluator(MemoryManager& memoryManager,
+        unique_ptr<ExpressionEvaluator> leftExpr, unique_ptr<ExpressionEvaluator> rightExpr,
+        ExpressionType expressionType, DataType dataType);
 
     void evaluate() override;
 
-    shared_ptr<ValueVector> createResultValueVector();
+    shared_ptr<ValueVector> createResultValueVector(MemoryManager& memoryManager);
 
 private:
     function<void(ValueVector&, ValueVector&, ValueVector&)> operation;

--- a/src/expression_evaluator/include/expression_evaluator.h
+++ b/src/expression_evaluator/include/expression_evaluator.h
@@ -22,13 +22,14 @@ public:
         ExpressionType type);
 
     // Creates a leaf literal as value vector expression_evaluator expression.
-    ExpressionEvaluator(shared_ptr<ValueVector> result, ExpressionType expressionType)
-        : result{result}, valueVectorPos{UINT64_MAX}, expressionType{expressionType},
-          dataType(result->dataType) {}
+    ExpressionEvaluator(MemoryManager& memoryManager, const shared_ptr<ValueVector>& result,
+        ExpressionType expressionType)
+        : result{result}, dataChunkPos{0}, valueVectorPos{UINT64_MAX},
+          expressionType{expressionType}, dataType(result->dataType) {}
 
     // Creates a leaf variable value vector expression_evaluator expression.
-    ExpressionEvaluator(
-        shared_ptr<ValueVector> result, uint64_t dataChunkPos, uint64_t valueVectorPos)
+    ExpressionEvaluator(MemoryManager& memoryManager, const shared_ptr<ValueVector>& result,
+        uint64_t dataChunkPos, uint64_t valueVectorPos)
         : result{result}, dataChunkPos{dataChunkPos}, valueVectorPos{valueVectorPos},
           expressionType{PROPERTY}, dataType(result->dataType) {}
 
@@ -51,7 +52,7 @@ public:
     DataType dataType;
 
 protected:
-    ExpressionEvaluator() = default;
+    explicit ExpressionEvaluator() = default;
 
     vector<unique_ptr<ExpressionEvaluator>> childrenExpr;
 };

--- a/src/expression_evaluator/include/unary_expression_evaluator.h
+++ b/src/expression_evaluator/include/unary_expression_evaluator.h
@@ -9,12 +9,12 @@ namespace evaluator {
 class UnaryExpressionEvaluator : public ExpressionEvaluator {
 
 public:
-    UnaryExpressionEvaluator(
-        unique_ptr<ExpressionEvaluator> child, ExpressionType expressionType, DataType dataType);
+    UnaryExpressionEvaluator(MemoryManager& memoryManager, unique_ptr<ExpressionEvaluator> child,
+        ExpressionType expressionType, DataType dataType);
 
     void evaluate() override;
 
-    shared_ptr<ValueVector> createResultValueVector();
+    shared_ptr<ValueVector> createResultValueVector(MemoryManager& memoryManager);
 
 protected:
     function<void(ValueVector&, ValueVector&)> operation;

--- a/src/expression_evaluator/unary_expression_evaluator.cpp
+++ b/src/expression_evaluator/unary_expression_evaluator.cpp
@@ -3,13 +3,13 @@
 namespace graphflow {
 namespace evaluator {
 
-UnaryExpressionEvaluator::UnaryExpressionEvaluator(
+UnaryExpressionEvaluator::UnaryExpressionEvaluator(MemoryManager& memoryManager,
     unique_ptr<ExpressionEvaluator> child, ExpressionType expressionType, DataType dataType) {
     childrenExpr.push_back(move(child));
     this->expressionType = expressionType;
     this->dataType = dataType;
     operation = getUnaryOperation(expressionType);
-    result = createResultValueVector();
+    result = createResultValueVector(memoryManager);
 }
 
 void UnaryExpressionEvaluator::evaluate() {
@@ -17,8 +17,9 @@ void UnaryExpressionEvaluator::evaluate() {
     operation(*childrenExpr[0]->result, *result);
 }
 
-shared_ptr<ValueVector> UnaryExpressionEvaluator::createResultValueVector() {
-    auto valueVector = make_shared<ValueVector>(dataType);
+shared_ptr<ValueVector> UnaryExpressionEvaluator::createResultValueVector(
+    MemoryManager& memoryManager) {
+    auto valueVector = make_shared<ValueVector>(&memoryManager, dataType);
     if (expressionType == CAST_TO_UNSTRUCTURED_VECTOR) {
         auto unstructuredValues = (Value*)valueVector->values;
         for (auto i = 0u; i < DEFAULT_VECTOR_CAPACITY; i++) {

--- a/src/main/system.cpp
+++ b/src/main/system.cpp
@@ -39,8 +39,8 @@ pair<unique_ptr<PhysicalPlan>, unique_ptr<ExecutionContext>> System::prepareQuer
     auto logicalPlan = Enumerator(*graph, *boundQuery).getBestPlan();
     planningTimeMetric->stop();
 
-    auto executionContext =
-        make_unique<ExecutionContext>(*context.profiler, context.activeTransaction);
+    auto executionContext = make_unique<ExecutionContext>(
+        *context.profiler, context.activeTransaction, processor->memManager.get());
     auto mappingTimeMetric = context.profiler->registerTimeMetric(MAPPING_STAGE);
     mappingTimeMetric->start();
     auto mapper = PlanMapper(*graph);
@@ -72,8 +72,8 @@ vector<unique_ptr<LogicalPlan>> System::enumerateAllPlans(SessionContext& sessio
 unique_ptr<QueryResult> System::executePlan(
     unique_ptr<LogicalPlan> logicalPlan, SessionContext& sessionContext) const {
     sessionContext.profiler->resetMetrics();
-    auto executionContext =
-        ExecutionContext(*sessionContext.profiler, sessionContext.activeTransaction);
+    auto executionContext = ExecutionContext(
+        *sessionContext.profiler, sessionContext.activeTransaction, processor->memManager.get());
     auto physicalPlan = PlanMapper(*graph).mapToPhysical(move(logicalPlan), executionContext);
     return processor->execute(physicalPlan.get(), sessionContext.numThreads);
 }

--- a/src/processor/include/execution_context.h
+++ b/src/processor/include/execution_context.h
@@ -11,12 +11,13 @@ namespace processor {
 struct ExecutionContext {
 
 public:
-    ExecutionContext(Profiler& profiler, Transaction* transaction)
-        : profiler{profiler}, transaction{transaction} {}
+    ExecutionContext(Profiler& profiler, Transaction* transaction, MemoryManager* memoryManager)
+        : profiler{profiler}, transaction{transaction}, memoryManager{memoryManager} {}
 
 public:
     Profiler& profiler;
     Transaction* transaction;
+    MemoryManager* memoryManager;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/expression_mapper.h
+++ b/src/processor/include/physical_plan/expression_mapper.h
@@ -14,11 +14,12 @@ namespace processor {
 class ExpressionMapper {
 
 public:
-    static unique_ptr<ExpressionEvaluator> mapToPhysical(const Expression& expression,
-        PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet);
+    static unique_ptr<ExpressionEvaluator> mapToPhysical(MemoryManager& memoryManager,
+        const Expression& expression, PhysicalOperatorsInfo& physicalOperatorInfo,
+        ResultSet& resultSet);
 
     static unique_ptr<ExpressionEvaluator> clone(
-        const ExpressionEvaluator& expression, ResultSet& resultSet);
+        MemoryManager& memoryManager, const ExpressionEvaluator& expression, ResultSet& resultSet);
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -77,21 +77,16 @@ public:
         auto cloneOp = make_unique<HashJoinBuild>(keyDataChunkPos, keyVectorPos,
             dataChunkPosToIsFlat, prevOperator->clone(), context, id);
         cloneOp->sharedState = this->sharedState;
-        cloneOp->memManager = this->memManager;
         return cloneOp;
     }
 
     // Finalize the hash table directory
     void finalize() override;
 
-    // The memory manager should be set when processor prepares pipeline tasks
-    inline void setMemoryManager(MemoryManager* memManager) { this->memManager = memManager; }
-
     shared_ptr<HashJoinSharedState> sharedState;
     uint64_t numBytesForFixedTuplePart;
 
 private:
-    MemoryManager* memManager;
     uint64_t keyDataChunkPos;
     uint64_t keyVectorPos;
     vector<bool> dataChunkPosToIsFlat;

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -84,11 +84,12 @@ private:
     shared_ptr<DataChunk> outKeyDataChunk;
     vector<unique_ptr<overflow_value_t[]>> buildSideVectorPtrs;
 
+    void createVectorsFromExistingOnesAndAppend(
+        DataChunk& inDataChunk, DataChunk& outDataChunk, vector<uint64_t>& vectorPositions);
     // This function initializes:
     // 1) the outKeyDataChunk and appended unflat output data chunks, which are used to initialize
     // the output resultSet. 2) buildSideVectorPtrs for build side unflat non-key data chunks.
     void initializeOutResultSetAndVectorPtrs();
-
     // For each probe keyVector[i]=k, this function fills the probedTuples[i] with the pointer from
     // the slot that has hash(k) in directory (collision chain), without checking the actual key
     // value.
@@ -97,7 +98,6 @@ private:
     // probedTuples that points to a collision chain, this function finds all matched tuples along
     // the chain one batch at a time.
     void getNextBatchOfMatchedTuples();
-
     // This function reads matched tuples from ht and populates:
     // 1) outKeyDataChunk with values from probe side key data chunk, build side key data chunk
     // (except for build side keys), and also build side flat non-key data chunks. 2) populates

--- a/src/processor/include/physical_plan/operator/load_csv/load_csv.h
+++ b/src/processor/include/physical_plan/operator/load_csv/load_csv.h
@@ -12,7 +12,7 @@ template<bool IS_OUT_DATACHUNK_FILTERED>
 class LoadCSV : public PhysicalOperator {
 
 public:
-    LoadCSV(string fname, char tokenSeparator, vector<DataType> csvColumnDataTypes,
+    LoadCSV(const string& fname, char tokenSeparator, vector<DataType> csvColumnDataTypes,
         ExecutionContext& context, uint32_t id);
 
     void getNextTuples() override;

--- a/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
@@ -16,8 +16,6 @@ public:
 
     void getNextTuples() override;
 
-    void setMemoryManager(MemoryManager* memMan) { this->memMan = memMan; }
-
     unique_ptr<PhysicalOperator> clone() override;
 
 private:
@@ -38,7 +36,6 @@ private:
     // Each thread uses their vector and handle for uncoordinated extensions.
     vector<shared_ptr<NodeIDVector>> vectors;
     vector<unique_ptr<DataStructureHandle>> handles;
-    MemoryManager* memMan;
 
     struct CurrentOutputPosition {
         bool hasMoreTuplesToProduce;

--- a/src/processor/include/processor.h
+++ b/src/processor/include/processor.h
@@ -26,11 +26,13 @@ private:
     void decomposePlanIntoTasks(PhysicalOperator* op, Task* parentTask, uint64_t numThreads);
     void scheduleTask(Task* task);
 
+public:
+    unique_ptr<MemoryManager> memManager;
+
 private:
     TaskQueue queue;
     bool stopThreads{false};
     vector<thread> threads;
-    unique_ptr<MemoryManager> memManager;
 };
 
 } // namespace processor

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -11,61 +11,68 @@ namespace graphflow {
 namespace processor {
 
 static unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToPhysical(
-    const Expression& expression);
+    MemoryManager& memoryManager, const Expression& expression);
 
 static unique_ptr<ExpressionEvaluator> mapLogicalPropertyOrCSVLineExtractExpressionToPhysical(
-    const Expression& expression, PhysicalOperatorsInfo& physicalOperatorInfo,
-    ResultSet& resultSet);
+    MemoryManager& memoryManager, const Expression& expression,
+    PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet);
 
-unique_ptr<ExpressionEvaluator> ExpressionMapper::mapToPhysical(const Expression& expression,
-    PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet) {
+unique_ptr<ExpressionEvaluator> ExpressionMapper::mapToPhysical(MemoryManager& memoryManager,
+    const Expression& expression, PhysicalOperatorsInfo& physicalOperatorInfo,
+    ResultSet& resultSet) {
     auto expressionType = expression.expressionType;
     if (isExpressionLeafLiteral(expressionType)) {
-        return mapLogicalLiteralExpressionToPhysical(expression);
+        return mapLogicalLiteralExpressionToPhysical(memoryManager, expression);
     } else if (isExpressionLeafVariable(expressionType)) {
         /**
          *Both CSV_LINE_EXTRACT and PropertyExpression are mapped to the same physical expression
          *evaluator, because both of them only grab data from a value vector.
          */
         return mapLogicalPropertyOrCSVLineExtractExpressionToPhysical(
-            expression, physicalOperatorInfo, resultSet);
+            memoryManager, expression, physicalOperatorInfo, resultSet);
     } else if (isExpressionUnary(expressionType)) {
-        auto child = mapToPhysical(expression.getChildExpr(0), physicalOperatorInfo, resultSet);
+        auto child = mapToPhysical(
+            memoryManager, expression.getChildExpr(0), physicalOperatorInfo, resultSet);
         return make_unique<UnaryExpressionEvaluator>(
-            move(child), expressionType, expression.dataType);
+            memoryManager, move(child), expressionType, expression.dataType);
     } else {
         assert(isExpressionBinary(expressionType));
-        auto lExpr = mapToPhysical(expression.getChildExpr(0), physicalOperatorInfo, resultSet);
-        auto rExpr = mapToPhysical(expression.getChildExpr(1), physicalOperatorInfo, resultSet);
+        auto lExpr = mapToPhysical(
+            memoryManager, expression.getChildExpr(0), physicalOperatorInfo, resultSet);
+        auto rExpr = mapToPhysical(
+            memoryManager, expression.getChildExpr(1), physicalOperatorInfo, resultSet);
         return make_unique<BinaryExpressionEvaluator>(
-            move(lExpr), move(rExpr), expressionType, expression.dataType);
+            memoryManager, move(lExpr), move(rExpr), expressionType, expression.dataType);
     }
 }
 
 unique_ptr<ExpressionEvaluator> ExpressionMapper::clone(
-    const ExpressionEvaluator& expression, ResultSet& resultSet) {
+    MemoryManager& memoryManager, const ExpressionEvaluator& expression, ResultSet& resultSet) {
     if (isExpressionLeafLiteral(expression.expressionType)) {
-        return make_unique<ExpressionEvaluator>(expression.result, expression.expressionType);
+        return make_unique<ExpressionEvaluator>(
+            memoryManager, expression.result, expression.expressionType);
     } else if (isExpressionLeafVariable(expression.expressionType)) {
         auto dataChunk = resultSet.dataChunks[expression.dataChunkPos];
         auto valueVector = dataChunk->getValueVector(expression.valueVectorPos);
         return make_unique<ExpressionEvaluator>(
-            valueVector, expression.dataChunkPos, expression.valueVectorPos);
+            memoryManager, valueVector, expression.dataChunkPos, expression.valueVectorPos);
     } else if (expression.getNumChildrenExpr() == 1) { // unary expression.
-        return make_unique<UnaryExpressionEvaluator>(clone(expression.getChildExpr(0), resultSet),
-            expression.expressionType, expression.dataType);
+        return make_unique<UnaryExpressionEvaluator>(memoryManager,
+            clone(memoryManager, expression.getChildExpr(0), resultSet), expression.expressionType,
+            expression.dataType);
     } else { // binary expression.
-        return make_unique<BinaryExpressionEvaluator>(clone(expression.getChildExpr(0), resultSet),
-            clone(expression.getChildExpr(1), resultSet), expression.expressionType,
+        return make_unique<BinaryExpressionEvaluator>(memoryManager,
+            clone(memoryManager, expression.getChildExpr(0), resultSet),
+            clone(memoryManager, expression.getChildExpr(1), resultSet), expression.expressionType,
             expression.dataType);
     }
 }
 
 unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToPhysical(
-    const Expression& expression) {
+    MemoryManager& memoryManager, const Expression& expression) {
     auto& literalExpression = (LiteralExpression&)expression;
     // We create an owner dataChunk which is flat and of size 1 to contain the literal.
-    auto vector = make_shared<ValueVector>(
+    auto vector = make_shared<ValueVector>(&memoryManager,
         literalExpression.storeAsPrimitiveVector ? literalExpression.dataType : UNSTRUCTURED,
         true /* isSingleValue */);
     vector->state = VectorState::getSingleValueDataChunkState();
@@ -112,18 +119,19 @@ unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToPhysical(
             assert(false);
         }
     }
-    return make_unique<ExpressionEvaluator>(vector, expression.expressionType);
+    return make_unique<ExpressionEvaluator>(memoryManager, vector, expression.expressionType);
 }
 
 unique_ptr<ExpressionEvaluator> mapLogicalPropertyOrCSVLineExtractExpressionToPhysical(
-    const Expression& expression, PhysicalOperatorsInfo& physicalOperatorInfo,
-    ResultSet& resultSet) {
+    MemoryManager& memoryManager, const Expression& expression,
+    PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet) {
     const auto& variableName = expression.variableName;
     auto dataChunkPos = physicalOperatorInfo.getDataChunkPos(variableName);
     auto valueVectorPos = physicalOperatorInfo.getValueVectorPos(variableName);
     auto dataChunk = resultSet.dataChunks[dataChunkPos];
     auto valueVector = dataChunk->getValueVector(valueVectorPos);
-    return make_unique<ExpressionEvaluator>(valueVector, dataChunkPos, valueVectorPos);
+    return make_unique<ExpressionEvaluator>(
+        memoryManager, valueVector, dataChunkPos, valueVectorPos);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/filter/filter.cpp
+++ b/src/processor/physical_plan/operator/filter/filter.cpp
@@ -57,7 +57,8 @@ void Filter<IS_AFTER_FLATTEN>::getNextTuples() {
 template<bool IS_AFTER_FLATTEN>
 unique_ptr<PhysicalOperator> Filter<IS_AFTER_FLATTEN>::clone() {
     auto prevOperatorClone = prevOperator->clone();
-    auto rootExprClone = ExpressionMapper::clone(*rootExpr, *prevOperatorClone->getResultSet());
+    auto rootExprClone = ExpressionMapper::clone(
+        *context.memoryManager, *rootExpr, *prevOperatorClone->getResultSet());
     return make_unique<Filter<IS_AFTER_FLATTEN>>(
         move(rootExprClone), dataChunkToSelectPos, move(prevOperatorClone), context, id);
 }

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -27,7 +27,7 @@ HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::HashJoinProbe(uint64_t buildSideKeyDat
 
     decompressedProbeKeyVector = make_shared<NodeIDVector>(0, NodeIDCompressionScheme(8, 8), false);
     decompressedProbeKeyVector->state = probeSideKeyVector->state;
-    hashedProbeKeyVector = make_shared<ValueVector>(INT64);
+    hashedProbeKeyVector = make_shared<ValueVector>(context.memoryManager, INT64);
     hashedProbeKeyVector->state = probeSideKeyVector->state;
 
     probeState = make_unique<ProbeState>(DEFAULT_VECTOR_CAPACITY);
@@ -35,7 +35,8 @@ HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::HashJoinProbe(uint64_t buildSideKeyDat
     initializeOutResultSetAndVectorPtrs();
 }
 
-static void createVectorsFromExistingOnesAndAppend(
+template<bool IS_OUT_DATACHUNK_FILTERED>
+void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::createVectorsFromExistingOnesAndAppend(
     DataChunk& inDataChunk, DataChunk& outDataChunk, vector<uint64_t>& vectorPositions) {
     for (auto pos : vectorPositions) {
         auto inVector = inDataChunk.valueVectors[pos];
@@ -45,7 +46,7 @@ static void createVectorsFromExistingOnesAndAppend(
             outVector = make_shared<NodeIDVector>(nodeIDVector->representation.commonLabel,
                 nodeIDVector->representation.compressionScheme, false);
         } else {
-            outVector = make_shared<ValueVector>(inVector->dataType);
+            outVector = make_shared<ValueVector>(context.memoryManager, inVector->dataType);
         }
         outDataChunk.append(outVector);
     }

--- a/src/processor/physical_plan/operator/load_csv/load_csv.cpp
+++ b/src/processor/physical_plan/operator/load_csv/load_csv.cpp
@@ -10,7 +10,7 @@ namespace graphflow {
 namespace processor {
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
-LoadCSV<IS_OUT_DATACHUNK_FILTERED>::LoadCSV(string fname, char tokenSeparator,
+LoadCSV<IS_OUT_DATACHUNK_FILTERED>::LoadCSV(const string& fname, char tokenSeparator,
     vector<DataType> csvColumnDataTypes, ExecutionContext& context, uint32_t id)
     : PhysicalOperator{LOAD_CSV, context, id}, fname{fname}, tokenSeparator{tokenSeparator},
       reader{fname, tokenSeparator}, csvColumnDataTypes{csvColumnDataTypes} {
@@ -18,7 +18,8 @@ LoadCSV<IS_OUT_DATACHUNK_FILTERED>::LoadCSV(string fname, char tokenSeparator,
     outDataChunk =
         make_shared<DataChunk>(!IS_OUT_DATACHUNK_FILTERED /* initializeSelectedValuesPos */);
     for (auto tokenIdx = 0u; tokenIdx < csvColumnDataTypes.size(); tokenIdx++) {
-        outValueVectors.emplace_back(new ValueVector(csvColumnDataTypes[tokenIdx]));
+        outValueVectors.emplace_back(
+            new ValueVector(context.memoryManager, csvColumnDataTypes[tokenIdx]));
     }
     for (auto& outValueVector : outValueVectors) {
         outDataChunk->append(outValueVector);

--- a/src/processor/physical_plan/operator/projection/projection.cpp
+++ b/src/processor/physical_plan/operator/projection/projection.cpp
@@ -53,7 +53,8 @@ unique_ptr<PhysicalOperator> Projection::clone() {
     auto rootExpressionsCloned = make_unique<vector<unique_ptr<ExpressionEvaluator>>>();
     for (auto& expr : *expressions) {
         (*rootExpressionsCloned)
-            .push_back(ExpressionMapper::clone(*expr, *prevOperatorClone->getResultSet()));
+            .push_back(ExpressionMapper::clone(
+                *context.memoryManager, *expr, *prevOperatorClone->getResultSet()));
     }
     return make_unique<Projection>(move(rootExpressionsCloned), expressionPosToDataChunkPos,
         discardedDataChunkPos, move(prevOperatorClone), context, id);

--- a/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
@@ -205,7 +205,7 @@ FrontierSet* FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::createInitialFrontierSet
         return nullptr;
     }
     auto frontier = new FrontierSet();
-    frontier->setMemoryManager(memMan);
+    frontier->setMemoryManager(context.memoryManager);
     frontier->initHashTable(numSlots);
     do {
         lists->readValues(nodeOffset, vectors[0], vectors[0]->state->size, handles[0], MAX_TO_READ,
@@ -230,7 +230,7 @@ FrontierSet* FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::makeFrontierSet(uint64_t
         return nullptr;
     }
     auto frontier = new FrontierSet();
-    frontier->setMemoryManager(memMan);
+    frontier->setMemoryManager(context.memoryManager);
     frontier->initHashTable(numSlots < NUM_SLOTS_BAG ? NUM_SLOTS_BAG : numSlots);
     return frontier;
 }
@@ -238,7 +238,7 @@ FrontierSet* FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::makeFrontierSet(uint64_t
 template<bool IS_OUT_DATACHUNK_FILTERED>
 FrontierBag* FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::createFrontierBag() {
     auto frontierBag = new FrontierBag();
-    frontierBag->setMemoryManager(memMan);
+    frontierBag->setMemoryManager(context.memoryManager);
     frontierBag->initHashTable();
     return frontierBag;
 }
@@ -248,7 +248,6 @@ unique_ptr<PhysicalOperator> FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::clone() 
     auto cloneOp =
         make_unique<FrontierExtend<IS_OUT_DATACHUNK_FILTERED>>(inDataChunkPos, inValueVectorPos,
             (AdjLists*)lists, startLayer, endLayer, prevOperator->clone(), context, id);
-    cloneOp->memMan = this->memMan;
     return cloneOp;
 }
 

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -8,7 +8,7 @@ ReadRelPropertyList::ReadRelPropertyList(uint64_t inDataChunkPos, uint64_t inVal
     ExecutionContext& context, uint32_t id)
     : ReadList{inDataChunkPos, inValueVectorPos, lists, move(prevOperator), context, id},
       outDataChunkPos(outDataChunkPos) {
-    outValueVector = make_shared<ValueVector>(lists->getDataType());
+    outValueVector = make_shared<ValueVector>(context.memoryManager, lists->getDataType());
     outDataChunk = resultSet->dataChunks[outDataChunkPos];
     handle->setListSyncState(resultSet->getListSyncState(outDataChunkPos));
     outDataChunk->append(outValueVector);

--- a/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
@@ -9,7 +9,7 @@ ScanStructuredProperty::ScanStructuredProperty(uint64_t dataChunkPos, uint64_t v
     BaseColumn* column, unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context,
     uint32_t id)
     : ScanColumn{dataChunkPos, valueVectorPos, column, move(prevOperator), context, id} {
-    outValueVector = make_shared<ValueVector>(column->getDataType());
+    outValueVector = make_shared<ValueVector>(context.memoryManager, column->getDataType());
     inDataChunk->append(outValueVector);
 }
 

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -14,7 +14,7 @@ ScanUnstructuredProperty::ScanUnstructuredProperty(uint64_t dataChunkPos, uint64
     inDataChunk = resultSet->dataChunks[dataChunkPos];
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
     handle = make_unique<DataStructureHandle>();
-    outValueVector = make_shared<ValueVector>(lists->getDataType());
+    outValueVector = make_shared<ValueVector>(context.memoryManager, lists->getDataType());
     inDataChunk->append(outValueVector);
 }
 

--- a/src/processor/physical_plan/plan_mapper.cpp
+++ b/src/processor/physical_plan/plan_mapper.cpp
@@ -161,8 +161,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFilterToPhysical(
         logicalRootExpr, move(prevOperator), physicalOperatorInfo, context);
     auto dataChunkToSelectPos =
         getDependentUnflatDataChunkPos(logicalRootExpr, physicalOperatorInfo);
-    auto physicalRootExpr = ExpressionMapper::mapToPhysical(
-        logicalRootExpr, physicalOperatorInfo, *prevOperator->getResultSet());
+    auto physicalRootExpr = ExpressionMapper::mapToPhysical(*context.memoryManager, logicalRootExpr,
+        physicalOperatorInfo, *prevOperator->getResultSet());
     if (prevOperator->operatorType == FLATTEN) {
         return make_unique<Filter<true /* isAfterFlatten */>>(move(physicalRootExpr),
             dataChunkToSelectPos, move(prevOperator), context, physicalOperatorID++);
@@ -188,7 +188,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalProjectionToPhysical(
     for (const auto& logicalRootExpr : logicalProjection.expressionsToProject) {
         prevOperator = appendFlattenOperatorsIfNecessary(
             *logicalRootExpr, move(prevOperator), physicalOperatorInfo, context);
-        expressionEvaluators->push_back(ExpressionMapper::mapToPhysical(
+        expressionEvaluators->push_back(ExpressionMapper::mapToPhysical(*context.memoryManager,
             *logicalRootExpr, physicalOperatorInfo, *prevOperator->getResultSet()));
     }
 

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -62,13 +62,11 @@ void QueryProcessor::decomposePlanIntoTasks(
             auto hashJoinProbe = reinterpret_cast<HashJoinProbe<true>*>(op);
             auto hashJoinBuild =
                 reinterpret_cast<HashJoinBuild*>(hashJoinProbe->buildSidePrevOp.get());
-            hashJoinBuild->setMemoryManager(memManager.get());
             decomposePlanIntoTasks(hashJoinBuild, parentTask, numThreads);
         } else {
             auto hashJoinProbe = reinterpret_cast<HashJoinProbe<false>*>(op);
             auto hashJoinBuild =
                 reinterpret_cast<HashJoinBuild*>(hashJoinProbe->buildSidePrevOp.get());
-            hashJoinBuild->setMemoryManager(memManager.get());
             decomposePlanIntoTasks(hashJoinBuild, parentTask, numThreads);
         }
         decomposePlanIntoTasks(op->prevOperator.get(), parentTask, numThreads);
@@ -80,12 +78,6 @@ void QueryProcessor::decomposePlanIntoTasks(
         decomposePlanIntoTasks(op->prevOperator.get(), childTask.get(), numThreads);
         childTask->parent = parentTask;
         parentTask->children.push_back(move(childTask));
-        break;
-    }
-    case FRONTIER_EXTEND: {
-        auto frontierExtend = reinterpret_cast<FrontierExtend<true>*>(op);
-        frontierExtend->setMemoryManager(memManager.get());
-        decomposePlanIntoTasks(op->prevOperator.get(), parentTask, numThreads);
         break;
     }
     case SCAN:

--- a/src/storage/data_structure/lists/lists.cpp
+++ b/src/storage/data_structure/lists/lists.cpp
@@ -157,7 +157,7 @@ void Lists<UNSTRUCTURED>::readUnstrPropertyKeyIdxAndDatatype(uint8_t* propertyKe
     LogicalToPhysicalPageIdxMapper& mapper, BufferManagerMetrics& metrics) {
     auto frame = bufferManager.get(fileHandle, physicalPageIdx, metrics);
     const uint8_t* readFrom;
-    if (pageCursor.offset + UNSTR_PROP_HEADER_LEN < PAGE_SIZE) {
+    if ((uint64_t)(pageCursor.offset + UNSTR_PROP_HEADER_LEN) < PAGE_SIZE) {
         readFrom = frame + pageCursor.offset;
         pageCursor.offset += UNSTR_PROP_HEADER_LEN;
     } else {

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -52,7 +52,7 @@ void HashIndex::initialize(const string& indexBasePath, uint64_t indexId) {
 // For now, we don't support re-write of keys. Existing keys will not be inserted.
 // Return: true, insertion succeeds. false, insertion failed due to that the key already exists.
 vector<bool> HashIndex::insert(ValueVector& keys, ValueVector& values) {
-    auto hashes = make_shared<ValueVector>(INT64);
+    auto hashes = make_shared<ValueVector>(&memoryManager, INT64);
     hashes->state = keys.state;
     VectorHashOperations::Hash(keys, *hashes);
     auto keyNotExists = notExists(keys, *hashes);
@@ -65,7 +65,7 @@ vector<bool> HashIndex::insert(ValueVector& keys, ValueVector& values) {
 void HashIndex::lookup(ValueVector& keys, ValueVector& result, BufferManagerMetrics& metrics) {
     uint8_t* keyData = keys.values;
     auto resultData = (uint64_t*)result.values;
-    auto hashes = make_shared<ValueVector>(INT64);
+    auto hashes = make_shared<ValueVector>(&memoryManager, INT64);
     hashes->state = keys.state;
     VectorHashOperations::Hash(keys, *hashes);
     auto offset = keys.state->isFlat() ? keys.state->getCurrSelectedValuesPos() : 0;

--- a/src/storage/index/overflow_pages_manager.cpp
+++ b/src/storage/index/overflow_pages_manager.cpp
@@ -104,7 +104,7 @@ void OverflowPagesManager::serOverflowPagesAllocationBitsets() {
 
 void OverflowPagesManager::deSerOverflowPagesAllocationBitsets() {
     auto numPageGroups = fileHandle->numPages / NUM_PAGES_PER_PAGE_GROUP;
-    for (auto pageGroupId = 0; pageGroupId < numPageGroups; pageGroupId++) {
+    for (auto pageGroupId = 0ul; pageGroupId < numPageGroups; pageGroupId++) {
         bitset<NUM_PAGES_PER_PAGE_GROUP> pageGroupBitset;
         uint8_t* block = getMemoryBlock(pageGroupId * NUM_PAGES_PER_PAGE_GROUP);
         for (auto pageInGroupId = 0ul; pageInGroupId < NUM_PAGES_PER_PAGE_GROUP; pageInGroupId++) {

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -9,16 +9,17 @@ using namespace std;
 TEST(VectorArithTests, test) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = 100;
+    auto memoryManager = make_unique<MemoryManager>();
 
-    auto lVector = make_shared<ValueVector>(INT32);
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
     dataChunk->append(lVector);
     auto lData = (int32_t*)lVector->values;
 
-    auto rVector = make_shared<ValueVector>(INT32);
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), INT32);
     dataChunk->append(rVector);
     auto rData = (int32_t*)rVector->values;
 
-    auto result = make_shared<ValueVector>(INT32);
+    auto result = make_shared<ValueVector>(memoryManager.get(), INT32);
     dataChunk->append(result);
     auto resultData = (int32_t*)result->values;
 
@@ -59,7 +60,7 @@ TEST(VectorArithTests, test) {
         ASSERT_EQ(resultData[i], i % (110 - i));
     }
 
-    result = make_shared<ValueVector>(DOUBLE);
+    result = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
     dataChunk->append(result);
     auto resultDataAsDoubleArr = (double_t*)result->values;
     VectorArithmeticOperations::Power(*lVector, *rVector, *result);

--- a/test/common/vector/operations/vector_boolean_operations_test.cpp
+++ b/test/common/vector/operations/vector_boolean_operations_test.cpp
@@ -10,16 +10,17 @@ TEST(VectorBoolTests, test) {
     auto VECTOR_SIZE = 4;
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = VECTOR_SIZE;
+    auto memoryManager = make_unique<MemoryManager>();
 
-    auto lVector = make_shared<ValueVector>(BOOL);
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->append(lVector);
     auto lData = (uint8_t*)lVector->values;
 
-    auto rVector = make_shared<ValueVector>(BOOL);
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->append(rVector);
     auto rData = (uint8_t*)rVector->values;
 
-    auto result = make_shared<ValueVector>(BOOL);
+    auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->append(result);
     auto resultData = (uint8_t*)result->values;
 

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -12,16 +12,17 @@ TEST(VectorCmpTests, cmpInt) {
 
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = numTuples;
+    auto memoryManager = make_unique<MemoryManager>();
 
-    auto lVector = make_shared<ValueVector>(INT32);
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
     dataChunk->append(lVector);
     auto lData = (int32_t*)lVector->values;
 
-    auto rVector = make_shared<ValueVector>(INT32);
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), INT32);
     dataChunk->append(rVector);
     auto rData = (int32_t*)rVector->values;
 
-    auto result = make_shared<ValueVector>(BOOL);
+    auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->append(result);
     auto resultData = result->values;
 
@@ -68,26 +69,29 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = numTuples;
     dataChunk->state->currPos = 0;
+    auto memoryManager = make_unique<MemoryManager>();
 
-    auto lVector = make_shared<ValueVector>(STRING);
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->append(lVector);
     auto lData = ((gf_string_t*)lVector->values);
 
-    auto rVector = make_shared<ValueVector>(STRING);
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->append(rVector);
     auto rData = ((gf_string_t*)rVector->values);
 
-    auto result = make_shared<ValueVector>(BOOL);
+    auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->append(result);
     auto resultData = result->values;
 
-    char* value = "abcdefgh";
+    string value = "abcdefgh";
     lData[0].len = 8;
     rData[0].len = 8;
-    memcpy(lData[0].prefix, value, gf_string_t::PREFIX_LENGTH);
-    memcpy(rData[0].prefix, value, gf_string_t::PREFIX_LENGTH);
-    memcpy(lData[0].data, value + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
-    memcpy(rData[0].data, value + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
+    memcpy(lData[0].prefix, value.data(), gf_string_t::PREFIX_LENGTH);
+    memcpy(rData[0].prefix, value.data(), gf_string_t::PREFIX_LENGTH);
+    memcpy(
+        lData[0].data, value.data() + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
+    memcpy(
+        rData[0].data, value.data() + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
 
     VectorComparisonOperations::Equals(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], TRUE);
@@ -131,30 +135,31 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
     auto dataChunk = make_shared<DataChunk>();
     dataChunk->state->size = VECTOR_SIZE;
     dataChunk->state->currPos = 0;
+    auto memoryManager = make_unique<MemoryManager>();
 
-    auto lVector = make_shared<ValueVector>(STRING);
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->append(lVector);
     auto lData = ((gf_string_t*)lVector->values);
 
-    auto rVector = make_shared<ValueVector>(STRING);
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->append(rVector);
     auto rData = ((gf_string_t*)rVector->values);
 
-    auto result = make_shared<ValueVector>(BOOL);
+    auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->append(result);
     auto resultData = result->values;
 
-    char* value = "abcdefghijklmnopqrstuvwxy"; // 25.
+    string value = "abcdefghijklmnopqrstuvwxy"; // 25.
     lData[0].len = 25;
     rData[0].len = 25;
-    memcpy(lData[0].prefix, value, gf_string_t::PREFIX_LENGTH);
-    memcpy(rData[0].prefix, value, gf_string_t::PREFIX_LENGTH);
+    memcpy(lData[0].prefix, value.data(), gf_string_t::PREFIX_LENGTH);
+    memcpy(rData[0].prefix, value.data(), gf_string_t::PREFIX_LENGTH);
     auto overflowLen = 25;
     char lOverflow[overflowLen];
-    memcpy(lOverflow, value, overflowLen);
+    memcpy(lOverflow, value.data(), overflowLen);
     lData->overflowPtr = reinterpret_cast<uintptr_t>(lOverflow);
     char rOverflow[overflowLen];
-    memcpy(rOverflow, value, overflowLen);
+    memcpy(rOverflow, value.data(), overflowLen);
     rData->overflowPtr = reinterpret_cast<uintptr_t>(rOverflow);
 
     VectorComparisonOperations::Equals(*lVector, *rVector, *result);

--- a/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
+++ b/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
@@ -17,7 +17,8 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
     dataChunk->append(nodeVector);
     auto nodeData = (uint64_t*)nodeVector->values;
 
-    auto result = make_shared<ValueVector>(INT64);
+    auto memoryManager = make_unique<MemoryManager>();
+    auto result = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(result);
     auto resultData = (uint64_t*)result->values;
 
@@ -50,7 +51,8 @@ TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
     nodeVector->setStartOffset(10);
     dataChunk->append(nodeVector);
 
-    auto result = make_shared<ValueVector>(INT64);
+    auto memoryManager = make_unique<MemoryManager>();
+    auto result = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(result);
     auto resultData = (uint64_t*)result->values;
 

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -16,7 +16,8 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
     auto addLogicalOperator = make_unique<Expression>(
         ExpressionType::ADD, DataType::INT32, move(propertyExpression), move(literalExpression));
 
-    auto valueVector = make_shared<ValueVector>(INT32);
+    auto memoryManager = make_unique<MemoryManager>();
+    auto valueVector = make_shared<ValueVector>(memoryManager.get(), INT32);
     auto values = (int32_t*)valueVector->values;
     for (auto i = 0u; i < 100; i++) {
         values[i] = i;
@@ -30,8 +31,8 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
     physicalOperatorInfo.appendAsNewDataChunk("a.prop");
     resultSet.append(dataChunk);
 
-    auto rootExpressionEvaluator =
-        ExpressionMapper::mapToPhysical(*addLogicalOperator, physicalOperatorInfo, resultSet);
+    auto rootExpressionEvaluator = ExpressionMapper::mapToPhysical(
+        *memoryManager, *addLogicalOperator, physicalOperatorInfo, resultSet);
     rootExpressionEvaluator->evaluate();
 
     auto results = (int32_t*)rootExpressionEvaluator->result->values;
@@ -46,7 +47,8 @@ TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
     auto negateLogicalOperator =
         make_unique<Expression>(ExpressionType::NEGATE, DataType::INT32, move(propertyExpression));
 
-    auto valueVector = make_shared<ValueVector>(INT32);
+    auto memoryManager = make_unique<MemoryManager>();
+    auto valueVector = make_shared<ValueVector>(memoryManager.get(), INT32);
     auto values = (int32_t*)valueVector->values;
     for (auto i = 0u; i < 100; i++) {
         int32_t value = i;
@@ -65,8 +67,8 @@ TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
     physicalOperatorInfo.appendAsNewDataChunk("a.prop");
     resultSet.append(dataChunk);
 
-    auto rootExpressionEvaluator =
-        ExpressionMapper::mapToPhysical(*negateLogicalOperator, physicalOperatorInfo, resultSet);
+    auto rootExpressionEvaluator = ExpressionMapper::mapToPhysical(
+        *memoryManager, *negateLogicalOperator, physicalOperatorInfo, resultSet);
     rootExpressionEvaluator->evaluate();
 
     auto results = (int32_t*)rootExpressionEvaluator->result->values;

--- a/test/processor/physical_plan/operator/scan/scan_test.cpp
+++ b/test/processor/physical_plan/operator/scan/scan_test.cpp
@@ -7,7 +7,8 @@ using namespace graphflow::processor;
 TEST(ScanTests, ScanTest) {
     auto morsel = make_shared<MorselsDesc>(0, 1025013 /*numNodes*/);
     auto profiler = make_unique<Profiler>();
-    auto executionContext = ExecutionContext(*profiler, nullptr);
+    auto memoryManager = make_unique<MemoryManager>();
+    auto executionContext = ExecutionContext(*profiler, nullptr, memoryManager.get());
     auto scan = make_unique<ScanNodeID<true>>(morsel, executionContext, 0);
     auto resultSet = scan->getResultSet();
     auto dataChunk = resultSet->dataChunks[0];

--- a/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
+++ b/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
@@ -13,13 +13,14 @@ public:
         auto dataChunkB = make_shared<DataChunk>();
         auto dataChunkC = make_shared<DataChunk>();
 
+        auto memoryManager = make_unique<MemoryManager>();
         NodeIDCompressionScheme compressionScheme;
         auto vectorA1 = make_shared<NodeIDVector>(18, compressionScheme, false);
-        auto vectorA2 = make_shared<ValueVector>(INT32);
+        auto vectorA2 = make_shared<ValueVector>(memoryManager.get(), INT32);
         auto vectorB1 = make_shared<NodeIDVector>(28, compressionScheme, false);
-        auto vectorB2 = make_shared<ValueVector>(DOUBLE);
+        auto vectorB2 = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
         auto vectorC1 = make_shared<NodeIDVector>(38, compressionScheme, false);
-        auto vectorC2 = make_shared<ValueVector>(BOOL);
+        auto vectorC2 = make_shared<ValueVector>(memoryManager.get(), BOOL);
         auto vectorA1Data = (uint64_t*)vectorA1->values;
         auto vectorA2Data = (uint32_t*)vectorA2->values;
         auto vectorB1Data = (uint64_t*)vectorB1->values;

--- a/test/processor/processor_test.cpp
+++ b/test/processor/processor_test.cpp
@@ -25,7 +25,8 @@ TEST(ProcessorTests, MultiThreadedScanTest) {
     unique_ptr<Graph> graph = make_unique<GraphStub>();
     auto morsel = make_shared<MorselsDesc>(0, 1025013 /*numNodes*/);
     auto profiler = make_unique<Profiler>();
-    auto executionContext = ExecutionContext(*profiler, nullptr);
+    auto memoryManager = make_unique<MemoryManager>();
+    auto executionContext = ExecutionContext(*profiler, nullptr, memoryManager.get());
     auto plan = make_unique<PhysicalPlan>(
         make_unique<ResultCollector>(make_unique<ScanNodeID<true>>(morsel, executionContext, 0),
             RESULT_COLLECTOR, executionContext, 1));


### PR DESCRIPTION
This PR makes following changes:
1. Adds `MemoryManager` to the `StringBuffer`. StringBuffer now makes use of MemoryManager to allocate new memory blocks.
2. Adds a new field, MemoryManager, into the `ExeuctionContext`, which is set from our `QueryProcessor` in the `system.cpp`, so all physical operators access their memory manager through the execution context. (HashJoinBuild, HashJoinProbe, and FrontierExtend don't need to set their own memory manager object anymore.)
3. Adds string buffer resetting in the `ResultCollector`. ResultCollector appends all string buffers in result value vectors, and creates new ones for each string value vector.

Two minor changes:
1. Change `string fname` to `const string& fname` in `LoadCSV`.
2. Fix the warning on comparison of int and usigned int in `Lists` and `'OverflowPagesManager`.
3. Fix the warning `-Wwrite-strings` in `vector_comparison_operations_test.cpp`.