### PR TITLE
add csv export functionality to API

### DIFF
--- a/src/main/include/query_result.h
+++ b/src/main/include/query_result.h
@@ -41,6 +41,8 @@ public:
     // TODO: this is not efficient and should be replaced by iterator
     std::shared_ptr<processor::FlatTuple> getNext();
 
+    void writeToCSV(string filename);
+
     inline uint64_t getNumColumns() const { return header->columnDataTypes.size(); }
 
     inline QuerySummary* getQuerySummary() const { return querySummary.get(); }

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -1,5 +1,7 @@
 #include "include/query_result.h"
 
+#include <fstream>
+
 using namespace std;
 using namespace graphflow::processor;
 
@@ -26,6 +28,53 @@ shared_ptr<FlatTuple> QueryResult::getNext() {
     }
     validateQuerySucceed();
     return iterator->getNextFlatTuple();
+}
+
+void QueryResult::writeToCSV(string filename) {
+    ofstream file;
+    file.open(filename);
+    shared_ptr<FlatTuple> nextTuple;
+    while (hasNext()) {
+        nextTuple = getNext();
+        for (auto idx = 0ul; idx < nextTuple->len(); idx++) {
+            string resultVal = nextTuple->getResultValue(idx)->to_string();
+            bool isStringList = false;
+            if (Types::dataTypeToString(nextTuple->getResultValue(idx)->getDataType()) ==
+                "STRING[]") {
+                isStringList = true;
+            }
+            bool surroundQuotes = false;
+            string thisValueStr;
+            for (long unsigned int j = 0; j < resultVal.length(); j++) {
+                if (!surroundQuotes) {
+                    if (resultVal[j] == '"' || resultVal[j] == '\n' || resultVal[j] == ',') {
+                        surroundQuotes = true;
+                    }
+                }
+                if (resultVal[j] == '"') {
+                    thisValueStr += "\"\"";
+                } else if (resultVal[j] == ',' && isStringList) {
+                    thisValueStr += "\"\",\"\"";
+                } else if (resultVal[j] == '[' && isStringList) {
+                    thisValueStr += "[\"\"";
+                } else if (resultVal[j] == ']' && isStringList) {
+                    thisValueStr += "\"\"]";
+                } else {
+                    thisValueStr += resultVal[j];
+                }
+            }
+            if (surroundQuotes) {
+                thisValueStr = '"' + thisValueStr + '"';
+            }
+            file << thisValueStr;
+            if (idx < nextTuple->len() - 1) {
+                file << ",";
+            } else {
+                file << endl;
+            }
+        }
+    }
+    file.close();
 }
 
 void QueryResult::validateQuerySucceed() {

--- a/test/main/csv_output_test.cpp
+++ b/test/main/csv_output_test.cpp
@@ -1,0 +1,43 @@
+#include <string>
+
+#include "include/main_test_helper.h"
+
+class CSVOutputTest : public ApiTest {};
+
+TEST_F(CSVOutputTest, BasicCSVTest) {
+    string newline = "\n";
+    string basicOutput = R"(Carol,1,5.000000,1940-06-22,1911-08-20 02:32:21,CsWork)" + newline +
+                         R"(Dan,2,4.800000,1950-07-23,2031-11-30 12:25:30,DEsWork)" + newline +
+                         R"(Elizabeth,1,4.700000,1980-10-26,1976-12-23 11:21:42,DEsWork)" + newline;
+    auto query = "MATCH (a:person)-[:workAt]->(o:organisation) RETURN a.fName, a.gender,"
+                 "a.eyeSight, a.birthdate, a.registerTime, o.name";
+    auto result = conn->query(query);
+    result->writeToCSV("output_CSV_BASIC.csv");
+    ifstream f("output_CSV_BASIC.csv");
+    ostringstream ss;
+    ss << f.rdbuf();
+    string fileString = ss.str();
+    ASSERT_STREQ(fileString.c_str(), basicOutput.c_str());
+}
+
+TEST_F(CSVOutputTest, ListCSVTest) {
+    string newline = "\n";
+    string listOutput =
+        R"([""Aida""],"[10,5]","[""Alice"",""Alice""]")" + newline +
+        R"([""Bobby""],"[12,8]","[""Bob"",""Bob""]")" + newline +
+        R"("[""Carmen"",""Fred""]","[4,5]","[""Carol"",""Carol""]")" + newline +
+        R"("[""Wolfeschlegelstein"",""Daniel""]","[1,9]","[""Dan"",""Dan""]")" + newline +
+        R"([""Ein""],[2],"[""Elizabeth"",""Elizabeth""]")" + newline +
+        R"([""Fesdwe""],"[3,4,5,6,7]","[""Farooq"",""Farooq""]")" + newline +
+        R"([""Grad""],[1],"[""Greg"",""Greg""]")" + newline +
+        R"("[""Ad"",""De"",""Hi"",""Kye"",""Orlan""]","[10,11,12,3,4,5,6,7]","[""Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"",""Hubert Blaine Wolfeschlegelsteinhausenbergerdorff""]")" +
+        newline;
+    auto query = "MATCH (a:person) RETURN a.usedNames, a.workedHours, [a.fName, a.fName]";
+    auto result = conn->query(query);
+    result->writeToCSV("output_CSV_LIST.csv");
+    ifstream f("output_CSV_LIST.csv");
+    ostringstream ss;
+    ss << f.rdbuf();
+    string fileString = ss.str();
+    ASSERT_STREQ(fileString.c_str(), listOutput.c_str());
+}

--- a/tools/python_api/BUILD.bazel
+++ b/tools/python_api/BUILD.bazel
@@ -53,6 +53,7 @@ py_test(
         "test/test_exception.py",
         "test/test_main.py",
         "test/test_parameter.py",
+        "test/test_write_to_csv.py"
     ],
     data = [
         "//dataset",

--- a/tools/python_api/include/py_query_result.h
+++ b/tools/python_api/include/py_query_result.h
@@ -19,6 +19,8 @@ public:
 
     py::list getNext();
 
+    void writeToCSV(py::str filename);
+
     void close();
 
     static py::object convertValueToPyObject(const ResultValue& value);

--- a/tools/python_api/py_query_result.cpp
+++ b/tools/python_api/py_query_result.cpp
@@ -11,6 +11,7 @@ void PyQueryResult::initialize(py::handle& m) {
     py::class_<PyQueryResult>(m, "result")
         .def("hasNext", &PyQueryResult::hasNext)
         .def("getNext", &PyQueryResult::getNext)
+        .def("writeToCSV", &PyQueryResult::writeToCSV)
         .def("close", &PyQueryResult::close)
         .def("getAsDF", &PyQueryResult::getAsDF);
 
@@ -31,6 +32,10 @@ py::list PyQueryResult::getNext() {
         result[i] = convertValueToPyObject(*tuple->getResultValue(i));
     }
     return move(result);
+}
+
+void PyQueryResult::writeToCSV(py::str filename) {
+    queryResult->writeToCSV(filename);
 }
 
 void PyQueryResult::close() {

--- a/tools/python_api/test/test_main.py
+++ b/tools/python_api/test/test_main.py
@@ -4,6 +4,7 @@ from test_datatype import *
 from test_parameter import *
 from test_exception import *
 from test_df import *
+from test_write_to_csv import *
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tools/python_api/test/test_write_to_csv.py
+++ b/tools/python_api/test/test_write_to_csv.py
@@ -1,0 +1,9 @@
+def test_write_to_csv(establish_connection):
+    outputString = """Alice,[""Aida""],"[10,5]"\nBob,[""Bobby""],"[12,8]"\nCarol,"[""Carmen"",""Fred""]","[4,5]"\nDan,"[""Wolfeschlegelstein"",""Daniel""]","[1,9]"\nElizabeth,[""Ein""],[2]\nFarooq,[""Fesdwe""],"[3,4,5,6,7]"\nGreg,[""Grad""],[1]\nHubert Blaine Wolfeschlegelsteinhausenbergerdorff,"[""Ad"",""De"",""Hi"",""Kye"",""Orlan""]","[10,11,12,3,4,5,6,7]"
+""" 
+    conn, db = establish_connection
+    result = conn.execute("MATCH (a:person) RETURN a.fName, a.usedNames, a.workedHours")
+    result.writeToCSV("test_PYTHON_CSV.csv")
+    with open("test_PYTHON_CSV.csv") as csv_file:
+         data = csv_file.read()
+    assert(data == outputString)  


### PR DESCRIPTION
query results can now be exported to csv using the new `writeCSV` command of the API

Added:
- New function in `QueryResult` class: `writeCSV`
- Added this function to the python api as well
- Wrote two tests: `BasicCsvTest` and `ListCsvTest`