### PR TITLE
fixed slow copy to shell issue

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -107,6 +107,7 @@
 
 #include <ctype.h>
 #include <errno.h>
+#include <poll.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -696,7 +697,13 @@ int linenoiseEditInsert(struct linenoiseState* l, char c) {
                 if (write(l->ofd, &d, 1) == -1)
                     return -1;
             } else {
-                refreshLine(l);
+                struct pollfd fd {
+                    l->ifd, POLLIN, 0
+                };
+                int pastedInput = poll(&fd, 1, 0);
+                if (pastedInput == 0) {
+                    refreshLine(l);
+                }
             }
         } else {
             memmove(l->buf + l->pos + 1, l->buf + l->pos, l->len - l->pos);
@@ -1020,10 +1027,6 @@ static int linenoiseEdit(
                 }
             }
             break;
-        default:
-            if (linenoiseEditInsert(&l, c))
-                return -1;
-            break;
         case CTRL_U: /* Ctrl+u, delete the whole line. */
             buf[0] = '\0';
             l.pos = l.len = 0;
@@ -1047,8 +1050,11 @@ static int linenoiseEdit(
         case CTRL_W: /* ctrl+w, delete previous word */
             linenoiseEditDeletePrevWord(&l);
             break;
+        default:
+            if (linenoiseEditInsert(&l, c))
+                return -1;
+            break;
         }
-        refreshLine(&l);
     }
     return l.len;
 }


### PR DESCRIPTION
Fixed slow copying to shell, from issue https://github.com/graphflowdb/graphflowdb/issues/433 

- Stopped the line from being refreshed at every character input. 
- Detect if there is more than one character input from stdin (i.e. multiple characters have been pasted), and stopped line refresh in that case. 