### PR TITLE
Add the support of mark join type in hash join

### DIFF
--- a/src/planner/include/join_order_enumerator.h
+++ b/src/planner/include/join_order_enumerator.h
@@ -107,7 +107,7 @@ private:
     static void appendHashJoin(const vector<shared_ptr<NodeExpression>>& joinNodes,
         JoinType joinType, bool isProbeAcc, LogicalPlan& probePlan, LogicalPlan& buildPlan);
     static void appendMarkJoin(const vector<shared_ptr<NodeExpression>>& joinNodes,
-        shared_ptr<Expression>& mark, LogicalPlan& probePlan, LogicalPlan& buildPlan);
+        const shared_ptr<Expression>& mark, LogicalPlan& probePlan, LogicalPlan& buildPlan);
     static void appendIntersect(const shared_ptr<NodeExpression>& intersectNode,
         vector<shared_ptr<NodeExpression>>& boundNodes, LogicalPlan& probePlan,
         vector<unique_ptr<LogicalPlan>>& buildPlans);

--- a/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_hash_join.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "base_logical_operator.h"
 #include "schema.h"
 
@@ -62,7 +64,7 @@ public:
     inline JoinType getJoinType() const { return joinType; }
 
     inline shared_ptr<Expression> getMark() const {
-        assert(joinType == JoinType::MARK);
+        assert(joinType == JoinType::MARK && mark);
         return mark;
     }
     inline bool getIsProbeAcc() const { return isProbeAcc; }
@@ -70,7 +72,7 @@ public:
     inline vector<uint64_t> getFlatOutputGroupPositions() const { return flatOutputGroupPositions; }
 
     inline unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalHashJoin>(joinNodes, joinType, isProbeAcc,
+        return make_unique<LogicalHashJoin>(joinNodes, joinType, mark, isProbeAcc,
             buildSideSchema->copy(), flatOutputGroupPositions, expressionsToMaterialize,
             children[0]->copy(), children[1]->copy());
     }

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_build.h
@@ -81,7 +81,6 @@ private:
 
 private:
     shared_ptr<HashJoinSharedState> sharedState;
-
     BuildDataInfo buildDataInfo;
     vector<shared_ptr<ValueVector>> vectorsToAppend;
     unique_ptr<JoinHashTable> hashTable;

--- a/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
+++ b/src/processor/include/physical_plan/operator/hash_join/hash_join_probe.h
@@ -30,15 +30,19 @@ struct ProbeDataInfo {
 
 public:
     ProbeDataInfo(vector<DataPos> keysDataPos, vector<DataPos> payloadsOutputDataPos)
-        : keysDataPos{std::move(keysDataPos)}, payloadsOutputDataPos{
-                                                   std::move(payloadsOutputDataPos)} {}
+        : keysDataPos{std::move(keysDataPos)},
+          payloadsOutputDataPos{std::move(payloadsOutputDataPos)}, markDataPos{
+                                                                       UINT32_MAX, UINT32_MAX} {}
 
     ProbeDataInfo(const ProbeDataInfo& other)
-        : ProbeDataInfo{other.keysDataPos, other.payloadsOutputDataPos} {}
+        : ProbeDataInfo{other.keysDataPos, other.payloadsOutputDataPos} {
+        markDataPos = other.markDataPos;
+    }
 
 public:
     vector<DataPos> keysDataPos;
     vector<DataPos> payloadsOutputDataPos;
+    DataPos markDataPos;
 };
 
 // Probe side on left, i.e. children[0] and build side on right, i.e. children[1]
@@ -79,11 +83,10 @@ private:
     bool getNextBatchOfMatchedTuples();
     uint64_t getNextInnerJoinResult();
     uint64_t getNextLeftJoinResult();
+    uint64_t getNextMarkJoinResult();
     void setVectorsToNull(vector<shared_ptr<ValueVector>>& vectors);
 
-    inline uint64_t getNextJoinResult() {
-        return joinType == JoinType::LEFT ? getNextLeftJoinResult() : getNextInnerJoinResult();
-    }
+    uint64_t getNextJoinResult();
 
 private:
     shared_ptr<HashJoinSharedState> sharedState;
@@ -95,6 +98,7 @@ private:
     vector<uint32_t> columnIdxsToReadFrom;
     vector<shared_ptr<ValueVector>> keyVectors;
     vector<SelectionVector*> keySelVectors;
+    shared_ptr<ValueVector> markVector;
     unique_ptr<ProbeState> probeState;
 };
 

--- a/test/test_files/tinySNB/subquery/exists.test
+++ b/test/test_files/tinySNB/subquery/exists.test
@@ -1,20 +1,20 @@
-#-NAME ExistSubqueryTest
-#-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) } RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#5
+-NAME ExistSubqueryTest
+-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) } RETURN COUNT(*)
+-ENUMERATE
+---- 1
+5
 
-#-NAME ExistSubqueryTest2
-#-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE b.fName='Farooq' } RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#1
+-NAME ExistSubqueryTest2
+-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE b.fName='Farooq' } RETURN COUNT(*)
+-ENUMERATE
+---- 1
+1
 
-#-NAME ExistSubqueryTest3
-#-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE EXISTS { MATCH (a)-[:studyAt]->(c:organisation) } OR b.fName='Greg'  RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#7
+-NAME ExistSubqueryTest3
+-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE EXISTS { MATCH (a)-[:studyAt]->(c:organisation) } OR b.fName='Greg'  RETURN COUNT(*)
+-ENUMERATE
+---- 1
+7
 
 #-NAME ExistSubqueryTest4
 #-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE a.fName='Alice' } RETURN COUNT(*)
@@ -28,11 +28,11 @@
 #---- 1
 #4
 
-#-NAME NotExistSubqueryTest
-#-QUERY MATCH (a:person) WHERE NOT EXISTS { MATCH (a)-[:knows]->(b:person) } RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#3
+-NAME NotExistSubqueryTest
+-QUERY MATCH (a:person) WHERE NOT EXISTS { MATCH (a)-[:knows]->(b:person) } RETURN COUNT(*)
+-ENUMERATE
+---- 1
+3
 
 #-NAME ExistSubqueryMultiPartCyclicTest
 #-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person), (b)-[:knows]->(a) } RETURN COUNT(*)
@@ -40,23 +40,23 @@
 #---- 1
 #4
 
-#-NAME ExistsSubqueryColExtendTest
-#-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:studyAt]->(b:organisation) } RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#3
+-NAME ExistsSubqueryColExtendTest
+-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:studyAt]->(b:organisation) } RETURN COUNT(*)
+-ENUMERATE
+---- 1
+3
 
-#-NAME ExistsSubqueryORTest
-#-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:studyAt]->(b:organisation) } OR EXISTS { MATCH (a)-[:workAt]->(c:organisation) } RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#6
+-NAME ExistsSubqueryORTest
+-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:studyAt]->(b:organisation) } OR EXISTS { MATCH (a)-[:workAt]->(c:organisation) } RETURN COUNT(*)
+-ENUMERATE
+---- 1
+6
 
-#-NAME NestedSubqueryTest
-#-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE EXISTS { MATCH (b)-[:workAt]->(c:organisation) } } RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#4
+-NAME NestedSubqueryTest
+-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE EXISTS { MATCH (b)-[:workAt]->(c:organisation) } } RETURN COUNT(*)
+-ENUMERATE
+---- 1
+4
 
 #-NAME ExistSubqueryAliasTest1
 #-QUERY MATCH (a:person) WITH a, a.fName AS newName WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE newName='Alice' } RETURN COUNT(*)
@@ -70,12 +70,12 @@
 #---- 1
 #7
 
-#-NAME ExistSubqueryReturnTest
-#-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) } RETURN a.fName
-#-ENUMERATE
-#---- 5
-#Alice
-#Bob
-#Carol
-#Dan
-#Elizabeth
+-NAME ExistSubqueryReturnTest
+-QUERY MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) } RETURN a.fName
+-ENUMERATE
+---- 5
+Alice
+Bob
+Carol
+Dan
+Elizabeth


### PR DESCRIPTION
Mark join is a special join type for exists subquery, which will keep a boolean vector as the probe result to indicate if each probe key has matched tuples or not.