### PR TITLE
remove NODE_ID and make back-end using NODE, add LOGICAL_NODE and LOG…

### DIFF
--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -234,8 +234,7 @@ shared_ptr<Expression> ExpressionBinder::bindIDFunctionExpression(
     const ParsedExpression& parsedExpression) {
     auto child = bindExpression(*parsedExpression.getChild(0));
     validateExpectedDataType(*child, NODE);
-    return make_shared<PropertyExpression>(DataType(NODE_ID), INTERNAL_ID_SUFFIX,
-        UINT32_MAX /* property key for internal id */, move(child));
+    return ((NodeExpression&)*child).getNodeIDPropertyExpression();
 }
 
 shared_ptr<Expression> ExpressionBinder::bindParameterExpression(
@@ -367,13 +366,13 @@ shared_ptr<Expression> ExpressionBinder::implicitCastToUnstructured(
 }
 
 void ExpressionBinder::validateExpectedDataType(
-    const Expression& expression, const unordered_set<DataTypeID>& expectedTypes) {
+    const Expression& expression, const unordered_set<DataTypeID>& targets) {
     auto dataType = expression.dataType;
-    if (!expectedTypes.contains(dataType.typeID)) {
-        vector<DataTypeID> expectedTypesVec{expectedTypes.begin(), expectedTypes.end()};
+    if (!targets.contains(dataType.typeID)) {
+        vector<DataTypeID> targetsVec{targets.begin(), targets.end()};
         throw BinderException(expression.getRawName() + " has data type " +
                               Types::dataTypeToString(dataType.typeID) + ". " +
-                              Types::dataTypesToString(expectedTypesVec) + " was expected.");
+                              Types::dataTypesToString(targetsVec) + " was expected.");
     }
 }
 

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -61,12 +61,11 @@ private:
     static shared_ptr<Expression> implicitCastToTimestamp(const shared_ptr<Expression>& expression);
 
     /****** validation *****/
-    static void validateExpectedDataType(const Expression& expression, DataTypeID expectedType) {
-        validateExpectedDataType(expression, unordered_set<DataTypeID>{expectedType});
+    static void validateExpectedDataType(const Expression& expression, DataTypeID target) {
+        validateExpectedDataType(expression, unordered_set<DataTypeID>{target});
     }
     static void validateExpectedDataType(
-        const Expression& expression, const unordered_set<DataTypeID>& expectedTypes);
-
+        const Expression& expression, const unordered_set<DataTypeID>& targets);
     // E.g. SUM(SUM(a.age)) is not allowed
     static void validateAggregationExpressionIsNotNested(const Expression& expression);
 

--- a/src/binder/query_binder.cpp
+++ b/src/binder/query_binder.cpp
@@ -147,7 +147,6 @@ expression_vector QueryBinder::rewriteProjectionExpressions(const expression_vec
 
 expression_vector QueryBinder::rewriteNodeAsAllProperties(
     const shared_ptr<Expression>& expression) {
-    assert(expression->dataType.typeID == NODE);
     auto& node = (NodeExpression&)*expression;
     expression_vector result;
     for (auto& property : catalog.getAllNodeProperties(node.getLabel())) {
@@ -160,7 +159,6 @@ expression_vector QueryBinder::rewriteNodeAsAllProperties(
 }
 
 expression_vector QueryBinder::rewriteRelAsAllProperties(const shared_ptr<Expression>& expression) {
-    assert(expression->dataType.typeID == REL);
     auto& rel = (RelExpression&)*expression;
     expression_vector result;
     for (auto& property : catalog.getRelProperties(rel.getLabel())) {

--- a/src/catalog/include/catalog_structs.h
+++ b/src/catalog/include/catalog_structs.h
@@ -66,10 +66,6 @@ public:
             false /* is node label */);
     }
 
-    static Property constructDummyPropertyForAdjColumnEdges(label_t relLabel) {
-        return Property("", DataType(NODE), UINT32_MAX, relLabel, false /* is node label */);
-    }
-
 public:
     uint32_t propertyID;
     label_t label;

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -66,7 +66,7 @@ public:
     inline uint64_t getNumBytesPerValue() const { return Types::getDataTypeSize(dataType); }
 
     inline node_offset_t readNodeOffset(uint64_t pos) const {
-        assert(dataType.typeID == NODE);
+        assert(dataType.typeID == NODE_ID);
         return ((nodeID_t*)values)[pos].offset;
     }
 

--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -104,7 +104,7 @@ string TypeUtils::toString(const Literal& literal) {
         return TypeUtils::toString(literal.val.int64Val);
     case DOUBLE:
         return TypeUtils::toString(literal.val.doubleVal);
-    case NODE:
+    case NODE_ID:
         return TypeUtils::toString(literal.val.nodeID);
     case DATE:
         return TypeUtils::toString(literal.val.dateVal);
@@ -141,7 +141,7 @@ string TypeUtils::toString(const Value& val) {
         return TypeUtils::toString(val.val.doubleVal);
     case STRING:
         return TypeUtils::toString(val.val.strVal);
-    case NODE:
+    case NODE_ID:
         return TypeUtils::toString(val.val.nodeID);
     case DATE:
         return TypeUtils::toString(val.val.dateVal);

--- a/src/common/types/include/types.h
+++ b/src/common/types/include/types.h
@@ -25,25 +25,32 @@ struct overflow_value_t {
 };
 
 enum DataTypeID : uint8_t {
+    // NOTE: Not all data types can be used in processor. For example, ANY should be resolved during
+    // query compilation. Similarly logical data types should also only be used in compilation.
+    // Some use cases are as follows.
+    //    - differentiate whether is a variable refers to node table or rel table
+    //    - bind (static evaluate) functions work on node/rel table.
+    //      E.g. ID(a "datatype:NODE") -> node ID property "datatype:NODE_ID"
+
+    // logical  types
     ANY = 0,
+    NODE = 10,
+    REL = 11,
 
-    REL = 1,
-    NODE = 2,
-    LABEL = 3,
-    BOOL = 4,
-    INT64 = 5,
-    DOUBLE = 6,
-    STRING = 7,
-    NODE_ID = 8,
-    UNSTRUCTURED = 9,
-    DATE = 10,
-    TIMESTAMP = 11,
-    INTERVAL = 12,
-    LIST = 13,
+    // physical fixed size types
+    LABEL = 20,
+    NODE_ID = 21,
+    BOOL = 22,
+    INT64 = 23,
+    DOUBLE = 24,
+    DATE = 25,
+    TIMESTAMP = 26,
+    INTERVAL = 27,
+
+    STRING = 50,
+    UNSTRUCTURED = 51,
+    LIST = 52,
 };
-
-const string DataTypeIdNames[] = {"ANY", "REL", "NODE", "LABEL", "BOOL", "INT64", "DOUBLE",
-    "STRING", "NODE_ID", "UNSTRUCTURED", "DATE", "TIMESTAMP", "INTERVAL", "LIST"};
 
 class DataType {
 public:
@@ -66,8 +73,8 @@ public:
         return vector<DataTypeID>{INT64, DOUBLE, UNSTRUCTURED};
     }
     static inline vector<DataTypeID> getAllValidTypeIDs() {
-        return vector<DataTypeID>{REL, NODE, LABEL, BOOL, INT64, DOUBLE, STRING, NODE_ID,
-            UNSTRUCTURED, DATE, TIMESTAMP, INTERVAL, LIST};
+        return vector<DataTypeID>{LABEL, NODE_ID, BOOL, INT64, DOUBLE, STRING, UNSTRUCTURED, DATE,
+            TIMESTAMP, INTERVAL, LIST};
     }
 
     DataType& operator=(const DataType& other);

--- a/src/common/types/include/value.h
+++ b/src/common/types/include/value.h
@@ -27,7 +27,7 @@ public:
 
     explicit Value(const string& value) : dataType(STRING) { this->val.strVal.set(value); }
 
-    explicit Value(nodeID_t value) : dataType(NODE) { this->val.nodeID = value; }
+    explicit Value(nodeID_t value) : dataType(NODE_ID) { this->val.nodeID = value; }
 
     explicit Value(date_t value) : dataType(DATE) { this->val.dateVal = value; }
 

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -58,10 +58,8 @@ DataType Types::dataTypeFromString(const string& dataTypeString) {
 DataTypeID Types::dataTypeIDFromString(const std::string& dataTypeIDString) {
     if ("LABEL" == dataTypeIDString) {
         return LABEL;
-    } else if ("NODE" == dataTypeIDString) {
-        return NODE;
-    } else if ("REL" == dataTypeIDString) {
-        return REL;
+    } else if ("NODE_ID" == dataTypeIDString) {
+        return NODE_ID;
     } else if ("INT64" == dataTypeIDString) {
         return INT64;
     } else if ("DOUBLE" == dataTypeIDString) {
@@ -93,7 +91,38 @@ string Types::dataTypeToString(const DataType& dataType) {
 
 string Types::dataTypeToString(DataTypeID dataTypeID) {
     assert(dataTypeID != LIST);
-    return DataTypeIdNames[dataTypeID];
+    switch (dataTypeID) {
+    case ANY:
+        return "ANY";
+    case NODE:
+        return "NODE";
+    case REL:
+        return "REL";
+    case LABEL:
+        return "LABEL";
+    case NODE_ID:
+        return "NODE_ID";
+    case BOOL:
+        return "BOOL";
+    case INT64:
+        return "INT64";
+    case DOUBLE:
+        return "DOUBLE";
+    case DATE:
+        return "DATE";
+    case TIMESTAMP:
+        return "TIMESTAMP";
+    case INTERVAL:
+        return "INTERVAL";
+    case STRING:
+        return "STRING";
+    case UNSTRUCTURED:
+        return "UNSTRUCTURED";
+    case LIST:
+        return "LIST";
+    default:
+        assert(false);
+    }
 }
 
 string Types::dataTypesToString(const vector<DataType>& dataTypes) {
@@ -120,24 +149,24 @@ size_t Types::getDataTypeSize(DataTypeID dataTypeID) {
     switch (dataTypeID) {
     case LABEL:
         return sizeof(label_t);
-    case NODE:
+    case NODE_ID:
         return sizeof(nodeID_t);
+    case BOOL:
+        return sizeof(uint8_t);
     case INT64:
         return sizeof(int64_t);
     case DOUBLE:
         return sizeof(double_t);
-    case BOOL:
-        return sizeof(uint8_t);
-    case STRING:
-        return sizeof(gf_string_t);
-    case UNSTRUCTURED:
-        return sizeof(Value);
     case DATE:
         return sizeof(date_t);
     case TIMESTAMP:
         return sizeof(timestamp_t);
     case INTERVAL:
         return sizeof(interval_t);
+    case STRING:
+        return sizeof(gf_string_t);
+    case UNSTRUCTURED:
+        return sizeof(Value);
     case LIST:
         return sizeof(gf_list_t);
     default:

--- a/src/function/aggregate/aggregate_function.cpp
+++ b/src/function/aggregate/aggregate_function.cpp
@@ -95,7 +95,7 @@ unique_ptr<AggregateFunction> AggregateFunctionUtil::getMinMaxFunction(
         return make_unique<AggregateFunction>(MinMaxFunction<gf_string_t>::initialize,
             MinMaxFunction<gf_string_t>::update<FUNC>, MinMaxFunction<gf_string_t>::combine<FUNC>,
             MinMaxFunction<gf_string_t>::finalize, inputType, isDistinct);
-    case NODE:
+    case NODE_ID:
         return make_unique<AggregateFunction>(MinMaxFunction<nodeID_t>::initialize,
             MinMaxFunction<nodeID_t>::update<FUNC>, MinMaxFunction<nodeID_t>::combine<FUNC>,
             MinMaxFunction<nodeID_t>::finalize, inputType, isDistinct);

--- a/src/function/aggregate/built_in_aggregate_functions.cpp
+++ b/src/function/aggregate/built_in_aggregate_functions.cpp
@@ -117,7 +117,8 @@ void BuiltInAggregateFunctions::registerAvg() {
 
 void BuiltInAggregateFunctions::registerMin() {
     vector<unique_ptr<AggregateFunctionDefinition>> definitions;
-    for (auto typeID : vector<DataTypeID>{BOOL, INT64, DOUBLE, DATE, STRING, NODE, UNSTRUCTURED}) {
+    for (auto typeID :
+        vector<DataTypeID>{BOOL, INT64, DOUBLE, DATE, STRING, NODE_ID, UNSTRUCTURED}) {
         for (auto isDistinct : vector<bool>{true, false}) {
             definitions.push_back(make_unique<AggregateFunctionDefinition>(MIN_FUNC_NAME,
                 vector<DataTypeID>{typeID}, typeID,
@@ -129,7 +130,8 @@ void BuiltInAggregateFunctions::registerMin() {
 
 void BuiltInAggregateFunctions::registerMax() {
     vector<unique_ptr<AggregateFunctionDefinition>> definitions;
-    for (auto typeID : vector<DataTypeID>{BOOL, INT64, DOUBLE, DATE, STRING, NODE, UNSTRUCTURED}) {
+    for (auto typeID :
+        vector<DataTypeID>{BOOL, INT64, DOUBLE, DATE, STRING, NODE_ID, UNSTRUCTURED}) {
         for (auto isDistinct : vector<bool>{true, false}) {
             definitions.push_back(make_unique<AggregateFunctionDefinition>(MAX_FUNC_NAME,
                 vector<DataTypeID>{typeID}, typeID,

--- a/src/loader/in_mem_structure/builder/in_mem_structures_builder.cpp
+++ b/src/loader/in_mem_structure/builder/in_mem_structures_builder.cpp
@@ -55,7 +55,7 @@ vector<PropertyNameDataType> InMemStructuresBuilder::parseCSVFileHeader(string& 
                 // skip over this property.
             } else if (colHeaderDefinition.name == LoaderConfig::START_ID_FIELD ||
                        colHeaderDefinition.name == LoaderConfig::END_ID_FIELD) {
-                colHeaderDefinition.dataType.typeID = NODE;
+                colHeaderDefinition.dataType.typeID = NODE_ID;
             } else if (colHeaderDefinition.name == LoaderConfig::START_ID_LABEL_FIELD ||
                        colHeaderDefinition.name == LoaderConfig::END_ID_LABEL_FIELD) {
                 colHeaderDefinition.dataType.typeID = LABEL;
@@ -66,10 +66,10 @@ vector<PropertyNameDataType> InMemStructuresBuilder::parseCSVFileHeader(string& 
         } else {
             colHeaderDefinition.name = colHeaderComponents[0];
             colHeaderDefinition.dataType = Types::dataTypeFromString(colHeaderComponents[1]);
-            if (colHeaderDefinition.dataType.typeID == NODE ||
+            if (colHeaderDefinition.dataType.typeID == NODE_ID ||
                 colHeaderDefinition.dataType.typeID == LABEL) {
-                throw LoaderException(
-                    "PropertyNameDataType column header cannot be of system types NODE or LABEL.");
+                throw LoaderException("PropertyNameDataType column header cannot be of system "
+                                      "types NODE_ID or LABEL.");
             }
         }
         if (columnNameSet.find(colHeaderDefinition.name) != columnNameSet.end()) {

--- a/src/loader/in_mem_structure/in_mem_lists.cpp
+++ b/src/loader/in_mem_structure/in_mem_lists.cpp
@@ -34,7 +34,7 @@ InMemLists::InMemLists(string fName, DataType dataType, uint64_t numBytesForElem
 
 void InMemLists::init() {
     pages = make_unique<InMemPages>(fName, numBytesForElement,
-        this->dataType.typeID != NODE && this->dataType.typeID != UNSTRUCTURED,
+        this->dataType.typeID != NODE_ID && this->dataType.typeID != UNSTRUCTURED,
         listsMetadata->getNumPages());
 }
 

--- a/src/loader/include/in_mem_structure/in_mem_column.h
+++ b/src/loader/include/in_mem_structure/in_mem_column.h
@@ -61,7 +61,7 @@ class InMemAdjColumn : public InMemColumn {
 public:
     InMemAdjColumn(
         string fName, const NodeIDCompressionScheme& compressionScheme, uint64_t numElements)
-        : InMemColumn{move(fName), DataType(NODE), compressionScheme.getNumTotalBytes(),
+        : InMemColumn{move(fName), DataType(NODE_ID), compressionScheme.getNumTotalBytes(),
               numElements},
           compressionScheme{compressionScheme} {};
 

--- a/src/loader/include/in_mem_structure/in_mem_lists.h
+++ b/src/loader/include/in_mem_structure/in_mem_lists.h
@@ -74,7 +74,7 @@ class InMemAdjLists : public InMemLists {
 
 public:
     InMemAdjLists(string fName, const NodeIDCompressionScheme& compressionScheme, uint64_t numNodes)
-        : InMemLists{move(fName), DataType(NODE), compressionScheme.getNumTotalBytes()},
+        : InMemLists{move(fName), DataType(NODE_ID), compressionScheme.getNumTotalBytes()},
           compressionScheme{compressionScheme} {
         listHeaders = make_unique<ListHeaders>(numNodes);
     };

--- a/src/processor/include/physical_plan/operator/var_length_extend/var_length_extend.h
+++ b/src/processor/include/physical_plan/operator/var_length_extend/var_length_extend.h
@@ -13,7 +13,7 @@ namespace processor {
 struct DFSLevelInfo {
     DFSLevelInfo(uint8_t level, ExecutionContext& context)
         : level{level}, hasBeenOutput{false}, children{make_shared<ValueVector>(
-                                                  context.memoryManager, NODE)} {};
+                                                  context.memoryManager, NODE_ID)} {};
     const uint8_t level;
     bool hasBeenOutput;
     shared_ptr<ValueVector> children;

--- a/src/processor/physical_plan/mapper/map_sink.cpp
+++ b/src/processor/physical_plan/mapper/map_sink.cpp
@@ -22,10 +22,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalSinkToPhysical(
     for (auto& expression : logicalSink.getExpressions()) {
         auto expressionName = expression->getUniqueName();
         outDataPoses.emplace_back(mapperContext.getDataPos(expressionName));
-        // TODO(Xiyang): solve this together with issue #244
-        outVecDataTypes.push_back(expression->getDataType().typeID == NODE_ID ?
-                                      DataType(NODE) :
-                                      expression->getDataType());
+        outVecDataTypes.push_back(expression->getDataType());
         mapperContext.addComputedExpressions(expressionName);
     }
     auto sharedState = resultCollector->getSharedState();

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -5,7 +5,7 @@ namespace processor {
 
 shared_ptr<ResultSet> AdjListExtend::init(ExecutionContext* context) {
     resultSet = ReadList::init(context);
-    outValueVector = make_shared<ValueVector>(context->memoryManager, NODE);
+    outValueVector = make_shared<ValueVector>(context->memoryManager, NODE_ID);
     outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
     auto listSyncState = make_shared<ListSyncState>();
     resultSet->insert(outDataPos.dataChunkPos, listSyncState);

--- a/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
@@ -5,7 +5,7 @@ namespace processor {
 
 shared_ptr<ResultSet> AdjColumnExtend::init(ExecutionContext* context) {
     resultSet = BaseScanColumn::init(context);
-    outputVector = make_shared<ValueVector>(context->memoryManager, NODE);
+    outputVector = make_shared<ValueVector>(context->memoryManager, NODE_ID);
     inputNodeIDDataChunk->insert(outputVectorPos.valueVectorPos, outputVector);
     return resultSet;
 }
@@ -35,7 +35,7 @@ bool AdjColumnExtend::getNextTuples() {
 }
 
 bool AdjColumnExtend::discardNullNodesInVector(ValueVector& valueVector) {
-    assert(valueVector.dataType.typeID == NODE);
+    assert(valueVector.dataType.typeID == NODE_ID);
     if (valueVector.state->isFlat()) {
         return !valueVector.isNull(valueVector.state->getPositionOfCurrIdx());
     } else {

--- a/src/processor/physical_plan/operator/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id.cpp
@@ -18,7 +18,7 @@ shared_ptr<ResultSet> ScanNodeID::init(ExecutionContext* context) {
     PhysicalOperator::init(context);
     resultSet = populateResultSet();
     outDataChunk = resultSet->dataChunks[outDataPos.dataChunkPos];
-    outValueVector = make_shared<ValueVector>(context->memoryManager, NODE);
+    outValueVector = make_shared<ValueVector>(context->memoryManager, NODE_ID);
     outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
     return resultSet;
 }

--- a/src/processor/physical_plan/operator/var_length_extend/var_length_extend.cpp
+++ b/src/processor/physical_plan/operator/var_length_extend/var_length_extend.cpp
@@ -16,7 +16,7 @@ shared_ptr<ResultSet> VarLengthExtend::init(ExecutionContext* context) {
     resultSet = PhysicalOperator::init(context);
     boundNodeValueVector = resultSet->dataChunks[boundNodeDataPos.dataChunkPos]
                                ->valueVectors[boundNodeDataPos.valueVectorPos];
-    nbrNodeValueVector = make_shared<ValueVector>(context->memoryManager, NODE);
+    nbrNodeValueVector = make_shared<ValueVector>(context->memoryManager, NODE_ID);
     resultSet->dataChunks[nbrNodeDataPos.dataChunkPos]->insert(
         nbrNodeDataPos.valueVectorPos, nbrNodeValueVector);
     return resultSet;

--- a/src/processor/physical_plan/result/factorized_table.cpp
+++ b/src/processor/physical_plan/result/factorized_table.cpp
@@ -391,7 +391,7 @@ void FlatTupleIterator::readValueBufferToFlatTuple(
     case STRING: {
         iteratorFlatTuple->getValue(flatTupleValIdx)->val.strVal = *((gf_string_t*)valueBuffer);
     } break;
-    case NODE: {
+    case NODE_ID: {
         iteratorFlatTuple->getValue(flatTupleValIdx)->val.nodeID = *((nodeID_t*)valueBuffer);
     } break;
     case UNSTRUCTURED: {

--- a/src/storage/include/storage_structure/column.h
+++ b/src/storage/include/storage_structure/column.h
@@ -98,7 +98,7 @@ class AdjColumn : public Column {
 public:
     AdjColumn(const StorageStructureIDAndFName structureIDAndFName, BufferManager& bufferManager,
         const NodeIDCompressionScheme& nodeIDCompressionScheme, bool isInMemory, WAL* wal)
-        : Column{structureIDAndFName, DataType(NODE), nodeIDCompressionScheme.getNumTotalBytes(),
+        : Column{structureIDAndFName, DataType(NODE_ID), nodeIDCompressionScheme.getNumTotalBytes(),
               bufferManager, isInMemory, wal},
           nodeIDCompressionScheme(nodeIDCompressionScheme){};
 

--- a/src/storage/include/storage_structure/lists/lists.h
+++ b/src/storage/include/storage_structure/lists/lists.h
@@ -102,7 +102,7 @@ class AdjLists : public Lists {
 public:
     AdjLists(const string& fName, BufferManager& bufferManager,
         NodeIDCompressionScheme nodeIDCompressionScheme, bool isInMemory)
-        : Lists{fName, DataType(NODE), nodeIDCompressionScheme.getNumTotalBytes(),
+        : Lists{fName, DataType(NODE_ID), nodeIDCompressionScheme.getNumTotalBytes(),
               make_shared<ListHeaders>(fName), bufferManager, false, isInMemory},
           nodeIDCompressionScheme{nodeIDCompressionScheme} {};
 

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -5,7 +5,7 @@ namespace storage {
 
 void Column::readValues(Transaction* transaction, const shared_ptr<ValueVector>& nodeIDVector,
     const shared_ptr<ValueVector>& valueVector) {
-    assert(nodeIDVector->dataType.typeID == NODE);
+    assert(nodeIDVector->dataType.typeID == NODE_ID);
     if (nodeIDVector->state->isFlat()) {
         auto pos = nodeIDVector->state->getPositionOfCurrIdx();
         readForSingleNodeIDPosition(transaction, pos, nodeIDVector, valueVector);

--- a/src/storage/storage_structure/lists/lists.cpp
+++ b/src/storage/storage_structure/lists/lists.cpp
@@ -44,7 +44,7 @@ void Lists::readValues(node_offset_t nodeOffset, const shared_ptr<ValueVector>& 
 /**
  * Note: This function is called for property lists other than STRINGS. This is called by
  * readValues, which is the main function for reading all lists except UNSTRUCTURED
- * and NODE.
+ * and NODE_ID.
  */
 void Lists::readFromLargeList(const shared_ptr<ValueVector>& valueVector,
     const unique_ptr<LargeListHandle>& largeListHandle, ListInfo& info) {

--- a/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
+++ b/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
@@ -14,7 +14,7 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
     auto bufferManager = make_unique<BufferManager>();
     auto memoryManager = make_unique<MemoryManager>(bufferManager.get());
 
-    auto nodeVector = make_shared<ValueVector>(memoryManager.get(), NODE);
+    auto nodeVector = make_shared<ValueVector>(memoryManager.get(), NODE_ID);
     dataChunk->insert(0, nodeVector);
     auto nodeData = (nodeID_t*)nodeVector->values;
 
@@ -48,7 +48,7 @@ TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
     auto bufferManager = make_unique<BufferManager>();
     auto memoryManager = make_unique<MemoryManager>(bufferManager.get());
 
-    auto nodeVector = make_shared<ValueVector>(memoryManager.get(), NODE);
+    auto nodeVector = make_shared<ValueVector>(memoryManager.get(), NODE_ID);
     for (auto i = 0u; i < 1000; i++) {
         ((nodeID_t*)nodeVector->values)[i].label = 100;
         ((nodeID_t*)nodeVector->values)[i].offset = 10 + i;

--- a/test/processor/physical_plan/result/factorized_table_test.cpp
+++ b/test/processor/physical_plan/result/factorized_table_test.cpp
@@ -12,9 +12,9 @@ public:
         auto result = make_unique<ResultSet>(2);
         auto dataChunkA = make_shared<DataChunk>(2);
         auto dataChunkB = make_shared<DataChunk>(2);
-        auto vectorA1 = make_shared<ValueVector>(memoryManager.get(), NODE);
+        auto vectorA1 = make_shared<ValueVector>(memoryManager.get(), NODE_ID);
         auto vectorA2 = make_shared<ValueVector>(memoryManager.get(), INT64);
-        auto vectorB1 = make_shared<ValueVector>(memoryManager.get(), NODE);
+        auto vectorB1 = make_shared<ValueVector>(memoryManager.get(), NODE_ID);
         auto vectorB2 = make_shared<ValueVector>(memoryManager.get(), DOUBLE);
         dataChunkA->insert(0, vectorA1);
         dataChunkA->insert(1, vectorA2);
@@ -82,7 +82,7 @@ public:
     static void checkFlatTupleIteratorResult(FlatTupleIterator& flatTupleIterator) {
         for (auto i = 0; i < 100; i++) {
             for (auto j = 0; j < 100; j++) {
-                vector<DataType> dataTypesInFlatTuple = {DataType(NODE), DataType(NODE)};
+                vector<DataType> dataTypesInFlatTuple = {DataType(NODE_ID), DataType(NODE_ID)};
                 ASSERT_EQ(flatTupleIterator.hasNextFlatTuple(), true);
                 auto& resultFlatTuple = *flatTupleIterator.getNextFlatTuple();
                 if (i % 15) {
@@ -209,7 +209,7 @@ TEST_F(FactorizedTableTest, AppendMultipleTuplesScanOneAtAtime) {
 TEST_F(FactorizedTableTest, ReadFlatTuplesFromFactorizedTable) {
     auto factorizedTable = appendMultipleTuples(false /* isAppendFlatVectorToUnflatCol */);
     auto flatTupleIterator =
-        FlatTupleIterator(*factorizedTable, vector<DataType>{DataType(NODE), DataType(NODE)});
+        FlatTupleIterator(*factorizedTable, vector<DataType>{DataType(NODE_ID), DataType(NODE_ID)});
     checkFlatTupleIteratorResult(flatTupleIterator);
     ASSERT_EQ(flatTupleIterator.hasNextFlatTuple(), false);
 }
@@ -222,7 +222,7 @@ TEST_F(FactorizedTableTest, FactorizedTableMergeTest) {
     factorizedTable->merge(*factorizedTable1);
     ASSERT_EQ(factorizedTable->getTotalNumFlatTuples(), 20000);
     auto flatTupleIterator =
-        FlatTupleIterator(*factorizedTable, vector<DataType>{DataType(NODE), DataType(NODE)});
+        FlatTupleIterator(*factorizedTable, vector<DataType>{DataType(NODE_ID), DataType(NODE_ID)});
     checkFlatTupleIteratorResult(flatTupleIterator);
     checkFlatTupleIteratorResult(flatTupleIterator);
     ASSERT_EQ(flatTupleIterator.hasNextFlatTuple(), false);

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -28,7 +28,7 @@ public:
             database->getCatalog()->getNodeProperty(personNodeLabel, "eyeSight").propertyID;
 
         dataChunk = make_shared<DataChunk>(3);
-        nodeVector = make_shared<ValueVector>(database->getMemoryManager(), NODE);
+        nodeVector = make_shared<ValueVector>(database->getMemoryManager(), NODE_ID);
         dataChunk->insert(0, nodeVector);
         ((nodeID_t*)nodeVector->values)[0].offset = 0;
         ((nodeID_t*)nodeVector->values)[1].offset = 1;

--- a/tools/python_api/py_query_result.cpp
+++ b/tools/python_api/py_query_result.cpp
@@ -70,7 +70,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value, bool isNull
     case LIST: {
         return convertValueToPyObject((uint8_t*)(&value.val.listVal), dataType);
     }
-    case NODE: {
+    case NODE_ID: {
         // TODO: Somehow Neo4j allows exposing of internal type. But I start thinking we shouldn't.
         return convertValueToPyObject((uint8_t*)(&value.val.nodeID), dataType);
     }
@@ -128,7 +128,7 @@ py::object PyQueryResult::convertValueToPyObject(uint8_t* val, const DataType& d
         }
         return move(list);
     }
-    case NODE: {
+    case NODE_ID: {
         auto nodeVal = *(nodeID_t*)val;
         return py::cast(make_pair(nodeVal.label, nodeVal.offset));
     }


### PR DESCRIPTION
This PR solves issue #244 

Previously our processor was using NODE and NODE_ID inconsistently.  This PR unifies the usage and has
- the back-end, i.e. loader, storage, and processor, use NODE_ID as data type during execution.
- the front-end use NODE and REL during compilation