### PR TITLE
fix read nodeIDs on the small list

### DIFF
--- a/src/processor/physical_plan/operator/result/tuple.cpp
+++ b/src/processor/physical_plan/operator/result/tuple.cpp
@@ -1,7 +1,7 @@
 #include "src/processor/include/physical_plan/operator/result/tuple.h"
 
 #include <iomanip>
-#include <iostream>
+#include <sstream>
 #include <string>
 
 namespace graphflow {

--- a/src/storage/data_structure/column.cpp
+++ b/src/storage/data_structure/column.cpp
@@ -88,16 +88,9 @@ void AdjColumn::readValues(const shared_ptr<ValueVector>& nodeIDVector,
     auto resultVectorValues = (nodeID_t*)resultVector->values;
     if (nodeIDVector->isSequence) {
         auto pageCursor = getPageCursorForOffset(nodeIDValues[0].offset);
-        auto numValuesLeftToCopy = nodeIDVector->state->originalSize;
-        while (numValuesLeftToCopy > 0) {
-            auto numValuesToCopyInPage =
-                min((numElementsPerPage - pageCursor.offset / elementSize), numValuesLeftToCopy);
-            readNodeIDsFromAPage(resultVectorValues, pageCursor.idx, pageCursor.offset,
-                numValuesToCopyInPage, nodeIDCompressionScheme, metrics);
-            numValuesLeftToCopy -= numValuesToCopyInPage;
-            pageCursor.offset = 0;
-            pageCursor.idx++;
-        }
+        readNodeIDsFromSequentialPages(
+            resultVector, pageCursor, [](uint64_t i) { return i; }, nodeIDCompressionScheme,
+            metrics);
     } else {
         auto numValuesToCopy =
             nodeIDVector->state->isFlat() ? 1 : nodeIDVector->state->selectedSize;

--- a/src/storage/data_structure/lists/lists.cpp
+++ b/src/storage/data_structure/lists/lists.cpp
@@ -109,11 +109,8 @@ void AdjLists::readFromLargeList(const shared_ptr<ValueVector>& valueVector,
 void AdjLists::readSmallList(
     const shared_ptr<ValueVector>& valueVector, ListInfo& info, BufferManagerMetrics& metrics) {
     valueVector->state->initOriginalAndSelectedSize(info.listLen);
-    auto values = (nodeID_t*)valueVector->values;
-    auto numValuesLeftToCopy = valueVector->state->originalSize;
-    auto physicalPageId = info.mapper(info.cursor.idx);
-    readNodeIDsFromAPage(values, physicalPageId, info.cursor.offset, numValuesLeftToCopy,
-        nodeIDCompressionScheme, metrics);
+    readNodeIDsFromSequentialPages(
+        valueVector, info.cursor, info.mapper, nodeIDCompressionScheme, metrics);
 }
 
 unique_ptr<vector<nodeID_t>> AdjLists::readAdjacencyListOfNode(

--- a/src/storage/include/data_structure/data_structure.h
+++ b/src/storage/include/data_structure/data_structure.h
@@ -47,6 +47,11 @@ protected:
         const std::function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper,
         BufferManagerMetrics& metrics);
 
+    void readNodeIDsFromSequentialPages(const shared_ptr<ValueVector>& valueVector,
+        PageCursor& pageCursor,
+        const std::function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper,
+        NodeIDCompressionScheme compressionScheme, BufferManagerMetrics& metrics);
+
     void copyFromAPage(uint8_t* values, uint32_t physicalPageIdx, uint64_t sizeToCopy,
         uint32_t pageOffset, BufferManagerMetrics& metrics);
 

--- a/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
+++ b/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
@@ -57,47 +57,42 @@ public:
 TEST_F(AggrExpressionEvaluatorTest, CountStarTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(COUNT_STAR_FUNC, INT64,
         AggregateExpressionEvaluator::getAggregationFunction(COUNT_STAR_FUNC, INT64));
-    auto countStarAggrEvaluator =
-        reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto countStarState = countStarAggrEvaluator->getFunction()->initialize();
-    countStarAggrEvaluator->getFunction()->update(
+    auto countStarState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)countStarState.get(), nullptr, resultSet->getNumTuples());
-    auto otherCountStarState = countStarAggrEvaluator->getFunction()->initialize();
+    auto otherCountStarState = exprEvaluator->getFunction()->initialize();
     *((uint64_t*)otherCountStarState->val.get()) = 10;
-    countStarAggrEvaluator->getFunction()->combine(
+    exprEvaluator->getFunction()->combine(
         (uint8_t*)countStarState.get(), (uint8_t*)otherCountStarState.get());
-    countStarAggrEvaluator->getFunction()->finalize((uint8_t*)countStarState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)countStarState.get());
     ASSERT_EQ(*((uint64_t*)countStarState->val.get()), 110);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, CountTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         COUNT_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(COUNT_FUNC, INT64));
-    auto countAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto countState = countAggrEvaluator->getFunction()->initialize();
-    countAggrEvaluator->getFunction()->update(
+    auto countState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)countState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
-    auto otherCountState = countAggrEvaluator->getFunction()->initialize();
+    auto otherCountState = exprEvaluator->getFunction()->initialize();
     *((uint64_t*)otherCountState->val.get()) = 10;
-    countAggrEvaluator->getFunction()->combine(
+    exprEvaluator->getFunction()->combine(
         (uint8_t*)countState.get(), (uint8_t*)otherCountState.get());
-    countAggrEvaluator->getFunction()->finalize((uint8_t*)countState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)countState.get());
     ASSERT_EQ(*((uint64_t*)countState->val.get()), 60);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, INT64SumTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         SUM_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(SUM_FUNC, INT64));
-    auto sumAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto sumState = sumAggrEvaluator->getFunction()->initialize();
-    sumAggrEvaluator->getFunction()->update(
+    auto sumState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)sumState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
-    auto otherSumState = sumAggrEvaluator->getFunction()->initialize();
+    auto otherSumState = exprEvaluator->getFunction()->initialize();
     *((uint64_t*)otherSumState->val.get()) = 10;
     otherSumState->isNull = false;
-    sumAggrEvaluator->getFunction()->combine(
-        (uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
-    sumAggrEvaluator->getFunction()->finalize((uint8_t*)sumState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)sumState.get());
     auto sumValue = *(uint64_t*)otherSumState->val.get();
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
@@ -110,16 +105,14 @@ TEST_F(AggrExpressionEvaluatorTest, INT64SumTest) {
 TEST_F(AggrExpressionEvaluatorTest, DOUBLESumTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         SUM_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(SUM_FUNC, DOUBLE));
-    auto sumAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto sumState = sumAggrEvaluator->getFunction()->initialize();
-    sumAggrEvaluator->getFunction()->update(
+    auto sumState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)sumState.get(), doubleValueVector.get(), doubleValueVector->state->selectedSize);
-    auto otherSumState = sumAggrEvaluator->getFunction()->initialize();
+    auto otherSumState = exprEvaluator->getFunction()->initialize();
     *((double_t*)otherSumState->val.get()) = 10.0;
     otherSumState->isNull = false;
-    sumAggrEvaluator->getFunction()->combine(
-        (uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
-    sumAggrEvaluator->getFunction()->finalize((uint8_t*)sumState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)sumState.get());
     auto sumValue = *((double_t*)otherSumState->val.get());
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
@@ -132,16 +125,14 @@ TEST_F(AggrExpressionEvaluatorTest, DOUBLESumTest) {
 TEST_F(AggrExpressionEvaluatorTest, UNSTRSumTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(SUM_FUNC, UNSTRUCTURED,
         AggregateExpressionEvaluator::getAggregationFunction(SUM_FUNC, UNSTRUCTURED));
-    auto sumAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto sumState = sumAggrEvaluator->getFunction()->initialize();
-    sumAggrEvaluator->getFunction()->update(
+    auto sumState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)sumState.get(), unStrValueVector.get(), unStrValueVector->state->selectedSize);
-    auto otherSumState = sumAggrEvaluator->getFunction()->initialize();
+    auto otherSumState = exprEvaluator->getFunction()->initialize();
     *((Value*)otherSumState->val.get()) = Value((int64_t)10);
     otherSumState->isNull = false;
-    sumAggrEvaluator->getFunction()->combine(
-        (uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
-    sumAggrEvaluator->getFunction()->finalize((uint8_t*)sumState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)sumState.get());
     auto sumValue = ((Value*)otherSumState->val.get())->val.int64Val;
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
@@ -154,17 +145,15 @@ TEST_F(AggrExpressionEvaluatorTest, UNSTRSumTest) {
 TEST_F(AggrExpressionEvaluatorTest, INT64AvgTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         AVG_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(AVG_FUNC, INT64));
-    auto avgAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto avgState = avgAggrEvaluator->getFunction()->initialize();
-    avgAggrEvaluator->getFunction()->update(
+    auto avgState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)avgState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
-    auto otherAvgState = avgAggrEvaluator->getFunction()->initialize();
+    auto otherAvgState = exprEvaluator->getFunction()->initialize();
     *((double_t*)otherAvgState->val.get()) = 10;
     ((AvgFunction<int64_t>::AvgState&)otherAvgState).numValues = 1;
     otherAvgState->isNull = false;
-    avgAggrEvaluator->getFunction()->combine(
-        (uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
-    avgAggrEvaluator->getFunction()->finalize((uint8_t*)avgState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)avgState.get());
     auto sumValue = 10;
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
@@ -177,17 +166,15 @@ TEST_F(AggrExpressionEvaluatorTest, INT64AvgTest) {
 TEST_F(AggrExpressionEvaluatorTest, DOUBLEAvgTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         AVG_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(AVG_FUNC, DOUBLE));
-    auto avgAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto avgState = avgAggrEvaluator->getFunction()->initialize();
-    avgAggrEvaluator->getFunction()->update(
+    auto avgState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)avgState.get(), doubleValueVector.get(), doubleValueVector->state->selectedSize);
-    auto otherAvgState = avgAggrEvaluator->getFunction()->initialize();
+    auto otherAvgState = exprEvaluator->getFunction()->initialize();
     *((double_t*)otherAvgState->val.get()) = 10.0;
     ((AvgFunction<double_t>::AvgState&)otherAvgState).numValues = 1;
     otherAvgState->isNull = false;
-    avgAggrEvaluator->getFunction()->combine(
-        (uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
-    avgAggrEvaluator->getFunction()->finalize((uint8_t*)avgState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)avgState.get());
     auto sumValue = 10.0;
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
@@ -200,81 +187,71 @@ TEST_F(AggrExpressionEvaluatorTest, DOUBLEAvgTest) {
 TEST_F(AggrExpressionEvaluatorTest, INT64MaxTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         MAX_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, INT64));
-    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto maxState = maxAggrEvaluator->getFunction()->initialize();
-    maxAggrEvaluator->getFunction()->update(
+    auto maxState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)maxState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
-    auto otherMaxState = maxAggrEvaluator->getFunction()->initialize();
+    auto otherMaxState = exprEvaluator->getFunction()->initialize();
     *((int64_t*)otherMaxState->val.get()) = 101;
     otherMaxState->isNull = false;
-    maxAggrEvaluator->getFunction()->combine(
-        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
-    maxAggrEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
     ASSERT_EQ(*((int64_t*)maxState->val.get()), 101);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, DOUBLEMaxTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         MAX_FUNC, DOUBLE, AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, DOUBLE));
-    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto maxState = maxAggrEvaluator->getFunction()->initialize();
-    maxAggrEvaluator->getFunction()->update(
+    auto maxState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)maxState.get(), doubleValueVector.get(), doubleValueVector->state->selectedSize);
-    auto otherMaxState = maxAggrEvaluator->getFunction()->initialize();
+    auto otherMaxState = exprEvaluator->getFunction()->initialize();
     *((double_t*)otherMaxState->val.get()) = 101.0;
     otherMaxState->isNull = false;
-    maxAggrEvaluator->getFunction()->combine(
-        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
-    maxAggrEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
     ASSERT_EQ(*((double_t*)maxState->val.get()), 148.5);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, STRINGMaxTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         MAX_FUNC, STRING, AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, STRING));
-    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto maxState = maxAggrEvaluator->getFunction()->initialize();
-    maxAggrEvaluator->getFunction()->update(
+    auto maxState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)maxState.get(), stringValueVector.get(), stringValueVector->state->selectedSize);
-    auto otherMaxState = maxAggrEvaluator->getFunction()->initialize();
+    auto otherMaxState = exprEvaluator->getFunction()->initialize();
     gf_string_t otherStr;
     otherStr.set("0");
     *((gf_string_t*)otherMaxState->val.get()) = otherStr;
     otherMaxState->isNull = false;
-    maxAggrEvaluator->getFunction()->combine(
-        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
-    maxAggrEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
     ASSERT_EQ(((gf_string_t*)maxState->val.get())->getAsString(), "99");
 }
 
 TEST_F(AggrExpressionEvaluatorTest, UNSTRMaxTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(MAX_FUNC, UNSTRUCTURED,
         AggregateExpressionEvaluator::getAggregationFunction(MAX_FUNC, UNSTRUCTURED));
-    auto maxAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto maxState = maxAggrEvaluator->getFunction()->initialize();
-    maxAggrEvaluator->getFunction()->update(
+    auto maxState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)maxState.get(), unStrValueVector.get(), unStrValueVector->state->selectedSize);
-    auto otherMaxState = maxAggrEvaluator->getFunction()->initialize();
+    auto otherMaxState = exprEvaluator->getFunction()->initialize();
     *((Value*)otherMaxState->val.get()) = Value((int64_t)101);
     otherMaxState->isNull = false;
-    maxAggrEvaluator->getFunction()->combine(
-        (uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
-    maxAggrEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)maxState.get(), (uint8_t*)otherMaxState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)maxState.get());
     ASSERT_EQ(((Value*)maxState->val.get())->val.int64Val, 101);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, INT64MinTest) {
     auto exprEvaluator = make_unique<AggregateExpressionEvaluator>(
         MIN_FUNC, INT64, AggregateExpressionEvaluator::getAggregationFunction(MIN_FUNC, INT64));
-    auto minAggrEvaluator = reinterpret_cast<AggregateExpressionEvaluator*>(exprEvaluator.get());
-    auto minState = minAggrEvaluator->getFunction()->initialize();
-    minAggrEvaluator->getFunction()->update(
+    auto minState = exprEvaluator->getFunction()->initialize();
+    exprEvaluator->getFunction()->update(
         (uint8_t*)minState.get(), int64ValueVector.get(), int64ValueVector->state->selectedSize);
-    auto otherMinState = minAggrEvaluator->getFunction()->initialize();
+    auto otherMinState = exprEvaluator->getFunction()->initialize();
     *((int64_t*)otherMinState->val.get()) = -10;
     otherMinState->isNull = false;
-    minAggrEvaluator->getFunction()->combine(
-        (uint8_t*)minState.get(), (uint8_t*)otherMinState.get());
-    minAggrEvaluator->getFunction()->finalize((uint8_t*)minState.get());
+    exprEvaluator->getFunction()->combine((uint8_t*)minState.get(), (uint8_t*)otherMinState.get());
+    exprEvaluator->getFunction()->finalize((uint8_t*)minState.get());
     ASSERT_EQ(*((int64_t*)minState->val.get()), -10);
 }

--- a/tools/benchmark/include/benchmark.h
+++ b/tools/benchmark/include/benchmark.h
@@ -19,11 +19,11 @@ public:
     Benchmark(const string& benchmarkPath, System& system, BenchmarkConfig& config);
 
     void run();
-    void log();
+    void log() const;
 
 private:
     void loadBenchmark(const string& benchmarkPath);
-    void verify();
+    void verify() const;
 
 public:
     System& system;

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -3,8 +3,8 @@
 #include <algorithm>
 #include <cctype>
 #include <iomanip>
-#include <iostream>
 #include <regex>
+#include <sstream>
 
 #include "src/processor/include/physical_plan/operator/result/result_set_iterator.h"
 


### PR DESCRIPTION
- fix read nodeIDs on the small list.
- update benchmark tools to get the first tuple value as the num of outputs to compare (this is a hacky way for now. We should change it to be like our testing framework that compares the actual content of result tuples).