### PR TITLE
Dockerize self-hosted test runner

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: self-hosted-testing
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt update && sudo apt install -y python3-pip
       - run: pip install -r tools/python_api/requirements_dev.txt
 
       - name: build
@@ -28,7 +27,6 @@ jobs:
     runs-on: self-hosted-testing
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt update && sudo apt install -y python3-pip
       - run: pip install -r tools/python_api/requirements_dev.txt
 
       - name: build
@@ -46,9 +44,8 @@ jobs:
         with:
           repository: Sarcasm/run-clang-format
           path: run-clang-format
-      - run: sudo apt install -y clang-format-11
-      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format-11 -r src/
-      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format-11 -r test/
+      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format -r src/
+      - run: python3 run-clang-format/run-clang-format.py --clang-format-executable /usr/bin/clang-format -r test/
 
   benchmark:
     name: benchmark

--- a/scripts/dockerized-ci-tests-runner/Dockerfile
+++ b/scripts/dockerized-ci-tests-runner/Dockerfile
@@ -3,20 +3,20 @@ FROM python:3.9
 ENV RUNNER_ALLOW_RUNASROOT=1
 
 # Configure bazel
-RUN apt install -y apt-transport-https curl gnupg
+RUN apt-get install -y apt-transport-https curl gnupg
 RUN curl -fsSL https://bazel.build/bazel-release.pub.gpg | gpg --dearmor >bazel-archive-keyring.gpg
 RUN mv bazel-archive-keyring.gpg /usr/share/keyrings
 RUN echo "deb [arch=amd64 signed-by=/usr/share/keyrings/bazel-archive-keyring.gpg] https://storage.googleapis.com/bazel-apt stable jdk1.8" | tee /etc/apt/sources.list.d/bazel.list
 
 # Install dependencies
-RUN apt update
-RUN apt install -y bazel
-RUN apt install -y openjdk-11-jdk
-RUN apt install -y clang
-RUN apt install -y clang-format
-RUN apt install clang-13
-RUN apt install -y nodejs
-RUN apt install -y jq
+RUN apt-get update
+RUN apt-get install -y bazel
+RUN apt-get install -y openjdk-11-jdk
+RUN apt-get install -y clang
+RUN apt-get install -y clang-format
+RUN apt-get install -y clang-13
+RUN apt-get install -y nodejs
+RUN apt-get install -y jq
 
 # Install GitHub action runner
 RUN mkdir /actions-runner

--- a/scripts/dockerized-ci-tests-runner/README.md
+++ b/scripts/dockerized-ci-tests-runner/README.md
@@ -1,0 +1,13 @@
+## Build
+```
+docker build -t graphflow-self-hosted-test-runner .
+```
+
+## Start Container
+```
+docker run  --name self-hosted-test-runner-X --detach --restart=always\
+            -e GITHUB_ACCESS_TOKEN=YOUR_GITHUB_ACCESS_TOKEN\
+            -e MACHINE_NAME=NAME_OF_THE_PHYSICAL_MACHINE graphflow-self-hosted-test-runner
+```
+
+Note: `GITHUB_ACCESS_TOKEN` is the account-level access token that can be acquired at [GitHub developer settings](https://github.com/settings/tokens).

--- a/scripts/dockerized-ci-tests-runner/start.sh
+++ b/scripts/dockerized-ci-tests-runner/start.sh
@@ -3,18 +3,25 @@
 cd /actions-runner
 
 # Get registration token
-REG_TOKEN = $(curl \
+REG_TOKEN=$(curl \
     -X POST \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
     https://api.github.com/repos/graphflowdb/graphflowdb/actions/runners/registration-token | jq .token --raw-output)
 
+LABELS="self-hosted-testing"
+if [ -z "${MACHINE_NAME}" ]; then
+    echo "MACHINE_NAME is not set. The label is ignored."
+else
+    LABELS="self-hosted-testing,$MACHINE_NAME"
+fi
+
 # Register runner
-./config.sh --url https://github.com/graphflowdb/graphflowdb --token $REG_TOKEN --name --unattended --labels 'self-hosted-testing'
+./config.sh --url https://github.com/graphflowdb/graphflowdb --token $REG_TOKEN --name --unattended --labels $LABELS
 
 cleanup() {
     echo "Removing runner..."
-    REMOVE_TOKEN = $(curl \
+    REMOVE_TOKEN=$(curl \
         -X POST \
         -H "Accept: application/vnd.github+json" \
         -H "Authorization: Bearer ${GITHUB_ACCESS_TOKEN}" \
@@ -26,4 +33,5 @@ cleanup() {
 trap 'cleanup; exit 130' INT
 trap 'cleanup; exit 143' TERM
 
-./run.sh & wait $!
+./run.sh &
+wait $!


### PR DESCRIPTION
This PR dockerizes self-hosted test runners to simplify management and allow multiple instances of the runner to run concurrently on machine. It features auto registration and graceful exiting. When the container is started, it will automatically acquire the token from the GitHub API and register with GitHub. When it is stopped, it will automatically run `./config.sh remove` to remove itself from the list of runners.