### PR TITLE
Create clause parsing and binding

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -67,7 +67,8 @@ gF_QueryPart
     : (oC_ReadingClause SP? )* ( oC_UpdatingClause SP? )* oC_With ;
 
 oC_UpdatingClause
-    : oC_Set
+    : oC_Create
+        | oC_Set
         | oC_Delete
         ;
 
@@ -80,6 +81,11 @@ oC_Match
 OPTIONAL : ( 'O' | 'o' ) ( 'P' | 'p' ) ( 'T' | 't' ) ( 'I' | 'i' ) ( 'O' | 'o' ) ( 'N' | 'n' ) ( 'A' | 'a' ) ( 'L' | 'l' ) ;
 
 MATCH : ( 'M' | 'm' ) ( 'A' | 'a' ) ( 'T' | 't' ) ( 'C' | 'c' ) ( 'H' | 'h' ) ;
+
+oC_Create
+    : CREATE SP? oC_NodePattern ( SP? ',' SP? oC_NodePattern )*;
+
+CREATE : ( 'C' | 'c' ) ( 'R' | 'r' ) ( 'E' | 'e' ) ( 'A' | 'a' ) ( 'T' | 't' ) ( 'E' | 'e' ) ;
 
 oC_Set
     : SET SP? oC_SetItem ( SP? ',' SP? oC_SetItem )* ;
@@ -171,8 +177,8 @@ oC_PatternElement
         ;
 
 oC_NodePattern
-    : '(' SP? ( oC_Variable SP? )? ( oC_NodeLabel SP? )? ')'
-        | SP? ( oC_Variable SP? )? ( oC_NodeLabel SP? )? { notifyNodePatternWithoutParentheses($oC_Variable.text, $oC_Variable.start); }
+    : '(' SP? ( oC_Variable SP? )? ( oC_NodeLabel SP? )? ( gF_Properties SP? )? ')'
+        | SP? ( oC_Variable SP? )? ( oC_NodeLabel SP? )? ( gF_Properties SP? )? { notifyNodePatternWithoutParentheses($oC_Variable.text, $oC_Variable.start); }
         ;
 
 oC_PatternElementChain
@@ -185,6 +191,12 @@ oC_RelationshipPattern
 
 oC_RelationshipDetail
     : '[' SP? ( oC_Variable SP? )? ( oC_RelTypeName SP? )? ( oC_RangeLiteral SP? ) ? ']' ;
+
+// The original oC_Properties definition is  oC_MapLiteral | oC_Parameter.
+// We choose to not support parameter as properties which will be the decision for a long time.
+// We then substitute with oC_MapLiteral definition. We create oC_MapLiteral only when we decide to add MAP type.
+gF_Properties
+    : '{' SP? ( oC_PropertyKeyName SP? ':' SP? oC_Expression SP? ( ',' SP? oC_PropertyKeyName SP? ':' SP? oC_Expression SP? )* )? '}';
 
 oC_NodeLabel
     : ':' SP? oC_LabelName ;

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -123,15 +123,7 @@ shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
     validateExpectedDataType(*child, unordered_set<DataTypeID>{NODE, REL});
     auto& catalog = queryBinder->catalog;
     if (NODE == child->dataType.typeID) {
-        auto node = static_pointer_cast<NodeExpression>(child);
-        if (catalog.containNodeProperty(node->getLabel(), propertyName)) {
-            auto& property = catalog.getNodeProperty(node->getLabel(), propertyName);
-            return make_shared<PropertyExpression>(
-                property.dataType, propertyName, property.propertyID, move(child));
-        } else {
-            throw BinderException(
-                "Node " + node->getRawName() + " does not have property " + propertyName + ".");
-        }
+        return bindNodePropertyExpression(child, propertyName);
     } else if (REL == child->dataType.typeID) {
         auto rel = static_pointer_cast<RelExpression>(child);
         if (catalog.containRelProperty(rel->getLabel(), propertyName)) {
@@ -144,6 +136,20 @@ shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
         }
     }
     assert(false);
+}
+
+shared_ptr<Expression> ExpressionBinder::bindNodePropertyExpression(
+    shared_ptr<Expression> node, const string& propertyName) {
+    auto& catalog = queryBinder->catalog;
+    auto nodeExpression = static_pointer_cast<NodeExpression>(node);
+    if (catalog.containNodeProperty(nodeExpression->getLabel(), propertyName)) {
+        auto& property = catalog.getNodeProperty(nodeExpression->getLabel(), propertyName);
+        return make_shared<PropertyExpression>(
+            property.dataType, propertyName, property.propertyID, move(node));
+    } else {
+        throw BinderException("Node " + nodeExpression->getRawName() + " does not have property " +
+                              propertyName + ".");
+    }
 }
 
 shared_ptr<Expression> ExpressionBinder::bindFunctionExpression(

--- a/src/binder/include/expression_binder.h
+++ b/src/binder/include/expression_binder.h
@@ -30,6 +30,8 @@ private:
     shared_ptr<Expression> bindNullOperatorExpression(const ParsedExpression& parsedExpression);
 
     shared_ptr<Expression> bindPropertyExpression(const ParsedExpression& parsedExpression);
+    shared_ptr<Expression> bindNodePropertyExpression(
+        shared_ptr<Expression> node, const string& propertyName);
 
     shared_ptr<Expression> bindFunctionExpression(const ParsedExpression& parsedExpression);
     shared_ptr<Expression> bindScalarFunctionExpression(

--- a/src/binder/include/query_binder.h
+++ b/src/binder/include/query_binder.h
@@ -33,6 +33,7 @@ private:
     unique_ptr<BoundMatchClause> bindMatchClause(const MatchClause& matchClause);
 
     unique_ptr<BoundUpdatingClause> bindUpdatingClause(const UpdatingClause& updatingClause);
+    unique_ptr<BoundUpdatingClause> bindCreateClause(const UpdatingClause& updatingClause);
     unique_ptr<BoundUpdatingClause> bindSetClause(const UpdatingClause& updatingClause);
     unique_ptr<BoundUpdatingClause> bindDeleteClause(const UpdatingClause& updatingClause);
 
@@ -69,6 +70,7 @@ private:
 
     shared_ptr<NodeExpression> bindQueryNode(
         const NodePattern& nodePattern, QueryGraph& queryGraph);
+    shared_ptr<NodeExpression> createQueryNode(const NodePattern& nodePattern);
 
     label_t bindRelLabel(const string& parsed_label);
 

--- a/src/binder/query/updating_clause/include/bound_create_clause.h
+++ b/src/binder/query/updating_clause/include/bound_create_clause.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "bound_updating_clause.h"
+#include "update_info.h"
+
+namespace graphflow {
+namespace binder {
+
+class BoundCreateClause : public BoundUpdatingClause {
+public:
+    BoundCreateClause() : BoundUpdatingClause{ClauseType::CREATE} {};
+    ~BoundCreateClause() override = default;
+
+    inline void addNodeUpdateInfo(unique_ptr<NodeUpdateInfo> updateInfo) {
+        nodeUpdateInfos.push_back(move(updateInfo));
+    }
+
+    inline expression_vector getPropertiesToRead() const override {
+        expression_vector result;
+        for (auto& nodeUpdateInfo : nodeUpdateInfos) {
+            for (auto& property : nodeUpdateInfo->getPropertiesToRead()) {
+                result.push_back(property);
+            }
+        }
+        return result;
+    }
+
+    inline unique_ptr<BoundUpdatingClause> copy() override {
+        auto result = make_unique<BoundCreateClause>();
+        for (auto& nodeUpdateInfo : nodeUpdateInfos) {
+            result->addNodeUpdateInfo(make_unique<NodeUpdateInfo>(*nodeUpdateInfo));
+        }
+        return result;
+    }
+
+private:
+    vector<unique_ptr<NodeUpdateInfo>> nodeUpdateInfos;
+};
+
+} // namespace binder
+} // namespace graphflow

--- a/src/binder/query/updating_clause/include/bound_set_clause.h
+++ b/src/binder/query/updating_clause/include/bound_set_clause.h
@@ -1,35 +1,29 @@
 #pragma once
 
 #include "bound_updating_clause.h"
+#include "update_info.h"
 
 namespace graphflow {
 namespace binder {
-
-struct BoundSetItem {
-    BoundSetItem(shared_ptr<Expression> origin, shared_ptr<Expression> target)
-        : origin{move(origin)}, target{move(target)} {}
-    BoundSetItem(const BoundSetItem& other) : BoundSetItem{other.origin, other.target} {}
-
-    shared_ptr<Expression> origin;
-    shared_ptr<Expression> target;
-};
 
 class BoundSetClause : public BoundUpdatingClause {
 
 public:
     BoundSetClause() : BoundUpdatingClause{ClauseType::SET} {};
-    ~BoundSetClause() = default;
+    ~BoundSetClause() override = default;
 
-    inline void addSetItem(unique_ptr<BoundSetItem> boundSetItem) {
-        boundSetItems.push_back(move(boundSetItem));
+    inline void addUpdateInfo(unique_ptr<PropertyUpdateInfo> updateInfo) {
+        propertyUpdateInfos.push_back(move(updateInfo));
     }
-    inline uint32_t getNumSetItems() const { return boundSetItems.size(); }
-    inline BoundSetItem* getSetItem(uint32_t idx) const { return boundSetItems[idx].get(); }
+    inline uint32_t getNumPropertyUpdateInfos() const { return propertyUpdateInfos.size(); }
+    inline PropertyUpdateInfo* getPropertyUpdateInfo(uint32_t idx) const {
+        return propertyUpdateInfos[idx].get();
+    }
 
     inline expression_vector getPropertiesToRead() const override {
         expression_vector result;
-        for (auto& setItem : boundSetItems) {
-            for (auto& property : setItem->target->getSubPropertyExpressions()) {
+        for (auto& propertyUpdateInfo : propertyUpdateInfos) {
+            for (auto& property : propertyUpdateInfo->getPropertiesToRead()) {
                 result.push_back(property);
             }
         }
@@ -38,14 +32,14 @@ public:
 
     inline unique_ptr<BoundUpdatingClause> copy() override {
         auto result = make_unique<BoundSetClause>();
-        for (auto& setItem : boundSetItems) {
-            result->addSetItem(make_unique<BoundSetItem>(*setItem));
+        for (auto& updateInfo : propertyUpdateInfos) {
+            result->addUpdateInfo(make_unique<PropertyUpdateInfo>(*updateInfo));
         }
         return result;
     }
 
 private:
-    vector<unique_ptr<BoundSetItem>> boundSetItems;
+    vector<unique_ptr<PropertyUpdateInfo>> propertyUpdateInfos;
 };
 
 } // namespace binder

--- a/src/binder/query/updating_clause/include/update_info.h
+++ b/src/binder/query/updating_clause/include/update_info.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "src/binder/expression/include/expression.h"
+
+namespace graphflow {
+namespace binder {
+
+class PropertyUpdateInfo {
+public:
+    PropertyUpdateInfo(shared_ptr<Expression> property, shared_ptr<Expression> target)
+        : property{move(property)}, target{move(target)} {
+        assert(this->property->expressionType == PROPERTY &&
+               this->property->dataType == this->target->dataType);
+    }
+    PropertyUpdateInfo(const PropertyUpdateInfo& other)
+        : PropertyUpdateInfo{other.property, other.target} {}
+
+    inline shared_ptr<Expression> getProperty() const { return property; }
+    inline shared_ptr<Expression> getTarget() const { return target; }
+
+    inline expression_vector getPropertiesToRead() const {
+        return target->getSubPropertyExpressions();
+    }
+
+private:
+    shared_ptr<Expression> property;
+    shared_ptr<Expression> target;
+};
+
+class NodeUpdateInfo {
+public:
+    explicit NodeUpdateInfo(shared_ptr<Expression> node) : node{move(node)} {
+        assert(this->node->expressionType == VARIABLE && this->node->dataType.typeID == NODE);
+    }
+    NodeUpdateInfo(const NodeUpdateInfo& other) : node{other.node} {
+        for (auto& propertyUpdateInfo : other.propertyUpdateInfos) {
+            propertyUpdateInfos.push_back(make_unique<PropertyUpdateInfo>(*propertyUpdateInfo));
+        }
+    }
+
+    inline void addPropertyUpdateInfo(unique_ptr<PropertyUpdateInfo> propertyUpdateInfo) {
+        propertyUpdateInfos.push_back(move(propertyUpdateInfo));
+    }
+
+    inline expression_vector getPropertiesToRead() const {
+        expression_vector result;
+        for (auto& propertyUpdateInfo : propertyUpdateInfos) {
+            for (auto& property : propertyUpdateInfo->getPropertiesToRead()) {
+                result.push_back(property);
+            }
+        }
+        return result;
+    }
+
+private:
+    shared_ptr<Expression> node;
+    vector<unique_ptr<PropertyUpdateInfo>> propertyUpdateInfos;
+};
+
+} // namespace binder
+} // namespace graphflow

--- a/src/common/include/clause_type.h
+++ b/src/common/include/clause_type.h
@@ -9,6 +9,7 @@ enum class ClauseType : uint8_t {
     // updating clause
     SET = 0,
     DELETE = 1,
+    CREATE = 2,
 };
 
 } // namespace common

--- a/src/parser/include/transformer.h
+++ b/src/parser/include/transformer.h
@@ -2,6 +2,7 @@
 
 #include "src/antlr4/CypherParser.h"
 #include "src/parser/query/include/regular_query.h"
+#include "src/parser/query/updating_clause/include/create_clause.h"
 #include "src/parser/query/updating_clause/include/delete_clause.h"
 #include "src/parser/query/updating_clause/include/set_clause.h"
 
@@ -33,6 +34,8 @@ private:
     unique_ptr<MatchClause> transformReadingClause(CypherParser::OC_ReadingClauseContext& ctx);
 
     unique_ptr<MatchClause> transformMatch(CypherParser::OC_MatchContext& ctx);
+
+    unique_ptr<CreateClause> transformCreate(CypherParser::OC_CreateContext& ctx);
 
     unique_ptr<SetClause> transformSet(CypherParser::OC_SetContext& ctx);
 
@@ -70,6 +73,9 @@ private:
 
     unique_ptr<RelPattern> transformRelationshipPattern(
         CypherParser::OC_RelationshipPatternContext& ctx);
+
+    vector<pair<string, unique_ptr<ParsedExpression>>> transformProperties(
+        CypherParser::GF_PropertiesContext& ctx);
 
     string transformNodeLabel(CypherParser::OC_NodeLabelContext& ctx);
 

--- a/src/parser/query/match_clause/BUILD.bazel
+++ b/src/parser/query/match_clause/BUILD.bazel
@@ -15,3 +15,16 @@ cc_library(
         "//src/parser/expression:parsed_expression",
     ],
 )
+
+cc_library(
+    name = "node_pattern",
+    hdrs = [
+        "include/node_pattern.h",
+    ],
+    visibility = [
+        "//src/parser/query/updating_clause:__pkg__",
+    ],
+    deps = [
+        "//src/parser/expression:parsed_expression",
+    ],
+)

--- a/src/parser/query/match_clause/include/node_pattern.h
+++ b/src/parser/query/match_clause/include/node_pattern.h
@@ -3,18 +3,21 @@
 #include <memory>
 #include <string>
 
+#include "src/parser/expression/include/parsed_expression.h"
+
 using namespace std;
 
 namespace graphflow {
 namespace parser {
 
 /**
- * NodePattern represents "(nodeName:NodeType)"
+ * NodePattern represents "(nodeName:NodeLabel {p1:v1, p2:v2, ...})"
  */
 class NodePattern {
-
 public:
-    NodePattern(string name, string label) : name{move(name)}, label{move(label)} {}
+    NodePattern(
+        string name, string label, vector<pair<string, unique_ptr<ParsedExpression>>> properties)
+        : name{move(name)}, label{move(label)}, properties{move(properties)} {}
 
     ~NodePattern() = default;
 
@@ -22,8 +25,24 @@ public:
 
     inline string getLabel() const { return label; }
 
+    inline uint32_t getNumProperties() const { return properties.size(); }
+    inline pair<string, ParsedExpression*> getProperty(uint32_t idx) const {
+        return make_pair(properties[idx].first, properties[idx].second.get());
+    }
+
     bool operator==(const NodePattern& other) const {
-        return name == other.name && label == other.label;
+        if (!(name == other.name && label == other.label &&
+                properties.size() == other.properties.size())) {
+            return false;
+        }
+        for (auto i = 0u; i < properties.size(); ++i) {
+            auto& [name, expression] = properties[i];
+            auto& [otherName, otherExpression] = other.properties[i];
+            if (!(name == otherName && *expression == *otherExpression)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     bool operator!=(const NodePattern& other) const { return !operator==(other); }
@@ -31,6 +50,7 @@ public:
 private:
     string name;
     string label;
+    vector<pair<string, unique_ptr<ParsedExpression>>> properties;
 };
 
 } // namespace parser

--- a/src/parser/query/updating_clause/BUILD.bazel
+++ b/src/parser/query/updating_clause/BUILD.bazel
@@ -11,5 +11,6 @@ cc_library(
     ],
     deps = [
         "//src/common:clause_type",
+        "//src/parser/query/match_clause:node_pattern",
     ],
 )

--- a/src/parser/query/updating_clause/include/create_clause.h
+++ b/src/parser/query/updating_clause/include/create_clause.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "updating_clause.h"
+
+#include "src/parser/expression/include/parsed_expression.h"
+#include "src/parser/query/match_clause/include/node_pattern.h"
+
+namespace graphflow {
+namespace parser {
+
+class CreateClause : public UpdatingClause {
+public:
+    CreateClause() : UpdatingClause{ClauseType::CREATE} {};
+    ~CreateClause() override = default;
+
+    inline void addNodePattern(unique_ptr<NodePattern> nodePattern) {
+        nodePatterns.push_back(move(nodePattern));
+    }
+    inline uint32_t getNumNodePatterns() const { return nodePatterns.size(); }
+    inline NodePattern* getNodePattern(uint32_t idx) const { return nodePatterns[idx].get(); }
+
+private:
+    vector<unique_ptr<NodePattern>> nodePatterns;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/query/updating_clause/include/delete_clause.h
+++ b/src/parser/query/updating_clause/include/delete_clause.h
@@ -8,7 +8,6 @@ namespace graphflow {
 namespace parser {
 
 class DeleteClause : public UpdatingClause {
-
 public:
     DeleteClause() : UpdatingClause{ClauseType::DELETE} {};
     ~DeleteClause() override = default;

--- a/src/planner/include/update_planner.h
+++ b/src/planner/include/update_planner.h
@@ -25,6 +25,8 @@ public:
 
 private:
     void planUpdatingClause(BoundUpdatingClause& updatingClause, LogicalPlan& plan);
+    void planPropertyUpdateInfo(
+        shared_ptr<Expression> property, shared_ptr<Expression> target, LogicalPlan& plan);
 
     void appendSink(LogicalPlan& plan);
     void appendSet(BoundSetClause& setClause, LogicalPlan& plan);

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -117,6 +117,12 @@ TEST_F(BinderErrorTest, BindPropertyNotExist) {
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
+TEST_F(BinderErrorTest, BindPropertyNotExist2) {
+    string expectedException = "Binder exception: Node a does not have property foo.";
+    auto input = "Create (a:person {foo:'x'});";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
 TEST_F(BinderErrorTest, BindIDArithmetic) {
     string expectedException =
         "Binder exception: Cannot match a built-in function for given function +(NODE_ID,INT64). "

--- a/test/parser/reading_clause_test.cpp
+++ b/test/parser/reading_clause_test.cpp
@@ -12,10 +12,14 @@ public:
         return make_unique<RelPattern>(
             name, type, "1" /*lowerBound*/, "1" /*upperBound*/, direction);
     }
+
+    vector<pair<string, unique_ptr<ParsedExpression>>> getDummyProperties() {
+        return vector<pair<string, unique_ptr<ParsedExpression>>>{};
+    }
 };
 
 TEST_F(ReadingClauseTest, EmptyMatchTest) {
-    auto expectNode = make_unique<NodePattern>(string(), string());
+    auto expectNode = make_unique<NodePattern>(string(), string(), getDummyProperties());
     auto expectPElements = vector<unique_ptr<PatternElement>>();
     expectPElements.emplace_back(make_unique<PatternElement>(move(expectNode)));
     auto expectedMatch = make_unique<MatchClause>(move(expectPElements));
@@ -27,8 +31,8 @@ TEST_F(ReadingClauseTest, EmptyMatchTest) {
 }
 
 TEST_F(ReadingClauseTest, MATCHSingleEdgeTest) {
-    auto expectNodeA = make_unique<NodePattern>("a", "Person");
-    auto expectNodeB = make_unique<NodePattern>("b", "Student");
+    auto expectNodeA = make_unique<NodePattern>("a", "Person", getDummyProperties());
+    auto expectNodeB = make_unique<NodePattern>("b", "Student", getDummyProperties());
     auto expectRel = makeRelPattern("e1", "knows", RIGHT);
     auto expectPElementChain = make_unique<PatternElementChain>(move(expectRel), move(expectNodeB));
     auto expectPElement = make_unique<PatternElement>(move(expectNodeA));
@@ -44,12 +48,12 @@ TEST_F(ReadingClauseTest, MATCHSingleEdgeTest) {
 }
 
 TEST_F(ReadingClauseTest, MATCHMultiEdgesTest) {
-    auto expectNodeA = make_unique<NodePattern>("a", "Person");
-    auto expectNodeB = make_unique<NodePattern>("b", "Student");
+    auto expectNodeA = make_unique<NodePattern>("a", "Person", getDummyProperties());
+    auto expectNodeB = make_unique<NodePattern>("b", "Student", getDummyProperties());
     auto expectRel1 = makeRelPattern(string(), "knows", RIGHT);
     auto expectedPElementChain1 =
         make_unique<PatternElementChain>(move(expectRel1), move(expectNodeB));
-    auto expectNodeC = make_unique<NodePattern>("c", "Student");
+    auto expectNodeC = make_unique<NodePattern>("c", "Student", getDummyProperties());
     auto expectRel2 = makeRelPattern("e2", "likes", LEFT);
     auto expectedPElementChain2 =
         make_unique<PatternElementChain>(move(expectRel2), move(expectNodeC));
@@ -67,16 +71,16 @@ TEST_F(ReadingClauseTest, MATCHMultiEdgesTest) {
 }
 
 TEST_F(ReadingClauseTest, MATCHMultiElementsTest) {
-    auto expectNodeA = make_unique<NodePattern>("a", "Person");
-    auto expectNodeB = make_unique<NodePattern>("b", "Student");
+    auto expectNodeA = make_unique<NodePattern>("a", "Person", getDummyProperties());
+    auto expectNodeB = make_unique<NodePattern>("b", "Student", getDummyProperties());
     auto expectRel1 = makeRelPattern(string(), "knows", RIGHT);
     auto expectedPElementChain1 =
         make_unique<PatternElementChain>(move(expectRel1), move(expectNodeB));
     auto expectPElement1 = make_unique<PatternElement>(move(expectNodeA));
     expectPElement1->addPatternElementChain(move(expectedPElementChain1));
 
-    auto expectNodeB2 = make_unique<NodePattern>("b", string());
-    auto expectNodeC = make_unique<NodePattern>("c", "Student");
+    auto expectNodeB2 = make_unique<NodePattern>("b", string(), getDummyProperties());
+    auto expectNodeC = make_unique<NodePattern>("c", "Student", getDummyProperties());
     auto expectRel2 = makeRelPattern("e2", "likes", LEFT);
     auto expectedPElementChain2 =
         make_unique<PatternElementChain>(move(expectRel2), move(expectNodeC));
@@ -95,8 +99,8 @@ TEST_F(ReadingClauseTest, MATCHMultiElementsTest) {
 }
 
 TEST_F(ReadingClauseTest, MultiMatchTest) {
-    auto expectNodeA = make_unique<NodePattern>("a", "Person");
-    auto expectNodeB = make_unique<NodePattern>("b", "Student");
+    auto expectNodeA = make_unique<NodePattern>("a", "Person", getDummyProperties());
+    auto expectNodeB = make_unique<NodePattern>("b", "Student", getDummyProperties());
     auto expectRel1 = makeRelPattern(string(), "knows", RIGHT);
     auto expectedPElementChain1 =
         make_unique<PatternElementChain>(move(expectRel1), move(expectNodeB));
@@ -106,8 +110,8 @@ TEST_F(ReadingClauseTest, MultiMatchTest) {
     expectPElements1.emplace_back(move(expectPElement1));
     auto expectedMatch1 = make_unique<MatchClause>(move(expectPElements1));
 
-    auto expectNodeB2 = make_unique<NodePattern>("b", string());
-    auto expectNodeC = make_unique<NodePattern>("c", "Student");
+    auto expectNodeB2 = make_unique<NodePattern>("b", string(), getDummyProperties());
+    auto expectNodeC = make_unique<NodePattern>("c", "Student", getDummyProperties());
     auto expectRel2 = makeRelPattern("e2", "likes", LEFT);
     auto expectedPElementChain2 =
         make_unique<PatternElementChain>(move(expectRel2), move(expectNodeC));

--- a/test/parser/subquery_test.cpp
+++ b/test/parser/subquery_test.cpp
@@ -11,7 +11,8 @@ class SubqueryTest : public ::testing::Test {
 
 public:
     static unique_ptr<MatchClause> makeEmptyMatchClause() {
-        auto expectNode = make_unique<NodePattern>(string(), string());
+        auto expectNode = make_unique<NodePattern>(
+            string(), string(), vector<pair<string, unique_ptr<ParsedExpression>>>{});
         auto expectPElements = vector<unique_ptr<PatternElement>>();
         expectPElements.emplace_back(make_unique<PatternElement>(move(expectNode)));
         return make_unique<MatchClause>(move(expectPElements));


### PR DESCRIPTION
This PR adds parsing and binding logic for CREATE clause. Note that we start allowing properties map in node pattern.
`E.g. (a:person {p1:v1, p2:v2})`.

This node pattern is being used for both CREATE and MATCH. However, we disable its usage for MATCH clause because 
`MATCH (a:person {p1:v1})` is semantically equivalent to `MATCH (a:person) WHERE a.p1 = v1`