### PR TITLE
Disk array storage structure

### DIFF
--- a/src/common/types/include/types.h
+++ b/src/common/types/include/types.h
@@ -16,6 +16,8 @@ namespace common {
 typedef uint16_t sel_t;
 typedef uint64_t hash_t;
 typedef uint32_t page_idx_t;
+constexpr page_idx_t PAGE_IDX_MAX = UINT32_MAX;
+typedef uint32_t list_header_t;
 
 // System representation for a variable-sized overflow value.
 struct overflow_value_t {

--- a/src/loader/in_mem_storage_structure/in_mem_lists.cpp
+++ b/src/loader/in_mem_storage_structure/in_mem_lists.cpp
@@ -59,7 +59,7 @@ void InMemAdjLists::setElement(
 }
 
 void InMemAdjLists::saveToFile() {
-    listHeaders->saveToDisk(fName);
+    listHeaders->saveToDisk();
     InMemLists::saveToFile();
 }
 
@@ -124,7 +124,7 @@ void InMemUnstructuredLists::setComponentOfUnstrProperty(
 }
 
 void InMemUnstructuredLists::saveToFile() {
-    listHeaders->saveToDisk(fName);
+    listHeaders->saveToDisk();
     InMemListsWithOverflow::saveToFile();
 }
 

--- a/src/loader/in_mem_storage_structure/include/in_mem_lists.h
+++ b/src/loader/in_mem_storage_structure/include/in_mem_lists.h
@@ -75,7 +75,7 @@ public:
     InMemAdjLists(string fName, const NodeIDCompressionScheme& compressionScheme, uint64_t numNodes)
         : InMemLists{move(fName), DataType(NODE_ID), compressionScheme.getNumTotalBytes()},
           compressionScheme{compressionScheme} {
-        listHeaders = make_unique<ListHeaders>(numNodes);
+        listHeaders = make_unique<ListHeaders>(this->fName, numNodes);
     };
 
     ~InMemAdjLists() override = default;
@@ -111,7 +111,7 @@ public:
     InMemUnstructuredLists(string fName, uint64_t numNodes)
         : InMemListsWithOverflow{move(fName), DataType(UNSTRUCTURED)} {
         listSizes = make_unique<atomic_uint64_vec_t>(numNodes);
-        listHeaders = make_unique<ListHeaders>(numNodes);
+        listHeaders = make_unique<ListHeaders>(this->fName, numNodes);
     };
 
     inline ListHeaders* getListHeaders() { return listHeaders.get(); }

--- a/src/storage/buffer_manager/include/file_handle.h
+++ b/src/storage/buffer_manager/include/file_handle.h
@@ -96,6 +96,10 @@ public:
 
     void releasePageLock(page_idx_t pageIdx) { pageLocks[pageIdx]->clear(); }
 
+    inline uint64_t getPageSize() const {
+        return isLargePaged() ? LARGE_PAGE_SIZE : DEFAULT_PAGE_SIZE;
+    }
+
 protected:
     page_idx_t addNewPageWithoutLock();
 
@@ -114,10 +118,6 @@ protected:
     }
 
     inline void unswizzle(page_idx_t pageIdx) { pageIdxToFrameMap[pageIdx]->store(UINT32_MAX); }
-
-    inline uint64_t getPageSize() const {
-        return isLargePaged() ? LARGE_PAGE_SIZE : DEFAULT_PAGE_SIZE;
-    }
 
     inline void addNewPageLockAndFramePtrWithoutLock(page_idx_t pageIdx) {
         pageLocks[pageIdx] = make_unique<atomic_flag>();

--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -166,7 +166,8 @@ public:
     inline static pair<uint64_t, uint64_t> getQuotientRemainder(uint64_t i, uint64_t divisor) {
         return make_pair(i / divisor, i % divisor);
     }
-};
 
+    static uint64_t all1sMaskForLeastSignificantBits(uint64_t numBits);
+};
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/storage_structure/BUILD.bazel
+++ b/src/storage/storage_structure/BUILD.bazel
@@ -1,4 +1,17 @@
 load("@rules_cc//cc:defs.bzl", "cc_library")
+cc_library(
+    name = "disk_array",
+    srcs = [
+        "disk_array.cpp",
+    ],
+    hdrs = [
+        "include/disk_array.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//src/storage/buffer_manager:file_handle",
+    ],
+)
 
 cc_library(
     name = "storage_structure",
@@ -13,6 +26,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "disk_array",
         "//src/common:vector",
         "//src/storage:compression_scheme",
         "//src/storage:storage_utils",

--- a/src/storage/storage_structure/disk_array.cpp
+++ b/src/storage/storage_structure/disk_array.cpp
@@ -1,0 +1,153 @@
+#include "include/disk_array.h"
+
+namespace graphflow {
+namespace storage {
+
+DiskArrayHeader::DiskArrayHeader(
+    uint64_t elementSize, uint64_t numElements, uint64_t firstPIPPageIdx)
+    : elementSize{elementSize}, numElements{numElements}, firstPIPPageIdx{firstPIPPageIdx} {
+    numElementsPerPageLog2 = static_cast<uint64_t>(floor(log2(DEFAULT_PAGE_SIZE / elementSize)));
+    elementPageOffsetMask = StorageUtils::all1sMaskForLeastSignificantBits(numElementsPerPageLog2);
+    numArrayPages = (numElements >> numElementsPerPageLog2) +
+                    ((numElements & elementPageOffsetMask) > 0 ? 1 : 0);
+}
+
+void DiskArrayHeader::saveToDisk(FileHandle& fileHandle, uint64_t headerPageIdx) {
+    FileUtils::writeToFile(fileHandle.getFileInfo(), reinterpret_cast<uint8_t*>(this),
+        sizeof(DiskArrayHeader), headerPageIdx * fileHandle.getPageSize());
+}
+
+void DiskArrayHeader::readFromFile(FileHandle& fileHandle, uint64_t headerPageIdx) {
+    FileUtils::readFromFile(fileHandle.getFileInfo(), reinterpret_cast<uint8_t*>(this),
+        sizeof(DiskArrayHeader), headerPageIdx * fileHandle.getPageSize());
+}
+
+void DiskArrayHeader::print() {
+    cout << "firstPIPPageIdx: " << firstPIPPageIdx << endl;
+    cout << "elementSize: " << elementSize << endl;
+    cout << "numElements: " << numElements << endl;
+    cout << "numElementsPerPageLog2: " << numElementsPerPageLog2 << endl;
+    cout << "elementPageOffsetMask: " << elementPageOffsetMask << endl;
+    cout << "numArrayPages: " << numArrayPages << endl;
+}
+
+void PIP::print() {
+    cout << "nextPipPageIdx: " << nextPipPageIdx << endl;
+    cout << "pageIdxs:";
+    for (int i = 0; i < NUM_PAGE_IDXS_PER_PIP; ++i) {
+        cout << " " << pageIdxs[i];
+    }
+    cout << endl;
+}
+
+BaseDiskArray::BaseDiskArray(shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx,
+    uint64_t elementSize, uint64_t numElements)
+    : header(elementSize, numElements, fileHandle->addNewPage() /* first pip pageIdx */),
+      fileHandle(fileHandle), headerPageIdx(headerPageIdx) {
+    assert(!fileHandle->isLargePaged());
+    uint64_t numArrayPagesLeft = header.numArrayPages;
+    uint64_t pipIdx = 0;
+    while (numArrayPagesLeft > 0) {
+        uint64_t pipPageIdx = (pipIdx == 0) ? header.firstPIPPageIdx : fileHandle->addNewPage();
+        pips.emplace_back(pipPageIdx);
+        if (pipIdx > 0) {
+            pips[pipIdx - 1].pipContents.nextPipPageIdx = pipPageIdx;
+        }
+        pipIdx++;
+        numArrayPagesLeft -= min(numArrayPagesLeft, NUM_PAGE_IDXS_PER_PIP);
+    }
+    for (int i = 0; i < header.numArrayPages; ++i) {
+        uint64_t pageIdx = fileHandle->addNewPage();
+        auto pipIdxAndOffset = StorageUtils::getQuotientRemainder(i, NUM_PAGE_IDXS_PER_PIP);
+        pips[pipIdxAndOffset.first].pipContents.pageIdxs[pipIdxAndOffset.second] = pageIdx;
+    }
+}
+
+BaseDiskArray::BaseDiskArray(shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx)
+    : fileHandle(fileHandle), headerPageIdx(headerPageIdx) {
+    header.readFromFile(*this->fileHandle, headerPageIdx);
+    pips.emplace_back(fileHandle, header.firstPIPPageIdx);
+    while (pips[pips.size() - 1].pipContents.nextPipPageIdx != PAGE_IDX_MAX) {
+        pips.emplace_back(fileHandle, pips[pips.size() - 1].pipContents.nextPipPageIdx);
+    }
+}
+
+page_idx_t BaseDiskArray::getArrayFilePageIdx(page_idx_t arrayPageIdx) {
+    assert(arrayPageIdx < header.numArrayPages);
+    auto pipIdxAndOffset = StorageUtils::getQuotientRemainder(arrayPageIdx, NUM_PAGE_IDXS_PER_PIP);
+    return pips[pipIdxAndOffset.first].pipContents.pageIdxs[pipIdxAndOffset.second];
+}
+
+void BaseDiskArray::saveToDisk() {
+    header.saveToDisk(*fileHandle, headerPageIdx);
+    for (int i = 0; i < pips.size(); ++i) {
+        fileHandle->writePage(reinterpret_cast<uint8_t*>(&pips[i].pipContents), pips[i].pipPageIdx);
+    }
+}
+
+void BaseDiskArray::print() {
+    cout << "Printing BaseDisk Array" << endl;
+    cout << "headerPageIdx: " << headerPageIdx << endl;
+    header.print();
+    for (int i = 0; i < pips.size(); ++i) {
+        pips[i].print();
+    }
+}
+
+template<class U>
+InMemDiskArray<U>::InMemDiskArray(
+    shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx, uint64_t numElements)
+    : BaseDiskArray(fileHandle, headerPageIdx, sizeof(U) /* elementSize */, numElements) {
+    for (uint64_t i = 0; i < header.numArrayPages; ++i) {
+        dataPages.emplace_back(make_unique<U[]>(1ull << header.numElementsPerPageLog2));
+    }
+}
+
+template<class U>
+InMemDiskArray<U>::InMemDiskArray(shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx)
+    : BaseDiskArray(fileHandle, headerPageIdx) {
+    for (page_idx_t arrayPageIdx = 0; arrayPageIdx < header.numArrayPages; ++arrayPageIdx) {
+        dataPages.emplace_back(make_unique<U[]>(1ull << header.numElementsPerPageLog2));
+        fileHandle->readPage(reinterpret_cast<uint8_t*>(dataPages[arrayPageIdx].get()),
+            getArrayFilePageIdx(arrayPageIdx));
+    }
+}
+
+// [] operator to be used when building an InMemDiskArray without transactional updates. This
+// changes the contents directly in memory and not on disk (nor on the wal)
+template<class U>
+U& InMemDiskArray<U>::operator[](uint64_t idx) {
+    page_idx_t arrayPageIdx = idx >> header.numElementsPerPageLog2;
+    uint64_t arrayPageOffset = idx & header.elementPageOffsetMask;
+    assert(arrayPageIdx < header.numArrayPages);
+    return dataPages[arrayPageIdx][arrayPageOffset];
+}
+
+template<class U>
+void InMemDiskArray<U>::saveToDisk() {
+    BaseDiskArray::saveToDisk();
+    for (page_idx_t arrayPageIdx = 0; arrayPageIdx < header.numArrayPages; ++arrayPageIdx) {
+        fileHandle->writePage(reinterpret_cast<uint8_t*>(dataPages[arrayPageIdx].get()),
+            getArrayFilePageIdx(arrayPageIdx));
+    }
+}
+
+template<class U>
+void InMemDiskArray<U>::print() {
+    BaseDiskArray::print();
+    for (page_idx_t arrayPageIdx = 0; arrayPageIdx < header.numArrayPages; ++arrayPageIdx) {
+        auto numElementsPerPage = 1 << header.numElementsPerPageLog2;
+        cout << "array page " << arrayPageIdx
+             << " (file pageIdx: " << getArrayFilePageIdx(arrayPageIdx) << ") contents: ";
+        for (int j = 0; j < numElementsPerPage; ++j) {
+            cout << " " << dataPages[arrayPageIdx][j];
+        }
+        cout << endl;
+        dataPages.emplace_back(make_unique<U[]>(1 << header.numElementsPerPageLog2));
+    }
+}
+
+template class InMemDiskArray<list_header_t>;
+
+} // namespace storage
+} // namespace graphflow

--- a/src/storage/storage_structure/include/disk_array.h
+++ b/src/storage/storage_structure/include/disk_array.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include <iostream>
+
+#include "src/storage/buffer_manager/include/versioned_file_handle.h"
+
+namespace graphflow {
+namespace storage {
+
+static constexpr uint64_t NUM_PAGE_IDXS_PER_PIP =
+    (DEFAULT_PAGE_SIZE - sizeof(page_idx_t)) / sizeof(page_idx_t);
+
+/**
+ * Header page of a disk array.
+ */
+struct DiskArrayHeader {
+    DiskArrayHeader(){};
+
+    DiskArrayHeader(uint64_t elementSize, uint64_t numElements, uint64_t firstPIPPageIdx);
+
+    void saveToDisk(FileHandle& fileHandle, uint64_t headerPageIdx);
+
+    void readFromFile(FileHandle& fileHandle, uint64_t headerPageIdx);
+
+    // TODO(Semih): This is only for debugging purposes. Will be removed.
+    void print();
+
+    // We do not need to store numElementsPerPageLog2, elementPageOffsetMask, and numArrayPages or
+    // save them on disk as they are functions of elementSize and numElements but we
+    // nonetheless store them (and save them to disk) for simplicity.
+    uint64_t elementSize;
+    uint64_t numElements;
+    uint64_t firstPIPPageIdx;
+    uint64_t numElementsPerPageLog2;
+    uint64_t elementPageOffsetMask;
+    uint64_t numArrayPages;
+};
+
+struct PIP {
+    PIP() : nextPipPageIdx{PAGE_IDX_MAX} {}
+
+    // TODO(Semih): This is only for debugging purposes. Will be removed.
+    void print();
+
+    page_idx_t nextPipPageIdx;
+    page_idx_t pageIdxs[NUM_PAGE_IDXS_PER_PIP];
+};
+
+struct PIPWrapper {
+    PIPWrapper(shared_ptr<FileHandle> fileHandle, page_idx_t pipPageIdx) : pipPageIdx(pipPageIdx) {
+        fileHandle->readPage(reinterpret_cast<uint8_t*>(&pipContents), pipPageIdx);
+    }
+
+    PIPWrapper(page_idx_t pipPageIdx) : pipPageIdx(pipPageIdx) {}
+
+    // TODO(Semih): This is only for debugging purposes. Will be removed.
+    void print() {
+        cout << "Printing PIPWrapper pipPageIdx: " << pipPageIdx << endl;
+        pipContents.print();
+    }
+
+    page_idx_t pipPageIdx;
+    PIP pipContents;
+};
+
+/**
+ * DiskArray stores a disk-based array in a file. The array is broken down into a predefined and
+ * stable header page, i.e., the header page of the array is always in a pre-allocated page in the
+ * file. The header page contains the pointer to the first ``page indices page'' (pip). Each pip
+ * stores a list of page indices that store the ``array pages''. Each pip also stores the pageIdx of
+ * the next pip if one exists (or we use PAGE_IDX_MAX as null). Array pages store the actual data in
+ * the array.
+ *
+ * Storage structures can use multiple disk arrays in a single file by giving each one a different
+ * pre-allocated stable header pageIdxs.
+ */
+class BaseDiskArray {
+public:
+    // Every DiskArray needs to have a pre-allocated header page, so we can know where to start to
+    // read the array (its pips and array pages).
+    BaseDiskArray(shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx, uint64_t elementSize,
+        uint64_t numElements);
+
+    BaseDiskArray(shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx);
+
+    virtual ~BaseDiskArray() {}
+
+    // This function does division and mod and should not be used in performance critical code
+    page_idx_t getArrayFilePageIdx(page_idx_t arrayPageIdx);
+
+    virtual void saveToDisk();
+
+    // TODO(Semih): This is only for debugging purposes. Will be removed.
+    void print();
+
+public:
+    DiskArrayHeader header;
+
+protected:
+    shared_ptr<FileHandle> fileHandle;
+    page_idx_t headerPageIdx;
+    vector<PIPWrapper> pips;
+};
+
+/**
+ * Stores an array of type U's page by page in memory, using OS memory and not the buffer manager.
+ * Designed currently to be used by lists headers and metadata, where we want to avoid using
+ * pins/unpins when accessing data through the buffer manager.
+ */
+template<class U>
+class InMemDiskArray : public BaseDiskArray {
+public:
+    InMemDiskArray(
+        shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx, uint64_t numElements);
+
+    InMemDiskArray(shared_ptr<FileHandle> fileHandle, page_idx_t headerPageIdx);
+
+    // [] operator to be used when building an InMemDiskArray without transactional updates. This
+    // changes the contents directly in memory and not on disk (nor on the wal)
+    U& operator[](uint64_t idx);
+
+    void saveToDisk() override;
+
+    // TODO(Semih): This is only for debugging purposes. Will be removed.
+    void print();
+
+private:
+    vector<unique_ptr<U[]>> dataPages;
+};
+
+} // namespace storage
+} // namespace graphflow

--- a/src/storage/storage_structure/include/lists/list_headers.h
+++ b/src/storage/storage_structure/include/lists/list_headers.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "src/common/types/include/types_include.h"
+#include "src/storage/storage_structure/include/disk_array.h"
 
 using namespace std;
 using namespace graphflow::common;
@@ -15,66 +16,61 @@ namespace graphflow {
 namespace storage {
 
 /**
- * ListHeaders holds the headers of all lists in a single Lists data structure.
+ * ListHeaders holds the headers of all lists in a single Lists data structure, which implements a
+ * chunked CSR, where each chunk stores StorageConfig::LISTS_CHUNK_SIZE many lists.
  *
  * A header of a list is a unsigned integer values. Each value describes the following
  * information about the list: 1) type: small or large, 2) location of list in pages.
  *
  * If the list is small, the layout of header is:
- *      1. MSB (31st bit) is reset
- *      2. 30-22 bits denote the index in the chunkPagesMaps[chunkId] where disk page ID is
- *      located, where chunkId = idx of the list / LISTS_CHUNK_SIZE.
- *      3. 21-11 bits denote the offset in the disk page.
+ *      1. MSB (31st bit) is 0
+ *      2. 30-11 bits denote the "logical" CSR offset in the chunk. Using Lists::numElementsPerPage
+ *      (which is stored in the base class StorageStructure), this offset can be turned into a
+ *      logical pageIdx, which can later be turned into a physical page index in the .lists file.
+ *      This logic is encapsulated in Lists::getListInfo(node_offset_t nodeOffset) function.
  *      4. 10-0  bits denote the number of elements in the list.
  *
  * If list is a large one (during initial data ingest, the criterion for being large is
  * whether or not a list fits in a single page), the layout of header is:
- *      1. MSB (31st bit) is set
+ *      1. MSB (31st bit) is 1
  *      2. 30-0  bits denote the idx in the largeListsPagesMaps where the length and the disk
  *      page IDs are located.
  * */
 class ListHeaders {
 
 public:
-    explicit ListHeaders(uint32_t size);
+    static constexpr uint64_t LIST_HEADERS_HEADER_PAGE_IDX = 0;
+
+    explicit ListHeaders(const string& fName, uint64_t numElements);
     explicit ListHeaders(const string& listBaseFName);
 
-    inline uint32_t getHeader(node_offset_t offset) {
-        assert(offset < size);
-        return headers[offset];
-    };
-    inline void setHeader(node_offset_t offset, uint32_t header) {
-        assert(offset < size);
-        headers[offset] = header;
+    inline list_header_t getHeader(node_offset_t offset) { return (*headers)[offset]; };
+    inline void setHeader(node_offset_t offset, list_header_t header) {
+        (*headers)[offset] = header;
     }
 
-    static inline bool isALargeList(uint32_t header) { return header & 0x80000000; };
+    static inline bool isALargeList(list_header_t header) { return header & 0x80000000; };
 
     // For small lists.
-    static inline uint32_t getSmallListLen(uint32_t header) { return header & 0x7ff; };
-    static inline uint32_t getSmallListCSROffset(uint32_t header) {
+    static inline uint32_t getSmallListLen(list_header_t header) { return header & 0x7ff; };
+    static inline uint32_t getSmallListCSROffset(list_header_t header) {
         return header >> 11 & 0xfffff;
     };
     static inline uint32_t getSmallListHeader(uint32_t csrOffset, uint32_t numElementsInList) {
-        return ((csrOffset & 0xfffff) << 11) + (numElementsInList & 0x7ff);
+        return ((csrOffset & 0xfffff) << 11) | (numElementsInList & 0x7ff);
     }
 
     // For large lists.
-    static inline uint32_t getLargeListIdx(uint32_t header) { return header & 0x7fffffff; };
+    static inline uint32_t getLargeListIdx(list_header_t header) { return header & 0x7fffffff; };
     static inline uint32_t getLargeListHeader(uint32_t listIdx) {
-        return 0x80000000 + (listIdx & 0x7fffffff);
+        return 0x80000000 | (listIdx & 0x7fffffff);
     }
 
-    void saveToDisk(const string& fName);
-
-private:
-    void readFromDisk(const string& fName);
+    void saveToDisk();
 
 private:
     shared_ptr<spdlog::logger> logger;
-
-    unique_ptr<uint32_t[]> headers;
-    uint32_t size;
+    unique_ptr<InMemDiskArray<list_header_t>> headers;
 };
 
 } // namespace storage

--- a/src/storage/storage_structure/include/lists/lists_metadata.h
+++ b/src/storage/storage_structure/include/lists/lists_metadata.h
@@ -36,13 +36,13 @@ public:
     // pageIdx in a disk file.
     inline std::function<uint32_t(uint32_t)> getPageMapperForChunkIdx(uint32_t chunkIdx) {
         return getLogicalToPhysicalPageMapper(
-            chunkPageLists.get(), chunkToPageListHeadIdxMap[chunkIdx], chunkIdx);
+            chunkPageLists.get(), chunkToPageListHeadIdxMap[chunkIdx]);
     }
     // Returns a function that can map the logical pageIdx of a largeList to its corresponding
     // physical pageIdx in a disk file.
     inline std::function<uint32_t(uint32_t)> getPageMapperForLargeListIdx(uint32_t largeListIdx) {
-        return getLogicalToPhysicalPageMapper(largeListPageLists.get(),
-            largeListIdxToPageListHeadIdxMap[2 * largeListIdx], largeListIdx);
+        return getLogicalToPhysicalPageMapper(
+            largeListPageLists.get(), largeListIdxToPageListHeadIdxMap[2 * largeListIdx]);
     }
 
     void initChunkPageLists(uint32_t numChunks);
@@ -62,12 +62,12 @@ private:
     void readFromDisk(const string& fName);
 
     inline static std::function<uint32_t(uint32_t)> getLogicalToPhysicalPageMapper(
-        uint32_t* pageLists, uint32_t pageListsHead, uint32_t pageIdx) {
+        uint32_t* pageLists, uint32_t pageListsHead) {
         return bind(getPageIdxFromAPageList, pageLists, pageListsHead, placeholders::_1);
     }
 
     static uint64_t getPageIdxFromAPageList(
-        uint32_t* pageLists, uint32_t pageListHead, uint32_t pageIdx);
+        uint32_t* pageLists, uint32_t pageListHead, uint32_t logicalPageIdx);
 
     // Below functions are to be used only in the loader to create the ListsMetadata object
     // initially.

--- a/src/storage/storage_structure/lists/lists.cpp
+++ b/src/storage/storage_structure/lists/lists.cpp
@@ -30,7 +30,7 @@ ListInfo Lists::getListInfo(node_offset_t nodeOffset) {
 // a largeList, then the input to this function can be nodeOffset: 5 and largeListHandle containing
 // information about the last portion of v7's large list. Similarly, if nodeOffset is v3 and v3
 // has a small list then largeListHandle does not contain anything specific to v3 (it would likely
-// be containing information about the last portion of the last large list that was read.
+// be containing information about the last portion of the last large list that was read).
 void Lists::readValues(node_offset_t nodeOffset, const shared_ptr<ValueVector>& valueVector,
     const unique_ptr<LargeListHandle>& largeListHandle) {
     auto info = getListInfo(nodeOffset);

--- a/src/storage/storage_structure/lists/lists_metadata.cpp
+++ b/src/storage/storage_structure/lists/lists_metadata.cpp
@@ -73,13 +73,13 @@ void ListsMetadata::readFromDisk(const string& fName) {
 }
 
 uint64_t ListsMetadata::getPageIdxFromAPageList(
-    uint32_t* pageLists, uint32_t pageListHeadIdx, uint32_t pageIdx) {
+    uint32_t* pageLists, uint32_t pageListHeadIdx, uint32_t logicalPageIdx) {
     auto pageListGroupHeadIdx = pageListHeadIdx;
-    while (PAGE_LIST_GROUP_SIZE <= pageIdx) {
+    while (PAGE_LIST_GROUP_SIZE <= logicalPageIdx) {
         pageListGroupHeadIdx = pageLists[pageListGroupHeadIdx + PAGE_LIST_GROUP_SIZE];
-        pageIdx -= PAGE_LIST_GROUP_SIZE;
+        logicalPageIdx -= PAGE_LIST_GROUP_SIZE;
     }
-    return pageLists[pageListGroupHeadIdx + pageIdx];
+    return pageLists[pageListGroupHeadIdx + logicalPageIdx];
 }
 
 void ListsMetadata::initChunkPageLists(uint32_t numChunks_) {

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -31,5 +31,9 @@ uint32_t StorageUtils::readListOfIntsFromFile(unique_ptr<uint32_t[]>& data, cons
     return listSize;
 }
 
+uint64_t StorageUtils::all1sMaskForLeastSignificantBits(uint64_t numBits) {
+    assert(numBits <= 64);
+    return numBits == 64 ? UINT64_MAX : (1l << numBits) - 1;
+}
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/store/nodes_metadata.cpp
+++ b/src/storage/store/nodes_metadata.cpp
@@ -206,7 +206,7 @@ void NodeMetadata::commitIfNecessary() {
     if (!hasUpdates()) {
         return;
     }
-    nodeOffsetsInfoForReadOnlyTrx = make_unique<NodeOffsetsInfo>(*nodeOffsetsInfoForWriteTrx);
+    nodeOffsetsInfoForReadOnlyTrx = move(nodeOffsetsInfoForWriteTrx);
 }
 
 NodesMetadata::NodesMetadata(const string& directory) {

--- a/src/storage/wal/include/wal_record.h
+++ b/src/storage/wal/include/wal_record.h
@@ -71,6 +71,7 @@ struct StorageStructureID {
         label_t nodeLabel, uint32_t propertyID) {
         return newStructuredNodePropertyColumnID(nodeLabel, propertyID, false /* is main file */);
     }
+
     inline static StorageStructureID newStructuredNodePropertyColumnOverflowPagesID(
         label_t nodeLabel, uint32_t propertyID) {
         return newStructuredNodePropertyColumnID(

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -31,7 +31,7 @@ public:
 
     node_offset_t addNode() {
         // TODO(Guodong/Semih/Xiyang): Currently it is not clear when and from where the hash index,
-        // structured columns, unstructured property lists, ha adjacency lists, and adj columns of a
+        // structured columns, unstructured property lists, adjacency lists, and adj columns of a
         // newly added node should be informed that a new node is being inserted, so these data
         // structures either write values or NULLs or empty lists etc. Within the scope of these
         // tests we only have an ID column and we are manually from outside NodesMetadata adding


### PR DESCRIPTION
This is a baby step towards making lists update-able. Implements a BaseDiskArray and InMemDiskArray classes.

- InMemDiskArray: stores an array of data backed by a file on disk. This will be improved with functions that make it easy to update these arrays transactionally. Stores the array in memory as a sequence of pages instead of a large array. If we think this affects any performance critical part, we can store it in larger chunks (e.g., 2MB). Currently replaces the headers field of ListHeaders (which was a vanilla C++ array) without changing the ListHeaders class at all.

- BaseDiskArray: This is the subclass of InMemDiskArray and is meant to be used by other storage structures, e.g., HashIndex, which does not store its pages in memory. But it can still benefit from the yet-to-be-implemented infrastructure to update disk arrays transactionally.

In my next PR, I will replace several arrays in listsmetadata with InMemDiskArray. After a few such small PRs, my plan is to coalesce all list files into a single .lists file (instead of the 6 7 files we have now).

Also squeezes in an unrelated minor change in commitIfNecessary function in NodeMetadata, which was not releasing the nodeOffsetsInfoForWriteTrx. This was not creating a bug but would unnecessarily keep a duplicate version of the readVersion when there is no transactions. This was not the intended use.