### PR TITLE
Projection map fix

### DIFF
--- a/src/planner/include/logical_plan/logical_plan.h
+++ b/src/planner/include/logical_plan/logical_plan.h
@@ -29,12 +29,21 @@ public:
             LOGICAL_HASH_JOIN, LOGICAL_AGGREGATE, LOGICAL_ORDER_BY});
     }
 
+    inline void setExpressionsToCollect(vector<shared_ptr<Expression>> expressions) {
+        expressionsToCollect = move(expressions);
+    }
+    inline vector<shared_ptr<Expression>> getExpressionsToCollect() { return expressionsToCollect; }
+
     unique_ptr<LogicalPlan> copy() const;
 
 public:
     shared_ptr<LogicalOperator> lastOperator;
     unique_ptr<Schema> schema;
     uint64_t cost;
+
+private:
+    // This fields represents return columns in the same order as user input.
+    vector<shared_ptr<Expression>> expressionsToCollect;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/limit/logical_limit.h
+++ b/src/planner/include/logical_plan/operator/limit/logical_limit.h
@@ -8,10 +8,10 @@ namespace planner {
 class LogicalLimit : public LogicalOperator {
 
 public:
-    LogicalLimit(uint64_t limitNumber, uint32_t groupPosToSelect, vector<uint32_t> groupsPosToLimit,
-        shared_ptr<LogicalOperator> child)
+    LogicalLimit(uint64_t limitNumber, uint32_t groupPosToSelect,
+        unordered_set<uint32_t> groupsPosInScope, shared_ptr<LogicalOperator> child)
         : LogicalOperator{move(child)}, limitNumber{limitNumber},
-          groupPosToSelect{groupPosToSelect}, groupsPosToLimit{move(groupsPosToLimit)} {}
+          groupPosToSelect{groupPosToSelect}, groupsPosInScope{move(groupsPosInScope)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override { return LOGICAL_LIMIT; }
 
@@ -19,17 +19,17 @@ public:
 
     inline uint64_t getLimitNumber() const { return limitNumber; }
     inline uint32_t getGroupPosToSelect() const { return groupPosToSelect; }
-    inline const vector<uint32_t>& getGroupsPosToLimit() const { return groupsPosToLimit; }
+    inline unordered_set<uint32_t> getGroupsPosToLimit() const { return groupsPosInScope; }
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalLimit>(
-            limitNumber, groupPosToSelect, groupsPosToLimit, children[0]->copy());
+            limitNumber, groupPosToSelect, groupsPosInScope, children[0]->copy());
     }
 
 private:
     uint64_t limitNumber;
     uint32_t groupPosToSelect;
-    vector<uint32_t> groupsPosToLimit;
+    unordered_set<uint32_t> groupsPosInScope;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/projection/logical_projection.h
+++ b/src/planner/include/logical_plan/operator/projection/logical_projection.h
@@ -10,7 +10,7 @@ class LogicalProjection : public LogicalOperator {
 
 public:
     explicit LogicalProjection(vector<shared_ptr<Expression>> expressions,
-        vector<uint32_t> discardedGroupsPos, shared_ptr<LogicalOperator> child)
+        unordered_set<uint32_t> discardedGroupsPos, shared_ptr<LogicalOperator> child)
         : LogicalOperator{move(child)}, expressionsToProject{move(expressions)},
           discardedGroupsPos{move(discardedGroupsPos)} {}
 
@@ -33,7 +33,7 @@ public:
 
 public:
     vector<shared_ptr<Expression>> expressionsToProject;
-    vector<uint32_t> discardedGroupsPos;
+    unordered_set<uint32_t> discardedGroupsPos;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/operator/skip/logical_skip.h
+++ b/src/planner/include/logical_plan/operator/skip/logical_skip.h
@@ -8,10 +8,10 @@ namespace planner {
 class LogicalSkip : public LogicalOperator {
 
 public:
-    LogicalSkip(uint64_t skipNumber, uint32_t groupPosToSelect, vector<uint32_t> groupsPosToSkip,
-        shared_ptr<LogicalOperator> child)
+    LogicalSkip(uint64_t skipNumber, uint32_t groupPosToSelect,
+        unordered_set<uint32_t> groupsPosInScope, shared_ptr<LogicalOperator> child)
         : LogicalOperator(move(child)), skipNumber{skipNumber}, groupPosToSelect{groupPosToSelect},
-          groupsPosToSkip{move(groupsPosToSkip)} {}
+          groupsPosInScope{move(groupsPosInScope)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override { return LOGICAL_SKIP; }
 
@@ -19,17 +19,17 @@ public:
 
     inline uint64_t getSkipNumber() const { return skipNumber; }
     inline uint32_t getGroupPosToSelect() const { return groupPosToSelect; }
-    inline const vector<uint32_t>& getGroupsPosToSkip() const { return groupsPosToSkip; };
+    inline unordered_set<uint32_t> getGroupsPosToSkip() const { return groupsPosInScope; };
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalSkip>(
-            skipNumber, groupPosToSelect, groupsPosToSkip, children[0]->copy());
+            skipNumber, groupPosToSelect, groupsPosInScope, children[0]->copy());
     }
 
 private:
     uint64_t skipNumber;
     uint32_t groupPosToSelect;
-    vector<uint32_t> groupsPosToSkip;
+    unordered_set<uint32_t> groupsPosInScope;
 };
 
 } // namespace planner

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -58,23 +58,24 @@ public:
 
     void insertToGroup(const string& expressionName, uint32_t groupPos);
 
-    void insertToGroup(const FactorizationGroup& otherGroup, uint32_t groupPos);
+    void insertToGroupAndScope(const string& expressionName, uint32_t groupPos);
+
+    void insertToGroupAndScope(const FactorizationGroup& otherGroup, uint32_t groupPos);
 
     uint32_t getGroupPos(const string& expressionName) const;
 
-    unordered_set<uint32_t> getGroupsPos() const;
+    inline void flattenGroup(uint32_t pos) { groups[pos]->isFlat = true; }
 
-    void flattenGroup(uint32_t pos);
-
-    bool containExpression(const string& expressionName) const {
+    inline bool containExpression(const string& expressionName) const {
         return expressionNameToGroupPos.contains(expressionName);
     }
 
-    void removeExpression(const string& expressionName) {
-        auto groupPos = getGroupPos(expressionName);
-        groups[groupPos]->removeExpression(expressionName);
-        expressionNameToGroupPos.erase(expressionName);
-    }
+    void removeExpression(const string& expressionName);
+
+    inline void clearExpressionsInScope() { expressionNamesInScope.clear(); }
+
+    // Get the group positions containing at least one expression in scope.
+    unordered_set<uint32_t> getGroupsPosInScope() const;
 
     void addLogicalExtend(const string& queryRel, LogicalExtend* extend);
 
@@ -85,7 +86,7 @@ public:
 
     unique_ptr<Schema> copy() const;
 
-    void clearGroups();
+    void clear();
 
 public:
     vector<unique_ptr<FactorizationGroup>> groups;
@@ -93,7 +94,10 @@ public:
     // requires direction information which only available in the LogicalExtend.
     unordered_map<string, LogicalExtend*> queryRelLogicalExtendMap;
     unordered_map<string, uint32_t> expressionNameToGroupPos;
-    vector<shared_ptr<Expression>> expressionsToCollect;
+
+    // Our projection doesn't explicitly remove expressions. Instead, we keep track of what
+    // expressions are in scope (i.e. being projected).
+    unordered_set<string> expressionNamesInScope;
 };
 
 } // namespace planner

--- a/src/planner/logical_plan/logical_plan.cpp
+++ b/src/planner/logical_plan/logical_plan.cpp
@@ -13,6 +13,7 @@ unique_ptr<LogicalPlan> LogicalPlan::copy() const {
     auto plan = make_unique<LogicalPlan>(schema->copy());
     plan->lastOperator = lastOperator;
     plan->cost = cost;
+    plan->expressionsToCollect = expressionsToCollect;
     return plan;
 }
 

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -20,16 +20,9 @@ public:
         : graph{graph}, outerMapperContext{nullptr}, expressionMapper{} {}
 
     unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(
-        unique_ptr<LogicalPlan> logicalPlan, ExecutionContext& executionContext) {
-        return mapLogicalPlanToPhysical(
-            logicalPlan->lastOperator, *logicalPlan->schema, executionContext);
-    }
+        unique_ptr<LogicalPlan> logicalPlan, ExecutionContext& executionContext);
 
 private:
-    unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(
-        const shared_ptr<LogicalOperator>& lastOperator, const Schema& schema,
-        ExecutionContext& executionContext);
-
     // Returns current physicalOperatorsInfo whoever calls enterSubquery is responsible to save the
     // return physicalOperatorsInfo and pass it back when calling exitSubquery()
     const MapperContext* enterSubquery(const MapperContext* newMapperContext);

--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
@@ -30,7 +30,8 @@ class SimpleAggregate : public Sink {
 public:
     SimpleAggregate(unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id,
         shared_ptr<AggregationSharedState> aggregationSharedState,
-        vector<unique_ptr<AggregateExpressionEvaluator>> aggregationEvaluators);
+        vector<unique_ptr<AggregateExpressionEvaluator>> aggregationEvaluators,
+        unordered_set<uint32_t> dataChunksPosInScope);
 
     PhysicalOperatorType getOperatorType() override { return AGGREGATION; }
 
@@ -46,6 +47,8 @@ private:
     shared_ptr<AggregationSharedState> sharedState;
     vector<unique_ptr<AggregateExpressionEvaluator>> aggregationEvaluators;
     vector<unique_ptr<AggregationState>> aggregationStates;
+
+    unordered_set<uint32_t> dataChunksPosInScope;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/limit.h
+++ b/src/processor/include/physical_plan/operator/limit.h
@@ -9,11 +9,11 @@ class Limit : public PhysicalOperator {
 
 public:
     Limit(uint64_t limitNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
-        vector<uint32_t> dataChunksToLimitPos, unique_ptr<PhysicalOperator> child,
+        unordered_set<uint32_t> dataChunksPosInScope, unique_ptr<PhysicalOperator> child,
         ExecutionContext& context, uint32_t id)
         : PhysicalOperator{move(child), context, id}, limitNumber{limitNumber},
           counter{move(counter)}, dataChunkToSelectPos{dataChunkToSelectPos},
-          dataChunksToLimitPos(move(dataChunksToLimitPos)) {}
+          dataChunksPosInScope(move(dataChunksPosInScope)) {}
 
     PhysicalOperatorType getOperatorType() override { return LIMIT; }
 
@@ -22,7 +22,7 @@ public:
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Limit>(limitNumber, counter, dataChunkToSelectPos, dataChunksToLimitPos,
+        return make_unique<Limit>(limitNumber, counter, dataChunkToSelectPos, dataChunksPosInScope,
             children[0]->clone(), context, id);
     }
 
@@ -30,7 +30,7 @@ private:
     uint64_t limitNumber;
     shared_ptr<atomic_uint64_t> counter;
     uint32_t dataChunkToSelectPos;
-    vector<uint32_t> dataChunksToLimitPos;
+    unordered_set<uint32_t> dataChunksPosInScope;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -33,10 +33,10 @@ enum PhysicalOperatorType : uint8_t {
     SCAN_NODE_ID,
     SCAN_STRUCTURED_PROPERTY,
     SCAN_UNSTRUCTURED_PROPERTY,
+    SKIP,
     ORDER_BY,
     ORDER_BY_MERGE,
     ORDER_BY_SCAN,
-    SKIP,
 };
 
 const string PhysicalOperatorTypeNames[] = {"AGGREGATION", "AGGREGATION_SCAN", "COLUMN_EXTEND",

--- a/src/processor/include/physical_plan/operator/projection.h
+++ b/src/processor/include/physical_plan/operator/projection.h
@@ -14,11 +14,11 @@ class Projection : public PhysicalOperator {
 
 public:
     Projection(vector<unique_ptr<ExpressionEvaluator>> expressions,
-        vector<DataPos> expressionsOutputPos, vector<uint32_t> discardedDataChunksPos,
+        vector<DataPos> expressionsOutputPos, unordered_set<uint32_t> discardedDataChunksPos,
         unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
         : PhysicalOperator(move(child), context, id),
           expressions(move(expressions)), expressionsOutputPos{move(expressionsOutputPos)},
-          discardedDataChunksPos{move(discardedDataChunksPos)}, prevMultiplicity{0} {}
+          discardedDataChunksPos{move(discardedDataChunksPos)}, prevMultiplicity{1} {}
 
     PhysicalOperatorType getOperatorType() override { return PROJECTION; }
 
@@ -38,10 +38,9 @@ private:
 private:
     vector<unique_ptr<ExpressionEvaluator>> expressions;
     vector<DataPos> expressionsOutputPos;
-    vector<uint32_t> discardedDataChunksPos;
+    unordered_set<uint32_t> discardedDataChunksPos;
 
     uint64_t prevMultiplicity;
-    unique_ptr<ResultSet> discardedResultSet;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/result_collector.h
+++ b/src/processor/include/physical_plan/operator/result_collector.h
@@ -10,11 +10,8 @@ namespace processor {
 class ResultCollector : public Sink {
 
 public:
-    explicit ResultCollector(vector<DataPos> vectorsToCollectPos,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : Sink{move(child), context, id},
-          queryResult{make_unique<QueryResult>(vectorsToCollectPos)}, vectorsToCollectPos{move(
-                                                                          vectorsToCollectPos)} {}
+    ResultCollector(vector<DataPos> vectorsToCollectPos, unique_ptr<PhysicalOperator> child,
+        ExecutionContext& context, uint32_t id);
 
     PhysicalOperatorType getOperatorType() override { return RESULT_COLLECTOR; }
 
@@ -34,6 +31,7 @@ private:
 
 private:
     vector<DataPos> vectorsToCollectPos;
+    unordered_set<uint32_t> dataChunksPosInScope;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/skip.h
+++ b/src/processor/include/physical_plan/operator/skip.h
@@ -10,12 +10,12 @@ class Skip : public PhysicalOperator, public FilteringOperator {
 
 public:
     Skip(uint64_t skipNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
-        vector<uint32_t> dataChunksToSkipPos, unique_ptr<PhysicalOperator> child,
+        unordered_set<uint32_t> dataChunksPosInScope, unique_ptr<PhysicalOperator> child,
         ExecutionContext& context, uint32_t id)
         : PhysicalOperator{move(child), context, id},
           FilteringOperator(), skipNumber{skipNumber}, counter{move(counter)},
-          dataChunkToSelectPos{dataChunkToSelectPos}, dataChunksToSkipPos{
-                                                          move(dataChunksToSkipPos)} {}
+          dataChunkToSelectPos{dataChunkToSelectPos}, dataChunksPosInScope{
+                                                          move(dataChunksPosInScope)} {}
 
     PhysicalOperatorType getOperatorType() override { return SKIP; }
 
@@ -24,7 +24,7 @@ public:
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Skip>(skipNumber, counter, dataChunkToSelectPos, dataChunksToSkipPos,
+        return make_unique<Skip>(skipNumber, counter, dataChunkToSelectPos, dataChunksPosInScope,
             children[0]->clone(), context, id);
     }
 
@@ -32,7 +32,7 @@ private:
     uint64_t skipNumber;
     shared_ptr<atomic_uint64_t> counter;
     uint32_t dataChunkToSelectPos;
-    vector<uint32_t> dataChunksToSkipPos;
+    unordered_set<uint32_t> dataChunksPosInScope;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/result/query_result.h
+++ b/src/processor/include/physical_plan/result/query_result.h
@@ -11,11 +11,10 @@ namespace processor {
 class QueryResult {
 
 public:
-    QueryResult(uint64_t numTuples, vector<DataPos> vectorsToCollectPos)
-        : numTuples{numTuples}, vectorsToCollectPos{move(vectorsToCollectPos)} {}
-
-    explicit QueryResult(vector<DataPos> vectorsToCollectPos)
-        : QueryResult(0, move(vectorsToCollectPos)) {}
+    QueryResult(vector<DataPos> vectorsToCollectPos, unordered_set<uint32_t> dataChunksPosInScope)
+        : numTuples{0}, vectorsToCollectPos{move(vectorsToCollectPos)}, dataChunksPosInScope{move(
+                                                                            dataChunksPosInScope)} {
+    }
 
     void appendQueryResult(unique_ptr<QueryResult> queryResult);
 
@@ -24,6 +23,7 @@ public:
 public:
     uint64_t numTuples;
     vector<DataPos> vectorsToCollectPos;
+    unordered_set<uint32_t> dataChunksPosInScope;
     vector<unique_ptr<ResultSet>> resultSetCollection;
     vector<unique_ptr<BufferBlock>> bufferBlocks;
 };

--- a/src/processor/include/physical_plan/result/result_set_iterator.h
+++ b/src/processor/include/physical_plan/result/result_set_iterator.h
@@ -10,9 +10,10 @@ namespace processor {
 
 class ResultSetIterator {
 public:
-    explicit ResultSetIterator(ResultSet* resultSet, vector<DataPos> vectorsToCollectPos)
-        : resultSet{resultSet}, vectorsToCollectPos{move(vectorsToCollectPos)}, numIteratedTuples{
-                                                                                    0} {
+    explicit ResultSetIterator(ResultSet* resultSet, vector<DataPos> vectorsToCollectPos,
+        unordered_set<uint32_t> dataChunksPosInScope)
+        : resultSet{resultSet}, vectorsToCollectPos{move(vectorsToCollectPos)},
+          dataChunksPosInScope{move(dataChunksPosInScope)}, numIteratedTuples{0} {
         reset();
     }
 
@@ -35,6 +36,7 @@ private:
 
     ResultSet* resultSet;
     vector<DataPos> vectorsToCollectPos;
+    unordered_set<uint32_t> dataChunksPosInScope;
 
     uint64_t numRepeatOfCurrentTuple;
     uint64_t numIteratedTuples;

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -92,7 +92,7 @@ bool HashJoinProbe::getNextTuples() {
     if (tuplePosToReadInProbedState < probeState->numMatchedTuples) {
         populateResultSet();
         metrics->executionTime.stop();
-        metrics->numOutputTuple.increase(resultSet->getNumTuples());
+        metrics->numOutputTuple.increase(probeState->numMatchedTuples);
         return true;
     }
     getNextBatchOfMatchedTuples();
@@ -102,7 +102,7 @@ bool HashJoinProbe::getNextTuples() {
     }
     populateResultSet();
     metrics->executionTime.stop();
-    metrics->numOutputTuple.increase(resultSet->getNumTuples());
+    metrics->numOutputTuple.increase(probeState->numMatchedTuples);
     return true;
 }
 } // namespace processor

--- a/src/processor/physical_plan/operator/limit.cpp
+++ b/src/processor/physical_plan/operator/limit.cpp
@@ -15,11 +15,7 @@ bool Limit::getNextTuples() {
         metrics->executionTime.stop();
         return false;
     }
-    auto numTupleAvailable = 1u;
-    for (auto& dataChunkToLimitPos : dataChunksToLimitPos) {
-        numTupleAvailable *=
-            resultSet->dataChunks[dataChunkToLimitPos]->state->getNumSelectedValues();
-    }
+    auto numTupleAvailable = resultSet->getNumTuples(dataChunksPosInScope);
     auto numTupleProcessedBefore = counter->fetch_add(numTupleAvailable);
     if (numTupleProcessedBefore + numTupleAvailable > limitNumber) {
         int64_t numTupleToProcessInCurrentResultSet = limitNumber - numTupleProcessedBefore;

--- a/src/processor/physical_plan/operator/result_collector.cpp
+++ b/src/processor/physical_plan/operator/result_collector.cpp
@@ -3,6 +3,15 @@
 namespace graphflow {
 namespace processor {
 
+ResultCollector::ResultCollector(vector<DataPos> vectorsToCollectPos,
+    unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
+    : Sink{move(child), context, id}, vectorsToCollectPos{move(vectorsToCollectPos)} {
+    for (auto& dataPos : this->vectorsToCollectPos) {
+        dataChunksPosInScope.insert(dataPos.dataChunkPos);
+    }
+    queryResult = make_unique<QueryResult>(this->vectorsToCollectPos, dataChunksPosInScope);
+}
+
 shared_ptr<ResultSet> ResultCollector::initResultSet() {
     resultSet = children[0]->initResultSet();
     return resultSet;
@@ -12,14 +21,11 @@ void ResultCollector::execute() {
     metrics->executionTime.start();
     Sink::execute();
     while (children[0]->getNextTuples()) {
-        queryResult->numTuples += resultSet->getNumTuples();
+        queryResult->numTuples += resultSet->getNumTuples(dataChunksPosInScope);
         auto clonedResultSet = make_unique<ResultSet>(resultSet->getNumDataChunks());
-        for (auto i = 0u; i < resultSet->getNumDataChunks(); ++i) {
-            if (!resultSet->dataChunksMask[i]) {
-                continue;
-            }
-            auto dataChunk = resultSet->dataChunks[i];
-            clonedResultSet->insert(i,
+        for (auto& pos : dataChunksPosInScope) {
+            auto dataChunk = resultSet->dataChunks[pos];
+            clonedResultSet->insert(pos,
                 make_shared<DataChunk>(dataChunk->getNumValueVectors(), dataChunk->state->clone()));
         }
         for (auto& dataPos : vectorsToCollectPos) {
@@ -32,7 +38,6 @@ void ResultCollector::execute() {
             }
         }
         clonedResultSet->multiplicity = resultSet->multiplicity;
-        clonedResultSet->dataChunksMask = resultSet->dataChunksMask;
         queryResult->resultSetCollection.push_back(move(clonedResultSet));
         resetStringBuffer();
     }

--- a/src/processor/physical_plan/operator/skip.cpp
+++ b/src/processor/physical_plan/operator/skip.cpp
@@ -21,10 +21,7 @@ bool Skip::getNextTuples() {
             return false;
         }
         saveDataChunkSelectorState(dataChunkToSelect);
-        for (auto& dataChunkToSkipPos : dataChunksToSkipPos) {
-            numTuplesAvailable *=
-                resultSet->dataChunks[dataChunkToSkipPos]->state->getNumSelectedValues();
-        }
+        numTuplesAvailable = resultSet->getNumTuples(dataChunksPosInScope);
         numTupleSkippedBefore = counter->fetch_add(numTuplesAvailable);
     } while (numTupleSkippedBefore + numTuplesAvailable <= skipNumber);
     int64_t numTupleToSkipInCurrentResultSet = skipNumber - numTupleSkippedBefore;

--- a/src/processor/physical_plan/result/result_set.cpp
+++ b/src/processor/physical_plan/result/result_set.cpp
@@ -3,13 +3,11 @@
 namespace graphflow {
 namespace processor {
 
-uint64_t ResultSet::getNumTuples() {
+uint64_t ResultSet::getNumTuples(const unordered_set<uint32_t>& dataChunksPosInScope) {
+    assert(!dataChunksPosInScope.empty());
     uint64_t numTuples = 1;
-    for (auto i = 0u; i < dataChunks.size(); ++i) {
-        if (!dataChunksMask[i]) {
-            continue;
-        }
-        numTuples *= dataChunks[i]->state->getNumSelectedValues();
+    for (auto& dataChunkPos : dataChunksPosInScope) {
+        numTuples *= dataChunks[dataChunkPos]->state->getNumSelectedValues();
     }
     return numTuples * multiplicity;
 }

--- a/src/processor/physical_plan/result/result_set_iterator.cpp
+++ b/src/processor/physical_plan/result/result_set_iterator.cpp
@@ -6,13 +6,13 @@ namespace graphflow {
 namespace processor {
 
 bool ResultSetIterator::hasNextTuple() {
-    return numIteratedTuples < resultSet->getNumTuples();
+    return numIteratedTuples < resultSet->getNumTuples(dataChunksPosInScope);
 }
 
 void ResultSetIterator::reset() {
     tuplePositions.clear();
     for (uint64_t i = 0; i < resultSet->dataChunks.size(); i++) {
-        if (!resultSet->dataChunksMask[i]) {
+        if (!dataChunksPosInScope.contains(i)) {
             tuplePositions.push_back(UINT64_MAX);
             continue;
         }
@@ -29,7 +29,8 @@ void ResultSetIterator::reset() {
 }
 
 bool ResultSetIterator::updateTuplePositions(int64_t chunkIdx) {
-    if (!resultSet->dataChunksMask[chunkIdx] || resultSet->dataChunks[chunkIdx]->state->isFlat()) {
+    if (!dataChunksPosInScope.contains(chunkIdx) ||
+        resultSet->dataChunks[chunkIdx]->state->isFlat()) {
         return false;
     }
     tuplePositions[chunkIdx] = tuplePositions[chunkIdx] + 1;

--- a/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
+++ b/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
@@ -63,8 +63,8 @@ TEST_F(AggrExpressionEvaluatorTest, CountStarTest) {
     auto countStarState =
         static_unique_pointer_cast<AggregationState, CountFunction<true>::CountState>(
             exprEvaluator->getFunction()->initialize());
-    exprEvaluator->getFunction()->update(
-        (uint8_t*)countStarState.get(), nullptr, resultSet->getNumTuples());
+    exprEvaluator->getFunction()->update((uint8_t*)countStarState.get(), nullptr,
+        resultSet->getNumTuples(unordered_set<uint32_t>{0}));
     auto otherCountStarState =
         static_unique_pointer_cast<AggregationState, CountFunction<true>::CountState>(
             exprEvaluator->getFunction()->initialize());

--- a/test/processor/physical_plan/expression_mapper_test.cpp
+++ b/test/processor/physical_plan/expression_mapper_test.cpp
@@ -141,8 +141,8 @@ TEST_F(ExpressionMapperTest, AggrExpressionEvaluatorTest) {
     auto countStarState =
         static_unique_pointer_cast<AggregationState, CountFunction<true>::CountState>(
             countStarAggrEvaluator->getFunction()->initialize());
-    countStarAggrEvaluator->getFunction()->update(
-        (uint8_t*)countStarState.get(), nullptr, resultSet.getNumTuples());
+    countStarAggrEvaluator->getFunction()->update((uint8_t*)countStarState.get(), nullptr,
+        resultSet.getNumTuples(unordered_set<uint32_t>{0}));
     auto otherCountStarState =
         static_unique_pointer_cast<AggregationState, CountFunction<true>::CountState>(
             countStarAggrEvaluator->getFunction()->initialize());

--- a/test/processor/physical_plan/result/result_set_iterator_test.cpp
+++ b/test/processor/physical_plan/result/result_set_iterator_test.cpp
@@ -87,7 +87,8 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest1) {
     dataChunkB->state->currIdx = -1;
     dataChunkC->state->currIdx = 10;
 
-    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
+    ResultSetIterator resultSetIterator(
+        resultSet.get(), vectorToCollectPos, unordered_set<uint32_t>{0, 1, 2});
     auto tupleIndex = 0;
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
@@ -137,7 +138,8 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest2) {
     dataChunkA->state->currIdx = 1;
     dataChunkB->state->currIdx = -1;
     dataChunkC->state->currIdx = -1;
-    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
+    ResultSetIterator resultSetIterator(
+        resultSet.get(), vectorToCollectPos, unordered_set<uint32_t>{0, 1, 2});
     while (resultSetIterator.hasNextTuple()) {
         auto bid = tupleIndex / 100;
         auto cid = tupleIndex % 100;
@@ -168,7 +170,8 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest3) {
     dataChunkA->state->currIdx = -1;
     dataChunkB->state->currIdx = 10;
     dataChunkC->state->currIdx = -1;
-    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
+    ResultSetIterator resultSetIterator(
+        resultSet.get(), vectorToCollectPos, unordered_set<uint32_t>{0, 1, 2});
     while (resultSetIterator.hasNextTuple()) {
         auto aid = tupleIndex / 100;
         auto cid = tupleIndex % 100;
@@ -199,7 +202,8 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTest4) {
     dataChunkC->state->currIdx = 20;
 
     auto tupleIndex = 0;
-    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
+    ResultSetIterator resultSetIterator(
+        resultSet.get(), vectorToCollectPos, unordered_set<uint32_t>{0, 1, 2});
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
         string tupleStr = tuple.toString(vector<uint32_t>(tuple.len(), 0));
@@ -228,7 +232,8 @@ TEST_F(ResultSetIteratorTest, DataChunksIteratorTestWithSelector) {
     dataChunkC->state->currIdx = 20;
 
     auto tupleIndex = 0;
-    ResultSetIterator resultSetIterator(resultSet.get(), vectorToCollectPos);
+    ResultSetIterator resultSetIterator(
+        resultSet.get(), vectorToCollectPos, unordered_set<uint32_t>{0, 1, 2});
     while (resultSetIterator.hasNextTuple()) {
         resultSetIterator.getNextTuple(tuple);
         string tupleStr = tuple.toString(vector<uint32_t>(tuple.len(), 0));

--- a/test/runner/queries/projection/projection.test
+++ b/test/runner/queries/projection/projection.test
@@ -1,7 +1,6 @@
 # description: projections
 
 -NAME AbsFunctionTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:organisation) RETURN abs(a.score)
 ---- 3
 100
@@ -9,7 +8,6 @@
 7
 
 -NAME AbsFunctionTest2
--COMPARE_RESULT 1
 -QUERY MATCH (a:organisation) RETURN abs(a.unstrNumericProp)
 ---- 3
 
@@ -17,7 +15,6 @@
 3.100000
 
 -NAME FloorFunctionTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:organisation) RETURN floor(a.score)
 ---- 3
 -2
@@ -25,7 +22,6 @@
 7
 
 -NAME FloorFunctionTest2
--COMPARE_RESULT 1
 -QUERY MATCH (a:organisation) RETURN floor(a.unstrNumericProp)
 ---- 3
 -13.000000
@@ -33,7 +29,6 @@
 -4.000000
 
 -NAME CeilFunctionTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:organisation) RETURN ceil(a.score)
 ---- 3
 -2
@@ -41,7 +36,6 @@
 7
 
 -NAME CeilFunctionTest2
--COMPARE_RESULT 1
 -QUERY MATCH (a:organisation) RETURN ceil(a.unstrNumericProp)
 ---- 3
 -12.000000
@@ -49,7 +43,6 @@
 -3.000000
 
 -NAME CeilFloorFunctionTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:organisation) RETURN ceil(ceil(a.unstrNumericProp + abs(-0.5)) + floor(3.5))
 ---- 3
 
@@ -64,7 +57,6 @@
 6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|||-3.100000
 
 -NAME PersonNodesTestUnstructuredProperty
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.ID,a.unstrDateProp1
 ---- 8
 0|1900-01-01
@@ -77,7 +69,6 @@
 9|
 
 -NAME PersonNodesTestString
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.fName
 ---- 8
 Alice
@@ -90,7 +81,6 @@ Greg
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 
 -NAME PersonNodesTestInt
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.age
 ---- 8
 35
@@ -103,7 +93,6 @@ Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 83
 
 -NAME PersonNodesTestBoolean
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.isStudent
 ---- 8
 True
@@ -116,7 +105,6 @@ False
 False
 
 -NAME PersonNodesTestDouble
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.eyeSight
 ---- 8
 5.000000
@@ -129,7 +117,6 @@ False
 4.900000
 
 -NAME PersonNodesTestDate
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.birthdate
 ---- 8
 1900-01-01
@@ -142,7 +129,6 @@ False
 1990-11-27
 
 -NAME KnowsRelTestDate
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[e:knows]->(b:person) RETURN e.date
 ---- 14
 2021-06-30
@@ -161,7 +147,6 @@ False
 1905-12-12
 
 -NAME KnowsOneHopTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE b.age=20 RETURN b.age
 ---- 3
 20
@@ -169,15 +154,13 @@ False
 20
 
 -NAME KnowsOneHopTest2
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE b.age=20 RETURN b.age * 2
 ---- 3
 40
 40
 40
 
--NAME KnowsOneHopTest2
--COMPARE_RESULT 1
+-NAME KnowsOneHopTest3
 -QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE a.age>20 RETURN b.fName
 ---- 9
 Alice
@@ -191,7 +174,6 @@ Dan
 Dan
 
 -NAME KnowsTwoHopTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[:knows]->(:person)-[:knows]->(b:person) WHERE b.age>40 RETURN b.age
 ---- 9
 45
@@ -205,7 +187,6 @@ Dan
 45
 
 -NAME KnowsTwoHopTest2
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[:knows]->(:person)-[:knows]->(b:person) WHERE a.age>b.age+10 RETURN a.age, b.age
 ---- 6
 35|20
@@ -216,7 +197,6 @@ Dan
 45|30
 
 -NAME KnowsTwoHopTest3
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE a.age>c.age+10 RETURN a.age, b.fName, c.age
 ---- 6
 35|Bob|20
@@ -227,7 +207,6 @@ Dan
 45|Dan|30
 
 -NAME KnowsTwoHopTest4
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN a.fName, b.fName
 ---- 36
 Alice|Bob
@@ -266,3 +245,8 @@ Dan|Bob
 Dan|Carol
 Dan|Carol
 Dan|Carol
+
+-NAME KnowsFourHopTest
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person)-[:knows]->(e:person) WITH e.ID as dummy RETURN COUNT(*)
+---- 1
+324

--- a/test/runner/queries/projection/skip_limit.test
+++ b/test/runner/queries/projection/skip_limit.test
@@ -1,7 +1,6 @@
 # description: skip and limit tests
 
 -NAME BasicSkipTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.fName Skip 5
 ---- 3
 Farooq
@@ -9,19 +8,26 @@ Greg
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 
 -NAME BasicSkipTest2
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.fName Skip 10
 ---- 0
 
+-NAME BasicSkipTest3
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person) WITH d.ID as dummy SKIP 10 RETURN COUNT(*)
+---- 1
+98
+
+-NAME BasicSkipTest4
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person)-[:knows]->(e:person) WITH e.ID as dummy SKIP 300 RETURN COUNT(*)
+---- 1
+24
+
 -NAME BasicLimitTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.fName LIMIT 2
 ---- 2
 Alice
 Bob
 
 -NAME BasicLimitTest2
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.fName LIMIT 10
 ---- 8
 Alice
@@ -33,21 +39,28 @@ Farooq
 Greg
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 
+-NAME BasicLimitTest3
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person) WITH d.fName AS k LIMIT 5 RETURN COUNT(*)
+---- 1
+5
+
+-NAME BasicLimitTest4
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person)-[:knows]->(e:person) WITH d.fName AS k LIMIT 5 RETURN COUNT(*)
+---- 1
+5
+
 -NAME BasicSkipLimitTest
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) RETURN a.fName SKIP 1 LIMIT 2
 ---- 2
 Bob
 Carol
 
 -NAME KnowsTwoHopLimitTest
--COMPARE_RESULT 1
 -QUERY MATCH (a:person)-[:knows]->(:person)-[:knows]->(b:person) WHERE a.age=35 RETURN b.fName LIMIT 1
 ---- 1
 Alice
 
 -NAME KnowsOneHopWithLimitTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) WHERE a.age>20 WITH a LIMIT 1 MATCH (a)-[e:knows]->(b:person) RETURN b.fName
 ---- 3
 Bob
@@ -55,22 +68,19 @@ Carol
 Dan
 
 -NAME KnowsOneHopWithSkipLimitTest1
--COMPARE_RESULT 1
 -QUERY MATCH (a:person) WHERE a.age>20 WITH a SKIP 2 MATCH (a)-[e:knows]->(b:person) RETURN b.fName LIMIT 2
 ---- 2
 Alice
 Bob
 
--NAME KnowsOneHopWithSkipLimitTest1
--COMPARE_RESULT 1
+-NAME KnowsOneHopWithSkipLimitTest2
 -QUERY MATCH (a:person) WHERE a.age>20 WITH a SKIP 1 LIMIT 1 MATCH (a)-[e:knows]->(b:person) RETURN b.fName
 ---- 3
 Alice
 Carol
 Dan
 
--NAME KnowsOneHopWithLimitTest2
--COMPARE_RESULT 1
+-NAME KnowsOneHopWithLimitTest3
 -QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE a.age=35 WITH b LIMIT 1 RETURN b.fName
 ---- 1
 Bob

--- a/test/test_utility/test_helper.cpp
+++ b/test/test_utility/test_helper.cpp
@@ -119,8 +119,9 @@ void BaseGraphLoadingTest::SetUp() {
 vector<string> TestHelper::getActualOutput(QueryResult& queryResult, bool checkOutputOrder) {
     vector<string> actualOutput;
     if (queryResult.numTuples != 0) {
-        auto resultSetIterator = make_unique<ResultSetIterator>(
-            queryResult.resultSetCollection[0].get(), queryResult.vectorsToCollectPos);
+        auto resultSetIterator =
+            make_unique<ResultSetIterator>(queryResult.resultSetCollection[0].get(),
+                queryResult.vectorsToCollectPos, queryResult.dataChunksPosInScope);
         Tuple tuple(resultSetIterator->dataTypes);
         for (auto& resultSet : queryResult.resultSetCollection) {
             resultSetIterator->setResultSet(resultSet.get());

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -267,7 +267,7 @@ void EmbeddedShell::printExecutionResult() {
         printf(">> Executing time: %.2fms\n", context.executingTime);
         if (!context.queryResult->resultSetCollection.empty()) {
             ResultSetIterator resultSetIterator(context.queryResult->resultSetCollection[0].get(),
-                context.queryResult->vectorsToCollectPos);
+                context.queryResult->vectorsToCollectPos, context.queryResult->dataChunksPosInScope);
             Tuple tuple(resultSetIterator.dataTypes);
             vector<uint32_t> colsWidth(tuple.len(), 2);
             uint32_t lineSeparatorLen = 1u + colsWidth.size();


### PR DESCRIPTION
This PR resolves issue #376 and the second failed query in issue #430 

## Bug Description
In the previous design, we have a `dataChunkMask` in `ResultSet` which indicates which dataChunk is projected away. However, since our resultSet is shared, `dataChunkMask` can only reflect the final state instead of the intermediate state. This creates trouble when we have multiple projects.

## Changes
### ResultSet
- Remove `dataChunkMask`
- Change `getNumTuple()` to `getNumTuple(unorder_set<uint> dataChunksPosInScope)`
  -  The rationale is our project does not explicitly remove dataChunk. Therefore, whoever tries to read from multiple dataChunks needs to specify the positions. Blindly reading from all dataChunks is prohibited. 
- Add dataChunksPosInScope to operators  (both logical and physical) that might read from multiple dataChunks.
  -  Includes, SKIP, LIMIT, SIMPLE_AGGREGATE 