### PR TITLE
add sequential scan to string overflow

### DIFF
--- a/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
@@ -26,7 +26,7 @@ bool AdjColumnExtend::getNextTuples() {
         }
         saveDataChunkSelectorState(inputNodeIDDataChunk);
         outputVector->setAllNull();
-        nodeIDColumn->readValues(transaction, inputNodeIDVector, outputVector);
+        nodeIDColumn->read(transaction, inputNodeIDVector, outputVector);
         hasAtLeastOneNonNullValue = discardNullNodesInVector(*outputVector);
     } while (!hasAtLeastOneNonNullValue);
     metrics->executionTime.stop();

--- a/src/processor/physical_plan/operator/scan_column/scan_structured_property.cpp
+++ b/src/processor/physical_plan/operator/scan_column/scan_structured_property.cpp
@@ -25,7 +25,7 @@ bool ScanStructuredProperty::getNextTuples() {
     }
     for (auto i = 0u; i < propertyColumns.size(); ++i) {
         outputVectors[i]->resetOverflowBuffer();
-        propertyColumns[i]->readValues(transaction, inputNodeIDVector, outputVectors[i]);
+        propertyColumns[i]->read(transaction, inputNodeIDVector, outputVectors[i]);
     }
     metrics->executionTime.stop();
     return true;

--- a/src/processor/physical_plan/operator/var_length_extend/var_length_column_extend.cpp
+++ b/src/processor/physical_plan/operator/var_length_extend/var_length_column_extend.cpp
@@ -69,7 +69,7 @@ bool VarLengthColumnExtend::addDFSLevelToStackIfParentExtends(
     shared_ptr<ValueVector>& parentValueVector, uint8_t level) {
     auto dfsLevelInfo = static_pointer_cast<ColumnExtendDFSLevelInfo>(dfsLevelInfos[level - 1]);
     dfsLevelInfo->reset();
-    ((Column*)storage)->readValues(transaction, parentValueVector, dfsLevelInfo->children);
+    ((Column*)storage)->read(transaction, parentValueVector, dfsLevelInfo->children);
     if (!dfsLevelInfo->children->isNull(parentValueVector->state->getPositionOfCurrIdx())) {
         dfsStack.emplace(move(dfsLevelInfo));
         return true;

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -50,7 +50,7 @@ public:
     void readAndAssertAgePropertyNode(
         uint64_t nodeOffset, Transaction* trx, int64_t expectedValue, bool isNull) {
         dataChunk->state->currIdx = nodeOffset;
-        personAgeColumn->readValues(trx, nodeVector, agePropertyVectorToReadDataInto);
+        personAgeColumn->read(trx, nodeVector, agePropertyVectorToReadDataInto);
         if (isNull) {
             ASSERT_TRUE(agePropertyVectorToReadDataInto->isNull(dataChunk->state->currIdx));
         } else {
@@ -63,7 +63,7 @@ public:
     void readAndAssertEyeSightPropertyNode(
         uint64_t nodeOffset, Transaction* trx, double expectedValue, bool isNull) {
         dataChunk->state->currIdx = nodeOffset;
-        personEyeSightColumn->readValues(trx, nodeVector, eyeSightVectorToReadDataInto);
+        personEyeSightColumn->read(trx, nodeVector, eyeSightVectorToReadDataInto);
         if (isNull) {
             ASSERT_TRUE(eyeSightVectorToReadDataInto->isNull(dataChunk->state->currIdx));
         } else {


### PR DESCRIPTION
- Add sequential string overflow scan
- Refactor column scan interface. Provide 3 virtual scan functions that should be overwritten by different columns.
   - scanSingle: scan a single element. Used for flat vector or unflat vector random access.
   - scanSequential: fast path for sequential scan
   - scanSequentialWithSelState: fast path for sequential scan with filters