### PR TITLE
Add SelectionVector

### DIFF
--- a/src/common/data_chunk/data_chunk_state.cpp
+++ b/src/common/data_chunk/data_chunk_state.cpp
@@ -3,23 +3,14 @@
 namespace graphflow {
 namespace common {
 
-DataChunkState::DataChunkState(uint64_t capacity) : currIdx{-1}, originalSize{0}, selectedSize{0} {
-    selectedPositionsBuffer = make_unique<sel_t[]>(capacity);
-    resetSelectorToUnselected();
-}
-
-uint64_t DataChunkState::getNumSelectedValues() const {
-    return isFlat() ? 1 : selectedSize;
-}
-
 shared_ptr<DataChunkState> DataChunkState::getSingleValueDataChunkState() {
     auto state = make_shared<DataChunkState>(1);
-    state->selectedSize = 1;
+    state->selVector->selectedSize = 1;
     state->currIdx = 0;
     return state;
 }
 
-const sel_t DataChunkState::INCREMENTAL_SELECTED_POS[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+const sel_t SelectionVector::INCREMENTAL_SELECTED_POS[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
     13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36,
     37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60,
     61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84,

--- a/src/common/include/data_chunk/data_chunk.h
+++ b/src/common/include/data_chunk/data_chunk.h
@@ -31,7 +31,7 @@ public:
 
     inline void referState(const DataChunk& other) { state = other.state; }
 
-    inline uint32_t getNumValueVectors() { return valueVectors.size(); }
+    inline uint32_t getNumValueVectors() const { return valueVectors.size(); }
 
     inline shared_ptr<ValueVector> getValueVector(uint64_t valueVectorPos) {
         return valueVectors[valueVectorPos];

--- a/src/common/include/data_chunk/data_chunk_state.h
+++ b/src/common/include/data_chunk/data_chunk_state.h
@@ -12,54 +12,68 @@ using namespace std;
 namespace graphflow {
 namespace common {
 
-class DataChunkState {
-
+class SelectionVector {
 public:
-    DataChunkState() : DataChunkState(DEFAULT_VECTOR_CAPACITY) {}
-    explicit DataChunkState(uint64_t capacity);
-
-    // returns a dataChunkState for vectors holding a single value.
-    static shared_ptr<DataChunkState> getSingleValueDataChunkState();
+    explicit SelectionVector(sel_t capacity) : selectedSize{0} {
+        selectedPositionsBuffer = make_unique<sel_t[]>(capacity);
+        resetSelectorToUnselected();
+    }
 
     inline bool isUnfiltered() const {
         return selectedPositions == (sel_t*)&INCREMENTAL_SELECTED_POS;
     }
-
     inline void resetSelectorToUnselected() {
         selectedPositions = (sel_t*)&INCREMENTAL_SELECTED_POS;
     }
-
     inline void resetSelectorToValuePosBuffer() {
         selectedPositions = selectedPositionsBuffer.get();
     }
+    inline sel_t* getSelectedPositionsBuffer() { return selectedPositionsBuffer.get(); }
 
-    inline void setSelectedSize(uint64_t size) { selectedSize = size; }
-
-    void initOriginalAndSelectedSize(uint64_t size) {
-        originalSize = size;
-        selectedSize = size;
-    }
-
-    inline bool isFlat() const { return currIdx != -1; }
-
-    inline uint64_t getPositionOfCurrIdx() const { return selectedPositions[currIdx]; }
-
-    uint64_t getNumSelectedValues() const;
-
-public:
     static const sel_t INCREMENTAL_SELECTED_POS[DEFAULT_VECTOR_CAPACITY];
 
+public:
+    sel_t* selectedPositions;
+    sel_t selectedSize;
+
+private:
+    unique_ptr<sel_t[]> selectedPositionsBuffer;
+};
+
+class DataChunkState {
+
+public:
+    DataChunkState() : DataChunkState(DEFAULT_VECTOR_CAPACITY) {}
+    explicit DataChunkState(uint64_t capacity) : currIdx{-1}, originalSize{0} {
+        selVector = make_unique<SelectionVector>(capacity);
+    }
+
+    // returns a dataChunkState for vectors holding a single value.
+    static shared_ptr<DataChunkState> getSingleValueDataChunkState();
+
+    inline void initOriginalAndSelectedSize(uint64_t size) {
+        originalSize = size;
+        selVector->selectedSize = size;
+    }
+    inline bool isFlat() const { return currIdx != -1; }
+    inline bool isCurrIdxLast() const { return currIdx == selVector->selectedSize - 1; }
+    inline uint64_t getPositionOfCurrIdx() const {
+        assert(isFlat());
+        return selVector->selectedPositions[currIdx];
+    }
+    inline uint64_t getNumSelectedValues() const { return isFlat() ? 1 : selVector->selectedSize; }
+
+public:
     // The currIdx is >= 0 when vectors are flattened and -1 if the vectors are unflat.
     int64_t currIdx;
     // We need to keep track of originalSize of DataChunks to perform consistent scans of vectors
-    // or lists. This is because all of the vectors in a datachunk has to be the same length as they
-    // share the same selectedPositions array.Therefore if there is a scan after a filter on the
-    // datachunk, the selectedSize might decrease, so the scan cannot know how much it has to
-    // scan to generate a vector that is consistent with the rest of the vectors in the datachunk.
+    // or lists. This is because all the vectors in a data chunk has to be the same length as they
+    // share the same selectedPositions array.Therefore, if there is a scan after a filter on the
+    // data chunk, the selectedSize of selVector might decrease, so the scan cannot know how much it
+    // has to scan to generate a vector that is consistent with the rest of the vectors in the
+    // data chunk.
     uint64_t originalSize;
-    uint64_t selectedSize;
-    sel_t* selectedPositions;
-    unique_ptr<sel_t[]> selectedPositionsBuffer;
+    unique_ptr<SelectionVector> selVector;
 };
 
 } // namespace common

--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -85,9 +85,7 @@ private:
     bool _isSequential = false;
     unique_ptr<OverflowBuffer> overflowBuffer;
     unique_ptr<uint8_t[]> valueBuffer;
-    // This is a shared pointer because sometimes ValueVectors may share NullMasks, e.g., the result
-    // ValueVectors of unary expressions, point to the nullMasks of operands.
-    shared_ptr<NullMask> nullMask;
+    unique_ptr<NullMask> nullMask;
     uint32_t numBytesPerValue;
 };
 

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -27,11 +27,11 @@ void FunctionExpressionEvaluator::evaluate() {
     execFunc(parameters, *resultVector);
 }
 
-uint64_t FunctionExpressionEvaluator::select(sel_t* selectedPos) {
+bool FunctionExpressionEvaluator::select(SelectionVector& selVector) {
     for (auto& child : children) {
         child->evaluate();
     }
-    return selectFunc(parameters, selectedPos);
+    return selectFunc(parameters, selVector);
 }
 
 unique_ptr<BaseExpressionEvaluator> FunctionExpressionEvaluator::clone() {

--- a/src/expression_evaluator/include/base_evaluator.h
+++ b/src/expression_evaluator/include/base_evaluator.h
@@ -39,7 +39,7 @@ public:
 
     virtual void evaluate() = 0;
 
-    virtual uint64_t select(sel_t* selectedPos) = 0;
+    virtual bool select(SelectionVector& selVector) = 0;
 
     virtual unique_ptr<BaseExpressionEvaluator> clone() = 0;
 

--- a/src/expression_evaluator/include/function_evaluator.h
+++ b/src/expression_evaluator/include/function_evaluator.h
@@ -20,7 +20,7 @@ public:
 
     void evaluate() override;
 
-    uint64_t select(sel_t* selectedPos) override;
+    bool select(SelectionVector& selVector) override;
 
     unique_ptr<BaseExpressionEvaluator> clone() override;
 

--- a/src/expression_evaluator/include/literal_evaluator.h
+++ b/src/expression_evaluator/include/literal_evaluator.h
@@ -17,7 +17,7 @@ public:
 
     inline void evaluate() override {}
 
-    uint64_t select(sel_t* selectedPos) override;
+    bool select(SelectionVector& selVector) override;
 
     inline unique_ptr<BaseExpressionEvaluator> clone() override {
         return make_unique<LiteralExpressionEvaluator>(literal);

--- a/src/expression_evaluator/include/reference_evaluator.h
+++ b/src/expression_evaluator/include/reference_evaluator.h
@@ -8,14 +8,14 @@ namespace evaluator {
 class ReferenceExpressionEvaluator : public BaseExpressionEvaluator {
 
 public:
-    ReferenceExpressionEvaluator(const DataPos& vectorPos)
+    explicit ReferenceExpressionEvaluator(const DataPos& vectorPos)
         : BaseExpressionEvaluator{}, vectorPos{vectorPos} {}
 
     void init(const ResultSet& resultSet, MemoryManager* memoryManager) override;
 
     inline void evaluate() override {}
 
-    uint64_t select(sel_t* selectedPos) override;
+    bool select(SelectionVector& selVector) override;
 
     inline unique_ptr<BaseExpressionEvaluator> clone() override {
         return make_unique<ReferenceExpressionEvaluator>(vectorPos);

--- a/src/expression_evaluator/literal_evaluator.cpp
+++ b/src/expression_evaluator/literal_evaluator.cpp
@@ -12,7 +12,7 @@ void LiteralExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager*
     resultVector->state = DataChunkState::getSingleValueDataChunkState();
 }
 
-uint64_t LiteralExpressionEvaluator::select(sel_t* selectedPos) {
+bool LiteralExpressionEvaluator::select(SelectionVector& selVector) {
     auto pos = resultVector->state->getPositionOfCurrIdx();
     assert(pos == 0u);
     return resultVector->values[pos] == true && (!resultVector->isNull(pos));

--- a/src/function/aggregate/include/avg.h
+++ b/src/function/aggregate/include/avg.h
@@ -28,13 +28,13 @@ struct AvgFunction {
         auto state = reinterpret_cast<AvgState*>(state_);
         assert(!input->state->isFlat());
         if (input->hasNoNullsGuarantee()) {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                auto pos = input->state->selectedPositions[i];
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
+                auto pos = input->state->selVector->selectedPositions[i];
                 updateSingleValue(state, input, pos, multiplicity);
             }
         } else {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                auto pos = input->state->selectedPositions[i];
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
+                auto pos = input->state->selVector->selectedPositions[i];
                 if (!input->isNull(pos)) {
                     updateSingleValue(state, input, pos, multiplicity);
                 }

--- a/src/function/aggregate/include/count.h
+++ b/src/function/aggregate/include/count.h
@@ -10,12 +10,12 @@ struct CountFunction : public BaseCountFunction {
     static void updateAll(uint8_t* state_, ValueVector* input, uint64_t multiplicity) {
         auto state = reinterpret_cast<CountState*>(state_);
         if (input->hasNoNullsGuarantee()) {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
                 state->count += multiplicity;
             }
         } else {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                auto pos = input->state->selectedPositions[i];
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
+                auto pos = input->state->selVector->selectedPositions[i];
                 if (!input->isNull(pos)) {
                     state->count += multiplicity;
                 }

--- a/src/function/aggregate/include/min_max.h
+++ b/src/function/aggregate/include/min_max.h
@@ -26,13 +26,13 @@ struct MinMaxFunction {
         assert(!input->state->isFlat());
         auto state = reinterpret_cast<MinMaxState*>(state_);
         if (input->hasNoNullsGuarantee()) {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                auto pos = input->state->selectedPositions[i];
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
+                auto pos = input->state->selVector->selectedPositions[i];
                 updateSingleValue<OP>(state, input, pos);
             }
         } else {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                auto pos = input->state->selectedPositions[i];
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
+                auto pos = input->state->selVector->selectedPositions[i];
                 if (!input->isNull(pos)) {
                     updateSingleValue<OP>(state, input, pos);
                 }

--- a/src/function/aggregate/include/sum.h
+++ b/src/function/aggregate/include/sum.h
@@ -25,13 +25,13 @@ struct SumFunction {
         assert(!input->state->isFlat());
         auto state = reinterpret_cast<SumState*>(state_);
         if (input->hasNoNullsGuarantee()) {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                auto pos = input->state->selectedPositions[i];
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
+                auto pos = input->state->selVector->selectedPositions[i];
                 updateSingleValue(state, input, pos, multiplicity);
             }
         } else {
-            for (auto i = 0u; i < input->state->selectedSize; ++i) {
-                auto pos = input->state->selectedPositions[i];
+            for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
+                auto pos = input->state->selVector->selectedPositions[i];
                 if (!input->isNull(pos)) {
                     updateSingleValue(state, input, pos, multiplicity);
                 }

--- a/src/function/boolean/include/vector_boolean_operations.h
+++ b/src/function/boolean/include/vector_boolean_operations.h
@@ -25,11 +25,10 @@ private:
     }
 
     template<typename FUNC>
-    static uint64_t BinaryBooleanSelectFunction(
-        const vector<shared_ptr<ValueVector>>& params, sel_t* selectedPositions) {
+    static bool BinaryBooleanSelectFunction(
+        const vector<shared_ptr<ValueVector>>& params, SelectionVector& selVector) {
         assert(params.size() == 2);
-        return BinaryBooleanOperationExecutor::select<FUNC>(
-            *params[0], *params[1], selectedPositions);
+        return BinaryBooleanOperationExecutor::select<FUNC>(*params[0], *params[1], selVector);
     }
 
     template<typename FUNC>
@@ -40,10 +39,10 @@ private:
     }
 
     template<typename FUNC>
-    static uint64_t UnaryBooleanSelectFunction(
-        const vector<shared_ptr<ValueVector>>& params, sel_t* selectedPositions) {
+    static bool UnaryBooleanSelectFunction(
+        const vector<shared_ptr<ValueVector>>& params, SelectionVector& selVector) {
         assert(params.size() == 1);
-        return UnaryBooleanOperationExecutor::select<FUNC>(*params[0], selectedPositions);
+        return UnaryBooleanOperationExecutor::select<FUNC>(*params[0], selVector);
     }
 
     static scalar_exec_func bindBinaryExecFunction(

--- a/src/function/hash/include/vector_hash_operations.h
+++ b/src/function/hash/include/vector_hash_operations.h
@@ -21,19 +21,19 @@ struct UnaryHashOperationExecutor {
             }
         } else {
             if (operand.hasNoNullsGuarantee()) {
-                if (operand.state->isUnfiltered()) {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                if (operand.state->selVector->isUnfiltered()) {
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                         operation::Hash::operation(operandValues[i], resultValues[i]);
                     }
                 } else {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
-                        auto pos = operand.state->selectedPositions[i];
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
+                        auto pos = operand.state->selVector->selectedPositions[i];
                         operation::Hash::operation(operandValues[pos], resultValues[pos]);
                     }
                 }
             } else {
-                if (operand.state->isUnfiltered()) {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                if (operand.state->selVector->isUnfiltered()) {
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                         if (!operand.isNull(i)) {
                             operation::Hash::operation(operandValues[i], resultValues[i]);
                         } else {
@@ -41,8 +41,8 @@ struct UnaryHashOperationExecutor {
                         }
                     }
                 } else {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
-                        auto pos = operand.state->selectedPositions[i];
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
+                        auto pos = operand.state->selVector->selectedPositions[i];
                         if (!operand.isNull(pos)) {
                             operation::Hash::operation(operandValues[pos], resultValues[pos]);
                         } else {

--- a/src/function/include/binary_operation_executor.h
+++ b/src/function/include/binary_operation_executor.h
@@ -72,21 +72,21 @@ struct BinaryOperationExecutor {
         if (left.isNull(lPos)) {
             result.setAllNull();
         } else if (right.hasNoNullsGuarantee()) {
-            if (right.state->isUnfiltered()) {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+            if (right.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
                     executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         left, right, result, lPos, i, i);
                 }
             } else {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
-                    auto rPos = right.state->selectedPositions[i];
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
+                    auto rPos = right.state->selVector->selectedPositions[i];
                     executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         left, right, result, lPos, rPos, rPos);
                 }
             }
         } else {
-            if (right.state->isUnfiltered()) {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+            if (right.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
                     result.setNull(i, right.isNull(i)); // left is always not null
                     if (!result.isNull(i)) {
                         executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -94,8 +94,8 @@ struct BinaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
-                    auto rPos = right.state->selectedPositions[i];
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
+                    auto rPos = right.state->selVector->selectedPositions[i];
                     result.setNull(rPos, right.isNull(rPos)); // left is always not null
                     if (!result.isNull(rPos)) {
                         executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -114,21 +114,21 @@ struct BinaryOperationExecutor {
         if (right.isNull(rPos)) {
             result.setAllNull();
         } else if (left.hasNoNullsGuarantee()) {
-            if (left.state->isUnfiltered()) {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+            if (left.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
                     executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         left, right, result, i, rPos, i);
                 }
             } else {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
-                    auto lPos = left.state->selectedPositions[i];
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
+                    auto lPos = left.state->selVector->selectedPositions[i];
                     executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         left, right, result, lPos, rPos, lPos);
                 }
             }
         } else {
-            if (left.state->isUnfiltered()) {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+            if (left.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
                     result.setNull(i, left.isNull(i)); // right is always not null
                     if (!result.isNull(i)) {
                         executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -136,8 +136,8 @@ struct BinaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
-                    auto lPos = left.state->selectedPositions[i];
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
+                    auto lPos = left.state->selVector->selectedPositions[i];
                     result.setNull(lPos, left.isNull(lPos)); // right is always not null
                     if (!result.isNull(lPos)) {
                         executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -154,21 +154,21 @@ struct BinaryOperationExecutor {
         assert(left.state == right.state);
         result.state = left.state;
         if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
-            if (result.state->isUnfiltered()) {
-                for (uint64_t i = 0; i < result.state->selectedSize; i++) {
+            if (result.state->selVector->isUnfiltered()) {
+                for (uint64_t i = 0; i < result.state->selVector->selectedSize; i++) {
                     executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         left, right, result, i, i, i);
                 }
             } else {
-                for (uint64_t i = 0; i < result.state->selectedSize; i++) {
-                    auto pos = result.state->selectedPositions[i];
+                for (uint64_t i = 0; i < result.state->selVector->selectedSize; i++) {
+                    auto pos = result.state->selVector->selectedPositions[i];
                     executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         left, right, result, pos, pos, pos);
                 }
             }
         } else {
-            if (result.state->isUnfiltered()) {
-                for (uint64_t i = 0; i < result.state->selectedSize; i++) {
+            if (result.state->selVector->isUnfiltered()) {
+                for (uint64_t i = 0; i < result.state->selVector->selectedSize; i++) {
                     result.setNull(i, left.isNull(i) || right.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -176,8 +176,8 @@ struct BinaryOperationExecutor {
                     }
                 }
             } else {
-                for (uint64_t i = 0; i < result.state->selectedSize; i++) {
-                    auto pos = result.state->selectedPositions[i];
+                for (uint64_t i = 0; i < result.state->selVector->selectedSize; i++) {
+                    auto pos = result.state->selVector->selectedPositions[i];
                     result.setNull(pos, left.isNull(pos) || right.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -230,12 +230,12 @@ struct BinaryOperationExecutor {
 
     template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
     static void selectOnValue(ValueVector& left, ValueVector& right, uint64_t lPos, uint64_t rPos,
-        uint64_t resPos, uint64_t& numSelectedValues, sel_t* selectedPositions) {
+        uint64_t resPos, uint64_t& numSelectedValues, sel_t* selectedPositionsBuffer) {
         auto lValues = (LEFT_TYPE*)left.values;
         auto rValues = (RIGHT_TYPE*)right.values;
         uint8_t resultValue = 0;
         FUNC::operation(lValues[lPos], rValues[rPos], resultValue);
-        selectedPositions[numSelectedValues] = resPos;
+        selectedPositionsBuffer[numSelectedValues] = resPos;
         numSelectedValues += (resultValue == true);
     }
 
@@ -253,139 +253,145 @@ struct BinaryOperationExecutor {
     }
 
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
-    static uint64_t selectFlatUnFlat(
-        ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+    static bool selectFlatUnFlat(
+        ValueVector& left, ValueVector& right, SelectionVector& selVector) {
         auto lPos = left.state->getPositionOfCurrIdx();
         uint64_t numSelectedValues = 0;
+        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
         if (left.isNull(lPos)) {
             return numSelectedValues;
         } else if (right.hasNoNullsGuarantee()) {
-            if (right.state->isUnfiltered()) {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+            if (right.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
                     selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                        left, right, lPos, i, i, numSelectedValues, selectedPositions);
+                        left, right, lPos, i, i, numSelectedValues, selectedPositionsBuffer);
                 }
             } else {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
-                    auto rPos = right.state->selectedPositions[i];
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
+                    auto rPos = right.state->selVector->selectedPositions[i];
                     selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                        left, right, lPos, rPos, rPos, numSelectedValues, selectedPositions);
+                        left, right, lPos, rPos, rPos, numSelectedValues, selectedPositionsBuffer);
                 }
             }
         } else {
-            if (right.state->isUnfiltered()) {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
+            if (right.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
                     if (!right.isNull(i)) {
                         selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                            left, right, lPos, i, i, numSelectedValues, selectedPositions);
+                            left, right, lPos, i, i, numSelectedValues, selectedPositionsBuffer);
                     }
                 }
             } else {
-                for (auto i = 0u; i < right.state->selectedSize; ++i) {
-                    auto rPos = right.state->selectedPositions[i];
+                for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
+                    auto rPos = right.state->selVector->selectedPositions[i];
                     if (!right.isNull(rPos)) {
-                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                            left, right, lPos, rPos, rPos, numSelectedValues, selectedPositions);
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, lPos, rPos, rPos,
+                            numSelectedValues, selectedPositionsBuffer);
                     }
                 }
             }
         }
-        return numSelectedValues;
+        selVector.selectedSize = numSelectedValues;
+        return numSelectedValues > 0;
     }
 
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
-    static uint64_t selectUnFlatFlat(
-        ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+    static bool selectUnFlatFlat(
+        ValueVector& left, ValueVector& right, SelectionVector& selVector) {
         auto rPos = right.state->getPositionOfCurrIdx();
         uint64_t numSelectedValues = 0;
+        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
         if (right.isNull(rPos)) {
             return numSelectedValues;
         } else if (left.hasNoNullsGuarantee()) {
-            if (left.state->isUnfiltered()) {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+            if (left.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
                     selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                        left, right, i, rPos, i, numSelectedValues, selectedPositions);
+                        left, right, i, rPos, i, numSelectedValues, selectedPositionsBuffer);
                 }
             } else {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
-                    auto lPos = left.state->selectedPositions[i];
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
+                    auto lPos = left.state->selVector->selectedPositions[i];
                     selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                        left, right, lPos, rPos, lPos, numSelectedValues, selectedPositions);
+                        left, right, lPos, rPos, lPos, numSelectedValues, selectedPositionsBuffer);
                 }
             }
         } else {
-            if (left.state->isUnfiltered()) {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
+            if (left.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
                     if (!left.isNull(i)) {
                         selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                            left, right, i, rPos, i, numSelectedValues, selectedPositions);
+                            left, right, i, rPos, i, numSelectedValues, selectedPositionsBuffer);
                     }
                 }
             } else {
-                for (auto i = 0u; i < left.state->selectedSize; ++i) {
-                    auto lPos = left.state->selectedPositions[i];
+                for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
+                    auto lPos = left.state->selVector->selectedPositions[i];
                     if (!left.isNull(lPos)) {
-                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                            left, right, lPos, rPos, lPos, numSelectedValues, selectedPositions);
+                        selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, lPos, rPos, lPos,
+                            numSelectedValues, selectedPositionsBuffer);
                     }
                 }
             }
         }
-        return numSelectedValues;
+        selVector.selectedSize = numSelectedValues;
+        return numSelectedValues > 0;
     }
 
     // Right, left, and result vectors share the same selectedPositions.
     template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
-    static uint64_t selectBothUnFlat(
-        ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+    static bool selectBothUnFlat(
+        ValueVector& left, ValueVector& right, SelectionVector& selVector) {
         uint64_t numSelectedValues = 0;
+        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
         if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
-            if (left.state->isUnfiltered()) {
-                for (auto i = 0u; i < left.state->selectedSize; i++) {
+            if (left.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < left.state->selVector->selectedSize; i++) {
                     selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                        left, right, i, i, i, numSelectedValues, selectedPositions);
+                        left, right, i, i, i, numSelectedValues, selectedPositionsBuffer);
                 }
             } else {
-                for (auto i = 0u; i < left.state->selectedSize; i++) {
-                    auto pos = left.state->selectedPositions[i];
+                for (auto i = 0u; i < left.state->selVector->selectedSize; i++) {
+                    auto pos = left.state->selVector->selectedPositions[i];
                     selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                        left, right, pos, pos, pos, numSelectedValues, selectedPositions);
+                        left, right, pos, pos, pos, numSelectedValues, selectedPositionsBuffer);
                 }
             }
         } else {
-            if (left.state->isUnfiltered()) {
-                for (uint64_t i = 0; i < left.state->selectedSize; i++) {
+            if (left.state->selVector->isUnfiltered()) {
+                for (uint64_t i = 0; i < left.state->selVector->selectedSize; i++) {
                     auto isNull = left.isNull(i) || right.isNull(i);
                     if (!isNull) {
                         selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                            left, right, i, i, i, numSelectedValues, selectedPositions);
+                            left, right, i, i, i, numSelectedValues, selectedPositionsBuffer);
                     }
                 }
             } else {
-                for (uint64_t i = 0; i < left.state->selectedSize; i++) {
-                    auto pos = left.state->selectedPositions[i];
+                for (uint64_t i = 0; i < left.state->selVector->selectedSize; i++) {
+                    auto pos = left.state->selVector->selectedPositions[i];
                     auto isNull = left.isNull(pos) || right.isNull(pos);
                     if (!isNull) {
                         selectOnValue<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-                            left, right, pos, pos, pos, numSelectedValues, selectedPositions);
+                            left, right, pos, pos, pos, numSelectedValues, selectedPositionsBuffer);
                     }
                 }
             }
         }
-        return numSelectedValues;
+        selVector.selectedSize = numSelectedValues;
+        return numSelectedValues > 0;
     }
 
     // COMPARISON (GT, GTE, LT, LTE, EQ, NEQ), BOOLEAN (AND, OR, XOR)
     template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
-    static uint64_t select(ValueVector& left, ValueVector& right, sel_t* selectedPositions) {
+    static bool select(ValueVector& left, ValueVector& right, SelectionVector& selVector) {
         if (left.state->isFlat() && right.state->isFlat()) {
             return selectBothFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right);
         } else if (left.state->isFlat() && !right.state->isFlat()) {
-            return selectFlatUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selectedPositions);
+            return selectFlatUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selVector);
         } else if (!left.state->isFlat() && right.state->isFlat()) {
-            return selectUnFlatFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selectedPositions);
+            return selectUnFlatFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selVector);
         } else {
-            return selectBothUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selectedPositions);
+            return selectBothUnFlat<LEFT_TYPE, RIGHT_TYPE, FUNC>(left, right, selVector);
         }
     }
 };

--- a/src/function/include/ternary_operation_executor.h
+++ b/src/function/include/ternary_operation_executor.h
@@ -64,21 +64,21 @@ struct TernaryOperationExecutor {
         if (a.isNull(aPos) || b.isNull(bPos)) {
             result.setAllNull();
         } else if (c.hasNoNullsGuarantee()) {
-            if (c.state->isUnfiltered()) {
-                for (auto i = 0u; i < c.state->selectedSize; ++i) {
+            if (c.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < c.state->selVector->selectedSize; ++i) {
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, aPos, bPos, i, i);
                 }
             } else {
-                for (auto i = 0u; i < c.state->selectedSize; ++i) {
-                    auto pos = c.state->selectedPositions[i];
+                for (auto i = 0u; i < c.state->selVector->selectedSize; ++i) {
+                    auto pos = c.state->selVector->selectedPositions[i];
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, aPos, bPos, pos, pos);
                 }
             }
         } else {
-            if (c.state->isUnfiltered()) {
-                for (auto i = 0u; i < c.state->selectedSize; ++i) {
+            if (c.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < c.state->selVector->selectedSize; ++i) {
                     result.setNull(i, c.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -86,8 +86,8 @@ struct TernaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < c.state->selectedSize; ++i) {
-                    auto pos = c.state->selectedPositions[i];
+                for (auto i = 0u; i < c.state->selVector->selectedSize; ++i) {
+                    auto pos = c.state->selVector->selectedPositions[i];
                     result.setNull(pos, c.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -108,21 +108,21 @@ struct TernaryOperationExecutor {
         if (a.isNull(aPos)) {
             result.setAllNull();
         } else if (b.hasNoNullsGuarantee() && c.hasNoNullsGuarantee()) {
-            if (b.state->isUnfiltered()) {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
+            if (b.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, aPos, i, i, i);
                 }
             } else {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
-                    auto pos = b.state->selectedPositions[i];
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
+                    auto pos = b.state->selVector->selectedPositions[i];
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, aPos, pos, pos, pos);
                 }
             }
         } else {
-            if (b.state->isUnfiltered()) {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
+            if (b.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
                     result.setNull(i, b.isNull(i) || c.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -130,8 +130,8 @@ struct TernaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
-                    auto pos = b.state->selectedPositions[i];
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
+                    auto pos = b.state->selVector->selectedPositions[i];
                     result.setNull(pos, b.isNull(pos) || c.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -152,21 +152,21 @@ struct TernaryOperationExecutor {
         if (a.isNull(aPos) || c.isNull(cPos)) {
             result.setAllNull();
         } else if (b.hasNoNullsGuarantee()) {
-            if (b.state->isUnfiltered()) {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
+            if (b.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, aPos, i, cPos, i);
                 }
             } else {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
-                    auto pos = b.state->selectedPositions[i];
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
+                    auto pos = b.state->selVector->selectedPositions[i];
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, aPos, pos, cPos, pos);
                 }
             }
         } else {
-            if (b.state->isUnfiltered()) {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
+            if (b.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
                     result.setNull(i, b.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -174,8 +174,8 @@ struct TernaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < b.state->selectedSize; ++i) {
-                    auto pos = b.state->selectedPositions[i];
+                for (auto i = 0u; i < b.state->selVector->selectedSize; ++i) {
+                    auto pos = b.state->selVector->selectedPositions[i];
                     result.setNull(pos, b.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -193,21 +193,21 @@ struct TernaryOperationExecutor {
         assert(a.state == b.state && b.state == c.state);
         result.state = a.state;
         if (a.hasNoNullsGuarantee() && b.hasNoNullsGuarantee() && c.hasNoNullsGuarantee()) {
-            if (a.state->isUnfiltered()) {
-                for (uint64_t i = 0; i < a.state->selectedSize; i++) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (uint64_t i = 0; i < a.state->selVector->selectedSize; i++) {
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, i, i, i, i);
                 }
             } else {
-                for (uint64_t i = 0; i < a.state->selectedSize; i++) {
-                    auto pos = a.state->selectedPositions[i];
+                for (uint64_t i = 0; i < a.state->selVector->selectedSize; i++) {
+                    auto pos = a.state->selVector->selectedPositions[i];
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, pos, pos, pos, pos);
                 }
             }
         } else {
-            if (a.state->isUnfiltered()) {
-                for (uint64_t i = 0; i < a.state->selectedSize; i++) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (uint64_t i = 0; i < a.state->selVector->selectedSize; i++) {
                     result.setNull(i, a.isNull(i) || b.isNull(i) || c.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -215,8 +215,8 @@ struct TernaryOperationExecutor {
                     }
                 }
             } else {
-                for (uint64_t i = 0; i < a.state->selectedSize; i++) {
-                    auto pos = a.state->selectedPositions[i];
+                for (uint64_t i = 0; i < a.state->selVector->selectedSize; i++) {
+                    auto pos = a.state->selVector->selectedPositions[i];
                     result.setNull(pos, a.isNull(pos) || b.isNull(pos) || c.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -237,21 +237,21 @@ struct TernaryOperationExecutor {
         if (b.isNull(bPos) || c.isNull(cPos)) {
             result.setAllNull();
         } else if (a.hasNoNullsGuarantee()) {
-            if (a.state->isUnfiltered()) {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, i, bPos, cPos, i);
                 }
             } else {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
-                    auto pos = a.state->selectedPositions[i];
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
+                    auto pos = a.state->selVector->selectedPositions[i];
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, pos, bPos, cPos, pos);
                 }
             }
         } else {
-            if (a.state->isUnfiltered()) {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
                     result.setNull(i, a.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -259,8 +259,8 @@ struct TernaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
-                    auto pos = a.state->selectedPositions[i];
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
+                    auto pos = a.state->selVector->selectedPositions[i];
                     result.setNull(pos, a.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -281,21 +281,21 @@ struct TernaryOperationExecutor {
         if (b.isNull(bPos)) {
             result.setAllNull();
         } else if (a.hasNoNullsGuarantee() && c.hasNoNullsGuarantee()) {
-            if (a.state->isUnfiltered()) {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, i, bPos, i, i);
                 }
             } else {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
-                    auto pos = a.state->selectedPositions[i];
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
+                    auto pos = a.state->selVector->selectedPositions[i];
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, pos, bPos, pos, pos);
                 }
             }
         } else {
-            if (a.state->isUnfiltered()) {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
                     result.setNull(i, a.isNull(i) || c.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -303,8 +303,8 @@ struct TernaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
-                    auto pos = b.state->selectedPositions[i];
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
+                    auto pos = b.state->selVector->selectedPositions[i];
                     result.setNull(pos, a.isNull(pos) || c.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -325,21 +325,21 @@ struct TernaryOperationExecutor {
         if (c.isNull(cPos)) {
             result.setAllNull();
         } else if (a.hasNoNullsGuarantee() && b.hasNoNullsGuarantee()) {
-            if (a.state->isUnfiltered()) {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, i, i, cPos, i);
                 }
             } else {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
-                    auto pos = a.state->selectedPositions[i];
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
+                    auto pos = a.state->selVector->selectedPositions[i];
                     executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                         a, b, c, result, pos, pos, cPos, pos);
                 }
             }
         } else {
-            if (a.state->isUnfiltered()) {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
+            if (a.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
                     result.setNull(i, a.isNull(i) || b.isNull(i));
                     if (!result.isNull(i)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -347,8 +347,8 @@ struct TernaryOperationExecutor {
                     }
                 }
             } else {
-                for (auto i = 0u; i < a.state->selectedSize; ++i) {
-                    auto pos = a.state->selectedPositions[i];
+                for (auto i = 0u; i < a.state->selVector->selectedSize; ++i) {
+                    auto pos = a.state->selVector->selectedPositions[i];
                     result.setNull(pos, a.isNull(pos) || b.isNull(pos));
                     if (!result.isNull(pos)) {
                         executeOnValue<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(

--- a/src/function/include/unary_operation_executor.h
+++ b/src/function/include/unary_operation_executor.h
@@ -59,21 +59,21 @@ struct UnaryOperationExecutor {
             }
         } else {
             if (operand.hasNoNullsGuarantee()) {
-                if (operand.state->isUnfiltered()) {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                if (operand.state->selVector->isUnfiltered()) {
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                         executeOnValue<OPERAND_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                             operand, i, resultValues[i], result);
                     }
                 } else {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
-                        auto pos = operand.state->selectedPositions[i];
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
+                        auto pos = operand.state->selVector->selectedPositions[i];
                         executeOnValue<OPERAND_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
                             operand, pos, resultValues[pos], result);
                     }
                 }
             } else {
-                if (operand.state->isUnfiltered()) {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
+                if (operand.state->selVector->isUnfiltered()) {
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                         result.setNull(i, operand.isNull(i));
                         if (!result.isNull(i)) {
                             executeOnValue<OPERAND_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(
@@ -81,8 +81,8 @@ struct UnaryOperationExecutor {
                         }
                     }
                 } else {
-                    for (auto i = 0u; i < operand.state->selectedSize; i++) {
-                        auto pos = operand.state->selectedPositions[i];
+                    for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
+                        auto pos = operand.state->selVector->selectedPositions[i];
                         result.setNull(pos, operand.isNull(pos));
                         if (!result.isNull(pos)) {
                             executeOnValue<OPERAND_TYPE, RESULT_TYPE, FUNC, OP_WRAPPER>(

--- a/src/function/include/vector_operations.h
+++ b/src/function/include/vector_operations.h
@@ -18,7 +18,8 @@ namespace function {
 struct VectorOperationDefinition;
 
 using scalar_exec_func = std::function<void(const vector<shared_ptr<ValueVector>>&, ValueVector&)>;
-using scalar_select_func = std::function<uint64_t(const vector<shared_ptr<ValueVector>>&, sel_t*)>;
+using scalar_select_func =
+    std::function<bool(const vector<shared_ptr<ValueVector>>&, SelectionVector&)>;
 using scalar_bind_func =
     std::function<void(const vector<DataType>&, VectorOperationDefinition*, DataType&)>;
 
@@ -71,11 +72,11 @@ public:
     }
 
     template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
-    static uint64_t BinarySelectFunction(
-        const vector<shared_ptr<ValueVector>>& params, sel_t* selectedPositions) {
+    static bool BinarySelectFunction(
+        const vector<shared_ptr<ValueVector>>& params, SelectionVector& selVector) {
         assert(params.size() == 2);
         return BinaryOperationExecutor::select<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-            *params[0], *params[1], selectedPositions);
+            *params[0], *params[1], selVector);
     }
 
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>

--- a/src/function/list/vector_list_operation.cpp
+++ b/src/function/list/vector_list_operation.cpp
@@ -37,8 +37,9 @@ void VectorListOperations::ListCreation(
         OverflowBufferUtils::copyListNonRecursive(
             listElements, gfList, result.dataType, result.getOverflowBuffer());
     } else {
-        for (auto selectedPos = 0u; selectedPos < result.state->selectedSize; ++selectedPos) {
-            auto pos = result.state->selectedPositions[selectedPos];
+        for (auto selectedPos = 0u; selectedPos < result.state->selVector->selectedSize;
+             ++selectedPos) {
+            auto pos = result.state->selVector->selectedPositions[selectedPos];
             auto& gfList = ((gf_list_t*)result.values)[pos];
             for (auto paramIdx = 0u; paramIdx < parameters.size(); paramIdx++) {
                 auto parameterPos = parameters[paramIdx]->state->isFlat() ?

--- a/src/function/null/include/null_operation_executor.h
+++ b/src/function/null/include/null_operation_executor.h
@@ -17,13 +17,13 @@ struct NullOperationExecutor {
             auto pos = operand.state->getPositionOfCurrIdx();
             FUNC::operation(operandValues[pos], (bool)operand.isNull(pos), resultValues[pos]);
         } else {
-            if (operand.state->isUnfiltered()) {
-                for (auto i = 0u; i < operand.state->selectedSize; i++) {
+            if (operand.state->selVector->isUnfiltered()) {
+                for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                     FUNC::operation(operandValues[i], (bool)operand.isNull(i), resultValues[i]);
                 }
             } else {
-                for (auto i = 0u; i < operand.state->selectedSize; i++) {
-                    auto pos = operand.state->selectedPositions[i];
+                for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
+                    auto pos = operand.state->selVector->selectedPositions[i];
                     FUNC::operation(
                         operandValues[pos], (bool)operand.isNull(pos), resultValues[pos]);
                 }
@@ -32,7 +32,7 @@ struct NullOperationExecutor {
     }
 
     template<typename FUNC>
-    static uint64_t select(ValueVector& operand, sel_t* selectedPositions) {
+    static bool select(ValueVector& operand, SelectionVector& selVector) {
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             uint8_t resultValue = 0;
@@ -40,21 +40,23 @@ struct NullOperationExecutor {
             return resultValue == true;
         } else {
             uint64_t numSelectedValues = 0;
-            for (auto i = 0ul; i < operand.state->selectedSize; i++) {
-                auto pos = operand.state->selectedPositions[i];
-                selectOnValue<FUNC>(operand, pos, numSelectedValues, selectedPositions);
+            auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+            for (auto i = 0ul; i < operand.state->selVector->selectedSize; i++) {
+                auto pos = operand.state->selVector->selectedPositions[i];
+                selectOnValue<FUNC>(operand, pos, numSelectedValues, selectedPositionsBuffer);
             }
-            return numSelectedValues;
+            selVector.selectedSize = numSelectedValues;
+            return numSelectedValues > 0;
         }
     }
 
     template<typename FUNC>
     static void selectOnValue(ValueVector& operand, uint64_t operandPos,
-        uint64_t& numSelectedValues, sel_t* selectedPositions) {
+        uint64_t& numSelectedValues, sel_t* selectedPositionsBuffer) {
         uint8_t resultValue = 0;
         auto operandValues = operand.values;
         FUNC::operation(operandValues[operandPos], operand.isNull(operandPos), resultValue);
-        selectedPositions[numSelectedValues] = operandPos;
+        selectedPositionsBuffer[numSelectedValues] = operandPos;
         numSelectedValues += resultValue == true;
     }
 };

--- a/src/function/null/include/vector_null_operations.h
+++ b/src/function/null/include/vector_null_operations.h
@@ -25,10 +25,10 @@ private:
     }
 
     template<typename FUNC>
-    static uint64_t UnaryNullSelectFunction(
-        const vector<shared_ptr<ValueVector>>& params, sel_t* selectedPositions) {
+    static bool UnaryNullSelectFunction(
+        const vector<shared_ptr<ValueVector>>& params, SelectionVector& selVector) {
         assert(params.size() == 1);
-        return NullOperationExecutor::select<FUNC>(*params[0], selectedPositions);
+        return NullOperationExecutor::select<FUNC>(*params[0], selVector);
     }
 
     static scalar_exec_func bindUnaryExecFunction(

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -31,6 +31,9 @@ cc_library(
     hdrs = [
         "include/physical_plan/operator/filtering_operator.h",
     ],
+    srcs = [
+        "physical_plan/operator/filtering_operator.cpp",
+    ],
     deps = [
         "//src/common:data_chunk",
     ],

--- a/src/processor/include/physical_plan/operator/filtering_operator.h
+++ b/src/processor/include/physical_plan/operator/filtering_operator.h
@@ -12,46 +12,23 @@ namespace processor {
 class FilteringOperator {
 
 public:
-    FilteringOperator()
-        : prevNumSelectedValues{0ul}, prevSelectedValues{nullptr},
-          prevSelectedValuesBuffer{make_unique<sel_t[]>(DEFAULT_VECTOR_CAPACITY)} {};
+    FilteringOperator() {
+        prevSelVector = make_unique<SelectionVector>(DEFAULT_VECTOR_CAPACITY);
+        prevSelVector->selectedPositions = nullptr;
+    }
 
 protected:
     inline void reInitToRerunSubPlan() {
-        prevNumSelectedValues = 0ul;
-        prevSelectedValues = nullptr;
+        prevSelVector->selectedSize = 0;
+        prevSelVector->selectedPositions = nullptr;
     }
 
-    inline void restoreDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect) {
-        if (prevSelectedValues == nullptr) {
-            return;
-        }
-        dataChunkToSelect->state->selectedSize = prevNumSelectedValues;
-        if (prevSelectedValues == (sel_t*)&DataChunkState::INCREMENTAL_SELECTED_POS) {
-            dataChunkToSelect->state->resetSelectorToUnselected();
-        } else {
-            dataChunkToSelect->state->resetSelectorToValuePosBuffer();
-            memcpy(dataChunkToSelect->state->selectedPositions, prevSelectedValuesBuffer.get(),
-                prevNumSelectedValues * sizeof(sel_t));
-        }
-    };
+    void restoreDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect);
 
-    inline void saveDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect) {
-        prevNumSelectedValues = dataChunkToSelect->state->selectedSize;
-        if (dataChunkToSelect->state->isUnfiltered()) {
-            prevSelectedValues = (sel_t*)&DataChunkState::INCREMENTAL_SELECTED_POS;
-        } else {
-            memcpy(prevSelectedValuesBuffer.get(),
-                dataChunkToSelect->state->selectedPositionsBuffer.get(),
-                prevNumSelectedValues * sizeof(sel_t));
-            prevSelectedValues = prevSelectedValuesBuffer.get();
-        }
-    };
+    void saveDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect);
 
 protected:
-    uint64_t prevNumSelectedValues;
-    sel_t* prevSelectedValues;
-    unique_ptr<sel_t[]> prevSelectedValuesBuffer;
+    unique_ptr<SelectionVector> prevSelVector;
 };
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/include/physical_plan/operator/source_operator.h
+++ b/src/processor/include/physical_plan/operator/source_operator.h
@@ -25,7 +25,7 @@ protected:
     void reInitToRerunSubPlan(ResultSet& resultSet) {
         for (auto& dataChunk : resultSet.dataChunks) {
             dataChunk->state->initOriginalAndSelectedSize(0);
-            dataChunk->state->resetSelectorToUnselected();
+            dataChunk->state->selVector->resetSelectorToUnselected();
             dataChunk->state->currIdx = -1;
         }
     }

--- a/src/processor/include/physical_plan/result/factorized_table.h
+++ b/src/processor/include/physical_plan/result/factorized_table.h
@@ -25,7 +25,7 @@ struct BlockAppendingInfo {
 // released when this struct goes out of scope.
 struct DataBlock {
 public:
-    DataBlock(MemoryManager* memoryManager) : numTuples{0}, memoryManager{memoryManager} {
+    explicit DataBlock(MemoryManager* memoryManager) : numTuples{0}, memoryManager{memoryManager} {
         block = memoryManager->allocateBlock(true);
         freeSize = block->size;
     }

--- a/src/processor/physical_plan/hash_table/join_hash_table.cpp
+++ b/src/processor/physical_plan/hash_table/join_hash_table.cpp
@@ -50,8 +50,9 @@ void JoinHashTable::allocateHashSlots(uint64_t numTuples) {
 // numTuplesToAppend here.
 void JoinHashTable::append(const vector<shared_ptr<ValueVector>>& vectorsToAppend) {
     assert(factorizedTable->getTableSchema()->getColumn(0)->isFlat());
-    auto numTuplesToAppend =
-        vectorsToAppend[0]->state->isFlat() ? 1 : vectorsToAppend[0]->state->selectedSize;
+    auto numTuplesToAppend = vectorsToAppend[0]->state->isFlat() ?
+                                 1 :
+                                 vectorsToAppend[0]->state->selVector->selectedSize;
     auto appendInfos = factorizedTable->allocateTupleBlocks(numTuplesToAppend);
     for (auto i = 0u; i < vectorsToAppend.size(); i++) {
         auto numAppendedTuples = 0ul;

--- a/src/processor/physical_plan/operator/aggregate/simple_aggregate_scan.cpp
+++ b/src/processor/physical_plan/operator/aggregate/simple_aggregate_scan.cpp
@@ -21,7 +21,7 @@ bool SimpleAggregateScan::getNextTuples() {
     auto outDataChunk = resultSet->dataChunks[aggregatesPos[0].dataChunkPos];
     outDataChunk->state->initOriginalAndSelectedSize(1);
     metrics->executionTime.stop();
-    metrics->numOutputTuple.increase(outDataChunk->state->selectedSize);
+    metrics->numOutputTuple.increase(outDataChunk->state->selVector->selectedSize);
     return true;
 }
 

--- a/src/processor/physical_plan/operator/filter.cpp
+++ b/src/processor/physical_plan/operator/filter.cpp
@@ -25,20 +25,15 @@ bool Filter::getNextTuples() {
             return false;
         }
         saveDataChunkSelectorState(dataChunkToSelect);
-        if (dataChunkToSelect->state->isFlat()) {
-            hasAtLeastOneSelectedValue =
-                expressionEvaluator->select(dataChunkToSelect->state->selectedPositions) > 0;
-        } else {
-            dataChunkToSelect->state->selectedSize = expressionEvaluator->select(
-                dataChunkToSelect->state->selectedPositionsBuffer.get());
-            if (dataChunkToSelect->state->isUnfiltered()) {
-                dataChunkToSelect->state->resetSelectorToValuePosBuffer();
-            }
-            hasAtLeastOneSelectedValue = dataChunkToSelect->state->selectedSize > 0;
+        hasAtLeastOneSelectedValue =
+            expressionEvaluator->select(*dataChunkToSelect->state->selVector);
+        if (!dataChunkToSelect->state->isFlat() &&
+            dataChunkToSelect->state->selVector->isUnfiltered()) {
+            dataChunkToSelect->state->selVector->resetSelectorToValuePosBuffer();
         }
     } while (!hasAtLeastOneSelectedValue);
     metrics->executionTime.stop();
-    metrics->numOutputTuple.increase(dataChunkToSelect->state->selectedSize);
+    metrics->numOutputTuple.increase(dataChunkToSelect->state->selVector->selectedSize);
     return true;
 }
 

--- a/src/processor/physical_plan/operator/filtering_operator.cpp
+++ b/src/processor/physical_plan/operator/filtering_operator.cpp
@@ -1,0 +1,34 @@
+#include "src/processor/include/physical_plan/operator/filtering_operator.h"
+
+namespace graphflow {
+namespace processor {
+
+void FilteringOperator::restoreDataChunkSelectorState(
+    const shared_ptr<DataChunk>& dataChunkToSelect) {
+    if (prevSelVector->selectedPositions == nullptr) {
+        return;
+    }
+    dataChunkToSelect->state->selVector->selectedSize = prevSelVector->selectedSize;
+    if (prevSelVector->isUnfiltered()) {
+        dataChunkToSelect->state->selVector->resetSelectorToUnselected();
+    } else {
+        dataChunkToSelect->state->selVector->resetSelectorToValuePosBuffer();
+        memcpy(dataChunkToSelect->state->selVector->selectedPositions,
+            prevSelVector->getSelectedPositionsBuffer(),
+            prevSelVector->selectedSize * sizeof(sel_t));
+    }
+}
+
+void FilteringOperator::saveDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect) {
+    prevSelVector->selectedSize = dataChunkToSelect->state->selVector->selectedSize;
+    if (dataChunkToSelect->state->selVector->isUnfiltered()) {
+        prevSelVector->resetSelectorToUnselected();
+    } else {
+        memcpy(prevSelVector->getSelectedPositionsBuffer(),
+            dataChunkToSelect->state->selVector->getSelectedPositionsBuffer(),
+            prevSelVector->selectedSize * sizeof(sel_t));
+        prevSelVector->resetSelectorToValuePosBuffer();
+    }
+}
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/physical_plan/operator/flatten.cpp
+++ b/src/processor/physical_plan/operator/flatten.cpp
@@ -16,8 +16,7 @@ void Flatten::reInitToRerunSubPlan() {
 bool Flatten::getNextTuples() {
     metrics->executionTime.start();
     // currentIdx == -1 is the check for initial case
-    if (dataChunkToFlatten->state->currIdx == -1 ||
-        dataChunkToFlatten->state->selectedSize == dataChunkToFlatten->state->currIdx + 1ul) {
+    if (dataChunkToFlatten->state->currIdx == -1 || dataChunkToFlatten->state->isCurrIdxLast()) {
         dataChunkToFlatten->state->currIdx = -1;
         if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();

--- a/src/processor/physical_plan/operator/limit.cpp
+++ b/src/processor/physical_plan/operator/limit.cpp
@@ -23,8 +23,8 @@ bool Limit::getNextTuples() {
             // = limitNumber. So execution is terminated in above if statement.
             auto& dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];
             assert(!dataChunkToSelect->state->isFlat());
-            dataChunkToSelect->state->selectedSize = numTupleToProcessInCurrentResultSet;
-            metrics->numOutputTuple.increase(dataChunkToSelect->state->selectedSize);
+            dataChunkToSelect->state->selVector->selectedSize = numTupleToProcessInCurrentResultSet;
+            metrics->numOutputTuple.increase(numTupleToProcessInCurrentResultSet);
         }
     } else {
         metrics->numOutputTuple.increase(numTupleAvailable);

--- a/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/read_list/adj_list_extend.cpp
@@ -18,7 +18,7 @@ bool AdjListExtend::getNextTuples() {
     if (largeListHandle->hasMoreToRead()) {
         readValuesFromList();
         metrics->executionTime.stop();
-        metrics->numOutputTuple.increase(outDataChunk->state->selectedSize);
+        metrics->numOutputTuple.increase(outDataChunk->state->selVector->selectedSize);
         return true;
     }
     do {
@@ -27,9 +27,9 @@ bool AdjListExtend::getNextTuples() {
             return false;
         }
         readValuesFromList();
-    } while (outDataChunk->state->selectedSize == 0);
+    } while (outDataChunk->state->selVector->selectedSize == 0);
     metrics->executionTime.stop();
-    metrics->numOutputTuple.increase(outDataChunk->state->selectedSize);
+    metrics->numOutputTuple.increase(outDataChunk->state->selVector->selectedSize);
     return true;
 }
 

--- a/src/processor/physical_plan/operator/read_list/read_list.cpp
+++ b/src/processor/physical_plan/operator/read_list/read_list.cpp
@@ -19,7 +19,7 @@ void ReadList::reInitToRerunSubPlan() {
 void ReadList::readValuesFromList() {
     auto currentIdx = inDataChunk->state->getPositionOfCurrIdx();
     if (inValueVector->isNull(currentIdx)) {
-        outValueVector->state->setSelectedSize(0);
+        outValueVector->state->selVector->selectedSize = 0;
         return;
     }
     auto nodeOffset = inValueVector->readNodeOffset(inDataChunk->state->getPositionOfCurrIdx());

--- a/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
@@ -30,7 +30,7 @@ bool AdjColumnExtend::getNextTuples() {
         hasAtLeastOneNonNullValue = NodeIDVector::discardNull(*outputVector);
     } while (!hasAtLeastOneNonNullValue);
     metrics->executionTime.stop();
-    metrics->numOutputTuple.increase(inputNodeIDDataChunk->state->selectedSize);
+    metrics->numOutputTuple.increase(inputNodeIDDataChunk->state->selVector->selectedSize);
     return true;
 }
 

--- a/src/processor/physical_plan/operator/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id.cpp
@@ -40,13 +40,13 @@ bool ScanNodeID::getNextTuples() {
             nodeIDValues[i].label = nodeTable->nodeMetadata->getLabelID();
         }
         outDataChunk->state->initOriginalAndSelectedSize(size);
-        outDataChunk->state->resetSelectorToUnselected();
+        outDataChunk->state->selVector->resetSelectorToUnselected();
         nodeTable->nodeMetadata->setDeletedNodeOffsetsForMorsel(transaction, outValueVector);
-        if (outDataChunk->state->selectedSize <= 0) {
+        if (outDataChunk->state->selVector->selectedSize <= 0) {
             continue;
         }
         metrics->executionTime.stop();
-        metrics->numOutputTuple.increase(outValueVector->state->selectedSize);
+        metrics->numOutputTuple.increase(outValueVector->state->selVector->selectedSize);
         return true;
     }
 }

--- a/src/processor/physical_plan/operator/skip.cpp
+++ b/src/processor/physical_plan/operator/skip.cpp
@@ -27,21 +27,22 @@ bool Skip::getNextTuples() {
         // If all dataChunks are flat, numTupleAvailable = 1 which means numTupleSkippedBefore =
         // skipNumber. So execution is handled in above if statement.
         assert(!dataChunkToSelect->state->isFlat());
-        auto selectedPosBuffer = dataChunkToSelect->state->selectedPositionsBuffer.get();
-        if (dataChunkToSelect->state->isUnfiltered()) {
+        auto selectedPosBuffer = dataChunkToSelect->state->selVector->getSelectedPositionsBuffer();
+        if (dataChunkToSelect->state->selVector->isUnfiltered()) {
             for (uint64_t i = numTupleToSkipInCurrentResultSet;
-                 i < dataChunkToSelect->state->selectedSize; ++i) {
+                 i < dataChunkToSelect->state->selVector->selectedSize; ++i) {
                 selectedPosBuffer[i - numTupleToSkipInCurrentResultSet] = i;
             }
-            dataChunkToSelect->state->resetSelectorToValuePosBuffer();
+            dataChunkToSelect->state->selVector->resetSelectorToValuePosBuffer();
         } else {
             for (uint64_t i = numTupleToSkipInCurrentResultSet;
-                 i < dataChunkToSelect->state->selectedSize; ++i) {
+                 i < dataChunkToSelect->state->selVector->selectedSize; ++i) {
                 selectedPosBuffer[i - numTupleToSkipInCurrentResultSet] = selectedPosBuffer[i];
             }
         }
-        dataChunkToSelect->state->selectedSize -= numTupleToSkipInCurrentResultSet;
-        metrics->numOutputTuple.increase(dataChunkToSelect->state->selectedSize);
+        dataChunkToSelect->state->selVector->selectedSize =
+            dataChunkToSelect->state->selVector->selectedSize - numTupleToSkipInCurrentResultSet;
+        metrics->numOutputTuple.increase(dataChunkToSelect->state->selVector->selectedSize);
     }
     metrics->executionTime.stop();
     return true;

--- a/src/processor/physical_plan/operator/var_length_extend/var_length_adj_list_extend.cpp
+++ b/src/processor/physical_plan/operator/var_length_extend/var_length_adj_list_extend.cpp
@@ -43,18 +43,19 @@ bool VarLengthAdjListExtend::getNextTuples() {
                 // It is impossible for the children to have a null value, so we don't need
                 // to copy the null mask to the nbrNodeValueVector.
                 memcpy(nbrNodeValueVector->values, dfsLevelInfo->children->values,
-                    dfsLevelInfo->children->state->selectedSize *
+                    dfsLevelInfo->children->state->selVector->selectedSize *
                         Types::getDataTypeSize(dfsLevelInfo->children->dataType));
-                nbrNodeValueVector->state->selectedSize =
-                    dfsLevelInfo->children->state->selectedSize;
+                nbrNodeValueVector->state->selVector->selectedSize =
+                    dfsLevelInfo->children->state->selVector->selectedSize;
                 dfsLevelInfo->hasBeenOutput = true;
                 metrics->executionTime.stop();
                 return true;
-            } else if (dfsLevelInfo->childrenIdx < dfsLevelInfo->children->state->selectedSize &&
+            } else if (dfsLevelInfo->childrenIdx <
+                           dfsLevelInfo->children->state->selVector->selectedSize &&
                        dfsLevelInfo->level != upperBound) {
                 addDFSLevelToStackIfParentExtends(
                     dfsLevelInfo->children->readNodeOffset(
-                        dfsLevelInfo->children->state
+                        dfsLevelInfo->children->state->selVector
                             ->selectedPositions[dfsLevelInfo->childrenIdx]),
                     dfsLevelInfo->level + 1);
                 dfsLevelInfo->childrenIdx++;
@@ -89,7 +90,7 @@ bool VarLengthAdjListExtend::addDFSLevelToStackIfParentExtends(uint64_t parent, 
     auto dfsLevelInfo = static_pointer_cast<AdjListExtendDFSLevelInfo>(dfsLevelInfos[level - 1]);
     dfsLevelInfo->reset(parent);
     ((AdjLists*)storage)->readValues(parent, dfsLevelInfo->children, dfsLevelInfo->largeListHandle);
-    if (dfsLevelInfo->children->state->selectedSize != 0) {
+    if (dfsLevelInfo->children->state->selVector->selectedSize != 0) {
         dfsStack.emplace(move(dfsLevelInfo));
         return true;
     }

--- a/src/processor/physical_plan/operator/var_length_extend/var_length_column_extend.cpp
+++ b/src/processor/physical_plan/operator/var_length_extend/var_length_column_extend.cpp
@@ -43,7 +43,7 @@ bool VarLengthColumnExtend::getNextTuples() {
                         Types::getDataTypeSize(dfsLevelInfo->children->dataType) *
                             dfsLevelInfo->children->state->getPositionOfCurrIdx(),
                     Types::getDataTypeSize(dfsLevelInfo->children->dataType));
-                nbrNodeValueVector->state->selectedSize = 1;
+                nbrNodeValueVector->state->selVector->selectedSize = 1;
                 dfsLevelInfo->hasBeenOutput = true;
                 metrics->executionTime.stop();
                 return true;

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -14,14 +14,14 @@ void Column::read(Transaction* transaction, const shared_ptr<ValueVector>& nodeI
         // In sequential read, we fetch start offset regardless of selected position.
         auto startOffset = nodeIDVector->readNodeOffset(0);
         auto pageCursor = PageUtils::getPageElementCursorForPos(startOffset, numElementsPerPage);
-        if (nodeIDVector->state->isUnfiltered()) {
+        if (nodeIDVector->state->selVector->isUnfiltered()) {
             scan(transaction, resultVector, pageCursor);
         } else {
             scanWithSelState(transaction, resultVector, pageCursor);
         }
     } else {
-        for (auto i = 0ul; i < nodeIDVector->state->selectedSize; i++) {
-            auto pos = nodeIDVector->state->selectedPositions[i];
+        for (auto i = 0ul; i < nodeIDVector->state->selVector->selectedSize; i++) {
+            auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             lookup(transaction, nodeIDVector, resultVector, pos);
         }
     }
@@ -35,18 +35,18 @@ void Column::writeValues(
             nodeOffset, vectorToWriteFrom, vectorToWriteFrom->state->getPositionOfCurrIdx());
     } else if (nodeIDVector->state->isFlat() && !vectorToWriteFrom->state->isFlat()) {
         auto nodeOffset = nodeIDVector->readNodeOffset(nodeIDVector->state->getPositionOfCurrIdx());
-        auto lastPos = vectorToWriteFrom->state->selectedSize - 1;
+        auto lastPos = vectorToWriteFrom->state->selVector->selectedSize - 1;
         writeValueForSingleNodeIDPosition(nodeOffset, vectorToWriteFrom, lastPos);
     } else if (!nodeIDVector->state->isFlat() && vectorToWriteFrom->state->isFlat()) {
-        for (auto i = 0u; i < nodeIDVector->state->selectedSize; ++i) {
+        for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
             auto nodeOffset =
-                nodeIDVector->readNodeOffset(nodeIDVector->state->selectedPositions[i]);
+                nodeIDVector->readNodeOffset(nodeIDVector->state->selVector->selectedPositions[i]);
             writeValueForSingleNodeIDPosition(
                 nodeOffset, vectorToWriteFrom, vectorToWriteFrom->state->getPositionOfCurrIdx());
         }
     } else if (!nodeIDVector->state->isFlat() && !vectorToWriteFrom->state->isFlat()) {
-        for (auto i = 0u; i < nodeIDVector->state->selectedSize; ++i) {
-            auto pos = nodeIDVector->state->selectedPositions[i];
+        for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
+            auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             auto nodeOffset = nodeIDVector->readNodeOffset(pos);
             writeValueForSingleNodeIDPosition(nodeOffset, vectorToWriteFrom, pos);
         }

--- a/src/storage/storage_structure/lists/list_headers.cpp
+++ b/src/storage/storage_structure/lists/list_headers.cpp
@@ -17,7 +17,7 @@ ListHeadersBuilder::ListHeadersBuilder(const string& fName, uint64_t numElements
     fileHandle = make_unique<FileHandle>(
         fName + ".headers", FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
     // DiskArray assumes that its header page already exists. To ensure that we need to add a page
-    // to the fileHandle. Currently the header page is at page 0, so we add one page here.
+    // to the fileHandle. Currently, the header page is at page 0, so we add one page here.
     fileHandle->addNewPage();
     headersBuilder = make_unique<InMemDiskArrayBuilder<list_header_t>>(
         *fileHandle, LIST_HEADERS_HEADER_PAGE_IDX, numElements);

--- a/src/storage/storage_structure/lists/lists.cpp
+++ b/src/storage/storage_structure/lists/lists.cpp
@@ -103,7 +103,7 @@ void AdjLists::readFromLargeList(const shared_ptr<ValueVector>& valueVector,
     auto numValuesToCopy = min((uint32_t)(info.listLen - csrOffset),
         numElementsPerPage - (uint32_t)(csrOffset % numElementsPerPage));
     valueVector->state->initOriginalAndSelectedSize(numValuesToCopy);
-    listSyncState->set(csrOffset, valueVector->state->selectedSize);
+    listSyncState->set(csrOffset, valueVector->state->selVector->selectedSize);
     // map logical pageIdx to physical pageIdx
     auto physicalPageId = info.mapper(info.cursor.pageIdx);
     readNodeIDsFromAPageBySequentialCopy(valueVector, 0, physicalPageId, info.cursor.posInPage,

--- a/src/storage/storage_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists.cpp
@@ -11,8 +11,8 @@ void UnstructuredPropertyLists::readProperties(ValueVector* nodeIDVector,
         auto pos = nodeIDVector->state->getPositionOfCurrIdx();
         readPropertiesForPosition(nodeIDVector, pos, propertyKeyToResultVectorMap);
     } else {
-        for (auto i = 0u; i < nodeIDVector->state->selectedSize; ++i) {
-            auto pos = nodeIDVector->state->selectedPositions[i];
+        for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
+            auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             readPropertiesForPosition(nodeIDVector, pos, propertyKeyToResultVectorMap);
         }
     }

--- a/src/storage/storage_structure/overflow_file.cpp
+++ b/src/storage/storage_structure/overflow_file.cpp
@@ -10,8 +10,8 @@ namespace storage {
 
 void OverflowFile::readStringsToVector(Transaction* transaction, ValueVector& valueVector) {
     assert(!valueVector.state->isFlat());
-    for (auto i = 0u; i < valueVector.state->selectedSize; i++) {
-        auto pos = valueVector.state->selectedPositions[i];
+    for (auto i = 0u; i < valueVector.state->selVector->selectedSize; i++) {
+        auto pos = valueVector.state->selVector->selectedPositions[i];
         if (valueVector.isNull(pos)) {
             continue;
         }
@@ -39,8 +39,8 @@ void OverflowFile::scanSequentialStringOverflow(Transaction* transaction, ValueV
     FileHandle* cachedFileHandle = nullptr;
     page_idx_t cachedPageIdx = UINT32_MAX;
     uint8_t* cachedFrame = nullptr;
-    for (auto i = 0u; i < vector.state->selectedSize; ++i) {
-        auto pos = vector.state->selectedPositions[i];
+    for (auto i = 0u; i < vector.state->selVector->selectedSize; ++i) {
+        auto pos = vector.state->selVector->selectedPositions[i];
         if (vector.isNull(pos)) {
             continue;
         }
@@ -77,8 +77,8 @@ void OverflowFile::scanSequentialStringOverflow(Transaction* transaction, ValueV
 
 void OverflowFile::readListsToVector(ValueVector& valueVector) {
     assert(!valueVector.state->isFlat());
-    for (auto i = 0u; i < valueVector.state->selectedSize; i++) {
-        auto pos = valueVector.state->selectedPositions[i];
+    for (auto i = 0u; i < valueVector.state->selVector->selectedSize; i++) {
+        auto pos = valueVector.state->selVector->selectedPositions[i];
         if (!valueVector.isNull(pos)) {
             readListToVector(((gf_list_t*)valueVector.values)[pos], valueVector.dataType,
                 valueVector.getOverflowBuffer());

--- a/src/storage/storage_structure/storage_structure.cpp
+++ b/src/storage/storage_structure/storage_structure.cpp
@@ -103,16 +103,16 @@ void BaseColumnOrList::readBySequentialCopyWithSelState(Transaction* transaction
     while (true) {
         uint64_t numValuesInPage = numElementsPerPage - cursor.posInPage;
         uint64_t numValuesToReadInPage = min(numValuesInPage, numValuesToRead - vectorPos);
-        if (isInRange(selectedState->selectedPositions[selectedStatePos], vectorPos,
+        if (isInRange(selectedState->selVector->selectedPositions[selectedStatePos], vectorPos,
                 vectorPos + numValuesToReadInPage)) {
             auto physicalPageIdx = logicalToPhysicalPageMapper(cursor.pageIdx);
             readAPageBySequentialCopy(transaction, vector, vectorPos, physicalPageIdx,
                 cursor.posInPage, numValuesToReadInPage);
         }
         vectorPos += numValuesToReadInPage;
-        while (selectedState->selectedPositions[selectedStatePos] < vectorPos) {
+        while (selectedState->selVector->selectedPositions[selectedStatePos] < vectorPos) {
             selectedStatePos++;
-            if (selectedStatePos == selectedState->selectedSize) {
+            if (selectedStatePos == selectedState->selVector->selectedSize) {
                 return;
             }
         }
@@ -148,16 +148,16 @@ void BaseColumnOrList::readNodeIDsBySequentialCopyWithSelState(
     while (true) {
         uint64_t numValuesInPage = numElementsPerPage - cursor.posInPage;
         uint64_t numValuesToReadInPage = min(numValuesInPage, numValuesToRead - vectorPos);
-        if (isInRange(selectedState->selectedPositions[selectedStatePos], vectorPos,
+        if (isInRange(selectedState->selVector->selectedPositions[selectedStatePos], vectorPos,
                 vectorPos + numValuesToReadInPage)) {
             auto physicalPageIdx = logicalToPhysicalPageMapper(cursor.pageIdx);
             readNodeIDsFromAPageBySequentialCopy(vector, vectorPos, physicalPageIdx,
                 cursor.posInPage, numValuesToReadInPage, compressionScheme, false /* isAdjList */);
         }
         vectorPos += numValuesToReadInPage;
-        while (selectedState->selectedPositions[selectedStatePos] < vectorPos) {
+        while (selectedState->selVector->selectedPositions[selectedStatePos] < vectorPos) {
             selectedStatePos++;
-            if (selectedStatePos == selectedState->selectedSize) {
+            if (selectedStatePos == selectedState->selVector->selectedSize) {
                 return;
             }
         }

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -39,8 +39,8 @@ void NodeTable::deleteNodes(ValueVector* nodeIDVector, ValueVector* primaryKeyVe
         auto pos = nodeIDVector->state->getPositionOfCurrIdx();
         deleteNode(nodeIDVector, primaryKeyVector, pos);
     } else {
-        for (auto i = 0u; i < nodeIDVector->state->selectedSize; ++i) {
-            auto pos = nodeIDVector->state->selectedPositions[i];
+        for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
+            auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             deleteNode(nodeIDVector, primaryKeyVector, pos);
         }
     }

--- a/src/storage/store/nodes_metadata.cpp
+++ b/src/storage/store/nodes_metadata.cpp
@@ -41,7 +41,7 @@ void NodeOffsetsInfo::setDeletedNodeOffsetsForMorsel(shared_ptr<ValueVector> nod
     if (hasDeletedNodesPerMorsel[morselIdxAndOffset.first]) {
         auto deletedNodeOffsets = deletedNodeOffsetsPerMorsel[morselIdxAndOffset.first];
         uint64_t morselBeginOffset = morselIdxAndOffset.first * DEFAULT_VECTOR_CAPACITY;
-        nodeOffsetVector->state->resetSelectorToValuePosBuffer();
+        nodeOffsetVector->state->selVector->resetSelectorToValuePosBuffer();
         auto itr = deletedNodeOffsets.begin();
         sel_t nextDeletedNodeOffset = *itr - morselBeginOffset;
         uint64_t nextSelectedPosition = 0;
@@ -57,10 +57,10 @@ void NodeOffsetsInfo::setDeletedNodeOffsetsForMorsel(shared_ptr<ValueVector> nod
                 nextDeletedNodeOffset = *itr - morselBeginOffset;
                 continue;
             }
-            nodeOffsetVector->state->selectedPositions[nextSelectedPosition++] = pos;
+            nodeOffsetVector->state->selVector->selectedPositions[nextSelectedPosition++] = pos;
         }
-        nodeOffsetVector->state->setSelectedSize(
-            nodeOffsetVector->state->originalSize - deletedNodeOffsets.size());
+        nodeOffsetVector->state->selVector->selectedSize =
+            nodeOffsetVector->state->originalSize - deletedNodeOffsets.size();
     }
 }
 

--- a/test/common/include/vector/operations/vector_operations_test_helper.h
+++ b/test/common/include/vector/operations/vector_operations_test_helper.h
@@ -37,7 +37,7 @@ public:
     void initDataChunk() {
         initVectors();
         dataChunk = make_shared<DataChunk>(3);
-        dataChunk->state->selectedSize = NUM_TUPLES;
+        dataChunk->state->selVector->selectedSize = NUM_TUPLES;
         dataChunk->insert(0, vector1);
         dataChunk->insert(1, vector2);
         dataChunk->insert(2, result);
@@ -53,11 +53,11 @@ public:
     void initDataChunk() {
         initVectors();
         dataChunkWithVector1 = make_shared<DataChunk>(1);
-        dataChunkWithVector1->state->selectedSize = NUM_TUPLES;
+        dataChunkWithVector1->state->selVector->selectedSize = NUM_TUPLES;
         dataChunkWithVector1->insert(0, vector1);
 
         dataChunkWithVector2AndResult = make_shared<DataChunk>(2);
-        dataChunkWithVector2AndResult->state->selectedSize = NUM_TUPLES;
+        dataChunkWithVector2AndResult->state->selVector->selectedSize = NUM_TUPLES;
         dataChunkWithVector2AndResult->insert(0, vector2);
         dataChunkWithVector2AndResult->insert(1, result);
     }

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -99,7 +99,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
 
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Divide,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
+    for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
         ASSERT_EQ(resultData[i], i / (110 - i));
         ASSERT_FALSE(result->isNull(i));
     }
@@ -107,7 +107,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
 
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Modulo,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
+    for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
         ASSERT_EQ(resultData[i], i % (110 - i));
         ASSERT_FALSE(result->isNull(i));
     }

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -206,7 +206,7 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
     auto numTuples = 1;
 
     auto dataChunk = make_shared<DataChunk>(3);
-    dataChunk->state->selectedSize = numTuples;
+    dataChunk->state->selVector->selectedSize = numTuples;
     dataChunk->state->currIdx = 0;
     auto bufferManager = make_unique<BufferManager>();
     auto memoryManager = make_unique<MemoryManager>(bufferManager.get());
@@ -284,7 +284,7 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
     auto VECTOR_SIZE = 1;
 
     auto dataChunk = make_shared<DataChunk>(3);
-    dataChunk->state->selectedSize = VECTOR_SIZE;
+    dataChunk->state->selVector->selectedSize = VECTOR_SIZE;
     dataChunk->state->currIdx = 0;
     auto bufferManager = make_unique<BufferManager>();
     auto memoryManager = make_unique<MemoryManager>(bufferManager.get());

--- a/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
+++ b/test/common/vector/operations/vector_hash_nodeid_operations_test.cpp
@@ -10,7 +10,7 @@ using namespace std;
 
 TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
     auto dataChunk = make_shared<DataChunk>(2);
-    dataChunk->state->selectedSize = 1000;
+    dataChunk->state->selVector->selectedSize = 1000;
     auto bufferManager = make_unique<BufferManager>();
     auto memoryManager = make_unique<MemoryManager>(bufferManager.get());
 
@@ -44,7 +44,7 @@ TEST(VectorHashNodeIDTests, nonSequenceNodeIDTest) {
 
 TEST(VectorHashNodeIDTests, sequenceNodeIDTest) {
     auto dataChunk = make_shared<DataChunk>(2);
-    dataChunk->state->selectedSize = 1000;
+    dataChunk->state->selVector->selectedSize = 1000;
     auto bufferManager = make_unique<BufferManager>();
     auto memoryManager = make_unique<MemoryManager>(bufferManager.get());
 

--- a/test/common/vector/value_vector_test.cpp
+++ b/test/common/vector/value_vector_test.cpp
@@ -14,7 +14,7 @@ TEST(ValueVectorTests, TestDefaultHasNull) {
     shared_ptr<DataChunkState> dataChunkState =
         make_shared<DataChunkState>(DEFAULT_VECTOR_CAPACITY);
     valueVector.state = dataChunkState;
-    valueVector.state->selectedSize = 3;
+    valueVector.state->selVector->selectedSize = 3;
     for (int i = 0; i < 3; ++i) {
         ((uint64_t*)valueVector.values)[i] = i;
     }

--- a/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
+++ b/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
@@ -39,7 +39,7 @@ public:
                 unStrValueVector->setNull(i, true /* isNull */);
             }
         }
-        dataChunk->state->selectedSize = 100;
+        dataChunk->state->selVector->selectedSize = 100;
         dataChunk->insert(0, int64ValueVector);
         dataChunk->insert(1, doubleValueVector);
         dataChunk->insert(2, stringValueVector);

--- a/test/expression_evaluator/operation_executor_test.cpp
+++ b/test/expression_evaluator/operation_executor_test.cpp
@@ -23,10 +23,10 @@ public:
         unFlatDataChunk = make_shared<DataChunk>(5);
 
         flatDataChunk->state->currIdx = 0;
-        flatDataChunk->state->selectedSize = 3;
+        flatDataChunk->state->selVector->selectedSize = 3;
         flatDataChunk->state->originalSize = 3;
         unFlatDataChunk->state->currIdx = -1;
-        unFlatDataChunk->state->selectedSize = 3;
+        unFlatDataChunk->state->selVector->selectedSize = 3;
         unFlatDataChunk->state->originalSize = 3;
 
         flatDataChunk->insert(0, getStringValueVector());
@@ -64,7 +64,8 @@ public:
                 if (expectedValues[i] == "") {
                     ASSERT_EQ(valueVector->isNull(i), true);
                 } else {
-                    ASSERT_EQ(actualValues[valueVector->state->selectedPositions[i]].getAsString(),
+                    ASSERT_EQ(actualValues[valueVector->state->selVector->selectedPositions[i]]
+                                  .getAsString(),
                         expectedValues[i]);
                 }
             }
@@ -79,17 +80,17 @@ public:
             ASSERT_EQ(actualValues[valueVector->state->getPositionOfCurrIdx()], expectedValues[0]);
         } else {
             for (auto i = 0u; i < expectedValues.size(); i++) {
-                ASSERT_EQ(
-                    actualValues[valueVector->state->selectedPositions[i]], expectedValues[i]);
+                ASSERT_EQ(actualValues[valueVector->state->selVector->selectedPositions[i]],
+                    expectedValues[i]);
             }
         }
     }
 
     void setUnFlatDataChunkFiltered() {
-        unFlatDataChunk->state->selectedSize = 2;
-        unFlatDataChunk->state->resetSelectorToValuePosBuffer();
-        unFlatDataChunk->state->selectedPositions[0] = (sel_t)0;
-        unFlatDataChunk->state->selectedPositions[1] = (sel_t)2;
+        unFlatDataChunk->state->selVector->selectedSize = 2;
+        unFlatDataChunk->state->selVector->resetSelectorToValuePosBuffer();
+        unFlatDataChunk->state->selVector->selectedPositions[0] = (sel_t)0;
+        unFlatDataChunk->state->selVector->selectedPositions[1] = (sel_t)2;
     }
 
     // Since nullmask is a private field of valueVector, we do this trick to let
@@ -390,7 +391,6 @@ TEST_F(OperationExecutorTest, NullOperationExecutorUnFlatFiltered) {
 TEST_F(OperationExecutorTest, NullOperationSelect) {
     vector<bool> expectedResult = {true};
     flatValueVectorA->setNull(0, true);
-    ASSERT_EQ(NullOperationExecutor::select<operation::IsNull>(
-                  *flatValueVectorA, nullptr /* selectedPositions */),
-        true);
+    SelectionVector selVector(DEFAULT_VECTOR_CAPACITY);
+    ASSERT_EQ(NullOperationExecutor::select<operation::IsNull>(*flatValueVectorA, selVector), true);
 }

--- a/test/processor/physical_plan/hash_table/aggregate_hash_table_test.cpp
+++ b/test/processor/physical_plan/hash_table/aggregate_hash_table_test.cpp
@@ -34,10 +34,10 @@ public:
         }
         group3Values[0] = 20;
         dataChunk = make_shared<DataChunk>(4);
-        dataChunk->state->selectedSize = 100;
+        dataChunk->state->selVector->selectedSize = 100;
         dataChunk->state->currIdx = 0;
         dataChunk1 = make_shared<DataChunk>(1);
-        dataChunk1->state->selectedSize = 1;
+        dataChunk1->state->selVector->selectedSize = 1;
         dataChunk1->state->currIdx = 0;
         dataChunk->insert(0, group1Vector);
         dataChunk->insert(1, group2Vector);
@@ -64,7 +64,7 @@ public:
         aggregateVectors.push_back(nullptr);
         aggregateVectors.push_back(aggr2Vector.get());
         if (isGroupByKeyFlat) {
-            while (dataChunk->state->currIdx < dataChunk->state->selectedSize) {
+            while (dataChunk->state->currIdx < dataChunk->state->selVector->selectedSize) {
                 ht->append(
                     groupVectors, vector<ValueVector*>(), aggregateVectors, 1 /* multiplicity */);
                 dataChunk->state->currIdx++;
@@ -110,7 +110,7 @@ public:
         if (isFirstGroupByKeyFlat && isSecondGroupByKeyFlat) {
             flatGroupByVector.push_back(group1Vector.get());
             flatGroupByVector.push_back(group2Vector.get());
-            while (dataChunk->state->currIdx < dataChunk->state->selectedSize) {
+            while (dataChunk->state->currIdx < dataChunk->state->selVector->selectedSize) {
                 ht->append(
                     flatGroupByVector, unflatGroupByVector, aggregateVectors, 1 /* multiplicity */);
                 dataChunk->state->currIdx++;

--- a/test/processor/physical_plan/operator/orderBy/key_block_merger_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/key_block_merger_test.cpp
@@ -48,10 +48,10 @@ public:
         uint16_t factorizedTableIdx, bool hasPayLoadCol,
         vector<shared_ptr<FactorizedTable>>& factorizedTables, shared_ptr<DataChunk>& dataChunk) {
         GF_ASSERT(sortingData.size() == nullMasks.size());
-        dataChunk->state->selectedSize = sortingData.size();
+        dataChunk->state->selVector->selectedSize = sortingData.size();
         auto valueVector = make_shared<ValueVector>(memoryManager.get(), dataTypeID);
         auto values = (T*)valueVector->values;
-        for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
+        for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
             if (nullMasks[i]) {
                 valueVector->setNull(i, true);
             } else if constexpr (is_same<T, string>::value) {
@@ -73,7 +73,7 @@ public:
 
         if (hasPayLoadCol) {
             auto payloadValueVector = make_shared<ValueVector>(memoryManager.get(), STRING);
-            for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
+            for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
                 payloadValueVector->addString(i, to_string(i));
             }
             dataChunk->insert(1, payloadValueVector);
@@ -155,7 +155,7 @@ public:
             factorizedTableIdx, numTuplesPerBlockInFT);
 
         auto factorizedTable = make_unique<FactorizedTable>(memoryManager.get(), move(tableSchema));
-        for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
+        for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
             factorizedTable->append(orderByVectors);
             orderByKeyEncoder.encodeKeys();
             dataChunk->state->currIdx++;
@@ -170,7 +170,7 @@ public:
         shared_ptr<DataChunk>& dataChunk) {
         assert(int64Values.size() == doubleValues.size());
         assert(doubleValues.size() == timestampValues.size());
-        dataChunk->state->selectedSize = int64Values.size();
+        dataChunk->state->selVector->selectedSize = int64Values.size();
         dataChunk->state->currIdx = 0;
 
         auto int64ValueVector = make_shared<ValueVector>(memoryManager.get(), INT64);
@@ -283,7 +283,7 @@ public:
         vector<vector<string>>& strValues, uint16_t factorizedTableIdx,
         vector<shared_ptr<FactorizedTable>>& factorizedTables) {
         dataChunk->state->currIdx = 0;
-        dataChunk->state->selectedSize = strValues[0].size();
+        dataChunk->state->selVector->selectedSize = strValues[0].size();
         for (auto i = 0u; i < strValues.size(); i++) {
             auto strValueVector = make_shared<ValueVector>(memoryManager.get(), STRING);
             dataChunk->insert(i, strValueVector);

--- a/test/processor/physical_plan/operator/orderBy/order_by_key_encoder_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/order_by_key_encoder_test.cpp
@@ -46,7 +46,7 @@ public:
     vector<shared_ptr<ValueVector>> getInt64TestValueVector(
         const uint64_t numOfElementsPerCol, const uint64_t numOfOrderByCols, bool flatCol) {
         shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(numOfOrderByCols);
-        dataChunk->state->selectedSize = numOfElementsPerCol;
+        dataChunk->state->selVector->selectedSize = numOfElementsPerCol;
         vector<shared_ptr<ValueVector>> valueVectors;
         for (auto i = 0u; i < numOfOrderByCols; i++) {
             shared_ptr<ValueVector> valueVector =
@@ -126,7 +126,7 @@ public:
 
 TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 6;
+    dataChunk->state->selVector->selectedSize = 6;
     shared_ptr<ValueVector> int64ValueVector = make_shared<ValueVector>(memoryManager.get(), INT64);
     auto int64Values = (int64_t*)int64ValueVector->values;
     int64Values[0] = 73; // positive number
@@ -202,10 +202,10 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatWithFilterTest) {
     dataChunk->insert(0, int64ValueVector);
     // Only the first and the third value is selected, so the encoder should
     // not encode the second value.
-    int64ValueVector->state->resetSelectorToValuePosBuffer();
-    int64ValueVector->state->selectedPositions[0] = 0;
-    int64ValueVector->state->selectedPositions[1] = 2;
-    int64ValueVector->state->selectedSize = 2;
+    int64ValueVector->state->selVector->resetSelectorToValuePosBuffer();
+    int64ValueVector->state->selVector->selectedPositions[0] = 0;
+    int64ValueVector->state->selVector->selectedPositions[1] = 2;
+    int64ValueVector->state->selVector->selectedSize = 2;
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(int64ValueVector);
     auto isAscOrder = vector<bool>(1, true);
@@ -235,7 +235,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatWithFilterTest) {
 
 TEST_F(OrderByKeyEncoderTest, singleOrderByColBoolUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 3;
+    dataChunk->state->selVector->selectedSize = 3;
     shared_ptr<ValueVector> boolValueVector = make_shared<ValueVector>(memoryManager.get(), BOOL);
     auto boolValues = (bool*)boolValueVector->values;
     boolValues[0] = true;
@@ -266,7 +266,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColBoolUnflatTest) {
 
 TEST_F(OrderByKeyEncoderTest, singleOrderByColDateUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 3;
+    dataChunk->state->selVector->selectedSize = 3;
     shared_ptr<ValueVector> dateValueVector = make_shared<ValueVector>(memoryManager.get(), DATE);
     auto dateValues = (date_t*)dateValueVector->values;
     dateValues[0] = Date::FromCString("2035-07-04", strlen("2035-07-04")); // date after 1970-01-01
@@ -303,7 +303,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColDateUnflatTest) {
 
 TEST_F(OrderByKeyEncoderTest, singleOrderByColTimestampUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 3;
+    dataChunk->state->selVector->selectedSize = 3;
     shared_ptr<ValueVector> timestampValueVector =
         make_shared<ValueVector>(memoryManager.get(), TIMESTAMP);
     auto timestampValues = (timestamp_t*)timestampValueVector->values;
@@ -355,7 +355,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColTimestampUnflatTest) {
 
 TEST_F(OrderByKeyEncoderTest, singleOrderByColIntervalUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 2;
+    dataChunk->state->selVector->selectedSize = 2;
     shared_ptr<ValueVector> intervalValueVector =
         make_shared<ValueVector>(memoryManager.get(), INTERVAL);
     auto intervalValues = (interval_t*)intervalValueVector->values;
@@ -402,7 +402,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColIntervalUnflatTest) {
 
 TEST_F(OrderByKeyEncoderTest, singleOrderByColStringUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 4;
+    dataChunk->state->selVector->selectedSize = 4;
     shared_ptr<ValueVector> stringValueVector =
         make_shared<ValueVector>(memoryManager.get(), STRING);
     stringValueVector->addString(0, "short str"); // short string
@@ -475,7 +475,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColStringUnflatTest) {
 
 TEST_F(OrderByKeyEncoderTest, singleOrderByColDoubleUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 6;
+    dataChunk->state->selVector->selectedSize = 6;
     shared_ptr<ValueVector> doubleValueVector =
         make_shared<ValueVector>(memoryManager.get(), DOUBLE);
     auto doubleValues = (double*)doubleValueVector->values;
@@ -562,7 +562,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColUnstrUnflatTest) {
     // For unstr datatype, orderByEncoder should ignore the actual datatype and simply encode them
     // as 0.
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = 5;
+    dataChunk->state->selVector->selectedSize = 5;
     shared_ptr<ValueVector> unstrValueVector =
         make_shared<ValueVector>(memoryManager.get(), UNSTRUCTURED);
     auto unstrValues = (Value*)unstrValueVector->values;
@@ -582,7 +582,7 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColUnstrUnflatTest) {
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
     // For unstr values, we only need to check the nullByte and whether the encoded value is 0.
-    for (auto i = 0u; i < unstrValueVector->state->selectedSize; i++) {
+    for (auto i = 0u; i < unstrValueVector->state->selVector->selectedSize; i++) {
         if (i == 1) {
             // Note: the 2nd value is a null.
             checkNullVal(keyBlockPtr, UNSTRUCTURED, isAscOrder[0]);

--- a/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/radix_sort_test.cpp
@@ -62,10 +62,10 @@ public:
         GF_ASSERT(sortingData.size() == nullMasks.size());
         GF_ASSERT(sortingData.size() == expectedBlockOffsetOrder.size());
         auto dataChunk = make_shared<DataChunk>(hasPayLoadCol ? 2 : 1);
-        dataChunk->state->selectedSize = sortingData.size();
+        dataChunk->state->selVector->selectedSize = sortingData.size();
         auto valueVector = make_shared<ValueVector>(memoryManager.get(), dataTypeID);
         auto values = (T*)valueVector->values;
-        for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
+        for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
             if (nullMasks[i]) {
                 valueVector->setNull(i, true);
             } else if constexpr (is_same<T, string>::value) {
@@ -89,7 +89,7 @@ public:
         if (hasPayLoadCol) {
             // Create a new payloadValueVector for the payload column.
             auto payloadValueVector = make_shared<ValueVector>(memoryManager.get(), STRING);
-            for (auto i = 0u; i < dataChunk->state->selectedSize; i++) {
+            for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
                 payloadValueVector->addString(i, to_string(i));
             }
             dataChunk->insert(1, payloadValueVector);

--- a/test/processor/physical_plan/result/factorized_table_test.cpp
+++ b/test/processor/physical_plan/result/factorized_table_test.cpp
@@ -56,8 +56,8 @@ public:
             }
             vectorB2Data[i] = (double)((double)i / 2.0);
         }
-        resultSet->dataChunks[0]->state->selectedSize = 100;
-        resultSet->dataChunks[1]->state->selectedSize = 100;
+        resultSet->dataChunks[0]->state->selVector->selectedSize = 100;
+        resultSet->dataChunks[1]->state->selVector->selectedSize = 100;
     }
 
     unique_ptr<FactorizedTable> appendMultipleTuples(bool isAppendFlatVectorToUnflatCol) {
@@ -154,8 +154,8 @@ TEST_F(FactorizedTableTest, AppendAndScanOneTupleAtATime) {
         // Since A2 is an unflat column, we can only read one tuple from factorizedTable at a
         // time.
         factorizedTable->scan(vectorsToRead, i, 1);
-        ASSERT_EQ(readResultSet->dataChunks[0]->state->selectedSize, 100);
-        ASSERT_EQ(readResultSet->dataChunks[1]->state->selectedSize, 1);
+        ASSERT_EQ(readResultSet->dataChunks[0]->state->selVector->selectedSize, 100);
+        ASSERT_EQ(readResultSet->dataChunks[1]->state->selVector->selectedSize, 1);
         if (i % 10) {
             ASSERT_EQ(vectorB1->isNull(i), false);
             ASSERT_EQ(vectorB1Data[vectorB1->state->currIdx].label, 28);
@@ -177,7 +177,8 @@ TEST_F(FactorizedTableTest, AppendAndScanOneTupleAtATime) {
 
 TEST_F(FactorizedTableTest, AppendMultipleTuplesScanOneAtAtime) {
     auto factorizedTable = appendMultipleTuples(false /* isAppendFlatVectorToUnflatCol */);
-    ASSERT_EQ(factorizedTable->getNumTuples(), resultSet->dataChunks[0]->state->selectedSize);
+    ASSERT_EQ(
+        factorizedTable->getNumTuples(), resultSet->dataChunks[0]->state->selVector->selectedSize);
 
     auto readResultSet = initResultSet();
     readResultSet->dataChunks[0]->state->currIdx = -1;
@@ -193,8 +194,8 @@ TEST_F(FactorizedTableTest, AppendMultipleTuplesScanOneAtAtime) {
         // Since B1 is an unflat column in factorizedTable , we can only read one tuple from
         // factorizedTable at a time.
         factorizedTable->scan(vectorsToScan, i, 1);
-        ASSERT_EQ(readResultSet->dataChunks[0]->state->selectedSize, 1);
-        ASSERT_EQ(readResultSet->dataChunks[1]->state->selectedSize, 100);
+        ASSERT_EQ(readResultSet->dataChunks[0]->state->selVector->selectedSize, 1);
+        ASSERT_EQ(readResultSet->dataChunks[1]->state->selVector->selectedSize, 100);
         if (i % 15) {
             ASSERT_EQ(vectorA1->isNull(0), false);
             ASSERT_EQ(vectorA1Data[0].label, 18);
@@ -242,7 +243,7 @@ TEST_F(FactorizedTableTest, FactorizedTableMergeOverflowBufferTest) {
     auto numRowsToAppend = 1000;
     auto resultSet = make_unique<ResultSet>(1);
     auto dataChunk = make_shared<DataChunk>(1);
-    dataChunk->state->selectedSize = numRowsToAppend;
+    dataChunk->state->selVector->selectedSize = numRowsToAppend;
     dataChunk->state->currIdx = 0;
     shared_ptr<ValueVector> strValueVector = make_shared<ValueVector>(memoryManager.get(), STRING);
     resultSet->insert(0, dataChunk);


### PR DESCRIPTION
This is a refactoring, adding the SelectionVector class which abstracts logic related to selectedPositions.
For now, this is only used by DataChunkState, but I intend to use it in operators, e.g., HashJoin, Aggregation, OrderBy, as intermediate data structures to record updated selected positions, for example, sel positions with matched keys.

Also, changed `scalar_select_func` to take in `SelectionVector&`.

 It's annoying to review all changes, perhaps focus on following ones:
- data_chunk_state.h
- filtering_operator.h
- xxx_operation_executor.h
- filter.cpp