### PR TITLE
Refactor and add more tests for rel insertions

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -278,7 +278,7 @@ unique_ptr<BoundUpdatingClause> Binder::bindCreateClause(const UpdatingClause& u
             setItemsPerNode.push_back(propertyCollection->getPropertyKeyValPairs(*node));
         }
         for (auto j = 0u; j < queryGraph->getNumQueryRels(); ++j) {
-            auto rel = queryGraph->getQueryRel(i);
+            auto rel = queryGraph->getQueryRel(j);
             if (!prevVariablesInScope.contains(rel->getRawName())) {
                 relsToCreate.push_back(rel);
             }

--- a/src/planner/enumerator.cpp
+++ b/src/planner/enumerator.cpp
@@ -333,6 +333,10 @@ void Enumerator::appendExpressionsScan(expression_vector& expressions, LogicalPl
     auto groupPos = schema->createGroup();
     schema->flattenGroup(groupPos); // Mark group holding constant as flat.
     for (auto& expression : expressions) {
+        // No need to insert repeated constant.
+        if (schema->isExpressionInScope(*expression)) {
+            continue;
+        }
         schema->insertToGroupAndScope(expression, groupPos);
     }
     auto expressionsScan = make_shared<LogicalExpressionsScan>(std::move(expressions));

--- a/src/processor/operator/cross_product.cpp
+++ b/src/processor/operator/cross_product.cpp
@@ -23,6 +23,10 @@ bool CrossProduct::getNextTuples() {
     // Note: we should NOT morselize right table scanning (i.e. calling sharedState.getMorsel)
     // because every thread should scan its own table.
     auto table = sharedState->getTable();
+    if (table->getNumTuples() == 0) {
+        metrics->executionTime.stop();
+        return false;
+    }
     if (startIdx == table->getNumTuples()) { // no more to scan from right
         if (!children[0]->getNextTuples()) { // fetch a new left tuple
             metrics->executionTime.stop();

--- a/src/storage/store/include/rels_store.h
+++ b/src/storage/store/include/rels_store.h
@@ -69,8 +69,6 @@ public:
         }
     }
 
-    void initEmptyRelsForNewNode(nodeID_t& nodeID);
-
 private:
     unordered_map<table_id_t, unique_ptr<RelTable>> relTables;
     RelsStatistics relsStatistics;

--- a/src/storage/store/rels_store.cpp
+++ b/src/storage/store/rels_store.cpp
@@ -28,11 +28,5 @@ pair<vector<AdjLists*>, vector<AdjColumn*>> RelsStore::getAdjListsAndColumns(
     return make_pair(adjListsRetVal, adjColumnsRetVal);
 }
 
-void RelsStore::initEmptyRelsForNewNode(nodeID_t& nodeID) {
-    for (auto& relTable : relTables) {
-        relTable.second->initEmptyRelsForNewNode(nodeID);
-    }
-}
-
 } // namespace storage
 } // namespace graphflow

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -311,6 +311,11 @@ TEST_F(TinySnbDDLTest, MultipleCreateRelTables) {
     ASSERT_EQ(result->getNumTuples(), 0);
     result = conn->query("MATCH (o:organisation)-[l:employees]->(p1:person) return l.ID");
     ASSERT_FALSE(result->isSuccess());
+    result = conn->query("CREATE (p:person {ID:100})-[:likes]->(p1:person {ID:101})");
+    ASSERT_TRUE(result->isSuccess());
+    result = conn->query("MATCH (p:person)-[l:likes]->(p1:person) return l");
+    ASSERT_TRUE(result->isSuccess());
+    ASSERT_EQ(result->getNumTuples(), 1);
 }
 
 TEST_F(TinySnbDDLTest, CreateRelTableCommitNormalExecution) {

--- a/test/test_files/tinySNB/filter/node.test
+++ b/test/test_files/tinySNB/filter/node.test
@@ -199,3 +199,9 @@
 -ENUMERATE
 ---- 1
 3
+
+-NAME nodeCrossProduct
+-QUERY MATCH (a:person), (b:person) WHERE a.ID = 1000 RETURN COUNT(*)
+-ENUMERATE
+---- 1
+0


### PR DESCRIPTION
Move the following logic to front-end
- finding connected rel table for a newly inserted node
- finding src and dot node table ID for a newly inserted rel (we cannot insert a rel with multiple src or dst node label)

Add e2e tests for creating complex patterns