### PR TITLE
move result construction out from operator constructor

### DIFF
--- a/src/common/data_chunk/data_chunk_state.cpp
+++ b/src/common/data_chunk/data_chunk_state.cpp
@@ -33,6 +33,7 @@ shared_ptr<DataChunkState> DataChunkState::getSingleValueDataChunkState() {
 shared_ptr<DataChunkState> DataChunkState::clone() {
     auto newState = make_shared<DataChunkState>(selectedSize);
     newState->currIdx = currIdx;
+    newState->originalSize = originalSize;
     newState->selectedSize = selectedSize;
     memcpy(newState->selectedPositionsBuffer.get(), selectedPositionsBuffer.get(),
         selectedSize * sizeof(sel_t));

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -13,12 +13,12 @@ class NullMask {
     friend class ValueVector;
 
 public:
-    explicit NullMask(uint64_t vectorCapacity)
+    explicit NullMask()
         : mask(make_unique<bool[]>(DEFAULT_VECTOR_CAPACITY)), mayContainNulls{false} {
-        fill_n(mask.get(), vectorCapacity, false /* not null */);
+        fill_n(mask.get(), DEFAULT_VECTOR_CAPACITY, false /* not null */);
     };
 
-    shared_ptr<NullMask> clone(uint64_t vectorCapacity);
+    shared_ptr<NullMask> clone();
 
 private:
     unique_ptr<bool[]> mask;
@@ -30,10 +30,8 @@ private:
 class ValueVector {
 
 public:
-    ValueVector(MemoryManager* memoryManager, DataType dataType, bool isSingleValue = false,
-        bool isSequence = false)
-        : ValueVector(memoryManager, isSingleValue ? 1 : DEFAULT_VECTOR_CAPACITY,
-              TypeUtils::getDataTypeSize(dataType), dataType, isSequence) {}
+    ValueVector(MemoryManager* memoryManager, DataType dataType, bool isSequence = false)
+        : ValueVector(memoryManager, TypeUtils::getDataTypeSize(dataType), dataType, isSequence) {}
 
     ~ValueVector() = default;
 
@@ -81,13 +79,11 @@ public:
     shared_ptr<ValueVector> clone();
 
 protected:
-    ValueVector(MemoryManager* memoryManager, uint64_t vectorCapacity, uint64_t numBytesPerValue,
-        DataType dataType, bool isSequence)
-        : vectorCapacity{vectorCapacity},
-          bufferValues(make_unique<uint8_t[]>(numBytesPerValue * vectorCapacity)),
+    ValueVector(
+        MemoryManager* memoryManager, uint64_t numBytesPerValue, DataType dataType, bool isSequence)
+        : bufferValues(make_unique<uint8_t[]>(numBytesPerValue * DEFAULT_VECTOR_CAPACITY)),
           memoryManager{memoryManager}, dataType{dataType}, values{bufferValues.get()},
-          stringBuffer{nullptr}, isSequence{isSequence}, nullMask{make_shared<NullMask>(
-                                                             vectorCapacity)} {
+          stringBuffer{nullptr}, isSequence{isSequence}, nullMask{make_shared<NullMask>()} {
         if (dataType == STRING || dataType == UNSTRUCTURED) {
             assert(memoryManager);
             stringBuffer = make_unique<StringBuffer>(*memoryManager);
@@ -95,7 +91,6 @@ protected:
     }
 
 protected:
-    uint64_t vectorCapacity;
     unique_ptr<uint8_t[]> bufferValues;
     MemoryManager* memoryManager;
 

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -7,9 +7,9 @@ using namespace graphflow::common::operation;
 namespace graphflow {
 namespace common {
 
-shared_ptr<NullMask> NullMask::clone(uint64_t vectorCapacity) {
-    auto newNullMask = make_shared<NullMask>(vectorCapacity);
-    memcpy(newNullMask->mask.get(), mask.get(), vectorCapacity);
+shared_ptr<NullMask> NullMask::clone() {
+    auto newNullMask = make_shared<NullMask>();
+    memcpy(newNullMask->mask.get(), mask.get(), DEFAULT_VECTOR_CAPACITY);
     return newNullMask;
 }
 
@@ -90,12 +90,12 @@ bool ValueVector::discardNullNodes() {
 
 // Notice that this clone function only copies values and mask without copying string buffers.
 shared_ptr<ValueVector> ValueVector::clone() {
-    auto newVector = make_shared<ValueVector>(memoryManager, dataType, vectorCapacity == 1);
+    auto newVector = make_shared<ValueVector>(memoryManager, dataType);
     // Warning: This is a potential bug because sometimes nullMasks of ValueVectors point to
     // null masks of other ValueVectors, e.g., the result ValueVectors of unary expressions, point
     // to the nullMasks of operands. In which case these should not be copied over.
-    newVector->nullMask = nullMask->clone(vectorCapacity);
-    memcpy(newVector->values, values, vectorCapacity * getNumBytesPerValue());
+    newVector->nullMask = nullMask->clone();
+    memcpy(newVector->values, values, DEFAULT_VECTOR_CAPACITY * getNumBytesPerValue());
     return newVector;
 }
 

--- a/src/expression_evaluator/BUILD.bazel
+++ b/src/expression_evaluator/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     deps = [
         "//src/common:data_chunk",
         "//src/common:vector_operations",
+        "//src/processor:data_pos",
         "//src/processor:result_set",
     ],
 )

--- a/src/expression_evaluator/aggregate_expression_evaluator.cpp
+++ b/src/expression_evaluator/aggregate_expression_evaluator.cpp
@@ -142,5 +142,12 @@ unique_ptr<AggregationFunction> AggregateExpressionEvaluator::getMinMaxFunction(
     }
 }
 
+void AggregateExpressionEvaluator::initResultSet(
+    const ResultSet& resultSet, MemoryManager& memoryManager) {
+    for (auto& child : childrenExpr) {
+        child->initResultSet(resultSet, memoryManager);
+    }
+}
+
 } // namespace evaluator
 } // namespace graphflow

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -137,6 +137,12 @@ ExpressionEvaluator::getBinaryVectorSelectOperation(ExpressionType type) {
     }
 }
 
+void ExpressionEvaluator::initResultSet(const ResultSet& resultSet, MemoryManager& memoryManager) {
+    if (dataPos.dataChunkPos != UINT32_MAX && dataPos.valueVectorPos != UINT32_MAX) {
+        result = resultSet.dataChunks[dataPos.dataChunkPos]->valueVectors[dataPos.valueVectorPos];
+    }
+}
+
 // Select function for leaf expressions, for the expression's return data type is boolean.
 uint64_t ExpressionEvaluator::select(sel_t* selectedPositions) {
     assert(dataType == BOOL);
@@ -166,16 +172,13 @@ bool ExpressionEvaluator::isResultFlat() {
     return true;
 }
 
-unique_ptr<ExpressionEvaluator> ExpressionEvaluator::clone(
-    MemoryManager& memoryManager, const ResultSet& resultSet) {
+unique_ptr<ExpressionEvaluator> ExpressionEvaluator::clone() {
     if (isExpressionLiteral(expressionType)) {
         return make_unique<ExpressionEvaluator>(result, expressionType);
     } else {
         // property expression evaluator clone
         assert(childrenExpr.empty());
-        return make_unique<ExpressionEvaluator>(
-            resultSet.dataChunks[dataChunkPos]->getValueVector(valueVectorPos), dataChunkPos,
-            valueVectorPos, expressionType);
+        return make_unique<ExpressionEvaluator>(dataPos, expressionType, dataType);
     }
 }
 

--- a/src/expression_evaluator/include/aggregate_expression_evaluator.h
+++ b/src/expression_evaluator/include/aggregate_expression_evaluator.h
@@ -25,10 +25,9 @@ public:
         childrenExpr.push_back(move(child));
     }
 
-    unique_ptr<ExpressionEvaluator> clone(
-        MemoryManager& memoryManager, const ResultSet& resultSet) override {
-        return nullptr;
-    }
+    void initResultSet(const ResultSet& resultSet, MemoryManager& memoryManager) override;
+
+    unique_ptr<ExpressionEvaluator> clone() override { return nullptr; }
 
     uint64_t select(sel_t* selectedPositions) override { return 0; }
 

--- a/src/expression_evaluator/include/binary_expression_evaluator.h
+++ b/src/expression_evaluator/include/binary_expression_evaluator.h
@@ -11,17 +11,18 @@ namespace evaluator {
 class BinaryExpressionEvaluator : public ExpressionEvaluator {
 
 public:
-    BinaryExpressionEvaluator(MemoryManager& memoryManager,
-        unique_ptr<ExpressionEvaluator> leftExpr, unique_ptr<ExpressionEvaluator> rightExpr,
-        ExpressionType expressionType, DataType dataType);
+    BinaryExpressionEvaluator(unique_ptr<ExpressionEvaluator> leftExpr,
+        unique_ptr<ExpressionEvaluator> rightExpr, ExpressionType expressionType,
+        DataType dataType);
+
+    void initResultSet(const ResultSet& resultSet, MemoryManager& memoryManager) override;
 
     void evaluate() override;
     uint64_t select(sel_t* selectedPositions) override;
 
     shared_ptr<ValueVector> createResultValueVector(MemoryManager& memoryManager);
 
-    unique_ptr<ExpressionEvaluator> clone(
-        MemoryManager& memoryManager, const ResultSet& resultSet) override;
+    unique_ptr<ExpressionEvaluator> clone() override;
 
 private:
     std::function<void(ValueVector&, ValueVector&, ValueVector&)> executeOperation;

--- a/src/expression_evaluator/include/existential_subquery_evaluator.h
+++ b/src/expression_evaluator/include/existential_subquery_evaluator.h
@@ -11,16 +11,16 @@ namespace evaluator {
 class ExistentialSubqueryEvaluator : public ExpressionEvaluator {
 
 public:
-    ExistentialSubqueryEvaluator(
-        MemoryManager& memoryManager, unique_ptr<ResultCollector> subPlanResultCollector);
+    ExistentialSubqueryEvaluator(unique_ptr<ResultCollector> subPlanResultCollector);
+
+    void initResultSet(const ResultSet& resultSet, MemoryManager& memoryManager) override;
 
     uint64_t executeSubplan();
 
     void evaluate() override;
     uint64_t select(sel_t* selectedPositions) override;
 
-    unique_ptr<ExpressionEvaluator> clone(
-        MemoryManager& memoryManager, const ResultSet& resultSet) override;
+    unique_ptr<ExpressionEvaluator> clone() override;
 
 private:
     unique_ptr<ResultCollector> subPlanResultCollector;

--- a/src/expression_evaluator/include/unary_expression_evaluator.h
+++ b/src/expression_evaluator/include/unary_expression_evaluator.h
@@ -9,8 +9,10 @@ namespace evaluator {
 class UnaryExpressionEvaluator : public ExpressionEvaluator {
 
 public:
-    UnaryExpressionEvaluator(MemoryManager& memoryManager, unique_ptr<ExpressionEvaluator> child,
-        ExpressionType expressionType, DataType dataType);
+    UnaryExpressionEvaluator(
+        unique_ptr<ExpressionEvaluator> child, ExpressionType expressionType, DataType dataType);
+
+    void initResultSet(const ResultSet& resultSet, MemoryManager& memoryManager) override;
 
     void evaluate() override;
 
@@ -18,8 +20,7 @@ public:
 
     shared_ptr<ValueVector> createResultValueVector(MemoryManager& memoryManager);
 
-    unique_ptr<ExpressionEvaluator> clone(
-        MemoryManager& memoryManager, const ResultSet& resultSet) override;
+    unique_ptr<ExpressionEvaluator> clone() override;
 
 protected:
     std::function<void(ValueVector&, ValueVector&)> executeOperation;

--- a/src/expression_evaluator/unary_expression_evaluator.cpp
+++ b/src/expression_evaluator/unary_expression_evaluator.cpp
@@ -3,15 +3,20 @@
 namespace graphflow {
 namespace evaluator {
 
-UnaryExpressionEvaluator::UnaryExpressionEvaluator(MemoryManager& memoryManager,
+UnaryExpressionEvaluator::UnaryExpressionEvaluator(
     unique_ptr<ExpressionEvaluator> child, ExpressionType expressionType, DataType dataType)
     : ExpressionEvaluator{expressionType, dataType} {
     childrenExpr.push_back(move(child));
     executeOperation = getUnaryVectorExecuteOperation(expressionType);
-    result = createResultValueVector(memoryManager);
     if (dataType == BOOL) {
         selectOperation = getUnaryVectorSelectOperation(expressionType);
     }
+}
+
+void UnaryExpressionEvaluator::initResultSet(
+    const ResultSet& resultSet, MemoryManager& memoryManager) {
+    childrenExpr[0]->initResultSet(resultSet, memoryManager);
+    result = createResultValueVector(memoryManager);
 }
 
 void UnaryExpressionEvaluator::evaluate() {
@@ -48,10 +53,9 @@ shared_ptr<ValueVector> UnaryExpressionEvaluator::createResultValueVector(
     return resultVector;
 }
 
-unique_ptr<ExpressionEvaluator> UnaryExpressionEvaluator::clone(
-    MemoryManager& memoryManager, const ResultSet& resultSet) {
+unique_ptr<ExpressionEvaluator> UnaryExpressionEvaluator::clone() {
     return make_unique<UnaryExpressionEvaluator>(
-        memoryManager, childrenExpr[0]->clone(memoryManager, resultSet), expressionType, dataType);
+        childrenExpr[0]->clone(), expressionType, dataType);
 }
 
 } // namespace evaluator

--- a/src/planner/include/logical_plan/logical_plan.h
+++ b/src/planner/include/logical_plan/logical_plan.h
@@ -15,7 +15,8 @@ public:
 
     void appendOperator(shared_ptr<LogicalOperator> op);
 
-    bool isEmpty() { return lastOperator == nullptr; }
+    inline bool isEmpty() { return lastOperator == nullptr; }
+    inline Schema* getSchema() { return schema.get(); }
 
     unique_ptr<LogicalPlan> copy() const;
 

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -8,6 +8,7 @@
 
 #include "src/common/include/assert.h"
 
+using namespace graphflow::common;
 using namespace std;
 
 namespace graphflow {
@@ -24,12 +25,14 @@ public:
         : isFlat{other.isFlat},
           estimatedCardinality{other.estimatedCardinality}, variables{other.variables} {}
 
-    void insertVariable(const string& variable) { variables.insert(variable); }
+    inline void insertVariable(const string& variable) { variables.insert(variable); }
 
     inline string getAnyVariable() {
         GF_ASSERT(!variables.empty());
         return *variables.begin();
     }
+
+    inline uint32_t getNumVariables() const { return variables.size(); }
 
 public:
     bool isFlat;
@@ -40,6 +43,9 @@ public:
 class Schema {
 
 public:
+    inline uint32_t getNumGroups() const { return groups.size(); }
+    inline FactorizationGroup* getGroup(uint32_t pos) const { return groups[pos].get(); }
+
     uint32_t createGroup();
 
     void insertToGroup(const string& variable, uint32_t groupPos);

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -1,6 +1,14 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
+    name = "data_pos",
+    hdrs = [
+        "include/physical_plan/data_pos.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "execution_context",
     hdrs = [
         "include/execution_context.h",
@@ -56,6 +64,7 @@ cc_library(
         "include/physical_plan/operator/physical_operator.h",
     ],
     deps = [
+        "data_pos",
         "execution_context",
         "result_set",
     ],
@@ -134,6 +143,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "base_operator",
+        "data_pos",
         "//src/common:csv_reader",
         "//src/expression_evaluator:base_evaluator",
     ],

--- a/src/processor/include/physical_plan/data_pos.h
+++ b/src/processor/include/physical_plan/data_pos.h
@@ -1,0 +1,20 @@
+#pragma once
+
+namespace graphflow {
+namespace processor {
+
+struct DataPos {
+
+public:
+    DataPos(uint32_t dataChunkPos, uint32_t valueVectorPos)
+        : dataChunkPos{dataChunkPos}, valueVectorPos{valueVectorPos} {}
+
+    DataPos(const DataPos& other) : DataPos(other.dataChunkPos, other.valueVectorPos) {}
+
+public:
+    uint32_t dataChunkPos;
+    uint32_t valueVectorPos;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/physical_plan/expression_mapper.h
+++ b/src/processor/include/physical_plan/expression_mapper.h
@@ -20,14 +20,12 @@ public:
     explicit ExpressionMapper(PlanMapper* planMapper) : planMapper{planMapper} {};
 
     unique_ptr<ExpressionEvaluator> mapToPhysical(const Expression& expression,
-        PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet* resultSet,
-        ExecutionContext& context);
+        const PhysicalOperatorsInfo& physicalOperatorInfo, ExecutionContext& context);
 
 private:
     unique_ptr<ExpressionEvaluator> mapChildExpressionAndCastToUnstructuredIfNecessary(
         const Expression& expression, bool castToUnstructured,
-        PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet* resultSet,
-        ExecutionContext& context);
+        const PhysicalOperatorsInfo& physicalOperatorInfo, ExecutionContext& context);
 
     unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToUnstructuredPhysical(
         const Expression& expression, ExecutionContext& context);
@@ -35,12 +33,12 @@ private:
     unique_ptr<ExpressionEvaluator> mapLogicalLiteralExpressionToStructuredPhysical(
         const Expression& expression, ExecutionContext& context);
 
-    unique_ptr<ExpressionEvaluator> mapLogicalLeafExpressionToPhysical(const Expression& expression,
-        PhysicalOperatorsInfo& physicalOperatorInfo, ResultSet* resultSet);
+    unique_ptr<ExpressionEvaluator> mapLogicalLeafExpressionToPhysical(
+        const Expression& expression, const PhysicalOperatorsInfo& physicalOperatorInfo);
 
     unique_ptr<ExpressionEvaluator> mapLogicalExistentialSubqueryExpressionToPhysical(
-        const Expression& expression, PhysicalOperatorsInfo& physicalOperatorInfo,
-        ResultSet* resultSet, ExecutionContext& context);
+        const Expression& expression, const PhysicalOperatorsInfo& physicalOperatorInfo,
+        ExecutionContext& context);
 
 private:
     PlanMapper* planMapper;

--- a/src/processor/include/physical_plan/operator/filter/filter.h
+++ b/src/processor/include/physical_plan/operator/filter/filter.h
@@ -12,8 +12,13 @@ namespace processor {
 class Filter : public PhysicalOperator, public FilteringOperator {
 
 public:
-    Filter(unique_ptr<ExpressionEvaluator> rootExpr, uint64_t dataChunkToSelectPos,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+    Filter(unique_ptr<ExpressionEvaluator> rootExpr, uint32_t dataChunkToSelectPos,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(prevOperator), FILTER, context, id},
+          FilteringOperator(), rootExpr{move(rootExpr)},
+          dataChunkToSelectPos(dataChunkToSelectPos) {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void reInitialize() override;
 
@@ -21,12 +26,11 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override;
 
-protected:
-    shared_ptr<DataChunk> dataChunkToSelect;
-    unique_ptr<ExpressionEvaluator> rootExpr;
-
 private:
-    uint64_t dataChunkToSelectPos;
+    unique_ptr<ExpressionEvaluator> rootExpr;
+    uint32_t dataChunkToSelectPos;
+
+    shared_ptr<DataChunk> dataChunkToSelect;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/filtering_operator.h
+++ b/src/processor/include/physical_plan/operator/filtering_operator.h
@@ -12,10 +12,9 @@ namespace processor {
 class FilteringOperator {
 
 public:
-    explicit FilteringOperator(shared_ptr<DataChunk> dataChunkToSelect)
-        : dataChunkToSelect(move(dataChunkToSelect)), prevNumSelectedValues{0ul},
-          prevSelectedValues{nullptr}, prevSelectedValuesBuffer{
-                                           make_unique<sel_t[]>(DEFAULT_VECTOR_CAPACITY)} {};
+    FilteringOperator()
+        : prevNumSelectedValues{0ul}, prevSelectedValues{nullptr},
+          prevSelectedValuesBuffer{make_unique<sel_t[]>(DEFAULT_VECTOR_CAPACITY)} {};
 
 protected:
     inline void reInitialize() {
@@ -23,7 +22,7 @@ protected:
         prevSelectedValues = nullptr;
     }
 
-    inline void restoreDataChunkSelectorState() {
+    inline void restoreDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect) {
         if (prevSelectedValues == nullptr) {
             return;
         }
@@ -37,7 +36,7 @@ protected:
         }
     };
 
-    inline void saveDataChunkSelectorState() {
+    inline void saveDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect) {
         prevNumSelectedValues = dataChunkToSelect->state->selectedSize;
         if (dataChunkToSelect->state->isUnfiltered()) {
             prevSelectedValues = (sel_t*)&DataChunkState::INCREMENTAL_SELECTED_POS;
@@ -50,7 +49,6 @@ protected:
     };
 
 protected:
-    shared_ptr<DataChunk> dataChunkToSelect;
     uint64_t prevNumSelectedValues;
     sel_t* prevSelectedValues;
     unique_ptr<sel_t[]> prevSelectedValuesBuffer;

--- a/src/processor/include/physical_plan/operator/flatten/flatten.h
+++ b/src/processor/include/physical_plan/operator/flatten/flatten.h
@@ -8,8 +8,12 @@ namespace processor {
 class Flatten : public PhysicalOperator {
 
 public:
-    Flatten(uint64_t dataChunkToFlattenPos, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    Flatten(uint32_t dataChunkToFlattenPos, unique_ptr<PhysicalOperator> prevOperator,
+        ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(prevOperator), FLATTEN, context, id}, dataChunkToFlattenPos{
+                                                                          dataChunkToFlattenPos} {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void getNextTuples() override;
 
@@ -18,7 +22,7 @@ public:
     }
 
 private:
-    uint64_t dataChunkToFlattenPos;
+    uint32_t dataChunkToFlattenPos;
     shared_ptr<DataChunk> dataChunkToFlatten;
 };
 

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -38,37 +38,30 @@ struct BuildSideVectorInfo {
 struct ProbeDataChunksInfo {
 
 public:
-    ProbeDataChunksInfo(uint32_t keyDataChunkPos, uint32_t keyValueVectorPos,
-        uint32_t newFlatDataChunkPos, uint32_t newFlatDataChunkSize,
-        vector<uint32_t> newUnFlatDataChunksPos, vector<uint32_t> newUnFlatDataChunksSize)
-        : keyDataChunkPos{keyDataChunkPos}, keyValueVectorPos{keyValueVectorPos},
-          newFlatDataChunkPos{newFlatDataChunkPos}, newFlatDataChunkSize{newFlatDataChunkSize},
-          newUnFlatDataChunksPos{move(newUnFlatDataChunksPos)}, newUnFlatDataChunksSize{move(
-                                                                    newUnFlatDataChunksSize)} {}
+    ProbeDataChunksInfo(const DataPos& keyDataPos, uint32_t newFlatDataChunkPos,
+        vector<uint32_t> newUnFlatDataChunksPos)
+        : keyDataPos{keyDataPos}, newFlatDataChunkPos{newFlatDataChunkPos},
+          newUnFlatDataChunksPos{move(newUnFlatDataChunksPos)} {}
 
     ProbeDataChunksInfo(const ProbeDataChunksInfo& other)
-        : ProbeDataChunksInfo(other.keyDataChunkPos, other.keyValueVectorPos,
-              other.newFlatDataChunkPos, other.newFlatDataChunkSize, other.newUnFlatDataChunksPos,
-              other.newUnFlatDataChunksSize){};
+        : ProbeDataChunksInfo(
+              other.keyDataPos, other.newFlatDataChunkPos, other.newUnFlatDataChunksPos){};
 
 public:
-    uint32_t keyDataChunkPos;
-    uint32_t keyValueVectorPos;
+    DataPos keyDataPos;
     uint32_t newFlatDataChunkPos;
-    uint32_t newFlatDataChunkSize;
     vector<uint32_t> newUnFlatDataChunksPos;
-    vector<uint32_t> newUnFlatDataChunksSize;
 };
 
 class HashJoinProbe : public PhysicalOperator {
 public:
     HashJoinProbe(const BuildDataChunksInfo& buildDataChunksInfo,
         const ProbeDataChunksInfo& probeDataChunksInfo,
-        vector<unordered_map<uint32_t, pair<uint32_t, uint32_t>>> buildSideValueVectorsOutputPos,
+        vector<unordered_map<uint32_t, DataPos>> buildSideValueVectorsOutputPos,
         unique_ptr<PhysicalOperator> buildSidePrevOp, unique_ptr<PhysicalOperator> probeSidePrevOp,
         ExecutionContext& context, uint32_t id);
 
-    HashJoinProbe();
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void reInitialize() override;
 
@@ -89,7 +82,7 @@ public:
 private:
     BuildDataChunksInfo buildDataChunksInfo;
     ProbeDataChunksInfo probeDataChunksInfo;
-    vector<unordered_map<uint32_t, pair<uint32_t, uint32_t>>> buildSideValueVectorsOutputPos;
+    vector<unordered_map<uint32_t, DataPos>> buildSideValueVectorsOutputPos;
 
     uint64_t numProbeSidePrevKeyValueVectors;
 

--- a/src/processor/include/physical_plan/operator/intersect/intersect.h
+++ b/src/processor/include/physical_plan/operator/intersect/intersect.h
@@ -9,27 +9,28 @@ namespace processor {
 class Intersect : public PhysicalOperator, public FilteringOperator {
 
 public:
-    Intersect(uint64_t leftDataChunkPos, uint64_t leftValueVectorPos, uint64_t rightDataChunkPos,
-        uint64_t rightValueVectorPos, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    Intersect(const DataPos& leftDataPos, const DataPos& rightDataPos,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(prevOperator), INTERSECT, context, id}, FilteringOperator{},
+          leftDataPos{leftDataPos}, rightDataPos{rightDataPos}, leftIdx{0} {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Intersect>(leftDataChunkPos, leftValueVectorPos, rightDataChunkPos,
-            rightValueVectorPos, prevOperator->clone(), context, id);
+        return make_unique<Intersect>(
+            leftDataPos, rightDataPos, prevOperator->clone(), context, id);
     }
 
 private:
-    uint64_t leftDataChunkPos;
-    uint64_t leftValueVectorPos;
-    uint64_t rightDataChunkPos;
-    uint64_t rightValueVectorPos;
+    DataPos leftDataPos;
+    DataPos rightDataPos;
 
     shared_ptr<DataChunk> leftDataChunk;
-    shared_ptr<ValueVector> leftNodeIDVector;
+    shared_ptr<ValueVector> leftValueVector;
     shared_ptr<DataChunk> rightDataChunk;
-    shared_ptr<ValueVector> rightNodeIDVector;
+    shared_ptr<ValueVector> rightValueVector;
 
     uint64_t leftIdx;
 };

--- a/src/processor/include/physical_plan/operator/limit/limit.h
+++ b/src/processor/include/physical_plan/operator/limit/limit.h
@@ -8,9 +8,12 @@ namespace processor {
 class Limit : public PhysicalOperator {
 
 public:
-    Limit(uint64_t limitNumber, shared_ptr<atomic_uint64_t> counter, uint64_t dataChunkToSelectPos,
-        vector<uint64_t> dataChunksToLimitPos, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    Limit(uint64_t limitNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
+        vector<uint32_t> dataChunksToLimitPos, unique_ptr<PhysicalOperator> prevOperator,
+        ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(prevOperator), LIMIT, context, id}, limitNumber{limitNumber},
+          counter{move(counter)}, dataChunkToSelectPos{dataChunkToSelectPos},
+          dataChunksToLimitPos(move(dataChunksToLimitPos)) {}
 
     void getNextTuples() override;
 
@@ -22,8 +25,8 @@ public:
 private:
     uint64_t limitNumber;
     shared_ptr<atomic_uint64_t> counter;
-    uint64_t dataChunkToSelectPos;
-    vector<uint64_t> dataChunksToLimitPos;
+    uint32_t dataChunkToSelectPos;
+    vector<uint32_t> dataChunksToLimitPos;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/load_csv/load_csv.h
+++ b/src/processor/include/physical_plan/operator/load_csv/load_csv.h
@@ -12,16 +12,18 @@ class LoadCSV : public PhysicalOperator {
 
 public:
     LoadCSV(const string& fname, char tokenSeparator, vector<DataType> csvColumnDataTypes,
-        uint32_t totalNumDataChunks, uint32_t outDataChunkSize, uint32_t outDataChunkPos,
-        vector<uint32_t> outValueVectorsPos, ExecutionContext& context, uint32_t id);
+        uint32_t outDataChunkPos, vector<uint32_t> outValueVectorsPos, ExecutionContext& context,
+        uint32_t id);
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void reInitialize() override {}
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<LoadCSV>(fname, tokenSeparator, csvColumnDataTypes, totalNumDataChunks,
-            outDataChunkSize, outDataChunkPos, outValueVectorsPos, context, id);
+        return make_unique<LoadCSV>(fname, tokenSeparator, csvColumnDataTypes, outDataChunkPos,
+            outValueVectorsPos, context, id);
     }
 
 private:
@@ -30,8 +32,6 @@ private:
     vector<DataType> csvColumnDataTypes;
     CSVReader reader;
 
-    uint32_t totalNumDataChunks;
-    uint32_t outDataChunkSize;
     uint32_t outDataChunkPos;
     vector<uint32_t> outValueVectorsPos;
 

--- a/src/processor/include/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.h
+++ b/src/processor/include/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.h
@@ -9,7 +9,9 @@ class MultiplicityReducer : public PhysicalOperator {
 
 public:
     MultiplicityReducer(
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(prevOperator), MULTIPLICITY_REDUCER, context, id},
+          prevMultiplicity{1}, numRepeat{0} {}
 
     void reInitialize() override;
 

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/processor/include/execution_context.h"
+#include "src/processor/include/physical_plan/data_pos.h"
 #include "src/processor/include/physical_plan/operator/result/result_set.h"
 
 using namespace graphflow::transaction;
@@ -66,6 +67,8 @@ public:
         bool isOutDataChunkFiltered, ExecutionContext& context, uint32_t id);
 
     virtual ~PhysicalOperator() = default;
+
+    virtual void initResultSet(const shared_ptr<ResultSet>& resultSet);
 
     // For subquery, we rerun a plan multiple times. ReInitialize() should be called before each run
     // to ensure

--- a/src/processor/include/physical_plan/operator/physical_operator_info.h
+++ b/src/processor/include/physical_plan/operator/physical_operator_info.h
@@ -5,6 +5,7 @@
 
 #include "src/common/include/assert.h"
 #include "src/planner/include/logical_plan/schema.h"
+#include "src/processor/include/physical_plan/data_pos.h"
 
 using namespace graphflow::planner;
 using namespace std;
@@ -17,32 +18,18 @@ class PhysicalOperatorsInfo {
 public:
     explicit PhysicalOperatorsInfo(const Schema& schema);
 
-    inline bool containVariable(const string& variable) {
+    inline bool containVariable(const string& variable) const {
         return variableToDataPosMap.contains(variable);
     }
 
-    inline pair<uint32_t, uint32_t> getDataChunkAndValueVectorPos(const string& variable) {
+    inline DataPos getDataPos(const string& variable) const {
         GF_ASSERT(variableToDataPosMap.contains(variable));
         return variableToDataPosMap.at(variable);
     }
 
-    inline uint32_t getDataChunkPos(const string& variable) {
-        return getDataChunkAndValueVectorPos(variable).first;
-    }
-
-    inline uint32_t getTotalNumDataChunks() { return totalNumDataChunks; }
-
-    inline uint32_t getDataChunkSize(uint32_t dataChunkPos) {
-        GF_ASSERT(dataChunkPosToNumValueVectors.contains(dataChunkPos));
-        return dataChunkPosToNumValueVectors.at(dataChunkPos);
-    }
-
 private:
     // Map each variable to its position pair (dataChunkPos, vectorPos)
-    unordered_map<string, pair<uint32_t, uint32_t>> variableToDataPosMap;
-
-    uint32_t totalNumDataChunks;
-    unordered_map<uint32_t, uint32_t> dataChunkPosToNumValueVectors;
+    unordered_map<string, DataPos> variableToDataPosMap;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/projection/projection.h
+++ b/src/processor/include/physical_plan/operator/projection/projection.h
@@ -13,26 +13,27 @@ namespace processor {
 class Projection : public PhysicalOperator {
 
 public:
-    Projection(uint32_t totalNumDataChunks, vector<uint32_t> outDataChunksSize,
-        vector<unique_ptr<ExpressionEvaluator>> expressions,
-        vector<pair<uint32_t, uint32_t>> expressionsOutputPos,
-        vector<uint32_t> discardedDataChunksPos, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    Projection(vector<unique_ptr<ExpressionEvaluator>> expressions,
+        vector<DataPos> expressionsOutputPos, vector<uint32_t> discardedDataChunksPos,
+        shared_ptr<ResultSet> inResultSet, unique_ptr<PhysicalOperator> prevOperator,
+        ExecutionContext& context, uint32_t id)
+        : PhysicalOperator(move(prevOperator), PROJECTION, context, id),
+          expressions(move(expressions)), expressionsOutputPos{move(expressionsOutputPos)},
+          discardedDataChunksPos{move(discardedDataChunksPos)}, inResultSet{move(inResultSet)} {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override;
 
 private:
-    uint32_t totalNumDataChunks;
-    vector<uint32_t> outDataChunksSize;
-
     vector<unique_ptr<ExpressionEvaluator>> expressions;
-    vector<pair<uint32_t, uint32_t>> expressionsOutputPos;
+    vector<DataPos> expressionsOutputPos;
     vector<uint32_t> discardedDataChunksPos;
+    shared_ptr<ResultSet> inResultSet;
 
     shared_ptr<ResultSet> discardedResultSet;
-    shared_ptr<ResultSet> inResultSet;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
@@ -8,20 +8,19 @@ namespace processor {
 class AdjListExtend : public ReadList {
 
 public:
-    AdjListExtend(uint32_t inDataChunkPos, uint32_t inValueVectorPos, uint32_t outDataChunkSize,
-        uint32_t outDataChunkPos, uint32_t outValueVectorPos, AdjLists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+    AdjListExtend(const DataPos& inDataPos, const DataPos& outDataPos, AdjLists* lists,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : ReadList{inDataPos, outDataPos, lists, move(prevOperator), context, id,
+              true /* isAdjList */} {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<AdjListExtend>(inDataChunkPos, inValueVectorPos, outDataChunkSize,
-            outDataChunkPos, outValueVectorPos, (AdjLists*)lists, prevOperator->clone(), context,
-            id);
+        return make_unique<AdjListExtend>(
+            inDataPos, outDataPos, (AdjLists*)lists, prevOperator->clone(), context, id);
     }
-
-private:
-    uint32_t outDataChunkSize;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
@@ -9,10 +9,11 @@ namespace processor {
 class FrontierExtend : public ReadList {
 
 public:
-    FrontierExtend(uint32_t inDataChunkPos, uint32_t inValueVectorPos, uint32_t outDataChunkSize,
-        uint32_t outDataChunkPos, uint32_t outValueVectorPos, AdjLists* lists,
+    FrontierExtend(const DataPos& inDataPos, const DataPos& outDataPos, AdjLists* lists,
         label_t outNodeIDVectorLabel, uint64_t lowerBound, uint64_t upperBound,
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void getNextTuples() override;
 
@@ -51,8 +52,6 @@ private:
     } currOutputPos;
 
     label_t outNodeIDVectorLabel;
-
-    uint32_t outDataChunkSize;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/read_list/read_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_list.h
@@ -9,20 +9,25 @@ namespace processor {
 class ReadList : public PhysicalOperator {
 
 public:
-    ReadList(uint32_t inDataChunkPos, uint32_t inValueVectorPos, uint32_t outDataChunkPos,
-        uint32_t outValueVectorPos, Lists* lists, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id, bool isAdjList);
+    ReadList(const DataPos& inDataPos, const DataPos& outDataPos, Lists* lists,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id,
+        bool isAdjList)
+        : PhysicalOperator{move(prevOperator), READ_LIST, context, id}, inDataPos{inDataPos},
+          outDataPos{outDataPos}, lists{lists}, largeListHandle{
+                                                    make_unique<LargeListHandle>(isAdjList)} {}
+
     ~ReadList() override{};
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
+
     void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
 
 protected:
     void readValuesFromList();
 
 protected:
-    uint32_t inDataChunkPos;
-    uint32_t inValueVectorPos;
-    uint32_t outDataChunkPos;
-    uint32_t outValueVectorPos;
+    DataPos inDataPos;
+    DataPos outDataPos;
 
     shared_ptr<DataChunk> inDataChunk;
     shared_ptr<ValueVector> inValueVector;

--- a/src/processor/include/physical_plan/operator/read_list/read_rel_property_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_rel_property_list.h
@@ -8,15 +8,18 @@ namespace processor {
 class ReadRelPropertyList : public ReadList {
 
 public:
-    ReadRelPropertyList(uint32_t inDataChunkPos, uint32_t inValueVectorPos,
-        uint32_t outDataChunkPos, uint32_t outValueVectorPos, Lists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+    ReadRelPropertyList(const DataPos& inDataPos, const DataPos& outDataPos, Lists* lists,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : ReadList{inDataPos, outDataPos, lists, move(prevOperator), context, id,
+              false /* is not adj list */} {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ReadRelPropertyList>(inDataChunkPos, inValueVectorPos, outDataChunkPos,
-            outValueVectorPos, lists, prevOperator->clone(), context, id);
+        return make_unique<ReadRelPropertyList>(
+            inDataPos, outDataPos, lists, prevOperator->clone(), context, id);
     }
 };
 

--- a/src/processor/include/physical_plan/operator/result/result_set.h
+++ b/src/processor/include/physical_plan/operator/result/result_set.h
@@ -15,10 +15,14 @@ public:
     explicit ResultSet(uint32_t numDataChunks)
         : multiplicity{1}, dataChunks(numDataChunks), listSyncStatesPerDataChunk(numDataChunks) {}
 
-    void insert(uint32_t pos, const shared_ptr<DataChunk>& dataChunk,
-        const shared_ptr<ListSyncState>& listSyncState);
     inline void insert(uint32_t pos, const shared_ptr<DataChunk>& dataChunk) {
-        insert(pos, dataChunk, nullptr);
+        assert(dataChunks.size() > pos);
+        dataChunks[pos] = dataChunk;
+    }
+
+    inline void insert(uint32_t pos, const shared_ptr<ListSyncState>& listSyncState) {
+        assert(listSyncStatesPerDataChunk.size() > pos);
+        listSyncStatesPerDataChunk[pos] = listSyncState;
     }
 
     uint64_t getNumTuples();

--- a/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
@@ -9,17 +9,20 @@ namespace processor {
 class AdjColumnExtend : public ScanColumn, public FilteringOperator {
 
 public:
-    AdjColumnExtend(uint32_t inAndOutDataChunkPos, uint32_t inValueVectorPos,
-        uint32_t outValueVectorPos, Column* column, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    AdjColumnExtend(const DataPos& inDataPos, const DataPos& outDataPos, Column* column,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : ScanColumn{inDataPos, outDataPos, column, move(prevOperator), context, id},
+          FilteringOperator() {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void reInitialize() override;
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<AdjColumnExtend>(inAndOutDataChunkPos, inValueVectorPos,
-            outValueVectorPos, column, prevOperator->clone(), context, id);
+        return make_unique<AdjColumnExtend>(
+            inDataPos, outDataPos, column, prevOperator->clone(), context, id);
     }
 };
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
@@ -10,16 +10,18 @@ namespace processor {
 class ScanAttribute : public PhysicalOperator {
 
 public:
-    ScanAttribute(uint32_t inAndOutDataChunkPos, uint32_t inValueVectorPos,
-        uint32_t outValueVectorPos, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    ScanAttribute(const DataPos& inDataPos, const DataPos& outDataPos,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(prevOperator), SCAN_ATTRIBUTE, context, id}, inDataPos{inDataPos},
+          outDataPos{outDataPos} {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
 
 protected:
-    uint32_t inAndOutDataChunkPos;
-    uint32_t inValueVectorPos;
-    uint32_t outValueVectorPos;
+    DataPos inDataPos;
+    DataPos outDataPos;
 
     shared_ptr<DataChunk> inDataChunk;
     shared_ptr<ValueVector> inValueVector;

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_column.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_column.h
@@ -11,13 +11,16 @@ namespace processor {
 class ScanColumn : public ScanAttribute {
 
 public:
-    ScanColumn(uint32_t inAndOutDataChunkPos, uint32_t inValueVectorPos, uint32_t outValueVectorPos,
-        Column* column, unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context,
-        uint32_t id)
-        : ScanAttribute{inAndOutDataChunkPos, inValueVectorPos, outValueVectorPos,
-              move(prevOperator), context, id},
-          column{column} {};
+    ScanColumn(const DataPos& inDataPos, const DataPos& outDataPos, Column* column,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : ScanAttribute{inDataPos, outDataPos, move(prevOperator), context, id}, column{column} {};
+
     ~ScanColumn() override{};
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override {
+        ScanAttribute::initResultSet(resultSet);
+    }
+
     void getNextTuples() override;
 
 protected:

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_structured_property.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_structured_property.h
@@ -8,15 +8,17 @@ namespace processor {
 class ScanStructuredProperty : public ScanColumn {
 
 public:
-    ScanStructuredProperty(uint32_t inAndOutDataChunkPos, uint32_t inValueVectorPos,
-        uint32_t outValueVectorPos, Column* column, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    ScanStructuredProperty(const DataPos& inDataPos, const DataPos& outDataPos, Column* column,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : ScanColumn{inDataPos, outDataPos, column, move(prevOperator), context, id} {}
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ScanStructuredProperty>(inAndOutDataChunkPos, inValueVectorPos,
-            outValueVectorPos, column, prevOperator->clone(), context, id);
+        return make_unique<ScanStructuredProperty>(
+            inDataPos, outDataPos, column, prevOperator->clone(), context, id);
     }
 };
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_unstructured_property.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_unstructured_property.h
@@ -11,15 +11,21 @@ namespace processor {
 class ScanUnstructuredProperty : public ScanAttribute {
 
 public:
-    ScanUnstructuredProperty(uint32_t inAndOutDataChunkPos, uint32_t inValueVectorPos,
-        uint32_t outValueVectorPos, uint32_t propertyKey, UnstructuredPropertyLists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+    ScanUnstructuredProperty(const DataPos& inDataPos, const DataPos& outDataPos,
+        uint32_t propertyKey, UnstructuredPropertyLists* lists,
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        : ScanAttribute{inDataPos, outDataPos, move(prevOperator), context, id},
+          propertyKey{propertyKey}, lists{lists} {}
+
     ~ScanUnstructuredProperty(){};
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
+
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ScanUnstructuredProperty>(inAndOutDataChunkPos, inValueVectorPos,
-            outValueVectorPos, propertyKey, lists, prevOperator->clone(), context, id);
+        return make_unique<ScanUnstructuredProperty>(
+            inDataPos, outDataPos, propertyKey, lists, prevOperator->clone(), context, id);
     }
 
 protected:

--- a/src/processor/include/physical_plan/operator/select_scan/select_scan.h
+++ b/src/processor/include/physical_plan/operator/select_scan/select_scan.h
@@ -12,28 +12,28 @@ namespace processor {
 class SelectScan : public PhysicalOperator {
 
 public:
-    SelectScan(uint32_t totalNumDataChunks, const ResultSet* inResultSet,
-        vector<pair<uint32_t, uint32_t>> inDataChunkAndValueVectorsPos, uint32_t outDataChunkSize,
-        uint32_t outDataChunkPos, vector<uint32_t> outValueVectorsPos, ExecutionContext& context,
-        uint32_t id);
+    SelectScan(vector<DataPos> inDataPoses, uint32_t outDataChunkPos,
+        vector<uint32_t> outValueVectorsPos, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{SELECT_SCAN, context, id}, inDataPoses{move(inDataPoses)},
+          outDataChunkPos{outDataChunkPos}, outValueVectorsPos{move(outValueVectorsPos)},
+          isFirstExecution{true} {}
 
     inline void setInResultSet(const ResultSet* resultSet) { inResultSet = resultSet; }
+
+    void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
     void reInitialize() override;
 
     void getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<SelectScan>(totalNumDataChunks, inResultSet,
-            inDataChunkAndValueVectorsPos, outDataChunkSize, outDataChunkPos, outValueVectorsPos,
-            context, id);
+        return make_unique<SelectScan>(
+            inDataPoses, outDataChunkPos, outValueVectorsPos, context, id);
     }
 
 private:
-    uint32_t totalNumDataChunks;
     const ResultSet* inResultSet;
-    vector<pair<uint32_t, uint32_t>> inDataChunkAndValueVectorsPos;
-    uint32_t outDataChunkSize;
+    vector<DataPos> inDataPoses;
     uint32_t outDataChunkPos;
     vector<uint32_t> outValueVectorsPos;
 

--- a/src/processor/include/physical_plan/operator/sink/sink.h
+++ b/src/processor/include/physical_plan/operator/sink/sink.h
@@ -8,11 +8,13 @@ namespace processor {
 class Sink : public PhysicalOperator {
 
 public:
-    Sink(unique_ptr<PhysicalOperator> prevOperator, PhysicalOperatorType operatorType,
-        ExecutionContext& context, uint32_t id)
+    Sink(shared_ptr<ResultSet> resultSet, unique_ptr<PhysicalOperator> prevOperator,
+        PhysicalOperatorType operatorType, ExecutionContext& context, uint32_t id)
         : PhysicalOperator{move(prevOperator), operatorType, context, id} {
-        resultSet = this->prevOperator->getResultSet();
-    };
+        this->resultSet = move(resultSet);
+    }
+
+    virtual void init() { prevOperator->initResultSet(resultSet); }
 
     virtual void execute() = 0;
 

--- a/src/processor/include/physical_plan/operator/skip/skip.h
+++ b/src/processor/include/physical_plan/operator/skip/skip.h
@@ -9,9 +9,13 @@ namespace processor {
 class Skip : public PhysicalOperator, public FilteringOperator {
 
 public:
-    Skip(uint64_t skipNumber, shared_ptr<atomic_uint64_t> counter, uint64_t dataChunkToSelectPos,
-        vector<uint64_t> dataChunksToSkipPos, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    Skip(uint64_t skipNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
+        vector<uint32_t> dataChunksToSkipPos, unique_ptr<PhysicalOperator> prevOperator,
+        ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(prevOperator), SKIP, context, id},
+          FilteringOperator(), skipNumber{skipNumber}, counter{move(counter)},
+          dataChunkToSelectPos{dataChunkToSelectPos}, dataChunksToSkipPos{
+                                                          move(dataChunksToSkipPos)} {}
 
     void reInitialize() override;
 
@@ -25,8 +29,8 @@ public:
 private:
     uint64_t skipNumber;
     shared_ptr<atomic_uint64_t> counter;
-    uint64_t dataChunkToSelectPos;
-    vector<uint64_t> dataChunksToSkipPos;
+    uint32_t dataChunkToSelectPos;
+    vector<uint32_t> dataChunksToSkipPos;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/plan_mapper.h
+++ b/src/processor/include/physical_plan/plan_mapper.h
@@ -16,59 +16,59 @@ class PlanMapper {
 public:
     // Create plan mapper with default mapper context.
     explicit PlanMapper(const Graph& graph)
-        : graph{graph}, outerQueryResultSet{nullptr}, physicalOperatorID{0},
+        : graph{graph}, outerPhysicalOperatorsInfo{nullptr}, physicalOperatorID{0},
           physicalIDToLogicalOperatorMap{}, expressionMapper{this} {}
 
     unique_ptr<PhysicalPlan> mapToPhysical(
         unique_ptr<LogicalPlan> logicalPlan, ExecutionContext& executionContext);
 
-    // Returns currentOuterQueryResultSet and current physicalOperatorsInfo Whoever calls
-    // enterSubquery is responsible to save the return resultSet and physicalOperatorsInfo and pass
-    // it back when calling exitSubquery()
-    pair<ResultSet*, PhysicalOperatorsInfo*> enterSubquery(
-        ResultSet* newOuterQueryResultSet, PhysicalOperatorsInfo* newPhysicalOperatorsInfo);
-    void exitSubquery(
-        ResultSet* prevOuterQueryResultSet, PhysicalOperatorsInfo* prevPhysicalOperatorsInfo);
+    // Returns current physicalOperatorsInfo whoever calls enterSubquery is responsible to save the
+    // return physicalOperatorsInfo and pass it back when calling exitSubquery()
+    const PhysicalOperatorsInfo* enterSubquery(
+        const PhysicalOperatorsInfo* newPhysicalOperatorsInfo);
+    void exitSubquery(const PhysicalOperatorsInfo* prevPhysicalOperatorsInfo);
 
 private:
     unique_ptr<PhysicalOperator> mapLogicalOperatorToPhysical(
-        const shared_ptr<LogicalOperator>& logicalOperator, PhysicalOperatorsInfo& info,
+        const shared_ptr<LogicalOperator>& logicalOperator, const PhysicalOperatorsInfo& info,
         ExecutionContext& executionContext);
 
-    unique_ptr<PhysicalOperator> mapLogicalScanNodeIDToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalSelectScanToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalExtendToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalFlattenToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalFilterToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalIntersectToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalProjectionToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalScanNodeIDToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalSelectScanToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalExtendToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalFlattenToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalFilterToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalIntersectToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalProjectionToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
     unique_ptr<PhysicalOperator> mapLogicalScanNodePropertyToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
+        LogicalOperator* logicalOperator, const PhysicalOperatorsInfo& info,
+        ExecutionContext& context);
     unique_ptr<PhysicalOperator> mapLogicalScanRelPropertyToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalHashJoinToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalLoadCSVToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
+        LogicalOperator* logicalOperator, const PhysicalOperatorsInfo& info,
+        ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalHashJoinToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalLoadCSVToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
     unique_ptr<PhysicalOperator> mapLogicalMultiplicityReducerToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalSkipToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
-    unique_ptr<PhysicalOperator> mapLogicalLimitToPhysical(
-        LogicalOperator* logicalOperator, PhysicalOperatorsInfo& info, ExecutionContext& context);
+        LogicalOperator* logicalOperator, const PhysicalOperatorsInfo& info,
+        ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalSkipToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
+    unique_ptr<PhysicalOperator> mapLogicalLimitToPhysical(LogicalOperator* logicalOperator,
+        const PhysicalOperatorsInfo& info, ExecutionContext& context);
 
 public:
     const Graph& graph;
 
-    ResultSet* outerQueryResultSet;
-    PhysicalOperatorsInfo* outerPhysicalOperatorsInfo;
+    const PhysicalOperatorsInfo* outerPhysicalOperatorsInfo;
 
     uint32_t physicalOperatorID;
     // used for EXPLAIN & PROFILE which require print physical operator and logical information.

--- a/src/processor/physical_plan/operator/flatten/flatten.cpp
+++ b/src/processor/physical_plan/operator/flatten/flatten.cpp
@@ -3,12 +3,9 @@
 namespace graphflow {
 namespace processor {
 
-Flatten::Flatten(uint64_t dataChunkPos, unique_ptr<PhysicalOperator> prevOperator,
-    ExecutionContext& context, uint32_t id)
-    : PhysicalOperator{move(prevOperator), FLATTEN, context, id}, dataChunkToFlattenPos{
-                                                                      dataChunkPos} {
-    resultSet = this->prevOperator->getResultSet();
-    dataChunkToFlatten = resultSet->dataChunks[dataChunkPos];
+void Flatten::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    PhysicalOperator::initResultSet(resultSet);
+    dataChunkToFlatten = resultSet->dataChunks[dataChunkToFlattenPos];
 }
 
 void Flatten::getNextTuples() {

--- a/src/processor/physical_plan/operator/limit/limit.cpp
+++ b/src/processor/physical_plan/operator/limit/limit.cpp
@@ -3,15 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-Limit::Limit(uint64_t limitNumber, shared_ptr<atomic_uint64_t> counter,
-    uint64_t dataChunkToSelectPos, vector<uint64_t> dataChunksToLimitPos,
-    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-    : PhysicalOperator{move(prevOperator), LIMIT, context, id},
-      limitNumber{limitNumber}, counter{move(counter)}, dataChunkToSelectPos{dataChunkToSelectPos},
-      dataChunksToLimitPos(move(dataChunksToLimitPos)) {
-    resultSet = this->prevOperator->getResultSet();
-}
-
 void Limit::getNextTuples() {
     metrics->executionTime.start();
     prevOperator->getNextTuples();

--- a/src/processor/physical_plan/operator/load_csv/load_csv.cpp
+++ b/src/processor/physical_plan/operator/load_csv/load_csv.cpp
@@ -10,24 +10,24 @@ namespace graphflow {
 namespace processor {
 
 LoadCSV::LoadCSV(const string& fname, char tokenSeparator, vector<DataType> csvColumnDataTypes,
-    uint32_t totalNumDataChunks, uint32_t outDataChunkSize, uint32_t outDataChunkPos,
-    vector<uint32_t> outValueVectorsPos, ExecutionContext& context, uint32_t id)
+    uint32_t outDataChunkPos, vector<uint32_t> outValueVectorsPos, ExecutionContext& context,
+    uint32_t id)
     : PhysicalOperator{LOAD_CSV, context, id}, fname{fname}, tokenSeparator{tokenSeparator},
-      csvColumnDataTypes{csvColumnDataTypes}, reader{fname, tokenSeparator},
-      totalNumDataChunks{totalNumDataChunks}, outDataChunkSize{outDataChunkSize},
+      csvColumnDataTypes{move(csvColumnDataTypes)}, reader{fname, tokenSeparator},
       outDataChunkPos{outDataChunkPos}, outValueVectorsPos{move(outValueVectorsPos)} {
-    resultSet = make_shared<ResultSet>(totalNumDataChunks);
-    outDataChunk = make_shared<DataChunk>(outDataChunkSize);
-    for (auto& csvColumnDataType : csvColumnDataTypes) {
-        outValueVectors.emplace_back(new ValueVector(context.memoryManager, csvColumnDataType));
-    }
-    for (auto i = 0u; i < outValueVectors.size(); ++i) {
-        outDataChunk->insert(this->outValueVectorsPos[i], outValueVectors[i]);
-    }
-    resultSet->insert(outDataChunkPos, outDataChunk);
     // skip the file header.
     if (reader.hasNextLine()) {
         reader.skipLine();
+    }
+}
+
+void LoadCSV::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    PhysicalOperator::initResultSet(resultSet);
+    outDataChunk = this->resultSet->dataChunks[outDataChunkPos];
+    for (auto i = 0u; i < outValueVectorsPos.size(); ++i) {
+        auto valueVector = make_shared<ValueVector>(context.memoryManager, csvColumnDataTypes[i]);
+        outValueVectors.push_back(valueVector);
+        outDataChunk->insert(outValueVectorsPos[i], valueVector);
     }
 }
 

--- a/src/processor/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.cpp
+++ b/src/processor/physical_plan/operator/multiplicity_reducer/multiplicity_reducer.cpp
@@ -3,13 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-MultiplicityReducer::MultiplicityReducer(
-    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-    : PhysicalOperator{move(prevOperator), MULTIPLICITY_REDUCER, context, id},
-      prevMultiplicity{1}, numRepeat{0} {
-    resultSet = this->prevOperator->getResultSet();
-}
-
 void MultiplicityReducer::reInitialize() {
     PhysicalOperator::reInitialize();
     prevMultiplicity = 1;

--- a/src/processor/physical_plan/operator/physical_operator.cpp
+++ b/src/processor/physical_plan/operator/physical_operator.cpp
@@ -13,6 +13,13 @@ PhysicalOperator::PhysicalOperator(unique_ptr<PhysicalOperator> prevOperator,
     registerProfilingMetrics();
 }
 
+void PhysicalOperator::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    if (prevOperator != nullptr) {
+        prevOperator->initResultSet(resultSet);
+    }
+    this->resultSet = resultSet;
+}
+
 void PhysicalOperator::registerProfilingMetrics() {
     auto executionTime = context.profiler.registerTimeMetric(getTimeMetricKey());
     auto numOutputTuple = context.profiler.registerNumericMetric(getNumTupleMetricKey());

--- a/src/processor/physical_plan/operator/physical_operator_info.cpp
+++ b/src/processor/physical_plan/operator/physical_operator_info.cpp
@@ -8,13 +8,11 @@ PhysicalOperatorsInfo::PhysicalOperatorsInfo(const Schema& schema) {
     for (auto& group : schema.groups) {
         auto vectorPos = 0ul;
         for (auto& variable : group->variables) {
-            variableToDataPosMap.insert({variable, make_pair(dataChunkPos, vectorPos)});
+            variableToDataPosMap.insert({variable, DataPos(dataChunkPos, vectorPos)});
             vectorPos++;
         }
-        dataChunkPosToNumValueVectors.insert({dataChunkPos, vectorPos});
         dataChunkPos++;
     }
-    totalNumDataChunks = dataChunkPos;
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -3,18 +3,12 @@
 namespace graphflow {
 namespace processor {
 
-AdjListExtend::AdjListExtend(uint32_t inDataChunkPos, uint32_t inValueVectorPos,
-    uint32_t outDataChunkSize, uint32_t outDataChunkPos, uint32_t outValueVectorPos,
-    AdjLists* lists, unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context,
-    uint32_t id)
-    : ReadList{inDataChunkPos, inValueVectorPos, outDataChunkPos, outValueVectorPos, lists,
-          move(prevOperator), context, id, true /* is adj list */},
-      outDataChunkSize{outDataChunkSize} {
+void AdjListExtend::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    ReadList::initResultSet(resultSet);
     outValueVector = make_shared<ValueVector>(context.memoryManager, NODE);
-    outDataChunk = make_shared<DataChunk>(outDataChunkSize);
-    outDataChunk->insert(outValueVectorPos, outValueVector);
+    outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
     auto listSyncState = make_shared<ListSyncState>();
-    resultSet->insert(outDataChunkPos, outDataChunk, listSyncState);
+    resultSet->insert(outDataPos.dataChunkPos, listSyncState);
     largeListHandle->setListSyncState(listSyncState);
 }
 

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -3,17 +3,11 @@
 namespace graphflow {
 namespace processor {
 
-ReadList::ReadList(uint32_t inDataChunkPos, uint32_t inValueVectorPos, uint32_t outDataChunkPos,
-    uint32_t outValueVectorPos, Lists* lists, unique_ptr<PhysicalOperator> prevOperator,
-    ExecutionContext& context, uint32_t id, bool isAdjList)
-    : PhysicalOperator{move(prevOperator), READ_LIST, context, id}, inDataChunkPos{inDataChunkPos},
-      inValueVectorPos{inValueVectorPos}, outDataChunkPos{outDataChunkPos},
-      outValueVectorPos{outValueVectorPos}, lists{lists} {
-    resultSet = this->prevOperator->getResultSet();
-    inDataChunk = resultSet->dataChunks[inDataChunkPos];
-    inValueVector = inDataChunk->getValueVector(inValueVectorPos);
-    assert(inValueVector->dataType == NODE);
-    largeListHandle = make_unique<LargeListHandle>(isAdjList);
+void ReadList::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    PhysicalOperator::initResultSet(resultSet);
+    inDataChunk = this->resultSet->dataChunks[inDataPos.dataChunkPos];
+    inValueVector = inDataChunk->valueVectors[inDataPos.valueVectorPos];
+    outDataChunk = this->resultSet->dataChunks[outDataPos.dataChunkPos];
 }
 
 void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -5,15 +5,11 @@
 namespace graphflow {
 namespace processor {
 
-ReadRelPropertyList::ReadRelPropertyList(uint32_t inDataChunkPos, uint32_t inValueVectorPos,
-    uint32_t outDataChunkPos, uint32_t outValueVectorPos, Lists* lists,
-    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-    : ReadList{inDataChunkPos, inValueVectorPos, outDataChunkPos, outValueVectorPos, lists,
-          move(prevOperator), context, id, false /* is not adj list */} {
+void ReadRelPropertyList::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    ReadList::initResultSet(resultSet);
     outValueVector = make_shared<ValueVector>(context.memoryManager, lists->getDataType());
-    outDataChunk = resultSet->dataChunks[outDataChunkPos];
-    largeListHandle->setListSyncState(resultSet->getListSyncState(outDataChunkPos));
-    outDataChunk->insert(outValueVectorPos, outValueVector);
+    outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
+    largeListHandle->setListSyncState(resultSet->getListSyncState(outDataPos.dataChunkPos));
 }
 
 void ReadRelPropertyList::getNextTuples() {

--- a/src/processor/physical_plan/operator/result/result_set.cpp
+++ b/src/processor/physical_plan/operator/result/result_set.cpp
@@ -3,13 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-void ResultSet::insert(uint32_t pos, const shared_ptr<DataChunk>& dataChunk,
-    const shared_ptr<ListSyncState>& listSyncState) {
-    assert(dataChunks.size() > pos);
-    dataChunks[pos] = dataChunk;
-    listSyncStatesPerDataChunk[pos] = listSyncState;
-}
-
 uint64_t ResultSet::getNumTuples() {
     uint64_t numTuples = 1;
     for (auto& dataChunk : dataChunks) {

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -3,14 +3,10 @@
 namespace graphflow {
 namespace processor {
 
-AdjColumnExtend::AdjColumnExtend(uint32_t inAndOutDataChunkPos, uint32_t inValueVectorPos,
-    uint32_t outValueVectorPos, Column* column, unique_ptr<PhysicalOperator> prevOperator,
-    ExecutionContext& context, uint32_t id)
-    : ScanColumn{inAndOutDataChunkPos, inValueVectorPos, outValueVectorPos, column,
-          move(prevOperator), context, id},
-      FilteringOperator(this->inDataChunk) {
+void AdjColumnExtend::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    ScanColumn::initResultSet(resultSet);
     outValueVector = make_shared<ValueVector>(context.memoryManager, NODE);
-    inDataChunk->insert(outValueVectorPos, outValueVector);
+    inDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
 }
 
 void AdjColumnExtend::reInitialize() {
@@ -22,9 +18,9 @@ void AdjColumnExtend::getNextTuples() {
     metrics->executionTime.start();
     bool hasAtLeastOneNonNullValue;
     do {
-        restoreDataChunkSelectorState();
+        restoreDataChunkSelectorState(inDataChunk);
         ScanColumn::getNextTuples();
-        saveDataChunkSelectorState();
+        saveDataChunkSelectorState(inDataChunk);
         hasAtLeastOneNonNullValue = outValueVector->discardNullNodes();
     } while (inDataChunk->state->selectedSize > 0 && !hasAtLeastOneNonNullValue);
     metrics->executionTime.stop();

--- a/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
@@ -3,16 +3,11 @@
 namespace graphflow {
 namespace processor {
 
-ScanAttribute::ScanAttribute(uint32_t inAndOutDataChunkPos, uint32_t inValueVectorPos,
-    uint32_t outValueVectorPos, unique_ptr<PhysicalOperator> prevOperator,
-    ExecutionContext& context, uint32_t id)
-    : PhysicalOperator{move(prevOperator), SCAN_ATTRIBUTE, context, id},
-      inAndOutDataChunkPos{inAndOutDataChunkPos}, inValueVectorPos{inValueVectorPos},
-      outValueVectorPos{outValueVectorPos} {
-    resultSet = this->prevOperator->getResultSet();
-    inDataChunk = resultSet->dataChunks[inAndOutDataChunkPos];
-    inValueVector = inDataChunk->getValueVector(inValueVectorPos);
-    assert(inValueVector->dataType == NODE);
+void ScanAttribute::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    PhysicalOperator::initResultSet(resultSet);
+    assert(inDataPos.dataChunkPos == outDataPos.dataChunkPos);
+    inDataChunk = this->resultSet->dataChunks[inDataPos.dataChunkPos];
+    inValueVector = inDataChunk->valueVectors[inDataPos.valueVectorPos];
 }
 
 void ScanAttribute::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {

--- a/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
@@ -5,13 +5,10 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace processor {
 
-ScanStructuredProperty::ScanStructuredProperty(uint32_t inAndOutDataChunkPos,
-    uint32_t inValueVectorPos, uint32_t outValueVectorPos, Column* column,
-    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-    : ScanColumn{inAndOutDataChunkPos, inValueVectorPos, outValueVectorPos, column,
-          move(prevOperator), context, id} {
+void ScanStructuredProperty::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    ScanColumn::initResultSet(resultSet);
     outValueVector = make_shared<ValueVector>(context.memoryManager, column->getDataType());
-    inDataChunk->insert(outValueVectorPos, outValueVector);
+    inDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
 }
 
 void ScanStructuredProperty::getNextTuples() {

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -5,18 +5,10 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace processor {
 
-ScanUnstructuredProperty::ScanUnstructuredProperty(uint32_t inAndOutDataChunkPos,
-    uint32_t inValueVectorPos, uint32_t outValueVectorPos, uint32_t propertyKey,
-    UnstructuredPropertyLists* lists, unique_ptr<PhysicalOperator> prevOperator,
-    ExecutionContext& context, uint32_t id)
-    : ScanAttribute{inAndOutDataChunkPos, inValueVectorPos, outValueVectorPos, move(prevOperator),
-          context, id},
-      propertyKey{propertyKey}, lists{lists} {
-    resultSet = this->prevOperator->getResultSet();
-    inDataChunk = resultSet->dataChunks[inAndOutDataChunkPos];
-    inValueVector = inDataChunk->getValueVector(inValueVectorPos);
+void ScanUnstructuredProperty::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    ScanAttribute::initResultSet(resultSet);
     outValueVector = make_shared<ValueVector>(context.memoryManager, lists->getDataType());
-    inDataChunk->insert(outValueVectorPos, outValueVector);
+    inDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
 }
 
 void ScanUnstructuredProperty::getNextTuples() {

--- a/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
@@ -3,31 +3,11 @@
 namespace graphflow {
 namespace processor {
 
-ScanNodeID::ScanNodeID(uint32_t totalNumDataChunks, uint32_t outDataChunkSize,
-    uint32_t outDataChunkPos, uint32_t outValueVectorPos, shared_ptr<MorselsDesc>& morsel,
-    ExecutionContext& context, uint32_t id)
-    : PhysicalOperator(SCAN, context, id), totalNumDataChunks{totalNumDataChunks},
-      outDataChunkSize{outDataChunkSize}, outDataChunkPos{outDataChunkPos},
-      outValueVectorPos{outValueVectorPos}, morsel{morsel} {
-    resultSet = make_shared<ResultSet>(totalNumDataChunks);
-    initResultSet(outDataChunkSize);
-}
-
-ScanNodeID::ScanNodeID(uint32_t outDataChunkSize, uint32_t outDataChunkPos,
-    uint32_t outValueVectorPos, shared_ptr<MorselsDesc>& morsel,
-    unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-    : PhysicalOperator{move(prevOperator), SCAN, context, id}, outDataChunkSize{outDataChunkSize},
-      outDataChunkPos{outDataChunkPos}, outValueVectorPos{outValueVectorPos}, morsel{morsel} {
-    resultSet = this->prevOperator->getResultSet();
-    initResultSet(outDataChunkSize);
-}
-
-void ScanNodeID::initResultSet(uint32_t outDataChunkSize) {
-    outValueVector = make_shared<ValueVector>(
-        context.memoryManager, NODE, true /* isSingleValue */, true /* isSequence */);
-    outDataChunk = make_shared<DataChunk>(outDataChunkSize);
-    outDataChunk->insert(outValueVectorPos, outValueVector);
-    resultSet->insert(outDataChunkPos, outDataChunk);
+void ScanNodeID::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+    PhysicalOperator::initResultSet(resultSet);
+    outDataChunk = this->resultSet->dataChunks[outDataPos.dataChunkPos];
+    outValueVector = make_shared<ValueVector>(context.memoryManager, NODE, true /* isSequence */);
+    outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
 }
 
 void ScanNodeID::reInitialize() {

--- a/src/processor/physical_plan/operator/skip/skip.cpp
+++ b/src/processor/physical_plan/operator/skip/skip.cpp
@@ -3,16 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-Skip::Skip(uint64_t skipNumber, shared_ptr<atomic_uint64_t> counter, uint64_t dataChunkToSelectPos,
-    vector<uint64_t> dataChunksToSkipPos, unique_ptr<PhysicalOperator> prevOperator,
-    ExecutionContext& context, uint32_t id)
-    : PhysicalOperator{move(prevOperator), SKIP, context, id},
-      FilteringOperator(this->prevOperator->getResultSet()->dataChunks[dataChunkToSelectPos]),
-      skipNumber{skipNumber}, counter{move(counter)}, dataChunkToSelectPos{dataChunkToSelectPos},
-      dataChunksToSkipPos{move(dataChunksToSkipPos)} {
-    resultSet = this->prevOperator->getResultSet();
-}
-
 void Skip::reInitialize() {
     PhysicalOperator::reInitialize();
     FilteringOperator::reInitialize();
@@ -20,10 +10,11 @@ void Skip::reInitialize() {
 
 void Skip::getNextTuples() {
     metrics->executionTime.start();
+    auto& dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];
     auto numTupleSkippedBefore = 0u;
     auto numTuplesAvailable = 1u;
     do {
-        restoreDataChunkSelectorState();
+        restoreDataChunkSelectorState(dataChunkToSelect);
         prevOperator->getNextTuples();
         for (auto& dataChunkToSkipPos : dataChunksToSkipPos) {
             numTuplesAvailable *=
@@ -33,7 +24,7 @@ void Skip::getNextTuples() {
         if (numTuplesAvailable == 0) {
             return;
         }
-        saveDataChunkSelectorState();
+        saveDataChunkSelectorState(dataChunkToSelect);
         numTupleSkippedBefore = counter->fetch_add(numTuplesAvailable);
     } while (numTupleSkippedBefore + numTuplesAvailable <= skipNumber);
     int64_t numTupleToSkipInCurrentResultSet = skipNumber - numTupleSkippedBefore;
@@ -44,7 +35,6 @@ void Skip::getNextTuples() {
         // If all dataChunks are flat, numTupleAvailable = 1 which means numTupleSkippedBefore =
         // skipNumber. So execution is handled in above if statement.
         assert(!dataChunkToSelect->state->isFlat());
-        auto& dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];
         auto selectedPosBuffer = dataChunkToSelect->state->selectedPositionsBuffer.get();
         if (dataChunkToSelect->state->isUnfiltered()) {
             for (uint64_t i = numTupleToSkipInCurrentResultSet;

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -70,7 +70,8 @@ TEST_F(ExpressionMapperTest, BinaryExpressionEvaluatorTest) {
     auto physicalOperatorInfo = makeSimplePhysicalOperatorInfo();
     auto rootExpressionEvaluator =
         ExpressionMapper(planMapper.get())
-            .mapToPhysical(*addLogicalOperator, physicalOperatorInfo, &resultSet, *context);
+            .mapToPhysical(*addLogicalOperator, physicalOperatorInfo, *context);
+    rootExpressionEvaluator->initResultSet(resultSet, *memoryManager);
     rootExpressionEvaluator->evaluate();
 
     auto results = (int64_t*)rootExpressionEvaluator->result->values;
@@ -102,7 +103,8 @@ TEST_F(ExpressionMapperTest, UnaryExpressionEvaluatorTest) {
     auto physicalOperatorInfo = makeSimplePhysicalOperatorInfo();
     auto rootExpressionEvaluator =
         ExpressionMapper(planMapper.get())
-            .mapToPhysical(*negateLogicalOperator, physicalOperatorInfo, &resultSet, *context);
+            .mapToPhysical(*negateLogicalOperator, physicalOperatorInfo, *context);
+    rootExpressionEvaluator->initResultSet(resultSet, *memoryManager);
     rootExpressionEvaluator->evaluate();
 
     auto results = (int64_t*)rootExpressionEvaluator->result->values;
@@ -135,9 +137,11 @@ TEST_F(ExpressionMapperTest, AggrExpressionEvaluatorTest) {
     auto countStarExpr = make_unique<Expression>(ExpressionType::COUNT_STAR_FUNC, DataType::INT64);
     auto countStarExprEvaluator =
         ExpressionMapper(planMapper.get())
-            .mapToPhysical(*countStarExpr, physicalOperatorInfo, &resultSet, *context);
+            .mapToPhysical(*countStarExpr, physicalOperatorInfo, *context);
     auto countStarAggrEvaluator =
         reinterpret_cast<AggregateExpressionEvaluator*>(countStarExprEvaluator.get());
+    countStarAggrEvaluator->initResultSet(resultSet, *memoryManager);
+
     auto countStarState = make_unique<CountFunction<true>::CountState>();
     countStarAggrEvaluator->getFunction()->initialize((uint8_t*)countStarState.get());
     countStarAggrEvaluator->getFunction()->update(
@@ -153,11 +157,12 @@ TEST_F(ExpressionMapperTest, AggrExpressionEvaluatorTest) {
 
     auto countExpr =
         make_unique<Expression>(ExpressionType::COUNT_FUNC, DataType::INT64, makeAPropExpression());
-    auto countExprEvaluator =
-        ExpressionMapper(planMapper.get())
-            .mapToPhysical(*countExpr, physicalOperatorInfo, &resultSet, *context);
+    auto countExprEvaluator = ExpressionMapper(planMapper.get())
+                                  .mapToPhysical(*countExpr, physicalOperatorInfo, *context);
     auto countAggrEvaluator =
         reinterpret_cast<AggregateExpressionEvaluator*>(countExprEvaluator.get());
+    countStarAggrEvaluator->initResultSet(resultSet, *memoryManager);
+
     auto countState = make_unique<CountFunction<false>::CountState>();
     countAggrEvaluator->getFunction()->initialize((uint8_t*)countState.get());
     countAggrEvaluator->getFunction()->update(
@@ -174,9 +179,10 @@ TEST_F(ExpressionMapperTest, AggrExpressionEvaluatorTest) {
     auto sumExpr =
         make_unique<Expression>(ExpressionType::SUM_FUNC, DataType::INT64, makeAPropExpression());
     auto sumExprEvaluator =
-        ExpressionMapper(planMapper.get())
-            .mapToPhysical(*sumExpr, physicalOperatorInfo, &resultSet, *context);
+        ExpressionMapper(planMapper.get()).mapToPhysical(*sumExpr, physicalOperatorInfo, *context);
     auto sumAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(sumExprEvaluator.get());
+    sumAggrEvaluator->initResultSet(resultSet, *memoryManager);
+
     auto sumState = make_unique<SumFunction<int64_t>::SumState>();
     sumAggrEvaluator->getFunction()->initialize((uint8_t*)sumState.get());
     sumAggrEvaluator->getFunction()->update(
@@ -199,9 +205,10 @@ TEST_F(ExpressionMapperTest, AggrExpressionEvaluatorTest) {
     auto avgExpr =
         make_unique<Expression>(ExpressionType::AVG_FUNC, DataType::INT64, makeAPropExpression());
     auto avgExprEvaluator =
-        ExpressionMapper(planMapper.get())
-            .mapToPhysical(*avgExpr, physicalOperatorInfo, &resultSet, *context);
+        ExpressionMapper(planMapper.get()).mapToPhysical(*avgExpr, physicalOperatorInfo, *context);
     auto avgAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(avgExprEvaluator.get());
+    avgAggrEvaluator->initResultSet(resultSet, *memoryManager);
+
     auto avgState = make_unique<AvgFunction<int64_t>::AvgState>();
     avgAggrEvaluator->getFunction()->initialize((uint8_t*)avgState.get());
     avgAggrEvaluator->getFunction()->update(
@@ -219,9 +226,10 @@ TEST_F(ExpressionMapperTest, AggrExpressionEvaluatorTest) {
     auto maxExpr =
         make_unique<Expression>(ExpressionType::MAX_FUNC, DataType::INT64, makeAPropExpression());
     auto maxExprEvaluator =
-        ExpressionMapper(planMapper.get())
-            .mapToPhysical(*maxExpr, physicalOperatorInfo, &resultSet, *context);
+        ExpressionMapper(planMapper.get()).mapToPhysical(*maxExpr, physicalOperatorInfo, *context);
     auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(maxExprEvaluator.get());
+    maxAggrEvaluator->initResultSet(resultSet, *memoryManager);
+
     auto maxState = make_unique<MinMaxFunction<int64_t>::MinMaxState>();
     maxAggrEvaluator->getFunction()->initialize((uint8_t*)maxState.get());
     maxAggrEvaluator->getFunction()->update(

--- a/test/processor/physical_plan/operator/scan/scan_test.cpp
+++ b/test/processor/physical_plan/operator/scan/scan_test.cpp
@@ -9,8 +9,10 @@ TEST(ScanTests, ScanTest) {
     auto profiler = make_unique<Profiler>();
     auto memoryManager = make_unique<MemoryManager>();
     auto executionContext = ExecutionContext(*profiler, nullptr, memoryManager.get());
-    auto scan = make_unique<ScanNodeID>(1, 1, 0, 0, morsel, executionContext, 0);
-    auto resultSet = scan->getResultSet();
+    auto scan = make_unique<ScanNodeID>(DataPos{0, 0}, morsel, executionContext, 0);
+    auto resultSet = make_shared<ResultSet>(1);
+    resultSet->dataChunks[0] = make_shared<DataChunk>(1);
+    scan->initResultSet(resultSet);
     auto dataChunk = resultSet->dataChunks[0];
     auto nodeVector = dataChunk->getValueVector(0);
     node_offset_t currNodeOffset = 0;

--- a/test/processor/processor_test.cpp
+++ b/test/processor/processor_test.cpp
@@ -27,8 +27,10 @@ TEST(ProcessorTests, MultiThreadedScanTest) {
     auto profiler = make_unique<Profiler>();
     auto memoryManager = make_unique<MemoryManager>();
     auto executionContext = ExecutionContext(*profiler, nullptr, memoryManager.get());
-    auto plan = make_unique<PhysicalPlan>(make_unique<ResultCollector>(
-        make_unique<ScanNodeID>(1, 1, 0, 0, morsel, executionContext, 0), RESULT_COLLECTOR,
+    auto resultSet = make_shared<ResultSet>(1);
+    resultSet->dataChunks[0] = make_shared<DataChunk>(1);
+    auto plan = make_unique<PhysicalPlan>(make_unique<ResultCollector>(move(resultSet),
+        make_unique<ScanNodeID>(DataPos{0, 0}, morsel, executionContext, 0), RESULT_COLLECTOR,
         executionContext, 1, false));
     auto processor = make_unique<QueryProcessor>(10);
     auto result = processor->execute(plan.get(), 1);

--- a/test/runner/queries/structural/frontier.test
+++ b/test/runner/queries/structural/frontier.test
@@ -1,9 +1,5 @@
 # description: extending frontiers.
 
--NAME FourHopThreeKnowsOneStudyAtTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person)-[e4:studyAt]->(e:organisation) RETURN COUNT(*)
----- 54
-
 -NAME KnowsOneToTwoHopTest
 -QUERY MATCH (a:person)-[:knows*1..2]->(b:person) RETURN COUNT(*)
 ---- 50


### PR DESCRIPTION
This PR move the resulset construction logic away from operator construction

- Resultset is created based on schema
- PhysicalOperator exposes an initResultSet() interface which gets called recusrivly to set in/out dataChunk/valueVector.