### PR TITLE
Property scan pushdown

### DIFF
--- a/src/common/include/exception.h
+++ b/src/common/include/exception.h
@@ -39,5 +39,10 @@ class InternalException : public Exception {
 public:
     explicit InternalException(const string& msg) : Exception(msg){};
 };
+
+class NotImplementedException : public Exception {
+public:
+    explicit NotImplementedException(const string& msg) : Exception(msg){};
+};
 } // namespace common
 } // namespace graphflow

--- a/src/main/system.cpp
+++ b/src/main/system.cpp
@@ -2,7 +2,7 @@
 
 #include "src/binder/include/query_binder.h"
 #include "src/parser/include/parser.h"
-#include "src/planner/include/enumerator.h"
+#include "src/planner/include/planner.h"
 #include "src/processor/include/physical_plan/plan_mapper.h"
 
 using namespace graphflow::parser;
@@ -37,7 +37,7 @@ void System::executeQuery(SessionContext& context) const {
     compilingTimeMetric.start();
     auto boundQuery = QueryBinder(graph->getCatalog()).bind(*parsedQuery);
 
-    auto logicalPlan = Enumerator(*graph).getBestPlan(*boundQuery);
+    auto logicalPlan = Planner::getBestPlan(*graph, *boundQuery);
 
     auto executionContext = make_unique<ExecutionContext>(
         *context.profiler, context.activeTransaction, memManager.get());
@@ -69,8 +69,7 @@ vector<unique_ptr<LogicalPlan>> System::enumerateAllPlans(SessionContext& sessio
     }
     auto parsedQuery = Parser::parseQuery(sessionContext.query);
     auto boundQuery = QueryBinder(graph->getCatalog()).bind(*parsedQuery);
-    auto logicalPlans = Enumerator(*graph).enumeratePlans(*boundQuery);
-    return logicalPlans;
+    return Planner::getAllPlans(*graph, *boundQuery);
 }
 
 unique_ptr<QueryResult> System::executePlan(

--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -17,7 +17,6 @@ const double PREDICATE_SELECTIVITY = 0.2;
  * JoinOrderEnumerator is currently responsible for
  *      join order enumeration
  *      filter push down
- *      property scanner push down
  */
 class JoinOrderEnumerator {
     friend class Enumerator;
@@ -34,7 +33,6 @@ private:
     unique_ptr<JoinOrderEnumeratorContext> enterSubquery(
         vector<shared_ptr<Expression>> expressionsToSelect);
     void exitSubquery(unique_ptr<JoinOrderEnumeratorContext> prevContext);
-    void appendMissingPropertyScans(const vector<unique_ptr<LogicalPlan>>& plans);
 
     // join order enumeration functions
     void enumerateSelectScan();
@@ -53,8 +51,6 @@ private:
         const NodeExpression& joinNode, LogicalPlan& buildPlan, LogicalPlan& probePlan);
     // appendIntersect return false if a nodeID is flat in which case we should use filter
     bool appendIntersect(const string& leftNodeID, const string& rightNodeID, LogicalPlan& plan);
-    void appendScanPropertiesIfNecessary(
-        const string& variableName, bool isNode, LogicalPlan& plan);
 
     // helper functions
     uint64_t getExtensionRate(label_t boundNodeLabel, label_t relLabel, Direction direction);

--- a/src/planner/include/join_order_enumerator_context.h
+++ b/src/planner/include/join_order_enumerator_context.h
@@ -15,12 +15,7 @@ public:
           mergedQueryGraph{make_unique<QueryGraph>()} {}
 
     void init(const NormalizedQueryPart& queryPart, vector<unique_ptr<LogicalPlan>> prevPlans);
-    void populatePropertiesMap(const NormalizedQueryPart& queryPart);
 
-    inline const unordered_map<string, vector<shared_ptr<Expression>>>&
-    getVariableToPropertiesMap() {
-        return variableToPropertiesMap;
-    }
     inline vector<shared_ptr<Expression>> getWhereExpressions() {
         return whereExpressionsSplitOnAND;
     }
@@ -64,7 +59,6 @@ public:
     }
 
 private:
-    unordered_map<string, vector<shared_ptr<Expression>>> variableToPropertiesMap;
     vector<shared_ptr<Expression>> whereExpressionsSplitOnAND;
 
     uint32_t currentLevel;

--- a/src/planner/include/logical_plan/operator/aggregate/logical_aggregate.h
+++ b/src/planner/include/logical_plan/operator/aggregate/logical_aggregate.h
@@ -33,6 +33,11 @@ public:
     }
     inline Schema* getSchemaBeforeAggregate() const { return schemaBeforeAggregate.get(); }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalAggregate>(
+            expressionsToAggregate, schemaBeforeAggregate->copy(), prevOperator->copy());
+    }
+
 private:
     vector<shared_ptr<Expression>> expressionsToAggregate;
     unique_ptr<Schema> schemaBeforeAggregate;

--- a/src/planner/include/logical_plan/operator/crud/logical_crud_node.h
+++ b/src/planner/include/logical_plan/operator/crud/logical_crud_node.h
@@ -2,6 +2,7 @@
 
 #include <unordered_map>
 
+#include "src/common/include/exception.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
 
 namespace graphflow {
@@ -19,6 +20,11 @@ public:
 
     string getExpressionsForPrinting() const override {
         return LogicalOperatorTypeNames[CRUDType] + ": " + to_string(nodeLabel);
+    }
+
+    unique_ptr<LogicalOperator> copy() override {
+        return NotImplementedException(
+            "Copy function is not implemented for logical crud operator.");
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/extend/logical_extend.h
+++ b/src/planner/include/logical_plan/operator/extend/logical_extend.h
@@ -24,6 +24,11 @@ public:
         return boundNodeID + (direction == Direction::FWD ? "->" : "<-") + nbrNodeID;
     }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalExtend>(boundNodeID, boundNodeLabel, nbrNodeID, nbrNodeLabel,
+            relLabel, direction, isColumn, lowerBound, upperBound, prevOperator->copy());
+    }
+
 public:
     string boundNodeID;
     label_t boundNodeLabel;

--- a/src/planner/include/logical_plan/operator/filter/logical_filter.h
+++ b/src/planner/include/logical_plan/operator/filter/logical_filter.h
@@ -22,6 +22,10 @@ public:
 
     string getExpressionsForPrinting() const override { return expression->rawExpression; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalFilter>(expression, groupPosToSelect, prevOperator->copy());
+    }
+
 public:
     shared_ptr<Expression> expression;
     uint32_t groupPosToSelect;

--- a/src/planner/include/logical_plan/operator/flatten/logical_flatten.h
+++ b/src/planner/include/logical_plan/operator/flatten/logical_flatten.h
@@ -19,6 +19,10 @@ public:
 
     string getExpressionsForPrinting() const override { return variable; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalFlatten>(variable, prevOperator->copy());
+    }
+
 public:
     string variable;
 };

--- a/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
+++ b/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
@@ -34,6 +34,12 @@ public:
 
     string getExpressionsForPrinting() const override { return joinNodeID; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalHashJoin>(joinNodeID, buildSidePrevOperator->copy(),
+            buildSideSchema->copy(), probeSideFlatGroupPos, probeSideUnFlatGroupsPos,
+            prevOperator->copy());
+    }
+
 public:
     const string joinNodeID;
     shared_ptr<LogicalOperator> buildSidePrevOperator;

--- a/src/planner/include/logical_plan/operator/intersect/logical_intersect.h
+++ b/src/planner/include/logical_plan/operator/intersect/logical_intersect.h
@@ -27,6 +27,10 @@ public:
     inline string getLeftNodeID() const { return leftNodeID; }
     inline string getRightNodeID() const { return rightNodeID; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalIntersect>(leftNodeID, rightNodeID, prevOperator->copy());
+    }
+
 private:
     string leftNodeID;
     // Right node ID should be the temporary node ID

--- a/src/planner/include/logical_plan/operator/limit/logical_limit.h
+++ b/src/planner/include/logical_plan/operator/limit/logical_limit.h
@@ -19,7 +19,12 @@ public:
 
     inline uint64_t getLimitNumber() const { return limitNumber; }
     inline uint32_t getGroupPosToSelect() const { return groupPosToSelect; }
-    inline const vector<uint32_t>& getGroupsPosToLimit() const { return groupsPosToLimit; };
+    inline const vector<uint32_t>& getGroupsPosToLimit() const { return groupsPosToLimit; }
+
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalLimit>(
+            limitNumber, groupPosToSelect, groupsPosToLimit, prevOperator->copy());
+    }
 
 private:
     uint64_t limitNumber;

--- a/src/planner/include/logical_plan/operator/load_csv/logical_load_csv.h
+++ b/src/planner/include/logical_plan/operator/load_csv/logical_load_csv.h
@@ -20,6 +20,10 @@ public:
 
     string getExpressionsForPrinting() const override { return path; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalLoadCSV>(path, tokenSeparator, csvColumnVariables);
+    }
+
 public:
     string path;
     char tokenSeparator;

--- a/src/planner/include/logical_plan/operator/logical_operator.h
+++ b/src/planner/include/logical_plan/operator/logical_operator.h
@@ -63,6 +63,9 @@ public:
 
     virtual string getExpressionsForPrinting() const = 0;
 
+    // TODO: remove this function once planner do not share operator across plans
+    virtual unique_ptr<LogicalOperator> copy() = 0;
+
 public:
     shared_ptr<LogicalOperator> prevOperator;
 };

--- a/src/planner/include/logical_plan/operator/multiplicity_reducer/logical_multiplcity_reducer.h
+++ b/src/planner/include/logical_plan/operator/multiplicity_reducer/logical_multiplcity_reducer.h
@@ -16,6 +16,10 @@ public:
     }
 
     string getExpressionsForPrinting() const override { return string(); }
+
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalMultiplicityReducer>(prevOperator->copy());
+    }
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/projection/logical_projection.h
+++ b/src/planner/include/logical_plan/operator/projection/logical_projection.h
@@ -26,6 +26,11 @@ public:
         return result;
     }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalProjection>(
+            expressionsToProject, discardedGroupsPos, prevOperator->copy());
+    }
+
 public:
     vector<shared_ptr<Expression>> expressionsToProject;
     vector<uint32_t> discardedGroupsPos;

--- a/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
+++ b/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
@@ -19,6 +19,11 @@ public:
 
     string getExpressionsForPrinting() const override { return nodeID; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return prevOperator ? make_unique<LogicalScanNodeID>(nodeID, label, prevOperator->copy()) :
+                              make_unique<LogicalScanNodeID>(nodeID, label);
+    }
+
 public:
     const string nodeID;
     const label_t label;

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
@@ -20,6 +20,11 @@ public:
 
     string getExpressionsForPrinting() const override { return propertyVariableName; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalScanNodeProperty>(nodeID, nodeLabel, propertyVariableName,
+            propertyKey, isUnstructuredProperty, prevOperator->copy());
+    }
+
 public:
     const string nodeID;
     const label_t nodeLabel;

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
@@ -22,6 +22,11 @@ public:
 
     string getExpressionsForPrinting() const override { return propertyVariableName; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalScanRelProperty>(boundNodeID, boundNodeLabel, nbrNodeID, relLabel,
+            direction, propertyVariableName, propertyKey, isColumn, prevOperator->copy());
+    }
+
 public:
     string boundNodeID;
     label_t boundNodeLabel;

--- a/src/planner/include/logical_plan/operator/select_scan/logical_select_scan.h
+++ b/src/planner/include/logical_plan/operator/select_scan/logical_select_scan.h
@@ -26,6 +26,10 @@ public:
 
     inline const unordered_set<string>& getVariablesToSelect() const { return variablesToSelect; }
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalSelectScan>(variablesToSelect);
+    }
+
 private:
     unordered_set<string> variablesToSelect;
 };

--- a/src/planner/include/logical_plan/operator/skip/logical_skip.h
+++ b/src/planner/include/logical_plan/operator/skip/logical_skip.h
@@ -21,6 +21,11 @@ public:
     inline uint32_t getGroupPosToSelect() const { return groupPosToSelect; }
     inline const vector<uint32_t>& getGroupsPosToSkip() const { return groupsPosToSkip; };
 
+    unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalSkip>(
+            skipNumber, groupPosToSelect, groupsPosToSkip, prevOperator->copy());
+    }
+
 private:
     uint64_t skipNumber;
     uint32_t groupPosToSelect;

--- a/src/planner/include/planner.h
+++ b/src/planner/include/planner.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "src/planner/include/enumerator.h"
+
+namespace graphflow {
+namespace planner {
+
+class Planner {
+
+public:
+    static unique_ptr<LogicalPlan> getBestPlan(const Graph& graph, const BoundSingleQuery& query);
+
+    static vector<unique_ptr<LogicalPlan>> getAllPlans(
+        const Graph& graph, const BoundSingleQuery& query);
+
+private:
+    static unique_ptr<LogicalPlan> optimize(unique_ptr<LogicalPlan> plan);
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/property_scan_pushdown.h
+++ b/src/planner/include/property_scan_pushdown.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <unordered_map>
+
+#include "src/planner/include/logical_plan/operator/logical_operator.h"
+
+namespace graphflow {
+namespace planner {
+
+// This optimization extract all property scanners and append them on top of scan node ID / extend.
+class PropertyScanPushDown {
+
+public:
+    shared_ptr<LogicalOperator> rewrite(shared_ptr<LogicalOperator> op);
+
+private:
+    shared_ptr<LogicalOperator> rewriteScanNodeID(const shared_ptr<LogicalOperator>& op);
+
+    shared_ptr<LogicalOperator> rewriteExtend(const shared_ptr<LogicalOperator>& op);
+
+    shared_ptr<LogicalOperator> rewriteScanNodeProperty(const shared_ptr<LogicalOperator>& op);
+
+    shared_ptr<LogicalOperator> rewriteScanRelProperty(const shared_ptr<LogicalOperator>& op);
+
+    shared_ptr<LogicalOperator> applyPropertyScansIfNecessary(
+        const string& nodeID, const shared_ptr<LogicalOperator>& op);
+
+    void rewriteChildrenOperators(LogicalOperator& op);
+
+    void addPropertyScan(const string& nodeID, const shared_ptr<LogicalOperator>& op);
+
+private:
+    unordered_map<string, vector<shared_ptr<LogicalOperator>>> nodeIDToPropertyScansMap;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/join_order_enumerator_context.cpp
+++ b/src/planner/join_order_enumerator_context.cpp
@@ -26,17 +26,6 @@ void JoinOrderEnumeratorContext::init(
     currentLevel = 0;
 }
 
-void JoinOrderEnumeratorContext::populatePropertiesMap(const NormalizedQueryPart& queryPart) {
-    variableToPropertiesMap.clear();
-    for (auto& propertyExpression : queryPart.getDependentPropertiesFromWhereAndProjection()) {
-        auto variableName = propertyExpression->children[0]->getInternalName();
-        if (!variableToPropertiesMap.contains(variableName)) {
-            variableToPropertiesMap.insert({variableName, vector<shared_ptr<Expression>>()});
-        }
-        variableToPropertiesMap.at(variableName).push_back(propertyExpression);
-    }
-}
-
 SubqueryGraph JoinOrderEnumeratorContext::getFullyMatchedSubqueryGraph() const {
     auto matchedSubgraph = SubqueryGraph(*mergedQueryGraph);
     for (auto i = 0u; i < mergedQueryGraph->getNumQueryNodes(); ++i) {

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -1,0 +1,31 @@
+#include "src/planner/include/planner.h"
+
+#include "src/planner/include/property_scan_pushdown.h"
+
+namespace graphflow {
+namespace planner {
+
+unique_ptr<LogicalPlan> Planner::getBestPlan(const Graph& graph, const BoundSingleQuery& query) {
+    // join order enumeration with filter push down
+    auto bestPlan = Enumerator(graph).getBestJoinOrderPlan(query);
+    return optimize(move(bestPlan));
+}
+
+vector<unique_ptr<LogicalPlan>> Planner::getAllPlans(
+    const Graph& graph, const BoundSingleQuery& query) {
+    auto plans = Enumerator(graph).getAllPlans(query);
+    vector<unique_ptr<LogicalPlan>> optimizedPlans;
+    for (auto& plan : plans) {
+        optimizedPlans.push_back(optimize(move(plan)));
+    }
+    return optimizedPlans;
+}
+
+unique_ptr<LogicalPlan> Planner::optimize(unique_ptr<LogicalPlan> plan) {
+    auto propertyScanPushDown = PropertyScanPushDown();
+    plan->lastOperator = propertyScanPushDown.rewrite(plan->lastOperator);
+    return plan;
+}
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/projection_enumerator.cpp
+++ b/src/planner/projection_enumerator.cpp
@@ -75,6 +75,12 @@ void ProjectionEnumerator::appendProjection(const vector<shared_ptr<Expression>>
 
 void ProjectionEnumerator::appendAggregate(
     const vector<shared_ptr<Expression>>& expressions, LogicalPlan& plan) {
+    for (auto& expression : expressions) {
+        if (expression->expressionType == COUNT_STAR_FUNC) {
+            continue;
+        }
+        enumerator->appendScanPropertiesIfNecessary(*expression->children[0], plan);
+    }
     auto aggregate =
         make_shared<LogicalAggregate>(expressions, plan.schema->copy(), plan.lastOperator);
     plan.schema->clearGroups();

--- a/src/planner/property_scan_pushdown.cpp
+++ b/src/planner/property_scan_pushdown.cpp
@@ -1,0 +1,92 @@
+#include "src/planner/include/property_scan_pushdown.h"
+
+#include "src/planner/include/logical_plan/operator/extend/logical_extend.h"
+#include "src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h"
+#include "src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h"
+#include "src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h"
+#include "src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h"
+
+namespace graphflow {
+namespace planner {
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewrite(shared_ptr<LogicalOperator> op) {
+    switch (op->getLogicalOperatorType()) {
+    case LOGICAL_SCAN_NODE_ID:
+        return rewriteScanNodeID(op);
+    case LOGICAL_EXTEND:
+        return rewriteExtend(op);
+    case LOGICAL_SCAN_NODE_PROPERTY:
+        return rewriteScanNodeProperty(op);
+    case LOGICAL_SCAN_REL_PROPERTY:
+        return rewriteScanRelProperty(op);
+    default:
+        rewriteChildrenOperators(*op);
+        return op;
+    }
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteScanNodeID(
+    const shared_ptr<LogicalOperator>& op) {
+    auto& scanNodeID = (LogicalScanNodeID&)*op;
+    return applyPropertyScansIfNecessary(scanNodeID.nodeID, op);
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteExtend(
+    const shared_ptr<LogicalOperator>& op) {
+    auto& extend = (LogicalExtend&)*op;
+    return applyPropertyScansIfNecessary(extend.nbrNodeID, op);
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteScanNodeProperty(
+    const shared_ptr<LogicalOperator>& op) {
+    auto& scanNodeProperty = (LogicalScanNodeProperty&)*op;
+    addPropertyScan(scanNodeProperty.nodeID, op);
+    return rewrite(scanNodeProperty.prevOperator);
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteScanRelProperty(
+    const shared_ptr<LogicalOperator>& op) {
+    auto& scanRelProperty = (LogicalScanRelProperty&)*op;
+    addPropertyScan(scanRelProperty.nbrNodeID, op);
+    return rewrite(scanRelProperty.prevOperator);
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::applyPropertyScansIfNecessary(
+    const string& nodeID, const shared_ptr<LogicalOperator>& op) {
+    if (!nodeIDToPropertyScansMap.contains(nodeID)) {
+        // nothing needs to be applied
+        rewriteChildrenOperators(*op);
+        return op;
+    }
+    auto& propertyScans = nodeIDToPropertyScansMap.at(nodeID);
+    // chain property scans
+    for (auto i = 0u; i < propertyScans.size() - 1; ++i) {
+        propertyScans[i]->prevOperator = propertyScans[i + 1];
+    }
+    propertyScans.back()->prevOperator = op;
+    rewriteChildrenOperators(*op);
+    return propertyScans[0];
+}
+
+void PropertyScanPushDown::rewriteChildrenOperators(LogicalOperator& op) {
+    if (op.prevOperator) {
+        op.prevOperator = rewrite(op.prevOperator);
+    }
+    // TODO: We should consider move to prevOperators instead of prevOperator if there is more than
+    // one binary operator.
+    if (op.getLogicalOperatorType() == LOGICAL_HASH_JOIN) {
+        auto& hashJoin = (LogicalHashJoin&)op;
+        hashJoin.buildSidePrevOperator = rewrite(hashJoin.buildSidePrevOperator);
+    }
+}
+
+void PropertyScanPushDown::addPropertyScan(
+    const string& nodeID, const shared_ptr<LogicalOperator>& op) {
+    if (!nodeIDToPropertyScansMap.contains(nodeID)) {
+        nodeIDToPropertyScansMap.insert({nodeID, vector<shared_ptr<LogicalOperator>>()});
+    }
+    nodeIDToPropertyScansMap.at(nodeID).push_back(op);
+}
+
+} // namespace planner
+} // namespace graphflow

--- a/test/planner/planner_test_helper.h
+++ b/test/planner/planner_test_helper.h
@@ -3,7 +3,7 @@
 
 #include "src/binder/include/query_binder.h"
 #include "src/parser/include/parser.h"
-#include "src/planner/include/enumerator.h"
+#include "src/planner/include/planner.h"
 
 using ::testing::NiceMock;
 using ::testing::Test;
@@ -18,7 +18,13 @@ public:
     unique_ptr<LogicalPlan> getBestPlan(const string& query) {
         auto parsedQuery = Parser::parseQuery(query);
         auto boundQuery = QueryBinder(graph.getCatalog()).bind(*parsedQuery);
-        return Enumerator(graph).getBestPlan(*boundQuery);
+        return Planner::getBestPlan(graph, *boundQuery);
+    }
+
+    vector<unique_ptr<LogicalPlan>> getAllPlans(const string& query) {
+        auto parsedQuery = Parser::parseQuery(query);
+        auto boundQuery = QueryBinder(graph.getCatalog()).bind(*parsedQuery);
+        return Planner::getAllPlans(graph, *boundQuery);
     }
 
     bool containSubstr(const string& str, const string& substr) {


### PR DESCRIPTION
This PR move the logic of property pushdown to its own optimizer.

Push down logic
- extracts node/rel property scanner
- append property scanner on top of node ID scanner / extend

Additional change
- introduce logical operator copy because property pushdown optimization require each logical plan to be independent (change of one logical operator's prevOperator field does not affect other plan. )