### PR TITLE
add semi mask for sjoins

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -7,7 +7,8 @@
 namespace graphflow {
 namespace common {
 
-constexpr uint64_t DEFAULT_VECTOR_CAPACITY = 2048;
+constexpr uint64_t DEFAULT_VECTOR_CAPACITY_LOG_2 = 11;
+constexpr uint64_t DEFAULT_VECTOR_CAPACITY = (uint64_t)1 << DEFAULT_VECTOR_CAPACITY_LOG_2;
 
 // Currently the system supports files with 2 different pages size, which we refer to as
 // DEFAULT_PAGE_SIZE and LARGE_PAGE_SIZE. Default size of the page which is the unit of read/write

--- a/src/main/include/connection.h
+++ b/src/main/include/connection.h
@@ -126,7 +126,7 @@ public:
     string getRelPropertyNames(const string& relLabelName);
 
     // Used in test helper. Note: for our testing framework, we should not catch exception and
-    // instead let IDE catch these exception
+    // instead let IDE catch these exceptions.
     std::vector<unique_ptr<planner::LogicalPlan>> enumeratePlans(const std::string& query);
     unique_ptr<planner::LogicalPlan> getBestPlan(const std::string& query);
     std::unique_ptr<QueryResult> executePlan(unique_ptr<planner::LogicalPlan> logicalPlan);

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -5,8 +5,6 @@
 #include "src/processor/include/physical_plan/result/result_set.h"
 #include "src/storage/buffer_manager/include/buffer_manager.h"
 
-using namespace std;
-
 namespace graphflow {
 namespace processor {
 
@@ -35,6 +33,7 @@ enum PhysicalOperatorType : uint8_t {
     SCAN_NODE_ID,
     SCAN_STRUCTURED_PROPERTY,
     SCAN_UNSTRUCTURED_PROPERTY,
+    SEMI_MASKER,
     SET,
     SKIP,
     ORDER_BY,
@@ -51,8 +50,8 @@ const string PhysicalOperatorTypeNames[] = {"AGGREGATE", "AGGREGATE_SCAN", "COLU
     "CREATE", "DELETE", "EXISTS", "FACTORIZED_TABLE_SCAN", "FILTER", "FLATTEN", "HASH_JOIN_BUILD",
     "HASH_JOIN_PROBE", "INTERSECT", "LEFT_NESTED_LOOP_JOIN", "LIMIT", "LIST_EXTEND",
     "MULTIPLICITY_REDUCER", "PROJECTION", "READ_REL_PROPERTY", "RESULT_COLLECTOR", "RESULT_SCAN",
-    "SCAN_NODE_ID", "SCAN_STRUCTURED_PROPERTY", "SCAN_UNSTRUCTURED_PROPERTY", "SET", "SKIP",
-    "ORDER_BY", "ORDER_BY_MERGE", "ORDER_BY_SCAN", "UNION_ALL_SCAN", "CREATE_NODE_TABLE",
+    "SCAN_NODE_ID", "SCAN_STRUCTURED_PROPERTY", "SCAN_UNSTRUCTURED_PROPERTY", "SEMI_MASKER", "SET",
+    "SKIP", "ORDER_BY", "ORDER_BY_MERGE", "ORDER_BY_SCAN", "UNION_ALL_SCAN", "CREATE_NODE_TABLE",
     "CREATE_REL_TABLE"};
 
 struct OperatorMetrics {

--- a/src/processor/include/physical_plan/operator/scan_node_id.h
+++ b/src/processor/include/physical_plan/operator/scan_node_id.h
@@ -9,26 +9,52 @@
 namespace graphflow {
 namespace processor {
 
+struct SemiMask {
+public:
+    SemiMask(node_offset_t maxNodeOffset, uint64_t maxMorselIdx) {
+        morselMask = make_unique<bool[]>(maxMorselIdx + 1);
+        nodeMask = make_unique<bool[]>(maxNodeOffset + 1);
+        fill(morselMask.get(), morselMask.get() + maxMorselIdx + 1, false);
+        fill(nodeMask.get(), nodeMask.get() + maxNodeOffset + 1, false);
+    }
+
+    unique_ptr<bool[]> morselMask;
+    unique_ptr<bool[]> nodeMask;
+};
+
 class ScanNodeIDSharedState {
 
 public:
-    explicit ScanNodeIDSharedState(NodesMetadata* nodesMetadata, label_t labelID)
-        : nodesMetadata{nodesMetadata}, labelID{labelID}, maxNodeOffset{UINT64_MAX},
-          currentNodeOffset{0} {}
+    explicit ScanNodeIDSharedState(
+        NodesMetadata* nodesMetadata, label_t labelID, bool enableSemiMask = false)
+        : initialized{false}, enableSemiMask{enableSemiMask}, nodesMetadata{nodesMetadata},
+          labelID{labelID}, maxNodeOffset{UINT64_MAX}, maxMorselIdx{UINT64_MAX}, currentNodeOffset{
+                                                                                     0} {}
 
-    inline void initMaxNodeOffset(Transaction* transaction) {
-        unique_lock uLck{mtx};
-        maxNodeOffset = nodesMetadata->getMaxNodeOffset(transaction, labelID);
-    }
+    void initialize(Transaction* transaction);
 
     pair<uint64_t, uint64_t> getNextRangeToRead();
 
+    // Notice: This function is not protected with a lock for concurrent writes because of the
+    // special use case that there is no mixed reads and writes to the mask, and all writes to the
+    // mask try to set a position to true, thus it doesn't matter which thread succeeds.
+    inline void setMask(uint64_t nodeOffset) {
+        mask->morselMask[nodeOffset >> DEFAULT_VECTOR_CAPACITY_LOG_2] = true;
+        mask->nodeMask[nodeOffset] = true;
+    }
+    inline bool isSemiMaskEnabled() const { return enableSemiMask; }
+    inline bool isNodeMasked(node_offset_t nodeOffset) const { return mask->nodeMask[nodeOffset]; }
+
 private:
     mutex mtx;
+    bool initialized;
+    bool enableSemiMask;
     NodesMetadata* nodesMetadata;
     label_t labelID;
     uint64_t maxNodeOffset;
+    uint64_t maxMorselIdx;
     uint64_t currentNodeOffset;
+    unique_ptr<SemiMask> mask;
 };
 
 class ScanNodeID : public PhysicalOperator, public SourceOperator {
@@ -36,9 +62,9 @@ class ScanNodeID : public PhysicalOperator, public SourceOperator {
 public:
     ScanNodeID(unique_ptr<ResultSetDescriptor> resultSetDescriptor, NodeTable* nodeTable,
         const DataPos& outDataPos, shared_ptr<ScanNodeIDSharedState> sharedState, uint32_t id,
-        string paramsString)
-        : PhysicalOperator{id, paramsString}, SourceOperator{move(resultSetDescriptor)},
-          nodeTable{nodeTable}, outDataPos{outDataPos}, sharedState{move(sharedState)} {}
+        const string& paramsString)
+        : PhysicalOperator{id, paramsString}, SourceOperator{std::move(resultSetDescriptor)},
+          nodeTable{nodeTable}, outDataPos{outDataPos}, sharedState{std::move(sharedState)} {}
 
     PhysicalOperatorType getOperatorType() override { return SCAN_NODE_ID; }
 
@@ -54,6 +80,9 @@ public:
     inline double getExecutionTime(Profiler& profiler) const override {
         return profiler.sumAllTimeMetricsWithKey(getTimeMetricKey());
     }
+
+private:
+    void setSelVector(node_offset_t startOffset, node_offset_t endOffset);
 
 private:
     NodeTable* nodeTable;

--- a/src/processor/include/physical_plan/operator/semi_masker.h
+++ b/src/processor/include/physical_plan/operator/semi_masker.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "src/processor/include/physical_plan/operator/physical_operator.h"
+#include "src/processor/include/physical_plan/operator/scan_node_id.h"
+
+namespace graphflow {
+namespace processor {
+
+class SemiMasker : public PhysicalOperator {
+
+public:
+    SemiMasker(const DataPos& keyDataPos, ScanNodeIDSharedState* scanNodeIDSharedState,
+        unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
+        : PhysicalOperator{std::move(child), id, paramsString}, keyDataPos{keyDataPos},
+          scanNodeIDSharedState{scanNodeIDSharedState} {}
+
+    inline PhysicalOperatorType getOperatorType() override { return SEMI_MASKER; }
+
+    shared_ptr<ResultSet> init(ExecutionContext* context) override;
+
+    bool getNextTuples() override;
+
+    inline unique_ptr<PhysicalOperator> clone() override {
+        auto clonedSemiMasker = make_unique<SemiMasker>(
+            keyDataPos, scanNodeIDSharedState, children[0]->clone(), id, paramsString);
+    }
+
+private:
+    DataPos keyDataPos;
+    shared_ptr<ValueVector> keyValueVector;
+    ScanNodeIDSharedState* scanNodeIDSharedState;
+};
+} // namespace processor
+} // namespace graphflow

--- a/src/processor/physical_plan/operator/scan_node_id.cpp
+++ b/src/processor/physical_plan/operator/scan_node_id.cpp
@@ -3,11 +3,32 @@
 namespace graphflow {
 namespace processor {
 
+void ScanNodeIDSharedState::initialize(graphflow::transaction::Transaction* transaction) {
+    unique_lock uLck{mtx};
+    if (initialized) {
+        return;
+    }
+    maxNodeOffset = nodesMetadata->getMaxNodeOffset(transaction, labelID);
+    maxMorselIdx = maxNodeOffset >> DEFAULT_VECTOR_CAPACITY_LOG_2;
+    if (enableSemiMask) {
+        mask = make_unique<SemiMask>(maxNodeOffset, maxMorselIdx);
+    }
+    initialized = true;
+}
+
 pair<uint64_t, uint64_t> ScanNodeIDSharedState::getNextRangeToRead() {
     unique_lock lck{mtx};
     // Note: we use maxNodeOffset=UINT64_MAX to represent an empty table.
     if (currentNodeOffset > maxNodeOffset || maxNodeOffset == UINT64_MAX) {
         return make_pair(currentNodeOffset, currentNodeOffset);
+    }
+    if (mask) {
+        auto currentMorselIdx = currentNodeOffset >> DEFAULT_VECTOR_CAPACITY_LOG_2;
+        assert(currentNodeOffset % DEFAULT_VECTOR_CAPACITY == 0);
+        while (currentMorselIdx <= maxMorselIdx && !mask->morselMask[currentMorselIdx]) {
+            currentMorselIdx++;
+        }
+        currentNodeOffset = min(currentMorselIdx * DEFAULT_VECTOR_CAPACITY, maxNodeOffset);
     }
     auto startOffset = currentNodeOffset;
     auto range = min(DEFAULT_VECTOR_CAPACITY, maxNodeOffset + 1 - currentNodeOffset);
@@ -22,13 +43,13 @@ shared_ptr<ResultSet> ScanNodeID::init(ExecutionContext* context) {
     outValueVector = make_shared<ValueVector>(NODE_ID, context->memoryManager);
     outValueVector->setSequential();
     outDataChunk->insert(outDataPos.valueVectorPos, outValueVector);
-    sharedState->initMaxNodeOffset(transaction);
+    sharedState->initialize(transaction);
     return resultSet;
 }
 
 bool ScanNodeID::getNextTuples() {
     metrics->executionTime.start();
-    while (true) {
+    do {
         auto [startOffset, endOffset] = sharedState->getNextRangeToRead();
         if (startOffset >= endOffset) {
             metrics->executionTime.stop();
@@ -41,16 +62,35 @@ bool ScanNodeID::getNextTuples() {
             nodeIDValues[i].label = nodeTable->labelID;
         }
         outDataChunk->state->initOriginalAndSelectedSize(size);
+        setSelVector(startOffset, endOffset);
         outDataChunk->state->selVector->resetSelectorToUnselected();
         nodeTable->getNodesMetadata()->setDeletedNodeOffsetsForMorsel(
             transaction, outValueVector, nodeTable->getLabelID());
-        if (outDataChunk->state->selVector->selectedSize <= 0) {
-            continue;
+    } while (outDataChunk->state->selVector->selectedSize == 0);
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(outValueVector->state->selVector->selectedSize);
+    return true;
+}
+
+void ScanNodeID::setSelVector(node_offset_t startOffset, node_offset_t endOffset) {
+    if (sharedState->isSemiMaskEnabled()) {
+        outDataChunk->state->selVector->resetSelectorToValuePosBuffer();
+        // Fill selected positions based on node mask for nodes between the given startOffset and
+        // endOffset. If the node is masked (i.e., valid for read), then it is set to the selected
+        // positions. Finally, we update the selectedSize for selVector.
+        sel_t numSelectedValues = 0;
+        for (auto i = 0u; i < (endOffset - startOffset); i++) {
+            outDataChunk->state->selVector->selectedPositions[numSelectedValues] = i;
+            numSelectedValues += sharedState->isNodeMasked(i + startOffset);
         }
-        metrics->executionTime.stop();
-        metrics->numOutputTuple.increase(outValueVector->state->selVector->selectedSize);
-        return true;
+        outDataChunk->state->selVector->selectedSize = numSelectedValues;
+    } else {
+        // By default, the selected positions is set to the const incremental pos array.
+        outDataChunk->state->selVector->resetSelectorToUnselected();
     }
+    // Apply changes to the selVector from nodes metadata.
+    nodeTable->getNodesMetadata()->setDeletedNodeOffsetsForMorsel(
+        transaction, outValueVector, nodeTable->getLabelID());
 }
 
 } // namespace processor

--- a/src/processor/physical_plan/operator/semi_masker.cpp
+++ b/src/processor/physical_plan/operator/semi_masker.cpp
@@ -1,0 +1,36 @@
+#include "src/processor/include/physical_plan/operator/semi_masker.h"
+
+namespace graphflow {
+namespace processor {
+
+shared_ptr<ResultSet> SemiMasker::init(graphflow::processor::ExecutionContext* context) {
+    resultSet = PhysicalOperator::init(context);
+    keyValueVector = resultSet->getValueVector(keyDataPos);
+    assert(keyValueVector->dataType.typeID == NODE_ID);
+    return resultSet;
+}
+
+bool SemiMasker::getNextTuples() {
+    metrics->executionTime.start();
+    if (!children[0]->getNextTuples()) {
+        metrics->executionTime.stop();
+        return false;
+    }
+    auto values = (nodeID_t*)keyValueVector->values;
+    if (keyValueVector->state->isFlat()) {
+        auto pos = keyValueVector->state->getPositionOfCurrIdx();
+        scanNodeIDSharedState->setMask(values[pos].offset);
+    } else {
+        for (auto i = 0u; i < keyValueVector->state->selVector->selectedSize; i++) {
+            auto pos = keyValueVector->state->selVector->selectedPositions[i];
+            scanNodeIDSharedState->setMask(values[pos].offset);
+        }
+    }
+    metrics->executionTime.stop();
+    metrics->numOutputTuple.increase(
+        keyValueVector->state->isFlat() ? 1 : keyValueVector->state->selVector->selectedSize);
+    return true;
+}
+
+} // namespace processor
+} // namespace graphflow

--- a/src/storage/storage_structure/lists/lists_update_iterator.cpp
+++ b/src/storage/storage_structure/lists/lists_update_iterator.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "src/storage/storage_structure/include/lists/lists_update_iterator.h"
 
 #include "src/storage/storage_structure/include/storage_structure_utils.h"


### PR DESCRIPTION
This PR sets up the backend for binary and multi-way SJoins.
We introduce a new operator `SemiMasker` to set SemiMask in another pipeline's ScanNodeID's shared state, so the (filtering) information can be passed from the current pipeline to another one.

This is not a complete PR ready to use due to the lack of support from front-end.
So I want to document a bit here on how SemiMask is used in different cases, given a query `MATCH (a:person)-[e1:knows]->(b:person) WHERE a.ID=10 RETURN COUNT(*)`, two possible plans enumerated with sjoins are (ignore the filtering operator):
1. Binary SJoin 
```
                HashJoinProbe(b)
Scan(b.id)             HashJoinBuild
                       SemiMasker(b.id) 
                       Extend(e1)
                       Scan(a.id)
```
2. Multi-way SJoin
```
                        HashJoinProbe(b)
FTableScan        HashJoinBuild          ResultCollector 
                  Scan(b.id)             SemiMasker(b.id)
                                         Extend(e1)
                                         Scan(a.id)
```

**Notice**:
This PR doesn't support passing multiple semi masks to the same node scanning operator for now. To do that, each SemiMasker should hold a full mask for the target node itself, and setting it (in parallel), finally masking it with the one in the target node's shared state. Currently, I assume the front end will not enumerate such plans to pass multiple masks to the same node scanning.