### PR TITLE
remove notion of leaf expression from binder, enumerator

### DIFF
--- a/src/binder/expression/existential_subquery_expression.cpp
+++ b/src/binder/expression/existential_subquery_expression.cpp
@@ -25,34 +25,14 @@ vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getDependentVariab
     return result;
 }
 
-vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getDependentProperties() {
-    auto& firstQueryPart = *normalizedSubquery->getQueryPart(0);
-    vector<shared_ptr<Expression>> result;
-    if (firstQueryPart.hasWhereExpression()) {
-        for (auto& variable : firstQueryPart.getWhereExpression()->getDependentProperties()) {
-            result.push_back(variable);
-        }
-    }
-    for (auto& projectExpression : firstQueryPart.getProjectionBody()->getProjectionExpressions()) {
-        for (auto& variable : projectExpression->getDependentProperties()) {
-            result.push_back(variable);
-        }
-    }
-    return result;
-}
-
-vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getDependentLeafExpressions() {
+vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getDependentExpressions() {
     auto& firstQueryPart = *normalizedSubquery->getQueryPart(0);
     auto result = firstQueryPart.getDependentNodeID();
     if (firstQueryPart.hasWhereExpression()) {
-        for (auto& variable : firstQueryPart.getWhereExpression()->getDependentLeafExpressions()) {
-            result.push_back(variable);
-        }
+        result.push_back(firstQueryPart.getWhereExpression());
     }
     for (auto& projectExpression : firstQueryPart.getProjectionBody()->getProjectionExpressions()) {
-        for (auto& variable : projectExpression->getDependentLeafExpressions()) {
-            result.push_back(variable);
-        }
+        result.push_back(projectExpression);
     }
     return result;
 }

--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -69,32 +69,6 @@ vector<shared_ptr<Expression>> Expression::getDependentVariables() {
     return result;
 }
 
-vector<shared_ptr<Expression>> Expression::getDependentProperties() {
-    if (expressionType == PROPERTY) {
-        return vector<shared_ptr<Expression>>{shared_from_this()};
-    }
-    vector<shared_ptr<Expression>> result;
-    for (auto& child : children) {
-        for (auto& expression : child->getDependentProperties()) {
-            result.push_back(expression);
-        }
-    }
-    return result;
-}
-
-vector<shared_ptr<Expression>> Expression::getDependentLeafExpressions() {
-    if (expressionType == PROPERTY || expressionType == CSV_LINE_EXTRACT) {
-        return vector<shared_ptr<Expression>>{shared_from_this()};
-    }
-    vector<shared_ptr<Expression>> result;
-    for (auto& child : children) {
-        for (auto& expression : child->getDependentLeafExpressions()) {
-            result.push_back(expression);
-        }
-    }
-    return result;
-}
-
 vector<shared_ptr<Expression>> Expression::getDependentSubqueryExpressions() {
     if (expressionType == EXISTENTIAL_SUBQUERY) {
         return vector<shared_ptr<Expression>>{shared_from_this()};

--- a/src/binder/include/expression/existential_subquery_expression.h
+++ b/src/binder/include/expression/existential_subquery_expression.h
@@ -28,8 +28,7 @@ public:
     inline unique_ptr<LogicalPlan> getSubPlan() { return subPlan->copy(); }
 
     vector<shared_ptr<Expression>> getDependentVariables() override;
-    vector<shared_ptr<Expression>> getDependentProperties() override;
-    vector<shared_ptr<Expression>> getDependentLeafExpressions() override;
+    vector<shared_ptr<Expression>> getDependentExpressions();
 
 private:
     unique_ptr<BoundSingleQuery> boundSubquery;

--- a/src/binder/include/expression/expression.h
+++ b/src/binder/include/expression/expression.h
@@ -43,8 +43,6 @@ public:
     unordered_set<string> getDependentVariableNames();
 
     virtual vector<shared_ptr<Expression>> getDependentVariables();
-    virtual vector<shared_ptr<Expression>> getDependentProperties();
-    virtual vector<shared_ptr<Expression>> getDependentLeafExpressions();
     vector<shared_ptr<Expression>> getDependentSubqueryExpressions();
 
     vector<shared_ptr<Expression>> splitOnAND();

--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -79,7 +79,6 @@ private:
         unordered_map<string, shared_ptr<Expression>> prevVariablesInScope);
     void validateCSVHeaderColumnNamesAreUnique(const vector<pair<string, DataType>>& headerInfo);
     uint64_t validateAndExtractSkipLimitNumber(const ParsedExpression& skipOrLimitExpression);
-
     /******* helpers *********/
     string getUniqueExpressionName(const string& name);
 

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -41,25 +41,30 @@ private:
     vector<unique_ptr<LogicalPlan>> enumerateQueryPart(
         const NormalizedQueryPart& queryPart, vector<unique_ptr<LogicalPlan>> prevPlans);
 
-    void planSubquery(ExistentialSubqueryExpression& subqueryExpression, LogicalPlan& plan);
+    void planSubquery(
+        const shared_ptr<ExistentialSubqueryExpression>& subqueryExpression, LogicalPlan& plan);
 
     void appendLoadCSV(const BoundLoadCSVStatement& loadCSVStatement, LogicalPlan& plan);
+    void appendFlattens(const unordered_set<uint32_t>& groupsPos, LogicalPlan& plan);
     // return position of the only unFlat group
-    uint32_t appendFlattensButOne(
-        const unordered_set<uint32_t>& unFlatGroupsPos, LogicalPlan& plan);
+    // or position of any flat group if there is no unFlat group.
+    uint32_t appendFlattensButOne(const unordered_set<uint32_t>& groupsPos, LogicalPlan& plan);
     void appendFlattenIfNecessary(uint32_t groupPos, LogicalPlan& plan);
     void appendFilter(const shared_ptr<Expression>& expression, LogicalPlan& plan);
     uint32_t appendScanPropertiesFlattensAndPlanSubqueryIfNecessary(
-        Expression& expression, LogicalPlan& plan);
-    void appendScanPropertiesIfNecessary(Expression& expression, LogicalPlan& plan);
+        const shared_ptr<Expression>& expression, LogicalPlan& plan);
+    void appendScanPropertiesIfNecessary(
+        const shared_ptr<Expression>& expression, LogicalPlan& plan);
     void appendScanNodePropertyIfNecessary(
         const PropertyExpression& propertyExpression, LogicalPlan& plan);
     void appendScanRelPropertyIfNecessary(
         const PropertyExpression& propertyExpression, LogicalPlan& plan);
 
     static vector<unique_ptr<LogicalPlan>> getInitialEmptyPlans();
-    static unordered_set<uint32_t> getUnFlatGroupsPos(Expression& expression, const Schema& schema);
-    static uint32_t getAnyGroupPos(Expression& expression, const Schema& schema);
+    static vector<shared_ptr<Expression>> getExpressionsInSchema(
+        const shared_ptr<Expression>& expression, const Schema& schema);
+    static vector<shared_ptr<Expression>> getPropertyExpressionsNotInSchema(
+        const shared_ptr<Expression>& expression, const Schema& schema);
 
 private:
     JoinOrderEnumerator joinOrderEnumerator;

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -24,22 +24,24 @@ public:
     FactorizationGroup() : isFlat{false}, estimatedCardinality{1} {}
 
     FactorizationGroup(const FactorizationGroup& other)
-        : isFlat{other.isFlat},
-          estimatedCardinality{other.estimatedCardinality}, variables{other.variables} {}
+        : isFlat{other.isFlat}, estimatedCardinality{other.estimatedCardinality},
+          expressionNames{other.expressionNames} {}
 
-    inline void insertVariable(const string& variable) { variables.insert(variable); }
-
-    inline string getAnyVariable() {
-        GF_ASSERT(!variables.empty());
-        return *variables.begin();
+    inline void insertExpression(const string& expressionName) {
+        expressionNames.insert(expressionName);
     }
 
-    inline uint32_t getNumVariables() const { return variables.size(); }
+    inline string getAnyExpressionName() {
+        GF_ASSERT(!expressionNames.empty());
+        return *expressionNames.begin();
+    }
+
+    inline uint32_t getNumExpressions() const { return expressionNames.size(); }
 
 public:
     bool isFlat;
     uint64_t estimatedCardinality;
-    unordered_set<string> variables;
+    unordered_set<string> expressionNames;
 };
 
 class Schema {
@@ -50,20 +52,18 @@ public:
 
     uint32_t createGroup();
 
-    void insertToGroup(const string& variable, uint32_t groupPos);
+    void insertToGroup(const string& expressionName, uint32_t groupPos);
 
     void insertToGroup(const FactorizationGroup& otherGroup, uint32_t groupPos);
 
-    uint32_t getGroupPos(const string& variable) const;
+    uint32_t getGroupPos(const string& expressionName) const;
 
-    unordered_set<uint32_t> getUnFlatGroupsPos() const;
-
-    uint32_t getAnyGroupPos() const;
+    unordered_set<uint32_t> getGroupsPos() const;
 
     void flattenGroup(uint32_t pos);
 
-    bool containVariable(const string& variable) const {
-        return variableToGroupPos.contains(variable);
+    bool containExpression(const string& expressionName) const {
+        return expressionNameToGroupPos.contains(expressionName);
     }
 
     void addLogicalExtend(const string& queryRel, LogicalExtend* extend);
@@ -82,8 +82,7 @@ public:
     // Maps a queryRel to the LogicalExtend that matches it. This is needed because ScanRelProperty
     // requires direction information which only available in the LogicalExtend.
     unordered_map<string, LogicalExtend*> queryRelLogicalExtendMap;
-    // All flat variables are considered as in the same factorization group
-    unordered_map<string, uint32_t> variableToGroupPos;
+    unordered_map<string, uint32_t> expressionNameToGroupPos;
     vector<shared_ptr<Expression>> expressionsToCollect;
 };
 

--- a/src/planner/include/norm_query/normalized_query_part.h
+++ b/src/planner/include/norm_query/normalized_query_part.h
@@ -50,7 +50,6 @@ public:
     inline BoundProjectionBody* getProjectionBody() const { return projectionBody.get(); }
 
     vector<shared_ptr<Expression>> getDependentNodeID() const;
-    vector<shared_ptr<Expression>> getDependentPropertiesFromWhereAndProjection() const;
 
 private:
     unique_ptr<BoundLoadCSVStatement> loadCSVStatement;

--- a/src/planner/logical_plan/schema.cpp
+++ b/src/planner/logical_plan/schema.cpp
@@ -9,14 +9,14 @@ uint32_t Schema::createGroup() {
     return pos;
 }
 
-void Schema::insertToGroup(const string& variable, uint32_t groupPos) {
-    variableToGroupPos.insert({variable, groupPos});
-    groups[groupPos]->insertVariable(variable);
+void Schema::insertToGroup(const string& expressionName, uint32_t groupPos) {
+    expressionNameToGroupPos.insert({expressionName, groupPos});
+    groups[groupPos]->insertExpression(expressionName);
 }
 
 void Schema::insertToGroup(const FactorizationGroup& otherGroup, uint32_t groupPos) {
-    for (auto& variable : otherGroup.variables) {
-        insertToGroup(variable, groupPos);
+    for (auto& expressionName : otherGroup.expressionNames) {
+        insertToGroup(expressionName, groupPos);
     }
 }
 
@@ -24,24 +24,17 @@ void Schema::flattenGroup(uint32_t pos) {
     groups[pos]->isFlat = true;
 }
 
-uint32_t Schema::getGroupPos(const string& variable) const {
-    GF_ASSERT(variableToGroupPos.contains(variable));
-    return variableToGroupPos.at(variable);
+uint32_t Schema::getGroupPos(const string& expressionName) const {
+    GF_ASSERT(expressionNameToGroupPos.contains(expressionName));
+    return expressionNameToGroupPos.at(expressionName);
 }
 
-unordered_set<uint32_t> Schema::getUnFlatGroupsPos() const {
-    unordered_set<uint32_t> result;
+unordered_set<uint32_t> Schema::getGroupsPos() const {
+    unordered_set<uint32_t> groupsPos;
     for (auto i = 0u; i < groups.size(); ++i) {
-        if (!groups[i]->isFlat) {
-            result.insert(i);
-        }
+        groupsPos.insert(i);
     }
-    return result;
-}
-
-uint32_t Schema::getAnyGroupPos() const {
-    GF_ASSERT(!groups.empty());
-    return 0;
+    return groupsPos;
 }
 
 void Schema::addLogicalExtend(const string& queryRel, LogicalExtend* extend) {
@@ -56,7 +49,7 @@ LogicalExtend* Schema::getExistingLogicalExtend(const string& queryRel) {
 unique_ptr<Schema> Schema::copy() const {
     auto newSchema = make_unique<Schema>();
     newSchema->queryRelLogicalExtendMap = queryRelLogicalExtendMap;
-    newSchema->variableToGroupPos = variableToGroupPos;
+    newSchema->expressionNameToGroupPos = expressionNameToGroupPos;
     for (auto& group : groups) {
         auto newGroup = make_unique<FactorizationGroup>(*group);
         newSchema->groups.push_back(move(newGroup));
@@ -66,7 +59,7 @@ unique_ptr<Schema> Schema::copy() const {
 
 void Schema::clearGroups() {
     groups.clear();
-    variableToGroupPos.clear();
+    expressionNameToGroupPos.clear();
 }
 
 } // namespace planner

--- a/src/planner/norm_query/normalized_query_part.cpp
+++ b/src/planner/norm_query/normalized_query_part.cpp
@@ -13,21 +13,5 @@ vector<shared_ptr<Expression>> NormalizedQueryPart::getDependentNodeID() const {
     return result;
 }
 
-vector<shared_ptr<Expression>>
-NormalizedQueryPart::getDependentPropertiesFromWhereAndProjection() const {
-    vector<shared_ptr<Expression>> result;
-    if (hasWhereExpression()) {
-        for (auto& property : whereExpression->getDependentProperties()) {
-            result.push_back(property);
-        }
-    }
-    for (auto& projectionExpression : projectionBody->getProjectionExpressions()) {
-        for (auto& property : projectionExpression->getDependentProperties()) {
-            result.push_back(property);
-        }
-    }
-    return result;
-}
-
 } // namespace planner
 } // namespace graphflow

--- a/src/processor/physical_plan/mapper/physical_operator_info.cpp
+++ b/src/processor/physical_plan/mapper/physical_operator_info.cpp
@@ -7,8 +7,8 @@ PhysicalOperatorsInfo::PhysicalOperatorsInfo(const Schema& schema) {
     auto dataChunkPos = 0ul;
     for (auto& group : schema.groups) {
         auto vectorPos = 0ul;
-        for (auto& variable : group->variables) {
-            expressionNameToDataPosMap.insert({variable, DataPos(dataChunkPos, vectorPos)});
+        for (auto& expressionName : group->expressionNames) {
+            expressionNameToDataPosMap.insert({expressionName, DataPos(dataChunkPos, vectorPos)});
             vectorPos++;
         }
         dataChunkPos++;

--- a/src/processor/physical_plan/mapper/plan_mapper.cpp
+++ b/src/processor/physical_plan/mapper/plan_mapper.cpp
@@ -48,7 +48,7 @@ namespace processor {
 static shared_ptr<ResultSet> populateResultSet(const Schema& schema) {
     auto resultSet = make_shared<ResultSet>(schema.getNumGroups());
     for (auto i = 0u; i < schema.getNumGroups(); ++i) {
-        resultSet->insert(i, make_shared<DataChunk>(schema.getGroup(i)->getNumVariables()));
+        resultSet->insert(i, make_shared<DataChunk>(schema.getGroup(i)->getNumExpressions()));
     }
     return resultSet;
 }
@@ -311,16 +311,16 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
     for (auto i = 0u; i < hashJoin.buildSideSchema->groups.size(); ++i) {
         buildSideValueVectorsOutputPos.emplace_back(unordered_map<uint32_t, DataPos>());
         auto& buildSideGroup = *hashJoin.buildSideSchema->groups[i];
-        for (auto& variable : buildSideGroup.variables) {
+        for (auto& expressionName : buildSideGroup.expressionNames) {
             if (i == buildDataChunksInfo.keyDataPos.dataChunkPos &&
-                variable == hashJoin.joinNodeID) {
+                expressionName == hashJoin.joinNodeID) {
                 continue;
             }
             auto [buildSideDataChunkPos, buildSideValueVectorPos] =
-                buildSideInfo.getDataPos(variable);
+                buildSideInfo.getDataPos(expressionName);
             assert(buildSideDataChunkPos == i);
             buildSideValueVectorsOutputPos[i].insert(
-                {buildSideValueVectorPos, info.getDataPos(variable)});
+                {buildSideValueVectorPos, info.getDataPos(expressionName)});
         }
     }
 

--- a/test/planner/cost_model_test.cpp
+++ b/test/planner/cost_model_test.cpp
@@ -8,7 +8,7 @@ class CostModelTest : public PlannerTest {};
 TEST_F(CostModelTest, OneHopSingleFilter) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = 1 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = *plan->lastOperator->prevOperator;
+    auto& op1 = *plan->lastOperator->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
     auto& op2 = *op1.prevOperator->prevOperator->prevOperator->prevOperator;
@@ -20,7 +20,7 @@ TEST_F(CostModelTest, OneHopMultiFilters) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age > 10 AND a.age < 20 AND b.age "
                  "= 45 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = *plan->lastOperator->prevOperator->prevOperator->prevOperator;
+    auto& op1 = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
     auto& op2 = *op1.prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
@@ -31,7 +31,8 @@ TEST_F(CostModelTest, OneHopMultiFilters) {
 TEST_F(CostModelTest, TwoHop) {
     auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator;
+    auto& op1 =
+        *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID_SUFFIX));
 }
@@ -41,7 +42,7 @@ TEST_F(CostModelTest, TwoHopMultiFilters) {
                  "b.age = 35 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
     auto& op1 = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator
-                     ->prevOperator->prevOperator->prevOperator->prevOperator;
+                     ->prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID_SUFFIX));
 }
@@ -78,7 +79,7 @@ TEST_F(PlannerTest, OrderByTest2) {
 TEST_F(PlannerTest, OrderByTest3) {
     auto query = "MATCH (a:person) RETURN COUNT(*) ORDER BY COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = plan->lastOperator;
+    auto& op1 = plan->lastOperator->prevOperator;
     ASSERT_EQ(LOGICAL_ORDER_BY, op1->getLogicalOperatorType());
     auto& op2 = op1->prevOperator;
     ASSERT_EQ(LOGICAL_AGGREGATE, op2->getLogicalOperatorType());

--- a/test/planner/property_scan_push_down_test.cpp
+++ b/test/planner/property_scan_push_down_test.cpp
@@ -9,8 +9,8 @@ class PropertyScanPushDownTest : public PlannerTest {};
 TEST_F(PropertyScanPushDownTest, FilterPropertyPushDownTest) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = b.age RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op =
-        *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
+    auto& op = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator
+                    ->prevOperator->prevOperator;
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op.getLogicalOperatorType());
     auto& scanNodeProperty = (LogicalScanNodeProperty&)op;
     ASSERT_TRUE(containSubstr(scanNodeProperty.nodeID, "_b." + INTERNAL_ID_SUFFIX));

--- a/test/runner/queries/aggregate/simple_aggregate.test
+++ b/test/runner/queries/aggregate/simple_aggregate.test
@@ -1,17 +1,5 @@
 # description: aggregation without groups and distinct
 
--NAME StructuredDateArithmeticAddInt
--QUERY MATCH (a:person) RETURN a.birthdate + 32
----- 8
-1900-02-02
-1900-02-02
-1940-07-24
-1950-08-24
-1980-11-27
-1980-11-27
-1980-11-27
-1990-12-29
-
 -NAME SimpleCountTest
 -QUERY MATCH (a:person) RETURN COUNT(a.age), COUNT(a.unstrNumericProp)
 ---- 1


### PR DESCRIPTION
This PR removes the notion of leaf expression from the binder and enumerator.

Previously, leaf expression was defined as a set of expression types (PROPERTY, CSV_LINE_VARIABLE, ...) whose value is written to value vector before expression evaluation starts. This method is not correct since we could have an expression being aliased and become a leaf. For example, MATCH (a) WITH a.age + 2 AS newAge MATCH (b) RETURN b.age > newAge. In this case, newAge is a leaf expression when evaluating b.age > newAge.

This PR changes leaf expression to be an expression whose value exists in the schema, i.e., has been previously evaluated.  This is done through recursively check is a sub-expression exists in the schema or not