### PR TITLE
Fix upper/factorial/orderByTest/binaryOperationExecutor bugs.

### DIFF
--- a/src/function/arithmetic/operations/include/arithmetic_operations.h
+++ b/src/function/arithmetic/operations/include/arithmetic_operations.h
@@ -163,10 +163,12 @@ struct Even {
 };
 
 struct Factorial {
-    template<class T>
-    static inline void operation(T& input, bool isNull, T& result) {
+    static inline void operation(int64_t& input, bool isNull, int64_t& result) {
         assert(!isNull);
-        result = tgamma(input + 1);
+        result = 1;
+        for (int64_t i = 2; i <= input; i++) {
+            result *= i;
+        }
     }
 };
 
@@ -581,107 +583,102 @@ inline void Abs::operation(Value& operand, bool isNull, Value& result) {
 template<>
 inline void Floor::operation(Value& operand, bool isNull, Value& result) {
     ArithmeticOnValues::operation<Floor, floorStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Ceil::operation(Value& operand, bool isNull, Value& result) {
     ArithmeticOnValues::operation<Ceil, ceilStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Sin::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Sin, sinStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Cos::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Cos, cosStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Tan::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Tan, tanStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Cot::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Cot, cotStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Asin::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Asin, asinStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Acos::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Acos, acosStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Atan::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Atan, atanStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Even::operation(Value& operand, bool isNull, int64_t& result) {
     ArithmeticOnValues::operation<Even, evenStr>(operand, isNull, result);
-};
-
-template<>
-inline void Factorial::operation(Value& operand, bool isNull, Value& result) {
-    ArithmeticOnValues::operation<Factorial, factorialStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Sign::operation(Value& operand, bool isNull, int64_t& result) {
     ArithmeticOnValues::operation<Sign, signStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Sqrt::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Sqrt, sqrtStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Cbrt::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Cbrt, cbrtStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Gamma::operation(Value& operand, bool isNull, Value& result) {
     ArithmeticOnValues::operation<Gamma, gammaStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Lgamma::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Lgamma, lgammaStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Ln::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Ln, lnStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Log::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Log, logStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Log2::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Log2, log2Str>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Degrees::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Degrees, degreesStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Radians::operation(Value& operand, bool isNull, double_t& result) {
     ArithmeticOnValues::operation<Radians, radiansStr>(operand, isNull, result);
-};
+}
 
 template<>
 inline void Atan2::operation(

--- a/src/function/arithmetic/vector_arithmetic_operations.cpp
+++ b/src/function/arithmetic/vector_arithmetic_operations.cpp
@@ -231,10 +231,9 @@ vector<unique_ptr<VectorOperationDefinition>> AtanVectorOperation::getDefinition
 
 vector<unique_ptr<VectorOperationDefinition>> FactorialVectorOperation::getDefinitions() {
     vector<unique_ptr<VectorOperationDefinition>> result;
-    for (auto& typeID : DataType::getNumericalAndUnstructuredTypeIDs()) {
-        result.push_back(
-            getUnaryDefinition<operation::Factorial>(FACTORIAL_FUNC_NAME, typeID, typeID));
-    }
+    result.push_back(
+        make_unique<VectorOperationDefinition>(FACTORIAL_FUNC_NAME, vector<DataTypeID>{INT64},
+            INT64, UnaryExecFunction<int64_t, int64_t, operation::Factorial>));
     return result;
 }
 

--- a/src/function/include/binary_operation_executor.h
+++ b/src/function/include/binary_operation_executor.h
@@ -61,7 +61,7 @@ struct BinaryOperationExecutor {
     static void executeFlatUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
         auto lPos = left.state->getPositionOfCurrIdx();
         if (left.isNull(lPos)) {
-            right.setAllNull();
+            result.setAllNull();
         } else if (right.hasNoNullsGuarantee()) {
             if (right.state->isUnfiltered()) {
                 for (auto i = 0u; i < right.state->selectedSize; ++i) {
@@ -102,7 +102,7 @@ struct BinaryOperationExecutor {
     static void executeUnFlatFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
         auto rPos = right.state->getPositionOfCurrIdx();
         if (right.isNull(rPos)) {
-            left.setAllNull();
+            result.setAllNull();
         } else if (left.hasNoNullsGuarantee()) {
             if (left.state->isUnfiltered()) {
                 for (auto i = 0u; i < left.state->selectedSize; ++i) {

--- a/src/function/string/operations/include/upper_operation.h
+++ b/src/function/string/operations/include/upper_operation.h
@@ -26,6 +26,7 @@ private:
         for (auto i = 0u; i < len; i++) {
             str[i] = toupper(str[i]);
         }
+        return len;
     }
 };
 

--- a/test/runner/order_by_end_to_end_test.cpp
+++ b/test/runner/order_by_end_to_end_test.cpp
@@ -9,7 +9,7 @@ public:
 
     void SetUp() override {
         BaseGraphLoadingTest::SetUp();
-        systemConfig->largePageBufferPoolSize = (1ull << 22);
+        systemConfig->largePageBufferPoolSize = (1ull << 23);
         createConn();
     }
 };

--- a/test/runner/queries/order_by/order_by_large_dataset.test
+++ b/test/runner/queries/order_by/order_by_large_dataset.test
@@ -1,3 +1,12 @@
+# We need a maximum of 23 large pages for this test:
+# OrderByKeyEncoder: 1 page(need at least 1 page to store encoded key blocks) * 6 (number of threads)
+# RadixSort: 2(need 2 pages for temporary sorting buffer) * 6 (number of threads)
+# MergeSort: 1 page for merged keyBlocks
+# OrderBy physical operator:
+# FactorizedTable: 2 pages (store orderBy/payload columns)
+# ResultCollector:
+# FactorizedTable: 2 pages (store results)
+# In total: we need 23 pages for this test case
 -NAME OrderByWithLimitTest
 -QUERY MATCH (p:person) RETURN p.balance ORDER BY p.balance limit 25
 -PARALLELISM 6


### PR DESCRIPTION
This bugs fix the following bugs:
1. Missing return statement for `upperStr()` #566 
2. Changed the input/return type for `factorial` to INT64 only
3. Changed the `largePageBufferPoolSize` for orderByEndToEndTest to 8MB, and added a comment for the calculation.
4. Fixed a bug in the binaryOperationExecutor