### PR TITLE
Physical op children refactor

### DIFF
--- a/src/main/BUILD.bazel
+++ b/src/main/BUILD.bazel
@@ -12,7 +12,6 @@ cc_library(
     deps = [
         "//src/common:profiler",
         "//src/planner:logical_plan",
-        "//src/processor:operator_impls",
         "//src/processor:physical_plan",
     ],
 )

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -222,12 +222,12 @@ cc_library(
     ],
     hdrs = [
         "include/processor.h",
-        "include/processor_task.h"
+        "include/processor_task.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "operator_impls",
         "physical_plan",
-        "//src/common:task_system"
+        "result_collector",
+        "//src/common:task_system",
     ],
 )

--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
@@ -28,9 +28,11 @@ struct AggregationSharedState {
 class SimpleAggregate : public Sink {
 
 public:
-    SimpleAggregate(unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context,
-        uint32_t id, shared_ptr<AggregationSharedState> aggregationSharedState,
+    SimpleAggregate(unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id,
+        shared_ptr<AggregationSharedState> aggregationSharedState,
         vector<unique_ptr<AggregateExpressionEvaluator>> aggregationEvaluators);
+
+    PhysicalOperatorType getOperatorType() override { return AGGREGATION; }
 
     shared_ptr<ResultSet> initResultSet() override;
 

--- a/src/processor/include/physical_plan/operator/filter.h
+++ b/src/processor/include/physical_plan/operator/filter.h
@@ -13,10 +13,11 @@ class Filter : public PhysicalOperator, public FilteringOperator {
 
 public:
     Filter(unique_ptr<ExpressionEvaluator> rootExpr, uint32_t dataChunkToSelectPos,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), FILTER, context, id},
-          FilteringOperator(), rootExpr{move(rootExpr)},
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(child), context, id}, FilteringOperator{}, rootExpr{move(rootExpr)},
           dataChunkToSelectPos(dataChunkToSelectPos) {}
+
+    PhysicalOperatorType getOperatorType() override { return FILTER; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -24,7 +25,10 @@ public:
 
     bool getNextTuples() override;
 
-    unique_ptr<PhysicalOperator> clone() override;
+    unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<Filter>(
+            rootExpr->clone(), dataChunkToSelectPos, children[0]->clone(), context, id);
+    }
 
 private:
     unique_ptr<ExpressionEvaluator> rootExpr;

--- a/src/processor/include/physical_plan/operator/flatten.h
+++ b/src/processor/include/physical_plan/operator/flatten.h
@@ -8,10 +8,12 @@ namespace processor {
 class Flatten : public PhysicalOperator {
 
 public:
-    Flatten(uint32_t dataChunkToFlattenPos, unique_ptr<PhysicalOperator> prevOperator,
+    Flatten(uint32_t dataChunkToFlattenPos, unique_ptr<PhysicalOperator> child,
         ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), FLATTEN, context, id}, dataChunkToFlattenPos{
-                                                                          dataChunkToFlattenPos} {}
+        : PhysicalOperator{move(child), context, id}, dataChunkToFlattenPos{dataChunkToFlattenPos} {
+    }
+
+    PhysicalOperatorType getOperatorType() override { return FLATTEN; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -20,7 +22,7 @@ public:
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Flatten>(dataChunkToFlattenPos, prevOperator->clone(), context, id);
+        return make_unique<Flatten>(dataChunkToFlattenPos, children[0]->clone(), context, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -54,24 +54,23 @@ public:
 
 class HashJoinBuild : public Sink {
 public:
-    HashJoinBuild(const BuildDataInfo& buildDataInfo, unique_ptr<PhysicalOperator> prevOperator,
-        ExecutionContext& context, uint32_t id);
+    HashJoinBuild(shared_ptr<HashJoinSharedState> sharedState, const BuildDataInfo& buildDataInfo,
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
+
+    PhysicalOperatorType getOperatorType() override { return HASH_JOIN_BUILD; }
 
     shared_ptr<ResultSet> initResultSet() override;
     void execute() override;
     void finalize() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-
-        auto cloneOp =
-            make_unique<HashJoinBuild>(buildDataInfo, prevOperator->clone(), context, id);
-        cloneOp->sharedState = this->sharedState;
-        return cloneOp;
+        return make_unique<HashJoinBuild>(
+            sharedState, buildDataInfo, children[0]->clone(), context, id);
     }
 
+private:
     shared_ptr<HashJoinSharedState> sharedState;
 
-private:
     BuildDataInfo buildDataInfo;
     shared_ptr<DataChunk> keyDataChunk;
     vector<shared_ptr<ValueVector>> vectorsToAppend;

--- a/src/processor/include/physical_plan/operator/intersect.h
+++ b/src/processor/include/physical_plan/operator/intersect.h
@@ -10,9 +10,11 @@ class Intersect : public PhysicalOperator, public FilteringOperator {
 
 public:
     Intersect(const DataPos& leftDataPos, const DataPos& rightDataPos,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), INTERSECT, context, id}, FilteringOperator{},
-          leftDataPos{leftDataPos}, rightDataPos{rightDataPos}, leftIdx{0} {}
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(child), context, id}, FilteringOperator{}, leftDataPos{leftDataPos},
+          rightDataPos{rightDataPos}, leftIdx{0} {}
+
+    PhysicalOperatorType getOperatorType() override { return INTERSECT; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -21,8 +23,7 @@ public:
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Intersect>(
-            leftDataPos, rightDataPos, prevOperator->clone(), context, id);
+        return make_unique<Intersect>(leftDataPos, rightDataPos, children[0]->clone(), context, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/limit.h
+++ b/src/processor/include/physical_plan/operator/limit.h
@@ -9,11 +9,13 @@ class Limit : public PhysicalOperator {
 
 public:
     Limit(uint64_t limitNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
-        vector<uint32_t> dataChunksToLimitPos, unique_ptr<PhysicalOperator> prevOperator,
+        vector<uint32_t> dataChunksToLimitPos, unique_ptr<PhysicalOperator> child,
         ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), LIMIT, context, id}, limitNumber{limitNumber},
+        : PhysicalOperator{move(child), context, id}, limitNumber{limitNumber},
           counter{move(counter)}, dataChunkToSelectPos{dataChunkToSelectPos},
           dataChunksToLimitPos(move(dataChunksToLimitPos)) {}
+
+    PhysicalOperatorType getOperatorType() override { return LIMIT; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -21,7 +23,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<Limit>(limitNumber, counter, dataChunkToSelectPos, dataChunksToLimitPos,
-            prevOperator->clone(), context, id);
+            children[0]->clone(), context, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/multiplicity_reducer.h
+++ b/src/processor/include/physical_plan/operator/multiplicity_reducer.h
@@ -8,10 +8,10 @@ namespace processor {
 class MultiplicityReducer : public PhysicalOperator {
 
 public:
-    MultiplicityReducer(
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), MULTIPLICITY_REDUCER, context, id},
-          prevMultiplicity{1}, numRepeat{0} {}
+    MultiplicityReducer(unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(child), context, id}, prevMultiplicity{1}, numRepeat{0} {}
+
+    PhysicalOperatorType getOperatorType() override { return MULTIPLICITY_REDUCER; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -20,7 +20,7 @@ public:
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<MultiplicityReducer>(prevOperator->clone(), context, id);
+        return make_unique<MultiplicityReducer>(children[0]->clone(), context, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/projection.h
+++ b/src/processor/include/physical_plan/operator/projection.h
@@ -15,10 +15,12 @@ class Projection : public PhysicalOperator {
 public:
     Projection(vector<unique_ptr<ExpressionEvaluator>> expressions,
         vector<DataPos> expressionsOutputPos, vector<uint32_t> discardedDataChunksPos,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator(move(prevOperator), PROJECTION, context, id),
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator(move(child), context, id),
           expressions(move(expressions)), expressionsOutputPos{move(expressionsOutputPos)},
           discardedDataChunksPos{move(discardedDataChunksPos)}, prevMultiplicity{0} {}
+
+    PhysicalOperatorType getOperatorType() override { return PROJECTION; }
 
     shared_ptr<ResultSet> initResultSet() override;
 

--- a/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
@@ -9,9 +9,10 @@ class AdjListExtend : public ReadList {
 
 public:
     AdjListExtend(const DataPos& inDataPos, const DataPos& outDataPos, AdjLists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : ReadList{inDataPos, outDataPos, lists, move(prevOperator), context, id,
-              true /* isAdjList */} {}
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : ReadList{inDataPos, outDataPos, lists, move(child), context, id, true /* isAdjList */} {}
+
+    PhysicalOperatorType getOperatorType() override { return LIST_EXTEND; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -19,7 +20,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<AdjListExtend>(
-            inDataPos, outDataPos, (AdjLists*)lists, prevOperator->clone(), context, id);
+            inDataPos, outDataPos, (AdjLists*)lists, children[0]->clone(), context, id);
     }
 };
 

--- a/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/frontier_extend.h
@@ -11,13 +11,18 @@ class FrontierExtend : public ReadList {
 public:
     FrontierExtend(const DataPos& inDataPos, const DataPos& outDataPos, AdjLists* lists,
         label_t outNodeIDVectorLabel, uint64_t lowerBound, uint64_t upperBound,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id);
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
+
+    PhysicalOperatorType getOperatorType() override { return FRONTIER_EXTEND; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
     bool getNextTuples() override;
 
-    unique_ptr<PhysicalOperator> clone() override;
+    unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<FrontierExtend>(inDataPos, outDataPos, (AdjLists*)lists,
+            outNodeIDVectorLabel, startLayer, endLayer, children[0]->clone(), context, id);
+    }
 
 private:
     bool computeFrontiers();

--- a/src/processor/include/physical_plan/operator/read_list/read_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_list.h
@@ -10,13 +10,13 @@ class ReadList : public PhysicalOperator {
 
 public:
     ReadList(const DataPos& inDataPos, const DataPos& outDataPos, Lists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id,
-        bool isAdjList)
-        : PhysicalOperator{move(prevOperator), READ_LIST, context, id}, inDataPos{inDataPos},
-          outDataPos{outDataPos}, lists{lists}, largeListHandle{
-                                                    make_unique<LargeListHandle>(isAdjList)} {}
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id, bool isAdjList)
+        : PhysicalOperator{move(child), context, id}, inDataPos{inDataPos}, outDataPos{outDataPos},
+          lists{lists}, largeListHandle{make_unique<LargeListHandle>(isAdjList)} {}
 
     ~ReadList() override{};
+
+    PhysicalOperatorType getOperatorType() override = 0;
 
     shared_ptr<ResultSet> initResultSet() override;
 

--- a/src/processor/include/physical_plan/operator/read_list/read_rel_property_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_rel_property_list.h
@@ -9,9 +9,11 @@ class ReadRelPropertyList : public ReadList {
 
 public:
     ReadRelPropertyList(const DataPos& inDataPos, const DataPos& outDataPos, Lists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : ReadList{inDataPos, outDataPos, lists, move(prevOperator), context, id,
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : ReadList{inDataPos, outDataPos, lists, move(child), context, id,
               false /* is not adj list */} {}
+
+    PhysicalOperatorType getOperatorType() override { return READ_REL_PROPERTY; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -19,7 +21,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ReadRelPropertyList>(
-            inDataPos, outDataPos, lists, prevOperator->clone(), context, id);
+            inDataPos, outDataPos, lists, children[0]->clone(), context, id);
     }
 };
 

--- a/src/processor/include/physical_plan/operator/result_collector.h
+++ b/src/processor/include/physical_plan/operator/result_collector.h
@@ -11,19 +11,19 @@ class ResultCollector : public Sink {
 
 public:
     explicit ResultCollector(vector<DataPos> vectorsToCollectPos,
-        unique_ptr<PhysicalOperator> prevOperator, PhysicalOperatorType operatorType,
-        ExecutionContext& context, uint32_t id)
-        : Sink{move(prevOperator), operatorType, context, id},
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : Sink{move(child), context, id},
           queryResult{make_unique<QueryResult>(vectorsToCollectPos)}, vectorsToCollectPos{move(
                                                                           vectorsToCollectPos)} {}
+
+    PhysicalOperatorType getOperatorType() override { return RESULT_COLLECTOR; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
     void execute() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ResultCollector>(
-            vectorsToCollectPos, prevOperator->clone(), operatorType, context, id);
+        return make_unique<ResultCollector>(vectorsToCollectPos, children[0]->clone(), context, id);
     }
 
 public:

--- a/src/processor/include/physical_plan/operator/result_scan.h
+++ b/src/processor/include/physical_plan/operator/result_scan.h
@@ -16,13 +16,15 @@ public:
     ResultScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> inDataPoses,
         uint32_t outDataChunkPos, vector<uint32_t> outValueVectorsPos, ExecutionContext& context,
         uint32_t id)
-        : PhysicalOperator{SELECT_SCAN, context, id}, SourceOperator{move(resultSetDescriptor)},
+        : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
           inDataPoses{move(inDataPoses)}, outDataChunkPos{outDataChunkPos},
           outValueVectorsPos{move(outValueVectorsPos)}, isFirstExecution{true} {}
 
     inline void setResultSetToCopyFrom(const ResultSet* resultSet) {
         resultSetToCopyFrom = resultSet;
     }
+
+    PhysicalOperatorType getOperatorType() override { return RESULT_SCAN; }
 
     shared_ptr<ResultSet> initResultSet() override;
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/adj_column_extend.h
@@ -11,9 +11,11 @@ class AdjColumnExtend : public ScanAttribute, public FilteringOperator {
 
 public:
     AdjColumnExtend(const DataPos& inDataPos, const DataPos& outDataPos, Column* column,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : ScanAttribute{inDataPos, outDataPos, move(prevOperator), context, id},
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : ScanAttribute{inDataPos, outDataPos, move(child), context, id},
           FilteringOperator(), column{column} {}
+
+    PhysicalOperatorType getOperatorType() override { return COLUMN_EXTEND; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -23,7 +25,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<AdjColumnExtend>(
-            inDataPos, outDataPos, column, prevOperator->clone(), context, id);
+            inDataPos, outDataPos, column, children[0]->clone(), context, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_attribute.h
@@ -11,9 +11,11 @@ class ScanAttribute : public PhysicalOperator {
 
 public:
     ScanAttribute(const DataPos& inDataPos, const DataPos& outDataPos,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), SCAN_ATTRIBUTE, context, id}, inDataPos{inDataPos},
-          outDataPos{outDataPos} {}
+        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(child), context, id}, inDataPos{inDataPos}, outDataPos{outDataPos} {
+    }
+
+    PhysicalOperatorType getOperatorType() override = 0;
 
     shared_ptr<ResultSet> initResultSet() override;
 

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_structured_property.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_structured_property.h
@@ -13,13 +13,15 @@ public:
         unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
         : ScanAttribute{inDataPos, outDataPos, move(prevOperator), context, id}, column{column} {}
 
+    PhysicalOperatorType getOperatorType() override { return SCAN_STRUCTURED_PROPERTY; }
+
     shared_ptr<ResultSet> initResultSet() override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ScanStructuredProperty>(
-            inDataPos, outDataPos, column, prevOperator->clone(), context, id);
+            inDataPos, outDataPos, column, children[0]->clone(), context, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/scan_attribute/scan_unstructured_property.h
+++ b/src/processor/include/physical_plan/operator/scan_attribute/scan_unstructured_property.h
@@ -12,12 +12,14 @@ class ScanUnstructuredProperty : public ScanAttribute {
 
 public:
     ScanUnstructuredProperty(const DataPos& inDataPos, const DataPos& outDataPos,
-        uint32_t propertyKey, UnstructuredPropertyLists* lists,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
-        : ScanAttribute{inDataPos, outDataPos, move(prevOperator), context, id},
+        uint32_t propertyKey, UnstructuredPropertyLists* lists, unique_ptr<PhysicalOperator> child,
+        ExecutionContext& context, uint32_t id)
+        : ScanAttribute{inDataPos, outDataPos, move(child), context, id},
           propertyKey{propertyKey}, lists{lists} {}
 
     ~ScanUnstructuredProperty(){};
+
+    PhysicalOperatorType getOperatorType() override { return SCAN_UNSTRUCTURED_PROPERTY; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -25,7 +27,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ScanUnstructuredProperty>(
-            inDataPos, outDataPos, propertyKey, lists, prevOperator->clone(), context, id);
+            inDataPos, outDataPos, propertyKey, lists, children[0]->clone(), context, id);
     }
 
 protected:

--- a/src/processor/include/physical_plan/operator/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id.h
@@ -13,8 +13,10 @@ public:
     ScanNodeID(unique_ptr<ResultSetDescriptor> resultSetDescriptor, label_t nodeLabel,
         const DataPos& outDataPos, shared_ptr<MorselsDesc> morsel, ExecutionContext& context,
         uint32_t id)
-        : PhysicalOperator{SCAN, context, id}, SourceOperator{move(resultSetDescriptor)},
+        : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
           nodeLabel{nodeLabel}, outDataPos{outDataPos}, morsel{move(morsel)} {}
+
+    PhysicalOperatorType getOperatorType() override { return SCAN_NODE_ID; }
 
     shared_ptr<ResultSet> initResultSet() override;
 

--- a/src/processor/include/physical_plan/operator/sink.h
+++ b/src/processor/include/physical_plan/operator/sink.h
@@ -8,21 +8,20 @@ namespace processor {
 class Sink : public PhysicalOperator {
 
 public:
-    Sink(unique_ptr<PhysicalOperator> prevOperator, PhysicalOperatorType operatorType,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), operatorType, context, id} {}
+    Sink(unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+        : PhysicalOperator{move(child), context, id} {}
+
+    PhysicalOperatorType getOperatorType() override = 0;
 
     shared_ptr<ResultSet> initResultSet() override = 0;
 
-    // In case there is a sub-plan, the pipeline under sink might be executed repeatedly and thus
-    // require a re-initialization after each execution.
     virtual void execute() { initResultSet(); };
 
     bool getNextTuples() final {
         throw invalid_argument("Sink operator should implement execute instead of getNextTuples");
     }
 
-    virtual void finalize() {}
+    virtual void finalize(){};
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/skip.h
+++ b/src/processor/include/physical_plan/operator/skip.h
@@ -10,12 +10,14 @@ class Skip : public PhysicalOperator, public FilteringOperator {
 
 public:
     Skip(uint64_t skipNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
-        vector<uint32_t> dataChunksToSkipPos, unique_ptr<PhysicalOperator> prevOperator,
+        vector<uint32_t> dataChunksToSkipPos, unique_ptr<PhysicalOperator> child,
         ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(prevOperator), SKIP, context, id},
+        : PhysicalOperator{move(child), context, id},
           FilteringOperator(), skipNumber{skipNumber}, counter{move(counter)},
           dataChunkToSelectPos{dataChunkToSelectPos}, dataChunksToSkipPos{
                                                           move(dataChunksToSkipPos)} {}
+
+    PhysicalOperatorType getOperatorType() override { return SKIP; }
 
     shared_ptr<ResultSet> initResultSet() override;
 
@@ -23,7 +25,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<Skip>(skipNumber, counter, dataChunkToSelectPos, dataChunksToSkipPos,
-            prevOperator->clone(), context, id);
+            children[0]->clone(), context, id);
     }
 
 private:

--- a/src/processor/physical_plan/operator/exists.cpp
+++ b/src/processor/physical_plan/operator/exists.cpp
@@ -6,36 +6,31 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> Exists::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     auto dataChunkToWrite = resultSet->dataChunks[outDataPos.dataChunkPos].get();
     valueVectorToWrite = make_shared<ValueVector>(context.memoryManager, BOOL);
     dataChunkToWrite->insert(outDataPos.valueVectorPos, valueVectorToWrite);
     // side way information passing: give resultSet reference to subPlan
-    auto op = subPlanLastOperator->getLeafOperator();
-    assert(op->operatorType == SELECT_SCAN);
+    auto op = children[1]->getLeafOperator();
+    assert(op->getOperatorType() == RESULT_SCAN);
     ((ResultScan*)op)->setResultSetToCopyFrom(resultSet.get());
-    subPlanLastOperator->initResultSet();
+    children[1]->initResultSet();
     return resultSet;
 }
 
 void Exists::reInitToRerunSubPlan() {
-    prevOperator->reInitToRerunSubPlan();
+    children[0]->reInitToRerunSubPlan();
 }
 
 bool Exists::getNextTuples() {
-    if (!prevOperator->getNextTuples()) {
+    if (!children[0]->getNextTuples()) {
         return false;
     }
-    subPlanLastOperator->reInitToRerunSubPlan();
+    children[1]->reInitToRerunSubPlan();
     assert(valueVectorToWrite->state->currIdx != -1);
-    auto hasAtLeastOneTuple = subPlanLastOperator->getNextTuples();
+    auto hasAtLeastOneTuple = children[1]->getNextTuples();
     valueVectorToWrite->values[valueVectorToWrite->state->currIdx] = hasAtLeastOneTuple;
     return true;
-}
-
-unique_ptr<PhysicalOperator> Exists::clone() {
-    return make_unique<Exists>(
-        outDataPos, subPlanLastOperator->clone(), prevOperator->clone(), context, id);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/flatten.cpp
+++ b/src/processor/physical_plan/operator/flatten.cpp
@@ -4,13 +4,13 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> Flatten::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     dataChunkToFlatten = resultSet->dataChunks[dataChunkToFlattenPos];
     return resultSet;
 }
 
 void Flatten::reInitToRerunSubPlan() {
-    prevOperator->reInitToRerunSubPlan();
+    children[0]->reInitToRerunSubPlan();
 }
 
 bool Flatten::getNextTuples() {
@@ -19,7 +19,7 @@ bool Flatten::getNextTuples() {
     if (dataChunkToFlatten->state->currIdx == -1 ||
         dataChunkToFlatten->state->selectedSize == dataChunkToFlatten->state->currIdx + 1ul) {
         dataChunkToFlatten->state->currIdx = -1;
-        if (!prevOperator->getNextTuples()) {
+        if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }

--- a/src/processor/physical_plan/operator/intersect.cpp
+++ b/src/processor/physical_plan/operator/intersect.cpp
@@ -6,7 +6,7 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> Intersect::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     leftDataChunk = resultSet->dataChunks[leftDataPos.dataChunkPos];
     leftValueVector = leftDataChunk->valueVectors[leftDataPos.valueVectorPos];
     rightDataChunk = resultSet->dataChunks[rightDataPos.dataChunkPos];
@@ -15,7 +15,7 @@ shared_ptr<ResultSet> Intersect::initResultSet() {
 }
 
 void Intersect::reInitToRerunSubPlan() {
-    prevOperator->reInitToRerunSubPlan();
+    children[0]->reInitToRerunSubPlan();
     FilteringOperator::reInitToRerunSubPlan();
     leftIdx = 0;
 }
@@ -36,7 +36,7 @@ bool Intersect::getNextTuples() {
         if (rightDataChunk->state->currIdx == -1 ||
             rightDataChunk->state->selectedSize == rightDataChunk->state->currIdx + 1ul) {
             rightDataChunk->state->currIdx = -1;
-            if (!prevOperator->getNextTuples()) {
+            if (!children[0]->getNextTuples()) {
                 metrics->executionTime.stop();
                 return false;
             }

--- a/src/processor/physical_plan/operator/limit.cpp
+++ b/src/processor/physical_plan/operator/limit.cpp
@@ -4,14 +4,14 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> Limit::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     return resultSet;
 }
 
 bool Limit::getNextTuples() {
     metrics->executionTime.start();
     // end of execution due to no more input
-    if (!prevOperator->getNextTuples()) {
+    if (!children[0]->getNextTuples()) {
         metrics->executionTime.stop();
         return false;
     }

--- a/src/processor/physical_plan/operator/multiplicity_reducer.cpp
+++ b/src/processor/physical_plan/operator/multiplicity_reducer.cpp
@@ -4,12 +4,12 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> MultiplicityReducer::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     return resultSet;
 }
 
 void MultiplicityReducer::reInitToRerunSubPlan() {
-    prevOperator->reInitToRerunSubPlan();
+    children[0]->reInitToRerunSubPlan();
     prevMultiplicity = 1;
     numRepeat = 0;
 }
@@ -18,7 +18,7 @@ bool MultiplicityReducer::getNextTuples() {
     metrics->executionTime.start();
     if (numRepeat == 0) {
         restoreMultiplicity();
-        if (!prevOperator->getNextTuples()) {
+        if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }

--- a/src/processor/physical_plan/operator/projection.cpp
+++ b/src/processor/physical_plan/operator/projection.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> Projection::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     for (auto i = 0u; i < expressions.size(); ++i) {
         auto& expression = *expressions[i];
         expression.initResultSet(*resultSet, *context.memoryManager);
@@ -22,13 +22,13 @@ shared_ptr<ResultSet> Projection::initResultSet() {
 }
 
 void Projection::reInitToRerunSubPlan() {
-    prevOperator->reInitToRerunSubPlan();
+    children[0]->reInitToRerunSubPlan();
 }
 
 bool Projection::getNextTuples() {
     metrics->executionTime.start();
     restoreMultiplicity();
-    if (!prevOperator->getNextTuples()) {
+    if (!children[0]->getNextTuples()) {
         metrics->executionTime.stop();
         return false;
     }
@@ -47,7 +47,7 @@ unique_ptr<PhysicalOperator> Projection::clone() {
         rootExpressionsCloned.push_back(expression->clone());
     }
     return make_unique<Projection>(move(rootExpressionsCloned), expressionsOutputPos,
-        discardedDataChunksPos, prevOperator->clone(), context, id);
+        discardedDataChunksPos, children[0]->clone(), context, id);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -22,7 +22,7 @@ bool AdjListExtend::getNextTuples() {
         return true;
     }
     do {
-        if (!prevOperator->getNextTuples()) {
+        if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> ReadList::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     inDataChunk = resultSet->dataChunks[inDataPos.dataChunkPos];
     inValueVector = inDataChunk->valueVectors[inDataPos.valueVectorPos];
     outDataChunk = resultSet->dataChunks[outDataPos.dataChunkPos];
@@ -12,7 +12,7 @@ shared_ptr<ResultSet> ReadList::initResultSet() {
 }
 
 void ReadList::reInitToRerunSubPlan() {
-    prevOperator->reInitToRerunSubPlan();
+    children[0]->reInitToRerunSubPlan();
 }
 
 void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -1,7 +1,5 @@
 #include "src/processor/include/physical_plan/operator/read_list/read_rel_property_list.h"
 
-#include "src/common/include/date.h"
-
 namespace graphflow {
 namespace processor {
 
@@ -15,7 +13,7 @@ shared_ptr<ResultSet> ReadRelPropertyList::initResultSet() {
 
 bool ReadRelPropertyList::getNextTuples() {
     metrics->executionTime.start();
-    if (!prevOperator->getNextTuples()) {
+    if (!children[0]->getNextTuples()) {
         metrics->executionTime.stop();
         return false;
     }

--- a/src/processor/physical_plan/operator/result_collector.cpp
+++ b/src/processor/physical_plan/operator/result_collector.cpp
@@ -4,14 +4,14 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> ResultCollector::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     return resultSet;
 }
 
 void ResultCollector::execute() {
     metrics->executionTime.start();
     Sink::execute();
-    while (prevOperator->getNextTuples()) {
+    while (children[0]->getNextTuples()) {
         queryResult->numTuples += resultSet->getNumTuples();
         auto clonedResultSet = make_unique<ResultSet>(resultSet->getNumDataChunks());
         for (auto i = 0u; i < resultSet->getNumDataChunks(); ++i) {

--- a/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/adj_column_extend.cpp
@@ -20,7 +20,7 @@ bool AdjColumnExtend::getNextTuples() {
     bool hasAtLeastOneNonNullValue;
     do {
         restoreDataChunkSelectorState(inDataChunk);
-        if (!prevOperator->getNextTuples()) {
+        if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }

--- a/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_attribute.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> ScanAttribute::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     assert(inDataPos.dataChunkPos == outDataPos.dataChunkPos);
     inDataChunk = resultSet->dataChunks[inDataPos.dataChunkPos];
     inValueVector = inDataChunk->valueVectors[inDataPos.valueVectorPos];
@@ -12,7 +12,7 @@ shared_ptr<ResultSet> ScanAttribute::initResultSet() {
 }
 
 void ScanAttribute::reInitToRerunSubPlan() {
-    prevOperator->reInitToRerunSubPlan();
+    children[0]->reInitToRerunSubPlan();
 }
 
 void ScanAttribute::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {

--- a/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
@@ -14,7 +14,7 @@ shared_ptr<ResultSet> ScanStructuredProperty::initResultSet() {
 
 bool ScanStructuredProperty::getNextTuples() {
     metrics->executionTime.start();
-    if (!prevOperator->getNextTuples()) {
+    if (!children[0]->getNextTuples()) {
         metrics->executionTime.stop();
         return false;
     }

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -14,7 +14,7 @@ shared_ptr<ResultSet> ScanUnstructuredProperty::initResultSet() {
 
 bool ScanUnstructuredProperty::getNextTuples() {
     metrics->executionTime.start();
-    if (!prevOperator->getNextTuples()) {
+    if (!children[0]->getNextTuples()) {
         metrics->executionTime.stop();
         return false;
     }

--- a/src/processor/physical_plan/operator/skip.cpp
+++ b/src/processor/physical_plan/operator/skip.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace processor {
 
 shared_ptr<ResultSet> Skip::initResultSet() {
-    resultSet = prevOperator->initResultSet();
+    resultSet = children[0]->initResultSet();
     return resultSet;
 }
 
@@ -16,7 +16,7 @@ bool Skip::getNextTuples() {
     do {
         restoreDataChunkSelectorState(dataChunkToSelect);
         // end of execution due to no more input
-        if (!prevOperator->getNextTuples()) {
+        if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -1,8 +1,5 @@
 #include "src/processor/include/processor.h"
 
-#include "src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h"
-#include "src/processor/include/physical_plan/operator/hash_join/hash_join_build.h"
-#include "src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h"
 #include "src/processor/include/physical_plan/operator/result_collector.h"
 #include "src/processor/include/physical_plan/operator/sink.h"
 #include "src/processor/include/physical_plan/result/query_result.h"
@@ -31,30 +28,25 @@ unique_ptr<QueryResult> QueryProcessor::execute(PhysicalPlan* physicalPlan, uint
 
 void QueryProcessor::decomposePlanIntoTasks(
     PhysicalOperator* op, Task* parentTask, uint64_t numThreads) {
-    switch (op->operatorType) {
-    case HASH_JOIN_PROBE: {
-        auto hashJoinProbe = reinterpret_cast<HashJoinProbe*>(op);
-        decomposePlanIntoTasks(hashJoinProbe->buildSidePrevOp.get(), parentTask, numThreads);
-        decomposePlanIntoTasks(hashJoinProbe->prevOperator.get(), parentTask, numThreads);
-    } break;
+    switch (op->getOperatorType()) {
     case HASH_JOIN_BUILD: {
-        auto hashJoinBuild = reinterpret_cast<HashJoinBuild*>(op);
-        auto childTask =
-            make_unique<ProcessorTask>(reinterpret_cast<Sink*>(hashJoinBuild), numThreads);
-        decomposePlanIntoTasks(hashJoinBuild->prevOperator.get(), childTask.get(), numThreads);
+        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), numThreads);
+        decomposePlanIntoTasks(op->getFirstChild(), childTask.get(), numThreads);
         parentTask->addChildTask(move(childTask));
     } break;
-    case AGGREGATE: {
-        auto aggregate = reinterpret_cast<SimpleAggregate*>(op);
-        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(aggregate), numThreads);
-        decomposePlanIntoTasks(aggregate->prevOperator.get(), childTask.get(), numThreads);
+    case AGGREGATION: {
+        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), numThreads);
+        decomposePlanIntoTasks(op->getFirstChild(), childTask.get(), numThreads);
         parentTask->addChildTask(move(childTask));
     } break;
-    case SCAN:
-        break;
-    default:
-        decomposePlanIntoTasks(op->prevOperator.get(), parentTask, numThreads);
-        break;
+    default: {
+        if (op->hasFirstChild()) {
+            decomposePlanIntoTasks(op->getFirstChild(), parentTask, numThreads);
+        }
+        if (op->hasSecondChild()) {
+            decomposePlanIntoTasks(op->getSecondChild(), parentTask, numThreads);
+        }
+    } break;
     }
 }
 

--- a/test/processor/processor_test.cpp
+++ b/test/processor/processor_test.cpp
@@ -35,7 +35,7 @@ TEST(ProcessorTests, MultiThreadedScanTest) {
     auto plan = make_unique<PhysicalPlan>(make_unique<ResultCollector>(vectorsToCollect,
         make_unique<ScanNodeID>(
             make_unique<ResultSetDescriptor>(schema), 0, aIDPos, morsel, executionContext, 0),
-        RESULT_COLLECTOR, executionContext, 1));
+        executionContext, 1));
     auto processor = make_unique<QueryProcessor>(10);
     auto result = processor->execute(plan.get(), 1);
     ASSERT_EQ(result->numTuples, 1025013);


### PR DESCRIPTION
This PR contains the following changes

## Physical Operator
- Use `vector<unique_ptr<PhysicalOperator>>`  to replace `unique_ptr<PhysicalOperator>`
  - Decouple `processor` from physical operator implementataions
  - Decouple `plan_printer` from physical operator implementations
- Use `getOperatorType()` to replace `operatorType` field so that we have a unified design between logical and physical operators.

## Physical Plan Clone across Different Pipelines
- We no longer clone the children of a pipeline source operator
  -  `HashJoinProbe` does not clone `HashJoinBuild` 
  -   `AggregationScan` does not clone `Aggregation`

## Minor changes
-  Be more specific about operator type
  - Use `LIST_EXTEND`, `COLUMN_EXTEND`, and `FRONTIER_EXTEND` to replace `READ_LIST`
  - Use `SCAN_STRUCTURED_PROPERTY`, `SCAN_UNSTRUCTURED_PROPERTY`, and `READ_REL_PROPERTY` to replace `SCAN_PROPERTY`