### PR TITLE
add group by and aggregate support for unstructure type

### DIFF
--- a/src/function/aggregate/aggregate_function.cpp
+++ b/src/function/aggregate/aggregate_function.cpp
@@ -47,6 +47,9 @@ unique_ptr<AggregateFunction> AggregateFunctionUtil::getAvgFunction(DataType dat
         return make_unique<AggregateFunction>(AvgFunction<double_t>::initialize,
             AvgFunction<double_t>::update, AvgFunction<double_t>::combine,
             AvgFunction<double_t>::finalize);
+    case UNSTRUCTURED:
+        return make_unique<AggregateFunction>(AvgFunction<Value>::initialize,
+            AvgFunction<Value>::update, AvgFunction<Value>::combine, AvgFunction<Value>::finalize);
     default:
         throw invalid_argument("Data type " + DataTypeNames[dataType] + " not supported for AVG.");
     }

--- a/src/function/include/aggregate/aggregate_function.h
+++ b/src/function/include/aggregate/aggregate_function.h
@@ -14,8 +14,8 @@ namespace graphflow {
 namespace function {
 
 struct AggregateState {
-    virtual inline uint64_t getValSize() const = 0;
-    virtual uint8_t* getFinalVal() const = 0;
+    virtual inline uint64_t getStateSize() const = 0;
+    virtual uint8_t* getResult() const = 0;
 
     bool isNull = true;
 };
@@ -36,7 +36,7 @@ public:
         initialNullAggregateState = createInitialNullAggregateState();
     }
 
-    inline uint64_t getAggregateStateSize() { return initialNullAggregateState->getValSize(); }
+    inline uint64_t getAggregateStateSize() { return initialNullAggregateState->getStateSize(); }
 
     inline AggregateState* getInitialNullAggregateState() {
         return initialNullAggregateState.get();

--- a/src/function/include/aggregate/base_count.h
+++ b/src/function/include/aggregate/base_count.h
@@ -8,10 +8,10 @@ namespace function {
 struct BaseCountFunction {
 
     struct CountState : public AggregateState {
-        uint64_t val = 0;
+        inline uint64_t getStateSize() const override { return sizeof(*this); }
+        inline uint8_t* getResult() const override { return (uint8_t*)&count; }
 
-        inline uint64_t getValSize() const override { return sizeof(*this); }
-        inline uint8_t* getFinalVal() const override { return (uint8_t*)&val; }
+        uint64_t count = 0;
     };
 
     static unique_ptr<AggregateState> initialize() {
@@ -23,7 +23,7 @@ struct BaseCountFunction {
     static void combine(uint8_t* state_, uint8_t* otherState_) {
         auto state = reinterpret_cast<CountState*>(state_);
         auto otherState = reinterpret_cast<CountState*>(otherState_);
-        state->val += otherState->val;
+        state->count += otherState->count;
     }
 
     static void finalize(uint8_t* state_) {}

--- a/src/function/include/aggregate/count.h
+++ b/src/function/include/aggregate/count.h
@@ -12,18 +12,18 @@ struct CountFunction : public BaseCountFunction {
         if (input->state->isFlat()) {
             auto pos = input->state->getPositionOfCurrIdx();
             if (!input->isNull(pos)) {
-                state->val += multiplicity;
+                state->count += multiplicity;
             }
         } else {
             if (input->hasNoNullsGuarantee()) {
                 for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                    state->val += multiplicity;
+                    state->count += multiplicity;
                 }
             } else {
                 for (auto i = 0u; i < input->state->selectedSize; ++i) {
                     auto pos = input->state->selectedPositions[i];
                     if (!input->isNull(pos)) {
-                        state->val += multiplicity;
+                        state->count += multiplicity;
                     }
                 }
             }

--- a/src/function/include/aggregate/count_star.h
+++ b/src/function/include/aggregate/count_star.h
@@ -10,7 +10,7 @@ struct CountStarFunction : public BaseCountFunction {
     static void update(uint8_t* state_, ValueVector* input, uint64_t multiplicity) {
         auto state = reinterpret_cast<CountState*>(state_);
         assert(input == nullptr);
-        state->val += multiplicity;
+        state->count += multiplicity;
     }
 };
 

--- a/src/function/include/aggregate/min_max.h
+++ b/src/function/include/aggregate/min_max.h
@@ -12,10 +12,10 @@ template<typename T>
 struct MinMaxFunction {
 
     struct MinMaxState : public AggregateState {
-        T val;
+        inline uint64_t getStateSize() const override { return sizeof(*this); }
+        inline uint8_t* getResult() const override { return (uint8_t*)&val; }
 
-        inline uint64_t getValSize() const override { return sizeof(*this); }
-        inline uint8_t* getFinalVal() const override { return (uint8_t*)&val; }
+        T val;
     };
 
     static unique_ptr<AggregateState> initialize() { return make_unique<MinMaxState>(); }
@@ -53,8 +53,8 @@ struct MinMaxFunction {
             state->isNull = false;
         } else {
             uint8_t compare_result;
-            OP::template operation<T, T>(
-                inputValues[pos], state->val, compare_result, false, false);
+            OP::template operation(inputValues[pos], state->val, compare_result,
+                false /* isLeftNull */, false /* isRightNull */);
             state->val = compare_result ? inputValues[pos] : state->val;
         }
     }
@@ -71,7 +71,7 @@ struct MinMaxFunction {
             state->isNull = false;
         } else {
             uint8_t compareResult;
-            OP::template operation<T, T>(otherState->val, state->val, compareResult,
+            OP::template operation(otherState->val, state->val, compareResult,
                 false /* isLeftNull */, false /* isRightNull */);
             state->val = compareResult == 1 ? otherState->val : state->val;
         }

--- a/src/function/include/aggregate/sum.h
+++ b/src/function/include/aggregate/sum.h
@@ -12,10 +12,10 @@ template<typename T>
 struct SumFunction {
 
     struct SumState : public AggregateState {
-        T val;
+        inline uint64_t getStateSize() const override { return sizeof(*this); }
+        inline uint8_t* getResult() const override { return (uint8_t*)&sum; }
 
-        inline uint64_t getValSize() const override { return sizeof(*this); }
-        inline uint8_t* getFinalVal() const override { return (uint8_t*)&val; }
+        T sum;
     };
 
     static unique_ptr<AggregateState> initialize() { return make_unique<SumState>(); }
@@ -49,11 +49,11 @@ struct SumFunction {
         auto inputValues = (T*)input->values;
         for (auto j = 0u; j < multiplicity; ++j) {
             if (state->isNull) {
-                state->val = inputValues[pos];
+                state->sum = inputValues[pos];
                 state->isNull = false;
             } else {
-                Add::operation<T, T, T>(state->val, inputValues[pos], state->val,
-                    false /* isLeftNull */, false /* isRightNull */);
+                Add::operation(state->sum, inputValues[pos], state->sum, false /* isLeftNull */,
+                    false /* isRightNull */);
             }
         }
     }
@@ -65,10 +65,10 @@ struct SumFunction {
         }
         auto state = reinterpret_cast<SumState*>(state_);
         if (state->isNull) {
-            state->val = otherState->val;
+            state->sum = otherState->sum;
             state->isNull = false;
         } else {
-            Add::operation<T, T, T>(state->val, otherState->val, state->val, false /* isLeftNull */,
+            Add::operation(state->sum, otherState->sum, state->sum, false /* isLeftNull */,
                 false /* isRightNull */);
         }
     }

--- a/src/processor/include/physical_plan/operator/aggregate/base_aggregate_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/base_aggregate_scan.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "src/function/include/aggregate/aggregate_function.h"
 #include "src/processor/include/physical_plan/operator/physical_operator.h"
 #include "src/processor/include/physical_plan/operator/source_operator.h"
+
+using namespace graphflow::function;
 
 namespace graphflow {
 namespace processor {
@@ -10,16 +13,16 @@ class BaseAggregateScan : public PhysicalOperator, public SourceOperator {
 
 public:
     BaseAggregateScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        vector<DataPos> aggregatesPos, vector<DataType> aggregatesDataType,
+        vector<DataPos> aggregatesPos, vector<DataType> aggregateDataTypes,
         unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
         : PhysicalOperator{move(child), context, id}, SourceOperator{move(resultSetDescriptor)},
-          aggregatesPos{move(aggregatesPos)}, aggregatesDataType{move(aggregatesDataType)} {}
+          aggregatesPos{move(aggregatesPos)}, aggregateDataTypes{move(aggregateDataTypes)} {}
 
     BaseAggregateScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        vector<DataPos> aggregatesPos, vector<DataType> aggregatesDataType,
+        vector<DataPos> aggregatesPos, vector<DataType> aggregateDataTypes,
         ExecutionContext& context, uint32_t id)
         : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
-          aggregatesPos{move(aggregatesPos)}, aggregatesDataType{move(aggregatesDataType)} {}
+          aggregatesPos{move(aggregatesPos)}, aggregateDataTypes{move(aggregateDataTypes)} {}
 
     PhysicalOperatorType getOperatorType() override { return AGGREGATE_SCAN; }
 
@@ -30,9 +33,13 @@ public:
     unique_ptr<PhysicalOperator> clone() override = 0;
 
 protected:
+    void writeAggregateResultToVector(
+        ValueVector* vector, uint64_t pos, AggregateState* aggregateState);
+
+protected:
     vector<DataPos> aggregatesPos;
-    vector<DataType> aggregatesDataType;
-    vector<ValueVector*> aggregatesVector;
+    vector<DataType> aggregateDataTypes;
+    vector<ValueVector*> aggregateVectors;
     DataChunk* outDataChunk;
 };
 

--- a/src/processor/include/physical_plan/operator/aggregate/hash_aggregate_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/hash_aggregate_scan.h
@@ -12,10 +12,10 @@ public:
     HashAggregateScan(shared_ptr<HashAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> groupByKeyVectorsPos,
         vector<DataType> groupByKeyVectorDataTypes, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregatesDataType, unique_ptr<PhysicalOperator> child,
+        vector<DataType> aggregateDataTypes, unique_ptr<PhysicalOperator> child,
         ExecutionContext& context, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregatesDataType), move(child), context, id},
+              move(aggregateDataTypes), move(child), context, id},
           groupByKeyVectorsPos{move(groupByKeyVectorsPos)},
           groupByKeyVectorDataTypes{move(groupByKeyVectorDataTypes)}, sharedState{
                                                                           move(sharedState)} {}
@@ -23,9 +23,9 @@ public:
     HashAggregateScan(shared_ptr<HashAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> groupByKeyVectorsPos,
         vector<DataType> groupByKeyVectorDataTypes, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregatesDataType, ExecutionContext& context, uint32_t id)
+        vector<DataType> aggregateDataTypes, ExecutionContext& context, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregatesDataType), context, id},
+              move(aggregateDataTypes), context, id},
           groupByKeyVectorsPos{move(groupByKeyVectorsPos)},
           groupByKeyVectorDataTypes{move(groupByKeyVectorDataTypes)}, sharedState{
                                                                           move(sharedState)} {}
@@ -36,7 +36,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<HashAggregateScan>(sharedState, resultSetDescriptor->copy(),
-            groupByKeyVectorsPos, groupByKeyVectorDataTypes, aggregatesPos, aggregatesDataType,
+            groupByKeyVectorsPos, groupByKeyVectorDataTypes, aggregatesPos, aggregateDataTypes,
             context, id);
     }
 

--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregate_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregate_scan.h
@@ -11,18 +11,18 @@ class SimpleAggregateScan : public BaseAggregateScan {
 public:
     SimpleAggregateScan(shared_ptr<SimpleAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregatesDataType, unique_ptr<PhysicalOperator> child,
+        vector<DataType> aggregateDataTypes, unique_ptr<PhysicalOperator> child,
         ExecutionContext& context, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregatesDataType), move(child), context, id},
+              move(aggregateDataTypes), move(child), context, id},
           sharedState{move(sharedState)} {}
 
     // This constructor is used for cloning only.
     SimpleAggregateScan(shared_ptr<SimpleAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregatesDataType, ExecutionContext& context, uint32_t id)
+        vector<DataType> aggregateDataTypes, ExecutionContext& context, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregatesDataType), context, id},
+              move(aggregateDataTypes), context, id},
           sharedState{move(sharedState)} {}
 
     bool getNextTuples() override;
@@ -30,7 +30,7 @@ public:
     // SimpleAggregateScan is the source operator of a pipeline, so it should not clone its child.
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<SimpleAggregateScan>(sharedState, resultSetDescriptor->copy(),
-            aggregatesPos, aggregatesDataType, context, id);
+            aggregatesPos, aggregateDataTypes, context, id);
     }
 
 private:

--- a/src/processor/physical_plan/operator/aggregate/base_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/base_aggregate_scan.cpp
@@ -7,11 +7,21 @@ shared_ptr<ResultSet> BaseAggregateScan::initResultSet() {
     resultSet = populateResultSet();
     outDataChunk = resultSet->dataChunks[aggregatesPos[0].dataChunkPos].get();
     for (auto i = 0u; i < aggregatesPos.size(); i++) {
-        auto valueVector = make_shared<ValueVector>(context.memoryManager, aggregatesDataType[i]);
+        auto valueVector = make_shared<ValueVector>(context.memoryManager, aggregateDataTypes[i]);
         outDataChunk->insert(aggregatesPos[i].valueVectorPos, valueVector);
-        aggregatesVector.push_back(valueVector.get());
+        aggregateVectors.push_back(valueVector.get());
     }
     return resultSet;
+}
+
+void BaseAggregateScan::writeAggregateResultToVector(
+    ValueVector* vector, uint64_t pos, AggregateState* aggregateState) {
+    if (aggregateState->isNull) {
+        vector->setNull(pos, true);
+    } else {
+        auto size = TypeUtils::getDataTypeSize(vector->dataType);
+        memcpy(vector->values + pos * size, aggregateState->getResult(), size);
+    }
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/aggregate/hash_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/hash_aggregate_scan.cpp
@@ -30,11 +30,10 @@ bool HashAggregateScan::getNextTuples() {
             memcpy(vector->values + pos * size, entry + offset, size);
             offset += size;
         }
-        for (auto& vector : aggregatesVector) {
-            auto size = TypeUtils::getDataTypeSize(vector->dataType);
+        for (auto& vector : aggregateVectors) {
             auto aggState = (AggregateState*)(entry + offset);
-            memcpy(vector->values + pos * size, aggState->getFinalVal(), size);
-            offset += aggState->getValSize();
+            writeAggregateResultToVector(vector, pos, aggState);
+            offset += aggState->getStateSize();
         }
     }
     outDataChunk->state->initOriginalAndSelectedSize(numRowsToScan);

--- a/src/processor/physical_plan/operator/aggregate/simple_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/simple_aggregate_scan.cpp
@@ -14,14 +14,9 @@ bool SimpleAggregateScan::getNextTuples() {
         // Output of simple aggregate is guaranteed to be a single value for each aggregate.
         assert(startOffset == endOffset);
         assert(startOffset == 0);
-        for (auto i = 0u; i < aggregatesVector.size(); i++) {
-            auto vector = aggregatesVector[i];
-            auto aggState = sharedState->getAggregateState(i);
-            memcpy(vector->values, aggState->getFinalVal(),
-                TypeUtils::getDataTypeSize(aggregatesDataType[i]));
-            if (aggState->isNull) {
-                vector->setNull(0, true);
-            }
+        for (auto i = 0u; i < aggregateVectors.size(); i++) {
+            writeAggregateResultToVector(
+                aggregateVectors[i], 0 /* position to write */, sharedState->getAggregateState(i));
         }
         outDataChunk->state->initOriginalAndSelectedSize(1);
         metrics->executionTime.stop();

--- a/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
+++ b/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
@@ -66,11 +66,11 @@ TEST_F(AggrExpressionEvaluatorTest, CountStarTest) {
     auto otherCountStarState =
         static_unique_pointer_cast<AggregateState, BaseCountFunction::CountState>(
             countFunction->createInitialNullAggregateState());
-    otherCountStarState->val = 10;
+    otherCountStarState->count = 10;
     countFunction->combineState(
         (uint8_t*)countStarState.get(), (uint8_t*)otherCountStarState.get());
     countFunction->finalizeState((uint8_t*)countStarState.get());
-    ASSERT_EQ(countStarState->val, 110);
+    ASSERT_EQ(countStarState->count, 110);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, CountTest) {
@@ -82,10 +82,10 @@ TEST_F(AggrExpressionEvaluatorTest, CountTest) {
     auto otherCountState =
         static_unique_pointer_cast<AggregateState, BaseCountFunction::CountState>(
             countFunction->createInitialNullAggregateState());
-    otherCountState->val = 10;
+    otherCountState->count = 10;
     countFunction->combineState((uint8_t*)countState.get(), (uint8_t*)otherCountState.get());
     countFunction->finalizeState((uint8_t*)countState.get());
-    ASSERT_EQ(countState->val, 60);
+    ASSERT_EQ(countState->count, 60);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, INT64SumTest) {
@@ -96,17 +96,17 @@ TEST_F(AggrExpressionEvaluatorTest, INT64SumTest) {
         (uint8_t*)sumState.get(), int64ValueVector.get(), 1 /* multiplicity */);
     auto otherSumState = static_unique_pointer_cast<AggregateState, SumFunction<int64_t>::SumState>(
         sumFunction->createInitialNullAggregateState());
-    otherSumState->val = 10;
+    otherSumState->sum = 10;
     otherSumState->isNull = false;
     sumFunction->combineState((uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
     sumFunction->finalizeState((uint8_t*)sumState.get());
-    auto sumValue = otherSumState->val;
+    auto sumValue = otherSumState->sum;
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
             sumValue += i;
         }
     }
-    ASSERT_EQ(sumState->val, sumValue);
+    ASSERT_EQ(sumState->sum, sumValue);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, DOUBLESumTest) {
@@ -118,17 +118,17 @@ TEST_F(AggrExpressionEvaluatorTest, DOUBLESumTest) {
     auto otherSumState =
         static_unique_pointer_cast<AggregateState, SumFunction<double_t>::SumState>(
             sumFunction->createInitialNullAggregateState());
-    otherSumState->val = 10.0;
+    otherSumState->sum = 10.0;
     otherSumState->isNull = false;
     sumFunction->combineState((uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
     sumFunction->finalizeState((uint8_t*)sumState.get());
-    auto sumValue = otherSumState->val;
+    auto sumValue = otherSumState->sum;
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
             sumValue += i * 1.5;
         }
     }
-    ASSERT_EQ(sumState->val, sumValue);
+    ASSERT_EQ(sumState->sum, sumValue);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, UNSTRSumTest) {
@@ -139,17 +139,17 @@ TEST_F(AggrExpressionEvaluatorTest, UNSTRSumTest) {
         (uint8_t*)sumState.get(), unStrValueVector.get(), 1 /* multiplicity */);
     auto otherSumState = static_unique_pointer_cast<AggregateState, SumFunction<Value>::SumState>(
         sumFunction->createInitialNullAggregateState());
-    otherSumState->val = Value((int64_t)10);
+    otherSumState->sum = Value((int64_t)10);
     otherSumState->isNull = false;
     sumFunction->combineState((uint8_t*)sumState.get(), (uint8_t*)otherSumState.get());
     sumFunction->finalizeState((uint8_t*)sumState.get());
-    auto sumValue = otherSumState->val.val.int64Val;
+    auto sumValue = otherSumState->sum.val.int64Val;
     for (auto i = 0u; i < 100; i++) {
         if (i % 2 != 0) {
             sumValue += i;
         }
     }
-    ASSERT_EQ(sumState->val.val.int64Val, sumValue);
+    ASSERT_EQ(sumState->sum.val.int64Val, sumValue);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, INT64AvgTest) {
@@ -160,8 +160,8 @@ TEST_F(AggrExpressionEvaluatorTest, INT64AvgTest) {
         (uint8_t*)avgState.get(), int64ValueVector.get(), 1 /* multiplicity */);
     auto otherAvgState = static_unique_pointer_cast<AggregateState, AvgFunction<int64_t>::AvgState>(
         avgFunction->createInitialNullAggregateState());
-    otherAvgState->val = 10;
-    otherAvgState->numValues = 1;
+    otherAvgState->sum = 10;
+    otherAvgState->count = 1;
     otherAvgState->isNull = false;
     avgFunction->combineState((uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
     avgFunction->finalizeState((uint8_t*)avgState.get());
@@ -171,7 +171,7 @@ TEST_F(AggrExpressionEvaluatorTest, INT64AvgTest) {
             sumValue += i;
         }
     }
-    ASSERT_EQ(avgState->val, (double_t)(sumValue) / (double_t)51);
+    ASSERT_EQ(avgState->avg, (double_t)(sumValue) / (double_t)51);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, DOUBLEAvgTest) {
@@ -183,8 +183,8 @@ TEST_F(AggrExpressionEvaluatorTest, DOUBLEAvgTest) {
     auto otherAvgState =
         static_unique_pointer_cast<AggregateState, AvgFunction<double_t>::AvgState>(
             avgFunction->createInitialNullAggregateState());
-    otherAvgState->val = 10.0;
-    otherAvgState->numValues = 1;
+    otherAvgState->sum = 10.0;
+    otherAvgState->count = 1;
     otherAvgState->isNull = false;
     avgFunction->combineState((uint8_t*)avgState.get(), (uint8_t*)otherAvgState.get());
     avgFunction->finalizeState((uint8_t*)avgState.get());
@@ -194,7 +194,7 @@ TEST_F(AggrExpressionEvaluatorTest, DOUBLEAvgTest) {
             sumValue += i * 1.5;
         }
     }
-    ASSERT_EQ(avgState->val, (double_t)(sumValue) / (double_t)51);
+    ASSERT_EQ(avgState->avg, (double_t)(sumValue) / (double_t)51);
 }
 
 TEST_F(AggrExpressionEvaluatorTest, INT64MaxTest) {

--- a/test/runner/queries/aggregate/hash_aggregate.test
+++ b/test/runner/queries/aggregate/hash_aggregate.test
@@ -9,6 +9,12 @@
 45|3|5.000000|1
 83|10|4.900000|1
 
+-NAME SingleNodeAggTest2
+-QUERY MATCH (a:person) RETURN a.unstrDateProp1, SUM(a.unstrNumericProp), COUNT(*)
+---- 2
+1900-01-01||1
+1950-01-01|99|2
+
 -NAME OneHopAggTest
 -QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.age, a.gender, COUNT(*)
 ---- 5
@@ -17,6 +23,13 @@
 30|2|3
 35|1|3
 45|1|3
+
+-NAME OneHopAggTest2
+-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.unstrNumericProp, SUM(a.unstrNumericProp2)
+---- 3
+47|60
+52|
+68.000000|
 
 -NAME TwoHopAggTest
 -QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN a.gender, COUNT(*)

--- a/test/runner/queries/aggregate/simple_aggregate.test
+++ b/test/runner/queries/aggregate/simple_aggregate.test
@@ -1,16 +1,11 @@
 # description: aggregation without groups and distinct
 
--NAME TwoHopSumTest
--QUERY MATCH (a:person)-[:knows]->(b:person) RETURN SUM(b.age), MIN(b.ID), AVG(b.eyeSight)
+-NAME SimpleAvgTest
+-QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight), AVG(a.unstrNumericProp)
 ---- 1
-455|0|4.935714
+37.250000|4.862500|55.666667
 
 -NAME SimpleCountTest
--QUERY MATCH (a:person) RETURN COUNT(a.age), COUNT(a.unstrNumericProp)
----- 1
-8|3
-
--NAME SimpleCountEvaluationTest
 -QUERY MATCH (a:person) RETURN COUNT(a.age) + 1, COUNT(a.unstrNumericProp) * 2.0
 ---- 1
 9|6.000000
@@ -20,27 +15,22 @@
 ---- 1
 298|38.900000|167.000000
 
--NAME SimpleSumWithterTest
--QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age), SUM(a.eyeSight)
----- 1
-85|14.100000
-
--NAME SimpleSumWithFilterTest2
+-NAME SimpleSumTest2
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age+10), SUM(a.age*2)
 ---- 1
 115|170
 
--NAME SimpleSumWithFilterEvaluationTest
+-NAME SimpleSumTest3
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age+10) > SUM(a.age*2)
 ---- 1
 False
 
 -NAME SimpleAvgTest
--QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight)
+-QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight), AVG(a.unstrNumericProp)
 ---- 1
-37.250000|4.862500
+37.250000|4.862500|55.666667
 
--NAME SimpleAvgWithFilterTest
+-NAME SimpleAvgTest2
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN AVG(a.age), AVG(a.eyeSight)
 ---- 1
 28.333333|4.700000
@@ -49,3 +39,8 @@ False
 -QUERY MATCH (a:person) RETURN MIN(a.age), MAX(a.age), MIN(a.isStudent), MAX(a.isStudent), MIN(a.eyeSight), MAX(a.eyeSight), MIN(a.birthdate), MAX(a.birthdate)
 ---- 1
 20|83|False|True|4.500000|5.100000|1900-01-01|1990-11-27
+
+-NAME TwoHopTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN SUM(b.age), MIN(b.ID), AVG(b.eyeSight), MAX(b.unstrNumericProp)
+---- 1
+455|0|4.935714|52

--- a/test/test_utility/test_helper.cpp
+++ b/test/test_utility/test_helper.cpp
@@ -1,6 +1,5 @@
 #include "test/test_utility/include/test_helper.h"
 
-#include <filesystem>
 #include <fstream>
 
 #include "spdlog/spdlog.h"


### PR DESCRIPTION
This PR adds group by and aggregate support on unstructured types. Changes are

## Aggregate Functions
- Add an `avg` field (which is fixed to double type) to store the result value of AVG aggregate.
- Use template type T to aggregate for SUM and AVG.

## Hash Operation
- Add hash operation for unstructured type.

## NOTE
This PR skips NULL group by keys in order to test unstructured property grouping. Once we migrate to FactorizedTable design (i.e. able to store NULL values), we should hash on NULL group by keys.