### PR TITLE
Skip reading node labels for single-typed rels

### DIFF
--- a/src/storage/in_mem_csv_copier/include/in_mem_rel_csv_copier.h
+++ b/src/storage/in_mem_csv_copier/include/in_mem_rel_csv_copier.h
@@ -41,7 +41,8 @@ private:
 
     static void inferTableIDsAndOffsets(CSVReader& reader, vector<nodeID_t>& nodeIDs,
         vector<DataType>& nodeIDTypes, const vector<unique_ptr<HashIndex>>& IDIndexes,
-        Transaction* transaction, const Catalog& catalog, vector<bool> hasTableLabelColumn);
+        Transaction* transaction, const Catalog& catalog, vector<bool> hasTableLabelColumn,
+        vector<bool> requireToReadTableLabels);
     static void putPropsOfLineIntoColumns(uint32_t numPropertiesToRead,
         vector<table_property_in_mem_columns_map_t>& directionTablePropertyColumns,
         const vector<Property>& properties,


### PR DESCRIPTION
This PR skips reading source and destination labels from the CSV if the schema definition specifies a single type of node.