### PR TITLE
Implicit cast

### DIFF
--- a/src/binder/expression/BUILD.bazel
+++ b/src/binder/expression/BUILD.bazel
@@ -35,11 +35,7 @@ cc_library(
         "include/rel_expression.h",
     ],
     visibility = [
-        "//src/binder:__subpackages__",
-        "//src/expression_evaluator:__pkg__",
-        "//src/function:__pkg__",
-        "//src/planner:__pkg__",
-        "//src/processor:__pkg__",
+        "//visibility:public",
     ],
     deps = [
         "base_expression",

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -34,8 +34,9 @@ private:
     shared_ptr<Expression> bindPropertyExpression(const ParsedExpression& parsedExpression);
 
     shared_ptr<Expression> bindFunctionExpression(const ParsedExpression& parsedExpression);
-    shared_ptr<Expression> bindSpecialFunctions(const string& functionName,
+    shared_ptr<Expression> staticEvaluate(const string& functionName,
         const ParsedExpression& parsedExpression, const expression_vector& children);
+
     shared_ptr<Expression> bindCountStarFunctionExpression(
         const ParsedExpression& parsedExpression);
     shared_ptr<Expression> bindCountFunctionExpression(const ParsedExpression& parsedExpression);
@@ -52,16 +53,16 @@ private:
         const ParsedExpression& parsedExpression);
 
     /****** cast *****/
-    static shared_ptr<Expression> castUnstructuredToBool(shared_ptr<Expression> expression);
+    static shared_ptr<Expression> implicitCastIfNecessary(
+        const shared_ptr<Expression>& expression, const DataType& targetType);
+    static shared_ptr<Expression> implicitCastToBool(const shared_ptr<Expression>& expression);
+    static shared_ptr<Expression> implicitCastToUnstructured(
+        const shared_ptr<Expression>& expression);
+    static shared_ptr<Expression> implicitCastToString(const shared_ptr<Expression>& expression);
 
     // For overload functions (e.g. arithmetic and comparison), if any parameter is UNSTRUCTURED, we
     // cast all parameters as UNSTRUCTURED.
     static expression_vector castToUnstructuredIfNecessary(const expression_vector& parameters);
-
-    template<typename T>
-    static shared_ptr<Expression> castStringToTemporalLiteral(
-        const shared_ptr<Expression>& expression, ExpressionType expressionType,
-        const DataType& resultType, std::function<T(const char*, uint64_t)> castFunction);
 
     /****** validation *****/
 

--- a/src/function/boolean/include/vector_boolean_operations.h
+++ b/src/function/boolean/include/vector_boolean_operations.h
@@ -43,11 +43,6 @@ private:
 
     static scalar_select_func bindUnarySelectFunction(
         ExpressionType expressionType, const expression_vector& children);
-
-    static void validate(
-        ExpressionType expressionType, const DataType& leftType, const DataType& rightType);
-
-    static void validate(ExpressionType expressionType, const DataType& childType);
 };
 
 } // namespace function

--- a/src/function/boolean/vector_boolean_operations.cpp
+++ b/src/function/boolean/vector_boolean_operations.cpp
@@ -30,7 +30,7 @@ scalar_exec_func VectorBooleanOperations::bindBinaryExecFunction(
     assert(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
-    validate(expressionType, leftType, rightType);
+    assert(leftType.typeID == BOOL && rightType.typeID == BOOL);
     switch (expressionType) {
     case AND: {
         return BinaryBooleanExecFunction<operation::And>;
@@ -51,7 +51,7 @@ scalar_select_func VectorBooleanOperations::bindBinarySelectFunction(
     assert(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
-    validate(expressionType, leftType, rightType);
+    assert(leftType.typeID == BOOL && rightType.typeID == BOOL);
     switch (expressionType) {
     case AND: {
         return BinaryBooleanSelectFunction<operation::And>;
@@ -69,9 +69,7 @@ scalar_select_func VectorBooleanOperations::bindBinarySelectFunction(
 
 scalar_exec_func VectorBooleanOperations::bindUnaryExecFunction(
     ExpressionType expressionType, const expression_vector& children) {
-    assert(children.size() == 1);
-    auto childType = children[0]->dataType;
-    validate(expressionType, childType);
+    assert(children.size() == 1 && children[0]->dataType.typeID == BOOL);
     switch (expressionType) {
     case NOT: {
         return UnaryExecFunction<bool, uint8_t, operation::Not>;
@@ -83,33 +81,13 @@ scalar_exec_func VectorBooleanOperations::bindUnaryExecFunction(
 
 scalar_select_func VectorBooleanOperations::bindUnarySelectFunction(
     ExpressionType expressionType, const expression_vector& children) {
-    assert(children.size() == 1);
-    auto childType = children[0]->dataType;
-    validate(expressionType, childType);
+    assert(children.size() == 1 && children[0]->dataType.typeID == BOOL);
     switch (expressionType) {
     case NOT: {
         return UnarySelectFunction<bool, operation::Not>;
     }
     default:
         assert(false);
-    }
-}
-
-void VectorBooleanOperations::validate(
-    ExpressionType expressionType, const DataType& leftType, const DataType& rightType) {
-    if (leftType.typeID != BOOL || rightType.typeID != BOOL) {
-        throw invalid_argument(expressionTypeToString(expressionType) +
-                               " is defined on (BOOL, BOOL) but get (" +
-                               Types::dataTypeToString(leftType.typeID) + ", " +
-                               Types::dataTypeToString(rightType.typeID) + ").");
-    }
-}
-
-void VectorBooleanOperations::validate(ExpressionType expressionType, const DataType& childType) {
-    if (childType.typeID != BOOL) {
-        throw invalid_argument(expressionTypeToString(expressionType) +
-                               " is defined on (BOOL) but get (" +
-                               Types::dataTypeToString(childType.typeID) + ").");
     }
 }
 

--- a/src/function/built_in_functions_binder.cpp
+++ b/src/function/built_in_functions_binder.cpp
@@ -12,16 +12,16 @@ pair<scalar_exec_func, DataType> BuiltInFunctionsBinder::bindExecFunction(
     validateFunctionExistence(functionName);
     switch (functionNameToIndicesMap.at(functionName)) {
     case CAST_STRING_TO_DATE: {
-        return VectorCastOperations::bindCastStringToDateExecFunction(children);
+        return VectorCastOperations::bindExplicitCastStringToDate(children);
     }
     case CAST_STRING_TO_TIMESTAMP: {
-        return VectorCastOperations::bindCastStringToTimestampExecFunction(children);
+        return VectorCastOperations::bindExplicitCastStringToTimestamp(children);
     }
     case CAST_STRING_TO_INTERVAL: {
-        return VectorCastOperations::bindCastStringToIntervalExecFunction(children);
+        return VectorCastOperations::bindExplicitCastStringToInterval(children);
     }
     case CAST_TO_STRING: {
-        return VectorCastOperations::bindCastStructuredToStringExecFunction(children);
+        return VectorCastOperations::bindExplicitCastToString(children);
     }
     case LIST_CREATION: {
         return VectorListOperations::bindListCreationExecFunction(children);

--- a/src/function/include/built_in_functions_binder.h
+++ b/src/function/include/built_in_functions_binder.h
@@ -25,7 +25,7 @@ enum BuiltInFunctionIndices : uint8_t {
     // id function
     INTERNAL_ID = 100,
 
-    // unary arithmetic functions
+    // Arithmetic functions
     ABS = 150,
     FLOOR = 151,
     CEIL = 152,
@@ -51,17 +51,34 @@ enum BuiltInFunctionIndices : uint8_t {
 };
 
 static const unordered_map<string, BuiltInFunctionIndices> functionNameToIndicesMap{
-    {CAST_TO_DATE_FUNCTION_NAME, CAST_STRING_TO_DATE},
-    {CAST_TO_TIMESTAMP_FUNCTION_NAME, CAST_STRING_TO_TIMESTAMP},
-    {CAST_TO_INTERVAL_FUNCTION_NAME, CAST_STRING_TO_INTERVAL},
-    {CAST_TO_STRING_FUNCTION_NAME, CAST_TO_STRING}, {LIST_CREATION_FUNC_NAME, LIST_CREATION},
-    {ID_FUNC_NAME, INTERNAL_ID}, {ABS_FUNC_NAME, ABS}, {FLOOR_FUNC_NAME, FLOOR},
-    {CEIL_FUNC_NAME, CEIL}, {SIN_FUNC_NAME, SIN}, {COS_FUNC_NAME, COS}, {TAN_FUNC_NAME, TAN},
-    {COT_FUNC_NAME, COT}, {ASIN_FUNC_NAME, ASIN}, {ACOS_FUNC_NAME, ACOS}, {ATAN_FUNC_NAME, ATAN},
-    {EVEN_FUNC_NAME, EVEN}, {FACTORIAL_FUNC_NAME, FACTORIAL}, {SIGN_FUNC_NAME, SIGN},
-    {SQRT_FUNC_NAME, SQRT}, {CBRT_FUNC_NAME, CBRT}, {GAMMA_FUNC_NAME, GAMMA},
-    {LGAMMA_FUNC_NAME, LGAMMA}, {LN_FUNC_NAME, LN}, {LOG_FUNC_NAME, LOG}, {LOG2_FUNC_NAME, LOG2},
-    {DEGREES_FUNC_NAME, DEGREES}, {RADIANS_FUNC_NAME, RADIANS}};
+    {CAST_TO_DATE_FUNCTION_NAME, CAST_STRING_TO_DATE},           //
+    {CAST_TO_TIMESTAMP_FUNCTION_NAME, CAST_STRING_TO_TIMESTAMP}, //
+    {CAST_TO_INTERVAL_FUNCTION_NAME, CAST_STRING_TO_INTERVAL},   //
+    {CAST_TO_STRING_FUNCTION_NAME, CAST_TO_STRING},              //
+    {LIST_CREATION_FUNC_NAME, LIST_CREATION},                    //
+    {ID_FUNC_NAME, INTERNAL_ID},                                 //
+    {ABS_FUNC_NAME, ABS},                                        //
+    {FLOOR_FUNC_NAME, FLOOR},                                    //
+    {CEIL_FUNC_NAME, CEIL},                                      //
+    {SIN_FUNC_NAME, SIN},                                        //
+    {COS_FUNC_NAME, COS},                                        //
+    {TAN_FUNC_NAME, TAN},                                        //
+    {COT_FUNC_NAME, COT},                                        //
+    {ASIN_FUNC_NAME, ASIN},                                      //
+    {ACOS_FUNC_NAME, ACOS},                                      //
+    {ATAN_FUNC_NAME, ATAN},                                      //
+    {EVEN_FUNC_NAME, EVEN},                                      //
+    {FACTORIAL_FUNC_NAME, FACTORIAL},                            //
+    {SIGN_FUNC_NAME, SIGN},                                      //
+    {SQRT_FUNC_NAME, SQRT},                                      //
+    {CBRT_FUNC_NAME, CBRT},                                      //
+    {GAMMA_FUNC_NAME, GAMMA},                                    //
+    {LGAMMA_FUNC_NAME, LGAMMA},                                  //
+    {LN_FUNC_NAME, LN},                                          //
+    {LOG_FUNC_NAME, LOG},                                        //
+    {LOG2_FUNC_NAME, LOG2},                                      //
+    {DEGREES_FUNC_NAME, DEGREES},                                //
+    {RADIANS_FUNC_NAME, RADIANS}};
 
 class BuiltInFunctionsBinder {
 

--- a/src/function/include/vector_operations.h
+++ b/src/function/include/vector_operations.h
@@ -16,7 +16,7 @@ using scalar_select_func = std::function<uint64_t(const vector<shared_ptr<ValueV
 
 class VectorOperations {
 
-protected:
+public:
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
     static void BinaryExecFunction(
         const vector<shared_ptr<ValueVector>>& params, ValueVector& result) {

--- a/src/function/string/include/vector_string_operations.h
+++ b/src/function/string/include/vector_string_operations.h
@@ -20,9 +20,6 @@ private:
 
     static scalar_select_func bindBinarySelectFunction(
         ExpressionType expressionType, const expression_vector& children);
-
-    static void validate(
-        ExpressionType expressionType, DataTypeID leftTypeID, DataTypeID rightTypeID);
 };
 
 } // namespace function

--- a/src/function/string/vector_string_operations.cpp
+++ b/src/function/string/vector_string_operations.cpp
@@ -24,7 +24,7 @@ scalar_exec_func VectorStringOperations::bindBinaryExecFunction(
     assert(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
-    validate(expressionType, leftType.typeID, rightType.typeID);
+    assert(leftType.typeID == STRING && rightType.typeID == STRING);
     switch (expressionType) {
     case ADD: {
         return BinaryExecFunction<gf_string_t, gf_string_t, gf_string_t, operation::Concat>;
@@ -45,7 +45,7 @@ scalar_select_func VectorStringOperations::bindBinarySelectFunction(
     assert(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
-    validate(expressionType, leftType.typeID, rightType.typeID);
+    assert(leftType.typeID == STRING && rightType.typeID == STRING);
     switch (expressionType) {
     case CONTAINS: {
         return BinarySelectFunction<gf_string_t, gf_string_t, operation::Contains>;
@@ -55,16 +55,6 @@ scalar_select_func VectorStringOperations::bindBinarySelectFunction(
     }
     default:
         assert(false);
-    }
-}
-
-void VectorStringOperations::validate(
-    ExpressionType expressionType, DataTypeID leftTypeID, DataTypeID rightTypeID) {
-    if (leftTypeID != STRING || rightTypeID != STRING) {
-        throw invalid_argument(expressionTypeToString(expressionType) +
-                               " is defined on (STRING, STRING) but get (" +
-                               Types::dataTypeToString(leftTypeID) + ", " +
-                               Types::dataTypeToString(rightTypeID) + ").");
     }
 }
 

--- a/test/common/vector/operations/vector_cast_operations_test.cpp
+++ b/test/common/vector/operations/vector_cast_operations_test.cpp
@@ -39,7 +39,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredBoolToUnstructuredValueTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = (i % 2) == 0;
     }
-    VectorCastOperations::castStructuredToUnstructuredValue(
+    VectorOperations::UnaryExecFunction<uint8_t, Value, operation::CastToUnstructured>(
         vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].val.booleanVal, (i % 2) == 0);
@@ -59,7 +59,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredInt64ToUnstructuredValueTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = i * 2;
     }
-    VectorCastOperations::castStructuredToUnstructuredValue(
+    VectorOperations::UnaryExecFunction<int64_t, Value, operation::CastToUnstructured>(
         vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, i * 2);
@@ -79,7 +79,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredDoubleToUnstructuredValueTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = (double)(i * 2);
     }
-    VectorCastOperations::castStructuredToUnstructuredValue(
+    VectorOperations::UnaryExecFunction<double_t, Value, operation::CastToUnstructured>(
         vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)(i * 2));
@@ -99,7 +99,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredDateToUnstructuredValueTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = date_t(i * 2);
     }
-    VectorCastOperations::castStructuredToUnstructuredValue(
+    VectorOperations::UnaryExecFunction<date_t, Value, operation::CastToUnstructured>(
         vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].val.dateVal, date_t(i * 2));
@@ -120,7 +120,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredStringToUnstructuredValueTest) {
         string lStr = to_string(i * 2);
         TypeUtils::copyString(lStr, lData[i], lVector->getOverflowBuffer());
     }
-    VectorCastOperations::castStructuredToUnstructuredValue(
+    VectorCastOperations::castStringToUnstructured(
         vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].val.strVal.getAsString(), to_string(i * 2));
@@ -140,7 +140,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredBooleanToStringTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = i % 2 == 0;
     }
-    VectorCastOperations::castStructuredToString(vector<shared_ptr<ValueVector>>{lVector}, *result);
+    VectorCastOperations::castToString<bool>(vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].getAsString(), (i % 2 == 0 ? "True" : "False"));
     }
@@ -159,7 +159,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredInt32ToStringTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = i * 2;
     }
-    VectorCastOperations::castStructuredToString(vector<shared_ptr<ValueVector>>{lVector}, *result);
+    VectorCastOperations::castToString<int64_t>(vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].getAsString(), to_string(i * 2));
     }
@@ -178,7 +178,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredDoubleToStringTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = (double)(i * 2);
     }
-    VectorCastOperations::castStructuredToString(vector<shared_ptr<ValueVector>>{lVector}, *result);
+    VectorCastOperations::castToString<double_t>(vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].getAsString(), to_string((double)(i * 2)));
     }
@@ -197,7 +197,7 @@ TEST_F(VectorCastOperationsTest, CastStructuredDateToStringTest) {
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         lData[i] = date_t(1000 + i);
     }
-    VectorCastOperations::castStructuredToString(vector<shared_ptr<ValueVector>>{lVector}, *result);
+    VectorCastOperations::castToString<date_t>(vector<shared_ptr<ValueVector>>{lVector}, *result);
     for (int32_t i = 0; i < VECTOR_SIZE; i++) {
         ASSERT_EQ(resultData[i].getAsString(), Date::toString(date_t(1000 + i)));
     }

--- a/test/runner/queries/functions/string_functions.test
+++ b/test/runner/queries/functions/string_functions.test
@@ -23,7 +23,7 @@ Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 ---- 1
 14
 
--NAME StartsWithReturn
+-NAME StartsWithReturn1
 -QUERY MATCH (a:person) RETURN a.fName, a.fName STARTS WITH "A" ORDER BY a.fName
 ---- 8
 Alice|True
@@ -35,7 +35,19 @@ Farooq|False
 Greg|False
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|False
 
--NAME StartsWithReturn
+-NAME StartsWithReturn2
+-QUERY MATCH (a:person) RETURN a.label1, a.label1 STARTS WITH "g" ORDER BY a.fName
+---- 8
+excellent|False
+good|True
+good|True
+good|True
+|
+|
+|
+|
+
+-NAME StartsWithSelect
 -QUERY MATCH (a:person) WHERE a.fName STARTS WITH "C" RETURN a.fName
 ---- 1
 Carol


### PR DESCRIPTION
This PR refactors casting of non-overloaded functions (specifically boolean and string functions) into a common `implicitCastIfNecessary` interface. This interface will be used to resolve the data type for parameter expression later on.

Other refactors
- templating string casting functions
- add cast unstructured to string