### PR TITLE
Remove non sequential extend

### DIFF
--- a/src/binder/query/match_clause/include/query_graph.h
+++ b/src/binder/query/match_clause/include/query_graph.h
@@ -40,8 +40,12 @@ struct SubqueryGraph {
         queryNodesSelector |= other.queryNodesSelector;
     }
 
+    inline uint32_t getNumQueryRels() const { return queryRelsSelector.count(); }
     inline uint32_t getTotalNumVariables() const {
         return queryNodesSelector.count() + queryRelsSelector.count();
+    }
+    inline bool isSingleRel() const {
+        return queryRelsSelector.count() == 1 && queryNodesSelector.count() == 0;
     }
 
     bool containAllVariables(unordered_set<string>& variables) const;

--- a/src/planner/include/join_order_enumerator_context.h
+++ b/src/planner/include/join_order_enumerator_context.h
@@ -20,9 +20,6 @@ public:
 
     inline expression_vector getWhereExpressions() { return whereExpressionsSplitOnAND; }
 
-    inline SubqueryGraphPlansMap* getSubqueryGraphPlansMap(uint32_t level) const {
-        return subPlansTable->getSubqueryGraphPlansMap(level);
-    }
     inline bool containPlans(const SubqueryGraph& subqueryGraph) const {
         return subPlansTable->containSubgraphPlans(subqueryGraph);
     }

--- a/src/planner/include/subplans_table.h
+++ b/src/planner/include/subplans_table.h
@@ -12,10 +12,9 @@ using namespace graphflow::binder;
 namespace graphflow {
 namespace planner {
 
-typedef unordered_map<SubqueryGraph, vector<unique_ptr<LogicalPlan>>, SubqueryGraphHasher>
-    SubqueryGraphPlansMap;
-
 class SubPlansTable {
+    typedef unordered_map<SubqueryGraph, vector<unique_ptr<LogicalPlan>>, SubqueryGraphHasher>
+        SubqueryGraphPlansMap;
 
 public:
     void resize(uint32_t newSize);
@@ -24,9 +23,7 @@ public:
 
     vector<unique_ptr<LogicalPlan>>& getSubgraphPlans(const SubqueryGraph& subqueryGraph);
 
-    SubqueryGraphPlansMap* getSubqueryGraphPlansMap(uint32_t level) {
-        return subPlans[level].get();
-    }
+    vector<SubqueryGraph> getSubqueryGraphs(uint32_t level);
 
     void addPlan(const SubqueryGraph& subqueryGraph, unique_ptr<LogicalPlan> plan);
     void finalizeLevel(uint32_t level);

--- a/src/planner/subplans_table.cpp
+++ b/src/planner/subplans_table.cpp
@@ -26,6 +26,14 @@ vector<unique_ptr<LogicalPlan>>& SubPlansTable::getSubgraphPlans(
     return subqueryGraphPlansMap->at(subqueryGraph);
 }
 
+vector<SubqueryGraph> SubPlansTable::getSubqueryGraphs(uint32_t level) {
+    vector<SubqueryGraph> result;
+    for (auto& [subGraph, plans] : *subPlans[level]) {
+        result.push_back(subGraph);
+    }
+    return result;
+}
+
 void SubPlansTable::addPlan(const SubqueryGraph& subqueryGraph, unique_ptr<LogicalPlan> plan) {
     assert(subPlans[subqueryGraph.getTotalNumVariables()]);
     auto subgraphPlansMap = subPlans[subqueryGraph.getTotalNumVariables()].get();

--- a/test/runner/e2e_read_list_test.cpp
+++ b/test/runner/e2e_read_list_test.cpp
@@ -48,8 +48,8 @@ TEST_F(EndToEndReadLists2BytesPerEdgeTest, PropLists4BytesPerEdgeTest) {
 //    ASSERT_TRUE(TestHelper::testQueries(queryConfigs, *conn));
 //}
 
-TEST_F(EndToEndReadListsSubQueryTest, LargeListSubQueryTest) {
-    auto queryConfigs =
-        TestHelper::parseTestFile("test/test_files/read_list/large-list-sub-query.test");
-    ASSERT_TRUE(TestHelper::testQueries(queryConfigs, *conn));
-}
+// TEST_F(EndToEndReadListsSubQueryTest, LargeListSubQueryTest) {
+//    auto queryConfigs =
+//        TestHelper::parseTestFile("test/test_files/read_list/large-list-sub-query.test");
+//    ASSERT_TRUE(TestHelper::testQueries(queryConfigs, *conn));
+//}

--- a/test/runner/e2e_read_test.cpp
+++ b/test/runner/e2e_read_test.cpp
@@ -55,13 +55,13 @@ TEST_F(TinySnbReadTest, Projection) {
     runTest("test/test_files/tinySNB/projection/multi_query_part.test");
 }
 
-TEST_F(TinySnbReadTest, Subquery) {
-    runTest("test/test_files/tinySNB/subquery/subquery.test");
-}
-
-TEST_F(TinySnbReadTest, OptionalMatch) {
-    runTest("test/test_files/tinySNB/optional_match/optional_match.test");
-}
+// TEST_F(TinySnbReadTest, Subquery) {
+//    runTest("test/test_files/tinySNB/subquery/subquery.test");
+//}
+//
+// TEST_F(TinySnbReadTest, OptionalMatch) {
+//    runTest("test/test_files/tinySNB/optional_match/optional_match.test");
+//}
 
 TEST_F(TinySnbReadTest, OrderBy) {
     auto queryConfigs = TestHelper::parseTestFile(

--- a/test/test_files/tinySNB/projection/skip_limit.test
+++ b/test/test_files/tinySNB/projection/skip_limit.test
@@ -72,11 +72,11 @@ Carol
 Dan
 
 -NAME KnowsOneHopWithSkipLimitTest1
--QUERY MATCH (a:person) WHERE a.age>20 WITH a SKIP 2 MATCH (a)-[e:knows]->(b:person) RETURN b.fName LIMIT 2
+-QUERY MATCH (a:person) WHERE a.age>20 WITH a ORDER BY a.ID SKIP 2 MATCH (a)-[e:knows]->(b:person) RETURN a.fName, b.fName ORDER BY b.fName LIMIT 2
 -ENUMERATE
 ---- 2
-Alice
-Bob
+Carol|Alice
+Carol|Bob
 
 -NAME KnowsOneHopWithSkipLimitTest2
 -QUERY MATCH (a:person) WHERE a.age>20 WITH a SKIP 1 LIMIT 1 MATCH (a)-[e:knows]->(b:person) RETURN b.fName

--- a/tools/join_order_pick/test/test.cpp
+++ b/tools/join_order_pick/test/test.cpp
@@ -41,8 +41,8 @@ public:
 
 TEST_F(JoinOrderPickTest, OneHop) {
     auto queryStr = "MATCH (a:person)-[:knows]->(b:person) RETURN a.ID";
-    ASSERT_TRUE(conn->query(queryStr, "E(b)S(a)")->isSuccess());
-    ASSERT_TRUE(conn->query(queryStr, "E(a)S(b)")->isSuccess());
+    ASSERT_FALSE(conn->query(queryStr, "E(b)S(a)")->isSuccess());
+    ASSERT_FALSE(conn->query(queryStr, "E(a)S(b)")->isSuccess());
     ASSERT_TRUE(conn->query(queryStr, "HJ(b){E(b)S(a)}{S(b)}")->isSuccess());
 }
 


### PR DESCRIPTION
This PR adds rel table scan into DP table and uses hash join with rel table to replace non-sequential extend.

As a side effect, subquery is temporarily disabled in this PR.