### PR TITLE
add null support for rowCollection

### DIFF
--- a/src/common/include/exception.h
+++ b/src/common/include/exception.h
@@ -51,5 +51,11 @@ public:
         : Exception("OrderBy encoder exception: " + msg){};
 };
 
+class RowCollectionException : public Exception {
+public:
+    explicit RowCollectionException(const string& msg)
+        : Exception("RowCollection exception: " + msg){};
+};
+
 } // namespace common
 } // namespace graphflow

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -38,7 +38,9 @@ struct nodeID_t {
 
 // System representation for a variable-sized overflow value.
 struct overflow_value_t {
-    uint64_t len;
+    // the size of the overflow buffer can be calculated as:
+    // numElements * sizeof(Element) + nullMap(4 bytes alignment)
+    uint64_t numElements;
     uint8_t* value;
 };
 

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -63,7 +63,7 @@ public:
         nullMask->mayContainNulls |= isNull;
     }
 
-    inline uint8_t isNull(uint64_t pos) { return nullMask->mask[pos]; }
+    inline uint8_t isNull(uint64_t pos) const { return nullMask->mask[pos]; }
 
     inline shared_ptr<NullMask> getNullMask() { return nullMask; }
     inline uint64_t getNumBytesPerValue() const { return TypeUtils::getDataTypeSize(dataType); }

--- a/src/processor/include/physical_plan/result/row_collection.h
+++ b/src/processor/include/physical_plan/result/row_collection.h
@@ -33,14 +33,16 @@ private:
 };
 
 struct FieldInLayout {
-    FieldInLayout(uint64_t size, bool isVectorOverflow)
-        : size{size}, isVectorOverflow{isVectorOverflow} {}
+    FieldInLayout(DataType dataType, uint64_t size, bool isVectorOverflow)
+        : dataType{dataType}, size{size}, isVectorOverflow{isVectorOverflow} {}
 
     inline bool operator==(const FieldInLayout& other) const {
-        return size == other.size && isVectorOverflow == other.isVectorOverflow;
+        return dataType == other.dataType && size == other.size &&
+               isVectorOverflow == other.isVectorOverflow;
     }
     inline bool operator!=(const FieldInLayout& other) const { return !(*this == other); }
 
+    DataType dataType;
     uint64_t size;
     bool isVectorOverflow;
 };
@@ -52,26 +54,59 @@ struct RowLayout {
         for (auto& field : this->fields) {
             numBytesPerRow += field.size;
         }
+        initialize();
     }
 
     RowLayout(const RowLayout& layout) = default;
 
     inline void appendField(const FieldInLayout& field) {
+        assert(!isInitialized);
         fields.push_back(field);
         numBytesPerRow += field.size;
     }
 
+    inline uint64_t getNullMapOffset() const { return numBytesPerRow - getNullMapAlignedSize(); }
+
+    inline uint64_t getNullMapAlignedSize() const {
+        // 4 bytes alignment for nullMap
+        return ((nullMapSizeInBytes >> 2) + ((nullMapSizeInBytes & 3) != 0))
+               << 2; // &3 is the same as %4
+    }
+
+    inline void initialize() {
+        assert(!isInitialized);
+        // we utilize the bitmap to represent the nullMask for each column.
+        // 1 byte nullMap can represent the nullMasks for 8 columns
+        nullMapSizeInBytes =
+            (this->fields.size() >> 3) + ((this->fields.size() & 7) != 0); // &7 is the same as %8
+        numBytesPerRow += getNullMapAlignedSize();
+        isInitialized = true;
+    }
+
     bool operator==(const RowLayout& other) const;
     inline bool operator!=(const RowLayout& other) const { return !(*this == other); }
-
+    bool isInitialized = false;
     vector<FieldInLayout> fields;
     uint64_t numBytesPerRow;
+    uint64_t nullMapSizeInBytes;
 };
 
+// To represent the null values in RowCollection, we use a bitmap to represent the null fields in
+// each row
+// 1. For overflow columns, we use a large bitmap to represent the nulls in the whole overflow
+// columns and stores it at the end of the overflow memory.
+// 2. For all other columns, we just store a bitmap at the end of each row.
+// For example: we have 3 columns: a1   a2(overflow)      a3
+//                                  1   [null,4,6,7]      null
+// Since the 3rd column is a null value, we set the 3rd bit(from right to left) of the first byte
+// to 1.
+// The memory of the row Collection looks like: 1st row: 1  overflowPtrToA2  0 nullMap:4(00000100).
+// Since the 1st element in the overflow column is a null value, we set the 1st
+// bit(from right to left) of the first byte to 1.
+// The overflow column memory: 3 4 6 0 nullMap:0(00000001).
 class RowCollection {
 public:
     RowCollection(MemoryManager& memoryManager, const RowLayout& layout);
-
     void append(const vector<shared_ptr<ValueVector>>& vectors, uint64_t numRowsToAppend);
     // Actual number of rows scanned is returned. If it's 0, the scan already hits the end.
     uint64_t scan(const vector<uint64_t>& fieldsToScan, const vector<DataPos>& resultDataPos,
@@ -80,6 +115,7 @@ public:
         ResultSet& resultSet, uint8_t** rowsToRead, uint64_t startPos,
         uint64_t numRowsToRead) const;
     void merge(unique_ptr<RowCollection> other);
+    uint64_t getFieldOffsetInRow(uint64_t fieldId) const;
 
     inline uint64_t getNumRows() const { return numRows; }
     inline uint8_t* getRow(uint64_t rowId) const {
@@ -90,27 +126,34 @@ public:
     }
     inline vector<DataBlock>& getRowDataBlocks() { return rowDataBlocks; }
     inline const RowLayout& getLayout() { return layout; }
-
-    uint64_t getFieldOffsetInRow(uint64_t fieldId) const;
+    inline bool isNull(uint8_t* nullMapBuffer, uint64_t colIdx) const {
+        uint32_t nullMapIdx = colIdx >> 3;
+        uint8_t nullMapMask = 0x1 << (colIdx & 7); // note: &7 is the same as %8
+        return nullMapBuffer[nullMapIdx] & nullMapMask;
+    }
+    inline void setNullMap(uint8_t* nullMapBuffer, uint32_t colIdx) {
+        uint32_t nullMapIdx = colIdx >> 3;
+        uint8_t nullMapMask = 0x1 << (colIdx & 7); // note: &7 is the same as %8
+        nullMapBuffer[nullMapIdx] |= nullMapMask;
+    }
 
 private:
     vector<BlockAppendingInfo> allocateDataBlocks(vector<DataBlock>& dataBlocks,
         uint64_t numBytesPerEntry, uint64_t numEntriesToAppend, bool allocateOnlyFromLastBlock);
 
     void copyVectorToBlock(const ValueVector& vector, const BlockAppendingInfo& blockAppendInfo,
-        const FieldInLayout& field, uint64_t posInVector, uint64_t offsetInRow);
-    overflow_value_t appendUnFlatVectorToOverflowBlocks(const ValueVector& vector);
+        const FieldInLayout& field, uint64_t posInVector, uint64_t offsetInRow, uint64_t colIdx);
+    overflow_value_t appendUnFlatVectorToOverflowBlocks(const ValueVector& vector, uint64_t colIdx);
 
     void appendVector(ValueVector& valueVector, const vector<BlockAppendingInfo>& blockAppendInfos,
-        const FieldInLayout& field, uint64_t numRows, uint64_t offsetInRow);
-    void readVector(const FieldInLayout& field, uint8_t** rows, uint64_t offsetInRow,
-        uint64_t startRowPos, ValueVector& vector, uint64_t numValues) const;
-
-    static void copyVectorDataToBuffer(const ValueVector& vector, uint64_t valuePosInVec,
+        const FieldInLayout& field, uint64_t numRows, uint64_t offsetInRow, uint64_t colIdx);
+    void readOverflowVector(
+        uint8_t** rows, uint64_t offsetInRow, uint64_t startRowPos, ValueVector& vector) const;
+    void readNonOverflowVector(uint8_t** rows, uint64_t offsetInRow, ValueVector& vector,
+        uint64_t numRowsToRead, uint64_t colIdx) const;
+    void copyVectorDataToBuffer(const ValueVector& vector, uint64_t valuePosInVec,
         uint64_t posStride, uint8_t* buffer, uint64_t offsetInBuffer, uint64_t offsetStride,
-        uint64_t numValues);
-    static void copyBufferDataToVector(uint8_t** locations, uint64_t offset, uint64_t length,
-        ValueVector& vector, uint64_t valuePosInVec, uint64_t numValues);
+        uint64_t numValues, uint64_t colIdx, bool isVectorOverflow);
 
     MemoryManager& memoryManager;
     RowLayout layout;

--- a/test/processor/physical_plan/result/row_collection_test.cpp
+++ b/test/processor/physical_plan/result/row_collection_test.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 
+#include "src/common/include/exception.h"
 #include "src/processor/include/physical_plan/result/row_collection.h"
 
 using namespace graphflow::processor;
@@ -26,6 +27,7 @@ public:
 
     void SetUp() override {
         resultSet = initResultSet();
+        memoryManager = make_unique<MemoryManager>();
         auto vectorA1 = resultSet->dataChunks[0]->valueVectors[0];
         auto vectorA2 = resultSet->dataChunks[0]->valueVectors[1];
         auto vectorB1 = resultSet->dataChunks[1]->valueVectors[0];
@@ -36,140 +38,240 @@ public:
         auto vectorB1Data = (nodeID_t*)vectorB1->values;
         auto vectorB2Data = (double*)vectorB2->values;
         for (auto i = 0u; i < 100; i++) {
-            vectorA1Data[i].label = 18;
-            vectorA1Data[i].offset = (uint64_t)i;
-            vectorA2Data[i] = i * 2;
-            vectorB1Data[i].label = 28;
-            vectorB1Data[i].offset = (uint64_t)(i);
+            if (i % 15) {
+                vectorA1Data[i].label = 18;
+                vectorA1Data[i].offset = (uint64_t)i;
+            } else {
+                vectorA1->setNull(i, true);
+            }
+
+            if (i % 10) {
+                vectorA2Data[i] = i << 1;
+                vectorB1Data[i].label = 28;
+                vectorB1Data[i].offset = (uint64_t)(i);
+            } else {
+                vectorA2->setNull(i, true);
+                vectorB1->setNull(i, true);
+            }
             vectorB2Data[i] = (double)((double)i / 2.0);
         }
         resultSet->dataChunks[0]->state->selectedSize = 100;
         resultSet->dataChunks[1]->state->selectedSize = 100;
     }
 
+    static void checkA2OverflowValuesAndNulls(shared_ptr<ValueVector> vectorA2) {
+        for (auto i = 0u; i < 100; i++) {
+            if (i % 10) {
+                ASSERT_EQ(vectorA2->isNull(i), false);
+                ASSERT_EQ(((int64_t*)vectorA2->values)[i], i << 1);
+            } else {
+                ASSERT_EQ(vectorA2->isNull(i), true);
+            }
+        }
+    }
+
+    unique_ptr<RowCollection> appendMultipleRows(bool isAppendFlatVectorToOverFlowCol) {
+        // Prepare the rowCollection and unflat vectors (B1, A2).
+        RowLayout rowLayout({{NODE, TypeUtils::getDataTypeSize(NODE), false /* isVectorOverflow */},
+            {NODE, TypeUtils::getDataTypeSize(NODE), true /* isVectorOverflow */}});
+        auto rowCollection = make_unique<RowCollection>(*memoryManager, rowLayout);
+        vector<shared_ptr<ValueVector>> vectorsToAppend = {
+            resultSet->dataChunks[0]->valueVectors[0], resultSet->dataChunks[1]->valueVectors[0]};
+        if (isAppendFlatVectorToOverFlowCol) {
+            // Flat B1 will cause an exception in the append function, because we are trying to
+            // append a flat valueVector to an overflow column
+            resultSet->dataChunks[1]->state->currIdx = 1;
+        }
+
+        rowCollection->append(vectorsToAppend, 100);
+        return rowCollection;
+    }
+
 public:
     unique_ptr<ResultSet> resultSet;
+    unique_ptr<MemoryManager> memoryManager;
+    vector<uint64_t> fieldIdsToScan = {0, 1};
 };
 
-TEST_F(RowCollectionTest, TestSingleUnFlatDataChunk) {
-    auto memoryManager = make_unique<MemoryManager>();
-    vector<FieldInLayout> fields;
-    fields.emplace_back(TypeUtils::getDataTypeSize(NODE), false);
-    fields.emplace_back(TypeUtils::getDataTypeSize(NODE), false);
-    RowLayout rowLayout(fields);
+TEST_F(RowCollectionTest, AppendAndReadOneRowAtATime) {
+    // Prepare the rowCollection and vector B1 (flat), A2(unflat)
+    RowLayout rowLayout({{NODE, TypeUtils::getDataTypeSize(NODE), false /* isVectorOverflow */},
+        {INT64, sizeof(overflow_value_t), true /* isVectorOverflow */}});
     auto rowCollection = make_unique<RowCollection>(*memoryManager, rowLayout);
-    resultSet->dataChunks[1]->state->currIdx = 0; // Flat dataChunks[1], only append dataChunks[0]
-    vector<shared_ptr<ValueVector>> vectorsToAppend;
-    vectorsToAppend.push_back(resultSet->dataChunks[0]->valueVectors[0]);
-    vectorsToAppend.push_back(resultSet->dataChunks[0]->valueVectors[1]);
-    rowCollection->append(vectorsToAppend, 100);
+    resultSet->dataChunks[1]->state->currIdx = 0;
+    vector<shared_ptr<ValueVector>> vectorsToAppend = {
+        resultSet->dataChunks[1]->valueVectors[0], resultSet->dataChunks[0]->valueVectors[1]};
 
-    vector<DataPos> readDataPos;
-    readDataPos.emplace_back(0, 0);
-    readDataPos.emplace_back(0, 1);
-    auto readResultSet = initResultSet();
-    auto vectorA1 = resultSet->dataChunks[0]->valueVectors[0];
-    auto vectorA2 = resultSet->dataChunks[0]->valueVectors[1];
-    readResultSet->dataChunks[0]->state->currIdx = -1;
-    // Read from the first row.
-    vector<uint64_t> fieldIdsToScan{0, 1};
-    auto numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 0, 100);
-    ASSERT_EQ(numRowsRead, 100);
-    ASSERT_EQ(readResultSet->dataChunks[0]->state->selectedSize, 100);
-    auto vectorA1Data = (nodeID_t*)vectorA1->values;
-    auto vectorA2Data = (int64_t*)vectorA2->values;
+    // Append B1, A2 to the rowCollection where B1 is an unflat valueVector and A2 is a flat
+    // valueVector. The first column in the rowCollection stores the values of B1, and the second
+    // column stores the overflow pointer to an overflow buffer which contains the values of A2.
     for (auto i = 0u; i < 100; i++) {
-        ASSERT_EQ(vectorA1Data[i].label, 18);
-        ASSERT_EQ(vectorA1Data[i].offset, (uint64_t)i);
-        ASSERT_EQ(vectorA2Data[i], i * 2);
+        rowCollection->append(vectorsToAppend, 1);
+        resultSet->dataChunks[1]->state->currIdx++;
     }
-    // Read from the middle.
-    numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 50, 50);
-    ASSERT_EQ(numRowsRead, 50);
-    // Read from the last row.
-    numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 100, 0);
-    ASSERT_EQ(numRowsRead, 0);
+
+    // Prepare the valueVectors where B1 is flat and A2 is unflat. We will read the first column to
+    // B1, and the second column to A2.
+    vector<DataPos> readDataPos = {{1, 0}, {0, 1}};
+    auto readResultSet = initResultSet();
+    readResultSet->dataChunks[0]->state->currIdx = -1;
+    readResultSet->dataChunks[1]->state->currIdx = 0;
+    auto vectorB1 = readResultSet->dataChunks[1]->valueVectors[0];
+    auto vectorB1Data = (nodeID_t*)vectorB1->values;
+
+    for (auto i = 0u; i < 100; i++) {
+        // Since A2 is an overflow column, we can only read one row from rowCollection at a time.
+        auto numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, i, 1);
+        ASSERT_EQ(numRowsRead, 1);
+        ASSERT_EQ(readResultSet->dataChunks[0]->state->selectedSize, 100);
+        ASSERT_EQ(readResultSet->dataChunks[1]->state->selectedSize, 1);
+        if (i % 10) {
+            ASSERT_EQ(vectorB1->isNull(i), false);
+            ASSERT_EQ(vectorB1Data[vectorB1->state->currIdx].label, 28);
+            ASSERT_EQ(vectorB1Data[vectorB1->state->currIdx].offset, (uint64_t)i);
+        } else {
+            ASSERT_EQ(vectorB1->isNull(i), true);
+        }
+        checkA2OverflowValuesAndNulls(readResultSet->dataChunks[0]->valueVectors[1]);
+        readResultSet->dataChunks[1]->state->currIdx++;
+    }
 }
 
-TEST_F(RowCollectionTest, TestDataChunksWithVectorOverflows) {
-    auto memoryManager = make_unique<MemoryManager>();
-    vector<FieldInLayout> fields;
-    fields.emplace_back(TypeUtils::getDataTypeSize(NODE), false);
-    fields.emplace_back(TypeUtils::getDataTypeSize(NODE), true);
-    RowLayout rowLayout(fields);
+TEST_F(RowCollectionTest, AppendMultipleRowsReadOneAtAtime) {
+    // Prepare the append rowCollection and unflat vectors (B1, A2).
+    RowLayout rowLayout({{NODE, TypeUtils::getDataTypeSize(NODE), false /* isVectorOverflow */},
+        {INT64, sizeof(overflow_value_t), true /* isVectorOverflow */}});
     auto rowCollection = make_unique<RowCollection>(*memoryManager, rowLayout);
-    resultSet->dataChunks[0]->state->currIdx = 10;
-    resultSet->dataChunks[1]->state->currIdx = -1;
-    vector<shared_ptr<ValueVector>> vectorsToAppend;
-    vectorsToAppend.push_back(resultSet->dataChunks[0]->valueVectors[0]);
-    vectorsToAppend.push_back(resultSet->dataChunks[1]->valueVectors[0]);
-    rowCollection->append(vectorsToAppend, 1);
+    vector<shared_ptr<ValueVector>> vectorsToAppend = {
+        resultSet->dataChunks[0]->valueVectors[0], resultSet->dataChunks[0]->valueVectors[1]};
 
-    vector<DataPos> readDataPos;
-    readDataPos.emplace_back(0, 0);
-    readDataPos.emplace_back(1, 0);
+    // The first column in the rowCollection stores the values of B1, and the second column stores
+    // the same valuePtr which points to the overflow buffer of A2
+    rowCollection->append(vectorsToAppend, 100);
+
+    // Prepare the valueVectors where B1 and A2 are both unflat. We will read the first column to
+    // B1, and the second column to A2.
+    vector<DataPos> readDataPos = {{1, 0}, {0, 1}};
     auto readResultSet = initResultSet();
+    auto vectorB1 = readResultSet->dataChunks[1]->valueVectors[0];
+    auto vectorB1Data = (nodeID_t*)vectorB1->values;
+
+    for (auto i = 0u; i < 100; i++) {
+        // Since A2 is an overflow column, we can only read one row from rowCollection at a time.
+        auto numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, i, 1);
+        ASSERT_EQ(numRowsRead, 1);
+        ASSERT_EQ(readResultSet->dataChunks[0]->state->selectedSize, 100);
+        ASSERT_EQ(readResultSet->dataChunks[1]->state->selectedSize, 1);
+        // Since we only read one row at a time, we can only read one value from the nonOverflow
+        // column
+        if (i % 15) {
+            ASSERT_EQ(vectorB1->isNull(0), false);
+            ASSERT_EQ(vectorB1Data[0].label, 18);
+            ASSERT_EQ(vectorB1Data[0].offset, (uint64_t)i);
+        } else {
+            ASSERT_EQ(vectorB1->isNull(0), true);
+        }
+        checkA2OverflowValuesAndNulls(readResultSet->dataChunks[0]->valueVectors[1]);
+    }
+}
+
+TEST_F(RowCollectionTest, AppendMultipleRowsReadMultipleRowsWithOverflows) {
+    auto rowCollection = appendMultipleRows(false /* isAppendFlatVectorToOverFlowCol */);
+
+    // Prepare the read valueVectors where A1 is flat and B1 is unflat.
+    vector<DataPos> readDataPos = {{0, 0}, {1, 0}};
+    auto readResultSet = initResultSet();
+    readResultSet->dataChunks[0]->state->currIdx = 0;
     auto vectorA1 = readResultSet->dataChunks[0]->valueVectors[0];
     auto vectorB1 = readResultSet->dataChunks[1]->valueVectors[0];
-    readResultSet->dataChunks[0]->state->currIdx = 0;
-    readResultSet->dataChunks[1]->state->currIdx = -1;
-    vector<uint64_t> fieldIdsToScan{0, 1};
-    // Read from the first row.
+    auto vectorB1Data = (nodeID_t*)vectorB1->values;
+
+    // If there is an overflow column, and we are trying to read more than one row,
+    // the scan function will just read one row from the rowCollection instead of 100 rows.
+    // A1 will only contain one element, and B1 will contain 100 elements since B1 is an overflow
+    // column.
     auto numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 0, 100);
     ASSERT_EQ(numRowsRead, 1);
+    ASSERT_EQ(readResultSet->dataChunks[0]->state->selectedSize, 1);
     ASSERT_EQ(readResultSet->dataChunks[1]->state->selectedSize, 100);
-    auto vectorA1Data = (nodeID_t*)vectorA1->values;
-    auto vectorB1Data = (nodeID_t*)vectorB1->values;
-    ASSERT_EQ(vectorA1Data[0].label, 18);
-    ASSERT_EQ(vectorA1Data[0].offset, (uint64_t)10);
+    ASSERT_EQ(vectorA1->isNull(0), true);
     for (auto i = 0u; i < 100; i++) {
-        ASSERT_EQ(vectorB1Data[i].label, 28);
-        ASSERT_EQ(vectorB1Data[i].offset, (uint64_t)(i));
+        if (i % 10) {
+            ASSERT_EQ(vectorB1->isNull(i), false);
+            ASSERT_EQ(vectorB1Data[i].label, 28);
+            ASSERT_EQ(vectorB1Data[i].offset, (uint64_t)(i));
+        } else {
+            ASSERT_EQ(vectorB1->isNull(i), true);
+        }
     }
-    // Read from the last row.
-    numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 100, 0);
-    ASSERT_EQ(numRowsRead, 0);
 }
 
-TEST_F(RowCollectionTest, TestFlatAndUnFlatDataChunk) {
-    auto memoryManager = make_unique<MemoryManager>();
-    vector<FieldInLayout> fields;
-    fields.emplace_back(TypeUtils::getDataTypeSize(NODE), false);
-    fields.emplace_back(TypeUtils::getDataTypeSize(NODE), false);
-    RowLayout rowLayout(fields);
+TEST_F(RowCollectionTest, AppendMultipleRowsReadMultipleRowsNoOverflow) {
+    // Prepare the rowCollection, valueVector A1(flat) and B1(unflat)
+    RowLayout rowLayout({{NODE, TypeUtils::getDataTypeSize(NODE), false /* isVectorOverflow */},
+        {NODE, TypeUtils::getDataTypeSize(NODE), false /* isVectorOverflow */}});
     auto rowCollection = make_unique<RowCollection>(*memoryManager, rowLayout);
     resultSet->dataChunks[0]->state->currIdx = 10;
-    resultSet->dataChunks[1]->state->currIdx = -1;
-    vector<shared_ptr<ValueVector>> vectorsToAppend;
-    vectorsToAppend.push_back(resultSet->dataChunks[0]->valueVectors[0]);
-    vectorsToAppend.push_back(resultSet->dataChunks[1]->valueVectors[0]);
+    vector<shared_ptr<ValueVector>> vectorsToAppend = {
+        resultSet->dataChunks[0]->valueVectors[0], resultSet->dataChunks[1]->valueVectors[0]};
+
+    // The valueVectorA1 will be replicated 100 times, since B1 is unflat and not overflow
     rowCollection->append(vectorsToAppend, 100);
 
-    vector<DataPos> readDataPos;
-    readDataPos.emplace_back(0, 0);
-    readDataPos.emplace_back(0, 1);
-    auto readResultSet = make_unique<ResultSet>(1);
-    auto readDataChunk = make_shared<DataChunk>(2);
-    auto vectorA1 = make_shared<ValueVector>(nullptr, NODE, false);
-    auto vectorA2 = make_shared<ValueVector>(nullptr, NODE, false);
-    readDataChunk->insert(0, vectorA1);
-    readDataChunk->insert(1, vectorA2);
-    readResultSet->insert(0, readDataChunk);
-    readResultSet->dataChunks[0]->state->currIdx = -1;
-    vector<uint64_t> fieldIdsToScan{0, 1};
-    // Read from the first row.
+    // Prepare the rowCollection where both A1 and B1 are unflat because we will read multiple rows
+    // from rowCollection
+    vector<DataPos> readDataPos = {{0, 0}, {1, 0}};
+    auto readResultSet = initResultSet();
+    auto vectorB1 = readResultSet->dataChunks[1]->valueVectors[0];
+    auto vectorA1Data = (nodeID_t*)readResultSet->dataChunks[0]->valueVectors[0]->values;
+    auto vectorB1Data = (nodeID_t*)vectorB1->values;
+
+    // we can read multiple rows at a time if the read vectors are unflat, and there is no overflow
+    // column to read
     auto numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 0, 100);
     ASSERT_EQ(numRowsRead, 100);
     ASSERT_EQ(readResultSet->dataChunks[0]->state->selectedSize, 100);
-    auto vectorA1Data = (nodeID_t*)vectorA1->values;
-    auto vectorA2Data = (nodeID_t*)vectorA2->values;
+    ASSERT_EQ(readResultSet->dataChunks[1]->state->selectedSize, 100);
     for (auto i = 0u; i < 100; i++) {
-        ASSERT_EQ(vectorA1Data[0].label, 18);
-        ASSERT_EQ(vectorA1Data[0].offset, (uint64_t)10);
-        ASSERT_EQ(vectorA2Data[i].label, 28);
-        ASSERT_EQ(vectorA2Data[i].offset, (uint64_t)(i));
+        // A1 data is duplicated 100 times during append, so each entry of A1 is exactly the same
+        ASSERT_EQ(vectorA1Data[i].label, 18);
+        ASSERT_EQ(vectorA1Data[i].offset, (uint64_t)10);
+        if (i % 10) {
+            ASSERT_EQ(vectorB1->isNull(i), false);
+            ASSERT_EQ(vectorB1Data[i].label, 28);
+            ASSERT_EQ(vectorB1Data[i].offset, (uint64_t)(i));
+        } else {
+            ASSERT_EQ(vectorB1->isNull(i), true);
+        }
     }
-    // Read from the last row.
-    numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 100, 0);
-    ASSERT_EQ(numRowsRead, 0);
+}
+
+TEST_F(RowCollectionTest, AppendFlatVectorToOverflowColFails) {
+    // Users are not allowed to append a flat vector to an overflow column
+    try {
+        appendMultipleRows(true /* isAppendFlatVectorToOverFlowCol */);
+        FAIL();
+    } catch (RowCollectionException& e) {
+        ASSERT_STREQ(e.what(), "RowCollection exception: Append an unflat vector to an overflow "
+                               "column is not allowed!");
+    } catch (exception& e) { FAIL(); }
+}
+
+TEST_F(RowCollectionTest, ReadOverflowColToFlatVectorFails) {
+    // The first column is not overflow, the second column is an overflow column.
+    auto rowCollection = appendMultipleRows(false /* isAppendFlatVectorToOverFlowCol */);
+
+    // Prepare the read valueVector where A1 is unflat and B1 is flat
+    auto readResultSet = initResultSet();
+    vector<DataPos> readDataPos = {{0, 0}, {1, 0}};
+    readResultSet->dataChunks[1]->state->currIdx = 0;
+
+    // Users are not allowed to read an overflow column to a flat valueVector
+    try {
+        auto numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 0, 100);
+        FAIL();
+    } catch (RowCollectionException& e) {
+        ASSERT_STREQ(e.what(), "RowCollection exception: Read an overflow column to a flat "
+                               "valueVector is not allowed!");
+    } catch (exception& e) { FAIL(); }
 }


### PR DESCRIPTION
 To represent the null values in RowCollection, we use a bitmap to represent the null fields in each row
1. For overflow columns, we use a large bitmap to represent the nulls in the whole overflow columns and stores it at the end of the overflow memory.
2. For all other columns, we just store a bitmap at the end of each row.

For example:
we have 3 columns: a1   a2(overflow)   a3 = (1   [null,4,6,7]  null)     

                       
Since the 3rd column is a null value, we set the 3rd bit(from right to left) of the first byte to 1.
The memory of the row Collection looks like: 
1  overflowPtrToA2  0 nullMap:4(00000100).

Since the 1st element in the overflow column is a null value, we set the 1st bit(from right to left) of the first byte to 1.
The overflow column memory looks like: 
3 4 6 0 nullMap:1(00000001).