### PR TITLE
solve issue 620, add safer expression handling in planner

### DIFF
--- a/src/planner/include/enumerator.h
+++ b/src/planner/include/enumerator.h
@@ -67,8 +67,9 @@ private:
     static void appendFlattenIfNecessary(
         const shared_ptr<Expression>& expression, LogicalPlan& plan);
     static inline void appendFlattenIfNecessary(uint32_t groupPos, LogicalPlan& plan) {
-        auto expression = plan.getSchema()->getGroup(groupPos)->getFirstExpression();
-        appendFlattenIfNecessary(expression, plan);
+        auto expressions = plan.getSchema()->getExpressionsInScope(groupPos);
+        assert(!expressions.empty());
+        appendFlattenIfNecessary(expressions[0], plan);
     }
 
     void appendFilter(const shared_ptr<Expression>& expression, LogicalPlan& plan);

--- a/src/planner/join_order_enumerator.cpp
+++ b/src/planner/join_order_enumerator.cpp
@@ -184,7 +184,7 @@ void JoinOrderEnumerator::planWCOJoin(uint32_t leftLevel, uint32_t rightLevel) {
     }
 }
 
-// TODO: explain
+// As a heuristic for wcoj, we always pick rel scan that starts from the bound node.
 static unique_ptr<LogicalPlan> getWCOJBuildPlanForRel(
     vector<unique_ptr<LogicalPlan>>& candidatePlans, const NodeExpression& boundNode) {
     unique_ptr<LogicalPlan> result;

--- a/src/planner/logical_plan/logical_operator/include/schema.h
+++ b/src/planner/logical_plan/logical_operator/include/schema.h
@@ -28,10 +28,6 @@ public:
     inline void insertExpression(const shared_ptr<Expression>& expression) {
         expressions.push_back(expression);
     }
-    inline shared_ptr<Expression> getFirstExpression() const {
-        assert(!expressions.empty());
-        return expressions[0];
-    }
     inline expression_vector getExpressions() const { return expressions; }
 
 private:
@@ -56,11 +52,20 @@ public:
 
     uint32_t createGroup();
 
+    void insertToScope(const shared_ptr<Expression>& expression, uint32_t groupPos);
+
     void insertToGroupAndScope(const shared_ptr<Expression>& expression, uint32_t groupPos);
 
     void insertToGroupAndScope(const expression_vector& expressions, uint32_t groupPos);
 
-    uint32_t getGroupPos(const string& expressionName) const;
+    inline uint32_t getGroupPos(const Expression& expression) {
+        return getGroupPos(expression.getUniqueName());
+    }
+
+    inline uint32_t getGroupPos(const string& expressionName) const {
+        assert(expressionNameToGroupPos.contains(expressionName));
+        return expressionNameToGroupPos.at(expressionName);
+    }
 
     inline void flattenGroup(uint32_t pos) { groups[pos]->isFlat = true; }
 
@@ -74,7 +79,10 @@ public:
 
     unordered_set<uint32_t> getDependentGroupsPos(const shared_ptr<Expression>& expression);
 
-    inline void clearExpressionsInScope() { expressionsInScope.clear(); }
+    inline void clearExpressionsInScope() {
+        expressionNameToGroupPos.clear();
+        expressionsInScope.clear();
+    }
 
     // Get the group positions containing at least one expression in scope.
     unordered_set<uint32_t> getGroupsPosInScope() const;

--- a/src/planner/logical_plan/logical_operator/schema.cpp
+++ b/src/planner/logical_plan/logical_operator/schema.cpp
@@ -9,7 +9,14 @@ uint32_t Schema::createGroup() {
     return pos;
 }
 
+void Schema::insertToScope(const shared_ptr<Expression>& expression, uint32_t groupPos) {
+    assert(!expressionNameToGroupPos.contains(expression->getUniqueName()));
+    expressionNameToGroupPos.insert({expression->getUniqueName(), groupPos});
+    expressionsInScope.push_back(expression);
+}
+
 void Schema::insertToGroupAndScope(const shared_ptr<Expression>& expression, uint32_t groupPos) {
+    assert(!expressionNameToGroupPos.contains(expression->getUniqueName()));
     expressionNameToGroupPos.insert({expression->getUniqueName(), groupPos});
     groups[groupPos]->insertExpression(expression);
     expressionsInScope.push_back(expression);
@@ -19,11 +26,6 @@ void Schema::insertToGroupAndScope(const expression_vector& expressions, uint32_
     for (auto& expression : expressions) {
         insertToGroupAndScope(expression, groupPos);
     }
-}
-
-uint32_t Schema::getGroupPos(const string& expressionName) const {
-    assert(expressionNameToGroupPos.contains(expressionName));
-    return expressionNameToGroupPos.at(expressionName);
 }
 
 bool Schema::isExpressionInScope(const Expression& expression) const {
@@ -87,7 +89,6 @@ unique_ptr<Schema> Schema::copy() const {
 
 void Schema::clear() {
     groups.clear();
-    expressionNameToGroupPos.clear();
     clearExpressionsInScope();
 }
 

--- a/test/test_files/tinySNB/agg/multi_query_part.test
+++ b/test/test_files/tinySNB/agg/multi_query_part.test
@@ -7,3 +7,8 @@ False
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') WITH AVG(a.age) AS avgAge, AVG(a.eyeSight) AS avgEyeSight RETURN avgAge > avgEyeSight
 ---- 1
 True
+
+-NAME SimpleCountMultiQueryTest2
+-QUERY MATCH (p:person) WITH p AS f RETURN COUNT(f);
+---- 1
+8

--- a/test/test_files/tinySNB/agg/simple.test
+++ b/test/test_files/tinySNB/agg/simple.test
@@ -8,6 +8,11 @@
 ---- 1
 9|6.000000
 
+-NAME SimpleCountTest2
+-QUERY MATCH (a:person)-[e1:knows]->(:person) RETURN COUNT(e1)
+---- 1
+14
+
 -NAME SimpleSumTest
 -QUERY MATCH (a:person) RETURN SUM(a.age), SUM(a.eyeSight), SUM(a.unstrNumericProp)
 ---- 1


### PR DESCRIPTION
This PR solves issue #620 by adding binding logic for aggregate on node/rel variables. We rewrite aggregate on node/rel variables as aggregate on their ID properties.

This PR also adds more strict schema changing constraint. Any expression gets inserted into the schema must first validate it is not already in the scope.