### PR TITLE
refactor testing framework

### DIFF
--- a/dataset/copy-csv-empty-lists-test/copy_csv.cypher
+++ b/dataset/copy-csv-empty-lists-test/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/copy-csv-empty-lists-test/vPerson.csv"

--- a/dataset/copy-csv-empty-lists-test/schema.cypher
+++ b/dataset/copy-csv-empty-lists-test/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, PRIMARY KEY (ID));

--- a/dataset/copy-csv-fault-tests/duplicate-ids/copy_csv.cypher
+++ b/dataset/copy-csv-fault-tests/duplicate-ids/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/copy-csv-fault-tests/duplicate-ids/vPerson.csv"

--- a/dataset/copy-csv-fault-tests/duplicate-ids/schema.cypher
+++ b/dataset/copy-csv-fault-tests/duplicate-ids/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, fName STRING, PRIMARY KEY (ID));

--- a/dataset/copy-csv-fault-tests/long-string/copy_csv.cypher
+++ b/dataset/copy-csv-fault-tests/long-string/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/copy-csv-fault-tests/long-string/vPerson.csv"

--- a/dataset/copy-csv-fault-tests/long-string/schema.cypher
+++ b/dataset/copy-csv-fault-tests/long-string/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, fName STRING, gender INT64, PRIMARY KEY (ID));

--- a/dataset/copy-csv-node-property-test/copy_csv.cypher
+++ b/dataset/copy-csv-node-property-test/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/copy-csv-node-property-test/vPerson.csv"

--- a/dataset/copy-csv-node-property-test/schema.cypher
+++ b/dataset/copy-csv-node-property-test/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, randomString STRING, PRIMARY KEY (ID));

--- a/dataset/copy-csv-special-char-test/copy_csv.cypher
+++ b/dataset/copy-csv-special-char-test/copy_csv.cypher
@@ -1,0 +1,3 @@
+COPY person FROM "dataset/copy-csv-special-char-test/vPerson.csv" (ESCAPE = "#", QUOTE = "-", DELIM="|");
+COPY organisation FROM "dataset/copy-csv-special-char-test/vOrganisation.csv" (ESCAPE = "#", QUOTE = "=", DELIM=",");  
+COPY workAt FROM "dataset/copy-csv-special-char-test/eWorkAt.csv" (ESCAPE = "#", QUOTE = "=", DELIM="|");

--- a/dataset/copy-csv-special-char-test/schema.cypher
+++ b/dataset/copy-csv-special-char-test/schema.cypher
@@ -1,0 +1,3 @@
+create node table person (ID INT64, randomString STRING, date DATE, PRIMARY KEY (ID));
+create node table organisation (ID INT64, name STRING, orgCode INT64, mark DOUBLE,score INT64, history STRING, licenseValidInterval INTERVAL, PRIMARY KEY (ID));
+create rel workAt (FROM person TO organisation, length STRING, MANY_ONE);

--- a/dataset/empty-db/copy_csv.cypher
+++ b/dataset/empty-db/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/empty-db/vPerson.csv"

--- a/dataset/empty-db/schema.cypher
+++ b/dataset/empty-db/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, PRIMARY KEY (ID));

--- a/dataset/node-insertion-deletion-tests/copy_csv.cypher
+++ b/dataset/node-insertion-deletion-tests/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/node-insertion-deletion-tests/vPerson.csv"

--- a/dataset/node-insertion-deletion-tests/schema.cypher
+++ b/dataset/node-insertion-deletion-tests/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, PRIMARY KEY (ID));

--- a/dataset/non-empty-disk-array-db/copy_csv.cypher
+++ b/dataset/non-empty-disk-array-db/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/non-empty-disk-array-db/vPerson.csv"

--- a/dataset/non-empty-disk-array-db/schema.cypher
+++ b/dataset/non-empty-disk-array-db/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, PRIMARY KEY (ID));

--- a/dataset/order-by-tests/copy_csv.cypher
+++ b/dataset/order-by-tests/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/order-by-tests/vPerson.csv"

--- a/dataset/order-by-tests/schema.cypher
+++ b/dataset/order-by-tests/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, studentID INT64, balance INT64, PRIMARY KEY (ID));

--- a/dataset/read-list-tests/2-bytes-per-edge/copy_csv.cypher
+++ b/dataset/read-list-tests/2-bytes-per-edge/copy_csv.cypher
@@ -1,0 +1,2 @@
+COPY person FROM "dataset/read-list-tests/2-bytes-per-edge/vPerson.csv";
+COPY knows FROM "dataset/read-list-tests/2-bytes-per-edge/eKnows.csv";

--- a/dataset/read-list-tests/2-bytes-per-edge/schema.cypher
+++ b/dataset/read-list-tests/2-bytes-per-edge/schema.cypher
@@ -1,0 +1,2 @@
+create node table person (ID INT64, PRIMARY KEY (ID));
+create rel knows (FROM person TO person, int64Prop INT64, MANY_MANY);

--- a/dataset/read-list-tests/3-bytes-per-edge/copy_csv.cypher
+++ b/dataset/read-list-tests/3-bytes-per-edge/copy_csv.cypher
@@ -1,0 +1,3 @@
+COPY animal FROM "dataset/read-list-tests/3-bytes-per-edge/vAnimal.csv"
+COPY person FROM "dataset/read-list-tests/3-bytes-per-edge/vPerson.csv"
+COPY knows FROM "dataset/read-list-tests/3-bytes-per-edge/eKnows.csv"

--- a/dataset/read-list-tests/3-bytes-per-edge/schema.cypher
+++ b/dataset/read-list-tests/3-bytes-per-edge/schema.cypher
@@ -1,0 +1,3 @@
+create node table animal (ID INT64, PRIMARY KEY (ID));
+create node table person (ID INT64, PRIMARY KEY (ID));
+create rel knows (FROM animal|person TO animal|person, MANY_MANY);

--- a/dataset/read-list-tests/4-bytes-per-edge/copy_csv.cypher
+++ b/dataset/read-list-tests/4-bytes-per-edge/copy_csv.cypher
@@ -1,0 +1,2 @@
+COPY person FROM "dataset/read-list-tests/4-bytes-per-edge/vPerson.csv";
+COPY knows FROM "dataset/read-list-tests/4-bytes-per-edge/eKnows.csv";

--- a/dataset/read-list-tests/4-bytes-per-edge/schema.cypher
+++ b/dataset/read-list-tests/4-bytes-per-edge/schema.cypher
@@ -1,0 +1,2 @@
+create node table person (ID INT64, PRIMARY KEY (ID));
+create rel knows (FROM person TO person, MANY_MANY);

--- a/dataset/read-list-tests/5-bytes-per-edge/copy_csv.cypher
+++ b/dataset/read-list-tests/5-bytes-per-edge/copy_csv.cypher
@@ -1,0 +1,3 @@
+COPY person FROM "dataset/read-list-tests/5-bytes-per-edge/vPerson.csv"
+COPY animal FROM "dataset/read-list-tests/5-bytes-per-edge/vAnimal.csv"
+COPY knows FROM "dataset/read-list-tests/5-bytes-per-edge/eKnows.csv"

--- a/dataset/read-list-tests/5-bytes-per-edge/schema.cypher
+++ b/dataset/read-list-tests/5-bytes-per-edge/schema.cypher
@@ -1,0 +1,3 @@
+create node table person (ID INT64, PRIMARY KEY (ID));
+create node table animal (ID INT64, PRIMARY KEY (ID));
+create rel knows (FROM animal | person TO person | animal, MANY_MANY);

--- a/dataset/read-list-tests/large-list-sub-query-tests/copy_csv.cypher
+++ b/dataset/read-list-tests/large-list-sub-query-tests/copy_csv.cypher
@@ -1,0 +1,2 @@
+COPY person FROM "dataset/read-list-tests/large-list-sub-query-tests/vPerson.csv"
+COPY knows FROM "dataset/read-list-tests/large-list-sub-query-tests/eKnows.csv"

--- a/dataset/read-list-tests/large-list-sub-query-tests/schema.cypher
+++ b/dataset/read-list-tests/large-list-sub-query-tests/schema.cypher
@@ -1,0 +1,2 @@
+create node table person (ID INT64, PRIMARY KEY (ID));
+create rel knows (FROM person TO person, MANY_MANY);

--- a/dataset/tinysnb/copy_csv.cypher
+++ b/dataset/tinysnb/copy_csv.cypher
@@ -1,0 +1,6 @@
+COPY person FROM "dataset/tinysnb/vPerson.csv";
+COPY organisation FROM "dataset/tinysnb/vOrganisation.csv";
+COPY knows FROM "dataset/tinysnb/eKnows.csv";
+COPY studyAt FROM "dataset/tinysnb/eStudyAt.csv"
+COPY workAt FROM "dataset/tinysnb/eWorkAt.csv"
+COPY meets FROM "dataset/tinysnb/eMeets.csv"

--- a/dataset/tinysnb/schema.cypher
+++ b/dataset/tinysnb/schema.cypher
@@ -1,0 +1,6 @@
+create node table person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], PRIMARY KEY (ID));
+create node table organisation (ID INT64, name STRING, orgCode INT64, mark DOUBLE, score INT64, history STRING, licenseValidInterval INTERVAL, rating DOUBLE, PRIMARY KEY (ID));
+create rel knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], MANY_MANY);
+create rel studyAt (FROM person TO organisation, year INT64, places STRING[], MANY_ONE);
+create rel workAt (FROM person TO organisation, year INT64, MANY_ONE);
+create rel meets (FROM person TO person, MANY_ONE);

--- a/dataset/unstructured-property-lists-updates-tests/copy_csv.cypher
+++ b/dataset/unstructured-property-lists-updates-tests/copy_csv.cypher
@@ -1,0 +1,1 @@
+COPY person FROM "dataset/unstructured-property-lists-updates-tests/vPerson.csv"

--- a/dataset/unstructured-property-lists-updates-tests/schema.cypher
+++ b/dataset/unstructured-property-lists-updates-tests/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (ID INT64, PRIMARY KEY (ID));

--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -44,7 +44,7 @@ const std::string INTERNAL_ID_SUFFIX = "_id";
 
 struct StorageConfig {
     // The default amount of memory pre-allocated to both the default and large pages buffer pool.
-    static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 23; // (8MB)
+    static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 24; // (16MB)
     // The default ratio of buffer allocated to large pages.
     static constexpr double DEFAULT_PAGES_BUFFER_RATIO = 0.5;
     static constexpr double LARGE_PAGES_BUFFER_RATIO = 1.0 - DEFAULT_PAGES_BUFFER_RATIO;

--- a/test/copy_csv/copy_csv_dates_test.cpp
+++ b/test/copy_csv/copy_csv_dates_test.cpp
@@ -5,7 +5,9 @@ using namespace graphflow::common;
 using namespace graphflow::storage;
 using namespace graphflow::testing;
 
-class TinySnbCopyCSVDateTest : public InMemoryDBTest {};
+class TinySnbCopyCSVDateTest : public InMemoryDBTest {
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+};
 
 // Warning: This test assumes that each line in tinysnb's vPerson.csv gets
 // the node offsets that start from 0 consecutively (so first line gets person ID 0, second person

--- a/test/copy_csv/copy_csv_index_test.cpp
+++ b/test/copy_csv/copy_csv_index_test.cpp
@@ -5,7 +5,9 @@ using namespace graphflow::common;
 using namespace graphflow::storage;
 using namespace graphflow::testing;
 
-class TinySnbIndexTest : public InMemoryDBTest {};
+class TinySnbIndexTest : public InMemoryDBTest {
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+};
 
 TEST_F(TinySnbIndexTest, PersonNodeIDIndex) {
     auto storageManager = database->getStorageManager();

--- a/test/copy_csv/copy_csv_interval_test.cpp
+++ b/test/copy_csv/copy_csv_interval_test.cpp
@@ -7,7 +7,9 @@ using namespace graphflow::common;
 using namespace graphflow::storage;
 using namespace graphflow::testing;
 
-class TinySnbCopyCSVIntervalTest : public InMemoryDBTest {};
+class TinySnbCopyCSVIntervalTest : public InMemoryDBTest {
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+};
 
 // Warning: This test assumes that each line in tinysnb's vPerson.csv gets
 // the node offsets that start from 0 consecutively (so first line gets person ID 0, second person

--- a/test/copy_csv/copy_csv_lists_test.cpp
+++ b/test/copy_csv/copy_csv_lists_test.cpp
@@ -24,6 +24,7 @@ public:
         }
         return true;
     }
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
 };
 
 // Warning: This test assumes that each line in tinysnb's vPerson.csv gets

--- a/test/copy_csv/copy_csv_test.cpp
+++ b/test/copy_csv/copy_csv_test.cpp
@@ -14,86 +14,37 @@ namespace testing {
 
 class CopyNodeCSVPropertyTest : public InMemoryDBTest {
 public:
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, randomString STRING, PRIMARY "
-                                          "KEY (ID))");
-        conn->query("COPY person FROM \"dataset/copy-csv-node-property-test/vPerson.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/copy-csv-node-property-test/"; }
 };
 
 class CopyCSVSpecialCharTest : public InMemoryDBTest {
 public:
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix +
-                    "person (ID INT64, randomString STRING, date DATE, PRIMARY "
-                    "KEY (ID))");
-        conn->query("COPY person FROM \"dataset/copy-csv-special-char-test/vPerson.csv\" (ESCAPE = "
-                    "\"#\", QUOTE = \"-\", DELIM=\"|\")");
-        conn->query(createNodeCmdPrefix +
-                    "organisation (ID INT64, name STRING, orgCode INT64, mark DOUBLE,score INT64, "
-                    "history STRING, licenseValidInterval INTERVAL, PRIMARY KEY (ID))");
-        conn->query(
-            "COPY organisation FROM \"dataset/copy-csv-special-char-test/vOrganisation.csv\" "
-            "(ESCAPE = \"#\", QUOTE = \"=\", DELIM=\",\")");
-        conn->query(createRelCmdPrefix + "workAt (FROM person TO organisation, length STRING, "
-                                         "MANY_ONE)");
-        conn->query("COPY workAt FROM \"dataset/copy-csv-special-char-test/eWorkAt.csv\" (ESCAPE "
-                    "= \"#\", QUOTE = \"=\", DELIM=\"|\")");
-    }
+    string getInputCSVDir() override { return "dataset/copy-csv-special-char-test/"; }
 };
 
 class CopyCSVReadLists2BytesPerEdgeTest : public InMemoryDBTest {
 public:
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/read-list-tests/2-bytes-per-edge/vPerson.csv\"");
-        conn->query(
-            createRelCmdPrefix + "knows (FROM person TO person, int64Prop INT64, MANY_MANY)");
-        conn->query("COPY knows FROM \"dataset/read-list-tests/2-bytes-per-edge/eKnows.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/read-list-tests/2-bytes-per-edge/"; }
 };
 
 class CopyCSVReadLists3BytesPerEdgeTest : public InMemoryDBTest {
 public:
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "animal (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY animal FROM \"dataset/read-list-tests/3-bytes-per-edge/vAnimal.csv\"");
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/read-list-tests/3-bytes-per-edge/vPerson.csv\"");
-        conn->query(createRelCmdPrefix + "knows (FROM animal|person TO animal|person, MANY_MANY)");
-        conn->query("COPY knows FROM \"dataset/read-list-tests/3-bytes-per-edge/eKnows.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/read-list-tests/3-bytes-per-edge/"; }
 };
 
 class CopyCSVReadLists4BytesPerEdgeTest : public InMemoryDBTest {
 public:
-    void initGraph() {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/read-list-tests/4-bytes-per-edge/vPerson.csv\"");
-        conn->query(createRelCmdPrefix + "knows (FROM person TO person, MANY_MANY)");
-        conn->query("COPY knows FROM \"dataset/read-list-tests/4-bytes-per-edge/eKnows.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/read-list-tests/4-bytes-per-edge/"; }
 };
 
 class CopyCSVReadLists5BytesPerEdgeTest : public InMemoryDBTest {
 public:
-    void initGraph() {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/read-list-tests/5-bytes-per-edge/vPerson.csv\"");
-        conn->query(createNodeCmdPrefix + "animal (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY animal FROM \"dataset/read-list-tests/5-bytes-per-edge/vAnimal.csv\"");
-        conn->query(
-            createRelCmdPrefix + "knows (FROM animal | person TO person | animal, MANY_MANY)");
-        conn->query("COPY knows FROM \"dataset/read-list-tests/5-bytes-per-edge/eKnows.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/read-list-tests/5-bytes-per-edge/"; }
 };
 
 class CopyCSVEmptyListsTest : public InMemoryDBTest {
 public:
-    void initGraph() {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/copy-csv-empty-lists-test/vPerson.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/copy-csv-empty-lists-test/"; }
     // The test is here because accessing protected/private members of Lists and ListsMetadata
     // requires the code to be inside CopyCSVEmptyListsTest class, which is a friend class to
     // Lists and ListsMetadata.

--- a/test/copy_csv/copy_csv_timestamp_test.cpp
+++ b/test/copy_csv/copy_csv_timestamp_test.cpp
@@ -5,7 +5,9 @@ using namespace graphflow::common;
 using namespace graphflow::storage;
 using namespace graphflow::testing;
 
-class TinySnbTimestampTest : public InMemoryDBTest {};
+class TinySnbTimestampTest : public InMemoryDBTest {
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+};
 
 // Warning: This test assumes that each line in tinysnb's vPerson.csv gets
 // the node offsets that start from 0 consecutively (so first line gets person ID 0, second person

--- a/test/main/include/main_test_helper.h
+++ b/test/main/include/main_test_helper.h
@@ -4,15 +4,18 @@
 
 using namespace graphflow::testing;
 
-class ApiTest : public BaseGraphTest {
+class ApiTest : public EmptyDBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
+        EmptyDBTest::SetUp();
         systemConfig->defaultPageBufferPoolSize = (1ull << 26);
         systemConfig->largePageBufferPoolSize = (1ull << 26);
         createDBAndConn();
+        initGraph();
     }
+
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
 
     static void assertMatchPersonCountStar(Connection* conn) {
         auto result = conn->query("MATCH (a:person) RETURN COUNT(*)");

--- a/test/runner/e2e_copy_csv_transaction_test.cpp
+++ b/test/runner/e2e_copy_csv_transaction_test.cpp
@@ -7,16 +7,14 @@ using namespace graphflow::testing;
 namespace graphflow {
 namespace transaction {
 
-class TinySnbCopyCSVTransactionTest : public BaseGraphTest {
+class TinySnbCopyCSVTransactionTest : public EmptyDBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
+        EmptyDBTest::SetUp();
         createDBAndConn();
         catalog = conn->database->getCatalog();
     }
-
-    void initGraph() override {}
 
     void initWithoutLoadingGraph() {
         createDBAndConn();
@@ -221,8 +219,7 @@ public:
     void copyRelCSVCommitAndRecoveryTest(TransactionTestType transactionTestType) {
         conn->query(createPersonTableCmd);
         conn->query(copyPersonTableCmd);
-        conn->query(createRelCmdPrefix +
-                    "knows (FROM person TO person, date DATE, meetTime TIMESTAMP, "
+        conn->query("create rel knows (FROM person TO person, date DATE, meetTime TIMESTAMP, "
                     "validInterval INTERVAL, comments STRING[], MANY_MANY)");
         auto preparedStatement =
             conn->prepareNoLock("COPY knows FROM \"dataset/tinysnb/eKnows.csv\"");
@@ -248,8 +245,8 @@ public:
 
     Catalog* catalog;
     string createPersonTableCmd =
-        createNodeCmdPrefix +
-        "person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, "
+        "create node table person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, "
+        "isWorker BOOLEAN, "
         "age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration "
         "INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], "
         "PRIMARY KEY (ID))";

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -5,19 +5,20 @@ using namespace graphflow::testing;
 namespace graphflow {
 namespace transaction {
 
-class TinySnbDDLTest : public BaseGraphTest {
+class TinySnbDDLTest : public DBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
-        createDBAndConn();
+        DBTest::SetUp();
         catalog = conn->database->getCatalog();
     }
 
     void initWithoutLoadingGraph() {
-        createDBAndConn(TransactionTestType::RECOVERY);
+        createDBAndConn();
         catalog = conn->database->getCatalog();
     }
+
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
 
     // Since DDL statements are in an auto-commit transaction, we can't use the query interface to
     // test the recovery algorithm and parallel read.

--- a/test/runner/e2e_delete_create_transaction_test.cpp
+++ b/test/runner/e2e_delete_create_transaction_test.cpp
@@ -2,19 +2,15 @@
 
 using namespace graphflow::testing;
 
-class DeleteCreateTransactionTest : public BaseGraphTest {
+class DeleteCreateTransactionTest : public DBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
-        createDBAndConn();
+        DBTest::SetUp();
         readConn = make_unique<Connection>(database.get());
     }
 
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/node-insertion-deletion-tests/vPerson.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/node-insertion-deletion-tests/"; }
 
     void checkNodeExists(Connection* connection, uint64_t nodeID) {
         auto result =
@@ -154,7 +150,7 @@ TEST_F(DeleteCreateTransactionTest, SimpleAddCommitRecoveryTest) {
     add100Nodes(conn.get());
     conn->commitButSkipCheckpointingForTestingRecovery();
     // This should run the recovery algorithm
-    createDBAndConn(TransactionTestType::RECOVERY);
+    createDBAndConn();
     string query = "MATCH (a:person) RETURN count(*)";
     ASSERT_EQ(getCountStarVal(conn.get(), query), 10100);
 }

--- a/test/runner/e2e_order_by_test.cpp
+++ b/test/runner/e2e_order_by_test.cpp
@@ -2,20 +2,10 @@
 
 using namespace graphflow::testing;
 
-class OrderByTests : public BaseGraphTest {
+class OrderByTests : public DBTest {
 
 public:
-    void SetUp() override {
-        BaseGraphTest::SetUp();
-        systemConfig->largePageBufferPoolSize = (1ull << 23);
-        createDBAndConn();
-    }
-
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix +
-                    "person (ID INT64, studentID INT64, balance INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/order-by-tests/vPerson.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/order-by-tests/"; }
 };
 
 TEST_F(OrderByTests, OrderByLargeDatasetTest) {

--- a/test/runner/e2e_read_list_test.cpp
+++ b/test/runner/e2e_read_list_test.cpp
@@ -8,34 +8,18 @@ using namespace graphflow::testing;
 
 class EndToEndReadLists2BytesPerEdgeTest : public DBTest {
 public:
-    void initGraph() {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/read-list-tests/2-bytes-per-edge/vPerson.csv\"");
-        conn->query(
-            createRelCmdPrefix + "knows (FROM person TO person, int64Prop INT64, MANY_MANY)");
-        conn->query("COPY knows FROM \"dataset/read-list-tests/2-bytes-per-edge/eKnows.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/read-list-tests/2-bytes-per-edge/"; }
 };
 
 class EndToEndReadLists4BytesPerEdgeTest : public DBTest {
 public:
-    void initGraph() {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/read-list-tests/4-bytes-per-edge/vPerson.csv\"");
-        conn->query(createRelCmdPrefix + "knows (FROM person TO person, MANY_MANY)");
-        conn->query("COPY knows FROM \"dataset/read-list-tests/4-bytes-per-edge/eKnows.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/read-list-tests/4-bytes-per-edge/"; }
 };
 
 class EndToEndReadListsSubQueryTest : public DBTest {
 public:
-    void initGraph() {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM "
-                    "\"dataset/read-list-tests/large-list-sub-query-tests/vPerson.csv\"");
-        conn->query(createRelCmdPrefix + "knows (FROM person TO person, MANY_MANY)");
-        conn->query(
-            "COPY knows FROM \"dataset/read-list-tests/large-list-sub-query-tests/eKnows.csv\"");
+    string getInputCSVDir() override {
+        return "dataset/read-list-tests/large-list-sub-query-tests/";
     }
 };
 

--- a/test/runner/e2e_read_test.cpp
+++ b/test/runner/e2e_read_test.cpp
@@ -3,18 +3,14 @@
 using ::testing::Test;
 using namespace graphflow::testing;
 
-class TinySnbReadTest : public BaseGraphTest {
+class TinySnbReadTest : public DBTest {
 public:
-    void SetUp() override {
-        BaseGraphTest::SetUp();
-        systemConfig->largePageBufferPoolSize = (1ull << 23);
-        createDBAndConn();
-    }
-
     inline void runTest(const string& queryFile) {
         auto queryConfigs = TestHelper::parseTestFile(queryFile);
         ASSERT_TRUE(TestHelper::testQueries(queryConfigs, *conn));
     }
+
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
 };
 
 TEST_F(TinySnbReadTest, MatchExecute) {

--- a/test/runner/e2e_set_transaction_test.cpp
+++ b/test/runner/e2e_set_transaction_test.cpp
@@ -3,14 +3,15 @@
 using namespace graphflow::testing;
 
 // Test manual transaction. Auto transaction is tested in update test.
-class SetTransactionTest : public BaseGraphTest {
+class SetTransactionTest : public DBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
-        createDBAndConn();
+        DBTest::SetUp();
         readConn = make_unique<Connection>(database.get());
     }
+
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
 
     void checkResult(vector<string>& result, vector<string>& groundTruth) {
         ASSERT_EQ(result.size(), groundTruth.size());

--- a/test/runner/e2e_update_test.cpp
+++ b/test/runner/e2e_update_test.cpp
@@ -2,12 +2,9 @@
 
 using namespace graphflow::testing;
 
-class TinySnbUpdateTest : public BaseGraphTest {
+class TinySnbUpdateTest : public DBTest {
 public:
-    void SetUp() override {
-        BaseGraphTest::SetUp();
-        createDBAndConn();
-    }
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
 };
 
 TEST_F(TinySnbUpdateTest, SetNodeIntPropTest) {

--- a/test/storage/disk_array_update_test.cpp
+++ b/test/storage/disk_array_update_test.cpp
@@ -11,16 +11,16 @@ using namespace graphflow::testing;
 // update the disk array and then checkpoint manually, and check that we obtain the correct version.
 // The updates we perform on the list do not correspond to a real update that would happen on the
 // database.
-class BaseDiskArrayUpdateTests : public BaseGraphTest {
+class BaseDiskArrayUpdateTests : public DBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
-        initWithoutLoadingGraph(TransactionTestType::NORMAL_EXECUTION);
+        DBTest::SetUp();
+        initWithoutLoadingGraph();
     }
 
-    void initWithoutLoadingGraph(TransactionTestType transactionTestType) {
-        createDBAndConn(transactionTestType);
+    void initWithoutLoadingGraph() {
+        createDBAndConn();
         auto personNodeLabel =
             database->getCatalog()->getReadOnlyVersion()->getNodeLabelFromName("person");
         personNodeTable = database->getStorageManager()->getNodesStore().getNode(personNodeLabel);
@@ -32,7 +32,7 @@ public:
         commitOrRollbackConnection(isCommit, transactionTestType);
         if (transactionTestType == TransactionTestType::RECOVERY) {
             // This creates a new database/conn/readConn and should run the recovery algorithm
-            initWithoutLoadingGraph(transactionTestType);
+            initWithoutLoadingGraph();
         }
     }
 
@@ -164,19 +164,13 @@ public:
 class DiskArrayUpdateTests : public BaseDiskArrayUpdateTests {
 
 public:
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/non-empty-disk-array-db/vPerson.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/non-empty-disk-array-db/"; }
 };
 
 class DiskArrayUpdateEmptyDBTests : public BaseDiskArrayUpdateTests {
 
 public:
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/empty-db/vPerson.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/empty-db/"; }
 };
 
 TEST_F(DiskArrayUpdateTests, BasicUpdateTestCommitNormalExecution) {

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -7,21 +7,18 @@ using namespace graphflow::testing;
 
 // Note: ID and nodeOffset in this test are equal for each node, so we use nodeID and nodeOffset
 // interchangeably.
-class NodeInsertionDeletionTests : public BaseGraphTest {
+class NodeInsertionDeletionTests : public DBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
-        initDBAndConnection(TransactionTestType::NORMAL_EXECUTION);
+        DBTest::SetUp();
+        initDBAndConnection();
     }
 
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query("COPY person FROM \"dataset/node-insertion-deletion-tests/vPerson.csv\"");
-    }
+    string getInputCSVDir() override { return "dataset/node-insertion-deletion-tests/"; }
 
-    void initDBAndConnection(TransactionTestType transactionTestType) {
-        createDBAndConn(transactionTestType);
+    void initDBAndConnection() {
+        createDBAndConn();
         readConn = make_unique<Connection>(database.get());
         label_t personNodeLabel =
             database->getCatalog()->getReadOnlyVersion()->getNodeLabelFromName("person");
@@ -40,7 +37,7 @@ public:
         commitOrRollbackConnection(isCommit, transactionTestType);
         if (transactionTestType == TransactionTestType::RECOVERY) {
             // This creates a new database/conn/readConn and should run the recovery algorithm
-            initDBAndConnection(transactionTestType);
+            initDBAndConnection();
         }
     }
 

--- a/test/storage/unstructured_property_lists_updates_test.cpp
+++ b/test/storage/unstructured_property_lists_updates_test.cpp
@@ -7,19 +7,23 @@ using namespace graphflow::testing;
 
 // Note: ID and nodeOffsetForPropKeys in this test are equal for each node, so we use nodeID and
 // nodeOffsetForPropKeys interchangeably.
-class UnstructuredPropertyListsUpdateTests : public BaseGraphTest {
+class UnstructuredPropertyListsUpdateTests : public DBTest {
 
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
-        initWithoutLoadingGraph(TransactionTestType::NORMAL_EXECUTION);
+        DBTest::SetUp();
+        initWithoutLoadingGraph();
     }
 
-    void initWithoutLoadingGraph(TransactionTestType transactionTestType) {
+    string getInputCSVDir() override {
+        return "dataset/unstructured-property-lists-updates-tests/";
+    }
+
+    void initWithoutLoadingGraph() {
         if (overflowBuffer) {
             overflowBuffer.reset();
         }
-        createDBAndConn(transactionTestType);
+        createDBAndConn();
         overflowBuffer = make_unique<OverflowBuffer>(database->getMemoryManager());
         readConn = make_unique<Connection>(database.get());
         personNodeLabel =
@@ -46,18 +50,12 @@ public:
         conn->beginWriteTransaction();
     }
 
-    void initGraph() override {
-        conn->query(createNodeCmdPrefix + "person (ID INT64, PRIMARY KEY (ID))");
-        conn->query(
-            "COPY person FROM \"dataset/unstructured-property-lists-updates-tests/vPerson.csv\"");
-    }
-
     void commitOrRollbackConnectionAndInitDBIfNecessary(
         bool isCommit, TransactionTestType transactionTestType) {
         commitOrRollbackConnection(isCommit, transactionTestType);
         if (transactionTestType == TransactionTestType::RECOVERY) {
             // This creates a new database/conn/readConn and should run the recovery algorithm
-            initWithoutLoadingGraph(transactionTestType);
+            initWithoutLoadingGraph();
         }
     }
 

--- a/test/storage/wal_replayer_test.cpp
+++ b/test/storage/wal_replayer_test.cpp
@@ -5,7 +5,9 @@
 using namespace graphflow::storage;
 using namespace graphflow::testing;
 
-class WALReplayerTests : public DBTest {};
+class WALReplayerTests : public DBTest {
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+};
 
 TEST_F(WALReplayerTests, ReplayingUncommittedWALForChekpointErrors) {
     auto walIterator = database->getWAL()->getIterator();

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -4,18 +4,20 @@
 
 using namespace graphflow::testing;
 
-class TransactionTests : public BaseGraphTest {
+class TransactionTests : public DBTest {
 public:
     void SetUp() override {
-        BaseGraphTest::SetUp();
-        initWithoutLoadingGraph(TransactionTestType::NORMAL_EXECUTION);
+        DBTest::SetUp();
+        initWithoutLoadingGraph();
     }
 
-    void initWithoutLoadingGraph(TransactionTestType transactionTestType) {
+    string getInputCSVDir() override { return "dataset/tinysnb/"; }
+
+    void initWithoutLoadingGraph() {
         systemConfig->largePageBufferPoolSize = (1ull << 22);
         // Note we do not actually use the connection field in these tests. We only need the
         // database.
-        createDBAndConn(transactionTestType);
+        createDBAndConn();
         writeTrx = database->getTransactionManager()->beginWriteTransaction();
         readTrx = database->getTransactionManager()->beginReadOnlyTransaction();
 
@@ -157,7 +159,7 @@ public:
         // initWithoutLoadingGraph will construct a completely new databse, writeTrx, readTrx,
         // and personAgeColumn, and personEyeSightColumn classes. We could use completely
         // different variables here but we would need to duplicate this construction code.
-        initWithoutLoadingGraph(TransactionTestType::RECOVERY);
+        initWithoutLoadingGraph();
         if (committingTransaction) {
             assertUpdatedAgeAndEyeSightPropertiesForNodes0And1(writeTrx.get());
             assertUpdatedAgeAndEyeSightPropertiesForNodes0And1(readTrx.get());


### PR DESCRIPTION
This PR refactors the existing testing classes, issue: #748.

we now have three types of testing classes:

1. BaseGraphTest: used when the test doesn't need to init a graph based on any pre-defined datasets.
2. DBTest: used when the test needs to init a graph based on a pre-defined dataset and execute in disk mode.
3. InMemoryDBTest: used when the test needs to init a graph based on a  pre-defined dataset and execute in inMemory mode.


Also adds an api to the testHelper, which takes in a cypher script and execute all cypher statements in that script.
As a result, each dataset will come with two files:
1. schema.cypher: contains cypher statements to create node/rel tables for the dataset.
2. copy_csv.cypher. contains copy-csv statements to copy the csv files to table.
