### PR TITLE
fix order by empty result bug

### DIFF
--- a/src/processor/operator/order_by/include/key_block_merger.h
+++ b/src/processor/operator/order_by/include/key_block_merger.h
@@ -189,8 +189,9 @@ class KeyBlockMergeTaskDispatcher {
 public:
     inline bool isDoneMerge() {
         lock_guard<mutex> keyBlockMergeDispatcherLock{mtx};
-        // Returns true if there are no more merge task to do.
-        return sortedKeyBlocks->size() == 1 && activeKeyBlockMergeTasks.empty();
+        // Returns true if there are no more merge task to do or the sortedKeyBlocks is empty
+        // (meaning that the resultSet is empty).
+        return sortedKeyBlocks->size() <= 1 && activeKeyBlockMergeTasks.empty();
     }
 
     unique_ptr<KeyBlockMergeMorsel> getMorsel();

--- a/src/processor/operator/order_by/include/order_by_scan.h
+++ b/src/processor/operator/order_by/include/order_by_scan.h
@@ -7,6 +7,16 @@
 namespace graphflow {
 namespace processor {
 
+struct MergedKeyBlockScanState {
+    bool scanSingleTuple;
+    uint32_t nextTupleIdxToReadInMergedKeyBlock;
+    shared_ptr<MergedKeyBlocks> mergedKeyBlock;
+    uint32_t tupleIdxAndFactorizedTableIdxOffset;
+    vector<uint32_t> colsToScan;
+    unique_ptr<uint8_t*[]> tuplesToRead;
+    unique_ptr<BlockPtrInfo> blockPtrInfo;
+};
+
 // To preserve the ordering of tuples, the orderByScan operator will only
 // be executed in single-thread mode.
 class OrderByScan : public PhysicalOperator, public SourceOperator {
@@ -16,9 +26,9 @@ public:
         const vector<DataPos>& outDataPoses,
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState,
         unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(child), id, paramsString},
-          SourceOperator{move(resultSetDescriptor)}, outDataPoses{outDataPoses},
-          sharedState{move(sharedState)}, nextTupleIdxToReadInMergedKeyBlock{0} {}
+        : PhysicalOperator{move(child), id, paramsString}, SourceOperator{move(
+                                                               resultSetDescriptor)},
+          outDataPoses{outDataPoses}, sharedState{move(sharedState)} {}
 
     // This constructor is used for cloning only.
     OrderByScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
@@ -26,8 +36,7 @@ public:
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState, uint32_t id,
         const string& paramsString)
         : PhysicalOperator{id, paramsString}, SourceOperator{move(resultSetDescriptor)},
-          outDataPoses{outDataPoses}, sharedState{move(sharedState)},
-          nextTupleIdxToReadInMergedKeyBlock{0} {}
+          outDataPoses{outDataPoses}, sharedState{move(sharedState)} {}
 
     PhysicalOperatorType getOperatorType() override { return ORDER_BY_SCAN; }
 
@@ -45,16 +54,13 @@ public:
     }
 
 private:
-    bool scanSingleTuple;
+    void initMergedKeyBlockScanStateIfNecessary();
+
+private:
     vector<DataPos> outDataPoses;
     shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState;
     vector<shared_ptr<ValueVector>> vectorsToRead;
-    uint32_t nextTupleIdxToReadInMergedKeyBlock;
-    shared_ptr<MergedKeyBlocks> mergedKeyBlock;
-    uint32_t tupleIdxAndFactorizedTableIdxOffset;
-    vector<uint32_t> colsToScan;
-    unique_ptr<uint8_t*[]> tuplesToRead;
-    unique_ptr<BlockPtrInfo> blockPtrInfo;
+    unique_ptr<MergedKeyBlockScanState> mergedKeyBlockScanState;
 };
 
 } // namespace processor

--- a/src/processor/operator/order_by/order_by_scan.cpp
+++ b/src/processor/operator/order_by/order_by_scan.cpp
@@ -14,63 +14,60 @@ shared_ptr<ResultSet> OrderByScan::init(ExecutionContext* context) {
         outDataChunk->insert(outDataPos.valueVectorPos, valueVector);
         vectorsToRead.emplace_back(valueVector);
     }
-    scanSingleTuple = sharedState->factorizedTables[0]->hasUnflatCol();
-
-    mergedKeyBlock = sharedState->sortedKeyBlocks->front();
-    tupleIdxAndFactorizedTableIdxOffset = mergedKeyBlock->getNumBytesPerTuple() - 8;
-    colsToScan = vector<uint32_t>(vectorsToRead.size());
-    iota(colsToScan.begin(), colsToScan.end(), 0);
-    if (!scanSingleTuple) {
-        tuplesToRead = make_unique<uint8_t*[]>(DEFAULT_VECTOR_CAPACITY);
-    }
-    blockPtrInfo = make_unique<BlockPtrInfo>(
-        0 /* startTupleIdx */, mergedKeyBlock->getNumTuples(), mergedKeyBlock);
+    initMergedKeyBlockScanStateIfNecessary();
     return resultSet;
 }
 
 bool OrderByScan::getNextTuples() {
     metrics->executionTime.start();
     // If there is no more tuples to read, just return false.
-    if (nextTupleIdxToReadInMergedKeyBlock >= mergedKeyBlock->getNumTuples()) {
+    if (mergedKeyBlockScanState == nullptr ||
+        mergedKeyBlockScanState->nextTupleIdxToReadInMergedKeyBlock >=
+            mergedKeyBlockScanState->mergedKeyBlock->getNumTuples()) {
         metrics->executionTime.stop();
         return false;
     } else {
         // If there is an unflat col in factorizedTable, we can only read one
         // tuple at a time. Otherwise, we can read min(DEFAULT_VECTOR_CAPACITY,
         // numTuplesRemainingInMemBlock) tuples.
-        if (scanSingleTuple) {
-            auto tupleInfoBuffer = blockPtrInfo->curTuplePtr + tupleIdxAndFactorizedTableIdxOffset;
+        if (mergedKeyBlockScanState->scanSingleTuple) {
+            auto tupleInfoBuffer = mergedKeyBlockScanState->blockPtrInfo->curTuplePtr +
+                                   mergedKeyBlockScanState->tupleIdxAndFactorizedTableIdxOffset;
             auto blockIdx = OrderByKeyEncoder::getEncodedFTBlockIdx(tupleInfoBuffer);
             auto blockOffset = OrderByKeyEncoder::getEncodedFTBlockOffset(tupleInfoBuffer);
             auto ft =
                 sharedState->factorizedTables[OrderByKeyEncoder::getEncodedFTIdx(tupleInfoBuffer)];
             ft->scan(vectorsToRead, blockIdx * ft->getNumTuplesPerBlock() + blockOffset,
                 1 /* numTuples */);
-            blockPtrInfo->curTuplePtr += mergedKeyBlock->getNumBytesPerTuple();
-            blockPtrInfo->updateTuplePtrIfNecessary();
-            nextTupleIdxToReadInMergedKeyBlock++;
+            mergedKeyBlockScanState->blockPtrInfo->curTuplePtr +=
+                mergedKeyBlockScanState->mergedKeyBlock->getNumBytesPerTuple();
+            mergedKeyBlockScanState->blockPtrInfo->updateTuplePtrIfNecessary();
+            mergedKeyBlockScanState->nextTupleIdxToReadInMergedKeyBlock++;
             metrics->numOutputTuple.increase(1);
         } else {
             auto numTuplesToRead = min(DEFAULT_VECTOR_CAPACITY,
-                mergedKeyBlock->getNumTuples() - nextTupleIdxToReadInMergedKeyBlock);
+                mergedKeyBlockScanState->mergedKeyBlock->getNumTuples() -
+                    mergedKeyBlockScanState->nextTupleIdxToReadInMergedKeyBlock);
             auto numTuplesRead = 0;
             while (numTuplesRead < numTuplesToRead) {
-                auto numTuplesToReadInCurBlock = min(
-                    numTuplesToRead - numTuplesRead, blockPtrInfo->getNumTuplesLeftInCurBlock());
+                auto numTuplesToReadInCurBlock = min(numTuplesToRead - numTuplesRead,
+                    mergedKeyBlockScanState->blockPtrInfo->getNumTuplesLeftInCurBlock());
 
                 for (auto i = 0u; i < numTuplesToReadInCurBlock; i++) {
                     auto tupleInfoBuffer =
-                        blockPtrInfo->curTuplePtr + tupleIdxAndFactorizedTableIdxOffset;
+                        mergedKeyBlockScanState->blockPtrInfo->curTuplePtr +
+                        mergedKeyBlockScanState->tupleIdxAndFactorizedTableIdxOffset;
                     auto blockIdx = OrderByKeyEncoder::getEncodedFTBlockIdx(tupleInfoBuffer);
                     auto blockOffset = OrderByKeyEncoder::getEncodedFTBlockOffset(tupleInfoBuffer);
                     auto ft =
                         sharedState
                             ->factorizedTables[OrderByKeyEncoder::getEncodedFTIdx(tupleInfoBuffer)];
-                    tuplesToRead[numTuplesRead + i] =
+                    mergedKeyBlockScanState->tuplesToRead[numTuplesRead + i] =
                         ft->getTuple(blockIdx * ft->getNumTuplesPerBlock() + blockOffset);
-                    blockPtrInfo->curTuplePtr += mergedKeyBlock->getNumBytesPerTuple();
+                    mergedKeyBlockScanState->blockPtrInfo->curTuplePtr +=
+                        mergedKeyBlockScanState->mergedKeyBlock->getNumBytesPerTuple();
                 }
-                blockPtrInfo->updateTuplePtrIfNecessary();
+                mergedKeyBlockScanState->blockPtrInfo->updateTuplePtrIfNecessary();
                 numTuplesRead += numTuplesToReadInCurBlock;
             }
             // TODO(Ziyi): This is a hacky way of using factorizedTable::lookup function,
@@ -78,14 +75,34 @@ bool OrderByScan::getNextTuples() {
             // lookup function doesn't perform a check on whether it holds all the tuples in
             // tuplesToRead. We should optimize this lookup function in the orderByScan
             // optimization PR.
-            sharedState->factorizedTables[0]->lookup(
-                vectorsToRead, colsToScan, tuplesToRead.get(), 0, numTuplesToRead);
+            sharedState->factorizedTables[0]->lookup(vectorsToRead,
+                mergedKeyBlockScanState->colsToScan, mergedKeyBlockScanState->tuplesToRead.get(), 0,
+                numTuplesToRead);
             metrics->numOutputTuple.increase(numTuplesToRead);
-            nextTupleIdxToReadInMergedKeyBlock += numTuplesToRead;
+            mergedKeyBlockScanState->nextTupleIdxToReadInMergedKeyBlock += numTuplesToRead;
         }
         metrics->executionTime.stop();
         return true;
     }
+}
+
+void OrderByScan::initMergedKeyBlockScanStateIfNecessary() {
+    if (sharedState->sortedKeyBlocks->empty()) {
+        return;
+    }
+    mergedKeyBlockScanState = make_unique<MergedKeyBlockScanState>();
+    mergedKeyBlockScanState->mergedKeyBlock = sharedState->sortedKeyBlocks->front();
+    mergedKeyBlockScanState->tupleIdxAndFactorizedTableIdxOffset =
+        mergedKeyBlockScanState->mergedKeyBlock->getNumBytesPerTuple() - 8;
+    mergedKeyBlockScanState->colsToScan = vector<uint32_t>(vectorsToRead.size());
+    iota(mergedKeyBlockScanState->colsToScan.begin(), mergedKeyBlockScanState->colsToScan.end(), 0);
+    mergedKeyBlockScanState->scanSingleTuple = sharedState->factorizedTables[0]->hasUnflatCol();
+    if (!mergedKeyBlockScanState->scanSingleTuple) {
+        mergedKeyBlockScanState->tuplesToRead = make_unique<uint8_t*[]>(DEFAULT_VECTOR_CAPACITY);
+    }
+    mergedKeyBlockScanState->blockPtrInfo = make_unique<BlockPtrInfo>(0 /* startTupleIdx */,
+        mergedKeyBlockScanState->mergedKeyBlock->getNumTuples(),
+        mergedKeyBlockScanState->mergedKeyBlock);
 }
 
 } // namespace processor

--- a/test/test_files/tinySNB/order_by/order_by.test
+++ b/test/test_files/tinySNB/order_by/order_by.test
@@ -234,3 +234,7 @@ Bob
 Carol
 Elizabeth
 Elizabeth
+
+-NAME OrderByEmptyResult
+-QUERY MATCH (p:person) WHERE p.age > 100 RETURN p.age ORDER BY p.age 
+---- 0


### PR DESCRIPTION
1. If the sortedKeyBlocks is empty (meaning there is no tuples in resultSet and numSortedKeyBlocks=0), the `isDoneMerge()` will always return false. Thus, it causes an infinite loop in orderByMerge.
2. Fixes the orderByScan. If the mergedKeyBlock is null, it shouldn't init the scanState for mergedKeyBlock.