### PR TITLE
Sink operator refactor

### DIFF
--- a/src/binder/expression/include/rel_expression.h
+++ b/src/binder/expression/include/rel_expression.h
@@ -27,6 +27,8 @@ public:
 
     inline uint64_t getUpperBound() const { return upperBound; }
 
+    inline bool isVariableLength() const { return !(lowerBound == 1 && upperBound == 1); }
+
 private:
     label_t label;
     shared_ptr<NodeExpression> srcNode;

--- a/src/binder/query/match_clause/include/query_graph.h
+++ b/src/binder/query/match_clause/include/query_graph.h
@@ -100,10 +100,12 @@ public:
     inline bool containsQueryRel(const string& queryRelName) const {
         return queryRelNameToPosMap.contains(queryRelName);
     }
-    inline RelExpression* getQueryRel(const string& queryRelName) const {
-        return queryRels.at(queryRelNameToPosMap.at(queryRelName)).get();
+    inline shared_ptr<RelExpression> getQueryRel(const string& queryRelName) const {
+        return queryRels.at(queryRelNameToPosMap.at(queryRelName));
     }
-    inline RelExpression* getQueryRel(uint32_t relPos) const { return queryRels[relPos].get(); }
+    inline shared_ptr<RelExpression> getQueryRel(uint32_t relPos) const {
+        return queryRels[relPos];
+    }
     inline uint32_t getQueryRelPos(const string& queryRelName) const {
         return queryRelNameToPosMap.at(queryRelName);
     }

--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -75,13 +75,11 @@ private:
     void planFiltersForHashJoin(expression_vector& predicates, LogicalPlan& plan);
 
     void appendResultScan(const expression_vector& expressionsToSelect, LogicalPlan& plan);
-    void appendScanNodeID(shared_ptr<NodeExpression> queryNode, LogicalPlan& plan);
+    void appendScanNodeID(shared_ptr<NodeExpression>& node, LogicalPlan& plan);
 
-    void appendExtend(const RelExpression& queryRel, RelDirection direction, LogicalPlan& plan);
+    void appendExtend(shared_ptr<RelExpression>& rel, RelDirection direction, LogicalPlan& plan);
     void appendHashJoin(
         const shared_ptr<NodeExpression>& joinNode, LogicalPlan& probePlan, LogicalPlan& buildPlan);
-    // AppendIntersect return false if a nodeID is flat in which case we should use filter.
-    bool appendIntersect(const string& leftNodeID, const string& rightNodeID, LogicalPlan& plan);
 
     expression_vector getPropertiesForVariable(Expression& expression, Expression& variable);
     uint64_t getExtensionRate(label_t boundNodeLabel, label_t relLabel, RelDirection relDirection);

--- a/src/planner/include/update_planner.h
+++ b/src/planner/include/update_planner.h
@@ -29,7 +29,7 @@ private:
     void planPropertyUpdateInfo(
         shared_ptr<Expression> property, shared_ptr<Expression> target, LogicalPlan& plan);
 
-    void appendSink(LogicalPlan& plan);
+    void appendAccumulate(LogicalPlan& plan);
     void appendTableScan(BoundCreateClause& createClause, LogicalPlan& plan);
     void appendCreate(BoundCreateClause& createClause, LogicalPlan& plan);
     void appendSet(BoundSetClause& setClause, LogicalPlan& plan);

--- a/src/planner/logical_plan/logical_operator/BUILD.bazel
+++ b/src/planner/logical_plan/logical_operator/BUILD.bazel
@@ -5,10 +5,12 @@ cc_library(
     srcs = [
         "base_logical_operator.cpp",
         "schema.cpp",
+        "sink_util.cpp",
     ],
     hdrs = [
         "include/base_logical_operator.h",
         "include/schema.h",
+        "include/sink_util.h",
     ],
     visibility = [
         "//src/planner:__subpackages__",

--- a/src/planner/logical_plan/logical_operator/base_logical_operator.cpp
+++ b/src/planner/logical_plan/logical_operator/base_logical_operator.cpp
@@ -13,6 +13,12 @@ LogicalOperator::LogicalOperator(
     children.push_back(move(right));
 }
 
+LogicalOperator::LogicalOperator(vector<shared_ptr<LogicalOperator>> children) {
+    for (auto& child : children) {
+        this->children.push_back(child);
+    }
+}
+
 bool LogicalOperator::descendantsContainType(
     const unordered_set<LogicalOperatorType>& types) const {
     if (types.contains(getLogicalOperatorType())) {

--- a/src/planner/logical_plan/logical_operator/include/base_logical_operator.h
+++ b/src/planner/logical_plan/logical_operator/include/base_logical_operator.h
@@ -1,9 +1,6 @@
 #pragma once
 
-#include <memory>
-#include <string>
-#include <unordered_set>
-#include <vector>
+#include "schema.h"
 
 using namespace std;
 
@@ -33,7 +30,7 @@ enum LogicalOperatorType : uint8_t {
     LOGICAL_CREATE,
     LOGICAL_SET,
     LOGICAL_DELETE,
-    LOGICAL_SINK,
+    LOGICAL_ACCUMULATE,
     LOGICAL_STATIC_TABLE_SCAN,
     LOGICAL_CREATE_NODE_TABLE,
     LOGICAL_CREATE_REL_TABLE,
@@ -46,11 +43,10 @@ const string LogicalOperatorTypeNames[] = {"LOGICAL_SCAN_NODE_ID", "LOGICAL_SELE
     "LOGICAL_HASH_JOIN", "LOGICAL_MULTIPLICITY_REDUCER", "LOGICAL_LIMIT", "LOGICAL_SKIP",
     "LOGICAL_AGGREGATE", "LOGICAL_ORDER_BY", "LOGICAL_EXISTS", "LOGICAL_LEFT_NESTED_LOOP_JOIN",
     "LOGICAL_UNION_ALL", "LOGICAL_DISTINCT", "LOGICAL_CREATE", "LOGICAL_SET", "LOGICAL_DELETE",
-    "LOGICAL_SINK", "LOGICAL_STATIC_TABLE_SCAN", "LOGICAL_CREATE_NODE_TABLE",
+    "LOGICAL_ACCUMULATE", "LOGICAL_STATIC_TABLE_SCAN", "LOGICAL_CREATE_NODE_TABLE",
     "LOGICAL_CREATE_REL_TABLE", "LOGICAL_COPY_CSV"};
 
 class LogicalOperator {
-
 public:
     // Leaf operator.
     LogicalOperator() = default;
@@ -58,6 +54,7 @@ public:
     LogicalOperator(shared_ptr<LogicalOperator> child);
     // Binary operator.
     LogicalOperator(shared_ptr<LogicalOperator> left, shared_ptr<LogicalOperator> right);
+    LogicalOperator(vector<shared_ptr<LogicalOperator>> children);
 
     virtual ~LogicalOperator() = default;
 

--- a/src/planner/logical_plan/logical_operator/include/logical_accumulate.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_accumulate.h
@@ -6,17 +6,16 @@
 namespace graphflow {
 namespace planner {
 
-class LogicalSink : public LogicalOperator {
-
+class LogicalAccumulate : public LogicalOperator {
 public:
-    LogicalSink(expression_vector expressions, vector<uint64_t> flatOutputGroupPositions,
+    LogicalAccumulate(expression_vector expressions, vector<uint64_t> flatOutputGroupPositions,
         unique_ptr<Schema> schemaBeforeSink, shared_ptr<LogicalOperator> child)
         : LogicalOperator{move(child)}, expressions{move(expressions)},
           flatOutputGroupPositions{move(flatOutputGroupPositions)}, schemaBeforeSink{
                                                                         move(schemaBeforeSink)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
-        return LogicalOperatorType::LOGICAL_SINK;
+        return LogicalOperatorType::LOGICAL_ACCUMULATE;
     }
 
     string getExpressionsForPrinting() const override {
@@ -32,12 +31,11 @@ public:
     inline Schema* getSchemaBeforeSink() const { return schemaBeforeSink.get(); }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalSink>(
+        return make_unique<LogicalAccumulate>(
             expressions, flatOutputGroupPositions, schemaBeforeSink->copy(), children[0]->copy());
     }
 
 private:
-    // Expressions to materialize and scan
     expression_vector expressions;
     // TODO(Xiyang): remove this when fixing issue #606
     vector<uint64_t> flatOutputGroupPositions;

--- a/src/planner/logical_plan/logical_operator/include/logical_aggregate.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_aggregate.h
@@ -7,7 +7,6 @@ namespace graphflow {
 namespace planner {
 
 class LogicalAggregate : public LogicalOperator {
-
 public:
     LogicalAggregate(expression_vector expressionsToGroupBy,
         expression_vector expressionsToAggregate, unique_ptr<Schema> schemaBeforeAggregate,
@@ -16,18 +15,15 @@ public:
           expressionsToAggregate{move(expressionsToAggregate)}, schemaBeforeAggregate{
                                                                     move(schemaBeforeAggregate)} {}
 
-    LogicalOperatorType getLogicalOperatorType() const override {
+    inline LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_AGGREGATE;
     }
 
     string getExpressionsForPrinting() const override;
 
     inline bool hasExpressionsToGroupBy() const { return !expressionsToGroupBy.empty(); }
-
     inline expression_vector getExpressionsToGroupBy() const { return expressionsToGroupBy; }
-
     inline expression_vector getExpressionsToAggregate() const { return expressionsToAggregate; }
-
     inline Schema* getSchemaBeforeAggregate() const { return schemaBeforeAggregate.get(); }
 
     unique_ptr<LogicalOperator> copy() override {

--- a/src/planner/logical_plan/logical_operator/include/logical_distinct.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_distinct.h
@@ -3,13 +3,10 @@
 #include "base_logical_operator.h"
 #include "schema.h"
 
-using namespace graphflow::binder;
-
 namespace graphflow {
 namespace planner {
 
 class LogicalDistinct : public LogicalOperator {
-
 public:
     LogicalDistinct(expression_vector expressionsToDistinct,
         unique_ptr<Schema> schemaBeforeDistinct, shared_ptr<LogicalOperator> child)
@@ -21,7 +18,6 @@ public:
     string getExpressionsForPrinting() const override;
 
     inline expression_vector getExpressionsToDistinct() const { return expressionsToDistinct; }
-
     inline Schema* getSchemaBeforeDistinct() const { return schemaBeforeDistinct.get(); }
 
     unique_ptr<LogicalOperator> copy() override {

--- a/src/planner/logical_plan/logical_operator/include/logical_flatten.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_flatten.h
@@ -10,7 +10,6 @@ namespace graphflow {
 namespace planner {
 
 class LogicalFlatten : public LogicalOperator {
-
 public:
     LogicalFlatten(shared_ptr<Expression> expression, shared_ptr<LogicalOperator> child)
         : LogicalOperator{move(child)}, expression{move(expression)} {}
@@ -19,9 +18,15 @@ public:
         return LogicalOperatorType::LOGICAL_FLATTEN;
     }
 
-    string getExpressionsForPrinting() const override { return expression->getUniqueName(); }
+    inline string getExpressionsForPrinting() const override { return expression->getUniqueName(); }
 
-    inline shared_ptr<Expression> getExpressionToFlatten() const { return expression; }
+    inline shared_ptr<Expression> getExpression() const { return expression; }
+
+    inline void computeSchema(Schema& schema) {
+        auto group = schema.getGroup(expression);
+        assert(!group->getIsFlat());
+        group->setIsFlat(true);
+    }
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalFlatten>(expression, children[0]->copy());

--- a/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
@@ -15,13 +15,12 @@ public:
     // Probe side on left, i.e. children[0]. Build side on right, i.e. children[1].
     LogicalHashJoin(shared_ptr<NodeExpression> joinNode, unique_ptr<Schema> buildSideSchema,
         vector<uint64_t> flatOutputGroupPositions, expression_vector expressionsToMaterialize,
-        bool isOutputAFlatTuple, shared_ptr<LogicalOperator> probeSideChild,
+        bool isScanOneRow, shared_ptr<LogicalOperator> probeSideChild,
         shared_ptr<LogicalOperator> buildSideChild)
         : LogicalOperator{move(probeSideChild), move(buildSideChild)}, joinNode(move(joinNode)),
           buildSideSchema(move(buildSideSchema)), flatOutputGroupPositions{move(
                                                       flatOutputGroupPositions)},
-          expressionsToMaterialize{move(expressionsToMaterialize)}, isOutputAFlatTuple{
-                                                                        isOutputAFlatTuple} {}
+          expressionsToMaterialize{move(expressionsToMaterialize)}, isScanOneRow{isScanOneRow} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_HASH_JOIN;
@@ -36,12 +35,12 @@ public:
     inline shared_ptr<NodeExpression> getJoinNode() const { return joinNode; }
     inline Schema* getBuildSideSchema() const { return buildSideSchema.get(); }
     inline vector<uint64_t> getFlatOutputGroupPositions() const { return flatOutputGroupPositions; }
-    inline bool getIsOutputAFlatTuple() const { return isOutputAFlatTuple; }
+    inline bool getIsScanOneRow() const { return isScanOneRow; }
 
     unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalHashJoin>(joinNode, buildSideSchema->copy(),
-            flatOutputGroupPositions, expressionsToMaterialize, isOutputAFlatTuple,
-            children[0]->copy(), children[1]->copy());
+            flatOutputGroupPositions, expressionsToMaterialize, isScanOneRow, children[0]->copy(),
+            children[1]->copy());
     }
 
 private:
@@ -50,7 +49,7 @@ private:
     // TODO(Xiyang): solve this with issue 606
     vector<uint64_t> flatOutputGroupPositions;
     expression_vector expressionsToMaterialize;
-    bool isOutputAFlatTuple;
+    bool isScanOneRow;
 };
 } // namespace planner
 } // namespace graphflow

--- a/src/planner/logical_plan/logical_operator/include/logical_order_by.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_order_by.h
@@ -9,7 +9,6 @@ namespace graphflow {
 namespace planner {
 
 class LogicalOrderBy : public LogicalOperator {
-
 public:
     LogicalOrderBy(expression_vector expressionsToOrderBy, vector<bool> sortOrders,
         expression_vector expressionsToMaterialize, unique_ptr<Schema> schemaBeforeOrderBy,
@@ -18,18 +17,15 @@ public:
           isAscOrders{move(sortOrders)}, expressionsToMaterialize{move(expressionsToMaterialize)},
           schemaBeforeOrderBy{move(schemaBeforeOrderBy)} {}
 
-    LogicalOperatorType getLogicalOperatorType() const override {
+    inline LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_ORDER_BY;
     }
 
     string getExpressionsForPrinting() const override;
 
     inline expression_vector getExpressionsToOrderBy() const { return expressionsToOrderBy; }
-
     inline vector<bool> getIsAscOrders() const { return isAscOrders; }
-
     inline Schema* getSchemaBeforeOrderBy() const { return schemaBeforeOrderBy.get(); }
-
     inline expression_vector getExpressionsToMaterialize() const {
         return expressionsToMaterialize;
     }

--- a/src/planner/logical_plan/logical_operator/include/logical_projection.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_projection.h
@@ -10,12 +10,11 @@ namespace graphflow {
 namespace planner {
 
 class LogicalProjection : public LogicalOperator {
-
 public:
-    explicit LogicalProjection(expression_vector expressionsToProject,
+    explicit LogicalProjection(expression_vector expressions,
         unordered_set<uint32_t> discardedGroupsPos, shared_ptr<LogicalOperator> child)
-        : LogicalOperator{move(child)}, expressionsToProject{move(expressionsToProject)},
-          discardedGroupsPos{move(discardedGroupsPos)} {}
+        : LogicalOperator{move(child)}, expressions{move(expressions)}, discardedGroupsPos{move(
+                                                                            discardedGroupsPos)} {}
 
     LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_PROJECTION;
@@ -23,17 +22,16 @@ public:
 
     string getExpressionsForPrinting() const override;
 
-    inline expression_vector getExpressionsToProject() const { return expressionsToProject; }
+    inline expression_vector getExpressionsToProject() const { return expressions; }
 
     inline unordered_set<uint32_t> getDiscardedGroupsPos() const { return discardedGroupsPos; }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalProjection>(
-            expressionsToProject, discardedGroupsPos, children[0]->copy());
+        return make_unique<LogicalProjection>(expressions, discardedGroupsPos, children[0]->copy());
     }
 
 private:
-    expression_vector expressionsToProject;
+    expression_vector expressions;
     unordered_set<uint32_t> discardedGroupsPos;
 };
 

--- a/src/planner/logical_plan/logical_operator/include/logical_scan_node_id.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_scan_node_id.h
@@ -10,23 +10,27 @@ using namespace graphflow::binder;
 
 class LogicalScanNodeID : public LogicalOperator {
 public:
-    LogicalScanNodeID(shared_ptr<NodeExpression> nodeExpression)
-        : nodeExpression{move(nodeExpression)} {}
+    explicit LogicalScanNodeID(shared_ptr<NodeExpression> node) : node{move(node)} {}
 
-    LogicalOperatorType getLogicalOperatorType() const override {
+    inline LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_SCAN_NODE_ID;
     }
 
-    string getExpressionsForPrinting() const override { return nodeExpression->getRawName(); }
+    inline string getExpressionsForPrinting() const override { return node->getRawName(); }
 
-    inline shared_ptr<NodeExpression> getNodeExpression() const { return nodeExpression; }
+    inline void computeSchema(Schema& schema) {
+        auto groupPos = schema.createGroup();
+        schema.insertToGroupAndScope(node->getNodeIDPropertyExpression(), groupPos);
+    }
 
-    unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalScanNodeID>(nodeExpression);
+    inline shared_ptr<NodeExpression> getNodeExpression() const { return node; }
+
+    inline unique_ptr<LogicalOperator> copy() override {
+        return make_unique<LogicalScanNodeID>(node);
     }
 
 private:
-    shared_ptr<NodeExpression> nodeExpression;
+    shared_ptr<NodeExpression> node;
 };
 
 } // namespace planner

--- a/src/planner/logical_plan/logical_operator/include/schema.h
+++ b/src/planner/logical_plan/logical_operator/include/schema.h
@@ -29,7 +29,7 @@ public:
     inline void insertExpression(const shared_ptr<Expression>& expression) {
         expressions.push_back(expression);
     }
-    inline shared_ptr<Expression> getAnyExpression() const {
+    inline shared_ptr<Expression> getFirstExpression() const {
         assert(!expressions.empty());
         return expressions[0];
     }
@@ -44,6 +44,10 @@ private:
 class Schema {
 public:
     inline uint32_t getNumGroups() const { return groups.size(); }
+
+    inline FactorizationGroup* getGroup(shared_ptr<Expression> expression) const {
+        return getGroup(getGroupPos(expression->getUniqueName()));
+    }
 
     inline FactorizationGroup* getGroup(const string& expressionName) const {
         return getGroup(getGroupPos(expressionName));
@@ -66,6 +70,10 @@ public:
     inline expression_vector getExpressionsInScope() const { return expressionsInScope; }
 
     expression_vector getExpressionsInScope(uint32_t pos) const;
+
+    expression_vector getSubExpressionsInScope(const shared_ptr<Expression>& expression);
+
+    unordered_set<uint32_t> getDependentGroupsPos(const shared_ptr<Expression>& expression);
 
     inline void clearExpressionsInScope() { expressionsInScope.clear(); }
 

--- a/src/planner/logical_plan/logical_operator/include/sink_util.h
+++ b/src/planner/logical_plan/logical_operator/include/sink_util.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "schema.h"
+
+namespace graphflow {
+namespace planner {
+using namespace graphflow::binder;
+
+// This class contains the logic for re-computing factorization structure after
+class SinkOperatorUtil {
+public:
+    static void mergeSchema(
+        const Schema& inputSchema, Schema& result, const string& key, bool isScanOneRow);
+
+    static void reComputeSchema(const Schema& inputSchema, Schema& result);
+
+    static unordered_set<uint32_t> getGroupsPosIgnoringKeyGroup(
+        const Schema& schema, const string& key);
+
+private:
+    static void mergeKeyGroup(const Schema& inputSchema, Schema& resultSchema, const string& key);
+
+    static inline expression_vector getFlatPayloadsIgnoringKeyGroup(
+        const Schema& schema, const string& key) {
+        return getFlatPayloads(schema, getGroupsPosIgnoringKeyGroup(schema, key));
+    }
+    static inline expression_vector getFlatPayloads(const Schema& schema) {
+        return getFlatPayloads(schema, schema.getGroupsPosInScope());
+    }
+    static expression_vector getFlatPayloads(
+        const Schema& schema, unordered_set<uint32_t> payloadGroupsPos);
+
+    static inline bool hasUnflatPayloadIgnoringKeyGroup(const Schema& schema, const string& key) {
+        return hasUnFlatPayload(schema, getGroupsPosIgnoringKeyGroup(schema, key));
+    }
+    static inline bool hasUnFlatPayload(const Schema& schema) {
+        return hasUnFlatPayload(schema, schema.getGroupsPosInScope());
+    }
+    static bool hasUnFlatPayload(const Schema& schema, unordered_set<uint32_t> payloadGroupsPos);
+
+    static uint32_t appendPayloadsToNewGroup(Schema& schema, expression_vector& payloads);
+};
+
+} // namespace planner
+} // namespace graphflow

--- a/src/planner/logical_plan/logical_operator/logical_projection.cpp
+++ b/src/planner/logical_plan/logical_operator/logical_projection.cpp
@@ -5,7 +5,7 @@ namespace planner {
 
 string LogicalProjection::getExpressionsForPrinting() const {
     auto result = string();
-    for (auto& expression : expressionsToProject) {
+    for (auto& expression : expressions) {
         result += expression->getUniqueName() + ", ";
     }
     return result;

--- a/src/planner/logical_plan/logical_operator/schema.cpp
+++ b/src/planner/logical_plan/logical_operator/schema.cpp
@@ -45,6 +45,28 @@ expression_vector Schema::getExpressionsInScope(uint32_t pos) const {
     return result;
 }
 
+expression_vector Schema::getSubExpressionsInScope(const shared_ptr<Expression>& expression) {
+    expression_vector results;
+    if (isExpressionInScope(*expression)) {
+        results.push_back(expression);
+        return results;
+    }
+    for (auto& child : expression->getChildren()) {
+        for (auto& subExpression : getSubExpressionsInScope(child)) {
+            results.push_back(subExpression);
+        }
+    }
+    return results;
+}
+
+unordered_set<uint32_t> Schema::getDependentGroupsPos(const shared_ptr<Expression>& expression) {
+    unordered_set<uint32_t> result;
+    for (auto& subExpression : getSubExpressionsInScope(expression)) {
+        result.insert(getGroupPos(subExpression->getUniqueName()));
+    }
+    return result;
+}
+
 unordered_set<uint32_t> Schema::getGroupsPosInScope() const {
     unordered_set<uint32_t> result;
     for (auto& expressionInScope : expressionsInScope) {

--- a/src/planner/logical_plan/logical_operator/sink_util.cpp
+++ b/src/planner/logical_plan/logical_operator/sink_util.cpp
@@ -1,0 +1,103 @@
+#include "include/sink_util.h"
+
+namespace graphflow {
+namespace planner {
+
+void SinkOperatorUtil::mergeSchema(
+    const Schema& inputSchema, Schema& result, const string& key, bool isScanOneRow) {
+    mergeKeyGroup(inputSchema, result, key);
+    if (getGroupsPosIgnoringKeyGroup(inputSchema, key).empty()) { // nothing else to merge
+        return;
+    }
+    auto flatPayloads = getFlatPayloadsIgnoringKeyGroup(inputSchema, key);
+    if (!flatPayloads.empty()) {
+        auto flatPayloadsOutputGroupPos = appendPayloadsToNewGroup(result, flatPayloads);
+        if (isScanOneRow) {
+            result.flattenGroup(flatPayloadsOutputGroupPos);
+        }
+    }
+    for (auto& payloadGroupPos : getGroupsPosIgnoringKeyGroup(inputSchema, key)) {
+        auto payloadGroup = inputSchema.getGroup(payloadGroupPos);
+        if (!payloadGroup->getIsFlat()) {
+            auto payloads = inputSchema.getExpressionsInScope(payloadGroupPos);
+            auto outputGroupPos = appendPayloadsToNewGroup(result, payloads);
+            result.getGroup(outputGroupPos)->setMultiplier(payloadGroup->getMultiplier());
+        }
+    }
+}
+
+void SinkOperatorUtil::reComputeSchema(const Schema& inputSchema, Schema& result) {
+    assert(!inputSchema.getExpressionsInScope().empty());
+    result.clear();
+    auto flatPayloads = getFlatPayloads(inputSchema);
+    if (!hasUnFlatPayload(inputSchema)) {
+        appendPayloadsToNewGroup(result, flatPayloads);
+    } else {
+        if (!flatPayloads.empty()) {
+            auto flatPayloadsOutputGroupPos = appendPayloadsToNewGroup(result, flatPayloads);
+            result.flattenGroup(flatPayloadsOutputGroupPos);
+        }
+        for (auto& payloadGroupPos : inputSchema.getGroupsPosInScope()) {
+            auto payloadGroup = inputSchema.getGroup(payloadGroupPos);
+            if (!payloadGroup->getIsFlat()) {
+                auto payloads = inputSchema.getExpressionsInScope(payloadGroupPos);
+                auto outputGroupPos = appendPayloadsToNewGroup(result, payloads);
+                result.getGroup(outputGroupPos)->setMultiplier(payloadGroup->getMultiplier());
+            }
+        }
+    }
+}
+
+unordered_set<uint32_t> SinkOperatorUtil::getGroupsPosIgnoringKeyGroup(
+    const Schema& schema, const string& key) {
+    auto keyGroupPos = schema.getGroupPos(key);
+    auto payloadGroupsPos = schema.getGroupsPosInScope();
+    payloadGroupsPos.erase(keyGroupPos);
+    return payloadGroupsPos;
+}
+
+void SinkOperatorUtil::mergeKeyGroup(
+    const Schema& inputSchema, Schema& resultSchema, const string& key) {
+    auto inputKeyGroupPos = inputSchema.getGroupPos(key);
+    auto resultKeyGroupPos = resultSchema.getGroupPos(key);
+    for (auto& expression : inputSchema.getExpressionsInScope(inputKeyGroupPos)) {
+        if (expression->getUniqueName() == key) {
+            continue;
+        }
+        resultSchema.insertToGroupAndScope(expression, resultKeyGroupPos);
+    }
+}
+
+expression_vector SinkOperatorUtil::getFlatPayloads(
+    const Schema& schema, unordered_set<uint32_t> payloadGroupsPos) {
+    expression_vector result;
+    for (auto& payloadGroupPos : payloadGroupsPos) {
+        if (schema.getGroup(payloadGroupPos)->getIsFlat()) {
+            for (auto& payload : schema.getExpressionsInScope(payloadGroupPos)) {
+                result.push_back(payload);
+            }
+        }
+    }
+    return result;
+}
+
+bool SinkOperatorUtil::hasUnFlatPayload(
+    const Schema& schema, unordered_set<uint32_t> payloadGroupsPos) {
+    for (auto& payloadGroupPos : payloadGroupsPos) {
+        if (!schema.getGroup(payloadGroupPos)->getIsFlat()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+uint32_t SinkOperatorUtil::appendPayloadsToNewGroup(Schema& schema, expression_vector& payloads) {
+    auto outputGroupPos = schema.createGroup();
+    for (auto& payload : payloads) {
+        schema.insertToGroupAndScope(payload, outputGroupPos);
+    }
+    return outputGroupPos;
+}
+
+} // namespace planner
+} // namespace graphflow

--- a/src/processor/include/physical_plan/mapper/plan_mapper.h
+++ b/src/processor/include/physical_plan/mapper/plan_mapper.h
@@ -70,7 +70,7 @@ private:
         LogicalOperator* logicalOperator, MapperContext& mapperContext);
     unique_ptr<PhysicalOperator> mapLogicalUnionAllToPhysical(
         LogicalOperator* logicalOperator, MapperContext& mapperContext);
-    unique_ptr<PhysicalOperator> mapLogicalSinkToPhysical(
+    unique_ptr<PhysicalOperator> mapLogicalAccumulateToPhysical(
         LogicalOperator* logicalOperator, MapperContext& mapperContext);
     unique_ptr<PhysicalOperator> mapLogicalTableScanToPhysical(
         LogicalOperator* logicalOperator, MapperContext& mapperContext);

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -51,22 +51,22 @@ class HashJoinProbe : public PhysicalOperator, FilteringOperator {
 public:
     HashJoinProbe(shared_ptr<HashJoinSharedState> sharedState,
         vector<uint64_t> flatDataChunkPositions, const ProbeDataInfo& probeDataInfo,
-        bool isOutputAFlatTuple, unique_ptr<PhysicalOperator> probeChild,
+        bool isScanOneRow, unique_ptr<PhysicalOperator> probeChild,
         unique_ptr<PhysicalOperator> buildChild, uint32_t id, const string& paramsString)
         : PhysicalOperator{std::move(probeChild), std::move(buildChild), id, paramsString},
           FilteringOperator{1 /* numStatesToSave */}, sharedState{std::move(sharedState)},
           flatDataChunkPositions{std::move(flatDataChunkPositions)}, probeDataInfo{probeDataInfo},
-          isOutputAFlatTuple{isOutputAFlatTuple} {}
+          isScanOneRow{isScanOneRow} {}
 
     // This constructor is used for cloning only.
     HashJoinProbe(shared_ptr<HashJoinSharedState> sharedState,
         vector<uint64_t> flatDataChunkPositions, const ProbeDataInfo& probeDataInfo,
-        bool isOutputAFlatTuple, unique_ptr<PhysicalOperator> probeChild, uint32_t id,
+        bool isScanOneRow, unique_ptr<PhysicalOperator> probeChild, uint32_t id,
         const string& paramsString)
         : PhysicalOperator{std::move(probeChild), id, paramsString},
           FilteringOperator{1 /* numStatesToSave */}, sharedState{std::move(sharedState)},
           flatDataChunkPositions{std::move(flatDataChunkPositions)}, probeDataInfo{probeDataInfo},
-          isOutputAFlatTuple{isOutputAFlatTuple} {}
+          isScanOneRow{isScanOneRow} {}
 
     PhysicalOperatorType getOperatorType() override { return HASH_JOIN_PROBE; }
 
@@ -77,7 +77,7 @@ public:
     // HashJoinProbe do not need to clone hashJoinBuild which is on a different pipeline.
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<HashJoinProbe>(sharedState, flatDataChunkPositions, probeDataInfo,
-            isOutputAFlatTuple, children[0]->clone(), id, paramsString);
+            isScanOneRow, children[0]->clone(), id, paramsString);
     }
 
 private:
@@ -93,7 +93,7 @@ private:
     vector<uint32_t> columnIdxsToReadFrom;
     shared_ptr<ValueVector> probeSideKeyVector;
     unique_ptr<ProbeState> probeState;
-    bool isOutputAFlatTuple;
+    bool isScanOneRow;
 };
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/physical_plan/mapper/map_hash_join.cpp
+++ b/src/processor/physical_plan/mapper/map_hash_join.cpp
@@ -49,7 +49,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
     // create hashJoin probe
     auto probeDataInfo = ProbeDataInfo(probeSideKeyIDDataPos, probeSideNonKeyDataPoses);
     auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState,
-        hashJoin->getFlatOutputGroupPositions(), probeDataInfo, hashJoin->getIsOutputAFlatTuple(),
+        hashJoin->getFlatOutputGroupPositions(), probeDataInfo, hashJoin->getIsScanOneRow(),
         std::move(probeSidePrevOperator), std::move(hashJoinBuild), getOperatorID(), paramsString);
     return hashJoinProbe;
 }

--- a/src/processor/physical_plan/mapper/plan_mapper.cpp
+++ b/src/processor/physical_plan/mapper/plan_mapper.cpp
@@ -136,8 +136,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOperatorToPhysical(
     case LOGICAL_UNION_ALL: {
         physicalOperator = mapLogicalUnionAllToPhysical(logicalOperator.get(), mapperContext);
     } break;
-    case LOGICAL_SINK: {
-        physicalOperator = mapLogicalSinkToPhysical(logicalOperator.get(), mapperContext);
+    case LOGICAL_ACCUMULATE: {
+        physicalOperator = mapLogicalAccumulateToPhysical(logicalOperator.get(), mapperContext);
     } break;
     case LOGICAL_STATIC_TABLE_SCAN: {
         physicalOperator = mapLogicalTableScanToPhysical(logicalOperator.get(), mapperContext);
@@ -191,12 +191,12 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalResultScanToPhysical(
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFlattenToPhysical(
     LogicalOperator* logicalOperator, MapperContext& mapperContext) {
-    auto& flatten = (const LogicalFlatten&)*logicalOperator;
+    auto flatten = (LogicalFlatten*)logicalOperator;
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto dataChunkPos =
-        mapperContext.getDataPos(flatten.getExpressionToFlatten()->getUniqueName()).dataChunkPos;
+        mapperContext.getDataPos(flatten->getExpression()->getUniqueName()).dataChunkPos;
     return make_unique<Flatten>(
-        dataChunkPos, move(prevOperator), getOperatorID(), flatten.getExpressionsForPrinting());
+        dataChunkPos, move(prevOperator), getOperatorID(), flatten->getExpressionsForPrinting());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFilterToPhysical(

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -77,7 +77,7 @@ uint64_t HashJoinProbe::populateResultSet() {
     // Note: When the probe side is flat, and the build side: a) has no unflat columns; b) has no
     // payloads in the key data chunk; c) has payloads required to read from hash table, we apply an
     // optimization to unflat the probe side payloads in the resultSet.
-    auto numTuplesToRead = isOutputAFlatTuple ? 1 : probeState->matchedSelVector->selectedSize;
+    auto numTuplesToRead = isScanOneRow ? 1 : probeState->matchedSelVector->selectedSize;
     if (!probeSideKeyVector->state->isFlat() &&
         probeSideKeyVector->state->selVector->selectedSize != numTuplesToRead) {
         // Update probeSideKeyVector's selectedPositions when the probe side is unflat and its

--- a/test/test_files/tinySNB/subquery/subquery.test
+++ b/test/test_files/tinySNB/subquery/subquery.test
@@ -35,11 +35,11 @@
 ---- 1
 3
 
--NAME ExistSubqueryMultiPartCyclicTest
--QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WITH a, b AS c MATCH (c)-[:knows]->(a) RETURN a.ID } RETURN COUNT(*)
--ENUMERATE
----- 1
-4
+#-NAME ExistSubqueryMultiPartCyclicTest
+#-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WITH a, b AS c MATCH (c)-[:knows]->(a) RETURN a.ID } RETURN COUNT(*)
+#-ENUMERATE
+#---- 1
+#4
 
 -NAME ExistsSubqueryColExtendTest
 -QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:studyAt]->(b:organisation) RETURN a.ID } RETURN COUNT(*)


### PR DESCRIPTION
This PR refactors the common logic for recomputing factorization structure after sinking (i.e. OrderBy, Aggregate, Accumulate & HashJoin) into 2 cases
- reComputeSchema: clear the original schema and reorganize (OrderBy, Accumulate)
- mergeSchema: merge one schema into another based on join key (HashJoin)

Minor changes:
- remove intersect
- start adding computeSchema() interface to logical operator