### PR TITLE
Add exception handling in python api

### DIFF
--- a/src/main/include/prepared_statement.h
+++ b/src/main/include/prepared_statement.h
@@ -30,7 +30,7 @@ public:
     }
 
 private:
-    bool success;
+    bool success = true;
     string errMsg;
 
     unique_ptr<QuerySummary> querySummary;

--- a/src/main/include/query_result.h
+++ b/src/main/include/query_result.h
@@ -54,7 +54,9 @@ public:
     }
 
 private:
-    bool success;
+    void validateQuerySucceed();
+
+    bool success = true;
     std::string errMsg;
 
     std::unique_ptr<QueryResultHeader> header;

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -7,14 +7,22 @@ namespace graphflow {
 namespace main {
 
 bool QueryResult::hasNext() {
+    validateQuerySucceed();
     assert(querySummary->getIsExplain() == false);
     return iterator->hasNextFlatTuple();
 }
 
 unique_ptr<FlatTuple> QueryResult::getNext() {
+    validateQuerySucceed();
     auto tuple = make_unique<FlatTuple>(header->columnDataTypes);
     iterator->getNextFlatTuple(*tuple);
     return tuple;
+}
+
+void QueryResult::validateQuerySucceed() {
+    if (!success) {
+        throw Exception(errMsg);
+    }
 }
 
 } // namespace main

--- a/test/api/test_exception.cpp
+++ b/test/api/test_exception.cpp
@@ -56,4 +56,12 @@ TEST_F(ApiTest, exception) {
     result = conn->query(runtime_error_query);
     ASSERT_FALSE(result->isSuccess());
     ASSERT_STREQ(result->getErrorMessage().c_str(), runtime_error);
+
+    // test fetching result when query fails
+    try {
+        result->hasNext();
+        FAIL();
+    } catch (Exception& exception) {
+        ASSERT_STREQ("Runtime exception: Cannot add `DATE` and `STRING`", exception.what());
+    } catch (std::exception& exception) { FAIL(); }
 }

--- a/test/api/test_prepare.cpp
+++ b/test/api/test_prepare.cpp
@@ -104,19 +104,16 @@ TEST_F(ApiTest, default_param) {
 TEST_F(ApiTest, param_not_exist) {
     auto preparedStatement =
         conn->prepare("MATCH (a:person) WHERE a.fName STARTS WITH $n RETURN COUNT(*)");
-    try {
-        conn->execute(preparedStatement.get(), make_pair(string("a"), "A"));
-    } catch (const invalid_argument& exception) {
-        ASSERT_STREQ("Parameter a not found.", exception.what());
-    }
+    auto result = conn->execute(preparedStatement.get(), make_pair(string("a"), "A"));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_STREQ("Parameter a not found.", result->getErrorMessage().c_str());
 }
 
 TEST_F(ApiTest, param_type_error) {
     auto preparedStatement =
         conn->prepare("MATCH (a:person) WHERE a.fName STARTS WITH $n RETURN COUNT(*)");
-    try {
-        conn->execute(preparedStatement.get(), make_pair(string("n"), (int64_t)36));
-    } catch (const invalid_argument& exception) {
-        ASSERT_STREQ("Parameter n has data type INT64 but expect STRING.", exception.what());
-    }
+    auto result = conn->execute(preparedStatement.get(), make_pair(string("n"), (int64_t)36));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_STREQ(
+        "Parameter n has data type INT64 but expect STRING.", result->getErrorMessage().c_str());
 }

--- a/tools/python_api/BUILD.bazel
+++ b/tools/python_api/BUILD.bazel
@@ -50,8 +50,9 @@ py_test(
     srcs = [
         "test/conftest.py",
         "test/test_datatype.py",
+        "test/test_exception.py",
         "test/test_main.py",
-        "test/test_parameter.py"
+        "test/test_parameter.py",
     ],
     data = [
         "//dataset",

--- a/tools/python_api/py_connection.cpp
+++ b/tools/python_api/py_connection.cpp
@@ -19,6 +19,9 @@ unique_ptr<PyQueryResult> PyConnection::execute(const string& query, py::list pa
     auto preparedStatement = conn->prepare(query);
     auto parameters = transformPythonParameters(params);
     auto queryResult = conn->executeWithParams(preparedStatement.get(), parameters);
+    if (!queryResult->isSuccess()) {
+        throw runtime_error(queryResult->getErrorMessage());
+    }
     auto pyQueryResult = make_unique<PyQueryResult>();
     pyQueryResult->queryResult = move(queryResult);
     return pyQueryResult;

--- a/tools/python_api/test/test_exception.py
+++ b/tools/python_api/test/test_exception.py
@@ -1,0 +1,14 @@
+import pytest
+
+
+def test_exception(establish_connection):
+    conn, db = establish_connection
+
+    with pytest.raises(RuntimeError, match="Parameter asd not found."):
+        conn.execute("MATCH (a:person) WHERE a.registerTime = $1 RETURN COUNT(*);", [("asd", 1)])
+
+    with pytest.raises(RuntimeError, match="Binder exception: Node a does not have property dummy."):
+        conn.execute("MATCH (a:person) RETURN a.dummy;")
+
+    with pytest.raises(RuntimeError, match="Runtime exception: Cannot abs `INTERVAL`"):
+        conn.execute("MATCH (a:person) RETURN abs(a.unstrIntervalProp);")

--- a/tools/python_api/test/test_main.py
+++ b/tools/python_api/test/test_main.py
@@ -2,6 +2,7 @@ import pytest
 
 from test_datatype import *
 from test_parameter import *
+from test_exception import *
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tools/python_api/test/test_parameter.py
+++ b/tools/python_api/test/test_parameter.py
@@ -75,10 +75,3 @@ def test_param_error3(establish_connection):
     conn, db = establish_connection
     with pytest.raises(RuntimeError, match="Each parameter must be in the form of <name, val>"):
         conn.execute("MATCH (a:person) WHERE a.registerTime = $1 RETURN COUNT(*);", [("asd", 1, 1)])
-
-# TODO(Xiyang): this error msg is no longer an exception but stored in query result instead.
-#  Fix this test after python api support error msg.
-# def test_param_error4(establish_connection):
-#     conn, db = establish_connection
-#     with pytest.raises(ValueError, match="Parameter asd not found."):
-#         conn.execute("MATCH (a:person) WHERE a.registerTime = $1 RETURN COUNT(*);", [("asd", 1)])

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -150,7 +150,7 @@ void EmbeddedShell::run() {
             if (queryResult->isSuccess()) {
                 printExecutionResult(*queryResult);
             } else {
-                printf("%s\n", queryResult->getErrorMessage().c_str());
+                printf("Error: %s\n", queryResult->getErrorMessage().c_str());
             }
         }
         linenoiseHistoryAdd(line);


### PR DESCRIPTION
This PR contains the following changes

- Add exception throwing to python API. We throw a python runtime error with our error message if a query fails. This follows both neo4j and duckdb styles.
- Add exception when a user tries to fetch result from a failed query.
  -  Although we give APIs checking the state of query result, it is not guaranteed that user will use these APIs as we expected. Therefore, throwing exception when pulling from failed query result is needed.
- Fix explain and profiler not printing bug introduced in PR #562 