### PR TITLE
NodesMetadata refactor

### DIFF
--- a/src/catalog/BUILD.bazel
+++ b/src/catalog/BUILD.bazel
@@ -31,6 +31,7 @@ cc_library(
         "//src/common:ser_deser",
         "//src/function:built_in_vector_operations",
         "//src/function/aggregate:built_in_aggregate_functions",
+        "//src/storage/wal",
         "@gabime_spdlog",
         "@nlohmann_json",
     ],

--- a/src/catalog/catalog_structs.cpp
+++ b/src/catalog/catalog_structs.cpp
@@ -28,5 +28,12 @@ void NodeLabel::addUnstructuredProperties(vector<string>& unstructuredPropertyNa
     }
 }
 
+vector<Property> NodeLabel::getAllNodeProperties() const {
+    auto allProperties = structuredProperties;
+    allProperties.insert(
+        allProperties.end(), unstructuredProperties.begin(), unstructuredProperties.end());
+    return allProperties;
+}
+
 } // namespace catalog
 } // namespace graphflow

--- a/src/catalog/include/catalog_structs.h
+++ b/src/catalog/include/catalog_structs.h
@@ -95,6 +95,10 @@ struct NodeLabel : Label {
     inline void addFwdRelLabel(label_t relLabelId) { fwdRelLabelIdSet.insert(relLabelId); }
     inline void addBwdRelLabel(label_t relLabelId) { bwdRelLabelIdSet.insert(relLabelId); }
 
+    inline Property getPrimaryKey() const { return structuredProperties[primaryPropertyId]; }
+
+    vector<Property> getAllNodeProperties() const;
+
     uint64_t primaryPropertyId;
     vector<Property> structuredProperties, unstructuredProperties;
     unordered_set<label_t> fwdRelLabelIdSet; // srcNode->rel

--- a/src/loader/in_mem_builder/in_mem_node_builder.cpp
+++ b/src/loader/in_mem_builder/in_mem_node_builder.cpp
@@ -4,7 +4,6 @@
 
 #include "src/loader/include/loader_task.h"
 #include "src/storage/storage_structure/include/in_mem_file.h"
-#include "src/storage/storage_structure/include/lists/unstructured_property_lists.h"
 
 namespace graphflow {
 namespace loader {
@@ -42,11 +41,10 @@ void InMemNodeBuilder::createTableSchema() {
             propertyDefinition.dataType = IDType;
         }
     }
-    auto newNodeLabel = catalogBuilder.createNodeLabel(
+    auto newLabelID = catalogBuilder.createAndAddNodeLabel(
         labelName, LoaderConfig::ID_FIELD, move(propertyDefinitions));
     assert(nodeLabel == nullptr);
-    nodeLabel = newNodeLabel.get();
-    catalogBuilder.addNodeLabel(move(newNodeLabel));
+    nodeLabel = catalogBuilder.getReadOnlyVersion()->getNodeLabel(newLabelID);
 }
 
 void InMemNodeBuilder::initializeColumnsAndList() {

--- a/src/loader/in_mem_builder/in_mem_structures_builder.cpp
+++ b/src/loader/in_mem_builder/in_mem_structures_builder.cpp
@@ -174,7 +174,6 @@ void InMemStructuresBuilder::calculateListsMetadataAndAllocateInMemListPagesTask
     if (0 != (numNodes & (StorageConfig::LISTS_CHUNK_SIZE - 1))) {
         numChunks++;
     }
-    inMemList->getListsMetadataBuilder()->initChunkPageLists(numChunks);
     node_offset_t nodeOffset = 0u;
     auto largeListIdx = 0u;
     for (auto chunkId = 0u; chunkId < numChunks; chunkId++) {

--- a/src/loader/in_mem_storage_structure/include/in_mem_lists.h
+++ b/src/loader/in_mem_storage_structure/include/in_mem_lists.h
@@ -33,7 +33,7 @@ public:
 class InMemLists {
 
 public:
-    InMemLists(string fName, DataType dataType, uint64_t numBytesForElement);
+    InMemLists(string fName, DataType dataType, uint64_t numBytesForElement, uint64_t numNodes);
 
     virtual ~InMemLists() = default;
 
@@ -58,7 +58,7 @@ protected:
 class InMemListsWithOverflow : public InMemLists {
 
 protected:
-    InMemListsWithOverflow(string fName, DataType dataType);
+    InMemListsWithOverflow(string fName, DataType dataType, uint64_t numNodes);
 
     ~InMemListsWithOverflow() override = default;
 
@@ -73,7 +73,8 @@ class InMemAdjLists : public InMemLists {
 
 public:
     InMemAdjLists(string fName, const NodeIDCompressionScheme& compressionScheme, uint64_t numNodes)
-        : InMemLists{move(fName), DataType(NODE_ID), compressionScheme.getNumTotalBytes()},
+        : InMemLists{move(fName), DataType(NODE_ID), compressionScheme.getNumTotalBytes(),
+              numNodes},
           compressionScheme{compressionScheme} {
         listHeadersBuilder = make_unique<ListHeadersBuilder>(this->fName, numNodes);
     };
@@ -94,22 +95,22 @@ private:
 class InMemStringLists : public InMemListsWithOverflow {
 
 public:
-    explicit InMemStringLists(string fName)
-        : InMemListsWithOverflow{move(fName), DataType(STRING)} {};
+    explicit InMemStringLists(string fName, uint64_t numNodes)
+        : InMemListsWithOverflow{move(fName), DataType(STRING), numNodes} {};
 };
 
 class InMemListLists : public InMemListsWithOverflow {
 
 public:
-    InMemListLists(string fName, DataType dataType)
-        : InMemListsWithOverflow{move(fName), move(dataType)} {};
+    InMemListLists(string fName, DataType dataType, uint64_t numNodes)
+        : InMemListsWithOverflow{move(fName), move(dataType), numNodes} {};
 };
 
 class InMemUnstructuredLists : public InMemListsWithOverflow {
 
 public:
     InMemUnstructuredLists(string fName, uint64_t numNodes)
-        : InMemListsWithOverflow{move(fName), DataType(UNSTRUCTURED)} {
+        : InMemListsWithOverflow{move(fName), DataType(UNSTRUCTURED), numNodes} {
         listSizes = make_unique<atomic_uint64_vec_t>(numNodes);
         listHeadersBuilder = make_unique<ListHeadersBuilder>(this->fName, numNodes);
     };

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -1,20 +1,26 @@
 #include "include/database.h"
 
+#include "spdlog/spdlog.h"
+
 #include "src/common/include/configs.h"
+#include "src/storage/include/wal_replayer.h"
 
 namespace graphflow {
 namespace main {
 
 Database::Database(const DatabaseConfig& databaseConfig, const SystemConfig& systemConfig)
-    : databaseConfig{databaseConfig}, systemConfig{systemConfig} {
+    : databaseConfig{databaseConfig},
+      systemConfig{systemConfig}, logger{LoggerUtils::getOrCreateSpdLogger("database")} {
     bufferManager = make_unique<BufferManager>(
         systemConfig.defaultPageBufferPoolSize, systemConfig.largePageBufferPoolSize);
+    wal = make_unique<WAL>(databaseConfig.databasePath, *bufferManager);
+    recoverIfNecessary();
     memoryManager = make_unique<MemoryManager>(bufferManager.get());
     queryProcessor = make_unique<processor::QueryProcessor>(systemConfig.maxNumThreads);
-    catalog = make_unique<catalog::Catalog>(databaseConfig.databasePath);
+    catalog = make_unique<catalog::Catalog>(databaseConfig.databasePath, wal.get());
     storageManager = make_unique<storage::StorageManager>(
-        *catalog, *bufferManager, databaseConfig.databasePath, databaseConfig.inMemoryMode);
-    transactionManager = make_unique<transaction::TransactionManager>(storageManager->getWAL());
+        *catalog, *bufferManager, databaseConfig.inMemoryMode, wal.get());
+    transactionManager = make_unique<transaction::TransactionManager>(*wal);
 }
 
 void Database::resizeBufferManager(uint64_t newSize) {
@@ -24,6 +30,37 @@ void Database::resizeBufferManager(uint64_t newSize) {
     systemConfig.largePageBufferPoolSize = newSize * StorageConfig::LARGE_PAGES_BUFFER_RATIO;
     bufferManager->resize(
         systemConfig.defaultPageBufferPoolSize, systemConfig.largePageBufferPoolSize);
+}
+
+void Database::recoverIfNecessary() {
+    if (!wal->isEmptyWAL()) {
+        if (wal->isLastLoggedRecordCommit()) {
+            logger->info("Starting up StorageManager and found a non-empty WAL with a committed "
+                         "transaction. Replaying to checkpoint.");
+            checkpointOrRollbackAndClearWAL(true /* is recovering */, true /* checkpoint */);
+        } else {
+            logger->info("Starting up StorageManager and found a non-empty WAL but last record is "
+                         "not commit. Clearing the WAL.");
+            wal->clearWAL();
+        }
+    }
+}
+
+void Database::checkpointOrRollbackAndClearWAL(bool isRecovering, bool isCheckpoint) {
+    logger->info(
+        "Starting " +
+        (isCheckpoint ? string("checkpointing") : string("rolling back the wal contents")) +
+        " in the storage manager during " +
+        (isRecovering ? "recovery." : "normal db execution (i.e., not recovering)."));
+    WALReplayer walReplayer = isRecovering ? WALReplayer(wal.get()) :
+                                             WALReplayer(wal.get(), storageManager.get(),
+                                                 bufferManager.get(), isCheckpoint);
+    walReplayer.replay();
+    logger->info(
+        "Finished " +
+        (isCheckpoint ? string("checkpointing") : string("rolling back the wal contents")) +
+        " in the storage manager.");
+    wal->clearWAL();
 }
 
 } // namespace main

--- a/src/planner/logical_plan/include/logical_plan.h
+++ b/src/planner/logical_plan/include/logical_plan.h
@@ -20,8 +20,8 @@ public:
     inline bool isEmpty() const { return lastOperator == nullptr; }
 
     inline bool isReadOnly() const {
-        return !lastOperator->descendantsContainType(
-            unordered_set<LogicalOperatorType>{LOGICAL_SET, LOGICAL_CREATE_NODE_TABLE});
+        return !lastOperator->descendantsContainType(unordered_set<LogicalOperatorType>{
+            LOGICAL_SET, LOGICAL_CREATE_NODE_TABLE, LOGICAL_CREATE, LOGICAL_DELETE});
     }
 
     // Our sub-plan (specific to the right plan of Exists and LeftNestedLoopJoin operator) does not

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -19,7 +19,7 @@ public:
     // Create plan mapper with default mapper context.
     PlanMapper(const StorageManager& storageManager, MemoryManager* memoryManager, Catalog* catalog)
         : storageManager{storageManager}, memoryManager{memoryManager}, outerMapperContext{nullptr},
-          expressionMapper{}, physicalOperatorID{0}, catalog{catalog} {}
+          expressionMapper{}, catalog{catalog}, physicalOperatorID{0} {}
 
     unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(unique_ptr<LogicalPlan> logicalPlan);
 

--- a/src/processor/include/physical_plan/operator/create_node_table.h
+++ b/src/processor/include/physical_plan/operator/create_node_table.h
@@ -3,6 +3,7 @@
 #include "src/catalog/include/catalog.h"
 #include "src/processor/include/physical_plan/operator/physical_operator.h"
 #include "src/processor/include/physical_plan/operator/source_operator.h"
+#include "src/storage/store/include/nodes_metadata.h"
 
 using namespace std;
 using namespace graphflow::common;
@@ -16,10 +17,10 @@ class CreateNodeTable : public PhysicalOperator, public SourceOperator {
 public:
     CreateNodeTable(Catalog* catalog, string labelName,
         vector<PropertyNameDataType> propertyNameDataTypes, string primaryKey, uint32_t id,
-        const string& paramsString)
-        : PhysicalOperator{id, paramsString},
-          SourceOperator{nullptr}, catalog{catalog}, labelName{move(labelName)},
-          propertyNameDataTypes{move(propertyNameDataTypes)}, primaryKey{move(primaryKey)} {}
+        const string& paramsString, NodesMetadata* nodesMetadata)
+        : PhysicalOperator{id, paramsString}, SourceOperator{nullptr}, catalog{catalog},
+          labelName{move(labelName)}, propertyNameDataTypes{move(propertyNameDataTypes)},
+          primaryKey{move(primaryKey)}, nodesMetadata{nodesMetadata} {}
 
     PhysicalOperatorType getOperatorType() override { return CREATE_NODE_TABLE; }
 
@@ -29,7 +30,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<CreateNodeTable>(
-            catalog, labelName, propertyNameDataTypes, primaryKey, id, paramsString);
+            catalog, labelName, propertyNameDataTypes, primaryKey, id, paramsString, nodesMetadata);
     }
 
     inline double getExecutionTime(Profiler& profiler) const override {
@@ -41,6 +42,7 @@ private:
     string labelName;
     string primaryKey;
     vector<PropertyNameDataType> propertyNameDataTypes;
+    NodesMetadata* nodesMetadata;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id.h
@@ -12,19 +12,21 @@ namespace processor {
 class ScanNodeIDSharedState {
 
 public:
-    explicit ScanNodeIDSharedState(NodeMetadata* nodeMetadata)
-        : nodeMetadata{nodeMetadata}, maxNodeOffset{UINT64_MAX}, currentNodeOffset{0} {}
+    explicit ScanNodeIDSharedState(NodesMetadata* nodesMetadata, label_t labelID)
+        : nodesMetadata{nodesMetadata}, labelID{labelID}, maxNodeOffset{UINT64_MAX},
+          currentNodeOffset{0} {}
 
     inline void initMaxNodeOffset(Transaction* transaction) {
         unique_lock uLck{mtx};
-        maxNodeOffset = nodeMetadata->getMaxNodeOffset(transaction);
+        maxNodeOffset = nodesMetadata->getMaxNodeOffset(transaction, labelID);
     }
 
     pair<uint64_t, uint64_t> getNextRangeToRead();
 
 private:
     mutex mtx;
-    NodeMetadata* nodeMetadata;
+    NodesMetadata* nodesMetadata;
+    label_t labelID;
     uint64_t maxNodeOffset;
     uint64_t currentNodeOffset;
 };

--- a/src/processor/physical_plan/mapper/map_scan_node_id.cpp
+++ b/src/processor/physical_plan/mapper/map_scan_node_id.cpp
@@ -11,7 +11,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodeIDToPhysical(
     auto nodeExpression = logicalScan->getNodeExpression();
     auto& nodesStore = storageManager.getNodesStore();
     auto sharedState = make_shared<ScanNodeIDSharedState>(
-        nodesStore.getNodesMetadata().getNodeMetadata(nodeExpression->getLabel()));
+        &nodesStore.getNodesMetadata(), nodeExpression->getLabel());
     auto dataPos = mapperContext.getDataPos(nodeExpression->getIDProperty());
     mapperContext.addComputedExpressions(nodeExpression->getIDProperty());
     return make_unique<ScanNodeID>(mapperContext.getResultSetDescriptor()->copy(),

--- a/src/processor/physical_plan/mapper/plan_mapper.cpp
+++ b/src/processor/physical_plan/mapper/plan_mapper.cpp
@@ -427,7 +427,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalCreateNodeTableToPhysical(
     auto& createNodeTable = (LogicalCreateNodeTable&)*logicalOperator;
     return make_unique<CreateNodeTable>(catalog, createNodeTable.getLabelName(),
         createNodeTable.getPropertyNameDataTypes(), createNodeTable.getPrimaryKey(),
-        getOperatorID(), createNodeTable.getExpressionsForPrinting());
+        getOperatorID(), createNodeTable.getExpressionsForPrinting(),
+        &storageManager.getNodesStore().getNodesMetadata());
 }
 
 unique_ptr<ResultCollector> PlanMapper::appendResultCollector(

--- a/src/processor/physical_plan/operator/create_node_table.cpp
+++ b/src/processor/physical_plan/operator/create_node_table.cpp
@@ -4,8 +4,9 @@ namespace graphflow {
 namespace processor {
 
 bool CreateNodeTable::getNextTuples() {
-    auto newNodeLabel = catalog->createNodeLabel(labelName, primaryKey, propertyNameDataTypes);
-    catalog->addNodeLabel(move(newNodeLabel));
+    auto newNodeLabelID =
+        catalog->createAndAddNodeLabel(labelName, primaryKey, propertyNameDataTypes);
+    nodesMetadata->addNodeMetadata(catalog->getWriteVersion()->getNodeLabel(newNodeLabelID));
     return false;
 }
 

--- a/src/processor/physical_plan/operator/update/create.cpp
+++ b/src/processor/physical_plan/operator/update/create.cpp
@@ -15,7 +15,7 @@ bool CreateNode::getNextTuples() {
         return false;
     }
     for (auto& nodeTable : nodeTables) {
-        nodeTable->addNode();
+        nodeTable->getNodesMetadata()->addNode(nodeTable->getLabelID());
     }
     metrics->executionTime.stop();
     return true;

--- a/src/storage/include/storage_manager.h
+++ b/src/storage/include/storage_manager.h
@@ -16,40 +16,21 @@ namespace storage {
 class StorageManager {
 
 public:
-    StorageManager(catalog::Catalog& catalog, BufferManager& bufferManager, string directory,
-        bool isInMemoryMode);
+    StorageManager(
+        catalog::Catalog& catalog, BufferManager& bufferManager, bool isInMemoryMode, WAL* wal);
 
     virtual ~StorageManager();
 
     inline RelsStore& getRelsStore() const { return *relsStore; }
     inline NodesStore& getNodesStore() const { return *nodesStore; }
-    inline WAL& getWAL() const { return *wal; }
-    inline void checkpointAndClearWAL() {
-        checkpointOrRollbackAndClearWAL(false /* is not recovering */, true /* isCheckpoint */);
-    }
-
-    inline void rollbackAndClearWAL() {
-        checkpointOrRollbackAndClearWAL(
-            false /* is not recovering */, false /* rolling back updates */);
-    }
-
-    inline string getDBDirectory() { return directory; }
-
     inline Catalog* getCatalog() { return &catalog; }
 
 private:
-    void checkpointOrRollbackAndClearWAL(bool isRecovering, bool isCheckpoint);
-    void recoverIfNecessary();
-
-private:
     shared_ptr<spdlog::logger> logger;
-    BufferManager& bufferManager;
-    string directory;
-    unique_ptr<storage::WAL> wal;
     unique_ptr<RelsStore> relsStore;
     unique_ptr<NodesStore> nodesStore;
-    mutex checkpointMtx;
     Catalog& catalog;
+    WAL* wal;
 };
 
 } // namespace storage

--- a/src/storage/include/wal_replayer.h
+++ b/src/storage/include/wal_replayer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "src/catalog/include/catalog.h"
 #include "src/storage/buffer_manager/include/buffer_manager.h"
 #include "src/storage/buffer_manager/include/versioned_file_handle.h"
 #include "src/storage/wal/include/wal.h"
@@ -17,9 +16,13 @@ class StorageManager;
 
 class WALReplayer {
 public:
-    WALReplayer(StorageManager* storageManager);
+    // This interface is used for recovery only. We always recover the disk files before
+    // constructing the storageManager and catalog. So this specialized recovery constructor
+    // doesn't take in storageManager and bufferManager.
+    WALReplayer(WAL* wal);
 
-    WALReplayer(StorageManager* storageManager, BufferManager* bufferManager, bool isCheckpoint);
+    WALReplayer(
+        WAL* wal, StorageManager* storageManager, BufferManager* bufferManager, bool isCheckpoint);
 
     void replay();
 
@@ -43,6 +46,7 @@ private:
     unordered_set<ListFileID, ListFileIDHasher> fileIDsOfListsToCheckpointOrRollback;
 
     shared_ptr<spdlog::logger> logger;
+    WAL* wal;
 };
 
 } // namespace storage

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -11,60 +11,19 @@ namespace graphflow {
 namespace storage {
 
 StorageManager::StorageManager(
-    catalog::Catalog& catalog, BufferManager& bufferManager, string directory, bool isInMemoryMode)
-    : logger{LoggerUtils::getOrCreateSpdLogger("storage")},
-      bufferManager{bufferManager}, directory{directory}, catalog{catalog} {
-    logger->info("Initializing StorageManager from directory: " + directory);
-    wal = make_unique<storage::WAL>(directory, bufferManager);
-    recoverIfNecessary();
-    nodesStore =
-        make_unique<NodesStore>(catalog, bufferManager, directory, isInMemoryMode, wal.get());
-    vector<uint64_t> maxNodeOffsetPerLabel =
-        nodesStore->getNodesMetadata().getMaxNodeOffsetPerLabel();
-    relsStore = make_unique<RelsStore>(
-        catalog, maxNodeOffsetPerLabel, bufferManager, directory, isInMemoryMode, wal.get());
+    catalog::Catalog& catalog, BufferManager& bufferManager, bool isInMemoryMode, WAL* wal)
+    : logger{LoggerUtils::getOrCreateSpdLogger("storage")}, catalog{catalog}, wal{wal} {
+    logger->info("Initializing StorageManager from directory: " + wal->getDirectory());
+    nodesStore = make_unique<NodesStore>(catalog, bufferManager, isInMemoryMode, wal);
+    relsStore =
+        make_unique<RelsStore>(catalog, nodesStore->getNodesMetadata().getMaxNodeOffsetPerLabel(),
+            bufferManager, wal->getDirectory(), isInMemoryMode, wal);
     nodesStore->getNodesMetadata().setAdjListsAndColumns(relsStore.get());
-    // TODO(ZIYI): we currently don't add nodes created by DDL to the nodeStore. When restarting
-    // database, we can't rebuild the nodeStore based on the replayed catalog. For now, we
-    // should just rebuild catalog after building nodeStore. The next PR will implement the logic
-    // to add a new node to nodeStore, then this code can be removed.
-    catalog.getReadOnlyVersion()->readFromFile(directory);
     logger->info("Done.");
 }
 
 StorageManager::~StorageManager() {
     spdlog::drop("storage");
-}
-
-void StorageManager::checkpointOrRollbackAndClearWAL(bool isRecovering, bool isCheckpoint) {
-    lock_t lck{checkpointMtx};
-    logger->info(
-        "Starting " +
-        (isCheckpoint ? string("checkpointing") : string("rolling back the wal contents")) +
-        " in the storage manager during " +
-        (isRecovering ? "recovery." : "normal db execution (i.e., not recovering)."));
-    WALReplayer walReplayer =
-        isRecovering ? WALReplayer(this) : WALReplayer(this, &bufferManager, isCheckpoint);
-    walReplayer.replay();
-    logger->info(
-        "Finished " +
-        (isCheckpoint ? string("checkpointing") : string("rolling back the wal contents")) +
-        " in the storage manager.");
-    wal->clearWAL();
-}
-
-void StorageManager::recoverIfNecessary() {
-    if (!wal->isEmptyWAL()) {
-        if (wal->isLastLoggedRecordCommit()) {
-            logger->info("Starting up StorageManager and found a non-empty WAL with a committed "
-                         "transaction. Replaying to checkpoint.");
-            checkpointOrRollbackAndClearWAL(true /* is recovering */, true /* checkpoint */);
-        } else {
-            logger->info("Starting up StorageManager and found a non-empty WAL but last record is "
-                         "not commit. Clearing the WAL.");
-            wal->clearWAL();
-        }
-    }
 }
 
 } // namespace storage

--- a/src/storage/store/BUILD.bazel
+++ b/src/storage/store/BUILD.bazel
@@ -19,6 +19,7 @@ cc_library(
     visibility = ["//visibility:public"],
     deps = [
         "//src/catalog",
+        "//src/loader/in_mem_storage_structure",
         "//src/storage/index:hash_index",
         "//src/storage/storage_structure:column",
         "//src/storage/storage_structure:lists",

--- a/src/storage/store/include/node_table.h
+++ b/src/storage/store/include/node_table.h
@@ -2,7 +2,6 @@
 
 #include "src/catalog/include/catalog.h"
 #include "src/storage/index/include/hash_index.h"
-#include "src/storage/storage_structure/include/column.h"
 #include "src/storage/storage_structure/include/lists/lists.h"
 #include "src/storage/storage_structure/include/lists/unstructured_property_lists.h"
 #include "src/storage/store/include/nodes_metadata.h"
@@ -18,8 +17,8 @@ namespace storage {
 class NodeTable {
 
 public:
-    NodeTable(NodeMetadata* nodeMetadata, BufferManager& bufferManager, bool isInMemory,
-        const vector<catalog::Property>& properties, const string& directory, WAL* wal);
+    NodeTable(NodesMetadata* nodesMetadata, BufferManager& bufferManager, bool isInMemory, WAL* wal,
+        NodeLabel* nodeLabel);
 
     inline Column* getPropertyColumn(uint64_t propertyIdx) {
         return propertyColumns[propertyIdx].get();
@@ -29,14 +28,21 @@ public:
     }
     inline HashIndex* getIDIndex() const { return IDIndex.get(); }
 
-    inline void addNode() { nodeMetadata->addNode(); }
+    inline NodesMetadata* getNodesMetadata() const { return nodesMetadata; }
+
+    inline label_t getLabelID() const { return labelID; }
+
     void deleteNodes(ValueVector* nodeIDVector, ValueVector* primaryKeyVector);
 
+    static void createEmptyDBFilesForNewNodeTable(
+        Catalog* catalog, label_t label, string directory);
+
 private:
-    void deleteNode(ValueVector* nodeIDVector, ValueVector* primaryKeyVector, uint32_t pos);
+    void deleteNode(ValueVector* nodeIDVector, ValueVector* primaryKeyVector, uint32_t pos) const;
 
 public:
-    NodeMetadata* nodeMetadata;
+    NodesMetadata* nodesMetadata;
+    label_t labelID;
 
 private:
     // This is for structured properties.

--- a/src/storage/store/include/nodes_store.h
+++ b/src/storage/store/include/nodes_store.h
@@ -15,8 +15,7 @@ namespace storage {
 class NodesStore {
 
 public:
-    NodesStore(const Catalog& catalog, BufferManager& bufferManager, const string& directory,
-        bool isInMemoryMode, WAL* wal);
+    NodesStore(const Catalog& catalog, BufferManager& bufferManager, bool isInMemoryMode, WAL* wal);
 
     inline Column* getNodePropertyColumn(label_t nodeLabel, uint64_t propertyIdx) const {
         return nodeTables[nodeLabel]->getPropertyColumn(propertyIdx);
@@ -31,9 +30,20 @@ public:
     // TODO: rename to getNodeTable
     inline NodeTable* getNode(label_t nodeLabel) const { return nodeTables[nodeLabel].get(); }
 
+    // Since ddl statements are wrapped in a single auto-committed transaction, we don't need to
+    // maintain a write-only version of nodeTables. We just need to add the actual nodeTable to
+    // nodeStore when checkpointing and not in recovery mode.
+    inline void createNodeTable(
+        label_t labelID, BufferManager* bufferManager, WAL* wal, Catalog* catalog) {
+        nodeTables.push_back(make_unique<NodeTable>(&nodesMetadata, *bufferManager, isInMemoryMode,
+            wal, catalog->getReadOnlyVersion()->getNodeLabel(labelID)));
+    }
+
 private:
     vector<unique_ptr<NodeTable>> nodeTables;
     NodesMetadata nodesMetadata;
+    // Used to dynamically create nodeTables during checkpointing.
+    bool isInMemoryMode;
 };
 
 } // namespace storage

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -1,30 +1,29 @@
 #include "src/storage/store/include/node_table.h"
 
+#include "src/loader/in_mem_storage_structure/include/in_mem_column.h"
+#include "src/loader/in_mem_storage_structure/include/in_mem_lists.h"
+
 namespace graphflow {
 namespace storage {
 
-NodeTable::NodeTable(NodeMetadata* nodeMetadata, BufferManager& bufferManager, bool isInMemory,
-    const vector<catalog::Property>& properties, const string& directory, WAL* wal)
-    : nodeMetadata{nodeMetadata} {
-    auto IDPropertyIdx = UINT32_MAX;
-    for (const auto& property : properties) {
-        if (property.name == LoaderConfig::ID_FIELD) {
-            IDPropertyIdx = property.propertyID;
-        }
+NodeTable::NodeTable(NodesMetadata* nodesMetadata, BufferManager& bufferManager, bool isInMemory,
+    WAL* wal, NodeLabel* nodeLabel)
+    : nodesMetadata{nodesMetadata}, labelID{nodeLabel->labelId} {
+    for (const auto& property : nodeLabel->getAllNodeProperties()) {
         if (property.dataType.typeID != UNSTRUCTURED) {
             propertyColumns.push_back(ColumnFactory::getColumn(
                 StorageUtils::getStructuredNodePropertyColumnStructureIDAndFName(
-                    directory, property),
+                    wal->getDirectory(), property),
                 property.dataType, bufferManager, isInMemory, wal));
         }
     }
     unstrPropertyLists = make_unique<UnstructuredPropertyLists>(
         StorageUtils::getUnstructuredNodePropertyListsStructureIDAndFName(
-            directory, nodeMetadata->getLabelID()),
+            wal->getDirectory(), labelID),
         bufferManager, isInMemory, wal);
-    IDIndex = make_unique<HashIndex>(
-        StorageUtils::getNodeIndexIDAndFName(directory, nodeMetadata->getLabelID()),
-        properties[IDPropertyIdx].dataType, bufferManager, isInMemory);
+    IDIndex =
+        make_unique<HashIndex>(StorageUtils::getNodeIndexIDAndFName(wal->getDirectory(), labelID),
+            nodeLabel->getPrimaryKey().dataType, bufferManager, isInMemory);
 }
 
 void NodeTable::deleteNodes(ValueVector* nodeIDVector, ValueVector* primaryKeyVector) {
@@ -41,10 +40,33 @@ void NodeTable::deleteNodes(ValueVector* nodeIDVector, ValueVector* primaryKeyVe
     }
 }
 
-void NodeTable::deleteNode(ValueVector* nodeIDVector, ValueVector* primaryKeyVector, uint32_t pos) {
+void NodeTable::deleteNode(
+    ValueVector* nodeIDVector, ValueVector* primaryKeyVector, uint32_t pos) const {
     auto nodeOffset = nodeIDVector->readNodeOffset(pos);
-    nodeMetadata->deleteNode(nodeOffset);
+    nodesMetadata->deleteNode(labelID, nodeOffset);
     // TODO(Guodong): delete primary key index
+}
+
+void NodeTable::createEmptyDBFilesForNewNodeTable(
+    Catalog* catalog, label_t label, string directory) {
+    auto nodeLabel = catalog->getReadOnlyVersion()->getNodeLabel(label);
+    for (auto& property : nodeLabel->structuredProperties) {
+        auto fName = StorageUtils::getNodePropertyColumnFName(
+            directory, nodeLabel->labelId, property.propertyID);
+        loader::InMemColumnFactory::getInMemPropertyColumn(
+            fName, property.dataType, 0 /* numNodes */)
+            ->saveToFile();
+    }
+    auto unstrPropertyLists = make_unique<loader::InMemUnstructuredLists>(
+        StorageUtils::getNodeUnstrPropertyListsFName(directory, nodeLabel->labelId),
+        0 /* numNodes */);
+    unstrPropertyLists->getListsMetadataBuilder()->initLargeListPageLists(0 /* largeListIdx */);
+    unstrPropertyLists->saveToFile();
+    auto IDIndex =
+        make_unique<InMemHashIndex>(StorageUtils::getNodeIndexFName(directory, nodeLabel->labelId),
+            nodeLabel->getPrimaryKey().dataType);
+    IDIndex->bulkReserve(0 /* numNodes */);
+    IDIndex->flush();
 }
 
 } // namespace storage

--- a/src/storage/store/nodes_store.cpp
+++ b/src/storage/store/nodes_store.cpp
@@ -3,14 +3,13 @@
 namespace graphflow {
 namespace storage {
 
-NodesStore::NodesStore(const Catalog& catalog, BufferManager& bufferManager,
-    const string& directory, bool isInMemoryMode, WAL* wal)
-    : nodesMetadata(directory) {
+NodesStore::NodesStore(
+    const Catalog& catalog, BufferManager& bufferManager, bool isInMemoryMode, WAL* wal)
+    : nodesMetadata(wal->getDirectory()), isInMemoryMode{isInMemoryMode} {
     nodeTables.resize(catalog.getReadOnlyVersion()->getNumNodeLabels());
     for (auto label = 0u; label < catalog.getReadOnlyVersion()->getNumNodeLabels(); label++) {
-        nodeTables[label] = make_unique<NodeTable>(nodesMetadata.getNodeMetadata(label),
-            bufferManager, isInMemoryMode,
-            catalog.getReadOnlyVersion()->getAllNodeProperties(label), directory, wal);
+        nodeTables[label] = make_unique<NodeTable>(&nodesMetadata, bufferManager, isInMemoryMode,
+            wal, catalog.getReadOnlyVersion()->getNodeLabel(label));
     }
 }
 

--- a/src/storage/wal/include/wal.h
+++ b/src/storage/wal/include/wal.h
@@ -101,6 +101,8 @@ public:
 
     void logCatalogRecord();
 
+    void logNodeTableRecord(label_t labelID);
+
     // Removes the contents of WAL file.
     void clearWAL();
 
@@ -122,6 +124,8 @@ public:
             FileUtils::joinPath(directory, string(StorageConfig::WAL_FILE_SUFFIX)),
             FileHandle::O_DefaultPagedExistingDBFileCreateIfNotExists);
     }
+
+    inline string getDirectory() const { return directory; }
 
 private:
     inline void flushHeaderPages() {

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -53,6 +53,12 @@ void WAL::logCatalogRecord() {
     addNewWALRecordWithoutLock(walRecord);
 }
 
+void WAL::logNodeTableRecord(label_t labelID) {
+    lock_t lck{mtx};
+    WALRecord walRecord = WALRecord::newNodeTableRecord(labelID);
+    addNewWALRecordWithoutLock(walRecord);
+}
+
 void WAL::clearWAL() {
     // We remove the nodeMetadata back up file if necessary.
     bufferManager.removeFilePagesFromFrames(*fileHandle);

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -112,6 +112,13 @@ WALRecord WALRecord::newCatalogRecord() {
     return retVal;
 }
 
+WALRecord WALRecord::newNodeTableRecord(label_t labelID) {
+    WALRecord retVal;
+    retVal.recordType = NODE_TABLE_RECORD;
+    retVal.nodeTableRecord = NodeTableRecord(labelID);
+    return retVal;
+}
+
 void WALRecord::constructWALRecordFromBytes(WALRecord& retVal, uint8_t* bytes, uint64_t& offset) {
     ((WALRecord*)&retVal)[0] = ((WALRecord*)(bytes + offset))[0];
     offset += sizeof(WALRecord);

--- a/test/catalog/catalog_builder_test.cpp
+++ b/test/catalog/catalog_builder_test.cpp
@@ -34,9 +34,10 @@ public:
         personProperties.emplace_back("courseScoresPerTerm",
             DataType(LIST, make_unique<DataType>(LIST, make_unique<DataType>(INT64))));
         vector<string> unstrPropertyNames{"unstrIntProp"};
-        auto nodeLabel = catalogBuilder->createNodeLabel("person", "ID", move(personProperties));
+        auto labelID =
+            catalogBuilder->createAndAddNodeLabel("person", "ID", move(personProperties));
+        auto nodeLabel = catalogBuilder->getReadOnlyVersion()->getNodeLabel(labelID);
         nodeLabel->addUnstructuredProperties(unstrPropertyNames);
-        catalogBuilder->addNodeLabel(move(nodeLabel));
 
         vector<PropertyNameDataType> knowsProperties;
         knowsProperties.emplace_back("START_ID_LABEL", STRING);
@@ -127,7 +128,8 @@ TEST_F(CatalogBuilderTest, SaveAndReadTest) {
     catalogBuilder->getReadOnlyVersion()->saveToFile(
         CATALOG_TEMP_DIRECTORY, false /* isForWALRecord */);
     auto newCatalog = make_unique<CatalogBuilder>();
-    newCatalog->getReadOnlyVersion()->readFromFile(CATALOG_TEMP_DIRECTORY);
+    newCatalog->getReadOnlyVersion()->readFromFile(
+        CATALOG_TEMP_DIRECTORY, false /* isForWALRecord */);
     ASSERT_TRUE(newCatalog->getReadOnlyVersion()->getStructuredNodeProperties(0)[0].isIDProperty());
     // Test getting label id from string
     ASSERT_TRUE(catalogBuilder->getReadOnlyVersion()->containNodeLabel("person"));

--- a/test/runner/e2e_delete_create_transaction_test.cpp
+++ b/test/runner/e2e_delete_create_transaction_test.cpp
@@ -84,16 +84,6 @@ TEST_F(DeleteCreateTransactionTest, ReadAfterRollback) {
     }
 }
 
-TEST_F(DeleteCreateTransactionTest, DeleteSameNodeErrorTest) {
-    auto nodeIDsToDelete = vector<uint64_t>{3};
-    deleteNodes(conn.get(), nodeIDsToDelete);
-    auto result =
-        conn->query("MATCH (a:person) WHERE a.ID=" + to_string(nodeIDsToDelete[0]) + " DELETE a");
-    ASSERT_FALSE(result->isSuccess());
-    ASSERT_STREQ(result->getErrorMessage().c_str(),
-        "Runtime exception: Node with offset 3 is already deleted.");
-}
-
 TEST_F(DeleteCreateTransactionTest, DeleteEntireMorselTest) {
     conn->beginWriteTransaction();
     conn->query("MATCH (a:person) WHERE a.ID < 4096 DELETE a");

--- a/test/storage/wal_replayer_test.cpp
+++ b/test/storage/wal_replayer_test.cpp
@@ -11,9 +11,9 @@ public:
 };
 
 TEST_F(WALReplayerTests, ReplayingUncommittedWALForChekpointErrors) {
-    auto walIterator = database->getStorageManager()->getWAL().getIterator();
-    WALReplayer walReplayer(
-        database->getStorageManager(), database->getBufferManager(), true /* is checkpointWAL */);
+    auto walIterator = database->getWAL()->getIterator();
+    WALReplayer walReplayer(database->getWAL(), database->getStorageManager(),
+        database->getBufferManager(), true /* is checkpointWAL */);
     try {
         walReplayer.replay();
         FAIL();


### PR DESCRIPTION
1. This PR removes the two versions of nodeOffsetInfo from nodeMetadata, instead, the nodesMetadata keeps two versions of vector<unique_ptr<NodeMetada>>.
2. Adds the logic to create nodeMetadata.
3. Moves the wal_replayer and recovery logic from `storageManager` to `database`
4. Fixes a bug in `isReadOnly` interface of logical plan