### PR TITLE
Rework InMemPages and the resizing logic of InMemOverflowPages; fix #625

### DIFF
--- a/src/loader/BUILD.bazel
+++ b/src/loader/BUILD.bazel
@@ -45,12 +45,12 @@ cc_library(
 cc_library(
     name = "in_mem_pages",
     srcs = [
+        "in_mem_structure/in_mem_file.cpp",
         "in_mem_structure/in_mem_page.cpp",
-        "in_mem_structure/in_mem_pages.cpp",
     ],
     hdrs = [
+        "include/in_mem_structure/in_mem_file.h",
         "include/in_mem_structure/in_mem_page.h",
-        "include/in_mem_structure/in_mem_pages.h",
     ],
     visibility = ["//visibility:public"],
     deps = [

--- a/src/loader/in_mem_structure/builder/in_mem_node_builder.cpp
+++ b/src/loader/in_mem_structure/builder/in_mem_node_builder.cpp
@@ -2,7 +2,7 @@
 
 #include "spdlog/spdlog.h"
 
-#include "src/loader/include/in_mem_structure/in_mem_pages.h"
+#include "src/loader/include/in_mem_structure/in_mem_file.h"
 #include "src/loader/include/loader_task.h"
 #include "src/storage/include/storage_structure/lists/unstructured_property_lists.h"
 
@@ -15,7 +15,7 @@ InMemNodeBuilder::InMemNodeBuilder(label_t nodeLabel, const NodeFileDescription&
     : InMemStructuresBuilder{nodeLabel, fileDescription.labelName, fileDescription.filePath,
           move(outputDirectory), fileDescription.csvReaderConfig, taskScheduler, catalog,
           progressBar},
-      IDType{fileDescription.IDType}, bufferManager{bufferManager} {}
+      IDType{fileDescription.IDType}, bm{bufferManager} {}
 
 unique_ptr<HashIndex> InMemNodeBuilder::load() {
     logger->info("Loading node {} with label {}.", labelName, label);
@@ -100,7 +100,7 @@ unique_ptr<HashIndex> InMemNodeBuilder::populateColumnsAndCountUnstrPropertyList
     logger->info("Populating structured properties and Counting unstructured properties.");
     auto IDIndex =
         make_unique<HashIndex>(StorageUtils::getNodeIndexFName(this->outputDirectory, label),
-            IDType, bufferManager, false /* isInMemoryForLookup */);
+            IDType, bm, false /* isInMemoryForLookup */);
     IDIndex->bulkReserve(numNodes);
     uint32_t IDColumnIdx = UINT32_MAX;
     auto properties = catalog.getStructuredNodeProperties(label);

--- a/src/loader/in_mem_structure/in_mem_page.cpp
+++ b/src/loader/in_mem_structure/in_mem_page.cpp
@@ -9,52 +9,49 @@
 namespace graphflow {
 namespace loader {
 
-InMemPage::InMemPage(uint32_t maxElements, uint8_t* pagePointer, bool hasNULLBytes) {
-    numElementsInPage = maxElements;
-    data = pagePointer;
+InMemPage::InMemPage(uint32_t maxNumElements, bool hasNULLBytes) : maxNumElements{maxNumElements} {
+    buffer = make_unique<uint8_t[]>(DEFAULT_PAGE_SIZE);
+    data = buffer.get();
     if (hasNULLBytes) {
-        uncompressedNULLs = std::make_unique<bool[]>(maxElements);
         // By default, we consider all elements in the page to be NULL. When a new element comes in
         // to be put at a pos, its respective NULL bit is reset to denote a non-NULL value.
-        std::fill(uncompressedNULLs.get(), uncompressedNULLs.get() + maxElements, 1);
-    } else {
-        uncompressedNULLs = nullptr;
+        nullMask = std::make_unique<vector<bool>>(maxNumElements, true);
     }
 }
 
-void InMemPage::write(uint32_t pageOffset, uint32_t posInPage, const uint8_t* value1,
-    uint32_t numBytesForValue1, const uint8_t* value2, uint32_t numBytesForValue2) {
-    auto writePtr = getPtrToMemLoc(pageOffset);
-    memcpy(writePtr, value1, numBytesForValue1);
-    memcpy(writePtr + numBytesForValue1, value2, numBytesForValue2);
-    if (uncompressedNULLs) {
-        uncompressedNULLs[posInPage] = false;
+uint8_t* InMemPage::write(nodeID_t* nodeID, uint32_t byteOffsetInPage, uint32_t elemPosInPage,
+    const NodeIDCompressionScheme& compressionScheme) {
+    memcpy(data + byteOffsetInPage, &nodeID->label, compressionScheme.getNumBytesForLabel());
+    memcpy(data + byteOffsetInPage + compressionScheme.getNumBytesForLabel(), &nodeID->offset,
+        compressionScheme.getNumBytesForOffset());
+    if (nullMask) {
+        nullMask->operator[](elemPosInPage) = false;
     }
+    return data + byteOffsetInPage;
 }
 
-uint8_t* InMemPage::write(
-    uint32_t pageOffset, uint32_t posInPage, const uint8_t* value, uint32_t numBytesForValue) {
-    auto writePtr = getPtrToMemLoc(pageOffset);
-    memcpy(writePtr, value, numBytesForValue);
-    if (uncompressedNULLs) {
-        uncompressedNULLs[posInPage] = false;
+uint8_t* InMemPage::write(uint32_t byteOffsetInPage, uint32_t elemPosInPage, const uint8_t* elem,
+    uint32_t numBytesForElem) {
+    memcpy(data + byteOffsetInPage, elem, numBytesForElem);
+    if (nullMask) {
+        nullMask->operator[](elemPosInPage) = false;
     }
-    return writePtr;
+    return data + byteOffsetInPage;
 }
 
 // We hold isNULL value of each element in in_mem_pages in a boolean array. This is packed together
 // as bits and the collection of NULLBytes (1 byte has isNULL value of 8 elements) is written to
 // the end of the page when writing the page to the disk.
-void InMemPage::encodeNULLBytes() {
-    if (!uncompressedNULLs) {
+void InMemPage::encodeNullBits() {
+    if (!nullMask) {
         return;
     }
     auto pos = 0;
-    auto numNULLBytes = ceil((double)numElementsInPage / 8);
+    auto numNULLBytes = ceil((double)maxNumElements / 8);
     for (auto i = 0; i < numNULLBytes; i++) {
         uint8_t NULLByte = 0b0000000;
         for (auto j = 0; j < 8; j++) {
-            if (uncompressedNULLs[pos]) {
+            if (nullMask->operator[](pos)) {
                 NULLByte = NULLByte | storage::bitMasksWithSingle1s[pos % 8];
             }
             pos++;

--- a/src/loader/include/in_mem_structure/builder/in_mem_node_builder.h
+++ b/src/loader/include/in_mem_structure/builder/in_mem_node_builder.h
@@ -57,7 +57,7 @@ private:
     vector<uint64_t> numLinesPerBlock;
     DataType IDType;
 
-    BufferManager& bufferManager;
+    BufferManager& bm;
     vector<unique_ptr<InMemColumn>> structuredColumns;
     unique_ptr<InMemUnstructuredLists> unstrPropertyLists;
 };

--- a/src/loader/include/in_mem_structure/builder/in_mem_rel_builder.h
+++ b/src/loader/include/in_mem_structure/builder/in_mem_rel_builder.h
@@ -37,13 +37,13 @@ private:
         const Catalog& catalog, vector<bool>& requireToReadLabels);
     static void putPropsOfLineIntoColumns(
         vector<label_property_columns_map_t>& directionLabelPropertyColumns,
-        const vector<Property>& properties, vector<unique_ptr<InMemOverflowPages>>& overflowPages,
+        const vector<Property>& properties, vector<unique_ptr<InMemOverflowFile>>& overflowPages,
         vector<PageByteCursor>& overflowCursors, CSVReader& reader,
         const vector<nodeID_t>& nodeIDs);
     static void putPropsOfLineIntoLists(
         vector<label_property_lists_map_t>& directionLabelPropertyLists,
         vector<label_adj_lists_map_t>& directionLabelAdjLists, const vector<Property>& properties,
-        vector<unique_ptr<InMemOverflowPages>>& overflowPages,
+        vector<unique_ptr<InMemOverflowFile>>& overflowPages,
         vector<PageByteCursor>& overflowCursors, CSVReader& reader, const vector<nodeID_t>& nodeIDs,
         const vector<uint64_t>& reversePos);
 
@@ -53,12 +53,12 @@ private:
     static void populateAdjAndPropertyListsTask(uint64_t blockId, InMemRelBuilder* builder);
     static void sortOverflowValuesOfPropertyColumnTask(const DataType& dataType,
         node_offset_t offsetStart, node_offset_t offsetEnd, InMemColumn* propertyColumn,
-        InMemOverflowPages* unorderedOverflowPages, InMemOverflowPages* orderedOverflowPages,
+        InMemOverflowFile* unorderedOverflowPages, InMemOverflowFile* orderedOverflowPages,
         LoaderProgressBar* progressBar);
     static void sortOverflowValuesOfPropertyListsTask(const DataType& dataType,
         node_offset_t offsetStart, node_offset_t offsetEnd, InMemAdjLists* adjLists,
-        InMemLists* propertyLists, InMemOverflowPages* unorderedStringOverflowPages,
-        InMemOverflowPages* orderedStringOverflowPages, LoaderProgressBar* progressBar);
+        InMemLists* propertyLists, InMemOverflowFile* unorderedStringOverflowPages,
+        InMemOverflowFile* orderedStringOverflowPages, LoaderProgressBar* progressBar);
 
 private:
     RelMultiplicity relMultiplicity;
@@ -73,8 +73,8 @@ private:
     vector<label_property_columns_map_t> directionLabelPropertyColumns{2};
     vector<label_adj_lists_map_t> directionLabelAdjLists{2};
     vector<label_property_lists_map_t> directionLabelPropertyLists{2};
-    vector<unique_ptr<InMemOverflowPages>> propertyColumnsOverflowPages;
-    vector<unique_ptr<InMemOverflowPages>> propertyListsOverflowPages;
+    vector<unique_ptr<InMemOverflowFile>> propertyColumnsOverflowFiles;
+    vector<unique_ptr<InMemOverflowFile>> propertyListsOverflowFiles;
 };
 
 } // namespace loader

--- a/src/loader/include/in_mem_structure/in_mem_column.h
+++ b/src/loader/include/in_mem_structure/in_mem_column.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "src/loader/include/in_mem_structure/in_mem_pages.h"
+#include "src/loader/include/in_mem_structure/in_mem_file.h"
 #include "src/storage/include/compression_scheme.h"
 #include "src/storage/include/storage_structure/overflow_pages.h"
 
@@ -20,10 +20,10 @@ public:
     virtual void setElement(node_offset_t offset, const uint8_t* val);
     inline uint8_t* getElement(node_offset_t offset) {
         auto cursor = getPageElementCursorForOffset(offset);
-        return pages->pages[cursor.pageIdx]->data + (cursor.pos * numBytesForElement);
+        return inMemFile->pages[cursor.pageIdx]->data + (cursor.pos * numBytesForElement);
     }
 
-    virtual inline InMemOverflowPages* getOverflowPages() { return nullptr; }
+    virtual inline InMemOverflowFile* getOverflowPages() { return nullptr; }
 
     inline DataType getDataType() { return dataType; }
 
@@ -38,7 +38,7 @@ protected:
     DataType dataType;
     uint64_t numBytesForElement;
     uint64_t numElementsInAPage;
-    unique_ptr<InMemPages> pages;
+    unique_ptr<InMemFile> inMemFile;
 };
 
 class InMemColumnWithOverflow : public InMemColumn {
@@ -50,10 +50,10 @@ protected:
 
     void saveToFile() override;
 
-    inline InMemOverflowPages* getOverflowPages() override { return overflowPages.get(); }
+    inline InMemOverflowFile* getOverflowPages() override { return inMemOverflowFile.get(); }
 
 protected:
-    unique_ptr<InMemOverflowPages> overflowPages;
+    unique_ptr<InMemOverflowFile> inMemOverflowFile;
 };
 
 class InMemAdjColumn : public InMemColumn {

--- a/src/loader/include/in_mem_structure/in_mem_file.h
+++ b/src/loader/include/in_mem_structure/in_mem_file.h
@@ -5,6 +5,7 @@
 #include "src/common/include/configs.h"
 #include "src/common/types/include/literal.h"
 #include "src/loader/include/in_mem_structure/in_mem_page.h"
+#include "src/storage/include/buffer_manager.h"
 #include "src/storage/include/storage_utils.h"
 
 using namespace graphflow::common;
@@ -13,45 +14,45 @@ using namespace graphflow::storage;
 namespace graphflow {
 namespace loader {
 
-// InMemPages holds a collection of in-memory page in the memory.
-class InMemPages {
+// InMemFile holds a collection of in-memory page in the memory.
+class InMemFile {
 
 public:
-    InMemPages(
-        std::string fName, uint16_t numBytesForElement, bool hasNULLBytes, uint64_t numPages);
+    InMemFile(
+        std::string filePath, uint16_t numBytesForElement, bool hasNullMask, uint64_t numPages);
+    InMemFile(uint16_t numBytesForElement, bool hasNullMask, uint64_t numPages)
+        : InMemFile("", numBytesForElement, hasNullMask, numPages) {}
 
-    virtual ~InMemPages() = default;
+    virtual ~InMemFile() = default;
 
-    virtual void saveToFile();
+    virtual void flush();
+
+protected:
+    uint32_t addANewPage();
 
 public:
-    const std::string fName;
-    std::unique_ptr<uint8_t[]> data;
-    vector<std::unique_ptr<InMemPage>> pages;
+    string filePath;
+    uint64_t numElementsInAPage;
+    uint32_t numUsedPages;
+    bool hasNullMask;
+    vector<unique_ptr<InMemPage>> pages;
 };
 
-//  InMemPages for storing overflow of PropertyColumn or PropertyLists.
-class InMemOverflowPages : public InMemPages {
+//  InMemFile for storing overflow of PropertyColumn or PropertyLists.
+class InMemOverflowFile : public InMemFile {
 
 public:
-    explicit InMemOverflowPages(const std::string& fName) : InMemPages(fName, 1, false, 8) {
-        numUsedPages = 0;
-    };
-
-    InMemOverflowPages() : InMemOverflowPages(""){};
-
-    ~InMemOverflowPages() override = default;
+    explicit InMemOverflowFile(const std::string& fName) : InMemFile{fName, 1, false, 8} {}
+    explicit InMemOverflowFile() : InMemFile{1, false, 8} {}
 
     gf_string_t addString(const char* rawString, PageByteCursor& overflowCursor);
     gf_list_t addList(const Literal& listLiteral, PageByteCursor& overflowCursor);
     // Copy overflow data at srcOverflow into dstGFString.
     void copyStringOverflow(
         PageByteCursor& overflowCursor, uint8_t* srcOverflow, gf_string_t* dstGFString);
-    void copyListOverflow(InMemOverflowPages* srcOverflowPages,
+    void copyListOverflow(InMemOverflowFile* srcOverflowPages,
         const PageByteCursor& srcOverflowCursor, PageByteCursor& dstOverflowCursor,
         gf_list_t* dstGFList, DataType* listChildDataType);
-
-    void saveToFile() override;
 
 private:
     uint32_t getNewOverflowPageIdx();
@@ -64,7 +65,6 @@ private:
 
 private:
     std::shared_mutex lock;
-    uint64_t numUsedPages;
 };
 
 } // namespace loader

--- a/src/loader/include/in_mem_structure/in_mem_lists.h
+++ b/src/loader/include/in_mem_structure/in_mem_lists.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "src/loader/include/in_mem_structure/in_mem_pages.h"
+#include "src/loader/include/in_mem_structure/in_mem_file.h"
 #include "src/storage/include/storage_structure/lists/list_headers.h"
 #include "src/storage/include/storage_structure/lists/lists_metadata.h"
 #include "src/storage/include/storage_structure/overflow_pages.h"
@@ -40,10 +40,10 @@ public:
 
     virtual void saveToFile();
     virtual void setElement(uint32_t header, node_offset_t nodeOffset, uint64_t pos, uint8_t* val);
-    virtual inline InMemOverflowPages* getOverflowPages() { return nullptr; }
+    virtual inline InMemOverflowFile* getOverflowPages() { return nullptr; }
     inline ListsMetadata* getListsMetadata() { return listsMetadata.get(); }
     inline uint8_t* getMemPtrToLoc(uint64_t pageIdx, uint16_t posInPage) {
-        return pages->pages[pageIdx]->data + (posInPage * numBytesForElement);
+        return inMemFile->pages[pageIdx]->data + (posInPage * numBytesForElement);
     }
 
     void init();
@@ -53,7 +53,7 @@ protected:
     DataType dataType;
     uint64_t numBytesForElement;
     unique_ptr<ListsMetadata> listsMetadata;
-    unique_ptr<InMemPages> pages;
+    unique_ptr<InMemFile> inMemFile;
 };
 
 class InMemListsWithOverflow : public InMemLists {
@@ -63,11 +63,11 @@ protected:
 
     ~InMemListsWithOverflow() override = default;
 
-    InMemOverflowPages* getOverflowPages() override { return overflowPages.get(); }
+    InMemOverflowFile* getOverflowPages() override { return overflowInMemFile.get(); }
     void saveToFile() override;
 
 protected:
-    unique_ptr<InMemOverflowPages> overflowPages;
+    unique_ptr<InMemOverflowFile> overflowInMemFile;
 };
 
 class InMemAdjLists : public InMemLists {

--- a/src/loader/include/in_mem_structure/in_mem_page.h
+++ b/src/loader/include/in_mem_structure/in_mem_page.h
@@ -1,8 +1,11 @@
 #pragma once
 
 #include <memory>
+#include <vector>
 
 #include "src/common/include/configs.h"
+#include "src/common/types/include/node_id_t.h"
+#include "src/storage/include/compression_scheme.h"
 
 using namespace graphflow::common;
 
@@ -13,25 +16,23 @@ class InMemPage {
 
 public:
     // Creates an in-memory page with a boolean array to store NULL bits
-    InMemPage(uint32_t maxElements, uint8_t* pagePointer, bool hasNULLBytes);
+    InMemPage(uint32_t maxNumElements, bool hasNULLBytes);
 
-    // Writes to pages and also unsets NULL bit
-    void write(uint32_t pageOffset, uint32_t posInPage, const uint8_t* value1,
-        uint32_t numBytesForValue1, const uint8_t* value2, uint32_t numBytesForValue2);
-    uint8_t* write(
-        uint32_t pageOffset, uint32_t posInPage, const uint8_t* value, uint32_t numBytesForValue);
+    uint8_t* write(nodeID_t* nodeID, uint32_t byteOffsetInPage, uint32_t elemPosInPage,
+        const NodeIDCompressionScheme& compressionScheme);
+    uint8_t* write(uint32_t byteOffsetInPage, uint32_t elemPosInPage, const uint8_t* elem,
+        uint32_t numBytesForElem);
 
-    inline uint8_t* getPtrToMemLoc(uint32_t pageOffset) const { return data + pageOffset; }
-
-    void encodeNULLBytes();
+    void encodeNullBits();
 
 public:
     uint8_t* data;
 
 private:
+    uint32_t maxNumElements;
+    unique_ptr<uint8_t[]> buffer;
     // Following fields are needed for accommodating storage of NULLs in the page.
-    std::unique_ptr<bool[]> uncompressedNULLs;
-    uint32_t numElementsInPage;
+    std::unique_ptr<std::vector<bool>> nullMask;
 };
 
 } // namespace loader

--- a/src/loader/loader_runner.cpp
+++ b/src/loader/loader_runner.cpp
@@ -49,8 +49,9 @@ int main(int argc, char* argv[]) {
     }
     spdlog::set_level(verbosity ? args::get(verbosity) : verbosityMap["info"]);
     auto numThreads = threads ? args::get(threads) : thread::hardware_concurrency();
-    auto bufferPoolSizeInBytes = bufferPoolSizeInMB ? args::get(bufferPoolSizeInMB) * 1024 * 1024 :
-                                                      StorageConfig::DEFAULT_BUFFER_POOL_SIZE;
+    auto bufferPoolSizeInBytes = bufferPoolSizeInMB ?
+                                     (uint64_t)args::get(bufferPoolSizeInMB) * 1024 * 1024 :
+                                     StorageConfig::DEFAULT_BUFFER_POOL_SIZE;
     try {
         GraphLoader graphLoader(args::get(inputDir), args::get(outputDir), numThreads,
             bufferPoolSizeInBytes * StorageConfig::DEFAULT_PAGES_BUFFER_RATIO,

--- a/src/storage/include/buffer_manager.h
+++ b/src/storage/include/buffer_manager.h
@@ -53,9 +53,9 @@ namespace storage {
  * pin/unpin calls of the users of BM.
  *
  * BufferManager supports a special pin function called pinWithoutReadingFromFile. A caller can
- * call the uint32_t newPageIdx = fh::addNewPage() function on the FileHandle fh they have, and then
- * call bm::pinWithoutReadingFromFile(fh, newPageIdx), and the BM will not try to read this page
- * from the file (because the page has not yet been written).
+ * call the uint32_t newPageIdx = fh::addNewPage() function on the FileHandle fh they have, and
+ * then call bm::pinWithoutReadingFromFile(fh, newPageIdx), and the BM will not try to read this
+ * page from the file (because the page has not yet been written).
  */
 class BufferManager {
 

--- a/src/storage/include/index/hash_index.h
+++ b/src/storage/include/index/hash_index.h
@@ -7,7 +7,7 @@
 #include "src/common/include/file_utils.h"
 #include "src/common/include/vector/value_vector.h"
 #include "src/function/hash/operations/include/hash_operations.h"
-#include "src/loader/include/in_mem_structure/in_mem_pages.h"
+#include "src/loader/include/in_mem_structure/in_mem_file.h"
 #include "src/storage/include/buffer_manager.h"
 #include "src/storage/include/index/hash_index_utils.h"
 #include "src/storage/include/memory_manager.h"
@@ -221,7 +221,7 @@ private:
     vector<uint8_t*> ovfPinnedFrames;
 
     // Used when writing to the index.
-    unique_ptr<InMemOverflowPages> inMemStringOvfPages;
+    unique_ptr<InMemOverflowFile> inMemStringOvfPages;
     PageByteCursor stringOvfPageCursor;
     // Used when reading from the index.
     unique_ptr<OverflowPages> stringOvfPages;

--- a/src/storage/include/index/hash_index_utils.h
+++ b/src/storage/include/index/hash_index_utils.h
@@ -3,7 +3,7 @@
 #include <functional>
 
 #include "src/function/hash/operations/include/hash_operations.h"
-#include "src/loader/include/in_mem_structure/in_mem_pages.h"
+#include "src/loader/include/in_mem_structure/in_mem_file.h"
 #include "src/storage/include/storage_structure/overflow_pages.h"
 
 using namespace graphflow::common;
@@ -14,9 +14,9 @@ namespace storage {
 
 using hash_function_t = std::function<hash_t(const uint8_t*)>;
 using insert_function_t =
-    std::function<void(const uint8_t*, uint8_t*, InMemOverflowPages*, PageByteCursor*)>;
+    std::function<void(const uint8_t*, uint8_t*, InMemOverflowFile*, PageByteCursor*)>;
 using equals_in_write_function_t =
-    std::function<bool(const uint8_t*, const uint8_t*, const InMemOverflowPages*)>;
+    std::function<bool(const uint8_t*, const uint8_t*, const InMemOverflowFile*)>;
 using equals_in_read_function_t =
     std::function<bool(const uint8_t*, const uint8_t*, OverflowPages*)>;
 
@@ -37,11 +37,11 @@ public:
     static hash_function_t initializeHashFunc(const DataTypeID& dataTypeID);
     // InsertFunc
     inline static void insertInt64KeyToEntryFunc(const uint8_t* key, uint8_t* entry,
-        InMemOverflowPages* overflowPages = nullptr, PageByteCursor* overflowCursor = nullptr) {
+        InMemOverflowFile* overflowPages = nullptr, PageByteCursor* overflowCursor = nullptr) {
         memcpy(entry, key, Types::getDataTypeSize(INT64));
     }
     inline static void insertStringKeyToEntryFunc(const uint8_t* key, uint8_t* entry,
-        InMemOverflowPages* overflowPages, PageByteCursor* overflowCursor) {
+        InMemOverflowFile* overflowPages, PageByteCursor* overflowCursor) {
         auto gfString =
             overflowPages->addString(reinterpret_cast<const char*>(key), *overflowCursor);
         memcpy(entry, &gfString, Types::getDataTypeSize(STRING));
@@ -52,11 +52,11 @@ public:
         const uint8_t* keyToLookup, const gf_string_t* keyInEntry);
     // equalsFuncInWrite: used in the WRITE_MODE, when performing insertions.
     inline static bool equalsFuncInWriteModeForInt64(const uint8_t* keyToLookup,
-        const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages) {
+        const uint8_t* keyInEntry, const InMemOverflowFile* overflowPages) {
         return memcmp(keyToLookup, keyInEntry, sizeof(int64_t)) == 0;
     }
     static bool equalsFuncInWriteModeForString(const uint8_t* keyToLookup,
-        const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages);
+        const uint8_t* keyInEntry, const InMemOverflowFile* overflowPages);
     static equals_in_write_function_t initializeEqualsFuncInWriteMode(const DataTypeID& dataTypeID);
     // equalsFuncInRead: used in the READ_MODE, when performing lookups.
     inline static bool equalsFuncInReadModeForInt64(

--- a/src/storage/include/storage_structure/column.h
+++ b/src/storage/include/storage_structure/column.h
@@ -15,12 +15,12 @@ namespace storage {
 class Column : public BaseColumnOrList {
 
 public:
-    Column(const StorageStructureIDAndFName structureIDAndFName, const DataType& dataType,
+    Column(const StorageStructureIDAndFName& structureIDAndFName, const DataType& dataType,
         size_t elementSize, BufferManager& bufferManager, bool isInMemory, WAL* wal)
         : BaseColumnOrList{structureIDAndFName, dataType, elementSize, bufferManager,
               true /*hasNULLBytes*/, isInMemory, wal} {};
 
-    Column(const StorageStructureIDAndFName structureIDAndFName, const DataType& dataType,
+    Column(const StorageStructureIDAndFName& structureIDAndFName, const DataType& dataType,
         BufferManager& bufferManager, bool isInMemory, WAL* wal)
         : Column(structureIDAndFName, dataType, Types::getDataTypeSize(dataType), bufferManager,
               isInMemory, wal){};
@@ -68,7 +68,7 @@ protected:
 class StringPropertyColumn : public Column {
 
 public:
-    StringPropertyColumn(const StorageStructureIDAndFName structureIDAndFNameOfMainColumn,
+    StringPropertyColumn(const StorageStructureIDAndFName& structureIDAndFNameOfMainColumn,
         const DataType& dataType, BufferManager& bufferManager, bool isInMemory, WAL* wal)
         : Column{structureIDAndFNameOfMainColumn, dataType, bufferManager, isInMemory, wal},
           stringOverflowPages{structureIDAndFNameOfMainColumn, bufferManager, isInMemory, wal} {};
@@ -77,7 +77,7 @@ public:
         const shared_ptr<ValueVector>& valueVector) override;
 
     void writeValueForSingleNodeIDPosition(node_offset_t nodeOffset,
-        const shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom);
+        const shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
 
     // Currently, used only in Loader tests.
     Literal readValue(node_offset_t offset) override;
@@ -93,7 +93,7 @@ private:
 class ListPropertyColumn : public Column {
 
 public:
-    ListPropertyColumn(const StorageStructureIDAndFName structureIDAndFNameOfMainColumn,
+    ListPropertyColumn(const StorageStructureIDAndFName& structureIDAndFNameOfMainColumn,
         const DataType& dataType, BufferManager& bufferManager, bool isInMemory, WAL* wal)
         : Column{structureIDAndFNameOfMainColumn, dataType, bufferManager, isInMemory, wal},
           listOverflowPages{structureIDAndFNameOfMainColumn, bufferManager, isInMemory, wal} {};
@@ -109,7 +109,7 @@ private:
 class AdjColumn : public Column {
 
 public:
-    AdjColumn(const StorageStructureIDAndFName structureIDAndFName, BufferManager& bufferManager,
+    AdjColumn(const StorageStructureIDAndFName& structureIDAndFName, BufferManager& bufferManager,
         const NodeIDCompressionScheme& nodeIDCompressionScheme, bool isInMemory, WAL* wal)
         : Column{structureIDAndFName, DataType(NODE_ID), nodeIDCompressionScheme.getNumTotalBytes(),
               bufferManager, isInMemory, wal},
@@ -141,7 +141,7 @@ private:
 class ColumnFactory {
 
 public:
-    static unique_ptr<Column> getColumn(const StorageStructureIDAndFName structureIDAndFName,
+    static unique_ptr<Column> getColumn(const StorageStructureIDAndFName& structureIDAndFName,
         const DataType& dataType, BufferManager& bufferManager, bool isInMemory, WAL* wal) {
         switch (dataType.typeID) {
         case INT64:

--- a/src/storage/include/storage_structure/overflow_pages.h
+++ b/src/storage/include/storage_structure/overflow_pages.h
@@ -20,7 +20,7 @@ namespace storage {
 class OverflowPages : public StorageStructure {
 
 public:
-    explicit OverflowPages(const StorageStructureIDAndFName storageStructureIDAndFNameOfMainDBFile,
+    explicit OverflowPages(const StorageStructureIDAndFName& storageStructureIDAndFNameOfMainDBFile,
         BufferManager& bufferManager, bool isInMemory, WAL* wal)
         : StorageStructure(
               constructOverflowStorageStructureIDAndFName(storageStructureIDAndFNameOfMainDBFile),
@@ -29,8 +29,8 @@ public:
     }
 
     // TODO(Semih/Guodong): This overloaded constructor exists for storage structures that hold
-    // overflow pages but is not yet updateable, such as hash index or rel property lists storing
-    // strings. Currently, it creates a dummy StorageStrutureID. This should be removed when we
+    // overflow pages but is not yet updatable, such as hash index or rel property lists storing
+    // strings. Currently, it creates a dummy StorageStructureID. This should be removed when we
     // support updates for those structures too.
     explicit OverflowPages(const string& fName, BufferManager& bufferManager, bool isInMemory)
         : OverflowPages(
@@ -44,8 +44,8 @@ public:
         }
     }
 
-    StorageStructureIDAndFName constructOverflowStorageStructureIDAndFName(
-        StorageStructureIDAndFName storageStructureIDAndFNameForMainDBFile) {
+    static inline StorageStructureIDAndFName constructOverflowStorageStructureIDAndFName(
+        const StorageStructureIDAndFName& storageStructureIDAndFNameForMainDBFile) {
         StorageStructureID newOverflowStorageStructureID =
             storageStructureIDAndFNameForMainDBFile.storageStructureID;
         newOverflowStorageStructureID.isOverflow = true;
@@ -64,7 +64,7 @@ public:
     string readString(const gf_string_t& str);
     vector<Literal> readList(const gf_list_t& listVal, const DataType& dataType);
     void writeStringOverflowAndUpdateOverflowPtr(
-        gf_string_t& stringToWriteTo, gf_string_t& strToWriteFrom);
+        gf_string_t& strToWriteTo, gf_string_t& strToWriteFrom);
 
 private:
     void insertNewOverflowPageIfNecessaryWithoutLock(gf_string_t& strToWriteFrom);

--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -22,7 +22,7 @@ constexpr uint8_t bitMasksWithSingle0s[8] = {
 
 struct StorageStructureIDAndFName {
     StorageStructureIDAndFName(StorageStructureID storageStructureID, string fName)
-        : storageStructureID{storageStructureID}, fName{fName} {};
+        : storageStructureID{storageStructureID}, fName{move(fName)} {};
 
     StorageStructureID storageStructureID;
     string fName;
@@ -136,15 +136,15 @@ public:
     }
 
     inline static string getAdjListsFName(const string& directory, const label_t& relLabel,
-        const label_t& nodeLabel, const RelDirection& direction) {
-        auto fName = StringUtils::string_format("r-%d-%d-%d", relLabel, nodeLabel, direction);
+        const label_t& nodeLabel, const RelDirection& relDirection) {
+        auto fName = StringUtils::string_format("r-%d-%d-%d", relLabel, nodeLabel, relDirection);
         return FileUtils::joinPath(directory, fName + StorageConfig::LISTS_FILE_SUFFIX);
     }
 
     inline static string getRelPropertyColumnFName(const string& directory, const label_t& relLabel,
-        const label_t& nodeLabel, const string& propertyName) {
-        auto fName =
-            StringUtils::string_format("r-%d-%d-%s", relLabel, nodeLabel, propertyName.data());
+        const label_t& nodeLabel, const RelDirection& relDirection, const string& propertyName) {
+        auto fName = StringUtils::string_format(
+            "r-%d-%d-%d-%s", relLabel, nodeLabel, relDirection, propertyName.data());
         return FileUtils::joinPath(directory, fName + StorageConfig::COLUMN_FILE_SUFFIX);
     }
     // TODO(Semih): Warning: We currently do not support updates on adj columns or their
@@ -153,16 +153,17 @@ public:
     // is correct.
     inline static StorageStructureIDAndFName getRelPropertyColumnStructureIDAndFName(
         const string& directory, const label_t& relLabel, const label_t& nodeLabel,
-        const string& propertyName) {
-        auto fName = getRelPropertyColumnFName(directory, relLabel, nodeLabel, propertyName);
+        const RelDirection& relDirection, const string& propertyName) {
+        auto fName =
+            getRelPropertyColumnFName(directory, relLabel, nodeLabel, relDirection, propertyName);
         return StorageStructureIDAndFName(
             StorageStructureID::newStructuredNodePropertyMainColumnID(nodeLabel, -1), fName);
     }
 
     inline static string getRelPropertyListsFName(const string& directory, const label_t& relLabel,
-        const label_t& nodeLabel, const RelDirection& direction, const string& propertyName) {
+        const label_t& nodeLabel, const RelDirection& relDirection, const string& propertyName) {
         auto fName = StringUtils::string_format(
-            "r-%d-%d-%d-%s", relLabel, nodeLabel, direction, propertyName.data());
+            "r-%d-%d-%d-%s", relLabel, nodeLabel, relDirection, propertyName.data());
         return FileUtils::joinPath(directory, fName + StorageConfig::LISTS_FILE_SUFFIX);
     }
 

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -58,7 +58,7 @@ void HashIndex::initializeHeaderAndPages(const DataType& keyDataType) {
         }
         inMemStringOvfPages =
             indexHeader->keyDataTypeID == STRING ?
-                make_unique<InMemOverflowPages>(StorageUtils::getOverflowPagesFName(fName)) :
+                make_unique<InMemOverflowFile>(StorageUtils::getOverflowPagesFName(fName)) :
                 nullptr;
     } else {
         // Read the index header from file.
@@ -330,7 +330,7 @@ void HashIndex::flush() {
     isFlushed = true;
     // Flush string overflow pages if necessary, and flush page mappings to the end of the file.
     if (indexHeader->keyDataTypeID == STRING) {
-        inMemStringOvfPages->saveToFile();
+        inMemStringOvfPages->flush();
     }
     writeLogicalToPhysicalPageMappings();
 }

--- a/src/storage/index/hash_index_utils.cpp
+++ b/src/storage/index/hash_index_utils.cpp
@@ -37,8 +37,8 @@ bool HashIndexUtils::isStringPrefixAndLenEquals(
     return false;
 }
 
-bool HashIndexUtils::equalsFuncInWriteModeForString(const uint8_t* keyToLookup,
-    const uint8_t* keyInEntry, const InMemOverflowPages* overflowPages) {
+bool HashIndexUtils::equalsFuncInWriteModeForString(
+    const uint8_t* keyToLookup, const uint8_t* keyInEntry, const InMemOverflowFile* overflowPages) {
     auto gfStringInEntry = (gf_string_t*)keyInEntry;
     // Checks if prefix and len matches first.
     if (!isStringPrefixAndLenEquals(keyToLookup, gfStringInEntry)) {

--- a/src/storage/store/rel.cpp
+++ b/src/storage/store/rel.cpp
@@ -74,7 +74,7 @@ void Rel::initPropertyColumnsForRelLabel(const Catalog& catalog, const string& d
         propertyColumns[nodeLabel].resize(properties.size());
         for (auto& property : properties) {
             auto storageStructureIDAndFName = StorageUtils::getRelPropertyColumnStructureIDAndFName(
-                directory, relLabel, nodeLabel, property.name);
+                directory, relLabel, nodeLabel, relDirection, property.name);
             logger->debug(
                 "DIR {} nodeLabelForAdjColumnAndProperties {} propertyIdx {} type {} name `{}`",
                 relDirection, nodeLabel, property.propertyID, property.dataType.typeID,


### PR DESCRIPTION
This is a minor PR that makes two changes:
1. `InMemPages` -> `InMemFile`. The large bytes array in `InMemPages` is changed to a set of blocks, each of which is held by an `InMemPage`.
2. fix issue #625.