### PR TITLE
Implemented list slice for strings

### DIFF
--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -334,7 +334,8 @@ oC_StringListNullOperatorExpression
     : oC_PropertyOrLabelsExpression ( oC_StringOperatorExpression | oC_ListOperatorExpression | oC_NullOperatorExpression )? ;
 
 oC_ListOperatorExpression
-    : ( SP ? '[' oC_Expression ']' ) ;
+    : ( SP ? '[' oC_Expression ']' )
+        | ( SP ? '[' oC_Expression? ':' oC_Expression? ']' );
 
 oC_StringOperatorExpression
     :  ( ( SP STARTS SP WITH ) | ( SP ENDS SP WITH ) | ( SP CONTAINS ) ) SP? oC_PropertyOrLabelsExpression ;

--- a/src/function/list/operations/include/list_extract_operation.h
+++ b/src/function/list/operations/include/list_extract_operation.h
@@ -48,7 +48,7 @@ public:
             throw RuntimeException("list_extract not implemented for unstructured lists");
         } else {
             throw RuntimeException(
-                "incorrect type given to [] operator. Type must be either LIST or INT");
+                "incorrect type given to [] operator. Type must be either LIST or STRING");
         }
     }
 };

--- a/src/function/list/operations/include/list_slice_operation.h
+++ b/src/function/list/operations/include/list_slice_operation.h
@@ -17,12 +17,43 @@ struct ListSlice {
     // list is 1).
     static inline void operation(gf_list_t& list, int64_t& begin, int64_t& end, gf_list_t& result,
         ValueVector& resultValueVector) {
+        int64_t startIdx = (begin == 0) ? 1 : begin;
+        int64_t endIdx = (end == 0) ? list.size : end;
         auto elementSize = Types::getDataTypeSize(resultValueVector.dataType.childType->typeID);
-        result.size = end - begin;
+        result.size = endIdx - startIdx;
         result.overflowPtr = reinterpret_cast<uint64_t>(
             resultValueVector.getOverflowBuffer().allocateSpace(result.size * elementSize));
         OverflowBufferUtils::copyListRecursiveIfNested(list, result, resultValueVector.dataType,
-            resultValueVector.getOverflowBuffer(), begin - 1, end - 2);
+            resultValueVector.getOverflowBuffer(), startIdx - 1, endIdx - 2);
+    }
+
+    static inline void operation(gf_string_t& str, int64_t& begin, int64_t& end,
+        gf_string_t& result, ValueVector& resultValueVector) {
+        int64_t startIdx = (begin == 0) ? 1 : begin;
+        int64_t endIdx = (end == 0) ? str.len : end;
+        result.len = min(endIdx - startIdx + 1, str.len - startIdx + 1);
+
+        if (!gf_string_t::isShortString(result.len)) {
+            result.overflowPtr = reinterpret_cast<uint64_t>(
+                resultValueVector.getOverflowBuffer().allocateSpace(result.len));
+        }
+        memcpy((uint8_t*)result.getData(), str.getData() + startIdx - 1, result.len);
+        if (!gf_string_t::isShortString(result.len)) {
+            memcpy(result.prefix, result.getData(), gf_string_t::PREFIX_LENGTH);
+        }
+    }
+
+    static inline void operation(
+        Value& item, int64_t& begin, int64_t& end, Value& result, ValueVector& resultValueVector) {
+        if (item.dataType.typeID == STRING) {
+            result.dataType.typeID = STRING;
+            operation(item.val.strVal, begin, end, result.val.strVal, resultValueVector);
+        } else if (item.dataType.typeID == LIST) {
+            throw RuntimeException("list_slice not implemented for unstructured lists");
+        } else {
+            throw RuntimeException(
+                "incorrect type given to [] operator. Type must be either LIST or STRING");
+        }
     }
 };
 

--- a/src/function/list/vector_list_operation.cpp
+++ b/src/function/list/vector_list_operation.cpp
@@ -276,6 +276,14 @@ vector<unique_ptr<VectorOperationDefinition>> ListSliceVectorOperation::getDefin
         vector<DataTypeID>{LIST, INT64, INT64}, LIST,
         TernaryListExecFunction<gf_list_t, int64_t, int64_t, gf_list_t, operation::ListSlice>,
         nullptr, bindFunc, false /* isVarlength*/));
+    result.push_back(make_unique<VectorOperationDefinition>(LIST_SLICE_FUNC_NAME,
+        vector<DataTypeID>{STRING, INT64, INT64}, STRING,
+        TernaryListExecFunction<gf_string_t, int64_t, int64_t, gf_string_t, operation::ListSlice>,
+        false /* isVarlength */));
+    result.push_back(make_unique<VectorOperationDefinition>(LIST_SLICE_FUNC_NAME,
+        vector<DataTypeID>{UNSTRUCTURED, INT64, INT64}, UNSTRUCTURED,
+        TernaryListExecFunction<Value, int64_t, int64_t, Value, operation::ListSlice>,
+        false /* isVarlength */));
     return result;
 }
 

--- a/test/test_files/tinySNB/function/list.test
+++ b/test/test_files/tinySNB/function/list.test
@@ -627,6 +627,51 @@ True
 [[10]]
 [[7]]
 
+-NAME ListSliceStructuredString
+-QUERY MATCH (o:organisation) RETURN o.name[1:4]
+---- 3
+ABFs
+CsWo
+DEsW
+
+-NAME ListSliceUnstructuredString
+-QUERY MATCH (o:organisation) RETURN o.unstrStr[5:8]
+---- 3
+RfEC
+cELL
+ org
+
+-NAME ListSliceStructuredStringRight
+-QUERY MATCH (a:person) RETURN a.fName[4:]
+---- 8
+ce
+
+ol
+
+zabeth
+ooq
+g
+ert Blaine Wolfeschlegelsteinhausenbergerdorff
+
+-NAME ListSliceStructuredStringLeft
+-QUERY MATCH (a:person) RETURN a.fName[:5]
+---- 8
+Alice
+Bob
+Carol
+Dan
+Eliza
+Faroo
+Greg
+Huber
+
+-NAME ListSliceStructuredStringNull
+-QUERY MATCH (o:organisation) RETURN o.name[:]
+---- 3
+ABFsUni
+CsWork
+DEsWork
+
 # TODO(Xiyang): this is most likely a list executor bug
 #-NAME ListCreate2
 #-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN [a.age, b.age]


### PR DESCRIPTION
- Added a new rule to the grammar to be able to recognize [x:y] syntax. 
- Implemented the list slicing operation for both structured and unstructured strings. 
- Modified transformer to be able to use the syntax [x:], [:x], and [:]. 
- Finally, added some tests for string slicing.
This is the last feature required for issue #538 