### PR TITLE
Issue 397

### DIFF
--- a/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
+++ b/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
@@ -10,13 +10,10 @@ class LogicalHashJoin : public LogicalOperator {
 
 public:
     LogicalHashJoin(string joinNodeID, shared_ptr<LogicalOperator> buildSidePrevOperator,
-        unique_ptr<Schema> buildSideSchema, uint32_t probeSideFlatGroupPos,
-        vector<uint32_t> probeSideUnFlatGroupsPos,
-        shared_ptr<LogicalOperator> probeSidePrevOperator)
+        unique_ptr<Schema> buildSideSchema, shared_ptr<LogicalOperator> probeSidePrevOperator)
         : LogicalOperator(move(probeSidePrevOperator)),
           joinNodeID(move(joinNodeID)), buildSidePrevOperator{move(buildSidePrevOperator)},
-          buildSideSchema(move(buildSideSchema)), probeSideFlatGroupPos{probeSideFlatGroupPos},
-          probeSideUnFlatGroupsPos{move(probeSideUnFlatGroupsPos)} {}
+          buildSideSchema(move(buildSideSchema)) {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_HASH_JOIN;
@@ -36,16 +33,13 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalHashJoin>(joinNodeID, buildSidePrevOperator->copy(),
-            buildSideSchema->copy(), probeSideFlatGroupPos, probeSideUnFlatGroupsPos,
-            prevOperator->copy());
+            buildSideSchema->copy(), prevOperator->copy());
     }
 
 public:
     const string joinNodeID;
     shared_ptr<LogicalOperator> buildSidePrevOperator;
     unique_ptr<Schema> buildSideSchema;
-    uint32_t probeSideFlatGroupPos;
-    vector<uint32_t> probeSideUnFlatGroupsPos;
 };
 } // namespace planner
 } // namespace graphflow

--- a/src/planner/join_order_enumerator.cpp
+++ b/src/planner/join_order_enumerator.cpp
@@ -285,7 +285,6 @@ void JoinOrderEnumerator::appendLogicalHashJoin(
     auto allGroupsOnBuildSideIsFlat = true;
     // the appended probe side group that holds all flat groups on build side
     auto probeSideNewFlatGroupPos = UINT32_MAX;
-    vector<uint32_t> probeSideNewUnFlatGroupsPos;
     for (auto i = 0u; i < buildPlan.schema->groups.size(); ++i) {
         if (i == buildSideKeyGroupPos) {
             continue;
@@ -304,16 +303,14 @@ void JoinOrderEnumerator::appendLogicalHashJoin(
             probePlan.schema->insertToGroup(*buildSideGroup, groupPos);
             probePlan.schema->groups[groupPos]->estimatedCardinality =
                 buildSideGroup->estimatedCardinality;
-            probeSideNewUnFlatGroupsPos.push_back(groupPos);
         }
     }
 
     if (!allGroupsOnBuildSideIsFlat && probeSideNewFlatGroupPos != UINT32_MAX) {
         probePlan.schema->flattenGroup(probeSideNewFlatGroupPos);
     }
-    auto hashJoin =
-        make_shared<LogicalHashJoin>(joinNodeID, buildPlan.lastOperator, buildPlan.schema->copy(),
-            probeSideNewFlatGroupPos, probeSideNewUnFlatGroupsPos, probePlan.lastOperator);
+    auto hashJoin = make_shared<LogicalHashJoin>(
+        joinNodeID, buildPlan.lastOperator, buildPlan.schema->copy(), probePlan.lastOperator);
     probePlan.appendOperator(move(hashJoin));
 }
 


### PR DESCRIPTION
This PR solves issue #397 

This PR introduces a design pattern for merging result sets from different branches (pipelines). For example, hash join probe result set need to merge hash join build result set. We might follow a similar pattern when merging subquery or scanning aggregation/order by tables. The pattern is described as following.

Build side takes a schema (BuildDataInfo) describing what vectors should be materialized. It contains
-  DataPos keyIDDataPos: describes the position of hash key.
-  vector<DataPos> nonKeyDataPoses: describes the positions of all payload vectors.

Probe side takes a schema (ProbeDataInfo) describing how to append build side payload to probe side. It contains
- DataPos keyIDDataPos: describe the position of hash key. On probe side, this hash key is only used for probing.
- vector<DataPos> nonKeyDataPoses: describes the appending positions of payload vectors.
  -  Note that build and probe side nonKeyDataPoses have one-to-one mapping which means we should scan all columns that are materialized. Otherwise those columns should not be part of the payload. 