### PR TITLE
fix issue-726

### DIFF
--- a/src/processor/include/physical_plan/data_pos.h
+++ b/src/processor/include/physical_plan/data_pos.h
@@ -11,7 +11,7 @@ public:
 
     DataPos(const DataPos& other) : DataPos(other.dataChunkPos, other.valueVectorPos) {}
 
-    inline bool operator==(const DataPos& rhs) {
+    inline bool operator==(const DataPos& rhs) const {
         return (dataChunkPos == rhs.dataChunkPos) && (valueVectorPos == rhs.valueVectorPos);
     }
 

--- a/src/processor/include/physical_plan/result/factorized_table.h
+++ b/src/processor/include/physical_plan/result/factorized_table.h
@@ -306,18 +306,20 @@ public:
     shared_ptr<FlatTuple> getNextFlatTuple();
 
 private:
-    void readValueBufferToFlatTuple(uint64_t flatTupleValIdx, const uint8_t* valueBuffer);
-
-    void readUnflatColToFlatTuple(uint64_t flatTupleValIdx, uint8_t* valueBuffer);
-
-    void readFlatColToFlatTuple(uint32_t colIdx, uint8_t* valueBuffer);
-
     // The dataChunkPos may be not consecutive, which means some entries in the
     // flatTuplePositionsInDataChunk is invalid. We put pair(UINT64_MAX, UINT64_MAX) in the
     // invalid entries.
     inline bool isValidDataChunkPos(uint32_t dataChunkPos) const {
         return flatTuplePositionsInDataChunk[dataChunkPos].first != UINT64_MAX;
     }
+    inline void readValueBufferToFlatTuple(uint64_t flatTupleValIdx, const uint8_t* valueBuffer) {
+        iteratorFlatTuple->getResultValue(flatTupleValIdx)
+            ->set(valueBuffer, columnDataTypes[flatTupleValIdx]);
+    }
+
+    void readUnflatColToFlatTuple(uint64_t flatTupleValIdx, uint8_t* valueBuffer);
+
+    void readFlatColToFlatTuple(uint32_t colIdx, uint8_t* valueBuffer);
 
     // We put pair(UINT64_MAX, UINT64_MAX) in all invalid entries in
     // FlatTuplePositionsInDataChunk.

--- a/src/processor/physical_plan/result/flat_tuple.cpp
+++ b/src/processor/physical_plan/result/flat_tuple.cpp
@@ -9,15 +9,128 @@
 namespace graphflow {
 namespace processor {
 
+void ResultValue::set(const uint8_t* value, DataType& valueType) {
+    switch (valueType.typeID) {
+    case INT64: {
+        val.int64Val = *((int64_t*)value);
+    } break;
+    case BOOL: {
+        val.booleanVal = *((bool*)value);
+    } break;
+    case DOUBLE: {
+        val.doubleVal = *((double*)value);
+    } break;
+    case STRING: {
+        stringVal = ((gf_string_t*)value)->getAsString();
+    } break;
+    case UNSTRUCTURED: {
+        setFromUnstructuredValue(*(Value*)value);
+    } break;
+    case DATE: {
+        val.dateVal = *((date_t*)value);
+    } break;
+    case TIMESTAMP: {
+        val.timestampVal = *((timestamp_t*)value);
+    } break;
+    case INTERVAL: {
+        val.intervalVal = *((interval_t*)value);
+    } break;
+    case LIST: {
+        listVal = convertGFListToVector(*(gf_list_t*)value);
+    } break;
+    default:
+        assert(false);
+    }
+}
+
+string ResultValue::to_string() const {
+    if (isNull) {
+        return "";
+    }
+    switch (dataType.typeID) {
+    case BOOL:
+        return TypeUtils::toString(val.booleanVal);
+    case INT64:
+        return TypeUtils::toString(val.int64Val);
+    case DOUBLE:
+        return TypeUtils::toString(val.doubleVal);
+    case STRING:
+        return stringVal;
+    case DATE:
+        return TypeUtils::toString(val.dateVal);
+    case TIMESTAMP:
+        return TypeUtils::toString(val.timestampVal);
+    case INTERVAL:
+        return TypeUtils::toString(val.intervalVal);
+    case LIST: {
+        string result = "[";
+        for (auto i = 0u; i < listVal.size(); ++i) {
+            result += listVal[i].to_string();
+            result += (i == listVal.size() - 1 ? "]" : ",");
+        }
+        return result;
+    }
+    default:
+        assert(false);
+    }
+}
+
+vector<ResultValue> ResultValue::convertGFListToVector(gf_list_t& list) const {
+    vector<ResultValue> listResultValue;
+    auto numBytesPerElement = Types::getDataTypeSize(*dataType.childType);
+    for (auto i = 0; i < list.size; i++) {
+        ResultValue childResultValue{*dataType.childType};
+        childResultValue.set(reinterpret_cast<uint8_t*>(list.overflowPtr + i * numBytesPerElement),
+            *dataType.childType);
+        listResultValue.emplace_back(move(childResultValue));
+    }
+    return listResultValue;
+}
+
+void ResultValue::setFromUnstructuredValue(Value& value) {
+    dataType = value.dataType;
+    switch (value.dataType.typeID) {
+    case INT64: {
+        set((uint8_t*)&value.val.int64Val, value.dataType);
+    } break;
+    case BOOL: {
+        set((uint8_t*)&value.val.booleanVal, value.dataType);
+    } break;
+    case DOUBLE: {
+        set((uint8_t*)&value.val.doubleVal, value.dataType);
+    } break;
+    case STRING: {
+        set((uint8_t*)&value.val.strVal, value.dataType);
+    } break;
+    case NODE_ID: {
+        set((uint8_t*)&value.val.nodeID, value.dataType);
+    } break;
+    case DATE: {
+        set((uint8_t*)&value.val.dateVal, value.dataType);
+    } break;
+    case TIMESTAMP: {
+        set((uint8_t*)&value.val.timestampVal, value.dataType);
+    } break;
+    case INTERVAL: {
+        set((uint8_t*)&value.val.intervalVal, value.dataType);
+    } break;
+    case LIST: {
+        set((uint8_t*)&value.val.listVal, value.dataType);
+    } break;
+    default:
+        assert(false);
+    }
+}
+
 string FlatTuple::toString(const vector<uint32_t>& colsWidth, const string& delimiter) {
     ostringstream result;
-    for (auto i = 0ul; i < values.size(); i++) {
-        string value = nullMask[i] ? "" : TypeUtils::toString(*values[i]);
+    for (auto i = 0ul; i < resultValues.size(); i++) {
+        string value = resultValues[i]->to_string();
         if (colsWidth[i] != 0) {
             value = " " + value + " ";
         }
         result << left << setw((int)colsWidth[i]) << setfill(' ') << value;
-        if (i != values.size() - 1) {
+        if (i != resultValues.size() - 1) {
             result << delimiter;
         }
     }

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -26,7 +26,6 @@ void WALReplayer::init() {
     pageBuffer = make_unique<uint8_t[]>(DEFAULT_PAGE_SIZE);
 }
 void WALReplayer::replayWALRecord(WALRecord& walRecord) {
-    auto type = walRecord.recordType;
     switch (walRecord.recordType) {
     case PAGE_UPDATE_OR_INSERT_RECORD: {
         // 1. As the first step we copy over the page on disk, regardless of if we are recovering

--- a/test/main/include/main_test_helper.h
+++ b/test/main/include/main_test_helper.h
@@ -21,7 +21,7 @@ public:
         auto result = conn->query("MATCH (a:person) RETURN COUNT(*)");
         ASSERT_TRUE(result->hasNext());
         auto tuple = result->getNext();
-        ASSERT_EQ(tuple->getValue(0)->val.int64Val, 8);
+        ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 8);
         ASSERT_FALSE(result->hasNext());
     }
 };

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -7,7 +7,7 @@ TEST_F(ApiTest, MultiParamsPrepare) {
         preparedStatement.get(), make_pair(string("n"), "A"), make_pair(string("xx"), "ooq"));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 2);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 2);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -17,7 +17,7 @@ TEST_F(ApiTest, PrepareBool) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("1"), true));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 3);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 3);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -26,7 +26,7 @@ TEST_F(ApiTest, PrepareInt) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("1"), (int64_t)10));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 45);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 45);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -36,7 +36,7 @@ TEST_F(ApiTest, PrepareDouble) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("1"), (double_t)10.5));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.doubleVal, 15.5);
+    ASSERT_EQ(tuple->getResultValue(0)->getDoubleVal(), 15.5);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -46,7 +46,7 @@ TEST_F(ApiTest, PrepareString) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("n"), "A"));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 1);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 1);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -57,7 +57,7 @@ TEST_F(ApiTest, PrepareDate) {
         conn->execute(preparedStatement.get(), make_pair(string("n"), Date::FromDate(1900, 1, 1)));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 2);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 2);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -70,7 +70,7 @@ TEST_F(ApiTest, PrepareTimestamp) {
         preparedStatement.get(), make_pair(string("n"), Timestamp::FromDatetime(date, time)));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 1);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 1);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -82,7 +82,7 @@ TEST_F(ApiTest, PrepareInterval) {
         make_pair(string("n"), Interval::FromCString(intervalStr.c_str(), intervalStr.length())));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 2);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 2);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -92,7 +92,7 @@ TEST_F(ApiTest, DefaultParam) {
         make_pair(string("2"), (int64_t)1.4));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getValue(0)->val.int64Val, 8);
+    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 8);
     ASSERT_FALSE(result->hasNext());
 }
 

--- a/test/runner/e2e_copy_csv_transaction_test.cpp
+++ b/test/runner/e2e_copy_csv_transaction_test.cpp
@@ -27,7 +27,7 @@ public:
         auto queryResult = conn->query("match (p:person) return p.age");
         while (queryResult->hasNext()) {
             auto tuple = queryResult->getNext();
-            actualResult.insert(tuple->getValue(0)->val.int64Val);
+            actualResult.insert(tuple->getResultValue(0)->getInt64Val());
         }
         ASSERT_EQ(expectedResult, actualResult);
     }
@@ -106,7 +106,7 @@ public:
         auto queryResult = conn->query("match (:person)-[e:knows]->(:person) return e.date");
         while (queryResult->hasNext()) {
             auto tuple = queryResult->getNext();
-            actualResult.insert(tuple->getValue(0)->val.dateVal);
+            actualResult.insert(tuple->getResultValue(0)->getDateVal());
         }
         ASSERT_EQ(expectedResult, actualResult);
     }

--- a/test/runner/e2e_delete_create_transaction_test.cpp
+++ b/test/runner/e2e_delete_create_transaction_test.cpp
@@ -15,7 +15,7 @@ public:
     void checkNodeExists(Connection* connection, uint64_t nodeID) {
         auto result =
             connection->query("MATCH (a:person) WHERE a.ID=" + to_string(nodeID) + " RETURN a.ID");
-        ASSERT_EQ(result->getNext()->getValue(0)->val.int64Val, nodeID);
+        ASSERT_EQ(result->getNext()->getResultValue(0)->getInt64Val(), nodeID);
     }
 
     void checkNodeNotExists(Connection* connection, uint64_t nodeID) {
@@ -36,12 +36,12 @@ public:
 
     int64_t getCountStarVal(Connection* connection, const string& query) {
         auto result = connection->query(query);
-        return result->getNext()->getValue(0)->val.int64Val;
+        return result->getNext()->getResultValue(0)->getInt64Val();
     }
 
     int64_t getNumNodes(Connection* connection) {
         auto result = connection->query("MATCH (:person) RETURN count(*)");
-        return result->getNext()->getValue(0)->val.int64Val;
+        return result->getNext()->getResultValue(0)->getInt64Val();
     }
 
     void addNodes(Connection* connection, uint64_t numNodes) {

--- a/test/runner/e2e_set_transaction_test.cpp
+++ b/test/runner/e2e_set_transaction_test.cpp
@@ -43,7 +43,7 @@ public:
                               to_string(numWriteQueries) + "))");
         }
         auto result = connection->query("MATCH (a:person) WHERE a.ID=2 RETURN a.fName");
-        ASSERT_EQ(result->getNext()->getValue(0)->val.strVal.getAsString(),
+        ASSERT_EQ(result->getNext()->getResultValue(0)->getStringVal(),
             "abcdefghijklmnopqrstuvwxyz" + to_string(numWriteQueries + 2));
     }
 };
@@ -153,7 +153,7 @@ TEST_F(SetNodeStructuredPropTransactionTest, SetNodeLongStringPropRollbackTest) 
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdefghijklmnopqrstuvwxyz'");
     conn->rollback();
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.strVal.getAsString(), "Alice");
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getStringVal(), "Alice");
 }
 
 TEST_F(SetNodeStructuredPropTransactionTest, SetVeryLongStringErrorsTest) {
@@ -171,7 +171,7 @@ TEST_F(SetNodeStructuredPropTransactionTest, SetManyNodeLongStringPropCommitTest
     insertLongStrings1000TimesAndVerify(conn.get());
     conn->commit();
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.strVal.getAsString(),
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getStringVal(),
         "abcdefghijklmnopqrstuvwxyz" + to_string(1000));
 }
 
@@ -180,7 +180,7 @@ TEST_F(SetNodeStructuredPropTransactionTest, SetManyNodeLongStringPropRollbackTe
     insertLongStrings1000TimesAndVerify(conn.get());
     conn->rollback();
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.strVal.getAsString(), "Alice");
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getStringVal(), "Alice");
 }
 
 class SetNodeUnstrPropTransactionTest : public BaseSetNodePropTransactionTest {

--- a/test/runner/e2e_update_test.cpp
+++ b/test/runner/e2e_update_test.cpp
@@ -22,76 +22,74 @@ public:
 TEST_F(TinySnbUpdateTest, SetNodeIntPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.age=20 + 50");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.age");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.int64Val, 70);
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getInt64Val(), 70);
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeDoublePropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.eyeSight=1.0");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.eyeSight");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.doubleVal, 1.0);
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getDoubleVal(), 1.0);
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeBoolPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.isStudent=false");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.isStudent");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.booleanVal, false);
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getBooleanVal(), false);
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeDatePropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.birthdate=date('2200-10-10')");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.birthdate");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.dateVal, Date::FromDate(2200, 10, 10));
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getDateVal(), Date::FromDate(2200, 10, 10));
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeTimestampPropTest) {
     conn->query(
         "MATCH (a:person) WHERE a.ID=0 SET a.registerTime=timestamp('2200-10-10 12:01:01')");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.registerTime");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.timestampVal,
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getTimestampVal(),
         Timestamp::FromDatetime(Date::FromDate(2200, 10, 10), Time::FromTime(12, 1, 1)));
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeShortStringPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdef'");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getValue(0)->val.strVal.getAsString(), "abcdef");
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getStringVal(), "abcdef");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeLongStringPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdefghijklmnopqrstuvwxyz'");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(
-        result->getNext()->getValue(0)->val.strVal.getAsString(), "abcdefghijklmnopqrstuvwxyz");
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getStringVal(), "abcdefghijklmnopqrstuvwxyz");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeListOfIntPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.workedHours=[10,20]");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.workedHours");
-    auto value = result->getNext()->getValue(0);
-    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType), "[10,20]");
+    auto value = result->getNext()->getResultValue(0);
+    ASSERT_EQ(value->to_string(), "[10,20]");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeListOfShortStringPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['intel','microsoft']");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames");
-    auto value = result->getNext()->getValue(0);
-    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType), "[intel,microsoft]");
+    auto value = result->getNext()->getResultValue(0);
+    ASSERT_EQ(value->to_string(), "[intel,microsoft]");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeListOfLongStringPropTest) {
     conn->query(
         "MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames");
-    auto value = result->getNext()->getValue(0);
-    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType),
-        "[abcndwjbwesdsd,microsofthbbjuwgedsd]");
+    auto value = result->getNext()->getResultValue(0);
+    ASSERT_EQ(value->to_string(), "[abcndwjbwesdsd,microsofthbbjuwgedsd]");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeListofListPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=8 SET a.courseScoresPerTerm=[[10,20],[0,0,0]]");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=8 RETURN a.courseScoresPerTerm");
-    auto value = result->getNext()->getValue(0);
-    ASSERT_EQ(TypeUtils::toString(value->val.listVal, value->dataType), "[[10,20],[0,0,0]]");
+    auto value = result->getNext()->getResultValue(0);
+    ASSERT_EQ(value->to_string(), "[[10,20],[0,0,0]]");
 }
 
 TEST_F(TinySnbUpdateTest, SetVeryLongListErrorsTest) {
@@ -105,7 +103,7 @@ TEST_F(TinySnbUpdateTest, SetNodeIntervalPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.lastJobDuration=interval('1 years 1 days')");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.lastJobDuration");
     string intervalStr = "1 years 1 days";
-    ASSERT_EQ(result->getNext()->getValue(0)->val.intervalVal,
+    ASSERT_EQ(result->getNext()->getResultValue(0)->getIntervalVal(),
         Interval::FromCString(intervalStr.c_str(), intervalStr.length()));
 }
 

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -67,7 +67,7 @@ public:
     void checkNodeWithIDExists(Connection* connection, uint64_t nodeID) {
         auto result =
             connection->query("MATCH (a:person) WHERE a.ID=" + to_string(nodeID) + " RETURN a.ID");
-        ASSERT_EQ(result->getNext()->getValue(0)->val.int64Val, nodeID);
+        ASSERT_EQ(result->getNext()->getResultValue(0)->getInt64Val(), nodeID);
     }
 
     void checkNodeWithIDDoesNotExist(Connection* connection, uint64_t nodeID) {
@@ -128,16 +128,16 @@ public:
                 personNodeTable->getTableID(), nodeOffset);
         }
         string query = "MATCH (a:person) RETURN count(DISTINCT a.ID)";
-        ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
-        ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 10000);
+        ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
+        ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10000);
 
         commitOrRollbackConnectionAndInitDBIfNecessary(isCommit, transactionTestType);
         if (isCommit) {
-            ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
-            ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
+            ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
+            ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
         } else {
-            ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 10000);
-            ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 10000);
+            ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10000);
+            ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10000);
         }
     }
 
@@ -172,11 +172,11 @@ TEST_F(NodeInsertionDeletionTests, DeleteEntireMorselTestCommitNormalExecution) 
             personNodeTable->getTableID(), nodeOffset);
     }
     string query = "MATCH (a:person) WHERE a.ID >= 2048 AND a.ID < 4096 RETURN count(*)";
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 2048);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 2048);
     conn->commit();
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
 }
 
 TEST_F(NodeInsertionDeletionTests, DeleteAllNodesCommitNormalExecution) {
@@ -212,34 +212,34 @@ TEST_F(NodeInsertionDeletionTests, DeleteAddMixedTest) {
     }
 
     string query = "MATCH (a:person) RETURN count(*)";
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 10010);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 10000);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10010);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10000);
     conn->commit();
     conn->beginWriteTransaction();
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 10010);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 10010);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10010);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10010);
 
     for (node_offset_t nodeOffset = 0; nodeOffset < 10010; ++nodeOffset) {
         personNodeTable->getNodeStatisticsAndDeletedIDs()->deleteNode(
             personNodeTable->getTableID(), nodeOffset);
     }
 
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 10010);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 10010);
     conn->commit();
     conn->beginWriteTransaction();
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
 
     for (int i = 0; i < 5000; ++i) {
         auto nodeOffset = addNode();
         ASSERT_TRUE(nodeOffset >= 0 && nodeOffset < 10010);
     }
 
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 5000);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 0);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 5000);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 0);
     conn->commit();
     conn->beginWriteTransaction();
-    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->val.int64Val, 5000);
-    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->val.int64Val, 5000);
+    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 5000);
+    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getInt64Val(), 5000);
 }

--- a/test/storage/rel_insertion_test.cpp
+++ b/test/storage/rel_insertion_test.cpp
@@ -129,16 +129,16 @@ public:
         bool containNullValues, bool containLongString) {
         for (auto i = 0u; i < numInsertedRels; i++) {
             auto tuple = queryResult->getNext();
-            ASSERT_EQ(tuple->isNull(0), containNullValues && (i % 2 != 0));
+            ASSERT_EQ(tuple->getResultValue(0)->isNullVal(), containNullValues && (i % 2 != 0));
             if (!containNullValues || i % 2 == 0) {
-                ASSERT_EQ(tuple->getValue(0)->val.int64Val, i);
+                ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), i);
             }
-            ASSERT_EQ(tuple->isNull(1), containNullValues);
+            ASSERT_EQ(tuple->getResultValue(1)->isNullVal(), containNullValues);
             if (!containNullValues) {
-                ASSERT_EQ(tuple->getValue(1)->val.strVal.getAsString(),
+                ASSERT_EQ(tuple->getResultValue(1)->getStringVal(),
                     (containLongString ? "long long string prefix " : "") + to_string(i));
             }
-            ASSERT_EQ(((gf_string_t*)tuple->getValue(2)->val.listVal.overflowPtr)[0].getAsString(),
+            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(),
                 (containLongString ? "long long string prefix " : "") + to_string(i));
         }
     }
@@ -170,11 +170,10 @@ public:
     void validateSmallListAfterInsertion(QueryResult* result, uint64_t numInsertedRels) {
         for (auto i = 0u; i < 51; i++) {
             auto tuple = result->getNext();
-            ASSERT_EQ(tuple->getValue(0)->val.int64Val, i);
+            ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), i);
             auto strVal = getStringValToValidate(1000 - i);
-            ASSERT_EQ(tuple->getValue(1)->val.strVal.getAsString(), strVal);
-            ASSERT_EQ(((gf_string_t*)tuple->getValue(2)->val.listVal.overflowPtr)[0].getAsString(),
-                strVal);
+            ASSERT_EQ(tuple->getResultValue(1)->getStringVal(), strVal);
+            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(), strVal);
             if (i == 1) {
                 validateInsertedRels(result, numInsertedRels, false /* containNullValues */,
                     false /* testLongString */);
@@ -205,11 +204,10 @@ public:
         QueryResult* result, uint64_t numInsertedRels, bool containNullValues) {
         for (auto i = 0u; i < 2500; i++) {
             auto tuple = result->getNext();
-            ASSERT_EQ(tuple->getValue(0)->val.int64Val, 3 * i);
+            ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 3 * i);
             auto strVal = getStringValToValidate(3000 - i);
-            ASSERT_EQ(tuple->getValue(1)->val.strVal.getAsString(), strVal);
-            ASSERT_EQ(((gf_string_t*)tuple->getValue(2)->val.listVal.overflowPtr)[0].getAsString(),
-                strVal);
+            ASSERT_EQ(tuple->getResultValue(1)->getStringVal(), strVal);
+            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(), strVal);
         }
         validateInsertedRels(
             result, numInsertedRels, containNullValues, false /* testLongString */);
@@ -310,11 +308,10 @@ public:
         for (auto i = 0u; i < 50; i++) {
             auto tuple = result->getNext();
             // Check rels stored in the persistent store.
-            ASSERT_EQ(tuple->getValue(0)->val.int64Val, i);
+            ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), i);
             auto strVal = getStringValToValidate(1000 - i);
-            ASSERT_EQ(tuple->getValue(1)->val.strVal.getAsString(), strVal);
-            ASSERT_EQ(((gf_string_t*)tuple->getValue(2)->val.listVal.overflowPtr)[0].getAsString(),
-                strVal);
+            ASSERT_EQ(tuple->getResultValue(1)->getStringVal(), strVal);
+            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(), strVal);
             if (!isCommit) {
                 continue;
             }
@@ -328,22 +325,20 @@ public:
                 for (auto j = 0u; j < 100; j++) {
                     tuple = result->getNext();
                     auto dstNodeOffset = 700 + i + j;
-                    ASSERT_EQ(tuple->getValue(0)->val.int64Val, dstNodeOffset * 3);
+                    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), dstNodeOffset * 3);
                     ASSERT_EQ(
-                        tuple->getValue(1)->val.strVal.getAsString(), to_string(dstNodeOffset - 5));
-                    ASSERT_EQ(((gf_string_t*)tuple->getValue(2)->val.listVal.overflowPtr)[0]
-                                  .getAsString(),
+                        tuple->getResultValue(1)->getStringVal(), to_string(dstNodeOffset - 5));
+                    ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(),
                         to_string(dstNodeOffset - 5));
                 }
             } else {
                 for (auto j = 0u; j < 1000; j++) {
                     tuple = result->getNext();
                     auto dstNodeOffset = 500 + i + j;
-                    ASSERT_EQ(tuple->getValue(0)->val.int64Val, dstNodeOffset * 2);
-                    ASSERT_EQ(tuple->getValue(1)->val.strVal.getAsString(),
-                        to_string(dstNodeOffset - 25));
-                    ASSERT_EQ(((gf_string_t*)tuple->getValue(2)->val.listVal.overflowPtr)[0]
-                                  .getAsString(),
+                    ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), dstNodeOffset * 2);
+                    ASSERT_EQ(
+                        tuple->getResultValue(1)->getStringVal(), to_string(dstNodeOffset - 25));
+                    ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(),
                         to_string(dstNodeOffset - 25));
                 }
             }
@@ -382,11 +377,11 @@ public:
         for (auto i = 0u; i < 10; i++) {
             auto tuple = queryResult->getNext();
             ASSERT_EQ(
-                tuple->getValue(0)->val.strVal.getAsString(), to_string(i + 1) + to_string(i + 1));
+                tuple->getResultValue(0)->getStringVal(), to_string(i + 1) + to_string(i + 1));
         }
         for (auto i = 0u; i < numValuesToInsert; i++) {
             auto tuple = queryResult->getNext();
-            ASSERT_EQ(tuple->getValue(0)->val.strVal.getAsString(), to_string(i));
+            ASSERT_EQ(tuple->getResultValue(0)->getStringVal(), to_string(i));
         }
     }
 
@@ -439,13 +434,13 @@ public:
             // is an inserted edge(checked by i % 10) and the srcNodeOffset is not a multiple of
             // 20(checked by i % 20).
             auto isNull = i % 10 == 0 && (testNull && i % 20);
-            ASSERT_EQ(tuple->isNull(0), isNull);
+            ASSERT_EQ(tuple->getResultValue(0)->isNullVal(), isNull);
             if (!isNull) {
                 // If this is an inserted edge(checked by i % 10), the length property value
                 // is i / 10. Otherwise, the length property value is i.
-                ASSERT_EQ(tuple->getValue(0)->val.int64Val, i % 10 ? i : i / 10);
+                ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), i % 10 ? i : i / 10);
             }
-            ASSERT_EQ(tuple->isNull(1), isNull);
+            ASSERT_EQ(tuple->getResultValue(1)->isNullVal(), isNull);
             if (!isNull) {
                 // If this is an inserted edge(checked by i % 10), the place property value
                 // is prefix(if we are testing long strings) + i / 10. Otherwise,
@@ -457,7 +452,7 @@ public:
                                  to_string(2000 - i) + to_string(2000 - i) + to_string(2000 - i)) :
                         ((testLongString && i % 20 ? "long string prefix " : "") +
                             to_string(i / 10));
-                ASSERT_EQ(tuple->getValue(1)->val.strVal.getAsString(), strVal);
+                ASSERT_EQ(tuple->getResultValue(1)->getStringVal(), strVal);
             }
         }
     }
@@ -510,7 +505,7 @@ public:
                     tuple = queryResult->getNext();
                 }
                 // The length property's value is equal to the srcPerson's ID.
-                ASSERT_EQ(tuple->getValue(0)->val.int64Val, i * 10 + j);
+                ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), i * 10 + j);
             }
         }
     }

--- a/test/storage/unstructured_property_lists_updates_test.cpp
+++ b/test/storage/unstructured_property_lists_updates_test.cpp
@@ -86,34 +86,35 @@ public:
         auto writeQResult = conn->query(query);
         auto writeConTuple = writeQResult->getNext();
         if (expectedIntForWriteTrx == nullptr) {
-            ASSERT_TRUE(writeConTuple->isNull(0));
+            ASSERT_TRUE(writeConTuple->getResultValue(0)->isNullVal());
         } else {
-            ASSERT_FALSE(writeConTuple->isNull(0));
-            ASSERT_EQ(
-                writeConTuple->getValue(0)->val.int64Val, expectedIntForWriteTrx->val.int64Val);
+            ASSERT_FALSE(writeConTuple->getResultValue(0)->isNullVal());
+            ASSERT_EQ(writeConTuple->getResultValue(0)->getInt64Val(),
+                expectedIntForWriteTrx->val.int64Val);
         }
         if (expectedStrValueForWriteTrx == nullptr) {
-            ASSERT_TRUE(writeConTuple->isNull(1));
+            ASSERT_TRUE(writeConTuple->getResultValue(1)->isNullVal());
         } else {
-            ASSERT_FALSE(writeConTuple->isNull(1));
-            ASSERT_EQ(
-                writeConTuple->getValue(1)->val.strVal, expectedStrValueForWriteTrx->val.strVal);
+            ASSERT_FALSE(writeConTuple->getResultValue(1)->isNullVal());
+            ASSERT_EQ(writeConTuple->getResultValue(1)->getStringVal(),
+                expectedStrValueForWriteTrx->val.strVal.getAsString());
         }
 
         auto readQResult = readConn->query(query);
         auto readConTuple = readQResult->getNext();
         if (expectedIntForReadTrx == nullptr) {
-            ASSERT_TRUE(readConTuple->isNull(0));
+            ASSERT_TRUE(readConTuple->getResultValue(0)->isNullVal());
         } else {
-            ASSERT_FALSE(readConTuple->isNull(0));
-            ASSERT_EQ(readConTuple->getValue(0)->val.int64Val, expectedIntForReadTrx->val.int64Val);
+            ASSERT_FALSE(readConTuple->getResultValue(0)->isNullVal());
+            ASSERT_EQ(readConTuple->getResultValue(0)->getInt64Val(),
+                expectedIntForReadTrx->val.int64Val);
         }
         if (expectedStrValueForReadTrx == nullptr) {
-            ASSERT_TRUE(readConTuple->isNull(1));
+            ASSERT_TRUE(readConTuple->getResultValue(1)->isNullVal());
         } else {
-            ASSERT_FALSE(readConTuple->isNull(1));
-            ASSERT_EQ(
-                readConTuple->getValue(1)->val.strVal, expectedStrValueForReadTrx->val.strVal);
+            ASSERT_FALSE(readConTuple->getResultValue(1)->isNullVal());
+            ASSERT_EQ(readConTuple->getResultValue(1)->getStringVal(),
+                expectedStrValueForReadTrx->val.strVal.getAsString());
         }
     }
 
@@ -146,7 +147,7 @@ public:
                            " IS NOT NULL RETURN count (*)";
             auto qResult = connection->query(query);
             auto tuple = qResult->getNext();
-            ASSERT_EQ(tuple->getValue(0)->val.int64Val, 0);
+            ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 0);
         }
     }
 
@@ -161,13 +162,13 @@ public:
             if (nodeOffsetForPropKeys == 250) {
                 // If we are looking for 250's properties, e.g., ui250 and us250, then we expect the
                 // count to be only 1 because only node 250 contains these
-                ASSERT_EQ(tuple->getValue(0)->val.int64Val, 1);
+                ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 1);
             } else {
                 // If we are not looking for 250's properties, e.g., ui0 and us0, then we expect the
                 // count to be 2 because there are 2 nodes with those properties: 1 is the node with
                 // nodeID=nodeOffsetForPropKeys; and 2 is node 250 which has all unstructured
                 // properties.
-                ASSERT_EQ(tuple->getValue(0)->val.int64Val, 2);
+                ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), 2);
             }
         }
     }

--- a/tools/python_api/include/py_query_result.h
+++ b/tools/python_api/include/py_query_result.h
@@ -21,12 +21,9 @@ public:
 
     void close();
 
-    static py::object convertValueToPyObject(const Value& value, bool isNull);
+    static py::object convertValueToPyObject(const ResultValue& value);
 
     py::object getAsDF();
-
-private:
-    static py::object convertValueToPyObject(uint8_t* val, const DataType& dataType);
 
 private:
     unique_ptr<QueryResult> queryResult;

--- a/tools/python_api/include/py_query_result_converter.h
+++ b/tools/python_api/include/py_query_result_converter.h
@@ -11,7 +11,7 @@ struct NPArrayWrapper {
 public:
     NPArrayWrapper(const DataType& type, uint64_t numFlatTuple);
 
-    void appendElement(Value* value, bool isNull);
+    void appendElement(ResultValue* value);
 
 private:
     py::dtype convertToArrayType(const DataType& type);

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -292,10 +292,10 @@ void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
         while (queryResult.hasNext()) {
             auto tuple = queryResult.getNext();
             for (auto i = 0u; i < colsWidth.size(); i++) {
-                if (tuple->nullMask[i]) {
+                if (tuple->getResultValue(i)->isNullVal()) {
                     continue;
                 }
-                uint32_t fieldLen = TypeUtils::toString(*tuple->getValue(i)).length() + 2;
+                uint32_t fieldLen = tuple->getResultValue(i)->to_string().length() + 2;
                 colsWidth[i] = (fieldLen > colsWidth[i]) ? fieldLen : colsWidth[i];
             }
         }


### PR DESCRIPTION
This PR fixes issue #726
Instead of reusing the unstructuredValue in FlatTuple, we defined a new data structure called resultValue.
The fields in resultValue are primitive types, so the strings/lists values are still valid after the database/queryResult object has been destroyed.