### PR TITLE
Refactoring Diskarray files, ListsMetadata, and ListHeaders into builder and for regular system execution classes

### DIFF
--- a/src/loader/in_mem_builder/in_mem_node_builder.cpp
+++ b/src/loader/in_mem_builder/in_mem_node_builder.cpp
@@ -224,19 +224,19 @@ void InMemNodeBuilder::calcUnstrListsHeadersAndMetadata() {
     if (unstrPropertyLists == nullptr) {
         return;
     }
-    logger->debug("Initializing UnstructuredPropertyListHeaders.");
+    logger->debug("Initializing UnstructuredPropertyListHeaderBuilders.");
     progressBar->addAndStartNewJob("Calculating lists headers for node: " + labelName, 1);
     taskScheduler.scheduleTask(LoaderTaskFactory::createLoaderTask(calculateListHeadersTask,
-        numNodes, 1, unstrPropertyLists->getListSizes(), unstrPropertyLists->getListHeaders(),
-        logger, progressBar));
+        numNodes, 1, unstrPropertyLists->getListSizes(),
+        unstrPropertyLists->getListHeadersBuilder(), logger, progressBar));
     logger->debug("Done initializing UnstructuredPropertyListHeaders.");
     taskScheduler.waitAllTasksToCompleteOrError();
     logger->debug("Initializing UnstructuredPropertyListsMetadata.");
     progressBar->addAndStartNewJob("Calculating lists metadata for node: " + labelName, 1);
-    taskScheduler.scheduleTask(
-        LoaderTaskFactory::createLoaderTask(calculateListsMetadataAndAllocateInMemListPagesTask,
-            numNodes, 1, unstrPropertyLists->getListSizes(), unstrPropertyLists->getListHeaders(),
-            unstrPropertyLists.get(), false /*hasNULLBytes*/, logger, progressBar));
+    taskScheduler.scheduleTask(LoaderTaskFactory::createLoaderTask(
+        calculateListsMetadataAndAllocateInMemListPagesTask, numNodes, 1,
+        unstrPropertyLists->getListSizes(), unstrPropertyLists->getListHeadersBuilder(),
+        unstrPropertyLists.get(), false /*hasNULLBytes*/, logger, progressBar));
     logger->debug("Done initializing UnstructuredPropertyListsMetadata.");
     taskScheduler.waitAllTasksToCompleteOrError();
 }
@@ -368,8 +368,8 @@ void InMemNodeBuilder::putUnstrPropsOfALineToLists(CSVReader& reader, node_offse
         auto reversePos = InMemListsUtils::decrementListSize(*unstrPropertyLists->getListSizes(),
             nodeOffset, UnstructuredPropertyLists::UNSTR_PROP_HEADER_LEN + dataTypeSize);
         PageElementCursor pageElementCursor = InMemListsUtils::calcPageElementCursor(
-            unstrPropertyLists->getListHeaders()->getHeader(nodeOffset), reversePos, 1, nodeOffset,
-            *unstrPropertyLists->getListsMetadata(), false /*hasNULLBytes*/);
+            unstrPropertyLists->getListHeadersBuilder()->getHeader(nodeOffset), reversePos, 1,
+            nodeOffset, *unstrPropertyLists->getListsMetadataBuilder(), false /*hasNULLBytes*/);
         PageByteCursor pageCursor{pageElementCursor.pageIdx, pageElementCursor.posInPage};
         char* valuePtr = unstrPropertyStringBreaker2 + 1;
         switch (dataType.typeID) {

--- a/src/loader/in_mem_builder/include/in_mem_structures_builder.h
+++ b/src/loader/in_mem_builder/include/in_mem_structures_builder.h
@@ -34,21 +34,21 @@ protected:
         const string& filePath, vector<PropertyNameDataType>& colDefinitions);
 
     // Concurrent tasks
-    // Initializes (in listHeaders) the header of each list in a Lists structure, from the
+    // Initializes (in listHeadersBuilder) the header of each list in a Lists structure, from the
     // listSizes. ListSizes is used to determine if the list is small or large, based on which,
     // information is encoded in the 4 byte header.
     static void calculateListHeadersTask(node_offset_t numNodes, uint32_t elementSize,
-        atomic_uint64_vec_t* listSizes, ListHeaders* listHeaders,
+        atomic_uint64_vec_t* listSizes, ListHeadersBuilder* listHeadersBuilder,
         const shared_ptr<spdlog::logger>& logger, LoaderProgressBar* progressBar);
     // Initializes Metadata information of a Lists structure, that is chunksPagesMap and
-    // largeListsPagesMap, using listSizes and listHeaders.
+    // largeListsPagesMap, using listSizes and listHeadersBuilder.
     // **Note that this file also allocates the in-memory pages of the InMemFile that will actually
     // stores the data in the lists (e.g., neighbor ids or edge properties or unstructured
     // properties).
     static void calculateListsMetadataAndAllocateInMemListPagesTask(uint64_t numNodes,
-        uint32_t elementSize, atomic_uint64_vec_t* listSizes, ListHeaders* listHeaders,
-        InMemLists* inMemList, bool hasNULLBytes, const shared_ptr<spdlog::logger>& logger,
-        LoaderProgressBar* progressBar);
+        uint32_t elementSize, atomic_uint64_vec_t* listSizes,
+        ListHeadersBuilder* listHeadersBuilder, InMemLists* inMemList, bool hasNULLBytes,
+        const shared_ptr<spdlog::logger>& logger, LoaderProgressBar* progressBar);
 
 private:
     vector<PropertyNameDataType> parseCSVFileHeader(string& header) const;

--- a/src/loader/in_mem_storage_structure/BUILD.bazel
+++ b/src/loader/in_mem_storage_structure/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/storage/buffer_manager:file_handle",
         "//src/storage:compression_scheme",
         "//src/storage:storage_utils",
     ],

--- a/src/storage/buffer_manager/BUILD.bazel
+++ b/src/storage/buffer_manager/BUILD.bazel
@@ -3,10 +3,12 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 cc_library(
     name = "file_handle",
     srcs = [
+        "disk_array.cpp",
         "file_handle.cpp",
         "versioned_file_handle.cpp",
     ],
     hdrs = [
+        "include/disk_array.h",
         "include/file_handle.h",
         "include/versioned_file_handle.h",
     ],

--- a/src/storage/buffer_manager/include/disk_array.h
+++ b/src/storage/buffer_manager/include/disk_array.h
@@ -2,10 +2,15 @@
 
 #include <iostream>
 
-#include "src/storage/buffer_manager/include/versioned_file_handle.h"
+#include "src/common/include/configs.h"
+#include "src/common/types/include/types.h"
+
+using namespace graphflow::common;
 
 namespace graphflow {
 namespace storage {
+
+class FileHandle;
 
 static constexpr uint64_t NUM_PAGE_IDXS_PER_PIP =
     (DEFAULT_PAGE_SIZE - sizeof(page_idx_t)) / sizeof(page_idx_t);
@@ -50,9 +55,7 @@ struct PIP {
 };
 
 struct PIPWrapper {
-    PIPWrapper(FileHandle& fileHandle, page_idx_t pipPageIdx) : pipPageIdx(pipPageIdx) {
-        fileHandle.readPage(reinterpret_cast<uint8_t*>(&pipContents), pipPageIdx);
-    }
+    PIPWrapper(FileHandle& fileHandle, page_idx_t pipPageIdx);
 
     PIPWrapper(page_idx_t pipPageIdx) : pipPageIdx(pipPageIdx) {}
 
@@ -79,33 +82,16 @@ struct PIPWrapper {
  */
 class BaseDiskArray {
 public:
-    // Every DiskArray needs to have a pre-allocated header page, so we can know where to start to
-    // read the array (its pips and array pages).
-    BaseDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx, uint64_t elementSize,
-        uint64_t numElements);
-
+    // Used by builders
+    BaseDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx, uint64_t elementSize);
+    // Used when loading from file
     BaseDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx);
-
-    virtual ~BaseDiskArray() {}
-
-    void setNumElementsAndAllocateDiskArrayPagesForBuilding(uint64_t newNumElements);
 
     // This function does division and mod and should not be used in performance critical code
     page_idx_t getArrayFilePageIdx(page_idx_t arrayPageIdx);
 
-    virtual void saveToDisk();
-
     // TODO(Semih): This is only for debugging purposes. Will be removed.
     void print();
-
-protected:
-    void addNewArrayPageForBuilding();
-
-private:
-    inline uint64_t getNumArrayPagesNeededForElements(uint64_t numElements) {
-        return (numElements >> header.numElementsPerPageLog2) +
-               ((numElements & header.elementPageOffsetMask) > 0 ? 1 : 0);
-    }
 
 public:
     DiskArrayHeader header;
@@ -116,38 +102,60 @@ protected:
     vector<PIPWrapper> pips;
 };
 
+template<class U>
+class BaseInMemDiskArray : public BaseDiskArray {
+protected:
+    BaseInMemDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx, uint64_t elementSize);
+    BaseInMemDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx);
+
+public:
+    // [] operator to be used when building an InMemDiskArrayBuilder without transactional updates.
+    // This changes the contents directly in memory and not on disk (nor on the wal)
+    U& operator[](uint64_t idx);
+
+    // TODO(Semih): This is only for debugging purposes. Will be removed.
+    void print();
+
+protected:
+    void addInMemoryPage() {
+        dataPages.emplace_back(make_unique<U[]>(1ull << header.numElementsPerPageLog2));
+    }
+
+protected:
+    vector<unique_ptr<U[]>> dataPages;
+};
+
 /**
  * Stores an array of type U's page by page in memory, using OS memory and not the buffer manager.
  * Designed currently to be used by lists headers and metadata, where we want to avoid using
  * pins/unpins when accessing data through the buffer manager.
  */
-template<class U>
-class InMemDiskArray : public BaseDiskArray {
+template<typename T>
+class InMemDiskArray : public BaseInMemDiskArray<T> {
 public:
-    InMemDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx, uint64_t numElements);
-
     InMemDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx);
+};
 
-    // [] operator to be used when building an InMemDiskArray without transactional updates. This
-    // changes the contents directly in memory and not on disk (nor on the wal)
-    U& operator[](uint64_t idx);
+template<typename T>
+class InMemDiskArrayBuilder : public BaseInMemDiskArray<T> {
+public:
+    InMemDiskArrayBuilder(FileHandle& fileHandle, page_idx_t headerPageIdx, uint64_t numElements);
 
-    void saveToDisk() override;
     // This function is designed to be used during building of a disk array, i.e., during loading.
     // In particular, it changes the needed capacity non-transactionally, i.e., without writing
     // anything to the wal.
     void setNewNumElementsAndIncreaseCapacityIfNeeded(uint64_t newNumElements);
 
-    // TODO(Semih): This is only for debugging purposes. Will be removed.
-    void print();
+    void saveToDisk();
 
 private:
-    void addInMemoryPage() {
-        dataPages.emplace_back(make_unique<U[]>(1ull << header.numElementsPerPageLog2));
+    inline uint64_t getNumArrayPagesNeededForElements(uint64_t numElements) {
+        return (numElements >> this->header.numElementsPerPageLog2) +
+               ((numElements & this->header.elementPageOffsetMask) > 0 ? 1 : 0);
     }
+    void addNewArrayPageForBuilding();
 
-private:
-    vector<unique_ptr<U[]>> dataPages;
+    void setNumElementsAndAllocateDiskArrayPagesForBuilding(uint64_t newNumElements);
 };
 
 } // namespace storage

--- a/src/storage/buffer_manager/include/versioned_file_handle.h
+++ b/src/storage/buffer_manager/include/versioned_file_handle.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "file_handle.h"
+
 #include "src/common/include/configs.h"
 #include "src/storage/buffer_manager/include/file_handle.h"
 #include "src/storage/include/storage_utils.h"

--- a/src/storage/storage_structure/BUILD.bazel
+++ b/src/storage/storage_structure/BUILD.bazel
@@ -1,18 +1,3 @@
-load("@rules_cc//cc:defs.bzl", "cc_library")
-cc_library(
-    name = "disk_array",
-    srcs = [
-        "disk_array.cpp",
-    ],
-    hdrs = [
-        "include/disk_array.h",
-    ],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//src/storage/buffer_manager:file_handle",
-    ],
-)
-
 cc_library(
     name = "storage_structure",
     srcs = [
@@ -26,7 +11,6 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
     deps = [
-        "disk_array",
         "//src/common:vector",
         "//src/storage:compression_scheme",
         "//src/storage:storage_utils",

--- a/src/storage/storage_structure/include/lists/lists.h
+++ b/src/storage/storage_structure/include/lists/lists.h
@@ -57,7 +57,7 @@ protected:
         shared_ptr<ListHeaders> headers, BufferManager& bufferManager, bool hasNULLBytes,
         bool isInMemory)
         : BaseColumnOrList{fName, dataType, elementSize, bufferManager, hasNULLBytes, isInMemory},
-          metadata{fName, false /* is not for building */}, headers(move(headers)){};
+          metadata{fName}, headers(move(headers)){};
 
     virtual void readFromLargeList(const shared_ptr<ValueVector>& valueVector,
         const unique_ptr<LargeListHandle>& largeListHandle, ListInfo& info);

--- a/src/storage/storage_structure/include/lists/lists_metadata.h
+++ b/src/storage/storage_structure/include/lists/lists_metadata.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "src/storage/storage_structure/include/disk_array.h"
+#include "src/storage/buffer_manager/include/disk_array.h"
 #include "src/storage/storage_structure/include/storage_structure.h"
 
 using namespace std;
@@ -19,28 +19,47 @@ class LoaderEmptyListsTest;
 namespace graphflow {
 namespace storage {
 
-/**
- * Lists Metadata holds the information necessary to locate a list in the collection of disk pages
- * that organizes and stores {@class Lists} data structure. Each object of Lists requires
- * ListsMetadata object that helps in locating.
- *
- * The Mapper functions (called, logicalToPhysicalPageMappers) of this class maps the logical
- * location of the list to the actual physical location in disk pages.
- */
-class ListsMetadata {
-    friend class graphflow::loader::LoaderEmptyListsTest;
+class BaseListsMetadata {
 
+public:
     static constexpr uint64_t CHUNK_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX = 0;
     static constexpr uint64_t LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX = 1;
     static constexpr uint64_t CHUNK_PAGE_LIST_HEADER_PAGE_IDX = 2;
+    // All pageLists (defined later) are broken in pieces (called a pageListGroups) of size
+    // PAGE_LIST_GROUP_SIZE + 1 each and chained together. In each piece, there are
+    // PAGE_LIST_GROUP_SIZE elements of that list and the offset to the next pageListGroups in the
+    // blob that contains all pageListGroups of all lists.
+    static constexpr uint32_t PAGE_LIST_GROUP_SIZE = 3;
+    static constexpr uint32_t PAGE_LIST_GROUP_WITH_NEXT_PTR_SIZE = PAGE_LIST_GROUP_SIZE + 1;
+
+    explicit BaseListsMetadata(const string& listBaseFName) {
+        metadataFileHandle = make_unique<FileHandle>(
+            listBaseFName + ".metadata", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
+        logger = LoggerUtils::getOrCreateSpdLogger("storage");
+    }
+
+    inline static std::function<uint32_t(uint32_t)> getLogicalToPhysicalPageMapper(
+        BaseInMemDiskArray<page_idx_t>* pageLists, uint32_t pageListsHead) {
+        return bind(getPageIdxFromAPageList, pageLists, pageListsHead, placeholders::_1);
+    }
+
+    static uint64_t getPageIdxFromAPageList(
+        BaseInMemDiskArray<page_idx_t>* pageLists, uint32_t pageListHead, uint32_t logicalPageIdx);
+
+protected:
+    shared_ptr<spdlog::logger> logger;
+    unique_ptr<FileHandle> metadataFileHandle;
+};
+
+class ListsMetadata : public BaseListsMetadata {
+    friend class graphflow::loader::LoaderEmptyListsTest;
 
 public:
-    explicit ListsMetadata(const string& listBaseFName, bool isForBuilding);
+    explicit ListsMetadata(const string& listBaseFName);
 
     inline uint64_t getNumElementsInLargeLists(uint64_t largeListIdx) {
         return (*largeListIdxToPageListHeadIdxMap)[(2 * largeListIdx) + 1];
     };
-
     // Returns a function that can map the logical pageIdx of a chunk ito its corresponding physical
     // pageIdx in a disk file.
     inline std::function<uint32_t(uint32_t)> getPageMapperForChunkIdx(uint32_t chunkIdx) {
@@ -54,6 +73,55 @@ public:
             pageLists.get(), (*largeListIdxToPageListHeadIdxMap)[2 * largeListIdx]);
     }
 
+private:
+    // chunkToPageListHeadIdxMapBuilder holds pointers to the head of pageList of each chunk.
+    // For instance, chunkToPageListHeadIdxMapBuilder[3] is a pointer in `pageLists` from where
+    // the pageList of chunk 3 begins.
+    unique_ptr<InMemDiskArray<uint32_t>> chunkToPageListHeadIdxMap;
+    // largeListIdxToPageListHeadIdxMapBuilder is similar to chunkToPageListHeadIdxMapBuilder
+    // in the sense that it too holds pointers to the head of pageList of each large list. Along
+    // with the pointer, this also stores the size of the large list adjacent to the pointer. For
+    // instance, the pointer of the head of pageList for largeList 3 is at
+    // largeListIdxToPageListHeadIdxMapBuilder[2
+    // * 3] and the size is at largeListIdxToPageListHeadIdxMapBuilder[(2 * 3) + 1].
+    unique_ptr<InMemDiskArray<uint32_t>> largeListIdxToPageListHeadIdxMap;
+    // pageLists is a blob that contains the pageList of each chunk. Each pageList is broken
+    // into smaller list group of size PAGE_LIST_GROUP_SIZE and chained together. List group may
+    // not be contiguous and requires pointer chasing to read the required physical pageId from the
+    // list. pageLists is used both to store the list of pages for large lists as well as small
+    // lists of each chunk.
+    unique_ptr<InMemDiskArray<page_idx_t>> pageLists;
+};
+
+/**
+ * Lists Metadata holds the information necessary to locate a list in the collection of disk pages
+ * that organizes and stores {@class Lists} data structure. Each object of Lists requires
+ * ListsMetadata object that helps in locating.
+ *
+ * The Mapper functions (called, logicalToPhysicalPageMappers) of this class maps the logical
+ * location of the list to the actual physical location in disk pages.
+ */
+class ListsMetadataBuilder : public BaseListsMetadata {
+
+public:
+    explicit ListsMetadataBuilder(const string& listBaseFName);
+
+    inline uint64_t getNumElementsInLargeLists(uint64_t largeListIdx) {
+        return (*largeListIdxToPageListHeadIdxMapBuilder)[(2 * largeListIdx) + 1];
+    };
+
+    // Returns a function that can map the logical pageIdx of a chunk ito its corresponding physical
+    // pageIdx in a disk file.
+    inline std::function<uint32_t(uint32_t)> getPageMapperForChunkIdx(uint32_t chunkIdx) {
+        return getLogicalToPhysicalPageMapper(
+            pageListsBuilder.get(), (*chunkToPageListHeadIdxMapBuilder)[chunkIdx]);
+    }
+    // Returns a function that can map the logical pageIdx of a largeList to its corresponding
+    // physical pageIdx in a disk file.
+    inline std::function<uint32_t(uint32_t)> getPageMapperForLargeListIdx(uint32_t largeListIdx) {
+        return getLogicalToPhysicalPageMapper(
+            pageListsBuilder.get(), (*largeListIdxToPageListHeadIdxMapBuilder)[2 * largeListIdx]);
+    }
     void initChunkPageLists(uint32_t numChunks);
     void initLargeListPageLists(uint32_t numLargeLists);
 
@@ -68,50 +136,14 @@ public:
     void saveToDisk();
 
 private:
-    void readFromDisk(const string& fName);
-
-    inline static std::function<uint32_t(uint32_t)> getLogicalToPhysicalPageMapper(
-        InMemDiskArray<page_idx_t>* pageLists, uint32_t pageListsHead) {
-        return bind(getPageIdxFromAPageList, pageLists, pageListsHead, placeholders::_1);
-    }
-
-    static uint64_t getPageIdxFromAPageList(
-        InMemDiskArray<page_idx_t>* pageLists, uint32_t pageListHead, uint32_t logicalPageIdx);
-
-    // Below functions are to be used only in the loader to create the ListsMetadata object
-    // initially.
-
     // Creates a new pageList (in pageListGroups of size 3) by enumerating the pageIds sequentially
     // in the list, starting from `startPageId` till `startPageId + numPages - 1`.
     void populatePageIdsInAPageList(uint32_t numPages, uint32_t startPageId);
 
-public:
-    // All pageLists (defined later) are broken in pieces (called a pageListGroups) of size
-    // PAGE_LIST_GROUP_SIZE + 1 each and chained together. In each piece, there are
-    // PAGE_LIST_GROUP_SIZE elements of that list and the offset to the next pageListGroups in the
-    // blob that contains all pageListGroups of all lists.
-    static constexpr uint32_t PAGE_LIST_GROUP_SIZE = 3;
-    static constexpr uint32_t PAGE_LIST_GROUP_WITH_NEXT_PTR_SIZE = PAGE_LIST_GROUP_SIZE + 1;
-
 private:
-    shared_ptr<spdlog::logger> logger;
-    unique_ptr<FileHandle> metadataFileHandle;
-    // chunkToPageListHeadIdxMap holds pointers to the head of pageList of each chunk. For instance,
-    // chunkToPageListHeadIdxMap[3] is a pointer in `pageLists` from where the pageList of
-    // chunk 3 begins.
-    unique_ptr<InMemDiskArray<uint32_t>> chunkToPageListHeadIdxMap;
-    // largeListIdxToPageListHeadIdxMap is similar to chunkToPageListHeadIdxMap in the sense that it
-    // too holds pointers to the head of pageList of each large list. Along with the pointer, this
-    // also stores the size of the large list adjacent to the pointer. For instance, the pointer of
-    // the head of pageList for largeList 3 is at largeListIdxToPageListHeadIdxMap[2
-    // * 3] and the size is at largeListIdxToPageListHeadIdxMap[(2 * 3) + 1].
-    unique_ptr<InMemDiskArray<uint32_t>> largeListIdxToPageListHeadIdxMap;
-    // pageLists is a blob that contains the pageList of each chunk. Each pageList is broken
-    // into smaller list group of size PAGE_LIST_GROUP_SIZE and chained together. List group may
-    // not be contiguous and requires pointer chasing to read the required physical pageId from the
-    // list. pageLists is used both to store the list of pages for large lists as well as small
-    // lists of each chunk.
-    unique_ptr<InMemDiskArray<page_idx_t>> pageLists;
+    unique_ptr<InMemDiskArrayBuilder<uint32_t>> chunkToPageListHeadIdxMapBuilder;
+    unique_ptr<InMemDiskArrayBuilder<uint32_t>> largeListIdxToPageListHeadIdxMapBuilder;
+    unique_ptr<InMemDiskArrayBuilder<page_idx_t>> pageListsBuilder;
 };
 
 } // namespace storage

--- a/src/storage/storage_structure/lists/list_headers.cpp
+++ b/src/storage/storage_structure/lists/list_headers.cpp
@@ -7,29 +7,29 @@
 namespace graphflow {
 namespace storage {
 
-ListHeaders::ListHeaders(const string& fName, uint64_t numElements) {
+BaseListHeaders::BaseListHeaders(const string& fName) {
     logger = LoggerUtils::getOrCreateSpdLogger("storage");
     headersFileHandle = make_unique<FileHandle>(
         fName + ".headers", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
+}
+ListHeadersBuilder::ListHeadersBuilder(const string& fName, uint64_t numElements)
+    : BaseListHeaders(fName) {
     // DiskArray assumes that its header page already exists. To ensure that we need to add a page
     // to the fileHandle. Currently the header page is at page 0, so we add one page here.
     headersFileHandle->addNewPage();
-    headers = make_unique<InMemDiskArray<list_header_t>>(
+    headersBuilder = make_unique<InMemDiskArrayBuilder<list_header_t>>(
         *headersFileHandle, LIST_HEADERS_HEADER_PAGE_IDX, numElements);
 }
 
-ListHeaders::ListHeaders(const string& listBaseFName) {
-    logger = LoggerUtils::getOrCreateSpdLogger("storage");
-    headersFileHandle = make_unique<FileHandle>(
-        listBaseFName + ".headers", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
+void ListHeadersBuilder::saveToDisk() {
+    headersBuilder->saveToDisk();
+}
+
+ListHeaders::ListHeaders(const string& fName) : BaseListHeaders(fName) {
     headers = make_unique<InMemDiskArray<list_header_t>>(
         *headersFileHandle, LIST_HEADERS_HEADER_PAGE_IDX);
     logger->trace("ListHeaders: #numNodeOffsets {}", headers->header.numElements);
 };
-
-void ListHeaders::saveToDisk() {
-    headers->saveToDisk();
-}
 
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/storage_structure/lists/lists_metadata.cpp
+++ b/src/storage/storage_structure/lists/lists_metadata.cpp
@@ -8,43 +8,17 @@
 namespace graphflow {
 namespace storage {
 
-ListsMetadata::ListsMetadata(const string& listBaseFName, bool isForBuilding) {
-    metadataFileHandle = make_unique<FileHandle>(
-        listBaseFName + ".metadata", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
-    logger = LoggerUtils::getOrCreateSpdLogger("storage");
-    if (!isForBuilding) {
-        readFromDisk(listBaseFName);
-    } else {
-        // When building list metadata during loading, we need to make space for the header of each
-        // disk array in listsMetadata (so that these header pages are pre-allocated and not used
-        // for another purpose)
-        metadataFileHandle->addNewPage(); // CHUNK_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX=0
-        metadataFileHandle
-            ->addNewPage(); // LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX
-        metadataFileHandle->addNewPage(); // CHUNK_PAGE_LIST_HEADER_PAGE_IDX
-        // Initialize an empty page lists array for building
-        pageLists = make_unique<InMemDiskArray<page_idx_t>>(
-            *metadataFileHandle, CHUNK_PAGE_LIST_HEADER_PAGE_IDX, 0);
-    }
-}
-
-void ListsMetadata::saveToDisk() {
-    chunkToPageListHeadIdxMap->saveToDisk();
-    pageLists->saveToDisk();
-    largeListIdxToPageListHeadIdxMap->saveToDisk();
-}
-
-void ListsMetadata::readFromDisk(const string& fName) {
+ListsMetadata::ListsMetadata(const string& listBaseFName) : BaseListsMetadata(listBaseFName) {
     chunkToPageListHeadIdxMap = make_unique<InMemDiskArray<uint32_t>>(
         *metadataFileHandle, CHUNK_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX);
-    pageLists = make_unique<InMemDiskArray<page_idx_t>>(
-        *metadataFileHandle, CHUNK_PAGE_LIST_HEADER_PAGE_IDX);
     largeListIdxToPageListHeadIdxMap = make_unique<InMemDiskArray<uint32_t>>(
         *metadataFileHandle, LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX);
+    pageLists = make_unique<InMemDiskArray<page_idx_t>>(
+        *metadataFileHandle, CHUNK_PAGE_LIST_HEADER_PAGE_IDX);
 }
 
-uint64_t ListsMetadata::getPageIdxFromAPageList(
-    InMemDiskArray<page_idx_t>* pageLists, uint32_t pageListHead, uint32_t logicalPageIdx) {
+uint64_t BaseListsMetadata::getPageIdxFromAPageList(
+    BaseInMemDiskArray<page_idx_t>* pageLists, uint32_t pageListHead, uint32_t logicalPageIdx) {
     auto pageListGroupHeadIdx = pageListHead;
     while (PAGE_LIST_GROUP_SIZE <= logicalPageIdx) {
         pageListGroupHeadIdx = (*pageLists)[pageListGroupHeadIdx + PAGE_LIST_GROUP_SIZE];
@@ -53,44 +27,64 @@ uint64_t ListsMetadata::getPageIdxFromAPageList(
     return (*pageLists)[pageListGroupHeadIdx + logicalPageIdx];
 }
 
-void ListsMetadata::initChunkPageLists(uint32_t numChunks_) {
-    chunkToPageListHeadIdxMap = make_unique<InMemDiskArray<uint32_t>>(
+ListsMetadataBuilder::ListsMetadataBuilder(const string& listBaseFName)
+    : BaseListsMetadata(listBaseFName) {
+    // When building list metadata during loading, we need to make space for the header of each
+    // disk array in listsMetadata (so that these header pages are pre-allocated and not used
+    // for another purpose)
+    metadataFileHandle->addNewPage(); // CHUNK_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX=0
+    metadataFileHandle->addNewPage(); // LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX
+    metadataFileHandle->addNewPage(); // CHUNK_PAGE_LIST_HEADER_PAGE_IDX
+    // Initialize an empty page lists array for building
+    pageListsBuilder = make_unique<InMemDiskArrayBuilder<page_idx_t>>(
+        *metadataFileHandle, CHUNK_PAGE_LIST_HEADER_PAGE_IDX, 0);
+}
+
+void ListsMetadataBuilder::saveToDisk() {
+    chunkToPageListHeadIdxMapBuilder->saveToDisk();
+    largeListIdxToPageListHeadIdxMapBuilder->saveToDisk();
+    pageListsBuilder->saveToDisk();
+}
+
+void ListsMetadataBuilder::initChunkPageLists(uint32_t numChunks_) {
+    chunkToPageListHeadIdxMapBuilder = make_unique<InMemDiskArrayBuilder<uint32_t>>(
         *metadataFileHandle, CHUNK_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX, numChunks_);
     for (uint64_t chunkIdx = 0; chunkIdx < numChunks_; ++chunkIdx) {
-        (*chunkToPageListHeadIdxMap)[chunkIdx] = UINT32_MAX;
+        (*chunkToPageListHeadIdxMapBuilder)[chunkIdx] = UINT32_MAX;
     }
 }
 
-void ListsMetadata::initLargeListPageLists(uint32_t numLargeLists_) {
+void ListsMetadataBuilder::initLargeListPageLists(uint32_t numLargeLists_) {
     // For each largeList, we store the PageListHeadIdx in pageLists and also the number of elements
     // in the large list.
-    largeListIdxToPageListHeadIdxMap = make_unique<InMemDiskArray<uint32_t>>(*metadataFileHandle,
-        LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX, (2 * numLargeLists_));
+    largeListIdxToPageListHeadIdxMapBuilder =
+        make_unique<InMemDiskArrayBuilder<uint32_t>>(*metadataFileHandle,
+            LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX, (2 * numLargeLists_));
     for (uint64_t largeListIdx = 0; largeListIdx < numLargeLists_; ++largeListIdx) {
-        (*largeListIdxToPageListHeadIdxMap)[largeListIdx] = UINT32_MAX;
+        (*largeListIdxToPageListHeadIdxMapBuilder)[largeListIdx] = UINT32_MAX;
     }
 }
 
-void ListsMetadata::populateChunkPageList(
+void ListsMetadataBuilder::populateChunkPageList(
     uint32_t chunkId, uint32_t numPages_, uint32_t startPageId) {
     if (numPages_ == 0) {
         return;
     }
-    (*chunkToPageListHeadIdxMap)[chunkId] = pageLists->header.numElements;
+    (*chunkToPageListHeadIdxMapBuilder)[chunkId] = pageListsBuilder->header.numElements;
     populatePageIdsInAPageList(numPages_, startPageId);
 }
 
-void ListsMetadata::populateLargeListPageList(
+void ListsMetadataBuilder::populateLargeListPageList(
     uint32_t largeListIdx, uint32_t numPages_, uint32_t numElements, uint32_t startPageId) {
     cout << "populateLargeListPageList called. numPages_: " << numPages_ << endl;
     assert(numPages_ > 0);
     auto offsetInMap = 2 * largeListIdx;
-    (*largeListIdxToPageListHeadIdxMap)[offsetInMap] = pageLists->header.numElements;
-    (*largeListIdxToPageListHeadIdxMap)[offsetInMap + 1] = numElements;
+    (*largeListIdxToPageListHeadIdxMapBuilder)[offsetInMap] = pageListsBuilder->header.numElements;
+    (*largeListIdxToPageListHeadIdxMapBuilder)[offsetInMap + 1] = numElements;
     populatePageIdsInAPageList(numPages_, startPageId);
 }
 
-void ListsMetadata::populatePageIdsInAPageList(uint32_t numPages, uint32_t startPageId) {
+void ListsMetadataBuilder::populatePageIdsInAPageList(uint32_t numPages, uint32_t startPageId) {
     // calculate the number of pageListGroups to accommodate the pageList completely.
     auto numPageListGroups = numPages / PAGE_LIST_GROUP_SIZE;
     if (0 != numPages % PAGE_LIST_GROUP_SIZE) {
@@ -99,23 +93,23 @@ void ListsMetadata::populatePageIdsInAPageList(uint32_t numPages, uint32_t start
     // During the initial allocation, we allocate all the pageListGroups of a pageList contiguously.
     // pageListTailIdx is the id in the pageLists blob where the pageList ends and the next
     // pageLists should start.
-    uint32_t pageListHeadIdx = pageLists->header.numElements;
+    uint32_t pageListHeadIdx = pageListsBuilder->header.numElements;
     auto pageListTailIdx =
         pageListHeadIdx + ((PAGE_LIST_GROUP_WITH_NEXT_PTR_SIZE)*numPageListGroups);
-    pageLists->setNewNumElementsAndIncreaseCapacityIfNeeded(pageListTailIdx);
+    pageListsBuilder->setNewNumElementsAndIncreaseCapacityIfNeeded(pageListTailIdx);
     for (auto i = 0u; i < numPageListGroups; i++) {
         auto numPagesInThisGroup = min(PAGE_LIST_GROUP_SIZE, numPages);
         for (auto j = 0u; j < numPagesInThisGroup; j++) {
-            (*pageLists)[pageListHeadIdx + j] = startPageId++;
+            (*pageListsBuilder)[pageListHeadIdx + j] = startPageId++;
         }
         // if there are empty spots in the pageListGroup, put PAGE_IDX_MAX in them.
         for (auto j = numPagesInThisGroup; j < PAGE_LIST_GROUP_SIZE; j++) {
-            (*pageLists)[pageListHeadIdx + j] = PAGE_IDX_MAX;
+            (*pageListsBuilder)[pageListHeadIdx + j] = PAGE_IDX_MAX;
         }
         numPages -= numPagesInThisGroup;
         pageListHeadIdx += PAGE_LIST_GROUP_SIZE;
         // store the id to the next pageListGroup, if exists, other PAGE_IDX_MAX.
-        (*pageLists)[pageListHeadIdx] = (0 == numPages) ? PAGE_IDX_MAX : 1 + pageListHeadIdx;
+        (*pageListsBuilder)[pageListHeadIdx] = (0 == numPages) ? PAGE_IDX_MAX : 1 + pageListHeadIdx;
         pageListHeadIdx++;
     }
 }

--- a/test/loader/loader_test.cpp
+++ b/test/loader/loader_test.cpp
@@ -54,19 +54,23 @@ public:
         label_t pLabel = catalog.getNodeLabelFromName("person");
         auto unstrPropLists =
             database->getStorageManager()->getNodesStore().getNodeUnstrPropertyLists(pLabel);
+        unstrPropLists->metadata.chunkToPageListHeadIdxMap->header.print();
+        unstrPropLists->metadata.largeListIdxToPageListHeadIdxMap->header.print();
+        unstrPropLists->metadata.pageLists->header.print();
         // The vPerson table has 4 chunks (2000/512) and only nodeOffset=1030, which is in
-        // chunk idx 2 has a non-empty list. So chunk ids 0, 1, and 3's chunkToPageListHeadIdxMap
-        // need to point to UINT32_MAX (representing null), while chunk 2 should point to 0.
+        // chunk idx 2 has a non-empty list. So chunk ids 0, 1, and 3's
+        // chunkToPageListHeadIdxMap need to point to UINT32_MAX (representing null),
+        // while chunk 2 should point to 0.
         uint64_t numChunks = 4;
         EXPECT_EQ(
-            numChunks, unstrPropLists->metadata.chunkToPageListHeadIdxMap->header.elementSize);
+            numChunks, unstrPropLists->metadata.chunkToPageListHeadIdxMap->header.numElements);
         for (int chunkIdx = 0; chunkIdx < numChunks; chunkIdx++) {
             EXPECT_EQ(chunkIdx == 2 ? 0 : UINT32_MAX,
                 (*unstrPropLists->metadata.chunkToPageListHeadIdxMap)[chunkIdx]);
         }
         // Check chunk idx 2's pageLists.
         EXPECT_EQ(storage::ListsMetadata::PAGE_LIST_GROUP_WITH_NEXT_PTR_SIZE,
-            unstrPropLists->metadata.pageLists->header.elementSize);
+            unstrPropLists->metadata.pageLists->header.numElements);
         for (int chunkPageListIdx = 0;
              chunkPageListIdx < storage::ListsMetadata::PAGE_LIST_GROUP_WITH_NEXT_PTR_SIZE;
              ++chunkPageListIdx) {


### PR DESCRIPTION
This is a pure refactoring PR that refactors lists metadata and header into builder and for regular system execution (let's call this distinction Builder vs Normal). This creates some code duplication:
- DiskArray is broken into the following:
  - BaseDiskArray: This is the base class that stores the header and pips. This is its own class for now only because I expect HashIndex to use it. If this assumption ends up being wrong, we should merge it with BaseInMemDiskArray as it is never instantiated on its own. This is not separated into Builder vs Normal. Therefore this needs to have different constructors one to be used by Builder and by Normal. But there is no function that is only used by Builder or Normal.  
  - BaseInMemDiskArray : BaseDiskArray with a vector<unique_ptr<U[]>> dataPages; Similar to above, this one is not separated into Builder vs Normal but similarly also does not contain any function that is only used by Builder or Normal. 
  - InMemDiskArray : BaseInMemDiskArray: For now only extends BaseInMemDiskArray and is empty otherwise but this is the class that will contain transactional update logic to update lists.
  - InMemDiskArrayBuilder extends BaseInMemDiskArray and contains all functions related to building.
Overall there is no code duplication in the refactoring in DiskArray files.
  - ListMetadata is broken into:
  - BaseListsMetadata
  - ListsMetadata : BaseListsMetadata
  - ListsMetadataBuilder : BaseListsMetadata
Code duplication:
  1) ListsMetadatBuilder and ListsMetadata have similar 3 fields: {chunkToPageListHeadIdxMapBuilder; largeListIdxToPageListHeadIdxMapBuilder; pageListsBuilder} vs {chunkToPageListHeadIdxMap; largeListIdxToPageListHeadIdxMap; pageLists}
  2) Because   ListsMetadataBuilder and ListsMetadata use InMemDiskArrayBuilder vs InMemDiskArray both contain two wrapper functions around getLogicalToPhysicalPageMapper: getPageMapperForChunkIdx(uint32_t chunkIdx) and getPageMapperForLargeListIdx. The names of the functions are the same, so these convenience functions are repeated.

- ListHeaders is broken into 
  - BaseListHeaders
  - ListHeaders
  - ListHeadersBuilder
Code duplication:
   3) Similar to ListsMetadata case there is now 1 field that is repeated: headersBuilder vs header, the former is InMemDiskArrayBuilder while the latter is InMemDiskArray. 
   4) Currently getHeader(node_offset offset) function is repeated to read a particular header.

Independently also moves disk_array into file_handle. This is terrible but I was playing around with adding some freePage maintenance logic to each db file we have and this requires the file handle to use InMemDiskArray for its free pages, which creates a circular dependency. To get around it, I moved them to the same package. But this PR does not implement free page maintenance logic.