### PR TITLE
Rework hash join: enable unflat probe side key

### DIFF
--- a/src/common/include/vector/value_vector.h
+++ b/src/common/include/vector/value_vector.h
@@ -92,6 +92,7 @@ private:
 class NodeIDVector {
 public:
     // If there is still non-null values after discarding, return true. Otherwise, return false.
+    // For an unflat vector, its selection vector is also updated to the resultSelVector.
     static bool discardNull(ValueVector& vector);
 };
 

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -28,11 +28,11 @@ cc_library(
 
 cc_library(
     name = "filtering_operator",
-    hdrs = [
-        "include/physical_plan/operator/filtering_operator.h",
-    ],
     srcs = [
         "physical_plan/operator/filtering_operator.cpp",
+    ],
+    hdrs = [
+        "include/physical_plan/operator/filtering_operator.h",
     ],
     deps = [
         "//src/common:data_chunk",
@@ -124,6 +124,7 @@ cc_library(
         "include/physical_plan/operator/hash_join/*.h",
     ]),
     deps = [
+        "filtering_operator",
         "hash_table",
         "sink_operator",
     ],
@@ -230,7 +231,6 @@ cc_library(
         "result",
         "//src/function/aggregate:aggregate_function",
         "//src/function/hash:vector_hash_operations",
-
     ],
 )
 

--- a/src/processor/include/physical_plan/hash_table/base_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/base_hash_table.h
@@ -14,12 +14,14 @@ namespace processor {
 class BaseHashTable {
 public:
     explicit BaseHashTable(MemoryManager& memoryManager)
-        : maxNumHashSlots{0}, bitMask{0}, numSlotsPerBlockLog2{0}, slotIdxInBlockMask{0},
+        : maxNumHashSlots{0}, bitmask{0}, numSlotsPerBlockLog2{0}, slotIdxInBlockMask{0},
           memoryManager{memoryManager} {}
+
+    inline uint64_t getSlotIdxForHash(hash_t hash) const { return hash & bitmask; }
 
 protected:
     uint64_t maxNumHashSlots;
-    uint64_t bitMask;
+    uint64_t bitmask;
     vector<unique_ptr<DataBlock>> hashSlotsBlocks;
     uint64_t numSlotsPerBlockLog2;
     uint64_t slotIdxInBlockMask;

--- a/src/processor/physical_plan/result/factorized_table.cpp
+++ b/src/processor/physical_plan/result/factorized_table.cpp
@@ -460,21 +460,21 @@ void FactorizedTable::readFlatColToUnflatVector(
     if (hasNoNullGuarantee(colIdx)) {
         vector.setAllNonNull();
         for (auto i = 0u; i < numTuplesToRead; i++) {
-            auto positionInVectorToRead = vector.state->selVector->selectedPositions[i];
+            auto positionInVectorToWrite = vector.state->selVector->selectedPositions[i];
             auto srcData = tuplesToRead[i] + tableSchema->getColOffset(colIdx);
             ValueVectorUtils::copyNonNullDataWithSameTypeIntoPos(
-                vector, positionInVectorToRead, srcData);
+                vector, positionInVectorToWrite, srcData);
         }
     } else {
         for (auto i = 0u; i < numTuplesToRead; i++) {
-            auto positionInVectorToRead = vector.state->selVector->selectedPositions[i];
+            auto positionInVectorToWrite = vector.state->selVector->selectedPositions[i];
             auto dataBuffer = tuplesToRead[i];
             if (isNonOverflowColNull(dataBuffer + tableSchema->getNullMapOffset(), colIdx)) {
-                vector.setNull(positionInVectorToRead, true);
+                vector.setNull(positionInVectorToWrite, true);
             } else {
-                vector.setNull(positionInVectorToRead, false);
-                ValueVectorUtils::copyNonNullDataWithSameTypeIntoPos(
-                    vector, positionInVectorToRead, dataBuffer + tableSchema->getColOffset(colIdx));
+                vector.setNull(positionInVectorToWrite, false);
+                ValueVectorUtils::copyNonNullDataWithSameTypeIntoPos(vector,
+                    positionInVectorToWrite, dataBuffer + tableSchema->getColOffset(colIdx));
             }
         }
     }


### PR DESCRIPTION
Adds the support for unflat probe side key in cases where each key has only 0 or 1 match from the hash table.

There is still a TODO in the planner that I need @andyfengHKU to take a look at and help me with.