### PR TITLE
fix orderBy bug

### DIFF
--- a/src/processor/include/physical_plan/operator/order_by/key_block_merger.h
+++ b/src/processor/include/physical_plan/operator/order_by/key_block_merger.h
@@ -40,6 +40,7 @@ public:
     MergedKeyBlocks(uint64_t numBytesPerTuple, shared_ptr<DataBlock> keyBlock);
 
     inline uint8_t* getTuple(uint64_t tupleIdx) const {
+        assert(tupleIdx < numTuples);
         return keyBlocks[tupleIdx / (LARGE_PAGE_SIZE / numBytesPerTuple)]->getData() +
                numBytesPerTuple * (tupleIdx % (LARGE_PAGE_SIZE / numBytesPerTuple));
     }

--- a/src/processor/physical_plan/operator/order_by/key_block_merger.cpp
+++ b/src/processor/physical_plan/operator/order_by/key_block_merger.cpp
@@ -110,38 +110,36 @@ void KeyBlockMerger::mergeKeyBlocks(KeyBlockMergeMorsel& keyBlockMergeMorsel) co
     auto leftKeyBlock = keyBlockMergeMorsel.keyBlockMergeTask->leftKeyBlock;
     auto rightKeyBlock = keyBlockMergeMorsel.keyBlockMergeTask->rightKeyBlock;
     auto resultKeyBlock = keyBlockMergeMorsel.keyBlockMergeTask->resultKeyBlock;
-    auto leftKeyBlockBuffer = leftKeyBlock->getTuple(leftKeyBlockIdx);
-    auto rightKeyBlockBuffer = rightKeyBlock->getTuple(rightKeyBlockIdx);
-    auto resultKeyBlockBuffer = resultKeyBlock->getTuple(leftKeyBlockIdx + rightKeyBlockIdx);
+    uint8_t *leftKeyBlockBuffer, *rightKeyBlockBuffer, *resultKeyBlockBuffer;
 
-    while (leftKeyBlockIdx < keyBlockMergeMorsel.leftKeyBlockEndIdx &&
-           rightKeyBlockIdx < keyBlockMergeMorsel.rightKeyBlockEndIdx) {
+    while ((leftKeyBlockIdx < keyBlockMergeMorsel.leftKeyBlockEndIdx) &&
+           (rightKeyBlockIdx < keyBlockMergeMorsel.rightKeyBlockEndIdx)) {
+        leftKeyBlockBuffer = leftKeyBlock->getTuple(leftKeyBlockIdx);
+        rightKeyBlockBuffer = rightKeyBlock->getTuple(rightKeyBlockIdx);
+        resultKeyBlockBuffer = resultKeyBlock->getTuple(leftKeyBlockIdx + rightKeyBlockIdx);
         if (compareTupleBuffer(leftKeyBlockBuffer, rightKeyBlockBuffer)) {
             memcpy(resultKeyBlockBuffer, rightKeyBlockBuffer, numBytesPerTuple);
             rightKeyBlockIdx++;
-            rightKeyBlockBuffer = rightKeyBlock->getTuple(rightKeyBlockIdx);
         } else {
             memcpy(resultKeyBlockBuffer, leftKeyBlockBuffer, numBytesPerTuple);
             leftKeyBlockIdx++;
-            leftKeyBlockBuffer = leftKeyBlock->getTuple(leftKeyBlockIdx);
         }
-        resultKeyBlockBuffer = resultKeyBlock->getTuple(leftKeyBlockIdx + rightKeyBlockIdx);
     }
 
     // If there are still unmerged tuples in the left or right memBlock, just append them to the
     // result memBlock.
     while (leftKeyBlockIdx < keyBlockMergeMorsel.leftKeyBlockEndIdx) {
-        memcpy(resultKeyBlockBuffer, leftKeyBlockBuffer, numBytesPerTuple);
-        leftKeyBlockIdx++;
         leftKeyBlockBuffer = leftKeyBlock->getTuple(leftKeyBlockIdx);
         resultKeyBlockBuffer = resultKeyBlock->getTuple(leftKeyBlockIdx + rightKeyBlockIdx);
+        memcpy(resultKeyBlockBuffer, leftKeyBlockBuffer, numBytesPerTuple);
+        leftKeyBlockIdx++;
     }
 
     while (rightKeyBlockIdx < keyBlockMergeMorsel.rightKeyBlockEndIdx) {
-        memcpy(resultKeyBlockBuffer, rightKeyBlockBuffer, numBytesPerTuple);
-        rightKeyBlockIdx++;
         rightKeyBlockBuffer = rightKeyBlock->getTuple(rightKeyBlockIdx);
         resultKeyBlockBuffer = resultKeyBlock->getTuple(leftKeyBlockIdx + rightKeyBlockIdx);
+        memcpy(resultKeyBlockBuffer, rightKeyBlockBuffer, numBytesPerTuple);
+        rightKeyBlockIdx++;
     }
 }
 

--- a/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by_scan.cpp
@@ -5,8 +5,8 @@ namespace processor {
 
 pair<uint64_t, uint64_t> OrderByScan::getNextFactorizedTableIdxAndTupleIdxPair() {
     auto tupleInfoBuffer =
-        sharedState->sortedKeyBlocks->front()->getTuple(nextTupleIdxToReadInMemBlock + 1) -
-        sizeof(uint64_t);
+        sharedState->sortedKeyBlocks->front()->getTuple(nextTupleIdxToReadInMemBlock) +
+        sharedState->sortedKeyBlocks->front()->getNumBytesPerTuple() - sizeof(uint64_t);
     uint16_t factorizedTableIdx = OrderByKeyEncoder::getEncodedFactorizedTableIdx(tupleInfoBuffer);
     uint64_t tupleIdx = OrderByKeyEncoder::getEncodedTupleIdx(tupleInfoBuffer);
     return make_pair(factorizedTableIdx, tupleIdx);


### PR DESCRIPTION
The PR fixes the following bug:

The keyBlockMerger tries to update the left/right/resultKeyBlockBuffer after incrementing the left/right/resultBlockIdx.
The left/right/resultBlockIdx may eventually become invalid, but we are still trying to update the left/right/resultKeyBlockBuffer using the left/right/resultBlockIdx. This will cause an exception in MergerKeyBlocks::getTuple()