### PR TITLE
add getResultHeader related python APIs

### DIFF
--- a/tools/python_api/BUILD.bazel
+++ b/tools/python_api/BUILD.bazel
@@ -51,9 +51,10 @@ py_test(
         "test/test_datatype.py",
         "test/test_df.py",
         "test/test_exception.py",
+        "test/test_get_header.py",
         "test/test_main.py",
         "test/test_parameter.py",
-        "test/test_write_to_csv.py"
+        "test/test_write_to_csv.py",
     ],
     data = [
         "//dataset",

--- a/tools/python_api/include/py_query_result.h
+++ b/tools/python_api/include/py_query_result.h
@@ -27,6 +27,10 @@ public:
 
     py::object getAsDF();
 
+    py::list getColumnDataTypes();
+
+    py::list getColumnNames();
+
 private:
     unique_ptr<QueryResult> queryResult;
 };

--- a/tools/python_api/py_query_result.cpp
+++ b/tools/python_api/py_query_result.cpp
@@ -13,8 +13,9 @@ void PyQueryResult::initialize(py::handle& m) {
         .def("getNext", &PyQueryResult::getNext)
         .def("writeToCSV", &PyQueryResult::writeToCSV)
         .def("close", &PyQueryResult::close)
-        .def("getAsDF", &PyQueryResult::getAsDF);
-
+        .def("getAsDF", &PyQueryResult::getAsDF)
+        .def("getColumnNames", &PyQueryResult::getColumnNames)
+        .def("getColumnDataTypes", &PyQueryResult::getColumnDataTypes);
     // PyDateTime_IMPORT is a macro that must be invoked before calling any other cpython datetime
     // macros. One could also invoke this in a separate function like constructor. See
     // https://docs.python.org/3/c-api/datetime.html for details.
@@ -102,4 +103,22 @@ py::object PyQueryResult::convertValueToPyObject(const ResultValue& value) {
 
 py::object PyQueryResult::getAsDF() {
     return QueryResultConverter(queryResult.get()).toDF();
+}
+
+py::list PyQueryResult::getColumnDataTypes() {
+    auto columnDataTypes = queryResult->getColumnDataTypes();
+    py::tuple result(columnDataTypes.size());
+    for (auto i = 0u; i < columnDataTypes.size(); ++i) {
+        result[i] = py::cast(Types::dataTypeToString(columnDataTypes[i]));
+    }
+    return move(result);
+}
+
+py::list PyQueryResult::getColumnNames() {
+    auto columnNames = queryResult->getColumnNames();
+    py::tuple result(columnNames.size());
+    for (auto i = 0u; i < columnNames.size(); ++i) {
+        result[i] = py::cast(columnNames[i]);
+    }
+    return move(result);
 }

--- a/tools/python_api/test/conftest.py
+++ b/tools/python_api/test/conftest.py
@@ -18,11 +18,15 @@ def init_tiny_snb(tmp_path):
                  "INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], PRIMARY "
                  "KEY (ID))")
     conn.execute("COPY person FROM \"dataset/tinysnb/vPerson.csv\" (HEADER=true)")
+    conn.execute(
+        "create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, "
+        "comments STRING[], MANY_MANY);")
+    conn.execute("COPY knows FROM \"dataset/tinysnb/eKnows.csv\"")
     return output_path
 
 
 @pytest.fixture
 def establish_connection(init_tiny_snb):
-    db = gdb.database(init_tiny_snb, buffer_pool_size = 256 * 1024 * 1024)
+    db = gdb.database(init_tiny_snb, buffer_pool_size=256 * 1024 * 1024)
     conn = gdb.connection(db, num_threads=4)
     return conn, db

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -12,7 +12,7 @@ def test_to_df(establish_connection):
         assert pd['p.ID'].tolist() == [0, 2, 3, 5, 7, 8, 9, 10]
         assert str(pd['p.ID'].dtype) == "int64"
         assert pd['p.fName'].tolist() == ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
-                                        "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
+                                          "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
         assert str(pd['p.fName'].dtype) == "object"
         assert pd['p.gender'].tolist() == [1, 2, 1, 2, 1, 2, 2, 2]
         assert str(pd['p.gender'].dtype) == "int64"
@@ -21,19 +21,24 @@ def test_to_df(establish_connection):
         assert pd['p.eyeSight'].tolist() == [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9]
         assert str(pd['p.eyeSight'].dtype) == "float64"
         assert pd['p.birthdate'].tolist() == [Timestamp('1900-01-01'), Timestamp('1900-01-01'),
-                                            Timestamp('1940-06-22'), Timestamp('1950-07-23 '),
-                                            Timestamp('1980-10-26'), Timestamp('1980-10-26'),
-                                            Timestamp('1980-10-26'), Timestamp('1990-11-27')]
+                                              Timestamp('1940-06-22'), Timestamp('1950-07-23 '),
+                                              Timestamp('1980-10-26'), Timestamp('1980-10-26'),
+                                              Timestamp('1980-10-26'), Timestamp('1990-11-27')]
         assert str(pd['p.birthdate'].dtype) == "datetime64[ns]"
-        assert pd['p.registerTime'].tolist() == [Timestamp('2011-08-20 11:25:30'), Timestamp('2008-11-03 15:25:30.000526'),
-                                                Timestamp('1911-08-20 02:32:21'), Timestamp('2031-11-30 12:25:30'),
-                                                Timestamp('1976-12-23 11:21:42'), Timestamp('1972-07-31 13:22:30.678559'),
-                                                Timestamp('1976-12-23 04:41:42'), Timestamp('2023-02-21 13:25:30')]
+        assert pd['p.registerTime'].tolist() == [Timestamp('2011-08-20 11:25:30'),
+                                                 Timestamp('2008-11-03 15:25:30.000526'),
+                                                 Timestamp('1911-08-20 02:32:21'), Timestamp('2031-11-30 12:25:30'),
+                                                 Timestamp('1976-12-23 11:21:42'),
+                                                 Timestamp('1972-07-31 13:22:30.678559'),
+                                                 Timestamp('1976-12-23 04:41:42'), Timestamp('2023-02-21 13:25:30')]
         assert str(pd['p.registerTime'].dtype) == "datetime64[ns]"
-        assert pd['p.lastJobDuration'].tolist() == [Timedelta('1082 days 13:02:00'), Timedelta('3750 days 13:00:00.000024'),
-                                                    Timedelta('2 days 00:24:11'), Timedelta('3750 days 13:00:00.000024'),
+        assert pd['p.lastJobDuration'].tolist() == [Timedelta('1082 days 13:02:00'),
+                                                    Timedelta('3750 days 13:00:00.000024'),
+                                                    Timedelta('2 days 00:24:11'),
+                                                    Timedelta('3750 days 13:00:00.000024'),
                                                     Timedelta('2 days 00:24:11'), Timedelta('0 days 00:18:00.024000'),
-                                                    Timedelta('3750 days 13:00:00.000024'), Timedelta('1082 days 13:02:00')]
+                                                    Timedelta('3750 days 13:00:00.000024'),
+                                                    Timedelta('1082 days 13:02:00')]
         assert str(pd['p.lastJobDuration'].dtype) == "timedelta64[ns]"
         assert pd['p.workedHours'].tolist() == [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
                                                 [10, 11, 12, 3, 4, 5, 6, 7]]
@@ -42,8 +47,8 @@ def test_to_df(establish_connection):
                                                 [10, 11, 12, 3, 4, 5, 6, 7]]
         assert str(pd['p.workedHours'].dtype) == "object"
         assert pd['p.usedNames'].tolist() == [["Aida"], ['Bobby'], ['Carmen', 'Fred'],
-                                            ['Wolfeschlegelstein', 'Daniel'], ['Ein'], ['Fesdwe'], ['Grad'],
-                                            ['Ad', 'De', 'Hi', 'Kye', 'Orlan']]
+                                              ['Wolfeschlegelstein', 'Daniel'], ['Ein'], ['Fesdwe'], ['Grad'],
+                                              ['Ad', 'De', 'Hi', 'Kye', 'Orlan']]
         assert str(pd['p.usedNames'].dtype) == "object"
         assert pd['p.courseScoresPerTerm'].tolist() == [[[10, 8], [6, 7, 8]], [[8, 9], [9, 10]], [[8, 10]],
                                                         [[7, 4], [8, 8], [9]], [[6], [7], [8]], [[8]], [[10]],
@@ -57,7 +62,7 @@ def test_to_df(establish_connection):
         # assert unstrProp[2] == '52'
         # assert unstrProp[4] == '68.000000'
         # assert str(pd['p.unstrNumericProp'].dtype) == "object"
-    
+
     _test_to_df(conn)
 
     conn.set_max_threads_for_exec(2)

--- a/tools/python_api/test/test_get_header.py
+++ b/tools/python_api/test/test_get_header.py
@@ -1,0 +1,26 @@
+def test_get_column_names(establish_connection):
+    conn, db = establish_connection
+    result = conn.execute("MATCH (a:person)-[e:knows]->(b:person) RETURN a.fName, e.date, b.ID;")
+    column_names = result.getColumnNames()
+    assert column_names[0] == 'a.fName'
+    assert column_names[1] == 'e.date'
+    assert column_names[2] == 'b.ID'
+    result.close()
+
+
+def test_get_column_data_types(establish_connection):
+    conn, db = establish_connection
+    result = conn.execute(
+        "MATCH (p:person) RETURN p.ID, p.fName, p.isStudent, p.eyeSight, p.birthdate, p.registerTime, "
+        "p.lastJobDuration, p.workedHours, p.courseScoresPerTerm;")
+    column_data_types = result.getColumnDataTypes()
+    assert column_data_types[0] == 'INT64'
+    assert column_data_types[1] == 'STRING'
+    assert column_data_types[2] == 'BOOL'
+    assert column_data_types[3] == 'DOUBLE'
+    assert column_data_types[4] == 'DATE'
+    assert column_data_types[5] == 'TIMESTAMP'
+    assert column_data_types[6] == 'INTERVAL'
+    assert column_data_types[7] == 'INT64[]'
+    assert column_data_types[8] == 'INT64[][]'
+    result.close()

--- a/tools/python_api/test/test_main.py
+++ b/tools/python_api/test/test_main.py
@@ -5,6 +5,7 @@ from test_parameter import *
 from test_exception import *
 from test_df import *
 from test_write_to_csv import *
+from test_get_header import *
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))


### PR DESCRIPTION
This PR mainly extends our python API by adding these two new functions:
```
    py::list getColumnDataTypes();  => returns the columnDataTypes of the queryResult
    py::list getColumnNames();      => returns the columnNames of the queryResult
```