### PR TITLE
changed BM system config behaviour

### DIFF
--- a/benchmark/benchmark_runner.py
+++ b/benchmark/benchmark_runner.py
@@ -143,8 +143,7 @@ def run_graphflowdb(serialized_graph_path):
             '--warmup=' + str(num_warmup),
             '--run=' + str(num_run),
             '--out=' + benchmark_log_dir + '/' + group,
-            '--default-bm=20480',
-            '--large-bm=20480',
+            '--bm-size=81920',
             '--profile'
         ]
         process = subprocess.Popen(tuple(benchmark_cmd), stdout=subprocess.PIPE)

--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -46,7 +46,7 @@ struct StorageConfig {
     // The default amount of memory pre-allocated to both the default and large pages buffer pool.
     static constexpr uint64_t DEFAULT_BUFFER_POOL_SIZE = 1ull << 24; // (16MB)
     // The default ratio of buffer allocated to large pages.
-    static constexpr double DEFAULT_PAGES_BUFFER_RATIO = 0.5;
+    static constexpr double DEFAULT_PAGES_BUFFER_RATIO = 0.75;
     static constexpr double LARGE_PAGES_BUFFER_RATIO = 1.0 - DEFAULT_PAGES_BUFFER_RATIO;
     static constexpr char OVERFLOW_FILE_SUFFIX[] = ".ovf";
     static constexpr char COLUMN_FILE_SUFFIX[] = ".col";

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -44,8 +44,6 @@ void Database::initDBDirAndCoreFilesIfNecessary() {
 }
 
 void Database::resizeBufferManager(uint64_t newSize) {
-    // Currently we are resizing both buffer pools to the same size. If needed we can
-    // extend this functionality.
     systemConfig.defaultPageBufferPoolSize = newSize * StorageConfig::DEFAULT_PAGES_BUFFER_RATIO;
     systemConfig.largePageBufferPoolSize = newSize * StorageConfig::LARGE_PAGES_BUFFER_RATIO;
     bufferManager->resize(

--- a/src/main/include/database.h
+++ b/src/main/include/database.h
@@ -25,13 +25,11 @@ namespace main {
 
 struct SystemConfig {
 
-    explicit SystemConfig(
-        uint64_t defaultPageBufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE *
-                                             StorageConfig::DEFAULT_PAGES_BUFFER_RATIO,
-        uint64_t largePageBufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE *
-                                           StorageConfig::LARGE_PAGES_BUFFER_RATIO)
-        : defaultPageBufferPoolSize{defaultPageBufferPoolSize}, largePageBufferPoolSize{
-                                                                    largePageBufferPoolSize} {}
+    explicit SystemConfig(uint64_t bufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE)
+        : defaultPageBufferPoolSize{(uint64_t)(
+              bufferPoolSize * StorageConfig::DEFAULT_PAGES_BUFFER_RATIO)},
+          largePageBufferPoolSize{
+              (uint64_t)(bufferPoolSize * StorageConfig::LARGE_PAGES_BUFFER_RATIO)} {}
 
     uint64_t defaultPageBufferPoolSize;
     uint64_t largePageBufferPoolSize;

--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -12,7 +12,7 @@ const string BENCHMARK_SUFFIX = ".benchmark";
 BenchmarkRunner::BenchmarkRunner(const string& datasetPath, unique_ptr<BenchmarkConfig> config)
     : config{move(config)} {
     database = make_unique<Database>(DatabaseConfig(datasetPath, this->config->isInMemoryMode),
-        SystemConfig(this->config->defaultBufferPoolSize, this->config->largeBufferPoolSize));
+        SystemConfig(this->config->bufferPoolSize));
 }
 
 void BenchmarkRunner::registerBenchmarks(const string& path) {

--- a/tools/benchmark/include/benchmark_config.h
+++ b/tools/benchmark/include/benchmark_config.h
@@ -22,8 +22,7 @@ struct BenchmarkConfig {
     string outputPath;
     // in-memory mode
     bool isInMemoryMode = false;
-    uint64_t defaultBufferPoolSize = 1 << 22;
-    uint64_t largeBufferPoolSize = 1 << 22;
+    uint64_t bufferPoolSize = 1 << 23;
 };
 
 } // namespace benchmark

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -35,10 +35,8 @@ int main(int argc, char** argv) {
             config->isInMemoryMode = true;
         } else if (arg.starts_with("--profile")) {
             config->enableProfile = true;
-        } else if (arg.starts_with("--default-bm")) {
-            config->defaultBufferPoolSize = (uint64_t)stoull(getArgumentValue(arg)) << 20;
-        } else if (arg.starts_with("--large-bm")) {
-            config->largeBufferPoolSize = (uint64_t)stoull(getArgumentValue(arg)) << 20;
+        } else if (arg.starts_with("--bm-size")) {
+            config->bufferPoolSize = (uint64_t)stoull(getArgumentValue(arg)) << 20;
         } else {
             printf("Unrecognized option %s", arg.c_str());
             exit(1);

--- a/tools/python_api/include/py_database.h
+++ b/tools/python_api/include/py_database.h
@@ -12,8 +12,7 @@ class PyDatabase {
 public:
     static void initialize(py::handle& m);
 
-    explicit PyDatabase(const string& databasePath, uint64_t defaultPageBufferPoolSize,
-        uint64_t largePageBufferPoolSize);
+    explicit PyDatabase(const string& databasePath, uint64_t bufferPoolSize);
 
     void resizeBufferManager(uint64_t newSize);
 

--- a/tools/python_api/py_database.cpp
+++ b/tools/python_api/py_database.cpp
@@ -2,20 +2,18 @@
 
 void PyDatabase::initialize(py::handle& m) {
     py::class_<PyDatabase>(m, "database")
-        .def(py::init<const string&, uint64_t, uint64_t>(), py::arg("database_path"),
-            py::arg("default_page_buffer_pool_size") = 0,
-            py::arg("large_page_buffer_pool_size") = 0)
+        .def(py::init<const string&, uint64_t>(), py::arg("database_path"),
+            py::arg("buffer_pool_size") = 0)
         .def("resize_buffer_manager", &PyDatabase::resizeBufferManager, py::arg("new_size"));
 }
 
-PyDatabase::PyDatabase(const string& databasePath, uint64_t defaultPageBufferPoolSize,
-    uint64_t largePageBufferPoolSize) {
+PyDatabase::PyDatabase(const string& databasePath, uint64_t bufferPoolSize) {
     auto systemConfig = SystemConfig();
-    if (defaultPageBufferPoolSize > 0) {
-        systemConfig.defaultPageBufferPoolSize = defaultPageBufferPoolSize;
-    }
-    if (largePageBufferPoolSize > 0) {
-        systemConfig.largePageBufferPoolSize = largePageBufferPoolSize;
+    if (bufferPoolSize > 0) {
+        systemConfig.defaultPageBufferPoolSize =
+            bufferPoolSize * StorageConfig::DEFAULT_PAGES_BUFFER_RATIO;
+        systemConfig.largePageBufferPoolSize =
+            bufferPoolSize * StorageConfig::LARGE_PAGES_BUFFER_RATIO;
     }
     database = make_unique<Database>(DatabaseConfig(databasePath), systemConfig);
 }

--- a/tools/python_api/test/conftest.py
+++ b/tools/python_api/test/conftest.py
@@ -23,7 +23,6 @@ def init_tiny_snb(tmp_path):
 
 @pytest.fixture
 def establish_connection(init_tiny_snb):
-    db = gdb.database(init_tiny_snb, default_page_buffer_pool_size=128 *
-                      1024 * 1024, large_page_buffer_pool_size=128 * 1024 * 1024)
+    db = gdb.database(init_tiny_snb, buffer_pool_size = 256 * 1024 * 1024)
     conn = gdb.connection(db, num_threads=4)
     return conn, db

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -183,7 +183,7 @@ void EmbeddedShell::run() {
         } else if (lineStr.rfind(shellCommand.THREAD) == 0) {
             setNumThreads(lineStr.substr(shellCommand.THREAD.length()));
         } else if (lineStr.rfind(shellCommand.BUFFER_MANAGER_SIZE) == 0) {
-            setBufferMangerSize(lineStr.substr(shellCommand.BUFFER_MANAGER_SIZE.length()));
+            setBufferManagerSize(lineStr.substr(shellCommand.BUFFER_MANAGER_SIZE.length()));
         } else if (lineStr.rfind(shellCommand.BUFFER_MANAGER_DEBUG_INFO) == 0) {
             printf("Buffer Manager Debug Info: \n %s \n",
                 database->getBufferManager()->debugInfo()->dump(4).c_str());
@@ -227,7 +227,7 @@ void EmbeddedShell::setNumThreads(const string& numThreadsString) {
     } catch (Exception& e) { printf("%s", e.what()); }
 }
 
-void EmbeddedShell::setBufferMangerSize(const string& bufferManagerSizeString) {
+void EmbeddedShell::setBufferManagerSize(const string& bufferManagerSizeString) {
     auto newPageSize = 0;
     try {
         newPageSize = stoull(bufferManagerSizeString);

--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -19,7 +19,7 @@ public:
 private:
     void setNumThreads(const string& numThreadsString);
 
-    void setBufferMangerSize(const string& bufferManagerSizeString);
+    void setBufferManagerSize(const string& bufferManagerSizeString);
 
     void printNodeSchema(const string& tableName);
     void printRelSchema(const string& tableName);

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -10,12 +10,9 @@ int main(int argc, char* argv[]) {
     args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
     args::ValueFlag<string> inputDirFlag(
         parser, "", "Path to serialized db files.", {'i', "inputDir"}, args::Options::Required);
-    // The default size of buffer pool for holding default page sizes is 1 GB
-    args::ValueFlag<uint64_t> defaultPagedBPSizeInMBFlag(parser, "",
-        "Size of default paged buffer manager in megabytes", {'d', "defaultPageBPSize"}, 1024);
-    // The default size of buffer pool for holding default page sizes is 512 MB
-    args::ValueFlag<uint64_t> largePagedBPSizeInMBFlag(parser, "",
-        "Size of large paged buffer manager in megabytes", {'l', "largePageBPSize"}, 512);
+    args::ValueFlag<uint64_t> bpSizeInMBFlag(parser, "",
+        "Size of buffer pool for default and large page sizes in megabytes", {'d', "defaultBPSize"},
+        1024);
     args::Flag inMemoryFlag(parser, "", "Runs the system in in-memory mode", {'m', "in-memory"});
     try {
         parser.ParseCLI(argc, argv);
@@ -25,13 +22,11 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     auto serializedGraphPath = args::get(inputDirFlag);
-    uint64_t defaultPagedBPSizeInMB = args::get(defaultPagedBPSizeInMBFlag);
-    uint64_t largePagedBPSizeInMB = args::get(largePagedBPSizeInMBFlag);
+    uint64_t bpSizeInMB = args::get(bpSizeInMBFlag);
     cout << "serializedGraphPath: " << serializedGraphPath << endl;
     cout << "inMemory: " << (inMemoryFlag ? "true" : "false") << endl;
-    cout << "defaultPagedBPSizeInMB: " << to_string(defaultPagedBPSizeInMB) << endl;
-    cout << "largePagedBPSizeInMB: " << to_string(largePagedBPSizeInMB) << endl;
-    SystemConfig systemConfig(defaultPagedBPSizeInMB << 20, largePagedBPSizeInMB << 20);
+    cout << "bufferPoolSizeInMB: " << to_string(bpSizeInMB) << endl;
+    SystemConfig systemConfig(bpSizeInMB << 20);
     DatabaseConfig databaseConfig(serializedGraphPath, inMemoryFlag);
     auto shell = EmbeddedShell(databaseConfig, systemConfig);
     shell.run();


### PR DESCRIPTION
This closes issue #773 
In this PR:
 - Changed the default/large buffer ratio from 0.5/0.5 to 0.75/0.25
 - Changed `SystemConfig` constructor to include one argument instead of two
 - Changed shell runner so that it displays one BM size flag instead of two
 - Fixed a typo