### PR TITLE
add group by front end logic, unify expression logic in enumerator

### DIFF
--- a/src/binder/bound_statements/bound_projection_body.cpp
+++ b/src/binder/bound_statements/bound_projection_body.cpp
@@ -12,16 +12,5 @@ bool BoundProjectionBody::hasAggregationExpressions() const {
     return false;
 }
 
-vector<shared_ptr<Expression>> BoundProjectionBody::getAggregationExpressions() const {
-    vector<shared_ptr<Expression>> aggregationExpressions;
-    for (auto& projectionExpression : projectionExpressions) {
-        for (auto& aggregationExpression :
-            projectionExpression->getTopLevelSubAggregationExpressions()) {
-            aggregationExpressions.push_back(aggregationExpression);
-        }
-    }
-    return aggregationExpressions;
-}
-
 } // namespace binder
 } // namespace graphflow

--- a/src/binder/expression/existential_subquery_expression.cpp
+++ b/src/binder/expression/existential_subquery_expression.cpp
@@ -3,18 +3,11 @@
 namespace graphflow {
 namespace binder {
 
-vector<shared_ptr<Expression>> ExistentialSubqueryExpression::getSubVariableExpressions() {
-    auto& firstQueryPart = *normalizedSubquery->getQueryPart(0);
-    vector<shared_ptr<Expression>> result;
-    for (auto& node : firstQueryPart.getQueryGraph()->queryNodes) {
-        result.push_back(node);
-    }
-    for (auto& rel : firstQueryPart.getQueryGraph()->queryRels) {
-        result.push_back(rel);
-    }
+unordered_set<string> ExistentialSubqueryExpression::getDependentVariableNames() {
+    unordered_set<string> result;
     for (auto& expression : getSubExpressions()) {
-        for (auto& variable : expression->getSubVariableExpressions()) {
-            result.push_back(variable);
+        for (auto& variableName : expression->getDependentVariableNames()) {
+            result.insert(variableName);
         }
     }
     return result;

--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -26,20 +26,13 @@ Expression::Expression(ExpressionType expressionType, DataType dataType, const s
 
 unordered_set<string> Expression::getDependentVariableNames() {
     unordered_set<string> result;
-    for (auto& variableExpression : getSubVariableExpressions()) {
-        result.insert(variableExpression->getUniqueName());
-    }
-    return result;
-}
-
-vector<shared_ptr<Expression>> Expression::getSubVariableExpressions() {
     if (expressionType == VARIABLE) {
-        return vector<shared_ptr<Expression>>{shared_from_this()};
+        result.insert(getUniqueName());
+        return result;
     }
-    vector<shared_ptr<Expression>> result;
     for (auto& child : children) {
-        for (auto& expression : child->getSubVariableExpressions()) {
-            result.push_back(expression);
+        for (auto& variableName : child->getDependentVariableNames()) {
+            result.insert(variableName);
         }
     }
     return result;

--- a/src/binder/include/bound_statements/bound_projection_body.h
+++ b/src/binder/include/bound_statements/bound_projection_body.h
@@ -26,7 +26,6 @@ public:
     inline void setLimitNumber(uint64_t number) { limitNumber = number; }
 
     bool hasAggregationExpressions() const;
-    vector<shared_ptr<Expression>> getAggregationExpressions() const;
     inline vector<shared_ptr<Expression>> getProjectionExpressions() const {
         return projectionExpressions;
     }

--- a/src/binder/include/expression/existential_subquery_expression.h
+++ b/src/binder/include/expression/existential_subquery_expression.h
@@ -27,7 +27,7 @@ public:
     inline bool hasSubPlan() { return subPlan != nullptr; }
     inline unique_ptr<LogicalPlan> getSubPlan() { return subPlan->copy(); }
 
-    vector<shared_ptr<Expression>> getSubVariableExpressions() override;
+    unordered_set<string> getDependentVariableNames() override;
     vector<shared_ptr<Expression>> getSubExpressions();
 
 private:

--- a/src/binder/include/expression/expression.h
+++ b/src/binder/include/expression/expression.h
@@ -41,12 +41,8 @@ public:
     bool hasAggregationExpression() const { return hasSubExpressionOfType(isExpressionAggregate); }
     bool hasSubqueryExpression() const { return hasSubExpressionOfType(isExpressionSubquery); }
 
-    unordered_set<string> getDependentVariableNames();
+    virtual unordered_set<string> getDependentVariableNames();
 
-    virtual vector<shared_ptr<Expression>> getSubVariableExpressions();
-    vector<shared_ptr<Expression>> getTopLevelSubAggregationExpressions() {
-        return getTopLevelSubExpressionsOfType(isExpressionAggregate);
-    }
     vector<shared_ptr<Expression>> getTopLevelSubSubqueryExpressions() {
         return getTopLevelSubExpressionsOfType(isExpressionSubquery);
     }

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -102,6 +102,9 @@ private:
     static void validateExpectedBinaryOperation(const Expression& left, const Expression& right,
         ExpressionType type, const unordered_set<ExpressionType>& expectedTypes);
 
+    // E.g. SUM(SUM(a.age)) is not allowed
+    static void validateAggregationExpressionIsNotNested(const Expression& expression);
+
 private:
     template<typename T>
     shared_ptr<Expression> bindStringCastingFunctionExpression(

--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -73,8 +73,6 @@ private:
         label_t relLabel, label_t nodeLabel, Direction direction);
     // E.g. RETURN a, b AS a
     void validateProjectionColumnNamesAreUnique(const vector<shared_ptr<Expression>>& expressions);
-    // Current system does not support aggregations with group by.
-    void validateAggregationsHaveNoGroupBy(const vector<shared_ptr<Expression>>& expressions);
     void validateQueryGraphIsConnected(const QueryGraph& queryGraph,
         unordered_map<string, shared_ptr<Expression>> prevVariablesInScope);
     void validateCSVHeaderColumnNamesAreUnique(const vector<pair<string, DataType>>& headerInfo);

--- a/src/binder/query_binder.cpp
+++ b/src/binder/query_binder.cpp
@@ -163,7 +163,6 @@ vector<shared_ptr<Expression>> QueryBinder::bindProjectionExpressions(
         }
     }
     validateProjectionColumnNamesAreUnique(boundProjectionExpressions);
-    validateAggregationsHaveNoGroupBy(boundProjectionExpressions);
     return boundProjectionExpressions;
 }
 
@@ -352,19 +351,6 @@ void QueryBinder::validateProjectionColumnNamesAreUnique(
                                    expression->getRawName() + " are not supported.");
         }
         existColumnNames.insert(expression->getRawName());
-    }
-}
-
-void QueryBinder::validateAggregationsHaveNoGroupBy(
-    const vector<shared_ptr<Expression>>& expressions) {
-    auto numAggregationExpressions = 0u;
-    auto numNonAggregationExpressions = 0u;
-    for (auto& expression : expressions) {
-        isExpressionAggregate(expression->expressionType) ? numAggregationExpressions++ :
-                                                            numNonAggregationExpressions++;
-    }
-    if (numAggregationExpressions != 0 && numNonAggregationExpressions != 0) {
-        throw invalid_argument("Aggregations with group by is not supported.");
     }
 }
 

--- a/src/planner/include/projection_enumerator.h
+++ b/src/planner/include/projection_enumerator.h
@@ -26,14 +26,18 @@ public:
 private:
     void appendProjection(const vector<shared_ptr<Expression>>& expressions, LogicalPlan& plan,
         bool isRewritingAllProperties);
-    void appendAggregateIfNecessary(
-        const vector<shared_ptr<Expression>>& expressions, LogicalPlan& plan);
+    void appendAggregate(const vector<shared_ptr<Expression>>& expressionsToGroupBy,
+        const vector<shared_ptr<Expression>>& expressionsToAggregate, LogicalPlan& plan);
     void appendOrderBy(const vector<shared_ptr<Expression>>& expressions,
         const vector<bool>& isAscOrders, LogicalPlan& plan);
     void appendMultiplicityReducer(LogicalPlan& plan);
     void appendLimit(uint64_t limitNumber, LogicalPlan& plan);
     void appendSkip(uint64_t skipNumber, LogicalPlan& plan);
 
+    vector<shared_ptr<Expression>> getExpressionToGroupBy(
+        const BoundProjectionBody& projectionBody, const Schema& schema);
+    vector<shared_ptr<Expression>> getExpressionsToAggregate(
+        const BoundProjectionBody& projectionBody, const Schema& schema);
     vector<shared_ptr<Expression>> rewriteVariableExpression(
         const shared_ptr<Expression>& variable, bool isRewritingAllProperties);
     vector<shared_ptr<Expression>> rewriteNodeExpression(

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -157,14 +157,14 @@ TEST_F(BinderErrorTest, BindFunctionWithWrongParamType) {
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
-TEST_F(BinderErrorTest, AggregationWithGroupBy) {
-    string expectedException = "Aggregations with group by is not supported.";
-    auto input = "MATCH (a:person) RETURN a.name, SUM(a.age);";
-    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
-}
-
 TEST_F(BinderErrorTest, OrderByVariableNotInScope) {
     string expectedException = "Variable a not defined.";
     auto input = "MATCH (a:person)-[e1:knows]->(b:person) RETURN SUM(a.age) ORDER BY a;";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, NestedAggregation) {
+    string expectedException = "Expression SUM(SUM(a.age)) contains nested aggregation.";
+    auto input = "MATCH (a:person) RETURN SUM(SUM(a.age));";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }


### PR DESCRIPTION
This PR adds support for group by in the front end

Major changes
- Abstract getSubExpressionsNotInSchemaOfType() interface which is used to collect property and aggregation sub-expressions that haven't been evaluated for a given input expression.
- Add appendAggregateIfNecessary logic. 
   -  For a given return expression, fetch all sub-aggregation expressions that haven't been evaluated. If there is none sub-agg expression, then it's a group-by expression.
   - If there is no agg expression to evaluate, we do not append aggregate operator. 
 - Unify expression handling logic in enumerator
   -  First appendScanProperties and plan subquery if needed
   -  Then collect all dependent groups
   -  Apply flattenAll or flattenAllButOne depends on the operator
 
Minor changes
- Add nested aggregation validation
- Remove unused interface in Expression