### PR TITLE
refactor prevOperator to vector for logical operator

### DIFF
--- a/src/main/system.cpp
+++ b/src/main/system.cpp
@@ -43,7 +43,7 @@ void System::executeQuery(SessionContext& context) const {
     auto boundQuery = QueryBinder(graph->getCatalog()).bind(*parsedQuery);
 
     auto logicalPlan = Planner::getBestPlan(*graph, *boundQuery);
-    if (logicalPlan->containAggregation && context.numThreads > 1) {
+    if (logicalPlan->containAggregation() && context.numThreads > 1) {
         throw invalid_argument("Aggregation with multi-threading is not implemented.");
     }
 

--- a/src/planner/BUILD.bazel
+++ b/src/planner/BUILD.bazel
@@ -35,6 +35,9 @@ cc_library(
 
 cc_library(
     name = "base_logical_operator",
+    srcs = [
+        "logical_plan/operator/logical_operator.cpp",
+    ],
     hdrs = [
         "include/logical_plan/operator/logical_operator.h",
     ],

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -36,6 +36,8 @@ public:
 private:
     vector<unique_ptr<LogicalPlan>> enumeratePlans(const BoundSingleQuery& singleQuery);
 
+    // See logical_plan.h for detailed description of our sub-plan limitation.
+    vector<unique_ptr<LogicalPlan>> getValidSubPlans(vector<unique_ptr<LogicalPlan>> plans);
     unique_ptr<LogicalPlan> getBestPlan(vector<unique_ptr<LogicalPlan>> plans);
 
     vector<unique_ptr<LogicalPlan>> enumerateQueryPart(

--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -49,7 +49,7 @@ private:
         LogicalPlan& plan);
     void appendExtend(const RelExpression& queryRel, Direction direction, LogicalPlan& plan);
     void appendLogicalHashJoin(
-        const NodeExpression& joinNode, LogicalPlan& buildPlan, LogicalPlan& probePlan);
+        const NodeExpression& joinNode, LogicalPlan& probePlan, LogicalPlan& buildPlan);
     // appendIntersect return false if a nodeID is flat in which case we should use filter
     bool appendIntersect(const string& leftNodeID, const string& rightNodeID, LogicalPlan& plan);
 

--- a/src/planner/include/logical_plan/operator/aggregate/logical_aggregate.h
+++ b/src/planner/include/logical_plan/operator/aggregate/logical_aggregate.h
@@ -13,8 +13,8 @@ class LogicalAggregate : public LogicalOperator {
 public:
     LogicalAggregate(vector<shared_ptr<Expression>> expressionsToGroupBy,
         vector<shared_ptr<Expression>> expressionsToAggregate,
-        unique_ptr<Schema> schemaBeforeAggregate, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{move(prevOperator)}, expressionsToGroupBy{move(expressionsToGroupBy)},
+        unique_ptr<Schema> schemaBeforeAggregate, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, expressionsToGroupBy{move(expressionsToGroupBy)},
           expressionsToAggregate{move(expressionsToAggregate)}, schemaBeforeAggregate{
                                                                     move(schemaBeforeAggregate)} {}
 
@@ -42,7 +42,7 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalAggregate>(expressionsToGroupBy, expressionsToAggregate,
-            schemaBeforeAggregate->copy(), prevOperator->copy());
+            schemaBeforeAggregate->copy(), children[0]->copy());
     }
 
 private:

--- a/src/planner/include/logical_plan/operator/exists/logical_exist.h
+++ b/src/planner/include/logical_plan/operator/exists/logical_exist.h
@@ -6,36 +6,26 @@
 namespace graphflow {
 namespace planner {
 
+// Sub-plan last operator on right, i.e. children[1].
 class LogicalExists : public LogicalOperator {
 
 public:
-    LogicalExists(shared_ptr<Expression> subqueryExpression,
-        shared_ptr<LogicalOperator> subPlanLastOperator, unique_ptr<Schema> subPlanSchema,
-        shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{move(prevOperator)}, subqueryExpression{move(subqueryExpression)},
-          subPlanLastOperator{move(subPlanLastOperator)}, subPlanSchema{move(subPlanSchema)} {}
+    LogicalExists(shared_ptr<Expression> subqueryExpression, unique_ptr<Schema> subPlanSchema,
+        shared_ptr<LogicalOperator> child, shared_ptr<LogicalOperator> subPlanChild)
+        : LogicalOperator{move(child), move(subPlanChild)},
+          subqueryExpression{move(subqueryExpression)}, subPlanSchema{move(subPlanSchema)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override { return LOGICAL_EXISTS; }
-
-    string toString(uint64_t depth = 0) const override {
-        string result = LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
-                        getExpressionsForPrinting() + "]\n";
-        result += prevOperator->toString(depth + 1);
-        result += "\nSUBPLAN: \n";
-        result += subPlanLastOperator->toString(depth + 1);
-        return result;
-    }
 
     string getExpressionsForPrinting() const override { return string(); }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalExists>(subqueryExpression, subPlanLastOperator->copy(),
-            subPlanSchema->copy(), prevOperator->copy());
+        return make_unique<LogicalExists>(
+            subqueryExpression, subPlanSchema->copy(), children[0]->copy(), children[1]->copy());
     }
 
 public:
     shared_ptr<Expression> subqueryExpression;
-    shared_ptr<LogicalOperator> subPlanLastOperator;
     unique_ptr<Schema> subPlanSchema;
 };
 

--- a/src/planner/include/logical_plan/operator/extend/logical_extend.h
+++ b/src/planner/include/logical_plan/operator/extend/logical_extend.h
@@ -10,8 +10,8 @@ class LogicalExtend : public LogicalOperator {
 public:
     LogicalExtend(const string& boundNodeID, label_t boundNodeLabel, const string& nbrNodeID,
         label_t nbrNodeLabel, label_t relLabel, Direction direction, bool isColumn,
-        uint8_t lowerBound, uint8_t upperBound, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, boundNodeID{boundNodeID}, boundNodeLabel{boundNodeLabel},
+        uint8_t lowerBound, uint8_t upperBound, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, boundNodeID{boundNodeID}, boundNodeLabel{boundNodeLabel},
           nbrNodeID{nbrNodeID}, nbrNodeLabel{nbrNodeLabel}, relLabel{relLabel},
           direction{direction}, isColumn{isColumn}, lowerBound{lowerBound}, upperBound{upperBound} {
     }
@@ -26,7 +26,7 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalExtend>(boundNodeID, boundNodeLabel, nbrNodeID, nbrNodeLabel,
-            relLabel, direction, isColumn, lowerBound, upperBound, prevOperator->copy());
+            relLabel, direction, isColumn, lowerBound, upperBound, children[0]->copy());
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/filter/logical_filter.h
+++ b/src/planner/include/logical_plan/operator/filter/logical_filter.h
@@ -12,9 +12,9 @@ class LogicalFilter : public LogicalOperator {
 
 public:
     LogicalFilter(shared_ptr<Expression> expression, uint32_t groupPosToSelect,
-        shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, expression{expression}, groupPosToSelect{
-                                                                     groupPosToSelect} {}
+        shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, expression{move(expression)}, groupPosToSelect{
+                                                                          groupPosToSelect} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_FILTER;
@@ -23,7 +23,7 @@ public:
     string getExpressionsForPrinting() const override { return expression->getUniqueName(); }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalFilter>(expression, groupPosToSelect, prevOperator->copy());
+        return make_unique<LogicalFilter>(expression, groupPosToSelect, children[0]->copy());
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/flatten/logical_flatten.h
+++ b/src/planner/include/logical_plan/operator/flatten/logical_flatten.h
@@ -10,8 +10,8 @@ namespace planner {
 class LogicalFlatten : public LogicalOperator {
 
 public:
-    LogicalFlatten(string variable, const shared_ptr<LogicalOperator>& prevOperator)
-        : LogicalOperator{prevOperator}, variable{move(variable)} {}
+    LogicalFlatten(string variable, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, variable{move(variable)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_FLATTEN;
@@ -20,7 +20,7 @@ public:
     string getExpressionsForPrinting() const override { return variable; }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalFlatten>(variable, prevOperator->copy());
+        return make_unique<LogicalFlatten>(variable, children[0]->copy());
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
+++ b/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
@@ -9,36 +9,25 @@ namespace planner {
 class LogicalHashJoin : public LogicalOperator {
 
 public:
-    LogicalHashJoin(string joinNodeID, shared_ptr<LogicalOperator> buildSidePrevOperator,
-        unique_ptr<Schema> buildSideSchema, shared_ptr<LogicalOperator> probeSidePrevOperator)
-        : LogicalOperator(move(probeSidePrevOperator)),
-          joinNodeID(move(joinNodeID)), buildSidePrevOperator{move(buildSidePrevOperator)},
+    // Probe side on left, i.e. children[0]. Build side on right, i.e. children[1].
+    LogicalHashJoin(string joinNodeID, unique_ptr<Schema> buildSideSchema,
+        shared_ptr<LogicalOperator> probeSideChild, shared_ptr<LogicalOperator> buildSideChild)
+        : LogicalOperator{move(probeSideChild), move(buildSideChild)}, joinNodeID(move(joinNodeID)),
           buildSideSchema(move(buildSideSchema)) {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_HASH_JOIN;
     }
 
-    string toString(uint64_t depth = 0) const {
-        string result = LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
-                        getExpressionsForPrinting() + "]";
-        result += "\nBUILD SIDE: \n";
-        result += buildSidePrevOperator->toString(depth + 1);
-        result += "\nPROBE SIDE: \n";
-        result += prevOperator->toString(depth + 1);
-        return result;
-    }
-
     string getExpressionsForPrinting() const override { return joinNodeID; }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalHashJoin>(joinNodeID, buildSidePrevOperator->copy(),
-            buildSideSchema->copy(), prevOperator->copy());
+        return make_unique<LogicalHashJoin>(
+            joinNodeID, buildSideSchema->copy(), children[0]->copy(), children[1]->copy());
     }
 
 public:
     const string joinNodeID;
-    shared_ptr<LogicalOperator> buildSidePrevOperator;
     unique_ptr<Schema> buildSideSchema;
 };
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/intersect/logical_intersect.h
+++ b/src/planner/include/logical_plan/operator/intersect/logical_intersect.h
@@ -13,10 +13,9 @@ namespace planner {
 class LogicalIntersect : public LogicalOperator {
 
 public:
-    LogicalIntersect(
-        string leftNodeID, string rightNodeID, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{move(prevOperator)}, leftNodeID{move(leftNodeID)}, rightNodeID{move(
-                                                                                 rightNodeID)} {}
+    LogicalIntersect(string leftNodeID, string rightNodeID, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, leftNodeID{move(leftNodeID)}, rightNodeID{
+                                                                          move(rightNodeID)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_INTERSECT;
@@ -28,7 +27,7 @@ public:
     inline string getRightNodeID() const { return rightNodeID; }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalIntersect>(leftNodeID, rightNodeID, prevOperator->copy());
+        return make_unique<LogicalIntersect>(leftNodeID, rightNodeID, children[0]->copy());
     }
 
 private:

--- a/src/planner/include/logical_plan/operator/limit/logical_limit.h
+++ b/src/planner/include/logical_plan/operator/limit/logical_limit.h
@@ -9,8 +9,8 @@ class LogicalLimit : public LogicalOperator {
 
 public:
     LogicalLimit(uint64_t limitNumber, uint32_t groupPosToSelect, vector<uint32_t> groupsPosToLimit,
-        shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{move(prevOperator)}, limitNumber{limitNumber},
+        shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, limitNumber{limitNumber},
           groupPosToSelect{groupPosToSelect}, groupsPosToLimit{move(groupsPosToLimit)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override { return LOGICAL_LIMIT; }
@@ -23,7 +23,7 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalLimit>(
-            limitNumber, groupPosToSelect, groupsPosToLimit, prevOperator->copy());
+            limitNumber, groupPosToSelect, groupsPosToLimit, children[0]->copy());
     }
 
 private:

--- a/src/planner/include/logical_plan/operator/multiplicity_reducer/logical_multiplcity_reducer.h
+++ b/src/planner/include/logical_plan/operator/multiplicity_reducer/logical_multiplcity_reducer.h
@@ -8,8 +8,8 @@ namespace planner {
 class LogicalMultiplicityReducer : public LogicalOperator {
 
 public:
-    explicit LogicalMultiplicityReducer(shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator(move(prevOperator)) {}
+    explicit LogicalMultiplicityReducer(shared_ptr<LogicalOperator> child)
+        : LogicalOperator(move(child)) {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_MULTIPLICITY_REDUCER;
@@ -18,7 +18,7 @@ public:
     string getExpressionsForPrinting() const override { return string(); }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalMultiplicityReducer>(prevOperator->copy());
+        return make_unique<LogicalMultiplicityReducer>(children[0]->copy());
     }
 };
 

--- a/src/planner/include/logical_plan/operator/order_by/logical_order_by.h
+++ b/src/planner/include/logical_plan/operator/order_by/logical_order_by.h
@@ -12,9 +12,9 @@ class LogicalOrderBy : public LogicalOperator {
 
 public:
     LogicalOrderBy(vector<shared_ptr<Expression>> expressions, vector<bool> sortOrders,
-        shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{move(prevOperator)}, orderByExpressions{move(expressions)},
-          isAscOrders{move(sortOrders)} {}
+        shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, orderByExpressions{move(expressions)}, isAscOrders{move(
+                                                                                   sortOrders)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_ORDER_BY;
@@ -29,7 +29,7 @@ public:
     }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalOrderBy>(orderByExpressions, isAscOrders, prevOperator->copy());
+        return make_unique<LogicalOrderBy>(orderByExpressions, isAscOrders, children[0]->copy());
     }
 
 private:

--- a/src/planner/include/logical_plan/operator/projection/logical_projection.h
+++ b/src/planner/include/logical_plan/operator/projection/logical_projection.h
@@ -10,8 +10,8 @@ class LogicalProjection : public LogicalOperator {
 
 public:
     explicit LogicalProjection(vector<shared_ptr<Expression>> expressions,
-        vector<uint32_t> discardedGroupsPos, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{move(prevOperator)}, expressionsToProject{move(expressions)},
+        vector<uint32_t> discardedGroupsPos, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, expressionsToProject{move(expressions)},
           discardedGroupsPos{move(discardedGroupsPos)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
@@ -28,7 +28,7 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalProjection>(
-            expressionsToProject, discardedGroupsPos, prevOperator->copy());
+            expressionsToProject, discardedGroupsPos, children[0]->copy());
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
+++ b/src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h
@@ -10,9 +10,6 @@ class LogicalScanNodeID : public LogicalOperator {
 public:
     LogicalScanNodeID(string nodeID, label_t label) : nodeID{move(nodeID)}, label{label} {}
 
-    LogicalScanNodeID(string nodeID, label_t label, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, nodeID{move(nodeID)}, label{label} {}
-
     LogicalOperatorType getLogicalOperatorType() const {
         return LogicalOperatorType::LOGICAL_SCAN_NODE_ID;
     }
@@ -20,8 +17,7 @@ public:
     string getExpressionsForPrinting() const override { return nodeID; }
 
     unique_ptr<LogicalOperator> copy() override {
-        return prevOperator ? make_unique<LogicalScanNodeID>(nodeID, label, prevOperator->copy()) :
-                              make_unique<LogicalScanNodeID>(nodeID, label);
+        return make_unique<LogicalScanNodeID>(nodeID, label);
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
@@ -9,8 +9,8 @@ class LogicalScanNodeProperty : public LogicalOperator {
 
 public:
     LogicalScanNodeProperty(string nodeID, label_t nodeLabel, string propertyVariableName,
-        uint32_t propertyKey, bool isUnstructuredProperty, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, nodeID{move(nodeID)}, nodeLabel{nodeLabel},
+        uint32_t propertyKey, bool isUnstructuredProperty, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, nodeID{move(nodeID)}, nodeLabel{nodeLabel},
           propertyVariableName{move(propertyVariableName)}, propertyKey{propertyKey},
           isUnstructuredProperty{isUnstructuredProperty} {}
 
@@ -22,7 +22,7 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalScanNodeProperty>(nodeID, nodeLabel, propertyVariableName,
-            propertyKey, isUnstructuredProperty, prevOperator->copy());
+            propertyKey, isUnstructuredProperty, children[0]->copy());
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
@@ -10,8 +10,8 @@ class LogicalScanRelProperty : public LogicalOperator {
 public:
     LogicalScanRelProperty(string boundNodeID, label_t boundNodeLabel, string nbrNodeID,
         label_t relLabel, Direction direction, string propertyVariableName, uint32_t propertyKey,
-        bool isColumn, shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator{prevOperator}, boundNodeID{move(boundNodeID)},
+        bool isColumn, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, boundNodeID{move(boundNodeID)},
           boundNodeLabel{boundNodeLabel}, nbrNodeID{move(nbrNodeID)}, relLabel{relLabel},
           direction{direction}, propertyVariableName(move(propertyVariableName)),
           propertyKey{propertyKey}, isColumn{isColumn} {}
@@ -24,7 +24,7 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalScanRelProperty>(boundNodeID, boundNodeLabel, nbrNodeID, relLabel,
-            direction, propertyVariableName, propertyKey, isColumn, prevOperator->copy());
+            direction, propertyVariableName, propertyKey, isColumn, children[0]->copy());
     }
 
 public:

--- a/src/planner/include/logical_plan/operator/skip/logical_skip.h
+++ b/src/planner/include/logical_plan/operator/skip/logical_skip.h
@@ -9,9 +9,9 @@ class LogicalSkip : public LogicalOperator {
 
 public:
     LogicalSkip(uint64_t skipNumber, uint32_t groupPosToSelect, vector<uint32_t> groupsPosToSkip,
-        shared_ptr<LogicalOperator> prevOperator)
-        : LogicalOperator(move(prevOperator)), skipNumber{skipNumber},
-          groupPosToSelect{groupPosToSelect}, groupsPosToSkip{move(groupsPosToSkip)} {}
+        shared_ptr<LogicalOperator> child)
+        : LogicalOperator(move(child)), skipNumber{skipNumber}, groupPosToSelect{groupPosToSelect},
+          groupsPosToSkip{move(groupsPosToSkip)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override { return LOGICAL_SKIP; }
 
@@ -23,7 +23,7 @@ public:
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalSkip>(
-            skipNumber, groupPosToSelect, groupsPosToSkip, prevOperator->copy());
+            skipNumber, groupPosToSelect, groupsPosToSkip, children[0]->copy());
     }
 
 private:

--- a/src/planner/logical_plan/logical_plan.cpp
+++ b/src/planner/logical_plan/logical_plan.cpp
@@ -13,7 +13,6 @@ unique_ptr<LogicalPlan> LogicalPlan::copy() const {
     auto plan = make_unique<LogicalPlan>(schema->copy());
     plan->lastOperator = lastOperator;
     plan->cost = cost;
-    plan->containAggregation = containAggregation;
     return plan;
 }
 

--- a/src/planner/logical_plan/operator/logical_operator.cpp
+++ b/src/planner/logical_plan/operator/logical_operator.cpp
@@ -1,0 +1,45 @@
+#include "src/planner/include/logical_plan/operator/logical_operator.h"
+
+#include <cassert>
+
+namespace graphflow {
+namespace planner {
+
+LogicalOperator::LogicalOperator(shared_ptr<LogicalOperator> child) {
+    children.push_back(move(child));
+}
+
+LogicalOperator::LogicalOperator(
+    shared_ptr<LogicalOperator> left, shared_ptr<LogicalOperator> right) {
+    children.push_back(move(left));
+    children.push_back(move(right));
+}
+
+bool LogicalOperator::descendantsContainType(
+    const unordered_set<LogicalOperatorType>& types) const {
+    if (types.contains(getLogicalOperatorType())) {
+        return true;
+    }
+    for (auto& child : children) {
+        if (child->descendantsContainType(types)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+string LogicalOperator::toString(uint64_t depth) const {
+    string result = string(depth * 4, ' ');
+    result += LogicalOperatorTypeNames[getLogicalOperatorType()] + "[" +
+              getExpressionsForPrinting() + "]";
+    if (children.size() == 1) {
+        result += "\n" + children[0]->toString(depth);
+    } else if (children.size() == 2) {
+        result += "\nLEFT:\n" + children[0]->toString(depth + 1);
+        result += "\nRIGHT:\n" + children[1]->toString(depth + 1);
+    }
+    return result;
+}
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/projection_enumerator.cpp
+++ b/src/planner/projection_enumerator.cpp
@@ -19,8 +19,6 @@ void ProjectionEnumerator::enumerateProjectionBody(const BoundProjectionBody& pr
         if (!expressionsToAggregate.empty()) {
             appendAggregate(getExpressionToGroupBy(projectionBody, *plan->schema),
                 expressionsToAggregate, *plan);
-            // See logical_plan.h for explanation.
-            plan->containAggregation = true;
         }
         if (projectionBody.hasOrderByExpressions()) {
             appendOrderBy(

--- a/test/planner/cost_model_test.cpp
+++ b/test/planner/cost_model_test.cpp
@@ -3,48 +3,72 @@
 #include "src/planner/include/logical_plan/operator/extend/logical_extend.h"
 #include "src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h"
 
-class CostModelTest : public PlannerTest {};
+class CostModelTest : public PlannerTest {
+
+public:
+};
 
 TEST_F(CostModelTest, OneHopSingleFilter) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = 1 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = *plan->lastOperator->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
-    ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
-    auto& op2 = *op1.prevOperator->prevOperator->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2.getLogicalOperatorType());
-    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op2).nodeID, "_a." + INTERNAL_ID_SUFFIX));
+    auto op1 = plan->lastOperator->getFirstChild()->getFirstChild().get();
+    ASSERT_EQ(LOGICAL_EXTEND, op1->getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalExtend*)op1)->nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
+    auto op2 = op1->getFirstChild()->getFirstChild()->getFirstChild()->getFirstChild().get();
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2->getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op2)->nodeID, "_a." + INTERNAL_ID_SUFFIX));
 }
 
 TEST_F(CostModelTest, OneHopMultiFilters) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age > 10 AND a.age < 20 AND b.age "
                  "= 45 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_EXTEND, op1.getLogicalOperatorType());
-    ASSERT_TRUE(containSubstr(((LogicalExtend&)op1).nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
-    auto& op2 = *op1.prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2.getLogicalOperatorType());
-    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op2).nodeID, "_a." + INTERNAL_ID_SUFFIX));
+    auto op1 = plan->lastOperator->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   .get();
+    ASSERT_EQ(LOGICAL_EXTEND, op1->getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalExtend*)op1)->nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
+    auto op2 = op1->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   .get();
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2->getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op2)->nodeID, "_a." + INTERNAL_ID_SUFFIX));
 }
 
 TEST_F(CostModelTest, TwoHop) {
     auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 =
-        *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
-    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID_SUFFIX));
+    auto op1 = plan->lastOperator->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   .get();
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1->getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op1)->nodeID, "_b." + INTERNAL_ID_SUFFIX));
 }
 
 TEST_F(CostModelTest, TwoHopMultiFilters) {
     auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE a.age = 20 AND "
                  "b.age = 35 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator
-                     ->prevOperator->prevOperator->prevOperator->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1.getLogicalOperatorType());
-    ASSERT_TRUE(containSubstr(((LogicalScanNodeID&)op1).nodeID, "_b." + INTERNAL_ID_SUFFIX));
+    auto op1 = plan->lastOperator->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   ->getFirstChild()
+                   .get();
+    ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1->getLogicalOperatorType());
+    ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op1)->nodeID, "_b." + INTERNAL_ID_SUFFIX));
 }
 
 // temporary tests for order by logical plans
@@ -52,13 +76,13 @@ TEST_F(CostModelTest, TwoHopMultiFilters) {
 TEST_F(PlannerTest, OrderByTest1) {
     auto query = "MATCH (a:person) RETURN a.age ORDER BY a.age";
     auto plan = getBestPlan(query);
-    auto& op1 = plan->lastOperator;
+    auto op1 = plan->lastOperator.get();
     ASSERT_EQ(LOGICAL_PROJECTION, op1->getLogicalOperatorType());
-    auto& op2 = op1->prevOperator;
+    auto op2 = op1->getFirstChild().get();
     ASSERT_EQ(LOGICAL_ORDER_BY, op2->getLogicalOperatorType());
-    auto& op3 = op2->prevOperator;
+    auto op3 = op2->getFirstChild().get();
     ASSERT_EQ(LOGICAL_FLATTEN, op3->getLogicalOperatorType());
-    auto& op4 = op3->prevOperator;
+    auto op4 = op3->getFirstChild().get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op4->getLogicalOperatorType());
 }
 
@@ -66,21 +90,21 @@ TEST_F(PlannerTest, OrderByTest1) {
 TEST_F(PlannerTest, OrderByTest2) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) RETURN b.age ORDER BY a.age";
     auto plan = getBestPlan(query);
-    auto& op1 = plan->lastOperator;
+    auto op1 = plan->lastOperator.get();
     ASSERT_EQ(LOGICAL_PROJECTION, op1->getLogicalOperatorType());
-    auto& op2 = op1->prevOperator;
+    auto op2 = op1->getFirstChild().get();
     ASSERT_EQ(LOGICAL_ORDER_BY, op2->getLogicalOperatorType());
-    auto& op3 = op2->prevOperator;
+    auto op3 = op2->getFirstChild().get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op3->getLogicalOperatorType());
-    auto& op4 = op3->prevOperator;
+    auto op4 = op3->getFirstChild().get();
     ASSERT_EQ(LOGICAL_EXTEND, op4->getLogicalOperatorType());
 }
 
 TEST_F(PlannerTest, OrderByTest3) {
     auto query = "MATCH (a:person) RETURN COUNT(*) ORDER BY COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op1 = plan->lastOperator->prevOperator;
+    auto op1 = plan->lastOperator->getFirstChild().get();
     ASSERT_EQ(LOGICAL_ORDER_BY, op1->getLogicalOperatorType());
-    auto& op2 = op1->prevOperator;
+    auto op2 = op1->getFirstChild().get();
     ASSERT_EQ(LOGICAL_AGGREGATE, op2->getLogicalOperatorType());
 }

--- a/test/planner/property_scan_push_down_test.cpp
+++ b/test/planner/property_scan_push_down_test.cpp
@@ -1,6 +1,5 @@
 #include "test/planner/planner_test_helper.h"
 
-#include "src/planner/include/logical_plan/operator/aggregate/logical_aggregate.h"
 #include "src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h"
 
 class PropertyScanPushDownTest : public PlannerTest {};
@@ -9,21 +8,30 @@ class PropertyScanPushDownTest : public PlannerTest {};
 TEST_F(PropertyScanPushDownTest, FilterPropertyPushDownTest) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = b.age RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto& op = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator
-                    ->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op.getLogicalOperatorType());
-    auto& scanNodeProperty = (LogicalScanNodeProperty&)op;
-    ASSERT_TRUE(containSubstr(scanNodeProperty.nodeID, "_b." + INTERNAL_ID_SUFFIX));
+    auto op = plan->lastOperator->getFirstChild()
+                  ->getFirstChild()
+                  ->getFirstChild()
+                  ->getFirstChild()
+                  ->getFirstChild()
+                  ->getFirstChild()
+                  .get();
+    ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op->getLogicalOperatorType());
+    auto scanNodeProperty = (LogicalScanNodeProperty*)op;
+    ASSERT_TRUE(containSubstr(scanNodeProperty->nodeID, "_b." + INTERNAL_ID_SUFFIX));
 }
 
 // Assume optimizer picks QVO: b, a
 TEST_F(PropertyScanPushDownTest, ProjectionPropertyPushDownTest) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) RETURN a.age, b.age";
     auto plan = getBestPlan(query);
-    auto& op = *plan->lastOperator->prevOperator->prevOperator->prevOperator->prevOperator;
-    ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op.getLogicalOperatorType());
-    auto& scanNodeProperty = (LogicalScanNodeProperty&)op;
-    ASSERT_TRUE(containSubstr(scanNodeProperty.nodeID, "_b." + INTERNAL_ID_SUFFIX));
+    auto op = plan->lastOperator->getFirstChild()
+                  ->getFirstChild()
+                  ->getFirstChild()
+                  ->getFirstChild()
+                  .get();
+    ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op->getLogicalOperatorType());
+    auto scanNodeProperty = (LogicalScanNodeProperty*)op;
+    ASSERT_TRUE(containSubstr(scanNodeProperty->nodeID, "_b." + INTERNAL_ID_SUFFIX));
 }
 
 // This test is to capture the bug where operator is not cloned (might lead to a bug where change of
@@ -35,7 +43,7 @@ TEST_F(PropertyScanPushDownTest, LogicalPlanCloneTest) {
     auto plan = move(getAllPlans(query)[1]);
     auto op = plan->lastOperator.get();
     while (op->getLogicalOperatorType() != LOGICAL_SCAN_NODE_PROPERTY) {
-        op = op->prevOperator.get();
+        op = op->getFirstChild().get();
     }
-    ASSERT_TRUE(op->prevOperator->getLogicalOperatorType() != LOGICAL_SCAN_NODE_PROPERTY);
+    ASSERT_TRUE(op->getFirstChild()->getLogicalOperatorType() != LOGICAL_SCAN_NODE_PROPERTY);
 }

--- a/test/runner/queries/subquery/subquery.test
+++ b/test/runner/queries/subquery/subquery.test
@@ -20,6 +20,12 @@
 ---- 1
 1
 
+# test our sub-plan should not contain hash join
+-NAME ExistSubqueryTest5
+-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person)-[:knows]->(c:person), (a)-[:knows]->(d:person)-[:knows]->(e:person) RETURN a.ID } RETURN COUNT(*)
+---- 1
+4
+
 -NAME NotExistSubqueryTest
 -QUERY MATCH (a:person) WHERE NOT EXISTS { MATCH (a)-[:knows]->(b:person) RETURN a.ID } RETURN COUNT(*)
 ---- 1


### PR DESCRIPTION
This PR contains the following changes

### Logical Operator
- Use `vector<shared_ptr<LogicalOperator>>` to replace `shared_ptr<LogicalOperator>`. So we do not need to know specific operator types to traverse a logical plan.
- Add logical plan traversal logic to find operators with a particular type
  -  Find plans with aggregation to avoid multi-thread execution on aggregation
  -  Find plans with pipeline-breaker to avoid executing sub-plan with multiple pipelines (described in issue #438). Also add test cases.

### Minor change
HashJoin Probe now on left side and Build on right side.