### PR TITLE
fixing the loader bug after saving empty unstructured property lists

### DIFF
--- a/src/loader/in_mem_builder/in_mem_structures_builder.cpp
+++ b/src/loader/in_mem_builder/in_mem_structures_builder.cpp
@@ -137,10 +137,7 @@ void InMemStructuresBuilder::calculateListHeadersTask(node_offset_t numNodes, ui
     const shared_ptr<spdlog::logger>& logger, LoaderProgressBar* progressBar) {
     logger->trace("Start: ListHeadersBuilder={0:p}", (void*)listHeadersBuilder);
     auto numElementsPerPage = PageUtils::getNumElementsInAPage(elementSize, false /* hasNull */);
-    auto numChunks = StorageUtils::getListChunkIdx(numNodes);
-    if (0 != (numNodes & (StorageConfig::LISTS_CHUNK_SIZE - 1))) {
-        numChunks++;
-    }
+    auto numChunks = StorageUtils::getNumChunks(numNodes);
     node_offset_t nodeOffset = 0u;
     uint64_t lAdjListsIdx = 0u;
     for (auto chunkId = 0u; chunkId < numChunks; chunkId++) {
@@ -169,11 +166,7 @@ void InMemStructuresBuilder::calculateListsMetadataAndAllocateInMemListPagesTask
     LoaderProgressBar* progressBar) {
     logger->trace("Start: listsMetadataBuilder={0:p} adjListHeadersBuilder={1:p}",
         (void*)inMemList->getListsMetadataBuilder(), (void*)listHeadersBuilder);
-
-    auto numChunks = StorageUtils::getListChunkIdx(numNodes);
-    if (0 != (numNodes & (StorageConfig::LISTS_CHUNK_SIZE - 1))) {
-        numChunks++;
-    }
+    auto numChunks = StorageUtils::getNumChunks(numNodes);
     node_offset_t nodeOffset = 0u;
     auto largeListIdx = 0u;
     for (auto chunkId = 0u; chunkId < numChunks; chunkId++) {
@@ -199,7 +192,6 @@ void InMemStructuresBuilder::calculateListsMetadataAndAllocateInMemListPagesTask
                 if (0 != numElementsInList % numPerPage) {
                     numPagesForLargeList++;
                 }
-
                 inMemList->getListsMetadataBuilder()->populateLargeListPageList(largeListIdx,
                     numPagesForLargeList, numElementsInList,
                     inMemList->inMemFile->getNumPages() /* start idx of pages in .lists file */);

--- a/src/loader/in_mem_builder/include/in_mem_node_builder.h
+++ b/src/loader/in_mem_builder/include/in_mem_node_builder.h
@@ -48,7 +48,7 @@ private:
     static void populateColumnsAndCountUnstrPropertyListSizesTask(uint64_t IDColumnIdx,
         uint64_t blockId, uint64_t offsetStart, InMemHashIndex* IDIndex, InMemNodeBuilder* builder);
     static void populateUnstrPropertyListsTask(
-        uint64_t blockId, node_offset_t offsetStart, InMemNodeBuilder* builder);
+        uint64_t blockId, node_offset_t nodeOffsetStart, InMemNodeBuilder* builder);
 
 private:
     DataType IDType;

--- a/src/storage/include/storage_utils.h
+++ b/src/storage/include/storage_utils.h
@@ -256,6 +256,14 @@ public:
                                         common::StorageConfig::NODES_METADATA_FILE_NAME);
     }
 
+    static inline uint64_t getNumChunks(node_offset_t numNodes) {
+        auto numChunks = StorageUtils::getListChunkIdx(numNodes);
+        if (0 != (numNodes & (StorageConfig::LISTS_CHUNK_SIZE - 1))) {
+            numChunks++;
+        }
+        return numChunks;
+    }
+
     static inline uint64_t getListChunkIdx(node_offset_t nodeOffset) {
         return nodeOffset >> StorageConfig::LISTS_CHUNK_SIZE_LOG_2;
     }


### PR DESCRIPTION
This was actually major bug: we were giving wrong arguments to the loader function populateUnstrPropertyListsTask; specifically instead of blockId we were giving offsetStart, which is the start of the nodeOffset for that block. This never surfaced because : 1) we never used large datasets, those with node csv files > 8MB (which is our block size), that had unstructured properties; 2) our tests, which contain node csv files with unstructured dataset also are small (< 8MBs). Now that we are storing unstructured property lists even if a node csv file does not contain any unstructured properties, this bug surfaced and we were giving a very large blockId to the CSVreader (which was off course not the blockId but node_offset). 