### PR TITLE
Order by front end

### DIFF
--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -69,6 +69,8 @@ private:
         label_t relLabel, label_t nodeLabel, Direction direction);
     // E.g. RETURN a, b AS a
     void validateProjectionColumnNamesAreUnique(const vector<shared_ptr<Expression>>& expressions);
+    void validateOrderByFollowedBySkipOrLimitInWithStatement(
+        const BoundProjectionBody& boundProjectionBody);
     // E.g. RETURN a, b, COUNT(*)
     // Note: this validation should be removed once we have group by implemented.
     void validateAggregationsHaveNoGroupBy(const vector<shared_ptr<Expression>>& expressions);

--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -74,7 +74,7 @@ void Enumerator::planOptionalMatch(const QueryGraph& queryGraph,
             getSubExpressionsInSchema(queryGraphPredicate, *outerPlan.schema);
     }
     for (auto& nodeIDExpression : queryGraph.getNodeIDExpressions()) {
-        if (outerPlan.schema->containExpression(nodeIDExpression->getUniqueName())) {
+        if (outerPlan.schema->expressionInScope(nodeIDExpression->getUniqueName())) {
             expressionsToScanFromOuter.push_back(nodeIDExpression);
         }
     }
@@ -100,7 +100,7 @@ void Enumerator::planOptionalMatch(const QueryGraph& queryGraph,
     auto firstInnerGroupMapToOuterPos = UINT32_MAX;
     // Merge first inner group into outer. This merging handles the logic above.
     for (auto& expressionName : firstInnerGroup->expressionNames) {
-        if (outerPlan.schema->containExpression(expressionName)) {
+        if (outerPlan.schema->expressionInScope(expressionName)) {
             continue;
         }
         if (firstInnerGroupMapToOuterPos == UINT32_MAX) {
@@ -211,7 +211,7 @@ void Enumerator::appendScanPropertiesIfNecessary(
     for (auto& expr : getPropertyExpressionsNotInSchema(expression, *plan.schema)) {
         auto& propertyExpression = (PropertyExpression&)*expr;
         // skip properties that has been evaluated
-        if (plan.schema->containExpression(propertyExpression.getUniqueName())) {
+        if (plan.schema->expressionInScope(propertyExpression.getUniqueName())) {
             continue;
         }
         NODE == propertyExpression.getChild(0)->dataType ?
@@ -223,7 +223,7 @@ void Enumerator::appendScanPropertiesIfNecessary(
 void Enumerator::appendScanNodePropertyIfNecessary(
     const PropertyExpression& propertyExpression, LogicalPlan& plan) {
     auto& nodeExpression = (const NodeExpression&)*propertyExpression.getChild(0);
-    if (!plan.schema->containExpression(nodeExpression.getIDProperty())) {
+    if (!plan.schema->expressionInScope(nodeExpression.getIDProperty())) {
         return;
     }
     auto scanProperty = make_shared<LogicalScanNodeProperty>(nodeExpression.getIDProperty(),
@@ -268,7 +268,7 @@ unordered_set<uint32_t> Enumerator::getDependentGroupsPos(
 vector<shared_ptr<Expression>> Enumerator::getSubExpressionsInSchema(
     const shared_ptr<Expression>& expression, const Schema& schema) {
     vector<shared_ptr<Expression>> results;
-    if (schema.containExpression(expression->getUniqueName())) {
+    if (schema.expressionInScope(expression->getUniqueName())) {
         results.push_back(expression);
         return results;
     }
@@ -285,7 +285,7 @@ vector<shared_ptr<Expression>> Enumerator::getSubExpressionsNotInSchemaOfType(
     const shared_ptr<Expression>& expression, const Schema& schema,
     const std::function<bool(ExpressionType)>& typeCheckFunc) {
     vector<shared_ptr<Expression>> results;
-    if (schema.containExpression(expression->getUniqueName())) {
+    if (schema.expressionInScope(expression->getUniqueName())) {
         return results;
     }
     if (typeCheckFunc(expression->expressionType)) {

--- a/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
+++ b/src/planner/include/logical_plan/operator/hash_join/logical_hash_join.h
@@ -11,9 +11,11 @@ class LogicalHashJoin : public LogicalOperator {
 public:
     // Probe side on left, i.e. children[0]. Build side on right, i.e. children[1].
     LogicalHashJoin(string joinNodeID, unique_ptr<Schema> buildSideSchema,
+        unordered_set<string> expressionToMaterializeNames,
         shared_ptr<LogicalOperator> probeSideChild, shared_ptr<LogicalOperator> buildSideChild)
         : LogicalOperator{move(probeSideChild), move(buildSideChild)}, joinNodeID(move(joinNodeID)),
-          buildSideSchema(move(buildSideSchema)) {}
+          buildSideSchema(move(buildSideSchema)), expressionToMaterializeNames{
+                                                      move(expressionToMaterializeNames)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_HASH_JOIN;
@@ -21,14 +23,25 @@ public:
 
     string getExpressionsForPrinting() const override { return joinNodeID; }
 
+    inline unordered_set<string> getExpressionToMaterializeNames() const {
+        return expressionToMaterializeNames;
+    }
+
+    inline void addExpressionToMaterialize(const string& name) {
+        expressionToMaterializeNames.insert(name);
+    }
+
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalHashJoin>(
-            joinNodeID, buildSideSchema->copy(), children[0]->copy(), children[1]->copy());
+        return make_unique<LogicalHashJoin>(joinNodeID, buildSideSchema->copy(),
+            expressionToMaterializeNames, children[0]->copy(), children[1]->copy());
     }
 
 public:
     const string joinNodeID;
     unique_ptr<Schema> buildSideSchema;
+
+private:
+    unordered_set<string> expressionToMaterializeNames;
 };
 } // namespace planner
 } // namespace graphflow

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -60,15 +60,21 @@ public:
 
     void insertToGroupAndScope(const string& expressionName, uint32_t groupPos);
 
-    void insertToGroupAndScope(const FactorizationGroup& otherGroup, uint32_t groupPos);
+    void insertToGroupAndScope(const unordered_set<string>& expressionNames, uint32_t groupPos);
 
     uint32_t getGroupPos(const string& expressionName) const;
 
     inline void flattenGroup(uint32_t pos) { groups[pos]->isFlat = true; }
 
-    inline bool containExpression(const string& expressionName) const {
-        return expressionNameToGroupPos.contains(expressionName);
+    inline bool expressionInScope(const string& expressionName) const {
+        return expressionNamesInScope.contains(expressionName);
     }
+
+    inline unordered_set<string> getExpressionNamesInScope() const {
+        return expressionNamesInScope;
+    }
+
+    unordered_set<string> getExpressionNamesInScope(uint32_t pos) const;
 
     void removeExpression(const string& expressionName);
 
@@ -93,8 +99,9 @@ public:
     // Maps a queryRel to the LogicalExtend that matches it. This is needed because ScanRelProperty
     // requires direction information which only available in the LogicalExtend.
     unordered_map<string, LogicalExtend*> queryRelLogicalExtendMap;
-    unordered_map<string, uint32_t> expressionNameToGroupPos;
 
+private:
+    unordered_map<string, uint32_t> expressionNameToGroupPos;
     // Our projection doesn't explicitly remove expressions. Instead, we keep track of what
     // expressions are in scope (i.e. being projected).
     unordered_set<string> expressionNamesInScope;

--- a/src/planner/include/projection_enumerator.h
+++ b/src/planner/include/projection_enumerator.h
@@ -40,11 +40,14 @@ private:
     vector<shared_ptr<Expression>> getExpressionsToAggregate(
         const BoundProjectionBody& projectionBody, const Schema& schema);
     vector<shared_ptr<Expression>> getExpressionsToProject(
-        const BoundProjectionBody& projectionBody, bool isRewritingAllProperties);
-    vector<shared_ptr<Expression>> rewriteVariableExpression(
-        const shared_ptr<Expression>& variable, bool isRewritingAllProperties);
-    vector<shared_ptr<Expression>> rewriteNodeExpression(const shared_ptr<NodeExpression>& node);
-    vector<shared_ptr<Expression>> rewriteRelExpression(const shared_ptr<RelExpression>& rel);
+        const BoundProjectionBody& projectionBody, const Schema& schema,
+        bool isRewritingAllProperties);
+    vector<shared_ptr<Expression>> rewriteVariableExpression(const shared_ptr<Expression>& variable,
+        const Schema& schema, bool isRewritingAllProperties);
+    vector<shared_ptr<Expression>> rewriteNodeExpressionAsAllProperties(
+        const shared_ptr<NodeExpression>& node);
+    vector<shared_ptr<Expression>> rewriteRelExpressionAsAllProperties(
+        const shared_ptr<RelExpression>& rel);
     vector<shared_ptr<Expression>> createPropertyExpressions(
         const shared_ptr<Expression>& variable, const vector<PropertyDefinition>& properties);
 

--- a/src/planner/include/property_scan_pushdown.h
+++ b/src/planner/include/property_scan_pushdown.h
@@ -33,6 +33,9 @@ private:
     shared_ptr<LogicalOperator> rewriteAggregate(
         const shared_ptr<LogicalOperator>& op, Schema& schema);
 
+    shared_ptr<LogicalOperator> rewriteOrderBy(
+        const shared_ptr<LogicalOperator>& op, Schema& schema);
+
     shared_ptr<LogicalOperator> rewriteHashJoin(
         const shared_ptr<LogicalOperator>& op, Schema& schema);
 
@@ -51,7 +54,9 @@ private:
 
     // For operators that merge right branch into left, i.e. hashJoin and leftNestedLoopJoin, any
     // property scanners that are pushed down into the right branch will also be merged into left.
-    void addRemainingPropertyScansToLeftSchema(Schema& schema);
+    void addPropertyScansToLeftSchema(Schema& schema);
+
+    unordered_set<string> getRemainingPropertyExpressionNames();
 
 private:
     unordered_map<string, vector<shared_ptr<LogicalOperator>>> nodeIDToPropertyScansMap;

--- a/src/planner/logical_plan/schema.cpp
+++ b/src/planner/logical_plan/schema.cpp
@@ -19,8 +19,9 @@ void Schema::insertToGroupAndScope(const string& expressionName, uint32_t groupP
     insertToGroup(expressionName, groupPos);
 }
 
-void Schema::insertToGroupAndScope(const FactorizationGroup& otherGroup, uint32_t groupPos) {
-    for (auto& expressionName : otherGroup.expressionNames) {
+void Schema::insertToGroupAndScope(
+    const unordered_set<string>& expressionNames, uint32_t groupPos) {
+    for (auto& expressionName : expressionNames) {
         insertToGroupAndScope(expressionName, groupPos);
     }
 }
@@ -28,6 +29,16 @@ void Schema::insertToGroupAndScope(const FactorizationGroup& otherGroup, uint32_
 uint32_t Schema::getGroupPos(const string& expressionName) const {
     GF_ASSERT(expressionNameToGroupPos.contains(expressionName));
     return expressionNameToGroupPos.at(expressionName);
+}
+
+unordered_set<string> Schema::getExpressionNamesInScope(uint32_t pos) const {
+    unordered_set<string> result;
+    for (auto& expressionName : groups[pos]->expressionNames) {
+        if (expressionInScope(expressionName)) {
+            result.insert(expressionName);
+        }
+    }
+    return result;
 }
 
 void Schema::removeExpression(const string& expressionName) {

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -76,7 +76,8 @@ private:
     vector<shared_ptr<ValueVector>> vectorsToAppend;
     unique_ptr<RowCollection> rowCollection;
 
-    void appendResultSet();
+    void appendVectors();
+    void appendVectorsOnce();
 };
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/include/physical_plan/result/result_set_descriptor.h
+++ b/src/processor/include/physical_plan/result/result_set_descriptor.h
@@ -16,11 +16,11 @@ namespace processor {
 class DataChunkDescriptor {
 
 public:
-    DataChunkDescriptor() = default;
+    DataChunkDescriptor() : isFlat{false} {};
 
     DataChunkDescriptor(const DataChunkDescriptor& other)
         : expressionNameToValueVectorPosMap{other.expressionNameToValueVectorPosMap},
-          expressionNames{other.expressionNames} {}
+          expressionNames{other.expressionNames}, isFlat{other.isFlat} {}
 
     inline uint32_t getValueVectorPos(const string& name) const {
         assert(expressionNameToValueVectorPosMap.contains(name));
@@ -34,9 +34,15 @@ public:
         expressionNames.push_back(name);
     }
 
+    inline void flatten() { isFlat = true; }
+
+    inline bool getIsFlat() const { return isFlat; }
+
 private:
     unordered_map<string, uint32_t> expressionNameToValueVectorPosMap;
     vector<string> expressionNames;
+
+    bool isFlat;
 };
 
 class ResultSetDescriptor {
@@ -52,6 +58,10 @@ public:
 
     inline DataChunkDescriptor* getDataChunkDescriptor(uint32_t pos) const {
         return dataChunkDescriptors[pos].get();
+    }
+
+    inline bool isDataChunkFlat(uint32_t pos) const {
+        return dataChunkDescriptors[pos]->getIsFlat();
     }
 
     inline unique_ptr<ResultSetDescriptor> copy() const {

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -78,10 +78,16 @@ void HashJoinBuild::finalize() {
     }
 }
 
-void HashJoinBuild::appendResultSet() {
+void HashJoinBuild::appendVectors() {
     if (keyDataChunk->state->selectedSize == 0) {
         return;
     }
+    for (auto i = 0u; i < resultSet->multiplicity; ++i) {
+        appendVectorsOnce();
+    }
+}
+
+void HashJoinBuild::appendVectorsOnce() {
     auto& keyVector = vectorsToAppend[0];
     if (keyVector->state->isFlat()) {
         if (keyVector->isNull(keyVector->state->getPositionOfCurrIdx())) {
@@ -111,7 +117,7 @@ void HashJoinBuild::execute() {
     Sink::execute();
     // Append thread-local tuples
     while (children[0]->getNextTuples()) {
-        appendResultSet();
+        appendVectors();
     }
     // Merge thread-local state (numEntries, htBlocks, overflowBlocks) with the shared one
     {

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -211,3 +211,9 @@ TEST_F(BinderErrorTest, SubqueryWithOrderBy) {
         "RETURN COUNT(*);";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
+
+TEST_F(BinderErrorTest, OrderByWithoutSkipLimitInWithClause) {
+    string expectedException = "In WITH clause, ORDER BY must be followed by SKIP or LIMIT.";
+    auto input = "MATCH (a:person) WITH a.age AS k ORDER BY k RETURN k";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}

--- a/test/runner/queries/filtered/multi_query.test
+++ b/test/runner/queries/filtered/multi_query.test
@@ -15,7 +15,7 @@
 ---- 1
 3
 
-#-NAME MultiQueryTwoHopKnowsFilteredTest2
-#-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a.age AS foo, b MATCH (b)-[e2:knows]->(c:person) WHERE foo = c.age RETURN COUNT(*)
-#----i1
-#12
+-NAME MultiQueryTwoHopKnowsFilteredTest2
+-QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a.age AS foo, b MATCH (b)-[e2:knows]->(c:person) WHERE foo = c.age RETURN COUNT(*)
+---- 1
+12

--- a/test/runner/queries/order_by/order_by_tiny_snb.test
+++ b/test/runner/queries/order_by/order_by_tiny_snb.test
@@ -1,4 +1,17 @@
--NAME OrderByInt64Test
+-NAME OrderByInt64Test1
+-QUERY MATCH (p:person) RETURN p.age ORDER BY p.ID
+-PARALLELISM 3
+---- 8
+35
+30
+45
+20
+20
+25
+40
+83
+
+-NAME OrderByInt64Test2
 -QUERY MATCH (p:person) RETURN p.age ORDER BY p.age
 -PARALLELISM 3
 ---- 8
@@ -89,3 +102,17 @@ False
 30|5.100000
 35|5.000000
 40|4.900000
+
+-NAME OrderByMultipleColTest2
+-QUERY MATCH (p:person) RETURN p.age, p.unstrNumericProp ORDER BY p.isStudent, p.ID
+-PARALLELISM 4
+---- 8
+45|52
+20|
+20|68.000000
+40|
+83|
+35|
+30|47
+25|
+

--- a/test/runner/queries/structural/multi_query.test
+++ b/test/runner/queries/structural/multi_query.test
@@ -32,3 +32,13 @@
 -QUERY MATCH (b:person)<-[e1:knows]-(a:person) WITH a AS k MATCH (k)-[e2:knows]->(c:person),(k)-[e3:knows]->(d:person) RETURN COUNT(*)
 ---- 1
 116
+
+-NAME MultiQueryFourHopKnowsTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WITH c MATCH (c)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
+---- 1
+324
+
+-NAME MultiQueryFiveHopKnowsTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WITH b, c MATCH (c)-[e3:knows]->(d:person)-[e4:knows]->(e:person), (b)-[:knows]->(f:person) RETURN COUNT(*)
+---- 1
+972


### PR DESCRIPTION
This PR contains the following changes

## Order By Front-end Validation
- Detailed rule as described in issue #447 

## HashJoinBuild and OrderBy Operator Only Materialize Vectors In Scope
- Related to issue #455 
- Instead of looping through all vectors, HashJoinBuild and OrderBy now have a field indicating what vectors are in the scope (in case there are projections before).
  -  This field needs to be updated when pushing a property scanner below HashJoinBuild or OrderBy which means both operators should also materialize the pushed-down property.
  -   Fix a minor bug in HashJoinProbe when the build side does not have any payload vector. Detailed description is added in the code.

## Minor changes
- We check whether an expression is in scope before getting its position in the enumerator. 
- When rewriting a node expression in WITH clause. Instead of only rewriting it to node ID property, we rewrite it to all properties that are in the scope.