### PR TITLE
binary operation executor rework and simplify executor template arguments

### DIFF
--- a/src/common/include/operations/arithmetic_operations.h
+++ b/src/common/include/operations/arithmetic_operations.h
@@ -14,42 +14,48 @@ namespace operation {
 
 struct Add {
     template<class A, class B, class R>
-    static inline void operation(A& left, B& right, R& result) {
+    static inline void operation(A& left, B& right, R& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left + right;
     }
 };
 
 struct Subtract {
     template<class A, class B, class R>
-    static inline void operation(A& left, B& right, R& result) {
+    static inline void operation(A& left, B& right, R& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left - right;
     }
 };
 
 struct Multiply {
     template<class A, class B, class R>
-    static inline void operation(A& left, B& right, R& result) {
+    static inline void operation(A& left, B& right, R& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left * right;
     }
 };
 
 struct Divide {
     template<class A, class B, class R>
-    static inline void operation(A& left, B& right, R& result) {
+    static inline void operation(A& left, B& right, R& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left / right;
     }
 };
 
 struct Modulo {
     template<class A, class B, class R>
-    static inline void operation(A& left, B& right, R& result) {
+    static inline void operation(A& left, B& right, R& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         assert(false);
     }
 };
 
 struct Power {
     template<class A, class B, class R>
-    static inline void operation(A& left, B& right, R& result) {
+    static inline void operation(A& left, B& right, R& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = pow(left, right);
     }
 };
@@ -93,22 +99,30 @@ struct Ceil {
  ********************************************/
 
 template<>
-inline void Modulo::operation(int64_t& left, int64_t& right, int64_t& result) {
+inline void Modulo::operation(
+    int64_t& left, int64_t& right, int64_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = left % right;
 }
 
 template<>
-inline void Modulo::operation(int64_t& left, double_t& right, double_t& result) {
+inline void Modulo::operation(
+    int64_t& left, double_t& right, double_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = fmod(left, right);
 }
 
 template<>
-inline void Modulo::operation(double_t& left, int64_t& right, double_t& result) {
+inline void Modulo::operation(
+    double_t& left, int64_t& right, double_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = fmod(left, right);
 }
 
 template<>
-inline void Modulo::operation(double_t& left, double_t& right, double_t& result) {
+inline void Modulo::operation(
+    double_t& left, double_t& right, double_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = fmod(left, right);
 }
 
@@ -119,7 +133,9 @@ inline void Modulo::operation(double_t& left, double_t& right, double_t& result)
  **************************************************/
 
 template<>
-inline void Add::operation(gf_string_t& left, gf_string_t& right, gf_string_t& result) {
+inline void Add::operation(
+    gf_string_t& left, gf_string_t& right, gf_string_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     auto len = left.len + right.len;
     if (len <= gf_string_t::SHORT_STR_LENGTH /* concat's result is short */) {
         memcpy(result.prefix, left.prefix, left.len);
@@ -134,7 +150,9 @@ inline void Add::operation(gf_string_t& left, gf_string_t& right, gf_string_t& r
 }
 
 template<>
-inline void Add::operation(date_t& left, interval_t& right, date_t& result) {
+inline void Add::operation(
+    date_t& left, interval_t& right, date_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     if (right.months != 0) {
         int32_t year, month, day, maxDayInMonth;
         Date::Convert(left, year, month, day);
@@ -165,12 +183,13 @@ inline void Add::operation(date_t& left, interval_t& right, date_t& result) {
 }
 
 template<>
-inline void Add::operation(timestamp_t& left, interval_t& right, timestamp_t& result) {
+inline void Add::operation(
+    timestamp_t& left, interval_t& right, timestamp_t& result, bool isLeftNull, bool isRightNull) {
     date_t date;
     date_t result_date;
     dtime_t time;
     Timestamp::Convert(left, date, time);
-    Add::operation<date_t, interval_t, date_t>(date, right, result_date);
+    Add::operation<date_t, interval_t, date_t>(date, right, result_date, isLeftNull, isRightNull);
     date = result_date;
     int64_t diff =
         right.micros - ((right.micros / Interval::MICROS_PER_DAY) * Interval::MICROS_PER_DAY);
@@ -186,7 +205,9 @@ inline void Add::operation(timestamp_t& left, interval_t& right, timestamp_t& re
 }
 
 template<>
-inline void Add::operation(interval_t& left, interval_t& right, interval_t& result) {
+inline void Add::operation(
+    interval_t& left, interval_t& right, interval_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result.months = left.months + right.months;
     result.days = left.days + right.days;
     result.micros = left.micros + right.micros;
@@ -199,21 +220,26 @@ inline void Add::operation(interval_t& left, interval_t& right, interval_t& resu
  *********************************************/
 
 template<>
-inline void Subtract::operation(date_t& left, interval_t& right, date_t& result) {
+inline void Subtract::operation(
+    date_t& left, interval_t& right, date_t& result, bool isLeftNull, bool isRightNull) {
     interval_t inverseRight;
     inverseRight.months = -right.months;
     inverseRight.days = -right.days;
     inverseRight.micros = -right.micros;
-    Add::operation<date_t, interval_t, date_t>(left, inverseRight, result);
+    Add::operation<date_t, interval_t, date_t>(left, inverseRight, result, isLeftNull, isRightNull);
 }
 
 template<>
-inline void Subtract::operation(date_t& left, date_t& right, int64_t& result) {
+inline void Subtract::operation(
+    date_t& left, date_t& right, int64_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = left.days - right.days;
 }
 
 template<>
-inline void Subtract::operation(timestamp_t& left, timestamp_t& right, interval_t& result) {
+inline void Subtract::operation(
+    timestamp_t& left, timestamp_t& right, interval_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     uint64_t diff = abs(left.value - right.value);
     result.months = 0;
     result.days = diff / Interval::MICROS_PER_DAY;
@@ -225,23 +251,29 @@ inline void Subtract::operation(timestamp_t& left, timestamp_t& right, interval_
 }
 
 template<>
-inline void Subtract::operation(timestamp_t& left, interval_t& right, timestamp_t& result) {
+inline void Subtract::operation(
+    timestamp_t& left, interval_t& right, timestamp_t& result, bool isLeftNull, bool isRightNull) {
     interval_t inverseRight;
     inverseRight.months = -right.months;
     inverseRight.days = -right.days;
     inverseRight.micros = -right.micros;
-    Add::operation<timestamp_t, interval_t, timestamp_t>(left, inverseRight, result);
+    Add::operation<timestamp_t, interval_t, timestamp_t>(
+        left, inverseRight, result, isLeftNull, isRightNull);
 }
 
 template<>
-inline void Subtract::operation(interval_t& left, interval_t& right, interval_t& result) {
+inline void Subtract::operation(
+    interval_t& left, interval_t& right, interval_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result.months = left.months - right.months;
     result.days = left.days - right.days;
     result.micros = left.micros - right.micros;
 }
 
 template<>
-inline void Divide::operation(interval_t& left, int64_t& right, interval_t& result) {
+inline void Divide::operation(
+    interval_t& left, int64_t& right, interval_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     int32_t monthsRemainder = left.months % right;
     int32_t daysRemainder = (left.days + monthsRemainder * Interval::DAYS_PER_MONTH) % right;
     result.months = left.months / right;
@@ -257,17 +289,20 @@ inline void Divide::operation(interval_t& left, int64_t& right, interval_t& resu
 
 struct ArithmeticOnValues {
     template<class FUNC, const char* arithmeticOpStr>
-    static void operation(Value& left, Value& right, Value& result) {
+    static void operation(
+        Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
         switch (left.dataType) {
         case INT64:
             switch (right.dataType) {
             case INT64: {
                 result.dataType = INT64;
-                FUNC::operation(left.val.int64Val, right.val.int64Val, result.val.int64Val);
+                FUNC::operation(left.val.int64Val, right.val.int64Val, result.val.int64Val,
+                    isLeftNull, isRightNull);
             } break;
             case DOUBLE: {
                 result.dataType = DOUBLE;
-                FUNC::operation(left.val.int64Val, right.val.doubleVal, result.val.doubleVal);
+                FUNC::operation(left.val.int64Val, right.val.doubleVal, result.val.doubleVal,
+                    isLeftNull, isRightNull);
             } break;
             default:
                 throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `INT64` and `" +
@@ -278,11 +313,13 @@ struct ArithmeticOnValues {
             switch (right.dataType) {
             case INT64: {
                 result.dataType = DOUBLE;
-                FUNC::operation(left.val.doubleVal, right.val.int64Val, result.val.doubleVal);
+                FUNC::operation(left.val.doubleVal, right.val.int64Val, result.val.doubleVal,
+                    isLeftNull, isRightNull);
             } break;
             case DOUBLE: {
                 result.dataType = DOUBLE;
-                FUNC::operation(left.val.doubleVal, right.val.doubleVal, result.val.doubleVal);
+                FUNC::operation(left.val.doubleVal, right.val.doubleVal, result.val.doubleVal,
+                    isLeftNull, isRightNull);
             } break;
             default:
                 throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `DOUBLE` and `" +
@@ -327,87 +364,107 @@ static const char floorStr[] = "floor";
 static const char ceilStr[] = "ceil";
 
 template<>
-inline void Add::operation(Value& left, Value& right, Value& result) {
+inline void Add::operation(
+    Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
     if (left.dataType == STRING) {
         assert(right.dataType == STRING);
         result.dataType = STRING;
-        Add::operation(left.val.strVal, right.val.strVal, result.val.strVal);
+        Add::operation(
+            left.val.strVal, right.val.strVal, result.val.strVal, isLeftNull, isRightNull);
         return;
     } else if (left.dataType == DATE && right.dataType == INTERVAL) {
         result.dataType = DATE;
-        Add::operation(left.val.dateVal, right.val.intervalVal, result.val.dateVal);
+        Add::operation(
+            left.val.dateVal, right.val.intervalVal, result.val.dateVal, isLeftNull, isRightNull);
         return;
     } else if (left.dataType == DATE && right.dataType == INT64) {
         result.dataType = DATE;
-        Add::operation(left.val.dateVal, right.val.int64Val, result.val.dateVal);
+        Add::operation(
+            left.val.dateVal, right.val.int64Val, result.val.dateVal, isLeftNull, isRightNull);
         return;
     } else if (left.dataType == TIMESTAMP) {
         assert(right.dataType == INTERVAL);
         result.dataType = TIMESTAMP;
-        Add::operation(left.val.timestampVal, right.val.intervalVal, result.val.timestampVal);
+        Add::operation(left.val.timestampVal, right.val.intervalVal, result.val.timestampVal,
+            isLeftNull, isRightNull);
         return;
     } else if (left.dataType == INTERVAL) {
         assert(right.dataType == INTERVAL);
         result.dataType = INTERVAL;
-        Add::operation(left.val.intervalVal, right.val.intervalVal, result.val.intervalVal);
+        Add::operation(left.val.intervalVal, right.val.intervalVal, result.val.intervalVal,
+            isLeftNull, isRightNull);
         return;
     }
-    ArithmeticOnValues::operation<Add, addStr>(left, right, result);
+    ArithmeticOnValues::operation<Add, addStr>(left, right, result, isLeftNull, isRightNull);
 }
 
 template<>
-inline void Subtract::operation(Value& left, Value& right, Value& result) {
+inline void Subtract::operation(
+    Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
     if (left.dataType == DATE && right.dataType == INTERVAL) {
         result.dataType = DATE;
-        Subtract::operation(left.val.dateVal, right.val.intervalVal, result.val.dateVal);
+        Subtract::operation(
+            left.val.dateVal, right.val.intervalVal, result.val.dateVal, isLeftNull, isRightNull);
         return;
     } else if (left.dataType == DATE && right.dataType == INT64) {
         result.dataType = DATE;
-        Subtract::operation(left.val.dateVal, right.val.int64Val, result.val.dateVal);
+        Subtract::operation(
+            left.val.dateVal, right.val.int64Val, result.val.dateVal, isLeftNull, isRightNull);
         return;
     } else if (left.dataType == DATE && right.dataType == DATE) {
         result.dataType = INT64;
-        Subtract::operation(left.val.dateVal, right.val.dateVal, result.val.int64Val);
+        Subtract::operation(
+            left.val.dateVal, right.val.dateVal, result.val.int64Val, isLeftNull, isRightNull);
         return;
     } else if (left.dataType == TIMESTAMP && right.dataType == INTERVAL) {
         result.dataType = TIMESTAMP;
-        Subtract::operation(left.val.timestampVal, right.val.intervalVal, result.val.timestampVal);
+        Subtract::operation(left.val.timestampVal, right.val.intervalVal, result.val.timestampVal,
+            isLeftNull, isRightNull);
         return;
     } else if (left.dataType == TIMESTAMP && right.dataType == TIMESTAMP) {
         result.dataType = INTERVAL;
-        Subtract::operation(left.val.timestampVal, right.val.timestampVal, result.val.intervalVal);
+        Subtract::operation(left.val.timestampVal, right.val.timestampVal, result.val.intervalVal,
+            isLeftNull, isRightNull);
         return;
     } else if (left.dataType == INTERVAL && right.dataType == INTERVAL) {
         result.dataType = INTERVAL;
-        Subtract::operation(left.val.intervalVal, right.val.intervalVal, result.val.intervalVal);
+        Subtract::operation(left.val.intervalVal, right.val.intervalVal, result.val.intervalVal,
+            isLeftNull, isRightNull);
         return;
     }
-    ArithmeticOnValues::operation<Subtract, subtractStr>(left, right, result);
+    ArithmeticOnValues::operation<Subtract, subtractStr>(
+        left, right, result, isLeftNull, isRightNull);
 }
 
 template<>
-inline void Multiply::operation(Value& left, Value& right, Value& result) {
-    ArithmeticOnValues::operation<Multiply, multiplyStr>(left, right, result);
+inline void Multiply::operation(
+    Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
+    ArithmeticOnValues::operation<Multiply, multiplyStr>(
+        left, right, result, isLeftNull, isRightNull);
 }
 
 template<>
-inline void Divide::operation(Value& left, Value& right, Value& result) {
+inline void Divide::operation(
+    Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
     if (left.dataType == INTERVAL && right.dataType == INT64) {
         result.dataType = INTERVAL;
-        Divide::operation(left.val.intervalVal, right.val.int64Val, result.val.intervalVal);
+        Divide::operation(left.val.intervalVal, right.val.int64Val, result.val.intervalVal,
+            isLeftNull, isRightNull);
         return;
     }
-    ArithmeticOnValues::operation<Divide, divideStr>(left, right, result);
+    ArithmeticOnValues::operation<Divide, divideStr>(left, right, result, isLeftNull, isRightNull);
 }
 
 template<>
-inline void Modulo::operation(Value& left, Value& right, Value& result) {
-    ArithmeticOnValues::operation<Modulo, moduloStr>(left, right, result);
+inline void Modulo::operation(
+    Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
+    ArithmeticOnValues::operation<Modulo, moduloStr>(left, right, result, isLeftNull, isRightNull);
 }
 
 template<>
-inline void Power::operation(Value& left, Value& right, Value& result) {
-    ArithmeticOnValues::operation<Power, powerStr>(left, right, result);
+inline void Power::operation(
+    Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
+    ArithmeticOnValues::operation<Power, powerStr>(left, right, result, isLeftNull, isRightNull);
 }
 
 template<>

--- a/src/common/include/operations/boolean_operations.h
+++ b/src/common/include/operations/boolean_operations.h
@@ -9,38 +9,31 @@ namespace common {
 namespace operation {
 
 struct And {
-    static inline uint8_t operation(
-        uint8_t left, uint8_t right, bool isLeftNull, bool isRightNull) {
+    static inline void operation(
+        uint8_t left, uint8_t right, uint8_t& result, bool isLeftNull, bool isRightNull) {
         if (left == FALSE || right == FALSE) {
-            return FALSE;
+            result = FALSE;
+        } else {
+            result = isLeftNull || isRightNull ? NULL_BOOL : TRUE;
         }
-        if (isLeftNull || isRightNull) {
-            return NULL_BOOL;
-        }
-        return TRUE;
     }
 };
 
 struct Or {
-    static inline uint8_t operation(
-        uint8_t left, uint8_t right, bool isLeftNull, bool isRightNull) {
+    static inline void operation(
+        uint8_t left, uint8_t right, uint8_t& result, bool isLeftNull, bool isRightNull) {
         if (left == TRUE || right == TRUE) {
-            return TRUE;
+            result = TRUE;
+        } else {
+            result = isLeftNull || isRightNull ? NULL_BOOL : FALSE;
         }
-        if (isLeftNull || isRightNull) {
-            return NULL_BOOL;
-        }
-        return FALSE;
     }
 };
 
 struct Xor {
-    static inline uint8_t operation(
-        uint8_t left, uint8_t right, bool isLeftNull, bool isRightNull) {
-        if (isLeftNull || isRightNull) {
-            return NULL_BOOL;
-        }
-        return left ^ right;
+    static inline void operation(
+        uint8_t left, uint8_t right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        result = (isLeftNull || isRightNull) ? NULL_BOOL : left ^ right;
     }
 };
 

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -11,42 +11,54 @@ namespace operation {
 
 struct Equals {
     template<class A, class B>
-    static inline void operation(const A& left, const B& right, uint8_t& result) {
+    static inline void operation(
+        const A& left, const B& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left == right;
     }
 };
 
 struct NotEquals {
     template<class A, class B>
-    static inline void operation(const A& left, const B& right, uint8_t& result) {
+    static inline void operation(
+        const A& left, const B& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left != right;
     }
 };
 
 struct GreaterThan {
     template<class A, class B>
-    static inline void operation(const A& left, const B& right, uint8_t& result) {
+    static inline void operation(
+        const A& left, const B& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left > right;
     }
 };
 
 struct GreaterThanEquals {
     template<class A, class B>
-    static inline void operation(const A& left, const B& right, uint8_t& result) {
+    static inline void operation(
+        const A& left, const B& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left >= right;
     }
 };
 
 struct LessThan {
     template<class A, class B>
-    static inline void operation(const A& left, const B& right, uint8_t& result) {
+    static inline void operation(
+        const A& left, const B& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left < right;
     }
 };
 
 struct LessThanEquals {
     template<class A, class B>
-    static inline void operation(const A& left, const B& right, uint8_t& result) {
+    static inline void operation(
+        const A& left, const B& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         result = left <= right;
     }
 };
@@ -81,56 +93,71 @@ struct IsNotNull {
 
 struct EqualsOrNotEqualsValues {
     template<bool equals>
-    static inline void operation(const Value& left, const Value& right, uint8_t& result) {
+    static inline void operation(
+        const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
         if (left.dataType == right.dataType) {
             switch (left.dataType) {
             case BOOL: {
                 if constexpr (equals) {
-                    Equals::operation(left.val.booleanVal, right.val.booleanVal, result);
+                    Equals::operation(
+                        left.val.booleanVal, right.val.booleanVal, result, isLeftNull, isRightNul);
                 } else {
-                    NotEquals::operation(left.val.booleanVal, right.val.booleanVal, result);
+                    NotEquals::operation(
+                        left.val.booleanVal, right.val.booleanVal, result, isLeftNull, isRightNul);
                 }
             } break;
             case INT64: {
                 if constexpr (equals) {
-                    Equals::operation(left.val.int64Val, right.val.int64Val, result);
+                    Equals::operation(
+                        left.val.int64Val, right.val.int64Val, result, isLeftNull, isRightNul);
                 } else {
-                    NotEquals::operation(left.val.int64Val, right.val.int64Val, result);
+                    NotEquals::operation(
+                        left.val.int64Val, right.val.int64Val, result, isLeftNull, isRightNul);
                 }
             } break;
             case DOUBLE: {
                 if constexpr (equals) {
-                    Equals::operation(left.val.doubleVal, right.val.doubleVal, result);
+                    Equals::operation(
+                        left.val.doubleVal, right.val.doubleVal, result, isLeftNull, isRightNul);
                 } else {
-                    NotEquals::operation(left.val.doubleVal, right.val.doubleVal, result);
+                    NotEquals::operation(
+                        left.val.doubleVal, right.val.doubleVal, result, isLeftNull, isRightNul);
                 }
             } break;
             case STRING: {
                 if constexpr (equals) {
-                    Equals::operation(left.val.strVal, right.val.strVal, result);
+                    Equals::operation(
+                        left.val.strVal, right.val.strVal, result, isLeftNull, isRightNul);
                 } else {
-                    NotEquals::operation(left.val.strVal, right.val.strVal, result);
+                    NotEquals::operation(
+                        left.val.strVal, right.val.strVal, result, isLeftNull, isRightNul);
                 }
             } break;
             case DATE: {
                 if constexpr (equals) {
-                    Equals::operation(left.val.dateVal, right.val.dateVal, result);
+                    Equals::operation(
+                        left.val.dateVal, right.val.dateVal, result, isLeftNull, isRightNul);
                 } else {
-                    NotEquals::operation(left.val.dateVal, right.val.dateVal, result);
+                    NotEquals::operation(
+                        left.val.dateVal, right.val.dateVal, result, isLeftNull, isRightNul);
                 }
             } break;
             case TIMESTAMP: {
                 if constexpr (equals) {
-                    Equals::operation(left.val.timestampVal, right.val.timestampVal, result);
+                    Equals::operation(left.val.timestampVal, right.val.timestampVal, result,
+                        isLeftNull, isRightNul);
                 } else {
-                    NotEquals::operation(left.val.timestampVal, right.val.timestampVal, result);
+                    NotEquals::operation(left.val.timestampVal, right.val.timestampVal, result,
+                        isLeftNull, isRightNul);
                 }
             } break;
             case INTERVAL: {
                 if constexpr (equals) {
-                    Equals::operation(left.val.intervalVal, right.val.intervalVal, result);
+                    Equals::operation(left.val.intervalVal, right.val.intervalVal, result,
+                        isLeftNull, isRightNul);
                 } else {
-                    NotEquals::operation(left.val.intervalVal, right.val.intervalVal, result);
+                    NotEquals::operation(left.val.intervalVal, right.val.intervalVal, result,
+                        isLeftNull, isRightNul);
                 }
             } break;
             default:
@@ -138,15 +165,19 @@ struct EqualsOrNotEqualsValues {
             }
         } else if (left.dataType == INT64 && right.dataType == DOUBLE) {
             if constexpr (equals) {
-                Equals::operation(left.val.int64Val, right.val.doubleVal, result);
+                Equals::operation(
+                    left.val.int64Val, right.val.doubleVal, result, isLeftNull, isRightNul);
             } else {
-                NotEquals::operation(left.val.int64Val, right.val.doubleVal, result);
+                NotEquals::operation(
+                    left.val.int64Val, right.val.doubleVal, result, isLeftNull, isRightNul);
             }
         } else if (left.dataType == DOUBLE && right.dataType == INT64) {
             if constexpr (equals) {
-                Equals::operation(left.val.doubleVal, right.val.int64Val, result);
+                Equals::operation(
+                    left.val.doubleVal, right.val.int64Val, result, isLeftNull, isRightNul);
             } else {
-                NotEquals::operation(left.val.doubleVal, right.val.int64Val, result);
+                NotEquals::operation(
+                    left.val.doubleVal, right.val.int64Val, result, isLeftNull, isRightNul);
             }
         } else {
             result = equals ? FALSE : TRUE;
@@ -156,13 +187,15 @@ struct EqualsOrNotEqualsValues {
 
 // specialized for Value.
 template<>
-inline void Equals::operation(const Value& left, const Value& right, uint8_t& result) {
-    EqualsOrNotEqualsValues::operation<true>(left, right, result);
+inline void Equals::operation(
+    const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
+    EqualsOrNotEqualsValues::operation<true>(left, right, result, isLeftNull, isRightNul);
 };
 
 template<>
-inline void NotEquals::operation(const Value& left, const Value& right, uint8_t& result) {
-    EqualsOrNotEqualsValues::operation<false>(left, right, result);
+inline void NotEquals::operation(
+    const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
+    EqualsOrNotEqualsValues::operation<false>(left, right, result, isLeftNull, isRightNul);
 };
 
 // Equals and NotEquals function for gf_string_t.
@@ -183,7 +216,8 @@ struct StringComparisonOperators {
 
     // compare gf_string_t up to shared length. if still the same, Compare lengths.
     template<class FUNC>
-    static void Compare(const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
+    static void Compare(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
+        bool isLeftNull, bool isRightNul) {
         auto len = left.len < right.len ? left.len : right.len;
         auto memcmpResult = memcmp(left.prefix, right.prefix,
             len <= gf_string_t::PREFIX_LENGTH ? len : gf_string_t::PREFIX_LENGTH);
@@ -191,33 +225,40 @@ struct StringComparisonOperators {
             memcmpResult = memcmp(left.getData(), right.getData(), len);
         }
         if (memcmpResult == 0) {
-            FUNC::operation(left.len, right.len, result);
+            FUNC::operation(left.len, right.len, result, isLeftNull, isRightNul);
         } else {
-            FUNC::operation(memcmpResult, 0, result);
+            FUNC::operation(memcmpResult, 0, result, isLeftNull, isRightNul);
         }
     };
 };
 
 // specialized for gf_string_t.
 template<>
-inline void Equals::operation(const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
+inline void Equals::operation(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     StringComparisonOperators::EqualsOrNot<true>(left, right, result);
 };
 
 template<>
-inline void NotEquals::operation(
-    const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
+inline void NotEquals::operation(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     StringComparisonOperators::EqualsOrNot<false>(left, right, result);
 };
 
 // specialized for nodeID_t.
 template<>
-inline void Equals::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result) {
+inline void Equals::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = left.label == right.label && left.offset == right.offset;
 };
 
 template<>
-inline void NotEquals::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result) {
+inline void NotEquals::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = left.label != right.label || left.offset != right.offset;
 };
 
@@ -229,37 +270,44 @@ inline void NotEquals::operation(const nodeID_t& left, const nodeID_t& right, ui
 
 struct CompareValues {
     template<class FUNC = std::function<uint8_t(Value, Value)>>
-    static inline void operation(const Value& left, const Value& right, uint8_t& result) {
+    static inline void operation(
+        const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
         if (left.dataType == right.dataType) {
             switch (left.dataType) {
             case BOOL: {
-                FUNC::operation(left.val.booleanVal, right.val.booleanVal, result);
+                FUNC::operation(
+                    left.val.booleanVal, right.val.booleanVal, result, isLeftNull, isRightNul);
             } break;
             case INT64: {
-                FUNC::operation(left.val.int64Val, right.val.int64Val, result);
+                FUNC::operation(
+                    left.val.int64Val, right.val.int64Val, result, isLeftNull, isRightNul);
             } break;
             case DOUBLE: {
-                FUNC::operation(left.val.doubleVal, right.val.doubleVal, result);
+                FUNC::operation(
+                    left.val.doubleVal, right.val.doubleVal, result, isLeftNull, isRightNul);
             } break;
             case STRING: {
-                FUNC::operation(left.val.strVal, right.val.strVal, result);
+                FUNC::operation(left.val.strVal, right.val.strVal, result, isLeftNull, isRightNul);
             } break;
             case DATE: {
-                FUNC::operation(left.val.dateVal, right.val.dateVal, result);
+                FUNC::operation(
+                    left.val.dateVal, right.val.dateVal, result, isLeftNull, isRightNul);
             } break;
             case TIMESTAMP: {
-                FUNC::operation(left.val.timestampVal, right.val.timestampVal, result);
+                FUNC::operation(
+                    left.val.timestampVal, right.val.timestampVal, result, isLeftNull, isRightNul);
             } break;
             case INTERVAL: {
-                FUNC::operation(left.val.intervalVal, right.val.intervalVal, result);
+                FUNC::operation(
+                    left.val.intervalVal, right.val.intervalVal, result, isLeftNull, isRightNul);
             } break;
             default:
                 assert(false);
             }
         } else if (left.dataType == INT64 && right.dataType == DOUBLE) {
-            FUNC::operation(left.val.int64Val, right.val.doubleVal, result);
+            FUNC::operation(left.val.int64Val, right.val.doubleVal, result, isLeftNull, isRightNul);
         } else if (left.dataType == DOUBLE && right.dataType == INT64) {
-            FUNC::operation(left.val.doubleVal, right.val.int64Val, result);
+            FUNC::operation(left.val.doubleVal, right.val.int64Val, result, isLeftNull, isRightNul);
         } else {
             result = NULL_BOOL;
         }
@@ -268,82 +316,97 @@ struct CompareValues {
 
 // specialized for Value.
 template<>
-inline void GreaterThan::operation(const Value& left, const Value& right, uint8_t& result) {
-    CompareValues::operation<GreaterThan>(left, right, result);
+inline void GreaterThan::operation(
+    const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
+    CompareValues::operation<GreaterThan>(left, right, result, isLeftNull, isRightNul);
 };
 
 template<>
-inline void GreaterThanEquals::operation(const Value& left, const Value& right, uint8_t& result) {
-    CompareValues::operation<GreaterThanEquals>(left, right, result);
+inline void GreaterThanEquals::operation(
+    const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
+    CompareValues::operation<GreaterThanEquals>(left, right, result, isLeftNull, isRightNul);
 };
 
 template<>
-inline void LessThan::operation(const Value& left, const Value& right, uint8_t& result) {
-    CompareValues::operation<LessThan>(left, right, result);
+inline void LessThan::operation(
+    const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
+    CompareValues::operation<LessThan>(left, right, result, isLeftNull, isRightNul);
 };
 
 template<>
-inline void LessThanEquals::operation(const Value& left, const Value& right, uint8_t& result) {
-    CompareValues::operation<LessThanEquals>(left, right, result);
+inline void LessThanEquals::operation(
+    const Value& left, const Value& right, uint8_t& result, bool isLeftNull, bool isRightNul) {
+    CompareValues::operation<LessThanEquals>(left, right, result, isLeftNull, isRightNul);
 };
 
 // specialized for uint8_t.
 template<>
-inline void GreaterThan::operation(const uint8_t& left, const uint8_t& right, uint8_t& result) {
+inline void GreaterThan::operation(
+    const uint8_t& left, const uint8_t& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = !right && left;
 };
 
 template<>
-inline void LessThan::operation(const uint8_t& left, const uint8_t& right, uint8_t& result) {
+inline void LessThan::operation(
+    const uint8_t& left, const uint8_t& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = !left && right;
 };
 
 // specialized for gf_string_t.
 template<>
-inline void GreaterThan::operation(
-    const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
-    StringComparisonOperators::Compare<GreaterThan>(left, right, result);
+inline void GreaterThan::operation(const gf_string_t& left, const gf_string_t& right,
+    uint8_t& result, bool isLeftNull, bool isRightNul) {
+    StringComparisonOperators::Compare<GreaterThan>(left, right, result, isLeftNull, isRightNul);
 };
 
 template<>
-inline void GreaterThanEquals::operation(
-    const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
-    StringComparisonOperators::Compare<GreaterThanEquals>(left, right, result);
+inline void GreaterThanEquals::operation(const gf_string_t& left, const gf_string_t& right,
+    uint8_t& result, bool isLeftNull, bool isRightNul) {
+    StringComparisonOperators::Compare<GreaterThanEquals>(
+        left, right, result, isLeftNull, isRightNul);
 };
 
 template<>
-inline void LessThan::operation(
-    const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
-    StringComparisonOperators::Compare<LessThan>(left, right, result);
+inline void LessThan::operation(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNul) {
+    StringComparisonOperators::Compare<LessThan>(left, right, result, isLeftNull, isRightNul);
 };
 
 template<>
-inline void LessThanEquals::operation(
-    const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
-    StringComparisonOperators::Compare<LessThanEquals>(left, right, result);
+inline void LessThanEquals::operation(const gf_string_t& left, const gf_string_t& right,
+    uint8_t& result, bool isLeftNull, bool isRightNul) {
+    StringComparisonOperators::Compare<LessThanEquals>(left, right, result, isLeftNull, isRightNul);
 };
 
 // specialized for nodeID_t.
 template<>
-inline void GreaterThan::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result) {
+inline void GreaterThan::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result =
         (left.label > right.label) || (left.label == right.label && left.offset > right.offset);
 };
 
 template<>
-inline void GreaterThanEquals::operation(
-    const nodeID_t& left, const nodeID_t& right, uint8_t& result) {
+inline void GreaterThanEquals::operation(const nodeID_t& left, const nodeID_t& right,
+    uint8_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = left.label > right.label || (left.label == right.label && left.offset >= right.offset);
 };
 
 template<>
-inline void LessThan::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result) {
+inline void LessThan::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = left.label < right.label || (left.label == right.label && left.offset < right.offset);
 };
 
 template<>
-inline void LessThanEquals::operation(
-    const nodeID_t& left, const nodeID_t& right, uint8_t& result) {
+inline void LessThanEquals::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result,
+    bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
     result = left.label < right.label || (left.label == right.label && left.offset <= right.offset);
 };
 

--- a/src/common/vector/operations/vector_arithmetic_operations.cpp
+++ b/src/common/vector/operations/vector_arithmetic_operations.cpp
@@ -17,18 +17,15 @@ public:
             case INT64: {
                 if (std::is_same<OP, operation::Power>::value) {
                     assert(result.dataType == DOUBLE);
-                    BinaryOperationExecutor::execute<int64_t, int64_t, double_t, OP,
-                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    BinaryOperationExecutor::execute<int64_t, int64_t, double_t, OP>(
                         left, right, result);
                 } else {
-                    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, OP,
-                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, OP>(
                         left, right, result);
                 }
             } break;
             case DOUBLE:
-                BinaryOperationExecutor::execute<int64_t, double_t, double_t, OP,
-                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                BinaryOperationExecutor::execute<int64_t, double_t, double_t, OP>(
                     left, right, result);
                 break;
             default:
@@ -38,13 +35,11 @@ public:
         case DOUBLE: {
             switch (right.dataType) {
             case INT64:
-                BinaryOperationExecutor::execute<double_t, int64_t, double_t, OP,
-                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                BinaryOperationExecutor::execute<double_t, int64_t, double_t, OP>(
                     left, right, result);
                 break;
             case DOUBLE:
-                BinaryOperationExecutor::execute<double_t, double_t, double_t, OP,
-                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                BinaryOperationExecutor::execute<double_t, double_t, double_t, OP>(
                     left, right, result);
                 break;
             default:
@@ -53,16 +48,20 @@ public:
         } break;
         case STRING: {
             assert(right.dataType == STRING && (is_same<OP, operation::Add>::value));
-            BinaryOperationExecutor::execute<gf_string_t, gf_string_t, gf_string_t, operation::Add,
-                true /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(left, right, result);
+            if constexpr ((is_same<OP, operation::Add>::value)) {
+                assert(right.dataType == STRING);
+                BinaryOperationExecutor::execute<gf_string_t, gf_string_t, gf_string_t, OP>(
+                    left, right, result);
+            } else {
+                assert(false);
+            }
         } break;
         case DATE: {
             switch (right.dataType) {
             case INT64: {
                 if constexpr (is_same<OP, operation::Add>::value ||
                               is_same<OP, operation::Subtract>::value) {
-                    BinaryOperationExecutor::execute<date_t, int64_t, date_t, OP,
-                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    BinaryOperationExecutor::execute<date_t, int64_t, date_t, OP>(
                         left, right, result);
                 } else {
                     assert(false);
@@ -71,18 +70,19 @@ public:
             case INTERVAL: {
                 if constexpr (is_same<OP, operation::Add>::value ||
                               is_same<OP, operation::Subtract>::value) {
-                    BinaryOperationExecutor::execute<date_t, interval_t, date_t, OP,
-                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    BinaryOperationExecutor::execute<date_t, interval_t, date_t, OP>(
                         left, right, result);
                 } else {
                     assert(false);
                 }
             } break;
             case DATE: {
-                assert((is_same<OP, operation::Subtract>::value));
-                BinaryOperationExecutor::execute<date_t, date_t, int64_t, operation::Subtract,
-                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
-                    left, right, result);
+                if constexpr ((is_same<OP, operation::Subtract>::value)) {
+                    BinaryOperationExecutor::execute<date_t, date_t, int64_t, OP>(
+                        left, right, result);
+                } else {
+                    assert(false);
+                }
             } break;
             default:
                 assert(false);
@@ -91,16 +91,17 @@ public:
         case TIMESTAMP: {
             switch (right.dataType) {
             case TIMESTAMP: {
-                assert((is_same<OP, operation::Subtract>::value));
-                BinaryOperationExecutor::execute<timestamp_t, timestamp_t, interval_t,
-                    operation::Subtract, false /* IS_STRUCTURED_STRING */,
-                    false /* IS_UNSTRUCTURED */>(left, right, result);
+                if constexpr ((is_same<OP, operation::Subtract>::value)) {
+                    BinaryOperationExecutor::execute<timestamp_t, timestamp_t, interval_t, OP>(
+                        left, right, result);
+                } else {
+                    assert(false);
+                }
             } break;
             case INTERVAL: {
                 if constexpr (is_same<OP, operation::Add>::value ||
                               is_same<OP, operation::Subtract>::value) {
-                    BinaryOperationExecutor::execute<timestamp_t, interval_t, timestamp_t, OP,
-                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    BinaryOperationExecutor::execute<timestamp_t, interval_t, timestamp_t, OP>(
                         left, right, result);
                 } else {
                     assert(false);
@@ -115,18 +116,19 @@ public:
             case INTERVAL: {
                 if constexpr (is_same<OP, operation::Add>::value ||
                               is_same<OP, operation::Subtract>::value) {
-                    BinaryOperationExecutor::execute<interval_t, interval_t, interval_t, OP,
-                        false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
+                    BinaryOperationExecutor::execute<interval_t, interval_t, interval_t, OP>(
                         left, right, result);
                 } else {
                     assert(false);
                 }
             } break;
             case INT64: {
-                assert((is_same<OP, operation::Divide>::value));
-                BinaryOperationExecutor::execute<interval_t, int64_t, interval_t, operation::Divide,
-                    false /* IS_STRUCTURED_STRING */, false /* IS_UNSTRUCTURED */>(
-                    left, right, result);
+                if constexpr ((is_same<OP, operation::Divide>::value)) {
+                    BinaryOperationExecutor::execute<interval_t, int64_t, interval_t, OP>(
+                        left, right, result);
+                } else {
+                    assert(false);
+                }
             } break;
             default:
                 assert(false);
@@ -134,8 +136,7 @@ public:
         } break;
         case UNSTRUCTURED: {
             assert(right.dataType == UNSTRUCTURED);
-            BinaryOperationExecutor::execute<Value, Value, Value, OP,
-                false /* IS_STRUCTURED_STRING */, true /* IS_UNSTRUCTURED */>(left, right, result);
+            BinaryOperationExecutor::execute<Value, Value, Value, OP>(left, right, result);
         } break;
         default:
             assert(false);
@@ -146,16 +147,13 @@ public:
     static inline void execute(ValueVector& operand, ValueVector& result) {
         switch (operand.dataType) {
         case INT64: {
-            UnaryOperationExecutor::execute<int64_t, int64_t, OP, false /* IS_NODE_ID */,
-                true /* SKIP_NULL */>(operand, result);
+            UnaryOperationExecutor::execute<int64_t, int64_t, OP>(operand, result);
         } break;
         case DOUBLE: {
-            UnaryOperationExecutor::execute<double_t, double_t, OP, false /* IS_NODE_ID */,
-                true /* SKIP_NULL */>(operand, result);
+            UnaryOperationExecutor::execute<double_t, double_t, OP>(operand, result);
         } break;
         case UNSTRUCTURED: {
-            UnaryOperationExecutor::execute<Value, Value, OP, false /* IS_NODE_ID */,
-                true /* SKIP_NULL */>(operand, result);
+            UnaryOperationExecutor::execute<Value, Value, OP>(operand, result);
         } break;
         default:
             assert(false);

--- a/src/common/vector/operations/vector_boolean_operations.cpp
+++ b/src/common/vector/operations/vector_boolean_operations.cpp
@@ -8,20 +8,23 @@ namespace graphflow {
 namespace common {
 
 void VectorBooleanOperations::And(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::executeBooleanOps<operation::And>(left, right, result);
+    BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, operation::And,
+        false /* SKIP_NULL */>(left, right, result);
 }
 
 void VectorBooleanOperations::Or(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::executeBooleanOps<operation::Or>(left, right, result);
+    BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, operation::Or,
+        false /* SKIP_NULL */>(left, right, result);
 }
 
 void VectorBooleanOperations::Xor(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::executeBooleanOps<operation::Xor>(left, right, result);
+    BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, operation::Xor,
+        false /* SKIP_NULL */>(left, right, result);
 }
 
 void VectorBooleanOperations::Not(ValueVector& operand, ValueVector& result) {
-    UnaryOperationExecutor::execute<uint8_t, uint8_t, operation::Not, false /* IS_NODE_ID */,
-        false /* SKIP_NULL */>(operand, result);
+    UnaryOperationExecutor::execute<uint8_t, uint8_t, operation::Not, false /* SKIP_NULL */>(
+        operand, result);
 }
 
 uint64_t VectorBooleanOperations::AndSelect(

--- a/src/common/vector/operations/vector_comparison_operations.cpp
+++ b/src/common/vector/operations/vector_comparison_operations.cpp
@@ -14,18 +14,17 @@ public:
         switch (left.dataType) {
         case BOOL: {
             assert(right.dataType == BOOL);
-            BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, OP,
-                false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+            BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, OP>(left, right, result);
         } break;
         case INT64: {
             switch (right.dataType) {
             case INT64: {
-                BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, OP,
-                    false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+                BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, OP>(
+                    left, right, result);
             } break;
             case DOUBLE: {
-                BinaryOperationExecutor::execute<int64_t, double_t, uint8_t, OP,
-                    false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+                BinaryOperationExecutor::execute<int64_t, double_t, uint8_t, OP>(
+                    left, right, result);
             } break;
             default:
                 assert(false);
@@ -34,12 +33,12 @@ public:
         case DOUBLE: {
             switch (right.dataType) {
             case INT64: {
-                BinaryOperationExecutor::execute<double_t, int64_t, uint8_t, OP,
-                    false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+                BinaryOperationExecutor::execute<double_t, int64_t, uint8_t, OP>(
+                    left, right, result);
             } break;
             case DOUBLE: {
-                BinaryOperationExecutor::execute<double_t, double_t, uint8_t, OP,
-                    false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+                BinaryOperationExecutor::execute<double_t, double_t, uint8_t, OP>(
+                    left, right, result);
             } break;
             default:
                 assert(false);
@@ -47,32 +46,30 @@ public:
         } break;
         case STRING: {
             assert(right.dataType == STRING);
-            BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, OP,
-                false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+            BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, OP>(
+                left, right, result);
         } break;
         case UNSTRUCTURED: {
             assert(right.dataType == UNSTRUCTURED);
-            BinaryOperationExecutor::execute<Value, Value, uint8_t, OP,
-                false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+            BinaryOperationExecutor::execute<Value, Value, uint8_t, OP>(left, right, result);
         } break;
         case DATE: {
             assert(right.dataType == DATE);
-            BinaryOperationExecutor::execute<date_t, date_t, uint8_t, OP,
-                false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+            BinaryOperationExecutor::execute<date_t, date_t, uint8_t, OP>(left, right, result);
         } break;
         case TIMESTAMP: {
             assert(right.dataType == TIMESTAMP);
-            BinaryOperationExecutor::execute<timestamp_t, timestamp_t, uint8_t, OP,
-                false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+            BinaryOperationExecutor::execute<timestamp_t, timestamp_t, uint8_t, OP>(
+                left, right, result);
         } break;
         case INTERVAL: {
             assert(right.dataType == INTERVAL);
-            BinaryOperationExecutor::execute<interval_t, interval_t, uint8_t, OP,
-                false /*IS_STRUCTURED_STRING*/, false /*IS_UNSTRUCTURED*/>(left, right, result);
+            BinaryOperationExecutor::execute<interval_t, interval_t, uint8_t, OP>(
+                left, right, result);
         } break;
         case NODE: {
             assert(right.dataType == NODE);
-            BinaryOperationExecutor::executeNodeIDOps<OP>(left, right, result);
+            BinaryOperationExecutor::execute<nodeID_t, nodeID_t, uint8_t, OP>(left, right, result);
         } break;
         default:
             assert(false);
@@ -177,13 +174,11 @@ void VectorComparisonOperations::LessThanEquals(
 }
 
 void VectorComparisonOperations::IsNull(ValueVector& operand, ValueVector& result) {
-    UnaryOperationExecutor::execute<uint8_t, uint8_t, operation::IsNull, false, true>(
-        operand, result);
+    UnaryOperationExecutor::execute<uint8_t, uint8_t, operation::IsNull>(operand, result);
 }
 
 void VectorComparisonOperations::IsNotNull(ValueVector& operand, ValueVector& result) {
-    UnaryOperationExecutor::execute<uint8_t, uint8_t, operation::IsNotNull, false, true>(
-        operand, result);
+    UnaryOperationExecutor::execute<uint8_t, uint8_t, operation::IsNotNull>(operand, result);
 }
 
 uint64_t VectorComparisonOperations::EqualsSelect(

--- a/src/common/vector/operations/vector_hash_operations.cpp
+++ b/src/common/vector/operations/vector_hash_operations.cpp
@@ -9,32 +9,25 @@ namespace common {
 void VectorHashOperations::Hash(ValueVector& operand, ValueVector& result) {
     switch (operand.dataType) {
     case NODE: {
-        UnaryOperationExecutor::execute<nodeID_t, hash_t, operation::Hash, true /* IS_NODE_ID */,
-            true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<nodeID_t, hash_t, operation::Hash>(operand, result);
     } break;
     case INT64: {
-        UnaryOperationExecutor::execute<int64_t, hash_t, operation::Hash, false /* IS_NODE_ID */,
-            true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<int64_t, hash_t, operation::Hash>(operand, result);
     } break;
     case DOUBLE: {
-        UnaryOperationExecutor::execute<double_t, hash_t, operation::Hash, false /* IS_NODE_ID */,
-            true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<double_t, hash_t, operation::Hash>(operand, result);
     } break;
     case STRING: {
-        UnaryOperationExecutor::execute<gf_string_t, hash_t, operation::Hash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<gf_string_t, hash_t, operation::Hash>(operand, result);
     } break;
     case DATE: {
-        UnaryOperationExecutor::execute<date_t, hash_t, operation::Hash, false /* IS_NODE_ID */,
-            true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<date_t, hash_t, operation::Hash>(operand, result);
     } break;
     case TIMESTAMP: {
-        UnaryOperationExecutor::execute<timestamp_t, hash_t, operation::Hash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<timestamp_t, hash_t, operation::Hash>(operand, result);
     } break;
     case INTERVAL: {
-        UnaryOperationExecutor::execute<interval_t, hash_t, operation::Hash, false /* IS_NODE_ID */,
-            true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<interval_t, hash_t, operation::Hash>(operand, result);
     } break;
     default:
         assert(false);
@@ -44,32 +37,28 @@ void VectorHashOperations::Hash(ValueVector& operand, ValueVector& result) {
 void VectorHashOperations::CombineHash(ValueVector& operand, ValueVector& result) {
     switch (operand.dataType) {
     case NODE: {
-        UnaryOperationExecutor::execute<nodeID_t, hash_t, operation::CombineHash,
-            true /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<nodeID_t, hash_t, operation::CombineHash>(operand, result);
     } break;
     case INT64: {
-        UnaryOperationExecutor::execute<int64_t, hash_t, operation::CombineHash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<int64_t, hash_t, operation::CombineHash>(operand, result);
     } break;
     case DOUBLE: {
-        UnaryOperationExecutor::execute<double_t, hash_t, operation::CombineHash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<double_t, hash_t, operation::CombineHash>(operand, result);
     } break;
     case STRING: {
-        UnaryOperationExecutor::execute<gf_string_t, hash_t, operation::CombineHash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<gf_string_t, hash_t, operation::CombineHash>(
+            operand, result);
     } break;
     case DATE: {
-        UnaryOperationExecutor::execute<date_t, hash_t, operation::CombineHash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<date_t, hash_t, operation::CombineHash>(operand, result);
     } break;
     case TIMESTAMP: {
-        UnaryOperationExecutor::execute<timestamp_t, hash_t, operation::CombineHash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<timestamp_t, hash_t, operation::CombineHash>(
+            operand, result);
     } break;
     case INTERVAL: {
-        UnaryOperationExecutor::execute<interval_t, hash_t, operation::CombineHash,
-            false /* IS_NODE_ID */, true /* SKIP_NULL */>(operand, result);
+        UnaryOperationExecutor::execute<interval_t, hash_t, operation::CombineHash>(
+            operand, result);
     } break;
     default:
         assert(false);

--- a/src/function/include/aggregation/avg.h
+++ b/src/function/include/aggregation/avg.h
@@ -33,8 +33,9 @@ struct AvgFunction {
                     state->val = (double_t)inputValues[input->state->selectedPositions[i]];
                     state->isNull = false;
                 } else {
-                    Add::template operation<double_t, T, double_t>(
-                        state->val, inputValues[input->state->selectedPositions[i]], state->val);
+                    Add::template operation<double_t, T, double_t>(state->val,
+                        inputValues[input->state->selectedPositions[i]], state->val,
+                        false /* isLeftNull */, false /* isRightNull */);
                 }
             }
             state->numValues = state->numValues + count;
@@ -47,7 +48,8 @@ struct AvgFunction {
                         state->isNull = false;
                     } else {
                         Add::template operation<double_t, T, double_t>(state->val,
-                            inputValues[input->state->selectedPositions[i]], state->val);
+                            inputValues[input->state->selectedPositions[i]], state->val,
+                            false /* isLeftNull */, false /* isRightNull */);
                     }
                     state->numValues = state->numValues + 1;
                 }
@@ -65,8 +67,8 @@ struct AvgFunction {
             state->val = otherState->val;
             state->isNull = false;
         } else {
-            Add::template operation<double_t, double_t, double_t>(
-                state->val, otherState->val, state->val);
+            Add::template operation<double_t, double_t, double_t>(state->val, otherState->val,
+                state->val, false /* isLeftNull */, false /* isRightNull */);
         }
         state->numValues = state->numValues + otherState->numValues;
     }

--- a/src/function/include/aggregation/min_max.h
+++ b/src/function/include/aggregation/min_max.h
@@ -34,7 +34,8 @@ struct MinMaxFunction {
                     state->val = inputValues[pos];
                     state->isNull = false;
                 } else {
-                    OP::template operation<T, T>(inputValues[pos], state->val, compare_result);
+                    OP::template operation<T, T>(inputValues[pos], state->val, compare_result,
+                        false /* isLeftNull */, false /* isRightNull */);
                     state->val = compare_result == TRUE ? inputValues[pos] : state->val;
                 }
             }
@@ -46,7 +47,8 @@ struct MinMaxFunction {
                         state->val = inputValues[pos];
                         state->isNull = false;
                     } else {
-                        OP::template operation<T, T>(inputValues[pos], state->val, compare_result);
+                        OP::template operation<T, T>(inputValues[pos], state->val, compare_result,
+                            false /* isLeftNull */, false /* isRightNull */);
                         state->val = compare_result == TRUE ? inputValues[pos] : state->val;
                     }
                 }
@@ -66,7 +68,8 @@ struct MinMaxFunction {
             state->isNull = false;
         } else {
             uint8_t compareResult;
-            OP::template operation<T, T>(otherState->val, state->val, compareResult);
+            OP::template operation<T, T>(otherState->val, state->val, compareResult,
+                false /* isLeftNull */, false /* isRightNull */);
             state->val = compareResult == 1 ? otherState->val : state->val;
         }
     }

--- a/src/function/include/aggregation/sum.h
+++ b/src/function/include/aggregation/sum.h
@@ -28,8 +28,8 @@ struct SumFunction {
                     state->val = inputValues[input->state->selectedPositions[i]];
                     state->isNull = false;
                 } else {
-                    Add::operation(
-                        state->val, inputValues[input->state->selectedPositions[i]], state->val);
+                    Add::operation(state->val, inputValues[input->state->selectedPositions[i]],
+                        state->val, false /* isLeftNull */, false /* isRightNull */);
                 }
             }
         } else {
@@ -41,7 +41,7 @@ struct SumFunction {
                         state->isNull = false;
                     } else {
                         Add::operation(state->val, inputValues[input->state->selectedPositions[i]],
-                            state->val);
+                            state->val, false /* isLeftNull */, false /* isRightNull */);
                     }
                 }
             }
@@ -58,7 +58,8 @@ struct SumFunction {
             state->val = otherState->val;
             state->isNull = false;
         } else {
-            Add::operation(state->val, otherState->val, state->val);
+            Add::operation(state->val, otherState->val, state->val, false /* isLeftNull */,
+                false /* isRightNull */);
         }
     }
 


### PR DESCRIPTION
- Merge `executeNodeIDOps` and `executeBooleanOps` in binary operation executor into a single `execute` template function.
- Simplify template arguments for the unary/binary operation executor.