### PR TITLE
fix the heap-use-after-free bug in enumerator

### DIFF
--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -36,7 +36,7 @@ public:
 
     void appendToGroup(const string& variable, uint32_t pos);
 
-    void appendToGroup(FactorizationGroup& otherGroup, uint32_t pos);
+    void appendToGroup(const FactorizationGroup& otherGroup, uint32_t pos);
 
     uint32_t getGroupPos(const string& variable);
 
@@ -51,7 +51,7 @@ public:
     unique_ptr<Schema> copy();
 
 public:
-    vector<FactorizationGroup> groups;
+    vector<unique_ptr<FactorizationGroup>> groups;
     // Maps a queryRel to the LogicalExtend that matches it. This is needed because ScanRelProperty
     // requires direction information which only available in the LogicalExtend.
     unordered_map<string, LogicalExtend*> queryRelLogicalExtendMap;

--- a/src/planner/logical_plan/schema.cpp
+++ b/src/planner/logical_plan/schema.cpp
@@ -7,23 +7,23 @@ namespace planner {
 
 uint32_t Schema::createGroup() {
     auto pos = groups.size();
-    groups.emplace_back(FactorizationGroup());
+    groups.push_back(make_unique<FactorizationGroup>());
     return pos;
 }
 
 void Schema::appendToGroup(const string& variable, uint32_t pos) {
     variableToGroupPos.insert({variable, pos});
-    groups[pos].appendVariable(variable);
+    groups[pos]->appendVariable(variable);
 }
 
-void Schema::appendToGroup(FactorizationGroup& otherGroup, uint32_t pos) {
+void Schema::appendToGroup(const FactorizationGroup& otherGroup, uint32_t pos) {
     for (auto& variable : otherGroup.variables) {
         appendToGroup(variable, pos);
     }
 }
 
 void Schema::flattenGroup(uint32_t pos) {
-    groups[pos].isFlat = true;
+    groups[pos]->isFlat = true;
 }
 
 uint32_t Schema::getGroupPos(const string& variable) {
@@ -44,7 +44,10 @@ unique_ptr<Schema> Schema::copy() {
     auto newSchema = make_unique<Schema>();
     newSchema->queryRelLogicalExtendMap = queryRelLogicalExtendMap;
     newSchema->variableToGroupPos = variableToGroupPos;
-    newSchema->groups = groups;
+    for (auto& group : groups) {
+        auto newGroup = make_unique<FactorizationGroup>(*group);
+        newSchema->groups.push_back(move(newGroup));
+    }
     return newSchema;
 }
 

--- a/src/processor/physical_plan/operator/physical_operator_info.cpp
+++ b/src/processor/physical_plan/operator/physical_operator_info.cpp
@@ -7,7 +7,7 @@ PhysicalOperatorsInfo::PhysicalOperatorsInfo(const Schema& schema) {
     auto dataChunkPos = 0ul;
     for (auto& group : schema.groups) {
         auto vectorPos = 0ul;
-        for (auto& variable : group.variables) {
+        for (auto& variable : group->variables) {
             variableToDataPosMap.insert({variable, make_pair(dataChunkPos, vectorPos)});
             vectorPos++;
         }

--- a/src/processor/physical_plan/plan_mapper.cpp
+++ b/src/processor/physical_plan/plan_mapper.cpp
@@ -222,7 +222,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
     auto buildSideKeyVectorPos = buildSideInfo.getValueVectorPos(hashJoin.joinNodeID);
     vector<bool> dataChunkPosToIsFlat;
     for (auto& buildSideGroup : hashJoin.buildSideSchema->groups) {
-        dataChunkPosToIsFlat.push_back(buildSideGroup.isFlat);
+        dataChunkPosToIsFlat.push_back(buildSideGroup->isFlat);
     }
     auto hashJoinBuild = make_unique<HashJoinBuild>(buildSideKeyDataChunkPos, buildSideKeyVectorPos,
         dataChunkPosToIsFlat, move(buildSidePrevOperator), context, physicalOperatorID++);


### PR DESCRIPTION
This bug is due to the invalid reference to the groups vector. we took a reference to one of the values in the vector, but then groups is updated and resized so the reference is invalid in later usage.