### PR TITLE
fix benchmark API

### DIFF
--- a/tools/benchmark/include/benchmark.h
+++ b/tools/benchmark/include/benchmark.h
@@ -23,8 +23,8 @@ public:
 
 private:
     void loadBenchmark(const string& benchmarkPath);
-    void logQueryInfo(ofstream& log, uint32_t runNum, QueryResult& queryResult) const;
-    void verify(QueryResult& queryResult) const;
+    void logQueryInfo(ofstream& log, uint32_t runNum, vector<string>& actualOutput) const;
+    void verify(vector<string>& actualOutput) const;
 
 public:
     BenchmarkConfig& config;


### PR DESCRIPTION
Reason for the bug:
The benchmark API calls `convertResultToString` twice to convert a queryResult to strings. The `convertResultToString` will update the counter in the iterator. However, it doesn't reset the iterator after the first call, so the second call will eventually fail.

Fix:
The benchmark API just need to call `convertResultToString`  once, and save the result strings in the stack.