### PR TITLE
Seperate schema creating and data loading API in NodeLoader

### DIFF
--- a/src/catalog/BUILD.bazel
+++ b/src/catalog/BUILD.bazel
@@ -2,30 +2,33 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 
 cc_library(
     name = "catalog_structs",
-    srcs = [],
-    hdrs = glob([
+    srcs = [
+        "catalog_structs.cpp",
+    ],
+    hdrs = [
         "include/catalog_structs.h",
-    ]),
+    ],
     visibility = ["//visibility:public"],
     deps = [
+        "//src/common:configs",
         "//src/common/types",
     ],
 )
 
 cc_library(
     name = "catalog",
-    srcs = glob([
+    srcs = [
         "catalog.cpp",
-    ]),
-    hdrs = glob([
+    ],
+    hdrs = [
         "include/catalog.h",
-    ]),
+    ],
     visibility = ["//visibility:public"],
     deps = [
+        "catalog_structs",
         "//src/binder/bound_create_node_clause",
         "//src/common:configs",
         "//src/common:ser_deser",
-        "//src/common/types",
         "//src/function:built_in_vector_operations",
         "//src/function/aggregate:built_in_aggregate_functions",
         "@gabime_spdlog",

--- a/src/catalog/catalog_structs.cpp
+++ b/src/catalog/catalog_structs.cpp
@@ -1,0 +1,17 @@
+#include "include/catalog_structs.h"
+
+namespace graphflow {
+namespace catalog {
+
+void NodeLabel::addUnstructuredProperties(vector<string>& unstructuredPropertyNames) {
+    for (auto& unstrPropertyName : unstructuredPropertyNames) {
+        auto unstrPropertyId = unstructuredProperties.size();
+        unstrPropertiesNameToIdMap[unstrPropertyName] = unstrPropertyId;
+        Property property = Property::constructUnstructuredNodeProperty(
+            unstrPropertyName, unstrPropertyId, labelId);
+        unstructuredProperties.emplace_back(property);
+    }
+}
+
+} // namespace catalog
+} // namespace graphflow

--- a/src/catalog/include/catalog_structs.h
+++ b/src/catalog/include/catalog_structs.h
@@ -82,9 +82,16 @@ public:
 };
 
 struct NodeLabel : Label {
-    NodeLabel() : Label{"", 0}, primaryPropertyId{0} {}
+    NodeLabel() : NodeLabel{"", UINT64_MAX, UINT64_MAX, vector<Property>{}} {}
     NodeLabel(string labelName, label_t labelId, uint64_t primaryPropertyId,
-        vector<Property> structuredProperties, const vector<string>& unstructuredPropertyNames);
+        vector<Property> structuredProperties)
+        : Label{move(labelName), labelId}, primaryPropertyId{primaryPropertyId},
+          structuredProperties{move(structuredProperties)} {}
+
+    inline uint64_t getNumStructuredProperties() const { return structuredProperties.size(); }
+    inline bool hasUnstructuredProperties() const { return getNumUnstructuredProperties() != 0; }
+    inline uint64_t getNumUnstructuredProperties() const { return unstructuredProperties.size(); }
+    void addUnstructuredProperties(vector<string>& unstructuredPropertyNames);
 
     uint64_t primaryPropertyId;
     vector<Property> structuredProperties, unstructuredProperties;

--- a/src/loader/graph_loader.cpp
+++ b/src/loader/graph_loader.cpp
@@ -82,13 +82,11 @@ void GraphLoader::readAndParseMetadata(DatasetMetadata& metadata) {
 
 void GraphLoader::loadNodes() {
     logger->info("Starting to load nodes.");
-    auto numNodeLabels = datasetMetadata.getNumNodeFiles();
-    for (auto nodeLabel = 0u; nodeLabel < numNodeLabels; nodeLabel++) {
-        auto nodeBuilder = make_unique<InMemNodeBuilder>(nodeLabel,
-            datasetMetadata.getNodeFileDescription(nodeLabel), outputDirectory, *taskScheduler,
-            *catalog, progressBar.get());
-        nodeBuilder->load();
-        maxNodeOffsetsPerNodeLabel.push_back(nodeBuilder->getNumNodes() - 1);
+    for (auto i = 0u; i < datasetMetadata.getNumNodeFiles(); ++i) {
+        auto nodeBuilder = make_unique<InMemNodeBuilder>(datasetMetadata.getNodeFileDescription(i),
+            outputDirectory, *taskScheduler, *catalog, progressBar.get());
+        auto numNodesLoaded = nodeBuilder->load();
+        maxNodeOffsetsPerNodeLabel.push_back(numNodesLoaded - 1);
     }
     logger->info("Done loading nodes.");
 }

--- a/src/loader/in_mem_builder/include/in_mem_node_builder.h
+++ b/src/loader/in_mem_builder/include/in_mem_node_builder.h
@@ -9,20 +9,21 @@ namespace loader {
 class InMemNodeBuilder : public InMemStructuresBuilder {
 
 public:
-    InMemNodeBuilder(label_t nodeLabel, const NodeFileDescription& fileDescription,
-        string outputDirectory, TaskScheduler& taskScheduler, Catalog& catalog,
-        LoaderProgressBar* progressBar);
+    InMemNodeBuilder(const NodeFileDescription& fileDescription, string outputDirectory,
+        TaskScheduler& taskScheduler, Catalog& catalog, LoaderProgressBar* progressBar);
 
     ~InMemNodeBuilder() override = default;
 
-    inline uint64_t getNumNodes() { return numNodes; }
-    void load();
+    uint64_t load();
     void saveToFile() override;
 
 private:
+    // Create node table schema based on csv header. Note this can only create structured
+    // properties.
+    void createTableSchema();
     void initializeColumnsAndList();
     vector<string> countLinesPerBlockAndParseUnstrPropertyNames(uint64_t numStructuredProperties);
-    void populateColumnsAndCountUnstrPropertyListSizes(uint64_t numNodes);
+    void populateColumnsAndCountUnstrPropertyListSizes();
     void calcUnstrListsHeadersAndMetadata();
     void populateUnstrPropertyLists();
 
@@ -50,6 +51,7 @@ private:
 
 private:
     DataType IDType;
+    NodeLabel* nodeLabel;
     uint64_t numNodes;
     vector<unique_ptr<InMemColumn>> structuredColumns;
     unique_ptr<InMemUnstructuredLists> unstrPropertyLists;

--- a/src/loader/in_mem_builder/include/in_mem_rel_builder.h
+++ b/src/loader/in_mem_builder/include/in_mem_rel_builder.h
@@ -72,6 +72,7 @@ private:
         InMemOverflowFile* orderedStringOverflowPages, LoaderProgressBar* progressBar);
 
 private:
+    label_t label;
     RelMultiplicity relMultiplicity;
     vector<string> srcNodeLabelNames;
     vector<string> dstNodeLabelNames;

--- a/src/loader/in_mem_builder/include/in_mem_structures_builder.h
+++ b/src/loader/in_mem_builder/include/in_mem_structures_builder.h
@@ -19,9 +19,9 @@ using label_adj_lists_map_t = unordered_map<label_t, unique_ptr<InMemAdjLists>>;
 
 class InMemStructuresBuilder {
 protected:
-    InMemStructuresBuilder(label_t label, string labelName, string inputFilePath,
-        string outputDirectory, CSVReaderConfig csvReaderConfig, TaskScheduler& taskScheduler,
-        Catalog& catalog, LoaderProgressBar* progressBar);
+    InMemStructuresBuilder(string labelName, string inputFilePath, string outputDirectory,
+        CSVReaderConfig csvReaderConfig, TaskScheduler& taskScheduler, Catalog& catalog,
+        LoaderProgressBar* progressBar);
 
     virtual ~InMemStructuresBuilder() = default;
 
@@ -29,6 +29,12 @@ public:
     virtual void saveToFile() = 0;
 
 protected:
+    vector<PropertyNameDataType> parseCSVHeader(const string& filePath);
+
+    void calculateNumBlocks(const string& filePath);
+
+    uint64_t calculateNumRowsWithoutHeader();
+
     // Chunk file into fixed-size blocks. Return number of blocks.
     uint64_t parseHeaderAndChunkFile(
         const string& filePath, vector<PropertyNameDataType>& colDefinitions);
@@ -60,11 +66,10 @@ protected:
         const shared_ptr<spdlog::logger>& logger, LoaderProgressBar* progressBar);
 
 private:
-    vector<PropertyNameDataType> parseCSVFileHeader(string& header) const;
+    vector<PropertyNameDataType> parseHeaderLine(string& header) const;
 
 protected:
     shared_ptr<spdlog::logger> logger;
-    label_t label;
     string labelName;
     string inputFilePath;
     string outputDirectory;

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -34,8 +34,10 @@ public:
         personProperties.emplace_back("courseScoresPerTerm",
             DataType(LIST, make_unique<DataType>(LIST, make_unique<DataType>(INT64))));
         vector<string> unstrPropertyNames{"unstrIntProp"};
-        catalog->addNodeLabel(
-            "person", DataType(INT64), move(personProperties), unstrPropertyNames);
+        auto nodeLabel =
+            catalog->createNodeLabel("person", DataType(INT64), move(personProperties));
+        nodeLabel->addUnstructuredProperties(unstrPropertyNames);
+        catalog->addNodeLabel(move(nodeLabel));
 
         vector<PropertyNameDataType> knowsProperties;
         knowsProperties.emplace_back("START_ID_LABEL", STRING);


### PR DESCRIPTION
This PR contains the following changes
- Extract the logic of parsing leader line and create schema as an API. Future DDL execution should replace this API.
- Use unique_ptr for nodes labels that are stored in Catalog. (I believe we should rely on smart pointers to control the life cycle in our codebase. )
- Keeping a node label pointer in the node builder to avoid unnecessary access to the catalog. The right way to think of this is catalog is exposed simply because we need to add node label. Otherwise node builder should be read-only on its own node label