### PR TITLE
orderBy string optimization

### DIFF
--- a/src/processor/include/physical_plan/operator/aggregate/hash_aggregate_scan.h
+++ b/src/processor/include/physical_plan/operator/aggregate/hash_aggregate_scan.h
@@ -45,7 +45,7 @@ private:
     vector<DataType> groupByKeyVectorDataTypes;
     vector<shared_ptr<ValueVector>> groupByKeyVectors;
     shared_ptr<HashAggregateSharedState> sharedState;
-    vector<uint64_t> groupByKeyVectorsColIdxes;
+    vector<uint32_t> groupByKeyVectorsColIdxes;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -75,7 +75,7 @@ private:
     ProbeDataInfo probeDataInfo;
     uint64_t tuplePosToReadInProbedState;
     vector<shared_ptr<ValueVector>> vectorsToRead;
-    vector<uint64_t> columnsToRead;
+    vector<uint32_t> columnsToRead;
     shared_ptr<ValueVector> probeSideKeyVector;
     unique_ptr<ProbeState> probeState;
 

--- a/src/processor/include/physical_plan/operator/order_by/order_by.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by.h
@@ -25,13 +25,13 @@ public:
         : nextFactorizedTableIdx{0}, sortedKeyBlocks{
                                          make_shared<queue<shared_ptr<MergedKeyBlocks>>>()} {}
 
-    uint16_t getNextFactorizedTableIdx() {
+    uint8_t getNextFactorizedTableIdx() {
         lock_guard<mutex> lck{orderBySharedStateMutex};
         return nextFactorizedTableIdx++;
     }
 
     void appendFactorizedTable(
-        uint16_t factorizedTableIdx, shared_ptr<FactorizedTable> factorizedTable) {
+        uint8_t factorizedTableIdx, shared_ptr<FactorizedTable> factorizedTable) {
         lock_guard<mutex> lck{orderBySharedStateMutex};
         // If the factorizedTables is full, resize the factorizedTables and
         // insert the factorizedTable to the set.
@@ -46,7 +46,7 @@ public:
         sortedKeyBlocks->emplace(mergedDataBlocks);
     }
 
-    void setNumBytesPerTuple(uint64_t numBytesPerTuple) {
+    void setNumBytesPerTuple(uint32_t numBytesPerTuple) {
         lock_guard<mutex> lck{orderBySharedStateMutex};
         this->numBytesPerTuple = numBytesPerTuple;
     }
@@ -69,10 +69,10 @@ private:
 
 public:
     vector<shared_ptr<FactorizedTable>> factorizedTables;
-    uint16_t nextFactorizedTableIdx;
+    uint8_t nextFactorizedTableIdx;
     shared_ptr<queue<shared_ptr<MergedKeyBlocks>>> sortedKeyBlocks;
 
-    uint64_t numBytesPerTuple;
+    uint32_t numBytesPerTuple;
     vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo;
     vector<DataType> dataTypes;
 };
@@ -117,7 +117,7 @@ public:
     }
 
 private:
-    uint16_t factorizedTableIdx;
+    uint8_t factorizedTableIdx;
     OrderByDataInfo orderByDataInfo;
     unique_ptr<OrderByKeyEncoder> orderByKeyEncoder;
     unique_ptr<RadixSort> radixSorter;

--- a/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
+++ b/src/processor/include/physical_plan/operator/order_by/order_by_scan.h
@@ -49,10 +49,10 @@ private:
     vector<DataPos> outDataPoses;
     shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState;
     vector<shared_ptr<ValueVector>> vectorsToRead;
-    uint64_t nextTupleIdxToReadInMergedKeyBlock;
+    uint32_t nextTupleIdxToReadInMergedKeyBlock;
     shared_ptr<MergedKeyBlocks> mergedKeyBlock;
-    uint64_t tupleIdxAndFactorizedTableIdxOffset;
-    vector<uint64_t> colsToScan;
+    uint32_t tupleIdxAndFactorizedTableIdxOffset;
+    vector<uint32_t> colsToScan;
     unique_ptr<uint8_t*[]> tuplesToRead;
     unique_ptr<BlockPtrInfo> blockPtrInfo;
 };

--- a/test/runner/queries/order_by/order_by_tiny_snb.test
+++ b/test/runner/queries/order_by/order_by_tiny_snb.test
@@ -213,7 +213,7 @@ Carol
 # If the payload column and the orderBy key column are in different dataChunks and one of them is unflat, the order by
 # scanner can only scan one tuple from factorizedTable at a time.
 -NAME OrderByScanSingleTupleTest
--QUERY MATCH (a:person)-[:knows]->(b:person) return a.fName order by b.fName
+-QUERY MATCH (a:person)-[:knows]->(b:person) return a.fName order by b.fName, a.fName
 -PARALLELISM 2
 ---- 14
 Bob


### PR DESCRIPTION
This PR does the following optimizations for orderBy string column:
1.  OrderByScan: 
- Instead of encoding 6 bytes for tupleIdx and 2 bytes for factorizedTableIdx. We do: 4 bytes encoding for factorizedTableBlockIdx, 3 bytes encoding for factorizedTableBlockOffset, 1 byte for factorizedTableIdx. This can accelerate the fetching the string from the factorizedTable because we no longer need to do a division and mod operation to calculate the tuplePtr in factorizedTable. The drawBack is that the 1 byte encoding limits our maximum number of threads to 256.
- We encode one more byte for strings to indicate whether this string is a long or a short string. The new encoding length for string will be 14 bytes (1byte null + 12 bytes prefix  + 1byte long/short flag)
- EncodeTuples() for loop optimization

2. Radix sort:
- Instead of fetching the actual string from factorizedTable for each string comparison in quickSort, we can utilize the encoded long/short string flag to minimize the number of string fetch from factorizedTable.
- FindTies() for loop change to minimize the number of multiplications.

3. KeyBlockMerger:
- Minimizes the number of times of fetching strings from factorizedTable by utilizing the long/short string flag in compareTuplePtr().

4. FactorizedTable:
- Table schema now stores the numBytesPerTuple. We don't need to calculate the numBytesPerTuple dynamically during getNumBytesPerTuple().
- Change the getCell() interface. Instead of dynamically getting the colOffset, getCell() now takes in a colOffset parameter.
