### PR TITLE
Executor state init

### DIFF
--- a/src/expression_evaluator/base_evaluator.cpp
+++ b/src/expression_evaluator/base_evaluator.cpp
@@ -19,14 +19,5 @@ void BaseExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager* me
     }
 }
 
-bool BaseExpressionEvaluator::isResultVectorFlat() {
-    for (auto& child : children) {
-        if (!child->isResultVectorFlat()) {
-            return false;
-        }
-    }
-    return true;
-}
-
 } // namespace evaluator
 } // namespace graphflow

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -14,18 +14,9 @@ void FunctionExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager
     resultVector = make_shared<ValueVector>(memoryManager, expression->dataType);
     if (children.empty()) {
         resultVector->state = DataChunkState::getSingleValueDataChunkState();
-    } else {
-        // set resultVector state to the state of its unFlat child if there is any
-        resultVector->state = children[0]->resultVector->state;
-        for (auto& child : children) {
-            if (!child->isResultVectorFlat()) {
-                resultVector->state = child->resultVector->state;
-                break;
-            }
-        }
-        for (auto& child : children) {
-            parameters.push_back(child->resultVector);
-        }
+    }
+    for (auto& child : children) {
+        parameters.push_back(child->resultVector);
     }
 }
 

--- a/src/expression_evaluator/include/base_evaluator.h
+++ b/src/expression_evaluator/include/base_evaluator.h
@@ -37,8 +37,6 @@ public:
 
     virtual void init(const ResultSet& resultSet, MemoryManager* memoryManager);
 
-    virtual bool isResultVectorFlat();
-
     virtual void evaluate() = 0;
 
     virtual uint64_t select(sel_t* selectedPos) = 0;

--- a/src/expression_evaluator/include/function_evaluator.h
+++ b/src/expression_evaluator/include/function_evaluator.h
@@ -25,11 +25,6 @@ public:
     unique_ptr<BaseExpressionEvaluator> clone() override;
 
 private:
-    void getExecFunction();
-
-    void getSelectFunction();
-
-private:
     shared_ptr<Expression> expression;
     scalar_exec_func execFunc;
     scalar_select_func selectFunc;

--- a/src/expression_evaluator/include/literal_evaluator.h
+++ b/src/expression_evaluator/include/literal_evaluator.h
@@ -15,8 +15,6 @@ public:
 
     void init(const ResultSet& resultSet, MemoryManager* memoryManager) override;
 
-    inline bool isResultVectorFlat() override { return true; }
-
     inline void evaluate() override {}
 
     uint64_t select(sel_t* selectedPos) override;

--- a/src/expression_evaluator/include/reference_evaluator.h
+++ b/src/expression_evaluator/include/reference_evaluator.h
@@ -8,24 +8,21 @@ namespace evaluator {
 class ReferenceExpressionEvaluator : public BaseExpressionEvaluator {
 
 public:
-    ReferenceExpressionEvaluator(const DataPos& vectorPos, bool isVectorFlat)
-        : BaseExpressionEvaluator{}, vectorPos{vectorPos}, isVectorFlat{isVectorFlat} {}
+    ReferenceExpressionEvaluator(const DataPos& vectorPos)
+        : BaseExpressionEvaluator{}, vectorPos{vectorPos} {}
 
     void init(const ResultSet& resultSet, MemoryManager* memoryManager) override;
-
-    inline bool isResultVectorFlat() override { return isVectorFlat; }
 
     inline void evaluate() override {}
 
     uint64_t select(sel_t* selectedPos) override;
 
     inline unique_ptr<BaseExpressionEvaluator> clone() override {
-        return make_unique<ReferenceExpressionEvaluator>(vectorPos, isVectorFlat);
+        return make_unique<ReferenceExpressionEvaluator>(vectorPos);
     }
 
 private:
     DataPos vectorPos;
-    bool isVectorFlat;
 };
 
 } // namespace evaluator

--- a/src/function/boolean/include/boolean_operation_executor.h
+++ b/src/function/boolean/include/boolean_operation_executor.h
@@ -30,6 +30,7 @@ struct BinaryBooleanOperationExecutor {
 
     template<typename FUNC>
     static void executeBothFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        result.state = left.state;
         auto lPos = left.state->getPositionOfCurrIdx();
         auto rPos = right.state->getPositionOfCurrIdx();
         auto resPos = result.state->getPositionOfCurrIdx();
@@ -38,6 +39,7 @@ struct BinaryBooleanOperationExecutor {
 
     template<typename FUNC>
     static void executeFlatUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        result.state = right.state;
         auto lPos = left.state->getPositionOfCurrIdx();
         if (right.state->isUnfiltered()) {
             for (auto i = 0u; i < right.state->selectedSize; ++i) {
@@ -53,6 +55,7 @@ struct BinaryBooleanOperationExecutor {
 
     template<typename FUNC>
     static void executeUnFlatFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        result.state = left.state;
         auto rPos = right.state->getPositionOfCurrIdx();
         if (left.state->isUnfiltered()) {
             for (auto i = 0u; i < left.state->selectedSize; ++i) {
@@ -68,6 +71,8 @@ struct BinaryBooleanOperationExecutor {
 
     template<typename FUNC>
     static void executeBothUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        assert(left.state == right.state);
+        result.state = left.state;
         if (left.state->isUnfiltered()) {
             for (auto i = 0u; i < left.state->selectedSize; ++i) {
                 executeOnValue<FUNC>(left, right, result, i, i, i);

--- a/src/function/include/binary_operation_executor.h
+++ b/src/function/include/binary_operation_executor.h
@@ -59,6 +59,7 @@ struct BinaryOperationExecutor {
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC,
         typename OP_WRAPPER>
     static void executeBothFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        result.state = left.state;
         auto lPos = left.state->getPositionOfCurrIdx();
         auto rPos = right.state->getPositionOfCurrIdx();
         auto resPos = result.state->getPositionOfCurrIdx();
@@ -72,6 +73,7 @@ struct BinaryOperationExecutor {
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC,
         typename OP_WRAPPER>
     static void executeFlatUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        result.state = right.state;
         auto lPos = left.state->getPositionOfCurrIdx();
         if (left.isNull(lPos)) {
             result.setAllNull();
@@ -113,6 +115,7 @@ struct BinaryOperationExecutor {
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC,
         typename OP_WRAPPER>
     static void executeUnFlatFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
+        result.state = left.state;
         auto rPos = right.state->getPositionOfCurrIdx();
         if (right.isNull(rPos)) {
             result.setAllNull();
@@ -154,7 +157,8 @@ struct BinaryOperationExecutor {
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC,
         typename OP_WRAPPER>
     static void executeBothUnFlat(ValueVector& left, ValueVector& right, ValueVector& result) {
-        // right, left, and result vectors share the same selectedPositions.
+        assert(left.state == right.state);
+        result.state = left.state;
         if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
             if (result.state->isUnfiltered()) {
                 for (uint64_t i = 0; i < result.state->selectedSize; i++) {

--- a/src/function/include/ternary_operation_executor.h
+++ b/src/function/include/ternary_operation_executor.h
@@ -43,6 +43,7 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeAllFlat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
+        result.state = a.state;
         auto aPos = a.state->getPositionOfCurrIdx();
         auto bPos = b.state->getPositionOfCurrIdx();
         auto cPos = c.state->getPositionOfCurrIdx();
@@ -58,10 +59,9 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeFlatFlatUnflat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
+        result.state = c.state;
         auto aPos = a.state->getPositionOfCurrIdx();
         auto bPos = b.state->getPositionOfCurrIdx();
-        // c and result should share the same dataChunk state.
-        assert(c.state == result.state);
         if (a.isNull(aPos) || b.isNull(bPos)) {
             result.setAllNull();
         } else if (c.hasNoNullsGuarantee()) {
@@ -103,9 +103,9 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeFlatUnflatUnflat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
+        assert(b.state == c.state);
+        result.state = b.state;
         auto aPos = a.state->getPositionOfCurrIdx();
-        // b, c and result should share the same dataChunk state.
-        assert(b.state == c.state && c.state == result.state);
         if (a.isNull(aPos)) {
             result.setAllNull();
         } else if (b.hasNoNullsGuarantee() && c.hasNoNullsGuarantee()) {
@@ -147,10 +147,9 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeFlatUnflatFlat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
+        result.state = b.state;
         auto aPos = a.state->getPositionOfCurrIdx();
         auto cPos = c.state->getPositionOfCurrIdx();
-        // b and result should share the same dataChunk state.
-        assert(b.state == result.state);
         if (a.isNull(aPos) || c.isNull(cPos)) {
             result.setAllNull();
         } else if (b.hasNoNullsGuarantee()) {
@@ -192,8 +191,8 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeAllUnFlat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
-        // a, b, c and result should share the same dataChunk state.
-        assert(a.state == b.state && b.state == c.state && c.state == result.state);
+        assert(a.state == b.state && b.state == c.state);
+        result.state = a.state;
         if (a.hasNoNullsGuarantee() && b.hasNoNullsGuarantee() && c.hasNoNullsGuarantee()) {
             if (a.state->isUnfiltered()) {
                 for (uint64_t i = 0; i < a.state->selectedSize; i++) {
@@ -233,10 +232,9 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeUnflatFlatFlat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
+        result.state = a.state;
         auto bPos = b.state->getPositionOfCurrIdx();
         auto cPos = c.state->getPositionOfCurrIdx();
-        // a and result should share the same dataChunk state.
-        assert(a.state == result.state);
         if (b.isNull(bPos) || c.isNull(cPos)) {
             result.setAllNull();
         } else if (a.hasNoNullsGuarantee()) {
@@ -278,9 +276,9 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeUnflatFlatUnflat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
+        assert(a.state == c.state);
+        result.state = a.state;
         auto bPos = b.state->getPositionOfCurrIdx();
-        // a, c and result should share the same dataChunk state.
-        assert(a.state == c.state && c.state == result.state);
         if (b.isNull(bPos)) {
             result.setAllNull();
         } else if (a.hasNoNullsGuarantee() && c.hasNoNullsGuarantee()) {
@@ -322,9 +320,9 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeUnflatUnFlatFlat(
         ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result) {
+        assert(a.state == b.state);
+        result.state = a.state;
         auto cPos = c.state->getPositionOfCurrIdx();
-        // a, b and result should share the same dataChunk state.
-        assert(a.state == b.state && b.state == result.state);
         if (c.isNull(cPos)) {
             result.setAllNull();
         } else if (a.hasNoNullsGuarantee() && b.hasNoNullsGuarantee()) {

--- a/src/function/include/unary_operation_executor.h
+++ b/src/function/include/unary_operation_executor.h
@@ -49,10 +49,10 @@ struct UnaryOperationExecutor {
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC, typename OP_WRAPPER>
     static void executeSwitch(ValueVector& operand, ValueVector& result) {
         result.resetOverflowBuffer();
+        result.state = operand.state;
         auto resultValues = (RESULT_TYPE*)result.values;
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
-            assert(pos == result.state->getPositionOfCurrIdx());
             result.setNull(pos, operand.isNull(pos));
             if (!result.isNull(pos)) {
                 executeOnValue<OPERAND_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(

--- a/src/function/list/vector_list_operation.cpp
+++ b/src/function/list/vector_list_operation.cpp
@@ -15,8 +15,15 @@ namespace function {
 
 void VectorListOperations::ListCreation(
     const vector<shared_ptr<ValueVector>>& parameters, ValueVector& result) {
-    result.resetOverflowBuffer();
     assert(!parameters.empty() && result.dataType.typeID == LIST);
+    result.state = parameters[0]->state;
+    for (auto& parameter : parameters) {
+        if (!parameter->state->isFlat()) {
+            result.state = parameter->state;
+            break;
+        }
+    }
+    result.resetOverflowBuffer();
     auto& childType = parameters[0]->dataType;
     auto numBytesOfListElement = Types::getDataTypeSize(childType);
     vector<uint8_t*> listElements(parameters.size());

--- a/src/function/null/include/null_operation_executor.h
+++ b/src/function/null/include/null_operation_executor.h
@@ -10,11 +10,11 @@ struct NullOperationExecutor {
     template<typename FUNC>
     static void execute(ValueVector& operand, ValueVector& result) {
         assert(result.dataType.typeID == BOOL);
+        result.state = operand.state;
         auto operandValues = (uint8_t*)operand.values;
         auto resultValues = (uint8_t*)result.values;
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
-            assert(pos == result.state->getPositionOfCurrIdx());
             FUNC::operation(operandValues[pos], (bool)operand.isNull(pos), resultValues[pos]);
         } else {
             if (operand.state->isUnfiltered()) {

--- a/src/processor/include/physical_plan/mapper/mapper_context.h
+++ b/src/processor/include/physical_plan/mapper/mapper_context.h
@@ -17,14 +17,6 @@ public:
         return resultSetDescriptor->getDataPos(name);
     }
 
-    inline void flattenDataChunk(uint64_t dataChunkPos) {
-        resultSetDescriptor->getDataChunkDescriptor(dataChunkPos)->flatten();
-    }
-
-    inline bool isDataChunkFlat(uint64_t dataChunkPos) const {
-        return resultSetDescriptor->getDataChunkDescriptor(dataChunkPos)->getIsFlat();
-    }
-
     // We keep track of computed expressions during a bottom-up mapping of logical plan so that we
     // can differentiate if an expression is leaf or not.
     inline void addComputedExpressions(const string& name) { computedExpressionNames.insert(name); }

--- a/src/processor/include/physical_plan/result/result_set_descriptor.h
+++ b/src/processor/include/physical_plan/result/result_set_descriptor.h
@@ -16,19 +16,11 @@ namespace processor {
 class DataChunkDescriptor {
 
 public:
-    DataChunkDescriptor() : isFlat{false} {};
+    DataChunkDescriptor() = default;
 
     DataChunkDescriptor(const DataChunkDescriptor& other)
-        : isFlat{other.isFlat},
-          expressionNameToValueVectorPosMap{other.expressionNameToValueVectorPosMap},
+        : expressionNameToValueVectorPosMap{other.expressionNameToValueVectorPosMap},
           expressionNames{other.expressionNames} {}
-
-    inline void flatten() {
-        assert(isFlat == false);
-        isFlat = true;
-    }
-
-    inline bool getIsFlat() const { return isFlat; }
 
     inline uint32_t getValueVectorPos(const string& name) const {
         assert(expressionNameToValueVectorPosMap.contains(name));
@@ -43,7 +35,6 @@ public:
     }
 
 private:
-    bool isFlat;
     unordered_map<string, uint32_t> expressionNameToValueVectorPosMap;
     vector<string> expressionNames;
 };

--- a/src/processor/physical_plan/mapper/expression_mapper.cpp
+++ b/src/processor/physical_plan/mapper/expression_mapper.cpp
@@ -39,8 +39,7 @@ unique_ptr<BaseExpressionEvaluator> ExpressionMapper::mapParameterExpression(
 unique_ptr<BaseExpressionEvaluator> ExpressionMapper::mapReferenceExpression(
     const shared_ptr<Expression>& expression, const MapperContext& mapperContext) {
     auto vectorPos = mapperContext.getDataPos(expression->getUniqueName());
-    return make_unique<ReferenceExpressionEvaluator>(
-        vectorPos, mapperContext.isDataChunkFlat(vectorPos.dataChunkPos));
+    return make_unique<ReferenceExpressionEvaluator>(vectorPos);
 }
 
 unique_ptr<BaseExpressionEvaluator> ExpressionMapper::mapFunctionExpression(

--- a/src/processor/physical_plan/mapper/plan_mapper.cpp
+++ b/src/processor/physical_plan/mapper/plan_mapper.cpp
@@ -237,7 +237,6 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFlattenToPhysical(
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto dataChunkPos =
         mapperContext.getDataPos(flatten.getExpressionToFlatten()->getUniqueName()).dataChunkPos;
-    mapperContext.flattenDataChunk(dataChunkPos);
     return make_unique<Flatten>(dataChunkPos, move(prevOperator), mapperContext.getOperatorID());
 }
 


### PR DESCRIPTION
Set expression evaluator result state during runtime. This does not give us performance benefit but instead makes our proceesor design more unified. Our operators do not make assumption about whether an input vector is flat or not and instead makes runtime decisions. Therefore, our expression evaluator shouldn't acquire flat information during compile time.