### PR TITLE
add schema change after order by

### DIFF
--- a/src/planner/include/logical_plan/operator/order_by/logical_order_by.h
+++ b/src/planner/include/logical_plan/operator/order_by/logical_order_by.h
@@ -12,10 +12,11 @@ class LogicalOrderBy : public LogicalOperator {
 
 public:
     LogicalOrderBy(vector<string> orderByExpressionNames, vector<bool> sortOrders,
-        unordered_set<string> expressionToMaterializeNames, shared_ptr<LogicalOperator> child)
+        unique_ptr<Schema> schemaBeforeOrderBy, unordered_set<string> expressionToMaterializeNames,
+        shared_ptr<LogicalOperator> child)
         : LogicalOperator{move(child)}, orderByExpressionNames{move(orderByExpressionNames)},
-          isAscOrders{move(sortOrders)}, expressionToMaterializeNames{
-                                             move(expressionToMaterializeNames)} {}
+          isAscOrders{move(sortOrders)}, schemaBeforeOrderBy{move(schemaBeforeOrderBy)},
+          expressionToMaterializeNames{move(expressionToMaterializeNames)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_ORDER_BY;
@@ -34,6 +35,8 @@ public:
 
     inline vector<bool> getIsAscOrders() const { return isAscOrders; }
 
+    inline Schema* getSchemaBeforeOrderBy() const { return schemaBeforeOrderBy.get(); }
+
     inline unordered_set<string> getExpressionToMaterializeNames() const {
         return expressionToMaterializeNames;
     }
@@ -42,13 +45,14 @@ public:
     }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalOrderBy>(
-            orderByExpressionNames, isAscOrders, expressionToMaterializeNames, children[0]->copy());
+        return make_unique<LogicalOrderBy>(orderByExpressionNames, isAscOrders,
+            schemaBeforeOrderBy->copy(), expressionToMaterializeNames, children[0]->copy());
     }
 
 private:
     vector<string> orderByExpressionNames;
     vector<bool> isAscOrders;
+    unique_ptr<Schema> schemaBeforeOrderBy;
 
     unordered_set<string> expressionToMaterializeNames;
 };

--- a/src/planner/include/logical_plan/schema.h
+++ b/src/planner/include/logical_plan/schema.h
@@ -52,6 +52,11 @@ class Schema {
 
 public:
     inline uint32_t getNumGroups() const { return groups.size(); }
+
+    inline FactorizationGroup* getGroup(const string& expressionName) const {
+        return getGroup(getGroupPos(expressionName));
+    }
+
     inline FactorizationGroup* getGroup(uint32_t pos) const { return groups[pos].get(); }
 
     uint32_t createGroup();

--- a/src/planner/include/property_scan_pushdown.h
+++ b/src/planner/include/property_scan_pushdown.h
@@ -52,9 +52,12 @@ private:
 
     void addPropertyScan(const string& nodeID, const shared_ptr<LogicalOperator>& op);
 
-    // For operators that merge right branch into left, i.e. hashJoin and leftNestedLoopJoin, any
-    // property scanners that are pushed down into the right branch will also be merged into left.
-    void addPropertyScansToLeftSchema(Schema& schema);
+    // For operators that compute a new schema from an older schema, i.e. hashJoin,
+    // leftNestedLoopJoin and orderBy, any property scanners, that are pushed down under these
+    // operators, were removed from new schema and being added to older schema. We also need to
+    // append them back to the new schema if the operator is merging vectors from old schema into
+    // new schema.
+    void addPropertyScansToSchema(Schema& schema);
 
     unordered_set<string> getRemainingPropertyExpressionNames();
 

--- a/src/planner/projection_enumerator.cpp
+++ b/src/planner/projection_enumerator.cpp
@@ -107,8 +107,13 @@ void ProjectionEnumerator::appendOrderBy(const vector<shared_ptr<Expression>>& e
         enumerator->appendFlattens(dependentGroupsPos, plan);
         orderByExpressionNames.push_back(expression->getUniqueName());
     }
+    auto schemaBeforeOrderBy = plan.schema->copy();
+    plan.schema->clear();
+    Enumerator::computeSchemaForHashJoinAndOrderBy(
+        schemaBeforeOrderBy->getGroupsPosInScope(), *schemaBeforeOrderBy, *plan.schema);
     auto orderBy = make_shared<LogicalOrderBy>(orderByExpressionNames, isAscOrders,
-        plan.schema->getExpressionNamesInScope(), plan.lastOperator);
+        schemaBeforeOrderBy->copy(), schemaBeforeOrderBy->getExpressionNamesInScope(),
+        plan.lastOperator);
     plan.appendOperator(move(orderBy));
 }
 

--- a/src/processor/include/physical_plan/result/result_set_descriptor.h
+++ b/src/processor/include/physical_plan/result/result_set_descriptor.h
@@ -16,11 +16,11 @@ namespace processor {
 class DataChunkDescriptor {
 
 public:
-    DataChunkDescriptor() : isFlat{false} {};
+    DataChunkDescriptor() = default;
 
     DataChunkDescriptor(const DataChunkDescriptor& other)
         : expressionNameToValueVectorPosMap{other.expressionNameToValueVectorPosMap},
-          expressionNames{other.expressionNames}, isFlat{other.isFlat} {}
+          expressionNames{other.expressionNames} {}
 
     inline uint32_t getValueVectorPos(const string& name) const {
         assert(expressionNameToValueVectorPosMap.contains(name));
@@ -34,15 +34,9 @@ public:
         expressionNames.push_back(name);
     }
 
-    inline void flatten() { isFlat = true; }
-
-    inline bool getIsFlat() const { return isFlat; }
-
 private:
     unordered_map<string, uint32_t> expressionNameToValueVectorPosMap;
     vector<string> expressionNames;
-
-    bool isFlat;
 };
 
 class ResultSetDescriptor {
@@ -58,10 +52,6 @@ public:
 
     inline DataChunkDescriptor* getDataChunkDescriptor(uint32_t pos) const {
         return dataChunkDescriptors[pos].get();
-    }
-
-    inline bool isDataChunkFlat(uint32_t pos) const {
-        return dataChunkDescriptors[pos]->getIsFlat();
     }
 
     inline unique_ptr<ResultSetDescriptor> copy() const {

--- a/test/runner/queries/order_by/order_by_tiny_snb.test
+++ b/test/runner/queries/order_by/order_by_tiny_snb.test
@@ -1,4 +1,23 @@
 -NAME OrderByInt64Test1
+-QUERY MATCH (p:person)-[:knows]->(x:person) RETURN p.age ORDER BY p.ID
+-PARALLELISM 3
+---- 14
+35
+35
+35
+30
+30
+30
+45
+45
+45
+20
+20
+20
+20
+20
+
+-NAME OrderByInt64Test1
 -QUERY MATCH (p:person) RETURN p.age ORDER BY p.ID
 -PARALLELISM 3
 ---- 8


### PR DESCRIPTION
This PR removes the assumption that order by does not change the schema. It contains the following change

## Abstract general rule to update schema after a sink operator that materializes vectors
For `HashJoinBuild` and `OrderBy` that materialize tuple into `RowCollection`, we might scan from their `RowCollection` with a different factorized structure. Detailed rule is written in `enumerator.h`.