### PR TITLE
Integrate hash index into the graph loader

### DIFF
--- a/dataset/loader-fault-tests/duplicate-ids/metadata.json
+++ b/dataset/loader-fault-tests/duplicate-ids/metadata.json
@@ -1,0 +1,12 @@
+{
+  "tokenSeparator": ",",
+  "nodeFileDescriptions": [
+    {
+      "filename": "vPerson.csv",
+      "label": "person",
+      "IDType": "INT64"
+    }
+  ],
+  "relFileDescriptions": [
+  ]
+}

--- a/dataset/loader-fault-tests/duplicate-ids/vPerson.csv
+++ b/dataset/loader-fault-tests/duplicate-ids/vPerson.csv
@@ -1,0 +1,5 @@
+:ID,fName:STRING
+10,Guodong
+24,Semih
+31,Xiyang
+10,Ziyi

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -368,17 +368,6 @@ const Property& Catalog::getNodeProperty(label_t labelId, const string& property
     return getUnstructuredNodeProperties(labelId)[unstrPropertyIdx];
 }
 
-const Property& Catalog::getStructuredNodeProperty(
-    label_t labelID, const uint32_t propertyID) const {
-    for (auto& property : nodeLabels[labelID].structuredProperties) {
-        if (propertyID == property.propertyID) {
-            return property;
-        }
-    }
-    throw CatalogException("Structured Node Property with labelID: " + to_string(labelID) +
-                           " propertyID: " + to_string(propertyID) + " does not exist");
-}
-
 bool Catalog::containRelProperty(label_t labelId, const string& propertyName) const {
     for (auto& property : relLabels[labelId].properties) {
         if (propertyName == property.name) {

--- a/src/catalog/include/catalog.h
+++ b/src/catalog/include/catalog.h
@@ -207,7 +207,6 @@ public:
     // getNodeProperty and getRelProperty should be called after checking if property exists
     // (containNodeProperty and containRelProperty).
     virtual const Property& getNodeProperty(label_t labelId, const string& propertyName) const;
-    const Property& getStructuredNodeProperty(label_t labelId, const uint32_t propertyID) const;
     virtual const Property& getRelProperty(label_t labelId, const string& propertyName) const;
 
     vector<Property> getAllNodeProperties(label_t nodeLabel) const;

--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -36,11 +36,12 @@ constexpr const uint64_t DEFAULT_CHECKPOINT_WAIT_TIMEOUT_FOR_TRANSACTIONS_TO_LEA
 
 struct StorageConfig {
     // The default amount of memory pre-allocated to the buffer pool (= 2MB).
-    static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 21;
+    static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 22;
     static constexpr char OVERFLOW_FILE_SUFFIX[] = ".ovf";
     static constexpr char COLUMN_FILE_SUFFIX[] = ".col";
     static constexpr char LISTS_FILE_SUFFIX[] = ".lists";
     static constexpr char WAL_FILE_SUFFIX[] = ".wal";
+    static constexpr char INDEX_FILE_SUFFIX[] = ".hindex";
     // LIST_CHUNK_SIZE should strictly be a power of 2.
     constexpr static uint16_t LISTS_CHUNK_SIZE_LOG_2 = 9;
     constexpr static uint16_t LISTS_CHUNK_SIZE = 1 << LISTS_CHUNK_SIZE_LOG_2;

--- a/src/common/types/gf_string.cpp
+++ b/src/common/types/gf_string.cpp
@@ -44,7 +44,9 @@ string gf_string_t::getAsString() const {
 
 bool gf_string_t::operator==(const gf_string_t& rhs) const {
     // First compare the length and prefix of the strings.
-    if (!memcmp(this, &rhs, gf_string_t::STR_LENGTH_PLUS_PREFIX_LENGTH)) {
+    auto numBytesOfLenAndPrefix =
+        sizeof(uint32_t) + min((uint64_t)len, static_cast<uint64_t>(gf_string_t::PREFIX_LENGTH));
+    if (!memcmp(this, &rhs, numBytesOfLenAndPrefix)) {
         // If length and prefix of a and b are equal, we compare the overflow buffer.
         return !memcmp(getData(), rhs.getData(), len);
     }

--- a/src/common/types/include/gf_string.h
+++ b/src/common/types/include/gf_string.h
@@ -10,7 +10,6 @@ namespace common {
 struct gf_string_t {
 
     static const uint64_t PREFIX_LENGTH = 4;
-    static const uint64_t STR_LENGTH_PLUS_PREFIX_LENGTH = sizeof(uint32_t) + PREFIX_LENGTH;
     static const uint64_t INLINED_SUFFIX_LENGTH = 8;
     static const uint64_t SHORT_STR_LENGTH = PREFIX_LENGTH + INLINED_SUFFIX_LENGTH;
 

--- a/src/loader/BUILD.bazel
+++ b/src/loader/BUILD.bazel
@@ -34,6 +34,7 @@ cc_library(
         "//src/common:type_utils",
         "//src/common/types",
         "//src/storage:compression_scheme",
+        "//src/storage:hash_index",
         "//src/storage:storage_manager",
         "@gabime_spdlog",
         "@martinus_robin_hood_hashing",

--- a/src/loader/include/graph_loader.h
+++ b/src/loader/include/graph_loader.h
@@ -7,7 +7,7 @@
 #include "src/common/include/task_system/task_scheduler.h"
 #include "src/loader/include/dataset_metadata.h"
 #include "src/loader/include/loader_progress_bar.h"
-#include "src/loader/include/node_id_map.h"
+#include "src/storage/include/index/hash_index.h"
 
 using namespace graphflow::storage;
 using namespace graphflow::catalog;
@@ -26,8 +26,8 @@ public:
 private:
     void readAndParseMetadata(DatasetMetadata& metadata);
 
-    vector<unique_ptr<NodeIDMap>> loadNodes();
-    void loadRels(const vector<unique_ptr<NodeIDMap>>& nodeIDMaps);
+    vector<unique_ptr<HashIndex>> loadNodes();
+    void loadRels(const vector<unique_ptr<HashIndex>>& IDIndexes);
 
     void cleanup();
 
@@ -37,6 +37,7 @@ private:
     const string inputDirectory;
     const string outputDirectory;
     unique_ptr<Catalog> catalog;
+    unique_ptr<BufferManager> bufferManager;
     DatasetMetadata datasetMetadata;
     unique_ptr<LoaderProgressBar> progressBar;
 };

--- a/src/loader/include/in_mem_structure/builder/in_mem_rel_builder.h
+++ b/src/loader/include/in_mem_structure/builder/in_mem_rel_builder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/loader/include/in_mem_structure/builder/in_mem_structures_builder.h"
+#include "src/storage/include/index/hash_index.h"
 
 namespace graphflow {
 namespace loader {
@@ -10,7 +11,7 @@ class InMemRelBuilder : public InMemStructuresBuilder {
 public:
     InMemRelBuilder(label_t label, const RelFileDescription& fileDescription,
         string outputDirectory, TaskScheduler& taskScheduler, Catalog& catalog,
-        const vector<unique_ptr<NodeIDMap>>& nodeIDMaps, LoaderProgressBar* progressBar);
+        const vector<unique_ptr<HashIndex>>& IDIndexes, LoaderProgressBar* progressBar);
 
     ~InMemRelBuilder() override = default;
 
@@ -32,8 +33,8 @@ private:
 
     uint64_t getNumTasksOfInitializingAdjAndPropertyListsMetadata();
     static void inferLabelsAndOffsets(CSVReader& reader, vector<nodeID_t>& nodeIDs,
-        const vector<unique_ptr<NodeIDMap>>& nodeIDMaps, const Catalog& catalog,
-        vector<bool>& requireToReadLabels);
+        vector<DataType>& nodeIDTypes, const vector<unique_ptr<HashIndex>>& IDIndexes,
+        const Catalog& catalog, vector<bool>& requireToReadLabels);
     static void putPropsOfLineIntoColumns(
         vector<label_property_columns_map_t>& directionLabelPropertyColumns,
         const vector<Property>& properties, vector<unique_ptr<InMemOverflowPages>>& overflowPages,
@@ -64,7 +65,7 @@ private:
     vector<string> srcNodeLabelNames;
     vector<string> dstNodeLabelNames;
 
-    const vector<unique_ptr<NodeIDMap>>& nodeIDMaps;
+    const vector<unique_ptr<HashIndex>>& IDIndexes;
     vector<vector<unique_ptr<atomic_uint64_vec_t>>> directionLabelListSizes{2};
     vector<unique_ptr<atomic_uint64_vec_t>> directionNumRelsPerLabel{2};
     vector<NodeIDCompressionScheme> directionNodeIDCompressionScheme{2};

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -155,22 +155,22 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "column",
+        "hash_index",
         "lists",
         "//src/catalog",
     ],
 )
-
 
 cc_library(
     name = "wal",
     srcs = [
         "wal/wal.cpp",
         "wal/wal_record.cpp",
-        ],
+    ],
     hdrs = [
         "include/wal/wal.h",
         "include/wal/wal_record.h",
-        ],
+    ],
     visibility = [
         "//visibility:public",
     ],
@@ -185,11 +185,11 @@ cc_library(
     name = "storage_manager",
     srcs = [
         "storage_manager.cpp",
-        "wal_replayer.cpp"
+        "wal_replayer.cpp",
     ],
     hdrs = [
         "include/storage_manager.h",
-        "include/wal_replayer.h"
+        "include/wal_replayer.h",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/storage/buffer_pool.cpp
+++ b/src/storage/buffer_pool.cpp
@@ -254,8 +254,9 @@ void BufferPool::moveClockHand(uint64_t newClockHand) {
 void BufferPool::unpin(FileHandle& fileHandle, uint32_t pageIdx) {
     fileHandle.acquirePageLock(pageIdx, true /*block*/);
     auto& frame = bufferCache[fileHandle.getFrameIdx(pageIdx)];
-    assert(frame->pinCount.load() >= 1);
-    frame->pinCount.fetch_sub(1);
+    // `count` is the value of `pinCount` before sub.
+    auto count = frame->pinCount.fetch_sub(1);
+    assert(count >= 1);
     fileHandle.releasePageLock(pageIdx);
 }
 } // namespace storage

--- a/src/storage/include/index/hash_index.h
+++ b/src/storage/include/index/hash_index.h
@@ -133,9 +133,11 @@ constexpr uint64_t INDEX_HEADER_PAGE_ID = 0;
 
 class HashIndex {
 
+    enum IndexMode { READ_ONLY, WRITE };
+
 public:
-    HashIndex(
-        string fName, const DataType& keyDataType, BufferManager& bufferManager, bool isInMemory);
+    HashIndex(string fName, const DataType& keyDataType, BufferManager& bufferManager,
+        bool isInMemoryForLookup);
 
     ~HashIndex();
 
@@ -161,7 +163,7 @@ public:
     void flush();
 
 private:
-    void initializeHeaderAndPages(const DataType& keyDataType, bool isInMemory);
+    void initializeHeaderAndPages(const DataType& keyDataType);
     bool insertInternal(const uint8_t* key, node_offset_t value);
     bool lookupInternal(const uint8_t* key, node_offset_t& result);
 
@@ -198,6 +200,9 @@ private:
 
 private:
     string fName;
+    bool isInMemoryForLookup;
+    bool isFlushed;
+    IndexMode indexMode;
     unique_ptr<FileHandle> fh;
     BufferManager& bm;
     unique_ptr<HashIndexHeader> indexHeader;

--- a/src/storage/include/storage_manager.h
+++ b/src/storage/include/storage_manager.h
@@ -6,28 +6,14 @@
 #include "src/storage/include/store/rels_store.h"
 #include "src/storage/include/wal/wal.h"
 
-using namespace std;
-using lock_t = unique_lock<mutex>;
-
 namespace spdlog {
 class logger;
 }
 
 namespace graphflow {
-namespace loader {
-
-class GraphLoader;
-class RelsLoader;
-
-} // namespace loader
-} // namespace graphflow
-
-namespace graphflow {
 namespace storage {
 
 class StorageManager {
-    friend class graphflow::loader::GraphLoader;
-    friend class graphflow::loader::RelsLoader;
 
 public:
     StorageManager(const catalog::Catalog& catalog, BufferManager& bufferManager, string directory,
@@ -54,7 +40,6 @@ private:
     shared_ptr<spdlog::logger> logger;
     BufferManager& bufferManager;
     string directory;
-    bool isInMemoryMode;
     unique_ptr<storage::WAL> wal;
     unique_ptr<NodesStore> nodesStore;
     unique_ptr<RelsStore> relsStore;

--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -88,6 +88,10 @@ public:
     static void saveListOfIntsToFile(const string& fName, uint8_t* data, uint32_t listSize);
     static uint32_t readListOfIntsFromFile(unique_ptr<uint32_t[]>& data, const string& fName);
 
+    inline static string getNodeIndexFName(const string& directory, const label_t& nodeLabel) {
+        auto fName = StringUtils::string_format("n-%d", nodeLabel);
+        return FileUtils::joinPath(directory, fName + StorageConfig::INDEX_FILE_SUFFIX);
+    }
     inline static string getNodePropertyColumnFName(
         const string& directory, const label_t& nodeLabel, const string& propertyName) {
         auto fName = StringUtils::string_format("n-%d-%s", nodeLabel, propertyName.data());

--- a/src/storage/include/store/node.h
+++ b/src/storage/include/store/node.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/catalog/include/catalog.h"
+#include "src/storage/include/index/hash_index.h"
 #include "src/storage/include/storage_structure/column.h"
 #include "src/storage/include/storage_structure/lists/lists.h"
 #include "src/storage/include/storage_structure/lists/unstructured_property_lists.h"
@@ -21,13 +22,15 @@ public:
     inline UnstructuredPropertyLists* getUnstrPropertyLists() const {
         return unstrPropertyLists.get();
     }
+    inline HashIndex* getIDIndex() const { return IDIndex.get(); }
 
 private:
-    label_t labelID;
     // This is for structured properties.
     vector<unique_ptr<Column>> propertyColumns;
     // All unstructured properties of a node are stored inside one UnstructuredPropertyLists.
     unique_ptr<UnstructuredPropertyLists> unstrPropertyLists;
+    // The index for ID property.
+    unique_ptr<HashIndex> IDIndex;
 };
 
 } // namespace storage

--- a/src/storage/include/store/nodes_store.h
+++ b/src/storage/include/store/nodes_store.h
@@ -22,6 +22,7 @@ public:
     inline UnstructuredPropertyLists* getNodeUnstrPropertyLists(label_t nodeLabel) const {
         return nodes[nodeLabel]->getUnstrPropertyLists();
     }
+    inline HashIndex* getIDIndex(label_t nodeLabel) { return nodes[nodeLabel]->getIDIndex(); }
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/index/hash_index_utils.cpp
+++ b/src/storage/index/hash_index_utils.cpp
@@ -28,13 +28,13 @@ insert_function_t HashIndexUtils::initializeInsertKeyToEntryFunc(const DataTypeI
 
 bool HashIndexUtils::isStringPrefixAndLenEquals(
     const uint8_t* keyToLookup, const gf_string_t* keyInEntry) {
-    if (memcmp(keyToLookup, keyInEntry->prefix, gf_string_t::PREFIX_LENGTH) != 0) {
-        return false;
+    auto prefixLen =
+        min((uint64_t)keyInEntry->len, static_cast<uint64_t>(gf_string_t::PREFIX_LENGTH));
+    if (strlen(reinterpret_cast<const char*>(keyToLookup)) == keyInEntry->len &&
+        memcmp(keyToLookup, keyInEntry->prefix, prefixLen) == 0) {
+        return true;
     }
-    if (strlen(reinterpret_cast<const char*>(keyToLookup)) != keyInEntry->len) {
-        return false;
-    }
-    return true;
+    return false;
 }
 
 bool HashIndexUtils::equalsFuncInWriteModeForString(const uint8_t* keyToLookup,

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -13,7 +13,7 @@ namespace storage {
 StorageManager::StorageManager(const catalog::Catalog& catalog, BufferManager& bufferManager,
     string directory, bool isInMemoryMode)
     : logger{LoggerUtils::getOrCreateSpdLogger("storage")},
-      bufferManager{bufferManager}, directory{move(directory)}, isInMemoryMode{isInMemoryMode} {
+      bufferManager{bufferManager}, directory{move(directory)} {
     logger->info("Initializing StorageManager from directory: " + this->directory);
     wal = make_unique<storage::WAL>(
         FileUtils::joinPath(this->directory, string(StorageConfig::WAL_FILE_SUFFIX)),

--- a/src/storage/store/node.cpp
+++ b/src/storage/store/node.cpp
@@ -4,10 +4,13 @@ namespace graphflow {
 namespace storage {
 
 Node::Node(label_t labelID, BufferManager& bufferManager, bool isInMemory,
-    const vector<catalog::Property>& properties, const string& directory, WAL* wal)
-    : labelID{labelID} {
+    const vector<catalog::Property>& properties, const string& directory, WAL* wal) {
     bool hasUnstructuredProperties = false;
+    auto IDPropertyIdx = UINT32_MAX;
     for (const auto& property : properties) {
+        if (property.name == LoaderConfig::ID_FIELD) {
+            IDPropertyIdx = property.propertyID;
+        }
         if (property.dataType.typeID == UNSTRUCTURED) {
             hasUnstructuredProperties = true;
         } else {
@@ -21,6 +24,8 @@ Node::Node(label_t labelID, BufferManager& bufferManager, bool isInMemory,
             StorageUtils::getNodeUnstrPropertyListsFName(directory, labelID), bufferManager,
             isInMemory);
     }
+    IDIndex = make_unique<HashIndex>(StorageUtils::getNodeIndexFName(directory, labelID),
+        properties[IDPropertyIdx].dataType, bufferManager, isInMemory);
 }
 
 } // namespace storage

--- a/test/loader/BUILD.bazel
+++ b/test/loader/BUILD.bazel
@@ -2,6 +2,7 @@ cc_test(
     name = "loader_test",
     srcs = [
         "load_dates_test.cpp",
+        "load_index_test.cpp",
         "load_interval_test.cpp",
         "load_lists_test.cpp",
         "load_timestamp_test.cpp",
@@ -15,8 +16,8 @@ cc_test(
         "//dataset",
     ],
     deps = [
-        "//src/common/types",
         "//src/common:type_utils",
+        "//src/common/types",
         "//test/test_utility:test_helper",
         "@gtest",
         "@gtest//:gtest_main",

--- a/test/loader/load_index_test.cpp
+++ b/test/loader/load_index_test.cpp
@@ -1,0 +1,38 @@
+#include "test/test_utility/include/test_helper.h"
+
+using namespace std;
+using namespace graphflow::common;
+using namespace graphflow::storage;
+using namespace graphflow::testing;
+
+class TinySnbIndexTest : public InMemoryDBLoadedTest {
+
+public:
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+};
+
+TEST_F(TinySnbIndexTest, PersonNodeIDIndex) {
+    auto storageManager = database->getStorageManager();
+    auto& nodesStore = storageManager->getNodesStore();
+    auto personIDIndex = nodesStore.getIDIndex(0);
+    int64_t personIDs[8] = {0, 2, 3, 5, 7, 8, 9, 10};
+    node_offset_t nodeOffset;
+    for (auto i = 0u; i < 8; i++) {
+        auto found = personIDIndex->lookup(personIDs[i], nodeOffset);
+        ASSERT_TRUE(found);
+        ASSERT_EQ(nodeOffset, i);
+    }
+}
+
+TEST_F(TinySnbIndexTest, OrganisationNodeIDIndex) {
+    auto storageManager = database->getStorageManager();
+    auto& nodesStore = storageManager->getNodesStore();
+    auto organisationIDIndex = nodesStore.getIDIndex(1);
+    int64_t organisationIDs[3] = {1, 4, 6};
+    node_offset_t nodeOffset;
+    for (auto i = 0u; i < 3; i++) {
+        auto found = organisationIDIndex->lookup(organisationIDs[i], nodeOffset);
+        ASSERT_TRUE(found);
+        ASSERT_EQ(nodeOffset, i);
+    }
+}

--- a/test/loader/loader_fault_test.cpp
+++ b/test/loader/loader_fault_test.cpp
@@ -63,6 +63,10 @@ class LoaderDuplicateColHeaderTest : public LoaderFaultTest {
     string getInputCSVDir() override { return "dataset/loader-fault-tests/duplicate-col-header/"; }
 };
 
+class LoaderDuplicateIDTest : public LoaderFaultTest {
+    string getInputCSVDir() override { return "dataset/loader-fault-tests/duplicate-ids/"; }
+};
+
 TEST_F(LoaderLongStringTest, LongStringError) {
     checkLoadingFaultWithErrMsg(
         "Maximum length of strings is 4096. Input string's length is 5625.");
@@ -99,4 +103,9 @@ TEST_F(LoaderImproperPropertyColHeaderTest, ImproperPropertyColHeaderError) {
 TEST_F(LoaderDuplicateColHeaderTest, DuplicateColHeaderError) {
     checkLoadingFaultWithErrMsg(
         "Loader exception: Column fName already appears previously in the column headers.");
+}
+
+TEST_F(LoaderDuplicateIDTest, DuplicateIDsError) {
+    checkLoadingFaultWithErrMsg(
+        "Loader exception: ID value 10 violates the uniqueness constraint for the ID property.");
 }


### PR DESCRIPTION
This PR replaces the NodeIDMap in the loader with HashIndex.
The changes are tested on ldbc-10 dataset already.

Two minor changes:
- string equal comparison starts to fail on my machine (I think it's due to I accidentally upgraded my clang version), and a fix is applied for it.
- removed useless function `getStructuredNodeProperty` in catalog.