### PR TITLE
Add buffer pool size parameter into loader

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -38,8 +38,11 @@ constexpr const uint64_t DEFAULT_CHECKPOINT_WAIT_TIMEOUT_FOR_TRANSACTIONS_TO_LEA
     5000000;
 
 struct StorageConfig {
-    // The default amount of memory pre-allocated to the buffer pool (= 2MB).
-    static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 22;
+    // The default amount of memory pre-allocated to both the default and large pages buffer pool.
+    static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 23; // (8MB)
+    // The default ratio of buffer allocated to large pages.
+    static constexpr double DEFAULT_PAGES_BUFFER_RATIO = 0.5;
+    static constexpr double LARGE_PAGES_BUFFER_RATIO = 1.0 - DEFAULT_PAGES_BUFFER_RATIO;
     static constexpr char OVERFLOW_FILE_SUFFIX[] = ".ovf";
     static constexpr char COLUMN_FILE_SUFFIX[] = ".col";
     static constexpr char LISTS_FILE_SUFFIX[] = ".lists";

--- a/src/loader/graph_loader.cpp
+++ b/src/loader/graph_loader.cpp
@@ -14,12 +14,13 @@ using namespace std::chrono;
 namespace graphflow {
 namespace loader {
 
-GraphLoader::GraphLoader(string inputDirectory, string outputDirectory, uint32_t numThreads)
+GraphLoader::GraphLoader(string inputDirectory, string outputDirectory, uint32_t numThreads,
+    uint64_t defaultPageBufferPoolSize, uint64_t largePageBufferPoolSize)
     : logger{LoggerUtils::getOrCreateSpdLogger("loader")},
       inputDirectory{std::move(inputDirectory)}, outputDirectory{std::move(outputDirectory)} {
     taskScheduler = make_unique<TaskScheduler>(numThreads);
     catalog = make_unique<Catalog>();
-    bufferManager = make_unique<BufferManager>();
+    bufferManager = make_unique<BufferManager>(defaultPageBufferPoolSize, largePageBufferPoolSize);
 }
 
 GraphLoader::~GraphLoader() {

--- a/src/loader/include/graph_loader.h
+++ b/src/loader/include/graph_loader.h
@@ -18,7 +18,8 @@ namespace loader {
 class GraphLoader {
 
 public:
-    GraphLoader(string inputDirectory, string outputDirectory, uint32_t numThreads);
+    GraphLoader(string inputDirectory, string outputDirectory, uint32_t numThreads,
+        uint64_t defaultPageBufferPoolSize, uint64_t largePageBufferPoolSize);
     ~GraphLoader();
 
     void loadGraph();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -20,9 +20,10 @@ Database::Database(const DatabaseConfig& databaseConfig, const SystemConfig& sys
 void Database::resizeBufferManager(uint64_t newSize) {
     // Currently we are resizing both buffer pools to the same size. If needed we can
     // extend this functionality.
-    systemConfig.defaultPageBufferPoolSize = newSize;
-    systemConfig.largePageBufferPoolSize = newSize;
-    bufferManager->resize(newSize, newSize);
+    systemConfig.defaultPageBufferPoolSize = newSize * StorageConfig::DEFAULT_PAGES_BUFFER_RATIO;
+    systemConfig.largePageBufferPoolSize = newSize * StorageConfig::LARGE_PAGES_BUFFER_RATIO;
+    bufferManager->resize(
+        systemConfig.defaultPageBufferPoolSize, systemConfig.largePageBufferPoolSize);
 }
 
 } // namespace main

--- a/src/main/include/database.h
+++ b/src/main/include/database.h
@@ -15,8 +15,10 @@ namespace main {
 struct SystemConfig {
 
     explicit SystemConfig(
-        uint64_t defaultPageBufferPoolSize = common::StorageConfig::DEFAULT_BUFFER_POOL_SIZE,
-        uint64_t largePageBufferPoolSize = common::StorageConfig::DEFAULT_BUFFER_POOL_SIZE)
+        uint64_t defaultPageBufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE *
+                                             StorageConfig::DEFAULT_PAGES_BUFFER_RATIO,
+        uint64_t largePageBufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE *
+                                           StorageConfig::LARGE_PAGES_BUFFER_RATIO)
         : defaultPageBufferPoolSize{defaultPageBufferPoolSize}, largePageBufferPoolSize{
                                                                     largePageBufferPoolSize} {}
 

--- a/src/storage/include/buffer_manager.h
+++ b/src/storage/include/buffer_manager.h
@@ -60,8 +60,11 @@ namespace storage {
 class BufferManager {
 
 public:
-    BufferManager() : BufferManager(512 * DEFAULT_PAGE_SIZE, 26 * LARGE_PAGE_SIZE) {}
-    BufferManager(uint64_t maxSizeForDefaultPagePool, uint64_t maxSizeForLargePagePool);
+    explicit BufferManager(
+        uint64_t maxSizeForDefaultPagePool = StorageConfig::DEFAULT_BUFFER_POOL_SIZE *
+                                             StorageConfig::DEFAULT_PAGES_BUFFER_RATIO,
+        uint64_t maxSizeForLargePagePool = StorageConfig::DEFAULT_BUFFER_POOL_SIZE *
+                                           StorageConfig::LARGE_PAGES_BUFFER_RATIO);
     ~BufferManager();
 
     uint8_t* pin(FileHandle& fileHandle, uint32_t pageIdx);

--- a/test/main/config_test.cpp
+++ b/test/main/config_test.cpp
@@ -3,8 +3,10 @@
 TEST_F(ApiTest, DatabaseConfig) {
     auto db = make_unique<Database>(DatabaseConfig(TestHelper::TEMP_TEST_DIR));
     ASSERT_NO_THROW(db->resizeBufferManager(StorageConfig::DEFAULT_BUFFER_POOL_SIZE * 2));
-    ASSERT_EQ(db->getDefaultBMSize(), StorageConfig::DEFAULT_BUFFER_POOL_SIZE * 2);
-    ASSERT_EQ(db->getLargeBMSize(), StorageConfig::DEFAULT_BUFFER_POOL_SIZE * 2);
+    ASSERT_EQ(db->getDefaultBMSize(), (uint64_t)(StorageConfig::DEFAULT_BUFFER_POOL_SIZE * 2 *
+                                                 StorageConfig::DEFAULT_PAGES_BUFFER_RATIO));
+    ASSERT_EQ(db->getLargeBMSize(), (uint64_t)(StorageConfig::DEFAULT_BUFFER_POOL_SIZE * 2 *
+                                               StorageConfig::LARGE_PAGES_BUFFER_RATIO));
 }
 
 TEST_F(ApiTest, ClientConfig) {

--- a/test/test_utility/test_helper.cpp
+++ b/test/test_utility/test_helper.cpp
@@ -116,8 +116,9 @@ vector<string> TestHelper::convertResultToString(QueryResult& queryResult, bool 
 }
 
 void BaseGraphLoadingTest::loadGraph() {
-    GraphLoader graphLoader(
-        getInputCSVDir(), TestHelper::TEMP_TEST_DIR, systemConfig->maxNumThreads);
+    GraphLoader graphLoader(getInputCSVDir(), TestHelper::TEMP_TEST_DIR,
+        systemConfig->maxNumThreads, systemConfig->defaultPageBufferPoolSize,
+        systemConfig->largePageBufferPoolSize);
     graphLoader.loadGraph();
 }
 

--- a/tools/python_api/py_loader.cpp
+++ b/tools/python_api/py_loader.cpp
@@ -5,6 +5,8 @@ void PyLoader::initialize(py::handle& m) {
 }
 
 void PyLoader::load(const string& inputDir, const string& outputDir) {
-    GraphLoader graphLoader(inputDir, outputDir, thread::hardware_concurrency());
+    GraphLoader graphLoader(inputDir, outputDir, thread::hardware_concurrency(),
+        StorageConfig::DEFAULT_BUFFER_POOL_SIZE * StorageConfig::DEFAULT_PAGES_BUFFER_RATIO,
+        StorageConfig::DEFAULT_BUFFER_POOL_SIZE * StorageConfig::LARGE_PAGES_BUFFER_RATIO);
     graphLoader.loadGraph();
 }


### PR DESCRIPTION
This PR makes two changes:
- Add a loader param, buffePoolSize, to set the total buffer size.
- Add a default ratio of large pages, which is set to 0.5 for now.