### PR TITLE
Cyclic query support

### DIFF
--- a/src/binder/include/expression/node_expression.h
+++ b/src/binder/include/expression/node_expression.h
@@ -10,8 +10,8 @@ const string INTERNAL_ID_SUFFIX = "_id";
 class NodeExpression : public VariableExpression {
 
 public:
-    NodeExpression(const string& nodeName, uint32_t id, label_t label)
-        : VariableExpression{VARIABLE, NODE, nodeName, id}, label{label} {}
+    NodeExpression(const string& uniqueName, label_t label)
+        : VariableExpression{VARIABLE, NODE, uniqueName}, label{label} {}
 
     inline string getIDProperty() const { return uniqueName + "." + INTERNAL_ID_SUFFIX; }
 

--- a/src/binder/include/expression/rel_expression.h
+++ b/src/binder/include/expression/rel_expression.h
@@ -8,10 +8,10 @@ namespace binder {
 class RelExpression : public VariableExpression {
 
 public:
-    RelExpression(const string& relName, uint32_t id, label_t label, NodeExpression* srcNode,
-        NodeExpression* dstNode, uint64_t lowerBound, uint64_t upperBound)
-        : VariableExpression{VARIABLE, REL, relName, id}, label{label}, srcNode{srcNode},
-          dstNode{dstNode}, lowerBound{lowerBound}, upperBound{upperBound} {}
+    RelExpression(const string& uniqueName, label_t label, shared_ptr<NodeExpression> srcNode,
+        shared_ptr<NodeExpression> dstNode, uint64_t lowerBound, uint64_t upperBound)
+        : VariableExpression{VARIABLE, REL, uniqueName}, label{label}, srcNode{move(srcNode)},
+          dstNode{move(dstNode)}, lowerBound{lowerBound}, upperBound{upperBound} {}
 
     inline string getSrcNodeName() const { return srcNode->getInternalName(); }
 
@@ -19,8 +19,8 @@ public:
 
 public:
     label_t label;
-    NodeExpression* srcNode;
-    NodeExpression* dstNode;
+    shared_ptr<NodeExpression> srcNode;
+    shared_ptr<NodeExpression> dstNode;
     uint64_t lowerBound;
     uint64_t upperBound;
 };

--- a/src/binder/include/expression/variable_expression.h
+++ b/src/binder/include/expression/variable_expression.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "src/binder/include/expression/expression.h"
 
 namespace graphflow {
@@ -12,18 +14,10 @@ namespace binder {
 class VariableExpression : public Expression {
 
 public:
-    VariableExpression(
-        ExpressionType expressionType, DataType dataType, const string& name, uint32_t id)
-        : Expression{expressionType, dataType} {
-        makeUniqueName(name, id);
-    }
+    VariableExpression(ExpressionType expressionType, DataType dataType, string uniqueName)
+        : Expression{expressionType, dataType}, uniqueName{move(uniqueName)} {}
 
     string getInternalName() const override { return uniqueName; }
-
-private:
-    void makeUniqueName(const string& name, uint32_t id) {
-        uniqueName = "_" + to_string(id) + "_" + name;
-    }
 
 protected:
     string uniqueName;

--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -52,8 +52,8 @@ private:
 
     unique_ptr<QueryGraph> bindQueryGraph(const vector<unique_ptr<PatternElement>>& graphPattern);
 
-    void bindQueryRel(const RelPattern& relPattern, NodeExpression* leftNode,
-        NodeExpression* rightNode, QueryGraph& queryGraph);
+    void bindQueryRel(const RelPattern& relPattern, const shared_ptr<NodeExpression>& leftNode,
+        const shared_ptr<NodeExpression>& rightNode, QueryGraph& queryGraph);
 
     shared_ptr<NodeExpression> bindQueryNode(
         const NodePattern& nodePattern, QueryGraph& queryGraph);

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -30,15 +30,17 @@ private:
     void enumerateReadingStatement(BoundReadingStatement& readingStatement);
     void enumerateLoadCSVStatement(const BoundLoadCSVStatement& loadCSVStatement);
     void updateQueryGraph(QueryGraph& queryGraph);
-    void enumerateSubplans(const vector<shared_ptr<Expression>>& whereClause);
-    void enumerateSingleQueryNode(const vector<shared_ptr<Expression>>& whereClause);
-    void enumerateNextLevel(const vector<shared_ptr<Expression>>& whereClauseSplitOnAND);
-    void enumerateHashJoin(const vector<shared_ptr<Expression>>& whereClauseSplitOnAND);
-    void enumerateExtend(const vector<shared_ptr<Expression>>& whereClauseSplitOnAND);
+    void enumerateSubplans(const vector<shared_ptr<Expression>>& whereExpressions);
+    void enumerateSingleQueryNode(const vector<shared_ptr<Expression>>& whereExpressions);
+    void enumerateNextLevel(const vector<shared_ptr<Expression>>& whereExpressions);
+    void enumerateHashJoin(const vector<shared_ptr<Expression>>& whereExpressions);
+    void enumerateExtend(const vector<shared_ptr<Expression>>& whereExpressions);
 
     void appendLoadCSV(const BoundLoadCSVStatement& loadCSVStatement, LogicalPlan& plan);
     void appendScan(uint32_t queryNodePos, LogicalPlan& plan);
-    void appendExtend(uint32_t queryRelPos, Direction direction, LogicalPlan& plan);
+    void appendExtendAndNecessaryFilters(const RelExpression& queryRel, Direction direction,
+        const vector<shared_ptr<Expression>>& expressionsToFilter, LogicalPlan& plan);
+    void appendExtend(const RelExpression& queryRel, Direction direction, LogicalPlan& plan);
     string appendNecessaryFlattens(const Expression& expression,
         const unordered_map<uint32_t, string>& unFlatGroupsPos, LogicalPlan& plan);
     void appendFlatten(const string& variable, LogicalPlan& plan);

--- a/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
@@ -9,14 +9,18 @@ class AdjListExtend : public ReadList {
 
 public:
     AdjListExtend(uint64_t inDataChunkPos, uint64_t inValueVectorPos, AdjLists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+        label_t outNodeIDVectorLabel, unique_ptr<PhysicalOperator> prevOperator,
+        ExecutionContext& context, uint32_t id);
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<AdjListExtend>(
-            inDataChunkPos, inValueVectorPos, (AdjLists*)lists, prevOperator->clone(), context, id);
+        return make_unique<AdjListExtend>(inDataChunkPos, inValueVectorPos, (AdjLists*)lists,
+            outNodeIDVectorLabel, prevOperator->clone(), context, id);
     }
+
+private:
+    label_t outNodeIDVectorLabel;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
@@ -10,8 +10,8 @@ class FrontierExtend : public ReadList {
 
 public:
     FrontierExtend(uint64_t inDataChunkPos, uint64_t inValueVectorPos, AdjLists* lists,
-        uint64_t lowerBound, uint64_t upperBound, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+        label_t outNodeIDVectorLabel, uint64_t lowerBound, uint64_t upperBound,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
 
     void getNextTuples() override;
 
@@ -48,6 +48,8 @@ private:
             blockIdx = slot = 0u;
         }
     } currOutputPos;
+
+    label_t outNodeIDVectorLabel;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
@@ -10,14 +10,18 @@ class AdjColumnExtend : public ScanColumn, public FilteringOperator {
 
 public:
     AdjColumnExtend(uint64_t dataChunkPos, uint64_t valueVectorPos, BaseColumn* column,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+        label_t outNodeIDVectorLabel, unique_ptr<PhysicalOperator> prevOperator,
+        ExecutionContext& context, uint32_t id);
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<AdjColumnExtend>(
-            dataChunkPos, valueVectorPos, column, prevOperator->clone(), context, id);
+        return make_unique<AdjColumnExtend>(dataChunkPos, valueVectorPos, column,
+            outNodeIDVectorLabel, prevOperator->clone(), context, id);
     }
+
+private:
+    label_t outNodeIDVectorLabel;
 };
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -4,9 +4,12 @@ namespace graphflow {
 namespace processor {
 
 AdjListExtend::AdjListExtend(uint64_t inDataChunkPos, uint64_t inValueVectorPos, AdjLists* lists,
-    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-    : ReadList{inDataChunkPos, inValueVectorPos, lists, move(prevOperator), context, id} {
-    outValueVector = make_shared<NodeIDVector>(0, lists->getNodeIDCompressionScheme(), false);
+    label_t outNodeIDVectorLabel, unique_ptr<PhysicalOperator> prevOperator,
+    ExecutionContext& context, uint32_t id)
+    : ReadList{inDataChunkPos, inValueVectorPos, lists, move(prevOperator), context, id},
+      outNodeIDVectorLabel{outNodeIDVectorLabel} {
+    outValueVector =
+        make_shared<NodeIDVector>(outNodeIDVectorLabel, lists->getNodeIDCompressionScheme(), false);
     outDataChunk = make_shared<DataChunk>();
     outDataChunk->append(outValueVector);
     auto listSyncState = make_shared<ListSyncState>();

--- a/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
@@ -8,12 +8,13 @@ namespace processor {
 static uint64_t getNextPowerOfTwo(uint64_t value);
 
 FrontierExtend::FrontierExtend(uint64_t inDataChunkPos, uint64_t inValueVectorPos, AdjLists* lists,
-    uint64_t lowerBound, uint64_t upperBound, unique_ptr<PhysicalOperator> prevOperator,
-    ExecutionContext& context, uint32_t id)
+    label_t outNodeIDVectorLabel, uint64_t lowerBound, uint64_t upperBound,
+    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
     : ReadList{inDataChunkPos, inValueVectorPos, lists, move(prevOperator), context, id},
-      startLayer{lowerBound}, endLayer{upperBound} {
+      startLayer{lowerBound}, endLayer{upperBound}, outNodeIDVectorLabel{outNodeIDVectorLabel} {
     operatorType = FRONTIER_EXTEND;
-    outValueVector = make_shared<NodeIDVector>(0, NodeIDCompressionScheme(), false);
+    outValueVector =
+        make_shared<NodeIDVector>(outNodeIDVectorLabel, NodeIDCompressionScheme(), false);
     outDataChunk = make_shared<DataChunk>();
     outDataChunk->append(outValueVector);
     outValueVector->state->initMultiplicity();
@@ -229,7 +230,7 @@ FrontierBag* FrontierExtend::createFrontierBag() {
 
 unique_ptr<PhysicalOperator> FrontierExtend::clone() {
     auto cloneOp = make_unique<FrontierExtend>(inDataChunkPos, inValueVectorPos, (AdjLists*)lists,
-        startLayer, endLayer, prevOperator->clone(), context, id);
+        outNodeIDVectorLabel, startLayer, endLayer, prevOperator->clone(), context, id);
     return cloneOp;
 }
 

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -4,11 +4,12 @@ namespace graphflow {
 namespace processor {
 
 AdjColumnExtend::AdjColumnExtend(uint64_t dataChunkPos, uint64_t valueVectorPos, BaseColumn* column,
-    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+    label_t outNodeIDVectorLabel, unique_ptr<PhysicalOperator> prevOperator,
+    ExecutionContext& context, uint32_t id)
     : ScanColumn{dataChunkPos, valueVectorPos, column, move(prevOperator), context, id},
-      FilteringOperator(this->inDataChunk) {
-    auto outNodeIDVector = make_shared<NodeIDVector>(
-        0, ((AdjColumn*)column)->getCompressionScheme(), false /*inNodeIDVector->isSequence()*/);
+      FilteringOperator(this->inDataChunk), outNodeIDVectorLabel{outNodeIDVectorLabel} {
+    auto outNodeIDVector = make_shared<NodeIDVector>(outNodeIDVectorLabel,
+        ((AdjColumn*)column)->getCompressionScheme(), false /*inNodeIDVector->isSequence()*/);
     outValueVector = static_pointer_cast<ValueVector>(outNodeIDVector);
     inDataChunk->append(outValueVector);
 }

--- a/src/processor/physical_plan/plan_mapper.cpp
+++ b/src/processor/physical_plan/plan_mapper.cpp
@@ -109,17 +109,17 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
         GF_ASSERT(extend.lowerBound == extend.upperBound && extend.lowerBound == 1);
         return make_unique<AdjColumnExtend>(dataChunkPos, valueVectorPos,
             relsStore.getAdjColumn(extend.direction, extend.boundNodeLabel, extend.relLabel),
-            move(prevOperator), context, physicalOperatorID++);
+            extend.nbrNodeLabel, move(prevOperator), context, physicalOperatorID++);
     } else {
         auto adjLists =
             relsStore.getAdjLists(extend.direction, extend.boundNodeLabel, extend.relLabel);
         if (extend.lowerBound == 1 && extend.lowerBound == extend.upperBound) {
             return make_unique<AdjListExtend>(dataChunkPos, valueVectorPos, adjLists,
-                move(prevOperator), context, physicalOperatorID++);
+                extend.nbrNodeLabel, move(prevOperator), context, physicalOperatorID++);
         } else {
             return make_unique<FrontierExtend>(dataChunkPos, valueVectorPos, adjLists,
-                extend.lowerBound, extend.upperBound, move(prevOperator), context,
-                physicalOperatorID++);
+                extend.nbrNodeLabel, extend.lowerBound, extend.upperBound, move(prevOperator),
+                context, physicalOperatorID++);
         }
     }
 }

--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -26,9 +26,9 @@ TEST_F(BinderTest, LOADCSVBasicTest) {
     expectedCSVColumnInfo.emplace_back(make_pair("age", INT64));
     expectedCSVColumnInfo.emplace_back(make_pair("name", STRING));
     auto csvLines = vector<shared_ptr<VariableExpression>>();
-    auto csvLine0 = make_shared<VariableExpression>(CSV_LINE_EXTRACT, INT64, "csvLine[0]", 0);
+    auto csvLine0 = make_shared<VariableExpression>(CSV_LINE_EXTRACT, INT64, "_0_csvLine[0]");
     csvLine0->rawExpression = "csvLine[0]";
-    auto csvLine1 = make_shared<VariableExpression>(CSV_LINE_EXTRACT, STRING, "csvLine[1]", 1);
+    auto csvLine1 = make_shared<VariableExpression>(CSV_LINE_EXTRACT, STRING, "_1_csvLine[1]");
     csvLine1->rawExpression = "csvLine[1]";
     csvLines.push_back(csvLine0);
     csvLines.push_back(csvLine1);
@@ -46,10 +46,10 @@ TEST_F(BinderTest, LOADCSVBasicTest) {
 }
 
 TEST_F(BinderTest, LOADCSVMATCHTest) {
-    auto a = make_shared<NodeExpression>("a", 2, 0);
+    auto a = make_shared<NodeExpression>("_2_a", 0);
     a->rawExpression = "a";
     auto aName = make_shared<PropertyExpression>(STRING, "name", 1, move(a));
-    auto csvLine1 = make_shared<VariableExpression>(CSV_LINE_EXTRACT, STRING, "csvLine[1]", 1);
+    auto csvLine1 = make_shared<VariableExpression>(CSV_LINE_EXTRACT, STRING, "_1_csvLine[1]");
     csvLine1->rawExpression = "csvLine[1]";
     auto expectedWhere = make_shared<Expression>(EQUALS, BOOL, move(aName), move(csvLine1));
     expectedWhere->rawExpression = "a.name = csvLine[1]";

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -9,7 +9,7 @@ using namespace graphflow::processor;
 using namespace graphflow::binder;
 
 TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
-    auto nodeExpression = make_unique<NodeExpression>("a", 0, 0);
+    auto nodeExpression = make_unique<NodeExpression>("_0_a", 0);
     auto propertyExpression =
         make_unique<PropertyExpression>(DataType::INT64, "prop", 0, move(nodeExpression));
     Literal literal = Literal((int64_t)5);
@@ -47,7 +47,7 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
 }
 
 TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
-    auto nodeExpression = make_unique<NodeExpression>("a", 0, 0);
+    auto nodeExpression = make_unique<NodeExpression>("_0_a", 0);
     auto propertyExpression =
         make_shared<PropertyExpression>(DataType::INT64, "prop", 0, move(nodeExpression));
     auto negateLogicalOperator =

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -23,6 +23,7 @@ filegroup(
     name = "testfiles",
     srcs = [
         "queries/data_types/date_data_type.test",
+        "queries/filtered/cyclic.test",
         "queries/filtered/id_comparison.test",
         "queries/filtered/load_csv.test",
         "queries/filtered/multi_query.test",
@@ -32,6 +33,7 @@ filegroup(
         "queries/filtered/str_operations.test",
         "queries/filtered/unstructured_properties.test",
         "queries/projection/projection.test",
+        "queries/structural/cyclic.test",
         "queries/structural/frontier.test",
         "queries/structural/multi_query.test",
         "queries/structural/nodes.test",

--- a/test/runner/end_to_end_test.cpp
+++ b/test/runner/end_to_end_test.cpp
@@ -21,6 +21,8 @@ TEST_F(TinySnbProcessorTest, StructuralQueries) {
     ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
     queryConfig = TestHelper::parseTestFile("test/runner/queries/structural/multi_query.test");
     ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
+    queryConfig = TestHelper::parseTestFile("test/runner/queries/structural/cyclic.test");
+    ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
 }
 
 TEST_F(TinySnbProcessorTest, FilteredQueries) {
@@ -41,6 +43,8 @@ TEST_F(TinySnbProcessorTest, FilteredQueries) {
     queryConfig = TestHelper::parseTestFile("test/runner/queries/filtered/load_csv.test");
     ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
     queryConfig = TestHelper::parseTestFile("test/runner/queries/filtered/multi_query.test");
+    ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
+    queryConfig = TestHelper::parseTestFile("test/runner/queries/filtered/cyclic.test");
     ASSERT_TRUE(TestHelper::runTest(*queryConfig, *defaultSystem));
 }
 

--- a/test/runner/queries/filtered/cyclic.test
+++ b/test/runner/queries/filtered/cyclic.test
@@ -1,0 +1,13 @@
+# description: filter cycles
+
+-NAME TriangleFilterTest
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person), (a)-[e:knows]->(c) WHERE e.date=date('2000-01-01') RETURN COUNT(*)
+---- 4
+
+-NAME TriangleFilterTest2
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:studyAt]->(c:organisation), (a)-[e:studyAt]->(c) WHERE a.fName='Alice' RETURN COUNT(*)
+---- 1
+
+-NAME SquareFilterTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person), (a)-[e2:knows]->(d) WHERE e1.date=e2.date AND e1.date=date('2000-01-01') RETURN COUNT(*)
+---- 6

--- a/test/runner/queries/structural/cyclic.test
+++ b/test/runner/queries/structural/cyclic.test
@@ -1,0 +1,14 @@
+# description: matching cycles
+
+-NAME TriangleTest
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person), (a)-[:knows]->(c) RETURN COUNT(*)
+---- 24
+
+-NAME TriangleTest2
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:studyAt]->(c:organisation), (a)-[:studyAt]->(c) RETURN COUNT(*)
+---- 2
+
+-NAME SquareTest
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person), (a)-[:knows]->(d) RETURN COUNT(*)
+---- 84
+


### PR DESCRIPTION
This PR add supports to cyclic queries and closes issue #140 

Cyclic query is handled as an Extend followed by an ID filter.
E.g. MATCH (a)-[e1]->(b)-[e2]->(c), (a)-[e3]->(c) and a plan that closes cycle on c

We first cover e1 and e2 with plan S(a)->E(e1,b)->E(e2,c). Then we try to close the cycle with e3 on c.
We append another extend E(e3,c). Note that the two outValueVector e2,c and e3,c should have different identifier in order to apply an ID filter later. We prefix the second c with its rel name, so its identifier becomes e3_c. After that we do a filter on c.id=e3_c.id.

The final plan is S(a)->E(e1,b)->E(e2,c)->E(e3,e3_c)->Filter(c.id=e3_c.id)

Minor change
- Fix bug in Extend outValueVector common label (used to hard code to 0)