### PR TITLE
fix encode null bits; make stopThreads safe

### DIFF
--- a/src/common/include/task_system/task_scheduler.h
+++ b/src/common/include/task_system/task_scheduler.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <deque>
 #include <thread>
 
@@ -88,7 +89,7 @@ private:
     shared_ptr<spdlog::logger> logger;
     mutex mtx;
     deque<shared_ptr<ScheduledTask>> taskQueue;
-    bool stopThreads{false};
+    atomic<bool> stopThreads{false};
     vector<thread> threads;
     uint64_t nextScheduledTaskID;
 };

--- a/src/common/task_system/task_scheduler.cpp
+++ b/src/common/task_system/task_scheduler.cpp
@@ -17,7 +17,7 @@ TaskScheduler::TaskScheduler(uint64_t numThreads)
 }
 
 TaskScheduler::~TaskScheduler() {
-    stopThreads = true;
+    stopThreads.store(true);
     for (auto& thread : threads) {
         thread.join();
     }
@@ -126,7 +126,7 @@ void TaskScheduler::removeErroringTask(uint64_t scheduledTaskID) {
 
 void TaskScheduler::runWorkerThread() {
     while (true) {
-        if (stopThreads) {
+        if (stopThreads.load()) {
             break;
         }
         auto scheduledTask = getTaskAndRegister();

--- a/src/loader/in_mem_storage_structure/in_mem_file.cpp
+++ b/src/loader/in_mem_storage_structure/in_mem_file.cpp
@@ -35,6 +35,7 @@ void InMemFile::flush() {
     }
     auto fileInfo = FileUtils::openFile(filePath, O_CREAT | O_WRONLY);
     for (auto pageIdx = 0u; pageIdx < pages.size(); pageIdx++) {
+        pages[pageIdx]->encodeNullBits();
         FileUtils::writeToFile(
             fileInfo.get(), pages[pageIdx]->data, DEFAULT_PAGE_SIZE, pageIdx * DEFAULT_PAGE_SIZE);
     }

--- a/src/loader/in_mem_storage_structure/in_mem_page.cpp
+++ b/src/loader/in_mem_storage_structure/in_mem_page.cpp
@@ -8,7 +8,7 @@ namespace graphflow {
 namespace loader {
 
 InMemPage::InMemPage(uint32_t maxNumElements, uint16_t numBytesForElement, bool hasNullEntries)
-    : nullEntries{nullptr} {
+    : nullEntriesInPage{nullptr}, maxNumElements{maxNumElements} {
     buffer = make_unique<uint8_t[]>(DEFAULT_PAGE_SIZE);
     data = buffer.get();
     if (hasNullEntries) {
@@ -17,17 +17,19 @@ InMemPage::InMemPage(uint32_t maxNumElements, uint16_t numBytesForElement, bool 
         // null or not. By default, we consider all elements in the page to be NULL. When a new
         // element comes in to be put at a pos, its respective NULL bit is reset to denote a
         // non-NULL value.
-        nullEntries = (uint64_t*)(data + (numBytesForElement * maxNumElements));
+        nullEntriesInPage = (uint64_t*)(data + (numBytesForElement * maxNumElements));
         auto numNullEntries = (maxNumElements + NullMask::NUM_BITS_PER_NULL_ENTRY - 1) /
                               NullMask::NUM_BITS_PER_NULL_ENTRY;
-        fill(nullEntries, nullEntries + numNullEntries, NullMask::ALL_NULL_ENTRY);
+        fill(nullEntriesInPage, nullEntriesInPage + numNullEntries, NullMask::ALL_NULL_ENTRY);
+        nullMask = make_unique<uint8_t[]>(maxNumElements);
+        memset(nullMask.get(), UINT8_MAX, maxNumElements);
     }
 }
 
 void InMemPage::setElementAtPosToNonNull(uint32_t pos) {
     auto entryPos = pos >> NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2;
     auto bitPosInEntry = pos - (entryPos << NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2);
-    nullEntries[entryPos] &= NULL_BITMASKS_WITH_SINGLE_ZERO[bitPosInEntry];
+    nullEntriesInPage[entryPos] &= NULL_BITMASKS_WITH_SINGLE_ZERO[bitPosInEntry];
 }
 
 uint8_t* InMemPage::write(nodeID_t* nodeID, uint32_t byteOffsetInPage, uint32_t elemPosInPage,
@@ -35,8 +37,8 @@ uint8_t* InMemPage::write(nodeID_t* nodeID, uint32_t byteOffsetInPage, uint32_t 
     memcpy(data + byteOffsetInPage, &nodeID->label, compressionScheme.getNumBytesForLabel());
     memcpy(data + byteOffsetInPage + compressionScheme.getNumBytesForLabel(), &nodeID->offset,
         compressionScheme.getNumBytesForOffset());
-    if (nullEntries) {
-        setElementAtPosToNonNull(elemPosInPage);
+    if (nullMask) {
+        nullMask[elemPosInPage] = false;
     }
     return data + byteOffsetInPage;
 }
@@ -44,10 +46,21 @@ uint8_t* InMemPage::write(nodeID_t* nodeID, uint32_t byteOffsetInPage, uint32_t 
 uint8_t* InMemPage::write(uint32_t byteOffsetInPage, uint32_t elemPosInPage, const uint8_t* elem,
     uint32_t numBytesForElem) {
     memcpy(data + byteOffsetInPage, elem, numBytesForElem);
-    if (nullEntries) {
-        setElementAtPosToNonNull(elemPosInPage);
+    if (nullMask) {
+        nullMask[elemPosInPage] = false;
     }
     return data + byteOffsetInPage;
+}
+
+void InMemPage::encodeNullBits() {
+    if (nullMask == nullptr) {
+        return;
+    }
+    for (auto i = 0u; i < maxNumElements; i++) {
+        if (!nullMask[i]) {
+            setElementAtPosToNonNull(i);
+        }
+    }
 }
 
 } // namespace loader

--- a/src/loader/in_mem_storage_structure/include/in_mem_file.h
+++ b/src/loader/in_mem_storage_structure/include/in_mem_file.h
@@ -24,7 +24,7 @@ public:
 
     virtual ~InMemFile() = default;
 
-    virtual void flush();
+    void flush();
 
     void addNewPages(uint64_t numNewPagesToAdd, bool setToZero = false);
 

--- a/src/loader/in_mem_storage_structure/include/in_mem_page.h
+++ b/src/loader/in_mem_storage_structure/include/in_mem_page.h
@@ -24,6 +24,8 @@ public:
     uint8_t* write(uint32_t byteOffsetInPage, uint32_t elemPosInPage, const uint8_t* elem,
         uint32_t numBytesForElem);
 
+    void encodeNullBits();
+
 public:
     uint8_t* data;
 
@@ -32,7 +34,9 @@ private:
 
     unique_ptr<uint8_t[]> buffer;
     // The pointer to the beginning of null entries in the page.
-    uint64_t* nullEntries;
+    uint64_t* nullEntriesInPage;
+    unique_ptr<uint8_t[]> nullMask;
+    uint32_t maxNumElements;
 };
 
 } // namespace loader


### PR DESCRIPTION
This PR fixes a potential concurrency bug in the loader with null bits.
Previously, we directly set null bit in a page through `setElementAtPosToNonNull`, in which is changing the value of a null entry, i.e., uint64_t integer (`uint64_t* nullEntries;`). However, multiple threads might happen to set the null bits inside the same null entry. For example, T1 sets null for position 5, and T2 for 6, so they happen to write the same null entry concurrently, which causes bugs.
In this PR, I add an array for each value in a page to be null or not (no two threads will set the same value) and encode the array to the page when we flush it.

Also, this PR changes the `stopThreads` in TaskScheduler to atomic, so it's thread-safe. Practically, it is unnecessary for now, because we only set `stopThreads` to false once, and we don't care much when other threads will stop. But I want to fix this as it introduces minimal overhead and makes the code more robust for any future changes.