### PR TITLE
Making the scheduling thread wait for all threads to finish during errors. 

### DIFF
--- a/src/common/include/task_system/task.h
+++ b/src/common/include/task_system/task.h
@@ -43,12 +43,17 @@ public:
 
     inline bool isCompletedOrHasException() {
         lock_t lck{mtx};
-        return hasException() || isCompletedNoLock();
+        return hasExceptionNoLock() || isCompletedNoLock();
+    }
+
+    inline bool isCompleted() {
+        lock_t lck{mtx};
+        return isCompletedNoLock();
     }
 
     inline bool isCompletedSuccessfully() {
         lock_t lck{mtx};
-        return isCompletedNoLock() && !hasException();
+        return isCompletedNoLock() && !hasExceptionNoLock();
     }
 
     inline bool isCompletedNoLock() {
@@ -68,7 +73,10 @@ public:
         }
     }
 
-    bool hasException() const { return exceptionsPtr != nullptr; }
+    inline bool hasException() {
+        lock_t lck{mtx};
+        return exceptionsPtr != nullptr;
+    }
 
     std::exception_ptr getExceptionPtr() {
         lock_t lck{mtx};
@@ -79,6 +87,8 @@ private:
     bool canRegisterInternalNoLock() const {
         return 0 == numThreadsFinished && maxNumThreads > numThreadsRegistered;
     }
+
+    inline bool hasExceptionNoLock() const { return exceptionsPtr != nullptr; }
 
 public:
     Task* parent = nullptr;

--- a/src/common/include/task_system/task_scheduler.h
+++ b/src/common/include/task_system/task_scheduler.h
@@ -54,7 +54,8 @@ public:
     // Schedules the dependencies of the given task and finally the task one after another (so
     // not concurrently), and throws an exception if any of the tasks errors. Regardless of
     // whether or not the given task or one of its dependencies errors, when this function
-    // returns, no task related to the given task will be in the task queue.
+    // returns, no task related to the given task will be in the task queue. Further no worker
+    // thread will be working on the given task.
     void scheduleTaskAndWaitOrError(const shared_ptr<Task>& task);
 
     // If a user, e.g., currently the loader, adds a set of tasks T1, ..., Tk, to the task scheduler

--- a/src/common/task_system/task.cpp
+++ b/src/common/task_system/task.cpp
@@ -7,7 +7,7 @@ Task::Task(uint64_t maxNumThreads) : maxNumThreads{maxNumThreads} {}
 
 bool Task::registerThread() {
     lock_t lck{mtx};
-    if (!hasException() && canRegisterInternalNoLock()) {
+    if (!hasExceptionNoLock() && canRegisterInternalNoLock()) {
         numThreadsRegistered++;
         return true;
     }
@@ -17,7 +17,7 @@ bool Task::registerThread() {
 void Task::deRegisterThreadAndFinalizeTaskIfNecessary() {
     lock_t lck{mtx};
     ++numThreadsFinished;
-    if (isCompletedNoLock()) {
+    if (!hasExceptionNoLock() && isCompletedNoLock()) {
         finalizeIfNecessary();
     }
 }

--- a/src/common/task_system/task_scheduler.cpp
+++ b/src/common/task_system/task_scheduler.cpp
@@ -2,6 +2,8 @@
 
 #include "src/common/include/configs.h"
 
+// TODO(Semih): Remove
+#include <iostream>
 using namespace graphflow::common;
 
 namespace graphflow {
@@ -61,7 +63,7 @@ void TaskScheduler::scheduleTaskAndWaitOrError(const shared_ptr<Task>& task) {
         scheduleTaskAndWaitOrError(dependency);
     }
     auto scheduledTask = scheduleTask(task);
-    while (!task->isCompletedOrHasException()) {
+    while (!task->isCompleted()) {
         this_thread::sleep_for(chrono::microseconds(THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS));
     }
     if (task->hasException()) {
@@ -138,9 +140,10 @@ void TaskScheduler::runWorkerThread() {
             logger->debug(
                 "Thread {} completed task successfully.", ThreadUtils::getThreadIDString());
         } catch (exception& e) {
-            logger->debug("Thread {} caught an exception. Setting the exception of the task.",
+            logger->info("Thread {} caught an exception. Setting the exception of the task.",
                 ThreadUtils::getThreadIDString());
             scheduledTask->task->setException(current_exception());
+            scheduledTask->task->deRegisterThreadAndFinalizeTaskIfNecessary();
             continue;
         }
     }


### PR DESCRIPTION
We used to remove a task in which at least one worker thread errored from the task queue. This means that by the time the application is notified that there is an exception in the query another worker thread could still be working on a pipeline of this query. This can be a problem when we implement transactions. For example, when we implement transactions, the connection could rollback a transaction but the "continuing worker thread" can still have a handle to this transaction and use it to scan data etc. 
This PR does the safer thing and ensures that no worker thread is working no any task related to the query before the application is notified.