### PR TITLE
Separating ListHandle from DataStructureHandle

### DIFF
--- a/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
@@ -32,10 +32,10 @@ private:
     uint64_t endLayer;
     vector<FrontierSet*> frontierPerLayer;
     vector<vector<FrontierBag*>> threadLocalFrontierPerLayer;
-    // We create a vector and handle per thread assuming omp_get_max_threads() threads.
-    // Each thread uses their vector and handle for uncoordinated extensions.
+    // We create a vector and listHandle per thread assuming omp_get_max_threads() threads.
+    // Each thread uses their vector and listHandle for uncoordinated extensions.
     vector<shared_ptr<NodeIDVector>> vectors;
-    vector<unique_ptr<DataStructureHandle>> handles;
+    vector<unique_ptr<ListHandle>> listHandles;
 
     struct CurrentOutputPosition {
         bool hasMoreTuplesToProduce;

--- a/src/processor/include/physical_plan/operator/read_list/read_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_list.h
@@ -13,7 +13,7 @@ public:
     ReadList(const uint64_t& inDataChunkPos, const uint64_t& inValueVectorPos, BaseLists* lists,
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
 
-    ~ReadList() { lists->reclaim(handle); }
+    ~ReadList() { lists->reclaim(*listHandle); }
 
     void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
 
@@ -31,7 +31,7 @@ protected:
     shared_ptr<ValueVector> outValueVector;
 
     BaseLists* lists;
-    unique_ptr<DataStructureHandle> handle;
+    unique_ptr<ListHandle> listHandle;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
@@ -22,7 +22,7 @@ protected:
     shared_ptr<DataChunk> inDataChunk;
     shared_ptr<NodeIDVector> inNodeIDVector;
     shared_ptr<ValueVector> outValueVector;
-    unique_ptr<DataStructureHandle> handle;
+    unique_ptr<PageHandle> pageHandle;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_column.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_column.h
@@ -16,7 +16,7 @@ public:
         : ScanAttribute{dataChunkPos, valueVectorPos, move(prevOperator), context, id},
           column{column} {};
 
-    ~ScanColumn() { column->reclaim(handle); }
+    ~ScanColumn() { column->reclaim(*pageHandle); }
 
     void getNextTuples() override;
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_unstructured_property.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_unstructured_property.h
@@ -15,7 +15,7 @@ public:
         BaseLists* lists, unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context,
         uint32_t id);
 
-    ~ScanUnstructuredProperty() { lists->reclaim(handle); }
+    ~ScanUnstructuredProperty() { lists->reclaim(*pageHandle); }
 
     void getNextTuples() override;
 

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -13,14 +13,14 @@ AdjListExtend<IS_OUT_DATACHUNK_FILTERED>::AdjListExtend(uint64_t inDataChunkPos,
     outDataChunk->append(outValueVector);
     auto listSyncState = make_shared<ListSyncState>();
     resultSet->append(outDataChunk, listSyncState);
-    handle->setListSyncState(listSyncState);
-    handle->setIsAdjListHandle();
+    listHandle->setListSyncState(listSyncState);
+    listHandle->setIsAdjListHandle();
 }
 
 template<bool IS_OUT_DATACHUNK_FILTERED>
 void AdjListExtend<IS_OUT_DATACHUNK_FILTERED>::getNextTuples() {
     metrics->executionTime.start();
-    if (handle->hasMoreToRead()) {
+    if (listHandle->hasMoreToRead()) {
         readValuesFromList();
         if constexpr (IS_OUT_DATACHUNK_FILTERED) {
             outDataChunk->state->initializeSelector();

--- a/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
@@ -21,14 +21,14 @@ FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::FrontierExtend(uint64_t inDataChunkPo
     resultSet->append(outDataChunk, make_shared<ListSyncState>());
     uint64_t maxNumThreads = omp_get_max_threads();
     vectors.reserve(maxNumThreads);
-    handles.reserve(maxNumThreads);
+    listHandles.reserve(maxNumThreads);
     for (auto i = 0u; i < maxNumThreads; i++) {
         vectors.push_back(make_shared<NodeIDVector>(0, lists->getNodeIDCompressionScheme(), false));
         vectors[i]->state =
             make_shared<VectorState>(false /* initSelectedValuesPos */, DEFAULT_VECTOR_CAPACITY);
-        handles.push_back(make_unique<DataStructureHandle>());
-        handles[i]->setListSyncState(make_shared<ListSyncState>());
-        handles[i]->setIsAdjListHandle();
+        listHandles.push_back(make_unique<ListHandle>());
+        listHandles[i]->setListSyncState(make_shared<ListSyncState>());
+        listHandles[i]->setIsAdjListHandle();
     }
     frontierPerLayer.reserve(upperBound + 1);
     threadLocalFrontierPerLayer.reserve(upperBound);
@@ -104,12 +104,12 @@ void FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::extendToThreadLocalFrontiers(uin
                             // Warning: we use non-thread-safe metric inside openmp parallelization
                             // metrics won't be exactly but hopefully good enough.
                             lists->readValues(slot->nodeOffset, vectors[threadId],
-                                vectors[threadId]->state->size, handles[threadId], MAX_TO_READ,
+                                vectors[threadId]->state->size, listHandles[threadId], MAX_TO_READ,
                                 *metrics->bufferManagerMetrics);
                             threadLocalFrontierPerLayer[layer][threadId]->append(
                                 *(NodeIDVector*)(vectors[threadId].get()), slot->multiplicity);
-                        } while (handles[threadId]->hasMoreToRead());
-                        lists->reclaim(handles[threadId]);
+                        } while (listHandles[threadId]->hasMoreToRead());
+                        lists->reclaim(*listHandles[threadId]);
                         slot = slot->next;
                     }
                 }
@@ -209,11 +209,11 @@ FrontierSet* FrontierExtend<IS_OUT_DATACHUNK_FILTERED>::createInitialFrontierSet
     frontier->setMemoryManager(context.memoryManager);
     frontier->initHashTable(numSlots);
     do {
-        lists->readValues(nodeOffset, vectors[0], vectors[0]->state->size, handles[0], MAX_TO_READ,
-            *metrics->bufferManagerMetrics);
+        lists->readValues(nodeOffset, vectors[0], vectors[0]->state->size, listHandles[0],
+            MAX_TO_READ, *metrics->bufferManagerMetrics);
         frontier->insert(*vectors[0]);
-    } while (handles[0]->hasMoreToRead());
-    lists->reclaim(handles[0]);
+    } while (listHandles[0]->hasMoreToRead());
+    lists->reclaim(*listHandles[0]);
     return frontier;
 }
 

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -10,7 +10,7 @@ ReadList::ReadList(const uint64_t& dataChunkPos, const uint64_t& valueVectorPos,
     resultSet = this->prevOperator->getResultSet();
     inDataChunk = resultSet->dataChunks[dataChunkPos];
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
-    handle = make_unique<DataStructureHandle>();
+    listHandle = make_unique<ListHandle>();
 }
 
 void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
@@ -19,11 +19,11 @@ void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
 }
 
 void ReadList::readValuesFromList() {
-    lists->reclaim(handle);
+    lists->reclaim(*listHandle);
     auto nodeOffset =
         inNodeIDVector->readNodeOffset(inDataChunk->state->getCurrSelectedValuesPos());
-    lists->readValues(nodeOffset, outValueVector, outDataChunk->state->size, handle, MAX_TO_READ,
-        *metrics->bufferManagerMetrics);
+    lists->readValues(nodeOffset, outValueVector, outDataChunk->state->size, listHandle,
+        MAX_TO_READ, *metrics->bufferManagerMetrics);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -10,7 +10,7 @@ ReadRelPropertyList::ReadRelPropertyList(uint64_t inDataChunkPos, uint64_t inVal
       outDataChunkPos(outDataChunkPos) {
     outValueVector = make_shared<ValueVector>(context.memoryManager, lists->getDataType());
     outDataChunk = resultSet->dataChunks[outDataChunkPos];
-    handle->setListSyncState(resultSet->getListSyncState(outDataChunkPos));
+    listHandle->setListSyncState(resultSet->getListSyncState(outDataChunkPos));
     outDataChunk->append(outValueVector);
 }
 

--- a/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
@@ -6,7 +6,7 @@ namespace processor {
 ScanAttribute::ScanAttribute(uint64_t dataChunkPos, uint64_t valueVectorPos,
     unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
     : PhysicalOperator{move(prevOperator), SCAN_ATTRIBUTE, context, id}, dataChunkPos{dataChunkPos},
-      valueVectorPos{valueVectorPos}, handle{make_unique<DataStructureHandle>()} {
+      valueVectorPos{valueVectorPos}, pageHandle{make_unique<PageHandle>()} {
     resultSet = this->prevOperator->getResultSet();
     inDataChunk = resultSet->dataChunks[dataChunkPos];
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));

--- a/src/processor/physical_plan/operator/scan_attribute/scan_column.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_column.cpp
@@ -6,8 +6,9 @@ namespace processor {
 void ScanColumn::getNextTuples() {
     prevOperator->getNextTuples();
     if (inDataChunk->state->size > 0) {
-        column->reclaim(handle);
-        column->readValues(inNodeIDVector, outValueVector, handle, *metrics->bufferManagerMetrics);
+        column->reclaim(*pageHandle);
+        column->readValues(
+            inNodeIDVector, outValueVector, pageHandle, *metrics->bufferManagerMetrics);
     }
 }
 

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -13,7 +13,7 @@ ScanUnstructuredProperty::ScanUnstructuredProperty(uint64_t dataChunkPos, uint64
     resultSet = this->prevOperator->getResultSet();
     inDataChunk = resultSet->dataChunks[dataChunkPos];
     inNodeIDVector = static_pointer_cast<NodeIDVector>(inDataChunk->getValueVector(valueVectorPos));
-    handle = make_unique<DataStructureHandle>();
+    pageHandle = make_unique<PageHandle>();
     outValueVector = make_shared<ValueVector>(context.memoryManager, lists->getDataType());
     inDataChunk->append(outValueVector);
 }
@@ -22,9 +22,9 @@ void ScanUnstructuredProperty::getNextTuples() {
     metrics->executionTime.start();
     prevOperator->getNextTuples();
     if (inDataChunk->state->size > 0) {
-        lists->reclaim(handle);
-        lists->readValues(
-            inNodeIDVector, propertyKey, outValueVector, handle, *metrics->bufferManagerMetrics);
+        lists->reclaim(*pageHandle);
+        lists->readValues(inNodeIDVector, propertyKey, outValueVector, pageHandle,
+            *metrics->bufferManagerMetrics);
     }
     metrics->executionTime.stop();
 }

--- a/src/storage/include/data_structure/column.h
+++ b/src/storage/include/data_structure/column.h
@@ -18,7 +18,7 @@ class BaseColumn : public DataStructure {
 
 public:
     virtual void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
-        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<PageHandle>& pageHandle,
         BufferManagerMetrics& metrics);
 
 protected:
@@ -27,7 +27,7 @@ protected:
         : DataStructure{fName, dataType, elementSize, bufferManager} {};
 
     void readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& nodeIDVector,
-        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<PageHandle>& pageHandle,
         BufferManagerMetrics& metrics);
 };
 
@@ -48,7 +48,7 @@ public:
           stringOverflowPages{fName, bufferManager} {};
 
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
-        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<PageHandle>& pageHandle,
         BufferManagerMetrics& metrics) override;
 
 private:

--- a/src/storage/include/data_structure/data_structure.h
+++ b/src/storage/include/data_structure/data_structure.h
@@ -19,7 +19,7 @@ namespace storage {
 class DataStructure {
 
 public:
-    void reclaim(const unique_ptr<DataStructureHandle>& handle);
+    void reclaim(PageHandle& pageHandle);
 
     DataType getDataType() { return dataType; }
 
@@ -36,14 +36,12 @@ protected:
 
     virtual ~DataStructure() = default;
 
-    void readBySettingFrame(const shared_ptr<ValueVector>& valueVector,
-        const unique_ptr<DataStructureHandle>& handle, PageCursor& pageCursor,
-        BufferManagerMetrics& metrics);
+    void readBySettingFrame(const shared_ptr<ValueVector>& valueVector, PageHandle& pageHandle,
+        PageCursor& pageCursor, BufferManagerMetrics& metrics);
 
-    void readBySequentialCopy(const shared_ptr<ValueVector>& valueVector,
-        const unique_ptr<DataStructureHandle>& handle, uint64_t sizeLeftToCopy,
-        PageCursor& pageCursor, unique_ptr<LogicalToPhysicalPageIdxMapper> mapper,
-        BufferManagerMetrics& metrics);
+    void readBySequentialCopy(const shared_ptr<ValueVector>& valueVector, PageHandle& pageHandle,
+        uint64_t sizeLeftToCopy, PageCursor& pageCursor,
+        unique_ptr<LogicalToPhysicalPageIdxMapper> mapper, BufferManagerMetrics& metrics);
 
 public:
     DataType dataType;

--- a/src/storage/include/data_structure/data_structure_handle.h
+++ b/src/storage/include/data_structure/data_structure_handle.h
@@ -10,17 +10,33 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace storage {
 
-// DataStructureHandle stores the state of reading from a list or a column across multiple calls to
-// the readValues() function. It holds three pieces information:
-// 1. pageIdx: reference of the page that is currently pinned by the Column/Lists to make the Frame
-// available to the readValues() caller.
-// 2. listSyncer: to synchronize reading of values between multiple lists that have related data so
-// that they end up reading the correct portion of the list.
-// 3. isAdjListsHandle: true, if the handle stores the state of anAdjLists, else false.
-class DataStructureHandle {
+// PageHandle stores the state a pageIdx when reading from a list or a column across multiple calls
+// to the readValues() function. The pageIdx is the pageIdx of the page that is currently pinned by
+// the Column/Lists to make the Frame available to the readValues() caller.
+class PageHandle {
 
 public:
-    DataStructureHandle() : pageIdx{-1u}, isAdjListsHandle{false} {};
+    PageHandle() : pageIdx{-1u} {};
+
+    inline bool hasPageIdx() { return -1u != pageIdx; }
+    inline uint32_t getPageIdx() { return pageIdx; }
+    inline void setPageIdx(uint32_t pageIdx) { this->pageIdx = pageIdx; }
+    inline void resetPageIdx() { pageIdx = -1u; }
+
+private:
+    uint32_t pageIdx;
+};
+
+// ListHandle stores the state of reading from a list cross multiple calls to
+// the readValues() function. It extends PageHandle, so stores a pinned pageIdx. In addition it
+// holds two other pieces information:
+// 1. listSyncer: to synchronize reading of values between multiple lists that have related data so
+// that they end up reading the correct portion of the list.
+// 2. isAdjListsHandle: true, if the listHandle stores the state of anAdjLists, else false.
+class ListHandle : public PageHandle {
+
+public:
+    ListHandle() : PageHandle(), isAdjListsHandle{false} {};
 
     inline void setIsAdjListHandle() { isAdjListsHandle = true; }
     inline bool getIsAdjListsHandle() { return isAdjListsHandle; }
@@ -30,21 +46,14 @@ public:
     }
     inline shared_ptr<ListSyncState> getListSyncState() { return listSyncState; }
 
-    inline bool hasPageIdx() { return -1u != pageIdx; }
-    inline uint32_t getPageIdx() { return pageIdx; }
-    inline void setPageIdx(uint32_t pageIdx) { this->pageIdx = pageIdx; }
-    inline void resetPageIdx() { pageIdx = -1u; }
-
     bool hasMoreToRead() {
         return isAdjListsHandle ? listSyncState->hasNewRangeToRead() :
                                   listSyncState->hasValidRangeToRead();
     }
 
 private:
-    uint32_t pageIdx;
     shared_ptr<ListSyncState> listSyncState;
     bool isAdjListsHandle;
 };
-
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/include/data_structure/lists/list_sync_state.h
+++ b/src/storage/include/data_structure/lists/list_sync_state.h
@@ -7,11 +7,12 @@ namespace storage {
 
 // ListSyncState holds the data that is required to synchronize reading from multiple Lists that
 // have related data and hence share same AdjListHeaders. The Lists that share a single copy of
-// AdjListHeaders are - a single-directional edges of a rel label and edges' properties. For the
-// case of reading from a large list, we do not / cannot read the entire list in a single
-// operation since it can be very big, hence we read in batches from a definite start point to an
-// end point. List Sync holds this information and helps in co-ordinating all related lists so
-// that all of them read the correct portion of data.
+// AdjListHeaders are - edges, i.e., adjlists of a rel label in a particular direction, e.g.,
+// forward or backward, and the properties of those edges. For the case of reading from a large
+// list, we do not / cannot read the entire list in a single operation since it can be very big,
+// hence we read in batches from a definite start point to an end point. List Sync holds this
+// information and helps in co-ordinating all related lists so that all of them read the correct
+// portion of data.
 class ListSyncState {
 
 public:

--- a/src/storage/include/data_structure/lists/lists.h
+++ b/src/storage/include/data_structure/lists/lists.h
@@ -19,8 +19,8 @@ class BaseLists : public DataStructure {
 
 public:
     void readValues(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle,
-        uint32_t maxElementsToRead, BufferManagerMetrics& metrics);
+        uint64_t& listLen, const unique_ptr<ListHandle>& listHandle, uint32_t maxElementsToRead,
+        BufferManagerMetrics& metrics);
 
     uint64_t getNumElementsInList(node_offset_t nodeOffset);
 
@@ -31,11 +31,11 @@ protected:
           headers(move(headers)){};
 
     virtual void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& listLen,
-        const unique_ptr<DataStructureHandle>& handle, uint32_t header, uint32_t maxElementsToRead,
+        const unique_ptr<ListHandle>& listHandle, uint32_t header, uint32_t maxElementsToRead,
         BufferManagerMetrics& metrics);
 
     virtual void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle, uint32_t header,
+        uint64_t& listLen, const unique_ptr<ListHandle>& listHandle, uint32_t header,
         BufferManagerMetrics& metrics);
 
 public:
@@ -67,11 +67,11 @@ public:
 
 private:
     void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& listLen,
-        const unique_ptr<DataStructureHandle>& handle, uint32_t header, uint32_t maxElementsToRead,
+        const unique_ptr<ListHandle>& listHandle, uint32_t header, uint32_t maxElementsToRead,
         BufferManagerMetrics& metrics) override;
 
     void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle, uint32_t header,
+        uint64_t& listLen, const unique_ptr<ListHandle>& listHandle, uint32_t header,
         BufferManagerMetrics& metrics) override;
 
 private:
@@ -95,11 +95,11 @@ public:
 
 private:
     void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& listLen,
-        const unique_ptr<DataStructureHandle>& handle, uint32_t header, uint32_t maxElementsToRead,
+        const unique_ptr<ListHandle>& listHandle, uint32_t header, uint32_t maxElementsToRead,
         BufferManagerMetrics& metrics) override;
 
     void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& listLen, const unique_ptr<DataStructureHandle>& handle, uint32_t header,
+        uint64_t& listLen, const unique_ptr<ListHandle>& listHandle, uint32_t header,
         BufferManagerMetrics& metrics) override;
 
 private:
@@ -123,23 +123,22 @@ public:
     // readValues is overloaded. Lists<UNSTRUCTURED> is not supposed to use the one defined in
     // BaseLists.
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector, uint32_t propertyKeyIdxToRead,
-        const shared_ptr<ValueVector>& valueVector, const unique_ptr<DataStructureHandle>& handle,
+        const shared_ptr<ValueVector>& valueVector, const unique_ptr<PageHandle>& pageHandle,
         BufferManagerMetrics& metrics);
 
 private:
     void readUnstrPropertyListOfNode(node_offset_t nodeOffset, uint32_t propertyKeyIdxToRead,
         const shared_ptr<ValueVector>& valueVector, uint64_t pos,
-        const unique_ptr<DataStructureHandle>& handle, uint32_t header,
-        BufferManagerMetrics& metrics);
+        const unique_ptr<PageHandle>& pageHandle, uint32_t header, BufferManagerMetrics& metrics);
 
     void readUnstrPropertyKeyIdxAndDatatype(uint8_t* propertyKeyDataTypeCache,
         uint64_t& physicalPageIdx, const uint32_t*& propertyKeyIdxPtr,
-        DataType& propertyKeyDataType, const unique_ptr<DataStructureHandle>& handle,
+        DataType& propertyKeyDataType, const unique_ptr<PageHandle>& pageHandle,
         PageCursor& pageCursor, uint64_t& listLen, LogicalToPhysicalPageIdxMapper& mapper,
         BufferManagerMetrics& metrics);
 
     void readOrSkipUnstrPropertyValue(uint64_t& physicalPageIdx, DataType& propertyDataType,
-        const unique_ptr<DataStructureHandle>& handle, PageCursor& pageCursor, uint64_t& listLen,
+        const unique_ptr<PageHandle>& pageHandle, PageCursor& pageCursor, uint64_t& listLen,
         LogicalToPhysicalPageIdxMapper& mapper, const shared_ptr<ValueVector>& valueVector,
         uint64_t pos, bool toRead, BufferManagerMetrics& metrics);
 

--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -38,16 +38,30 @@ void BenchmarkRunner::registerBenchmark(const string& path) {
     }
 }
 
+double BenchmarkRunner::computeAverageOfLastRuns(
+    double* runTimes, const int& len, const int& lastRunsToAverage) {
+    double sum = 0;
+    for (int i = len - lastRunsToAverage; i < len; ++i) {
+        sum += runTimes[i];
+    }
+    return sum / lastRunsToAverage;
+}
+
 void BenchmarkRunner::runBenchmark(Benchmark* benchmark) {
     spdlog::info("Running benchmark {} with {} thread", benchmark->name, config->numThreads);
     for (auto i = 0u; i < config->numWarmups; ++i) {
         spdlog::info("Warm up");
         benchmark->run();
     }
+    double runTimes[config->numRuns];
     for (auto i = 0u; i < config->numRuns; ++i) {
         benchmark->run();
         benchmark->log();
+        runTimes[i] = benchmark->context->executingTime;
     }
+    spdlog::info("Time Taken (Average of Last 3 runs) (ms): " +
+                 to_string(computeAverageOfLastRuns(
+                     runTimes, config->numRuns, (int)3 /* numRunsToAverage */)));
 }
 
 } // namespace benchmark

--- a/tools/benchmark/include/benchmark_runner.h
+++ b/tools/benchmark/include/benchmark_runner.h
@@ -14,6 +14,8 @@ public:
     void registerBenchmarks(const string& path);
 
     void runAllBenchmarks();
+    static double computeAverageOfLastRuns(
+        double* runTimes, const int& len, const int& lastRunsToAverage);
 
 private:
     void registerBenchmark(const string& path);


### PR DESCRIPTION
- Renames DataStructureHandle to PageHandle and makes it only use a PageIdx. This is used by operators that read columns and unstructured properties, which is stored as a list. These are operators that extend ScanAttribute. 
- Adds a new ListHandle class that extends PageHandle. Used by operators that read lists, AdjListExtend, FrontierExtend, and ReadRelPropertyList. 