### PR TITLE
Unique hash key

### DIFF
--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -66,7 +66,7 @@ private:
     void planPropertyScansForRel(RelExpression& rel, RelDirection direction, LogicalPlan& plan);
 
     inline void planHashJoin() {
-        auto maxLeftLevel = ceil(context->currentLevel / 2.0);
+        auto maxLeftLevel = floor(context->currentLevel / 2.0);
         for (auto leftLevel = 1; leftLevel <= maxLeftLevel; ++leftLevel) {
             auto rightLevel = context->currentLevel - leftLevel;
             planHashJoin(leftLevel, rightLevel);


### PR DESCRIPTION
This PR solves issue #700. Instead of maintaining additional info in the schema, I think the case for a unique hash key on the build side is quite limited. The condition can be described as following

- Build side has 1 group (no cartesian product)
- Build side has no multiplicity (no group has been projected out)
- JoinNodeID is the same node as in ScanNodeID. And build side plan is linear (we lose guarantee once a hash join happened or the check could be super complicated.)