### PR TITLE
fix aggregation bug on ldbc

### DIFF
--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -63,7 +63,7 @@ public:
 
     inline uint8_t isNull(uint32_t pos) const { return nullMask->mask[pos]; }
 
-    inline uint64_t getNumBytesPerValue() const { return Types::getDataTypeSize(dataType); }
+    inline uint32_t getNumBytesPerValue() const { return Types::getDataTypeSize(dataType); }
 
     inline node_offset_t readNodeOffset(uint64_t pos) const {
         assert(dataType.typeID == NODE_ID);

--- a/src/common/types/include/types.h
+++ b/src/common/types/include/types.h
@@ -100,13 +100,15 @@ private:
 
 class Types {
 public:
-    static size_t getDataTypeSize(const DataType& dataType);
-    static size_t getDataTypeSize(DataTypeID dataTypeID);
     static string dataTypeToString(const DataType& dataType);
     static string dataTypeToString(DataTypeID dataTypeID);
     static string dataTypesToString(const vector<DataType>& dataTypes);
     static string dataTypesToString(const vector<DataTypeID>& dataTypeIDs);
     static DataType dataTypeFromString(const string& dataTypeString);
+    static uint32_t getDataTypeSize(DataTypeID dataTypeID);
+    static inline uint32_t getDataTypeSize(const DataType& dataType) {
+        return getDataTypeSize(dataType.typeID);
+    }
 
 private:
     static DataTypeID dataTypeIDFromString(const string& dataTypeIDString);

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -145,7 +145,7 @@ string Types::dataTypesToString(const vector<DataTypeID>& dataTypeIDs) {
     return result;
 }
 
-size_t Types::getDataTypeSize(DataTypeID dataTypeID) {
+uint32_t Types::getDataTypeSize(DataTypeID dataTypeID) {
     switch (dataTypeID) {
     case LABEL:
         return sizeof(label_t);
@@ -173,10 +173,6 @@ size_t Types::getDataTypeSize(DataTypeID dataTypeID) {
         throw Exception(
             "Cannot infer the size of dataTypeID: " + dataTypeToString(dataTypeID) + ".");
     }
-}
-
-size_t Types::getDataTypeSize(const DataType& dataType) {
-    return getDataTypeSize(dataType.typeID);
 }
 
 RelDirection operator!(RelDirection& direction) {

--- a/src/function/aggregate/include/aggregate_function.h
+++ b/src/function/aggregate/include/aggregate_function.h
@@ -25,7 +25,7 @@ struct AggregateFunctionDefinition : public FunctionDefinition {
 };
 
 struct AggregateState {
-    virtual inline uint64_t getStateSize() const = 0;
+    virtual inline uint32_t getStateSize() const = 0;
     virtual uint8_t* getResult() const = 0;
     virtual ~AggregateState() = default;
 
@@ -51,7 +51,7 @@ public:
         initialNullAggregateState = createInitialNullAggregateState();
     }
 
-    inline uint64_t getAggregateStateSize() { return initialNullAggregateState->getStateSize(); }
+    inline uint32_t getAggregateStateSize() { return initialNullAggregateState->getStateSize(); }
 
     inline AggregateState* getInitialNullAggregateState() {
         return initialNullAggregateState.get();

--- a/src/function/aggregate/include/avg.h
+++ b/src/function/aggregate/include/avg.h
@@ -14,7 +14,7 @@ template<typename T>
 struct AvgFunction {
 
     struct AvgState : public AggregateState {
-        inline uint64_t getStateSize() const override { return sizeof(*this); }
+        inline uint32_t getStateSize() const override { return sizeof(*this); }
         inline uint8_t* getResult() const override { return (uint8_t*)&avg; }
 
         T sum;

--- a/src/function/aggregate/include/base_count.h
+++ b/src/function/aggregate/include/base_count.h
@@ -8,7 +8,7 @@ namespace function {
 struct BaseCountFunction {
 
     struct CountState : public AggregateState {
-        inline uint64_t getStateSize() const override { return sizeof(*this); }
+        inline uint32_t getStateSize() const override { return sizeof(*this); }
         inline uint8_t* getResult() const override { return (uint8_t*)&count; }
 
         uint64_t count = 0;

--- a/src/function/aggregate/include/min_max.h
+++ b/src/function/aggregate/include/min_max.h
@@ -13,7 +13,7 @@ template<typename T>
 struct MinMaxFunction {
 
     struct MinMaxState : public AggregateState {
-        inline uint64_t getStateSize() const override { return sizeof(*this); }
+        inline uint32_t getStateSize() const override { return sizeof(*this); }
         inline uint8_t* getResult() const override { return (uint8_t*)&val; }
 
         T val;

--- a/src/function/aggregate/include/sum.h
+++ b/src/function/aggregate/include/sum.h
@@ -13,7 +13,7 @@ template<typename T>
 struct SumFunction {
 
     struct SumState : public AggregateState {
-        inline uint64_t getStateSize() const override { return sizeof(*this); }
+        inline uint32_t getStateSize() const override { return sizeof(*this); }
         inline uint8_t* getResult() const override { return (uint8_t*)&sum; }
 
         T sum;

--- a/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
@@ -133,7 +133,7 @@ private:
     HashSlot* getHashSlot(uint64_t slotIdx) {
         assert(slotIdx < maxNumHashSlots);
         return (HashSlot*)(hashSlotsBlocks[slotIdx / numHashSlotsPerBlock]->getData() +
-                           slotIdx % numHashSlotsPerBlock * sizeof(uint8_t*));
+                           slotIdx % numHashSlotsPerBlock * sizeof(HashSlot));
     }
 
     void addDataBlocksIfNecessary(uint64_t maxNumHashSlots);

--- a/src/processor/include/physical_plan/result/factorized_table.h
+++ b/src/processor/include/physical_plan/result/factorized_table.h
@@ -36,6 +36,8 @@ public:
 
     uint8_t* getData() const { return block->data; }
 
+    void resetToZero() { memset(block->data, 0, LARGE_PAGE_SIZE); }
+
 public:
     uint64_t freeSize;
     uint32_t numTuples;

--- a/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
+++ b/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
@@ -318,6 +318,9 @@ void AggregateHashTable::resize(uint64_t newSize) {
     maxNumHashSlots = newSize;
     bitMask = maxNumHashSlots - 1;
     addDataBlocksIfNecessary(maxNumHashSlots);
+    for (auto& block : hashSlotsBlocks) {
+        block->resetToZero();
+    }
     for (auto& tupleBlock : factorizedTable->getTupleDataBlocks()) {
         uint8_t* tuple = tupleBlock->getData();
         for (auto i = 0u; i < tupleBlock->numTuples; i++) {

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -33,7 +33,8 @@ shared_ptr<ResultSet> HashJoinBuild::init(ExecutionContext* context) {
         auto vector = dataChunk->valueVectors[vectorPos];
         auto isVectorFlat = buildDataInfo.isNonKeyDataFlat[i];
         tableSchema.appendColumn({!isVectorFlat, dataChunkPos,
-            isVectorFlat ? Types::getDataTypeSize(vector->dataType) : sizeof(overflow_value_t)});
+            (isVectorFlat ? Types::getDataTypeSize(vector->dataType) :
+                            (uint32_t)sizeof(overflow_value_t))});
         vectorsToAppend.push_back(vector);
         sharedState->appendNonKeyDataPosesDataTypes(vector->dataType);
     }

--- a/src/processor/physical_plan/operator/order_by/order_by.cpp
+++ b/src/processor/physical_plan/operator/order_by/order_by.cpp
@@ -27,8 +27,7 @@ shared_ptr<ResultSet> OrderBy::init(ExecutionContext* context) {
         }
         bool isUnflat = !orderByDataInfo.isVectorFlat[i] && !flattenAllColumnsInFactorizedTable;
         tableSchema.appendColumn({isUnflat, dataChunkPos,
-            isUnflat ? (uint32_t)sizeof(overflow_value_t) :
-                       (uint32_t)vector->getNumBytesPerValue()});
+            isUnflat ? (uint32_t)sizeof(overflow_value_t) : vector->getNumBytesPerValue()});
         dataTypes.push_back(vector->dataType);
         vectorsToAppend.push_back(vector);
     }

--- a/src/processor/physical_plan/operator/result_collector.cpp
+++ b/src/processor/physical_plan/operator/result_collector.cpp
@@ -29,7 +29,8 @@ shared_ptr<ResultSet> ResultCollector::init(ExecutionContext* context) {
             resultSet->dataChunks[dataPos.dataChunkPos]->valueVectors[dataPos.valueVectorPos];
         vectorsToCollect.push_back(vector);
         tableSchema.appendColumn({!vectorToCollectInfo.second, dataPos.dataChunkPos,
-            vectorToCollectInfo.second ? vector->getNumBytesPerValue() : sizeof(overflow_value_t)});
+            vectorToCollectInfo.second ? vector->getNumBytesPerValue() :
+                                         (uint32_t)sizeof(overflow_value_t)});
     }
     localTable = make_unique<FactorizedTable>(context->memoryManager, tableSchema);
     sharedState->initTableIfNecessary(context->memoryManager, tableSchema);

--- a/test/processor/physical_plan/operator/orderBy/key_block_merger_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/key_block_merger_test.cpp
@@ -68,8 +68,8 @@ public:
             valueVector}; // all columns including orderBy and payload columns
 
         TableSchema tableSchema;
-        tableSchema.appendColumn({false /* isUnflat */, 0 /* dataChunkPos */,
-            (uint32_t)Types::getDataTypeSize(dataTypeID)});
+        tableSchema.appendColumn(
+            {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(dataTypeID)});
 
         if (hasPayLoadCol) {
             auto payloadValueVector = make_shared<ValueVector>(memoryManager.get(), STRING);
@@ -81,7 +81,7 @@ public:
             // payload column at index 0, and the orderByCol at index 1.
             allVectors.insert(allVectors.begin(), payloadValueVector);
             tableSchema.appendColumn(
-                {false, 0 /* dataChunkPos */, (uint32_t)Types::getDataTypeSize(dataTypeID)});
+                {false, 0 /* dataChunkPos */, Types::getDataTypeSize(dataTypeID)});
         }
 
         auto factorizedTable = make_unique<FactorizedTable>(memoryManager.get(), tableSchema);
@@ -210,15 +210,14 @@ public:
         prepareMultipleOrderByColsValueVector(
             int64Values2, doubleValues2, timestampValues2, dataChunk2);
 
-        TableSchema tableSchema({{false /* isUnflat */, 0 /* dataChunkPos */,
-                                     (uint32_t)Types::getDataTypeSize(INT64)},
-            {false /* isUnflat */, 0 /* dataChunkPos */, (uint32_t)Types::getDataTypeSize(DOUBLE)},
-            {false /* isUnflat */, 0 /* dataChunkPos */,
-                (uint32_t)Types::getDataTypeSize(TIMESTAMP)}});
+        TableSchema tableSchema(
+            {{false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(INT64)},
+                {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(DOUBLE)},
+                {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(TIMESTAMP)}});
 
         if (hasStrCol) {
-            tableSchema.appendColumn({false /* isUnflat */, 0 /* dataChunkPos */,
-                (uint32_t)Types::getDataTypeSize(STRING)});
+            tableSchema.appendColumn(
+                {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(STRING)});
             auto stringValueVector1 = make_shared<ValueVector>(memoryManager.get(), STRING);
             auto stringValueVector2 = make_shared<ValueVector>(memoryManager.get(), STRING);
             dataChunk1->insert(3, stringValueVector1);

--- a/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
@@ -82,8 +82,8 @@ public:
         vector<bool> isAscOrder{isAsc};
 
         TableSchema tupleSchema;
-        tupleSchema.appendColumn({false /* isUnflat */, 0 /* dataChunkPos */,
-            (uint32_t)Types::getDataTypeSize(dataTypeID)});
+        tupleSchema.appendColumn(
+            {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(dataTypeID)});
         vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo;
 
         if (hasPayLoadCol) {
@@ -96,8 +96,8 @@ public:
             // To test whether the orderByCol -> ftIdx works properly, we put the
             // payload column at index 0, and the orderByCol at index 1.
             allVectors.insert(allVectors.begin(), payloadValueVector);
-            tupleSchema.appendColumn({false /* isUnflat */, 0 /* dataChunkPos */,
-                (uint32_t)Types::getDataTypeSize(dataTypeID)});
+            tupleSchema.appendColumn(
+                {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(dataTypeID)});
             stringAndUnstructuredKeyColInfo.emplace_back(StringAndUnstructuredKeyColInfo(
                 tupleSchema.getColOffset(1) /* colOffsetInFT */, 0 /* colOffsetInEncodedKeyBlock */,
                 isAsc, is_same<T, string>::value /* isStrCol */));
@@ -422,12 +422,12 @@ TEST_F(RadixSortTest, multipleOrderByColNoTieTest) {
     dateValues[3] = Date::FromCString("1964-01-21", strlen("1964-01-21"));
     dateValues[4] = Date::FromCString("2000-11-13", strlen("2000-11-13"));
 
-    TableSchema tableSchema({{false /* isUnflat */, 0 /* dataChunkPos */,
-                                 (uint32_t)Types::getDataTypeSize(INT64)},
-        {false /* isUnflat */, 0 /* dataChunkPos */, (uint32_t)Types::getDataTypeSize(DOUBLE)},
-        {false /* isUnflat */, 0 /* dataChunkPos */, (uint32_t)Types::getDataTypeSize(STRING)},
-        {false /* isUnflat */, 0 /* dataChunkPos */, (uint32_t)Types::getDataTypeSize(TIMESTAMP)},
-        {false /* isUnflat */, 0 /* dataChunkPos */, (uint32_t)Types::getDataTypeSize(DATE)}});
+    TableSchema tableSchema(
+        {{false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(INT64)},
+            {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(DOUBLE)},
+            {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(STRING)},
+            {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(TIMESTAMP)},
+            {false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(DATE)}});
     FactorizedTable factorizedTable(memoryManager.get(), tableSchema);
     vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo = {
         StringAndUnstructuredKeyColInfo(16 /* colOffsetInFT */,


### PR DESCRIPTION
This PR fixes a bug in the aggregation:
1. HashSlots stores a list of HashSlots. We should use sizeof(HashSlot) as the size of each entry rather than sizeof(uint8_t*).
2. We don't reset old hashslots to 0 when we resize the hashslots.
3. The data type of variable `columnSize` of factorizedTable has changed from `uint64_t`->`uint32_t`. When constructing this field, we should do an explicit casting.