### PR TITLE
fix rel-insertion issues #866

### DIFF
--- a/src/planner/join_order_enumerator.cpp
+++ b/src/planner/join_order_enumerator.cpp
@@ -663,7 +663,9 @@ expression_vector JoinOrderEnumerator::getPropertiesForVariable(
 
 uint64_t JoinOrderEnumerator::getExtensionRate(
     table_id_t boundTableID, table_id_t relTableID, RelDirection relDirection) {
-    auto numRels = ((RelStatistics*)((*relsStatistics.getReadOnlyVersion())[relTableID].get()))
+    auto numRels = ((RelStatistics*)relsStatistics.getReadOnlyVersion()
+                        ->tableStatisticPerTable[relTableID]
+                        .get())
                        ->getNumRelsForDirectionBoundTable(relDirection, boundTableID);
     return ceil(
         (double)numRels / nodesStatisticsAndDeletedIDs.getNodeStatisticsAndDeletedIDs(boundTableID)

--- a/src/processor/operator/copy_csv/include/copy_csv.h
+++ b/src/processor/operator/copy_csv/include/copy_csv.h
@@ -30,8 +30,9 @@ public:
 
 protected:
     void errorIfTableIsNonEmpty(TablesStatistics* tablesStatistics) {
-        auto numTuples =
-            tablesStatistics->getReadOnlyVersion()->at(tableSchema.tableID)->getNumTuples();
+        auto numTuples = tablesStatistics->getReadOnlyVersion()
+                             ->tableStatisticPerTable.at(tableSchema.tableID)
+                             ->getNumTuples();
         if (numTuples > 0) {
             throw CopyCSVException(
                 "COPY CSV commands can be executed only on completely empty tables. Table: " +

--- a/src/processor/operator/update/include/create.h
+++ b/src/processor/operator/update/include/create.h
@@ -97,7 +97,9 @@ public:
 private:
     RelsStatistics& relsStatistics;
     vector<unique_ptr<CreateRelInfo>> createRelInfos;
-    vector<vector<shared_ptr<ValueVector>>> vectorsToInsertPerRel;
+    vector<shared_ptr<ValueVector>> srcNodeIDVectorPerRelTable;
+    vector<shared_ptr<ValueVector>> dstNodeIDVectorPerRelTable;
+    vector<vector<shared_ptr<ValueVector>>> relPropertyVectorsPerRelTable;
 };
 
 } // namespace processor

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -276,11 +276,7 @@ void FactorizedTable::copyToInMemList(uint32_t colIdx, vector<uint64_t>& tupleId
     auto numBytesPerValue = nodeIDCompressionScheme == nullptr ?
                                 Types::getDataTypeSize(type) :
                                 nodeIDCompressionScheme->getNumBytesForNodeIDAfterCompression();
-    auto colOffset =
-        tableSchema->getColOffset(colIdx) +
-        (nodeIDCompressionScheme == nullptr ?
-                0 :
-                sizeof(nodeID_t) - nodeIDCompressionScheme->getNumBytesForNodeIDAfterCompression());
+    auto colOffset = tableSchema->getColOffset(colIdx);
     auto listToFill = data + startElemPosInList * numBytesPerValue;
     for (auto i = 0u; i < tupleIdxesToRead.size(); i++) {
         auto tuple = getTuple(tupleIdxesToRead[i]);

--- a/src/storage/in_mem_csv_copier/in_mem_rel_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_rel_csv_copier.cpp
@@ -8,13 +8,13 @@ namespace storage {
 
 InMemRelCSVCopier::InMemRelCSVCopier(CSVDescription& csvDescription, string outputDirectory,
     TaskScheduler& taskScheduler, Catalog& catalog,
-    map<table_id_t, uint64_t> maxNodeOffsetsPerNodeTable, BufferManager* bufferManager,
+    map<table_id_t, node_offset_t> maxNodeOffsetsPerNodeTable, BufferManager* bufferManager,
     table_id_t tableID, RelsStatistics* relsStatistics)
     : InMemStructuresCSVCopier{csvDescription, move(outputDirectory), taskScheduler, catalog},
       maxNodeOffsetsPerTable{move(maxNodeOffsetsPerNodeTable)}, relsStatistics{relsStatistics} {
-    startRelID = relsStatistics->getNextRelID();
-    relTableSchema = catalog.getReadOnlyVersion()->getRelTableSchema(tableID);
     dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
+    startRelID = relsStatistics->getNextRelID(dummyReadOnlyTrx.get());
+    relTableSchema = catalog.getReadOnlyVersion()->getRelTableSchema(tableID);
     for (auto& nodeTableID : relTableSchema->getAllNodeTableIDs()) {
         assert(!IDIndexes.contains(nodeTableID));
         IDIndexes[nodeTableID] = make_unique<HashIndex>(

--- a/src/storage/in_mem_csv_copier/include/in_mem_rel_csv_copier.h
+++ b/src/storage/in_mem_csv_copier/include/in_mem_rel_csv_copier.h
@@ -19,7 +19,7 @@ class InMemRelCSVCopier : public InMemStructuresCSVCopier {
 public:
     InMemRelCSVCopier(CSVDescription& csvDescription, string outputDirectory,
         TaskScheduler& taskScheduler, Catalog& catalog,
-        map<table_id_t, uint64_t> maxNodeOffsetsPerNodeTable, BufferManager* bufferManager,
+        map<table_id_t, node_offset_t> maxNodeOffsetsPerNodeTable, BufferManager* bufferManager,
         table_id_t tableID, RelsStatistics* relsStatistics);
 
     ~InMemRelCSVCopier() override = default;
@@ -82,7 +82,7 @@ private:
         InMemOverflowFile* orderedInMemOverflowFile);
 
 private:
-    const map<table_id_t, uint64_t> maxNodeOffsetsPerTable;
+    const map<table_id_t, node_offset_t> maxNodeOffsetsPerTable;
     uint64_t startRelID;
     RelTableSchema* relTableSchema;
     RelsStatistics* relsStatistics;

--- a/src/storage/include/wal_replayer_utils.h
+++ b/src/storage/include/wal_replayer_utils.h
@@ -14,7 +14,7 @@ namespace storage {
 class WALReplayerUtils {
 public:
     static void createEmptyDBFilesForNewRelTable(Catalog* catalog, table_id_t tableID,
-        const string& directory, const map<table_id_t, uint64_t>& maxNodeOffsetsPerTable);
+        const string& directory, const map<table_id_t, node_offset_t>& maxNodeOffsetsPerTable);
 
     static void createEmptyDBFilesForNewNodeTable(
         Catalog* catalog, table_id_t tableID, string directory);

--- a/src/storage/storage_structure/include/lists/adj_and_property_lists_update_store.h
+++ b/src/storage/storage_structure/include/lists/adj_and_property_lists_update_store.h
@@ -58,7 +58,11 @@ public:
         DiskOverflowFile* diskOverflowFile, DataType dataType,
         NodeIDCompressionScheme* nodeIDCompressionScheme);
 
-    void insertRelIfNecessary(vector<shared_ptr<ValueVector>>& srcDstNodeIDAndRelProperties);
+    // If this is a one-to-one relTable, all properties are stored in columns.
+    // In this case, the adjAndPropertyListsUpdateStore should not store the insert rels in FT.
+    void insertRelIfNecessary(shared_ptr<ValueVector>& srcNodeIDVector,
+        shared_ptr<ValueVector>& dstNodeIDVector,
+        vector<shared_ptr<ValueVector>>& relPropertyVectors);
 
     uint64_t getNumInsertedRelsForNodeOffset(
         ListFileID& listFileID, node_offset_t nodeOffset) const;
@@ -85,10 +89,7 @@ private:
                    listFileID.relPropertyListID.relNodeTableAndDir;
     }
     uint32_t getColIdxInFT(ListFileID& listFileID) const;
-    void validateSrcDstNodeIDAndRelProperties(
-        vector<shared_ptr<ValueVector>> srcDstNodeIDAndRelProperties) const;
     void initListUpdatesPerTablePerDirection();
-    static void getErrorMsgForInvalidTableID(uint64_t tableID, bool isSrcTableID, string tableName);
 
 private:
     unique_ptr<FactorizedTable> factorizedTable;

--- a/src/storage/store/include/rel_table.h
+++ b/src/storage/store/include/rel_table.h
@@ -18,8 +18,8 @@ using table_property_lists_map_t =
 class RelTable {
 
 public:
-    explicit RelTable(const catalog::Catalog& catalog, table_id_t tableID,
-        BufferManager& bufferManager, MemoryManager& memoryManager, bool isInMemoryMode, WAL* wal);
+    RelTable(const catalog::Catalog& catalog, table_id_t tableID, BufferManager& bufferManager,
+        MemoryManager& memoryManager, bool isInMemoryMode, WAL* wal);
 
     void loadColumnsAndListsFromDisk(const catalog::Catalog& catalog, BufferManager& bufferManager);
 
@@ -41,6 +41,7 @@ public:
     inline AdjAndPropertyListsUpdateStore* getAdjAndPropertyListsUpdateStore() {
         return adjAndPropertyListsUpdateStore.get();
     }
+    inline table_id_t getRelTableID() const { return tableID; }
 
     vector<AdjLists*> getAdjListsForNodeTable(table_id_t tableID);
     vector<AdjColumn*> getAdjColumnsForNodeTable(table_id_t tableID);
@@ -49,7 +50,9 @@ public:
     void checkpointInMemoryIfNecessary();
     void rollbackInMemoryIfNecessary();
 
-    void insertRels(vector<shared_ptr<ValueVector>>& valueVectorsToInsert);
+    void insertRels(shared_ptr<ValueVector>& srcNodeIDVector,
+        shared_ptr<ValueVector>& dstNodeIDVector,
+        vector<shared_ptr<ValueVector>>& relPropertyVectors);
     void initEmptyRelsForNewNode(nodeID_t& nodeID);
 
 private:

--- a/src/storage/store/nodes_statistics_and_deleted_ids.cpp
+++ b/src/storage/store/nodes_statistics_and_deleted_ids.cpp
@@ -154,17 +154,17 @@ NodesStatisticsAndDeletedIDs::NodesStatisticsAndDeletedIDs(
     : TablesStatistics{} {
     initTableStatisticPerTableForWriteTrxIfNecessary();
     for (auto& nodeStatistics : nodesStatisticsAndDeletedIDs) {
-        (*tableStatisticPerTableForReadOnlyTrx)[nodeStatistics.first] =
+        tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable[nodeStatistics.first] =
             make_unique<NodeStatisticsAndDeletedIDs>(
                 *(NodeStatisticsAndDeletedIDs*)nodeStatistics.second.get());
-        (*tableStatisticPerTableForWriteTrx)[nodeStatistics.first] =
+        tablesStatisticsContentForWriteTrx->tableStatisticPerTable[nodeStatistics.first] =
             make_unique<NodeStatisticsAndDeletedIDs>(
                 *(NodeStatisticsAndDeletedIDs*)nodeStatistics.second.get());
     }
 }
 
 void NodesStatisticsAndDeletedIDs::setAdjListsAndColumns(RelsStore* relsStore) {
-    for (auto& tableIDStatistics : *tableStatisticPerTableForReadOnlyTrx) {
+    for (auto& tableIDStatistics : tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable) {
         getNodeStatisticsAndDeletedIDs(tableIDStatistics.first)
             ->setAdjListsAndColumns(relsStore->getAdjListsAndColumns(tableIDStatistics.first));
     }
@@ -172,7 +172,7 @@ void NodesStatisticsAndDeletedIDs::setAdjListsAndColumns(RelsStore* relsStore) {
 
 map<table_id_t, node_offset_t> NodesStatisticsAndDeletedIDs::getMaxNodeOffsetPerTable() const {
     map<table_id_t, node_offset_t> retVal;
-    for (auto& tableIDStatistics : *tableStatisticPerTableForReadOnlyTrx) {
+    for (auto& tableIDStatistics : tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable) {
         retVal[tableIDStatistics.first] =
             getNodeStatisticsAndDeletedIDs(tableIDStatistics.first)->getMaxNodeOffset();
     }
@@ -182,24 +182,26 @@ map<table_id_t, node_offset_t> NodesStatisticsAndDeletedIDs::getMaxNodeOffsetPer
 void NodesStatisticsAndDeletedIDs::setDeletedNodeOffsetsForMorsel(
     Transaction* transaction, const shared_ptr<ValueVector>& nodeOffsetVector, table_id_t tableID) {
     // NOTE: We can remove the lock under the following assumptions, that should currently hold:
-    // 1) During the phases when nodeStatisticsAndDeletedIDsPerTableForReadOnlyTrx change, which is
-    // during checkpointing, this function, which is called during scans, cannot be called. 2) In a
-    // read-only transaction, the same morsel cannot be scanned concurrently. 3) A write transaction
-    // cannot have two concurrent pipelines where one is writing and the other is reading
-    // nodeStatisticsAndDeletedIDsPerTableForWriteTrx. That is the pipeline in a query where
-    // scans/reads happen in a write transaction cannot run concurrently with the pipeline that
-    // performs an add/delete node.
+    // 1) During the phases when nodeStatisticsAndDeletedIDsPerTableForReadOnlyTrx change, which
+    // is during checkpointing, this function, which is called during scans, cannot be called.
+    // 2) In a read-only transaction, the same morsel cannot be scanned concurrently. 3) A write
+    // transaction cannot have two concurrent pipelines where one is writing and the other is
+    // reading nodeStatisticsAndDeletedIDsPerTableForWriteTrx. That is the pipeline in a query
+    // where scans/reads happen in a write transaction cannot run concurrently with the pipeline
+    // that performs an add/delete node.
     lock_t lck{mtx};
-    (transaction->isReadOnly() || !tableStatisticPerTableForWriteTrx) ?
+    (transaction->isReadOnly() || tablesStatisticsContentForWriteTrx == nullptr) ?
         getNodeStatisticsAndDeletedIDs(tableID)->setDeletedNodeOffsetsForMorsel(nodeOffsetVector) :
-        ((NodeStatisticsAndDeletedIDs*)(*tableStatisticPerTableForWriteTrx)[tableID].get())
+        ((NodeStatisticsAndDeletedIDs*)tablesStatisticsContentForWriteTrx
+                ->tableStatisticPerTable[tableID]
+                .get())
             ->setDeletedNodeOffsetsForMorsel(nodeOffsetVector);
 }
 
 void NodesStatisticsAndDeletedIDs::addNodeStatisticsAndDeletedIDs(NodeTableSchema* tableSchema) {
     initTableStatisticPerTableForWriteTrxIfNecessary();
     // We use UINT64_MAX to represent an empty nodeTable which doesn't contain any nodes.
-    (*tableStatisticPerTableForWriteTrx)[tableSchema->tableID] =
+    tablesStatisticsContentForWriteTrx->tableStatisticPerTable[tableSchema->tableID] =
         make_unique<NodeStatisticsAndDeletedIDs>(
             tableSchema->tableID, UINT64_MAX /* maxNodeOffset */);
 }

--- a/src/storage/store/table_statistics.cpp
+++ b/src/storage/store/table_statistics.cpp
@@ -7,8 +7,7 @@ namespace storage {
 
 TablesStatistics::TablesStatistics() {
     logger = LoggerUtils::getOrCreateSpdLogger("storage");
-    tableStatisticPerTableForReadOnlyTrx =
-        make_unique<unordered_map<table_id_t, unique_ptr<TableStatistics>>>();
+    tablesStatisticsContentForReadOnlyTrx = make_unique<TablesStatisticsContent>();
 }
 
 void TablesStatistics::readFromFile(const string& directory) {
@@ -17,13 +16,15 @@ void TablesStatistics::readFromFile(const string& directory) {
     logger->info("Reading {} from {}.", getTableTypeForPrinting(), filePath);
     uint64_t offset = 0;
     uint64_t numTables;
+    offset = SerDeser::deserializeValue(
+        tablesStatisticsContentForReadOnlyTrx->nextRelID, fileInfo.get(), offset);
     offset = SerDeser::deserializeValue<uint64_t>(numTables, fileInfo.get(), offset);
     for (auto i = 0u; i < numTables; i++) {
         uint64_t numTuples;
         offset = SerDeser::deserializeValue<uint64_t>(numTuples, fileInfo.get(), offset);
         table_id_t tableID;
         offset = SerDeser::deserializeValue<uint64_t>(tableID, fileInfo.get(), offset);
-        (*tableStatisticPerTableForReadOnlyTrx)[tableID] =
+        tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable[tableID] =
             deserializeTableStatistics(numTuples, offset, fileInfo.get(), tableID);
     }
     FileUtils::closeFile(fileInfo->fd);
@@ -35,12 +36,14 @@ void TablesStatistics::saveToFile(
     logger->info("Writing {} to {}.", getTableTypeForPrinting(), filePath);
     auto fileInfo = FileUtils::openFile(filePath, O_WRONLY | O_CREAT);
     uint64_t offset = 0;
-    auto& tableStatisticPerTable = (transactionType == TransactionType::READ_ONLY ||
-                                       tableStatisticPerTableForWriteTrx == nullptr) ?
-                                       tableStatisticPerTableForReadOnlyTrx :
-                                       tableStatisticPerTableForWriteTrx;
-    offset = SerDeser::serializeValue(tableStatisticPerTable->size(), fileInfo.get(), offset);
-    for (auto& tableStatistic : *tableStatisticPerTable) {
+    auto& tablesStatisticsContent = (transactionType == TransactionType::READ_ONLY ||
+                                        tablesStatisticsContentForWriteTrx == nullptr) ?
+                                        tablesStatisticsContentForReadOnlyTrx :
+                                        tablesStatisticsContentForWriteTrx;
+    offset = SerDeser::serializeValue(tablesStatisticsContent->nextRelID, fileInfo.get(), offset);
+    offset = SerDeser::serializeValue(
+        tablesStatisticsContent->tableStatisticPerTable.size(), fileInfo.get(), offset);
+    for (auto& tableStatistic : tablesStatisticsContent->tableStatisticPerTable) {
         auto tableStatistics = tableStatistic.second.get();
         offset = SerDeser::serializeValue(tableStatistics->getNumTuples(), fileInfo.get(), offset);
         offset = SerDeser::serializeValue(tableStatistic.first, fileInfo.get(), offset);
@@ -51,11 +54,12 @@ void TablesStatistics::saveToFile(
 }
 
 void TablesStatistics::initTableStatisticPerTableForWriteTrxIfNecessary() {
-    if (tableStatisticPerTableForWriteTrx == nullptr) {
-        tableStatisticPerTableForWriteTrx =
-            make_unique<unordered_map<table_id_t, unique_ptr<TableStatistics>>>();
-        for (auto& tableStatistic : *tableStatisticPerTableForReadOnlyTrx) {
-            (*tableStatisticPerTableForWriteTrx)[tableStatistic.first] =
+    if (tablesStatisticsContentForWriteTrx == nullptr) {
+        tablesStatisticsContentForWriteTrx = make_unique<TablesStatisticsContent>();
+        tablesStatisticsContentForWriteTrx->nextRelID =
+            tablesStatisticsContentForReadOnlyTrx->nextRelID;
+        for (auto& tableStatistic : tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable) {
+            tablesStatisticsContentForWriteTrx->tableStatisticPerTable[tableStatistic.first] =
                 constructTableStatistic(tableStatistic.second.get());
         }
     }

--- a/test/runner/e2e_update_test.cpp
+++ b/test/runner/e2e_update_test.cpp
@@ -314,13 +314,14 @@ TEST_F(TinySnbUpdateTest, InsertNodeAfterMatchListTest) {
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
 }
 
-// TODO(ziyi): check this query. If "RETURN a.ID, b.ID, e.ID", then b.ID and e.ID seems to be
-// in-correct.
 TEST_F(TinySnbUpdateTest, InsertRelBasicTest) {
     conn->query("MATCH (a:person)-[:knows]->(b:person) WHERE a.ID = 7 "
                 "CREATE (a)<-[:knows {date:date('1997-03-22')}]-(b);");
-    auto groundTruth = vector<string>{"4"};
-    auto result =
-        conn->query("MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 6 RETURN COUNT(*)");
+    auto groundTruth = vector<string>{"7|8|12", "7|9|13", "8|7|37", "9|7|38"};
+    auto result = conn->query("MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 6 RETURN a.ID, "
+                              "b.ID, e._id order by a.ID, b.ID");
+    // After rel insertions,the query will return 4 rels: person7->person8, person7->person9,
+    // person8->person7, person9->person7.
+    ASSERT_EQ(result->getNumTuples(), 4);
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
 }


### PR DESCRIPTION
This PR solves the rel-insertion issues as desribed in #866 
1. The `RelTable::insertRels` now assumes that all input vectors are flat (including src,dst,property vectors).
2. Changes the  `RelTable::insertRel(vectors)` API to ` RelTable::insertRel(srcNodeID, dstNodeID, properties)`
3. Fixes the relID issue by introducing some new functions and vars to relStatistics:
     a. `nextRelID`: records the next relID to give to the caller.
     b. `incrementNumRelsByOneForTable`,  `incrementNumRelsPerDirectionBoundTableByOne`: as their name suggest, they increment the numberRels/numRelsPerDirectionBoundTable by one. These functions will be called in the create physical operator after it has inserted a rel to the relTable.