### PR TITLE
Removing getNumBytesToWrite and constructFrom/writeToBytes functions from wal_record structs.

### DIFF
--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -65,9 +65,6 @@ struct PageUtils {
 class StorageUtils {
 
 public:
-    static void saveListOfIntsToFile(const string& fName, uint8_t* data, uint32_t listSize);
-    static uint32_t readListOfIntsFromFile(unique_ptr<uint32_t[]>& data, const string& fName);
-
     inline static string getNodeIndexFName(const string& directory, const label_t& nodeLabel) {
         auto fName = StringUtils::string_format("n-%d", nodeLabel);
         return FileUtils::joinPath(directory, fName + StorageConfig::INDEX_FILE_SUFFIX);

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -14,23 +14,6 @@ uint32_t PageUtils::getNumElementsInAPage(uint32_t elementSize, bool hasNull) {
     return (DEFAULT_PAGE_SIZE - (numNullEntries * numBytesPerNullEntry)) / elementSize;
 }
 
-void StorageUtils::saveListOfIntsToFile(const string& fName, uint8_t* data, uint32_t listSize) {
-    assert(data);
-    auto fileInfo = FileUtils::openFile(fName, O_WRONLY | O_CREAT);
-    FileUtils::writeToFile(fileInfo.get(), data, sizeof(uint32_t) * listSize, 0 /*offset*/);
-    FileUtils::closeFile(fileInfo->fd);
-}
-
-uint32_t StorageUtils::readListOfIntsFromFile(unique_ptr<uint32_t[]>& data, const string& fName) {
-    auto fileInfo = FileUtils::openFile(fName, O_RDONLY);
-    auto bytesToRead = FileUtils::getFileSize(fileInfo->fd);
-    auto listSize = bytesToRead / sizeof(uint32_t);
-    data.reset(new uint32_t[listSize]);
-    FileUtils::readFromFile(fileInfo.get(), data.get(), bytesToRead, 0 /*offset*/);
-    FileUtils::closeFile(fileInfo->fd);
-    return listSize;
-}
-
 uint64_t StorageUtils::all1sMaskForLeastSignificantBits(uint64_t numBits) {
     assert(numBits <= 64);
     return numBits == 64 ? UINT64_MAX : (1l << numBits) - 1;

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -78,7 +78,7 @@ void WAL::initCurrentPageAndResetIsLastRecordCommitAndContainsNodesMetadataField
 }
 
 void WAL::addNewWALRecordWithoutLock(WALRecord& walRecord) {
-    if (offsetInCurrentHeaderPage + walRecord.numBytesToWrite() > WAL_HEADER_PAGE_SIZE) {
+    if (offsetInCurrentHeaderPage + sizeof(WALRecord) > WAL_HEADER_PAGE_SIZE) {
         uint64_t nextHeaderPageIdx = fileHandle->addNewPage();
         setNextHeaderPageOfCurrentHeaderPage(nextHeaderPageIdx);
         // We next write the currentHeaderPageBuffer. This allows us to only keep track

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -3,22 +3,6 @@
 namespace graphflow {
 namespace storage {
 
-void StructuredNodePropertyColumnID::constructStructuredNodePropertyColumnIDFromBytes(
-    StructuredNodePropertyColumnID& retVal, uint8_t* bytes, uint64_t& offset) {
-    retVal.nodeLabel = ((label_t*)(bytes + offset))[0];
-    offset += sizeof(label_t);
-    retVal.propertyID = ((uint32_t*)(bytes + offset))[0];
-    offset += 4;
-};
-
-void StructuredNodePropertyColumnID::writeStructuredNodePropertyColumnIDToBytes(
-    uint8_t* bytes, uint64_t& offset) {
-    ((label_t*)(bytes + offset))[0] = nodeLabel;
-    offset += sizeof(label_t);
-    ((uint32_t*)(bytes + offset))[0] = propertyID;
-    offset += 4;
-}
-
 StorageStructureID StorageStructureID::newStructuredNodePropertyColumnID(
     label_t nodeLabel, uint32_t propertyID, bool isOverflow) {
     StorageStructureID retVal;
@@ -27,39 +11,6 @@ StorageStructureID StorageStructureID::newStructuredNodePropertyColumnID(
     retVal.structuredNodePropertyColumnID.nodeLabel = nodeLabel;
     retVal.structuredNodePropertyColumnID.propertyID = propertyID;
     return retVal;
-}
-
-void StorageStructureID::constructStorageStructureIDFromBytes(
-    StorageStructureID& retVal, uint8_t* bytes, uint64_t& offset) {
-    retVal.storageStructureType =
-        static_cast<StorageStructureType>(bytes[offset++]); // 1 byte for StorageStructureType
-    retVal.isOverflow = ((bool*)(bytes + offset++))[0];     // 1 byte for isOverflow
-    switch (retVal.storageStructureType) {
-    case STRUCTURED_NODE_PROPERTY_COLUMN: {
-        StructuredNodePropertyColumnID::constructStructuredNodePropertyColumnIDFromBytes(
-            retVal.structuredNodePropertyColumnID, bytes, offset);
-    } break;
-    default: {
-        throw RuntimeException("Unrecognized StorageStructureType when reading WAL record in "
-                               "constructStorageStructureIDFromBytes(). StorageStructureType:" +
-                               to_string(retVal.storageStructureType));
-    }
-    }
-}
-
-void StorageStructureID::writeStorageStructureIDToBytes(uint8_t* bytes, uint64_t& offset) {
-    bytes[offset++] = storageStructureType;
-    bytes[offset++] = isOverflow;
-    switch (storageStructureType) {
-    case STRUCTURED_NODE_PROPERTY_COLUMN: {
-        structuredNodePropertyColumnID.writeStructuredNodePropertyColumnIDToBytes(bytes, offset);
-    } break;
-    default: {
-        throw RuntimeException("Unrecognized StorageStructureType when reading WAL record in "
-                               "writeStorageStructureIDToBytes(). StorageStructureType:" +
-                               to_string(storageStructureType));
-    }
-    }
 }
 
 PageUpdateOrInsertRecord PageUpdateOrInsertRecord::newPageInsertOrUpdateRecord(
@@ -73,42 +24,10 @@ PageUpdateOrInsertRecord PageUpdateOrInsertRecord::newPageInsertOrUpdateRecord(
     return retVal;
 }
 
-void PageUpdateOrInsertRecord::constructPageUpdateOrInsertRecordFromBytes(
-    PageUpdateOrInsertRecord& retVal, uint8_t* bytes, uint64_t& offset) {
-    StorageStructureID::constructStorageStructureIDFromBytes(
-        retVal.storageStructureID, bytes, offset);
-    retVal.pageIdxInOriginalFile = ((uint64_t*)(bytes + offset))[0];
-    retVal.pageIdxInWAL = ((uint64_t*)(bytes + offset))[1];
-    offset += 2 * sizeof(uint64_t);
-    retVal.isInsert = ((bool*)(bytes + offset))[0];
-    offset += sizeof(bool);
-}
-
-void PageUpdateOrInsertRecord::writePageUpdateOrInsertRecordToBytes(
-    uint8_t* bytes, uint64_t& offset) {
-    storageStructureID.writeStorageStructureIDToBytes(bytes, offset);
-    ((uint64_t*)(bytes + offset))[0] = pageIdxInOriginalFile;
-    ((uint64_t*)(bytes + offset))[1] = pageIdxInWAL;
-    offset += 2 * sizeof(uint64_t);
-    ((bool*)(bytes + offset))[0] = isInsert;
-    offset += sizeof(bool);
-}
-
 CommitRecord CommitRecord::newCommitRecord(uint64_t transactionID) {
     CommitRecord retVal;
     retVal.transactionID = transactionID;
     return retVal;
-}
-
-void CommitRecord::constructCommitRecordFromBytes(
-    CommitRecord& retVal, uint8_t* bytes, uint64_t& offset) {
-    retVal.transactionID = ((uint64_t*)(bytes + offset))[0];
-    offset += sizeof(uint64_t);
-}
-
-void CommitRecord::writeCommitRecordToBytes(uint8_t* bytes, uint64_t& offset) {
-    ((uint64_t*)(bytes + offset))[0] = transactionID;
-    offset += sizeof(uint64_t);
 }
 
 WALRecord WALRecord::newPageInsertOrUpdateRecord(StorageStructureID storageStructureID_,
@@ -146,44 +65,13 @@ WALRecord WALRecord::newNodeMetadataRecord() {
 }
 
 void WALRecord::constructWALRecordFromBytes(WALRecord& retVal, uint8_t* bytes, uint64_t& offset) {
-    retVal.recordType = static_cast<WALRecordType>(bytes[offset++]);
-    switch (retVal.recordType) {
-    case PAGE_UPDATE_OR_INSERT_RECORD: {
-        PageUpdateOrInsertRecord::constructPageUpdateOrInsertRecordFromBytes(
-            retVal.pageInsertOrUpdateRecord, bytes, offset);
-    } break;
-    case NODES_METADATA_RECORD: {
-        // We don't have to do anything more than reading the recordType for NODES_METADATA_RECORD.
-    } break;
-    case COMMIT_RECORD: {
-        CommitRecord::constructCommitRecordFromBytes(retVal.commitRecord, bytes, offset);
-    } break;
-    default: {
-        throw RuntimeException(
-            "Unrecognized WAL record type in constructWALRecordFromBytes(). recordType: " +
-            to_string(retVal.recordType));
-    }
-    }
+    ((WALRecord*)&retVal)[0] = ((WALRecord*)(bytes + offset))[0];
+    offset += sizeof(WALRecord);
 }
 
 void WALRecord::writeWALRecordToBytes(uint8_t* bytes, uint64_t& offset) {
-    bytes[offset++] = recordType;
-    switch (recordType) {
-    case PAGE_UPDATE_OR_INSERT_RECORD: {
-        pageInsertOrUpdateRecord.writePageUpdateOrInsertRecordToBytes(bytes, offset);
-    } break;
-    case NODES_METADATA_RECORD: {
-        // We do not have to write anything for NODES_METADATA_RECORD.
-    } break;
-    case COMMIT_RECORD: {
-        commitRecord.writeCommitRecordToBytes(bytes, offset);
-    } break;
-    default: {
-        throw RuntimeException(
-            "Unrecognized WAL record type in writeWALRecordToBytes(). recordType: " +
-            to_string(recordType));
-    }
-    }
+    ((WALRecord*)(bytes + offset))[0] = *this;
+    offset += sizeof(WALRecord);
 }
 
 } // namespace storage

--- a/test/storage/wal/wal_record_test.cpp
+++ b/test/storage/wal/wal_record_test.cpp
@@ -25,7 +25,7 @@ public:
         WALRecord recordReadBack;
         WALRecord::constructWALRecordFromBytes(recordReadBack, bytes.get(), offset);
         // Test the offset was moved correctly
-        ASSERT_EQ(offset, previousOffset + expectedWALRecord.numBytesToWrite());
+        ASSERT_EQ(offset, previousOffset + sizeof(WALRecord));
         ASSERT_EQ(recordReadBack, expectedWALRecord);
     }
 
@@ -33,7 +33,7 @@ public:
         uint64_t offset = 0;
         expectedWALRecord.writeWALRecordToBytes(bytes.get(), offset);
         // Test the offset was moved correctly
-        ASSERT_EQ(offset, expectedWALRecord.numBytesToWrite());
+        ASSERT_EQ(offset, sizeof(WALRecord));
         // Test we read back what we wrote
         offset = 0;
         readBackWALRecordAndAssert(expectedWALRecord, offset);
@@ -90,12 +90,11 @@ TEST_F(WALRecordTest, MultipleRecordWritingTest) {
 
     uint64_t offset = 0;
     expectedWALRecord1.writeWALRecordToBytes(bytes.get(), offset);
-    ASSERT_EQ(offset, expectedWALRecord1.numBytesToWrite());
+    ASSERT_EQ(offset, sizeof(WALRecord));
     expectedWALRecord2.writeWALRecordToBytes(bytes.get(), offset);
-    ASSERT_EQ(offset, expectedWALRecord1.numBytesToWrite() + expectedWALRecord2.numBytesToWrite());
+    ASSERT_EQ(offset, 2 * sizeof(WALRecord));
     expectedWALRecord3.writeWALRecordToBytes(bytes.get(), offset);
-    ASSERT_EQ(offset, expectedWALRecord1.numBytesToWrite() + expectedWALRecord2.numBytesToWrite() +
-                          expectedWALRecord3.numBytesToWrite());
+    ASSERT_EQ(offset, 3 * sizeof(WALRecord));
     offset = 0;
     readBackWALRecordAndAssert(expectedWALRecord1, offset);
     readBackWALRecordAndAssert(expectedWALRecord2, offset);


### PR DESCRIPTION
This is a simple clean up PR that only removes code (with minor code change). In addition to what's in the title also removes the saveListOfIntsToFile and readListOfIntsFromFile functions, which are no longer used now that we moved to using DiskArray structures.