### PR TITLE
add unary arithmetic functions

### DIFF
--- a/dataset/tinysnb/vOrganisation.csv
+++ b/dataset/tinysnb/vOrganisation.csv
@@ -1,4 +1,4 @@
-:ID,name:STRING,orgCode:INT64,mark:DOUBLE,score:INT64,history:STRING,licenseValidInterval:INTERVAL
-1,ABFsUni,325,3.7,-2,10 years 5 months 13 hours 24 us,3 years 5 days,unstrNumericProp:DOUBLE:-12.5,unstrIntervalProp1:INTERVAL:23 hours 48 days,unstrIntervalProp2:INTERVAL:23 hours 48 days
-4,CsWork,934,4.1,-100,2 years 4 days 10 hours,26 years 52 days 48 hours,unstrIntervalProp1:INTERVAL:26 years 52 days 48 hours,unstrIntervalProp2:INTERVAL:32 years 123 days 48 hours
-6,DEsWork,824,4.1,7,2 years 4 hours 22 us 34 minutes,82 hours 100 milliseconds,unstrNumericProp:DOUBLE:-3.1
+:ID,name:STRING,orgCode:INT64,mark:DOUBLE,score:INT64,history:STRING,licenseValidInterval:INTERVAL,rating:DOUBLE
+1,ABFsUni,325,3.7,-2,10 years 5 months 13 hours 24 us,3 years 5 days,1,unstrNumericProp:DOUBLE:-12.5,unstrIntervalProp1:INTERVAL:23 hours 48 days,unstrIntervalProp2:INTERVAL:23 hours 48 days
+4,CsWork,934,4.1,-100,2 years 4 days 10 hours,26 years 52 days 48 hours,0.78,unstrIntervalProp1:INTERVAL:26 years 52 days 48 hours,unstrIntervalProp2:INTERVAL:32 years 123 days 48 hours,unstrInt64Prop:INT64:-4
+6,DEsWork,824,4.1,7,2 years 4 hours 22 us 34 minutes,82 hours 100 milliseconds,0.52,unstrNumericProp:DOUBLE:3.3,unstrInt64Prop:INT64:10

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -32,6 +32,25 @@ const string ID_FUNC_NAME = "ID";
 const string ABS_FUNC_NAME = "ABS";
 const string FLOOR_FUNC_NAME = "FLOOR";
 const string CEIL_FUNC_NAME = "CEIL";
+const string SIN_FUNC_NAME = "SIN";
+const string COS_FUNC_NAME = "COS";
+const string TAN_FUNC_NAME = "TAN";
+const string COT_FUNC_NAME = "COT";
+const string ASIN_FUNC_NAME = "ASIN";
+const string ACOS_FUNC_NAME = "ACOS";
+const string ATAN_FUNC_NAME = "ATAN";
+const string EVEN_FUNC_NAME = "EVEN";
+const string FACTORIAL_FUNC_NAME = "FACTORIAL";
+const string SIGN_FUNC_NAME = "SIGN";
+const string SQRT_FUNC_NAME = "SQRT";
+const string CBRT_FUNC_NAME = "CBRT";
+const string GAMMA_FUNC_NAME = "GAMMA";
+const string LGAMMA_FUNC_NAME = "LGAMMA";
+const string LN_FUNC_NAME = "LN";
+const string LOG_FUNC_NAME = "LOG";
+const string LOG2_FUNC_NAME = "LOG2";
+const string DEGREES_FUNC_NAME = "DEGREES";
+const string RADIANS_FUNC_NAME = "RADIANS";
 
 enum ExpressionType : uint8_t {
 

--- a/src/function/arithmetic/include/vector_arithmetic_operations.h
+++ b/src/function/arithmetic/include/vector_arithmetic_operations.h
@@ -18,6 +18,49 @@ public:
 
     static pair<scalar_exec_func, DataType> bindCeilExecFunction(const expression_vector& children);
 
+    static pair<scalar_exec_func, DataType> bindSinExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindCosExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindTanExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindCotExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindAsinExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindAcosExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindAtanExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindEvenExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindFactorialExecFunction(
+        const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindSignExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindSqrtExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindCbrtExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindGammaExecFunction(
+        const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindLgammaExecFunction(
+        const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindLnExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindLogExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindLog2ExecFunction(const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindDegreesExecFunction(
+        const expression_vector& children);
+
+    static pair<scalar_exec_func, DataType> bindRadiansExecFunction(
+        const expression_vector& children);
+
 private:
     static pair<scalar_exec_func, DataType> bindBinaryExecFunction(
         ExpressionType expressionType, const expression_vector& children);

--- a/src/function/arithmetic/operations/include/arithmetic_operations.h
+++ b/src/function/arithmetic/operations/include/arithmetic_operations.h
@@ -93,6 +93,163 @@ struct Ceil {
     }
 };
 
+struct Sin {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = sin(input);
+    }
+};
+
+struct Cos {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = cos(input);
+    }
+};
+
+struct Tan {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = tan(input);
+    }
+};
+
+struct Cot {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        double tanValue;
+        Tan::operation(input, isNull, tanValue);
+        result = 1 / tanValue;
+    }
+};
+
+struct Asin {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = asin(input);
+    }
+};
+
+struct Acos {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = acos(input);
+    }
+};
+
+struct Atan {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = atan(input);
+    }
+};
+
+struct Even {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = input >= 0 ? ceil(input) : floor(input);
+        if (result % 2) {
+            result += (input >= 0 ? 1 : -1);
+        }
+    }
+};
+
+struct Factorial {
+    template<class T>
+    static inline void operation(T& input, bool isNull, T& result) {
+        assert(!isNull);
+        result = tgamma(input + 1);
+    }
+};
+
+struct Sign {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = (input > 0) - (input < 0);
+    }
+};
+
+struct Sqrt {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = sqrt(input);
+    }
+};
+
+struct Cbrt {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = cbrt(input);
+    }
+};
+
+struct Gamma {
+    template<class T>
+    static inline void operation(T& input, bool isNull, T& result) {
+        assert(!isNull);
+        result = tgamma(input);
+    }
+};
+
+struct Lgamma {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = lgamma(input);
+    }
+};
+
+struct Ln {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = log(input);
+    }
+};
+
+struct Log {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = log10(input);
+    }
+};
+
+struct Log2 {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = log2(input);
+    }
+};
+
+struct Degrees {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = input * 180 / M_PI;
+    }
+};
+
+struct Radians {
+    template<class T, class R>
+    static inline void operation(T& input, bool isNull, R& result) {
+        assert(!isNull);
+        result = input * M_PI / 180;
+    }
+};
+
 /********************************************
  **                                        **
  **   Specialized Modulo implementations   **
@@ -125,6 +282,21 @@ inline void Modulo::operation(
     double_t& left, double_t& right, double_t& result, bool isLeftNull, bool isRightNull) {
     assert(!isLeftNull && !isRightNull);
     result = fmod(left, right);
+}
+
+template<class FUNC>
+inline constexpr bool isFuncInputNumericOutputDouble() {
+    return is_same<FUNC, Sin>::value || is_same<FUNC, Cos>::value || is_same<FUNC, Tan>::value ||
+           is_same<FUNC, Cot>::value || is_same<FUNC, Asin>::value || is_same<FUNC, Acos>::value ||
+           is_same<FUNC, Atan>::value || is_same<FUNC, Sqrt>::value || is_same<FUNC, Cbrt>::value ||
+           is_same<FUNC, Lgamma>::value || is_same<FUNC, Ln>::value || is_same<FUNC, Log>::value ||
+           is_same<FUNC, Log2>::value || is_same<FUNC, Degrees>::value ||
+           is_same<FUNC, Radians>::value;
+}
+
+template<class FUNC>
+inline constexpr bool isFuncInputNumericOutputInt64() {
+    return is_same<FUNC, Even>::value || is_same<FUNC, Sign>::value;
 }
 
 /**********************************************
@@ -182,18 +354,46 @@ struct ArithmeticOnValues {
     template<class FUNC, const char* arithmeticOpStr>
     static void operation(Value& input, bool isNull, Value& result) {
         assert(!isNull);
-        switch (input.dataType.typeID) {
-        case INT64: {
-            result.dataType.typeID = INT64;
-            FUNC::operation(input.val.int64Val, isNull, result.val.int64Val);
-        } break;
-        case DOUBLE: {
+        if constexpr (isFuncInputNumericOutputDouble<FUNC>()) {
             result.dataType.typeID = DOUBLE;
-            FUNC::operation(input.val.doubleVal, isNull, result.val.doubleVal);
-        } break;
-        default:
-            throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `" +
-                                   Types::dataTypeToString(input.dataType.typeID) + "`");
+            switch (input.dataType.typeID) {
+            case INT64: {
+                FUNC::operation(input.val.int64Val, isNull, result.val.doubleVal);
+            } break;
+            case DOUBLE: {
+                FUNC::operation(input.val.doubleVal, isNull, result.val.doubleVal);
+            } break;
+            default:
+                throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `" +
+                                       Types::dataTypeToString(input.dataType.typeID) + "`");
+            }
+        } else if constexpr (isFuncInputNumericOutputInt64<FUNC>()) {
+            result.dataType.typeID = INT64;
+            switch (input.dataType.typeID) {
+            case INT64: {
+                FUNC::operation(input.val.int64Val, isNull, result.val.int64Val);
+            } break;
+            case DOUBLE: {
+                FUNC::operation(input.val.doubleVal, isNull, result.val.int64Val);
+            } break;
+            default:
+                throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `" +
+                                       Types::dataTypeToString(input.dataType.typeID) + "`");
+            }
+        } else {
+            switch (input.dataType.typeID) {
+            case INT64: {
+                result.dataType.typeID = INT64;
+                FUNC::operation(input.val.int64Val, isNull, result.val.int64Val);
+            } break;
+            case DOUBLE: {
+                result.dataType.typeID = DOUBLE;
+                FUNC::operation(input.val.doubleVal, isNull, result.val.doubleVal);
+            } break;
+            default:
+                throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `" +
+                                       Types::dataTypeToString(input.dataType.typeID) + "`");
+            }
         }
     }
 };
@@ -208,6 +408,26 @@ static const char negateStr[] = "negate";
 static const char absStr[] = "abs";
 static const char floorStr[] = "floor";
 static const char ceilStr[] = "ceil";
+static const char sinStr[] = "sin";
+static const char cosStr[] = "cos";
+static const char tanStr[] = "tan";
+static const char cotStr[] = "cot";
+static const char asinStr[] = "asin";
+static const char acosStr[] = "acos";
+static const char atanStr[] = "atan";
+static const char evenStr[] = "even";
+static const char factorialStr[] = "factorial";
+static const char signStr[] = "sign";
+static const char sqrtStr[] = "sqrt";
+static const char cbrtStr[] = "cbrt";
+static const char gammaStr[] = "gamma";
+static const char lgammaStr[] = "lgamma";
+static const char lnStr[] = "ln";
+static const char logStr[] = "log";
+static const char log2Str[] = "log2";
+static const char degreesStr[] = "degrees";
+static const char radiansStr[] = "radians";
+static const char bitCountStr[] = "bitCount";
 
 template<>
 inline void Add::operation(
@@ -339,6 +559,101 @@ inline void Floor::operation(Value& operand, bool isNull, Value& result) {
 template<>
 inline void Ceil::operation(Value& operand, bool isNull, Value& result) {
     ArithmeticOnValues::operation<Ceil, ceilStr>(operand, isNull, result);
+};
+
+template<>
+inline void Sin::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Sin, sinStr>(operand, isNull, result);
+};
+
+template<>
+inline void Cos::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Cos, cosStr>(operand, isNull, result);
+};
+
+template<>
+inline void Tan::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Tan, tanStr>(operand, isNull, result);
+};
+
+template<>
+inline void Cot::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Cot, cotStr>(operand, isNull, result);
+};
+
+template<>
+inline void Asin::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Asin, asinStr>(operand, isNull, result);
+};
+
+template<>
+inline void Acos::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Acos, acosStr>(operand, isNull, result);
+};
+
+template<>
+inline void Atan::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Atan, atanStr>(operand, isNull, result);
+};
+
+template<>
+inline void Even::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Even, evenStr>(operand, isNull, result);
+};
+
+template<>
+inline void Factorial::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Factorial, factorialStr>(operand, isNull, result);
+};
+
+template<>
+inline void Sign::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Sign, signStr>(operand, isNull, result);
+};
+
+template<>
+inline void Sqrt::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Sqrt, sqrtStr>(operand, isNull, result);
+};
+
+template<>
+inline void Cbrt::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Cbrt, cbrtStr>(operand, isNull, result);
+};
+
+template<>
+inline void Gamma::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Gamma, gammaStr>(operand, isNull, result);
+};
+
+template<>
+inline void Lgamma::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Lgamma, lgammaStr>(operand, isNull, result);
+};
+
+template<>
+inline void Ln::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Ln, lnStr>(operand, isNull, result);
+};
+
+template<>
+inline void Log::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Log, logStr>(operand, isNull, result);
+};
+
+template<>
+inline void Log2::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Log2, log2Str>(operand, isNull, result);
+};
+
+template<>
+inline void Degrees::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Degrees, degreesStr>(operand, isNull, result);
+};
+
+template<>
+inline void Radians::operation(Value& operand, bool isNull, Value& result) {
+    ArithmeticOnValues::operation<Radians, radiansStr>(operand, isNull, result);
 };
 
 } // namespace operation

--- a/src/function/arithmetic/vector_arithmetic_operations.cpp
+++ b/src/function/arithmetic/vector_arithmetic_operations.cpp
@@ -35,6 +35,120 @@ pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindCeilExecFunctio
     return bindUnaryExecFunction<operation::Ceil>(children[0]->dataType);
 }
 
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindSinExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(SIN_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Sin>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindCosExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(COS_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Cos>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindTanExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(TAN_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Tan>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindCotExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(COT_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Cot>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindAsinExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(ASIN_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Asin>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindAcosExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(ACOS_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Acos>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindAtanExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(ATAN_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Atan>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindEvenExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(EVEN_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Even>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindFactorialExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(FACTORIAL_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Factorial>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindSignExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(SIGN_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Sign>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindSqrtExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(SQRT_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Sqrt>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindCbrtExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(CBRT_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Cbrt>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindGammaExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(GAMMA_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Gamma>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindLgammaExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(LGAMMA_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Lgamma>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindLnExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(LN_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Ln>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindLogExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(LOG_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Log>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindLog2ExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(LOG2_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Log2>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindDegreesExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(DEGREES_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Degrees>(children[0]->dataType);
+}
+
+pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindRadiansExecFunction(
+    const expression_vector& children) {
+    validateNumParameters(RADIANS_FUNC_NAME, children.size(), 1);
+    return bindUnaryExecFunction<operation::Radians>(children[0]->dataType);
+}
+
 pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindBinaryExecFunction(
     ExpressionType expressionType, const expression_vector& children) {
     assert(children.size() == 2);
@@ -276,18 +390,48 @@ pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindUnaryExecFuncti
 template<typename FUNC>
 pair<scalar_exec_func, DataType> VectorArithmeticOperations::bindUnaryExecFunction(
     const DataType& operandType) {
-    switch (operandType.typeID) {
-    case INT64: {
-        return make_pair(UnaryExecFunction<int64_t, int64_t, FUNC>, DataType(INT64));
-    }
-    case DOUBLE: {
-        return make_pair(UnaryExecFunction<double_t, double_t, FUNC>, DataType(DOUBLE));
-    }
-    case UNSTRUCTURED: {
-        return make_pair(UnaryExecFunction<Value, Value, FUNC>, DataType(UNSTRUCTURED));
-    }
-    default:
-        assert(false);
+    if constexpr (operation::isFuncInputNumericOutputDouble<FUNC>()) {
+        switch (operandType.typeID) {
+        case INT64: {
+            return make_pair(UnaryExecFunction<int64_t, double_t, FUNC>, DataType(DOUBLE));
+        }
+        case DOUBLE: {
+            return make_pair(UnaryExecFunction<double_t, double_t, FUNC>, DataType(DOUBLE));
+        }
+        case UNSTRUCTURED: {
+            return make_pair(UnaryExecFunction<Value, Value, FUNC>, DataType(UNSTRUCTURED));
+        }
+        default:
+            assert(false);
+        }
+    } else if constexpr (operation::isFuncInputNumericOutputInt64<FUNC>()) {
+        switch (operandType.typeID) {
+        case INT64: {
+            return make_pair(UnaryExecFunction<int64_t, int64_t, FUNC>, DataType(INT64));
+        }
+        case DOUBLE: {
+            return make_pair(UnaryExecFunction<double_t, int64_t, FUNC>, DataType(INT64));
+        }
+        case UNSTRUCTURED: {
+            return make_pair(UnaryExecFunction<Value, Value, FUNC>, DataType(UNSTRUCTURED));
+        }
+        default:
+            assert(false);
+        }
+    } else {
+        switch (operandType.typeID) {
+        case INT64: {
+            return make_pair(UnaryExecFunction<int64_t, int64_t, FUNC>, DataType(INT64));
+        }
+        case DOUBLE: {
+            return make_pair(UnaryExecFunction<double_t, double_t, FUNC>, DataType(DOUBLE));
+        }
+        case UNSTRUCTURED: {
+            return make_pair(UnaryExecFunction<Value, Value, FUNC>, DataType(UNSTRUCTURED));
+        }
+        default:
+            assert(false);
+        }
     }
 }
 

--- a/src/function/built_in_functions_binder.cpp
+++ b/src/function/built_in_functions_binder.cpp
@@ -35,6 +35,63 @@ pair<scalar_exec_func, DataType> BuiltInFunctionsBinder::bindExecFunction(
     case CEIL: {
         return VectorArithmeticOperations::bindCeilExecFunction(children);
     }
+    case SIN: {
+        return VectorArithmeticOperations::bindSinExecFunction(children);
+    }
+    case COS: {
+        return VectorArithmeticOperations::bindCosExecFunction(children);
+    }
+    case TAN: {
+        return VectorArithmeticOperations::bindTanExecFunction(children);
+    }
+    case COT: {
+        return VectorArithmeticOperations::bindCotExecFunction(children);
+    }
+    case ASIN: {
+        return VectorArithmeticOperations::bindAsinExecFunction(children);
+    }
+    case ACOS: {
+        return VectorArithmeticOperations::bindAcosExecFunction(children);
+    }
+    case ATAN: {
+        return VectorArithmeticOperations::bindAtanExecFunction(children);
+    }
+    case EVEN: {
+        return VectorArithmeticOperations::bindEvenExecFunction(children);
+    }
+    case FACTORIAL: {
+        return VectorArithmeticOperations::bindFactorialExecFunction(children);
+    }
+    case SIGN: {
+        return VectorArithmeticOperations::bindSignExecFunction(children);
+    }
+    case SQRT: {
+        return VectorArithmeticOperations::bindSqrtExecFunction(children);
+    }
+    case CBRT: {
+        return VectorArithmeticOperations::bindCbrtExecFunction(children);
+    }
+    case GAMMA: {
+        return VectorArithmeticOperations::bindGammaExecFunction(children);
+    }
+    case LGAMMA: {
+        return VectorArithmeticOperations::bindLgammaExecFunction(children);
+    }
+    case LN: {
+        return VectorArithmeticOperations::bindLnExecFunction(children);
+    }
+    case LOG: {
+        return VectorArithmeticOperations::bindLogExecFunction(children);
+    }
+    case LOG2: {
+        return VectorArithmeticOperations::bindLog2ExecFunction(children);
+    }
+    case DEGREES: {
+        return VectorArithmeticOperations::bindDegreesExecFunction(children);
+    }
+    case RADIANS: {
+        return VectorArithmeticOperations::bindRadiansExecFunction(children);
+    }
     default:
         assert(false);
     }

--- a/src/function/include/built_in_functions_binder.h
+++ b/src/function/include/built_in_functions_binder.h
@@ -25,10 +25,29 @@ enum BuiltInFunctionIndices : uint8_t {
     // id function
     INTERNAL_ID = 100,
 
-    // arithmetic functions
+    // unary arithmetic functions
     ABS = 150,
     FLOOR = 151,
     CEIL = 152,
+    SIN = 153,
+    COS = 154,
+    TAN = 155,
+    COT = 156,
+    ASIN = 157,
+    ACOS = 158,
+    ATAN = 159,
+    EVEN = 160,
+    FACTORIAL = 161,
+    SIGN = 162,
+    SQRT = 163,
+    CBRT = 164,
+    GAMMA = 165,
+    LGAMMA = 166,
+    LN = 167,
+    LOG = 168,
+    LOG2 = 169,
+    DEGREES = 170,
+    RADIANS = 171,
 };
 
 static const unordered_map<string, BuiltInFunctionIndices> functionNameToIndicesMap{
@@ -37,7 +56,12 @@ static const unordered_map<string, BuiltInFunctionIndices> functionNameToIndices
     {CAST_TO_INTERVAL_FUNCTION_NAME, CAST_STRING_TO_INTERVAL},
     {CAST_TO_STRING_FUNCTION_NAME, CAST_TO_STRING}, {LIST_CREATION_FUNC_NAME, LIST_CREATION},
     {ID_FUNC_NAME, INTERNAL_ID}, {ABS_FUNC_NAME, ABS}, {FLOOR_FUNC_NAME, FLOOR},
-    {CEIL_FUNC_NAME, CEIL}};
+    {CEIL_FUNC_NAME, CEIL}, {SIN_FUNC_NAME, SIN}, {COS_FUNC_NAME, COS}, {TAN_FUNC_NAME, TAN},
+    {COT_FUNC_NAME, COT}, {ASIN_FUNC_NAME, ASIN}, {ACOS_FUNC_NAME, ACOS}, {ATAN_FUNC_NAME, ATAN},
+    {EVEN_FUNC_NAME, EVEN}, {FACTORIAL_FUNC_NAME, FACTORIAL}, {SIGN_FUNC_NAME, SIGN},
+    {SQRT_FUNC_NAME, SQRT}, {CBRT_FUNC_NAME, CBRT}, {GAMMA_FUNC_NAME, GAMMA},
+    {LGAMMA_FUNC_NAME, LGAMMA}, {LN_FUNC_NAME, LN}, {LOG_FUNC_NAME, LOG}, {LOG2_FUNC_NAME, LOG2},
+    {DEGREES_FUNC_NAME, DEGREES}, {RADIANS_FUNC_NAME, RADIANS}};
 
 class BuiltInFunctionsBinder {
 

--- a/test/runner/queries/functions/arithmetic_functions.test
+++ b/test/runner/queries/functions/arithmetic_functions.test
@@ -1,0 +1,505 @@
+-NAME sinFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN sin(a.mark)
+---- 3
+-0.529836
+-0.818277
+-0.818277
+
+-NAME sinFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN sin(a.orgCode)
+---- 3
+-0.988036
+-0.811656
+0.785018
+
+-NAME sinFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN sin(a.unstrInt64Prop)
+---- 3
+-0.544021
+0.756802
+
+
+-NAME sinFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN sin(a.unstrNumericProp)
+---- 3
+0.066322
+-0.157746
+
+
+-NAME cosFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN cos(a.mark)
+---- 3
+-0.848100
+-0.574824
+-0.574824
+-NAME cosFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN cos(a.orgCode)
+---- 3
+-0.154222
+-0.584135
+0.619473
+
+-NAME cosFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN cos(a.unstrInt64Prop)
+---- 3
+-0.839072
+-0.653644
+
+
+-NAME cosFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN cos(a.unstrNumericProp)
+---- 3
+0.997798
+-0.987480
+
+
+-NAME tanFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN tan(a.mark)
+---- 3
+0.624733
+1.423526
+1.423526
+
+-NAME tanFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN tan(a.orgCode)
+---- 3
+6.406598
+1.389500
+1.267234
+
+-NAME tanFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN tan(a.unstrInt64Prop)
+---- 3
+0.648361
+-1.157821
+
+
+-NAME tanFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN tan(a.unstrNumericProp)
+---- 3
+0.066468
+0.159746
+
+
+-NAME cotFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN cot(a.mark)
+---- 3
+1.600684
+0.702481
+0.702481
+
+-NAME cotFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN cot(a.orgCode)
+---- 3
+0.156089
+0.719683
+0.789120
+
+-NAME cotFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN cot(a.unstrInt64Prop)
+---- 3
+1.542351
+-0.863691
+
+
+-NAME cotFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN cot(a.unstrNumericProp)
+---- 3
+15.044779
+6.259948
+
+
+-NAME asinFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN asin(a.rating)
+---- 3
+1.570796
+0.894666
+0.546851
+
+-NAME asinFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN asin(a.orgCode % 2 - 1)
+---- 3
+0.000000
+-1.570796
+-1.570796
+
+-NAME asinFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN asin(a.unstrInt64Prop % 2 - 1)
+---- 3
+-1.570796
+-1.570796
+
+
+-NAME asinFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN asin(a.unstrNumericProp / 14)
+---- 3
+-1.103650
+0.237953
+
+
+-NAME acosFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN acos(a.rating)
+---- 3
+0.000000
+0.676131
+1.023945
+
+-NAME acosFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN acos(a.orgCode % 2 - 1)
+---- 3
+1.570796
+3.141593
+3.141593
+
+-NAME acosFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN acos(a.unstrInt64Prop % 2 - 1)
+---- 3
+3.141593
+3.141593
+
+
+-NAME acosFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN acos(a.unstrNumericProp / 14)
+---- 3
+2.674447
+1.332843
+
+
+-NAME atanFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN atan(a.rating)
+---- 3
+0.785398
+0.662426
+0.479519
+
+-NAME atanFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN atan(a.orgCode % 2 - 1)
+---- 3
+0.000000
+-0.785398
+-0.785398
+
+-NAME atanFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN atan(a.unstrInt64Prop % 2 - 1)
+---- 3
+-0.785398
+-0.785398
+
+
+-NAME atanFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN atan(a.unstrNumericProp / 14)
+---- 3
+-0.728855
+0.231489
+
+-NAME evenFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN even(a.mark)
+---- 3
+4
+6
+6
+
+-NAME evenFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN even(a.orgCode)
+---- 3
+326
+934
+824
+
+-NAME evenFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN even(a.unstrInt64Prop)
+---- 3
+10
+-4
+
+
+-NAME evenFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN even(a.unstrNumericProp)
+---- 3
+-14
+4
+
+-NAME factorialFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN factorial(a.orgCode % 20)
+---- 3
+120
+24
+87178291200
+
+-NAME factorialFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN factorial(a.unstrInt64Prop + 4)
+---- 3
+87178291200
+1
+
+
+-NAME signFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN sign(a.mark)
+---- 3
+1
+1
+1
+
+-NAME signFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN sign(a.orgCode)
+---- 3
+1
+1
+1
+
+-NAME signFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN sign(a.unstrInt64Prop)
+---- 3
+1
+-1
+
+
+-NAME signFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN sign(a.unstrNumericProp)
+---- 3
+-1
+1
+
+-NAME sqrtFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN sqrt(a.mark)
+---- 3
+1.923538
+2.024846
+2.024846
+
+-NAME sqrtFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN sqrt(a.orgCode)
+---- 3
+18.027756
+30.561414
+28.705400
+
+-NAME sqrtFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN sqrt(a.unstrInt64Prop + 6)
+---- 3
+1.414214
+4.000000
+
+
+-NAME sqrtFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN sqrt(a.unstrNumericProp + 13.5)
+---- 3
+1.000000
+4.098780
+
+
+-NAME cbrtFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN cbrt(a.mark)
+---- 3
+1.546680
+1.600521
+1.600521
+
+-NAME cbrtFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN cbrt(a.orgCode)
+---- 3
+6.875344
+9.774974
+9.375096
+
+-NAME cbrtFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN cbrt(a.unstrInt64Prop)
+---- 3
+2.154435
+-1.587401
+
+
+-NAME cbrtFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN cbrt(a.unstrNumericProp)
+---- 3
+-2.320794
+1.488806
+
+
+-NAME gammaFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN gamma(a.mark)
+---- 3
+4.170652
+6.812623
+6.812623
+
+-NAME gammaFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN gamma(a.orgCode % 10)
+---- 3
+24
+6
+6
+
+-NAME gammaFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN gamma(a.unstrInt64Prop + 7)
+---- 3
+20922789888000
+2
+
+
+-NAME gammaFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN gamma(a.unstrNumericProp + 12.9)
+---- 3
+2.218160
+2265368186995.468750
+
+-NAME lgammaFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN lgamma(a.mark)
+---- 3
+1.428072
+1.918777
+1.918777
+
+-NAME lgammaFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN lgamma(a.orgCode)
+---- 3
+1552.770467
+5451.570283
+4706.038471
+
+-NAME lgammaFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN lgamma(a.unstrInt64Prop + 5)
+---- 3
+0.000000
+25.191221
+
+
+-NAME lnFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN ln(a.mark)
+---- 3
+1.308333
+1.410987
+1.410987
+
+-NAME lnFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN ln(a.orgCode)
+---- 3
+5.783825
+6.839476
+6.714171
+
+-NAME lnFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN ln(a.unstrInt64Prop + 5)
+---- 3
+2.708050
+0.000000
+
+
+-NAME lnFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN ln(a.unstrNumericProp + 13.2)
+---- 3
+-0.356675
+2.803360
+
+
+-NAME logFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN log(a.mark)
+---- 3
+0.568202
+0.612784
+0.612784
+
+-NAME logFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN log(a.orgCode)
+---- 3
+2.511883
+2.970347
+2.915927
+
+-NAME logFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN log(a.unstrInt64Prop + 5)
+---- 3
+1.176091
+0.000000
+
+
+-NAME logFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN log(a.unstrNumericProp + 13.2)
+---- 3
+-0.154902
+1.217484
+
+
+-NAME log2FunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN log2(a.mark)
+---- 3
+1.887525
+2.035624
+2.035624
+
+-NAME log2FunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN log2(a.orgCode)
+---- 3
+8.344296
+9.867279
+9.686501
+
+-NAME log2FunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN log2(a.unstrInt64Prop + 5)
+---- 3
+3.906891
+0.000000
+
+
+-NAME log2FunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN log2(a.unstrNumericProp + 13.2)
+---- 3
+-0.514573
+4.044394
+
+
+-NAME degreesFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN degrees(a.mark)
+---- 3
+211.994384
+234.912696
+234.912696
+
+-NAME degreesFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN degrees(a.orgCode)
+---- 3
+18621.128342
+53514.258065
+47211.722319
+
+-NAME degreesFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN degrees(a.unstrInt64Prop)
+---- 3
+572.957795
+-229.183118
+
+
+-NAME degreesFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN degrees(a.unstrNumericProp)
+---- 3
+-716.197244
+189.076072
+
+
+-NAME radiansFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN radians(a.mark)
+---- 3
+0.064577
+0.071558
+0.071558
+
+-NAME radiansFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN radians(a.orgCode)
+---- 3
+5.672320
+16.301375
+14.381513
+
+-NAME radiansFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN radians(a.unstrInt64Prop)
+---- 3
+0.174533
+-0.069813
+
+
+-NAME radiansFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN radians(a.unstrNumericProp)
+---- 3
+-0.218166
+0.057596
+

--- a/test/runner/queries/projection/projection.test
+++ b/test/runner/queries/projection/projection.test
@@ -12,7 +12,7 @@
 ---- 3
 
 12.500000
-3.100000
+3.300000
 
 -NAME FloorFunctionTest1
 -QUERY MATCH (a:organisation) RETURN floor(a.score)
@@ -26,7 +26,7 @@
 ---- 3
 -13.000000
 
--4.000000
+3.000000
 
 -NAME CeilFunctionTest1
 -QUERY MATCH (a:organisation) RETURN ceil(a.score)
@@ -40,14 +40,14 @@
 ---- 3
 -12.000000
 
--3.000000
+4.000000
 
 -NAME CeilFloorFunctionTest1
 -QUERY MATCH (a:organisation) RETURN ceil(ceil(a.unstrNumericProp + abs(-0.5)) + floor(3.5))
 ---- 3
 
 -9.000000
-1.000000
+7.000000
 
 -NAME IsNullTest1
 -QUERY MATCH (a:person) RETURN a.fName, a.unstrNumericProp IS NULL, a.unstrDateProp1 IS NOT NULL
@@ -64,9 +64,9 @@ Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|True|False
 -NAME OrgNodesReturnStarTest
 -QUERY MATCH (a:organisation) RETURN *
 ---- 3
-1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|48 days 23:00:00|48 days 23:00:00|-12.500000
-4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|32 years 123 days 48:00:00|26 years 52 days 48:00:00|
-6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|||-3.100000
+1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000|48 days 23:00:00||48 days 23:00:00|-12.500000
+4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000|32 years 123 days 48:00:00|-4|26 years 52 days 48:00:00|
+6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000||10||3.300000
 
 -NAME PersonNodesTestUnstructuredProperty
 -QUERY MATCH (a:person) RETURN a.ID,a.unstrDateProp1

--- a/test/runner/tinysnb_end_to_end_test.cpp
+++ b/test/runner/tinysnb_end_to_end_test.cpp
@@ -91,6 +91,9 @@ TEST_F(TinySnbProcessorTest, FunctionTests) {
     ASSERT_TRUE(TestHelper::runTest(queryConfigs, *conn));
     queryConfigs = TestHelper::parseTestFile("test/runner/queries/functions/string_functions.test");
     ASSERT_TRUE(TestHelper::runTest(queryConfigs, *conn));
+    queryConfigs =
+        TestHelper::parseTestFile("test/runner/queries/functions/arithmetic_functions.test");
+    ASSERT_TRUE(TestHelper::runTest(queryConfigs, *conn));
 }
 
 TEST_F(TinySnbProcessorTest, ProjectionTests) {


### PR DESCRIPTION
This PR adds some unary arithmetic functions as described in this issue #539 
These unary arithmetic functions are added in this PR:

-  sin(x)
-  cos(x)
-  tan(x)
-  cot(x)
-  asin(x)
-  acos(x)
-  atan(x)
- even(x)
-  factorial(x)
-  sign(x)
-  sqrt(x)
-  cbrt(x)
-  gamma(x)
-  lgamma(x)
- ln(x)
-  log(x)
-  log2(x)
- degrees(x)
-  radians(x)