### PR TITLE
add optimization for aggregation on id

### DIFF
--- a/src/binder/expression/include/node_expression.h
+++ b/src/binder/expression/include/node_expression.h
@@ -5,8 +5,6 @@
 namespace graphflow {
 namespace binder {
 
-const string INTERNAL_ID_SUFFIX = "_id";
-
 class NodeExpression : public Expression {
 
 public:

--- a/src/binder/expression/include/property_expression.h
+++ b/src/binder/expression/include/property_expression.h
@@ -5,6 +5,8 @@
 namespace graphflow {
 namespace binder {
 
+const string INTERNAL_ID_SUFFIX = "_id";
+
 class PropertyExpression : public Expression {
 
 public:
@@ -14,6 +16,8 @@ public:
     inline string getPropertyName() const { return propertyName; }
 
     inline uint32_t getPropertyKey() const { return propertyKey; }
+
+    inline bool isInternalID() const { return getPropertyName() == INTERNAL_ID_SUFFIX; }
 
 private:
     string propertyName;

--- a/src/processor/include/physical_plan/operator/aggregate/hash_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/hash_aggregate.h
@@ -34,7 +34,8 @@ class HashAggregate : public BaseAggregate {
 
 public:
     HashAggregate(shared_ptr<HashAggregateSharedState> sharedState,
-        vector<DataPos> groupByKeyVectorsPos, vector<DataPos> aggregateVectorsPos,
+        vector<DataPos> inputGroupByHashKeyVectorsPos,
+        vector<DataPos> inputGroupByNonHashKeyVectorsPos, vector<DataPos> aggregateVectorsPos,
         vector<unique_ptr<AggregateFunction>> aggregateFunctions,
         unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
 
@@ -47,8 +48,10 @@ public:
     unique_ptr<PhysicalOperator> clone() override;
 
 private:
-    vector<DataPos> groupByKeyVectorsPos;
-    vector<ValueVector*> groupByKeyVectors;
+    vector<DataPos> groupByHashKeyVectorsPos;
+    vector<DataPos> groupByNonHashKeyVectorsPos;
+    vector<ValueVector*> groupByHashKeyVectors;
+    vector<ValueVector*> groupByNonHashKeyVectors;
 
     shared_ptr<HashAggregateSharedState> sharedState;
     unique_ptr<AggregateHashTable> localAggregateHashTable;


### PR DESCRIPTION
This PR adds the optimization for aggregation with primary keys.

For example:
Query: `match (p:person) return p.ID, sum(p.salary).`
Since attribute salary is functionally dependent on ID(p.ID  => P.salary), we just need to compute the hash value for p.ID.