### PR TITLE
NULL NODE IDs support

### DIFF
--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -47,6 +47,11 @@ public:
         nullMask->mayContainNulls = true;
     }
 
+    inline void setAllNonNull() {
+        std::fill(nullMask->mask.get(), nullMask->mask.get() + state->originalSize, false);
+        nullMask->mayContainNulls = false;
+    }
+
     // Note that if this function returns true, there are no null. However if it returns false, it
     // doesn't mean there are nulls, i.e., there may or may not be nulls.
     inline bool hasNoNullsGuarantee() {

--- a/src/planner/include/join_order_enumerator_context.h
+++ b/src/planner/include/join_order_enumerator_context.h
@@ -44,6 +44,9 @@ public:
      * the MergedQueryGraph when all of its nodes and rels are matched
      */
     SubqueryGraph getFullyMatchedSubqueryGraph() const;
+    inline void mergeQueryGraph(const QueryGraph& queryGraph) {
+        mergedQueryGraph->merge(queryGraph);
+    }
     inline QueryGraph* getQueryGraph() { return mergedQueryGraph.get(); }
     inline const bitset<MAX_NUM_VARIABLES>& getMatchedQueryRels() const { return matchedQueryRels; }
     inline const bitset<MAX_NUM_VARIABLES>& getMatchedQueryNodes() const {

--- a/src/planner/include/logical_plan/operator/nested_loop_join/logical_left_nested_loop_join.h
+++ b/src/planner/include/logical_plan/operator/nested_loop_join/logical_left_nested_loop_join.h
@@ -8,10 +8,12 @@ namespace planner {
 class LogicalLeftNestedLoopJoin : public LogicalOperator {
 
 public:
-    LogicalLeftNestedLoopJoin(shared_ptr<LogicalOperator> subPlanLastOperator,
-        unique_ptr<Schema> subPlanSchema, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{move(prevOperator)}, subPlanLastOperator{move(subPlanLastOperator)},
-          subPlanSchema{move(subPlanSchema)} {}
+    LogicalLeftNestedLoopJoin(const shared_ptr<LogicalOperator>& subPlanLastOperator,
+        unique_ptr<Schema> subPlanSchema, vector<string> matchedNodeIDsInSubPlan,
+        shared_ptr<LogicalOperator> prevOperator)
+        : LogicalOperator{move(prevOperator)}, subPlanLastOperator{subPlanLastOperator},
+          subPlanSchema{move(subPlanSchema)}, matchedNodeIDsInSubPlan{
+                                                  move(matchedNodeIDsInSubPlan)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LOGICAL_LEFT_NESTED_LOOP_JOIN;
@@ -29,13 +31,16 @@ public:
     string getExpressionsForPrinting() const override { return string(); }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalLeftNestedLoopJoin>(
-            subPlanLastOperator->copy(), subPlanSchema->copy(), prevOperator->copy());
+        return make_unique<LogicalLeftNestedLoopJoin>(subPlanLastOperator->copy(),
+            subPlanSchema->copy(), matchedNodeIDsInSubPlan, prevOperator->copy());
     }
 
 public:
     shared_ptr<LogicalOperator> subPlanLastOperator;
     unique_ptr<Schema> subPlanSchema;
+
+    // This field is used to push property scanners on top of left nested loop join.
+    vector<string> matchedNodeIDsInSubPlan;
 };
 
 } // namespace planner

--- a/src/planner/include/property_scan_pushdown.h
+++ b/src/planner/include/property_scan_pushdown.h
@@ -18,6 +18,8 @@ private:
 
     shared_ptr<LogicalOperator> rewriteExtend(const shared_ptr<LogicalOperator>& op);
 
+    shared_ptr<LogicalOperator> rewriteLeftNestedLoopJoin(const shared_ptr<LogicalOperator>& op);
+
     shared_ptr<LogicalOperator> rewriteScanNodeProperty(const shared_ptr<LogicalOperator>& op);
 
     shared_ptr<LogicalOperator> rewriteScanRelProperty(const shared_ptr<LogicalOperator>& op);
@@ -25,7 +27,7 @@ private:
     shared_ptr<LogicalOperator> applyPropertyScansIfNecessary(
         const string& nodeID, const shared_ptr<LogicalOperator>& op);
 
-    void rewriteChildrenOperators(LogicalOperator& op);
+    void rewriteChildrenOperators(const shared_ptr<LogicalOperator>& op);
 
     void addPropertyScan(const string& nodeID, const shared_ptr<LogicalOperator>& op);
 

--- a/src/planner/join_order_enumerator_context.cpp
+++ b/src/planner/join_order_enumerator_context.cpp
@@ -12,7 +12,7 @@ void JoinOrderEnumeratorContext::init(const QueryGraph& queryGraph,
     auto fullyMatchedSubqueryGraph = getFullyMatchedSubqueryGraph();
     matchedQueryRels = fullyMatchedSubqueryGraph.queryRelsSelector;
     matchedQueryNodes = fullyMatchedSubqueryGraph.queryNodesSelector;
-    mergedQueryGraph->merge(queryGraph);
+    mergeQueryGraph(queryGraph);
     // clear and resize subPlansTable
     subPlansTable->clear();
     subPlansTable->resize(mergedQueryGraph->getNumQueryRels());

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -26,7 +26,8 @@ public:
 
 private:
     unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(
-        const shared_ptr<LogicalOperator>& lastOperator, Schema& schema, ExecutionContext& context);
+        const shared_ptr<LogicalOperator>& lastOperator, const Schema& schema,
+        ExecutionContext& context);
 
     // Returns current physicalOperatorsInfo whoever calls enterSubquery is responsible to save the
     // return physicalOperatorsInfo and pass it back when calling exitSubquery()

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -64,6 +64,11 @@ public:
 
     virtual ~PhysicalOperator() = default;
 
+    // This function grab leaf operator by traversing prevOperator pointer. For binary operators,
+    // f.g. hash join probe, left nested loop join, caller should determine which branch's leaf to
+    // get.
+    PhysicalOperator* getLeafOperator();
+
     virtual void initResultSet(const shared_ptr<ResultSet>& resultSet);
 
     // For subquery, we rerun a plan multiple times. ReInitialize() should be called before each run

--- a/src/processor/include/physical_plan/operator/sink.h
+++ b/src/processor/include/physical_plan/operator/sink.h
@@ -14,14 +14,6 @@ public:
         this->resultSet = move(resultSet);
     }
 
-    PhysicalOperator* getPipelineLeafOperator() {
-        PhysicalOperator* op = this;
-        while (op->prevOperator != nullptr) {
-            op = op->prevOperator.get();
-        }
-        return op;
-    }
-
     virtual void init() { prevOperator->initResultSet(resultSet); }
 
     // In case there is a sub-plan, the pipeline under sink might be executed repeatedly and thus

--- a/src/processor/physical_plan/operator/exists.cpp
+++ b/src/processor/physical_plan/operator/exists.cpp
@@ -14,7 +14,7 @@ void Exists::initResultSet(const shared_ptr<ResultSet>& resultSet) {
     dataChunkToWrite->insert(outDataPos.valueVectorPos, valueVectorToWrite);
     // side way information passing: give resultSet reference to subPlan
     auto subPlanResultCollector = (ResultCollector*)subPlan->lastOperator.get();
-    auto op = subPlanResultCollector->getPipelineLeafOperator();
+    auto op = subPlanResultCollector->getLeafOperator();
     assert(op->operatorType == SELECT_SCAN);
     ((ResultScan*)op)->setResultSetToCopyFrom(this->resultSet.get());
     subPlanResultCollector->init();

--- a/src/processor/physical_plan/operator/physical_operator.cpp
+++ b/src/processor/physical_plan/operator/physical_operator.cpp
@@ -11,6 +11,14 @@ PhysicalOperator::PhysicalOperator(unique_ptr<PhysicalOperator> prevOperator,
     registerProfilingMetrics();
 }
 
+PhysicalOperator* PhysicalOperator::getLeafOperator() {
+    PhysicalOperator* op = this;
+    while (op->prevOperator != nullptr) {
+        op = op->prevOperator.get();
+    }
+    return op;
+}
+
 void PhysicalOperator::initResultSet(const shared_ptr<ResultSet>& resultSet) {
     if (prevOperator != nullptr) {
         prevOperator->initResultSet(resultSet);

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -16,8 +16,14 @@ void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
 }
 
 void ReadList::readValuesFromList() {
+    auto currentIdx = inDataChunk->state->getPositionOfCurrIdx();
+    if (inValueVector->isNull(currentIdx)) {
+        outValueVector->state->setSelectedSize(0);
+        return;
+    }
     auto nodeOffset = inValueVector->readNodeOffset(inDataChunk->state->getPositionOfCurrIdx());
     lists->readValues(nodeOffset, outValueVector, largeListHandle, *metrics->bufferManagerMetrics);
+    outValueVector->setAllNonNull();
 }
 
 } // namespace processor

--- a/src/storage/include/data_structure/column.h
+++ b/src/storage/include/data_structure/column.h
@@ -30,6 +30,9 @@ protected:
     void readFromNonSequentialLocations(const shared_ptr<ValueVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector, BufferManagerMetrics& metrics);
 
+    void readForSingleNodeIDPosition(uint32_t pos, const shared_ptr<ValueVector>& nodeIDVector,
+        const shared_ptr<ValueVector>& valueVector, BufferManagerMetrics& metrics);
+
 public:
     static constexpr char COLUMN_SUFFIX[] = ".col";
 };

--- a/src/storage/include/data_structure/lists/unstructured_property_lists.h
+++ b/src/storage/include/data_structure/lists/unstructured_property_lists.h
@@ -32,9 +32,9 @@ public:
         node_offset_t nodeOffset, BufferManagerMetrics& metrics);
 
 private:
-    void readUnstrPropertyFromAList(uint32_t propertyKeyIdxToRead,
-        const shared_ptr<ValueVector>& valueVector, uint64_t pos, ListInfo& info,
-        BufferManagerMetrics& metrics);
+    void readUnstructuredPropertyForSingleNodeIDPosition(uint32_t pos,
+        const shared_ptr<ValueVector>& nodeIDVector, uint32_t propertyKeyIdxToRead,
+        const shared_ptr<ValueVector>& valueVector, BufferManagerMetrics& metrics);
 
     void readUnstrPropertyKeyIdxAndDatatype(uint8_t* propertyKeyDataType, PageByteCursor& cursor,
         uint64_t& listLen, const std::function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper,

--- a/test/runner/queries/optional/optional_match.test
+++ b/test/runner/queries/optional/optional_match.test
@@ -1,21 +1,74 @@
 # description: optional match test
 
--NAME OptionalMatchTest1
+-NAME MixedMatchStatementTest1
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) MATCH (b)-[:knows]->(c:person) RETURN COUNT(*)
+---- 1
+36
+
+-NAME MixedMatchStatementTest2
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) MATCH (b)-[:studyAt]->(c:organisation) RETURN COUNT(*)
+---- 1
+7
+
+-NAME MixedMatchStatementTest3
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) WHERE b.fName='Farooq' MATCH (b)<-[:knows]-(c:person) RETURN COUNT(*)
+---- 1
+1
+
+-NAME MixedMatchStatementHashJoinTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) OPTIONAL MATCH (b)-[:knows]->(c:person) MATCH (c)-[:knows]->(d:person)-[:knows]->(e:person) RETURN COUNT(*)
+---- 1
+324
+
+-NAME OptionalReadStringPropertyTest
+-QUERY MATCH (a:person) WHERE a.fName='Elizabeth' OR a.fName='Hubert Blaine Wolfeschlegelsteinhausenbergerdorff' OPTIONAL MATCH (a)-[:knows]->(b:person) RETURN a.fName, b.fName
+---- 3
+Elizabeth|Farooq
+Elizabeth|Greg
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
+
+
+-NAME OptionalReadUnstrPropertyTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Elizabeth' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.unstrNumericProp
+---- 2
+
+-12.500000
+
+-NAME OptionalReturnTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Alice' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.orgCode
+---- 3
+
+
+325
+
+-NAME OptionalReturnTest2
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) WHERE b.fName='Farooq' RETURN a.fName, b.fName
+---- 8
+Alice|
+Bob|
+Carol|
+Dan|
+Elizabeth|Farooq
+Farooq|
+Greg|
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
+
+-NAME OptionalListExtendCountTest
 -QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) RETURN COUNT(*)
 ---- 1
 17
 
--NAME OptionalMatchTest2
--QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:studyAt]->(b:organisation) RETURN COUNT(*)
+-NAME OptionalListExtendTest2
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person)-[:knows]->(c:person) RETURN COUNT(*)
+---- 1
+40
+
+-NAME OptionalColExtendTest
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:workAt]->(b:organisation) RETURN COUNT(*)
 ---- 1
 8
 
--NAME OptionalMatchTest3
+-NAME MultipleOptionalCountTest
 -QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) OPTIONAL MATCH (b)-[:knows]->(c:person) RETURN COUNT(*)
 ---- 1
 41
-
--NAME OptionalMatchTest2
--QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Alice' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN COUNT(*)
----- 1
-3


### PR DESCRIPTION
This PR adds processor level support on computation related to NULL NODE IDs. Changes are as following.

### Changes related to NULL ID reading
#### StructuredPropertyScanner, ColumnExtend(Column) and UnstructuredPropertyScanner (UnstructuredPropertyList)
If input NODE ID at position "i" is NULL, we set NULL mask to true at position "i" for result vector.
#### AdjListExtend
if input NODE ID is NULL, pull another tuple.
#### ResultScan
If input vector is NULL, update result vector null mask.
#### HashJoin
Build: only build hash key that is not NULL.
Probe: only probe hash key that is not NULL.

### Other changes
#### Property Push Down
Push property scanners corresponding to a NODE ID that is scanned in subquery on top of LeftNestedLoopJoin operator.
#### Physical LeftNestedLoopJoin
Remove Sink operator from subplan (which was a wrong design). Current logic is, keep pulling from sub plan if there is more to read, otherwise pull a new tuple from outer plan.