### PR TITLE
optimization for aggregation

### DIFF
--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -52,7 +52,7 @@ public:
 
     inline uint8_t isNull(uint32_t pos) const { return nullMask->isNull(pos); }
 
-    inline uint32_t getNumBytesPerValue() const { return Types::getDataTypeSize(dataType); }
+    inline uint32_t getNumBytesPerValue() const { return numBytesPerValue; }
 
     inline node_offset_t readNodeOffset(uint64_t pos) const {
         assert(dataType.typeID == NODE_ID);
@@ -88,6 +88,7 @@ private:
     // This is a shared pointer because sometimes ValueVectors may share NullMasks, e.g., the result
     // ValueVectors of unary expressions, point to the nullMasks of operands.
     shared_ptr<NullMask> nullMask;
+    uint32_t numBytesPerValue;
 };
 
 } // namespace common

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -16,6 +16,7 @@ ValueVector::ValueVector(MemoryManager* memoryManager, DataType dataType)
         overflowBuffer = make_unique<OverflowBuffer>(memoryManager);
     }
     nullMask = make_shared<NullMask>();
+    numBytesPerValue = Types::getDataTypeSize(dataType);
 }
 
 void ValueVector::addString(uint64_t pos, char* value, uint64_t len) const {

--- a/src/function/BUILD.bazel
+++ b/src/function/BUILD.bazel
@@ -19,10 +19,10 @@ cc_library(
     srcs = [],
     hdrs = [
         "include/binary_operation_executor.h",
+        "include/const_operation_executor.h",
         "include/ternary_operation_executor.h",
         "include/unary_operation_executor.h",
         "include/vector_operations.h",
-        "include/const_operation_executor.h",
     ],
     visibility = [
         "//src/binder/expression:__pkg__",

--- a/src/function/aggregate/include/avg.h
+++ b/src/function/aggregate/include/avg.h
@@ -42,12 +42,9 @@ struct AvgFunction {
         }
     }
 
-    static void updatePos(
+    static inline void updatePos(
         uint8_t* state_, ValueVector* input, uint64_t multiplicity, uint32_t pos) {
-        auto state = reinterpret_cast<AvgState*>(state_);
-        if ((!input->state->isFlat() && input->hasNoNullsGuarantee()) || !input->isNull(pos)) {
-            updateSingleValue(state, input, pos, multiplicity);
-        }
+        updateSingleValue(reinterpret_cast<AvgState*>(state_), input, pos, multiplicity);
     }
 
     static void updateSingleValue(

--- a/src/function/aggregate/include/count.h
+++ b/src/function/aggregate/include/count.h
@@ -23,12 +23,9 @@ struct CountFunction : public BaseCountFunction {
         }
     }
 
-    static void updatePos(
+    static inline void updatePos(
         uint8_t* state_, ValueVector* input, uint64_t multiplicity, uint32_t pos) {
-        auto state = reinterpret_cast<CountState*>(state_);
-        if ((!input->state->isFlat() && input->hasNoNullsGuarantee()) || !input->isNull(pos)) {
-            state->count += multiplicity;
-        }
+        reinterpret_cast<CountState*>(state_)->count += multiplicity;
     }
 };
 

--- a/src/function/aggregate/include/min_max.h
+++ b/src/function/aggregate/include/min_max.h
@@ -41,12 +41,9 @@ struct MinMaxFunction {
     }
 
     template<class OP>
-    static void updatePos(
+    static inline void updatePos(
         uint8_t* state_, ValueVector* input, uint64_t multiplicity, uint32_t pos) {
-        auto state = reinterpret_cast<MinMaxState*>(state_);
-        if ((!input->state->isFlat() && input->hasNoNullsGuarantee()) || !input->isNull(pos)) {
-            updateSingleValue<OP>(state, input, pos);
-        }
+        updateSingleValue<OP>(reinterpret_cast<MinMaxState*>(state_), input, pos);
     }
 
     template<class OP>

--- a/src/function/aggregate/include/sum.h
+++ b/src/function/aggregate/include/sum.h
@@ -39,12 +39,10 @@ struct SumFunction {
         }
     }
 
-    static void updatePos(
+    static inline void updatePos(
         uint8_t* state_, ValueVector* input, uint64_t multiplicity, uint32_t pos) {
         auto state = reinterpret_cast<SumState*>(state_);
-        if ((!input->state->isFlat() && input->hasNoNullsGuarantee()) || !input->isNull(pos)) {
-            updateSingleValue(state, input, pos, multiplicity);
-        }
+        updateSingleValue(state, input, pos, multiplicity);
     }
 
     static void updateSingleValue(

--- a/src/function/hash/BUILD.bazel
+++ b/src/function/hash/BUILD.bazel
@@ -1,0 +1,17 @@
+cc_library(
+    name = "vector_hash_operations",
+    srcs = glob([
+        "*.cpp",
+    ]),
+    hdrs = glob([
+        "include/*.h",
+    ]),
+    visibility = [
+        "//src/function:__pkg__",
+        "//src/processor:__pkg__",
+    ],
+    deps = [
+        "//src/function",
+        "//src/function/hash/operations:hash_operations",
+    ],
+)

--- a/src/function/hash/include/vector_hash_operations.h
+++ b/src/function/hash/include/vector_hash_operations.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include "src/common/include/vector/value_vector.h"
+#include "src/function/hash/operations/include/hash_operations.h"
+
+namespace graphflow {
+namespace function {
+
+struct UnaryHashOperationExecutor {
+    template<typename OPERAND_TYPE, typename RESULT_TYPE>
+    static void execute(ValueVector& operand, ValueVector& result) {
+        result.state = operand.state;
+        auto resultValues = (RESULT_TYPE*)result.values;
+        auto operandValues = (OPERAND_TYPE*)operand.values;
+        if (operand.state->isFlat()) {
+            auto pos = operand.state->getPositionOfCurrIdx();
+            if (!operand.isNull(pos)) {
+                operation::Hash::operation(operandValues[pos], resultValues[pos]);
+            } else {
+                resultValues[pos] = operation::NULL_HASH;
+            }
+        } else {
+            if (operand.hasNoNullsGuarantee()) {
+                if (operand.state->isUnfiltered()) {
+                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                        operation::Hash::operation(operandValues[i], resultValues[i]);
+                    }
+                } else {
+                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                        auto pos = operand.state->selectedPositions[i];
+                        operation::Hash::operation(operandValues[pos], resultValues[pos]);
+                    }
+                }
+            } else {
+                if (operand.state->isUnfiltered()) {
+                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                        if (!operand.isNull(i)) {
+                            operation::Hash::operation(operandValues[i], resultValues[i]);
+                        } else {
+                            resultValues[i] = operation::NULL_HASH;
+                        }
+                    }
+                } else {
+                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                        auto pos = operand.state->selectedPositions[i];
+                        if (!operand.isNull(pos)) {
+                            operation::Hash::operation(operandValues[pos], resultValues[pos]);
+                        } else {
+                            resultValues[pos] = operation::NULL_HASH;
+                        }
+                    }
+                }
+            }
+        }
+    }
+};
+
+struct VectorHashOperations {
+    static void computeHash(ValueVector* operand, ValueVector* result);
+
+    static void combineHash(ValueVector* left, ValueVector* right, ValueVector* result);
+};
+
+} // namespace function
+} // namespace graphflow

--- a/src/function/hash/operations/BUILD.bazel
+++ b/src/function/hash/operations/BUILD.bazel
@@ -7,6 +7,7 @@ cc_library(
         "include/*.h",
     ]),
     visibility = [
+        "//src/function/hash:__subpackages__",
         "//src/processor:__pkg__",
         "//src/storage:__pkg__",
         "//src/storage/index:__pkg__",

--- a/src/function/hash/vector_hash_operations.cpp
+++ b/src/function/hash/vector_hash_operations.cpp
@@ -1,0 +1,55 @@
+#include "src/function/hash/include/vector_hash_operations.h"
+
+#include "src/function/include/binary_operation_executor.h"
+#include "src/function/include/unary_operation_executor.h"
+
+namespace graphflow {
+namespace function {
+
+void VectorHashOperations::computeHash(ValueVector* operand, ValueVector* result) {
+    assert(result->dataType.typeID == INT64);
+    switch (operand->dataType.typeID) {
+    case NODE_ID: {
+        UnaryHashOperationExecutor::execute<nodeID_t, hash_t>(*operand, *result);
+    } break;
+    case BOOL: {
+        UnaryHashOperationExecutor::execute<bool, hash_t>(*operand, *result);
+    } break;
+    case INT64: {
+        UnaryHashOperationExecutor::execute<int64_t, hash_t>(*operand, *result);
+    } break;
+    case DOUBLE: {
+        UnaryHashOperationExecutor::execute<double, hash_t>(*operand, *result);
+    } break;
+    case STRING: {
+        UnaryHashOperationExecutor::execute<gf_string_t, hash_t>(*operand, *result);
+    } break;
+    case DATE: {
+        UnaryHashOperationExecutor::execute<date_t, hash_t>(*operand, *result);
+    } break;
+    case TIMESTAMP: {
+        UnaryHashOperationExecutor::execute<timestamp_t, hash_t>(*operand, *result);
+    } break;
+    case INTERVAL: {
+        UnaryHashOperationExecutor::execute<interval_t, hash_t>(*operand, *result);
+    } break;
+    case UNSTRUCTURED: {
+        UnaryHashOperationExecutor::execute<Value, hash_t>(*operand, *result);
+    } break;
+    default: {
+        throw RuntimeException(
+            "Cannot hash data type " + Types::dataTypeToString(operand->dataType.typeID));
+    }
+    }
+}
+
+void VectorHashOperations::combineHash(ValueVector* left, ValueVector* right, ValueVector* result) {
+    assert(left->dataType.typeID == INT64);
+    assert(left->dataType.typeID == right->dataType.typeID);
+    assert(left->dataType.typeID == result->dataType.typeID);
+    BinaryOperationExecutor::execute<hash_t, hash_t, hash_t, operation::CombineHash>(
+        *left, *right, *result);
+}
+
+} // namespace function
+} // namespace graphflow

--- a/src/function/include/binary_operation_executor.h
+++ b/src/function/include/binary_operation_executor.h
@@ -42,13 +42,11 @@ struct BinaryListPosAndContainsOperationWrapper {
 struct BinaryOperationExecutor {
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC,
         typename OP_WRAPPER>
-    static void executeOnValue(ValueVector& left, ValueVector& right,
+    static inline void executeOnValue(ValueVector& left, ValueVector& right,
         ValueVector& resultValueVector, uint64_t lPos, uint64_t rPos, uint64_t resPos) {
-        auto lValues = (LEFT_TYPE*)left.values;
-        auto rValues = (RIGHT_TYPE*)right.values;
-        auto resValues = (RESULT_TYPE*)resultValueVector.values;
-        OP_WRAPPER::template operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(lValues[lPos],
-            rValues[rPos], resValues[resPos], (void*)&left, (void*)&right,
+        OP_WRAPPER::template operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+            ((LEFT_TYPE*)left.values)[lPos], ((RIGHT_TYPE*)right.values)[rPos],
+            ((RESULT_TYPE*)resultValueVector.values)[resPos], (void*)&left, (void*)&right,
             (void*)&resultValueVector);
     }
 

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -225,7 +225,8 @@ cc_library(
     deps = [
         "result",
         "//src/function/aggregate:aggregate_function",
-        "//src/function/hash/operations:hash_operations",
+        "//src/function/hash:vector_hash_operations",
+
     ],
 )
 
@@ -247,9 +248,9 @@ cc_library(
         "scan_column",
         "update",
         "var_length_extend",
-        "//src/storage/store:store",
         "//src/common:csv_reader",
         "//src/expression_evaluator:base_expression_evaluator",
+        "//src/storage/store",
     ],
 )
 


### PR DESCRIPTION
This PR includes the following optimizations for aggregation.
1. Create two vector operations: `VectorComputeHashOperation` `VectorCombineHashOperation`  and `VectorComputeHashOperation`: computes the hash value of the input vector and ouputs to oputput vector.
`VectorCombineHashOperation`: combines the two input hash vectors and outputs the combined hash value to the output vector.
2. Refactor the `findHashSlots`  to use tight loop.
3. Define a customized matchGroupByKey function for each column, so we don't neeed to check the column datatype in each iteration.
4. Add quick path for vector with `noNullGuarantee` and `unfiltered`
5. Avoid checking nulls for valueVectors when the valueVector has `noNullGuarantee` 
6. Update the updateAggState to use tight loop

Overall: performance has increased from 14.454s (baseline master) to 5.454s (current branch).
Testing env: himrod-14, ldbc-100, query: `match (c:Comment) return c.length % 1, count(c.ID);`