### PR TITLE
fix expression rewriting for star in projection enumerator

### DIFF
--- a/src/main/system.cpp
+++ b/src/main/system.cpp
@@ -43,6 +43,9 @@ void System::executeQuery(SessionContext& context) const {
     auto boundQuery = QueryBinder(graph->getCatalog()).bind(*parsedQuery);
 
     auto logicalPlan = Planner::getBestPlan(*graph, *boundQuery);
+    if (logicalPlan->containAggregation && context.numThreads > 1) {
+        throw invalid_argument("Aggregation with multi-threading is not implemented.");
+    }
 
     auto executionContext = make_unique<ExecutionContext>(*context.profiler, memManager.get());
     auto mapper = PlanMapper(*graph);

--- a/src/planner/include/logical_plan/logical_plan.h
+++ b/src/planner/include/logical_plan/logical_plan.h
@@ -9,7 +9,7 @@ namespace planner {
 class LogicalPlan {
 
 public:
-    LogicalPlan() : cost{0} { schema = make_unique<Schema>(); }
+    LogicalPlan() : schema{make_unique<Schema>()}, cost{0}, containAggregation{false} {}
 
     explicit LogicalPlan(unique_ptr<Schema> schema) : schema{move(schema)}, cost{0} {}
 
@@ -24,6 +24,10 @@ public:
     shared_ptr<LogicalOperator> lastOperator;
     unique_ptr<Schema> schema;
     uint64_t cost;
+
+    // Note: this is a protection to avoid executing plan contain aggregation with multi-threading.
+    // We should remove this field when we support aggregation with multi-threading.
+    bool containAggregation;
 };
 
 } // namespace planner

--- a/src/planner/include/projection_enumerator.h
+++ b/src/planner/include/projection_enumerator.h
@@ -25,8 +25,8 @@ public:
         const vector<unique_ptr<LogicalPlan>>& plans, bool isFinalReturn);
 
 private:
-    void appendProjection(const vector<shared_ptr<Expression>>& expressions, LogicalPlan& plan,
-        bool isRewritingAllProperties);
+    void appendProjection(
+        const vector<shared_ptr<Expression>>& expressionsToProject, LogicalPlan& plan);
     void appendAggregate(const vector<shared_ptr<Expression>>& expressionsToGroupBy,
         const vector<shared_ptr<Expression>>& expressionsToAggregate, LogicalPlan& plan);
     void appendOrderBy(const vector<shared_ptr<Expression>>& expressions,
@@ -39,10 +39,11 @@ private:
         const BoundProjectionBody& projectionBody, const Schema& schema);
     vector<shared_ptr<Expression>> getExpressionsToAggregate(
         const BoundProjectionBody& projectionBody, const Schema& schema);
+    vector<shared_ptr<Expression>> getExpressionsToProject(
+        const BoundProjectionBody& projectionBody, bool isRewritingAllProperties);
     vector<shared_ptr<Expression>> rewriteVariableExpression(
         const shared_ptr<Expression>& variable, bool isRewritingAllProperties);
-    vector<shared_ptr<Expression>> rewriteNodeExpression(
-        const shared_ptr<NodeExpression>& node, bool isRewritingAllProperties);
+    vector<shared_ptr<Expression>> rewriteNodeExpression(const shared_ptr<NodeExpression>& node);
     vector<shared_ptr<Expression>> rewriteRelExpression(const shared_ptr<RelExpression>& rel);
     vector<shared_ptr<Expression>> createPropertyExpressions(
         const shared_ptr<Expression>& variable, const vector<PropertyDefinition>& properties);

--- a/src/planner/logical_plan/logical_plan.cpp
+++ b/src/planner/logical_plan/logical_plan.cpp
@@ -13,6 +13,7 @@ unique_ptr<LogicalPlan> LogicalPlan::copy() const {
     auto plan = make_unique<LogicalPlan>(schema->copy());
     plan->lastOperator = lastOperator;
     plan->cost = cost;
+    plan->containAggregation = containAggregation;
     return plan;
 }
 

--- a/test/runner/queries/projection/projection.test
+++ b/test/runner/queries/projection/projection.test
@@ -56,6 +56,13 @@
 -9.000000
 1.000000
 
+-NAME OrgNodesReturnStarTest
+-QUERY MATCH (a:organisation) RETURN *
+---- 3
+1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|48 days 23:00:00|48 days 23:00:00|-12.500000
+4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|32 years 123 days 48:00:00|26 years 52 days 48:00:00|
+6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|||-3.100000
+
 -NAME PersonNodesTestUnstructuredProperty
 -COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.ID,a.unstrDateProp1


### PR DESCRIPTION
This PR fixes expression rewriting of variable expression, including star in projection enumerator as described in issue #419 

This PR also validates multi-threading is not enabled when the plan contains aggregation. Also quick fix for issue #424.
