### PR TITLE
remove TRUE and FALSE consts, localize NULL_BOOL to bool_ops, bug fixes

### DIFF
--- a/src/common/include/literal.h
+++ b/src/common/include/literal.h
@@ -13,7 +13,7 @@ public:
 
     Literal(const Literal& other);
 
-    explicit Literal(uint8_t value) : dataType(BOOL) { this->val.booleanVal = value; }
+    explicit Literal(bool value) : dataType(BOOL) { this->val.booleanVal = value; }
 
     explicit Literal(int64_t value) : dataType(INT64) { this->val.int64Val = value; }
 
@@ -33,7 +33,7 @@ public:
 
 public:
     union Val {
-        uint8_t booleanVal;
+        bool booleanVal;
         int64_t int64Val;
         double doubleVal;
         nodeID_t nodeID;

--- a/src/common/include/operations/boolean_operations.h
+++ b/src/common/include/operations/boolean_operations.h
@@ -8,37 +8,118 @@ namespace graphflow {
 namespace common {
 namespace operation {
 
+/**
+ * The boolean operators (AND, OR, XOR, NOT) works a little differently from other operators. While
+ * other operators can operate on only non null operands, boolean operators can operate even with
+ * null operands in certain cases, for instance, Null OR True = True. Hence, the result value of
+ * the boolean operator can be True, False or Null. To accommodate for this, the dataType of result
+ * is uint8_t (that can have more than 2 values) rather than bool. In case, the result is computed
+ * to be Null based on the operands, we set result = NULL_BOOL, which should rightly be
+ * interpreted by operator executors as NULL and not as True.
+ * */
+
+/**
+ * IMPORTANT: Not to be used outside the context of boolean operators.
+ * */
+const uint8_t NULL_BOOL = 2;
+
+/**
+ * AND operator Truth table:
+ *
+ *    left      isLeftNull       right       isRightNull        result
+ *   ------    ------------     -------     -------------      --------
+ *     T            F              T              F               1
+ *     T            F              F              F               0
+ *     F            F              T              F               0
+ *     F            F              F              F               0
+ *     -            T              T              F               2
+ *     -            T              F              F               0
+ *     T            F              -              T               2
+ *     F            F              -              T               0
+ *     -            T              -              T               2
+ * */
 struct And {
     static inline void operation(
-        uint8_t left, uint8_t right, uint8_t& result, bool isLeftNull, bool isRightNull) {
-        if (left == FALSE || right == FALSE) {
-            result = FALSE;
+        bool left, bool right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        if (!left && !isLeftNull) {
+            result = false;
+        } else if (!right && !isRightNull) {
+            result = false;
+        } else if (isLeftNull || isRightNull) {
+            result = NULL_BOOL;
         } else {
-            result = isLeftNull || isRightNull ? NULL_BOOL : TRUE;
+            result = true;
         }
     }
 };
 
+/**
+ * OR operator Truth table:
+ *
+ *    left      isLeftNull       right       isRightNull        result
+ *   ------    ------------     -------     -------------      --------
+ *     T            F              T              F               1
+ *     T            F              F              F               1
+ *     F            F              T              F               1
+ *     F            F              F              F               0
+ *     -            T              T              F               1
+ *     -            T              F              F               2
+ *     T            F              -              T               1
+ *     F            F              -              T               2
+ *     -            T              -              T               2
+ * */
 struct Or {
     static inline void operation(
-        uint8_t left, uint8_t right, uint8_t& result, bool isLeftNull, bool isRightNull) {
-        if (left == TRUE || right == TRUE) {
-            result = TRUE;
+        bool left, bool right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        if (left && !isLeftNull) {
+            result = true;
+        } else if (right && !isRightNull) {
+            result = true;
+        } else if (isLeftNull || isRightNull) {
+            result = NULL_BOOL;
         } else {
-            result = isLeftNull || isRightNull ? NULL_BOOL : FALSE;
+            result = false;
         }
     }
 };
 
+/**
+ * XOR operator Truth table:
+ *
+ *    left      isLeftNull       right       isRightNull        result
+ *   ------    ------------     -------     -------------      --------
+ *     T            F              T              F               0
+ *     T            F              F              F               1
+ *     F            F              T              F               1
+ *     F            F              F              F               0
+ *     -            T              T              F               2
+ *     -            T              F              F               2
+ *     T            F              -              T               2
+ *     F            F              -              T               2
+ *     -            T              -              T               2
+ * */
 struct Xor {
     static inline void operation(
-        uint8_t left, uint8_t right, uint8_t& result, bool isLeftNull, bool isRightNull) {
-        result = (isLeftNull || isRightNull) ? NULL_BOOL : left ^ right;
+        bool left, bool right, uint8_t& result, bool isLeftNull, bool isRightNull) {
+        if (isLeftNull || isRightNull) {
+            result = NULL_BOOL;
+        } else {
+            result = left ^ right;
+        }
     }
 };
 
+/**
+ * NOT operator Truth table:
+ *
+ *    operand         isNull        right
+ *   ---------    ------------     -------
+ *       T            F              0
+ *       F            F              1
+ *       -            T              2
+ * */
 struct Not {
-    static inline void operation(uint8_t operand, bool isNull, uint8_t& result) {
+    static inline void operation(bool operand, bool isNull, uint8_t& result) {
         result = isNull ? NULL_BOOL : !operand;
     }
 };

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -161,11 +161,6 @@ struct timestamp_t {
     interval_t operator-(const timestamp_t& rhs) const;
 };
 
-const uint8_t FALSE = 0;
-const uint8_t TRUE = 1;
-
-const uint8_t NULL_BOOL = 2;
-
 enum DataType : uint8_t {
     REL = 0,
     NODE = 1,
@@ -198,7 +193,7 @@ public:
 
     static double_t convertToDouble(const char* data);
 
-    static uint8_t convertToBoolean(const char* data);
+    static bool convertToBoolean(const char* data);
 
     static size_t getDataTypeSize(DataType dataType);
 
@@ -208,9 +203,7 @@ public:
 
     static bool isNumericalType(DataType dataType);
 
-    static string toString(uint8_t boolVal) {
-        return boolVal == TRUE ? "True" : (boolVal == FALSE ? "False" : "");
-    }
+    static string toString(bool boolVal) { return boolVal ? "True" : "False"; }
 
     static string toString(int64_t val) { return to_string(val); }
 

--- a/src/common/include/value.h
+++ b/src/common/include/value.h
@@ -19,7 +19,7 @@ public:
 
     explicit Value(DataType dataType) : dataType(dataType) {}
 
-    explicit Value(uint8_t value) : dataType(BOOL) { this->val.booleanVal = value; }
+    explicit Value(bool value) : dataType(BOOL) { this->val.booleanVal = value; }
 
     explicit Value(int64_t value) : dataType(INT64) { this->val.int64Val = value; }
 
@@ -41,7 +41,7 @@ public:
 
 public:
     union Val {
-        uint8_t booleanVal;
+        bool booleanVal;
         int64_t int64Val;
         double doubleVal;
         gf_string_t strVal{};

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -121,14 +121,14 @@ double_t TypeUtils::convertToDouble(const char* data) {
     return retVal;
 };
 
-uint8_t TypeUtils::convertToBoolean(const char* data) {
+bool TypeUtils::convertToBoolean(const char* data) {
     auto len = strlen(data);
     if (len == 4 && 't' == tolower(data[0]) && 'r' == tolower(data[1]) && 'u' == tolower(data[2]) &&
         'e' == tolower(data[3])) {
-        return TRUE;
+        return true;
     } else if (len == 5 && 'f' == tolower(data[0]) && 'a' == tolower(data[1]) &&
                'l' == tolower(data[2]) && 's' == tolower(data[3]) && 'e' == tolower(data[4])) {
-        return FALSE;
+        return false;
     }
     throw ConversionException(
         prefixConversionExceptionMessage(data, BOOL) +

--- a/src/common/vector/operations/vector_boolean_operations.cpp
+++ b/src/common/vector/operations/vector_boolean_operations.cpp
@@ -8,41 +8,41 @@ namespace graphflow {
 namespace common {
 
 void VectorBooleanOperations::And(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, operation::And,
-        false /* SKIP_NULL */>(left, right, result);
+    BinaryOperationExecutor::execute<bool, bool, uint8_t, operation::And, true /* IS_BOOL_OP */>(
+        left, right, result);
 }
 
 void VectorBooleanOperations::Or(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, operation::Or,
-        false /* SKIP_NULL */>(left, right, result);
+    BinaryOperationExecutor::execute<bool, bool, uint8_t, operation::Or, true /* IS_BOOL_OP */>(
+        left, right, result);
 }
 
 void VectorBooleanOperations::Xor(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::execute<uint8_t, uint8_t, uint8_t, operation::Xor,
-        false /* SKIP_NULL */>(left, right, result);
+    BinaryOperationExecutor::execute<bool, bool, uint8_t, operation::Xor, true /* IS_BOOL_OP */>(
+        left, right, result);
 }
 
 void VectorBooleanOperations::Not(ValueVector& operand, ValueVector& result) {
-    UnaryOperationExecutor::execute<uint8_t, uint8_t, operation::Not, false /* SKIP_NULL */>(
+    UnaryOperationExecutor::execute<bool, uint8_t, operation::Not, true /* IS_BOOL_OP */>(
         operand, result);
 }
 
 uint64_t VectorBooleanOperations::AndSelect(
     ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
-    return BinaryOperationExecutor::select<uint8_t, uint8_t, uint8_t, operation::And,
-        false /* SKIP_NULL */>(left, right, selectedPositions);
+    return BinaryOperationExecutor::select<bool, bool, uint8_t, operation::And,
+        true /* IS_BOOL_OP */>(left, right, selectedPositions);
 }
 
 uint64_t VectorBooleanOperations::OrSelect(
     ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
-    return BinaryOperationExecutor::select<uint8_t, uint8_t, uint8_t, operation::Or,
-        false /* SKIP_NULL */>(left, right, selectedPositions);
+    return BinaryOperationExecutor::select<bool, bool, uint8_t, operation::Or,
+        true /* IS_BOOL_OP */>(left, right, selectedPositions);
 }
 
 uint64_t VectorBooleanOperations::XorSelect(
     ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
-    return BinaryOperationExecutor::select<uint8_t, uint8_t, uint8_t, operation::Xor,
-        false /* SKIP_NULL */>(left, right, selectedPositions);
+    return BinaryOperationExecutor::select<bool, bool, uint8_t, operation::Xor,
+        true /* IS_BOOL_OP */>(left, right, selectedPositions);
 }
 
 uint64_t VectorBooleanOperations::NotSelect(ValueVector& operand, sel_t* selectedPositions) {

--- a/src/common/vector/operations/vector_cast_operations.cpp
+++ b/src/common/vector/operations/vector_cast_operations.cpp
@@ -110,7 +110,7 @@ void VectorCastOperations::castStructuredToString(ValueVector& operand, ValueVec
         string val;
         switch (operand.dataType) {
         case BOOL: {
-            val = TypeUtils::toString(operand.values[pos]);
+            val = TypeUtils::toString(((bool*)operand.values)[pos]);
         } break;
         case INT64: {
             val = TypeUtils::toString(((int64_t*)operand.values)[pos]);
@@ -136,7 +136,7 @@ void VectorCastOperations::castStructuredToString(ValueVector& operand, ValueVec
         case BOOL: {
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
-                result.addString(pos, TypeUtils::toString(operand.values[pos]));
+                result.addString(pos, TypeUtils::toString(((bool*)operand.values)[pos]));
             }
         } break;
         case INT64: {

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -160,12 +160,12 @@ uint64_t ExpressionEvaluator::select(sel_t* selectedPositions) {
     uint64_t numSelectedValues = 0;
     if (result->state->isFlat()) {
         auto pos = result->state->getPositionOfCurrIdx();
-        numSelectedValues += (result->values[pos] == TRUE) && (!result->isNull(pos));
+        numSelectedValues += result->values[pos] == true && (!result->isNull(pos));
     } else {
         for (auto i = 0u; i < result->state->selectedSize; i++) {
             auto pos = result->state->selectedPositions[i];
             selectedPositions[numSelectedValues] = pos;
-            numSelectedValues += (result->values[pos] == TRUE) && (!result->isNull(pos));
+            numSelectedValues += result->values[pos] == true && (!result->isNull(pos));
         }
     }
     return numSelectedValues;

--- a/src/function/include/aggregation/min_max.h
+++ b/src/function/include/aggregation/min_max.h
@@ -36,7 +36,7 @@ struct MinMaxFunction {
                 } else {
                     OP::template operation<T, T>(inputValues[pos], state->val, compare_result,
                         false /* isLeftNull */, false /* isRightNull */);
-                    state->val = compare_result == TRUE ? inputValues[pos] : state->val;
+                    state->val = compare_result ? inputValues[pos] : state->val;
                 }
             }
         } else {
@@ -49,7 +49,7 @@ struct MinMaxFunction {
                     } else {
                         OP::template operation<T, T>(inputValues[pos], state->val, compare_result,
                             false /* isLeftNull */, false /* isRightNull */);
-                        state->val = compare_result == TRUE ? inputValues[pos] : state->val;
+                        state->val = compare_result ? inputValues[pos] : state->val;
                     }
                 }
             }

--- a/src/processor/physical_plan/mapper/expression_mapper.cpp
+++ b/src/processor/physical_plan/mapper/expression_mapper.cpp
@@ -138,9 +138,7 @@ unique_ptr<ExpressionEvaluator> ExpressionMapper::mapLogicalLiteralExpressionToS
         ((double_t*)vector->values)[0] = literalExpression.literal.val.doubleVal;
     } break;
     case BOOL: {
-        auto val = literalExpression.literal.val.booleanVal;
-        vector->setNull(0, val == NULL_BOOL);
-        vector->values[0] = val;
+        ((bool*)vector->values)[0] = literalExpression.literal.val.booleanVal;
     } break;
     case STRING: {
         vector->addString(0 /* pos */, literalExpression.literal.strVal);

--- a/test/common/types_test.cpp
+++ b/test/common/types_test.cpp
@@ -103,15 +103,15 @@ TEST(TypesTests, StringToDoubleConversionErrors) {
 }
 
 TEST(TypesTests, StringToBoolConversion) {
-    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("true"));
-    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("TRUE"));
-    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("True"));
-    EXPECT_EQ(TRUE, TypeUtils::TypeUtils::convertToBoolean("TRUe"));
+    EXPECT_EQ(true, TypeUtils::TypeUtils::convertToBoolean("true"));
+    EXPECT_EQ(true, TypeUtils::TypeUtils::convertToBoolean("TRUE"));
+    EXPECT_EQ(true, TypeUtils::TypeUtils::convertToBoolean("True"));
+    EXPECT_EQ(true, TypeUtils::TypeUtils::convertToBoolean("TRUe"));
 
-    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("false"));
-    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("FALSE"));
-    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("False"));
-    EXPECT_EQ(FALSE, TypeUtils::TypeUtils::convertToBoolean("fALse"));
+    EXPECT_EQ(false, TypeUtils::TypeUtils::convertToBoolean("false"));
+    EXPECT_EQ(false, TypeUtils::TypeUtils::convertToBoolean("FALSE"));
+    EXPECT_EQ(false, TypeUtils::TypeUtils::convertToBoolean("False"));
+    EXPECT_EQ(false, TypeUtils::TypeUtils::convertToBoolean("fALse"));
 }
 
 TEST(TypesTests, StringToBoolConversionErrors) {

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -130,7 +130,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatW
     auto resultData = (int64_t*)result->values;
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
-        rVector->setNull(i, (i % 2) == 1 ? true : false);
+        rVector->setNull(i, (i % 2) == 1);
     }
 
     // Unary UnaryOperationExecutor::executeArithmeticOps assumes that when the operand is unflat
@@ -191,7 +191,7 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
     auto resultData = (int64_t*)result->values;
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
-        rVector->setNull(i, (i % 2) == 1 ? true : false);
+        rVector->setNull(i, (i % 2) == 1);
     }
     // Flatten dataChunkWithVector1, which holds vector1
     dataChunkWithVector1->state->currIdx = 80;

--- a/test/common/vector/operations/vector_boolean_operations_test.cpp
+++ b/test/common/vector/operations/vector_boolean_operations_test.cpp
@@ -1,63 +1,364 @@
+#include <unordered_set>
+
 #include "gtest/gtest.h"
+#include "test/common/include/vector/operations/vector_operations_test_helper.h"
 
 #include "src/common/include/data_chunk/data_chunk.h"
 #include "src/common/include/vector/operations/vector_boolean_operations.h"
 
 using namespace graphflow::common;
+using namespace graphflow::testing;
 using namespace std;
 
-TEST(VectorBooleanTests, test) {
-    auto VECTOR_SIZE = 4;
-    auto dataChunk = make_shared<DataChunk>(3);
-    dataChunk->state->selectedSize = VECTOR_SIZE;
-    auto memoryManager = make_unique<MemoryManager>();
+/**
+ * Populates the 2 vectors with boolean for numTuples number of values.
+ *            lVector              rVector
+ *          -----------          ----------
+ *  0            T                    T
+ *  1            F                    T
+ *  2            T                    F
+ *  3            F                    F
+ *              ...                  ...     (Pattern continues)
+ * */
+static void setValuesInVectors(const shared_ptr<ValueVector>& lVector,
+    const shared_ptr<ValueVector>& rVector, uint32_t numTuples) {
+    auto lVectorData = (bool*)lVector->values;
+    auto rVectorData = (bool*)rVector->values;
+    for (int i = 0; i < numTuples; i++) {
+        lVectorData[i] = i % 2 == 0;
+        rVectorData[i] = (i >> 1) % 2 == 0;
+    }
+}
 
-    auto lVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
-    dataChunk->insert(0, lVector);
-    auto lData = (uint8_t*)lVector->values;
-
-    auto rVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
-    dataChunk->insert(1, rVector);
-    auto rData = (uint8_t*)rVector->values;
-
-    auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
-    dataChunk->insert(2, result);
-    auto resultData = (uint8_t*)result->values;
-
-    // Fill values before the comparison.
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        if (i < 2)
-            lData[i] = FALSE;
-        else if (i < 4)
-            lData[i] = TRUE;
-
-        if (i % 2 == 0)
-            rData[i] = FALSE;
-        else if (i % 2 == 1)
-            rData[i] = TRUE;
+/**
+ * Sets isNull bits for the 2 vectors for numTuples number of values. For lVector, alternating
+ * groups of 4 are set as either notNull or Null. For rVector, alternating groups are of size 8.
+ * If vectors are populated with setValuesInVectors() before, the vectors will be as follows ((N)
+ * denotes that the values is marked Null.)
+ *            lVector              rVector
+ *          -----------          ----------
+ *  0            T                    T
+ *  1            F                    T
+ *  2            T                    F
+ *  3            F                    F
+ *  4            T (N)                T
+ *  5            F (N)                T
+ *  6            T (N)                F
+ *  7            F (N)                F
+ *  8            T                    T (N)
+ *  9            F                    T (N)
+ *  10           T                    F (N)
+ *  11           F                    F (N)
+ *  12           T (N)                T (N)
+ *  13           F (N)                T (N)
+ *  14           T (N)                F (N)
+ *  15           F (N)                F (N)
+ *             ...                  ...     (Pattern continues)
+ * */
+static void setNullsInVectors(const shared_ptr<ValueVector>& lVector,
+    const shared_ptr<ValueVector>& rVector, uint32_t numTuples) {
+    for (int i = 0; i < numTuples; ++i) {
+        lVector->setNull(i, ((i >> 2) % 2) == 1);
     }
 
-    uint8_t andExpectedResult[] = {FALSE, FALSE, FALSE, TRUE};
-    VectorBooleanOperations::And(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i], andExpectedResult[i]);
+    for (int i = 0; i < numTuples; ++i) {
+        rVector->setNull(i, ((i >> 3) % 2) == 1);
     }
+}
 
-    uint8_t orExpectedResult[] = {FALSE, TRUE, TRUE, TRUE};
-    VectorBooleanOperations::Or(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i], orExpectedResult[i]);
-    }
+class BoolOperandsInSameDataChunkTest : public OperandsInSameDataChunk, public Test {
 
-    uint8_t xorExpectedResult[] = {FALSE, TRUE, TRUE, FALSE};
-    VectorBooleanOperations::Xor(*lVector, *rVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i], xorExpectedResult[i]);
-    }
+public:
+    DataType getDataTypeOfOperands() override { return BOOL; }
+    DataType getDataTypeOfResultVector() override { return BOOL; }
 
-    uint8_t notExpectedResult[] = {TRUE, TRUE, FALSE, FALSE};
-    VectorBooleanOperations::Not(*lVector, *result);
-    for (int32_t i = 0; i < VECTOR_SIZE; i++) {
-        ASSERT_EQ(resultData[i], notExpectedResult[i]);
+    void SetUp() override {
+        initDataChunk();
+        setValuesInVectors(vector1, vector2, NUM_TUPLES);
     }
+};
+
+class BoolOperandsInDifferentDataChunksTest : public OperandsInDifferentDataChunks, public Test {
+
+public:
+    DataType getDataTypeOfOperands() override { return BOOL; }
+    DataType getDataTypeOfResultVector() override { return BOOL; }
+
+    void SetUp() override {
+        initDataChunk();
+        setValuesInVectors(vector1, vector2, NUM_TUPLES);
+    }
+};
+
+static void checkResultVectorNoNulls(const shared_ptr<ValueVector>& result,
+    const function<bool(uint32_t)>& idxOfTrueValueFunc, uint32_t numTuples) {
+    auto resultData = (bool*)result->values;
+    for (int i = 0; i < numTuples; i++) {
+        if (idxOfTrueValueFunc(i)) {
+            ASSERT_TRUE(resultData[i]);
+        } else {
+            ASSERT_FALSE(resultData[i]);
+        }
+        ASSERT_FALSE(result->isNull(i));
+    }
+    ASSERT_TRUE(result->hasNoNullsGuarantee());
+}
+
+TEST_F(BoolOperandsInSameDataChunkTest, BoolUnaryAndBinaryAllUnflatNoNulls) {
+
+    VectorBooleanOperations::And(*vector1, *vector2, *result);
+    // Value at positions {0, 4, 8, 16 ...} are expected to be true
+    checkResultVectorNoNulls(
+        result, [](uint32_t i) { return i % 4 == 0; }, NUM_TUPLES);
+
+    VectorBooleanOperations::Or(*vector1, *vector2, *result);
+    // Value at all positions except {3, 7, 11, 15 ...} are expected to be true
+    checkResultVectorNoNulls(
+        result, [](uint32_t i) { return i % 4 != 3; }, NUM_TUPLES);
+
+    VectorBooleanOperations::Xor(*vector1, *vector2, *result);
+    // Value at positions {1, 5, 8 ...} and {2, 6, 8 ...} are expected to be true
+    checkResultVectorNoNulls(
+        result, [](uint32_t i) { return i % 4 == 1 || i % 4 == 2; }, NUM_TUPLES);
+
+    VectorBooleanOperations::Not(*vector1, *result);
+    // Value at positions {1, 3, 5, 7 ...} are expected to be true
+    checkResultVectorNoNulls(
+        result, [](uint32_t i) { return i % 2 == 1; }, NUM_TUPLES);
+}
+
+// This function works only on the resultant vector that is outcome of the vectors that has been
+// populated by the scheme specified above. That is, it assumes that the True/False/Null pattern
+// repeat after every 16 elements.
+static void checkResultVectorWithNulls(const shared_ptr<ValueVector>& result,
+    const unordered_set<uint32_t>& idxOfTrueValuePer16Elements,
+    const unordered_set<uint32_t>& idxOfFalseValuePer16Elements, uint32_t numTuples) {
+    auto resultData = (bool*)result->values;
+    for (int i = 0; i < numTuples; i++) {
+        if (idxOfTrueValuePer16Elements.contains(i % 16)) {
+            ASSERT_TRUE(resultData[i]);
+            ASSERT_FALSE(result->isNull(i));
+        } else if (idxOfFalseValuePer16Elements.contains(i % 16)) {
+            ASSERT_FALSE(resultData[i]);
+            ASSERT_FALSE(result->isNull(i));
+        } else {
+            ASSERT_TRUE(result->isNull(i));
+        }
+    }
+    ASSERT_FALSE(result->hasNoNullsGuarantee());
+}
+
+TEST_F(BoolOperandsInSameDataChunkTest, BoolUnaryAndBinaryAllUnflatWithNulls) {
+    setNullsInVectors(vector1, vector2, NUM_TUPLES);
+
+    VectorBooleanOperations::And(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {0}, {1, 2, 3, 6, 7, 9, 11}, NUM_TUPLES);
+
+    VectorBooleanOperations::Or(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {0, 1, 2, 4, 5, 8, 10}, {3}, NUM_TUPLES);
+
+    VectorBooleanOperations::Xor(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {1, 2}, {0, 3}, NUM_TUPLES);
+
+    result->setNullMask(vector1->getNullMask());
+    VectorBooleanOperations::Not(*vector1, *result);
+    checkResultVectorWithNulls(result, {1, 3, 9, 11}, {0, 2, 8, 10}, NUM_TUPLES);
+}
+
+TEST_F(BoolOperandsInDifferentDataChunksTest, BoolBinaryOneFlatOneUnflatNoNulls) {
+    // Flatten dataChunkWithVector1, which holds vector1
+    dataChunkWithVector1->state->currIdx = 0;
+
+    VectorBooleanOperations::And(*vector1, *vector2, *result);
+    // Value at positions {0, 1, 4, 5, 8, 9 ...} are expected to be true
+    checkResultVectorNoNulls(
+        result, [](uint32_t i) { return (i >> 1) % 2 == 0; }, NUM_TUPLES);
+
+    VectorBooleanOperations::Or(*vector1, *vector2, *result);
+    // All values are expected to be true.
+    checkResultVectorNoNulls(
+        result, [](uint32_t i) { return true; }, NUM_TUPLES);
+
+    VectorBooleanOperations::Xor(*vector1, *vector2, *result);
+    // Value at positions {2, 3, 6, 7 ...} are expected to be true
+    checkResultVectorNoNulls(
+        result, [](uint32_t i) { return (i >> 1) % 2 == 1; }, NUM_TUPLES);
+}
+
+TEST_F(BoolOperandsInDifferentDataChunksTest, BoolBinaryOneFlatOneUnflatWithNulls) {
+    setNullsInVectors(vector1, vector2, NUM_TUPLES);
+
+    // CASE 1: Flat value is TRUE
+    dataChunkWithVector1->state->currIdx = 0;
+
+    VectorBooleanOperations::And(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {0, 1, 4, 5}, {2, 3, 6, 7}, NUM_TUPLES);
+
+    VectorBooleanOperations::Or(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(
+        result, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15}, {}, NUM_TUPLES);
+
+    VectorBooleanOperations::Xor(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {2, 3, 6, 7}, {0, 1, 4, 5}, NUM_TUPLES);
+
+    // CASE 2: Flat pos has isNull = TRUE
+    dataChunkWithVector1->state->currIdx = 4;
+
+    VectorBooleanOperations::And(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {}, {2, 3, 6, 7}, NUM_TUPLES);
+
+    VectorBooleanOperations::Or(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {0, 1, 4, 5}, {}, NUM_TUPLES);
+
+    VectorBooleanOperations::Xor(*vector1, *vector2, *result);
+    checkResultVectorWithNulls(result, {}, {}, NUM_TUPLES);
+}
+
+static void checkSelectedPos(uint32_t actualNumSelectedPos, const sel_t* actualSelectedPos,
+    const function<bool(uint32_t)>& isSelectedPos, uint32_t numTuples) {
+    vector<uint32_t> expectedSelectedPos;
+    for (auto i = 0; i < numTuples; i++) {
+        if (isSelectedPos(i)) {
+            expectedSelectedPos.emplace_back(i);
+        }
+    }
+    EXPECT_EQ(actualNumSelectedPos, expectedSelectedPos.size());
+    for (auto i = 0; i < actualNumSelectedPos; i++) {
+        EXPECT_EQ(actualSelectedPos[i], expectedSelectedPos[i]);
+    }
+}
+
+TEST_F(BoolOperandsInSameDataChunkTest, BoolUnaryAndBinarySelectAllUnflatNoNulls) {
+    auto selectedPosBuffer = result->state->selectedPositionsBuffer.get();
+    auto numSelectedPos = 0u;
+
+    numSelectedPos = VectorBooleanOperations::AndSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are multiples of 4 {0, 4, 8, 16 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 4 == 0; }, NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::OrSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are follow that pattern {0, 1, 2, 4, 5, 6 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 4 != 3; }, NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::XorSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions follow the pattern {1, 2, 5, 6, 9, 10 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 4 == 1 || i % 4 == 2; },
+        NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::NotSelect(*vector1, selectedPosBuffer);
+    // selected positions are all odd positions {1, 3, 5 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 2 == 1; }, NUM_TUPLES);
+}
+
+TEST_F(BoolOperandsInSameDataChunkTest, BoolUnaryAndBinarySelectAllUnflatWithNulls) {
+    setNullsInVectors(vector1, vector2, NUM_TUPLES);
+
+    auto selectedPosBuffer = result->state->selectedPositionsBuffer.get();
+    auto numSelectedPos = 0u;
+
+    numSelectedPos = VectorBooleanOperations::AndSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are multiples of 16 {0, 16, 32, 48 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 16 == 0; }, NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::OrSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are union of {0, 8, 16 ...}, {2, 10, 18 ...}, {1, 17, 33 ...},
+    // {4, 20, 36 ...} and {5, 21, 37 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer,
+        [](uint32_t i) {
+            return i % 8 == 0 || i % 8 == 2 || i % 16 == 1 || i % 16 == 4 || i % 16 == 5;
+        },
+        NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::XorSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are union of {1, 17, 33 ...} and {2, 18, 34 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 16 == 1 || i % 16 == 2; },
+        NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::NotSelect(*vector1, selectedPosBuffer);
+    // selected positions are union of {1, 9, 17 ...} and {3, 11, 19 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 8 == 1 || i % 8 == 3; },
+        NUM_TUPLES);
+}
+
+TEST_F(BoolOperandsInDifferentDataChunksTest, BoolBinarySelectOneFlatOneUnflatNoNulls) {
+    dataChunkWithVector1->state->currIdx = 0;
+
+    auto selectedPosBuffer = result->state->selectedPositionsBuffer.get();
+    auto numSelectedPos = 0u;
+
+    numSelectedPos = VectorBooleanOperations::AndSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are union of multiples of 4 and {1, 5, 9 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 4 == 0 || i % 4 == 1; },
+        NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::OrSelect(*vector1, *vector2, selectedPosBuffer);
+    // all positions are selected.
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return true; }, NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::XorSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are union of {2, 6, 10 ...} and {3, 7, 1 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return i % 4 == 2 || i % 4 == 3; },
+        NUM_TUPLES);
+}
+
+TEST_F(BoolOperandsInDifferentDataChunksTest, BoolBinarySelectOneFlatOneUnflatWithNulls) {
+    setNullsInVectors(vector1, vector2, NUM_TUPLES);
+    auto selectedPosBuffer = result->state->selectedPositionsBuffer.get();
+    auto numSelectedPos = 0u;
+
+    // CASE 1: Flat value is TRUE
+    dataChunkWithVector1->state->currIdx = 0;
+
+    numSelectedPos = VectorBooleanOperations::AndSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are union of multiples of 16, {1, 17, 33 ...}, {4, 20, 36 ...} and
+    // {5, 21, 37}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer,
+        [](uint32_t i) { return i % 16 == 0 || i % 16 == 1 || i % 16 == 4 || i % 16 == 5; },
+        NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::OrSelect(*vector1, *vector2, selectedPosBuffer);
+    // all positions are selected.
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return true; }, NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::XorSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are union of {2, 18, 34 ...}, {3, 19, 35 ...}, {6, 22, 38} and
+    // {7, 23, 39 ...}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer,
+        [](uint32_t i) { return i % 16 == 2 || i % 16 == 3 || i % 16 == 6 || i % 16 == 7; },
+        NUM_TUPLES);
+
+    // CASE 2: Flat pos has isNull = TRUE
+    dataChunkWithVector1->state->currIdx = 4;
+
+    numSelectedPos = VectorBooleanOperations::AndSelect(*vector1, *vector2, selectedPosBuffer);
+    // no positions are selected.
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return false; }, NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::OrSelect(*vector1, *vector2, selectedPosBuffer);
+    // selected positions are union of multiples of 16, {1, 17, 33 ...}, {4, 20, 36 ...} and
+    // {5, 21, 37}
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer,
+        [](uint32_t i) { return i % 16 == 0 || i % 16 == 1 || i % 16 == 4 || i % 16 == 5; },
+        NUM_TUPLES);
+
+    numSelectedPos = VectorBooleanOperations::XorSelect(*vector1, *vector2, selectedPosBuffer);
+    // no poisitons are selected.
+    checkSelectedPos(
+        numSelectedPos, selectedPosBuffer, [](uint32_t i) { return false; }, NUM_TUPLES);
 }

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -55,42 +55,42 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
 
     VectorComparisonOperations::Equals(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i == 45 ? TRUE : FALSE);
+        ASSERT_EQ(resultData[i], i == 45 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorComparisonOperations::NotEquals(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i == 45 ? FALSE : TRUE);
+        ASSERT_EQ(resultData[i], i == 45 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 45 ? TRUE : FALSE);
+        ASSERT_EQ(resultData[i], i < 45 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 46 ? TRUE : FALSE);
+        ASSERT_EQ(resultData[i], i < 46 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 46 ? FALSE : TRUE);
+        ASSERT_EQ(resultData[i], i < 46 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 45 ? FALSE : TRUE);
+        ASSERT_EQ(resultData[i], i < 45 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -103,13 +103,13 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatWithNulls) {
     auto resultData = result->values;
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
-        vector2->setNull(i, (i % 2) == 1 ? true : false);
+        vector2->setNull(i, (i % 2) == 1);
     }
 
     VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
-            ASSERT_EQ(resultData[i], i < 45 ? TRUE : FALSE);
+            ASSERT_EQ(resultData[i], i < 45 ? true : false);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -133,7 +133,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNo
     result->setNullMask(vector2->getNullMask());
     VectorComparisonOperations::LessThan(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 10 ? TRUE : FALSE);
+        ASSERT_EQ(resultData[i], i < 10 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -143,7 +143,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNo
     // is false and the rest is true.
     VectorComparisonOperations::LessThan(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 11 ? FALSE : TRUE);
+        ASSERT_EQ(resultData[i], i < 11 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -155,7 +155,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
     dataChunkWithVector1->state->currIdx = 80;
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
-        vector2->setNull(i, (i % 2) == 1 ? true : false);
+        vector2->setNull(i, (i % 2) == 1);
     }
     // Recall vector2 and result are in the same data chunk
     auto resultData = result->values;
@@ -167,7 +167,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
     VectorComparisonOperations::LessThan(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if ((i % 2) == 0) {
-            ASSERT_EQ(resultData[i], i < 10 ? TRUE : FALSE);
+            ASSERT_EQ(resultData[i], i < 10 ? true : false);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -186,7 +186,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
     VectorComparisonOperations::LessThan(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if ((i % 2) == 0) {
-            ASSERT_EQ(resultData[i], i < 11 ? FALSE : TRUE);
+            ASSERT_EQ(resultData[i], i < 11 ? false : true);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -226,39 +226,39 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
         rData[0].data, value.data() + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
 
     VectorComparisonOperations::Equals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     rData[0].data[3] = 'i';
     VectorComparisonOperations::Equals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::NotEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     rData[0].data[3] = 'a';
     VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 }
 
 TEST(VectorCmpTests, cmpTwoLongStrings) {
@@ -295,37 +295,37 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
     rData->overflowPtr = reinterpret_cast<uintptr_t>(rOverflow);
 
     VectorComparisonOperations::Equals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     rOverflow[overflowLen - 1] = 'z';
     VectorComparisonOperations::Equals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::NotEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     rOverflow[overflowLen - 1] = 'a';
     VectorComparisonOperations::LessThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::LessThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], FALSE);
+    ASSERT_EQ(resultData[0], false);
 
     VectorComparisonOperations::GreaterThan(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 
     VectorComparisonOperations::GreaterThanEquals(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], TRUE);
+    ASSERT_EQ(resultData[0], true);
 }

--- a/test/common/vector/value_vector_test.cpp
+++ b/test/common/vector/value_vector_test.cpp
@@ -21,15 +21,15 @@ TEST(ValueVectorTests, TestDefaultHasNull) {
     EXPECT_TRUE(valueVector.hasNoNullsGuarantee());
 
     // Test that after an update of a value to non-NULL the vector still does not contain any NULLs.
-    valueVector.setNull(2, FALSE);
+    valueVector.setNull(2, false);
     EXPECT_TRUE(valueVector.hasNoNullsGuarantee());
 
     // Test that after an update of a value to NULL the vector may now contain NULLs.
-    valueVector.setNull(4, TRUE);
+    valueVector.setNull(4, true);
     EXPECT_FALSE(valueVector.hasNoNullsGuarantee());
 
     // Test that even if we revert the previous update of non-NULL the vector may still
     // contain  NULLs.
-    valueVector.setNull(4, FALSE);
+    valueVector.setNull(4, false);
     EXPECT_FALSE(valueVector.hasNoNullsGuarantee());
 }


### PR DESCRIPTION
- bug fixes in the binary/unary_operation_exector
- removed constants TRUE / FALSE, shifted NULL_BOOL to boolean_operators.h to be only used in the context of boolean operators. 
- corrected logic for AND, OR, NOT, XOR.
- Changed system representation of boolean from uint8_t to bool type.