### PR TITLE
Add function date() to create date literal

### DIFF
--- a/src/binder/expression/literal_expression.cpp
+++ b/src/binder/expression/literal_expression.cpp
@@ -1,11 +1,15 @@
 #include "src/binder/include/expression/literal_expression.h"
 
+#include "src/common/include/date.h"
+
 namespace graphflow {
 namespace binder {
+
 LiteralExpression::LiteralExpression(
     ExpressionType expressionType, DataType dataType, const Literal& literal)
     : Expression(expressionType, dataType), literal{literal} {
-    assert(dataType == BOOL || dataType == INT64 || dataType == DOUBLE || dataType == STRING);
+    assert(dataType == BOOL || dataType == INT64 || dataType == DOUBLE || dataType == STRING ||
+           dataType == DATE);
 }
 
 void LiteralExpression::castToString() {
@@ -19,6 +23,9 @@ void LiteralExpression::castToString() {
         break;
     case DOUBLE:
         valAsString = TypeUtils::toString(literal.val.doubleVal);
+        break;
+    case DATE:
+        valAsString = Date::toString(literal.val.dateVal);
         break;
     default:
         assert(false);

--- a/src/binder/include/expression/expression.h
+++ b/src/binder/include/expression/expression.h
@@ -13,10 +13,6 @@ using namespace std;
 namespace graphflow {
 namespace binder {
 
-// replace this with function enum once we have more functions
-const string FUNCTION_COUNT_STAR = "COUNT_STAR";
-const string FUNCTION_ID = "ID";
-
 class Expression {
 
 public:

--- a/src/binder/query_binder.cpp
+++ b/src/binder/query_binder.cpp
@@ -360,7 +360,7 @@ void validateProjectionColumnNamesAreUnique(const vector<shared_ptr<Expression>>
 void validateOnlyFunctionIsCountStar(vector<shared_ptr<Expression>>& expressions) {
     for (auto& expression : expressions) {
         if (FUNCTION == expression->expressionType &&
-            FUNCTION_COUNT_STAR == expression->variableName && expressions.size() != 1) {
+            COUNT_STAR_FUNC_NAME == expression->variableName && expressions.size() != 1) {
             throw invalid_argument("The only function in the return clause should be COUNT(*).");
         }
     }

--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -146,12 +146,10 @@ cc_library(
 
 cc_library(
     name = "configs",
-    srcs = [],
     hdrs = [
         "include/configs.h",
     ],
     visibility = ["//visibility:public"],
-    deps = [],
 )
 
 cc_library(
@@ -189,7 +187,6 @@ cc_library(
         "include/file_ser_deser_helper.h",
     ],
     visibility = ["//visibility:public"],
-    deps = [],
 )
 
 cc_library(
@@ -213,5 +210,16 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "timer",
+    ],
+)
+
+cc_library(
+    name = "functions",
+    hdrs = [
+        "include/function.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "types",
     ],
 )

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -39,7 +39,7 @@ bool isExpressionNullComparison(ExpressionType type) {
 
 bool isExpressionLeafLiteral(ExpressionType type) {
     return LITERAL_INT == type || LITERAL_DOUBLE == type || LITERAL_STRING == type ||
-           LITERAL_BOOLEAN == type || LITERAL_NULL == type;
+           LITERAL_BOOLEAN == type || LITERAL_DATE == type || LITERAL_NULL == type;
 }
 
 /**

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -85,7 +85,8 @@ enum ExpressionType : uint8_t {
     LITERAL_DOUBLE = 81,
     LITERAL_STRING = 82,
     LITERAL_BOOLEAN = 83,
-    LITERAL_NULL = 84,
+    LITERAL_DATE = 84,
+    LITERAL_NULL = 85,
 
     /**
      * Variable Expression

--- a/src/common/include/function.h
+++ b/src/common/include/function.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <memory>
+
+#include "src/common/include/types.h"
+
+namespace graphflow {
+namespace common {
+
+const string COUNT_STAR_FUNC_NAME = "COUNT_STAR";
+const string ID_FUNC_NAME = "ID";
+const string DATE_FUNC_NAME = "DATE";
+
+class Function {
+
+public:
+    inline uint32_t getNumParameters() const { return parameterTypes.size(); }
+
+protected:
+    Function(string name, DataType returnType) : name{move(name)}, returnType{returnType} {}
+
+    Function(string name, DataType returnType, vector<DataType> parameterTypes)
+        : name{move(name)}, returnType{returnType}, parameterTypes{move(parameterTypes)} {}
+
+public:
+    string name;
+    DataType returnType;
+    vector<DataType> parameterTypes;
+};
+
+class CountStarFunc : public Function {
+
+public:
+    CountStarFunc() : Function{COUNT_STAR_FUNC_NAME, INT64} {}
+};
+
+class IDFunc : public Function {
+
+public:
+    IDFunc() : Function{ID_FUNC_NAME, NODE_ID, vector<DataType>{NODE}} {}
+};
+
+class DateFunc : public Function {
+
+public:
+    DateFunc() : Function{DATE_FUNC_NAME, DATE, vector<DataType>{STRING}} {}
+};
+
+} // namespace common
+} // namespace graphflow

--- a/src/common/include/literal.h
+++ b/src/common/include/literal.h
@@ -17,6 +17,8 @@ public:
 
     explicit Literal(double value) : dataType(DOUBLE) { this->val.doubleVal = value; }
 
+    explicit Literal(date_t value) : dataType(DATE) { this->val.dateVal = value; }
+
     explicit Literal(const string& value) : dataType(STRING) { this->strVal = value; }
 
     Literal& operator=(const Literal& other);
@@ -29,6 +31,7 @@ public:
         int64_t int64Val;
         double doubleVal;
         nodeID_t nodeID;
+        date_t dateVal;
     } val{};
 
     string strVal;

--- a/src/common/include/utils.h
+++ b/src/common/include/utils.h
@@ -22,6 +22,14 @@ class StringUtils {
 public:
     static vector<string> split(const string& input, const string& delimiter);
 
+    static void toUpper(string& input) {
+        transform(input.begin(), input.end(), input.begin(), ::toupper);
+    }
+
+    static void toLower(string& input) {
+        transform(input.begin(), input.end(), input.begin(), ::tolower);
+    }
+
     static bool CharacterIsSpace(char c) {
         return c == ' ' || c == '\t' || c == '\n' || c == '\v' || c == '\f' || c == '\r';
     }

--- a/src/common/literal.cpp
+++ b/src/common/literal.cpp
@@ -1,6 +1,7 @@
 #include "src/common/include/literal.h"
 
-#include <cassert>
+#include "src/common/include/assert.h"
+#include "src/common/include/date.h"
 
 namespace graphflow {
 namespace common {
@@ -17,11 +18,14 @@ Literal& Literal::operator=(const Literal& other) {
     case DOUBLE: {
         val.doubleVal = other.val.doubleVal;
     } break;
+    case DATE: {
+        val.dateVal = other.val.dateVal;
+    } break;
     case STRING: {
         strVal = other.strVal;
     } break;
     default:
-        assert(false);
+        GF_ASSERT(false);
     }
 
     return *this;
@@ -35,13 +39,17 @@ string Literal::toString() const {
         return TypeUtils::toString(val.int64Val);
     case DOUBLE:
         return TypeUtils::toString(val.doubleVal);
-    case STRING:
-        return strVal;
     case NODE:
         return TypeUtils::toString(val.nodeID);
+    case DATE:
+        return Date::toString(val.dateVal);
+    case STRING:
+        return strVal;
     default:
-        assert(false);
+        GF_ASSERT(false);
     }
+    // Should never happen. Add empty return to remove compilation warning.
+    return string();
 }
 } // namespace common
 } // namespace graphflow

--- a/src/common/vector/operations/vector_cast_operations.cpp
+++ b/src/common/vector/operations/vector_cast_operations.cpp
@@ -89,14 +89,13 @@ void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, Val
         string val;
         switch (operand.dataType) {
         case BOOL: {
-            val = operand.values[pos] == TRUE ? "True" :
-                                                (operand.values[pos] == FALSE ? "False" : "");
+            val = TypeUtils::toString(operand.values[pos]);
         } break;
         case INT64: {
-            val = to_string(((int64_t*)operand.values)[pos]);
+            val = TypeUtils::toString(((int64_t*)operand.values)[pos]);
         } break;
         case DOUBLE: {
-            val = to_string(((double_t*)operand.values)[pos]);
+            val = TypeUtils::toString(((double_t*)operand.values)[pos]);
         } break;
         case DATE: {
             val = Date::toString(((date_t*)operand.values)[pos]);
@@ -110,23 +109,21 @@ void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, Val
         case BOOL: {
             for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
-                result.addString(pos, operand.values[pos] == TRUE ?
-                                          "True" :
-                                          (operand.values[pos] == FALSE ? "False" : ""));
+                result.addString(pos, TypeUtils::toString(operand.values[pos]));
             }
         } break;
         case INT64: {
             auto intValues = (int64_t*)operand.values;
             for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
-                result.addString(pos, to_string(intValues[pos]));
+                result.addString(pos, TypeUtils::toString(intValues[pos]));
             }
         } break;
         case DOUBLE: {
             auto doubleValues = (double_t*)operand.values;
             for (auto i = 0u; i < operand.state->size; i++) {
                 auto pos = operand.state->selectedValuesPos[i];
-                result.addString(pos, to_string(doubleValues[pos]));
+                result.addString(pos, TypeUtils::toString(doubleValues[pos]));
             }
         } break;
         case DATE: {

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -20,6 +20,7 @@ cc_library(
     deps = [
         "queries",
         "//src/antlr4:cypher_grammar_lib",
+        "//src/common:functions",
         "//src/common:utils",
     ],
 )

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -1,6 +1,7 @@
 #include "src/parser/include/transformer.h"
 
 #include "src/common/include/assert.h"
+#include "src/common/include/function.h"
 #include "src/parser/include/statements/load_csv_statement.h"
 #include "src/parser/include/statements/match_statement.h"
 
@@ -457,7 +458,7 @@ unique_ptr<ParsedExpression> Transformer::transformAtom(CypherParser::OC_AtomCon
     if (ctx.oC_Literal()) {
         return transformLiteral(*ctx.oC_Literal());
     } else if (ctx.STAR()) {
-        return make_unique<ParsedExpression>(FUNCTION, "COUNT_STAR", ctx.getText());
+        return make_unique<ParsedExpression>(FUNCTION, COUNT_STAR_FUNC_NAME, ctx.getText());
     } else if (ctx.oC_ParenthesizedExpression()) {
         return transformParenthesizedExpression(*ctx.oC_ParenthesizedExpression());
     } else if (ctx.oC_FunctionInvocation()) {

--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -352,7 +352,7 @@ void Enumerator::appendProjection(
     const vector<shared_ptr<Expression>>& returnOrWithClause, LogicalPlan& plan) {
     // Do not append projection in case of RETURN COUNT(*)
     if (1 == returnOrWithClause.size() && FUNCTION == returnOrWithClause[0]->expressionType &&
-        FUNCTION_COUNT_STAR == returnOrWithClause[0]->variableName) {
+        COUNT_STAR_FUNC_NAME == returnOrWithClause[0]->variableName) {
         return;
     }
     auto expressionsToProject = vector<shared_ptr<Expression>>();

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -121,6 +121,9 @@ static unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToUnstructured
     case BOOL: {
         val.val.booleanVal = literalExpression.literal.val.booleanVal;
     } break;
+    case DATE: {
+        val.val.dateVal = literalExpression.literal.val.dateVal;
+    } break;
     case STRING: {
         vector->allocateStringOverflowSpace(
             val.val.strVal, literalExpression.literal.strVal.length());
@@ -153,6 +156,9 @@ unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToStructuredPhysical(
     } break;
     case STRING: {
         vector->addString(0 /* pos */, literalExpression.literal.strVal);
+    } break;
+    case DATE: {
+        ((date_t*)vector->values)[0] = literalExpression.literal.val.dateVal;
     } break;
     default:
         assert(false);

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -114,6 +114,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/common:functions",
         "//src/common:types",
         "@fraillt_bitsery",
         "@gabime_spdlog",

--- a/src/storage/catalog.cpp
+++ b/src/storage/catalog.cpp
@@ -152,11 +152,13 @@ uint64_t Catalog::deSerializeValue<RelLabelDefinition>(
 
 Catalog::Catalog() {
     logger = spdlog::get("storage");
+    registerBuiltInFunctions();
 }
 
 Catalog::Catalog(const string& directory) : Catalog() {
     logger->info("Initializing catalog.");
     readFromFile(directory);
+    registerBuiltInFunctions();
     logger->info("Initializing catalog done.");
 }
 
@@ -388,6 +390,12 @@ string Catalog::getNodeLabelsString(const unordered_set<label_t>& nodeLabelIds) 
         nodeLabelsStr += nodeLabels[nodeLabelId].labelName;
     }
     return nodeLabelsStr;
+}
+
+void Catalog::registerBuiltInFunctions() {
+    builtInFunctions.insert({COUNT_STAR_FUNC_NAME, make_unique<CountStarFunc>()});
+    builtInFunctions.insert({ID_FUNC_NAME, make_unique<IDFunc>()});
+    builtInFunctions.insert({DATE_FUNC_NAME, make_unique<DateFunc>()});
 }
 
 } // namespace storage

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -7,6 +7,7 @@
 #include "nlohmann/json.hpp"
 
 #include "src/common/include/file_utils.h"
+#include "src/common/include/function.h"
 #include "src/common/include/types.h"
 #include "src/common/include/utils.h"
 
@@ -150,6 +151,13 @@ public:
         label_t nodeLabel) const {
         return nodeLabels[nodeLabel].unstrPropertiesNameToIdMap;
     }
+    // getFunction() should always be called after containFunction()
+    inline bool containFunction(const string& functionName) const {
+        return builtInFunctions.contains(functionName);
+    }
+    inline Function* getFunction(const string& functionName) const {
+        return builtInFunctions.at(functionName).get();
+    }
 
     unique_ptr<nlohmann::json> debugInfo();
     void saveToFile(const string& directory);
@@ -171,13 +179,16 @@ private:
 
     string getNodeLabelsString(const unordered_set<label_t>& nodeLabels) const;
 
+    void registerBuiltInFunctions();
+
     shared_ptr<spdlog::logger> logger;
     vector<NodeLabelDefinition> nodeLabels;
     vector<RelLabelDefinition> relLabels;
-    // These two maps are maintained as caches for label name and id mapping. They are not
-    // serialized to the catalog file, but is re-constructed when reading from the catalog file.
+    // These three maps are maintained as caches. They are not serialized to the catalog file, but
+    // is re-constructed when reading from the catalog file.
     unordered_map<string, label_t> nodeLabelNameToIdMap;
     unordered_map<string, label_t> relLabelNameToIdMap;
+    unordered_map<string, unique_ptr<Function>> builtInFunctions;
 };
 
 } // namespace storage

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -131,3 +131,21 @@ TEST_F(BinderErrorTest, BindDateArithmetic) {
     auto input = "MATCH (a:person) WHERE a.birthdate + 1 < 5 RETURN *;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
+
+TEST_F(BinderErrorTest, BindNonExistingFunction) {
+    string expectedException = "dummy function does not exist.";
+    auto input = "MATCH (a:person) WHERE dummy() < 2 RETURN COUNT(*);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, BindFunctionWithWrongNumParams) {
+    string expectedException = "Expected 1 parameters for date function but get 0.";
+    auto input = "MATCH (a:person) WHERE date() < 2 RETURN COUNT(*);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, BindFunctionWithWrongParamType) {
+    string expectedException = "2012 has data type INT64. STRING was expected.";
+    auto input = "MATCH (a:person) WHERE date(2012) < 2 RETURN COUNT(*);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -9,6 +9,9 @@
 using ::testing::NiceMock;
 using ::testing::Test;
 
+/**
+ * Remove this test once LIST data type is supported.
+ */
 class BinderTest : public Test {
 
 public:

--- a/test/runner/queries/data_types/date_data_type.test
+++ b/test/runner/queries/data_types/date_data_type.test
@@ -1,40 +1,52 @@
 # description: handling of date properties
 
--NAME StruturedDateComparisonAcrossNodesEquality
+-NAME DateLiteralEqualityComparison
+-QUERY MATCH (a:person) WHERE a.birthdate = date('1900-1-1') RETURN COUNT(*)
+---- 2
+
+-NAME DateLiteralGreaterThanComparison
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE b.birthdate > date('1970-09-11') RETURN COUNT(*)
+---- 2
+
+-NAME DateLiteralLessThanComparison
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE e1.date < date('1960-09-11') RETURN COUNT(*)
+---- 6
+
+-NAME StructuredDateComparisonAcrossNodesEquality
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate = b.birthdate RETURN COUNT(*)
 ---- 4
 
--NAME StruturedDateComparisonAcrossNodesNonEquality
+-NAME StructuredDateComparisonAcrossNodesNonEquality
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate <> b.birthdate RETURN COUNT(*)
 ---- 10
 
--NAME StruturedDateComparisonAcrossNodesLessThan
+-NAME StructuredDateComparisonAcrossNodesLessThan
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate < b.birthdate RETURN COUNT(*)
 ---- 5
 
--NAME StruturedDateComparisonAcrossNodesLessThanOrEqualTo
+-NAME StructuredDateComparisonAcrossNodesLessThanOrEqualTo
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate <= b.birthdate RETURN COUNT(*)
 ---- 9
 
--NAME StruturedDateComparisonAcrossNodesGreaterThan
+-NAME StructuredDateComparisonAcrossNodesGreaterThan
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate > b.birthdate RETURN COUNT(*)
 ---- 5
 
--NAME StruturedDateComparisonAcrossNodesGreaterThanOrEqualTo
+-NAME StructuredDateComparisonAcrossNodesGreaterThanOrEqualTo
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate >= b.birthdate RETURN COUNT(*)
 ---- 9
 
--NAME StruturedDateComparisonAcrossEdges
+-NAME StructuredDateComparisonAcrossEdges
 -QUERY MATCH (a:person)<-[e1:knows]-(b:person)-[e2:knows]->(c:person) WHERE e1.date = e2.date AND id(a) <> id(c) RETURN COUNT(*)
 ---- 10
 
 #  For the below query, these are the 3 edges that should pass the filter: (1) 5, 2,1950-05-14 (5's birthday is 1950-7-23)
 #  (2-3) 7,8,1905-12-12 and 7,9,1905-12-12 (7's birthday is 1980-10-26)
--NAME StruturedDateComparisonAcrossEdgeAndNode
+-NAME StructuredDateComparisonAcrossEdgeAndNode
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate > e1.date  RETURN COUNT(*)
 ---- 3
 
--NAME UnstruturedStructuredDateComparison
+-NAME UnstructuredStructuredDateComparison
 -QUERY MATCH (a:person) WHERE a.birthdate = a.unstrDateProp1 RETURN COUNT(*)
 ---- 1
 
@@ -46,3 +58,6 @@
 -QUERY MATCH (a:person) WHERE a.unstrDateProp1 >= a.unstrDateProp2 RETURN COUNT(*)
 ---- 1
 
+-NAME UnstructuredDateLiteralComparison
+-QUERY MATCH (a:person) WHERE a.unstrDateProp1 <= date('1990-02-02') RETURN COUNT(*)
+---- 3


### PR DESCRIPTION
This PR adds function definition for binder validation (function evaluator is not added).

- COUNT(*)
  - Count star is the default behavior of our query and does not require any evaluation 
- ID()
  - ID(a) is bound as a._id which is property expression  
- Date()
  - Date(2012-10-10) is bound as a date literal which is literal expression

Minor refactor
Make VectorCastOperations::castStructuredToStringValue to use TypeUtils::toString()