### PR TITLE
add multiplicity and change orderByScan

### DIFF
--- a/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
@@ -39,6 +39,9 @@ public:
     }
 
 private:
+    pair<uint64_t, uint64_t> getNextRowCollectionIdxAndRowIdxPair();
+
+    bool scanSingleTuple;
     vector<DataPos> outDataPoses;
     shared_ptr<SharedRowCollectionsAndSortedKeyBlocks> sharedState;
     vector<uint64_t> fieldsToReadInRowCollection;

--- a/src/processor/include/physical_plan/result/row_collection.h
+++ b/src/processor/include/physical_plan/result/row_collection.h
@@ -115,8 +115,14 @@ public:
     uint64_t lookup(const vector<uint64_t>& fieldsToRead, const vector<DataPos>& resultDataPos,
         ResultSet& resultSet, uint8_t** rowsToRead, uint64_t startPos,
         uint64_t numRowsToRead) const;
+    // This is a specialized scan function to read one non-overflow tuple in rowCollection to an
+    // unflat valueVector.
+    void readNonOverflowTupleToUnflatVector(const vector<uint64_t>& fieldsToScan,
+        const vector<DataPos>& resultDataPos, ResultSet& resultSet, uint64_t rowId,
+        uint64_t valuePosInVec) const;
     void merge(unique_ptr<RowCollection> other);
     uint64_t getFieldOffsetInRow(uint64_t fieldId) const;
+    bool hasOverflowColToRead(const vector<uint64_t>& fieldsToRead) const;
 
     inline uint64_t getNumRows() const { return numRows; }
     inline uint8_t* getRow(uint64_t rowId) const {
@@ -151,11 +157,13 @@ private:
     void readOverflowVector(
         uint8_t** rows, uint64_t offsetInRow, uint64_t startRowPos, ValueVector& vector) const;
     void readNonOverflowVector(uint8_t** rows, uint64_t offsetInRow, ValueVector& vector,
-        uint64_t numRowsToRead, uint64_t colIdx) const;
+        uint64_t numRowsToRead, uint64_t colIdx, uint64_t startPos, uint64_t valuePosInVec) const;
     // If the given vector is flat valuePosInVecIfUnflat will be ignored.
     void copyVectorDataToBuffer(ValueVector& vector, uint64_t valuePosInVecIfUnflat,
         uint8_t* buffer, uint64_t offsetInBuffer, uint64_t offsetStride, uint64_t numValues,
         uint64_t colIdx, bool isVectorOverflow);
+
+    vector<uint64_t> computeFieldOffsets(const vector<uint64_t>& fieldsToRead) const;
 
     MemoryManager& memoryManager;
     RowLayout layout;

--- a/src/processor/physical_plan/operator/order_by/order_by.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by.cpp
@@ -82,13 +82,14 @@ void OrderBy::execute() {
     Sink::execute();
     // Append thread-local tuples
     while (children[0]->getNextTuples()) {
-        orderByKeyEncoder->encodeKeys();
-        // If there is only one unflat orderBy key col, then we flatten the unflat orderBy key col
-        // in rowCollection.
-        // Each thread uses a unique identifier: rowCollectionID to get its private rowCollection,
-        // and only appends rows to that rowCollection.
-        localRowCollection->append(vectorsToAppend,
-            keyVectors[0]->state->isFlat() ? 1 : keyVectors[0]->state->selectedSize);
+        for (auto i = 0u; i < resultSet->multiplicity; i++) {
+            orderByKeyEncoder->encodeKeys();
+            // If there is only one unflat orderBy key col, then we flatten the unflat orderBy key
+            // col in rowCollection. Each thread uses a unique identifier: rowCollectionID to get
+            // its private rowCollection, and only appends rows to that rowCollection.
+            localRowCollection->append(vectorsToAppend,
+                keyVectors[0]->state->isFlat() ? 1 : keyVectors[0]->state->selectedSize);
+        }
     }
 
     for (auto& keyBlock : orderByKeyEncoder->getKeyBlocks()) {

--- a/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
@@ -3,6 +3,15 @@
 namespace graphflow {
 namespace processor {
 
+pair<uint64_t, uint64_t> OrderByScan::getNextRowCollectionIdxAndRowIdxPair() {
+    auto rowInfoBuffer = sharedState->sortedKeyBlocks->front()->getMemBlockData() +
+                         (nextRowIdxToReadInMemBlock + 1) * sharedState->keyBlockEntrySizeInBytes -
+                         sizeof(uint64_t);
+    uint16_t rowCollectionIdx = OrderByKeyEncoder::getEncodedRowCollectionIdx(rowInfoBuffer);
+    uint64_t rowIdx = OrderByKeyEncoder::getEncodedRowIdx(rowInfoBuffer);
+    return make_pair(rowCollectionIdx, rowIdx);
+}
+
 shared_ptr<ResultSet> OrderByScan::initResultSet() {
     resultSet = populateResultSet();
     for (auto i = 0u; i < outDataPoses.size(); i++) {
@@ -13,30 +22,44 @@ shared_ptr<ResultSet> OrderByScan::initResultSet() {
                 sharedState->rowCollections[0]->getLayout().fields[i].dataType));
         fieldsToReadInRowCollection.emplace_back(i);
     }
+    scanSingleTuple =
+        sharedState->rowCollections[0]->hasOverflowColToRead(fieldsToReadInRowCollection);
     return resultSet;
 }
 
 bool OrderByScan::getNextTuples() {
     metrics->executionTime.start();
-    auto& resultKeyBlock = sharedState->sortedKeyBlocks->front();
-    auto memBuffer = resultKeyBlock->getMemBlockData();
+    auto numRowsInMemBlock = sharedState->sortedKeyBlocks->front()->numEntriesInMemBlock;
     // If there is no more rows to read, just return false.
-    if (nextRowIdxToReadInMemBlock >= resultKeyBlock->numEntriesInMemBlock) {
+    if (nextRowIdxToReadInMemBlock >= numRowsInMemBlock) {
         metrics->executionTime.stop();
         return false;
     } else {
-        // The rowInfoBuffer saves rowCollectionID and rowID for each row.
-        auto rowInfoBuffer =
-            memBuffer + (nextRowIdxToReadInMemBlock + 1) * sharedState->keyBlockEntrySizeInBytes -
-            sizeof(uint64_t);
-        uint16_t rowCollectionIdx = OrderByKeyEncoder::getEncodedRowCollectionIdx(rowInfoBuffer);
-        uint64_t rowIdx = OrderByKeyEncoder::getEncodedRowIdx(rowInfoBuffer);
-        // todo: add support to read values from rowCollection to unflat valueVectors.
-        // issue: 443
-        sharedState->rowCollections[rowCollectionIdx]->scan(
-            fieldsToReadInRowCollection, outDataPoses, *resultSet, rowIdx, 1);
-        nextRowIdxToReadInMemBlock++;
-        metrics->numOutputTuple.increase(1);
+        // If there is an overflow column in fieldsToReadInRowCollection, we can only read one
+        // row at a time. Otherwise, we can read min(DEFAULT_VECTOR_CAPACITY,
+        // numRowsRemainingInMemBlock) rows.
+        if (scanSingleTuple) {
+            auto rowCollectionIdxAndRowIdxPair = getNextRowCollectionIdxAndRowIdxPair();
+            sharedState->rowCollections[rowCollectionIdxAndRowIdxPair.first]->scan(
+                fieldsToReadInRowCollection, outDataPoses, *resultSet,
+                rowCollectionIdxAndRowIdxPair.second, 1 /* numRowsToScan */);
+            nextRowIdxToReadInMemBlock++;
+            metrics->numOutputTuple.increase(1);
+        } else {
+            auto numRowsToLookup =
+                min(DEFAULT_VECTOR_CAPACITY, numRowsInMemBlock - nextRowIdxToReadInMemBlock);
+            for (auto i = 0u; i < numRowsToLookup; i++) {
+                auto rowCollectionIdxAndRowIdxPair = getNextRowCollectionIdxAndRowIdxPair();
+                // todo: add support to read values from rowCollection to
+                // unflat valueVectors. issue: 443
+                sharedState->rowCollections[rowCollectionIdxAndRowIdxPair.first]
+                    ->readNonOverflowTupleToUnflatVector(fieldsToReadInRowCollection, outDataPoses,
+                        *resultSet, rowCollectionIdxAndRowIdxPair.second, i);
+                nextRowIdxToReadInMemBlock++;
+                metrics->numOutputTuple.increase(1);
+            }
+        }
+
         metrics->executionTime.stop();
         return true;
     }

--- a/test/runner/queries/order_by/order_by_tiny_snb.test
+++ b/test/runner/queries/order_by/order_by_tiny_snb.test
@@ -1,36 +1,4 @@
--NAME OrderByInt64Test1
--QUERY MATCH (p:person)-[:knows]->(x:person) RETURN p.age ORDER BY p.ID
--PARALLELISM 3
----- 14
-35
-35
-35
-30
-30
-30
-45
-45
-45
-20
-20
-20
-20
-20
-
--NAME OrderByInt64Test1
--QUERY MATCH (p:person) RETURN p.age ORDER BY p.ID
--PARALLELISM 3
----- 8
-35
-30
-45
-20
-20
-25
-40
-83
-
--NAME OrderByInt64Test2
+-NAME OrderByInt64Test
 -QUERY MATCH (p:person) RETURN p.age ORDER BY p.age
 -PARALLELISM 3
 ---- 8
@@ -183,6 +151,18 @@ Alice
 1900-01-01
 2008-11-03 13:25:30.000526
 
+-NAME OrderByUnstrMultipleColTest2
+-QUERY MATCH (p:person) RETURN p.age, p.unstrNumericProp ORDER BY p.isStudent, p.ID
+-PARALLELISM 4
+---- 8
+45|52
+20|
+20|68.000000
+40|
+83|
+35|
+30|47
+25|
 
 -NAME OrderByStrMultipleColTest
 -QUERY MATCH (p:person) RETURN p.age, p.eyeSight ORDER BY p.isWorker desc, p.age, p.eyeSight desc
@@ -197,16 +177,35 @@ Alice
 35|5.000000
 40|4.900000
 
--NAME OrderByMultipleColTest2
--QUERY MATCH (p:person) RETURN p.age, p.unstrNumericProp ORDER BY p.isStudent, p.ID
--PARALLELISM 4
----- 8
-45|52
-20|
-20|68.000000
-40|
-83|
-35|
-30|47
-25|
+-NAME OrderByProjectionTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) with b return b.fName order by b.fName desc
+-PARALLELISM 2
+---- 14
+Greg
+Farooq
+Dan
+Dan
+Dan
+Carol
+Carol
+Carol
+Bob
+Bob
+Bob
+Alice
+Alice
+Alice
 
+-NAME OrderByThreeHopTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person) RETURN a.fName order by d.age desc, c.age asc, b.age asc, a.age desc limit 10
+---- 10
+Carol
+Alice
+Dan
+Carol
+Bob
+Dan
+Alice
+Bob
+Dan
+Carol


### PR DESCRIPTION
1. Adds a speciailzed scan function to rowCollection: readNonOverflowTupleToUnflatVector().
2. Changes the orderByScan so that it can scan multiple rows from rowCollection to an unflat valueVector at a time by calling the speciailized function readNonOverflowTupleToUnflatVector().
3. Adds the logic to handle multiplicity in resultSet.
4. Solves a bug in RowCollection:
The old readNonOverflowVector() doesn't take in `startPos`, which may cause reading incorrect rows from rowCollection.
5. Opened an issue #466 