### PR TITLE
Adds INT64 and remove INT32

### DIFF
--- a/dataset/tinysnb/eStudyAt.csv
+++ b/dataset/tinysnb/eStudyAt.csv
@@ -1,4 +1,4 @@
-fromLabel:LABEL,from:NODE,toLabel:LABEL,to:NODE,year:INT32
+fromLabel:LABEL,from:NODE,toLabel:LABEL,to:NODE,year:INT64
 person,0,organisation,1,2021
 person,2,organisation,1,2020
 person,8,organisation,1,2020

--- a/dataset/tinysnb/eWorkAt.csv
+++ b/dataset/tinysnb/eWorkAt.csv
@@ -1,4 +1,4 @@
-fromLabel:LABEL,from:NODE,toLabel:LABEL,to:NODE,year:INT32
+fromLabel:LABEL,from:NODE,toLabel:LABEL,to:NODE,year:INT64
 person,3,organisation,4,2015
 person,5,organisation,6,2010
 person,7,organisation,6,2015

--- a/dataset/tinysnb/params.csv
+++ b/dataset/tinysnb/params.csv
@@ -1,3 +1,3 @@
-age:INT32,name:STRING
+age:INT64,name:STRING
 25,Xiyang
 30,Guodong

--- a/dataset/tinysnb/vOrganisation.csv
+++ b/dataset/tinysnb/vOrganisation.csv
@@ -1,4 +1,4 @@
-id:INT32,name:STRING,orgCode:INT32,mark:DOUBLE
+id:INT64,name:STRING,orgCode:INT64,mark:DOUBLE
 1,ABFsUni,325,3.7
 4,CsWork,934,4.1
 6,DEsWork,824,4.1

--- a/dataset/tinysnb/vPerson.csv
+++ b/dataset/tinysnb/vPerson.csv
@@ -1,7 +1,7 @@
-id:INT32,fName:STRING,gender:INT32,isStudent:BOOLEAN,isWorker:BOOLEAN,age:INT32,eyeSight:DOUBLE,birthdate:DATE
+id:INT64,fName:STRING,gender:INT64,isStudent:BOOLEAN,isWorker:BOOLEAN,age:INT64,eyeSight:DOUBLE,birthdate:DATE
 0,Alice,1,true,false,35,5.0,1900-01-01,unstrDateProp1:DATE:1900-01-01,unstrDateProp2:DATE:1920-01-01
-2,Bob,2,true,false,30,5.1,1900-01-01,unstrDateProp1:DATE:1950-01-01,unstrNumericProp:INT32:47,unstrNumericProp2:INT32:20,unstrDateProp2:DATE:1970-01-01
-3,Carol,1,false,true,45,5.0,1940-06-22,unstrNumericProp:INT32:52,unstrDateProp1:DATE:1950-01-01,unstrDateProp2:DATE:1950-01-01
+2,Bob,2,true,false,30,5.1,1900-01-01,unstrDateProp1:DATE:1950-01-01,unstrNumericProp:INT64:47,unstrNumericProp2:INT64:20,unstrDateProp2:DATE:1970-01-01
+3,Carol,1,false,true,45,5.0,1940-06-22,unstrNumericProp:INT64:52,unstrDateProp1:DATE:1950-01-01,unstrDateProp2:DATE:1950-01-01
 5,Dan,2,false,true,20,4.8,1950-7-23
 7,Elizabeth,1,false,true,20,4.7,1980-10-26,unstrNumericProp:DOUBLE:68
 8,Farooq,2,true,false,25,4.5,1980-10-26

--- a/src/binder/expression/literal_expression.cpp
+++ b/src/binder/expression/literal_expression.cpp
@@ -4,19 +4,21 @@ namespace graphflow {
 namespace binder {
 LiteralExpression::LiteralExpression(
     ExpressionType expressionType, DataType dataType, const Literal& literal)
-    : Expression(expressionType, dataType), literal{literal} {}
+    : Expression(expressionType, dataType), literal{literal} {
+    assert(dataType == BOOL || dataType == INT64 || dataType == DOUBLE || dataType == STRING);
+}
 
 void LiteralExpression::castToString() {
     string valAsString;
     switch (dataType) {
     case BOOL:
-        valAsString = literal.val.booleanVal == TRUE ? "True" : "False";
+        valAsString = TypeUtils::toString(literal.val.booleanVal);
         break;
-    case INT32:
-        valAsString = to_string(literal.val.int32Val);
+    case INT64:
+        valAsString = TypeUtils::toString(literal.val.int64Val);
         break;
     case DOUBLE:
-        valAsString = to_string(literal.val.doubleVal);
+        valAsString = TypeUtils::toString(literal.val.doubleVal);
         break;
     default:
         assert(false);

--- a/src/binder/query_binder.cpp
+++ b/src/binder/query_binder.cpp
@@ -156,7 +156,8 @@ shared_ptr<Expression> QueryBinder::bindWhereExpression(const ParsedExpression& 
     auto whereExpression = expressionBinder->bindExpression(parsedExpression);
     if (BOOL != whereExpression->dataType) {
         throw invalid_argument("Type mismatch: " + whereExpression->rawExpression + " returns " +
-                               dataTypeToString(whereExpression->dataType) + " expected Boolean.");
+                               TypeUtils::dataTypeToString(whereExpression->dataType) +
+                               " expected Boolean.");
     }
     return whereExpression;
 }
@@ -203,7 +204,7 @@ void QueryBinder::bindQueryRel(const RelPattern& relPattern, NodeExpression* lef
         auto variableInScope = variablesInScope.at(parsedName);
         if (REL != variableInScope->dataType) {
             throw invalid_argument(parsedName + " defined with conflicting type " +
-                                   dataTypeToString(variableInScope->dataType) +
+                                   TypeUtils::dataTypeToString(variableInScope->dataType) +
                                    " (expect RELATIONSHIP).");
         } else {
             // Bind to queryRel in scope requires QueryRel takes multiple src & dst nodes
@@ -251,7 +252,8 @@ shared_ptr<NodeExpression> QueryBinder::bindQueryNode(
         auto variableInScope = variablesInScope.at(parsedName);
         if (NODE != variableInScope->dataType) {
             throw invalid_argument(parsedName + " defined with conflicting type " +
-                                   dataTypeToString(variableInScope->dataType) + " (expect NODE).");
+                                   TypeUtils::dataTypeToString(variableInScope->dataType) +
+                                   " (expect NODE).");
         }
         queryNode = static_pointer_cast<NodeExpression>(variableInScope);
         auto otherLabel = bindNodeLabel(nodePattern.label);
@@ -306,7 +308,8 @@ vector<pair<string, DataType>> parseCSVHeader(const string& headerLine, char tok
         } else if (propertyDataType.size() > 2) {
             throw invalid_argument("Multiple dataType in " + entry + " is not supported.");
         }
-        headerInfo.emplace_back(make_pair(propertyDataType[0], getDataType(propertyDataType[1])));
+        headerInfo.emplace_back(
+            make_pair(propertyDataType[0], TypeUtils::getDataType(propertyDataType[1])));
     }
     return headerInfo;
 }

--- a/src/common/csv_reader/csv_reader.cpp
+++ b/src/common/csv_reader/csv_reader.cpp
@@ -100,19 +100,19 @@ bool CSVReader::hasNextToken() {
     return true;
 }
 
-int32_t CSVReader::getInt32() {
+int64_t CSVReader::getInt64() {
     setNextTokenIsNotProcessed();
-    return convertToInt32(line + linePtrStart);
+    return TypeUtils::convertToInt64(line + linePtrStart);
 }
 
 double_t CSVReader::getDouble() {
     setNextTokenIsNotProcessed();
-    return convertToDouble(line + linePtrStart);
+    return TypeUtils::convertToDouble(line + linePtrStart);
 }
 
 uint8_t CSVReader::getBoolean() {
     setNextTokenIsNotProcessed();
-    return convertToBoolean(line + linePtrStart);
+    return TypeUtils::convertToBoolean(line + linePtrStart);
 }
 
 char* CSVReader::getString() {

--- a/src/common/include/csv_reader/csv_reader.h
+++ b/src/common/include/csv_reader/csv_reader.h
@@ -38,7 +38,7 @@ public:
     bool skipTokenIfNull();
 
     // reads the data currently pointed to by the cursor and returns the value in a specific format.
-    int32_t getInt32();
+    int64_t getInt64();
     double_t getDouble();
     uint8_t getBoolean();
     char* getString();

--- a/src/common/include/literal.h
+++ b/src/common/include/literal.h
@@ -13,7 +13,7 @@ public:
 
     explicit Literal(uint8_t value) : dataType(BOOL) { this->val.booleanVal = value; }
 
-    explicit Literal(int32_t value) : dataType(INT32) { this->val.int32Val = value; }
+    explicit Literal(int64_t value) : dataType(INT64) { this->val.int64Val = value; }
 
     explicit Literal(double value) : dataType(DOUBLE) { this->val.doubleVal = value; }
 
@@ -26,7 +26,7 @@ public:
 public:
     union Val {
         uint8_t booleanVal;
-        int32_t int32Val;
+        int64_t int64Val;
         double doubleVal;
         nodeID_t nodeID;
     } val{};

--- a/src/common/include/operations/arithmetic_operations.h
+++ b/src/common/include/operations/arithmetic_operations.h
@@ -65,17 +65,17 @@ struct Negate {
  ********************************************/
 
 template<>
-inline void Modulo::operation(int32_t& left, int32_t& right, int32_t& result) {
+inline void Modulo::operation(int64_t& left, int64_t& right, int64_t& result) {
     result = right % left;
 };
 
 template<>
-inline void Modulo::operation(int32_t& left, double_t& right, double_t& result) {
+inline void Modulo::operation(int64_t& left, double_t& right, double_t& result) {
     result = fmod(left, right);
 };
 
 template<>
-inline void Modulo::operation(double_t& left, int32_t& right, double_t& result) {
+inline void Modulo::operation(double_t& left, int64_t& right, double_t& result) {
     result = fmod(left, right);
 };
 
@@ -115,26 +115,26 @@ struct ArithmeticOnValues {
     template<class FUNC, const char* arithmeticOpStr>
     static void operation(Value& left, Value& right, Value& result) {
         switch (left.dataType) {
-        case INT32:
+        case INT64:
             switch (right.dataType) {
-            case INT32:
-                result.dataType = INT32;
-                FUNC::operation(left.val.int32Val, right.val.int32Val, result.val.int32Val);
+            case INT64:
+                result.dataType = INT64;
+                FUNC::operation(left.val.int64Val, right.val.int64Val, result.val.int64Val);
                 break;
             case DOUBLE:
                 result.dataType = DOUBLE;
-                FUNC::operation(left.val.int32Val, right.val.doubleVal, result.val.doubleVal);
+                FUNC::operation(left.val.int64Val, right.val.doubleVal, result.val.doubleVal);
                 break;
             default:
-                throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `INT32` and `" +
-                                       dataTypeToString(right.dataType) + "`");
+                throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `INT64` and `" +
+                                       TypeUtils::dataTypeToString(right.dataType) + "`");
             }
             break;
         case DOUBLE:
             switch (right.dataType) {
-            case INT32:
+            case INT64:
                 result.dataType = DOUBLE;
-                FUNC::operation(left.val.doubleVal, right.val.int32Val, result.val.doubleVal);
+                FUNC::operation(left.val.doubleVal, right.val.int64Val, result.val.doubleVal);
                 break;
             case DOUBLE:
                 result.dataType = DOUBLE;
@@ -142,13 +142,13 @@ struct ArithmeticOnValues {
                 break;
             default:
                 throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `DOUBLE` and `" +
-                                       dataTypeToString(right.dataType) + "`");
+                                       TypeUtils::dataTypeToString(right.dataType) + "`");
             }
             break;
         default:
             throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `" +
-                                   dataTypeToString(left.dataType) + "` and `" +
-                                   dataTypeToString(right.dataType) + "`");
+                                   TypeUtils::dataTypeToString(left.dataType) + "` and `" +
+                                   TypeUtils::dataTypeToString(right.dataType) + "`");
         }
     }
 };
@@ -200,9 +200,9 @@ inline void Power::operation(Value& left, Value& right, Value& result) {
 template<>
 inline void Negate::operation(Value& operand, Value& result) {
     switch (operand.dataType) {
-    case INT32:
-        result.dataType = INT32;
-        result.val.int32Val = -operand.val.int32Val;
+    case INT64:
+        result.dataType = INT64;
+        result.val.int64Val = -operand.val.int64Val;
         break;
     case DOUBLE:
         result.dataType = DOUBLE;

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -80,9 +80,9 @@ struct EqualsOrNotEqualsValues {
             case BOOL:
                 return equals ? Equals::operation(left.val.booleanVal, right.val.booleanVal) :
                                 NotEquals::operation(left.val.booleanVal, right.val.booleanVal);
-            case INT32:
-                return equals ? Equals::operation(left.val.int32Val, right.val.int32Val) :
-                                NotEquals::operation(left.val.int32Val, right.val.int32Val);
+            case INT64:
+                return equals ? Equals::operation(left.val.int64Val, right.val.int64Val) :
+                                NotEquals::operation(left.val.int64Val, right.val.int64Val);
             case DOUBLE:
                 return equals ? Equals::operation(left.val.doubleVal, right.val.doubleVal) :
                                 NotEquals::operation(left.val.doubleVal, right.val.doubleVal);
@@ -95,12 +95,12 @@ struct EqualsOrNotEqualsValues {
             default:
                 assert(false);
             }
-        } else if (left.dataType == INT32 && right.dataType == DOUBLE) {
-            return equals ? Equals::operation(left.val.int32Val, right.val.doubleVal) :
-                            NotEquals::operation(left.val.int32Val, right.val.doubleVal);
-        } else if (left.dataType == DOUBLE && right.dataType == INT32) {
-            return equals ? Equals::operation(left.val.doubleVal, right.val.int32Val) :
-                            NotEquals::operation(left.val.doubleVal, right.val.int32Val);
+        } else if (left.dataType == INT64 && right.dataType == DOUBLE) {
+            return equals ? Equals::operation(left.val.int64Val, right.val.doubleVal) :
+                            NotEquals::operation(left.val.int64Val, right.val.doubleVal);
+        } else if (left.dataType == DOUBLE && right.dataType == INT64) {
+            return equals ? Equals::operation(left.val.doubleVal, right.val.int64Val) :
+                            NotEquals::operation(left.val.doubleVal, right.val.int64Val);
         } else {
             return equals ? FALSE : TRUE;
         }
@@ -168,8 +168,8 @@ struct CompareValues {
             switch (left.dataType) {
             case BOOL:
                 return FUNC::operation(left.val.booleanVal, right.val.booleanVal);
-            case INT32:
-                return FUNC::operation(left.val.int32Val, right.val.int32Val);
+            case INT64:
+                return FUNC::operation(left.val.int64Val, right.val.int64Val);
             case DOUBLE:
                 return FUNC::operation(left.val.doubleVal, right.val.doubleVal);
             case STRING:
@@ -179,10 +179,10 @@ struct CompareValues {
             default:
                 assert(false);
             }
-        } else if (left.dataType == INT32 && right.dataType == DOUBLE) {
-            return FUNC::operation(left.val.int32Val, right.val.doubleVal);
-        } else if (left.dataType == DOUBLE && right.dataType == INT32) {
-            return FUNC::operation(left.val.doubleVal, right.val.int32Val);
+        } else if (left.dataType == INT64 && right.dataType == DOUBLE) {
+            return FUNC::operation(left.val.int64Val, right.val.doubleVal);
+        } else if (left.dataType == DOUBLE && right.dataType == INT64) {
+            return FUNC::operation(left.val.doubleVal, right.val.int64Val);
         } else {
             return NULL_BOOL;
         }
@@ -288,8 +288,8 @@ inline uint8_t IsNull::operation(const uint8_t& value) {
 };
 
 template<>
-inline uint8_t IsNull::operation(const int32_t& value) {
-    return value == NULL_INT32 ? TRUE : FALSE;
+inline uint8_t IsNull::operation(const int64_t& value) {
+    return value == NULL_INT64 ? TRUE : FALSE;
 };
 
 template<>
@@ -313,8 +313,8 @@ inline uint8_t IsNotNull::operation(const uint8_t& value) {
 };
 
 template<>
-inline uint8_t IsNotNull::operation(const int32_t& value) {
-    return value != NULL_INT32 ? TRUE : FALSE;
+inline uint8_t IsNotNull::operation(const int64_t& value) {
+    return value != NULL_INT64 ? TRUE : FALSE;
 };
 
 template<>

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -49,7 +49,7 @@ const uint8_t FALSE = 0;
 const uint8_t TRUE = 1;
 
 const uint8_t NULL_BOOL = 2;
-const int32_t NULL_INT32 = INT32_MIN;
+const int64_t NULL_INT64 = INT64_MIN;
 const double_t NULL_DOUBLE = DBL_MIN;
 const date_t NULL_DATE = date_t(INT32_MIN);
 const uint64_t NUM_BYTES_PER_NODE_ID = sizeof(node_offset_t) + sizeof(label_t);
@@ -59,31 +59,16 @@ enum DataType : uint8_t {
     NODE = 1,
     LABEL = 2,
     BOOL = 3,
-    INT32 = 4,
-    INT64 = 5,
-    DOUBLE = 6,
-    STRING = 7,
-    NODE_ID = 8,
-    UNSTRUCTURED = 9,
-    DATE = 10,
+    INT64 = 4,
+    DOUBLE = 5,
+    STRING = 6,
+    NODE_ID = 7,
+    UNSTRUCTURED = 8,
+    DATE = 9,
 };
 
-const string DataTypeNames[] = {"REL", "NODE", "LABEL", "BOOL", "INT32", "INT64", "DOUBLE",
-    "STRING", "NODE_ID", "UNSTRUCTURED", "DATE"};
-
-int32_t convertToInt32(char* data);
-
-double_t convertToDouble(char* data);
-
-uint8_t convertToBoolean(char* data);
-
-size_t getDataTypeSize(DataType dataType);
-
-DataType getDataType(const std::string& dataTypeString);
-
-string dataTypeToString(DataType dataType);
-
-bool isNumericalType(DataType dataType);
+const string DataTypeNames[] = {
+    "REL", "NODE", "LABEL", "BOOL", "INT64", "DOUBLE", "STRING", "NODE_ID", "UNSTRUCTURED", "DATE"};
 
 // Direction
 enum Direction : uint8_t { FWD = 0, BWD = 1 };
@@ -91,6 +76,42 @@ enum Direction : uint8_t { FWD = 0, BWD = 1 };
 const vector<Direction> DIRECTIONS = {FWD, BWD};
 
 Direction operator!(Direction& direction);
+
+class TypeUtils {
+
+public:
+    static int64_t convertToInt64(const char* data);
+
+    static double_t convertToDouble(const char* data);
+
+    static uint8_t convertToBoolean(const char* data);
+
+    static size_t getDataTypeSize(DataType dataType);
+
+    static DataType getDataType(const std::string& dataTypeString);
+
+    static string dataTypeToString(DataType dataType);
+
+    static bool isNumericalType(DataType dataType);
+
+    static string toString(uint8_t boolVal) {
+        return boolVal == TRUE ? "True" : (boolVal == FALSE ? "False" : "");
+    }
+
+    static string toString(int64_t val) { return to_string(val); }
+
+    static string toString(double val) { return to_string(val); }
+
+    static string toString(nodeID_t val) {
+        return to_string(val.label) + ":" + to_string(val.offset);
+    }
+
+private:
+    static void throwConversionExceptionOutOfRange(const char* data, const DataType dataType);
+    static void throwConversionExceptionIfNoOrNotEveryCharacterIsConsumed(
+        const char* data, const char* eptr, const DataType dataType);
+    static string prefixConversionEexceptionMessage(const char* data, const DataType dataType);
+};
 
 } // namespace common
 } // namespace graphflow

--- a/src/common/include/value.h
+++ b/src/common/include/value.h
@@ -19,7 +19,7 @@ public:
 
     explicit Value(uint8_t value) : dataType(BOOL) { this->val.booleanVal = value; }
 
-    explicit Value(int32_t value) : dataType(INT32) { this->val.int32Val = value; }
+    explicit Value(int64_t value) : dataType(INT64) { this->val.int64Val = value; }
 
     explicit Value(double value) : dataType(DOUBLE) { this->val.doubleVal = value; }
 
@@ -32,7 +32,7 @@ public:
 public:
     union Val {
         uint8_t booleanVal;
-        int32_t int32Val;
+        int64_t int64Val;
         double doubleVal;
         gf_string_t strVal{};
         nodeID_t nodeID;

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -16,7 +16,7 @@ class ValueVector {
 public:
     ValueVector(MemoryManager* memoryManager, DataType dataType, bool isSingleValue = false)
         : ValueVector(memoryManager, isSingleValue ? 1 : DEFAULT_VECTOR_CAPACITY,
-              getDataTypeSize(dataType), dataType) {}
+              TypeUtils::getDataTypeSize(dataType), dataType) {}
 
     virtual ~ValueVector() = default;
 
@@ -30,12 +30,11 @@ public:
     void addString(uint64_t pos, string value) const;
     void addString(uint64_t pos, char* value, uint64_t len) const;
     void allocateStringOverflowSpace(gf_string_t& gfString, uint64_t len) const;
-
     inline void reset() { values = bufferValues.get(); }
 
     void fillNullMask();
 
-    virtual inline int64_t getNumBytesPerValue() { return getDataTypeSize(dataType); }
+    virtual inline int64_t getNumBytesPerValue() { return TypeUtils::getDataTypeSize(dataType); }
 
     virtual shared_ptr<ValueVector> clone();
 

--- a/src/common/literal.cpp
+++ b/src/common/literal.cpp
@@ -11,8 +11,8 @@ Literal& Literal::operator=(const Literal& other) {
     case BOOL: {
         val.booleanVal = other.val.booleanVal;
     } break;
-    case INT32: {
-        val.int32Val = other.val.int32Val;
+    case INT64: {
+        val.int64Val = other.val.int64Val;
     } break;
     case DOUBLE: {
         val.doubleVal = other.val.doubleVal;
@@ -30,16 +30,15 @@ Literal& Literal::operator=(const Literal& other) {
 string Literal::toString() const {
     switch (dataType) {
     case BOOL:
-        return val.booleanVal == TRUE ? "True" : (val.booleanVal == FALSE ? "False" : "");
-    case INT32:
+        return TypeUtils::toString(val.booleanVal);
     case INT64:
-        return to_string(val.int32Val);
+        return TypeUtils::toString(val.int64Val);
     case DOUBLE:
-        return to_string(val.doubleVal);
+        return TypeUtils::toString(val.doubleVal);
     case STRING:
         return strVal;
     case NODE:
-        return to_string(val.nodeID.label) + ":" + to_string(val.nodeID.offset);
+        return TypeUtils::toString(val.nodeID);
     default:
         assert(false);
     }

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 
 #include "src/common/include/date.h"
+#include "src/common/include/types.h"
 
 using namespace std;
 
@@ -15,8 +16,8 @@ Value& Value::operator=(const Value& other) {
     case BOOL: {
         val.booleanVal = other.val.booleanVal;
     } break;
-    case INT32: {
-        val.int32Val = other.val.int32Val;
+    case INT64: {
+        val.int64Val = other.val.int64Val;
     } break;
     case DOUBLE: {
         val.doubleVal = other.val.doubleVal;
@@ -37,16 +38,15 @@ Value& Value::operator=(const Value& other) {
 string Value::toString() const {
     switch (dataType) {
     case BOOL:
-        return val.booleanVal == TRUE ? "True" : (val.booleanVal == FALSE ? "False" : "");
-    case INT32:
+        return TypeUtils::toString(val.booleanVal);
     case INT64:
-        return to_string(val.int32Val);
+        return TypeUtils::toString(val.int64Val);
     case DOUBLE:
-        return to_string(val.doubleVal);
+        return TypeUtils::toString(val.doubleVal);
     case STRING:
         return val.strVal.getAsString();
     case NODE:
-        return to_string(val.nodeID.label) + ":" + to_string(val.nodeID.offset);
+        return TypeUtils::toString(val.nodeID);
     case DATE:
         return Date::toString(val.dateVal);
     default:

--- a/src/common/vector/operations/vector_arithmetic_operations.cpp
+++ b/src/common/vector/operations/vector_arithmetic_operations.cpp
@@ -1,7 +1,6 @@
 #include "src/common/include/vector/operations/vector_arithmetic_operations.h"
 
 #include <cassert>
-#include <stdexcept>
 
 #include "src/common/include/operations/arithmetic_operations.h"
 #include "src/common/include/vector/operations/executors/binary_operation_executor.h"
@@ -15,21 +14,21 @@ public:
     template<class OP>
     static inline void execute(ValueVector& left, ValueVector& right, ValueVector& result) {
         switch (left.dataType) {
-        case INT32:
+        case INT64:
             switch (right.dataType) {
-            case INT32:
+            case INT64:
                 if (std::is_same<OP, operation::Power>::value) {
-                    BinaryOperationExecutor::executeArithmeticOps<int32_t, int32_t, double_t, OP,
+                    BinaryOperationExecutor::executeArithmeticOps<int64_t, int64_t, double_t, OP,
                         false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
                         left, right, result);
                 } else {
-                    BinaryOperationExecutor::executeArithmeticOps<int32_t, int32_t, int32_t, OP,
+                    BinaryOperationExecutor::executeArithmeticOps<int64_t, int64_t, int64_t, OP,
                         false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
                         left, right, result);
                 }
                 break;
             case DOUBLE:
-                BinaryOperationExecutor::executeArithmeticOps<int32_t, double_t, double_t, OP,
+                BinaryOperationExecutor::executeArithmeticOps<int64_t, double_t, double_t, OP,
                     false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
                     left, right, result);
                 break;
@@ -39,8 +38,8 @@ public:
             break;
         case DOUBLE:
             switch (right.dataType) {
-            case INT32:
-                BinaryOperationExecutor::executeArithmeticOps<double_t, int32_t, double_t, OP,
+            case INT64:
+                BinaryOperationExecutor::executeArithmeticOps<double_t, int64_t, double_t, OP,
                     false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
                     left, right, result);
                 break;
@@ -56,9 +55,7 @@ public:
         case UNSTRUCTURED:
             assert(right.dataType == UNSTRUCTURED);
             BinaryOperationExecutor::executeArithmeticOps<Value, Value, Value, OP,
-                false
-                /* IS_STRUCTURED_STRING */,
-                true /* IS_UNSTRUCTURED */>(left, right, result);
+                false /* IS_STRUCTURED_STRING */, true /* IS_UNSTRUCTURED */>(left, right, result);
             break;
         default:
             assert(false);
@@ -68,8 +65,8 @@ public:
     template<class OP>
     static inline void execute(ValueVector& operand, ValueVector& result) {
         switch (operand.dataType) {
-        case INT32:
-            UnaryOperationExecutor::executeArithmeticOps<int32_t, int32_t, OP>(operand, result);
+        case INT64:
+            UnaryOperationExecutor::executeArithmeticOps<int64_t, int64_t, OP>(operand, result);
             break;
         case DOUBLE:
             UnaryOperationExecutor::executeArithmeticOps<double_t, double_t, OP>(operand, result);

--- a/src/common/vector/operations/vector_cast_operations.cpp
+++ b/src/common/vector/operations/vector_cast_operations.cpp
@@ -19,8 +19,8 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
         case BOOL: {
             outValues[resPos].val.booleanVal = operand.values[pos];
         } break;
-        case INT32: {
-            outValues[resPos].val.int32Val = ((int32_t*)operand.values)[pos];
+        case INT64: {
+            outValues[resPos].val.int64Val = ((int64_t*)operand.values)[pos];
         } break;
         case DOUBLE: {
             outValues[resPos].val.doubleVal = ((double_t*)operand.values)[pos];
@@ -44,11 +44,11 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
                 outValues[pos].val.booleanVal = operand.values[pos];
             }
         } break;
-        case INT32: {
-            auto intValues = (int32_t*)operand.values;
+        case INT64: {
+            auto intValues = (int64_t*)operand.values;
             for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
-                outValues[pos].val.int32Val = intValues[pos];
+                outValues[pos].val.int64Val = intValues[pos];
             }
         } break;
         case DOUBLE: {
@@ -80,7 +80,7 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
 }
 
 void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, ValueVector& result) {
-    assert((operand.dataType == INT32 || operand.dataType == DOUBLE || operand.dataType == BOOL ||
+    assert((operand.dataType == INT64 || operand.dataType == DOUBLE || operand.dataType == BOOL ||
                operand.dataType == DATE) &&
            result.dataType == STRING);
     if (operand.state->isFlat()) {
@@ -92,8 +92,8 @@ void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, Val
             val = operand.values[pos] == TRUE ? "True" :
                                                 (operand.values[pos] == FALSE ? "False" : "");
         } break;
-        case INT32: {
-            val = to_string(((int32_t*)operand.values)[pos]);
+        case INT64: {
+            val = to_string(((int64_t*)operand.values)[pos]);
         } break;
         case DOUBLE: {
             val = to_string(((double_t*)operand.values)[pos]);
@@ -115,8 +115,8 @@ void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, Val
                                           (operand.values[pos] == FALSE ? "False" : ""));
             }
         } break;
-        case INT32: {
-            auto intValues = (int32_t*)operand.values;
+        case INT64: {
+            auto intValues = (int64_t*)operand.values;
             for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
                 result.addString(pos, to_string(intValues[pos]));

--- a/src/common/vector/operations/vector_comparison_operations.cpp
+++ b/src/common/vector/operations/vector_comparison_operations.cpp
@@ -24,14 +24,14 @@ public:
                 assert(false);
             }
             break;
-        case INT32:
+        case INT64:
             switch (right.dataType) {
-            case INT32:
-                BinaryOperationExecutor::executeComparisonOps<int32_t, int32_t, OP>(
+            case INT64:
+                BinaryOperationExecutor::executeComparisonOps<int64_t, int64_t, OP>(
                     left, right, result);
                 break;
             case DOUBLE:
-                BinaryOperationExecutor::executeComparisonOps<int32_t, double_t, OP>(
+                BinaryOperationExecutor::executeComparisonOps<int64_t, double_t, OP>(
                     left, right, result);
                 break;
             default:
@@ -40,8 +40,8 @@ public:
             break;
         case DOUBLE:
             switch (right.dataType) {
-            case INT32:
-                BinaryOperationExecutor::executeComparisonOps<double_t, int32_t, OP>(
+            case INT64:
+                BinaryOperationExecutor::executeComparisonOps<double_t, int64_t, OP>(
                     left, right, result);
                 break;
             case DOUBLE:

--- a/src/common/vector/operations/vector_hash_operations.cpp
+++ b/src/common/vector/operations/vector_hash_operations.cpp
@@ -10,9 +10,6 @@ struct VectorHashExecutor {
     template<class OP>
     static inline void execute(ValueVector& operand, ValueVector& result) {
         switch (operand.dataType) {
-        case INT32:
-            UnaryOperationExecutor::executeHashOps<int32_t, OP>(operand, result);
-            break;
         case INT64:
             UnaryOperationExecutor::executeHashOps<int64_t, OP>(operand, result);
             break;

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -26,8 +26,8 @@ void ValueVector::fillNullMask() {
     case BOOL:
         fillOperandNullMask<uint8_t>(*this);
         break;
-    case INT32:
-        fillOperandNullMask<int32_t>(*this);
+    case INT64:
+        fillOperandNullMask<int64_t>(*this);
         break;
     case DOUBLE:
         fillOperandNullMask<double_t>(*this);
@@ -40,8 +40,8 @@ void ValueVector::fillNullMask() {
         //  Currently we do not distinguish empty and NULL gf_string_t.
         break;
     default:
-        throw std::invalid_argument(
-            "Invalid or unsupported type for comparison: " + dataTypeToString(dataType) + ".");
+        throw std::invalid_argument("Invalid or unsupported type for comparison: " +
+                                    TypeUtils::dataTypeToString(dataType) + ".");
     }
 }
 

--- a/src/loader/adj_and_prop_lists_builder.cpp
+++ b/src/loader/adj_and_prop_lists_builder.cpp
@@ -71,8 +71,8 @@ void AdjAndPropertyListsBuilder::setProperty(const vector<uint64_t>& pos,
     for (auto& direction : DIRECTIONS) {
         auto header = directionLabelAdjListHeaders[direction][nodeIDs[direction].label]
                           .headers[nodeIDs[direction].offset];
-        ListsLoaderHelper::calculatePageCursor(header, pos[direction], getDataTypeSize(type),
-            nodeIDs[direction].offset, cursor,
+        ListsLoaderHelper::calculatePageCursor(header, pos[direction],
+            TypeUtils::getDataTypeSize(type), nodeIDs[direction].offset, cursor,
             directionLabelPropertyIdxPropertyListsMetadata[direction][nodeIDs[direction].label]
                                                           [propertyIdx]);
         directionLabelPropertyIdxPropertyLists[direction][nodeIDs[direction].label][propertyIdx]
@@ -86,7 +86,7 @@ void AdjAndPropertyListsBuilder::setStringProperty(const vector<uint64_t>& pos,
     PageCursor propertyListCursor;
     ListsLoaderHelper::calculatePageCursor(
         directionLabelAdjListHeaders[FWD][nodeIDs[FWD].label].headers[nodeIDs[FWD].offset],
-        pos[FWD], getDataTypeSize(STRING), nodeIDs[FWD].offset, propertyListCursor,
+        pos[FWD], TypeUtils::getDataTypeSize(STRING), nodeIDs[FWD].offset, propertyListCursor,
         directionLabelPropertyIdxPropertyListsMetadata[FWD][nodeIDs[FWD].label][propertyIdx]);
     auto encodedStrFwd = reinterpret_cast<gf_string_t*>(
         directionLabelPropertyIdxPropertyLists[FWD][nodeIDs[FWD].label][propertyIdx]
@@ -95,12 +95,12 @@ void AdjAndPropertyListsBuilder::setStringProperty(const vector<uint64_t>& pos,
         strVal, stringOverflowCursor, encodedStrFwd);
     ListsLoaderHelper::calculatePageCursor(
         directionLabelAdjListHeaders[BWD][nodeIDs[BWD].label].headers[nodeIDs[BWD].offset],
-        pos[BWD], getDataTypeSize(STRING), nodeIDs[BWD].offset, propertyListCursor,
+        pos[BWD], TypeUtils::getDataTypeSize(STRING), nodeIDs[BWD].offset, propertyListCursor,
         directionLabelPropertyIdxPropertyListsMetadata[BWD][nodeIDs[BWD].label][propertyIdx]);
     auto encodedStrBwd = reinterpret_cast<gf_string_t*>(
         directionLabelPropertyIdxPropertyLists[BWD][nodeIDs[BWD].label][propertyIdx]
             ->getPtrToMemLoc(propertyListCursor));
-    memcpy((void*)encodedStrBwd, (void*)encodedStrFwd, getDataTypeSize(STRING));
+    memcpy((void*)encodedStrBwd, (void*)encodedStrFwd, TypeUtils::getDataTypeSize(STRING));
 }
 
 void AdjAndPropertyListsBuilder::sortOverflowStrings() {
@@ -241,7 +241,7 @@ void AdjAndPropertyListsBuilder::initAdjListsAndPropertyListsMetadata() {
                 auto numNodeOffsets = graph.getNumNodesPerLabel()[nodeLabel];
                 for (auto& property : description.properties) {
                     auto idx = property.id;
-                    auto numPerPage = PAGE_SIZE / getDataTypeSize(property.dataType);
+                    auto numPerPage = PAGE_SIZE / TypeUtils::getDataTypeSize(property.dataType);
                     threadPool.execute(ListsLoaderHelper::calculateListsMetadataTask,
                         numNodeOffsets, numPerPage, listsSizes,
                         &directionLabelAdjListHeaders[direction][nodeLabel],
@@ -291,7 +291,7 @@ void AdjAndPropertyListsBuilder::buildInMemPropertyLists() {
                     make_unique<InMemPropertyPages>(fName,
                         directionLabelPropertyIdxPropertyListsMetadata[direction][nodeLabel][idx]
                             .numPages,
-                        getDataTypeSize(property.dataType));
+                        TypeUtils::getDataTypeSize(property.dataType));
             }
         }
     }
@@ -320,7 +320,7 @@ void AdjAndPropertyListsBuilder::sortOverflowStringsOfPropertyListsTask(node_off
             len = ListHeaders::getSmallListLen(header);
         }
         for (auto pos = len; pos > 0; pos--) {
-            ListsLoaderHelper::calculatePageCursor(header, pos, getDataTypeSize(STRING),
+            ListsLoaderHelper::calculatePageCursor(header, pos, TypeUtils::getDataTypeSize(STRING),
                 offsetStart, propertyListCursor, *listsMetadata);
             auto valPtr =
                 reinterpret_cast<gf_string_t*>(propertyLists->getPtrToMemLoc(propertyListCursor));

--- a/src/loader/graph_loader.cpp
+++ b/src/loader/graph_loader.cpp
@@ -154,7 +154,7 @@ vector<PropertyDefinition> GraphLoader::parseHeader(string& header) const {
                 "Property name " + propertyName + " already exists in the node label.");
         }
         propertyNameSet.insert(propertyName);
-        auto dataType = getDataType(propertyDescriptors[1]);
+        auto dataType = TypeUtils::getDataType(propertyDescriptors[1]);
         if (NODE != dataType && LABEL != dataType) {
             propertyDefinitions.emplace_back(propertyName, propertyId++, dataType);
         }

--- a/src/loader/rels_loader.cpp
+++ b/src/loader/rels_loader.cpp
@@ -224,10 +224,10 @@ void RelsLoader::putPropsOfLineIntoInMemPropertyColumns(
     auto propertyIdx = 0u;
     while (reader.hasNextToken()) {
         switch (properties[propertyIdx].dataType) {
-        case INT32: {
-            auto intVal = reader.skipTokenIfNull() ? NULL_INT32 : reader.getInt32();
+        case INT64: {
+            auto intVal = reader.skipTokenIfNull() ? NULL_INT64 : reader.getInt64();
             adjAndPropertyColumnsBuilder->setProperty(
-                nodeID, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT32);
+                nodeID, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT64);
             break;
         }
         case DOUBLE: {
@@ -273,10 +273,10 @@ void RelsLoader::putPropsOfLineIntoInMemRelPropLists(const vector<PropertyDefini
     auto propertyIdx = 0;
     while (reader.hasNextToken()) {
         switch (properties[propertyIdx].dataType) {
-        case INT32: {
-            auto intVal = reader.skipTokenIfNull() ? NULL_INT32 : reader.getInt32();
+        case INT64: {
+            auto intVal = reader.skipTokenIfNull() ? NULL_INT64 : reader.getInt64();
             adjAndPropertyListsBuilder->setProperty(
-                pos, nodeIDs, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT32);
+                pos, nodeIDs, propertyIdx, reinterpret_cast<uint8_t*>(&intVal), INT64);
             break;
         }
         case DOUBLE: {

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -112,8 +112,8 @@ static unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToUnstructured
     auto& val = ((Value*)vector->values)[0];
     val.dataType = literalExpression.literal.dataType;
     switch (val.dataType) {
-    case INT32: {
-        val.val.int32Val = literalExpression.literal.val.int32Val;
+    case INT64: {
+        val.val.int64Val = literalExpression.literal.val.int64Val;
     } break;
     case DOUBLE: {
         val.val.doubleVal = literalExpression.literal.val.doubleVal;
@@ -140,8 +140,8 @@ unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToStructuredPhysical(
         &memoryManager, literalExpression.dataType, true /* isSingleValue */);
     vector->state = VectorState::getSingleValueDataChunkState();
     switch (expression.dataType) {
-    case INT32: {
-        ((int32_t*)vector->values)[0] = literalExpression.literal.val.int32Val;
+    case INT64: {
+        ((int64_t*)vector->values)[0] = literalExpression.literal.val.int64Val;
     } break;
     case DOUBLE: {
         ((double_t*)vector->values)[0] = literalExpression.literal.val.doubleVal;

--- a/src/processor/physical_plan/operator/load_csv/load_csv.cpp
+++ b/src/processor/physical_plan/operator/load_csv/load_csv.cpp
@@ -41,9 +41,9 @@ void LoadCSV<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
             auto& vector = *outValueVectors[tokenIdx];
             auto vectorDataType = csvColumnDataTypes[tokenIdx];
             switch (vectorDataType) {
-            case INT32: {
-                ((int*)vector.values)[lineIdx] =
-                    reader.skipTokenIfNull() ? NULL_INT32 : reader.getInt32();
+            case INT64: {
+                ((int64_t*)vector.values)[lineIdx] =
+                    reader.skipTokenIfNull() ? NULL_INT64 : reader.getInt64();
                 break;
             }
             case DOUBLE: {

--- a/src/processor/physical_plan/operator/result/result_set_iterator.cpp
+++ b/src/processor/physical_plan/operator/result/result_set_iterator.cpp
@@ -63,9 +63,9 @@ void ResultSetIterator::getNextTuple(Tuple& tuple) {
         for (auto& vector : dataChunk->valueVectors) {
             auto selectedTuplePos = vector->state->selectedValuesPos[tuplePosition];
             switch (vector->dataType) {
-            case INT32: {
-                tuple.getValue(valueInTupleIdx)->val.int32Val =
-                    (((int32_t*)vector->values)[selectedTuplePos]);
+            case INT64: {
+                tuple.getValue(valueInTupleIdx)->val.int64Val =
+                    (((int64_t*)vector->values)[selectedTuplePos]);
             } break;
             case BOOL: {
                 tuple.getValue(valueInTupleIdx)->val.booleanVal = vector->values[selectedTuplePos];

--- a/src/storage/data_structure/lists/lists.cpp
+++ b/src/storage/data_structure/lists/lists.cpp
@@ -183,7 +183,7 @@ void Lists<UNSTRUCTURED>::readOrSkipUnstrPropertyValue(uint64_t& physicalPageIdx
     const shared_ptr<ValueVector>& valueVector, uint64_t pos, bool toRead,
     BufferManagerMetrics& metrics) {
     auto frame = bufferManager.get(fileHandle, physicalPageIdx, metrics);
-    auto dataTypeSize = getDataTypeSize(propertyDataType);
+    auto dataTypeSize = TypeUtils::getDataTypeSize(propertyDataType);
     auto values = (Value*)valueVector->values;
     if (pageCursor.offset + dataTypeSize < PAGE_SIZE) {
         if (toRead) {

--- a/src/storage/include/data_structure/column.h
+++ b/src/storage/include/data_structure/column.h
@@ -37,7 +37,7 @@ class Column : public BaseColumn {
 
 public:
     Column(const string& path, const uint64_t& numElements, BufferManager& bufferManager)
-        : BaseColumn{path, D, getDataTypeSize(D), numElements, bufferManager} {};
+        : BaseColumn{path, D, TypeUtils::getDataTypeSize(D), numElements, bufferManager} {};
 };
 
 template<>
@@ -75,7 +75,7 @@ private:
     NodeIDCompressionScheme nodeIDCompressionScheme;
 };
 
-typedef Column<INT32> PropertyColumnInt;
+typedef Column<INT64> PropertyColumnInt64;
 typedef Column<DOUBLE> PropertyColumnDouble;
 typedef Column<BOOL> PropertyColumnBool;
 typedef Column<STRING> PropertyColumnString;

--- a/src/storage/include/data_structure/lists/lists.h
+++ b/src/storage/include/data_structure/lists/lists.h
@@ -48,7 +48,7 @@ class Lists : public BaseLists {
 
 public:
     Lists(const string& fname, shared_ptr<ListHeaders> headers, BufferManager& bufferManager)
-        : BaseLists{fname, D, getDataTypeSize(D), headers, bufferManager} {};
+        : BaseLists{fname, D, TypeUtils::getDataTypeSize(D), headers, bufferManager} {};
 };
 
 // Lists<NODE> is the specialization of Lists<D> for lists of nodeIDs.
@@ -117,7 +117,7 @@ public:
     FileHandle overflowPagesFileHandle;
 };
 
-typedef Lists<INT32> RelPropertyListsInt;
+typedef Lists<INT64> RelPropertyListsInt64;
 typedef Lists<DOUBLE> RelPropertyListsDouble;
 typedef Lists<BOOL> RelPropertyListsBool;
 typedef Lists<STRING> RelPropertyListsString;

--- a/src/storage/include/store/nodes_store.h
+++ b/src/storage/include/store/nodes_store.h
@@ -39,7 +39,7 @@ public:
     }
 
 private:
-    void initPropertyColumnsAndLists(const Catalog& catalog,
+    void initStructuredPropertyColumnsAndUnstructuredPropertyLists(const Catalog& catalog,
         const vector<uint64_t>& numNodesPerLabel, const string& directory,
         BufferManager& bufferManager);
 

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -12,7 +12,8 @@ HashIndex::HashIndex(const string& indexPath, uint64_t indexId, MemoryManager& m
     : memoryManager{memoryManager}, bufferManager{bufferManager}, overflowPagesManager{
                                                                       overflowPagesManager} {
     // Entry in slot: hash + key (fixed sized part) + node_offset
-    numBytesPerEntry = sizeof(uint64_t) + getDataTypeSize(keyType) + sizeof(node_offset_t);
+    numBytesPerEntry =
+        sizeof(uint64_t) + TypeUtils::getDataTypeSize(keyType) + sizeof(node_offset_t);
     numBytesPerSlot = (numBytesPerEntry * indexHeader.slotCapacity) + NUM_BYTES_PER_SLOT_HEADER;
     numSlotsPerPrimaryBlock = PAGE_SIZE / numBytesPerSlot;
     numSlotsPerOverflowBlock = numSlotsPerPrimaryBlock;

--- a/src/storage/store/nodes_store.cpp
+++ b/src/storage/store/nodes_store.cpp
@@ -11,11 +11,12 @@ NodesStore::NodesStore(const Catalog& catalog, const vector<uint64_t>& numNodesP
     const string& directory, BufferManager& bufferManager)
     : logger{spdlog::get("storage")} {
     logger->info("Initializing NodesStore.");
-    initPropertyColumnsAndLists(catalog, numNodesPerLabel, directory, bufferManager);
+    initStructuredPropertyColumnsAndUnstructuredPropertyLists(
+        catalog, numNodesPerLabel, directory, bufferManager);
     logger->info("Done NodesStore.");
 }
 
-void NodesStore::initPropertyColumnsAndLists(const Catalog& catalog,
+void NodesStore::initStructuredPropertyColumnsAndUnstructuredPropertyLists(const Catalog& catalog,
     const vector<uint64_t>& numNodesPerLabel, const string& directory,
     BufferManager& bufferManager) {
     auto numNodeLabels = catalog.getNodeLabelsCount();
@@ -30,8 +31,8 @@ void NodesStore::initPropertyColumnsAndLists(const Catalog& catalog,
             logger->debug("nodeLabel {} propertyId {} type {} name `{}`", nodeLabel, property.id,
                 property.dataType, property.name);
             switch (property.dataType) {
-            case INT32:
-                propertyColumns[nodeLabel][propertyId] = make_unique<PropertyColumnInt>(
+            case INT64:
+                propertyColumns[nodeLabel][propertyId] = make_unique<PropertyColumnInt64>(
                     fName, numNodesPerLabel[nodeLabel], bufferManager);
                 break;
             case DOUBLE:

--- a/src/storage/store/rels_store.cpp
+++ b/src/storage/store/rels_store.cpp
@@ -110,9 +110,10 @@ void RelsStore::initPropertyColumnsForRelLabel(const Catalog& catalog,
             logger->debug("DIR {} nodeLabel {} propertyIdx {} type {} name `{}`", dir, nodeLabel,
                 property.id, property.dataType, property.name);
             switch (property.dataType) {
-            case INT32:
-                propertyColumns[nodeLabel][relLabel][property.id] = make_unique<PropertyColumnInt>(
-                    fname, numNodesPerLabel[nodeLabel], bufferManager);
+            case INT64:
+                propertyColumns[nodeLabel][relLabel][property.id] =
+                    make_unique<PropertyColumnInt64>(
+                        fname, numNodesPerLabel[nodeLabel], bufferManager);
                 break;
             case DOUBLE:
                 propertyColumns[nodeLabel][relLabel][property.id] =
@@ -151,9 +152,9 @@ void RelsStore::initPropertyListsForRelLabel(const Catalog& catalog,
                 logger->debug("DIR {} nodeLabel {} propertyIdx {} type {} name `{}`", dir,
                     nodeLabel, property.id, property.dataType, property.name);
                 switch (property.dataType) {
-                case INT32:
+                case INT64:
                     propertyLists[dir][nodeLabel][relLabel][property.id] =
-                        make_unique<RelPropertyListsInt>(fname, adjListsHeaders, bufferManager);
+                        make_unique<RelPropertyListsInt64>(fname, adjListsHeaders, bufferManager);
                     break;
                 case DOUBLE:
                     propertyLists[dir][nodeLabel][relLabel][property.id] =

--- a/src/transaction/local_storage.cpp
+++ b/src/transaction/local_storage.cpp
@@ -4,24 +4,24 @@ namespace graphflow {
 namespace transaction {
 
 static unique_ptr<uint8_t[]> getNullValuePtrForDataType(DataType dataType) {
-    auto nullValue = make_unique<uint8_t[]>(getDataTypeSize(dataType));
+    auto nullValue = make_unique<uint8_t[]>(TypeUtils::getDataTypeSize(dataType));
     switch (dataType) {
-    case INT32:
-        memcpy(nullValue.get(), &NULL_INT32, getDataTypeSize(dataType));
+    case INT64:
+        memcpy(nullValue.get(), &NULL_INT64, TypeUtils::getDataTypeSize(dataType));
         break;
     case DOUBLE:
-        memcpy(nullValue.get(), &NULL_DOUBLE, getDataTypeSize(dataType));
+        memcpy(nullValue.get(), &NULL_DOUBLE, TypeUtils::getDataTypeSize(dataType));
         break;
     case BOOL:
-        memcpy(nullValue.get(), &NULL_BOOL, getDataTypeSize(dataType));
+        memcpy(nullValue.get(), &NULL_BOOL, TypeUtils::getDataTypeSize(dataType));
         break;
     case DATE:
-        memcpy(nullValue.get(), &NULL_DATE, getDataTypeSize(dataType));
+        memcpy(nullValue.get(), &NULL_DATE, TypeUtils::getDataTypeSize(dataType));
         break;
     case STRING: {
         gf_string_t nullStr;
         nullStr.set(string(&gf_string_t::EMPTY_STRING));
-        memcpy(nullValue.get(), &NULL_BOOL, getDataTypeSize(dataType));
+        memcpy(nullValue.get(), &NULL_BOOL, TypeUtils::getDataTypeSize(dataType));
         break;
     }
     default:

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -83,7 +83,7 @@ TEST_F(BinderErrorTest, BindToDifferentVariableType1) {
 }
 
 TEST_F(BinderErrorTest, BindToDifferentVariableType2) {
-    string expectedException = "a defined with conflicting type INT32 (expect NODE).";
+    string expectedException = "a defined with conflicting type INT64 (expect NODE).";
     auto input = "MATCH (a:person)-[e1:knows]->(b:person) WITH a.age + 1 AS a MATCH (a) RETURN *;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
@@ -108,7 +108,7 @@ TEST_F(BinderErrorTest, BindVariableNotInScope2) {
 }
 
 TEST_F(BinderErrorTest, BindPropertyLookUpOnExpression) {
-    string expectedException = "Type mismatch: expect NODE or REL, but a.age + 2 was INT32.";
+    string expectedException = "Type mismatch: expect NODE or REL, but a.age + 2 was INT64.";
     auto input = "MATCH (a:person)-[e1:knows]->(b:person) RETURN (a.age + 2).age;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -20,10 +20,10 @@ public:
 
 TEST_F(BinderTest, LOADCSVBasicTest) {
     auto expectedCSVColumnInfo = vector<pair<string, DataType>>();
-    expectedCSVColumnInfo.emplace_back(make_pair("age", INT32));
+    expectedCSVColumnInfo.emplace_back(make_pair("age", INT64));
     expectedCSVColumnInfo.emplace_back(make_pair("name", STRING));
     auto csvLines = vector<shared_ptr<Expression>>();
-    auto csvLine0 = make_shared<Expression>(CSV_LINE_EXTRACT, INT32, "_gf0_csvLine[0]");
+    auto csvLine0 = make_shared<Expression>(CSV_LINE_EXTRACT, INT64, "_gf0_csvLine[0]");
     csvLine0->alias = "csvLine[0]";
     auto csvLine1 = make_shared<Expression>(CSV_LINE_EXTRACT, STRING, "_gf0_csvLine[1]");
     csvLine1->alias = "csvLine[1]";

--- a/test/common/BUILD.bazel
+++ b/test/common/BUILD.bazel
@@ -16,8 +16,9 @@ cc_test(
 )
 
 cc_test(
-    name = "date_test",
+    name = "types_test",
     srcs = [
+        "types_test.cpp",
         "date_test.cpp",
     ],
     copts = [

--- a/test/common/date_test.cpp
+++ b/test/common/date_test.cpp
@@ -17,18 +17,20 @@ TEST(DateTests, FromDate) {
     // Year out of range
     try {
         date_t result = Date::FromDate(110000, 11, 42);
-    } catch (ConversionException e) {
-    } catch (exception e) { FAIL(); }
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
     // Month out of range
     try {
         date_t result = Date::FromDate(2000, 15, 22);
-    } catch (ConversionException e) {
-    } catch (exception e) { FAIL(); }
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
     // Day out of range
     try {
         date_t result = Date::FromDate(2000, 11, 42);
-    } catch (ConversionException e) {
-    } catch (exception e) { FAIL(); }
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
 
     EXPECT_EQ(0, Date::FromDate(1970, 1, 1).days);
     EXPECT_EQ(7, Date::FromDate(1970, 1, 8).days);

--- a/test/common/types_test.cpp
+++ b/test/common/types_test.cpp
@@ -1,0 +1,131 @@
+#include <string>
+
+#include "include/gtest/gtest.h"
+
+#include "src/common/include/exception.h"
+#include "src/common/include/types.h"
+
+using namespace graphflow::common;
+using namespace std;
+
+TEST(TypesTests, StringToINT64Conversion) {
+    EXPECT_EQ(2147483648, TypeUtils::TypeUtils::convertToInt64("2147483648"));
+    EXPECT_EQ(-2147483648, TypeUtils::TypeUtils::convertToInt64("-2147483648"));
+    EXPECT_EQ(2147483648000, TypeUtils::TypeUtils::convertToInt64("2147483648000"));
+    EXPECT_EQ(-2147483648000, TypeUtils::TypeUtils::convertToInt64("-2147483648000"));
+    EXPECT_EQ(648, TypeUtils::TypeUtils::convertToInt64("648"));
+    EXPECT_EQ(-648, TypeUtils::TypeUtils::convertToInt64("-648"));
+    EXPECT_EQ(0, TypeUtils::TypeUtils::convertToInt64("0"));
+    EXPECT_EQ(0, TypeUtils::TypeUtils::convertToInt64("-0"));
+}
+
+TEST(TypesTests, StringToINT64ConversionErrors) {
+    // Max overflow
+    try {
+        int64_t result = TypeUtils::TypeUtils::convertToInt64("2147483648000000000000");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Min underflow
+    try {
+        int64_t result = TypeUtils::TypeUtils::convertToInt64("-2147483648000000000000");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Wrong input
+    try {
+        int64_t result = TypeUtils::TypeUtils::convertToInt64("qq1244");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Empty input
+    try {
+        int64_t result = TypeUtils::TypeUtils::convertToInt64("");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Not all characters consumed
+    try {
+        int64_t result = TypeUtils::TypeUtils::convertToInt64("24x[xd432");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Not all characters consumed
+    try {
+        int64_t result = TypeUtils::TypeUtils::convertToInt64("0L");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+}
+
+TEST(TypesTests, StringToDoubleConversion) {
+    EXPECT_EQ(12235.14, TypeUtils::TypeUtils::convertToDouble("12235.14"));
+    EXPECT_EQ(-12235.14013, TypeUtils::TypeUtils::convertToDouble("-12235.14013"));
+    EXPECT_EQ(0.001, TypeUtils::TypeUtils::convertToDouble("0.001"));
+    EXPECT_EQ(-0.001, TypeUtils::TypeUtils::convertToDouble("-0.001"));
+    EXPECT_EQ(0.0, TypeUtils::TypeUtils::convertToDouble("0.0"));
+    EXPECT_EQ(0.0, TypeUtils::TypeUtils::convertToDouble("-0.0"));
+}
+
+TEST(TypesTests, StringToDoubleConversionErrors) {
+    // Wrong input
+    try {
+        double_t result = TypeUtils::TypeUtils::convertToDouble("x2.4r432");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Empty input
+    try {
+        double_t result = TypeUtils::TypeUtils::convertToDouble("");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Not all characters consumed
+    try {
+        double_t result = TypeUtils::TypeUtils::convertToDouble("2.4r432");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    // Not all characters consumed
+    try {
+        double_t result = TypeUtils::TypeUtils::convertToDouble("0.0f");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+}
+
+TEST(TypesTests, StringToBoolConversion) {
+    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("true"));
+    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("TRUE"));
+    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("True"));
+    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("TRUe"));
+
+    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("false"));
+    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("FALSE"));
+    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("False"));
+    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("fALse"));
+
+    EXPECT_EQ(NULL_BOOL, TypeUtils::TypeUtils::convertToBoolean(""));
+}
+
+TEST(TypesTests, StringToBoolConversionErrors) {
+    try {
+        uint8_t result = TypeUtils::TypeUtils::convertToDouble("TREE");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+
+    try {
+        uint8_t result = TypeUtils::TypeUtils::convertToDouble("falst ");
+        FAIL();
+    } catch (ConversionException& e) {
+    } catch (exception& e) { FAIL(); }
+}

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -22,18 +22,18 @@ public:
     unique_ptr<MemoryManager> memoryManager;
 };
 
-TEST_F(VectorArithmeticOperationsTest, Int32Test) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+TEST_F(VectorArithmeticOperationsTest, Int64Test) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(lVector);
-    auto lData = (int32_t*)lVector->values;
+    auto lData = (int64_t*)lVector->values;
 
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(rVector);
-    auto rData = (int32_t*)rVector->values;
+    auto rData = (int64_t*)rVector->values;
 
-    auto result = make_shared<ValueVector>(memoryManager.get(), INT32);
+    auto result = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(result);
-    auto resultData = (int32_t*)result->values;
+    auto resultData = (int64_t*)result->values;
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -128,7 +128,7 @@ TEST_F(VectorArithmeticOperationsTest, BigStringTest) {
     }
 }
 
-TEST_F(VectorArithmeticOperationsTest, UnstructuredInt32Test) {
+TEST_F(VectorArithmeticOperationsTest, UnstructuredInt64Test) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->append(lVector);
     auto lData = (Value*)lVector->values;
@@ -143,39 +143,39 @@ TEST_F(VectorArithmeticOperationsTest, UnstructuredInt32Test) {
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        lData[i] = Value(i);
-        rData[i] = Value(110 - i);
+        lData[i] = Value((int64_t)i);
+        rData[i] = Value((int64_t)110 - i);
     }
 
     VectorArithmeticOperations::Negate(*lVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i].val.int32Val, -i);
+        ASSERT_EQ(resultData[i].val.int64Val, -i);
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i].val.int32Val, 110);
+        ASSERT_EQ(resultData[i].val.int64Val, 110);
     }
 
     VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i].val.int32Val, 2 * i - 110);
+        ASSERT_EQ(resultData[i].val.int64Val, 2 * i - 110);
     }
 
     VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i].val.int32Val, i * (110 - i));
+        ASSERT_EQ(resultData[i].val.int64Val, i * (110 - i));
     }
 
     VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i].val.int32Val, i / (110 - i));
+        ASSERT_EQ(resultData[i].val.int64Val, i / (110 - i));
     }
 
     /* note rVector and lVector are flipped */
     VectorArithmeticOperations::Modulo(*rVector, *lVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i].val.int32Val, i % (110 - i));
+        ASSERT_EQ(resultData[i].val.int64Val, i % (110 - i));
     }
 }
 
@@ -195,7 +195,7 @@ TEST_F(VectorArithmeticOperationsTest, UnstructuredInt32AndDoubleTest) {
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = Value((double)i);
-        rData[i] = Value(110 - i);
+        rData[i] = Value((int64_t)110 - i);
     }
 
     VectorArithmeticOperations::Negate(*lVector, *result);
@@ -243,7 +243,7 @@ TEST_F(VectorArithmeticOperationsTest, UnstructuredStringAndInt32Test) {
         lVector->allocateStringOverflowSpace(lData[i].val.strVal, lStr.length());
         lData[i].val.strVal.set(lStr);
         lData[i].dataType = STRING;
-        rData[i] = Value(110 - i);
+        rData[i] = Value((int64_t)110 - i);
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);

--- a/test/common/vector/operations/vector_cast_operations_test.cpp
+++ b/test/common/vector/operations/vector_cast_operations_test.cpp
@@ -43,10 +43,10 @@ TEST_F(VectorCastOperationsTest, CastStructuredBoolToUnstructuredValueTest) {
     }
 }
 
-TEST_F(VectorCastOperationsTest, CastStructuredInt32ToUnstructuredValueTest) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+TEST_F(VectorCastOperationsTest, CastStructuredInt64ToUnstructuredValueTest) {
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(lVector);
-    auto lData = (int32_t*)lVector->values;
+    auto lData = (int64_t*)lVector->values;
 
     auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->append(result);
@@ -58,7 +58,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredInt32ToUnstructuredValueTest) {
     }
     VectorCastOperations::castStructuredToUnstructuredValue(*lVector, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i].val.int32Val, i * 2);
+        ASSERT_EQ(resultData[i].val.int64Val, i * 2);
     }
 }
 
@@ -141,9 +141,9 @@ TEST_F(VectorCastOperationsTest, CastStructuredBooleanToStringTest) {
 }
 
 TEST_F(VectorCastOperationsTest, CastStructuredInt32ToStringTest) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(lVector);
-    auto lData = (int32_t*)lVector->values;
+    auto lData = (int64_t*)lVector->values;
 
     auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->append(result);

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -14,13 +14,13 @@ TEST(VectorCmpTests, cmpInt) {
     dataChunk->state->size = numTuples;
     auto memoryManager = make_unique<MemoryManager>();
 
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(lVector);
-    auto lData = (int32_t*)lVector->values;
+    auto lData = (int64_t*)lVector->values;
 
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), INT32);
+    auto rVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->append(rVector);
-    auto rData = (int32_t*)rVector->values;
+    auto rData = (int64_t*)rVector->values;
 
     auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->append(result);

--- a/test/mock/mock_catalog.h
+++ b/test/mock/mock_catalog.h
@@ -51,7 +51,7 @@ public:
 /**
  * Mock tiny snb catalog with 2 node labels person and organisation
  * and 2 rel label knows and workAt.
- * Person has property age with type INT32.
+ * Person has property age with type INT64.
  * Knows has property description with type STRING.
  */
 class TinySnbCatalog : public MockCatalog {
@@ -175,7 +175,7 @@ private:
 
     void setProperties() {
         ageProperty =
-            make_unique<PropertyDefinition>(AGE_PROPERTY_KEY_STR, AGE_PROPERTY_KEY_ID, INT32);
+            make_unique<PropertyDefinition>(AGE_PROPERTY_KEY_STR, AGE_PROPERTY_KEY_ID, INT64);
         nameProperty =
             make_unique<PropertyDefinition>(NAME_PROPERTY_KEY_STR, NAME_PROPERTY_KEY_ID, STRING);
         birthDateProperty = make_unique<PropertyDefinition>(

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -8,17 +8,17 @@ using namespace graphflow::binder;
 
 TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
     auto propertyExpression =
-        make_unique<Expression>(ExpressionType::PROPERTY, DataType::INT32, "a.prop");
-    auto literal = Literal(5);
+        make_unique<Expression>(ExpressionType::PROPERTY, DataType::INT64, "a.prop");
+    Literal literal = Literal((int64_t)5);
     auto literalExpression =
-        make_unique<LiteralExpression>(ExpressionType::LITERAL_INT, DataType::INT32, literal);
+        make_unique<LiteralExpression>(ExpressionType::LITERAL_INT, DataType::INT64, literal);
 
     auto addLogicalOperator = make_unique<Expression>(
-        ExpressionType::ADD, DataType::INT32, move(propertyExpression), move(literalExpression));
+        ExpressionType::ADD, DataType::INT64, move(propertyExpression), move(literalExpression));
 
     auto memoryManager = make_unique<MemoryManager>();
-    auto valueVector = make_shared<ValueVector>(memoryManager.get(), INT32);
-    auto values = (int32_t*)valueVector->values;
+    auto valueVector = make_shared<ValueVector>(memoryManager.get(), INT64);
+    auto values = (int64_t*)valueVector->values;
     for (auto i = 0u; i < 100; i++) {
         values[i] = i;
     }
@@ -35,7 +35,7 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
         *memoryManager, *addLogicalOperator, physicalOperatorInfo, resultSet);
     rootExpressionEvaluator->evaluate();
 
-    auto results = (int32_t*)rootExpressionEvaluator->result->values;
+    auto results = (int64_t*)rootExpressionEvaluator->result->values;
     for (auto i = 0u; i < 100; i++) {
         ASSERT_EQ(results[i], i + 5);
     }
@@ -43,15 +43,15 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
 
 TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
     auto propertyExpression =
-        make_unique<Expression>(ExpressionType::PROPERTY, DataType::INT32, "a.prop");
+        make_unique<Expression>(ExpressionType::PROPERTY, DataType::INT64, "a.prop");
     auto negateLogicalOperator =
-        make_unique<Expression>(ExpressionType::NEGATE, DataType::INT32, move(propertyExpression));
+        make_unique<Expression>(ExpressionType::NEGATE, DataType::INT64, move(propertyExpression));
 
     auto memoryManager = make_unique<MemoryManager>();
-    auto valueVector = make_shared<ValueVector>(memoryManager.get(), INT32);
-    auto values = (int32_t*)valueVector->values;
+    auto valueVector = make_shared<ValueVector>(memoryManager.get(), INT64);
+    auto values = (int64_t*)valueVector->values;
     for (auto i = 0u; i < 100; i++) {
-        int32_t value = i;
+        int64_t value = i;
         if (i % 2ul == 0ul) {
             values[i] = value;
         } else {
@@ -71,9 +71,9 @@ TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
         *memoryManager, *negateLogicalOperator, physicalOperatorInfo, resultSet);
     rootExpressionEvaluator->evaluate();
 
-    auto results = (int32_t*)rootExpressionEvaluator->result->values;
+    auto results = (int64_t*)rootExpressionEvaluator->result->values;
     for (auto i = 0u; i < 100; i++) {
-        int32_t value = i;
+        int64_t value = i;
         if (i % 2ul == 0ul) {
             ASSERT_EQ(results[i], -value);
         } else {

--- a/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
+++ b/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
@@ -16,13 +16,13 @@ public:
         auto memoryManager = make_unique<MemoryManager>();
         NodeIDCompressionScheme compressionScheme;
         auto vectorA1 = make_shared<NodeIDVector>(18, compressionScheme, false);
-        auto vectorA2 = make_shared<ValueVector>(memoryManager.get(), INT32);
+        auto vectorA2 = make_shared<ValueVector>(memoryManager.get(), INT64);
         auto vectorB1 = make_shared<NodeIDVector>(28, compressionScheme, false);
         auto vectorB2 = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
         auto vectorC1 = make_shared<NodeIDVector>(38, compressionScheme, false);
         auto vectorC2 = make_shared<ValueVector>(memoryManager.get(), BOOL);
         auto vectorA1Data = (uint64_t*)vectorA1->values;
-        auto vectorA2Data = (uint32_t*)vectorA2->values;
+        auto vectorA2Data = (int64_t*)vectorA2->values;
         auto vectorB1Data = (uint64_t*)vectorB1->values;
         auto vectorB2Data = (double*)vectorB2->values;
         auto vectorC1Data = (uint64_t*)vectorC1->values;
@@ -30,7 +30,7 @@ public:
 
         for (int32_t i = 0; i < 100; i++) {
             vectorA1Data[i] = (uint64_t)i;
-            vectorA2Data[i] = (int32_t)(i * 2);
+            vectorA2Data[i] = (int64_t)(i * 2);
             vectorB1Data[i] = (uint64_t)(i);
             vectorB2Data[i] = (double)(i / 2);
             vectorC1Data[i] = (uint64_t)i;
@@ -82,7 +82,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest1) {
         resultSetIterator.getNextTuple(tuple);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.label, 18);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.offset, 1);
-        ASSERT_EQ(tuple.getValue(1)->val.int32Val, (int32_t)(1 * 2));
+        ASSERT_EQ(tuple.getValue(1)->val.int64Val, (int64_t)(1 * 2));
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.label, 28);
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.offset, tupleIndex);
         ASSERT_EQ(tuple.getValue(3)->val.doubleVal, (double)(tupleIndex / 2));
@@ -102,7 +102,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest1) {
         resultSetIterator.getNextTuple(tuple);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.label, 18);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.offset, 1);
-        ASSERT_EQ(tuple.getValue(1)->val.int32Val, (int32_t)(1 * 2));
+        ASSERT_EQ(tuple.getValue(1)->val.int64Val, (int64_t)(1 * 2));
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.label, 28);
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.offset, 9);
         ASSERT_EQ(tuple.getValue(3)->val.doubleVal, (double)(9 / 2));
@@ -133,7 +133,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest2) {
         resultSetIterator.getNextTuple(tuple);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.label, 18);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.offset, 1);
-        ASSERT_EQ(tuple.getValue(1)->val.int32Val, (int32_t)(1 * 2));
+        ASSERT_EQ(tuple.getValue(1)->val.int64Val, (int64_t)(1 * 2));
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.label, 28);
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.offset, bid);
         ASSERT_EQ(tuple.getValue(3)->val.doubleVal, (double)(bid / 2));
@@ -164,7 +164,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest3) {
         resultSetIterator.getNextTuple(tuple);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.label, 18);
         ASSERT_EQ(tuple.getValue(0)->val.nodeID.offset, aid);
-        ASSERT_EQ(tuple.getValue(1)->val.int32Val, (int32_t)(aid * 2));
+        ASSERT_EQ(tuple.getValue(1)->val.int64Val, (int64_t)(aid * 2));
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.label, 28);
         ASSERT_EQ(tuple.getValue(2)->val.nodeID.offset, 10);
         ASSERT_EQ(tuple.getValue(3)->val.doubleVal, (double)(10 / 2));

--- a/test/storage/catalog_test.cpp
+++ b/test/storage/catalog_test.cpp
@@ -26,18 +26,18 @@ public:
 
     void setupCatalog() const {
         vector<PropertyDefinition> personProperties;
-        personProperties.emplace_back("id", 0, INT32);
+        personProperties.emplace_back("id", 0, INT64);
         personProperties.emplace_back("fName", 1, STRING);
-        personProperties.emplace_back("gender", 2, INT32);
+        personProperties.emplace_back("gender", 2, INT64);
         personProperties.emplace_back("isStudent", 3, BOOL);
         personProperties.emplace_back("isWorker", 4, BOOL);
-        personProperties.emplace_back("age", 5, INT32);
+        personProperties.emplace_back("age", 5, INT64);
         personProperties.emplace_back("eyeSight", 6, DOUBLE);
         catalog->addNodeLabel("person", move(personProperties), "id");
         catalog->addNodeUnstrProperty(0, "unstrIntProp");
 
         vector<PropertyDefinition> knowsProperties;
-        knowsProperties.emplace_back("date", 0, INT32);
+        knowsProperties.emplace_back("date", 0, INT64);
         vector<string> knowsSrcNodeLabelNames = {"person"};
         vector<string> knowsDstNodeLabelNames = {"person"};
         catalog->addRelLabel("knows", MANY_MANY, move(knowsProperties), knowsSrcNodeLabelNames,
@@ -61,10 +61,10 @@ TEST_F(CatalogTest, AddLabelsTest) {
     // Test property definition
     ASSERT_TRUE(catalog->getNodeProperties(0)[0].isPrimaryKey);
     ASSERT_EQ(catalog->getNodeProperty(0, "age").id, 5);
-    ASSERT_EQ(catalog->getNodeProperty(0, "age").dataType, INT32);
+    ASSERT_EQ(catalog->getNodeProperty(0, "age").dataType, INT64);
     ASSERT_EQ(catalog->getUnstrPropertiesNameToIdMap(0).at("unstrIntProp"), 7);
     ASSERT_EQ(catalog->getNodeProperties(0)[7].dataType, UNSTRUCTURED);
-    ASSERT_EQ(catalog->getRelProperty(0, "date").dataType, INT32);
+    ASSERT_EQ(catalog->getRelProperty(0, "date").dataType, INT64);
 }
 
 TEST_F(CatalogTest, SaveAndReadTest) {


### PR DESCRIPTION
- Adds INT64 type and removes the INT32 type. As such, it touches many many files but in minor ways.
- Standardizes the conversion of string/text to system-level data types (INT64, BOOL, etc.) all in types.h/cpp. This was duplicated and scattered in Literal, csv reader, and nodes_loader (for unstructured properties). Also extended these conversions (e.g., "true"/"false" matching is now case insensitive) and added erroring logic when conversions cannot happen. Also added tests for these conversion functions.