### PR TITLE
add unstructured datatype support for orderby

### DIFF
--- a/dataset/tinysnb/vPerson.csv
+++ b/dataset/tinysnb/vPerson.csv
@@ -1,9 +1,9 @@
 :ID,fName:STRING,gender:INT64,isStudent:BOOLEAN,isWorker:BOOLEAN,age:INT64,eyeSight:DOUBLE,birthdate:DATE,registerTime:TIMESTAMP,lastJobDuration:INTERVAL
-0,Alice,1,true,false,35,5.0,1900-01-01,2011-08-20 11:25:30,3 years 2 days 13 hours 2 minutes,unstrDateProp1:DATE:1900-01-01,unstrDateProp2:DATE:1920-01-01
+0,Alice,1,true,false,35,5.0,1900-01-01,2011-08-20 11:25:30,3 years 2 days 13 hours 2 minutes,unstrDateProp1:DATE:1900-01-01,unstrDateProp2:DATE:1920-01-01,unstrTimeProp1:DATE:1900-01-01
 2,Bob,2,true,false,30,5.1,1900-01-01,2008-11-03 13:25:30.000526,10 years 5 months 13 hours 24 us,unstrDateProp1:DATE:1950-01-01,unstrNumericProp:INT64:47,unstrNumericProp2:INT64:20,unstrDateProp2:DATE:1970-01-01
-3,Carol,1,false,true,45,5.0,1940-06-22,1911-08-20 02:32:21,48 hours 24 minutes 11 seconds,unstrNumericProp:INT64:52,unstrDateProp1:DATE:1950-01-01,unstrDateProp2:DATE:1950-01-01
+3,Carol,1,false,true,45,5.0,1940-06-22,1911-08-20 02:32:21,48 hours 24 minutes 11 seconds,unstrNumericProp:INT64:52,unstrDateProp1:DATE:1950-01-01,unstrDateProp2:DATE:1950-01-01,unstrTimeProp1:TIMESTAMP:2008-11-03 13:25:30.000526
 5,Dan,2,false,true,20,4.8,1950-7-23,2031-11-30 12:25:30,10 years 5 months 13 hours 24 us,unstrTimestampProp1:TIMESTAMP:2031-11-30 12:25:30
 7,Elizabeth,1,false,true,20,4.7,1980-10-26,1976-12-23 11:21:42,48 hours 24 minutes 11 seconds,unstrNumericProp:DOUBLE:68,unstrTimestampProp1:TIMESTAMP:1946-08-25 19:07:22,unstrTimestampProp2:TIMESTAMP:2008-11-03 13:25:30.000526
-8,Farooq,2,true,false,25,4.5,1980-10-26,1972-07-31 13:22:30.678559,18 minutes 24 milliseconds
+8,Farooq,2,true,false,25,4.5,1980-10-26,1972-07-31 13:22:30.678559,18 minutes 24 milliseconds,unstrTimeProp1:DATE:1982-05-04
 9,Greg,2,false,false,40,4.9,1980-10-26,1976-12-23 11:21:42,10 years 5 months 13 hours 24 us,unstrTimestampProp1:TIMESTAMP:1962-05-22 13:11:22.562,unstrTimestampProp2:TIMESTAMP:1976-12-23 11:21:42
-10,Hubert Blaine Wolfeschlegelsteinhausenbergerdorff,2,false,true,83,4.9,1990-11-27,2023-02-21 13:25:30,3 years 2 days 13 hours 2 minutes,unstrTimestampProp1:TIMESTAMP:2023-02-21 13:25:30
+10,Hubert Blaine Wolfeschlegelsteinhausenbergerdorff,2,false,true,83,4.9,1990-11-27,2023-02-21 13:25:30,3 years 2 days 13 hours 2 minutes,unstrTimestampProp1:TIMESTAMP:2023-02-21 13:25:30,unstrTimeProp1:TIMESTAMP:1982-05-04 01:02:07

--- a/src/common/include/operations/comparison_operations.h
+++ b/src/common/include/operations/comparison_operations.h
@@ -179,6 +179,22 @@ struct EqualsOrNotEqualsValues {
                 NotEquals::operation(
                     left.val.doubleVal, right.val.int64Val, result, isLeftNull, isRightNul);
             }
+        } else if (left.dataType == DATE && right.dataType == TIMESTAMP) {
+            if constexpr (equals) {
+                Equals::operation(
+                    left.val.dateVal, right.val.timestampVal, result, isLeftNull, isRightNul);
+            } else {
+                NotEquals::operation(
+                    left.val.dateVal, right.val.timestampVal, result, isLeftNull, isRightNul);
+            }
+        } else if (left.dataType == TIMESTAMP && right.dataType == DATE) {
+            if constexpr (equals) {
+                Equals::operation(
+                    left.val.timestampVal, right.val.dateVal, result, isLeftNull, isRightNul);
+            } else {
+                NotEquals::operation(
+                    left.val.timestampVal, right.val.dateVal, result, isLeftNull, isRightNul);
+            }
         } else {
             if constexpr (equals) {
                 throw invalid_argument("Cannot equals `" +
@@ -252,6 +268,12 @@ struct CompareValues {
             FUNC::operation(left.val.int64Val, right.val.doubleVal, result, isLeftNull, isRightNul);
         } else if (left.dataType == DOUBLE && right.dataType == INT64) {
             FUNC::operation(left.val.doubleVal, right.val.int64Val, result, isLeftNull, isRightNul);
+        } else if (left.dataType == DATE && right.dataType == TIMESTAMP) {
+            FUNC::operation(
+                left.val.dateVal, right.val.timestampVal, result, isLeftNull, isRightNul);
+        } else if (left.dataType == TIMESTAMP && right.dataType == DATE) {
+            FUNC::operation(
+                left.val.timestampVal, right.val.dateVal, result, isLeftNull, isRightNul);
         } else {
             throw invalid_argument("Cannot " + string(comparisonOpStr) + " `" +
                                    TypeUtils::dataTypeToString(left.dataType) + "` and `" +

--- a/src/common/include/types.h
+++ b/src/common/include/types.h
@@ -83,6 +83,8 @@ struct interval_t {
     interval_t operator/(const uint64_t& rhs) const;
 };
 
+struct timestamp_t;
+
 // System representation of dates as the number of days since 1970-01-01.
 struct date_t {
     int32_t days;
@@ -90,13 +92,23 @@ struct date_t {
     date_t() = default;
     explicit inline date_t(int32_t days_p) : days(days_p) {}
 
-    // comparison operators
+    // Comparison operators with date_t.
     inline bool operator==(const date_t& rhs) const { return days == rhs.days; };
     inline bool operator!=(const date_t& rhs) const { return days != rhs.days; };
     inline bool operator<=(const date_t& rhs) const { return days <= rhs.days; };
     inline bool operator<(const date_t& rhs) const { return days < rhs.days; };
     inline bool operator>(const date_t& rhs) const { return days > rhs.days; };
     inline bool operator>=(const date_t& rhs) const { return days >= rhs.days; };
+
+    // Comparison operators with timestamp_t.
+    bool operator==(const timestamp_t& rhs) const;
+    inline bool operator!=(const timestamp_t& rhs) const { return !(*this == rhs); };
+    bool operator<(const timestamp_t& rhs) const;
+    inline bool operator<=(const timestamp_t& rhs) const {
+        return (*this) < rhs || (*this) == rhs;
+    };
+    inline bool operator>(const timestamp_t& rhs) const { return !(*this <= rhs); };
+    inline bool operator>=(const timestamp_t& rhs) const { return !(*this < rhs); };
 
     // arithmetic operators
     inline date_t operator+(const int32_t& day) const { return date_t(this->days + day); };
@@ -146,13 +158,21 @@ struct timestamp_t {
     // explicit conversion
     explicit inline operator int64_t() const { return value; }
 
-    // comparison operators
+    // Comparison operators with timestamp_t.
     inline bool operator==(const timestamp_t& rhs) const { return value == rhs.value; };
     inline bool operator!=(const timestamp_t& rhs) const { return value != rhs.value; };
     inline bool operator<=(const timestamp_t& rhs) const { return value <= rhs.value; };
     inline bool operator<(const timestamp_t& rhs) const { return value < rhs.value; };
     inline bool operator>(const timestamp_t& rhs) const { return value > rhs.value; };
     inline bool operator>=(const timestamp_t& rhs) const { return value >= rhs.value; };
+
+    // Comparison operators with date_t.
+    inline bool operator==(const date_t& rhs) const { return rhs == *this; };
+    inline bool operator!=(const date_t& rhs) const { return !(rhs == *this); };
+    inline bool operator<(const date_t& rhs) const { return rhs > *this; };
+    inline bool operator<=(const date_t& rhs) const { return rhs >= *this; };
+    inline bool operator>(const date_t& rhs) const { return rhs < *this; };
+    inline bool operator>=(const date_t& rhs) const { return rhs <= *this; };
 
     // arithmetic operator
     timestamp_t operator+(const interval_t& interval) const;

--- a/src/common/types.cpp
+++ b/src/common/types.cpp
@@ -213,6 +213,14 @@ int64_t date_t::operator-(const date_t& rhs) const {
     return (*this).days - rhs.days;
 }
 
+bool date_t::operator==(const timestamp_t& rhs) const {
+    return Timestamp::FromDatetime(*this, dtime_t(0)).value == rhs.value;
+}
+
+bool date_t::operator<(const timestamp_t& rhs) const {
+    return Timestamp::FromDatetime(*this, dtime_t(0)).value < rhs.value;
+}
+
 timestamp_t timestamp_t::operator+(const interval_t& interval) const {
     date_t date{};
     date_t result_date{};

--- a/src/processor/include/physical_plan/operator/order_by/order_by.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by.h
@@ -17,8 +17,8 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace processor {
 
-// This class contains rowCollections, nextRowCollectionID, strColInfo, sortedKeyBlocks and
-// the size of each row in keyBlocks. The class is shared between the orderBy,
+// This class contains rowCollections, nextRowCollectionID, stringAndUnstructuredKeyColInfo,
+// sortedKeyBlocks and the size of each row in keyBlocks. The class is shared between the orderBy,
 // orderByMerge, orderByScan operators. All functions are guaranteed to be thread-safe,
 // so caller doesn't need to acquire a lock before calling these functions.
 class SharedRowCollectionsAndSortedKeyBlocks {
@@ -51,9 +51,10 @@ public:
         this->keyBlockEntrySizeInBytes = keyBlockEntrySizeInBytes;
     }
 
-    void setStrKeyColInfo(vector<StrKeyColInfo>& strKeyColInfo) {
+    void setStringAndUnstructuredKeyColInfo(
+        vector<StringAndUnstructuredKeyColInfo>& stringAndUnstructuredKeyColInfo) {
         lock_guard<mutex> sharedStateLock{orderBySharedStateLock};
-        this->strKeyColInfo = move(strKeyColInfo);
+        this->stringAndUnstructuredKeyColInfo = move(stringAndUnstructuredKeyColInfo);
     }
 
 private:
@@ -65,7 +66,7 @@ public:
     shared_ptr<queue<shared_ptr<KeyBlock>>> sortedKeyBlocks;
 
     uint64_t keyBlockEntrySizeInBytes;
-    vector<StrKeyColInfo> strKeyColInfo;
+    vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo;
 };
 
 struct OrderByDataInfo {
@@ -112,7 +113,7 @@ private:
     unique_ptr<RadixSort> radixSorter;
     vector<shared_ptr<ValueVector>> keyVectors;
     vector<shared_ptr<ValueVector>> vectorsToAppend;
-    vector<StrKeyColInfo> strKeyColInfo;
+    vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo;
     shared_ptr<SharedRowCollectionsAndSortedKeyBlocks> sharedState;
     shared_ptr<RowCollection> localRowCollection;
 };

--- a/src/processor/include/physical_plan/operator/order_by/order_by_key_encoder.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_key_encoder.h
@@ -102,6 +102,10 @@ public:
 
     static uint64_t getEncodingSize(DataType dataType);
 
+    static inline bool isNullVal(const uint8_t* nullBuffer, bool isAscOrder) {
+        return *(nullBuffer) == (isAscOrder ? UINT8_MAX : 0);
+    }
+
 private:
     uint8_t flipSign(uint8_t key_byte);
 
@@ -125,6 +129,8 @@ private:
     void encodeInterval(interval_t data, uint8_t* resultPtr);
 
     void encodeString(gf_string_t data, uint8_t* resultPtr);
+
+    void encodeUnstr(uint8_t* resultPtr);
 
     void allocateMemoryIfFull();
 

--- a/src/processor/physical_plan/operator/order_by/order_by_merge.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_merge.cpp
@@ -10,7 +10,7 @@ shared_ptr<ResultSet> OrderByMerge::initResultSet() {
     // sharedState by merging sortedKeyBlocks, So we don't need to initialize the resultSet.
     keyBlockMerger =
         make_unique<KeyBlockMerger>(sharedRowCollectionsAndSortedKeyBlocks->rowCollections,
-            sharedRowCollectionsAndSortedKeyBlocks->strKeyColInfo,
+            sharedRowCollectionsAndSortedKeyBlocks->stringAndUnstructuredKeyColInfo,
             sharedRowCollectionsAndSortedKeyBlocks->keyBlockEntrySizeInBytes);
     return resultSet;
 }
@@ -19,7 +19,7 @@ void OrderByMerge::execute() {
     keyBlockMergeTaskDispatcher->initIfNecessary(context.memoryManager,
         sharedRowCollectionsAndSortedKeyBlocks->sortedKeyBlocks,
         sharedRowCollectionsAndSortedKeyBlocks->rowCollections,
-        sharedRowCollectionsAndSortedKeyBlocks->strKeyColInfo,
+        sharedRowCollectionsAndSortedKeyBlocks->stringAndUnstructuredKeyColInfo,
         sharedRowCollectionsAndSortedKeyBlocks->keyBlockEntrySizeInBytes);
     metrics->executionTime.start();
     Sink::execute();

--- a/test/runner/queries/order_by/order_by_tiny_snb.test
+++ b/test/runner/queries/order_by/order_by_tiny_snb.test
@@ -90,7 +90,82 @@ False
 48:24:11
 00:18:00.024
 
--NAME OrderByMultipleColTest
+-NAME OrderByStringTest
+-QUERY MATCH (p:person) RETURN p.fName ORDER BY p.fName desc
+-PARALLELISM 2
+---- 8
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+Greg
+Farooq
+Elizabeth
+Dan
+Carol
+Bob
+Alice
+
+-NAME OrderByUnstrSameDataTypeTest
+-QUERY MATCH (p:person) RETURN p.unstrDateProp1 ORDER BY p.unstrDateProp1 desc
+-PARALLELISM 2
+---- 8
+
+
+
+
+
+1950-01-01
+1950-01-01
+1900-01-01
+
+-NAME OrderByUnstrNumericTest
+-QUERY MATCH (p:person) RETURN p.unstrNumericProp ORDER BY p.unstrNumericProp asc
+-PARALLELISM 4
+---- 8
+47
+52
+68.000000
+
+
+
+
+
+
+-NAME OrderByUnstrTimeTest
+-QUERY MATCH (p:person) RETURN p.unstrTimeProp1 ORDER BY p.unstrTimeProp1 desc
+-PARALLELISM 3
+---- 8
+
+
+
+
+2008-11-03 13:25:30.000526
+1982-05-04 01:02:07
+1982-05-04
+1900-01-01
+
+-NAME OrderByUnstrWithFilterTest
+-QUERY MATCH (p:person) WHERE p.gender = 2 RETURN p.unstrNumericProp ORDER BY p.unstrNumericProp desc
+-PARALLELISM 2
+---- 5
+
+
+
+
+47
+
+-NAME OrderByUnstrMultipleColTest
+-QUERY MATCH (p:person) RETURN p.unstrTimeProp1 ORDER BY p.gender desc, p.unstrTimeProp1 asc
+-PARALLELISM 3
+---- 8
+1982-05-04
+1982-05-04 01:02:07
+
+
+
+1900-01-01
+2008-11-03 13:25:30.000526
+
+
+-NAME OrderByStrMultipleColTest
 -QUERY MATCH (p:person) RETURN p.age, p.eyeSight ORDER BY p.isWorker desc, p.age, p.eyeSight desc
 -PARALLELISM 4
 ---- 8

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -267,7 +267,8 @@ void EmbeddedShell::printExecutionResult() {
         printf(">> Executing time: %.2fms\n", context.executingTime);
         if (!context.queryResult->resultSetCollection.empty()) {
             ResultSetIterator resultSetIterator(context.queryResult->resultSetCollection[0].get(),
-                context.queryResult->vectorsToCollectPos, context.queryResult->dataChunksPosInScope);
+                context.queryResult->vectorsToCollectPos,
+                context.queryResult->dataChunksPosInScope);
             Tuple tuple(resultSetIterator.dataTypes);
             vector<uint32_t> colsWidth(tuple.len(), 2);
             uint32_t lineSeparatorLen = 1u + colsWidth.size();


### PR DESCRIPTION
This PR adds the unstructured datatype support for orderBy.
The orderByEncoder encodes unstructured values as 0, meaning there is a tie for all the rows in that  unstructured column. The radix sort will try to solve the ties by looking up the actual value in rowCollection.