### PR TITLE
simplifies wal replayer logic to not rely on storage manager during recovery

### DIFF
--- a/src/loader/in_mem_builder/in_mem_node_builder.cpp
+++ b/src/loader/in_mem_builder/in_mem_node_builder.cpp
@@ -50,7 +50,7 @@ void InMemNodeBuilder::initializeColumnsAndList() {
     structuredColumns.resize(nodeLabel->getNumStructuredProperties());
     for (auto& property : nodeLabel->structuredProperties) {
         auto fName = StorageUtils::getNodePropertyColumnFName(
-            outputDirectory, nodeLabel->labelId, property.name);
+            outputDirectory, nodeLabel->labelId, property.propertyID);
         structuredColumns[property.propertyID] =
             InMemColumnFactory::getInMemPropertyColumn(fName, property.dataType, numNodes);
     }

--- a/src/loader/in_mem_builder/in_mem_rel_builder.cpp
+++ b/src/loader/in_mem_builder/in_mem_rel_builder.cpp
@@ -137,8 +137,8 @@ void InMemRelBuilder::initializeLists(RelDirection relDirection) {
         for (auto i = 0u; i < relLabel->getNumProperties(); ++i) {
             auto propertyName = relLabel->properties[i].name;
             auto propertyDataType = relLabel->properties[i].dataType;
-            auto fName = StorageUtils::getRelPropertyListsFName(
-                outputDirectory, relLabel->labelId, nodeLabel, relDirection, propertyName);
+            auto fName = StorageUtils::getRelPropertyListsFName(outputDirectory, relLabel->labelId,
+                nodeLabel, relDirection, relLabel->properties[i].propertyID);
             propertyLists[i] =
                 InMemListsFactory::getInMemPropertyLists(fName, propertyDataType, numNodes);
         }

--- a/src/storage/buffer_manager/include/disk_array.h
+++ b/src/storage/buffer_manager/include/disk_array.h
@@ -107,8 +107,9 @@ protected:
     BaseInMemDiskArray(FileHandle& fileHandle, page_idx_t headerPageIdx);
 
 public:
-    // [] operator to be used when building an InMemDiskArrayBuilder without transactional updates.
-    // This changes the contents directly in memory and not on disk (nor on the wal)
+    // [] operator can be used to update elements, e.g., diskArray[5] = 4, when building an
+    // InMemDiskArrayBuilder without transactional updates. This changes the contents directly in
+    // memory and not on disk (nor on the wal).
     U& operator[](uint64_t idx);
 
     // TODO(Semih): This is only for debugging purposes. Will be removed.

--- a/src/storage/buffer_manager/include/versioned_file_handle.h
+++ b/src/storage/buffer_manager/include/versioned_file_handle.h
@@ -41,7 +41,7 @@ public:
     }
 
     void createPageVersionGroupIfNecessary(page_idx_t pageIdx);
-    void clearUpdatedWALPageVersion(page_idx_t pageIdx);
+    void clearUpdatedWALPageVersionIfNecessary(page_idx_t pageIdx);
 
     void setUpdatedWALPageVersionNoLock(page_idx_t originalPageIdx, page_idx_t pageIdxInWAL);
 
@@ -52,6 +52,7 @@ public:
     }
 
 private:
+    page_idx_t addNewPageWithoutLock();
     uint32_t getNumPageGroups() {
         return ceil((double)numPages / MULTI_VERSION_FILE_PAGE_GROUP_SIZE);
     }

--- a/src/storage/include/storage_manager.h
+++ b/src/storage/include/storage_manager.h
@@ -25,17 +25,18 @@ public:
     inline NodesStore& getNodesStore() const { return *nodesStore; }
     inline WAL& getWAL() const { return *wal; }
     inline void checkpointAndClearWAL() {
-        checkpointOrRollbackAndClearWAL(true /* isCheckpoint */);
+        checkpointOrRollbackAndClearWAL(false /* is not recovering */, true /* isCheckpoint */);
     }
 
     inline void rollbackAndClearWAL() {
-        checkpointOrRollbackAndClearWAL(false /* rolling back updates */);
+        checkpointOrRollbackAndClearWAL(
+            false /* is not recovering */, false /* rolling back updates */);
     }
 
     inline string getDBDirectory() { return directory; }
 
 private:
-    void checkpointOrRollbackAndClearWAL(bool isCheckpoint);
+    void checkpointOrRollbackAndClearWAL(bool isRecovering, bool isCheckpoint);
     void recoverIfNecessary();
 
 private:

--- a/src/storage/include/wal_replayer.h
+++ b/src/storage/include/wal_replayer.h
@@ -1,7 +1,12 @@
 #pragma once
 
 #include "src/storage/buffer_manager/include/buffer_manager.h"
+#include "src/storage/wal/include/wal.h"
 #include "src/storage/wal/include/wal_record.h"
+
+namespace spdlog {
+class logger;
+}
 
 namespace graphflow {
 namespace storage {
@@ -10,19 +15,26 @@ class StorageManager;
 
 class WALReplayer {
 public:
-    WALReplayer(StorageManager& storageManager, BufferManager& bufferManager, bool isCheckpoint);
+    WALReplayer(StorageManager* storageManager);
+
+    WALReplayer(StorageManager* storageManager, BufferManager* bufferManager, bool isCheckpoint);
 
     void replay();
 
 private:
+    void init();
     void replayWALRecord(WALRecord& walRecord);
 
 private:
-    StorageManager& storageManager;
-    BufferManager& bufferManager;
+    bool isRecovering;
+    bool isCheckpoint; // if true does redo operations; if false does undo operations
+    // Warning: Some fields of the storageManager may not yet be initialized if the WALReplayer
+    // has been initialized during recovery, i.e., isRecovering=true.
+    StorageManager* storageManager;
+    BufferManager* bufferManager;
     shared_ptr<FileHandle> walFileHandle;
     unique_ptr<uint8_t[]> pageBuffer;
-    bool isCheckpoint; // if true does redo operations; if false does undo operations
+    shared_ptr<spdlog::logger> logger;
 };
 
 } // namespace storage

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -99,6 +99,8 @@ UpdatedPageInfoAndWALPageFrame Column::beginUpdatingPage(node_offset_t nodeOffse
     auto originalPageCursor = PageUtils::getPageElementCursorForPos(nodeOffset, numElementsPerPage);
     if (originalPageCursor.pageIdx >= fileHandle.getNumPages()) {
         assert(originalPageCursor.pageIdx == fileHandle.getNumPages());
+        // TODO(Semih/Guodong): What if the column is in memory? How do we ensure that the file
+        // remains pinned?
         addNewPageToFileHandle();
     }
     auto updatedPageInfoAndWALPageFrame =
@@ -111,8 +113,7 @@ UpdatedPageInfoAndWALPageFrame Column::beginUpdatingPage(node_offset_t nodeOffse
     setNullBitOfAPosInFrame(updatedPageInfoAndWALPageFrame.frame,
         updatedPageInfoAndWALPageFrame.originalPageCursor.posInPage,
         vectorToWriteFrom->isNull(posInVectorToWriteFrom));
-    return UpdatedPageInfoAndWALPageFrame(updatedPageInfoAndWALPageFrame.originalPageCursor,
-        updatedPageInfoAndWALPageFrame.pageIdxInWAL, updatedPageInfoAndWALPageFrame.frame);
+    return updatedPageInfoAndWALPageFrame;
 }
 
 void Column::writeValueForSingleNodeIDPosition(node_offset_t nodeOffset,

--- a/src/storage/store/include/nodes_metadata.h
+++ b/src/storage/store/include/nodes_metadata.h
@@ -68,9 +68,9 @@ public:
     void setDeletedNodeOffsetsForMorsel(
         Transaction* transaction, shared_ptr<ValueVector> nodeOffsetVector);
 
-    void commitIfNecessary();
+    void checkpointInMemoryIfNecessary();
 
-    void rollbackIfNecessary();
+    void rollbackInMemoryIfNecessary();
 
     inline bool hasUpdates() { return nodeOffsetsInfoForWriteTrx != nullptr; }
 
@@ -146,9 +146,9 @@ public:
 
     bool hasUpdates();
 
-    void commitIfNecessary();
+    void checkpointInMemoryIfNecessary();
 
-    void rollbackIfNecessary();
+    void rollbackInMemoryIfNecessary();
 
     void readFromFile(const string& directory);
 

--- a/src/storage/store/nodes_metadata.cpp
+++ b/src/storage/store/nodes_metadata.cpp
@@ -195,12 +195,12 @@ void NodeMetadata::setDeletedNodeOffsetsForMorsel(
     nodeOffsetsInfo->setDeletedNodeOffsetsForMorsel(nodeOffsetVector);
 }
 
-void NodeMetadata::rollbackIfNecessary() {
+void NodeMetadata::rollbackInMemoryIfNecessary() {
     lock_t lck{mtx};
     nodeOffsetsInfoForWriteTrx.reset();
 }
 
-void NodeMetadata::commitIfNecessary() {
+void NodeMetadata::checkpointInMemoryIfNecessary() {
     lock_t lck{mtx};
     if (!hasUpdates()) {
         return;
@@ -224,15 +224,15 @@ bool NodesMetadata::hasUpdates() {
     return false;
 }
 
-void NodesMetadata::commitIfNecessary() {
+void NodesMetadata::checkpointInMemoryIfNecessary() {
     for (label_t label = 0u; label < nodeMetadataPerLabel.size(); ++label) {
-        nodeMetadataPerLabel[label]->commitIfNecessary();
+        nodeMetadataPerLabel[label]->checkpointInMemoryIfNecessary();
     }
 }
 
-void NodesMetadata::rollbackIfNecessary() {
+void NodesMetadata::rollbackInMemoryIfNecessary() {
     for (label_t label = 0u; label < nodeMetadataPerLabel.size(); ++label) {
-        nodeMetadataPerLabel[label]->rollbackIfNecessary();
+        nodeMetadataPerLabel[label]->rollbackInMemoryIfNecessary();
     }
 }
 

--- a/src/storage/wal/include/wal.h
+++ b/src/storage/wal/include/wal.h
@@ -120,12 +120,13 @@ public:
         return currentHeaderPageIdx == 0 && (getNumRecordsInCurrentHeaderPage() == 0);
     }
 
-private:
-    inline void createFileHandle(const string& path) {
-        fileHandle = make_shared<FileHandle>(
-            path, FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
+    inline static shared_ptr<FileHandle> createWALFileHandle(const string& directory) {
+        return make_shared<FileHandle>(
+            FileUtils::joinPath(directory, string(StorageConfig::WAL_FILE_SUFFIX)),
+            FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
     }
 
+private:
     inline void flushHeaderPages() {
         if (!isEmptyWAL()) {
             fileHandle->writePage(currentHeaderPageBuffer.get(), currentHeaderPageIdx);

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -12,7 +12,7 @@ WAL::WAL(const string& directory, BufferManager& bufferManager)
     : logger{LoggerUtils::getOrCreateSpdLogger("wal")}, directory{directory},
       bufferManager{bufferManager}, isLastLoggedRecordCommit_{false}, containsNodesMetadataRecord_{
                                                                           false} {
-    createFileHandle(FileUtils::joinPath(directory, string(StorageConfig::WAL_FILE_SUFFIX)));
+    fileHandle = WAL::createWALFileHandle(directory);
     initCurrentPageAndResetIsLastRecordCommitAndContainsNodesMetadataFields();
 }
 

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -1,25 +1,56 @@
 #include "src/storage/include/wal_replayer.h"
 
+#include "spdlog/spdlog.h"
+
 #include "src/storage/include/storage_manager.h"
 
 namespace graphflow {
 namespace storage {
 
-WALReplayer::WALReplayer(
-    StorageManager& storageManager, BufferManager& bufferManager, bool isCheckpoint)
-    : storageManager{storageManager}, bufferManager{bufferManager},
-      walFileHandle{storageManager.getWAL().fileHandle}, isCheckpoint{isCheckpoint} {
-    pageBuffer = make_unique<uint8_t[]>(DEFAULT_PAGE_SIZE);
+WALReplayer::WALReplayer(StorageManager* storageManager)
+    : isRecovering{true}, isCheckpoint{true}, storageManager{storageManager} {
+    init();
 }
 
+WALReplayer::WALReplayer(
+    StorageManager* storageManager, BufferManager* bufferManager, bool isCheckpoint)
+    : isRecovering{false}, isCheckpoint{isCheckpoint}, storageManager{storageManager},
+      bufferManager{bufferManager} {
+    init();
+}
+
+void WALReplayer::init() {
+    logger = LoggerUtils::getOrCreateSpdLogger("storage");
+    walFileHandle = WAL::createWALFileHandle(storageManager->getDBDirectory());
+    pageBuffer = make_unique<uint8_t[]>(DEFAULT_PAGE_SIZE);
+}
 void WALReplayer::replayWALRecord(WALRecord& walRecord) {
     switch (walRecord.recordType) {
     case PAGE_UPDATE_OR_INSERT_RECORD: {
-        Column* column;
+        // 1. As the first step we copy over the page on disk, regardless of if we are recovering
+        // (and checkpointing) or checkpointing while during regular execution.
         auto storageStructureID = walRecord.pageInsertOrUpdateRecord.storageStructureID;
+        unique_ptr<FileInfo> fileInfoOfStorageStructure = StorageUtils::getFileInfoForReadWrite(
+            storageManager->getDBDirectory(), storageStructureID);
+        if (isCheckpoint) {
+            walFileHandle->readPage(
+                pageBuffer.get(), walRecord.pageInsertOrUpdateRecord.pageIdxInWAL);
+            FileUtils::writeToFile(fileInfoOfStorageStructure.get(), pageBuffer.get(),
+                DEFAULT_PAGE_SIZE,
+                walRecord.pageInsertOrUpdateRecord.pageIdxInOriginalFile * DEFAULT_PAGE_SIZE);
+        }
+        // If we are recovering there is nothing else to do and we can return
+        if (isRecovering) {
+            return;
+        }
+
+        // 2: If we are not recovering, we do any in-memory checkpointing or rolling back work to
+        // make sure that the system's in-memory structures are consistent with what is on disk.
+        // For example, we update the BM's image of the pages.
+        Column* column;
         switch (storageStructureID.storageStructureType) {
         case STRUCTURED_NODE_PROPERTY_COLUMN: {
-            column = storageManager.getNodesStore().getNodePropertyColumn(
+            column = storageManager->getNodesStore().getNodePropertyColumn(
                 storageStructureID.structuredNodePropertyColumnID.nodeLabel,
                 storageStructureID.structuredNodePropertyColumnID.propertyID);
         } break;
@@ -28,54 +59,45 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) {
                                    "WALReplayer::replay(). StorageStructureType:" +
                                    to_string(storageStructureID.storageStructureType));
         }
-        // TODO(Semih/Guodong): We are explicitly assuming that if the log record's
-        // storageStructureID is an overflow file, then the storage structure is a
-        // StringPropertyColumn. This should change as we support other variable length data types
-        // and in other storage structures.
+        // TODO: We are explicitly assuming that if the log record's storageStructureID is an
+        // overflow file, then the storage structure is a StringPropertyColumn. This should change
+        // as we support other variable length data types and in other storage structures.
         VersionedFileHandle* fileHandle =
             storageStructureID.isOverflow ?
                 reinterpret_cast<StringPropertyColumn*>(column)->getOverflowFileHandle() :
                 column->getFileHandle();
+        fileHandle->clearUpdatedWALPageVersionIfNecessary(
+            walRecord.pageInsertOrUpdateRecord.pageIdxInOriginalFile);
         if (isCheckpoint) {
-            walFileHandle->readPage(
-                pageBuffer.get(), walRecord.pageInsertOrUpdateRecord.pageIdxInWAL);
-            if (walRecord.pageInsertOrUpdateRecord.isInsert) {
-                // TODO(Semih/Guodong): Here we assume that the order of added pages in a file
-                // need to be consecutive. This assumption for now holds. We should change this
-                // logic later if this assumption no longer holds.
-                fileHandle->addNewPage();
-            }
-            fileHandle->writePage(
-                pageBuffer.get(), walRecord.pageInsertOrUpdateRecord.pageIdxInOriginalFile);
             // Update the page in buffer manager if it is in a frame
-            bufferManager.updateFrameIfPageIsInFrameWithoutPageOrFrameLock(*fileHandle,
+            bufferManager->updateFrameIfPageIsInFrameWithoutPageOrFrameLock(*fileHandle,
                 pageBuffer.get(), walRecord.pageInsertOrUpdateRecord.pageIdxInOriginalFile);
-        }
-        if (!isCheckpoint && walRecord.pageInsertOrUpdateRecord.isInsert) {
-            // Note: We can directly call removePageIdxAndTruncateIfNecessary here because we assume
-            // there is a single write transaction in the system at any point in time. Suppose page
-            // 5 and page 6 were added to a file during a transaction, which is now rolling back. As
-            // we replay the log to rollback, we see page 5's insertion first. However, we can
-            // directly truncate the file to 5 (even if later we will see a page 6 insertion),
-            // because we assume that if there were further new page additions to the same file,
-            // they must also be part of the rolling back transaction. If this assumption fails,
-            // instead of truncating, we need to indicate that page 5 is a "free" page again and
-            // have some logic to maintain free pages.
+        } else if (walRecord.pageInsertOrUpdateRecord.isInsert) {
+            // If we are rolling back and this is a page insertion we truncate the fileHandle's
+            // data structures that hold locks for pageIdxs.
+            // Note: We can directly call removePageIdxAndTruncateIfNecessary here because we
+            // assume there is a single write transaction in the system at any point in time.
+            // Suppose page 5 and page 6 were added to a file during a transaction, which is now
+            // rolling back. As we replay the log to rollback, we see page 5's insertion first.
+            // However, we can directly truncate the file to 5 (even if later we will see a page
+            // 6 insertion), because we assume that if there were further new page additions to
+            // the same file, they must also be part of the rolling back transaction. If this
+            // assumption fails, instead of truncating, we need to indicate that page 5 is a
+            // "free" page again and have some logic to maintain free pages.
             fileHandle->removePageIdxAndTruncateIfNecessary(
-                walRecord.pageInsertOrUpdateRecord.pageIdxInOriginalFile);
-        } else {
-            fileHandle->clearUpdatedWALPageVersion(
                 walRecord.pageInsertOrUpdateRecord.pageIdxInOriginalFile);
         }
     } break;
     case NODES_METADATA_RECORD: {
         if (isCheckpoint) {
             StorageUtils::overwriteNodesMetadataFileWithVersionFromWAL(
-                storageManager.getDBDirectory());
-            storageManager.getNodesStore().getNodesMetadata().commitIfNecessary();
+                storageManager->getDBDirectory());
+            if (!isRecovering) {
+                storageManager->getNodesStore().getNodesMetadata().checkpointInMemoryIfNecessary();
+            }
         } else {
-            StorageUtils::removeNodesMetadataFileForWALIfExists(storageManager.getDBDirectory());
-            storageManager.getNodesStore().getNodesMetadata().rollbackIfNecessary();
+            StorageUtils::removeNodesMetadataFileForWALIfExists(storageManager->getDBDirectory());
+            storageManager->getNodesStore().getNodesMetadata().rollbackInMemoryIfNecessary();
         }
     } break;
     case COMMIT_RECORD: {
@@ -90,11 +112,16 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) {
 void WALReplayer::replay() {
     // Note: We assume no other thread is accessing the wal during the following operations. If this
     // assumption no longer holds, we need to lock the wal.
-    if (isCheckpoint && !storageManager.getWAL().isLastLoggedRecordCommit()) {
+    if (!isRecovering && isCheckpoint && !storageManager->getWAL().isLastLoggedRecordCommit()) {
         throw StorageException(
             "Cannot checkpointWAL because last logged record is not a commit record.");
     }
-    auto walIterator = storageManager.getWAL().getIterator();
+    if (isRecovering && !storageManager->getWAL().isLastLoggedRecordCommit()) {
+        logger->info("WALReplayer is in recovery mode but the last record is not commit, so not "
+                     "replaying. This should not happen and the caller should instead not call "
+                     "WALReplayer::replay.");
+    }
+    auto walIterator = storageManager->getWAL().getIterator();
     WALRecord walRecord;
     while (walIterator->hasNextRecord()) {
         walIterator->getNextRecord(walRecord);

--- a/test/storage/wal_replayer_test.cpp
+++ b/test/storage/wal_replayer_test.cpp
@@ -13,7 +13,7 @@ public:
 TEST_F(WALReplayerTests, ReplayingUncommittedWALForChekpointErrors) {
     auto walIterator = database->getStorageManager()->getWAL().getIterator();
     WALReplayer walReplayer(
-        *database->getStorageManager(), *database->getBufferManager(), true /* is checkpointWAL */);
+        database->getStorageManager(), database->getBufferManager(), true /* is checkpointWAL */);
     try {
         walReplayer.replay();
         FAIL();


### PR DESCRIPTION
This is a simple PR that I will need for implementing transactional update logic to disk-array. I'm pushing it early because this will conflict with Ziyi's current PR, so we can simplify rebasing a bit.