### PR TITLE
Implemented CLI completion for node tables and rel tables

### DIFF
--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -28,6 +28,8 @@ private:
 
     void printExecutionResult(QueryResult& queryResult) const;
 
+    void updateTableNames();
+
 private:
     unique_ptr<Database> database;
     unique_ptr<Connection> conn;


### PR DESCRIPTION
Now, when writing a query: 
`MATCH (o:`
Pressing <TAB> will give suggestions such as:
`MATCH (o:organisation)`
`MATCH (o:person)`
Depending on which node tables and rel tables exist in the system. 

This is related to issue https://github.com/graphflowdb/graphflowdb/issues/433 