### PR TITLE
solve issue #814

### DIFF
--- a/src/storage/storage_structure/include/lists/adj_and_property_lists_update_store.h
+++ b/src/storage/storage_structure/include/lists/adj_and_property_lists_update_store.h
@@ -42,7 +42,7 @@ public:
     inline vector<map<table_id_t, InsertedRelsPerChunk>>& getInsertedRelsPerTableIDPerDirection() {
         return insertedRelsPerTableIDPerDirection;
     }
-    void readToListAndUpdateOverflowIfNecessary(ListFileID& listFileID, vector<uint64_t> tupleIdxes,
+    void readInsertionsToList(ListFileID& listFileID, vector<uint64_t> tupleIdxes,
         InMemList& inMemList, uint64_t numElementsInPersistentStore,
         DiskOverflowFile* diskOverflowFile, DataType dataType,
         NodeIDCompressionScheme* nodeIDCompressionScheme);

--- a/src/storage/storage_structure/lists/adj_and_property_lists_update_store.cpp
+++ b/src/storage/storage_structure/lists/adj_and_property_lists_update_store.cpp
@@ -30,7 +30,8 @@ AdjAndPropertyListsUpdateStore::AdjAndPropertyListsUpdateStore(
     initInsertedRelsPerTableIDPerDirection();
 }
 
-void AdjAndPropertyListsUpdateStore::readToListAndUpdateOverflowIfNecessary(ListFileID& listFileID,
+// Note: This function also resets the overflowptr of each string in inMemList if necessary.
+void AdjAndPropertyListsUpdateStore::readInsertionsToList(ListFileID& listFileID,
     vector<uint64_t> tupleIdxes, InMemList& inMemList, uint64_t numElementsInPersistentStore,
     DiskOverflowFile* diskOverflowFile, DataType dataType,
     NodeIDCompressionScheme* nodeIDCompressionScheme) {

--- a/src/storage/storage_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists.cpp
@@ -73,7 +73,7 @@ void UnstructuredPropertyLists::prepareCommitOrRollbackIfNecessary(bool isCommit
 void UnstructuredPropertyLists::prepareCommit(ListsUpdateIterator& listsUpdateIterator) {
     // Note: In C++ iterating through maps happens in non-descending order of the keys. This
     // property is critical when using UnstructuredPropertyListsUpdateIterator, which requires
-    // the user to make calls to writeListToListPages in ascending order of nodeOffsets.
+    // the user to make calls to writeInMemListToListPages in ascending order of nodeOffsets.
     for (auto updatedChunkItr = unstructuredListUpdateStore.updatedChunks.begin();
          updatedChunkItr != unstructuredListUpdateStore.updatedChunks.end(); ++updatedChunkItr) {
         for (auto updatedNodeOffsetItr = updatedChunkItr->second->begin();


### PR DESCRIPTION
This PR solves issue #814 which is about optimizing committing to largeList optimization.
For RelProperty/AdjLists:
If the initial list is a largeList, we don't need to rewrite the largeList with data from persistentStore + updateStore. Instead, we can simply append data from updateStore to largeList.