### PR TITLE
Add operators for timestamp and date

### DIFF
--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -54,6 +54,7 @@ private:
     shared_ptr<Expression> bindDateFunctionExpression(const ParsedExpression& parsedExpression);
     shared_ptr<Expression> bindTimestampFunctionExpression(
         const ParsedExpression& parsedExpression);
+    shared_ptr<Expression> bindIntervalFunctionExpression(const ParsedExpression& parsedExpression);
 
     shared_ptr<Expression> bindLiteralExpression(const ParsedExpression& parsedExpression);
 
@@ -76,6 +77,10 @@ private:
         shared_ptr<Expression> expression);
     // NOTE: this validation should be removed once we rewrite aggregation as an alias.
     static void validateAggregationIsRoot(const Expression& expression);
+    static void validateTimestampArithmeticType(
+        const ParsedExpression& parsedExpression, shared_ptr<Expression>& right);
+    static void validateDateArithmeticType(
+        const ParsedExpression& parsedExpression, shared_ptr<Expression>& right);
 
 private:
     QueryBinder* queryBinder;

--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -121,6 +121,7 @@ cc_library(
     srcs = [
         "date.cpp",
         "gf_string.cpp",
+        "interval.cpp",
         "literal.cpp",
         "time.cpp",
         "timestamp.cpp",

--- a/src/common/date.cpp
+++ b/src/common/date.cpp
@@ -277,5 +277,11 @@ bool Date::IsValid(int32_t year, int32_t month, int32_t day) {
     }
     return Date::IsLeapYear(year) ? day <= Date::LEAP_DAYS[month] : day <= Date::NORMAL_DAYS[month];
 }
+
+int32_t Date::MonthDays(int32_t year, int32_t month) {
+    GF_ASSERT(month >= 1 && month <= 12);
+    return Date::IsLeapYear(year) ? Date::LEAP_DAYS[month] : Date::NORMAL_DAYS[month];
+}
+
 } // namespace common
 } // namespace graphflow

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -9,7 +9,7 @@ bool isExpressionUnary(ExpressionType type) {
     return NOT == type || NEGATE == type || IS_NULL == type || IS_NOT_NULL == type ||
            CAST_TO_STRING == type || CAST_TO_UNSTRUCTURED_VECTOR == type ||
            CAST_UNSTRUCTURED_VECTOR_TO_BOOL_VECTOR == type || ABS_FUNC == type ||
-           FLOOR_FUNC == type || CEIL_FUNC == type;
+           FLOOR_FUNC == type || CEIL_FUNC == type || INTERVAL_FUNC == type;
 }
 
 bool isExpressionBinary(ExpressionType type) {
@@ -173,6 +173,8 @@ string expressionTypeToString(ExpressionType type) {
         return FLOOR_FUNC_NAME;
     case CEIL_FUNC:
         return CEIL_FUNC_NAME;
+    case INTERVAL_FUNC:
+        return INTERVAL_FUNC_NAME;
     case COUNT_STAR_FUNC:
         return COUNT_STAR_FUNC_NAME;
     case COUNT_FUNC:

--- a/src/common/include/date.h
+++ b/src/common/include/date.h
@@ -49,6 +49,8 @@ public:
     // Helper function to parse two digits from a string (e.g. "30" -> 30, "03" -> 3, "3" -> 3)
     static bool ParseDoubleDigit(const char* buf, uint64_t len, uint64_t& pos, int32_t& result);
 
+    static int32_t MonthDays(int32_t year, int32_t month);
+
 private:
     static void ExtractYearOffset(int32_t& n, int32_t& year, int32_t& year_offset);
 };

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -24,6 +24,7 @@ const string DATE_FUNC_NAME = "DATE";
 const string TIMESTAMP_FUNC_NAME = "TIMESTAMP";
 const string FLOOR_FUNC_NAME = "FLOOR";
 const string CEIL_FUNC_NAME = "CEIL";
+const string INTERVAL_FUNC_NAME = "INTERVAL";
 
 enum ExpressionType : uint8_t {
 
@@ -113,7 +114,6 @@ enum ExpressionType : uint8_t {
     CAST_TO_STRING = 100,
     CAST_TO_UNSTRUCTURED_VECTOR = 101,
     CAST_UNSTRUCTURED_VECTOR_TO_BOOL_VECTOR = 102,
-
     FUNCTION = 110,
 
     /**
@@ -122,6 +122,7 @@ enum ExpressionType : uint8_t {
     ABS_FUNC = 111,
     FLOOR_FUNC = 112,
     CEIL_FUNC = 113,
+    INTERVAL_FUNC = 114,
 
     /**
      * Aggregation Function Expression

--- a/src/common/include/interval.h
+++ b/src/common/include/interval.h
@@ -11,6 +11,7 @@ namespace common {
 // The Interval class is a static class that holds helper functions for the Interval type.
 class Interval {
 public:
+    static constexpr const int32_t MONTHS_PER_YEAR = 12;
     static constexpr const int64_t MSECS_PER_SEC = 1000;
     static constexpr const int32_t SECS_PER_MINUTE = 60;
     static constexpr const int32_t MINS_PER_HOUR = 60;
@@ -21,6 +22,12 @@ public:
     static constexpr const int64_t MICROS_PER_MINUTE = MICROS_PER_SEC * SECS_PER_MINUTE;
     static constexpr const int64_t MICROS_PER_HOUR = MICROS_PER_MINUTE * MINS_PER_HOUR;
     static constexpr const int64_t MICROS_PER_DAY = MICROS_PER_HOUR * HOURS_PER_DAY;
+
+    static void addition(interval_t& result, uint64_t number, string specifierStr);
+    static void parseIntervalField(
+        const char* buf, uint64_t& pos, uint64_t len, interval_t& result);
+    static interval_t FromCString(const char* str, uint64_t len);
+    static string toString(interval_t interval);
 };
 
 } // namespace common

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -55,6 +55,10 @@ struct date_t {
     inline bool operator<(const date_t& rhs) const { return days < rhs.days; };
     inline bool operator>(const date_t& rhs) const { return days > rhs.days; };
     inline bool operator>=(const date_t& rhs) const { return days >= rhs.days; };
+
+    // arithmetic operators
+    inline date_t operator+(const int32_t& day) const { return date_t(this->days + day); };
+    inline date_t operator-(const int32_t& day) const { return date_t(this->days - day); };
 };
 
 // Type used to represent time (microseconds)
@@ -104,6 +108,15 @@ struct timestamp_t {
     inline bool operator>=(const timestamp_t& rhs) const { return value >= rhs.value; };
 };
 
+struct interval_t {
+    int32_t months;
+    int32_t days;
+    int64_t micros;
+    inline bool operator==(const interval_t& rhs) const {
+        return this->days == rhs.days && this->months == rhs.months && this->micros == rhs.micros;
+    }
+};
+
 const uint8_t FALSE = 0;
 const uint8_t TRUE = 1;
 
@@ -126,6 +139,7 @@ enum DataType : uint8_t {
     UNSTRUCTURED = 8,
     DATE = 9,
     TIMESTAMP = 10,
+    INTERVAL = 11,
 };
 
 const string DataTypeNames[] = {"REL", "NODE", "LABEL", "BOOL", "INT64", "DOUBLE", "STRING",

--- a/src/common/include/value.h
+++ b/src/common/include/value.h
@@ -40,6 +40,7 @@ public:
         nodeID_t nodeID;
         date_t dateVal;
         timestamp_t timestampVal;
+        interval_t intervalVal;
     } val;
     // Note: dataType cannot be UNSTRUCTURED. Any Value has a fixed known data type.
     DataType dataType;

--- a/src/common/include/vector/operations/vector_arithmetic_operations.h
+++ b/src/common/include/vector/operations/vector_arithmetic_operations.h
@@ -26,6 +26,8 @@ struct VectorArithmeticOperations {
     static void Floor(ValueVector& operand, ValueVector& result);
     // result = ceil(operand)
     static void Ceil(ValueVector& operand, ValueVector& result);
+    // result = interval(operand)
+    static void Interval(ValueVector& operand, ValueVector& result);
 };
 
 } // namespace common

--- a/src/common/interval.cpp
+++ b/src/common/interval.cpp
@@ -1,0 +1,90 @@
+#include "src/common/include/interval.h"
+
+#include "src/common/include/cast_helpers.h"
+#include "src/common/include/exception.h"
+#include "src/common/include/utils.h"
+
+using namespace std;
+
+namespace graphflow {
+namespace common {
+
+void Interval::addition(interval_t& result, uint64_t number, string specifierStr) {
+    StringUtils::toLower(specifierStr);
+    if (specifierStr == "year" || specifierStr == "years" || specifierStr == "y") {
+        result.months += number * MONTHS_PER_YEAR;
+    } else if (specifierStr == "month" || specifierStr == "months" || specifierStr == "mon") {
+        result.months += number;
+    } else if (specifierStr == "day" || specifierStr == "days" || specifierStr == "d") {
+        result.days += number;
+    } else if (specifierStr == "hour" || specifierStr == "hours" || specifierStr == "h") {
+        result.micros += number * MICROS_PER_HOUR;
+    } else if (specifierStr == "minute" || specifierStr == "minutes" || specifierStr == "m") {
+        result.micros += number * MICROS_PER_MINUTE;
+    } else if (specifierStr == "second" || specifierStr == "seconds" || specifierStr == "s") {
+        result.micros += number * MICROS_PER_SEC;
+    } else if (specifierStr == "millisecond" || specifierStr == "milliseconds" ||
+               specifierStr == "ms" || specifierStr == "msec") {
+        result.micros += number * MICROS_PER_MSEC;
+    } else if (specifierStr == "microsecond" || specifierStr == "microseconds" ||
+               specifierStr == "us") {
+        result.micros += number;
+    } else {
+        throw ConversionException("Unrecognized interval specifier string: " + specifierStr);
+    }
+}
+
+void Interval::parseIntervalField(
+    const char* buf, uint64_t& pos, uint64_t len, interval_t& result) {
+    uint64_t number;
+    uint64_t offset = 0;
+    // parse digits
+    number = stoi(buf + pos, &offset);
+    pos += offset;
+    // skip spaces
+    while (pos < len && isspace(buf[pos])) {
+        pos++;
+    }
+    if (pos == len) {
+        throw ConversionException(string(buf, len) + " is not in a correct format");
+    }
+    // Parse intervalPartSpecifier (eg. hours, dates, minutes)
+    uint64_t spacePos = string(buf).find(' ', pos);
+    if (spacePos == string::npos) {
+        spacePos = len;
+    }
+    string specifierStr = string(buf).substr(pos, spacePos - pos);
+    pos = spacePos;
+    addition(result, number, specifierStr);
+}
+
+interval_t Interval::FromCString(const char* str, uint64_t len) {
+    interval_t result;
+    uint64_t pos = 0;
+    result.days = 0;
+    result.micros = 0;
+    result.months = 0;
+
+    if (str[pos] == '@') {
+        pos++;
+    }
+
+    while (pos < len) {
+        if (isdigit(str[pos])) {
+            parseIntervalField(str, pos, len, result);
+        } else if (!isspace(str[pos])) {
+            throw ConversionException(string(str, len) + " is not in a correct format");
+        }
+        pos++;
+    }
+    return result;
+}
+
+string Interval::toString(interval_t interval) {
+    char buffer[70];
+    uint64_t length = IntervalToStringCast::Format(interval, buffer);
+    return string(buffer, length);
+}
+
+} // namespace common
+} // namespace graphflow

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -63,6 +63,8 @@ size_t TypeUtils::getDataTypeSize(DataType dataType) {
         return sizeof(date_t);
     case TIMESTAMP:
         return sizeof(timestamp_t);
+    case INTERVAL:
+        return sizeof(interval_t);
     default:
         throw invalid_argument(
             "Cannot infer the size of dataType: " + dataTypeToString(dataType) + ".");

--- a/src/common/value.cpp
+++ b/src/common/value.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 
 #include "src/common/include/date.h"
+#include "src/common/include/interval.h"
 #include "src/common/include/timestamp.h"
 #include "src/common/include/types.h"
 
@@ -32,6 +33,9 @@ Value& Value::operator=(const Value& other) {
     case TIMESTAMP: {
         val.timestampVal = other.val.timestampVal;
     } break;
+    case INTERVAL: {
+        val.intervalVal = other.val.intervalVal;
+    } break;
     default:
         assert(false);
     }
@@ -55,6 +59,8 @@ string Value::toString() const {
         return Date::toString(val.dateVal);
     case TIMESTAMP:
         return Timestamp::toString(val.timestampVal);
+    case INTERVAL:
+        return Interval::toString(val.intervalVal);
     default:
         assert(false);
     }

--- a/src/common/vector/operations/vector_arithmetic_operations.cpp
+++ b/src/common/vector/operations/vector_arithmetic_operations.cpp
@@ -84,6 +84,15 @@ void VectorArithmeticOperations::Add(ValueVector& left, ValueVector& right, Valu
         assert(right.dataType == STRING);
         BinaryOperationExecutor::execute<gf_string_t, gf_string_t, gf_string_t, operation::Add,
             true /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else if (left.dataType == DATE && right.dataType == INT64) {
+        BinaryOperationExecutor::execute<date_t, int64_t, date_t, operation::Add,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else if (left.dataType == DATE && right.dataType == INTERVAL) {
+        BinaryOperationExecutor::execute<date_t, interval_t, date_t, operation::Add,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else if (left.dataType == TIMESTAMP) {
+        BinaryOperationExecutor::execute<timestamp_t, interval_t, timestamp_t, operation::Add,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
     } else {
         VectorArithmeticOperationExecutor::execute<operation::Add>(left, right, result);
     }
@@ -91,7 +100,24 @@ void VectorArithmeticOperations::Add(ValueVector& left, ValueVector& right, Valu
 
 void VectorArithmeticOperations::Subtract(
     ValueVector& left, ValueVector& right, ValueVector& result) {
-    VectorArithmeticOperationExecutor::execute<operation::Subtract>(left, right, result);
+    if (left.dataType == DATE && right.dataType == INTERVAL) {
+        BinaryOperationExecutor::execute<date_t, interval_t, date_t, operation::Subtract,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else if (left.dataType == DATE && right.dataType == INT64) {
+        BinaryOperationExecutor::execute<date_t, int64_t, date_t, operation::Subtract,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else if (left.dataType == DATE && right.dataType == DATE) {
+        BinaryOperationExecutor::execute<date_t, date_t, int64_t, operation::Subtract,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else if (left.dataType == TIMESTAMP && right.dataType == INTERVAL) {
+        BinaryOperationExecutor::execute<timestamp_t, interval_t, timestamp_t, operation::Subtract,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else if (left.dataType == TIMESTAMP && right.dataType == TIMESTAMP) {
+        BinaryOperationExecutor::execute<timestamp_t, timestamp_t, interval_t, operation::Subtract,
+            false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+    } else {
+        VectorArithmeticOperationExecutor::execute<operation::Subtract>(left, right, result);
+    }
 }
 
 void VectorArithmeticOperations::Multiply(
@@ -127,6 +153,11 @@ void VectorArithmeticOperations::Floor(ValueVector& operand, ValueVector& result
 
 void VectorArithmeticOperations::Ceil(ValueVector& operand, ValueVector& result) {
     VectorArithmeticOperationExecutor::execute<operation::Ceil>(operand, result);
+}
+
+void VectorArithmeticOperations::Interval(ValueVector& operand, ValueVector& result) {
+    UnaryOperationExecutor::execute<gf_string_t, interval_t, operation::IntervalFunc>(
+        operand, result);
 }
 
 } // namespace common

--- a/src/common/vector/operations/vector_cast_operations.cpp
+++ b/src/common/vector/operations/vector_cast_operations.cpp
@@ -1,6 +1,7 @@
 #include "src/common/include/vector/operations/vector_cast_operations.h"
 
 #include "src/common/include/date.h"
+#include "src/common/include/interval.h"
 #include "src/common/include/timestamp.h"
 #include "src/common/include/value.h"
 
@@ -29,6 +30,9 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
         } break;
         case TIMESTAMP: {
             outValues[resPos].val.timestampVal = ((timestamp_t*)operand.values)[pos];
+        } break;
+        case INTERVAL: {
+            outValues[resPos].val.intervalVal = ((interval_t*)operand.values)[pos];
         } break;
         case STRING: {
             auto& operandVal = ((gf_string_t*)operand.values)[pos];
@@ -111,6 +115,9 @@ void VectorCastOperations::castStructuredToStringValue(ValueVector& operand, Val
         } break;
         case TIMESTAMP: {
             val = Timestamp::toString(((timestamp_t*)operand.values)[pos]);
+        } break;
+        case INTERVAL: {
+            val = Interval::toString(((interval_t*)operand.values)[pos]);
         } break;
         default:
             assert(false);

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -34,6 +34,8 @@ std::function<void(ValueVector&, ValueVector&)> ExpressionEvaluator::getUnaryVec
         return VectorArithmeticOperations::Floor;
     case CEIL_FUNC:
         return VectorArithmeticOperations::Ceil;
+    case INTERVAL_FUNC:
+        return VectorArithmeticOperations::Interval;
     default:
         throw invalid_argument("Unsupported expression type: " + expressionTypeToString(type));
     }

--- a/src/processor/physical_plan/operator/result/result_set_iterator.cpp
+++ b/src/processor/physical_plan/operator/result/result_set_iterator.cpp
@@ -103,6 +103,10 @@ void ResultSetIterator::getNextTuple(Tuple& tuple) {
             tuple.getValue(valueInTupleIdx)->val.timestampVal =
                 ((timestamp_t*)vector->values)[selectedTuplePos];
         } break;
+        case INTERVAL: {
+            tuple.getValue(valueInTupleIdx)->val.intervalVal =
+                ((interval_t*)vector->values)[selectedTuplePos];
+        } break;
         default:
             assert(false);
         }

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -119,17 +119,25 @@ TEST_F(BinderErrorTest, BindIDArithmetic) {
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
-TEST_F(BinderErrorTest, BindDateArithmetic) {
-    string expectedException =
-        "a.birthdate has data type DATE. A numerical data type was expected.";
-    auto input = "MATCH (a:person) WHERE a.birthdate + 1 < 5 RETURN *;";
+TEST_F(BinderErrorTest, BindDateAddDate) {
+    string expectedException = "date('2031-02-01') has data type DATE! DATE can only add an "
+                               "interval/int or subtract an interval/int/date";
+    auto input = "MATCH (a:person) RETURN a.birthdate + date('2031-02-01');";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
 TEST_F(BinderErrorTest, BindTimestampArithmetic) {
-    string expectedException =
-        "a.registerTime has data type TIMESTAMP. A numerical data type was expected.";
+    string expectedException = "1 has data type INT64! TIMESTAMP can only add an interval or "
+                               "subtract an interval/timestamp";
     auto input = "MATCH (a:person) WHERE a.registerTime + 1 < 5 RETURN *;";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, BindTimestampAddTimestamp) {
+    string expectedException =
+        "timestamp('2031-02-11 01:02:03') has data type TIMESTAMP! TIMESTAMP can only add an "
+        "interval or subtract an interval/timestamp";
+    auto input = "MATCH (a:person) RETURN a.registerTime + timestamp('2031-02-11 01:02:03');";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 

--- a/test/runner/queries/data_types/date_data_type.test
+++ b/test/runner/queries/data_types/date_data_type.test
@@ -77,3 +77,150 @@
 ---- 1
 3
 
+-NAME StructuredDateArithmeticAddInt
+-QUERY MATCH (a:person) RETURN a.birthdate + 32
+---- 8
+1900-02-02
+1900-02-02
+1940-07-24
+1950-08-24
+1980-11-27
+1980-11-27
+1980-11-27
+1990-12-29
+
+-NAME UnstructuredDateArithmeticAddInt
+-QUERY MATCH (a:person) RETURN a.unstrDateProp1 + 41
+---- 8
+
+
+
+
+
+1900-02-11
+1950-02-11
+1950-02-11
+
+-NAME StructuredDateArithmeticAddInterval1
+-QUERY MATCH (a:person) WHERE a.birthdate <> date('1900-01-01') RETURN a.birthdate + interval('2 years 3 months 4 days')
+---- 6
+1942-09-26
+1952-10-27
+1983-01-30
+1983-01-30
+1983-01-30
+1993-03-03
+
+-NAME StructuredDateArithmeticAddInterval2
+-QUERY MATCH (a:person) WHERE a.birthdate <> date('1900-01-01') RETURN a.birthdate + interval('47 hours 60 minutes')
+---- 6
+1940-06-24
+1950-07-25
+1980-10-28
+1980-10-28
+1980-10-28
+1990-11-29
+
+-NAME UnstructuredDateArithmeticAddInterval
+-QUERY MATCH (a:person) RETURN a.unstrDateProp2 + interval('20 years 3 days 32 minutes 10512 ms')
+---- 8
+
+
+
+
+
+1940-01-04
+1970-01-04
+1990-01-04
+
+-NAME structuredDateArithmeticSubtractInt
+-QUERY MATCH (a:person) WHERE a.birthdate <> date('1900-01-01') RETURN a.birthdate - 25
+---- 6
+1940-05-28
+1950-06-28
+1980-10-01
+1980-10-01
+1980-10-01
+1990-11-02
+
+-NAME UnstructuredDateArithmeticSubtractInt
+-QUERY MATCH (a:person) RETURN a.unstrDateProp1 - 25
+---- 8
+
+
+
+
+
+1899-12-07
+1949-12-07
+1949-12-07
+
+-NAME StructuredDateArithmeticSubtractInterval
+-QUERY MATCH (a:person) WHERE a.birthdate <> date('1900-01-01') RETURN a.birthdate - interval('4 years 11 months 31 days 100 seconds')
+---- 6
+1935-06-21
+1945-07-23
+1975-10-26
+1975-10-26
+1975-10-26
+1985-11-26
+
+-NAME UnstructuredDateArithmeticSubtractInterval
+-QUERY MATCH (a:person) RETURN a.unstrDateProp1 - interval('15 month 32 days 30 minutes 40 minute')
+---- 8
+
+
+
+
+
+1898-08-30
+1948-08-30
+1948-08-30
+
+-NAME StructuredDateArithmeticSubtractDate
+-QUERY MATCH (a:person) RETURN a.birthdate - date('1920-03-21')
+---- 8
+-7384
+-7384
+11081
+22134
+22134
+22134
+25818
+7398
+
+-NAME UnstructuredDateArithmeticSubtractDate
+-QUERY MATCH (a:person) RETURN a.unstrDateProp1 - date('1921-05-04')
+---- 8
+
+
+
+
+
+-7793
+10469
+10469
+
+-NAME StructuredDateMixedArithmeticOperations
+-QUERY MATCH (a:person) RETURN a.birthdate + 10 - interval('4 years 2 months 3 days') - 20 - date('1912-04-12');
+---- 8
+-6019
+-6019
+8763
+12446
+23499
+23499
+23499
+27183
+
+-NAME UnstructuredDateMixedArithmeticOperations
+-QUERY MATCH (a:person) RETURN a.unstrDateProp1 + 100 - interval('11 months 12 days') - 10 - date('1945-04-12');
+---- 8
+
+
+
+
+
+-16794
+1468
+1468

--- a/test/runner/queries/data_types/timestamp_data_type.test
+++ b/test/runner/queries/data_types/timestamp_data_type.test
@@ -74,3 +74,112 @@
 -QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 <= timestamp('1985-11-22 13:12:22.562') RETURN COUNT(*)
 ---- 1
 2
+
+-NAME StructuredTimestampArithmeticAddInterval1
+-QUERY MATCH (a:person) RETURN a.registerTime + interval('47 hours 30 minutes 30 seconds')
+---- 8
+1911-08-22 02:02:51
+1972-08-02 12:53:00.678559
+1976-12-25 10:52:12
+1976-12-25 10:52:12
+2008-11-05 12:56:00.000526
+2011-08-22 10:56:00
+2023-02-23 12:56:00
+2031-12-02 11:56:00
+
+
+-NAME StructuredTimestampArithmeticAddInterval2
+-QUERY MATCH (a:person) RETURN a.registerTime + interval('2 years 3 days 34 h 28 minutes 300 milliseconds 20 us')
+---- 8
+1913-08-24 13:00:21.30002
+1974-08-04 23:50:30.978579
+1978-12-27 21:49:42.30002
+1978-12-27 21:49:42.30002
+2010-11-07 23:53:30.300546
+2013-08-24 21:53:30.30002
+2025-02-25 23:53:30.30002
+2033-12-04 22:53:30.30002
+
+-NAME UnstructuredTimestampArithmeticAddInterval
+-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 + interval('10 years 20 days 42 h 32 minutes 312 milliseconds')
+---- 8
+
+
+
+
+1956-09-16 13:39:22.312
+1972-06-13 07:43:22.874
+2033-03-15 07:57:30.312
+2041-12-22 06:57:30.312
+
+-NAME StructuredTimestampArithmeticSubtractInterval
+-QUERY MATCH (a:person) RETURN a.registerTime - interval('12 years 7 months 10 days 20 h 30 m 100 us')
+---- 8
+1899-01-09 06:02:20.9999
+1959-12-20 16:52:30.678459
+1964-05-12 14:51:41.9999
+1964-05-12 14:51:41.9999
+1996-03-23 16:55:30.000426
+1999-01-09 14:55:29.9999
+2010-07-10 16:55:29.9999
+2019-04-19 15:55:29.9999
+
+-NAME UnstructuredTimestampArithmeticSubtractInterval
+-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - interval('40 months 200 days 420 hour 320 minutes 312 seconds')
+---- 8
+
+
+
+
+1942-09-20 01:42:10
+1958-06-18 19:46:10.562
+2019-03-17 20:00:18
+2027-12-25 19:00:18
+
+-NAME StructuredTimestampArithmeticSubtractTimestamp
+-QUERY MATCH (a:person) RETURN a.registerTime - timestamp('2013-01-02 14:22:31.45612')
+---- 8
+-37026 days -11:50:10.45612
+-14765 days -01:00:00.777561
+-13159 days -03:00:49.45612
+-13159 days -03:00:49.45612
+-1521 days -00:57:01.455594
+-501 days -02:57:01.45612
+3701 days 23:02:58.54388
+6905 days 22:02:58.54388
+
+-NAME UnstructuredTimestampArithmeticSubtractTimestamp
+-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - timestamp('1976-01-02 13:44:12')
+---- 8
+
+
+
+
+-10721 days -18:36:50
+-4973 days -00:32:49.438
+17216 days 23:41:18
+20420 days 22:41:18
+
+-NAME StructuredTimestampMixedArithmeticOperations
+-QUERY MATCH (a:person) RETURN a.registerTime + interval('2 hours 48 minutes 1000 seconds') - interval('188 days 48 hours') - timestamp('1976-01-02 13:44:12')
+---- 8
+-23701 days -08:07:11
+-1439 days -21:17:01.321441
+166 days 00:42:10
+166 days 00:42:10
+11804 days 02:45:58.000526
+12824 days 00:45:58
+17027 days 02:45:58
+20231 days 01:45:58
+
+-NAME UnstructuredTimestampMixedArithmeticOperations
+-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - interval('2 years 18 days 24 minutes')  + interval('12 hours 100 seconds') - timestamp('1976-01-02 13:44:12')
+---- 8
+
+
+
+
+-11469 days -06:59:10
+-5720 days -12:55:09.438
+16469 days 11:18:58
+19673 days 10:18:58


### PR DESCRIPTION
1. Add 8 operators for timestamp and date structure.
a. Timestamp +/- interval = Timestamp (eg. 1920-01-02 13:01:02 + 3 days = 1920-01-05 13:01:02)
b. Timestamp - Timestamp = interval (eg. 1921-03-04 13:00:00 - 1921-03-03 13:00:00 =  1 days)
c. Date +/- interval = Date (eg. 1920-03-05 + 2 years = 1922-03-05)
d. Date - Date = int (eg. 1921-04-05 - 1921-04-04 = 1 )
e. Date + int = Date (eg. 2020-02-03 + 1 = 2020-02-04)
f. Date - int = Date (eg. 2020-02-03 - 1 = 2020-02-02)
2. Add Interval() function, which takes in a string and returns an interval structure.

We don't support DATE/TIMESTAMP appearing on the right-hand side of the binary operator(+) yet. Opened an issue about this problem: #364