### PR TITLE
Bug fix resulting in reading wrong vector positions in flat vectors

### DIFF
--- a/src/processor/include/physical_plan/result/row_collection.h
+++ b/src/processor/include/physical_plan/result/row_collection.h
@@ -151,9 +151,10 @@ private:
         uint8_t** rows, uint64_t offsetInRow, uint64_t startRowPos, ValueVector& vector) const;
     void readNonOverflowVector(uint8_t** rows, uint64_t offsetInRow, ValueVector& vector,
         uint64_t numRowsToRead, uint64_t colIdx) const;
-    void copyVectorDataToBuffer(const ValueVector& vector, uint64_t valuePosInVec,
-        uint64_t posStride, uint8_t* buffer, uint64_t offsetInBuffer, uint64_t offsetStride,
-        uint64_t numValues, uint64_t colIdx, bool isVectorOverflow);
+    // If the given vector is flat valuePosInVecIfUnflat will be ignored.
+    void copyVectorDataToBuffer(const ValueVector& vector, uint64_t valuePosInVecIfUnflat,
+        uint8_t* buffer, uint64_t offsetInBuffer, uint64_t offsetStride, uint64_t numValues,
+        uint64_t colIdx, bool isVectorOverflow);
 
     MemoryManager& memoryManager;
     RowLayout layout;


### PR DESCRIPTION
This fixes a bug I noticed in RowCollection when reading data into buffers from flat vectors. The position within the vector that we are reading should not be read from selected positions and instead by directly calling     vector.state->getPositionOfCurrIdx() because flat vectors, from the perspective of the user cannot be filtered, otherwise the entire tuple would be removed. So the logic to first check if the vector is flat was missing.