### PR TITLE
fix over-large writes in writeToFile()

### DIFF
--- a/src/common/include/file_utils.h
+++ b/src/common/include/file_utils.h
@@ -24,8 +24,9 @@ public:
     static void closeFile(int fd);
 
     static unique_ptr<uint8_t[]> readFile(FileInfo* fileInfo);
-    static void readFromFile(FileInfo* fileInfo, void* buffer, int64_t numBytes, uint64_t position);
-    static void writeToFile(FileInfo* fileInfo, void* buffer, int64_t numBytes, uint64_t offset);
+    static void readFromFile(
+        FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position);
+    static void writeToFile(FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t offset);
 
     static void createDir(const string& dir);
     static void removeDir(const string& dir);

--- a/src/loader/in_mem_pages.cpp
+++ b/src/loader/in_mem_pages.cpp
@@ -14,7 +14,7 @@ void InMemPages::saveToFile() {
         throw invalid_argument("InMemPages: Empty filename");
     }
     auto fileInfo = FileUtils::openFile(fName, O_WRONLY | O_CREAT);
-    auto size = numPages << PAGE_SIZE_LOG_2;
+    uint64_t size = numPages << PAGE_SIZE_LOG_2;
     FileUtils::writeToFile(fileInfo.get(), data.get(), size, 0);
     FileUtils::closeFile(fileInfo->fd);
 }


### PR DESCRIPTION
Over-large writes will cause error when writing the file due to overflow (pwrite's `count` should be no greater than `SSIZE_MAX`, which is 32 bits) or partially write (On Linux, `write()` will transfer at most `0x7ffff000` (`2,147,479,552`) bytes).
In this PR, we split the write in `writeToFile()` to at most 1GB at a time, which is the same as our readFile, and large enough to get good io performance.