### PR TITLE
reading large files in pieces

### DIFF
--- a/src/common/include/file_utils.h
+++ b/src/common/include/file_utils.h
@@ -17,6 +17,7 @@ public:
     static int openFile(const string& path, int flags);
     static void closeFile(int fd);
 
+    static unique_ptr<uint8_t[]> readFile(int fd);
     static void readFromFile(int fd, void* buffer, int64_t numBytes, uint64_t position);
     static void writeToFile(int fd, void* buffer, int64_t numBytes, uint64_t offset);
 

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -20,8 +20,7 @@ FileHandle::FileHandle(const string& path, int flags, bool isInMemory)
     }
     if (isInMemory) {
         logger->trace("FileHandle[in-memory]: Size {}B", fileLength);
-        buffer = make_unique<uint8_t[]>(fileLength);
-        FileUtils::readFromFile(fileDescriptor, buffer.get(), fileLength, 0);
+        buffer = FileUtils::readFile(fileDescriptor);
     } else {
         logger->trace("FileHandle[disk]: Size {}B, #4KB-pages {}", fileLength, numPages);
         pageIdxToFrameMap = new unique_ptr<atomic<uint64_t>>[numPages];


### PR DESCRIPTION
The pread system call fails if we try to read a very large file directly into a buffer, e.g., ~3GB, which makes the system crash when trying to run the system in memory on LDBC100. This PR adds a new function to FileUtils to read a large file through multiple pread calls.