### PR TITLE
Change config of memory manager and processor thread sleep time

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -105,15 +105,15 @@ cc_library(
     name = "utils",
     srcs = [
         "assert.cpp",
-        "utils.cpp",
         "exception.cpp",
-        "file_utils.cpp"
+        "file_utils.cpp",
+        "utils.cpp",
     ],
     hdrs = [
         "include/assert.h",
-        "include/utils.h",
         "include/exception.h",
-        "include/file_utils.h"
+        "include/file_utils.h",
+        "include/utils.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -174,7 +174,9 @@ cc_library(
         "include/memory_manager.h",
     ],
     visibility = ["//visibility:public"],
-    deps = [],
+    deps = [
+        "configs",
+    ],
 )
 
 cc_library(

--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -5,10 +5,10 @@
 namespace graphflow {
 namespace common {
 
-constexpr bool ENABLE_DEBUG = true;
+constexpr bool ENABLE_DEBUG = false;
 
 // Size (in bytes) of the chunks to be read in GraphLoader.
-const uint64_t CSV_READING_BLOCK_SIZE = 1 << 23;
+constexpr uint64_t CSV_READING_BLOCK_SIZE = 1 << 23;
 
 // Size of the page which is the unit of read/write to the files.
 // For now, this value cannot be changed. But technically it can change from 2^12 to 2^16. 2^12
@@ -16,10 +16,11 @@ const uint64_t CSV_READING_BLOCK_SIZE = 1 << 23;
 // number of bits for relOffInPage and the maximum number of bytes needed for an edge is 20 bytes
 // so 11 + log_2(20) = 15.xxx, so certainly over 2^16-size pages, we cannot utilize the page for
 // storing adjacency lists.
-const uint64_t PAGE_SIZE = 1 << 12;
+constexpr uint64_t PAGE_SIZE = 1 << 12;
 
 // The default amount of memory pre-allocated to the buffer pool (= 1GB).
-const uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 30;
+constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 30;
+constexpr uint64_t DEFAULT_MEMORY_MANAGER_MAX_MEMORY = 1ull << 38;
 
 // Hash Index Configurations
 struct HashIndexConfig {

--- a/src/common/include/memory_manager.h
+++ b/src/common/include/memory_manager.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <mutex>
 
+#include "src/common/include/configs.h"
+
 using namespace std;
 
 namespace graphflow {
@@ -26,8 +28,6 @@ private:
 
 // Memory manager for allocating/reclaiming large intermediate memory blocks.
 class MemoryManager {
-    static constexpr uint64_t DEFAULT_MEMORY_MANAGER_MAX_MEMORY = 1 << 30;
-
 public:
     explicit MemoryManager(uint64_t maxMemory = DEFAULT_MEMORY_MANAGER_MAX_MEMORY)
         : maxMemory(maxMemory), usedMemory(0) {}

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -95,7 +95,7 @@ void QueryProcessor::run() {
         }
         auto task = queue.getTask();
         if (!task) {
-            this_thread::sleep_for(chrono::milliseconds(10));
+            this_thread::sleep_for(chrono::microseconds(100));
             continue;
         }
         task->run();


### PR DESCRIPTION
This is a quick PR for benchmarking, which makes following changes:
- move DEFAULT_MEMORY_MANAGER_MAX_MEMORY to the configs.h and reset it to 64GB.
- change processor thread sleep to 100us.