### PR TITLE
benchmark interface change

### DIFF
--- a/test/test_utility/include/test_helper.h
+++ b/test/test_utility/include/test_helper.h
@@ -41,6 +41,8 @@ public:
     static unique_ptr<System> getInitializedSystem(TestSuiteSystemConfig& config) {
         return make_unique<System>(config.graphOutputDir, config.isInMemory);
     }
+
+    static vector<string> getActualOutput(QueryResult& queryResult);
 };
 
 class BaseGraphLoadingTest : public Test {

--- a/tools/benchmark/BUILD.bazel
+++ b/tools/benchmark/BUILD.bazel
@@ -13,6 +13,7 @@ cc_library(
     ],
     deps = [
         "//src/main:system",
+        "//test/test_utility:test_helper",
     ],
 )
 

--- a/tools/benchmark/include/benchmark.h
+++ b/tools/benchmark/include/benchmark.h
@@ -23,16 +23,14 @@ public:
 
 private:
     void loadBenchmark(const string& benchmarkPath);
-    void logQueryInfo(ofstream& log, uint64_t numTuples, uint32_t runNum) const;
+    void logQueryInfo(ofstream& log, uint32_t runNum) const;
     void verify() const;
 
 public:
     System& system;
     BenchmarkConfig& config;
-
     string name;
-    uint64_t expectedNumOutput;
-
+    vector<string> expectedOutput;
     unique_ptr<SessionContext> context;
 };
 


### PR DESCRIPTION
The original benchmark interface only supports checking the number of output tuples.
Changed the benchmark interface so that it can compare the actual value of output tuples with the expected values.

