### PR TITLE
using null mask in adjColumn extend

### DIFF
--- a/src/common/include/vector/operations/executors/binary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/binary_operation_executor.h
@@ -118,8 +118,8 @@ struct BinaryOperationExecutor {
                 } else {
                     for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
                         auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                        result.setNull(
-                            unFlatPos, unFlatVec.isNull(unFlatPos)); // isFlatNull is always false.
+                        result.setNull(unFlatPos,
+                            unFlatVec.isNull(unFlatPos)); // isFlatNull is always false.
                         if (!result.isNull(unFlatPos)) {
                             executeOnTuple<A, B, R, FUNC>(left, right, result,
                                 isLeftFlat ? flatPos : unFlatPos, isLeftFlat ? unFlatPos : flatPos,
@@ -138,8 +138,8 @@ struct BinaryOperationExecutor {
             } else {
                 for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
                     auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                    result.setNull(
-                        unFlatPos, unFlatVec.isNull(unFlatPos)); // isFlatNull is always false.
+                    result.setNull(unFlatPos,
+                        unFlatVec.isNull(unFlatPos)); // isFlatNull is always false.
                     executeOnTuple<A, B, R, FUNC>(left, right, result,
                         isLeftFlat ? flatPos : unFlatPos, isLeftFlat ? unFlatPos : flatPos,
                         unFlatPos);

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -69,24 +69,21 @@ void ValueVector::readNodeID(uint64_t pos, nodeID_t& nodeID) const {
 
 bool ValueVector::discardNullNodes() {
     assert(dataType == NODE);
-    node_offset_t nodeOffset;
     if (state->isFlat()) {
-        nodeOffset = ((nodeID_t*)values)[state->getPositionOfCurrIdx()].offset;
-        return nodeOffset != UINT64_MAX;
+        return !nullMask->mask[state->getPositionOfCurrIdx()];
     } else {
         auto selectedPos = 0u;
         if (state->isUnfiltered()) {
             state->resetSelectorToValuePosBuffer();
             for (auto i = 0u; i < state->selectedSize; i++) {
-                nodeOffset = ((nodeID_t*)values)[i].offset;
                 state->selectedPositions[selectedPos] = i;
-                selectedPos += (nodeOffset != UINT64_MAX);
+                selectedPos += !nullMask->mask[i];
             }
         } else {
             for (auto i = 0u; i < state->selectedSize; i++) {
-                nodeOffset = ((nodeID_t*)values)[state->selectedPositions[i]].offset;
+                auto pos = state->selectedPositions[i];
                 state->selectedPositions[selectedPos] = i;
-                selectedPos += (nodeOffset != UINT64_MAX);
+                selectedPos += !nullMask->mask[pos];
             }
         }
         state->selectedSize = selectedPos;

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -23,6 +23,7 @@ bool AdjColumnExtend::getNextTuples() {
             metrics->executionTime.stop();
             return false;
         }
+        outValueVector->setAllNull();
         column->readValues(inValueVector, outValueVector, *metrics->bufferManagerMetrics);
         saveDataChunkSelectorState(inDataChunk);
         hasAtLeastOneNonNullValue = outValueVector->discardNullNodes();

--- a/src/storage/data_structure/column.cpp
+++ b/src/storage/data_structure/column.cpp
@@ -1,5 +1,7 @@
 #include "src/storage/include/data_structure/column.h"
 
+#include <iostream>
+
 namespace graphflow {
 namespace storage {
 
@@ -85,7 +87,6 @@ void AdjColumn::readValues(const shared_ptr<ValueVector>& nodeIDVector,
     const shared_ptr<ValueVector>& resultVector, BufferManagerMetrics& metrics) {
     assert(nodeIDVector->dataType == NODE && nodeIDVector->state == resultVector->state);
     auto nodeIDValues = (nodeID_t*)nodeIDVector->values;
-    auto resultVectorValues = (nodeID_t*)resultVector->values;
     if (nodeIDVector->isSequence) {
         auto pageCursor = getPageCursorForOffset(nodeIDValues[0].offset);
         readNodeIDsFromSequentialPages(
@@ -99,7 +100,7 @@ void AdjColumn::readValues(const shared_ptr<ValueVector>& nodeIDVector,
                                                        nodeIDVector->state->selectedPositions[i];
             auto nodeOffset = nodeIDValues[pos].offset;
             auto pageCursor = getPageCursorForOffset(nodeOffset);
-            readNodeIDsFromAPage(&resultVectorValues[i], pageCursor.idx, pageCursor.offset,
+            readNodeIDsFromAPage(resultVector, pos, pageCursor.idx, pageCursor.offset,
                 1 /* numValuesToCopy */, nodeIDCompressionScheme, metrics);
         }
     }

--- a/src/storage/data_structure/lists/lists.cpp
+++ b/src/storage/data_structure/lists/lists.cpp
@@ -99,8 +99,7 @@ void AdjLists::readFromLargeList(const shared_ptr<ValueVector>& valueVector,
     listSyncState->set(csrOffset, valueVector->state->selectedSize);
     // map logical pageIdx to physical pageIdx
     auto physicalPageId = info.mapper(info.cursor.idx);
-    auto values = (nodeID_t*)valueVector->values;
-    readNodeIDsFromAPage(values, physicalPageId, info.cursor.offset, numValuesToCopy,
+    readNodeIDsFromAPage(valueVector, 0, physicalPageId, info.cursor.offset, numValuesToCopy,
         nodeIDCompressionScheme, metrics);
 }
 

--- a/src/storage/include/data_structure/data_structure.h
+++ b/src/storage/include/data_structure/data_structure.h
@@ -55,9 +55,9 @@ protected:
     void copyFromAPage(uint8_t* values, uint32_t physicalPageIdx, uint64_t sizeToCopy,
         uint32_t pageOffset, BufferManagerMetrics& metrics);
 
-    void readNodeIDsFromAPage(nodeID_t* resultVectorValues, uint32_t physicalPageId,
-        uint32_t pageOffset, uint64_t numValuesToCopy, NodeIDCompressionScheme& compressionScheme,
-        BufferManagerMetrics& metrics);
+    void readNodeIDsFromAPage(const shared_ptr<ValueVector>& valueVector, uint32_t posInVector,
+        uint32_t physicalPageId, uint32_t pageOffset, uint64_t numValuesToCopy,
+        NodeIDCompressionScheme& compressionScheme, BufferManagerMetrics& metrics);
 
 public:
     DataType dataType;


### PR DESCRIPTION
even though reading from adjColumns can have NULL edges, we were not using the nullMask it indicate the NULL edges. This PR caters for that. Now we set NULL values in the vector (to which we read edges from adjColumns) and use that to update selectedPos in valueVector later.

I am doing this separately because in not necessarily a part of the larger NULL bits PR but is rather important as this uses NullMask in a new way (earlier it was just used in expressions).

Also, fixes a bug that was not getting caught in tests.