### PR TITLE
Add fully in-memory storage mode

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -18,8 +18,12 @@ constexpr uint64_t PAGE_SIZE_LOG_2 = 12;
 constexpr uint64_t PAGE_SIZE = 1 << PAGE_SIZE_LOG_2;
 
 // The default amount of memory pre-allocated to the buffer pool (= 1GB).
-constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 30;
 constexpr uint64_t DEFAULT_MEMORY_MANAGER_MAX_MEMORY = 1ull << 38;
+
+struct StorageConfig {
+    // The default amount of memory pre-allocated to the buffer pool (= 1GB).
+    static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 30;
+};
 
 // Hash Index Configurations
 struct HashIndexConfig {

--- a/src/main/include/system.h
+++ b/src/main/include/system.h
@@ -17,7 +17,7 @@ namespace main {
 class System {
 
 public:
-    explicit System(const string& path);
+    explicit System(const string& path, bool isInMemoryMode);
 
     void executeQuery(SessionContext& context) const;
 

--- a/src/main/server.cpp
+++ b/src/main/server.cpp
@@ -62,7 +62,8 @@ void Server::registerPOSTLoad(router_t& router) {
     router.http_post("/load", [&](request_handle_t req, auto) {
         try {
             auto path = req->body();
-            system = make_unique<System>(path);
+            // Notice: only disk-based storage is supported for the server right now.
+            system = make_unique<System>(path, false /* isInMemoryMode */);
             session = make_unique<Session>(*system);
             nlohmann::json json;
             json["msg"] = "Initialized the Graph at " + path + ".";

--- a/src/main/system.cpp
+++ b/src/main/system.cpp
@@ -12,10 +12,11 @@ using namespace graphflow::planner;
 namespace graphflow {
 namespace main {
 
-System::System(const string& path) {
+System::System(const string& path, bool isInMemoryMode) {
     memManager = make_unique<MemoryManager>();
-    bufferManager = make_unique<BufferManager>(DEFAULT_BUFFER_POOL_SIZE);
-    graph = make_unique<Graph>(path, *bufferManager);
+    bufferManager =
+        make_unique<BufferManager>(isInMemoryMode ? 0 : StorageConfig::DEFAULT_BUFFER_POOL_SIZE);
+    graph = make_unique<Graph>(path, *bufferManager, isInMemoryMode);
     processor = make_unique<QueryProcessor>(thread::hardware_concurrency());
     transactionManager = make_unique<TransactionManager>();
     initialized = true;

--- a/src/storage/catalog.cpp
+++ b/src/storage/catalog.cpp
@@ -203,7 +203,7 @@ const PropertyDefinition& Catalog::getNodeProperty(
     assert(false);
 }
 
-const string Catalog::getNodePropertyAsString(label_t labelId, const uint32_t propertyID) const {
+string Catalog::getNodePropertyAsString(label_t labelId, uint32_t propertyID) const {
     for (auto& property : nodeLabels[labelId].properties) {
         if (propertyID == property.id) {
             return property.name;

--- a/src/storage/data_structure/data_structure.cpp
+++ b/src/storage/data_structure/data_structure.cpp
@@ -6,10 +6,10 @@ namespace graphflow {
 namespace storage {
 
 DataStructure::DataStructure(const string& fName, const DataType& dataType,
-    const size_t& elementSize, BufferManager& bufferManager)
+    const size_t& elementSize, BufferManager& bufferManager, bool isInMemory)
     : dataType{dataType}, elementSize{elementSize}, numElementsPerPage{(uint32_t)(
                                                         PAGE_SIZE / elementSize)},
-      logger{LoggerUtils::getOrCreateSpdLogger("storage")}, fileHandle{fName, O_RDWR},
+      logger{LoggerUtils::getOrCreateSpdLogger("storage")}, fileHandle{fName, O_RDWR, isInMemory},
       bufferManager(bufferManager){};
 
 void DataStructure::reclaim(PageHandle& pageHandle) {

--- a/src/storage/graph.cpp
+++ b/src/storage/graph.cpp
@@ -66,13 +66,15 @@ uint64_t SerDeser::deserializeVector<vector<vector<uint64_t>>>(
 namespace graphflow {
 namespace storage {
 
-Graph::Graph(const string& path, BufferManager& bufferManager)
+Graph::Graph(const string& path, BufferManager& bufferManager, bool isInMemoryMode)
     : logger{LoggerUtils::getOrCreateSpdLogger("storage")}, path{path} {
     logger->info("Initializing Graph.");
     catalog = make_unique<Catalog>(path);
     readFromFile(path);
-    nodesStore = make_unique<NodesStore>(*catalog, numNodesPerLabel, path, bufferManager);
-    relsStore = make_unique<RelsStore>(*catalog, numNodesPerLabel, path, bufferManager);
+    nodesStore =
+        make_unique<NodesStore>(*catalog, numNodesPerLabel, path, bufferManager, isInMemoryMode);
+    relsStore =
+        make_unique<RelsStore>(*catalog, numNodesPerLabel, path, bufferManager, isInMemoryMode);
     logger->info("Done.");
 }
 

--- a/src/storage/include/catalog.h
+++ b/src/storage/include/catalog.h
@@ -113,7 +113,7 @@ public:
     // (containNodeProperty and containRelProperty).
     virtual const PropertyDefinition& getNodeProperty(
         label_t labelId, const string& propertyName) const;
-    virtual const string getNodePropertyAsString(label_t labelId, const uint32_t propertyID) const;
+    virtual string getNodePropertyAsString(label_t labelId, uint32_t propertyID) const;
     virtual const PropertyDefinition& getRelProperty(
         label_t labelId, const string& propertyName) const;
     const unordered_set<label_t>& getNodeLabelsForRelLabelDirection(

--- a/src/storage/include/data_structure/column.h
+++ b/src/storage/include/data_structure/column.h
@@ -21,8 +21,8 @@ public:
 
 protected:
     BaseColumn(const string& fName, const DataType& dataType, const size_t& elementSize,
-        const uint64_t& numElements, BufferManager& bufferManager)
-        : DataStructure{fName, dataType, elementSize, bufferManager} {};
+        const uint64_t& numElements, BufferManager& bufferManager, bool isInMemory)
+        : DataStructure{fName, dataType, elementSize, bufferManager, isInMemory} {};
 
     void readFromNonSequentialLocations(const shared_ptr<NodeIDVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, const unique_ptr<PageHandle>& pageHandle,
@@ -36,17 +36,20 @@ template<DataType D>
 class Column : public BaseColumn {
 
 public:
-    Column(const string& fName, const uint64_t& numElements, BufferManager& bufferManager)
-        : BaseColumn{fName, D, TypeUtils::getDataTypeSize(D), numElements, bufferManager} {};
+    Column(const string& fName, const uint64_t& numElements, BufferManager& bufferManager,
+        bool isInMemory)
+        : BaseColumn{
+              fName, D, TypeUtils::getDataTypeSize(D), numElements, bufferManager, isInMemory} {};
 };
 
 template<>
 class Column<STRING> : public BaseColumn {
 
 public:
-    Column(const string& fName, const uint64_t& numElements, BufferManager& bufferManager)
-        : BaseColumn{fName, STRING, sizeof(gf_string_t), numElements, bufferManager},
-          stringOverflowPages{fName, bufferManager} {};
+    Column(const string& fName, const uint64_t& numElements, BufferManager& bufferManager,
+        bool isInMemory)
+        : BaseColumn{fName, STRING, sizeof(gf_string_t), numElements, bufferManager, isInMemory},
+          stringOverflowPages{fName, bufferManager, isInMemory} {};
 
     void readValues(const shared_ptr<NodeIDVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, const unique_ptr<PageHandle>& pageHandle,
@@ -61,9 +64,9 @@ class Column<NODE> : public BaseColumn {
 
 public:
     Column(const string& fName, const uint64_t& numElements, BufferManager& bufferManager,
-        const NodeIDCompressionScheme& nodeIDCompressionScheme)
+        const NodeIDCompressionScheme& nodeIDCompressionScheme, bool isInMemory)
         : BaseColumn{fName, NODE, nodeIDCompressionScheme.getNumTotalBytes(), numElements,
-              bufferManager},
+              bufferManager, isInMemory},
           nodeIDCompressionScheme(nodeIDCompressionScheme){};
 
     NodeIDCompressionScheme getCompressionScheme() const { return nodeIDCompressionScheme; }

--- a/src/storage/include/data_structure/data_structure.h
+++ b/src/storage/include/data_structure/data_structure.h
@@ -40,7 +40,7 @@ public:
 
 protected:
     DataStructure(const string& fName, const DataType& dataType, const size_t& elementSize,
-        BufferManager& bufferManager);
+        BufferManager& bufferManager, bool isInMemory);
 
     virtual ~DataStructure() = default;
 

--- a/src/storage/include/data_structure/string_overflow_pages.h
+++ b/src/storage/include/data_structure/string_overflow_pages.h
@@ -15,8 +15,9 @@ namespace storage {
 class StringOverflowPages {
 
 public:
-    explicit StringOverflowPages(const string& fName, BufferManager& bufferManager)
-        : fileHandle{getStringOverflowPagesFName(fName), O_RDWR}, bufferManager{bufferManager} {}
+    explicit StringOverflowPages(const string& fname, BufferManager& bufferManager, bool isInMemory)
+        : fileHandle{getStringOverflowPagesFName(fname), O_RDWR, isInMemory}, bufferManager{
+                                                                                  bufferManager} {}
 
     static string getStringOverflowPagesFName(const string& fName) {
         return fName + OVERFLOW_FILE_SUFFIX;

--- a/src/storage/include/file_handle.h
+++ b/src/storage/include/file_handle.h
@@ -22,7 +22,7 @@ class FileHandle {
     friend class BufferManager;
 
 public:
-    explicit FileHandle(const string& path, int flags);
+    explicit FileHandle(const string& path, int flags, bool isInMemory);
     ~FileHandle();
 
     bool inline hasPage(uint64_t pageIdx) const { return pageIdx < numPages; }
@@ -50,8 +50,10 @@ public:
 private:
     shared_ptr<spdlog::logger> logger;
     const int fileDescriptor;
+    bool isInMemory;
     unique_ptr<atomic<uint64_t>>* pageIdxToFrameMap;
     unique_ptr<atomic_flag>* pageLocks;
+    unique_ptr<uint8_t[]> buffer;
 };
 
 } // namespace storage

--- a/src/storage/include/graph.h
+++ b/src/storage/include/graph.h
@@ -26,7 +26,7 @@ class Graph {
     friend class graphflow::loader::RelsLoader;
 
 public:
-    Graph(const string& path, BufferManager& bufferManager);
+    Graph(const string& path, BufferManager& bufferManager, bool isInMemoryMode);
 
     virtual ~Graph();
 

--- a/src/storage/include/store/nodes_store.h
+++ b/src/storage/include/store/nodes_store.h
@@ -17,7 +17,7 @@ class NodesStore {
 
 public:
     NodesStore(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
-        const string& directory, BufferManager& bufferManager);
+        const string& directory, BufferManager& bufferManager, bool isInMemoryMode);
 
     BaseColumn* getNodePropertyColumn(const label_t& label, const uint64_t& propertyIdx) const {
         return propertyColumns[label][propertyIdx].get();
@@ -42,7 +42,7 @@ public:
 private:
     void initStructuredPropertyColumnsAndUnstructuredPropertyLists(const Catalog& catalog,
         const vector<uint64_t>& numNodesPerLabel, const string& directory,
-        BufferManager& bufferManager);
+        BufferManager& bufferManager, bool isInMemoryMode);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/include/store/rels_store.h
+++ b/src/storage/include/store/rels_store.h
@@ -17,7 +17,7 @@ class RelsStore {
 
 public:
     RelsStore(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
-        const string& directory, BufferManager& bufferManager);
+        const string& directory, BufferManager& bufferManager, bool isInMemoryMode);
 
     inline BaseColumn* getRelPropertyColumn(
         const label_t& relLabel, const label_t& nodeLabel, const uint64_t& propertyIdx) const {
@@ -67,22 +67,23 @@ public:
 
 private:
     void initAdjColumns(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
-        const string& directory, BufferManager& bufferManager);
+        const string& directory, BufferManager& bufferManager, bool isInMemoryMode);
 
     void initAdjLists(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
-        const string& directory, BufferManager& bufferManager);
+        const string& directory, BufferManager& bufferManager, bool isInMemoryMode);
 
     void initPropertyListsAndColumns(const Catalog& catalog,
         const vector<uint64_t>& numNodesPerLabel, const string& directory,
-        BufferManager& bufferManager);
+        BufferManager& bufferManager, bool isInMemoryMode);
 
     void initPropertyColumnsForRelLabel(const Catalog& catalog,
         const vector<uint64_t>& numNodesPerLabel, const string& directory,
-        BufferManager& bufferManager, const label_t& relLabel, const Direction& direction);
+        BufferManager& bufferManager, const label_t& relLabel, const Direction& direction,
+        bool isInMemoryMode);
 
     void initPropertyListsForRelLabel(const Catalog& catalog,
         const vector<uint64_t>& numNodesPerLabel, const string& directory,
-        BufferManager& bufferManager, const label_t& relLabel);
+        BufferManager& bufferManager, const label_t& relLabel, bool isInMemoryMode);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -37,7 +37,7 @@ void HashIndex::initialize(const string& indexBasePath, uint64_t indexId) {
         flags |= O_CREAT;
         isIndexFileExist = false;
     }
-    fileHandle = make_unique<FileHandle>(filePath, flags);
+    fileHandle = make_unique<FileHandle>(filePath, flags, false /* isInMemory */);
     // Cache the first page of primary index file
     getMemoryBlock(0);
     if (isIndexFileExist) {

--- a/src/storage/index/overflow_pages_manager.cpp
+++ b/src/storage/index/overflow_pages_manager.cpp
@@ -13,7 +13,7 @@ OverflowPagesManager::OverflowPagesManager(const string& indexPath, MemoryManage
         flags |= O_CREAT;
         isIndexFileExist = false;
     }
-    fileHandle = make_unique<FileHandle>(filePath, flags);
+    fileHandle = make_unique<FileHandle>(filePath, flags, false /* isInMemory */);
     // Cache the first page of overflow index file
     getMemoryBlock(0);
     if (isIndexFileExist) {

--- a/src/storage/store/nodes_store.cpp
+++ b/src/storage/store/nodes_store.cpp
@@ -4,17 +4,17 @@ namespace graphflow {
 namespace storage {
 
 NodesStore::NodesStore(const Catalog& catalog, const vector<uint64_t>& numNodesPerLabel,
-    const string& directory, BufferManager& bufferManager)
+    const string& directory, BufferManager& bufferManager, bool isInMemoryMode)
     : logger{LoggerUtils::getOrCreateSpdLogger("storage")} {
     logger->info("Initializing NodesStore.");
     initStructuredPropertyColumnsAndUnstructuredPropertyLists(
-        catalog, numNodesPerLabel, directory, bufferManager);
+        catalog, numNodesPerLabel, directory, bufferManager, isInMemoryMode);
     logger->info("Done NodesStore.");
 }
 
 void NodesStore::initStructuredPropertyColumnsAndUnstructuredPropertyLists(const Catalog& catalog,
-    const vector<uint64_t>& numNodesPerLabel, const string& directory,
-    BufferManager& bufferManager) {
+    const vector<uint64_t>& numNodesPerLabel, const string& directory, BufferManager& bufferManager,
+    bool isInMemoryMode) {
     auto numNodeLabels = catalog.getNodeLabelsCount();
     propertyColumns.resize(numNodeLabels);
     unstrPropertyLists.resize(numNodeLabels);
@@ -29,27 +29,28 @@ void NodesStore::initStructuredPropertyColumnsAndUnstructuredPropertyLists(const
             switch (property.dataType) {
             case INT64:
                 propertyColumns[nodeLabel][propertyId] = make_unique<PropertyColumnInt64>(
-                    fName, numNodesPerLabel[nodeLabel], bufferManager);
+                    fName, numNodesPerLabel[nodeLabel], bufferManager, isInMemoryMode);
                 break;
             case DOUBLE:
                 propertyColumns[nodeLabel][propertyId] = make_unique<PropertyColumnDouble>(
-                    fName, numNodesPerLabel[nodeLabel], bufferManager);
+                    fName, numNodesPerLabel[nodeLabel], bufferManager, isInMemoryMode);
                 break;
             case BOOL:
                 propertyColumns[nodeLabel][propertyId] = make_unique<PropertyColumnBool>(
-                    fName, numNodesPerLabel[nodeLabel], bufferManager);
+                    fName, numNodesPerLabel[nodeLabel], bufferManager, isInMemoryMode);
                 break;
             case STRING:
                 propertyColumns[nodeLabel][propertyId] = make_unique<PropertyColumnString>(
-                    fName, numNodesPerLabel[nodeLabel], bufferManager);
+                    fName, numNodesPerLabel[nodeLabel], bufferManager, isInMemoryMode);
                 break;
             case UNSTRUCTURED:
                 unstrPropertyLists[nodeLabel] = make_unique<UnstructuredPropertyLists>(
-                    getNodeUnstrPropertyListsFName(directory, nodeLabel), bufferManager);
+                    getNodeUnstrPropertyListsFName(directory, nodeLabel), bufferManager,
+                    isInMemoryMode);
                 break;
             case DATE:
                 propertyColumns[nodeLabel][propertyId] = make_unique<PropertyColumnDate>(
-                    fName, numNodesPerLabel[nodeLabel], bufferManager);
+                    fName, numNodesPerLabel[nodeLabel], bufferManager, isInMemoryMode);
                 break;
             default:
                 throw invalid_argument("invalid type for property column and lists creation.");

--- a/test/storage/hash_index_test.cpp
+++ b/test/storage/hash_index_test.cpp
@@ -19,7 +19,8 @@ public:
         graphflow::testing::TestHelper::createDirOrError(TEMP_INDEX);
         LoggerUtils::getOrCreateSpdLogger("storage");
         auto insertionMemoryManager = make_unique<MemoryManager>();
-        auto insertionBufferManager = make_unique<BufferManager>(DEFAULT_BUFFER_POOL_SIZE);
+        auto insertionBufferManager =
+            make_unique<BufferManager>(StorageConfig::DEFAULT_BUFFER_POOL_SIZE);
         OverflowPagesManager ovfPagesManager(TEMP_INDEX, *insertionMemoryManager);
         HashIndex insertionHashIndex(TEMP_INDEX, 0, *insertionMemoryManager,
             *insertionBufferManager, ovfPagesManager, INT64);
@@ -56,7 +57,7 @@ public:
 
 TEST_F(HashIndexTest, HashIndexInsertExists) {
     auto memoryManager = make_unique<MemoryManager>();
-    auto bufferManager = make_unique<BufferManager>(DEFAULT_BUFFER_POOL_SIZE);
+    auto bufferManager = make_unique<BufferManager>(StorageConfig::DEFAULT_BUFFER_POOL_SIZE);
     OverflowPagesManager ovfPagesManager(TEMP_INDEX, *memoryManager);
     HashIndex hashIndex(TEMP_INDEX, 0, *memoryManager, *bufferManager, ovfPagesManager, INT64);
     auto numEntries = 10;
@@ -81,7 +82,7 @@ TEST_F(HashIndexTest, HashIndexInsertExists) {
 
 TEST_F(HashIndexTest, HashIndexSmallLookup) {
     auto memoryManager = make_unique<MemoryManager>();
-    auto bufferManager = make_unique<BufferManager>(DEFAULT_BUFFER_POOL_SIZE);
+    auto bufferManager = make_unique<BufferManager>(StorageConfig::DEFAULT_BUFFER_POOL_SIZE);
     OverflowPagesManager ovfPagesManager(TEMP_INDEX, *memoryManager);
     HashIndex hashIndex(TEMP_INDEX, 0, *memoryManager, *bufferManager, ovfPagesManager, INT64);
     auto numEntries = 10;
@@ -104,7 +105,7 @@ TEST_F(HashIndexTest, HashIndexSmallLookup) {
 
 TEST_F(HashIndexTest, HashIndexRandomLookup) {
     auto memoryManager = make_unique<MemoryManager>();
-    auto bufferManager = make_unique<BufferManager>(DEFAULT_BUFFER_POOL_SIZE);
+    auto bufferManager = make_unique<BufferManager>(StorageConfig::DEFAULT_BUFFER_POOL_SIZE);
     OverflowPagesManager ovfPagesManager(TEMP_INDEX, *memoryManager);
     HashIndex hashIndex(TEMP_INDEX, 0, *memoryManager, *bufferManager, ovfPagesManager, INT64);
     auto numEntries = 1000;

--- a/test/test_utility/include/test_helper.h
+++ b/test/test_utility/include/test_helper.h
@@ -18,7 +18,6 @@ struct TestSuiteSystemConfig {
     string graphInputDir;
     string graphOutputDir;
     uint64_t maxNumThreads = 1;
-    uint64_t bufferPoolSize = DEFAULT_BUFFER_POOL_SIZE;
 };
 
 struct TestSuiteQueryConfig {

--- a/test/test_utility/test_helper.cpp
+++ b/test/test_utility/test_helper.cpp
@@ -128,7 +128,7 @@ void TestHelper::loadGraph(TestSuiteSystemConfig& config) {
 
 unique_ptr<System> TestHelper::getInitializedSystem(TestSuiteSystemConfig& config) {
     loadGraph(config);
-    return make_unique<System>(config.graphOutputDir);
+    return make_unique<System>(config.graphOutputDir, false /* isInMemoryMode */);
 }
 
 void TestHelper::createDirOrError(const string& dir) {

--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -11,7 +11,7 @@ const string BENCHMARK_SUFFIX = ".benchmark";
 
 BenchmarkRunner::BenchmarkRunner(const string& datasetPath, unique_ptr<BenchmarkConfig> config)
     : config{move(config)} {
-    system = make_unique<System>(datasetPath);
+    system = make_unique<System>(datasetPath, this->config->isInMemoryMode);
 }
 
 void BenchmarkRunner::registerBenchmarks(const string& path) {

--- a/tools/benchmark/include/benchmark_config.h
+++ b/tools/benchmark/include/benchmark_config.h
@@ -20,6 +20,8 @@ struct BenchmarkConfig {
     uint32_t numThreads = 1;
     // output benchmark log to file
     string outputPath;
+    // in-memory mode
+    bool isInMemoryMode = false;
 };
 
 } // namespace benchmark

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -31,6 +31,8 @@ int main(int argc, char** argv) {
             config->numThreads = stoul(getArgumentValue(arg));
         } else if (arg.starts_with("--out")) { // save benchmark result to file
             config->outputPath = getArgumentValue(arg);
+        } else if (arg.starts_with("--in-memory")) {
+            config->isInMemoryMode = true;
         } else if (arg.starts_with("--profile")) {
             config->enableProfile = true;
         } else {

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -4,12 +4,22 @@
 using namespace std;
 
 int main(int argc, char* argv[]) {
-    if (argc != 2) {
-        fprintf(stderr, "Usage: %s [path to serialized dataset].\n", argv[0]);
+    if (argc <= 1 || argc >= 4) {
+        fprintf(stderr, "Usage: %s <path to serialized dataset> [:IN-MEMORY].\n", argv[0]);
         exit(1);
     }
     auto serializedGraphPath = argv[1];
-    auto system = System(serializedGraphPath);
+    bool isInMemoryMode = false;
+    if (argc == 3) {
+        string storageMode = argv[2];
+        if (storageMode == ":IN-MEMORY") {
+            isInMemoryMode = true;
+        } else {
+            fprintf(stderr, "Usage: %s <path to serialized dataset> [:IN-MEMORY].\n", argv[0]);
+            exit(1);
+        }
+    }
+    auto system = System(serializedGraphPath, isInMemoryMode);
     auto shell = EmbeddedShell(system);
     shell.initialize();
     shell.run();


### PR DESCRIPTION
This PR adds a configuration in the `configs.h` that can set the database storage to fully in-memory mode.
When the storage mode is set to in-memory only, the buffer manager will hold 0 pages, and each file handler will automatically cache all the content the file during system startup.

In the shell, the user can start the system with in-memory mode by specifying ":IN-MEMORY" as a param.
for example, `./graphflowdb path-to-serialize-dataset :IN-MEMORY`

**Notice**: this should only be used for testing now, for that there is no memory usage checks, so the system might crash due to failing of memory allocation.

One idea can be further done to remove the bool propogation if possible: use buffer manager's numFrames for the purpose, since we always set buffer manager to 0 pages if it's in-memory only.