### PR TITLE
fixes on expression evaluation of unstructured values

### DIFF
--- a/dataset/tinysnb/vPerson.csv
+++ b/dataset/tinysnb/vPerson.csv
@@ -1,6 +1,6 @@
 id:NODE,fName:STRING,gender:INT32,isStudent:BOOLEAN,isWorker:BOOLEAN,age:INT32,eyeSight:DOUBLE
 0,Alice,1,true,false,35,5.0
-2,Bob,2,true,false,30,5.1,unstrProp:INT32:47
+2,Bob,2,true,false,30,5.1,unstrProp:INT32:47,unstrProp2:INT32:20
 3,Carol,1,false,true,45,5.0,unstrProp:INT32:52
 5,Dan,2,false,true,20,4.8
 7,Elizabeth,1,false,true,20,4.7,unstrProp:DOUBLE:68

--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -4,14 +4,14 @@ namespace graphflow {
 namespace binder {
 
 Expression::Expression(ExpressionType expressionType, DataType dataType,
-    shared_ptr<Expression> left, shared_ptr<Expression> right)
+    const shared_ptr<Expression>& left, const shared_ptr<Expression>& right)
     : Expression(expressionType, dataType) {
     childrenExpr.push_back(left);
     childrenExpr.push_back(right);
 }
 
 Expression::Expression(
-    ExpressionType expressionType, DataType dataType, shared_ptr<Expression> child)
+    ExpressionType expressionType, DataType dataType, const shared_ptr<Expression>& child)
     : Expression(expressionType, dataType) {
     childrenExpr.push_back(child);
 }

--- a/src/binder/include/expression/expression.h
+++ b/src/binder/include/expression/expression.h
@@ -21,11 +21,12 @@ class Expression {
 
 public:
     // creates a non-leaf logical binary expression.
-    Expression(ExpressionType expressionType, DataType dataType, shared_ptr<Expression> left,
-        shared_ptr<Expression> right);
+    Expression(ExpressionType expressionType, DataType dataType, const shared_ptr<Expression>& left,
+        const shared_ptr<Expression>& right);
 
     // creates a non-leaf logical unary expression.
-    Expression(ExpressionType expressionType, DataType dataType, shared_ptr<Expression> child);
+    Expression(
+        ExpressionType expressionType, DataType dataType, const shared_ptr<Expression>& child);
 
     Expression(ExpressionType expressionType, DataType dataType, const string& variableName);
 

--- a/src/common/gf_string.cpp
+++ b/src/common/gf_string.cpp
@@ -22,6 +22,7 @@ void gf_string_t::set(const string& str) {
 
 void gf_string_t::set(const char* value, uint64_t length) {
     auto prefixLen = length < gf_string_t::PREFIX_LENGTH ? length : gf_string_t::PREFIX_LENGTH;
+    this->len = length;
     memcpy(prefix, value, prefixLen);
     if (length > gf_string_t::PREFIX_LENGTH) {
         if (length <= gf_string_t::SHORT_STR_LENGTH) {

--- a/src/common/include/operations/arithmetic_operations.h
+++ b/src/common/include/operations/arithmetic_operations.h
@@ -129,6 +129,7 @@ struct ArithmeticOnValues {
                 throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `INT32` and `" +
                                        dataTypeToString(right.dataType) + "`");
             }
+            break;
         case DOUBLE:
             switch (left.dataType) {
             case INT32:
@@ -162,13 +163,8 @@ static const char negateStr[] = "negate";
 
 template<>
 inline void Add::operation(Value& left, Value& right, Value& result) {
-    if (left.dataType == STRING || right.dataType == STRING) {
-        if (left.dataType != STRING) {
-            left.castToString();
-        }
-        if (right.dataType != STRING) {
-            right.castToString();
-        }
+    if (left.dataType == STRING) {
+        assert(right.dataType == STRING);
         result.dataType = STRING;
         Add::operation(left.val.strVal, right.val.strVal, result.val.strVal);
         return;

--- a/src/common/include/value.h
+++ b/src/common/include/value.h
@@ -27,9 +27,6 @@ public:
 
     Value& operator=(const Value& other);
 
-    // todo: move this to the StringVector level
-    void castToString();
-
     string toString() const;
 
 public:

--- a/src/common/include/vector/string_buffer.h
+++ b/src/common/include/vector/string_buffer.h
@@ -30,7 +30,7 @@ public:
         : memoryManager{memoryManager}, currentBlock{nullptr} {};
 
 public:
-    gf_string_t allocateLargeString(uint64_t len);
+    void allocateLargeString(gf_string_t& result, uint64_t len);
     void appendBuffer(StringBuffer& other);
 
 private:

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -29,7 +29,7 @@ public:
 
     void addString(uint64_t pos, string value) const;
     void addString(uint64_t pos, char* value, uint64_t len) const;
-    void allocateStringOverflowSpace(uint64_t pos, uint64_t len) const;
+    void allocateStringOverflowSpace(gf_string_t& gfString, uint64_t len) const;
 
     inline void reset() { values = bufferValues.get(); }
 

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -29,23 +29,6 @@ Value& Value::operator=(const Value& other) {
     return *this;
 }
 
-void Value::castToString() {
-    switch (dataType) {
-    case BOOL: {
-        val.strVal.set(to_string(val.booleanVal));
-    } break;
-    case INT32: {
-        val.strVal.set(to_string(val.int32Val));
-    } break;
-    case DOUBLE: {
-        val.strVal.set(to_string(val.doubleVal));
-    } break;
-    default:
-        assert(false);
-    }
-    dataType = STRING;
-}
-
 string Value::toString() const {
     switch (dataType) {
     case BOOL:

--- a/src/common/vector/operations/vector_arithmetic_operations.cpp
+++ b/src/common/vector/operations/vector_arithmetic_operations.cpp
@@ -20,15 +20,18 @@ public:
             case INT32:
                 if (std::is_same<OP, operation::Power>::value) {
                     BinaryOperationExecutor::executeArithmeticOps<int32_t, int32_t, double_t, OP,
-                        false /* ALLOCATE_STRING_OVERFLOW */>(left, right, result);
+                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                        left, right, result);
                 } else {
                     BinaryOperationExecutor::executeArithmeticOps<int32_t, int32_t, int32_t, OP,
-                        false /* ALLOCATE_STRING_OVERFLOW */>(left, right, result);
+                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                        left, right, result);
                 }
                 break;
             case DOUBLE:
                 BinaryOperationExecutor::executeArithmeticOps<int32_t, double_t, double_t, OP,
-                    false /* ALLOCATE_STRING_OVERFLOW */>(left, right, result);
+                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    left, right, result);
                 break;
             default:
                 assert(false);
@@ -38,11 +41,13 @@ public:
             switch (right.dataType) {
             case INT32:
                 BinaryOperationExecutor::executeArithmeticOps<double_t, int32_t, double_t, OP,
-                    false /* ALLOCATE_STRING_OVERFLOW */>(left, right, result);
+                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    left, right, result);
                 break;
             case DOUBLE:
                 BinaryOperationExecutor::executeArithmeticOps<double_t, double_t, double_t, OP,
-                    false /* ALLOCATE_STRING_OVERFLOW */>(left, right, result);
+                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    left, right, result);
                 break;
             default:
                 assert(false);
@@ -51,7 +56,9 @@ public:
         case UNSTRUCTURED:
             assert(right.dataType == UNSTRUCTURED);
             BinaryOperationExecutor::executeArithmeticOps<Value, Value, Value, OP,
-                false /* ALLOCATE_STRING_OVERFLOW */>(left, right, result);
+                false
+                /* IS_STRUCTURED_STRING */,
+                true /* IS_UNSTRUCTURED */>(left, right, result);
             break;
         default:
             assert(false);
@@ -80,7 +87,8 @@ void VectorArithmeticOperations::Add(ValueVector& left, ValueVector& right, Valu
     if (left.dataType == STRING) {
         assert(right.dataType == STRING);
         BinaryOperationExecutor::executeArithmeticOps<gf_string_t, gf_string_t, gf_string_t,
-            operation::Add, true /* ALLOCATE_STRING_OVERFLOW */>(left, right, result);
+            operation::Add, true /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+            left, right, result);
     } else {
         ArithmeticOperationExecutor::execute<operation::Add>(left, right, result);
     }

--- a/src/common/vector/string_buffer.cpp
+++ b/src/common/vector/string_buffer.cpp
@@ -5,7 +5,7 @@
 namespace graphflow {
 namespace common {
 
-gf_string_t StringBuffer::allocateLargeString(uint64_t len) {
+void StringBuffer::allocateLargeString(gf_string_t& result, uint64_t len) {
     assert(len > gf_string_t::SHORT_STR_LENGTH);
     if (currentBlock == nullptr || (currentBlock->currentOffset + len) > currentBlock->size) {
         auto blockSize = max(len, MIN_BUFFER_BLOCK_SIZE);
@@ -14,12 +14,9 @@ gf_string_t StringBuffer::allocateLargeString(uint64_t len) {
         currentBlock = newBlock.get();
         blocks.push_back(move(newBlock));
     }
-    gf_string_t result;
-    result.len = len;
     result.overflowPtr =
         reinterpret_cast<uint64_t>(currentBlock->data + currentBlock->currentOffset);
     currentBlock->currentOffset += len;
-    return result;
 }
 
 void StringBuffer::appendBuffer(StringBuffer& other) {

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -54,20 +54,19 @@ shared_ptr<ValueVector> ValueVector::clone() {
     return newVector;
 }
 
-void ValueVector::allocateStringOverflowSpace(uint64_t pos, uint64_t len) const {
-    assert(dataType == STRING);
-    auto vectorData = (gf_string_t*)values;
-    vectorData[pos].len = len;
+void ValueVector::allocateStringOverflowSpace(gf_string_t& result, uint64_t len) const {
+    assert(dataType == STRING || dataType == UNSTRUCTURED);
     if (len > gf_string_t::SHORT_STR_LENGTH) {
-        vectorData[pos] = stringBuffer->allocateLargeString(len);
+        stringBuffer->allocateLargeString(result, len);
     }
 }
 
 void ValueVector::addString(uint64_t pos, char* value, uint64_t len) const {
     assert(dataType == STRING);
     auto vectorData = (gf_string_t*)values;
-    allocateStringOverflowSpace(pos, len);
-    vectorData[pos].set(value, len);
+    auto& result = vectorData[pos];
+    allocateStringOverflowSpace(result, len);
+    result.set(value, len);
 }
 
 void ValueVector::addString(uint64_t pos, string value) const {

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -90,10 +90,8 @@ unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToPhysical(
             val.val.booleanVal = literalExpression.literal.val.booleanVal;
         } break;
         case STRING: {
-            if (literalExpression.literal.strVal.length() > gf_string_t::SHORT_STR_LENGTH) {
-                val.val.strVal = vector->stringBuffer->allocateLargeString(
-                    literalExpression.literal.strVal.length());
-            }
+            vector->allocateStringOverflowSpace(
+                val.val.strVal, literalExpression.literal.strVal.length());
             val.val.strVal.set(literalExpression.literal.strVal);
         } break;
         default:

--- a/test/runner/queries/filtered/unstructured_properties.test
+++ b/test/runner/queries/filtered/unstructured_properties.test
@@ -11,3 +11,23 @@
 -NAME PersonUnstrFilteredTest3
 -QUERY MATCH (a:person) WHERE a.unstrProp = 52 RETURN COUNT(*)
 ---- 1
+
+-NAME PersonUnstrFilteredTest4
+-QUERY MATCH (a:person) WHERE 10 + a.unstrProp = 57 RETURN COUNT(*)
+---- 1
+
+-NAME PersonUnstrFilteredTest5
+-QUERY MATCH (a:person) WHERE a.unstrProp + a.unstrProp2 = 67 RETURN COUNT(*)
+---- 1
+
+-NAME PersonUnstrFilteredTest6
+-QUERY MATCH (a:person) WHERE a.unstrProp - 10 > a.unstrProp2 RETURN COUNT(*)
+---- 1
+
+-NAME PersonUnstrFilteredTest7
+-QUERY MATCH (a:person) WHERE 'abc ' + a.unstrProp = 'abc 52' RETURN COUNT(*)
+---- 1
+
+-NAME PersonUnstrFilteredTest8
+-QUERY MATCH (a:person) WHERE a.unstrProp2 + ' abcdefghijklm' = '20 abcdefghijklm' RETURN COUNT(*)
+---- 1


### PR DESCRIPTION
This PR makes following changes to the expression evaluation:
- expression involving structured and unstructured values: structured values will be casted to unstructured ones.
- fix casting of unstructured values to string.

After this PR, following tests can pass, and they are added in this PR.
```
MATCH (a:person) WHERE 10 + a.unstrProp = 57 RETURN COUNT(*)
MATCH (a:person) WHERE a.unstrProp + a.unstrProp2 = 67 RETURN COUNT(*)
MATCH (a:person) WHERE a.unstrProp - 10 > a.unstrProp2 RETURN COUNT(*)
MATCH (a:person) WHERE 'abc ' + a.unstrProp = 'abc 52' RETURN COUNT(*)
MATCH (a:person) WHERE a.unstrProp2 + ' abcdefghijklm' = '20 abcdefghijklm' RETURN COUNT(*)
```