### PR TITLE
refactor orderby to use rowCollection

### DIFF
--- a/src/processor/include/physical_plan/operator/order_by/order_by_key_encoder.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_key_encoder.h
@@ -10,6 +10,7 @@
 #include "src/common/include/types.h"
 #include "src/common/include/utils.h"
 #include "src/common/include/vector/value_vector.h"
+#include "src/processor/include/physical_plan/result/row_collection.h"
 
 using namespace std;
 using namespace graphflow::common;
@@ -33,15 +34,21 @@ class OrderByKeyEncoder {
 
 public:
     explicit OrderByKeyEncoder(vector<shared_ptr<ValueVector>>& orderByVectors,
-        vector<bool>& isAscOrder, MemoryManager& memoryManager)
+        vector<bool>& isAscOrder, MemoryManager& memoryManager, uint16_t threadID)
         : curBlockUsedEntries{0}, memoryManager{memoryManager}, orderByVectors{orderByVectors},
-          isAscOrder{isAscOrder}, entrySize{getEntrySize(orderByVectors)},
-          entriesPerBlock{SORT_BLOCK_SIZE / entrySize}, nextGlobalRowID{0} {
+          isAscOrder{isAscOrder}, nextLocalRowID{0}, threadID{threadID} {
         keyBlocks.emplace_back(memoryManager.allocateBlock(SORT_BLOCK_SIZE));
+        keyBlockEntrySizeInBytes = 0;
+        for (auto& orderByVector : orderByVectors) {
+            keyBlockEntrySizeInBytes += getEncodingSize(orderByVector->dataType);
+        }
+        // 6 bytes for rowID and 2 bytes for threadID
+        keyBlockEntrySizeInBytes += 8;
+        entriesPerBlock = SORT_BLOCK_SIZE / keyBlockEntrySizeInBytes;
         if (entriesPerBlock <= 0) {
             throw EncodingException(StringUtils::string_format(
-                "EntrySize(%d bytes) is larger than the SORT_BLOCK_SIZE(%d bytes)", entrySize,
-                SORT_BLOCK_SIZE));
+                "EntrySize(%d bytes) is larger than the SORT_BLOCK_SIZE(%d bytes)",
+                keyBlockEntrySizeInBytes, SORT_BLOCK_SIZE));
         }
     }
 
@@ -49,9 +56,37 @@ public:
 
     inline vector<unique_ptr<MemoryBlock>>& getKeyBlocks() { return keyBlocks; }
 
-    static uint64_t getEncodingSize(DataType dataType);
+    inline vector<bool>& getIsAscOrder() { return isAscOrder; }
 
-    static uint64_t getEntrySize(vector<shared_ptr<ValueVector>>& keys);
+    inline vector<shared_ptr<ValueVector>>& getOrderByVectors() { return orderByVectors; }
+
+    inline uint64_t getKeyBlockEntrySizeInBytes() const { return keyBlockEntrySizeInBytes; }
+
+    inline uint64_t getEntriesPerBlock() const { return entriesPerBlock; }
+
+    inline uint64_t getCurBlockUsedEntries() const { return curBlockUsedEntries; }
+
+    static inline uint64_t getEncodedRowIDSizeInBytes() {
+        return sizeof(nextLocalRowID) - sizeof(threadID);
+    }
+
+    static inline uint64_t getEncodedRowID(const uint8_t* rowInfoBuffer) {
+        uint64_t encodedRowID = 0;
+        // Only the lower 6 bytes are used for localRowID.
+        memcpy(&encodedRowID, rowInfoBuffer, getEncodedRowIDSizeInBytes());
+        return encodedRowID;
+    }
+
+    static inline uint64_t getEncodedThreadID(const uint8_t* rowInfoBuffer) {
+        uint16_t encodedThreadID = 0;
+        // The lower 6 bytes are used for localRowID, only the higher two bytes are used for
+        // threadID.
+        memcpy(&encodedThreadID, rowInfoBuffer + getEncodedRowIDSizeInBytes(),
+            sizeof(encodedThreadID));
+        return encodedThreadID;
+    }
+
+    static uint64_t getEncodingSize(DataType dataType);
 
 private:
     uint8_t flipSign(uint8_t key_byte);
@@ -79,17 +114,20 @@ private:
 
     void allocateMemoryIfFull();
 
-public:
-    uint64_t curBlockUsedEntries;
-    MemoryManager& memoryManager;
-
 private:
+    MemoryManager& memoryManager;
     vector<unique_ptr<MemoryBlock>> keyBlocks;
-    vector<shared_ptr<ValueVector>> orderByVectors;
-    vector<bool> isAscOrder;
-    uint64_t entrySize;
+    uint64_t curBlockUsedEntries;
+    vector<shared_ptr<ValueVector>>& orderByVectors;
+    vector<bool>& isAscOrder;
+    uint64_t keyBlockEntrySizeInBytes;
     uint64_t entriesPerBlock;
-    uint64_t nextGlobalRowID;
+    // We only use 6 bytes to represent the nextLocalRowID, and 2 bytes to represent the threadID.
+    // Only the lower 6 bytes of nextLocalRowID are actually used, so the MAX_LOCAL_ROW_ID is
+    // 2^48-1.
+    const uint64_t MAX_LOCAL_ROW_ID = (1ull << 48) - 1;
+    uint64_t nextLocalRowID;
+    uint16_t threadID;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/result/row_collection.h
+++ b/src/processor/include/physical_plan/result/row_collection.h
@@ -125,7 +125,7 @@ public:
         return rowDataBlocks[blockId].data + rowIdInBlock * layout.numBytesPerRow;
     }
     inline vector<DataBlock>& getRowDataBlocks() { return rowDataBlocks; }
-    inline const RowLayout& getLayout() { return layout; }
+    inline const RowLayout& getLayout() const { return layout; }
     inline bool isNull(uint8_t* nullMapBuffer, uint64_t colIdx) const {
         uint32_t nullMapIdx = colIdx >> 3;
         uint8_t nullMapMask = 0x1 << (colIdx & 7); // note: &7 is the same as %8


### PR DESCRIPTION
1. Refactor orderby to use rowCollection
2. Changed the radixSort interface: 
RadixSort(MemoryManager& memoryManager, RowCollection& rowCollection, OrderByKeyEncoder& orderByKeyEncoder, vector<uint64_t>& orderByColOffsetInRowCollection). 
3. Added a test for the rowCollection which contains a payload column.