### PR TITLE
Explain fix

### DIFF
--- a/src/common/profiler.cpp
+++ b/src/common/profiler.cpp
@@ -21,7 +21,9 @@ NumericMetric* Profiler::registerNumericMetric(const string& key) {
 
 double Profiler::sumAllTimeMetricsWithKey(const string& key) {
     auto sum = 0.0;
-    assert(metrics.contains(key));
+    if (!metrics.contains(key)) {
+        return sum;
+    }
     for (auto& metric : metrics.at(key)) {
         sum += ((TimeMetric*)metric.get())->getElapsedTimeMS();
     }
@@ -30,7 +32,9 @@ double Profiler::sumAllTimeMetricsWithKey(const string& key) {
 
 uint64_t Profiler::sumAllNumericMetricsWithKey(const string& key) {
     auto sum = 0ul;
-    assert(metrics.contains(key));
+    if (!metrics.contains(key)) {
+        return sum;
+    }
     for (auto& metric : metrics.at(key)) {
         sum += ((NumericMetric*)metric.get())->accumulatedValue;
     }

--- a/src/processor/include/execution_context.h
+++ b/src/processor/include/execution_context.h
@@ -17,7 +17,7 @@ struct ExecutionContext {
     ExecutionContext(uint64_t numThreads, Profiler* profiler, MemoryManager* memoryManager,
         BufferManager* bufferManager)
         : numThreads{numThreads}, profiler{profiler}, memoryManager{memoryManager},
-          bufferManager{bufferManager} {}
+          bufferManager{bufferManager}, transaction{nullptr} {}
 
     uint64_t numThreads;
     Profiler* profiler;


### PR DESCRIPTION
Fixes two bugs relating to the EXPLAIN keyword. 
Relates to issue #835

Bug 1: Segfault on running any query with the EXPLAIN keyword. 
Fix: This bug was being caused by transaction in ExecutionContext not being initialized to null, leading the test `transaction == nullptr` to fail in nodesStatisticsAndDeletedIDs, leading to transaction->isReadOnly() to be called. Since transaction isn't initialized to anything, this resulted in a segfault.

Bug 2: Assertion error on some queries with the EXPLAIN keyword. 
Fix: Automatically return a 0.0 execution time for queries with explain