### PR TITLE
Fix the loader overflow bug with ldbc100

### DIFF
--- a/src/storage/buffer_manager.cpp
+++ b/src/storage/buffer_manager.cpp
@@ -13,10 +13,8 @@ namespace storage {
 
 BufferManager::BufferManager(uint64_t maxSizeForDefaultPagePool, uint64_t maxSizeForLargePagePool)
     : logger{LoggerUtils::getOrCreateSpdLogger("buffer_manager")},
-      bufferPoolDefaultPages(
-          make_unique<BufferPool>(DEFAULT_PAGE_SIZE_LOG_2, maxSizeForDefaultPagePool)),
-      bufferPoolLargePages(
-          make_unique<BufferPool>(LARGE_PAGE_SIZE_LOG_2, maxSizeForLargePagePool)) {
+      bufferPoolDefaultPages(make_unique<BufferPool>(DEFAULT_PAGE_SIZE, maxSizeForDefaultPagePool)),
+      bufferPoolLargePages(make_unique<BufferPool>(LARGE_PAGE_SIZE, maxSizeForLargePagePool)) {
     logger->info("Done Initializing Buffer Manager.");
 }
 

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -34,7 +34,7 @@ void FileHandle::constructExistingFileHandle(const string& path) {
     int openFlags = O_RDWR | ((createFileIfNotExists()) ? O_CREAT : 0x00000000);
     fileInfo = FileUtils::openFile(path, openFlags);
     auto fileLength = FileUtils::getFileSize(fileInfo->fd);
-    numPages = fileLength >> getPageSizeLog2();
+    numPages = ceil((double)fileLength / (double)getPageSize());
     logger->trace("FileHandle[disk]: Size {}B, #{}B-pages {}", fileLength, getPageSize(), numPages);
     pageCapacity = numPages;
     initPageIdxToFrameMapAndLocks();
@@ -77,11 +77,11 @@ bool FileHandle::acquire(uint32_t pageIdx) {
 }
 
 void FileHandle::readPage(uint8_t* frame, uint64_t pageIdx) const {
-    FileUtils::readFromFile(fileInfo.get(), frame, getPageSize(), pageIdx << getPageSizeLog2());
+    FileUtils::readFromFile(fileInfo.get(), frame, getPageSize(), pageIdx * getPageSize());
 }
 
 void FileHandle::writePage(uint8_t* buffer, uint64_t pageIdx) const {
-    FileUtils::writeToFile(fileInfo.get(), buffer, getPageSize(), pageIdx << getPageSizeLog2());
+    FileUtils::writeToFile(fileInfo.get(), buffer, getPageSize(), pageIdx * getPageSize());
 }
 
 void FileHandle::addNewPageLockAndFramePtrWithoutLock(uint64_t i) {

--- a/src/storage/include/buffer_pool.h
+++ b/src/storage/include/buffer_pool.h
@@ -70,7 +70,7 @@ class BufferPool {
     friend class BufferManager;
 
 public:
-    BufferPool(uint64_t pageSizeLog2, uint64_t maxSize);
+    BufferPool(uint64_t pageSize, uint64_t maxSize);
 
     uint8_t* pin(FileHandle& fileHandle, uint32_t pageIdx);
 
@@ -118,7 +118,7 @@ private:
 
 private:
     shared_ptr<spdlog::logger> logger;
-    uint64_t pageSizeLog2;
+    uint64_t pageSize;
     vector<unique_ptr<Frame>> bufferCache;
     atomic<uint64_t> clockHand;
     uint32_t numFrames;

--- a/src/storage/include/file_handle.h
+++ b/src/storage/include/file_handle.h
@@ -107,9 +107,6 @@ private:
     inline uint64_t getPageSize() const {
         return isLargePaged() ? LARGE_PAGE_SIZE : DEFAULT_PAGE_SIZE;
     }
-    inline uint64_t getPageSizeLog2() const {
-        return isLargePaged() ? LARGE_PAGE_SIZE_LOG_2 : DEFAULT_PAGE_SIZE_LOG_2;
-    }
 
     inline void addNewPageLockAndFramePtrWithoutLock(uint64_t i);
 

--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -17,7 +17,7 @@ constexpr uint8_t bitMasksWithSingle0s[8] = {
 struct PageByteCursor {
 
     PageByteCursor(uint64_t idx, uint16_t offset) : idx{idx}, offset{offset} {};
-    PageByteCursor() : PageByteCursor{-1ul, (uint16_t)-1} {};
+    PageByteCursor() : PageByteCursor{UINT64_MAX, UINT16_MAX} {};
 
     uint64_t idx;
     uint16_t offset;


### PR DESCRIPTION
There is a bug caused by overflow in `InMemOverflowPages::getNewOverflowPageIdx()`:

```
    for (auto i = 0u; i < numPages; i++) {
        pages[i] = make_unique<InMemPage>(
            numElementsInAPage, data.get() + (i << DEFAULT_PAGE_SIZE_LOG_2), hasNULLBytes);
    }
```
In this for loop, `i` is automatically interpreted as `uint32_t`, and the shifting causes an overflow problem with `uint32_t` in a large dataset with large overflows, i.e., ldbc100.

This is a quite tricky bug, to avoid cases caused by this, I propose to simplify the use of shifting with page size with multiplying/dividing.