### PR TITLE
Linux precompile fix

### DIFF
--- a/scripts/pre-compiled-bins/pre_compile.py
+++ b/scripts/pre-compiled-bins/pre_compile.py
@@ -24,7 +24,8 @@ def cleanup():
 
 
 def build():
-    args = ['--cxxopt=-std=c++2a', '--cxxopt=-O3', '--cxxopt=-fPIC', '--cxxopt=-DNDEBUG']
+    args = ['--cxxopt=-std=c++2a', '--cxxopt=-O3', '--cxxopt=-fPIC',
+            '--cxxopt=-DNDEBUG', '--cxxopt=-D_GLIBCXX_USE_CXX11_ABI=1']
     if sys.platform == 'darwin':
         archflags = os.getenv("ARCHFLAGS", "")
         if len(archflags) > 0:


### PR DESCRIPTION
This PR fixes some compatibility issues with pre-compiled Linux. The pipeline has been tested on https://github.com/graphflowdb/graphflowdb/actions/runs/3412758225

The precompiled bins has been verified on various Linux distros. The results are at: https://docs.google.com/spreadsheets/d/13A3MA3IsBJB_CJBSMqWFktIzyb6unJqH0-3njDycDpQ/edit?usp=sharing