### PR TITLE
change Unary/BinaryOpExecutor for string functions, add string functions, binary numeric functions

### DIFF
--- a/dataset/tinysnb/vOrganisation.csv
+++ b/dataset/tinysnb/vOrganisation.csv
@@ -1,4 +1,4 @@
 :ID,name:STRING,orgCode:INT64,mark:DOUBLE,score:INT64,history:STRING,licenseValidInterval:INTERVAL,rating:DOUBLE
-1,ABFsUni,325,3.7,-2,10 years 5 months 13 hours 24 us,3 years 5 days,1,unstrNumericProp:DOUBLE:-12.5,unstrIntervalProp1:INTERVAL:23 hours 48 days,unstrIntervalProp2:INTERVAL:23 hours 48 days
-4,CsWork,934,4.1,-100,2 years 4 days 10 hours,26 years 52 days 48 hours,0.78,unstrIntervalProp1:INTERVAL:26 years 52 days 48 hours,unstrIntervalProp2:INTERVAL:32 years 123 days 48 hours,unstrInt64Prop:INT64:-4
-6,DEsWork,824,4.1,7,2 years 4 hours 22 us 34 minutes,82 hours 100 milliseconds,0.52,unstrNumericProp:DOUBLE:3.3,unstrInt64Prop:INT64:10,unstrStringProp:STRING:1900-01-01
+1,ABFsUni,325,3.7,-2,10 years 5 months 13 hours 24 us,3 years 5 days,1,unstrNumericProp:DOUBLE:-12.5,unstrIntervalProp1:INTERVAL:23 hours 48 days,unstrIntervalProp2:INTERVAL:23 hours 48 days,unstrStr:STRING:  pERfECt
+4,CsWork,934,4.1,-100,2 years 4 days 10 hours,26 years 52 days 48 hours,0.78,unstrIntervalProp1:INTERVAL:26 years 52 days 48 hours,unstrIntervalProp2:INTERVAL:32 years 123 days 48 hours,unstrInt64Prop:INT64:-4,unstrStr:STRING:  EXcELLENT organisation   
+6,DEsWork,824,4.1,7,2 years 4 hours 22 us 34 minutes,82 hours 100 milliseconds,0.52,unstrNumericProp:DOUBLE:3.3,unstrInt64Prop:INT64:10,unstrStringProp:STRING:1900-01-01,unstrStr:STRING:GoOd organisation ! 

--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -74,11 +74,23 @@ const string LOG_FUNC_NAME = "LOG";
 const string LOG2_FUNC_NAME = "LOG2";
 const string DEGREES_FUNC_NAME = "DEGREES";
 const string RADIANS_FUNC_NAME = "RADIANS";
+const string ATAN2_FUNC_NAME = "ATAN2";
+const string ROUND_FUNC_NAME = "ROUND";
+const string BITWISE_XOR_FUNC_NAME = "BITWISE_XOR";
 
 // string
+const string CONCAT_FUNC_NAME = "CONCAT";
 const string CONTAINS_FUNC_NAME = "CONTAINS";
 const string STARTS_WITH_FUNC_NAME = "STARTS_WITH";
 const string ENDS_WITH_FUNC_NAME = "ENDS_WITH";
+const string LOWER_FUNC_NAME = "LOWER";
+const string UPPER_FUNC_NAME = "UPPER";
+const string TRIM_FUNC_NAME = "TRIM";
+const string LTRIM_FUNC_NAME = "LTRIM";
+const string RTRIM_FUNC_NAME = "RTRIM";
+const string LENGTH_FUNC_NAME = "LENGTH";
+const string REPEAT_FUNC_NAME = "REPEAT";
+const string REVERSE_FUNC_NAME = "REVERSE";
 
 // Date functions.
 const string DAYNAME_FUNC_NAME = "DAYNAME";

--- a/src/function/arithmetic/include/vector_arithmetic_operations.h
+++ b/src/function/arithmetic/include/vector_arithmetic_operations.h
@@ -56,7 +56,11 @@ private:
             }
         }
         case UNSTRUCTURED: {
-            return BinaryExecFunction<Value, Value, Value, FUNC>;
+            if constexpr (DOUBLE_RESULT) {
+                return BinaryExecFunction<Value, Value, double_t, FUNC>;
+            } else {
+                return BinaryExecFunction<Value, Value, Value, FUNC>;
+            }
         }
         default:
             assert(false);
@@ -208,6 +212,18 @@ struct EvenVectorOperation : public VectorArithmeticOperations {
 };
 
 struct SignVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct Atan2VectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct RoundVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct BitwiseXorVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 

--- a/src/function/arithmetic/operations/include/arithmetic_operations.h
+++ b/src/function/arithmetic/operations/include/arithmetic_operations.h
@@ -250,6 +250,33 @@ struct Radians {
     }
 };
 
+struct Atan2 {
+    template<class A, class B>
+    static inline void operation(
+        A& left, B& right, double_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
+        result = atan2(left, right);
+    }
+};
+
+struct Round {
+    template<class A, class B>
+    static inline void operation(
+        A& left, B& right, double_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
+        auto multiplier = pow(10, right);
+        result = round(left * multiplier) / multiplier;
+    }
+};
+
+struct BitwiseXor {
+    static inline void operation(
+        int64_t& left, int64_t& right, int64_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
+        result = left ^ right;
+    }
+};
+
 /********************************************
  **                                        **
  **   Specialized Modulo implementations   **
@@ -273,6 +300,7 @@ struct ArithmeticOnValues {
     template<class FUNC, const char* arithmeticOpStr>
     static void operation(
         Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
         switch (left.dataType.typeID) {
         case INT64:
             switch (right.dataType.typeID) {
@@ -302,6 +330,48 @@ struct ArithmeticOnValues {
                 result.dataType.typeID = DOUBLE;
                 FUNC::operation(left.val.doubleVal, right.val.doubleVal, result.val.doubleVal,
                     isLeftNull, isRightNull);
+            } break;
+            default:
+                throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `DOUBLE` and `" +
+                                       Types::dataTypeToString(right.dataType.typeID) + "`");
+            }
+            break;
+        default:
+            throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `" +
+                                   Types::dataTypeToString(left.dataType.typeID) + "` and `" +
+                                   Types::dataTypeToString(right.dataType.typeID) + "`");
+        }
+    }
+
+    template<class FUNC, const char* arithmeticOpStr>
+    static void operation(
+        Value& left, Value& right, double_t& result, bool isLeftNull, bool isRightNull) {
+        assert(!isLeftNull && !isRightNull);
+        switch (left.dataType.typeID) {
+        case INT64:
+            switch (right.dataType.typeID) {
+            case INT64: {
+                FUNC::operation(
+                    left.val.int64Val, right.val.int64Val, result, isLeftNull, isRightNull);
+            } break;
+            case DOUBLE: {
+                FUNC::operation(
+                    left.val.int64Val, right.val.doubleVal, result, isLeftNull, isRightNull);
+            } break;
+            default:
+                throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `INT64` and `" +
+                                       Types::dataTypeToString(right.dataType.typeID) + "`");
+            }
+            break;
+        case DOUBLE:
+            switch (right.dataType.typeID) {
+            case INT64: {
+                FUNC::operation(
+                    left.val.doubleVal, right.val.int64Val, result, isLeftNull, isRightNull);
+            } break;
+            case DOUBLE: {
+                FUNC::operation(
+                    left.val.doubleVal, right.val.doubleVal, result, isLeftNull, isRightNull);
             } break;
             default:
                 throw invalid_argument("Cannot " + string(arithmeticOpStr) + " `DOUBLE` and `" +
@@ -396,24 +466,13 @@ static const char logStr[] = "log";
 static const char log2Str[] = "log2";
 static const char degreesStr[] = "degrees";
 static const char radiansStr[] = "radians";
+static const char atan2Str[] = "atan2";
 
 template<>
 inline void Add::operation(
     Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
     if (left.dataType.typeID == STRING || right.dataType.typeID == STRING) {
-        result.dataType.typeID = STRING;
-        if (left.dataType.typeID == STRING && right.dataType.typeID == STRING) {
-            Concat::operation(
-                left.val.strVal, right.val.strVal, result.val.strVal, isLeftNull, isRightNull);
-        } else {
-            // This is the case when one of the left or right unstructured Value needs to be cast
-            // to string. Because we don't have access to overflow buffers, we need to treat them
-            // as regular strings.
-            auto lVal = TypeUtils::toString(left);
-            auto rVal = TypeUtils::toString(right);
-            Concat::operation(lVal, rVal, result.val.strVal, isLeftNull, isRightNull);
-        }
-        return;
+        throw invalid_argument("Unimplemented string addition operator.");
     } else if (left.dataType.typeID == DATE && right.dataType.typeID == INTERVAL) {
         result.dataType.typeID = DATE;
         Add::operation(
@@ -505,7 +564,7 @@ inline void Modulo::operation(
 
 template<>
 inline void Power::operation(
-    Value& left, Value& right, Value& result, bool isLeftNull, bool isRightNull) {
+    Value& left, Value& right, double_t& result, bool isLeftNull, bool isRightNull) {
     ArithmeticOnValues::operation<Power, powerStr>(left, right, result, isLeftNull, isRightNull);
 }
 
@@ -623,6 +682,34 @@ template<>
 inline void Radians::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Radians, radiansStr>(operand, isNull, result);
 };
+
+template<>
+inline void Atan2::operation(
+    Value& left, Value& right, double_t& result, bool isLeftNull, bool isRightNull) {
+    ArithmeticOnValues::operation<Atan2, atan2Str>(left, right, result, isLeftNull, isRightNull);
+}
+
+template<>
+inline void Round::operation(
+    Value& left, Value& right, double_t& result, bool isLeftNull, bool isRightNull) {
+    assert(!isLeftNull && !isRightNull);
+    if (right.dataType.typeID != INT64) {
+        throw invalid_argument("Round: Invalid right argument datatype: " +
+                               Types::dataTypeToString(right.dataType.typeID));
+    }
+    switch (left.dataType.typeID) {
+    case INT64: {
+        Round::operation(left.val.int64Val, right.val.int64Val, result, isLeftNull, isRightNull);
+    } break;
+    case DOUBLE: {
+        Round::operation(left.val.doubleVal, right.val.int64Val, result, isLeftNull, isRightNull);
+    } break;
+    default: {
+        throw invalid_argument("Round: Invalid left argument datatype: " +
+                               Types::dataTypeToString(left.dataType.typeID));
+    }
+    }
+}
 
 } // namespace operation
 } // namespace function

--- a/src/function/arithmetic/vector_arithmetic_operations.cpp
+++ b/src/function/arithmetic/vector_arithmetic_operations.cpp
@@ -22,10 +22,6 @@ vector<unique_ptr<VectorOperationDefinition>> AddVectorOperation::getDefinitions
     }
     result.push_back(getBinaryDefinition<operation::Add>(
         ADD_FUNC_NAME, UNSTRUCTURED, UNSTRUCTURED, UNSTRUCTURED));
-    // string + string -> string
-    result.push_back(
-        make_unique<VectorOperationDefinition>(ADD_FUNC_NAME, vector<DataTypeID>{STRING, STRING},
-            STRING, BinaryExecFunction<gf_string_t, gf_string_t, gf_string_t, operation::Concat>));
     // date + int → date
     result.push_back(
         make_unique<VectorOperationDefinition>(ADD_FUNC_NAME, vector<DataTypeID>{DATE, INT64}, DATE,
@@ -133,8 +129,8 @@ vector<unique_ptr<VectorOperationDefinition>> PowerVectorOperation::getDefinitio
                 POWER_FUNC_NAME, leftTypeID, rightTypeID, DOUBLE));
         }
     }
-    result.push_back(getBinaryDefinition<operation::Power>(
-        POWER_FUNC_NAME, UNSTRUCTURED, UNSTRUCTURED, UNSTRUCTURED));
+    result.push_back(getBinaryDefinition<operation::Power, true /* DOUBLE_RESULT */>(
+        POWER_FUNC_NAME, UNSTRUCTURED, UNSTRUCTURED, DOUBLE));
     return result;
 }
 
@@ -339,6 +335,38 @@ vector<unique_ptr<VectorOperationDefinition>> SignVectorOperation::getDefinition
         result.push_back(
             getUnaryDefinition<operation::Sign, true, false>(SIGN_FUNC_NAME, typeID, INT64));
     }
+    return result;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> Atan2VectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> result;
+    for (auto& leftTypeID : DataType::getNumericalTypeIDs()) {
+        for (auto& rightTypeID : DataType::getNumericalTypeIDs()) {
+            result.push_back(getBinaryDefinition<operation::Atan2, true /* DOUBLE_RESULT */
+                >(ATAN2_FUNC_NAME, leftTypeID, rightTypeID, DOUBLE));
+        }
+    }
+    result.push_back(getBinaryDefinition<operation::Atan2, true /* DOUBLE_RESULT */>(
+        ATAN2_FUNC_NAME, UNSTRUCTURED, UNSTRUCTURED, DOUBLE));
+    return result;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> RoundVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> result;
+    for (auto& leftTypeID : DataType::getNumericalTypeIDs()) {
+        result.push_back(getBinaryDefinition<operation::Round, true /* DOUBLE_RESULT */>(
+            ROUND_FUNC_NAME, leftTypeID, INT64, DOUBLE));
+    }
+    result.push_back(getBinaryDefinition<operation::Round, true /* DOUBLE_RESULT */>(
+        ROUND_FUNC_NAME, UNSTRUCTURED, UNSTRUCTURED, DOUBLE));
+    return result;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> BitwiseXorVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> result;
+    result.push_back(make_unique<VectorOperationDefinition>(BITWISE_XOR_FUNC_NAME,
+        vector<DataTypeID>{INT64, INT64}, INT64,
+        BinaryExecFunction<int64_t, int64_t, int64_t, operation::BitwiseXor>));
     return result;
 }
 

--- a/src/function/boolean/include/boolean_operation_executor.h
+++ b/src/function/boolean/include/boolean_operation_executor.h
@@ -83,7 +83,7 @@ struct BinaryBooleanOperationExecutor {
     template<typename FUNC>
     static inline void executeOnValue(ValueVector& left, ValueVector& right, ValueVector& result,
         uint64_t lPos, uint64_t rPos, uint64_t resPos) {
-        BinaryOperationExecutor::executeOnValue<bool, bool, uint8_t, FUNC>(
+        BinaryOperationExecutor::executeOnValue<bool, bool, uint8_t, FUNC, BinaryOperationWrapper>(
             left, right, result, lPos, rPos, resPos);
         result.setNull(resPos, result.values[resPos] == operation::NULL_BOOL);
     }

--- a/src/function/built_in_vector_operations.cpp
+++ b/src/function/built_in_vector_operations.cpp
@@ -218,6 +218,9 @@ void BuiltInVectorOperations::registerArithmeticOperations() {
     vectorOperations.insert({RADIANS_FUNC_NAME, RadiansVectorOperation::getDefinitions()});
     vectorOperations.insert({EVEN_FUNC_NAME, EvenVectorOperation::getDefinitions()});
     vectorOperations.insert({SIGN_FUNC_NAME, SignVectorOperation::getDefinitions()});
+    vectorOperations.insert({ATAN2_FUNC_NAME, Atan2VectorOperation::getDefinitions()});
+    vectorOperations.insert({ROUND_FUNC_NAME, RoundVectorOperation::getDefinitions()});
+    vectorOperations.insert({BITWISE_XOR_FUNC_NAME, BitwiseXorVectorOperation::getDefinitions()});
 }
 
 void BuiltInVectorOperations::registerDateOperations() {
@@ -250,8 +253,17 @@ void BuiltInVectorOperations::registerIntervalOperations() {
 }
 
 void BuiltInVectorOperations::registerStringOperations() {
+    vectorOperations.insert({CONCAT_FUNC_NAME, ConcatVectorOperation::getDefinitions()});
     vectorOperations.insert({CONTAINS_FUNC_NAME, ContainsVectorOperation::getDefinitions()});
     vectorOperations.insert({STARTS_WITH_FUNC_NAME, StartsWithVectorOperation::getDefinitions()});
+    vectorOperations.insert({LOWER_FUNC_NAME, LowerVectorOperation::getDefinitions()});
+    vectorOperations.insert({UPPER_FUNC_NAME, UpperVectorOperation::getDefinitions()});
+    vectorOperations.insert({TRIM_FUNC_NAME, TrimVectorOperation::getDefinitions()});
+    vectorOperations.insert({LTRIM_FUNC_NAME, LtrimVectorOperation::getDefinitions()});
+    vectorOperations.insert({RTRIM_FUNC_NAME, RtrimVectorOperation::getDefinitions()});
+    vectorOperations.insert({LENGTH_FUNC_NAME, LengthVectorOperation::getDefinitions()});
+    vectorOperations.insert({REPEAT_FUNC_NAME, RepeatVectorOperation::getDefinitions()});
+    vectorOperations.insert({REVERSE_FUNC_NAME, ReverseVectorOperation::getDefinitions()});
 }
 
 void BuiltInVectorOperations::registerCastOperations() {

--- a/src/function/include/vector_operations.h
+++ b/src/function/include/vector_operations.h
@@ -47,6 +47,14 @@ public:
             *params[0], *params[1], result);
     }
 
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void BinaryStringExecFunction(
+        const vector<shared_ptr<ValueVector>>& params, ValueVector& result) {
+        assert(params.size() == 2);
+        BinaryOperationExecutor::executeString<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+            *params[0], *params[1], result);
+    }
+
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
     static uint64_t BinarySelectFunction(
         const vector<shared_ptr<ValueVector>>& params, sel_t* selectedPositions) {
@@ -60,6 +68,13 @@ public:
         const vector<shared_ptr<ValueVector>>& params, ValueVector& result) {
         assert(params.size() == 1);
         UnaryOperationExecutor::execute<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
+    }
+
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void UnaryStringExecFunction(
+        const vector<shared_ptr<ValueVector>>& params, ValueVector& result) {
+        assert(params.size() == 1);
+        UnaryOperationExecutor::executeString<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
     }
 
     template<typename OPERAND_TYPE, typename FUNC>

--- a/src/function/null/include/null_operation_executor.h
+++ b/src/function/null/include/null_operation_executor.h
@@ -10,25 +10,22 @@ struct NullOperationExecutor {
     template<typename FUNC>
     static void execute(ValueVector& operand, ValueVector& result) {
         assert(result.dataType.typeID == BOOL);
+        auto operandValues = (uint8_t*)operand.values;
         auto resultValues = (uint8_t*)result.values;
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             assert(pos == result.state->getPositionOfCurrIdx());
-            UnaryOperationExecutor::executeOnValue<uint8_t, uint8_t, FUNC>(
-                operand, pos, resultValues[pos]);
+            FUNC::operation(operandValues[pos], (bool)operand.isNull(pos), resultValues[pos]);
         } else {
             if (operand.state->isUnfiltered()) {
                 for (auto i = 0u; i < operand.state->selectedSize; i++) {
-                    UnaryOperationExecutor::executeOnValue<
-                        uint8_t /* operand type does not matter for null operations */, uint8_t,
-                        FUNC>(operand, i, resultValues[i]);
+                    FUNC::operation(operandValues[i], (bool)operand.isNull(i), resultValues[i]);
                 }
             } else {
                 for (auto i = 0u; i < operand.state->selectedSize; i++) {
                     auto pos = operand.state->selectedPositions[i];
-                    UnaryOperationExecutor::executeOnValue<
-                        uint8_t /* operand type does not matter for null operations */, uint8_t,
-                        FUNC>(operand, pos, resultValues[pos]);
+                    FUNC::operation(
+                        operandValues[pos], (bool)operand.isNull(pos), resultValues[pos]);
                 }
             }
         }

--- a/src/function/string/include/vector_string_operations.h
+++ b/src/function/string/include/vector_string_operations.h
@@ -1,17 +1,81 @@
 #pragma once
 
 #include "src/function/include/vector_operations.h"
+#include "src/function/string/operations/include/lower_operation.h"
+#include "src/function/string/operations/include/ltrim_operation.h"
+#include "src/function/string/operations/include/reverse_operation.h"
+#include "src/function/string/operations/include/rtrim_operation.h"
+#include "src/function/string/operations/include/trim_operation.h"
+#include "src/function/string/operations/include/upper_operation.h"
 
 namespace graphflow {
 namespace function {
 
-struct VectorStringOperations : public VectorOperations {};
+struct VectorStringOperations : public VectorOperations {
+    template<class OPERATION>
+    static inline vector<unique_ptr<VectorOperationDefinition>> getUnaryStrFunctionDefintion(
+        string funcName) {
+        vector<unique_ptr<VectorOperationDefinition>> definitions;
+        auto execFunc = UnaryStringExecFunction<gf_string_t, gf_string_t, OPERATION>;
+        definitions.emplace_back(make_unique<VectorOperationDefinition>(
+            funcName, vector<DataTypeID>{STRING}, STRING, execFunc, false /* isVarLength */));
+        return definitions;
+    }
+};
 
 struct ContainsVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
 struct StartsWithVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct ConcatVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct LowerVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Lower>(LOWER_FUNC_NAME);
+    }
+};
+
+struct UpperVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Upper>(UPPER_FUNC_NAME);
+    }
+};
+
+struct TrimVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Trim>(TRIM_FUNC_NAME);
+    }
+};
+
+struct LtrimVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Ltrim>(LTRIM_FUNC_NAME);
+    }
+};
+
+struct RtrimVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Rtrim>(RTRIM_FUNC_NAME);
+    }
+};
+
+struct ReverseVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Reverse>(REVERSE_FUNC_NAME);
+    }
+};
+
+struct LengthVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct RepeatVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 

--- a/src/function/string/operations/include/base_str_operation.h
+++ b/src/function/string/operations/include/base_str_operation.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct BaseStrOperation {
+public:
+    static inline void operation(gf_string_t& input, bool isNull, gf_string_t& result,
+        ValueVector& resultValueVector, uint32_t (*strOperation)(char* data, uint32_t len)) {
+        assert(!isNull);
+        if (input.len <= gf_string_t::SHORT_STR_LENGTH) {
+            memcpy(result.prefix, input.prefix, input.len);
+            result.len = strOperation((char*)result.prefix, input.len);
+        } else {
+            result.overflowPtr = reinterpret_cast<uint64_t>(
+                resultValueVector.getOverflowBuffer().allocateSpace(input.len));
+            auto buffer = reinterpret_cast<char*>(result.overflowPtr);
+            memcpy(buffer, input.getData(), input.len);
+            result.len = strOperation(buffer, input.len);
+            memcpy(result.prefix, buffer,
+                result.len < gf_string_t::PREFIX_LENGTH ? result.len : gf_string_t::PREFIX_LENGTH);
+        }
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/concat_operation.h
+++ b/src/function/string/operations/include/concat_operation.h
@@ -14,41 +14,40 @@ namespace operation {
 
 struct Concat {
     template<class A, class B, class R>
-    static inline void operation(A& left, B& right, R& result, bool isLeftNull, bool isRightNull);
+    static inline void operation(
+        A& left, B& right, R& result, bool isLeftNull, bool isRightNull, ValueVector& valueVector);
+
+    static void concat(const char* left, uint32_t leftLen, const char* right, uint32_t rightLen,
+        gf_string_t& result, ValueVector& resultValueVector) {
+        auto len = leftLen + rightLen;
+        if (len <= gf_string_t::SHORT_STR_LENGTH /* concat's result is short */) {
+            memcpy(result.prefix, left, leftLen);
+            memcpy(result.prefix + leftLen, right, rightLen);
+        } else {
+            result.overflowPtr = reinterpret_cast<uint64_t>(
+                resultValueVector.getOverflowBuffer().allocateSpace(len));
+            auto buffer = reinterpret_cast<char*>(result.overflowPtr);
+            memcpy(buffer, left, leftLen);
+            memcpy(buffer + leftLen, right, rightLen);
+            memcpy(result.prefix, buffer, gf_string_t::PREFIX_LENGTH);
+        }
+        result.len = len;
+    }
 };
 
 template<>
-inline void Concat::operation(
-    gf_string_t& left, gf_string_t& right, gf_string_t& result, bool isLeftNull, bool isRightNull) {
+inline void Concat::operation(gf_string_t& left, gf_string_t& right, gf_string_t& result,
+    bool isLeftNull, bool isRightNull, ValueVector& resultValueVector) {
     assert(!isLeftNull && !isRightNull);
-    auto len = left.len + right.len;
-    if (len <= gf_string_t::SHORT_STR_LENGTH /* concat's result is short */) {
-        memcpy(result.prefix, left.prefix, left.len);
-        memcpy(result.prefix + left.len, right.prefix, right.len);
-    } else {
-        auto buffer = reinterpret_cast<char*>(result.overflowPtr);
-        memcpy(buffer, left.getData(), left.len);
-        memcpy(buffer + left.len, right.getData(), right.len);
-        memcpy(result.prefix, buffer, gf_string_t::PREFIX_LENGTH);
-    }
-    result.len = len;
+    concat((const char*)left.getData(), left.len, (const char*)right.getData(), right.len, result,
+        resultValueVector);
 }
 
 template<>
-inline void Concat::operation(
-    string& left, string& right, gf_string_t& result, bool isLeftNull, bool isRightNull) {
+inline void Concat::operation(string& left, string& right, gf_string_t& result, bool isLeftNull,
+    bool isRightNull, ValueVector& resultValueVector) {
     assert(!isLeftNull && !isRightNull);
-    auto len = left.length() + right.length();
-    if (len <= gf_string_t::SHORT_STR_LENGTH /* concat's result is short */) {
-        memcpy(result.prefix, left.c_str(), left.length());
-        memcpy(result.prefix + left.length(), right.c_str(), right.length());
-    } else {
-        auto buffer = reinterpret_cast<char*>(result.overflowPtr);
-        memcpy(buffer, left.c_str(), left.length());
-        memcpy(buffer + left.length(), right.c_str(), right.length());
-        memcpy(result.prefix, buffer, gf_string_t::PREFIX_LENGTH);
-    }
-    result.len = len;
+    concat(left.c_str(), left.length(), right.c_str(), right.length(), result, resultValueVector);
 }
 
 } // namespace operation

--- a/src/function/string/operations/include/length_operation.h
+++ b/src/function/string/operations/include/length_operation.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Length {
+    static inline void operation(gf_string_t& input, bool isNull, int64_t& result) {
+        assert(!isNull);
+        result = input.len;
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/lower_operation.h
+++ b/src/function/string/operations/include/lower_operation.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "base_str_operation.h"
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Lower {
+public:
+    static inline void operation(
+        gf_string_t& input, bool isNull, gf_string_t& result, ValueVector& resultValueVector) {
+        BaseStrOperation::operation(input, isNull, result, resultValueVector, lowerStr);
+    }
+
+private:
+    static uint32_t lowerStr(char* str, uint32_t len) {
+        for (auto i = 0u; i < len; i++) {
+            str[i] = tolower(str[i]);
+        }
+        return len;
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/ltrim_operation.h
+++ b/src/function/string/operations/include/ltrim_operation.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "base_str_operation.h"
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Ltrim {
+    static inline void operation(
+        gf_string_t& input, bool isNull, gf_string_t& result, ValueVector& resultValueVector) {
+        BaseStrOperation::operation(input, isNull, result, resultValueVector, ltrim);
+    }
+
+    static uint32_t ltrim(char* data, uint32_t len) {
+        auto counter = 0u;
+        for (; counter < len; counter++) {
+            if (!isspace(data[counter])) {
+                break;
+            }
+        }
+        memcpy(data, data + counter, len - counter);
+        return len - counter;
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/repeat_operation.h
+++ b/src/function/string/operations/include/repeat_operation.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Repeat {
+public:
+    static inline void operation(gf_string_t& left, int64_t& right, gf_string_t& result,
+        bool isLeftNull, bool isRightNull, ValueVector& resultValueVector) {
+        assert(!isLeftNull && !isRightNull);
+        result.len = left.len * right;
+        if (result.len <= gf_string_t::SHORT_STR_LENGTH) {
+            repeatStr((char*)result.prefix, left.getAsString(), right);
+        } else {
+            result.overflowPtr = reinterpret_cast<uint64_t>(
+                resultValueVector.getOverflowBuffer().allocateSpace(result.len));
+            auto buffer = reinterpret_cast<char*>(result.overflowPtr);
+            repeatStr(buffer, left.getAsString(), right);
+            memcpy(result.prefix, buffer, gf_string_t::PREFIX_LENGTH);
+        }
+    }
+
+private:
+    static void repeatStr(char* data, string pattern, uint64_t count) {
+        for (auto i = 0u; i < count; i++) {
+            memcpy(data + i * pattern.length(), pattern.c_str(), pattern.length());
+        }
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/reverse_operation.h
+++ b/src/function/string/operations/include/reverse_operation.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "base_str_operation.h"
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Reverse {
+public:
+    static inline void operation(
+        gf_string_t& input, bool isNull, gf_string_t& result, ValueVector& resultValueVector) {
+        BaseStrOperation::operation(input, isNull, result, resultValueVector, reverseStr);
+    }
+
+private:
+    static uint32_t reverseStr(char* data, uint32_t len) {
+        for (auto i = 0u; i < len / 2; i++) {
+            swap(data[i], data[len - i - 1]);
+        }
+        return len;
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/rtrim_operation.h
+++ b/src/function/string/operations/include/rtrim_operation.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "base_str_operation.h"
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Rtrim {
+    static inline void operation(
+        gf_string_t& input, bool isNull, gf_string_t& result, ValueVector& resultValueVector) {
+        BaseStrOperation::operation(input, isNull, result, resultValueVector, rtrim);
+    }
+
+    static uint32_t rtrim(char* data, uint32_t len) {
+        auto counter = len - 1;
+        for (; counter >= 0; counter--) {
+            if (!isspace(data[counter])) {
+                break;
+            }
+        }
+        return counter + 1;
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/trim_operation.h
+++ b/src/function/string/operations/include/trim_operation.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "ltrim_operation.h"
+#include "rtrim_operation.h"
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Trim : BaseStrOperation {
+public:
+    static inline void operation(
+        gf_string_t& input, bool isNull, gf_string_t& result, ValueVector& resultValueVector) {
+        BaseStrOperation::operation(input, isNull, result, resultValueVector, trim);
+    }
+
+private:
+    static uint32_t trim(char* data, uint32_t len) {
+        return Rtrim::rtrim(data, Ltrim::ltrim(data, len));
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/operations/include/upper_operation.h
+++ b/src/function/string/operations/include/upper_operation.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cassert>
+#include <cstring>
+
+#include "base_str_operation.h"
+
+#include "src/common/types/include/gf_string.h"
+
+using namespace std;
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace function {
+namespace operation {
+
+struct Upper {
+public:
+    static inline void operation(
+        gf_string_t& input, bool isNull, gf_string_t& result, ValueVector& resultValueVector) {
+        BaseStrOperation::operation(input, isNull, result, resultValueVector, upperStr);
+    }
+
+private:
+    static uint32_t upperStr(char* str, uint32_t len) {
+        for (auto i = 0u; i < len; i++) {
+            str[i] = toupper(str[i]);
+        }
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace graphflow

--- a/src/function/string/vector_string_operations.cpp
+++ b/src/function/string/vector_string_operations.cpp
@@ -2,6 +2,8 @@
 
 #include "operations/include/concat_operation.h"
 #include "operations/include/contains_operation.h"
+#include "operations/include/length_operation.h"
+#include "operations/include/repeat_operation.h"
 #include "operations/include/starts_with_operation.h"
 
 namespace graphflow {
@@ -11,8 +13,8 @@ vector<unique_ptr<VectorOperationDefinition>> ContainsVectorOperation::getDefini
     vector<unique_ptr<VectorOperationDefinition>> definitions;
     auto execFunc = BinaryExecFunction<gf_string_t, gf_string_t, uint8_t, operation::Contains>;
     auto selectFunc = BinarySelectFunction<gf_string_t, gf_string_t, operation::Contains>;
-    definitions.emplace_back(make_unique<VectorOperationDefinition>(
-        CONTAINS_FUNC_NAME, vector<DataTypeID>{STRING, STRING}, BOOL, execFunc, selectFunc, false));
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(CONTAINS_FUNC_NAME,
+        vector<DataTypeID>{STRING, STRING}, BOOL, execFunc, selectFunc, false /* isVarLength */));
     return definitions;
 }
 
@@ -21,7 +23,32 @@ vector<unique_ptr<VectorOperationDefinition>> StartsWithVectorOperation::getDefi
     auto execFunc = BinaryExecFunction<gf_string_t, gf_string_t, uint8_t, operation::StartsWith>;
     auto selectFunc = BinarySelectFunction<gf_string_t, gf_string_t, operation::StartsWith>;
     definitions.emplace_back(make_unique<VectorOperationDefinition>(STARTS_WITH_FUNC_NAME,
-        vector<DataTypeID>{STRING, STRING}, BOOL, execFunc, selectFunc, false));
+        vector<DataTypeID>{STRING, STRING}, BOOL, execFunc, selectFunc, false /* isVarLength */));
+    return definitions;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> ConcatVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> definitions;
+    auto execFunc =
+        BinaryStringExecFunction<gf_string_t, gf_string_t, gf_string_t, operation::Concat>;
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(CONCAT_FUNC_NAME,
+        vector<DataTypeID>{STRING, STRING}, STRING, execFunc, false /* isVarLength */));
+    return definitions;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> LengthVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> definitions;
+    auto execFunc = UnaryExecFunction<gf_string_t, int64_t, operation::Length>;
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(
+        LENGTH_FUNC_NAME, vector<DataTypeID>{STRING}, INT64, execFunc, false /* isVarLength */));
+    return definitions;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> RepeatVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> definitions;
+    auto execFunc = BinaryStringExecFunction<gf_string_t, int64_t, gf_string_t, operation::Repeat>;
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(REPEAT_FUNC_NAME,
+        vector<DataTypeID>{STRING, INT64}, STRING, execFunc, false /* isVarLength */));
     return definitions;
 }
 

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -120,7 +120,7 @@ TEST_F(BinderErrorTest, BindIDArithmetic) {
         "Cannot match a built-in function for given function +(NODE_ID,INT64). Supported inputs "
         "are\n(INT64,INT64) -> INT64\n(INT64,DOUBLE) -> DOUBLE\n(DOUBLE,INT64) -> "
         "DOUBLE\n(DOUBLE,DOUBLE) -> DOUBLE\n(UNSTRUCTURED,UNSTRUCTURED) -> "
-        "UNSTRUCTURED\n(STRING,STRING) -> STRING\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
+        "UNSTRUCTURED\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
         "DATE\n(TIMESTAMP,INTERVAL) -> TIMESTAMP\n(INTERVAL,INTERVAL) -> INTERVAL\n";
     auto input = "MATCH (a:person)-[e1:knows]->(b:person) WHERE id(a) + 1 < id(b) RETURN *;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
@@ -131,7 +131,7 @@ TEST_F(BinderErrorTest, BindDateAddDate) {
         "Cannot match a built-in function for given function +(DATE,DATE). Supported inputs "
         "are\n(INT64,INT64) -> INT64\n(INT64,DOUBLE) -> DOUBLE\n(DOUBLE,INT64) -> "
         "DOUBLE\n(DOUBLE,DOUBLE) -> DOUBLE\n(UNSTRUCTURED,UNSTRUCTURED) -> "
-        "UNSTRUCTURED\n(STRING,STRING) -> STRING\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
+        "UNSTRUCTURED\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
         "DATE\n(TIMESTAMP,INTERVAL) -> TIMESTAMP\n(INTERVAL,INTERVAL) -> INTERVAL\n";
     auto input = "MATCH (a:person) RETURN a.birthdate + date('2031-02-01');";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
@@ -142,7 +142,7 @@ TEST_F(BinderErrorTest, BindTimestampArithmetic) {
         "Cannot match a built-in function for given function +(TIMESTAMP,INT64). Supported "
         "inputs are\n(INT64,INT64) -> INT64\n(INT64,DOUBLE) -> DOUBLE\n(DOUBLE,INT64) -> "
         "DOUBLE\n(DOUBLE,DOUBLE) -> DOUBLE\n(UNSTRUCTURED,UNSTRUCTURED) -> "
-        "UNSTRUCTURED\n(STRING,STRING) -> STRING\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
+        "UNSTRUCTURED\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
         "DATE\n(TIMESTAMP,INTERVAL) -> TIMESTAMP\n(INTERVAL,INTERVAL) -> INTERVAL\n";
     auto input = "MATCH (a:person) WHERE a.registerTime + 1 < 5 RETURN *;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
@@ -153,7 +153,7 @@ TEST_F(BinderErrorTest, BindTimestampAddTimestamp) {
         "Cannot match a built-in function for given function +(TIMESTAMP,TIMESTAMP). Supported "
         "inputs are\n(INT64,INT64) -> INT64\n(INT64,DOUBLE) -> DOUBLE\n(DOUBLE,INT64) -> "
         "DOUBLE\n(DOUBLE,DOUBLE) -> DOUBLE\n(UNSTRUCTURED,UNSTRUCTURED) -> "
-        "UNSTRUCTURED\n(STRING,STRING) -> STRING\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
+        "UNSTRUCTURED\n(DATE,INT64) -> DATE\n(DATE,INTERVAL) -> "
         "DATE\n(TIMESTAMP,INTERVAL) -> TIMESTAMP\n(INTERVAL,INTERVAL) -> INTERVAL\n";
     auto input = "MATCH (a:person) RETURN a.registerTime + timestamp('2031-02-11 01:02:03');";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -73,40 +73,40 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Add>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], 110);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Subtract>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Subtract,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], 2 * i - 110);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Multiply>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Multiply,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i * (110 - i));
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Divide>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Divide,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
         ASSERT_EQ(resultData[i], i / (110 - i));
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Modulo>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Modulo,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
         ASSERT_EQ(resultData[i], i % (110 - i));
         ASSERT_FALSE(result->isNull(i));
@@ -116,8 +116,8 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
     result = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
     dataChunk->insert(0, result);
     auto resultDataAsDoubleArr = (double_t*)result->values;
-    BinaryOperationExecutor::execute<int64_t, int64_t, double_t, operation::Power>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, double_t, operation::Power,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultDataAsDoubleArr[i], pow(i, 110 - i));
         ASSERT_FALSE(result->isNull(i));
@@ -146,8 +146,8 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatW
     }
     ASSERT_FALSE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Add>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
             ASSERT_EQ(resultData[i], 110);
@@ -168,8 +168,8 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
 
     // Test 1: Left flat and right is unflat.
     // The addition is 80 + [110, 109, ...., 8, 9]. The results are: [190, 189, ...., 88, 89]
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Add>(
-        *vector1, *vector2, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
+        BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], 190 - i);
         ASSERT_FALSE(result->isNull(i));
@@ -177,8 +177,8 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     // Test 2: Left unflat and right is flat. The result is the same as above.
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Add>(
-        *vector2, *vector1, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
+        BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], 190 - i);
         ASSERT_FALSE(result->isNull(i));
@@ -200,8 +200,8 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
 
     // Test 1: Left flat and right is unflat.
     // The addition is 80 + [110, 109, ...., 8, 9]. The results are: [190, NULL, ...., 88, NULL]
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Add>(
-        *vector1, *vector2, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
+        BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
             ASSERT_EQ(resultData[i], 190 - i);
@@ -213,8 +213,8 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
     ASSERT_FALSE(result->hasNoNullsGuarantee());
 
     // Test 2: Left unflat and right is flat. The result is the same as above.
-    BinaryOperationExecutor::execute<int64_t, int64_t, int64_t, operation::Add>(
-        *vector2, *vector1, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
+        BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
             ASSERT_EQ(resultData[i], 190 - i);
@@ -244,32 +244,32 @@ TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt64Test)
         ASSERT_EQ(resultData[i].val.int64Val, -i);
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Add>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Add,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, 110);
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Subtract>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Subtract,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, 2 * i - 110);
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Multiply>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Multiply,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, i * (110 - i));
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Divide>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Divide,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, i / (110 - i));
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Modulo>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Modulo,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.int64Val, i % (110 - i));
     }
@@ -293,49 +293,27 @@ TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt32AndDo
         ASSERT_EQ(resultData[i].val.doubleVal, (double)-i);
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Add>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Add,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)110);
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Subtract>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Subtract,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)(2 * i - 110));
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Multiply>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Multiply,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)(i * (110 - i)));
     }
 
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Divide>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Divide,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].val.doubleVal, (double)i / (110 - i));
-    }
-}
-
-TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredStringAndInt32Test) {
-    auto lVector = vector1;
-    auto rVector = vector2;
-    auto lData = (Value*)lVector->values;
-    auto rData = (Value*)rVector->values;
-    auto resultData = (Value*)result->values;
-
-    // Fill values before the comparison.
-    for (int i = 0; i < NUM_TUPLES; i++) {
-        string lStr = to_string(i);
-        TypeUtils::copyString(lStr, lData[i].val.strVal, lVector->getOverflowBuffer());
-        lData[i].dataType.typeID = STRING;
-        rData[i] = Value((int64_t)110 - i);
-    }
-
-    BinaryOperationExecutor::execute<Value, Value, Value, operation::Add>(
-        *lVector, *rVector, *result);
-    for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.strVal.getAsString(), to_string(i) + to_string(110 - i));
     }
 }

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -52,48 +52,48 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     auto rVector = vector2;
     auto resultData = result->values;
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::Equals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::Equals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i == 45 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::NotEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::NotEquals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i == 45 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::LessThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i < 45 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::LessThanEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThanEquals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i < 46 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::GreaterThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::GreaterThan,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i < 46 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::GreaterThanEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::GreaterThanEquals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i < 45 ? false : true);
         ASSERT_FALSE(result->isNull(i));
@@ -111,8 +111,8 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatWithNulls) {
         vector2->setNull(i, (i % 2) == 1);
     }
 
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::LessThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
             ASSERT_EQ(resultData[i], i < 45 ? true : false);
@@ -134,8 +134,8 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNo
     // Test 1: Left flat and right is unflat.
     // The comparison ins 80 < [90, 89, ...., -9]. The first 10 (90, ..., 81) the result is true,
     // the rest should be false.
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::LessThan>(
-        *vector1, *vector2, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i < 10 ? true : false);
         ASSERT_FALSE(result->isNull(i));
@@ -145,8 +145,8 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNo
     // Test 2: Left unflat and right is flat.
     // Now the comparison is [90, 89, ...., -9] < 80. So now the first 11 (90, ..., 81) the result
     // is false and the rest is true.
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::LessThan>(
-        *vector2, *vector1, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i], i < 11 ? false : true);
         ASSERT_FALSE(result->isNull(i));
@@ -169,8 +169,8 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
     // The comparison ins 80 < [90, NULL, 88, NULL ...., -8, NULL]. The first 10 (90, ..., 81) the
     // result is true for even and NULL for odd indices. For the rest, the result is false for even
     // and NULL for odd indices.
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::LessThan>(
-        *vector1, *vector2, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if ((i % 2) == 0) {
             ASSERT_EQ(resultData[i], i < 10 ? true : false);
@@ -189,8 +189,8 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
     // Now the comparison is [90, 89, ...., -9] < 80. So now for the first 11 (90, ..., 81) the
     // result is false for even and NULL for odd indices. For the rest, the result is true for even
     // and NULL for odd indices.
-    BinaryOperationExecutor::execute<int64_t, int64_t, uint8_t, operation::LessThan>(
-        *vector2, *vector1, *result);
+    BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if ((i % 2) == 0) {
             ASSERT_EQ(resultData[i], i < 11 ? false : true);
@@ -233,50 +233,50 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
     memcpy(
         rData[0].data, value.data() + gf_string_t::PREFIX_LENGTH, 8 - gf_string_t::PREFIX_LENGTH);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::Equals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::Equals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
     rData[0].data[3] = 'i';
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::Equals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::Equals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::NotEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::NotEquals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThanEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::GreaterThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t,
-        operation::GreaterThanEquals>(*lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
     rData[0].data[3] = 'a';
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThanEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::GreaterThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t,
-        operation::GreaterThanEquals>(*lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 }
 
@@ -314,49 +314,49 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
     memcpy(rOverflow, value.data(), overflowLen);
     rData->overflowPtr = reinterpret_cast<uintptr_t>(rOverflow);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::Equals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::Equals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
     rOverflow[overflowLen - 1] = 'z';
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::Equals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::Equals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::NotEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::NotEquals,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThanEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::GreaterThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t,
-        operation::GreaterThanEquals>(*lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
     rOverflow[overflowLen - 1] = 'a';
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t, operation::LessThan,
+        BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::LessThanEquals>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], false);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t, operation::GreaterThan>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, uint8_t,
-        operation::GreaterThanEquals>(*lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, uint8_t,
+        operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
     ASSERT_EQ(resultData[0], true);
 }

--- a/test/common/vector/operations/vector_string_operations_test.cpp
+++ b/test/common/vector/operations/vector_string_operations_test.cpp
@@ -26,8 +26,8 @@ TEST_F(StringArithmeticOperandsInSameDataChunkTest, StringTest) {
         rVector->addString(i, to_string(110 - i));
     }
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, gf_string_t, operation::Concat>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, gf_string_t, operation::Concat,
+        BinaryStringOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].getAsString(), to_string(i) + to_string(110 - i));
     }
@@ -43,8 +43,8 @@ TEST_F(StringArithmeticOperandsInSameDataChunkTest, BigStringTest) {
         rVector->addString(i, to_string(110 - i) + "abcdefabcdefqwert");
     }
 
-    BinaryOperationExecutor::execute<gf_string_t, gf_string_t, gf_string_t, operation::Concat>(
-        *lVector, *rVector, *result);
+    BinaryOperationExecutor::executeSwitch<gf_string_t, gf_string_t, gf_string_t, operation::Concat,
+        BinaryStringOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         ASSERT_EQ(resultData[i].getAsString(),
             to_string(i) + "abcdefabcdefqwert" + to_string(110 - i) + "abcdefabcdefqwert");

--- a/test/runner/queries/data_types/date_data_type.test
+++ b/test/runner/queries/data_types/date_data_type.test
@@ -226,7 +226,7 @@
 1468
 
 -NAME StructuredDateConcatenateString
--QUERY MATCH (a:person) RETURN 'Birthdate: ' + string(a.birthdate) + ' test'
+-QUERY MATCH (a:person) RETURN concat(concat('Birthdate: ', string(a.birthdate)), ' test')
 ---- 8
 Birthdate: 1900-01-01 test
 Birthdate: 1900-01-01 test
@@ -238,7 +238,7 @@ Birthdate: 1980-10-26 test
 Birthdate: 1990-11-27 test
 
 -NAME UnstructuredDateConcatenateString
--QUERY MATCH (a:person) RETURN 'unstrDate: ' + a.unstrDateProp1 + ' test'
+-QUERY MATCH (a:person) RETURN concat(concat('unstrDate: ', a.unstrDateProp1), ' test')
 ---- 8
 
 

--- a/test/runner/queries/data_types/interval_data_type.test
+++ b/test/runner/queries/data_types/interval_data_type.test
@@ -140,14 +140,14 @@
 24 years -66 days 27:05:40
 
 -NAME StructuredIntervalConcatenateString
--QUERY MATCH (o:organisation) RETURN 'The license is valid until ' + string(o.licenseValidInterval) + ' test'
+-QUERY MATCH (o:organisation) RETURN concat(concat('The license is valid until ', string(o.licenseValidInterval)), ' test')
 ---- 3
 The license is valid until 26 years 52 days 48:00:00 test
 The license is valid until 3 years 5 days test
 The license is valid until 82:00:00.1 test
 
 -NAME UnstructuredIntervalConcatenateString
--QUERY MATCH (o:organisation) RETURN 'unstrIntervalProp1: ' + o.unstrIntervalProp1 + ' test'
+-QUERY MATCH (o:organisation) RETURN concat(concat('unstrIntervalProp1: ', o.unstrIntervalProp1), ' test')
 ---- 3
 
 unstrIntervalProp1: 26 years 52 days 48:00:00 test

--- a/test/runner/queries/data_types/timestamp_data_type.test
+++ b/test/runner/queries/data_types/timestamp_data_type.test
@@ -185,7 +185,7 @@
 19673 days 10:18:58
 
 -NAME StructuredTimestampConcatenateString
--QUERY MATCH (a:person) RETURN 'Register Time: ' + string(a.registerTime) + ' test'
+-QUERY MATCH (a:person) RETURN concat(concat('Register Time: ', string(a.registerTime)), ' test')
 ---- 8
 Register Time: 1911-08-20 02:32:21 test
 Register Time: 1972-07-31 13:22:30.678559 test
@@ -197,7 +197,7 @@ Register Time: 2023-02-21 13:25:30 test
 Register Time: 2031-11-30 12:25:30 test
 
 -NAME UnstructuredTimestampConcatenateString
--QUERY MATCH (a:person) RETURN 'unstrTimestampProp1: ' + a.unstrTimestampProp1 + ' test'
+-QUERY MATCH (a:person) RETURN concat(concat('unstrTimestampProp1: ', a.unstrTimestampProp1), ' test')
 ---- 8
 
 

--- a/test/runner/queries/filtered/str_operations.test
+++ b/test/runner/queries/filtered/str_operations.test
@@ -1,106 +1,106 @@
 # description: matching nodes
 
 -NAME StrVarAndStrLiteralConcat
--QUERY MATCH (a:person) WHERE a.fName + 'xyz' = 'Farooqxyz' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(a.fName, 'xyz') = 'Farooqxyz' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndStrLiteralConcat2
--QUERY MATCH (a:person) WHERE 'xyz'+ a.fName = 'xyzFarooq' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat('xyz', a.fName) = 'xyzFarooq' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndStrLiteralConcat3
--QUERY MATCH (a:person) WHERE 'Farooqxyz' = a.fName + 'xyz' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE 'Farooqxyz' = concat(a.fName, 'xyz') RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndStrLiteralConcat4
--QUERY MATCH (a:person) WHERE 'xyzFarooq' = 'xyz' + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE 'xyzFarooq' = concat('xyz', a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndIntLiteralConcat
--QUERY MATCH (a:person) WHERE a.fName + string(10) = 'Farooq10' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(a.fName, string(10)) = 'Farooq10' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndIntLiteralConcat2
--QUERY MATCH (a:person) WHERE 'Farooq10' = a.fName + string(10) RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE 'Farooq10' = concat(a.fName, string(10)) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME IntLiteralAndStrVarConcat
--QUERY MATCH (a:person) WHERE string(10) + a.fName = '10Farooq' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(string(10), a.fName) = '10Farooq' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME IntLiteralAndStrVarConcat2
--QUERY MATCH (a:person) WHERE '10Farooq' = string(10) + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE '10Farooq' = concat(string(10), a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndBoolLiteralConcat
--QUERY MATCH (a:person) WHERE a.fName + string(true) = 'FarooqTrue' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(a.fName, string(true)) = 'FarooqTrue' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndBoolLiteralConcat2
--QUERY MATCH (a:person) WHERE 'FarooqTrue' = a.fName + string(true) RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE 'FarooqTrue' = concat(a.fName, string(true)) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME BoolLiteralAndStrVarConcat
--QUERY MATCH (a:person) WHERE string(false) + a.fName = 'FalseFarooq' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(string(false), a.fName) = 'FalseFarooq' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME BoolLiteralAndStrVarConcat
--QUERY MATCH (a:person) WHERE 'FalseFarooq' = string(FALse) + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE 'FalseFarooq' = concat(string(FALse), a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndDoubleLiteralConcat
--QUERY MATCH (a:person) WHERE a.fName + string(11.7) = 'Farooq11.700000' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(a.fName, string(11.7)) = 'Farooq11.700000' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndIntegerVarConcat
--QUERY MATCH (a:person) WHERE a.fName + string(a.age) = 'Farooq25' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(a.fName, string(a.age)) = 'Farooq25' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME StrVarAndIntegerVarConcat2
--QUERY MATCH (a:person) WHERE 'Farooq25' = a.fName + string(a.age) RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE 'Farooq25' = concat(a.fName, string(a.age)) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME IntegerVarAndStrVarConcat
--QUERY MATCH (a:person) WHERE string(a.age) + a.fName = '25Farooq' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(string(a.age), a.fName) = '25Farooq' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME IntegerVarAndStrVarConcat2
--QUERY MATCH (a:person) WHERE '25Farooq' = string(a.age) + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE '25Farooq' = concat(string(a.age), a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME DateVarAndStrVarConcatStructured
--QUERY MATCH (a:person) WHERE '1900-01-01Alice' = string(a.birthdate) + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE '1900-01-01Alice' = concat(string(a.birthdate), a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME UnstrDateVarAndStrVarConcatUnstructured
--QUERY MATCH (a:person) WHERE '1950-01-01Carol' = a.unstrDateProp1 + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE '1950-01-01Carol' = concat(a.unstrDateProp1, a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME TimestampVarAndStrVarConcatStructured
--QUERY MATCH (a:person) WHERE '2011-08-20 11:25:30Alice' = string(a.registerTime) + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE '2011-08-20 11:25:30Alice' = concat(string(a.registerTime), a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME UnstrTimestampVarAndStrVarConcatUnstructured
--QUERY MATCH (a:person) WHERE '1962-05-22 13:11:22.562Greg' = a.unstrTimestampProp1 + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE '1962-05-22 13:11:22.562Greg' = concat(a.unstrTimestampProp1, a.fName) RETURN COUNT(*)
 ---- 1
 1

--- a/test/runner/queries/filtered/unstructured_properties.test
+++ b/test/runner/queries/filtered/unstructured_properties.test
@@ -31,12 +31,12 @@
 1
 
 -NAME PersonUnstrFilteredTest7
--QUERY MATCH (a:person) WHERE 'abc ' + a.unstrNumericProp = 'abc 52' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat('abc ', string(a.unstrNumericProp)) = 'abc 52' RETURN COUNT(*)
 ---- 1
 1
 
 -NAME PersonUnstrFilteredTest8
--QUERY MATCH (a:person) WHERE a.unstrNumericProp2 + ' abcdefghijklm' = '20 abcdefghijklm' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(a.unstrNumericProp2, ' abcdefghijklm') = '20 abcdefghijklm' RETURN COUNT(*)
 ---- 1
 1
 
@@ -46,12 +46,12 @@
 1
 
 -NAME PersonUnstrFilteredTest10
--QUERY MATCH (a:person) WHERE '47Bob' = a.unstrNumericProp + a.fName RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE '47Bob' = concat(string(a.unstrNumericProp), a.fName) RETURN COUNT(*)
 ---- 1
 1
 
 -NAME PersonUnstrFilteredTest11
--QUERY MATCH (a:person) WHERE a.unstrDateProp1 + a.fName = '1950-01-01Bob' RETURN COUNT(*)
+-QUERY MATCH (a:person) WHERE concat(string(a.unstrDateProp1), a.fName) = '1950-01-01Bob' RETURN COUNT(*)
 ---- 1
 1
 

--- a/test/runner/queries/functions/arithmetic_functions.test
+++ b/test/runner/queries/functions/arithmetic_functions.test
@@ -503,3 +503,72 @@
 -0.218166
 0.057596
 
+
+-NAME atan2FunctionOnDoubleDoubleTest
+-QUERY MATCH (a:organisation) RETURN atan2(a.mark, a.mark)
+---- 3
+0.785398
+0.785398
+0.785398
+
+-NAME atan2FunctionOnDoubleInt64Test
+-QUERY MATCH (a:organisation) RETURN atan2(a.mark, a.orgCode)
+---- 3
+0.011384
+0.004390
+0.004976
+
+-NAME atan2FunctionOnInt64Int64Test
+-QUERY MATCH (a:organisation) RETURN atan2(a.orgCode, a.orgCode)
+---- 3
+0.785398
+0.785398
+0.785398
+
+-NAME atan2FunctionOnInt64DoubleTest
+-QUERY MATCH (a:organisation) RETURN atan2(a.orgCode, a.mark)
+---- 3
+1.559412
+1.566407
+1.565821
+
+-NAME atan2FunctionOnUnstrInt64DoubleTest
+-QUERY MATCH (a:organisation) RETURN atan2(a.unstrInt64Prop, a.unstrNumericProp)
+---- 3
+1.252049
+
+
+
+-NAME roundFunctionOnDoubleTest
+-QUERY MATCH (a:organisation) RETURN round(a.rating, 1)
+---- 3
+0.800000
+0.500000
+1.000000
+
+-NAME roundFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN round(a.orgCode, 2)
+---- 3
+325.000000
+824.000000
+934.000000
+
+-NAME roundFunctionOnUnstrDoubleTest
+-QUERY MATCH (a:organisation) RETURN round(a.unstrNumericProp, a.unstrInt64Prop)
+---- 3
+3.300000
+
+
+
+-NAME bitwiseXorFunctionOnInt64Test
+-QUERY MATCH (a:organisation) RETURN bitwise_xor(a.orgCode, a.score)
+---- 3
+-325
+-966
+831
+
+-NAME bitwiseXorFunctionOnUnstrInt64Test
+-QUERY MATCH (a:organisation) RETURN bitwise_xor(a.unstrInt64Prop, a.unstrInt64Prop)
+---- 3
+0
+0

--- a/test/runner/queries/functions/string_functions.test
+++ b/test/runner/queries/functions/string_functions.test
@@ -51,3 +51,115 @@ good|True
 -QUERY MATCH (a:person) WHERE a.fName STARTS WITH "C" RETURN a.fName
 ---- 1
 Carol
+
+-NAME LowerStructuredStr
+-QUERY MATCH (o:organisation) RETURN lower(o.name)
+---- 3
+abfsuni
+cswork
+deswork
+
+-NAME LowerUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN lower(o.unstrStr)
+---- 3
+  perfect
+  excellent organisation   
+good organisation ! 
+ 
+-NAME UpperStructuredStr
+-QUERY MATCH (o:organisation) RETURN upper(o.name)
+---- 3
+ABFSUNI
+CSWORK
+DESWORK
+
+-NAME UpperUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN upper(o.unstrStr)
+---- 3
+  PERFECT
+  EXCELLENT ORGANISATION   
+GOOD ORGANISATION ! 
+
+-NAME TrimStructuredStr
+-QUERY MATCH (o:organisation) RETURN trim(o.name)
+---- 3
+ABFsUni
+CsWork
+DEsWork
+
+-NAME TrimUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN trim(o.unstrStr)
+---- 3
+pERfECt
+EXcELLENT organisation
+GoOd organisation !
+
+-NAME LtrimStructuredStr
+-QUERY MATCH (o:organisation) RETURN ltrim(o.name)
+---- 3
+ABFsUni
+CsWork
+DEsWork
+
+-NAME LtrimUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN ltrim(o.unstrStr)
+---- 3
+pERfECt
+EXcELLENT organisation   
+GoOd organisation ! 
+
+-NAME RtrimStructuredStr
+-QUERY MATCH (o:organisation) RETURN rtrim(o.name)
+---- 3
+ABFsUni
+CsWork
+DEsWork
+
+-NAME RtrimUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN rtrim(o.unstrStr)
+---- 3
+  pERfECt
+  EXcELLENT organisation
+GoOd organisation !
+
+-NAME ReverseStructuredStr
+-QUERY MATCH (o:organisation) RETURN reverse(o.name)
+---- 3
+inUsFBA
+kroWsC
+kroWsED
+
+-NAME ReverseUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN reverse(o.unstrStr)
+---- 3
+tCEfREp  
+   noitasinagro TNELLEcXE  
+ ! noitasinagro dOoG
+
+-NAME LengthStructuredStr
+-QUERY MATCH (o:organisation) RETURN length(o.name)
+---- 3
+7
+6
+7
+
+-NAME LengthUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN length(o.unstrStr)
+---- 3
+9
+27
+20
+
+-NAME RepeatStructuredStr
+-QUERY MATCH (o:organisation) RETURN repeat(o.name, o.ID)
+---- 3
+ABFsUni
+CsWorkCsWorkCsWorkCsWork
+DEsWorkDEsWorkDEsWorkDEsWorkDEsWorkDEsWork
+
+-NAME RepeatUnstructuredStr
+-QUERY MATCH (o:organisation) RETURN repeat(o.unstrStr, o.ID)
+---- 3
+  pERfECt
+  EXcELLENT organisation     EXcELLENT organisation     EXcELLENT organisation     EXcELLENT organisation   
+GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! 

--- a/test/runner/queries/projection/projection.test
+++ b/test/runner/queries/projection/projection.test
@@ -64,9 +64,9 @@ Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|True|False
 -NAME OrgNodesReturnStarTest
 -QUERY MATCH (a:organisation) RETURN *
 ---- 3
-1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000||48 days 23:00:00|48 days 23:00:00|-12.500000|
-4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000|-4|26 years 52 days 48:00:00|32 years 123 days 48:00:00||
-6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000|10|||3.300000|1900-01-01
+1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000||48 days 23:00:00|48 days 23:00:00|-12.500000|  pERfECt|
+4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000|-4|26 years 52 days 48:00:00|32 years 123 days 48:00:00||  EXcELLENT organisation   |
+6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000|10|||3.300000|GoOd organisation ! |1900-01-01
 
 -NAME PersonNodesTestUnstructuredProperty
 -QUERY MATCH (a:person) RETURN a.ID,a.unstrDateProp1


### PR DESCRIPTION
1. This PR changes the unary/binary operator executor so that it passes in the `resultValueVector` to the string operations that need to allocate overflow buffer for result string.
2. Adds some binary numeric functions as described in this issue: #539
3. Adds string functions as described in this issue: #538