### PR TITLE
Solve issue #839 (bug in listColumn)

### DIFF
--- a/dataset/tinysnb/copy_csv.cypher
+++ b/dataset/tinysnb/copy_csv.cypher
@@ -5,3 +5,4 @@ COPY studyAt FROM "dataset/tinysnb/eStudyAt.csv" (HEADER=true);
 COPY workAt FROM "dataset/tinysnb/eWorkAt.csv"
 COPY meets FROM "dataset/tinysnb/eMeets.csv"
 COPY mixed FROM "dataset/tinysnb/eMixed.csv"
+COPY marries FROM "dataset/tinysnb/eMarries.csv"

--- a/dataset/tinysnb/eMarries.csv
+++ b/dataset/tinysnb/eMarries.csv
@@ -1,0 +1,3 @@
+0,2,["toronto"],
+3,5,,"long long long string"
+7,8,["vancouver"],"short str"

--- a/dataset/tinysnb/schema.cypher
+++ b/dataset/tinysnb/schema.cypher
@@ -5,3 +5,4 @@ create rel table studyAt (FROM person TO organisation, year INT64, places STRING
 create rel table workAt (FROM person TO organisation, year INT64, MANY_ONE);
 create rel table meets (FROM person TO person, MANY_ONE);
 create rel table mixed (FROM person TO person|organisation, year INT64, MANY_ONE);
+create rel table marries (FROM person TO person, usedAddress STRING[], note STRING, ONE_ONE);

--- a/test/main/catalog_printing_test.cpp
+++ b/test/main/catalog_printing_test.cpp
@@ -1,9 +1,9 @@
 #include "include/main_test_helper.h"
 
 TEST_F(ApiTest, CatalogPrinting) {
-    ASSERT_STREQ(conn->getNodeTableNames().c_str(), "Node tables: \n\tperson\n\torganisation\n");
+    ASSERT_STREQ(conn->getNodeTableNames().c_str(), "Node tables: \n\torganisation\n\tperson\n");
     ASSERT_STREQ(conn->getRelTableNames().c_str(),
-        "Rel tables: \n\tmixed\n\tworkAt\n\tknows\n\tstudyAt\n\tmeets\n");
+        "Rel tables: \n\tmarries\n\tmeets\n\tstudyAt\n\tknows\n\tworkAt\n\tmixed\n");
 
     ASSERT_STREQ(conn->getRelPropertyNames("studyAt").c_str(),
         "studyAt src nodes: \n\tperson\nstudyAt dst nodes: \n\torganisation\nstudyAt properties: "

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -140,14 +140,14 @@ public:
         if (transactionTestType == TransactionTestType::RECOVERY) {
             conn->commitButSkipCheckpointingForTestingRecovery();
             ASSERT_FALSE(catalog->getReadOnlyVersion()->containRelTable("likes"));
-            ASSERT_EQ(database->getStorageManager()->getRelsStore().getNumRelTables(), 5);
+            ASSERT_EQ(database->getStorageManager()->getRelsStore().getNumRelTables(), 6);
             initWithoutLoadingGraph();
             ASSERT_TRUE(catalog->getReadOnlyVersion()->containRelTable("likes"));
-            ASSERT_EQ(database->getStorageManager()->getRelsStore().getNumRelTables(), 6);
+            ASSERT_EQ(database->getStorageManager()->getRelsStore().getNumRelTables(), 7);
         } else {
             conn->commit();
             ASSERT_TRUE(catalog->getReadOnlyVersion()->containRelTable("likes"));
-            ASSERT_EQ(database->getStorageManager()->getRelsStore().getNumRelTables(), 6);
+            ASSERT_EQ(database->getStorageManager()->getRelsStore().getNumRelTables(), 7);
         }
     }
 

--- a/test/runner/e2e_update_test.cpp
+++ b/test/runner/e2e_update_test.cpp
@@ -319,7 +319,7 @@ TEST_F(TinySnbUpdateTest, InsertSingleNToNRelTest) {
         "MATCH (a:person), (b:person) WHERE a.ID = 9 AND b.ID = 10 "
         "CREATE (a)-[:knows {meetTime:timestamp('1976-12-23 11:21:42'), validInterval:interval('2 "
         "years'), comments:['A', 'k'], date:date('1997-03-22')}]->(b);");
-    auto groundTruth = vector<string>{"9|10|1997-03-22|1976-12-23 11:21:42|2 years|[A,k]|37"};
+    auto groundTruth = vector<string>{"9|10|1997-03-22|1976-12-23 11:21:42|2 years|[A,k]|40"};
     auto result =
         conn->query("MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 8 RETURN a.ID, b.ID, e");
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
@@ -330,7 +330,7 @@ TEST_F(TinySnbUpdateTest, InsertSingleNTo1RelTest) {
     conn->query("MATCH (a:person), (b:organisation) WHERE a.ID = 9 AND b.orgCode = 934 "
                 "CREATE (a)-[:studyAt {year:2022}]->(b);");
     auto groundTruth =
-        vector<string>{"8|325|2020|[awndsnjwejwen,isuhuwennjnuhuhuwewe]|16", "9|934|2022||37"};
+        vector<string>{"8|325|2020|[awndsnjwejwen,isuhuwennjnuhuhuwewe]|16", "9|934|2022||40"};
     auto result = conn->query(
         "MATCH (a:person)-[e:studyAt]->(b:organisation) WHERE a.ID > 5 RETURN a.ID, b.orgCode, e");
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
@@ -367,7 +367,7 @@ TEST_F(TinySnbUpdateTest, InsertMixedRelTest) {
 TEST_F(TinySnbUpdateTest, InsertMultipleRelsTest) {
     conn->query("MATCH (a:person)-[:knows]->(b:person) WHERE a.ID = 7 "
                 "CREATE (a)<-[:knows]-(b);");
-    auto groundTruth = vector<string>{"7|8|12", "7|9|13", "8|7|37", "9|7|38"};
+    auto groundTruth = vector<string>{"7|8|12", "7|9|13", "8|7|40", "9|7|41"};
     auto result = conn->query("MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 6 RETURN a.ID, "
                               "b.ID, e._id");
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
@@ -385,7 +385,7 @@ TEST_F(TinySnbUpdateTest, InsertNodeAndRelTest) {
 TEST_F(TinySnbUpdateTest, InsertNodeAndRelTest2) {
     conn->query(
         "CREATE (c:organisation {ID:50})<-[:workAt]-(a:person {ID:100}), (a)-[:studyAt]->(c)");
-    auto groundTruth = vector<string>{"100|50|38|37"};
+    auto groundTruth = vector<string>{"100|50|41|40"};
     auto result = conn->query(
         "MATCH (a:person)-[e1:studyAt]->(b:organisation), (a)-[e2:workAt]->(b) RETURN a.ID, "
         "b.ID, e1._id, e2._id");

--- a/test/test_files/tinySNB/projection/projection.test
+++ b/test/test_files/tinySNB/projection/projection.test
@@ -341,3 +341,10 @@ Dan|Carol
 17
 18
 19
+
+-NAME QueryOneToOneRelTable
+-QUERY MATCH (:person)-[m:marries]->(:person) RETURN m.usedAddress, m.note
+---- 3
+[toronto]|
+|long long long string
+[vancouver]|short str


### PR DESCRIPTION
This PR solves issue #839 
1. Instead of keeping `vector<unique_ptr<InMemOverflowFile>>` for columns and lists separately,
```
 vector<unique_ptr<InMemOverflowFile>> propertyColumnsOverflowFiles;
  vector<unique_ptr<InMemOverflowFile>> propertyListsOverflowFiles;
```
we use a single map that maps the `propertyID` to `inMemOverflowFile`
    `unordered_map<uint32_t, unique_ptr<InMemOverflowFile>> overflowFilePerPropertyID;`
2. Fixes the listColumn bug in one-to-one relTable