### PR TITLE
Add support for set of list data type in Column

### DIFF
--- a/src/loader/in_mem_structure/in_mem_lists.cpp
+++ b/src/loader/in_mem_structure/in_mem_lists.cpp
@@ -13,14 +13,14 @@ PageElementCursor InMemListsUtils::calcPageElementCursor(uint32_t header, uint64
     if (ListHeaders::isALargeList(header)) {
         auto lAdjListIdx = ListHeaders::getLargeListIdx(header);
         auto pos = metadata.getNumElementsInLargeLists(lAdjListIdx) - reversePos;
-        cursor = PageUtils::getPageElementCursorForOffset(pos, numElementsInAPage);
+        cursor = PageUtils::getPageElementCursorForPos(pos, numElementsInAPage);
         cursor.pageIdx = metadata.getPageMapperForLargeListIdx(lAdjListIdx)(cursor.pageIdx);
     } else {
         auto chunkId = nodeOffset >> StorageConfig::LISTS_CHUNK_SIZE_LOG_2;
         auto csrOffset = ListHeaders::getSmallListCSROffset(header);
         auto listLen = ListHeaders::getSmallListLen(header);
         auto pos = listLen - reversePos;
-        cursor = PageUtils::getPageElementCursorForOffset(csrOffset + pos, numElementsInAPage);
+        cursor = PageUtils::getPageElementCursorForPos(csrOffset + pos, numElementsInAPage);
         cursor.pageIdx =
             metadata.getPageMapperForChunkIdx(chunkId)((csrOffset + pos) / numElementsInAPage);
     }

--- a/src/storage/include/storage_structure/column.h
+++ b/src/storage/include/storage_structure/column.h
@@ -28,7 +28,7 @@ public:
     virtual void readValues(Transaction* transaction, const shared_ptr<ValueVector>& nodeIDVector,
         const shared_ptr<ValueVector>& resultVector);
 
-    virtual void writeValues(const shared_ptr<ValueVector>& nodeIDVector,
+    void writeValues(const shared_ptr<ValueVector>& nodeIDVector,
         const shared_ptr<ValueVector>& vectorToWriteFrom);
 
     // Currently, used only in Loader tests.
@@ -97,6 +97,9 @@ public:
         const DataType& dataType, BufferManager& bufferManager, bool isInMemory, WAL* wal)
         : Column{structureIDAndFNameOfMainColumn, dataType, bufferManager, isInMemory, wal},
           listOverflowPages{structureIDAndFNameOfMainColumn, bufferManager, isInMemory, wal} {};
+
+    void writeValueForSingleNodeIDPosition(node_offset_t nodeOffset,
+        const shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
 
     void readValues(Transaction* transaction, const shared_ptr<ValueVector>& nodeIDVector,
         const shared_ptr<ValueVector>& valueVector) override;

--- a/src/storage/include/storage_structure/overflow_pages.h
+++ b/src/storage/include/storage_structure/overflow_pages.h
@@ -64,12 +64,17 @@ public:
     string readString(const gf_string_t& str);
     vector<Literal> readList(const gf_list_t& listVal, const DataType& dataType);
     void writeStringOverflowAndUpdateOverflowPtr(
-        gf_string_t& strToWriteTo, gf_string_t& strToWriteFrom);
+        const gf_string_t& strToWriteFrom, gf_string_t& strToWriteTo);
+    void writeListOverflowAndUpdateOverflowPtr(const gf_list_t& listToWriteFrom,
+        gf_list_t& listToWriteTo, const DataType& elementDataType);
 
 private:
-    void insertNewOverflowPageIfNecessaryWithoutLock(gf_string_t& strToWriteFrom);
+    void addNewPageIfNecessaryWithoutLock(uint32_t numBytesToAppend);
     void readListToVector(
         gf_list_t& gfList, const DataType& dataType, OverflowBuffer& overflowBuffer);
+    void setStringOverflowWithoutLock(const gf_string_t& src, gf_string_t& dst);
+    void setListRecursiveIfNestedWithoutLock(
+        const gf_list_t& src, gf_list_t& dst, const DataType& dataType);
 
 private:
     // This is the index of the last free byte to which we can write.

--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -82,11 +82,11 @@ struct PageUtils {
 
     // This function returns the page pageIdx of the page where element will be found and the pos of
     // the element in the page as the offset.
-    static PageElementCursor getPageElementCursorForOffset(
-        const uint64_t& elementOffset, const uint32_t numElementsPerPage) {
-        assert((elementOffset / numElementsPerPage) < UINT32_MAX);
-        return PageElementCursor{(page_idx_t)(elementOffset / numElementsPerPage),
-            (uint16_t)(elementOffset % numElementsPerPage)};
+    static PageElementCursor getPageElementCursorForPos(
+        const uint64_t& elementPos, const uint32_t numElementsPerPage) {
+        assert((elementPos / numElementsPerPage) < UINT32_MAX);
+        return PageElementCursor{(page_idx_t)(elementPos / numElementsPerPage),
+            (uint16_t)(elementPos % numElementsPerPage)};
     }
 };
 

--- a/src/storage/include/versioned_file_handle.h
+++ b/src/storage/include/versioned_file_handle.h
@@ -22,7 +22,7 @@ public:
 
     // This function assumes that the caller has already acquired the lock for originalPageIdx.
     inline bool hasUpdatedWALPageVersionNoLock(page_idx_t originalPageIdx) {
-        auto pageGroupIdxAndPosInGroup = PageUtils::getPageElementCursorForOffset(
+        auto pageGroupIdxAndPosInGroup = PageUtils::getPageElementCursorForPos(
             originalPageIdx, MULTI_VERSION_FILE_PAGE_GROUP_SIZE);
         // There is an updated wal page if the PageVersionAndLockInfo for the page group exists
         // and the page version for the page is not null (which is UINT32_MAX).
@@ -35,7 +35,7 @@ public:
 
     // This function assumes that the caller has already acquired the lock for originalPageIdx.
     inline page_idx_t getUpdatedWALPageVersionNoLock(page_idx_t originalPageIdx) {
-        auto pageGroupIdxAndPosInGroup = PageUtils::getPageElementCursorForOffset(
+        auto pageGroupIdxAndPosInGroup = PageUtils::getPageElementCursorForPos(
             originalPageIdx, MULTI_VERSION_FILE_PAGE_GROUP_SIZE);
         return pageVersions[pageGroupIdxAndPosInGroup.pageIdx][pageGroupIdxAndPosInGroup.posInPage];
     }

--- a/src/storage/storage_structure/storage_structure.cpp
+++ b/src/storage/storage_structure/storage_structure.cpp
@@ -24,7 +24,7 @@ UpdatedPageInfoAndWALPageFrame
 StorageStructure::getUpdatePageInfoForElementAndCreateWALVersionOfPageIfNecessary(
     uint64_t elementOffset, uint64_t numElementsPerPage) {
     auto originalPageCursor =
-        PageUtils::getPageElementCursorForOffset(elementOffset, numElementsPerPage);
+        PageUtils::getPageElementCursorForPos(elementOffset, numElementsPerPage);
     fileHandle.createPageVersionGroupIfNecessary(originalPageCursor.pageIdx);
     fileHandle.acquirePageLock(originalPageCursor.pageIdx, true /* block */);
     page_idx_t pageIdxInWAL;

--- a/src/storage/versioned_file_handle.cpp
+++ b/src/storage/versioned_file_handle.cpp
@@ -11,11 +11,11 @@ VersionedFileHandle::VersionedFileHandle(
 }
 
 void VersionedFileHandle::createPageVersionGroupIfNecessary(page_idx_t pageIdx) {
-    // Although getPageElementCursorForOffset is written to get offsets of elements
+    // Although getPageElementCursorForPos is written to get offsets of elements
     // in pages, it simply can be used to find the group/chunk and offset/pos in group/chunk for
     // any chunked data structure.
     auto pageGroupIdxAndPosInGroup =
-        PageUtils::getPageElementCursorForOffset(pageIdx, MULTI_VERSION_FILE_PAGE_GROUP_SIZE);
+        PageUtils::getPageElementCursorForPos(pageIdx, MULTI_VERSION_FILE_PAGE_GROUP_SIZE);
     // If we have not created a vector of locks and pageVersion array for each page in this
     // group, first create them.
     bool pageGroupLockAcquired = false;
@@ -31,8 +31,8 @@ void VersionedFileHandle::createPageVersionGroupIfNecessary(page_idx_t pageIdx) 
 
 void VersionedFileHandle::setUpdatedWALPageVersionNoLock(
     page_idx_t originalPageIdx, page_idx_t pageIdxInWAL) {
-    auto pageGroupIdxAndPosInGroup = PageUtils::getPageElementCursorForOffset(
-        originalPageIdx, MULTI_VERSION_FILE_PAGE_GROUP_SIZE);
+    auto pageGroupIdxAndPosInGroup =
+        PageUtils::getPageElementCursorForPos(originalPageIdx, MULTI_VERSION_FILE_PAGE_GROUP_SIZE);
     pageVersions[pageGroupIdxAndPosInGroup.pageIdx][pageGroupIdxAndPosInGroup.posInPage] =
         pageIdxInWAL;
 }

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -47,8 +47,8 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) {
         }
         if (!isCheckpoint && walRecord.pageInsertOrUpdateRecord.isInsert) {
             // Note: We can directly call removePageIdxAndTruncateIfNecessary here because we assume
-            // there is asingle write transaction in the system at any point in time. Suppose page 5
-            // and page 6 were added to a file during a transaction, which is now rolling back. As
+            // there is a single write transaction in the system at any point in time. Suppose page
+            // 5 and page 6 were added to a file during a transaction, which is now rolling back. As
             // we replay the log to rollback, we see page 5's insertion first. However, we can
             // directly truncate the file to 5 (even if later we will see a page 6 insertion),
             // because we assume that if there were further new page additions to the same file,
@@ -61,7 +61,7 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) {
             fileHandle->clearUpdatedWALPageVersion(
                 walRecord.pageInsertOrUpdateRecord.pageIdxInOriginalFile);
         }
-    }
+    } break;
     case COMMIT_RECORD: {
         break;
     }

--- a/test/runner/tinysnb_end_to_end_update_test.cpp
+++ b/test/runner/tinysnb_end_to_end_update_test.cpp
@@ -114,6 +114,48 @@ TEST_F(TinySnbUpdateTest, SetManyNodeLongStringPropRollbackTest) {
     ASSERT_EQ(result->getNext()->getValue(0)->val.strVal.getAsString(), "Alice");
 }
 
+TEST_F(TinySnbUpdateTest, SetOneNodeListOfIntPropTest) {
+    conn->query("MATCH (a:person) WHERE a.ID=0 SET a.workedHours=[10,20]");
+    auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.workedHours");
+    auto value = result->getNext()->getValue(0);
+    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType), "[10,20]");
+}
+
+TEST_F(TinySnbUpdateTest, SetOneNodeListOfShortStringPropTest) {
+    conn->query("MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['intel','microsoft']");
+    auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames");
+    auto value = result->getNext()->getValue(0);
+    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType), "[intel,microsoft]");
+}
+
+TEST_F(TinySnbUpdateTest, SetOneNodeListOfLongStringPropTest) {
+    conn->query(
+        "MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']");
+    auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames");
+    auto value = result->getNext()->getValue(0);
+    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType),
+        "[abcndwjbwesdsd,microsofthbbjuwgedsd]");
+}
+
+TEST_F(TinySnbUpdateTest, SetManyNodeListPropTest) {
+    conn->query("MATCH (a:person) WHERE a.ID=8 SET a.courseScoresPerTerm=[[10,20],[0,0,0]]");
+    auto result = conn->query("MATCH (a:person) WHERE a.ID=8 RETURN a.courseScoresPerTerm");
+    auto value = result->getNext()->getValue(0);
+    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType), "[[10,20],[0,0,0]]");
+}
+
+TEST_F(TinySnbUpdateTest, SetVeryLongListErrorsTest) {
+    conn->beginWriteTransaction();
+    string veryLongList = "[";
+    for (int i = 0; i < 599; ++i) {
+        veryLongList += to_string(i);
+        veryLongList += ",";
+    }
+    veryLongList += "599]";
+    auto result = conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName=" + veryLongList);
+    ASSERT_FALSE(result->isSuccess());
+}
+
 TEST_F(TinySnbUpdateTest, SetNodeIntervalPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.lastJobDuration=interval('1 years 1 days')");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.lastJobDuration");


### PR DESCRIPTION
This PR adds support for setting a list value in a Column, following the way how a string is set and also the logic of copying a list in `OverflowBufferUtils::copyListRecursiveIfNested`.