### PR TITLE
Add boolean executor

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -49,6 +49,7 @@ cc_library(
     ],
     hdrs = [
         "include/vector/operations/executors/binary_operation_executor.h",
+        "include/vector/operations/executors/boolean_operation_executor.h",
         "include/vector/operations/executors/unary_operation_executor.h",
         "include/vector/operations/vector_arithmetic_operations.h",
         "include/vector/operations/vector_boolean_operations.h",

--- a/src/common/include/vector/operations/executors/binary_operation_executor.h
+++ b/src/common/include/vector/operations/executors/binary_operation_executor.h
@@ -10,11 +10,11 @@ namespace common {
 
 struct BinaryOperationExecutor {
 
-    template<typename A, typename B, typename R>
-    static void allocateStringIfNecessary(A& lValue, B& rValue, R& resultVal, ValueVector& lVec,
-        ValueVector& rVec, ValueVector& resultVec) {
-        assert((is_same<R, Value>::value) || (is_same<R, gf_string_t>::value));
-        if constexpr ((is_same<R, Value>::value)) {
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE>
+    static void allocateStringIfNecessary(LEFT_TYPE& lValue, RIGHT_TYPE& rValue,
+        RESULT_TYPE& resultVal, ValueVector& lVec, ValueVector& rVec, ValueVector& resultVec) {
+        assert((is_same<RESULT_TYPE, Value>::value) || (is_same<RESULT_TYPE, gf_string_t>::value));
+        if constexpr ((is_same<RESULT_TYPE, Value>::value)) {
             resultVec.allocateStringOverflowSpaceIfNecessary(
                 resultVal.val.strVal, lValue.toString().length() + rValue.toString().length());
         } else {
@@ -22,275 +22,267 @@ struct BinaryOperationExecutor {
         }
     }
 
-    template<typename A, typename B, typename R, typename FUNC>
-    static void executeOnTuple(ValueVector& left, ValueVector& right, ValueVector& result,
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void executeOnValue(ValueVector& left, ValueVector& right, ValueVector& result,
         uint64_t lPos, uint64_t rPos, uint64_t resPos) {
-        auto resValues = (R*)result.values;
-        if constexpr ((is_same<A, nodeID_t>::value) && (is_same<B, nodeID_t>::value)) {
-            nodeID_t lNodeID{}, rNodeID{};
-            left.readNodeID(lPos, lNodeID);
-            right.readNodeID(rPos, rNodeID);
-            FUNC::operation(lNodeID, rNodeID, resValues[resPos], (bool)left.isNull(lPos),
-                (bool)right.isNull(rPos));
-        } else {
-            auto lValues = (A*)left.values;
-            auto rValues = (B*)right.values;
-            if constexpr ((is_same<R, gf_string_t>::value) || (is_same<R, Value>::value)) {
-                allocateStringIfNecessary<A, B, R>(
-                    lValues[lPos], rValues[rPos], resValues[resPos], left, right, result);
-            }
-            FUNC::operation(lValues[lPos], rValues[rPos], resValues[resPos],
-                (bool)left.isNull(lPos), (bool)right.isNull(rPos));
+        auto lValues = (LEFT_TYPE*)left.values;
+        auto rValues = (RIGHT_TYPE*)right.values;
+        auto resValues = (RESULT_TYPE*)result.values;
+        if constexpr ((is_same<RESULT_TYPE, gf_string_t>::value) ||
+                      (is_same<RESULT_TYPE, Value>::value)) {
+            allocateStringIfNecessary<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
+                lValues[lPos], rValues[rPos], resValues[resPos], left, right, result);
         }
+        FUNC::operation(lValues[lPos], rValues[rPos], resValues[resPos], (bool)left.isNull(lPos),
+            (bool)right.isNull(rPos));
     }
 
-    template<typename A, typename B, typename R, typename FUNC, bool IS_BOOL_OP>
-    static void executeForLeftAndRightAreFlat(
-        ValueVector& left, ValueVector& right, ValueVector& result) {
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void executeBothFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
         auto lPos = left.state->getPositionOfCurrIdx();
         auto rPos = right.state->getPositionOfCurrIdx();
         auto resPos = result.state->getPositionOfCurrIdx();
-        if constexpr (!IS_BOOL_OP) {
-            result.setNull(resPos, left.isNull(lPos) || right.isNull(rPos));
-            if (!result.isNull(resPos)) {
-                executeOnTuple<A, B, R, FUNC>(left, right, result, lPos, rPos, resPos);
-            }
-        } else /* IS_BOOL_OP = true */ {
-            executeOnTuple<A, B, R, FUNC>(left, right, result, lPos, rPos, resPos);
-            result.setNull(resPos, result.values[resPos] == operation::NULL_BOOL);
+        result.setNull(resPos, left.isNull(lPos) || right.isNull(rPos));
+        if (!result.isNull(resPos)) {
+            executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                left, right, result, lPos, rPos, resPos);
         }
     }
 
-    template<typename A, typename B, typename R, typename FUNC, bool IS_BOOL_OP>
-    static void executeForLeftOrRightIsFlat(
-        ValueVector& left, ValueVector& right, ValueVector& result) {
-        auto& flatVec = left.state->isFlat() ? left : right;
-        auto& unFlatVec = left.state->isFlat() ? right : left;
-        auto flatPos = flatVec.state->getPositionOfCurrIdx();
-        auto isFlatNull = flatVec.isNull(flatPos);
-        auto isLeftFlat = left.state->isFlat();
-        if constexpr (!IS_BOOL_OP) {
-            if (isFlatNull) {
-                unFlatVec.setAllNull();
-            } else if (unFlatVec.hasNoNullsGuarantee()) {
-                if (unFlatVec.state->isUnfiltered()) {
-                    for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                        executeOnTuple<A, B, R, FUNC>(left, right, result, isLeftFlat ? flatPos : i,
-                            isLeftFlat ? i : flatPos, i);
-                    }
-                } else {
-                    for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                        auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                        executeOnTuple<A, B, R, FUNC>(left, right, result,
-                            isLeftFlat ? flatPos : unFlatPos, isLeftFlat ? unFlatPos : flatPos,
-                            unFlatPos);
-                    }
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void executeFlatUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        auto lPos = left.state->getPositionOfCurrIdx();
+        if (left.isNull(lPos)) {
+            right.setAllNull();
+        } else if (right.hasNoNullsGuarantee()) {
+            if (right.state->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                        left, right, result, lPos, i, i);
                 }
             } else {
-                if (unFlatVec.state->isUnfiltered()) {
-                    for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                        result.setNull(i, unFlatVec.isNull(i)); // isFlatNull is always false.
-                        if (!result.isNull(i)) {
-                            executeOnTuple<A, B, R, FUNC>(left, right, result,
-                                isLeftFlat ? flatPos : i, isLeftFlat ? i : flatPos, i);
-                        }
-                    }
-                } else {
-                    for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                        auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                        result.setNull(
-                            unFlatPos, unFlatVec.isNull(unFlatPos)); // isFlatNull is always false.
-                        if (!result.isNull(unFlatPos)) {
-                            executeOnTuple<A, B, R, FUNC>(left, right, result,
-                                isLeftFlat ? flatPos : unFlatPos, isLeftFlat ? unFlatPos : flatPos,
-                                unFlatPos);
-                        }
-                    }
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    auto rPos = right.state->selectedPositions[i];
+                    executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                        left, right, result, lPos, rPos, rPos);
                 }
             }
-        } else /* IS_BOOL_OP = true */ {
-            if (unFlatVec.state->isUnfiltered()) {
-                for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                    executeOnTuple<A, B, R, FUNC>(
-                        left, right, result, isLeftFlat ? flatPos : i, isLeftFlat ? i : flatPos, i);
-                    result.setNull(i, result.values[i] == operation::NULL_BOOL);
+        } else {
+            if (right.state->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    result.setNull(i, right.isNull(i)); // left is always not null
+                    if (!result.isNull(i)) {
+                        executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                            left, right, result, lPos, i, i);
+                    }
                 }
             } else {
-                for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                    auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                    executeOnTuple<A, B, R, FUNC>(left, right, result,
-                        isLeftFlat ? flatPos : unFlatPos, isLeftFlat ? unFlatPos : flatPos,
-                        unFlatPos);
-                    result.setNull(unFlatPos, result.values[unFlatPos] == operation::NULL_BOOL);
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    auto rPos = right.state->selectedPositions[i];
+                    result.setNull(rPos, right.isNull(rPos)); // left is always not null
+                    if (!result.isNull(rPos)) {
+                        executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                            left, right, result, lPos, rPos, rPos);
+                    }
                 }
             }
         }
     }
 
-    template<typename A, typename B, typename R, typename FUNC, bool IS_BOOL_OP>
-    static void executeForLeftAndRightAreUnFlat(
-        ValueVector& left, ValueVector& right, ValueVector& result) {
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void executeUnFlatFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        auto rPos = right.state->getPositionOfCurrIdx();
+        if (right.isNull(rPos)) {
+            left.setAllNull();
+        } else if (left.hasNoNullsGuarantee()) {
+            if (left.state->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                        left, right, result, i, rPos, i);
+                }
+            } else {
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    auto lPos = left.state->selectedPositions[i];
+                    executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                        left, right, result, lPos, rPos, lPos);
+                }
+            }
+        } else {
+            if (left.state->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    result.setNull(i, left.isNull(i)); // right is always not null
+                    if (!result.isNull(i)) {
+                        executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                            left, right, result, i, rPos, i);
+                    }
+                }
+            } else {
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    auto lPos = left.state->selectedPositions[i];
+                    result.setNull(lPos, left.isNull(lPos)); // right is always not null
+                    if (!result.isNull(lPos)) {
+                        executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                            left, right, result, lPos, rPos, lPos);
+                    }
+                }
+            }
+        }
+    }
+
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void executeBothUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
         // right, left, and result vectors share the same selectedPositions.
-        if constexpr (!IS_BOOL_OP) {
-            if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
-                if (result.state->isUnfiltered()) {
-                    for (uint64_t i = 0; i < result.state->selectedSize; i++) {
-                        executeOnTuple<A, B, R, FUNC>(left, right, result, i, i, i);
-                    }
-                } else {
-                    for (uint64_t i = 0; i < result.state->selectedSize; i++) {
-                        auto pos = result.state->selectedPositions[i];
-                        executeOnTuple<A, B, R, FUNC>(left, right, result, pos, pos, pos);
-                    }
-                }
-            } else {
-                if (result.state->isUnfiltered()) {
-                    for (uint64_t i = 0; i < result.state->selectedSize; i++) {
-                        result.setNull(i, left.isNull(i) || right.isNull(i));
-                        if (!result.isNull(i)) {
-                            executeOnTuple<A, B, R, FUNC>(left, right, result, i, i, i);
-                        }
-                    }
-                } else {
-                    for (uint64_t i = 0; i < result.state->selectedSize; i++) {
-                        auto pos = result.state->selectedPositions[i];
-                        result.setNull(pos, left.isNull(pos) || right.isNull(pos));
-                        if (!result.isNull(pos)) {
-                            executeOnTuple<A, B, R, FUNC>(left, right, result, pos, pos, pos);
-                        }
-                    }
-                }
-            }
-        } else /* IS_BOOL_OP = true */ {
+        if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
             if (result.state->isUnfiltered()) {
                 for (uint64_t i = 0; i < result.state->selectedSize; i++) {
-                    executeOnTuple<A, B, R, FUNC>(left, right, result, i, i, i);
-                    result.setNull(i, result.values[i] == operation::NULL_BOOL);
+                    executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                        left, right, result, i, i, i);
                 }
             } else {
                 for (uint64_t i = 0; i < result.state->selectedSize; i++) {
                     auto pos = result.state->selectedPositions[i];
-                    executeOnTuple<A, B, R, FUNC>(left, right, result, pos, pos, pos);
-                    result.setNull(pos, result.values[pos] == operation::NULL_BOOL);
+                    executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                        left, right, result, pos, pos, pos);
+                }
+            }
+        } else {
+            if (result.state->isUnfiltered()) {
+                for (uint64_t i = 0; i < result.state->selectedSize; i++) {
+                    result.setNull(i, left.isNull(i) || right.isNull(i));
+                    if (!result.isNull(i)) {
+                        executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                            left, right, result, i, i, i);
+                    }
+                }
+            } else {
+                for (uint64_t i = 0; i < result.state->selectedSize; i++) {
+                    auto pos = result.state->selectedPositions[i];
+                    result.setNull(pos, left.isNull(pos) || right.isNull(pos));
+                    if (!result.isNull(pos)) {
+                        executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+                            left, right, result, pos, pos, pos);
+                    }
                 }
             }
         }
     }
 
-    template<typename A, typename B, typename R, typename FUNC, bool IS_BOOL_OP = false>
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
     static void execute(ValueVector& left, ValueVector& right, ValueVector& result) {
-        assert(!IS_BOOL_OP || (IS_BOOL_OP && (is_same<A, bool>::value) &&
-                                  (is_same<B, bool>::value) && (is_same<R, uint8_t>::value)));
         result.resetStringBuffer();
         if (left.state->isFlat() && right.state->isFlat()) {
-            executeForLeftAndRightAreFlat<A, B, R, FUNC, IS_BOOL_OP>(left, right, result);
-        } else if (left.state->isFlat() || right.state->isFlat()) {
-            executeForLeftOrRightIsFlat<A, B, R, FUNC, IS_BOOL_OP>(left, right, result);
+            executeBothFlat<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(left, right, result);
+        } else if (left.state->isFlat() && !right.state->isFlat()) {
+            executeFlatUnFlat<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(left, right, result);
+        } else if (!left.state->isFlat() && right.state->isFlat()) {
+            executeUnFlatFlat<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(left, right, result);
         } else {
-            executeForLeftAndRightAreUnFlat<A, B, R, FUNC, IS_BOOL_OP>(left, right, result);
+            executeBothUnFlat<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(left, right, result);
         }
     }
 
-    // By default, UPDATE_SELECTED_POSITIONS is set to true. It is set to false only when both left
-    // and right are flat, in that case, we are not supposed to update the selectedPositions.
-    template<class A, class B, class R, class FUNC, bool UPDATE_SELECTED_POSITIONS = true>
-    static void selectOnTuple(ValueVector& left, ValueVector& right, uint64_t lPos, uint64_t rPos,
+    template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
+    static void selectOnValue(ValueVector& left, ValueVector& right, uint64_t lPos, uint64_t rPos,
         uint64_t resPos, uint64_t& numSelectedValues, sel_t* selectedPositions) {
+        auto lValues = (LEFT_TYPE*)left.values;
+        auto rValues = (RIGHT_TYPE*)right.values;
         uint8_t resultValue = 0;
-        if constexpr ((is_same<A, nodeID_t>::value) && (is_same<B, nodeID_t>::value)) {
-            nodeID_t lNodeID{}, rNodeID{};
-            left.readNodeID(lPos, lNodeID);
-            right.readNodeID(rPos, rNodeID);
-            FUNC::operation(
-                lNodeID, rNodeID, resultValue, (bool)left.isNull(lPos), (bool)right.isNull(rPos));
-        } else {
-            auto lValues = (A*)left.values;
-            auto rValues = (B*)right.values;
-            FUNC::operation(lValues[lPos], rValues[rPos], resultValue, (bool)left.isNull(lPos),
-                (bool)right.isNull(rPos));
-        }
-        if constexpr (UPDATE_SELECTED_POSITIONS) {
-            assert(selectedPositions);
-            selectedPositions[numSelectedValues] = resPos;
-        }
+        FUNC::operation(lValues[lPos], rValues[rPos], resultValue, (bool)left.isNull(lPos),
+            (bool)right.isNull(rPos));
+        selectedPositions[numSelectedValues] = resPos;
         numSelectedValues += (resultValue == true);
     }
 
-    template<class A, class B, class R, class FUNC, bool IS_BOOL_OP>
-    static uint64_t selectForLeftAndRightAreFlat(ValueVector& left, ValueVector& right) {
+    template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
+    static uint64_t selectBothFlat(ValueVector& left, ValueVector& right) {
         auto lPos = left.state->getPositionOfCurrIdx();
         auto rPos = right.state->getPositionOfCurrIdx();
+        auto lValues = (LEFT_TYPE*)left.values;
+        auto rValues = (RIGHT_TYPE*)right.values;
+        uint8_t resultValue = 0;
+        if (!left.isNull(lPos) && !right.isNull(rPos)) {
+            FUNC::operation(lValues[lPos], rValues[rPos], resultValue, (bool)left.isNull(lPos),
+                (bool)right.isNull(rPos));
+        }
+        return resultValue == true;
+    }
+
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
+    static uint64_t selectFlatUnFlat(
+        ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+        auto lPos = left.state->getPositionOfCurrIdx();
         uint64_t numSelectedValues = 0;
-        if constexpr (!IS_BOOL_OP) {
-            if (!left.isNull(lPos) && !right.isNull(rPos)) {
-                selectOnTuple<A, B, R, FUNC, false /* UPDATE_SELECTED_POSITIONS */>(
-                    left, right, lPos, rPos, 0 /* resPos */, numSelectedValues, nullptr);
+        if (left.isNull(lPos)) {
+            return numSelectedValues;
+        } else if (right.hasNoNullsGuarantee()) {
+            if (right.state->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                        left, right, lPos, i, i, numSelectedValues, selectedPositions);
+                }
+            } else {
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    auto rPos = right.state->selectedPositions[i];
+                    selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                        left, right, lPos, rPos, rPos, numSelectedValues, selectedPositions);
+                }
             }
-        } else /* IS_BOOL_OP = true */ {
-            selectOnTuple<A, B, R, FUNC, false /* UPDATE_SELECTED_POSITIONS */>(
-                left, right, lPos, rPos, 0 /* resPos */, numSelectedValues, nullptr);
+        } else {
+            if (right.state->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    if (!right.isNull(i)) {
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                            left, right, lPos, i, i, numSelectedValues, selectedPositions);
+                    }
+                }
+            } else {
+                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                    auto rPos = right.state->selectedPositions[i];
+                    if (!right.isNull(rPos)) {
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                            left, right, lPos, rPos, rPos, numSelectedValues, selectedPositions);
+                    }
+                }
+            }
         }
         return numSelectedValues;
     }
 
-    template<class A, class B, class R, class FUNC, bool IS_BOOL_OP>
-    static uint64_t selectForLeftOrRightIsFlat(
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
+    static uint64_t selectUnFlatFlat(
         ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
-        auto& flatVec = left.state->isFlat() ? left : right;
-        auto& unFlatVec = left.state->isFlat() ? right : left;
-        auto flatPos = flatVec.state->getPositionOfCurrIdx();
-        auto isFlatNull = flatVec.isNull(flatPos);
-        auto isLeftFlat = left.state->isFlat();
+        auto rPos = right.state->getPositionOfCurrIdx();
         uint64_t numSelectedValues = 0;
-        if constexpr (!IS_BOOL_OP) {
-            if (isFlatNull) {
-                // Do nothing here: numSelectedValues = 0;
-            } else if (unFlatVec.hasNoNullsGuarantee()) {
-                // right and result vectors share the same selectedPositions.
-                if (unFlatVec.state->isUnfiltered()) {
-                    for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                        selectOnTuple<A, B, R, FUNC>(left, right, isLeftFlat ? flatPos : i,
-                            isLeftFlat ? i : flatPos, i, numSelectedValues, selectedPositions);
-                    }
-                } else {
-                    for (auto i = 0u; i < unFlatVec.state->selectedSize; i++) {
-                        auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                        selectOnTuple<A, B, R, FUNC>(left, right, isLeftFlat ? flatPos : unFlatPos,
-                            isLeftFlat ? unFlatPos : flatPos, unFlatPos, numSelectedValues,
-                            selectedPositions);
-                    }
+        if (right.isNull(rPos)) {
+            return numSelectedValues;
+        } else if (left.hasNoNullsGuarantee()) {
+            if (left.state->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                        left, right, i, rPos, i, numSelectedValues, selectedPositions);
                 }
             } else {
-                if (unFlatVec.state->isUnfiltered()) {
-                    for (uint64_t i = 0; i < unFlatVec.state->selectedSize; i++) {
-                        if (!unFlatVec.isNull(i)) {
-                            selectOnTuple<A, B, R, FUNC>(left, right, isLeftFlat ? flatPos : i,
-                                isLeftFlat ? i : flatPos, i, numSelectedValues, selectedPositions);
-                        }
-                    }
-                } else {
-                    for (uint64_t i = 0; i < unFlatVec.state->selectedSize; i++) {
-                        auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                        if (!unFlatVec.isNull(unFlatPos)) {
-                            selectOnTuple<A, B, R, FUNC>(left, right,
-                                isLeftFlat ? flatPos : unFlatPos, isLeftFlat ? unFlatPos : flatPos,
-                                unFlatPos, numSelectedValues, selectedPositions);
-                        }
-                    }
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    auto lPos = left.state->selectedPositions[i];
+                    selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                        left, right, lPos, rPos, lPos, numSelectedValues, selectedPositions);
                 }
             }
-        } else /* IS_BOOL_OP = true */ {
-            if (unFlatVec.state->isUnfiltered()) {
-                for (uint64_t i = 0; i < unFlatVec.state->selectedSize; i++) {
-                    selectOnTuple<A, B, R, FUNC>(left, right, isLeftFlat ? flatPos : i,
-                        isLeftFlat ? i : flatPos, i, numSelectedValues, selectedPositions);
+        } else {
+            if (left.state->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    if (!left.isNull(i)) {
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                            left, right, i, rPos, i, numSelectedValues, selectedPositions);
+                    }
                 }
             } else {
-                for (uint64_t i = 0; i < unFlatVec.state->selectedSize; i++) {
-                    auto unFlatPos = unFlatVec.state->selectedPositions[i];
-                    selectOnTuple<A, B, R, FUNC>(left, right, isLeftFlat ? flatPos : unFlatPos,
-                        isLeftFlat ? unFlatPos : flatPos, unFlatPos, numSelectedValues,
-                        selectedPositions);
+                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                    auto lPos = left.state->selectedPositions[i];
+                    if (!left.isNull(lPos)) {
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                            left, right, lPos, rPos, lPos, numSelectedValues, selectedPositions);
+                    }
                 }
             }
         }
@@ -298,55 +290,40 @@ struct BinaryOperationExecutor {
     }
 
     // Right, left, and result vectors share the same selectedPositions.
-    template<class A, class B, class R, class FUNC, bool IS_BOOL_OP = false>
-    static uint64_t selectForLeftAndRightAreUnFlat(
+    template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
+    static uint64_t selectBothUnFlat(
         ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
         uint64_t numSelectedValues = 0;
-        if constexpr (!IS_BOOL_OP) {
-            if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
-                if (left.state->isUnfiltered()) {
-                    for (auto i = 0u; i < left.state->selectedSize; i++) {
-                        selectOnTuple<A, B, R, FUNC>(
-                            left, right, i, i, i, numSelectedValues, selectedPositions);
-                    }
-                } else {
-                    for (auto i = 0u; i < left.state->selectedSize; i++) {
-                        auto pos = left.state->selectedPositions[i];
-                        selectOnTuple<A, B, R, FUNC>(
-                            left, right, pos, pos, pos, numSelectedValues, selectedPositions);
-                    }
-                }
-            } else {
-                if (left.state->isUnfiltered()) {
-                    for (uint64_t i = 0; i < left.state->selectedSize; i++) {
-                        auto isNull = left.isNull(i) || right.isNull(i);
-                        if (!isNull) {
-                            selectOnTuple<A, B, R, FUNC>(
-                                left, right, i, i, i, numSelectedValues, selectedPositions);
-                        }
-                    }
-                } else {
-                    for (uint64_t i = 0; i < left.state->selectedSize; i++) {
-                        auto pos = left.state->selectedPositions[i];
-                        auto isNull = left.isNull(pos) || right.isNull(pos);
-                        if (!isNull) {
-                            selectOnTuple<A, B, R, FUNC>(
-                                left, right, pos, pos, pos, numSelectedValues, selectedPositions);
-                        }
-                    }
-                }
-            }
-        } else /* IS_BOOL_OP = true */ {
+        if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
             if (left.state->isUnfiltered()) {
                 for (auto i = 0u; i < left.state->selectedSize; i++) {
-                    selectOnTuple<A, B, R, FUNC>(
+                    selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
                         left, right, i, i, i, numSelectedValues, selectedPositions);
                 }
             } else {
                 for (auto i = 0u; i < left.state->selectedSize; i++) {
                     auto pos = left.state->selectedPositions[i];
-                    selectOnTuple<A, B, R, FUNC>(
+                    selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
                         left, right, pos, pos, pos, numSelectedValues, selectedPositions);
+                }
+            }
+        } else {
+            if (left.state->isUnfiltered()) {
+                for (uint64_t i = 0; i < left.state->selectedSize; i++) {
+                    auto isNull = left.isNull(i) || right.isNull(i);
+                    if (!isNull) {
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                            left, right, i, i, i, numSelectedValues, selectedPositions);
+                    }
+                }
+            } else {
+                for (uint64_t i = 0; i < left.state->selectedSize; i++) {
+                    auto pos = left.state->selectedPositions[i];
+                    auto isNull = left.isNull(pos) || right.isNull(pos);
+                    if (!isNull) {
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+                            left, right, pos, pos, pos, numSelectedValues, selectedPositions);
+                    }
                 }
             }
         }
@@ -354,16 +331,16 @@ struct BinaryOperationExecutor {
     }
 
     // COMPARISON (GT, GTE, LT, LTE, EQ, NEQ), BOOLEAN (AND, OR, XOR)
-    template<class A, class B, class R, class FUNC, bool IS_BOOL_OP = false>
+    template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
     static uint64_t select(ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
         if (left.state->isFlat() && right.state->isFlat()) {
-            return selectForLeftAndRightAreFlat<A, B, R, FUNC, IS_BOOL_OP>(left, right);
-        } else if (left.state->isFlat() || right.state->isFlat()) {
-            return selectForLeftOrRightIsFlat<A, B, R, FUNC, IS_BOOL_OP>(
-                left, right, selectedPositions);
+            return selectBothFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right);
+        } else if (left.state->isFlat() && !right.state->isFlat()) {
+            return selectFlatUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selectedPositions);
+        } else if (!left.state->isFlat() && right.state->isFlat()) {
+            return selectUnFlatFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selectedPositions);
         } else {
-            return selectForLeftAndRightAreUnFlat<A, B, R, FUNC, IS_BOOL_OP>(
-                left, right, selectedPositions);
+            return selectBothUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selectedPositions);
         }
     }
 };

--- a/src/common/include/vector/operations/executors/boolean_operation_executor.h
+++ b/src/common/include/vector/operations/executors/boolean_operation_executor.h
@@ -1,0 +1,180 @@
+#pragma once
+
+#include "src/common/include/vector/operations/executors/binary_operation_executor.h"
+
+namespace graphflow {
+namespace common {
+
+/**
+ * Binary boolean operation requires special executor implementation because it's truth table
+ * handles null differently (e.g. NULL OR TRUE = TRUE). Note that unary boolean operation (currently
+ * only NOT) does not require special implementation because NOT NULL = NULL.
+ */
+struct BinaryBooleanOperationExecutor {
+
+    template<typename FUNC>
+    static void execute(ValueVector& left, ValueVector& right, ValueVector& result) {
+        assert(left.dataType == BOOL);
+        assert(right.dataType == BOOL);
+        assert(result.dataType == BOOL);
+        result.resetStringBuffer();
+        if (left.state->isFlat() && right.state->isFlat()) {
+            executeBothFlat<FUNC>(left, right, result);
+        } else if (left.state->isFlat() && !right.state->isFlat()) {
+            executeFlatUnFlat<FUNC>(left, right, result);
+        } else if (!left.state->isFlat() && right.state->isFlat()) {
+            executeUnFlatFlat<FUNC>(left, right, result);
+        } else {
+            executeBothUnFlat<FUNC>(left, right, result);
+        }
+    }
+
+    template<typename FUNC>
+    static void executeBothFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        auto lPos = left.state->getPositionOfCurrIdx();
+        auto rPos = right.state->getPositionOfCurrIdx();
+        auto resPos = result.state->getPositionOfCurrIdx();
+        executeOnValue<FUNC>(left, right, result, lPos, rPos, resPos);
+    }
+
+    template<typename FUNC>
+    static void executeFlatUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        auto lPos = left.state->getPositionOfCurrIdx();
+        if (right.state->isUnfiltered()) {
+            for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                executeOnValue<FUNC>(left, right, result, lPos, i, i);
+            }
+        } else {
+            for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                auto rPos = right.state->selectedPositions[i];
+                executeOnValue<FUNC>(left, right, result, lPos, rPos, rPos);
+            }
+        }
+    }
+
+    template<typename FUNC>
+    static void executeUnFlatFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        auto rPos = right.state->getPositionOfCurrIdx();
+        if (left.state->isUnfiltered()) {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                executeOnValue<FUNC>(left, right, result, i, rPos, i);
+            }
+        } else {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                auto lPos = left.state->selectedPositions[i];
+                executeOnValue<FUNC>(left, right, result, lPos, rPos, lPos);
+            }
+        }
+    }
+
+    template<typename FUNC>
+    static void executeBothUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        if (left.state->isUnfiltered()) {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                executeOnValue<FUNC>(left, right, result, i, i, i);
+            }
+        } else {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                auto pos = left.state->selectedPositions[i];
+                executeOnValue<FUNC>(left, right, result, pos, pos, pos);
+            }
+        }
+    }
+
+    template<typename FUNC>
+    static inline void executeOnValue(ValueVector& left, ValueVector& right, ValueVector& result,
+        uint64_t lPos, uint64_t rPos, uint64_t resPos) {
+        BinaryOperationExecutor::executeOnValue<bool, bool, uint8_t, FUNC>(
+            left, right, result, lPos, rPos, resPos);
+        result.setNull(resPos, result.values[resPos] == operation::NULL_BOOL);
+    }
+
+    template<typename FUNC>
+    static uint64_t select(ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+        assert(left.dataType == BOOL);
+        assert(right.dataType == BOOL);
+        if (left.state->isFlat() && right.state->isFlat()) {
+            return selectBothFlat<FUNC>(left, right);
+        } else if (left.state->isFlat() && !right.state->isFlat()) {
+            return selectFlatUnFlat<FUNC>(left, right, selectedPositions);
+        } else if (!left.state->isFlat() && right.state->isFlat()) {
+            return selectUnFlatFlat<FUNC>(left, right, selectedPositions);
+        } else {
+            return selectBothUnFlat<FUNC>(left, right, selectedPositions);
+        }
+    }
+
+    template<typename FUNC>
+    static uint64_t selectBothFlat(ValueVector& left, ValueVector& right) {
+        auto lPos = left.state->getPositionOfCurrIdx();
+        auto rPos = right.state->getPositionOfCurrIdx();
+        auto lValues = (bool*)left.values;
+        auto rValues = (bool*)right.values;
+        uint8_t resultValue = 0;
+        FUNC::operation(lValues[lPos], rValues[rPos], resultValue, (bool)left.isNull(lPos),
+            (bool)right.isNull(rPos));
+        return resultValue == true;
+    }
+
+    template<typename FUNC>
+    static uint64_t selectFlatUnFlat(
+        ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+        auto lPos = left.state->getPositionOfCurrIdx();
+        uint64_t numSelectedValues = 0;
+        if (right.state->isUnfiltered()) {
+            for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                BinaryOperationExecutor::selectOnValue<bool, bool, FUNC>(
+                    left, right, lPos, i, i, numSelectedValues, selectedPositions);
+            }
+        } else {
+            for (auto i = 0u; i < right.state->selectedSize; ++i) {
+                auto rPos = right.state->selectedPositions[i];
+                BinaryOperationExecutor::selectOnValue<bool, bool, FUNC>(
+                    left, right, lPos, rPos, rPos, numSelectedValues, selectedPositions);
+            }
+        }
+        return numSelectedValues;
+    }
+
+    template<typename FUNC>
+    static uint64_t selectUnFlatFlat(
+        ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+        auto rPos = right.state->getPositionOfCurrIdx();
+        uint64_t numSelectedValues = 0;
+        if (left.state->isUnfiltered()) {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                BinaryOperationExecutor::selectOnValue<bool, bool, FUNC>(
+                    left, right, i, rPos, i, numSelectedValues, selectedPositions);
+            }
+        } else {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                auto lPos = left.state->selectedPositions[i];
+                BinaryOperationExecutor::selectOnValue<bool, bool, FUNC>(
+                    left, right, lPos, rPos, lPos, numSelectedValues, selectedPositions);
+            }
+        }
+        return numSelectedValues;
+    }
+
+    template<typename FUNC>
+    static uint64_t selectBothUnFlat(
+        ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+        uint64_t numSelectedValues = 0;
+        if (left.state->isUnfiltered()) {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                BinaryOperationExecutor::selectOnValue<bool, bool, FUNC>(
+                    left, right, i, i, i, numSelectedValues, selectedPositions);
+            }
+        } else {
+            for (auto i = 0u; i < left.state->selectedSize; ++i) {
+                auto pos = left.state->selectedPositions[i];
+                BinaryOperationExecutor::selectOnValue<bool, bool, FUNC>(
+                    left, right, pos, pos, pos, numSelectedValues, selectedPositions);
+            }
+        }
+        return numSelectedValues;
+    }
+};
+
+} // namespace common
+} // namespace graphflow

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -78,11 +78,6 @@ public:
 
     bool discardNullNodes();
 
-    inline void readNodeID(uint64_t pos, nodeID_t& nodeID) const {
-        assert(dataType == NODE);
-        nodeID = ((nodeID_t*)values)[pos];
-    }
-
     inline node_offset_t readNodeOffset(uint64_t pos) const {
         assert(dataType == NODE);
         return ((nodeID_t*)values)[pos].offset;

--- a/src/common/vector/operations/vector_boolean_operations.cpp
+++ b/src/common/vector/operations/vector_boolean_operations.cpp
@@ -1,48 +1,41 @@
 #include "src/common/include/vector/operations/vector_boolean_operations.h"
 
 #include "src/common/include/operations/boolean_operations.h"
-#include "src/common/include/vector/operations/executors/binary_operation_executor.h"
+#include "src/common/include/vector/operations/executors/boolean_operation_executor.h"
 #include "src/common/include/vector/operations/executors/unary_operation_executor.h"
 
 namespace graphflow {
 namespace common {
 
 void VectorBooleanOperations::And(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::execute<bool, bool, uint8_t, operation::And, true /* IS_BOOL_OP */>(
-        left, right, result);
+    BinaryBooleanOperationExecutor::execute<operation::And>(left, right, result);
 }
 
 void VectorBooleanOperations::Or(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::execute<bool, bool, uint8_t, operation::Or, true /* IS_BOOL_OP */>(
-        left, right, result);
+    BinaryBooleanOperationExecutor::execute<operation::Or>(left, right, result);
 }
 
 void VectorBooleanOperations::Xor(ValueVector& left, ValueVector& right, ValueVector& result) {
-    BinaryOperationExecutor::execute<bool, bool, uint8_t, operation::Xor, true /* IS_BOOL_OP */>(
-        left, right, result);
+    BinaryBooleanOperationExecutor::execute<operation::Xor>(left, right, result);
 }
 
 void VectorBooleanOperations::Not(ValueVector& operand, ValueVector& result) {
-    UnaryOperationExecutor::execute<bool, uint8_t, operation::Not, true /* IS_BOOL_OP */>(
-        operand, result);
+    UnaryOperationExecutor::execute<bool, uint8_t, operation::Not>(operand, result);
 }
 
 uint64_t VectorBooleanOperations::AndSelect(
     ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
-    return BinaryOperationExecutor::select<bool, bool, uint8_t, operation::And,
-        true /* IS_BOOL_OP */>(left, right, selectedPositions);
+    return BinaryBooleanOperationExecutor::select<operation::And>(left, right, selectedPositions);
 }
 
 uint64_t VectorBooleanOperations::OrSelect(
     ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
-    return BinaryOperationExecutor::select<bool, bool, uint8_t, operation::Or,
-        true /* IS_BOOL_OP */>(left, right, selectedPositions);
+    return BinaryBooleanOperationExecutor::select<operation::Or>(left, right, selectedPositions);
 }
 
 uint64_t VectorBooleanOperations::XorSelect(
     ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
-    return BinaryOperationExecutor::select<bool, bool, uint8_t, operation::Xor,
-        true /* IS_BOOL_OP */>(left, right, selectedPositions);
+    return BinaryBooleanOperationExecutor::select<operation::Xor>(left, right, selectedPositions);
 }
 
 uint64_t VectorBooleanOperations::NotSelect(ValueVector& operand, sel_t* selectedPositions) {

--- a/src/common/vector/operations/vector_comparison_operations.cpp
+++ b/src/common/vector/operations/vector_comparison_operations.cpp
@@ -81,16 +81,16 @@ public:
         switch (left.dataType) {
         case BOOL: {
             assert(right.dataType == BOOL);
-            return BinaryOperationExecutor::select<uint8_t, uint8_t, uint8_t, OP>(
+            return BinaryOperationExecutor::select<uint8_t, uint8_t, OP>(
                 left, right, selectedPositions);
         }
         case INT64: {
             switch (right.dataType) {
             case INT64:
-                return BinaryOperationExecutor::select<int64_t, int64_t, uint8_t, OP>(
+                return BinaryOperationExecutor::select<int64_t, int64_t, OP>(
                     left, right, selectedPositions);
             case DOUBLE:
-                return BinaryOperationExecutor::select<int64_t, double_t, uint8_t, OP>(
+                return BinaryOperationExecutor::select<int64_t, double_t, OP>(
                     left, right, selectedPositions);
             default:
                 assert(false);
@@ -99,10 +99,10 @@ public:
         case DOUBLE: {
             switch (right.dataType) {
             case INT64:
-                return BinaryOperationExecutor::select<double_t, int64_t, uint8_t, OP>(
+                return BinaryOperationExecutor::select<double_t, int64_t, OP>(
                     left, right, selectedPositions);
             case DOUBLE:
-                return BinaryOperationExecutor::select<double_t, double_t, uint8_t, OP>(
+                return BinaryOperationExecutor::select<double_t, double_t, OP>(
                     left, right, selectedPositions);
             default:
                 assert(false);
@@ -110,32 +110,32 @@ public:
         } break;
         case STRING: {
             assert(right.dataType == STRING);
-            return BinaryOperationExecutor::select<gf_string_t, gf_string_t, uint8_t, OP>(
+            return BinaryOperationExecutor::select<gf_string_t, gf_string_t, OP>(
                 left, right, selectedPositions);
         }
         case UNSTRUCTURED: {
             assert(right.dataType == UNSTRUCTURED);
-            return BinaryOperationExecutor::select<Value, Value, uint8_t, OP>(
+            return BinaryOperationExecutor::select<Value, Value, OP>(
                 left, right, selectedPositions);
         }
         case DATE: {
             assert(right.dataType == DATE);
-            return BinaryOperationExecutor::select<date_t, date_t, uint8_t, OP>(
+            return BinaryOperationExecutor::select<date_t, date_t, OP>(
                 left, right, selectedPositions);
         }
         case TIMESTAMP: {
             assert(right.dataType == TIMESTAMP);
-            return BinaryOperationExecutor::select<timestamp_t, timestamp_t, uint8_t, OP>(
+            return BinaryOperationExecutor::select<timestamp_t, timestamp_t, OP>(
                 left, right, selectedPositions);
         }
         case INTERVAL: {
             assert(right.dataType == INTERVAL);
-            return BinaryOperationExecutor::select<interval_t, interval_t, uint8_t, OP>(
+            return BinaryOperationExecutor::select<interval_t, interval_t, OP>(
                 left, right, selectedPositions);
         }
         case NODE: {
             assert(right.dataType == NODE);
-            return BinaryOperationExecutor::select<nodeID_t, nodeID_t, uint8_t, OP>(
+            return BinaryOperationExecutor::select<nodeID_t, nodeID_t, OP>(
                 left, right, selectedPositions);
         }
         default:

--- a/src/expression_evaluator/include/base_evaluator.h
+++ b/src/expression_evaluator/include/base_evaluator.h
@@ -29,7 +29,7 @@ public:
     BaseExpressionEvaluator(
         unique_ptr<BaseExpressionEvaluator> left, unique_ptr<BaseExpressionEvaluator> right);
 
-    ~BaseExpressionEvaluator() = default;
+    virtual ~BaseExpressionEvaluator() = default;
 
     virtual void init(const ResultSet& resultSet, MemoryManager* memoryManager);
 

--- a/src/expression_evaluator/reference_evaluator.cpp
+++ b/src/expression_evaluator/reference_evaluator.cpp
@@ -3,6 +3,11 @@
 namespace graphflow {
 namespace evaluator {
 
+inline static bool isTrue(ValueVector& vector, uint64_t pos) {
+    assert(vector.dataType == BOOL);
+    return !vector.isNull(pos) && ((bool*)vector.values)[pos];
+}
+
 void ReferenceExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager* memoryManager) {
     assert(children.empty());
     resultVector =
@@ -13,19 +18,18 @@ uint64_t ReferenceExpressionEvaluator::select(sel_t* selectedPos) {
     uint64_t numSelectedValues = 0;
     if (resultVector->state->isFlat()) {
         auto pos = resultVector->state->getPositionOfCurrIdx();
-        numSelectedValues += resultVector->values[pos] == true && (!resultVector->isNull(pos));
+        numSelectedValues += isTrue(*resultVector, pos);
     } else {
         if (resultVector->state->isUnfiltered()) {
             for (auto i = 0u; i < resultVector->state->selectedSize; i++) {
                 selectedPos[numSelectedValues] = i;
-                numSelectedValues += resultVector->values[i] == true && !resultVector->isNull(i);
+                numSelectedValues += isTrue(*resultVector, i);
             }
         } else {
             for (auto i = 0u; i < resultVector->state->selectedSize; i++) {
                 auto pos = resultVector->state->selectedPositions[i];
                 selectedPos[numSelectedValues] = pos;
-                numSelectedValues +=
-                    resultVector->values[pos] == true && !resultVector->isNull(pos);
+                numSelectedValues += isTrue(*resultVector, pos);
             }
         }
     }

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -48,7 +48,7 @@ void HashJoinProbe::getNextBatchOfMatchedTuples() {
             if (probeSideKeyVector->isNull(currentIdx)) {
                 continue;
             }
-            probeSideKeyVector->readNodeID(currentIdx, probeState->probeSideKeyNodeID);
+            probeState->probeSideKeyNodeID = ((nodeID_t*)probeSideKeyVector->values)[currentIdx];
             probeState->probedTuple =
                 *sharedState->getHashTable()->findHashEntry(probeState->probeSideKeyNodeID);
         }

--- a/src/storage/include/storage_structure/string_overflow_pages.h
+++ b/src/storage/include/storage_structure/string_overflow_pages.h
@@ -18,17 +18,16 @@ class StringOverflowPages {
 public:
     explicit StringOverflowPages(const string& fName, BufferManager& bufferManager, bool isInMemory)
         : fileHandle{getStringOverflowPagesFName(fName), FileHandle::O_DefaultPagedExistingDBFile},
-          bufferManager{bufferManager},
-          isInMemory{isInMemory} {
-              //        if (isInMemory) {
-              //            StorageStructureUtils::pinEachPageOfFile(fileHandle, bufferManager);
-              //        }
-          };
+          bufferManager{bufferManager}, isInMemory{isInMemory} {
+        if (isInMemory) {
+            StorageStructureUtils::pinEachPageOfFile(fileHandle, bufferManager);
+        }
+    };
 
     ~StringOverflowPages() {
-        //        if (isInMemory) {
-        //            StorageStructureUtils::unpinEachPageOfFile(fileHandle, bufferManager);
-        //        }
+        if (isInMemory) {
+            StorageStructureUtils::unpinEachPageOfFile(fileHandle, bufferManager);
+        }
     }
 
     static string getStringOverflowPagesFName(const string& fName) {


### PR DESCRIPTION
This PR refactors operation executor by adding a BinaryBooleanExecutor which does NOT use generic BinaryExecutor code. This change is necessary because for non-boolean operations, any operation with NULL will return NULL. On the other hand, boolean operation has its own truth table with NULL (e.g. NULL OR TRUE = TRUE). Changes are as follows:

- Add BinaryBooleanExecutor
- Replace execute(select)LeftOrRightIsFlat by execute(select)FlatUnFlat and execute(select)UnFlatFlat
  -  Although we write more code, this design should be more performant 
- Rename template parameters to be more meaningful
- Remove readNodeID() interface
- Solve issue #378 