### PR TITLE
Add the concept of primary key for nodes into loader

### DIFF
--- a/dataset/tinysnb/metadata.json
+++ b/dataset/tinysnb/metadata.json
@@ -3,11 +3,13 @@
   "nodeFileDescriptions": [
     {
       "filename": "vPerson.csv",
-      "label": "person"
+      "label": "person",
+      "primaryKey": "id"
     },
     {
       "filename": "vOrganisation.csv",
-      "label": "organisation"
+      "label": "organisation",
+      "primaryKey": "id"
     }
   ],
   "relFileDescriptions": [
@@ -15,25 +17,46 @@
       "filename": "eKnows.csv",
       "label": "knows",
       "cardinality": "MANY_MANY",
-      "srcNodeLabels" : ["person"],
-      "dstNodeLabels" : ["person"],
-      "storeCompressed": [false, true]
+      "srcNodeLabels": [
+        "person"
+      ],
+      "dstNodeLabels": [
+        "person"
+      ],
+      "storeCompressed": [
+        false,
+        true
+      ]
     },
     {
       "filename": "eStudyAt.csv",
       "label": "studyAt",
       "cardinality": "MANY_ONE",
-      "srcNodeLabels" : ["person"],
-      "dstNodeLabels" : ["organisation"],
-      "storeCompressed": [false, true]
+      "srcNodeLabels": [
+        "person"
+      ],
+      "dstNodeLabels": [
+        "organisation"
+      ],
+      "storeCompressed": [
+        false,
+        true
+      ]
     },
     {
       "filename": "eWorkAt.csv",
       "label": "workAt",
       "cardinality": "MANY_ONE",
-      "srcNodeLabels" : ["person"],
-      "dstNodeLabels" : ["organisation"],
-      "storeCompressed": [false, true]
+      "srcNodeLabels": [
+        "person"
+      ],
+      "dstNodeLabels": [
+        "organisation"
+      ],
+      "storeCompressed": [
+        false,
+        true
+      ]
     }
   ]
 }

--- a/dataset/tinysnb/vOrganisation.csv
+++ b/dataset/tinysnb/vOrganisation.csv
@@ -1,4 +1,4 @@
-id:NODE,name:STRING,orgCode:INT32,mark:DOUBLE
+id:INT32,name:STRING,orgCode:INT32,mark:DOUBLE
 1,ABFsUni,325,3.7
 4,CsWork,934,4.1
 6,DEsWork,824,4.1

--- a/dataset/tinysnb/vPerson.csv
+++ b/dataset/tinysnb/vPerson.csv
@@ -1,4 +1,4 @@
-id:NODE,fName:STRING,gender:INT32,isStudent:BOOLEAN,isWorker:BOOLEAN,age:INT32,eyeSight:DOUBLE
+id:INT32,fName:STRING,gender:INT32,isStudent:BOOLEAN,isWorker:BOOLEAN,age:INT32,eyeSight:DOUBLE
 0,Alice,1,true,false,35,5.0
 2,Bob,2,true,false,30,5.1,unstrProp:INT32:47,unstrProp2:INT32:20
 3,Carol,1,false,true,45,5.0,unstrProp:INT32:52

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -64,13 +64,15 @@ uint8_t convertToBoolean(char* data);
 class PropertyKey {
 
 public:
-    PropertyKey(){};
+    PropertyKey() : dataType{0}, idx{0}, isPrimaryKey{false} {};
 
-    PropertyKey(DataType dataType, uint32_t idx) : dataType{dataType}, idx{idx} {};
+    PropertyKey(DataType dataType, uint32_t idx, bool isPrimaryKey)
+        : dataType{dataType}, idx{idx}, isPrimaryKey{isPrimaryKey} {};
 
 public:
-    DataType dataType{};
-    uint32_t idx{};
+    DataType dataType;
+    uint32_t idx;
+    bool isPrimaryKey;
 };
 
 size_t getDataTypeSize(DataType dataType);

--- a/src/loader/include/graph_loader.h
+++ b/src/loader/include/graph_loader.h
@@ -33,21 +33,24 @@ private:
     unique_ptr<nlohmann::json> readMetadata();
 
     void assignIdxToLabels(stringToLabelMap_t& map, const nlohmann::json& fileDescriptions);
-
     void setCardinalitiesOfRelLabels(const nlohmann::json& metadata);
-
     void setSrcDstNodeLabelsForRelLabels(const nlohmann::json& metadata);
 
+    void checkNodePrimaryKeyConstraints();
     unique_ptr<vector<unique_ptr<NodeIDMap>>> loadNodes(const nlohmann::json& metadata);
 
     void loadRels(const nlohmann::json& metadata, vector<unique_ptr<NodeIDMap>>& nodeIDMaps);
 
     void inferFnamesFromMetadataFileDesriptions(
         label_t numLabels, nlohmann::json fileDescriptions, vector<string>& filenames);
+    vector<string> getNodePrimaryKeysFromMetadata(
+        label_t numLabels, nlohmann::json fileDescriptions);
 
     void initPropertyKeyMapAndCalcNumBlocks(label_t numLabels, vector<string>& filenames,
         vector<uint64_t>& numBlocksPerLabel,
         vector<unordered_map<string, PropertyKey>>& propertyKeysMaps, const char tokenSeparator);
+
+    void initNodePropertyPrimaryKeys(vector<string>& primaryKeys);
 
     void parseHeader(const char tokenSeparator, string& header,
         unordered_map<string, PropertyKey>& propertyKeyMap);

--- a/src/loader/include/nodes_loader.h
+++ b/src/loader/include/nodes_loader.h
@@ -54,9 +54,9 @@ private:
     // Concurrent Tasks
 
     static void populatePropertyColumnsAndCountUnstrPropertyListSizesTask(string fname,
-        uint64_t blockId, char tokenSeparator, const vector<DataType> propertyDataTypes,
-        uint64_t numElements, node_offset_t offsetStart, NodeIDMap* nodeIDMap,
-        vector<string> propertyColumnFnames,
+        uint64_t blockId, char tokenSeparator, vector<DataType> propertyDataTypes,
+        vector<bool> isPrimaryKeys, uint64_t numElements, node_offset_t offsetStart,
+        NodeIDMap* nodeIDMap, vector<string> propertyColumnFnames,
         vector<unique_ptr<InMemStringOverflowPages>>* stringOverflowPages,
         listSizes_t* unstrPropertyListSizes, shared_ptr<spdlog::logger> logger);
 
@@ -74,9 +74,10 @@ private:
         shared_ptr<spdlog::logger> logger);
 
     static void putPropsOfLineIntoBuffers(const vector<DataType>& propertyDataTypes,
-        CSVReader& reader, vector<unique_ptr<uint8_t[]>>& buffers, const uint32_t& bufferOffset,
-        vector<unique_ptr<InMemStringOverflowPages>>& InMemStringOverflowPages,
-        vector<PageCursor>& stringOverflowPagesCursors, shared_ptr<spdlog::logger> logger);
+        const vector<bool>& isPrimaryKeys, CSVReader& reader,
+        vector<unique_ptr<uint8_t[]>>& buffers, const uint32_t& bufferOffset,
+        vector<unique_ptr<InMemStringOverflowPages>>& inMemStringOverflowPages,
+        vector<PageCursor>& stringOverflowPagesCursors, NodeIDMap* nodeIDMap, uint64_t nodeOffset);
 
     static void calcLengthOfUnstrPropertyLists(
         CSVReader& reader, node_offset_t nodeOffset, listSizes_t& unstrPropertyListSizes);

--- a/src/loader/include/utils.h
+++ b/src/loader/include/utils.h
@@ -49,6 +49,8 @@ private:
 vector<DataType> createPropertyDataTypesArray(
     const unordered_map<string, PropertyKey>& propertyMap);
 
+vector<bool> getPropertyIsPrimaryKeys(const unordered_map<string, PropertyKey>& propertyMap);
+
 // Holds information about a rel label that is needed to construct adjRels and adjLists
 // indexes, property columns, and property lists.
 class RelLabelDescription {

--- a/src/loader/loader_runner.cpp
+++ b/src/loader/loader_runner.cpp
@@ -57,7 +57,9 @@ int main(int argc, char* argv[]) {
     spdlog::set_level(verbosity ? args::get(verbosity) : verbosityMap["info"]);
     createDirectory(args::get(outputDir));
     auto numThreads = threads ? args::get(threads) : thread::hardware_concurrency();
-    GraphLoader graphLoader(args::get(inputDir), args::get(outputDir), numThreads);
-    graphLoader.loadGraph();
+    try {
+        GraphLoader graphLoader(args::get(inputDir), args::get(outputDir), numThreads);
+        graphLoader.loadGraph();
+    } catch (const exception& e) { cerr << "Failed to load graph. Error: " << e.what() << endl; }
     return 0;
 }

--- a/src/loader/utils.cpp
+++ b/src/loader/utils.cpp
@@ -39,6 +39,14 @@ vector<DataType> createPropertyDataTypesArray(
     return propertyDataTypes;
 }
 
+vector<bool> getPropertyIsPrimaryKeys(const unordered_map<string, PropertyKey>& propertyMap) {
+    vector<bool> isPrimaryKeys(propertyMap.size());
+    for (auto& property : propertyMap) {
+        isPrimaryKeys[property.second.idx] = property.second.isPrimaryKey;
+    }
+    return isPrimaryKeys;
+}
+
 void ListsLoaderHelper::calculateListHeadersTask(node_offset_t numNodeOffsets,
     uint32_t numElementsPerPage, listSizes_t* listSizes, ListHeaders* listHeaders,
     shared_ptr<spdlog::logger> logger) {

--- a/src/storage/catalog.cpp
+++ b/src/storage/catalog.cpp
@@ -73,8 +73,9 @@ bool Catalog::isSingleCaridinalityInDir(label_t relLabel, Direction dir) const {
 template<typename S>
 void Catalog::serialize(S& s) {
     auto propertyMapsFunc = [](S& s, unordered_map<string, PropertyKey>& v) {
-        s.ext(v, bitsery::ext::StdMap{UINT32_MAX},
-            [](S& s, string& key, PropertyKey& value) { s(key, value.dataType, value.idx); });
+        s.ext(v, bitsery::ext::StdMap{UINT32_MAX}, [](S& s, string& key, PropertyKey& value) {
+            s(key, value.dataType, value.idx, value.isPrimaryKey);
+        });
     };
     s.container(nodePropertyKeyMaps, UINT32_MAX, propertyMapsFunc);
     s.container(relPropertyKeyMaps, UINT32_MAX, propertyMapsFunc);


### PR DESCRIPTION
Currently, we by default take the first column/property in the csv file as the primary key, and that column/property is only used to construct the node id map, but not kept in the storage.

This PR adds the concept of primary key into loader.
Each node csv file now requires that, in the header, one and only one column/property is specified as a primary key.
The way to specifiy a column as a primary key is to append the keyword `PRIMARY` after the data type.
An example is like this:
`id:INT32:PRIMARY,name:STRING,orgCode:INT32,mark:DOUBLE`.

 Currently, the data types for the primary key is limited to INT32 and STRING. (the NodeIDMap will always map the key to a string value, which should be changed later to support both int32 and string).