### PR TITLE
add better error messages for API

### DIFF
--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -20,6 +20,10 @@ bool QueryResult::hasNext() {
 }
 
 shared_ptr<FlatTuple> QueryResult::getNext() {
+    if (!hasNext()) {
+        throw RuntimeException(
+            "No more tuples in QueryResult, Please check hasNext() before calling getNext().");
+    }
     validateQuerySucceed();
     return iterator->getNextFlatTuple();
 }

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "src/common/include/type_utils.h"
+#include "src/common/include/utils.h"
 
 namespace graphflow {
 namespace processor {
@@ -120,6 +121,15 @@ void ResultValue::setFromUnstructuredValue(Value& value) {
     default:
         assert(false);
     }
+}
+
+ResultValue* FlatTuple::getResultValue(uint32_t valIdx) {
+    if (valIdx >= len()) {
+        throw RuntimeException(StringUtils::string_format(
+            "ValIdx is out of range. Number of values in flatTuple: %d, valIdx: %d.", len(),
+            valIdx));
+    }
+    return resultValues[valIdx].get();
 }
 
 string FlatTuple::toString(const vector<uint32_t>& colsWidth, const string& delimiter) {

--- a/src/processor/result/include/flat_tuple.h
+++ b/src/processor/result/include/flat_tuple.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 
+#include "src/common/include/exception.h"
 #include "src/common/include/type_utils.h"
 #include "src/common/types/include/value.h"
 
@@ -73,9 +74,9 @@ public:
         }
     }
 
-    inline ResultValue* getResultValue(uint32_t valIdx) { return resultValues[valIdx].get(); }
-
     inline uint32_t len() { return resultValues.size(); }
+
+    ResultValue* getResultValue(uint32_t valIdx);
 
     string toString(const vector<uint32_t>& colsWidth, const string& delimiter = "|");
 

--- a/test/main/result_value_test.cpp
+++ b/test/main/result_value_test.cpp
@@ -1,0 +1,36 @@
+#include "include/main_test_helper.h"
+
+class ResultValueTest : public ApiTest {};
+
+TEST_F(ResultValueTest, getNextException) {
+    auto query = "MATCH (o:organisation) RETURN o.name";
+    auto result = conn->query(query);
+    try {
+        for (int i = 0; i < 4; i++) {
+            result->getNext();
+        }
+        FAIL();
+    } catch (RuntimeException& exception) {
+        ASSERT_STREQ("Runtime exception: No more tuples in QueryResult, Please check hasNext() "
+                     "before calling getNext().",
+            exception.what());
+    } catch (Exception& exception) { FAIL(); } catch (std::exception& exception) {
+        FAIL();
+    }
+}
+
+TEST_F(ResultValueTest, getResultValueException) {
+    auto query = "MATCH (a:person) RETURN a.fName";
+    auto result = conn->query(query);
+    auto flatTuple = result->getNext();
+    try {
+        flatTuple->getResultValue(100);
+        FAIL();
+    } catch (RuntimeException& exception) {
+        ASSERT_STREQ("Runtime exception: ValIdx is out of range. Number of values in flatTuple: 1, "
+                     "valIdx: 100.",
+            exception.what());
+    } catch (Exception& exception) { FAIL(); } catch (std::exception& exception) {
+        FAIL();
+    }
+}


### PR DESCRIPTION
Fix for issue #697 

Added:
- A better error message in `getNextFlatTuple` (to take care of the `getNext()` case), instead of just having a failing assertion.
- A better error message in `getResultValue` (currently, `resultValues[valIdx]` is undefined behaviour)