### PR TITLE
add setEmptyList API to relStore

### DIFF
--- a/src/catalog/include/catalog_structs.h
+++ b/src/catalog/include/catalog_structs.h
@@ -145,7 +145,7 @@ struct RelTableSchema : TableSchema {
 
     inline uint32_t getNumProperties() const { return properties.size(); }
     inline uint32_t getNumPropertiesToReadFromCSV() const { return properties.size(); }
-    inline bool isRelPropertyList(RelDirection relDirection) const {
+    inline bool isStoredAsLists(RelDirection relDirection) const {
         return relMultiplicity == MANY_MANY ||
                (relMultiplicity == ONE_MANY && relDirection == FWD) ||
                (relMultiplicity == MANY_ONE && relDirection == BWD);

--- a/src/processor/mapper/map_create.cpp
+++ b/src/processor/mapper/map_create.cpp
@@ -18,8 +18,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalCreateNodeToPhysical(
         auto outDataPos = mapperContext.getDataPos(node->getIDProperty());
         createNodeInfos.push_back(make_unique<CreateNodeInfo>(table, outDataPos));
     }
-    return make_unique<CreateNode>(std::move(createNodeInfos), std::move(prevOperator),
-        getOperatorID(), logicalCreateNode->getExpressionsForPrinting());
+    return make_unique<CreateNode>(std::move(createNodeInfos), storageManager.getRelsStore(),
+        std::move(prevOperator), getOperatorID(), logicalCreateNode->getExpressionsForPrinting());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalCreateRelToPhysical(

--- a/src/processor/operator/update/create.cpp
+++ b/src/processor/operator/update/create.cpp
@@ -26,12 +26,12 @@ bool CreateNode::getNextTuples() {
         auto nodeTable = createNodeInfos[i]->table;
         auto nodeOffset =
             nodeTable->getNodeStatisticsAndDeletedIDs()->addNode(nodeTable->getTableID());
-        // TODO(Ziyi/Xiyang): we should also set emptyList for relTables connected to this node.
-        nodeTable->getUnstrPropertyLists()->setPropertyListEmpty(nodeOffset);
         auto vector = outValueVectors[i];
         auto& nodeIDValue = ((nodeID_t*)vector->values)[vector->state->getPositionOfCurrIdx()];
         nodeIDValue.tableID = nodeTable->getTableID();
         nodeIDValue.offset = nodeOffset;
+        nodeTable->getUnstrPropertyLists()->initEmptyPropertyLists(nodeOffset);
+        relsStore.initEmptyRelsForNewNode(nodeIDValue);
     }
     metrics->executionTime.stop();
     return true;

--- a/src/processor/operator/update/include/create.h
+++ b/src/processor/operator/update/include/create.h
@@ -22,10 +22,10 @@ struct CreateNodeInfo {
 
 class CreateNode : public PhysicalOperator {
 public:
-    CreateNode(vector<unique_ptr<CreateNodeInfo>> createNodeInfos,
+    CreateNode(vector<unique_ptr<CreateNodeInfo>> createNodeInfos, RelsStore& relsStore,
         unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
-        : PhysicalOperator{std::move(child), id, paramsString}, createNodeInfos{
-                                                                    std::move(createNodeInfos)} {}
+        : PhysicalOperator{std::move(child), id, paramsString},
+          createNodeInfos{std::move(createNodeInfos)}, relsStore{relsStore} {}
 
     inline PhysicalOperatorType getOperatorType() override {
         return PhysicalOperatorType::CREATE_NODE;
@@ -41,12 +41,13 @@ public:
             clonedCreateNodeInfos.push_back(createNodeInfo->clone());
         }
         return make_unique<CreateNode>(
-            std::move(clonedCreateNodeInfos), children[0]->clone(), id, paramsString);
+            std::move(clonedCreateNodeInfos), relsStore, children[0]->clone(), id, paramsString);
     }
 
 private:
     vector<unique_ptr<CreateNodeInfo>> createNodeInfos;
     vector<ValueVector*> outValueVectors;
+    RelsStore& relsStore;
 };
 
 struct CreateRelInfo {

--- a/src/storage/storage_structure/include/lists/adj_and_property_lists_update_store.h
+++ b/src/storage/storage_structure/include/lists/adj_and_property_lists_update_store.h
@@ -14,8 +14,14 @@ namespace storage {
 using namespace processor;
 using namespace catalog;
 
-using InsertedRelsPerNodeOffset = map<node_offset_t, vector<uint64_t>>;
-using InsertedRelsPerChunk = map<uint64_t, InsertedRelsPerNodeOffset>;
+struct ListUpdates {
+    ListUpdates() : emptyListInPersistentStore{false} {}
+    bool emptyListInPersistentStore;
+    vector<uint64_t> insertedRelsTupleIdxInFT;
+};
+
+using ListUpdatesPerNode = map<node_offset_t, ListUpdates>;
+using ListUpdatesPerChunk = map<uint64_t, ListUpdatesPerNode>;
 
 struct InMemList;
 
@@ -32,16 +38,21 @@ public:
     inline bool isEmpty() const { return factorizedTable->isEmpty(); }
     inline void clear() {
         factorizedTable->clear();
-        initInsertedRelsPerTableIDPerDirection();
+        initListUpdatesPerTablePerDirection();
     }
-    inline InsertedRelsPerChunk& getInsertedRelsPerChunk(ListFileID& listFileID) {
+    inline ListUpdatesPerChunk& getListUpdatesPerChunk(ListFileID& listFileID) {
         auto relNodeTableAndDir = getRelNodeTableAndDirFromListFileID(listFileID);
-        return insertedRelsPerTableIDPerDirection[relNodeTableAndDir.dir].at(
+        return listUpdatesPerTablePerDirection[relNodeTableAndDir.dir].at(
             relNodeTableAndDir.srcNodeTableID);
     }
-    inline vector<map<table_id_t, InsertedRelsPerChunk>>& getInsertedRelsPerTableIDPerDirection() {
-        return insertedRelsPerTableIDPerDirection;
+    inline vector<map<table_id_t, ListUpdatesPerChunk>>& getListUpdatesPerTablePerDirection() {
+        return listUpdatesPerTablePerDirection;
     }
+
+    bool isListEmptyInPersistentStore(ListFileID& listFileID, node_offset_t nodeOffset) const;
+
+    bool hasUpdates() const;
+
     void readInsertionsToList(ListFileID& listFileID, vector<uint64_t> tupleIdxes,
         InMemList& inMemList, uint64_t numElementsInPersistentStore,
         DiskOverflowFile* diskOverflowFile, DataType dataType,
@@ -55,6 +66,17 @@ public:
     void readValues(ListFileID& listFileID, ListSyncState& listSyncState,
         shared_ptr<ValueVector> valueVector) const;
 
+    void initEmptyListInPersistentStore(nodeID_t& nodeID) {
+        for (auto direction : REL_DIRECTIONS) {
+            if (listUpdatesPerTablePerDirection[direction].contains(nodeID.tableID)) {
+                listUpdatesPerTablePerDirection[direction][nodeID.tableID]
+                                               [StorageUtils::getListChunkIdx(nodeID.offset)]
+                                               [nodeID.offset]
+                                                   .emptyListInPersistentStore = true;
+            }
+        }
+    }
+
 private:
     static inline RelNodeTableAndDir getRelNodeTableAndDirFromListFileID(ListFileID& listFileID) {
         assert(listFileID.listType != ListType::UNSTRUCTURED_NODE_PROPERTY_LISTS);
@@ -65,7 +87,7 @@ private:
     uint32_t getColIdxInFT(ListFileID& listFileID) const;
     void validateSrcDstNodeIDAndRelProperties(
         vector<shared_ptr<ValueVector>> srcDstNodeIDAndRelProperties) const;
-    void initInsertedRelsPerTableIDPerDirection();
+    void initListUpdatesPerTablePerDirection();
     static void getErrorMsgForInvalidTableID(uint64_t tableID, bool isSrcTableID, string tableName);
 
 private:
@@ -73,7 +95,7 @@ private:
     shared_ptr<ValueVector> srcNodeVector;
     shared_ptr<ValueVector> dstNodeVector;
     shared_ptr<DataChunk> nodeDataChunk;
-    vector<map<table_id_t, InsertedRelsPerChunk>> insertedRelsPerTableIDPerDirection;
+    vector<map<table_id_t, ListUpdatesPerChunk>> listUpdatesPerTablePerDirection;
     unordered_map<uint32_t, uint32_t> propertyIDToColIdxMap;
     RelTableSchema relTableSchema;
 };

--- a/src/storage/storage_structure/include/lists/unstructured_property_lists.h
+++ b/src/storage/storage_structure/include/lists/unstructured_property_lists.h
@@ -32,7 +32,7 @@ public:
     void writeValues(
         ValueVector* nodeIDVector, uint32_t propertyKey, ValueVector* vectorToWriteFrom);
 
-    void setPropertyListEmpty(node_offset_t nodeOffset);
+    void initEmptyPropertyLists(node_offset_t nodeOffset);
     void setOrRemoveProperty(
         node_offset_t nodeOffset, uint32_t propertyKey, bool isSetting, Value* value = nullptr);
     inline void setProperty(node_offset_t nodeOffset, uint32_t propertyKey, Value* value) {

--- a/src/storage/storage_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists.cpp
@@ -107,7 +107,7 @@ void UnstructuredPropertyLists::readPropertiesForPosition(Transaction* transacti
         auto header = headers->getHeader(nodeOffset);
         CursorAndMapper cursorAndMapper;
         cursorAndMapper.reset(metadata, numElementsPerPage, header, nodeOffset);
-        uint64_t numElementsInLIst = getNumElementsInPersistentStore(nodeOffset);
+        uint64_t numElementsInLIst = getNumElementsFromListHeader(nodeOffset);
         InMemList inMemList{numElementsInLIst, elementSize, false /* requireNullMask */};
         fillInMemListsFromPersistentStore(cursorAndMapper, numElementsInLIst, inMemList);
         primaryStoreListWrapper = make_unique<UnstrPropListWrapper>(
@@ -161,7 +161,7 @@ unique_ptr<map<uint32_t, Literal>> UnstructuredPropertyLists::readUnstructuredPr
     node_offset_t nodeOffset) {
     CursorAndMapper cursorAndMapper;
     cursorAndMapper.reset(metadata, numElementsPerPage, headers->getHeader(nodeOffset), nodeOffset);
-    auto numElementsInList = getNumElementsInPersistentStore(nodeOffset);
+    auto numElementsInList = getNumElementsFromListHeader(nodeOffset);
     auto retVal = make_unique<map<uint32_t /*unstructuredProperty pageIdx*/, Literal>>();
     PageByteCursor byteCursor{cursorAndMapper.cursor.pageIdx, cursorAndMapper.cursor.elemPosInPage};
     auto propertyKeyDataType = UnstructuredPropertyKeyDataType{UINT32_MAX, ANY};
@@ -236,7 +236,7 @@ void UnstructuredPropertyLists::readFromAPage(uint8_t* value, uint64_t bytesToRe
     cursor.offsetInPage += bytesToRead;
 }
 
-void UnstructuredPropertyLists::setPropertyListEmpty(node_offset_t nodeOffset) {
+void UnstructuredPropertyLists::initEmptyPropertyLists(node_offset_t nodeOffset) {
     lock_t lck{mtx};
     unstructuredListUpdateStore.setEmptyUpdatedPropertiesList(nodeOffset);
 }
@@ -248,7 +248,7 @@ void UnstructuredPropertyLists::setOrRemoveProperty(
         CursorAndMapper cursorAndMapper;
         cursorAndMapper.reset(
             metadata, numElementsPerPage, headers->getHeader(nodeOffset), nodeOffset);
-        auto numElementsInList = getNumElementsInPersistentStore(nodeOffset);
+        auto numElementsInList = getNumElementsFromListHeader(nodeOffset);
         uint64_t updatedListCapacity = max(numElementsInList,
             (uint64_t)(numElementsInList * StorageConfig::ARRAY_RESIZING_FACTOR));
         InMemList inMemList{updatedListCapacity, elementSize, false /* requireNullMask */};

--- a/src/storage/store/include/rel_table.h
+++ b/src/storage/store/include/rel_table.h
@@ -52,6 +52,7 @@ public:
     void rollbackInMemoryIfNecessary();
 
     void insertRels(vector<shared_ptr<ValueVector>>& valueVectorsToInsert);
+    void initEmptyRelsForNewNode(nodeID_t& nodeID);
 
 private:
     inline void addToUpdatedRelTables() { wal->addToUpdatedRelTables(tableID); }
@@ -64,8 +65,8 @@ private:
         BufferManager& bufferManager, WAL* wal);
     void initPropertyListsForRelTable(const catalog::Catalog& catalog, RelDirection relDirection,
         BufferManager& bufferManager, WAL* wal);
-    void performOpOnListsWithUpdates(std::function<void(Lists*)> opOnListsWithUpdates,
-        std::function<void()> opIfHasInsertedRels);
+    void performOpOnListsWithUpdates(
+        std::function<void(Lists*)> opOnListsWithUpdates, std::function<void()> opIfHasUpdates);
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/store/include/rels_store.h
+++ b/src/storage/store/include/rels_store.h
@@ -69,6 +69,8 @@ public:
         }
     }
 
+    void initEmptyRelsForNewNode(nodeID_t& nodeID);
+
 private:
     unordered_map<table_id_t, unique_ptr<RelTable>> relTables;
     RelsStatistics relsStatistics;

--- a/src/storage/store/rels_store.cpp
+++ b/src/storage/store/rels_store.cpp
@@ -28,5 +28,11 @@ pair<vector<AdjLists*>, vector<AdjColumn*>> RelsStore::getAdjListsAndColumns(
     return make_pair(adjListsRetVal, adjColumnsRetVal);
 }
 
+void RelsStore::initEmptyRelsForNewNode(nodeID_t& nodeID) {
+    for (auto& relTable : relTables) {
+        relTable.second->initEmptyRelsForNewNode(nodeID);
+    }
+}
+
 } // namespace storage
 } // namespace graphflow

--- a/test/runner/e2e_delete_create_transaction_test.cpp
+++ b/test/runner/e2e_delete_create_transaction_test.cpp
@@ -30,7 +30,7 @@ public:
         }
         auto query = "MATCH (a:person) " + predicate + " DELETE a";
         auto result = connection->query(query);
-        assert(result->isSuccess());
+        ASSERT_TRUE(result->isSuccess());
     }
 
     int64_t getCountStarVal(Connection* connection, const string& query) {
@@ -47,7 +47,7 @@ public:
         for (auto i = 0u; i < numNodes; ++i) {
             auto id = 10000 + i;
             auto result = conn->query("CREATE (a:person {ID: " + to_string(id) + "})");
-            assert(result->isSuccess());
+            ASSERT_TRUE(result->isSuccess());
         }
     }
 

--- a/test/storage/disk_array_update_test.cpp
+++ b/test/storage/disk_array_update_test.cpp
@@ -46,7 +46,7 @@ public:
     // then the WALReplayer will call checkpoint/rollbackInMemory on this UnstructuredPropertyLists;
     // finally UnstructuredPropertyLists will call headerDA->checkpoint/rollbackInMemoryIfNecessary.
     void setNodeOffset0ToEmptyListToTriggerCheckpointOrRecoveryMechanism() {
-        personNodeTable->getUnstrPropertyLists()->setPropertyListEmpty(0);
+        personNodeTable->getUnstrPropertyLists()->initEmptyPropertyLists(0);
     }
 
     void testBasicUpdate(bool isCommit, TransactionTestType transactionTestType) {

--- a/test/storage/unstructured_property_lists_updates_test.cpp
+++ b/test/storage/unstructured_property_lists_updates_test.cpp
@@ -120,7 +120,7 @@ public:
 
     void removeAllPropertiesBySetPropertyListEmptyTest(
         bool isCommit, TransactionTestType transactionTestType) {
-        personNodeTable->getUnstrPropertyLists()->setPropertyListEmpty(123);
+        personNodeTable->getUnstrPropertyLists()->initEmptyPropertyLists(123);
         queryAndVerifyResults(123, "ui123", "us123", nullptr /* expected int for write trx */,
             nullptr /* expected str for write trx */,
             &existingIntVal /* expected int for read trx */,
@@ -261,7 +261,7 @@ public:
                                        .propertyID;
         // Inserting until 1100 ensures that chunk 1 is filled and a new chunk 2 is started
         for (node_offset_t nodeOffset = 601; nodeOffset < 1100; ++nodeOffset) {
-            personNodeTable->getUnstrPropertyLists()->setPropertyListEmpty(nodeOffset);
+            personNodeTable->getUnstrPropertyLists()->initEmptyPropertyLists(nodeOffset);
             personNodeTable->getUnstrPropertyLists()->setProperty(
                 nodeOffset, unstrIntPropKey, &existingIntVal);
             personNodeTable->getUnstrPropertyLists()->setProperty(


### PR DESCRIPTION
1. Add `setListOrColumnEmptyForNewNode(nodeID_t nodeID)` API to relStore, which sets the lists/column entry for nodeOffset to empty. The create operator should call this function when it adds a new nodeOffset to nodeTable.
2. Refactors the adj_and_property_lists_update_store so it can record whether the list is empty in persistent store for each nodeOffset.
3. Refactors the lists_update_iterator, so it can correctly update the header when it encounters a new nodeOffset.