### PR TITLE
move CI to self-hosted machine, and fix build errors on ubuntu22

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -7,67 +7,56 @@ on:
   push:
     branches:
       - master
-env:
-  USE_BAZEL_VERSION: 4.1.0
 
 jobs:
   gcc-build-test:
     name: gcc build & test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-testing
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt update && sudo apt install -y python3-pip
       - run: pip install -r tools/python_api/requirements_dev.txt
 
-      - name: bazel-info
-        run: bazel info
-
       - name: build
-        run: CC=gcc-9 bazel build --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
+        run: CC=gcc-11 bazel build --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
 
       - name: test
-        run: CC=gcc-9 bazel test --test_output=errors --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
+        run: CC=gcc-11 bazel test --test_output=errors --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
 
   clang-build-test:
     name: clang build & test
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-testing
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt update && sudo apt install -y python3-pip
       - run: pip install -r tools/python_api/requirements_dev.txt
 
-      - name: bazel-info
-        run: bazel info
-
       - name: build
-        run: CC=clang-10 bazel build --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
+        run: CC=clang-14 bazel build --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
 
       - name: test
-        run: CC=clang-10 bazel test --test_output=errors --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
+        run: CC=clang-14 bazel test --test_output=errors --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all
 
   clang-formatting-check:
     name: clang-formatting-check
-    runs-on: ubuntu-latest
+    runs-on: self-hosted-testing
     steps:
       - uses: actions/checkout@v2
       - uses: actions/checkout@v2
         with:
           repository: Sarcasm/run-clang-format
           path: run-clang-format
-      - run: sudo apt update && sudo apt install -y clang-format-10
-      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format-10 -r src/
-      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format-10 -r test/
+      - run: sudo apt install -y clang-format-11
+      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format-11 -r src/
+      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format-11 -r test/
 
   benchmark:
     name: benchmark
-    runs-on: self-hosted
+    runs-on: self-hosted-himrod
     steps:
       - uses: actions/checkout@v2
       - run: sudo apt install -y python3-pip && sudo apt install -y sqlite3
       - run: pip3 install -r tools/python_api/requirements_dev.txt
-
-      - name: bazel-info
-        run: bazel info
 
       - name: build
         run: CC=gcc-9 bazel build --cxxopt='-std=c++2a' --cxxopt='-O3' //...:all

--- a/src/common/include/utils.h
+++ b/src/common/include/utils.h
@@ -2,6 +2,7 @@
 
 #include <cassert>
 #include <cstring>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <thread>

--- a/src/storage/buffer_manager/include/file_handle.h
+++ b/src/storage/buffer_manager/include/file_handle.h
@@ -2,6 +2,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <vector>
 

--- a/src/storage/storage_structure/in_mem_file.cpp
+++ b/src/storage/storage_structure/in_mem_file.cpp
@@ -1,5 +1,7 @@
 #include "src/storage/storage_structure/include/in_mem_file.h"
 
+#include <mutex>
+
 #include "src/common/include/type_utils.h"
 
 namespace graphflow {


### PR DESCRIPTION
1. This PR fixes a build issue on ubuntu 22.04 as reported here: #750 
2. Moves the gcc/clang/clang-format-check CI to use our own machine