### PR TITLE
Projection refact

### DIFF
--- a/src/common/data_chunk/data_chunk.cpp
+++ b/src/common/data_chunk/data_chunk.cpp
@@ -3,12 +3,10 @@
 namespace graphflow {
 namespace common {
 
-unique_ptr<DataChunk> DataChunk::clone() {
-    auto newChunk = make_unique<DataChunk>(valueVectors.size(), state->clone());
-    for (auto i = 0; i < valueVectors.size(); ++i) {
-        newChunk->insert(i, valueVectors[i]->clone());
-    }
-    return newChunk;
+void DataChunk::insert(uint32_t pos, const shared_ptr<ValueVector>& valueVector) {
+    valueVector->state = this->state;
+    assert(valueVectors.size() > pos);
+    valueVectors[pos] = valueVector;
 }
 
 } // namespace common

--- a/src/common/include/data_chunk/data_chunk.h
+++ b/src/common/include/data_chunk/data_chunk.h
@@ -26,19 +26,15 @@ public:
         : DataChunk(numValueVectors, make_shared<DataChunkState>()){};
 
     DataChunk(uint32_t numValueVectors, const shared_ptr<DataChunkState>& state)
-        : valueVectors{numValueVectors}, state{state} {};
+        : valueVectors(numValueVectors), state{state} {};
 
-    void insert(uint32_t pos, const shared_ptr<ValueVector>& valueVector) {
-        valueVector->state = this->state;
-        assert(valueVectors.size() > pos);
-        valueVectors[pos] = valueVector;
-    }
+    void insert(uint32_t pos, const shared_ptr<ValueVector>& valueVector);
+
+    inline uint32_t getNumValueVectors() { return valueVectors.size(); }
 
     inline shared_ptr<ValueVector> getValueVector(uint64_t valueVectorPos) {
         return valueVectors[valueVectorPos];
     }
-
-    unique_ptr<DataChunk> clone();
 
 public:
     vector<shared_ptr<ValueVector>> valueVectors;

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -29,6 +29,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "base_logical_operator",
+        "//src/binder:base_expression",
     ],
 )
 

--- a/src/planner/include/logical_plan/operator/projection/logical_projection.h
+++ b/src/planner/include/logical_plan/operator/projection/logical_projection.h
@@ -10,11 +10,9 @@ class LogicalProjection : public LogicalOperator {
 
 public:
     explicit LogicalProjection(vector<shared_ptr<Expression>> expressions,
-        unique_ptr<Schema> schemaBeforeProjection, vector<uint32_t> discardedGroupPos,
-        shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, expressionsToProject{move(expressions)},
-          schemaBeforeProjection{move(schemaBeforeProjection)},
-          discardedGroupPos(move(discardedGroupPos)) {}
+        vector<uint32_t> discardedGroupsPos, shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{move(prevOperator)}, expressionsToProject{move(expressions)},
+          discardedGroupsPos{move(discardedGroupsPos)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_PROJECTION;
@@ -30,8 +28,7 @@ public:
 
 public:
     vector<shared_ptr<Expression>> expressionsToProject;
-    unique_ptr<Schema> schemaBeforeProjection;
-    vector<uint32_t> discardedGroupPos;
+    vector<uint32_t> discardedGroupsPos;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -6,8 +6,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include "src/binder/include/expression/expression.h"
 #include "src/common/include/assert.h"
 
+using namespace graphflow::binder;
 using namespace graphflow::common;
 using namespace std;
 
@@ -82,6 +84,7 @@ public:
     unordered_map<string, LogicalExtend*> queryRelLogicalExtendMap;
     // All flat variables are considered as in the same factorization group
     unordered_map<string, uint32_t> variableToGroupPos;
+    vector<shared_ptr<Expression>> expressionsToCollect;
 };
 
 } // namespace planner

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -165,6 +165,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "data_pos",
         "//src/common:data_chunk",
         "//src/storage:lists",
     ],

--- a/src/processor/include/physical_plan/operator/projection/projection.h
+++ b/src/processor/include/physical_plan/operator/projection/projection.h
@@ -15,11 +15,10 @@ class Projection : public PhysicalOperator {
 public:
     Projection(vector<unique_ptr<ExpressionEvaluator>> expressions,
         vector<DataPos> expressionsOutputPos, vector<uint32_t> discardedDataChunksPos,
-        shared_ptr<ResultSet> inResultSet, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id)
+        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
         : PhysicalOperator(move(prevOperator), PROJECTION, context, id),
           expressions(move(expressions)), expressionsOutputPos{move(expressionsOutputPos)},
-          discardedDataChunksPos{move(discardedDataChunksPos)}, inResultSet{move(inResultSet)} {}
+          discardedDataChunksPos{move(discardedDataChunksPos)}, prevMultiplicity{0} {}
 
     void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
@@ -28,12 +27,17 @@ public:
     unique_ptr<PhysicalOperator> clone() override;
 
 private:
+    inline void saveMultiplicity() { prevMultiplicity = resultSet->multiplicity; }
+
+    inline void restoreMultiplicity() { resultSet->multiplicity = prevMultiplicity; }
+
+private:
     vector<unique_ptr<ExpressionEvaluator>> expressions;
     vector<DataPos> expressionsOutputPos;
     vector<uint32_t> discardedDataChunksPos;
-    shared_ptr<ResultSet> inResultSet;
 
-    shared_ptr<ResultSet> discardedResultSet;
+    uint64_t prevMultiplicity;
+    unique_ptr<ResultSet> discardedResultSet;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/result/result_set.h
+++ b/src/processor/include/physical_plan/operator/result/result_set.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/common/include/data_chunk/data_chunk.h"
+#include "src/processor/include/physical_plan/data_pos.h"
 #include "src/storage/include/data_structure/lists/list_sync_state.h"
 
 using namespace graphflow::common;
@@ -13,7 +14,8 @@ class ResultSet {
 
 public:
     explicit ResultSet(uint32_t numDataChunks)
-        : multiplicity{1}, dataChunks(numDataChunks), listSyncStatesPerDataChunk(numDataChunks) {}
+        : multiplicity{1}, dataChunks(numDataChunks), dataChunksMask(numDataChunks, true),
+          listSyncStatesPerDataChunk(numDataChunks) {}
 
     inline void insert(uint32_t pos, const shared_ptr<DataChunk>& dataChunk) {
         assert(dataChunks.size() > pos);
@@ -25,9 +27,13 @@ public:
         listSyncStatesPerDataChunk[pos] = listSyncState;
     }
 
-    uint64_t getNumTuples();
+    inline uint32_t getNumDataChunks() const { return dataChunks.size(); }
 
-    unique_ptr<ResultSet> clone();
+    inline shared_ptr<ValueVector> getValueVector(DataPos& dataPos) {
+        return dataChunks[dataPos.dataChunkPos]->valueVectors[dataPos.valueVectorPos];
+    }
+
+    uint64_t getNumTuples();
 
     shared_ptr<ListSyncState> getListSyncState(uint64_t dataChunkPos) {
         return listSyncStatesPerDataChunk[dataChunkPos];
@@ -36,6 +42,8 @@ public:
 public:
     uint64_t multiplicity;
     vector<shared_ptr<DataChunk>> dataChunks;
+    // A dataChunk might be projected away and its mask value will be set to false.
+    vector<bool> dataChunksMask;
 
 private:
     vector<shared_ptr<ListSyncState>> listSyncStatesPerDataChunk;

--- a/src/processor/include/physical_plan/operator/result/result_set_iterator.h
+++ b/src/processor/include/physical_plan/operator/result/result_set_iterator.h
@@ -10,7 +10,9 @@ namespace processor {
 
 class ResultSetIterator {
 public:
-    explicit ResultSetIterator(ResultSet* resultSet) : resultSet(resultSet), numIteratedTuples(0) {
+    explicit ResultSetIterator(ResultSet* resultSet, vector<DataPos> vectorsToCollectPos)
+        : resultSet{resultSet}, vectorsToCollectPos{move(vectorsToCollectPos)}, numIteratedTuples{
+                                                                                    0} {
         reset();
     }
 
@@ -32,6 +34,7 @@ private:
     void setDataChunksTypes();
 
     ResultSet* resultSet;
+    vector<DataPos> vectorsToCollectPos;
 
     uint64_t numRepeatOfCurrentTuple;
     uint64_t numIteratedTuples;

--- a/src/processor/include/physical_plan/operator/sink/result_collector.h
+++ b/src/processor/include/physical_plan/operator/sink/result_collector.h
@@ -10,11 +10,12 @@ namespace processor {
 class ResultCollector : public Sink {
 
 public:
-    explicit ResultCollector(shared_ptr<ResultSet> resultSet,
+    explicit ResultCollector(shared_ptr<ResultSet> resultSet, vector<DataPos> vectorsToCollectPos,
         unique_ptr<PhysicalOperator> prevOperator, PhysicalOperatorType operatorType,
         ExecutionContext& context, uint32_t id)
         : Sink{move(resultSet), move(prevOperator), operatorType, context, id},
-          queryResult{make_unique<QueryResult>()} {}
+          queryResult{make_unique<QueryResult>(vectorsToCollectPos)}, vectorsToCollectPos{move(
+                                                                          vectorsToCollectPos)} {}
 
     void reInitialize() override;
 
@@ -26,8 +27,8 @@ public:
             clonedResultSet->insert(
                 i, make_shared<DataChunk>(resultSet->dataChunks[i]->valueVectors.size()));
         }
-        return make_unique<ResultCollector>(
-            move(clonedResultSet), prevOperator->clone(), operatorType, context, id);
+        return make_unique<ResultCollector>(move(clonedResultSet), vectorsToCollectPos,
+            prevOperator->clone(), operatorType, context, id);
     }
 
 public:
@@ -35,6 +36,9 @@ public:
 
 private:
     void resetStringBuffer();
+
+private:
+    vector<DataPos> vectorsToCollectPos;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/query_result.h
+++ b/src/processor/include/physical_plan/query_result.h
@@ -11,9 +11,11 @@ namespace processor {
 class QueryResult {
 
 public:
-    explicit QueryResult(uint64_t numTuples) : numTuples{numTuples} {}
+    QueryResult(uint64_t numTuples, vector<DataPos> vectorsToCollectPos)
+        : numTuples{numTuples}, vectorsToCollectPos{move(vectorsToCollectPos)} {}
 
-    QueryResult() : QueryResult(0) {}
+    explicit QueryResult(vector<DataPos> vectorsToCollectPos)
+        : QueryResult(0, move(vectorsToCollectPos)) {}
 
     void appendQueryResult(unique_ptr<QueryResult> queryResult);
 
@@ -21,6 +23,7 @@ public:
 
 public:
     uint64_t numTuples;
+    vector<DataPos> vectorsToCollectPos;
     vector<unique_ptr<ResultSet>> resultSetCollection;
     vector<unique_ptr<BufferBlock>> bufferBlocks;
 };

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -180,7 +180,7 @@ bool HashJoinProbe::getNextTuples() {
         buildSideFlatResultDataChunk->state->currIdx += 1;
         updateAppendedUnFlatDataChunks();
         metrics->executionTime.stop();
-        metrics->numOutputTuple.increase(resultSet->getNumTuples());
+        // TODO: Guodong fill in how many tuples increased in metrics
         return true;
     }
     getNextBatchOfMatchedTuples();
@@ -193,7 +193,7 @@ bool HashJoinProbe::getNextTuples() {
     buildSideFlatResultDataChunk->state->currIdx = buildSideVectorPtrs.empty() ? -1 : 0;
     updateAppendedUnFlatDataChunks();
     metrics->executionTime.stop();
-    metrics->numOutputTuple.increase(resultSet->getNumTuples());
+    metrics->numOutputTuple.increase(probeState->matchedTuplesSize);
     return true;
 }
 } // namespace processor

--- a/src/processor/physical_plan/operator/projection/projection.cpp
+++ b/src/processor/physical_plan/operator/projection/projection.cpp
@@ -4,32 +4,33 @@ namespace graphflow {
 namespace processor {
 
 void Projection::initResultSet(const shared_ptr<ResultSet>& resultSet) {
-    prevOperator->initResultSet(inResultSet);
-    this->resultSet = resultSet;
+    PhysicalOperator::initResultSet(resultSet);
     for (auto i = 0u; i < expressions.size(); ++i) {
         auto& expression = *expressions[i];
-        expression.initResultSet(*inResultSet, *context.memoryManager);
+        expression.initResultSet(*this->resultSet, *context.memoryManager);
         auto [outDataChunkPos, outValueVectorPos] = expressionsOutputPos[i];
         auto dataChunk = this->resultSet->dataChunks[outDataChunkPos];
         dataChunk->state = expression.result->state;
         dataChunk->insert(outValueVectorPos, expression.result);
     }
-    discardedResultSet = make_shared<ResultSet>(discardedDataChunksPos.size());
+    discardedResultSet = make_unique<ResultSet>(discardedDataChunksPos.size());
     for (auto i = 0u; i < discardedDataChunksPos.size(); ++i) {
-        discardedResultSet->insert(i, inResultSet->dataChunks[discardedDataChunksPos[i]]);
+        this->resultSet->dataChunksMask[discardedDataChunksPos[i]] = false;
+        discardedResultSet->insert(i, this->resultSet->dataChunks[discardedDataChunksPos[i]]);
     }
 }
 
 bool Projection::getNextTuples() {
     metrics->executionTime.start();
+    restoreMultiplicity();
     if (!prevOperator->getNextTuples()) {
         metrics->executionTime.stop();
         return false;
     }
+    saveMultiplicity();
     for (auto& expression : expressions) {
         expression->evaluate();
     }
-    discardedResultSet->multiplicity = inResultSet->multiplicity;
     resultSet->multiplicity = discardedResultSet->getNumTuples();
     metrics->executionTime.stop();
     return true;
@@ -40,13 +41,8 @@ unique_ptr<PhysicalOperator> Projection::clone() {
     for (auto& expression : expressions) {
         rootExpressionsCloned.push_back(expression->clone());
     }
-    auto clonedInResultSet = make_shared<ResultSet>(inResultSet->dataChunks.size());
-    for (auto i = 0u; i < inResultSet->dataChunks.size(); ++i) {
-        clonedInResultSet->insert(
-            i, make_shared<DataChunk>(inResultSet->dataChunks[i]->valueVectors.size()));
-    }
     return make_unique<Projection>(move(rootExpressionsCloned), expressionsOutputPos,
-        discardedDataChunksPos, clonedInResultSet, prevOperator->clone(), context, id);
+        discardedDataChunksPos, prevOperator->clone(), context, id);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/result/result_set.cpp
+++ b/src/processor/physical_plan/operator/result/result_set.cpp
@@ -5,19 +5,13 @@ namespace processor {
 
 uint64_t ResultSet::getNumTuples() {
     uint64_t numTuples = 1;
-    for (auto& dataChunk : dataChunks) {
-        numTuples *= dataChunk->state->getNumSelectedValues();
+    for (auto i = 0u; i < dataChunks.size(); ++i) {
+        if (!dataChunksMask[i]) {
+            continue;
+        }
+        numTuples *= dataChunks[i]->state->getNumSelectedValues();
     }
     return numTuples * multiplicity;
-}
-
-unique_ptr<ResultSet> ResultSet::clone() {
-    auto clonedResultSet = make_unique<ResultSet>(dataChunks.size());
-    for (auto i = 0u; i < dataChunks.size(); ++i) {
-        clonedResultSet->insert(i, dataChunks[i]->clone());
-    }
-    clonedResultSet->multiplicity = multiplicity;
-    return clonedResultSet;
 }
 
 } // namespace processor

--- a/src/transaction/include/local_storage.h
+++ b/src/transaction/include/local_storage.h
@@ -16,7 +16,7 @@ class LocalStorage {
 
 public:
     void addDataChunk(DataChunk* dataChunk) {
-        dataChunks.emplace_back(dataChunk->clone());
+        //        dataChunks.emplace_back(dataChunk->clone());
         numTuples += dataChunk->state->selectedSize;
     }
 

--- a/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
+++ b/test/processor/physical_plan/operator/tuple/result_set_iterator_test.cpp
@@ -8,6 +8,13 @@ class ResultSetIteratorTest : public ::testing::Test {
 
 public:
     void SetUp() override {
+        vectorToCollectPos.emplace_back(0, 0);
+        vectorToCollectPos.emplace_back(0, 1);
+        vectorToCollectPos.emplace_back(1, 0);
+        vectorToCollectPos.emplace_back(1, 1);
+        vectorToCollectPos.emplace_back(2, 0);
+        vectorToCollectPos.emplace_back(2, 1);
+
         resultSet = make_unique<ResultSet>(3);
 
         auto dataChunkA = make_shared<DataChunk>(2);
@@ -66,6 +73,7 @@ public:
 
 public:
     unique_ptr<ResultSet> resultSet;
+    vector<DataPos> vectorToCollectPos;
 };
 
 TEST_F(ResultSetIteratorTest, DataChunksIteratorTest1) {
@@ -79,7 +87,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest1) {
     dataChunkB->state->currIdx = -1;
     dataChunkC->state->currIdx = 10;
 
-    ResultSetIterator resultSetIterator(resultSet.get());
+    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
     auto tupleIndex = 0;
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
@@ -129,7 +137,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest2) {
     dataChunkA->state->currIdx = 1;
     dataChunkB->state->currIdx = -1;
     dataChunkC->state->currIdx = -1;
-    ResultSetIterator resultSetIterator(resultSet.get());
+    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
     while (resultSetIterator.hasNextTuple()) {
         auto bid = tupleIndex / 100;
         auto cid = tupleIndex % 100;
@@ -160,7 +168,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest3) {
     dataChunkA->state->currIdx = -1;
     dataChunkB->state->currIdx = 10;
     dataChunkC->state->currIdx = -1;
-    ResultSetIterator resultSetIterator(resultSet.get());
+    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
     while (resultSetIterator.hasNextTuple()) {
         auto aid = tupleIndex / 100;
         auto cid = tupleIndex % 100;
@@ -191,7 +199,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest4) {
     dataChunkC->state->currIdx = 20;
 
     auto tupleIndex = 0;
-    ResultSetIterator resultSetIterator(resultSet.get());
+    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
         string tupleStr = tuple.toString(vector<uint32_t>(tuple.len(), 0));
@@ -220,7 +228,7 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTestWithSelector) {
     dataChunkC->state->currIdx = 20;
 
     auto tupleIndex = 0;
-    ResultSetIterator resultSetIterator(resultSet.get());
+    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
         string tupleStr = tuple.toString(vector<uint32_t>(tuple.len(), 0));

--- a/test/processor/processor_test.cpp
+++ b/test/processor/processor_test.cpp
@@ -29,9 +29,11 @@ TEST(ProcessorTests, MultiThreadedScanTest) {
     auto executionContext = ExecutionContext(*profiler, nullptr, memoryManager.get());
     auto resultSet = make_shared<ResultSet>(1);
     resultSet->dataChunks[0] = make_shared<DataChunk>(1);
+    auto aIDPos = DataPos{0, 0};
+    auto vectorsToCollect = vector<DataPos>{aIDPos};
     auto plan = make_unique<PhysicalPlan>(make_unique<ResultCollector>(move(resultSet),
-        make_unique<ScanNodeID>(DataPos{0, 0}, morsel, executionContext, 0), RESULT_COLLECTOR,
-        executionContext, 1));
+        vectorsToCollect, make_unique<ScanNodeID>(aIDPos, morsel, executionContext, 0),
+        RESULT_COLLECTOR, executionContext, 1));
     auto processor = make_unique<QueryProcessor>(10);
     auto result = processor->execute(plan.get(), 1);
     ASSERT_EQ(result->numTuples, 1025013);

--- a/test/runner/queries/aggregate/simple_aggregate.test
+++ b/test/runner/queries/aggregate/simple_aggregate.test
@@ -3,29 +3,29 @@
 -NAME SimpleSumTest
 -QUERY MATCH (a:person) RETURN SUM(a.age), SUM(a.eyeSight), SUM(a.unstrNumericProp)
 ---- 1
-298|38.900000|167.000000
+167.000000|38.900000|298
 
 -NAME SimpleSumWithterTest
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age), SUM(a.eyeSight)
 ---- 1
-85|14.100000
+14.100000|85
 
 -NAME SimpleSumWithFilterTest2
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age+10), SUM(a.age*2)
 ---- 1
-115|170
+170|115
 
 -NAME SimpleAvgTest
 -QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight)
 ---- 1
-37.250000|4.862500
+4.862500|37.250000
 
 -NAME SimpleAvgWithFilterTest
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN AVG(a.age), AVG(a.eyeSight)
 ---- 1
-28.333333|4.700000
+4.700000|28.333333
 
 -NAME SimpleMinMaxTest
 -QUERY MATCH (a:person) RETURN MIN(a.age), MAX(a.age), MIN(a.isStudent), MAX(a.isStudent), MIN(a.eyeSight), MAX(a.eyeSight), MIN(a.birthdate), MAX(a.birthdate)
 ---- 1
-20|83|False|True|4.500000|5.100000|1900-01-01|1990-11-27
+1990-11-27|1900-01-01|5.100000|False|4.500000|83|20|True

--- a/test/runner/queries/projection/projection.test
+++ b/test/runner/queries/projection/projection.test
@@ -20,14 +20,14 @@
 -COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.id,a.unstrDateProp1
 ---- 8
-1900-01-01|0
-1950-01-01|2
-1950-01-01|3
-|10
-|5
-|7
-|8
-|9
+0|1900-01-01
+10|
+2|1950-01-01
+3|1950-01-01
+5|
+7|
+8|
+9|
 
 -NAME PersonNodesTestString
 -COMPARE_RESULT 1
@@ -161,23 +161,23 @@ Dan
 -COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[:knows]->(:person)-[:knows]->(b:person) WHERE a.age>b.age+10 RETURN a.age, b.age
 ---- 6
-20|35
-20|35
-20|45
-20|45
-30|45
-30|45
+35|20
+35|20
+45|20
+45|20
+45|30
+45|30
 
 -NAME KnowsTwoHopTest3
 -COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE a.age>c.age+10 RETURN a.age, b.fName, c.age
 ---- 6
-20|Alice|45
-20|Bob|35
-20|Bob|45
-20|Carol|35
-30|Alice|45
-30|Dan|45
+35|Bob|20
+35|Carol|20
+45|Alice|20
+45|Alice|30
+45|Bob|20
+45|Dan|30
 
 -NAME KnowsTwoHopTest4
 -COMPARE_RESULT 1

--- a/test/test_utility/test_helper.cpp
+++ b/test/test_utility/test_helper.cpp
@@ -41,8 +41,8 @@ bool TestHelper::runTest(const vector<TestQueryConfig>& testConfigs, const Syste
             } else {
                 vector<string> resultTuples;
                 if (result->numTuples != 0) {
-                    auto resultSetIterator =
-                        make_unique<ResultSetIterator>(result->resultSetCollection[0].get());
+                    auto resultSetIterator = make_unique<ResultSetIterator>(
+                        result->resultSetCollection[0].get(), result->vectorsToCollectPos);
                     Tuple tuple(resultSetIterator->dataTypes);
                     for (auto& resultSet : result->resultSetCollection) {
                         resultSetIterator->setResultSet(resultSet.get());

--- a/tools/benchmark/benchmark.cpp
+++ b/tools/benchmark/benchmark.cpp
@@ -87,7 +87,8 @@ void Benchmark::log() const {
 void Benchmark::verify() const {
     if (context->queryResult->numTuples == 1) {
         uint64_t numTuples = 0;
-        ResultSetIterator resultSetIterator(context->queryResult->resultSetCollection[0].get());
+        ResultSetIterator resultSetIterator(context->queryResult->resultSetCollection[0].get(),
+            context->queryResult->vectorsToCollectPos);
         Tuple tuple(resultSetIterator.dataTypes);
         resultSetIterator.setResultSet(context->queryResult->resultSetCollection[0].get());
         resultSetIterator.getNextTuple(tuple);

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -263,7 +263,8 @@ void EmbeddedShell::printExecutionResult() {
         printf(">> Compiling time: %.2fms\n", context.compilingTime);
         printf(">> Executing time: %.2fms\n", context.executingTime);
         if (!context.queryResult->resultSetCollection.empty()) {
-            ResultSetIterator resultSetIterator(context.queryResult->resultSetCollection[0].get());
+            ResultSetIterator resultSetIterator(context.queryResult->resultSetCollection[0].get(),
+                context.queryResult->vectorsToCollectPos);
             Tuple tuple(resultSetIterator.dataTypes);
             vector<uint32_t> colsWidth(tuple.len(), 2);
             uint32_t lineSeparatorLen = 1u + colsWidth.size();


### PR DESCRIPTION
This PR refacts projection operator and result collector/collection/iterator

Changes include
- Introduce dataChunkMask so projection does not recreate new resultSet. Instead, it update dataChunk mask to represents which dataChunk should not be counted while counting tuples.
- Now each pipeline shares a single resultSet
- ResultCollector/Collection/Iterator takes a vector<DataPos> to decide which vector to copy/iterate. This also helps us to control the order of columns being enumerated. Previously we are blindly enumerating based on dataChunk order