### PR TITLE
Fix bug in Intersect

### DIFF
--- a/src/processor/include/physical_plan/operator/filter.h
+++ b/src/processor/include/physical_plan/operator/filter.h
@@ -14,8 +14,9 @@ class Filter : public PhysicalOperator, public FilteringOperator {
 public:
     Filter(unique_ptr<BaseExpressionEvaluator> expressionEvaluator, uint32_t dataChunkToSelectPos,
         unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(child), id, paramsString}, FilteringOperator{},
-          expressionEvaluator{move(expressionEvaluator)},
+        : PhysicalOperator{move(child), id, paramsString},
+          FilteringOperator{1 /* numStatesToSave */}, expressionEvaluator{move(
+                                                          expressionEvaluator)},
           dataChunkToSelectPos(dataChunkToSelectPos) {}
 
     PhysicalOperatorType getOperatorType() override { return FILTER; }

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -51,15 +51,16 @@ public:
         vector<uint64_t> flatDataChunkPositions, const ProbeDataInfo& probeDataInfo,
         unique_ptr<PhysicalOperator> probeChild, unique_ptr<PhysicalOperator> buildChild,
         uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(probeChild), move(buildChild), id, paramsString}, sharedState{move(
-                                                                                      sharedState)},
+        : PhysicalOperator{move(probeChild), move(buildChild), id, paramsString},
+          FilteringOperator{1 /* numStatesToSave */}, sharedState{move(sharedState)},
           flatDataChunkPositions{move(flatDataChunkPositions)}, probeDataInfo{probeDataInfo} {}
 
     // This constructor is used for cloning only.
     HashJoinProbe(shared_ptr<HashJoinSharedState> sharedState,
         vector<uint64_t> flatDataChunkPositions, const ProbeDataInfo& probeDataInfo,
         unique_ptr<PhysicalOperator> probeChild, uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(probeChild), id, paramsString}, sharedState{move(sharedState)},
+        : PhysicalOperator{move(probeChild), id, paramsString},
+          FilteringOperator{1 /* numStatesToSave */}, sharedState{move(sharedState)},
           flatDataChunkPositions{move(flatDataChunkPositions)}, probeDataInfo{probeDataInfo} {}
 
     PhysicalOperatorType getOperatorType() override { return HASH_JOIN_PROBE; }

--- a/src/processor/include/physical_plan/operator/intersect.h
+++ b/src/processor/include/physical_plan/operator/intersect.h
@@ -7,12 +7,12 @@ namespace graphflow {
 namespace processor {
 
 class Intersect : public PhysicalOperator, public FilteringOperator {
-
 public:
     Intersect(const DataPos& leftDataPos, const DataPos& rightDataPos,
         unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(child), id, paramsString}, FilteringOperator{},
-          leftDataPos{leftDataPos}, rightDataPos{rightDataPos}, leftIdx{0} {}
+        : PhysicalOperator{move(child), id, paramsString},
+          FilteringOperator{2 /* numStatesToSave */}, leftDataPos{leftDataPos}, rightDataPos{
+                                                                                    rightDataPos} {}
 
     PhysicalOperatorType getOperatorType() override { return INTERSECT; }
 
@@ -35,8 +35,7 @@ private:
     shared_ptr<ValueVector> leftValueVector;
     shared_ptr<DataChunk> rightDataChunk;
     shared_ptr<ValueVector> rightValueVector;
-
-    uint64_t leftIdx;
+    vector<SelectionVector*> selVectorsToSaveRestore;
 };
 
 } // namespace processor

--- a/src/processor/include/physical_plan/operator/scan_column/adj_column_extend.h
+++ b/src/processor/include/physical_plan/operator/scan_column/adj_column_extend.h
@@ -15,7 +15,7 @@ public:
         const string& paramsString)
         : ScanSingleColumn{inputNodeIDVectorPos, outputNodeIDVectorPos, move(child), id,
               paramsString},
-          FilteringOperator(), nodeIDColumn{nodeIDColumn} {}
+          FilteringOperator{1 /* numStatesToSave */}, nodeIDColumn{nodeIDColumn} {}
 
     PhysicalOperatorType getOperatorType() override { return COLUMN_EXTEND; }
 

--- a/src/processor/include/physical_plan/operator/skip.h
+++ b/src/processor/include/physical_plan/operator/skip.h
@@ -13,7 +13,8 @@ public:
         unordered_set<uint32_t> dataChunksPosInScope, unique_ptr<PhysicalOperator> child,
         uint32_t id, const string& paramsString)
         : PhysicalOperator{move(child), id, paramsString},
-          FilteringOperator(), skipNumber{skipNumber}, counter{move(counter)},
+          FilteringOperator{1 /* numStatesToSave */}, skipNumber{skipNumber}, counter{move(
+                                                                                  counter)},
           dataChunkToSelectPos{dataChunkToSelectPos}, dataChunksPosInScope{
                                                           move(dataChunksPosInScope)} {}
 

--- a/src/processor/physical_plan/operator/filter.cpp
+++ b/src/processor/physical_plan/operator/filter.cpp
@@ -19,12 +19,12 @@ bool Filter::getNextTuples() {
     metrics->executionTime.start();
     bool hasAtLeastOneSelectedValue;
     do {
-        restoreDataChunkSelectorState(dataChunkToSelect);
+        restoreSelVector(dataChunkToSelect->state->selVector.get());
         if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }
-        saveDataChunkSelectorState(dataChunkToSelect);
+        saveSelVector(dataChunkToSelect->state->selVector.get());
         hasAtLeastOneSelectedValue =
             expressionEvaluator->select(*dataChunkToSelect->state->selVector);
         if (!dataChunkToSelect->state->isFlat() &&

--- a/src/processor/physical_plan/operator/filtering_operator.cpp
+++ b/src/processor/physical_plan/operator/filtering_operator.cpp
@@ -3,32 +3,33 @@
 namespace graphflow {
 namespace processor {
 
-void FilteringOperator::restoreDataChunkSelectorState(
-    const shared_ptr<DataChunk>& dataChunkToSelect) {
+void FilteringOperator::restoreSelVector(
+    SelectionVector* prevSelVector, SelectionVector* selVector) {
     if (prevSelVector->selectedPositions == nullptr) {
         return;
     }
-    dataChunkToSelect->state->selVector->selectedSize = prevSelVector->selectedSize;
+    selVector->selectedSize = prevSelVector->selectedSize;
     if (prevSelVector->isUnfiltered()) {
-        dataChunkToSelect->state->selVector->resetSelectorToUnselected();
+        selVector->resetSelectorToUnselected();
     } else {
-        dataChunkToSelect->state->selVector->resetSelectorToValuePosBuffer();
-        memcpy(dataChunkToSelect->state->selVector->selectedPositions,
-            prevSelVector->getSelectedPositionsBuffer(),
-            prevSelVector->selectedSize * sizeof(sel_t));
+        auto sizeToCopy = prevSelVector->selectedSize * sizeof(sel_t);
+        selVector->resetSelectorToValuePosBuffer();
+        memcpy(
+            selVector->selectedPositions, prevSelVector->getSelectedPositionsBuffer(), sizeToCopy);
     }
 }
 
-void FilteringOperator::saveDataChunkSelectorState(const shared_ptr<DataChunk>& dataChunkToSelect) {
-    prevSelVector->selectedSize = dataChunkToSelect->state->selVector->selectedSize;
-    if (dataChunkToSelect->state->selVector->isUnfiltered()) {
+void FilteringOperator::saveSelVector(SelectionVector* prevSelVector, SelectionVector* selVector) {
+    prevSelVector->selectedSize = selVector->selectedSize;
+    if (selVector->isUnfiltered()) {
         prevSelVector->resetSelectorToUnselected();
     } else {
-        memcpy(prevSelVector->getSelectedPositionsBuffer(),
-            dataChunkToSelect->state->selVector->getSelectedPositionsBuffer(),
-            prevSelVector->selectedSize * sizeof(sel_t));
+        auto sizeToCopy = prevSelVector->selectedSize * sizeof(sel_t);
+        memcpy(prevSelVector->getSelectedPositionsBuffer(), selVector->getSelectedPositionsBuffer(),
+            sizeToCopy);
         prevSelVector->resetSelectorToValuePosBuffer();
     }
 }
+
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -38,11 +38,11 @@ bool HashJoinProbe::getNextBatchOfMatchedTuples() {
     auto keys = (nodeID_t*)probeSideKeyVector->values;
     do {
         if (probeState->numMatchedTuples == 0) {
-            restoreDataChunkSelectorState(probeSideKeyDataChunk);
+            restoreSelVector(probeSideKeyDataChunk->state->selVector.get());
             if (!children[0]->getNextTuples()) {
                 return false;
             }
-            saveDataChunkSelectorState(probeSideKeyDataChunk);
+            saveSelVector(probeSideKeyDataChunk->state->selVector.get());
             sharedState->getHashTable()->probe(
                 *probeSideKeyVector, probeState->probedTuples.get(), *probeState->probeSelVector);
         }

--- a/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
+++ b/src/processor/physical_plan/operator/scan_column/adj_column_extend.cpp
@@ -19,12 +19,12 @@ bool AdjColumnExtend::getNextTuples() {
     metrics->executionTime.start();
     bool hasAtLeastOneNonNullValue;
     do {
-        restoreDataChunkSelectorState(inputNodeIDDataChunk);
+        restoreSelVector(inputNodeIDDataChunk->state->selVector.get());
         if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }
-        saveDataChunkSelectorState(inputNodeIDDataChunk);
+        saveSelVector(inputNodeIDDataChunk->state->selVector.get());
         outputVector->setAllNull();
         nodeIDColumn->read(transaction, inputNodeIDVector, outputVector);
         hasAtLeastOneNonNullValue = NodeIDVector::discardNull(*outputVector);

--- a/src/processor/physical_plan/operator/skip.cpp
+++ b/src/processor/physical_plan/operator/skip.cpp
@@ -9,13 +9,13 @@ bool Skip::getNextTuples() {
     auto numTupleSkippedBefore = 0u;
     auto numTuplesAvailable = 1u;
     do {
-        restoreDataChunkSelectorState(dataChunkToSelect);
+        restoreSelVector(dataChunkToSelect->state->selVector.get());
         // end of execution due to no more input
         if (!children[0]->getNextTuples()) {
             metrics->executionTime.stop();
             return false;
         }
-        saveDataChunkSelectorState(dataChunkToSelect);
+        saveSelVector(dataChunkToSelect->state->selVector.get());
         numTuplesAvailable = resultSet->getNumTuples(dataChunksPosInScope);
         numTupleSkippedBefore = counter->fetch_add(numTuplesAvailable);
     } while (numTupleSkippedBefore + numTuplesAvailable <= skipNumber);


### PR DESCRIPTION
This PR fixes several bugs that lead to incorrect output tuple for intersect-based plans on LDBC. These bugs are

- Sorting on selected position didn't set to buffer. So it always points to the static unselect array.
- The right select state wasn't saved and restored
  - In order to solve this, this PR also refactors the filtering operator interface to allow saving and restoring for multiple selected states.
-  Avoid internal flattening in intersect operator