### PR TITLE
add checks to error on duplicated/reserved column name

### DIFF
--- a/src/binder/include/binder.h
+++ b/src/binder/include/binder.h
@@ -116,7 +116,8 @@ private:
         string pkColName, vector<pair<string, string>> propertyNameDataTypes);
 
     static vector<PropertyNameDataType> bindPropertyNameDataTypes(
-        vector<pair<string, string>> propertyNameDataTypes);
+        vector<pair<string, string>> propertyNameDataTypes,
+        unordered_set<string> reservedPropertyName);
 
     SrcDstTableIDs bindRelConnections(RelConnection relConnections) const;
 

--- a/src/catalog/include/catalog.h
+++ b/src/catalog/include/catalog.h
@@ -205,6 +205,10 @@ public:
         wal->logDropTableRecord(tableSchema->isNodeTable, tableSchema->tableID);
     }
 
+    static inline unordered_set<string> getReservedPropertyNames() {
+        return unordered_set<string>{INTERNAL_ID_SUFFIX};
+    }
+
 protected:
     unique_ptr<BuiltInVectorOperations> builtInVectorOperations;
     unique_ptr<BuiltInAggregateFunctions> builtInAggregateFunctions;

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -306,6 +306,14 @@ TEST_F(BinderErrorTest, CreateNodeTableInvalidDataType) {
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
+TEST_F(BinderErrorTest, CreateNodeTableDuplicatedColumnName) {
+    string expectedException =
+        "Binder exception: Duplicated column name: eyesight, column name must be unique.";
+    auto input =
+        "CREATE NODE TABLE student (id INT64, eyesight double, eyesight double, PRIMARY KEY(id));";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
 TEST_F(BinderErrorTest, CopyCSVInvalidParsingOption) {
     string expectedException = "Binder exception: Unrecognized parsing csv option: pk.";
     auto input = R"(COPY person FROM "person_0_0.csv" (pk=","))";
@@ -347,6 +355,20 @@ TEST_F(BinderErrorTest, CreateRelTableInvalidRelMultiplicity) {
 TEST_F(BinderErrorTest, CreateRelTableInvalidDataType) {
     string expectedException = "Cannot parse dataTypeID: SMALLINT";
     auto input = "CREATE REL TABLE knows_post ( FROM person TO person, ID SMALLINT, MANY_MANY);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, CreateRelTableDuplicatedColumnName) {
+    string expectedException =
+        "Binder exception: Duplicated column name: date, column name must be unique.";
+    auto input = "CREATE REL TABLE teaches (FROM person TO person, date DATE, date TIMESTAMP);";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, CreateRelTableReservedColumnName) {
+    string expectedException =
+        "Binder exception: PropertyName: _id is an internal reserved propertyName.";
+    auto input = "CREATE REL TABLE teaches (FROM person TO person, _id INT64);";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 


### PR DESCRIPTION
This PR adds some checks to error on duplicated/reserved column name.
1. Duplicated column name: two columns have the exactly same name in a createTable clause.
eg. `create node table person(ID INT64, eyesight double, eyesight string, primary key(ID))`
2. Reserved column name: `_id` is an internal column in the relTable, the user shouldn't define a rel table with columnName=`_id`
eg.  `create rel table knows(FROM person TO person, _id INT64)`