### PR TITLE
Fixes: issue 685, hash aggregation multiple threads

### DIFF
--- a/src/binder/expression/include/expression.h
+++ b/src/binder/expression/include/expression.h
@@ -40,6 +40,8 @@ public:
     Expression(ExpressionType expressionType, DataType dataType, const string& uniqueName)
         : Expression{expressionType, move(dataType), expression_vector{}, uniqueName} {}
 
+    virtual ~Expression() = default;
+
 protected:
     Expression(ExpressionType expressionType, DataTypeID dataTypeID, const string& uniqueName)
         : Expression{expressionType, DataType(dataTypeID), uniqueName} {

--- a/src/parser/expression/include/parsed_expression.h
+++ b/src/parser/expression/include/parsed_expression.h
@@ -20,6 +20,8 @@ public:
     ParsedExpression(ExpressionType type, unique_ptr<ParsedExpression> left,
         unique_ptr<ParsedExpression> right, string rawName);
 
+    virtual ~ParsedExpression() = default;
+
     inline ExpressionType getExpressionType() const { return type; }
 
     inline void setAlias(string name) { alias = move(name); }

--- a/src/planner/logical_plan/logical_operator/include/logical_scan_node_id.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_scan_node_id.h
@@ -10,7 +10,7 @@ class LogicalScanNodeID : public LogicalOperator {
 public:
     LogicalScanNodeID(string nodeID, label_t label) : nodeID{move(nodeID)}, label{label} {}
 
-    LogicalOperatorType getLogicalOperatorType() const {
+    LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_SCAN_NODE_ID;
     }
 

--- a/src/processor/include/physical_plan/operator/aggregate/base_aggregate.h
+++ b/src/processor/include/physical_plan/operator/aggregate/base_aggregate.h
@@ -18,6 +18,8 @@ protected:
 
     virtual pair<uint64_t, uint64_t> getNextRangeToRead() = 0;
 
+    virtual ~BaseAggregateSharedState() {}
+
 protected:
     mutex mtx;
     uint64_t currentOffset;

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -21,6 +21,9 @@ namespace processor {
 // task/pipeline, and probed by the HashJoinProbe operators.
 class HashJoinSharedState {
 public:
+    explicit HashJoinSharedState(vector<DataType> nonKeyDataPosesDataTypes)
+        : nonKeyDataPosesDataTypes{move(nonKeyDataPosesDataTypes)} {}
+
     void initEmptyHashTableIfNecessary(
         MemoryManager& memoryManager, unique_ptr<TableSchema> tableSchema);
 
@@ -29,10 +32,6 @@ public:
     inline JoinHashTable* getHashTable() { return hashTable.get(); }
 
     inline vector<DataType> getNonKeyDataPosesDataTypes() { return nonKeyDataPosesDataTypes; }
-
-    inline void appendNonKeyDataPosesDataTypes(const DataType& dataType) {
-        nonKeyDataPosesDataTypes.push_back(dataType);
-    }
 
 private:
     mutex hashJoinSharedStateMutex;

--- a/src/processor/include/physical_plan/operator/order_by/radix_sort.h
+++ b/src/processor/include/physical_plan/operator/order_by/radix_sort.h
@@ -34,7 +34,7 @@ public:
         vector<StringAndUnstructuredKeyColInfo> stringAndUnstructuredKeyColInfo)
         : tmpSortingResultBlock{make_unique<DataBlock>(memoryManager)},
           tmpTuplePtrSortingBlock{make_unique<DataBlock>(memoryManager)},
-          orderByKeyEncoder{orderByKeyEncoder}, factorizedTable{factorizedTable},
+          factorizedTable{factorizedTable},
           stringAndUnstructuredKeyColInfo{stringAndUnstructuredKeyColInfo},
           numBytesPerTuple{orderByKeyEncoder.getNumBytesPerTuple()}, numBytesToRadixSort{
                                                                          numBytesPerTuple - 8} {}
@@ -71,7 +71,6 @@ private:
     // MaxNumOfTuplePointers=(LARGE_PAGE_SIZE / numBytesPerTuple) <= LARGE_PAGE_SIZE. As a result,
     // we only need one dataBlock to store the tuplePointers while solving the string ties.
     unique_ptr<DataBlock> tmpTuplePtrSortingBlock;
-    OrderByKeyEncoder& orderByKeyEncoder;
     // factorizedTable stores all columns in the tuples that will be sorted, including the order by
     // key columns. RadixSort uses factorizedTable to access the full contents of the string and
     // unstructured columns when resolving ties.

--- a/src/processor/include/physical_plan/operator/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id.h
@@ -16,6 +16,7 @@ public:
         : nodeMetadata{nodeMetadata}, maxNodeOffset{UINT64_MAX}, currentNodeOffset{0} {}
 
     inline void initMaxNodeOffset(Transaction* transaction) {
+        unique_lock uLck{mtx};
         maxNodeOffset = nodeMetadata->getMaxNodeOffset(transaction);
     }
 

--- a/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
+++ b/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
@@ -67,9 +67,9 @@ bool AggregateHashTable::isAggregateValueDistinctForGroupByKeys(
 void AggregateHashTable::merge(AggregateHashTable& other) {
     shared_ptr<DataChunkState> vectorsToScanState = make_shared<DataChunkState>();
     vector<shared_ptr<ValueVector>> vectorsToScan(
-        groupByHashKeysDataTypes.size() + groupByHashKeysDataTypes.size() + 1);
+        groupByHashKeysDataTypes.size() + groupByNonHashKeysDataTypes.size());
     vector<ValueVector*> groupByHashVectors(groupByHashKeysDataTypes.size());
-    vector<ValueVector*> groupByNonHashVectors(groupByNonHashVectors.size());
+    vector<ValueVector*> groupByNonHashVectors(groupByNonHashKeysDataTypes.size());
     vector<shared_ptr<ValueVector>> hashKeyVectors(groupByHashKeysDataTypes.size());
     vector<shared_ptr<ValueVector>> nonHashKeyVectors(groupByNonHashVectors.size());
     for (auto i = 0u; i < groupByHashKeysDataTypes.size(); i++) {

--- a/src/processor/physical_plan/mapper/map_hash_join.cpp
+++ b/src/processor/physical_plan/mapper/map_hash_join.cpp
@@ -33,7 +33,13 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
         probeSideNonKeyDataPoses.push_back(mapperContext.getDataPos(expressionName));
     }
 
-    auto sharedState = make_shared<HashJoinSharedState>();
+    vector<DataType> nonKeyDataPosesDataTypes(buildSideNonKeyDataPoses.size());
+    for (auto i = 0u; i < buildSideNonKeyDataPoses.size(); i++) {
+        auto [dataChunkPos, valueVectorPos] = buildSideNonKeyDataPoses[i];
+        nonKeyDataPosesDataTypes[i] =
+            buildSideSchema.getGroup(dataChunkPos)->getExpressions()[valueVectorPos]->getDataType();
+    }
+    auto sharedState = make_shared<HashJoinSharedState>(nonKeyDataPosesDataTypes);
     // create hashJoin build
     auto buildDataInfo =
         BuildDataInfo(buildSideKeyIDDataPos, buildSideNonKeyDataPoses, isBuildSideNonKeyDataFlat);

--- a/src/processor/physical_plan/mapper/plan_mapper.cpp
+++ b/src/processor/physical_plan/mapper/plan_mapper.cpp
@@ -54,18 +54,6 @@ using namespace graphflow::planner;
 namespace graphflow {
 namespace processor {
 
-static unique_ptr<PhysicalOperator> createHashAggregate(
-    vector<unique_ptr<AggregateFunction>> aggregateFunctions, vector<DataPos> inputAggVectorsPos,
-    vector<DataPos> outputAggVectorsPos, vector<DataType> outputAggVectorsDataTypes,
-    const expression_vector& groupByExpressions, Schema* schema,
-    unique_ptr<PhysicalOperator> prevOperator, MapperContext& mapperContextBeforeAggregate,
-    MapperContext& mapperContext);
-
-static void appendGroupByExpressions(const expression_vector& groupByExpressions,
-    vector<DataPos>& inputGroupByHashKeyVectorsPos, vector<DataPos>& outputGroupByKeyVectorsPos,
-    vector<DataType>& outputGroupByKeyVectorsDataTypes, MapperContext& mapperContextBeforeAggregate,
-    MapperContext& mapperContext, Schema* schema, vector<bool>& isInputGroupByHashKeyVectorFlat);
-
 unique_ptr<PhysicalPlan> PlanMapper::mapLogicalPlanToPhysical(unique_ptr<LogicalPlan> logicalPlan) {
     auto mapperContext = MapperContext(make_unique<ResultSetDescriptor>(*logicalPlan->getSchema()));
     auto prevOperator = mapLogicalOperatorToPhysical(logicalPlan->getLastOperator(), mapperContext);

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -7,14 +7,14 @@ namespace processor {
 
 void HashJoinSharedState::initEmptyHashTableIfNecessary(
     MemoryManager& memoryManager, unique_ptr<TableSchema> tableSchema) {
-    lock_guard<mutex> lck(hashJoinSharedStateMutex);
+    unique_lock lck(hashJoinSharedStateMutex);
     if (hashTable == nullptr) {
         hashTable = make_unique<JoinHashTable>(memoryManager, 0 /* numTuples */, move(tableSchema));
     }
 }
 
 void HashJoinSharedState::mergeLocalHashTable(JoinHashTable& localHashTable) {
-    lock_guard<mutex> lck(hashJoinSharedStateMutex);
+    unique_lock lck(hashJoinSharedStateMutex);
     hashTable->getFactorizedTable()->merge(*localHashTable.getFactorizedTable());
 }
 
@@ -41,7 +41,6 @@ shared_ptr<ResultSet> HashJoinBuild::init(ExecutionContext* context) {
                                (uint32_t)sizeof(overflow_value_t)));
         }
         vectorsToAppend.push_back(vector);
-        sharedState->appendNonKeyDataPosesDataTypes(vector->dataType);
     }
     // The prev pointer column.
     tableSchema->appendColumn(make_unique<ColumnSchema>(false /* is flat */,

--- a/src/processor/physical_plan/operator/physical_operator.cpp
+++ b/src/processor/physical_plan/operator/physical_operator.cpp
@@ -63,9 +63,8 @@ void PhysicalOperator::printTimeAndNumOutputMetrics(nlohmann::json& json, Profil
     // By subtracting prevOperator runtime, we get the runtime of current operator
     auto executionTime = profiler.sumAllTimeMetricsWithKey(getTimeMetricKey()) - prevExecutionTime;
     auto numOutputTuples = profiler.sumAllNumericMetricsWithKey(getNumTupleMetricKey());
-    json["executionTime"] =
-        to_string(profiler.sumAllTimeMetricsWithKey(getTimeMetricKey()) - prevExecutionTime);
-    json["numOutputTuples"] = profiler.sumAllNumericMetricsWithKey(getNumTupleMetricKey());
+    json["executionTime"] = to_string(executionTime);
+    json["numOutputTuples"] = numOutputTuples;
 }
 
 double PhysicalOperator::getExecutionTime(Profiler& profiler) const {

--- a/test/planner/planner_test_helper.h
+++ b/test/planner/planner_test_helper.h
@@ -19,9 +19,9 @@ public:
         catalog.setUp();
         vector<unique_ptr<NodeMetadata>> nodeMetadataPerLabel;
         nodeMetadataPerLabel.push_back(
-            move(make_unique<NodeMetadata>(PERSON_LABEL_ID, NUM_PERSON_NODES)));
+            make_unique<NodeMetadata>(PERSON_LABEL_ID, NUM_PERSON_NODES));
         nodeMetadataPerLabel.push_back(
-            move(make_unique<NodeMetadata>(ORGANISATION_LABEL_ID, NUM_ORGANISATION_NODES)));
+            make_unique<NodeMetadata>(ORGANISATION_LABEL_ID, NUM_ORGANISATION_NODES));
         mockNodeMetadata = make_unique<NodesMetadata>(nodeMetadataPerLabel);
     }
 

--- a/test/runner/queries/aggregate/hash_aggregate.test
+++ b/test/runner/queries/aggregate/hash_aggregate.test
@@ -55,6 +55,7 @@ good||1
 
 -NAME OneHopAggFlatUnflatVecTest
 -QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.ID, b.gender, sum(b.age)
+-PARALLELISM 4
 ---- 9
 0|1|45
 0|2|50

--- a/test/runner/queries/order_by/order_by_tiny_snb.test
+++ b/test/runner/queries/order_by/order_by_tiny_snb.test
@@ -180,7 +180,7 @@ Alice
 # TODO(Xiyang): Fix PARALLELISM also all queries should run in multi-threading in default.
 -NAME OrderByProjectionTest
 -QUERY MATCH (a:person)-[:knows]->(b:person) with b return b.fName order by b.fName desc
-#-PARALLELISM 2
+-PARALLELISM 4
 ---- 14
 Greg
 Farooq


### PR DESCRIPTION
- This PR fixes issue 685 by setting `nonKeyDataPosesDataTypes;` in the mapper.
- Fixed a small bug in the aggregation hash table.
- Add missing virtual destructors for virtual classes (based on compiling errors on my local).