### PR TITLE
Add unflat optimization for hash join probe

### DIFF
--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -79,7 +79,7 @@ private:
 
     void appendExtend(const RelExpression& queryRel, RelDirection direction, LogicalPlan& plan);
     void appendHashJoin(
-        shared_ptr<NodeExpression> joinNode, LogicalPlan& probePlan, LogicalPlan& buildPlan);
+        const shared_ptr<NodeExpression>& joinNode, LogicalPlan& probePlan, LogicalPlan& buildPlan);
     // AppendIntersect return false if a nodeID is flat in which case we should use filter.
     bool appendIntersect(const string& leftNodeID, const string& rightNodeID, LogicalPlan& plan);
 

--- a/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
@@ -15,11 +15,13 @@ public:
     // Probe side on left, i.e. children[0]. Build side on right, i.e. children[1].
     LogicalHashJoin(shared_ptr<NodeExpression> joinNode, unique_ptr<Schema> buildSideSchema,
         vector<uint64_t> flatOutputGroupPositions, expression_vector expressionsToMaterialize,
-        shared_ptr<LogicalOperator> probeSideChild, shared_ptr<LogicalOperator> buildSideChild)
+        bool isOutputAFlatTuple, shared_ptr<LogicalOperator> probeSideChild,
+        shared_ptr<LogicalOperator> buildSideChild)
         : LogicalOperator{move(probeSideChild), move(buildSideChild)}, joinNode(move(joinNode)),
           buildSideSchema(move(buildSideSchema)), flatOutputGroupPositions{move(
                                                       flatOutputGroupPositions)},
-          expressionsToMaterialize{move(expressionsToMaterialize)} {}
+          expressionsToMaterialize{move(expressionsToMaterialize)}, isOutputAFlatTuple{
+                                                                        isOutputAFlatTuple} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_HASH_JOIN;
@@ -34,11 +36,12 @@ public:
     inline shared_ptr<NodeExpression> getJoinNode() const { return joinNode; }
     inline Schema* getBuildSideSchema() const { return buildSideSchema.get(); }
     inline vector<uint64_t> getFlatOutputGroupPositions() const { return flatOutputGroupPositions; }
+    inline bool getIsOutputAFlatTuple() const { return isOutputAFlatTuple; }
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalHashJoin>(joinNode, buildSideSchema->copy(),
-            flatOutputGroupPositions, expressionsToMaterialize, children[0]->copy(),
-            children[1]->copy());
+            flatOutputGroupPositions, expressionsToMaterialize, isOutputAFlatTuple,
+            children[0]->copy(), children[1]->copy());
     }
 
 private:
@@ -47,6 +50,7 @@ private:
     // TODO(Xiyang): solve this with issue 606
     vector<uint64_t> flatOutputGroupPositions;
     expression_vector expressionsToMaterialize;
+    bool isOutputAFlatTuple;
 };
 } // namespace planner
 } // namespace graphflow

--- a/src/processor/include/physical_plan/hash_table/join_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/join_hash_table.h
@@ -30,6 +30,7 @@ public:
     inline uint8_t** getPrevTuple(const uint8_t* tuple) const {
         return (uint8_t**)(tuple + colOffsetOfPrevPtrInTuple);
     }
+    inline bool hasUnflatColumns() { return factorizedTable->hasUnflatCol(); }
 
 private:
     uint8_t** findHashSlot(const nodeID_t& value) const;

--- a/src/processor/physical_plan/mapper/map_hash_join.cpp
+++ b/src/processor/physical_plan/mapper/map_hash_join.cpp
@@ -44,13 +44,13 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
     // create hashJoin build
     auto buildDataInfo =
         BuildDataInfo(buildSideKeyIDDataPos, buildSideNonKeyDataPoses, isBuildSideNonKeyDataFlat);
-    auto hashJoinBuild = make_unique<HashJoinBuild>(
-        sharedState, buildDataInfo, move(buildSidePrevOperator), getOperatorID(), paramsString);
+    auto hashJoinBuild = make_unique<HashJoinBuild>(sharedState, buildDataInfo,
+        std::move(buildSidePrevOperator), getOperatorID(), paramsString);
     // create hashJoin probe
     auto probeDataInfo = ProbeDataInfo(probeSideKeyIDDataPos, probeSideNonKeyDataPoses);
     auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState,
-        hashJoin->getFlatOutputGroupPositions(), probeDataInfo, move(probeSidePrevOperator),
-        move(hashJoinBuild), getOperatorID(), paramsString);
+        hashJoin->getFlatOutputGroupPositions(), probeDataInfo, hashJoin->getIsOutputAFlatTuple(),
+        std::move(probeSidePrevOperator), std::move(hashJoinBuild), getOperatorID(), paramsString);
     return hashJoinProbe;
 }
 

--- a/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_build.cpp
@@ -48,7 +48,7 @@ shared_ptr<ResultSet> HashJoinBuild::init(ExecutionContext* context) {
         Types::getDataTypeSize(INT64)));
     hashTable = make_unique<JoinHashTable>(
         *context->memoryManager, 0 /* empty table */, make_unique<TableSchema>(*tableSchema));
-    sharedState->initEmptyHashTableIfNecessary(*context->memoryManager, move(tableSchema));
+    sharedState->initEmptyHashTableIfNecessary(*context->memoryManager, std::move(tableSchema));
     return resultSet;
 }
 

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -74,9 +74,10 @@ bool HashJoinProbe::getNextBatchOfMatchedTuples() {
 }
 
 uint64_t HashJoinProbe::populateResultSet() {
-    // Copy the matched value from the build side key data chunk into the resultKeyDataChunk.
-    auto numTuplesToRead =
-        probeSideKeyVector->state->isFlat() ? 1 : probeState->matchedSelVector->selectedSize;
+    // Note: When the probe side is flat, and the build side: a) has no unflat columns; b) has no
+    // payloads in the key data chunk; c) has payloads required to read from hash table, we apply an
+    // optimization to unflat the probe side payloads in the resultSet.
+    auto numTuplesToRead = isOutputAFlatTuple ? 1 : probeState->matchedSelVector->selectedSize;
     if (!probeSideKeyVector->state->isFlat() &&
         probeSideKeyVector->state->selVector->selectedSize != numTuplesToRead) {
         // Update probeSideKeyVector's selectedPositions when the probe side is unflat and its

--- a/test/test_files/tinySNB/filter/multi_query_part.test
+++ b/test/test_files/tinySNB/filter/multi_query_part.test
@@ -1,19 +1,23 @@
 -NAME MultiQueryOneHopKnowsFilteredTest1
 -QUERY MATCH (a:person) WHERE a.gender = 1 WITH a AS k MATCH (k)-[e:knows]->(b:person) WHERE b.gender = 2 RETURN COUNT(*)
+-ENUMERATE
 ---- 1
 6
 
 -NAME MultiQueryOneHopKnowsFilteredTest2
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE (a.gender/2 <= 0.5) WITH b WHERE b.gender*3.5 = 7.0 RETURN COUNT(*)
+-ENUMERATE
 ---- 1
 6
 
 -NAME MultiQueryTwoHopKnowsFilteredTest1
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a, b WHERE b.age=35 MATCH (b)-[e2:knows]->(c:person) WHERE a.age = c.age RETURN COUNT(*)
+-ENUMERATE
 ---- 1
 3
 
 -NAME MultiQueryTwoHopKnowsFilteredTest2
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH a.age AS foo, b MATCH (b)-[e2:knows]->(c:person) WHERE foo = c.age RETURN COUNT(*)
+-ENUMERATE
 ---- 1
 12

--- a/test/test_files/tinySNB/match/multi_query_part.test
+++ b/test/test_files/tinySNB/match/multi_query_part.test
@@ -1,5 +1,6 @@
 -NAME MultiQueryOneHopKnowsTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH b.age AS m RETURN m
+-ENUMERATE
 ---- 14
 20
 20
@@ -18,20 +19,24 @@
 
 -NAME MultiQueryTwoHopKnowsTest
 -QUERY MATCH (a:person)-[:knows]->(b:person) WITH b AS m WITH m AS n MATCH (n)-[e2:knows]->(c:person) RETURN COUNT(*)
+-ENUMERATE
 ---- 1
 36
 
 -NAME MultiQueryThreeHopTwoKnowsOneWorkAtTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WITH * MATCH (b)-[e2:knows]->(c:person)-[e3:workAt]->(d:organisation) RETURN COUNT(*)
+-ENUMERATE
 ---- 1
 18
 
 -NAME OpenWedgeKnowsTest3
 -QUERY MATCH (b:person)<-[e1:knows]-(a:person) WITH a AS k MATCH (k)-[e2:knows]->(c:person),(k)-[e3:knows]->(d:person) RETURN COUNT(*)
+-ENUMERATE
 ---- 1
 116
 
 -NAME MultiQueryFourHopKnowsTest
+-ENUMERATE
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person) WITH c MATCH (c)-[e3:knows]->(d:person)-[e4:knows]->(e:person) RETURN COUNT(*)
 ---- 1
 324

--- a/test/test_files/tinySNB/projection/multi_query_part.test
+++ b/test/test_files/tinySNB/projection/multi_query_part.test
@@ -14,6 +14,7 @@
 -NAME KnowsOneHopWithTest1
 -COMPARE_RESULT 1
 -QUERY MATCH (a:person) WHERE a.age>20 WITH a MATCH (a)-[e:knows]->(b:person) RETURN b.fName
+-ENUMERATE
 ---- 9
 Alice
 Alice


### PR DESCRIPTION
For hash join probe, there are cases where we can form factorized structure based on the probing of matched tuples. The idea is that when the probe side is flat, and potentially it matches to multiple tuples in the build side, in some cases (explain next) we can unflat the output data chunk of build side payloads. Thus, we can re-form a new factorized structure.

In details, cases are that when the build side satisfies:
a) has no unflat columns to read (i.e., unflat output payload data chunks);
b) build side key group doesn't contain any payloads.

Additionally, if the probe is flat and it doesn't read anything from the hash table, we must force the probe operator to read one tuple at a time, because it might still matches to multiple tuples though not actually reading any of them from the hash table, if we don't force reading one tuple at a time, we lose the multiplicity here.