### PR TITLE
Fix unsafe mem access and mem leak

### DIFF
--- a/src/common/csv_reader/csv_reader.cpp
+++ b/src/common/csv_reader/csv_reader.cpp
@@ -7,7 +7,7 @@ namespace graphflow {
 namespace common {
 
 CSVReader::CSVReader(const string& fName, const char tokenSeparator, uint64_t blockId)
-    : fd{nullptr}, tokenSeparator{tokenSeparator}, line{new char[1 << 10]},
+    : fd{nullptr}, tokenSeparator{tokenSeparator}, line{(char*)malloc(sizeof(char) * 1024)},
       readingBlockIdx{CSV_READING_BLOCK_SIZE * blockId}, readingBlockEndIdx{CSV_READING_BLOCK_SIZE *
                                                                             (blockId + 1)} {
     openFile(fName);
@@ -26,7 +26,7 @@ CSVReader::CSVReader(const string& fName, const char tokenSeparator, uint64_t bl
 }
 
 CSVReader::CSVReader(const string& fname, const char tokenSeparator)
-    : tokenSeparator(tokenSeparator), line{new char[1 << 10]} {
+    : tokenSeparator(tokenSeparator), line{(char*)malloc(sizeof(char) * 1024)} {
     openFile(fname);
     readingBlockIdx = 0;
     readingBlockEndIdx = UINT64_MAX;
@@ -34,7 +34,7 @@ CSVReader::CSVReader(const string& fname, const char tokenSeparator)
 
 CSVReader::~CSVReader() {
     fclose(fd);
-    delete[](line);
+    free(line);
 }
 
 bool CSVReader::hasNextLine() {

--- a/src/loader/adj_and_prop_lists_builder.cpp
+++ b/src/loader/adj_and_prop_lists_builder.cpp
@@ -52,7 +52,7 @@ void AdjAndPropertyListsBuilder::buildInMemStructures() {
 }
 
 void AdjAndPropertyListsBuilder::setRel(
-    const uint64_t& pos, const Direction& direction, const vector<nodeID_t>& nodeIDs) {
+    uint64_t pos, Direction direction, const vector<nodeID_t>& nodeIDs) {
     PageCursor cursor;
     auto header = directionLabelAdjListHeaders[direction][nodeIDs[direction].label]
                       .headers[nodeIDs[direction].offset];
@@ -65,8 +65,7 @@ void AdjAndPropertyListsBuilder::setRel(
 }
 
 void AdjAndPropertyListsBuilder::setProperty(const vector<uint64_t>& pos,
-    const vector<nodeID_t>& nodeIDs, const uint32_t& propertyIdx, const uint8_t* val,
-    const DataType& type) {
+    const vector<nodeID_t>& nodeIDs, uint32_t propertyIdx, const uint8_t* val, DataType type) {
     PageCursor cursor;
     for (auto& direction : DIRECTIONS) {
         auto header = directionLabelAdjListHeaders[direction][nodeIDs[direction].label]

--- a/src/loader/include/adj_and_prop_lists_builder.h
+++ b/src/loader/include/adj_and_prop_lists_builder.h
@@ -59,12 +59,12 @@ public:
 
     // Sets a neighbour nodeID in the adjList of the given nodeID in a particular adjLists
     // structure.
-    void setRel(const uint64_t& pos, const Direction& direction, const vector<nodeID_t>& nodeIDs);
+    void setRel(uint64_t pos, Direction direction, const vector<nodeID_t>& nodeIDs);
 
     // Sets a proeprty in the propertyList of the given nodeID in a particular RelPropertyLists
     // structure.
     void setProperty(const vector<uint64_t>& pos, const vector<nodeID_t>& nodeIDs,
-        const uint32_t& propertyIdx, const uint8_t* val, const DataType& type);
+        uint32_t propertyIdx, const uint8_t* val, DataType type);
 
     // Sets a string proeprty in the propertyList of the given nodeID in a particular
     // RelPropertyLists structure.

--- a/src/loader/include/utils.h
+++ b/src/loader/include/utils.h
@@ -133,8 +133,8 @@ public:
 
     // Calculates the page id and offset in page where the data of a particular list has to be put
     // in the in-mem pages.
-    static void calculatePageCursor(const uint32_t& header, const uint64_t& reversePos,
-        const uint8_t& numBytesPerElement, const node_offset_t& nodeOffset, PageCursor& cursor,
+    static void calculatePageCursor(uint32_t header, uint64_t reversePos,
+        uint8_t numBytesPerElement, node_offset_t nodeOffset, PageCursor& cursor,
         ListsMetadata& metadata);
 };
 

--- a/src/loader/rels_loader.cpp
+++ b/src/loader/rels_loader.cpp
@@ -171,8 +171,10 @@ void RelsLoader::populateAdjListsTask(RelLabelDescription* description, uint64_t
         }
     }
     vector<bool> requireToReadLabels{true, true};
-    vector<nodeID_t> nodeIDs{2};
-    vector<uint64_t> reversePos{2};
+    vector<nodeID_t> nodeIDs;
+    nodeIDs.reserve(2);
+    vector<uint64_t> reversePos;
+    reversePos.reserve(2);
     vector<PageCursor> stringOverflowPagesCursors{description->properties.size()};
     for (auto& direction : DIRECTIONS) {
         requireToReadLabels[direction] = 1 != description->nodeLabelsPerDirection[direction].size();

--- a/src/loader/utils.cpp
+++ b/src/loader/utils.cpp
@@ -13,8 +13,8 @@ namespace graphflow {
 namespace loader {
 
 NodeIDMap::~NodeIDMap() {
-    for (auto& charArray : nodeIDToOffsetMap) {
-        delete[] charArray.first;
+    for (auto i = 0u; i < size; ++i) {
+        delete[] offsetToNodeIDMap[i];
     }
 }
 
@@ -122,8 +122,8 @@ void ListsLoaderHelper::calculateListsMetadataTask(uint64_t numNodeOffsets, uint
         "End: listsMetadata={0:p} listHeaders={1:p}", (void*)listsMetadata, (void*)listHeaders);
 }
 
-void ListsLoaderHelper::calculatePageCursor(const uint32_t& header, const uint64_t& reversePos,
-    const uint8_t& numBytesPerElement, const node_offset_t& nodeOffset, PageCursor& cursor,
+void ListsLoaderHelper::calculatePageCursor(uint32_t header, uint64_t reversePos,
+    uint8_t numBytesPerElement, node_offset_t nodeOffset, PageCursor& cursor,
     ListsMetadata& metadata) {
     auto numElementsInAPage = PAGE_SIZE / numBytesPerElement;
     if (ListHeaders::isALargeList(header)) {


### PR DESCRIPTION
This PR fix unsafe mem access and mem leak based on valgrind check

- Mismatched delete/delete[]
  - In csv_reader.cpp, hasNextLine() will call getLine() which triggers a malloc if the string buffer is not big enough. Our string buffer is created by `new` and released by `delete[]`. While getLine() use `malloc` and `free` which causes a mismatch.
- Invalid read/write
  - In rels_loader.cpp, reversePos is created by `reversePos{2}`, we meant to create a vector of size 2 but the constructor is for vector of size 1 and has single element 2
-  Memory leak in NodeIDMap  
   - Both `nodeIDToOffsetMap` and `offsetToNodeIDMap` holds the same pointer to a char array. We used to free `nodeIDToOffsetMap`. However, loader may throw invalid argument (e.g. string exceeds maximum length) and terminate. In this case,  `nodeIDToOffsetMap` has not yet been populated. So we free  `offsetToNodeIDMap` in the deconstructor instead.


Minor change
- change const reference of primitive type to copy
  - e.g. `const uint32_t&` ->`uint32_t`