### PR TITLE
avoid keeping logicalExtend info in schema

### DIFF
--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -19,8 +19,8 @@ class Enumerator {
 
 public:
     explicit Enumerator(const Catalog& catalog, const NodesMetadata& nodesMetadata)
-        : joinOrderEnumerator{catalog, nodesMetadata, this}, projectionEnumerator{catalog, this},
-          updatePlanner{catalog, this} {}
+        : catalog{catalog}, joinOrderEnumerator{catalog, nodesMetadata, this},
+          projectionEnumerator{catalog, this}, updatePlanner{catalog, this} {}
 
     vector<unique_ptr<LogicalPlan>> getAllPlans(const BoundRegularQuery& regularQuery);
 
@@ -73,14 +73,14 @@ private:
     void appendScanNodePropIfNecessary(
         expression_vector& properties, NodeExpression& node, LogicalPlan& plan, bool isStructured);
 
-    inline void appendScanRelPropsIfNecessary(
-        expression_vector& properties, RelExpression& rel, LogicalPlan& plan) {
+    inline void appendScanRelPropsIfNecessary(expression_vector& properties, RelExpression& rel,
+        RelDirection direction, LogicalPlan& plan) {
         for (auto& property : properties) {
-            appendScanRelPropIfNecessary(property, rel, plan);
+            appendScanRelPropIfNecessary(property, rel, direction, plan);
         }
     }
-    void appendScanRelPropIfNecessary(
-        shared_ptr<Expression>& expression, RelExpression& rel, LogicalPlan& plan);
+    void appendScanRelPropIfNecessary(shared_ptr<Expression>& expression, RelExpression& rel,
+        RelDirection direction, LogicalPlan& plan);
 
     unique_ptr<LogicalPlan> createUnionPlan(
         vector<unique_ptr<LogicalPlan>>& childrenPlans, bool isUnionAll);
@@ -119,6 +119,7 @@ private:
         vector<vector<unique_ptr<LogicalPlan>>> childrenLogicalPlans);
 
 private:
+    const Catalog& catalog;
     expression_vector propertiesToScan;
     JoinOrderEnumerator joinOrderEnumerator;
     ProjectionEnumerator projectionEnumerator;

--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -60,9 +60,10 @@ private:
     void planRelINPJoin(const SubqueryGraph& prevSubgraph, uint32_t relPos,
         vector<unique_ptr<LogicalPlan>>& prevPlans);
     // Filter push down for rel table.
-    void planFiltersForRel(expression_vector& predicates, RelExpression& rel, LogicalPlan& plan);
+    void planFiltersForRel(expression_vector& predicates, RelExpression& rel,
+        RelDirection direction, LogicalPlan& plan);
     // Property push down for rel table.
-    void planPropertyScansForRel(RelExpression& rel, LogicalPlan& plan);
+    void planPropertyScansForRel(RelExpression& rel, RelDirection direction, LogicalPlan& plan);
 
     inline void planHashJoin() {
         auto maxLeftLevel = ceil(context->currentLevel / 2.0);

--- a/src/planner/logical_plan/logical_operator/include/schema.h
+++ b/src/planner/logical_plan/logical_operator/include/schema.h
@@ -11,8 +11,6 @@ using namespace std;
 namespace graphflow {
 namespace planner {
 
-class LogicalExtend;
-
 class FactorizationGroup {
     friend class Schema;
 
@@ -84,10 +82,6 @@ public:
     // Get the group positions containing at least one expression in scope.
     unordered_set<uint32_t> getGroupsPosInScope() const;
 
-    void addLogicalExtend(const string& queryRel, LogicalExtend* extend);
-
-    LogicalExtend* getExistingLogicalExtend(const string& queryRel);
-
     unique_ptr<Schema> copy() const;
 
     void clear();
@@ -95,9 +89,6 @@ public:
 private:
     vector<unique_ptr<FactorizationGroup>> groups;
     unordered_map<string, uint32_t> expressionNameToGroupPos;
-    // Maps a queryRel to the LogicalExtend that matches it. This is needed because ScanRelProperty
-    // requires direction information which only available in the LogicalExtend.
-    unordered_map<string, LogicalExtend*> queryRelLogicalExtendMap;
     // Our projection doesn't explicitly remove expressions. Instead, we keep track of what
     // expressions are in scope (i.e. being projected).
     expression_vector expressionsInScope;

--- a/src/planner/logical_plan/logical_operator/schema.cpp
+++ b/src/planner/logical_plan/logical_operator/schema.cpp
@@ -53,18 +53,8 @@ unordered_set<uint32_t> Schema::getGroupsPosInScope() const {
     return result;
 }
 
-void Schema::addLogicalExtend(const string& queryRel, LogicalExtend* extend) {
-    queryRelLogicalExtendMap.insert({queryRel, extend});
-}
-
-LogicalExtend* Schema::getExistingLogicalExtend(const string& queryRel) {
-    assert(queryRelLogicalExtendMap.contains(queryRel));
-    return queryRelLogicalExtendMap.at(queryRel);
-}
-
 unique_ptr<Schema> Schema::copy() const {
     auto newSchema = make_unique<Schema>();
-    newSchema->queryRelLogicalExtendMap = queryRelLogicalExtendMap;
     newSchema->expressionNameToGroupPos = expressionNameToGroupPos;
     for (auto& group : groups) {
         newSchema->groups.push_back(make_unique<FactorizationGroup>(*group));


### PR DESCRIPTION
Our RelPropertyReader reads property based on rel and direction instead of rel ID. Therefore, in the previous design, where RelPropertyReader doesn't necessarily follow an Extend. We need to save extend info (specifically rel and direction) in schema so that we know to read rel properties later now. Now since we are enforcing read immediately after extend, we don't need to save it anymore. 