### PR TITLE
making all storage structures obtain a storagestructureidandfname

### DIFF
--- a/src/loader/in_mem_builder/in_mem_rel_builder.cpp
+++ b/src/loader/in_mem_builder/in_mem_rel_builder.cpp
@@ -28,7 +28,7 @@ InMemRelBuilder::InMemRelBuilder(label_t label, const RelFileDescription& fileDe
         auto nodeLabel = catalog.getNodeLabelFromName(labelName);
         assert(IDIndexes[nodeLabel] == nullptr);
         IDIndexes[nodeLabel] = make_unique<HashIndex>(
-            StorageUtils::getNodeIndexFName(this->outputDirectory, nodeLabel),
+            StorageUtils::getNodeIndexIDAndFName(this->outputDirectory, nodeLabel),
             catalog.getNodeProperty(nodeLabel, LoaderConfig::ID_FIELD).dataType, bm,
             true /* isInMemory */);
     }

--- a/src/storage/buffer_manager/disk_array.cpp
+++ b/src/storage/buffer_manager/disk_array.cpp
@@ -131,6 +131,10 @@ U& BaseInMemDiskArray<U>::operator[](uint64_t idx) {
 }
 
 template<class T>
+InMemDiskArray<T>::InMemDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx)
+    : BaseInMemDiskArray<T>(fileHandle, headerPageIdx) {}
+
+template<class T>
 InMemDiskArrayBuilder<T>::InMemDiskArrayBuilder(
     FileHandle& fileHandle, page_idx_t headerPageIdx, uint64_t numElements)
     : BaseInMemDiskArray<T>(fileHandle, headerPageIdx, sizeof(T)) {
@@ -139,10 +143,6 @@ InMemDiskArrayBuilder<T>::InMemDiskArrayBuilder(
         this->addInMemoryPage();
     }
 }
-
-template<class T>
-InMemDiskArray<T>::InMemDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx)
-    : BaseInMemDiskArray<T>(fileHandle, headerPageIdx) {}
 
 template<class T>
 void InMemDiskArrayBuilder<T>::saveToDisk() {

--- a/src/storage/buffer_manager/include/disk_array.h
+++ b/src/storage/buffer_manager/include/disk_array.h
@@ -28,8 +28,6 @@ struct DiskArrayHeader {
 
     void readFromFile(FileHandle& fileHandle, uint64_t headerPageIdx);
 
-    inline uint64_t getCapacity() { return numArrayPages << numElementsPerPageLog2; }
-
     // TODO(Semih): This is only for debugging purposes. Will be removed.
     void print();
 

--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -19,6 +19,9 @@ struct StorageStructureIDAndFName {
     StorageStructureIDAndFName(StorageStructureID storageStructureID, string fName)
         : storageStructureID{storageStructureID}, fName{move(fName)} {};
 
+    StorageStructureIDAndFName(const StorageStructureIDAndFName& other)
+        : storageStructureID{other.storageStructureID}, fName{other.fName} {};
+
     StorageStructureID storageStructureID;
     string fName;
 };
@@ -80,6 +83,45 @@ public:
         auto fName = getNodePropertyColumnFName(directory, property.label, property.name);
         return StorageStructureIDAndFName(StorageStructureID::newStructuredNodePropertyMainColumnID(
                                               property.label, property.propertyID),
+            fName);
+    }
+
+    inline static StorageStructureIDAndFName getNodeIndexIDAndFName(
+        const string& directory, label_t nodeLabel) {
+        auto fName = getNodeIndexFName(directory, nodeLabel);
+        return StorageStructureIDAndFName(StorageStructureID::newNodeIndexID(nodeLabel), fName);
+    }
+
+    // Returns the StorageStructureIDAndFName for the "base" lists structure/file. Callers need to
+    // modify it to obtain versions for METADATA and HEADERS structures/files.
+    inline static StorageStructureIDAndFName getUnstructuredNodePropertyListsStructureIDAndFName(
+        const string& directory, label_t nodeLabel) {
+        auto fName = getNodeUnstrPropertyListsFName(directory, nodeLabel);
+        return StorageStructureIDAndFName(StorageStructureID::newUnstructuredNodePropertyListsID(
+                                              nodeLabel, ListFileType::BASE_LISTS),
+            fName);
+    }
+
+    // Returns the StorageStructureIDAndFName for the "base" lists structure/file. Callers need to
+    // modify it to obtain versions for METADATA and HEADERS structures/files.
+    inline static StorageStructureIDAndFName getAdjListsStructureIDAndFName(
+        const string& directory, label_t relLabel, label_t srcNodeLabel, RelDirection dir) {
+        auto fName = getAdjListsFName(directory, relLabel, srcNodeLabel, dir);
+        return StorageStructureIDAndFName(StorageStructureID::newAdjListsID(relLabel, srcNodeLabel,
+                                              dir, ListFileType::BASE_LISTS),
+            fName);
+    }
+
+    // Returns the StorageStructureIDAndFName for the "base" lists structure/file. Callers need to
+    // modify it to obtain versions for METADATA and HEADERS structures/files.
+    inline static StorageStructureIDAndFName getRelPropertyListsStructureIDAndFName(
+        const string& directory, label_t relLabel, label_t srcNodeLabel, RelDirection dir,
+        const catalog::Property& property) {
+        auto fName =
+            getRelPropertyListsFName(directory, relLabel, srcNodeLabel, dir, property.name);
+        return StorageStructureIDAndFName(
+            StorageStructureID::newRelPropertyListsID(
+                relLabel, srcNodeLabel, dir, property.propertyID, ListFileType::BASE_LISTS),
             fName);
     }
 

--- a/src/storage/index/include/hash_index.h
+++ b/src/storage/index/include/hash_index.h
@@ -94,8 +94,8 @@ class HashIndex {
     static constexpr bool LOOKUP_FLAG = false;
 
 public:
-    HashIndex(
-        string fName, const DataType& keyDataType, BufferManager& bufferManager, bool isInMemory);
+    HashIndex(const StorageStructureIDAndFName storageStructureIDAndFName,
+        const DataType& keyDataType, BufferManager& bufferManager, bool isInMemory);
 
     ~HashIndex();
 
@@ -156,7 +156,7 @@ private:
         uint8_t* slot, const uint8_t* key, node_offset_t* result = nullptr) const;
 
 private:
-    string fName;
+    StorageStructureIDAndFName storageStructureIDAndFName;
     bool isInMemory;
     unique_ptr<FileHandle> fh;
     BufferManager& bm;

--- a/src/storage/storage_structure/include/lists/list_headers.h
+++ b/src/storage/storage_structure/include/lists/list_headers.h
@@ -63,7 +63,7 @@ public:
 
 protected:
     shared_ptr<spdlog::logger> logger;
-    unique_ptr<FileHandle> headersFileHandle;
+    unique_ptr<FileHandle> fileHandle;
 };
 
 class ListHeadersBuilder : public BaseListHeaders {
@@ -83,11 +83,14 @@ private:
 
 class ListHeaders : public BaseListHeaders {
 public:
-    explicit ListHeaders(const string& fName);
+    explicit ListHeaders(const StorageStructureIDAndFName storageStructureIDAndFNameForBaseList);
 
     inline list_header_t getHeader(node_offset_t offset) { return (*headers)[offset]; };
 
     unique_ptr<InMemDiskArray<list_header_t>> headers;
+
+private:
+    StorageStructureIDAndFName storageStructureIDAndFName;
 };
 } // namespace storage
 } // namespace graphflow

--- a/src/storage/storage_structure/include/lists/lists_metadata.h
+++ b/src/storage/storage_structure/include/lists/lists_metadata.h
@@ -55,7 +55,7 @@ class ListsMetadata : public BaseListsMetadata {
     friend class graphflow::loader::LoaderEmptyListsTest;
 
 public:
-    explicit ListsMetadata(const string& listBaseFName);
+    explicit ListsMetadata(const StorageStructureIDAndFName storageStructureIDAndFNameForBaseList);
 
     inline uint64_t getNumElementsInLargeLists(uint64_t largeListIdx) {
         return (*largeListIdxToPageListHeadIdxMap)[(2 * largeListIdx) + 1];
@@ -74,6 +74,7 @@ public:
     }
 
 private:
+    StorageStructureIDAndFName storageStructureIDAndFName;
     // chunkToPageListHeadIdxMapBuilder holds pointers to the head of pageList of each chunk.
     // For instance, chunkToPageListHeadIdxMapBuilder[3] is a pointer in `pageLists` from where
     // the pageList of chunk 3 begins.

--- a/src/storage/storage_structure/include/lists/unstructured_property_lists.h
+++ b/src/storage/storage_structure/include/lists/unstructured_property_lists.h
@@ -19,10 +19,13 @@ struct UnstructuredPropertyKeyDataType {
 class UnstructuredPropertyLists : public Lists {
 
 public:
-    UnstructuredPropertyLists(const string& fName, BufferManager& bufferManager, bool isInMemory)
-        : Lists{fName, DataType(UNSTRUCTURED), 1, make_shared<ListHeaders>(fName), bufferManager,
+    UnstructuredPropertyLists(const StorageStructureIDAndFName& storageStructureIDAndFName,
+        BufferManager& bufferManager, bool isInMemory)
+        : Lists{storageStructureIDAndFName, DataType(UNSTRUCTURED), 1,
+              make_shared<ListHeaders>(storageStructureIDAndFName), bufferManager,
               false /*hasNULLBytes*/, isInMemory},
-          stringOverflowPages{fName, bufferManager, isInMemory} {};
+          stringOverflowPages{storageStructureIDAndFName, bufferManager, isInMemory,
+              nullptr /* no wal for now */} {};
 
     void readProperties(ValueVector* nodeIDVector,
         const unordered_map<uint32_t, ValueVector*>& propertyKeyToResultVectorMap);

--- a/src/storage/storage_structure/include/overflow_file.h
+++ b/src/storage/storage_structure/include/overflow_file.h
@@ -29,16 +29,6 @@ public:
         nextBytePosToWriteTo = fileHandle.getNumPages() * DEFAULT_PAGE_SIZE;
     }
 
-    // TODO(Semih/Guodong): This overloaded constructor exists for storage structures that hold
-    // overflow pages but is not yet updatable, such as hash index or rel property lists storing
-    // strings. Currently, it creates a dummy StorageStructureID. This should be removed when we
-    // support updates for those structures too.
-    OverflowFile(const string& fName, BufferManager& bufferManager, bool isInMemory)
-        : OverflowFile(
-              StorageStructureIDAndFName(
-                  StorageStructureID::newStructuredNodePropertyMainColumnID(-1, -1), fName),
-              bufferManager, isInMemory, nullptr /* wal is null */) {}
-
     ~OverflowFile() {
         if (isInMemory_) {
             StorageStructureUtils::unpinEachPageOfFile(fileHandle, bufferManager);
@@ -47,6 +37,7 @@ public:
 
     static inline StorageStructureIDAndFName constructOverflowStorageStructureIDAndFName(
         const StorageStructureIDAndFName& storageStructureIDAndFNameForMainDBFile) {
+        // TODO(Semih): Change this to use the copy constructor of StorageStructureIDAndFName.
         StorageStructureID newOverflowStorageStructureID =
             storageStructureIDAndFNameForMainDBFile.storageStructureID;
         newOverflowStorageStructureID.isOverflow = true;

--- a/src/storage/storage_structure/include/storage_structure.h
+++ b/src/storage/storage_structure/include/storage_structure.h
@@ -88,14 +88,6 @@ protected:
         DataType dataType, const size_t& elementSize, BufferManager& bufferManager,
         bool hasNULLBytes, bool isInMemory, WAL* wal);
 
-    BaseColumnOrList(const string& fName, const DataType& dataType, const size_t& elementSize,
-        BufferManager& bufferManager, bool hasNULLBytes, bool isInMemory)
-        : BaseColumnOrList{
-              StorageStructureIDAndFName(
-                  StorageStructureID::newStructuredNodePropertyMainColumnID(-1, -1), fName),
-              dataType, elementSize, bufferManager, hasNULLBytes, isInMemory,
-              nullptr /* null wal */} {}
-
     virtual ~BaseColumnOrList() {
         if (isInMemory_) {
             StorageStructureUtils::unpinEachPageOfFile(fileHandle, bufferManager);

--- a/src/storage/storage_structure/lists/list_headers.cpp
+++ b/src/storage/storage_structure/lists/list_headers.cpp
@@ -7,27 +7,32 @@
 namespace graphflow {
 namespace storage {
 
-BaseListHeaders::BaseListHeaders(const string& fName) {
+BaseListHeaders::BaseListHeaders(const string& listBaseFName) {
     logger = LoggerUtils::getOrCreateSpdLogger("storage");
-    headersFileHandle = make_unique<FileHandle>(
-        fName + ".headers", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
+    fileHandle = make_unique<FileHandle>(
+        listBaseFName + ".headers", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
 }
 ListHeadersBuilder::ListHeadersBuilder(const string& fName, uint64_t numElements)
     : BaseListHeaders(fName) {
+    fileHandle = make_unique<FileHandle>(
+        fName + ".headers", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
     // DiskArray assumes that its header page already exists. To ensure that we need to add a page
     // to the fileHandle. Currently the header page is at page 0, so we add one page here.
-    headersFileHandle->addNewPage();
+    fileHandle->addNewPage();
     headersBuilder = make_unique<InMemDiskArrayBuilder<list_header_t>>(
-        *headersFileHandle, LIST_HEADERS_HEADER_PAGE_IDX, numElements);
+        *fileHandle, LIST_HEADERS_HEADER_PAGE_IDX, numElements);
 }
 
 void ListHeadersBuilder::saveToDisk() {
     headersBuilder->saveToDisk();
 }
 
-ListHeaders::ListHeaders(const string& fName) : BaseListHeaders(fName) {
-    headers = make_unique<InMemDiskArray<list_header_t>>(
-        *headersFileHandle, LIST_HEADERS_HEADER_PAGE_IDX);
+ListHeaders::ListHeaders(const StorageStructureIDAndFName storageStructureIDAndFNameForBaseList)
+    : BaseListHeaders(storageStructureIDAndFNameForBaseList.fName),
+      storageStructureIDAndFName(storageStructureIDAndFNameForBaseList) {
+    storageStructureIDAndFName.storageStructureID.listFileID.listFileType = ListFileType::HEADERS;
+    storageStructureIDAndFName.fName = fileHandle->getFileInfo()->path;
+    headers = make_unique<InMemDiskArray<list_header_t>>(*fileHandle, LIST_HEADERS_HEADER_PAGE_IDX);
     logger->trace("ListHeaders: #numNodeOffsets {}", headers->header.numElements);
 };
 

--- a/src/storage/storage_structure/lists/lists_metadata.cpp
+++ b/src/storage/storage_structure/lists/lists_metadata.cpp
@@ -8,7 +8,11 @@
 namespace graphflow {
 namespace storage {
 
-ListsMetadata::ListsMetadata(const string& listBaseFName) : BaseListsMetadata(listBaseFName) {
+ListsMetadata::ListsMetadata(const StorageStructureIDAndFName storageStructureIDAndFNameForBaseList)
+    : BaseListsMetadata(storageStructureIDAndFNameForBaseList.fName),
+      storageStructureIDAndFName(storageStructureIDAndFNameForBaseList) {
+    storageStructureIDAndFName.storageStructureID.listFileID.listFileType = ListFileType::METADATA;
+    storageStructureIDAndFName.fName = metadataFileHandle->getFileInfo()->path;
     chunkToPageListHeadIdxMap = make_unique<InMemDiskArray<uint32_t>>(
         *metadataFileHandle, CHUNK_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX);
     largeListIdxToPageListHeadIdxMap = make_unique<InMemDiskArray<uint32_t>>(
@@ -55,8 +59,8 @@ void ListsMetadataBuilder::initChunkPageLists(uint32_t numChunks_) {
 }
 
 void ListsMetadataBuilder::initLargeListPageLists(uint32_t numLargeLists_) {
-    // For each largeList, we store the PageListHeadIdx in pageLists and also the number of elements
-    // in the large list.
+    // For each largeList, we store the PageListHeadIdx in pageLists and also the number of
+    // elements in the large list.
     largeListIdxToPageListHeadIdxMapBuilder =
         make_unique<InMemDiskArrayBuilder<uint32_t>>(*metadataFileHandle,
             LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX, (2 * numLargeLists_));
@@ -90,9 +94,9 @@ void ListsMetadataBuilder::populatePageIdsInAPageList(uint32_t numPages, uint32_
     if (0 != numPages % PAGE_LIST_GROUP_SIZE) {
         numPageListGroups++;
     }
-    // During the initial allocation, we allocate all the pageListGroups of a pageList contiguously.
-    // pageListTailIdx is the id in the pageLists blob where the pageList ends and the next
-    // pageLists should start.
+    // During the initial allocation, we allocate all the pageListGroups of a pageList
+    // contiguously. pageListTailIdx is the id in the pageLists blob where the pageList ends and
+    // the next pageLists should start.
     uint32_t pageListHeadIdx = pageListsBuilder->header.numElements;
     auto pageListTailIdx =
         pageListHeadIdx + ((PAGE_LIST_GROUP_WITH_NEXT_PTR_SIZE)*numPageListGroups);

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -23,11 +23,12 @@ NodeTable::NodeTable(NodeMetadata* nodeMetadata, BufferManager& bufferManager, b
     }
     if (hasUnstructuredProperties) {
         unstrPropertyLists = make_unique<UnstructuredPropertyLists>(
-            StorageUtils::getNodeUnstrPropertyListsFName(directory, nodeMetadata->getLabelID()),
+            StorageUtils::getUnstructuredNodePropertyListsStructureIDAndFName(
+                directory, nodeMetadata->getLabelID()),
             bufferManager, isInMemory);
     }
     IDIndex = make_unique<HashIndex>(
-        StorageUtils::getNodeIndexFName(directory, nodeMetadata->getLabelID()),
+        StorageUtils::getNodeIndexIDAndFName(directory, nodeMetadata->getLabelID()),
         properties[IDPropertyIdx].dataType, bufferManager, isInMemory);
 }
 

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -66,10 +66,10 @@ void RelTable::initAdjColumnOrLists(const Catalog& catalog,
                 adjColumns[relDirection].emplace(nodeLabel, move(adjColumn));
             } else {
                 // Add adj list.
-                auto fName =
-                    StorageUtils::getAdjListsFName(directory, relLabel, nodeLabel, relDirection);
-                auto adjList = make_unique<AdjLists>(
-                    fName, bufferManager, nodeIDCompressionScheme, isInMemoryMode);
+                auto adjList =
+                    make_unique<AdjLists>(StorageUtils::getAdjListsStructureIDAndFName(
+                                              directory, relLabel, nodeLabel, relDirection),
+                        bufferManager, nodeIDCompressionScheme, isInMemoryMode);
                 adjLists[relDirection].emplace(nodeLabel, move(adjList));
             }
         }
@@ -123,14 +123,14 @@ void RelTable::initPropertyListsForRelLabel(const Catalog& catalog, const string
         propertyLists[relDirection].emplace(
             nodeLabel, vector<unique_ptr<Lists>>(properties.size()));
         for (auto propertyIdx = 0u; propertyIdx < properties.size(); propertyIdx++) {
-            auto fName = StorageUtils::getRelPropertyListsFName(
-                directory, relLabel, nodeLabel, relDirection, properties[propertyIdx].name);
             logger->debug("relDirection {} nodeLabelForAdjColumnAndProperties {} propertyIdx {} "
                           "type {} name `{}`",
                 relDirection, nodeLabel, properties[propertyIdx].propertyID,
                 properties[propertyIdx].dataType.typeID, properties[propertyIdx].name);
-            auto propertyList = ListsFactory::getLists(fName, properties[propertyIdx].dataType,
-                adjListsHeaders, bufferManager, isInMemoryMode);
+            auto propertyList = ListsFactory::getLists(
+                StorageUtils::getRelPropertyListsStructureIDAndFName(
+                    directory, relLabel, nodeLabel, relDirection, properties[propertyIdx]),
+                properties[propertyIdx].dataType, adjListsHeaders, bufferManager, isInMemoryMode);
             propertyLists[relDirection].at(nodeLabel)[propertyIdx] = move(propertyList);
         }
     }

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -8,25 +8,40 @@ StorageStructureID StorageStructureID::newStructuredNodePropertyColumnID(
     StorageStructureID retVal;
     retVal.storageStructureType = STRUCTURED_NODE_PROPERTY_COLUMN;
     retVal.isOverflow = isOverflow;
-    retVal.structuredNodePropertyColumnID.nodeLabel = nodeLabel;
-    retVal.structuredNodePropertyColumnID.propertyID = propertyID;
+    retVal.structuredNodePropertyColumnID = StructuredNodePropertyColumnID(nodeLabel, propertyID);
     return retVal;
 }
 
-PageUpdateOrInsertRecord PageUpdateOrInsertRecord::newPageInsertOrUpdateRecord(
-    StorageStructureID storageStructureID_, uint64_t pageIdxInOriginalFile, uint64_t pageIdxInWAL,
-    bool isInsert) {
-    PageUpdateOrInsertRecord retVal;
-    retVal.storageStructureID = storageStructureID_;
-    retVal.pageIdxInOriginalFile = pageIdxInOriginalFile;
-    retVal.pageIdxInWAL = pageIdxInWAL;
-    retVal.isInsert = isInsert;
+StorageStructureID StorageStructureID::newNodeIndexID(label_t nodeLabel) {
+    StorageStructureID retVal;
+    retVal.storageStructureType = NODE_INDEX;
+    retVal.nodeIndexID = NodeIndexID(nodeLabel);
     return retVal;
 }
 
-CommitRecord CommitRecord::newCommitRecord(uint64_t transactionID) {
-    CommitRecord retVal;
-    retVal.transactionID = transactionID;
+StorageStructureID StorageStructureID::newUnstructuredNodePropertyListsID(
+    label_t nodeLabel, ListFileType listFileType) {
+    StorageStructureID retVal;
+    retVal.storageStructureType = LISTS;
+    retVal.listFileID = ListFileID(listFileType, UnstructuredNodePropertyListsID(nodeLabel));
+    return retVal;
+}
+
+StorageStructureID StorageStructureID::newAdjListsID(
+    label_t relLabel, label_t srcNodeLabel, RelDirection dir, ListFileType listFileType) {
+    StorageStructureID retVal;
+    retVal.storageStructureType = LISTS;
+    retVal.listFileID =
+        ListFileID(listFileType, AdjListsID(RelNodeLabelAndDir(relLabel, srcNodeLabel, dir)));
+    return retVal;
+}
+
+StorageStructureID StorageStructureID::newRelPropertyListsID(label_t relLabel, label_t srcNodeLabel,
+    RelDirection dir, uint32_t propertyID, ListFileType listFileType) {
+    StorageStructureID retVal;
+    retVal.storageStructureType = LISTS;
+    retVal.listFileID = ListFileID(listFileType,
+        RelPropertyListID(RelNodeLabelAndDir(relLabel, srcNodeLabel, dir), propertyID));
     return retVal;
 }
 
@@ -34,7 +49,7 @@ WALRecord WALRecord::newPageInsertOrUpdateRecord(StorageStructureID storageStruc
     uint64_t pageIdxInOriginalFile, uint64_t pageIdxInWAL, bool isInsert) {
     WALRecord retVal;
     retVal.recordType = PAGE_UPDATE_OR_INSERT_RECORD;
-    retVal.pageInsertOrUpdateRecord = PageUpdateOrInsertRecord::newPageInsertOrUpdateRecord(
+    retVal.pageInsertOrUpdateRecord = PageUpdateOrInsertRecord(
         storageStructureID_, pageIdxInOriginalFile, pageIdxInWAL, isInsert);
     return retVal;
 }
@@ -54,7 +69,7 @@ WALRecord WALRecord::newPageInsertRecord(
 WALRecord WALRecord::newCommitRecord(uint64_t transactionID) {
     WALRecord retVal;
     retVal.recordType = COMMIT_RECORD;
-    retVal.commitRecord = CommitRecord::newCommitRecord(transactionID);
+    retVal.commitRecord = CommitRecord(transactionID);
     return retVal;
 }
 


### PR DESCRIPTION
This is a minor PR that is independent of the list updates. This makes all storage structures, specifically lists and hashindex, use StorageStructureIDAndFName instead of string fName. This is needed to create wal records for these structures. 