### PR TITLE
add the basic aggregate hash table

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -20,6 +20,10 @@ constexpr uint64_t PAGE_SIZE = 1 << PAGE_SIZE_LOG_2;
 // The default amount of memory pre-allocated to the buffer pool (= 1GB).
 constexpr uint64_t DEFAULT_MEMORY_MANAGER_MAX_MEMORY = 1ull << 38;
 
+// By default, ht block size is 256KB
+constexpr const uint64_t DEFAULT_HT_BLOCK_SIZE = 1 << 18;
+constexpr const double DEFAULT_HT_LOAD_FACTOR = 1.5;
+
 struct StorageConfig {
     // The default amount of memory pre-allocated to the buffer pool (= 1GB).
     static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 22;
@@ -28,7 +32,6 @@ struct StorageConfig {
 // Hash Index Configurations
 struct HashIndexConfig {
     static constexpr uint64_t SLOT_CAPACITY = 4;
-    static constexpr double MAX_LOAD_FACTOR = 0.5;
 };
 
 } // namespace common

--- a/src/common/include/operations/hash_operations.h
+++ b/src/common/include/operations/hash_operations.h
@@ -10,45 +10,58 @@ namespace graphflow {
 namespace common {
 namespace operation {
 
-inline uint64_t murmurhash64(uint64_t x) {
+inline hash_t murmurhash64(uint64_t x) {
     return x * UINT64_C(0xbf58476d1ce4e5b9);
+}
+
+inline hash_t combineHashScalar(hash_t a, hash_t b) {
+    return (a * UINT64_C(0xbf58476d1ce4e5b9)) ^ b;
 }
 
 struct Hash {
     template<class T>
-    static inline void operation(const T& key, uint64_t& result) {
+    static inline void operation(const T& key, hash_t& result) {
         throw invalid_argument(
             StringUtils::string_format("Hash type: %s is not supported.", typeid(T).name()));
     }
 };
 
+struct CombineHash {
+    template<class T>
+    static inline void operation(const T& key, hash_t& result) {
+        uint64_t otherHash;
+        Hash::operation(key, otherHash);
+        result = combineHashScalar(result, otherHash);
+    }
+};
+
 template<>
-inline void Hash::operation(const uint32_t& key, uint64_t& result) {
+inline void Hash::operation(const uint32_t& key, hash_t& result) {
     result = murmurhash64(key);
 }
 
 template<>
-inline void Hash::operation(const uint64_t& key, uint64_t& result) {
+inline void Hash::operation(const uint64_t& key, hash_t& result) {
     result = murmurhash64(key);
 }
 
 template<>
-inline void Hash::operation(const int64_t& key, uint64_t& result) {
+inline void Hash::operation(const int64_t& key, hash_t& result) {
     result = murmurhash64(key);
 }
 
 template<>
-inline void Hash::operation(const string& key, uint64_t& result) {
+inline void Hash::operation(const string& key, hash_t& result) {
     result = std::hash<string>()(key);
 }
 
 template<>
-inline void Hash::operation(const nodeID_t& nodeID, uint64_t& result) {
+inline void Hash::operation(const nodeID_t& nodeID, hash_t& result) {
     result = murmurhash64(nodeID.offset) ^ murmurhash64(nodeID.label);
 }
 
 template<>
-inline void Hash::operation(const unordered_set<string>& key, uint64_t& result) {
+inline void Hash::operation(const unordered_set<string>& key, hash_t& result) {
     for (auto&& s : key) {
         result ^= std::hash<string>()(s);
     }

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -16,6 +16,7 @@ constexpr uint64_t DEFAULT_VECTOR_CAPACITY = 2048;
 typedef uint64_t label_t;
 typedef uint64_t node_offset_t;
 typedef uint16_t sel_t;
+typedef uint64_t hash_t;
 
 // System representation for nodeID.
 struct nodeID_t {

--- a/src/common/include/vector/operations/vector_hash_operations.h
+++ b/src/common/include/vector/operations/vector_hash_operations.h
@@ -7,6 +7,7 @@ namespace common {
 
 struct VectorHashOperations {
     static void Hash(ValueVector& operand, ValueVector& result);
+    static void CombineHash(ValueVector& operand, ValueVector& result);
 };
 
 } // namespace common

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -26,7 +26,7 @@ private:
 };
 
 //! A Vector represents values of the same data type.
-//! The capacity of a ValueVector is either 1 (single value) or DEFAULT_VECTOR_CAPACITY.
+//! The capacity of a ValueVector is either 1 (sequence) or DEFAULT_VECTOR_CAPACITY.
 class ValueVector {
 
 public:

--- a/src/common/interval.cpp
+++ b/src/common/interval.cpp
@@ -38,7 +38,7 @@ void Interval::parseIntervalField(string buf, uint64_t& pos, uint64_t len, inter
     uint64_t number;
     uint64_t offset = 0;
     // parse digits
-    number = stoi(buf.c_str() + pos, &offset);
+    number = stoi(buf.c_str() + pos, reinterpret_cast<size_t*>(&offset));
     pos += offset;
     // skip spaces
     while (pos < len && isspace(buf[pos])) {

--- a/src/common/vector/operations/vector_hash_operations.cpp
+++ b/src/common/vector/operations/vector_hash_operations.cpp
@@ -9,13 +9,29 @@ namespace common {
 void VectorHashOperations::Hash(ValueVector& operand, ValueVector& result) {
     switch (operand.dataType) {
     case INT64:
-        UnaryOperationExecutor::execute<int64_t, uint64_t, operation::Hash>(operand, result);
+        UnaryOperationExecutor::execute<int64_t, hash_t, operation::Hash>(operand, result);
         break;
     case DOUBLE:
-        UnaryOperationExecutor::execute<double_t, uint64_t, operation::Hash>(operand, result);
+        UnaryOperationExecutor::execute<double_t, hash_t, operation::Hash>(operand, result);
         break;
     case NODE:
-        UnaryOperationExecutor::executeNodeIDOps<uint64_t, operation::Hash>(operand, result);
+        UnaryOperationExecutor::executeNodeIDOps<hash_t, operation::Hash>(operand, result);
+        break;
+    default:
+        assert(false);
+    }
+}
+
+void VectorHashOperations::CombineHash(ValueVector& operand, ValueVector& result) {
+    switch (operand.dataType) {
+    case INT64:
+        UnaryOperationExecutor::execute<int64_t, hash_t, operation::CombineHash>(operand, result);
+        break;
+    case DOUBLE:
+        UnaryOperationExecutor::execute<double_t, hash_t, operation::CombineHash>(operand, result);
+        break;
+    case NODE:
+        UnaryOperationExecutor::executeNodeIDOps<hash_t, operation::CombineHash>(operand, result);
         break;
     default:
         assert(false);

--- a/src/expression_evaluator/include/expression_evaluator.h
+++ b/src/expression_evaluator/include/expression_evaluator.h
@@ -19,15 +19,15 @@ namespace evaluator {
 class ExpressionEvaluator {
 
 public:
-    static function<void(ValueVector&, ValueVector&)> getUnaryVectorExecuteOperation(
+    static std::function<void(ValueVector&, ValueVector&)> getUnaryVectorExecuteOperation(
         ExpressionType type);
-    static function<uint64_t(ValueVector&, sel_t*)> getUnaryVectorSelectOperation(
+    static std::function<uint64_t(ValueVector&, sel_t*)> getUnaryVectorSelectOperation(
         ExpressionType type);
 
-    static function<void(ValueVector&, ValueVector&, ValueVector&)> getBinaryVectorExecuteOperation(
-        ExpressionType type);
-    static function<uint64_t(ValueVector&, ValueVector&, sel_t*)> getBinaryVectorSelectOperation(
-        ExpressionType type);
+    static std::function<void(ValueVector&, ValueVector&, ValueVector&)>
+    getBinaryVectorExecuteOperation(ExpressionType type);
+    static std::function<uint64_t(ValueVector&, ValueVector&, sel_t*)>
+    getBinaryVectorSelectOperation(ExpressionType type);
 
     // Creates a leaf literal as value vector expression_evaluator expression.
     ExpressionEvaluator(const shared_ptr<ValueVector>& result, ExpressionType expressionType)

--- a/src/expression_evaluator/unary_expression_evaluator.cpp
+++ b/src/expression_evaluator/unary_expression_evaluator.cpp
@@ -34,12 +34,11 @@ shared_ptr<ValueVector> UnaryExpressionEvaluator::createResultValueVector(
     shared_ptr<ValueVector> resultVector;
     uint64_t resultVectorCapacity;
     if (childrenExpr[0]->isResultFlat()) {
-        resultVector = make_shared<ValueVector>(&memoryManager, dataType, true /* isSingleValue */);
+        resultVector = make_shared<ValueVector>(&memoryManager, dataType, true /* isSequence */);
         resultVectorCapacity = 1;
         resultVector->state = DataChunkState::getSingleValueDataChunkState();
     } else {
-        resultVector =
-            make_shared<ValueVector>(&memoryManager, dataType, false /* isSingleValue */);
+        resultVector = make_shared<ValueVector>(&memoryManager, dataType, false /* isSequence */);
         resultVector->state = childrenExpr[0]->result->state;
         resultVectorCapacity = DEFAULT_VECTOR_CAPACITY;
     }

--- a/src/function/include/aggregation/aggregation_function.h
+++ b/src/function/include/aggregation/aggregation_function.h
@@ -13,7 +13,9 @@ namespace graphflow {
 namespace function {
 
 struct AggregationState {
-    unique_ptr<uint8_t[]> val;
+    virtual inline uint64_t getValSize() const = 0;
+    virtual uint8_t* getFinalVal() const = 0;
+
     bool isNull = true;
 };
 

--- a/src/function/include/aggregation/avg.h
+++ b/src/function/include/aggregation/avg.h
@@ -3,6 +3,7 @@
 #include "src/common/include/operations/arithmetic_operations.h"
 #include "src/function/include/aggregation/aggregation_function.h"
 
+using namespace std;
 using namespace graphflow::common::operation;
 
 namespace graphflow {
@@ -12,44 +13,43 @@ template<typename T>
 struct AvgFunction {
 
     struct AvgState : public AggregationState {
+        double_t val;
         uint64_t numValues = 0;
+
+        inline uint64_t getValSize() const override { return sizeof(*this); }
+        inline uint8_t* getFinalVal() const override { return (uint8_t*)&val; }
     };
 
-    static unique_ptr<AggregationState> initialize() {
-        auto state = make_unique<AvgState>();
-        state->val = make_unique<uint8_t[]>(sizeof(double_t));
-        return state;
-    }
+    static unique_ptr<AggregationState> initialize() { return make_unique<AvgState>(); }
 
     static void update(uint8_t* state_, ValueVector* input, uint64_t count) {
         assert(input && !input->state->isFlat());
         count = input->state->selectedSize;
         auto state = reinterpret_cast<AvgState*>(state_);
-        auto stateValue = (double_t*)state->val.get();
         auto inputValues = (T*)input->values;
         if (input->hasNoNullsGuarantee()) {
             for (auto i = 0u; i < count; i++) {
                 if (state->isNull) {
-                    *stateValue = inputValues[input->state->selectedPositions[i]];
+                    state->val = (double_t)inputValues[input->state->selectedPositions[i]];
                     state->isNull = false;
                 } else {
                     Add::template operation<double_t, T, double_t>(
-                        *stateValue, inputValues[input->state->selectedPositions[i]], *stateValue);
+                        state->val, inputValues[input->state->selectedPositions[i]], state->val);
                 }
             }
-            state->numValues += count;
+            state->numValues = state->numValues + count;
         } else {
             for (auto i = 0u; i < count; i++) {
                 auto pos = input->state->selectedPositions[i];
                 if (!input->isNull(pos)) {
                     if (state->isNull) {
-                        *stateValue = inputValues[input->state->selectedPositions[i]];
+                        state->val = inputValues[input->state->selectedPositions[i]];
                         state->isNull = false;
                     } else {
-                        Add::template operation<double_t, T, double_t>(*stateValue,
-                            inputValues[input->state->selectedPositions[i]], *stateValue);
+                        Add::template operation<double_t, T, double_t>(state->val,
+                            inputValues[input->state->selectedPositions[i]], state->val);
                     }
-                    state->numValues++;
+                    state->numValues = state->numValues + 1;
                 }
             }
         }
@@ -61,23 +61,20 @@ struct AvgFunction {
             return;
         }
         auto state = reinterpret_cast<AvgState*>(state_);
-        auto stateValue = (double_t*)state->val.get();
-        auto otherStateValue = (double_t*)otherState->val.get();
         if (state->isNull) {
-            *stateValue = *otherStateValue;
+            state->val = otherState->val;
             state->isNull = false;
         } else {
             Add::template operation<double_t, double_t, double_t>(
-                *stateValue, *otherStateValue, *stateValue);
+                state->val, otherState->val, state->val);
         }
-        state->numValues += otherState->numValues;
+        state->numValues = state->numValues + otherState->numValues;
     }
 
     static void finalize(uint8_t* state_) {
         auto state = reinterpret_cast<AvgState*>(state_);
-        auto stateValue = (double_t*)state->val.get();
         if (!state->isNull) {
-            *stateValue = *stateValue / (double_t)state->numValues;
+            state->val = state->val / (double_t)state->numValues;
         }
     }
 };

--- a/src/function/include/aggregation/count.h
+++ b/src/function/include/aggregation/count.h
@@ -7,29 +7,31 @@ namespace function {
 template<bool IS_COUNT_STAR>
 struct CountFunction {
 
-    struct CountState : public AggregationState {};
+    struct CountState : public AggregationState {
+        uint64_t val = 0;
+
+        inline uint64_t getValSize() const override { return sizeof(*this); }
+        inline uint8_t* getFinalVal() const override { return (uint8_t*)&val; }
+    };
 
     static unique_ptr<AggregationState> initialize() {
-        auto state = make_unique<AggregationState>();
-        state->val = make_unique<uint8_t[]>(sizeof(uint64_t));
-        *((uint64_t*)state->val.get()) = 0;
+        auto state = make_unique<CountState>();
         state->isNull = false;
         return state;
     }
 
     static void update(uint8_t* state_, ValueVector* input, uint64_t count) {
         auto state = reinterpret_cast<CountState*>(state_);
-        auto stateValue = (uint64_t*)state->val.get();
         if constexpr (IS_COUNT_STAR) {
             assert(input == nullptr);
-            *stateValue += count;
+            state->val += count;
         } else {
             assert(input && count == input->state->selectedSize);
             if (input->hasNoNullsGuarantee()) {
-                *stateValue += count;
+                state->val += count;
             } else {
                 for (auto i = 0u; i < count; i++) {
-                    *stateValue += (1 - input->isNull(input->state->selectedPositions[i]));
+                    state->val += (1 - input->isNull(input->state->selectedPositions[i]));
                 }
             }
         }
@@ -37,10 +39,8 @@ struct CountFunction {
 
     static void combine(uint8_t* state_, uint8_t* otherState_) {
         auto state = reinterpret_cast<CountState*>(state_);
-        auto stateValue = (uint64_t*)state->val.get();
         auto otherState = reinterpret_cast<CountState*>(otherState_);
-        auto otherStateValue = (uint64_t*)otherState->val.get();
-        *stateValue += *otherStateValue;
+        state->val += otherState->val;
     }
 
     static void finalize(uint8_t* state_) {}

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -74,8 +74,9 @@ cc_library(
 cc_library(
     name = "operator_impls",
     srcs = [
-        "physical_plan/operator/aggregate/aggregate.cpp",
-        "physical_plan/operator/aggregate/aggregation_scan.cpp",
+        "physical_plan/operator/aggregate/simple_aggregate.cpp",
+        "physical_plan/operator/aggregate/simple_aggregation_scan.cpp",
+        "physical_plan/operator/aggregate/aggregate_hash_table.cpp",
         "physical_plan/operator/crud/create_node.cpp",
         "physical_plan/operator/crud/crud.cpp",
         "physical_plan/operator/crud/delete_node.cpp",
@@ -106,8 +107,9 @@ cc_library(
         "physical_plan/query_result.cpp",
     ],
     hdrs = [
-        "include/physical_plan/operator/aggregate/aggregate.h",
-        "include/physical_plan/operator/aggregate/aggregation_scan.h",
+        "include/physical_plan/operator/aggregate/simple_aggregate.h",
+        "include/physical_plan/operator/aggregate/simple_aggregation_scan.h",
+        "include/physical_plan/operator/aggregate/aggregate_hash_table.h",
         "include/physical_plan/operator/crud/create_node.h",
         "include/physical_plan/operator/crud/crud.h",
         "include/physical_plan/operator/crud/crud_node.h",

--- a/src/processor/include/physical_plan/operator/aggregate/aggregate_hash_table.h
+++ b/src/processor/include/physical_plan/operator/aggregate/aggregate_hash_table.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "src/common/include/memory_manager.h"
+#include "src/expression_evaluator/include/aggregate_expression_evaluator.h"
+#include "src/processor/include/physical_plan/data_pos.h"
+#include "src/processor/include/physical_plan/operator/result/result_set.h"
+
+using namespace graphflow::evaluator;
+
+namespace graphflow {
+namespace processor {
+
+constexpr uint32_t EMPTY_BLOCK_ID = 0; // Valid block id starts from 1
+constexpr uint16_t HASH_PREFIX_SHIFT = (sizeof(hash_t) - sizeof(uint16_t)) * 8;
+
+struct HashSlot {
+    uint16_t hashPrefix;    // 16 high bits of the hash value for fast comparison.
+    uint16_t offsetInBlock; // i-th entry in a block.
+    uint32_t blockId;       // i-th block in the blocks array.
+};
+
+//! The hash table uses linear probing for collision resolution.
+class AggregateHashTable {
+public:
+    AggregateHashTable(MemoryManager& memoryManager,
+        vector<unique_ptr<AggregateExpressionEvaluator>> aggregates, uint64_t groupsSizeInEntry,
+        uint64_t numBytesPerEntry);
+
+    void append(const vector<shared_ptr<ValueVector>>& groupVectors,
+        const vector<shared_ptr<ValueVector>>& aggregateVectors);
+    uint8_t* lookup(const vector<shared_ptr<ValueVector>>& groupVectors);
+
+private:
+    void resize(uint64_t newSize);
+    uint8_t* findGroup(const vector<shared_ptr<ValueVector>>& groupVectors);
+    uint8_t* createNewGroup(const vector<shared_ptr<ValueVector>>& groupVectors);
+    void addNewBlock();
+    void updateHashSlot(hash_t hash, uint32_t blockId, uint16_t offsetInBlock) const;
+    bool matchGroups(const vector<shared_ptr<ValueVector>>& groupVectors, uint8_t* entry);
+    void computeHashesForVectors(const vector<shared_ptr<ValueVector>>& vectors) const;
+
+private:
+    MemoryManager& memoryManager;
+    vector<unique_ptr<AggregateExpressionEvaluator>> aggregates;
+    uint64_t numBytesPerEntry; // Entry: [hash, group key, ..., aggregate state, ...]
+    uint64_t numBytesForGroupKeys;
+    uint64_t numGroups;
+    uint64_t capacity; // Max num of slots in current hashSlotBlock.
+    uint64_t bitmask;
+    uint64_t numEntriesPerBlock;
+    uint64_t offsetInCurrentBlock;
+    vector<unique_ptr<MemoryBlock>> blocks; // Blocks for hash table entries
+    unique_ptr<MemoryBlock> hashSlotsBlock; // The block for hash slots
+    HashSlot* hashSlots;
+
+    vector<unique_ptr<AggregationState>> initializedStates;
+    unique_ptr<ValueVector> groupHashes;
+};
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
@@ -26,10 +26,10 @@ struct AggregationSharedState {
     uint64_t currentGroupOffset;
 };
 
-class Aggregate : public Sink {
+class SimpleAggregate : public Sink {
 
 public:
-    Aggregate(shared_ptr<ResultSet> resultSet, unique_ptr<PhysicalOperator> prevOperator,
+    SimpleAggregate(shared_ptr<ResultSet> resultSet, unique_ptr<PhysicalOperator> prevOperator,
         ExecutionContext& context, uint32_t id,
         shared_ptr<AggregationSharedState> aggregationSharedState,
         vector<unique_ptr<AggregateExpressionEvaluator>> aggregationEvaluators);

--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregation_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregation_scan.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "src/processor/include/physical_plan/operator/aggregate/aggregate.h"
+#include "src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h"
 #include "src/processor/include/physical_plan/operator/physical_operator.h"
 
 using namespace graphflow::function;
@@ -8,11 +8,12 @@ using namespace graphflow::function;
 namespace graphflow {
 namespace processor {
 
-class AggregationScan : public PhysicalOperator {
+class SimpleAggregationScan : public PhysicalOperator {
 
 public:
-    AggregationScan(const vector<DataPos>& outDataPos, unique_ptr<PhysicalOperator> prevOperator,
-        shared_ptr<AggregationSharedState> sharedState, ExecutionContext& context, uint32_t id)
+    SimpleAggregationScan(const vector<DataPos>& outDataPos,
+        unique_ptr<PhysicalOperator> prevOperator, shared_ptr<AggregationSharedState> sharedState,
+        ExecutionContext& context, uint32_t id)
         : PhysicalOperator{move(prevOperator), AGGREGATION_SCAN, context, id}, outDataChunkPos{0},
           outDataPos{outDataPos}, sharedState{move(sharedState)} {}
 
@@ -21,7 +22,7 @@ public:
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<AggregationScan>(
+        return make_unique<SimpleAggregationScan>(
             outDataPos, prevOperator->clone(), move(sharedState), context, id);
     }
 

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -13,8 +13,6 @@ using namespace graphflow::common::operation;
 namespace graphflow {
 namespace processor {
 
-// By default, ht block size is 256KB
-constexpr const uint64_t DEFAULT_HT_BLOCK_SIZE = 1 << 18;
 // By default, overflow block size is 2MB
 constexpr const int64_t DEFAULT_OVERFLOW_BLOCK_SIZE = 1 << 21;
 

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -70,7 +70,7 @@ public:
 
     // For subquery, we rerun a plan multiple times. ReInitialize() should be called before each run
     // to ensure
-    virtual void reInitialize() { prevOperator->reInitialize(); }
+    virtual void reInitialize();
 
     // Return false if no more tuples to pull, otherwise return true
     virtual bool getNextTuples() = 0;

--- a/src/processor/include/physical_plan/operator/scan_node_id/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id/scan_node_id.h
@@ -20,8 +20,6 @@ public:
 
     void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
 
-    void reInitialize() override;
-
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/physical_plan/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/physical_plan/operator/aggregate/aggregate_hash_table.cpp
@@ -1,0 +1,164 @@
+#include "src/processor/include/physical_plan/operator/aggregate/aggregate_hash_table.h"
+
+#include "src/common/include/vector/operations/vector_hash_operations.h"
+
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace processor {
+
+AggregateHashTable::AggregateHashTable(MemoryManager& memoryManager,
+    vector<unique_ptr<AggregateExpressionEvaluator>> aggregates, uint64_t groupsSizeInEntry,
+    uint64_t numBytesPerEntry)
+    : memoryManager{memoryManager}, aggregates{move(aggregates)},
+      numBytesPerEntry{numBytesPerEntry}, numBytesForGroupKeys{groupsSizeInEntry}, numGroups{0},
+      offsetInCurrentBlock{0} {
+    numEntriesPerBlock = DEFAULT_HT_BLOCK_SIZE / numBytesPerEntry;
+    for (auto& aggregate : this->aggregates) {
+        initializedStates.push_back(aggregate->getFunction()->initialize());
+    }
+    hashSlotsBlock = memoryManager.allocateBlock(DEFAULT_HT_BLOCK_SIZE, true);
+    hashSlots = (HashSlot*)hashSlotsBlock->data;
+    groupHashes = make_unique<ValueVector>(nullptr, INT64, true);
+    groupHashes->state = DataChunkState::getSingleValueDataChunkState();
+    capacity = hashSlotsBlock->size / sizeof(HashSlot);
+    bitmask = capacity - 1;
+}
+
+void AggregateHashTable::append(const vector<shared_ptr<ValueVector>>& groupVectors,
+    const vector<shared_ptr<ValueVector>>& aggregateVectors) {
+    if (numGroups >= capacity - 1 ||
+        (double)numGroups > (double)capacity / DEFAULT_HT_LOAD_FACTOR) {
+        resize(capacity * 2);
+    }
+    computeHashesForVectors(groupVectors);
+    auto entry = findGroup(groupVectors);
+    if (entry == nullptr) {
+        entry = createNewGroup(groupVectors);
+    }
+    auto aggregateOffset = sizeof(hash_t) + numBytesForGroupKeys;
+    for (auto i = 0u; i < aggregates.size(); i++) {
+        aggregates[i]->getFunction()->update(
+            entry + aggregateOffset, aggregates[i]->getChildResult(), 1);
+        aggregateOffset += initializedStates[i]->getValSize();
+    }
+}
+
+uint8_t* AggregateHashTable::lookup(const vector<shared_ptr<ValueVector>>& groupVectors) {
+    computeHashesForVectors(groupVectors);
+    return findGroup(groupVectors);
+}
+
+uint8_t* AggregateHashTable::findGroup(const vector<shared_ptr<ValueVector>>& groupVectors) {
+    assert(hashSlots);
+    // todo: remove the assumption that input groups are flat.
+    auto hash = ((hash_t*)groupHashes->values)[0];
+    auto slotOffset = hash & bitmask;
+    uint8_t* entry;
+    while (true) {
+        auto slot = hashSlots[slotOffset];
+        if (slot.blockId == EMPTY_BLOCK_ID) {
+            break;
+        } else if (slot.hashPrefix == hash >> HASH_PREFIX_SHIFT) {
+            entry = blocks[slot.blockId - 1]->data + (numBytesPerEntry * slot.offsetInBlock);
+            if (*(hash_t*)entry == hash && matchGroups(groupVectors, entry)) {
+                return entry;
+            }
+        }
+        slotOffset++;
+    }
+    return nullptr;
+}
+
+void AggregateHashTable::computeHashesForVectors(
+    const vector<shared_ptr<ValueVector>>& vectors) const {
+    VectorHashOperations::Hash(*vectors[0], *groupHashes);
+    for (auto i = 1; i < vectors.size(); i++) {
+        VectorHashOperations::CombineHash(*vectors[i], *groupHashes);
+    }
+}
+
+bool AggregateHashTable::matchGroups(
+    const vector<shared_ptr<ValueVector>>& groupVectors, uint8_t* entry) {
+    entry += sizeof(hash_t); // Skip the hash value.
+    for (auto& groupVector : groupVectors) {
+        auto groupValueOffset = groupVector->state->getPositionOfCurrIdx();
+        auto groupValue =
+            groupVector->values + groupValueOffset * groupVector->getNumBytesPerValue();
+        if (memcmp(entry, groupValue, groupVector->getNumBytesPerValue()) == 0) {
+            entry += groupVector->getNumBytesPerValue();
+        } else {
+            return false;
+        }
+    }
+    return true;
+}
+
+uint8_t* AggregateHashTable::createNewGroup(const vector<shared_ptr<ValueVector>>& groupVectors) {
+    if (blocks.empty() || offsetInCurrentBlock == numEntriesPerBlock) {
+        addNewBlock();
+    }
+    auto entry = blocks.back()->data + (offsetInCurrentBlock * numBytesPerEntry);
+    auto hash = ((hash_t*)groupHashes->values)[0];
+    updateHashSlot(hash, blocks.size(), offsetInCurrentBlock++);
+    *(hash_t*)entry = hash;
+    uint64_t offsetInEntry = sizeof(hash_t); // Skip the hash.
+    for (auto& groupVector : groupVectors) {
+        auto groupValueOffset = groupVector->state->getPositionOfCurrIdx();
+        auto groupValue =
+            groupVector->values + groupValueOffset * groupVector->getNumBytesPerValue();
+        memcpy(entry + offsetInEntry, groupValue, groupVector->getNumBytesPerValue());
+        offsetInEntry += groupVector->getNumBytesPerValue();
+    }
+    for (auto i = 0u; i < aggregates.size(); i++) {
+        memcpy(entry + offsetInEntry, (uint8_t*)initializedStates[i].get(),
+            initializedStates[i]->getValSize());
+        offsetInEntry += initializedStates[i]->getValSize();
+    }
+    numGroups++;
+    return entry;
+}
+
+void AggregateHashTable::addNewBlock() {
+    blocks.push_back(memoryManager.allocateBlock(DEFAULT_HT_BLOCK_SIZE, true));
+    offsetInCurrentBlock = 0;
+}
+
+void AggregateHashTable::resize(uint64_t size) {
+    assert(size > capacity);
+    auto numBytesForSlots = size * sizeof(HashSlot);
+    assert(numBytesForSlots > hashSlotsBlock->size);
+    hashSlotsBlock = memoryManager.allocateBlock(numBytesForSlots, true);
+    hashSlots = (HashSlot*)hashSlotsBlock->data;
+    capacity = size;
+    bitmask = capacity - 1;
+    auto numEntriesToReHash = (blocks.size() - 1) * numEntriesPerBlock + offsetInCurrentBlock;
+    for (auto blockId = 1u; blockId <= blocks.size(); blockId++) {
+        auto numEntriesInBlock = min(numEntriesToReHash, numEntriesPerBlock);
+        for (auto entryId = 0u; entryId < numEntriesInBlock; entryId++) {
+            auto entry = blocks[blockId - 1]->data + (entryId * numBytesPerEntry);
+            auto hash = *(hash_t*)entry;
+            assert((hash & bitmask) == (hash % capacity));
+            updateHashSlot(hash, blockId, entryId);
+        }
+        numEntriesToReHash -= numEntriesInBlock;
+    }
+}
+
+void AggregateHashTable::updateHashSlot(
+    hash_t hash, uint32_t blockId, uint16_t offsetInBlock) const {
+    auto slotOffset = hash & bitmask;
+    while (hashSlots[slotOffset].blockId != EMPTY_BLOCK_ID) {
+        slotOffset++;
+        if (slotOffset > capacity) {
+            slotOffset = 0;
+        }
+    }
+    assert(hashSlots[slotOffset].blockId == EMPTY_BLOCK_ID);
+    hashSlots[slotOffset].hashPrefix = hash >> HASH_PREFIX_SHIFT;
+    hashSlots[slotOffset].blockId = blockId;
+    hashSlots[slotOffset].offsetInBlock = offsetInBlock;
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/physical_plan/operator/aggregate/simple_aggregation_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/simple_aggregation_scan.cpp
@@ -1,9 +1,11 @@
-#include "src/processor/include/physical_plan/operator/aggregate/aggregation_scan.h"
+#include "src/processor/include/physical_plan/operator/aggregate/simple_aggregation_scan.h"
+
+#include <iostream>
 
 namespace graphflow {
 namespace processor {
 
-void AggregationScan::initResultSet(const shared_ptr<ResultSet>& resultSet) {
+void SimpleAggregationScan::initResultSet(const shared_ptr<ResultSet>& resultSet) {
     this->resultSet = resultSet;
     // All aggregation results are materialized in the same dataChunk.
     outDataChunkPos = outDataPos[0].dataChunkPos;
@@ -16,7 +18,7 @@ void AggregationScan::initResultSet(const shared_ptr<ResultSet>& resultSet) {
     }
 }
 
-bool AggregationScan::getNextTuples() {
+bool SimpleAggregationScan::getNextTuples() {
     metrics->executionTime.start();
     auto outDataChunk = this->resultSet->dataChunks[outDataChunkPos];
     {
@@ -32,7 +34,7 @@ bool AggregationScan::getNextTuples() {
                     outDataChunk->valueVectors[i]->setNull(0, true);
                 } else {
                     auto outValues = outDataChunk->valueVectors[i]->values;
-                    memcpy(outValues, sharedState->aggregationStates[i]->val.get(),
+                    memcpy(outValues, sharedState->aggregationStates[i]->getFinalVal(),
                         TypeUtils::getDataTypeSize(sharedState->dataTypes[i]));
                 }
             }

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -58,7 +58,7 @@ void HashJoinBuild::finalize() {
         directory_capacity * sizeof(uint8_t*), true /* initialize */);
 
     nodeID_t nodeId;
-    uint64_t hash;
+    hash_t hash;
     auto directory = (uint8_t**)sharedState->htDirectory->data;
     for (auto& block : sharedState->htBlocks) {
         uint8_t* basePtr = block.data;

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -74,7 +74,7 @@ void HashJoinProbe::getNextBatchOfMatchedTuples() {
             probeSideKeyVector->readNodeID(
                 probeSideKeyVector->state->getPositionOfCurrIdx(), probeState->probeSideKeyNodeID);
             auto directory = (uint8_t**)sharedState->htDirectory->data;
-            uint64_t hash;
+            hash_t hash;
             Hash::operation<nodeID_t>(probeState->probeSideKeyNodeID, hash);
             hash = hash & sharedState->hashBitMask;
             probeState->probedTuple = (uint8_t*)(directory[hash]);

--- a/src/processor/physical_plan/operator/physical_operator.cpp
+++ b/src/processor/physical_plan/operator/physical_operator.cpp
@@ -18,6 +18,12 @@ void PhysicalOperator::initResultSet(const shared_ptr<ResultSet>& resultSet) {
     this->resultSet = resultSet;
 }
 
+void PhysicalOperator::reInitialize() {
+    if (prevOperator) {
+        prevOperator->reInitialize();
+    }
+}
+
 void PhysicalOperator::registerProfilingMetrics() {
     auto executionTime = context.profiler.registerTimeMetric(getTimeMetricKey());
     auto numOutputTuple = context.profiler.registerNumericMetric(getNumTupleMetricKey());

--- a/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id/scan_node_id.cpp
@@ -10,12 +10,6 @@ void ScanNodeID::initResultSet(const shared_ptr<ResultSet>& resultSet) {
     outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
 }
 
-void ScanNodeID::reInitialize() {
-    if (prevOperator) {
-        prevOperator->reInitialize();
-    }
-}
-
 bool ScanNodeID::getNextTuples() {
     metrics->executionTime.start();
     if (prevOperator) {

--- a/src/processor/physical_plan/plan_mapper.cpp
+++ b/src/processor/physical_plan/plan_mapper.cpp
@@ -18,8 +18,8 @@
 #include "src/planner/include/logical_plan/operator/select_scan/logical_select_scan.h"
 #include "src/planner/include/logical_plan/operator/skip/logical_skip.h"
 #include "src/processor/include/physical_plan/expression_mapper.h"
-#include "src/processor/include/physical_plan/operator/aggregate/aggregate.h"
-#include "src/processor/include/physical_plan/operator/aggregate/aggregation_scan.h"
+#include "src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h"
+#include "src/processor/include/physical_plan/operator/aggregate/simple_aggregation_scan.h"
 #include "src/processor/include/physical_plan/operator/filter/filter.h"
 #include "src/processor/include/physical_plan/operator/flatten/flatten.h"
 #include "src/processor/include/physical_plan/operator/hash_join/hash_join_build.h"
@@ -416,9 +416,9 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAggregateToPhysical(
     auto sharedState =
         make_shared<AggregationSharedState>(move(aggregationStates), aggregationDataTypes);
 
-    auto aggregate = make_unique<Aggregate>(move(resultSetBeforeAggregate), move(prevOperator),
-        context, physicalOperatorID++, sharedState, move(expressionEvaluators));
-    auto aggregationScan = make_unique<AggregationScan>(
+    auto aggregate = make_unique<SimpleAggregate>(move(resultSetBeforeAggregate),
+        move(prevOperator), context, physicalOperatorID++, sharedState, move(expressionEvaluators));
+    auto aggregationScan = make_unique<SimpleAggregationScan>(
         expressionsOutputPos, move(aggregate), sharedState, context, physicalOperatorID++);
     return aggregationScan;
 }

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -1,6 +1,6 @@
 #include "src/processor/include/processor.h"
 
-#include "src/processor/include/physical_plan/operator/aggregate/aggregate.h"
+#include "src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h"
 #include "src/processor/include/physical_plan/operator/hash_join/hash_join_build.h"
 #include "src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h"
 #include "src/processor/include/physical_plan/operator/sink/result_collector.h"
@@ -66,7 +66,7 @@ void QueryProcessor::decomposePlanIntoTasks(
         break;
     }
     case AGGREGATE: {
-        auto aggregate = reinterpret_cast<Aggregate*>(op);
+        auto aggregate = reinterpret_cast<SimpleAggregate*>(op);
         auto childTask = make_unique<Task>(reinterpret_cast<Sink*>(aggregate), numThreads);
         decomposePlanIntoTasks(aggregate->prevOperator.get(), childTask.get(), numThreads);
         parentTask->addChildTask(move(childTask));

--- a/src/storage/include/index/hash_index.h
+++ b/src/storage/include/index/hash_index.h
@@ -29,14 +29,12 @@ struct HashIndexHeader {
 public:
     explicit HashIndexHeader()
         : slotCapacity{HashIndexConfig::SLOT_CAPACITY}, currentNumSlots{2}, currentNumEntries{0},
-          maxLoadFactor{HashIndexConfig::MAX_LOAD_FACTOR}, currentLevel{1}, nextSplitSlotId{0},
-          nextBlockIdForOverflowPageSet{0} {}
+          currentLevel{1}, nextSplitSlotId{0}, nextBlockIdForOverflowPageSet{0} {}
 
 public:
     uint64_t slotCapacity;
     uint64_t currentNumSlots;
     uint64_t currentNumEntries;
-    double maxLoadFactor;
     uint64_t currentLevel;
     uint64_t nextSplitSlotId;
     uint64_t nextBlockIdForOverflowPageSet;

--- a/test/processor/BUILD.bazel
+++ b/test/processor/BUILD.bazel
@@ -4,6 +4,7 @@ cc_test(
     name = "processor_tests",
     srcs = [
         "physical_plan/expression_mapper_test.cpp",
+        "physical_plan/operator/aggregate/aggregate_hash_table_test.cpp",
         "physical_plan/operator/frontier/frontier_test.cpp",
         "physical_plan/operator/scan/scan_test.cpp",
         "physical_plan/operator/tuple/result_set_iterator_test.cpp",

--- a/test/processor/physical_plan/operator/aggregate/aggregate_hash_table_test.cpp
+++ b/test/processor/physical_plan/operator/aggregate/aggregate_hash_table_test.cpp
@@ -1,0 +1,124 @@
+#include "gtest/gtest.h"
+
+#include "src/function/include/aggregation/count.h"
+#include "src/processor/include/physical_plan/operator/aggregate/aggregate_hash_table.h"
+
+using ::testing::Test;
+
+class AggregateHashTableTest : public Test {
+
+public:
+    void SetUp() override {
+        memoryManager = make_unique<MemoryManager>();
+        group1Vector = make_shared<ValueVector>(memoryManager.get(), INT64);
+        group2Vector = make_shared<ValueVector>(memoryManager.get(), INT64);
+        aggr1Vector = make_shared<ValueVector>(memoryManager.get(), INT64);
+        aggr2Vector = make_shared<ValueVector>(memoryManager.get(), INT64);
+        auto group1Values = (int64_t*)group1Vector->values;
+        auto group2Values = (int64_t*)group2Vector->values;
+        auto aggr1Values = (int64_t*)aggr1Vector->values;
+        auto aggr2Values = (int64_t*)aggr2Vector->values;
+        for (auto i = 0u; i < 100; i++) {
+            group1Values[i] = i % 4;
+            group2Values[i] = i;
+            aggr1Values[i] = i * 2;
+            aggr2Values[i] = i * 2;
+        }
+        dataChunk = make_shared<DataChunk>(4);
+        dataChunk->state->selectedSize = 100;
+        dataChunk->state->currIdx = 0;
+        dataChunk->insert(0, group1Vector);
+        dataChunk->insert(1, group2Vector);
+        dataChunk->insert(2, aggr1Vector);
+        dataChunk->insert(3, aggr2Vector);
+        resultSet = make_shared<ResultSet>(1);
+        resultSet->insert(0, dataChunk);
+    }
+
+public:
+    unique_ptr<MemoryManager> memoryManager;
+    unique_ptr<AggregateHashTable> ht;
+    shared_ptr<ValueVector> group1Vector;
+    shared_ptr<ValueVector> group2Vector;
+    shared_ptr<ValueVector> aggr1Vector;
+    shared_ptr<ValueVector> aggr2Vector;
+    shared_ptr<DataChunk> dataChunk;
+    shared_ptr<ResultSet> resultSet;
+};
+
+TEST_F(AggregateHashTableTest, SingleGroupTest) {
+    vector<unique_ptr<AggregateExpressionEvaluator>> aggregates;
+    auto count1Aggregate = make_unique<AggregateExpressionEvaluator>(COUNT_STAR_FUNC, INT64,
+        AggregateExpressionEvaluator::getAggregationFunction(COUNT_STAR_FUNC, INT64));
+    auto count2Aggregate = make_unique<AggregateExpressionEvaluator>(COUNT_STAR_FUNC, INT64,
+        AggregateExpressionEvaluator::getAggregationFunction(COUNT_STAR_FUNC, INT64));
+    auto count1State = count1Aggregate->getFunction()->initialize();
+    auto count2State = count2Aggregate->getFunction()->initialize();
+    auto groupsSize = sizeof(uint64_t);
+    auto entrySize =
+        sizeof(hash_t) + groupsSize + count1State->getValSize() + count2State->getValSize();
+    aggregates.push_back(move(count1Aggregate));
+    aggregates.push_back(move(count2Aggregate));
+    auto ht =
+        make_unique<AggregateHashTable>(*memoryManager, move(aggregates), groupsSize, entrySize);
+    vector<shared_ptr<ValueVector>> groupVectors, aggregateVectors;
+    groupVectors.push_back(group1Vector);
+    aggregateVectors.push_back(aggr1Vector);
+    aggregateVectors.push_back(aggr2Vector);
+    while (dataChunk->state->currIdx < dataChunk->state->selectedSize) {
+        ht->append(groupVectors, aggregateVectors);
+        dataChunk->state->currIdx++;
+    }
+    dataChunk->state->currIdx = 0;
+    while (dataChunk->state->currIdx < 4) {
+        auto entry = ht->lookup(groupVectors);
+        ASSERT_TRUE(entry != nullptr);
+        auto count1AggrState =
+            (CountFunction<true>::CountState*)(entry + sizeof(hash_t) + groupsSize);
+        ASSERT_EQ(count1AggrState->val, 25);
+        auto count2AggrState =
+            (CountFunction<true>::CountState*)(entry + sizeof(hash_t) + groupsSize +
+                                               count1AggrState->getValSize());
+        ASSERT_EQ(count2AggrState->val, 25);
+        dataChunk->state->currIdx++;
+    }
+}
+
+TEST_F(AggregateHashTableTest, TwoGroupsTest) {
+    vector<unique_ptr<AggregateExpressionEvaluator>> aggregates;
+    auto count1Aggregate = make_unique<AggregateExpressionEvaluator>(COUNT_STAR_FUNC, INT64,
+        AggregateExpressionEvaluator::getAggregationFunction(COUNT_STAR_FUNC, INT64));
+    auto count2Aggregate = make_unique<AggregateExpressionEvaluator>(COUNT_STAR_FUNC, INT64,
+        AggregateExpressionEvaluator::getAggregationFunction(COUNT_STAR_FUNC, INT64));
+    auto count1State = count1Aggregate->getFunction()->initialize();
+    auto count2State = count2Aggregate->getFunction()->initialize();
+    auto groupsSize = sizeof(uint64_t) + sizeof(uint64_t);
+    auto entrySize =
+        sizeof(hash_t) + groupsSize + count1State->getValSize() + count2State->getValSize();
+    aggregates.push_back(move(count1Aggregate));
+    aggregates.push_back(move(count2Aggregate));
+    auto ht =
+        make_unique<AggregateHashTable>(*memoryManager, move(aggregates), groupsSize, entrySize);
+    vector<shared_ptr<ValueVector>> groupVectors, aggregateVectors;
+    groupVectors.push_back(group1Vector);
+    groupVectors.push_back(group2Vector);
+    aggregateVectors.push_back(aggr1Vector);
+    aggregateVectors.push_back(aggr2Vector);
+    while (dataChunk->state->currIdx < dataChunk->state->selectedSize) {
+        ht->append(groupVectors, aggregateVectors);
+        dataChunk->state->currIdx++;
+    }
+    dataChunk->state->currIdx = 0;
+    while (dataChunk->state->currIdx < dataChunk->state->selectedSize) {
+        auto entry = ht->lookup(groupVectors);
+        ASSERT_TRUE(entry != nullptr);
+        auto count1AggrState =
+            (CountFunction<true>::CountState*)(entry + sizeof(hash_t) + groupsSize);
+        ASSERT_EQ(count1AggrState->val, 1);
+        auto count2AggrState =
+            (CountFunction<true>::CountState*)(entry + sizeof(hash_t) + groupsSize +
+                                               count1AggrState->getValSize());
+        ASSERT_EQ(count2AggrState->val, 1);
+        dataChunk->state->currIdx++;
+    }
+}


### PR DESCRIPTION
The hash table is specialized for aggregations for now. It utilizes the linear hashing scheme for the collision confection resolving.
The hash table consists of hash slots and entry blocks, where hash slots serve as pointers to entries, and resizing the hash table will iterate all entries and update hash slots (entry blocks left as untouched).