### PR TITLE
Refactoring of Catalog

### DIFF
--- a/dataset/tinysnb/metadata.json
+++ b/dataset/tinysnb/metadata.json
@@ -16,46 +16,34 @@
     {
       "filename": "eKnows.csv",
       "label": "knows",
-      "cardinality": "MANY_MANY",
+      "multiplicity": "MANY_MANY",
       "srcNodeLabels": [
         "person"
       ],
       "dstNodeLabels": [
         "person"
-      ],
-      "storeCompressed": [
-        false,
-        true
       ]
     },
     {
       "filename": "eStudyAt.csv",
       "label": "studyAt",
-      "cardinality": "MANY_ONE",
+      "multiplicity": "MANY_ONE",
       "srcNodeLabels": [
         "person"
       ],
       "dstNodeLabels": [
         "organisation"
-      ],
-      "storeCompressed": [
-        false,
-        true
       ]
     },
     {
       "filename": "eWorkAt.csv",
       "label": "workAt",
-      "cardinality": "MANY_ONE",
+      "multiplicity": "MANY_ONE",
       "srcNodeLabels": [
         "person"
       ],
       "dstNodeLabels": [
         "organisation"
-      ],
-      "storeCompressed": [
-        false,
-        true
       ]
     }
   ]

--- a/docs/physicalDesign.md
+++ b/docs/physicalDesign.md
@@ -7,57 +7,76 @@ Each store is composed of multiple instances of STRUCTURE having a fixed LAYOUT.
 - AdjListsIndexes
 
 ## Structures:
-Data structure that we use to hold some data. The **Layout** is fixed by the data it holds. 
+
+Data structure that we use to hold some data. The **Layout** is fixed by the data it holds.
+
 - Vertex Column **(VCOL)**
-- Property Lists **(PROPL)** 
+- Property Lists **(PROPL)**
 - Adjacency Lists **(ADJL)**
 
 Eg, VCOL\<int> is a Vertex Column with layout for storing integers.
 
 ## Node Property Store:
-Holds properties of nodes in Vertex columns. There is one VCOL for each (node label, property) pair with a fixed layout. VCOLs can be instances of following types:
+
+Holds properties of nodes in Vertex columns. There is one VCOL for each (node label, property) pair with a fixed layout.
+VCOLs can be instances of following types:
+
 - COL\<int>, VCOL\<double>, VCOL\<bool>, VCOL\<str>
 
 ## Rel Property Store:
-Holds properties of rels in Vertex columns (for rels having single cardinality in any direction) and Property lists (for MANY-MANY rels).
-  - PROPL\<int>, PROPL\<double>, PROPL\<bool>, PROPL\<str>
-  - VCOL\<int>, VCOL\<double>, VCOL\<bool>, VCOL\<str>
+
+Holds properties of rels in Vertex columns (for rels having single relMultiplicity in any direction) and Property
+lists (for MANY-MANY rels).
+
+- PROPL\<int>, PROPL\<double>, PROPL\<bool>, PROPL\<str>
+- VCOL\<int>, VCOL\<double>, VCOL\<bool>, VCOL\<str>
 
 ## AdjacencyListsIndexes
-Holds adjacency lists in the FWD as well as the BWD direction. In each direction, the adjlsts are stored in either Defualts Adjacency Lists (ADJL) (for relLabels that have MANY cardinality) or in Vertex Columns (VCOL) (for rels that have single cardinality). 
-  - FWD
-    - ADJL\<label, offset>
-      - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
-      - offset : [1 byte, 2 byte, 4 byte, 8 byte]
-    - COL<label, offset>
-      - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
-      - offset : [1 byte, 2 byte, 4 byte, 8 byte]
-  - BWD
-    - ADJL<label, offset, loffest>
-      - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
-      - offset : [1 byte, 2 byte, 4 byte, 8 byte]
-      - loffset: [Optional] [none, 1 byte, 2 byte, 4 byte]
-    - COL<label,  offset>
-      - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
-      - offset : [1 byte, 2 byte, 4 byte, 8 byte]
 
-## FILE: 
-Each instance of a STRUCTURE (with definite layout) has a FILE object that controls the storage of its data in a file in a physical disk.
-  - `fileDescriptor:int` owns the FileStream.
-  - `page:uint64_t[]` array of handles, one per populated page.
-  - recieves request for the page from STRUCTURE and routes it to the BUFFER MANAGER.
+Holds adjacency lists in the FWD as well as the BWD direction. In each direction, the adjlsts are stored in either
+Defualts Adjacency Lists (ADJL) (for relLabels that have MANY relMultiplicity) or in Vertex Columns (VCOL) (for rels
+that have single relMultiplicity).
+
+- FWD
+    - ADJL\<label, offset>
+        - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
+        - offset : [1 byte, 2 byte, 4 byte, 8 byte]
+    - COL<label, offset>
+        - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
+        - offset : [1 byte, 2 byte, 4 byte, 8 byte]
+- BWD
+    - ADJL<label, offset, loffest>
+        - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
+        - offset : [1 byte, 2 byte, 4 byte, 8 byte]
+        - loffset: [Optional] [none, 1 byte, 2 byte, 4 byte]
+    - COL<label, offset>
+        - label  : [Optional] [none, 1 byte, 2 byte, 4 byte]
+        - offset : [1 byte, 2 byte, 4 byte, 8 byte]
+
+## FILE:
+
+Each instance of a STRUCTURE (with definite layout) has a FILE object that controls the storage of its data in a file in
+a physical disk.
+
+- `fileDescriptor:int` owns the FileStream.
+- `page:uint64_t[]` array of handles, one per populated page.
+- recieves request for the page from STRUCTURE and routes it to the BUFFER MANAGER.
 
 ## PAGE:
-Each file is broken into PAGES (of fixed size of 4096 bytes). 
+
+Each file is broken into PAGES (of fixed size of 4096 bytes).
 
 ## BUFFER MANAGER:
-  - `lock` needed for synchronized operations.
-  - `list:FrameHandles[]` {size: max_size/page_size}.
-  - `pointer` needed for the CLOCK replacement policy.
+
+- `lock` needed for synchronized operations.
+- `list:FrameHandles[]` {size: max_size/page_size}.
+- `pointer` needed for the CLOCK replacement policy.
 
 ## FRAME HANDLE:
-Manages a frame in the buffer manager. 
-  - `location:uint64_t *`: holds the page's address corresponding to the data in frame, else null_ptr.
-  - `unswizzledContent:uint64_t`: content of 
-  - `pinAndRecentlyAccessed:uint8_t` 
-  - `frame:uint8_t[]`
+
+Manages a frame in the buffer manager.
+
+- `location:uint64_t *`: holds the page's address corresponding to the data in frame, else null_ptr.
+- `unswizzledContent:uint64_t`: content of
+- `pinAndRecentlyAccessed:uint8_t`
+- `frame:uint8_t[]`

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -216,14 +216,9 @@ shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
         auto node = static_pointer_cast<NodeExpression>(childExpression);
         auto propertyVariableName = node->variableName + "." + propertyName;
         if (catalog.containNodeProperty(node->label, propertyName)) {
-            auto dataType = catalog.getNodePropertyTypeFromString(node->label, propertyName);
-            auto propertyKey = catalog.getNodePropertyKeyFromString(node->label, propertyName);
+            auto property = catalog.getNodeProperty(node->label, propertyName);
             return make_shared<PropertyExpression>(
-                propertyVariableName, dataType, propertyKey, move(childExpression));
-        } else if (catalog.containUnstrNodeProperty(node->label, propertyName)) {
-            auto propertyKey = catalog.getUnstrNodePropertyKeyFromString(node->label, propertyName);
-            return make_shared<PropertyExpression>(
-                propertyVariableName, UNSTRUCTURED, propertyKey, move(childExpression));
+                propertyVariableName, property.dataType, property.id, move(childExpression));
         } else {
             throw invalid_argument("Node " + node->getAliasElseRawExpression() +
                                    " does not have property " + propertyName + ".");
@@ -233,10 +228,9 @@ shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
         auto rel = static_pointer_cast<RelExpression>(childExpression);
         auto propertyVariableName = rel->variableName + "." + propertyName;
         if (catalog.containRelProperty(rel->label, propertyName)) {
-            auto dataType = catalog.getRelPropertyTypeFromString(rel->label, propertyName);
-            auto propertyKey = catalog.getRelPropertyKeyFromString(rel->label, propertyName);
+            auto property = catalog.getRelProperty(rel->label, propertyName);
             return make_shared<PropertyExpression>(
-                propertyVariableName, dataType, propertyKey, move(childExpression));
+                propertyVariableName, property.dataType, property.id, move(childExpression));
         } else {
             throw invalid_argument("Rel " + rel->getAliasElseRawExpression() +
                                    " does not have property " + propertyName + ".");

--- a/src/binder/query_binder.cpp
+++ b/src/binder/query_binder.cpp
@@ -277,7 +277,7 @@ label_t QueryBinder::bindRelLabel(const string& parsed_label) {
     if (parsed_label.empty()) {
         return ANY_LABEL;
     }
-    if (!catalog.containRelLabel(parsed_label.c_str())) {
+    if (!catalog.containRelLabel(parsed_label)) {
         throw invalid_argument("Rel label " + parsed_label + " does not exist.");
     }
     return catalog.getRelLabelFromString(parsed_label.c_str());
@@ -287,7 +287,7 @@ label_t QueryBinder::bindNodeLabel(const string& parsed_label) {
     if (parsed_label.empty()) {
         return ANY_LABEL;
     }
-    if (!catalog.containNodeLabel(parsed_label.c_str())) {
+    if (!catalog.containNodeLabel(parsed_label)) {
         throw invalid_argument("Node label " + parsed_label + " does not exist.");
     }
     return catalog.getNodeLabelFromString(parsed_label.c_str());

--- a/src/common/compression_scheme.cpp
+++ b/src/common/compression_scheme.cpp
@@ -7,7 +7,7 @@ namespace common {
 
 static uint32_t getNumBytesForEncoding(const uint64_t& maxValToEncode, const uint8_t& minNumBytes);
 
-NodeIDCompressionScheme::NodeIDCompressionScheme(const vector<label_t>& nbrNodeLabels,
+NodeIDCompressionScheme::NodeIDCompressionScheme(const unordered_set<label_t>& nbrNodeLabels,
     const vector<uint64_t>& numNodesPerLabel, const uint32_t& numNodeLabels) {
     auto maxNodeOffsetToFit = 0ull;
     for (auto nodeLabel : nbrNodeLabels) {

--- a/src/common/include/compression_scheme.h
+++ b/src/common/include/compression_scheme.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -12,7 +13,7 @@ namespace common {
 class NodeIDCompressionScheme {
 
 public:
-    NodeIDCompressionScheme(const vector<label_t>& nbrNodeLabels,
+    NodeIDCompressionScheme(const unordered_set<label_t>& nbrNodeLabels,
         const vector<uint64_t>& numNodesPerLabel, const uint32_t& numNodeLabels);
     NodeIDCompressionScheme() : NodeIDCompressionScheme(0, 8){};
     NodeIDCompressionScheme(uint32_t numBytesForLabel, uint32_t numBytesForOffset)

--- a/src/common/include/csv_reader/csv_reader.h
+++ b/src/common/include/csv_reader/csv_reader.h
@@ -1,13 +1,6 @@
 #pragma once
 
-#include <stdio.h>
-#include <string.h>
-
-#include <cmath>
 #include <fstream>
-#include <iostream>
-#include <memory>
-#include <string>
 
 #include "src/common/include/types.h"
 
@@ -34,8 +27,6 @@ public:
     bool hasNextLine();
     // returns true if the currently-pointed to line has more data to be parsed, else false.
     bool hasNextToken();
-    // returns the lenght of the next token (the len of the char *)
-    uint64_t getNextTokenLen();
 
     // Marks the currently-pointed to line as processed. hasNextLine() has to be called the move the
     // iterator to the next line.
@@ -54,11 +45,11 @@ public:
     date_t getDate();
 
 private:
-    void openFile(string fname);
+    void openFile(const string& fName);
     void setNextTokenIsNotProcessed();
 
 private:
-    FILE* f;
+    FILE* fd;
     const char tokenSeparator;
     bool nextLineIsNotProcessed = false, isEndOfBlock = false, nextTokenIsNotProcessed = false;
     char* line;

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -69,22 +69,6 @@ double_t convertToDouble(char* data);
 
 uint8_t convertToBoolean(char* data);
 
-// A PropertyKey is a pair of index and a dataType. If the property is unstructured, then the
-// dataType is UNKNOWN, otherwise it is one of those supported by the system.
-class PropertyKey {
-
-public:
-    PropertyKey() : dataType{0}, idx{0}, isPrimaryKey{false} {};
-
-    PropertyKey(DataType dataType, uint32_t idx, bool isPrimaryKey)
-        : dataType{dataType}, idx{idx}, isPrimaryKey{isPrimaryKey} {};
-
-public:
-    DataType dataType;
-    uint32_t idx;
-    bool isPrimaryKey;
-};
-
 size_t getDataTypeSize(DataType dataType);
 
 DataType getDataType(const std::string& dataTypeString);
@@ -93,16 +77,10 @@ string dataTypeToString(DataType dataType);
 
 bool isNumericalType(DataType dataType);
 
-// Rel Label Cardinality
-enum Cardinality : uint8_t { MANY_MANY, MANY_ONE, ONE_MANY, ONE_ONE };
-const string CardinalityNames[] = {"MANY_MANY", "MANY_ONE", "ONE_MANY", "ONE_ONE"};
-
-Cardinality getCardinality(const string& cardinalityString);
-
 // Direction
 enum Direction : uint8_t { FWD = 0, BWD = 1 };
 
-const vector<Direction> DIRS = {FWD, BWD};
+const vector<Direction> DIRECTIONS = {FWD, BWD};
 
 Direction operator!(Direction& direction);
 

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -85,19 +85,6 @@ uint8_t convertToBoolean(char* data) {
     throw invalid_argument("invalid boolean val.");
 }
 
-Cardinality getCardinality(const string& cardinalityString) {
-    if ("ONE_ONE" == cardinalityString) {
-        return ONE_ONE;
-    } else if ("MANY_ONE" == cardinalityString) {
-        return MANY_ONE;
-    } else if ("ONE_MANY" == cardinalityString) {
-        return ONE_MANY;
-    } else if ("MANY_MANY" == cardinalityString) {
-        return MANY_MANY;
-    }
-    throw invalid_argument("Invalid cardinality string \"" + cardinalityString + "\"");
-}
-
 Direction operator!(Direction& direction) {
     return (FWD == direction) ? BWD : FWD;
 }

--- a/src/loader/adj_and_prop_structures_builder.cpp
+++ b/src/loader/adj_and_prop_structures_builder.cpp
@@ -6,25 +6,25 @@ namespace graphflow {
 namespace loader {
 
 AdjAndPropertyStructuresBuilder::AdjAndPropertyStructuresBuilder(RelLabelDescription& description,
-    ThreadPool& threadPool, const Graph& graph, const string& outputDirectory)
+    ThreadPool& threadPool, const Graph& graph, string outputDirectory)
     : logger{spdlog::get("loader")}, description{description}, threadPool{threadPool}, graph{graph},
-      outputDirectory{outputDirectory} {};
+      outputDirectory{move(outputDirectory)} {}
 
 void AdjAndPropertyStructuresBuilder::populateNumRelsInfo(
     vector<vector<vector<uint64_t>>>& numRelsPerDirBoundLabelRelLabel, bool forColumns) {
-    for (auto& dir : DIRS) {
+    for (auto& direction : DIRECTIONS) {
         if (forColumns) {
-            if (description.isSingleCardinalityPerDir[dir]) {
-                for (auto boundNodeLabel : description.nodeLabelsPerDir[dir]) {
-                    numRelsPerDirBoundLabelRelLabel[dir][boundNodeLabel][description.label] =
-                        (*dirLabelNumRels[dir])[boundNodeLabel].load();
+            if (description.isSingleMultiplicityPerDirection[direction]) {
+                for (auto boundNodeLabel : description.nodeLabelsPerDirection[direction]) {
+                    numRelsPerDirBoundLabelRelLabel[direction][boundNodeLabel][description.label] =
+                        (*directionLabelNumRels[direction])[boundNodeLabel].load();
                 }
             }
         } else {
-            if (!description.isSingleCardinalityPerDir[dir]) {
-                for (auto boundNodeLabel : description.nodeLabelsPerDir[dir]) {
-                    numRelsPerDirBoundLabelRelLabel[dir][boundNodeLabel][description.label] =
-                        (*dirLabelNumRels[dir])[boundNodeLabel].load();
+            if (!description.isSingleMultiplicityPerDirection[direction]) {
+                for (auto boundNodeLabel : description.nodeLabelsPerDirection[direction]) {
+                    numRelsPerDirBoundLabelRelLabel[direction][boundNodeLabel][description.label] =
+                        (*directionLabelNumRels[direction])[boundNodeLabel].load();
                 }
             }
         }

--- a/src/loader/in_mem_pages.cpp
+++ b/src/loader/in_mem_pages.cpp
@@ -1,8 +1,8 @@
 #include "src/loader/include/in_mem_pages.h"
 
 #include <fcntl.h>
-#include <string.h>
 
+#include <cstring>
 #include <iostream>
 
 #include "src/common/include/file_utils.h"
@@ -11,10 +11,10 @@ namespace graphflow {
 namespace loader {
 
 void InMemPages::saveToFile() {
-    if (0 == fname.length()) {
+    if (0 == fName.length()) {
         throw invalid_argument("InMemPages: Empty filename");
     }
-    int fd = FileUtils::openFile(fname, O_WRONLY | O_CREAT);
+    int fd = FileUtils::openFile(fName, O_WRONLY | O_CREAT);
     auto size = numPages * PAGE_SIZE;
     FileUtils::writeToFile(fd, data.get(), size, 0);
     FileUtils::closeFile(fd);

--- a/src/loader/include/adj_and_prop_columns_builder.h
+++ b/src/loader/include/adj_and_prop_columns_builder.h
@@ -13,23 +13,23 @@ namespace graphflow {
 namespace loader {
 
 // This class helps RelsLoader to build AdjColumns and RelPropertyColumns for a particular rel
-// label if FWD/BWD cardinality is 1. AdjAndPropertyColumnsBuilder exposes functions to construct
-// columns step-by-step and populate in-memory pages (for AdjColumns and RelPropertyColumns) and
-// finally save the in-mem data structures to the disk.
+// label if FWD/BWD relMultiplicity is 1. AdjAndPropertyColumnsBuilder exposes functions to
+// construct columns step-by-step and populate in-memory pages (for AdjColumns and
+// RelPropertyColumns) and finally save the in-mem data structures to the disk.
 class AdjAndPropertyColumnsBuilder : public AdjAndPropertyStructuresBuilder {
 
     typedef vector<vector<unique_ptr<InMemStringOverflowPages>>> labelPropertyIdxStringOverflow_t;
     typedef vector<vector<unique_ptr<InMemPropertyPages>>> labelPropertyIdxPropertyColumn_t;
-    typedef vector<vector<unique_ptr<InMemAdjPages>>> dirLabelAdjColumn_t;
+    typedef vector<vector<unique_ptr<InMemAdjPages>>> directionLabelAdjColumn_t;
 
 public:
     // Initialize the builder and construct relevant propertyColumns and adjColumns.
     AdjAndPropertyColumnsBuilder(RelLabelDescription& description, ThreadPool& threadPool,
         const Graph& graph, const string& outputDirectory);
 
-    // Sets a neighbour nodeID of the given nodeID in a corresponding adjColumn. If dir=FWD,
+    // Sets a neighbour nodeID of the given nodeID in a corresponding adjColumn. If direction=FWD,
     // adjCol[nodeIDs[FWD]] = nodeIDs[BWD], and vice-versa.
-    void setRel(const Direction& dir, const vector<nodeID_t>& nodeIDs);
+    void setRel(Direction direction, const vector<nodeID_t>& nodeIDs);
 
     // Sets a property of a rel in RelPropertyColumn at a given nodeID.
     void setProperty(const nodeID_t& nodeID, const uint32_t& propertyIdx, const uint8_t* val,
@@ -44,7 +44,7 @@ public:
     void saveToFile() override;
 
 private:
-    void buildInMemPropertyColumns(Direction dir);
+    void buildInMemPropertyColumns(Direction direction);
     void buildInMemAdjColumns();
 
     static void calculatePageCursor(
@@ -55,12 +55,12 @@ private:
     static void sortOverflowStringsofPropertyColumnTask(node_offset_t offsetStart,
         node_offset_t offsetEnd, InMemPropertyPages* propertyColumn,
         InMemStringOverflowPages* unorderedStringOverflow,
-        InMemStringOverflowPages* orderedStringOverflow, shared_ptr<spdlog::logger> logger);
+        InMemStringOverflowPages* orderedStringOverflow);
 
 private:
-    dirLabelAdjColumn_t dirLabelAdjColumns{2};
+    directionLabelAdjColumn_t dirLabelAdjColumns{2};
 
-    unique_ptr<labelPropertyIdxStringOverflow_t> labelPropertyIdxStringOverflowPages;
+    labelPropertyIdxStringOverflow_t labelPropertyIdxStringOverflowPages;
     labelPropertyIdxPropertyColumn_t labelPropertyIdxPropertyColumn;
 };
 

--- a/src/loader/include/adj_and_prop_lists_builder.h
+++ b/src/loader/include/adj_and_prop_lists_builder.h
@@ -14,38 +14,39 @@ namespace graphflow {
 namespace loader {
 
 // This builder class helps RelsLoader to build AdjLists and RelPropertyLists for a particular rel
-// label if FWD/BWD cardinality is not 1. Similar to AdjAndPropertyColsBuilderAndListSizeCounter,
-// this also exposes functions to construct Lists step-by-step and populate in-memory pages and
-// finally save the in-mem data structures to the disk.
+// label if FWD/BWD relMultiplicity is not 1. Similar to
+// AdjAndPropertyColsBuilderAndListSizeCounter, this also exposes functions to construct Lists
+// step-by-step and populate in-memory pages and finally save the in-mem data structures to the
+// disk.
 class AdjAndPropertyListsBuilder : public AdjAndPropertyStructuresBuilder {
 
-    typedef vector<vector<unique_ptr<listSizes_t>>> dirLabelListSizes_t;
+    typedef vector<vector<unique_ptr<listSizes_t>>> directionLabelListSizes_t;
 
-    typedef vector<vector<ListHeaders>> dirLabelListHeaders_t;
+    typedef vector<vector<ListHeaders>> directionLabelListHeaders_t;
 
-    typedef vector<vector<ListsMetadata>> dirLabelAdjListsMetadata_t;
-    typedef vector<vector<unique_ptr<InMemAdjPages>>> dirLabelAdjLists_t;
+    typedef vector<vector<ListsMetadata>> directionLabelAdjListsMetadata_t;
+    typedef vector<vector<unique_ptr<InMemAdjPages>>> directionLabelAdjLists_t;
 
-    typedef vector<vector<vector<ListsMetadata>>> dirLabelPropertyIdxPropertyListsMetadata_t;
+    typedef vector<vector<vector<ListsMetadata>>> directionLabelPropertyIdxPropertyListsMetadata_t;
     typedef vector<vector<vector<unique_ptr<InMemPropertyPages>>>>
-        dirLabelPropertyIdxPropertyLists_t;
+        directionLabelPropertyIdxPropertyLists_t;
 
     typedef vector<vector<vector<unique_ptr<InMemStringOverflowPages>>>>
-        dirLabelPropertyIdxStringOverflowPages_t;
+        directionLabelPropertyIdxStringOverflowPages_t;
 
 public:
     AdjAndPropertyListsBuilder(RelLabelDescription& description, ThreadPool& threadPool,
         const Graph& graph, const string& outputDirectory);
 
-    inline void incrementListSize(const Direction& dir, const nodeID_t& nodeID) {
+    inline void incrementListSize(const Direction& direction, const nodeID_t& nodeID) {
         ListsLoaderHelper::incrementListSize(
-            *dirLabelListSizes[dir][nodeID.label], nodeID.offset, 1);
-        (*dirLabelNumRels[dir])[nodeID.label]++;
+            *directionLabelListSizes[direction][nodeID.label], nodeID.offset, 1);
+        (*directionLabelNumRels[direction])[nodeID.label]++;
     }
 
-    inline uint64_t decrementListSize(const Direction& dir, const nodeID_t& nodeID) {
+    inline uint64_t decrementListSize(const Direction& direction, const nodeID_t& nodeID) {
         return ListsLoaderHelper::decrementListSize(
-            *dirLabelListSizes[dir][nodeID.label], nodeID.offset, 1);
+            *directionLabelListSizes[direction][nodeID.label], nodeID.offset, 1);
     }
 
     // Should be called after the listSizes has been updated. Encodes the header info of each list
@@ -58,7 +59,7 @@ public:
 
     // Sets a neighbour nodeID in the adjList of the given nodeID in a particular adjLists
     // structure.
-    void setRel(const uint64_t& pos, const Direction& dir, const vector<nodeID_t>& nodeIDs);
+    void setRel(const uint64_t& pos, const Direction& direction, const vector<nodeID_t>& nodeIDs);
 
     // Sets a proeprty in the propertyList of the given nodeID in a particular RelPropertyLists
     // structure.
@@ -86,19 +87,21 @@ private:
     static void sortOverflowStringsOfPropertyListsTask(node_offset_t offsetStart,
         node_offset_t offsetEnd, InMemPropertyPages* propertyLists, ListHeaders* adjListsHeaders,
         ListsMetadata* listsMetadata, InMemStringOverflowPages* unorederedStringOverflowPages,
-        InMemStringOverflowPages* orderedStringOverflowPages, shared_ptr<spdlog::logger> logger);
+        InMemStringOverflowPages* orderedStringOverflowPages);
 
 private:
-    dirLabelListSizes_t dirLabelListSizes{2};
+    directionLabelListSizes_t directionLabelListSizes{2};
 
-    dirLabelListHeaders_t dirLabelAdjListHeaders{2};
-    dirLabelAdjListsMetadata_t dirLabelAdjListsMetadata{2};
-    dirLabelAdjLists_t dirLabelAdjLists{2};
+    directionLabelListHeaders_t directionLabelAdjListHeaders{2};
+    directionLabelAdjListsMetadata_t directionLabelAdjListsMetadata{2};
+    directionLabelAdjLists_t directionLabelAdjLists{2};
 
-    dirLabelPropertyIdxPropertyListsMetadata_t dirLabelPropertyIdxPropertyListsMetadata{2};
-    dirLabelPropertyIdxPropertyLists_t dirLabelPropertyIdxPropertyLists{2};
+    directionLabelPropertyIdxPropertyListsMetadata_t directionLabelPropertyIdxPropertyListsMetadata{
+        2};
+    directionLabelPropertyIdxPropertyLists_t directionLabelPropertyIdxPropertyLists{2};
     unique_ptr<vector<unique_ptr<InMemStringOverflowPages>>> propertyIdxUnordStringOverflowPages;
-    unique_ptr<dirLabelPropertyIdxStringOverflowPages_t> dirLabelPropertyIdxStringOverflowPages;
+    unique_ptr<directionLabelPropertyIdxStringOverflowPages_t>
+        directionLabelPropertyIdxStringOverflowPages;
 };
 
 } // namespace loader

--- a/src/loader/include/adj_and_prop_structures_builder.h
+++ b/src/loader/include/adj_and_prop_structures_builder.h
@@ -13,7 +13,7 @@ namespace loader {
 // Base class for AdjAndPropertyColumnsBuilder and AdjAndPropertyListsBuilder.
 class AdjAndPropertyStructuresBuilder {
 
-    typedef vector<unique_ptr<listSizes_t>> dirLabelNumRels_t;
+    typedef vector<unique_ptr<listSizes_t>> directionLabelNumRels_t;
 
 public:
     void populateNumRelsInfo(
@@ -27,7 +27,7 @@ public:
 
 protected:
     AdjAndPropertyStructuresBuilder(RelLabelDescription& description, ThreadPool& threadPool,
-        const Graph& graph, const string& outputDirectory);
+        const Graph& graph, string outputDirectory);
 
 protected:
     shared_ptr<spdlog::logger> logger;
@@ -37,7 +37,7 @@ protected:
     const string outputDirectory;
 
     // To count the number of rels per adjLists/adjColumn
-    dirLabelNumRels_t dirLabelNumRels{2};
+    directionLabelNumRels_t directionLabelNumRels{2};
 };
 
 } // namespace loader

--- a/src/loader/include/graph_loader.h
+++ b/src/loader/include/graph_loader.h
@@ -18,62 +18,52 @@ using namespace std;
 namespace graphflow {
 namespace loader {
 
+const string UNSTR_PROPERTY_SEPARATOR = ":";
+const string DEFAULT_METADATA_JSON_FILENAME = "metadata.json";
+const char DEFAULT_TOKEN_SEPARATOR = ',';
+
 class GraphLoader {
 
-    typedef vector<vector<unordered_set<const char*, charArrayHasher, charArrayEqualTo>>>
-        labelBlockUnstrPropertyKeys_t;
-
 public:
-    GraphLoader(const string& inputDirectory, const string& outputDirectory, uint32_t numThreads);
+    GraphLoader(string inputDirectory, string outputDirectory, uint32_t numThreads);
     ~GraphLoader();
 
     void loadGraph();
 
 private:
-    unique_ptr<nlohmann::json> readMetadata();
+    void readAndParseMetadata(vector<NodeFileDescription>& nodeFileDescriptions,
+        vector<RelFileDescription>& relFileDescriptions);
+    void readCSVHeaderAndCalcNumBlocks(const vector<string>& fileNames,
+        vector<uint64_t>& numBlocksPerFile, vector<string>& fileHeaders);
+    void addNodeLabelsIntoGraphCatalog(
+        const vector<NodeFileDescription>& fileDescriptions, vector<string>& fileHeaders);
+    void addRelLabelsIntoGraphCatalog(
+        const vector<RelFileDescription>& fileDescriptions, vector<string>& fileHeaders);
+    vector<PropertyDefinition> parseHeader(string& header) const;
 
-    void assignIdxToLabels(stringToLabelMap_t& map, const nlohmann::json& fileDescriptions);
-    void setCardinalitiesOfRelLabels(const nlohmann::json& metadata);
-    void setSrcDstNodeLabelsForRelLabels(const nlohmann::json& metadata);
+    unique_ptr<vector<unique_ptr<NodeIDMap>>> loadNodes(
+        const vector<NodeFileDescription>& nodeFileDescriptions);
 
-    void checkNodePrimaryKeyConstraints();
-    unique_ptr<vector<unique_ptr<NodeIDMap>>> loadNodes(const nlohmann::json& metadata);
+    void loadRels(const vector<RelFileDescription>& relFileDescriptions,
+        vector<unique_ptr<NodeIDMap>>& nodeIDMaps);
 
-    void loadRels(const nlohmann::json& metadata, vector<unique_ptr<NodeIDMap>>& nodeIDMaps);
-
-    void inferFnamesFromMetadataFileDesriptions(
-        label_t numLabels, nlohmann::json fileDescriptions, vector<string>& filenames);
-    vector<string> getNodePrimaryKeysFromMetadata(
-        label_t numLabels, nlohmann::json fileDescriptions);
-
-    void initPropertyKeyMapAndCalcNumBlocks(label_t numLabels, vector<string>& filenames,
-        vector<uint64_t>& numBlocksPerLabel,
-        vector<unordered_map<string, PropertyKey>>& propertyKeysMaps, const char tokenSeparator);
-
-    void initNodePropertyPrimaryKeys(vector<string>& primaryKeys);
-
-    void parseHeader(const char tokenSeparator, string& header,
-        unordered_map<string, PropertyKey>& propertyKeyMap);
-
-    void countLinesAndGetUnstrPropertyKeys(vector<vector<uint64_t>>& numLinesPerBlock,
-        labelBlockUnstrPropertyKeys_t& labelBlockUnstrPropertyKeys,
-        vector<uint64_t>& numBlocksPerLabel, const char tokenSeparator, vector<string>& fnames);
-
-    void initNodeUnstrPropertyKeyMaps(labelBlockUnstrPropertyKeys_t& labelBlockUnstrPropertyKeys);
+    void countLinesAndAddUnstrPropertiesInCatalog(vector<vector<uint64_t>>& numLinesPerBlock,
+        vector<vector<unordered_set<string>>>& labelBlockUnstrProperties,
+        vector<uint64_t>& numBlocksPerLabel, const vector<string>& filePaths);
 
     // Concurrent Tasks
 
-    static void countLinesAndScanUnstrPropertiesInBlockTask(string fname, char tokenSeparator,
-        const uint32_t numProperties,
-        unordered_set<const char*, charArrayHasher, charArrayEqualTo>* unstrPropertyKeys,
-        vector<vector<uint64_t>>* numLinesPerBlock, label_t label, uint32_t blockId,
-        shared_ptr<spdlog::logger> logger);
+    static void countLinesAndScanUnstrPropertiesInBlockTask(const string& fName,
+        char tokenSeparator, uint32_t numStructuredProperties,
+        unordered_set<string>* unstrPropertyNameSet, vector<vector<uint64_t>>* numLinesPerBlock,
+        label_t label, uint32_t blockId, const shared_ptr<spdlog::logger>& logger);
 
 private:
     shared_ptr<spdlog::logger> logger;
     ThreadPool threadPool;
     const string inputDirectory;
     const string outputDirectory;
+    char tokenSeparator;
 
     Graph graph;
 };

--- a/src/loader/include/in_mem_pages.h
+++ b/src/loader/include/in_mem_pages.h
@@ -19,7 +19,7 @@ namespace loader {
 class InMemPages {
 
 public:
-    InMemPages(const string& fname, const uint64_t& numPages) : fname{fname}, numPages{numPages} {
+    InMemPages(string fName, const uint64_t& numPages) : fName{move(fName)}, numPages{numPages} {
         auto size = numPages * PAGE_SIZE;
         data = make_unique<uint8_t[]>(size);
         fill(data.get(), data.get() + size, UINT8_MAX);
@@ -29,7 +29,7 @@ public:
 
 protected:
     unique_ptr<uint8_t[]> data;
-    const string fname;
+    const string fName;
     uint64_t numPages;
 };
 
@@ -37,9 +37,9 @@ protected:
 class InMemAdjPages : public InMemPages {
 
 public:
-    InMemAdjPages(const string& fname, const uint64_t& numPages, const uint8_t& numBytesPerLabel,
+    InMemAdjPages(const string& fName, const uint64_t& numPages, const uint8_t& numBytesPerLabel,
         const uint8_t& numBytesPerOffset)
-        : InMemPages{fname, numPages}, numBytesPerLabel{numBytesPerLabel},
+        : InMemPages{fName, numPages}, numBytesPerLabel{numBytesPerLabel},
           numBytesPerOffset(numBytesPerOffset){};
 
     void setNbrNode(const PageCursor& cursor, const nodeID_t& nbrNodeID);
@@ -53,8 +53,8 @@ protected:
 class InMemPropertyPages : public InMemPages {
 
 public:
-    InMemPropertyPages(const string& fname, uint64_t numPages, const uint8_t& numBytesPerElement)
-        : InMemPages{fname, numPages}, numBytesPerElement{numBytesPerElement} {};
+    InMemPropertyPages(const string& fName, uint64_t numPages, const uint8_t& numBytesPerElement)
+        : InMemPages{fName, numPages}, numBytesPerElement{numBytesPerElement} {};
 
     inline void setPorperty(const PageCursor& cursor, const uint8_t* val) {
         memcpy(getPtrToMemLoc(cursor), val, numBytesPerElement);
@@ -72,8 +72,8 @@ private:
 class InMemUnstrPropertyPages : public InMemPages {
 
 public:
-    InMemUnstrPropertyPages(const string& fname, uint64_t numPages)
-        : InMemPages{fname, numPages} {};
+    InMemUnstrPropertyPages(const string& fName, uint64_t numPages)
+        : InMemPages{fName, numPages} {};
 
     inline uint8_t* getPtrToMemLoc(const PageCursor& cursor) {
         return data.get() + (PAGE_SIZE * cursor.idx) + cursor.offset;
@@ -87,7 +87,7 @@ public:
 class InMemStringOverflowPages : public InMemPages {
 
 public:
-    InMemStringOverflowPages(const string& fname) : InMemPages{fname, 8} {
+    explicit InMemStringOverflowPages(const string& fName) : InMemPages{fName, 8} {
         maxPages = numPages;
         numPages = 0;
     };

--- a/src/loader/include/rels_loader.h
+++ b/src/loader/include/rels_loader.h
@@ -14,10 +14,10 @@ class RelsLoader {
     friend class GraphLoader;
 
 private:
-    RelsLoader(ThreadPool& threadPool, Graph& graph, const nlohmann::json& metadata,
-        vector<unique_ptr<NodeIDMap>>& nodeIDMaps, const string& outputDirectory);
+    RelsLoader(ThreadPool& threadPool, Graph& graph, string outputDirectory, char tokenSeparator,
+        vector<unique_ptr<NodeIDMap>>& nodeIDMaps);
 
-    void load(vector<string>& fnames, vector<uint64_t>& numBlocksPerLabel);
+    void load(const vector<string>& filePaths, vector<uint64_t>& numBlocksPerLabel);
 
     void loadRelsForLabel(RelLabelDescription& relLabelMetadata);
 
@@ -33,16 +33,16 @@ private:
     // Concurrent Tasks
 
     static void populateAdjColumnsAndCountRelsInAdjListsTask(RelLabelDescription* description,
-        uint64_t blockId, const char tokenSeparator,
+        uint64_t blockId, char tokenSeparator,
         AdjAndPropertyListsBuilder* adjAndPropertyListsBuilder,
         AdjAndPropertyColumnsBuilder* adjAndPropertyColumnsBuilder,
         vector<unique_ptr<NodeIDMap>>* nodeIDMaps, const Catalog* catalog,
-        shared_ptr<spdlog::logger> logger);
+        shared_ptr<spdlog::logger>& logger);
 
     static void populateAdjListsTask(RelLabelDescription* description, uint64_t blockId,
-        const char tokenSeparator, AdjAndPropertyListsBuilder* adjAndPropertyListsBuilder,
+        char tokenSeparator, AdjAndPropertyListsBuilder* adjAndPropertyListsBuilder,
         vector<unique_ptr<NodeIDMap>>* nodeIDMaps, const Catalog* catalog,
-        shared_ptr<spdlog::logger> logger);
+        shared_ptr<spdlog::logger>& logger);
 
     // Task Helpers
 
@@ -50,23 +50,22 @@ private:
         vector<unique_ptr<NodeIDMap>>* nodeIDMaps, const Catalog* catalog,
         vector<bool>& requireToReadLabels);
 
-    static void putPropsOfLineIntoInMemPropertyColumns(const vector<DataType>& propertyDataTypes,
+    static void putPropsOfLineIntoInMemPropertyColumns(const vector<PropertyDefinition>& properties,
         CSVReader& reader, AdjAndPropertyColumnsBuilder* adjAndPropertyColumnsBuilder,
-        const nodeID_t& nodeID, vector<PageCursor>& stringOvreflowPagesCursors,
-        shared_ptr<spdlog::logger> logger);
+        const nodeID_t& nodeID, vector<PageCursor>& stringOverflowPagesCursors);
 
-    static void putPropsOfLineIntoInMemRelPropLists(const vector<DataType>& propertyDataTypes,
+    static void putPropsOfLineIntoInMemRelPropLists(const vector<PropertyDefinition>& properties,
         CSVReader& reader, const vector<nodeID_t>& nodeIDs, const vector<uint64_t>& pos,
         AdjAndPropertyListsBuilder* adjAndPropertyListsBuilder,
-        vector<PageCursor>& stringOvreflowPagesCursors, shared_ptr<spdlog::logger> logger);
+        vector<PageCursor>& stringOverflowPagesCursors);
 
 private:
     shared_ptr<spdlog::logger> logger;
     ThreadPool& threadPool;
     Graph& graph;
-    const nlohmann::json& metadata;
-    vector<unique_ptr<NodeIDMap>>& nodeIDMaps;
     const string outputDirectory;
+    const char tokenSeparator;
+    vector<unique_ptr<NodeIDMap>>& nodeIDMaps;
 };
 
 } // namespace loader

--- a/src/loader/utils.cpp
+++ b/src/loader/utils.cpp
@@ -30,26 +30,9 @@ node_offset_t NodeIDMap::get(const char* nodeID) {
     return nodeIDToOffsetMap.at(nodeID);
 }
 
-vector<DataType> createPropertyDataTypesArray(
-    const unordered_map<string, PropertyKey>& propertyMap) {
-    vector<DataType> propertyDataTypes{propertyMap.size()};
-    for (auto property = propertyMap.begin(); property != propertyMap.end(); property++) {
-        propertyDataTypes[property->second.idx] = property->second.dataType;
-    }
-    return propertyDataTypes;
-}
-
-vector<bool> getPropertyIsPrimaryKeys(const unordered_map<string, PropertyKey>& propertyMap) {
-    vector<bool> isPrimaryKeys(propertyMap.size());
-    for (auto& property : propertyMap) {
-        isPrimaryKeys[property.second.idx] = property.second.isPrimaryKey;
-    }
-    return isPrimaryKeys;
-}
-
 void ListsLoaderHelper::calculateListHeadersTask(node_offset_t numNodeOffsets,
     uint32_t numElementsPerPage, listSizes_t* listSizes, ListHeaders* listHeaders,
-    shared_ptr<spdlog::logger> logger) {
+    const shared_ptr<spdlog::logger>& logger) {
     logger->trace("Start: ListHeaders={0:p}", (void*)listHeaders);
     auto numChunks = numNodeOffsets / BaseLists::LISTS_CHUNK_SIZE;
     if (0 != numNodeOffsets % BaseLists::LISTS_CHUNK_SIZE) {
@@ -78,7 +61,7 @@ void ListsLoaderHelper::calculateListHeadersTask(node_offset_t numNodeOffsets,
 
 void ListsLoaderHelper::calculateListsMetadataTask(uint64_t numNodeOffsets, uint32_t numPerPage,
     listSizes_t* listSizes, ListHeaders* listHeaders, ListsMetadata* listsMetadata,
-    shared_ptr<spdlog::logger> logger) {
+    const shared_ptr<spdlog::logger>& logger) {
     logger->trace("Start: listsMetadata={0:p} adjListHeaders={1:p}", (void*)listsMetadata,
         (void*)listHeaders);
     auto globalPageId = 0u;

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -25,9 +25,9 @@ public:
 
 public:
     unordered_set<string> variables;
-    // For flat factorization group, we store cardinality of the sub-query that contains variables
-    // in flat factorization group. Otherwise, for unflat factorization group, we store the
-    // extension rate per flat prefix.
+    // For flat factorization group, we store relMultiplicity of the sub-query that contains
+    // variables in flat factorization group. Otherwise, for unflat factorization group, we store
+    // the extension rate per flat prefix.
     uint64_t cardinalityOrExtensionRate;
 };
 

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -10,8 +10,8 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "//src/common:utils",
         "//src/common:configs",
+        "//src/common:utils",
         "@gabime_spdlog",
     ],
 )
@@ -82,8 +82,8 @@ cc_library(
     deps = [
         "buffer_manager",
         "lists_aux",
+        "//src/common:profiler",
         "//src/common:vector",
-        "//src/common:profiler"
     ],
 )
 
@@ -107,10 +107,10 @@ cc_library(
 cc_library(
     name = "catalog",
     srcs = [
-        "catalog.cpp"
+        "catalog.cpp",
     ],
     hdrs = [
-        "include/catalog.h"
+        "include/catalog.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -148,10 +148,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "buffer_manager",
+        "//src/common:memory_manager",
         "//src/common:types",
         "//src/common:vector",
         "//src/common:vector_operations",
-        "//src/common:memory_manager",
     ],
 )
-

--- a/src/storage/data_structure/lists/lists_metadata.cpp
+++ b/src/storage/data_structure/lists/lists_metadata.cpp
@@ -1,7 +1,5 @@
 #include "src/storage/include/data_structure/lists/lists_metadata.h"
 
-#include <fstream>
-
 #include "spdlog/spdlog.h"
 
 namespace graphflow {
@@ -127,7 +125,7 @@ uint32_t ListsMetadata::enumeratePageIdsInAPageList(unique_ptr<uint32_t[]>& page
         numPageListGroups++;
     }
     // During the initial allocation, we allocate all the pageListGroups of a pageList contiguously.
-    // pageListTailIdx is the idx in the pageLists blob where the pageList ends and the next
+    // pageListTailIdx is the id in the pageLists blob where the pageList ends and the next
     // pageLists should start.
     auto pageListTailIdx = pageListHeadIdx + ((PAGE_LIST_GROUP_SIZE + 1) * numPageListGroups);
     increasePageListsCapacityIfNeeded(pageLists, pageListsCapacity, pageListTailIdx);
@@ -142,7 +140,7 @@ uint32_t ListsMetadata::enumeratePageIdsInAPageList(unique_ptr<uint32_t[]>& page
         }
         numPages -= numPagesInThisGroup;
         pageListHeadIdx += PAGE_LIST_GROUP_SIZE;
-        // store the idx to the next pageListGroup, if exists, other -1.
+        // store the id to the next pageListGroup, if exists, other -1.
         pageLists[pageListHeadIdx] = (0 == numPages) ? -1 : 1 + pageListHeadIdx;
         pageListHeadIdx++;
     }

--- a/src/storage/graph.cpp
+++ b/src/storage/graph.cpp
@@ -45,7 +45,7 @@ void Graph::serialize(S& s) {
     s.container(numRelsPerDirBoundLabelRelLabel, UINT32_MAX, vectorSerFunc);
 }
 
-void Graph::saveToFile(const string& path) {
+void Graph::saveToFile(const string& path) const {
     auto graphPath = path + "/graph.bin";
     fstream f{graphPath, f.binary | f.trunc | f.out};
     if (f.fail()) {
@@ -77,7 +77,7 @@ unique_ptr<nlohmann::json> Graph::debugInfo() {
     auto json = catalog->debugInfo();
     (*json)["path"] = getPath();
     for (uint64_t labelIdx = 0; labelIdx < numNodesPerLabel.size(); ++labelIdx) {
-        (*json)["NodeLabelSizes"][catalog->getStringNodeLabel(labelIdx)]["numNodes"] =
+        (*json)["NodeLabelSizes"][catalog->getNodeLabelName(labelIdx)]["numNodes"] =
             to_string(numNodesPerLabel.at(labelIdx));
     }
     return json;

--- a/src/storage/include/data_structure/column.h
+++ b/src/storage/include/data_structure/column.h
@@ -46,7 +46,7 @@ class Column<STRING> : public BaseColumn {
 public:
     Column(const string& path, const uint64_t& numElements, BufferManager& bufferManager)
         : BaseColumn{path, STRING, sizeof(gf_string_t), numElements, bufferManager},
-          overflowPagesFileHandle{path + ".ovf", O_RDWR} {};
+          overflowPagesFileHandle{path + OVERFLOW_FILE_SUFFIX, O_RDWR} {};
 
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,

--- a/src/storage/include/data_structure/data_structure.h
+++ b/src/storage/include/data_structure/data_structure.h
@@ -12,6 +12,8 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace storage {
 
+const string OVERFLOW_FILE_SUFFIX = ".ovf";
+
 // DataStructure is the parent class of BaseColumn and BaseLists. It abstracts the state and
 // functions that are common in both column and lists, like, 1) layout info (size of a unit of
 // element and number of elements that can be accomodated in a page), 2) getting pageIdx and

--- a/src/storage/include/data_structure/lists/lists.h
+++ b/src/storage/include/data_structure/lists/lists.h
@@ -70,21 +70,22 @@ private:
     NodeIDCompressionScheme nodeIDCompressionScheme;
 };
 
-// Lists<UNKNOWN> is the specialization of Lists<D> for Node's unstructured PropertyLists. Though is
-// shares the identical representation as BaseLists, it is more aligned to Columns in terms of
-// access. In particular, readValues(...) of Lists<UNKNOWN> is given a NodeVector as input, similar
-// to readValues() in Columns. For each node in NodeVector, unstructured property list of that node
-// is read and the reqired property alongwith its dataType is copied to a specialized UNKNOWN-typed
-// ValueVector.
+// Lists<UNSTRUCTURED> is the specialization of Lists<D> for Node's unstructured PropertyLists.
+// Though this shares the identical representation as BaseLists, it is more aligned to Columns in
+// terms of access. In particular, readValues(...) of Lists<UNSTRUCTURED> is given a NodeVector as
+// input, similar to readValues() in Columns. For each node in NodeVector, unstructured property
+// list of that node is read and the reqired property alongwith its dataType is copied to a
+// specialized UNSTRUCTURED-typed ValueVector.
 template<>
 class Lists<UNSTRUCTURED> : public BaseLists {
 
 public:
     Lists(const string& fname, BufferManager& bufferManager)
         : BaseLists{fname, UNSTRUCTURED, 1, make_shared<ListHeaders>(fname), bufferManager},
-          overflowPagesFileHandle{fname + ".ovf", O_RDWR} {};
+          overflowPagesFileHandle{fname + OVERFLOW_FILE_SUFFIX, O_RDWR} {};
 
-    // readValues is overloaded. Lists<UNKNOWN> is not supposed to use the one defined in BaseLists.
+    // readValues is overloaded. Lists<UNSTRUCTURED> is not supposed to use the one defined in
+    // BaseLists.
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector, uint32_t propertyKeyIdxToRead,
         const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
         BufferManagerMetrics& metrics);

--- a/src/storage/include/data_structure/lists/lists_metadata.h
+++ b/src/storage/include/data_structure/lists/lists_metadata.h
@@ -62,7 +62,7 @@ private:
     void saveToDisk(const string& fname);
     void readFromDisk(const string& fname);
 
-    uint64_t getPageIdxFromAPageList(
+    static uint64_t getPageIdxFromAPageList(
         unique_ptr<uint32_t[]>& pageLists, uint32_t pageListHead, uint32_t pageIdx);
 
     // Below functions are to be used only in the loader to create the ListsMetadata object
@@ -81,11 +81,11 @@ private:
 
     // Creates a new pageList (in pageListGropus of size 3) by enumerating the pageIds sequentially
     // in the list, starting from `startPageId` till `startPageId + numPages - 1`.
-    uint32_t enumeratePageIdsInAPageList(unique_ptr<uint32_t[]>& pageLists,
+    static uint32_t enumeratePageIdsInAPageList(unique_ptr<uint32_t[]>& pageLists,
         uint64_t& pageListsCapacity, uint32_t pageListHead, uint32_t numPages,
         uint32_t startPageId);
 
-    void increasePageListsCapacityIfNeeded(
+    static void increasePageListsCapacityIfNeeded(
         unique_ptr<uint32_t[]>& pageLists, uint64_t& pageListsCapacity, uint32_t requiredCapacity);
 
 private:
@@ -135,10 +135,6 @@ private:
     // pages used by all chunks and large lists.
     uint32_t numPages;
 };
-
-void saveListOfIntsToFile(const string& path, unique_ptr<uint32_t[]>& data, uint32_t listSize);
-
-uint32_t readListOfIntsFromFile(unique_ptr<uint32_t[]>& data, const string& path);
 
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/include/graph.h
+++ b/src/storage/include/graph.h
@@ -3,6 +3,16 @@
 #include <iostream>
 #include <vector>
 
+#include "bitsery/adapter/stream.h"
+#include "bitsery/bitsery.h"
+#include "bitsery/ext/std_map.h"
+#include "bitsery/traits/string.h"
+#include "bitsery/traits/vector.h"
+#include <bitsery/brief_syntax.h>
+#include <bitsery/brief_syntax/string.h>
+#include <bitsery/ext/pointer.h>
+#include <bitsery/ext/std_map.h>
+
 #include "src/storage/include/store/nodes_store.h"
 #include "src/storage/include/store/rels_store.h"
 
@@ -34,7 +44,7 @@ public:
 
     virtual ~Graph();
 
-    virtual inline const Catalog& getCatalog() const { return *catalog; }
+    virtual inline Catalog& getCatalog() const { return *catalog; }
 
     inline const RelsStore& getRelsStore() const { return *relsStore; }
 
@@ -60,7 +70,7 @@ private:
     template<typename S>
     void serialize(S& s);
 
-    void saveToFile(const string& directory);
+    void saveToFile(const string& directory) const;
     void readFromFile(const string& directory);
 
 private:

--- a/src/storage/include/store/nodes_store.h
+++ b/src/storage/include/store/nodes_store.h
@@ -39,11 +39,9 @@ public:
     }
 
 private:
-    void initPropertyColumns(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
-        const string& directory, BufferManager& bufferManager);
-
-    void initUnstrPropertyLists(
-        const Catalog& catalog, const string& directory, BufferManager& bufferManager);
+    void initPropertyColumnsAndLists(const Catalog& catalog,
+        const vector<uint64_t>& numNodesPerLabel, const string& directory,
+        BufferManager& bufferManager);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/include/store/rels_store.h
+++ b/src/storage/include/store/rels_store.h
@@ -38,31 +38,31 @@ public:
         return adjLists[direction][nodeLabel][relLabel].get();
     }
 
-    inline static string getAdjColumnFname(const string& directory, const label_t& relLabel,
+    inline static string getAdjColumnFName(const string& directory, const label_t& relLabel,
         const label_t& nodeLabel, const Direction& direction) {
         return FileUtils::joinPath(directory, "r-" + to_string(relLabel) + "-" +
                                                   to_string(nodeLabel) + "-" +
                                                   to_string(direction) + ".col");
     }
 
-    inline static string getAdjListsFname(const string& directory, const label_t& relLabel,
+    inline static string getAdjListsFName(const string& directory, const label_t& relLabel,
         const label_t& nodeLabel, const Direction& direction) {
         return FileUtils::joinPath(directory, "r-" + to_string(relLabel) + "-" +
                                                   to_string(nodeLabel) + "-" +
                                                   to_string(direction) + ".lists");
     }
 
-    inline static string getRelPropertyColumnFname(const string& directory, const label_t& relLabel,
+    inline static string getRelPropertyColumnFName(const string& directory, const label_t& relLabel,
         const label_t& nodeLabel, const string& propertyName) {
         return FileUtils::joinPath(directory,
             "r-" + to_string(relLabel) + "-" + to_string(nodeLabel) + "-" + propertyName + ".col");
     }
 
-    inline static string getRelPropertyListsFname(const string& directory, const label_t& relLabel,
-        const label_t& nodeLabel, const Direction& dir, const string& propertyName) {
-        return FileUtils::joinPath(directory, "r-" + to_string(relLabel) + "-" +
-                                                  to_string(nodeLabel) + "-" + to_string(dir) +
-                                                  "-" + propertyName + ".lists");
+    inline static string getRelPropertyListsFName(const string& directory, const label_t& relLabel,
+        const label_t& nodeLabel, const Direction& direction, const string& propertyName) {
+        return FileUtils::joinPath(
+            directory, "r-" + to_string(relLabel) + "-" + to_string(nodeLabel) + "-" +
+                           to_string(direction) + "-" + propertyName + ".lists");
     }
 
 private:
@@ -78,7 +78,7 @@ private:
 
     void initPropertyColumnsForRelLabel(const Catalog& catalog,
         const vector<uint64_t>& numNodesPerLabel, const string& directory,
-        BufferManager& bufferManager, const label_t& relLabel, const Direction& dir);
+        BufferManager& bufferManager, const label_t& relLabel, const Direction& direction);
 
     void initPropertyListsForRelLabel(const Catalog& catalog,
         const vector<uint64_t>& numNodesPerLabel, const string& directory,

--- a/src/storage/store/rels_store.cpp
+++ b/src/storage/store/rels_store.cpp
@@ -18,51 +18,55 @@ RelsStore::RelsStore(const Catalog& catalog, const vector<uint64_t>& numNodesPer
 void RelsStore::initAdjColumns(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
     const string& directory, BufferManager& bufferManager) {
     logger->info("Initializing AdjColumns.");
-    for (auto dir : DIRS) {
-        adjColumns[dir].resize(catalog.getNodeLabelsCount());
-        for (auto nodeLabel = 0u; nodeLabel < catalog.getNodeLabelsCount(); nodeLabel++) {
-            adjColumns[dir][nodeLabel].resize(catalog.getRelLabelsCount());
-            for (auto relLabel : catalog.getRelLabelsForNodeLabelDirection(nodeLabel, dir)) {
-                if (catalog.isSingleCaridinalityInDir(relLabel, dir)) {
+    for (auto direction : DIRECTIONS) {
+        auto numNodeLabels = catalog.getNodeLabelsCount();
+        auto numRelLabels = catalog.getRelLabelsCount();
+        adjColumns[direction].resize(numNodeLabels);
+        for (auto nodeLabel = 0u; nodeLabel < numNodeLabels; nodeLabel++) {
+            adjColumns[direction][nodeLabel].resize(numRelLabels);
+            for (auto relLabel : catalog.getRelLabelsForNodeLabelDirection(nodeLabel, direction)) {
+                if (catalog.isSingleMultiplicityInDirection(relLabel, direction)) {
                     NodeIDCompressionScheme nodeIDCompressionScheme{
-                        catalog.getNodeLabelsForRelLabelDir(relLabel, !dir), numNodesPerLabel,
-                        catalog.getNodeLabelsCount()};
-                    logger->debug("DIR {} nodeLabel {} relLabel {} compressionScheme {},{}", dir,
-                        nodeLabel, relLabel, nodeIDCompressionScheme.getNumBytesForLabel(),
+                        catalog.getNodeLabelsForRelLabelDirection(relLabel, !direction),
+                        numNodesPerLabel, numNodeLabels};
+                    logger->debug("DIRECTION {} nodeLabel {} relLabel {} compressionScheme {},{}",
+                        direction, nodeLabel, relLabel,
+                        nodeIDCompressionScheme.getNumBytesForLabel(),
                         nodeIDCompressionScheme.getNumBytesForOffset());
-                    auto fname = getAdjColumnFname(directory, relLabel, nodeLabel, dir);
-                    adjColumns[dir][nodeLabel][relLabel] = make_unique<AdjColumn>(
-                        fname, numNodesPerLabel[nodeLabel], bufferManager, nodeIDCompressionScheme);
+                    auto fName = getAdjColumnFName(directory, relLabel, nodeLabel, direction);
+                    adjColumns[direction][nodeLabel][relLabel] = make_unique<AdjColumn>(
+                        fName, numNodesPerLabel[nodeLabel], bufferManager, nodeIDCompressionScheme);
                 }
             }
         }
     }
-    logger->info("Done.");
+    logger->info("Initializing AdjColumns done.");
 }
 
 void RelsStore::initAdjLists(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
     const string& directory, BufferManager& bufferManager) {
     logger->info("Initializing AdjLists.");
-    for (auto dir : DIRS) {
-        adjLists[dir].resize(catalog.getNodeLabelsCount());
+    for (auto direction : DIRECTIONS) {
+        adjLists[direction].resize(catalog.getNodeLabelsCount());
         for (auto nodeLabel = 0u; nodeLabel < catalog.getNodeLabelsCount(); nodeLabel++) {
-            adjLists[dir][nodeLabel].resize(catalog.getRelLabelsCount());
-            for (auto relLabel : catalog.getRelLabelsForNodeLabelDirection(nodeLabel, dir)) {
-                if (!catalog.isSingleCaridinalityInDir(relLabel, dir)) {
+            adjLists[direction][nodeLabel].resize(catalog.getRelLabelsCount());
+            for (auto relLabel : catalog.getRelLabelsForNodeLabelDirection(nodeLabel, direction)) {
+                if (!catalog.isSingleMultiplicityInDirection(relLabel, direction)) {
                     NodeIDCompressionScheme nodeIDCompressionScheme{
-                        catalog.getNodeLabelsForRelLabelDir(relLabel, !dir), numNodesPerLabel,
-                        catalog.getNodeLabelsCount()};
-                    logger->debug("DIR {} nodeLabel {} relLabel {} compressionScheme {},{}", dir,
-                        nodeLabel, relLabel, nodeIDCompressionScheme.getNumBytesForLabel(),
+                        catalog.getNodeLabelsForRelLabelDirection(relLabel, !direction),
+                        numNodesPerLabel, catalog.getNodeLabelsCount()};
+                    logger->debug("DIRECTION {} nodeLabel {} relLabel {} compressionScheme {},{}",
+                        direction, nodeLabel, relLabel,
+                        nodeIDCompressionScheme.getNumBytesForLabel(),
                         nodeIDCompressionScheme.getNumBytesForOffset());
-                    auto fname = getAdjListsFname(directory, relLabel, nodeLabel, dir);
-                    adjLists[dir][nodeLabel][relLabel] =
+                    auto fname = getAdjListsFName(directory, relLabel, nodeLabel, direction);
+                    adjLists[direction][nodeLabel][relLabel] =
                         make_unique<AdjLists>(fname, bufferManager, nodeIDCompressionScheme);
                 }
             }
         }
     }
-    logger->info("Done.");
+    logger->info("Initializing AdjLists done.");
 }
 
 void RelsStore::initPropertyListsAndColumns(const Catalog& catalog,
@@ -78,11 +82,11 @@ void RelsStore::initPropertyListsAndColumns(const Catalog& catalog,
         propertyLists[BWD][nodeLabel].resize(catalog.getRelLabelsCount());
     }
     for (auto relLabel = 0u; relLabel < catalog.getRelLabelsCount(); relLabel++) {
-        if (0 != catalog.getPropertyKeyMapForRelLabel(relLabel).size()) {
-            if (catalog.isSingleCaridinalityInDir(relLabel, FWD)) {
+        if (!catalog.getRelProperties(relLabel).empty()) {
+            if (catalog.isSingleMultiplicityInDirection(relLabel, FWD)) {
                 initPropertyColumnsForRelLabel(
                     catalog, numNodesPerLabel, directory, bufferManager, relLabel, FWD);
-            } else if (catalog.isSingleCaridinalityInDir(relLabel, BWD)) {
+            } else if (catalog.isSingleMultiplicityInDirection(relLabel, BWD)) {
                 initPropertyColumnsForRelLabel(
                     catalog, numNodesPerLabel, directory, bufferManager, relLabel, BWD);
             } else {
@@ -91,85 +95,85 @@ void RelsStore::initPropertyListsAndColumns(const Catalog& catalog,
             }
         }
     }
-    logger->info("Done.");
+    logger->info("Initializing PropertyLists and PropertyColumns Done.");
 }
 
 void RelsStore::initPropertyColumnsForRelLabel(const Catalog& catalog,
     const vector<uint64_t>& numNodesPerLabel, const string& directory, BufferManager& bufferManager,
     const label_t& relLabel, const Direction& dir) {
     logger->debug("Initializing PropertyColumns: relLabel {}", relLabel);
-    for (auto& nodeLabel : catalog.getNodeLabelsForRelLabelDir(relLabel, dir)) {
-        auto& propertyMap = catalog.getPropertyKeyMapForRelLabel(relLabel);
-        propertyColumns[nodeLabel][relLabel].resize(propertyMap.size());
-        for (auto property = propertyMap.begin(); property != propertyMap.end(); property++) {
-            auto idx = property->second.idx;
-            auto fname = getRelPropertyColumnFname(directory, relLabel, nodeLabel, property->first);
+    for (auto& nodeLabel : catalog.getNodeLabelsForRelLabelDirection(relLabel, dir)) {
+        auto& properties = catalog.getRelProperties(relLabel);
+        propertyColumns[nodeLabel][relLabel].resize(properties.size());
+        for (auto& property : properties) {
+            auto fname = getRelPropertyColumnFName(directory, relLabel, nodeLabel, property.name);
             logger->debug("DIR {} nodeLabel {} propertyIdx {} type {} name `{}`", dir, nodeLabel,
-                idx, property->second.dataType, property->first);
-            switch (property->second.dataType) {
+                property.id, property.dataType, property.name);
+            switch (property.dataType) {
             case INT32:
-                propertyColumns[nodeLabel][relLabel][idx] = make_unique<PropertyColumnInt>(
+                propertyColumns[nodeLabel][relLabel][property.id] = make_unique<PropertyColumnInt>(
                     fname, numNodesPerLabel[nodeLabel], bufferManager);
                 break;
             case DOUBLE:
-                propertyColumns[nodeLabel][relLabel][idx] = make_unique<PropertyColumnDouble>(
-                    fname, numNodesPerLabel[nodeLabel], bufferManager);
+                propertyColumns[nodeLabel][relLabel][property.id] =
+                    make_unique<PropertyColumnDouble>(
+                        fname, numNodesPerLabel[nodeLabel], bufferManager);
                 break;
             case BOOL:
-                propertyColumns[nodeLabel][relLabel][idx] = make_unique<PropertyColumnBool>(
+                propertyColumns[nodeLabel][relLabel][property.id] = make_unique<PropertyColumnBool>(
                     fname, numNodesPerLabel[nodeLabel], bufferManager);
                 break;
             case STRING:
-                propertyColumns[nodeLabel][relLabel][idx] = make_unique<PropertyColumnString>(
-                    fname, numNodesPerLabel[nodeLabel], bufferManager);
+                propertyColumns[nodeLabel][relLabel][property.id] =
+                    make_unique<PropertyColumnString>(
+                        fname, numNodesPerLabel[nodeLabel], bufferManager);
                 break;
             default:
-                throw invalid_argument("invalid type for property list creation.");
+                throw invalid_argument("Invalid type for property column creation.");
             }
         }
     }
-    logger->debug("Done.");
+    logger->debug("Initializing PropertyColumns done.");
 }
 
 void RelsStore::initPropertyListsForRelLabel(const Catalog& catalog,
     const vector<uint64_t>& numNodesPerLabel, const string& directory, BufferManager& bufferManager,
     const label_t& relLabel) {
     logger->debug("Initializing PropertyLists: relLabel {}", relLabel);
-    for (auto& dir : DIRS) {
-        for (auto& nodeLabel : catalog.getNodeLabelsForRelLabelDir(relLabel, dir)) {
-            auto& propertyMap = catalog.getPropertyKeyMapForRelLabel(relLabel);
-            propertyLists[dir][nodeLabel][relLabel].resize(propertyMap.size());
+    for (auto& dir : DIRECTIONS) {
+        for (auto& nodeLabel : catalog.getNodeLabelsForRelLabelDirection(relLabel, dir)) {
+            auto& properties = catalog.getRelProperties(relLabel);
+            propertyLists[dir][nodeLabel][relLabel].resize(properties.size());
             auto adjListsHeaders = adjLists[dir][nodeLabel][relLabel]->getHeaders();
-            for (auto property = propertyMap.begin(); property != propertyMap.end(); property++) {
+            for (auto& property : properties) {
                 auto fname =
-                    getRelPropertyListsFname(directory, relLabel, nodeLabel, dir, property->first);
-                auto idx = property->second.idx;
+                    getRelPropertyListsFName(directory, relLabel, nodeLabel, dir, property.name);
                 logger->debug("DIR {} nodeLabel {} propertyIdx {} type {} name `{}`", dir,
-                    nodeLabel, idx, property->second.dataType, property->first);
-                switch (property->second.dataType) {
+                    nodeLabel, property.id, property.dataType, property.name);
+                switch (property.dataType) {
                 case INT32:
-                    propertyLists[dir][nodeLabel][relLabel][idx] =
+                    propertyLists[dir][nodeLabel][relLabel][property.id] =
                         make_unique<RelPropertyListsInt>(fname, adjListsHeaders, bufferManager);
                     break;
                 case DOUBLE:
-                    propertyLists[dir][nodeLabel][relLabel][idx] =
+                    propertyLists[dir][nodeLabel][relLabel][property.id] =
                         make_unique<RelPropertyListsDouble>(fname, adjListsHeaders, bufferManager);
                     break;
                 case BOOL:
-                    propertyLists[dir][nodeLabel][relLabel][idx] =
+                    propertyLists[dir][nodeLabel][relLabel][property.id] =
                         make_unique<RelPropertyListsBool>(fname, adjListsHeaders, bufferManager);
                     break;
                 case STRING:
-                    propertyLists[dir][nodeLabel][relLabel][idx] =
+                    propertyLists[dir][nodeLabel][relLabel][property.id] =
                         make_unique<RelPropertyListsString>(fname, adjListsHeaders, bufferManager);
                     break;
                 default:
-                    throw invalid_argument("invalid type for property list creation.");
+                    throw invalid_argument("Invalid type for property list creation.");
                 }
             }
         }
     }
-    logger->debug("Done.");
+    logger->debug("Initializing PropertyLists done.");
 }
 
 } // namespace storage

--- a/test/mock/mock_catalog.h
+++ b/test/mock/mock_catalog.h
@@ -13,28 +13,22 @@ using namespace graphflow::storage;
 class MockCatalog : public Catalog {
 
 public:
-    MOCK_METHOD(bool, containNodeLabel, (const char* label), (const, override));
-    MOCK_METHOD(label_t, getNodeLabelFromString, (const char* label), (const, override));
-    MOCK_METHOD(bool, containRelLabel, (const char* label), (const, override));
-    MOCK_METHOD(label_t, getRelLabelFromString, (const char* label), (const, override));
-    MOCK_METHOD(const vector<label_t>&, getRelLabelsForNodeLabelDirection,
-        (label_t nodeLabel, Direction dir), (const, override));
-    MOCK_METHOD(bool, containNodeProperty, (label_t nodeLabel, const string& propertyName),
+    MOCK_METHOD(bool, containNodeProperty, (label_t labelId, const string& propertyName),
         (const, override));
-    MOCK_METHOD(DataType, getNodePropertyTypeFromString,
-        (label_t nodeLabel, const string& propertyName), (const, override));
-    MOCK_METHOD(uint32_t, getNodePropertyKeyFromString,
-        (label_t nodeLabel, const string& propertyName), (const, override));
-    MOCK_METHOD(bool, containUnstrNodeProperty, (label_t nodeLabel, const string& propertyName),
-        (const, override));
-    MOCK_METHOD(bool, containRelProperty, (label_t relLabel, const string& propertyName),
-        (const, override));
-    MOCK_METHOD(DataType, getRelPropertyTypeFromString,
-        (label_t relLabel, const string& propertyName), (const, override));
-    MOCK_METHOD(uint32_t, getRelPropertyKeyFromString,
-        (label_t relLabel, const string& propertyName), (const, override));
     MOCK_METHOD(
-        bool, isSingleCaridinalityInDir, (label_t relLabel, Direction dir), (const, override));
+        bool, containRelProperty, (label_t labelId, const string& propertyName), (const, override));
+    MOCK_METHOD(const PropertyDefinition&, getNodeProperty,
+        (label_t labelId, const string& propertyName), (const, override));
+    MOCK_METHOD(const PropertyDefinition&, getRelProperty,
+        (label_t labelId, const string& propertyName), (const, override));
+    MOCK_METHOD(const unordered_set<label_t>&, getRelLabelsForNodeLabelDirection,
+        (label_t nodeLabel, Direction direction), (const, override));
+    MOCK_METHOD(bool, isSingleMultiplicityInDirection, (label_t relLabel, Direction direction),
+        (const, override));
+    MOCK_METHOD(bool, containNodeLabel, (const string& label), (const, override));
+    MOCK_METHOD(bool, containRelLabel, (const string& label), (const, override));
+    MOCK_METHOD(label_t, getRelLabelFromString, (const char* label), (const, override));
+    MOCK_METHOD(label_t, getNodeLabelFromString, (const char* label), (const, override));
 };
 
 /**
@@ -49,43 +43,46 @@ public:
     void setUp() {
         setSrcNodeLabelToRelLabels();
         setDstNodeLabelToRelLabels();
+        setProperties();
 
-        setActionForContainNodeLabel();
-        setActionForGetNodeLabelFromString();
-        setActionForContainRelLabel();
-        setActionForGetRelLabelFromString();
-        setActionForGetRelLabelsForNodeLabelDirection();
         setActionForContainNodeProperty();
-        setActionForGetNodePropertyTypeFromString();
-        setActionForGetNodePropertyKeyFromString();
-        setActionForContainUnstrNodeProperty();
         setActionForContainRelProperty();
-        setActionForGetRelPropertyTypeFromString();
-        setActionForGetRelPropertyKeyFromString();
-        setActionForIsSingleCardinalityInDir();
+        secActionForGetNodeProperty();
+        secActionForGetRelProperty();
+        setActionForGetRelLabelsForNodeLabelDirection();
+        setActionForIsSingleMultiplicityInDirection();
+        setActionForContainNodeLabel();
+        setActionForContainRelLabel();
+        setActionForGetNodeLabelFromString();
+        setActionForGetRelLabelFromString();
     }
 
 private:
-    void setActionForContainNodeLabel() {
-        ON_CALL(*this, containNodeLabel(_)).WillByDefault(Return(false));
-        ON_CALL(*this, containNodeLabel(StrEq("person"))).WillByDefault(Return(true));
-        ON_CALL(*this, containNodeLabel(StrEq("organisation"))).WillByDefault(Return(true));
+    void setActionForContainNodeProperty() {
+        ON_CALL(*this, containNodeProperty(_, _))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, containNodeProperty(0, _)).WillByDefault(Return(false));
+        ON_CALL(*this, containNodeProperty(0, "age")).WillByDefault(Return(true));
+        ON_CALL(*this, containNodeProperty(0, "name")).WillByDefault(Return(true));
+        ON_CALL(*this, containNodeProperty(1, _)).WillByDefault(Return(false));
     }
 
-    void setActionForGetNodeLabelFromString() {
-        ON_CALL(*this, getNodeLabelFromString(StrEq("person"))).WillByDefault(Return(0));
-        ON_CALL(*this, getNodeLabelFromString(StrEq("workAt"))).WillByDefault(Return(1));
+    void setActionForContainRelProperty() {
+        ON_CALL(*this, containRelProperty(_, _))
+            .WillByDefault(Throw(invalid_argument("Should never happen.")));
+        ON_CALL(*this, containRelProperty(0, _)).WillByDefault(Return(false));
+        ON_CALL(*this, containRelProperty(0, "description")).WillByDefault(Return(true));
+        ON_CALL(*this, containRelProperty(1, _)).WillByDefault(Return(false));
     }
 
-    void setActionForContainRelLabel() {
-        ON_CALL(*this, containRelLabel(_)).WillByDefault(Return(false));
-        ON_CALL(*this, containRelLabel(StrEq("knows"))).WillByDefault(Return(true));
-        ON_CALL(*this, containRelLabel(StrEq("workAt"))).WillByDefault(Return(true));
+    void secActionForGetNodeProperty() {
+        ON_CALL(*this, getNodeProperty(0, "age")).WillByDefault(ReturnRef(*ageProperty));
+        ON_CALL(*this, getNodeProperty(0, "name")).WillByDefault(ReturnRef(*nameProperty));
     }
 
-    void setActionForGetRelLabelFromString() {
-        ON_CALL(*this, getRelLabelFromString(StrEq("knows"))).WillByDefault(Return(0));
-        ON_CALL(*this, getRelLabelFromString(StrEq("workAt"))).WillByDefault(Return(1));
+    void secActionForGetRelProperty() {
+        ON_CALL(*this, getRelProperty(0, "description"))
+            .WillByDefault(ReturnRef(*descriptionProperty));
     }
 
     void setActionForGetRelLabelsForNodeLabelDirection() {
@@ -97,67 +94,53 @@ private:
             .WillByDefault(ReturnRef(dstNodeLabelToRelLabels[0]));
     }
 
-    void setActionForContainNodeProperty() {
-        ON_CALL(*this, containNodeProperty(_, _))
-            .WillByDefault(Throw(invalid_argument("Should never happen.")));
-        ON_CALL(*this, containNodeProperty(0, _)).WillByDefault(Return(false));
-        ON_CALL(*this, containNodeProperty(0, "age")).WillByDefault(Return(true));
-        ON_CALL(*this, containNodeProperty(0, "name")).WillByDefault(Return(true));
-        ON_CALL(*this, containNodeProperty(1, _)).WillByDefault(Return(false));
+    void setActionForIsSingleMultiplicityInDirection() {
+        ON_CALL(*this, isSingleMultiplicityInDirection(_, _)).WillByDefault(Return(false));
+        ON_CALL(*this, isSingleMultiplicityInDirection(1, FWD)).WillByDefault(Return(true));
     }
 
-    void setActionForGetNodePropertyTypeFromString() {
-        ON_CALL(*this, getNodePropertyTypeFromString(0, "age")).WillByDefault(Return(INT32));
-        ON_CALL(*this, getNodePropertyTypeFromString(0, "name")).WillByDefault(Return(STRING));
+    void setActionForContainNodeLabel() {
+        ON_CALL(*this, containNodeLabel(_)).WillByDefault(Return(false));
+        ON_CALL(*this, containNodeLabel(StrEq("person"))).WillByDefault(Return(true));
+        ON_CALL(*this, containNodeLabel(StrEq("organisation"))).WillByDefault(Return(true));
     }
 
-    void setActionForGetNodePropertyKeyFromString() {
-        ON_CALL(*this, getNodePropertyKeyFromString(0, "age")).WillByDefault(Return(0));
-        ON_CALL(*this, getNodePropertyKeyFromString(0, "name")).WillByDefault(Return(1));
+    void setActionForContainRelLabel() {
+        ON_CALL(*this, containRelLabel(_)).WillByDefault(Return(false));
+        ON_CALL(*this, containRelLabel(StrEq("knows"))).WillByDefault(Return(true));
+        ON_CALL(*this, containRelLabel(StrEq("workAt"))).WillByDefault(Return(true));
     }
 
-    void setActionForContainUnstrNodeProperty() {
-        ON_CALL(*this, containUnstrNodeProperty(_, _))
-            .WillByDefault(Throw(invalid_argument("Should never happen.")));
-        ON_CALL(*this, containUnstrNodeProperty(0, _)).WillByDefault(Return(false));
-        ON_CALL(*this, containUnstrNodeProperty(1, _)).WillByDefault(Return(false));
+    void setActionForGetNodeLabelFromString() {
+        ON_CALL(*this, getNodeLabelFromString(StrEq("person"))).WillByDefault(Return(0));
+        ON_CALL(*this, getNodeLabelFromString(StrEq("organisation"))).WillByDefault(Return(1));
     }
 
-    void setActionForContainRelProperty() {
-        ON_CALL(*this, containRelProperty(_, _))
-            .WillByDefault(Throw(invalid_argument("Should never happen.")));
-        ON_CALL(*this, containRelProperty(0, _)).WillByDefault(Return(false));
-        ON_CALL(*this, containRelProperty(0, "description")).WillByDefault(Return(true));
-        ON_CALL(*this, containRelProperty(1, _)).WillByDefault(Return(false));
-    }
-
-    void setActionForGetRelPropertyTypeFromString() {
-        ON_CALL(*this, getRelPropertyTypeFromString(0, "description"))
-            .WillByDefault(Return(STRING));
-    }
-
-    void setActionForGetRelPropertyKeyFromString() {
-        ON_CALL(*this, getRelPropertyKeyFromString(0, "description")).WillByDefault(Return(0));
-    }
-
-    void setActionForIsSingleCardinalityInDir() {
-        ON_CALL(*this, isSingleCaridinalityInDir(_, _)).WillByDefault(Return(false));
-        ON_CALL(*this, isSingleCaridinalityInDir(1, FWD)).WillByDefault(Return(true));
+    void setActionForGetRelLabelFromString() {
+        ON_CALL(*this, getRelLabelFromString(StrEq("knows"))).WillByDefault(Return(0));
+        ON_CALL(*this, getRelLabelFromString(StrEq("workAt"))).WillByDefault(Return(1));
     }
 
     void setSrcNodeLabelToRelLabels() {
-        vector<label_t> personToRelLabels = {0, 1};
-        vector<label_t> organisationToRelLabels = {};
+        unordered_set<label_t> personToRelLabels = {0, 1};
+        unordered_set<label_t> organisationToRelLabels = {};
         srcNodeLabelToRelLabels.push_back(move(personToRelLabels));
         srcNodeLabelToRelLabels.push_back(move(organisationToRelLabels));
     }
 
     void setDstNodeLabelToRelLabels() {
-        vector<label_t> personToRelLabels = {0};
-        vector<label_t> organisationToRelLabels = {1};
+        unordered_set<label_t> personToRelLabels = {0};
+        unordered_set<label_t> organisationToRelLabels = {1};
         dstNodeLabelToRelLabels.push_back(move(personToRelLabels));
         dstNodeLabelToRelLabels.push_back(move(organisationToRelLabels));
     }
 
-    vector<vector<label_t>> srcNodeLabelToRelLabels, dstNodeLabelToRelLabels;
+    void setProperties() {
+        ageProperty = make_unique<PropertyDefinition>("age", 0, INT32);
+        nameProperty = make_unique<PropertyDefinition>("name", 1, STRING);
+        descriptionProperty = make_unique<PropertyDefinition>("description", 0, STRING);
+    }
+
+    vector<unordered_set<label_t>> srcNodeLabelToRelLabels, dstNodeLabelToRelLabels;
+    unique_ptr<PropertyDefinition> ageProperty, nameProperty, descriptionProperty;
 };

--- a/test/mock/mock_graph.h
+++ b/test/mock/mock_graph.h
@@ -15,7 +15,7 @@ using namespace graphflow::storage;
 class MockGraph : public Graph {
 
 public:
-    MOCK_METHOD(const Catalog&, getCatalog, (), (const, override));
+    MOCK_METHOD(Catalog&, getCatalog, (), (const, override));
     MOCK_METHOD(uint64_t, getNumNodes, (label_t label), (const, override));
     MOCK_METHOD(uint64_t, getNumRelsForDirBoundLabelRelLabel,
         (Direction direction, label_t boundNodeLabel, label_t relLabel), (const, override));

--- a/test/storage/BUILD.bazel
+++ b/test/storage/BUILD.bazel
@@ -4,15 +4,15 @@ cc_library(
     name = "loader_scanners",
     srcs = [
         "node_fixed_size_property_file_scanner.cpp",
-            ],
+    ],
     hdrs = [
         "include/node_fixed_size_property_file_scanner.h",
-        ],
+    ],
     visibility = ["//visibility:public"],
     deps = [
-            "//src/common:types",
-            "//src/common:utils",
-            "//src/storage:store",
+        "//src/common:types",
+        "//src/common:utils",
+        "//src/storage:store",
     ],
 )
 
@@ -26,6 +26,22 @@ cc_test(
     ],
     deps = [
         "//src/storage:hash_index",
+        "//test/test_utility:test_helper",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "catalog_test",
+    srcs = [
+        "catalog_test.cpp",
+    ],
+    copts = [
+        "-Iexternal/gtest/include",
+    ],
+    deps = [
+        "//src/storage:catalog",
         "//test/test_utility:test_helper",
         "@gtest",
         "@gtest//:gtest_main",

--- a/test/storage/catalog_test.cpp
+++ b/test/storage/catalog_test.cpp
@@ -1,0 +1,81 @@
+#include "gtest/gtest.h"
+#include "spdlog/sinks/stdout_sinks.h"
+#include "spdlog/spdlog.h"
+#include "test/test_utility/include/test_helper.h"
+
+#include "src/storage/include/catalog.h"
+
+using namespace std;
+using namespace graphflow::storage;
+
+class CatalogTest : public testing::Test {
+public:
+    const string CATALOG_TEMP_DIRECTORY = "test/catalog_temp";
+
+    void SetUp() override {
+        graphflow::testing::TestHelper::createDirOrError(CATALOG_TEMP_DIRECTORY);
+        catalog = make_unique<Catalog>();
+        setupCatalog();
+        spdlog::stdout_logger_mt("storage");
+    }
+
+    void TearDown() override {
+        graphflow::testing::TestHelper::removeDirOrError(CATALOG_TEMP_DIRECTORY);
+        spdlog::drop("storage");
+    }
+
+    void setupCatalog() const {
+        vector<PropertyDefinition> personProperties;
+        personProperties.emplace_back("id", 0, INT32);
+        personProperties.emplace_back("fName", 1, STRING);
+        personProperties.emplace_back("gender", 2, INT32);
+        personProperties.emplace_back("isStudent", 3, BOOL);
+        personProperties.emplace_back("isWorker", 4, BOOL);
+        personProperties.emplace_back("age", 5, INT32);
+        personProperties.emplace_back("eyeSight", 6, DOUBLE);
+        catalog->addNodeLabel("person", move(personProperties), "id");
+        catalog->addNodeUnstrProperty(0, "unstrProp");
+
+        vector<PropertyDefinition> knowsProperties;
+        knowsProperties.emplace_back("date", 0, INT32);
+        vector<string> knowsSrcNodeLabelNames = {"person"};
+        vector<string> knowsDstNodeLabelNames = {"person"};
+        catalog->addRelLabel("knows", MANY_MANY, move(knowsProperties), knowsSrcNodeLabelNames,
+            knowsDstNodeLabelNames);
+    }
+
+public:
+    unique_ptr<Catalog> catalog;
+};
+
+TEST_F(CatalogTest, AddLabelsTest) {
+    // Test getting label id from string
+    ASSERT_TRUE(catalog->containNodeLabel("person"));
+    ASSERT_FALSE(catalog->containNodeLabel("organisation"));
+    ASSERT_TRUE(catalog->containRelLabel("knows"));
+    ASSERT_FALSE(catalog->containRelLabel("likes"));
+    ASSERT_EQ(catalog->getNodeLabelFromString("person"), 0);
+    ASSERT_EQ(catalog->getRelLabelFromString("knows"), 0);
+    // Test rel single relMultiplicity
+    ASSERT_FALSE(catalog->isSingleMultiplicityInDirection(0, FWD));
+    // Test property definition
+    ASSERT_TRUE(catalog->getNodeProperties(0)[0].isPrimaryKey);
+    ASSERT_EQ(catalog->getNodeProperty(0, "age").id, 5);
+    ASSERT_EQ(catalog->getNodeProperty(0, "age").dataType, INT32);
+    ASSERT_EQ(catalog->getUnstrPropertiesNameToIdMap(0).at("unstrProp"), 7);
+    ASSERT_EQ(catalog->getNodeProperties(0)[7].dataType, UNSTRUCTURED);
+    ASSERT_EQ(catalog->getRelProperty(0, "date").dataType, INT32);
+}
+
+TEST_F(CatalogTest, SaveAndReadTest) {
+    catalog->saveToFile(CATALOG_TEMP_DIRECTORY);
+    auto newCatalog = make_unique<Catalog>();
+    newCatalog->readFromFile(CATALOG_TEMP_DIRECTORY);
+    ASSERT_TRUE(newCatalog->getNodeProperties(0)[0].isPrimaryKey);
+    // Test getting label id from string
+    ASSERT_TRUE(catalog->containNodeLabel("person"));
+    ASSERT_FALSE(catalog->containNodeLabel("organisation"));
+    ASSERT_TRUE(catalog->containRelLabel("knows"));
+    ASSERT_FALSE(catalog->containRelLabel("likes"));
+    ASSERT_EQ(catalog->getUnstrPropertiesNameToIdMap(0).at("unstrProp"), 7);
+}


### PR DESCRIPTION
This is a refactoring PR, which moves catalog related logic to the Catalog class, so the Catalog can be used independently of the loader, e.x, we can further support DML cypher statements easily.

Also, this PR does some refactorings:
- unify the use of const &.
- remove some unnecessary/unused function param passing.
- fix some typoes in variable name and comments.
- rename dir to direction, as directory and direction co-exist in loader. (there are some other small renamings not mentioned here, the renaming of `dir` is mentioned because it appears a lot).
- replace bitsery in catalog with simple template serialization functions, which can be further extended as a small serialization library in a following pr, so that Graph can also make use of this.