### PR TITLE
refactor ft

### DIFF
--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -33,7 +33,7 @@ public:
     inline void setMayContainNulls() { nullMask->setMayContainNulls(); }
     // Note that if this function returns true, there are no null. However if it returns false, it
     // doesn't mean there are nulls, i.e., there may or may not be nulls.
-    inline bool hasNoNullsGuarantee() {
+    inline bool hasNoNullsGuarantee() const {
         // This function should not be used for flat values. For flat values, the null value
         // of the value should be checked directly.
         assert(!state->isFlat());

--- a/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/aggregate_hash_table.h
@@ -92,7 +92,7 @@ private:
 
     inline void fillEntryWithNullMap(uint8_t* entryNullBuffer, uint8_t* groupByKeyNullBuffer) {
         memcpy(entryNullBuffer, groupByKeyNullBuffer,
-            factorizedTable->getTableSchema().getNumBytesForNullMap());
+            factorizedTable->getTableSchema()->getNumBytesForNullMap());
     }
 
     void initializeFT(const vector<unique_ptr<AggregateFunction>>& aggregateFunctions);

--- a/src/processor/include/physical_plan/hash_table/join_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/join_hash_table.h
@@ -13,7 +13,8 @@ namespace processor {
 
 class JoinHashTable : public BaseHashTable {
 public:
-    JoinHashTable(MemoryManager& memoryManager, uint64_t numTuples, TableSchema& tableSchema);
+    JoinHashTable(
+        MemoryManager& memoryManager, uint64_t numTuples, unique_ptr<TableSchema> tableSchema);
 
     template<class T>
     uint8_t** findHashEntry(T value) const {

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -21,7 +21,8 @@ namespace processor {
 // task/pipeline, and probed by the HashJoinProbe operators.
 class HashJoinSharedState {
 public:
-    void initEmptyHashTableIfNecessary(MemoryManager& memoryManager, TableSchema& tableSchema);
+    void initEmptyHashTableIfNecessary(
+        MemoryManager& memoryManager, unique_ptr<TableSchema> tableSchema);
 
     void mergeLocalFactorizedTable(FactorizedTable& factorizedTable);
 

--- a/src/processor/include/physical_plan/operator/result_collector.h
+++ b/src/processor/include/physical_plan/operator/result_collector.h
@@ -18,7 +18,7 @@ struct FTableScanMorsel {
 
 class FTableSharedState {
 public:
-    void initTableIfNecessary(MemoryManager* memoryManager, const TableSchema& tableSchema);
+    void initTableIfNecessary(MemoryManager* memoryManager, unique_ptr<TableSchema> tableSchema);
 
     inline void mergeLocalTable(FactorizedTable& localTable) {
         lock_guard<mutex> lck{mtx};

--- a/src/processor/physical_plan/hash_table/join_hash_table.cpp
+++ b/src/processor/physical_plan/hash_table/join_hash_table.cpp
@@ -4,7 +4,7 @@ namespace graphflow {
 namespace processor {
 
 JoinHashTable::JoinHashTable(
-    MemoryManager& memoryManager, uint64_t numTuples, TableSchema& tableSchema)
+    MemoryManager& memoryManager, uint64_t numTuples, unique_ptr<TableSchema> tableSchema)
     : BaseHashTable{memoryManager} {
     maxNumHashSlots = HashTableUtils::nextPowerOfTwo(numTuples * 2);
     bitMask = maxNumHashSlots - 1;
@@ -14,7 +14,7 @@ JoinHashTable::JoinHashTable(
     for (auto i = 0u; i < numBlocks; i++) {
         hashSlotsBlocks.emplace_back(make_unique<DataBlock>(&memoryManager));
     }
-    factorizedTable = make_unique<FactorizedTable>(&memoryManager, tableSchema);
+    factorizedTable = make_unique<FactorizedTable>(&memoryManager, move(tableSchema));
 }
 
 void JoinHashTable::allocateHashSlots(uint64_t numTuples) {

--- a/src/processor/physical_plan/operator/aggregate/hash_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/hash_aggregate_scan.cpp
@@ -29,7 +29,7 @@ bool HashAggregateScan::getNextTuples() {
         groupByKeyVectors, startOffset, numRowsToScan, groupByKeyVectorsColIdxes);
     for (auto pos = 0u; pos < numRowsToScan; ++pos) {
         auto entry = sharedState->getRow(startOffset + pos);
-        auto offset = sharedState->getFactorizedTable()->getTableSchema().getColOffset(
+        auto offset = sharedState->getFactorizedTable()->getTableSchema()->getColOffset(
             groupByKeyVectors.size());
         for (auto& vector : aggregateVectors) {
             auto aggState = (AggregateState*)(entry + offset);

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -57,9 +57,10 @@ void HashJoinProbe::getNextBatchOfMatchedTuples() {
             auto nodeID = *(nodeID_t*)probeState->probedTuple;
             probeState->matchedTuples[probeState->numMatchedTuples] = probeState->probedTuple;
             probeState->numMatchedTuples += nodeID == probeState->probeSideKeyNodeID;
-            probeState->probedTuple = *(
-                uint8_t**)(probeState->probedTuple +
-                           factorizedTable->getTableSchema().getNullMapOffset() - sizeof(uint8_t*));
+            probeState->probedTuple =
+                *(uint8_t**)(probeState->probedTuple +
+                             factorizedTable->getTableSchema()->getNullMapOffset() -
+                             sizeof(uint8_t*));
         }
     } while (probeState->numMatchedTuples == 0);
 }

--- a/test/processor/physical_plan/hash_table/join_hash_table_test.cpp
+++ b/test/processor/physical_plan/hash_table/join_hash_table_test.cpp
@@ -9,19 +9,21 @@ class HashTableTest : public ::testing::Test {
     void SetUp() override {
         bufferManager = make_unique<BufferManager>();
         memoryManager = make_unique<MemoryManager>(bufferManager.get());
-        tableSchema.appendColumn({false /* isUnflat */, 0 /* dataChunkPos */, sizeof(int64_t)});
+        tableSchema = make_unique<TableSchema>();
+        tableSchema->appendColumn(
+            make_unique<ColumnSchema>(false /* isUnflat */, 0 /* dataChunkPos */, sizeof(int64_t)));
     }
 
 public:
     unique_ptr<BufferManager> bufferManager;
     unique_ptr<MemoryManager> memoryManager;
-    TableSchema tableSchema;
+    unique_ptr<TableSchema> tableSchema;
 };
 
 TEST_F(HashTableTest, HashTableInsertionAndLookupTest) {
     const auto numTuples = 5ul;
 
-    JoinHashTable hashTable(*memoryManager, numTuples, tableSchema);
+    JoinHashTable hashTable(*memoryManager, numTuples, make_unique<TableSchema>(*tableSchema));
     int64_t values[numTuples] = {7, 20, 46, 3, 5};
     for (auto i = 0u; i < numTuples; i++) {
         hashTable.insertEntry<int64_t>((uint8_t*)(values + i));
@@ -33,7 +35,7 @@ TEST_F(HashTableTest, HashTableInsertionAndLookupTest) {
 
 TEST_F(HashTableTest, HashTableCollisionChainingTest) {
     const auto numTuples = 3ul;
-    JoinHashTable hashTable(*memoryManager, numTuples, tableSchema);
+    JoinHashTable hashTable(*memoryManager, numTuples, make_unique<TableSchema>(*tableSchema));
     // The three sevens will cause a collision in the hashTable. After inserting all the values
     // to hashTable, the corresponding slot should only store a single pointer to the last 7.
     int64_t values[numTuples] = {7, 7, 7};


### PR DESCRIPTION
1. Adds the noNullGuarantee(which is very similar to the one is valueVector) to factorizedTable.
3. Uses tight loop and hasNoNull quick path in `append` and `scan` functions of factorizedTable.
4. Refactors OrderByEncoder to use tightloop and hasNoNull quick path.
5. Refactors factorizedTable API.