### PR TITLE
Execution context rework

### DIFF
--- a/src/common/include/profiler.h
+++ b/src/common/include/profiler.h
@@ -19,12 +19,11 @@ public:
 
     uint64_t sumAllNumericMetricsWithKey(const string& key);
 
-    void resetMetrics();
-
 private:
     void addMetric(const string& key, unique_ptr<Metric> metric);
 
 public:
+    mutex mtx;
     bool enabled;
     unordered_map<string, vector<unique_ptr<Metric>>> metrics;
 };

--- a/src/common/profiler.cpp
+++ b/src/common/profiler.cpp
@@ -37,11 +37,8 @@ uint64_t Profiler::sumAllNumericMetricsWithKey(const string& key) {
     return sum;
 }
 
-void Profiler::resetMetrics() {
-    metrics.clear();
-}
-
 void Profiler::addMetric(const string& key, unique_ptr<Metric> metric) {
+    lock_guard<mutex> lck(mtx);
     if (!metrics.contains(key)) {
         metrics.insert({key, vector<unique_ptr<Metric>>()});
     }

--- a/src/main/include/prepared_statement.h
+++ b/src/main/include/prepared_statement.h
@@ -11,10 +11,7 @@ class PreparedStatement {
     friend class Connection;
 
 public:
-    PreparedStatement() {
-        querySummary = make_unique<QuerySummary>();
-        profiler = make_unique<Profiler>();
-    }
+    PreparedStatement() { querySummary = make_unique<QuerySummary>(); }
     ~PreparedStatement() = default;
 
     inline bool isSuccess() const { return success; }
@@ -24,7 +21,7 @@ public:
         resultHeader = make_unique<QueryResultHeader>(move(resultDataTypes));
     }
 
-    inline void createPlanPrinter() {
+    inline void createPlanPrinter(unique_ptr<Profiler> profiler) {
         querySummary->planPrinter = make_unique<PlanPrinter>(
             move(physicalPlan), move(physicalIDToLogicalOperatorMap), move(profiler));
     }
@@ -36,15 +33,11 @@ private:
     string errMsg;
 
     unique_ptr<QuerySummary> querySummary;
-    unique_ptr<Profiler> profiler;
     unordered_map<string, shared_ptr<Literal>> parameterMap;
     unique_ptr<QueryResultHeader> resultHeader;
     // TODO(Xiyang): Open an issue to remove this stupid map by copying whatever information needed
     // for plan printing.
     unordered_map<uint32_t, shared_ptr<LogicalOperator>> physicalIDToLogicalOperatorMap;
-    // TODO(Xiyang): Open an issue about the life cycle of executionContext and profiler, maybe
-    // using shared pointer is a more reasonable choice.
-    unique_ptr<ExecutionContext> executionContext;
     unique_ptr<PhysicalPlan> physicalPlan;
 };
 

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -43,6 +43,7 @@ cc_library(
     ],
     deps = [
         "//src/common:profiler",
+        "//src/transaction",
     ],
 )
 

--- a/src/processor/include/execution_context.h
+++ b/src/processor/include/execution_context.h
@@ -3,21 +3,25 @@
 #include "src/common/include/profiler.h"
 #include "src/storage/include/buffer_manager.h"
 #include "src/storage/include/memory_manager.h"
+#include "src/transaction/include/transaction.h"
 
 using namespace graphflow::common;
 using namespace graphflow::storage;
+using namespace graphflow::transaction;
 
 namespace graphflow {
 namespace processor {
 
 struct ExecutionContext {
 
-public:
-    ExecutionContext(Profiler& profiler, MemoryManager* memoryManager, BufferManager* bufferManager)
-        : profiler{profiler}, memoryManager{memoryManager}, bufferManager{bufferManager} {}
+    ExecutionContext(uint64_t numThreads, Profiler* profiler, Transaction* transaction,
+        MemoryManager* memoryManager, BufferManager* bufferManager)
+        : numThreads{numThreads}, profiler{profiler}, transaction{transaction},
+          memoryManager{memoryManager}, bufferManager{bufferManager} {}
 
-public:
-    Profiler& profiler;
+    uint64_t numThreads;
+    Profiler* profiler;
+    Transaction* transaction;
     MemoryManager* memoryManager;
     BufferManager* bufferManager;
 };

--- a/src/processor/include/physical_plan/mapper/expression_mapper.h
+++ b/src/processor/include/physical_plan/mapper/expression_mapper.h
@@ -18,8 +18,8 @@ class PlanMapper;
 class ExpressionMapper {
 
 public:
-    unique_ptr<BaseExpressionEvaluator> mapExpression(const shared_ptr<Expression>& expression,
-        const MapperContext& mapperContext, ExecutionContext& executionContext);
+    unique_ptr<BaseExpressionEvaluator> mapExpression(
+        const shared_ptr<Expression>& expression, const MapperContext& mapperContext);
 
 private:
     unique_ptr<BaseExpressionEvaluator> mapLiteralExpression(
@@ -32,8 +32,7 @@ private:
         const shared_ptr<Expression>& expression, const MapperContext& mapperContext);
 
     unique_ptr<BaseExpressionEvaluator> mapFunctionExpression(
-        const shared_ptr<Expression>& expression, const MapperContext& mapperContext,
-        ExecutionContext& executionContext);
+        const shared_ptr<Expression>& expression, const MapperContext& mapperContext);
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -21,8 +21,7 @@ public:
         : catalog{catalog}, storageManager{storageManager}, outerMapperContext{nullptr},
           expressionMapper{} {}
 
-    unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(
-        unique_ptr<LogicalPlan> logicalPlan, ExecutionContext& executionContext);
+    unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(unique_ptr<LogicalPlan> logicalPlan);
 
 private:
     // Returns current physicalOperatorsInfo whoever calls enterSubquery is responsible to save the
@@ -31,54 +30,48 @@ private:
     void exitSubquery(const MapperContext* prevMapperContext);
 
     unique_ptr<PhysicalOperator> mapLogicalOperatorToPhysical(
-        const shared_ptr<LogicalOperator>& logicalOperator, MapperContext& mapperContext,
-        ExecutionContext& executionContext);
+        const shared_ptr<LogicalOperator>& logicalOperator, MapperContext& mapperContext);
 
-    unique_ptr<PhysicalOperator> mapLogicalScanNodeIDToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalResultScanToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext) const;
-    unique_ptr<PhysicalOperator> mapLogicalExtendToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalFlattenToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalFilterToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalIntersectToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalProjectionToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
+    unique_ptr<PhysicalOperator> mapLogicalScanNodeIDToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalResultScanToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalExtendToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalFlattenToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalFilterToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalIntersectToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalProjectionToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
     unique_ptr<PhysicalOperator> mapLogicalScanNodePropertyToPhysical(
-        LogicalOperator* logicalOperator, MapperContext& mapperContext,
-        ExecutionContext& executionContext);
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
     unique_ptr<PhysicalOperator> mapLogicalScanRelPropertyToPhysical(
-        LogicalOperator* logicalOperator, MapperContext& mapperContext,
-        ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalHashJoinToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalHashJoinToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
     unique_ptr<PhysicalOperator> mapLogicalMultiplicityReducerToPhysical(
-        LogicalOperator* logicalOperator, MapperContext& mapperContext,
-        ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalSkipToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalLimitToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalAggregateToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalDistinctToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalExistsToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalSkipToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalLimitToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalAggregateToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalDistinctToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalExistsToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
     unique_ptr<PhysicalOperator> mapLogicalLeftNestedLoopJoinToPhysical(
-        LogicalOperator* logicalOperator, MapperContext& mapperContext,
-        ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalOrderByToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
-    unique_ptr<PhysicalOperator> mapLogicalUnionAllToPhysical(LogicalOperator* logicalOperator,
-        MapperContext& mapperContext, ExecutionContext& executionContext);
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalOrderByToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
+    unique_ptr<PhysicalOperator> mapLogicalUnionAllToPhysical(
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
     unique_ptr<ResultCollector> mapLogicalResultCollectorToPhysical(
-        LogicalOperator* logicalOperator, MapperContext& mapperContext,
-        ExecutionContext& executionContext);
+        LogicalOperator* logicalOperator, MapperContext& mapperContext);
 
 public:
     const catalog::Catalog& catalog;

--- a/src/processor/include/physical_plan/operator/aggregate/base_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/base_aggregate.h
@@ -32,17 +32,15 @@ public:
 protected:
     BaseAggregate(vector<DataPos> aggregateVectorsPos,
         vector<unique_ptr<AggregateFunction>> aggregateFunctions,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : Sink{move(child), context, id}, aggregateVectorsPos{move(aggregateVectorsPos)},
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : Sink{move(child), id}, aggregateVectorsPos{move(aggregateVectorsPos)},
           aggregateFunctions{move(aggregateFunctions)} {}
 
     PhysicalOperatorType getOperatorType() override { return AGGREGATE; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
-    void execute() override { Sink::execute(); }
-
-    void finalize() override = 0;
+    void finalize(ExecutionContext* context) override = 0;
 
     unique_ptr<PhysicalOperator> clone() override = 0;
 

--- a/src/processor/include/physical_plan/operator/aggregate/base_aggregate_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/base_aggregate_scan.h
@@ -14,19 +14,18 @@ class BaseAggregateScan : public PhysicalOperator, public SourceOperator {
 public:
     BaseAggregateScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
         vector<DataPos> aggregatesPos, vector<DataType> aggregateDataTypes,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, SourceOperator{move(resultSetDescriptor)},
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator{move(child), id}, SourceOperator{move(resultSetDescriptor)},
           aggregatesPos{move(aggregatesPos)}, aggregateDataTypes{move(aggregateDataTypes)} {}
 
     BaseAggregateScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        vector<DataPos> aggregatesPos, vector<DataType> aggregateDataTypes,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
+        vector<DataPos> aggregatesPos, vector<DataType> aggregateDataTypes, uint32_t id)
+        : PhysicalOperator{id}, SourceOperator{move(resultSetDescriptor)},
           aggregatesPos{move(aggregatesPos)}, aggregateDataTypes{move(aggregateDataTypes)} {}
 
     PhysicalOperatorType getOperatorType() override { return AGGREGATE_SCAN; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override = 0;
 

--- a/src/processor/include/physical_plan/operator/aggregate/hash_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/hash_aggregate.h
@@ -37,13 +37,17 @@ public:
         vector<DataPos> inputGroupByHashKeyVectorsPos,
         vector<DataPos> inputGroupByNonHashKeyVectorsPos, vector<DataPos> aggregateVectorsPos,
         vector<unique_ptr<AggregateFunction>> aggregateFunctions,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : BaseAggregate{move(aggregateVectorsPos), move(aggregateFunctions), move(child), id},
+          groupByHashKeyVectorsPos{move(inputGroupByHashKeyVectorsPos)},
+          groupByNonHashKeyVectorsPos{move(inputGroupByNonHashKeyVectorsPos)}, sharedState{move(
+                                                                                   sharedState)} {}
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
-    void execute() override;
+    void execute(ExecutionContext* context) override;
 
-    void finalize() override;
+    void finalize(ExecutionContext* context) override;
 
     unique_ptr<PhysicalOperator> clone() override;
 

--- a/src/processor/include/physical_plan/operator/aggregate/hash_aggregate_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/hash_aggregate_scan.h
@@ -12,10 +12,9 @@ public:
     HashAggregateScan(shared_ptr<HashAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> groupByKeyVectorsPos,
         vector<DataType> groupByKeyVectorDataTypes, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregateDataTypes, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id)
+        vector<DataType> aggregateDataTypes, unique_ptr<PhysicalOperator> child, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregateDataTypes), move(child), context, id},
+              move(aggregateDataTypes), move(child), id},
           groupByKeyVectorsPos{move(groupByKeyVectorsPos)},
           groupByKeyVectorDataTypes{move(groupByKeyVectorDataTypes)}, sharedState{
                                                                           move(sharedState)} {}
@@ -23,21 +22,20 @@ public:
     HashAggregateScan(shared_ptr<HashAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> groupByKeyVectorsPos,
         vector<DataType> groupByKeyVectorDataTypes, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregateDataTypes, ExecutionContext& context, uint32_t id)
+        vector<DataType> aggregateDataTypes, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregateDataTypes), context, id},
+              move(aggregateDataTypes), id},
           groupByKeyVectorsPos{move(groupByKeyVectorsPos)},
           groupByKeyVectorDataTypes{move(groupByKeyVectorDataTypes)}, sharedState{
                                                                           move(sharedState)} {}
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<HashAggregateScan>(sharedState, resultSetDescriptor->copy(),
-            groupByKeyVectorsPos, groupByKeyVectorDataTypes, aggregatesPos, aggregateDataTypes,
-            context, id);
+            groupByKeyVectorsPos, groupByKeyVectorDataTypes, aggregatesPos, aggregateDataTypes, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregate.h
@@ -32,11 +32,15 @@ public:
     SimpleAggregate(shared_ptr<SimpleAggregateSharedState> sharedState,
         vector<DataPos> aggregateVectorsPos,
         vector<unique_ptr<AggregateFunction>> aggregateFunctions,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
+        unique_ptr<PhysicalOperator> child, uint32_t id);
 
-    void execute() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
-    void finalize() override;
+    void execute(ExecutionContext* context) override;
+
+    inline void finalize(ExecutionContext* context) override {
+        sharedState->finalizeAggregateStates();
+    }
 
     unique_ptr<PhysicalOperator> clone() override;
 

--- a/src/processor/include/physical_plan/operator/aggregate/simple_aggregate_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/simple_aggregate_scan.h
@@ -11,26 +11,25 @@ class SimpleAggregateScan : public BaseAggregateScan {
 public:
     SimpleAggregateScan(shared_ptr<SimpleAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregateDataTypes, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id)
+        vector<DataType> aggregateDataTypes, unique_ptr<PhysicalOperator> child, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregateDataTypes), move(child), context, id},
+              move(aggregateDataTypes), move(child), id},
           sharedState{move(sharedState)} {}
 
     // This constructor is used for cloning only.
     SimpleAggregateScan(shared_ptr<SimpleAggregateSharedState> sharedState,
         unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> aggregatesPos,
-        vector<DataType> aggregateDataTypes, ExecutionContext& context, uint32_t id)
+        vector<DataType> aggregateDataTypes, uint32_t id)
         : BaseAggregateScan{move(resultSetDescriptor), move(aggregatesPos),
-              move(aggregateDataTypes), context, id},
+              move(aggregateDataTypes), id},
           sharedState{move(sharedState)} {}
 
     bool getNextTuples() override;
 
     // SimpleAggregateScan is the source operator of a pipeline, so it should not clone its child.
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<SimpleAggregateScan>(sharedState, resultSetDescriptor->copy(),
-            aggregatesPos, aggregateDataTypes, context, id);
+        return make_unique<SimpleAggregateScan>(
+            sharedState, resultSetDescriptor->copy(), aggregatesPos, aggregateDataTypes, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/exists.h
+++ b/src/processor/include/physical_plan/operator/exists.h
@@ -10,21 +10,19 @@ class Exists : public PhysicalOperator {
 
 public:
     Exists(const DataPos& outDataPos, unique_ptr<PhysicalOperator> child,
-        unique_ptr<PhysicalOperator> subPlanLastOperator, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), move(subPlanLastOperator), context, id}, outDataPos{
-                                                                                     outDataPos} {}
+        unique_ptr<PhysicalOperator> subPlanLastOperator, uint32_t id)
+        : PhysicalOperator{move(child), move(subPlanLastOperator), id}, outDataPos{outDataPos} {}
 
     PhysicalOperatorType getOperatorType() override { return EXISTS; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Exists>(
-            outDataPos, children[0]->clone(), children[1]->clone(), context, id);
+        return make_unique<Exists>(outDataPos, children[0]->clone(), children[1]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/filter.h
+++ b/src/processor/include/physical_plan/operator/filter.h
@@ -13,14 +13,14 @@ class Filter : public PhysicalOperator, public FilteringOperator {
 
 public:
     Filter(unique_ptr<BaseExpressionEvaluator> expressionEvaluator, uint32_t dataChunkToSelectPos,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, FilteringOperator{},
-          expressionEvaluator{move(expressionEvaluator)},
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator{move(child), id}, FilteringOperator{}, expressionEvaluator{move(
+                                                                      expressionEvaluator)},
           dataChunkToSelectPos(dataChunkToSelectPos) {}
 
     PhysicalOperatorType getOperatorType() override { return FILTER; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 
@@ -28,7 +28,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<Filter>(
-            expressionEvaluator->clone(), dataChunkToSelectPos, children[0]->clone(), context, id);
+            expressionEvaluator->clone(), dataChunkToSelectPos, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/flatten.h
+++ b/src/processor/include/physical_plan/operator/flatten.h
@@ -8,21 +8,19 @@ namespace processor {
 class Flatten : public PhysicalOperator {
 
 public:
-    Flatten(uint32_t dataChunkToFlattenPos, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, dataChunkToFlattenPos{dataChunkToFlattenPos} {
-    }
+    Flatten(uint32_t dataChunkToFlattenPos, unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator{move(child), id}, dataChunkToFlattenPos{dataChunkToFlattenPos} {}
 
     PhysicalOperatorType getOperatorType() override { return FLATTEN; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Flatten>(dataChunkToFlattenPos, children[0]->clone(), context, id);
+        return make_unique<Flatten>(dataChunkToFlattenPos, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -63,17 +63,18 @@ public:
 class HashJoinBuild : public Sink {
 public:
     HashJoinBuild(shared_ptr<HashJoinSharedState> sharedState, const BuildDataInfo& buildDataInfo,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : Sink{move(child), id}, sharedState{move(sharedState)}, buildDataInfo{buildDataInfo} {}
 
     PhysicalOperatorType getOperatorType() override { return HASH_JOIN_BUILD; }
 
-    shared_ptr<ResultSet> initResultSet() override;
-    void execute() override;
-    void finalize() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
+
+    void execute(ExecutionContext* context) override;
+    void finalize(ExecutionContext* context) override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<HashJoinBuild>(
-            sharedState, buildDataInfo, children[0]->clone(), context, id);
+        return make_unique<HashJoinBuild>(sharedState, buildDataInfo, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/intersect.h
+++ b/src/processor/include/physical_plan/operator/intersect.h
@@ -10,20 +10,20 @@ class Intersect : public PhysicalOperator, public FilteringOperator {
 
 public:
     Intersect(const DataPos& leftDataPos, const DataPos& rightDataPos,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, FilteringOperator{}, leftDataPos{leftDataPos},
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator{move(child), id}, FilteringOperator{}, leftDataPos{leftDataPos},
           rightDataPos{rightDataPos}, leftIdx{0} {}
 
     PhysicalOperatorType getOperatorType() override { return INTERSECT; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<Intersect>(leftDataPos, rightDataPos, children[0]->clone(), context, id);
+        return make_unique<Intersect>(leftDataPos, rightDataPos, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/left_nested_loop_join.h
+++ b/src/processor/include/physical_plan/operator/left_nested_loop_join.h
@@ -11,14 +11,14 @@ class LeftNestedLoopJoin : public PhysicalOperator {
 public:
     LeftNestedLoopJoin(vector<pair<DataPos, DataPos>> subPlanVectorsToRefPosMapping,
         unique_ptr<PhysicalOperator> child, unique_ptr<PhysicalOperator> subPlanLastOperator,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), move(subPlanLastOperator), context, id},
+        uint32_t id)
+        : PhysicalOperator{move(child), move(subPlanLastOperator), id},
           subPlanVectorsToRefPosMapping{move(subPlanVectorsToRefPosMapping)}, isFirstExecution{
                                                                                   true} {}
 
     PhysicalOperatorType getOperatorType() override { return LEFT_NESTED_LOOP_JOIN; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 
@@ -28,7 +28,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<LeftNestedLoopJoin>(
-            subPlanVectorsToRefPosMapping, children[0]->clone(), children[1]->clone(), context, id);
+            subPlanVectorsToRefPosMapping, children[0]->clone(), children[1]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/limit.h
+++ b/src/processor/include/physical_plan/operator/limit.h
@@ -10,20 +10,18 @@ class Limit : public PhysicalOperator {
 public:
     Limit(uint64_t limitNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
         unordered_set<uint32_t> dataChunksPosInScope, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, limitNumber{limitNumber},
-          counter{move(counter)}, dataChunkToSelectPos{dataChunkToSelectPos},
+        uint32_t id)
+        : PhysicalOperator{move(child), id}, limitNumber{limitNumber}, counter{move(counter)},
+          dataChunkToSelectPos{dataChunkToSelectPos},
           dataChunksPosInScope(move(dataChunksPosInScope)) {}
 
     PhysicalOperatorType getOperatorType() override { return LIMIT; }
-
-    shared_ptr<ResultSet> initResultSet() override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<Limit>(limitNumber, counter, dataChunkToSelectPos, dataChunksPosInScope,
-            children[0]->clone(), context, id);
+            children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/multiplicity_reducer.h
+++ b/src/processor/include/physical_plan/operator/multiplicity_reducer.h
@@ -8,19 +8,17 @@ namespace processor {
 class MultiplicityReducer : public PhysicalOperator {
 
 public:
-    MultiplicityReducer(unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, prevMultiplicity{1}, numRepeat{0} {}
+    MultiplicityReducer(unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator{move(child), id}, prevMultiplicity{1}, numRepeat{0} {}
 
     PhysicalOperatorType getOperatorType() override { return MULTIPLICITY_REDUCER; }
-
-    shared_ptr<ResultSet> initResultSet() override;
 
     void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<MultiplicityReducer>(children[0]->clone(), context, id);
+        return make_unique<MultiplicityReducer>(children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/order_by/order_by.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by.h
@@ -100,18 +100,17 @@ class OrderBy : public Sink {
 public:
     OrderBy(const OrderByDataInfo& orderByDataInfo,
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : Sink{move(child), context, id}, orderByDataInfo{orderByDataInfo}, sharedState{
-                                                                                sharedState} {}
-
-    shared_ptr<ResultSet> initResultSet() override;
-    void execute() override;
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : Sink{move(child), id}, orderByDataInfo{orderByDataInfo}, sharedState{move(sharedState)} {}
 
     PhysicalOperatorType getOperatorType() override { return ORDER_BY; }
 
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
+
+    void execute(ExecutionContext* context) override;
+
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<OrderBy>(
-            orderByDataInfo, sharedState, children[0]->clone(), context, id);
+        return make_unique<OrderBy>(orderByDataInfo, sharedState, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/order_by/order_by_merge.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_merge.h
@@ -18,28 +18,28 @@ public:
     // This constructor will only be called by the mapper when constructing the orderByMerge
     // operator, because the mapper doesn't know the existence of keyBlockMergeTaskDispatcher
     OrderByMerge(shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : Sink{move(child), context, id}, SourceOperator{nullptr},
-          sharedFactorizedTablesAndSortedKeyBlocks{sharedState},
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : Sink{move(child), id}, SourceOperator{nullptr},
+          sharedFactorizedTablesAndSortedKeyBlocks{move(sharedState)},
           keyBlockMergeTaskDispatcher{make_shared<KeyBlockMergeTaskDispatcher>()} {}
 
     // This constructor is used for cloning only.
     OrderByMerge(shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState,
         shared_ptr<KeyBlockMergeTaskDispatcher> keyBlockMergeTaskDispatcher,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : Sink{move(child), context, id}, SourceOperator{nullptr},
-          sharedFactorizedTablesAndSortedKeyBlocks{sharedState}, keyBlockMergeTaskDispatcher{
-                                                                     keyBlockMergeTaskDispatcher} {}
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : Sink{move(child), id}, SourceOperator{nullptr},
+          sharedFactorizedTablesAndSortedKeyBlocks{move(sharedState)},
+          keyBlockMergeTaskDispatcher{move(keyBlockMergeTaskDispatcher)} {}
 
     PhysicalOperatorType getOperatorType() override { return ORDER_BY_MERGE; }
 
-    shared_ptr<ResultSet> initResultSet() override;
-    void execute() override;
-    void finalize() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
+
+    void execute(ExecutionContext* context) override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<OrderByMerge>(sharedFactorizedTablesAndSortedKeyBlocks,
-            keyBlockMergeTaskDispatcher, children[0]->clone(), context, id);
+            keyBlockMergeTaskDispatcher, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
@@ -15,27 +15,27 @@ public:
     OrderByScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
         const vector<DataPos>& outDataPoses,
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, SourceOperator{move(resultSetDescriptor)},
-          outDataPoses{outDataPoses}, sharedState{sharedState}, nextTupleIdxToReadInMemBlock{0} {}
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator{move(child), id}, SourceOperator{move(resultSetDescriptor)},
+          outDataPoses{outDataPoses}, sharedState{move(sharedState)}, nextTupleIdxToReadInMemBlock{
+                                                                          0} {}
 
     // This constructor is used for cloning only.
     OrderByScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
         const vector<DataPos>& outDataPoses,
-        shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState, ExecutionContext& context,
-        uint32_t id)
-        : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
-          outDataPoses{outDataPoses}, sharedState{sharedState}, nextTupleIdxToReadInMemBlock{0} {}
+        shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState, uint32_t id)
+        : PhysicalOperator{id}, SourceOperator{move(resultSetDescriptor)},
+          outDataPoses{outDataPoses}, sharedState{move(sharedState)}, nextTupleIdxToReadInMemBlock{
+                                                                          0} {}
 
     PhysicalOperatorType getOperatorType() override { return ORDER_BY_SCAN; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<OrderByScan>(
-            resultSetDescriptor->copy(), outDataPoses, sharedState, context, id);
+        return make_unique<OrderByScan>(resultSetDescriptor->copy(), outDataPoses, sharedState, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/projection.h
+++ b/src/processor/include/physical_plan/operator/projection.h
@@ -15,17 +15,17 @@ class Projection : public PhysicalOperator {
 public:
     Projection(vector<unique_ptr<BaseExpressionEvaluator>> expressionEvaluators,
         vector<DataPos> expressionsOutputPos, unordered_set<uint32_t> discardedDataChunksPos,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator(move(child), context, id),
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator(move(child), id),
           expressionEvaluators(move(expressionEvaluators)), expressionsOutputPos{move(
                                                                 expressionsOutputPos)},
           discardedDataChunksPos{move(discardedDataChunksPos)}, prevMultiplicity{1} {}
 
     PhysicalOperatorType getOperatorType() override { return PROJECTION; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
-    void reInitToRerunSubPlan() override;
+    inline void reInitToRerunSubPlan() override { children[0]->reInitToRerunSubPlan(); }
 
     bool getNextTuples() override;
 

--- a/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
+++ b/src/processor/include/physical_plan/operator/read_list/adj_list_extend.h
@@ -9,18 +9,18 @@ class AdjListExtend : public ReadList {
 
 public:
     AdjListExtend(const DataPos& inDataPos, const DataPos& outDataPos, AdjLists* lists,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : ReadList{inDataPos, outDataPos, lists, move(child), context, id, true /* isAdjList */} {}
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : ReadList{inDataPos, outDataPos, lists, move(child), id, true /* isAdjList */} {}
 
     PhysicalOperatorType getOperatorType() override { return LIST_EXTEND; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<AdjListExtend>(
-            inDataPos, outDataPos, (AdjLists*)lists, children[0]->clone(), context, id);
+            inDataPos, outDataPos, (AdjLists*)lists, children[0]->clone(), id);
     }
 };
 

--- a/src/processor/include/physical_plan/operator/read_list/read_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_list.h
@@ -10,19 +10,17 @@ class ReadList : public PhysicalOperator {
 
 public:
     ReadList(const DataPos& inDataPos, const DataPos& outDataPos, Lists* lists,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id, bool isAdjList)
-        : PhysicalOperator{move(child), context, id}, inDataPos{inDataPos}, outDataPos{outDataPos},
+        unique_ptr<PhysicalOperator> child, uint32_t id, bool isAdjList)
+        : PhysicalOperator{move(child), id}, inDataPos{inDataPos}, outDataPos{outDataPos},
           lists{lists}, largeListHandle{make_unique<LargeListHandle>(isAdjList)} {}
 
     ~ReadList() override{};
 
     PhysicalOperatorType getOperatorType() override = 0;
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
-
-    void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
 
 protected:
     void readValuesFromList();

--- a/src/processor/include/physical_plan/operator/read_list/read_rel_property_list.h
+++ b/src/processor/include/physical_plan/operator/read_list/read_rel_property_list.h
@@ -9,19 +9,18 @@ class ReadRelPropertyList : public ReadList {
 
 public:
     ReadRelPropertyList(const DataPos& inDataPos, const DataPos& outDataPos, Lists* lists,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : ReadList{inDataPos, outDataPos, lists, move(child), context, id,
-              false /* is not adj list */} {}
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : ReadList{inDataPos, outDataPos, lists, move(child), id, false /* is not adj list */} {}
 
     PhysicalOperatorType getOperatorType() override { return READ_REL_PROPERTY; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ReadRelPropertyList>(
-            inDataPos, outDataPos, lists, children[0]->clone(), context, id);
+            inDataPos, outDataPos, lists, children[0]->clone(), id);
     }
 };
 

--- a/src/processor/include/physical_plan/operator/result_collector.h
+++ b/src/processor/include/physical_plan/operator/result_collector.h
@@ -34,19 +34,21 @@ class ResultCollector : public Sink {
 public:
     ResultCollector(vector<pair<DataPos, bool>> vectorsToCollectInfo,
         shared_ptr<SharedQueryResults> sharedQueryResults, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id);
+        uint32_t id)
+        : Sink{move(child), id}, vectorsToCollectInfo{move(vectorsToCollectInfo)},
+          sharedQueryResults{move(sharedQueryResults)} {}
 
     PhysicalOperatorType getOperatorType() override { return RESULT_COLLECTOR; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
-    void execute() override;
+    void execute(ExecutionContext* context) override;
 
-    void finalize() override;
+    void finalize(ExecutionContext* context) override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ResultCollector>(
-            vectorsToCollectInfo, sharedQueryResults, children[0]->clone(), context, id);
+            vectorsToCollectInfo, sharedQueryResults, children[0]->clone(), id);
     }
 
     inline shared_ptr<FactorizedTable> getResultFactorizedTable() {

--- a/src/processor/include/physical_plan/operator/result_scan.h
+++ b/src/processor/include/physical_plan/operator/result_scan.h
@@ -14,9 +14,8 @@ class ResultScan : public PhysicalOperator, public SourceOperator {
 
 public:
     ResultScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> inDataPoses,
-        uint32_t outDataChunkPos, vector<uint32_t> outValueVectorsPos, ExecutionContext& context,
-        uint32_t id)
-        : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
+        uint32_t outDataChunkPos, vector<uint32_t> outValueVectorsPos, uint32_t id)
+        : PhysicalOperator{id}, SourceOperator{move(resultSetDescriptor)},
           inDataPoses{move(inDataPoses)}, outDataChunkPos{outDataChunkPos},
           outValueVectorsPos{move(outValueVectorsPos)}, isFirstExecution{true} {}
 
@@ -26,15 +25,15 @@ public:
 
     PhysicalOperatorType getOperatorType() override { return RESULT_SCAN; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ResultScan>(resultSetDescriptor->copy(), inDataPoses, outDataChunkPos,
-            outValueVectorsPos, context, id);
+        return make_unique<ResultScan>(
+            resultSetDescriptor->copy(), inDataPoses, outDataChunkPos, outValueVectorsPos, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/scan_column/adj_column_extend.h
+++ b/src/processor/include/physical_plan/operator/scan_column/adj_column_extend.h
@@ -11,14 +11,13 @@ class AdjColumnExtend : public ScanSingleColumn, public FilteringOperator {
 
 public:
     AdjColumnExtend(const DataPos& inputNodeIDVectorPos, const DataPos& outputNodeIDVectorPos,
-        Column* nodeIDColumn, unique_ptr<PhysicalOperator> child, ExecutionContext& context,
-        uint32_t id)
-        : ScanSingleColumn{inputNodeIDVectorPos, outputNodeIDVectorPos, move(child), context, id},
+        Column* nodeIDColumn, unique_ptr<PhysicalOperator> child, uint32_t id)
+        : ScanSingleColumn{inputNodeIDVectorPos, outputNodeIDVectorPos, move(child), id},
           FilteringOperator(), nodeIDColumn{nodeIDColumn} {}
 
     PhysicalOperatorType getOperatorType() override { return COLUMN_EXTEND; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 
@@ -26,7 +25,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<AdjColumnExtend>(
-            inputNodeIDVectorPos, outputVectorPos, nodeIDColumn, children[0]->clone(), context, id);
+            inputNodeIDVectorPos, outputVectorPos, nodeIDColumn, children[0]->clone(), id);
     }
 
     static bool discardNullNodesInVector(ValueVector& valueVector);

--- a/src/processor/include/physical_plan/operator/scan_column/scan_column.h
+++ b/src/processor/include/physical_plan/operator/scan_column/scan_column.h
@@ -10,17 +10,15 @@ namespace processor {
 class BaseScanColumn : public PhysicalOperator {
 
 public:
-    BaseScanColumn(const DataPos& inputNodeIDVectorPos, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id}, inputNodeIDVectorPos{inputNodeIDVectorPos} {}
+    BaseScanColumn(
+        const DataPos& inputNodeIDVectorPos, unique_ptr<PhysicalOperator> child, uint32_t id)
+        : PhysicalOperator{move(child), id}, inputNodeIDVectorPos{inputNodeIDVectorPos} {}
 
     PhysicalOperatorType getOperatorType() override = 0;
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
-    void reInitToRerunSubPlan() override;
-
-    void printMetricsToJson(nlohmann::json& json, Profiler& profiler) override;
+    inline void reInitToRerunSubPlan() override { children[0]->reInitToRerunSubPlan(); }
 
 protected:
     DataPos inputNodeIDVectorPos;
@@ -33,9 +31,8 @@ class ScanSingleColumn : public BaseScanColumn {
 
 protected:
     ScanSingleColumn(const DataPos& inputNodeIDVectorPos, const DataPos& outputVectorPos,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : BaseScanColumn{inputNodeIDVectorPos, move(child), context, id}, outputVectorPos{
-                                                                              outputVectorPos} {}
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : BaseScanColumn{inputNodeIDVectorPos, move(child), id}, outputVectorPos{outputVectorPos} {}
 
 protected:
     DataPos outputVectorPos;
@@ -47,9 +44,9 @@ class ScanMultipleColumns : public BaseScanColumn {
 
 protected:
     ScanMultipleColumns(const DataPos& inputNodeIDVectorPos, vector<DataPos> outputVectorsPos,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : BaseScanColumn{inputNodeIDVectorPos, move(child), context, id}, outputVectorsPos{move(
-                                                                              outputVectorsPos)} {}
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : BaseScanColumn{inputNodeIDVectorPos, move(child), id}, outputVectorsPos{
+                                                                     move(outputVectorsPos)} {}
 
 protected:
     vector<DataPos> outputVectorsPos;

--- a/src/processor/include/physical_plan/operator/scan_column/scan_structured_property.h
+++ b/src/processor/include/physical_plan/operator/scan_column/scan_structured_property.h
@@ -11,20 +11,20 @@ class ScanStructuredProperty : public ScanMultipleColumns {
 public:
     ScanStructuredProperty(const DataPos& inputNodeIDVectorPos,
         vector<DataPos> outputPropertyVectorsPos, vector<Column*> propertyColumns,
-        unique_ptr<PhysicalOperator> prevOperator, ExecutionContext& context, uint32_t id)
+        unique_ptr<PhysicalOperator> prevOperator, uint32_t id)
         : ScanMultipleColumns{inputNodeIDVectorPos, move(outputPropertyVectorsPos),
-              move(prevOperator), context, id},
+              move(prevOperator), id},
           propertyColumns{move(propertyColumns)} {}
 
     PhysicalOperatorType getOperatorType() override { return SCAN_STRUCTURED_PROPERTY; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ScanStructuredProperty>(inputNodeIDVectorPos, outputVectorsPos,
-            propertyColumns, children[0]->clone(), context, id);
+        return make_unique<ScanStructuredProperty>(
+            inputNodeIDVectorPos, outputVectorsPos, propertyColumns, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/scan_column/scan_unstructured_property.h
+++ b/src/processor/include/physical_plan/operator/scan_column/scan_unstructured_property.h
@@ -16,22 +16,22 @@ public:
     ScanUnstructuredProperty(const DataPos& inputNodeIDVectorPos,
         vector<DataPos> outputPropertyVectorsPos, vector<uint32_t> propertyKeys,
         UnstructuredPropertyLists* unstructuredPropertyLists, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id)
+        uint32_t id)
         : ScanMultipleColumns{inputNodeIDVectorPos, move(outputPropertyVectorsPos), move(child),
-              context, id},
+              id},
           propertyKeys{move(propertyKeys)}, unstructuredPropertyLists{unstructuredPropertyLists} {}
 
-    ~ScanUnstructuredProperty(){};
+    ~ScanUnstructuredProperty() = default;
 
     PhysicalOperatorType getOperatorType() override { return SCAN_UNSTRUCTURED_PROPERTY; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ScanUnstructuredProperty>(inputNodeIDVectorPos, outputVectorsPos,
-            propertyKeys, unstructuredPropertyLists, children[0]->clone(), context, id);
+            propertyKeys, unstructuredPropertyLists, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id.h
@@ -28,20 +28,19 @@ class ScanNodeID : public PhysicalOperator, public SourceOperator {
 
 public:
     ScanNodeID(unique_ptr<ResultSetDescriptor> resultSetDescriptor, label_t nodeLabel,
-        const DataPos& outDataPos, shared_ptr<ScanNodeIDSharedState> sharedState,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
-          nodeLabel{nodeLabel}, outDataPos{outDataPos}, sharedState{move(sharedState)} {}
+        const DataPos& outDataPos, shared_ptr<ScanNodeIDSharedState> sharedState, uint32_t id)
+        : PhysicalOperator{id}, SourceOperator{move(resultSetDescriptor)}, nodeLabel{nodeLabel},
+          outDataPos{outDataPos}, sharedState{move(sharedState)} {}
 
     PhysicalOperatorType getOperatorType() override { return SCAN_NODE_ID; }
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ScanNodeID>(
-            resultSetDescriptor->copy(), nodeLabel, outDataPos, sharedState, context, id);
+            resultSetDescriptor->copy(), nodeLabel, outDataPos, sharedState, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/sink.h
+++ b/src/processor/include/physical_plan/operator/sink.h
@@ -8,18 +8,15 @@ namespace processor {
 class Sink : public PhysicalOperator {
 
 public:
-    Sink(unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id} {}
+    Sink(unique_ptr<PhysicalOperator> child, uint32_t id) : PhysicalOperator{move(child), id} {}
 
     PhysicalOperatorType getOperatorType() override = 0;
 
-    shared_ptr<ResultSet> initResultSet() override = 0;
-
-    virtual void execute() { initResultSet(); };
+    virtual void execute(ExecutionContext* context) = 0;
 
     bool getNextTuples() final { assert(false); }
 
-    virtual void finalize(){};
+    virtual void finalize(ExecutionContext* context){};
 
     unique_ptr<PhysicalOperator> clone() override = 0;
 };

--- a/src/processor/include/physical_plan/operator/skip.h
+++ b/src/processor/include/physical_plan/operator/skip.h
@@ -11,21 +11,19 @@ class Skip : public PhysicalOperator, public FilteringOperator {
 public:
     Skip(uint64_t skipNumber, shared_ptr<atomic_uint64_t> counter, uint32_t dataChunkToSelectPos,
         unordered_set<uint32_t> dataChunksPosInScope, unique_ptr<PhysicalOperator> child,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(child), context, id},
+        uint32_t id)
+        : PhysicalOperator{move(child), id},
           FilteringOperator(), skipNumber{skipNumber}, counter{move(counter)},
           dataChunkToSelectPos{dataChunkToSelectPos}, dataChunksPosInScope{
                                                           move(dataChunksPosInScope)} {}
 
     PhysicalOperatorType getOperatorType() override { return SKIP; }
 
-    shared_ptr<ResultSet> initResultSet() override;
-
     bool getNextTuples() override;
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<Skip>(skipNumber, counter, dataChunkToSelectPos, dataChunksPosInScope,
-            children[0]->clone(), context, id);
+            children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/union_all_scan.h
+++ b/src/processor/include/physical_plan/operator/union_all_scan.h
@@ -54,9 +54,8 @@ private:
 class UnionAllScan : public PhysicalOperator, public SourceOperator {
 public:
     UnionAllScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> outDataPoses,
-        vector<DataType> dataTypes, vector<unique_ptr<PhysicalOperator>> children,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{move(children), context, id}, SourceOperator{move(resultSetDescriptor)},
+        vector<DataType> dataTypes, vector<unique_ptr<PhysicalOperator>> children, uint32_t id)
+        : PhysicalOperator{move(children), id}, SourceOperator{move(resultSetDescriptor)},
           outDataPoses{move(outDataPoses)}, dataTypes{move(dataTypes)} {
         unionAllScanSharedState = make_shared<UnionAllScanSharedState>(this->children);
     }
@@ -64,20 +63,20 @@ public:
     // For clone only.
     UnionAllScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor, vector<DataPos> outDataPoses,
         vector<DataType> dataTypes, shared_ptr<UnionAllScanSharedState> unionAllScanSharedState,
-        ExecutionContext& context, uint32_t id)
-        : PhysicalOperator{context, id}, SourceOperator{move(resultSetDescriptor)},
+        uint32_t id)
+        : PhysicalOperator{id}, SourceOperator{move(resultSetDescriptor)},
           unionAllScanSharedState{move(unionAllScanSharedState)},
           outDataPoses{move(outDataPoses)}, dataTypes{move(dataTypes)} {}
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     PhysicalOperatorType getOperatorType() override { return UNION_ALL_SCAN; }
 
     unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<UnionAllScan>(resultSetDescriptor->copy(), outDataPoses, dataTypes,
-            unionAllScanSharedState, context, id);
+        return make_unique<UnionAllScan>(
+            resultSetDescriptor->copy(), outDataPoses, dataTypes, unionAllScanSharedState, id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/var_length_extend/var_length_adj_list_extend.h
+++ b/src/processor/include/physical_plan/operator/var_length_extend/var_length_adj_list_extend.h
@@ -24,17 +24,21 @@ class VarLengthAdjListExtend : public VarLengthExtend {
 public:
     VarLengthAdjListExtend(const DataPos& boundNodeDataPos, const DataPos& nbrNodeDataPos,
         StorageStructure* adjLists, uint8_t lowerBound, uint8_t upperBound,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : VarLengthExtend(boundNodeDataPos, nbrNodeDataPos, adjLists, lowerBound, upperBound,
+              move(child), id) {}
+
+    PhysicalOperatorType getOperatorType() override { return VAR_LENGTH_ADJ_LIST_EXTEND; }
+
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
     void reInitToRerunSubPlan() override;
 
-    PhysicalOperatorType getOperatorType() override { return VAR_LENGTH_ADJ_LIST_EXTEND; }
-
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<VarLengthAdjListExtend>(boundNodeDataPos, nbrNodeDataPos, storage,
-            lowerBound, upperBound, children[0]->clone(), context, id);
+            lowerBound, upperBound, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/var_length_extend/var_length_column_extend.h
+++ b/src/processor/include/physical_plan/operator/var_length_extend/var_length_column_extend.h
@@ -26,17 +26,19 @@ class VarLengthColumnExtend : public VarLengthExtend {
 public:
     VarLengthColumnExtend(const DataPos& boundNodeDataPos, const DataPos& nbrNodeDataPos,
         StorageStructure* storage, uint8_t lowerBound, uint8_t upperBound,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
-
-    shared_ptr<ResultSet> initResultSet() override;
-
-    bool getNextTuples() override;
+        unique_ptr<PhysicalOperator> child, uint32_t id)
+        : VarLengthExtend(
+              boundNodeDataPos, nbrNodeDataPos, storage, lowerBound, upperBound, move(child), id) {}
 
     PhysicalOperatorType getOperatorType() override { return VAR_LENGTH_COLUMN_EXTEND; }
 
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
+
+    bool getNextTuples() override;
+
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<VarLengthColumnExtend>(boundNodeDataPos, nbrNodeDataPos, storage,
-            lowerBound, upperBound, children[0]->clone(), context, id);
+            lowerBound, upperBound, children[0]->clone(), id);
     }
 
 private:

--- a/src/processor/include/physical_plan/operator/var_length_extend/var_length_extend.h
+++ b/src/processor/include/physical_plan/operator/var_length_extend/var_length_extend.h
@@ -24,9 +24,9 @@ class VarLengthExtend : public PhysicalOperator {
 public:
     VarLengthExtend(const DataPos& boundNodeDataPos, const DataPos& nbrNodeDataPos,
         StorageStructure* storage, uint8_t lowerBound, uint8_t upperBound,
-        unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id);
+        unique_ptr<PhysicalOperator> child, uint32_t id);
 
-    shared_ptr<ResultSet> initResultSet() override;
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     void reInitToRerunSubPlan() override;
 

--- a/src/processor/include/processor.h
+++ b/src/processor/include/processor.h
@@ -17,11 +17,11 @@ class QueryProcessor {
 public:
     explicit QueryProcessor(uint64_t numThreads);
 
-    shared_ptr<FactorizedTable> execute(PhysicalPlan* physicalPlan, uint64_t numThreads);
+    shared_ptr<FactorizedTable> execute(PhysicalPlan* physicalPlan, ExecutionContext* context);
 
 private:
-    void decomposePlanIntoTasks(
-        PhysicalOperator* op, PhysicalOperator* parent, Task* parentTask, uint64_t numThreads);
+    void decomposePlanIntoTasks(PhysicalOperator* op, PhysicalOperator* parent, Task* parentTask,
+        ExecutionContext* context);
 
 private:
     unique_ptr<TaskScheduler> taskScheduler;

--- a/src/processor/include/processor_task.h
+++ b/src/processor/include/processor_task.h
@@ -11,13 +11,15 @@ namespace processor {
 class ProcessorTask : public Task {
 
 public:
-    ProcessorTask(Sink* sinkOp, uint64_t numThreads);
+    ProcessorTask(Sink* sinkOp, ExecutionContext* executionContext)
+        : Task{executionContext->numThreads}, sinkOp{sinkOp}, executionContext{executionContext} {}
 
     void run() override;
     void finalizeIfNecessary() override;
 
 private:
     Sink* sinkOp;
+    ExecutionContext* executionContext;
 };
 
 } // namespace processor

--- a/src/processor/physical_plan/mapper/expression_mapper.cpp
+++ b/src/processor/physical_plan/mapper/expression_mapper.cpp
@@ -10,8 +10,7 @@ namespace graphflow {
 namespace processor {
 
 unique_ptr<BaseExpressionEvaluator> ExpressionMapper::mapExpression(
-    const shared_ptr<Expression>& expression, const MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    const shared_ptr<Expression>& expression, const MapperContext& mapperContext) {
     auto expressionType = expression->expressionType;
     if (isExpressionLiteral(expressionType)) {
         return mapLiteralExpression(expression);
@@ -20,7 +19,7 @@ unique_ptr<BaseExpressionEvaluator> ExpressionMapper::mapExpression(
     } else if (mapperContext.expressionHasComputed(expression->getUniqueName())) {
         return mapReferenceExpression(expression, mapperContext);
     } else {
-        return mapFunctionExpression(expression, mapperContext, executionContext);
+        return mapFunctionExpression(expression, mapperContext);
     }
 }
 
@@ -45,11 +44,10 @@ unique_ptr<BaseExpressionEvaluator> ExpressionMapper::mapReferenceExpression(
 }
 
 unique_ptr<BaseExpressionEvaluator> ExpressionMapper::mapFunctionExpression(
-    const shared_ptr<Expression>& expression, const MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    const shared_ptr<Expression>& expression, const MapperContext& mapperContext) {
     vector<unique_ptr<BaseExpressionEvaluator>> children;
     for (auto i = 0u; i < expression->getNumChildren(); ++i) {
-        children.push_back(mapExpression(expression->getChild(i), mapperContext, executionContext));
+        children.push_back(mapExpression(expression->getChild(i), mapperContext));
     }
     return make_unique<FunctionExpressionEvaluator>(expression, move(children));
 }

--- a/src/processor/physical_plan/mapper/plan_mapper.cpp
+++ b/src/processor/physical_plan/mapper/plan_mapper.cpp
@@ -64,19 +64,17 @@ static unique_ptr<PhysicalOperator> createHashAggregate(
     vector<unique_ptr<AggregateFunction>> aggregateFunctions, vector<DataPos> inputAggVectorsPos,
     vector<DataPos> outputAggVectorsPos, vector<DataType> outputAggVectorsDataTypes,
     const expression_vector& groupByExpressions, unique_ptr<PhysicalOperator> prevOperator,
-    MapperContext& mapperContextBeforeAggregate, MapperContext& mapperContext,
-    ExecutionContext& executionContext);
+    MapperContext& mapperContextBeforeAggregate, MapperContext& mapperContext);
 
 static void appendGroupByExpressions(const expression_vector& groupByExpressions,
     vector<DataPos>& inputGroupByHashKeyVectorsPos, vector<DataPos>& outputGroupByKeyVectorsPos,
     vector<DataType>& outputGroupByKeyVectorsDataTypes, MapperContext& mapperContextBeforeAggregate,
     MapperContext& mapperContext);
 
-unique_ptr<PhysicalPlan> PlanMapper::mapLogicalPlanToPhysical(
-    unique_ptr<LogicalPlan> logicalPlan, ExecutionContext& executionContext) {
+unique_ptr<PhysicalPlan> PlanMapper::mapLogicalPlanToPhysical(unique_ptr<LogicalPlan> logicalPlan) {
     auto mapperContext = MapperContext(make_unique<ResultSetDescriptor>(*logicalPlan->getSchema()));
-    auto resultCollector = mapLogicalOperatorToPhysical(
-        logicalPlan->getLastOperator(), mapperContext, executionContext);
+    auto resultCollector =
+        mapLogicalOperatorToPhysical(logicalPlan->getLastOperator(), mapperContext);
     return make_unique<PhysicalPlan>(move(resultCollector));
 }
 
@@ -91,90 +89,74 @@ void PlanMapper::exitSubquery(const MapperContext* prevMapperContext) {
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOperatorToPhysical(
-    const shared_ptr<LogicalOperator>& logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    const shared_ptr<LogicalOperator>& logicalOperator, MapperContext& mapperContext) {
     unique_ptr<PhysicalOperator> physicalOperator;
     auto operatorType = logicalOperator->getLogicalOperatorType();
     switch (operatorType) {
     case LOGICAL_SCAN_NODE_ID: {
-        physicalOperator =
-            mapLogicalScanNodeIDToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalScanNodeIDToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_SELECT_SCAN: {
-        physicalOperator =
-            mapLogicalResultScanToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalResultScanToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_EXTEND: {
-        physicalOperator =
-            mapLogicalExtendToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalExtendToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_FLATTEN: {
-        physicalOperator =
-            mapLogicalFlattenToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalFlattenToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_FILTER: {
-        physicalOperator =
-            mapLogicalFilterToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalFilterToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_INTERSECT: {
-        physicalOperator =
-            mapLogicalIntersectToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalIntersectToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_PROJECTION: {
-        physicalOperator =
-            mapLogicalProjectionToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalProjectionToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_HASH_JOIN: {
-        physicalOperator =
-            mapLogicalHashJoinToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalHashJoinToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_SCAN_NODE_PROPERTY: {
-        physicalOperator = mapLogicalScanNodePropertyToPhysical(
-            logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator =
+            mapLogicalScanNodePropertyToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_SCAN_REL_PROPERTY: {
-        physicalOperator = mapLogicalScanRelPropertyToPhysical(
-            logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator =
+            mapLogicalScanRelPropertyToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_MULTIPLICITY_REDUCER: {
-        physicalOperator = mapLogicalMultiplicityReducerToPhysical(
-            logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator =
+            mapLogicalMultiplicityReducerToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_SKIP: {
-        physicalOperator =
-            mapLogicalSkipToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalSkipToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_LIMIT: {
-        physicalOperator =
-            mapLogicalLimitToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalLimitToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_AGGREGATE: {
-        physicalOperator =
-            mapLogicalAggregateToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalAggregateToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_DISTINCT: {
-        physicalOperator =
-            mapLogicalDistinctToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalDistinctToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_EXISTS: {
-        physicalOperator =
-            mapLogicalExistsToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalExistsToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_LEFT_NESTED_LOOP_JOIN: {
-        physicalOperator = mapLogicalLeftNestedLoopJoinToPhysical(
-            logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator =
+            mapLogicalLeftNestedLoopJoinToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_ORDER_BY: {
-        physicalOperator =
-            mapLogicalOrderByToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalOrderByToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_UNION_ALL: {
-        physicalOperator =
-            mapLogicalUnionAllToPhysical(logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator = mapLogicalUnionAllToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_RESULT_COLLECTOR: {
-        physicalOperator = mapLogicalResultCollectorToPhysical(
-            logicalOperator.get(), mapperContext, executionContext);
+        physicalOperator =
+            mapLogicalResultCollectorToPhysical(logicalOperator.get(), mapperContext);
     } break;
     default:
         assert(false);
@@ -185,19 +167,17 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOperatorToPhysical(
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodeIDToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalScan = (const LogicalScanNodeID&)*logicalOperator;
     auto sharedState = make_shared<ScanNodeIDSharedState>(catalog.getNumNodes(logicalScan.label));
     auto dataPos = mapperContext.getDataPos(logicalScan.nodeID);
     mapperContext.addComputedExpressions(logicalScan.nodeID);
     return make_unique<ScanNodeID>(mapperContext.getResultSetDescriptor()->copy(),
-        logicalScan.label, dataPos, sharedState, executionContext, mapperContext.getOperatorID());
+        logicalScan.label, dataPos, sharedState, mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalResultScanToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) const {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& resultScan = (const LogicalResultScan&)*logicalOperator;
     auto expressionsToScan = resultScan.getExpressionsToScan();
     assert(!expressionsToScan.empty());
@@ -214,16 +194,14 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalResultScanToPhysical(
         mapperContext.addComputedExpressions(expressionName);
     }
     return make_unique<ResultScan>(mapperContext.getResultSetDescriptor()->copy(),
-        move(inDataPoses), outDataChunkPos, move(outValueVectorsPos), executionContext,
+        move(inDataPoses), outDataChunkPos, move(outValueVectorsPos),
         mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& extend = (const LogicalExtend&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto inDataPos = mapperContext.getDataPos(extend.boundNodeID);
     auto outDataPos = mapperContext.getDataPos(extend.nbrNodeID);
     mapperContext.addComputedExpressions(extend.nbrNodeID);
@@ -232,90 +210,77 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
         if (extend.lowerBound == 1 && extend.lowerBound == extend.upperBound) {
             return make_unique<AdjColumnExtend>(inDataPos, outDataPos,
                 relsStore.getAdjColumn(extend.direction, extend.boundNodeLabel, extend.relLabel),
-                move(prevOperator), executionContext, mapperContext.getOperatorID());
+                move(prevOperator), mapperContext.getOperatorID());
         } else {
             return make_unique<VarLengthColumnExtend>(inDataPos, outDataPos,
                 relsStore.getAdjColumn(extend.direction, extend.boundNodeLabel, extend.relLabel),
-                extend.lowerBound, extend.upperBound, move(prevOperator), executionContext,
+                extend.lowerBound, extend.upperBound, move(prevOperator),
                 mapperContext.getOperatorID());
         }
     } else {
         auto adjLists =
             relsStore.getAdjLists(extend.direction, extend.boundNodeLabel, extend.relLabel);
         if (extend.lowerBound == 1 && extend.lowerBound == extend.upperBound) {
-            return make_unique<AdjListExtend>(inDataPos, outDataPos, adjLists, move(prevOperator),
-                executionContext, mapperContext.getOperatorID());
+            return make_unique<AdjListExtend>(
+                inDataPos, outDataPos, adjLists, move(prevOperator), mapperContext.getOperatorID());
         } else {
             return make_unique<VarLengthAdjListExtend>(inDataPos, outDataPos, adjLists,
-                extend.lowerBound, extend.upperBound, move(prevOperator), executionContext,
+                extend.lowerBound, extend.upperBound, move(prevOperator),
                 mapperContext.getOperatorID());
         }
     }
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFlattenToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& flatten = (const LogicalFlatten&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto dataChunkPos =
         mapperContext.getDataPos(flatten.getExpressionToFlatten()->getUniqueName()).dataChunkPos;
     mapperContext.flattenDataChunk(dataChunkPos);
-    return make_unique<Flatten>(
-        dataChunkPos, move(prevOperator), executionContext, mapperContext.getOperatorID());
+    return make_unique<Flatten>(dataChunkPos, move(prevOperator), mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFilterToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalFilter = (const LogicalFilter&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto dataChunkToSelectPos = logicalFilter.groupPosToSelect;
-    auto physicalRootExpr =
-        expressionMapper.mapExpression(logicalFilter.expression, mapperContext, executionContext);
+    auto physicalRootExpr = expressionMapper.mapExpression(logicalFilter.expression, mapperContext);
     return make_unique<Filter>(move(physicalRootExpr), dataChunkToSelectPos, move(prevOperator),
-        executionContext, mapperContext.getOperatorID());
-}
-
-unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
-    auto& logicalIntersect = (const LogicalIntersect&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
-    auto leftDataPos = mapperContext.getDataPos(logicalIntersect.getLeftNodeID());
-    auto rightDataPos = mapperContext.getDataPos(logicalIntersect.getRightNodeID());
-    return make_unique<Intersect>(leftDataPos, rightDataPos, move(prevOperator), executionContext,
         mapperContext.getOperatorID());
 }
 
+unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
+    auto& logicalIntersect = (const LogicalIntersect&)*logicalOperator;
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
+    auto leftDataPos = mapperContext.getDataPos(logicalIntersect.getLeftNodeID());
+    auto rightDataPos = mapperContext.getDataPos(logicalIntersect.getRightNodeID());
+    return make_unique<Intersect>(
+        leftDataPos, rightDataPos, move(prevOperator), mapperContext.getOperatorID());
+}
+
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalProjectionToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalProjection = (const LogicalProjection&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     vector<unique_ptr<BaseExpressionEvaluator>> expressionEvaluators;
     vector<DataPos> expressionsOutputPos;
     for (auto& expression : logicalProjection.getExpressionsToProject()) {
-        expressionEvaluators.push_back(
-            expressionMapper.mapExpression(expression, mapperContext, executionContext));
+        expressionEvaluators.push_back(expressionMapper.mapExpression(expression, mapperContext));
         expressionsOutputPos.push_back(mapperContext.getDataPos(expression->getUniqueName()));
         mapperContext.addComputedExpressions(expression->getUniqueName());
     }
     return make_unique<Projection>(move(expressionEvaluators), move(expressionsOutputPos),
-        logicalProjection.getDiscardedGroupsPos(), move(prevOperator), executionContext,
+        logicalProjection.getDiscardedGroupsPos(), move(prevOperator),
         mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodePropertyToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& scanProperty = (const LogicalScanNodeProperty&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto inputNodeIDVectorPos = mapperContext.getDataPos(scanProperty.getNodeID());
     vector<DataPos> outputPropertyVectorsPos;
     for (auto& propertyName : scanProperty.getPropertyNames()) {
@@ -327,7 +292,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodePropertyToPhysical(
         auto lists = nodeStore.getNodeUnstrPropertyLists(scanProperty.getNodeLabel());
         return make_unique<ScanUnstructuredProperty>(inputNodeIDVectorPos,
             move(outputPropertyVectorsPos), scanProperty.getPropertyKeys(), lists,
-            move(prevOperator), executionContext, mapperContext.getOperatorID());
+            move(prevOperator), mapperContext.getOperatorID());
     }
     vector<Column*> propertyColumns;
     for (auto& propertyKey : scanProperty.getPropertyKeys()) {
@@ -335,15 +300,13 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodePropertyToPhysical(
             nodeStore.getNodePropertyColumn(scanProperty.getNodeLabel(), propertyKey));
     }
     return make_unique<ScanStructuredProperty>(inputNodeIDVectorPos, move(outputPropertyVectorsPos),
-        move(propertyColumns), move(prevOperator), executionContext, mapperContext.getOperatorID());
+        move(propertyColumns), move(prevOperator), mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanRelPropertyToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& scanRelProperty = (const LogicalScanRelProperty&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto inputNodeIDVectorPos = mapperContext.getDataPos(scanRelProperty.getBoundNodeID());
     auto propertyName = scanRelProperty.getPropertyName();
     auto propertyKey = scanRelProperty.getPropertyKey();
@@ -355,24 +318,22 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanRelPropertyToPhysical(
             scanRelProperty.getRelLabel(), scanRelProperty.getBoundNodeLabel(), propertyKey);
         return make_unique<ScanStructuredProperty>(inputNodeIDVectorPos,
             vector<DataPos>{outputPropertyVectorPos}, vector<Column*>{column}, move(prevOperator),
-            executionContext, mapperContext.getOperatorID());
+            mapperContext.getOperatorID());
     }
     auto lists = relStore.getRelPropertyLists(scanRelProperty.getDirection(),
         scanRelProperty.getBoundNodeLabel(), scanRelProperty.getRelLabel(), propertyKey);
     return make_unique<ReadRelPropertyList>(inputNodeIDVectorPos, move(outputPropertyVectorPos),
-        lists, move(prevOperator), executionContext, mapperContext.getOperatorID());
+        lists, move(prevOperator), mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& hashJoin = (const LogicalHashJoin&)*logicalOperator;
     auto buildSideMapperContext =
         MapperContext(make_unique<ResultSetDescriptor>(*hashJoin.getBuildSideSchema()));
-    auto buildSidePrevOperator = mapLogicalOperatorToPhysical(
-        hashJoin.getChild(1), buildSideMapperContext, executionContext);
-    auto probeSidePrevOperator =
-        mapLogicalOperatorToPhysical(hashJoin.getChild(0), mapperContext, executionContext);
+    auto buildSidePrevOperator =
+        mapLogicalOperatorToPhysical(hashJoin.getChild(1), buildSideMapperContext);
+    auto probeSidePrevOperator = mapLogicalOperatorToPhysical(hashJoin.getChild(0), mapperContext);
     // Populate build side and probe side vector positions
     auto buildSideKeyIDDataPos = buildSideMapperContext.getDataPos(hashJoin.getJoinNodeID());
     auto probeSideKeyIDDataPos = mapperContext.getDataPos(hashJoin.getJoinNodeID());
@@ -395,55 +356,48 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
     // create hashJoin build
     auto buildDataInfo =
         BuildDataInfo(buildSideKeyIDDataPos, buildSideNonKeyDataPoses, isBuildSideNonKeyDataFlat);
-    auto hashJoinBuild = make_unique<HashJoinBuild>(sharedState, buildDataInfo,
-        move(buildSidePrevOperator), executionContext, mapperContext.getOperatorID());
+    auto hashJoinBuild = make_unique<HashJoinBuild>(
+        sharedState, buildDataInfo, move(buildSidePrevOperator), mapperContext.getOperatorID());
     // create hashJoin probe
     auto probeDataInfo = ProbeDataInfo(probeSideKeyIDDataPos, probeSideNonKeyDataPoses);
-    auto hashJoinProbe =
-        make_unique<HashJoinProbe>(sharedState, probeDataInfo, move(probeSidePrevOperator),
-            move(hashJoinBuild), executionContext, mapperContext.getOperatorID());
+    auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState, probeDataInfo,
+        move(probeSidePrevOperator), move(hashJoinBuild), mapperContext.getOperatorID());
     return hashJoinProbe;
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalMultiplicityReducerToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
-    return make_unique<MultiplicityReducer>(
-        move(prevOperator), executionContext, mapperContext.getOperatorID());
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
+    return make_unique<MultiplicityReducer>(move(prevOperator), mapperContext.getOperatorID());
 }
 
-unique_ptr<PhysicalOperator> PlanMapper::mapLogicalSkipToPhysical(LogicalOperator* logicalOperator,
-    MapperContext& mapperContext, ExecutionContext& executionContext) {
+unique_ptr<PhysicalOperator> PlanMapper::mapLogicalSkipToPhysical(
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalSkip = (const LogicalSkip&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto dataChunkToSelectPos = logicalSkip.getGroupPosToSelect();
     return make_unique<Skip>(logicalSkip.getSkipNumber(), make_shared<atomic_uint64_t>(0),
         dataChunkToSelectPos, logicalSkip.getGroupsPosToSkip(), move(prevOperator),
-        executionContext, mapperContext.getOperatorID());
+        mapperContext.getOperatorID());
 }
 
-unique_ptr<PhysicalOperator> PlanMapper::mapLogicalLimitToPhysical(LogicalOperator* logicalOperator,
-    MapperContext& mapperContext, ExecutionContext& executionContext) {
+unique_ptr<PhysicalOperator> PlanMapper::mapLogicalLimitToPhysical(
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalLimit = (const LogicalLimit&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto dataChunkToSelectPos = logicalLimit.getGroupPosToSelect();
     return make_unique<Limit>(logicalLimit.getLimitNumber(), make_shared<atomic_uint64_t>(0),
         dataChunkToSelectPos, logicalLimit.getGroupsPosToLimit(), move(prevOperator),
-        executionContext, mapperContext.getOperatorID());
+        mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAggregateToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalAggregate = (const LogicalAggregate&)*logicalOperator;
     auto mapperContextBeforeAggregate = MapperContext(
         make_unique<ResultSetDescriptor>(*logicalAggregate.getSchemaBeforeAggregate()));
-    auto prevOperator = mapLogicalOperatorToPhysical(
-        logicalOperator->getChild(0), mapperContextBeforeAggregate, executionContext);
+    auto prevOperator =
+        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContextBeforeAggregate);
     vector<DataPos> inputAggVectorsPos;
     vector<DataPos> outputAggVectorsPos;
     vector<DataType> outputAggVectorsDataTypes;
@@ -466,28 +420,25 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAggregateToPhysical(
         return createHashAggregate(move(aggregateFunctions), inputAggVectorsPos,
             outputAggVectorsPos, outputAggVectorsDataTypes,
             logicalAggregate.getExpressionsToGroupBy(), move(prevOperator),
-            mapperContextBeforeAggregate, mapperContext, executionContext);
+            mapperContextBeforeAggregate, mapperContext);
     } else {
         auto sharedState = make_shared<SimpleAggregateSharedState>(aggregateFunctions);
-        auto aggregate =
-            make_unique<SimpleAggregate>(sharedState, inputAggVectorsPos, move(aggregateFunctions),
-                move(prevOperator), executionContext, mapperContext.getOperatorID());
+        auto aggregate = make_unique<SimpleAggregate>(sharedState, inputAggVectorsPos,
+            move(aggregateFunctions), move(prevOperator), mapperContext.getOperatorID());
         auto aggregateScan = make_unique<SimpleAggregateScan>(sharedState,
             mapperContext.getResultSetDescriptor()->copy(), outputAggVectorsPos,
-            outputAggVectorsDataTypes, move(aggregate), executionContext,
-            mapperContext.getOperatorID());
+            outputAggVectorsDataTypes, move(aggregate), mapperContext.getOperatorID());
         return aggregateScan;
     }
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalDistinctToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalDistinct = (const LogicalDistinct&)*logicalOperator;
     auto mapperContextBeforeDistinct =
         MapperContext(make_unique<ResultSetDescriptor>(*logicalDistinct.getSchemaBeforeDistinct()));
-    auto prevOperator = mapLogicalOperatorToPhysical(
-        logicalOperator->getChild(0), mapperContextBeforeDistinct, executionContext);
+    auto prevOperator =
+        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContextBeforeDistinct);
     vector<unique_ptr<AggregateFunction>> emptyAggregateFunctions;
     vector<DataPos> emptyInputAggVectorsPos;
     vector<DataPos> emptyOutputAggVectorsPos;
@@ -495,38 +446,34 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalDistinctToPhysical(
     return createHashAggregate(move(emptyAggregateFunctions), emptyInputAggVectorsPos,
         emptyOutputAggVectorsPos, emptyOutputAggVectorsDataTypes,
         logicalDistinct.getExpressionsToDistinct(), move(prevOperator), mapperContextBeforeDistinct,
-        mapperContext, executionContext);
+        mapperContext);
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExistsToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalExists = (LogicalExists&)*logicalOperator;
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto subPlanMapperContext =
         MapperContext(make_unique<ResultSetDescriptor>(*logicalExists.subPlanSchema));
     auto prevContext = enterSubquery(&mapperContext);
-    auto subPlanLastOperator = mapLogicalOperatorToPhysical(
-        logicalExists.getChild(1), subPlanMapperContext, executionContext);
+    auto subPlanLastOperator =
+        mapLogicalOperatorToPhysical(logicalExists.getChild(1), subPlanMapperContext);
     exitSubquery(prevContext);
     mapperContext.addComputedExpressions(logicalExists.subqueryExpression->getUniqueName());
     auto outDataPos = mapperContext.getDataPos(logicalExists.subqueryExpression->getUniqueName());
-    return make_unique<Exists>(outDataPos, move(prevOperator), move(subPlanLastOperator),
-        executionContext, mapperContext.getOperatorID());
+    return make_unique<Exists>(
+        outDataPos, move(prevOperator), move(subPlanLastOperator), mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalLeftNestedLoopJoinToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalLeftNestedLoopJoin = (LogicalLeftNestedLoopJoin&)*logicalOperator;
     auto& subPlanSchema = *logicalLeftNestedLoopJoin.subPlanSchema;
     auto subPlanMapperContext = MapperContext(make_unique<ResultSetDescriptor>(subPlanSchema));
-    auto prevOperator =
-        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext, executionContext);
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto prevMapperContext = enterSubquery(&mapperContext);
-    auto subPlanLastOperator = mapLogicalOperatorToPhysical(
-        logicalLeftNestedLoopJoin.getChild(1), subPlanMapperContext, executionContext);
+    auto subPlanLastOperator =
+        mapLogicalOperatorToPhysical(logicalLeftNestedLoopJoin.getChild(1), subPlanMapperContext);
     exitSubquery(prevMapperContext);
     vector<pair<DataPos, DataPos>> subPlanVectorsToRefPosMapping;
     // Populate data position mapping for merging sub-plan result set
@@ -544,18 +491,17 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalLeftNestedLoopJoinToPhysical(
         }
     }
     return make_unique<LeftNestedLoopJoin>(move(subPlanVectorsToRefPosMapping), move(prevOperator),
-        move(subPlanLastOperator), executionContext, mapperContext.getOperatorID());
+        move(subPlanLastOperator), mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOrderByToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& logicalOrderBy = (LogicalOrderBy&)*logicalOperator;
     auto& schemaBeforeOrderBy = *logicalOrderBy.getSchemaBeforeOrderBy();
     auto mapperContextBeforeOrderBy =
         MapperContext(make_unique<ResultSetDescriptor>(schemaBeforeOrderBy));
-    auto orderByPrevOperator = mapLogicalOperatorToPhysical(
-        logicalOrderBy.getChild(0), mapperContextBeforeOrderBy, executionContext);
+    auto orderByPrevOperator =
+        mapLogicalOperatorToPhysical(logicalOrderBy.getChild(0), mapperContextBeforeOrderBy);
     vector<DataPos> keyDataPoses;
     for (auto& expression : logicalOrderBy.getExpressionsToOrderBy()) {
         keyDataPoses.emplace_back(
@@ -577,23 +523,21 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOrderByToPhysical(
     auto orderBySharedState = make_shared<SharedFactorizedTablesAndSortedKeyBlocks>();
 
     auto orderBy = make_unique<OrderBy>(orderByDataInfo, orderBySharedState,
-        move(orderByPrevOperator), executionContext, mapperContext.getOperatorID());
-    auto orderByMerge = make_unique<OrderByMerge>(
-        orderBySharedState, move(orderBy), executionContext, mapperContext.getOperatorID());
+        move(orderByPrevOperator), mapperContext.getOperatorID());
+    auto orderByMerge =
+        make_unique<OrderByMerge>(orderBySharedState, move(orderBy), mapperContext.getOperatorID());
     auto orderByScan = make_unique<OrderByScan>(mapperContext.getResultSetDescriptor()->copy(),
-        outputDataPoses, orderBySharedState, move(orderByMerge), executionContext,
-        mapperContext.getOperatorID());
+        outputDataPoses, orderBySharedState, move(orderByMerge), mapperContext.getOperatorID());
     return orderByScan;
 }
 
 unique_ptr<ResultCollector> PlanMapper::mapLogicalResultCollectorToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& resultCollector = (LogicalResultCollector&)*logicalOperator;
     auto resultCollectorMapperContext =
         MapperContext(make_unique<ResultSetDescriptor>(*resultCollector.getSchema()));
-    auto prevOperator = mapLogicalOperatorToPhysical(
-        logicalOperator->getChild(0), resultCollectorMapperContext, executionContext);
+    auto prevOperator =
+        mapLogicalOperatorToPhysical(logicalOperator->getChild(0), resultCollectorMapperContext);
 
     vector<pair<DataPos, bool>> valueVectorsToCollectInfo;
     for (auto& expression : resultCollector.getExpressionsToCollect()) {
@@ -602,13 +546,11 @@ unique_ptr<ResultCollector> PlanMapper::mapLogicalResultCollectorToPhysical(
                 resultCollector.getSchema()->getGroup(expression->getUniqueName())->getIsFlat()));
     }
     return make_unique<ResultCollector>(valueVectorsToCollectInfo,
-        make_shared<SharedQueryResults>(), move(prevOperator), executionContext,
-        mapperContext.getOperatorID());
+        make_shared<SharedQueryResults>(), move(prevOperator), mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalUnionAllToPhysical(
-    LogicalOperator* logicalOperator, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    LogicalOperator* logicalOperator, MapperContext& mapperContext) {
     auto& unionAll = (LogicalUnion&)*logicalOperator;
     vector<DataType> dataTypes;
     vector<DataPos> outDataPoses;
@@ -618,20 +560,18 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalUnionAllToPhysical(
     }
     vector<unique_ptr<PhysicalOperator>> children;
     for (auto i = 0u; i < logicalOperator->getNumChildren(); i++) {
-        children.emplace_back(mapLogicalResultCollectorToPhysical(
-            logicalOperator->getChild(i).get(), mapperContext, executionContext));
+        children.emplace_back(
+            mapLogicalResultCollectorToPhysical(logicalOperator->getChild(i).get(), mapperContext));
     }
     return make_unique<UnionAllScan>(mapperContext.getResultSetDescriptor()->copy(),
-        move(outDataPoses), move(dataTypes), move(children), executionContext,
-        mapperContext.getOperatorID());
+        move(outDataPoses), move(dataTypes), move(children), mapperContext.getOperatorID());
 }
 
 unique_ptr<PhysicalOperator> createHashAggregate(
     vector<unique_ptr<AggregateFunction>> aggregateFunctions, vector<DataPos> inputAggVectorsPos,
     vector<DataPos> outputAggVectorsPos, vector<DataType> outputAggVectorsDataType,
     const expression_vector& groupByExpressions, unique_ptr<PhysicalOperator> prevOperator,
-    MapperContext& mapperContextBeforeAggregate, MapperContext& mapperContext,
-    ExecutionContext& executionContext) {
+    MapperContext& mapperContextBeforeAggregate, MapperContext& mapperContext) {
     vector<DataPos> inputGroupByHashKeyVectorsPos;
     vector<DataPos> inputGroupByNonHashKeyVectorsPos;
     vector<DataPos> outputGroupByKeyVectorsPos;
@@ -664,12 +604,11 @@ unique_ptr<PhysicalOperator> createHashAggregate(
     auto sharedState = make_shared<HashAggregateSharedState>(aggregateFunctions);
     auto aggregate = make_unique<HashAggregate>(sharedState, inputGroupByHashKeyVectorsPos,
         inputGroupByNonHashKeyVectorsPos, move(inputAggVectorsPos), move(aggregateFunctions),
-        move(prevOperator), executionContext, mapperContext.getOperatorID());
-    auto aggregateScan =
-        make_unique<HashAggregateScan>(sharedState, mapperContext.getResultSetDescriptor()->copy(),
-            outputGroupByKeyVectorsPos, outputGroupByKeyVectorsDataTypeId,
-            move(outputAggVectorsPos), move(outputAggVectorsDataType), move(aggregate),
-            executionContext, mapperContext.getOperatorID());
+        move(prevOperator), mapperContext.getOperatorID());
+    auto aggregateScan = make_unique<HashAggregateScan>(sharedState,
+        mapperContext.getResultSetDescriptor()->copy(), outputGroupByKeyVectorsPos,
+        outputGroupByKeyVectorsDataTypeId, move(outputAggVectorsPos),
+        move(outputAggVectorsDataType), move(aggregate), mapperContext.getOperatorID());
     return aggregateScan;
 }
 

--- a/src/processor/physical_plan/operator/aggregate/base_aggregate.cpp
+++ b/src/processor/physical_plan/operator/aggregate/base_aggregate.cpp
@@ -20,8 +20,8 @@ bool BaseAggregate::containDistinctAggregate() const {
     return false;
 }
 
-shared_ptr<ResultSet> BaseAggregate::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> BaseAggregate::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     for (auto& dataPos : aggregateVectorsPos) {
         if (dataPos.dataChunkPos == UINT32_MAX) {
             // COUNT(*) aggregate does not take any input vector.

--- a/src/processor/physical_plan/operator/aggregate/base_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/base_aggregate_scan.cpp
@@ -3,10 +3,11 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> BaseAggregateScan::initResultSet() {
+shared_ptr<ResultSet> BaseAggregateScan::init(ExecutionContext* context) {
+    PhysicalOperator::init(context);
     resultSet = populateResultSet();
     for (auto i = 0u; i < aggregatesPos.size(); i++) {
-        auto valueVector = make_shared<ValueVector>(context.memoryManager, aggregateDataTypes[i]);
+        auto valueVector = make_shared<ValueVector>(context->memoryManager, aggregateDataTypes[i]);
         auto outDataChunk = resultSet->dataChunks[aggregatesPos[i].dataChunkPos];
         outDataChunk->insert(aggregatesPos[i].valueVectorPos, valueVector);
         aggregateVectors.push_back(valueVector);

--- a/src/processor/physical_plan/operator/aggregate/hash_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/hash_aggregate_scan.cpp
@@ -3,11 +3,11 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> HashAggregateScan::initResultSet() {
-    auto result = BaseAggregateScan::initResultSet();
+shared_ptr<ResultSet> HashAggregateScan::init(ExecutionContext* context) {
+    auto result = BaseAggregateScan::init(context);
     for (auto i = 0u; i < groupByKeyVectorsPos.size(); i++) {
         auto valueVector =
-            make_shared<ValueVector>(context.memoryManager, groupByKeyVectorDataTypes[i]);
+            make_shared<ValueVector>(context->memoryManager, groupByKeyVectorDataTypes[i]);
         auto outDataChunk = resultSet->dataChunks[groupByKeyVectorsPos[i].dataChunkPos];
         outDataChunk->insert(groupByKeyVectorsPos[i].valueVectorPos, valueVector);
         groupByKeyVectors.push_back(valueVector);

--- a/src/processor/physical_plan/operator/exists.cpp
+++ b/src/processor/physical_plan/operator/exists.cpp
@@ -5,16 +5,16 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> Exists::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> Exists::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     auto dataChunkToWrite = resultSet->dataChunks[outDataPos.dataChunkPos].get();
-    valueVectorToWrite = make_shared<ValueVector>(context.memoryManager, BOOL);
+    valueVectorToWrite = make_shared<ValueVector>(context->memoryManager, BOOL);
     dataChunkToWrite->insert(outDataPos.valueVectorPos, valueVectorToWrite);
     // side way information passing: give resultSet reference to subPlan
     auto op = children[1]->getLeafOperator();
     assert(op->getOperatorType() == RESULT_SCAN);
     ((ResultScan*)op)->setResultSetToCopyFrom(resultSet.get());
-    children[1]->initResultSet();
+    children[1]->init(context);
     return resultSet;
 }
 

--- a/src/processor/physical_plan/operator/filter.cpp
+++ b/src/processor/physical_plan/operator/filter.cpp
@@ -3,9 +3,9 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> Filter::initResultSet() {
-    resultSet = children[0]->initResultSet();
-    expressionEvaluator->init(*resultSet, context.memoryManager);
+shared_ptr<ResultSet> Filter::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
+    expressionEvaluator->init(*resultSet, context->memoryManager);
     dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];
     return resultSet;
 }

--- a/src/processor/physical_plan/operator/flatten.cpp
+++ b/src/processor/physical_plan/operator/flatten.cpp
@@ -3,8 +3,8 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> Flatten::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> Flatten::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     dataChunkToFlatten = resultSet->dataChunks[dataChunkToFlattenPos];
     return resultSet;
 }

--- a/src/processor/physical_plan/operator/intersect.cpp
+++ b/src/processor/physical_plan/operator/intersect.cpp
@@ -5,8 +5,8 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> Intersect::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> Intersect::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     leftDataChunk = resultSet->dataChunks[leftDataPos.dataChunkPos];
     leftValueVector = leftDataChunk->valueVectors[leftDataPos.valueVectorPos];
     rightDataChunk = resultSet->dataChunks[rightDataPos.dataChunkPos];

--- a/src/processor/physical_plan/operator/left_nested_loop_join.cpp
+++ b/src/processor/physical_plan/operator/left_nested_loop_join.cpp
@@ -5,13 +5,13 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> LeftNestedLoopJoin::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> LeftNestedLoopJoin::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     // side way information passing: give resultSet reference to subPlan.
     PhysicalOperator* op = children[1]->getLeafOperator();
     assert(op->getOperatorType() == RESULT_SCAN);
     ((ResultScan*)op)->setResultSetToCopyFrom(resultSet.get());
-    auto subPlanResultSet = children[1]->initResultSet();
+    auto subPlanResultSet = children[1]->init(context);
     // mering sub-plan result set into current result set.
     for (auto& posMapping : subPlanVectorsToRefPosMapping) {
         auto [dataChunkToRefPos, vectorToRefPos] = posMapping.first;

--- a/src/processor/physical_plan/operator/limit.cpp
+++ b/src/processor/physical_plan/operator/limit.cpp
@@ -3,11 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> Limit::initResultSet() {
-    resultSet = children[0]->initResultSet();
-    return resultSet;
-}
-
 bool Limit::getNextTuples() {
     metrics->executionTime.start();
     // end of execution due to no more input

--- a/src/processor/physical_plan/operator/multiplicity_reducer.cpp
+++ b/src/processor/physical_plan/operator/multiplicity_reducer.cpp
@@ -3,11 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> MultiplicityReducer::initResultSet() {
-    resultSet = children[0]->initResultSet();
-    return resultSet;
-}
-
 void MultiplicityReducer::reInitToRerunSubPlan() {
     children[0]->reInitToRerunSubPlan();
     prevMultiplicity = 1;

--- a/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
@@ -12,13 +12,14 @@ pair<uint64_t, uint64_t> OrderByScan::getNextFactorizedTableIdxAndTupleIdxPair()
     return make_pair(factorizedTableIdx, tupleIdx);
 }
 
-shared_ptr<ResultSet> OrderByScan::initResultSet() {
+shared_ptr<ResultSet> OrderByScan::init(ExecutionContext* context) {
+    PhysicalOperator::init(context);
     resultSet = populateResultSet();
     for (auto i = 0u; i < outDataPoses.size(); i++) {
         auto outDataPos = outDataPoses[i];
         auto outDataChunk = resultSet->dataChunks[outDataPos.dataChunkPos];
         auto valueVector =
-            make_shared<ValueVector>(context.memoryManager, sharedState->getDataType(i));
+            make_shared<ValueVector>(context->memoryManager, sharedState->getDataType(i));
         outDataChunk->insert(outDataPos.valueVectorPos, valueVector);
         vectorsToRead.emplace_back(valueVector);
     }
@@ -55,7 +56,6 @@ bool OrderByScan::getNextTuples() {
                 metrics->numOutputTuple.increase(1);
             }
         }
-
         metrics->executionTime.stop();
         return true;
     }

--- a/src/processor/physical_plan/operator/projection.cpp
+++ b/src/processor/physical_plan/operator/projection.cpp
@@ -3,20 +3,16 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> Projection::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> Projection::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     for (auto i = 0u; i < expressionEvaluators.size(); ++i) {
         auto& expressionEvaluator = *expressionEvaluators[i];
-        expressionEvaluator.init(*resultSet, context.memoryManager);
+        expressionEvaluator.init(*resultSet, context->memoryManager);
         auto [outDataChunkPos, outValueVectorPos] = expressionsOutputPos[i];
         auto dataChunk = resultSet->dataChunks[outDataChunkPos];
         dataChunk->valueVectors[outValueVectorPos] = expressionEvaluator.resultVector;
     }
     return resultSet;
-}
-
-void Projection::reInitToRerunSubPlan() {
-    children[0]->reInitToRerunSubPlan();
 }
 
 bool Projection::getNextTuples() {
@@ -44,7 +40,7 @@ unique_ptr<PhysicalOperator> Projection::clone() {
         rootExpressionsCloned.push_back(expressionEvaluator->clone());
     }
     return make_unique<Projection>(move(rootExpressionsCloned), expressionsOutputPos,
-        discardedDataChunksPos, children[0]->clone(), context, id);
+        discardedDataChunksPos, children[0]->clone(), id);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -3,9 +3,9 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> AdjListExtend::initResultSet() {
-    ReadList::initResultSet();
-    outValueVector = make_shared<ValueVector>(context.memoryManager, NODE);
+shared_ptr<ResultSet> AdjListExtend::init(ExecutionContext* context) {
+    resultSet = ReadList::init(context);
+    outValueVector = make_shared<ValueVector>(context->memoryManager, NODE);
     outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
     auto listSyncState = make_shared<ListSyncState>();
     resultSet->insert(outDataPos.dataChunkPos, listSyncState);

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -3,8 +3,8 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> ReadList::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> ReadList::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     inDataChunk = resultSet->dataChunks[inDataPos.dataChunkPos];
     inValueVector = inDataChunk->valueVectors[inDataPos.valueVectorPos];
     outDataChunk = resultSet->dataChunks[outDataPos.dataChunkPos];
@@ -14,10 +14,6 @@ shared_ptr<ResultSet> ReadList::initResultSet() {
 void ReadList::reInitToRerunSubPlan() {
     largeListHandle->reset();
     children[0]->reInitToRerunSubPlan();
-}
-
-void ReadList::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
-    PhysicalOperator::printTimeAndNumOutputMetrics(json, profiler);
 }
 
 void ReadList::readValuesFromList() {

--- a/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_rel_property_list.cpp
@@ -3,9 +3,9 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> ReadRelPropertyList::initResultSet() {
-    ReadList::initResultSet();
-    outValueVector = make_shared<ValueVector>(context.memoryManager, lists->dataType);
+shared_ptr<ResultSet> ReadRelPropertyList::init(ExecutionContext* context) {
+    resultSet = ReadList::init(context);
+    outValueVector = make_shared<ValueVector>(context->memoryManager, lists->dataType);
     outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
     largeListHandle->setListSyncState(resultSet->getListSyncState(outDataPos.dataChunkPos));
     return resultSet;

--- a/src/processor/physical_plan/operator/result_scan.cpp
+++ b/src/processor/physical_plan/operator/result_scan.cpp
@@ -5,7 +5,8 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> ResultScan::initResultSet() {
+shared_ptr<ResultSet> ResultScan::init(ExecutionContext* context) {
+    PhysicalOperator::init(context);
     resultSet = populateResultSet();
     outDataChunk = resultSet->dataChunks[outDataChunkPos];
     for (auto i = 0u; i < inDataPoses.size(); ++i) {
@@ -13,7 +14,7 @@ shared_ptr<ResultSet> ResultScan::initResultSet() {
         auto& inValueVector =
             *resultSetToCopyFrom->dataChunks[inDataChunkPos]->valueVectors[inValueVectorPos];
         auto outValueVector =
-            make_shared<ValueVector>(context.memoryManager, inValueVector.dataType);
+            make_shared<ValueVector>(context->memoryManager, inValueVector.dataType);
         outDataChunk->insert(outValueVectorsPos[i], outValueVector);
     }
     return resultSet;

--- a/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
@@ -3,9 +3,9 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> AdjColumnExtend::initResultSet() {
-    BaseScanColumn::initResultSet();
-    outputVector = make_shared<ValueVector>(context.memoryManager, NODE);
+shared_ptr<ResultSet> AdjColumnExtend::init(ExecutionContext* context) {
+    resultSet = BaseScanColumn::init(context);
+    outputVector = make_shared<ValueVector>(context->memoryManager, NODE);
     inputNodeIDDataChunk->insert(outputVectorPos.valueVectorPos, outputVector);
     return resultSet;
 }

--- a/src/processor/physical_plan/operator/scan_column/scan_column.cpp
+++ b/src/processor/physical_plan/operator/scan_column/scan_column.cpp
@@ -3,19 +3,11 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> BaseScanColumn::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> BaseScanColumn::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     inputNodeIDDataChunk = resultSet->dataChunks[inputNodeIDVectorPos.dataChunkPos];
     inputNodeIDVector = inputNodeIDDataChunk->valueVectors[inputNodeIDVectorPos.valueVectorPos];
     return resultSet;
-}
-
-void BaseScanColumn::reInitToRerunSubPlan() {
-    children[0]->reInitToRerunSubPlan();
-}
-
-void BaseScanColumn::printMetricsToJson(nlohmann::json& json, Profiler& profiler) {
-    PhysicalOperator::printMetricsToJson(json, profiler);
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/scan_column/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_column/scan_structured_property.cpp
@@ -5,11 +5,12 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> ScanStructuredProperty::initResultSet() {
-    resultSet = BaseScanColumn::initResultSet();
+shared_ptr<ResultSet> ScanStructuredProperty::init(ExecutionContext* context) {
+    resultSet = BaseScanColumn::init(context);
     assert(outputVectorsPos.size() == propertyColumns.size());
     for (auto i = 0u; i < propertyColumns.size(); ++i) {
-        auto vector = make_shared<ValueVector>(context.memoryManager, propertyColumns[i]->dataType);
+        auto vector =
+            make_shared<ValueVector>(context->memoryManager, propertyColumns[i]->dataType);
         inputNodeIDDataChunk->insert(outputVectorsPos[i].valueVectorPos, vector);
         outputVectors.push_back(vector);
     }

--- a/src/processor/physical_plan/operator/scan_column/scan_unstructured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_column/scan_unstructured_property.cpp
@@ -5,11 +5,11 @@ using namespace graphflow::common;
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> ScanUnstructuredProperty::initResultSet() {
-    resultSet = BaseScanColumn::initResultSet();
+shared_ptr<ResultSet> ScanUnstructuredProperty::init(ExecutionContext* context) {
+    resultSet = BaseScanColumn::init(context);
     for (auto i = 0u; i < outputVectorsPos.size(); ++i) {
         assert(unstructuredPropertyLists->getDataTypeId() == UNSTRUCTURED);
-        auto vector = make_shared<ValueVector>(context.memoryManager, UNSTRUCTURED);
+        auto vector = make_shared<ValueVector>(context->memoryManager, UNSTRUCTURED);
         inputNodeIDDataChunk->insert(outputVectorsPos[i].valueVectorPos, vector);
         outputVectors.push_back(vector);
         propertyKeyToResultVectorMap.insert({propertyKeys[i], vector.get()});

--- a/src/processor/physical_plan/operator/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id.cpp
@@ -14,10 +14,11 @@ pair<uint64_t, uint64_t> ScanNodeIDSharedState::getNextRangeToRead() {
     return make_pair(startOffset, startOffset + range);
 }
 
-shared_ptr<ResultSet> ScanNodeID::initResultSet() {
+shared_ptr<ResultSet> ScanNodeID::init(ExecutionContext* context) {
+    PhysicalOperator::init(context);
     resultSet = populateResultSet();
     outDataChunk = resultSet->dataChunks[outDataPos.dataChunkPos];
-    outValueVector = make_shared<ValueVector>(context.memoryManager, NODE);
+    outValueVector = make_shared<ValueVector>(context->memoryManager, NODE);
     outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
     return resultSet;
 }

--- a/src/processor/physical_plan/operator/skip.cpp
+++ b/src/processor/physical_plan/operator/skip.cpp
@@ -3,11 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-shared_ptr<ResultSet> Skip::initResultSet() {
-    resultSet = children[0]->initResultSet();
-    return resultSet;
-}
-
 bool Skip::getNextTuples() {
     metrics->executionTime.start();
     auto& dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];

--- a/src/processor/physical_plan/operator/union_all_scan.cpp
+++ b/src/processor/physical_plan/operator/union_all_scan.cpp
@@ -25,12 +25,13 @@ unique_ptr<UnionAllScanMorsel> UnionAllScanSharedState::getMorsel() {
     return unionAllScanMorsel;
 }
 
-shared_ptr<ResultSet> UnionAllScan::initResultSet() {
+shared_ptr<ResultSet> UnionAllScan::init(ExecutionContext* context) {
+    PhysicalOperator::init(context);
     resultSet = populateResultSet();
     for (auto i = 0u; i < outDataPoses.size(); i++) {
         auto outDataPos = outDataPoses[i];
         auto outDataChunk = resultSet->dataChunks[outDataPos.dataChunkPos];
-        auto valueVector = make_shared<ValueVector>(context.memoryManager, dataTypes[i]);
+        auto valueVector = make_shared<ValueVector>(context->memoryManager, dataTypes[i]);
         outDataChunk->insert(outDataPos.valueVectorPos, valueVector);
         vectorsToRead.push_back(valueVector);
     }

--- a/src/processor/physical_plan/operator/var_length_extend/var_length_adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/var_length_extend/var_length_adj_list_extend.cpp
@@ -25,14 +25,12 @@ void AdjListExtendDFSLevelInfo::reset(uint64_t parent_) {
     this->hasBeenOutput = false;
 }
 
-VarLengthAdjListExtend::VarLengthAdjListExtend(const DataPos& boundNodeDataPos,
-    const DataPos& nbrNodeDataPos, StorageStructure* adjLists, uint8_t lowerBound,
-    uint8_t upperBound, unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-    : VarLengthExtend(boundNodeDataPos, nbrNodeDataPos, adjLists, lowerBound, upperBound,
-          move(child), context, id) {
+shared_ptr<ResultSet> VarLengthAdjListExtend::init(ExecutionContext* context) {
+    resultSet = VarLengthExtend::init(context);
     for (uint8_t i = 0; i < upperBound; i++) {
-        dfsLevelInfos[i] = make_shared<AdjListExtendDFSLevelInfo>(i + 1, context);
+        dfsLevelInfos[i] = make_shared<AdjListExtendDFSLevelInfo>(i + 1, *context);
     }
+    return resultSet;
 }
 
 bool VarLengthAdjListExtend::getNextTuples() {

--- a/src/processor/physical_plan/operator/var_length_extend/var_length_extend.cpp
+++ b/src/processor/physical_plan/operator/var_length_extend/var_length_extend.cpp
@@ -5,18 +5,18 @@ namespace processor {
 
 VarLengthExtend::VarLengthExtend(const DataPos& boundNodeDataPos, const DataPos& nbrNodeDataPos,
     StorageStructure* storage, uint8_t lowerBound, uint8_t upperBound,
-    unique_ptr<PhysicalOperator> child, ExecutionContext& context, uint32_t id)
-    : PhysicalOperator{move(child), context, id}, boundNodeDataPos{boundNodeDataPos},
+    unique_ptr<PhysicalOperator> child, uint32_t id)
+    : PhysicalOperator{move(child), id}, boundNodeDataPos{boundNodeDataPos},
       nbrNodeDataPos{nbrNodeDataPos}, storage{storage}, lowerBound{lowerBound}, upperBound{
                                                                                     upperBound} {
     dfsLevelInfos.resize(upperBound);
 }
 
-shared_ptr<ResultSet> VarLengthExtend::initResultSet() {
-    resultSet = children[0]->initResultSet();
+shared_ptr<ResultSet> VarLengthExtend::init(ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
     boundNodeValueVector = resultSet->dataChunks[boundNodeDataPos.dataChunkPos]
                                ->valueVectors[boundNodeDataPos.valueVectorPos];
-    nbrNodeValueVector = make_shared<ValueVector>(context.memoryManager, NODE);
+    nbrNodeValueVector = make_shared<ValueVector>(context->memoryManager, NODE);
     resultSet->dataChunks[nbrNodeDataPos.dataChunkPos]->insert(
         nbrNodeDataPos.valueVectorPos, nbrNodeValueVector);
     return resultSet;

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -15,59 +15,59 @@ QueryProcessor::QueryProcessor(uint64_t numThreads) {
 }
 
 shared_ptr<FactorizedTable> QueryProcessor::execute(
-    PhysicalPlan* physicalPlan, uint64_t numThreads) {
+    PhysicalPlan* physicalPlan, ExecutionContext* context) {
     auto lastOperator = physicalPlan->lastOperator.get();
     auto resultCollector = reinterpret_cast<ResultCollector*>(lastOperator);
     // The root pipeline(task) consists of operators and its prevOperator only, because we
     // expect to have linear plans. For binary operators, e.g., HashJoin, we  keep probe and its
     // prevOperator in the same pipeline, and decompose build and its prevOperator into another one.
-    auto task = make_shared<ProcessorTask>(resultCollector, numThreads);
-    decomposePlanIntoTasks(lastOperator, lastOperator, task.get(), numThreads);
+    auto task = make_shared<ProcessorTask>(resultCollector, context);
+    decomposePlanIntoTasks(lastOperator, lastOperator, task.get(), context);
     taskScheduler->scheduleTaskAndWaitOrError(task);
     return resultCollector->getResultFactorizedTable();
 }
 
 void QueryProcessor::decomposePlanIntoTasks(
-    PhysicalOperator* op, PhysicalOperator* parent, Task* parentTask, uint64_t numThreads) {
+    PhysicalOperator* op, PhysicalOperator* parent, Task* parentTask, ExecutionContext* context) {
     switch (op->getOperatorType()) {
     case RESULT_COLLECTOR: {
         if (parent->getOperatorType() == UNION_ALL_SCAN) {
             // Only breaks the pipeline if the parent operator is a UNION_ALL_SCAN.
-            auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), numThreads);
-            decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), numThreads);
+            auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), context);
+            decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), context);
             parentTask->addChildTask(move(childTask));
         } else {
-            decomposePlanIntoTasks(op->getChild(0), op, parentTask, numThreads);
+            decomposePlanIntoTasks(op->getChild(0), op, parentTask, context);
         }
     } break;
     case ORDER_BY_MERGE: {
-        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), numThreads);
-        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), numThreads);
+        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), context);
+        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), context);
         parentTask->addChildTask(move(childTask));
         parentTask->setSingleThreadedTask();
     } break;
     case ORDER_BY: {
-        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), numThreads);
-        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), numThreads);
+        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), context);
+        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), context);
         parentTask->addChildTask(move(childTask));
     } break;
     case HASH_JOIN_BUILD: {
-        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), numThreads);
-        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), numThreads);
+        auto childTask = make_unique<ProcessorTask>(reinterpret_cast<Sink*>(op), context);
+        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), context);
         parentTask->addChildTask(move(childTask));
     } break;
     case AGGREGATE: {
         auto aggregate = (BaseAggregate*)op;
-        auto childTask = make_unique<ProcessorTask>(aggregate, numThreads);
+        auto childTask = make_unique<ProcessorTask>(aggregate, context);
         if (aggregate->containDistinctAggregate()) {
             childTask->setSingleThreadedTask();
         }
-        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), numThreads);
+        decomposePlanIntoTasks(op->getChild(0), op, childTask.get(), context);
         parentTask->addChildTask(move(childTask));
     } break;
     default: {
         for (auto i = 0u; i < op->getNumChildren(); i++) {
-            decomposePlanIntoTasks(op->getChild(i), op, parentTask, numThreads);
+            decomposePlanIntoTasks(op->getChild(i), op, parentTask, context);
         }
     } break;
     }

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -3,9 +3,6 @@
 namespace graphflow {
 namespace processor {
 
-ProcessorTask::ProcessorTask(Sink* sinkOp, uint64_t maxNumThreads)
-    : Task{maxNumThreads}, sinkOp{sinkOp} {}
-
 void ProcessorTask::run() {
     // We need the lock when cloning because multiple threads can be accessing to clone,
     // which is not thread safe
@@ -13,11 +10,11 @@ void ProcessorTask::run() {
     unique_ptr<PhysicalOperator> lastOp = sinkOp->clone();
     lck.unlock();
     auto& sink = (Sink&)*lastOp;
-    sink.execute();
+    sink.execute(executionContext);
 }
 
 void ProcessorTask::finalizeIfNecessary() {
-    sinkOp->finalize();
+    sinkOp->finalize(executionContext);
 }
 
 } // namespace processor


### PR DESCRIPTION
This PR adds transaction pointer into execution context. To do so, we remove execution context from physical operator constructor and instead give as a parameter in `execute()`, `finalize()` and `init()` interface. 

## Minor change
Make profiler thread safe.

## For reviewers
- processor .h/.cpp
- processor_task .h/.cpp
- connection .h/.cpp
- physical_operator.h (also check one of the sink operator e.g. result_collector.cpp)