### PR TITLE
Left hash join

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -212,6 +212,14 @@ cc_library(
 )
 
 cc_library(
+    name = "join_type",
+    hdrs = [
+        "include/join_type.h",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+cc_library(
     name = "statement_type",
     hdrs = [
         "include/statement_type.h",

--- a/src/common/include/join_type.h
+++ b/src/common/include/join_type.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+
+namespace graphflow {
+namespace common {
+
+enum class JoinType : uint8_t {
+    INNER = 0,
+    LEFT = 1,
+};
+
+} // namespace common
+} // namespace graphflow

--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -202,7 +202,10 @@ void Enumerator::planOptionalMatch(const QueryGraph& queryGraph,
     auto bestInnerPlan = getBestPlan(joinOrderEnumerator.enumerateJoinOrder(
         *queryGraphToEnumerate, queryGraphPredicate, getInitialEmptyPlans()));
     joinOrderEnumerator.exitSubquery(std::move(prevContext));
-    joinOrderEnumerator.appendHashJoin(joinNode, outerPlan, *bestInnerPlan);
+    // TOOD(Xiyang): Update the cost for outer plan here.
+    Enumerator::appendFlattenIfNecessary(
+        outerPlan.getSchema()->getGroupPos(joinNode->getIDProperty()), outerPlan);
+    joinOrderEnumerator.appendHashJoin(joinNode, JoinType::LEFT, outerPlan, *bestInnerPlan);
 }
 
 void Enumerator::planExistsSubquery(

--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -2,6 +2,7 @@
 
 #include "src/binder/query/include/normalized_single_query.h"
 #include "src/catalog/include/catalog.h"
+#include "src/common/include/join_type.h"
 #include "src/planner/include/join_order_enumerator_context.h"
 #include "src/storage/store/include/nodes_statistics_and_deleted_ids.h"
 
@@ -71,18 +72,18 @@ private:
         auto maxLeftLevel = floor(level / 2.0);
         for (auto leftLevel = 1u; leftLevel <= maxLeftLevel; ++leftLevel) {
             auto rightLevel = level - leftLevel;
-            planJoin(leftLevel, rightLevel);
+            planInnerJoin(leftLevel, rightLevel);
         }
         context->subPlansTable->finalizeLevel(level);
     }
 
-    void planJoin(uint32_t leftLevel, uint32_t rightLevel);
+    void planInnerJoin(uint32_t leftLevel, uint32_t rightLevel);
 
     bool canApplyINLJoin(const SubqueryGraph& subgraph, const SubqueryGraph& otherSubgraph,
         shared_ptr<NodeExpression> joinNode);
-    void planINLJoin(const SubqueryGraph& subgraph, const SubqueryGraph& otherSubgraph,
+    void planInnerINLJoin(const SubqueryGraph& subgraph, const SubqueryGraph& otherSubgraph,
         shared_ptr<NodeExpression> joinNode);
-    void planHashJoin(const SubqueryGraph& subgraph, const SubqueryGraph& otherSubgraph,
+    void planInnerHashJoin(const SubqueryGraph& subgraph, const SubqueryGraph& otherSubgraph,
         shared_ptr<NodeExpression> joinNode, bool flipPlan);
     // Filter push down for hash join.
     void planFiltersForHashJoin(expression_vector& predicates, LogicalPlan& plan);
@@ -91,8 +92,8 @@ private:
     void appendScanNodeID(shared_ptr<NodeExpression>& node, LogicalPlan& plan);
 
     void appendExtend(shared_ptr<RelExpression>& rel, RelDirection direction, LogicalPlan& plan);
-    void appendHashJoin(
-        const shared_ptr<NodeExpression>& joinNode, LogicalPlan& probePlan, LogicalPlan& buildPlan);
+    void appendHashJoin(const shared_ptr<NodeExpression>& joinNode, JoinType joinType,
+        LogicalPlan& probePlan, LogicalPlan& buildPlan);
     expression_vector getPropertiesForVariable(Expression& expression, Expression& variable);
     uint64_t getExtensionRate(
         table_id_t boundTableID, table_id_t relTableID, RelDirection relDirection);

--- a/src/planner/logical_plan/BUILD.bazel
+++ b/src/planner/logical_plan/BUILD.bazel
@@ -15,6 +15,7 @@ cc_library(
     ],
     deps = [
         "//src/binder/expression:base_expression",
+        "//src/common:join_type",
         "//src/planner/logical_plan/logical_operator:base_logical_operator",
     ],
 )

--- a/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
@@ -4,6 +4,7 @@
 #include "schema.h"
 
 #include "src/binder/expression/include/node_expression.h"
+#include "src/common/include/join_type.h"
 
 namespace graphflow {
 namespace planner {
@@ -12,37 +13,37 @@ using namespace graphflow::binder;
 class LogicalHashJoin : public LogicalOperator {
 public:
     // Probe side on left, i.e. children[0]. Build side on right, i.e. children[1].
-    LogicalHashJoin(shared_ptr<NodeExpression> joinNode, unique_ptr<Schema> buildSideSchema,
-        vector<uint64_t> flatOutputGroupPositions, expression_vector expressionsToMaterialize,
-        shared_ptr<LogicalOperator> probeSideChild, shared_ptr<LogicalOperator> buildSideChild)
+    LogicalHashJoin(shared_ptr<NodeExpression> joinNode, JoinType joinType,
+        unique_ptr<Schema> buildSideSchema, vector<uint64_t> flatOutputGroupPositions,
+        expression_vector expressionsToMaterialize, shared_ptr<LogicalOperator> probeSideChild,
+        shared_ptr<LogicalOperator> buildSideChild)
         : LogicalOperator{std::move(probeSideChild), std::move(buildSideChild)},
-          joinNode(std::move(joinNode)), buildSideSchema(move(buildSideSchema)),
+          joinNode(std::move(joinNode)), joinType{joinType}, buildSideSchema(move(buildSideSchema)),
           flatOutputGroupPositions{move(flatOutputGroupPositions)}, expressionsToMaterialize{move(
                                                                         expressionsToMaterialize)} {
     }
 
-    LogicalOperatorType getLogicalOperatorType() const override {
+    inline LogicalOperatorType getLogicalOperatorType() const override {
         return LogicalOperatorType::LOGICAL_HASH_JOIN;
     }
-
-    string getExpressionsForPrinting() const override { return joinNode->getRawName(); }
-
+    inline string getExpressionsForPrinting() const override { return joinNode->getRawName(); }
     inline expression_vector getExpressionsToMaterialize() const {
         return expressionsToMaterialize;
     }
-
     inline shared_ptr<NodeExpression> getJoinNode() const { return joinNode; }
+    inline JoinType getJoinType() const { return joinType; }
     inline Schema* getBuildSideSchema() const { return buildSideSchema.get(); }
     inline vector<uint64_t> getFlatOutputGroupPositions() const { return flatOutputGroupPositions; }
 
     unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalHashJoin>(joinNode, buildSideSchema->copy(),
+        return make_unique<LogicalHashJoin>(joinNode, joinType, buildSideSchema->copy(),
             flatOutputGroupPositions, expressionsToMaterialize, children[0]->copy(),
             children[1]->copy());
     }
 
 private:
     shared_ptr<NodeExpression> joinNode;
+    JoinType joinType;
     unique_ptr<Schema> buildSideSchema;
     // TODO(Xiyang): solve this with issue 606
     vector<uint64_t> flatOutputGroupPositions;

--- a/src/processor/BUILD.bazel
+++ b/src/processor/BUILD.bazel
@@ -127,6 +127,7 @@ cc_library(
         "filtering_operator",
         "hash_table",
         "sink_operator",
+        "//src/common:join_type",
     ],
 )
 

--- a/src/processor/include/physical_plan/hash_table/join_hash_table.h
+++ b/src/processor/include/physical_plan/hash_table/join_hash_table.h
@@ -19,7 +19,7 @@ public:
     void append(const vector<shared_ptr<ValueVector>>& vectorsToAppend);
     void allocateHashSlots(uint64_t numTuples);
     void buildHashSlots();
-    void probe(ValueVector& keyVector, uint8_t** probedTuples, SelectionVector& probeSelVector);
+    void probe(ValueVector& keyVector, uint8_t** probedTuples);
 
     inline void lookup(vector<shared_ptr<ValueVector>>& vectors, vector<uint32_t>& colIdxesToScan,
         uint8_t** tuplesToRead, uint64_t startPos, uint64_t numTuplesToRead) {

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "src/common/include/join_type.h"
 #include "src/processor/include/physical_plan/operator/filtering_operator.h"
 #include "src/processor/include/physical_plan/operator/hash_join/hash_join_build.h"
 #include "src/processor/include/physical_plan/operator/physical_operator.h"
@@ -12,8 +13,6 @@ struct ProbeState {
     explicit ProbeState() : nextMatchedTupleIdx{0} {
         matchedTuples = make_unique<uint8_t*[]>(DEFAULT_VECTOR_CAPACITY);
         probedTuples = make_unique<uint8_t*[]>(DEFAULT_VECTOR_CAPACITY);
-        probeSelVector = make_unique<SelectionVector>(DEFAULT_VECTOR_CAPACITY);
-        probeSelVector->resetSelectorToValuePosBuffer();
         matchedSelVector = make_unique<SelectionVector>(DEFAULT_VECTOR_CAPACITY);
         matchedSelVector->resetSelectorToValuePosBuffer();
     }
@@ -23,7 +22,6 @@ struct ProbeState {
     // Pointers to tuples in ht that actually matched.
     unique_ptr<uint8_t*[]> matchedTuples;
     // Selective index mapping each probed tuple to its probe side key vector.
-    unique_ptr<SelectionVector> probeSelVector;
     unique_ptr<SelectionVector> matchedSelVector;
     sel_t nextMatchedTupleIdx;
 };
@@ -49,47 +47,58 @@ public:
 // Probe side on left, i.e. children[0] and build side on right, i.e. children[1]
 class HashJoinProbe : public PhysicalOperator, FilteringOperator {
 public:
-    HashJoinProbe(shared_ptr<HashJoinSharedState> sharedState,
+    HashJoinProbe(shared_ptr<HashJoinSharedState> sharedState, JoinType joinType,
         vector<uint64_t> flatDataChunkPositions, const ProbeDataInfo& probeDataInfo,
         unique_ptr<PhysicalOperator> probeChild, unique_ptr<PhysicalOperator> buildChild,
         uint32_t id, const string& paramsString)
         : PhysicalOperator{std::move(probeChild), std::move(buildChild), id, paramsString},
-          FilteringOperator{1 /* numStatesToSave */}, sharedState{std::move(sharedState)},
+          FilteringOperator{1 /* numStatesToSave */},
+          sharedState{std::move(sharedState)}, joinType{joinType},
           flatDataChunkPositions{std::move(flatDataChunkPositions)}, probeDataInfo{probeDataInfo} {}
 
     // This constructor is used for cloning only.
-    HashJoinProbe(shared_ptr<HashJoinSharedState> sharedState,
+    // HashJoinProbe do not need to clone hashJoinBuild which is on a different pipeline.
+    HashJoinProbe(shared_ptr<HashJoinSharedState> sharedState, JoinType joinType,
         vector<uint64_t> flatDataChunkPositions, const ProbeDataInfo& probeDataInfo,
         unique_ptr<PhysicalOperator> probeChild, uint32_t id, const string& paramsString)
         : PhysicalOperator{std::move(probeChild), id, paramsString},
-          FilteringOperator{1 /* numStatesToSave */}, sharedState{std::move(sharedState)},
+          FilteringOperator{1 /* numStatesToSave */},
+          sharedState{std::move(sharedState)}, joinType{joinType},
           flatDataChunkPositions{std::move(flatDataChunkPositions)}, probeDataInfo{probeDataInfo} {}
 
-    PhysicalOperatorType getOperatorType() override { return HASH_JOIN_PROBE; }
+    inline PhysicalOperatorType getOperatorType() override { return HASH_JOIN_PROBE; }
 
     shared_ptr<ResultSet> init(ExecutionContext* context) override;
 
     bool getNextTuples() override;
 
-    // HashJoinProbe do not need to clone hashJoinBuild which is on a different pipeline.
-    unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<HashJoinProbe>(sharedState, flatDataChunkPositions, probeDataInfo,
-            children[0]->clone(), id, paramsString);
+    inline unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<HashJoinProbe>(sharedState, joinType, flatDataChunkPositions,
+            probeDataInfo, children[0]->clone(), id, paramsString);
     }
 
 private:
+    bool hasMoreLeft();
     bool getNextBatchOfMatchedTuples();
-    uint64_t populateResultSet();
+    uint64_t getNextInnerJoinResult();
+    uint64_t getNextLeftJoinResult();
+    void setVectorsToNull(vector<shared_ptr<ValueVector>>& vectors);
+
+    inline uint64_t getNextJoinResult() {
+        return joinType == JoinType::LEFT ? getNextLeftJoinResult() : getNextInnerJoinResult();
+    }
 
 private:
     shared_ptr<HashJoinSharedState> sharedState;
+    JoinType joinType;
     vector<uint64_t> flatDataChunkPositions;
 
     ProbeDataInfo probeDataInfo;
     vector<shared_ptr<ValueVector>> vectorsToReadInto;
     vector<uint32_t> columnIdxsToReadFrom;
-    shared_ptr<ValueVector> probeSideKeyVector;
+    shared_ptr<ValueVector> probeKeyVector;
     unique_ptr<ProbeState> probeState;
 };
+
 } // namespace processor
 } // namespace graphflow

--- a/src/processor/include/physical_plan/operator/physical_operator.h
+++ b/src/processor/include/physical_plan/operator/physical_operator.h
@@ -27,7 +27,6 @@ enum PhysicalOperatorType : uint8_t {
     HASH_JOIN_BUILD,
     HASH_JOIN_PROBE,
     INTERSECT,
-    LEFT_NESTED_LOOP_JOIN,
     LIMIT,
     LIST_EXTEND,
     MULTIPLICITY_REDUCER,
@@ -52,10 +51,10 @@ enum PhysicalOperatorType : uint8_t {
 const string PhysicalOperatorTypeNames[] = {"AGGREGATE", "AGGREGATE_SCAN", "COLUMN_EXTEND",
     "COPY_NODE_CSV", "COPY_REL_CSV", "CREATE", "CREATE_NODE_TABLE", "CREATE_REL_TABLE", "DELETE",
     "DROP_TABLE", "EXISTS", "FACTORIZED_TABLE_SCAN", "FILTER", "FLATTEN", "HASH_JOIN_BUILD",
-    "HASH_JOIN_PROBE", "INTERSECT", "LEFT_NESTED_LOOP_JOIN", "LIMIT", "LIST_EXTEND",
-    "MULTIPLICITY_REDUCER", "PROJECTION", "READ_REL_PROPERTY", "RESULT_COLLECTOR", "RESULT_SCAN",
-    "SCAN_NODE_ID", "SCAN_STRUCTURED_PROPERTY", "SCAN_UNSTRUCTURED_PROPERTY", "SEMI_MASKER", "SET",
-    "SKIP", "ORDER_BY", "ORDER_BY_MERGE", "ORDER_BY_SCAN", "UNION_ALL_SCAN"};
+    "HASH_JOIN_PROBE", "INTERSECT", "LIMIT", "LIST_EXTEND", "MULTIPLICITY_REDUCER", "PROJECTION",
+    "READ_REL_PROPERTY", "RESULT_COLLECTOR", "RESULT_SCAN", "SCAN_NODE_ID",
+    "SCAN_STRUCTURED_PROPERTY", "SCAN_UNSTRUCTURED_PROPERTY", "SEMI_MASKER", "SET", "SKIP",
+    "ORDER_BY", "ORDER_BY_MERGE", "ORDER_BY_SCAN", "UNION_ALL_SCAN"};
 
 struct OperatorMetrics {
 
@@ -72,8 +71,8 @@ class PhysicalOperator {
 
 public:
     // Leaf operator
-    PhysicalOperator(uint32_t id, const string& paramsString)
-        : id{id}, paramsString{paramsString} {}
+    PhysicalOperator(uint32_t id, string paramsString)
+        : id{id}, transaction{nullptr}, paramsString{std::move(paramsString)} {}
     // Unary operator
     PhysicalOperator(unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString);
     // Binary operator

--- a/src/processor/physical_plan/mapper/map_hash_join.cpp
+++ b/src/processor/physical_plan/mapper/map_hash_join.cpp
@@ -48,7 +48,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
         std::move(buildSidePrevOperator), getOperatorID(), paramsString);
     // create hashJoin probe
     auto probeDataInfo = ProbeDataInfo(probeSideKeyIDDataPos, probeSideNonKeyDataPoses);
-    auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState,
+    auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState, hashJoin->getJoinType(),
         hashJoin->getFlatOutputGroupPositions(), probeDataInfo, std::move(probeSidePrevOperator),
         std::move(hashJoinBuild), getOperatorID(), paramsString);
     return hashJoinProbe;

--- a/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/physical_plan/operator/hash_join/hash_join_probe.cpp
@@ -11,8 +11,8 @@ namespace processor {
 shared_ptr<ResultSet> HashJoinProbe::init(ExecutionContext* context) {
     resultSet = PhysicalOperator::init(context);
     probeState = make_unique<ProbeState>();
-    probeSideKeyVector = resultSet->dataChunks[probeDataInfo.getKeyIDDataChunkPos()]
-                             ->valueVectors[probeDataInfo.getKeyIDVectorPos()];
+    probeKeyVector = resultSet->dataChunks[probeDataInfo.getKeyIDDataChunkPos()]
+                         ->valueVectors[probeDataInfo.getKeyIDVectorPos()];
     for (auto pos : flatDataChunkPositions) {
         auto dataChunk = resultSet->dataChunks[pos];
         dataChunk->state = DataChunkState::getSingleValueDataChunkState();
@@ -31,69 +31,92 @@ shared_ptr<ResultSet> HashJoinProbe::init(ExecutionContext* context) {
     return resultSet;
 }
 
+bool HashJoinProbe::hasMoreLeft() {
+    if (probeKeyVector->state->isFlat() &&
+        probeState->probedTuples[probeKeyVector->state->getPositionOfCurrIdx()] != nullptr) {
+        return true;
+    }
+    return false;
+}
+
 bool HashJoinProbe::getNextBatchOfMatchedTuples() {
     if (probeState->nextMatchedTupleIdx < probeState->matchedSelVector->selectedSize) {
         return true;
     }
-    auto keys = (nodeID_t*)probeSideKeyVector->values;
-    do {
-        if (probeState->probeSelVector->selectedSize == 0) {
-            restoreSelVector(probeSideKeyVector->state->selVector.get());
-            if (!children[0]->getNextTuples()) {
-                return false;
-            }
-            saveSelVector(probeSideKeyVector->state->selVector.get());
-            sharedState->getHashTable()->probe(
-                *probeSideKeyVector, probeState->probedTuples.get(), *probeState->probeSelVector);
+    if (!hasMoreLeft()) {
+        restoreSelVector(probeKeyVector->state->selVector.get());
+        if (!children[0]->getNextTuples()) {
+            return false;
         }
-        auto numMatchedTuples = 0;
-        while (true) {
-            if (numMatchedTuples == DEFAULT_VECTOR_CAPACITY ||
-                probeState->probeSelVector->selectedSize == 0) {
+        saveSelVector(probeKeyVector->state->selVector.get());
+        sharedState->getHashTable()->probe(*probeKeyVector, probeState->probedTuples.get());
+    }
+    auto keys = (nodeID_t*)probeKeyVector->values;
+    auto numMatchedTuples = 0;
+    auto startKeyIdx = probeKeyVector->state->isFlat() ? probeKeyVector->state->currIdx : 0;
+    auto numKeys =
+        probeKeyVector->state->isFlat() ? 1 : probeKeyVector->state->selVector->selectedSize;
+    for (auto i = 0u; i < numKeys; i++) {
+        auto pos = probeKeyVector->state->selVector->selectedPositions[i + startKeyIdx];
+        while (probeState->probedTuples[pos]) {
+            if (numMatchedTuples == DEFAULT_VECTOR_CAPACITY) {
                 break;
             }
-            auto numNonNullProbedTuples = 0;
-            for (auto i = 0u; i < probeState->probeSelVector->selectedSize; i++) {
-                auto pos = probeState->probeSelVector->selectedPositions[i];
-                auto currentTuple = probeState->probedTuples[i];
-                probeState->matchedTuples[numMatchedTuples] = currentTuple;
-                probeState->matchedSelVector->selectedPositions[numMatchedTuples] = pos;
-                numMatchedTuples += *(nodeID_t*)currentTuple == keys[pos];
-                probeState->probedTuples[numNonNullProbedTuples] =
-                    *sharedState->getHashTable()->getPrevTuple(currentTuple);
-                probeState->probeSelVector->selectedPositions[numNonNullProbedTuples] = pos;
-                numNonNullProbedTuples +=
-                    probeState->probedTuples[numNonNullProbedTuples] != nullptr;
-            }
-            probeState->probeSelVector->selectedSize = numNonNullProbedTuples;
+            auto currentTuple = probeState->probedTuples[pos];
+            probeState->matchedTuples[numMatchedTuples] = currentTuple;
+            probeState->matchedSelVector->selectedPositions[numMatchedTuples] = pos;
+            numMatchedTuples += *(nodeID_t*)currentTuple == keys[pos];
+            probeState->probedTuples[pos] =
+                *sharedState->getHashTable()->getPrevTuple(currentTuple);
         }
-        probeState->matchedSelVector->selectedSize = numMatchedTuples;
-        probeState->nextMatchedTupleIdx = 0;
-    } while (probeState->matchedSelVector->selectedSize == 0);
+    }
+    probeState->matchedSelVector->selectedSize = numMatchedTuples;
+    probeState->nextMatchedTupleIdx = 0;
     return true;
 }
 
-uint64_t HashJoinProbe::populateResultSet() {
-    // Note: When the probe side is flat, and the build side: a) has no unflat columns; b) has no
-    // payloads in the key data chunk; c) has payloads required to read from hash table, we apply an
-    // optimization to unflat the probe side payloads in the resultSet.
+void HashJoinProbe::setVectorsToNull(vector<shared_ptr<ValueVector>>& vectors) {
+    for (auto& vector : vectorsToReadInto) {
+        if (vector->state->isFlat()) {
+            vector->setNull(vector->state->getPositionOfCurrIdx(), true);
+        } else {
+            assert(vector->state != probeKeyVector->state);
+            auto pos = vector->state->selVector->selectedPositions[0];
+            vector->setNull(pos, true);
+            vector->state->selVector->selectedSize = 1;
+        }
+    }
+}
+
+uint64_t HashJoinProbe::getNextInnerJoinResult() {
+    if (probeState->matchedSelVector->selectedSize == 0) {
+        return 0;
+    }
     auto numTuplesToRead =
-        probeSideKeyVector->state->isFlat() ? 1 : probeState->matchedSelVector->selectedSize;
-    if (!probeSideKeyVector->state->isFlat() &&
-        probeSideKeyVector->state->selVector->selectedSize != numTuplesToRead) {
+        probeKeyVector->state->isFlat() ? 1 : probeState->matchedSelVector->selectedSize;
+    if (!probeKeyVector->state->isFlat() &&
+        probeKeyVector->state->selVector->selectedSize != numTuplesToRead) {
         // Update probeSideKeyVector's selectedPositions when the probe side is unflat and its
         // selected positions need to change (i.e., some keys has no matched tuples).
-        auto keySelectedBuffer = probeSideKeyVector->state->selVector->getSelectedPositionsBuffer();
+        auto keySelectedBuffer = probeKeyVector->state->selVector->getSelectedPositionsBuffer();
         for (auto i = 0u; i < numTuplesToRead; i++) {
             keySelectedBuffer[i] = probeState->matchedSelVector->selectedPositions[i];
         }
-        probeSideKeyVector->state->selVector->selectedSize = numTuplesToRead;
-        probeSideKeyVector->state->selVector->resetSelectorToValuePosBuffer();
+        probeKeyVector->state->selVector->selectedSize = numTuplesToRead;
+        probeKeyVector->state->selVector->resetSelectorToValuePosBuffer();
     }
     sharedState->getHashTable()->lookup(vectorsToReadInto, columnIdxsToReadFrom,
         probeState->matchedTuples.get(), probeState->nextMatchedTupleIdx, numTuplesToRead);
     probeState->nextMatchedTupleIdx += numTuplesToRead;
     return numTuplesToRead;
+}
+
+uint64_t HashJoinProbe::getNextLeftJoinResult() {
+    assert(probeKeyVector->state->isFlat());
+    if (getNextInnerJoinResult() == 0) {
+        setVectorsToNull(vectorsToReadInto);
+    }
+    return 1;
 }
 
 // The general flow of a hash join probe:
@@ -103,18 +126,18 @@ uint64_t HashJoinProbe::populateResultSet() {
 // VectorPtr corresponds to one unFlat build side data chunk that is appended to the resultSet).
 bool HashJoinProbe::getNextTuples() {
     metrics->executionTime.start();
-    if (sharedState->getHashTable()->getNumTuples() == 0) {
-        metrics->executionTime.stop();
-        return false;
-    }
-    if (!getNextBatchOfMatchedTuples()) {
-        metrics->executionTime.stop();
-        return false;
-    }
-    auto numPopulatedTuples = populateResultSet();
-    metrics->executionTime.stop();
+    uint64_t numPopulatedTuples;
+    do {
+        if (!getNextBatchOfMatchedTuples()) {
+            metrics->executionTime.stop();
+            return false;
+        }
+        numPopulatedTuples = getNextJoinResult();
+    } while (numPopulatedTuples == 0);
     metrics->numOutputTuple.increase(numPopulatedTuples);
+    metrics->executionTime.stop();
     return true;
 }
+
 } // namespace processor
 } // namespace graphflow

--- a/test/test_files/tinySNB/optional_match/optional_match.test
+++ b/test/test_files/tinySNB/optional_match/optional_match.test
@@ -22,69 +22,69 @@
 ---- 1
 324
 
-# TODO(Guodong): fix ground truth to be
-# Elizabeth|Farooq
-# Elizabeth|Greg
-# Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
 -NAME OptionalReadStringPropertyTest
 -QUERY MATCH (a:person) WHERE a.fName='Elizabeth' OR a.fName='Hubert Blaine Wolfeschlegelsteinhausenbergerdorff' OPTIONAL MATCH (a)-[:knows]->(b:person) RETURN a.fName, b.fName
 -ENUMERATE
----- 2
+---- 3
 Elizabeth|Farooq
 Elizabeth|Greg
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
 
-#-NAME OptionalReadUnstrPropertyTest
-#-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Elizabeth' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.unstrNumericProp
-#-ENUMERATE
-#---- 2
-#
-#-12.500000
-
-#-NAME OptionalReturnTest
-#-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Alice' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.orgCode
-#-ENUMERATE
-#---- 3
-#
-#
-#325
-
-#-NAME OptionalReturnTest2
-#-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) WHERE b.fName='Farooq' RETURN a.fName, b.fName
-#-ENUMERATE
-#---- 8
-#Alice|
-#Bob|
-#Carol|
-#Dan|
-#Elizabeth|Farooq
-#Farooq|
-#Greg|
-#Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
-
-# TODO(Guodong): fix ground truth to be 17
--NAME OptionalListExtendCountTest
--QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) RETURN COUNT(*)
+-NAME OptionalReadUnstrPropertyTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Elizabeth' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.unstrNumericProp
 -ENUMERATE
----- 1
-14
+---- 2
 
-# TODO(Guodong): fix ground truth to be 40
+-12.500000
+
+-NAME OptionalReturnTest
+-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Alice' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.orgCode
+-ENUMERATE
+---- 3
+
+
+325
+
+-NAME OptionalReturnTest2
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) WHERE b.fName='Farooq' RETURN a.fName, b.fName
+-ENUMERATE
+---- 8
+Alice|
+Bob|
+Carol|
+Dan|
+Elizabeth|Farooq
+Farooq|
+Greg|
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
+
+-NAME OptionalListExtendCountTest
+-QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:studyAt]->(b:organisation) RETURN a.fName, b.name
+-ENUMERATE
+---- 8
+Alice|ABFsUni
+Bob|ABFsUni
+Carol|
+Dan|
+Elizabeth|
+Farooq|ABFsUni
+Greg|
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
+
 -NAME OptionalListExtendTest2
 -QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person)-[:knows]->(c:person) RETURN COUNT(*)
 -ENUMERATE
 ---- 1
-36
+40
 
-# TODO(Guodong): fix ground truth to be 8
 -NAME OptionalColExtendTest
 -QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:workAt]->(b:organisation) RETURN COUNT(*)
 -ENUMERATE
 ---- 1
-3
+8
 
-# TODO(Guodong): fix ground truth to be 41
 -NAME MultipleOptionalCountTest
 -QUERY MATCH (a:person) OPTIONAL MATCH (a)-[:knows]->(b:person) OPTIONAL MATCH (b)-[:knows]->(c:person) RETURN COUNT(*)
 -ENUMERATE
 ---- 1
-36
+41


### PR DESCRIPTION
Add the support of left join in hash join.
Note that we enforce flattening on the probe side key when it comes to left join, as in almost all cases this is true according to our previous rules.