### PR TITLE
fix non-star COUNT expression in the front-end

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -243,13 +243,10 @@ oC_PropertyOrLabelsExpression
 oC_Atom
     : oC_Literal
         | oC_ParenthesizedExpression
-        | ( COUNT SP? '(' SP? '*' SP? ')' )
         | oC_FunctionInvocation
         | oC_ExistentialSubquery
         | oC_Variable
         ;
-
-COUNT : ( 'C' | 'c' ) ( 'O' | 'o' ) ( 'U' | 'u' ) ( 'N' | 'n' ) ( 'T' | 't' )  ;
 
 oC_Literal
     : oC_NumberLiteral
@@ -271,7 +268,8 @@ oC_ParenthesizedExpression
     : '(' SP? oC_Expression SP? ')' ;
 
 oC_FunctionInvocation
-    : oC_FunctionName SP? '(' SP? ( oC_Expression SP? ( ',' SP? oC_Expression SP? )* )? ')' ;
+    : oC_FunctionName SP? '(' SP? '*' SP? ')'
+        | oC_FunctionName SP? '(' SP? ( oC_Expression SP? ( ',' SP? oC_Expression SP? )* )? ')' ;
 
 oC_FunctionName
     : oC_SymbolicName ;

--- a/test/runner/queries/aggregate/simple_aggregate.test
+++ b/test/runner/queries/aggregate/simple_aggregate.test
@@ -1,5 +1,10 @@
 # description: aggregation without groups and distinct
 
+-NAME SimpleCountTest
+-QUERY MATCH (a:person) RETURN COUNT(a.age), COUNT(a.unstrNumericProp)
+---- 1
+3|8
+
 -NAME SimpleSumTest
 -QUERY MATCH (a:person) RETURN SUM(a.age), SUM(a.eyeSight), SUM(a.unstrNumericProp)
 ---- 1


### PR DESCRIPTION
This PR fixes the parsing error of non-star count expression, e.g., `COUNT(a)`.