### PR TITLE
grammar&binder support for subquery

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -245,6 +245,7 @@ oC_Atom
         | oC_ParenthesizedExpression
         | ( COUNT SP? '(' SP? '*' SP? ')' )
         | oC_FunctionInvocation
+        | oC_ExistentialSubquery
         | oC_Variable
         ;
 
@@ -274,6 +275,11 @@ oC_FunctionInvocation
 
 oC_FunctionName
     : oC_SymbolicName ;
+
+oC_ExistentialSubquery
+    :  EXISTS SP? '{' SP? oC_RegularQuery SP? '}' ;
+
+EXISTS : ( 'E' | 'e' ) ( 'X' | 'x' ) ( 'I' | 'i' ) ( 'S' | 's' ) ( 'T' | 't' ) ( 'S' | 's' ) ;
 
 oC_PropertyLookup
     : '.' SP? ( oC_PropertyKeyName ) ;

--- a/src/binder/BUILD.bazel
+++ b/src/binder/BUILD.bazel
@@ -2,49 +2,41 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "binder",
-    srcs = [
-        "expression_binder.cpp",
-        "query_binder.cpp",
-    ],
-    hdrs = [
-        "include/expression_binder.h",
-        "include/query_binder.h",
-    ],
+    srcs = glob([
+        "*_binder.cpp",
+    ]),
+    hdrs = glob([
+        "include/*.h",
+    ]),
     visibility = ["//visibility:public"],
     deps = [
-        "bound_query",
+        "bound_queries",
         "//src/common:csv_reader",
-        "//src/parser",
+        "//src/parser:parsed_queries",
         "//src/storage:catalog",
     ],
 )
 
 cc_library(
-    name = "bound_query",
-    srcs = [
-        "bound_queries/bound_query_part.cpp",
-        "bound_queries/bound_single_query.cpp",
-    ],
-    hdrs = [
-        "include/bound_queries/bound_query_part.h",
-        "include/bound_queries/bound_single_query.h",
-    ],
+    name = "bound_queries",
+    srcs = glob([
+        "bound_queries/*.cpp",
+    ]),
+    hdrs = glob([
+        "include/bound_queries/*.h",
+    ]),
+    # Bound query is exposed to enumerator
     visibility = ["//visibility:public"],
     deps = [
-        "bound_statement",
+        "bound_statements",
     ],
 )
 
 cc_library(
-    name = "bound_statement",
-    hdrs = [
-        "include/bound_statements/bound_load_csv_statement.h",
-        "include/bound_statements/bound_match_statement.h",
-        "include/bound_statements/bound_projection_body.h",
-        "include/bound_statements/bound_reading_statement.h",
-        "include/bound_statements/bound_return_statement.h",
-        "include/bound_statements/bound_with_statement.h",
-    ],
+    name = "bound_statements",
+    hdrs = glob([
+        "include/bound_statements/*.h",
+    ]),
     deps = [
         "query_graph",
         "//src/common:statement_type",
@@ -53,12 +45,12 @@ cc_library(
 
 cc_library(
     name = "query_graph",
-    srcs = [
-        "query_graph/query_graph.cpp",
-    ],
-    hdrs = [
-        "include/query_graph/query_graph.h",
-    ],
+    srcs = glob([
+        "query_graph/*.cpp",
+    ]),
+    hdrs = glob([
+        "include/query_graph/*.h",
+    ]),
     deps = [
         "expression",
     ],
@@ -66,18 +58,13 @@ cc_library(
 
 cc_library(
     name = "expression",
-    srcs = [
-        "expression/expression.cpp",
-        "expression/literal_expression.cpp",
-    ],
-    hdrs = [
-        "include/expression/expression.h",
-        "include/expression/literal_expression.h",
-        "include/expression/node_expression.h",
-        "include/expression/property_expression.h",
-        "include/expression/rel_expression.h",
-        "include/expression/variable_expression.h",
-    ],
+    srcs = glob([
+        "expression/*.cpp",
+    ]),
+    hdrs = glob([
+        "include/expression/*.h",
+    ]),
+    # Expression is exposed to ExpressionMapper
     visibility = ["//visibility:public"],
     deps = [
         "//src/common:expression_type",

--- a/src/binder/include/binder_context.h
+++ b/src/binder/include/binder_context.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "src/binder/include/expression/expression.h"
+
+namespace graphflow {
+namespace binder {
+
+/**
+ * Binder context keeps the state of expression binder and query binder. When binding subquery, new
+ * binder objects should be created with binder context copied.
+ */
+class BinderContext {
+
+public:
+    BinderContext(uint32_t& lastVariableId) : variablesInScope{}, lastVariableId{lastVariableId} {}
+
+    BinderContext(const BinderContext& other)
+        : variablesInScope{other.variablesInScope}, lastVariableId{other.lastVariableId} {}
+
+    inline bool hasVariableInScope() const { return !variablesInScope.empty(); }
+    inline const unordered_map<string, shared_ptr<Expression>>& getVariablesInScope() const {
+        return variablesInScope;
+    }
+    inline void setVariablesInScope(
+        unordered_map<string, shared_ptr<Expression>> newVariablesInScope) {
+        variablesInScope = move(newVariablesInScope);
+    }
+    inline bool containsVariable(const string& variableName) const {
+        return variablesInScope.contains(variableName);
+    }
+    inline shared_ptr<Expression> getVariable(const string& variableName) const {
+        return variablesInScope.at(variableName);
+    }
+    inline void addVariable(const string& name, shared_ptr<Expression> variable) {
+        variablesInScope.insert({name, move(variable)});
+    }
+
+    inline string getUniqueVariableName(const string& name) {
+        return "_" + to_string(lastVariableId++) + "_" + name;
+    }
+
+private:
+    unordered_map<string, shared_ptr<Expression>> variablesInScope;
+    uint32_t& lastVariableId;
+};
+
+} // namespace binder
+} // namespace graphflow

--- a/src/binder/include/expression/existential_subquery_expression.h
+++ b/src/binder/include/expression/existential_subquery_expression.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "src/binder/include/expression/expression.h"
+
+namespace graphflow {
+namespace binder {
+
+class BoundSingleQuery;
+
+class ExistentialSubqueryExpression : public Expression {
+
+public:
+    ExistentialSubqueryExpression(unique_ptr<BoundSingleQuery> subquery)
+        : Expression{EXISTENTIAL_SUBQUERY, BOOL}, subquery{move(subquery)} {}
+
+    inline BoundSingleQuery* getSubquery() { return subquery.get(); };
+
+private:
+    unique_ptr<BoundSingleQuery> subquery;
+};
+
+} // namespace binder
+} // namespace graphflow

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -1,11 +1,10 @@
 #pragma once
 
-#include "src/binder/include/expression/expression.h"
+#include "src/binder/include/binder_context.h"
 #include "src/parser/include/parsed_expression.h"
 #include "src/storage/include/catalog.h"
 
 using namespace graphflow::parser;
-using namespace graphflow::binder;
 using namespace graphflow::storage;
 
 namespace graphflow {
@@ -14,9 +13,8 @@ namespace binder {
 class ExpressionBinder {
 
 public:
-    ExpressionBinder(
-        const Catalog& catalog, unordered_map<string, shared_ptr<Expression>>& variablesInScope)
-        : catalog{catalog}, variablesInScope{variablesInScope} {}
+    ExpressionBinder(const Catalog& catalog, const BinderContext& context)
+        : catalog{catalog}, context{context} {}
 
     shared_ptr<Expression> bindExpression(const ParsedExpression& parsedExpression);
 
@@ -52,6 +50,9 @@ private:
 
     shared_ptr<Expression> bindVariableExpression(const ParsedExpression& parsedExpression);
 
+    shared_ptr<Expression> bindExistentialSubqueryExpression(
+        const ParsedExpression& parsedExpression);
+
     /****** validation *****/
 
     // NOTE: this validation should be removed and front end binds any null operation to null
@@ -67,7 +68,7 @@ private:
 
 private:
     const Catalog& catalog;
-    unordered_map<string, shared_ptr<Expression>>& variablesInScope;
+    const BinderContext& context;
 };
 
 } // namespace binder

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -127,7 +127,7 @@ enum ExpressionType : uint8_t {
      */
     DATE_FUNC = 170,
 
-    EXIST_SUBQUERY = 190,
+    EXISTENTIAL_SUBQUERY = 190,
 };
 
 bool isExpressionUnary(ExpressionType type);

--- a/src/expression_evaluator/existential_subquery_evaluator.cpp
+++ b/src/expression_evaluator/existential_subquery_evaluator.cpp
@@ -1,27 +1,27 @@
-#include "src/expression_evaluator/include/exist_subquery_evaluator.h"
+#include "src/expression_evaluator/include/existential_subquery_evaluator.h"
 
 namespace graphflow {
 namespace evaluator {
 
-ExistSubqueryEvaluator::ExistSubqueryEvaluator(
+ExistentialSubqueryEvaluator::ExistentialSubqueryEvaluator(
     MemoryManager& memoryManager, unique_ptr<ResultCollector> subPlanResultCollector)
-    : ExpressionEvaluator{EXIST_SUBQUERY, BOOL}, subPlanResultCollector{
-                                                     move(subPlanResultCollector)} {
+    : ExpressionEvaluator{EXISTENTIAL_SUBQUERY, BOOL}, subPlanResultCollector{
+                                                           move(subPlanResultCollector)} {
     result = make_shared<ValueVector>(&memoryManager, BOOL, true /* isSingleValue */);
     result->state = DataChunkState::getSingleValueDataChunkState();
 }
 
-void ExistSubqueryEvaluator::executeSubplan() {
+void ExistentialSubqueryEvaluator::executeSubplan() {
     subPlanResultCollector->reInitialize();
     subPlanResultCollector->execute();
 }
 
-void ExistSubqueryEvaluator::evaluate() {
+void ExistentialSubqueryEvaluator::evaluate() {
     executeSubplan();
     result->values[0] = subPlanResultCollector->queryResult->numTuples != 0;
 }
 
-uint64_t ExistSubqueryEvaluator::select(sel_t* selectedPositions) {
+uint64_t ExistentialSubqueryEvaluator::select(sel_t* selectedPositions) {
     executeSubplan();
     return subPlanResultCollector->queryResult->numTuples != 0;
 }

--- a/src/expression_evaluator/include/existential_subquery_evaluator.h
+++ b/src/expression_evaluator/include/existential_subquery_evaluator.h
@@ -9,10 +9,10 @@ using namespace graphflow::processor;
 namespace graphflow {
 namespace evaluator {
 
-class ExistSubqueryEvaluator : public ExpressionEvaluator {
+class ExistentialSubqueryEvaluator : public ExpressionEvaluator {
 
 public:
-    ExistSubqueryEvaluator(
+    ExistentialSubqueryEvaluator(
         MemoryManager& memoryManager, unique_ptr<ResultCollector> subPlanResultCollector);
 
     void executeSubplan();

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -3,68 +3,67 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "parser",
     srcs = [
-        "antlr_parser/graphflow_cypher_parser.cpp",
-        "antlr_parser/parser_error_listener.cpp",
-        "antlr_parser/parser_error_strategy.cpp",
         "parser.cpp",
         "transformer.cpp",
     ],
     hdrs = [
-        "include/antlr_parser/graphflow_cypher_parser.h",
-        "include/antlr_parser/parser_error_listener.h",
-        "include/antlr_parser/parser_error_strategy.h",
         "include/parser.h",
         "include/transformer.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "queries",
+        "antlr_parser",
+        "parsed_queries",
+    ],
+)
+
+cc_library(
+    name = "antlr_parser",
+    srcs = glob([
+        "antlr_parser/*.cpp",
+    ]),
+    hdrs = glob([
+        "include/antlr_parser/*.h",
+    ]),
+    deps = [
         "//src/antlr4:cypher_grammar_lib",
-        "//src/common:expression_type",
         "//src/common:utils",
     ],
 )
 
 cc_library(
-    name = "queries",
-    hdrs = [
-        "include/queries/query_part.h",
-        "include/queries/single_query.h",
-    ],
+    name = "parsed_queries",
+    hdrs = glob([
+        "include/queries/*.h",
+    ]),
+    # Parsed queries is exposed to binder
+    visibility = ["//visibility:public"],
     deps = [
-        "statements",
+        "parsed_statements",
     ],
 )
 
 cc_library(
-    name = "statements",
-    hdrs = [
-        "include/statements/load_csv_statement.h",
-        "include/statements/match_statement.h",
-        "include/statements/projection_body.h",
-        "include/statements/reading_statement.h",
-        "include/statements/return_statement.h",
-        "include/statements/with_statement.h",
-    ],
+    name = "parsed_statements",
+    hdrs = glob([
+        "include/statements/*.h",
+    ]),
     deps = [
-        "expressions",
-        "patterns",
+        "graph_patterns",
+        "parsed_expression",
         "//src/common:statement_type",
     ],
 )
 
 cc_library(
-    name = "patterns",
-    hdrs = [
-        "include/patterns/node_pattern.h",
-        "include/patterns/pattern_element.h",
-        "include/patterns/pattern_element_chain.h",
-        "include/patterns/rel_pattern.h",
-    ],
+    name = "graph_patterns",
+    hdrs = glob([
+        "include/patterns/*.h",
+    ]),
 )
 
 cc_library(
-    name = "expressions",
+    name = "parsed_expression",
     hdrs = [
         "include/parsed_expression.h",
     ],

--- a/src/parser/include/parsed_expression.h
+++ b/src/parser/include/parsed_expression.h
@@ -12,11 +12,16 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace parser {
 
+class SingleQuery;
+
 class ParsedExpression {
 
 public:
     ParsedExpression(ExpressionType type, string text, string rawExpression)
         : type{type}, text{move(text)}, rawExpression{move(rawExpression)} {}
+
+    ParsedExpression(ExpressionType type, unique_ptr<SingleQuery> subquery, string rawExpression)
+        : type{type}, subquery{move(subquery)}, rawExpression{move(rawExpression)} {};
 
     ParsedExpression(ExpressionType type, string text, string rawExpression,
         unique_ptr<ParsedExpression> left, unique_ptr<ParsedExpression> right)
@@ -29,6 +34,8 @@ public:
     ExpressionType type;
     // variableName, propertyName or functionName
     string text;
+    // existential subquery
+    unique_ptr<SingleQuery> subquery;
     string alias;
     string rawExpression;
     vector<unique_ptr<ParsedExpression>> children;

--- a/src/parser/include/transformer.h
+++ b/src/parser/include/transformer.h
@@ -130,6 +130,9 @@ private:
 
     string transformFunctionName(CypherParser::OC_FunctionNameContext& ctx);
 
+    unique_ptr<ParsedExpression> transformExistentialSubquery(
+        CypherParser::OC_ExistentialSubqueryContext& ctx);
+
     string transformPropertyLookup(CypherParser::OC_PropertyLookupContext& ctx);
 
     string transformVariable(CypherParser::OC_VariableContext& ctx);

--- a/src/parser/transformer.cpp
+++ b/src/parser/transformer.cpp
@@ -474,6 +474,8 @@ unique_ptr<ParsedExpression> Transformer::transformAtom(CypherParser::OC_AtomCon
         return transformParenthesizedExpression(*ctx.oC_ParenthesizedExpression());
     } else if (ctx.oC_FunctionInvocation()) {
         return transformFunctionInvocation(*ctx.oC_FunctionInvocation());
+    } else if (ctx.oC_ExistentialSubquery()) {
+        return transformExistentialSubquery(*ctx.oC_ExistentialSubquery());
     } else if (ctx.oC_Variable()) {
         return make_unique<ParsedExpression>(
             VARIABLE, transformVariable(*ctx.oC_Variable()), ctx.getText());
@@ -525,6 +527,12 @@ unique_ptr<ParsedExpression> Transformer::transformFunctionInvocation(
 
 string Transformer::transformFunctionName(CypherParser::OC_FunctionNameContext& ctx) {
     return transformSymbolicName(*ctx.oC_SymbolicName());
+}
+
+unique_ptr<ParsedExpression> Transformer::transformExistentialSubquery(
+    CypherParser::OC_ExistentialSubqueryContext& ctx) {
+    return make_unique<ParsedExpression>(
+        EXISTENTIAL_SUBQUERY, transformRegularQuery(*ctx.oC_RegularQuery()), ctx.getText());
 }
 
 string Transformer::transformPropertyLookup(CypherParser::OC_PropertyLookupContext& ctx) {

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -13,7 +13,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "logical_plan",
-        "//src/binder:bound_query",
+        "//src/binder:bound_queries",
         "//src/storage:graph",
     ],
 )

--- a/test/binder/BUILD.bazel
+++ b/test/binder/BUILD.bazel
@@ -15,10 +15,9 @@ cc_library(
 
 cc_test(
     name = "binder_test",
-    srcs = [
-        "binder_error_test.cpp",
-        "binder_test.cpp",
-    ],
+    srcs = glob([
+        "*_test.cpp",
+    ]),
     data = [
         "//dataset",
     ],

--- a/test/binder/binder_test_utils.cpp
+++ b/test/binder/binder_test_utils.cpp
@@ -27,7 +27,10 @@ bool BinderTestUtils::equals(const Expression& left, const Expression& right) {
             return false;
         }
     }
-    if (PROPERTY == left.expressionType) {
+    if (EXISTENTIAL_SUBQUERY == left.expressionType) {
+        throw invalid_argument(
+            "Equal comparison of ExistentialSubqueryExpression is not implemented.");
+    } else if (PROPERTY == left.expressionType) {
         return equals((PropertyExpression&)left, (PropertyExpression&)right);
     } else if (VARIABLE == left.expressionType) {
         if (NODE == left.dataType) {

--- a/test/parser/BUILD.bazel
+++ b/test/parser/BUILD.bazel
@@ -14,13 +14,10 @@ cc_library(
 )
 
 cc_test(
-    name = "parser_tests",
-    srcs = [
-        "expression_test.cpp",
-        "reading_clause_test.cpp",
-        "return_with_test.cpp",
-        "syntax_error_test.cpp",
-    ],
+    name = "parser_test",
+    srcs = glob([
+        "*_test.cpp",
+    ]),
     linkstatic = 1,
     deps = [
         "parser_test_utils",

--- a/test/parser/parser_test_utils.cpp
+++ b/test/parser/parser_test_utils.cpp
@@ -49,6 +49,47 @@ bool ParserTestUtils::equals(const ParsedExpression& left, const ParsedExpressio
     return true;
 }
 
+bool ParserTestUtils::equals(const SingleQuery& left, const SingleQuery& right) {
+    auto result = left.queryParts.size() == right.queryParts.size() &&
+                  left.readingStatements.size() == right.readingStatements.size() &&
+                  equals(*left.returnStatement, *right.returnStatement);
+    if (!result)
+        return false;
+    for (auto i = 0u; i < left.queryParts.size(); ++i) {
+        if (!equals(*left.queryParts[i], *right.queryParts[i])) {
+            return false;
+        }
+    }
+    for (auto i = 0u; i < left.readingStatements.size(); ++i) {
+        if (!equals(*left.readingStatements[i], *right.readingStatements[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ParserTestUtils::equals(const QueryPart& left, const QueryPart& right) {
+    auto result = left.readingStatements.size() == right.readingStatements.size() &&
+                  equals(*left.withStatement, *right.withStatement);
+    if (!result)
+        return false;
+    for (auto i = 0u; i < left.readingStatements.size(); ++i) {
+        if (!equals(*left.readingStatements[i], *right.readingStatements[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool ParserTestUtils::equals(const ReadingStatement& left, const ReadingStatement& right) {
+    auto result = left.statementType == right.statementType;
+    if (!result)
+        return false;
+    return left.statementType == MATCH_STATEMENT ?
+               equals((MatchStatement&)left, (MatchStatement&)right) :
+               equals((LoadCSVStatement&)left, (LoadCSVStatement&)right);
+}
+
 bool ParserTestUtils::equals(const ProjectionBody& left, const ProjectionBody& right) {
     auto result = left.isProjectStar() == right.isProjectStar() &&
                   equals(left.getProjectionExpressions(), right.getProjectionExpressions());

--- a/test/parser/parser_test_utils.h
+++ b/test/parser/parser_test_utils.h
@@ -16,6 +16,9 @@ public:
     static bool equals(const ParsedExpression& left, const ParsedExpression& right);
 
 private:
+    static bool equals(const SingleQuery& left, const SingleQuery& right);
+    static bool equals(const QueryPart& left, const QueryPart& right);
+    static bool equals(const ReadingStatement& left, const ReadingStatement& right);
     static bool equals(const ProjectionBody& left, const ProjectionBody& right);
     static bool equals(const vector<unique_ptr<ParsedExpression>>& left,
         const vector<unique_ptr<ParsedExpression>>& right);

--- a/test/parser/subquery_test.cpp
+++ b/test/parser/subquery_test.cpp
@@ -1,0 +1,60 @@
+#include "gtest/gtest.h"
+#include "test/parser/parser_test_utils.h"
+
+#include "src/parser/include/parser.h"
+
+using namespace graphflow::parser;
+
+class SubqueryTest : public ::testing::Test {
+
+public:
+    static unique_ptr<MatchStatement> makeEmptyMatchStatement() {
+        auto expectNode = make_unique<NodePattern>(string(), string());
+        auto expectPElements = vector<unique_ptr<PatternElement>>();
+        expectPElements.emplace_back(make_unique<PatternElement>(move(expectNode)));
+        return make_unique<MatchStatement>(move(expectPElements));
+    }
+
+    static unique_ptr<ReturnStatement> makeReturnStarStatement() {
+        auto expressions = vector<unique_ptr<ParsedExpression>>();
+        return make_unique<ReturnStatement>(make_unique<ProjectionBody>(true, move(expressions)));
+    }
+};
+
+TEST_F(SubqueryTest, ExistsTest) {
+    auto innerQuery = make_unique<SingleQuery>();
+    innerQuery->readingStatements.push_back(makeEmptyMatchStatement());
+    innerQuery->returnStatement = makeReturnStarStatement();
+
+    auto existentialExpression =
+        make_unique<ParsedExpression>(EXISTENTIAL_SUBQUERY, move(innerQuery), EMPTY);
+    auto expectedExpression = make_unique<ParsedExpression>(NOT, EMPTY, EMPTY);
+    expectedExpression->children.push_back(move(existentialExpression));
+
+    string input = "MATCH () WHERE NOT EXISTS { MATCH () RETURN * } RETURN COUNT(*);";
+    auto singleQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*singleQuery->readingStatements[0];
+    ASSERT_TRUE(ParserTestUtils::equals(*expectedExpression, *matchStatement.whereClause));
+}
+
+TEST_F(SubqueryTest, NestedExistsTest) {
+    auto secondInnerQuery = make_unique<SingleQuery>();
+    secondInnerQuery->readingStatements.push_back(makeEmptyMatchStatement());
+    secondInnerQuery->returnStatement = makeReturnStarStatement();
+
+    auto innerQuery = make_unique<SingleQuery>();
+    auto match = makeEmptyMatchStatement();
+    match->whereClause =
+        make_unique<ParsedExpression>(EXISTENTIAL_SUBQUERY, move(secondInnerQuery), EMPTY);
+    innerQuery->readingStatements.push_back(move(match));
+    innerQuery->returnStatement = makeReturnStarStatement();
+
+    auto expectedExpression =
+        make_unique<ParsedExpression>(EXISTENTIAL_SUBQUERY, move(innerQuery), EMPTY);
+
+    string input = "MATCH () WHERE EXISTS { MATCH () WHERE EXISTS { MATCH () RETURN * } RETURN "
+                   "* } RETURN COUNT(*);";
+    auto singleQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*singleQuery->readingStatements[0];
+    ASSERT_TRUE(ParserTestUtils::equals(*expectedExpression, *matchStatement.whereClause));
+}

--- a/test/planner/optimizer/BUILD.bazel
+++ b/test/planner/optimizer/BUILD.bazel
@@ -5,9 +5,6 @@ cc_test(
     srcs = [
         "optimizer_test.cpp",
     ],
-    data = [
-        "//dataset",
-    ],
     deps = [
         "//src/binder",
         "//src/parser",


### PR DESCRIPTION
This PR add parser and binder logic for subquery. Both logics are recursive since subquery should be parsed and bind in the same way as any query.

## Parser Change
ParsedExpression gets an extra field `unique_ptr<SingleQuery> subquery` because expression can have type `EXIST_SUBQUERY`.

## Binder Change 
Wrap binder states in class `BinderContext` so that the logic of copying state when creating new binder object is more clear.