### PR TITLE
add rel-deletion

### DIFF
--- a/dataset/rel-insertion-tests/eTeaches.csv
+++ b/dataset/rel-insertion-tests/eTeaches.csv
@@ -1,6 +1,6 @@
-person,11,person,1,"11"
-person,21,person,2,"21"
-person,22,person,2,"22"
-person,31,person,3,"31"
-person,32,person,3,"32"
-person,33,person,3,"33"
+person,11,person,1,11
+person,21,person,2,21
+person,22,person,2,22
+person,31,person,3,31
+person,32,person,3,32
+person,33,person,3,33

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -72,6 +72,13 @@ bool Column::isNull(node_offset_t nodeOffset) {
     return isNull;
 }
 
+void Column::setNodeOffsetToNull(node_offset_t nodeOffset) {
+    auto walPageInfo = createWALVersionOfPageIfNecessaryForElement(nodeOffset, numElementsPerPage);
+    setNullBitOfAPosInFrame(walPageInfo.frame, walPageInfo.posInPage, true /* isNull */);
+    StorageStructureUtils::unpinWALPageAndReleaseOriginalPageLock(
+        walPageInfo, fileHandle, bufferManager, *wal);
+}
+
 void Column::lookup(Transaction* transaction, const shared_ptr<ValueVector>& nodeIDVector,
     const shared_ptr<ValueVector>& resultVector, uint32_t vectorPos) {
     if (nodeIDVector->isNull(vectorPos)) {

--- a/src/storage/storage_structure/include/column.h
+++ b/src/storage/storage_structure/include/column.h
@@ -36,6 +36,8 @@ public:
     // Used only for tests.
     bool isNull(node_offset_t nodeOffset);
 
+    void setNodeOffsetToNull(node_offset_t nodeOffset);
+
 protected:
     void lookup(Transaction* transaction, const shared_ptr<ValueVector>& nodeIDVector,
         const shared_ptr<ValueVector>& resultVector, uint32_t vectorPos);

--- a/src/storage/storage_structure/lists/lists_update_iterator.cpp
+++ b/src/storage/storage_structure/lists/lists_update_iterator.cpp
@@ -81,7 +81,7 @@ void ListsUpdateIterator::slideListsIfNecessary(uint64_t endNodeOffsetInclusive)
                 cursorAndMapper.reset(lists->getListsMetadata(), lists->numElementsPerPage,
                     lists->getHeaders()->getHeader(nodeOffsetToSlide), nodeOffsetToSlide);
                 lists->fillInMemListsFromPersistentStore(cursorAndMapper,
-                    lists->getNumElementsInPersistentStore(nodeOffsetToSlide), inMemList);
+                    lists->getNumElementsFromListHeader(nodeOffsetToSlide), inMemList);
                 updateSmallListAndCurCSROffset(oldHeader, inMemList);
             } else {
                 curCSROffset += listLen;

--- a/src/storage/storage_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists.cpp
@@ -107,7 +107,7 @@ void UnstructuredPropertyLists::readPropertiesForPosition(Transaction* transacti
         auto header = headers->getHeader(nodeOffset);
         CursorAndMapper cursorAndMapper;
         cursorAndMapper.reset(metadata, numElementsPerPage, header, nodeOffset);
-        uint64_t numElementsInLIst = getNumElementsInPersistentStore(nodeOffset);
+        uint64_t numElementsInLIst = getNumElementsFromListHeader(nodeOffset);
         InMemList inMemList{numElementsInLIst, elementSize, false /* requireNullMask */};
         fillInMemListsFromPersistentStore(cursorAndMapper, numElementsInLIst, inMemList);
         primaryStoreListWrapper = make_unique<UnstrPropListWrapper>(
@@ -161,7 +161,7 @@ unique_ptr<map<uint32_t, Literal>> UnstructuredPropertyLists::readUnstructuredPr
     node_offset_t nodeOffset) {
     CursorAndMapper cursorAndMapper;
     cursorAndMapper.reset(metadata, numElementsPerPage, headers->getHeader(nodeOffset), nodeOffset);
-    auto numElementsInList = getNumElementsInPersistentStore(nodeOffset);
+    auto numElementsInList = getNumElementsFromListHeader(nodeOffset);
     auto retVal = make_unique<map<uint32_t /*unstructuredProperty pageIdx*/, Literal>>();
     PageByteCursor byteCursor{cursorAndMapper.cursor.pageIdx, cursorAndMapper.cursor.elemPosInPage};
     auto propertyKeyDataType = UnstructuredPropertyKeyDataType{UINT32_MAX, ANY};
@@ -248,7 +248,7 @@ void UnstructuredPropertyLists::setOrRemoveProperty(
         CursorAndMapper cursorAndMapper;
         cursorAndMapper.reset(
             metadata, numElementsPerPage, headers->getHeader(nodeOffset), nodeOffset);
-        auto numElementsInList = getNumElementsInPersistentStore(nodeOffset);
+        auto numElementsInList = getNumElementsFromListHeader(nodeOffset);
         uint64_t updatedListCapacity = max(numElementsInList,
             (uint64_t)(numElementsInList * StorageConfig::ARRAY_RESIZING_FACTOR));
         InMemList inMemList{updatedListCapacity, elementSize, false /* requireNullMask */};

--- a/src/storage/store/include/rel_table.h
+++ b/src/storage/store/include/rel_table.h
@@ -51,6 +51,7 @@ public:
     void checkpointInMemoryIfNecessary();
     void rollbackInMemoryIfNecessary();
     void insertRels(vector<shared_ptr<ValueVector>>& valueVectorsToInsert);
+    void deleteRels(shared_ptr<ValueVector>& nodeIDVector);
 
 private:
     inline void addToUpdatedRelTables() { wal->addToUpdatedRelTables(tableID); }

--- a/test/storage/BUILD.bazel
+++ b/test/storage/BUILD.bazel
@@ -104,7 +104,7 @@ cc_test(
 cc_test(
     name = "rel_insertion_test",
     srcs = [
-        "rel_insertion_test.cpp",
+        "rel_insertion_and_deletion_test.cpp",
     ],
     copts = [
         "-Iexternal/gtest/include",


### PR DESCRIPTION
1. This PR adds the `deleteRels(nodeIDVector)` API to relTable. It deletes all the rels in the relTable for the given nodeID.
2. To record emptyListInPersistentStore after rel deletion, we introduce a new struct `EmptyListInPersistentStoreAndInsertedRels`, which can both record emptyListInPersistentStore and insertedRels for a nodeOffset.
`