### PR TITLE
add load csv front end

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -15,7 +15,21 @@ grammar Cypher;
 
 oC_Cypher 
     : SP ? oC_AnyCypherOption? SP? oC_Statement ( SP? ';' )? SP? EOF
-        | SP ? gF_DDL ( SP? ';' )? SP? EOF ;
+        | SP ? gF_DDL ( SP? ';' )? SP? EOF 
+        | SP ? gF_CopyCSV ( SP? ';' )? SP? EOF ;
+        
+gF_CopyCSV
+    : COPY SP oC_SchemaName SP FROM SP StringLiteral ( SP '(' SP? gF_ParsingOptions SP? ')' )? ;
+
+gF_ParsingOptions
+    : gF_ParsingOption ( SP? ',' SP? gF_ParsingOption )* ;
+    
+gF_ParsingOption
+    : oC_SymbolicName SP? '=' SP? StringLiteral ;
+
+COPY : ( 'C' | 'c' ) ( 'O' | 'o' ) ( 'P' | 'p') ( 'Y' | 'y' ) ;    
+
+FROM : ( 'F' | 'f' ) ( 'R' | 'r' ) ( 'O' | 'o' ) ( 'M' | 'm' );
 
 gF_DDL
     : gF_CreateNode ;

--- a/src/binder/BUILD.bazel
+++ b/src/binder/BUILD.bazel
@@ -12,6 +12,7 @@ cc_library(
         "//visibility:public",
     ],
     deps = [
+        "//src/binder/bound_copy_csv",
         "//src/binder/bound_create_node_clause",
         "//src/binder/expression:expression_implementations",
         "//src/binder/query",
@@ -19,6 +20,7 @@ cc_library(
         "//src/function/boolean:vector_boolean_operations",
         "//src/function/cast:vector_cast_operations",
         "//src/function/null:vector_null_operations",
+        "//src/parser/copy_csv",
         "//src/parser/create_node_clause",
         "//src/parser/expression:parsed_expression_implementations",
         "//src/parser/query",

--- a/src/binder/bound_copy_csv/BUILD.bazel
+++ b/src/binder/bound_copy_csv/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+cc_library(
+    name = "bound_copy_csv",
+    hdrs = glob([
+        "include/*.h",
+    ]),
+    visibility = [
+        "//src/binder:__subpackages__",
+    ],
+    deps = [
+        "//src/binder/bound_statement",
+    ],
+)

--- a/src/binder/bound_copy_csv/include/bound_copy_csv.h
+++ b/src/binder/bound_copy_csv/include/bound_copy_csv.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <hash_map>
+
+#include "src/binder/bound_statement/include/bound_statement.h"
+#include "src/common/types/include/node_id_t.h"
+
+using namespace std;
+
+namespace graphflow {
+namespace binder {
+
+class BoundCopyCSV : public BoundStatement {
+public:
+    BoundCopyCSV(string csvFileName, label_t labelID, bool isNodeLabel,
+        unordered_map<string, char> parsingOptions)
+        : BoundStatement{StatementType::COPYCSV}, csvFileName{move(csvFileName)}, labelID{labelID},
+          isNodeLabel{isNodeLabel}, parsingOptions{move(parsingOptions)} {}
+
+    inline string getCSVFileName() const { return csvFileName; }
+    inline label_t getLabelID() const { return labelID; }
+    inline bool getIsNodeLabel() const { return isNodeLabel; }
+    inline unordered_map<string, char> getParsingOptions() const { return parsingOptions; }
+
+private:
+    string csvFileName;
+    label_t labelID;
+    bool isNodeLabel;
+    unordered_map<string, char> parsingOptions;
+};
+
+} // namespace binder
+} // namespace graphflow

--- a/src/binder/bound_create_node_clause/include/bound_create_node_clause.h
+++ b/src/binder/bound_create_node_clause/include/bound_create_node_clause.h
@@ -12,7 +12,7 @@ class BoundCreateNodeClause : public BoundStatement {
 public:
     explicit BoundCreateNodeClause(
         string labelName, string primaryKey, vector<PropertyNameDataType> propertyNameDataTypes)
-        : BoundStatement{StatementType::CreateNodeClause}, labelName{move(labelName)},
+        : BoundStatement{StatementType::CREATENODECLAUSE}, labelName{move(labelName)},
           primaryKey{move(primaryKey)}, propertyNameDataTypes{move(propertyNameDataTypes)} {}
 
     inline string getLabelName() const { return labelName; }

--- a/src/binder/copy_csv_binder.cpp
+++ b/src/binder/copy_csv_binder.cpp
@@ -1,0 +1,46 @@
+#include "include/copy_csv_binder.h"
+
+namespace graphflow {
+namespace binder {
+
+unique_ptr<BoundCopyCSV> CopyCSVBinder::bind(const CopyCSV& copyCSV) {
+    auto labelName = copyCSV.getLabelName();
+    validateLabelName(labelName);
+    auto isNodeLabel = catalog->getReadOnlyVersion()->containNodeLabel(labelName);
+    auto labelID = isNodeLabel ? catalog->getReadOnlyVersion()->getNodeLabelFromName(labelName) :
+                                 catalog->getReadOnlyVersion()->getRelLabelFromName(labelName);
+    return make_unique<BoundCopyCSV>(copyCSV.getCSVFileName(), labelID, isNodeLabel,
+        bindParsingOptions(copyCSV.getParsingOptions()));
+}
+
+void CopyCSVBinder::validateParsingOptionName(string& parsingOptionName) {
+    for (auto i = 0; i < size(LoaderConfig::CSV_PARSING_OPTIONS); i++) {
+        if (parsingOptionName == LoaderConfig::CSV_PARSING_OPTIONS[i]) {
+            return;
+        }
+    }
+    throw BinderException("Unrecognized parsing csv option: " + parsingOptionName + ".");
+}
+
+unordered_map<string, char> CopyCSVBinder::bindParsingOptions(
+    unordered_map<string, string> parsingOptions) {
+    unordered_map<string, char> boundParsingOptions = getDefaultParsingOptions();
+    for (auto& parsingOption : parsingOptions) {
+        auto loadOptionName = parsingOption.first;
+        validateParsingOptionName(loadOptionName);
+        boundParsingOptions[loadOptionName] = bindParsingOptionValue(parsingOption.second);
+    }
+    return boundParsingOptions;
+}
+
+char CopyCSVBinder::bindParsingOptionValue(string parsingOptionValue) {
+    if (parsingOptionValue.length() > 2 ||
+        (parsingOptionValue.length() == 2 && parsingOptionValue[0] != '\\')) {
+        throw BinderException("Copy csv option value can only be a single character with an "
+                              "optional escape character.");
+    }
+    return parsingOptionValue[parsingOptionValue.length() - 1];
+}
+
+} // namespace binder
+} // namespace graphflow

--- a/src/binder/include/copy_csv_binder.h
+++ b/src/binder/include/copy_csv_binder.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "src/binder/bound_copy_csv/include/bound_copy_csv.h"
+#include "src/catalog/include/catalog.h"
+#include "src/common/include/configs.h"
+#include "src/parser/copy_csv/include/copy_csv.h"
+
+using namespace graphflow::parser;
+using namespace graphflow::catalog;
+
+namespace graphflow {
+namespace binder {
+
+class CopyCSVBinder {
+public:
+    explicit CopyCSVBinder(Catalog* catalog) : catalog{catalog} {}
+
+    unique_ptr<BoundCopyCSV> bind(const CopyCSV& copyCSV);
+
+    /******* validations *********/
+    inline void validateLabelName(string& schemaName) {
+        if (!catalog->getReadOnlyVersion()->containNodeLabel(schemaName) &&
+            !catalog->getReadOnlyVersion()->containRelLabel(schemaName)) {
+            throw BinderException("Node/Rel " + schemaName + " does not exist.");
+        }
+    }
+
+    static void validateParsingOptionName(string& parsingOptionName);
+
+    static unordered_map<string, char> bindParsingOptions(
+        unordered_map<string, string> parsingOptions);
+
+    static char bindParsingOptionValue(string parsingOptionValue);
+
+    static unordered_map<string, char> getDefaultParsingOptions() {
+        return {{"ESCAPE", LoaderConfig::DEFAULT_ESCAPE_CHAR},
+            {"DELIM", LoaderConfig::DEFAULT_TOKEN_SEPARATOR},
+            {"QUOTE", LoaderConfig::DEFAULT_QUOTE_CHAR},
+            {"LIST_BEGIN", LoaderConfig::DEFAULT_LIST_BEGIN_CHAR},
+            {"LIST_END", LoaderConfig::DEFAULT_LIST_END_CHAR}};
+    }
+
+private:
+    Catalog* catalog;
+};
+
+} // namespace binder
+} // namespace graphflow

--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -91,6 +91,8 @@ struct LoaderConfig {
     static constexpr char LIST_FIELD_SUFFIX[] = "[]";
 
     // Default configuration for csv file parsing
+    static constexpr const char* CSV_PARSING_OPTIONS[5] = {
+        "ESCAPE", "DELIM", "QUOTE", "LIST_BEGIN", "LIST_END"};
     static constexpr char DEFAULT_ESCAPE_CHAR = '\\';
     static constexpr char DEFAULT_TOKEN_SEPARATOR = ',';
     static constexpr char DEFAULT_QUOTE_CHAR = '"';

--- a/src/common/include/statement_type.h
+++ b/src/common/include/statement_type.h
@@ -7,7 +7,8 @@ namespace common {
 
 enum class StatementType : uint8_t {
     QUERY = 0,
-    CreateNodeClause = 1,
+    CREATENODECLAUSE = 1,
+    COPYCSV = 2,
 };
 
 } // namespace common

--- a/src/parser/BUILD.bazel
+++ b/src/parser/BUILD.bazel
@@ -28,6 +28,7 @@ cc_library(
     deps = [
         "//src/common:type_utils",
         "//src/parser/antlr_parser",
+        "//src/parser/copy_csv",
         "//src/parser/create_node_clause",
         "//src/parser/expression:parsed_expression_implementations",
         "//src/parser/query",

--- a/src/parser/copy_csv/BUILD.bazel
+++ b/src/parser/copy_csv/BUILD.bazel
@@ -1,0 +1,13 @@
+cc_library(
+    name = "copy_csv",
+    hdrs = glob([
+        "include/*.h",
+    ]),
+    visibility = [
+        "//src/binder:__subpackages__",
+        "//src/parser:__subpackages__",
+    ],
+    deps = [
+        "//src/parser:statement",
+    ],
+)

--- a/src/parser/copy_csv/include/copy_csv.h
+++ b/src/parser/copy_csv/include/copy_csv.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "src/parser/include/statement.h"
+
+namespace graphflow {
+namespace parser {
+
+using namespace std;
+
+class CopyCSV : public Statement {
+public:
+    explicit CopyCSV(
+        string csvFileName, string labelName, unordered_map<string, string> parsingOptions)
+        : Statement{StatementType::COPYCSV}, csvFileName{move(csvFileName)},
+          labelName{move(labelName)}, parsingOptions{move(parsingOptions)} {}
+
+    inline string getCSVFileName() const { return csvFileName; }
+    inline string getLabelName() const { return labelName; }
+    inline unordered_map<string, string> getParsingOptions() const { return parsingOptions; }
+
+private:
+    string csvFileName;
+    string labelName;
+    unordered_map<string, string> parsingOptions;
+};
+
+} // namespace parser
+} // namespace graphflow

--- a/src/parser/create_node_clause/include/create_node_clause.h
+++ b/src/parser/create_node_clause/include/create_node_clause.h
@@ -14,7 +14,7 @@ class CreateNodeClause : public Statement {
 public:
     explicit CreateNodeClause(
         vector<pair<string, string>> propertyNameDataTypes, string primaryKey, string labelName)
-        : Statement{StatementType::CreateNodeClause}, labelName{move(labelName)},
+        : Statement{StatementType::CREATENODECLAUSE}, labelName{move(labelName)},
           primaryKey{move(primaryKey)}, propertyNameDataTypes{move(propertyNameDataTypes)} {}
 
     inline string getLabelName() const { return labelName; }

--- a/src/parser/include/transformer.h
+++ b/src/parser/include/transformer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "src/antlr4/CypherParser.h"
+#include "src/parser/copy_csv/include/copy_csv.h"
 #include "src/parser/create_node_clause/include/create_node_clause.h"
 #include "src/parser/query/include/regular_query.h"
 #include "src/parser/query/updating_clause/include/create_clause.h"
@@ -19,13 +20,7 @@ public:
 
     unique_ptr<RegularQuery> transformQuery();
 
-    inline unique_ptr<Statement> transform() {
-        if (root.oC_Statement()) {
-            return transformQuery();
-        } else {
-            return transformDDL();
-        }
-    }
+    unique_ptr<Statement> transform();
 
 private:
     unique_ptr<RegularQuery> transformQuery(CypherParser::OC_QueryContext& ctx);
@@ -187,6 +182,13 @@ private:
 
     vector<pair<string, string>> transformPropertyDefinitions(
         CypherParser::GF_PropertyDefinitionsContext& ctx);
+
+    unique_ptr<CopyCSV> transformCopyCSV();
+
+    unordered_map<string, string> transformParsingOptions(
+        CypherParser::GF_ParsingOptionsContext& ctx);
+
+    string transformStringLiteral(antlr4::tree::TerminalNode& stringLiteral);
 
 private:
     CypherParser::OC_CypherContext& root;

--- a/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
+++ b/src/processor/physical_plan/hash_table/aggregate_hash_table.cpp
@@ -567,7 +567,7 @@ uint64_t AggregateHashTable::matchFlatVecWithFTColumn(
     assert(vector->state->isFlat());
     auto colOffset = factorizedTable->getTableSchema()->getColOffset(colIdx);
     uint64_t mayMatchIdx = 0;
-    auto pos = vector->state->currIdx;
+    auto pos = vector->state->getPositionOfCurrIdx();
     auto isVectorNull = vector->isNull(pos);
     auto value = vector->values + pos * vector->getNumBytesPerValue();
     for (auto i = 0u; i < numMayMatches; i++) {


### PR DESCRIPTION
This PR adds the load csv front end support.
Grammar for LOAD CSV command:
`COPY person FROM "person_0_0.csv" (ESCAPE="\\", DELIM=';', QUOTE='"',LIST_BEGIN='{',LIST_END='}');`

Supported load options:
ESCAPE, DELIM, QUOTE, LIST_BEGIN, LIST_END