### PR TITLE
Refactor build files to avoid circular dependency of subquery expression. 

### DIFF
--- a/src/binder/BUILD.bazel
+++ b/src/binder/BUILD.bazel
@@ -11,6 +11,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "bound_queries",
+        "subquery_expression_impl",
         "//src/common:csv_reader",
         "//src/parser:parsed_queries",
         "//src/storage:catalog",
@@ -52,22 +53,51 @@ cc_library(
         "include/query_graph/*.h",
     ]),
     deps = [
-        "expression",
+        "expression_impls",
     ],
 )
 
 cc_library(
-    name = "expression",
-    srcs = glob([
-        "expression/*.cpp",
-    ]),
-    hdrs = glob([
-        "include/expression/*.h",
-    ]),
-    # Expression is exposed to ExpressionMapper
+    name = "base_expression",
+    srcs = [
+        "expression/expression.cpp",
+    ],
+    hdrs = [
+        "include/expression/expression.h",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/common:expression_type",
         "//src/common:types",
+    ],
+)
+
+cc_library(
+    name = "expression_impls",
+    srcs = [
+        "expression/literal_expression.cpp",
+    ],
+    hdrs = [
+        "include/expression/literal_expression.h",
+        "include/expression/node_expression.h",
+        "include/expression/property_expression.h",
+        "include/expression/rel_expression.h",
+        "include/expression/variable_expression.h",
+    ],
+    deps = [
+        "base_expression",
+    ],
+)
+
+cc_library(
+    name = "subquery_expression_impl",
+    hdrs = [
+        "include/expression/existential_subquery_expression.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "base_expression",
+        "bound_queries",
+        "//src/planner:logical_plan",
     ],
 )

--- a/src/binder/include/expression/existential_subquery_expression.h
+++ b/src/binder/include/expression/existential_subquery_expression.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include "src/binder/include/bound_queries/bound_single_query.h"
 #include "src/binder/include/expression/expression.h"
+#include "src/planner/include/logical_plan/logical_plan.h"
 
 namespace graphflow {
 namespace binder {
-
-class BoundSingleQuery;
 
 class ExistentialSubqueryExpression : public Expression {
 

--- a/src/expression_evaluator/BUILD.bazel
+++ b/src/expression_evaluator/BUILD.bazel
@@ -1,17 +1,36 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
-    name = "expression_evaluator",
-    srcs = glob([
-        "*.cpp",
-    ]),
-    hdrs = glob([
-        "include/*.h",
-    ]),
+    name = "base_evaluator",
+    srcs = [
+        "expression_evaluator.cpp",
+    ],
+    hdrs = [
+        "include/expression_evaluator.h",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/common:data_chunk",
         "//src/common:vector_operations",
-        "//src/processor:result_collector",
+        "//src/processor:result_set",
+    ],
+)
+
+cc_library(
+    name = "evaluator_impls",
+    srcs = [
+        "binary_expression_evaluator.cpp",
+        "existential_subquery_evaluator.cpp",
+        "unary_expression_evaluator.cpp",
+    ],
+    hdrs = [
+        "include/binary_expression_evaluator.h",
+        "include/existential_subquery_evaluator.h",
+        "include/unary_expression_evaluator.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "base_evaluator",
+        "//src/processor:operator_impls",
     ],
 )

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -166,5 +166,18 @@ bool ExpressionEvaluator::isResultFlat() {
     return true;
 }
 
+unique_ptr<ExpressionEvaluator> ExpressionEvaluator::clone(
+    MemoryManager& memoryManager, const ResultSet& resultSet) {
+    if (isExpressionLiteral(expressionType)) {
+        return make_unique<ExpressionEvaluator>(result, expressionType);
+    } else {
+        // property expression evaluator clone
+        assert(childrenExpr.empty());
+        return make_unique<ExpressionEvaluator>(
+            resultSet.dataChunks[dataChunkPos]->getValueVector(valueVectorPos), dataChunkPos,
+            valueVectorPos, expressionType);
+    }
+}
+
 } // namespace evaluator
 } // namespace graphflow

--- a/src/expression_evaluator/include/binary_expression_evaluator.h
+++ b/src/expression_evaluator/include/binary_expression_evaluator.h
@@ -13,12 +13,15 @@ class BinaryExpressionEvaluator : public ExpressionEvaluator {
 public:
     BinaryExpressionEvaluator(MemoryManager& memoryManager,
         unique_ptr<ExpressionEvaluator> leftExpr, unique_ptr<ExpressionEvaluator> rightExpr,
-        ExpressionType expressionType, DataType dataType, bool isSelectOperation);
+        ExpressionType expressionType, DataType dataType);
 
     void evaluate() override;
     uint64_t select(sel_t* selectedPositions) override;
 
     shared_ptr<ValueVector> createResultValueVector(MemoryManager& memoryManager);
+
+    unique_ptr<ExpressionEvaluator> clone(
+        MemoryManager& memoryManager, const ResultSet& resultSet) override;
 
 private:
     function<void(ValueVector&, ValueVector&, ValueVector&)> executeOperation;

--- a/src/expression_evaluator/include/existential_subquery_evaluator.h
+++ b/src/expression_evaluator/include/existential_subquery_evaluator.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "src/expression_evaluator/include/expression_evaluator.h"
-#include "src/processor/include/physical_plan/operator/scan_node_id/select_scan.h"
 #include "src/processor/include/physical_plan/operator/sink/result_collector.h"
 
 using namespace graphflow::processor;
@@ -15,10 +14,13 @@ public:
     ExistentialSubqueryEvaluator(
         MemoryManager& memoryManager, unique_ptr<ResultCollector> subPlanResultCollector);
 
-    void executeSubplan();
+    uint64_t executeSubplan();
 
     void evaluate() override;
     uint64_t select(sel_t* selectedPositions) override;
+
+    unique_ptr<ExpressionEvaluator> clone(
+        MemoryManager& memoryManager, const ResultSet& resultSet) override;
 
 private:
     unique_ptr<ResultCollector> subPlanResultCollector;

--- a/src/expression_evaluator/include/expression_evaluator.h
+++ b/src/expression_evaluator/include/expression_evaluator.h
@@ -7,7 +7,9 @@
 #include "src/common/include/expression_type.h"
 #include "src/common/include/value.h"
 #include "src/common/include/vector/value_vector.h"
+#include "src/processor/include/physical_plan/operator/result/result_set.h"
 
+using namespace graphflow::processor;
 using namespace graphflow::common;
 
 namespace graphflow {
@@ -27,16 +29,15 @@ public:
         ExpressionType type);
 
     // Creates a leaf literal as value vector expression_evaluator expression.
-    ExpressionEvaluator(MemoryManager& memoryManager, const shared_ptr<ValueVector>& result,
-        ExpressionType expressionType)
+    ExpressionEvaluator(const shared_ptr<ValueVector>& result, ExpressionType expressionType)
         : result{result}, dataChunkPos{UINT64_MAX}, valueVectorPos{UINT64_MAX},
-          expressionType{expressionType}, dataType(result->dataType) {}
+          expressionType{expressionType}, dataType{result->dataType} {}
 
     // Creates a leaf variable value vector expression_evaluator expression.
-    ExpressionEvaluator(MemoryManager& memoryManager, const shared_ptr<ValueVector>& result,
-        uint64_t dataChunkPos, uint64_t valueVectorPos, ExpressionType expressionType)
+    ExpressionEvaluator(const shared_ptr<ValueVector>& result, uint64_t dataChunkPos,
+        uint64_t valueVectorPos, ExpressionType expressionType)
         : result{result}, dataChunkPos{dataChunkPos}, valueVectorPos{valueVectorPos},
-          expressionType{expressionType}, dataType(result->dataType) {}
+          expressionType{expressionType}, dataType{result->dataType} {}
 
     virtual ~ExpressionEvaluator() = default;
 
@@ -48,17 +49,14 @@ public:
 
     bool isResultFlat();
 
-    inline uint32_t getNumChildrenExpr() const { return childrenExpr.size(); }
-
-    inline const ExpressionEvaluator& getChildExpr(uint64_t pos) const {
-        return *childrenExpr[pos];
-    }
+    virtual unique_ptr<ExpressionEvaluator> clone(
+        MemoryManager& memoryManager, const ResultSet& resultSet);
 
 public:
     shared_ptr<ValueVector> result;
     uint64_t dataChunkPos;
     uint64_t valueVectorPos;
-    // expression type is needed to clone unary and binary expressions.
+    // Fields below are needed to clone expressions.
     ExpressionType expressionType;
     DataType dataType;
 

--- a/src/expression_evaluator/include/unary_expression_evaluator.h
+++ b/src/expression_evaluator/include/unary_expression_evaluator.h
@@ -10,13 +10,16 @@ class UnaryExpressionEvaluator : public ExpressionEvaluator {
 
 public:
     UnaryExpressionEvaluator(MemoryManager& memoryManager, unique_ptr<ExpressionEvaluator> child,
-        ExpressionType expressionType, DataType dataType, bool isSelectOperation);
+        ExpressionType expressionType, DataType dataType);
 
     void evaluate() override;
 
     uint64_t select(sel_t* selectedPositions) override;
 
     shared_ptr<ValueVector> createResultValueVector(MemoryManager& memoryManager);
+
+    unique_ptr<ExpressionEvaluator> clone(
+        MemoryManager& memoryManager, const ResultSet& resultSet) override;
 
 protected:
     function<void(ValueVector&, ValueVector&)> executeOperation;

--- a/src/main/BUILD.bazel
+++ b/src/main/BUILD.bazel
@@ -6,14 +6,15 @@ cc_library(
         "plan_printer.cpp",
     ],
     hdrs = [
+        "include/plan_printer.h",
         "include/session_context.h",
-        "include/plan_printer.h"
     ],
     deps = [
-        "//src/transaction:transaction",
         "//src/common:profiler",
         "//src/planner:logical_plan",
-        "//src/processor:physical_plan"
+        "//src/processor:operator_impls",
+        "//src/processor:physical_plan",
+        "//src/transaction",
     ],
 )
 
@@ -27,18 +28,19 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "session_context",
         "//src/binder",
         "//src/parser",
         "//src/planner:enumerator",
         "//src/processor",
-        "session_context",
+        "//src/processor:mapper",
     ],
 )
 
 cc_library(
     name = "session",
     srcs = [
-        "session.cpp"
+        "session.cpp",
     ],
     hdrs = [
         "include/session.h",

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -2,64 +2,54 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "enumerator",
-    srcs = [
-        "enumerator.cpp",
-        "subplans_table.cpp",
-    ],
-    hdrs = [
-        "include/enumerator.h",
-        "include/subplans_table.h",
-    ],
+    srcs = glob([
+        "*.cpp",
+    ]),
+    hdrs = glob([
+        "include/*.h",
+    ]),
     visibility = ["//visibility:public"],
     deps = [
+        "logical_operator_impls",
         "logical_plan",
         "//src/binder:bound_queries",
+        "//src/binder:subquery_expression_impl",
         "//src/storage:graph",
     ],
 )
 
 cc_library(
     name = "logical_plan",
-    srcs = [
-        "logical_plan/logical_plan.cpp",
-    ],
-    hdrs = [
-        "include/logical_plan/logical_plan.h",
-        "include/logical_plan/operator/crud/logical_crud_node.h",
-        "include/logical_plan/operator/extend/logical_extend.h",
-        "include/logical_plan/operator/filter/logical_filter.h",
-        "include/logical_plan/operator/flatten/logical_flatten.h",
-        "include/logical_plan/operator/hash_join/logical_hash_join.h",
-        "include/logical_plan/operator/intersect/logical_intersect.h",
-        "include/logical_plan/operator/limit/logical_limit.h",
-        "include/logical_plan/operator/load_csv/logical_load_csv.h",
-        "include/logical_plan/operator/logical_operator.h",
-        "include/logical_plan/operator/multiplicity_reducer/logical_multiplcity_reducer.h",
-        "include/logical_plan/operator/projection/logical_projection.h",
-        "include/logical_plan/operator/scan_node_id/logical_scan_node_id.h",
-        "include/logical_plan/operator/scan_property/logical_scan_node_property.h",
-        "include/logical_plan/operator/scan_property/logical_scan_rel_property.h",
-        "include/logical_plan/operator/skip/logical_skip.h",
-    ],
+    srcs = glob([
+        "logical_plan/*.cpp",
+    ]),
+    hdrs = glob([
+        "include/logical_plan/*.h",
+    ]),
     visibility = ["//visibility:public"],
     deps = [
-        "schema",
-        "//src/binder:expression",
+        "base_logical_operator",
     ],
 )
 
 cc_library(
-    name = "schema",
-    srcs = [
-        "logical_plan/schema.cpp",
-    ],
+    name = "base_logical_operator",
     hdrs = [
-        "include/logical_plan/schema.h",
-    ],
-    visibility = [
-        "//visibility:public",
+        "include/logical_plan/operator/logical_operator.h",
     ],
     deps = [
-        "//src/common:utils",
+        "//src/common:types",
+    ],
+)
+
+cc_library(
+    name = "logical_operator_impls",
+    hdrs = glob([
+        "include/logical_plan/operator/**/logical_*.h",
+    ]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "base_logical_operator",
+        "//src/binder:base_expression",
     ],
 )

--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -1,5 +1,6 @@
 #include "src/planner/include/enumerator.h"
 
+#include "src/binder/include/expression/existential_subquery_expression.h"
 #include "src/planner/include/logical_plan/operator/extend/logical_extend.h"
 #include "src/planner/include/logical_plan/operator/filter/logical_filter.h"
 #include "src/planner/include/logical_plan/operator/flatten/logical_flatten.h"

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -12,9 +12,58 @@ cc_library(
 )
 
 cc_library(
-    name = "operators",
+    name = "mapper",
     srcs = [
         "physical_plan/expression_mapper.cpp",
+        "physical_plan/operator/physical_operator_info.cpp",
+        "physical_plan/plan_mapper.cpp",
+    ],
+    hdrs = [
+        "include/physical_plan/expression_mapper.h",
+        "include/physical_plan/operator/physical_operator_info.h",
+        "include/physical_plan/plan_mapper.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "operator_impls",
+        "physical_plan",
+        "//src/binder:subquery_expression_impl",
+        "//src/expression_evaluator:evaluator_impls",
+        "//src/planner:logical_operator_impls",
+        "//src/planner:logical_plan",
+        "//src/storage:graph",
+    ],
+)
+
+cc_library(
+    name = "physical_plan",
+    hdrs = [
+        "include/physical_plan/physical_plan.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "base_operator",
+    ],
+)
+
+cc_library(
+    name = "base_operator",
+    srcs = [
+        "physical_plan/operator/physical_operator.cpp",
+    ],
+    hdrs = [
+        "include/physical_plan/operator/physical_operator.h",
+    ],
+    deps = [
+        "execution_context",
+        "result_set",
+    ],
+)
+
+# TODO: compile sink impls separately so that evaluator_impls & processor only depends on sink impls
+cc_library(
+    name = "operator_impls",
+    srcs = [
         "physical_plan/operator/crud/create_node.cpp",
         "physical_plan/operator/crud/crud.cpp",
         "physical_plan/operator/crud/delete_node.cpp",
@@ -27,8 +76,6 @@ cc_library(
         "physical_plan/operator/limit/limit.cpp",
         "physical_plan/operator/load_csv/load_csv.cpp",
         "physical_plan/operator/multiplicity_reducer/multiplicity_reducer.cpp",
-        "physical_plan/operator/physical_operator.cpp",
-        "physical_plan/operator/physical_operator_info.cpp",
         "physical_plan/operator/projection/projection.cpp",
         "physical_plan/operator/read_list/adj_list_extend.cpp",
         "physical_plan/operator/read_list/frontier/frontier_bag.cpp",
@@ -42,11 +89,12 @@ cc_library(
         "physical_plan/operator/scan_attribute/scan_structured_property.cpp",
         "physical_plan/operator/scan_attribute/scan_unstructured_property.cpp",
         "physical_plan/operator/scan_node_id/scan_node_id.cpp",
+        "physical_plan/operator/scan_node_id/select_scan.cpp",
+        "physical_plan/operator/sink/result_collector.cpp",
         "physical_plan/operator/skip/skip.cpp",
         "physical_plan/query_result.cpp",
     ],
     hdrs = [
-        "include/physical_plan/expression_mapper.h",
         "include/physical_plan/operator/crud/create_node.h",
         "include/physical_plan/operator/crud/crud.h",
         "include/physical_plan/operator/crud/crud_node.h",
@@ -61,8 +109,6 @@ cc_library(
         "include/physical_plan/operator/limit/limit.h",
         "include/physical_plan/operator/load_csv/load_csv.h",
         "include/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.h",
-        "include/physical_plan/operator/physical_operator.h",
-        "include/physical_plan/operator/physical_operator_info.h",
         "include/physical_plan/operator/projection/projection.h",
         "include/physical_plan/operator/read_list/adj_list_extend.h",
         "include/physical_plan/operator/read_list/frontier/frontier.h",
@@ -78,6 +124,7 @@ cc_library(
         "include/physical_plan/operator/scan_attribute/scan_unstructured_property.h",
         "include/physical_plan/operator/scan_node_id/scan_node_id.h",
         "include/physical_plan/operator/scan_node_id/select_scan.h",
+        "include/physical_plan/operator/sink/result_collector.h",
         "include/physical_plan/operator/sink/sink.h",
         "include/physical_plan/operator/skip/skip.h",
         "include/physical_plan/query_result.h",
@@ -85,36 +132,9 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "execution_context",
-        "result_set",
-        "//src/binder:expression",
+        "base_operator",
         "//src/common:csv_reader",
-        "//src/common:memory_manager",
-        "//src/expression_evaluator",
-        "//src/planner:schema",
-        "//src/storage:graph",
-        "//src/transaction",
-    ],
-)
-
-cc_library(
-    name = "result_collector",
-    srcs = [
-        "physical_plan/operator/scan_node_id/select_scan.cpp",
-        "physical_plan/operator/sink/result_collector.cpp",
-        "physical_plan/query_result.cpp",
-    ],
-    hdrs = [
-        "include/physical_plan/operator/physical_operator.h",
-        "include/physical_plan/operator/scan_node_id/select_scan.h",
-        "include/physical_plan/operator/sink/result_collector.h",
-        "include/physical_plan/operator/sink/sink.h",
-        "include/physical_plan/query_result.h",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "execution_context",
-        "result_set",
+        "//src/expression_evaluator:base_evaluator",
     ],
 )
 
@@ -137,23 +157,6 @@ cc_library(
 )
 
 cc_library(
-    name = "physical_plan",
-    srcs = [
-        "physical_plan/plan_mapper.cpp",
-    ],
-    hdrs = [
-        "include/physical_plan/physical_plan.h",
-        "include/physical_plan/plan_mapper.h",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "operators",
-        "result_collector",
-        "//src/planner:logical_plan",
-    ],
-)
-
-cc_library(
     name = "processor",
     srcs = [
         "processor.cpp",
@@ -167,6 +170,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "operator_impls",
         "physical_plan",
     ],
 )

--- a/src/processor/include/physical_plan/expression_mapper.h
+++ b/src/processor/include/physical_plan/expression_mapper.h
@@ -16,15 +16,12 @@ class ExpressionMapper {
 public:
     static unique_ptr<ExpressionEvaluator> mapToPhysical(MemoryManager& memoryManager,
         const Expression& expression, PhysicalOperatorsInfo& physicalOperatorInfo,
-        ResultSet& resultSet, bool isSelectOperation);
-
-    static unique_ptr<ExpressionEvaluator> clone(MemoryManager& memoryManager,
-        const ExpressionEvaluator& expression, ResultSet& resultSet, bool isSelectOperation);
+        ResultSet& resultSet);
 
 private:
     static unique_ptr<ExpressionEvaluator> mapChildExpressionAndCastToUnstructuredIfNecessary(
         MemoryManager& memoryManager, const Expression& expression, bool castToUnstructured,
-        PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet, bool isSelectOperation);
+        PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet& resultSet);
 };
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/filter/filter.cpp
+++ b/src/processor/physical_plan/operator/filter/filter.cpp
@@ -1,7 +1,5 @@
 #include "src/processor/include/physical_plan/operator/filter/filter.h"
 
-#include "src/processor/include/physical_plan/expression_mapper.h"
-
 namespace graphflow {
 namespace processor {
 
@@ -47,10 +45,9 @@ void Filter::getNextTuples() {
 
 unique_ptr<PhysicalOperator> Filter::clone() {
     auto prevOperatorClone = prevOperator->clone();
-    auto rootExprClone = ExpressionMapper::clone(*context.memoryManager, *rootExpr,
-        *prevOperatorClone->getResultSet(), true /* isSelectOperation */);
     return make_unique<Filter>(
-        move(rootExprClone), dataChunkToSelectPos, move(prevOperatorClone), context, id);
+        rootExpr->clone(*context.memoryManager, *prevOperatorClone->getResultSet()),
+        dataChunkToSelectPos, move(prevOperatorClone), context, id);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/projection/projection.cpp
+++ b/src/processor/physical_plan/operator/projection/projection.cpp
@@ -1,7 +1,5 @@
 #include "src/processor/include/physical_plan/operator/projection/projection.h"
 
-#include "src/processor/include/physical_plan/expression_mapper.h"
-
 namespace graphflow {
 namespace processor {
 
@@ -58,9 +56,9 @@ void Projection::getNextTuples() {
 unique_ptr<PhysicalOperator> Projection::clone() {
     auto prevOperatorClone = prevOperator->clone();
     vector<unique_ptr<ExpressionEvaluator>> rootExpressionsCloned;
-    for (auto& expr : expressions) {
-        rootExpressionsCloned.push_back(ExpressionMapper::clone(*context.memoryManager, *expr,
-            *prevOperatorClone->getResultSet(), false /*isSelectOperation*/));
+    for (auto& expression : expressions) {
+        rootExpressionsCloned.push_back(
+            expression->clone(*context.memoryManager, *prevOperatorClone->getResultSet()));
     }
     return make_unique<Projection>(move(rootExpressionsCloned), expressionPosToDataChunkPos,
         discardedDataChunkPos, move(prevOperatorClone), context, id);

--- a/src/processor/physical_plan/plan_mapper.cpp
+++ b/src/processor/physical_plan/plan_mapper.cpp
@@ -157,8 +157,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFilterToPhysical(
     auto& logicalFilter = (const LogicalFilter&)*logicalOperator;
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->prevOperator, info, context);
     auto dataChunkToSelectPos = logicalFilter.groupPosToSelect;
-    auto physicalRootExpr = ExpressionMapper::mapToPhysical(*context.memoryManager,
-        *logicalFilter.expression, info, *prevOperator->getResultSet(), true /*isSelectOperation*/);
+    auto physicalRootExpr = ExpressionMapper::mapToPhysical(
+        *context.memoryManager, *logicalFilter.expression, info, *prevOperator->getResultSet());
     return make_unique<Filter>(move(physicalRootExpr), dataChunkToSelectPos, move(prevOperator),
         context, physicalOperatorID++);
 }
@@ -184,8 +184,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalProjectionToPhysical(
         mapLogicalOperatorToPhysical(logicalOperator->prevOperator, oldInfo, context);
     vector<unique_ptr<ExpressionEvaluator>> expressionEvaluators;
     for (auto& expression : logicalProjection.expressionsToProject) {
-        expressionEvaluators.push_back(ExpressionMapper::mapToPhysical(*context.memoryManager,
-            *expression, oldInfo, *prevOperator->getResultSet(), false /*isSelectOperation*/));
+        expressionEvaluators.push_back(ExpressionMapper::mapToPhysical(
+            *context.memoryManager, *expression, oldInfo, *prevOperator->getResultSet()));
     }
     // TODO: fix uint32 and uint64 mixed usage
     vector<uint64_t> exprResultInDataChunkPos;

--- a/test/processor/BUILD.bazel
+++ b/test/processor/BUILD.bazel
@@ -14,6 +14,7 @@ cc_test(
     ],
     deps = [
         "//src/processor",
+        "//src/processor:mapper",
         "//src/storage:graph",
         "@gtest",
         "@gtest//:gtest_main",

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -36,8 +36,8 @@ TEST(ExpressionTests, BinaryExpressionEvaluatorTest) {
     auto resultSet = ResultSet();
     resultSet.append(dataChunk);
 
-    auto rootExpressionEvaluator = ExpressionMapper::mapToPhysical(*memoryManager,
-        *addLogicalOperator, physicalOperatorInfo, resultSet, false /*isSelectOperation*/);
+    auto rootExpressionEvaluator = ExpressionMapper::mapToPhysical(
+        *memoryManager, *addLogicalOperator, physicalOperatorInfo, resultSet);
     rootExpressionEvaluator->evaluate();
 
     auto results = (int64_t*)rootExpressionEvaluator->result->values;
@@ -75,8 +75,8 @@ TEST(ExpressionTests, UnaryExpressionEvaluatorTest) {
     auto resultSet = ResultSet();
     resultSet.append(dataChunk);
 
-    auto rootExpressionEvaluator = ExpressionMapper::mapToPhysical(*memoryManager,
-        *negateLogicalOperator, physicalOperatorInfo, resultSet, false /*isSelectOperation*/);
+    auto rootExpressionEvaluator = ExpressionMapper::mapToPhysical(
+        *memoryManager, *negateLogicalOperator, physicalOperatorInfo, resultSet);
     rootExpressionEvaluator->evaluate();
 
     auto results = (int64_t*)rootExpressionEvaluator->result->values;

--- a/test/runner/BUILD.bazel
+++ b/test/runner/BUILD.bazel
@@ -50,6 +50,7 @@ cc_test(
         "//dataset",
     ],
     deps = [
+        "//src/expression_evaluator:evaluator_impls",
         "//test/test_utility:test_helper",
         "@gtest",
         "@gtest//:gtest_main",

--- a/test/runner/hard_code_plan_test.cpp
+++ b/test/runner/hard_code_plan_test.cpp
@@ -66,7 +66,7 @@ public:
         auto subqueryEvaluator =
             make_unique<ExistentialSubqueryEvaluator>(memoryManager, move(sink));
         return make_unique<UnaryExpressionEvaluator>(
-            memoryManager, move(subqueryEvaluator), NOT, BOOL, true);
+            memoryManager, move(subqueryEvaluator), NOT, BOOL);
     }
 
     string getInputCSVDir() override { return "dataset/tinysnb/"; }
@@ -192,7 +192,7 @@ TEST_F(TinySnbHardCodePlanTest, SubqueryExistColumnORTest) {
     auto rightSubqueryEvaluator =
         make_unique<ExistentialSubqueryEvaluator>(*memoryManager, move(rightInnerResultCollector));
     auto orEvaluator = make_unique<BinaryExpressionEvaluator>(
-        *memoryManager, move(leftSubqueryEvaluator), move(rightSubqueryEvaluator), OR, BOOL, true);
+        *memoryManager, move(leftSubqueryEvaluator), move(rightSubqueryEvaluator), OR, BOOL);
     auto filter = make_unique<Filter>(move(orEvaluator), 0, move(flatten), *context, operatorId++);
     auto resultCollector =
         make_unique<ResultCollector>(move(filter), RESULT_COLLECTOR, *context, operatorId++, false);


### PR DESCRIPTION
This PR refactor bazel build files to solve circular dependency introduced by subquery expression/evaluator.

### Circular dependency
Consider the case for expression_evaluator lib and physical_operator lib. 
- Expression_evaluator depends on physical_operator because subquery_evaluator requires the last operator of its subplan
- Physical_operator depends on expression_evaluator because filter/projection requires expression_evaluator
- In such case, bazel does know which lib to compile first.

### Solution
We create subquery_evaluator as its own lib. The updated dependency becomes
-  Physical_operator depends on expression_evaluator because filter/projection requires expression_evaluator
-  Subquery_evaluator depends on expression_evaluator
-  Subquery_evaluator depends on physical_operator
-  Compiling order becomes 
   -  expression_evaluator
   -  physical_operator
   -  subquery_evaluator
 
Same solution is applied to subquery_expression and logical_plan

### Additional change
Move clone() method from expression_mapper to expression_evaluator to decouple physical_operator and expression_mapper.
We used to compile physical_operator and expression_mapper together due to the clone() function. However, expression_mapper has to depend on subquery_evaluator while physical_operator can NOT depen on subquery_evaluator. So this decouple is needed.