### PR TITLE
Hash index with transaction

### DIFF
--- a/src/main/include/database.h
+++ b/src/main/include/database.h
@@ -121,7 +121,7 @@ public:
                 catalog->writeCatalogForWALRecord(databaseConfig.databasePath);
             }
         }
-        storageManager->prepareListsToCommitOrRollbackIfNecessary(isCommit);
+        storageManager->prepareCommitOrRollbackIfNecessary(isCommit);
 
         if (isCommit) {
             // Note: It is enough to stop and wait transactions to leave the system instead of

--- a/src/storage/include/storage_manager.h
+++ b/src/storage/include/storage_manager.h
@@ -24,9 +24,9 @@ public:
     inline RelsStore& getRelsStore() const { return *relsStore; }
     inline NodesStore& getNodesStore() const { return *nodesStore; }
     inline Catalog* getCatalog() { return &catalog; }
-    void prepareListsToCommitOrRollbackIfNecessary(bool isCommit) {
-        nodesStore->prepareUnstructuredPropertyListsToCommitOrRollbackIfNecessary(isCommit);
-        relsStore->prepareAdjAndRelPropertyListsToCommitOrRollbackIfNecessary(isCommit);
+    inline void prepareCommitOrRollbackIfNecessary(bool isCommit) {
+        nodesStore->prepareCommitOrRollbackIfNecessary(isCommit);
+        relsStore->prepareCommitOrRollbackIfNecessary(isCommit);
     }
     inline string getDirectory() const { return wal->getDirectory(); }
     inline WAL* getWAL() const { return wal; }

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -44,20 +44,22 @@ bool HashIndexLocalStorage::insert(const uint8_t* key, node_offset_t value) {
 
 HashIndex::HashIndex(const StorageStructureIDAndFName& storageStructureIDAndFName,
     const DataType& keyDataType, BufferManager& bufferManager, WAL* wal)
-    : BaseHashIndex{keyDataType}, bm{bufferManager} {
+    : BaseHashIndex{keyDataType},
+      storageStructureIDAndFName{storageStructureIDAndFName}, bm{bufferManager}, wal{wal} {
     assert(keyDataType.typeID == INT64);
     fileHandle = make_unique<VersionedFileHandle>(
         storageStructureIDAndFName, FileHandle::O_PERSISTENT_FILE_NO_CREATE);
     headerArray = make_unique<InMemDiskArray<HashIndexHeader>>(
         *fileHandle, INDEX_HEADER_ARRAY_HEADER_PAGE_IDX, &bm, wal);
     // Read indexHeader from the headerArray, which contains only one element.
-    indexHeader = make_unique<HashIndexHeader>(headerArray->get(0));
+    indexHeader =
+        make_unique<HashIndexHeader>(headerArray->get(INDEX_HEADER_IDX_IN_ARRAY, READ_ONLY));
     assert(indexHeader->keyDataTypeID == keyDataType.typeID);
     pSlots = make_unique<InMemDiskArray<Slot>>(*fileHandle, P_SLOTS_HEADER_PAGE_IDX, &bm, wal);
     oSlots = make_unique<InMemDiskArray<Slot>>(*fileHandle, O_SLOTS_HEADER_PAGE_IDX, &bm, wal);
-    pSlotsMutexes.resize(pSlots->getNumElements());
     // Initialize functions.
     keyHashFunc = HashIndexUtils::initializeHashFunc(indexHeader->keyDataTypeID);
+    keyInsertFunc = HashIndexUtils::initializeInsertFunc(indexHeader->keyDataTypeID);
     keyEqualsFunc = HashIndexUtils::initializeEqualsFunc(indexHeader->keyDataTypeID);
     localStorage = make_unique<HashIndexLocalStorage>(keyDataType);
 }
@@ -72,7 +74,7 @@ bool HashIndex::lookupInternal(
     Transaction* transaction, const uint8_t* key, node_offset_t& result) {
     assert(localStorage && transaction);
     if (transaction->isReadOnly()) {
-        return lookupInPersistentIndex(key, result);
+        return lookupInPersistentIndex(transaction->getType(), key, result);
     } else {
         assert(transaction->isWriteTransaction());
         auto localLookupState = localStorage->lookup(key, result);
@@ -82,14 +84,14 @@ bool HashIndex::lookupInternal(
             return false;
         } else {
             assert(localLookupState == HashIndexLocalLookupState::KEY_NOT_EXIST);
-            return lookupInPersistentIndex(key, result);
+            return lookupInPersistentIndex(transaction->getType(), key, result);
         }
     }
 }
 
 // For deletions, we don't check if the deleted keys exist or not. Thus, we don't need to check in
 // the persistent storage and directly delete keys in the local storage.
-void HashIndex::deleteInternal(Transaction* transaction, const uint8_t* key) {
+void HashIndex::deleteInternal(Transaction* transaction, const uint8_t* key) const {
     assert(localStorage && transaction && transaction->isWriteTransaction());
     localStorage->deleteKey(key);
 }
@@ -106,41 +108,223 @@ bool HashIndex::insertInternal(Transaction* transaction, const uint8_t* key, nod
     if (localLookupState == HashIndexLocalLookupState::KEY_FOUND) {
         return false;
     } else if (localLookupState == HashIndexLocalLookupState::KEY_NOT_EXIST) {
-        if (lookupInPersistentIndex(key, tmpResult)) {
+        if (lookupInPersistentIndex(transaction->getType(), key, tmpResult)) {
             return false;
         }
     }
     return localStorage->insert(key, value);
 }
 
-bool HashIndex::lookupInPersistentIndex(const uint8_t* key, node_offset_t& result) {
-    SlotInfo pSlotInfo{getPrimarySlotIdForKey(key), true};
-    SlotInfo currentSlotInfo = pSlotInfo;
-    Slot* currentSlot;
-    while (currentSlotInfo.isPSlot || currentSlotInfo.slotId > 0) {
-        currentSlot = getSlot(currentSlotInfo);
-        if (lookupInSlot(currentSlot, key, result)) {
-            return true;
+template<ChainedSlotsAction action>
+bool HashIndex::performActionInChainedSlots(TransactionType trxType, HashIndexHeader& header,
+    SlotInfo& slotInfo, const uint8_t* key, node_offset_t& result) {
+    while (slotInfo.slotType == SlotType::PRIMARY || slotInfo.slotId != 0) {
+        auto slot = getSlot(trxType, slotInfo);
+        if constexpr (action == ChainedSlotsAction::FIND_FREE_SLOT) {
+            if (slot.header.numEntries < HashIndexConfig::SLOT_CAPACITY ||
+                slot.header.nextOvfSlotId == 0) {
+                // Found a slot with empty space.
+                break;
+            }
+        } else {
+            auto entryPos = findMatchedEntryInSlot(slot, key);
+            if (entryPos != SlotHeader::INVALID_ENTRY_POS) {
+                if constexpr (action == ChainedSlotsAction::LOOKUP_IN_SLOTS) {
+                    result = *(node_offset_t*)(slot.entries[entryPos].data +
+                                               Types::getDataTypeSize(indexHeader->keyDataTypeID));
+                } else if constexpr (action == ChainedSlotsAction::DELETE_IN_SLOTS) {
+                    slot.header.setEntryInvalid(entryPos);
+                    slot.header.numEntries--;
+                    updateSlot(slotInfo, slot);
+                    header.numEntries--;
+                }
+                return true;
+            }
         }
-        currentSlotInfo.slotId = reinterpret_cast<SlotHeader*>(currentSlot)->nextOvfSlotId;
-        currentSlotInfo.isPSlot = false;
+        slotInfo.slotId = slot.header.nextOvfSlotId;
+        slotInfo.slotType = SlotType::OVF;
     }
     return false;
 }
 
-bool HashIndex::lookupInSlot(Slot* slot, const uint8_t* key, node_offset_t& result) const {
-    for (auto entryPos = 0u; entryPos < HashIndexConfig::SLOT_CAPACITY; entryPos++) {
-        if (!slot->header.isEntryValid(entryPos)) {
-            continue;
+bool HashIndex::lookupInPersistentIndex(
+    TransactionType trxType, const uint8_t* key, node_offset_t& result) {
+    auto header = trxType == TransactionType::READ_ONLY ?
+                      *indexHeader :
+                      headerArray->get(INDEX_HEADER_IDX_IN_ARRAY, TransactionType::WRITE);
+    SlotInfo slotInfo{getPrimarySlotIdForKey(header, key), SlotType::PRIMARY};
+    return performActionInChainedSlots<ChainedSlotsAction::LOOKUP_IN_SLOTS>(
+        trxType, header, slotInfo, key, result);
+}
+
+void HashIndex::insertIntoPersistentIndex(const uint8_t* key, node_offset_t value) {
+    auto header = headerArray->get(INDEX_HEADER_IDX_IN_ARRAY, TransactionType::WRITE);
+    slot_id_t numRequiredEntries = getNumRequiredEntries(header.numEntries, 1);
+    while (numRequiredEntries >
+           pSlots->getNumElements(TransactionType::WRITE) * HashIndexConfig::SLOT_CAPACITY) {
+        splitSlot(header);
+    }
+    auto pSlotId = getPrimarySlotIdForKey(header, key);
+    SlotInfo slotInfo{pSlotId, SlotType::PRIMARY};
+    node_offset_t result;
+    performActionInChainedSlots<ChainedSlotsAction::FIND_FREE_SLOT>(
+        TransactionType::WRITE, header, slotInfo, key, result);
+    Slot slot = getSlot(TransactionType::WRITE, slotInfo);
+    copyKVOrEntryToSlot(false /* insert kv */, slotInfo, slot, key, value);
+    header.numEntries++;
+    headerArray->update(INDEX_HEADER_IDX_IN_ARRAY, header);
+}
+
+void HashIndex::deleteFromPersistentIndex(const uint8_t* key) {
+    auto header = headerArray->get(INDEX_HEADER_IDX_IN_ARRAY, TransactionType::WRITE);
+    SlotInfo slotInfo{getPrimarySlotIdForKey(header, key), SlotType::PRIMARY};
+    node_offset_t result;
+    performActionInChainedSlots<ChainedSlotsAction::DELETE_IN_SLOTS>(
+        TransactionType::WRITE, header, slotInfo, key, result);
+    headerArray->update(INDEX_HEADER_IDX_IN_ARRAY, header);
+}
+
+void HashIndex::loopChainedSlotsToFindOneWithFreeSpace(SlotInfo& slotInfo, Slot& slot) {
+    while (slotInfo.slotType == SlotType::PRIMARY || slotInfo.slotId > 0) {
+        slot = getSlot(TransactionType::WRITE, slotInfo);
+        if (slot.header.numEntries < HashIndexConfig::SLOT_CAPACITY ||
+            slot.header.nextOvfSlotId == 0) {
+            // Found a slot with empty space.
+            break;
         }
-        auto entry = slot->entries[entryPos].data;
-        if (keyEqualsFunc(key, entry, diskOverflowFile.get())) {
-            memcpy(&result, entry + Types::getDataTypeSize(indexHeader->keyDataTypeID),
-                sizeof(node_offset_t));
-            return true;
+        slotInfo.slotId = slot.header.nextOvfSlotId;
+        slotInfo.slotType = SlotType::OVF;
+    }
+}
+
+void HashIndex::splitSlot(HashIndexHeader& header) {
+    pSlots->pushBack(Slot{});
+    rehashSlots(header);
+    header.incrementNextSplitSlotId();
+}
+
+void HashIndex::rehashSlots(HashIndexHeader& header) {
+    auto slotsToSplit = getChainedSlots(header.nextSplitSlotId);
+    for (auto& [slotInfo, slot] : slotsToSplit) {
+        auto slotHeader = slot.header;
+        slot.header.reset();
+        updateSlot(slotInfo, slot);
+        for (auto entryPos = 0u; entryPos < HashIndexConfig::SLOT_CAPACITY; entryPos++) {
+            if (!slotHeader.isEntryValid(entryPos)) {
+                continue; // Skip invalid entries.
+            }
+            auto key = slot.entries[entryPos].data;
+            auto newSlotId = keyHashFunc(key) & header.higherLevelHashMask;
+            copyEntryToSlot(newSlotId, key);
         }
     }
-    return false;
+}
+
+void HashIndex::copyEntryToSlot(slot_id_t slotId, uint8_t* entry) {
+    SlotInfo slotInfo{slotId, SlotType::PRIMARY};
+    Slot slot;
+    loopChainedSlotsToFindOneWithFreeSpace(slotInfo, slot);
+    copyKVOrEntryToSlot(true /* copy entry */, slotInfo, slot, entry, UINT32_MAX);
+    updateSlot(slotInfo, slot);
+}
+
+vector<pair<SlotInfo, Slot>> HashIndex::getChainedSlots(slot_id_t pSlotId) {
+    vector<pair<SlotInfo, Slot>> slots;
+    SlotInfo slotInfo{pSlotId, SlotType::PRIMARY};
+    while (slotInfo.slotType == SlotType::PRIMARY || slotInfo.slotId != 0) {
+        auto slot = getSlot(TransactionType::WRITE, slotInfo);
+        slots.emplace_back(slotInfo, slot);
+        slotInfo.slotId = slot.header.nextOvfSlotId;
+        slotInfo.slotType = SlotType::OVF;
+    }
+    return slots;
+}
+
+void HashIndex::copyAndUpdateSlotHeader(
+    bool isCopyEntry, Slot& slot, entry_pos_t entryPos, const uint8_t* key, node_offset_t value) {
+    if (isCopyEntry) {
+        memcpy(slot.entries[entryPos].data, key, indexHeader->numBytesPerEntry);
+    } else {
+        keyInsertFunc(key, value, slot.entries[entryPos].data, diskOverflowFile.get());
+    }
+    slot.header.setEntryValid(entryPos);
+    slot.header.numEntries++;
+}
+
+void HashIndex::copyKVOrEntryToSlot(bool isCopyEntry, const SlotInfo& slotInfo, Slot& slot,
+    const uint8_t* key, node_offset_t value) {
+    if (slot.header.numEntries == HashIndexConfig::SLOT_CAPACITY) {
+        // Allocate a new oSlot, insert the entry to the new oSlot, and update slot's nextOvfSlotId.
+        Slot newSlot;
+        auto entryPos = 0u; // Always insert to the first entry when there is a new slot.
+        copyAndUpdateSlotHeader(isCopyEntry, newSlot, entryPos, key, value);
+        slot.header.nextOvfSlotId = oSlots->pushBack(newSlot);
+    } else {
+        for (auto entryPos = 0u; entryPos < HashIndexConfig::SLOT_CAPACITY; entryPos++) {
+            if (!slot.header.isEntryValid(entryPos)) {
+                copyAndUpdateSlotHeader(isCopyEntry, slot, entryPos, key, value);
+                break;
+            }
+        }
+    }
+    updateSlot(slotInfo, slot);
+}
+
+entry_pos_t HashIndex::findMatchedEntryInSlot(const Slot& slot, const uint8_t* key) const {
+    for (auto entryPos = 0u; entryPos < HashIndexConfig::SLOT_CAPACITY; entryPos++) {
+        if (!slot.header.isEntryValid(entryPos)) {
+            continue;
+        }
+        if (keyEqualsFunc(key, slot.entries[entryPos].data, diskOverflowFile.get())) {
+            return entryPos;
+        }
+    }
+    return SlotHeader::INVALID_ENTRY_POS;
+}
+
+void HashIndex::prepareCommit() {
+    for (auto& [key, val] : localStorage->localDeletions) {
+        deleteFromPersistentIndex((uint8_t*)&key);
+    }
+    for (auto& [key, val] : localStorage->localInsertions) {
+        insertIntoPersistentIndex((uint8_t*)&key, val);
+    }
+}
+
+void HashIndex::prepareRollback() {
+    indexHeader = make_unique<HashIndexHeader>(
+        headerArray->get(INDEX_HEADER_ARRAY_HEADER_PAGE_IDX, TransactionType::READ_ONLY));
+}
+
+void HashIndex::prepareCommitOrRollbackIfNecessary(bool isCommit) {
+    unique_lock xlock{localStorage->localStorageSharedMutex};
+    if (!localStorage->hasUpdates()) {
+        return;
+    }
+    wal->addToUpdatedNodeTables(storageStructureIDAndFName.storageStructureID.nodeIndexID.tableID);
+    isCommit ? prepareCommit() : prepareRollback();
+}
+
+void HashIndex::checkpointInMemoryIfNecessary() {
+    if (!localStorage->hasUpdates()) {
+        return;
+    }
+    indexHeader = make_unique<HashIndexHeader>(
+        headerArray->get(INDEX_HEADER_IDX_IN_ARRAY, TransactionType::WRITE));
+    headerArray->checkpointInMemoryIfNecessary();
+    pSlots->checkpointInMemoryIfNecessary();
+    oSlots->checkpointInMemoryIfNecessary();
+    localStorage->clear();
+}
+
+void HashIndex::rollbackInMemoryIfNecessary() const {
+    if (!localStorage->hasUpdates()) {
+        return;
+    }
+    headerArray->rollbackInMemoryIfNecessary();
+    pSlots->rollbackInMemoryIfNecessary();
+    oSlots->rollbackInMemoryIfNecessary();
+    localStorage->clear();
 }
 
 } // namespace storage

--- a/src/storage/index/hash_index_utils.cpp
+++ b/src/storage/index/hash_index_utils.cpp
@@ -3,15 +3,18 @@
 namespace graphflow {
 namespace storage {
 
-in_mem_insert_function_t InMemHashIndexUtils::initializeInsertFunc(const DataTypeID& dataTypeID) {
+in_mem_insert_function_t InMemHashIndexUtils::initializeInsertFunc(DataTypeID dataTypeID) {
     switch (dataTypeID) {
-    case INT64:
+    case INT64: {
         return insertFuncForInt64;
-    case STRING:
+    }
+    case STRING: {
         return insertFuncForString;
-    default:
+    }
+    default: {
         throw StorageException(
             "Hash index insertion not defined for dataType other than INT64 and STRING.");
+    }
     }
 }
 
@@ -40,7 +43,7 @@ bool InMemHashIndexUtils::equalsFuncForString(const uint8_t* keyToLookup, const 
     }
 }
 
-in_mem_equals_function_t InMemHashIndexUtils::initializeEqualsFunc(const DataTypeID& dataTypeID) {
+in_mem_equals_function_t InMemHashIndexUtils::initializeEqualsFunc(DataTypeID dataTypeID) {
     switch (dataTypeID) {
     case INT64: {
         return equalsFuncForInt64;
@@ -55,14 +58,31 @@ in_mem_equals_function_t InMemHashIndexUtils::initializeEqualsFunc(const DataTyp
     }
 }
 
-hash_function_t HashIndexUtils::initializeHashFunc(const DataTypeID& dataTypeID) {
+insert_function_t HashIndexUtils::initializeInsertFunc(DataTypeID dataTypeID) {
     switch (dataTypeID) {
-    case INT64:
-        return hashFuncForInt64;
-    case STRING:
-        return hashFuncForString;
-    default:
+    case INT64: {
+        return insertFuncForInt64;
+    }
+    case STRING: {
+        return insertFuncForString;
+    }
+    default: {
         throw StorageException("Type " + Types::dataTypeToString(dataTypeID) + " not supported.");
+    }
+    }
+}
+
+hash_function_t HashIndexUtils::initializeHashFunc(DataTypeID dataTypeID) {
+    switch (dataTypeID) {
+    case INT64: {
+        return hashFuncForInt64;
+    }
+    case STRING: {
+        return hashFuncForString;
+    }
+    default: {
+        throw StorageException("Type " + Types::dataTypeToString(dataTypeID) + " not supported.");
+    }
     }
 }
 
@@ -84,15 +104,18 @@ bool HashIndexUtils::equalsFuncForString(
     return false;
 }
 
-equals_function_t HashIndexUtils::initializeEqualsFunc(const DataTypeID& dataTypeID) {
+equals_function_t HashIndexUtils::initializeEqualsFunc(DataTypeID dataTypeID) {
     switch (dataTypeID) {
-    case INT64:
+    case INT64: {
         return equalsFuncForInt64;
-    case STRING:
+    }
+    case STRING: {
         return equalsFuncForString;
-    default:
+    }
+    default: {
         throw StorageException(
             "Hash index equals is not supported for dataType other than INT64 and STRING.");
+    }
     }
 }
 

--- a/src/storage/index/include/hash_index_header.h
+++ b/src/storage/index/include/hash_index_header.h
@@ -15,12 +15,21 @@ public:
         levelHashMask = (1 << currentLevel) - 1;
         higherLevelHashMask = (1 << (currentLevel + 1)) - 1;
     }
+    inline void incrementNextSplitSlotId() {
+        if (nextSplitSlotId < (1ull << currentLevel) - 1) {
+            nextSplitSlotId++;
+        } else {
+            incrementLevel();
+        }
+    }
 
 public:
-    uint64_t currentLevel{0};
-    uint64_t levelHashMask{0};
-    uint64_t higherLevelHashMask{1};
+    uint64_t currentLevel{1};
+    uint64_t levelHashMask{1};
+    uint64_t higherLevelHashMask{3};
     slot_id_t nextSplitSlotId{0};
+    uint64_t numEntries{0};
+    uint32_t numBytesPerEntry{sizeof(int64_t) + sizeof(common::node_offset_t)};
     common::DataTypeID keyDataTypeID{common::INT64};
 };
 

--- a/src/storage/index/include/hash_index_slot.h
+++ b/src/storage/index/include/hash_index_slot.h
@@ -13,6 +13,8 @@ using slot_id_t = uint64_t;
 
 class SlotHeader {
 public:
+    static const entry_pos_t INVALID_ENTRY_POS = UINT8_MAX;
+
     SlotHeader() : numEntries{0}, validityMask{0}, nextOvfSlotId{0} {}
 
     void reset() {
@@ -25,6 +27,9 @@ public:
         return validityMask & ((uint32_t)1 << entryPos);
     }
     inline void setEntryValid(entry_pos_t entryPos) { validityMask |= ((uint32_t)1 << entryPos); }
+    inline void setEntryInvalid(entry_pos_t entryPos) {
+        validityMask &= ~((uint32_t)1 << entryPos);
+    }
 
 public:
     entry_pos_t numEntries;

--- a/src/storage/storage_structure/include/storage_structure_utils.h
+++ b/src/storage/storage_structure/include/storage_structure_utils.h
@@ -59,14 +59,14 @@ public:
         WAL& wal);
 
     static void readWALVersionOfPage(VersionedFileHandle& fileHandle, page_idx_t originalPageIdx,
-        BufferManager& bufferManager, WAL& wal, std::function<void(uint8_t*)> readOp);
+        BufferManager& bufferManager, WAL& wal, const std::function<void(uint8_t*)>& readOp);
 
     // Note: This function updates a page "transactionally", i.e., creates the WAL version of the
     // page if it doesn't exist. For the original page to be updated, the current WRITE trx needs to
     // commit and checkpoint.
     static void updatePage(VersionedFileHandle& fileHandle, page_idx_t originalPageIdx,
         bool isInsertingNewPage, BufferManager& bufferManager, WAL& wal,
-        std::function<void(uint8_t*)> updateOp);
+        const std::function<void(uint8_t*)>& updateOp);
 
     // Unpins the WAL version of a page that was updated and releases the lock of the page (recall
     // we use the same lock to do operations on both the original and WAL versions of the page).

--- a/src/storage/storage_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists.cpp
@@ -64,9 +64,8 @@ void UnstructuredPropertyLists::prepareCommitOrRollbackIfNecessary(bool isCommit
     // database class calls
     // nodesStore->prepareUnstructuredPropertyListsToCommitOrRollbackIfNecessary, which blindly
     // calls each Lists to check if they have something to commit or rollback.
-    wal->addToUpdatedUnstructuredPropertyLists(
-        storageStructureIDAndFName.storageStructureID.listFileID.unstructuredNodePropertyListsID
-            .tableID);
+    wal->addToUpdatedNodeTables(storageStructureIDAndFName.storageStructureID.listFileID
+                                    .unstructuredNodePropertyListsID.tableID);
     Lists::prepareCommitOrRollbackIfNecessary(isCommit);
 }
 

--- a/src/storage/storage_structure/storage_structure_utils.cpp
+++ b/src/storage/storage_structure/storage_structure_utils.cpp
@@ -15,7 +15,7 @@ pair<FileHandle*, page_idx_t> StorageStructureUtils::getFileHandleAndPhysicalPag
 
 void StorageStructureUtils::updatePage(VersionedFileHandle& fileHandle, page_idx_t originalPageIdx,
     bool isInsertingNewPage, BufferManager& bufferManager, WAL& wal,
-    std::function<void(uint8_t*)> updateOp) {
+    const std::function<void(uint8_t*)>& updateOp) {
     auto walPageIdxAndFrame = StorageStructureUtils::createWALVersionIfNecessaryAndPinPage(
         originalPageIdx, isInsertingNewPage, fileHandle, bufferManager, wal);
     updateOp(walPageIdxAndFrame.frame);
@@ -24,7 +24,7 @@ void StorageStructureUtils::updatePage(VersionedFileHandle& fileHandle, page_idx
 
 void StorageStructureUtils::readWALVersionOfPage(VersionedFileHandle& fileHandle,
     page_idx_t originalPageIdx, BufferManager& bufferManager, WAL& wal,
-    std::function<void(uint8_t*)> readOp) {
+    const std::function<void(uint8_t*)>& readOp) {
     page_idx_t pageIdxInWAL = fileHandle.getWALPageVersionNoPageLock(originalPageIdx);
     auto frame = bufferManager.pinWithoutAcquiringPageLock(
         *wal.fileHandle, pageIdxInWAL, false /* read from file */);

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -14,9 +14,9 @@ unique_ptr<FileInfo> StorageUtils::getFileInfoForReadWrite(
         fName = getListFName(directory, storageStructureID);
     } break;
     case NODE_INDEX: {
-        throw RuntimeException("There should not be any code path yet triggering getting "
-                               "NODE_INDEX file name from StorageStructureID.");
-    }
+        fName = getNodeIndexFName(
+            directory, storageStructureID.nodeIndexID.tableID, DBFileType::ORIGINAL);
+    } break;
     default: {
         throw RuntimeException("Unsupported StorageStructureID in "
                                "StorageUtils::getFileInfoFromStorageStructureID.");

--- a/src/storage/store/include/node_table.h
+++ b/src/storage/store/include/node_table.h
@@ -40,6 +40,17 @@ public:
     node_offset_t addNode();
     void deleteNodes(ValueVector* nodeIDVector, ValueVector* primaryKeyVector);
 
+    void prepareCommitOrRollbackIfNecessary(bool isCommit);
+
+    inline void checkpointInMemoryIfNecessary() {
+        unstrPropertyLists->checkpointInMemoryIfNecessary();
+        IDIndex->checkpointInMemoryIfNecessary();
+    }
+    inline void rollbackInMemoryIfNecessary() {
+        unstrPropertyLists->rollbackInMemoryIfNecessary();
+        IDIndex->rollbackInMemoryIfNecessary();
+    }
+
 private:
     void deleteNode(ValueVector* nodeIDVector, ValueVector* primaryKeyVector, uint32_t pos) const;
 
@@ -56,6 +67,7 @@ private:
     unique_ptr<HashIndex> IDIndex;
     table_id_t tableID;
     bool isInMemory;
+    WAL* wal;
 };
 
 } // namespace storage

--- a/src/storage/store/include/nodes_store.h
+++ b/src/storage/store/include/nodes_store.h
@@ -47,9 +47,9 @@ public:
         nodesStatisticsAndDeletedIDs.removeTableStatistic(tableID);
     }
 
-    void prepareUnstructuredPropertyListsToCommitOrRollbackIfNecessary(bool isCommit) {
-        for (auto& nodeTable : nodeTables) {
-            nodeTable.second->getUnstrPropertyLists()->prepareCommitOrRollbackIfNecessary(isCommit);
+    inline void prepareCommitOrRollbackIfNecessary(bool isCommit) {
+        for (auto& [_, nodeTable] : nodeTables) {
+            nodeTable->prepareCommitOrRollbackIfNecessary(isCommit);
         }
     }
 

--- a/src/storage/store/include/rels_store.h
+++ b/src/storage/store/include/rels_store.h
@@ -63,9 +63,9 @@ public:
         relTables.erase(tableID);
         relsStatistics.removeTableStatistic(tableID);
     }
-    void prepareAdjAndRelPropertyListsToCommitOrRollbackIfNecessary(bool isCommit) {
-        for (auto& relTable : relTables) {
-            relTable.second->prepareCommitOrRollbackIfNecessary(isCommit);
+    void prepareCommitOrRollbackIfNecessary(bool isCommit) {
+        for (auto& [_, relTable] : relTables) {
+            relTable->prepareCommitOrRollbackIfNecessary(isCommit);
         }
     }
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -6,7 +6,7 @@ namespace storage {
 NodeTable::NodeTable(NodesStatisticsAndDeletedIDs* nodesStatisticsAndDeletedIDs,
     BufferManager& bufferManager, bool isInMemory, WAL* wal, NodeTableSchema* nodeTableSchema)
     : nodesStatisticsAndDeletedIDs{nodesStatisticsAndDeletedIDs}, tableID{nodeTableSchema->tableID},
-      isInMemory{isInMemory} {
+      isInMemory{isInMemory}, wal{wal} {
     loadColumnsAndListsFromDisk(nodeTableSchema, bufferManager, wal);
 }
 
@@ -59,6 +59,11 @@ void NodeTable::deleteNode(
     auto nodeOffset = nodeIDVector->readNodeOffset(pos);
     nodesStatisticsAndDeletedIDs->deleteNode(tableID, nodeOffset);
     // TODO(Guodong): delete primary key index
+}
+
+void NodeTable::prepareCommitOrRollbackIfNecessary(bool isCommit) {
+    unstrPropertyLists->prepareCommitOrRollbackIfNecessary(isCommit);
+    IDIndex->prepareCommitOrRollbackIfNecessary(isCommit);
 }
 
 } // namespace storage

--- a/src/storage/wal/include/wal.h
+++ b/src/storage/wal/include/wal.h
@@ -140,12 +140,12 @@ public:
 
     inline string getDirectory() const { return directory; }
 
-    inline void addToUpdatedUnstructuredPropertyLists(table_id_t nodeTableID) {
-        updatedUnstructuredPropertyLists.push_back(nodeTableID);
+    inline void addToUpdatedNodeTables(table_id_t nodeTableID) {
+        updatedNodeTables.insert(nodeTableID);
     }
 
     inline void addToUpdatedRelTables(table_id_t relTableID) {
-        updatedRelTables.push_back(relTableID);
+        updatedRelTables.insert(relTableID);
     }
 
 private:
@@ -160,11 +160,10 @@ private:
     void setIsLastRecordCommit();
 
 public:
-    // Ideally we need a pointer to unstructuredPropertyLists but instead we store the nodeTableID
-    // because unstructuredPropertyLists depends on WAL and making WAL depend on
-    // unstructuredPropertyLists would create a circular dependency.
-    vector<table_id_t> updatedUnstructuredPropertyLists;
-    vector<table_id_t> updatedRelTables;
+    // Node/Rel tables that might have changes to their in-memory data structures that need to be
+    // committed/rolled back accordingly during the wal replaying.
+    unordered_set<table_id_t> updatedNodeTables;
+    unordered_set<table_id_t> updatedRelTables;
 
 private:
     shared_ptr<spdlog::logger> logger;

--- a/src/storage/wal/include/wal_record.h
+++ b/src/storage/wal/include/wal_record.h
@@ -45,7 +45,7 @@ struct UnstructuredNodePropertyListsID {
     table_id_t tableID;
     UnstructuredNodePropertyListsID() = default;
 
-    UnstructuredNodePropertyListsID(table_id_t tableID) : tableID{tableID} {}
+    explicit UnstructuredNodePropertyListsID(table_id_t tableID) : tableID{tableID} {}
 
     inline bool operator==(const UnstructuredNodePropertyListsID& rhs) const {
         return tableID == rhs.tableID;
@@ -57,7 +57,8 @@ struct AdjListsID {
 
     AdjListsID() = default;
 
-    AdjListsID(RelNodeTableAndDir relNodeTableAndDir) : relNodeTableAndDir{relNodeTableAndDir} {}
+    explicit AdjListsID(RelNodeTableAndDir relNodeTableAndDir)
+        : relNodeTableAndDir{relNodeTableAndDir} {}
 
     inline bool operator==(const AdjListsID& rhs) const {
         return relNodeTableAndDir == rhs.relNodeTableAndDir;
@@ -138,7 +139,8 @@ struct AdjColumnID {
 
     AdjColumnID() = default;
 
-    AdjColumnID(RelNodeTableAndDir relNodeTableAndDir) : relNodeTableAndDir{relNodeTableAndDir} {}
+    explicit AdjColumnID(RelNodeTableAndDir relNodeTableAndDir)
+        : relNodeTableAndDir{relNodeTableAndDir} {}
 
     inline bool operator==(const AdjColumnID& rhs) const {
         return relNodeTableAndDir == rhs.relNodeTableAndDir;
@@ -205,7 +207,7 @@ struct NodeIndexID {
 
     NodeIndexID() = default;
 
-    NodeIndexID(table_id_t tableID) : tableID{tableID} {}
+    explicit NodeIndexID(table_id_t tableID) : tableID{tableID} {}
 
     inline bool operator==(const NodeIndexID& rhs) const { return tableID == rhs.tableID; }
 };
@@ -310,7 +312,7 @@ struct CommitRecord {
 
     CommitRecord() = default;
 
-    CommitRecord(uint64_t transactionID) : transactionID{transactionID} {}
+    explicit CommitRecord(uint64_t transactionID) : transactionID{transactionID} {}
 
     inline bool operator==(const CommitRecord& rhs) const {
         return transactionID == rhs.transactionID;
@@ -322,7 +324,7 @@ struct NodeTableRecord {
 
     NodeTableRecord() = default;
 
-    NodeTableRecord(table_id_t tableID) : tableID{tableID} {}
+    explicit NodeTableRecord(table_id_t tableID) : tableID{tableID} {}
 
     inline bool operator==(const NodeTableRecord& rhs) const { return tableID == rhs.tableID; }
 };
@@ -332,7 +334,7 @@ struct RelTableRecord {
 
     RelTableRecord() = default;
 
-    RelTableRecord(table_id_t tableID) : tableID{tableID} {}
+    explicit RelTableRecord(table_id_t tableID) : tableID{tableID} {}
 
     inline bool operator==(const RelTableRecord& rhs) const { return tableID == rhs.tableID; }
 };
@@ -358,7 +360,7 @@ struct CopyNodeCSVRecord {
 
     CopyNodeCSVRecord() = default;
 
-    CopyNodeCSVRecord(table_id_t tableID) : tableID{tableID} {}
+    explicit CopyNodeCSVRecord(table_id_t tableID) : tableID{tableID} {}
 
     inline bool operator==(const CopyNodeCSVRecord& rhs) const { return tableID == rhs.tableID; }
 };
@@ -368,7 +370,7 @@ struct CopyRelCSVRecord {
 
     CopyRelCSVRecord() = default;
 
-    CopyRelCSVRecord(table_id_t tableID) : tableID{tableID} {}
+    explicit CopyRelCSVRecord(table_id_t tableID) : tableID{tableID} {}
 
     inline bool operator==(const CopyRelCSVRecord& rhs) const { return tableID == rhs.tableID; }
 };
@@ -378,7 +380,7 @@ struct TableStatisticsRecord {
 
     TableStatisticsRecord() = default;
 
-    TableStatisticsRecord(bool isNodeTable) : isNodeTable{isNodeTable} {}
+    explicit TableStatisticsRecord(bool isNodeTable) : isNodeTable{isNodeTable} {}
 
     inline bool operator==(const TableStatisticsRecord& rhs) const {
         return isNodeTable == rhs.isNodeTable;

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -96,7 +96,7 @@ void WAL::clearWAL() {
     fileHandle->resetToZeroPagesAndPageCapacity();
     initCurrentPage();
     StorageUtils::removeAllWALFiles(directory);
-    updatedUnstructuredPropertyLists.clear();
+    updatedNodeTables.clear();
     updatedRelTables.clear();
 }
 

--- a/test/storage/hash_index_test.cpp
+++ b/test/storage/hash_index_test.cpp
@@ -1,312 +1,279 @@
-#include <random>
-
 #include "gtest/gtest.h"
-#include "spdlog/spdlog.h"
+#include "test/test_utility/include/test_helper.h"
 
 #include "src/common/include/csv_reader/csv_reader.h"
-#include "src/common/include/utils.h"
 #include "src/storage/index/include/hash_index.h"
 
 using namespace graphflow::common;
 using namespace graphflow::storage;
+using namespace graphflow::testing;
 
-class HashIndexTest : public testing::Test {
+// TODO(Guodong): Add the support of string keys .
 
+class HashIndexTest : public DBTest {
 public:
-    HashIndexTest()
-        : storageStructureIdAndFName{StorageUtils::getNodeIndexIDAndFName(
-              "" /* dummy directory */, 0 /* dummy node table */)} {
-        FileUtils::createDir(TEMP_INDEX_DIR);
-    }
+    static constexpr uint64_t NUM_KEYS_FROM_CSV = 10000;
 
-    void TearDown() override { FileUtils::removeDir(TEMP_INDEX_DIR); }
-
-public:
-    const string TEMP_INDEX_DIR = "test/temp_index/";
-    StorageStructureIDAndFName storageStructureIdAndFName;
-    uint64_t numKeysInsertedToFile = 5000;
-};
-
-class LoadedHashIndexInt64KeyTest : public HashIndexTest {
-
-public:
-    LoadedHashIndexInt64KeyTest() : HashIndexTest() {}
+    HashIndexTest() : IDIndex{nullptr} {}
 
     void SetUp() override {
-        HashIndexBuilder hashIndexBuilder(storageStructureIdAndFName.fName, DataType(INT64));
-        hashIndexBuilder.bulkReserve(numKeysInsertedToFile);
-        // Inserting(key = i, value = i * 2) pairs
-        for (int64_t k = 0; k < numKeysInsertedToFile; k++) {
-            hashIndexBuilder.append(k, k << 1);
-        }
-        hashIndexBuilder.flush();
+        DBTest::SetUp();
+        initDBAndConnection();
     }
 
-    void testLookupWithReadTransaction(HashIndex* hashIndex, Transaction* tmpReadTransaction) {
-        node_offset_t result;
-        for (auto i = 0u; i < numKeysInsertedToFile; i++) {
-            ASSERT_TRUE(hashIndex->lookup(tmpReadTransaction, i, result));
-            ASSERT_EQ(result, i << 1);
-        }
-        for (auto i = 0; i < 100; i++) {
-            uint64_t key = numKeysInsertedToFile + i;
-            ASSERT_FALSE(hashIndex->lookup(tmpReadTransaction, key, result));
+    string getInputCSVDir() override { return "dataset/node-insertion-deletion-tests/"; }
+
+    void initDBAndConnection() {
+        createDBAndConn();
+        readConn = make_unique<Connection>(database.get());
+        table_id_t personTableID =
+            database->getCatalog()->getReadOnlyVersion()->getNodeTableIDFromName("person");
+        IDIndex = database->getStorageManager()
+                      ->getNodesStore()
+                      .getNodeTable(personTableID)
+                      ->getIDIndex();
+    }
+
+    void commitOrRollbackConnectionAndInitDBIfNecessary(
+        bool isCommit, TransactionTestType transactionTestType) {
+        commitOrRollbackConnection(isCommit, transactionTestType);
+        if (transactionTestType == TransactionTestType::RECOVERY) {
+            // This creates a new database/conn/readConn and should run the recovery algorithm
+            initDBAndConnection();
+            conn->beginWriteTransaction();
         }
     }
 
-    void testLookupWithWriteTransaction(HashIndex* hashIndex, Transaction* tmpWriteTransaction) {
+    static void verifyAfterInsertions(
+        Transaction* trx, HashIndex* IDIndex, uint32_t numKeysToInsert, bool assertTrue) {
         node_offset_t result;
-        for (auto i = 0u; i < numKeysInsertedToFile; i++) {
-            if (i % 2 == 0) {
-                ASSERT_FALSE(hashIndex->lookup(tmpWriteTransaction, i, result));
-            } else {
-                ASSERT_TRUE(hashIndex->lookup(tmpWriteTransaction, i, result));
-                ASSERT_EQ(result, i << 1);
+        if (assertTrue) {
+            for (auto i = 0u; i < numKeysToInsert; i++) {
+                uint64_t key = NUM_KEYS_FROM_CSV + i;
+                ASSERT_TRUE(IDIndex->lookup(trx, key, result));
+                ASSERT_EQ(result, key << 1);
+            }
+        } else {
+            for (auto i = 0u; i < numKeysToInsert; i++) {
+                uint64_t key = NUM_KEYS_FROM_CSV + i;
+                ASSERT_FALSE(IDIndex->lookup(trx, key, result));
             }
         }
     }
+
+    void insertTest(bool isCommit, TransactionTestType transactionTestType) {
+        auto numKeysToInsert = 1000;
+        conn->beginWriteTransaction();
+        for (auto i = 0u; i < numKeysToInsert; i++) {
+            uint64_t key = NUM_KEYS_FROM_CSV + i;
+            ASSERT_TRUE(IDIndex->insert(conn->getActiveTransaction(), key, key << 1));
+        }
+        if (isCommit) {
+            // Lookup with read transaction before committing.
+            readConn->beginReadOnlyTransaction();
+            verifyAfterInsertions(readConn->getActiveTransaction(), IDIndex, numKeysToInsert,
+                false /* assert false*/);
+            readConn->commit();
+        } else {
+            // Lookup with write transaction before rolling back.
+            verifyAfterInsertions(
+                conn->getActiveTransaction(), IDIndex, numKeysToInsert, true /* assert true */);
+        }
+        commitOrRollbackConnectionAndInitDBIfNecessary(isCommit, transactionTestType);
+        // Lookup with read transaction.
+        readConn->beginReadOnlyTransaction();
+        if (isCommit) {
+            verifyAfterInsertions(
+                readConn->getActiveTransaction(), IDIndex, numKeysToInsert, true /* assert true */);
+            verifyAfterInsertions(
+                conn->getActiveTransaction(), IDIndex, numKeysToInsert, true /* assert true */);
+        } else {
+            verifyAfterInsertions(readConn->getActiveTransaction(), IDIndex, numKeysToInsert,
+                false /* assert false */);
+            verifyAfterInsertions(
+                conn->getActiveTransaction(), IDIndex, numKeysToInsert, false /* assert false */);
+        }
+        readConn->commit();
+        conn->commit();
+    }
+
+    static void verifyAfterDeletions(
+        Transaction* trx, HashIndex* IDIndex, uint32_t numKeys, bool assertTrue) {
+        node_offset_t result;
+        if (assertTrue) {
+            for (auto i = 0u; i < numKeys; i++) {
+                ASSERT_TRUE(IDIndex->lookup(trx, i, result));
+            }
+        } else {
+            for (auto i = 0u; i < numKeys; i++) {
+                if (i % 2 == 0) {
+                    ASSERT_FALSE(IDIndex->lookup(trx, i, result));
+                } else {
+                    ASSERT_TRUE(IDIndex->lookup(trx, i, result));
+                }
+            }
+        }
+    }
+
+    void deleteTest(bool isCommit, TransactionTestType transactionTestType) {
+        node_offset_t result;
+        conn->beginWriteTransaction();
+        for (auto i = 0u; i < NUM_KEYS_FROM_CSV; i++) {
+            if (i % 2 == 0) {
+                IDIndex->deleteKey(conn->getActiveTransaction(), i);
+            }
+        }
+        if (isCommit) {
+            // Lookup with read transaction before committing.
+            readConn->beginReadOnlyTransaction();
+            verifyAfterDeletions(readConn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV,
+                true /* assert true */);
+            readConn->commit();
+        } else {
+            // Lookup with write transaction before rolling back.
+            verifyAfterDeletions(
+                conn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV, false /* assert false */);
+        }
+        commitOrRollbackConnectionAndInitDBIfNecessary(isCommit, transactionTestType);
+        // Lookup with read transaction.
+        readConn->beginReadOnlyTransaction();
+        if (isCommit) {
+            verifyAfterDeletions(readConn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV,
+                false /* assert false */);
+            verifyAfterDeletions(
+                conn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV, false /* assert false */);
+        } else {
+            verifyAfterDeletions(readConn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV,
+                true /* assert true */);
+            verifyAfterDeletions(
+                conn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV, true /* assert true */);
+        }
+        readConn->commit();
+        conn->commit();
+    }
+
+    void mixedDeleteAndInsertTest(bool isCommit, TransactionTestType transactionTestType) {
+        auto numKeysToInsert = 1000;
+        conn->beginWriteTransaction();
+        for (auto i = 0u; i < numKeysToInsert; i++) {
+            uint64_t key = NUM_KEYS_FROM_CSV + i;
+            ASSERT_TRUE(IDIndex->insert(conn->getActiveTransaction(), key, key << 1));
+        }
+        for (auto i = 0u; i < (NUM_KEYS_FROM_CSV + numKeysToInsert); i++) {
+            if (i % 2 == 0) {
+                IDIndex->deleteKey(conn->getActiveTransaction(), i);
+            }
+        }
+        if (isCommit) {
+            // Lookup with read transaction before committing.
+            readConn->beginReadOnlyTransaction();
+            verifyAfterInsertions(readConn->getActiveTransaction(), IDIndex, numKeysToInsert,
+                false /* assert false */);
+            verifyAfterDeletions(readConn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV,
+                true /* assert true */);
+            readConn->commit();
+        } else {
+            // Lookup with write transaction before rolling back.
+            verifyAfterDeletions(conn->getActiveTransaction(), IDIndex,
+                (NUM_KEYS_FROM_CSV + numKeysToInsert), false /* assert false */);
+        }
+        commitOrRollbackConnectionAndInitDBIfNecessary(isCommit, transactionTestType);
+        // Lookup with read transaction.
+        readConn->beginReadOnlyTransaction();
+        if (isCommit) {
+            verifyAfterDeletions(readConn->getActiveTransaction(), IDIndex,
+                (NUM_KEYS_FROM_CSV + numKeysToInsert), false /* assert false */);
+            verifyAfterDeletions(conn->getActiveTransaction(), IDIndex,
+                (NUM_KEYS_FROM_CSV + numKeysToInsert), false /* assert false */);
+        } else {
+            verifyAfterDeletions(readConn->getActiveTransaction(), IDIndex, NUM_KEYS_FROM_CSV,
+                true /* assert true */);
+            verifyAfterInsertions(
+                conn->getActiveTransaction(), IDIndex, numKeysToInsert, false /* assert false */);
+        }
+        readConn->commit();
+        conn->commit();
+    }
+
+public:
+    unique_ptr<Connection> readConn;
+    HashIndex* IDIndex;
 };
 
-// TODO(Guodong): Add the support of string keys back to fix this.
-// class LoadedHashIndexStringKeyTest : public HashIndexTest {
-//
-// public:
-//    LoadedHashIndexStringKeyTest() : HashIndexTest() {}
-//
-//    void SetUp() override {
-//        storageStructureIdAndFName.fName = TEMP_INDEX_DIR + "dummy_strings.hindex";
-//        HashIndexBuilder hashIndexBuilder(storageStructureIdAndFName.fName, DataType(STRING));
-//        hashIndexBuilder.bulkReserve(numKeysInsertedToFile);
-//        ifstream inf(inputFName, ios_base::in);
-//        inf.seekg(0, ios_base::end);
-//        auto numBlock = 1 + (inf.tellg() / CopyCSVConfig::CSV_READING_BLOCK_SIZE);
-//        inf.close();
-//        for (auto i = 0u; i < numBlock; i++) {
-//            CSVReaderConfig config;
-//            CSVReader reader{inputFName, config, i};
-//            while (reader.hasNextLine()) {
-//                reader.hasNextToken();
-//                auto key = string(reader.getString());
-//                reader.hasNextToken();
-//                node_offset_t value = reader.getInt64();
-//                map[key] = value;
-//                hashIndexBuilder.append(key.c_str(), value);
-//                reader.skipLine();
-//            }
-//        }
-//        hashIndexBuilder.flush();
-//    }
-//
-// public:
-//    string inputFName = "dataset/hash-index-test/stringKeyNodeOffset.data";
-//    unordered_map<string, node_offset_t> map{};
-//};
-
-TEST_F(LoadedHashIndexInt64KeyTest, InMemHashIndexInt64SequentialLookup) {
-    auto bufferManager = make_unique<BufferManager>();
-    HashIndex hashIndex(storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
+TEST_F(HashIndexTest, HashIndexBasicLookup) {
     node_offset_t result;
-    for (int64_t i = 0; i < numKeysInsertedToFile; i++) {
-        auto found = hashIndex.lookup(Transaction::getDummyReadOnlyTrx().get(), i, result);
-        ASSERT_TRUE(found);
-        ASSERT_EQ(result, i << 1);
+    readConn->beginReadOnlyTransaction();
+    conn->beginWriteTransaction();
+    for (auto i = 0u; i < NUM_KEYS_FROM_CSV; i++) {
+        ASSERT_TRUE(IDIndex->lookup(readConn->getActiveTransaction(), i, result));
+        ASSERT_EQ(result, i);
     }
+    for (int64_t i = NUM_KEYS_FROM_CSV; i < (2 * NUM_KEYS_FROM_CSV); i++) {
+        ASSERT_FALSE(IDIndex->lookup(conn->getActiveTransaction(), i, result));
+    }
+    readConn->commit();
+    conn->commit();
 }
 
-TEST_F(LoadedHashIndexInt64KeyTest, HashIndexInt64RandomLookup) {
-    auto bufferManager = make_unique<BufferManager>();
-    HashIndex hashIndex(storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
-    random_device rd;
-    mt19937::result_type seed =
-        rd() ^ ((mt19937::result_type)chrono::duration_cast<chrono::seconds>(
-                    chrono::system_clock::now().time_since_epoch())
-                       .count() +
-                   (mt19937::result_type)chrono::duration_cast<chrono::microseconds>(
-                       chrono::high_resolution_clock::now().time_since_epoch())
-                       .count());
-    mt19937 gen(seed);
-    uniform_int_distribution<unsigned> distribution(0, numKeysInsertedToFile - 1);
-    node_offset_t result;
-    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-    for (auto i = 0u; i < 10000; i++) {
-        int64_t key = distribution(gen);
-        hashIndex.lookup(dummyReadOnlyTrx.get(), key, result);
-        ASSERT_EQ(result, key << 1);
-    }
-}
-
-// TODO(Guodong): Add the support of string keys back to fix this.
-// TEST_F(LoadedHashIndexStringKeyTest, HashIndexStringSequentialLookup) {
-//    auto bufferManager = make_unique<BufferManager>();
-//    HashIndex hashIndex(storageStructureIdAndFName, DataType(STRING), *bufferManager, nullptr);
-//    node_offset_t result;
-//    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-//    for (auto& entry : map) {
-//        auto found = hashIndex.lookup(dummyReadOnlyTrx.get(), entry.first.c_str(), result);
-//        ASSERT_TRUE(found);
-//        ASSERT_EQ(result, entry.second);
-//    }
-//}
-
-TEST_F(HashIndexTest, InMemHashIndexInt64KeyInsertExists) {
-    auto bufferManager = make_unique<BufferManager>();
-    HashIndexBuilder hashIndexBuilder(storageStructureIdAndFName.fName, DataType(INT64));
-    auto numEntries = 10;
-    hashIndexBuilder.bulkReserve(10);
-    for (uint64_t i = 0; i < numEntries; i++) {
-        ASSERT_TRUE(hashIndexBuilder.append(i, i << 1));
-    }
-    for (uint64_t i = 0; i < numEntries; i++) {
-        ASSERT_FALSE(hashIndexBuilder.append(i, i << 1));
-    }
-    hashIndexBuilder.flush();
-}
-
-// TODO(Guodong): Add the support of string keys back to fix this.
-// TEST_F(HashIndexTest, InMemHashIndexStringKeyInsertExists) {
-//    auto bufferManager = make_unique<BufferManager>();
-//    InMemHashIndex hashIndexBuilder(storageStructureIdAndFName.fName, DataType(STRING));
-//    char const* strKeys[] = {"abc", "def", "ghi", "jkl", "mno"};
-//    hashIndexBuilder.bulkReserve(5);
-//    for (auto i = 0u; i < 5; i++) {
-//        ASSERT_TRUE(hashIndexBuilder.append(strKeys[i], i));
-//    }
-//    for (auto i = 0u; i < 5; i++) {
-//        ASSERT_FALSE(hashIndexBuilder.append(strKeys[i], i));
-//    }
-//    hashIndexBuilder.flush();
-//}
-
-static void parallel_insert(HashIndexBuilder* index, int64_t startId, uint64_t num) {
-    for (auto i = 0u; i < num; i++) {
-        index->append(startId + i, (startId + i) * 2);
-    }
-}
-
-TEST_F(HashIndexTest, ParallelHashIndexInsertions) {
-    auto hashIndexBuilder =
-        make_unique<HashIndexBuilder>(storageStructureIdAndFName.fName, DataType(INT64));
-    auto numKeysToInsert = 5000;
-    hashIndexBuilder->bulkReserve(numKeysToInsert);
-    auto numThreads = 10u;
-    auto numKeysPerThread = numKeysToInsert / numThreads;
-    thread threads[numThreads];
-    auto startId = 0;
-    for (auto i = 0u; i < numThreads; i++) {
-        threads[i] = thread(parallel_insert, hashIndexBuilder.get(), startId, numKeysPerThread);
-        startId += numKeysPerThread;
-    }
-    for (auto i = 0u; i < numThreads; i++) {
-        threads[i].join();
-    }
-    hashIndexBuilder->flush();
-
-    auto bufferManager = make_unique<BufferManager>();
-    auto hashIndex = make_unique<HashIndex>(
-        storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
-    node_offset_t result;
-    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-    for (auto i = 0u; i < numKeysToInsert; i++) {
-        ASSERT_TRUE(hashIndex->lookup(dummyReadOnlyTrx.get(), i, result));
-        ASSERT_EQ(result, i * 2);
-    }
-}
-
-TEST_F(LoadedHashIndexInt64KeyTest, InsertAndLookupWithLocalStorage) {
-    auto bufferManager = make_unique<BufferManager>();
-    auto hashIndex = make_unique<HashIndex>(
-        storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
-    auto dummyWriteTrx = Transaction::getDummyWriteTrx();
+TEST_F(HashIndexTest, HashIndexBasicDuplicateInsert) {
+    conn->beginWriteTransaction();
     for (auto i = 0u; i < 100; i++) {
-        uint64_t key = numKeysInsertedToFile + i;
-        ASSERT_TRUE(hashIndex->insert(dummyWriteTrx.get(), key, key << 1));
+        uint64_t key = NUM_KEYS_FROM_CSV + i;
+        ASSERT_TRUE(IDIndex->insert(conn->getActiveTransaction(), key, key << 1));
     }
-    node_offset_t result;
-    for (auto i = 0u; i < (numKeysInsertedToFile + 100); i++) {
-        ASSERT_TRUE(hashIndex->lookup(dummyWriteTrx.get(), i, result));
-        ASSERT_EQ(result, i << 1);
-    }
-    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-    testLookupWithReadTransaction(hashIndex.get(), dummyReadOnlyTrx.get());
-}
-
-TEST_F(LoadedHashIndexInt64KeyTest, DuplicateInsertWithLocalStorage) {
-    auto bufferManager = make_unique<BufferManager>();
-    auto hashIndex = make_unique<HashIndex>(
-        storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
-    auto dummyWriteTrx = Transaction::getDummyWriteTrx();
+    conn->commit();
+    conn->beginWriteTransaction();
     for (auto i = 0u; i < 100; i++) {
-        uint64_t key = numKeysInsertedToFile + i;
-        ASSERT_TRUE(hashIndex->insert(dummyWriteTrx.get(), key, key << 1));
+        uint64_t key = NUM_KEYS_FROM_CSV + i;
+        ASSERT_FALSE(IDIndex->insert(conn->getActiveTransaction(), key, key));
     }
-    for (auto i = 0u; i < (numKeysInsertedToFile + 100); i++) {
-        ASSERT_FALSE(hashIndex->insert(dummyWriteTrx.get(), i, i << 1));
-    }
-    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-    testLookupWithReadTransaction(hashIndex.get(), dummyReadOnlyTrx.get());
+    conn->commit();
 }
 
-TEST_F(LoadedHashIndexInt64KeyTest, DeleteAndLookupWithLocalStorage) {
-    auto bufferManager = make_unique<BufferManager>();
-    auto hashIndex = make_unique<HashIndex>(
-        storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
-    auto dummyWriteTrx = Transaction::getDummyWriteTrx();
-    for (auto i = 0u; i < numKeysInsertedToFile; i++) {
-        if (i % 2 == 0) {
-            hashIndex->deleteKey(dummyWriteTrx.get(), i);
-        }
-    }
-    testLookupWithWriteTransaction(hashIndex.get(), dummyWriteTrx.get());
-    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-    testLookupWithReadTransaction(hashIndex.get(), dummyReadOnlyTrx.get());
+TEST_F(HashIndexTest, InsertCommitNormalExecution) {
+    insertTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
 }
 
-TEST_F(LoadedHashIndexInt64KeyTest, InsertDeleteAndLookupWithLocalStorage) {
-    auto bufferManager = make_unique<BufferManager>();
-    auto hashIndex = make_unique<HashIndex>(
-        storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
-    auto dummyWriteTrx = Transaction::getDummyWriteTrx();
-    for (auto i = 0u; i < 100; i++) {
-        uint64_t key = numKeysInsertedToFile + i;
-        ASSERT_TRUE(hashIndex->insert(dummyWriteTrx.get(), key, key << 1));
-    }
-    for (auto i = 0u; i < (numKeysInsertedToFile + 100); i++) {
-        if (i % 2 == 0) {
-            hashIndex->deleteKey(dummyWriteTrx.get(), i);
-        }
-    }
-    testLookupWithWriteTransaction(hashIndex.get(), dummyWriteTrx.get());
-    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-    testLookupWithReadTransaction(hashIndex.get(), dummyReadOnlyTrx.get());
+TEST_F(HashIndexTest, InsertRollbackNormalExecution) {
+    insertTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
 }
 
-TEST_F(LoadedHashIndexInt64KeyTest, DeleteInsertAndLookupWithLocalStorage) {
-    auto bufferManager = make_unique<BufferManager>();
-    auto hashIndex = make_unique<HashIndex>(
-        storageStructureIdAndFName, DataType(INT64), *bufferManager, nullptr);
-    auto dummyWriteTrx = Transaction::getDummyWriteTrx();
-    // Delete even keys.
-    for (auto i = 0u; i < numKeysInsertedToFile; i++) {
-        if (i % 2 == 0) {
-            hashIndex->deleteKey(dummyWriteTrx.get(), i);
-        }
-    }
-    // Insert back deleted even keys.
-    for (auto i = 0u; i < numKeysInsertedToFile; i++) {
-        if (i % 2 == 0) {
-            ASSERT_TRUE(hashIndex->insert(dummyWriteTrx.get(), i, i << 1));
-        }
-    }
-    // Insert more odd keys.
-    for (auto i = 0u; i < 100; i++) {
-        uint64_t key = numKeysInsertedToFile + i;
-        ASSERT_TRUE(hashIndex->insert(dummyWriteTrx.get(), key, key << 1));
-    }
-    node_offset_t result;
-    for (auto i = 0u; i < (numKeysInsertedToFile + 100); i++) {
-        ASSERT_TRUE(hashIndex->lookup(dummyWriteTrx.get(), i, result));
-        ASSERT_EQ(result, i << 1);
-    }
-    auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
-    testLookupWithReadTransaction(hashIndex.get(), dummyReadOnlyTrx.get());
+TEST_F(HashIndexTest, InsertCommitRecovery) {
+    insertTest(true /* commit */, TransactionTestType::RECOVERY);
+}
+
+TEST_F(HashIndexTest, InsertRollbackRecovery) {
+    insertTest(false /* rollback */, TransactionTestType::RECOVERY);
+}
+
+TEST_F(HashIndexTest, DeleteCommitNormalExecution) {
+    deleteTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
+}
+
+TEST_F(HashIndexTest, DeleteRollbackNormalExecution) {
+    deleteTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
+}
+
+TEST_F(HashIndexTest, DeleteCommitRecovery) {
+    deleteTest(true /* commit */, TransactionTestType::RECOVERY);
+}
+
+TEST_F(HashIndexTest, DeleteRollbackRecovery) {
+    deleteTest(false /* rollback */, TransactionTestType::RECOVERY);
+}
+
+TEST_F(HashIndexTest, MixedDeleteAndInsertCommitNormalExecution) {
+    mixedDeleteAndInsertTest(true /* commit */, TransactionTestType::NORMAL_EXECUTION);
+}
+
+TEST_F(HashIndexTest, MixedDeleteAndInsertRollbackNormalExecution) {
+    mixedDeleteAndInsertTest(false /* rollback */, TransactionTestType::NORMAL_EXECUTION);
+}
+
+TEST_F(HashIndexTest, MixedDeleteAndInsertCommitRecovery) {
+    mixedDeleteAndInsertTest(true /* commit */, TransactionTestType::RECOVERY);
+}
+
+TEST_F(HashIndexTest, MixedDeleteAndInsertRollbackRecovery) {
+    mixedDeleteAndInsertTest(false /* rollback */, TransactionTestType::RECOVERY);
 }

--- a/test/test_utility/include/test_helper.h
+++ b/test/test_utility/include/test_helper.h
@@ -68,7 +68,7 @@ public:
 
     void initGraph();
 
-    void commitOrRollbackConnection(bool isCommit, TransactionTestType transactionTestType);
+    void commitOrRollbackConnection(bool isCommit, TransactionTestType transactionTestType) const;
 
 protected:
     void validateColumnFilesExistence(string fileName, bool existence, bool hasOverflow);

--- a/test/test_utility/test_helper.cpp
+++ b/test/test_utility/test_helper.cpp
@@ -242,7 +242,7 @@ void BaseGraphTest::initGraph() {
 }
 
 void BaseGraphTest::commitOrRollbackConnection(
-    bool isCommit, TransactionTestType transactionTestType) {
+    bool isCommit, TransactionTestType transactionTestType) const {
     if (transactionTestType == TransactionTestType::NORMAL_EXECUTION) {
         if (isCommit) {
             conn->commit();


### PR DESCRIPTION
For write transactions, hash index keeps a local storage for all inserted/deleted keys inside the transaction, and when the transaction state switches to commit, it first executes `prepareCommit` to apply changes from local storage to the persistent index.
Following changes are introduced to HashIndex:
- move HashIndex to BaseDiskArray, and add a read interface to BaseDiskArray `U BaseDiskArray<U>::get(TransactionType trxType, uint64_t idx)`. Notice that `get()` function returns a copy of element U. Another design is to not return U, but pass a read lambda function, which can possibly avoid the full copy of U (when the caller is only interested in a partial content of U), while this interface design is not safe from the perspective of DiskArray, as we cannot force the caller to only read inside the passed lambda function.
- add insert(rehashing) / delete support to the persistent index.
- integrate hash index with transaction commit/rollback.