### PR TITLE
read list-column fix

### DIFF
--- a/src/storage/index/hash_index_utils.cpp
+++ b/src/storage/index/hash_index_utils.cpp
@@ -98,7 +98,8 @@ bool HashIndexUtils::equalsFuncForString(
     const uint8_t* keyToLookup, const uint8_t* keyInEntry, DiskOverflowFile* diskOverflowFile) {
     auto keyInEntryString = (gf_string_t*)keyInEntry;
     if (isStringPrefixAndLenEquals(keyToLookup, keyInEntryString)) {
-        auto entryKeyString = diskOverflowFile->readString(*keyInEntryString);
+        auto entryKeyString = diskOverflowFile->readString(
+            Transaction::getDummyReadOnlyTrx().get(), *keyInEntryString);
         return memcmp(keyToLookup, entryKeyString.c_str(), entryKeyString.length()) == 0;
     }
     return false;

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -171,7 +171,7 @@ Literal StringPropertyColumn::readValue(node_offset_t offset) {
     auto frame = bufferManager.pin(fileHandle, cursor.pageIdx);
     memcpy(&gfString, frame + mapElementPosToByteOffset(cursor.elemPosInPage), sizeof(gf_string_t));
     bufferManager.unpin(fileHandle, cursor.pageIdx);
-    return Literal(diskOverflowFile.readString(gfString));
+    return Literal(diskOverflowFile.readString(Transaction::getDummyReadOnlyTrx().get(), gfString));
 }
 
 void ListPropertyColumn::writeValueForSingleNodeIDPosition(node_offset_t nodeOffset,
@@ -197,7 +197,9 @@ Literal ListPropertyColumn::readValue(node_offset_t offset) {
     auto frame = bufferManager.pin(fileHandle, cursor.pageIdx);
     memcpy(&gfList, frame + mapElementPosToByteOffset(cursor.elemPosInPage), sizeof(gf_list_t));
     bufferManager.unpin(fileHandle, cursor.pageIdx);
-    return Literal(diskOverflowFile.readList(gfList, dataType), dataType);
+    return Literal(
+        diskOverflowFile.readList(Transaction::getDummyReadOnlyTrx().get(), gfList, dataType),
+        dataType);
 }
 
 } // namespace storage

--- a/src/storage/storage_structure/include/column.h
+++ b/src/storage/storage_structure/include/column.h
@@ -153,12 +153,12 @@ private:
     inline void scan(Transaction* transaction, const shared_ptr<ValueVector>& resultVector,
         PageElementCursor& cursor) override {
         Column::scan(transaction, resultVector, cursor);
-        diskOverflowFile.readListsToVector(*resultVector);
+        diskOverflowFile.readListsToVector(transaction, *resultVector);
     }
     inline void scanWithSelState(Transaction* transaction,
         const shared_ptr<ValueVector>& resultVector, PageElementCursor& cursor) override {
         Column::scanWithSelState(transaction, resultVector, cursor);
-        diskOverflowFile.readListsToVector(*resultVector);
+        diskOverflowFile.readListsToVector(transaction, *resultVector);
     }
 };
 

--- a/src/storage/storage_structure/lists/lists.cpp
+++ b/src/storage/storage_structure/lists/lists.cpp
@@ -199,25 +199,25 @@ ListsWithAdjAndPropertyListsUpdateStore::getInMemListWithDataFromUpdateStoreOnly
 void StringPropertyLists::readFromLargeList(
     const shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
     ListsWithAdjAndPropertyListsUpdateStore::readFromLargeList(valueVector, listHandle);
-    diskOverflowFile.readStringsToVector(*valueVector);
+    diskOverflowFile.readStringsToVector(Transaction::getDummyReadOnlyTrx().get(), *valueVector);
 }
 
 void StringPropertyLists::readFromSmallList(
     const shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
     ListsWithAdjAndPropertyListsUpdateStore::readFromSmallList(valueVector, listHandle);
-    diskOverflowFile.readStringsToVector(*valueVector);
+    diskOverflowFile.readStringsToVector(Transaction::getDummyReadOnlyTrx().get(), *valueVector);
 }
 
 void ListPropertyLists::readFromLargeList(
     const shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
     ListsWithAdjAndPropertyListsUpdateStore::readFromLargeList(valueVector, listHandle);
-    diskOverflowFile.readListsToVector(*valueVector);
+    diskOverflowFile.readListsToVector(Transaction::getDummyReadOnlyTrx().get(), *valueVector);
 }
 
 void ListPropertyLists::readFromSmallList(
     const shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
     ListsWithAdjAndPropertyListsUpdateStore::readFromSmallList(valueVector, listHandle);
-    diskOverflowFile.readListsToVector(*valueVector);
+    diskOverflowFile.readListsToVector(Transaction::getDummyReadOnlyTrx().get(), *valueVector);
 }
 
 void AdjLists::readValues(const shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {

--- a/src/storage/storage_structure/lists/unstructured_property_lists.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists.cpp
@@ -177,8 +177,8 @@ unique_ptr<map<uint32_t, Literal>> UnstructuredPropertyLists::readUnstructuredPr
         numBytesRead += dataTypeSize;
         Literal propertyValueAsLiteral;
         if (STRING == propertyKeyDataType.dataTypeID) {
-            propertyValueAsLiteral =
-                Literal(diskOverflowFile.readString(unstrPropertyValue.val.strVal));
+            propertyValueAsLiteral = Literal(diskOverflowFile.readString(
+                Transaction::getDummyReadOnlyTrx().get(), unstrPropertyValue.val.strVal));
         } else {
             propertyValueAsLiteral = Literal(
                 (uint8_t*)&unstrPropertyValue.val, DataType(propertyKeyDataType.dataTypeID));

--- a/test/runner/e2e_update_test.cpp
+++ b/test/runner/e2e_update_test.cpp
@@ -262,12 +262,17 @@ TEST_F(TinySnbUpdateTest, InsertNodeWithStringTest) {
 }
 
 TEST_F(TinySnbUpdateTest, InsertNodeWithListTest) {
+    auto groundTruth = vector<string>{"10|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]",
+        "11|[1,2,3]|[A,this is a long name]", "9|[1]|[Grad]"};
+    conn->beginWriteTransaction();
     conn->query(
         "CREATE (:person {ID:11, workedHours:[1,2,3], usedNames:['A', 'this is a long name']});");
     auto result = conn->query("MATCH (a:person) WHERE a.ID > 8 "
                               "RETURN a.ID, a.workedHours,a.usedNames");
-    auto groundTruth = vector<string>{"10|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]",
-        "11|[1,2,3]|[A,this is a long name]", "9|[1]|[Grad]"};
+    ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
+    conn->commit();
+    result = conn->query("MATCH (a:person) WHERE a.ID > 8 "
+                         "RETURN a.ID, a.workedHours,a.usedNames");
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
 }
 


### PR DESCRIPTION
This PR fixes issue #897.
Reason for this bug:
We don't pass in the transaction to `DiskOverflowFile::readListToVector`, so we are always reading from the original version of the overflowFile. That is to say, a write transaction can't see its updates to listColumns before committing.
Fixes:
Simply pass the transaction to  `DiskOverflowFile::readListToVector`, and read the wal/original version of the overflowPages based on the transactionType.