### PR TITLE
log compiling time and execution time in system.executeQuery()

### DIFF
--- a/src/main/include/session_context.h
+++ b/src/main/include/session_context.h
@@ -16,6 +16,12 @@ struct SessionContext {
 public:
     SessionContext() { profiler = make_unique<Profiler>(); }
 
+    void clear() {
+        profiler->resetMetrics();
+        compilingTime = 0;
+        executingTime = 0;
+    };
+
 public:
     // configurable user input
     string query;
@@ -25,7 +31,12 @@ public:
     unique_ptr<Profiler> profiler;
     unique_ptr<PlanPrinter> planPrinter;
     Transaction* activeTransaction{nullptr};
+
+    // query execution information that will always be returned to user regardless whether EXPLAIN
+    // or PROFILE is enabled or not
     unique_ptr<QueryResult> queryResult;
+    double compilingTime;
+    double executingTime;
 };
 
 } // namespace main

--- a/src/main/include/system.h
+++ b/src/main/include/system.h
@@ -14,11 +14,6 @@ using namespace graphflow::planner;
 namespace graphflow {
 namespace main {
 
-const string BINDING_STAGE = "binding";
-const string PLANNING_STAGE = "planning";
-const string MAPPING_STAGE = "mapping";
-const string EXECUTING_STAGE = "executing";
-
 class System {
 
 public:

--- a/src/main/session.cpp
+++ b/src/main/session.cpp
@@ -24,15 +24,9 @@ nlohmann::json Session::executeQuery() {
                 sessionContext->planPrinter->printPlanToJson(*sessionContext->profiler);
         } else {
             json["result"]["numTuples"] = sessionContext->queryResult->numTuples;
+            json["result"]["compilingTime"] = sessionContext->compilingTime;
+            json["result"]["executingTime"] = sessionContext->executingTime;
             if (sessionContext->profiler->enabled) {
-                json["result"][BINDING_STAGE] =
-                    sessionContext->profiler->sumAllTimeMetricsWithKey(BINDING_STAGE);
-                json["result"][PLANNING_STAGE] =
-                    sessionContext->profiler->sumAllTimeMetricsWithKey(PLANNING_STAGE);
-                json["result"][MAPPING_STAGE] =
-                    sessionContext->profiler->sumAllTimeMetricsWithKey(MAPPING_STAGE);
-                json["result"][EXECUTING_STAGE] =
-                    sessionContext->profiler->sumAllTimeMetricsWithKey(EXECUTING_STAGE);
                 json["result"]["plan"] =
                     sessionContext->planPrinter->printPlanToJson(*sessionContext->profiler);
             }

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -36,7 +36,7 @@ unique_ptr<QueryResult> QueryProcessor::execute(PhysicalPlan* physicalPlan, uint
     scheduleTask(task.get());
     while (!task->isCompleted()) {
         /*busy wait*/
-        this_thread::sleep_for(chrono::milliseconds(10));
+        this_thread::sleep_for(chrono::microseconds(100));
     }
     return move(resultCollector->queryResult);
 }

--- a/tools/benchmark/benchmark.cpp
+++ b/tools/benchmark/benchmark.cpp
@@ -57,25 +57,24 @@ void Benchmark::loadBenchmark(const string& benchmarkPath) {
 }
 
 void Benchmark::run() {
-    auto timeMetric = TimeMetric(true);
-    timeMetric.start();
     system.executeQuery(*context);
-    timeMetric.stop();
-    executionTime = timeMetric.getElapsedTimeMS();
-
     verify();
 }
 
 void Benchmark::log() {
-    string time = "Execution time: " + to_string(executionTime);
+    auto numOutput = context->queryResult->numTuples;
     string plan = "Plan: \n" + context->planPrinter->printPlanToJson(*context->profiler).dump(4);
-    spdlog::info("{}", time);
+    spdlog::info("Number of output {}", numOutput);
+    spdlog::info("Compiling time {}", context->compilingTime);
+    spdlog::info("Execution time {}", context->executingTime);
     if (config.enableProfile) {
         spdlog::info("{}", plan);
     }
     if (!config.outputPath.empty()) {
         ofstream f(config.outputPath + "/" + name + ".result", ios_base::app);
-        f << time << endl;
+        f << "Number of ouput " << numOutput << endl;
+        f << "Compiling time " << context->compilingTime << endl;
+        f << "Execution time " << context->executingTime << endl;
         if (config.enableProfile) {
             f << plan << endl;
         }

--- a/tools/benchmark/include/benchmark.h
+++ b/tools/benchmark/include/benchmark.h
@@ -33,7 +33,6 @@ public:
     uint64_t expectedNumOutput;
 
     unique_ptr<SessionContext> context;
-    double executionTime;
 };
 
 } // namespace benchmark

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -124,14 +124,8 @@ void EmbeddedShell::printExecutionResult() {
             printf("==============================================\n");
             printf("=============== Profiler Summary =============\n");
             printf("==============================================\n");
-            printf(">> %s: %.2fms\n", BINDING_STAGE.c_str(),
-                context.profiler->sumAllTimeMetricsWithKey(BINDING_STAGE));
-            printf(">> %s: %.2fms\n", PLANNING_STAGE.c_str(),
-                context.profiler->sumAllTimeMetricsWithKey(PLANNING_STAGE));
-            printf(">> %s: %.2fms\n", MAPPING_STAGE.c_str(),
-                context.profiler->sumAllTimeMetricsWithKey(MAPPING_STAGE));
-            printf(">> %s: %.2fms\n", EXECUTING_STAGE.c_str(),
-                context.profiler->sumAllTimeMetricsWithKey(EXECUTING_STAGE));
+            printf(">> Compiling time: %.2fms\n", context.compilingTime);
+            printf(">> Executing time: %.2fms\n", context.executingTime);
             printf(">> plan\n");
             string plan = context.planPrinter->printPlanToJson(*context.profiler).dump(4);
             printf("%s\n", plan.c_str());


### PR DESCRIPTION
This PR changes query execution logging.

We log the compiling time and execution time of a query. And compiling time, execution time and numOutput are three results that will always be returned to user regardless whether EXPLAIN or PROFILE is enabled or not.