### PR TITLE
Add validation for empty query, group by clause and optional match

### DIFF
--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -60,12 +60,18 @@ private:
     label_t bindNodeLabel(const string& parsed_label);
 
     /******* validations *********/
-
+    // E.g. Optional MATCH (a) RETURN a.age
+    // Although this is doable in Neo4j, I don't think the semantic make a lot of sense because
+    // there is nothing to left join on.
+    void validateFirstMatchIsNotOptional(const SingleQuery& singleQuery);
     // E.g. MATCH (:person)-[:studyAt]->(:person)
     void validateNodeAndRelLabelIsConnected(
         label_t relLabel, label_t nodeLabel, Direction direction);
     // E.g. RETURN a, b AS a
     void validateProjectionColumnNamesAreUnique(const vector<shared_ptr<Expression>>& expressions);
+    // E.g. RETURN a, b, COUNT(*)
+    // Note: this validation should be removed once we have group by implemented.
+    void validateAggregationsHaveNoGroupBy(const vector<shared_ptr<Expression>>& expressions);
     void validateQueryGraphIsConnected(const QueryGraph& queryGraph,
         unordered_map<string, shared_ptr<Expression>> prevVariablesInScope);
     uint64_t validateAndExtractSkipLimitNumber(const ParsedExpression& skipOrLimitExpression);

--- a/src/common/include/utils.h
+++ b/src/common/include/utils.h
@@ -22,7 +22,7 @@ struct charArrayHasher {
 class LoggerUtils {
 
 public:
-    static shared_ptr<spdlog::logger> getOrCreateSpdLogger(string loggerName) {
+    static shared_ptr<spdlog::logger> getOrCreateSpdLogger(const string& loggerName) {
         shared_ptr<spdlog::logger> logger = spdlog::get(loggerName);
         if (!logger) {
             logger = spdlog::stdout_logger_mt(loggerName);

--- a/src/main/include/system.h
+++ b/src/main/include/system.h
@@ -27,6 +27,7 @@ public:
     unique_ptr<nlohmann::json> debugInfo() const;
 
 public:
+    shared_ptr<spdlog::logger> logger;
     unique_ptr<Graph> graph;
     unique_ptr<QueryProcessor> processor;
     unique_ptr<MemoryManager> memManager;

--- a/src/main/system.cpp
+++ b/src/main/system.cpp
@@ -12,7 +12,8 @@ using namespace graphflow::planner;
 namespace graphflow {
 namespace main {
 
-System::System(const string& path, bool isInMemoryMode) {
+System::System(const string& path, bool isInMemoryMode)
+    : logger{LoggerUtils::getOrCreateSpdLogger("System")} {
     memManager = make_unique<MemoryManager>();
     bufferManager =
         make_unique<BufferManager>(isInMemoryMode ? 0 : StorageConfig::DEFAULT_BUFFER_POOL_SIZE);
@@ -26,6 +27,11 @@ void System::executeQuery(SessionContext& context) const {
         throw invalid_argument("System is not initialized");
     }
     context.clear();
+
+    if (context.query.empty()) {
+        logger->warn("Empty query input.");
+        return;
+    }
 
     auto parsedQuery = Parser::parseQuery(context.query);
     context.enable_explain = parsedQuery->enable_explain;

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -33,6 +33,9 @@ cc_library(
 
 cc_library(
     name = "parsed_queries",
+    srcs = glob([
+        "queries/*.cpp",
+    ]),
     hdrs = glob([
         "include/queries/*.h",
     ]),

--- a/src/parser/include/queries/query_part.h
+++ b/src/parser/include/queries/query_part.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <cassert>
+
 #include "src/parser/include/statements/match_statement.h"
 #include "src/parser/include/statements/with_statement.h"
 
@@ -14,6 +16,13 @@ class QueryPart {
 public:
     explicit QueryPart(unique_ptr<WithStatement> withStatement)
         : withStatement{move(withStatement)} {}
+
+    inline bool hasMatchStatement() const { return !matchStatements.empty(); }
+
+    inline MatchStatement* getFirstMatchStatement() const {
+        assert(hasMatchStatement());
+        return matchStatements[0].get();
+    }
 
 public:
     vector<unique_ptr<MatchStatement>> matchStatements;

--- a/src/parser/include/queries/single_query.h
+++ b/src/parser/include/queries/single_query.h
@@ -11,6 +11,11 @@ namespace parser {
 class SingleQuery {
 
 public:
+    bool hasMatchStatement() const;
+
+    MatchStatement* getFirstMatchStatement() const;
+
+public:
     vector<unique_ptr<QueryPart>> queryParts;
     vector<unique_ptr<MatchStatement>> matchStatements;
     unique_ptr<ReturnStatement> returnStatement;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -16,11 +16,13 @@ unique_ptr<SingleQuery> Parser::parseQuery(const string& query) {
     auto parserErrorListener = ParserErrorListener();
 
     auto cypherLexer = CypherLexer(&inputStream);
+    cypherLexer.removeErrorListeners();
     cypherLexer.addErrorListener(&parserErrorListener);
     auto tokens = CommonTokenStream(&cypherLexer);
     tokens.fill();
 
     auto graphflowCypherParser = GraphflowCypherParser(&tokens);
+    graphflowCypherParser.removeErrorListeners();
     graphflowCypherParser.addErrorListener(&parserErrorListener);
     graphflowCypherParser.setErrorHandler(make_shared<ParserErrorStrategy>());
 

--- a/src/parser/queries/single_query.cpp
+++ b/src/parser/queries/single_query.cpp
@@ -1,0 +1,26 @@
+#include "src/parser/include/queries/single_query.h"
+
+namespace graphflow {
+namespace parser {
+
+bool SingleQuery::hasMatchStatement() const {
+    for (auto& queryPart : queryParts) {
+        if (queryPart->hasMatchStatement()) {
+            return true;
+        }
+    }
+    return !matchStatements.empty();
+}
+
+MatchStatement* SingleQuery::getFirstMatchStatement() const {
+    assert(hasMatchStatement());
+    for (auto& queryPart : queryParts) {
+        if (queryPart->hasMatchStatement()) {
+            return queryPart->getFirstMatchStatement();
+        }
+    }
+    return matchStatements[0].get();
+}
+
+} // namespace parser
+} // namespace graphflow

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -168,3 +168,15 @@ TEST_F(BinderErrorTest, NestedAggregation) {
     auto input = "MATCH (a:person) RETURN SUM(SUM(a.age));";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
+
+TEST_F(BinderErrorTest, OptionalMatchAsFirstMatch) {
+    string expectedException = "First match statement cannot be optional match.";
+    auto input = "OPTIONAL MATCH (a:person) RETURN *;";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, AggregationWithGroupBy) {
+    string expectedException = "Aggregations with group by is not supported.";
+    auto input = "MATCH (a:person) RETURN a, COUNT(*);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -255,6 +255,9 @@ void EmbeddedShell::prettyPrintPlan() {
 }
 
 void EmbeddedShell::printExecutionResult() {
+    if (!context.queryResult) { // empty query result
+        return;
+    }
     if (context.enable_explain) {
         prettyPrintPlan();
     } else {


### PR DESCRIPTION
This PR add validations for unsupported features and edge cases

- Validate empty query input (issue #417)
- Validate aggregation with group by (issue #419)
- Validate optional match as the first match statement