### PR TITLE
Add tests for aggregation expression evaluation

### DIFF
--- a/src/binder/bound_statements/bound_projection_body.cpp
+++ b/src/binder/bound_statements/bound_projection_body.cpp
@@ -5,7 +5,7 @@ namespace binder {
 
 bool BoundProjectionBody::hasAggregationExpressions() const {
     for (auto& projectionExpression : projectionExpressions) {
-        if (isExpressionAggregate(projectionExpression->expressionType)) {
+        if (projectionExpression->hasAggregationExpression()) {
             return true;
         }
     }
@@ -15,8 +15,9 @@ bool BoundProjectionBody::hasAggregationExpressions() const {
 vector<shared_ptr<Expression>> BoundProjectionBody::getAggregationExpressions() const {
     vector<shared_ptr<Expression>> aggregationExpressions;
     for (auto& projectionExpression : projectionExpressions) {
-        if (isExpressionAggregate(projectionExpression->expressionType)) {
-            aggregationExpressions.push_back(projectionExpression);
+        for (auto& aggregationExpression :
+            projectionExpression->getTopLevelSubAggregationExpressions()) {
+            aggregationExpressions.push_back(aggregationExpression);
         }
     }
     return aggregationExpressions;

--- a/src/binder/expression/existential_subquery_expression.cpp
+++ b/src/binder/expression/existential_subquery_expression.cpp
@@ -3,7 +3,7 @@
 namespace graphflow {
 namespace binder {
 
-vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getDependentVariables() {
+vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getSubVariableExpressions() {
     auto& firstQueryPart = *normalizedSubquery->getQueryPart(0);
     vector<shared_ptr<Expression>> result;
     for (auto& node : firstQueryPart.getQueryGraph()->queryNodes) {
@@ -12,22 +12,17 @@ vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getDependentVariab
     for (auto& rel : firstQueryPart.getQueryGraph()->queryRels) {
         result.push_back(rel);
     }
-    if (firstQueryPart.hasWhereExpression()) {
-        for (auto& variable : firstQueryPart.getWhereExpression()->getDependentVariables()) {
-            result.push_back(variable);
-        }
-    }
-    for (auto& projectExpression : firstQueryPart.getProjectionBody()->getProjectionExpressions()) {
-        for (auto& variable : projectExpression->getDependentVariables()) {
+    for (auto& expression : getSubExpressions()) {
+        for (auto& variable : expression->getSubVariableExpressions()) {
             result.push_back(variable);
         }
     }
     return result;
 }
 
-vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getDependentExpressions() {
+vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getSubExpressions() {
     auto& firstQueryPart = *normalizedSubquery->getQueryPart(0);
-    auto result = firstQueryPart.getDependentNodeID();
+    auto result = firstQueryPart.getNodeIDExpressions();
     if (firstQueryPart.hasWhereExpression()) {
         result.push_back(firstQueryPart.getWhereExpression());
     }

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -51,7 +51,6 @@ shared_ptr<Expression> ExpressionBinder::bindExpression(const ParsedExpression& 
         expression->setAlias(parsedExpression.alias);
     }
     expression->setRawName(parsedExpression.getRawName());
-    validateAggregationIsRoot(*expression);
     return expression;
 }
 
@@ -485,13 +484,6 @@ void ExpressionBinder::validateExpectedBinaryOperation(const Expression& left,
         throw invalid_argument("Operation " + expressionTypeToString(type) + " between " +
                                left.getRawName() + " and " + right.getRawName() +
                                " is not supported.");
-    }
-}
-
-void ExpressionBinder::validateAggregationIsRoot(const Expression& expression) {
-    if (!isExpressionAggregate(expression.expressionType) &&
-        expression.hasAggregationExpression()) {
-        throw invalid_argument("Aggregation function must be the root of expression tree.");
     }
 }
 

--- a/src/binder/include/expression/existential_subquery_expression.h
+++ b/src/binder/include/expression/existential_subquery_expression.h
@@ -27,8 +27,8 @@ public:
     inline bool hasSubPlan() { return subPlan != nullptr; }
     inline unique_ptr<LogicalPlan> getSubPlan() { return subPlan->copy(); }
 
-    vector<shared_ptr<Expression>> getDependentVariables() override;
-    vector<shared_ptr<Expression>> getDependentExpressions();
+    vector<shared_ptr<Expression>> getSubVariableExpressions() override;
+    vector<shared_ptr<Expression>> getSubExpressions();
 
 private:
     unique_ptr<BoundSingleQuery> boundSubquery;

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -101,8 +101,6 @@ private:
 
     static void validateExpectedBinaryOperation(const Expression& left, const Expression& right,
         ExpressionType type, const unordered_set<ExpressionType>& expectedTypes);
-    // NOTE: this validation should be removed once we rewrite aggregation as an alias.
-    static void validateAggregationIsRoot(const Expression& expression);
 
 private:
     template<typename T>

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -58,6 +58,10 @@ bool isExpressionAggregate(ExpressionType type) {
            MIN_FUNC == type || MAX_FUNC == type;
 }
 
+bool isExpressionSubquery(ExpressionType type) {
+    return EXISTENTIAL_SUBQUERY == type;
+}
+
 ExpressionType comparisonToIDComparison(ExpressionType type) {
     switch (type) {
     case EQUALS:

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -149,6 +149,7 @@ bool isExpressionStringOperator(ExpressionType type);
 bool isExpressionNullComparison(ExpressionType type);
 bool isExpressionLiteral(ExpressionType type);
 bool isExpressionAggregate(ExpressionType type);
+bool isExpressionSubquery(ExpressionType type);
 
 ExpressionType comparisonToIDComparison(ExpressionType type);
 string expressionTypeToString(ExpressionType type);

--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -117,7 +117,7 @@ uint32_t Enumerator::appendScanPropertiesFlattensAndPlanSubqueryIfNecessary(
     const shared_ptr<Expression>& expression, LogicalPlan& plan) {
     appendScanPropertiesIfNecessary(expression, plan);
     if (expression->hasSubqueryExpression()) {
-        auto expressions = expression->getDependentSubqueryExpressions();
+        auto expressions = expression->getTopLevelSubSubqueryExpressions();
         for (auto& expr : expressions) {
             auto subqueryExpression = static_pointer_cast<ExistentialSubqueryExpression>(expr);
             if (!subqueryExpression->hasSubPlan()) {
@@ -191,7 +191,7 @@ vector<shared_ptr<Expression>> Enumerator::getExpressionsInSchema(
     }
     if (EXISTENTIAL_SUBQUERY == expression->expressionType) {
         auto& subqueryExpression = (ExistentialSubqueryExpression&)*expression;
-        for (auto& child : subqueryExpression.getDependentExpressions()) {
+        for (auto& child : subqueryExpression.getSubExpressions()) {
             for (auto& subExpression : getExpressionsInSchema(child, schema)) {
                 results.push_back(subExpression);
             }
@@ -218,7 +218,7 @@ vector<shared_ptr<Expression>> Enumerator::getPropertyExpressionsNotInSchema(
     }
     if (EXISTENTIAL_SUBQUERY == expression->expressionType) {
         auto& subqueryExpression = (ExistentialSubqueryExpression&)*expression;
-        for (auto& child : subqueryExpression.getDependentExpressions()) {
+        for (auto& child : subqueryExpression.getSubExpressions()) {
             for (auto& subExpression : getPropertyExpressionsNotInSchema(child, schema)) {
                 results.push_back(subExpression);
             }

--- a/src/planner/include/norm_query/normalized_query_part.h
+++ b/src/planner/include/norm_query/normalized_query_part.h
@@ -49,7 +49,7 @@ public:
 
     inline BoundProjectionBody* getProjectionBody() const { return projectionBody.get(); }
 
-    vector<shared_ptr<Expression>> getDependentNodeID() const;
+    vector<shared_ptr<Expression>> getNodeIDExpressions() const;
 
 private:
     unique_ptr<BoundLoadCSVStatement> loadCSVStatement;

--- a/src/planner/include/projection_enumerator.h
+++ b/src/planner/include/projection_enumerator.h
@@ -26,7 +26,8 @@ public:
 private:
     void appendProjection(const vector<shared_ptr<Expression>>& expressions, LogicalPlan& plan,
         bool isRewritingAllProperties);
-    void appendAggregate(const vector<shared_ptr<Expression>>& expressions, LogicalPlan& plan);
+    void appendAggregateIfNecessary(
+        const vector<shared_ptr<Expression>>& expressions, LogicalPlan& plan);
     void appendOrderBy(const vector<shared_ptr<Expression>>& expressions,
         const vector<bool>& isAscOrders, LogicalPlan& plan);
     void appendMultiplicityReducer(LogicalPlan& plan);

--- a/src/planner/norm_query/normalized_query_part.cpp
+++ b/src/planner/norm_query/normalized_query_part.cpp
@@ -5,7 +5,7 @@
 namespace graphflow {
 namespace planner {
 
-vector<shared_ptr<Expression>> NormalizedQueryPart::getDependentNodeID() const {
+vector<shared_ptr<Expression>> NormalizedQueryPart::getNodeIDExpressions() const {
     vector<shared_ptr<Expression>> result;
     for (auto& node : queryGraph->queryNodes) {
         result.push_back(node->getNodeIDPropertyExpression());

--- a/src/planner/query_normalizer.cpp
+++ b/src/planner/query_normalizer.cpp
@@ -88,7 +88,7 @@ void QueryNormalizer::normalizeSubqueryExpression(
             auto& matchStatement = (BoundMatchStatement&)*boundReadingStatement;
             if (matchStatement.hasWhereExpression()) {
                 for (auto& expression :
-                    matchStatement.getWhereExpression()->getDependentSubqueryExpressions()) {
+                    matchStatement.getWhereExpression()->getTopLevelSubSubqueryExpressions()) {
                     auto& subqueryExpression = (ExistentialSubqueryExpression&)*expression;
                     subqueryExpression.setNormalizedSubquery(
                         normalizeQuery(*subqueryExpression.getBoundSubquery()));
@@ -98,7 +98,7 @@ void QueryNormalizer::normalizeSubqueryExpression(
     }
     if (boundQueryPart.boundWithStatement->hasWhereExpression()) {
         for (auto& expression : boundQueryPart.boundWithStatement->getWhereExpression()
-                                    ->getDependentSubqueryExpressions()) {
+                                    ->getTopLevelSubSubqueryExpressions()) {
             auto& subqueryExpression = (ExistentialSubqueryExpression&)*expression;
             subqueryExpression.setNormalizedSubquery(
                 normalizeQuery(*subqueryExpression.getBoundSubquery()));

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -157,12 +157,6 @@ TEST_F(BinderErrorTest, BindFunctionWithWrongParamType) {
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
-TEST_F(BinderErrorTest, AggregationFunctionNotAtRoot) {
-    string expectedException = "Aggregation function must be the root of expression tree.";
-    auto input = "MATCH (a:person) WITH SUM(a.age) > a.age RETURN a.age;";
-    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
-}
-
 TEST_F(BinderErrorTest, AggregationWithGroupBy) {
     string expectedException = "Aggregations with group by is not supported.";
     auto input = "MATCH (a:person) RETURN a.name, SUM(a.age);";

--- a/test/runner/queries/aggregate/multi_query.test
+++ b/test/runner/queries/aggregate/multi_query.test
@@ -1,0 +1,11 @@
+# description: aggregation without groups and distinct
+
+-NAME SimpleCountMultiQueryTest
+-QUERY MATCH (a:person) WITH COUNT(a.age) + COUNT(a.unstrNumericProp) AS newCount RETURN newCount > 12
+---- 1
+False
+
+-NAME SimpleAvgWithFilterMultiQueryTest
+-QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') WITH AVG(a.age) AS avgAge, AVG(a.eyeSight) AS avgEyeSight RETURN avgAge > avgEyeSight
+---- 1
+True

--- a/test/runner/queries/aggregate/simple_aggregate.test
+++ b/test/runner/queries/aggregate/simple_aggregate.test
@@ -5,6 +5,11 @@
 ---- 1
 8|3
 
+-NAME SimpleCountEvaluationTest
+-QUERY MATCH (a:person) RETURN COUNT(a.age) + 1, COUNT(a.unstrNumericProp) * 2.0
+---- 1
+9|6.000000
+
 -NAME SimpleSumTest
 -QUERY MATCH (a:person) RETURN SUM(a.age), SUM(a.eyeSight), SUM(a.unstrNumericProp)
 ---- 1
@@ -19,6 +24,11 @@
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age+10), SUM(a.age*2)
 ---- 1
 115|170
+
+-NAME SimpleSumWithFilterEvaluationTest
+-QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age+10) > SUM(a.age*2)
+---- 1
+False
 
 -NAME SimpleAvgTest
 -QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight)

--- a/test/runner/tinysnb_end_to_end_test.cpp
+++ b/test/runner/tinysnb_end_to_end_test.cpp
@@ -74,6 +74,8 @@ TEST_F(TinySnbProcessorTest, AggregateTests) {
     vector<TestQueryConfig> queryConfigs;
     queryConfigs = TestHelper::parseTestFile("test/runner/queries/aggregate/simple_aggregate.test");
     ASSERT_TRUE(TestHelper::runTest(queryConfigs, *defaultSystem));
+    queryConfigs = TestHelper::parseTestFile("test/runner/queries/aggregate/multi_query.test");
+    ASSERT_TRUE(TestHelper::runTest(queryConfigs, *defaultSystem));
 }
 
 TEST_F(TinySnbProcessorTest, ProjectionTests) {


### PR DESCRIPTION
This PR adds tests for aggregation expression evaluation where aggregation expression is not the root.

For example,
MATCH (a) RETURN COUNT(a.age) + 1;

This is done by first evaluating COUNT(a.age) in aggregate operator, and then evaluating COUNT(a.age) + 1 where COUNT(a.age) is treated as a root.

Bugfix
- Avoid appending aggregate operator if an aggregation has been evaluated. Consider the following query ` MATCH a with count(a.age) as newAge return newAge > 12.`, for the second query part, although newAge is an aggregation expression, we don't need to append aggregate operator since it has been evaluated.

Minor changes
- Refactor functions in the Expression class that have a similar children iteration logic. 
