### PR TITLE
add read/write lock to string overflow loading

### DIFF
--- a/src/loader/in_mem_pages.cpp
+++ b/src/loader/in_mem_pages.cpp
@@ -54,6 +54,7 @@ void InMemStringOverflowPages::copyOverflowString(
         cursor.offset = 0;
         cursor.idx = getNewOverflowPageIdx();
     }
+    shared_lock lck(lock);
     encodedString->setOverflowPtrInfo(cursor.idx, cursor.offset);
     auto writeOffset = data.get() + (cursor.idx << PAGE_SIZE_LOG_2) + cursor.offset;
     memcpy(writeOffset, ptrToCopy, encodedString->len);
@@ -61,7 +62,7 @@ void InMemStringOverflowPages::copyOverflowString(
 }
 
 uint32_t InMemStringOverflowPages::getNewOverflowPageIdx() {
-    lock_guard lck(lock);
+    unique_lock lck(lock);
     auto page = numPages++;
     if (numPages != maxPages) {
         return page;

--- a/src/loader/include/in_mem_pages.h
+++ b/src/loader/include/in_mem_pages.h
@@ -2,7 +2,7 @@
 
 #include <iostream>
 #include <memory>
-#include <mutex>
+#include <shared_mutex>
 
 #include "src/common/include/configs.h"
 #include "src/common/include/gf_string.h"
@@ -110,7 +110,7 @@ private:
     uint32_t getNewOverflowPageIdx();
 
 private:
-    mutex lock;
+    shared_mutex lock;
     uint64_t maxPages;
 };
 

--- a/src/loader/loader_runner.cpp
+++ b/src/loader/loader_runner.cpp
@@ -9,15 +9,6 @@
 using namespace graphflow::loader;
 using namespace std;
 
-void createDirectory(const string& directory) {
-    struct stat st;
-    if (stat(directory.c_str(), &st) != 0) {
-        if (mkdir(directory.c_str(), 0755) != 0 && errno != EEXIST) {
-            throw invalid_argument("Failed to create directory" + directory);
-        }
-    }
-}
-
 unordered_map<string, spdlog::level::level_enum> verbosityMap{
     {"trace", spdlog::level::trace},
     {"debug", spdlog::level::debug},
@@ -55,7 +46,6 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     spdlog::set_level(verbosity ? args::get(verbosity) : verbosityMap["info"]);
-    createDirectory(args::get(outputDir));
     auto numThreads = threads ? args::get(threads) : thread::hardware_concurrency();
     try {
         GraphLoader graphLoader(args::get(inputDir), args::get(outputDir), numThreads);


### PR DESCRIPTION
This PR fixes the multi-thread overflow string loading bug.

Also, this pr does one minor change to remove the `createDirectory` in the LoaderRunner, which conflicts with the GraphLoader's directory creation, and leads to errors of directory already existing.