### PR TITLE
Add multithread support and configurable buffer size for Python API

### DIFF
--- a/tools/python_api/include/py_connection.h
+++ b/tools/python_api/include/py_connection.h
@@ -8,11 +8,13 @@ class PyConnection {
 public:
     static void initialize(py::handle& m);
 
-    explicit PyConnection(PyDatabase* pyDatabase);
+    explicit PyConnection(PyDatabase* pyDatabase, uint64_t numThreads);
 
     ~PyConnection() = default;
 
     unique_ptr<PyQueryResult> execute(const string& query, py::list params);
+
+    void setMaxNumThreadForExec(uint64_t numThreads);
 
 private:
     unordered_map<string, shared_ptr<Literal>> transformPythonParameters(py::list params);

--- a/tools/python_api/include/py_database.h
+++ b/tools/python_api/include/py_database.h
@@ -12,7 +12,10 @@ class PyDatabase {
 public:
     static void initialize(py::handle& m);
 
-    explicit PyDatabase(const string& databasePath);
+    explicit PyDatabase(const string& databasePath, uint64_t defaultPageBufferPoolSize,
+        uint64_t largePageBufferPoolSize);
+
+    void resizeBufferManager(uint64_t newSize);
 
     ~PyDatabase() = default;
 

--- a/tools/python_api/py_database.cpp
+++ b/tools/python_api/py_database.cpp
@@ -1,9 +1,25 @@
 #include "include/py_database.h"
 
 void PyDatabase::initialize(py::handle& m) {
-    py::class_<PyDatabase>(m, "database").def(py::init<const string&>());
+    py::class_<PyDatabase>(m, "database")
+        .def(py::init<const string&, uint64_t, uint64_t>(), py::arg("database_path"),
+            py::arg("default_page_buffer_pool_size") = 0,
+            py::arg("large_page_buffer_pool_size") = 0)
+        .def("resize_buffer_manager", &PyDatabase::resizeBufferManager, py::arg("new_size"));
 }
 
-PyDatabase::PyDatabase(const string& databasePath) {
-    database = make_unique<Database>(DatabaseConfig(databasePath), SystemConfig());
+PyDatabase::PyDatabase(const string& databasePath, uint64_t defaultPageBufferPoolSize,
+    uint64_t largePageBufferPoolSize) {
+    auto systemConfig = SystemConfig();
+    if (defaultPageBufferPoolSize > 0) {
+        systemConfig.defaultPageBufferPoolSize = defaultPageBufferPoolSize;
+    }
+    if (largePageBufferPoolSize > 0) {
+        systemConfig.largePageBufferPoolSize = largePageBufferPoolSize;
+    }
+    database = make_unique<Database>(DatabaseConfig(databasePath), systemConfig);
+}
+
+void PyDatabase::resizeBufferManager(uint64_t newSize) {
+    database->resizeBufferManager(newSize);
 }

--- a/tools/python_api/test/conftest.py
+++ b/tools/python_api/test/conftest.py
@@ -23,6 +23,7 @@ def init_tiny_snb(tmp_path):
 
 @pytest.fixture
 def establish_connection(init_tiny_snb):
-    db = gdb.database(init_tiny_snb)
-    conn = gdb.connection(db)
+    db = gdb.database(init_tiny_snb, default_page_buffer_pool_size=128 *
+                      1024 * 1024, large_page_buffer_pool_size=128 * 1024 * 1024)
+    conn = gdb.connection(db, num_threads=4)
     return conn, db

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -5,52 +5,69 @@ from pandas import Timestamp, Timedelta, isna
 
 def test_to_df(establish_connection):
     conn, db = establish_connection
-    query = "MATCH (p:person) return *"
-    pd = conn.execute(query).getAsDF()
-    assert pd['p.ID'].tolist() == [0, 2, 3, 5, 7, 8, 9, 10]
-    assert str(pd['p.ID'].dtype) == "int64"
-    assert pd['p.fName'].tolist() == ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
-                                      "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
-    assert str(pd['p.fName'].dtype) == "object"
-    assert pd['p.gender'].tolist() == [1, 2, 1, 2, 1, 2, 2, 2]
-    assert str(pd['p.gender'].dtype) == "int64"
-    assert pd['p.isStudent'].tolist() == [True, True, False, False, False, True, False, False]
-    assert str(pd['p.isStudent'].dtype) == "bool"
-    assert pd['p.eyeSight'].tolist() == [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9]
-    assert str(pd['p.eyeSight'].dtype) == "float64"
-    assert pd['p.birthdate'].tolist() == [Timestamp('1900-01-01'), Timestamp('1900-01-01'),
-                                          Timestamp('1940-06-22'), Timestamp('1950-07-23 '),
-                                          Timestamp('1980-10-26'), Timestamp('1980-10-26'),
-                                          Timestamp('1980-10-26'), Timestamp('1990-11-27')]
-    assert str(pd['p.birthdate'].dtype) == "datetime64[ns]"
-    assert pd['p.registerTime'].tolist() == [Timestamp('2011-08-20 11:25:30'), Timestamp('2008-11-03 15:25:30.000526'),
-                                             Timestamp('1911-08-20 02:32:21'), Timestamp('2031-11-30 12:25:30'),
-                                             Timestamp('1976-12-23 11:21:42'), Timestamp('1972-07-31 13:22:30.678559'),
-                                             Timestamp('1976-12-23 04:41:42'), Timestamp('2023-02-21 13:25:30')]
-    assert str(pd['p.registerTime'].dtype) == "datetime64[ns]"
-    assert pd['p.lastJobDuration'].tolist() == [Timedelta('1082 days 13:02:00'), Timedelta('3750 days 13:00:00.000024'),
-                                                Timedelta('2 days 00:24:11'), Timedelta('3750 days 13:00:00.000024'),
-                                                Timedelta('2 days 00:24:11'), Timedelta('0 days 00:18:00.024000'),
-                                                Timedelta('3750 days 13:00:00.000024'), Timedelta('1082 days 13:02:00')]
-    assert str(pd['p.lastJobDuration'].dtype) == "timedelta64[ns]"
-    assert pd['p.workedHours'].tolist() == [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
-                                            [10, 11, 12, 3, 4, 5, 6, 7]]
-    assert str(pd['p.workedHours'].dtype) == "object"
-    assert pd['p.workedHours'].tolist() == [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
-                                            [10, 11, 12, 3, 4, 5, 6, 7]]
-    assert str(pd['p.workedHours'].dtype) == "object"
-    assert pd['p.usedNames'].tolist() == [["Aida"], ['Bobby'], ['Carmen', 'Fred'],
-                                          ['Wolfeschlegelstein', 'Daniel'], ['Ein'], ['Fesdwe'], ['Grad'],
-                                          ['Ad', 'De', 'Hi', 'Kye', 'Orlan']]
-    assert str(pd['p.usedNames'].dtype) == "object"
-    assert pd['p.courseScoresPerTerm'].tolist() == [[[10, 8], [6, 7, 8]], [[8, 9], [9, 10]], [[8, 10]],
-                                                    [[7, 4], [8, 8], [9]], [[6], [7], [8]], [[8]], [[10]],
-                                                    [[7], [10], [6, 7]]]
-    assert str(pd['p.courseScoresPerTerm'].dtype) == "object"
-    unstrProp = pd['p.unstrNumericProp'].tolist()
-    assert (isna(unstrProp[0]) and isna(unstrProp[3]) and isna(unstrProp[5]) and isna(unstrProp[6]) and isna(
-        unstrProp[7]))
-    assert unstrProp[1] == '47'
-    assert unstrProp[2] == '52'
-    assert unstrProp[4] == '68.000000'
-    assert str(pd['p.unstrNumericProp'].dtype) == "object"
+
+    def _test_to_df(conn):
+        query = "MATCH (p:person) return * ORDER BY p.ID"
+        pd = conn.execute(query).getAsDF()
+        assert pd['p.ID'].tolist() == [0, 2, 3, 5, 7, 8, 9, 10]
+        assert str(pd['p.ID'].dtype) == "int64"
+        assert pd['p.fName'].tolist() == ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
+                                        "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
+        assert str(pd['p.fName'].dtype) == "object"
+        assert pd['p.gender'].tolist() == [1, 2, 1, 2, 1, 2, 2, 2]
+        assert str(pd['p.gender'].dtype) == "int64"
+        assert pd['p.isStudent'].tolist() == [True, True, False, False, False, True, False, False]
+        assert str(pd['p.isStudent'].dtype) == "bool"
+        assert pd['p.eyeSight'].tolist() == [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9]
+        assert str(pd['p.eyeSight'].dtype) == "float64"
+        assert pd['p.birthdate'].tolist() == [Timestamp('1900-01-01'), Timestamp('1900-01-01'),
+                                            Timestamp('1940-06-22'), Timestamp('1950-07-23 '),
+                                            Timestamp('1980-10-26'), Timestamp('1980-10-26'),
+                                            Timestamp('1980-10-26'), Timestamp('1990-11-27')]
+        assert str(pd['p.birthdate'].dtype) == "datetime64[ns]"
+        assert pd['p.registerTime'].tolist() == [Timestamp('2011-08-20 11:25:30'), Timestamp('2008-11-03 15:25:30.000526'),
+                                                Timestamp('1911-08-20 02:32:21'), Timestamp('2031-11-30 12:25:30'),
+                                                Timestamp('1976-12-23 11:21:42'), Timestamp('1972-07-31 13:22:30.678559'),
+                                                Timestamp('1976-12-23 04:41:42'), Timestamp('2023-02-21 13:25:30')]
+        assert str(pd['p.registerTime'].dtype) == "datetime64[ns]"
+        assert pd['p.lastJobDuration'].tolist() == [Timedelta('1082 days 13:02:00'), Timedelta('3750 days 13:00:00.000024'),
+                                                    Timedelta('2 days 00:24:11'), Timedelta('3750 days 13:00:00.000024'),
+                                                    Timedelta('2 days 00:24:11'), Timedelta('0 days 00:18:00.024000'),
+                                                    Timedelta('3750 days 13:00:00.000024'), Timedelta('1082 days 13:02:00')]
+        assert str(pd['p.lastJobDuration'].dtype) == "timedelta64[ns]"
+        assert pd['p.workedHours'].tolist() == [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
+                                                [10, 11, 12, 3, 4, 5, 6, 7]]
+        assert str(pd['p.workedHours'].dtype) == "object"
+        assert pd['p.workedHours'].tolist() == [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
+                                                [10, 11, 12, 3, 4, 5, 6, 7]]
+        assert str(pd['p.workedHours'].dtype) == "object"
+        assert pd['p.usedNames'].tolist() == [["Aida"], ['Bobby'], ['Carmen', 'Fred'],
+                                            ['Wolfeschlegelstein', 'Daniel'], ['Ein'], ['Fesdwe'], ['Grad'],
+                                            ['Ad', 'De', 'Hi', 'Kye', 'Orlan']]
+        assert str(pd['p.usedNames'].dtype) == "object"
+        assert pd['p.courseScoresPerTerm'].tolist() == [[[10, 8], [6, 7, 8]], [[8, 9], [9, 10]], [[8, 10]],
+                                                        [[7, 4], [8, 8], [9]], [[6], [7], [8]], [[8]], [[10]],
+                                                        [[7], [10], [6, 7]]]
+        assert str(pd['p.courseScoresPerTerm'].dtype) == "object"
+        unstrProp = pd['p.unstrNumericProp'].tolist()
+        assert (isna(unstrProp[0]) and isna(unstrProp[3]) and isna(unstrProp[5]) and isna(unstrProp[6]) and isna(
+            unstrProp[7]))
+        assert unstrProp[1] == '47'
+        assert unstrProp[2] == '52'
+        assert unstrProp[4] == '68.000000'
+        assert str(pd['p.unstrNumericProp'].dtype) == "object"
+    
+    _test_to_df(conn)
+
+    conn.set_max_threads_for_exec(2)
+    _test_to_df(conn)
+
+    conn.set_max_threads_for_exec(1)
+    _test_to_df(conn)
+
+    db.resize_buffer_manager(384 * 1024 * 1024)
+    _test_to_df(conn)
+
+    db.resize_buffer_manager(512 * 1024 * 1024)
+    conn.set_max_threads_for_exec(4)
+    _test_to_df(conn)

--- a/tools/python_api/test/test_exception.py
+++ b/tools/python_api/test/test_exception.py
@@ -12,3 +12,6 @@ def test_exception(establish_connection):
 
     with pytest.raises(RuntimeError, match="Runtime exception: Cannot abs `INTERVAL`"):
         conn.execute("MATCH (a:person) RETURN abs(a.unstrIntervalProp);")
+    
+    with pytest.raises(RuntimeError, match="Buffer manager exception: Resizing to a smaller Buffer Pool Size is unsupported!"):
+        db.resize_buffer_manager(1)


### PR DESCRIPTION
This PR adds multi-threaded execution for Python API by releasing the GLI on query execution and also exposing the buffer pool size and number of threads configurations to the Python API. The config parameters are made optional (i.e. `gdb.database(database_dir)`, `gdb.database(database_dir, num_threads=4)`, and ` gdb.database(databaseDir, num_threads=8, default_page_buffer_pool_size=10000000)` all works in Python). Some manual performance tests are done over the `person_knows_person_100` with the query `MATCH (p:PERSON) RETURN MIN(p.ID);` to validate the performance improvement with this change:

| Threads | Time   |
|---------|--------|
| 1       | 0.0135 |
| 2       | 0.0075 |
| 4       | 0.0052 |
| 8       | 0.0037 |

Also, the single-threaded tests are duplicated and configured to run with multi-threading and 128 MB buffer pool size.