### PR TITLE
fix bugs for orderBy

### DIFF
--- a/src/processor/include/physical_plan/operator/order_by/order_by.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by.h
@@ -47,10 +47,12 @@ public:
     }
 
     void setKeyBlockEntrySizeInBytes(uint64_t keyBlockEntrySizeInBytes) {
+        lock_guard<mutex> sharedStateLock{orderBySharedStateLock};
         this->keyBlockEntrySizeInBytes = keyBlockEntrySizeInBytes;
     }
 
     void setStrKeyColInfo(vector<StrKeyColInfo>& strKeyColInfo) {
+        lock_guard<mutex> sharedStateLock{orderBySharedStateLock};
         this->strKeyColInfo = move(strKeyColInfo);
     }
 

--- a/src/processor/include/physical_plan/operator/order_by/radix_sort.h
+++ b/src/processor/include/physical_plan/operator/order_by/radix_sort.h
@@ -36,11 +36,9 @@ public:
             sizeof(uint8_t*) * (SORT_BLOCK_SIZE / orderByKeyEncoder.getKeyBlockEntrySizeInBytes()));
     }
 
-    void sortAllKeyBlocks();
-
-private:
     void sortSingleKeyBlock(const KeyBlock& keyBlock);
 
+private:
     void solveStringTies(TieRange& keyBlockTie, uint8_t* keyBlockPtr, queue<TieRange>& ties,
         bool isAscOrder, uint64_t fieldOffsetInRowCollection);
 

--- a/src/processor/physical_plan/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_key_encoder.cpp
@@ -191,7 +191,7 @@ void OrderByKeyEncoder::encodeKeys() {
                 uint64_t idxInOrderByVector =
                     orderByVectors[0]->state->isFlat() ?
                         orderByVectors[keyColIdx]->state->getPositionOfCurrIdx() :
-                        encodedRows;
+                        orderByVectors[keyColIdx]->state->selectedPositions[encodedRows];
                 encodeData(orderByVectors[keyColIdx], idxInOrderByVector, keyBlockPtr, keyColIdx);
                 keyBlockPtrOffset += getEncodingSize(orderByVectors[keyColIdx]->dataType);
             }

--- a/src/processor/physical_plan/operator/order_by/radix_sort.cpp
+++ b/src/processor/physical_plan/operator/order_by/radix_sort.cpp
@@ -193,14 +193,5 @@ void RadixSort::sortSingleKeyBlock(const KeyBlock& keyBlock) {
     }
 }
 
-void RadixSort::sortAllKeyBlocks() {
-    for (auto& keyBlock : orderByKeyEncoder.getKeyBlocks()) {
-        // The orderByKeyEncoder only creates a new memory block if all current memory blocks are
-        // full. If we have N memoryBlocks, the first N-1 memory blocks should be full and the Nth
-        // memory block can be either full or partially full.
-        sortSingleKeyBlock(*keyBlock);
-    }
-}
-
 } // namespace processor
 } // namespace graphflow

--- a/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
@@ -45,6 +45,12 @@ public:
         }
     }
 
+    void sortAllKeyBlocks(OrderByKeyEncoder& orderByKeyEncoder, RadixSort& radixSort) {
+        for (auto& keyBlock : orderByKeyEncoder.getKeyBlocks()) {
+            radixSort.sortSingleKeyBlock(*keyBlock);
+        }
+    }
+
     template<typename T>
     void singleOrderByColTest(const vector<T>& sortingData, const vector<bool>& nullMasks,
         const vector<uint64_t>& expectedRowIdxOrder, const DataType dataType, const bool isAsc,
@@ -104,7 +110,7 @@ public:
 
         RadixSort radixSort =
             RadixSort(*memoryManager, rowCollection, orderByKeyEncoder, strKeyColInfo);
-        radixSort.sortAllKeyBlocks();
+        sortAllKeyBlocks(orderByKeyEncoder, radixSort);
 
         checkRowIdxesAndRowCollectionIdxes(orderByKeyEncoder.getKeyBlocks()[0]->getMemBlockData(),
             orderByKeyEncoder.getKeyBlockEntrySizeInBytes(), expectedRowIdxOrder);
@@ -142,7 +148,7 @@ public:
         }
 
         auto radixSort = RadixSort(*memoryManager, rowCollection, orderByKeyEncoder, strKeyColInfo);
-        radixSort.sortAllKeyBlocks();
+        sortAllKeyBlocks(orderByKeyEncoder, radixSort);
 
         checkRowIdxesAndRowCollectionIdxes(orderByKeyEncoder.getKeyBlocks()[0]->getMemBlockData(),
             orderByKeyEncoder.getKeyBlockEntrySizeInBytes(), expectedRowIdxOrder);
@@ -379,7 +385,7 @@ TEST_F(RadixSortTest, multipleOrderByColNoTieTest) {
 
     RadixSort radixSort =
         RadixSort(*memoryManager, rowCollection, orderByKeyEncoder, strKeyColInfo);
-    radixSort.sortAllKeyBlocks();
+    sortAllKeyBlocks(orderByKeyEncoder, radixSort);
 
     vector<uint64_t> expectedRowIdxOrder = {1, 4, 0, 2, 3};
     checkRowIdxesAndRowCollectionIdxes(orderByKeyEncoder.getKeyBlocks()[0]->getMemBlockData(),


### PR DESCRIPTION
This PR fixes the following issues:
1. Solves the infinite loop problem when ordering by string columns with multi-threading.
2. Solves Issue #459 by acquiring a lock in `setKeyBlockEntrySizeInByte` , `setStrKeyColInfo` and changing `sharedState->rowCollection[rowCollectionID]` to `localRowCollection`
3. Solves the orderByEncoder bug by using the selectedPositions in unflat valueVector.
4. Adds a test for encoding unflat filtered valueVector.