### PR TITLE
Hash index concurrent insertions

### DIFF
--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -133,8 +133,8 @@ cc_library(
     deps = [
         "storage_structure",
         "wal",
-        "//src/catalog:catalog",
-        "//src/transaction:transaction",
+        "//src/catalog",
+        "//src/transaction",
     ],
 )
 
@@ -178,9 +178,11 @@ cc_library(
     name = "hash_index",
     srcs = [
         "index/hash_index.cpp",
+        "index/hash_index_utils.cpp",
     ],
     hdrs = [
         "include/index/hash_index.h",
+        "include/index/hash_index_utils.h",
     ],
     visibility = ["//visibility:public"],
     deps = [
@@ -196,12 +198,12 @@ cc_library(
     name = "wal",
     srcs = [
         "wal/wal.cpp",
-        "wal/wal_record.cpp"
-        ],
+        "wal/wal_record.cpp",
+    ],
     hdrs = [
         "include/wal/wal.h",
-        "include/wal/wal_record.h"
-        ],
+        "include/wal/wal_record.h",
+    ],
     visibility = [
         "//visibility:public",
     ],

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -58,7 +58,7 @@ uint8_t* BufferManager::pinWithoutReadingFromFile(FileHandle& fileHandle, uint32
 }
 
 // Important Note: The caller should make sure that they have pinned the page before calling this.
-const void BufferManager::setPinnedPageDirty(FileHandle& fileHandle, uint32_t pageIdx) {
+void BufferManager::setPinnedPageDirty(FileHandle& fileHandle, uint32_t pageIdx) {
     fileHandle.isLargePaged() ? bufferPoolLargePages->setPinnedPageDirty(fileHandle, pageIdx) :
                                 bufferPoolDefaultPages->setPinnedPageDirty(fileHandle, pageIdx);
 }
@@ -68,10 +68,11 @@ void BufferManager::unpin(FileHandle& fileHandle, uint32_t pageIdx) {
                                        bufferPoolDefaultPages->unpin(fileHandle, pageIdx);
 }
 
-void BufferManager::removeFilePagesFromFrames(FileHandle& fileHandle) {
+void BufferManager::removeOrFlushPagesFromFrames(FileHandle& fileHandle, bool isRemovingPages) {
     return fileHandle.isLargePaged() ?
-               bufferPoolLargePages->removeFilePagesFromFrames(fileHandle) :
-               bufferPoolDefaultPages->removeFilePagesFromFrames(fileHandle);
+               bufferPoolLargePages->removeOrFlushFilePagesFromFrames(fileHandle, isRemovingPages) :
+               bufferPoolDefaultPages->removeOrFlushFilePagesFromFrames(
+                   fileHandle, isRemovingPages);
 }
 
 unique_ptr<nlohmann::json> BufferManager::debugInfo() {

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -29,8 +29,8 @@ FileHandle::~FileHandle() {
 }
 
 void FileHandle::constructExistingFileHandle(const string& path) {
-    int flags = O_RDWR | ((createFileIfNotExists()) ? O_CREAT : 0x00000000);
-    fileInfo = FileUtils::openFile(path, flags);
+    int openFlags = O_RDWR | ((createFileIfNotExists()) ? O_CREAT : 0x00000000);
+    fileInfo = FileUtils::openFile(path, openFlags);
     auto fileLength = FileUtils::getFileSize(fileInfo->fd);
     numPages = fileLength >> getPageSizeLog2();
     logger->trace("FileHandle[disk]: Size {}B, #{}B-pages {}", fileLength, getPageSize(), numPages);

--- a/src/storage/include/buffer_manager.h
+++ b/src/storage/include/buffer_manager.h
@@ -70,7 +70,7 @@ public:
     // from disk
     uint8_t* pinWithoutReadingFromFile(FileHandle& fileHandle, uint32_t pageIdx);
 
-    const void setPinnedPageDirty(FileHandle& fileHandle, uint32_t pageIdx);
+    void setPinnedPageDirty(FileHandle& fileHandle, uint32_t pageIdx);
 
     // The function assumes that the requested page is already pinned.
     void unpin(FileHandle& fileHandle, uint32_t pageIdx);
@@ -79,7 +79,7 @@ public:
 
     void resize(uint64_t newSizeForDefaultPagePool, uint64_t newSizeForLargePagePool);
 
-    void removeFilePagesFromFrames(FileHandle& fileHandle);
+    void removeOrFlushPagesFromFrames(FileHandle& fileHandle, bool isRemovingPages);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/include/file_handle.h
+++ b/src/storage/include/file_handle.h
@@ -35,7 +35,6 @@ public:
 
     constexpr static uint8_t O_DefaultPagedExistingDBFileDoNotCreate{0b0000'0000};
     constexpr static uint8_t O_DefaultPagedExistingDBFileCreateIfNotExists{0b0000'0100};
-    constexpr static uint8_t O_LargePageExistingDBFileDoNotCreate{0b0000'0001};
     constexpr static uint8_t O_LargePagedInMemoryTmpFile{0b0000'0011};
 
     explicit FileHandle(const string& path, uint8_t flags);
@@ -76,14 +75,12 @@ public:
     inline bool createFileIfNotExists() const { return flags & createIfNotExistsMask; }
     inline uint32_t getNumPages() const { return numPages; }
     static inline bool isAFrame(uint64_t mappedFrameIdx) { return UINT64_MAX != mappedFrameIdx; }
+    inline FileInfo* getFileInfo() const { return fileInfo.get(); }
 
-    // This function is public for tests
     inline uint64_t getFrameIdx(uint32_t pageIdx) {
         shared_lock lock(fhSharedMutex);
         return pageIdxToFrameMap[pageIdx]->load();
     }
-
-    inline uint32_t getNumPages() { return numPages; }
 
 private:
     void initPageIdxToFrameMapAndLocks();
@@ -129,7 +126,7 @@ private:
     uint32_t numPages;
     // This is the maximum number of pages the filehandle can currently support.
     uint32_t pageCapacity;
-    // Intended to be used as a read/write lock
+    // Intended to be used as a read/write lock.
     shared_mutex fhSharedMutex;
 };
 

--- a/src/storage/include/index/hash_index_utils.h
+++ b/src/storage/include/index/hash_index_utils.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <functional>
+
+#include "src/function/hash/operations/include/hash_operations.h"
+#include "src/loader/include/in_mem_structure/in_mem_pages.h"
+#include "src/storage/include/storage_structure/overflow_pages.h"
+
+using namespace graphflow::common;
+using namespace graphflow::loader;
+
+namespace graphflow {
+namespace storage {
+
+using hash_function_t = std::function<hash_t(const uint8_t*)>;
+using insert_function_t =
+    std::function<void(const uint8_t*, uint8_t*, InMemOverflowPages*, PageByteCursor*)>;
+using equals_in_write_function_t =
+    std::function<bool(const uint8_t*, const uint8_t*, const InMemOverflowPages*)>;
+using equals_in_read_function_t =
+    std::function<bool(const uint8_t*, const uint8_t*, OverflowPages*)>;
+
+class HashIndexUtils {
+
+public:
+    // HashFunc
+    inline static hash_t hashFuncForInt64(const uint8_t* key) {
+        hash_t hash;
+        function::operation::Hash::operation(*(int64_t*)key, hash);
+        return hash;
+    }
+    inline static hash_t hashFuncForString(const uint8_t* key) {
+        hash_t hash;
+        function::operation::Hash::operation(string((char*)key), hash);
+        return hash;
+    }
+    static hash_function_t initializeHashFunc(const DataTypeID& dataTypeID);
+    // InsertFunc
+    inline static void insertInt64KeyToEntryFunc(const uint8_t* key, uint8_t* entry,
+        InMemOverflowPages* overflowPages = nullptr, PageByteCursor* overflowCursor = nullptr) {
+        memcpy(entry, key, Types::getDataTypeSize(INT64));
+    }
+    inline static void insertStringKeyToEntryFunc(const uint8_t* key, uint8_t* entry,
+        InMemOverflowPages* overflowPages, PageByteCursor* overflowCursor) {
+        auto gfString =
+            overflowPages->addString(reinterpret_cast<const char*>(key), *overflowCursor);
+        memcpy(entry, &gfString, Types::getDataTypeSize(STRING));
+    }
+    static insert_function_t initializeInsertKeyToEntryFunc(const DataTypeID& dataTypeID);
+    // This function checks if the prefix and length are the same.
+    static bool isStringPrefixAndLenEquals(
+        const uint8_t* keyToLookup, const gf_string_t* keyInEntry);
+    // equalsFuncInWrite: used in the WRITE_MODE, when performing insertions.
+    inline static bool equalsFuncInWriteModeForInt64(const uint8_t* keyToLookup,
+        const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages) {
+        return memcmp(keyToLookup, keyInEntry, sizeof(int64_t)) == 0;
+    }
+    static bool equalsFuncInWriteModeForString(const uint8_t* keyToLookup,
+        const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages);
+    static equals_in_write_function_t initializeEqualsFuncInWriteMode(const DataTypeID& dataTypeID);
+    // equalsFuncInRead: used in the READ_MODE, when performing lookups.
+    inline static bool equalsFuncInReadModeForInt64(
+        const uint8_t* keyToLookup, const uint8_t* keyInEntry, OverflowPages* ovfPages) {
+        return memcmp(keyToLookup, keyInEntry, sizeof(int64_t)) == 0;
+    }
+    static bool equalsFuncInReadModeForString(
+        const uint8_t* keyToLookup, const uint8_t* keyInEntry, OverflowPages* ovfPages);
+    static equals_in_read_function_t initializeEqualsFuncInReadMode(const DataTypeID& dataTypeID);
+};
+} // namespace storage
+} // namespace graphflow

--- a/src/storage/include/storage_structure/column.h
+++ b/src/storage/include/storage_structure/column.h
@@ -24,8 +24,8 @@ public:
         : StorageStructure{fName, property.dataType, elementSize, bufferManager,
               true /*hasNULLBytes*/, isInMemory},
           property{property},
-          nodeLabelForAdjColumnAndProperties{nodeLabelForAdjColumnAndProperties}, wal{wal},
-          pageVersionInfo(fileHandle.getNumPages()){};
+          nodeLabelForAdjColumnAndProperties{nodeLabelForAdjColumnAndProperties},
+          pageVersionInfo(fileHandle.getNumPages()), wal{wal} {};
 
     Column(const string& fName, const Property property, const label_t nodeLabel,
         BufferManager& bufferManager, bool isInMemory, WAL* wal)

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -5,10 +5,11 @@ using namespace std;
 namespace graphflow {
 namespace storage {
 
-HashIndexHeader::HashIndexHeader(DataType keyDataType) : keyDataType{move(keyDataType)} {
-    numBytesPerEntry = Types::getDataTypeSize(this->keyDataType) + sizeof(node_offset_t);
-    numBytesPerSlot = (numBytesPerEntry * slotCapacity) + sizeof(SlotHeader);
-    numSlotsPerPage = LARGE_PAGE_SIZE / numBytesPerSlot;
+HashIndexHeader::HashIndexHeader(DataTypeID keyDataTypeID) : keyDataTypeID{keyDataTypeID} {
+    numBytesPerEntry = Types::getDataTypeSize(this->keyDataTypeID) + sizeof(node_offset_t);
+    numBytesPerSlot = (numBytesPerEntry * HashIndexConfig::SLOT_CAPACITY) + sizeof(SlotHeader);
+    assert(numBytesPerSlot < DEFAULT_PAGE_SIZE);
+    numSlotsPerPage = DEFAULT_PAGE_SIZE / numBytesPerSlot;
 }
 
 void HashIndexHeader::incrementLevel() {
@@ -17,313 +18,306 @@ void HashIndexHeader::incrementLevel() {
     higherLevelHashMask = (1 << (currentLevel + 1)) - 1;
 }
 
-hash_function_t HashIndex::initializeHashFunc(const DataType& dataType) {
-    switch (dataType.typeID) {
-    case INT64:
-        return hashFuncForInt64;
-    case STRING:
-        return hashFuncForString;
-    default:
-        throw StorageException("Type " + Types::dataTypeToString(dataType) + " not supported.");
-    }
-}
-
-insert_function_t HashIndex::initializeInsertKeyToEntryFunc(const DataType& dataType) {
-    switch (dataType.typeID) {
-    case INT64:
-        return insertInt64KeyToEntryFunc;
-    case STRING:
-        return insertStringKeyToEntryFunc;
-    default:
-        throw StorageException(
-            "Hash index insertion not defined for dataType other than INT64 and STRING.");
-    }
-}
-
-bool HashIndex::isStringPrefixAndLenEquals(
-    const uint8_t* keyToLookup, const gf_string_t* keyInEntry) {
-    if (memcmp(keyToLookup, keyInEntry->prefix, gf_string_t::PREFIX_LENGTH) != 0) {
-        return false;
-    }
-    if (strlen(reinterpret_cast<const char*>(keyToLookup)) != keyInEntry->len) {
-        return false;
-    }
-    return true;
-}
-
-bool HashIndex::equalsFuncInWriteModeForString(const uint8_t* keyToLookup,
-    const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages) {
-    auto gfStringInEntry = (gf_string_t*)keyInEntry;
-    // Checks if prefix and len matches first.
-    if (!isStringPrefixAndLenEquals(keyToLookup, gfStringInEntry)) {
-        return false;
-    }
-    if (gfStringInEntry->len <= gf_string_t::PREFIX_LENGTH) {
-        // For strings shorter than PREFIX_LENGTH, the result must be true.
-        return true;
-    } else if (gfStringInEntry->len <= gf_string_t::SHORT_STR_LENGTH) {
-        // For short strings, whose lengths are larger than PREFIX_LENGTH, check if their actual
-        // values are equal.
-        return memcmp(keyToLookup, gfStringInEntry->prefix, gfStringInEntry->len) == 0;
-    } else {
-        // For long strings, read overflow values and check if they are true.
-        PageByteCursor cursor;
-        TypeUtils::decodeOverflowPtr(gfStringInEntry->overflowPtr, cursor.idx, cursor.offset);
-        return memcmp(keyToLookup, overflowPages->pages[cursor.idx]->data + cursor.offset,
-                   gfStringInEntry->len) == 0;
-    }
-}
-
-equals_in_write_function_t HashIndex::initializeEqualsFuncInWriteMode(const DataType& dataType) {
-    switch (dataType.typeID) {
-    case INT64:
-        return equalsFuncInWriteModeForInt64;
-    case STRING:
-        return equalsFuncInWriteModeForString;
-    default:
-        throw StorageException(
-            "Hash index equals is not supported for dataType other than INT64 and STRING.");
-    }
-}
-
-bool HashIndex::equalsFuncInReadModeForString(
-    const uint8_t* keyToLookup, const uint8_t* keyInEntry, OverflowPages* overflowPages) {
-    auto keyInEntryString = (gf_string_t*)keyInEntry;
-    if (isStringPrefixAndLenEquals(keyToLookup, keyInEntryString)) {
-        auto entryKeyString = overflowPages->readString(*keyInEntryString);
-        return memcmp(keyToLookup, entryKeyString.c_str(), entryKeyString.length()) == 0;
-    }
-    return false;
-}
-
-equals_in_read_function_t HashIndex::initializeEqualsFuncInReadMode(const DataType& dataType) {
-    switch (dataType.typeID) {
-    case INT64:
-        return equalsFuncInReadModeForInt64;
-    case STRING:
-        return equalsFuncInReadModeForString;
-    default:
-        throw StorageException(
-            "Hash index equals is not supported for dataType other than INT64 and STRING.");
-    }
-}
-
-// Opens the hash index in the write-mode that can only do insertions. Lookups in this mode are
-// undefined.
-HashIndex::HashIndex(const string& fName, DataType keyDataType, MemoryManager* memoryManager)
-    : fName{fName}, indexMode{WRITE_ONLY}, indexHeader{move(keyDataType)}, memoryManager{
-                                                                               memoryManager} {
-    assert(memoryManager != nullptr &&
-           (indexHeader.keyDataType.typeID == INT64 || indexHeader.keyDataType.typeID == STRING));
-    keyHashFunc = initializeHashFunc(indexHeader.keyDataType);
-    insertKeyToEntryFunc = initializeInsertKeyToEntryFunc(indexHeader.keyDataType);
-    equalsFuncInWrite = initializeEqualsFuncInWriteMode(indexHeader.keyDataType);
-    // When the Hash index is initialized without the BufferManager, it is opened for only writing.
-    // The default for this configuration, has 2 slots and a single primary page.
-    primaryPages.reserve(1);
-    primaryPages.emplace_back(memoryManager->allocateBlock(true));
-    // We intend ovfPages to start dispensing slots from ovfSlotId 1 because default values of
-    // ovfSlotId in slot headers is 0 which we reserve for null.
-    ovfPages.reserve(1);
-    ovfPages.emplace_back(memoryManager->allocateBlock(true));
-    if (indexHeader.keyDataType.typeID == STRING) {
-        inMemStringOvfPages =
-            make_unique<InMemOverflowPages>(OverflowPages::getOverflowPagesFName(fName));
-    }
-}
-
-// Opens the hash index in the read-mode that can only be used for the lookups. Insertions in this
-// mode are undefined.
-HashIndex::HashIndex(const string& fName, BufferManager* bufferManager, bool isInMemory)
-    : fName{fName}, indexMode{READ_ONLY}, bufferManager{bufferManager} {
-    assert(bufferManager != nullptr);
-    fileHandle = make_unique<FileHandle>(fName, FileHandle::O_LargePageExistingDBFileDoNotCreate);
-    auto buffer = bufferManager->pin(*fileHandle, 0);
-    indexHeader = *((HashIndexHeader*)buffer);
-    bufferManager->unpin(*fileHandle, 0);
-    keyHashFunc = initializeHashFunc(indexHeader.keyDataType);
-    equalsFuncInRead = initializeEqualsFuncInReadMode(indexHeader.keyDataType);
-    if (indexHeader.keyDataType.typeID == STRING) {
-        stringOvfPages = make_unique<OverflowPages>(fName, *bufferManager, isInMemory);
-    }
+HashIndex::HashIndex(
+    string fName, const DataType& keyDataType, BufferManager& bufferManager, bool isInMemory)
+    : fName{move(fName)}, bm{bufferManager} {
+    assert(keyDataType.typeID == INT64 || keyDataType.typeID == STRING);
+    fh = make_unique<FileHandle>(
+        this->fName, FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
+    initializeHeaderAndPages(keyDataType, isInMemory);
+    // Initialize functions.
+    keyHashFunc = HashIndexUtils::initializeHashFunc(indexHeader->keyDataTypeID);
+    insertKeyToEntryFunc =
+        HashIndexUtils::initializeInsertKeyToEntryFunc(indexHeader->keyDataTypeID);
+    equalsFuncInWrite = HashIndexUtils::initializeEqualsFuncInWriteMode(indexHeader->keyDataTypeID);
+    equalsFuncInRead = HashIndexUtils::initializeEqualsFuncInReadMode(indexHeader->keyDataTypeID);
 }
 
 HashIndex::~HashIndex() {
-    if (indexMode == WRITE_ONLY) {
-        memoryManager->freeBlock(0);
-        for (auto& page : primaryPages) {
-            memoryManager->freeBlock(page->pageIdx);
+    bm.removeOrFlushPagesFromFrames(*fh, false /* isRemovingPages */);
+}
+
+void HashIndex::initializeHeaderAndPages(const DataType& keyDataType, bool isInMemory) {
+    if (fh->getNumPages() == 0) {
+        indexHeader = make_unique<HashIndexHeader>(keyDataType.typeID);
+        // Allocate the index header page, which is always the first page in the index file.
+        auto headerPageIdx = fh->addNewPage();
+        assert(headerPageIdx == INDEX_HEADER_PAGE_ID);
+        // Allocate the first primary page.
+        allocateAndCachePageWithoutLock(true /* isPrimary */);
+        // Initialize mutexes for initial primary slots.
+        primarySlotMutexes.resize(1 << indexHeader->currentLevel);
+        for (auto i = 0u; i < (1 << indexHeader->currentLevel); i++) {
+            primarySlotMutexes[i] = make_unique<mutex>();
         }
-        for (auto& page : ovfPages) {
-            memoryManager->freeBlock(page->pageIdx);
-        }
+        inMemStringOvfPages =
+            indexHeader->keyDataTypeID == STRING ?
+                make_unique<InMemOverflowPages>(OverflowPages::getOverflowPagesFName(fName)) :
+                nullptr;
+    } else {
+        // Read the index header from file.
+        auto buffer = bm.pin(*fh, INDEX_HEADER_PAGE_ID);
+        indexHeader = make_unique<HashIndexHeader>(*(HashIndexHeader*)buffer);
+        bm.unpin(*fh, INDEX_HEADER_PAGE_ID);
+        assert(indexHeader->keyDataTypeID == keyDataType.typeID);
+        stringOvfPages = indexHeader->keyDataTypeID == STRING ?
+                             make_unique<OverflowPages>(fName, bm, isInMemory) :
+                             nullptr;
+        readLogicalToPhysicalPageMappings();
     }
 }
 
-void HashIndex::bulkReserve(uint32_t numEntries) {
-    // bulkReserve is only safe to be performed once and at the beginning.
-    assert(indexHeader.numEntries == 0);
-    assert(indexHeader.numPrimarySlots == 2);
-    auto capacity = (uint64_t)(numEntries * DEFAULT_HT_LOAD_FACTOR);
-    auto requiredNumSlots = capacity / indexHeader.slotCapacity;
-    if (capacity % indexHeader.slotCapacity != 0) {
+void HashIndex::bulkReserve(uint32_t numEntries_) {
+    // bulkReserve is only safe to be performed only once when the index is empty.
+    assert(indexHeader->numEntries == 0);
+    auto capacity = (uint64_t)(numEntries_ * DEFAULT_HT_LOAD_FACTOR);
+    auto requiredNumSlots = capacity / HashIndexConfig::SLOT_CAPACITY;
+    if (capacity % HashIndexConfig::SLOT_CAPACITY != 0) {
         requiredNumSlots++;
     }
     if (requiredNumSlots <= 2) {
         return;
     }
-    indexHeader.numPrimarySlots = requiredNumSlots;
-    auto lvlPower2 = 1 << indexHeader.currentLevel;
-    while (lvlPower2 * 2 < requiredNumSlots) {
-        indexHeader.incrementLevel();
+    auto lvlPower2 = 1 << indexHeader->currentLevel;
+    while ((lvlPower2 << 1) < requiredNumSlots) {
+        indexHeader->incrementLevel();
         lvlPower2 = lvlPower2 << 1;
     }
-    indexHeader.nextSplitSlotId = indexHeader.numPrimarySlots - lvlPower2;
-    indexHeader.numPrimaryPages = requiredNumSlots / indexHeader.numSlotsPerPage;
-    if (requiredNumSlots % indexHeader.numSlotsPerPage != 0) {
-        indexHeader.numPrimaryPages++;
+    indexHeader->nextSplitSlotId = requiredNumSlots - lvlPower2;
+    auto requiredNumPages = requiredNumSlots / indexHeader->numSlotsPerPage;
+    if (requiredNumSlots % indexHeader->numSlotsPerPage != 0) {
+        requiredNumPages++;
     }
-    // pre-allocate all pages.
-    // first page has already been allocated and page 0 is reserved.
-    for (auto i = 1; i < indexHeader.numPrimaryPages; i++) {
-        primaryPages.emplace_back(memoryManager->allocateBlock(true));
+    // Pre-allocate all pages. The first page has already been allocated and page 0 is reserved.
+    for (auto i = 1; i < requiredNumPages; i++) {
+        allocateAndCachePageWithoutLock(true /* isPrimary */);
+    }
+    auto previousNumSlots = primarySlotMutexes.size();
+    primarySlotMutexes.resize(requiredNumSlots);
+    for (auto i = previousNumSlots; i < requiredNumSlots; i++) {
+        primarySlotMutexes[i] = make_unique<mutex>();
     }
 }
 
 // First compute the hash, then check if key already exist, finally insert non-existing key.
 // For now, we don't support re-write of key. Existing key will not be inserted.
-// Return: true, insertion succeeds. false, insertion failed due to that the key already exists.
-bool HashIndex::insert(uint8_t* key, uint64_t value) {
-    auto slot = getSlotFromPrimaryPages(calculateSlotIdForHash(keyHashFunc(key)));
-    if (!notExistsInSlot(slot, key)) {
-        return false;
-    }
-    auto slotHeader = reinterpret_cast<SlotHeader*>(slot);
-    while (slotHeader->nextOvfSlotId != 0) {
-        slot = getOvfSlotFromOvfPages(slotHeader->nextOvfSlotId);
-        if (!notExistsInSlot(slot, key)) {
+// Return: true, insertion succeeds. false, insertion failed due to the key already existing.
+bool HashIndex::insertInternal(const uint8_t* key, uint64_t value) {
+    SlotInfo slotInfo{UINT32_MAX, true};
+    SlotInfo nextSlotInfo{UINT32_MAX, true};
+    uint8_t* slot = nullptr;
+    SlotHeader* slotHeader = nullptr;
+    nextSlotInfo.slotId = calculateSlotIdForHash(keyHashFunc(key));
+    while (nextSlotInfo.isPrimary || nextSlotInfo.slotId != 0) {
+        lockSlot(nextSlotInfo);
+        if (slotInfo.slotId != UINT32_MAX) {
+            unLockSlot(slotInfo);
+        }
+        slotInfo = nextSlotInfo;
+        slot = getSlotFromPages(slotInfo);
+        if (existsInSlot(slot, key)) {
+            unLockSlot(slotInfo);
             return false;
         }
         slotHeader = reinterpret_cast<SlotHeader*>(slot);
+        nextSlotInfo.slotId = slotHeader->nextOvfSlotId;
+        nextSlotInfo.isPrimary = false;
     }
-    if (slotHeader->numEntries == indexHeader.slotCapacity) {
-        slotHeader->nextOvfSlotId = reserveOvfSlot();
-        slot = getOvfSlotFromOvfPages(slotHeader->nextOvfSlotId);
+    if (slotHeader->numEntries == HashIndexConfig::SLOT_CAPACITY) {
+        // Allocate a new ovf slot.
+        nextSlotInfo.slotId = reserveOvfSlot();
+        nextSlotInfo.isPrimary = false;
+        lockSlot(nextSlotInfo);
+        slot = getSlotFromPages(nextSlotInfo);
+        slotHeader->nextOvfSlotId = nextSlotInfo.slotId;
+        unLockSlot(slotInfo);
+        slotInfo = nextSlotInfo;
     }
-    putNewEntryInSlotAndUpdateHeader(slot, key, value);
+    insertToSlot(slot, key, value);
+    unLockSlot(slotInfo);
+    numEntries.fetch_add(1);
     return true;
 }
 
-void HashIndex::putNewEntryInSlotAndUpdateHeader(uint8_t* slot, uint8_t* key, node_offset_t value) {
+void HashIndex::insertToSlot(uint8_t* slot, const uint8_t* key, node_offset_t value) {
     auto slotHeader = reinterpret_cast<SlotHeader*>(slot);
     auto entry = getEntryInSlot(slot, slotHeader->numEntries);
     insertKeyToEntryFunc(key, entry, inMemStringOvfPages.get(), &stringOvfPageCursor);
-    entry += Types::getDataTypeSize(indexHeader.keyDataType);
+    entry += Types::getDataTypeSize(indexHeader->keyDataTypeID);
     memcpy(entry, &value, sizeof(node_offset_t));
-    indexHeader.numEntries += 1;
     slotHeader->numEntries++;
 }
 
-bool HashIndex::notExistsInSlot(uint8_t* slot, uint8_t* key) {
+bool HashIndex::existsInSlot(uint8_t* slot, const uint8_t* key) {
     auto slotHeader = reinterpret_cast<SlotHeader*>(slot);
     for (auto entryPos = 0u; entryPos < slotHeader->numEntries; entryPos++) {
         auto keyInEntry = getEntryInSlot(slot, entryPos);
         bool foundKey = equalsFuncInWrite(key, keyInEntry, inMemStringOvfPages.get());
         if (foundKey) {
-            return false;
+            return true;
         }
     }
-    return true;
+    return false;
 }
 
-void HashIndex::saveToDisk() {
-    auto fileInfo = FileUtils::openFile(fName, O_WRONLY | O_CREAT);
-    auto writeOffset = 0u;
-    FileUtils::writeToFile(
-        fileInfo.get(), (uint8_t*)&indexHeader, sizeof(indexHeader), writeOffset);
-    writeOffset += LARGE_PAGE_SIZE;
-    for (auto& primaryPage : primaryPages) {
-        FileUtils::writeToFile(fileInfo.get(), primaryPage->data, LARGE_PAGE_SIZE, writeOffset);
-        writeOffset += LARGE_PAGE_SIZE;
-    }
-    for (auto& ovfPage : ovfPages) {
-        FileUtils::writeToFile(fileInfo.get(), ovfPage->data, LARGE_PAGE_SIZE, writeOffset);
-        writeOffset += LARGE_PAGE_SIZE;
-    }
-    FileUtils::closeFile(fileInfo->fd);
-    if (indexHeader.keyDataType.typeID == STRING) {
-        inMemStringOvfPages->saveToFile();
-    }
-}
-
-bool HashIndex::lookup(uint8_t* key, node_offset_t& result) {
+bool HashIndex::lookupInternal(const uint8_t* key, node_offset_t& result) {
     auto slotId = calculateSlotIdForHash(keyHashFunc(key));
     auto pageId = getPageIdForSlot(slotId);
     auto slotIdInPage = getSlotIdInPageForSlot(slotId);
-    auto physicalPageId = pageId + 1;
-    auto page = bufferManager->pin(*fileHandle, physicalPageId);
-    auto slot = getSlotInAPage(page, slotIdInPage);
+    auto physicalPageId = primaryLogicalToPhysicalPagesMapping[pageId];
+    auto page = bm.pin(*fh, physicalPageId);
+    auto slot = getSlotInPage(page, slotIdInPage);
     auto foundKey = lookupInSlot(slot, key, result);
     if (foundKey) {
-        bufferManager->unpin(*fileHandle, physicalPageId);
+        bm.unpin(*fh, physicalPageId);
         return true;
     }
     auto slotHeader = reinterpret_cast<SlotHeader*>(const_cast<uint8_t*>(slot));
     while (slotHeader->nextOvfSlotId != 0) {
         pageId = getPageIdForSlot(slotHeader->nextOvfSlotId);
         slotIdInPage = getSlotIdInPageForSlot(slotHeader->nextOvfSlotId);
-        bufferManager->unpin(*fileHandle, physicalPageId);
-        physicalPageId = 1 + indexHeader.numPrimaryPages + pageId;
-        page = bufferManager->pin(*fileHandle, physicalPageId);
-        slot = getSlotInAPage(page, slotIdInPage);
+        bm.unpin(*fh, physicalPageId);
+        physicalPageId = ovfLogicalToPhysicalPagesMapping[pageId];
+        page = bm.pin(*fh, physicalPageId);
+        slot = getSlotInPage(page, slotIdInPage);
         foundKey = lookupInSlot(slot, key, result);
         if (foundKey) {
-            bufferManager->unpin(*fileHandle, physicalPageId);
+            bm.unpin(*fh, physicalPageId);
             return true;
         }
         slotHeader = reinterpret_cast<SlotHeader*>(const_cast<uint8_t*>(slot));
     }
-    bufferManager->unpin(*fileHandle, physicalPageId);
+    bm.unpin(*fh, physicalPageId);
     return false;
 }
 
-bool HashIndex::lookupInSlot(const uint8_t* slot, uint8_t* key, node_offset_t& result) const {
+bool HashIndex::lookupInSlot(const uint8_t* slot, const uint8_t* key, node_offset_t& result) const {
     auto slotHeader = reinterpret_cast<SlotHeader*>(const_cast<uint8_t*>(slot));
     for (auto entryPos = 0u; entryPos < slotHeader->numEntries; entryPos++) {
         auto keyInEntry = getEntryInSlot(const_cast<uint8_t*>(slot), entryPos);
         bool foundKey = equalsFuncInRead(key, keyInEntry, stringOvfPages.get());
         if (foundKey) {
             result =
-                *(node_offset_t*)(keyInEntry + Types::getDataTypeSize(indexHeader.keyDataType));
+                *(node_offset_t*)(keyInEntry + Types::getDataTypeSize(indexHeader->keyDataTypeID));
             return true;
         }
     }
     return false;
 }
 
-uint64_t HashIndex::calculateSlotIdForHash(hash_t hash) const {
-    auto slotId = hash & indexHeader.levelHashMask;
+uint64_t HashIndex::calculateSlotIdForHash(hash_t hash) {
+    auto slotId = hash & indexHeader->levelHashMask;
     slotId =
-        slotId >= indexHeader.nextSplitSlotId ? slotId : (hash & indexHeader.higherLevelHashMask);
+        slotId >= indexHeader->nextSplitSlotId ? slotId : (hash & indexHeader->higherLevelHashMask);
     return slotId;
 }
 
-uint8_t* HashIndex::getSlotFromPrimaryPages(uint64_t slotId) const {
-    return const_cast<uint8_t*>(getSlotInAPage(
-        primaryPages[getPageIdForSlot(slotId)]->data, getSlotIdInPageForSlot(slotId)));
-}
-
-uint8_t* HashIndex::getOvfSlotFromOvfPages(uint64_t slotId) const {
-    return const_cast<uint8_t*>(
-        getSlotInAPage(ovfPages[getPageIdForSlot(slotId)]->data, getSlotIdInPageForSlot(slotId)));
+uint8_t* HashIndex::getSlotFromPages(const SlotInfo& slotInfo) {
+    if (slotInfo.isPrimary) {
+        auto logicalPageIdx = getPageIdForSlot(slotInfo.slotId);
+        return const_cast<uint8_t*>(getSlotInPage(
+            primaryPinnedFrames[logicalPageIdx], getSlotIdInPageForSlot(slotInfo.slotId)));
+    } else {
+        shared_lock s_lck{sharedLockForSlotMutexes};
+        auto logicalPageIdx = getPageIdForSlot(slotInfo.slotId);
+        return const_cast<uint8_t*>(getSlotInPage(
+            ovfPinnedFrames[logicalPageIdx], getSlotIdInPageForSlot(slotInfo.slotId)));
+    }
 }
 
 uint64_t HashIndex::reserveOvfSlot() {
-    if (indexHeader.numOvfSlots % indexHeader.numSlotsPerPage == 0) {
-        ovfPages.emplace_back(memoryManager->allocateBlock(true));
-        indexHeader.numOvfPages++;
+    unique_lock lck{lockForReservingOvfSlot};
+    if (numOvfSlots >= ovfSlotsCapacity) {
+        unique_lock u_lck{sharedLockForSlotMutexes};
+        allocateAndCachePageWithoutLock(false /* isPrimary */);
+        for (auto i = 0u; i < indexHeader->numSlotsPerPage; i++) {
+            ovfSlotMutexes.push_back(make_unique<mutex>());
+        }
+        ovfSlotsCapacity += indexHeader->numSlotsPerPage;
+        assert(ovfSlotsCapacity == ovfSlotMutexes.size());
     }
-    return indexHeader.numOvfSlots++;
+    return numOvfSlots++;
+}
+
+void HashIndex::allocateAndCachePageWithoutLock(bool isPrimary) {
+    auto physicalPageIdx = fh->addNewPage();
+    auto data = bm.pinWithoutReadingFromFile(*fh, physicalPageIdx);
+    memset(data, 0, DEFAULT_PAGE_SIZE);
+    if (isPrimary) {
+        primaryPinnedFrames.push_back(data);
+        primaryLogicalToPhysicalPagesMapping.push_back(physicalPageIdx);
+    } else {
+        ovfPinnedFrames.push_back(data);
+        ovfLogicalToPhysicalPagesMapping.push_back(physicalPageIdx);
+    }
+}
+
+void HashIndex::lockSlot(const SlotInfo& slotInfo) {
+    assert(slotInfo.slotId != UINT32_MAX);
+    if (slotInfo.isPrimary) {
+        primarySlotMutexes[slotInfo.slotId]->lock();
+    } else {
+        shared_lock lck{sharedLockForSlotMutexes};
+        ovfSlotMutexes[slotInfo.slotId]->lock();
+    }
+}
+
+void HashIndex::unLockSlot(const SlotInfo& slotInfo) {
+    if (slotInfo.isPrimary) {
+        primarySlotMutexes[slotInfo.slotId]->unlock();
+    } else {
+        shared_lock lck{sharedLockForSlotMutexes};
+        ovfSlotMutexes[slotInfo.slotId]->unlock();
+    }
+}
+
+void HashIndex::readLogicalToPhysicalPageMappings() {
+    // Skip the index header, primary, and ovf pages.
+    auto readOffset =
+        (indexHeader->numPrimaryPages + indexHeader->numOvfPages + 1) * DEFAULT_PAGE_SIZE;
+    primaryLogicalToPhysicalPagesMapping.resize(indexHeader->numPrimaryPages);
+    FileUtils::readFromFile(fh->getFileInfo(), &primaryLogicalToPhysicalPagesMapping[0],
+        indexHeader->numPrimaryPages * sizeof(uint32_t), readOffset);
+    readOffset += indexHeader->numPrimaryPages * sizeof(uint32_t);
+    ovfLogicalToPhysicalPagesMapping.resize(indexHeader->numOvfPages);
+    FileUtils::readFromFile(fh->getFileInfo(), &ovfLogicalToPhysicalPagesMapping[0],
+        indexHeader->numOvfPages * sizeof(uint32_t), readOffset);
+}
+
+void HashIndex::writeLogicalToPhysicalPageMappings() {
+    // Append mappings of both primary and ovf pages to the end of the file.
+    auto writeOffset = fh->getNumPages() * DEFAULT_PAGE_SIZE;
+    auto numBytesForPrimaryPages = primaryLogicalToPhysicalPagesMapping.size() * sizeof(uint32_t);
+    FileUtils::writeToFile(fh->getFileInfo(), (uint8_t*)&primaryLogicalToPhysicalPagesMapping[0],
+        numBytesForPrimaryPages, writeOffset);
+    writeOffset += numBytesForPrimaryPages;
+    FileUtils::writeToFile(fh->getFileInfo(), (uint8_t*)&ovfLogicalToPhysicalPagesMapping[0],
+        ovfLogicalToPhysicalPagesMapping.size() * sizeof(uint32_t), writeOffset);
+}
+
+void HashIndex::flush() {
+    if (primaryLogicalToPhysicalPagesMapping.empty()) {
+        return;
+    }
+    // Copy index header back to the page.
+    indexHeader->numEntries = numEntries.load();
+    indexHeader->numPrimaryPages = primaryLogicalToPhysicalPagesMapping.size();
+    indexHeader->numOvfPages = ovfLogicalToPhysicalPagesMapping.size();
+    // Populate and flush the index header page.
+    auto headerFrame = bm.pin(*fh, INDEX_HEADER_PAGE_ID);
+    memcpy(headerFrame, (uint8_t*)indexHeader.get(), sizeof(HashIndexHeader));
+    setDirtyAndUnPinPage(INDEX_HEADER_PAGE_ID);
+    // Flush primary and ovf pages.
+    for (auto page : primaryLogicalToPhysicalPagesMapping) {
+        setDirtyAndUnPinPage(page);
+    }
+    for (auto page : ovfLogicalToPhysicalPagesMapping) {
+        setDirtyAndUnPinPage(page);
+    }
+    if (indexHeader->keyDataTypeID == STRING) {
+        inMemStringOvfPages->saveToFile();
+    }
+    writeLogicalToPhysicalPageMappings();
 }
 
 } // namespace storage

--- a/src/storage/index/hash_index_utils.cpp
+++ b/src/storage/index/hash_index_utils.cpp
@@ -1,0 +1,100 @@
+#include "src/storage/include/index/hash_index_utils.h"
+
+namespace graphflow {
+namespace storage {
+
+hash_function_t HashIndexUtils::initializeHashFunc(const DataTypeID& dataTypeID) {
+    switch (dataTypeID) {
+    case INT64:
+        return hashFuncForInt64;
+    case STRING:
+        return hashFuncForString;
+    default:
+        throw StorageException("Type " + Types::dataTypeToString(dataTypeID) + " not supported.");
+    }
+}
+
+insert_function_t HashIndexUtils::initializeInsertKeyToEntryFunc(const DataTypeID& dataTypeID) {
+    switch (dataTypeID) {
+    case INT64:
+        return insertInt64KeyToEntryFunc;
+    case STRING:
+        return insertStringKeyToEntryFunc;
+    default:
+        throw StorageException(
+            "Hash index insertion not defined for dataType other than INT64 and STRING.");
+    }
+}
+
+bool HashIndexUtils::isStringPrefixAndLenEquals(
+    const uint8_t* keyToLookup, const gf_string_t* keyInEntry) {
+    if (memcmp(keyToLookup, keyInEntry->prefix, gf_string_t::PREFIX_LENGTH) != 0) {
+        return false;
+    }
+    if (strlen(reinterpret_cast<const char*>(keyToLookup)) != keyInEntry->len) {
+        return false;
+    }
+    return true;
+}
+
+bool HashIndexUtils::equalsFuncInWriteModeForString(const uint8_t* keyToLookup,
+    const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages) {
+    auto gfStringInEntry = (gf_string_t*)keyInEntry;
+    // Checks if prefix and len matches first.
+    if (!isStringPrefixAndLenEquals(keyToLookup, gfStringInEntry)) {
+        return false;
+    }
+    if (gfStringInEntry->len <= gf_string_t::PREFIX_LENGTH) {
+        // For strings shorter than PREFIX_LENGTH, the result must be true.
+        return true;
+    } else if (gfStringInEntry->len <= gf_string_t::SHORT_STR_LENGTH) {
+        // For short strings, whose lengths are larger than PREFIX_LENGTH, check if their actual
+        // values are equal.
+        return memcmp(keyToLookup, gfStringInEntry->prefix, gfStringInEntry->len) == 0;
+    } else {
+        // For long strings, read overflow values and check if they are true.
+        PageByteCursor cursor;
+        TypeUtils::decodeOverflowPtr(gfStringInEntry->overflowPtr, cursor.idx, cursor.offset);
+        return memcmp(keyToLookup, overflowPages->pages[cursor.idx]->data + cursor.offset,
+                   gfStringInEntry->len) == 0;
+    }
+}
+
+equals_in_write_function_t HashIndexUtils::initializeEqualsFuncInWriteMode(
+    const DataTypeID& dataTypeID) {
+    switch (dataTypeID) {
+    case INT64:
+        return equalsFuncInWriteModeForInt64;
+    case STRING:
+        return equalsFuncInWriteModeForString;
+    default:
+        throw StorageException(
+            "Hash index equals is not supported for dataType other than INT64 and STRING.");
+    }
+}
+
+bool HashIndexUtils::equalsFuncInReadModeForString(
+    const uint8_t* keyToLookup, const uint8_t* keyInEntry, OverflowPages* overflowPages) {
+    auto keyInEntryString = (gf_string_t*)keyInEntry;
+    if (isStringPrefixAndLenEquals(keyToLookup, keyInEntryString)) {
+        auto entryKeyString = overflowPages->readString(*keyInEntryString);
+        return memcmp(keyToLookup, entryKeyString.c_str(), entryKeyString.length()) == 0;
+    }
+    return false;
+}
+
+equals_in_read_function_t HashIndexUtils::initializeEqualsFuncInReadMode(
+    const DataTypeID& dataTypeID) {
+    switch (dataTypeID) {
+    case INT64:
+        return equalsFuncInReadModeForInt64;
+    case STRING:
+        return equalsFuncInReadModeForString;
+    default:
+        throw StorageException(
+            "Hash index equals is not supported for dataType other than INT64 and STRING.");
+    }
+}
+
+} // namespace storage
+} // namespace graphflow

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -30,7 +30,7 @@ void WAL::logCommit(uint64_t transactionID) {
 }
 
 void WAL::deleteAndReopenWALFile(BufferManager* bufferManager) {
-    bufferManager->removeFilePagesFromFrames(*fileHandle);
+    bufferManager->removeOrFlushPagesFromFrames(*fileHandle, true /* isRemovingPages */);
     fileHandle->resetToZeroPagesAndPageCapacity();
     initCurrentPage();
 }

--- a/test/storage/buffer_manager_test.cpp
+++ b/test/storage/buffer_manager_test.cpp
@@ -32,7 +32,7 @@ TEST_F(BufferManagerTests, RemoveFilePagesFromFramesTest) {
     }
     bufferManager->unpin(fileHandle, 10);
     bufferManager->unpin(fileHandle, 999);
-    bufferManager->removeFilePagesFromFrames(fileHandle);
+    bufferManager->removeOrFlushPagesFromFrames(fileHandle, true /* isRemovingPages */);
     for (int pageIdx = 0; pageIdx < numPagesToAdd; ++pageIdx) {
         ASSERT_FALSE(FileHandle::isAFrame(fileHandle.getFrameIdx(pageIdx)));
     }


### PR DESCRIPTION
This PR adds support for concurrent insertion after `bulkReserve` in HashIndex.
Also, cached blocks are changed to be managed through BufferManager. During flushing, cached blocks are marked as dirty, and will be flushed to disk by BufferManager.

The insertion locking scheme is that:
for each primary and ovf slot, there is a mutex, i.e., `primarySlotMutexes`, and `ovfSlotMutexes`. Access to a slot during insertion requires a lock first.
When a key is to be inserted, we first calculate its primary slot id, based on which, we will require its lock and read its header. Remind that the way we organize our slots is each primary slot is chained with a list of ovf slots. So during insertion, to find the correct slot for insertion, we follow the chain by acquiring the nextOvfSlot's lock, and releasing the previous one. In this way, we can minimize the impact of locking.

Ovf page allocation:
During insertion, when a primary/ovf slot is full, we need to allocate a new ovf slot to address the hash confliction. The allocation happens in two cases: 1) there are empty ovf slots available in a ovf page, we require a global lock, and increment the current soltId to the empty one; 2) there are no empty ovf slots available, we need to allocate a new ovf page. We first require a global lock, then acquire a lock on `ovfSharedMutex`, which coordinates accesses to ovf pages, i.e., `ovfCachedBlocks`. The double locking design is to minimize the conflict between reading a slot from `ovfCachedBlocks`, and allocating a new ovf page.

TODO:
- Change the comment in HashIndex accordingly.