### PR TITLE
fix aggregation scan out data position

### DIFF
--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregation_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregation_scan.h
@@ -14,7 +14,7 @@ public:
     SimpleAggregationScan(const vector<DataPos>& outDataPos,
         unique_ptr<PhysicalOperator> prevOperator, shared_ptr<AggregationSharedState> sharedState,
         ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), AGGREGATION_SCAN, context, id}, outDataChunkPos{0},
+        : PhysicalOperator{move(prevOperator), AGGREGATION_SCAN, context, id},
           outDataPos{outDataPos}, sharedState{move(sharedState)} {}
 
     void initResultSet(const shared_ptr<ResultSet>& resultSet) override;
@@ -27,8 +27,8 @@ public:
     }
 
 private:
-    uint32_t outDataChunkPos;
     vector<DataPos> outDataPos;
+    shared_ptr<DataChunk> outDataChunk;
     shared_ptr<AggregationSharedState> sharedState;
 };
 } // namespace processor

--- a/test/runner/queries/aggregate/simple_aggregate.test
+++ b/test/runner/queries/aggregate/simple_aggregate.test
@@ -15,34 +15,34 @@
 -NAME SimpleCountTest
 -QUERY MATCH (a:person) RETURN COUNT(a.age), COUNT(a.unstrNumericProp)
 ---- 1
-3|8
+8|3
 
 -NAME SimpleSumTest
 -QUERY MATCH (a:person) RETURN SUM(a.age), SUM(a.eyeSight), SUM(a.unstrNumericProp)
 ---- 1
-167.000000|38.900000|298
+298|38.900000|167.000000
 
 -NAME SimpleSumWithterTest
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age), SUM(a.eyeSight)
 ---- 1
-14.100000|85
+85|14.100000
 
 -NAME SimpleSumWithFilterTest2
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age+10), SUM(a.age*2)
 ---- 1
-170|115
+115|170
 
 -NAME SimpleAvgTest
 -QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight)
 ---- 1
-4.862500|37.250000
+37.250000|4.862500
 
 -NAME SimpleAvgWithFilterTest
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN AVG(a.age), AVG(a.eyeSight)
 ---- 1
-4.700000|28.333333
+28.333333|4.700000
 
-#-NAME SimpleMinMaxTest
-#-QUERY MATCH (a:person) RETURN MIN(a.age), MAX(a.age), MIN(a.isStudent), MAX(a.isStudent), MIN(a.eyeSight), MAX(a.eyeSight), MIN(a.birthdate), MAX(a.birthdate)
-#---- 1
-#1990-11-27|1900-01-01|5.100000|False|4.500000|83|20|True
+-NAME SimpleMinMaxTest
+-QUERY MATCH (a:person) RETURN MIN(a.age), MAX(a.age), MIN(a.isStudent), MAX(a.isStudent), MIN(a.eyeSight), MAX(a.eyeSight), MIN(a.birthdate), MAX(a.birthdate)
+---- 1
+20|83|False|True|4.500000|5.100000|1900-01-01|1990-11-27


### PR DESCRIPTION
This PR fixes the bug that the SimpleAggregationScan isn't correctly outputting results according to outDataPos.