### PR TITLE
fix explain issue #909

### DIFF
--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -304,10 +304,6 @@ std::unique_ptr<QueryResult> Connection::executeAndAutoCommitIfNecessaryNoLock(
         queryResult->querySummary = move(preparedStatement->querySummary);
         return queryResult;
     }
-    // NOTE: If EXPLAIN is enabled, we still need to init physical plan to register profiler because
-    // our plan printer will try to read from profiler metrics regardless whether it's enabled or
-    // not. A better solution could be that we don't print any metric during EXPLAIN.
-    preparedStatement->physicalPlan->lastOperator->init(executionContext.get());
     preparedStatement->createPlanPrinter(move(profiler));
     queryResult->querySummary = move(preparedStatement->querySummary);
     return queryResult;

--- a/src/processor/operator/order_by/order_by_scan.cpp
+++ b/src/processor/operator/order_by/order_by_scan.cpp
@@ -91,6 +91,7 @@ void OrderByScan::initMergedKeyBlockScanStateIfNecessary() {
         return;
     }
     mergedKeyBlockScanState = make_unique<MergedKeyBlockScanState>();
+    mergedKeyBlockScanState->nextTupleIdxToReadInMergedKeyBlock = 0;
     mergedKeyBlockScanState->mergedKeyBlock = sharedState->sortedKeyBlocks->front();
     mergedKeyBlockScanState->tupleIdxAndFactorizedTableIdxOffset =
         mergedKeyBlockScanState->mergedKeyBlock->getNumBytesPerTuple() - 8;

--- a/src/storage/store/include/table_statistics.h
+++ b/src/storage/store/include/table_statistics.h
@@ -20,6 +20,9 @@ class TableStatistics {
 
 public:
     TableStatistics() = default;
+
+    virtual ~TableStatistics() = default;
+
     explicit TableStatistics(uint64_t numTuples) : numTuples{numTuples} {
         assert(numTuples != UINT64_MAX);
     }
@@ -50,6 +53,8 @@ class TablesStatistics {
 public:
     TablesStatistics();
 
+    virtual ~TablesStatistics() = default;
+
     inline void writeTablesStatisticsFileForWALRecord(const string& directory) {
         saveToFile(directory, DBFileType::WAL_VERSION, TransactionType::WRITE);
     }
@@ -73,8 +78,6 @@ public:
     inline void removeTableStatistic(table_id_t tableID) {
         tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable.erase(tableID);
     }
-
-    virtual ~TablesStatistics() = default;
 
 protected:
     virtual inline string getTableTypeForPrinting() const = 0;

--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -119,3 +119,18 @@ TEST_F(ApiTest, BeginningMultipleTransactionErrors) {
         FAIL();
     } catch (ConnectionException& e) {}
 }
+
+// These two tests are designed to make sure that the explain and profile statements don't create a
+// segmentation fault.
+TEST_F(ApiTest, Explain) {
+    auto result = conn->query("EXPLAIN MATCH (a:person)-[:knows]->(b:person), "
+                              "(b)-[:knows]->(a) RETURN a.fName, b.fName ORDER BY a.ID");
+    ASSERT_TRUE(result->isSuccess());
+}
+
+TEST_F(ApiTest, Profile) {
+    auto result =
+        conn->query("EXPLAIN MATCH (a:person) WHERE EXISTS { MATCH (a)-[:knows]->(b:person) WHERE "
+                    "b.fName='Farooq' } RETURN a.ID, min(a.age)");
+    ASSERT_TRUE(result->isSuccess());
+}


### PR DESCRIPTION
This PR fixes the bug in explain #909 
The reason for this bug is that:
```
    preparedStatement->physicalPlan->lastOperator->init(executionContext.get());
````
We are trying to call `init` on a pipeline which is not cut properly and the dependency between operators are also not set correctly.
