### PR TITLE
add union all operator

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -37,9 +37,17 @@ oC_Query
     : oC_RegularQuery ;
 
 oC_RegularQuery
-    : oC_SingleQuery
+    : oC_SingleQuery ( SP? oC_Union )*
         | (oC_Return SP? )+ oC_SingleQuery { notifyReturnNotAtEnd($ctx->start); }
         ;
+
+oC_Union
+     :  ( UNION SP ALL SP? oC_SingleQuery )
+         ;
+
+UNION : ( 'U' | 'u' ) ( 'N' | 'n' ) ( 'I' | 'i' ) ( 'O' | 'o' ) ( 'N' | 'n' )  ;
+
+ALL : ( 'A' | 'a' ) ( 'L' | 'l' ) ( 'L' | 'l' )  ;
 
 oC_SingleQuery
     : oC_SinglePartQuery
@@ -281,7 +289,7 @@ oC_FunctionName
     : oC_SymbolicName ;
 
 oC_ExistentialSubquery
-    :  EXISTS SP? '{' SP? oC_RegularQuery SP? '}' ;
+    :  EXISTS SP? '{' SP? oC_SingleQuery SP? '}' ;
 
 EXISTS : ( 'E' | 'e' ) ( 'X' | 'x' ) ( 'I' | 'i' ) ( 'S' | 's' ) ( 'T' | 't' ) ( 'S' | 's' ) ;
 

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -427,7 +427,7 @@ shared_ptr<Expression> ExpressionBinder::bindVariableExpression(
 shared_ptr<Expression> ExpressionBinder::bindExistentialSubqueryExpression(
     const ParsedExpression& parsedExpression) {
     auto prevVariablesInScope = queryBinder->enterSubquery();
-    auto boundSingleQuery = queryBinder->bind(*parsedExpression.subquery);
+    auto boundSingleQuery = queryBinder->bindSingleQuery(*parsedExpression.subquery);
     queryBinder->exitSubquery(move(prevVariablesInScope));
     return make_shared<ExistentialSubqueryExpression>(move(boundSingleQuery),
         queryBinder->getUniqueExpressionName(parsedExpression.getRawName()));

--- a/src/binder/include/bound_queries/bound_regular_query.h
+++ b/src/binder/include/bound_queries/bound_regular_query.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "src/binder/include/bound_queries/bound_single_query.h"
+
+namespace graphflow {
+namespace binder {
+
+class BoundRegularQuery {
+
+public:
+    inline void addBoundSingleQuery(unique_ptr<BoundSingleQuery> boundSingleQuery) {
+        boundSingleQueries.push_back(move(boundSingleQuery));
+    }
+
+    inline BoundSingleQuery* getBoundSingleQuery(uint32_t idx) const {
+        return boundSingleQueries[idx].get();
+    }
+
+    inline uint64_t getNumBoundSingleQueries() const { return boundSingleQueries.size(); }
+
+private:
+    vector<unique_ptr<BoundSingleQuery>> boundSingleQueries;
+};
+
+} // namespace binder
+} // namespace graphflow

--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "src/binder/include/bound_queries/bound_regular_query.h"
 #include "src/binder/include/bound_queries/bound_single_query.h"
 #include "src/binder/include/expression_binder.h"
 #include "src/binder/include/query_graph/query_graph.h"
-#include "src/parser/include/queries/single_query.h"
+#include "src/parser/include/queries/regular_query.h"
 #include "src/parser/include/statements/match_statement.h"
 
 using namespace graphflow::parser;
@@ -18,7 +19,7 @@ public:
     explicit QueryBinder(const Catalog& catalog)
         : catalog{catalog}, lastExpressionId{0}, variablesInScope{}, expressionBinder{this} {}
 
-    unique_ptr<BoundSingleQuery> bind(const SingleQuery& singleQuery);
+    unique_ptr<BoundRegularQuery> bind(const RegularQuery& regularQuery);
 
 private:
     unique_ptr<BoundSingleQuery> bindSingleQuery(const SingleQuery& singleQuery);

--- a/src/binder/query_binder.cpp
+++ b/src/binder/query_binder.cpp
@@ -10,8 +10,12 @@
 namespace graphflow {
 namespace binder {
 
-unique_ptr<BoundSingleQuery> QueryBinder::bind(const SingleQuery& singleQuery) {
-    return bindSingleQuery(singleQuery);
+unique_ptr<BoundRegularQuery> QueryBinder::bind(const RegularQuery& regularQuery) {
+    auto boundRegularQuery = make_unique<BoundRegularQuery>();
+    for (auto i = 0u; i < regularQuery.getNumSingleQueries(); i++) {
+        boundRegularQuery->addBoundSingleQuery(bindSingleQuery(*regularQuery.getSingleQuery(i)));
+    }
+    return boundRegularQuery;
 }
 
 unique_ptr<BoundSingleQuery> QueryBinder::bindSingleQuery(const SingleQuery& singleQuery) {

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -18,11 +18,11 @@ nlohmann::json PlanPrinter::toJson(PhysicalOperator* physicalOperator, Profiler&
             "(" + physicalToLogicalOperatorMap.at(operatorID)->getExpressionsForPrinting() + ")";
     }
     json["name"] = operatorName;
-    if (physicalOperator->hasFirstChild()) {
-        json["prev"] = toJson(physicalOperator->getFirstChild(), profiler);
+    if (physicalOperator->getNumChildren()) {
+        json["prev"] = toJson(physicalOperator->getChild(0), profiler);
     }
-    if (physicalOperator->hasSecondChild()) {
-        json["right"] = toJson(physicalOperator->getSecondChild(), profiler);
+    if (physicalOperator->getNumChildren() > 1) {
+        json["right"] = toJson(physicalOperator->getChild(1), profiler);
     }
     if (profiler.enabled) {
         physicalOperator->printMetricsToJson(json, profiler);

--- a/src/main/system.cpp
+++ b/src/main/system.cpp
@@ -34,8 +34,8 @@ void System::executeQuery(SessionContext& context) const {
     }
 
     auto parsedQuery = Parser::parseQuery(context.query);
-    context.enable_explain = parsedQuery->enable_explain;
-    context.profiler->enabled = parsedQuery->enable_profile;
+    context.enable_explain = parsedQuery->isEnableExplain();
+    context.profiler->enabled = parsedQuery->isEnableProfile();
 
     // compiling stage
     auto compilingTimeMetric = TimeMetric(true);

--- a/src/parser/include/parsed_expression.h
+++ b/src/parser/include/parsed_expression.h
@@ -13,7 +13,6 @@ namespace graphflow {
 namespace parser {
 
 class SingleQuery;
-
 class ParsedExpression {
 
 public:

--- a/src/parser/include/parser.h
+++ b/src/parser/include/parser.h
@@ -1,4 +1,4 @@
-#include "src/parser/include/queries/single_query.h"
+#include "src/parser/include/queries/regular_query.h"
 
 namespace graphflow {
 namespace parser {
@@ -6,7 +6,7 @@ namespace parser {
 class Parser {
 
 public:
-    static unique_ptr<SingleQuery> parseQuery(const string& query);
+    static unique_ptr<RegularQuery> parseQuery(const string& query);
 };
 
 } // namespace parser

--- a/src/parser/include/queries/regular_query.h
+++ b/src/parser/include/queries/regular_query.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "src/parser/include/queries/single_query.h"
+
+namespace graphflow {
+namespace parser {
+
+class RegularQuery {
+
+public:
+    inline void addSingleQuery(unique_ptr<SingleQuery> singleQuery) {
+        singleQueries.push_back(move(singleQuery));
+    }
+
+    inline SingleQuery* getSingleQuery(uint32_t singleQueryIdx) const {
+        return singleQueries[singleQueryIdx].get();
+    }
+
+    inline uint64_t getNumSingleQueries() const { return singleQueries.size(); }
+
+    inline void setEnableExplain(bool option) { enable_explain = option; }
+
+    inline void setEnableProfile(bool option) { enable_profile = option; }
+
+    inline bool isEnableExplain() const { return enable_explain; }
+
+    inline bool isEnableProfile() const { return enable_profile; }
+
+private:
+    vector<unique_ptr<SingleQuery>> singleQueries;
+    // If explain is enabled, we do not execute query but return physical plan only.
+    bool enable_explain = false;
+    bool enable_profile = false;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/include/queries/single_query.h
+++ b/src/parser/include/queries/single_query.h
@@ -19,9 +19,6 @@ public:
     vector<unique_ptr<QueryPart>> queryParts;
     vector<unique_ptr<MatchStatement>> matchStatements;
     unique_ptr<ReturnStatement> returnStatement;
-    // If explain is enabled, we do not execute query but return physical plan only
-    bool enable_explain = false;
-    bool enable_profile = false;
 };
 
 } // namespace parser

--- a/src/parser/include/transformer.h
+++ b/src/parser/include/transformer.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "src/antlr4/CypherParser.h"
-#include "src/parser/include/queries/single_query.h"
+#include "src/parser/include/queries/regular_query.h"
 
 using namespace std;
 
@@ -12,12 +12,12 @@ class Transformer {
 public:
     explicit Transformer(CypherParser::OC_CypherContext& root) : root{root} {}
 
-    unique_ptr<SingleQuery> transform();
+    unique_ptr<RegularQuery> transform();
 
 private:
-    unique_ptr<SingleQuery> transformQuery(CypherParser::OC_QueryContext& ctx);
+    unique_ptr<RegularQuery> transformQuery(CypherParser::OC_QueryContext& ctx);
 
-    unique_ptr<SingleQuery> transformRegularQuery(CypherParser::OC_RegularQueryContext& ctx);
+    unique_ptr<RegularQuery> transformRegularQuery(CypherParser::OC_RegularQueryContext& ctx);
 
     unique_ptr<SingleQuery> transformSingleQuery(CypherParser::OC_SingleQueryContext& ctx);
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -11,7 +11,7 @@ using namespace antlr4;
 namespace graphflow {
 namespace parser {
 
-unique_ptr<SingleQuery> Parser::parseQuery(const string& query) {
+unique_ptr<RegularQuery> Parser::parseQuery(const string& query) {
     auto inputStream = ANTLRInputStream(query);
     auto parserErrorListener = ParserErrorListener();
 

--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -39,6 +39,9 @@ vector<unique_ptr<LogicalPlan>> Enumerator::enumeratePlans(const BoundSingleQuer
     for (auto& queryPart : normalizedQuery->getQueryParts()) {
         plans = enumerateQueryPart(*queryPart, move(plans));
     }
+    for (auto& plan : plans) {
+        appendLogicalResultCollector(*plan);
+    }
     return plans;
 }
 
@@ -303,7 +306,7 @@ vector<shared_ptr<Expression>> Enumerator::getSubExpressionsNotInSchemaOfType(
     return results;
 }
 
-void Enumerator::computeSchemaForHashJoinAndOrderBy(
+void Enumerator::computeSchemaForHashJoinAndOrderByAndUnionAll(
     const unordered_set<uint32_t>& groupsToMaterializePos, const Schema& schemaBeforeSink,
     Schema& schemaAfterSink) {
     auto flatVectorsOutputPos = UINT32_MAX;

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -3,6 +3,8 @@
 #include "src/binder/include/expression/existential_subquery_expression.h"
 #include "src/binder/include/expression/property_expression.h"
 #include "src/planner/include/join_order_enumerator.h"
+#include "src/planner/include/logical_plan/operator/result_collector/logical_result_collector.h"
+#include "src/planner/include/logical_plan/operator/union_all/logical_union_all.h"
 #include "src/planner/include/projection_enumerator.h"
 
 using namespace graphflow::binder;
@@ -32,6 +34,50 @@ public:
         }
         return result;
     }
+
+    static inline void appendLogicalResultCollector(LogicalPlan& logicalPlan) {
+        auto logicalResultCollector =
+            make_shared<LogicalResultCollector>(logicalPlan.getExpressionsToCollect(),
+                logicalPlan.schema->copy(), logicalPlan.lastOperator);
+        logicalPlan.lastOperator = logicalResultCollector;
+    }
+
+    static inline void appendLogicalUnionAll(
+        vector<unique_ptr<LogicalPlan>>& childrenPlans, LogicalPlan& logicalPlan) {
+        shared_ptr<LogicalUnionAll> logicalUnionAll = make_shared<LogicalUnionAll>();
+        for (auto i = 0u; i < childrenPlans.size(); i++) {
+            if (i == 0) {
+                // For now the schema of the logical plan and logicalUnionAll is exactly the same.
+                logicalPlan.setExpressionsToCollect(
+                    ((LogicalResultCollector*)childrenPlans[i]->lastOperator.get())
+                        ->getExpressionsToCollect());
+                Enumerator::computeSchemaForHashJoinAndOrderByAndUnionAll(
+                    childrenPlans[i]->schema->getGroupsPosInScope(), *childrenPlans[i]->schema,
+                    *logicalPlan.schema);
+                logicalPlan.lastOperator = logicalUnionAll;
+            }
+            logicalUnionAll->addChild(childrenPlans[i]->lastOperator);
+        }
+        logicalUnionAll->setExpressionsToUnion(logicalPlan.getExpressionsToCollect());
+    }
+
+    // For HashJoinProbe, the HashJoinProbe operator will read for a particular probe tuple t, the
+    // matching result tuples M that match t[k], where k suppose is the join key column. If M
+    // consists of flat tuples, i.e., all columns of tuples in M are flat, then we can output the
+    // join of t[k] with M as t X M. That is we can put up to M tuples in M into one single unflat
+    // dataChunk and output.  Otherwise even if t[k] matches |M| many tuples, because each tuple m
+    // in M represents multiple tuples, we need to output the join of t[k] with M one tuple at a
+    // time, t X m1, t X m2, etc.
+    //
+    // For OrderBy a similar logic exists. In order to order a set of tuples R, order by stores R in
+    // a FactorizedTable and orders on the keys. The key columns are necessarily flattened (even if
+    // they are given to OrderBy in an unflat format). But the non-key columns can be flat or unflat
+    // when stored. However, if all of the non-key columns are flat and since all key columns are
+    // flattened in FactorizedTable, we can output R with upto |R| many tuples in an unflat
+    // datachunk (though we would do it in chunks of DEFAULT_VECTOR_CAPACITY).
+    static void computeSchemaForHashJoinAndOrderByAndUnionAll(
+        const unordered_set<uint32_t>& groupsToMaterializePos, const Schema& schemaBeforeSink,
+        Schema& schemaAfterSink);
 
 private:
     vector<unique_ptr<LogicalPlan>> enumeratePlans(const BoundSingleQuery& singleQuery);
@@ -85,24 +131,6 @@ private:
         const shared_ptr<Expression>& expression, const Schema& schema) {
         return getSubExpressionsNotInSchemaOfType(expression, schema, isExpressionAggregate);
     }
-
-    // For HashJoinProbe, the HashJoinProbe operator will read for a particular probe tuple t, the
-    // matching result tuples M that match t[k], where k suppose is the join key column. If M
-    // consists of flat tuples, i.e., all columns of tuples in M are flat, then we can output the
-    // join of t[k] with M as t X M. That is we can put up to M tuples in M into one single unflat
-    // dataChunk and output.  Otherwise even if t[k] matches |M| many tuples, because each tuple m
-    // in M represents multiple tuples, we need to output the join of t[k] with M one tuple at a
-    // time, t X m1, t X m2, etc.
-    //
-    // For OrderBy a similar logic exists. In order to order a set of tuples R, order by stores R in
-    // a FactorizedTable and orders on the keys. The key columns are necessarily flattened (even if
-    // they are given to OrderBy in an unflat format). But the non-key columns can be flat or unflat
-    // when stored. However, if all of the non-key columns are flat and since all key columns are
-    // flattened in FactorizedTable, we can output R with upto |R| many tuples in an unflat
-    // datachunk (though we would do it in chunks of DEFAULT_VECTOR_CAPACITY).
-    static void computeSchemaForHashJoinAndOrderBy(
-        const unordered_set<uint32_t>& groupsToMaterializePos, const Schema& schemaBeforeSink,
-        Schema& schemaAfterSink);
 
 private:
     JoinOrderEnumerator joinOrderEnumerator;

--- a/src/planner/include/logical_plan/operator/logical_operator.h
+++ b/src/planner/include/logical_plan/operator/logical_operator.h
@@ -29,13 +29,16 @@ enum LogicalOperatorType : uint8_t {
     LOGICAL_ORDER_BY,
     LOGICAL_EXISTS,
     LOGICAL_LEFT_NESTED_LOOP_JOIN,
+    LOGICAL_UNION_ALL,
+    LOGICAL_RESULT_COLLECTOR,
 };
 
 const string LogicalOperatorTypeNames[] = {"LOGICAL_SCAN_NODE_ID", "LOGICAL_SELECT_SCAN",
     "LOGICAL_EXTEND", "LOGICAL_FLATTEN", "LOGICAL_FILTER", "LOGICAL_INTERSECT",
     "LOGICAL_PROJECTION", "LOGICAL_SCAN_NODE_PROPERTY", "LOGICAL_SCAN_REL_PROPERTY",
     "LOGICAL_HASH_JOIN", "LOGICAL_MULTIPLICITY_REDUCER", "LOGICAL_LIMIT", "LOGICAL_SKIP",
-    "LOGICAL_AGGREGATE", "LOGICAL_ORDER_BY", "LOGICAL_EXISTS", "LOGICAL_LEFT_NESTED_LOOP_JOIN"};
+    "LOGICAL_AGGREGATE", "LOGICAL_ORDER_BY", "LOGICAL_EXISTS", "LOGICAL_LEFT_NESTED_LOOP_JOIN",
+    "LOGICAL_UNION_ALL", "LOGICAL_RESULT_COLLECTOR"};
 
 class LogicalOperator {
 
@@ -50,10 +53,9 @@ public:
     virtual ~LogicalOperator() = default;
 
     inline uint32_t getNumChildren() const { return children.size(); }
-    inline shared_ptr<LogicalOperator> getFirstChild() const { return children[0]; }
-    inline shared_ptr<LogicalOperator> getSecondChild() const { return children[1]; }
-    inline void setFirstChild(shared_ptr<LogicalOperator> op) { children[0] = move(op); }
-    inline void setSecondChild(shared_ptr<LogicalOperator> op) { children[1] = move(op); }
+    inline void setChild(uint32_t idx, shared_ptr<LogicalOperator> op) { children[idx] = move(op); }
+    inline void addChild(shared_ptr<LogicalOperator> op) { children.push_back(op); }
+    inline shared_ptr<LogicalOperator> getChild(uint64_t idx) const { return children[idx]; }
 
     virtual LogicalOperatorType getLogicalOperatorType() const = 0;
 

--- a/src/planner/include/logical_plan/operator/result_collector/logical_result_collector.h
+++ b/src/planner/include/logical_plan/operator/result_collector/logical_result_collector.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "src/planner/include/logical_plan/operator/logical_operator.h"
+
+using namespace graphflow::binder;
+
+namespace graphflow {
+namespace planner {
+
+class LogicalResultCollector : public LogicalOperator {
+
+public:
+    LogicalResultCollector(vector<shared_ptr<Expression>> expressionsToCollect,
+        unique_ptr<Schema> schema, shared_ptr<LogicalOperator> child)
+        : LogicalOperator{move(child)},
+          expressionsToCollect{move(expressionsToCollect)}, schema{move(schema)} {}
+
+    inline LogicalOperatorType getLogicalOperatorType() const override {
+        return LogicalOperatorType::LOGICAL_RESULT_COLLECTOR;
+    }
+
+    inline string getExpressionsForPrinting() const override {
+        auto result = string();
+        for (auto& expression : expressionsToCollect) {
+            result += ", " + expression->getUniqueName();
+        }
+        return result;
+    }
+
+    inline vector<shared_ptr<Expression>> getExpressionsToCollect() { return expressionsToCollect; }
+
+    inline unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalResultCollector>(
+            expressionsToCollect, move(schema), getChild(0)->copy());
+    }
+
+    inline Schema* getSchema() { return schema.get(); }
+
+private:
+    vector<shared_ptr<Expression>> expressionsToCollect;
+    unique_ptr<Schema> schema;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/logical_plan/operator/union_all/logical_union_all.h
+++ b/src/planner/include/logical_plan/operator/union_all/logical_union_all.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "src/binder/include/expression/expression.h"
+#include "src/planner/include/logical_plan/operator/logical_operator.h"
+
+using namespace graphflow::binder;
+
+namespace graphflow {
+namespace planner {
+
+class LogicalUnionAll : public LogicalOperator {
+
+public:
+    inline LogicalOperatorType getLogicalOperatorType() const override {
+        return LogicalOperatorType::LOGICAL_UNION_ALL;
+    }
+
+    inline string getExpressionsForPrinting() const override {
+        auto result = string();
+        for (auto& expression : expressionsToUnion) {
+            result += ", " + expression->getUniqueName();
+        }
+        return result;
+    }
+
+    inline unique_ptr<LogicalOperator> copy() override { return make_unique<LogicalUnionAll>(); }
+
+    inline void setExpressionsToUnion(vector<shared_ptr<Expression>> expressionsToUnion) {
+        this->expressionsToUnion = move(expressionsToUnion);
+    }
+
+    inline vector<shared_ptr<Expression>> getExpressionsToUnion() { return expressionsToUnion; }
+
+private:
+    vector<shared_ptr<Expression>> expressionsToUnion;
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/include/planner.h
+++ b/src/planner/include/planner.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "src/binder/include/bound_queries/bound_regular_query.h"
 #include "src/planner/include/enumerator.h"
 
 namespace graphflow {
@@ -8,6 +9,11 @@ namespace planner {
 class Planner {
 
 public:
+    static unique_ptr<LogicalPlan> getBestPlan(const Graph& graph, const BoundRegularQuery& query);
+
+    static vector<unique_ptr<LogicalPlan>> getAllPlans(
+        const Graph& graph, const BoundRegularQuery& query);
+
     static unique_ptr<LogicalPlan> getBestPlan(const Graph& graph, const BoundSingleQuery& query);
 
     static vector<unique_ptr<LogicalPlan>> getAllPlans(

--- a/src/planner/include/property_scan_pushdown.h
+++ b/src/planner/include/property_scan_pushdown.h
@@ -45,6 +45,9 @@ private:
     shared_ptr<LogicalOperator> rewriteLeftNestedLoopJoin(
         const shared_ptr<LogicalOperator>& op, Schema& schema);
 
+    shared_ptr<LogicalOperator> rewriteResultCollector(
+        const shared_ptr<LogicalOperator>& op, Schema& schema);
+
     shared_ptr<LogicalOperator> applyPropertyScansIfNecessary(
         const string& nodeID, const shared_ptr<LogicalOperator>& op, Schema& schema);
 

--- a/src/planner/join_order_enumerator.cpp
+++ b/src/planner/join_order_enumerator.cpp
@@ -290,7 +290,7 @@ void JoinOrderEnumerator::appendLogicalHashJoin(
         }
         payloadGroupsPos.insert(groupPos);
     }
-    Enumerator::computeSchemaForHashJoinAndOrderBy(
+    Enumerator::computeSchemaForHashJoinAndOrderByAndUnionAll(
         payloadGroupsPos, buildSideSchema, *probePlan.schema);
 
     auto hashJoin = make_shared<LogicalHashJoin>(joinNodeID, buildSideSchema.copy(),

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -1,14 +1,38 @@
 #include "src/planner/include/planner.h"
 
+#include "src/planner/include/logical_plan/operator/result_collector/logical_result_collector.h"
 #include "src/planner/include/property_scan_pushdown.h"
-
 namespace graphflow {
 namespace planner {
 
-unique_ptr<LogicalPlan> Planner::getBestPlan(const Graph& graph, const BoundSingleQuery& query) {
-    // join order enumeration with filter push down
-    auto bestPlan = Enumerator(graph).getBestJoinOrderPlan(query);
-    return optimize(move(bestPlan));
+unique_ptr<LogicalPlan> Planner::getBestPlan(const Graph& graph, const BoundRegularQuery& query) {
+    if (query.getNumBoundSingleQueries() == 1) {
+        return getBestPlan(graph, *query.getBoundSingleQuery(0));
+    } else {
+        auto logicalPlan = make_unique<LogicalPlan>();
+        vector<unique_ptr<LogicalPlan>> childrenPlans;
+        for (auto i = 0u; i < query.getNumBoundSingleQueries(); i++) {
+            auto childPlan = getBestPlan(graph, *query.getBoundSingleQuery(i));
+            logicalPlan->cost += childPlan->cost;
+            childrenPlans.push_back(move(childPlan));
+        }
+        Enumerator::appendLogicalUnionAll(childrenPlans, *logicalPlan);
+        Enumerator::appendLogicalResultCollector(*logicalPlan);
+        return logicalPlan;
+    }
+}
+
+vector<unique_ptr<LogicalPlan>> Planner::getAllPlans(
+    const Graph& graph, const BoundRegularQuery& query) {
+    if (query.getNumBoundSingleQueries() == 1) {
+        return getAllPlans(graph, *query.getBoundSingleQuery(0));
+    } else {
+        // For regular queries, we don't do cartesian product on all sub-plans. We just return the
+        // best plan for regular queries.
+        vector<unique_ptr<LogicalPlan>> logicalPlans;
+        logicalPlans.push_back(getBestPlan(graph, query));
+        return logicalPlans;
+    }
 }
 
 vector<unique_ptr<LogicalPlan>> Planner::getAllPlans(
@@ -19,6 +43,12 @@ vector<unique_ptr<LogicalPlan>> Planner::getAllPlans(
         optimizedPlans.push_back(optimize(move(plan)));
     }
     return optimizedPlans;
+}
+
+unique_ptr<LogicalPlan> Planner::getBestPlan(const Graph& graph, const BoundSingleQuery& query) {
+    // join order enumeration with filter push down
+    auto bestPlan = Enumerator(graph).getBestJoinOrderPlan(query);
+    return optimize(move(bestPlan));
 }
 
 unique_ptr<LogicalPlan> Planner::optimize(unique_ptr<LogicalPlan> plan) {

--- a/src/planner/projection_enumerator.cpp
+++ b/src/planner/projection_enumerator.cpp
@@ -127,7 +127,7 @@ void ProjectionEnumerator::appendOrderBy(const vector<shared_ptr<Expression>>& e
     }
     auto schemaBeforeOrderBy = plan.schema->copy();
     plan.schema->clear();
-    Enumerator::computeSchemaForHashJoinAndOrderBy(
+    Enumerator::computeSchemaForHashJoinAndOrderByAndUnionAll(
         schemaBeforeOrderBy->getGroupsPosInScope(), *schemaBeforeOrderBy, *plan.schema);
     auto orderBy = make_shared<LogicalOrderBy>(orderByExpressionNames, isAscOrders,
         schemaBeforeOrderBy->copy(), schemaBeforeOrderBy->getExpressionNamesInScope(),

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -3,6 +3,7 @@
 #include "src/planner/include/logical_plan/logical_plan.h"
 #include "src/processor/include/physical_plan/mapper/expression_mapper.h"
 #include "src/processor/include/physical_plan/mapper/mapper_context.h"
+#include "src/processor/include/physical_plan/operator/result_collector.h"
 #include "src/processor/include/physical_plan/physical_plan.h"
 #include "src/storage/include/graph.h"
 
@@ -70,6 +71,11 @@ private:
         ExecutionContext& executionContext);
     unique_ptr<PhysicalOperator> mapLogicalOrderByToPhysical(LogicalOperator* logicalOperator,
         MapperContext& mapperContext, ExecutionContext& executionContext);
+    unique_ptr<PhysicalOperator> mapLogicalUnionAllToPhysical(LogicalOperator* logicalOperator,
+        MapperContext& mapperContext, ExecutionContext& executionContext);
+    unique_ptr<ResultCollector> mapLogicalResultCollectorToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext,
+        ExecutionContext& executionContext);
 
 public:
     const Graph& graph;

--- a/src/processor/include/physical_plan/operator/result_collector.h
+++ b/src/processor/include/physical_plan/operator/result_collector.h
@@ -49,7 +49,7 @@ public:
             vectorsToCollectInfo, sharedQueryResults, children[0]->clone(), context, id);
     }
 
-    inline shared_ptr<FactorizedTable> getFinalizedQueryResult() {
+    inline shared_ptr<FactorizedTable> getResultFactorizedTable() {
         return sharedQueryResults->getFinalizedQueryResult();
     }
 

--- a/src/processor/include/physical_plan/operator/union_all_scan.h
+++ b/src/processor/include/physical_plan/operator/union_all_scan.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "src/processor/include/physical_plan/operator/physical_operator.h"
+#include "src/processor/include/physical_plan/operator/result_collector.h"
+#include "src/processor/include/physical_plan/operator/source_operator.h"
+#include "src/processor/include/physical_plan/result/factorized_table.h"
+
+namespace graphflow {
+namespace processor {
+
+class UnionAllScanMorsel {
+public:
+    UnionAllScanMorsel(uint32_t resultCollectorIdx, uint32_t tupleIdx, uint32_t numRows)
+        : childIdx{resultCollectorIdx}, startTupleIdx{tupleIdx}, numTuples{numRows} {}
+
+    inline uint32_t getChildIdx() { return childIdx; }
+    inline uint32_t getStartTupleIdx() { return startTupleIdx; }
+    inline uint32_t getNumTuples() { return numTuples; }
+
+private:
+    uint32_t childIdx;
+    uint32_t startTupleIdx;
+    uint32_t numTuples;
+};
+
+class UnionAllScanSharedState {
+public:
+    UnionAllScanSharedState(vector<unique_ptr<PhysicalOperator>>& unionAllChildren)
+        : resultCollectorIdxToRead{0}, nextTupleIdxToRead{0}, unionAllChildren{unionAllChildren} {}
+
+    inline shared_ptr<FactorizedTable> getFactorizedTable(uint32_t idx) {
+        return ((ResultCollector*)(unionAllChildren[idx].get()))->getResultFactorizedTable();
+    }
+
+    // If there is an unflat column in the factorizedTable, we can only read one tuple at a
+    // time.
+    inline void initForScanning() {
+        lock_guard<mutex> lck{unionAllScanSharedStateMutex};
+        maxMorselSize = getFactorizedTable(0)->hasUnflatColToRead() ? 1 : DEFAULT_VECTOR_CAPACITY;
+    }
+
+    unique_ptr<UnionAllScanMorsel> getMorsel();
+
+    TupleSchema getTupleSchema() {
+        lock_guard<mutex> lck{unionAllScanSharedStateMutex};
+        return getFactorizedTable(0)->getTupleSchema();
+    }
+
+private:
+    uint64_t maxMorselSize;
+    uint64_t resultCollectorIdxToRead;
+    uint64_t nextTupleIdxToRead;
+
+    vector<unique_ptr<PhysicalOperator>>& unionAllChildren;
+    mutex unionAllScanSharedStateMutex;
+};
+
+class UnionAllScan : public PhysicalOperator, public SourceOperator {
+public:
+    UnionAllScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> outDataPoses,
+        vector<unique_ptr<PhysicalOperator>> children, ExecutionContext& context, uint32_t id)
+        : outDataPoses{outDataPoses}, PhysicalOperator{move(children), context, id},
+          SourceOperator{move(resultSetDescriptor)} {
+        unionAllScanSharedState = make_shared<UnionAllScanSharedState>(this->children);
+    }
+
+    // For clone only.
+    UnionAllScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> outDataPoses,
+        shared_ptr<UnionAllScanSharedState> unionAllScanSharedState, ExecutionContext& context,
+        uint32_t id)
+        : outDataPoses{outDataPoses}, unionAllScanSharedState{unionAllScanSharedState},
+          PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)} {}
+
+    shared_ptr<ResultSet> initResultSet() override;
+
+    bool getNextTuples() override;
+
+    PhysicalOperatorType getOperatorType() override { return UNION_ALL_SCAN; }
+
+    unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<UnionAllScan>(
+            resultSetDescriptor->copy(), outDataPoses, unionAllScanSharedState, context, id);
+    }
+
+private:
+    shared_ptr<UnionAllScanSharedState> unionAllScanSharedState;
+    vector<DataPos> outDataPoses;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/include/physical_plan/result/factorized_table.h
+++ b/src/processor/include/physical_plan/result/factorized_table.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <numeric>
 #include <unordered_map>
 
 #include "src/common/include/memory_manager.h"
@@ -122,6 +123,8 @@ public:
     // Actual number of tuples scanned is returned. If it's 0, the scan already hits the end.
     uint64_t scan(const vector<uint64_t>& fieldsToScan, const vector<DataPos>& resultDataPos,
         ResultSet& resultSet, uint64_t startTupleIdx, uint64_t numTuplesToScan) const;
+    uint64_t scan(const vector<DataPos>& resultDataPos, ResultSet& resultSet,
+        uint64_t startTupleIdx, uint64_t numTuplesToScan) const;
     uint64_t lookup(const vector<uint64_t>& fieldsToRead, const vector<DataPos>& resultDataPos,
         ResultSet& resultSet, uint8_t** tuplesToRead, uint64_t startPos,
         uint64_t numTuplesToRead) const;
@@ -133,6 +136,9 @@ public:
     void merge(FactorizedTable& other);
     uint64_t getFieldOffsetInTuple(uint64_t fieldId) const;
     bool hasUnflatColToRead(const vector<uint64_t>& fieldsToRead) const;
+    inline bool hasUnflatColToRead() const {
+        return hasUnflatColToRead(consecutiveIndicesOfAllFields);
+    }
 
     inline uint64_t getNumTuples() const { return numTuples; }
     inline uint8_t* getTuple(uint64_t tupleIdx) const {
@@ -224,6 +230,7 @@ private:
     vector<DataBlock> tupleDataBlocks;
     vector<DataBlock> vectorOverflowBlocks;
     unique_ptr<StringBuffer> stringBuffer;
+    vector<uint64_t> consecutiveIndicesOfAllFields;
 };
 
 class FlatTupleIterator {

--- a/src/processor/include/processor.h
+++ b/src/processor/include/processor.h
@@ -21,7 +21,8 @@ public:
 
 private:
     void run();
-    void decomposePlanIntoTasks(PhysicalOperator* op, Task* parentTask, uint64_t numThreads);
+    void decomposePlanIntoTasks(
+        PhysicalOperator* op, PhysicalOperator* parent, Task* parentTask, uint64_t numThreads);
     void scheduleTaskAndWaitUntilExecution(const shared_ptr<Task>& task);
 
 private:

--- a/src/processor/physical_plan/operator/union_all_scan.cpp
+++ b/src/processor/physical_plan/operator/union_all_scan.cpp
@@ -1,0 +1,65 @@
+#include "src/processor/include/physical_plan/operator/union_all_scan.h"
+
+namespace graphflow {
+namespace processor {
+
+unique_ptr<UnionAllScanMorsel> UnionAllScanSharedState::getMorsel() {
+    lock_guard<mutex> lck{unionAllScanSharedStateMutex};
+    // If we have read all the tuples for the current resultCollector, go to the next one.
+    // Note that: a queryResult may contain 0 tuple.
+    while (resultCollectorIdxToRead < unionAllChildren.size() &&
+           nextTupleIdxToRead >= getFactorizedTable(resultCollectorIdxToRead)->getNumTuples()) {
+        resultCollectorIdxToRead++;
+        nextTupleIdxToRead = 0;
+    }
+    // We have read all the tuples in all query results, just return a nullptr.
+    if (resultCollectorIdxToRead >= unionAllChildren.size()) {
+        return nullptr;
+    }
+
+    auto numTuplesToRead = min(maxMorselSize,
+        getFactorizedTable(resultCollectorIdxToRead)->getNumTuples() - nextTupleIdxToRead);
+    auto unionAllScanMorsel = make_unique<UnionAllScanMorsel>(
+        resultCollectorIdxToRead, nextTupleIdxToRead, numTuplesToRead);
+    nextTupleIdxToRead += numTuplesToRead;
+    return unionAllScanMorsel;
+}
+
+shared_ptr<ResultSet> UnionAllScan::initResultSet() {
+    resultSet = populateResultSet();
+    auto tupleSchema = unionAllScanSharedState->getTupleSchema();
+    vector<uint64_t> fieldsToReadInFactorizedTable;
+    for (auto i = 0u; i < outDataPoses.size(); i++) {
+        auto outDataPos = outDataPoses[i];
+        auto outDataChunk = resultSet->dataChunks[outDataPos.dataChunkPos];
+        outDataChunk->insert(outDataPos.valueVectorPos,
+            make_shared<ValueVector>(context.memoryManager, tupleSchema.fields[i].dataType));
+        fieldsToReadInFactorizedTable.emplace_back(i);
+    }
+    unionAllScanSharedState->initForScanning();
+    return resultSet;
+}
+
+bool UnionAllScan::getNextTuples() {
+    metrics->executionTime.start();
+    auto unionAllScanMorsel = unionAllScanSharedState->getMorsel();
+    if (unionAllScanMorsel == nullptr) {
+        return false;
+    }
+
+    // We scan one by one if there is an unflat column in the factorized tables (see how
+    // maxMorselSize is set in initForScanning).
+    unionAllScanSharedState->getFactorizedTable(unionAllScanMorsel->getChildIdx())
+        ->scan(outDataPoses, *resultSet, unionAllScanMorsel->getStartTupleIdx(),
+            unionAllScanMorsel->getNumTuples());
+    metrics->numOutputTuple.increase(
+        unionAllScanMorsel->getNumTuples() == 1 ?
+            unionAllScanSharedState->getFactorizedTable(unionAllScanMorsel->getChildIdx())
+                ->getNumFlatTuples(unionAllScanMorsel->getStartTupleIdx()) :
+            unionAllScanMorsel->getNumTuples());
+    metrics->executionTime.stop();
+    return true;
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/test/parser/expression_test.cpp
+++ b/test/parser/expression_test.cpp
@@ -43,8 +43,8 @@ TEST_F(ExpressionTest, FilterIDComparisonTest) {
     auto where = make_unique<ParsedExpression>(EQUALS, EMPTY, EMPTY, move(aID), move(bID));
 
     string input = "MATCH () WHERE id(a) = id(b) RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*where, *matchStatement.whereClause));
 }
 
@@ -58,8 +58,8 @@ TEST_F(ExpressionTest, FilterBooleanConnectionTest) {
     where->children.push_back(move(bIsNotMale));
 
     string input = "MATCH () WHERE a.isStudent AND NOT b.isMale RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*where, *matchStatement.whereClause));
 }
 
@@ -74,8 +74,8 @@ TEST_F(ExpressionTest, FilterNullOperatorTest) {
     auto where = make_unique<ParsedExpression>(AND, EMPTY, EMPTY, move(leftAnd), move(aNameIsNull));
 
     string input = "MATCH () WHERE a.isStudent AND b.isMale AND a.name IS NULL RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*where, *matchStatement.whereClause));
 }
 
@@ -93,8 +93,8 @@ TEST_F(ExpressionTest, FilterStringOperatorTest) {
 
     string input =
         "MATCH () WHERE (a.isStudent AND b.isMale) OR a.name CONTAINS \"Xiyang\" RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*where, *matchStatement.whereClause));
 }
 
@@ -108,8 +108,8 @@ TEST_F(ExpressionTest, FilterArithmeticComparisonTest) {
     auto where = make_unique<ParsedExpression>(EQUALS, EMPTY, EMPTY, move(left), move(aAge));
 
     string input = "MATCH () WHERE 2 + a * 0.1 = a.age RETURN *";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*where, *matchStatement.whereClause));
 }
 
@@ -124,8 +124,8 @@ TEST_F(ExpressionTest, FilterParenthesizeTest) {
         make_unique<ParsedExpression>(LESS_THAN_EQUALS, EMPTY, EMPTY, move(left), move(aAge));
 
     string input = "MATCH () WHERE ((2 - a) % 0.1) <= a.age RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*where, *matchStatement.whereClause));
 }
 
@@ -139,7 +139,7 @@ TEST_F(ExpressionTest, FilterFunctionMultiParamsTest) {
     where->children.push_back(move(bPowerTwo));
 
     string input = "MATCH () WHERE MIN(a, b^2) RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*where, *matchStatement.whereClause));
 }

--- a/test/parser/reading_clause_test.cpp
+++ b/test/parser/reading_clause_test.cpp
@@ -23,10 +23,10 @@ TEST_F(ReadingClauseTest, EmptyMatchTest) {
     auto expectedMatch = make_unique<MatchStatement>(move(expectPElements));
 
     string input = "MATCH () RETURN COUNT(*);";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(1u == singleQuery->matchStatements.size());
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(1u == regularQuery->getSingleQuery(0)->matchStatements.size());
     ASSERT_TRUE(ParserTestUtils::equals(
-        *expectedMatch, (MatchStatement&)(*singleQuery->matchStatements[0])));
+        *expectedMatch, (MatchStatement&)(*regularQuery->getSingleQuery(0)->matchStatements[0])));
 }
 
 TEST_F(ReadingClauseTest, MATCHSingleEdgeTest) {
@@ -41,10 +41,10 @@ TEST_F(ReadingClauseTest, MATCHSingleEdgeTest) {
     auto expectedMatch = make_unique<MatchStatement>(move(expectPElements));
 
     string input = "MATCH (a:Person)-[e1:knows]->(b:Student) RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(1u == singleQuery->matchStatements.size());
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(1u == regularQuery->getSingleQuery(0)->matchStatements.size());
     ASSERT_TRUE(ParserTestUtils::equals(
-        *expectedMatch, (MatchStatement&)(*singleQuery->matchStatements[0])));
+        *expectedMatch, (MatchStatement&)(*regularQuery->getSingleQuery(0)->matchStatements[0])));
 }
 
 TEST_F(ReadingClauseTest, MATCHMultiEdgesTest) {
@@ -65,10 +65,10 @@ TEST_F(ReadingClauseTest, MATCHMultiEdgesTest) {
     auto expectedMatch = make_unique<MatchStatement>(move(expectPElements));
 
     string input = "MATCH (a:Person)-[:knows]->(b:Student)<-[e2:likes]-(c:Student) RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(1u == singleQuery->matchStatements.size());
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(1u == regularQuery->getSingleQuery(0)->matchStatements.size());
     ASSERT_TRUE(ParserTestUtils::equals(
-        *expectedMatch, (MatchStatement&)(*singleQuery->matchStatements[0])));
+        *expectedMatch, (MatchStatement&)(*regularQuery->getSingleQuery(0)->matchStatements[0])));
 }
 
 TEST_F(ReadingClauseTest, MATCHMultiElementsTest) {
@@ -94,10 +94,10 @@ TEST_F(ReadingClauseTest, MATCHMultiElementsTest) {
     auto expectedMatch = make_unique<MatchStatement>(move(expectPElements));
 
     string input = "MATCH (a:Person)-[:knows]->(b:Student), (b)<-[e2:likes]-(c:Student) RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(1u == singleQuery->matchStatements.size());
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(1u == regularQuery->getSingleQuery(0)->matchStatements.size());
     ASSERT_TRUE(ParserTestUtils::equals(
-        *expectedMatch, (MatchStatement&)(*singleQuery->matchStatements[0])));
+        *expectedMatch, (MatchStatement&)(*regularQuery->getSingleQuery(0)->matchStatements[0])));
 }
 
 TEST_F(ReadingClauseTest, MultiMatchTest) {
@@ -125,10 +125,10 @@ TEST_F(ReadingClauseTest, MultiMatchTest) {
 
     string input =
         "MATCH (a:Person)-[:knows]->(b:Student) MATCH (b)<-[e2:likes]-(c:Student) RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(2u == singleQuery->matchStatements.size());
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(2u == regularQuery->getSingleQuery(0)->matchStatements.size());
     ASSERT_TRUE(ParserTestUtils::equals(
-        *expectedMatch1, (MatchStatement&)(*singleQuery->matchStatements[0])));
+        *expectedMatch1, (MatchStatement&)(*regularQuery->getSingleQuery(0)->matchStatements[0])));
     ASSERT_TRUE(ParserTestUtils::equals(
-        *expectedMatch2, (MatchStatement&)(*singleQuery->matchStatements[1])));
+        *expectedMatch2, (MatchStatement&)(*regularQuery->getSingleQuery(0)->matchStatements[1])));
 }

--- a/test/parser/return_with_test.cpp
+++ b/test/parser/return_with_test.cpp
@@ -28,8 +28,9 @@ TEST_F(ReturnWithTest, ReturnCountStarTest) {
         make_unique<ReturnStatement>(make_unique<ProjectionBody>(false, move(expressions)));
 
     string input = "MATCH () RETURN COUNT(*);";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(ParserTestUtils::equals(*returnStatement, *singleQuery->returnStatement));
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *returnStatement, *regularQuery->getSingleQuery(0)->returnStatement));
 }
 
 TEST_F(ReturnWithTest, ReturnStarAndPropertyTest) {
@@ -39,8 +40,9 @@ TEST_F(ReturnWithTest, ReturnStarAndPropertyTest) {
         make_unique<ReturnStatement>(make_unique<ProjectionBody>(true, move(expressions)));
 
     string input = "MATCH () RETURN *, a.name;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(ParserTestUtils::equals(*returnStatement, *singleQuery->returnStatement));
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *returnStatement, *regularQuery->getSingleQuery(0)->returnStatement));
 }
 
 TEST_F(ReturnWithTest, ReturnAliasTest) {
@@ -53,8 +55,9 @@ TEST_F(ReturnWithTest, ReturnAliasTest) {
         make_unique<ReturnStatement>(make_unique<ProjectionBody>(false, move(expressions)));
 
     string input = "MATCH () RETURN a.name, a.name AS whatever;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(ParserTestUtils::equals(*returnStatement, *singleQuery->returnStatement));
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *returnStatement, *regularQuery->getSingleQuery(0)->returnStatement));
 }
 
 TEST_F(ReturnWithTest, ReturnLimitTest) {
@@ -64,8 +67,9 @@ TEST_F(ReturnWithTest, ReturnLimitTest) {
     projectionBody->setLimitExpression(make_unique<ParsedExpression>(LITERAL_INT, "10", EMPTY));
     auto returnStatement = make_unique<ReturnStatement>(move(projectionBody));
     string input = "MATCH () RETURN a.name LIMIT 10;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(ParserTestUtils::equals(*returnStatement, *singleQuery->returnStatement));
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *returnStatement, *regularQuery->getSingleQuery(0)->returnStatement));
 }
 
 TEST_F(ReturnWithTest, SingleWithTest) {
@@ -80,11 +84,11 @@ TEST_F(ReturnWithTest, SingleWithTest) {
         make_unique<WithStatement>(make_unique<ProjectionBody>(false, move(expressions)));
 
     string input = "WITH 1 AS one, \"Xiyang\" AS name MATCH () RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(1u == singleQuery->queryParts.size());
-    ASSERT_TRUE(singleQuery->queryParts[0]->matchStatements.empty());
-    ASSERT_TRUE(
-        ParserTestUtils::equals(*withStatement, *singleQuery->queryParts[0]->withStatement));
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(1u == regularQuery->getSingleQuery(0)->queryParts.size());
+    ASSERT_TRUE(regularQuery->getSingleQuery(0)->queryParts[0]->matchStatements.empty());
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *withStatement, *regularQuery->getSingleQuery(0)->queryParts[0]->withStatement));
 }
 
 TEST_F(ReturnWithTest, MultiMatchWithStarTest) {
@@ -96,11 +100,11 @@ TEST_F(ReturnWithTest, MultiMatchWithStarTest) {
         make_unique<WithStatement>(make_unique<ProjectionBody>(true, move(expressions)));
 
     string input = "MATCH () MATCH () WITH *, 1 AS one MATCH () RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(1u == singleQuery->queryParts.size());
-    ASSERT_TRUE(2u == singleQuery->queryParts[0]->matchStatements.size());
-    ASSERT_TRUE(
-        ParserTestUtils::equals(*withStatement, *singleQuery->queryParts[0]->withStatement));
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(1u == regularQuery->getSingleQuery(0)->queryParts.size());
+    ASSERT_TRUE(2u == regularQuery->getSingleQuery(0)->queryParts[0]->matchStatements.size());
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *withStatement, *regularQuery->getSingleQuery(0)->queryParts[0]->withStatement));
 }
 
 TEST_F(ReturnWithTest, MultiWithWhereTest) {
@@ -125,12 +129,12 @@ TEST_F(ReturnWithTest, MultiWithWhereTest) {
 
     string input =
         "MATCH () WITH * WHERE a.age < 1 WITH a.age AS newAge WHERE newAge = 10 MATCH () RETURN *;";
-    auto singleQuery = Parser::parseQuery(input);
-    ASSERT_TRUE(2u == singleQuery->queryParts.size());
-    ASSERT_TRUE(1u == singleQuery->queryParts[0]->matchStatements.size());
-    ASSERT_TRUE(
-        ParserTestUtils::equals(*withStatement1, *singleQuery->queryParts[0]->withStatement));
-    ASSERT_TRUE(singleQuery->queryParts[1]->matchStatements.empty());
-    ASSERT_TRUE(
-        ParserTestUtils::equals(*withStatement2, *singleQuery->queryParts[1]->withStatement));
+    auto regularQuery = Parser::parseQuery(input);
+    ASSERT_TRUE(2u == regularQuery->getSingleQuery(0)->queryParts.size());
+    ASSERT_TRUE(1u == regularQuery->getSingleQuery(0)->queryParts[0]->matchStatements.size());
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *withStatement1, *regularQuery->getSingleQuery(0)->queryParts[0]->withStatement));
+    ASSERT_TRUE(regularQuery->getSingleQuery(0)->queryParts[1]->matchStatements.empty());
+    ASSERT_TRUE(ParserTestUtils::equals(
+        *withStatement2, *regularQuery->getSingleQuery(0)->queryParts[1]->withStatement));
 }

--- a/test/parser/subquery_test.cpp
+++ b/test/parser/subquery_test.cpp
@@ -32,8 +32,8 @@ TEST_F(SubqueryTest, ExistsTest) {
     expectedExpression->children.push_back(move(existentialExpression));
 
     string input = "MATCH () WHERE NOT EXISTS { MATCH () RETURN * } RETURN COUNT(*);";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*expectedExpression, *matchStatement.whereClause));
 }
 
@@ -54,7 +54,7 @@ TEST_F(SubqueryTest, NestedExistsTest) {
 
     string input = "MATCH () WHERE EXISTS { MATCH () WHERE EXISTS { MATCH () RETURN * } RETURN "
                    "* } RETURN COUNT(*);";
-    auto singleQuery = Parser::parseQuery(input);
-    auto& matchStatement = (MatchStatement&)*singleQuery->matchStatements[0];
+    auto regularQuery = Parser::parseQuery(input);
+    auto& matchStatement = (MatchStatement&)*regularQuery->getSingleQuery(0)->matchStatements[0];
     ASSERT_TRUE(ParserTestUtils::equals(*expectedExpression, *matchStatement.whereClause));
 }

--- a/test/planner/cost_model_test.cpp
+++ b/test/planner/cost_model_test.cpp
@@ -11,10 +11,10 @@ public:
 TEST_F(CostModelTest, OneHopSingleFilter) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = 1 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto op1 = plan->lastOperator->getFirstChild()->getFirstChild()->getFirstChild().get();
+    auto op1 = plan->lastOperator->getChild(0)->getChild(0)->getChild(0)->getChild(0).get();
     ASSERT_EQ(LOGICAL_EXTEND, op1->getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalExtend*)op1)->nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
-    auto op2 = op1->getFirstChild()->getFirstChild()->getFirstChild()->getFirstChild().get();
+    auto op2 = op1->getChild(0)->getChild(0)->getChild(0)->getChild(0).get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2->getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op2)->nodeID, "_a." + INTERNAL_ID_SUFFIX));
 }
@@ -23,20 +23,16 @@ TEST_F(CostModelTest, OneHopMultiFilters) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age > 10 AND a.age < 20 AND b.age "
                  "= 45 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto op1 = plan->lastOperator->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
+    auto op1 = plan->lastOperator->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
                    .get();
     ASSERT_EQ(LOGICAL_EXTEND, op1->getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalExtend*)op1)->nbrNodeID, "_b." + INTERNAL_ID_SUFFIX));
-    auto op2 = op1->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   .get();
+    auto op2 = op1->getChild(0)->getChild(0)->getChild(0)->getChild(0)->getChild(0).get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op2->getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op2)->nodeID, "_a." + INTERNAL_ID_SUFFIX));
 }
@@ -44,12 +40,13 @@ TEST_F(CostModelTest, OneHopMultiFilters) {
 TEST_F(CostModelTest, TwoHop) {
     auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto op1 = plan->lastOperator->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
+    auto op1 = plan->lastOperator->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
                    .get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1->getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op1)->nodeID, "_b." + INTERNAL_ID_SUFFIX));
@@ -59,16 +56,17 @@ TEST_F(CostModelTest, TwoHopMultiFilters) {
     auto query = "MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE a.age = 20 AND "
                  "b.age = 35 RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto op1 = plan->lastOperator->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
-                   ->getFirstChild()
+    auto op1 = plan->lastOperator->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
+                   ->getChild(0)
                    .get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_ID, op1->getLogicalOperatorType());
     ASSERT_TRUE(containSubstr(((LogicalScanNodeID*)op1)->nodeID, "_b." + INTERNAL_ID_SUFFIX));
@@ -79,13 +77,13 @@ TEST_F(CostModelTest, TwoHopMultiFilters) {
 TEST_F(PlannerTest, OrderByTest1) {
     auto query = "MATCH (a:person) RETURN a.age ORDER BY a.age";
     auto plan = getBestPlan(query);
-    auto op1 = plan->lastOperator.get();
+    auto op1 = plan->lastOperator->getChild(0).get();
     ASSERT_EQ(LOGICAL_PROJECTION, op1->getLogicalOperatorType());
-    auto op2 = op1->getFirstChild().get();
+    auto op2 = op1->getChild(0).get();
     ASSERT_EQ(LOGICAL_ORDER_BY, op2->getLogicalOperatorType());
-    auto op3 = op2->getFirstChild().get();
+    auto op3 = op2->getChild(0).get();
     ASSERT_EQ(LOGICAL_FLATTEN, op3->getLogicalOperatorType());
-    auto op4 = op3->getFirstChild().get();
+    auto op4 = op3->getChild(0).get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op4->getLogicalOperatorType());
 }
 
@@ -93,21 +91,21 @@ TEST_F(PlannerTest, OrderByTest1) {
 TEST_F(PlannerTest, OrderByTest2) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) RETURN b.age ORDER BY a.age";
     auto plan = getBestPlan(query);
-    auto op1 = plan->lastOperator.get();
+    auto op1 = plan->lastOperator->getChild(0).get();
     ASSERT_EQ(LOGICAL_PROJECTION, op1->getLogicalOperatorType());
-    auto op2 = op1->getFirstChild().get();
+    auto op2 = op1->getChild(0).get();
     ASSERT_EQ(LOGICAL_ORDER_BY, op2->getLogicalOperatorType());
-    auto op3 = op2->getFirstChild().get();
+    auto op3 = op2->getChild(0).get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op3->getLogicalOperatorType());
-    auto op4 = op3->getFirstChild().get();
+    auto op4 = op3->getChild(0).get();
     ASSERT_EQ(LOGICAL_EXTEND, op4->getLogicalOperatorType());
 }
 
 TEST_F(PlannerTest, OrderByTest3) {
     auto query = "MATCH (a:person) RETURN COUNT(*) ORDER BY COUNT(*)";
     auto plan = getBestPlan(query);
-    auto op1 = plan->lastOperator->getFirstChild().get();
+    auto op1 = plan->lastOperator->getChild(0)->getChild(0).get();
     ASSERT_EQ(LOGICAL_ORDER_BY, op1->getLogicalOperatorType());
-    auto op2 = op1->getFirstChild().get();
+    auto op2 = op1->getChild(0).get();
     ASSERT_EQ(LOGICAL_AGGREGATE, op2->getLogicalOperatorType());
 }

--- a/test/planner/property_scan_push_down_test.cpp
+++ b/test/planner/property_scan_push_down_test.cpp
@@ -9,13 +9,14 @@ class PropertyScanPushDownTest : public PlannerTest {};
 TEST_F(PropertyScanPushDownTest, FilterPropertyPushDownTest) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = b.age RETURN COUNT(*)";
     auto plan = getBestPlan(query);
-    auto op = plan->lastOperator->getFirstChild()
-                  ->getFirstChild()
-                  ->getFirstChild()
-                  ->getFirstChild()
-                  ->getFirstChild()
-                  ->getFirstChild()
-                  ->getFirstChild()
+    auto op = plan->lastOperator->getChild(0)
+                  ->getChild(0)
+                  ->getChild(0)
+                  ->getChild(0)
+                  ->getChild(0)
+                  ->getChild(0)
+                  ->getChild(0)
+                  ->getChild(0)
                   .get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op->getLogicalOperatorType());
     auto scanNodeProperty = (LogicalScanNodeProperty*)op;
@@ -26,11 +27,8 @@ TEST_F(PropertyScanPushDownTest, FilterPropertyPushDownTest) {
 TEST_F(PropertyScanPushDownTest, ProjectionPropertyPushDownTest) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) RETURN a.age, b.age";
     auto plan = getBestPlan(query);
-    auto op = plan->lastOperator->getFirstChild()
-                  ->getFirstChild()
-                  ->getFirstChild()
-                  ->getFirstChild()
-                  .get();
+    auto op =
+        plan->lastOperator->getChild(0)->getChild(0)->getChild(0)->getChild(0)->getChild(0).get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op->getLogicalOperatorType());
     auto scanNodeProperty = (LogicalScanNodeProperty*)op;
     ASSERT_TRUE(containSubstr(scanNodeProperty->nodeID, "_b." + INTERNAL_ID_SUFFIX));
@@ -43,18 +41,18 @@ TEST_F(PropertyScanPushDownTest, LogicalPlanCloneTest) {
                  "Return b.age";
     // if logical plan is not cloned before optimization, plan1 will have repeated scanNodeProperty
     auto plan = move(getAllPlans(query)[1]);
-    auto op = plan->lastOperator.get();
+    auto op = plan->lastOperator->getChild(0).get();
     while (op->getLogicalOperatorType() != LOGICAL_SCAN_NODE_PROPERTY) {
-        op = op->getFirstChild().get();
+        op = op->getChild(0).get();
     }
-    ASSERT_TRUE(op->getFirstChild()->getLogicalOperatorType() != LOGICAL_SCAN_NODE_PROPERTY);
+    ASSERT_TRUE(op->getChild(0)->getLogicalOperatorType() != LOGICAL_SCAN_NODE_PROPERTY);
 }
 
 TEST_F(PropertyScanPushDownTest, SubPlanPropertyPushDownTest) {
     auto query = "MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) RETURN a.age, b.age";
     auto plan = getBestPlan(query);
-    auto leftNLJ = (LogicalLeftNestedLoopJoin*)plan->lastOperator->getFirstChild().get();
-    auto op = leftNLJ->getSecondChild().get();
+    auto leftNLJ = (LogicalLeftNestedLoopJoin*)plan->lastOperator->getChild(0)->getChild(0).get();
+    auto op = leftNLJ->getChild(1).get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op->getLogicalOperatorType());
     auto scanNodeProperty = (LogicalScanNodeProperty*)op;
     ASSERT_TRUE(containSubstr(scanNodeProperty->nodeID, "_b." + INTERNAL_ID_SUFFIX));

--- a/test/runner/queries/union_all/union_all_tiny_snb.test
+++ b/test/runner/queries/union_all/union_all_tiny_snb.test
@@ -1,0 +1,67 @@
+-NAME UnionAllTwoQueriesTest
+-QUERY MATCH (p:person) RETURN p.age UNION ALL MATCH (p1:person) RETURN p1.age
+---- 16
+20
+20
+20
+20
+25
+25
+30
+30
+35
+35
+40
+40
+45
+45
+83
+83
+
+-NAME UnionAllMultipleQueriesTest
+-QUERY MATCH (p:person) RETURN p.age UNION ALL MATCH (p1:person) RETURN p1.age UNION ALL MATCH (p2:person) RETURN p2.age
+---- 24
+20
+20
+20
+20
+20
+20
+25
+25
+25
+30
+30
+30
+35
+35
+35
+40
+40
+40
+45
+45
+45
+83
+83
+83
+
+-NAME UnionAllMultipleColumnsTest
+-QUERY MATCH (p:person) RETURN p.age, p.eyeSight UNION ALL MATCH (p1:person) RETURN p1.age, p1.eyeSight
+---- 16
+20|4.700000
+20|4.700000
+20|4.800000
+20|4.800000
+25|4.500000
+25|4.500000
+30|5.100000
+30|5.100000
+35|5.000000
+35|5.000000
+40|4.900000
+40|4.900000
+45|5.000000
+45|5.000000
+83|4.900000
+83|4.900000

--- a/test/runner/tinysnb_end_to_end_test.cpp
+++ b/test/runner/tinysnb_end_to_end_test.cpp
@@ -109,3 +109,10 @@ TEST_F(TinySnbProcessorTest, OrderByTests) {
     }
     ASSERT_TRUE(TestHelper::runTest(queryConfigs, *defaultSystem));
 }
+
+TEST_F(TinySnbProcessorTest, UnionAllTests) {
+    vector<TestQueryConfig> queryConfigs;
+    queryConfigs =
+        TestHelper::parseTestFile("test/runner/queries/union_all/union_all_tiny_snb.test");
+    ASSERT_TRUE(TestHelper::runTest(queryConfigs, *defaultSystem));
+}


### PR DESCRIPTION
### Backend change:
1. The `decomposePlanIntoTasks` function now takes in an additional `parentOperator` parameter.
The resultCollector utilizes this parameter to tell whether to break the pipeline.

2.  Adds the `UNION_ALL_SCAN` opeartor, which outputs all the tuples of its children resultCollectors.

### Frontend Change:
1. Regular query support: Adds the regular query class which is just a collection of single queries.
2. Refactors the front end, so the binder/parser/transformer outputs a regular query instead a singleQuery.
3. Adds the logical opeartor for UNION_ALL_SCAN, and the logic to generate plans for UNION_ALL_SCAN.
4. Refactors the front end tests so that they are compatible with the front end changes.

### Couple of unresolved front end problems:
1. Binder should check the dataType matching/ number of columns of the `return statement` of single queries in the union all clause.
2. We may need a phsical UNION_ALL operator which ensures that the `unflat/flat status of vectorsToCollect` of each child is exactly the same. Otherwise, we may need to flatten columns in this operator.
3. The current exist subquery can only be a single query. We should add support to use regularQuery in the exist subquery.
