### PR TITLE
Subquery evaluator

### DIFF
--- a/src/common/include/data_chunk/data_chunk_state.h
+++ b/src/common/include/data_chunk/data_chunk_state.h
@@ -30,6 +30,9 @@ public:
     inline void resetSelectorToValuePosBuffer() {
         selectedPositions = selectedPositionsBuffer.get();
     }
+
+    inline void setSelectedSize(uint64_t size) { selectedSize = size; }
+
     void initOriginalAndSelectedSize(uint64_t size) {
         originalSize = size;
         selectedSize = size;

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -126,6 +126,8 @@ enum ExpressionType : uint8_t {
      * Temporal Function Expression
      */
     DATE_FUNC = 170,
+
+    EXIST_SUBQUERY = 190,
 };
 
 bool isExpressionUnary(ExpressionType type);

--- a/src/common/include/vector/node_vector.h
+++ b/src/common/include/vector/node_vector.h
@@ -30,6 +30,12 @@ public:
         : NodeIDVector{
               commonLabel, nodeIDCompressionScheme, isSequence, DEFAULT_VECTOR_CAPACITY} {};
 
+    NodeIDVector(
+        const NodeIDCompressionScheme& nodeIdCompressionScheme, bool isSequence, bool isSingleValue)
+        : ValueVector{nullptr, isSingleValue ? 1 : DEFAULT_VECTOR_CAPACITY,
+              nodeIdCompressionScheme.getNumTotalBytes(), NODE},
+          representation{NodeIDRepresentation{isSequence, UINT32_MAX, nodeIdCompressionScheme}} {};
+
     node_offset_t readNodeOffset(uint64_t pos) const override;
     void readNodeID(uint64_t pos, nodeID_t& nodeID) const override;
 

--- a/src/expression_evaluator/BUILD.bazel
+++ b/src/expression_evaluator/BUILD.bazel
@@ -2,19 +2,16 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "expression_evaluator",
-    srcs = [
-        "binary_expression_evaluator.cpp",
-        "expression_evaluator.cpp",
-        "unary_expression_evaluator.cpp",
-    ],
-    hdrs = [
-        "include/binary_expression_evaluator.h",
-        "include/expression_evaluator.h",
-        "include/unary_expression_evaluator.h",
-    ],
+    srcs = glob([
+        "*.cpp",
+    ]),
+    hdrs = glob([
+        "include/*.h",
+    ]),
     visibility = ["//visibility:public"],
     deps = [
         "//src/common:data_chunk",
         "//src/common:vector_operations",
+        "//src/processor:result_collector",
     ],
 )

--- a/src/expression_evaluator/exist_subquery_evaluator.cpp
+++ b/src/expression_evaluator/exist_subquery_evaluator.cpp
@@ -1,0 +1,30 @@
+#include "src/expression_evaluator/include/exist_subquery_evaluator.h"
+
+namespace graphflow {
+namespace evaluator {
+
+ExistSubqueryEvaluator::ExistSubqueryEvaluator(
+    MemoryManager& memoryManager, unique_ptr<ResultCollector> subPlanResultCollector)
+    : ExpressionEvaluator{EXIST_SUBQUERY, BOOL}, subPlanResultCollector{
+                                                     move(subPlanResultCollector)} {
+    result = make_shared<ValueVector>(&memoryManager, BOOL, true /* isSingleValue */);
+    result->state = DataChunkState::getSingleValueDataChunkState();
+}
+
+void ExistSubqueryEvaluator::executeSubplan() {
+    subPlanResultCollector->reInitialize();
+    subPlanResultCollector->execute();
+}
+
+void ExistSubqueryEvaluator::evaluate() {
+    executeSubplan();
+    result->values[0] = subPlanResultCollector->queryResult->numTuples != 0;
+}
+
+uint64_t ExistSubqueryEvaluator::select(sel_t* selectedPositions) {
+    executeSubplan();
+    return subPlanResultCollector->queryResult->numTuples != 0;
+}
+
+} // namespace evaluator
+} // namespace graphflow

--- a/src/expression_evaluator/include/exist_subquery_evaluator.h
+++ b/src/expression_evaluator/include/exist_subquery_evaluator.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "src/expression_evaluator/include/expression_evaluator.h"
+#include "src/processor/include/physical_plan/operator/scan_node_id/select_scan.h"
+#include "src/processor/include/physical_plan/operator/sink/result_collector.h"
+
+using namespace graphflow::processor;
+
+namespace graphflow {
+namespace evaluator {
+
+class ExistSubqueryEvaluator : public ExpressionEvaluator {
+
+public:
+    ExistSubqueryEvaluator(
+        MemoryManager& memoryManager, unique_ptr<ResultCollector> subPlanResultCollector);
+
+    void executeSubplan();
+
+    void evaluate() override;
+    uint64_t select(sel_t* selectedPositions) override;
+
+private:
+    unique_ptr<ResultCollector> subPlanResultCollector;
+};
+
+} // namespace evaluator
+} // namespace graphflow

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -41,7 +41,6 @@ cc_library(
         "physical_plan/operator/scan_attribute/scan_structured_property.cpp",
         "physical_plan/operator/scan_attribute/scan_unstructured_property.cpp",
         "physical_plan/operator/scan_node_id/scan_node_id.cpp",
-        "physical_plan/operator/sink/result_collector.cpp",
         "physical_plan/operator/skip/skip.cpp",
         "physical_plan/query_result.cpp",
     ],
@@ -76,7 +75,7 @@ cc_library(
         "include/physical_plan/operator/scan_attribute/scan_structured_property.h",
         "include/physical_plan/operator/scan_attribute/scan_unstructured_property.h",
         "include/physical_plan/operator/scan_node_id/scan_node_id.h",
-        "include/physical_plan/operator/sink/result_collector.h",
+        "include/physical_plan/operator/scan_node_id/select_scan.h",
         "include/physical_plan/operator/sink/sink.h",
         "include/physical_plan/operator/skip/skip.h",
         "include/physical_plan/query_result.h",
@@ -93,6 +92,27 @@ cc_library(
         "//src/planner:schema",
         "//src/storage:graph",
         "//src/transaction",
+    ],
+)
+
+cc_library(
+    name = "result_collector",
+    srcs = [
+        "physical_plan/operator/scan_node_id/select_scan.cpp",
+        "physical_plan/operator/sink/result_collector.cpp",
+        "physical_plan/query_result.cpp",
+    ],
+    hdrs = [
+        "include/physical_plan/operator/physical_operator.h",
+        "include/physical_plan/operator/scan_node_id/select_scan.h",
+        "include/physical_plan/operator/sink/result_collector.h",
+        "include/physical_plan/operator/sink/sink.h",
+        "include/physical_plan/query_result.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "execution_context",
+        "result_set",
     ],
 )
 
@@ -126,6 +146,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "operators",
+        "result_collector",
         "//src/planner:logical_plan",
     ],
 )

--- a/src/processor/include/physical_plan/operator/filter/filter.h
+++ b/src/processor/include/physical_plan/operator/filter/filter.h
@@ -15,6 +15,8 @@ public:
     Filter(unique_ptr<ExpressionEvaluator> rootExpr, uint64_t dataChunkToSelectPos,
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
 
+    void reInitialize() override;
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override;

--- a/src/processor/include/physical_plan/operator/filtering_operator.h
+++ b/src/processor/include/physical_plan/operator/filtering_operator.h
@@ -18,6 +18,11 @@ public:
                                            make_unique<sel_t[]>(DEFAULT_VECTOR_CAPACITY)} {};
 
 protected:
+    inline void reInitialize() {
+        prevNumSelectedValues = 0ul;
+        prevSelectedValues = nullptr;
+    }
+
     inline void restoreDataChunkSelectorState() {
         if (prevSelectedValues == nullptr) {
             return;

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -70,7 +70,7 @@ public:
         const vector<bool>& dataChunkPosToIsFlat, unique_ptr<PhysicalOperator> prevOperator,
         ExecutionContext& context, uint32_t id);
 
-    void getNextTuples() override;
+    void execute() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         auto cloneOp = make_unique<HashJoinBuild>(keyDataChunkPos, keyVectorPos,

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -41,6 +41,8 @@ public:
         uint64_t probeSideKeyVectorPos, unique_ptr<PhysicalOperator> buildSidePrevOp,
         unique_ptr<PhysicalOperator> probeSidePrevOp, ExecutionContext& context, uint32_t id);
 
+    void reInitialize() override;
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/load_csv/load_csv.h
+++ b/src/processor/include/physical_plan/operator/load_csv/load_csv.h
@@ -14,6 +14,8 @@ public:
     LoadCSV(const string& fname, char tokenSeparator, vector<DataType> csvColumnDataTypes,
         ExecutionContext& context, uint32_t id);
 
+    void reInitialize() override {}
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.h
+++ b/src/processor/include/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.h
@@ -11,6 +11,8 @@ public:
     MultiplicityReducer(
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
 
+    void reInitialize() override;
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -65,6 +65,10 @@ public:
 
     virtual ~PhysicalOperator() = default;
 
+    // For subquery, we rerun a plan multiple times. ReInitialize() should be called before each run
+    // to ensure
+    virtual void reInitialize() { prevOperator->reInitialize(); }
+
     virtual void getNextTuples() = 0;
 
     shared_ptr<ResultSet> getResultSet() { return resultSet; };

--- a/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
@@ -13,6 +13,8 @@ public:
         label_t outNodeIDVectorLabel, unique_ptr<PhysicalOperator> prevOperator,
         ExecutionContext& context, uint32_t id);
 
+    void reInitialize() override;
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/scan_node_id/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id/scan_node_id.h
@@ -16,6 +16,8 @@ public:
     ScanNodeID(shared_ptr<MorselsDesc>& morselsDesc, unique_ptr<PhysicalOperator> prevOperator,
         ExecutionContext& context, uint32_t id);
 
+    void reInitialize() override;
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/scan_node_id/select_scan.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id/select_scan.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "src/processor/include/physical_plan/operator/physical_operator.h"
+
+namespace graphflow {
+namespace processor {
+
+/**
+ * SelectScan is the scan (first) operator for subquery. It is responsible to copy a flat tuple from
+ * outer query into inner query and controls when to terminate inner query.
+ */
+class SelectScan : public PhysicalOperator {
+
+public:
+    SelectScan(const ResultSet& inResultSet,
+        vector<pair<uint64_t, uint64_t>> valueVectorsPosToSelect, ExecutionContext& context,
+        uint32_t id);
+
+    void reInitialize() override;
+
+    void getNextTuples() override;
+
+    unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<SelectScan>(inResultSet, valueVectorsPosToSelect, context, id);
+    }
+
+private:
+    const ResultSet& inResultSet;
+    vector<pair<uint64_t, uint64_t>> valueVectorsPosToSelect;
+
+    bool isFirstExecution;
+    shared_ptr<DataChunk> outDataChunk;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/physical_plan/operator/sink/result_collector.h
+++ b/src/processor/include/physical_plan/operator/sink/result_collector.h
@@ -18,7 +18,9 @@ public:
         queryResult = make_unique<QueryResult>();
     };
 
-    void getNextTuples() override;
+    void reInitialize() override;
+
+    void execute() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ResultCollector>(

--- a/src/processor/include/physical_plan/operator/sink/sink.h
+++ b/src/processor/include/physical_plan/operator/sink/sink.h
@@ -14,6 +14,12 @@ public:
         resultSet = this->prevOperator->getResultSet();
     };
 
+    virtual void execute() = 0;
+
+    void getNextTuples() override {
+        throw invalid_argument("Sink operator should implement execute instead of ");
+    }
+
     virtual void finalize() {}
 };
 

--- a/src/processor/include/physical_plan/operator/skip/skip.h
+++ b/src/processor/include/physical_plan/operator/skip/skip.h
@@ -13,6 +13,8 @@ public:
         vector<uint64_t> dataChunksToSkipPos, unique_ptr<PhysicalOperator> prevOperator,
         ExecutionContext& context, uint32_t id);
 
+    void reInitialize() override;
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/plan_mapper.h
+++ b/src/processor/include/physical_plan/plan_mapper.h
@@ -1,12 +1,10 @@
 #pragma once
 
-#include "src/binder/include/expression/expression.h"
 #include "src/planner/include/logical_plan/logical_plan.h"
 #include "src/processor/include/physical_plan/operator/physical_operator_info.h"
 #include "src/processor/include/physical_plan/physical_plan.h"
 #include "src/storage/include/graph.h"
 
-using namespace graphflow::binder;
 using namespace graphflow::planner;
 
 namespace graphflow {

--- a/src/processor/include/physical_plan/query_result.h
+++ b/src/processor/include/physical_plan/query_result.h
@@ -17,6 +17,8 @@ public:
 
     void appendQueryResult(unique_ptr<QueryResult> queryResult);
 
+    void clear();
+
 public:
     uint64_t numTuples;
     vector<unique_ptr<ResultSet>> resultSetCollection;

--- a/src/processor/physical_plan/operator/filter/filter.cpp
+++ b/src/processor/physical_plan/operator/filter/filter.cpp
@@ -14,6 +14,11 @@ Filter::Filter(unique_ptr<ExpressionEvaluator> rootExpr, uint64_t dataChunkToSel
     dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];
 }
 
+void Filter::reInitialize() {
+    PhysicalOperator::reInitialize();
+    FilteringOperator::reInitialize();
+}
+
 void Filter::getNextTuples() {
     metrics->executionTime.start();
     bool hasAtLeastOneSelectedValue;

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -274,7 +274,7 @@ void HashJoinBuild::appendResultSet() {
     numEntries += numTuplesToAppend;
 }
 
-void HashJoinBuild::getNextTuples() {
+void HashJoinBuild::execute() {
     metrics->executionTime.start();
     // Append thread-local tuples
     do {

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -195,6 +195,11 @@ void HashJoinProbe::updateAppendedUnFlatDataChunks() {
     }
 }
 
+void HashJoinProbe::reInitialize() {
+    PhysicalOperator::reInitialize();
+    buildSidePrevOp->reInitialize();
+}
+
 // The general flow of a hash join probe:
 // 1) find matched tuples of probe side key from ht.
 // 2) populate values from matched tuples into resultKeyDataChunk , buildSideFlatResultDataChunk

--- a/src/processor/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.cpp
+++ b/src/processor/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.cpp
@@ -10,6 +10,12 @@ MultiplicityReducer::MultiplicityReducer(
     resultSet = this->prevOperator->getResultSet();
 }
 
+void MultiplicityReducer::reInitialize() {
+    PhysicalOperator::reInitialize();
+    prevMultiplicity = 1;
+    numRepeat = 0;
+}
+
 void MultiplicityReducer::getNextTuples() {
     metrics->executionTime.start();
     if (numRepeat == 0) {

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -14,6 +14,11 @@ AdjColumnExtend::AdjColumnExtend(uint64_t dataChunkPos, uint64_t valueVectorPos,
     inDataChunk->append(outValueVector);
 }
 
+void AdjColumnExtend::reInitialize() {
+    PhysicalOperator::reInitialize();
+    FilteringOperator::reInitialize();
+}
+
 void AdjColumnExtend::getNextTuples() {
     metrics->executionTime.start();
     bool hasAtLeastOneNonNullValue;

--- a/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
@@ -22,6 +22,12 @@ ScanNodeID::ScanNodeID(shared_ptr<MorselsDesc>& morsel, unique_ptr<PhysicalOpera
     resultSet->append(outDataChunk);
 }
 
+void ScanNodeID::reInitialize() {
+    if (prevOperator) {
+        prevOperator->reInitialize();
+    }
+}
+
 void ScanNodeID::getNextTuples() {
     metrics->executionTime.start();
     if (prevOperator) {

--- a/src/processor/physical_plan/operator/scan_node_id/select_scan.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/select_scan.cpp
@@ -1,0 +1,78 @@
+#include "src/processor/include/physical_plan/operator/scan_node_id/select_scan.h"
+
+#include <cstring>
+
+namespace graphflow {
+namespace processor {
+
+SelectScan::SelectScan(const ResultSet& inResultSet,
+    vector<pair<uint64_t, uint64_t>> valueVectorsPosToSelect, ExecutionContext& context,
+    uint32_t id)
+    : PhysicalOperator{SCAN, context, id}, inResultSet{inResultSet},
+      valueVectorsPosToSelect{move(valueVectorsPosToSelect)}, isFirstExecution{true} {
+    resultSet = make_shared<ResultSet>();
+    outDataChunk = make_shared<DataChunk>(DataChunkState::getSingleValueDataChunkState());
+    for (auto& [dataChunkPos, valueVectorPos] : this->valueVectorsPosToSelect) {
+        auto& inValueVector =
+            *this->inResultSet.dataChunks[dataChunkPos]->getValueVector(valueVectorPos);
+        shared_ptr<ValueVector> outValueVector;
+        if (inValueVector.dataType == NODE) {
+            // force decompression given single value;
+            auto compressionScheme =
+                NodeIDCompressionScheme(sizeof(label_t), sizeof(node_offset_t));
+            outValueVector = make_shared<NodeIDVector>(
+                compressionScheme, false /*isSequence*/, true /*isSingleValue*/);
+        } else {
+            outValueVector = make_shared<ValueVector>(
+                context.memoryManager, inValueVector.dataType, true /*isSingleValue*/);
+        }
+        outDataChunk->append(outValueVector);
+    }
+    resultSet->append(outDataChunk);
+}
+
+void SelectScan::reInitialize() {
+    isFirstExecution = true;
+}
+
+/**
+ * SelectScan assumes all input is flat. Thus, getNextTuples() should be called exactly twice. On
+ * the first call SelectScan copies in the flat input tuple. On the second call SelectScan
+ * terminates the execution.
+ */
+void SelectScan::getNextTuples() {
+    if (isFirstExecution) {
+        isFirstExecution = false;
+        for (auto i = 0u; i < this->valueVectorsPosToSelect.size(); ++i) {
+            auto dataChunkPos = valueVectorsPosToSelect[i].first;
+            auto valueVectorPos = valueVectorsPosToSelect[i].second;
+            auto& inValueVector =
+                *this->inResultSet.dataChunks[dataChunkPos]->getValueVector(valueVectorPos);
+            assert(inValueVector.state->isFlat());
+            auto pos = inValueVector.state->getPositionOfCurrIdx();
+            if (inValueVector.dataType == NODE) {
+                nodeID_t nodeId;
+                inValueVector.readNodeID(pos, nodeId);
+                // copy label
+                memcpy(&outDataChunk->valueVectors[i]->values[0], &nodeId.label, sizeof(label_t));
+                // copy offset
+                memcpy(&outDataChunk->valueVectors[i]->values[0] + sizeof(label_t), &nodeId.offset,
+                    sizeof(node_offset_t));
+            } else {
+                auto elementSize = TypeUtils::getDataTypeSize(inValueVector.dataType);
+                memcpy(&outDataChunk->valueVectors[i]->values[0],
+                    inValueVector.values + pos * elementSize, elementSize);
+            }
+        }
+        // We don't need to initialize original size because it is set to 1 in the constructor and
+        // never gets updated
+        outDataChunk->state->setSelectedSize(1);
+        outDataChunk->state->currIdx = 0;
+    } else {
+        outDataChunk->state->setSelectedSize(0);
+        outDataChunk->state->currIdx = -1;
+    }
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/physical_plan/operator/skip/skip.cpp
+++ b/src/processor/physical_plan/operator/skip/skip.cpp
@@ -13,6 +13,11 @@ Skip::Skip(uint64_t skipNumber, shared_ptr<atomic_uint64_t> counter, uint64_t da
     resultSet = this->prevOperator->getResultSet();
 }
 
+void Skip::reInitialize() {
+    PhysicalOperator::reInitialize();
+    FilteringOperator::reInitialize();
+}
+
 void Skip::getNextTuples() {
     metrics->executionTime.start();
     auto numTupleSkippedBefore = 0u;

--- a/src/processor/physical_plan/query_result.cpp
+++ b/src/processor/physical_plan/query_result.cpp
@@ -10,5 +10,12 @@ void QueryResult::appendQueryResult(unique_ptr<QueryResult> queryResult) {
     move(begin(queryResult->bufferBlocks), end(queryResult->bufferBlocks),
         back_inserter(bufferBlocks));
 }
+
+void QueryResult::clear() {
+    numTuples = 0;
+    resultSetCollection.clear();
+    bufferBlocks.clear();
+}
+
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/task_system/task.cpp
+++ b/src/processor/task_system/task.cpp
@@ -17,9 +17,7 @@ void Task::run() {
     if (pipelineSinkCopy == nullptr) {
         return;
     }
-    do {
-        pipelineSinkCopy->getNextTuples();
-    } while (pipelineSinkCopy->getResultSet()->getNumTuples() > 0);
+    ((Sink&)*pipelineSinkCopy).execute();
     deregisterThread(move(pipelineSinkCopy));
 }
 

--- a/test/processor/BUILD.bazel
+++ b/test/processor/BUILD.bazel
@@ -14,6 +14,7 @@ cc_test(
     ],
     deps = [
         "//src/processor",
+        "//src/storage:graph",
         "@gtest",
         "@gtest//:gtest_main",
     ],

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -20,6 +20,24 @@ cc_test(
 )
 
 cc_test(
+    name = "hard_code_plan_test",
+    srcs = [
+        "hard_code_plan_test.cpp",
+    ],
+    copts = [
+        "-Iexternal/gtest/include",
+    ],
+    data = [
+        "//dataset",
+    ],
+    deps = [
+        "//test/test_utility:test_helper",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "read_lists_end_to_end_test",
     srcs = [
         "read_lists_end_to_end_test.cpp",

--- a/test/runner/hard_code_plan_test.cpp
+++ b/test/runner/hard_code_plan_test.cpp
@@ -1,0 +1,249 @@
+#include "gtest/gtest.h"
+#include "test/test_utility/include/test_helper.h"
+
+#include "src/expression_evaluator/include/binary_expression_evaluator.h"
+#include "src/expression_evaluator/include/exist_subquery_evaluator.h"
+#include "src/expression_evaluator/include/unary_expression_evaluator.h"
+#include "src/processor/include/physical_plan/operator/filter/filter.h"
+#include "src/processor/include/physical_plan/operator/flatten/flatten.h"
+#include "src/processor/include/physical_plan/operator/read_list/adj_list_extend.h"
+#include "src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h"
+#include "src/processor/include/physical_plan/operator/scan_node_id/scan_node_id.h"
+#include "src/processor/include/physical_plan/operator/scan_node_id/select_scan.h"
+#include "src/processor/include/physical_plan/operator/sink/result_collector.h"
+
+using ::testing::Test;
+using namespace graphflow::testing;
+using namespace graphflow::evaluator;
+
+class TinySnbHardCodePlanTest : public DBLoadedTest {
+public:
+    void SetUp() override {
+        DBLoadedTest::SetUp();
+        profiler = make_unique<Profiler>();
+        memoryManager = make_unique<MemoryManager>();
+        context =
+            make_unique<ExecutionContext>(*profiler, nullptr /*transaction*/, memoryManager.get());
+        operatorId = 0;
+    }
+
+    static unique_ptr<Flatten> getSimpleScanAndFlatten(
+        ExecutionContext& context, uint32_t& operatorId) {
+        auto morselDesc = make_shared<MorselsDesc>(0, 8);
+        auto scan = make_unique<ScanNodeID>(morselDesc, context, operatorId++);
+        return make_unique<Flatten>(0, move(scan), context, operatorId++);
+    }
+
+    // person - knows -> person
+    static unique_ptr<ResultCollector> getSimpleKnowsExtendInnerQuery(
+        const ResultSet& outerResultSet, vector<pair<uint64_t, uint64_t>> vectorsToSelect,
+        const Graph& graph, ExecutionContext& context, uint32_t& operatorId) {
+        auto selectScan =
+            make_unique<SelectScan>(outerResultSet, move(vectorsToSelect), context, operatorId++);
+        auto extend = make_unique<AdjListExtend>(0, 0, graph.getRelsStore().getAdjLists(FWD, 0, 0),
+            0, move(selectScan), context, operatorId++);
+        auto innerResultCollector = make_unique<ResultCollector>(
+            move(extend), RESULT_COLLECTOR, context, operatorId++, false);
+        return innerResultCollector;
+    }
+
+    // person - studyAt/workAt -> org
+    static unique_ptr<ResultCollector> getSimpleStudyAtExtendInnerQuery(
+        const ResultSet& outerResultSet, vector<pair<uint64_t, uint64_t>> vectorsToSelect,
+        const Graph& graph, ExecutionContext& context, uint32_t& operatorId, label_t relLabel) {
+        auto selectScan =
+            make_unique<SelectScan>(outerResultSet, move(vectorsToSelect), context, operatorId++);
+        auto extend =
+            make_unique<AdjColumnExtend>(0, 0, graph.getRelsStore().getAdjColumn(FWD, 0, relLabel),
+                1, move(selectScan), context, operatorId++);
+        auto innerResultCollector = make_unique<ResultCollector>(
+            move(extend), RESULT_COLLECTOR, context, operatorId++, false);
+        return innerResultCollector;
+    }
+
+    static unique_ptr<ExpressionEvaluator> getNotExistEvaluator(
+        MemoryManager& memoryManager, unique_ptr<ResultCollector> sink) {
+        auto subqueryEvaluator = make_unique<ExistSubqueryEvaluator>(memoryManager, move(sink));
+        return make_unique<UnaryExpressionEvaluator>(
+            memoryManager, move(subqueryEvaluator), NOT, BOOL, true);
+    }
+
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+
+public:
+    unique_ptr<Profiler> profiler;
+    unique_ptr<MemoryManager> memoryManager;
+    unique_ptr<ExecutionContext> context;
+    uint32_t operatorId;
+};
+
+/**
+ * MATCH (a:person) WHERE EXISTS {
+ *          MATCH (a)-[:knows]->(:Person)
+ *          RETURN *
+ *      }
+ * RETURN COUNT(*)
+ * Plan: SCAN(a)->Flatten(a)->Filter(subPlan)->ResultCollector
+ * SubPlan: SelectScan()->ListExtend(b)->ResultCollector
+ */
+TEST_F(TinySnbHardCodePlanTest, SubqueryExistListTest) {
+    auto& graph = *defaultSystem->graph;
+
+    auto flatten = TinySnbHardCodePlanTest::getSimpleScanAndFlatten(*context, operatorId);
+    //--- start inner subquery
+    auto vectorsToSelect = vector<pair<uint64_t, uint64_t>>{{0, 0}};
+    auto innerResultCollector = TinySnbHardCodePlanTest::getSimpleKnowsExtendInnerQuery(
+        *flatten->getResultSet(), move(vectorsToSelect), graph, *context, operatorId);
+    //--- end inner subquery
+    auto subqueryEvaluator =
+        make_unique<ExistSubqueryEvaluator>(*memoryManager, move(innerResultCollector));
+    auto filter =
+        make_unique<Filter>(move(subqueryEvaluator), 0, move(flatten), *context, operatorId++);
+    auto resultCollector =
+        make_unique<ResultCollector>(move(filter), RESULT_COLLECTOR, *context, operatorId++, false);
+
+    resultCollector->execute();
+    ASSERT_TRUE(resultCollector->queryResult->numTuples == 5);
+}
+
+/**
+ * MATCH (a:person) WHERE NOT EXISTS {
+ *          MATCH (a)-[:knows]->(:Person)
+ *          RETURN *
+ *      }
+ * RETURN COUNT(*)
+ * Plan: SCAN(a)->Flatten(a)->Filter(subPlan)->ResultCollector
+ * SubPlan: SelectScan()->ListExtend(b)->ResultCollector
+ */
+TEST_F(TinySnbHardCodePlanTest, SubqueryNotExistListTest) {
+    auto& graph = *defaultSystem->graph;
+
+    auto flatten = TinySnbHardCodePlanTest::getSimpleScanAndFlatten(*context, operatorId);
+    //--- start inner subquery
+    auto vectorsToSelect = vector<pair<uint64_t, uint64_t>>{{0, 0}};
+    auto innerResultCollector = TinySnbHardCodePlanTest::getSimpleKnowsExtendInnerQuery(
+        *flatten->getResultSet(), move(vectorsToSelect), graph, *context, operatorId);
+    //--- end inner subquery
+    auto notEvaluator =
+        TinySnbHardCodePlanTest::getNotExistEvaluator(*memoryManager, move(innerResultCollector));
+    auto filter = make_unique<Filter>(move(notEvaluator), 0, move(flatten), *context, operatorId++);
+    auto resultCollector =
+        make_unique<ResultCollector>(move(filter), RESULT_COLLECTOR, *context, operatorId++, false);
+
+    resultCollector->execute();
+    ASSERT_TRUE(resultCollector->queryResult->numTuples == 3);
+}
+
+/**
+ * MATCH (a:person) WHERE NOT EXISTS {
+ *          MATCH (a)-[:studyAt]->(:Organisation)
+ *          RETURN *
+ *      }
+ * RETURN COUNT(*)
+ * Plan: SCAN(a)->Flatten(a)->Filter(subPlan)->ResultCollector
+ * SubPlan: SelectScan()->ColExtend(b)->ResultCollector
+ */
+TEST_F(TinySnbHardCodePlanTest, SubqueryExistColumnTest) {
+    auto& graph = *defaultSystem->graph;
+
+    auto flatten = TinySnbHardCodePlanTest::getSimpleScanAndFlatten(*context, operatorId);
+    //--- start inner subquery
+    auto vectorsToSelect = vector<pair<uint64_t, uint64_t>>{{0, 0}};
+    auto innerResultCollector = TinySnbHardCodePlanTest::getSimpleStudyAtExtendInnerQuery(
+        *flatten->getResultSet(), move(vectorsToSelect), graph, *context, operatorId, 1);
+    //--- end inner subquery
+    auto notEvaluator =
+        TinySnbHardCodePlanTest::getNotExistEvaluator(*memoryManager, move(innerResultCollector));
+    auto filter = make_unique<Filter>(move(notEvaluator), 0, move(flatten), *context, operatorId++);
+    auto resultCollector =
+        make_unique<ResultCollector>(move(filter), RESULT_COLLECTOR, *context, operatorId++, false);
+
+    resultCollector->execute();
+    ASSERT_TRUE(resultCollector->queryResult->numTuples == 5);
+}
+
+/**
+ * MATCH (a:person) WHERE EXISTS {
+ *          MATCH (a)-[:studyAt]->(:Organisation)
+ *      } OR EXISTS {
+ *          MATCH (a)-[:workAt]->(:Organisation)
+ *      }
+ * Plan: SCAN(a)->Flatten(a)->Filter(leftSubPlan OR rightSubPlan)->ResultCollector
+ * LeftSubPlan: SelectScan()->ColExtend(b)->ResultCollector
+ * RightSubPlan: SelectScan()->ColExtend(b)->ResultCollector
+ */
+TEST_F(TinySnbHardCodePlanTest, SubqueryExistColumnORTest) {
+    auto& graph = *defaultSystem->graph;
+
+    auto flatten = TinySnbHardCodePlanTest::getSimpleScanAndFlatten(*context, operatorId);
+    //--- start left inner subquery
+    auto leftVectorsToSelect = vector<pair<uint64_t, uint64_t>>{{0, 0}};
+    auto leftInnerResultCollector = TinySnbHardCodePlanTest::getSimpleStudyAtExtendInnerQuery(
+        *flatten->getResultSet(), move(leftVectorsToSelect), graph, *context, operatorId, 1);
+    //--- end left inner subquery
+    //--- start right inner subquery
+    auto rightVectorsToSelect = vector<pair<uint64_t, uint64_t>>{{0, 0}};
+    auto rightInnerResultCollector = TinySnbHardCodePlanTest::getSimpleStudyAtExtendInnerQuery(
+        *flatten->getResultSet(), move(rightVectorsToSelect), graph, *context, operatorId, 2);
+    //--- end right inner subquery
+    auto leftSubqueryEvaluator =
+        make_unique<ExistSubqueryEvaluator>(*memoryManager, move(leftInnerResultCollector));
+    auto rightSubqueryEvaluator =
+        make_unique<ExistSubqueryEvaluator>(*memoryManager, move(rightInnerResultCollector));
+    auto orEvaluator = make_unique<BinaryExpressionEvaluator>(
+        *memoryManager, move(leftSubqueryEvaluator), move(rightSubqueryEvaluator), OR, BOOL, true);
+    auto filter = make_unique<Filter>(move(orEvaluator), 0, move(flatten), *context, operatorId++);
+    auto resultCollector =
+        make_unique<ResultCollector>(move(filter), RESULT_COLLECTOR, *context, operatorId++, false);
+
+    resultCollector->execute();
+    ASSERT_TRUE(resultCollector->queryResult->numTuples == 6);
+}
+
+/**
+ * MATCH (a:person) WHERE EXISTS {
+ *          MATCH (a)-[:knows]->(b:Person) WHERE EXISTS {
+ *              MATCH (b)-[:worksAt]->(c:Organisation)
+ *              RETURN *
+ *          }
+ *          RETURN *
+ *      }
+ * RETURN COUNT(*)
+ * Plan: SCAN(a)->Flatten(a)->Filter(leftSubPlan OR rightSubPlan)->ResultCollector
+ * SubPlan: SelectScan(a)->ListExtend(b)->ResultCollector
+ * InnerSubPlan: SelectScan(b)->ColExtend(c)->ResultCollector
+ */
+TEST_F(TinySnbHardCodePlanTest, NestedSubqueryTest) {
+    auto& graph = *defaultSystem->graph;
+
+    auto flatten = TinySnbHardCodePlanTest::getSimpleScanAndFlatten(*context, operatorId);
+    //--- start inner subquery
+    auto innerVectorsToSelect = vector<pair<uint64_t, uint64_t>>{{0, 0}};
+    auto innerScan = make_unique<SelectScan>(
+        *flatten->getResultSet(), move(innerVectorsToSelect), *context, operatorId++);
+    auto innerExtend = make_unique<AdjListExtend>(0, 0, graph.getRelsStore().getAdjLists(FWD, 0, 0),
+        0, move(innerScan), *context, operatorId++);
+    auto innerFlatten = make_unique<Flatten>(1, move(innerExtend), *context, operatorId++);
+    //------ start inner inner subquery
+    auto innerInnerVectorsToSelect = vector<pair<uint64_t, uint64_t>>{{1, 0}};
+    auto innerInnerResultCollector =
+        TinySnbHardCodePlanTest::getSimpleStudyAtExtendInnerQuery(*innerFlatten->getResultSet(),
+            move(innerInnerVectorsToSelect), graph, *context, operatorId, 2);
+    //------ end inner inner subquery
+    auto innerSubqueryEvaluator =
+        make_unique<ExistSubqueryEvaluator>(*memoryManager, move(innerInnerResultCollector));
+    auto innerFilter = make_unique<Filter>(
+        move(innerSubqueryEvaluator), 1, move(innerFlatten), *context, operatorId++);
+    auto innerResultCollector = make_unique<ResultCollector>(
+        move(innerFilter), RESULT_COLLECTOR, *context, operatorId++, false);
+    //--- end inner subquery
+    auto subqueryEvaluator =
+        make_unique<ExistSubqueryEvaluator>(*memoryManager, move(innerResultCollector));
+    auto filter =
+        make_unique<Filter>(move(subqueryEvaluator), 0, move(flatten), *context, operatorId++);
+    auto resultCollector =
+        make_unique<ResultCollector>(move(filter), RESULT_COLLECTOR, *context, operatorId++, false);
+
+    resultCollector->execute();
+    ASSERT_TRUE(resultCollector->queryResult->numTuples == 4);
+}


### PR DESCRIPTION
This PR adds ExistSubqueryEvaluator and SelectScan operator

## General Subquery Design
Inner subquery takes n value vectors as input from outer query. These inputs must be flat. So we run the subquery once for each input tuple.

### ExistSubqueryEvaluator
Holds the last operator of a subplan. Each call of evaluate() return true if subplan has at least one tuple.  This evaluator does NOT evaluate unflat input.

### SelectScan
Takes a vector of flat value vector as input and put them in a single flat dataChunk which becomes the input of subquery. Because SelectScan assumes single tuple input, on the second call of getNextTuple(), it terminates the execution of subplan.