### PR TITLE
Re-implements nullmask, allowing for fast path execution for no-null cases

### DIFF
--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -54,14 +54,14 @@ struct LessThanEquals {
 
 struct IsNull {
     template<class T>
-    static inline uint8_t operation(const T& value) {
+    static inline bool operation(const T& value) {
         throw std::invalid_argument("Unsupported type for IsNull.");
     }
 };
 
 struct IsNotNull {
     template<class T>
-    static inline uint8_t operation(const T& value) {
+    static inline bool operation(const T& value) {
         throw std::invalid_argument("Unsupported type for IsNotNull.");
     }
 };
@@ -283,23 +283,23 @@ inline uint8_t LessThanEquals::operation(const nodeID_t& left, const nodeID_t& r
  ********************************************/
 
 template<>
-inline uint8_t IsNull::operation(const uint8_t& value) {
-    return value == NULL_BOOL ? TRUE : FALSE;
+inline bool IsNull::operation(const uint8_t& value) {
+    return value == NULL_BOOL;
 };
 
 template<>
-inline uint8_t IsNull::operation(const int64_t& value) {
-    return value == NULL_INT64 ? TRUE : FALSE;
+inline bool IsNull::operation(const int64_t& value) {
+    return value == NULL_INT64;
 };
 
 template<>
-inline uint8_t IsNull::operation(const double_t& value) {
-    return value == NULL_DOUBLE ? TRUE : FALSE;
+inline bool IsNull::operation(const double_t& value) {
+    return value == NULL_DOUBLE;
 };
 
 template<>
-inline uint8_t IsNull::operation(const date_t& value) {
-    return value == NULL_DATE ? TRUE : FALSE;
+inline bool IsNull::operation(const date_t& value) {
+    return value == NULL_DATE;
 };
 
 /***********************************************
@@ -308,18 +308,18 @@ inline uint8_t IsNull::operation(const date_t& value) {
  **                                           **
  ***********************************************/
 template<>
-inline uint8_t IsNotNull::operation(const uint8_t& value) {
-    return value != NULL_BOOL ? TRUE : FALSE;
+inline bool IsNotNull::operation(const uint8_t& value) {
+    return value != NULL_BOOL;
 };
 
 template<>
-inline uint8_t IsNotNull::operation(const int64_t& value) {
-    return value != NULL_INT64 ? TRUE : FALSE;
+inline bool IsNotNull::operation(const int64_t& value) {
+    return value != NULL_INT64;
 };
 
 template<>
-inline uint8_t IsNotNull::operation(const double_t& value) {
-    return value != NULL_DOUBLE ? TRUE : FALSE;
+inline bool IsNotNull::operation(const double_t& value) {
+    return value != NULL_DOUBLE;
 };
 
 } // namespace operation

--- a/src/common/vector/node_vector.cpp
+++ b/src/common/vector/node_vector.cpp
@@ -66,7 +66,7 @@ bool NodeIDVector::discardNulls() {
 shared_ptr<ValueVector> NodeIDVector::clone() {
     auto newVector = make_shared<NodeIDVector>(
         representation.commonLabel, representation.compressionScheme, representation.isSequence);
-    memcpy(newVector->nullMask, nullMask, vectorCapacity);
+    newVector->setNullMask(getNullMask()->clone(vectorCapacity));
     memcpy(newVector->values, values, vectorCapacity * getNumBytesPerValue());
     return newVector;
 }

--- a/src/common/vector/operations/vector_boolean_operations.cpp
+++ b/src/common/vector/operations/vector_boolean_operations.cpp
@@ -22,12 +22,12 @@ void VectorBooleanOperations::Xor(ValueVector& left, ValueVector& right, ValueVe
 void VectorBooleanOperations::Not(ValueVector& operand, ValueVector& result) {
     if (operand.state->isFlat()) {
         auto pos = operand.state->getPositionOfCurrIdx();
-        result.values[pos] = operation::Not::operation(operand.values[pos], operand.nullMask[pos]);
+        result.values[pos] = operation::Not::operation(operand.values[pos], operand.isNull(pos));
     } else {
         for (auto i = 0ul; i < operand.state->size; i++) {
             auto pos = operand.state->selectedPositions[i];
             result.values[pos] =
-                operation::Not::operation(operand.values[pos], operand.nullMask[pos]);
+                operation::Not::operation(operand.values[pos], operand.isNull(pos));
         }
     }
 }

--- a/src/expression_evaluator/unary_expression_evaluator.cpp
+++ b/src/expression_evaluator/unary_expression_evaluator.cpp
@@ -26,7 +26,7 @@ shared_ptr<ValueVector> UnaryExpressionEvaluator::createResultValueVector(
         }
     }
     valueVector->state = childrenExpr[0]->result->state;
-    valueVector->nullMask = childrenExpr[0]->result->nullMask;
+    valueVector->setNullMask(childrenExpr[0]->result->getNullMask());
     return valueVector;
 }
 

--- a/src/processor/include/physical_plan/operator/filter/filter.h
+++ b/src/processor/include/physical_plan/operator/filter/filter.h
@@ -22,7 +22,6 @@ public:
 protected:
     unique_ptr<ExpressionEvaluator> rootExpr;
     uint8_t* exprResultValues;
-    bool* exprResultNullMask;
 
 private:
     uint64_t dataChunkToSelectPos;

--- a/src/processor/physical_plan/expression_mapper.cpp
+++ b/src/processor/physical_plan/expression_mapper.cpp
@@ -165,7 +165,7 @@ unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToStructuredPhysical(
     } break;
     case BOOL: {
         auto val = literalExpression.literal.val.booleanVal;
-        vector->nullMask[0] = val == NULL_BOOL;
+        vector->setNull(0, val == NULL_BOOL);
         vector->values[0] = val;
     } break;
     case STRING: {

--- a/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/frontier_extend.cpp
@@ -100,8 +100,8 @@ void FrontierExtend::extendToThreadLocalFrontiers(uint64_t layer) {
                             // Warning: we use non-thread-safe metric inside openmp parallelization
                             // metrics won't be exactly but hopefully good enough.
                             lists->readValues(slot->nodeOffset, vectors[threadId],
-                                vectors[threadId]->state->size, listsPageHandles[threadId],
-                                MAX_TO_READ, *metrics->bufferManagerMetrics);
+                                listsPageHandles[threadId], MAX_TO_READ,
+                                *metrics->bufferManagerMetrics);
                             threadLocalFrontierPerLayer[layer][threadId]->append(
                                 *(NodeIDVector*)(vectors[threadId].get()), slot->multiplicity);
                         } while (listsPageHandles[threadId]->hasMoreToRead());
@@ -195,8 +195,8 @@ FrontierSet* FrontierExtend::createInitialFrontierSet() {
     frontier->setMemoryManager(context.memoryManager);
     frontier->initHashTable(numSlots);
     do {
-        lists->readValues(nodeOffset, vectors[0], vectors[0]->state->size, listsPageHandles[0],
-            MAX_TO_READ, *metrics->bufferManagerMetrics);
+        lists->readValues(nodeOffset, vectors[0], listsPageHandles[0], MAX_TO_READ,
+            *metrics->bufferManagerMetrics);
         frontier->insert(*vectors[0]);
     } while (listsPageHandles[0]->hasMoreToRead());
     lists->reclaim(*listsPageHandles[0]);

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -21,8 +21,8 @@ void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
 void ReadList::readValuesFromList() {
     lists->reclaim(*listsPageHandle);
     auto nodeOffset = inNodeIDVector->readNodeOffset(inDataChunk->state->getPositionOfCurrIdx());
-    lists->readValues(nodeOffset, outValueVector, outDataChunk->state->size, listsPageHandle,
-        MAX_TO_READ, *metrics->bufferManagerMetrics);
+    lists->readValues(
+        nodeOffset, outValueVector, listsPageHandle, MAX_TO_READ, *metrics->bufferManagerMetrics);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/result/result_set_iterator.cpp
+++ b/src/processor/physical_plan/operator/result/result_set_iterator.cpp
@@ -62,8 +62,8 @@ void ResultSetIterator::getNextTuple(Tuple& tuple) {
         auto tuplePosition = tuplePositions[i];
         for (auto& vector : dataChunk->valueVectors) {
             auto selectedTuplePos = vector->state->selectedPositions[tuplePosition];
-            tuple.nullMask[valueInTupleIdx] = vector->nullMask[selectedTuplePos];
-            if (vector->nullMask[selectedTuplePos]) {
+            tuple.nullMask[valueInTupleIdx] = vector->isNull(selectedTuplePos);
+            if (vector->isNull(selectedTuplePos)) {
                 continue;
             }
             switch (vector->dataType) {

--- a/src/storage/include/data_structure/lists/lists.h
+++ b/src/storage/include/data_structure/lists/lists.h
@@ -38,8 +38,8 @@ class BaseLists : public DataStructure {
 
 public:
     void readValues(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& listLen, const unique_ptr<ListsPageHandle>& listsPageHandle,
-        uint32_t maxElementsToRead, BufferManagerMetrics& metrics);
+        const unique_ptr<ListsPageHandle>& listsPageHandle, uint32_t maxElementsToRead,
+        BufferManagerMetrics& metrics);
 
     inline uint64_t getNumElementsInList(node_offset_t nodeOffset) {
         return getListInfo(nodeOffset).listLen;
@@ -53,12 +53,12 @@ protected:
         : DataStructure{fName, dataType, elementSize, bufferManager, isInMemory}, metadata{fName},
           headers(move(headers)){};
 
-    virtual void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& lenToRead,
+    virtual void readFromLargeList(const shared_ptr<ValueVector>& valueVector,
         const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
         uint32_t maxElementsToRead, BufferManagerMetrics& metrics);
 
     virtual void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& lenToRead, const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
+        const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
         BufferManagerMetrics& metrics);
 
 public:
@@ -93,12 +93,12 @@ public:
           stringOverflowPages{fName, bufferManager, isInMemory} {};
 
 private:
-    void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& lenToRead,
+    void readFromLargeList(const shared_ptr<ValueVector>& valueVector,
         const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
         uint32_t maxElementsToRead, BufferManagerMetrics& metrics) override;
 
     void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& lenToRead, const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
+        const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
         BufferManagerMetrics& metrics) override;
 
 private:
@@ -121,12 +121,12 @@ public:
     shared_ptr<ListHeaders> getHeaders() { return headers; };
 
 private:
-    void readFromLargeList(const shared_ptr<ValueVector>& valueVector, uint64_t& lenToRead,
+    void readFromLargeList(const shared_ptr<ValueVector>& valueVector,
         const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
         uint32_t maxElementsToRead, BufferManagerMetrics& metrics) override;
 
     void readSmallList(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
-        uint64_t& lenToRead, const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
+        const unique_ptr<ListsPageHandle>& listsPageHandle, ListInfo& info,
         BufferManagerMetrics& metrics) override;
 
 private:

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -81,7 +81,7 @@ void HashIndex::lookup(ValueVector& keys, ValueVector& result, BufferManagerMetr
         auto resultValue =
             lookupKeyInSlot(expectedKey, numBytesPerKey, blockId, slotIdInBlock, metrics);
         resultData[keyPos] = resultValue;
-        result.nullMask[keyPos] = resultValue == UINT64_MAX;
+        result.setNull(keyPos, resultValue == UINT64_MAX);
     }
 }
 

--- a/test/common/BUILD.bazel
+++ b/test/common/BUILD.bazel
@@ -1,5 +1,18 @@
 load("@rules_cc//cc:defs.bzl", "cc_test")
 
+cc_library(
+    name = "vector_operations_test_helper",
+    srcs = [
+    ],
+    hdrs = [
+        "include/vector/operations/vector_operations_test_helper.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@gtest",
+    ],
+)
+
 cc_test(
     name = "memory_manager_test",
     srcs = [
@@ -32,6 +45,22 @@ cc_test(
 )
 
 cc_test(
+    name = "value_vector_tests",
+    srcs = [
+        "vector/value_vector_test.cpp",
+    ],
+    copts = [
+        "-Iexternal/gtest/include",
+    ],
+    deps = [
+        "//src/common:data_chunk",
+        "//src/common:memory_manager",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "vector_operations_tests",
     srcs = [
         "vector/operations/vector_arithmetic_operations_test.cpp",
@@ -44,6 +73,7 @@ cc_test(
         "-Iexternal/gtest/include",
     ],
     deps = [
+        "//test/common:vector_operations_test_helper",
         "//src/common:data_chunk",
         "//src/common:vector_operations",
         "@gtest",

--- a/test/common/include/vector/operations/vector_operations_test_helper.h
+++ b/test/common/include/vector/operations/vector_operations_test_helper.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "gtest/gtest.h"
+
+#include "src/common/include/data_chunk/data_chunk.h"
+
+using namespace graphflow::common;
+using ::testing::Test;
+
+namespace graphflow {
+namespace testing {
+
+class TwoOperands {
+public:
+    virtual DataType getDataTypeOfOperands() = 0;
+    virtual DataType getDataTypeOfResultVector() = 0;
+
+    void initVectors() {
+        memoryManager = make_unique<MemoryManager>();
+        vector1 = make_shared<ValueVector>(memoryManager.get(), getDataTypeOfOperands());
+        vector2 = make_shared<ValueVector>(memoryManager.get(), getDataTypeOfOperands());
+        result = make_shared<ValueVector>(memoryManager.get(), getDataTypeOfResultVector());
+    }
+
+public:
+    const int32_t NUM_TUPLES = 100;
+    shared_ptr<ValueVector> vector1;
+    shared_ptr<ValueVector> vector2;
+    shared_ptr<ValueVector> result;
+    unique_ptr<MemoryManager> memoryManager;
+};
+
+class OperandsInSameDataChunk : public TwoOperands {
+public:
+    void initDataChunk() {
+        initVectors();
+        dataChunk = make_shared<DataChunk>();
+        dataChunk->state->size = NUM_TUPLES;
+        dataChunk->append(vector1);
+        dataChunk->append(vector2);
+        dataChunk->append(result);
+    }
+
+public:
+    shared_ptr<DataChunk> dataChunk;
+};
+
+class OperandsInDifferentDataChunks : public TwoOperands {
+
+public:
+    void initDataChunk() {
+        initVectors();
+        dataChunkWithVector1 = make_shared<DataChunk>();
+        dataChunkWithVector1->state->size = NUM_TUPLES;
+        dataChunkWithVector1->append(vector1);
+
+        dataChunkWithVector2AndResult = make_shared<DataChunk>();
+        dataChunkWithVector2AndResult->state->size = NUM_TUPLES;
+        dataChunkWithVector2AndResult->append(vector2);
+        dataChunkWithVector2AndResult->append(result);
+    }
+
+public:
+    shared_ptr<DataChunk> dataChunkWithVector1;
+    shared_ptr<DataChunk> dataChunkWithVector2AndResult;
+};
+
+} // namespace testing
+} // namespace graphflow

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -1,243 +1,354 @@
 #include "gtest/gtest.h"
+#include "test/common/include/vector/operations/vector_operations_test_helper.h"
 
 #include "src/common/include/data_chunk/data_chunk.h"
 #include "src/common/include/value.h"
 #include "src/common/include/vector/operations/vector_arithmetic_operations.h"
 
 using namespace graphflow::common;
+using namespace graphflow::testing;
 using namespace std;
 
-class VectorArithmeticOperationsTest : public testing::Test {
+// Creates two vectors: vector1: [0, 1, ..., 100] and vector2: [110, 109, ...., 8, 9].
+class Int64ArithmeticOperandsInSameDataChunkTest : public OperandsInSameDataChunk, public Test {
+
 public:
-    const int32_t VECTOR_SIZE = 100;
+    DataType getDataTypeOfOperands() override { return INT64; }
+    DataType getDataTypeOfResultVector() override { return INT64; }
 
     void SetUp() override {
-        dataChunk = make_shared<DataChunk>();
-        dataChunk->state->size = VECTOR_SIZE;
-        memoryManager = make_unique<MemoryManager>();
+        initDataChunk();
+        auto lVectorData = (int64_t*)vector1->values;
+        auto rVectorData = (int64_t*)vector2->values;
+        for (int i = 0; i < NUM_TUPLES; i++) {
+            lVectorData[i] = i;
+            rVectorData[i] = 110 - i;
+        }
     }
-
-public:
-    shared_ptr<DataChunk> dataChunk;
-    unique_ptr<MemoryManager> memoryManager;
 };
 
-TEST_F(VectorArithmeticOperationsTest, Int64Test) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), INT64);
-    dataChunk->append(lVector);
-    auto lData = (int64_t*)lVector->values;
+// Creates two vectors: vector1: [0, 1, ..., 100] and vector2: [110, 109, ...., 8, 9].
+class Int64ArithmeticOperandsInDifferentDataChunksTest : public OperandsInDifferentDataChunks,
+                                                         public Test {
 
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), INT64);
-    dataChunk->append(rVector);
-    auto rData = (int64_t*)rVector->values;
+public:
+    DataType getDataTypeOfOperands() override { return INT64; }
+    DataType getDataTypeOfResultVector() override { return INT64; }
 
-    auto result = make_shared<ValueVector>(memoryManager.get(), INT64);
-    dataChunk->append(result);
+    void SetUp() override {
+        initDataChunk();
+        auto lVectorData = (int64_t*)vector1->values;
+        auto rVectorData = (int64_t*)vector2->values;
+        for (int i = 0; i < NUM_TUPLES; i++) {
+            lVectorData[i] = i;
+            rVectorData[i] = 110 - i;
+        }
+    }
+};
+
+class StringArithmeticOperandsInSameDataChunkTest : public OperandsInSameDataChunk, public Test {
+
+public:
+    DataType getDataTypeOfOperands() override { return STRING; }
+    DataType getDataTypeOfResultVector() override { return STRING; }
+
+    void SetUp() override { initDataChunk(); }
+};
+
+class UnstructuredArithmeticOperandsInSameDataChunkTest : public OperandsInSameDataChunk,
+                                                          public Test {
+
+public:
+    DataType getDataTypeOfOperands() override { return UNSTRUCTURED; }
+    DataType getDataTypeOfResultVector() override { return UNSTRUCTURED; }
+
+    void SetUp() override { initDataChunk(); }
+};
+
+TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatNoNulls) {
+    auto lVector = vector1;
+    auto rVector = vector2;
     auto resultData = (int64_t*)result->values;
 
-    // Fill values before the comparison.
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        lData[i] = i;
-        rData[i] = 110 - i;
-    }
-
     VectorArithmeticOperations::Negate(*lVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], -i);
+        ASSERT_FALSE(result->isNull(i));
     }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
+
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], 110);
+        ASSERT_FALSE(result->isNull(i));
     }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], 2 * i - 110);
+        ASSERT_FALSE(result->isNull(i));
     }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i * (110 - i));
+        ASSERT_FALSE(result->isNull(i));
     }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < dataChunk->state->size; i++) {
         ASSERT_EQ(resultData[i], i / (110 - i));
+        ASSERT_FALSE(result->isNull(i));
     }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     /* note rVector and lVector are flipped */
     VectorArithmeticOperations::Modulo(*rVector, *lVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < dataChunk->state->size; i++) {
         ASSERT_EQ(resultData[i], i % (110 - i));
+        ASSERT_FALSE(result->isNull(i));
     }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     result = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
     dataChunk->append(result);
     auto resultDataAsDoubleArr = (double_t*)result->values;
     VectorArithmeticOperations::Power(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultDataAsDoubleArr[i], pow(i, 110 - i));
+        ASSERT_FALSE(result->isNull(i));
     }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
 }
 
-TEST_F(VectorArithmeticOperationsTest, StringTest) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
-    dataChunk->append(lVector);
+// We use Negate and Addition as an example comparison operator.
+TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatWithNulls) {
+    auto lVector = vector1;
+    auto rVector = vector2;
+    auto resultData = (int64_t*)result->values;
+    // We set every odd value in vector 2 to NULL.
+    for (int i = 0; i < NUM_TUPLES; ++i) {
+        rVector->setNull(i, (i % 2) == 1 ? true : false);
+    }
 
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
-    dataChunk->append(rVector);
+    // Unary UnaryOperationExecutor::executeArithmeticOps assumes that when the operand is unflat
+    // the nullmask of result vector is the same as the operand's nullmask. So we set it so below.
+    result->setNullMask(rVector->getNullMask());
+    VectorArithmeticOperations::Negate(*rVector, *result);
+    for (int i = 0; i < NUM_TUPLES; i++) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(resultData[i], -(110 - i));
+            ASSERT_FALSE(result->isNull(i));
+        } else {
+            ASSERT_TRUE(result->isNull(i));
+        }
+    }
+    ASSERT_FALSE(result->hasNoNullsGuarantee());
 
-    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
-    dataChunk->append(result);
+    VectorArithmeticOperations::Add(*lVector, *rVector, *result);
+    for (int i = 0; i < NUM_TUPLES; i++) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(resultData[i], 110);
+            ASSERT_FALSE(result->isNull(i));
+        } else {
+            ASSERT_TRUE(result->isNull(i));
+        }
+    }
+    ASSERT_FALSE(result->hasNoNullsGuarantee());
+}
+
+// We use Addition as an example comparison operator.
+TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUnflatNoNulls) {
+    // Flatten dataChunkWithVector1, which holds vector1
+    dataChunkWithVector1->state->currIdx = 80;
+    // Recall vector2 and result are in the same data chunk
+    auto resultData = (uint64_t*)result->values;
+
+    // Test 1: Left flat and right is unflat.
+    // The addition is 80 + [110, 109, ...., 8, 9]. The results are: [190, 189, ...., 88, 89]
+    VectorArithmeticOperations::Add(*vector1, *vector2, *result);
+    for (int i = 0; i < NUM_TUPLES; i++) {
+        ASSERT_EQ(resultData[i], 190 - i);
+        ASSERT_FALSE(result->isNull(i));
+    }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
+
+    // Test 2: Left unflat and right is flat. The result is the same as above.
+    VectorArithmeticOperations::Add(*vector2, *vector1, *result);
+    for (int i = 0; i < NUM_TUPLES; i++) {
+        ASSERT_EQ(resultData[i], 190 - i);
+        ASSERT_FALSE(result->isNull(i));
+    }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
+}
+
+// We use Addition as an example comparison operator.
+TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUnflatWithNulls) {
+    auto lVector = vector1;
+    auto rVector = vector2;
+    auto resultData = (int64_t*)result->values;
+    // We set every odd value in vector 2 to NULL.
+    for (int i = 0; i < NUM_TUPLES; ++i) {
+        rVector->setNull(i, (i % 2) == 1 ? true : false);
+    }
+    // Flatten dataChunkWithVector1, which holds vector1
+    dataChunkWithVector1->state->currIdx = 80;
+
+    // Test 1: Left flat and right is unflat.
+    // The addition is 80 + [110, 109, ...., 8, 9]. The results are: [190, NULL, ...., 88, NULL]
+    VectorArithmeticOperations::Add(*vector1, *vector2, *result);
+    for (int i = 0; i < NUM_TUPLES; i++) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(resultData[i], 190 - i);
+            ASSERT_FALSE(result->isNull(i));
+        } else {
+            ASSERT_TRUE(result->isNull(i));
+        }
+    }
+    ASSERT_FALSE(result->hasNoNullsGuarantee());
+
+    // Test 2: Left unflat and right is flat. The result is the same as above.
+    VectorArithmeticOperations::Add(*vector2, *vector1, *result);
+    for (int i = 0; i < NUM_TUPLES; i++) {
+        if (i % 2 == 0) {
+            ASSERT_EQ(resultData[i], 190 - i);
+            ASSERT_FALSE(result->isNull(i));
+        } else {
+            ASSERT_TRUE(result->isNull(i));
+        }
+    }
+    ASSERT_FALSE(result->hasNoNullsGuarantee());
+}
+
+TEST_F(StringArithmeticOperandsInSameDataChunkTest, StringTest) {
+    auto lVector = vector1;
+    auto rVector = vector2;
     auto resultData = (gf_string_t*)result->values;
-
     // Fill values before the comparison.
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         lVector->addString(i, to_string(i));
         rVector->addString(i, to_string(110 - i));
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].getAsString(), to_string(i) + to_string(110 - i));
     }
 }
 
-TEST_F(VectorArithmeticOperationsTest, BigStringTest) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
-    dataChunk->append(lVector);
-
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
-    dataChunk->append(rVector);
-
-    auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
-    dataChunk->append(result);
+TEST_F(StringArithmeticOperandsInSameDataChunkTest, BigStringTest) {
+    auto lVector = vector1;
+    auto rVector = vector2;
     auto resultData = (gf_string_t*)result->values;
-
     // Fill values before the comparison.
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         lVector->addString(i, to_string(i) + "abcdefabcdefqwert");
         rVector->addString(i, to_string(110 - i) + "abcdefabcdefqwert");
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].getAsString(),
             to_string(i) + "abcdefabcdefqwert" + to_string(110 - i) + "abcdefabcdefqwert");
     }
 }
 
-TEST_F(VectorArithmeticOperationsTest, UnstructuredInt64Test) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(lVector);
+TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt64Test) {
+    auto lVector = vector1;
+    auto rVector = vector2;
     auto lData = (Value*)lVector->values;
-
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(rVector);
     auto rData = (Value*)rVector->values;
-
-    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(result);
     auto resultData = (Value*)result->values;
 
     // Fill values before the comparison.
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         lData[i] = Value((int64_t)i);
         rData[i] = Value((int64_t)110 - i);
     }
 
     VectorArithmeticOperations::Negate(*lVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, -i);
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, 110);
     }
 
     VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, 2 * i - 110);
     }
 
     VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, i * (110 - i));
     }
 
     VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, i / (110 - i));
     }
 
     /* note rVector and lVector are flipped */
     VectorArithmeticOperations::Modulo(*rVector, *lVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, i % (110 - i));
     }
 }
 
-TEST_F(VectorArithmeticOperationsTest, UnstructuredInt32AndDoubleTest) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(lVector);
+TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt32AndDoubleTest) {
+    auto lVector = vector1;
+    auto rVector = vector2;
     auto lData = (Value*)lVector->values;
-
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(rVector);
     auto rData = (Value*)rVector->values;
-
-    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(result);
     auto resultData = (Value*)result->values;
 
     // Fill values before the comparison.
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         lData[i] = Value((double)i);
         rData[i] = Value((int64_t)110 - i);
     }
 
     VectorArithmeticOperations::Negate(*lVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)-i);
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)110);
     }
 
     VectorArithmeticOperations::Subtract(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)(2 * i - 110));
     }
 
     VectorArithmeticOperations::Multiply(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)(i * (110 - i)));
     }
 
     VectorArithmeticOperations::Divide(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)i / (110 - i));
     }
 }
 
-TEST_F(VectorArithmeticOperationsTest, UnstructuredStringAndInt32Test) {
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(lVector);
+TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredStringAndInt32Test) {
+    auto lVector = vector1;
+    auto rVector = vector2;
     auto lData = (Value*)lVector->values;
-
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(rVector);
     auto rData = (Value*)rVector->values;
-
-    auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    dataChunk->append(result);
     auto resultData = (Value*)result->values;
 
     // Fill values before the comparison.
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         string lStr = to_string(i);
         lVector->allocateStringOverflowSpace(lData[i].val.strVal, lStr.length());
         lData[i].val.strVal.set(lStr);
@@ -246,7 +357,7 @@ TEST_F(VectorArithmeticOperationsTest, UnstructuredStringAndInt32Test) {
     }
 
     VectorArithmeticOperations::Add(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
+    for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.strVal.getAsString(), to_string(i) + to_string(110 - i));
     }
 }

--- a/test/common/vector/value_vector_test.cpp
+++ b/test/common/vector/value_vector_test.cpp
@@ -1,0 +1,35 @@
+
+#include "include/gtest/gtest.h"
+
+#include "src/common/include/memory_manager.h"
+#include "src/common/include/vector/value_vector.h"
+
+using namespace graphflow::common;
+using namespace std;
+
+TEST(ValueVectorTests, TestDefaultHasNull) {
+    auto memoryManager = make_unique<MemoryManager>();
+    ValueVector valueVector(memoryManager.get(), DataType::INT64);
+    shared_ptr<SharedVectorState> dataChunkState =
+        make_shared<SharedVectorState>(DEFAULT_VECTOR_CAPACITY);
+    valueVector.state = dataChunkState;
+    valueVector.state->size = 3;
+    for (int i = 0; i < 3; ++i) {
+        ((uint64_t*)valueVector.values)[i] = i;
+    }
+    // Test that initially the vector does not contain any NULLs.
+    EXPECT_TRUE(valueVector.hasNoNullsGuarantee());
+
+    // Test that after an update of a value to non-NULL the vector still does not contain any NULLs.
+    valueVector.setNull(2, FALSE);
+    EXPECT_TRUE(valueVector.hasNoNullsGuarantee());
+
+    // Test that after an update of a value to NULL the vector may now contain NULLs.
+    valueVector.setNull(4, TRUE);
+    EXPECT_FALSE(valueVector.hasNoNullsGuarantee());
+
+    // Test that even if we revert the previous update of non-NULL the vector may still
+    // contain  NULLs.
+    valueVector.setNull(4, FALSE);
+    EXPECT_FALSE(valueVector.hasNoNullsGuarantee());
+}


### PR DESCRIPTION
This PR extracts nullMasks in ValueVector to a new class that stores nullMask bool array as well as an additional bool mayContainNulls, that is false if the vector is guaranteed to not have nulls. This allows us to special case fast path executions that avoid null-related computation in executors. 
Other changes:
- NullMask bool array is no longer accessed directly but access through inline function calls to read and set nulls. These functions are in ValueVector instead of the NullMask class because some of these functions, e.g., `setAllNull`, require access to DataChunkState.
- Writes several tests to vector_comparison_operations and vector_arithmetic_operations to test the slow and fast paths, i.e., when the operands contain nulls and no nulls. Also extends some existing tests to verify that not only the result values are correct  but also their nullMasks are correct. 
- Refactors some common test code to construct DataChunk and ValueVectors in tests.
- An unrelated change that came up in this PR: Removed listLen from Lists::readValues and some other functions that readValues calls. This was a reference to DataChunkState->size, and was being set here (another reason we should have setters and getters instead of passing references), and was very difficult to track. We also realized this was not necessary since the ValueVector into which data will be read was being read was already passed to these functions as `const shared_ptr<ValueVector>& valueVector` argument, so we could set the size through this argument. So this argument was redundant.