### PR TITLE
Scan filter rework

### DIFF
--- a/src/binder/expression/include/property_expression.h
+++ b/src/binder/expression/include/property_expression.h
@@ -24,7 +24,5 @@ private:
     uint32_t propertyKey;
 };
 
-using property_vector = vector<shared_ptr<PropertyExpression>>;
-
 } // namespace binder
 } // namespace graphflow

--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -61,26 +61,28 @@ private:
 
     void appendFilter(const shared_ptr<Expression>& expression, LogicalPlan& plan);
 
-    void appendScanNodeProperty(const NodeExpression& node, LogicalPlan& plan);
+    // switch structured and unstructured node property scan
+    void appendScanNodePropIfNecessarySwitch(
+        expression_vector& properties, NodeExpression& node, LogicalPlan& plan);
+    void appendScanNodePropIfNecessary(
+        expression_vector& properties, NodeExpression& node, LogicalPlan& plan, bool isStructured);
 
-    void appendScanNodeProperty(
-        const property_vector& properties, const NodeExpression& node, LogicalPlan& plan);
-
-    void appendScanRelProperty(const RelExpression& rel, LogicalPlan& plan);
-
-    void appendScanRelProperty(const shared_ptr<PropertyExpression>& property,
-        const RelExpression& rel, LogicalPlan& plan);
+    inline void appendScanRelPropsIfNecessary(
+        expression_vector& properties, RelExpression& rel, LogicalPlan& plan) {
+        for (auto& property : properties) {
+            appendScanRelPropIfNecessary(property, rel, plan);
+        }
+    }
+    void appendScanRelPropIfNecessary(
+        shared_ptr<Expression>& expression, RelExpression& rel, LogicalPlan& plan);
 
     unique_ptr<LogicalPlan> createUnionPlan(
         vector<unique_ptr<LogicalPlan>>& childrenPlans, bool isUnionAll);
 
     static vector<unique_ptr<LogicalPlan>> getInitialEmptyPlans();
 
-    static property_vector getPropertiesForNode(
-        const property_vector& propertiesToScan, const NodeExpression& node, bool isStructured);
-
-    static property_vector getPropertiesForRel(
-        const property_vector& propertiesToScan, const RelExpression& rel);
+    expression_vector getPropertiesForNode(NodeExpression& node);
+    expression_vector getPropertiesForRel(RelExpression& rel);
 
     static unordered_set<uint32_t> getDependentGroupsPos(
         const shared_ptr<Expression>& expression, const Schema& schema);
@@ -111,7 +113,7 @@ private:
         vector<vector<unique_ptr<LogicalPlan>>> childrenLogicalPlans);
 
 private:
-    property_vector propertiesToScan;
+    expression_vector propertiesToScan;
     JoinOrderEnumerator joinOrderEnumerator;
     ProjectionEnumerator projectionEnumerator;
 };

--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -36,17 +36,27 @@ private:
     unique_ptr<JoinOrderEnumeratorContext> enterSubquery(expression_vector expressionsToScan);
     void exitSubquery(unique_ptr<JoinOrderEnumeratorContext> prevContext);
 
-    // join order enumeration functions
-    void enumerateResultScan();
-    void enumerateSingleNode();
-    void enumerateHashJoin();
-    void enumerateSingleRel();
+    void planResultScan();
+
+    void planNodeScan();
+    void planFiltersAfterNodeScan(
+        expression_vector& predicates, NodeExpression& node, LogicalPlan& plan);
+    void planPropertyScansAfterNodeScan(NodeExpression& node, LogicalPlan& plan);
+
+    void planExtend();
+    void planExtendFiltersAndScanProperties(RelExpression& queryRel, RelDirection direction,
+        expression_vector& predicates, LogicalPlan& plan);
+    void planFilterAfterExtend(expression_vector& predicates, RelExpression& rel,
+        NodeExpression& nbrNode, LogicalPlan& plan);
+    void planPropertyScansAfterExtend(
+        RelExpression& rel, NodeExpression& nbrNode, LogicalPlan& plan);
+
+    void planHashJoin();
 
     // append logical operator functions
     void appendResultScan(const expression_vector& expressionsToSelect, LogicalPlan& plan);
     void appendScanNodeID(NodeExpression& queryNode, LogicalPlan& plan);
-    void appendExtendFiltersAndScanProperties(const RelExpression& queryRel, RelDirection direction,
-        const expression_vector& expressionsToFilter, LogicalPlan& plan);
+
     void appendExtend(const RelExpression& queryRel, RelDirection direction, LogicalPlan& plan);
     void appendLogicalHashJoin(
         const NodeExpression& joinNode, LogicalPlan& probePlan, LogicalPlan& buildPlan);
@@ -54,6 +64,7 @@ private:
     bool appendIntersect(const string& leftNodeID, const string& rightNodeID, LogicalPlan& plan);
 
     // helper functions
+    expression_vector getPropertiesForVariable(Expression& expression, Expression& variable);
     uint64_t getExtensionRate(label_t boundNodeLabel, label_t relLabel, RelDirection relDirection);
 
 private:

--- a/src/storage/storage_structure/include/storage_structure.h
+++ b/src/storage/storage_structure/include/storage_structure.h
@@ -128,22 +128,9 @@ protected:
     void setNullBitOfAPosInFrame(uint8_t* frame, uint16_t elementPos, bool isNull) const;
 
 private:
-    uint64_t getNumValuesToSkipInSequentialCopy(
-        uint64_t numValuesTryToSkip, uint64_t numValuesInFirstPage) const;
-
     void readAPageBySequentialCopy(Transaction* transaction, const shared_ptr<ValueVector>& vector,
         uint64_t vectorStartPos, page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
         uint64_t numValuesToRead);
-
-    void readAPageBySequentialCopyWithSelState(Transaction* transaction,
-        const shared_ptr<ValueVector>& vector, uint64_t& nextSelectedPos,
-        page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
-        uint64_t vectorPosOfFirstUnselElement, uint64_t vectorPosOfLastUnselElement);
-
-    void readNodeIDsFromAPageBySequentialCopyWithSelState(const shared_ptr<ValueVector>& vector,
-        uint64_t& nextSelectedPos, page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
-        uint64_t vectorPosOfFirstUnselElement, uint64_t vectorPosOfLastUnselElement,
-        NodeIDCompressionScheme& compressionScheme);
 
     void readNullBitsFromAPage(const shared_ptr<ValueVector>& valueVector, const uint8_t* frame,
         uint64_t posInPage, uint64_t posInVector, uint64_t numBitsToRead) const;


### PR DESCRIPTION
This PR

- add filter push down. We used to scan all properties blindly and then apply filters. We now apply filters first and then scan leftover properties
- remove random element scan within a single page. For sequential scan with selected state, if a page contains at least one element, we scan the full page.