### PR TITLE
Template copies between vectors and columns

### DIFF
--- a/src/common/include/vector/value_vector_utils.h
+++ b/src/common/include/vector/value_vector_utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "src/common/include/overflow_buffer_utils.h"
 #include "src/common/include/vector/value_vector.h"
 
 namespace graphflow {
@@ -11,11 +12,24 @@ public:
     static void addLiteralToStructuredVector(
         ValueVector& resultVector, uint64_t pos, const Literal& literal);
 
-    // These two functions assume that the given uint8_t* srcData/dstData are pointing to a data
-    // with the same data type as this ValueVector. If this ValueVector is unstructured, then
-    // srcData/dstData are pointing to a Value.
-    static void copyNonNullDataWithSameTypeIntoPos(
-        ValueVector& resultVector, uint64_t pos, const uint8_t* srcData);
+    template<typename T>
+    static inline void templateCopyValue(
+        T* src, T* dest, const DataType& dataType, OverflowBuffer& overflowBuffer) {
+        if constexpr (is_same<T, gf_string_t>::value) {
+            OverflowBufferUtils::copyString(const_cast<const T&>(*src), *dest, overflowBuffer);
+        } else if constexpr (is_same<T, gf_list_t>::value) {
+            OverflowBufferUtils::copyListRecursiveIfNested(
+                const_cast<const T&>(*src), *dest, dataType, overflowBuffer);
+        } else if constexpr (is_same<T, Value>::value) {
+            memcpy(dest, src, sizeof(T));
+            if (src->dataType.typeID == STRING) {
+                OverflowBufferUtils::copyString(src->val.strVal, dest->val.strVal, overflowBuffer);
+            }
+        } else {
+            memcpy(dest, src, sizeof(T));
+        }
+    }
+
     static void copyNonNullDataWithSameTypeOutFromPos(const ValueVector& srcVector, uint64_t pos,
         uint8_t* dstData, OverflowBuffer& dstOverflowBuffer);
 

--- a/src/common/vector/value_vector_utils.cpp
+++ b/src/common/vector/value_vector_utils.cpp
@@ -1,6 +1,5 @@
 #include "src/common/include/vector/value_vector_utils.h"
 
-#include "src/common/include/overflow_buffer_utils.h"
 #include "src/common/types/include/value.h"
 
 using namespace graphflow;
@@ -37,13 +36,6 @@ void ValueVectorUtils::addLiteralToStructuredVector(
     default:
         assert(false);
     }
-}
-
-void ValueVectorUtils::copyNonNullDataWithSameTypeIntoPos(
-    ValueVector& resultVector, uint64_t pos, const uint8_t* srcData) {
-    copyNonNullDataWithSameType(resultVector.dataType, srcData,
-        resultVector.values + pos * resultVector.getNumBytesPerValue(),
-        resultVector.getOverflowBuffer());
 }
 
 void ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(const ValueVector& srcVector,

--- a/src/main/include/query_result.h
+++ b/src/main/include/query_result.h
@@ -4,6 +4,7 @@
 
 #include "src/common/types/include/types.h"
 #include "src/processor/include/physical_plan/result/factorized_table.h"
+#include "src/processor/include/physical_plan/result/factorized_tuple_iterator.h"
 #include "src/processor/include/physical_plan/result/flat_tuple.h"
 
 using namespace graphflow::processor;
@@ -29,10 +30,10 @@ public:
     inline bool isSuccess() const { return success; }
     inline string getErrorMessage() const { return errMsg; }
 
-    inline void setResultHeaderAndTable(std::unique_ptr<QueryResultHeader> header,
-        std::shared_ptr<processor::FactorizedTable> factorizedTable) {
-        this->header = move(header);
-        this->factorizedTable = move(factorizedTable);
+    inline void setResultHeaderAndTable(std::unique_ptr<QueryResultHeader> header_,
+        std::shared_ptr<processor::FactorizedTable> factorizedTable_) {
+        this->header = move(header_);
+        this->factorizedTable = move(factorizedTable_);
         resetIterator();
     }
 

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -19,7 +19,7 @@ public:
     // Create plan mapper with default mapper context.
     PlanMapper(const StorageManager& storageManager, MemoryManager* memoryManager, Catalog* catalog)
         : storageManager{storageManager}, memoryManager{memoryManager}, outerMapperContext{nullptr},
-          expressionMapper{}, physicalOperatorID{0}, catalog{catalog} {}
+          expressionMapper{}, catalog{catalog}, physicalOperatorID{0} {}
 
     unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(unique_ptr<LogicalPlan> logicalPlan);
 

--- a/src/processor/include/physical_plan/operator/create_node_table.h
+++ b/src/processor/include/physical_plan/operator/create_node_table.h
@@ -17,9 +17,9 @@ public:
     CreateNodeTable(Catalog* catalog, string labelName,
         vector<PropertyNameDataType> propertyNameDataTypes, string primaryKey, uint32_t id,
         const string& paramsString)
-        : PhysicalOperator{id, paramsString},
-          SourceOperator{nullptr}, catalog{catalog}, labelName{move(labelName)},
-          propertyNameDataTypes{move(propertyNameDataTypes)}, primaryKey{move(primaryKey)} {}
+        : PhysicalOperator{id, paramsString}, SourceOperator{nullptr}, catalog{catalog},
+          labelName{move(labelName)}, primaryKey{move(primaryKey)}, propertyNameDataTypes{move(
+                                                                        propertyNameDataTypes)} {}
 
     PhysicalOperatorType getOperatorType() override { return CREATE_NODE_TABLE; }
 

--- a/src/processor/include/physical_plan/result/factorized_table.h
+++ b/src/processor/include/physical_plan/result/factorized_table.h
@@ -192,9 +192,10 @@ public:
     bool isNonOverflowColNull(const uint8_t* nullBuffer, uint32_t colIdx) const;
     void setNonOverflowColNull(uint8_t* nullBuffer, uint32_t colIdx);
 
-private:
     static bool isNull(const uint8_t* nullMapBuffer, uint32_t idx);
-    void setNull(uint8_t* nullBuffer, uint32_t idx);
+    static void setNull(uint8_t* nullBuffer, uint32_t idx);
+
+private:
     void setOverflowColNull(uint8_t* nullBuffer, uint32_t colIdx, uint32_t tupleIdx);
 
     uint64_t computeNumTuplesToAppend(const vector<shared_ptr<ValueVector>>& vectorsToAppend) const;
@@ -209,32 +210,30 @@ private:
 
     vector<BlockAppendingInfo> allocateTupleBlocks(uint64_t numTuplesToAppend);
     uint8_t* allocateOverflowBlocks(uint32_t numBytes);
-    void copyFlatVectorToFlatColumn(
-        const ValueVector& vector, const BlockAppendingInfo& blockAppendInfo, uint32_t colIdx);
-    void copyUnflatVectorToFlatColumn(const ValueVector& vector,
-        const BlockAppendingInfo& blockAppendInfo, uint64_t numAppendedTuples, uint32_t colIdx);
-    inline void copyVectorToFlatColumn(const ValueVector& vector,
-        const BlockAppendingInfo& blockAppendInfo, uint64_t numAppendedTuples, uint32_t colIdx) {
+    void writeFlatVectorToFlatColumn(
+        const ValueVector& vector, uint8_t** tuples, uint32_t colIdx, uint64_t numTuplesToWrite);
+    void writeUnflatVectorToFlatColumn(
+        const ValueVector& vector, uint8_t** tuples, uint32_t colIdx, uint64_t numTuplesToWrite);
+    inline void writeVectorToFlatColumn(
+        const ValueVector& vector, uint8_t** tuples, uint32_t colIdx, uint64_t numTuplesToWrite) {
         vector.state->isFlat() ?
-            copyFlatVectorToFlatColumn(vector, blockAppendInfo, colIdx) :
-            copyUnflatVectorToFlatColumn(vector, blockAppendInfo, numAppendedTuples, colIdx);
+            writeFlatVectorToFlatColumn(vector, tuples, colIdx, numTuplesToWrite) :
+            writeUnflatVectorToFlatColumn(vector, tuples, colIdx, numTuplesToWrite);
     }
-    void copyVectorToUnflatColumn(
-        const ValueVector& vector, const BlockAppendingInfo& blockAppendInfo, uint32_t colIdx);
-    void copyVectorToColumn(const ValueVector& vector, const BlockAppendingInfo& blockAppendInfo,
-        uint64_t numAppendedTuples, uint32_t colIdx);
+    void writeVectorToUnflatColumn(
+        const ValueVector& vector, uint8_t** tuples, uint32_t colIdx, uint64_t numTuplesToWrite);
+    void writeVectorToColumn(
+        const ValueVector& vector, uint8_t** tuples, uint32_t colIdx, uint64_t numTuplesToWrite);
     overflow_value_t appendUnFlatVectorToOverflowBlocks(const ValueVector& vector, uint32_t colIdx);
 
-    void readUnflatCol(uint8_t** tuplesToRead, uint32_t colIdx, ValueVector& vector) const;
-    void readFlatColToFlatVector(
-        uint8_t** tuplesToRead, uint32_t colIdx, ValueVector& vector) const;
-    void readFlatColToUnflatVector(uint8_t** tuplesToRead, uint32_t colIdx, ValueVector& vector,
-        uint64_t numTuplesToRead) const;
-    inline void readFlatCol(uint8_t** tuplesToRead, uint32_t colIdx, ValueVector& vector,
-        uint64_t numTuplesToRead) const {
-        vector.state->isFlat() ?
-            readFlatColToFlatVector(tuplesToRead, colIdx, vector) :
-            readFlatColToUnflatVector(tuplesToRead, colIdx, vector, numTuplesToRead);
+    void readUnflatCol(uint8_t** tuples, uint32_t colIdx, ValueVector& result) const;
+    void readFlatColToFlatVector(uint8_t** tuples, uint32_t colIdx, ValueVector& result) const;
+    void readFlatColToUnflatVector(
+        uint8_t** tuples, uint32_t colIdx, ValueVector& result, uint64_t numTuplesToRead) const;
+    inline void readFlatCol(
+        uint8_t** tuples, uint32_t colIdx, ValueVector& result, uint64_t numTuplesToRead) const {
+        result.state->isFlat() ? readFlatColToFlatVector(tuples, colIdx, result) :
+                                 readFlatColToUnflatVector(tuples, colIdx, result, numTuplesToRead);
     }
 
     MemoryManager* memoryManager;
@@ -244,61 +243,6 @@ private:
     vector<unique_ptr<DataBlock>> tupleDataBlocks;
     vector<unique_ptr<DataBlock>> vectorOverflowBlocks;
     unique_ptr<OverflowBuffer> overflowBuffer;
-};
-
-class FlatTupleIterator {
-public:
-    explicit FlatTupleIterator(
-        FactorizedTable& factorizedTable, const vector<DataType>& columnDataTypes);
-
-    inline bool hasNextFlatTuple() {
-        return nextTupleIdx < factorizedTable.getNumTuples() || nextFlatTupleIdx < numFlatTuples;
-    }
-
-    shared_ptr<FlatTuple> getNextFlatTuple();
-
-private:
-    void readValueBufferToFlatTuple(uint64_t flatTupleValIdx, const uint8_t* valueBuffer);
-
-    void readUnflatColToFlatTuple(uint64_t flatTupleValIdx, uint8_t* valueBuffer);
-
-    void readFlatColToFlatTuple(uint32_t colIdx, uint8_t* valueBuffer);
-
-    // The dataChunkPos may be not consecutive, which means some entries in the
-    // flatTuplePositionsInDataChunk is invalid. We put pair(UINT64_MAX, UINT64_MAX) in the
-    // invalid entries.
-    inline bool isValidDataChunkPos(uint32_t dataChunkPos) const {
-        return flatTuplePositionsInDataChunk[dataChunkPos].first != UINT64_MAX;
-    }
-
-    // We put pair(UINT64_MAX, UINT64_MAX) in all invalid entries in
-    // FlatTuplePositionsInDataChunk.
-    void updateInvalidEntriesInFlatTuplePositionsInDataChunk();
-
-    // This function is used to update the number of elements in the dataChunk when we want
-    // to iterate a new tuple.
-    void updateNumElementsInDataChunk();
-
-    // This function updates the flatTuplePositionsInDataChunk, so that getNextFlatTuple() can
-    // correctly outputs the next flat tuple in the current tuple. For example, we want to read
-    // two unflat columns, which are on different dataChunks A,B and both have 100 columns. The
-    // flatTuplePositionsInDataChunk after the first call to getNextFlatTuple() looks like:
-    // {dataChunkA : [0, 100]}, {dataChunkB : [0, 100]} This function updates the
-    // flatTuplePositionsInDataChunk to: {dataChunkA: [1, 100]}, {dataChunkB: [0, 100]}. Meaning
-    // that the getNextFlatTuple() should read the second element in the first unflat column and
-    // the first element in the second unflat column.
-    void updateFlatTuplePositionsInDataChunk();
-
-    FactorizedTable& factorizedTable;
-    uint8_t* currentTupleBuffer;
-    uint64_t numFlatTuples;
-    uint32_t nextFlatTupleIdx;
-    uint64_t nextTupleIdx;
-    // This field stores the (nextIdxToReadInDataChunk, numElementsInDataChunk) of each dataChunk.
-    vector<pair<uint64_t, uint64_t>> flatTuplePositionsInDataChunk;
-
-    vector<DataType> columnDataTypes;
-    shared_ptr<FlatTuple> iteratorFlatTuple;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/result/factorized_tuple_iterator.h
+++ b/src/processor/include/physical_plan/result/factorized_tuple_iterator.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "src/processor/include/physical_plan/result/factorized_table.h"
+
+namespace graphflow {
+namespace processor {
+
+class FlatTupleIterator {
+public:
+    explicit FlatTupleIterator(
+        FactorizedTable& factorizedTable, const vector<DataType>& columnDataTypes);
+
+    inline bool hasNextFlatTuple() {
+        return nextTupleIdx < factorizedTable.getNumTuples() || nextFlatTupleIdx < numFlatTuples;
+    }
+
+    shared_ptr<FlatTuple> getNextFlatTuple();
+
+private:
+    void readValueBufferToFlatTuple(uint64_t flatTupleValIdx, const uint8_t* valueBuffer);
+
+    void readUnflatColToFlatTuple(uint64_t flatTupleValIdx, uint8_t* valueBuffer);
+
+    void readFlatColToFlatTuple(uint32_t colIdx, uint8_t* valueBuffer);
+
+    // The dataChunkPos may be not consecutive, which means some entries in the
+    // flatTuplePositionsInDataChunk is invalid. We put pair(UINT64_MAX, UINT64_MAX) in the
+    // invalid entries.
+    inline bool isValidDataChunkPos(uint32_t dataChunkPos) const {
+        return flatTuplePositionsInDataChunk[dataChunkPos].first != UINT64_MAX;
+    }
+
+    // We put pair(UINT64_MAX, UINT64_MAX) in all invalid entries in
+    // FlatTuplePositionsInDataChunk.
+    void updateInvalidEntriesInFlatTuplePositionsInDataChunk();
+
+    // This function is used to update the number of elements in the dataChunk when we want
+    // to iterate a new tuple.
+    void updateNumElementsInDataChunk();
+
+    // This function updates the flatTuplePositionsInDataChunk, so that getNextFlatTuple() can
+    // correctly outputs the next flat tuple in the current tuple. For example, we want to read
+    // two unflat columns, which are on different dataChunks A,B and both have 100 columns. The
+    // flatTuplePositionsInDataChunk after the first call to getNextFlatTuple() looks like:
+    // {dataChunkA : [0, 100]}, {dataChunkB : [0, 100]} This function updates the
+    // flatTuplePositionsInDataChunk to: {dataChunkA: [1, 100]}, {dataChunkB: [0, 100]}. Meaning
+    // that the getNextFlatTuple() should read the second element in the first unflat column and
+    // the first element in the second unflat column.
+    void updateFlatTuplePositionsInDataChunk();
+
+    FactorizedTable& factorizedTable;
+    uint8_t* currentTupleBuffer;
+    uint64_t numFlatTuples;
+    uint32_t nextFlatTupleIdx;
+    uint64_t nextTupleIdx;
+    // This field stores the (nextIdxToReadInDataChunk, numElementsInDataChunk) of each dataChunk.
+    vector<pair<uint64_t, uint64_t>> flatTuplePositionsInDataChunk;
+
+    vector<DataType> columnDataTypes;
+    shared_ptr<FlatTuple> iteratorFlatTuple;
+};
+
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/physical_plan/result/factorized_tuple_iterator.cpp
+++ b/src/processor/physical_plan/result/factorized_tuple_iterator.cpp
@@ -1,0 +1,163 @@
+#include "src/processor/include/physical_plan/result/factorized_tuple_iterator.h"
+
+namespace graphflow {
+namespace processor {
+
+FlatTupleIterator::FlatTupleIterator(
+    FactorizedTable& factorizedTable, const vector<DataType>& columnDataTypes)
+    : factorizedTable{factorizedTable}, numFlatTuples{0}, nextFlatTupleIdx{0}, nextTupleIdx{1},
+      columnDataTypes{columnDataTypes} {
+    if (factorizedTable.getNumTuples()) {
+        currentTupleBuffer = factorizedTable.getTuple(0);
+        numFlatTuples = factorizedTable.getNumFlatTuples(0);
+        updateNumElementsInDataChunk();
+        updateInvalidEntriesInFlatTuplePositionsInDataChunk();
+    }
+    // Note: there is difference between column data types and value types in iteratorFlatTuple.
+    // Column data type could be UNSTRUCTURED but value type must be a structured type.
+    iteratorFlatTuple = make_shared<FlatTuple>(columnDataTypes);
+    assert(columnDataTypes.size() == factorizedTable.tableSchema->getNumColumns());
+}
+
+shared_ptr<FlatTuple> FlatTupleIterator::getNextFlatTuple() {
+    // Go to the next tuple if we have iterated all the flat tuples of the current tuple.
+    if (nextFlatTupleIdx >= numFlatTuples) {
+        currentTupleBuffer = factorizedTable.getTuple(nextTupleIdx);
+        numFlatTuples = factorizedTable.getNumFlatTuples(nextTupleIdx);
+        nextFlatTupleIdx = 0;
+        updateNumElementsInDataChunk();
+        nextTupleIdx++;
+    }
+    for (auto i = 0ul; i < factorizedTable.getTableSchema()->getNumColumns(); i++) {
+        auto column = factorizedTable.getTableSchema()->getColumn(i);
+        if (column->isFlat()) {
+            readFlatColToFlatTuple(i, currentTupleBuffer);
+        } else {
+            readUnflatColToFlatTuple(i, currentTupleBuffer);
+        }
+    }
+    updateFlatTuplePositionsInDataChunk();
+    nextFlatTupleIdx++;
+    return iteratorFlatTuple;
+}
+
+void FlatTupleIterator::readValueBufferToFlatTuple(
+    uint64_t flatTupleValIdx, const uint8_t* valueBuffer) {
+    switch (columnDataTypes[flatTupleValIdx].typeID) {
+    case INT64: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.int64Val = *((int64_t*)valueBuffer);
+    } break;
+    case BOOL: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.booleanVal = *((bool*)valueBuffer);
+    } break;
+    case DOUBLE: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.doubleVal = *((double_t*)valueBuffer);
+    } break;
+    case STRING: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.strVal = *((gf_string_t*)valueBuffer);
+    } break;
+    case NODE_ID: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.nodeID = *((nodeID_t*)valueBuffer);
+    } break;
+    case UNSTRUCTURED: {
+        *iteratorFlatTuple->getValue(flatTupleValIdx) = *((Value*)valueBuffer);
+    } break;
+    case DATE: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.dateVal = *((date_t*)valueBuffer);
+    } break;
+    case TIMESTAMP: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.timestampVal =
+            *((timestamp_t*)valueBuffer);
+    } break;
+    case INTERVAL: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.intervalVal = *((interval_t*)valueBuffer);
+    } break;
+    case LIST: {
+        iteratorFlatTuple->getValue(flatTupleValIdx)->val.listVal = *((gf_list_t*)valueBuffer);
+    } break;
+    default:
+        assert(false);
+    }
+}
+
+void FlatTupleIterator::readUnflatColToFlatTuple(uint64_t colIdx, uint8_t* valueBuffer) {
+    auto overflowValue =
+        (overflow_value_t*)(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
+    auto columnInFactorizedTable = factorizedTable.getTableSchema()->getColumn(colIdx);
+    auto tupleSizeInOverflowBuffer = Types::getDataTypeSize(columnDataTypes[colIdx]);
+    valueBuffer =
+        overflowValue->value +
+        tupleSizeInOverflowBuffer *
+            flatTuplePositionsInDataChunk[columnInFactorizedTable->getDataChunkPos()].first;
+    iteratorFlatTuple->nullMask[colIdx] = factorizedTable.isOverflowColNull(
+        overflowValue->value + tupleSizeInOverflowBuffer * overflowValue->numElements,
+        flatTuplePositionsInDataChunk[columnInFactorizedTable->getDataChunkPos()].first, colIdx);
+    if (!iteratorFlatTuple->nullMask[colIdx]) {
+        readValueBufferToFlatTuple(colIdx, valueBuffer);
+    }
+}
+
+void FlatTupleIterator::readFlatColToFlatTuple(uint32_t colIdx, uint8_t* valueBuffer) {
+    iteratorFlatTuple->nullMask[colIdx] = factorizedTable.isNonOverflowColNull(
+        valueBuffer + factorizedTable.getTableSchema()->getNullMapOffset(), colIdx);
+    if (!iteratorFlatTuple->nullMask[colIdx]) {
+        readValueBufferToFlatTuple(
+            colIdx, valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
+    }
+}
+
+void FlatTupleIterator::updateInvalidEntriesInFlatTuplePositionsInDataChunk() {
+    for (auto i = 0u; i < flatTuplePositionsInDataChunk.size(); i++) {
+        bool isValidEntry = false;
+        for (auto j = 0u; j < factorizedTable.getTableSchema()->getNumColumns(); j++) {
+            if (factorizedTable.getTableSchema()->getColumn(j)->getDataChunkPos() == i) {
+                isValidEntry = true;
+                break;
+            }
+        }
+        if (!isValidEntry) {
+            flatTuplePositionsInDataChunk[i] = make_pair(UINT64_MAX, UINT64_MAX);
+        }
+    }
+}
+
+void FlatTupleIterator::updateNumElementsInDataChunk() {
+    auto colOffsetInTupleBuffer = 0ul;
+    for (auto i = 0u; i < factorizedTable.getTableSchema()->getNumColumns(); i++) {
+        auto column = factorizedTable.getTableSchema()->getColumn(i);
+        // If this is an unflat column, the number of elements is stored in the
+        // overflow_value_t struct. Otherwise, the number of elements is 1.
+        auto numElementsInDataChunk =
+            column->isFlat() ?
+                1 :
+                ((overflow_value_t*)(currentTupleBuffer + colOffsetInTupleBuffer))->numElements;
+        if (column->getDataChunkPos() >= flatTuplePositionsInDataChunk.size()) {
+            flatTuplePositionsInDataChunk.resize(column->getDataChunkPos() + 1);
+        }
+        flatTuplePositionsInDataChunk[column->getDataChunkPos()] =
+            make_pair(0 /* nextIdxToReadInDataChunk */, numElementsInDataChunk);
+        colOffsetInTupleBuffer += column->getNumBytes();
+    }
+}
+
+void FlatTupleIterator::updateFlatTuplePositionsInDataChunk() {
+    for (auto i = 0u; i < flatTuplePositionsInDataChunk.size(); i++) {
+        if (!isValidDataChunkPos(i)) {
+            continue;
+        }
+        flatTuplePositionsInDataChunk.at(i).first++;
+        // If we have output all elements in the current column, we reset the
+        // nextIdxToReadInDataChunk in the current column to 0.
+        if (flatTuplePositionsInDataChunk.at(i).first >=
+            flatTuplePositionsInDataChunk.at(i).second) {
+            flatTuplePositionsInDataChunk.at(i).first = 0;
+        } else {
+            // If the current dataChunk is not full, then we don't need to update the next
+            // dataChunk.
+            break;
+        }
+    }
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/test/processor/physical_plan/result/factorized_table_test.cpp
+++ b/test/processor/physical_plan/result/factorized_table_test.cpp
@@ -2,13 +2,14 @@
 
 #include "src/common/include/exception.h"
 #include "src/processor/include/physical_plan/result/factorized_table.h"
+#include "src/processor/include/physical_plan/result/factorized_tuple_iterator.h"
 
 using namespace graphflow::processor;
 
 class FactorizedTableTest : public ::testing::Test {
 
 public:
-    unique_ptr<ResultSet> initResultSet() {
+    unique_ptr<ResultSet> initResultSet() const {
         auto result = make_unique<ResultSet>(2);
         auto dataChunkA = make_shared<DataChunk>(2);
         auto dataChunkB = make_shared<DataChunk>(2);
@@ -60,7 +61,7 @@ public:
         resultSet->dataChunks[1]->state->selVector->selectedSize = 100;
     }
 
-    unique_ptr<FactorizedTable> appendMultipleTuples(bool isAppendFlatVectorToUnflatCol) {
+    unique_ptr<FactorizedTable> appendMultipleTuples(bool isAppendFlatVectorToUnflatCol) const {
         // Prepare the factorizedTable and unflat vectors (A1, B1).
         unique_ptr<TableSchema> tableSchema = make_unique<TableSchema>();
         tableSchema->appendColumn(make_unique<ColumnSchema>(
@@ -156,7 +157,7 @@ TEST_F(FactorizedTableTest, AppendAndScanOneTupleAtATime) {
         factorizedTable->scan(vectorsToRead, i, 1);
         ASSERT_EQ(readResultSet->dataChunks[0]->state->selVector->selectedSize, 100);
         ASSERT_EQ(readResultSet->dataChunks[1]->state->selVector->selectedSize, 1);
-        if (i % 10) {
+        if (i % 10 != 0) {
             ASSERT_EQ(vectorB1->isNull(i), false);
             ASSERT_EQ(vectorB1Data[vectorB1->state->currIdx].label, 28);
             ASSERT_EQ(vectorB1Data[vectorB1->state->currIdx].offset, (uint64_t)i);
@@ -164,7 +165,7 @@ TEST_F(FactorizedTableTest, AppendAndScanOneTupleAtATime) {
             ASSERT_EQ(vectorB1->isNull(i), true);
         }
         for (auto j = 0u; j < 100; j++) {
-            if (j % 10) {
+            if (j % 10 != 0) {
                 ASSERT_EQ(vectorA2->isNull(j), false);
                 ASSERT_EQ(((int64_t*)vectorA2->values)[j], j << 1);
             } else {

--- a/test/storage/unstructured_property_lists_updates_test.cpp
+++ b/test/storage/unstructured_property_lists_updates_test.cpp
@@ -214,7 +214,6 @@ TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllUnstructuredPropertiesOfAl
         }
     }
 
-    uint64_t numQueries = 0;
     for (uint64_t nodeOffsetForPropKeys = 0; nodeOffsetForPropKeys <= 600;
          nodeOffsetForPropKeys++) {
         string query = "MATCH (a:person) WHERE a.ui" + to_string(nodeOffsetForPropKeys) +


### PR DESCRIPTION
Add a new template function `templateCopyValue` in `ValueVectorUtils` to replace the usage of `copyNonNullDataWithSameType` which involves dynamic if/else branches for the copy of each value, and refactored read/write of vectors from/to columns in factorized table to use template functions, and vectorize the copy if possible.

Also, to simplify the factorized_table.cpp file, I moved FactorizedTupleIterator to separate files.