### PR TITLE
factorize hash join

### DIFF
--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -41,7 +41,6 @@ enum ExpressionType : uint8_t {
 
     /**
      * NODE ID Expressions
-     * Comparison and Decompress
      * */
     HASH_NODE_ID = 32,
     EQUALS_NODE_ID = 33,
@@ -50,7 +49,6 @@ enum ExpressionType : uint8_t {
     GREATER_THAN_EQUALS_NODE_ID = 36,
     LESS_THAN_NODE_ID = 37,
     LESS_THAN_EQUALS_NODE_ID = 38,
-    DECOMPRESS_NODE_ID = 39,
 
     /**
      * String Operator Expressions

--- a/src/common/include/operations/hash_operations.h
+++ b/src/common/include/operations/hash_operations.h
@@ -4,6 +4,7 @@
 #include <unordered_set>
 
 #include "src/common/include/types.h"
+#include "src/common/include/utils.h"
 
 namespace graphflow {
 namespace common {
@@ -16,7 +17,8 @@ inline uint64_t murmurhash64(uint64_t x) {
 struct Hash {
     template<class T>
     static inline uint64_t operation(const T& key) {
-        throw invalid_argument("Hash type: " + string(typeid(T).name()) + " is not supported.");
+        throw invalid_argument(
+            StringUtils::string_format("Hash type: %s is not supported.", typeid(T).name()));
     }
 };
 

--- a/src/common/include/vector/operations/vector_node_id_operations.h
+++ b/src/common/include/vector/operations/vector_node_id_operations.h
@@ -22,7 +22,6 @@ struct VectorNodeIDCompareOperations {
 
 struct VectorNodeIDOperations {
     static void Hash(ValueVector& operand, ValueVector& result);
-    static void Decompress(ValueVector& operand, ValueVector& result);
 };
 
 } // namespace common

--- a/src/common/vector/operations/vector_node_id_operations.cpp
+++ b/src/common/vector/operations/vector_node_id_operations.cpp
@@ -43,10 +43,5 @@ void VectorNodeIDOperations::Hash(ValueVector& operand, ValueVector& result) {
     UnaryOperationExecutor::executeOnNodeIDVector<uint64_t, operation::Hash>(operand, result);
 }
 
-void VectorNodeIDOperations::Decompress(ValueVector& operand, ValueVector& result) {
-    UnaryOperationExecutor::executeOnNodeIDVector<nodeID_t, operation::DecompressNodeID>(
-        operand, result);
-}
-
 } // namespace common
 } // namespace graphflow

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -22,8 +22,6 @@ std::function<void(ValueVector&, ValueVector&)> ExpressionEvaluator::getUnaryOpe
         return VectorComparisonOperations::IsNotNull;
     case HASH_NODE_ID:
         return VectorNodeIDOperations::Hash;
-    case DECOMPRESS_NODE_ID:
-        return VectorNodeIDOperations::Decompress;
     case CAST_TO_STRING:
         return VectorCastOperations::castStructuredToStringValue;
     case CAST_TO_UNSTRUCTURED_VECTOR:

--- a/src/processor/include/physical_plan/plan_mapper.h
+++ b/src/processor/include/physical_plan/plan_mapper.h
@@ -22,8 +22,8 @@ public:
 
 private:
     unique_ptr<PhysicalOperator> mapLogicalOperatorToPhysical(
-        shared_ptr<LogicalOperator> logicalOperator, PhysicalOperatorsInfo& physicalOperatorInfo,
-        ExecutionContext& executionContext);
+        const shared_ptr<LogicalOperator>& logicalOperator,
+        PhysicalOperatorsInfo& physicalOperatorInfo, ExecutionContext& executionContext);
 
     unique_ptr<PhysicalOperator> mapLogicalScanNodeIDToPhysical(LogicalOperator* logicalOperator,
         PhysicalOperatorsInfo& physicalOperatorInfo, ExecutionContext& context);

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -1,11 +1,13 @@
 #include "src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h"
 
+#include "src/common/include/operations/hash_operations.h"
+
 namespace graphflow {
 namespace processor {
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
 HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::HashJoinProbe(uint64_t buildSideKeyDataChunkPos,
-    uint64_t buildSideKeyVectorPos, vector<bool> buildSideDataChunkPosToIsFlat,
+    uint64_t buildSideKeyVectorPos, const vector<bool>& buildSideDataChunkPosToIsFlat,
     uint64_t probeSideKeyDataChunkPos, uint64_t probeSideKeyVectorPos,
     unique_ptr<PhysicalOperator> buildSidePrevOp, unique_ptr<PhysicalOperator> probeSidePrevOp,
     ExecutionContext& context, uint32_t id)
@@ -18,57 +20,54 @@ HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::HashJoinProbe(uint64_t buildSideKeyDat
                                                               probeSideKeyVectorPos} {
     // The buildSidePrevOp (HashJoinBuild) yields no actual resultSet, we get it from it's prevOp.
     buildSideResultSet = this->buildSidePrevOp->prevOperator->getResultSet();
-    buildSideKeyDataChunk = buildSideResultSet->dataChunks[buildSideKeyDataChunkPos];
     // The prevOperator is the probe side prev operator passed in to the PhysicalOperator
-    probeSideResultSet = prevOperator->getResultSet();
-    probeSideKeyDataChunk = probeSideResultSet->dataChunks[probeSideKeyDataChunkPos];
+    resultSet = prevOperator->getResultSet();
+    numProbeSidePrevDataChunks = resultSet->dataChunks.size();
+    probeSideKeyDataChunk = resultSet->dataChunks[probeSideKeyDataChunkPos];
+    // The probe side key data chunk is also the output keyDataChunk in the resultSet. Non-key
+    // vectors from the build side key data chunk are appended into the the probeSideKeyDataChunk.
+    resultKeyDataChunk = probeSideKeyDataChunk;
+    numProbeSidePrevKeyValueVectors = probeSideKeyDataChunk->valueVectors.size();
     probeSideKeyVector = static_pointer_cast<NodeIDVector>(
         probeSideKeyDataChunk->getValueVector(probeSideKeyVectorPos));
-
-    decompressedProbeKeyVector = make_shared<NodeIDVector>(0, NodeIDCompressionScheme(8, 8), false);
-    decompressedProbeKeyVector->state = probeSideKeyVector->state;
-    hashedProbeKeyVector = make_shared<ValueVector>(context.memoryManager, INT64);
-    hashedProbeKeyVector->state = probeSideKeyVector->state;
-
     probeState = make_unique<ProbeState>(DEFAULT_VECTOR_CAPACITY);
-
-    initializeOutResultSetAndVectorPtrs();
+    initializeResultSetAndVectorPtrs();
 }
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::createVectorsFromExistingOnesAndAppend(
-    DataChunk& inDataChunk, DataChunk& outDataChunk, vector<uint64_t>& vectorPositions) {
+    DataChunk& inDataChunk, DataChunk& resultDataChunk, vector<uint64_t>& vectorPositions) {
     for (auto pos : vectorPositions) {
         auto inVector = inDataChunk.valueVectors[pos];
-        shared_ptr<ValueVector> outVector;
+        shared_ptr<ValueVector> resultVector;
         if (inVector->dataType == NODE) {
             auto nodeIDVector = static_pointer_cast<NodeIDVector>(inVector);
-            outVector = make_shared<NodeIDVector>(nodeIDVector->representation.commonLabel,
+            resultVector = make_shared<NodeIDVector>(nodeIDVector->representation.commonLabel,
                 nodeIDVector->representation.compressionScheme, false);
         } else {
-            outVector = make_shared<ValueVector>(context.memoryManager, inVector->dataType);
+            resultVector = make_shared<ValueVector>(context.memoryManager, inVector->dataType);
         }
-        outDataChunk.append(outVector);
+        resultDataChunk.append(resultVector);
     }
 }
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
-void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeOutResultSetAndVectorPtrs() {
-    resultSet = make_shared<ResultSet>();
-    outKeyDataChunk = make_unique<DataChunk>();
-    resultSet->append(outKeyDataChunk);
-    vector<uint64_t> probeSideKeyVectorPositions(probeSideKeyDataChunk->valueVectors.size());
-    for (auto i = 0u; i < probeSideKeyDataChunk->valueVectors.size(); i++) {
-        probeSideKeyVectorPositions.push_back(i);
+void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::createVectorPtrs(DataChunk& buildSideDataChunk) {
+    for (auto j = 0u; j < buildSideDataChunk.valueVectors.size(); j++) {
+        auto vectorPtrs = make_unique<overflow_value_t[]>(NODE_SEQUENCE_VECTOR_CAPACITY);
+        BuildSideVectorInfo vectorInfo(buildSideDataChunk.valueVectors[j]->getNumBytesPerValue(),
+            resultSet->dataChunks.size(), j, buildSideVectorPtrs.size());
+        buildSideVectorInfos.push_back(vectorInfo);
+        buildSideVectorPtrs.push_back(move(vectorPtrs));
     }
-    createVectorsFromExistingOnesAndAppend(
-        *probeSideKeyDataChunk, *outKeyDataChunk, probeSideKeyVectorPositions);
-    for (auto i = 0u; i < probeSideResultSet->dataChunks.size(); i++) {
-        if (i != probeSideKeyDataChunkPos) {
-            resultSet->append(probeSideResultSet->dataChunks[i]);
-        }
-    }
-    vector<uint64_t> buildSideKeyVectorPositions(buildSideKeyDataChunk->valueVectors.size() - 1);
+}
+
+template<bool IS_OUT_DATACHUNK_FILTERED>
+void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeResultSetAndVectorPtrs() {
+    // Initialize vectors for build side key data chunk (except for the key vector, which is already
+    // included in the probe side key data chunk) and append them into the resultKeyDataChunk.
+    auto buildSideKeyDataChunk = buildSideResultSet->dataChunks[buildSideKeyDataChunkPos];
+    vector<uint64_t> buildSideKeyVectorPositions;
     for (auto i = 0u; i < buildSideKeyDataChunk->valueVectors.size(); i++) {
         if (i == buildSideKeyVectorPos) {
             continue;
@@ -76,162 +75,107 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::initializeOutResultSetAndVectorPt
         buildSideKeyVectorPositions.push_back(i);
     }
     createVectorsFromExistingOnesAndAppend(
-        *buildSideKeyDataChunk, *outKeyDataChunk, buildSideKeyVectorPositions);
-
+        *buildSideKeyDataChunk, *resultKeyDataChunk, buildSideKeyVectorPositions);
+    // Create vectors for build side non-key data chunks and append them into the resultSet:
+    // 1. Merge all (if any) flat non-key data chunks into buildSideFlatResultDataChunk. Notice that
+    // if build side has no flat data chunks, the buildSideFlatResultDataChunk can be empty, and not
+    // appended into the resultSet.
+    // 2. For each unFlat data chunk, create a new one, and allocate vectorPtrs.
+    buildSideFlatResultDataChunk = make_shared<DataChunk>();
     for (auto i = 0u; i < buildSideResultSet->dataChunks.size(); i++) {
         if (i == buildSideKeyDataChunkPos) {
             continue;
         }
-        auto dataChunk = buildSideResultSet->dataChunks[i];
-        vector<uint64_t> dataChunkVectorPositions(dataChunk->valueVectors.size());
+        auto& dataChunk = buildSideResultSet->dataChunks[i];
+        vector<uint64_t> dataChunkVectorPositions;
         for (auto j = 0u; j < dataChunk->valueVectors.size(); j++) {
             dataChunkVectorPositions.push_back(j);
         }
         if (buildSideDataChunkPosToIsFlat[i]) {
+            if (buildSideFlatResultDataChunk->valueVectors.empty()) {
+                buildSideFlatResultDataChunk = make_shared<DataChunk>();
+                resultSet->append(buildSideFlatResultDataChunk);
+            }
             createVectorsFromExistingOnesAndAppend(
-                *dataChunk, *outKeyDataChunk, dataChunkVectorPositions);
+                *dataChunk, *buildSideFlatResultDataChunk, dataChunkVectorPositions);
         } else {
             auto unFlatOutDataChunk = make_shared<DataChunk>();
             createVectorsFromExistingOnesAndAppend(
                 *dataChunk, *unFlatOutDataChunk, dataChunkVectorPositions);
-            for (auto j = 0u; j < dataChunk->valueVectors.size(); j++) {
-                auto vectorPtrs = make_unique<overflow_value_t[]>(NODE_SEQUENCE_VECTOR_CAPACITY);
-                BuildSideVectorInfo vectorInfo(dataChunk->valueVectors[j]->getNumBytesPerValue(),
-                    resultSet->dataChunks.size(), j, buildSideVectorPtrs.size());
-                buildSideVectorInfos.push_back(vectorInfo);
-                buildSideVectorPtrs.push_back(move(vectorPtrs));
-            }
+            createVectorPtrs(*dataChunk);
             resultSet->append(unFlatOutDataChunk);
         }
     }
 }
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
-void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::probeHTDirectory() {
-    auto keyCount = hashedProbeKeyVector->state->isFlat() ? 1 : hashedProbeKeyVector->state->size;
-    VectorNodeIDOperations::Hash(*probeSideKeyVector, *hashedProbeKeyVector);
-    auto hashes = (uint64_t*)hashedProbeKeyVector->values;
-    auto directory = (uint8_t**)sharedState->htDirectory->data;
-    if (hashedProbeKeyVector->state->isFlat()) {
-        auto hash = hashes[hashedProbeKeyVector->state->getCurrSelectedValuesPos()] &
-                    sharedState->hashBitMask;
-        probeState->probedTuples[0] = (uint8_t*)(directory[hash]);
-    } else {
-        for (auto i = 0u; i < keyCount; i++) {
-            auto pos = hashedProbeKeyVector->state->selectedValuesPos[i];
-            auto hash = hashes[pos] & sharedState->hashBitMask;
-            probeState->probedTuples[i] = (uint8_t*)(directory[hash]);
-        }
-    }
-    probeState->probedTuplesSize = keyCount;
-}
-
-template<bool IS_OUT_DATACHUNK_FILTERED>
 void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::getNextBatchOfMatchedTuples() {
     do {
-        if (probeState->probedTuplesSize == 0 ||
-            probeState->probeKeyPos == probeState->probedTuplesSize) {
+        if (probeState->matchedTuplesSize == 0) {
             prevOperator->getNextTuples();
             if (probeSideKeyDataChunk->state->size == 0) {
-                probeState->probedTuplesSize = 0;
                 return;
             }
-            probeHTDirectory();
-            VectorNodeIDOperations::Decompress(*probeSideKeyVector, *decompressedProbeKeyVector);
-            probeState->probeKeyPos = 0;
+            probeSideKeyVector->readNodeID(probeSideKeyVector->state->getCurrSelectedValuesPos(),
+                probeState->probeSideKeyNodeID);
+            auto directory = (uint8_t**)sharedState->htDirectory->data;
+            auto hash = Hash::operation<nodeID_t>(probeState->probeSideKeyNodeID) &
+                        sharedState->hashBitMask;
+            probeState->probedTuple = (uint8_t*)(directory[hash]);
         }
-        nodeID_t nodeId;
-        auto decompressedProbeKeys = (nodeID_t*)decompressedProbeKeyVector->values;
-        uint64_t decompressedProbeKeyPos, probeSelPos;
-        for (uint64_t i = probeState->probeKeyPos; i < probeState->probedTuplesSize; i++) {
-            while (probeState->probedTuples[i]) {
-                if (NODE_SEQUENCE_VECTOR_CAPACITY == probeState->matchedTuplesSize) {
-                    break;
-                }
-                memcpy(&nodeId, probeState->probedTuples[i], NUM_BYTES_PER_NODE_ID);
-                probeState->matchedTuples[probeState->matchedTuplesSize] =
-                    probeState->probedTuples[i];
-                if (probeSideKeyDataChunk->state->isFlat()) {
-                    probeSelPos = probeSideKeyDataChunk->state->getCurrSelectedValuesPos();
-                    decompressedProbeKeyPos =
-                        decompressedProbeKeyVector->state->getCurrSelectedValuesPos();
-                } else {
-                    probeSelPos =
-                        probeSideKeyDataChunk->state->selectedValuesPos[probeState->probeKeyPos];
-                    decompressedProbeKeyPos =
-                        decompressedProbeKeyVector->state->selectedValuesPos[i];
-                }
-                probeState->probeSelVector[probeState->matchedTuplesSize] = probeSelPos;
-                probeState->matchedTuplesSize +=
-                    (nodeId.label == decompressedProbeKeys[decompressedProbeKeyPos].label &&
-                        nodeId.offset == decompressedProbeKeys[decompressedProbeKeyPos].offset);
-                probeState->probedTuples[i] =
-                    *(uint8_t**)(probeState->probedTuples[i] +
-                                 sharedState->numBytesForFixedTuplePart - sizeof(uint8_t*));
+        nodeID_t nodeIDFromHT;
+        while (probeState->probedTuple) {
+            if (NODE_SEQUENCE_VECTOR_CAPACITY == probeState->matchedTuplesSize) {
+                break;
             }
-            probeState->probeKeyPos++;
+            memcpy(&nodeIDFromHT, probeState->probedTuple, NUM_BYTES_PER_NODE_ID);
+            probeState->matchedTuples[probeState->matchedTuplesSize] = probeState->probedTuple;
+            probeState->matchedTuplesSize +=
+                (nodeIDFromHT.label == probeState->probeSideKeyNodeID.label &&
+                    nodeIDFromHT.offset == probeState->probeSideKeyNodeID.offset);
+            probeState->probedTuple =
+                *(uint8_t**)(probeState->probedTuple + sharedState->numBytesForFixedTuplePart -
+                             sizeof(uint8_t*));
         }
     } while (probeState->matchedTuplesSize == 0);
 }
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
-void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::populateOutKeyDataChunkAndVectorPtrs() {
-    for (auto i = 0u; i < probeSideKeyDataChunk->valueVectors.size(); i++) {
-        auto probeVector = probeSideKeyDataChunk->getValueVector(i);
-        auto probeVectorValues = probeVector->values;
-        auto outKeyVector = outKeyDataChunk->getValueVector(i);
-        auto outKeyVectorValues = outKeyVector->values;
-        auto numBytesPerValue = outKeyVector->getNumBytesPerValue();
-        if (probeVector->dataType == NODE &&
-            static_pointer_cast<NodeIDVector>(probeVector)->isSequence()) {
-            auto outKeyVectorNodeOffsets = (node_offset_t*)outKeyVectorValues;
-            auto probeKeyStartOffset = *(node_offset_t*)(probeVectorValues);
-            for (auto j = 0u; j < probeState->matchedTuplesSize; j++) {
-                outKeyVectorNodeOffsets[j] = probeKeyStartOffset + probeState->probeSelVector[j];
-            }
-            static_pointer_cast<NodeIDVector>(outKeyVector)->representation.commonLabel =
-                static_pointer_cast<NodeIDVector>(probeVector)->representation.commonLabel;
-        } else {
-            for (auto j = 0u; j < probeState->matchedTuplesSize; j++) {
-                memcpy(outKeyVectorValues + (j * numBytesPerValue),
-                    probeVectorValues + (probeState->probeSelVector[j] * numBytesPerValue),
-                    numBytesPerValue);
-            }
-        }
-    }
-    auto outKeyDataChunkVectorPos = probeSideKeyDataChunk->valueVectors.size();
-    auto tupleReadOffset = NUM_BYTES_PER_NODE_ID;
-    for (auto i = 0u; i < buildSideKeyDataChunk->valueVectors.size(); i++) {
-        if (i == buildSideKeyVectorPos) {
-            continue;
-        }
-        auto outVectorValues = outKeyDataChunk->getValueVector(outKeyDataChunkVectorPos)->values;
-        auto numBytesPerValue = buildSideKeyDataChunk->getValueVector(i)->getNumBytesPerValue();
-        for (auto j = 0u; j < probeState->matchedTuplesSize; j++) {
-            memcpy(outVectorValues + (j * numBytesPerValue),
+void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::copyTuplesFromHT(DataChunk& resultDataChunk,
+    uint64_t numResultVectors, uint64_t resultVectorStartPosition, uint64_t& tupleReadOffset,
+    uint64_t startOffsetInResultVector, uint64_t numTuples) {
+    for (auto i = 0u; i < numResultVectors; i++) {
+        auto resultVector = resultDataChunk.getValueVector(resultVectorStartPosition++);
+        auto numBytesPerValue = resultVector->getNumBytesPerValue();
+        for (auto j = 0u; j < numTuples; j++) {
+            memcpy(resultVector->values + (startOffsetInResultVector * numBytesPerValue),
                 probeState->matchedTuples[j] + tupleReadOffset, numBytesPerValue);
+            startOffsetInResultVector++;
         }
         tupleReadOffset += numBytesPerValue;
-        outKeyDataChunkVectorPos++;
     }
+}
+
+template<bool IS_OUT_DATACHUNK_FILTERED>
+void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::populateResultFlatDataChunksAndVectorPtrs() {
+    // Copy the matched value from the build side key data chunk into the resultKeyDataChunk.
+    auto tupleReadOffset = NUM_BYTES_PER_NODE_ID;
+    copyTuplesFromHT(*resultKeyDataChunk,
+        buildSideResultSet->dataChunks[buildSideKeyDataChunkPos]->valueVectors.size() - 1,
+        numProbeSidePrevKeyValueVectors, tupleReadOffset,
+        resultKeyDataChunk->state->getCurrSelectedValuesPos(), 1);
+    // Copy the matched values from the build side non-key data chunks.
     auto buildSideVectorPtrsPos = 0;
+    auto mergedFlatDataChunkVectorPos = 0;
     for (auto i = 0u; i < buildSideResultSet->dataChunks.size(); i++) {
         if (i == buildSideKeyDataChunkPos) {
             continue;
         }
         auto dataChunk = buildSideResultSet->dataChunks[i];
         if (buildSideDataChunkPosToIsFlat[i]) {
-            for (auto& vector : dataChunk->valueVectors) {
-                auto outVectorValues =
-                    outKeyDataChunk->getValueVector(outKeyDataChunkVectorPos)->values;
-                auto numBytesPerValue = vector->getNumBytesPerValue();
-                for (auto j = 0u; j < probeState->matchedTuplesSize; j++) {
-                    memcpy(outVectorValues + (j * numBytesPerValue),
-                        probeState->matchedTuples[j] + tupleReadOffset, numBytesPerValue);
-                }
-                tupleReadOffset += numBytesPerValue;
-                outKeyDataChunkVectorPos++;
-            }
+            copyTuplesFromHT(*buildSideFlatResultDataChunk, dataChunk->valueVectors.size(),
+                mergedFlatDataChunkVectorPos, tupleReadOffset, 0, probeState->matchedTuplesSize);
+            mergedFlatDataChunkVectorPos += dataChunk->valueVectors.size();
         } else {
             for (auto& vector : dataChunk->valueVectors) {
                 for (auto j = 0u; j < probeState->matchedTuplesSize; j++) {
@@ -243,48 +187,41 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::populateOutKeyDataChunkAndVectorP
             }
         }
     }
-
-    outKeyDataChunk->state->size = probeState->matchedTuplesSize;
+    buildSideFlatResultDataChunk->state->size = probeState->matchedTuplesSize;
     probeState->matchedTuplesSize = 0;
 }
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
-void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::updateAppendedUnFlatOutResultSet() {
-    if (outKeyDataChunk->state->size == 0) {
-        for (auto& buildVectorInfo : buildSideVectorInfos) {
-            auto outDataChunk = resultSet->dataChunks[buildVectorInfo.outDataChunkPos];
-            outDataChunk->state->size = 0;
-        }
-    } else {
-        for (auto& buildVectorInfo : buildSideVectorInfos) {
-            auto outDataChunk = resultSet->dataChunks[buildVectorInfo.outDataChunkPos];
-            auto appendVectorData =
-                outDataChunk->getValueVector(buildVectorInfo.outVectorPos)->values;
-            auto overflowVal = buildSideVectorPtrs[buildVectorInfo.vectorPtrsPos].operator[](
-                outKeyDataChunk->state->currPos);
-            memcpy(appendVectorData, overflowVal.value, overflowVal.len);
-            outDataChunk->state->size = overflowVal.len / buildVectorInfo.numBytesPerValue;
-        }
+void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::updateAppendedUnFlatDataChunks() {
+    for (auto& buildVectorInfo : buildSideVectorInfos) {
+        auto outDataChunk = resultSet->dataChunks[buildVectorInfo.resultDataChunkPos];
+        auto appendVectorData =
+            outDataChunk->getValueVector(buildVectorInfo.resultVectorPos)->values;
+        auto overflowVal = buildSideVectorPtrs[buildVectorInfo.vectorPtrsPos].operator[](
+            buildSideFlatResultDataChunk->state->currPos);
+        memcpy(appendVectorData, overflowVal.value, overflowVal.len);
+        outDataChunk->state->size = overflowVal.len / buildVectorInfo.numBytesPerValue;
     }
 }
 
 // The general flow of a hash join probe:
-// 1) find matched tuples of probe side keys from ht.
-// 2) populate values from matched tuples into outKeyDataChunk and buildSideVectorPtrs.
-// 3) if build side doesn't contain any unflat non-key data chunks, which means buildSideVectorPtrs
-// is empty, directly unflat outKeyDataChunk. else flat outKeyDataChunk and update currPos of
-// outKeyDataChunk, and update appended unflat data chunks based on buildSideVectorPtrs and
-// outKeyDataChunk.currPos.
+// 1) find matched tuples of probe side key from ht.
+// 2) populate values from matched tuples into resultKeyDataChunk , buildSideFlatResultDataChunk
+// (all flat data chunks from the build side are merged into one) and buildSideVectorPtrs (each
+// VectorPtr corresponds to one unFlat build side data chunk that is appended to the resultSet).
+// 3) flat buildSideFlatResultDataChunk, updating its currPos, and also populates appended unFlat
+// data chunks. If there is no appended unFlat data chunks, which means buildSideVectorPtrs is
+// empty, directly unFlat buildSideFlatResultDataChunk (if it exists).
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
     metrics->executionTime.start();
     if (!buildSideVectorPtrs.empty() &&
-        outKeyDataChunk->state->currPos < (int64_t)(outKeyDataChunk->state->size - 1)) {
-        outKeyDataChunk->state->currPos += 1;
-        updateAppendedUnFlatOutResultSet();
+        buildSideFlatResultDataChunk->state->currPos <
+            (int64_t)(buildSideFlatResultDataChunk->state->size - 1)) {
+        buildSideFlatResultDataChunk->state->currPos += 1;
+        updateAppendedUnFlatDataChunks();
         if constexpr (IS_OUT_DATACHUNK_FILTERED) {
-            for (uint64_t i = (probeSideResultSet->dataChunks.size());
-                 i < resultSet->dataChunks.size(); i++) {
+            for (uint64_t i = (numProbeSidePrevDataChunks); i < resultSet->dataChunks.size(); i++) {
                 resultSet->dataChunks[i]->state->initializeSelector();
             }
         }
@@ -293,17 +230,21 @@ void HashJoinProbe<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
         return;
     }
     getNextBatchOfMatchedTuples();
-    populateOutKeyDataChunkAndVectorPtrs();
-    if (buildSideVectorPtrs.empty()) {
-        outKeyDataChunk->state->currPos = -1;
-    } else {
-        outKeyDataChunk->state->currPos = 0;
-        updateAppendedUnFlatOutResultSet();
+    if (probeState->matchedTuplesSize == 0) {
+        // No matching tuples, set size of appended data chunks to 0.
+        buildSideFlatResultDataChunk->state->size = 0;
+        for (auto& buildVectorInfo : buildSideVectorInfos) {
+            auto resultDataChunk = resultSet->dataChunks[buildVectorInfo.resultDataChunkPos];
+            resultDataChunk->state->size = 0;
+        }
+        return;
     }
+    populateResultFlatDataChunksAndVectorPtrs();
+    // UnFlat the buildSideFlatResultDataChunk if there is no build side unFlat non-key data chunks.
+    buildSideFlatResultDataChunk->state->currPos = buildSideVectorPtrs.empty() ? -1 : 0;
+    updateAppendedUnFlatDataChunks();
     if constexpr (IS_OUT_DATACHUNK_FILTERED) {
-        outKeyDataChunk->state->initializeSelector();
-        for (uint64_t i = (probeSideResultSet->dataChunks.size()); i < resultSet->dataChunks.size();
-             i++) {
+        for (uint64_t i = (numProbeSidePrevDataChunks); i < resultSet->dataChunks.size(); i++) {
             resultSet->dataChunks[i]->state->initializeSelector();
         }
     }

--- a/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
@@ -54,6 +54,7 @@ void FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
     do {
         prevOperator->getNextTuples();
         if (inNodeIDVector->state->size == 0) {
+            outDataChunk->state->size = 0;
             metrics->executionTime.stop();
             return;
         }

--- a/test/runner/queries/filtered/id_comparison.test
+++ b/test/runner/queries/filtered/id_comparison.test
@@ -4,7 +4,7 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE id(a) = id(c) RETURN COUNT(*)
 ---- 12
 
--NAME TwoHopKnowsIDEqualTest
+-NAME TwoHopKnowsIDNotEqualTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE id(a) <> id(c) RETURN COUNT(*)
 ---- 24
 

--- a/test/runner/queries/structural/stars.test
+++ b/test/runner/queries/structural/stars.test
@@ -1,6 +1,6 @@
 # description: matching stars
 
--NAME OpenWedgeKnowsTest
+-NAME OpenWedgeKnowsTest1
 -QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:knows]->(c:person) RETURN COUNT(*)
 ---- 40
 
@@ -12,7 +12,7 @@
 -QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:workAt]->(c:organisation) RETURN COUNT(*)
 ---- 8
 
--NAME OpenWedgeKnowsTest
+-NAME OpenWedgeKnowsTest2
 -QUERY MATCH (b:person)-[e1:knows]->(a:person)<-[e2:knows]-(c:person) RETURN COUNT(*)
 ---- 38
 
@@ -20,19 +20,19 @@
 -QUERY MATCH (b:organisation)<-[e1:studyAt]-(a:person)-[e2:studyAt]->(c:organisation) RETURN COUNT(*)
 ---- 3
 
--NAME OpenWedgeWorkAtTest
+-NAME OpenWedgeWorkAtTest1
 -QUERY MATCH (b:organisation)<-[e1:workAt]-(a:person)-[e2:workAt]->(c:organisation) RETURN COUNT(*)
 ---- 3
 
--NAME OpenWedgeWorkAtTest
+-NAME OpenWedgeWorkAtTest2
 -QUERY MATCH (b:organisation)<-[e1:workAt]-(a:person)-[e2:studyAt]->(c:organisation) RETURN COUNT(*)
 ---- 0
 
--NAME OpenWedgeKnowsTest
+-NAME OpenWedgeKnowsTest3
 -QUERY MATCH (b:person)<-[e1:knows]-(a:person)-[e2:knows]->(c:person),(a)-[e3:knows]->(d:person) RETURN COUNT(*)
 ---- 116
 
--NAME OpenWedgeKnowsTest
+-NAME OpenWedgeKnowsTest4
 -QUERY MATCH (b:person)-[e1:knows]->(a:person)<-[e2:knows]-(c:person),(a)<-[e3:knows]-(d:person) RETURN COUNT(*)
 ---- 110
 


### PR DESCRIPTION
This is the fix for issue #179 .

Key changes are:
1) add flatten operator to the probe side if the key is unFlat.
2) the resultKeyDataChunk of HashJoinProbe will always be flat.
3) resultKeyDataChunk reuses the probeSideKeyDataChunk, and the resultSet reuses the probeSideResultSet, so the plan mapper for hash join is simplified.

Minor change:
1) set size of the outDataChunk to 0 for FrontierExtend when the resultSet is assumed to be empty.
2) remove `VectorNodeIDOperations::Decompress`. It's previously used in HashJoinProbe, and not used anywhere now.
3) rename some tests with duplicated names.