### PR TITLE
Change hash index to use MemoryManager

### DIFF
--- a/src/common/overflow_buffer.cpp
+++ b/src/common/overflow_buffer.cpp
@@ -15,7 +15,7 @@ uint8_t* OverflowBuffer::allocateSpace(uint64_t size) {
 
 void OverflowBuffer::allocateNewBlock() {
     auto newBlock = make_unique<BufferBlock>(
-        memoryManager->allocateBMBackedBlock(false /* do not initialize to zero */));
+        memoryManager->allocateBlock(false /* do not initialize to zero */));
     currentBlock = newBlock.get();
     blocks.push_back(move(newBlock));
 }

--- a/src/function/hash/operations/include/hash_operations.h
+++ b/src/function/hash/operations/include/hash_operations.h
@@ -79,6 +79,11 @@ inline void Hash::operation(const double_t& key, hash_t& result) {
 }
 
 template<>
+inline void Hash::operation(const string& key, hash_t& result) {
+    result = std::hash<string>()(key);
+}
+
+template<>
 inline void Hash::operation(const gf_string_t& key, hash_t& result) {
     result = std::hash<string>()(key.getAsString());
 }

--- a/src/processor/include/physical_plan/result/factorized_table.h
+++ b/src/processor/include/physical_plan/result/factorized_table.h
@@ -26,13 +26,13 @@ struct BlockAppendingInfo {
 struct DataBlock {
 public:
     DataBlock(MemoryManager* memoryManager) : numTuples{0}, memoryManager{memoryManager} {
-        block = memoryManager->allocateBMBackedBlock(true);
+        block = memoryManager->allocateBlock(true);
         freeSize = block->size;
     }
 
     DataBlock(DataBlock&& other) = default;
 
-    ~DataBlock() { memoryManager->freeBMBackedBlock(block->pageIdx); }
+    ~DataBlock() { memoryManager->freeBlock(block->pageIdx); }
 
     uint8_t* getData() const { return block->data; }
 
@@ -42,7 +42,7 @@ public:
     MemoryManager* memoryManager;
 
 private:
-    unique_ptr<BMBackedMemoryBlock> block;
+    unique_ptr<MemoryBlock> block;
 };
 
 class ColumnSchema {

--- a/src/storage/include/file_handle.h
+++ b/src/storage/include/file_handle.h
@@ -31,6 +31,7 @@ public:
     constexpr static uint8_t isLargePagedMask{0b0000'0001}; // represents 1st least sig. bit (LSB)
     constexpr static uint8_t isNewTmpFileMask{0b0000'0010}; // represents 2nd LSB
     constexpr static uint8_t O_DefaultPagedExistingDBFile{0b0000'0000};
+    constexpr static uint8_t O_LargePageExistingDBFile{0b0000'0001};
     constexpr static uint8_t O_LargePagedTempFile{0b0000'0011};
 
     explicit FileHandle(const string& path, uint8_t flags);

--- a/src/storage/include/memory_manager.h
+++ b/src/storage/include/memory_manager.h
@@ -8,18 +8,15 @@
 #include "src/common/include/configs.h"
 #include "src/storage/include/buffer_manager.h"
 
-using namespace std;
 using namespace graphflow::storage;
 
 namespace graphflow {
 namespace storage {
 
-class MemoryManager;
-
-struct BMBackedMemoryBlock {
+struct MemoryBlock {
 
 public:
-    explicit BMBackedMemoryBlock(uint32_t pageIdx, uint8_t* data)
+    explicit MemoryBlock(uint32_t pageIdx, uint8_t* data)
         : size(LARGE_PAGE_SIZE), pageIdx(pageIdx), data(data) {}
 
 public:
@@ -39,9 +36,9 @@ public:
         fh = make_shared<FileHandle>("mm-place-holder-file-name", FileHandle::O_LargePagedTempFile);
     }
 
-    unique_ptr<BMBackedMemoryBlock> allocateBMBackedBlock(bool initializeToZero = false);
+    unique_ptr<MemoryBlock> allocateBlock(bool initializeToZero = false);
 
-    void freeBMBackedBlock(uint32_t pageIdx);
+    void freeBlock(uint32_t pageIdx);
 
 private:
     shared_ptr<FileHandle> fh;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -1,19 +1,14 @@
 #include "src/storage/include/index/hash_index.h"
 
-#include <cstring>
-
-#include "src/function/hash/operations/include/hash_operations.h"
-
 using namespace std;
-using namespace graphflow::function::operation;
 
 namespace graphflow {
 namespace storage {
 
-HashIndexHeader::HashIndexHeader(DataTypeID keyDataType) : keyDataType{keyDataType} {
-    numBytesPerEntry = Types::getDataTypeSize(keyDataType) + sizeof(node_offset_t);
+HashIndexHeader::HashIndexHeader(DataType keyDataType) : keyDataType{move(keyDataType)} {
+    numBytesPerEntry = Types::getDataTypeSize(this->keyDataType) + sizeof(node_offset_t);
     numBytesPerSlot = (numBytesPerEntry * slotCapacity) + sizeof(SlotHeader);
-    numSlotsPerPage = DEFAULT_PAGE_SIZE / numBytesPerSlot;
+    numSlotsPerPage = LARGE_PAGE_SIZE / numBytesPerSlot;
 }
 
 void HashIndexHeader::incrementLevel() {
@@ -22,20 +17,116 @@ void HashIndexHeader::incrementLevel() {
     higherLevelHashMask = (1 << (currentLevel + 1)) - 1;
 }
 
+hash_function_t HashIndex::initializeHashFunc(const DataType& dataType) {
+    switch (dataType.typeID) {
+    case INT64:
+        return hashFuncForInt64;
+    case STRING:
+        return hashFuncForString;
+    default:
+        throw StorageException("Type " + Types::dataTypeToString(dataType) + " not supported.");
+    }
+}
+
+insert_function_t HashIndex::initializeInsertKeyToEntryFunc(const DataType& dataType) {
+    switch (dataType.typeID) {
+    case INT64:
+        return insertInt64KeyToEntryFunc;
+    case STRING:
+        return insertStringKeyToEntryFunc;
+    default:
+        throw StorageException(
+            "Hash index insertion not defined for dataType other than INT64 and STRING.");
+    }
+}
+
+bool HashIndex::isStringPrefixAndLenEquals(
+    const uint8_t* keyToLookup, const gf_string_t* keyInEntry) {
+    if (memcmp(keyToLookup, keyInEntry->prefix, gf_string_t::PREFIX_LENGTH) != 0) {
+        return false;
+    }
+    if (strlen(reinterpret_cast<const char*>(keyToLookup)) != keyInEntry->len) {
+        return false;
+    }
+    return true;
+}
+
+bool HashIndex::equalsFuncInWriteModeForString(const uint8_t* keyToLookup,
+    const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages) {
+    auto gfStringInEntry = (gf_string_t*)keyInEntry;
+    // Checks if prefix and len matches first.
+    if (!isStringPrefixAndLenEquals(keyToLookup, gfStringInEntry)) {
+        return false;
+    }
+    if (gfStringInEntry->len <= gf_string_t::PREFIX_LENGTH) {
+        // For strings shorter than PREFIX_LENGTH, the result must be true.
+        return true;
+    } else if (gfStringInEntry->len <= gf_string_t::SHORT_STR_LENGTH) {
+        // For short strings, whose lengths are larger than PREFIX_LENGTH, check if their actual
+        // values are equal.
+        return memcmp(keyToLookup, gfStringInEntry->prefix, gfStringInEntry->len) == 0;
+    } else {
+        // For long strings, read overflow values and check if they are true.
+        PageByteCursor cursor;
+        TypeUtils::decodeOverflowPtr(gfStringInEntry->overflowPtr, cursor.idx, cursor.offset);
+        return memcmp(keyToLookup, overflowPages->pages[cursor.idx]->data + cursor.offset,
+                   gfStringInEntry->len) == 0;
+    }
+}
+
+equals_in_write_function_t HashIndex::initializeEqualsFuncInWriteMode(const DataType& dataType) {
+    switch (dataType.typeID) {
+    case INT64:
+        return equalsFuncInWriteModeForInt64;
+    case STRING:
+        return equalsFuncInWriteModeForString;
+    default:
+        throw StorageException(
+            "Hash index equals is not supported for dataType other than INT64 and STRING.");
+    }
+}
+
+bool HashIndex::equalsFuncInReadModeForString(
+    const uint8_t* keyToLookup, const uint8_t* keyInEntry, OverflowPages* overflowPages) {
+    auto keyInEntryString = (gf_string_t*)keyInEntry;
+    if (isStringPrefixAndLenEquals(keyToLookup, keyInEntryString)) {
+        auto entryKeyString = overflowPages->readString(*keyInEntryString);
+        return memcmp(keyToLookup, entryKeyString.c_str(), entryKeyString.length()) == 0;
+    }
+    return false;
+}
+
+equals_in_read_function_t HashIndex::initializeEqualsFuncInReadMode(const DataType& dataType) {
+    switch (dataType.typeID) {
+    case INT64:
+        return equalsFuncInReadModeForInt64;
+    case STRING:
+        return equalsFuncInReadModeForString;
+    default:
+        throw StorageException(
+            "Hash index equals is not supported for dataType other than INT64 and STRING.");
+    }
+}
+
 // Opens the hash index in the write-mode that can only do insertions. Lookups in this mode are
 // undefined.
-HashIndex::HashIndex(const string& fName, DataTypeID keyDataType)
-    : fName{fName}, indexHeader{keyDataType}, logger(LoggerUtils::getOrCreateSpdLogger("storage")) {
-    assert(keyDataType == INT64 || keyDataType == STRING);
+HashIndex::HashIndex(const string& fName, DataType keyDataType, MemoryManager* memoryManager)
+    : fName{fName}, indexMode{WRITE_ONLY}, indexHeader{move(keyDataType)}, memoryManager{
+                                                                               memoryManager} {
+    assert(memoryManager != nullptr &&
+           (indexHeader.keyDataType.typeID == INT64 || indexHeader.keyDataType.typeID == STRING));
+    keyHashFunc = initializeHashFunc(indexHeader.keyDataType);
+    insertKeyToEntryFunc = initializeInsertKeyToEntryFunc(indexHeader.keyDataType);
+    equalsFuncInWrite = initializeEqualsFuncInWriteMode(indexHeader.keyDataType);
     // When the Hash index is initialized without the BufferManager, it is opened for only writing.
     // The default for this configuration, has 2 slots and a single primary page.
     primaryPages.reserve(1);
-    primaryPages.emplace_back(getNewPage());
+    primaryPages.emplace_back(memoryManager->allocateBlock(true));
     // We intend ovfPages to start dispensing slots from ovfSlotId 1 because default values of
     // ovfSlotId in slot headers is 0 which we reserve for null.
     ovfPages.reserve(1);
-    ovfPages.emplace_back(getNewPage());
-    if (keyDataType == STRING) {
+    ovfPages.emplace_back(memoryManager->allocateBlock(true));
+    if (indexHeader.keyDataType.typeID == STRING) {
         inMemStringOvfPages =
             make_unique<InMemOverflowPages>(OverflowPages::getOverflowPagesFName(fName));
     }
@@ -43,15 +134,29 @@ HashIndex::HashIndex(const string& fName, DataTypeID keyDataType)
 
 // Opens the hash index in the read-mode that can only be used for the lookups. Insertions in this
 // mode are undefined.
-HashIndex::HashIndex(const string& fName, BufferManager& bufferManager, bool isInMemory)
-    : fName{fName},
-      logger(LoggerUtils::getOrCreateSpdLogger("storage")), bufferManager{&bufferManager} {
-    fileHandle = make_unique<FileHandle>(fName, FileHandle::O_DefaultPagedExistingDBFile);
-    unique_ptr<uint8_t[]> buffer{getNewPage()};
-    fileHandle->readPage(buffer.get(), 0);
-    indexHeader = *((HashIndexHeader*)buffer.get());
-    if (indexHeader.keyDataType == STRING) {
-        stringOvfPages = make_unique<OverflowPages>(fName, bufferManager, isInMemory);
+HashIndex::HashIndex(const string& fName, BufferManager* bufferManager, bool isInMemory)
+    : fName{fName}, indexMode{READ_ONLY}, bufferManager{bufferManager} {
+    assert(bufferManager != nullptr);
+    fileHandle = make_unique<FileHandle>(fName, FileHandle::O_LargePageExistingDBFile);
+    auto buffer = bufferManager->pin(*fileHandle, 0);
+    indexHeader = *((HashIndexHeader*)buffer);
+    bufferManager->unpin(*fileHandle, 0);
+    keyHashFunc = initializeHashFunc(indexHeader.keyDataType);
+    equalsFuncInRead = initializeEqualsFuncInReadMode(indexHeader.keyDataType);
+    if (indexHeader.keyDataType.typeID == STRING) {
+        stringOvfPages = make_unique<OverflowPages>(fName, *bufferManager, isInMemory);
+    }
+}
+
+HashIndex::~HashIndex() {
+    if (indexMode == WRITE_ONLY) {
+        memoryManager->freeBlock(0);
+        for (auto& page : primaryPages) {
+            memoryManager->freeBlock(page->pageIdx);
+        }
+        for (auto& page : ovfPages) {
+            memoryManager->freeBlock(page->pageIdx);
+        }
     }
 }
 
@@ -81,7 +186,7 @@ void HashIndex::bulkReserve(uint32_t numEntries) {
     // pre-allocate all pages.
     // first page has already been allocated and page 0 is reserved.
     for (auto i = 1; i < indexHeader.numPrimaryPages; i++) {
-        primaryPages.emplace_back(getNewPage());
+        primaryPages.emplace_back(memoryManager->allocateBlock(true));
     }
 }
 
@@ -89,7 +194,7 @@ void HashIndex::bulkReserve(uint32_t numEntries) {
 // For now, we don't support re-write of key. Existing key will not be inserted.
 // Return: true, insertion succeeds. false, insertion failed due to that the key already exists.
 bool HashIndex::insert(uint8_t* key, uint64_t value) {
-    auto slot = getSlotFromPrimaryPages(calculateSlotIdForHash(hashFunc(key)));
+    auto slot = getSlotFromPrimaryPages(calculateSlotIdForHash(keyHashFunc(key)));
     if (!notExistsInSlot(slot, key)) {
         return false;
     }
@@ -112,59 +217,18 @@ bool HashIndex::insert(uint8_t* key, uint64_t value) {
 void HashIndex::putNewEntryInSlotAndUpdateHeader(uint8_t* slot, uint8_t* key, node_offset_t value) {
     auto slotHeader = reinterpret_cast<SlotHeader*>(slot);
     auto entry = getEntryInSlot(slot, slotHeader->numEntries);
-    insertKey(key, entry);
+    insertKeyToEntryFunc(key, entry, inMemStringOvfPages.get(), &stringOvfPageCursor);
     entry += Types::getDataTypeSize(indexHeader.keyDataType);
     memcpy(entry, &value, sizeof(node_offset_t));
     indexHeader.numEntries += 1;
     slotHeader->numEntries++;
 }
 
-void HashIndex::insertKey(uint8_t* key, uint8_t* entry) {
-    switch (indexHeader.keyDataType) {
-    case INT64:
-        memcpy(entry, key, Types::getDataTypeSize(indexHeader.keyDataType));
-        break;
-    case STRING: {
-        auto gfString =
-            inMemStringOvfPages->addString(reinterpret_cast<const char*>(key), stringOvfPageCursor);
-        memcpy(entry, &gfString, Types::getDataTypeSize(indexHeader.keyDataType));
-        break;
-    }
-    default:
-        throw StorageException(
-            "Hash index insertion not defined for dataType other than INT64 and STRING");
-    }
-}
-
 bool HashIndex::notExistsInSlot(uint8_t* slot, uint8_t* key) {
     auto slotHeader = reinterpret_cast<SlotHeader*>(slot);
     for (auto entryPos = 0u; entryPos < slotHeader->numEntries; entryPos++) {
         auto keyInEntry = getEntryInSlot(slot, entryPos);
-        bool foundKey = false;
-        switch (indexHeader.keyDataType) {
-        case INT64:
-            foundKey = equalsInt64(key, keyInEntry);
-            break;
-        case STRING: {
-            auto keyInEntryString = (gf_string_t*)keyInEntry;
-            if (likelyEqualsString(key, keyInEntryString)) {
-                if (keyInEntryString->len <= gf_string_t::SHORT_STR_LENGTH) {
-                    foundKey = memcmp(key, keyInEntryString->prefix, keyInEntryString->len) == 0;
-                } else {
-                    PageByteCursor cursor;
-                    TypeUtils::decodeOverflowPtr(
-                        keyInEntryString->overflowPtr, cursor.idx, cursor.offset);
-                    foundKey =
-                        memcmp(key, inMemStringOvfPages->pages[cursor.idx]->data + cursor.offset,
-                            keyInEntryString->len) == 0;
-                }
-            }
-            break;
-        }
-        default:
-            throw StorageException(
-                "Hash index equals is not supported for dataType other than INT64 and STRING.");
-        }
+        bool foundKey = equalsFuncInWrite(key, keyInEntry, inMemStringOvfPages.get());
         if (foundKey) {
             return false;
         }
@@ -174,27 +238,26 @@ bool HashIndex::notExistsInSlot(uint8_t* slot, uint8_t* key) {
 
 void HashIndex::saveToDisk() {
     auto fileInfo = FileUtils::openFile(fName, O_WRONLY | O_CREAT);
-    unique_ptr<uint8_t[]> buffer(getNewPage());
-    memcpy(buffer.get(), &indexHeader, sizeof(indexHeader));
     auto writeOffset = 0u;
-    FileUtils::writeToFile(fileInfo.get(), buffer.get(), DEFAULT_PAGE_SIZE, writeOffset);
-    writeOffset += DEFAULT_PAGE_SIZE;
+    FileUtils::writeToFile(
+        fileInfo.get(), (uint8_t*)&indexHeader, sizeof(indexHeader), writeOffset);
+    writeOffset += LARGE_PAGE_SIZE;
     for (auto& primaryPage : primaryPages) {
-        FileUtils::writeToFile(fileInfo.get(), primaryPage.get(), DEFAULT_PAGE_SIZE, writeOffset);
-        writeOffset += DEFAULT_PAGE_SIZE;
+        FileUtils::writeToFile(fileInfo.get(), primaryPage->data, LARGE_PAGE_SIZE, writeOffset);
+        writeOffset += LARGE_PAGE_SIZE;
     }
     for (auto& ovfPage : ovfPages) {
-        FileUtils::writeToFile(fileInfo.get(), ovfPage.get(), DEFAULT_PAGE_SIZE, writeOffset);
-        writeOffset += DEFAULT_PAGE_SIZE;
+        FileUtils::writeToFile(fileInfo.get(), ovfPage->data, LARGE_PAGE_SIZE, writeOffset);
+        writeOffset += LARGE_PAGE_SIZE;
     }
     FileUtils::closeFile(fileInfo->fd);
-    if (indexHeader.keyDataType == STRING) {
+    if (indexHeader.keyDataType.typeID == STRING) {
         inMemStringOvfPages->saveToFile();
     }
 }
 
 bool HashIndex::lookup(uint8_t* key, node_offset_t& result) {
-    auto slotId = calculateSlotIdForHash(hashFunc(key));
+    auto slotId = calculateSlotIdForHash(keyHashFunc(key));
     auto pageId = getPageIdForSlot(slotId);
     auto slotIdInPage = getSlotIdInPageForSlot(slotId);
     auto physicalPageId = pageId + 1;
@@ -228,23 +291,7 @@ bool HashIndex::lookupInSlot(const uint8_t* slot, uint8_t* key, node_offset_t& r
     auto slotHeader = reinterpret_cast<SlotHeader*>(const_cast<uint8_t*>(slot));
     for (auto entryPos = 0u; entryPos < slotHeader->numEntries; entryPos++) {
         auto keyInEntry = getEntryInSlot(const_cast<uint8_t*>(slot), entryPos);
-        bool foundKey = false;
-        switch (indexHeader.keyDataType) {
-        case INT64:
-            foundKey = equalsInt64(key, keyInEntry);
-            break;
-        case STRING: {
-            auto keyInEntryString = (gf_string_t*)keyInEntry;
-            if (likelyEqualsString(key, keyInEntryString)) {
-                auto entryKeyString = stringOvfPages->readString(*keyInEntryString);
-                foundKey = entryKeyString == string(reinterpret_cast<const char*>(key));
-            }
-            break;
-        }
-        default:
-            throw StorageException(
-                "Hash index equals is not supported for dataType other than INT64 and STRING.");
-        }
+        bool foundKey = equalsFuncInRead(key, keyInEntry, stringOvfPages.get());
         if (foundKey) {
             result =
                 *(node_offset_t*)(keyInEntry + Types::getDataTypeSize(indexHeader.keyDataType));
@@ -263,56 +310,20 @@ uint64_t HashIndex::calculateSlotIdForHash(hash_t hash) const {
 
 uint8_t* HashIndex::getSlotFromPrimaryPages(uint64_t slotId) const {
     return const_cast<uint8_t*>(getSlotInAPage(
-        primaryPages[getPageIdForSlot(slotId)].get(), getSlotIdInPageForSlot(slotId)));
+        primaryPages[getPageIdForSlot(slotId)]->data, getSlotIdInPageForSlot(slotId)));
 }
 
 uint8_t* HashIndex::getOvfSlotFromOvfPages(uint64_t slotId) const {
     return const_cast<uint8_t*>(
-        getSlotInAPage(ovfPages[getPageIdForSlot(slotId)].get(), getSlotIdInPageForSlot(slotId)));
+        getSlotInAPage(ovfPages[getPageIdForSlot(slotId)]->data, getSlotIdInPageForSlot(slotId)));
 }
 
 uint64_t HashIndex::reserveOvfSlot() {
     if (indexHeader.numOvfSlots % indexHeader.numSlotsPerPage == 0) {
-        ovfPages.emplace_back(getNewPage());
+        ovfPages.emplace_back(memoryManager->allocateBlock(true));
         indexHeader.numOvfPages++;
     }
     return indexHeader.numOvfSlots++;
-}
-
-uint8_t* HashIndex::getNewPage() {
-    auto newPage = new uint8_t[DEFAULT_PAGE_SIZE];
-    memset(newPage, 0, DEFAULT_PAGE_SIZE);
-    return newPage;
-}
-
-hash_t HashIndex::hashFunc(uint8_t* key) {
-    hash_t hash;
-    switch (indexHeader.keyDataType) {
-    case INT64:
-        Hash::operation(*(int64_t*)(key), false /*isNULL*/, hash);
-        break;
-    case STRING:
-        hash = std::hash<string>{}(reinterpret_cast<const char*>(key));
-        break;
-    default:
-        throw StorageException(
-            "Type " + Types::dataTypeToString(indexHeader.keyDataType) + " not supported.");
-    }
-    return hash;
-}
-
-bool HashIndex::equalsInt64(uint8_t* key, uint8_t* entryKey) {
-    return memcmp(key, entryKey, sizeof(int64_t)) == 0;
-}
-
-bool HashIndex::likelyEqualsString(uint8_t* key, gf_string_t* entryKey) {
-    if (memcmp(key, entryKey->prefix, gf_string_t::PREFIX_LENGTH) != 0) {
-        return false;
-    }
-    if (strlen(reinterpret_cast<const char*>(key)) != entryKey->len) {
-        return false;
-    }
-    return true;
 }
 
 } // namespace storage

--- a/src/storage/memory_manager.cpp
+++ b/src/storage/memory_manager.cpp
@@ -5,7 +5,7 @@
 namespace graphflow {
 namespace storage {
 
-unique_ptr<BMBackedMemoryBlock> MemoryManager::allocateBMBackedBlock(bool initializeToZero) {
+unique_ptr<MemoryBlock> MemoryManager::allocateBlock(bool initializeToZero) {
     lock_guard<mutex> lock(memMgrLock);
     uint32_t pageIdx;
     uint8_t* data;
@@ -17,7 +17,7 @@ unique_ptr<BMBackedMemoryBlock> MemoryManager::allocateBMBackedBlock(bool initia
     }
     data = bm->pinWithoutReadingFromFile(*fh, pageIdx);
 
-    auto blockHandle = make_unique<BMBackedMemoryBlock>(pageIdx, data);
+    auto blockHandle = make_unique<MemoryBlock>(pageIdx, data);
     if (initializeToZero) {
         memset(blockHandle->data, 0, LARGE_PAGE_SIZE);
     }
@@ -25,7 +25,7 @@ unique_ptr<BMBackedMemoryBlock> MemoryManager::allocateBMBackedBlock(bool initia
     return blockHandle;
 }
 
-void MemoryManager::freeBMBackedBlock(uint32_t pageIdx) {
+void MemoryManager::freeBlock(uint32_t pageIdx) {
     lock_guard<mutex> lock(memMgrLock);
     bm->unpin(*fh, pageIdx);
     freePages.push(pageIdx);


### PR DESCRIPTION
This PR makes two small changes:
1. HashIndex will use `MemoryManager` to allocate pages for non-string-overflow data, also, the hash index will use large sized pages now.
2. Remove runtime switch cases for some functions, i.e., computing hashes for key, copying key values to entry, comparing keys. And make them as functors, which are bound when the HashIndex is constructed as the data type of key is always fixed.