### PR TITLE
Fix pip cross-compilation issue for arm64 Mac and move to self-host runner

### DIFF
--- a/.github/workflows/mac-wheel-workflow.yml
+++ b/.github/workflows/mac-wheel-workflow.yml
@@ -10,38 +10,42 @@ on:
 
 env:
   PYTHON_PACKAGE_VERSION: ${{ github.event.inputs.pythonPackageVersion }}
-  
+
 jobs:
-  build-x86-wheels:
-    runs-on: macOS-11
-    env:
-      MACOSX_DEPLOYMENT_TARGET: 10.15
+  build-wheels:
+    runs-on: self-hosted-mac
     steps:
       - uses: actions/checkout@v2
-      - name: fix-permission
-        run: |
-          cd ../ && sudo chown -R runner:staff graphflowdb/ && cd graphflowdb/
-          ls -al
       - name: create-source-distribution
         working-directory: ./scripts/pip-package/
         run: |
           rm -rf wheelhouse graphflowdb.tar.gz
           mkdir wheelhouse
           bash package_tar.sh
-          rm -rf ./sdist && mkdir ./sdist && tar -xf ./graphflowdb.tar.gz -C ./sdist
-          tar -czf sdist.tar.gz ./sdist/
 
-      - name: build-wheel
+      - name: build-arm-wheels
+        uses: pypa/cibuildwheel@v2.11.1
+        env:
+          CIBW_SKIP: pp*
+          CIBW_ARCHS_MACOS: arm64
+          CIBW_BUILD_VERBOSITY: 3
+          MACOSX_DEPLOYMENT_TARGET: 11.0
+        with:
+          package-dir: ./scripts/pip-package/graphflowdb.tar.gz
+          output-dir: ./scripts/pip-package/wheelhouse
+
+      - name: build-x86-wheel
         uses: pypa/cibuildwheel@v2.11.1
         env:
           CIBW_SKIP: pp*
           CIBW_ARCHS_MACOS: x86_64
           CIBW_BUILD_VERBOSITY: 3
+          MACOSX_DEPLOYMENT_TARGET: 10.15
         with:
-          package-dir: ./scripts/pip-package/sdist.tar.gz
+          package-dir: ./scripts/pip-package/graphflowdb.tar.gz
           output-dir: ./scripts/pip-package/wheelhouse
 
       - uses: actions/upload-artifact@v3
         with:
-          name: macos-x86-wheels
+          name: macos-wheels
           path: ./scripts/pip-package/wheelhouse/*.whl

--- a/scripts/pip-package/README.md
+++ b/scripts/pip-package/README.md
@@ -1,4 +1,4 @@
-# `pip install` from the Source
+# `pip install` from the source
 ```
 chmod +x package_tar.sh
 ./package_tar.sh
@@ -16,7 +16,7 @@ The container for manylinux builder automatically builds and upload wheels compa
 docker build -t graphflow-self-hosted-linux-builder .
 ```
 
-## Start Container
+## Start container
 ```
 docker run  --name self-hosted-linux-builder --detach --restart=always\
             -e GITHUB_ACCESS_TOKEN=YOUR_GITHUB_ACCESS_TOKEN\
@@ -26,4 +26,22 @@ docker run  --name self-hosted-linux-builder --detach --restart=always\
 Note: `GITHUB_ACCESS_TOKEN` is the account-level access token that can be acquired at [GitHub developer settings](https://github.com/settings/tokens).
 
 ## Bulid wheels for macOS
-We use [cibuildwheel](https://github.com/pypa/cibuildwheel). The configuration file is located at `.github/workflows/mac-wheel-workflow.yml`.
+We use [cibuildwheel](https://github.com/pypa/cibuildwheel). The configuration file is located at `.github/workflows/mac-wheel-workflow.yml`. Although we currently run the pipeline on a self-hosted Mac mini, this configuration also works for GitHub-hosted runners (`macos-11` and `macos-12`).
+
+### Self-hosted macOS runner setup
+The self-hosted runner needs to be properly configured for the pipeline to run. Please follow the instructions below to configure a self-hosted runner on macOS.
+
+- OS requirement: for support for C++20 and proper cross-compilation for ARM64, Xcode 13+ and macOS 11+ is required. If the hardware does not support macOS 11 officially, consider using [OpenCore Legacy Patcher](https://dortania.github.io/OpenCore-Legacy-Patcher/).
+- Machine configurations:
+    - Username: The username must be set to `runner` to be consistent with the GitHub-hosted runners. Otherwise, cibuildwheel configuration step will fail due to writing to directories that does not exist.
+    - `sudo` without password: The `runner` user needs to have the permission to `sudo` without password. Otherwise, cibuildwheel will not be able to install Python automatically due to not able to take user input for the password. To enable `sudo` without password, create a file (with arbitrary name) under `/private/etc/sudoers.d/` and add `runner    ALL = (ALL) NOPASSWD: ALL` to it.
+    - Keep the machine from going to sleep automatically: under System Preferences > Energy Saver, check "Prevent your Mac from sleeping automatically when the display is off" and uncheck "Put hard disks to sleep when possible".
+    - Automatic login: the GitHub self-hosted runner service on macOS is configured for the user space only. For the listener to be back online automatically after each reboot without manually logging in, automatic login should be turned on for `runner` user. Please follow [this instruction](https://support.apple.com/en-us/HT201476) to configure it.
+    - For the ease of remote management, consider enabling `sshd` and configure a DDNS service to keep the hostname updated with the correct IP address.
+- Dependencies installation:
+    - Xcode toolchain: after installing Xcode, run `xcode-select --install` to install Xcode Command Line Tools.
+    - Homebrew: follow the instructions on [brew.sh](https://brew.sh) to install it.
+    - Bazel: `brew install bazel`.
+    - OpenJDK-11: Installing bazel via Homebrew should also install it as a dependency automatically. However, For it to be detected by macOS, we need to run `sudo ln -sfn /usr/local/opt/openjdk@11/libexec/openjdk.jdk /Library/Java/JavaVirtualMachines/openjdk-11.jdk`.
+    - Pipx: `brew install pipx` and `pipx ensurepath`.
+- Github self-hosted runners configuration: follow [this documentation](https://docs.github.com/en/actions/hosting-your-own-runners/adding-self-hosted-runners) to add the self-hosted runner and [this documentation](https://docs.github.com/en/actions/hosting-your-own-runners/configuring-the-self-hosted-runner-application-as-a-service) for configuring self-hosted runner as a service.

--- a/scripts/pip-package/package_tar.sh
+++ b/scripts/pip-package/package_tar.sh
@@ -1,10 +1,25 @@
+#!/bin/bash
+
+# Collect source files
 tar --exclude="$(pwd)" \
     --exclude="./bazel-*" \
     --exclude="./scripts" \
     --exclude="./.?*" \
     -cf\
-    graphflowdb.tar\
+    graphflowdb-source.tar\
     -C ../../. .
+rm -rf graphflowdb-source && mkdir graphflowdb-source
+tar -xf graphflowdb-source.tar -C ./graphflowdb-source
+rm -rf graphflowdb-source.tar
 
-tar -rf graphflowdb.tar ./setup.py ./MANIFEST.in ./graphflowdb
-gzip graphflowdb.tar
+# Add all files under current directory
+touch sdist.tar
+tar -cf sdist.tar --exclude=./sdist.tar .
+rm -rf sdist && mkdir sdist
+tar -xf sdist.tar -C ./sdist
+rm -rf sdist.tar
+
+# Create tar.gz for PyPI
+rm -rf graphflowdb.tar.gz
+tar -czf graphflowdb.tar.gz sdist
+rm -rf sdist graphflowdb-source


### PR DESCRIPTION
This PR fixes the wheel building for ARM-based Macs. It also moves the runner to a self-hosted Mac mini 2012 computer and add instructions on how a self-hosted mac can be configured. The pipeline is tested with https://github.com/graphflowdb/graphflowdb/actions/runs/3340969356.