### PR TITLE
refactor exists and reInitialize

### DIFF
--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -105,6 +105,8 @@ private:
     // E.g. SUM(SUM(a.age)) is not allowed
     static void validateAggregationExpressionIsNotNested(const Expression& expression);
 
+    static void validateExistsSubqueryHasNoAggregationOrOrderBy(const Expression& expression);
+
 private:
     template<typename T>
     shared_ptr<Expression> bindStringCastingFunctionExpression(

--- a/src/planner/include/logical_plan/operator/exists/logical_exist.h
+++ b/src/planner/include/logical_plan/operator/exists/logical_exist.h
@@ -19,7 +19,7 @@ public:
 
     string toString(uint64_t depth = 0) const override {
         string result = LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
-                        getExpressionsForPrinting() + "]";
+                        getExpressionsForPrinting() + "]\n";
         result += prevOperator->toString(depth + 1);
         result += "\nSUBPLAN: \n";
         result += subPlanLastOperator->toString(depth + 1);

--- a/src/planner/include/logical_plan/operator/nested_loop_join/logical_left_nested_loop_join.h
+++ b/src/planner/include/logical_plan/operator/nested_loop_join/logical_left_nested_loop_join.h
@@ -21,7 +21,7 @@ public:
 
     string toString(uint64_t depth = 0) const override {
         string result = LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
-                        getExpressionsForPrinting() + "]";
+                        getExpressionsForPrinting() + "]\n";
         result += prevOperator->toString(depth + 1);
         result += "\nSUBPLAN: \n";
         result += subPlanLastOperator->toString(depth + 1);

--- a/src/processor/include/physical_plan/operator/exists.h
+++ b/src/processor/include/physical_plan/operator/exists.h
@@ -5,17 +5,17 @@
 namespace graphflow {
 namespace processor {
 
-class PhysicalPlan;
-
 class Exists : public PhysicalOperator {
 
 public:
-    Exists(const DataPos& outDataPos, unique_ptr<PhysicalPlan> subPlan,
+    Exists(const DataPos& outDataPos, unique_ptr<PhysicalOperator> subPlanLastOperator,
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), EXISTS, context, id},
-          outDataPos{outDataPos}, subPlan{move(subPlan)} {}
+        : PhysicalOperator{move(prevOperator), EXISTS, context, id}, outDataPos{outDataPos},
+          subPlanLastOperator{move(subPlanLastOperator)} {}
 
     shared_ptr<ResultSet> initResultSet() override;
+
+    void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 
@@ -23,7 +23,7 @@ public:
 
 private:
     DataPos outDataPos;
-    unique_ptr<PhysicalPlan> subPlan;
+    unique_ptr<PhysicalOperator> subPlanLastOperator;
     shared_ptr<ValueVector> valueVectorToWrite;
 };
 

--- a/src/processor/include/physical_plan/operator/filter.h
+++ b/src/processor/include/physical_plan/operator/filter.h
@@ -20,7 +20,7 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
-    void reInitialize() override;
+    void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 

--- a/src/processor/include/physical_plan/operator/filtering_operator.h
+++ b/src/processor/include/physical_plan/operator/filtering_operator.h
@@ -17,7 +17,7 @@ public:
           prevSelectedValuesBuffer{make_unique<sel_t[]>(DEFAULT_VECTOR_CAPACITY)} {};
 
 protected:
-    inline void reInitialize() {
+    inline void reInitToRerunSubPlan() {
         prevNumSelectedValues = 0ul;
         prevSelectedValues = nullptr;
     }

--- a/src/processor/include/physical_plan/operator/flatten.h
+++ b/src/processor/include/physical_plan/operator/flatten.h
@@ -15,6 +15,8 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
+    void reInitToRerunSubPlan() override;
+
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -50,7 +50,6 @@ public:
         unique_ptr<PhysicalOperator> probeSidePrevOp, ExecutionContext& context, uint32_t id);
 
     shared_ptr<ResultSet> initResultSet() override;
-    void reInitialize() override;
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/intersect.h
+++ b/src/processor/include/physical_plan/operator/intersect.h
@@ -16,6 +16,8 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
+    void reInitToRerunSubPlan() override;
+
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/left_nested_loop_join.h
+++ b/src/processor/include/physical_plan/operator/left_nested_loop_join.h
@@ -17,6 +17,8 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
+    void reInitToRerunSubPlan() override;
+
     bool getNextTuples() override;
 
     bool pullOnceFromLeftAndRight();

--- a/src/processor/include/physical_plan/operator/multiplicity_reducer.h
+++ b/src/processor/include/physical_plan/operator/multiplicity_reducer.h
@@ -15,7 +15,7 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
-    void reInitialize() override;
+    void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -71,9 +71,13 @@ public:
 
     virtual shared_ptr<ResultSet> initResultSet() = 0;
 
-    // For subquery, we rerun a plan multiple times. ReInitialize() should be called before each run
-    // to ensure
-    virtual void reInitialize();
+    // Only operators that can appear in a subPlan need to overwrite this function. Currently, we
+    // allow the following operators in subPlan: resultSetScan, extend, scanProperty, flatten,
+    // filter, intersect, projection, exists, leftNestedLoopJoin.
+    virtual void reInitToRerunSubPlan() {
+        throw invalid_argument("Operator " + PhysicalOperatorTypeNames[operatorType] +
+                               "  does not implement reInitToRerunSubPlan().");
+    }
 
     // Return false if no more tuples to pull, otherwise return true
     virtual bool getNextTuples() = 0;

--- a/src/processor/include/physical_plan/operator/projection.h
+++ b/src/processor/include/physical_plan/operator/projection.h
@@ -22,6 +22,8 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
+    void reInitToRerunSubPlan() override;
+
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override;

--- a/src/processor/include/physical_plan/operator/read_list/read_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_list.h
@@ -20,6 +20,8 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
+    void reInitToRerunSubPlan() override;
+
     void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
 
 protected:

--- a/src/processor/include/physical_plan/operator/result_collector.h
+++ b/src/processor/include/physical_plan/operator/result_collector.h
@@ -19,8 +19,6 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
-    void reInitialize() override;
-
     void execute() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/result_scan.h
+++ b/src/processor/include/physical_plan/operator/result_scan.h
@@ -26,7 +26,7 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
-    void reInitialize() override;
+    void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
@@ -17,7 +17,7 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
-    void reInitialize() override;
+    void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
@@ -17,6 +17,8 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
+    void reInitToRerunSubPlan() override;
+
     void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
 
 protected:

--- a/src/processor/include/physical_plan/operator/skip.h
+++ b/src/processor/include/physical_plan/operator/skip.h
@@ -19,8 +19,6 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
 
-    void reInitialize() override;
-
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {

--- a/src/processor/include/physical_plan/operator/source_operator.h
+++ b/src/processor/include/physical_plan/operator/source_operator.h
@@ -22,6 +22,14 @@ protected:
         return resultSet;
     }
 
+    void reInitToRerunSubPlan(ResultSet& resultSet) {
+        for (auto& dataChunk : resultSet.dataChunks) {
+            dataChunk->state->initOriginalAndSelectedSize(0);
+            dataChunk->state->resetSelectorToUnselected();
+            dataChunk->state->currIdx = -1;
+        }
+    }
+
 protected:
     unique_ptr<ResultSetDescriptor> resultSetDescriptor;
 };

--- a/src/processor/physical_plan/operator/exists.cpp
+++ b/src/processor/physical_plan/operator/exists.cpp
@@ -1,8 +1,6 @@
 #include "src/processor/include/physical_plan/operator/exists.h"
 
-#include "src/processor/include/physical_plan/operator/result_collector.h"
 #include "src/processor/include/physical_plan/operator/result_scan.h"
-#include "src/processor/include/physical_plan/physical_plan.h"
 
 namespace graphflow {
 namespace processor {
@@ -13,29 +11,31 @@ shared_ptr<ResultSet> Exists::initResultSet() {
     valueVectorToWrite = make_shared<ValueVector>(context.memoryManager, BOOL);
     dataChunkToWrite->insert(outDataPos.valueVectorPos, valueVectorToWrite);
     // side way information passing: give resultSet reference to subPlan
-    auto subPlanResultCollector = (ResultCollector*)subPlan->lastOperator.get();
-    auto op = subPlanResultCollector->getLeafOperator();
+    auto op = subPlanLastOperator->getLeafOperator();
     assert(op->operatorType == SELECT_SCAN);
     ((ResultScan*)op)->setResultSetToCopyFrom(resultSet.get());
+    subPlanLastOperator->initResultSet();
     return resultSet;
 }
 
+void Exists::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+}
+
 bool Exists::getNextTuples() {
-    auto subPlanResultCollector = (ResultCollector*)subPlan->lastOperator.get();
     if (!prevOperator->getNextTuples()) {
         return false;
     }
-    subPlanResultCollector->reInitialize();
-    subPlanResultCollector->execute();
+    subPlanLastOperator->reInitToRerunSubPlan();
     assert(valueVectorToWrite->state->currIdx != -1);
-    auto hasAtLeastOneTuple = subPlanResultCollector->queryResult->numTuples != 0;
+    auto hasAtLeastOneTuple = subPlanLastOperator->getNextTuples();
     valueVectorToWrite->values[valueVectorToWrite->state->currIdx] = hasAtLeastOneTuple;
     return true;
 }
 
 unique_ptr<PhysicalOperator> Exists::clone() {
-    auto subPlanClone = make_unique<PhysicalPlan>(subPlan->lastOperator->clone());
-    return make_unique<Exists>(outDataPos, move(subPlanClone), prevOperator->clone(), context, id);
+    return make_unique<Exists>(
+        outDataPos, subPlanLastOperator->clone(), prevOperator->clone(), context, id);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/filter.cpp
+++ b/src/processor/physical_plan/operator/filter.cpp
@@ -10,9 +10,9 @@ shared_ptr<ResultSet> Filter::initResultSet() {
     return resultSet;
 }
 
-void Filter::reInitialize() {
-    PhysicalOperator::reInitialize();
-    FilteringOperator::reInitialize();
+void Filter::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+    FilteringOperator::reInitToRerunSubPlan();
 }
 
 bool Filter::getNextTuples() {

--- a/src/processor/physical_plan/operator/flatten.cpp
+++ b/src/processor/physical_plan/operator/flatten.cpp
@@ -9,6 +9,10 @@ shared_ptr<ResultSet> Flatten::initResultSet() {
     return resultSet;
 }
 
+void Flatten::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+}
+
 bool Flatten::getNextTuples() {
     metrics->executionTime.start();
     // currentIdx == -1 is the check for initial case

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -87,11 +87,6 @@ void HashJoinProbe::populateResultSet() {
         probeState->numMatchedTuples - tuplePosToReadInProbedState);
 }
 
-void HashJoinProbe::reInitialize() {
-    PhysicalOperator::reInitialize();
-    buildSidePrevOp->reInitialize();
-}
-
 // The general flow of a hash join probe:
 // 1) find matched tuples of probe side key from ht.
 // 2) populate values from matched tuples into resultKeyDataChunk , buildSideFlatResultDataChunk

--- a/src/processor/physical_plan/operator/intersect.cpp
+++ b/src/processor/physical_plan/operator/intersect.cpp
@@ -14,6 +14,12 @@ shared_ptr<ResultSet> Intersect::initResultSet() {
     return resultSet;
 }
 
+void Intersect::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+    FilteringOperator::reInitToRerunSubPlan();
+    leftIdx = 0;
+}
+
 static void sortSelectedPos(const shared_ptr<ValueVector>& nodeIDVector) {
     auto selectedPos = nodeIDVector->state->selectedPositionsBuffer.get();
     auto size = nodeIDVector->state->selectedSize;

--- a/src/processor/physical_plan/operator/left_nested_loop_join.cpp
+++ b/src/processor/physical_plan/operator/left_nested_loop_join.cpp
@@ -26,6 +26,11 @@ shared_ptr<ResultSet> LeftNestedLoopJoin::initResultSet() {
     return resultSet;
 }
 
+void LeftNestedLoopJoin::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+    isFirstExecution = true;
+}
+
 bool LeftNestedLoopJoin::getNextTuples() {
     if (isFirstExecution) {
         isFirstExecution = false;
@@ -42,7 +47,7 @@ bool LeftNestedLoopJoin::pullOnceFromLeftAndRight() {
     if (!prevOperator->getNextTuples()) {
         return false;
     }
-    subPlanLastOperator->reInitialize();
+    subPlanLastOperator->reInitToRerunSubPlan();
     if (!subPlanLastOperator->getNextTuples()) { // Nothing is pulled from sub plan.
         for (auto& vector : vectorsToRef) {
             vector->state->initOriginalAndSelectedSize(1);

--- a/src/processor/physical_plan/operator/multiplicity_reducer.cpp
+++ b/src/processor/physical_plan/operator/multiplicity_reducer.cpp
@@ -8,8 +8,8 @@ shared_ptr<ResultSet> MultiplicityReducer::initResultSet() {
     return resultSet;
 }
 
-void MultiplicityReducer::reInitialize() {
-    PhysicalOperator::reInitialize();
+void MultiplicityReducer::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
     prevMultiplicity = 1;
     numRepeat = 0;
 }

--- a/src/processor/physical_plan/operator/physical_operator.cpp
+++ b/src/processor/physical_plan/operator/physical_operator.cpp
@@ -19,12 +19,6 @@ PhysicalOperator* PhysicalOperator::getLeafOperator() {
     return op;
 }
 
-void PhysicalOperator::reInitialize() {
-    if (prevOperator) {
-        prevOperator->reInitialize();
-    }
-}
-
 void PhysicalOperator::registerProfilingMetrics() {
     auto executionTime = context.profiler.registerTimeMetric(getTimeMetricKey());
     auto numOutputTuple = context.profiler.registerNumericMetric(getNumTupleMetricKey());

--- a/src/processor/physical_plan/operator/projection.cpp
+++ b/src/processor/physical_plan/operator/projection.cpp
@@ -21,6 +21,10 @@ shared_ptr<ResultSet> Projection::initResultSet() {
     return resultSet;
 }
 
+void Projection::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+}
+
 bool Projection::getNextTuples() {
     metrics->executionTime.start();
     restoreMultiplicity();

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -11,6 +11,10 @@ shared_ptr<ResultSet> ReadList::initResultSet() {
     return resultSet;
 }
 
+void ReadList::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+}
+
 void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
     PhysicalOperator::printTimeAndNumOutputMetrics(json, profiler);
     printBufferManagerMetrics(json, profiler);

--- a/src/processor/physical_plan/operator/result_collector.cpp
+++ b/src/processor/physical_plan/operator/result_collector.cpp
@@ -8,11 +8,6 @@ shared_ptr<ResultSet> ResultCollector::initResultSet() {
     return resultSet;
 }
 
-void ResultCollector::reInitialize() {
-    prevOperator->reInitialize();
-    queryResult->clear();
-}
-
 void ResultCollector::execute() {
     metrics->executionTime.start();
     Sink::execute();

--- a/src/processor/physical_plan/operator/result_scan.cpp
+++ b/src/processor/physical_plan/operator/result_scan.cpp
@@ -8,7 +8,6 @@ namespace processor {
 shared_ptr<ResultSet> ResultScan::initResultSet() {
     resultSet = populateResultSet();
     outDataChunk = resultSet->dataChunks[outDataChunkPos];
-    outDataChunk->state = DataChunkState::getSingleValueDataChunkState();
     for (auto i = 0u; i < inDataPoses.size(); ++i) {
         auto [inDataChunkPos, inValueVectorPos] = inDataPoses[i];
         auto& inValueVector =
@@ -20,7 +19,8 @@ shared_ptr<ResultSet> ResultScan::initResultSet() {
     return resultSet;
 }
 
-void ResultScan::reInitialize() {
+void ResultScan::reInitToRerunSubPlan() {
+    SourceOperator::reInitToRerunSubPlan(*resultSet);
     isFirstExecution = true;
 }
 
@@ -59,6 +59,8 @@ bool ResultScan::getNextTuples() {
             }
             outValueVector->setNull(0, false /* isNull */);
         }
+        outDataChunk->state->initOriginalAndSelectedSize(1);
+        outDataChunk->state->currIdx = 0;
         metrics->executionTime.stop();
         metrics->numOutputTuple.incrementByOne();
         return true;

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -10,9 +10,9 @@ shared_ptr<ResultSet> AdjColumnExtend::initResultSet() {
     return resultSet;
 }
 
-void AdjColumnExtend::reInitialize() {
-    PhysicalOperator::reInitialize();
-    FilteringOperator::reInitialize();
+void AdjColumnExtend::reInitToRerunSubPlan() {
+    ScanAttribute::reInitToRerunSubPlan();
+    FilteringOperator::reInitToRerunSubPlan();
 }
 
 bool AdjColumnExtend::getNextTuples() {

--- a/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
@@ -11,6 +11,10 @@ shared_ptr<ResultSet> ScanAttribute::initResultSet() {
     return resultSet;
 }
 
+void ScanAttribute::reInitToRerunSubPlan() {
+    prevOperator->reInitToRerunSubPlan();
+}
+
 void ScanAttribute::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
     PhysicalOperator::printMetricsToJson(json, profiler);
     printBufferManagerMetrics(json, profiler);

--- a/src/processor/physical_plan/operator/skip.cpp
+++ b/src/processor/physical_plan/operator/skip.cpp
@@ -8,11 +8,6 @@ shared_ptr<ResultSet> Skip::initResultSet() {
     return resultSet;
 }
 
-void Skip::reInitialize() {
-    PhysicalOperator::reInitialize();
-    FilteringOperator::reInitialize();
-}
-
 bool Skip::getNextTuples() {
     metrics->executionTime.start();
     auto& dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -180,3 +180,34 @@ TEST_F(BinderErrorTest, AggregationWithGroupBy) {
     auto input = "MATCH (a:person) RETURN a, COUNT(*);";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
+
+TEST_F(BinderErrorTest, SubqueryWithAggregation1) {
+    string expectedException = "Expression EXISTS { MATCH (a)-[:knows]->(b:person) RETURN COUNT(*) "
+                               "} is an existential subquery expression and should not contains "
+                               "any aggregation or order by in subquery RETURN or WITH clause.";
+    auto input = "MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) RETURN COUNT(*) } "
+                 "RETURN COUNT(*);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, SubqueryWithAggregation2) {
+    string expectedException =
+        "Expression EXISTS { MATCH (a)-[:knows]->(b:person) WITH COUNT(*) AS k RETURN k+1 } is an "
+        "existential subquery expression and should not contains any aggregation or order by in "
+        "subquery RETURN or WITH clause.";
+    auto input = "MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WITH COUNT(*) AS "
+                 "k RETURN k+1 } "
+                 "RETURN COUNT(*);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, SubqueryWithOrderBy) {
+    string expectedException =
+        "Expression EXISTS { MATCH (a)-[:knows]->(b:person) RETURN b ORDER "
+        "BY b.age } is an existential subquery expression and should not "
+        "contains any aggregation or order by in subquery RETURN or WITH clause.";
+    auto input =
+        "MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) RETURN b ORDER BY b.age } "
+        "RETURN COUNT(*);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}


### PR DESCRIPTION
This PR contains the following changes

### Exists operator refactor
- Remove sink operator from sub-plan and pull only once from sub-plan for each outer-plan input. The consequence of such design is that we have to reInitialize() for each outer-plan input.

### Reinitialize() interface refactor
- Rename reInitialize() to reInitialize() state.
- This interface only reInitialize local state (including operator level local state, e.g. Filtering Operator Interface's prevNumSelectedValue and resultSet level local state e.g. currentIdx) and will throw exception when reInitializing global state.

### Minor change
- Add Binder level validation to ensure subquery do not contain aggregation and order by (This is not a temporary solution and remains true under the semantic of Cypher 9)

