### PR TITLE
Rework null bits

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -53,7 +53,21 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "overflow_buffer",
-        "type_utils"
+        "type_utils",
+    ],
+)
+
+cc_library(
+    name = "null_mask",
+    srcs = [
+        "null_mask.cpp",
+    ],
+    hdrs = [
+        "include/null_mask.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "configs",
     ],
 )
 
@@ -72,8 +86,9 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "expression_type",
-        "type_utils",
+        "null_mask",
         "overflow_buffer_utils",
+        "type_utils",
         "//src/common/types",
         "//src/storage:memory_manager",
     ],

--- a/src/common/include/null_mask.h
+++ b/src/common/include/null_mask.h
@@ -1,0 +1,114 @@
+#pragma once
+
+#include <memory>
+#include <vector>
+
+#include "src/common/include/configs.h"
+
+namespace graphflow {
+namespace common {
+
+constexpr uint64_t NULL_BITMASKS_WITH_SINGLE_ONE[64] = {0x1, 0x2, 0x4, 0x8, 0x10, 0x20, 0x40, 0x80,
+    0x100, 0x200, 0x400, 0x800, 0x1000, 0x2000, 0x4000, 0x8000, 0x10000, 0x20000, 0x40000, 0x80000,
+    0x100000, 0x200000, 0x400000, 0x800000, 0x1000000, 0x2000000, 0x4000000, 0x8000000, 0x10000000,
+    0x20000000, 0x40000000, 0x80000000, 0x100000000, 0x200000000, 0x400000000, 0x800000000,
+    0x1000000000, 0x2000000000, 0x4000000000, 0x8000000000, 0x10000000000, 0x20000000000,
+    0x40000000000, 0x80000000000, 0x100000000000, 0x200000000000, 0x400000000000, 0x800000000000,
+    0x1000000000000, 0x2000000000000, 0x4000000000000, 0x8000000000000, 0x10000000000000,
+    0x20000000000000, 0x40000000000000, 0x80000000000000, 0x100000000000000, 0x200000000000000,
+    0x400000000000000, 0x800000000000000, 0x1000000000000000, 0x2000000000000000,
+    0x4000000000000000, 0x8000000000000000};
+constexpr uint64_t NULL_BITMASKS_WITH_SINGLE_ZERO[] = {0xfffffffffffffffe, 0xfffffffffffffffd,
+    0xfffffffffffffffb, 0xfffffffffffffff7, 0xffffffffffffffef, 0xffffffffffffffdf,
+    0xffffffffffffffbf, 0xffffffffffffff7f, 0xfffffffffffffeff, 0xfffffffffffffdff,
+    0xfffffffffffffbff, 0xfffffffffffff7ff, 0xffffffffffffefff, 0xffffffffffffdfff,
+    0xffffffffffffbfff, 0xffffffffffff7fff, 0xfffffffffffeffff, 0xfffffffffffdffff,
+    0xfffffffffffbffff, 0xfffffffffff7ffff, 0xffffffffffefffff, 0xffffffffffdfffff,
+    0xffffffffffbfffff, 0xffffffffff7fffff, 0xfffffffffeffffff, 0xfffffffffdffffff,
+    0xfffffffffbffffff, 0xfffffffff7ffffff, 0xffffffffefffffff, 0xffffffffdfffffff,
+    0xffffffffbfffffff, 0xffffffff7fffffff, 0xfffffffeffffffff, 0xfffffffdffffffff,
+    0xfffffffbffffffff, 0xfffffff7ffffffff, 0xffffffefffffffff, 0xffffffdfffffffff,
+    0xffffffbfffffffff, 0xffffff7fffffffff, 0xfffffeffffffffff, 0xfffffdffffffffff,
+    0xfffffbffffffffff, 0xfffff7ffffffffff, 0xffffefffffffffff, 0xffffdfffffffffff,
+    0xffffbfffffffffff, 0xffff7fffffffffff, 0xfffeffffffffffff, 0xfffdffffffffffff,
+    0xfffbffffffffffff, 0xfff7ffffffffffff, 0xffefffffffffffff, 0xffdfffffffffffff,
+    0xffbfffffffffffff, 0xff7fffffffffffff, 0xfeffffffffffffff, 0xfdffffffffffffff,
+    0xfbffffffffffffff, 0xf7ffffffffffffff, 0xefffffffffffffff, 0xdfffffffffffffff,
+    0xbfffffffffffffff, 0x7fffffffffffffff};
+
+const uint64_t NULL_LOWER_MASKS[] = {0x0, 0x1, 0x3, 0x7, 0xf, 0x1f, 0x3f, 0x7f, 0xff, 0x1ff, 0x3ff,
+    0x7ff, 0xfff, 0x1fff, 0x3fff, 0x7fff, 0xffff, 0x1ffff, 0x3ffff, 0x7ffff, 0xfffff, 0x1fffff,
+    0x3fffff, 0x7fffff, 0xffffff, 0x1ffffff, 0x3ffffff, 0x7ffffff, 0xfffffff, 0x1fffffff,
+    0x3fffffff, 0x7fffffff, 0xffffffff, 0x1ffffffff, 0x3ffffffff, 0x7ffffffff, 0xfffffffff,
+    0x1fffffffff, 0x3fffffffff, 0x7fffffffff, 0xffffffffff, 0x1ffffffffff, 0x3ffffffffff,
+    0x7ffffffffff, 0xfffffffffff, 0x1fffffffffff, 0x3fffffffffff, 0x7fffffffffff, 0xffffffffffff,
+    0x1ffffffffffff, 0x3ffffffffffff, 0x7ffffffffffff, 0xfffffffffffff, 0x1fffffffffffff,
+    0x3fffffffffffff, 0x7fffffffffffff, 0xffffffffffffff, 0x1ffffffffffffff, 0x3ffffffffffffff,
+    0x7ffffffffffffff, 0xfffffffffffffff, 0x1fffffffffffffff, 0x3fffffffffffffff,
+    0x7fffffffffffffff, 0xffffffffffffffff};
+const uint64_t NULL_HIGH_MASKS[] = {0x0, 0x8000000000000000, 0xc000000000000000, 0xe000000000000000,
+    0xf000000000000000, 0xf800000000000000, 0xfc00000000000000, 0xfe00000000000000,
+    0xff00000000000000, 0xff80000000000000, 0xffc0000000000000, 0xffe0000000000000,
+    0xfff0000000000000, 0xfff8000000000000, 0xfffc000000000000, 0xfffe000000000000,
+    0xffff000000000000, 0xffff800000000000, 0xffffc00000000000, 0xffffe00000000000,
+    0xfffff00000000000, 0xfffff80000000000, 0xfffffc0000000000, 0xfffffe0000000000,
+    0xffffff0000000000, 0xffffff8000000000, 0xffffffc000000000, 0xffffffe000000000,
+    0xfffffff000000000, 0xfffffff800000000, 0xfffffffc00000000, 0xfffffffe00000000,
+    0xffffffff00000000, 0xffffffff80000000, 0xffffffffc0000000, 0xffffffffe0000000,
+    0xfffffffff0000000, 0xfffffffff8000000, 0xfffffffffc000000, 0xfffffffffe000000,
+    0xffffffffff000000, 0xffffffffff800000, 0xffffffffffc00000, 0xffffffffffe00000,
+    0xfffffffffff00000, 0xfffffffffff80000, 0xfffffffffffc0000, 0xfffffffffffe0000,
+    0xffffffffffff0000, 0xffffffffffff8000, 0xffffffffffffc000, 0xffffffffffffe000,
+    0xfffffffffffff000, 0xfffffffffffff800, 0xfffffffffffffc00, 0xfffffffffffffe00,
+    0xffffffffffffff00, 0xffffffffffffff80, 0xffffffffffffffc0, 0xffffffffffffffe0,
+    0xfffffffffffffff0, 0xfffffffffffffff8, 0xfffffffffffffffc, 0xfffffffffffffffe,
+    0xffffffffffffffff};
+
+class NullMask {
+
+public:
+    static constexpr uint64_t NO_NULL_ENTRY = 0;
+    static constexpr uint64_t ALL_NULL_ENTRY = ~uint64_t(NO_NULL_ENTRY);
+    static constexpr uint64_t NUM_BITS_PER_NULL_ENTRY_LOG2 = 6;
+    static constexpr uint64_t NUM_BITS_PER_NULL_ENTRY = (uint64_t)1 << NUM_BITS_PER_NULL_ENTRY_LOG2;
+    static constexpr uint64_t NUM_NULL_ENTRIES =
+        DEFAULT_VECTOR_CAPACITY >> NUM_BITS_PER_NULL_ENTRY_LOG2;
+
+    NullMask() : mayContainNulls{false} {
+        buffer = std::make_unique<uint64_t[]>(NUM_NULL_ENTRIES);
+        data = buffer.get();
+        std::fill(data, data + NUM_NULL_ENTRIES, NO_NULL_ENTRY);
+    }
+
+    inline void setAllNonNull() {
+        std::fill(data, data + NUM_NULL_ENTRIES, NO_NULL_ENTRY);
+        mayContainNulls = false;
+    }
+    inline void setAllNull() {
+        std::fill(data, data + NUM_NULL_ENTRIES, ALL_NULL_ENTRY);
+        mayContainNulls = true;
+    }
+
+    void setMayContainNulls();
+    inline bool hasNoNullsGuarantee() const { return !mayContainNulls; }
+
+    void setNull(uint32_t pos, bool isNull);
+
+    static bool isNull(const uint64_t* nullEntries, uint32_t pos) {
+        auto entryPos = pos >> NUM_BITS_PER_NULL_ENTRY_LOG2;
+        auto bitPosInEntry = pos - (entryPos << NUM_BITS_PER_NULL_ENTRY_LOG2);
+        return nullEntries[entryPos] & NULL_BITMASKS_WITH_SINGLE_ONE[bitPosInEntry];
+    }
+
+    inline bool isNull(uint32_t pos) const { return isNull(data, pos); }
+
+    inline uint64_t* getData() { return data; }
+
+private:
+    uint64_t* data;
+    std::unique_ptr<uint64_t[]> buffer;
+    bool mayContainNulls;
+};
+
+} // namespace common
+} // namespace graphflow

--- a/src/common/null_mask.cpp
+++ b/src/common/null_mask.cpp
@@ -1,0 +1,23 @@
+#include "src/common/include/null_mask.h"
+
+namespace graphflow {
+
+namespace common {
+
+void NullMask::setMayContainNulls() {
+    mayContainNulls = true;
+}
+
+void NullMask::setNull(uint32_t pos, bool isNull) {
+    auto entryPos = pos >> NUM_BITS_PER_NULL_ENTRY_LOG2;
+    auto bitPosInEntry = pos - (entryPos << NUM_BITS_PER_NULL_ENTRY_LOG2);
+    if (isNull) {
+        data[entryPos] |= NULL_BITMASKS_WITH_SINGLE_ONE[bitPosInEntry];
+        mayContainNulls = true;
+    } else {
+        data[entryPos] &= NULL_BITMASKS_WITH_SINGLE_ZERO[bitPosInEntry];
+    }
+}
+
+} // namespace common
+} // namespace graphflow

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -1,16 +1,10 @@
 #include "src/common/include/vector/value_vector.h"
 
 #include "src/common/include/overflow_buffer_utils.h"
-#include "src/common/include/type_utils.h"
 #include "src/common/types/include/value.h"
 
 namespace graphflow {
 namespace common {
-
-NullMask::NullMask() : mayContainNulls{false} {
-    mask = make_unique<bool[]>(DEFAULT_VECTOR_CAPACITY);
-    fill_n(mask.get(), DEFAULT_VECTOR_CAPACITY, false /* not null */);
-}
 
 ValueVector::ValueVector(MemoryManager* memoryManager, DataType dataType)
     : dataType{move(dataType)} {

--- a/src/function/string/operations/include/concat_operation.h
+++ b/src/function/string/operations/include/concat_operation.h
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <cstring>
 
+#include "src/common/include/vector/value_vector.h"
 #include "src/common/types/include/gf_string.h"
 
 using namespace std;

--- a/src/loader/in_mem_structure/builder/in_mem_rel_builder.cpp
+++ b/src/loader/in_mem_structure/builder/in_mem_rel_builder.cpp
@@ -538,10 +538,10 @@ static void copyStringOverflowFromUnorderedToOrderedPages(gf_string_t* gfStr,
 
 static void copyListOverflowFromUnorderedToOrderedPages(gf_list_t* gfList, const DataType& dataType,
     PageByteCursor& unorderedOverflowCursor, PageByteCursor& orderedOverflowCursor,
-    InMemOverflowFile* unorderedOverflowPages, InMemOverflowFile* orderedOverflowPages) {
+    InMemOverflowFile* unorderedOverflowFile, InMemOverflowFile* orderedOverflowFile) {
     TypeUtils::decodeOverflowPtr(
         gfList->overflowPtr, unorderedOverflowCursor.pageIdx, unorderedOverflowCursor.offsetInPage);
-    orderedOverflowPages->copyListOverflow(unorderedOverflowPages, unorderedOverflowCursor,
+    orderedOverflowFile->copyListOverflow(unorderedOverflowFile, unorderedOverflowCursor,
         orderedOverflowCursor, gfList, dataType.childType.get());
 }
 

--- a/src/loader/in_mem_structure/builder/in_mem_structures_builder.cpp
+++ b/src/loader/in_mem_structure/builder/in_mem_structures_builder.cpp
@@ -88,7 +88,7 @@ void InMemStructuresBuilder::calculateListHeadersTask(node_offset_t numNodes, ui
     atomic_uint64_vec_t* listSizes, ListHeaders* listHeaders,
     const shared_ptr<spdlog::logger>& logger, LoaderProgressBar* progressBar) {
     logger->trace("Start: ListHeaders={0:p}", (void*)listHeaders);
-    auto numElementsPerPage = PageUtils::getNumElementsInAPageWithoutNULLBytes(elementSize);
+    auto numElementsPerPage = PageUtils::getNumElementsInAPage(elementSize, false /* hasNull */);
     auto numChunks = numNodes >> StorageConfig::LISTS_CHUNK_SIZE_LOG_2;
     if (0 != (numNodes & (StorageConfig::LISTS_CHUNK_SIZE - 1))) {
         numChunks++;
@@ -140,8 +140,7 @@ void InMemStructuresBuilder::calculateListsMetadataTask(uint64_t numNodes, uint3
     listsMetadata->initLargeListPageLists(largeListIdx);
     nodeOffset = 0u;
     largeListIdx = 0u;
-    auto numPerPage = hasNULLBytes ? PageUtils::getNumElementsInAPageWithNULLBytes(elementSize) :
-                                     PageUtils::getNumElementsInAPageWithoutNULLBytes(elementSize);
+    auto numPerPage = PageUtils::getNumElementsInAPage(elementSize, hasNULLBytes);
     for (auto chunkId = 0u; chunkId < numChunks; chunkId++) {
         auto numPages = 0u, offsetInPage = 0u;
         auto lastNodeOffsetInChunk = min(nodeOffset + StorageConfig::LISTS_CHUNK_SIZE, numNodes);

--- a/src/loader/in_mem_structure/in_mem_column.cpp
+++ b/src/loader/in_mem_structure/in_mem_column.cpp
@@ -1,5 +1,6 @@
 #include "src/loader/include/in_mem_structure/in_mem_column.h"
 
+#include <iostream>
 namespace graphflow {
 namespace loader {
 
@@ -7,7 +8,7 @@ InMemColumn::InMemColumn(
     std::string fName, DataType dataType, uint64_t numBytesForElement, uint64_t numElements)
     : fName{move(fName)}, dataType{move(dataType)}, numBytesForElement{numBytesForElement} {
     assert(dataType.typeID != UNSTRUCTURED);
-    numElementsInAPage = PageUtils::getNumElementsInAPageWithNULLBytes(numBytesForElement);
+    numElementsInAPage = PageUtils::getNumElementsInAPage(numBytesForElement, true /* hasNull */);
     auto numPages = ceil((double)numElements / (double)numElementsInAPage);
     inMemFile =
         make_unique<InMemFile>(this->fName, numBytesForElement, true /* hasNULLBytes */, numPages);

--- a/src/loader/in_mem_structure/in_mem_lists.cpp
+++ b/src/loader/in_mem_structure/in_mem_lists.cpp
@@ -7,9 +7,7 @@ PageElementCursor InMemListsUtils::calcPageElementCursor(uint32_t header, uint64
     uint8_t numBytesPerElement, node_offset_t nodeOffset, ListsMetadata& metadata,
     bool hasNULLBytes) {
     PageElementCursor cursor;
-    auto numElementsInAPage =
-        hasNULLBytes ? PageUtils::getNumElementsInAPageWithNULLBytes(numBytesPerElement) :
-                       PageUtils::getNumElementsInAPageWithoutNULLBytes(numBytesPerElement);
+    auto numElementsInAPage = PageUtils::getNumElementsInAPage(numBytesPerElement, hasNULLBytes);
     if (ListHeaders::isALargeList(header)) {
         auto lAdjListIdx = ListHeaders::getLargeListIdx(header);
         auto pos = metadata.getNumElementsInLargeLists(lAdjListIdx) - reversePos;

--- a/src/loader/include/in_mem_structure/in_mem_file.h
+++ b/src/loader/include/in_mem_structure/in_mem_file.h
@@ -32,6 +32,7 @@ protected:
 
 public:
     string filePath;
+    uint16_t numBytesForElement;
     uint64_t numElementsInAPage;
     uint32_t numUsedPages;
     bool hasNullMask;

--- a/src/loader/include/in_mem_structure/in_mem_page.h
+++ b/src/loader/include/in_mem_structure/in_mem_page.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "src/common/include/configs.h"
+#include "src/common/include/null_mask.h"
 #include "src/common/types/include/node_id_t.h"
 #include "src/storage/include/compression_scheme.h"
 
@@ -16,23 +17,22 @@ class InMemPage {
 
 public:
     // Creates an in-memory page with a boolean array to store NULL bits
-    InMemPage(uint32_t maxNumElements, bool hasNULLBytes);
+    InMemPage(uint32_t maxNumElements, uint16_t numBytesForElement, bool hasNullEntries);
 
     uint8_t* write(nodeID_t* nodeID, uint32_t byteOffsetInPage, uint32_t elemPosInPage,
         const NodeIDCompressionScheme& compressionScheme);
     uint8_t* write(uint32_t byteOffsetInPage, uint32_t elemPosInPage, const uint8_t* elem,
         uint32_t numBytesForElem);
 
-    void encodeNullBits();
-
 public:
     uint8_t* data;
 
 private:
-    uint32_t maxNumElements;
+    void setElementAtPosToNonNull(uint32_t pos);
+
     unique_ptr<uint8_t[]> buffer;
-    // Following fields are needed for accommodating storage of NULLs in the page.
-    std::unique_ptr<std::vector<bool>> nullMask;
+    // The pointer to the beginning of null entries in the page.
+    uint64_t* nullEntries;
 };
 
 } // namespace loader

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -33,8 +33,8 @@ shared_ptr<ResultSet> HashJoinBuild::init(ExecutionContext* context) {
         auto vector = dataChunk->valueVectors[vectorPos];
         auto isVectorFlat = buildDataInfo.isNonKeyDataFlat[i];
         tableSchema.appendColumn({!isVectorFlat, dataChunkPos,
-            (isVectorFlat ? Types::getDataTypeSize(vector->dataType) :
-                            (uint32_t)sizeof(overflow_value_t))});
+            isVectorFlat ? Types::getDataTypeSize(vector->dataType) :
+                           (uint32_t)sizeof(overflow_value_t)});
         vectorsToAppend.push_back(vector);
         sharedState->appendNonKeyDataPosesDataTypes(vector->dataType);
     }

--- a/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
@@ -49,7 +49,7 @@ bool AdjColumnExtend::discardNullNodesInVector(ValueVector& valueVector) {
         } else {
             for (auto i = 0u; i < valueVector.state->selectedSize; i++) {
                 auto pos = valueVector.state->selectedPositions[i];
-                valueVector.state->selectedPositions[selectedPos] = i;
+                valueVector.state->selectedPositions[selectedPos] = pos;
                 selectedPos += !valueVector.isNull(pos);
             }
         }

--- a/src/storage/BUILD.bazel
+++ b/src/storage/BUILD.bazel
@@ -19,7 +19,6 @@ cc_library(
     ],
 )
 
-
 cc_library(
     name = "buffer_manager",
     srcs = [
@@ -68,13 +67,13 @@ cc_library(
 
 cc_library(
     name = "storage_structure_utils",
-    srcs = [    ],
+    srcs = [],
     hdrs = [
         "include/storage_structure_utils.h",
     ],
     deps = [
         "buffer_manager",
-        "file_handle"
+        "file_handle",
     ],
 )
 
@@ -90,8 +89,9 @@ cc_library(
         "wal_record",
         "//src/catalog:catalog_structs",
         "//src/common:configs",
-        "//src/common/types:types",
+        "//src/common:null_mask",
         "//src/common:utils",
+        "//src/common/types",
     ],
 )
 
@@ -112,9 +112,9 @@ cc_library(
         "storage_structure_utils",
         "storage_utils",
         "wal",
-                "//src/transaction",
         "//src/common:profiler",
         "//src/common:vector",
+        "//src/transaction",
     ],
 )
 
@@ -152,7 +152,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "storage_structure",
-        "//src/catalog:catalog",
+        "//src/catalog",
     ],
 )
 
@@ -175,7 +175,7 @@ cc_library(
         "column",
         "hash_index",
         "lists",
-        "//src/catalog:catalog",
+        "//src/catalog",
     ],
 )
 
@@ -183,10 +183,10 @@ cc_library(
     name = "wal_record",
     srcs = [
         "wal/wal_record.cpp",
-        ],
+    ],
     hdrs = [
         "include/wal/wal_record.h",
-        ],
+    ],
     visibility = [
         "//visibility:public",
     ],
@@ -200,10 +200,10 @@ cc_library(
     name = "wal",
     srcs = [
         "wal/wal.cpp",
-        ],
+    ],
     hdrs = [
         "include/wal/wal.h",
-        ],
+    ],
     visibility = [
         "//visibility:public",
     ],

--- a/src/storage/include/storage_structure/storage_structure.h
+++ b/src/storage/include/storage_structure/storage_structure.h
@@ -83,7 +83,7 @@ public:
 
 protected:
     BaseColumnOrList(const StorageStructureIDAndFName& storageStructureIDAndFName,
-        const DataType& dataType, const size_t& elementSize, BufferManager& bufferManager,
+        DataType dataType, const size_t& elementSize, BufferManager& bufferManager,
         bool hasNULLBytes, bool isInMemory, WAL* wal);
 
     BaseColumnOrList(const string& fName, const DataType& dataType, const size_t& elementSize,
@@ -122,18 +122,14 @@ protected:
         uint64_t vectorStartPos, page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
         uint64_t numValuesToRead, NodeIDCompressionScheme& compressionScheme, bool isAdjLists);
 
-    static void setNULLBitsForAPos(const shared_ptr<ValueVector>& valueVector, uint8_t* frame,
-        uint64_t elementPos, uint64_t offsetInVector);
+    void readSingleNullBit(const shared_ptr<ValueVector>& valueVector, const uint8_t* frame,
+        uint64_t elementPos, uint64_t offsetInVector) const;
 
-    static void setNullBitOfAPosInFrame(uint8_t* frame, uint16_t elementPos, bool isNull);
-
-    static inline bool isNullFromNULLByte(uint8_t NULLByte, uint8_t byteLevelPos) {
-        return (NULLByte & bitMasksWithSingle1s[byteLevelPos]) > 0;
-    }
+    void setNullBitOfAPosInFrame(uint8_t* frame, uint16_t elementPos, bool isNull) const;
 
 private:
     uint64_t getNumValuesToSkipInSequentialCopy(
-        uint64_t numValuesTryToSkip, uint64_t numValuesInFirstPage);
+        uint64_t numValuesTryToSkip, uint64_t numValuesInFirstPage) const;
 
     void readAPageBySequentialCopy(Transaction* transaction, const shared_ptr<ValueVector>& vector,
         uint64_t vectorStartPos, page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
@@ -149,12 +145,8 @@ private:
         uint64_t vectorPosOfFirstUnselElement, uint64_t vectorPosOfLastUnselElement,
         NodeIDCompressionScheme& compressionScheme);
 
-    static void setNULLBitsForRange(const shared_ptr<ValueVector>& valueVector, uint8_t* frame,
-        uint64_t posInPage, uint64_t posInVector, uint64_t num);
-
-    static void setNULLBitsFromANULLByte(const shared_ptr<ValueVector>& valueVector,
-        pair<uint8_t, uint8_t> NULLByteAndByteLevelStartOffset, uint8_t num,
-        uint64_t offsetInVector);
+    void readNullBitsFromAPage(const shared_ptr<ValueVector>& valueVector, const uint8_t* frame,
+        uint64_t posInPage, uint64_t posInVector, uint64_t numBitsToRead) const;
 
 public:
     DataType dataType;


### PR DESCRIPTION
**Changes**:
This PR reworks null bits in the storage and query processor: Null bits are organized as uint64_t entries both in the physical storage and `NullMask` (used by `ValueVector`), and each entry consists of 64 bits, one bit for each element.
In physical pages, null entries are placed directly after element values.

This change is to optimize the scan of null bits from pages to ValueVector's `NullMask`, instead of setting one element at a time, when the scan is sequential, we can align and set the whole null entry one at a time.

**Bug fixes**:
This PR also fixes a bug of incorrectly setting `selectedPositions` when discarding nulls in `AdjColumnExtend`.