### PR TITLE
fix bugs/warnings in lists-update

### DIFF
--- a/src/processor/physical_plan/result/factorized_table.cpp
+++ b/src/processor/physical_plan/result/factorized_table.cpp
@@ -267,7 +267,7 @@ void FactorizedTable::copyToInMemList(uint32_t colIdx, vector<uint64_t>& tupleId
         (nodeIDCompressionScheme == nullptr ?
                 0 :
                 sizeof(nodeID_t) - nodeIDCompressionScheme->getNumBytesForNodeIDAfterCompression());
-    auto listToFill = data + startElemPosInList * Types::getDataTypeSize(type);
+    auto listToFill = data + startElemPosInList * numBytesPerValue;
     for (auto i = 0u; i < tupleIdxesToRead.size(); i++) {
         auto tuple = getTuple(tupleIdxesToRead[i]);
         auto isNullInFT = isNonOverflowColNull(tuple + tableSchema->getNullMapOffset(), colIdx);

--- a/src/storage/storage_structure/include/lists/lists.h
+++ b/src/storage/storage_structure/include/lists/lists.h
@@ -54,7 +54,7 @@ struct CursorAndMapper {
 };
 
 struct ListHandle {
-    ListHandle(ListSyncState& listSyncState) : listSyncState{listSyncState} {}
+    explicit ListHandle(ListSyncState& listSyncState) : listSyncState{listSyncState} {}
     inline void resetCursorMapper(ListsMetadata& listMetadata, uint64_t numElementsPerPage) {
         cursorAndMapper.reset(listMetadata, numElementsPerPage, listSyncState.getListHeader(),
             listSyncState.getBoundNodeOffset());
@@ -215,7 +215,7 @@ public:
     // Currently, used only in copyCSV tests.
     unique_ptr<vector<nodeID_t>> readAdjacencyListOfNode(node_offset_t nodeOffset);
 
-    void checkpointInMemoryIfNecessary() {
+    void checkpointInMemoryIfNecessary() override {
         if (listUpdateStore->isEmpty()) {
             return;
         }
@@ -224,7 +224,7 @@ public:
         listUpdateStore->clear();
     }
 
-    void rollbackInMemoryIfNecessary() {
+    void rollbackInMemoryIfNecessary() override {
         if (listUpdateStore->isEmpty()) {
             return;
         }

--- a/src/storage/storage_structure/include/lists/lists_update_iterator.h
+++ b/src/storage/storage_structure/include/lists/lists_update_iterator.h
@@ -37,11 +37,11 @@ namespace storage {
 
 class ListsUpdateIterator {
 public:
-    ListsUpdateIterator(Lists* lists)
+    explicit ListsUpdateIterator(Lists* lists)
         : lists{lists}, curChunkIdx{UINT64_MAX}, curUnprocessedNodeOffset{UINT64_MAX},
           curCSROffset{UINT64_MAX}, finishCalled{false} {}
 
-    ~ListsUpdateIterator() { assert(finishCalled); }
+    virtual ~ListsUpdateIterator() { assert(finishCalled); }
 
     void updateList(node_offset_t nodeOffset, InMemList& inMemList);
 
@@ -87,7 +87,7 @@ protected:
 
 class AdjOrUnstructuredListsUpdateIterator : public ListsUpdateIterator {
 public:
-    AdjOrUnstructuredListsUpdateIterator(Lists* lists) : ListsUpdateIterator{lists} {}
+    explicit AdjOrUnstructuredListsUpdateIterator(Lists* lists) : ListsUpdateIterator{lists} {}
 
 private:
     inline void updateLargeListHeaderIfNecessary(uint32_t largeListIdx) override {
@@ -109,7 +109,7 @@ private:
 
 class RelPropertyListsUpdateIterator : public ListsUpdateIterator {
 public:
-    RelPropertyListsUpdateIterator(Lists* lists) : ListsUpdateIterator{lists} {}
+    explicit RelPropertyListsUpdateIterator(Lists* lists) : ListsUpdateIterator{lists} {}
 
 private:
     // Only adjListUpdateIterator and unstructuredListUpdateIterator need to update small or large
@@ -125,7 +125,6 @@ private:
 };
 
 class ListsUpdateIteratorFactory {
-
 public:
     static unique_ptr<ListsUpdateIterator> getListsUpdateIterator(Lists* lists) {
         switch (lists->storageStructureIDAndFName.storageStructureID.listFileID.listType) {

--- a/src/storage/storage_structure/include/lists/rel_update_store.h
+++ b/src/storage/storage_structure/include/lists/rel_update_store.h
@@ -16,7 +16,7 @@ using namespace catalog;
 
 using InsertedEdgeTupleIdxs = map<node_offset_t, vector<uint64_t>>;
 
-class InMemList;
+struct InMemList;
 
 class ListUpdateStore {
 

--- a/src/storage/store/include/rels_statistics.h
+++ b/src/storage/store/include/rels_statistics.h
@@ -15,7 +15,6 @@ public:
         uint64_t numRels, vector<unordered_map<table_id_t, uint64_t>> numRelsPerDirectionBoundTable)
         : TableStatistics{numRels}, numRelsPerDirectionBoundTable{
                                         move(numRelsPerDirectionBoundTable)} {}
-
     RelStatistics(SrcDstTableIDs srcDstTableIDs);
 
     inline uint64_t getNumRelsForDirectionBoundTable(

--- a/src/storage/store/include/table_statistics.h
+++ b/src/storage/store/include/table_statistics.h
@@ -59,6 +59,8 @@ public:
         tableStatisticPerTableForReadOnlyTrx->erase(tableID);
     }
 
+    virtual ~TablesStatistics() = default;
+
 protected:
     virtual inline string getTableTypeForPrinting() const = 0;
 


### PR DESCRIPTION
1. This PR fixes a bug in FactorizedTable::copyToInMemList which uses incorrect numBytesPerValue while doing memcpy.
2. Fixes some warning in the codebase.
3. Adds virtual destructors for listsUpdateIterator and tablesStatistics