### PR TITLE
refactor gf_string_t comparison functions

### DIFF
--- a/src/common/gf_string.cpp
+++ b/src/common/gf_string.cpp
@@ -5,6 +5,30 @@
 namespace graphflow {
 namespace common {
 
+bool gf_string_t::operator==(const gf_string_t& rhs) const {
+    // First compare the length and prefix of the strings.
+    if (!memcmp(this, &rhs, gf_string_t::STR_LENGTH_PLUS_PREFIX_LENGTH)) {
+        // If length and prefix of a and b are equal, we compare the overflow buffer.
+        return !memcmp(getData(), rhs.getData(), len);
+    }
+    return false;
+}
+
+bool gf_string_t::operator>(const gf_string_t& rhs) const {
+    // Compare gf_string_t up to the shared length.
+    // If there is a tie, we just need to compare the string lengths.
+    auto sharedLen = min(len, rhs.len);
+    auto memcmpResult = memcmp(prefix, rhs.prefix,
+        sharedLen <= gf_string_t::PREFIX_LENGTH ? sharedLen : gf_string_t::PREFIX_LENGTH);
+    if (memcmpResult == 0 && len > gf_string_t::PREFIX_LENGTH) {
+        memcmpResult = memcmp(getData(), rhs.getData(), sharedLen);
+    }
+    if (memcmpResult == 0) {
+        return len > rhs.len;
+    }
+    return memcmpResult > 0;
+}
+
 void gf_string_t::setOverflowPtrInfo(const uint64_t& pageIdx, const uint16_t& pageOffset) {
     memcpy(&overflowPtr, &pageIdx, 6);
     memcpy(((uint8_t*)&overflowPtr) + 6, &pageOffset, 2);

--- a/src/common/include/gf_string.h
+++ b/src/common/include/gf_string.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 #include <string>
 
 using namespace std;
@@ -32,6 +33,18 @@ struct gf_string_t {
     inline const uint8_t* getData() const {
         return len <= SHORT_STR_LENGTH ? prefix : reinterpret_cast<uint8_t*>(overflowPtr);
     }
+
+    bool operator==(const gf_string_t& rhs) const;
+
+    inline bool operator!=(const gf_string_t& rhs) const { return !(*this == rhs); }
+
+    bool operator>(const gf_string_t& rhs) const;
+
+    inline bool operator>=(const gf_string_t& rhs) const { return (*this > rhs) || (*this == rhs); }
+
+    inline bool operator<(const gf_string_t& rhs) const { return !(*this >= rhs); }
+
+    inline bool operator<=(const gf_string_t& rhs) const { return !(*this > rhs); }
 
     // This function does *NOT* allocate/resize the overflow buffer, it only copies the content and
     // set the length.

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -190,55 +190,6 @@ inline void NotEquals::operation(
     EqualsOrNotEqualsValues::operation<false>(left, right, result, isLeftNull, isRightNul);
 };
 
-// Equals and NotEquals function for gf_string_t.
-struct StringComparisonOperators {
-    template<bool equals>
-    static inline void EqualsOrNot(
-        const gf_string_t& left, const gf_string_t& right, uint8_t& result) {
-        // first compare the length and prefix of the strings.
-        if (memcmp(&left, &right, gf_string_t::STR_LENGTH_PLUS_PREFIX_LENGTH) == 0) {
-            // length and prefix of a and b are equal.
-            if (memcmp(left.getData(), right.getData(), left.len) == 0) {
-                result = equals ? TRUE : FALSE;
-                return;
-            }
-        }
-        result = equals ? FALSE : TRUE;
-    }
-
-    // compare gf_string_t up to shared length. if still the same, Compare lengths.
-    template<class FUNC>
-    static void Compare(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
-        bool isLeftNull, bool isRightNul) {
-        auto len = left.len < right.len ? left.len : right.len;
-        auto memcmpResult = memcmp(left.prefix, right.prefix,
-            len <= gf_string_t::PREFIX_LENGTH ? len : gf_string_t::PREFIX_LENGTH);
-        if (memcmpResult == 0 && len > gf_string_t::PREFIX_LENGTH) {
-            memcmpResult = memcmp(left.getData(), right.getData(), len);
-        }
-        if (memcmpResult == 0) {
-            FUNC::operation(left.len, right.len, result, isLeftNull, isRightNul);
-        } else {
-            FUNC::operation(memcmpResult, 0, result, isLeftNull, isRightNul);
-        }
-    };
-};
-
-// specialized for gf_string_t.
-template<>
-inline void Equals::operation(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
-    bool isLeftNull, bool isRightNull) {
-    assert(!isLeftNull && !isRightNull);
-    StringComparisonOperators::EqualsOrNot<true>(left, right, result);
-};
-
-template<>
-inline void NotEquals::operation(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
-    bool isLeftNull, bool isRightNull) {
-    assert(!isLeftNull && !isRightNull);
-    StringComparisonOperators::EqualsOrNot<false>(left, right, result);
-};
-
 // specialized for nodeID_t.
 template<>
 inline void Equals::operation(const nodeID_t& left, const nodeID_t& right, uint8_t& result,
@@ -344,32 +295,6 @@ inline void LessThan::operation(
     const uint8_t& left, const uint8_t& right, uint8_t& result, bool isLeftNull, bool isRightNull) {
     assert(!isLeftNull && !isRightNull);
     result = !left && right;
-};
-
-// specialized for gf_string_t.
-template<>
-inline void GreaterThan::operation(const gf_string_t& left, const gf_string_t& right,
-    uint8_t& result, bool isLeftNull, bool isRightNul) {
-    StringComparisonOperators::Compare<GreaterThan>(left, right, result, isLeftNull, isRightNul);
-};
-
-template<>
-inline void GreaterThanEquals::operation(const gf_string_t& left, const gf_string_t& right,
-    uint8_t& result, bool isLeftNull, bool isRightNul) {
-    StringComparisonOperators::Compare<GreaterThanEquals>(
-        left, right, result, isLeftNull, isRightNul);
-};
-
-template<>
-inline void LessThan::operation(const gf_string_t& left, const gf_string_t& right, uint8_t& result,
-    bool isLeftNull, bool isRightNul) {
-    StringComparisonOperators::Compare<LessThan>(left, right, result, isLeftNull, isRightNul);
-};
-
-template<>
-inline void LessThanEquals::operation(const gf_string_t& left, const gf_string_t& right,
-    uint8_t& result, bool isLeftNull, bool isRightNul) {
-    StringComparisonOperators::Compare<LessThanEquals>(left, right, result, isLeftNull, isRightNul);
 };
 
 // specialized for nodeID_t.


### PR DESCRIPTION
Moved gf_string_t comparision functions from the 'comparison_operations.h' to the 'gf_string.h' file.
