### PR TITLE
order by optimization

### DIFF
--- a/src/processor/include/physical_plan/operator/order_by/order_by_key_encoder.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_key_encoder.h
@@ -47,15 +47,18 @@ public:
         return sizeof(nextLocalTupleIdx) - sizeof(factorizedTableIdx);
     }
 
-    static uint64_t getEncodedTupleIdx(const uint8_t* tupleInfoBuffer);
+    static uint64_t getEncodedTupleIdx(const uint8_t* tupleInfoPtr);
 
-    static uint64_t getEncodedFactorizedTableIdx(const uint8_t* tupleInfoBuffer);
+    static uint64_t getEncodedFactorizedTableIdx(const uint8_t* tupleInfoPtr);
 
     static uint64_t getEncodingSize(const DataType& dataType);
 
-    static inline bool isNullVal(const uint8_t* nullBuffer, bool isAscOrder) {
-        return *(nullBuffer) == (isAscOrder ? UINT8_MAX : 0);
+    static inline bool isNullVal(const uint8_t* nullBytePtr, bool isAscOrder) {
+        return *(nullBytePtr) == (isAscOrder ? UINT8_MAX : 0);
     }
+
+    static pair<uint64_t, uint64_t> getEncodedFactorizedTableIdxAndTupleIdx(
+        uint8_t* encodedTupleInfoPtr);
 
 private:
     uint8_t flipSign(uint8_t key_byte);
@@ -98,6 +101,7 @@ private:
     const uint64_t MAX_LOCAL_TUPLE_IDX = (1ull << 48) - 1;
     uint64_t nextLocalTupleIdx;
     uint16_t factorizedTableIdx;
+    bool swapBytes;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
@@ -16,10 +16,9 @@ public:
         const vector<DataPos>& outDataPoses,
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState,
         unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(child), id, paramsString}, SourceOperator{move(
-                                                               resultSetDescriptor)},
-          outDataPoses{outDataPoses}, sharedState{move(sharedState)}, nextTupleIdxToReadInMemBlock{
-                                                                          0} {}
+        : PhysicalOperator{move(child), id, paramsString},
+          SourceOperator{move(resultSetDescriptor)}, outDataPoses{outDataPoses},
+          sharedState{move(sharedState)}, nextTupleIdxToReadInMergedKeyBlock{0} {}
 
     // This constructor is used for cloning only.
     OrderByScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
@@ -27,8 +26,8 @@ public:
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState, uint32_t id,
         const string& paramsString)
         : PhysicalOperator{id, paramsString}, SourceOperator{move(resultSetDescriptor)},
-          outDataPoses{outDataPoses}, sharedState{move(sharedState)}, nextTupleIdxToReadInMemBlock{
-                                                                          0} {}
+          outDataPoses{outDataPoses}, sharedState{move(sharedState)},
+          nextTupleIdxToReadInMergedKeyBlock{0} {}
 
     PhysicalOperatorType getOperatorType() override { return ORDER_BY_SCAN; }
 
@@ -46,13 +45,16 @@ public:
     }
 
 private:
-    pair<uint64_t, uint64_t> getNextFactorizedTableIdxAndTupleIdxPair();
-
     bool scanSingleTuple;
     vector<DataPos> outDataPoses;
     shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState;
     vector<shared_ptr<ValueVector>> vectorsToRead;
-    uint64_t nextTupleIdxToReadInMemBlock;
+    uint64_t nextTupleIdxToReadInMergedKeyBlock;
+    shared_ptr<MergedKeyBlocks> mergedKeyBlock;
+    uint64_t tupleIdxAndFactorizedTableIdxOffset;
+    vector<uint64_t> colsToScan;
+    unique_ptr<uint8_t*[]> tuplesToRead;
+    unique_ptr<BlockPtrInfo> blockPtrInfo;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/order_by/radix_sort.h
+++ b/src/processor/include/physical_plan/operator/order_by/radix_sort.h
@@ -35,7 +35,10 @@ public:
         : tmpSortingResultBlock{make_unique<DataBlock>(memoryManager)},
           tmpTuplePtrSortingBlock{make_unique<DataBlock>(memoryManager)},
           orderByKeyEncoder{orderByKeyEncoder}, factorizedTable{factorizedTable},
-          stringAndUnstructuredKeyColInfo{stringAndUnstructuredKeyColInfo} {}
+          stringAndUnstructuredKeyColInfo{stringAndUnstructuredKeyColInfo},
+          numBytesPerTuple{orderByKeyEncoder.getNumBytesPerTuple()}, numBytesToRadixSort{
+                                                                         numBytesPerTuple -
+                                                                         sizeof(uint64_t)} {}
 
     void sortSingleKeyBlock(const DataBlock& keyBlock);
 
@@ -66,6 +69,8 @@ private:
     // unstructured columns when resolving ties.
     FactorizedTable& factorizedTable;
     vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo;
+    uint64_t numBytesPerTuple;
+    uint64_t numBytesToRadixSort;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/result/factorized_table.h
+++ b/src/processor/include/physical_plan/result/factorized_table.h
@@ -188,9 +188,9 @@ private:
 
     uint64_t computeNumTuplesToAppend(const vector<shared_ptr<ValueVector>>& vectorsToAppend) const;
 
-    void assertTupleIdxColIdxAndValueIsFlat(uint64_t tupleIdx, uint64_t colIdx) const;
-
-    uint8_t* getCell(uint64_t tupleIdx, uint64_t colIdx) const;
+    inline uint8_t* getCell(uint64_t tupleIdx, uint64_t colIdx) const {
+        return getTuple(tupleIdx) + tableSchema.getColOffset(colIdx);
+    }
 
     inline pair<uint64_t, uint64_t> getBlockIdxAndTupleIdxInBlock(uint64_t tupleIdx) const {
         return make_pair(tupleIdx / numTuplesPerBlock, tupleIdx % numTuplesPerBlock);

--- a/src/processor/physical_plan/result/factorized_table.cpp
+++ b/src/processor/physical_plan/result/factorized_table.cpp
@@ -203,17 +203,6 @@ uint64_t FactorizedTable::computeNumTuplesToAppend(
     return numTuplesToAppend;
 }
 
-void FactorizedTable::assertTupleIdxColIdxAndValueIsFlat(uint64_t tupleIdx, uint64_t colIdx) const {
-    assert(tupleIdx < numTuples);
-    assert(colIdx < tableSchema.getNumColumns());
-    assert(!tableSchema.getColumn(colIdx).getIsUnflat());
-}
-
-uint8_t* FactorizedTable::getCell(uint64_t tupleIdx, uint64_t colIdx) const {
-    assertTupleIdxColIdxAndValueIsFlat(tupleIdx, colIdx);
-    return getTuple(tupleIdx) + tableSchema.getColOffset(colIdx);
-}
-
 vector<BlockAppendingInfo> FactorizedTable::allocateTupleBlocks(uint64_t numTuplesToAppend) {
     auto numBytesPerTuple = tableSchema.getNumBytesPerTuple();
     assert(numBytesPerTuple < LARGE_PAGE_SIZE);

--- a/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
@@ -274,7 +274,7 @@ TEST_F(RadixSortTest, singleOrderByColUnstrSameDataTypeTest) {
     vector<Value> sortingData = {Value(4.7), Value(-0.5), Value(10.52), Value(double(0)) /* NULL */,
         Value(double(0)) /* NULL */};
     vector<bool> nullMasks = {false, false, false, true, true};
-    vector<uint64_t> expectedTupleIdxOrder = {1, 0, 2, 3, 4};
+    vector<uint64_t> expectedTupleIdxOrder = {1, 0, 2, 4, 3};
     singleOrderByColTest(sortingData, nullMasks, expectedTupleIdxOrder, UNSTRUCTURED,
         true /* isAsc */, false /* hasPayLoadCol */);
 }


### PR DESCRIPTION
This PR contains the following optimizations for orderBy operator:

1. OrderByScan: 
- Instead of reading from factorizedTable to valueVector one tuple at a time, we utilize the FactorizedTable::lookup() interface to read multiple tuples in factorizedTable to a valueVector at a time.
- Defined some constants to avoid repetitive computation (eg. tupleIdxAndFactorizedTableIdxOffset)

2. OrderByMerge:
- While merging two mergedKeyBlocks to a single mergedKeyBlock, we don't do an if/else cross partition check in each iteration.
- Optimize for compareTupleBuffer
- Defined some constants to avoid repetitve computation (eg. numBytesToCompare)

3. RadixSort: 
- We don't need to do radix sort on tuple/factorizedTable index (the last 8 bytes).
- Defined some constants to avoid repetitve computation (eg. numBytesToRadixSort)

4. OrderByKeyEncoder:
- We don't need to perform the isLittleEndian() check in each call to encodeKeys(). Instead, we save the `isLittleEndian` result in a local variable `swapBytes` to indicate whether to swap bytes.

5. Renamed all variables `*buffer` to `*ptr`