### PR TITLE
deprecate osBackedMemBlock

### DIFF
--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -63,7 +63,7 @@ public:
 
     inline node_offset_t readNodeOffset(uint64_t pos) const {
         assert(dataType == NODE);
-        return ((nodeID_t*)values)[pos].offset;
+        return ((nodeID_t*)values.get())[pos].offset;
     }
 
     inline void resetOverflowBuffer() const {
@@ -79,12 +79,11 @@ private:
 
 public:
     DataType dataType;
-    uint8_t* values;
+    unique_ptr<uint8_t[]> values;
     unique_ptr<OverflowBuffer> overflowBuffer;
     shared_ptr<DataChunkState> state;
 
 private:
-    unique_ptr<OSBackedMemoryBlock> bufferValues;
     // This is a shared pointer because sometimes ValueVectors may share NullMasks, e.g., the result
     // ValueVectors of unary expressions, point to the nullMasks of operands.
     shared_ptr<NullMask> nullMask;

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -13,11 +13,7 @@ NullMask::NullMask() : mayContainNulls{false} {
 
 ValueVector::ValueVector(MemoryManager* memoryManager, DataType dataType) : dataType{dataType} {
     assert(memoryManager != nullptr);
-    // TODO: Once MemoryManager's allocateOSBackedBlock is removed, this memory should be obtained
-    // directly through the OS. If that's , make sure to delete the memory during deconstruction.
-    bufferValues = memoryManager->allocateOSBackedBlock(
-        Types::getDataTypeSize(dataType) * DEFAULT_VECTOR_CAPACITY);
-    values = bufferValues->data;
+    values = make_unique<uint8_t[]>(Types::getDataTypeSize(dataType) * DEFAULT_VECTOR_CAPACITY);
     if (needOverflowBuffer()) {
         overflowBuffer = make_unique<OverflowBuffer>(memoryManager);
     }
@@ -26,7 +22,7 @@ ValueVector::ValueVector(MemoryManager* memoryManager, DataType dataType) : data
 
 void ValueVector::addString(uint64_t pos, char* value, uint64_t len) const {
     assert(dataType == STRING);
-    auto vectorData = (gf_string_t*)values;
+    auto vectorData = (gf_string_t*)values.get();
     auto& result = vectorData[pos];
     TypeUtils::copyString(value, len, result, *overflowBuffer);
 }

--- a/src/common/vector/value_vector_utils.cpp
+++ b/src/common/vector/value_vector_utils.cpp
@@ -10,22 +10,22 @@ void ValueVectorUtils::addLiteralToStructuredVector(
     ValueVector& resultVector, uint64_t pos, const Literal& literal) {
     switch (literal.dataType) {
     case INT64: {
-        ((int64_t*)resultVector.values)[pos] = literal.val.int64Val;
+        ((int64_t*)resultVector.values.get())[pos] = literal.val.int64Val;
     } break;
     case DOUBLE: {
-        ((double_t*)resultVector.values)[pos] = literal.val.doubleVal;
+        ((double_t*)resultVector.values.get())[pos] = literal.val.doubleVal;
     } break;
     case BOOL: {
-        ((bool*)resultVector.values)[pos] = literal.val.booleanVal;
+        ((bool*)resultVector.values.get())[pos] = literal.val.booleanVal;
     } break;
     case DATE: {
-        ((date_t*)resultVector.values)[pos] = literal.val.dateVal;
+        ((date_t*)resultVector.values.get())[pos] = literal.val.dateVal;
     } break;
     case TIMESTAMP: {
-        ((timestamp_t*)resultVector.values)[pos] = literal.val.timestampVal;
+        ((timestamp_t*)resultVector.values.get())[pos] = literal.val.timestampVal;
     } break;
     case INTERVAL: {
-        ((interval_t*)resultVector.values)[pos] = literal.val.intervalVal;
+        ((interval_t*)resultVector.values.get())[pos] = literal.val.intervalVal;
     } break;
     case STRING: {
         resultVector.addString(pos, literal.strVal);
@@ -38,7 +38,7 @@ void ValueVectorUtils::addLiteralToStructuredVector(
 void ValueVectorUtils::addLiteralToUnstructuredVector(
     ValueVector& resultVector, uint64_t pos, const Literal& value) {
     assert(resultVector.dataType == UNSTRUCTURED);
-    auto& val = ((Value*)resultVector.values)[pos];
+    auto& val = ((Value*)resultVector.values.get())[pos];
     val.dataType = value.dataType;
     switch (val.dataType) {
     case INT64: {
@@ -70,7 +70,7 @@ void ValueVectorUtils::addLiteralToUnstructuredVector(
 void ValueVectorUtils::addGFStringToUnstructuredVector(
     ValueVector& resultVector, uint64_t pos, const gf_string_t& value) {
     assert(resultVector.dataType == UNSTRUCTURED);
-    auto& val = ((Value*)resultVector.values)[pos];
+    auto& val = ((Value*)resultVector.values.get())[pos];
     val.dataType = STRING;
     TypeUtils::copyString(value, val.val.strVal, *resultVector.overflowBuffer);
 }
@@ -78,14 +78,14 @@ void ValueVectorUtils::addGFStringToUnstructuredVector(
 void ValueVectorUtils::copyNonNullDataWithSameTypeIntoPos(
     ValueVector& resultVector, uint64_t pos, const uint8_t* srcData) {
     copyNonNullDataWithSameType(resultVector.dataType, srcData,
-        resultVector.values + pos * resultVector.getNumBytesPerValue(),
+        resultVector.values.get() + pos * resultVector.getNumBytesPerValue(),
         *resultVector.overflowBuffer);
 }
 
 void ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(const ValueVector& srcVector,
     uint64_t pos, uint8_t* dstData, OverflowBuffer& dstOverflowBuffer) {
     copyNonNullDataWithSameType(srcVector.dataType,
-        srcVector.values + pos * srcVector.getNumBytesPerValue(), dstData, dstOverflowBuffer);
+        srcVector.values.get() + pos * srcVector.getNumBytesPerValue(), dstData, dstOverflowBuffer);
 }
 
 void ValueVectorUtils::copyNonNullDataWithSameType(

--- a/src/expression_evaluator/reference_evaluator.cpp
+++ b/src/expression_evaluator/reference_evaluator.cpp
@@ -5,7 +5,7 @@ namespace evaluator {
 
 inline static bool isTrue(ValueVector& vector, uint64_t pos) {
     assert(vector.dataType == BOOL);
-    return !vector.isNull(pos) && ((bool*)vector.values)[pos];
+    return !vector.isNull(pos) && ((bool*)vector.values.get())[pos];
 }
 
 void ReferenceExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager* memoryManager) {

--- a/src/function/boolean/include/boolean_operation_executor.h
+++ b/src/function/boolean/include/boolean_operation_executor.h
@@ -108,8 +108,8 @@ struct BinaryBooleanOperationExecutor {
     static uint64_t selectBothFlat(ValueVector& left, ValueVector& right) {
         auto lPos = left.state->getPositionOfCurrIdx();
         auto rPos = right.state->getPositionOfCurrIdx();
-        auto lValues = (bool*)left.values;
-        auto rValues = (bool*)right.values;
+        auto lValues = (bool*)left.values.get();
+        auto rValues = (bool*)right.values.get();
         uint8_t resultValue = 0;
         FUNC::operation(lValues[lPos], rValues[rPos], resultValue, (bool)left.isNull(lPos),
             (bool)right.isNull(rPos));

--- a/src/function/cast/vector_cast_operations.cpp
+++ b/src/function/cast/vector_cast_operations.cpp
@@ -39,18 +39,18 @@ void VectorCastOperations::castStructuredToUnstructuredValue(
             operand, result);
     } break;
     case STRING: {
-        auto outValues = (Value*)result.values;
+        auto outValues = (Value*)result.values.get();
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             assert(pos == result.state->getPositionOfCurrIdx());
             ValueVectorUtils::addGFStringToUnstructuredVector(
-                result, pos, ((gf_string_t*)operand.values)[pos]);
+                result, pos, ((gf_string_t*)operand.values.get())[pos]);
             outValues[pos].dataType = STRING;
         } else {
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
                 ValueVectorUtils::addGFStringToUnstructuredVector(
-                    result, pos, ((gf_string_t*)operand.values)[pos]);
+                    result, pos, ((gf_string_t*)operand.values.get())[pos]);
                 outValues[pos].dataType = STRING;
             }
         }
@@ -74,22 +74,22 @@ void VectorCastOperations::castStructuredToString(
         string val;
         switch (operand.dataType) {
         case BOOL: {
-            val = TypeUtils::toString(((bool*)operand.values)[pos]);
+            val = TypeUtils::toString(((bool*)operand.values.get())[pos]);
         } break;
         case INT64: {
-            val = TypeUtils::toString(((int64_t*)operand.values)[pos]);
+            val = TypeUtils::toString(((int64_t*)operand.values.get())[pos]);
         } break;
         case DOUBLE: {
-            val = TypeUtils::toString(((double_t*)operand.values)[pos]);
+            val = TypeUtils::toString(((double_t*)operand.values.get())[pos]);
         } break;
         case DATE: {
-            val = Date::toString(((date_t*)operand.values)[pos]);
+            val = Date::toString(((date_t*)operand.values.get())[pos]);
         } break;
         case TIMESTAMP: {
-            val = Timestamp::toString(((timestamp_t*)operand.values)[pos]);
+            val = Timestamp::toString(((timestamp_t*)operand.values.get())[pos]);
         } break;
         case INTERVAL: {
-            val = Interval::toString(((interval_t*)operand.values)[pos]);
+            val = Interval::toString(((interval_t*)operand.values.get())[pos]);
         } break;
         default:
             assert(false);
@@ -100,18 +100,18 @@ void VectorCastOperations::castStructuredToString(
         case BOOL: {
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
-                result.addString(pos, TypeUtils::toString(((bool*)operand.values)[pos]));
+                result.addString(pos, TypeUtils::toString(((bool*)operand.values.get())[pos]));
             }
         } break;
         case INT64: {
-            auto intValues = (int64_t*)operand.values;
+            auto intValues = (int64_t*)operand.values.get();
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
                 result.addString(pos, TypeUtils::toString(intValues[pos]));
             }
         } break;
         case DOUBLE: {
-            auto doubleValues = (double_t*)operand.values;
+            auto doubleValues = (double_t*)operand.values.get();
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
                 result.addString(pos, TypeUtils::toString(doubleValues[pos]));
@@ -120,19 +120,20 @@ void VectorCastOperations::castStructuredToString(
         case DATE: {
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
-                result.addString(pos, Date::toString(((date_t*)operand.values)[pos]));
+                result.addString(pos, Date::toString(((date_t*)operand.values.get())[pos]));
             }
         } break;
         case TIMESTAMP: {
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
-                result.addString(pos, Timestamp::toString(((timestamp_t*)operand.values)[pos]));
+                result.addString(
+                    pos, Timestamp::toString(((timestamp_t*)operand.values.get())[pos]));
             }
         } break;
         case INTERVAL: {
             for (auto i = 0u; i < operand.state->selectedSize; i++) {
                 auto pos = operand.state->selectedPositions[i];
-                result.addString(pos, Interval::toString(((interval_t*)operand.values)[pos]));
+                result.addString(pos, Interval::toString(((interval_t*)operand.values.get())[pos]));
             }
         } break;
         default:

--- a/src/function/include/aggregate/avg.h
+++ b/src/function/include/aggregate/avg.h
@@ -49,7 +49,7 @@ struct AvgFunction {
 
     static void updateSingleValue(
         AvgState* state, ValueVector* input, uint32_t pos, uint64_t multiplicity) {
-        auto inputValues = (T*)input->values;
+        auto inputValues = (T*)input->values.get();
         for (auto i = 0u; i < multiplicity; ++i) {
             if (state->isNull) {
                 state->sum = inputValues[pos];

--- a/src/function/include/aggregate/min_max.h
+++ b/src/function/include/aggregate/min_max.h
@@ -47,7 +47,7 @@ struct MinMaxFunction {
 
     template<class OP>
     static void updateSingleValue(MinMaxState* state, ValueVector* input, uint32_t pos) {
-        auto inputValues = (T*)input->values;
+        auto inputValues = (T*)input->values.get();
         if (state->isNull) {
             state->val = inputValues[pos];
             state->isNull = false;

--- a/src/function/include/aggregate/sum.h
+++ b/src/function/include/aggregate/sum.h
@@ -46,7 +46,7 @@ struct SumFunction {
 
     static void updateSingleValue(
         SumState* state, ValueVector* input, uint32_t pos, uint64_t multiplicity) {
-        auto inputValues = (T*)input->values;
+        auto inputValues = (T*)input->values.get();
         for (auto j = 0u; j < multiplicity; ++j) {
             if (state->isNull) {
                 state->sum = inputValues[pos];

--- a/src/function/include/binary_operation_executor.h
+++ b/src/function/include/binary_operation_executor.h
@@ -33,9 +33,9 @@ struct BinaryOperationExecutor {
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
     static void executeOnValue(ValueVector& left, ValueVector& right, ValueVector& result,
         uint64_t lPos, uint64_t rPos, uint64_t resPos) {
-        auto lValues = (LEFT_TYPE*)left.values;
-        auto rValues = (RIGHT_TYPE*)right.values;
-        auto resValues = (RESULT_TYPE*)result.values;
+        auto lValues = (LEFT_TYPE*)left.values.get();
+        auto rValues = (RIGHT_TYPE*)right.values.get();
+        auto resValues = (RESULT_TYPE*)result.values.get();
         if constexpr ((is_same<RESULT_TYPE, gf_string_t>::value) ||
                       (is_same<RESULT_TYPE, Value>::value)) {
             allocateStringIfNecessary<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE>(
@@ -192,8 +192,8 @@ struct BinaryOperationExecutor {
     template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
     static void selectOnValue(ValueVector& left, ValueVector& right, uint64_t lPos, uint64_t rPos,
         uint64_t resPos, uint64_t& numSelectedValues, sel_t* selectedPositions) {
-        auto lValues = (LEFT_TYPE*)left.values;
-        auto rValues = (RIGHT_TYPE*)right.values;
+        auto lValues = (LEFT_TYPE*)left.values.get();
+        auto rValues = (RIGHT_TYPE*)right.values.get();
         uint8_t resultValue = 0;
         FUNC::operation(lValues[lPos], rValues[rPos], resultValue, (bool)left.isNull(lPos),
             (bool)right.isNull(rPos));
@@ -205,8 +205,8 @@ struct BinaryOperationExecutor {
     static uint64_t selectBothFlat(ValueVector& left, ValueVector& right) {
         auto lPos = left.state->getPositionOfCurrIdx();
         auto rPos = right.state->getPositionOfCurrIdx();
-        auto lValues = (LEFT_TYPE*)left.values;
-        auto rValues = (RIGHT_TYPE*)right.values;
+        auto lValues = (LEFT_TYPE*)left.values.get();
+        auto rValues = (RIGHT_TYPE*)right.values.get();
         uint8_t resultValue = 0;
         if (!left.isNull(lPos) && !right.isNull(rPos)) {
             FUNC::operation(lValues[lPos], rValues[rPos], resultValue, (bool)left.isNull(lPos),

--- a/src/function/include/unary_operation_executor.h
+++ b/src/function/include/unary_operation_executor.h
@@ -17,14 +17,14 @@ struct UnaryOperationExecutor {
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
     static void executeOnValue(
         ValueVector& operand, uint64_t operandPos, RESULT_TYPE& resultValue) {
-        auto operandValues = (OPERAND_TYPE*)operand.values;
+        auto operandValues = (OPERAND_TYPE*)operand.values.get();
         FUNC::operation(operandValues[operandPos], (bool)operand.isNull(operandPos), resultValue);
     }
 
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
     static void execute(ValueVector& operand, ValueVector& result) {
         result.resetOverflowBuffer();
-        auto resultValues = (RESULT_TYPE*)result.values;
+        auto resultValues = (RESULT_TYPE*)result.values.get();
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             assert(pos == result.state->getPositionOfCurrIdx());
@@ -73,7 +73,7 @@ struct UnaryOperationExecutor {
     static void selectOnValue(ValueVector& operand, uint64_t operandPos,
         uint64_t& numSelectedValues, sel_t* selectedPositions) {
         uint8_t resultValue = 0;
-        auto operandValues = (OPERAND_TYPE*)operand.values;
+        auto operandValues = (OPERAND_TYPE*)operand.values.get();
         FUNC::operation(operandValues[operandPos], operand.isNull(operandPos), resultValue);
         selectedPositions[numSelectedValues] = operandPos;
         numSelectedValues += resultValue == true;

--- a/src/function/list/vector_list_creation_operation.cpp
+++ b/src/function/list/vector_list_creation_operation.cpp
@@ -14,22 +14,23 @@ void VectorListOperations::ListCreation(
     vector<uint8_t*> listElements(parameters.size());
     if (result.state->isFlat()) {
         auto pos = result.state->getPositionOfCurrIdx();
-        auto& gfList = ((gf_list_t*)result.values)[pos];
+        auto& gfList = ((gf_list_t*)result.values.get())[pos];
         for (auto paramIdx = 0u; paramIdx < parameters.size(); paramIdx++) {
             assert(parameters[paramIdx]->state->isFlat());
-            listElements[paramIdx] = parameters[paramIdx]->values + pos * numBytesOfListElement;
+            listElements[paramIdx] =
+                parameters[paramIdx]->values.get() + pos * numBytesOfListElement;
         }
         TypeUtils::copyList(childType, listElements, gfList, *result.overflowBuffer);
     } else {
         for (auto selectedPos = 0u; selectedPos < result.state->selectedSize; ++selectedPos) {
             auto pos = result.state->selectedPositions[selectedPos];
-            auto& gfList = ((gf_list_t*)result.values)[pos];
+            auto& gfList = ((gf_list_t*)result.values.get())[pos];
             for (auto paramIdx = 0u; paramIdx < parameters.size(); paramIdx++) {
                 auto parameterPos = parameters[paramIdx]->state->isFlat() ?
                                         parameters[paramIdx]->state->getPositionOfCurrIdx() :
                                         pos;
                 listElements[paramIdx] =
-                    parameters[paramIdx]->values + parameterPos * numBytesOfListElement;
+                    parameters[paramIdx]->values.get() + parameterPos * numBytesOfListElement;
             }
             TypeUtils::copyList(childType, listElements, gfList, *result.overflowBuffer);
         }

--- a/src/function/null/include/null_operation_executor.h
+++ b/src/function/null/include/null_operation_executor.h
@@ -10,7 +10,7 @@ struct NullOperationExecutor {
     template<typename FUNC>
     static void execute(ValueVector& operand, ValueVector& result) {
         assert(result.dataType == BOOL);
-        auto resultValues = (uint8_t*)result.values;
+        auto resultValues = (uint8_t*)result.values.get();
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             assert(pos == result.state->getPositionOfCurrIdx());

--- a/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
+++ b/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
@@ -223,7 +223,8 @@ hash_t AggregateHashTable::computeHash(ValueVector* keyVector) {
     auto pos = keyVector->state->getPositionOfCurrIdx();
     hash_t hash;
     HashOnBytes::operation(keyVector->dataType,
-        keyVector->values + pos * keyVector->getNumBytesPerValue(), keyVector->isNull(pos), hash);
+        keyVector->values.get() + pos * keyVector->getNumBytesPerValue(), keyVector->isNull(pos),
+        hash);
     return hash;
 }
 
@@ -253,7 +254,7 @@ bool AggregateHashTable::matchGroupByKeys(const vector<ValueVector*>& keyVectors
         auto keyVector = keyVectors[i];
         assert(keyVector->state->isFlat());
         auto pos = keyVector->state->getPositionOfCurrIdx();
-        auto keyValue = keyVector->values + pos * keyVector->getNumBytesPerValue();
+        auto keyValue = keyVector->values.get() + pos * keyVector->getNumBytesPerValue();
         auto isKeyVectorNull = keyVector->isNull(pos);
         auto isEntryKeyNull =
             FactorizedTable::isNull(entry + tableSchema.getNullMapOffset(), i + 1);

--- a/src/processor/physical_plan/operator/aggregate/base_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/base_aggregate_scan.cpp
@@ -19,7 +19,7 @@ void BaseAggregateScan::writeAggregateResultToVector(
     if (aggregateState->isNull) {
         vector->setNull(pos, true);
     } else {
-        memcpy(vector->values + pos * Types::getDataTypeSize(vector->dataType),
+        memcpy(vector->values.get() + pos * Types::getDataTypeSize(vector->dataType),
             aggregateState->getResult(), Types::getDataTypeSize(vector->dataType));
     }
 }

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -50,7 +50,8 @@ void HashJoinProbe::getNextBatchOfMatchedTuples() {
             if (probeSideKeyVector->isNull(currentIdx)) {
                 continue;
             }
-            probeState->probeSideKeyNodeID = ((nodeID_t*)probeSideKeyVector->values)[currentIdx];
+            probeState->probeSideKeyNodeID =
+                ((nodeID_t*)probeSideKeyVector->values.get())[currentIdx];
             probeState->probedTuple =
                 *sharedState->getHashTable()->findHashEntry(probeState->probeSideKeyNodeID);
         }

--- a/src/processor/physical_plan/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_key_encoder.cpp
@@ -168,31 +168,31 @@ void OrderByKeyEncoder::encodeData(shared_ptr<ValueVector>& orderByVector,
         auto keyBlockPtrAfterNullByte = keyBlockPtr + 1;
         switch (orderByVector->dataType) {
         case INT64:
-            encodeInt64(
-                ((int64_t*)orderByVector->values)[idxInOrderByVector], keyBlockPtrAfterNullByte);
+            encodeInt64(((int64_t*)orderByVector->values.get())[idxInOrderByVector],
+                keyBlockPtrAfterNullByte);
             break;
         case BOOL:
             encodeBool(
-                ((bool*)orderByVector->values)[idxInOrderByVector], keyBlockPtrAfterNullByte);
+                ((bool*)orderByVector->values.get())[idxInOrderByVector], keyBlockPtrAfterNullByte);
             break;
         case DOUBLE:
-            encodeDouble(
-                ((double*)orderByVector->values)[idxInOrderByVector], keyBlockPtrAfterNullByte);
+            encodeDouble(((double*)orderByVector->values.get())[idxInOrderByVector],
+                keyBlockPtrAfterNullByte);
             break;
         case DATE:
-            encodeDate(
-                ((date_t*)orderByVector->values)[idxInOrderByVector], keyBlockPtrAfterNullByte);
+            encodeDate(((date_t*)orderByVector->values.get())[idxInOrderByVector],
+                keyBlockPtrAfterNullByte);
             break;
         case TIMESTAMP:
-            encodeTimestamp(((timestamp_t*)orderByVector->values)[idxInOrderByVector],
+            encodeTimestamp(((timestamp_t*)orderByVector->values.get())[idxInOrderByVector],
                 keyBlockPtrAfterNullByte);
             break;
         case INTERVAL:
-            encodeInterval(
-                ((interval_t*)orderByVector->values)[idxInOrderByVector], keyBlockPtrAfterNullByte);
+            encodeInterval(((interval_t*)orderByVector->values.get())[idxInOrderByVector],
+                keyBlockPtrAfterNullByte);
             break;
         case STRING:
-            encodeString(((gf_string_t*)orderByVector->values)[idxInOrderByVector],
+            encodeString(((gf_string_t*)orderByVector->values.get())[idxInOrderByVector],
                 keyBlockPtrAfterNullByte);
             break;
         case UNSTRUCTURED:

--- a/src/processor/physical_plan/operator/result_scan.cpp
+++ b/src/processor/physical_plan/operator/result_scan.cpp
@@ -49,8 +49,8 @@ bool ResultScan::getNextTuples() {
                 continue;
             }
             auto elementSize = Types::getDataTypeSize(inValueVector.dataType);
-            memcpy(
-                &outValueVector->values[0], inValueVector.values + pos * elementSize, elementSize);
+            memcpy(&outValueVector->values[0], inValueVector.values.get() + pos * elementSize,
+                elementSize);
             outValueVector->setNull(0, false /* isNull */);
         }
         outDataChunk->state->initOriginalAndSelectedSize(1);

--- a/src/processor/physical_plan/operator/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id.cpp
@@ -29,7 +29,7 @@ bool ScanNodeID::getNextTuples() {
         metrics->executionTime.stop();
         return false;
     }
-    auto nodeIDValues = (nodeID_t*)(outValueVector->values);
+    auto nodeIDValues = (nodeID_t*)(outValueVector->values.get());
     auto size = endOffset - startOffset;
     for (auto i = 0u; i < size; ++i) {
         nodeIDValues[i].offset = startOffset + i;

--- a/src/processor/physical_plan/operator/var_length_adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/var_length_adj_list_extend.cpp
@@ -58,7 +58,7 @@ bool VarLengthAdjListExtend::getNextTuples() {
                 dfsLevelInfo->hasBeenOutput = true;
                 // It is impossible for the children to have a null value, so we don't need
                 // to copy the null mask to the nbrNodeValueVector.
-                memcpy(nbrNodeValueVector->values, dfsLevelInfo->children->values,
+                memcpy(nbrNodeValueVector->values.get(), dfsLevelInfo->children->values.get(),
                     dfsLevelInfo->children->state->selectedSize *
                         Types::getDataTypeSize(dfsLevelInfo->children->dataType));
                 nbrNodeValueVector->state->selectedSize =

--- a/src/storage/include/memory_manager.h
+++ b/src/storage/include/memory_manager.h
@@ -16,22 +16,6 @@ namespace common {
 
 class MemoryManager;
 
-// TODO(Deprecate). We should eventually remove this and rename BMBackedMemoryBlock to MemoryBlock.
-struct OSBackedMemoryBlock {
-public:
-    explicit OSBackedMemoryBlock(uint64_t size) : size(size) {
-        buffer = make_unique<uint8_t[]>(size);
-        data = buffer.get();
-    }
-
-public:
-    uint64_t size;
-    uint8_t* data;
-
-private:
-    unique_ptr<uint8_t[]> buffer;
-};
-
 struct BMBackedMemoryBlock {
 
 public:
@@ -44,10 +28,8 @@ public:
     uint8_t* data;
 };
 
-// Memory manager for allocating/reclaiming large intermediate memory blocks. Currently it can
-// allocate both memory directly from the OS and also through the buffer manager of the system. OS
-// backed memory can be of any size but buffer manager backed memory is given in fixed size of
-// LARGE_PAGE_SIZE, which is a constant defined in configs.h.
+// Memory manager for allocating/reclaiming large intermediate memory blocks. It can allocate a
+// memory block with fixed size of LARGE_PAGE_SIZE from the buffer manager.
 class MemoryManager {
 public:
     explicit MemoryManager(BufferManager* bm) : bm(bm) {
@@ -56,10 +38,6 @@ public:
         // purposes.
         fh = make_shared<FileHandle>("mm-place-holder-file-name", FileHandle::O_LargePagedTempFile);
     }
-
-    // TODO(Deprecate). We should remove this eventually and only use allocateBMBackedBlock.
-    unique_ptr<OSBackedMemoryBlock> allocateOSBackedBlock(
-        uint64_t size, bool initializeToZero = false);
 
     unique_ptr<BMBackedMemoryBlock> allocateBMBackedBlock(bool initializeToZero = false);
 

--- a/src/storage/memory_manager.cpp
+++ b/src/storage/memory_manager.cpp
@@ -31,16 +31,5 @@ void MemoryManager::freeBMBackedBlock(uint32_t pageIdx) {
     freePages.push(pageIdx);
 }
 
-unique_ptr<OSBackedMemoryBlock> MemoryManager::allocateOSBackedBlock(
-    uint64_t size, bool initializeToZero) {
-    lock_guard<mutex> lock(memMgrLock);
-
-    auto blockHandle = make_unique<OSBackedMemoryBlock>(size);
-    if (initializeToZero) {
-        memset(blockHandle->data, 0, size);
-    }
-
-    return blockHandle;
-}
 } // namespace common
 } // namespace graphflow

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -37,7 +37,7 @@ void Column::readForSingleNodeIDPosition(uint32_t pos, const shared_ptr<ValueVec
     auto pageCursor = PageUtils::getPageElementCursorForOffset(
         nodeIDVector->readNodeOffset(pos), numElementsPerPage);
     auto frame = bufferManager.pin(fileHandle, pageCursor.idx);
-    memcpy(resultVector->values + pos * elementSize,
+    memcpy(resultVector->values.get() + pos * elementSize,
         frame + mapElementPosToByteOffset(pageCursor.pos), elementSize);
     setNULLBitsForAPos(resultVector, frame, pageCursor.pos, pos);
     bufferManager.unpin(fileHandle, pageCursor.idx);

--- a/src/storage/storage_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists.cpp
@@ -39,7 +39,7 @@ void UnstructuredPropertyLists::readPropertiesForPosition(ValueVector* nodeIDVec
             propertyKeysFound.insert(propertyKeyDataType.keyIdx);
             auto vector = propertyKeyToResultVectorMap.at(propertyKeyDataType.keyIdx);
             vector->setNull(pos, false);
-            auto value = &((Value*)vector->values)[pos];
+            auto value = &((Value*)vector->values.get())[pos];
             readPropertyValue(value, dataTypeSize, cursor, info.mapper);
             value->dataType = propertyKeyDataType.dataType;
             if (propertyKeyDataType.dataType == STRING) {

--- a/src/storage/storage_structure/overflow_pages.cpp
+++ b/src/storage/storage_structure/overflow_pages.cpp
@@ -11,7 +11,7 @@ void OverflowPages::readStringsToVector(ValueVector& valueVector) {
         auto pos = valueVector.state->selectedPositions[i];
         if (!valueVector.isNull(pos)) {
             readStringToVector(
-                ((gf_string_t*)valueVector.values)[pos], *valueVector.overflowBuffer);
+                ((gf_string_t*)valueVector.values.get())[pos], *valueVector.overflowBuffer);
         }
     }
 }
@@ -21,7 +21,8 @@ void OverflowPages::readListsToVector(ValueVector& valueVector) {
     for (auto i = 0u; i < valueVector.state->selectedSize; i++) {
         auto pos = valueVector.state->selectedPositions[i];
         if (!valueVector.isNull(pos)) {
-            readListToVector(((gf_list_t*)valueVector.values)[pos], *valueVector.overflowBuffer);
+            readListToVector(
+                ((gf_list_t*)valueVector.values.get())[pos], *valueVector.overflowBuffer);
         }
     }
 }

--- a/src/storage/storage_structure/storage_structure.cpp
+++ b/src/storage/storage_structure/storage_structure.cpp
@@ -22,7 +22,7 @@ StorageStructure::StorageStructure(const string& fName, const DataType& dataType
 void StorageStructure::readBySequentialCopy(const shared_ptr<ValueVector>& valueVector,
     uint64_t sizeLeftToCopy, PageElementCursor& cursor,
     const function<uint32_t(uint32_t)>& logicalToPhysicalPageMapper) {
-    auto values = valueVector->values;
+    auto values = valueVector->values.get();
     auto offsetInVector = 0;
     while (sizeLeftToCopy) {
         auto physicalPageIdx = logicalToPhysicalPageMapper(cursor.idx);
@@ -62,7 +62,7 @@ void StorageStructure::readNodeIDsFromSequentialPages(const shared_ptr<ValueVect
 void StorageStructure::readNodeIDsFromAPage(const shared_ptr<ValueVector>& valueVector,
     uint32_t posInVector, uint32_t physicalPageId, uint32_t posInPage, uint64_t numValuesToCopy,
     NodeIDCompressionScheme& compressionScheme, bool isAdjLists) {
-    auto nodeValues = (nodeID_t*)valueVector->values;
+    auto nodeValues = (nodeID_t*)valueVector->values.get();
     auto labelSize = compressionScheme.getNumBytesForLabel();
     auto offsetSize = compressionScheme.getNumBytesForOffset();
     auto frame = bufferManager.pin(fileHandle, physicalPageId);

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -22,8 +22,8 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto lVectorData = (int64_t*)vector1->values;
-        auto rVectorData = (int64_t*)vector2->values;
+        auto lVectorData = (int64_t*)vector1->values.get();
+        auto rVectorData = (int64_t*)vector2->values.get();
         for (int i = 0; i < NUM_TUPLES; i++) {
             lVectorData[i] = i;
             rVectorData[i] = 110 - i;
@@ -41,8 +41,8 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto lVectorData = (int64_t*)vector1->values;
-        auto rVectorData = (int64_t*)vector2->values;
+        auto lVectorData = (int64_t*)vector1->values.get();
+        auto rVectorData = (int64_t*)vector2->values.get();
         for (int i = 0; i < NUM_TUPLES; i++) {
             lVectorData[i] = i;
             rVectorData[i] = 110 - i;
@@ -63,7 +63,7 @@ public:
 TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatNoNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (int64_t*)result->values;
+    auto resultData = (int64_t*)result->values.get();
 
     UnaryOperationExecutor::execute<int64_t, int64_t, operation::Negate>(*lVector, *result);
 
@@ -115,7 +115,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
 
     result = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
     dataChunk->insert(0, result);
-    auto resultDataAsDoubleArr = (double_t*)result->values;
+    auto resultDataAsDoubleArr = (double_t*)result->values.get();
     BinaryOperationExecutor::execute<int64_t, int64_t, double_t, operation::Power>(
         *lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
@@ -129,7 +129,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
 TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatWithNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (int64_t*)result->values;
+    auto resultData = (int64_t*)result->values.get();
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
         rVector->setNull(i, (i % 2) == 1);
@@ -164,7 +164,7 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
     // Flatten dataChunkWithVector1, which holds vector1
     dataChunkWithVector1->state->currIdx = 80;
     // Recall vector2 and result are in the same data chunk
-    auto resultData = (uint64_t*)result->values;
+    auto resultData = (uint64_t*)result->values.get();
 
     // Test 1: Left flat and right is unflat.
     // The addition is 80 + [110, 109, ...., 8, 9]. The results are: [190, 189, ...., 88, 89]
@@ -190,7 +190,7 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
 TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUnflatWithNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (int64_t*)result->values;
+    auto resultData = (int64_t*)result->values.get();
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
         rVector->setNull(i, (i % 2) == 1);
@@ -229,9 +229,9 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
 TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt64Test) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto lData = (Value*)lVector->values;
-    auto rData = (Value*)rVector->values;
-    auto resultData = (Value*)result->values;
+    auto lData = (Value*)lVector->values.get();
+    auto rData = (Value*)rVector->values.get();
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
@@ -278,9 +278,9 @@ TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt64Test)
 TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt32AndDoubleTest) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto lData = (Value*)lVector->values;
-    auto rData = (Value*)rVector->values;
-    auto resultData = (Value*)result->values;
+    auto lData = (Value*)lVector->values.get();
+    auto rData = (Value*)rVector->values.get();
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
@@ -321,9 +321,9 @@ TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt32AndDo
 TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredStringAndInt32Test) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto lData = (Value*)lVector->values;
-    auto rData = (Value*)rVector->values;
-    auto resultData = (Value*)result->values;
+    auto lData = (Value*)lVector->values.get();
+    auto rData = (Value*)rVector->values.get();
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {

--- a/test/common/vector/operations/vector_boolean_operations_test.cpp
+++ b/test/common/vector/operations/vector_boolean_operations_test.cpp
@@ -23,8 +23,8 @@ using namespace std;
  * */
 static void setValuesInVectors(const shared_ptr<ValueVector>& lVector,
     const shared_ptr<ValueVector>& rVector, uint32_t numTuples) {
-    auto lVectorData = (bool*)lVector->values;
-    auto rVectorData = (bool*)rVector->values;
+    auto lVectorData = (bool*)lVector->values.get();
+    auto rVectorData = (bool*)rVector->values.get();
     for (auto i = 0u; i < numTuples; i++) {
         lVectorData[i] = i % 2 == 0;
         rVectorData[i] = (i >> 1) % 2 == 0;
@@ -93,7 +93,7 @@ public:
 
 static void checkResultVectorNoNulls(const shared_ptr<ValueVector>& result,
     const function<bool(uint32_t)>& idxOfTrueValueFunc, uint32_t numTuples) {
-    auto resultData = (bool*)result->values;
+    auto resultData = (bool*)result->values.get();
     for (auto i = 0u; i < numTuples; i++) {
         if (idxOfTrueValueFunc(i)) {
             ASSERT_TRUE(resultData[i]);
@@ -135,7 +135,7 @@ TEST_F(BoolOperandsInSameDataChunkTest, BoolUnaryAndBinaryAllUnflatNoNulls) {
 static void checkResultVectorWithNulls(const shared_ptr<ValueVector>& result,
     const unordered_set<uint32_t>& idxOfTrueValuePer16Elements,
     const unordered_set<uint32_t>& idxOfFalseValuePer16Elements, uint32_t numTuples) {
-    auto resultData = (bool*)result->values;
+    auto resultData = (bool*)result->values.get();
     for (auto i = 0u; i < numTuples; i++) {
         if (idxOfTrueValuePer16Elements.contains(i % 16)) {
             ASSERT_TRUE(resultData[i]);

--- a/test/common/vector/operations/vector_cast_operations_test.cpp
+++ b/test/common/vector/operations/vector_cast_operations_test.cpp
@@ -29,11 +29,11 @@ public:
 TEST_F(VectorCastOperationsTest, CastStructuredBoolToUnstructuredValueTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->insert(0, lVector);
-    auto lData = (bool*)lVector->values;
+    auto lData = (bool*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->insert(1, result);
-    auto resultData = (Value*)result->values;
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -49,11 +49,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredBoolToUnstructuredValueTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredInt64ToUnstructuredValueTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->insert(0, lVector);
-    auto lData = (int64_t*)lVector->values;
+    auto lData = (int64_t*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->insert(1, result);
-    auto resultData = (Value*)result->values;
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -69,11 +69,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredInt64ToUnstructuredValueTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredDoubleToUnstructuredValueTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
     dataChunk->insert(0, lVector);
-    auto lData = (double*)lVector->values;
+    auto lData = (double*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->insert(1, result);
-    auto resultData = (Value*)result->values;
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -89,11 +89,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredDoubleToUnstructuredValueTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredDateToUnstructuredValueTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), DATE);
     dataChunk->insert(0, lVector);
-    auto lData = (date_t*)lVector->values;
+    auto lData = (date_t*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->insert(1, result);
-    auto resultData = (Value*)result->values;
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -109,11 +109,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredDateToUnstructuredValueTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredStringToUnstructuredValueTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(0, lVector);
-    auto lData = (gf_string_t*)lVector->values;
+    auto lData = (gf_string_t*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->insert(1, result);
-    auto resultData = (Value*)result->values;
+    auto resultData = (Value*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -130,11 +130,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredStringToUnstructuredValueTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredBooleanToStringTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->insert(0, lVector);
-    auto lData = (bool*)lVector->values;
+    auto lData = (bool*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(1, result);
-    auto resultData = (gf_string_t*)result->values;
+    auto resultData = (gf_string_t*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -149,11 +149,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredBooleanToStringTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredInt32ToStringTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->insert(0, lVector);
-    auto lData = (int64_t*)lVector->values;
+    auto lData = (int64_t*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(1, result);
-    auto resultData = (gf_string_t*)result->values;
+    auto resultData = (gf_string_t*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -168,11 +168,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredInt32ToStringTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredDoubleToStringTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
     dataChunk->insert(0, lVector);
-    auto lData = (double*)lVector->values;
+    auto lData = (double*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(1, result);
-    auto resultData = (gf_string_t*)result->values;
+    auto resultData = (gf_string_t*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -187,11 +187,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredDoubleToStringTest) {
 TEST_F(VectorCastOperationsTest, CastStructuredDateToStringTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), DATE);
     dataChunk->insert(0, lVector);
-    auto lData = (date_t*)lVector->values;
+    auto lData = (date_t*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(1, result);
-    auto resultData = (gf_string_t*)result->values;
+    auto resultData = (gf_string_t*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
@@ -206,11 +206,11 @@ TEST_F(VectorCastOperationsTest, CastStructuredDateToStringTest) {
 TEST_F(VectorCastOperationsTest, CastUnStructuredBooleanToBooleanTest) {
     auto lVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     dataChunk->insert(0, lVector);
-    auto lData = (Value*)lVector->values;
+    auto lData = (Value*)lVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->insert(1, result);
-    auto resultData = (bool*)result->values;
+    auto resultData = (bool*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -17,8 +17,8 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto vector1Data = (int64_t*)vector1->values;
-        auto vector2Data = (int64_t*)vector2->values;
+        auto vector1Data = (int64_t*)vector1->values.get();
+        auto vector2Data = (int64_t*)vector2->values.get();
 
         for (int i = 0; i < NUM_TUPLES; i++) {
             vector1Data[i] = i;
@@ -37,8 +37,8 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto vector1Data = (int64_t*)vector1->values;
-        auto vector2Data = (int64_t*)vector2->values;
+        auto vector1Data = (int64_t*)vector1->values.get();
+        auto vector2Data = (int64_t*)vector2->values.get();
 
         for (int i = 0; i < NUM_TUPLES; i++) {
             vector1Data[i] = i;
@@ -50,7 +50,7 @@ public:
 TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = result->values;
+    auto resultData = result->values.get();
 
     BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::Equals>(
         *lVector, *rVector, *result);
@@ -105,7 +105,7 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
 TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatWithNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = result->values;
+    auto resultData = result->values.get();
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
         vector2->setNull(i, (i % 2) == 1);
@@ -129,7 +129,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNo
     // Flatten dataChunkWithVector1, which holds vector1
     dataChunkWithVector1->state->currIdx = 80;
     // Recall vector2 and result are in the same data chunk
-    auto resultData = result->values;
+    auto resultData = result->values.get();
 
     // Test 1: Left flat and right is unflat.
     // The comparison ins 80 < [90, 89, ...., -9]. The first 10 (90, ..., 81) the result is true,
@@ -163,7 +163,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
         vector2->setNull(i, (i % 2) == 1);
     }
     // Recall vector2 and result are in the same data chunk
-    auto resultData = result->values;
+    auto resultData = result->values.get();
 
     // Test 1: Left flat and right is unflat.
     // The comparison ins 80 < [90, NULL, 88, NULL ...., -8, NULL]. The first 10 (90, ..., 81) the
@@ -213,15 +213,15 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
 
     auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(0, lVector);
-    auto lData = ((gf_string_t*)lVector->values);
+    auto lData = ((gf_string_t*)lVector->values.get());
 
     auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(1, rVector);
-    auto rData = ((gf_string_t*)rVector->values);
+    auto rData = ((gf_string_t*)rVector->values.get());
 
     auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->insert(2, result);
-    auto resultData = result->values;
+    auto resultData = result->values.get();
 
     string value = "abcdefgh";
     lData[0].len = 8;
@@ -291,15 +291,15 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
 
     auto lVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(0, lVector);
-    auto lData = ((gf_string_t*)lVector->values);
+    auto lData = ((gf_string_t*)lVector->values.get());
 
     auto rVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     dataChunk->insert(1, rVector);
-    auto rData = ((gf_string_t*)rVector->values);
+    auto rData = ((gf_string_t*)rVector->values.get());
 
     auto result = make_shared<ValueVector>(memoryManager.get(), BOOL);
     dataChunk->insert(2, result);
-    auto resultData = result->values;
+    auto resultData = result->values.get();
 
     string value = "abcdefghijklmnopqrstuvwxy"; // 25.
     lData[0].len = 25;

--- a/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
+++ b/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
@@ -16,11 +16,11 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
 
     auto nodeVector = make_shared<ValueVector>(memoryManager.get(), NODE);
     dataChunk->insert(0, nodeVector);
-    auto nodeData = (nodeID_t*)nodeVector->values;
+    auto nodeData = (nodeID_t*)nodeVector->values.get();
 
     auto result = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->insert(1, result);
-    auto resultData = (uint64_t*)result->values;
+    auto resultData = (uint64_t*)result->values.get();
 
     // Fill values before the comparison.
     for (int32_t i = 0; i < 1000; i++) {
@@ -50,14 +50,14 @@ TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
 
     auto nodeVector = make_shared<ValueVector>(memoryManager.get(), NODE);
     for (auto i = 0u; i < 1000; i++) {
-        ((nodeID_t*)nodeVector->values)[i].label = 100;
-        ((nodeID_t*)nodeVector->values)[i].offset = 10 + i;
+        ((nodeID_t*)nodeVector->values.get())[i].label = 100;
+        ((nodeID_t*)nodeVector->values.get())[i].offset = 10 + i;
     }
     dataChunk->insert(0, nodeVector);
 
     auto result = make_shared<ValueVector>(memoryManager.get(), INT64);
     dataChunk->insert(1, result);
-    auto resultData = (uint64_t*)result->values;
+    auto resultData = (uint64_t*)result->values.get();
 
     UnaryOperationExecutor::execute<nodeID_t, hash_t, operation::Hash>(*nodeVector, *result);
     for (int32_t i = 0; i < 1000; i++) {

--- a/test/common/vector/operations/vector_string_operations_test.cpp
+++ b/test/common/vector/operations/vector_string_operations_test.cpp
@@ -19,7 +19,7 @@ public:
 TEST_F(StringArithmeticOperandsInSameDataChunkTest, StringTest) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (gf_string_t*)result->values;
+    auto resultData = (gf_string_t*)result->values.get();
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
         lVector->addString(i, to_string(i));
@@ -36,7 +36,7 @@ TEST_F(StringArithmeticOperandsInSameDataChunkTest, StringTest) {
 TEST_F(StringArithmeticOperandsInSameDataChunkTest, BigStringTest) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (gf_string_t*)result->values;
+    auto resultData = (gf_string_t*)result->values.get();
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
         lVector->addString(i, to_string(i) + "abcdefabcdefqwert");

--- a/test/common/vector/value_vector_test.cpp
+++ b/test/common/vector/value_vector_test.cpp
@@ -16,7 +16,7 @@ TEST(ValueVectorTests, TestDefaultHasNull) {
     valueVector.state = dataChunkState;
     valueVector.state->selectedSize = 3;
     for (int i = 0; i < 3; ++i) {
-        ((uint64_t*)valueVector.values)[i] = i;
+        ((uint64_t*)valueVector.values.get())[i] = i;
     }
     // Test that initially the vector does not contain any NULLs.
     EXPECT_TRUE(valueVector.hasNoNullsGuarantee());

--- a/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
+++ b/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
@@ -26,9 +26,9 @@ public:
         stringValueVector = make_shared<ValueVector>(memoryManager.get(), STRING);
         unStrValueVector = make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
         dataChunk = make_shared<DataChunk>(4);
-        auto int64Values = (int64_t*)int64ValueVector->values;
-        auto doubleValues = (double_t*)doubleValueVector->values;
-        auto unStrValues = (Value*)unStrValueVector->values;
+        auto int64Values = (int64_t*)int64ValueVector->values.get();
+        auto doubleValues = (double_t*)doubleValueVector->values.get();
+        auto unStrValues = (Value*)unStrValueVector->values.get();
         for (auto i = 0u; i < 100; i++) {
             int64Values[i] = i;
             doubleValues[i] = (double)i * 1.5;

--- a/test/processor/physical_plan/hash_table/aggregate_hash_table_test.cpp
+++ b/test/processor/physical_plan/hash_table/aggregate_hash_table_test.cpp
@@ -22,10 +22,10 @@ public:
         group2Vector = make_shared<ValueVector>(memoryManager.get(), INT64);
         aggr1Vector = make_shared<ValueVector>(memoryManager.get(), INT64);
         aggr2Vector = make_shared<ValueVector>(memoryManager.get(), INT64);
-        auto group1Values = (int64_t*)group1Vector->values;
-        auto group2Values = (int64_t*)group2Vector->values;
-        auto aggr1Values = (int64_t*)aggr1Vector->values;
-        auto aggr2Values = (int64_t*)aggr2Vector->values;
+        auto group1Values = (int64_t*)group1Vector->values.get();
+        auto group2Values = (int64_t*)group2Vector->values.get();
+        auto aggr1Values = (int64_t*)aggr1Vector->values.get();
+        auto aggr2Values = (int64_t*)aggr2Vector->values.get();
         for (auto i = 0u; i < 100; i++) {
             group1Values[i] = i % 4;
             group2Values[i] = i;

--- a/test/processor/physical_plan/operator/orderBy/key_block_merger_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/key_block_merger_test.cpp
@@ -49,7 +49,7 @@ public:
         GF_ASSERT(sortingData.size() == nullMasks.size());
         dataChunk->state->selectedSize = sortingData.size();
         auto valueVector = make_shared<ValueVector>(memoryManager.get(), dataType);
-        auto values = (T*)valueVector->values;
+        auto values = (T*)valueVector->values.get();
         for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
             if (nullMasks[i]) {
                 valueVector->setNull(i, true);
@@ -183,9 +183,9 @@ public:
         dataChunk->insert(2, timestampValueVector);
 
         for (auto i = 0u; i < int64Values.size(); i++) {
-            ((int64_t*)int64ValueVector->values)[i] = int64Values[i];
-            ((double*)doubleValueVector->values)[i] = doubleValues[i];
-            ((timestamp_t*)timestampValueVector->values)[i] = timestampValues[i];
+            ((int64_t*)int64ValueVector->values.get())[i] = int64Values[i];
+            ((double*)doubleValueVector->values.get())[i] = doubleValues[i];
+            ((timestamp_t*)timestampValueVector->values.get())[i] = timestampValues[i];
         }
     }
 

--- a/test/processor/physical_plan/operator/orderBy/order_by_key_encoder_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/order_by_key_encoder_test.cpp
@@ -50,7 +50,7 @@ public:
         for (auto i = 0u; i < numOfOrderByCols; i++) {
             shared_ptr<ValueVector> valueVector =
                 make_shared<ValueVector>(memoryManager.get(), INT64);
-            auto intValuePtr = (int64_t*)valueVector->values;
+            auto intValuePtr = (int64_t*)valueVector->values.get();
             for (auto j = 0u; j < numOfElementsPerCol; j++) {
                 intValuePtr[j] = 5;
             }
@@ -122,7 +122,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     dataChunk->state->selectedSize = 6;
     shared_ptr<ValueVector> int64ValueVector = make_shared<ValueVector>(memoryManager.get(), INT64);
-    auto int64Values = (int64_t*)int64ValueVector->values;
+    auto int64Values = (int64_t*)int64ValueVector->values.get();
     int64Values[0] = 73; // positive number
     int64ValueVector->setNull(1, true);
     int64Values[2] = -132;  // negative 1 byte number
@@ -189,7 +189,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatWithFilterTest) {
     // valueVector.
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     shared_ptr<ValueVector> int64ValueVector = make_shared<ValueVector>(memoryManager.get(), INT64);
-    auto int64Values = (int64_t*)int64ValueVector->values;
+    auto int64Values = (int64_t*)int64ValueVector->values.get();
     int64Values[0] = 73;
     int64Values[1] = -52;
     int64Values[2] = -132;
@@ -231,7 +231,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColBoolUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     dataChunk->state->selectedSize = 3;
     shared_ptr<ValueVector> boolValueVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
-    auto boolValues = (bool*)boolValueVector->values;
+    auto boolValues = (bool*)boolValueVector->values.get();
     boolValues[0] = true;
     boolValues[1] = false;
     boolValueVector->setNull(2, true);
@@ -262,7 +262,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColDateUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     dataChunk->state->selectedSize = 3;
     shared_ptr<ValueVector> dateValueVector = make_shared<ValueVector>(memoryManager.get(), DATE);
-    auto dateValues = (date_t*)dateValueVector->values;
+    auto dateValues = (date_t*)dateValueVector->values.get();
     dateValues[0] = Date::FromCString("2035-07-04", strlen("2035-07-04")); // date after 1970-01-01
     dateValueVector->setNull(1, true);
     dateValues[2] = Date::FromCString("1949-10-01", strlen("1949-10-01")); // date before 1970-01-01
@@ -300,7 +300,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColTimestampUnflatTest) {
     dataChunk->state->selectedSize = 3;
     shared_ptr<ValueVector> timestampValueVector =
         make_shared<ValueVector>(memoryManager.get(), TIMESTAMP);
-    auto timestampValues = (timestamp_t*)timestampValueVector->values;
+    auto timestampValues = (timestamp_t*)timestampValueVector->values.get();
     // timestamp before 1970-01-01
     timestampValues[0] =
         Timestamp::FromCString("1962-04-07 11:12:35.123", strlen("1962-04-07 11:12:35.123"));
@@ -352,7 +352,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColIntervalUnflatTest) {
     dataChunk->state->selectedSize = 2;
     shared_ptr<ValueVector> intervalValueVector =
         make_shared<ValueVector>(memoryManager.get(), INTERVAL);
-    auto intervalValues = (interval_t*)intervalValueVector->values;
+    auto intervalValues = (interval_t*)intervalValueVector->values.get();
     intervalValues[0] = Interval::FromCString("18 hours 55 days 13 years 8 milliseconds 3 months",
         strlen("18 hours 55 days 13 years 8 milliseconds 3 months"));
     intervalValueVector->setNull(1, true);
@@ -469,7 +469,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColDoubleUnflatTest) {
     dataChunk->state->selectedSize = 6;
     shared_ptr<ValueVector> doubleValueVector =
         make_shared<ValueVector>(memoryManager.get(), DOUBLE);
-    auto doubleValues = (double*)doubleValueVector->values;
+    auto doubleValues = (double*)doubleValueVector->values.get();
     doubleValues[0] = 3.452; // small positive number
     doubleValueVector->setNull(1, true);
     doubleValues[2] = -0.00031213;     // very small negative number
@@ -556,7 +556,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColUnstrUnflatTest) {
     dataChunk->state->selectedSize = 5;
     shared_ptr<ValueVector> unstrValueVector =
         make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
-    auto unstrValues = (Value*)unstrValueVector->values;
+    auto unstrValues = (Value*)unstrValueVector->values.get();
     unstrValues[0] = Value(38.22);
     unstrValueVector->setNull(1, true);
     unstrValues[2] =
@@ -644,10 +644,10 @@ TEST_F(OrderByKeyEncoderTest, multipleOrderByColSingleBlockTest) {
     mockDataChunk->insert(3, timestampFlatValueVector);
     mockDataChunk->insert(4, dateFlatValueVector);
 
-    auto intValues = (int64_t*)intFlatValueVector->values;
-    auto doubleValues = (double*)doubleFlatValueVector->values;
-    auto timestampValues = (timestamp_t*)timestampFlatValueVector->values;
-    auto dateValues = (date_t*)dateFlatValueVector->values;
+    auto intValues = (int64_t*)intFlatValueVector->values.get();
+    auto doubleValues = (double*)doubleFlatValueVector->values.get();
+    auto timestampValues = (timestamp_t*)timestampFlatValueVector->values.get();
+    auto dateValues = (date_t*)dateFlatValueVector->values.get();
 
     intFlatValueVector->state->currIdx = 0;
     doubleFlatValueVector->state->currIdx = 0;

--- a/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
@@ -64,7 +64,7 @@ public:
         auto dataChunk = make_shared<DataChunk>(hasPayLoadCol ? 2 : 1);
         dataChunk->state->selectedSize = sortingData.size();
         auto valueVector = make_shared<ValueVector>(memoryManager.get(), dataType);
-        auto values = (T*)valueVector->values;
+        auto values = (T*)valueVector->values.get();
         for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
             if (nullMasks[i]) {
                 valueVector->setNull(i, true);
@@ -378,10 +378,10 @@ TEST_F(RadixSortTest, multipleOrderByColNoTieTest) {
     mockDataChunk->insert(3, timestampFlatValueVector);
     mockDataChunk->insert(4, dateFlatValueVector);
 
-    auto intValues = (int64_t*)intFlatValueVector->values;
-    auto doubleValues = (double*)doubleFlatValueVector->values;
-    auto timestampValues = (timestamp_t*)timestampFlatValueVector->values;
-    auto dateValues = (date_t*)dateFlatValueVector->values;
+    auto intValues = (int64_t*)intFlatValueVector->values.get();
+    auto doubleValues = (double*)doubleFlatValueVector->values.get();
+    auto timestampValues = (timestamp_t*)timestampFlatValueVector->values.get();
+    auto dateValues = (date_t*)dateFlatValueVector->values.get();
 
     intFlatValueVector->state->currIdx = 0;
     doubleFlatValueVector->state->currIdx = 0;

--- a/test/processor/physical_plan/result/factorized_table_test.cpp
+++ b/test/processor/physical_plan/result/factorized_table_test.cpp
@@ -34,10 +34,10 @@ public:
         auto vectorB1 = resultSet->dataChunks[1]->valueVectors[0];
         auto vectorB2 = resultSet->dataChunks[1]->valueVectors[1];
 
-        auto vectorA1Data = (nodeID_t*)vectorA1->values;
-        auto vectorA2Data = (int64_t*)vectorA2->values;
-        auto vectorB1Data = (nodeID_t*)vectorB1->values;
-        auto vectorB2Data = (double*)vectorB2->values;
+        auto vectorA1Data = (nodeID_t*)vectorA1->values.get();
+        auto vectorA2Data = (int64_t*)vectorA2->values.get();
+        auto vectorB1Data = (nodeID_t*)vectorB1->values.get();
+        auto vectorB2Data = (double*)vectorB2->values.get();
         for (auto i = 0u; i < 100; i++) {
             if (i % 15) {
                 vectorA1Data[i].label = 18;
@@ -138,7 +138,7 @@ TEST_F(FactorizedTableTest, AppendAndScanOneTupleAtATime) {
     vector<shared_ptr<ValueVector>> vectorsToRead = {readResultSet->dataChunks[1]->valueVectors[0],
         readResultSet->dataChunks[0]->valueVectors[1]};
     auto vectorB1 = vectorsToRead[0];
-    auto vectorB1Data = (nodeID_t*)vectorB1->values;
+    auto vectorB1Data = (nodeID_t*)vectorB1->values.get();
     auto vectorA2 = vectorsToRead[1];
 
     for (auto i = 0u; i < 100; i++) {
@@ -157,7 +157,7 @@ TEST_F(FactorizedTableTest, AppendAndScanOneTupleAtATime) {
         for (auto j = 0u; j < 100; j++) {
             if (j % 10) {
                 ASSERT_EQ(vectorA2->isNull(j), false);
-                ASSERT_EQ(((int64_t*)vectorA2->values)[j], j << 1);
+                ASSERT_EQ(((int64_t*)vectorA2->values.get())[j], j << 1);
             } else {
                 ASSERT_EQ(vectorA2->isNull(j), true);
             }
@@ -176,9 +176,9 @@ TEST_F(FactorizedTableTest, AppendMultipleTuplesScanOneAtAtime) {
     vector<shared_ptr<ValueVector>> vectorsToScan = {readResultSet->dataChunks[0]->valueVectors[0],
         readResultSet->dataChunks[1]->valueVectors[0]};
     auto vectorA1 = vectorsToScan[0];
-    auto vectorA1Data = (nodeID_t*)vectorA1->values;
+    auto vectorA1Data = (nodeID_t*)vectorA1->values.get();
     auto vectorB1 = vectorsToScan[1];
-    auto vectorB1Data = (nodeID_t*)vectorB1->values;
+    auto vectorB1Data = (nodeID_t*)vectorB1->values.get();
 
     for (auto i = 0u; i < 100; i++) {
         // Since B1 is an unflat column in factorizedTable , we can only read one tuple from


### PR DESCRIPTION
1. This PR removes the OSBackedMemBlock related functions and class. as mentioned in this issue: #494 
2. Refactors the ValueVector to allocate memory directly from the system rather than the memoryManager.