### PR TITLE
Transactions Warm Up

### DIFF
--- a/src/common/include/exception.h
+++ b/src/common/include/exception.h
@@ -75,5 +75,15 @@ public:
     explicit RuntimeException(const string& msg) : Exception("Runtime exception: " + msg){};
 };
 
+class ConnectionException : public Exception {
+public:
+    explicit ConnectionException(const string& msg) : Exception(msg){};
+};
+
+class TransactionManagerException : public Exception {
+public:
+    explicit TransactionManagerException(const string& msg) : Exception(msg){};
+};
+
 } // namespace common
 } // namespace graphflow

--- a/src/main/BUILD.bazel
+++ b/src/main/BUILD.bazel
@@ -17,5 +17,6 @@ cc_library(
         "//src/planner:enumerator",
         "//src/processor",
         "//src/processor:mapper",
+        "//src/transaction:transaction",
     ],
 )

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -12,6 +12,7 @@ Database::Database(const DatabaseConfig& databaseConfig, const SystemConfig& sys
     catalog = make_unique<catalog::Catalog>(databaseConfig.databasePath);
     storageManager = make_unique<storage::StorageManager>(
         *catalog, *bufferManager, databaseConfig.databasePath, databaseConfig.inMemoryMode);
+    transactionManager = make_unique<transaction::TransactionManager>();
 }
 
 void Database::resizeBufferManager(uint64_t newSize) {

--- a/src/main/include/connection.h
+++ b/src/main/include/connection.h
@@ -5,8 +5,11 @@
 #include "query_result.h"
 
 #include "src/planner/logical_plan/include/logical_plan.h"
+#include "src/transaction/include/transaction_manager.h"
 
 using namespace graphflow::planner;
+using namespace graphflow::transaction;
+using lock_t = unique_lock<mutex>;
 
 namespace graphflow {
 namespace main {
@@ -15,7 +18,55 @@ class Database;
 class Connection {
 
 public:
+    /**
+     * If the connection is in AUTO_COMMIT mode any query over the connection will be wrapped around
+     * a transaction and committed (even if the query is READ_ONLY).
+     * If the connection is in MANUAL transaction mode, which happens only if an application
+     * manually begins a transaction (see below), then an application has to manually commit or
+     * rollback the transaction by calling commit() or rollback().
+     *
+     * AUTO_COMMIT is the default mode when a Connection is created. If an application calls
+     * begin[ReadOnly/Write]Transaction at any point, the mode switches to MANUAL. This creates
+     * an "active transaction" in the connection. When a connection is in MANUAL mode and the
+     * active transaction is rolled back or committed, then the active transaction is removed (so
+     * the connection no longer has an active transaction) and the mode automatically switches
+     * back to AUTO_COMMIT.
+     * Note: When a Connection object is deconstructed, if the connection has an active (manual)
+     * transaction, then the active transaction is rolled back.
+     */
+    enum ConnectionTransactionMode : uint8_t { AUTO_COMMIT, MANUAL };
+
+public:
     explicit Connection(Database* database);
+
+    ~Connection();
+
+    inline ConnectionTransactionMode getTransactionMode() {
+        lock_t lck{mtx};
+        return transactionMode;
+    }
+
+    inline void beginReadOnlyTransaction() {
+        lock_t lck{mtx};
+        setTransactionModeNoLock(MANUAL);
+        beginTransactionNoLock(READ_ONLY);
+    }
+
+    inline void beginWriteTransaction() {
+        lock_t lck{mtx};
+        setTransactionModeNoLock(MANUAL);
+        beginTransactionNoLock(WRITE);
+    }
+
+    inline void commit() {
+        lock_t lck{mtx};
+        commitOrRollbackNoLock(true /* isCommit */);
+    }
+
+    inline void rollback() {
+        lock_t lck{mtx};
+        commitOrRollbackNoLock(false /* is rollback */);
+    }
 
     inline void setMaxNumThreadForExec(uint64_t numThreads) {
         clientContext->numThreadsForExecution = numThreads;
@@ -23,7 +74,10 @@ public:
 
     std::unique_ptr<QueryResult> query(const std::string& query);
 
-    std::unique_ptr<PreparedStatement> prepare(const std::string& query);
+    std::unique_ptr<PreparedStatement> prepare(const std::string& query) {
+        lock_t lck{mtx};
+        return prepareNoLock(query);
+    }
 
     template<typename... Args>
     inline std::unique_ptr<QueryResult> execute(
@@ -32,8 +86,12 @@ public:
         return executeWithParams(preparedStatement, inputParameters, args...);
     }
 
+    // Note: Any call that goes through executeWithParams acquires a lock in the end by calling
+    // executeLock(...).
     std::unique_ptr<QueryResult> executeWithParams(PreparedStatement* preparedStatement,
         unordered_map<string, shared_ptr<Literal>>& inputParams);
+
+    void close();
 
     /**
      * TODO(Xiyang): APIs that need to be added
@@ -44,12 +102,53 @@ public:
     // instead let IDE catch these exception
     std::vector<unique_ptr<planner::LogicalPlan>> enumeratePlans(const std::string& query);
     std::unique_ptr<QueryResult> executePlan(unique_ptr<planner::LogicalPlan> logicalPlan);
-    // Used in API test
-    inline uint64_t getMaxNumThreadForExec() const { return clientContext->numThreadsForExecution; }
+    // used in API test
+    inline uint64_t getMaxNumThreadForExec() {
+        lock_t lck{mtx};
+        return clientContext->numThreadsForExecution;
+    }
+
+    inline uint64_t getActiveTransactionID() {
+        lock_t lck{mtx};
+        return activeTransaction ? activeTransaction->getID() : UINT64_MAX;
+    }
+
+    inline bool hasActiveTransaction() {
+        lock_t lck{mtx};
+        return activeTransaction != nullptr;
+    }
 
 private:
-    std::unique_lock<mutex> acquireLock() { return std::unique_lock<std::mutex>{mtx}; }
+    void setTransactionModeNoLock(ConnectionTransactionMode newTransactionMode) {
+        if (activeTransaction && transactionMode == MANUAL && newTransactionMode == AUTO_COMMIT) {
+            throw ConnectionException(
+                "Cannot change transaction mode from MANUAL to AUTO_COMMING when there is an "
+                "active transaction. Need to first commit or rollback the active transaction.");
+        }
+        transactionMode = newTransactionMode;
+    }
 
+    bool isManualModeAndNoActiveTransactionNoLock() {
+        return transactionMode == MANUAL && !activeTransaction;
+    }
+
+    void beginTransactionNoLock(TransactionType type);
+    inline void commitNoLock() { commitOrRollbackNoLock(true /* is commit */); }
+    inline void rollbackNoLock() { commitOrRollbackNoLock(false /* is rollback */); }
+    void commitOrRollbackNoLock(bool isCommit);
+
+    unique_ptr<QueryResult> queryResultWithError(std::string& errMsg);
+
+    inline unique_ptr<QueryResult> queryResultWithErrorForNoActiveTransaction() {
+        std::string errMsg("Transaction mode is manual but there is no active "
+                           "transaction. Please begin a transaction"
+                           "or set the transaction mode of the connection to AUTO_COMMIT");
+        return queryResultWithError(errMsg);
+    }
+    std::unique_ptr<PreparedStatement> prepareNoLock(const std::string& query);
+
+    // Note: Any call that goes through executeWithParams acquires a lock in the end by calling
+    // executeLock(...).
     template<typename T, typename... Args>
     std::unique_ptr<QueryResult> executeWithParams(PreparedStatement* preparedStatement,
         unordered_map<string, shared_ptr<Literal>>& params, pair<string, T> arg,
@@ -60,14 +159,24 @@ private:
         return executeWithParams(preparedStatement, params, args...);
     }
 
-    void bindParameters(PreparedStatement* preparedStatement,
+    void bindParametersNoLock(PreparedStatement* preparedStatement,
         unordered_map<string, shared_ptr<Literal>>& inputParams);
 
-    std::unique_ptr<QueryResult> execute(PreparedStatement* preparedStatement);
+    std::unique_ptr<QueryResult> executeLock(PreparedStatement* preparedStatement) {
+        lock_t lck{mtx};
+        if (isManualModeAndNoActiveTransactionNoLock()) {
+            return queryResultWithErrorForNoActiveTransaction();
+        }
+        return executeAndAutoCommitIfNecessaryNoLock(preparedStatement);
+    }
+    std::unique_ptr<QueryResult> executeAndAutoCommitIfNecessaryNoLock(
+        PreparedStatement* preparedStatement);
 
 private:
     Database* database;
     std::unique_ptr<ClientContext> clientContext;
+    std::unique_ptr<Transaction> activeTransaction;
+    ConnectionTransactionMode transactionMode;
     std::mutex mtx;
 };
 

--- a/src/main/include/database.h
+++ b/src/main/include/database.h
@@ -6,6 +6,7 @@
 #include "src/storage/include/buffer_manager.h"
 #include "src/storage/include/memory_manager.h"
 #include "src/storage/include/storage_manager.h"
+#include "src/transaction/include/transaction_manager.h"
 
 namespace graphflow {
 namespace main {
@@ -64,6 +65,7 @@ private:
     std::unique_ptr<storage::BufferManager> bufferManager;
     std::unique_ptr<catalog::Catalog> catalog;
     std::unique_ptr<storage::StorageManager> storageManager;
+    std::unique_ptr<transaction::TransactionManager> transactionManager;
 };
 
 } // namespace main

--- a/src/main/include/prepared_statement.h
+++ b/src/main/include/prepared_statement.h
@@ -29,6 +29,8 @@ public:
             move(physicalPlan), move(physicalIDToLogicalOperatorMap), move(profiler));
     }
 
+    inline bool isReadOnly() { return physicalPlan->isReadOnly(); }
+
 private:
     bool success = true;
     string errMsg;

--- a/src/processor/include/physical_plan/physical_plan.h
+++ b/src/processor/include/physical_plan/physical_plan.h
@@ -15,6 +15,9 @@ public:
 
     PhysicalPlan(const PhysicalPlan& plan) : lastOperator{plan.lastOperator->clone()} {};
 
+    // TODO (Semih/Xiyang): This will change when CRUD statements/operators are added.
+    bool isReadOnly() { return true; }
+
 public:
     unique_ptr<PhysicalOperator> lastOperator;
 };

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -13,7 +13,7 @@ StorageManager::StorageManager(const catalog::Catalog& catalog, BufferManager& b
     string directory, bool isInMemoryMode)
     : logger{LoggerUtils::getOrCreateSpdLogger("storage")}, directory{move(directory)},
       isInMemoryMode{isInMemoryMode} {
-    logger->info("Initializing StorageManager.");
+    logger->info("Initializing StorageManager from directory: " + this->directory);
     nodesStore = make_unique<NodesStore>(catalog, bufferManager, this->directory, isInMemoryMode);
     relsStore = make_unique<RelsStore>(catalog, bufferManager, this->directory, isInMemoryMode);
     logger->info("Done.");

--- a/src/transaction/BUILD.bazel
+++ b/src/transaction/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+
+cc_library(
+    name = "transaction",
+    srcs = glob(["*.cpp"]),
+    hdrs = glob(["include/*.h"]),
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "//src/common:utils",
+    ],
+)

--- a/src/transaction/include/transaction.h
+++ b/src/transaction/include/transaction.h
@@ -1,0 +1,29 @@
+#pragma once
+
+namespace graphflow {
+namespace transaction {
+
+class TransactionManager;
+
+enum TransactionType : uint8_t { READ_ONLY, WRITE };
+
+class Transaction {
+    friend class TransactionManager;
+
+public:
+    inline TransactionType getType() { return type; }
+    inline bool isReadOnly() { return READ_ONLY == type; }
+    inline bool isWriteTransaction() { return WRITE == type; }
+    inline uint64_t getID() { return ID; }
+
+private:
+    Transaction(TransactionType transactionType, uint64_t transactionID)
+        : type{transactionType}, ID{transactionID} {}
+
+private:
+    TransactionType type;
+    uint64_t ID;
+};
+
+} // namespace transaction
+} // namespace graphflow

--- a/src/transaction/include/transaction_manager.h
+++ b/src/transaction/include/transaction_manager.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <memory>
+#include <mutex>
+#include <unordered_set>
+
+#include "transaction.h"
+
+#include "src/common/include/utils.h"
+
+using namespace std;
+using lock_t = unique_lock<mutex>;
+
+namespace graphflow {
+namespace transaction {
+
+class TransactionManager {
+
+public:
+    TransactionManager()
+        : activeWriteTransactionID{INT64_MAX}, lastTransactionID{0}, lastCommitID{0} {};
+    unique_ptr<Transaction> beginWriteTransaction();
+    unique_ptr<Transaction> beginReadOnlyTransaction();
+    void commit(Transaction* transaction);
+    void rollback(Transaction* transaction);
+
+    // Warning: Below public functions are for tests only
+    inline unordered_set<uint64_t>& getActiveReadOnlyTransactionIDs() {
+        lock_t lck{mtx};
+        return activeReadOnlyTransactionIDs;
+    }
+    inline uint64_t getActiveWriteTransactionID() {
+        lock_t lck{mtx};
+        return activeWriteTransactionID;
+    }
+    inline bool hasActiveWriteTransactionID() {
+        lock_t lck{mtx};
+        return activeWriteTransactionID != INT64_MAX;
+    }
+
+private:
+    inline bool hasActiveWriteTransactionNoLock() { return activeWriteTransactionID != INT64_MAX; }
+    inline void clearActiveWriteTransactionNoLock() { activeWriteTransactionID = INT64_MAX; }
+    void commitOrRollback(Transaction* transaction, bool isCommit);
+
+private:
+    shared_ptr<spdlog::logger> logger;
+
+    uint64_t activeWriteTransactionID;
+
+    unordered_set<uint64_t> activeReadOnlyTransactionIDs;
+
+    uint64_t lastTransactionID;
+
+    // ID of the last committed write transaction. This is currently used primarily for
+    // debugging purposes during development and is not written to disk in a db file.
+    // In particular, transactions do not use this to perform reads. Our current transaction design
+    // supports a concurrency model that requires on 2 versions, one for the read-only transactions
+    // and the for the writer transaction, so we can read correct version by looking at the type of
+    // the transaction.
+    uint64_t lastCommitID;
+    mutex mtx;
+};
+} // namespace transaction
+} // namespace graphflow

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -1,0 +1,56 @@
+#include "include/transaction_manager.h"
+
+#include "src/common/include/exception.h"
+
+using namespace graphflow::common;
+
+namespace graphflow {
+namespace transaction {
+
+unique_ptr<Transaction> TransactionManager::beginWriteTransaction() {
+    lock_t lck{mtx};
+    if (hasActiveWriteTransactionNoLock()) {
+        throw TransactionManagerException(
+            "Cannot start a new write transaction in the system. Only one write transaction at a "
+            "time is allowed in the system.");
+    }
+    auto transaction = unique_ptr<Transaction>(new Transaction(WRITE, ++lastTransactionID));
+    activeWriteTransactionID = lastTransactionID;
+    return transaction;
+}
+
+unique_ptr<Transaction> TransactionManager::beginReadOnlyTransaction() {
+    lock_t lck{mtx};
+    auto transaction = unique_ptr<Transaction>(new Transaction(READ_ONLY, ++lastTransactionID));
+    activeReadOnlyTransactionIDs.insert(transaction->getID());
+    return transaction;
+}
+
+void TransactionManager::commitOrRollback(Transaction* transaction, bool isCommit) {
+    lock_t lck{mtx};
+    if (transaction->isReadOnly()) {
+        activeReadOnlyTransactionIDs.erase(transaction->getID());
+        return;
+    }
+    if (activeWriteTransactionID != transaction->getID()) {
+        throw TransactionManagerException(
+            "The ID of the committing write transaction " + to_string(transaction->getID()) +
+            " is not equal to the ID of the activeWriteTransaction: " +
+            to_string(activeWriteTransactionID));
+    }
+    if (isCommit) {
+        lastCommitID++;
+    }
+    clearActiveWriteTransactionNoLock();
+}
+
+void TransactionManager::commit(Transaction* transaction) {
+    commitOrRollback(transaction, true /* is commit */);
+}
+
+void TransactionManager::rollback(Transaction* transaction) {
+    commitOrRollback(transaction, false /* is rollback */);
+}
+
+} // namespace transaction
+} // namespace graphflow

--- a/test/test_utility/include/test_helper.h
+++ b/test/test_utility/include/test_helper.h
@@ -86,6 +86,14 @@ public:
     }
 
     string getInputCSVDir() override { return "dataset/tinysnb/"; }
+
+    static void assertMatchPersonCountStar(Connection* conn) {
+        auto result = conn->query("MATCH (a:person) RETURN COUNT(*)");
+        ASSERT_TRUE(result->hasNext());
+        auto tuple = result->getNext();
+        ASSERT_EQ(tuple->getValue(0)->val.int64Val, 8);
+        ASSERT_FALSE(result->hasNext());
+    }
 };
 
 } // namespace testing

--- a/test/transaction/BUILD.bazel
+++ b/test/transaction/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
+cc_test(
+    name = "transaction_manager_test",
+    srcs = glob(["*.cpp"]),
+    copts = [
+        "-Iexternal/gtest/include",
+    ],
+    deps = [
+        "//src/transaction:transaction",
+        "@gtest",
+        "@gtest//:gtest_main",
+    ],
+)

--- a/test/transaction/transaction_manager_test.cpp
+++ b/test/transaction/transaction_manager_test.cpp
@@ -1,0 +1,107 @@
+#include "gtest/gtest.h"
+
+#include "src/common/include/exception.h"
+#include "src/transaction/include/transaction_manager.h"
+
+using namespace graphflow::common;
+using namespace graphflow::transaction;
+using ::testing::Test;
+
+class TransactionManagerTest : public Test {
+
+protected:
+    void SetUp() override { transactionManager = make_unique<TransactionManager>(); }
+
+    void TearDown() override {}
+
+public:
+    void runTwoCommitRollback(TransactionType type, bool firstIsCommit, bool secondIsCommit) {
+        unique_ptr<Transaction> trx = WRITE == type ?
+                                          transactionManager->beginWriteTransaction() :
+                                          transactionManager->beginReadOnlyTransaction();
+        if (firstIsCommit) {
+            transactionManager->commit(trx.get());
+        } else {
+            transactionManager->rollback(trx.get());
+        }
+        if (secondIsCommit) {
+            transactionManager->commit(trx.get());
+        } else {
+            transactionManager->rollback(trx.get());
+        }
+    }
+
+    unique_ptr<TransactionManager> transactionManager;
+};
+
+TEST_F(TransactionManagerTest, MultipleWriteTransactionsErrors) {
+    unique_ptr<Transaction> trx1 = transactionManager->beginWriteTransaction();
+    try {
+        transactionManager->beginWriteTransaction();
+        FAIL();
+    } catch (TransactionManagerException& e) {}
+}
+
+TEST_F(TransactionManagerTest, MultipleCommitsAndRollbacks) {
+    // At TransactionManager level, we disallow multiple commit/rollbacks on a write transaction.
+    try {
+        runTwoCommitRollback(WRITE, true /* firstIsCommit */, true /* secondIsCommit */);
+        FAIL();
+    } catch (TransactionManagerException& e) {}
+    try {
+        runTwoCommitRollback(WRITE, true /* firstIsCommit */, false /* secondIsRollback */);
+        FAIL();
+    } catch (TransactionManagerException& e) {}
+    try {
+        runTwoCommitRollback(WRITE, false /* firstIsRollback */, true /* secondIsCommit */);
+        FAIL();
+    } catch (TransactionManagerException& e) {}
+    try {
+        runTwoCommitRollback(WRITE, false /* firstIsRollback */, false /* secondIsRollback */);
+        FAIL();
+    } catch (TransactionManagerException& e) {}
+    // At TransactionManager level, we allow multiple commit/rollbacks on a read-only transaction.
+    runTwoCommitRollback(READ_ONLY, true /* firstIsCommit */, true /* secondIsCommit */);
+    runTwoCommitRollback(READ_ONLY, true /* firstIsCommit */, false /* secondIsRollback */);
+    runTwoCommitRollback(READ_ONLY, false /* firstIsRollback */, true /* secondIsCommit */);
+    runTwoCommitRollback(READ_ONLY, false /* firstIsRollback */, false /* secondIsRollback */);
+}
+
+TEST_F(TransactionManagerTest, BasicOneWriteMultipleReadOnlyTransactions) {
+    // Tests the internal states of the transaction manager at different points in time, e.g.,
+    // before and after commits or rollbacks under concurrent transactions. Specifically we test:
+    // that transaction IDs increase incrementally, the states of activeReadOnlyTransactionIDs set,
+    // and activeWriteTransactionID.
+    unique_ptr<Transaction> trx1 = transactionManager->beginReadOnlyTransaction();
+    unique_ptr<Transaction> trx2 = transactionManager->beginWriteTransaction();
+    unique_ptr<Transaction> trx3 = transactionManager->beginReadOnlyTransaction();
+    ASSERT_EQ(READ_ONLY, trx1->getType());
+    ASSERT_EQ(WRITE, trx2->getType());
+    ASSERT_EQ(READ_ONLY, trx3->getType());
+    ASSERT_EQ(trx1->getID() + 1, trx2->getID());
+    ASSERT_EQ(trx2->getID() + 1, trx3->getID());
+    ASSERT_EQ(trx2->getID(), transactionManager->getActiveWriteTransactionID());
+    unordered_set<uint64_t> expectedReadOnlyTransactionSet({trx1->getID(), trx3->getID()});
+    ASSERT_EQ(
+        expectedReadOnlyTransactionSet, transactionManager->getActiveReadOnlyTransactionIDs());
+
+    transactionManager->commit(trx2.get());
+    ASSERT_FALSE(transactionManager->hasActiveWriteTransactionID());
+    transactionManager->rollback(trx1.get());
+    expectedReadOnlyTransactionSet.erase(trx1->getID());
+    ASSERT_EQ(
+        expectedReadOnlyTransactionSet, transactionManager->getActiveReadOnlyTransactionIDs());
+    transactionManager->commit(trx3.get());
+    expectedReadOnlyTransactionSet.erase(trx3->getID());
+    ASSERT_EQ(
+        expectedReadOnlyTransactionSet, transactionManager->getActiveReadOnlyTransactionIDs());
+
+    unique_ptr<Transaction> trx4 = transactionManager->beginWriteTransaction();
+    unique_ptr<Transaction> trx5 = transactionManager->beginReadOnlyTransaction();
+    ASSERT_EQ(trx3->getID() + 1, trx4->getID());
+    ASSERT_EQ(trx4->getID() + 1, trx5->getID());
+    ASSERT_EQ(trx4->getID(), transactionManager->getActiveWriteTransactionID());
+    expectedReadOnlyTransactionSet.insert(trx5->getID());
+    ASSERT_EQ(
+        expectedReadOnlyTransactionSet, transactionManager->getActiveReadOnlyTransactionIDs());
+}


### PR DESCRIPTION
This PR adds basic support for beginning, committing, and rolling back transactions. Major classes that are added or modified are:
- TransactionManager
- Connection

The general behavior is explained in the comment above TransactionMode inside connection (copy pasted as it is in the current version of the PR):

    /**
     * If the connection is in AUTO_COMMIT mode any query over the connection will be wrapped around
     * a transaction and committed (even if the query is READ_ONLY).
     * If the connection is in MANUAL transaction mode, which happens only if an application
     * manually begins a transaction (see below), then an application has to manually commit or
     * rollback the transaction by calling commit() or rollback().
     *
     * AUTO_COMMIT is the default mode when a Connection is created. If an application calls
     * begin[ReadOnly/Write]Transaction at any point, the mode switches to MANUAL. This creates
     * an "active transaction" in the connection. When a connection is in MANUAL mode and the
     * active transaction is rolled back or committed, then the active transaction is removed (so
     * the connection no longer has an active transaction) and the mode automatically switches
     * back to AUTO_COMMIT.
     * Note: If connection is closed() and the connection has an active (manual) transaction, then
     * the active transaction is rolled back.
     */