### PR TITLE
Projection fixes for single query with structured and unstructured properties

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -5,8 +5,6 @@
 namespace graphflow {
 namespace common {
 
-constexpr bool ENABLE_DEBUG = false;
-
 // Size (in bytes) of the chunks to be read in GraphLoader.
 constexpr uint64_t CSV_READING_BLOCK_SIZE = 1 << 23;
 

--- a/src/common/include/vector/string_buffer.h
+++ b/src/common/include/vector/string_buffer.h
@@ -31,12 +31,13 @@ public:
 
 public:
     void allocateLargeString(gf_string_t& result, uint64_t len);
-    void appendBuffer(StringBuffer& other);
+
+public:
+    vector<unique_ptr<BufferBlock>> blocks;
 
 private:
     MemoryManager& memoryManager;
     BufferBlock* currentBlock;
-    vector<unique_ptr<BufferBlock>> blocks;
 };
 } // namespace common
 } // namespace graphflow

--- a/src/common/vector/string_buffer.cpp
+++ b/src/common/vector/string_buffer.cpp
@@ -19,13 +19,5 @@ void StringBuffer::allocateLargeString(gf_string_t& result, uint64_t len) {
     currentBlock->currentOffset += len;
 }
 
-void StringBuffer::appendBuffer(StringBuffer& other) {
-    if (other.blocks.empty()) {
-        return;
-    }
-    blocks.insert(blocks.end(), make_move_iterator(other.blocks.begin()),
-        make_move_iterator(other.blocks.end()));
-    currentBlock = other.currentBlock;
-}
 } // namespace common
 } // namespace graphflow

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -45,16 +45,11 @@ void ValueVector::fillNullMask() {
     }
 }
 
+// Notice that this clone function only copies values and nullMask without copying string buffers.
 shared_ptr<ValueVector> ValueVector::clone() {
-    auto newVector = make_shared<ValueVector>(memoryManager, dataType, vectorCapacity);
+    auto newVector = make_shared<ValueVector>(memoryManager, dataType, vectorCapacity == 1);
     memcpy(newVector->nullMask, nullMask, vectorCapacity);
-    if (STRING == dataType) {
-        for (auto i = 0u; i < vectorCapacity; i++) {
-            ((gf_string_t*)newVector->values)[i] = ((gf_string_t*)values)[i];
-        }
-    } else {
-        memcpy(newVector->values, values, vectorCapacity * getNumBytesPerValue());
-    }
+    memcpy(newVector->values, values, vectorCapacity * getNumBytesPerValue());
     return newVector;
 }
 

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -3,11 +3,11 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "execution_context",
     hdrs = [
-        "include/execution_context.h"
+        "include/execution_context.h",
     ],
     deps = [
         "//src/common:profiler",
-        "//src/transaction:transaction"
+        "//src/transaction",
     ],
 )
 
@@ -24,12 +24,13 @@ cc_library(
         "physical_plan/operator/hash_join/hash_join_build.cpp",
         "physical_plan/operator/hash_join/hash_join_probe.cpp",
         "physical_plan/operator/load_csv/load_csv.cpp",
+        "physical_plan/operator/physical_operator.cpp",
         "physical_plan/operator/physical_operator_info.cpp",
         "physical_plan/operator/projection/projection.cpp",
         "physical_plan/operator/read_list/adj_list_extend.cpp",
-        "physical_plan/operator/read_list/frontier_extend.cpp",
         "physical_plan/operator/read_list/frontier/frontier_bag.cpp",
         "physical_plan/operator/read_list/frontier/frontier_set.cpp",
+        "physical_plan/operator/read_list/frontier_extend.cpp",
         "physical_plan/operator/read_list/read_list.cpp",
         "physical_plan/operator/read_list/read_rel_property_list.cpp",
         "physical_plan/operator/scan_attribute/adj_column_extend.cpp",
@@ -39,7 +40,7 @@ cc_library(
         "physical_plan/operator/scan_attribute/scan_unstructured_property.cpp",
         "physical_plan/operator/scan_node_id/scan_node_id.cpp",
         "physical_plan/operator/sink/result_collector.cpp",
-        "physical_plan/operator/physical_operator.cpp"
+        "physical_plan/query_result.cpp",
     ],
     hdrs = [
         "include/physical_plan/expression_mapper.h",
@@ -57,10 +58,10 @@ cc_library(
         "include/physical_plan/operator/physical_operator_info.h",
         "include/physical_plan/operator/projection/projection.h",
         "include/physical_plan/operator/read_list/adj_list_extend.h",
-        "include/physical_plan/operator/read_list/frontier_extend.h",
+        "include/physical_plan/operator/read_list/frontier/frontier.h",
         "include/physical_plan/operator/read_list/frontier/frontier_bag.h",
         "include/physical_plan/operator/read_list/frontier/frontier_set.h",
-        "include/physical_plan/operator/read_list/frontier/frontier.h",
+        "include/physical_plan/operator/read_list/frontier_extend.h",
         "include/physical_plan/operator/read_list/read_list.h",
         "include/physical_plan/operator/read_list/read_rel_property_list.h",
         "include/physical_plan/operator/scan_attribute/adj_column_extend.h",
@@ -76,8 +77,8 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "result_set",
         "execution_context",
+        "result_set",
         "//src/binder:expression",
         "//src/common:csv_reader",
         "//src/common:memory_manager",

--- a/src/processor/include/physical_plan/operator/physical_operator_info.h
+++ b/src/processor/include/physical_plan/operator/physical_operator_info.h
@@ -6,6 +6,8 @@
 #include <utility>
 #include <vector>
 
+#include "src/common/include/assert.h"
+
 using namespace std;
 
 namespace graphflow {
@@ -20,10 +22,12 @@ public:
     void appendAsNewValueVector(const string& variableName, uint64_t dataChunkPos);
 
     inline uint64_t getDataChunkPos(const string& variableName) {
+        GF_ASSERT(variableToDataPosMap.contains(variableName));
         return variableToDataPosMap.at(variableName).first;
     }
 
     inline uint64_t getValueVectorPos(const string& variableName) {
+        GF_ASSERT(variableToDataPosMap.contains(variableName));
         return variableToDataPosMap.at(variableName).second;
     }
 

--- a/src/processor/include/physical_plan/operator/projection/projection.h
+++ b/src/processor/include/physical_plan/operator/projection/projection.h
@@ -13,7 +13,7 @@ namespace processor {
 class Projection : public PhysicalOperator {
 
 public:
-    Projection(unique_ptr<vector<unique_ptr<ExpressionEvaluator>>> expressions,
+    Projection(vector<unique_ptr<ExpressionEvaluator>> expressions,
         vector<uint64_t> expressionPosToDataChunkPos, const vector<uint64_t>& discardedDataChunkPos,
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
 
@@ -22,7 +22,7 @@ public:
     unique_ptr<PhysicalOperator> clone() override;
 
 private:
-    unique_ptr<vector<unique_ptr<ExpressionEvaluator>>> expressions;
+    vector<unique_ptr<ExpressionEvaluator>> expressions;
     vector<uint64_t> expressionPosToDataChunkPos;
     vector<uint64_t> discardedDataChunkPos;
     shared_ptr<ResultSet> discardedResultSet;

--- a/src/processor/include/physical_plan/operator/result/result_set.h
+++ b/src/processor/include/physical_plan/operator/result/result_set.h
@@ -23,6 +23,8 @@ public:
 
     uint64_t getNumTuples();
 
+    unique_ptr<ResultSet> clone();
+
     shared_ptr<ListSyncState> getListSyncState(uint64_t dataChunkPos) {
         return listSyncStatesPerDataChunk[dataChunkPos];
     }

--- a/src/processor/include/physical_plan/operator/result/result_set_iterator.h
+++ b/src/processor/include/physical_plan/operator/result/result_set_iterator.h
@@ -10,28 +10,28 @@ namespace processor {
 
 class ResultSetIterator {
 public:
-    explicit ResultSetIterator(ResultSet& resultSet) : resultSet(resultSet), numIteratedTuples(0) {
+    explicit ResultSetIterator(ResultSet* resultSet) : resultSet(resultSet), numIteratedTuples(0) {
         reset();
     }
 
-    void setDataChunks(ResultSet& dataChunks) {
-        this->resultSet = dataChunks;
+    void setResultSet(ResultSet* resultSet) {
+        this->resultSet = resultSet;
         reset();
     }
 
     bool hasNextTuple();
     void getNextTuple(Tuple& tuple);
-    void reset();
 
 public:
-    vector<DataType> dataChunksTypes;
+    vector<DataType> dataTypes;
 
 private:
+    void reset();
     bool updateTuplePositions(int64_t chunkIdx);
     void updateTuplePositions();
     void setDataChunksTypes();
 
-    ResultSet& resultSet;
+    ResultSet* resultSet;
 
     uint64_t numIteratedTuples;
     vector<uint64_t> tuplePositions;

--- a/src/processor/include/physical_plan/operator/result/tuple.h
+++ b/src/processor/include/physical_plan/operator/result/tuple.h
@@ -10,10 +10,12 @@ namespace processor {
 class Tuple {
 
 public:
-    explicit Tuple(const vector<DataType>& valueTypes) : multiplicity(1) {
-        for (auto& valueType : valueTypes) {
-            auto value = make_unique<Value>(valueType);
-            values.push_back(move(value));
+    explicit Tuple(const vector<DataType>& valueTypes) {
+        values.resize(valueTypes.size());
+        nullMask.resize(valueTypes.size());
+        for (auto i = 0u; i < valueTypes.size(); i++) {
+            values[i] = make_unique<Value>(valueTypes[i]);
+            nullMask[i] = false;
         }
     }
 
@@ -21,15 +23,20 @@ public:
 
     string toString(const string& delimiter = "|") {
         string result;
-        for (uint64_t i = 0; i < values.size() - 1; i++) {
-            result += values[i]->toString() + delimiter;
+        for (auto i = 0u; i < values.size() - 1; i++) {
+            if (!nullMask[i]) {
+                result += values[i]->toString();
+            }
+            result += delimiter;
         }
-        result += values[values.size() - 1]->toString();
+        if (!nullMask[values.size() - 1]) {
+            result += values[values.size() - 1]->toString();
+        }
         return result;
     }
 
 public:
-    uint64_t multiplicity;
+    vector<bool> nullMask;
 
 private:
     vector<unique_ptr<Value>> values;

--- a/src/processor/include/physical_plan/operator/sink/result_collector.h
+++ b/src/processor/include/physical_plan/operator/sink/result_collector.h
@@ -11,24 +11,27 @@ class ResultCollector : public Sink {
 
 public:
     explicit ResultCollector(unique_ptr<PhysicalOperator> prevOperator,
-        PhysicalOperatorType operatorType, ExecutionContext& context, uint32_t id)
-        : Sink{move(prevOperator), operatorType, context, id} {
+        PhysicalOperatorType operatorType, ExecutionContext& context, uint32_t id,
+        bool enableProjection)
+        : Sink{move(prevOperator), operatorType, context, id}, enableProjection{enableProjection} {
         resultSet = this->prevOperator->getResultSet();
-        resultSetIterator = make_unique<ResultSetIterator>(*resultSet);
         queryResult = make_unique<QueryResult>();
     };
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ResultCollector>(prevOperator->clone(), operatorType, context, id);
+        return make_unique<ResultCollector>(
+            prevOperator->clone(), operatorType, context, id, enableProjection);
     }
 
 public:
     unique_ptr<QueryResult> queryResult;
 
 private:
-    unique_ptr<ResultSetIterator> resultSetIterator;
+    void resetStringBuffer();
+
+    bool enableProjection;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/query_result.h
+++ b/src/processor/include/physical_plan/query_result.h
@@ -2,6 +2,7 @@
 
 #include <cstdint>
 
+#include "src/processor/include/physical_plan/operator/result/result_set.h"
 #include "src/processor/include/physical_plan/operator/result/tuple.h"
 
 namespace graphflow {
@@ -12,20 +13,14 @@ class QueryResult {
 public:
     explicit QueryResult(uint64_t numTuples) : numTuples{numTuples} {}
 
-    explicit QueryResult(vector<Tuple> tuples) : numTuples{tuples.size()}, tuples{move(tuples)} {}
-
     QueryResult() : QueryResult(0) {}
 
-    void appendQueryResult(unique_ptr<QueryResult> result) {
-        numTuples += result->numTuples;
-        if constexpr (ENABLE_DEBUG) {
-            move(begin(result->tuples), end(result->tuples), back_inserter(tuples));
-        }
-    }
+    void appendQueryResult(unique_ptr<QueryResult> queryResult);
 
 public:
     uint64_t numTuples;
-    vector<Tuple> tuples;
+    vector<unique_ptr<ResultSet>> resultSetCollection;
+    vector<unique_ptr<BufferBlock>> bufferBlocks;
 };
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/result/result_set.cpp
+++ b/src/processor/physical_plan/operator/result/result_set.cpp
@@ -11,5 +11,14 @@ uint64_t ResultSet::getNumTuples() {
     return numTuples;
 }
 
+unique_ptr<ResultSet> ResultSet::clone() {
+    auto clonedResultSet = make_unique<ResultSet>();
+    for (auto& dataChunk : dataChunks) {
+        clonedResultSet->dataChunks.push_back(dataChunk->clone());
+    }
+    clonedResultSet->multiplicity = multiplicity;
+    return clonedResultSet;
+}
+
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/result/result_set_iterator.cpp
+++ b/src/processor/physical_plan/operator/result/result_set_iterator.cpp
@@ -6,13 +6,13 @@ namespace graphflow {
 namespace processor {
 
 bool ResultSetIterator::hasNextTuple() {
-    return numIteratedTuples < resultSet.getNumTuples();
+    return numIteratedTuples < resultSet->getNumTuples();
 }
 
 void ResultSetIterator::reset() {
     tuplePositions.clear();
-    for (uint64_t i = 0; i < resultSet.dataChunks.size(); i++) {
-        auto dataChunk = resultSet.dataChunks[i];
+    for (uint64_t i = 0; i < resultSet->dataChunks.size(); i++) {
+        auto dataChunk = resultSet->dataChunks[i];
         if (dataChunk->state->isFlat()) {
             tuplePositions.push_back(dataChunk->state->currPos);
         } else {
@@ -24,11 +24,11 @@ void ResultSetIterator::reset() {
 }
 
 bool ResultSetIterator::updateTuplePositions(int64_t chunkIdx) {
-    if (resultSet.dataChunks[chunkIdx]->state->isFlat()) {
+    if (resultSet->dataChunks[chunkIdx]->state->isFlat()) {
         return false;
     }
     tuplePositions[chunkIdx] = tuplePositions[chunkIdx] + 1;
-    if (tuplePositions[chunkIdx] == resultSet.dataChunks[chunkIdx]->state->size) {
+    if (tuplePositions[chunkIdx] == resultSet->dataChunks[chunkIdx]->state->size) {
         tuplePositions[chunkIdx] = 0;
         return false;
     }
@@ -36,7 +36,7 @@ bool ResultSetIterator::updateTuplePositions(int64_t chunkIdx) {
 }
 
 void ResultSetIterator::updateTuplePositions() {
-    int64_t lastChunkIdx = resultSet.dataChunks.size() - 1;
+    int64_t lastChunkIdx = resultSet->dataChunks.size() - 1;
     while (!updateTuplePositions(lastChunkIdx)) {
         lastChunkIdx = lastChunkIdx - 1;
         if (lastChunkIdx < 0) {
@@ -46,22 +46,26 @@ void ResultSetIterator::updateTuplePositions() {
 }
 
 void ResultSetIterator::setDataChunksTypes() {
-    dataChunksTypes.clear();
-    for (uint64_t i = 0; i < resultSet.dataChunks.size(); i++) {
-        auto dataChunk = resultSet.dataChunks[i];
+    dataTypes.clear();
+    for (uint64_t i = 0; i < resultSet->dataChunks.size(); i++) {
+        auto dataChunk = resultSet->dataChunks[i];
         for (auto& vector : dataChunk->valueVectors) {
-            dataChunksTypes.push_back(vector->dataType);
+            dataTypes.push_back(vector->dataType);
         }
     }
 }
 
 void ResultSetIterator::getNextTuple(Tuple& tuple) {
     auto valueInTupleIdx = 0;
-    for (uint64_t i = 0; i < resultSet.dataChunks.size(); i++) {
-        auto dataChunk = resultSet.dataChunks[i];
+    for (uint64_t i = 0; i < resultSet->dataChunks.size(); i++) {
+        auto dataChunk = resultSet->dataChunks[i];
         auto tuplePosition = tuplePositions[i];
         for (auto& vector : dataChunk->valueVectors) {
             auto selectedTuplePos = vector->state->selectedValuesPos[tuplePosition];
+            tuple.nullMask[valueInTupleIdx] = vector->nullMask[selectedTuplePos];
+            if (vector->nullMask[selectedTuplePos]) {
+                continue;
+            }
             switch (vector->dataType) {
             case INT64: {
                 tuple.getValue(valueInTupleIdx)->val.int64Val =
@@ -82,10 +86,13 @@ void ResultSetIterator::getNextTuple(Tuple& tuple) {
                 nodeID_t nodeID;
                 vector->readNodeID(selectedTuplePos, nodeID);
                 tuple.getValue(valueInTupleIdx)->val.nodeID = nodeID;
-                break;
-            }
+            } break;
             case UNSTRUCTURED: {
                 *(tuple.getValue(valueInTupleIdx)) = ((Value*)vector->values)[selectedTuplePos];
+            } break;
+            case DATE: {
+                tuple.getValue(valueInTupleIdx)->val.dateVal =
+                    ((date_t*)vector->values)[selectedTuplePos];
             } break;
             default:
                 assert(false);

--- a/src/processor/physical_plan/operator/sink/result_collector.cpp
+++ b/src/processor/physical_plan/operator/sink/result_collector.cpp
@@ -8,16 +8,30 @@ void ResultCollector::getNextTuples() {
     prevOperator->getNextTuples();
     auto resultSet = prevOperator->getResultSet();
     queryResult->numTuples += resultSet->getNumTuples() * resultSet->multiplicity;
-    if constexpr (ENABLE_DEBUG) {
-        resultSetIterator->reset();
-        while (resultSetIterator->hasNextTuple()) {
-            Tuple tuple(resultSetIterator->dataChunksTypes);
-            tuple.multiplicity = resultSet->multiplicity;
-            resultSetIterator->getNextTuple(tuple);
-            queryResult->tuples.push_back(move(tuple));
+    if (enableProjection) {
+        auto clonedResultSet = resultSet->clone();
+        queryResult->resultSetCollection.push_back(move(clonedResultSet));
+        for (auto& dataChunk : resultSet->dataChunks) {
+            for (auto& vector : dataChunk->valueVectors) {
+                if (vector->stringBuffer != nullptr) {
+                    move(begin(vector->stringBuffer->blocks), end(vector->stringBuffer->blocks),
+                        back_inserter(queryResult->bufferBlocks));
+                }
+            }
         }
     }
+    resetStringBuffer();
     metrics->executionTime.stop();
+}
+
+void ResultCollector::resetStringBuffer() {
+    for (auto& dataChunk : resultSet->dataChunks) {
+        for (auto& vector : dataChunk->valueVectors) {
+            if (vector->stringBuffer != nullptr) {
+                vector->stringBuffer = make_unique<StringBuffer>(*context.memoryManager);
+            }
+        }
+    }
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/query_result.cpp
+++ b/src/processor/physical_plan/query_result.cpp
@@ -1,0 +1,14 @@
+#include "src/processor/include/physical_plan/query_result.h"
+
+namespace graphflow {
+namespace processor {
+
+void QueryResult::appendQueryResult(unique_ptr<QueryResult> queryResult) {
+    numTuples += queryResult->numTuples;
+    move(begin(queryResult->resultSetCollection), end(queryResult->resultSetCollection),
+        back_inserter(resultSetCollection));
+    move(begin(queryResult->bufferBlocks), end(queryResult->bufferBlocks),
+        back_inserter(bufferBlocks));
+}
+} // namespace processor
+} // namespace graphflow

--- a/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
+++ b/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
@@ -76,7 +76,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest1) {
     dataChunkB->state->currPos = -1;
     dataChunkC->state->currPos = 10;
 
-    ResultSetIterator resultSetIterator(resultSet);
+    ResultSetIterator resultSetIterator(&resultSet);
     auto tupleIndex = 0;
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
@@ -96,7 +96,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest1) {
     dataChunkA->state->currPos = 1;
     dataChunkB->state->currPos = 9;
     dataChunkC->state->currPos = 99;
-    resultSetIterator.setDataChunks(resultSet);
+    resultSetIterator.setResultSet(&resultSet);
     tupleIndex = 0;
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
@@ -126,7 +126,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest2) {
     dataChunkA->state->currPos = 1;
     dataChunkB->state->currPos = -1;
     dataChunkC->state->currPos = -1;
-    ResultSetIterator resultSetIterator(resultSet);
+    ResultSetIterator resultSetIterator(&resultSet);
     while (resultSetIterator.hasNextTuple()) {
         auto bid = tupleIndex / 100;
         auto cid = tupleIndex % 100;
@@ -157,7 +157,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest3) {
     dataChunkA->state->currPos = -1;
     dataChunkB->state->currPos = 10;
     dataChunkC->state->currPos = -1;
-    ResultSetIterator resultSetIterator(resultSet);
+    ResultSetIterator resultSetIterator(&resultSet);
     while (resultSetIterator.hasNextTuple()) {
         auto aid = tupleIndex / 100;
         auto cid = tupleIndex % 100;
@@ -188,7 +188,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest4) {
     dataChunkC->state->currPos = 20;
 
     auto tupleIndex = 0;
-    ResultSetIterator resultSetIterator(resultSet);
+    ResultSetIterator resultSetIterator(&resultSet);
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
         string tupleStr = tuple.toString();
@@ -214,7 +214,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTestWithSelector) {
     dataChunkC->state->currPos = 20;
 
     auto tupleIndex = 0;
-    ResultSetIterator resultSetIterator(resultSet);
+    ResultSetIterator resultSetIterator(&resultSet);
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
         string tupleStr = tuple.toString();

--- a/test/processor/processor_test.cpp
+++ b/test/processor/processor_test.cpp
@@ -29,7 +29,7 @@ TEST(ProcessorTests, MultiThreadedScanTest) {
     auto executionContext = ExecutionContext(*profiler, nullptr, memoryManager.get());
     auto plan = make_unique<PhysicalPlan>(
         make_unique<ResultCollector>(make_unique<ScanNodeID<true>>(morsel, executionContext, 0),
-            RESULT_COLLECTOR, executionContext, 1));
+            RESULT_COLLECTOR, executionContext, 1, false));
     auto processor = make_unique<QueryProcessor>(10);
     auto result = processor->execute(plan.get(), 1);
     ASSERT_EQ(result->numTuples, 1025013);

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -30,6 +30,7 @@ filegroup(
         "queries/filtered/stars.test",
         "queries/filtered/str_operations.test",
         "queries/filtered/unstructured_properties.test",
+        "queries/projection/projection.test",
         "queries/structural/frontier.test",
         "queries/structural/nodes.test",
         "queries/structural/paths.test",

--- a/test/runner/end_to_end_test.cpp
+++ b/test/runner/end_to_end_test.cpp
@@ -48,3 +48,9 @@ TEST_F(TinySnbProcessorTest, DateDataTypeTests) {
     queryConfig = TestHelper::parseTestFile("test/runner/queries/data_types/date_data_type.test");
     ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
 }
+
+TEST_F(TinySnbProcessorTest, ProjectionTests) {
+    unique_ptr<TestSuiteQueryConfig> queryConfig;
+    queryConfig = TestHelper::parseTestFile("test/runner/queries/projection/projection.test");
+    ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
+}

--- a/test/runner/queries/filtered/paths.test
+++ b/test/runner/queries/filtered/paths.test
@@ -20,18 +20,6 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WHERE a.age = c.age RETURN COUNT(*)
 ---- 12
 
--NAME TwoHopKnowsFilteredTest2
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b, a.age AS foo MATCH (b)-[e2:knows]->(c:person) WHERE foo = c.age RETURN COUNT(*)
----- 12
-
--NAME TwoHopKnowsFilteredTest3
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b AS d, a.age AS foo MATCH (d)-[e2:knows]->(c:person) WHERE foo * 3.1 = c.age * 3.1 RETURN COUNT(*)
----- 12
-
--NAME TwoHopKnowsFilteredTest4
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b AS d, a.age * 2.0 AS foo MATCH (d)-[e2:knows]->(c:person) WHERE foo = c.age * 2.0 RETURN COUNT(*)
----- 12
-
 -NAME OneHopOrgCodeFilter
 -QUERY MATCH (a:person)-[e1:studyAt]->(b:organisation) WHERE b.orgCode > 100 RETURN COUNT(*)
 ---- 3

--- a/test/runner/queries/filtered/stars.test
+++ b/test/runner/queries/filtered/stars.test
@@ -3,7 +3,3 @@
 -NAME TwoHopKnowsFilteredTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person), (a:person)-[e2:knows]->(c:person) WHERE e1.date = e2.date RETURN COUNT(*)
 ---- 24
-
--NAME TwoHopKnowsFilteredTwoQueryPartsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH * MATCH (a)-[e2:knows]->(c:person) WHERE e1.date = e2.date RETURN COUNT(*)
----- 24

--- a/test/runner/queries/filtered/str_operations.test
+++ b/test/runner/queries/filtered/str_operations.test
@@ -72,8 +72,6 @@
 -QUERY MATCH (a:person) WHERE '1900-01-01Alice' = a.birthdate + a.fName RETURN COUNT(*)
 ---- 1
 
-# This test is commented out because until we support casting structured strings to unstructured values
-# it gives a runtime error.
-#-NAME DateVarAndStrVarConcatUnstructured
-#-QUERY MATCH (a:person) WHERE '47Bob' = a.unstrNumericProp + a.fName RETURN COUNT(*)
-#---- 1
+-NAME DateVarAndStrVarConcatUnstructured
+-QUERY MATCH (a:person) WHERE '47Bob' = a.unstrNumericProp + a.fName RETURN COUNT(*)
+---- 1

--- a/test/runner/queries/projection/projection.test
+++ b/test/runner/queries/projection/projection.test
@@ -1,0 +1,142 @@
+# description: projections
+
+-NAME PersonNodesTestUnstructuredProperty
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person) RETURN a.id,a.unstrDateProp1
+---- 8
+0|1900-01-01
+2|1950-01-01
+3|1950-01-01
+5|
+7|
+8|
+9|
+10|
+
+-NAME PersonNodesTestString
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person) RETURN a.fName
+---- 8
+Alice
+Bob
+Carol
+Dan
+Elizabeth
+Farooq
+Greg
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+
+-NAME PersonNodesTestInt
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person) RETURN a.age
+---- 8
+35
+30
+45
+20
+20
+25
+40
+83
+
+-NAME PersonNodesTestBoolean
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person) RETURN a.isStudent
+---- 8
+True
+True
+False
+False
+False
+True
+False
+False
+
+-NAME PersonNodesTestDouble
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person) RETURN a.eyeSight
+---- 8
+5.000000
+5.100000
+5.000000
+4.800000
+4.700000
+4.500000
+4.900000
+4.900000
+
+-NAME PersonNodesTestDate
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person) RETURN a.birthdate
+---- 8
+1900-01-01
+1900-01-01
+1940-06-22
+1950-07-23
+1980-10-26
+1980-10-26
+1980-10-26
+1990-11-27
+
+-NAME KnowsRelTestDate
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person)-[e:knows]->(b:person) RETURN e.date
+---- 14
+2021-06-30
+2021-06-30
+2021-06-30
+2021-06-30
+1950-05-14
+1950-05-14
+2021-06-30
+1950-05-14
+2000-01-01
+2021-06-30
+1950-05-14
+2000-01-01
+1905-12-12
+1905-12-12
+
+-NAME KnowsOneHopTest
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE b.age=20 RETURN b.age
+---- 3
+20
+20
+20
+
+-NAME KnowsTwoHopTest1
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person)-[:knows]->(:person)-[:knows]->(b:person) WHERE b.age>40 RETURN b.age
+---- 9
+45
+45
+45
+45
+45
+45
+45
+45
+45
+
+-NAME KnowsTwoHopTest2
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person)-[:knows]->(:person)-[:knows]->(b:person) WHERE a.age>b.age+10 RETURN a.age, b.age
+---- 6
+35|20
+35|20
+45|20
+45|20
+45|30
+45|30
+
+-NAME KnowsTwoHopTest3
+-COMPARE_RESULT 1
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE a.age>c.age+10 RETURN a.age, b.fName, c.age
+---- 6
+35|Bob|20
+35|Carol|20
+45|Alice|20
+45|Bob|20
+45|Dan|30
+45|Alice|30

--- a/test/runner/queries/structural/paths.test
+++ b/test/runner/queries/structural/paths.test
@@ -16,10 +16,6 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) RETURN COUNT(*)
 ---- 36
 
--NAME TwoHopKnowsTest2
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b MATCH (b)-[e2:knows]->(c:person) RETURN COUNT(*)
----- 36
-
 -NAME TwoHopKnowsStudyAtTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:studyAt]->(c:organisation) RETURN COUNT(*)
 ---- 7
@@ -36,16 +32,8 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:studyAt]->(d:organisation) RETURN COUNT(*)
 ---- 18
 
--NAME ThreeHopTwoKnowsOneStudyAtTest2
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH * MATCH (b)-[e2:knows]->(c:person)-[e3:studyAt]->(d:organisation) RETURN COUNT(*)
----- 18
-
 -NAME ThreeHopTwoKnowsOneWorkAtTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:workAt]->(d:organisation) RETURN COUNT(*)
----- 18
-
--NAME ThreeHopTwoKnowsOneWorkAtTest2
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WITH * MATCH (c)-[e3:workAt]->(d:organisation) RETURN COUNT(*)
 ---- 18
 
 -NAME FourHopKnowsTest

--- a/test/runner/queries/structural/stars.test
+++ b/test/runner/queries/structural/stars.test
@@ -39,7 +39,3 @@
 -NAME OpenTwoHopWedgeKnowsTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person),(a:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
 ---- 324
-
--NAME OpenTwoHopWedgeKnowsTest3
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH * MATCH (b)-[e2:knows]->(c:person) WITH * MATCH (a)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
----- 324

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -2,6 +2,8 @@
 
 #include <iostream>
 
+#include "src/processor/include/physical_plan/operator/result/result_set_iterator.h"
+
 // prompt for user input
 const char* PROMPT = "graphflowdb> ";
 // file to read/write shell history
@@ -119,6 +121,19 @@ void EmbeddedShell::printExecutionResult() {
     } else {
         // print query result (numTuples & tuples)
         printf(">> Number of output tuples: %lu\n", context.queryResult->numTuples);
+        if (!context.queryResult->resultSetCollection.empty()) {
+            ResultSetIterator resultSetIterator(context.queryResult->resultSetCollection[0].get());
+            Tuple tuple(resultSetIterator.dataTypes);
+            for (auto& resultSet : context.queryResult->resultSetCollection) {
+                resultSetIterator.setResultSet(resultSet.get());
+                while (resultSetIterator.hasNextTuple()) {
+                    resultSetIterator.getNextTuple(tuple);
+                    for (uint64_t k = 0; k < resultSet->multiplicity; k++) {
+                        printf("%s\n", tuple.toString().c_str());
+                    }
+                }
+            }
+        }
         if (context.profiler->enabled) {
             // print plan with profiling metrics
             printf("==============================================\n");


### PR DESCRIPTION
This PR makes following changes:
- fix projection plan mapping and operator execution for single query.
- move result set iteration out of ResultCollector.
- remove end-to-end tests with WITH statements for now.

Also, minor changes:
- set ENABLE_DEBUG to true, which is needed by projection tests.
- minor fixes to enumerator.