### PR TITLE
Binary op property pushdown

### DIFF
--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -73,13 +73,9 @@ void Enumerator::planOptionalMatch(const QueryGraph& queryGraph,
         expressionsToScanFromOuter =
             getSubExpressionsInSchema(queryGraphPredicate, *outerPlan.schema);
     }
-    // See Logical_left_nested_loop_join.h for the usage of matchedNodeIDsInSubPlan.
-    vector<string> matchedNodeIDsInSubPlan;
     for (auto& nodeIDExpression : queryGraph.getNodeIDExpressions()) {
         if (outerPlan.schema->containExpression(nodeIDExpression->getUniqueName())) {
             expressionsToScanFromOuter.push_back(nodeIDExpression);
-        } else {
-            matchedNodeIDsInSubPlan.push_back(nodeIDExpression->getUniqueName());
         }
     }
     for (auto& expression : expressionsToScanFromOuter) {
@@ -120,9 +116,8 @@ void Enumerator::planOptionalMatch(const QueryGraph& queryGraph,
             outerPlan.schema->insertToGroup(expressionName, outerPos);
         }
     }
-    auto logicalLeftNestedLoopJoin =
-        make_shared<LogicalLeftNestedLoopJoin>(bestPlan->schema->copy(),
-            move(matchedNodeIDsInSubPlan), outerPlan.lastOperator, bestPlan->lastOperator);
+    auto logicalLeftNestedLoopJoin = make_shared<LogicalLeftNestedLoopJoin>(
+        bestPlan->schema->copy(), outerPlan.lastOperator, bestPlan->lastOperator);
     outerPlan.appendOperator(move(logicalLeftNestedLoopJoin));
 }
 

--- a/src/planner/include/logical_plan/operator/exists/logical_exist.h
+++ b/src/planner/include/logical_plan/operator/exists/logical_exist.h
@@ -2,6 +2,9 @@
 
 #include "src/binder/include/expression/expression.h"
 #include "src/planner/include/logical_plan/operator/logical_operator.h"
+#include "src/planner/include/logical_plan/schema.h"
+
+using namespace graphflow::binder;
 
 namespace graphflow {
 namespace planner {

--- a/src/planner/include/logical_plan/operator/nested_loop_join/logical_left_nested_loop_join.h
+++ b/src/planner/include/logical_plan/operator/nested_loop_join/logical_left_nested_loop_join.h
@@ -10,11 +10,9 @@ namespace planner {
 class LogicalLeftNestedLoopJoin : public LogicalOperator {
 
 public:
-    LogicalLeftNestedLoopJoin(unique_ptr<Schema> subPlanSchema,
-        vector<string> matchedNodeIDsInSubPlan, shared_ptr<LogicalOperator> child,
+    LogicalLeftNestedLoopJoin(unique_ptr<Schema> subPlanSchema, shared_ptr<LogicalOperator> child,
         shared_ptr<LogicalOperator> subPlanChild)
-        : LogicalOperator{move(child), move(subPlanChild)}, subPlanSchema{move(subPlanSchema)},
-          matchedNodeIDsInSubPlan{move(matchedNodeIDsInSubPlan)} {}
+        : LogicalOperator{move(child), move(subPlanChild)}, subPlanSchema{move(subPlanSchema)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LOGICAL_LEFT_NESTED_LOOP_JOIN;
@@ -23,15 +21,12 @@ public:
     string getExpressionsForPrinting() const override { return string(); }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalLeftNestedLoopJoin>(subPlanSchema->copy(),
-            matchedNodeIDsInSubPlan, children[0]->copy(), children[1]->copy());
+        return make_unique<LogicalLeftNestedLoopJoin>(
+            subPlanSchema->copy(), children[0]->copy(), children[1]->copy());
     }
 
 public:
     unique_ptr<Schema> subPlanSchema;
-
-    // This field is used to push property scanners on top of left nested loop join.
-    vector<string> matchedNodeIDsInSubPlan;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h
@@ -1,35 +1,31 @@
 #pragma once
 
-#include "src/planner/include/logical_plan/operator/logical_operator.h"
+#include "src/planner/include/logical_plan/operator/scan_property/logical_scan_property.h"
 
 namespace graphflow {
 namespace planner {
 
-class LogicalScanNodeProperty : public LogicalOperator {
+class LogicalScanNodeProperty : public LogicalScanProperty {
 
 public:
-    LogicalScanNodeProperty(string nodeID, label_t nodeLabel, string propertyVariableName,
+    LogicalScanNodeProperty(string nodeID, label_t nodeLabel, string propertyExpressionName,
         uint32_t propertyKey, bool isUnstructuredProperty, shared_ptr<LogicalOperator> child)
-        : LogicalOperator{move(child)}, nodeID{move(nodeID)}, nodeLabel{nodeLabel},
-          propertyVariableName{move(propertyVariableName)}, propertyKey{propertyKey},
-          isUnstructuredProperty{isUnstructuredProperty} {}
+        : LogicalScanProperty{move(propertyExpressionName), propertyKey, move(child)},
+          nodeID{move(nodeID)}, nodeLabel{nodeLabel}, isUnstructuredProperty{
+                                                          isUnstructuredProperty} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_SCAN_NODE_PROPERTY;
     }
 
-    string getExpressionsForPrinting() const override { return propertyVariableName; }
-
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalScanNodeProperty>(nodeID, nodeLabel, propertyVariableName,
+        return make_unique<LogicalScanNodeProperty>(nodeID, nodeLabel, propertyExpressionName,
             propertyKey, isUnstructuredProperty, children[0]->copy());
     }
 
 public:
     const string nodeID;
     const label_t nodeLabel;
-    const string propertyVariableName;
-    const uint32_t propertyKey;
     const bool isUnstructuredProperty;
 };
 

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_property.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "src/planner/include/logical_plan/operator/logical_operator.h"
+
+namespace graphflow {
+namespace planner {
+
+class LogicalScanProperty : public LogicalOperator {
+
+public:
+    LogicalScanProperty(
+        string propertyExpressionName, uint32_t propertyKey, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)}, propertyExpressionName{move(propertyExpressionName)},
+          propertyKey{propertyKey} {}
+
+    inline string getPropertyExpressionName() const { return propertyExpressionName; }
+    inline uint32_t getPropertyKey() const { return propertyKey; }
+
+    LogicalOperatorType getLogicalOperatorType() const override = 0;
+
+    string getExpressionsForPrinting() const override { return propertyExpressionName; }
+
+    unique_ptr<LogicalOperator> copy() override = 0;
+
+protected:
+    string propertyExpressionName;
+    uint32_t propertyKey;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
+++ b/src/planner/include/logical_plan/operator/scan_property/logical_scan_rel_property.h
@@ -1,30 +1,28 @@
 #pragma once
 
-#include "src/planner/include/logical_plan/operator/logical_operator.h"
+#include "src/planner/include/logical_plan/operator/scan_property/logical_scan_property.h"
 
 namespace graphflow {
 namespace planner {
 
-class LogicalScanRelProperty : public LogicalOperator {
+class LogicalScanRelProperty : public LogicalScanProperty {
 
 public:
     LogicalScanRelProperty(string boundNodeID, label_t boundNodeLabel, string nbrNodeID,
-        label_t relLabel, Direction direction, string propertyVariableName, uint32_t propertyKey,
+        label_t relLabel, Direction direction, string propertyExpressionName, uint32_t propertyKey,
         bool isColumn, shared_ptr<LogicalOperator> child)
-        : LogicalOperator{move(child)}, boundNodeID{move(boundNodeID)},
-          boundNodeLabel{boundNodeLabel}, nbrNodeID{move(nbrNodeID)}, relLabel{relLabel},
-          direction{direction}, propertyVariableName(move(propertyVariableName)),
-          propertyKey{propertyKey}, isColumn{isColumn} {}
+        : LogicalScanProperty{move(propertyExpressionName), propertyKey, move(child)},
+          boundNodeID{move(boundNodeID)}, boundNodeLabel{boundNodeLabel},
+          nbrNodeID{move(nbrNodeID)}, relLabel{relLabel}, direction{direction}, isColumn{isColumn} {
+    }
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_SCAN_REL_PROPERTY;
     }
 
-    string getExpressionsForPrinting() const override { return propertyVariableName; }
-
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalScanRelProperty>(boundNodeID, boundNodeLabel, nbrNodeID, relLabel,
-            direction, propertyVariableName, propertyKey, isColumn, children[0]->copy());
+            direction, propertyExpressionName, propertyKey, isColumn, children[0]->copy());
     }
 
 public:
@@ -33,8 +31,6 @@ public:
     string nbrNodeID;
     label_t relLabel;
     Direction direction;
-    string propertyVariableName;
-    uint32_t propertyKey;
     bool isColumn;
 };
 

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -31,6 +31,10 @@ public:
         expressionNames.insert(expressionName);
     }
 
+    inline void removeExpression(const string& expressionName) {
+        expressionNames.erase(expressionName);
+    }
+
     inline string getAnyExpressionName() {
         GF_ASSERT(!expressionNames.empty());
         return *expressionNames.begin();
@@ -64,6 +68,12 @@ public:
 
     bool containExpression(const string& expressionName) const {
         return expressionNameToGroupPos.contains(expressionName);
+    }
+
+    void removeExpression(const string& expressionName) {
+        auto groupPos = getGroupPos(expressionName);
+        groups[groupPos]->removeExpression(expressionName);
+        expressionNameToGroupPos.erase(expressionName);
     }
 
     void addLogicalExtend(const string& queryRel, LogicalExtend* extend);

--- a/src/planner/logical_plan/schema.cpp
+++ b/src/planner/logical_plan/schema.cpp
@@ -10,6 +10,7 @@ uint32_t Schema::createGroup() {
 }
 
 void Schema::insertToGroup(const string& expressionName, uint32_t groupPos) {
+    auto k = 1;
     expressionNameToGroupPos.insert({expressionName, groupPos});
     groups[groupPos]->insertExpression(expressionName);
 }

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -23,7 +23,7 @@ vector<unique_ptr<LogicalPlan>> Planner::getAllPlans(
 
 unique_ptr<LogicalPlan> Planner::optimize(unique_ptr<LogicalPlan> plan) {
     auto propertyScanPushDown = PropertyScanPushDown();
-    plan->lastOperator = propertyScanPushDown.rewrite(plan->lastOperator);
+    propertyScanPushDown.rewrite(*plan);
     return plan;
 }
 

--- a/src/planner/property_scan_pushdown.cpp
+++ b/src/planner/property_scan_pushdown.cpp
@@ -1,6 +1,9 @@
 #include "src/planner/include/property_scan_pushdown.h"
 
+#include "src/planner/include/logical_plan/operator/aggregate/logical_aggregate.h"
+#include "src/planner/include/logical_plan/operator/exists/logical_exist.h"
 #include "src/planner/include/logical_plan/operator/extend/logical_extend.h"
+#include "src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h"
 #include "src/planner/include/logical_plan/operator/nested_loop_join/logical_left_nested_loop_join.h"
 #include "src/planner/include/logical_plan/operator/scan_node_id/logical_scan_node_id.h"
 #include "src/planner/include/logical_plan/operator/scan_property/logical_scan_node_property.h"
@@ -9,67 +12,97 @@
 namespace graphflow {
 namespace planner {
 
-shared_ptr<LogicalOperator> PropertyScanPushDown::rewrite(shared_ptr<LogicalOperator> op) {
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewrite(
+    shared_ptr<LogicalOperator> op, Schema& schema) {
     switch (op->getLogicalOperatorType()) {
     case LOGICAL_SCAN_NODE_ID:
-        return rewriteScanNodeID(op);
+        return rewriteScanNodeID(op, schema);
     case LOGICAL_EXTEND:
-        return rewriteExtend(op);
+        return rewriteExtend(op, schema);
     case LOGICAL_SCAN_NODE_PROPERTY:
-        return rewriteScanNodeProperty(op);
+        return rewriteScanNodeProperty(op, schema);
     case LOGICAL_SCAN_REL_PROPERTY:
-        return rewriteScanRelProperty(op);
+        return rewriteScanRelProperty(op, schema);
+    case LOGICAL_AGGREGATE:
+        return rewriteAggregate(op, schema);
+    case LOGICAL_HASH_JOIN:
+        return rewriteHashJoin(op, schema);
+    case LOGICAL_EXISTS:
+        return rewriteExists(op, schema);
     case LOGICAL_LEFT_NESTED_LOOP_JOIN:
-        return rewriteLeftNestedLoopJoin(op);
+        return rewriteLeftNestedLoopJoin(op, schema);
     default:
-        rewriteChildrenOperators(op);
+        rewriteChildrenOperators(op, schema);
         return op;
     }
 }
 
 shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteScanNodeID(
-    const shared_ptr<LogicalOperator>& op) {
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
     auto& scanNodeID = (LogicalScanNodeID&)*op;
-    return applyPropertyScansIfNecessary(scanNodeID.nodeID, op);
+    return applyPropertyScansIfNecessary(scanNodeID.nodeID, op, schema);
 }
 
 shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteExtend(
-    const shared_ptr<LogicalOperator>& op) {
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
     auto& extend = (LogicalExtend&)*op;
-    return applyPropertyScansIfNecessary(extend.nbrNodeID, op);
-}
-
-// Push down all property scanners on node IDs computed in subquery on top on the left nested loop
-// join operator.
-shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteLeftNestedLoopJoin(
-    const shared_ptr<LogicalOperator>& op) {
-    auto& leftNLJ = (LogicalLeftNestedLoopJoin&)*op;
-    shared_ptr<LogicalOperator> result;
-    for (auto& nodeID : leftNLJ.matchedNodeIDsInSubPlan) {
-        result = applyPropertyScansIfNecessary(nodeID, op);
-    }
-    return result;
+    return applyPropertyScansIfNecessary(extend.nbrNodeID, op, schema);
 }
 
 shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteScanNodeProperty(
-    const shared_ptr<LogicalOperator>& op) {
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
     auto& scanNodeProperty = (LogicalScanNodeProperty&)*op;
     addPropertyScan(scanNodeProperty.nodeID, op);
-    return rewrite(scanNodeProperty.getFirstChild());
+    schema.removeExpression(scanNodeProperty.getPropertyExpressionName());
+    return rewrite(scanNodeProperty.getFirstChild(), schema);
 }
 
 shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteScanRelProperty(
-    const shared_ptr<LogicalOperator>& op) {
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
     auto& scanRelProperty = (LogicalScanRelProperty&)*op;
     addPropertyScan(scanRelProperty.nbrNodeID, op);
-    return rewrite(scanRelProperty.getFirstChild());
+    schema.removeExpression(scanRelProperty.getPropertyExpressionName());
+    return rewrite(scanRelProperty.getFirstChild(), schema);
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteAggregate(
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
+    auto& logicalAggregate = (LogicalAggregate&)*op;
+    op->setFirstChild(rewrite(op->getFirstChild(), *logicalAggregate.getSchemaBeforeAggregate()));
+    return op;
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteHashJoin(
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
+    auto& logicalHashJoin = (LogicalHashJoin&)*op;
+    op->setFirstChild(rewrite(op->getFirstChild(), schema));
+    addRemainingPropertyScansToLeftSchema(schema);
+    op->setSecondChild(rewrite(op->getSecondChild(), *logicalHashJoin.buildSideSchema));
+    return op;
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteExists(
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
+    auto& logicalExists = (LogicalExists&)*op;
+    op->setFirstChild(rewrite(op->getFirstChild(), schema));
+    op->setSecondChild(rewrite(op->getSecondChild(), *logicalExists.subPlanSchema));
+    return op;
+}
+
+shared_ptr<LogicalOperator> PropertyScanPushDown::rewriteLeftNestedLoopJoin(
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
+    auto& logicalLeftNLJ = (LogicalLeftNestedLoopJoin&)*op;
+    op->setFirstChild(rewrite(op->getFirstChild(), schema));
+    addRemainingPropertyScansToLeftSchema(schema);
+    op->setSecondChild(rewrite(op->getSecondChild(), *logicalLeftNLJ.subPlanSchema));
+    return op;
 }
 
 shared_ptr<LogicalOperator> PropertyScanPushDown::applyPropertyScansIfNecessary(
-    const string& nodeID, const shared_ptr<LogicalOperator>& op) {
+    const string& nodeID, const shared_ptr<LogicalOperator>& op, Schema& schema) {
     if (!nodeIDToPropertyScansMap.contains(nodeID)) {
         // nothing needs to be applied
-        rewriteChildrenOperators(op);
+        rewriteChildrenOperators(op, schema);
         return op;
     }
     auto& propertyScans = nodeIDToPropertyScansMap.at(nodeID);
@@ -79,18 +112,27 @@ shared_ptr<LogicalOperator> PropertyScanPushDown::applyPropertyScansIfNecessary(
     }
     propertyScans.back()->setFirstChild(op);
     auto result = propertyScans[0];
+    // update schema
+    auto groupPos = schema.getGroupPos(nodeID);
+    for (auto& propertyScan : propertyScans) {
+        auto& scanProperty = (LogicalScanProperty&)*propertyScan;
+        schema.insertToGroup(scanProperty.getPropertyExpressionName(), groupPos);
+    }
     nodeIDToPropertyScansMap.erase(nodeID);
-    rewriteChildrenOperators(op);
+    rewriteChildrenOperators(op, schema);
     return result;
 }
 
-void PropertyScanPushDown::rewriteChildrenOperators(const shared_ptr<LogicalOperator>& op) {
+void PropertyScanPushDown::rewriteChildrenOperators(
+    const shared_ptr<LogicalOperator>& op, Schema& schema) {
     if (op->getNumChildren() == 0) {
         return;
     }
-    op->setFirstChild(rewrite(op->getFirstChild()));
+    // If any property scanner is successfully pushed down, it will be removed from
+    // nodeIDtoPropertyScanMap.
+    op->setFirstChild(rewrite(op->getFirstChild(), schema));
     if (op->getNumChildren() == 2) {
-        op->setSecondChild(rewrite(op->getSecondChild()));
+        op->setSecondChild(rewrite(op->getSecondChild(), schema));
     }
 }
 
@@ -100,6 +142,16 @@ void PropertyScanPushDown::addPropertyScan(
         nodeIDToPropertyScansMap.insert({nodeID, vector<shared_ptr<LogicalOperator>>()});
     }
     nodeIDToPropertyScansMap.at(nodeID).push_back(op);
+}
+
+void PropertyScanPushDown::addRemainingPropertyScansToLeftSchema(Schema& schema) {
+    for (auto& [nodeID, propertyScanners] : nodeIDToPropertyScansMap) {
+        auto groupPos = schema.getGroupPos(nodeID);
+        for (auto& propertyScanner : propertyScanners) {
+            auto& scanNodeProperty = (LogicalScanProperty&)*propertyScanner;
+            schema.insertToGroup(scanNodeProperty.getPropertyExpressionName(), groupPos);
+        }
+    }
 }
 
 } // namespace planner

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -26,9 +26,11 @@ void HashJoinProbe::initializeResultSet() {
     probeSideKeyVector = resultSet->dataChunks[probeDataInfo.getKeyIDDataChunkPos()]
                              ->valueVectors[probeDataInfo.getKeyIDVectorPos()];
     auto rowCollectionLayout = sharedState->rowCollection->getLayout();
+    // Skip the first key field.
+    auto fieldIdx = 1;
     for (auto i = 0u; i < probeDataInfo.nonKeyOutputDataPos.size(); ++i) {
-        auto probeSideVector =
-            make_shared<ValueVector>(context.memoryManager, rowCollectionLayout.fields[i].dataType);
+        auto probeSideVector = make_shared<ValueVector>(
+            context.memoryManager, rowCollectionLayout.fields[fieldIdx + i].dataType);
         auto [dataChunkPos, valueVectorPos] = probeDataInfo.nonKeyOutputDataPos[i];
         resultSet->dataChunks[dataChunkPos]->insert(valueVectorPos, probeSideVector);
     }

--- a/test/runner/queries/filtered/paths.test
+++ b/test/runner/queries/filtered/paths.test
@@ -24,3 +24,13 @@
 -QUERY MATCH (a:person)-[e1:studyAt]->(b:organisation) WHERE b.orgCode > 100 RETURN COUNT(*)
 ---- 1
 3
+
+-NAME FourHopKnowsFilterTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person) WHERE a.fName = 'Alice' OR e.fName = 'Alice' RETURN COUNT(*)
+---- 1
+141
+
+-NAME FiveHopKnowsFilterTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person)-[:knows]->(f:person) WHERE a.age = 35 AND f.age = a.age  RETURN COUNT(*)
+---- 1
+60


### PR DESCRIPTION
This PR contains the following changes

## Property Scan Push Down
- Add property scan push down logic for binary operators (i.e. `HashJoin, Exists, LeftNestedLoopJoin`). Specifically, add schema updating logic.
  -  This PR also solves the first failed query in issue #430.