### PR TITLE
solve issues in union all frontend

### DIFF
--- a/src/binder/include/bound_queries/bound_single_query.h
+++ b/src/binder/include/bound_queries/bound_single_query.h
@@ -10,6 +10,10 @@ namespace binder {
  * Represents (QueryPart)* (Reading)* RETURN
  */
 class BoundSingleQuery {
+public:
+    inline vector<shared_ptr<Expression>> getExpressionsToReturn() {
+        return boundReturnStatement->getBoundProjectionBody()->getProjectionExpressions();
+    }
 
 public:
     // WITH query parts

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -19,6 +19,11 @@ public:
 
     shared_ptr<Expression> bindExpression(const ParsedExpression& parsedExpression);
 
+    // This function is used by queryBinder::validateUnionColumnsOfTheSameType, so it is marked
+    // as a public function.
+    static void validateExpectedDataType(
+        const Expression& expression, const unordered_set<DataType>& expectedTypes);
+
 private:
     shared_ptr<Expression> bindBinaryBooleanExpression(const ParsedExpression& parsedExpression);
 
@@ -84,8 +89,6 @@ private:
     static void validateNumberOfChildren(
         const ParsedExpression& parsedExpression, uint32_t expectedNumChildren);
 
-    static void validateExpectedDataType(
-        const Expression& expression, const unordered_set<DataType>& expectedTypes);
     static void validateNumeric(const Expression& expression) {
         validateExpectedDataType(expression, unordered_set<DataType>{INT64, DOUBLE});
     }

--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -75,6 +75,7 @@ private:
     void validateQueryGraphIsConnected(const QueryGraph& queryGraph,
         unordered_map<string, shared_ptr<Expression>> prevVariablesInScope);
     uint64_t validateAndExtractSkipLimitNumber(const ParsedExpression& skipOrLimitExpression);
+    void validateUnionColumnsOfTheSameType(const BoundRegularQuery& regularQuery);
 
     /******* helpers *********/
 

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -42,24 +42,8 @@ public:
         logicalPlan.lastOperator = logicalResultCollector;
     }
 
-    static inline void appendLogicalUnionAll(
-        vector<unique_ptr<LogicalPlan>>& childrenPlans, LogicalPlan& logicalPlan) {
-        shared_ptr<LogicalUnionAll> logicalUnionAll = make_shared<LogicalUnionAll>();
-        for (auto i = 0u; i < childrenPlans.size(); i++) {
-            if (i == 0) {
-                // For now the schema of the logical plan and logicalUnionAll is exactly the same.
-                logicalPlan.setExpressionsToCollect(
-                    ((LogicalResultCollector*)childrenPlans[i]->lastOperator.get())
-                        ->getExpressionsToCollect());
-                Enumerator::computeSchemaForHashJoinAndOrderByAndUnionAll(
-                    childrenPlans[i]->schema->getGroupsPosInScope(), *childrenPlans[i]->schema,
-                    *logicalPlan.schema);
-                logicalPlan.lastOperator = logicalUnionAll;
-            }
-            logicalUnionAll->addChild(childrenPlans[i]->lastOperator);
-        }
-        logicalUnionAll->setExpressionsToUnion(logicalPlan.getExpressionsToCollect());
-    }
+    static void appendLogicalUnionAll(
+        vector<unique_ptr<LogicalPlan>>& childrenPlans, LogicalPlan& logicalPlan);
 
     // For HashJoinProbe, the HashJoinProbe operator will read for a particular probe tuple t, the
     // matching result tuples M that match t[k], where k suppose is the join key column. If M
@@ -99,7 +83,7 @@ private:
     // return position of the only unFlat group
     // or position of any flat group if there is no unFlat group.
     uint32_t appendFlattensButOne(const unordered_set<uint32_t>& groupsPos, LogicalPlan& plan);
-    void appendFlattenIfNecessary(uint32_t groupPos, LogicalPlan& plan);
+    static void appendFlattenIfNecessary(uint32_t groupPos, LogicalPlan& plan);
     void appendFilter(const shared_ptr<Expression>& expression, LogicalPlan& plan);
     void appendScanPropertiesAndPlanSubqueryIfNecessary(
         const shared_ptr<Expression>& expression, LogicalPlan& plan);

--- a/src/planner/include/logical_plan/logical_plan.h
+++ b/src/planner/include/logical_plan/logical_plan.h
@@ -34,6 +34,12 @@ public:
     }
     inline vector<shared_ptr<Expression>> getExpressionsToCollect() { return expressionsToCollect; }
 
+    Schema* getSchema() { return schema.get(); }
+
+    unique_ptr<LogicalPlan> deepCopy() const;
+
+    // This copy function does a shallow copy of the logical Plan, so it should be renamed to
+    // shallowCopy().
     unique_ptr<LogicalPlan> copy() const;
 
 public:

--- a/src/planner/include/logical_plan/operator/result_collector/logical_result_collector.h
+++ b/src/planner/include/logical_plan/operator/result_collector/logical_result_collector.h
@@ -31,7 +31,7 @@ public:
 
     inline unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalResultCollector>(
-            expressionsToCollect, move(schema), getChild(0)->copy());
+            expressionsToCollect, schema->copy(), getChild(0)->copy());
     }
 
     inline Schema* getSchema() { return schema.get(); }

--- a/src/planner/include/planner.h
+++ b/src/planner/include/planner.h
@@ -21,6 +21,12 @@ public:
 
 private:
     static unique_ptr<LogicalPlan> optimize(unique_ptr<LogicalPlan> plan);
+
+    static unique_ptr<LogicalPlan> getLogicalPlanFromChildrenPlans(
+        vector<unique_ptr<LogicalPlan>> childrenLogicalPlans);
+
+    static vector<vector<unique_ptr<LogicalPlan>>> cartesianProductChildrenPlans(
+        vector<vector<unique_ptr<LogicalPlan>>> childrenLogicalPlans);
 };
 
 } // namespace planner

--- a/src/planner/logical_plan/logical_plan.cpp
+++ b/src/planner/logical_plan/logical_plan.cpp
@@ -17,5 +17,11 @@ unique_ptr<LogicalPlan> LogicalPlan::copy() const {
     return plan;
 }
 
+unique_ptr<LogicalPlan> LogicalPlan::deepCopy() const {
+    auto plan = this->copy();
+    plan->lastOperator = plan->lastOperator ? plan->lastOperator->copy() : plan->lastOperator;
+    return plan;
+}
+
 } // namespace planner
 } // namespace graphflow

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -211,3 +211,15 @@ TEST_F(BinderErrorTest, OrderByWithoutSkipLimitInWithClause) {
     auto input = "MATCH (a:person) WITH a.age AS k ORDER BY k RETURN k";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
+
+TEST_F(BinderErrorTest, UnionAllUnmatchedNumberOfExpressions) {
+    string expectedException = "The number of columns to union/union all must be the same.";
+    auto input = "MATCH (p:person) RETURN p.age,p.name UNION ALL MATCH (p1:person) RETURN p1.age";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, UnionAllUnmatchedDataTypesOfExpressions) {
+    string expectedException = "p1.age has data type INT64. STRING was expected.";
+    auto input = "MATCH (p:person) RETURN p.name UNION ALL MATCH (p1:person) RETURN p1.age";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}

--- a/test/runner/queries/union_all/union_all_tiny_snb.test
+++ b/test/runner/queries/union_all/union_all_tiny_snb.test
@@ -65,3 +65,105 @@
 45|5.000000
 83|4.900000
 83|4.900000
+
+# If an expression to union has different flat/unflat state in different single queries, we need to flatten that
+# expression in all the single queries.
+-NAME UnionAllFlatAndUnFlatColTest
+-QUERY MATCH (a:person)-[e:knows]->(b:person) RETURN a.age UNION ALL MATCH (a:person)-[e:knows]->(b:person) RETURN a.age UNION ALL MATCH (a:person)-[e:knows]->(b:person) RETURN a.age
+---- 42
+20
+20
+20
+20
+20
+20
+20
+20
+20
+20
+20
+20
+20
+20
+20
+30
+30
+30
+30
+30
+30
+30
+30
+30
+35
+35
+35
+35
+35
+35
+35
+35
+35
+45
+45
+45
+45
+45
+45
+45
+45
+45
+
+-NAME UnionAllWithTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) with b return b.age + 3 UNION ALL MATCH (a:person)-[e:knows]->(b:person) with a RETURN a.age
+---- 28
+20
+20
+20
+20
+20
+23
+23
+23
+28
+30
+30
+30
+33
+33
+33
+35
+35
+35
+38
+38
+38
+43
+45
+45
+45
+48
+48
+48
+
+-NAME UnionAllThreeHopsTest
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person) RETURN a.fName order by d.age desc, c.age asc, b.age asc, a.age desc limit 10 UNION ALL MATCH (p:person) RETURN p.fName
+---- 18
+Alice
+Alice
+Alice
+Bob
+Bob
+Bob
+Carol
+Carol
+Carol
+Carol
+Dan
+Dan
+Dan
+Dan
+Elizabeth
+Farooq
+Greg
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff


### PR DESCRIPTION
This PR solves the following issues:
1. Add grammar check for union all expressions:
The number/dataType of expressions to union all must be the same in each single query.
2. If an union all expression has different states in each single query, (eg. flat in the 1st single query, and unflat in the 2nd single query) we will flatten that expression in all single queries.
