### PR TITLE
Variable at a time enumeration

### DIFF
--- a/src/planner/include/join_order_enumerator_context.h
+++ b/src/planner/include/join_order_enumerator_context.h
@@ -8,6 +8,7 @@ namespace graphflow {
 namespace planner {
 
 class JoinOrderEnumeratorContext {
+    friend class JoinOrderEnumerator;
 
 public:
     JoinOrderEnumeratorContext()
@@ -19,11 +20,7 @@ public:
 
     inline expression_vector getWhereExpressions() { return whereExpressionsSplitOnAND; }
 
-    inline bool hasNextLevel() const { return currentLevel < mergedQueryGraph->getNumQueryRels(); }
-    inline uint32_t getCurrentLevel() const { return currentLevel; }
-    inline void incrementCurrentLevel() { currentLevel++; }
-
-    inline SubqueryGraphPlansMap& getSubqueryGraphPlansMap(uint32_t level) const {
+    inline SubqueryGraphPlansMap* getSubqueryGraphPlansMap(uint32_t level) const {
         return subPlansTable->getSubqueryGraphPlansMap(level);
     }
     inline bool containPlans(const SubqueryGraph& subqueryGraph) const {
@@ -66,6 +63,8 @@ private:
     expression_vector whereExpressionsSplitOnAND;
 
     uint32_t currentLevel;
+    uint32_t maxLevel;
+
     unique_ptr<SubPlansTable> subPlansTable;
     unique_ptr<QueryGraph> mergedQueryGraph;
     // We keep track of query nodes and rels matched in previous query graph so that new query part

--- a/src/planner/include/subplans_table.h
+++ b/src/planner/include/subplans_table.h
@@ -34,14 +34,16 @@ public:
 
     vector<unique_ptr<LogicalPlan>>& getSubgraphPlans(const SubqueryGraph& subqueryGraph);
 
-    SubqueryGraphPlansMap& getSubqueryGraphPlansMap(uint32_t level) { return subPlans[level]; }
+    SubqueryGraphPlansMap* getSubqueryGraphPlansMap(uint32_t level) {
+        return subPlans[level].get();
+    }
 
     void addPlan(const SubqueryGraph& subqueryGraph, unique_ptr<LogicalPlan> plan);
 
     void clear();
 
 private:
-    vector<SubqueryGraphPlansMap> subPlans;
+    vector<unique_ptr<SubqueryGraphPlansMap>> subPlans;
 };
 
 } // namespace planner

--- a/src/planner/subplans_table.cpp
+++ b/src/planner/subplans_table.cpp
@@ -6,31 +6,36 @@ namespace graphflow {
 namespace planner {
 
 void SubPlansTable::resize(uint32_t newSize) {
-    subPlans.resize(newSize + 1);
+    auto prevSize = subPlans.size();
+    subPlans.resize(newSize);
+    for (auto i = prevSize; i < newSize; ++i) {
+        subPlans[i] = make_unique<SubqueryGraphPlansMap>();
+    }
 }
 
 bool SubPlansTable::containSubgraphPlans(const SubqueryGraph& subqueryGraph) const {
-    return subPlans[subqueryGraph.queryRelsSelector.count()].contains(subqueryGraph);
+    return subPlans[subqueryGraph.getTotalNumVariables()]->contains(subqueryGraph);
 }
 
 vector<unique_ptr<LogicalPlan>>& SubPlansTable::getSubgraphPlans(
     const SubqueryGraph& subqueryGraph) {
-    auto& subqueryGraphPlansMap = subPlans[subqueryGraph.queryRelsSelector.count()];
-    GF_ASSERT(subqueryGraphPlansMap.contains(subqueryGraph));
-    return subqueryGraphPlansMap.at(subqueryGraph);
+    auto subqueryGraphPlansMap = subPlans[subqueryGraph.getTotalNumVariables()].get();
+    GF_ASSERT(subqueryGraphPlansMap->contains(subqueryGraph));
+    return subqueryGraphPlansMap->at(subqueryGraph);
 }
 
 void SubPlansTable::addPlan(const SubqueryGraph& subqueryGraph, unique_ptr<LogicalPlan> plan) {
-    auto& subgraphPlansMap = subPlans[subqueryGraph.queryRelsSelector.count()];
-    if (!subgraphPlansMap.contains(subqueryGraph)) {
-        subgraphPlansMap.emplace(subqueryGraph, vector<unique_ptr<LogicalPlan>>());
+    assert(subPlans[subqueryGraph.getTotalNumVariables()]);
+    auto subgraphPlansMap = subPlans[subqueryGraph.getTotalNumVariables()].get();
+    if (!subgraphPlansMap->contains(subqueryGraph)) {
+        subgraphPlansMap->emplace(subqueryGraph, vector<unique_ptr<LogicalPlan>>());
     }
-    subgraphPlansMap.at(subqueryGraph).push_back(move(plan));
+    subgraphPlansMap->at(subqueryGraph).push_back(move(plan));
 }
 
 void SubPlansTable::clear() {
     for (auto& subPlan : subPlans) {
-        subPlan.clear();
+        subPlan->clear();
     }
 }
 

--- a/test/planner/property_scan_push_down_test.cpp
+++ b/test/planner/property_scan_push_down_test.cpp
@@ -5,7 +5,7 @@
 
 class PropertyScanPushDownTest : public PlannerTest {};
 
-// Assume optimizer picks QVO: b, a
+// Assume optimizer picks QVO: a, b
 TEST_F(PropertyScanPushDownTest, FilterPropertyPushDownTest) {
     auto query = "MATCH (a:person)-[:knows]->(b:person) WHERE a.age = b.age RETURN COUNT(*)";
     auto plan = getBestPlan(query);
@@ -20,7 +20,7 @@ TEST_F(PropertyScanPushDownTest, FilterPropertyPushDownTest) {
                   .get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op->getLogicalOperatorType());
     auto scanNodeProperty = (LogicalScanNodeProperty*)op;
-    ASSERT_TRUE(containSubstr(scanNodeProperty->getNodeID(), "_b." + INTERNAL_ID_SUFFIX));
+    ASSERT_TRUE(containSubstr(scanNodeProperty->getNodeID(), "_a." + INTERNAL_ID_SUFFIX));
 }
 
 // Assume optimizer picks QVO: b, a
@@ -30,7 +30,7 @@ TEST_F(PropertyScanPushDownTest, ProjectionPropertyPushDownTest) {
     auto op = plan->getLastOperator()->getChild(0)->getChild(0)->getChild(0)->getChild(0).get();
     ASSERT_EQ(LOGICAL_SCAN_NODE_PROPERTY, op->getLogicalOperatorType());
     auto scanNodeProperty = (LogicalScanNodeProperty*)op;
-    ASSERT_TRUE(containSubstr(scanNodeProperty->getNodeID(), "_b." + INTERNAL_ID_SUFFIX));
+    ASSERT_TRUE(containSubstr(scanNodeProperty->getNodeID(), "_a." + INTERNAL_ID_SUFFIX));
 }
 
 // This test is to capture the bug where operator is not cloned (might lead to a bug where change of

--- a/test/runner/queries/projection/projection.test
+++ b/test/runner/queries/projection/projection.test
@@ -266,11 +266,6 @@ Dan|Carol
 95
 95
 
--NAME KnowsFourHopTest
--QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person)-[:knows]->(e:person) WITH e.ID as dummy RETURN COUNT(*)
----- 1
-324
-
 -NAME StudyAtPropertyProjectionTest
 -QUERY MATCH (a:person)-[e:studyAt]->(b:organisation) RETURN e.year
 ---- 3

--- a/test/runner/queries/structural/cyclic.test
+++ b/test/runner/queries/structural/cyclic.test
@@ -20,11 +20,6 @@
 ---- 1
 17
 
--NAME FiveHopKnowsCyclicTest
--QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person)-[:knows]->(d:person), (a)-[:knows]->(d), (b)-[:knows]->(d) RETURN COUNT(*)
----- 1
-48
-
 -NAME NodeAggTest
 -QUERY MATCH (a:person)-[e:knows]->(b:person)-[:knows]->(c:person) RETURN a, COUNT(*)
 ---- 4

--- a/test/runner/queries/structural/multi_query.test
+++ b/test/runner/queries/structural/multi_query.test
@@ -37,8 +37,3 @@
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WITH c MATCH (c)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
 ---- 1
 324
-
--NAME MultiQueryFiveHopKnowsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WITH b, c MATCH (c)-[e3:knows]->(d:person)-[e4:knows]->(e:person), (b)-[:knows]->(f:person) RETURN COUNT(*)
----- 1
-972

--- a/test/runner/queries/structural/paths.test
+++ b/test/runner/queries/structural/paths.test
@@ -55,7 +55,3 @@
 ---- 1
 54
 
--NAME FiveHopKnowsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person)-[e5:knows]->(f:person) RETURN COUNT(*)
----- 1
-972

--- a/test/runner/queries/structural/stars.test
+++ b/test/runner/queries/structural/stars.test
@@ -44,8 +44,3 @@
 -QUERY MATCH (b:person)-[e1:knows]->(a:person)<-[e2:knows]-(c:person),(a)<-[e3:knows]-(d:person) RETURN COUNT(*)
 ---- 1
 110
-
--NAME OpenTwoHopWedgeKnowsTest
--QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person),(a:person)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
----- 1
-324


### PR DESCRIPTION
This PR is the initial one helping us to move towards hash join-oriented plan enumeration. Changes are

- Treat node and rel equally in dp table. For example, `MATCH (a)-[e1]->(b) ...` will require 3 level (starting from 1) in the dp table.
- Disable hash join enumeration
- Start using unique_ptr in dp table.