### PR TITLE
Fixing string overflow lifecycle issue

### DIFF
--- a/src/common/include/gf_string.h
+++ b/src/common/include/gf_string.h
@@ -30,8 +30,10 @@ struct gf_string_t {
     void setOverflowPtrInfo(const uint64_t& pageIdx, const uint16_t& pageOffset);
     void getOverflowPtrInfo(uint64_t& pageIdx, uint16_t& pageOffset) const;
 
+    static bool isShortString(uint32_t len) { return len <= SHORT_STR_LENGTH; }
+
     inline const uint8_t* getData() const {
-        return len <= SHORT_STR_LENGTH ? prefix : reinterpret_cast<uint8_t*>(overflowPtr);
+        return isShortString(len) ? prefix : reinterpret_cast<uint8_t*>(overflowPtr);
     }
 
     bool operator==(const gf_string_t& rhs) const;
@@ -46,7 +48,7 @@ struct gf_string_t {
 
     inline bool operator<=(const gf_string_t& rhs) const { return !(*this > rhs); }
 
-    // This function does *NOT* allocate/resize the overflow buffer, it only copies the content and
+    // These functions do *NOT* allocate/resize the overflow buffer, it only copies the content and
     // set the length.
     void set(const string& value);
     void set(const char* value, uint64_t length);

--- a/src/common/include/vector/operations/executors/unary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/unary_operation_executor.h
@@ -25,6 +25,7 @@ struct UnaryOperationExecutor {
     static void execute(ValueVector& operand, ValueVector& result) {
         assert(!IS_BOOL_OP ||
                (IS_BOOL_OP && (is_same<T, bool>::value) && (is_same<R, uint8_t>::value)));
+        result.resetStringBuffer();
         auto resultValues = (R*)result.values;
         if (operand.state->isFlat()) {
             auto operandPos = operand.state->getPositionOfCurrIdx();

--- a/src/common/vector/operations/vector_cast_operations.cpp
+++ b/src/common/vector/operations/vector_cast_operations.cpp
@@ -35,9 +35,7 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
             outValues[resPos].val.intervalVal = ((interval_t*)operand.values)[pos];
         } break;
         case STRING: {
-            auto& operandVal = ((gf_string_t*)operand.values)[pos];
-            result.allocateStringOverflowSpace(outValues[resPos].val.strVal, operandVal.len);
-            outValues[resPos].val.strVal.set(operandVal);
+            result.addGFStringToUnstructuredVector(resPos, ((gf_string_t*)operand.values)[pos]);
         } break;
         default:
             assert(false);
@@ -88,9 +86,7 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
         case STRING: {
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
-                auto& operandVal = ((gf_string_t*)operand.values)[pos];
-                result.allocateStringOverflowSpace(outValues[pos].val.strVal, operandVal.len);
-                outValues[pos].val.strVal.set(operandVal);
+                result.addGFStringToUnstructuredVector(pos, ((gf_string_t*)operand.values)[pos]);
             }
         } break;
         default:

--- a/src/common/vector/string_buffer.cpp
+++ b/src/common/vector/string_buffer.cpp
@@ -5,8 +5,9 @@
 namespace graphflow {
 namespace common {
 
-void StringBuffer::allocateLargeString(gf_string_t& result, uint64_t len) {
-    assert(len > gf_string_t::SHORT_STR_LENGTH);
+void StringBuffer::allocateLargeStringIfNecessary(gf_string_t& result, uint64_t len) {
+    if (gf_string_t::isShortString(len))
+        return;
     if (currentBlock == nullptr || (currentBlock->currentOffset + len) > currentBlock->size) {
         auto blockSize = max(len, MIN_BUFFER_BLOCK_SIZE);
         auto newBlock = make_unique<BufferBlock>(

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -50,18 +50,68 @@ bool ValueVector::discardNullNodes() {
 // Notice that this clone function only copies values and mask without copying string buffers.
 shared_ptr<ValueVector> ValueVector::clone() {
     auto newVector = make_shared<ValueVector>(memoryManager, dataType);
-    // Warning: This is a potential bug because sometimes nullMasks of ValueVectors point to
-    // null masks of other ValueVectors, e.g., the result ValueVectors of unary expressions, point
-    // to the nullMasks of operands. In which case these should not be copied over.
+    // Warning: This is a potential bug because below we copy the nullMask of this ValueVector.
+    // However, nullmasks of ValueVectors point to null masks of other ValueVectors, e.g., the
+    // result ValueVectors of unary expressions, point to the nullMasks of operands. In which case
+    // these should not be copied over. newVector->nullMask = nullMask->clone();
     newVector->nullMask = nullMask->clone();
+    // We first blindly copy because we are assuming that the caller (which currently is the
+    // ResultCollector is using the DataChunkState of this vector, which may have filted positions.
+    // So the selected positions can be a subset of the actual values and if the datatype is
+    // string or unstructured (which might have strings), we want to fix the overflow pointers
+    // of the copied strings only for the selected positions. For non selected positions, it is not
+    // also safe to copy them, as they are not valid strings.
     memcpy(newVector->values, values, DEFAULT_VECTOR_CAPACITY * getNumBytesPerValue());
+    if (dataType == STRING || dataType == UNSTRUCTURED) {
+        for (int i = 0; i < state->selectedSize; ++i) {
+            if (!isNull(state->selectedPositions[i])) {
+                newVector->copyNonNullDataWithSameTypeIntoPos(state->selectedPositions[i],
+                    values + getNumBytesPerValue() * state->selectedPositions[i]);
+            }
+        }
+    }
     return newVector;
 }
 
-void ValueVector::allocateStringOverflowSpace(gf_string_t& result, uint64_t len) const {
+void ValueVector::allocateStringOverflowSpaceIfNecessary(gf_string_t& result, uint64_t len) const {
     assert(dataType == STRING || dataType == UNSTRUCTURED);
-    if (len > gf_string_t::SHORT_STR_LENGTH) {
-        stringBuffer->allocateLargeString(result, len);
+    stringBuffer->allocateLargeStringIfNecessary(result, len);
+}
+
+void ValueVector::copyNonNullDataWithSameTypeIntoPos(uint64_t pos, uint8_t* srcData) {
+    copyNonNullDataWithSameType(srcData, values + pos * getNumBytesPerValue(), *stringBuffer);
+}
+
+void ValueVector::copyNonNullDataWithSameTypeOutFromPos(
+    uint64_t pos, uint8_t* dstData, StringBuffer& dstStringBuffer) {
+    copyNonNullDataWithSameType(values + pos * getNumBytesPerValue(), dstData, dstStringBuffer);
+}
+
+void ValueVector::copyNonNullDataWithSameType(
+    const uint8_t* srcData, uint8_t* dstData, StringBuffer& stringBuffer) const {
+    if (dataType == STRING) {
+        auto gfStrSrcPtr = (gf_string_t*)srcData;
+        auto gfStrDstPtr = (gf_string_t*)dstData;
+        stringBuffer.allocateLargeStringIfNecessary(*gfStrDstPtr, gfStrSrcPtr->len);
+        gfStrDstPtr->set(*gfStrSrcPtr);
+    } else {
+        // Regardless of whether the dataType is unstructured or a structured non-string type, we
+        // first copy over the data in the src to the dst.
+        memcpy(dstData, srcData, getNumBytesPerValue());
+        if (dataType == UNSTRUCTURED) {
+            auto unstrValueSrcPtr = (Value*)srcData;
+            auto unstrValueDstPtr = (Value*)dstData;
+            // If further the dataType is unstructured and string we need to copy over the string
+            // overflow if necessary. Recall that an unstructured string has 16 bytes for the string
+            // but also stores its data type as an additional byte. That is why we need to copy over
+            // the entire data first even though the unstrValueDstPtr->val.strVal.set call below
+            // will copy over the 16 bytes for the string.
+            if (unstrValueSrcPtr->dataType == STRING) {
+                stringBuffer.allocateLargeStringIfNecessary(
+                    unstrValueDstPtr->val.strVal, unstrValueSrcPtr->val.strVal.len);
+                unstrValueDstPtr->val.strVal.set(unstrValueSrcPtr->val.strVal);
+            }
+        }
     }
 }
 
@@ -69,12 +119,53 @@ void ValueVector::addString(uint64_t pos, char* value, uint64_t len) const {
     assert(dataType == STRING);
     auto vectorData = (gf_string_t*)values;
     auto& result = vectorData[pos];
-    allocateStringOverflowSpace(result, len);
+    allocateStringOverflowSpaceIfNecessary(result, len);
     result.set(value, len);
 }
 
 void ValueVector::addString(uint64_t pos, string value) const {
     addString(pos, value.data(), value.length());
+}
+
+void ValueVector::addLiteralToUnstructuredVector(const uint64_t pos, const Literal& value) const {
+    assert(dataType == UNSTRUCTURED);
+    auto& val = ((Value*)values)[pos];
+    val.dataType = value.dataType;
+    switch (val.dataType) {
+    case INT64: {
+        val.val.int64Val = value.val.int64Val;
+    } break;
+    case DOUBLE: {
+        val.val.doubleVal = value.val.doubleVal;
+    } break;
+    case BOOL: {
+        val.val.booleanVal = value.val.booleanVal;
+    } break;
+    case DATE: {
+        val.val.dateVal = value.val.dateVal;
+    } break;
+    case TIMESTAMP: {
+        val.val.timestampVal = value.val.timestampVal;
+    } break;
+    case INTERVAL: {
+        val.val.intervalVal = value.val.intervalVal;
+    } break;
+    case STRING: {
+        allocateStringOverflowSpaceIfNecessary(val.val.strVal, value.strVal.length());
+        val.val.strVal.set(value.strVal);
+    } break;
+    default:
+        assert(false);
+    }
+}
+
+void ValueVector::addGFStringToUnstructuredVector(
+    const uint64_t pos, const gf_string_t& value) const {
+    assert(dataType == UNSTRUCTURED);
+    auto& val = ((Value*)values)[pos];
+    val.dataType = STRING;
+    allocateStringOverflowSpaceIfNecessary(val.val.strVal, value.len);
+    val.val.strVal.set(value);
 }
 
 } // namespace common

--- a/src/planner/include/logical_plan/operator/order_by/logical_order_by.h
+++ b/src/planner/include/logical_plan/operator/order_by/logical_order_by.h
@@ -44,6 +44,8 @@ public:
 private:
     vector<shared_ptr<Expression>> orderByExpressions;
     vector<bool> isAscOrders;
+
+public:
     unique_ptr<Schema> schemaBeforeOrderBy;
 };
 

--- a/src/processor/include/physical_plan/operator/order_by/order_by.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by.h
@@ -95,7 +95,6 @@ public:
 
     shared_ptr<ResultSet> initResultSet() override;
     void execute() override;
-    void finalize() override;
 
     PhysicalOperatorType getOperatorType() override { return ORDER_BY; }
 

--- a/src/processor/include/physical_plan/result/row_collection.h
+++ b/src/processor/include/physical_plan/result/row_collection.h
@@ -2,6 +2,7 @@
 
 #include "src/common/include/memory_manager.h"
 #include "src/common/include/types.h"
+#include "src/common/include/vector/string_buffer.h"
 #include "src/processor/include/physical_plan/result/result_set.h"
 
 using namespace graphflow::common;
@@ -141,9 +142,9 @@ private:
     vector<BlockAppendingInfo> allocateDataBlocks(vector<DataBlock>& dataBlocks,
         uint64_t numBytesPerEntry, uint64_t numEntriesToAppend, bool allocateOnlyFromLastBlock);
 
-    void copyVectorToBlock(const ValueVector& vector, const BlockAppendingInfo& blockAppendInfo,
+    void copyVectorToBlock(ValueVector& vector, const BlockAppendingInfo& blockAppendInfo,
         const FieldInLayout& field, uint64_t posInVector, uint64_t offsetInRow, uint64_t colIdx);
-    overflow_value_t appendUnFlatVectorToOverflowBlocks(const ValueVector& vector, uint64_t colIdx);
+    overflow_value_t appendUnFlatVectorToOverflowBlocks(ValueVector& vector, uint64_t colIdx);
 
     void appendVector(ValueVector& valueVector, const vector<BlockAppendingInfo>& blockAppendInfos,
         const FieldInLayout& field, uint64_t numRows, uint64_t offsetInRow, uint64_t colIdx);
@@ -152,7 +153,7 @@ private:
     void readNonOverflowVector(uint8_t** rows, uint64_t offsetInRow, ValueVector& vector,
         uint64_t numRowsToRead, uint64_t colIdx) const;
     // If the given vector is flat valuePosInVecIfUnflat will be ignored.
-    void copyVectorDataToBuffer(const ValueVector& vector, uint64_t valuePosInVecIfUnflat,
+    void copyVectorDataToBuffer(ValueVector& vector, uint64_t valuePosInVecIfUnflat,
         uint8_t* buffer, uint64_t offsetInBuffer, uint64_t offsetStride, uint64_t numValues,
         uint64_t colIdx, bool isVectorOverflow);
 
@@ -162,6 +163,7 @@ private:
     uint64_t numRowsPerBlock;
     vector<DataBlock> rowDataBlocks;
     vector<DataBlock> vectorOverflowBlocks;
+    unique_ptr<StringBuffer> stringBuffer;
 };
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/mapper/expression_mapper.cpp
+++ b/src/processor/physical_plan/mapper/expression_mapper.cpp
@@ -91,35 +91,7 @@ unique_ptr<ExpressionEvaluator> ExpressionMapper::mapLogicalLiteralExpressionToU
     auto vector = make_shared<ValueVector>(
         executionContext.memoryManager, UNSTRUCTURED, true /* isSingleValue */);
     vector->state = DataChunkState::getSingleValueDataChunkState();
-    auto& val = ((Value*)vector->values)[0];
-    val.dataType = literalExpression.literal.dataType;
-    switch (val.dataType) {
-    case INT64: {
-        val.val.int64Val = literalExpression.literal.val.int64Val;
-    } break;
-    case DOUBLE: {
-        val.val.doubleVal = literalExpression.literal.val.doubleVal;
-    } break;
-    case BOOL: {
-        val.val.booleanVal = literalExpression.literal.val.booleanVal;
-    } break;
-    case DATE: {
-        val.val.dateVal = literalExpression.literal.val.dateVal;
-    } break;
-    case TIMESTAMP: {
-        val.val.timestampVal = literalExpression.literal.val.timestampVal;
-    } break;
-    case INTERVAL: {
-        val.val.intervalVal = literalExpression.literal.val.intervalVal;
-    } break;
-    case STRING: {
-        vector->allocateStringOverflowSpace(
-            val.val.strVal, literalExpression.literal.strVal.length());
-        val.val.strVal.set(literalExpression.literal.strVal);
-    } break;
-    default:
-        assert(false);
-    }
+    vector->addLiteralToUnstructuredVector(0, literalExpression.literal);
     return make_unique<ExpressionEvaluator>(vector, expression.expressionType);
 }
 

--- a/src/processor/physical_plan/mapper/plan_mapper.cpp
+++ b/src/processor/physical_plan/mapper/plan_mapper.cpp
@@ -46,6 +46,8 @@
 #include "src/processor/include/physical_plan/operator/scan_node_id.h"
 #include "src/processor/include/physical_plan/operator/skip.h"
 
+// TODO(Semih): Remove
+#include <iostream>
 using namespace graphflow::planner;
 
 namespace graphflow {
@@ -503,6 +505,17 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOrderByToPhysical(
             isVectorFlat.emplace_back(group->isFlat);
         }
     }
+    // TODO(Semih): This commented for loop is a temporary fix to make returns or withs contain
+    // arbitrary projection set (the commented one allows only the subset of order by fields to be
+    // in return).
+    //    for (auto i = 0u; i < mapperContext.getResultSetDescriptor()->getNumDataChunks(); ++i) {
+    //        auto dataChunkDescriptor =
+    //            mapperContext.getResultSetDescriptor()->getDataChunkDescriptor(i);
+    //        for (auto j = 0u; j < dataChunkDescriptor->getNumValueVectors(); ++j) {
+    //            allDataPoses.emplace_back(DataPos(i, j));
+    //            isVectorFlat.emplace_back(logicalOrderBy.schemaBeforeOrderBy->groups[i]->isFlat);
+    //        }
+    //    }
 
     auto orderByDataInfo =
         OrderByDataInfo(keyDataPoses, allDataPoses, isVectorFlat, logicalOrderBy.getIsAscOrders());

--- a/src/processor/physical_plan/operator/order_by/order_by.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by.cpp
@@ -99,7 +99,5 @@ void OrderBy::execute() {
     metrics->executionTime.stop();
 }
 
-void OrderBy::finalize() {}
-
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -17,6 +17,7 @@ bool ReadRelPropertyList::getNextTuples() {
         metrics->executionTime.stop();
         return false;
     }
+    outValueVector->resetStringBuffer();
     readValuesFromList();
     metrics->executionTime.stop();
     return true;

--- a/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_structured_property.cpp
@@ -18,6 +18,7 @@ bool ScanStructuredProperty::getNextTuples() {
         metrics->executionTime.stop();
         return false;
     }
+    outValueVector->resetStringBuffer();
     column->readValues(inValueVector, outValueVector, *metrics->bufferManagerMetrics);
     metrics->executionTime.stop();
     return true;

--- a/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_attribute/scan_unstructured_property.cpp
@@ -18,6 +18,7 @@ bool ScanUnstructuredProperty::getNextTuples() {
         metrics->executionTime.stop();
         return false;
     }
+    outValueVector->resetStringBuffer();
     lists->readUnstructuredProperties(
         inValueVector, propertyKey, outValueVector, *metrics->bufferManagerMetrics);
     metrics->executionTime.stop();

--- a/src/storage/data_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/data_structure/lists/unstructured_property_lists.cpp
@@ -46,7 +46,8 @@ void UnstructuredPropertyLists::readUnstructuredPropertyForSingleNodeIDPosition(
             valueVector->setNull(pos, false);
             value->dataType = propertyKeyDataType.dataType;
             if (STRING == propertyKeyDataType.dataType) {
-                stringOverflowPages.readStringToVector(*valueVector, pos, metrics);
+                stringOverflowPages.readStringToVector(
+                    value->val.strVal, *valueVector->stringBuffer, metrics);
             }
             // found the property, exiting.
             return;

--- a/src/storage/include/data_structure/string_overflow_pages.h
+++ b/src/storage/include/data_structure/string_overflow_pages.h
@@ -25,7 +25,8 @@ public:
 
     void readStringsToVector(ValueVector& valueVector, BufferManagerMetrics& metrics);
 
-    void readStringToVector(ValueVector& valueVector, uint32_t pos, BufferManagerMetrics& metrics);
+    void readStringToVector(
+        gf_string_t& gfStr, StringBuffer& stringBuffer, BufferManagerMetrics& metrics);
 
     string readString(const gf_string_t& str, BufferManagerMetrics& metrics);
 

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -348,7 +348,7 @@ TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredStringAndI
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
         string lStr = to_string(i);
-        lVector->allocateStringOverflowSpace(lData[i].val.strVal, lStr.length());
+        lVector->allocateStringOverflowSpaceIfNecessary(lData[i].val.strVal, lStr.length());
         lData[i].val.strVal.set(lStr);
         lData[i].dataType = STRING;
         rData[i] = Value((int64_t)110 - i);

--- a/test/common/vector/operations/vector_cast_operations_test.cpp
+++ b/test/common/vector/operations/vector_cast_operations_test.cpp
@@ -112,7 +112,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredStringToUnstructuredValueTest) {
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         string lStr = to_string(i * 2);
-        lVector->allocateStringOverflowSpace(lData[i], lStr.length());
+        lVector->allocateStringOverflowSpaceIfNecessary(lData[i], lStr.length());
         lData[i].set(lStr);
     }
     VectorCastOperations::castStructuredToUnstructuredValue(*lVector, *result);

--- a/test/processor/physical_plan/result/row_collection_test.cpp
+++ b/test/processor/physical_plan/result/row_collection_test.cpp
@@ -271,7 +271,7 @@ TEST_F(RowCollectionTest, ReadOverflowColToFlatVectorFails) {
         auto numRowsRead = rowCollection->scan(fieldIdsToScan, readDataPos, *readResultSet, 0, 100);
         FAIL();
     } catch (RowCollectionException& e) {
-        ASSERT_STREQ(e.what(), "RowCollection exception: Read an overflow column to a flat "
+        ASSERT_STREQ(e.what(), "RowCollection exception: Reading an overflow column to a flat "
                                "valueVector is not allowed!");
     } catch (exception& e) { FAIL(); }
 }


### PR DESCRIPTION
This PR addresses #440 and #375, which are both related to not releasing the memory of StringBuffers of vectors that initially read strings from storage or copying them over at the final operators of pipelines. We address this as follows:

- At RowCollection and ResultCollectors (which calls ValueVector::clone) we now copy over the strings overflows to the RowCollection or cloned ValueVector, respectively.
- We reset StringBuffers at source operators that can possibly read strings into vectors (so either strings or unstructured properties).
- We also reset StringBuffers of ValueVectors in binary/unary_operation_executors, which might also be allocating stringbuffer space due to possible concatenations.
   