### PR TITLE
Removing casting of expressions to UNSTRUCTURED in the binder. This a…

### DIFF
--- a/src/binder/expression/literal_expression.cpp
+++ b/src/binder/expression/literal_expression.cpp
@@ -2,36 +2,27 @@
 
 namespace graphflow {
 namespace binder {
-
 LiteralExpression::LiteralExpression(
     ExpressionType expressionType, DataType dataType, const Literal& literal)
-    : Expression(expressionType, dataType), literal{literal} {
-    this->storeAsPrimitiveVector = true;
-}
+    : Expression(expressionType, dataType), literal{literal} {}
 
-void LiteralExpression::cast(DataType dataTypeToCast) {
-    assert(isExpressionLeafLiteral(expressionType));
-    if (dataTypeToCast == UNSTRUCTURED) {
-        storeAsPrimitiveVector = false;
-    } else {
-        assert(dataTypeToCast == STRING);
-        string valAsString;
-        switch (dataType) {
-        case BOOL:
-            valAsString = literal.val.booleanVal == TRUE ? "True" : "False";
-            break;
-        case INT32:
-            valAsString = to_string(literal.val.int32Val);
-            break;
-        case DOUBLE:
-            valAsString = to_string(literal.val.doubleVal);
-            break;
-        default:
-            assert(false);
-        }
-        literal.strVal = valAsString;
-        dataType = dataTypeToCast;
+void LiteralExpression::castToString() {
+    string valAsString;
+    switch (dataType) {
+    case BOOL:
+        valAsString = literal.val.booleanVal == TRUE ? "True" : "False";
+        break;
+    case INT32:
+        valAsString = to_string(literal.val.int32Val);
+        break;
+    case DOUBLE:
+        valAsString = to_string(literal.val.doubleVal);
+        break;
+    default:
+        assert(false);
     }
+    literal.strVal = valAsString;
+    dataType = STRING;
 }
 
 } // namespace binder

--- a/src/binder/include/expression/expression.h
+++ b/src/binder/include/expression/expression.h
@@ -30,10 +30,6 @@ public:
 
     Expression(ExpressionType expressionType, DataType dataType, const string& variableName);
 
-    virtual void cast(DataType dataTypeToCast) {
-        throw invalid_argument("Expression does not support cast(DataType).");
-    }
-
     inline const Expression& getChildExpr(uint64_t pos) const { return *childrenExpr[pos]; }
 
     inline const string getAliasElseRawExpression() const {

--- a/src/binder/include/expression/literal_expression.h
+++ b/src/binder/include/expression/literal_expression.h
@@ -11,13 +11,10 @@ class LiteralExpression : public Expression {
 public:
     LiteralExpression(ExpressionType expressionType, DataType dataType, const Literal& literal);
 
-    void cast(DataType dataTypeToCast) override;
+    void castToString();
 
 public:
     Literal literal;
-    // A logical literal expression by default stores in a primitive ValueVector.
-    // Alternatively, we store the literal in as a Vector of Value objects.
-    bool storeAsPrimitiveVector;
 };
 
 } // namespace binder

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -75,61 +75,31 @@ struct IsNotNull {
 struct EqualsOrNotEqualsValues {
     template<bool equals>
     static inline uint8_t operation(const Value& left, const Value& right) {
-        switch (left.dataType) {
-        case BOOL:
-            switch (right.dataType) {
+        if (left.dataType == right.dataType) {
+            switch (left.dataType) {
             case BOOL:
                 return equals ? Equals::operation(left.val.booleanVal, right.val.booleanVal) :
                                 NotEquals::operation(left.val.booleanVal, right.val.booleanVal);
             case INT32:
-            case DOUBLE:
-            case STRING:
-                return equals ? FALSE : TRUE;
-            default:
-                assert(false);
-            }
-        case INT32:
-            switch (right.dataType) {
-            case INT32:
                 return equals ? Equals::operation(left.val.int32Val, right.val.int32Val) :
                                 NotEquals::operation(left.val.int32Val, right.val.int32Val);
             case DOUBLE:
-                return equals ? Equals::operation(left.val.int32Val, right.val.doubleVal) :
-                                NotEquals::operation(left.val.int32Val, right.val.doubleVal);
-            case BOOL:
-            case STRING:
-                return equals ? FALSE : TRUE;
-            default:
-                assert(false);
-            }
-        case DOUBLE:
-            switch (right.dataType) {
-            case INT32:
-                return equals ? Equals::operation(left.val.doubleVal, right.val.int32Val) :
-                                NotEquals::operation(left.val.doubleVal, right.val.int32Val);
-            case DOUBLE:
                 return equals ? Equals::operation(left.val.doubleVal, right.val.doubleVal) :
                                 NotEquals::operation(left.val.doubleVal, right.val.doubleVal);
-            case BOOL:
-            case STRING:
-                return equals ? FALSE : TRUE;
-            default:
-                assert(false);
-            }
-        case STRING:
-            switch (right.dataType) {
-            case BOOL:
-            case INT32:
-            case DOUBLE:
-                return equals ? FALSE : TRUE;
             case STRING:
                 return equals ? Equals::operation(left.val.strVal, right.val.strVal) :
                                 NotEquals::operation(left.val.strVal, right.val.strVal);
             default:
                 assert(false);
             }
-        default:
-            assert(false);
+        } else if (left.dataType == INT32 && right.dataType == DOUBLE) {
+            return equals ? Equals::operation(left.val.int32Val, right.val.doubleVal) :
+                            NotEquals::operation(left.val.int32Val, right.val.doubleVal);
+        } else if (left.dataType == DOUBLE && right.dataType == INT32) {
+            return equals ? Equals::operation(left.val.doubleVal, right.val.int32Val) :
+                            NotEquals::operation(left.val.doubleVal, right.val.int32Val);
+        } else {
+            return equals ? FALSE : TRUE;
         }
     }
 };
@@ -191,55 +161,25 @@ inline uint8_t NotEquals::operation(const nodeID_t& left, const nodeID_t& right)
 struct CompareValues {
     template<class FUNC = function<uint8_t(Value, Value)>>
     static inline uint8_t operation(const Value& left, const Value& right) {
-        switch (left.dataType) {
-        case BOOL:
-            switch (right.dataType) {
+        if (left.dataType == right.dataType) {
+            switch (left.dataType) {
             case BOOL:
                 return FUNC::operation(left.val.booleanVal, right.val.booleanVal);
             case INT32:
-            case DOUBLE:
-            case STRING:
-                return NULL_BOOL;
-            default:
-                assert(false);
-            }
-        case INT32:
-            switch (right.dataType) {
-            case INT32:
                 return FUNC::operation(left.val.int32Val, right.val.int32Val);
             case DOUBLE:
-                return FUNC::operation(left.val.int32Val, right.val.doubleVal);
-            case BOOL:
-            case STRING:
-                return NULL_BOOL;
-            default:
-                assert(false);
-            }
-        case DOUBLE:
-            switch (right.dataType) {
-            case INT32:
-                return FUNC::operation(left.val.doubleVal, right.val.int32Val);
-            case DOUBLE:
                 return FUNC::operation(left.val.doubleVal, right.val.doubleVal);
-            case BOOL:
-            case STRING:
-                return NULL_BOOL;
-            default:
-                assert(false);
-            }
-        case STRING:
-            switch (right.dataType) {
-            case BOOL:
-            case INT32:
-            case DOUBLE:
-                return NULL_BOOL;
             case STRING:
                 return FUNC::operation(left.val.strVal, right.val.strVal);
             default:
                 assert(false);
             }
-        default:
-            assert(false);
+        } else if (left.dataType == INT32 && right.dataType == DOUBLE) {
+            return FUNC::operation(left.val.int32Val, right.val.doubleVal);
+        } else if (left.dataType == DOUBLE && right.dataType == INT32) {
+            return FUNC::operation(left.val.doubleVal, right.val.int32Val);
+        } else {
+            return NULL_BOOL;
         }
     }
 };

--- a/src/common/include/value.h
+++ b/src/common/include/value.h
@@ -37,7 +37,7 @@ public:
         gf_string_t strVal{};
         nodeID_t nodeID;
     } val;
-
+    // Note: dataType cannot be UNSTRUCTURED. Any Value has a fixed known data type.
     DataType dataType;
 };
 

--- a/src/processor/include/physical_plan/expression_mapper.h
+++ b/src/processor/include/physical_plan/expression_mapper.h
@@ -20,6 +20,11 @@ public:
 
     static unique_ptr<ExpressionEvaluator> clone(
         MemoryManager& memoryManager, const ExpressionEvaluator& expression, ResultSet& resultSet);
+
+private:
+    static unique_ptr<ExpressionEvaluator> mapChildExpressionAndCastToUnstructuredIfNecessary(
+        MemoryManager& memoryManager, const Expression& expression, bool castToUnstructured,
+        PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet);
 };
 
 } // namespace processor

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -10,7 +10,10 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace processor {
 
-static unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToPhysical(
+static unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToStructuredPhysical(
+    MemoryManager& memoryManager, const Expression& expression);
+
+static unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToUnstructuredPhysical(
     MemoryManager& memoryManager, const Expression& expression);
 
 static unique_ptr<ExpressionEvaluator> mapLogicalPropertyOrCSVLineExtractExpressionToPhysical(
@@ -22,28 +25,44 @@ unique_ptr<ExpressionEvaluator> ExpressionMapper::mapToPhysical(MemoryManager& m
     ResultSet& resultSet) {
     auto expressionType = expression.expressionType;
     if (isExpressionLeafLiteral(expressionType)) {
-        return mapLogicalLiteralExpressionToPhysical(memoryManager, expression);
-    } else if (isExpressionLeafVariable(expressionType)) {
+        return mapLogicalLiteralExpressionToStructuredPhysical(memoryManager, expression);
+    }
+    unique_ptr<ExpressionEvaluator> retVal;
+    if (isExpressionLeafVariable(expressionType)) {
         /**
          *Both CSV_LINE_EXTRACT and PropertyExpression are mapped to the same physical expression
          *evaluator, because both of them only grab data from a value vector.
          */
-        return mapLogicalPropertyOrCSVLineExtractExpressionToPhysical(
+        retVal = mapLogicalPropertyOrCSVLineExtractExpressionToPhysical(
             memoryManager, expression, physicalOperatorInfo, resultSet);
     } else if (isExpressionUnary(expressionType)) {
         auto child = mapToPhysical(
             memoryManager, expression.getChildExpr(0), physicalOperatorInfo, resultSet);
-        return make_unique<UnaryExpressionEvaluator>(
+        retVal = make_unique<UnaryExpressionEvaluator>(
             memoryManager, move(child), expressionType, expression.dataType);
     } else {
         assert(isExpressionBinary(expressionType));
-        auto lExpr = mapToPhysical(
-            memoryManager, expression.getChildExpr(0), physicalOperatorInfo, resultSet);
-        auto rExpr = mapToPhysical(
-            memoryManager, expression.getChildExpr(1), physicalOperatorInfo, resultSet);
-        return make_unique<BinaryExpressionEvaluator>(
+        // If one of the children expressions has UNSTRUCTURED data type, i.e. the type of the data
+        // is not fixed and can take on multiple values, then we add a cast operation to the other
+        // child (even if the other child's type is known in advance and is structured). The
+        // UNSTRUCTURED child's data will be stored in vectors that store boxed values instead of
+        // structured (i.e., primitive) values. The cast operation ensures that the other child's
+        // values are also boxed so we can call expression evaluation functions that expect two
+        // boxed values.
+        auto& logicalLExpr = expression.getChildExpr(0);
+        auto& logicalRExpr = expression.getChildExpr(1);
+        auto castLToUnstructured =
+            logicalRExpr.dataType == UNSTRUCTURED && logicalLExpr.dataType != UNSTRUCTURED;
+        auto lExpr = mapChildExpressionAndCastToUnstructuredIfNecessary(
+            memoryManager, logicalLExpr, castLToUnstructured, physicalOperatorInfo, resultSet);
+        auto castRToUnstructured =
+            logicalLExpr.dataType == UNSTRUCTURED && logicalRExpr.dataType != UNSTRUCTURED;
+        auto rExpr = mapChildExpressionAndCastToUnstructuredIfNecessary(
+            memoryManager, logicalRExpr, castRToUnstructured, physicalOperatorInfo, resultSet);
+        retVal = make_unique<BinaryExpressionEvaluator>(
             memoryManager, move(lExpr), move(rExpr), expressionType, expression.dataType);
     }
+    return retVal;
 }
 
 unique_ptr<ExpressionEvaluator> ExpressionMapper::clone(
@@ -67,55 +86,76 @@ unique_ptr<ExpressionEvaluator> ExpressionMapper::clone(
             expression.dataType);
     }
 }
+unique_ptr<ExpressionEvaluator>
+ExpressionMapper::mapChildExpressionAndCastToUnstructuredIfNecessary(MemoryManager& memoryManager,
+    const Expression& expression, bool castToUnstructured,
+    PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet) {
+    unique_ptr<ExpressionEvaluator> retVal;
+    if (castToUnstructured && isExpressionLeafLiteral(expression.expressionType)) {
+        retVal = mapLogicalLiteralExpressionToUnstructuredPhysical(memoryManager, expression);
+    } else {
+        retVal = mapToPhysical(memoryManager, expression, physicalOperatorInfo, resultSet);
+        if (castToUnstructured) {
+            retVal = make_unique<UnaryExpressionEvaluator>(
+                memoryManager, move(retVal), CAST_TO_UNSTRUCTURED_VECTOR, UNSTRUCTURED);
+        }
+    }
+    return retVal;
+}
 
-unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToPhysical(
+static unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToUnstructuredPhysical(
     MemoryManager& memoryManager, const Expression& expression) {
     auto& literalExpression = (LiteralExpression&)expression;
     // We create an owner dataChunk which is flat and of size 1 to contain the literal.
-    auto vector = make_shared<ValueVector>(&memoryManager,
-        literalExpression.storeAsPrimitiveVector ? literalExpression.dataType : UNSTRUCTURED,
-        true /* isSingleValue */);
+    auto vector = make_shared<ValueVector>(&memoryManager, UNSTRUCTURED, true /* isSingleValue */);
     vector->state = VectorState::getSingleValueDataChunkState();
-    if (!literalExpression.storeAsPrimitiveVector) {
-        auto& val = ((Value*)vector->values)[0];
-        val.dataType = literalExpression.literal.dataType;
-        switch (val.dataType) {
-        case INT32: {
-            val.val.int32Val = literalExpression.literal.val.int32Val;
-        } break;
-        case DOUBLE: {
-            val.val.doubleVal = literalExpression.literal.val.doubleVal;
-        } break;
-        case BOOL: {
-            val.val.booleanVal = literalExpression.literal.val.booleanVal;
-        } break;
-        case STRING: {
-            vector->allocateStringOverflowSpace(
-                val.val.strVal, literalExpression.literal.strVal.length());
-            val.val.strVal.set(literalExpression.literal.strVal);
-        } break;
-        default:
-            assert(false);
-        }
-    } else {
-        switch (expression.dataType) {
-        case INT32: {
-            ((int32_t*)vector->values)[0] = literalExpression.literal.val.int32Val;
-        } break;
-        case DOUBLE: {
-            ((double_t*)vector->values)[0] = literalExpression.literal.val.doubleVal;
-        } break;
-        case BOOL: {
-            auto val = literalExpression.literal.val.booleanVal;
-            vector->nullMask[0] = val == NULL_BOOL;
-            vector->values[0] = val;
-        } break;
-        case STRING: {
-            vector->addString(0 /* pos */, literalExpression.literal.strVal);
-        } break;
-        default:
-            assert(false);
-        }
+    auto& val = ((Value*)vector->values)[0];
+    val.dataType = literalExpression.literal.dataType;
+    switch (val.dataType) {
+    case INT32: {
+        val.val.int32Val = literalExpression.literal.val.int32Val;
+    } break;
+    case DOUBLE: {
+        val.val.doubleVal = literalExpression.literal.val.doubleVal;
+    } break;
+    case BOOL: {
+        val.val.booleanVal = literalExpression.literal.val.booleanVal;
+    } break;
+    case STRING: {
+        vector->allocateStringOverflowSpace(
+            val.val.strVal, literalExpression.literal.strVal.length());
+        val.val.strVal.set(literalExpression.literal.strVal);
+    } break;
+    default:
+        assert(false);
+    }
+    return make_unique<ExpressionEvaluator>(memoryManager, vector, expression.expressionType);
+}
+
+unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToStructuredPhysical(
+    MemoryManager& memoryManager, const Expression& expression) {
+    auto& literalExpression = (LiteralExpression&)expression;
+    // We create an owner dataChunk which is flat and of size 1 to contain the literal.
+    auto vector = make_shared<ValueVector>(
+        &memoryManager, literalExpression.dataType, true /* isSingleValue */);
+    vector->state = VectorState::getSingleValueDataChunkState();
+    switch (expression.dataType) {
+    case INT32: {
+        ((int32_t*)vector->values)[0] = literalExpression.literal.val.int32Val;
+    } break;
+    case DOUBLE: {
+        ((double_t*)vector->values)[0] = literalExpression.literal.val.doubleVal;
+    } break;
+    case BOOL: {
+        auto val = literalExpression.literal.val.booleanVal;
+        vector->nullMask[0] = val == NULL_BOOL;
+        vector->values[0] = val;
+    } break;
+    case STRING: {
+        vector->addString(0 /* pos */, literalExpression.literal.strVal);
+    } break;
+    default:
+        assert(false);
     }
     return make_unique<ExpressionEvaluator>(memoryManager, vector, expression.expressionType);
 }


### PR DESCRIPTION
- Removing casting of expressions to UNSTRUCTURED in the binder. This all happens during logical-to-physical expression mapper.
- As part of the change, also removes the storeAsPrimitiveVector field from LiteralExpression and also the cast() function from (Logical) Expression. Instead the only casting that is done right now is of a LiteralExpression to string (which makes sense to do in the binder), so we have a castToString() function in LiteralExpression.
- Modifies the code in several places to increase the readability of the if/else branches.