### PR TITLE
add aggregation function and aggreate expression evaluator

### DIFF
--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -52,6 +52,11 @@ bool isExpressionLiteral(ExpressionType type) {
            LITERAL_BOOLEAN == type || LITERAL_DATE == type || LITERAL_NULL == type;
 }
 
+bool isExpressionAggregate(ExpressionType type) {
+    return COUNT_STAR_FUNC == type || COUNT_FUNC == type || SUM_FUNC == type || AVG_FUNC == type ||
+           MIN_FUNC == type || MAX_FUNC == type;
+}
+
 ExpressionType comparisonToIDComparison(ExpressionType type) {
     switch (type) {
     case EQUALS:

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -116,6 +116,11 @@ enum ExpressionType : uint8_t {
      * Aggregation Function Expression
      */
     COUNT_STAR_FUNC = 130,
+    COUNT_FUNC = 131,
+    SUM_FUNC = 132,
+    AVG_FUNC = 133,
+    MIN_FUNC = 134,
+    MAX_FUNC = 135,
 
     /**
      * Scalar Function Expression
@@ -139,6 +144,7 @@ bool isExpressionArithmetic(ExpressionType type);
 bool isExpressionStringOperator(ExpressionType type);
 bool isExpressionNullComparison(ExpressionType type);
 bool isExpressionLiteral(ExpressionType type);
+bool isExpressionAggregate(ExpressionType type);
 
 ExpressionType comparisonToIDComparison(ExpressionType type);
 string expressionTypeToString(ExpressionType type);

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -206,7 +206,7 @@ inline void NotEquals::operation(const nodeID_t& left, const nodeID_t& right, ui
  *******************************************************/
 
 struct CompareValues {
-    template<class FUNC = function<uint8_t(Value, Value)>>
+    template<class FUNC = std::function<uint8_t(Value, Value)>>
     static inline void operation(const Value& left, const Value& right, uint8_t& result) {
         if (left.dataType == right.dataType) {
             switch (left.dataType) {

--- a/src/common/include/value.h
+++ b/src/common/include/value.h
@@ -13,6 +13,8 @@ namespace common {
 
 class Value {
 public:
+    Value() = default;
+
     Value(const Value& value) { *this = value; }
 
     explicit Value(DataType dataType) : dataType(dataType) {}

--- a/src/expression_evaluator/BUILD.bazel
+++ b/src/expression_evaluator/BUILD.bazel
@@ -19,11 +19,13 @@ cc_library(
 cc_library(
     name = "evaluator_impls",
     srcs = [
+        "aggregate_expression_evaluator.cpp",
         "binary_expression_evaluator.cpp",
         "existential_subquery_evaluator.cpp",
         "unary_expression_evaluator.cpp",
     ],
     hdrs = [
+        "include/aggregate_expression_evaluator.h",
         "include/binary_expression_evaluator.h",
         "include/existential_subquery_evaluator.h",
         "include/unary_expression_evaluator.h",
@@ -31,6 +33,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "base_evaluator",
+        "//src/function:aggregation_function",
         "//src/processor:operator_impls",
     ],
 )

--- a/src/expression_evaluator/aggregate_expression_evaluator.cpp
+++ b/src/expression_evaluator/aggregate_expression_evaluator.cpp
@@ -1,0 +1,146 @@
+#include "src/expression_evaluator/include/aggregate_expression_evaluator.h"
+
+#include "src/function/include/aggregation/avg.h"
+#include "src/function/include/aggregation/count.h"
+#include "src/function/include/aggregation/min_max.h"
+#include "src/function/include/aggregation/sum.h"
+
+namespace graphflow {
+namespace evaluator {
+
+unique_ptr<AggregationFunction> AggregateExpressionEvaluator::getAggregationFunction(
+    ExpressionType expressionType, DataType dataType) {
+    switch (expressionType) {
+    case COUNT_STAR_FUNC:
+        return getCountStarFunction();
+    case COUNT_FUNC:
+        return getCountFunction();
+    case SUM_FUNC:
+        return getSumFunction(dataType);
+    case AVG_FUNC:
+        return getAvgFunction(dataType);
+    case MIN_FUNC:
+        return getMinMaxFunction<true /* IS_MIN */>(dataType);
+    case MAX_FUNC:
+        return getMinMaxFunction<false /* IS_MIN */>(dataType);
+    default:
+        throw invalid_argument("Function not supported for now.");
+    }
+}
+
+unique_ptr<AggregationFunction> AggregateExpressionEvaluator::getCountStarFunction() {
+    return make_unique<AggregationFunction>(CountFunction<true /* IS_COUNT_STAR */>::initialize,
+        CountFunction<true /* IS_COUNT_STAR */>::update,
+        CountFunction<true /* IS_COUNT_STAR */>::combine,
+        CountFunction<true /* IS_COUNT_STAR */>::finalize);
+}
+
+unique_ptr<AggregationFunction> AggregateExpressionEvaluator::getCountFunction() {
+    return make_unique<AggregationFunction>(CountFunction<false /* IS_COUNT_STAR */>::initialize,
+        CountFunction<false /* IS_COUNT_STAR */>::update,
+        CountFunction<false /* IS_COUNT_STAR */>::combine,
+        CountFunction<false /* IS_COUNT_STAR */>::finalize);
+}
+
+unique_ptr<AggregationFunction> AggregateExpressionEvaluator::getAvgFunction(DataType dataType) {
+    switch (dataType) {
+    case INT64:
+        return make_unique<AggregationFunction>(AvgFunction<uint64_t>::initialize,
+            AvgFunction<uint64_t>::update, AvgFunction<uint64_t>::combine,
+            AvgFunction<uint64_t>::finalize);
+    case DOUBLE:
+        return make_unique<AggregationFunction>(AvgFunction<double_t>::initialize,
+            AvgFunction<double_t>::update, AvgFunction<double_t>::combine,
+            AvgFunction<double_t>::finalize);
+    default:
+        throw invalid_argument("Data type " + DataTypeNames[dataType] + " not supported for AVG.");
+    }
+}
+
+unique_ptr<AggregationFunction> AggregateExpressionEvaluator::getSumFunction(DataType dataType) {
+    switch (dataType) {
+    case INT64:
+        return make_unique<AggregationFunction>(SumFunction<uint64_t>::initialize,
+            SumFunction<uint64_t>::update, SumFunction<uint64_t>::combine,
+            SumFunction<uint64_t>::finalize);
+    case DOUBLE:
+        return make_unique<AggregationFunction>(SumFunction<double_t>::initialize,
+            SumFunction<double_t>::update, SumFunction<double_t>::combine,
+            SumFunction<double_t>::finalize);
+    case UNSTRUCTURED:
+        return make_unique<AggregationFunction>(SumFunction<Value>::initialize,
+            SumFunction<Value>::update, SumFunction<Value>::combine, SumFunction<Value>::finalize);
+    default:
+        throw invalid_argument("Data type " + DataTypeNames[dataType] + " not supported for SUM.");
+    }
+}
+
+template<bool IS_MIN>
+unique_ptr<AggregationFunction> AggregateExpressionEvaluator::getMinMaxFunction(DataType dataType) {
+    if constexpr (IS_MIN) {
+        switch (dataType) {
+        case INT64:
+            return make_unique<AggregationFunction>(MinMaxFunction<int64_t>::initialize,
+                MinMaxFunction<int64_t>::update<LessThan>,
+                MinMaxFunction<int64_t>::combine<LessThan>, MinMaxFunction<int64_t>::finalize);
+        case DOUBLE:
+            return make_unique<AggregationFunction>(MinMaxFunction<double_t>::initialize,
+                MinMaxFunction<double_t>::update<LessThan>,
+                MinMaxFunction<double_t>::combine<LessThan>, MinMaxFunction<double_t>::finalize);
+        case DATE:
+            return make_unique<AggregationFunction>(MinMaxFunction<date_t>::initialize,
+                MinMaxFunction<date_t>::update<LessThan>, MinMaxFunction<date_t>::combine<LessThan>,
+                MinMaxFunction<date_t>::finalize);
+        case STRING:
+            return make_unique<AggregationFunction>(MinMaxFunction<gf_string_t>::initialize,
+                MinMaxFunction<gf_string_t>::update<LessThan>,
+                MinMaxFunction<gf_string_t>::combine<LessThan>,
+                MinMaxFunction<gf_string_t>::finalize);
+        case NODE:
+            return make_unique<AggregationFunction>(MinMaxFunction<nodeID_t>::initialize,
+                MinMaxFunction<nodeID_t>::update<LessThan>,
+                MinMaxFunction<nodeID_t>::combine<LessThan>, MinMaxFunction<nodeID_t>::finalize);
+        case UNSTRUCTURED:
+            return make_unique<AggregationFunction>(MinMaxFunction<Value>::initialize,
+                MinMaxFunction<Value>::update<LessThan>, MinMaxFunction<Value>::combine<LessThan>,
+                MinMaxFunction<Value>::finalize);
+        default:
+            throw invalid_argument(
+                "Data type " + DataTypeNames[dataType] + " not supported for MIN.");
+        }
+    } else {
+        switch (dataType) {
+        case INT64:
+            return make_unique<AggregationFunction>(MinMaxFunction<int64_t>::initialize,
+                MinMaxFunction<int64_t>::update<GreaterThan>,
+                MinMaxFunction<int64_t>::combine<GreaterThan>, MinMaxFunction<int64_t>::finalize);
+        case DOUBLE:
+            return make_unique<AggregationFunction>(MinMaxFunction<double_t>::initialize,
+                MinMaxFunction<double_t>::update<GreaterThan>,
+                MinMaxFunction<double_t>::combine<GreaterThan>, MinMaxFunction<double_t>::finalize);
+        case DATE:
+            return make_unique<AggregationFunction>(MinMaxFunction<date_t>::initialize,
+                MinMaxFunction<date_t>::update<GreaterThan>,
+                MinMaxFunction<date_t>::combine<GreaterThan>, MinMaxFunction<date_t>::finalize);
+        case STRING:
+            return make_unique<AggregationFunction>(MinMaxFunction<gf_string_t>::initialize,
+                MinMaxFunction<gf_string_t>::update<GreaterThan>,
+                MinMaxFunction<gf_string_t>::combine<GreaterThan>,
+                MinMaxFunction<gf_string_t>::finalize);
+        case NODE:
+            return make_unique<AggregationFunction>(MinMaxFunction<nodeID_t>::initialize,
+                MinMaxFunction<nodeID_t>::update<GreaterThan>,
+                MinMaxFunction<nodeID_t>::combine<GreaterThan>, MinMaxFunction<nodeID_t>::finalize);
+        case UNSTRUCTURED:
+            return make_unique<AggregationFunction>(MinMaxFunction<Value>::initialize,
+                MinMaxFunction<Value>::update<GreaterThan>,
+                MinMaxFunction<Value>::combine<GreaterThan>, MinMaxFunction<Value>::finalize);
+        default:
+            throw invalid_argument(
+                "Data type " + DataTypeNames[dataType] + " not supported for MAX.");
+        }
+    }
+}
+
+} // namespace evaluator
+} // namespace graphflow

--- a/src/expression_evaluator/include/aggregate_expression_evaluator.h
+++ b/src/expression_evaluator/include/aggregate_expression_evaluator.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "src/expression_evaluator/include/expression_evaluator.h"
+#include "src/function/include/aggregation/aggregation_function.h"
+
+using namespace graphflow::function;
+
+namespace graphflow {
+namespace evaluator {
+
+class AggregateExpressionEvaluator : public ExpressionEvaluator {
+
+public:
+    static unique_ptr<AggregationFunction> getAggregationFunction(
+        ExpressionType expressionType, DataType dataType);
+
+public:
+    AggregateExpressionEvaluator(ExpressionType expressionType, DataType dataType,
+        unique_ptr<AggregationFunction> aggrFunction)
+        : ExpressionEvaluator(expressionType, dataType), aggrFunction{move(aggrFunction)} {}
+
+    AggregateExpressionEvaluator(ExpressionType expressionType, DataType dataType,
+        unique_ptr<ExpressionEvaluator> child, unique_ptr<AggregationFunction> aggrFunction)
+        : ExpressionEvaluator(expressionType, dataType), aggrFunction{move(aggrFunction)} {
+        childrenExpr.push_back(move(child));
+    }
+
+    unique_ptr<ExpressionEvaluator> clone(
+        MemoryManager& memoryManager, const ResultSet& resultSet) override {
+        return nullptr;
+    }
+
+    uint64_t select(sel_t* selectedPositions) override { return 0; }
+
+    inline AggregationFunction* getFunction() { return aggrFunction.get(); }
+
+private:
+    static unique_ptr<AggregationFunction> getCountStarFunction();
+    static unique_ptr<AggregationFunction> getCountFunction();
+    static unique_ptr<AggregationFunction> getAvgFunction(DataType dataType);
+    static unique_ptr<AggregationFunction> getSumFunction(DataType dataType);
+    template<bool IS_MIN>
+    static unique_ptr<AggregationFunction> getMinMaxFunction(DataType dataType);
+
+    unique_ptr<AggregationFunction> aggrFunction;
+};
+} // namespace evaluator
+} // namespace graphflow

--- a/src/expression_evaluator/include/binary_expression_evaluator.h
+++ b/src/expression_evaluator/include/binary_expression_evaluator.h
@@ -24,8 +24,8 @@ public:
         MemoryManager& memoryManager, const ResultSet& resultSet) override;
 
 private:
-    function<void(ValueVector&, ValueVector&, ValueVector&)> executeOperation;
-    function<uint64_t(ValueVector&, ValueVector&, sel_t*)> selectOperation;
+    std::function<void(ValueVector&, ValueVector&, ValueVector&)> executeOperation;
+    std::function<uint64_t(ValueVector&, ValueVector&, sel_t*)> selectOperation;
 };
 
 } // namespace evaluator

--- a/src/expression_evaluator/include/unary_expression_evaluator.h
+++ b/src/expression_evaluator/include/unary_expression_evaluator.h
@@ -22,8 +22,8 @@ public:
         MemoryManager& memoryManager, const ResultSet& resultSet) override;
 
 protected:
-    function<void(ValueVector&, ValueVector&)> executeOperation;
-    function<uint64_t(ValueVector&, sel_t*)> selectOperation;
+    std::function<void(ValueVector&, ValueVector&)> executeOperation;
+    std::function<uint64_t(ValueVector&, sel_t*)> selectOperation;
 };
 
 } // namespace evaluator

--- a/src/function/BUILD.bazel
+++ b/src/function/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "aggregation_function",
+    srcs = [
+    ],
+    hdrs = glob(["include/aggregation/*.h"]),
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/common:expression_type",
+        "//src/common:types",
+        "//src/common:vector",
+    ],
+)

--- a/src/function/include/aggregation/aggregation_function.h
+++ b/src/function/include/aggregation/aggregation_function.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <functional>
+#include <utility>
+
+#include "src/common/include/types.h"
+#include "src/common/include/vector/value_vector.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+
+typedef void (*aggr_initialize_function_t)(uint8_t* state);
+typedef void (*aggr_update_function_t)(uint8_t* state, ValueVector* input, uint64_t count);
+typedef void (*aggr_combine_function_t)(uint8_t* state, uint8_t* otherState);
+typedef void (*aggr_finalize_function_t)(uint8_t* inputState, uint8_t* finalState);
+
+template<typename T>
+struct AggregationState {
+    T val;
+};
+
+class AggregationFunction {
+
+public:
+    AggregationFunction(aggr_initialize_function_t initializeFunc,
+        aggr_update_function_t updateFunc, aggr_combine_function_t combineFunc,
+        aggr_finalize_function_t finalizeFunc)
+        : initializeFunc{initializeFunc}, updateFunc{updateFunc}, combineFunc{combineFunc},
+          finalizeFunc{finalizeFunc} {}
+
+    inline void initialize(uint8_t* state) { initializeFunc(state); }
+    inline void update(uint8_t* state, ValueVector* input, uint64_t count) {
+        updateFunc(state, input, count);
+    }
+    inline void combine(uint8_t* state, uint8_t* otherState) { combineFunc(state, otherState); }
+    inline void finalize(uint8_t* inputState, uint8_t* finalState) {
+        finalizeFunc(inputState, finalState);
+    }
+
+private:
+    aggr_initialize_function_t initializeFunc;
+    aggr_update_function_t updateFunc;
+    aggr_combine_function_t combineFunc;
+    aggr_finalize_function_t finalizeFunc;
+};
+} // namespace function
+} // namespace graphflow

--- a/src/function/include/aggregation/avg.h
+++ b/src/function/include/aggregation/avg.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "src/common/include/operations/arithmetic_operations.h"
+#include "src/function/include/aggregation/aggregation_function.h"
+
+using namespace graphflow::common::operation;
+
+namespace graphflow {
+namespace function {
+
+template<typename T>
+struct AvgFunction {
+
+    struct AvgState : public AggregationState<T> {
+        uint64_t numValues;
+        bool isSet;
+    };
+
+    static void initialize(uint8_t* state_) {
+        auto state = reinterpret_cast<AvgState*>(state_);
+        state->numValues = 0;
+        state->isSet = false;
+    }
+
+    static void update(uint8_t* state_, ValueVector* input, uint64_t count) {
+        assert(input && count == input->state->selectedSize);
+        auto state = reinterpret_cast<AvgState*>(state_);
+        auto inputValues = (T*)input->values;
+        if (input->hasNoNullsGuarantee()) {
+            for (auto i = 0u; i < count; i++) {
+                if (!state->isSet) {
+                    state->val = inputValues[input->state->selectedPositions[i]];
+                    state->isSet = true;
+                } else {
+                    Add::template operation<T, T, T>(
+                        state->val, inputValues[input->state->selectedPositions[i]], state->val);
+                }
+            }
+            state->numValues += count;
+        } else {
+            for (auto i = 0u; i < count; i++) {
+                auto pos = input->state->selectedPositions[i];
+                if (!input->isNull(pos)) {
+                    if (!state->isSet) {
+                        state->val = inputValues[input->state->selectedPositions[i]];
+                        state->isSet = true;
+                    } else {
+                        Add::template operation<T, T, T>(state->val,
+                            inputValues[input->state->selectedPositions[i]], state->val);
+                    }
+                    state->numValues++;
+                }
+            }
+        }
+    }
+
+    static void combine(uint8_t* state_, uint8_t* otherState_) {
+        auto state = reinterpret_cast<AvgState*>(state_);
+        auto otherState = reinterpret_cast<AvgState*>(otherState_);
+        Add::template operation<T, T, T>(state->val, otherState->val, state->val);
+        state->numValues += otherState->numValues;
+    }
+
+    static void finalize(uint8_t* inputState_, uint8_t* finalState_) {
+        auto inputState = reinterpret_cast<AvgState*>(inputState_);
+        auto finalState = reinterpret_cast<AvgFunction<double_t>::AvgState*>(finalState_);
+        finalState->val = (double_t)inputState->val / (double_t)inputState->numValues;
+    }
+};
+
+} // namespace function
+} // namespace graphflow

--- a/src/function/include/aggregation/count.h
+++ b/src/function/include/aggregation/count.h
@@ -1,0 +1,48 @@
+#pragma once
+#include "src/function/include/aggregation/aggregation_function.h"
+
+namespace graphflow {
+namespace function {
+
+template<bool IS_COUNT_STAR>
+struct CountFunction {
+
+    struct CountState : public AggregationState<uint64_t> {};
+
+    static void initialize(uint8_t* state_) {
+        auto state = reinterpret_cast<CountState*>(state_);
+        state->val = 0;
+    }
+
+    static void update(uint8_t* state_, ValueVector* input, uint64_t count) {
+        auto state = reinterpret_cast<CountState*>(state_);
+        if constexpr (IS_COUNT_STAR) {
+            assert(input == nullptr);
+            state->val += count;
+        } else {
+            assert(input && count == input->state->selectedSize);
+            if (input->hasNoNullsGuarantee()) {
+                state->val += count;
+            } else {
+                for (auto i = 0u; i < count; i++) {
+                    state->val += (1 - input->isNull(input->state->selectedPositions[i]));
+                }
+            }
+        }
+    }
+
+    static void combine(uint8_t* state_, uint8_t* otherState_) {
+        auto state = reinterpret_cast<CountState*>(state_);
+        auto otherState = reinterpret_cast<CountState*>(otherState_);
+        state->val += otherState->val;
+    }
+
+    static void finalize(uint8_t* inputState_, uint8_t* finalState_) {
+        auto inputState = reinterpret_cast<CountState*>(inputState_);
+        auto finalState = reinterpret_cast<CountState*>(finalState_);
+        finalState->val = inputState->val;
+    }
+};
+
+} // namespace function
+} // namespace graphflow

--- a/src/function/include/aggregation/min_max.h
+++ b/src/function/include/aggregation/min_max.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "src/common/include/operations/comparison_operations.h"
+#include "src/function/include/aggregation/aggregation_function.h"
+
+using namespace graphflow::common::operation;
+
+namespace graphflow {
+namespace function {
+
+template<typename T>
+struct MinMaxFunction {
+
+    struct MinMaxState : public AggregationState<T> {
+        bool hasNull;
+        bool isSet;
+    };
+
+    static void initialize(uint8_t* state_) {
+        auto state = reinterpret_cast<MinMaxState*>(state_);
+        state->hasNull = false;
+        state->isSet = false;
+    }
+
+    template<class OP>
+    static void update(uint8_t* state_, ValueVector* input, uint64_t count) {
+        assert(input && count == input->state->selectedSize);
+        auto state = reinterpret_cast<MinMaxState*>(state_);
+        auto inputValues = (T*)input->values;
+        uint8_t compare_result;
+        if (input->hasNoNullsGuarantee()) {
+            for (auto i = 0u; i < count; i++) {
+                auto inputVal = inputValues[input->state->selectedPositions[i]];
+                if (!state->isSet) {
+                    state->val = inputVal;
+                    state->isSet = true;
+                } else {
+                    OP::template operation<T, T>(inputVal, state->val, compare_result);
+                    state->val = compare_result == TRUE ? inputVal : state->val;
+                }
+            }
+        } else {
+            for (auto i = 0u; i < count; i++) {
+                auto pos = input->state->selectedPositions[i];
+                if (!input->isNull(pos)) {
+                    auto inputVal = inputValues[input->state->selectedPositions[i]];
+                    if (!state->isSet) {
+                        state->val = inputVal;
+                        state->isSet = true;
+                    } else {
+                        OP::template operation<T, T>(inputVal, state->val, compare_result);
+                        state->val = compare_result == TRUE ? inputVal : state->val;
+                    }
+                }
+            }
+        }
+    }
+
+    template<class OP>
+    static void combine(uint8_t* state_, uint8_t* otherState_) {
+        auto state = reinterpret_cast<MinMaxState*>(state_);
+        auto otherState = reinterpret_cast<MinMaxState*>(otherState_);
+        uint8_t compareResult;
+        OP::template operation<T, T>(otherState->val, state->val, compareResult);
+        state->val = compareResult == 1 ? otherState->val : state->val;
+        state->hasNull |= otherState->hasNull;
+    }
+
+    static void finalize(uint8_t* inputState_, uint8_t* finalState_) {
+        auto inputState = reinterpret_cast<MinMaxState*>(inputState_);
+        auto finalState = reinterpret_cast<MinMaxState*>(finalState_);
+        finalState->val = inputState->val;
+        finalState->hasNull = inputState->hasNull;
+    }
+};
+
+} // namespace function
+} // namespace graphflow

--- a/src/function/include/aggregation/sum.h
+++ b/src/function/include/aggregation/sum.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "src/function/include/aggregation/aggregation_function.h"
+
+namespace graphflow {
+namespace function {
+
+template<typename T>
+struct SumFunction {
+
+    struct SumState : public AggregationState<T> {
+        bool isSet;
+    };
+
+    static void initialize(uint8_t* state_) {
+        auto state = reinterpret_cast<SumState*>(state_);
+        state->isSet = false;
+    }
+
+    static void update(uint8_t* state_, ValueVector* input, uint64_t count) {
+        assert(input && count == input->state->selectedSize);
+        auto state = reinterpret_cast<SumState*>(state_);
+        auto inputValues = (T*)input->values;
+        if (input->hasNoNullsGuarantee()) {
+            for (auto i = 0u; i < count; i++) {
+                if (!state->isSet) {
+                    state->val = inputValues[input->state->selectedPositions[i]];
+                    state->isSet = true;
+                } else {
+                    Add::operation(
+                        state->val, inputValues[input->state->selectedPositions[i]], state->val);
+                }
+            }
+        } else {
+            for (auto i = 0u; i < count; i++) {
+                auto pos = input->state->selectedPositions[i];
+                if (!input->isNull(pos)) {
+                    if (!state->isSet) {
+                        state->val = inputValues[input->state->selectedPositions[i]];
+                        state->isSet = true;
+                    } else {
+                        Add::operation(state->val, inputValues[input->state->selectedPositions[i]],
+                            state->val);
+                    }
+                }
+            }
+        }
+    }
+
+    static void combine(uint8_t* state_, uint8_t* otherState_) {
+        auto state = reinterpret_cast<SumState*>(state_);
+        auto otherState = reinterpret_cast<SumState*>(otherState_);
+        Add::operation(state->val, otherState->val, state->val);
+    }
+
+    static void finalize(uint8_t* inputState_, uint8_t* finalState_) {
+        auto inputState = reinterpret_cast<SumState*>(inputState_);
+        auto finalState = reinterpret_cast<SumState*>(finalState_);
+        finalState->val = inputState->val;
+    }
+};
+
+} // namespace function
+} // namespace graphflow

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
         "physical_plan",
         "//src/binder:subquery_expression_impl",
         "//src/expression_evaluator:evaluator_impls",
+        "//src/function:aggregation_function",
         "//src/planner:logical_operator_impls",
         "//src/planner:logical_plan",
         "//src/storage:graph",

--- a/src/storage/include/data_structure/lists/lists.h
+++ b/src/storage/include/data_structure/lists/lists.h
@@ -17,7 +17,7 @@ namespace storage {
 struct ListInfo {
     bool isLargeList{false};
     uint64_t listLen{-1u};
-    function<uint32_t(uint32_t)> mapper;
+    std::function<uint32_t(uint32_t)> mapper;
     PageCursor cursor;
 };
 

--- a/src/storage/include/data_structure/lists/lists_metadata.h
+++ b/src/storage/include/data_structure/lists/lists_metadata.h
@@ -46,14 +46,14 @@ public:
 
     // Returns a function that can map the logical pageIdx of a chunk ito its corresponding physical
     // pageIdx in a disk file.
-    inline function<uint32_t(uint32_t)> getPageMapperForChunkIdx(uint32_t chunkIdx) {
+    inline std::function<uint32_t(uint32_t)> getPageMapperForChunkIdx(uint32_t chunkIdx) {
         return getLogicalToPhysicalPageMapper(
             chunkPageLists.get(), chunkToPageListHeadIdxMap[chunkIdx], chunkIdx);
     }
 
     // Returns a function that can map the logical pageIdx of a largeList to its corresponding
     // physical pageIdx in a disk file.
-    inline function<uint32_t(uint32_t)> getPageMapperForLargeListIdx(uint32_t largeListIdx) {
+    inline std::function<uint32_t(uint32_t)> getPageMapperForLargeListIdx(uint32_t largeListIdx) {
         return getLogicalToPhysicalPageMapper(largeListPageLists.get(),
             largeListIdxToPageListHeadIdxMap[2 * largeListIdx], largeListIdx);
     }
@@ -62,7 +62,7 @@ private:
     void saveToDisk(const string& fName);
     void readFromDisk(const string& fName);
 
-    inline static function<uint32_t(uint32_t)> getLogicalToPhysicalPageMapper(
+    inline static std::function<uint32_t(uint32_t)> getLogicalToPhysicalPageMapper(
         uint32_t* pageLists, uint32_t pageListsHead, uint32_t pageIdx) {
         return bind(getPageIdxFromAPageList, pageLists, pageListsHead, placeholders::_1);
     }

--- a/src/storage/include/data_structure/lists/unstructured_property_lists.h
+++ b/src/storage/include/data_structure/lists/unstructured_property_lists.h
@@ -36,11 +36,11 @@ private:
         BufferManagerMetrics& metrics);
 
     void readUnstrPropertyKeyIdxAndDatatype(uint8_t* propertyKeyDataType, PageCursor& pageCursor,
-        uint64_t& listLen, const function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper,
+        uint64_t& listLen, const std::function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper,
         BufferManagerMetrics& metrics);
 
     void readOrSkipUnstrPropertyValue(DataType& propertyDataType, PageCursor& pageCursor,
-        uint64_t& listLen, const function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper,
+        uint64_t& listLen, const std::function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper,
         Value* value, bool toRead, BufferManagerMetrics& metrics);
 
 public:

--- a/test/expression_evaluator/BUILD.bazel
+++ b/test/expression_evaluator/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_test(
+    name = "aggregation_expression_evaluator_test",
+    srcs = [
+        "aggregate_expression_evaluation_test.cpp",
+    ],
+    copts = [
+        "-Iexternal/gtest/include",
+    ],
+    deps = [
+        "//src/expression_evaluator:evaluator_impls",
+        "//src/processor:mapper",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
+++ b/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
@@ -1,0 +1,308 @@
+#include "gtest/gtest.h"
+
+#include "src/expression_evaluator/include/aggregate_expression_evaluator.h"
+#include "src/function/include/aggregation/avg.h"
+#include "src/function/include/aggregation/count.h"
+#include "src/function/include/aggregation/min_max.h"
+#include "src/function/include/aggregation/sum.h"
+
+using ::testing::Test;
+
+using namespace graphflow::processor;
+using namespace graphflow::function;
+using namespace graphflow::evaluator;
+
+class AggrExpressionEvaluatorTest : public Test {
+
+public:
+    void SetUp() override {
+        memoryManager = make_unique<MemoryManager>();
+        int64ValueVector = make_shared<ValueVector>(memoryManager.get(), INT64);
+        doubleValueVector = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
+        stringValueVector = make_shared<ValueVector>(memoryManager.get(), STRING);
+        unStrValueVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
+        dataChunk = make_shared<DataChunk>(4);
+        auto int64Values = (int64_t*)int64ValueVector->values;
+        auto doubleValues = (double_t*)doubleValueVector->values;
+        auto unStrValues = (Value*)unStrValueVector->values;
+        for (auto i = 0u; i < 100; i++) {
+            int64Values[i] = i;
+            doubleValues[i] = i * 1.5;
+            stringValueVector->addString(i, to_string(i));
+            unStrValues[i] = Value((int64_t)i);
+            if (i % 2 == 0) {
+                int64ValueVector->setNull(i, true /* isNull */);
+                doubleValueVector->setNull(i, true /* isNull */);
+                stringValueVector->setNull(i, true /* isNull */);
+                unStrValueVector->setNull(i, true /* isNull */);
+            }
+        }
+        dataChunk->state->selectedSize = 100;
+        dataChunk->insert(0, int64ValueVector);
+        dataChunk->insert(1, doubleValueVector);
+        dataChunk->insert(2, stringValueVector);
+        dataChunk->insert(3, unStrValueVector);
+        resultSet = make_shared<ResultSet>(1);
+        resultSet->insert(0, dataChunk);
+    }
+
+public:
+    unique_ptr<MemoryManager> memoryManager;
+    shared_ptr<ValueVector> int64ValueVector;
+    shared_ptr<ValueVector> doubleValueVector;
+    shared_ptr<ValueVector> stringValueVector;
+    shared_ptr<ValueVector> unStrValueVector;
+    shared_ptr<DataChunk> dataChunk;
+    shared_ptr<ResultSet> resultSet;
+};
+
+TEST_F(AggrExpressionEvaluatorTest, CountStarTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(COUNT_STAR_FUNC, INT64,
+        AggregateExpressionEvaluator::getAggregationFunction(COUNT_STAR_FUNC, INT64));
+    auto countStarAggrEvaluator =
+        reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto countStarState = make_unique<CountFunction<true>::CountState>();
+    countStarAggrEvaluator->getFunction()->initialize((uint8_t*)countStarState.get());
+    countStarAggrEvaluator->getFunction()->update(
+        (uint8_t*)countStarState.get(), nullptr, resultSet->getNumTuples());
+    auto otherCountStarState = make_unique<CountFunction<true>::CountState>();
+    otherCountStarState->val = 10;
+    countStarAggrEvaluator->getFunction()->combine(
+        (uint8_t*)countStarState.get(), (uint8_t*)otherCountStarState.get());
+    auto countStarFinalState = make_unique<CountFunction<true>::CountState>();
+    countStarAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)countStarState.get(), (uint8_t*)countStarFinalState.get());
+    ASSERT_EQ(countStarFinalState->val, 110);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, CountTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        COUNT_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(COUNT_FUNC, INT64));
+    auto countAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto countState = make_unique<CountFunction<false>::CountState>();
+    countAggrEvaluator->getFunction()->initialize((uint8_t*)countState.get());
+    countAggrEvaluator->getFunction()->update(
+        (uint8_t*)countState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
+    auto otherCountState = make_unique<CountFunction<false>::CountState>();
+    otherCountState->val = 10;
+    countAggrEvaluator->getFunction()->combine(
+        (uint8_t*)countState.get(), (uint8_t*)otherCountState.get());
+    auto countFinalState = make_unique<CountFunction<false>::CountState>();
+    countAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)countState.get(), (uint8_t*)countFinalState.get());
+    ASSERT_EQ(countFinalState->val, 60);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, INT64SumTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        SUM_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(SUM_FUNC, INT64));
+    auto sumAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto sumState = make_unique<SumFunction<int64_t>::SumState>();
+    sumAggrEvaluator->getFunction()->initialize((uint8_t*)sumState.get());
+    sumAggrEvaluator->getFunction()->update(
+        (uint8_t*)sumState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
+    auto otherSumState = make_unique<SumFunction<int64_t>::SumState>();
+    otherSumState->val = 10;
+    sumAggrEvaluator->getFunction()->combine(
+        (uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
+    auto sumFinalState = make_unique<SumFunction<int64_t>::SumState>();
+    sumAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)sumState.get(), (uint8_t*)sumFinalState.get());
+    auto sumValue = otherSumState->val;
+    for (auto i = 0u; i < 100; i++) {
+        if (i % 2 != 0) {
+            sumValue += i;
+        }
+    }
+    ASSERT_EQ(sumFinalState->val, sumValue);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, DOUBLESumTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        SUM_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(SUM_FUNC, DOUBLE));
+    auto sumAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto sumState = make_unique<SumFunction<double_t>::SumState>();
+    sumAggrEvaluator->getFunction()->initialize((uint8_t*)sumState.get());
+    sumAggrEvaluator->getFunction()->update(
+        (uint8_t*)sumState.get(), doubleValueVector.get(), doubleValueVector->state->selectedSize);
+    auto otherSumState = make_unique<SumFunction<double_t>::SumState>();
+    otherSumState->val = 10.0;
+    sumAggrEvaluator->getFunction()->combine(
+        (uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
+    auto sumFinalState = make_unique<SumFunction<double_t>::SumState>();
+    sumAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)sumState.get(), (uint8_t*)sumFinalState.get());
+    auto sumValue = otherSumState->val;
+    for (auto i = 0u; i < 100; i++) {
+        if (i % 2 != 0) {
+            sumValue += i * 1.5;
+        }
+    }
+    ASSERT_EQ(sumFinalState->val, sumValue);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, UNSTRSumTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(SUM_FUNC, UNSTRUCTURED,
+        AggregateExpressionEvaluator::getAggregationFunction(SUM_FUNC, UNSTRUCTURED));
+    auto sumAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto sumState = make_unique<SumFunction<Value>::SumState>();
+    sumAggrEvaluator->getFunction()->initialize((uint8_t*)sumState.get());
+    sumAggrEvaluator->getFunction()->update(
+        (uint8_t*)sumState.get(), unStrValueVector.get(), unStrValueVector->state->selectedSize);
+    auto otherSumState = make_unique<SumFunction<Value>::SumState>();
+    otherSumState->val = Value((int64_t)10);
+    sumAggrEvaluator->getFunction()->combine(
+        (uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
+    auto sumFinalState = make_unique<SumFunction<Value>::SumState>();
+    sumAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)sumState.get(), (uint8_t*)sumFinalState.get());
+    auto sumValue = otherSumState->val.val.int64Val;
+    for (auto i = 0u; i < 100; i++) {
+        if (i % 2 != 0) {
+            sumValue += i;
+        }
+    }
+    ASSERT_EQ(sumFinalState->val.val.int64Val, sumValue);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, INT64AvgTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        AVG_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(AVG_FUNC, INT64));
+    auto avgAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto avgState = make_unique<AvgFunction<int64_t>::AvgState>();
+    avgAggrEvaluator->getFunction()->initialize((uint8_t*)avgState.get());
+    avgAggrEvaluator->getFunction()->update(
+        (uint8_t*)avgState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
+    auto otherAvgState = make_unique<AvgFunction<int64_t>::AvgState>();
+    otherAvgState->val = 10;
+    otherAvgState->numValues = 1;
+    avgAggrEvaluator->getFunction()->combine(
+        (uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
+    auto avgFinalState = make_unique<AvgFunction<double_t>::AvgState>();
+    avgAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)avgState.get(), (uint8_t*)avgFinalState.get());
+    auto sumValue = otherAvgState->val;
+    for (auto i = 0u; i < 100; i++) {
+        if (i % 2 != 0) {
+            sumValue += i;
+        }
+    }
+    ASSERT_EQ(avgFinalState->val, (double_t)(sumValue) / (double_t)51);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, DOUBLEAvgTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        AVG_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(AVG_FUNC, DOUBLE));
+    auto avgAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto avgState = make_unique<AvgFunction<double_t>::AvgState>();
+    avgAggrEvaluator->getFunction()->initialize((uint8_t*)avgState.get());
+    avgAggrEvaluator->getFunction()->update(
+        (uint8_t*)avgState.get(), doubleValueVector.get(), doubleValueVector->state->selectedSize);
+    auto otherAvgState = make_unique<AvgFunction<double_t>::AvgState>();
+    otherAvgState->val = 10.0;
+    otherAvgState->numValues = 1;
+    avgAggrEvaluator->getFunction()->combine(
+        (uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
+    auto avgFinalState = make_unique<AvgFunction<double_t>::AvgState>();
+    avgAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)avgState.get(), (uint8_t*)avgFinalState.get());
+    auto sumValue = otherAvgState->val;
+    for (auto i = 0u; i < 100; i++) {
+        if (i % 2 != 0) {
+            sumValue += i * 1.5;
+        }
+    }
+    ASSERT_EQ(avgFinalState->val, (double_t)(sumValue) / (double_t)51);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, INT64MaxTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        MAX_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, INT64));
+    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto maxState = make_unique<MinMaxFunction<int64_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->initialize((uint8_t*)maxState.get());
+    maxAggrEvaluator->getFunction()->update(
+        (uint8_t*)maxState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
+    auto otherMaxState = make_unique<MinMaxFunction<int64_t>::MinMaxState>();
+    otherMaxState->val = 101;
+    maxAggrEvaluator->getFunction()->combine(
+        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    auto maxFinalState = make_unique<MinMaxFunction<int64_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)maxState.get(), (uint8_t*)maxFinalState.get());
+    ASSERT_EQ(maxFinalState->val, 101);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, DOUBLEMaxTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        MAX_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, DOUBLE));
+    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto maxState = make_unique<MinMaxFunction<double_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->initialize((uint8_t*)maxState.get());
+    maxAggrEvaluator->getFunction()->update(
+        (uint8_t*)maxState.get(), doubleValueVector.get(), doubleValueVector->state->selectedSize);
+    auto otherMaxState = make_unique<MinMaxFunction<double_t>::MinMaxState>();
+    otherMaxState->val = 101.0;
+    maxAggrEvaluator->getFunction()->combine(
+        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    auto maxFinalState = make_unique<MinMaxFunction<double_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)maxState.get(), (uint8_t*)maxFinalState.get());
+    ASSERT_EQ(maxFinalState->val, 148.5);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, STRINGMaxTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        MAX_FUNC, STRING, AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, STRING));
+    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto maxState = make_unique<MinMaxFunction<gf_string_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->initialize((uint8_t*)maxState.get());
+    maxAggrEvaluator->getFunction()->update(
+        (uint8_t*)maxState.get(), stringValueVector.get(), stringValueVector->state->selectedSize);
+    auto otherMaxState = make_unique<MinMaxFunction<gf_string_t>::MinMaxState>();
+    gf_string_t otherStr;
+    otherStr.set("0");
+    otherMaxState->val = otherStr;
+    maxAggrEvaluator->getFunction()->combine(
+        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    auto maxFinalState = make_unique<MinMaxFunction<gf_string_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)maxState.get(), (uint8_t*)maxFinalState.get());
+    ASSERT_EQ(maxFinalState->val.getAsString(), "99");
+}
+
+TEST_F(AggrExpressionEvaluatorTest, UNSTRMaxTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(MAX_FUNC, UNSTRUCTURED,
+        AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, UNSTRUCTURED));
+    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto maxState = make_unique<MinMaxFunction<Value>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->initialize((uint8_t*)maxState.get());
+    maxAggrEvaluator->getFunction()->update(
+        (uint8_t*)maxState.get(), unStrValueVector.get(), unStrValueVector->state->selectedSize);
+    auto otherMaxState = make_unique<MinMaxFunction<Value>::MinMaxState>();
+    otherMaxState->val = Value((int64_t)101);
+    maxAggrEvaluator->getFunction()->combine(
+        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    auto maxFinalState = make_unique<MinMaxFunction<Value>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)maxState.get(), (uint8_t*)maxFinalState.get());
+    ASSERT_EQ(maxFinalState->val.val.int64Val, 101);
+}
+
+TEST_F(AggrExpressionEvaluatorTest, INT64MinTest) {
+    auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
+        MIN_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(MIN_FUNC, INT64));
+    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
+    auto maxState = make_unique<MinMaxFunction<int64_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->initialize((uint8_t*)maxState.get());
+    maxAggrEvaluator->getFunction()->update(
+        (uint8_t*)maxState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
+    auto otherMaxState = make_unique<MinMaxFunction<int64_t>::MinMaxState>();
+    otherMaxState->val = -10;
+    maxAggrEvaluator->getFunction()->combine(
+        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    auto maxFinalState = make_unique<MinMaxFunction<int64_t>::MinMaxState>();
+    maxAggrEvaluator->getFunction()->finalize(
+        (uint8_t*)maxState.get(), (uint8_t*)maxFinalState.get());
+    ASSERT_EQ(maxFinalState->val, -10);
+}


### PR DESCRIPTION
This PR introduces the aggregation function interface and aggregate expression evaluator.
Also, adds five basic aggregate functions: MIN, MAX, COUNT, COUNT_STAR, AVG, SUM.

COUNT(arg): All NULLs are excluded from the calculation.
MIN/MAX(arg): support arg of data type NODE, INT64, DOUBLE, STRING, DATE, UNSTRUCTURED. All NULLs are excluded from the calculation.
SUM(arg): support arg of data type  INT64, DOUBLE, UNSTRUCTURED. All NULLs are excluded from the calculation.
AVG(arg): support arg of data type  INT64, DOUBLE. All NULLs are excluded from the calculation.