### PR TITLE
Truncate string with size > 4096 for CSV copier

### DIFF
--- a/src/common/include/csv_reader/csv_reader.h
+++ b/src/common/include/csv_reader/csv_reader.h
@@ -8,6 +8,10 @@
 
 using namespace std;
 
+namespace spdlog {
+class logger;
+}
+
 namespace graphflow {
 namespace common {
 
@@ -85,6 +89,7 @@ private:
 private:
     FILE* fd;
     const CSVReaderConfig& config;
+    shared_ptr<spdlog::logger> logger;
     bool nextLineIsNotProcessed, isEndOfBlock, nextTokenIsNotProcessed;
     char* line;
     size_t lineCapacity, lineLen;

--- a/test/copy_csv/copy_csv_fault_test.cpp
+++ b/test/copy_csv/copy_csv_fault_test.cpp
@@ -20,10 +20,6 @@ public:
     }
 };
 
-class CopyCSVLongStringTest : public CopyCSVFaultTest {
-    string getInputCSVDir() override { return "dataset/copy-csv-fault-tests/long-string/"; }
-};
-
 class CopyCSVDuplicateIDTest : public CopyCSVFaultTest {
     string getInputCSVDir() override { return "dataset/copy-csv-fault-tests/duplicate-ids/"; }
 };
@@ -31,13 +27,6 @@ class CopyCSVDuplicateIDTest : public CopyCSVFaultTest {
 class CopyNodeCSVUnmatchedColumnTypeTest : public CopyCSVFaultTest {
     string getInputCSVDir() override { return "dataset/copy-csv-fault-tests/long-string/"; }
 };
-
-TEST_F(CopyCSVLongStringTest, LongStringError) {
-    ASSERT_EQ(getCopyCSVException(),
-        "Failed to execute statement: COPY person FROM "
-        "\"dataset/copy-csv-fault-tests/long-string/vPerson.csv\".\nError: CSVReader "
-        "exception: Maximum length of strings is 4096. Input string's length is 5625.");
-}
 
 TEST_F(CopyCSVDuplicateIDTest, DuplicateIDsError) {
     ASSERT_EQ(getCopyCSVException(),


### PR DESCRIPTION
This PR truncates the string with length > 4096 and shows a warning in the log for CSV copier (instead of failing with exception) as requested in #504.