### PR TITLE
Recovery

### DIFF
--- a/src/storage/buffer_pool.cpp
+++ b/src/storage/buffer_pool.cpp
@@ -70,11 +70,11 @@ void BufferPool::resize(uint64_t newSize) {
 }
 
 uint8_t* BufferPool::pin(FileHandle& fileHandle, uint32_t pageIdx) {
-    return pin(fileHandle, pageIdx, false /* do not read page from file */);
+    return pin(fileHandle, pageIdx, false /* read page from file */);
 }
 
 uint8_t* BufferPool::pinWithoutReadingFromFile(FileHandle& fileHandle, uint32_t pageIdx) {
-    return pin(fileHandle, pageIdx, true /* read page from file */);
+    return pin(fileHandle, pageIdx, true /* do not read page from file */);
 }
 
 void BufferPool::removeFilePagesFromFrames(FileHandle& fileHandle) {

--- a/src/storage/include/storage_manager.h
+++ b/src/storage/include/storage_manager.h
@@ -38,11 +38,17 @@ public:
     inline RelsStore& getRelsStore() const { return *relsStore; }
     inline NodesStore& getNodesStore() const { return *nodesStore; }
     inline WAL& getWAL() const { return *wal; }
-    void checkpointWAL();
-    void rollbackWAL();
+    inline void checkpointAndClearWAL() {
+        checkpointOrRollbackAndClearWAL(true /* isCheckpoint */);
+    }
+
+    inline void rollbackAndClearWAL() {
+        checkpointOrRollbackAndClearWAL(false /* rolling back updates */);
+    }
 
 private:
-    void checkpointOrRollbackWAL(bool isCheckpoint);
+    void checkpointOrRollbackAndClearWAL(bool isCheckpoint);
+    void recoverIfNecessary();
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -64,7 +64,6 @@ void WALReplayer::replay() {
     }
     auto walIterator = storageManager.getWAL().getIterator();
     WALRecord walRecord;
-    uint64_t i = 0;
     while (walIterator->hasNextRecord()) {
         walIterator->getNextRecord(walRecord);
         replayWALRecord(walRecord);


### PR DESCRIPTION
Adds the recovery logic to StorageManager. When the StorageManager is constructed, it checks if the WAL existed and if so replays it if the last record is commit, otherwise discards it. Therefore we have an implicit assumption that a WAL file can only represent a single transaction's state. So for example you cannot find logs related two transactions where one has committed and the other has not. Once this assumption fails to hold, we need to change the logic to replay and possibly do redo operations even if the last record is not commit or something even more advanced.

If there are tests you'd like to see, let me know.