### PR TITLE
Fix issues and add tests for expression evaluation; simplify gf_string set function

### DIFF
--- a/src/common/gf_string.cpp
+++ b/src/common/gf_string.cpp
@@ -16,28 +16,36 @@ void gf_string_t::getOverflowPtrInfo(uint64_t& pageIdx, uint16_t& pageOffset) {
     memcpy(&pageOffset, ((uint8_t*)&overflowPtr) + 6, 2);
 }
 
-void gf_string_t::set(const string& str) {
-    set(str.data(), str.length());
+void gf_string_t::set(const string& value) {
+    set(value.data(), value.length());
 }
 
 void gf_string_t::set(const char* value, uint64_t length) {
-    auto prefixLen = length < gf_string_t::PREFIX_LENGTH ? length : gf_string_t::PREFIX_LENGTH;
     this->len = length;
-    memcpy(prefix, value, prefixLen);
-    if (length > gf_string_t::PREFIX_LENGTH) {
-        if (length <= gf_string_t::SHORT_STR_LENGTH) {
-            memcpy(data, value + gf_string_t::PREFIX_LENGTH, length - gf_string_t::PREFIX_LENGTH);
-        } else {
-            memcpy(reinterpret_cast<char*>(overflowPtr), value, length);
-        }
+    if (length <= SHORT_STR_LENGTH) {
+        memcpy(prefix, value, length);
+    } else {
+        memcpy(prefix, value, PREFIX_LENGTH);
+        memcpy(reinterpret_cast<char*>(overflowPtr), value, length);
     }
 }
 
-string gf_string_t::getAsString(const gf_string_t& gf_string) {
-    if (gf_string.len <= gf_string_t::SHORT_STR_LENGTH) {
-        return string((char*)gf_string.prefix, gf_string.len);
+void gf_string_t::set(const gf_string_t& value) {
+    this->len = value.len;
+    if (value.len <= SHORT_STR_LENGTH) {
+        memcpy(prefix, value.prefix, value.len);
     } else {
-        return string(reinterpret_cast<char*>(gf_string.overflowPtr), gf_string.len);
+        memcpy(prefix, value.prefix, PREFIX_LENGTH);
+        memcpy(reinterpret_cast<char*>(overflowPtr), reinterpret_cast<char*>(value.overflowPtr),
+            value.len);
+    }
+}
+
+string gf_string_t::getAsString() const {
+    if (len <= SHORT_STR_LENGTH) {
+        return string((char*)prefix, len);
+    } else {
+        return string(reinterpret_cast<char*>(overflowPtr), len);
     }
 }
 

--- a/src/common/include/gf_string.h
+++ b/src/common/include/gf_string.h
@@ -35,10 +35,11 @@ struct gf_string_t {
 
     // This function does *NOT* allocate/resize the overflow buffer, it only copies the content and
     // set the length.
-    void set(const string& str);
+    void set(const string& value);
     void set(const char* value, uint64_t length);
+    void set(const gf_string_t& value);
 
-    static string getAsString(const gf_string_t& gf_string);
+    string getAsString() const;
 };
 
 } // namespace common

--- a/src/common/include/operations/arithmetic_operations.h
+++ b/src/common/include/operations/arithmetic_operations.h
@@ -116,7 +116,7 @@ struct ArithmeticOnValues {
     static void operation(Value& left, Value& right, Value& result) {
         switch (left.dataType) {
         case INT32:
-            switch (left.dataType) {
+            switch (right.dataType) {
             case INT32:
                 result.dataType = INT32;
                 FUNC::operation(left.val.int32Val, right.val.int32Val, result.val.int32Val);
@@ -131,7 +131,7 @@ struct ArithmeticOnValues {
             }
             break;
         case DOUBLE:
-            switch (left.dataType) {
+            switch (right.dataType) {
             case INT32:
                 result.dataType = DOUBLE;
                 FUNC::operation(left.val.doubleVal, right.val.int32Val, result.val.doubleVal);

--- a/src/common/include/utils.h
+++ b/src/common/include/utils.h
@@ -26,21 +26,17 @@ public:
         return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
     }
 
-    //    static bool CharacterIsNewline(char c) {
-    //        return c == '\n' || c == '\r';
-    //    }
-    //
     static bool CharacterIsDigit(char c) { return c >= '0' && c <= '9'; }
     template<typename... Args>
-    static std::string string_format(const std::string& format, Args... args) {
-        int size_s = std::snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
+    static string string_format(const string& format, Args... args) {
+        int size_s = snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
         if (size_s <= 0) {
-            throw std::runtime_error("Error during formatting.");
+            throw runtime_error("Error during formatting.");
         }
         auto size = static_cast<size_t>(size_s);
-        auto buf = std::make_unique<char[]>(size);
-        std::snprintf(buf.get(), size, format.c_str(), args...);
-        return std::string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
+        auto buf = make_unique<char[]>(size);
+        snprintf(buf.get(), size, format.c_str(), args...);
+        return string(buf.get(), buf.get() + size - 1); // We don't want the '\0' inside
     }
 };
 

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -44,7 +44,7 @@ string Value::toString() const {
     case DOUBLE:
         return to_string(val.doubleVal);
     case STRING:
-        return gf_string_t::getAsString(val.strVal);
+        return val.strVal.getAsString();
     case NODE:
         return to_string(val.nodeID.label) + ":" + to_string(val.nodeID.offset);
     case DATE:

--- a/test/common/BUILD.bazel
+++ b/test/common/BUILD.bazel
@@ -35,6 +35,7 @@ cc_test(
     srcs = [
         "vector/operations/vector_arithmetic_operations_test.cpp",
         "vector/operations/vector_boolean_operations_test.cpp",
+        "vector/operations/vector_cast_operations_test.cpp",
         "vector/operations/vector_comparison_operations_test.cpp",
         "vector/operations/vector_hash_nodeid_operations_test.cpp",
     ],

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -1,16 +1,28 @@
 #include "gtest/gtest.h"
 
 #include "src/common/include/data_chunk/data_chunk.h"
+#include "src/common/include/value.h"
 #include "src/common/include/vector/operations/vector_arithmetic_operations.h"
 
 using namespace graphflow::common;
 using namespace std;
 
-TEST(VectorArithTests, test) {
-    auto dataChunk = make_shared<DataChunk>();
-    dataChunk->state->size = 100;
-    auto memoryManager = make_unique<MemoryManager>();
+class VectorArithmeticOperationsTest : public testing::Test {
+public:
+    const int32_t VECTOR_SIZE = 100;
 
+    void SetUp() override {
+        dataChunk = make_shared<DataChunk>();
+        dataChunk->state->size = VECTOR_SIZE;
+        memoryManager = make_unique<MemoryManager>();
+    }
+
+public:
+    shared_ptr<DataChunk> dataChunk;
+    unique_ptr<MemoryManager> memoryManager;
+};
+
+TEST_F(VectorArithmeticOperationsTest, Int32Test) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
     dataChunk->append(lVector);
     auto lData = (int32_t*)lVector->values;
@@ -24,39 +36,39 @@ TEST(VectorArithTests, test) {
     auto resultData = (int32_t*)result->values;
 
     // Fill values before the comparison.
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = i;
         rData[i] = 110 - i;
     }
 
     VectorArithmeticOperations::Negate(*lVector, *result);
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], -i);
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], 110);
     }
 
     VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], 2 * i - 110);
     }
 
     VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], i * (110 - i));
     }
 
     VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], i / (110 - i));
     }
 
     /* note rVector and lVector are flipped */
     VectorArithmeticOperations::Modulo(*rVector, *lVector, *result);
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i], i % (110 - i));
     }
 
@@ -64,7 +76,178 @@ TEST(VectorArithTests, test) {
     dataChunk->append(result);
     auto resultDataAsDoubleArr = (double_t*)result->values;
     VectorArithmeticOperations::Power(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < 100; i++) {
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultDataAsDoubleArr[i], pow(i, 110 - i));
+    }
+}
+
+TEST_F(VectorArithmeticOperationsTest, StringTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(lVector);
+
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(rVector);
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(result);
+    auto resultData = (gf_string_t*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lVector->addString(i, to_string(i));
+        rVector->addString(i, to_string(110 - i));
+    }
+
+    VectorArithmeticOperations::Add(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].getAsString(), to_string(i) + to_string(110 - i));
+    }
+}
+
+TEST_F(VectorArithmeticOperationsTest, BigStringTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(lVector);
+
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(rVector);
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(result);
+    auto resultData = (gf_string_t*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lVector->addString(i, to_string(i) + "abcdefabcdefqwert");
+        rVector->addString(i, to_string(110 - i) + "abcdefabcdefqwert");
+    }
+
+    VectorArithmeticOperations::Add(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].getAsString(),
+            to_string(i) + "abcdefabcdefqwert" + to_string(110 - i) + "abcdefabcdefqwert");
+    }
+}
+
+TEST_F(VectorArithmeticOperationsTest, UnstructuredInt32Test) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(lVector);
+    auto lData = (Value*)lVector->values;
+
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(rVector);
+    auto rData = (Value*)rVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = Value(i);
+        rData[i] = Value(110 - i);
+    }
+
+    VectorArithmeticOperations::Negate(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.int32Val, -i);
+    }
+
+    VectorArithmeticOperations::Add(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.int32Val, 110);
+    }
+
+    VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.int32Val, 2 * i - 110);
+    }
+
+    VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.int32Val, i * (110 - i));
+    }
+
+    VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.int32Val, i / (110 - i));
+    }
+
+    /* note rVector and lVector are flipped */
+    VectorArithmeticOperations::Modulo(*rVector, *lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.int32Val, i % (110 - i));
+    }
+}
+
+TEST_F(VectorArithmeticOperationsTest, UnstructuredInt32AndDoubleTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(lVector);
+    auto lData = (Value*)lVector->values;
+
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(rVector);
+    auto rData = (Value*)rVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = Value((double)i);
+        rData[i] = Value(110 - i);
+    }
+
+    VectorArithmeticOperations::Negate(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.doubleVal, (double)-i);
+    }
+
+    VectorArithmeticOperations::Add(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.doubleVal, (double)110);
+    }
+
+    VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.doubleVal, (double)(2 * i - 110));
+    }
+
+    VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.doubleVal, (double)(i * (110 - i)));
+    }
+
+    VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.doubleVal, (double)i / (110 - i));
+    }
+}
+
+TEST_F(VectorArithmeticOperationsTest, UnstructuredStringAndInt32Test) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(lVector);
+    auto lData = (Value*)lVector->values;
+
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(rVector);
+    auto rData = (Value*)rVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        string lStr = to_string(i);
+        lVector->allocateStringOverflowSpace(lData[i].val.strVal, lStr.length());
+        lData[i].val.strVal.set(lStr);
+        lData[i].dataType = STRING;
+        rData[i] = Value(110 - i);
+    }
+
+    VectorArithmeticOperations::Add(*lVector, *rVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.strVal.getAsString(), to_string(i) + to_string(110 - i));
     }
 }

--- a/test/common/vector/operations/vector_cast_operations_test.cpp
+++ b/test/common/vector/operations/vector_cast_operations_test.cpp
@@ -1,0 +1,218 @@
+#include "gtest/gtest.h"
+
+#include "src/common/include/data_chunk/data_chunk.h"
+#include "src/common/include/date.h"
+#include "src/common/include/value.h"
+#include "src/common/include/vector/operations/vector_cast_operations.h"
+
+using namespace graphflow::common;
+using namespace std;
+
+class VectorCastOperationsTest : public testing::Test {
+
+public:
+    const int32_t VECTOR_SIZE = 100;
+
+    void SetUp() override {
+        dataChunk = make_shared<DataChunk>();
+        dataChunk->state->size = VECTOR_SIZE;
+        memoryManager = make_unique<MemoryManager>();
+    }
+
+public:
+    shared_ptr<DataChunk> dataChunk;
+    unique_ptr<MemoryManager> memoryManager;
+};
+
+TEST_F(VectorCastOperationsTest, CastStructuredBoolToUnstructuredValueTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
+    dataChunk->append(lVector);
+    auto lData = (bool*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = (i % 2) == 0;
+    }
+    VectorCastOperations::castStructuredToUnstructuredValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.booleanVal, (i % 2) == 0);
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredInt32ToUnstructuredValueTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+    dataChunk->append(lVector);
+    auto lData = (int32_t*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = i * 2;
+    }
+    VectorCastOperations::castStructuredToUnstructuredValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.int32Val, i * 2);
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredDoubleToUnstructuredValueTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
+    dataChunk->append(lVector);
+    auto lData = (double*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = (double)(i * 2);
+    }
+    VectorCastOperations::castStructuredToUnstructuredValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.doubleVal, (double)(i * 2));
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredDateToUnstructuredValueTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), DATE);
+    dataChunk->append(lVector);
+    auto lData = (date_t*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = date_t(i * 2);
+    }
+    VectorCastOperations::castStructuredToUnstructuredValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.dateVal, date_t(i * 2));
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredStringToUnstructuredValueTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(lVector);
+    auto lData = (gf_string_t*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(result);
+    auto resultData = (Value*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        string lStr = to_string(i * 2);
+        lVector->allocateStringOverflowSpace(lData[i], lStr.length());
+        lData[i].set(lStr);
+    }
+    VectorCastOperations::castStructuredToUnstructuredValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].val.strVal.getAsString(), to_string(i * 2));
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredBooleanToStringTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
+    dataChunk->append(lVector);
+    auto lData = (bool*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(result);
+    auto resultData = (gf_string_t*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = i % 2 == 0;
+    }
+    VectorCastOperations::castStructuredToStringValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].getAsString(), (i % 2 == 0 ? "True" : "False"));
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredInt32ToStringTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+    dataChunk->append(lVector);
+    auto lData = (int32_t*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(result);
+    auto resultData = (gf_string_t*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = i * 2;
+    }
+    VectorCastOperations::castStructuredToStringValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].getAsString(), to_string(i * 2));
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredDoubleToStringTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
+    dataChunk->append(lVector);
+    auto lData = (double*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(result);
+    auto resultData = (gf_string_t*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = (double)(i * 2);
+    }
+    VectorCastOperations::castStructuredToStringValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].getAsString(), to_string((double)(i * 2)));
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastStructuredDateToStringTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), DATE);
+    dataChunk->append(lVector);
+    auto lData = (date_t*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
+    dataChunk->append(result);
+    auto resultData = (gf_string_t*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i] = date_t(1000 + i);
+    }
+    VectorCastOperations::castStructuredToStringValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i].getAsString(), Date::toString(date_t(1000 + i)));
+    }
+}
+
+TEST_F(VectorCastOperationsTest, CastUnStructuredBooleanToBooleanTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+    dataChunk->append(lVector);
+    auto lData = (Value*)lVector->values;
+
+    auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
+    dataChunk->append(result);
+    auto resultData = (bool*)result->values;
+
+    // Fill values before the comparison.
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        lData[i].val.booleanVal = (i % 2 == 0);
+        lData[i].dataType = BOOL;
+    }
+    VectorCastOperations::castUnstructuredToBoolValue(*lVector, *result);
+    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+        ASSERT_EQ(resultData[i], (i % 2 == 0));
+    }
+}

--- a/test/runner/queries/filtered/unstructured_properties.test
+++ b/test/runner/queries/filtered/unstructured_properties.test
@@ -35,3 +35,11 @@
 -NAME PersonUnstrFilteredTest9
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.unstrNumericProp > b.unstrNumericProp RETURN COUNT(*)
 ---- 1
+
+-NAME PersonUnstrFilteredTest10
+-QUERY MATCH (a:person) WHERE '47Bob' = a.unstrNumericProp + a.fName RETURN COUNT(*)
+---- 1
+
+-NAME PersonUnstrFilteredTest11
+-QUERY MATCH (a:person) WHERE a.unstrDateProp1 + a.fName = '1950-01-01Bob' RETURN COUNT(*)
+---- 1


### PR DESCRIPTION
1. This PR fixes the issue #232 . And also fixes other two issues in the expression evaluation:
- cast unstructured to boolean;
- arithmetic operation on unstructured values.

2. Besides fixes, this PR adds unit tests for vector cast and vector arithmetic operations.

3. As I go through the gf_string.cpp code, I realize we can make a small change to the `set` function to save memcpy and simplify if/else statements a bit. This is unrelated to the fixes, but I added it in this PR because it's an easy change.