### PR TITLE
refactor Orderby/HashTable/FactorizedTable to use BM

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -30,9 +30,6 @@ constexpr uint64_t DEFAULT_MEMORY_MANAGER_MAX_MEMORY = 1ull << 38;
 constexpr const uint64_t DEFAULT_MEMORY_BLOCK_SIZE = 1 << 18;
 constexpr const double DEFAULT_HT_LOAD_FACTOR = 1.5;
 
-// The number of bytes in a block of memory to store the keys of tuples.
-constexpr const uint64_t SORT_BLOCK_SIZE = 4096;
-
 // This is the default thread sleep time we use when a thread,
 // e.g., a worker thread is in TaskScheduler, needs to block.
 constexpr const uint64_t THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS = 100;

--- a/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
@@ -109,7 +109,7 @@ private:
 
     HashSlot* getHashSlot(uint64_t slotIdx) {
         assert(slotIdx < maxNumHashSlots);
-        return (HashSlot*)(hashSlotsBlocks[slotIdx / numHashSlotsPerBlock]->data +
+        return (HashSlot*)(hashSlotsBlocks[slotIdx / numHashSlotsPerBlock]->getData() +
                            slotIdx % numHashSlotsPerBlock * sizeof(uint8_t*));
     }
 

--- a/src/processor/include/physical_plan/hash_table/join_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/join_hash_table.h
@@ -20,7 +20,7 @@ public:
         hash_t hashValue;
         Hash::operation<T>(value, false /* isNull */, hashValue);
         auto slotIdx = hashValue & bitMask;
-        return (uint8_t**)(hashSlotsBlocks[slotIdx / numHashSlotsPerBlock]->data +
+        return (uint8_t**)(hashSlotsBlocks[slotIdx / numHashSlotsPerBlock]->getData() +
                            slotIdx % numHashSlotsPerBlock * sizeof(uint8_t*));
     }
 

--- a/src/processor/include/physical_plan/operator/order_by/order_by.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by.h
@@ -23,7 +23,8 @@ namespace processor {
 class SharedFactorizedTablesAndSortedKeyBlocks {
 public:
     explicit SharedFactorizedTablesAndSortedKeyBlocks()
-        : nextFactorizedTableIdx{0}, sortedKeyBlocks{make_shared<queue<shared_ptr<KeyBlock>>>()} {}
+        : nextFactorizedTableIdx{0}, sortedKeyBlocks{
+                                         make_shared<queue<shared_ptr<MergedKeyBlocks>>>()} {}
 
     uint16_t getNextFactorizedTableIdx() {
         lock_guard<mutex> lck{orderBySharedStateMutex};
@@ -41,14 +42,14 @@ public:
         factorizedTables[factorizedTableIdx] = move(factorizedTable);
     }
 
-    void appendSortedKeyBlock(shared_ptr<KeyBlock> keyBlock) {
+    void appendSortedKeyBlock(shared_ptr<MergedKeyBlocks> mergedDataBlocks) {
         lock_guard<mutex> lck{orderBySharedStateMutex};
-        sortedKeyBlocks->emplace(keyBlock);
+        sortedKeyBlocks->emplace(mergedDataBlocks);
     }
 
-    void setKeyBlockEntrySizeInBytes(uint64_t keyBlockEntrySizeInBytes) {
+    void setNumBytesPerTuple(uint64_t numBytesPerTuple) {
         lock_guard<mutex> lck{orderBySharedStateMutex};
-        this->keyBlockEntrySizeInBytes = keyBlockEntrySizeInBytes;
+        this->numBytesPerTuple = numBytesPerTuple;
     }
 
     void setStringAndUnstructuredKeyColInfo(
@@ -70,9 +71,9 @@ private:
 public:
     vector<shared_ptr<FactorizedTable>> factorizedTables;
     uint16_t nextFactorizedTableIdx;
-    shared_ptr<queue<shared_ptr<KeyBlock>>> sortedKeyBlocks;
+    shared_ptr<queue<shared_ptr<MergedKeyBlocks>>> sortedKeyBlocks;
 
-    uint64_t keyBlockEntrySizeInBytes;
+    uint64_t numBytesPerTuple;
     vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo;
     vector<DataType> dataTypes;
 };

--- a/src/processor/physical_plan/hash_table/join_hash_table.cpp
+++ b/src/processor/physical_plan/hash_table/join_hash_table.cpp
@@ -8,12 +8,11 @@ JoinHashTable::JoinHashTable(
     : BaseHashTable{memoryManager} {
     maxNumHashSlots = HashTableUtils::nextPowerOfTwo(numTuples * 2);
     bitMask = maxNumHashSlots - 1;
-    numHashSlotsPerBlock = DEFAULT_MEMORY_BLOCK_SIZE / sizeof(uint8_t*);
+    numHashSlotsPerBlock = LARGE_PAGE_SIZE / sizeof(uint8_t*);
     auto numBlocks =
         maxNumHashSlots / numHashSlotsPerBlock + (maxNumHashSlots % numHashSlotsPerBlock != 0);
     for (auto i = 0u; i < numBlocks; i++) {
-        hashSlotsBlocks.emplace_back(make_unique<DataBlock>(memoryManager.allocateOSBackedBlock(
-            DEFAULT_MEMORY_BLOCK_SIZE, true /* initialized to 0 */)));
+        hashSlotsBlocks.emplace_back(make_unique<DataBlock>(&memoryManager));
     }
     factorizedTable = make_unique<FactorizedTable>(&memoryManager, tableSchema);
 }
@@ -24,8 +23,7 @@ void JoinHashTable::allocateHashSlots(uint64_t numTuples) {
     auto numBlocksNeeded =
         maxNumHashSlots / numHashSlotsPerBlock + (maxNumHashSlots % numHashSlotsPerBlock != 0);
     while (hashSlotsBlocks.size() < numBlocksNeeded) {
-        hashSlotsBlocks.emplace_back(make_unique<DataBlock>(memoryManager.allocateOSBackedBlock(
-            DEFAULT_MEMORY_BLOCK_SIZE, true /* initialized to 0 */)));
+        hashSlotsBlocks.emplace_back(make_unique<DataBlock>(&memoryManager));
     }
 }
 

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -59,8 +59,8 @@ void HashJoinBuild::finalize() {
     hashTable->allocateHashSlots(factorizedTable->getNumTuples());
     auto& tableSchema = factorizedTable->getTableSchema();
     for (auto& tupleBlock : factorizedTable->getTupleDataBlocks()) {
-        uint8_t* tuple = tupleBlock.data;
-        for (auto i = 0u; i < tupleBlock.numEntries; i++) {
+        uint8_t* tuple = tupleBlock->getData();
+        for (auto i = 0u; i < tupleBlock->numTuples; i++) {
             auto lastSlotEntryInHT = hashTable->insertEntry<nodeID_t>(tuple);
             auto prevPtr = (uint8_t**)(tuple + tableSchema.getNullMapOffset() - sizeof(uint8_t*));
             memcpy((uint8_t*)prevPtr, &lastSlotEntryInHT, sizeof(uint8_t*));

--- a/src/processor/physical_plan/operator/order_by/order_by_merge.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_merge.cpp
@@ -11,7 +11,7 @@ shared_ptr<ResultSet> OrderByMerge::initResultSet() {
     keyBlockMerger =
         make_unique<KeyBlockMerger>(sharedFactorizedTablesAndSortedKeyBlocks->factorizedTables,
             sharedFactorizedTablesAndSortedKeyBlocks->stringAndUnstructuredKeyColInfo,
-            sharedFactorizedTablesAndSortedKeyBlocks->keyBlockEntrySizeInBytes);
+            sharedFactorizedTablesAndSortedKeyBlocks->numBytesPerTuple);
     return resultSet;
 }
 
@@ -20,7 +20,7 @@ void OrderByMerge::execute() {
         sharedFactorizedTablesAndSortedKeyBlocks->sortedKeyBlocks,
         sharedFactorizedTablesAndSortedKeyBlocks->factorizedTables,
         sharedFactorizedTablesAndSortedKeyBlocks->stringAndUnstructuredKeyColInfo,
-        sharedFactorizedTablesAndSortedKeyBlocks->keyBlockEntrySizeInBytes);
+        sharedFactorizedTablesAndSortedKeyBlocks->numBytesPerTuple);
     metrics->executionTime.start();
     Sink::execute();
     while (!keyBlockMergeTaskDispatcher->isDoneMerge()) {

--- a/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
@@ -5,8 +5,7 @@ namespace processor {
 
 pair<uint64_t, uint64_t> OrderByScan::getNextFactorizedTableIdxAndTupleIdxPair() {
     auto tupleInfoBuffer =
-        sharedState->sortedKeyBlocks->front()->getMemBlockData() +
-        (nextTupleIdxToReadInMemBlock + 1) * sharedState->keyBlockEntrySizeInBytes -
+        sharedState->sortedKeyBlocks->front()->getTuple(nextTupleIdxToReadInMemBlock + 1) -
         sizeof(uint64_t);
     uint16_t factorizedTableIdx = OrderByKeyEncoder::getEncodedFactorizedTableIdx(tupleInfoBuffer);
     uint64_t tupleIdx = OrderByKeyEncoder::getEncodedTupleIdx(tupleInfoBuffer);
@@ -29,7 +28,7 @@ shared_ptr<ResultSet> OrderByScan::initResultSet() {
 
 bool OrderByScan::getNextTuples() {
     metrics->executionTime.start();
-    auto numTuplesInMemBlock = sharedState->sortedKeyBlocks->front()->numEntriesInMemBlock;
+    auto numTuplesInMemBlock = sharedState->sortedKeyBlocks->front()->getNumTuples();
     // If there is no more tuples to read, just return false.
     if (nextTupleIdxToReadInMemBlock >= numTuplesInMemBlock) {
         metrics->executionTime.stop();

--- a/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
@@ -122,9 +122,8 @@ public:
             stringAndUnstructuredKeyColInfo);
         sortAllKeyBlocks(orderByKeyEncoder, radixSort);
 
-        checkTupleIdxesAndFactorizedTableIdxes(
-            orderByKeyEncoder.getKeyBlocks()[0]->getMemBlockData(),
-            orderByKeyEncoder.getKeyBlockEntrySizeInBytes(), expectedTupleIdxOrder);
+        checkTupleIdxesAndFactorizedTableIdxes(orderByKeyEncoder.getKeyBlocks()[0]->getData(),
+            orderByKeyEncoder.getNumBytesPerTuple(), expectedTupleIdxOrder);
     }
 
     void multipleOrderByColSolveTieTest(vector<bool>& isAscOrder,
@@ -163,9 +162,8 @@ public:
             stringAndUnstructuredKeyColInfo);
         sortAllKeyBlocks(orderByKeyEncoder, radixSort);
 
-        checkTupleIdxesAndFactorizedTableIdxes(
-            orderByKeyEncoder.getKeyBlocks()[0]->getMemBlockData(),
-            orderByKeyEncoder.getKeyBlockEntrySizeInBytes(), expectedTupleIdxOrder);
+        checkTupleIdxesAndFactorizedTableIdxes(orderByKeyEncoder.getKeyBlocks()[0]->getData(),
+            orderByKeyEncoder.getNumBytesPerTuple(), expectedTupleIdxOrder);
     }
 };
 
@@ -450,8 +448,8 @@ TEST_F(RadixSortTest, multipleOrderByColNoTieTest) {
     sortAllKeyBlocks(orderByKeyEncoder, radixSort);
 
     vector<uint64_t> expectedTupleIdxOrder = {1, 4, 0, 2, 3};
-    checkTupleIdxesAndFactorizedTableIdxes(orderByKeyEncoder.getKeyBlocks()[0]->getMemBlockData(),
-        orderByKeyEncoder.getKeyBlockEntrySizeInBytes(), expectedTupleIdxOrder);
+    checkTupleIdxesAndFactorizedTableIdxes(orderByKeyEncoder.getKeyBlocks()[0]->getData(),
+        orderByKeyEncoder.getNumBytesPerTuple(), expectedTupleIdxOrder);
 }
 
 TEST_F(RadixSortTest, multipleOrderByColSolvableTieTest) {

--- a/test/processor/processor_test.cpp
+++ b/test/processor/processor_test.cpp
@@ -1,5 +1,6 @@
 #include "gtest/gtest.h"
 
+#include "src/common/include/configs.h"
 #include "src/processor/include/physical_plan/operator/result_collector.h"
 #include "src/processor/include/physical_plan/operator/scan_node_id.h"
 #include "src/processor/include/processor.h"
@@ -25,7 +26,9 @@ TEST(ProcessorTests, MultiThreadedScanTest) {
     unique_ptr<Graph> graph = make_unique<GraphStub>();
     auto sharedState = make_shared<ScanNodeIDSharedState>(1025013 /*numNodes*/);
     auto profiler = make_unique<Profiler>();
-    auto bufferManager = make_unique<BufferManager>();
+    auto bufferManager =
+        make_unique<BufferManager>(512 * DEFAULT_PAGE_SIZE /* maxSizeForDefaultPagePool */,
+            1ull << 25 /* maxSizeForLargePagePool */);
     auto memoryManager = make_unique<MemoryManager>(bufferManager.get());
     auto executionContext = ExecutionContext(*profiler, memoryManager.get(), bufferManager.get());
     auto schema = Schema();

--- a/test/runner/order_by_end_to_end_test.cpp
+++ b/test/runner/order_by_end_to_end_test.cpp
@@ -9,6 +9,12 @@ using namespace graphflow::testing;
 class OrderByTests : public DBLoadedTest {
 public:
     string getInputCSVDir() override { return "dataset/order-by-tests/"; }
+
+    void SetUp() override {
+        BaseGraphLoadingTest::SetUp();
+        testSuiteSystemConfig.largePageBufferPoolSize = (1ull << 22);
+        defaultSystem = TestHelper::getInitializedSystem(testSuiteSystemConfig);
+    }
 };
 
 TEST_F(OrderByTests, OrderByLargeDatasetTest) {

--- a/test/runner/tinysnb_end_to_end_test.cpp
+++ b/test/runner/tinysnb_end_to_end_test.cpp
@@ -9,6 +9,12 @@ using namespace graphflow::testing;
 class TinySnbProcessorTest : public DBLoadedTest {
 public:
     string getInputCSVDir() override { return "dataset/tinysnb/"; }
+
+    void SetUp() override {
+        BaseGraphLoadingTest::SetUp();
+        testSuiteSystemConfig.largePageBufferPoolSize = (1ull << 22);
+        defaultSystem = TestHelper::getInitializedSystem(testSuiteSystemConfig);
+    }
 };
 
 TEST_F(TinySnbProcessorTest, StructuralQueries) {

--- a/test/test_utility/include/test_helper.h
+++ b/test/test_utility/include/test_helper.h
@@ -19,6 +19,8 @@ struct TestSuiteSystemConfig {
     string graphOutputDir;
     uint64_t maxNumThreads = 4;
     bool isInMemory = false;
+    uint64_t defaultPageBufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE;
+    uint64_t largePageBufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE;
 };
 
 struct TestQueryConfig {
@@ -40,7 +42,9 @@ public:
     static void loadGraph(TestSuiteSystemConfig& config);
 
     static unique_ptr<System> getInitializedSystem(TestSuiteSystemConfig& config) {
-        return make_unique<System>(config.graphOutputDir, SystemConfig(config.isInMemory));
+        return make_unique<System>(
+            config.graphOutputDir, SystemConfig(config.isInMemory, config.defaultPageBufferPoolSize,
+                                       config.largePageBufferPoolSize));
     }
 
     static vector<string> getActualOutput(


### PR DESCRIPTION
1. This PR adds a DataBlock structure to hold a BMAllocatedBlock. This structure will allocate and hold a BMAllocatedBlock when constructed, and free the BMAllocatedBlock when destructed.
2. This PR refactors Orderby/HashTable/FactorizedTable to use BM. #494
