### PR TITLE
fixing binder test

### DIFF
--- a/test/binder/binder_test.cpp
+++ b/test/binder/binder_test.cpp
@@ -24,12 +24,9 @@ TEST_F(BinderTest, VarLenExtendMaxDepthTest) {
     // If the upper bound of the varLenEtend is larger than VAR_LENGTH_EXTEND_MAX_DEPTH, the
     // upper bound will be set to VAR_LENGTH_EXTEND_MAX_DEPTH.
     auto input = "MATCH (a:person)-[:knows*2..32]->(b:person) return count(*)";
-    auto queryRel = QueryBinder(catalog)
-                        .bind(*Parser::parseQuery(input))
-                        ->getSingleQuery(0)
-                        ->getQueryPart(0)
-                        ->getQueryGraph(0)
-                        ->getQueryRel(0);
+    auto boundRegularQuery = QueryBinder(catalog).bind(*Parser::parseQuery(input));
+    auto queryRel =
+        boundRegularQuery->getSingleQuery(0)->getQueryPart(0)->getQueryGraph(0)->getQueryRel(0);
     ASSERT_EQ(queryRel->getLowerBound(), 2);
     ASSERT_EQ(queryRel->getUpperBound(), VAR_LENGTH_EXTEND_MAX_DEPTH);
 }


### PR DESCRIPTION
BinderTests were failing on my end because the RelExpression was running out of scope and the upperBound value was getting set to an arbitrary value that is not equal to 30. The reason this was happening was the following:

Binder test used to make this call to get a raw pointer to RelExpression:
```
    auto queryRel = QueryBinder(catalog).bind(*Parser::parseQuery(input));
                        ->getQueryPart(0)
                        ->getQueryGraph(0)
                        ->getQueryRel(0);

```
However, RelExpression is stored as a shared_ptr inside QueryGraph and this point, because we obtained a raw pointer to RelExpression and because there are pointers to QueryGraph (and therefore the shared_ptr<RelExpression> inside QueryGraph), QueryGraph and RelExpression are deconstructed. So now the raw pointer we obtained is dangling.

We are now explicitly holding onto queryGraph in a variable as follows:
```
    auto boundRegularQuery = QueryBinder(catalog).bind(*Parser::parseQuery(input));
    auto queryRel = boundRegularQuery->getSingleQuery(0)
                        ->getQueryPart(0)
                        ->getQueryGraph(0)
                        ->getQueryRel(0);
    ASSERT_EQ(queryRel->getLowerBound(), 2);
    ASSERT_EQ(queryRel->getUpperBound(), (uint64_t) VAR_LENGTH_EXTEND_MAX_DEPTH);
```
I believe technically a smart compiler can still figure out that after boundRegularQuery is not needed and deconstruct it but hopefully not.