### PR TITLE
Add benchmark runner

### DIFF
--- a/src/common/include/metric.h
+++ b/src/common/include/metric.h
@@ -29,6 +29,8 @@ public:
     void start();
     void stop();
 
+    double getElapsedTimeMS();
+
 public:
     double accumulatedTime;
     bool isStarted;

--- a/src/common/include/timer.h
+++ b/src/common/include/timer.h
@@ -26,7 +26,7 @@ public:
     double getDuration() {
         if (finished) {
             auto duration = stopTime - startTime;
-            return chrono::duration_cast<chrono::milliseconds>(duration).count();
+            return chrono::duration_cast<chrono::microseconds>(duration).count();
         }
         throw invalid_argument("Timer is still running.");
     }

--- a/src/common/metric.cpp
+++ b/src/common/metric.cpp
@@ -29,6 +29,10 @@ void TimeMetric::stop() {
     isStarted = false;
 }
 
+double TimeMetric::getElapsedTimeMS() {
+    return accumulatedTime / 1000;
+}
+
 NumericMetric::NumericMetric(bool enable) : Metric(enable) {
     accumulatedValue = 0u;
 }

--- a/src/common/profiler.cpp
+++ b/src/common/profiler.cpp
@@ -23,7 +23,7 @@ double Profiler::sumAllTimeMetricsWithKey(const string& key) {
     auto sum = 0.0;
     assert(metrics.contains(key));
     for (auto& metric : metrics.at(key)) {
-        sum += ((TimeMetric*)metric.get())->accumulatedTime;
+        sum += ((TimeMetric*)metric.get())->getElapsedTimeMS();
     }
     return sum;
 }

--- a/src/processor/physical_plan/operator/physical_operator.cpp
+++ b/src/processor/physical_plan/operator/physical_operator.cpp
@@ -37,7 +37,7 @@ void PhysicalOperator::printTimeAndNumOutputMetrics(nlohmann::json& json, Profil
     // Time metric measures execution time of the subplan under current operator (like a CDF).
     // By subtracting prevOperator runtime, we get the runtime of current operator
     json["executionTime"] =
-        profiler.sumAllTimeMetricsWithKey(getTimeMetricKey()) - prevExecutionTime;
+        to_string(profiler.sumAllTimeMetricsWithKey(getTimeMetricKey()) - prevExecutionTime);
     json["numOutputTuples"] = profiler.sumAllNumericMetricsWithKey(getNumTupleMetricKey());
 }
 
@@ -46,7 +46,7 @@ void PhysicalOperator::printBufferManagerMetrics(nlohmann::json& json, Profiler&
     auto bufferMiss = profiler.sumAllNumericMetricsWithKey(getNumBufferMissMetricKey());
     json["numBufferHit"] = bufferHit;
     json["numBufferMiss"] = bufferMiss;
-    json["cacheMissRatio"] = ((double)bufferMiss) / (double)(bufferMiss + bufferHit);
+    json["cacheMissRatio"] = to_string(((double)bufferMiss) / (double)(bufferMiss + bufferHit));
     json["numIO"] = profiler.sumAllNumericMetricsWithKey(getNumIOMetricKey());
 }
 

--- a/src/storage/store/rels_store.cpp
+++ b/src/storage/store/rels_store.cpp
@@ -162,6 +162,7 @@ void RelsStore::initPropertyListsForRelLabel(const Catalog& catalog,
                 case STRING:
                     propertyLists[dir][nodeLabel][relLabel][idx] =
                         make_unique<RelPropertyListsString>(fname, adjListsHeaders, bufferManager);
+                    break;
                 default:
                     throw invalid_argument("invalid type for property list creation.");
                 }

--- a/src/testing/test_helper.cpp
+++ b/src/testing/test_helper.cpp
@@ -12,7 +12,7 @@ namespace graphflow {
 namespace testing {
 
 bool TestHelper::runTest(const TestSuiteQueryConfig& testConfig, const System& system) {
-    auto sessionContext = SessionContext();
+    SessionContext context;
     auto numQueries = testConfig.query.size();
     uint64_t numPassedQueries = 0;
     vector<uint64_t> numPlansOfEachQuery(numQueries);
@@ -20,15 +20,15 @@ bool TestHelper::runTest(const TestSuiteQueryConfig& testConfig, const System& s
     for (uint64_t i = 0; i < numQueries; i++) {
         spdlog::info("TEST: {}", testConfig.name[i]);
         spdlog::info("QUERY: {}", testConfig.query[i]);
-        sessionContext.query = testConfig.query[i];
-        auto plans = system.enumerateAllPlans(sessionContext);
+        context.query = testConfig.query[i];
+        auto plans = system.enumerateAllPlans(context);
         auto numPlans = plans.size();
         assert(numPlans > 0);
         numPlansOfEachQuery[i] = numPlans;
         uint64_t numPassedPlans = 0;
         for (uint64_t j = 0; j < numPlans; j++) {
             auto planStr = plans[j]->lastOperator->toString();
-            auto result = system.executePlan(move(plans[j]), sessionContext);
+            auto result = system.executePlan(move(plans[j]), context);
             if (result->numTuples != testConfig.expectedNumTuples[i]) {
                 spdlog::error("PLAN{} NOT PASSED. Result num tuples: {}, Expected num tuples: {}",
                     j, result->numTuples, testConfig.expectedNumTuples[i]);

--- a/tools/benchmark/BUILD.bazel
+++ b/tools/benchmark/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "benchmark",
+    srcs = [
+        "benchmark.cpp",
+        "benchmark_runner.cpp",
+    ],
+    hdrs = [
+        "include/benchmark.h",
+        "include/benchmark_config.h",
+        "include/benchmark_runner.h",
+    ],
+    deps = [
+        "//src/main:system",
+    ],
+)
+
+cc_binary(
+    name = "benchmark_tool",
+    srcs = [
+        "main.cpp",
+    ],
+    linkopts = ["-lpthread"],
+    deps = [
+        "benchmark",
+    ],
+)

--- a/tools/benchmark/benchmark.cpp
+++ b/tools/benchmark/benchmark.cpp
@@ -1,0 +1,96 @@
+#include "tools/benchmark/include/benchmark.h"
+
+#include <filesystem>
+#include <fstream>
+
+#include "spdlog/spdlog.h"
+
+#include "src/common/include/utils.h"
+
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace benchmark {
+
+Benchmark::Benchmark(const string& benchmarkPath, System& system, BenchmarkConfig& config)
+    : system{system}, config{config} {
+    context = make_unique<SessionContext>();
+    context->numThreads = config.numThreads;
+    loadBenchmark(benchmarkPath);
+}
+
+void Benchmark::loadBenchmark(const string& benchmarkPath) {
+    if (!filesystem::exists(benchmarkPath)) {
+        throw invalid_argument(benchmarkPath + " does not exist.");
+    }
+    string line;
+    ifstream ifs(benchmarkPath);
+    while (getline(ifs, line)) {
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+        auto splits = StringUtils::split(line, " ");
+        if (splits[0] == "name") { // load benchmark name
+            if (splits.size() != 2) {
+                throw invalid_argument("Empty benchmark name.");
+            }
+            name = splits[1];
+        } else if (splits[0] == "query") { // load benchmark query
+            if (config.enableProfile) {
+                context->query += "PROFILE ";
+            }
+            while (getline(ifs, line)) {
+                if (line.empty()) {
+                    break;
+                }
+                context->query += line + " ";
+            }
+        } else if (splits[0] == "expectedNumOutput") { // load benchmark number of output tuples
+            if (splits.size() != 2) {
+                throw invalid_argument("Empty number of output tuples.");
+            }
+            expectedNumOutput = stoul(splits[1]);
+        } else {
+            throw invalid_argument("Unrecognized line " + line);
+        }
+    }
+}
+
+void Benchmark::run() {
+    auto timeMetric = TimeMetric(true);
+    timeMetric.start();
+    system.executeQuery(*context);
+    timeMetric.stop();
+    executionTime = timeMetric.getElapsedTimeMS();
+
+    verify();
+}
+
+void Benchmark::log() {
+    string time = "Execution time: " + to_string(executionTime);
+    string plan = "Plan: \n" + context->planPrinter->printPlanToJson(*context->profiler).dump(4);
+    spdlog::info("{}", time);
+    if (config.enableProfile) {
+        spdlog::info("{}", plan);
+    }
+    if (!config.outputPath.empty()) {
+        ofstream f(config.outputPath + "/" + name + ".result", ios_base::app);
+        f << time << endl;
+        if (config.enableProfile) {
+            f << plan << endl;
+        }
+        f.flush();
+        f.close();
+    }
+}
+
+void Benchmark::verify() {
+    if (context->queryResult->numTuples != expectedNumOutput) {
+        spdlog::error("Query: {}", context->query);
+        spdlog::error("Expected number of output equals {} but get {}", expectedNumOutput,
+            context->queryResult->numTuples);
+    }
+}
+
+} // namespace benchmark
+} // namespace graphflow

--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -1,0 +1,54 @@
+#include "tools/benchmark/include/benchmark_runner.h"
+
+#include <filesystem>
+
+#include "spdlog/spdlog.h"
+
+namespace graphflow {
+namespace benchmark {
+
+const string BENCHMARK_SUFFIX = ".benchmark";
+
+BenchmarkRunner::BenchmarkRunner(const string& datasetPath, unique_ptr<BenchmarkConfig> config)
+    : config{move(config)} {
+    system = make_unique<System>(datasetPath);
+}
+
+void BenchmarkRunner::registerBenchmarks(const string& path) {
+    if (filesystem::is_regular_file(path)) {
+        registerBenchmark(path);
+    } else if (filesystem::is_directory(path)) {
+        for (auto& f : filesystem::directory_iterator(path)) {
+            registerBenchmark(f.path());
+        }
+    }
+}
+
+void BenchmarkRunner::runAllBenchmarks() {
+    for (auto& benchmark : benchmarks) {
+        runBenchmark(benchmark.get());
+    }
+}
+
+void BenchmarkRunner::registerBenchmark(const string& path) {
+    if (path.ends_with(BENCHMARK_SUFFIX)) {
+        auto benchmark = make_unique<Benchmark>(path, *system, *config);
+        spdlog::info("Register benchmark {}", benchmark->name);
+        benchmarks.push_back(move(benchmark));
+    }
+}
+
+void BenchmarkRunner::runBenchmark(Benchmark* benchmark) {
+    spdlog::info("Running benchmark {} with {} thread", benchmark->name, config->numThreads);
+    for (auto i = 0u; i < config->numWarmups; ++i) {
+        spdlog::info("Warm up");
+        benchmark->run();
+    }
+    for (auto i = 0u; i < config->numRuns; ++i) {
+        benchmark->run();
+        benchmark->log();
+    }
+}
+
+} // namespace benchmark
+} // namespace graphflow

--- a/tools/benchmark/example/example.benchmark
+++ b/tools/benchmark/example/example.benchmark
@@ -1,0 +1,7 @@
+name example
+
+query
+MATCH (:Person)
+RETURN COUNT(*)
+
+expectedNumOutput 8

--- a/tools/benchmark/include/benchmark.h
+++ b/tools/benchmark/include/benchmark.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "tools/benchmark/include/benchmark_config.h"
+
+#include "src/main/include/system.h"
+
+using namespace std;
+using namespace graphflow::main;
+
+namespace graphflow {
+namespace benchmark {
+
+/**
+ * Each benchmark represents a query to be executed against the system
+ */
+class Benchmark {
+
+public:
+    Benchmark(const string& benchmarkPath, System& system, BenchmarkConfig& config);
+
+    void run();
+    void log();
+
+private:
+    void loadBenchmark(const string& benchmarkPath);
+    void verify();
+
+public:
+    System& system;
+    BenchmarkConfig& config;
+
+    string name;
+    uint64_t expectedNumOutput;
+
+    unique_ptr<SessionContext> context;
+    double executionTime;
+};
+
+} // namespace benchmark
+} // namespace graphflow

--- a/tools/benchmark/include/benchmark_config.h
+++ b/tools/benchmark/include/benchmark_config.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+using namespace std;
+
+namespace graphflow {
+namespace benchmark {
+
+/**
+ * Benchmark config should be shared for a suite of benchmarks
+ */
+struct BenchmarkConfig {
+    bool enableProfile = false;
+    // number of warm up runs
+    uint32_t numWarmups = 1;
+    // number of actual runs
+    uint32_t numRuns = 5;
+    // number of threads to execute benchmark
+    uint32_t numThreads = 1;
+    // output benchmark log to file
+    string outputPath;
+};
+
+} // namespace benchmark
+} // namespace graphflow

--- a/tools/benchmark/include/benchmark_runner.h
+++ b/tools/benchmark/include/benchmark_runner.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "tools/benchmark/include/benchmark.h"
+
+namespace graphflow {
+namespace benchmark {
+
+// Class stores information of a benchmark
+class BenchmarkRunner {
+
+public:
+    BenchmarkRunner(const string& datasetPath, unique_ptr<BenchmarkConfig> config);
+
+    void registerBenchmarks(const string& path);
+
+    void runAllBenchmarks();
+
+private:
+    void registerBenchmark(const string& path);
+
+    void runBenchmark(Benchmark* benchmark);
+
+public:
+    unique_ptr<BenchmarkConfig> config;
+    unique_ptr<System> system;
+    vector<unique_ptr<Benchmark>> benchmarks;
+};
+
+} // namespace benchmark
+} // namespace graphflow

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -1,0 +1,55 @@
+#include "tools/benchmark/include/benchmark_runner.h"
+
+#include "src/common/include/utils.h"
+
+using namespace graphflow::benchmark;
+
+static string getArgumentValue(const string& arg) {
+    auto splits = StringUtils::split(arg, "=");
+    if (splits.size() != 2) {
+        throw invalid_argument("Expect value associate with " + splits[0]);
+    }
+    return splits[1];
+}
+
+int main(int argc, char** argv) {
+    string datasetPath;
+    string benchmarkPath;
+    auto config = make_unique<BenchmarkConfig>();
+    // parse arguments
+    for (auto i = 1; i < argc; ++i) {
+        string arg = argv[i];
+        if (arg.starts_with("--dataset")) {
+            datasetPath = getArgumentValue(arg);
+        } else if (arg.starts_with("--benchmark")) {
+            benchmarkPath = getArgumentValue(arg);
+        } else if (arg.starts_with("--warmup")) {
+            config->numWarmups = stoul(getArgumentValue(arg));
+        } else if (arg.starts_with("--run")) {
+            config->numRuns = stoul(getArgumentValue(arg));
+        } else if (arg.starts_with("--thread")) {
+            config->numThreads = stoul(getArgumentValue(arg));
+        } else if (arg.starts_with("--out")) { // save benchmark result to file
+            config->outputPath = getArgumentValue(arg);
+        } else if (arg.starts_with("--profile")) {
+            config->enableProfile = true;
+        } else {
+            printf("Unrecognized option %s", arg.c_str());
+            exit(1);
+        }
+    }
+    if (datasetPath.empty()) {
+        printf("Missing --dataset input.");
+        exit(1);
+    }
+    if (benchmarkPath.empty()) {
+        printf("Missing --benchmark input");
+        exit(1);
+    }
+    auto runner = BenchmarkRunner(datasetPath, move(config));
+    try {
+        runner.registerBenchmarks(benchmarkPath);
+        runner.runAllBenchmarks();
+    } catch (exception& e) { printf("Error encountered during benchmarking. %s", e.what()); }
+    return 0;
+}


### PR DESCRIPTION
This PR adds benchmark runner

Benchmark runner has the following options
- require input dataset
- require input benchmark folder
  - benchmark file should have suffix .benchmark
  - each file has name, query and expected number of output tuples
- optional config number of thread
- optional config number of warm up
- optional config number of actual run
- optional config log result to an output directory
  - result will always log to terminal
  - if configured with file output, will write to file "name".result 
- optional config proflie