### PR TITLE
Temporarily comments out unstructured properties feature

### DIFF
--- a/src/catalog/catalog_structs.cpp
+++ b/src/catalog/catalog_structs.cpp
@@ -19,6 +19,8 @@ RelMultiplicity getRelMultiplicityFromString(const string& relMultiplicityString
 }
 
 void NodeTableSchema::addUnstructuredProperties(vector<string>& unstructuredPropertyNames) {
+    // TODO(Semih): Uncomment when enabling ad-hoc properties
+    assert(unstructuredProperties.empty());
     for (auto& unstrPropertyName : unstructuredPropertyNames) {
         auto unstrPropertyId = unstructuredProperties.size();
         unstrPropertiesNameToIdMap[unstrPropertyName] = unstrPropertyId;

--- a/src/catalog/include/catalog.h
+++ b/src/catalog/include/catalog.h
@@ -188,6 +188,8 @@ public:
 
     inline void setUnstructuredPropertiesOfNodeTableSchema(
         vector<string>& unstructuredProperties, table_id_t tableID) {
+        // TODO(Semih): Uncomment when enabling ad-hoc properties
+        assert(unstructuredProperties.empty());
         initCatalogContentForWriteTrxIfNecessary();
         catalogContentForWriteTrx->getNodeTableSchema(tableID)->addUnstructuredProperties(
             unstructuredProperties);

--- a/src/storage/in_mem_csv_copier/in_mem_structures_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_structures_csv_copier.cpp
@@ -60,9 +60,10 @@ void InMemStructuresCSVCopier::countNumLinesAndUnstrPropertiesPerBlockTask(const
     copier->numLinesPerBlock[blockId] = 0ull;
     while (reader.hasNextLine()) {
         copier->numLinesPerBlock[blockId]++;
-        if (unstrPropertyNames != nullptr) {
-            collectUnstrPropertyNamesInLine(reader, numTokensToSkip, unstrPropertyNames);
-        }
+        // TODO(Semih): Uncomment when enabling ad-hoc properties.
+        //        if (unstrPropertyNames != nullptr) {
+        //            collectUnstrPropertyNamesInLine(reader, numTokensToSkip, unstrPropertyNames);
+        //        }
     }
     copier->logger->trace("End: path=`{0}` blkIdx={1}", fName, blockId);
 }

--- a/test/copy_csv/copy_csv_test.cpp
+++ b/test/copy_csv/copy_csv_test.cpp
@@ -161,41 +161,44 @@ TEST_F(CopyNodeCSVPropertyTest, NodeStructuredStringPropertyTest) {
     }
 }
 
-TEST_F(CopyNodeCSVPropertyTest, NodeUnstructuredPropertyTest) {
-    auto graph = database->getStorageManager();
-    auto& catalog = *database->getCatalog();
-    auto tableID = catalog.getReadOnlyVersion()->getNodeTableIDFromName("person");
-    auto lists = reinterpret_cast<UnstructuredPropertyLists*>(
-        graph->getNodesStore().getNodeUnstrPropertyLists(tableID));
-    auto& propertyNameToIdMap =
-        catalog.getReadOnlyVersion()->getUnstrPropertiesNameToIdMap(tableID);
-    for (int i = 0; i < 1000; ++i) {
-        auto propertiesMap = lists->readUnstructuredPropertiesOfNode(i);
-        if (i == 300 || i == 400 || i == 500) {
-            EXPECT_EQ(i * 4, propertiesMap->size());
-            for (int j = 0; j < i; ++j) {
-                EXPECT_EQ("strPropVal" + to_string(j),
-                    propertiesMap->at(propertyNameToIdMap.at("strPropKey" + to_string(j))).strVal);
-                EXPECT_EQ(
-                    j, propertiesMap->at(propertyNameToIdMap.at("int64PropKey" + to_string(j)))
-                           .val.int64Val);
-                EXPECT_EQ(j * 1.0,
-                    propertiesMap->at(propertyNameToIdMap.at("doublePropKey" + to_string(j)))
-                        .val.doubleVal);
-                EXPECT_FALSE(propertiesMap->at(propertyNameToIdMap.at("boolPropKey" + to_string(j)))
-                                 .val.booleanVal);
-            }
-        } else {
-            EXPECT_EQ(4, propertiesMap->size());
-            EXPECT_EQ(
-                "strPropVal1", propertiesMap->at(propertyNameToIdMap.at("strPropKey1")).strVal);
-            EXPECT_EQ(1, propertiesMap->at(propertyNameToIdMap.at("int64PropKey1")).val.int64Val);
-            EXPECT_EQ(
-                1.0, propertiesMap->at(propertyNameToIdMap.at("doublePropKey1")).val.doubleVal);
-            EXPECT_TRUE(propertiesMap->at(propertyNameToIdMap.at("boolPropKey1")).val.booleanVal);
-        }
-    }
-}
+// TODO(Semih): Uncomment when enabling ad-hoc properties
+// TEST_F(CopyNodeCSVPropertyTest, NodeUnstructuredPropertyTest) {
+//    auto graph = database->getStorageManager();
+//    auto& catalog = *database->getCatalog();
+//    auto tableID = catalog.getReadOnlyVersion()->getNodeTableIDFromName("person");
+//    auto lists = reinterpret_cast<UnstructuredPropertyLists*>(
+//        graph->getNodesStore().getNodeUnstrPropertyLists(tableID));
+//    auto& propertyNameToIdMap =
+//        catalog.getReadOnlyVersion()->getUnstrPropertiesNameToIdMap(tableID);
+//    for (int i = 0; i < 1000; ++i) {
+//        auto propertiesMap = lists->readUnstructuredPropertiesOfNode(i);
+//        if (i == 300 || i == 400 || i == 500) {
+//            EXPECT_EQ(i * 4, propertiesMap->size());
+//            for (int j = 0; j < i; ++j) {
+//                EXPECT_EQ("strPropVal" + to_string(j),
+//                    propertiesMap->at(propertyNameToIdMap.at("strPropKey" +
+//                    to_string(j))).strVal);
+//                EXPECT_EQ(
+//                    j, propertiesMap->at(propertyNameToIdMap.at("int64PropKey" + to_string(j)))
+//                           .val.int64Val);
+//                EXPECT_EQ(j * 1.0,
+//                    propertiesMap->at(propertyNameToIdMap.at("doublePropKey" + to_string(j)))
+//                        .val.doubleVal);
+//                EXPECT_FALSE(propertiesMap->at(propertyNameToIdMap.at("boolPropKey" +
+//                to_string(j)))
+//                                 .val.booleanVal);
+//            }
+//        } else {
+//            EXPECT_EQ(4, propertiesMap->size());
+//            EXPECT_EQ(
+//                "strPropVal1", propertiesMap->at(propertyNameToIdMap.at("strPropKey1")).strVal);
+//            EXPECT_EQ(1, propertiesMap->at(propertyNameToIdMap.at("int64PropKey1")).val.int64Val);
+//            EXPECT_EQ(
+//                1.0, propertiesMap->at(propertyNameToIdMap.at("doublePropKey1")).val.doubleVal);
+//            EXPECT_TRUE(propertiesMap->at(propertyNameToIdMap.at("boolPropKey1")).val.booleanVal);
+//        }
+//    }
+//}
 
 void verifyP0ToP5999(KnowsTablePTablePKnowsLists& knowsTablePTablePKnowsLists) {
     // p0 has 5001 fwd edges to p0...p5000
@@ -323,9 +326,10 @@ TEST_F(CopyCSVSpecialCharTest, CopySpecialCharsCsv) {
     EXPECT_EQ("DEsW#ork", col->readValue(2).strVal);
 }
 
-TEST_F(CopyCSVEmptyListsTest, CopyCSVEmptyLists) {
-    testCopyCSVEmptyListsTest();
-}
+// TODO(Semih): Uncomment when enabling ad-hoc properties
+// TEST_F(CopyCSVEmptyListsTest, CopyCSVEmptyLists) {
+//    testCopyCSVEmptyListsTest();
+//}
 
 TEST_F(CopyCSVLongStringTest, LongStringError) {
     auto storageManager = database->getStorageManager();

--- a/test/main/exception_test.cpp
+++ b/test/main/exception_test.cpp
@@ -47,17 +47,18 @@ TEST_F(ApiTest, Exception) {
     ASSERT_FALSE(preparedStatement->isSuccess());
     ASSERT_STREQ(preparedStatement->getErrorMessage().c_str(), function_error);
 
-    auto runtime_error_query = "MATCH (a:person) RETURN a.unstrDateProp + 'hh'";
-    auto runtime_error = "Runtime exception: Cannot add `DATE` and `STRING`";
-    result = conn->query(runtime_error_query);
-    ASSERT_FALSE(result->isSuccess());
-    ASSERT_STREQ(result->getErrorMessage().c_str(), runtime_error);
-
-    // test fetching result when query fails
-    try {
-        result->hasNext();
-        FAIL();
-    } catch (Exception& exception) {
-        ASSERT_STREQ("Runtime exception: Cannot add `DATE` and `STRING`", exception.what());
-    } catch (std::exception& exception) { FAIL(); }
+    // TODO(Semih): Uncomment when enabling ad-hoc properties
+    //    auto runtime_error_query = "MATCH (a:person) RETURN a.unstrDateProp + 'hh'";
+    //    auto runtime_error = "Runtime exception: Cannot add `DATE` and `STRING`";
+    //    result = conn->query(runtime_error_query);
+    //    ASSERT_FALSE(result->isSuccess());
+    //    ASSERT_STREQ(result->getErrorMessage().c_str(), runtime_error);
+    //
+    //    // test fetching result when query fails
+    //    try {
+    //        result->hasNext();
+    //        FAIL();
+    //    } catch (Exception& exception) {
+    //        ASSERT_STREQ("Runtime exception: Cannot add `DATE` and `STRING`", exception.what());
+    //    } catch (std::exception& exception) { FAIL(); }
 }

--- a/test/runner/e2e_set_transaction_test.cpp
+++ b/test/runner/e2e_set_transaction_test.cpp
@@ -69,7 +69,7 @@ TEST_F(SetNodeStructuredPropTransactionTest,
     SingleTransactionReadWriteToFixedLengthStructuredNodePropertyNullTest) {
     conn->beginWriteTransaction();
     readAndAssertNodeProperty(conn.get(), 0 /* node offset */, "age", vector<string>{"35"});
-    conn->query("MATCH (a:person) WHERE a.ID = 0 SET a.age = a.unstrNumericProp;");
+    conn->query("MATCH (a:person) WHERE a.ID = 0 SET a.age = null;");
     readAndAssertNodeProperty(conn.get(), 0 /* node offset */, "age", vector<string>{""});
 }
 
@@ -77,7 +77,7 @@ TEST_F(SetNodeStructuredPropTransactionTest,
     SingleTransactionReadWriteToStringStructuredNodePropertyNullTest) {
     conn->beginWriteTransaction();
     readAndAssertNodeProperty(conn.get(), 0 /* node offset */, "fName", vector<string>{"Alice"});
-    auto result = conn->query("MATCH (a:person) WHERE a.ID = 0 SET a.fName = a.label3;");
+    auto result = conn->query("MATCH (a:person) WHERE a.ID = 0 SET a.fName = null;");
     readAndAssertNodeProperty(conn.get(), 0 /* node offset */, "fName", vector<string>{""});
 }
 
@@ -197,146 +197,147 @@ public:
     string lStrVal = "new-long-string";
 };
 
-TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringInTrx) {
-    conn->beginWriteTransaction();
-    conn->query(
-        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{intVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{sStrVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringCommitNormalExecution) {
-    conn->beginWriteTransaction();
-    conn->query(
-        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
-    conn->commit();
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{intVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{sStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringRollbackNormalExecution) {
-    conn->beginWriteTransaction();
-    conn->query(
-        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
-    conn->rollback();
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringCommitRecovery) {
-    conn->beginWriteTransaction();
-    conn->query(
-        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
-    conn->commitButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{intVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{sStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringRollbackRecovery) {
-    conn->beginWriteTransaction();
-    conn->query(
-        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
-    conn->rollbackButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestInTrx) {
-    conn->beginWriteTransaction();
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{lStrVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestCommitNormalExecution) {
-    conn->beginWriteTransaction();
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
-    conn->commit();
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{lStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestRollbackNormalExecution) {
-    conn->beginWriteTransaction();
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
-    conn->rollback();
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestCommitRecovery) {
-    conn->beginWriteTransaction();
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
-    conn->commitButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{lStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestRollbackRecovery) {
-    conn->beginWriteTransaction();
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
-    conn->rollbackButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, InsertNonExistingProps) {
-    conn->beginWriteTransaction();
-    conn->query(
-        "MATCH (a:person) WHERE a.ID=123 SET a.ui124=" + intVal + ",a.us125='" + lStrVal + "'");
-    readAndAssertNodeProperty(conn.get(), 123, "ui124", vector<string>{intVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{lStrVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "ui124", vector<string>{""});
-    readAndAssertNodeProperty(readConn.get(), 123, "us125", vector<string>{""});
-    conn->rollbackButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    readAndAssertNodeProperty(conn.get(), 123, "ui124", vector<string>{""});
-    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{""});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, RemoveExistingProperties) {
-    conn->beginWriteTransaction();
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.ui123=null,a.us123=null");
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{""});
-    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
-    conn->commit();
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{""});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, RemoveNonExistingProperties) {
-    conn->beginWriteTransaction();
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.ui124=null,a.us125=null");
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
-    conn->rollback();
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, RemoveNewlyAddedProperties) {
-    conn->beginWriteTransaction();
-    conn->query(
-        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us125='" + lStrVal + "'");
-    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.ui123=null,a.us125=null");
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{""});
-    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
-    readAndAssertNodeProperty(readConn.get(), 123, "us125", vector<string>{""});
-    conn->commitButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
-    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
-    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{""});
-}
+// TODO(Semih): Uncomment when enabling ad-hoc properties
+// TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringInTrx) {
+//    conn->beginWriteTransaction();
+//    conn->query(
+//        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{intVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{sStrVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringCommitNormalExecution) {
+//    conn->beginWriteTransaction();
+//    conn->query(
+//        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
+//    conn->commit();
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{intVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{sStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringRollbackNormalExecution) {
+//    conn->beginWriteTransaction();
+//    conn->query(
+//        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
+//    conn->rollback();
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringCommitRecovery) {
+//    conn->beginWriteTransaction();
+//    conn->query(
+//        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
+//    conn->commitButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{intVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{sStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, FixedLenPropertyShortStringRollbackRecovery) {
+//    conn->beginWriteTransaction();
+//    conn->query(
+//        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us123='" + sStrVal + "'");
+//    conn->rollbackButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestInTrx) {
+//    conn->beginWriteTransaction();
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{lStrVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestCommitNormalExecution) {
+//    conn->beginWriteTransaction();
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
+//    conn->commit();
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{lStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestRollbackNormalExecution) {
+//    conn->beginWriteTransaction();
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
+//    conn->rollback();
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestCommitRecovery) {
+//    conn->beginWriteTransaction();
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
+//    conn->commitButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{lStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, LongStringPropTestRollbackRecovery) {
+//    conn->beginWriteTransaction();
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.us123='" + lStrVal + "'");
+//    conn->rollbackButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, InsertNonExistingProps) {
+//    conn->beginWriteTransaction();
+//    conn->query(
+//        "MATCH (a:person) WHERE a.ID=123 SET a.ui124=" + intVal + ",a.us125='" + lStrVal + "'");
+//    readAndAssertNodeProperty(conn.get(), 123, "ui124", vector<string>{intVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{lStrVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "ui124", vector<string>{""});
+//    readAndAssertNodeProperty(readConn.get(), 123, "us125", vector<string>{""});
+//    conn->rollbackButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    readAndAssertNodeProperty(conn.get(), 123, "ui124", vector<string>{""});
+//    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{""});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, RemoveExistingProperties) {
+//    conn->beginWriteTransaction();
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.ui123=null,a.us123=null");
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{""});
+//    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
+//    conn->commit();
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{""});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, RemoveNonExistingProperties) {
+//    conn->beginWriteTransaction();
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.ui124=null,a.us125=null");
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
+//    conn->rollback();
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, RemoveNewlyAddedProperties) {
+//    conn->beginWriteTransaction();
+//    conn->query(
+//        "MATCH (a:person) WHERE a.ID=123 SET a.ui123=" + intVal + ",a.us125='" + lStrVal + "'");
+//    conn->query("MATCH (a:person) WHERE a.ID=123 SET a.ui123=null,a.us125=null");
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{""});
+//    readAndAssertNodeProperty(readConn.get(), 123, "ui123", vector<string>{existingIntVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "us123", vector<string>{existingStrVal});
+//    readAndAssertNodeProperty(readConn.get(), 123, "us125", vector<string>{""});
+//    conn->commitButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    readAndAssertNodeProperty(conn.get(), 123, "ui123", vector<string>{""});
+//    readAndAssertNodeProperty(conn.get(), 123, "us123", vector<string>{existingStrVal});
+//    readAndAssertNodeProperty(conn.get(), 123, "us125", vector<string>{""});
+//}
 
 static void insertALargeNumberOfProperties(
     Connection* conn, const string& intParam, const string& strParam) {
@@ -373,39 +374,40 @@ static void validateInsertALargeNumberOfPropertiesFails(
     }
 }
 
-TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesInTrx) {
-    conn->beginWriteTransaction();
-    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
-    validateInsertALargeNumberOfPropertiesSucceeds(conn.get(), intVal, lStrVal);
-    validateInsertALargeNumberOfPropertiesFails(readConn.get(), existingIntVal, existingStrVal);
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesCommitNormalExecution) {
-    conn->beginWriteTransaction();
-    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
-    conn->commit();
-    validateInsertALargeNumberOfPropertiesSucceeds(conn.get(), intVal, lStrVal);
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesRollbackNormalExecution) {
-    conn->beginWriteTransaction();
-    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
-    conn->rollback();
-    validateInsertALargeNumberOfPropertiesFails(conn.get(), existingIntVal, existingStrVal);
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesCommitRecovery) {
-    conn->beginWriteTransaction();
-    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
-    conn->commitButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    validateInsertALargeNumberOfPropertiesSucceeds(conn.get(), intVal, lStrVal);
-}
-
-TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesRollbackRecovery) {
-    conn->beginWriteTransaction();
-    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
-    conn->rollbackButSkipCheckpointingForTestingRecovery();
-    createDBAndConn(); // run recovery
-    validateInsertALargeNumberOfPropertiesFails(conn.get(), existingIntVal, existingStrVal);
-}
+// TODO(Semih): Uncomment when enabling ad-hoc properties
+// TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesInTrx) {
+//    conn->beginWriteTransaction();
+//    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
+//    validateInsertALargeNumberOfPropertiesSucceeds(conn.get(), intVal, lStrVal);
+//    validateInsertALargeNumberOfPropertiesFails(readConn.get(), existingIntVal, existingStrVal);
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesCommitNormalExecution) {
+//    conn->beginWriteTransaction();
+//    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
+//    conn->commit();
+//    validateInsertALargeNumberOfPropertiesSucceeds(conn.get(), intVal, lStrVal);
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesRollbackNormalExecution) {
+//    conn->beginWriteTransaction();
+//    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
+//    conn->rollback();
+//    validateInsertALargeNumberOfPropertiesFails(conn.get(), existingIntVal, existingStrVal);
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesCommitRecovery) {
+//    conn->beginWriteTransaction();
+//    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
+//    conn->commitButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    validateInsertALargeNumberOfPropertiesSucceeds(conn.get(), intVal, lStrVal);
+//}
+//
+// TEST_F(SetNodeUnstrPropTransactionTest, InsertALargeNumberOfPropertiesRollbackRecovery) {
+//    conn->beginWriteTransaction();
+//    insertALargeNumberOfProperties(conn.get(), intVal, lStrVal);
+//    conn->rollbackButSkipCheckpointingForTestingRecovery();
+//    createDBAndConn(); // run recovery
+//    validateInsertALargeNumberOfPropertiesFails(conn.get(), existingIntVal, existingStrVal);
+//}

--- a/test/runner/e2e_update_test.cpp
+++ b/test/runner/e2e_update_test.cpp
@@ -149,86 +149,87 @@ TEST_F(TinySnbUpdateTest, SetTwoHopNullTest) {
     auto groundTruth = vector<string>{"0|", "10|83", "2|", "3|", "5|", "7|20", "8|25", "9|40"};
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
 }
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrIntPropTest) {
-    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrInt64Prop=1");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrInt64Prop");
-    auto groundTruth = vector<string>{"0|1", "2|1", "3|4541124", "5|"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrDatePropTest) {
-    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrDateProp1=date('2022-10-10')");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrDateProp1");
-    auto groundTruth = vector<string>{"0|2022-10-10", "2|2022-10-10", "3|1950-01-01", "5|"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrIntervalPropTest) {
-    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrIntervalProp=interval('2 years')");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrIntervalProp");
-    auto groundTruth = vector<string>{"0|2 years", "2|2 years", "3|", "5|"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstBoolPropTest) {
-    conn->query("MATCH (a:person) WHERE a.ID < 4 SET a.unstrBoolProp1=True");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrBoolProp1");
-    auto groundTruth = vector<string>{"0|True", "2|True", "3|True", "5|False"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrShortStringPropTest) {
-    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.label1='abcd'");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.label1");
-    auto groundTruth = vector<string>{"0|abcd", "2|abcd", "3|", "5|good"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrLongStringPropTest) {
-    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.label1='abcdefghijklmnopqrstuvwxyz'");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.label1");
-    auto groundTruth = vector<string>{
-        "0|abcdefghijklmnopqrstuvwxyz", "2|abcdefghijklmnopqrstuvwxyz", "3|", "5|good"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstLongStringErrorTest) {
-    //    conn->query(
-    //        "MATCH (a:person) WHERE a.ID < 3 SET a.label1='" + getStringExceedsOverflow() + "'");
-    //    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.label1");
-    //    auto groundTruth = vector<string>{"0|", "2|", "3|4541124", "5|"};
-    //    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-    //    ASSERT_FALSE(result->isSuccess());
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrPropNullTest) {
-    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrInt64Prop=null");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrInt64Prop");
-    auto groundTruth = vector<string>{"0|", "2|", "3|4541124", "5|"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrPropFromSameNodeTest) {
-    conn->query("MATCH (a:person) SET a.label1=a.label2");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.label1");
-    auto groundTruth = vector<string>{"0|excellent", "2|excellent", "3|", "5|excellent"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeUnstrProp1HopTest) {
-    conn->query("MATCH (a:person)-[:knows]->(b:person) WHERE b.ID=0 SET a.label1=b.label2");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.label1");
-    auto groundTruth = vector<string>{"0|good", "2|excellent", "3|excellent", "5|excellent"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
-
-TEST_F(TinySnbUpdateTest, SetNodeMixedPropTest) {
-    conn->query("MATCH (a:person) WHERE a.ID= 0 SET a.label1='abcd', a.fName='A'");
-    auto result = conn->query("MATCH (a:person) WHERE a.ID < 3 RETURN a.ID,a.fName,a.label1");
-    auto groundTruth = vector<string>{"0|A|abcd", "2|Bob|"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
+// TODO(Semih): Uncomment when enabling ad-hoc properties
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrIntPropTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrInt64Prop=1");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrInt64Prop");
+//    auto groundTruth = vector<string>{"0|1", "2|1", "3|4541124", "5|"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrDatePropTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrDateProp1=date('2022-10-10')");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrDateProp1");
+//    auto groundTruth = vector<string>{"0|2022-10-10", "2|2022-10-10", "3|1950-01-01", "5|"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrIntervalPropTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrIntervalProp=interval('2 years')");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrIntervalProp");
+//    auto groundTruth = vector<string>{"0|2 years", "2|2 years", "3|", "5|"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstBoolPropTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID < 4 SET a.unstrBoolProp1=True");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrBoolProp1");
+//    auto groundTruth = vector<string>{"0|True", "2|True", "3|True", "5|False"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrShortStringPropTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.label1='abcd'");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.label1");
+//    auto groundTruth = vector<string>{"0|abcd", "2|abcd", "3|", "5|good"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrLongStringPropTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.label1='abcdefghijklmnopqrstuvwxyz'");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.label1");
+//    auto groundTruth = vector<string>{
+//        "0|abcdefghijklmnopqrstuvwxyz", "2|abcdefghijklmnopqrstuvwxyz", "3|", "5|good"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstLongStringErrorTest) {
+//    //    conn->query(
+//    //        "MATCH (a:person) WHERE a.ID < 3 SET a.label1='" + getStringExceedsOverflow() +
+//    "'");
+//    //    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.label1");
+//    //    auto groundTruth = vector<string>{"0|", "2|", "3|4541124", "5|"};
+//    //    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//    //    ASSERT_FALSE(result->isSuccess());
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrPropNullTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID < 3 SET a.unstrInt64Prop=null");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID,a.unstrInt64Prop");
+//    auto groundTruth = vector<string>{"0|", "2|", "3|4541124", "5|"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrPropFromSameNodeTest) {
+//    conn->query("MATCH (a:person) SET a.label1=a.label2");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.label1");
+//    auto groundTruth = vector<string>{"0|excellent", "2|excellent", "3|", "5|excellent"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeUnstrProp1HopTest) {
+//    conn->query("MATCH (a:person)-[:knows]->(b:person) WHERE b.ID=0 SET a.label1=b.label2");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.label1");
+//    auto groundTruth = vector<string>{"0|good", "2|excellent", "3|excellent", "5|excellent"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
+//
+// TEST_F(TinySnbUpdateTest, SetNodeMixedPropTest) {
+//    conn->query("MATCH (a:person) WHERE a.ID= 0 SET a.label1='abcd', a.fName='A'");
+//    auto result = conn->query("MATCH (a:person) WHERE a.ID < 3 RETURN a.ID,a.fName,a.label1");
+//    auto groundTruth = vector<string>{"0|A|abcd", "2|Bob|"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
 
 // Delete clause test
 
@@ -247,11 +248,10 @@ TEST_F(TinySnbUpdateTest, InsertNodeWithoutPrimaryKeyTest) {
 
 TEST_F(TinySnbUpdateTest, InsertNodeWithBoolIntDoubleTest) {
     conn->query("CREATE (:person {ID:80, isWorker:true,age:22,eyeSight:1.1});");
-    auto result =
-        conn->query("MATCH (a:person) WHERE a.ID > 8 "
-                    "RETURN a.ID, a.gender,a.isStudent, a.isWorker, a.age, a.eyeSight, a.label1");
-    auto groundTruth = vector<string>{"10|2|False|True|83|4.900000|", "80|||True|22|1.100000|",
-        "9|2|False|False|40|4.900000|good"};
+    auto result = conn->query("MATCH (a:person) WHERE a.ID > 8 "
+                              "RETURN a.ID, a.gender,a.isStudent, a.isWorker, a.age, a.eyeSight");
+    auto groundTruth = vector<string>{
+        "10|2|False|True|83|4.900000", "80|||True|22|1.100000", "9|2|False|False|40|4.900000"};
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
 }
 
@@ -294,14 +294,15 @@ TEST_F(TinySnbUpdateTest, InsertNodeWithMixedLabelTest) {
     ASSERT_EQ(TestHelper::convertResultToString(*oResult), oGroundTruth);
 }
 
-TEST_F(TinySnbUpdateTest, InsertNodeWithUnstrTest) {
-    conn->query("CREATE (:person {ID:11, label1:'a', label2:'abcdefghijklmn'});");
-    auto result = conn->query(
-        "MATCH (a:person) WHERE a.ID > 5 RETURN a.ID, a.label1, a.label2, a.unstrDateProp1");
-    auto groundTruth = vector<string>{
-        "10||good|", "11|a|abcdefghijklmn|", "7|||", "8|excellent|excellent|", "9|good||"};
-    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
-}
+// TODO(Semih): Uncomment when enabling ad-hoc properties
+// TEST_F(TinySnbUpdateTest, InsertNodeWithUnstrTest) {
+//    conn->query("CREATE (:person {ID:11, label1:'a', label2:'abcdefghijklmn'});");
+//    auto result = conn->query(
+//        "MATCH (a:person) WHERE a.ID > 5 RETURN a.ID, a.label1, a.label2, a.unstrDateProp1");
+//    auto groundTruth = vector<string>{
+//        "10||good|", "11|a|abcdefghijklmn|", "7|||", "8|excellent|excellent|", "9|good||"};
+//    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+//}
 
 TEST_F(TinySnbUpdateTest, InsertNodeAfterMatchListTest) {
     conn->query("MATCH (a:person) CREATE (:person {ID:a.ID+11, age:a.age*2});");

--- a/test/storage/unstructured_property_lists_updates_test.cpp
+++ b/test/storage/unstructured_property_lists_updates_test.cpp
@@ -304,76 +304,82 @@ public:
     Value existingStrVal, existingIntVal, shortStrVal, longStrVal, intVal;
 };
 
+// TODO(Semih): Uncomment when enabling ad-hoc properties
 // TODO(Xiyang): migrate to delete
-TEST_F(UnstructuredPropertyListsUpdateTests,
-    RemoveAllPropertiesBySetPropertyListEmptyCommitNormalExecution) {
-    removeAllPropertiesBySetPropertyListEmptyTest(
-        true /* commit */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests,
-    RemoveAllPropertiesBySetPropertyListEmptyRollbackNormalExecution) {
-    removeAllPropertiesBySetPropertyListEmptyTest(
-        false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(
-    UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesBySetPropertyListEmptyCommitRecovery) {
-    removeAllPropertiesBySetPropertyListEmptyTest(true /* commit */, TransactionTestType::RECOVERY);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests,
-    RemoveAllPropertiesBySetPropertyListEmptyRollbackRecovery) {
-    removeAllPropertiesBySetPropertyListEmptyTest(
-        false /* rollback */, TransactionTestType::RECOVERY);
-}
-
-// TODO(Semih/Ziyi): the following tests should be removed and moved into benchmark.
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesOfAllNodesCommitNormalExecution) {
-    removeAllPropertiesOfAllNodesTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesOfAllNodesRollbackNormalExecution) {
-    removeAllPropertiesOfAllNodesTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesOfAllNodesCommitRecovery) {
-    removeAllPropertiesOfAllNodesTest(true /* commit */, TransactionTestType::RECOVERY);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesOfAllNodesRollbackRecovery) {
-    removeAllPropertiesOfAllNodesTest(false /* rollback */, TransactionTestType::RECOVERY);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestCommitNormalExecution) {
-    removeAndWriteDataTwiceTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestRollbackNormalExecution) {
-    removeAndWriteDataTwiceTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestCommitRecovery) {
-    removeAndWriteDataTwiceTest(true /* commit */, TransactionTestType::RECOVERY);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestRollbackRecovery) {
-    removeAndWriteDataTwiceTest(false /* rollback */, TransactionTestType::RECOVERY);
-}
-
-// TODO(Xiyang): migrate to create
-TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestCommitNormalExecution) {
-    addNewListsTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestRollbackNormalExecution) {
-    addNewListsTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestCommitRecovery) {
-    addNewListsTest(true /* commit */, TransactionTestType::RECOVERY);
-}
-
-TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestRollbackRecovery) {
-    addNewListsTest(false /* rollback */, TransactionTestType::RECOVERY);
-}
+// TEST_F(UnstructuredPropertyListsUpdateTests,
+//    RemoveAllPropertiesBySetPropertyListEmptyCommitNormalExecution) {
+//    removeAllPropertiesBySetPropertyListEmptyTest(
+//        true /* commit */, TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests,
+//    RemoveAllPropertiesBySetPropertyListEmptyRollbackNormalExecution) {
+//    removeAllPropertiesBySetPropertyListEmptyTest(
+//        false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(
+//    UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesBySetPropertyListEmptyCommitRecovery)
+//    { removeAllPropertiesBySetPropertyListEmptyTest(true /* commit */,
+//    TransactionTestType::RECOVERY);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests,
+//    RemoveAllPropertiesBySetPropertyListEmptyRollbackRecovery) {
+//    removeAllPropertiesBySetPropertyListEmptyTest(
+//        false /* rollback */, TransactionTestType::RECOVERY);
+//}
+//
+//// TODO(Semih/Ziyi): the following tests should be removed and moved into benchmark.
+// TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesOfAllNodesCommitNormalExecution)
+// {
+//    removeAllPropertiesOfAllNodesTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests,
+// RemoveAllPropertiesOfAllNodesRollbackNormalExecution) {
+//    removeAllPropertiesOfAllNodesTest(false /* rollback */,
+//    TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesOfAllNodesCommitRecovery) {
+//    removeAllPropertiesOfAllNodesTest(true /* commit */, TransactionTestType::RECOVERY);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAllPropertiesOfAllNodesRollbackRecovery) {
+//    removeAllPropertiesOfAllNodesTest(false /* rollback */, TransactionTestType::RECOVERY);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestCommitNormalExecution) {
+//    removeAndWriteDataTwiceTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestRollbackNormalExecution)
+// {
+//    removeAndWriteDataTwiceTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestCommitRecovery) {
+//    removeAndWriteDataTwiceTest(true /* commit */, TransactionTestType::RECOVERY);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, RemoveAndWriteDataTwiceTestRollbackRecovery) {
+//    removeAndWriteDataTwiceTest(false /* rollback */, TransactionTestType::RECOVERY);
+//}
+//
+//// TODO(Xiyang): migrate to create
+// TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestCommitNormalExecution) {
+//    addNewListsTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestRollbackNormalExecution) {
+//    addNewListsTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestCommitRecovery) {
+//    addNewListsTest(true /* commit */, TransactionTestType::RECOVERY);
+//}
+//
+// TEST_F(UnstructuredPropertyListsUpdateTests, AddNewListTestRollbackRecovery) {
+//    addNewListsTest(false /* rollback */, TransactionTestType::RECOVERY);
+//}

--- a/test/test_files/tinySNB/agg/distinct_agg.test
+++ b/test/test_files/tinySNB/agg/distinct_agg.test
@@ -1,7 +1,9 @@
+# TODO(Semih): Add the following when enabling ad-hoc properties
+# in query: , COUNT(DISTINCT a.unstrDateProp1); in result: |2
 -NAME SingleNodeDistinctAggTest1
--QUERY MATCH (a:person) RETURN COUNT(DISTINCT a.gender), COUNT(DISTINCT a.age), COUNT(DISTINCT a.unstrDateProp1)
+-QUERY MATCH (a:person) RETURN COUNT(DISTINCT a.gender), COUNT(DISTINCT a.age)
 ---- 1
-2|7|2
+2|7
 
 -NAME SingleNodeDistinctAggTest2
 -QUERY MATCH (a:person) RETURN a.gender, COUNT(DISTINCT a.isStudent)
@@ -9,12 +11,13 @@
 1|2
 2|2
 
--NAME OneHopDistinctAggTest
--QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.isStudent, COUNT(a.ID), COUNT(DISTINCT b.unstrNumericProp)
--ENUMERATE
----- 2
-False|8|2
-True|6|2
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME OneHopDistinctAggTest
+#-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.isStudent, COUNT(a.ID), COUNT(DISTINCT b.unstrNumericProp)
+#-ENUMERATE
+#---- 2
+#False|8|2
+#True|6|2
 
 -NAME TwoHopDistinctAggTest
 -QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN a.ID, SUM(DISTINCT a.age), SUM(DISTINCT c.age)

--- a/test/test_files/tinySNB/agg/hash.test
+++ b/test/test_files/tinySNB/agg/hash.test
@@ -9,24 +9,25 @@
 45|3|5.000000|1
 83|10|4.900000|1
 
--NAME SingleNodeAggTest2
--QUERY MATCH (a:person) RETURN a.unstrDateProp1, SUM(a.unstrNumericProp), COUNT(*)
---PARALLELISM 4
----- 3
-1900-01-01||1
-1950-01-01|99|2
-|68.000000|5
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME SingleNodeAggTest2
+#-QUERY MATCH (a:person) RETURN a.unstrDateProp1, SUM(a.unstrNumericProp), COUNT(*)
+#--PARALLELISM 4
+#---- 3
+#1900-01-01||1
+#1950-01-01|99|2
+#|68.000000|5
 
--NAME GroupByKeyWithNullString
--QUERY MATCH (a:person) return a.label1,a.label2, count(*)
--PARALLELISM 1
----- 6
-excellent|excellent|1
-good|excellent|2
-good||1
-|excellent|1
-|good|1
-||2
+#-NAME GroupByKeyWithNullString
+#-QUERY MATCH (a:person) return a.label1,a.label2, count(*)
+#-PARALLELISM 1
+#---- 6
+#excellent|excellent|1
+#good|excellent|2
+#good||1
+#|excellent|1
+#|good|1
+#||2
 
 -NAME InMemOverflowBufferTest
 -QUERY MATCH (a:person) RETURN a.fName as name, COUNT(*) order by name desc
@@ -58,14 +59,15 @@ Alice|1
 35|1|3
 45|1|3
 
--NAME OneHopAggTest2
--QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.unstrNumericProp, SUM(a.unstrNumericProp2)
--ENUMERATE
----- 4
-47|60
-52|
-68.000000|
-|
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME OneHopAggTest2
+#-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN a.unstrNumericProp, SUM(a.unstrNumericProp2)
+#-ENUMERATE
+#---- 4
+#47|60
+#52|
+#68.000000|
+#|
 
 -NAME TwoHopAggTest
 -QUERY MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN a.gender, COUNT(*)

--- a/test/test_files/tinySNB/agg/multi_query_part.test
+++ b/test/test_files/tinySNB/agg/multi_query_part.test
@@ -1,7 +1,8 @@
--NAME SimpleCountMultiQueryTest
--QUERY MATCH (a:person) WITH COUNT(a.age) + COUNT(a.unstrNumericProp) AS newCount RETURN newCount > 12
----- 1
-False
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME SimpleCountMultiQueryTest
+#-QUERY MATCH (a:person) WITH COUNT(a.age) + COUNT(a.unstrNumericProp) AS newCount RETURN newCount > 12
+#---- 1
+#False
 
 -NAME SimpleAvgWithFilterMultiQueryTest
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') WITH AVG(a.age) AS avgAge, AVG(a.eyeSight) AS avgEyeSight RETURN avgAge > avgEyeSight

--- a/test/test_files/tinySNB/agg/simple.test
+++ b/test/test_files/tinySNB/agg/simple.test
@@ -1,22 +1,28 @@
+# TODO(Semih): Add the following when enabling ad-hoc properties
+# in query: AVG(a.unstrNumericProp); in result: |55.666667
 -NAME SimpleAvgTest
--QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight), AVG(a.unstrNumericProp)
+-QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight)
 ---- 1
-37.250000|4.862500|55.666667
+37.250000|4.862500
 
+# TODO(Semih): Add the following when enabling ad-hoc properties
+# in query: COUNT(a.unstrNumericProp) * 2.0; in result: |6.000000
 -NAME SimpleCountTest
--QUERY MATCH (a:person) RETURN COUNT(a.age) + 1, COUNT(a.unstrNumericProp) * 2.0
+-QUERY MATCH (a:person) RETURN COUNT(a.age) + 1
 ---- 1
-9|6.000000
+9
 
 -NAME SimpleCountTest2
 -QUERY MATCH (a:person)-[e1:knows]->(:person) RETURN COUNT(e1)
 ---- 1
 14
 
+# TODO(Semih): Add the following when enabling ad-hoc properties
+# in query: SUM(a.unstrNumericProp); in result: |167.000000
 -NAME SimpleSumTest
--QUERY MATCH (a:person) RETURN SUM(a.age), SUM(a.eyeSight), SUM(a.unstrNumericProp)
+-QUERY MATCH (a:person) RETURN SUM(a.age), SUM(a.eyeSight)
 ---- 1
-298|38.900000|167.000000
+298|38.900000
 
 -NAME SimpleSumTest2
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN SUM(a.age+10), SUM(a.age*2)
@@ -28,10 +34,12 @@
 ---- 1
 False
 
+# TODO(Semih): Add the following when enabling ad-hoc properties
+# in query: , AVG(a.unstrNumericProp); in result: |55.666667
 -NAME SimpleAvgTest
--QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight), AVG(a.unstrNumericProp)
+-QUERY MATCH (a:person) RETURN AVG(a.age), AVG(a.eyeSight)
 ---- 1
-37.250000|4.862500|55.666667
+37.250000|4.862500
 
 -NAME SimpleAvgTest2
 -QUERY MATCH (a:person) WHERE a.birthdate = date('1980-10-26') RETURN AVG(a.age), AVG(a.eyeSight)
@@ -43,8 +51,10 @@ False
 ---- 1
 20|83|False|True|4.500000|5.100000|1900-01-01|1990-11-27
 
+# TODO(Semih): Add the following when enabling ad-hoc properties
+# in query: MAX(b.unstrNumericProp); in result: |52
 -NAME TwoHopTest
--QUERY MATCH (a:person)-[:knows]->(b:person) RETURN SUM(b.age), MIN(b.ID), AVG(b.eyeSight), MAX(b.unstrNumericProp)
+-QUERY MATCH (a:person)-[:knows]->(b:person) RETURN SUM(b.age), MIN(b.ID), AVG(b.eyeSight)
 -ENUMERATE
 ---- 1
-455|0|4.935714|52
+455|0|4.935714

--- a/test/test_files/tinySNB/filter/node.test
+++ b/test/test_files/tinySNB/filter/node.test
@@ -123,72 +123,73 @@
 ---- 1
 3
 
--NAME PersonUnstrFilteredTest1
--QUERY MATCH (a:person) WHERE a.unstrNumericProp > 48 RETURN COUNT(*)
----- 1
-2
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME PersonUnstrFilteredTest1
+#-QUERY MATCH (a:person) WHERE a.unstrNumericProp > 48 RETURN COUNT(*)
+#---- 1
+#2
 
--NAME PersonUnstrFilteredTest2
--QUERY MATCH (a:person) WHERE a.unstrNumericProp <= 68 RETURN COUNT(*)
----- 1
-3
+#-NAME PersonUnstrFilteredTest2
+#-QUERY MATCH (a:person) WHERE a.unstrNumericProp <= 68 RETURN COUNT(*)
+#---- 1
+#3
 
--NAME PersonUnstrFilteredTest3
--QUERY MATCH (a:person) WHERE a.unstrNumericProp = 52 RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest3
+#-QUERY MATCH (a:person) WHERE a.unstrNumericProp = 52 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest4
--QUERY MATCH (a:person) WHERE 10 + a.unstrNumericProp = 57 RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest4
+#-QUERY MATCH (a:person) WHERE 10 + a.unstrNumericProp = 57 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest5
--QUERY MATCH (a:person) WHERE a.unstrNumericProp + a.unstrNumericProp2 = 67 RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest5
+#-QUERY MATCH (a:person) WHERE a.unstrNumericProp + a.unstrNumericProp2 = 67 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest6
--QUERY MATCH (a:person) WHERE a.unstrNumericProp - 10 > a.unstrNumericProp2 RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest6
+#-QUERY MATCH (a:person) WHERE a.unstrNumericProp - 10 > a.unstrNumericProp2 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest7
--QUERY MATCH (a:person) WHERE concat('abc ', string(a.unstrNumericProp)) = 'abc 52' RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest7
+#-QUERY MATCH (a:person) WHERE concat('abc ', string(a.unstrNumericProp)) = 'abc 52' RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest8
--QUERY MATCH (a:person) WHERE concat(a.unstrNumericProp2, ' abcdefghijklm') = '20 abcdefghijklm' RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest8
+#-QUERY MATCH (a:person) WHERE concat(a.unstrNumericProp2, ' abcdefghijklm') = '20 abcdefghijklm' RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest10
--QUERY MATCH (a:person) WHERE '47Bob' = concat(string(a.unstrNumericProp), a.fName) RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest10
+#-QUERY MATCH (a:person) WHERE '47Bob' = concat(string(a.unstrNumericProp), a.fName) RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest11
--QUERY MATCH (a:person) WHERE concat(string(a.unstrDateProp1), a.fName) = '1950-01-01Bob' RETURN COUNT(*)
----- 1
-1
+#-NAME PersonUnstrFilteredTest11
+#-QUERY MATCH (a:person) WHERE concat(string(a.unstrDateProp1), a.fName) = '1950-01-01Bob' RETURN COUNT(*)
+#---- 1
+#1
 
--NAME PersonUnstrFilteredTest12
--QUERY MATCH (a:person) WHERE a.unstrDateProp1 IS NULL RETURN COUNT(*)
----- 1
-5
+#-NAME PersonUnstrFilteredTest12
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp1 IS NULL RETURN COUNT(*)
+#---- 1
+#5
 
--NAME PersonUnstrFilteredTest13
--QUERY MATCH (a:person) WHERE a.unstrDateProp1 IS NOT NULL RETURN COUNT(*)
----- 1
-3
+#-NAME PersonUnstrFilteredTest13
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp1 IS NOT NULL RETURN COUNT(*)
+#---- 1
+#3
 
--NAME PersonUnstrFilteredTest14
--QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 IS NULL RETURN COUNT(*)
----- 1
-4
+#-NAME PersonUnstrFilteredTest14
+#-QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 IS NULL RETURN COUNT(*)
+#---- 1
+#4
 
--NAME PersonUnstrFilteredTest15
--QUERY MATCH (a:person) WHERE a.unstrTimestampProp2  IS NOT NULL RETURN COUNT(*)
----- 1
-2
+#-NAME PersonUnstrFilteredTest15
+#-QUERY MATCH (a:person) WHERE a.unstrTimestampProp2  IS NOT NULL RETURN COUNT(*)
+#---- 1
+#2

--- a/test/test_files/tinySNB/filter/one_hop.test
+++ b/test/test_files/tinySNB/filter/one_hop.test
@@ -32,8 +32,9 @@
 ---- 1
 6
 
--NAME PersonUnstrFilteredTest9
--QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.unstrNumericProp > b.unstrNumericProp RETURN COUNT(*)
--ENUMERATE
----- 1
-1
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME PersonUnstrFilteredTest9
+#-QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.unstrNumericProp > b.unstrNumericProp RETURN COUNT(*)
+#-ENUMERATE
+#---- 1
+#1

--- a/test/test_files/tinySNB/function/arithmetic.test
+++ b/test/test_files/tinySNB/function/arithmetic.test
@@ -5,12 +5,13 @@
 0.340000
 0.320000
 
--NAME powerFunctionOnUnstrIntUnstrIntTest
--QUERY MATCH (a:organisation) RETURN (a.unstrInt64Prop % 7) ^ abs(a.unstrInt64Prop)
----- 3
-59049.000000
-256.000000
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME powerFunctionOnUnstrIntUnstrIntTest
+#-QUERY MATCH (a:organisation) RETURN (a.unstrInt64Prop % 7) ^ abs(a.unstrInt64Prop)
+#---- 3
+#59049.000000
+#256.000000
+#
 
 -NAME sinFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) WHERE a.name <> 'abc' RETURN sin(a.mark)
@@ -26,19 +27,20 @@
 -0.811656
 0.785018
 
--NAME sinFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) WHERE a.name <> 'good' RETURN sin(a.unstrInt64Prop)
----- 3
--0.544021
-0.756802
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME sinFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) WHERE a.name <> 'good' RETURN sin(a.unstrInt64Prop)
+#---- 3
+#-0.544021
+#0.756802
+#
 
-
--NAME sinFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN sin(a.unstrNumericProp)
----- 3
-0.066322
--0.157746
-
+#-NAME sinFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN sin(a.unstrNumericProp)
+#---- 3
+#0.066322
+#-0.157746
+#
 
 -NAME cosFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN cos(a.mark)
@@ -53,19 +55,20 @@
 -0.584135
 0.619473
 
--NAME cosFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN cos(a.unstrInt64Prop)
----- 3
--0.839072
--0.653644
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME cosFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN cos(a.unstrInt64Prop)
+#---- 3
+#-0.839072
+#-0.653644
+#
 
-
--NAME cosFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN cos(a.unstrNumericProp)
----- 3
-0.997798
--0.987480
-
+#-NAME cosFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN cos(a.unstrNumericProp)
+#---- 3
+#0.997798
+#-0.987480
+#
 
 -NAME tanFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN tan(a.mark)
@@ -81,19 +84,20 @@
 1.389500
 1.267234
 
--NAME tanFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN tan(a.unstrInt64Prop)
----- 3
-0.648361
--1.157821
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME tanFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN tan(a.unstrInt64Prop)
+#---- 3
+#0.648361
+#-1.157821
+#
 
-
--NAME tanFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN tan(a.unstrNumericProp)
----- 3
-0.066468
-0.159746
-
+#-NAME tanFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN tan(a.unstrNumericProp)
+#---- 3
+#0.066468
+#0.159746
+#
 
 -NAME cotFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN cot(a.mark)
@@ -109,19 +113,20 @@
 0.719683
 0.789120
 
--NAME cotFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN cot(a.unstrInt64Prop)
----- 3
-1.542351
--0.863691
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME cotFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN cot(a.unstrInt64Prop)
+#---- 3
+#1.542351
+#-0.863691
+#
 
-
--NAME cotFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN cot(a.unstrNumericProp)
----- 3
-15.044779
-6.259948
-
+#-NAME cotFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN cot(a.unstrNumericProp)
+#---- 3
+#15.044779
+#6.259948
+#
 
 -NAME asinFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN asin(a.rating)
@@ -137,19 +142,20 @@
 -1.570796
 -1.570796
 
--NAME asinFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN asin(a.unstrInt64Prop % 2 - 1)
----- 3
--1.570796
--1.570796
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME asinFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN asin(a.unstrInt64Prop % 2 - 1)
+#---- 3
+#-1.570796
+#-1.570796
+#
 
-
--NAME asinFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN asin(a.unstrNumericProp / 14)
----- 3
--1.103650
-0.237953
-
+#-NAME asinFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN asin(a.unstrNumericProp / 14)
+#---- 3
+#-1.103650
+#0.237953
+#
 
 -NAME acosFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN acos(a.rating)
@@ -165,19 +171,20 @@
 3.141593
 3.141593
 
--NAME acosFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN acos(a.unstrInt64Prop % 2 - 1)
----- 3
-3.141593
-3.141593
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME acosFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN acos(a.unstrInt64Prop % 2 - 1)
+#---- 3
+#3.141593
+#3.141593
+#
 
-
--NAME acosFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN acos(a.unstrNumericProp / 14)
----- 3
-2.674447
-1.332843
-
+#-NAME acosFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN acos(a.unstrNumericProp / 14)
+#---- 3
+#2.674447
+#1.332843
+#
 
 -NAME atanFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN atan(a.rating)
@@ -193,18 +200,19 @@
 -0.785398
 -0.785398
 
--NAME atanFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN atan(a.unstrInt64Prop % 2 - 1)
----- 3
--0.785398
--0.785398
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME atanFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN atan(a.unstrInt64Prop % 2 - 1)
+#---- 3
+#-0.785398
+#-0.785398
+#
 
-
--NAME atanFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN atan(a.unstrNumericProp / 14)
----- 3
--0.728855
-0.231489
+#-NAME atanFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN atan(a.unstrNumericProp / 14)
+#---- 3
+#-0.728855
+#0.231489
 
 -NAME evenFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN even(a.mark)
@@ -220,18 +228,19 @@
 934
 824
 
--NAME evenFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN even(a.unstrInt64Prop)
----- 3
-10
--4
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME evenFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN even(a.unstrInt64Prop)
+#---- 3
+#10
+#-4
+#
 
-
--NAME evenFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN even(a.unstrNumericProp)
----- 3
--14
-4
+#-NAME evenFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN even(a.unstrNumericProp)
+#---- 3
+#-14
+#4
 
 -NAME factorialFunctionOnInt64Test
 -QUERY MATCH (a:organisation) RETURN factorial(a.orgCode % 20)
@@ -240,12 +249,13 @@
 24
 87178291200
 
--NAME factorialFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN factorial(a.unstrInt64Prop + 4)
----- 3
-87178291200
-1
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME factorialFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN factorial(a.unstrInt64Prop + 4)
+#---- 3
+#87178291200
+#1
+#
 
 -NAME signFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN sign(a.mark)
@@ -261,18 +271,19 @@
 1
 1
 
--NAME signFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN sign(a.unstrInt64Prop)
----- 3
-1
--1
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME signFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN sign(a.unstrInt64Prop)
+#---- 3
+#1
+#-1
+#
 
-
--NAME signFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN sign(a.unstrNumericProp)
----- 3
--1
-1
+#-NAME signFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN sign(a.unstrNumericProp)
+#---- 3
+#-1
+#1
 
 -NAME sqrtFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN sqrt(a.mark)
@@ -288,19 +299,20 @@
 30.561414
 28.705400
 
--NAME sqrtFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN sqrt(a.unstrInt64Prop + 6)
----- 3
-1.414214
-4.000000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME sqrtFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN sqrt(a.unstrInt64Prop + 6)
+#---- 3
+#1.414214
+#4.000000
+#
 
-
--NAME sqrtFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN sqrt(a.unstrNumericProp + 13.5)
----- 3
-1.000000
-4.098780
-
+#-NAME sqrtFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN sqrt(a.unstrNumericProp + 13.5)
+#---- 3
+#1.000000
+#4.098780
+#
 
 -NAME cbrtFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN cbrt(a.mark)
@@ -316,19 +328,20 @@
 9.774974
 9.375096
 
--NAME cbrtFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN cbrt(a.unstrInt64Prop)
----- 3
-2.154435
--1.587401
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME cbrtFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN cbrt(a.unstrInt64Prop)
+#---- 3
+#2.154435
+#-1.587401
+#
 
-
--NAME cbrtFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN cbrt(a.unstrNumericProp)
----- 3
--2.320794
-1.488806
-
+#-NAME cbrtFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN cbrt(a.unstrNumericProp)
+#---- 3
+#-2.320794
+#1.488806
+#
 
 -NAME gammaFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN gamma(a.mark)
@@ -344,17 +357,18 @@
 6
 6
 
--NAME gammaFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN gamma(a.unstrInt64Prop + 7)
----- 3
-20922789888000
-2
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME gammaFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN gamma(a.unstrInt64Prop + 7)
+#---- 3
+#20922789888000
+#2
 
--NAME gammaFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN gamma(abs(a.unstrNumericProp) - 3)
----- 3
-119292.461995
-2.991569
+#-NAME gammaFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN gamma(abs(a.unstrNumericProp) - 3)
+#---- 3
+#119292.461995
+#2.991569
 
 -NAME lgammaFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN lgamma(a.mark)
@@ -370,12 +384,13 @@
 5451.570283
 4706.038471
 
--NAME lgammaFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN lgamma(a.unstrInt64Prop + 5)
----- 3
-0.000000
-25.191221
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME lgammaFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN lgamma(a.unstrInt64Prop + 5)
+#---- 3
+#0.000000
+#25.191221
+#
 
 -NAME lnFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN ln(a.mark)
@@ -391,19 +406,20 @@
 6.839476
 6.714171
 
--NAME lnFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN ln(a.unstrInt64Prop + 5)
----- 3
-2.708050
-0.000000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME lnFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN ln(a.unstrInt64Prop + 5)
+#---- 3
+#2.708050
+#0.000000
+#
 
-
--NAME lnFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN ln(a.unstrNumericProp + 13.2)
----- 3
--0.356675
-2.803360
-
+#-NAME lnFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN ln(a.unstrNumericProp + 13.2)
+#---- 3
+#-0.356675
+#2.803360
+#
 
 -NAME logFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN log(a.mark)
@@ -419,19 +435,20 @@
 2.970347
 2.915927
 
--NAME logFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN log(a.unstrInt64Prop + 5)
----- 3
-1.176091
-0.000000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME logFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN log(a.unstrInt64Prop + 5)
+#---- 3
+#1.176091
+#0.000000
+#
 
-
--NAME logFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN log(a.unstrNumericProp + 13.2)
----- 3
--0.154902
-1.217484
-
+#-NAME logFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN log(a.unstrNumericProp + 13.2)
+#---- 3
+#-0.154902
+#1.217484
+#
 
 -NAME log2FunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN log2(a.mark)
@@ -447,19 +464,20 @@
 9.867279
 9.686501
 
--NAME log2FunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN log2(a.unstrInt64Prop + 5)
----- 3
-3.906891
-0.000000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME log2FunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN log2(a.unstrInt64Prop + 5)
+#---- 3
+#3.906891
+#0.000000
+#
 
-
--NAME log2FunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN log2(a.unstrNumericProp + 13.2)
----- 3
--0.514573
-4.044394
-
+#-NAME log2FunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN log2(a.unstrNumericProp + 13.2)
+#---- 3
+#-0.514573
+#4.044394
+#
 
 -NAME degreesFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN degrees(a.mark)
@@ -475,19 +493,20 @@
 53514.258065
 47211.722319
 
--NAME degreesFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN degrees(a.unstrInt64Prop)
----- 3
-572.957795
--229.183118
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME degreesFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN degrees(a.unstrInt64Prop)
+#---- 3
+#572.957795
+#-229.183118
+#
 
-
--NAME degreesFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN degrees(a.unstrNumericProp)
----- 3
--716.197244
-189.076072
-
+#-NAME degreesFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN degrees(a.unstrNumericProp)
+#---- 3
+#-716.197244
+#189.076072
+#
 
 -NAME radiansFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) RETURN radians(a.mark)
@@ -503,19 +522,20 @@
 16.301375
 14.381513
 
--NAME radiansFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN radians(a.unstrInt64Prop)
----- 3
-0.174533
--0.069813
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME radiansFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN radians(a.unstrInt64Prop)
+#---- 3
+#0.174533
+#-0.069813
+#
 
-
--NAME radiansFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN radians(a.unstrNumericProp)
----- 3
--0.218166
-0.057596
-
+#-NAME radiansFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN radians(a.unstrNumericProp)
+#---- 3
+#-0.218166
+#0.057596
+#
 
 -NAME atan2FunctionOnDoubleDoubleTest
 -QUERY MATCH (a:organisation) RETURN atan2(a.mark, a.mark)
@@ -545,26 +565,27 @@
 1.566407
 1.565821
 
--NAME atan2FunctionOnUnstrInt64DoubleTest
--QUERY MATCH (a:organisation) RETURN atan2(a.unstrInt64Prop, a.unstrNumericProp)
----- 3
-1.252049
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME atan2FunctionOnUnstrInt64DoubleTest
+#-QUERY MATCH (a:organisation) RETURN atan2(a.unstrInt64Prop, a.unstrNumericProp)
+#---- 3
+#1.252049
+#
+#
 
+#-NAME atan2FunctionOnUnstrDoubleUnstrDoubleTest
+#-QUERY MATCH (a:organisation) RETURN atan2(a.unstrNumericProp, a.unstrNumericProp)
+#---- 3
+#-2.356194
+#
+#0.785398
 
-
--NAME atan2FunctionOnUnstrDoubleUnstrDoubleTest
--QUERY MATCH (a:organisation) RETURN atan2(a.unstrNumericProp, a.unstrNumericProp)
----- 3
--2.356194
-
-0.785398
-
--NAME atan2FunctionOnUnstrDoubleUnstrIntTest
--QUERY MATCH (a:organisation) RETURN atan2(a.unstrNumericProp, a.unstrInt64Prop)
----- 3
-
-
-0.318748
+#-NAME atan2FunctionOnUnstrDoubleUnstrIntTest
+#-QUERY MATCH (a:organisation) RETURN atan2(a.unstrNumericProp, a.unstrInt64Prop)
+#---- 3
+#
+#
+#0.318748
 
 -NAME roundFunctionOnDoubleTest
 -QUERY MATCH (a:organisation) WHERE a.ID <> 2 RETURN round(a.rating, 1)
@@ -580,33 +601,35 @@
 824.000000
 934.000000
 
--NAME roundFunctionOnUnstrDoubleTest
--QUERY MATCH (a:organisation) WHERE a.ID <> 2 RETURN round(a.unstrNumericProp, a.unstrInt64Prop)
----- 3
-3.300000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME roundFunctionOnUnstrDoubleTest
+#-QUERY MATCH (a:organisation) WHERE a.ID <> 2 RETURN round(a.unstrNumericProp, a.unstrInt64Prop)
+#---- 3
+#3.300000
+#
+#
 
+#-NAME roundFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN round(a.unstrInt64Prop, 3)
+#---- 3
+#-4.000000
+#10.000000
+#
 
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME bitwiseXorFunctionOnInt64Test
+#-QUERY MATCH (a:organisation) WHERE a.ID <> 2 RETURN bitwise_xor(a.orgCode, a.score)
+#---- 3
+#-325
+#-966
+#831
 
--NAME roundFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN round(a.unstrInt64Prop, 3)
----- 3
--4.000000
-10.000000
-
-
--NAME bitwiseXorFunctionOnInt64Test
--QUERY MATCH (a:organisation) WHERE a.ID <> 2 RETURN bitwise_xor(a.orgCode, a.score)
----- 3
--325
--966
-831
-
--NAME bitwiseXorFunctionOnUnstrInt64Test
--QUERY MATCH (a:organisation) RETURN bitwise_xor(a.unstrInt64Prop, a.unstrInt64Prop)
----- 3
-0
-0
-
+#-NAME bitwiseXorFunctionOnUnstrInt64Test
+#-QUERY MATCH (a:organisation) RETURN bitwise_xor(a.unstrInt64Prop, a.unstrInt64Prop)
+#---- 3
+#0
+#0
+#
 
 -NAME piFunctionAddStrIntTest
 -QUERY MATCH (a:organisation) RETURN a.orgCode + pi()
@@ -615,17 +638,18 @@
 937.141593
 827.141593
 
--NAME piFunctionAddUnstrNumericalValTest
--QUERY MATCH (a:person) RETURN a.unstrNumericProp + pi()
----- 8
-50.141593
-55.141593
-71.141593
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME piFunctionAddUnstrNumericalValTest
+#-QUERY MATCH (a:person) RETURN a.unstrNumericProp + pi()
+#---- 8
+#50.141593
+#55.141593
+#71.141593
+#
+#
+#
+#
+#
 
 -NAME AbsFunctionStrInt
 -QUERY MATCH (a:organisation) RETURN abs(a.score)
@@ -634,12 +658,13 @@
 2
 7
 
--NAME AbsFunctionUnstrValue
--QUERY MATCH (a:organisation) RETURN abs(a.unstrNumericProp)
----- 3
-
-12.500000
-3.300000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME AbsFunctionUnstrValue
+#-QUERY MATCH (a:organisation) RETURN abs(a.unstrNumericProp)
+#---- 3
+#
+#12.500000
+#3.300000
 
 -NAME FloorFunctionStrInt
 -QUERY MATCH (a:organisation) RETURN floor(a.score)
@@ -648,12 +673,13 @@
 -100
 7
 
--NAME FloorFunctionUnstrValue
--QUERY MATCH (a:organisation) RETURN floor(a.unstrNumericProp)
----- 3
--13.000000
-
-3.000000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME FloorFunctionUnstrValue
+#-QUERY MATCH (a:organisation) RETURN floor(a.unstrNumericProp)
+#---- 3
+#-13.000000
+#
+#3.000000
 
 -NAME CeilFunctionStrInt
 -QUERY MATCH (a:organisation) RETURN ceil(a.score)
@@ -662,16 +688,17 @@
 -100
 7
 
--NAME CeilFunctionUnstrValue
--QUERY MATCH (a:organisation) RETURN ceiling(a.unstrNumericProp)
----- 3
--12.000000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME CeilFunctionUnstrValue
+#-QUERY MATCH (a:organisation) RETURN ceiling(a.unstrNumericProp)
+#---- 3
+#-12.000000
+#
+#4.000000
 
-4.000000
-
--NAME CeilFloorFunctionTest
--QUERY MATCH (a:organisation) RETURN ceil(ceil(a.unstrNumericProp + abs(-0.5)) + floor(3.5))
----- 3
-
--9.000000
-7.000000
+#-NAME CeilFloorFunctionTest
+#-QUERY MATCH (a:organisation) RETURN ceil(ceil(a.unstrNumericProp + abs(-0.5)) + floor(3.5))
+#---- 3
+#
+#-9.000000
+#7.000000

--- a/test/test_files/tinySNB/function/boolean.test
+++ b/test/test_files/tinySNB/function/boolean.test
@@ -44,20 +44,21 @@ Greg
 ---- 1
 7
 
--NAME UnstructuredBoolEqualTest
--QUERY MATCH (a:person) WHERE a.unstrBoolProp1 = a.isStudent RETURN count(*)
----- 1
-2
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredBoolEqualTest
+#-QUERY MATCH (a:person) WHERE a.unstrBoolProp1 = a.isStudent RETURN count(*)
+#---- 1
+#2
 
--NAME UnstructuredBoolNotEqualTest
--QUERY MATCH (a:person) WHERE a.unstrBoolProp1 <> a.isStudent RETURN count(*)
----- 1
-2
+#-NAME UnstructuredBoolNotEqualTest
+#-QUERY MATCH (a:person) WHERE a.unstrBoolProp1 <> a.isStudent RETURN count(*)
+#---- 1
+#2
 
--NAME UnstructuredBoolComparisonTest
--QUERY MATCH (a:person) WHERE a.unstrBoolProp1 > a.isWorker RETURN count(*)
----- 1
-0
+#-NAME UnstructuredBoolComparisonTest
+#-QUERY MATCH (a:person) WHERE a.unstrBoolProp1 > a.isWorker RETURN count(*)
+#---- 1
+#0
 
 -NAME BoolExecTest4
 -QUERY MATCH (a:person) WHERE a.fName = 'Alice' RETURN a.isStudent and a.isWorker

--- a/test/test_files/tinySNB/function/cast.test
+++ b/test/test_files/tinySNB/function/cast.test
@@ -106,98 +106,99 @@ Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 [[10]]
 [[7],[10],[6,7]]
 
--NAME CastUnstructuredNumericValueToString
--QUERY MATCH (p:person) RETURN string(p.unstrNumericProp)
----- 8
-47
-52
-68.000000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME CastUnstructuredNumericValueToString
+#-QUERY MATCH (p:person) RETURN string(p.unstrNumericProp)
+#---- 8
+#47
+#52
+#68.000000
+#
+#
+#
+#
+#
 
+#-NAME CastBoolToUnstructured
+#-QUERY MATCH (p:person) RETURN p.unstrBoolProp1 = p.isStudent
+#---- 8
+#
+#
+#True
+#True
+#False
+#
+#
+#False
 
+#-NAME CastInt64ToUnstructured
+#-QUERY MATCH (p:person) RETURN round(p.unstrNumericProp, p.gender)
+#---- 8
+#
+#
+#47.000000
+#52.000000
+#
+#68.000000
+#
+#
 
+#-NAME CastDoubleToUnstructured
+#-QUERY MATCH (p:person) RETURN atan2(p.unstrNumericProp, p.eyeSight)
+#---- 8
+#
+#
+#1.462709
+#1.474937
+#
+#1.501788
+#
+#
 
+#-NAME CastDateToUnstructured
+#-QUERY MATCH (p:person) RETURN least(p.unstrDateProp1, p.birthdate)
+#---- 8
+#1900-01-01
+#1900-01-01
+#1940-06-22
+#
+#
+#
+#
+#
 
+#-NAME CastTimestampToUnstructured
+#-QUERY MATCH (p:person) RETURN least(p.unstrTimestampProp1, p.registerTime)
+#---- 8
+#
+#
+#
+#2031-11-30 12:25:30
+#1946-08-25 19:07:22
+#
+#1962-05-22 13:11:22.562
+#2023-02-21 13:25:30
 
--NAME CastBoolToUnstructured
--QUERY MATCH (p:person) RETURN p.unstrBoolProp1 = p.isStudent
----- 8
+#-NAME CastIntervalToUnstructured
+#-QUERY MATCH (p:person) RETURN date_part(p.datePart, p.lastJobDuration)
+#---- 8
+#
+#
+#
+#
+#0
+#
+#
+#5
 
-
-True
-True
-False
-
-
-False
-
--NAME CastInt64ToUnstructured
--QUERY MATCH (p:person) RETURN round(p.unstrNumericProp, p.gender)
----- 8
-
-
-47.000000
-52.000000
-
-68.000000
-
-
-
--NAME CastDoubleToUnstructured
--QUERY MATCH (p:person) RETURN atan2(p.unstrNumericProp, p.eyeSight)
----- 8
-
-
-1.462709
-1.474937
-
-1.501788
-
-
-
--NAME CastDateToUnstructured
--QUERY MATCH (p:person) RETURN least(p.unstrDateProp1, p.birthdate)
----- 8
-1900-01-01
-1900-01-01
-1940-06-22
-
-
-
-
-
-
--NAME CastTimestampToUnstructured
--QUERY MATCH (p:person) RETURN least(p.unstrTimestampProp1, p.registerTime)
----- 8
-
-
-
-2031-11-30 12:25:30
-1946-08-25 19:07:22
-
-1962-05-22 13:11:22.562
-2023-02-21 13:25:30
-
--NAME CastIntervalToUnstructured
--QUERY MATCH (p:person) RETURN date_part(p.datePart, p.lastJobDuration)
----- 8
-
-
-
-
-0
-
-
-5
-
--NAME CastStringToUnstructured
--QUERY MATCH (p:person) RETURN p.fName = p.label1
----- 8
-
-
-
-
-False
-False
-False
-False
+#-NAME CastStringToUnstructured
+#-QUERY MATCH (p:person) RETURN p.fName = p.label1
+#---- 8
+#
+#
+#
+#
+#False
+#False
+#False
+#False

--- a/test/test_files/tinySNB/function/date.test
+++ b/test/test_files/tinySNB/function/date.test
@@ -3,40 +3,41 @@
 ---- 1
 2
 
--NAME UnstructuredStructuredDateComparison
--QUERY MATCH (a:person) WHERE a.birthdate = a.unstrDateProp1 RETURN COUNT(*)
----- 1
-1
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredStructuredDateComparison
+#-QUERY MATCH (a:person) WHERE a.birthdate = a.unstrDateProp1 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME DateTimestampEqual
--QUERY MATCH (a:person) WHERE a.unstrDateProp2 = timestamp('1920-01-01') RETURN COUNT(*)
----- 1
-1
+#-NAME DateTimestampEqual
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp2 = timestamp('1920-01-01') RETURN COUNT(*)
+#---- 1
+#1
 
--NAME DateTimestampGreaterThan
--QUERY MATCH (a:person) WHERE a.unstrDateProp2 >= timestamp('1920-01-01') RETURN COUNT(*)
----- 1
-3
+#-NAME DateTimestampGreaterThan
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp2 >= timestamp('1920-01-01') RETURN COUNT(*)
+#---- 1
+#3
 
--NAME TwoUnstructuredDateNotEqual
--QUERY MATCH (a:person) WHERE a.unstrDateProp1 <> a.unstrDateProp2 RETURN COUNT(*)
----- 1
-2
+#-NAME TwoUnstructuredDateNotEqual
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp1 <> a.unstrDateProp2 RETURN COUNT(*)
+#---- 1
+#2
 
--NAME TwoUnstructuredDateEqual
--QUERY MATCH (a:person) WHERE a.unstrDateProp1 = a.unstrDateProp2 RETURN COUNT(*)
----- 1
-1
+#-NAME TwoUnstructuredDateEqual
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp1 = a.unstrDateProp2 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME TwoUnstructuredDateComparison
--QUERY MATCH (a:person) WHERE a.unstrDateProp1 >= a.unstrDateProp2 RETURN COUNT(*)
----- 1
-1
+#-NAME TwoUnstructuredDateComparison
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp1 >= a.unstrDateProp2 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME UnstructuredDateLiteralComparison
--QUERY MATCH (a:person) WHERE a.unstrDateProp1 <= date('1990-02-02') RETURN COUNT(*)
----- 1
-3
+#-NAME UnstructuredDateLiteralComparison
+#-QUERY MATCH (a:person) WHERE a.unstrDateProp1 <= date('1990-02-02') RETURN COUNT(*)
+#---- 1
+#3
 
 -NAME StructuredDateArithmeticAddInt
 -QUERY MATCH (a:person) RETURN a.birthdate + 32
@@ -62,29 +63,30 @@
 1980-11-27
 1990-12-29
 
--NAME UnstructuredDateArithmeticAddInt
--QUERY MATCH (a:person) RETURN a.unstrDateProp1 + 41
----- 8
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateArithmeticAddInt
+#-QUERY MATCH (a:person) RETURN a.unstrDateProp1 + 41
+#---- 8
+#
+#
+#
+#
+#
+#1900-02-11
+#1950-02-11
+#1950-02-11
 
-
-
-
-
-1900-02-11
-1950-02-11
-1950-02-11
-
--NAME IntArithmeticAddUnstructuredDate
--QUERY MATCH (a:person) RETURN 52 + a.unstrDateProp1
----- 8
-
-
-
-
-
-1900-02-22
-1950-02-22
-1950-02-22
+#-NAME IntArithmeticAddUnstructuredDate
+#-QUERY MATCH (a:person) RETURN 52 + a.unstrDateProp1
+#---- 8
+#
+#
+#
+#
+#
+#1900-02-22
+#1950-02-22
+#1950-02-22
 
 -NAME StructuredDateArithmeticAddInterval1
 -QUERY MATCH (a:person) WHERE a.birthdate <> date('1900-01-01') RETURN a.birthdate + interval('2 years 3 months 4 days')
@@ -106,17 +108,18 @@
 1980-10-28
 1990-11-29
 
--NAME UnstructuredDateArithmeticAddInterval
--QUERY MATCH (a:person) RETURN a.unstrDateProp2 + interval('20 years 3 days 32 minutes 10512 ms')
----- 8
-
-
-
-
-
-1940-01-04
-1970-01-04
-1990-01-04
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateArithmeticAddInterval
+#-QUERY MATCH (a:person) RETURN a.unstrDateProp2 + interval('20 years 3 days 32 minutes 10512 ms')
+#---- 8
+#
+#
+#
+#
+#
+#1940-01-04
+#1970-01-04
+#1990-01-04
 
 -NAME structuredDateArithmeticSubtractInt
 -QUERY MATCH (a:person) WHERE a.birthdate <> date('1900-01-01') RETURN a.birthdate - 25
@@ -128,9 +131,10 @@
 1980-10-01
 1990-11-02
 
--NAME UnstructuredDateArithmeticSubtractInt
--QUERY MATCH (a:person) RETURN a.unstrDateProp1 - 25
----- 8
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateArithmeticSubtractInt
+#-QUERY MATCH (a:person) RETURN a.unstrDateProp1 - 25
+#---- 8
 
 
 
@@ -150,17 +154,18 @@
 1975-10-26
 1985-11-26
 
--NAME UnstructuredDateArithmeticSubtractInterval
--QUERY MATCH (a:person) RETURN a.unstrDateProp1 - interval('15 month 32 days 30 minutes 40 minute')
----- 8
-
-
-
-
-
-1898-08-30
-1948-08-30
-1948-08-30
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateArithmeticSubtractInterval
+#-QUERY MATCH (a:person) RETURN a.unstrDateProp1 - interval('15 month 32 days 30 minutes 40 minute')
+#---- 8
+#
+#
+#
+#
+#
+#1898-08-30
+#1948-08-30
+#1948-08-30
 
 -NAME StructuredDateArithmeticSubtractDate
 -QUERY MATCH (a:person) RETURN a.birthdate - date('1920-03-21')
@@ -174,17 +179,18 @@
 25818
 7398
 
--NAME UnstructuredDateArithmeticSubtractDate
--QUERY MATCH (a:person) RETURN a.unstrDateProp1 - date('1921-05-04')
----- 8
-
-
-
-
-
--7793
-10469
-10469
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateArithmeticSubtractDate
+#-QUERY MATCH (a:person) RETURN a.unstrDateProp1 - date('1921-05-04')
+#---- 8
+#
+#
+#
+#
+#
+#-7793
+#10469
+#10469
 
 -NAME StructuredDateMixedArithmeticOperations
 -QUERY MATCH (a:person) RETURN a.birthdate + 10 - interval('4 years 2 months 3 days') - 20 - date('1912-04-12');
@@ -198,17 +204,18 @@
 23499
 27183
 
--NAME UnstructuredDateMixedArithmeticOperations
--QUERY MATCH (a:person) RETURN a.unstrDateProp1 + 100 - interval('11 months 12 days') - 10 - date('1945-04-12');
----- 8
-
-
-
-
-
--16794
-1468
-1468
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateMixedArithmeticOperations
+#-QUERY MATCH (a:person) RETURN a.unstrDateProp1 + 100 - interval('11 months 12 days') - 10 - date('1945-04-12');
+#---- 8
+#
+#
+#
+#
+#
+#-16794
+#1468
+#1468
 
 -NAME StructuredDateConcatenateString
 -QUERY MATCH (a:person) RETURN concat(concat('Birthdate: ', string(a.birthdate)), ' test')
@@ -222,24 +229,25 @@ Birthdate: 1980-10-26 test
 Birthdate: 1980-10-26 test
 Birthdate: 1990-11-27 test
 
--NAME UnstructuredDateConcatenateString
--QUERY MATCH (a:person) RETURN concat(concat('unstrDate: ', a.unstrDateProp1), ' test')
----- 8
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateConcatenateString
+#-QUERY MATCH (a:person) RETURN concat(concat('unstrDate: ', a.unstrDateProp1), ' test')
+#---- 8
+#
+#
+#
+#
+#
+#unstrDate: 1900-01-01 test
+#unstrDate: 1950-01-01 test
+#unstrDate: 1950-01-01 test
 
-
-
-
-
-unstrDate: 1900-01-01 test
-unstrDate: 1950-01-01 test
-unstrDate: 1950-01-01 test
-
--NAME CastToDate
--QUERY MATCH (a:organisation) RETURN date(a.unstrStringProp)
----- 3
-
-
-1900-01-01
+#-NAME CastToDate
+#-QUERY MATCH (a:organisation) RETURN date(a.unstrStringProp)
+#---- 3
+#
+#
+#1900-01-01
 
 -NAME StructuredDateDayNameFuncTest
 -QUERY MATCH (p:person) RETURN dayname(p.birthdate)
@@ -253,17 +261,18 @@ Sunday
 Sunday
 Tuesday
 
--NAME UnstructuredDateDayNameFuncTest
--QUERY MATCH (p:person) RETURN dayname(p.unstrDateProp)
----- 8
-Tuesday
-Tuesday
-Saturday
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateDayNameFuncTest
+#-QUERY MATCH (p:person) RETURN dayname(p.unstrDateProp)
+#---- 8
+#Tuesday
+#Tuesday
+#Saturday
+#
+#
+#
+#
+#
 
 -NAME StructuredDateMonthNameFuncTest
 -QUERY MATCH (p:person) RETURN monthname(p.birthdate)
@@ -277,17 +286,18 @@ October
 October
 November
 
--NAME UnstructuredDateMonthNameFuncTest
--QUERY MATCH (p:person) RETURN monthname(p.unstrDateProp)
----- 8
-July
-February
-February
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateMonthNameFuncTest
+#-QUERY MATCH (p:person) RETURN monthname(p.unstrDateProp)
+#---- 8
+#July
+#February
+#February
+#
+#
+#
+#
+#
 
 -NAME StructuredDateLastDayFuncTest
 -QUERY MATCH (p:person) RETURN last_day(p.birthdate)
@@ -301,17 +311,18 @@ February
 1980-10-31
 1990-11-30
 
--NAME UnstructuredDateLastDayFuncTest
--QUERY MATCH (p:person) RETURN last_day(p.unstrDateProp)
----- 8
-1952-07-31
-2019-02-28
-2020-02-29
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateLastDayFuncTest
+#-QUERY MATCH (p:person) RETURN last_day(p.unstrDateProp)
+#---- 8
+#1952-07-31
+#2019-02-28
+#2020-02-29
+#
+#
+#
+#
+#
 
 -NAME StructuredDateExtractYearFuncTest
 -QUERY MATCH (p:person) RETURN date_part("year", p.birthdate)
@@ -325,17 +336,18 @@ February
 1980
 1990
 
--NAME UnstructuredDateExtractYearFuncTest
--QUERY MATCH (p:person) RETURN date_part("Y", p.unstrDateProp)
----- 8
-1952
-2019
-2020
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractYearFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("Y", p.unstrDateProp)
+#---- 8
+#1952
+#2019
+#2020
+#
+#
+#
+#
+#
 
 -NAME StructuredDateExtractMonthFuncTest
 -QUERY MATCH (p:person) RETURN date_part("month", p.birthdate)
@@ -349,16 +361,17 @@ February
 10
 11
 
--NAME UnstructuredDateExtractMonthFuncTest
--QUERY MATCH (p:person) RETURN date_part("mon", p.unstrDateProp)
----- 8
-7
-2
-2
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractMonthFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("mon", p.unstrDateProp)
+#---- 8
+#7
+#2
+#2
+#
+#
+#
+#
 
 -NAME StructuredDateExtractDayFuncTest
 -QUERY MATCH (p:person) RETURN date_part("Day", p.birthdate)
@@ -372,17 +385,18 @@ February
 26
 27
 
--NAME UnstructuredDateExtractDayFuncTest
--QUERY MATCH (p:person) RETURN date_part("daYs", p.unstrDateProp)
----- 8
-15
-12
-29
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractDayFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("daYs", p.unstrDateProp)
+#---- 8
+#15
+#12
+#29
+#
+#
+#
+#
+#
 
 -NAME StructuredDateExtractDecadeFuncTest
 -QUERY MATCH (p:person) RETURN date_part("decadE", p.birthdate)
@@ -396,17 +410,18 @@ February
 198
 199
 
--NAME UnstructuredDateExtractDecadeFuncTest
--QUERY MATCH (p:person) RETURN date_part("decAdes", p.unstrDateProp)
----- 8
-195
-201
-202
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractDecadeFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("decAdes", p.unstrDateProp)
+#---- 8
+#195
+#201
+#202
+#
+#
+#
+#
+#
 
 -NAME StructuredDateExtractCenturyFuncTest
 -QUERY MATCH (p:person) RETURN date_part("cenTury", p.birthdate)
@@ -420,17 +435,18 @@ February
 20
 20
 
--NAME UnstructuredDateExtractCenturyFuncTest
--QUERY MATCH (p:person) RETURN date_part("Centuries", p.unstrDateProp)
----- 8
-20
-21
-21
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractCenturyFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("Centuries", p.unstrDateProp)
+#---- 8
+#20
+#21
+#21
+#
+#
+#
+#
+#
 
 -NAME StructuredDateExtractMillenniumFuncTest
 -QUERY MATCH (p:person) RETURN date_part("millenniuM", p.birthdate)
@@ -444,17 +460,18 @@ February
 2
 2
 
--NAME UnstructuredDateExtractMillenniumFuncTest
--QUERY MATCH (p:person) RETURN date_part("millennia", p.unstrDateProp)
----- 8
-2
-3
-3
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractMillenniumFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("millennia", p.unstrDateProp)
+#---- 8
+#2
+#3
+#3
+#
+#
+#
+#
+#
 
 -NAME StructuredDateExtractQuarterFuncTest
 -QUERY MATCH (p:person) RETURN date_part("quarTer", p.birthdate)
@@ -468,17 +485,18 @@ February
 4
 4
 
--NAME UnstructuredDateExtractQuarterFuncTest
--QUERY MATCH (p:person) RETURN date_part("Quarters", p.unstrDateProp)
----- 8
-3
-1
-1
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractQuarterFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("Quarters", p.unstrDateProp)
+#---- 8
+#3
+#1
+#1
+#
+#
+#
+#
+#
 
 -NAME StructuredDateExtractMicroSecondsFuncTest
 -QUERY MATCH (p:person) RETURN date_part("microseconds", p.birthdate)
@@ -492,17 +510,18 @@ February
 0
 0
 
--NAME UnstructuredDateExtractMicroSecondsFuncTest
--QUERY MATCH (p:person) RETURN datepart("microsEcond", p.unstrDateProp)
----- 8
-0
-0
-0
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateExtractMicroSecondsFuncTest
+#-QUERY MATCH (p:person) RETURN datepart("microsEcond", p.unstrDateProp)
+#---- 8
+#0
+#0
+#0
+#
+#
+#
+#
+#
 
 -NAME StructuredDateTruncYearFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("year", p.birthdate)
@@ -516,17 +535,18 @@ February
 1980-01-01
 1990-01-01
 
--NAME UnstructuredDateTruncYearFuncTest
--QUERY MATCH (p:person) RETURN datetrunc("YEAR", p.unstrDateProp)
----- 8
-1952-01-01
-2019-01-01
-2020-01-01
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateTruncYearFuncTest
+#-QUERY MATCH (p:person) RETURN datetrunc("YEAR", p.unstrDateProp)
+#---- 8
+#1952-01-01
+#2019-01-01
+#2020-01-01
+#
+#
+#
+#
+#
 
 -NAME StructuredDateTruncMonthFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("month", p.birthdate)
@@ -540,16 +560,17 @@ February
 1980-10-01
 1990-11-01
 
--NAME UnstructuredDateTruncMonthFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("month", p.unstrDateProp)
----- 8
-1952-07-01
-2019-02-01
-2020-02-01
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateTruncMonthFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("month", p.unstrDateProp)
+#---- 8
+#1952-07-01
+#2019-02-01
+#2020-02-01
+#
+#
+#
+#
 
 -NAME StructuredDateTruncDayFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("Day", p.birthdate)
@@ -563,17 +584,17 @@ February
 1980-10-26
 1990-11-27
 
--NAME UnstructuredDateTruncDayFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("daY", p.unstrDateProp)
----- 8
-1952-07-15
-2019-02-12
-2020-02-29
-
-
-
-
-
+#-NAME UnstructuredDateTruncDayFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("daY", p.unstrDateProp)
+#---- 8
+#1952-07-15
+#2019-02-12
+#2020-02-29
+#
+#
+#
+#
+#
 
 -NAME StructuredDateTruncDecadeFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("decadE", p.birthdate)
@@ -587,17 +608,18 @@ February
 1980-01-01
 1990-01-01
 
--NAME UnstructuredDateTruncDecadeFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("decAde", p.unstrDateProp)
----- 8
-1950-01-01
-2010-01-01
-2020-01-01
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateTruncDecadeFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("decAde", p.unstrDateProp)
+#---- 8
+#1950-01-01
+#2010-01-01
+#2020-01-01
+#
+#
+#
+#
+#
 
 -NAME StructuredDateTruncCenturyFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("cenTury", p.birthdate)
@@ -611,17 +633,18 @@ February
 1900-01-01
 1900-01-01
 
--NAME UnstructuredDateTruncCenturyFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("Century", p.unstrDateProp)
----- 8
-1900-01-01
-2000-01-01
-2000-01-01
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateTruncCenturyFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("Century", p.unstrDateProp)
+#---- 8
+#1900-01-01
+#2000-01-01
+#2000-01-01
+#
+#
+#
+#
+#
 
 -NAME StructuredDateTruncMillenniumFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("millenniuM", p.birthdate)
@@ -635,17 +658,18 @@ February
 1000-01-01
 1000-01-01
 
--NAME UnstructuredDateTruncMillenniumFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("millennIum", p.unstrDateProp)
----- 8
-1000-01-01
-2000-01-01
-2000-01-01
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateTruncMillenniumFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("millennIum", p.unstrDateProp)
+#---- 8
+#1000-01-01
+#2000-01-01
+#2000-01-01
+#
+#
+#
+#
+#
 
 -NAME StructuredDateTruncQuarterFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("quarTer", p.birthdate)
@@ -659,17 +683,18 @@ February
 1980-10-01
 1990-10-01
 
--NAME UnstructuredDateTruncQuarterFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("Quarter", p.unstrDateProp)
----- 8
-1952-07-01
-2019-01-01
-2020-01-01
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateTruncQuarterFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("Quarter", p.unstrDateProp)
+#---- 8
+#1952-07-01
+#2019-01-01
+#2020-01-01
+#
+#
+#
+#
+#
 
 -NAME StructuredDateTruncSecondFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("second", p.birthdate)
@@ -683,17 +708,18 @@ February
 1980-10-26
 1990-11-27
 
--NAME UnstructuredDateTruncSecondFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("sEconds", p.unstrDateProp)
----- 8
-1952-07-15
-2019-02-12
-2020-02-29
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateTruncSecondFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("sEconds", p.unstrDateProp)
+#---- 8
+#1952-07-15
+#2019-02-12
+#2020-02-29
+#
+#
+#
+#
+#
 
 -NAME StructuredDateGreatestFuncTest
 -QUERY MATCH (p:person) RETURN greatest(p.birthdate, date("1980-10-02"))
@@ -707,17 +733,18 @@ February
 1980-10-26
 1990-11-27
 
--NAME UnstructuredDateGreatestFuncTest
--QUERY MATCH (p:person) RETURN greatest(p.unstrDateProp, date("1975-12-22"))
----- 8
-1975-12-22
-2019-02-12
-2020-02-29
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateGreatestFuncTest
+#-QUERY MATCH (p:person) RETURN greatest(p.unstrDateProp, date("1975-12-22"))
+#---- 8
+#1975-12-22
+#2019-02-12
+#2020-02-29
+#
+#
+#
+#
+#
 
 -NAME StructuredDateLeastFuncTest
 -QUERY MATCH (p:person) RETURN least(p.birthdate, date("1980-10-02"))
@@ -731,17 +758,18 @@ February
 1980-10-02
 1980-10-02
 
--NAME UnstructuredDateLeastFuncTest
--QUERY MATCH (p:person) RETURN least(p.unstrDateProp, date("1975-12-22"))
----- 8
-1952-07-15
-1975-12-22
-1975-12-22
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredDateLeastFuncTest
+#-QUERY MATCH (p:person) RETURN least(p.unstrDateProp, date("1975-12-22"))
+#---- 8
+#1952-07-15
+#1975-12-22
+#1975-12-22
+#
+#
+#
+#
+#
 
 -NAME StructuredIntMakeDateTest
 -QUERY MATCH (o:organisation) RETURN make_date(o.orgCode * 3, o.ID, 20)
@@ -750,16 +778,17 @@ February
 2802-04-20
 2472-06-20
 
--NAME UnstructuredIntMakeDateTest
--QUERY MATCH (p:person) RETURN make_date(1997, 12, p.unstrInt64Prop2 % 30)
----- 8
-
-
-
-1997-12-20
-
-1997-12-13
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntMakeDateTest
+#-QUERY MATCH (p:person) RETURN make_date(1997, 12, p.unstrInt64Prop2 % 30)
+#---- 8
+#
+#
+#
+#1997-12-20
+#
+#1997-12-13
+#
 
 -NAME StructuredDateComparisonAcrossNodesNonEquality
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.birthdate <> b.birthdate RETURN COUNT(*)

--- a/test/test_files/tinySNB/function/interval.test
+++ b/test/test_files/tinySNB/function/interval.test
@@ -10,25 +10,26 @@
 ---- 1
 2
 
--NAME UnstructuredStructuredIntervalComparison
--QUERY MATCH (o:organisation) WHERE o.licenseValidInterval = o.unstrIntervalProp1 RETURN COUNT(*)
----- 1
-1
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredStructuredIntervalComparison
+#-QUERY MATCH (o:organisation) WHERE o.licenseValidInterval = o.unstrIntervalProp1 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME TwoUnstructuredIntervalComparison1
--QUERY MATCH (o:organisation) WHERE o.unstrIntervalProp1 <> o.unstrIntervalProp2 RETURN COUNT(*)
----- 1
-1
+#-NAME TwoUnstructuredIntervalComparison1
+#-QUERY MATCH (o:organisation) WHERE o.unstrIntervalProp1 <> o.unstrIntervalProp2 RETURN COUNT(*)
+#---- 1
+#1
 
--NAME TwoUnstructuredIntervalComparison2
--QUERY MATCH (o:organisation) WHERE o.unstrIntervalProp1 <= o.unstrIntervalProp2 RETURN COUNT(*)
----- 1
-2
+#-NAME TwoUnstructuredIntervalComparison2
+#-QUERY MATCH (o:organisation) WHERE o.unstrIntervalProp1 <= o.unstrIntervalProp2 RETURN COUNT(*)
+#---- 1
+#2
 
--NAME UnstructuredIntervalFunctionComparison
--QUERY MATCH (o:organisation) WHERE o.unstrIntervalProp1 <= Interval('8 years 42 days 3 hours') RETURN COUNT(*)
----- 1
-1
+#-NAME UnstructuredIntervalFunctionComparison
+#-QUERY MATCH (o:organisation) WHERE o.unstrIntervalProp1 <= Interval('8 years 42 days 3 hours') RETURN COUNT(*)
+#---- 1
+#1
 
 -NAME StructuredIntervalAdd
 -QUERY MATCH (a:person) RETURN a.lastJobDuration + interval('47 hours 30 minutes 30 seconds')
@@ -64,24 +65,25 @@
 2025-02-25 23:53:30.30002
 2033-12-04 22:53:30.30002
 
--NAME StructuredIntervalAddUnstructuredTime
--QUERY MATCH (a:person) RETURN a.lastJobDuration + a.unstrTimeProp1
----- 8
-1903-01-03
-1982-05-04
-1985-05-06 14:04:07
-2008-11-05 13:49:41.000526
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME StructuredIntervalAddUnstructuredTime
+#-QUERY MATCH (a:person) RETURN a.lastJobDuration + a.unstrTimeProp1
+#---- 8
+#1903-01-03
+#1982-05-04
+#1985-05-06 14:04:07
+#2008-11-05 13:49:41.000526
+#
+#
+#
+#
 
-
-
-
-
--NAME UnstructuredIntervalAdd
--QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 + interval('10 years 20 days 42 h 32 minutes 312 milliseconds')
----- 3
-
-10 years 68 days 65:32:00.312
-36 years 72 days 90:32:00.312
+#-NAME UnstructuredIntervalAdd
+#-QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 + interval('10 years 20 days 42 h 32 minutes 312 milliseconds')
+#---- 3
+#
+#10 years 68 days 65:32:00.312
+#36 years 72 days 90:32:00.312
 
 -NAME StructuredIntervalSubtract
 -QUERY MATCH (a:person) RETURN a.lastJobDuration - interval('52 days 42 hours 31 seconds 22 milliseconds')
@@ -95,12 +97,13 @@
 3 years -50 days -28:58:31.022
 3 years -50 days -28:58:31.022
 
--NAME UnstructuredIntervalSubtract
--QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 - interval('40 months 200 days 420 hour 320 minutes 312 seconds')
----- 3
-
--3 years -4 months -152 days -402:25:12
-22 years 8 months -148 days -377:25:12
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalSubtract
+#-QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 - interval('40 months 200 days 420 hour 320 minutes 312 seconds')
+#---- 3
+#
+#-3 years -4 months -152 days -402:25:12
+#22 years 8 months -148 days -377:25:12
 
 -NAME StructuredIntervalMixedArithmeticOperations
 -QUERY MATCH (a:person) RETURN a.lastJobDuration + interval('2 hours 48 minutes 1000 seconds') - interval('188 days 48 hours') + interval('5 years 100 microseconds')
@@ -114,12 +117,13 @@
 8 years -186 days -31:53:19.9999
 8 years -186 days -31:53:19.9999
 
--NAME UnstructuredIntervalMixedArithmeticOperations
--QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 - interval('2 years 18 days 24 minutes')  + interval('12 hours 100 seconds') - interval('100 days 32 hours 32 minutes')
----- 3
-
--2 years -70 days 02:05:40
-24 years -66 days 27:05:40
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalMixedArithmeticOperations
+#-QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 - interval('2 years 18 days 24 minutes')  + interval('12 hours 100 seconds') - interval('100 days 32 hours 32 minutes')
+#---- 3
+#
+#-2 years -70 days 02:05:40
+#24 years -66 days 27:05:40
 
 -NAME StructuredIntervalConcatenateString
 -QUERY MATCH (o:organisation) RETURN concat(concat('The license is valid until ', string(o.licenseValidInterval)), ' test')
@@ -128,12 +132,13 @@ The license is valid until 26 years 52 days 48:00:00 test
 The license is valid until 3 years 5 days test
 The license is valid until 82:00:00.1 test
 
--NAME UnstructuredIntervalConcatenateString
--QUERY MATCH (o:organisation) RETURN concat(concat('unstrIntervalProp1: ', o.unstrIntervalProp1), ' test')
----- 3
-
-unstrIntervalProp1: 26 years 52 days 48:00:00 test
-unstrIntervalProp1: 48 days 23:00:00 test
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalConcatenateString
+#-QUERY MATCH (o:organisation) RETURN concat(concat('unstrIntervalProp1: ', o.unstrIntervalProp1), ' test')
+#---- 3
+#
+#unstrIntervalProp1: 26 years 52 days 48:00:00 test
+#unstrIntervalProp1: 48 days 23:00:00 test
 
 -NAME StructuredIntervalDivideInt
 -QUERY MATCH (p:person) RETURN p.lastJobDuration / 3
@@ -177,12 +182,13 @@ unstrIntervalProp1: 48 days 23:00:00 test
 4 years 6 days 09:36:00
 8 days 06:00:00
 
--NAME UnstructuredIntervalDivideInt
--QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 / 8
----- 3
-
-3 years 3 months 6 days 18:00:00
-6 days 02:52:30
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalDivideInt
+#-QUERY MATCH (o:organisation) RETURN o.unstrIntervalProp1 / 8
+#---- 3
+#
+#3 years 3 months 6 days 18:00:00
+#6 days 02:52:30
 
 -NAME StructuredIntervalExtractYearFuncTest
 -QUERY MATCH (p:person) RETURN date_part("yeAr", p.lastJobDuration)
@@ -196,17 +202,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 10
 3
 
--NAME UnstructuredIntervalExtractYearFuncTest
--QUERY MATCH (p:person) RETURN date_part("Y", p.unstrIntervalProp)
----- 8
-5
-0
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractYearFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("Y", p.unstrIntervalProp)
+#---- 8
+#5
+#0
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractMonthFuncTest
 -QUERY MATCH (p:person) RETURN date_part("month", p.lastJobDuration)
@@ -220,17 +227,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 5
 0
 
--NAME UnstructuredIntervalExtractMonthFuncTest
--QUERY MATCH (p:person) RETURN date_part("months", p.unstrIntervalProp)
----- 8
-0
-0
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractMonthFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("months", p.unstrIntervalProp)
+#---- 8
+#0
+#0
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractDayFuncTest
 -QUERY MATCH (p:person) RETURN date_part("day", p.lastJobDuration)
@@ -244,17 +252,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 0
 2
 
--NAME UnstructuredIntervalExtractDayFuncTest
--QUERY MATCH (p:person) RETURN date_part("day", p.unstrIntervalProp)
----- 8
-700
-300
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractDayFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("day", p.unstrIntervalProp)
+#---- 8
+#700
+#300
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractDecadeFuncTest
 -QUERY MATCH (p:person) RETURN date_part("Decade", p.lastJobDuration)
@@ -268,17 +277,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 1
 0
 
--NAME UnstructuredIntervalExtractDecadeFuncTest
--QUERY MATCH (p:person) RETURN date_part("decade", p.unstrIntervalProp)
----- 8
-0
-0
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractDecadeFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("decade", p.unstrIntervalProp)
+#---- 8
+#0
+#0
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractCenturyFuncTest
 -QUERY MATCH (p:person) RETURN date_part("century", p.lastJobDuration)
@@ -292,17 +302,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 0
 0
 
--NAME UnstructuredIntervalExtractCenturyFuncTest
--QUERY MATCH (p:person) RETURN date_part("century", p.unstrIntervalProp)
----- 8
-0
-0
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractCenturyFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("century", p.unstrIntervalProp)
+#---- 8
+#0
+#0
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractMillenniumFuncTest
 -QUERY MATCH (p:person) RETURN date_part("MILLENNIUM", p.lastJobDuration)
@@ -316,17 +327,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 0
 0
 
--NAME UnstructuredIntervalExtractMillenniumFuncTest
--QUERY MATCH (p:person) RETURN date_part("MILLENNIUM", p.unstrIntervalProp)
----- 8
-0
-0
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractMillenniumFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("MILLENNIUM", p.unstrIntervalProp)
+#---- 8
+#0
+#0
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractQuarterFuncTest
 -QUERY MATCH (p:person) RETURN date_part("QUARTER", p.lastJobDuration)
@@ -340,17 +352,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 2
 1
 
--NAME UnstructuredIntervalExtractQuarterFuncTest
--QUERY MATCH (p:person) RETURN date_part("QUARTER", p.unstrIntervalProp)
----- 8
-1
-1
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractQuarterFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("QUARTER", p.unstrIntervalProp)
+#---- 8
+#1
+#1
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractMicrosecondFuncTest
 -QUERY MATCH (p:person) RETURN date_part("MICROSECOND", p.lastJobDuration)
@@ -364,17 +377,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 24
 0
 
--NAME UnstructuredIntervalExtractMicrosecondFuncTest
--QUERY MATCH (p:person) RETURN date_part("MICROSECOND", p.unstrIntervalProp)
----- 8
-0
-1000
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractMicrosecondFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("MICROSECOND", p.unstrIntervalProp)
+#---- 8
+#0
+#1000
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractMillisecondFuncTest
 -QUERY MATCH (p:person) RETURN date_part("MILLISECOND", p.lastJobDuration)
@@ -388,17 +402,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 0
 0
 
--NAME UnstructuredIntervalExtractMillisecondFuncTest
--QUERY MATCH (p:person) RETURN date_part("MILLISECOND", p.unstrIntervalProp)
----- 8
-0
-1
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractMillisecondFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("MILLISECOND", p.unstrIntervalProp)
+#---- 8
+#0
+#1
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractSecondFuncTest
 -QUERY MATCH (p:person) RETURN date_part("second", p.lastJobDuration)
@@ -412,17 +427,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 0
 0
 
--NAME UnstructuredIntervalExtractSecondFuncTest
--QUERY MATCH (p:person) RETURN date_part("seconds", p.unstrIntervalProp)
----- 8
-0
-0
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractSecondFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("seconds", p.unstrIntervalProp)
+#---- 8
+#0
+#0
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractMinuteFuncTest
 -QUERY MATCH (p:person) RETURN date_part("minutes", p.lastJobDuration)
@@ -436,17 +452,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 0
 2
 
--NAME UnstructuredIntervalExtractMinuteFuncTest
--QUERY MATCH (p:person) RETURN date_part("minute", p.unstrIntervalProp)
----- 8
-0
-40
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractMinuteFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("minute", p.unstrIntervalProp)
+#---- 8
+#0
+#40
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalExtractHourFuncTest
 -QUERY MATCH (p:person) RETURN date_part("hours", p.lastJobDuration)
@@ -460,17 +477,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 13
 13
 
--NAME UnstructuredIntervalExtractHourFuncTest
--QUERY MATCH (p:person) RETURN date_part("hour", p.unstrIntervalProp)
----- 8
-5000
-50
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredIntervalExtractHourFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("hour", p.unstrIntervalProp)
+#---- 8
+#5000
+#50
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToYearFuncTest
 -QUERY MATCH (p:person) RETURN to_years(p.age)
@@ -484,17 +502,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 40 years
 83 years
 
--NAME UnstructuredInt64ToYearFuncTest
--QUERY MATCH (p:person) RETURN to_years(p.unstrInt64Prop2)
----- 8
-20 years
-43 years
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToYearFuncTest
+#-QUERY MATCH (p:person) RETURN to_years(p.unstrInt64Prop2)
+#---- 8
+#20 years
+#43 years
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToMonthsFuncTest
 -QUERY MATCH (p:person) RETURN to_months(p.age)
@@ -508,17 +527,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 3 years 4 months
 6 years 11 months
 
--NAME UnstructuredInt64ToMonthsFuncTest
--QUERY MATCH (p:person) RETURN to_months(p.unstrInt64Prop2)
----- 8
-1 year 8 months
-3 years 7 months
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToMonthsFuncTest
+#-QUERY MATCH (p:person) RETURN to_months(p.unstrInt64Prop2)
+#---- 8
+#1 year 8 months
+#3 years 7 months
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToDaysFuncTest
 -QUERY MATCH (p:person) RETURN to_days(p.age)
@@ -532,17 +552,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 40 days
 83 days
 
--NAME UnstructuredInt64ToDaysFuncTest
--QUERY MATCH (p:person) RETURN to_days(p.unstrInt64Prop2)
----- 8
-20 days
-43 days
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToDaysFuncTest
+#-QUERY MATCH (p:person) RETURN to_days(p.unstrInt64Prop2)
+#---- 8
+#20 days
+#43 days
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToHoursFuncTest
 -QUERY MATCH (p:person) RETURN to_hours(p.age)
@@ -556,17 +577,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 40:00:00
 83:00:00
 
--NAME UnstructuredInt64ToHoursFuncTest
--QUERY MATCH (p:person) RETURN to_hours(p.unstrInt64Prop2)
----- 8
-20:00:00
-43:00:00
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToHoursFuncTest
+#-QUERY MATCH (p:person) RETURN to_hours(p.unstrInt64Prop2)
+#---- 8
+#20:00:00
+#43:00:00
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToMinutesFuncTest
 -QUERY MATCH (p:person) RETURN to_minutes(p.age)
@@ -580,17 +602,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 00:40:00
 01:23:00
 
--NAME UnstructuredInt64ToMinutesFuncTest
--QUERY MATCH (p:person) RETURN to_minutes(p.unstrInt64Prop2)
----- 8
-00:20:00
-00:43:00
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToMinutesFuncTest
+#-QUERY MATCH (p:person) RETURN to_minutes(p.unstrInt64Prop2)
+#---- 8
+#00:20:00
+#00:43:00
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToSecondsFuncTest
 -QUERY MATCH (p:person) RETURN to_seconds(p.age)
@@ -604,17 +627,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 00:00:40
 00:01:23
 
--NAME UnstructuredInt64ToSecondsFuncTest
--QUERY MATCH (p:person) RETURN to_seconds(p.unstrInt64Prop2)
----- 8
-00:00:20
-00:00:43
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToSecondsFuncTest
+#-QUERY MATCH (p:person) RETURN to_seconds(p.unstrInt64Prop2)
+#---- 8
+#00:00:20
+#00:00:43
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToMillisecondsFuncTest
 -QUERY MATCH (p:person) RETURN to_milliseconds(p.age)
@@ -628,17 +652,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 00:00:00.04
 00:00:00.083
 
--NAME UnstructuredInt64ToMillisecondsFuncTest
--QUERY MATCH (p:person) RETURN to_milliseconds(p.unstrInt64Prop2)
----- 8
-00:00:00.02
-00:00:00.043
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToMillisecondsFuncTest
+#-QUERY MATCH (p:person) RETURN to_milliseconds(p.unstrInt64Prop2)
+#---- 8
+#00:00:00.02
+#00:00:00.043
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToMicrosecondsFuncTest
 -QUERY MATCH (p:person) RETURN to_microseconds(p.age)
@@ -652,17 +677,18 @@ unstrIntervalProp1: 48 days 23:00:00 test
 00:00:00.00004
 00:00:00.000083
 
--NAME UnstructuredInt64ToMicrosecondsFuncTest
--QUERY MATCH (p:person) RETURN to_microseconds(p.unstrInt64Prop2)
----- 8
-00:00:00.00002
-00:00:00.000043
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToMicrosecondsFuncTest
+#-QUERY MATCH (p:person) RETURN to_microseconds(p.unstrInt64Prop2)
+#---- 8
+#00:00:00.00002
+#00:00:00.000043
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredIntervalComparisonAcrossNodesNonEquality
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.lastJobDuration <> b.lastJobDuration RETURN COUNT(*)

--- a/test/test_files/tinySNB/function/list.test
+++ b/test/test_files/tinySNB/function/list.test
@@ -634,12 +634,13 @@ ABFs
 CsWo
 DEsW
 
--NAME ListSliceUnstructuredString
--QUERY MATCH (o:organisation) RETURN o.unstrStr[5:8]
----- 3
-RfEC
-cELL
- org
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME ListSliceUnstructuredString
+#-QUERY MATCH (o:organisation) RETURN o.unstrStr[5:8]
+#---- 3
+#RfEC
+#cELL
+# org
 
 -NAME ListSliceStructuredStringRight
 -QUERY MATCH (a:person) RETURN a.fName[4:]

--- a/test/test_files/tinySNB/function/string.test
+++ b/test/test_files/tinySNB/function/string.test
@@ -88,20 +88,22 @@
 ---- 1
 1
 
--NAME UnstrDateVarAndStrVarConcatUnstructured
--QUERY MATCH (a:person) WHERE '1950-01-01Carol' = concat(a.unstrDateProp1, a.fName) RETURN COUNT(*)
----- 1
-1
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstrDateVarAndStrVarConcatUnstructured
+#-QUERY MATCH (a:person) WHERE '1950-01-01Carol' = concat(a.unstrDateProp1, a.fName) RETURN COUNT(*)
+#---- 1
+#1
 
 -NAME TimestampVarAndStrVarConcatStructured
 -QUERY MATCH (a:person) WHERE '2011-08-20 11:25:30Alice' = concat(string(a.registerTime), a.fName) RETURN COUNT(*)
 ---- 1
 1
 
--NAME UnstrTimestampVarAndStrVarConcatUnstructured
--QUERY MATCH (a:person) WHERE '1962-05-22 13:11:22.562Greg' = concat(a.unstrTimestampProp1, a.fName) RETURN COUNT(*)
----- 1
-1
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstrTimestampVarAndStrVarConcatUnstructured
+#-QUERY MATCH (a:person) WHERE '1962-05-22 13:11:22.562Greg' = concat(a.unstrTimestampProp1, a.fName) RETURN COUNT(*)
+#---- 1
+#1
 
 -NAME ContainsReturn
 -QUERY MATCH (a:person) RETURN a.fName, a.fName CONTAINS "a" ORDER BY a.fName
@@ -130,10 +132,11 @@ Bob
 ---- 1
 7
 
--NAME ContainsSelect4
--QUERY MATCH (a:person) WHERE a.fName <> "Alice" and a.label2 CONTAINS a.label2 RETURN count(*)
----- 1
-4
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME ContainsSelect4
+#-QUERY MATCH (a:person) WHERE a.fName <> "Alice" and a.label2 CONTAINS a.label2 RETURN count(*)
+#---- 1
+#4
 
 -NAME StartsWithReturn1
 -QUERY MATCH (a:person) RETURN a.fName, a.fName STARTS WITH "A" ORDER BY a.fName
@@ -154,28 +157,29 @@ True
 False
 False
 
--NAME StartsWithReturn2
--QUERY MATCH (a:person) RETURN a.label1, a.label1 STARTS WITH "g" ORDER BY a.fName
----- 8
-excellent|False
-good|True
-good|True
-good|True
-|
-|
-|
-|
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME StartsWithReturn2
+#-QUERY MATCH (a:person) RETURN a.label1, a.label1 STARTS WITH "g" ORDER BY a.fName
+#---- 8
+#excellent|False
+#good|True
+#good|True
+#good|True
+#|
+#|
+#|
+#|
 
--NAME StartsWithFilterReturn
--QUERY MATCH (a:person) WHERE a.ID <> 0 RETURN a.label1, a.label1 STARTS WITH "g" ORDER BY a.fName
----- 7
-excellent|False
-good|True
-good|True
-|
-|
-|
-|
+#-NAME StartsWithFilterReturn
+#-QUERY MATCH (a:person) WHERE a.ID <> 0 RETURN a.label1, a.label1 STARTS WITH "g" ORDER BY a.fName
+#---- 7
+#excellent|False
+#good|True
+#good|True
+#|
+#|
+#|
+#|
 
 -NAME StartsWithSelect
 -QUERY MATCH (a:person) WHERE a.fName STARTS WITH "C" RETURN a.fName
@@ -189,12 +193,13 @@ abfsuni
 cswork
 deswork
 
--NAME LowerUnstructuredStr
--QUERY MATCH (o:organisation) RETURN lower(o.unstrStr)
----- 3
-  perfect
-  excellent organisation   
-good organisation ! 
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME LowerUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN lower(o.unstrStr)
+#---- 3
+#  perfect
+#  excellent organisation
+#good organisation !
 
 -NAME UpperStructuredStr
 -QUERY MATCH (o:organisation) RETURN upper(o.name)
@@ -203,12 +208,13 @@ ABFSUNI
 CSWORK
 DESWORK
 
--NAME UpperUnstructuredStr
--QUERY MATCH (o:organisation) RETURN ucase(o.unstrStr)
----- 3
-  PERFECT
-  EXCELLENT ORGANISATION   
-GOOD ORGANISATION ! 
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UpperUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN ucase(o.unstrStr)
+#---- 3
+#  PERFECT
+#  EXCELLENT ORGANISATION
+#GOOD ORGANISATION !
 
 -NAME TrimStructuredStr
 -QUERY MATCH (o:organisation) RETURN trim(o.name)
@@ -217,12 +223,13 @@ ABFsUni
 CsWork
 DEsWork
 
--NAME TrimUnstructuredStr
--QUERY MATCH (o:organisation) RETURN trim(o.unstrStr)
----- 3
-pERfECt
-EXcELLENT organisation
-GoOd organisation !
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME TrimUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN trim(o.unstrStr)
+#---- 3
+#pERfECt
+#EXcELLENT organisation
+#GoOd organisation !
 
 -NAME LtrimStructuredStr
 -QUERY MATCH (o:organisation) RETURN ltrim(o.name)
@@ -231,12 +238,13 @@ ABFsUni
 CsWork
 DEsWork
 
--NAME LtrimUnstructuredStr
--QUERY MATCH (o:organisation) RETURN ltrim(o.unstrStr)
----- 3
-pERfECt
-EXcELLENT organisation   
-GoOd organisation ! 
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME LtrimUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN ltrim(o.unstrStr)
+#---- 3
+#pERfECt
+#EXcELLENT organisation
+#GoOd organisation !
 
 -NAME RtrimStructuredStr
 -QUERY MATCH (o:organisation) RETURN rtrim(o.name)
@@ -245,12 +253,13 @@ ABFsUni
 CsWork
 DEsWork
 
--NAME RtrimUnstructuredStr
--QUERY MATCH (o:organisation) RETURN rtrim(o.unstrStr)
----- 3
-  pERfECt
-  EXcELLENT organisation
-GoOd organisation !
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME RtrimUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN rtrim(o.unstrStr)
+#---- 3
+#  pERfECt
+#  EXcELLENT organisation
+#GoOd organisation !
 
 -NAME ReverseStructuredStr
 -QUERY MATCH (o:organisation) RETURN reverse(o.name)
@@ -259,12 +268,13 @@ inUsFBA
 kroWsC
 kroWsED
 
--NAME ReverseUnstructuredStr
--QUERY MATCH (o:organisation) RETURN reverse(o.unstrStr)
----- 3
-tCEfREp  
-   noitasinagro TNELLEcXE  
- ! noitasinagro dOoG
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME ReverseUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN reverse(o.unstrStr)
+#---- 3
+#tCEfREp
+#   noitasinagro TNELLEcXE
+# ! noitasinagro dOoG
 
 -NAME LengthStructuredStr
 -QUERY MATCH (o:organisation) RETURN length(o.name)
@@ -273,12 +283,13 @@ tCEfREp
 6
 7
 
--NAME LengthUnstructuredStr
--QUERY MATCH (o:organisation) RETURN length(o.unstrStr)
----- 3
-9
-27
-20
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME LengthUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN length(o.unstrStr)
+#---- 3
+#9
+#27
+#20
 
 -NAME RepeatStructuredStr
 -QUERY MATCH (o:organisation) RETURN repeat(o.name, o.ID)
@@ -287,12 +298,13 @@ ABFsUni
 CsWorkCsWorkCsWorkCsWork
 DEsWorkDEsWorkDEsWorkDEsWorkDEsWorkDEsWork
 
--NAME RepeatUnstructuredStr
--QUERY MATCH (o:organisation) RETURN repeat(o.unstrStr, o.ID)
----- 3
-  pERfECt
-  EXcELLENT organisation     EXcELLENT organisation     EXcELLENT organisation     EXcELLENT organisation   
-GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! 
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME RepeatUnstructuredStr
+#-QUERY MATCH (o:organisation) RETURN repeat(o.unstrStr, o.ID)
+#---- 3
+#  pERfECt
+#  EXcELLENT organisation     EXcELLENT organisation     EXcELLENT organisation     EXcELLENT organisation
+#GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation ! GoOd organisation !
 
 -NAME LpadStructuredStrAndLiteralInt
 -QUERY MATCH (p:person) RETURN lpad(p.fName, 5, "<")
@@ -306,29 +318,30 @@ Faroo
 <Greg
 Huber
 
--NAME LpadStructuredStrAndStructuredInt
--QUERY MATCH (p:person) RETURN lpad(p.fName, p.ID, "<")
----- 8
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME LpadStructuredStrAndStructuredInt
+#-QUERY MATCH (p:person) RETURN lpad(p.fName, p.ID, "<")
+#---- 8
+#
+#Bo
+#Car
+#<<Dan
+#Elizabe
+#<<Farooq
+#<<<<<Greg
+#Hubert Bla
 
-Bo
-Car
-<<Dan
-Elizabe
-<<Farooq
-<<<<<Greg
-Hubert Bla
-
--NAME LpadUnstructuredStrAndLiteralInt
--QUERY MATCH (p:person) RETURN lpad(p.label1, 10, "<")
----- 8
-<<<<<<good
-<<<<<<good
-<excellent
-<<<<<<good
-
-
-
-
+#-NAME LpadUnstructuredStrAndLiteralInt
+#-QUERY MATCH (p:person) RETURN lpad(p.label1, 10, "<")
+#---- 8
+#<<<<<<good
+#<<<<<<good
+#<excellent
+#<<<<<<good
+#
+#
+#
+#
 
 -NAME RpadStructuredStrAndLiteralInt
 -QUERY MATCH (p:person) RETURN rpad(p.fName, 15, ">")
@@ -354,17 +367,18 @@ Farooq<<
 Greg<<<<<
 Hubert Bla
 
--NAME RpadUnstructuredStrAndLiteralInt
--QUERY MATCH (p:person) RETURN rpad(p.label1, 5, ">")
----- 8
-good>
-good>
-excel
-good>
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME RpadUnstructuredStrAndLiteralInt
+#-QUERY MATCH (p:person) RETURN rpad(p.label1, 5, ">")
+#---- 8
+#good>
+#good>
+#excel
+#good>
+#
+#
+#
+#
 
 -NAME SubStrStructuredStrAndLiteralInt
 -QUERY MATCH (p:person) RETURN substr(p.fName, 2, 12)
@@ -378,16 +392,17 @@ arooq
 reg
 ubert Blaine
 
--NAME SubStrUnstructuredStrAndLiteralInt
--QUERY MATCH (p:person) RETURN substring(p.label1, 3, 2)
----- 8
-od
-od
-ce
-od
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME SubStrUnstructuredStrAndLiteralInt
+#-QUERY MATCH (p:person) RETURN substring(p.label1, 3, 2)
+#---- 8
+#od
+#od
+#ce
+#od
+#
+#
+#
 
 -NAME LeftPositiveIdxStructuredStrAndLiteralInt
 -QUERY MATCH (p:person) RETURN left(p.fName, 11)
@@ -420,17 +435,18 @@ Far
 G
 Hubert Blaine Wolfeschlegelsteinhausenbergerdo
 
--NAME LeftUnstructuredStrAndLiteralInt
--QUERY MATCH (p:person) RETURN left(p.label1, 2)
----- 8
-go
-go
-ex
-go
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME LeftUnstructuredStrAndLiteralInt
+#-QUERY MATCH (p:person) RETURN left(p.label1, 2)
+#---- 8
+#go
+#go
+#ex
+#go
+#
+#
+#
+#
 
 -NAME RightPositiveIdxStructuredStrAndLiteralInt
 -QUERY MATCH (p:person) RETURN right(p.fName, 10)
@@ -463,17 +479,18 @@ rooq
 eg
 bert Blaine Wolfeschlegelsteinhausenbergerdorff
 
--NAME RightUnstructuredStrAndLiteralInt
--QUERY MATCH (p:person) RETURN right(p.label1, 3)
----- 8
-ood
-ood
-ent
-ood
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME RightUnstructuredStrAndLiteralInt
+#-QUERY MATCH (p:person) RETURN right(p.label1, 3)
+#---- 8
+#ood
+#ood
+#ent
+#ood
+#
+#
+#
+#
 
 -NAME ArrayExtractPositiveIdxStructuredStrAndStructuredInt
 -QUERY MATCH (o:organisation) RETURN array_extract(o.name, o.ID + 2)
@@ -496,27 +513,28 @@ B
 s
 E
 
--NAME ListExtractUnstructuredString
--QUERY MATCH (o:organisation) RETURN o.unstrStr[4]
----- 3
-E
-X
-d
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME ListExtractUnstructuredString
+#-QUERY MATCH (o:organisation) RETURN o.unstrStr[4]
+#---- 3
+#E
+#X
+#d
 
--NAME UnstrStrEqual
--QUERY MATCH (o:organisation) WHERE o.unstrStr = '  pERfECt' RETURN count(*)
----- 1
-1
+#-NAME UnstrStrEqual
+#-QUERY MATCH (o:organisation) WHERE o.unstrStr = '  pERfECt' RETURN count(*)
+#---- 1
+#1
 
--NAME UnstrStrNotEqual
--QUERY MATCH (o:organisation) WHERE o.unstrStr <> '  pERfECt' RETURN count(*)
----- 1
-2
+#-NAME UnstrStrNotEqual
+#-QUERY MATCH (o:organisation) WHERE o.unstrStr <> '  pERfECt' RETURN count(*)
+#---- 1
+#2
 
--NAME UnstrStrComparison
--QUERY MATCH (o:organisation) WHERE o.unstrStr < "Test string" RETURN count(*)
----- 1
-3
+#-NAME UnstrStrComparison
+#-QUERY MATCH (o:organisation) WHERE o.unstrStr < "Test string" RETURN count(*)
+#---- 1
+#3
 
 -NAME SuffixStructuredStr
 -QUERY MATCH (o:organisation) RETURN suffix(o.name, "Work")
@@ -525,17 +543,18 @@ False
 True
 True
 
--NAME SuffixUnstructuredStr
--QUERY MATCH (p:person) RETURN suffix(p.label1, "od")
----- 8
-True
-
-
-True
-
-False
-True
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME SuffixUnstructuredStr
+#-QUERY MATCH (p:person) RETURN suffix(p.label1, "od")
+#---- 8
+#True
+#
+#
+#True
+#
+#False
+#True
+#
 
 -NAME SuffixSelect
 -QUERY MATCH (p:person) WHERE suffix(p.fName, "l") RETURN p.fName

--- a/test/test_files/tinySNB/function/timestamp.test
+++ b/test/test_files/tinySNB/function/timestamp.test
@@ -3,10 +3,11 @@
 ---- 1
 1
 
--NAME TimestampDateEqual
--QUERY MATCH (a:person) WHERE date_trunc("daY", a.unstrTimestampProp2) = date('1976-12-23') RETURN COUNT(*)
----- 1
-1
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME TimestampDateEqual
+#-QUERY MATCH (a:person) WHERE date_trunc("daY", a.unstrTimestampProp2) = date('1976-12-23') RETURN COUNT(*)
+#---- 1
+#1
 
 -NAME TimestampDateNotEqual
 -QUERY MATCH (a:person) WHERE date_trunc("daY", a.registerTime) <> date('1976-12-23') RETURN COUNT(*)
@@ -33,25 +34,26 @@
 ---- 1
 2
 
--NAME UnstructuredStructuredTimestampComparison
--QUERY MATCH (a:person) WHERE a.registerTime = a.unstrTimestampProp1 RETURN COUNT(*)
----- 1
-2
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredStructuredTimestampComparison
+#-QUERY MATCH (a:person) WHERE a.registerTime = a.unstrTimestampProp1 RETURN COUNT(*)
+#---- 1
+#2
 
--NAME TwoUnstructuredTimestampComparison
--QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 <> a.unstrTimestampProp2 RETURN COUNT(*)
----- 1
-2
+#-NAME TwoUnstructuredTimestampComparison
+#-QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 <> a.unstrTimestampProp2 RETURN COUNT(*)
+#---- 1
+#2
 
--NAME TwoUnstructuredTimestampComparison
--QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 <= a.unstrTimestampProp2 RETURN COUNT(*)
----- 1
-2
+#-NAME TwoUnstructuredTimestampComparison
+#-QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 <= a.unstrTimestampProp2 RETURN COUNT(*)
+#---- 1
+#2
 
--NAME UnstructuredTimestampLiteralComparison
--QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 <= timestamp('1985-11-22 13:12:22.562') RETURN COUNT(*)
----- 1
-2
+#-NAME UnstructuredTimestampLiteralComparison
+#-QUERY MATCH (a:person) WHERE a.unstrTimestampProp1 <= timestamp('1985-11-22 13:12:22.562') RETURN COUNT(*)
+#---- 1
+#2
 
 -NAME StructuredTimestampArithmeticAddInterval1
 -QUERY MATCH (a:person) RETURN a.registerTime + interval('47 hours 30 minutes 30 seconds')
@@ -78,17 +80,18 @@
 2025-02-25 23:53:30.30002
 2033-12-04 22:53:30.30002
 
--NAME UnstructuredTimestampArithmeticAddInterval
--QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 + interval('10 years 20 days 42 h 32 minutes 312 milliseconds')
----- 8
-
-
-
-
-1956-09-16 13:39:22.312
-1972-06-13 07:43:22.874
-2033-03-15 07:57:30.312
-2041-12-22 06:57:30.312
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampArithmeticAddInterval
+#-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 + interval('10 years 20 days 42 h 32 minutes 312 milliseconds')
+#---- 8
+#
+#
+#
+#
+#1956-09-16 13:39:22.312
+#1972-06-13 07:43:22.874
+#2033-03-15 07:57:30.312
+#2041-12-22 06:57:30.312
 
 -NAME StructuredTimestampArithmeticSubtractInterval
 -QUERY MATCH (a:person) RETURN a.registerTime - interval('12 years 7 months 10 days 20 h 30 m 100 us')
@@ -102,17 +105,18 @@
 2010-07-10 16:55:29.9999
 2019-04-19 15:55:29.9999
 
--NAME UnstructuredTimestampArithmeticSubtractInterval
--QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - interval('40 months 200 days 420 hour 320 minutes 312 seconds')
----- 8
-
-
-
-
-1942-09-20 01:42:10
-1958-06-18 19:46:10.562
-2019-03-17 20:00:18
-2027-12-25 19:00:18
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampArithmeticSubtractInterval
+#-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - interval('40 months 200 days 420 hour 320 minutes 312 seconds')
+#---- 8
+#
+#
+#
+#
+#1942-09-20 01:42:10
+#1958-06-18 19:46:10.562
+#2019-03-17 20:00:18
+#2027-12-25 19:00:18
 
 -NAME StructuredTimestampArithmeticSubtractTimestamp
 -QUERY MATCH (a:person) RETURN a.registerTime - timestamp('2013-01-02 14:22:31.45612')
@@ -126,17 +130,18 @@
 3701 days 23:02:58.54388
 6905 days 22:02:58.54388
 
--NAME UnstructuredTimestampArithmeticSubtractTimestamp
--QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - timestamp('1976-01-02 13:44:12')
----- 8
-
-
-
-
--10721 days -18:36:50
--4973 days -00:32:49.438
-17216 days 23:41:18
-20420 days 22:41:18
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampArithmeticSubtractTimestamp
+#-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - timestamp('1976-01-02 13:44:12')
+#---- 8
+#
+#
+#
+#
+#-10721 days -18:36:50
+#-4973 days -00:32:49.438
+#17216 days 23:41:18
+#20420 days 22:41:18
 
 -NAME StructuredTimestampMixedArithmeticOperations
 -QUERY MATCH (a:person) RETURN a.registerTime + interval('2 hours 48 minutes 1000 seconds') - interval('188 days 48 hours') - timestamp('1976-01-02 13:44:12')
@@ -150,17 +155,18 @@
 17027 days 02:45:58
 20231 days 01:45:58
 
--NAME UnstructuredTimestampMixedArithmeticOperations
--QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - interval('2 years 18 days 24 minutes')  + interval('12 hours 100 seconds') - timestamp('1976-01-02 13:44:12')
----- 8
-
-
-
-
--11469 days -06:59:10
--5720 days -12:55:09.438
-16469 days 11:18:58
-19673 days 10:18:58
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampMixedArithmeticOperations
+#-QUERY MATCH (a:person) RETURN a.unstrTimestampProp1 - interval('2 years 18 days 24 minutes')  + interval('12 hours 100 seconds') - timestamp('1976-01-02 13:44:12')
+#---- 8
+#
+#
+#
+#
+#-11469 days -06:59:10
+#-5720 days -12:55:09.438
+#16469 days 11:18:58
+#19673 days 10:18:58
 
 -NAME StructuredTimestampConcatenateString
 -QUERY MATCH (a:person) RETURN concat(concat('Register Time: ', string(a.registerTime)), ' test')
@@ -174,12 +180,13 @@ Register Time: 2011-08-20 11:25:30 test
 Register Time: 2023-02-21 13:25:30 test
 Register Time: 2031-11-30 12:25:30 test
 
--NAME castToTimestamp
--QUERY MATCH (o:organisation) RETURN timestamp(o.unstrStringProp1)
----- 3
-
-
-1955-11-23 15:22:31
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME castToTimestamp
+#-QUERY MATCH (o:organisation) RETURN timestamp(o.unstrStringProp1)
+#---- 3
+#
+#
+#1955-11-23 15:22:31
 
 -NAME StructuredTimestampExtractYearFuncTest
 -QUERY MATCH (p:person) RETURN date_part("yeAr", p.registerTime)
@@ -193,17 +200,18 @@ Register Time: 2031-11-30 12:25:30 test
 1976
 2023
 
--NAME UnstructuredTimestampExtractYearFuncTest
--QUERY MATCH (p:person) RETURN date_part("Y", p.unstrTimestampProp1)
----- 8
-2031
-1946
-1962
-2023
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampExtractYearFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("Y", p.unstrTimestampProp1)
+#---- 8
+#2031
+#1946
+#1962
+#2023
+#
+#
+#
+#
 
 -NAME StructuredTimestampExtractMicroFuncTest
 -QUERY MATCH (p:person) RETURN date_part("microSeconds", p.registerTime)
@@ -217,17 +225,18 @@ Register Time: 2031-11-30 12:25:30 test
 42000000
 30000000
 
--NAME UnstructuredTimestampExtractMicroFuncTest
--QUERY MATCH (p:person) RETURN date_part("microsecond", p.unstrTimestampProp2)
----- 8
-42000000
-30000526
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampExtractMicroFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("microsecond", p.unstrTimestampProp2)
+#---- 8
+#42000000
+#30000526
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampExtractMsFuncTest
 -QUERY MATCH (p:person) RETURN date_part("millisEcond", p.registerTime)
@@ -241,17 +250,17 @@ Register Time: 2031-11-30 12:25:30 test
 42000
 30000
 
--NAME UnstructuredTimestampExtractMsFuncTest
--QUERY MATCH (p:person) RETURN date_part("miLlisEconds", p.unstrTimestampProp2)
----- 8
-42000
-30000
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampExtractMsFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("miLlisEconds", p.unstrTimestampProp2)
+#---- 8
+#42000
+#30000
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampExtractSecondFuncTest
 -QUERY MATCH (p:person) RETURN date_part("seConds", p.registerTime)
@@ -265,17 +274,18 @@ Register Time: 2031-11-30 12:25:30 test
 42
 30
 
--NAME UnstructuredTimestampExtractSecondFuncTest
--QUERY MATCH (p:person) RETURN date_part("seCOND", p.unstrTimestampProp2)
----- 8
-42
-30
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampExtractSecondFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("seCOND", p.unstrTimestampProp2)
+#---- 8
+#42
+#30
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampExtractMinuteFuncTest
 -QUERY MATCH (p:person) RETURN date_part("minute", p.registerTime)
@@ -289,17 +299,18 @@ Register Time: 2031-11-30 12:25:30 test
 41
 25
 
--NAME UnstructuredTimestampExtractMinuteFuncTest
--QUERY MATCH (p:person) RETURN date_part("miNutes", p.unstrTimestampProp2)
----- 8
-21
-25
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampExtractMinuteFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("miNutes", p.unstrTimestampProp2)
+#---- 8
+#21
+#25
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampExtractHourFuncTest
 -QUERY MATCH (p:person) RETURN date_part("hours", p.registerTime)
@@ -313,17 +324,18 @@ Register Time: 2031-11-30 12:25:30 test
 4
 13
 
--NAME UnstructuredTimestampExtractHourFuncTest
--QUERY MATCH (p:person) RETURN date_part("Hour", p.unstrTimestampProp2)
----- 8
-11
-13
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampExtractHourFuncTest
+#-QUERY MATCH (p:person) RETURN date_part("Hour", p.unstrTimestampProp2)
+#---- 8
+#11
+#13
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampTruncDayFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("Day", p.registerTime)
@@ -337,17 +349,18 @@ Register Time: 2031-11-30 12:25:30 test
 1976-12-23 00:00:00
 2023-02-21 00:00:00
 
--NAME UnstructuredTimestampTruncDayFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("daY", p.unstrTimestampProp2)
----- 8
-1976-12-23 00:00:00
-2008-11-03 00:00:00
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampTruncDayFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("daY", p.unstrTimestampProp2)
+#---- 8
+#1976-12-23 00:00:00
+#2008-11-03 00:00:00
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampTruncMicrosecondsFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("MIcroseCond", p.registerTime)
@@ -361,17 +374,18 @@ Register Time: 2031-11-30 12:25:30 test
 1976-12-23 04:41:42
 2023-02-21 13:25:30
 
--NAME UnstructuredTimestampTruncMicrosecondsFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("MIcroseconds", p.unstrTimestampProp2)
----- 8
-1976-12-23 11:21:42
-2008-11-03 13:25:30.000526
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampTruncMicrosecondsFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("MIcroseconds", p.unstrTimestampProp2)
+#---- 8
+#1976-12-23 11:21:42
+#2008-11-03 13:25:30.000526
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampTruncMillisecondsFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("mIlliSecond", p.registerTime)
@@ -385,17 +399,18 @@ Register Time: 2031-11-30 12:25:30 test
 1976-12-23 04:41:42
 2023-02-21 13:25:30
 
--NAME UnstructuredTimestampTruncMillisecondsFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("mIlliSeconds", p.unstrTimestampProp2)
----- 8
-1976-12-23 11:21:42
-2008-11-03 13:25:30
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampTruncMillisecondsFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("mIlliSeconds", p.unstrTimestampProp2)
+#---- 8
+#1976-12-23 11:21:42
+#2008-11-03 13:25:30
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampTruncSecondsFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("secOnds", p.registerTime)
@@ -409,17 +424,18 @@ Register Time: 2031-11-30 12:25:30 test
 1976-12-23 04:41:42
 2023-02-21 13:25:30
 
--NAME UnstructuredTimestampTruncSecondsFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("secondS", p.unstrTimestampProp2)
----- 8
-1976-12-23 11:21:42
-2008-11-03 13:25:30
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampTruncSecondsFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("secondS", p.unstrTimestampProp2)
+#---- 8
+#1976-12-23 11:21:42
+#2008-11-03 13:25:30
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampTruncMinuteFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("Minutes", p.registerTime)
@@ -433,17 +449,18 @@ Register Time: 2031-11-30 12:25:30 test
 1976-12-23 04:41:00
 2023-02-21 13:25:00
 
--NAME UnstructuredTimestampTruncMinuteFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("minutes", p.unstrTimestampProp2)
----- 8
-1976-12-23 11:21:00
-2008-11-03 13:25:00
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampTruncMinuteFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("minutes", p.unstrTimestampProp2)
+#---- 8
+#1976-12-23 11:21:00
+#2008-11-03 13:25:00
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampTruncHourFuncTest
 -QUERY MATCH (p:person) RETURN date_trunc("Hours", p.registerTime)
@@ -457,17 +474,18 @@ Register Time: 2031-11-30 12:25:30 test
 1976-12-23 04:00:00
 2023-02-21 13:00:00
 
--NAME UnstructuredTimestampTruncHourFuncTest
--QUERY MATCH (p:person) RETURN date_trunc("houRs", p.unstrTimestampProp2)
----- 8
-1976-12-23 11:00:00
-2008-11-03 13:00:00
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampTruncHourFuncTest
+#-QUERY MATCH (p:person) RETURN date_trunc("houRs", p.unstrTimestampProp2)
+#---- 8
+#1976-12-23 11:00:00
+#2008-11-03 13:00:00
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampCenturyFuncTest
 -QUERY MATCH (p:person) RETURN century(p.registerTime)
@@ -481,17 +499,18 @@ Register Time: 2031-11-30 12:25:30 test
 20
 21
 
--NAME UnstructuredTimestampCenturyFuncTest
--QUERY MATCH (p:person) RETURN century(p.unstrTimestampProp2)
----- 8
-20
-21
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampCenturyFuncTest
+#-QUERY MATCH (p:person) RETURN century(p.unstrTimestampProp2)
+#---- 8
+#20
+#21
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampDaynameFuncTest
 -QUERY MATCH (p:person) RETURN dayname(p.registerTime)
@@ -505,17 +524,18 @@ Monday
 Thursday
 Tuesday
 
--NAME UnstructuredTimestampDaynameFuncTest
--QUERY MATCH (p:person) RETURN dayname(p.unstrTimestampProp2)
----- 8
-Thursday
-Monday
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampDaynameFuncTest
+#-QUERY MATCH (p:person) RETURN dayname(p.unstrTimestampProp2)
+#---- 8
+#Thursday
+#Monday
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampMonthNameFuncTest
 -QUERY MATCH (p:person) RETURN monthname(p.registerTime)
@@ -529,17 +549,18 @@ July
 December
 February
 
--NAME UnstructuredTimestampMonthNameFuncTest
--QUERY MATCH (p:person) RETURN monthname(p.unstrTimestampProp2)
----- 8
-December
-November
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampMonthNameFuncTest
+#-QUERY MATCH (p:person) RETURN monthname(p.unstrTimestampProp2)
+#---- 8
+#December
+#November
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampLastDayFuncTest
 -QUERY MATCH (p:person) RETURN last_day(p.registerTime)
@@ -553,17 +574,18 @@ November
 1976-12-31
 2023-02-28
 
--NAME UnstructuredTimestampLastDayFuncTest
--QUERY MATCH (p:person) RETURN last_day(p.unstrTimestampProp2)
----- 8
-1976-12-31
-2008-11-30
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampLastDayFuncTest
+#-QUERY MATCH (p:person) RETURN last_day(p.unstrTimestampProp2)
+#---- 8
+#1976-12-31
+#2008-11-30
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64EpochMsFuncTest
 -QUERY MATCH (p:person) RETURN epoch_ms(p.age)
@@ -577,17 +599,18 @@ November
 1970-01-01 00:00:00.04
 1970-01-01 00:00:00.083
 
--NAME UnstructuredInt64EpochMsFuncTest
--QUERY MATCH (p:person) RETURN epoch_ms(p.unstrInt64Prop)
----- 8
-1970-01-06 05:20:44.124
-1970-01-01 01:15:41.124
-1970-01-01 01:13:32.124
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64EpochMsFuncTest
+#-QUERY MATCH (p:person) RETURN epoch_ms(p.unstrInt64Prop)
+#---- 8
+#1970-01-06 05:20:44.124
+#1970-01-01 01:15:41.124
+#1970-01-01 01:13:32.124
+#
+#
+#
+#
+#
 
 -NAME StructuredInt64ToTimestampFuncTest
 -QUERY MATCH (p:person) RETURN to_timestamp(p.age)
@@ -601,17 +624,18 @@ November
 1970-01-01 00:00:40
 1970-01-01 00:01:23
 
--NAME UnstructuredInt64ToTimestampFuncTest
--QUERY MATCH (p:person) RETURN to_timestamp(p.unstrInt64Prop)
----- 8
-1984-04-19 17:35:24
-1970-02-22 13:25:24
-1970-02-21 01:35:24
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredInt64ToTimestampFuncTest
+#-QUERY MATCH (p:person) RETURN to_timestamp(p.unstrInt64Prop)
+#---- 8
+#1984-04-19 17:35:24
+#1970-02-22 13:25:24
+#1970-02-21 01:35:24
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampGreatestFuncTest
 -QUERY MATCH (p:person) RETURN greatest(p.registerTime, timestamp("2006-02-12 11:25:33"))
@@ -625,17 +649,18 @@ November
 2006-02-12 11:25:33
 2023-02-21 13:25:30
 
--NAME UnstructuredTimestampGreatestFuncTest
--QUERY MATCH (p:person) RETURN greatest(p.unstrTimestampProp2, timestamp("1986-02-12 11:25:33"))
----- 8
-1986-02-12 11:25:33
-2008-11-03 13:25:30.000526
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampGreatestFuncTest
+#-QUERY MATCH (p:person) RETURN greatest(p.unstrTimestampProp2, timestamp("1986-02-12 11:25:33"))
+#---- 8
+#1986-02-12 11:25:33
+#2008-11-03 13:25:30.000526
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampLeastFuncTest
 -QUERY MATCH (p:person) RETURN least(p.registerTime, timestamp("2006-02-12 11:25:33"))
@@ -649,17 +674,18 @@ November
 1976-12-23 04:41:42
 2006-02-12 11:25:33
 
--NAME UnstructuredTimestampLeastFuncTest
--QUERY MATCH (p:person) RETURN least(p.unstrTimestampProp2, timestamp("1986-02-12 11:25:33"))
----- 8
-1976-12-23 11:21:42
-1986-02-12 11:25:33
-
-
-
-
-
-
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME UnstructuredTimestampLeastFuncTest
+#-QUERY MATCH (p:person) RETURN least(p.unstrTimestampProp2, timestamp("1986-02-12 11:25:33"))
+#---- 8
+#1976-12-23 11:21:42
+#1986-02-12 11:25:33
+#
+#
+#
+#
+#
+#
 
 -NAME StructuredTimestampComparisonAcrossNodesNonEquality
 -QUERY MATCH (a:person)-[e1:knows]->(b:person) WHERE a.registerTime <> b.registerTime RETURN COUNT(*)

--- a/test/test_files/tinySNB/optional_match/optional_match.test
+++ b/test/test_files/tinySNB/optional_match/optional_match.test
@@ -67,12 +67,13 @@ Elizabeth|Farooq
 Elizabeth|Greg
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
 
--NAME OptionalReadUnstrPropertyTest
--QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Elizabeth' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.unstrNumericProp
--ENUMERATE
----- 2
-
--12.500000
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME OptionalReadUnstrPropertyTest
+#-QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Elizabeth' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.unstrNumericProp
+#-ENUMERATE
+#---- 2
+#
+#-12.500000
 
 -NAME OptionalReturnTest
 -QUERY MATCH (a:person)-[:knows]->(b:person) WHERE a.fName='Alice' OPTIONAL MATCH (b)-[:studyAt]->(c:organisation) RETURN c.orgCode

--- a/test/test_files/tinySNB/order_by/order_by.test
+++ b/test/test_files/tinySNB/order_by/order_by.test
@@ -90,79 +90,80 @@ Carol
 Bob
 Alice
 
--NAME OrderByUnstrSameDataTypeTest
--QUERY MATCH (p:person) RETURN p.unstrDateProp1 ORDER BY p.unstrDateProp1 desc
--PARALLELISM 2
----- 8
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME OrderByUnstrSameDataTypeTest
+#-QUERY MATCH (p:person) RETURN p.unstrDateProp1 ORDER BY p.unstrDateProp1 desc
+#-PARALLELISM 2
+#---- 8
+#
+#
+#
+#
+#
+#1950-01-01
+#1950-01-01
+#1900-01-01
 
+#-NAME OrderByUnstrNumericTest
+#-QUERY MATCH (p:person) RETURN p.unstrNumericProp ORDER BY p.unstrNumericProp asc
+#-PARALLELISM 4
+#---- 8
+#47
+#52
+#68.000000
+#
+#
+#
+#
+#
 
+#-NAME OrderByUnstrTimeTest
+#-QUERY MATCH (p:person) RETURN p.unstrTimeProp1 ORDER BY p.unstrTimeProp1 desc
+#-PARALLELISM 3
+#---- 8
+#
+#
+#
+#
+#2008-11-03 13:25:30.000526
+#1982-05-04 01:02:07
+#1982-05-04
+#1900-01-01
 
+#-NAME OrderByUnstrWithFilterTest
+#-QUERY MATCH (p:person) WHERE p.gender = 2 RETURN p.unstrNumericProp ORDER BY p.unstrNumericProp desc
+#-PARALLELISM 2
+#---- 5
+#
+#
+#
+#
+#47
 
+#-NAME OrderByUnstrMultipleColTest
+#-QUERY MATCH (p:person) RETURN p.unstrTimeProp1 ORDER BY p.gender desc, p.unstrTimeProp1 asc
+#-PARALLELISM 3
+#---- 8
+#1982-05-04
+#1982-05-04 01:02:07
+#
+#
+#
+#1900-01-01
+#2008-11-03 13:25:30.000526
 
-1950-01-01
-1950-01-01
-1900-01-01
-
--NAME OrderByUnstrNumericTest
--QUERY MATCH (p:person) RETURN p.unstrNumericProp ORDER BY p.unstrNumericProp asc
--PARALLELISM 4
----- 8
-47
-52
-68.000000
-
-
-
-
-
-
--NAME OrderByUnstrTimeTest
--QUERY MATCH (p:person) RETURN p.unstrTimeProp1 ORDER BY p.unstrTimeProp1 desc
--PARALLELISM 3
----- 8
-
-
-
-
-2008-11-03 13:25:30.000526
-1982-05-04 01:02:07
-1982-05-04
-1900-01-01
-
--NAME OrderByUnstrWithFilterTest
--QUERY MATCH (p:person) WHERE p.gender = 2 RETURN p.unstrNumericProp ORDER BY p.unstrNumericProp desc
--PARALLELISM 2
----- 5
-
-
-
-
-47
-
--NAME OrderByUnstrMultipleColTest
--QUERY MATCH (p:person) RETURN p.unstrTimeProp1 ORDER BY p.gender desc, p.unstrTimeProp1 asc
--PARALLELISM 3
----- 8
-1982-05-04
-1982-05-04 01:02:07
-
-
-
-1900-01-01
-2008-11-03 13:25:30.000526
-
--NAME OrderByUnstrMultipleColTest2
--QUERY MATCH (p:person) RETURN p.age, p.unstrNumericProp ORDER BY p.isStudent, p.ID
--PARALLELISM 4
----- 8
-45|52
-20|
-20|68.000000
-40|
-83|
-35|
-30|47
-25|
+#-NAME OrderByUnstrMultipleColTest2
+#-QUERY MATCH (p:person) RETURN p.age, p.unstrNumericProp ORDER BY p.isStudent, p.ID
+#-PARALLELISM 4
+#---- 8
+#45|52
+#20|
+#20|68.000000
+#40|
+#83|
+#35|
+#30|47
+#25|
 
 -NAME OrderByStrMultipleColTest
 -QUERY MATCH (p:person) RETURN p.age, p.eyeSight ORDER BY p.isWorker desc, p.age, p.eyeSight desc

--- a/test/test_files/tinySNB/projection/projection.test
+++ b/test/test_files/tinySNB/projection/projection.test
@@ -15,36 +15,46 @@
 2
 2
 
--NAME IsNullTest1
--QUERY MATCH (a:person) RETURN a.fName, a.unstrNumericProp IS NULL, a.unstrDateProp1 IS NOT NULL
----- 8
-Alice|True|True
-Bob|False|True
-Carol|False|True
-Dan|True|False
-Elizabeth|False|False
-Farooq|True|False
-Greg|True|False
-Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|True|False
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME IsNullTest1
+#-QUERY MATCH (a:person) RETURN a.fName, a.unstrNumericProp IS NULL, a.unstrDateProp1 IS NOT NULL
+#---- 8
+#Alice|True|True
+#Bob|False|True
+#Carol|False|True
+#Dan|True|False
+#Elizabeth|False|False
+#Farooq|True|False
+#Greg|True|False
+#Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|True|False
 
+# TODO(Semih): Remove this test and uncomment below copy of this test when enabling ad-hoc properties
 -NAME OrgNodesReturnStarTest
 -QUERY MATCH (a:organisation) RETURN *
 ---- 3
-1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000||48 days 23:00:00|48 days 23:00:00|-12.500000|  pERfECt||
-4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000|-4|26 years 52 days 48:00:00|32 years 123 days 48:00:00||  EXcELLENT organisation   ||
-6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000|10|||3.300000|GoOd organisation ! |1900-01-01|1955-11-23 15:22:31
+1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000
+4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000
+6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000
 
--NAME PersonNodesTestUnstructuredProperty
--QUERY MATCH (a:person) RETURN a.ID,a.unstrDateProp1
----- 8
-0|1900-01-01
-10|
-2|1950-01-01
-3|1950-01-01
-5|
-7|
-8|
-9|
+#-NAME OrgNodesReturnStarTest
+#-QUERY MATCH (a:organisation) RETURN *
+#---- 3
+#1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000||48 days 23:00:00|48 days 23:00:00|-12.500000|  pERfECt||
+#4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000|-4|26 years 52 days 48:00:00|32 years 123 days 48:00:00||  EXcELLENT organisation   ||
+#6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000|10|||3.300000|GoOd organisation ! |1900-01-01|1955-11-23 15:22:31
+
+# TODO(Semih): Uncomment when enabling ad-hoc properties
+#-NAME PersonNodesTestUnstructuredProperty
+#-QUERY MATCH (a:person) RETURN a.ID,a.unstrDateProp1
+#---- 8
+#0|1900-01-01
+#10|
+#2|1950-01-01
+#3|1950-01-01
+#5|
+#7|
+#8|
+#9|
 
 -NAME PersonNodesTestNull
 -QUERY MATCH (a:person) RETURN a.ID, a.fName STARTS WITH NULL, a.isWorker, a.isWorker AND null

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -49,13 +49,14 @@ def test_to_df(establish_connection):
                                                         [[7, 4], [8, 8], [9]], [[6], [7], [8]], [[8]], [[10]],
                                                         [[7], [10], [6, 7]]]
         assert str(pd['p.courseScoresPerTerm'].dtype) == "object"
-        unstrProp = pd['p.unstrNumericProp'].tolist()
-        assert (isna(unstrProp[0]) and isna(unstrProp[3]) and isna(unstrProp[5]) and isna(unstrProp[6]) and isna(
-            unstrProp[7]))
-        assert unstrProp[1] == '47'
-        assert unstrProp[2] == '52'
-        assert unstrProp[4] == '68.000000'
-        assert str(pd['p.unstrNumericProp'].dtype) == "object"
+        # TODO(Xiyang): uncomment tests when adhoc properties are enabled
+        # unstrProp = pd['p.unstrNumericProp'].tolist()
+        # assert (isna(unstrProp[0]) and isna(unstrProp[3]) and isna(unstrProp[5]) and isna(unstrProp[6]) and isna(
+        #     unstrProp[7]))
+        # assert unstrProp[1] == '47'
+        # assert unstrProp[2] == '52'
+        # assert unstrProp[4] == '68.000000'
+        # assert str(pd['p.unstrNumericProp'].dtype) == "object"
     
     _test_to_df(conn)
 

--- a/tools/python_api/test/test_exception.py
+++ b/tools/python_api/test/test_exception.py
@@ -10,8 +10,9 @@ def test_exception(establish_connection):
     with pytest.raises(RuntimeError, match="Binder exception: Node a does not have property dummy."):
         conn.execute("MATCH (a:person) RETURN a.dummy;")
 
-    with pytest.raises(RuntimeError, match="Runtime exception: Cannot abs `INTERVAL`"):
-        conn.execute("MATCH (a:person) RETURN abs(a.unstrIntervalProp);")
-    
+    # TODO(Xiyang): uncomment test when adhoc properties are enabled
+    # with pytest.raises(RuntimeError, match="Runtime exception: Cannot abs `INTERVAL`"):
+    #    conn.execute("MATCH (a:person) RETURN abs(a.lastJobDuration);")
+
     with pytest.raises(RuntimeError, match="Buffer manager exception: Resizing to a smaller Buffer Pool Size is unsupported!"):
         db.resize_buffer_manager(1)


### PR DESCRIPTION
This PR comments out parts of node csv copier code that would read unstructured properties and any test that depended on unstructured properties. 

The current state of the code is ugly because there are many unused code and lots of commented out code. As soon as we open source, this will be the first thing to put back in the system. I have marked every place that needs uncommenting with a TODO(Semih): Uncomment ...

Independently, before I commented out unstructured properties code, I was fixing a bug in the in_mem_node_csv_copier.csv that would access unsafe memory when an unstructured property was not correctly specified. This PR also has a bit of code that fixes that. These changes are in the InMemNodeCSVCopier::calcLengthOfUnstrPropertyLists. There is a bit of code duplication this introduces with but I did not fix that because once dataType specifications are removed, that code will also change.
 