### PR TITLE
add groupByKey columns reorder logic

### DIFF
--- a/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
@@ -9,19 +9,17 @@ using namespace graphflow::function;
 namespace graphflow {
 namespace processor {
 
-constexpr uint16_t HASH_PREFIX_SHIFT = (sizeof(hash_t) - sizeof(uint16_t)) * 8;
-
 struct HashSlot {
-    hash_t hash;    // 16 high bits of the hash value for fast comparison.
-    uint8_t* entry; // pointer to the tuple buffer which stores [hash, groupKey1, ...
-                    // groupKeyN, aggregateState1, ..., aggregateStateN]
+    hash_t hash;    // 8 bytes for hashValues.
+    uint8_t* entry; // pointer to the tuple buffer which stores [groupKey1, ...
+                    // groupKeyN, aggregateState1, ..., aggregateStateN].
 };
 
 /**
  * AggregateHashTable Design
  *
  * 1. Payload
- * Entry layout: [hash, groupKey1, ... groupKeyN, aggregateState1, ..., aggregateStateN]
+ * Entry layout: [groupKey1, ... groupKeyN, aggregateState1, ..., aggregateStateN]
  * Payload is stored in the factorizedTable.
  *
  * 2. Hash slot
@@ -107,7 +105,7 @@ private:
         return getNumBytesForGroupByHashKeys() + getNumBytesForGroupByNonHashKeys();
     }
 
-    void increaseSlotOffset(uint64_t& slotOffset) const;
+    void increaseSlotIdx(uint64_t& slotIdx) const;
 
     void findHashSlots(const vector<ValueVector*>& groupByFlatHashKeyVectors,
         const vector<ValueVector*>& groupByUnFlatHashKeyVectors,

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -93,7 +93,8 @@ private:
     void appendGroupByExpressions(const expression_vector& groupByExpressions,
         vector<DataPos>& inputGroupByHashKeyVectorsPos, vector<DataPos>& outputGroupByKeyVectorsPos,
         vector<DataType>& outputGroupByKeyVectorsDataTypes,
-        MapperContext& mapperContextBeforeAggregate, MapperContext& mapperContext);
+        MapperContext& mapperContextBeforeAggregate, MapperContext& mapperContext, Schema* schema,
+        vector<bool>& isInputGroupByHashKeyVectorFlat);
 
 public:
     const StorageManager& storageManager;

--- a/test/runner/queries/aggregate/hash_aggregate.test
+++ b/test/runner/queries/aggregate/hash_aggregate.test
@@ -49,3 +49,29 @@ good||1
 |excellent|1
 |good|1
 ||2
+
+-NAME OneHopAggFlatUnflatVecTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.ID, b.gender, sum(b.age)
+---- 9
+0|1|45
+0|2|50
+2|1|80
+2|2|20
+3|1|35
+3|2|50
+5|1|80
+5|2|30
+7|2|65
+
+-NAME OneHopAggFlatUnflatVecWithNonHashKeyTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.ID, a.gender, b.gender, sum(b.age)
+---- 9
+0|1|1|45
+0|1|2|50
+2|2|1|80
+2|2|2|20
+3|1|1|35
+3|1|2|50
+5|2|1|80
+5|2|2|30
+7|1|2|65


### PR DESCRIPTION
The flat/unflat groupByKeys PR puts the groupByKeys to factorizedTable in the following order:
GroupByFlatHashKeys, GroupByUnflatHashKeys, GroupByNonHashKeys.
However the input/output groupByKey columns may not necessarily follow this order. The aggregation front end should handle the reorder  logic in aggregation.