### PR TITLE
add better casting error message for timestamp and date

### DIFF
--- a/src/common/types/date_t.cpp
+++ b/src/common/types/date_t.cpp
@@ -179,7 +179,7 @@ date_t Date::FromDate(int32_t year, int32_t month, int32_t day) {
     int32_t n = 0;
     if (!Date::IsValid(year, month, day)) {
         throw ConversionException(
-            StringUtils::string_format("Date out of range: %d-%d-%d", year, month, day));
+            StringUtils::string_format("Date out of range: %d-%d-%d.", year, month, day));
     }
     while (year < 1970) {
         year += Date::YEAR_INTERVAL;
@@ -295,8 +295,8 @@ date_t Date::FromCString(const char* buf, uint64_t len) {
     date_t result;
     uint64_t pos;
     if (!TryConvertDate(buf, len, pos, result)) {
-        throw ConversionException(
-            "date string " + string(buf, len) + " is not in expected format of (YYYY-MM-DD)");
+        throw ConversionException("Error occurred during parsing date. Given: \"" +
+                                  string(buf, len) + "\". Expected format: (YYYY-MM-DD)");
     }
     return result;
 }

--- a/src/common/types/dtime_t.cpp
+++ b/src/common/types/dtime_t.cpp
@@ -91,10 +91,9 @@ dtime_t Time::FromCString(const char* buf, uint64_t len) {
     dtime_t result;
     uint64_t pos;
     if (!Time::TryConvertTime(buf, len, pos, result)) {
-        throw ConversionException(
-            StringUtils::string_format("time field value out of range: \"%s\", "
-                                       "expected format is ([YYY-MM-DD ]HH:MM:SS[.MS])",
-                buf));
+        throw ConversionException(StringUtils::string_format(
+            "Error occurred during parsing time. Given: \"" + string(buf, len) +
+            "\". Expected format: (hh:mm:ss[.zzzzzz])."));
     }
     return result;
 }
@@ -121,7 +120,7 @@ bool Time::IsValid(int32_t hour, int32_t minute, int32_t second, int32_t microse
 dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
     if (!Time::IsValid(hour, minute, second, microseconds)) {
         throw ConversionException(StringUtils::string_format(
-            "time field value out of range: %d:%d:%d[.%d]", hour, minute, second, microseconds));
+            "Time field value out of range: %d:%d:%d[.%d].", hour, minute, second, microseconds));
     }
     int64_t result;
     result = hour;                                             // hours

--- a/src/common/types/include/timestamp_t.h
+++ b/src/common/types/include/timestamp_t.h
@@ -85,6 +85,12 @@ public:
 
     static bool TryParseUTCOffset(
         const char* str, uint64_t& pos, uint64_t len, int& hour_offset, int& minute_offset);
+
+private:
+    static string getTimestampConversionExceptionMsg(const char* str, uint64_t len) {
+        return "Error occurred during parsing timestamp. Given: \"" + string(str, len) +
+               "\". Expected format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])";
+    }
 };
 
 } // namespace common

--- a/src/common/types/interval_t.cpp
+++ b/src/common/types/interval_t.cpp
@@ -68,7 +68,7 @@ void Interval::addition(interval_t& result, uint64_t number, string specifierStr
                specifierStr == "us") {
         result.micros += number;
     } else {
-        throw ConversionException("Unrecognized interval specifier string: " + specifierStr);
+        throw ConversionException("Unrecognized interval specifier string: " + specifierStr + ".");
     }
 }
 
@@ -83,7 +83,7 @@ void Interval::parseIntervalField(string buf, uint64_t& pos, uint64_t len, inter
         pos++;
     }
     if (pos == len) {
-        throw ConversionException(buf + " is not in a correct format");
+        throw ConversionException("Error occurred during parsing interval. Field name is missing.");
     }
     // Parse intervalPartSpecifier (eg. hours, dates, minutes)
     uint64_t spacePos = string(buf).find(' ', pos);
@@ -111,7 +111,8 @@ interval_t Interval::FromCString(const char* gf_str, uint64_t len) {
         if (isdigit(str[pos])) {
             parseIntervalField(str, pos, len, result);
         } else if (!isspace(str[pos])) {
-            throw ConversionException(str + " is not in a correct format");
+            throw ConversionException(
+                "Error occurred during parsing interval. Given: \"" + str + "\".");
         }
         pos++;
     }

--- a/src/common/types/timestamp_t.cpp
+++ b/src/common/types/timestamp_t.cpp
@@ -64,9 +64,7 @@ timestamp_t Timestamp::FromCString(const char* str, uint64_t len) {
     }
 
     if (!Date::TryConvertDate(str, dateStrLen, pos, date)) {
-        throw ConversionException("Error occurred during parsing time Given: \"" +
-                                  string(str, len) +
-                                  "\"Expected Format: (YYYY-MM-DD HH:MM:SS[.MS][+/-HH:MM])");
+        throw ConversionException(getTimestampConversionExceptionMsg(str, len));
     }
     if (pos == len) {
         // no time: only a date
@@ -79,9 +77,7 @@ timestamp_t Timestamp::FromCString(const char* str, uint64_t len) {
     }
     uint64_t time_pos = 0;
     if (!Time::TryConvertTime(str + pos, len - pos, time_pos, time)) {
-        throw ConversionException("Error occurred during parsing time Given: \"" +
-                                  string(str, len) +
-                                  "\"Expected Format: (YYYY-MM-DD HH:MM:SS[.MS][+/-HH:MM])");
+        throw ConversionException(getTimestampConversionExceptionMsg(str, len));
     }
     pos += time_pos;
     result = FromDatetime(date, time);
@@ -100,7 +96,7 @@ timestamp_t Timestamp::FromCString(const char* str, uint64_t len) {
             pos++;
         }
         if (pos < len) {
-            throw ConversionException(string(str, len));
+            throw ConversionException(getTimestampConversionExceptionMsg(str, len));
         }
     }
     return result;

--- a/test/common/date_test.cpp
+++ b/test/common/date_test.cpp
@@ -2,7 +2,6 @@
 
 #include "include/gtest/gtest.h"
 
-#include "src/common/include/exception.h"
 #include "src/common/types/include/types_include.h"
 
 using namespace graphflow::common;
@@ -11,30 +10,6 @@ using namespace std;
 TEST(DateTests, IsLeapYearTest) {
     EXPECT_TRUE(Date::IsLeapYear(2000));
     EXPECT_FALSE(Date::IsLeapYear(2001));
-}
-
-TEST(DateTests, FromDate) {
-    // Year out of range
-    try {
-        Date::FromDate(110000, 11, 42);
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-    // Month out of range
-    try {
-        Date::FromDate(2000, 15, 22);
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-    // Day out of range
-    try {
-        Date::FromDate(2000, 11, 42);
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
-    EXPECT_EQ(0, Date::FromDate(1970, 1, 1).days);
-    EXPECT_EQ(7, Date::FromDate(1970, 1, 8).days);
-    EXPECT_EQ(-12, Date::FromDate(1969, 12, 20).days);
 }
 
 TEST(DateTests, FromDateConvertGivesSame) {

--- a/test/common/interval_test.cpp
+++ b/test/common/interval_test.cpp
@@ -2,66 +2,23 @@
 
 #include "include/gtest/gtest.h"
 
-#include "src/common/include/exception.h"
 #include "src/common/types/include/types_include.h"
 
 using namespace graphflow::common;
 using namespace std;
 
 TEST(IntervalTests, FromCString) {
-    // missing the specifier string (eg. days, minutes...)
-    try {
-        Interval::FromCString("3 years 2 months 45", strlen("3 years 2 months 45"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
-    // missing the number before the specifier string
-    try {
-        Interval::FromCString(
-            "20 years 30 months 20 days minutes", strlen("20 years 30 months 20 days minutes"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
-    // numbers and specifier string must be separated by spaces
-    try {
-        Interval::FromCString(
-            "2 years 30 minutes20 seconds", strlen("2 years 30 minutes20 seconds"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
-    // unrecognized specifier string (millseconds)
-    try {
-        Interval::FromCString("10 years 2 days 48 hours 28 seconds 12 millseconds",
-            strlen("10 years 2 days 48 hours 28 seconds 12 millseconds"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
-    // multiple specifier strings
-    try {
-        Interval::FromCString("10 years 2 days 48 hours 28 seconds microseconds",
-            strlen("10 years 2 days 48 hours 28 seconds microseconds"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
     interval_t result;
-
     result = Interval::FromCString("2 years 4 months 21 days 3 hours 4 minutes 28 us",
         strlen("2 years 4 months 21 days 3 hours 4 minutes 28 us"));
     EXPECT_EQ(result.months, 28);
     EXPECT_EQ(result.days, 21);
     EXPECT_EQ(result.micros, 11040000028);
-
     result = Interval::FromCString(
         "32 days 48 hours 12 minutes 280 us", strlen("32 days 48 hours 12 minutes 280 us"));
     EXPECT_EQ(result.months, 0);
     EXPECT_EQ(result.days, 32);
     EXPECT_EQ(result.micros, 173520000280);
-
     result = Interval::FromCString(
         "3 years 32 days     2 years 48 hours 12 minutes 280 us 52 days 32 months 20 minutes",
         strlen(

--- a/test/common/time_test.cpp
+++ b/test/common/time_test.cpp
@@ -14,6 +14,7 @@ TEST(TimeTests, FromTime) {
         Time::FromTime(25, 24, 32, 231321);
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Time field value out of range: 25:24:32[.231321].");
     } catch (exception& e) { FAIL(); }
 
     // Minute out of range
@@ -21,6 +22,7 @@ TEST(TimeTests, FromTime) {
         Time::FromTime(21, 60, 22, 212322);
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Time field value out of range: 21:60:22[.212322].");
     } catch (exception& e) { FAIL(); }
 
     // Second out of range
@@ -28,6 +30,7 @@ TEST(TimeTests, FromTime) {
         Time::FromTime(14, 22, 61);
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Time field value out of range: 14:22:61[.0].");
     } catch (exception& e) { FAIL(); }
 
     // Microsecond out of range
@@ -35,6 +38,7 @@ TEST(TimeTests, FromTime) {
         Time::FromTime(14, 22, 42, 1000001);
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Time field value out of range: 14:22:42[.1000001].");
     } catch (exception& e) { FAIL(); }
 
     EXPECT_EQ(80052000000, Time::FromTime(22, 14, 12).micros);
@@ -47,6 +51,8 @@ TEST(TimeTests, FromCString) {
         Time::FromCString("25:12:00", strlen("25:12:00"));
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Error occurred during parsing time. Given: \"25:12:00\". Expected "
+                               "format: (hh:mm:ss[.zzzzzz]).");
     } catch (exception& e) { FAIL(); }
     EXPECT_EQ(83531000000, Time::FromCString("23:12:11", strlen("23:12:11")).micros);
     EXPECT_EQ(46792122311, Time::FromCString("12:59:52.122311", strlen("12:59:52.122311")).micros);

--- a/test/common/timestamp_test.cpp
+++ b/test/common/timestamp_test.cpp
@@ -14,6 +14,7 @@ TEST(TimestampTests, FromDatetime) {
         Timestamp::FromDatetime(Date::FromDate(1968, 12, 42), Time::FromTime(21, 32, 51));
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Date out of range: 1968-12-42.");
     } catch (exception& e) { FAIL(); }
 
     // 2021 is not a leap year, February only has 28 days.
@@ -21,6 +22,7 @@ TEST(TimestampTests, FromDatetime) {
         Timestamp::FromDatetime(Date::FromDate(2021, 2, 29), Time::FromTime(21, 32, 51));
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Date out of range: 2021-2-29.");
     } catch (exception& e) { FAIL(); }
 
     // hour is out of range
@@ -28,6 +30,7 @@ TEST(TimestampTests, FromDatetime) {
         Timestamp::FromDatetime(Date::FromDate(1968, 12, 22), Time::FromTime(25, 32, 51));
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Time field value out of range: 25:32:51[.0].");
     } catch (exception& e) { FAIL(); }
 
     // second is out of range
@@ -35,6 +38,7 @@ TEST(TimestampTests, FromDatetime) {
         Timestamp::FromDatetime(Date::FromDate(2021, 2, 28), Time::FromTime(5, 52, 70));
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Time field value out of range: 5:52:70[.0].");
     } catch (exception& e) { FAIL(); }
 
     // microsecond is out of rarnge
@@ -42,6 +46,7 @@ TEST(TimestampTests, FromDatetime) {
         Timestamp::FromDatetime(Date::FromDate(2021, 2, 28), Time::FromTime(5, 52, 42, 1000002));
         FAIL();
     } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Time field value out of range: 5:52:42[.1000002].");
     } catch (exception& e) { FAIL(); }
 
     EXPECT_EQ(
@@ -68,27 +73,6 @@ TEST(TimestampTests, Convert) {
 }
 
 TEST(TimestampTests, FromCString) {
-    try {
-        // missing day
-        Timestamp::FromCString("2112-08 08:21:23.005612", strlen("2112-08 08:21:23.005612"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
-    try {
-        // missing second
-        Timestamp::FromCString("2112-08-04 08:23.005612", strlen("2112-08-04 08:23.005612"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
-    try {
-        // missing a digit in day
-        Timestamp::FromCString("2112-08-0", strlen("2112-08-0"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-
     EXPECT_EQ(
         Timestamp::FromCString("2112-08-21 08:21:23.005612", strlen("2112-08-21 08:21:23.005612"))
             .value,
@@ -125,33 +109,6 @@ TEST(TimestampTests, FromCString) {
         Timestamp::FromCString("1992-04-28T09:22:56-06:30", strlen("1992-04-28T09:22:56-06:30"))
             .value,
         704476376000000);
-    try {
-        // Invalid timezone format.
-        Timestamp::FromCString("1992-04-28T09:33:56-XX:DD", strlen("1992-04-28T09:33:56-XX:DD"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-    try {
-        // Missing +/- sign.
-        Timestamp::FromCString(
-            "2112-08-21 08:21:23.005612Z02:00", strlen("2112-08-21 08:21:23.005612Z02:00"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-    try {
-        // Incorrect timezone minutes.
-        Timestamp::FromCString(
-            "2112-08-21 08:21:23.005612Z+02:100", strlen("2112-08-21 08:21:23.005612Z+02:100"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
-    try {
-        // Incorrect timezone hours.
-        Timestamp::FromCString(
-            "2112-08-21 08:21:23.005612Z+021", strlen("2112-08-21 08:21:23.005612Z+021"));
-        FAIL();
-    } catch (ConversionException& e) {
-    } catch (exception& e) { FAIL(); }
 }
 
 TEST(TimestampTests, toString) {

--- a/test/runner/e2e_exception_test.cpp
+++ b/test/runner/e2e_exception_test.cpp
@@ -39,3 +39,77 @@ TEST_F(TinySnbExceptionTest, DeleteNodeWithEdgeErrorTest) {
     auto result = conn->query("MATCH (a:person) WHERE a.ID = 0 DELETE a");
     ASSERT_FALSE(result->isSuccess());
 }
+
+TEST_F(TinySnbExceptionTest, CastStrToTimestampError) {
+    // Missing day.
+    auto result = conn->query("MATCH (a:person) return timestamp(\"2112-08 08:21:23.005612\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing timestamp. Given: \"2112-08 08:21:23.005612\". Expected "
+        "format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])");
+
+    // Missing second.
+    result = conn->query("MATCH (a:person) return timestamp(\"2112-08-04 08:23.005612\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing timestamp. Given: \"2112-08-04 08:23.005612\". Expected "
+        "format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])");
+
+    // Missing a digit in day.
+    result = conn->query("MATCH (a:person) return timestamp(\"2112-08-0\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(), "Date out of range: 2112-8-0.");
+
+    // Invalid timezone format.
+    result = conn->query("MATCH (a:person) return timestamp(\"1992-04-28T09:33:56-XX:DD\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing timestamp. Given: \"1992-04-28T09:33:56-XX:DD\". Expected "
+        "format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])");
+
+    // Missing +/- sign.
+    result = conn->query("MATCH (a:person) return timestamp(\"2112-08-21 08:21:23.005612Z02:00\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing timestamp. Given: \"2112-08-21 08:21:23.005612Z02:00\". "
+        "Expected format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])");
+
+    // Incorrect timezone minutes.
+    result =
+        conn->query("MATCH (a:person) return timestamp(\"2112-08-21 08:21:23.005612Z+02:100\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing timestamp. Given: \"2112-08-21 08:21:23.005612Z+02:100\". "
+        "Expected format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])");
+
+    // Incorrect timezone hours.
+    result = conn->query("MATCH (a:person) return timestamp(\"2112-08-21 08:21:23.005612Z+021\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing timestamp. Given: \"2112-08-21 08:21:23.005612Z+021\". "
+        "Expected format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])");
+}
+
+TEST_F(TinySnbExceptionTest, CastStrToIntervalError) {
+    // Missing the specifier string (eg. days, minutes...).
+    auto result = conn->query("MATCH (a:person) return interval(\"3 years 2 months 45\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing interval. Field name is missing.");
+
+    // Missing the number before the specifier string.
+    result =
+        conn->query("MATCH (a:person) return interval(\"20 years 30 months 20 days minutes\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing interval. Given: \"20 years 30 months 20 days minutes\".");
+
+    // Numbers and specifier string are not separated by spaces.
+    result = conn->query("MATCH (a:person) return interval(\"2 years 30 minutes20 seconds\")");
+    ASSERT_STREQ(
+        result->getErrorMessage().c_str(), "Unrecognized interval specifier string: minutes20.");
+
+    // Unrecognized specifier string (millseconds).
+    result = conn->query(
+        "MATCH (a:person) return interval(\"10 years 2 days 48 hours 28 seconds 12 millseconds\")");
+    ASSERT_STREQ(
+        result->getErrorMessage().c_str(), "Unrecognized interval specifier string: millseconds.");
+
+    // Multiple specifier strings.
+    result = conn->query(
+        "MATCH (a:person) return interval(\"10 years 2 days 48 hours 28 seconds microseconds\")");
+    ASSERT_STREQ(result->getErrorMessage().c_str(),
+        "Error occurred during parsing interval. Given: \"10 "
+        "years 2 days 48 hours 28 seconds microseconds\".");
+}


### PR DESCRIPTION
This PR improves the error messages for invalid casting from string to date/timestamp. Solves #927 
For example: 
```
graphflowdb> UNWIND [timestamp("1992-09-20 11:30:00 2")] as x RETURN x;
Error: Error occurred during parsing timestamp. Given: "1992-09-20 11:30:00 2". Expected format: (YYYY-MM-DD hh:mm:ss[.zzzzzz][+-TT[:tt]])
```
