### PR TITLE
checkpointing logic

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -31,6 +31,9 @@ constexpr const uint64_t THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS = 100;
 
 constexpr const uint64_t PAGE_VERSION_INFO_PAGE_GROUP_SIZE = 64;
 
+constexpr const uint64_t DEFAULT_CHECKPOINT_WAIT_TIMEOUT_FOR_TRANSACTIONS_TO_LEAVE_IN_MICROS =
+    5000000;
+
 struct StorageConfig {
     // The default amount of memory pre-allocated to the buffer pool (= 2MB).
     static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 21;

--- a/src/common/include/task_system/task_scheduler.h
+++ b/src/common/include/task_system/task_scheduler.h
@@ -75,6 +75,7 @@ public:
     // from the task queue and remain in the queue. So for now, use this function if you
     // want the system to crash if any of the tasks fails.
     void waitAllTasksToCompleteOrError();
+    bool isTaskQueueEmpty() { return taskQueue.empty(); }
 
 private:
     void removeErroringTask(uint64_t scheduledTaskID);

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -295,8 +295,12 @@ void Connection::beginTransactionNoLock(TransactionType type) {
 
 void Connection::commitOrRollbackNoLock(bool isCommit) {
     if (activeTransaction) {
-        isCommit ? database->transactionManager->commit(activeTransaction.get()) :
-                   database->transactionManager->rollback(activeTransaction.get());
+        if (activeTransaction->isWriteTransaction()) {
+            database->commitAndCheckpointOrRollback(activeTransaction.get(), isCommit);
+        } else {
+            isCommit ? database->transactionManager->commit(activeTransaction.get()) :
+                       database->transactionManager->rollback(activeTransaction.get());
+        }
         activeTransaction.reset();
         transactionMode = AUTO_COMMIT;
     }

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -14,7 +14,7 @@ Database::Database(const DatabaseConfig& databaseConfig, const SystemConfig& sys
     catalog = make_unique<catalog::Catalog>(databaseConfig.databasePath);
     storageManager = make_unique<storage::StorageManager>(
         *catalog, *bufferManager, databaseConfig.databasePath, databaseConfig.inMemoryMode);
-    transactionManager = make_unique<transaction::TransactionManager>();
+    transactionManager = make_unique<transaction::TransactionManager>(storageManager->getWAL());
 }
 
 void Database::resizeBufferManager(uint64_t newSize) {

--- a/src/main/include/connection.h
+++ b/src/main/include/connection.h
@@ -5,6 +5,7 @@
 #include "query_result.h"
 
 #include "src/planner/logical_plan/include/logical_plan.h"
+#include "src/storage/include/wal/wal.h"
 #include "src/transaction/include/transaction_manager.h"
 
 using namespace graphflow::planner;

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -160,17 +160,41 @@ cc_library(
     ],
 )
 
+
+cc_library(
+    name = "wal",
+    srcs = [
+        "wal/wal.cpp",
+        "wal/wal_record.cpp",
+        ],
+    hdrs = [
+        "include/wal/wal.h",
+        "include/wal/wal_record.h",
+        ],
+    visibility = [
+        "//visibility:public",
+    ],
+    deps = [
+        "buffer_manager",
+        "//src/common:type_utils",
+        "//src/common:utils",
+    ],
+)
+
 cc_library(
     name = "storage_manager",
     srcs = [
         "storage_manager.cpp",
+        "wal_replayer.cpp"
     ],
     hdrs = [
         "include/storage_manager.h",
+        "include/wal_replayer.h"
     ],
     visibility = ["//visibility:public"],
     deps = [
         "store",
+        "wal",
     ],
 )
 
@@ -191,25 +215,5 @@ cc_library(
         "//src/common/types",
         "//src/function/hash/operations:hash_operations",
         "//src/loader:in_mem_pages",
-    ],
-)
-
-cc_library(
-    name = "wal",
-    srcs = [
-        "wal/wal.cpp",
-        "wal/wal_record.cpp",
-    ],
-    hdrs = [
-        "include/wal/wal.h",
-        "include/wal/wal_record.h",
-    ],
-    visibility = [
-        "//visibility:public",
-    ],
-    deps = [
-        "buffer_manager",
-        "//src/common:type_utils",
-        "//src/common:utils",
     ],
 )

--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -68,11 +68,23 @@ void BufferManager::unpin(FileHandle& fileHandle, uint32_t pageIdx) {
                                        bufferPoolDefaultPages->unpin(fileHandle, pageIdx);
 }
 
-void BufferManager::removeOrFlushPagesFromFrames(FileHandle& fileHandle, bool isRemovingPages) {
-    return fileHandle.isLargePaged() ?
-               bufferPoolLargePages->removeOrFlushFilePagesFromFrames(fileHandle, isRemovingPages) :
-               bufferPoolDefaultPages->removeOrFlushFilePagesFromFrames(
-                   fileHandle, isRemovingPages);
+void BufferManager::removeFilePagesFromFrames(FileHandle& fileHandle) {
+    fileHandle.isLargePaged() ? bufferPoolLargePages->removeFilePagesFromFrames(fileHandle) :
+                                bufferPoolDefaultPages->removeFilePagesFromFrames(fileHandle);
+}
+
+void BufferManager::flushAllDirtyPagesInFrames(FileHandle& fileHandle) {
+    fileHandle.isLargePaged() ? bufferPoolLargePages->flushAllDirtyPagesInFrames(fileHandle) :
+                                bufferPoolDefaultPages->flushAllDirtyPagesInFrames(fileHandle);
+}
+
+void BufferManager::updateFrameIfPageIsInFrameWithoutPageOrFrameLock(
+    FileHandle& fileHandle, uint8_t* newPage, uint64_t pageIdx) {
+    fileHandle.isLargePaged() ?
+        bufferPoolLargePages->updateFrameIfPageIsInFrameWithoutPageOrFrameLock(
+            fileHandle, newPage, pageIdx) :
+        bufferPoolDefaultPages->updateFrameIfPageIsInFrameWithoutPageOrFrameLock(
+            fileHandle, newPage, pageIdx);
 }
 
 unique_ptr<nlohmann::json> BufferManager::debugInfo() {

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -49,6 +49,7 @@ void FileHandle::resetToZeroPagesAndPageCapacity() {
     unique_lock lock(fhSharedMutex);
     numPages = 0;
     pageCapacity = 0;
+    FileUtils::truncateFileToEmpty(fileInfo.get());
     initPageIdxToFrameMapAndLocks();
 }
 

--- a/src/storage/include/buffer_manager.h
+++ b/src/storage/include/buffer_manager.h
@@ -79,7 +79,11 @@ public:
 
     void resize(uint64_t newSizeForDefaultPagePool, uint64_t newSizeForLargePagePool);
 
-    void removeOrFlushPagesFromFrames(FileHandle& fileHandle, bool isRemovingPages);
+    void removeFilePagesFromFrames(FileHandle& fileHandle);
+
+    void flushAllDirtyPagesInFrames(FileHandle& fileHandle);
+    void updateFrameIfPageIsInFrameWithoutPageOrFrameLock(
+        FileHandle& fileHandle, uint8_t* newPage, uint64_t pageIdx);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/include/buffer_pool.h
+++ b/src/storage/include/buffer_pool.h
@@ -86,10 +86,14 @@ public:
 
     void resize(uint64_t newSize);
 
-    // Note: This function is not designed for concurrency and therefore not tested under
-    // concurrency. If this is called while other threads are accessing the BM, it should work
-    // safely but this is not tested.
-    void removeOrFlushFilePagesFromFrames(FileHandle& fileHandle, bool isRemovingPages);
+    // Note: These two functions that remove pages from frames is not designed for concurrency and
+    // therefore not tested under concurrency. If this is called while other threads are accessing
+    // the BM, it should work safely but this is not tested.
+    void removeFilePagesFromFrames(FileHandle& fileHandle);
+
+    void flushAllDirtyPagesInFrames(FileHandle& fileHandle);
+    void updateFrameIfPageIsInFrameWithoutPageOrFrameLock(
+        FileHandle& fileHandle, uint8_t* newPage, uint64_t pageIdx);
 
 private:
     uint8_t* pin(FileHandle& fileHandle, uint32_t pageIdx, bool doNotReadFromFile);
@@ -106,6 +110,11 @@ private:
 
     void readNewPageIntoFrame(
         Frame& frame, FileHandle& fileHandle, uint32_t pageIdx, bool doNotReadFromFile);
+
+    void flushIfDirtyWithoutPageOrFrameLock(const unique_ptr<Frame>& frame);
+
+    void removePageFromFrameOrFlushIfDirty(
+        FileHandle& fileHandle, uint64_t pageIdx, bool isRemoving);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/include/storage_manager.h
+++ b/src/storage/include/storage_manager.h
@@ -1,10 +1,13 @@
 #pragma once
 
+#include <mutex>
+
 #include "src/storage/include/store/nodes_store.h"
 #include "src/storage/include/store/rels_store.h"
 #include "src/storage/include/wal/wal.h"
 
 using namespace std;
+using lock_t = unique_lock<mutex>;
 
 namespace spdlog {
 class logger;
@@ -34,14 +37,22 @@ public:
 
     inline RelsStore& getRelsStore() const { return *relsStore; }
     inline NodesStore& getNodesStore() const { return *nodesStore; }
+    inline WAL& getWAL() const { return *wal; }
+    void checkpointWAL();
+    void rollbackWAL();
+
+private:
+    void checkpointOrRollbackWAL(bool isCheckpoint);
 
 private:
     shared_ptr<spdlog::logger> logger;
+    BufferManager& bufferManager;
     string directory;
     bool isInMemoryMode;
     unique_ptr<storage::WAL> wal;
     unique_ptr<NodesStore> nodesStore;
     unique_ptr<RelsStore> relsStore;
+    mutex checkpointMtx;
 };
 
 } // namespace storage

--- a/src/storage/include/storage_structure/column.h
+++ b/src/storage/include/storage_structure/column.h
@@ -49,6 +49,8 @@ public:
     // Used only for tests.
     bool isNull(node_offset_t nodeOffset);
 
+    void clearPageVersionInfo(uint64_t pageIdx);
+
 protected:
     virtual void readForSingleNodeIDPosition(const transaction::Transaction* transaction,
         uint32_t pos, const shared_ptr<ValueVector>& nodeIDVector,

--- a/src/storage/include/storage_structure/page_version_info.h
+++ b/src/storage/include/storage_structure/page_version_info.h
@@ -24,6 +24,11 @@ struct PageLocksAndVersionsPerPageGroup {
         pageVersions.resize(PAGE_VERSION_INFO_PAGE_GROUP_SIZE, UINT64_MAX);
     }
 
+    inline void resizeToEmpty() {
+        pageLocks.resize(0);
+        pageVersions.resize(0);
+    }
+
     bool empty() { return pageLocks.empty(); }
 };
 
@@ -33,6 +38,8 @@ public:
     explicit PageVersionInfo(uint64_t numPages);
 
     void acquireLockForWritingToPage(uint64_t pageIdx);
+
+    void clearUpdatedWALPageVersion(uint64_t pageIdx);
 
     // This function assumes that the caller has already acquired the lock for originalPageIdx.
     void setUpdatedWALPageVersionNoLock(uint64_t originalPageIdx, uint64_t pageIdxInWAL);
@@ -57,7 +64,7 @@ public:
     }
 
     // This function assumes that the caller has already acquired the lock for the page.
-    void releaseLock(uint32_t originalPageIdx);
+    void releaseLock(uint32_t pageIdx);
 
 private:
     uint64_t numPages;

--- a/src/storage/include/storage_structure/storage_structure.h
+++ b/src/storage/include/storage_structure/storage_structure.h
@@ -27,12 +27,16 @@ public:
         return pageElementPos * elementSize;
     }
 
+    inline FileHandle* getFileHandle() { return &fileHandle; }
+
+    inline bool isInMemory() { return isInMemory_; }
+
 protected:
     StorageStructure(const string& fName, const DataType& dataType, const size_t& elementSize,
         BufferManager& bufferManager, bool hasNULLBytes, bool isInMemory);
 
     virtual ~StorageStructure() {
-        if (isInMemory) {
+        if (isInMemory_) {
             StorageStructureUtils::unpinEachPageOfFile(fileHandle, bufferManager);
         }
     }
@@ -76,9 +80,7 @@ protected:
 
     FileHandle fileHandle;
     BufferManager& bufferManager;
-
-private:
-    bool isInMemory;
+    bool isInMemory_;
 };
 
 } // namespace storage

--- a/src/storage/include/wal/wal_record.h
+++ b/src/storage/include/wal/wal_record.h
@@ -57,7 +57,6 @@ struct FileID {
     };
 
     inline bool operator==(const FileID& rhs) const {
-
         if (fileIDType != rhs.fileIDType) {
             return false;
         }

--- a/src/storage/include/wal_replayer.h
+++ b/src/storage/include/wal_replayer.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "src/storage/include/buffer_manager.h"
+#include "src/storage/include/wal/wal_record.h"
+
+namespace graphflow {
+namespace storage {
+
+class StorageManager;
+
+class WALReplayer {
+public:
+    WALReplayer(StorageManager& storageManager, BufferManager& bufferManager, bool isCheckpoint);
+
+    void replay();
+
+private:
+    void replayWALRecord(WALRecord& walRecord);
+
+private:
+    StorageManager& storageManager;
+    BufferManager& bufferManager;
+    shared_ptr<FileHandle> walFileHandle;
+    unique_ptr<uint8_t[]> pageBuffer;
+    bool isCheckpoint; // if true does redo operations; if false does undo operations
+};
+
+} // namespace storage
+} // namespace graphflow

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -34,7 +34,7 @@ HashIndex::HashIndex(
 }
 
 HashIndex::~HashIndex() {
-    bm.removeOrFlushPagesFromFrames(*fh, false /* isRemovingPages */);
+    bm.flushAllDirtyPagesInFrames(*fh);
 }
 
 void HashIndex::initializeHeaderAndPages(const DataType& keyDataType, bool isInMemory) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -5,16 +5,19 @@
 #include "spdlog/spdlog.h"
 
 #include "src/storage/include/buffer_manager.h"
+#include "src/storage/include/wal_replayer.h"
 
 namespace graphflow {
 namespace storage {
 
 StorageManager::StorageManager(const catalog::Catalog& catalog, BufferManager& bufferManager,
     string directory, bool isInMemoryMode)
-    : logger{LoggerUtils::getOrCreateSpdLogger("storage")}, directory{move(directory)},
-      isInMemoryMode{isInMemoryMode} {
+    : logger{LoggerUtils::getOrCreateSpdLogger("storage")},
+      bufferManager{bufferManager}, directory{move(directory)}, isInMemoryMode{isInMemoryMode} {
     logger->info("Initializing StorageManager from directory: " + this->directory);
-    wal = make_unique<storage::WAL>(directory + StorageConfig::WAL_FILE_SUFFIX);
+    wal = make_unique<storage::WAL>(
+        FileUtils::joinPath(this->directory, string(StorageConfig::WAL_FILE_SUFFIX)),
+        bufferManager);
     nodesStore =
         make_unique<NodesStore>(catalog, bufferManager, this->directory, isInMemoryMode, wal.get());
     relsStore =
@@ -24,6 +27,20 @@ StorageManager::StorageManager(const catalog::Catalog& catalog, BufferManager& b
 
 StorageManager::~StorageManager() {
     spdlog::drop("storage");
+}
+
+void StorageManager::checkpointOrRollbackWAL(bool isCheckpoint) {
+    lock_t lck{checkpointMtx};
+    WALReplayer walReplayer(*this, bufferManager, isCheckpoint);
+    walReplayer.replay();
+}
+
+void StorageManager::checkpointWAL() {
+    checkpointOrRollbackWAL(true /* isCheckpoint */);
+}
+
+void StorageManager::rollbackWAL() {
+    checkpointOrRollbackWAL(false /* rolling back updates */);
 }
 
 } // namespace storage

--- a/src/storage/storage_structure/page_version_info.cpp
+++ b/src/storage/storage_structure/page_version_info.cpp
@@ -38,6 +38,12 @@ void PageVersionInfo::acquireLockForWritingToPage(uint64_t pageIdx) {
     }
 }
 
+void PageVersionInfo::clearUpdatedWALPageVersion(uint64_t pageIdx) {
+    acquireLockForWritingToPage(pageIdx);
+    setUpdatedWALPageVersionNoLock(pageIdx, UINT64_MAX);
+    releaseLock(pageIdx);
+}
+
 void PageVersionInfo::setUpdatedWALPageVersionNoLock(
     uint64_t originalPageIdx, uint64_t pageIdxInWAL) {
     auto pageGroupIdxAndPosInGroup = PageUtils::getPageElementCursorForOffset(
@@ -46,9 +52,9 @@ void PageVersionInfo::setUpdatedWALPageVersionNoLock(
         .pageVersions[pageGroupIdxAndPosInGroup.pos] = pageIdxInWAL;
 }
 
-void PageVersionInfo::releaseLock(uint32_t originalPageIdx) {
-    auto pageGroupIdxAndPosInGroup = PageUtils::getPageElementCursorForOffset(
-        originalPageIdx, PAGE_VERSION_INFO_PAGE_GROUP_SIZE);
+void PageVersionInfo::releaseLock(uint32_t pageIdx) {
+    auto pageGroupIdxAndPosInGroup =
+        PageUtils::getPageElementCursorForOffset(pageIdx, PAGE_VERSION_INFO_PAGE_GROUP_SIZE);
     pageLocksAndVersionsPerPageGroup[pageGroupIdxAndPosInGroup.idx]
         .pageLocks[pageGroupIdxAndPosInGroup.pos]
         ->clear();

--- a/src/storage/storage_structure/storage_structure.cpp
+++ b/src/storage/storage_structure/storage_structure.cpp
@@ -10,7 +10,7 @@ StorageStructure::StorageStructure(const string& fName, const DataType& dataType
     : dataType{dataType}, elementSize{elementSize}, logger{LoggerUtils::getOrCreateSpdLogger(
                                                         "storage")},
       fileHandle{fName, FileHandle::O_DefaultPagedExistingDBFileDoNotCreate},
-      bufferManager{bufferManager}, isInMemory{isInMemory} {
+      bufferManager{bufferManager}, isInMemory_{isInMemory} {
     numElementsPerPage = hasNULLBytes ?
                              PageUtils::getNumElementsInAPageWithNULLBytes(elementSize) :
                              PageUtils::getNumElementsInAPageWithoutNULLBytes(elementSize);

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -1,0 +1,75 @@
+#include "src/storage/include/wal_replayer.h"
+
+#include "src/storage/include/storage_manager.h"
+
+namespace graphflow {
+namespace storage {
+
+WALReplayer::WALReplayer(
+    StorageManager& storageManager, BufferManager& bufferManager, bool isCheckpoint)
+    : storageManager{storageManager}, bufferManager{bufferManager},
+      walFileHandle{storageManager.getWAL().fileHandle}, isCheckpoint{isCheckpoint} {
+    pageBuffer = make_unique<uint8_t[]>(DEFAULT_PAGE_SIZE);
+}
+
+void WALReplayer::replayWALRecord(WALRecord& walRecord) {
+    switch (walRecord.recordType) {
+    case PAGE_UPDATE_RECORD: {
+        Column* column;
+        auto fileID = walRecord.pageUpdateRecord.fileID;
+        switch (fileID.fileIDType) {
+        case STRUCTURED_NODE_PROPERTY_FILE_ID: {
+            column = storageManager.getNodesStore().getNodePropertyColumn(
+                fileID.structuredNodePropFileID.nodeLabel,
+                fileID.structuredNodePropFileID.propertyID);
+        } break;
+        case ADJ_COLUMN_PROPERTY_FILE_ID: {
+            column = storageManager.getRelsStore().getRelPropertyColumn(
+                fileID.adjColumnPropertyFileID.relLabel, fileID.adjColumnPropertyFileID.nodeLabel,
+                fileID.adjColumnPropertyFileID.propertyID);
+        } break;
+        default:
+            throw RuntimeException(
+                "Unrecognized FileIDType inside WALReplayer::replay(). FileIDType:" +
+                to_string(fileID.fileIDType));
+        }
+        if (isCheckpoint) {
+            // First update the original db file on disk
+            FileHandle* fileHandleToWriteTo = column->getFileHandle();
+            walFileHandle->readPage(pageBuffer.get(), walRecord.pageUpdateRecord.pageIdxInWAL);
+            fileHandleToWriteTo->writePage(
+                pageBuffer.get(), walRecord.pageUpdateRecord.pageIdxInOriginalFile);
+            // Update the page in buffer manager if it is in a frame
+            bufferManager.updateFrameIfPageIsInFrameWithoutPageOrFrameLock(*fileHandleToWriteTo,
+                pageBuffer.get(), walRecord.pageUpdateRecord.pageIdxInOriginalFile);
+        }
+        column->clearPageVersionInfo(walRecord.pageUpdateRecord.pageIdxInOriginalFile);
+    }
+    case COMMIT_RECORD: {
+        break;
+    }
+    default:
+        throw RuntimeException(
+            "Unrecognized WAL record type inside WALReplayer::replay. recordType: " +
+            to_string(walRecord.recordType));
+    }
+}
+
+void WALReplayer::replay() {
+    // Note: We assume no other thread is accessing the wal during the following operations. If this
+    // assumption no longer holds, we need to lock the wal.
+    if (isCheckpoint && !storageManager.getWAL().isLastLoggedRecordCommit()) {
+        throw StorageException(
+            "Cannot checkpointWAL because last logged record is not a commit record.");
+    }
+    auto walIterator = storageManager.getWAL().getIterator();
+    WALRecord walRecord;
+    uint64_t i = 0;
+    while (walIterator->hasNextRecord()) {
+        walIterator->getNextRecord(walRecord);
+        replayWALRecord(walRecord);
+    }
+}
+
+} // namespace storage
+} // namespace graphflow

--- a/src/transaction/BUILD.bazel
+++ b/src/transaction/BUILD.bazel
@@ -12,5 +12,6 @@ cc_library(
     ],
     deps = [
         "//src/common:utils",
+        "//src/storage:wal",
     ],
 )

--- a/src/transaction/include/transaction_manager.h
+++ b/src/transaction/include/transaction_manager.h
@@ -7,6 +7,7 @@
 #include "transaction.h"
 
 #include "src/common/include/utils.h"
+#include "src/storage/include/wal/wal.h"
 
 using namespace std;
 using lock_t = unique_lock<mutex>;
@@ -17,34 +18,52 @@ namespace transaction {
 class TransactionManager {
 
 public:
-    TransactionManager()
-        : activeWriteTransactionID{INT64_MAX}, lastTransactionID{0}, lastCommitID{0} {};
+    TransactionManager(storage::WAL& wal)
+        : logger{LoggerUtils::getOrCreateSpdLogger("transaction_manager")}, wal{wal},
+          activeWriteTransactionID{INT64_MAX}, lastTransactionID{0}, lastCommitID{0} {};
     unique_ptr<Transaction> beginWriteTransaction();
     unique_ptr<Transaction> beginReadOnlyTransaction();
     void commit(Transaction* transaction);
+    void commitButKeepActiveWriteTransaction(Transaction* transaction);
+    void manuallyClearActiveWriteTransaction(Transaction* transaction);
     void rollback(Transaction* transaction);
+    // This functions locks the mutex to start new transactions. This lock needs to be manually
+    // unlocked later by calling allowReceivingNewTransactions() by the thread that called
+    // stopNewTransactionsAndWaitUntilAllReadTransactionsLeave().
+    void stopNewTransactionsAndWaitUntilAllReadTransactionsLeave();
+    void allowReceivingNewTransactions();
 
     // Warning: Below public functions are for tests only
     inline unordered_set<uint64_t>& getActiveReadOnlyTransactionIDs() {
-        lock_t lck{mtx};
+        lock_t lck{mtxForSerializingPublicFunctionCalls};
         return activeReadOnlyTransactionIDs;
     }
     inline uint64_t getActiveWriteTransactionID() {
-        lock_t lck{mtx};
+        lock_t lck{mtxForSerializingPublicFunctionCalls};
         return activeWriteTransactionID;
     }
     inline bool hasActiveWriteTransactionID() {
-        lock_t lck{mtx};
+        lock_t lck{mtxForSerializingPublicFunctionCalls};
         return activeWriteTransactionID != INT64_MAX;
+    }
+    inline void setCheckPointWaitTimeoutForTransactionsToLeaveInMicros(uint64_t waitTimeInMicros) {
+        checkPointWaitTimeoutForTransactionsToLeaveInMicros = waitTimeInMicros;
     }
 
 private:
     inline bool hasActiveWriteTransactionNoLock() { return activeWriteTransactionID != INT64_MAX; }
-    inline void clearActiveWriteTransactionNoLock() { activeWriteTransactionID = INT64_MAX; }
-    void commitOrRollback(Transaction* transaction, bool isCommit);
+    inline void clearActiveWriteTransactionIfWriteTransactionNoLock(Transaction* transaction) {
+        if (transaction->isWriteTransaction()) {
+            activeWriteTransactionID = INT64_MAX;
+        }
+    }
+    void commitOrRollbackNoLock(Transaction* transaction, bool isCommit);
+    void assertActiveWriteTransationIsCorrectNoLock(Transaction* transaction);
 
 private:
     shared_ptr<spdlog::logger> logger;
+
+    storage::WAL& wal;
 
     uint64_t activeWriteTransactionID;
 
@@ -59,7 +78,13 @@ private:
     // and the for the writer transaction, so we can read correct version by looking at the type of
     // the transaction.
     uint64_t lastCommitID;
-    mutex mtx;
+    // This mutex is used to ensure thread safety and letting only one public function to be called
+    // at any time except the stopNewTransactionsAndWaitUntilAllReadTransactionsLeave
+    // function, which needs to let calls to comming and rollback.
+    mutex mtxForSerializingPublicFunctionCalls;
+    mutex mtxForStartingNewTransactions;
+    uint64_t checkPointWaitTimeoutForTransactionsToLeaveInMicros =
+        DEFAULT_CHECKPOINT_WAIT_TIMEOUT_FOR_TRANSACTIONS_TO_LEAVE_IN_MICROS;
 };
 } // namespace transaction
 } // namespace graphflow

--- a/test/loader/loader_test.cpp
+++ b/test/loader/loader_test.cpp
@@ -93,7 +93,6 @@ TEST_F(LoaderNodePropertyTest, NodeStructuredStringPropertyTest) {
         csvReader.hasNextToken();
         csvReader.skipToken();
         csvReader.hasNextToken();
-        cout << "count: " << count;
         if ((count % 100) == 0) {
             ASSERT_TRUE(column->isNull(count /* nodeOffset */));
         } else {

--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -45,16 +45,27 @@ TEST_F(ApiTest, TransactionModes) {
     // Test beginning a transaction (first in read only mode) sets mode to MANUAL automatically.
     conn->beginReadOnlyTransaction();
     ASSERT_EQ(Connection::ConnectionTransactionMode::MANUAL, conn->getTransactionMode());
+    // Test commit automatically switches the mode to AUTO_COMMIT read transaction
+    conn->commit();
+    ASSERT_EQ(Connection::ConnectionTransactionMode::AUTO_COMMIT, conn->getTransactionMode());
 
-    // Test commit automatically switches the mode to AUTO_COMMIT
+    conn->beginReadOnlyTransaction();
+    ASSERT_EQ(Connection::ConnectionTransactionMode::MANUAL, conn->getTransactionMode());
+    // Test rollback automatically switches the mode to AUTO_COMMIT for read transaction
+    conn->rollback();
+    ASSERT_EQ(Connection::ConnectionTransactionMode::AUTO_COMMIT, conn->getTransactionMode());
+
+    // Test beginning a transaction (now in write mode) sets mode to MANUAL automatically.
+    conn->beginWriteTransaction();
+    ASSERT_EQ(Connection::ConnectionTransactionMode::MANUAL, conn->getTransactionMode());
+    // Test commit automatically switches the mode to AUTO_COMMIT for write transaction
     conn->commit();
     ASSERT_EQ(Connection::ConnectionTransactionMode::AUTO_COMMIT, conn->getTransactionMode());
 
     // Test beginning a transaction (now in write mode) sets mode to MANUAL automatically.
     conn->beginWriteTransaction();
     ASSERT_EQ(Connection::ConnectionTransactionMode::MANUAL, conn->getTransactionMode());
-
-    // Test rollback automatically switches the mode to AUTO_COMMIT
+    // Test rollback automatically switches the mode to AUTO_COMMIT write transaction
     conn->rollback();
     ASSERT_EQ(Connection::ConnectionTransactionMode::AUTO_COMMIT, conn->getTransactionMode());
 }

--- a/test/runner/queries/functions/arithmetic_functions.test
+++ b/test/runner/queries/functions/arithmetic_functions.test
@@ -336,7 +336,6 @@
 20922789888000
 2
 
-
 -NAME gammaFunctionOnUnstrDoubleTest
 -QUERY MATCH (a:organisation) RETURN gamma(abs(a.unstrNumericProp) - 3)
 ---- 3

--- a/test/storage/BUILD.bazel
+++ b/test/storage/BUILD.bazel
@@ -32,3 +32,20 @@ cc_test(
         "@gtest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "wal_replayer_test",
+    srcs = [
+        "wal_replayer_test.cpp",
+    ],
+    copts = [
+        "-Iexternal/gtest/include",
+    ],
+    data = [
+        "//dataset",
+    ],
+    deps = [
+        "//src/storage:storage_manager",
+        "//test/test_utility:test_helper",
+    ],
+)

--- a/test/storage/buffer_manager_test.cpp
+++ b/test/storage/buffer_manager_test.cpp
@@ -32,7 +32,7 @@ TEST_F(BufferManagerTests, RemoveFilePagesFromFramesTest) {
     }
     bufferManager->unpin(fileHandle, 10);
     bufferManager->unpin(fileHandle, 999);
-    bufferManager->removeOrFlushPagesFromFrames(fileHandle, true /* isRemovingPages */);
+    bufferManager->removeFilePagesFromFrames(fileHandle);
     for (int pageIdx = 0; pageIdx < numPagesToAdd; ++pageIdx) {
         ASSERT_FALSE(FileHandle::isAFrame(fileHandle.getFrameIdx(pageIdx)));
     }

--- a/test/storage/wal_replayer_test.cpp
+++ b/test/storage/wal_replayer_test.cpp
@@ -1,0 +1,22 @@
+#include "test/test_utility/include/test_helper.h"
+
+#include "src/storage/include/wal_replayer.h"
+
+using namespace graphflow::storage;
+using namespace graphflow::testing;
+
+class WALReplayerTests : public DBLoadedTest {
+public:
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+};
+
+TEST_F(WALReplayerTests, ReplayingUncommittedWALForChekpointErrors) {
+    auto walIterator = database->getStorageManager()->getWAL().getIterator();
+    WALReplayer walReplayer(
+        *database->getStorageManager(), *database->getBufferManager(), true /* is checkpointWAL */);
+    try {
+        walReplayer.replay();
+        FAIL();
+    } catch (StorageException& e) {
+    } catch (Exception& e) { FAIL(); }
+}

--- a/test/test_utility/include/test_helper.h
+++ b/test/test_utility/include/test_helper.h
@@ -33,6 +33,8 @@ public:
     static vector<string> getOutput(QueryResult& queryResult, bool checkOutputOrder = false);
 };
 
+// Loads a database from raw csv files and creates a disk-based DatabaseConfig. To have an in-memory
+// version, the databaseConfig field needs to be manually changed as in InMemoryDBLoadedTest.
 class BaseGraphLoadingTest : public Test {
 
 public:
@@ -42,7 +44,10 @@ public:
         loadGraph();
     }
 
-    void TearDown() override { FileUtils::removeDir(TestHelper::TEMP_TEST_DIR); }
+    void TearDown() override {
+        FileUtils::removeDir(TestHelper::TEMP_TEST_DIR);
+        auto fullFilePath = TestHelper::TEMP_TEST_DIR + string(".wal");
+    }
 
     virtual string getInputCSVDir() = 0;
 


### PR DESCRIPTION
Adds checkpointing logic for a committed transactions. The logic is currently implemented in database.h temporarily. That is because in absence of the frontend, the current tests do not use the connection class to interact with the db using transactions. Instead, we manually create transactions by calling transactionManager::beginWriteTransaction etc. Ideally this logic should go to connection.cpp. The logic is this:

For a write transaction that is committing:
1. write ahead the wal to disk
2. wait until all other running (read-only) transactions leave the system
3. commit (but keep the active transaction alive because currently each commit is immediately followed by a checkpoint)
4. storageManager::checkpoint()
5. truncate the wal to empty (by calling wal::clearWAL.
6. clear active transaction
7. allow new transactions to come in the system

For a write transaction that is rolling back:
only steps 6 and 7 run.

We currently have the logic to error and rollback if waiting for existing transactions to leave the system. This will be better tested when we start testing transactions through connection. For example we don't currently test that after this error the transaction is rolled back and wal is cleared etc, which will automatically happen through the connection. 
 
Checkpointing Algorithm:
This is implemented in a new WALReplayer (wal_replayer.h/cpp) class and is straightforward: We loop over each log and redo during checkpointing.  WALReplayer is also used for rolling back to undo some operations and these two algorithms share code. Although database files are guaranteed to not be updated during WAL, other structures, such as PageVersionInfo, can be updated and need to be undone. WALReplayer can be constructed either in checkpoint or rollback mode and in both modes call the same replay() function which for checkpointing does the extra work of copying over updates from WAL pages to the original db files and in both modes replay() also undoes the changes to the PageVersionInfo (and later possibly other structures).