### PR TITLE
Add initial test script for macOS CI build

### DIFF
--- a/.github/workflows/mac-wheel-workflow.yml
+++ b/.github/workflows/mac-wheel-workflow.yml
@@ -1,0 +1,43 @@
+name: Build-Mac-Wheels
+
+on:
+  workflow_dispatch:
+    inputs:
+      pythonPackageVersion:
+        description: "Version of output Python package"
+        required: true
+        default: "0.0.1"
+
+env:
+  PYTHON_PACKAGE_VERSION: ${{ github.event.inputs.pythonPackageVersion }}
+
+jobs:
+  build-x86-wheels:
+    runs-on: macOS-11
+    env:
+      MACOSX_DEPLOYMENT_TARGET: 10.15
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: create-source-distribution
+        working-directory: ./scripts/pip-package/
+        run: |
+          rm -rf wheelhouse graphflowdb.tar.gz sdist
+          mkdir wheelhouse sdist
+          bash package_tar.sh
+          tar -xf ./graphflowdb.tar.gz -C ./sdist
+
+      - name: build-wheel
+        uses: pypa/cibuildwheel@v2.11.1
+        env:
+          CIBW_SKIP: pp*
+          CIBW_ARCHS_MACOS: x86_64
+          CIBW_BUILD_VERBOSITY: 3
+        with:
+          package-dir: ./scripts/pip-package/sdist
+          output-dir: ./scripts/pip-package/wheelhouse
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: macos-x86-wheels
+          path: ./scripts/pip-package/wheelhouse/*.whl

--- a/scripts/pip-package/README.md
+++ b/scripts/pip-package/README.md
@@ -1,0 +1,29 @@
+# `pip install` from the Source
+```
+chmod +x package_tar.sh
+./package_tar.sh
+pip install graphflowdb.tar.gz    
+```
+
+Note: installing from source requires the full toolchain for building the project, including bazel, OpenJDK, and a compiler compatible with C++20. The package works for both Linux and macOS.
+
+# Container for self-hosted manylinux builder
+## Introduction
+The container for manylinux builder automatically builds and upload wheels compatiable with `manylinux2014_x86_64` platform tag when it is manually triggered from CI. The spec for manylinux can be found at [https://github.com/pypa/manylinux](https://github.com/pypa/manylinux).
+
+## Build
+```
+docker build -t graphflow-self-hosted-linux-builder .
+```
+
+## Start Container
+```
+docker run  --name self-hosted-linux-builder --detach --restart=always\
+            -e GITHUB_ACCESS_TOKEN=YOUR_GITHUB_ACCESS_TOKEN\
+            -e MACHINE_NAME=NAME_OF_THE_PHYSICAL_MACHINE graphflow-self-hosted-linux-builder
+```
+
+Note: `GITHUB_ACCESS_TOKEN` is the account-level access token that can be acquired at [GitHub developer settings](https://github.com/settings/tokens).
+
+## Bulid wheels for macOS
+We use [cibuildwheel](https://github.com/pypa/cibuildwheel). The configuration file is located at `.github/workflows/mac-wheel-workflow.yml`.

--- a/scripts/pip-package/setup.py
+++ b/scripts/pip-package/setup.py
@@ -23,6 +23,11 @@ class BazelBuild(build_ext):
     def build_extension(self, ext: BazelExtension) -> None:
         self.announce("Building native extension...", level=3)
         args = ['--cxxopt=-std=c++2a', '--cxxopt=-O3']
+        # It seems bazel does not automatically pick up MACOSX_DEPLOYMENT_TARGET
+        # from the environment, so we need to pass it explicitly.
+        if "MACOSX_DEPLOYMENT_TARGET" in os.environ:
+            args.append("--macos_minimum_os=" +
+                        os.environ["MACOSX_DEPLOYMENT_TARGET"])
         full_cmd = ['bazel', 'build', *args, '//tools/python_api:all']
         env_vars = os.environ.copy()
         env_vars['PYTHON_BIN_PATH'] = sys.executable


### PR DESCRIPTION
This PR adds build scripts for building macOS pip wheels. The script is based on [cibuildwheel](https://github.com/pypa/cibuildwheel).

Note: since the new GitHub action cannot be tested without merged first, we merge this one first. Will create another PR as fix if it does not work properly.