### PR TITLE
fix function ordering in codebase

### DIFF
--- a/src/common/include/expression_type.h
+++ b/src/common/include/expression_type.h
@@ -66,79 +66,89 @@ const string GREATER_THAN_EQUALS_FUNC_NAME = "GREATER_THAN_EQUALS";
 const string LESS_THAN_FUNC_NAME = "LESS_THAN";
 const string LESS_THAN_EQUALS_FUNC_NAME = "LESS_THAN_EQUALS";
 
-// arithmetics
+// arithmetics operators
 const string ADD_FUNC_NAME = "+";
 const string SUBTRACT_FUNC_NAME = "-";
 const string MULTIPLY_FUNC_NAME = "*";
 const string DIVIDE_FUNC_NAME = "/";
 const string MODULO_FUNC_NAME = "%";
 const string POWER_FUNC_NAME = "^";
-const string NEGATE_FUNC_NAME = "NEGATE";
+
+// arithmetics functions
 const string ABS_FUNC_NAME = "ABS";
-const string FLOOR_FUNC_NAME = "FLOOR";
+const string ACOS_FUNC_NAME = "ACOS";
+const string ASIN_FUNC_NAME = "ASIN";
+const string ATAN_FUNC_NAME = "ATAN";
+const string ATAN2_FUNC_NAME = "ATAN2";
+const string BITWISE_XOR_FUNC_NAME = "BITWISE_XOR";
+const string CBRT_FUNC_NAME = "CBRT";
 const string CEIL_FUNC_NAME = "CEIL";
 const string CEILING_FUNC_NAME = "CEILING";
-const string SIN_FUNC_NAME = "SIN";
 const string COS_FUNC_NAME = "COS";
-const string TAN_FUNC_NAME = "TAN";
 const string COT_FUNC_NAME = "COT";
-const string ASIN_FUNC_NAME = "ASIN";
-const string ACOS_FUNC_NAME = "ACOS";
-const string ATAN_FUNC_NAME = "ATAN";
+const string DEGREES_FUNC_NAME = "DEGREES";
 const string EVEN_FUNC_NAME = "EVEN";
 const string FACTORIAL_FUNC_NAME = "FACTORIAL";
-const string SIGN_FUNC_NAME = "SIGN";
-const string SQRT_FUNC_NAME = "SQRT";
-const string CBRT_FUNC_NAME = "CBRT";
+const string FLOOR_FUNC_NAME = "FLOOR";
 const string GAMMA_FUNC_NAME = "GAMMA";
 const string LGAMMA_FUNC_NAME = "LGAMMA";
 const string LN_FUNC_NAME = "LN";
 const string LOG_FUNC_NAME = "LOG";
 const string LOG2_FUNC_NAME = "LOG2";
-const string DEGREES_FUNC_NAME = "DEGREES";
-const string RADIANS_FUNC_NAME = "RADIANS";
-const string ATAN2_FUNC_NAME = "ATAN2";
-const string ROUND_FUNC_NAME = "ROUND";
-const string BITWISE_XOR_FUNC_NAME = "BITWISE_XOR";
+const string LOG10_FUNC_NAME = "LOG10";
+const string NEGATE_FUNC_NAME = "NEGATE";
 const string PI_FUNC_NAME = "PI";
+const string POW_FUNC_NAME = "POW";
+const string RADIANS_FUNC_NAME = "RADIANS";
+const string ROUND_FUNC_NAME = "ROUND";
+const string SIN_FUNC_NAME = "SIN";
+const string SIGN_FUNC_NAME = "SIGN";
+const string SQRT_FUNC_NAME = "SQRT";
+const string TAN_FUNC_NAME = "TAN";
 
 // string
+const string ARRAY_EXTRACT_FUNC_NAME = "ARRAY_EXTRACT";
 const string CONCAT_FUNC_NAME = "CONCAT";
 const string CONTAINS_FUNC_NAME = "CONTAINS";
-const string STARTS_WITH_FUNC_NAME = "STARTS_WITH";
 const string ENDS_WITH_FUNC_NAME = "ENDS_WITH";
-const string LOWER_FUNC_NAME = "LOWER";
-const string UPPER_FUNC_NAME = "UPPER";
-const string TRIM_FUNC_NAME = "TRIM";
-const string LTRIM_FUNC_NAME = "LTRIM";
-const string RTRIM_FUNC_NAME = "RTRIM";
+const string LCASE_FUNC_NAME = "LCASE";
+const string LEFT_FUNC_NAME = "LEFT";
 const string LENGTH_FUNC_NAME = "LENGTH";
+const string LOWER_FUNC_NAME = "LOWER";
+const string LPAD_FUNC_NAME = "LPAD";
+const string LTRIM_FUNC_NAME = "LTRIM";
+const string PREFIX_FUNC_NAME = "PREFIX";
 const string REPEAT_FUNC_NAME = "REPEAT";
 const string REVERSE_FUNC_NAME = "REVERSE";
-const string LPAD_FUNC_NAME = "LPAD";
-const string RPAD_FUNC_NAME = "RPAD";
-const string SUBSTRING_FUNC_NAME = "SUBSTRING";
-const string SUBSTR_FUNC_NAME = "SUBSTR";
-const string LEFT_FUNC_NAME = "LEFT";
 const string RIGHT_FUNC_NAME = "RIGHT";
-const string ARRAY_EXTRACT_FUNC_NAME = "ARRAY_EXTRACT";
-const string UCASE_FUNC_NAME = "UCASE";
-const string PREFIX_FUNC_NAME = "PREFIX";
+const string RPAD_FUNC_NAME = "RPAD";
+const string RTRIM_FUNC_NAME = "RTRIM";
+const string STARTS_WITH_FUNC_NAME = "STARTS_WITH";
+const string SUBSTR_FUNC_NAME = "SUBSTR";
+const string SUBSTRING_FUNC_NAME = "SUBSTRING";
 const string SUFFIX_FUNC_NAME = "SUFFIX";
+const string TRIM_FUNC_NAME = "TRIM";
+const string UCASE_FUNC_NAME = "UCASE";
+const string UPPER_FUNC_NAME = "UPPER";
 
 // Date functions.
-const string DAYNAME_FUNC_NAME = "DAYNAME";
-const string MONTHNAME_FUNC_NAME = "MONTHNAME";
-const string LAST_DAY_FUNC_NAME = "LAST_DAY";
 const string DATE_PART_FUNC_NAME = "DATE_PART";
 const string DATEPART_FUNC_NAME = "DATEPART";
 const string DATE_TRUNC_FUNC_NAME = "DATE_TRUNC";
 const string DATETRUNC_FUNC_NAME = "DATETRUNC";
+const string DAYNAME_FUNC_NAME = "DAYNAME";
 const string GREATEST_FUNC_NAME = "GREATEST";
+const string LAST_DAY_FUNC_NAME = "LAST_DAY";
 const string LEAST_FUNC_NAME = "LEAST";
+const string MAKE_DATE_FUNC_NAME = "MAKE_DATE";
+const string MONTHNAME_FUNC_NAME = "MONTHNAME";
+
+// Timestamp functions.
 const string CENTURY_FUNC_NAME = "CENTURY";
 const string EPOCH_MS_FUNC_NAME = "EPOCH_MS";
 const string TO_TIMESTAMP_FUNC_NAME = "TO_TIMESTAMP";
+
+// Interval functions.
 const string TO_YEARS_FUNC_NAME = "TO_YEARS";
 const string TO_MONTHS_FUNC_NAME = "TO_MONTHS";
 const string TO_DAYS_FUNC_NAME = "TO_DAYS";
@@ -147,7 +157,6 @@ const string TO_MINUTES_FUNC_NAME = "TO_MINUTES";
 const string TO_SECONDS_FUNC_NAME = "TO_SECONDS";
 const string TO_MILLISECONDS_FUNC_NAME = "TO_MILLISECONDS";
 const string TO_MICROSECONDS_FUNC_NAME = "TO_MICROSECONDS";
-const string MAKE_DATE_FUNC_NAME = "MAKE_DATE";
 
 const string ID_FUNC_NAME = "ID";
 

--- a/src/function/arithmetic/include/vector_arithmetic_operations.h
+++ b/src/function/arithmetic/include/vector_arithmetic_operations.h
@@ -123,39 +123,7 @@ struct PowerVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct NegateVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
 struct AbsVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct FloorVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct CeilVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct SinVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct CosVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct TanVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct CotVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct AsinVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -163,7 +131,43 @@ struct AcosVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
+struct AsinVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
 struct AtanVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct Atan2VectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct BitwiseXorVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct CbrtVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct CeilVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct CosVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct CotVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct DegreesVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct EvenVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -171,11 +175,7 @@ struct FactorialVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct SqrtVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct CbrtVectorOperation : public VectorArithmeticOperations {
+struct FloorVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -199,7 +199,11 @@ struct Log2VectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct DegreesVectorOperation : public VectorArithmeticOperations {
+struct NegateVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct PiVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -207,7 +211,11 @@ struct RadiansVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct EvenVectorOperation : public VectorArithmeticOperations {
+struct RoundVectorOperation : public VectorArithmeticOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct SinVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -215,19 +223,11 @@ struct SignVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct Atan2VectorOperation : public VectorArithmeticOperations {
+struct SqrtVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct RoundVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct BitwiseXorVectorOperation : public VectorArithmeticOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct PiVectorOperation : public VectorArithmeticOperations {
+struct TanVectorOperation : public VectorArithmeticOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 

--- a/src/function/built_in_vector_operations.cpp
+++ b/src/function/built_in_vector_operations.cpp
@@ -205,49 +205,49 @@ void BuiltInVectorOperations::registerArithmeticOperations() {
     vectorOperations.insert({MODULO_FUNC_NAME, ModuloVectorOperation::getDefinitions()});
     vectorOperations.insert({POWER_FUNC_NAME, PowerVectorOperation::getDefinitions()});
 
-    vectorOperations.insert({NEGATE_FUNC_NAME, NegateVectorOperation::getDefinitions()});
     vectorOperations.insert({ABS_FUNC_NAME, AbsVectorOperation::getDefinitions()});
-    vectorOperations.insert({FLOOR_FUNC_NAME, FloorVectorOperation::getDefinitions()});
+    vectorOperations.insert({ACOS_FUNC_NAME, AcosVectorOperation::getDefinitions()});
+    vectorOperations.insert({ASIN_FUNC_NAME, AsinVectorOperation::getDefinitions()});
+    vectorOperations.insert({ATAN_FUNC_NAME, AtanVectorOperation::getDefinitions()});
+    vectorOperations.insert({ATAN2_FUNC_NAME, Atan2VectorOperation::getDefinitions()});
+    vectorOperations.insert({BITWISE_XOR_FUNC_NAME, BitwiseXorVectorOperation::getDefinitions()});
+    vectorOperations.insert({CBRT_FUNC_NAME, CbrtVectorOperation::getDefinitions()});
     vectorOperations.insert({CEIL_FUNC_NAME, CeilVectorOperation::getDefinitions()});
     vectorOperations.insert({CEILING_FUNC_NAME, CeilVectorOperation::getDefinitions()});
-
-    vectorOperations.insert({SIN_FUNC_NAME, SinVectorOperation::getDefinitions()});
     vectorOperations.insert({COS_FUNC_NAME, CosVectorOperation::getDefinitions()});
-    vectorOperations.insert({TAN_FUNC_NAME, TanVectorOperation::getDefinitions()});
     vectorOperations.insert({COT_FUNC_NAME, CotVectorOperation::getDefinitions()});
-    vectorOperations.insert({ASIN_FUNC_NAME, AsinVectorOperation::getDefinitions()});
-    vectorOperations.insert({ACOS_FUNC_NAME, AcosVectorOperation::getDefinitions()});
-    vectorOperations.insert({ATAN_FUNC_NAME, AtanVectorOperation::getDefinitions()});
-
+    vectorOperations.insert({DEGREES_FUNC_NAME, DegreesVectorOperation::getDefinitions()});
+    vectorOperations.insert({EVEN_FUNC_NAME, EvenVectorOperation::getDefinitions()});
     vectorOperations.insert({FACTORIAL_FUNC_NAME, FactorialVectorOperation::getDefinitions()});
-    vectorOperations.insert({SQRT_FUNC_NAME, SqrtVectorOperation::getDefinitions()});
-    vectorOperations.insert({CBRT_FUNC_NAME, CbrtVectorOperation::getDefinitions()});
+    vectorOperations.insert({FLOOR_FUNC_NAME, FloorVectorOperation::getDefinitions()});
     vectorOperations.insert({GAMMA_FUNC_NAME, GammaVectorOperation::getDefinitions()});
     vectorOperations.insert({LGAMMA_FUNC_NAME, LgammaVectorOperation::getDefinitions()});
     vectorOperations.insert({LN_FUNC_NAME, LnVectorOperation::getDefinitions()});
     vectorOperations.insert({LOG_FUNC_NAME, LogVectorOperation::getDefinitions()});
     vectorOperations.insert({LOG2_FUNC_NAME, Log2VectorOperation::getDefinitions()});
-    vectorOperations.insert({DEGREES_FUNC_NAME, DegreesVectorOperation::getDefinitions()});
-    vectorOperations.insert({RADIANS_FUNC_NAME, RadiansVectorOperation::getDefinitions()});
-    vectorOperations.insert({EVEN_FUNC_NAME, EvenVectorOperation::getDefinitions()});
-    vectorOperations.insert({SIGN_FUNC_NAME, SignVectorOperation::getDefinitions()});
-    vectorOperations.insert({ATAN2_FUNC_NAME, Atan2VectorOperation::getDefinitions()});
-    vectorOperations.insert({ROUND_FUNC_NAME, RoundVectorOperation::getDefinitions()});
-    vectorOperations.insert({BITWISE_XOR_FUNC_NAME, BitwiseXorVectorOperation::getDefinitions()});
+    vectorOperations.insert({LOG10_FUNC_NAME, LogVectorOperation::getDefinitions()});
+    vectorOperations.insert({NEGATE_FUNC_NAME, NegateVectorOperation::getDefinitions()});
     vectorOperations.insert({PI_FUNC_NAME, PiVectorOperation::getDefinitions()});
+    vectorOperations.insert({POW_FUNC_NAME, PowerVectorOperation::getDefinitions()});
+    vectorOperations.insert({RADIANS_FUNC_NAME, RadiansVectorOperation::getDefinitions()});
+    vectorOperations.insert({ROUND_FUNC_NAME, RoundVectorOperation::getDefinitions()});
+    vectorOperations.insert({SIN_FUNC_NAME, SinVectorOperation::getDefinitions()});
+    vectorOperations.insert({SIGN_FUNC_NAME, SignVectorOperation::getDefinitions()});
+    vectorOperations.insert({SQRT_FUNC_NAME, SqrtVectorOperation::getDefinitions()});
+    vectorOperations.insert({TAN_FUNC_NAME, TanVectorOperation::getDefinitions()});
 }
 
 void BuiltInVectorOperations::registerDateOperations() {
-    vectorOperations.insert({DAYNAME_FUNC_NAME, DayNameVectorOperation::getDefinitions()});
-    vectorOperations.insert({MONTHNAME_FUNC_NAME, MonthNameVectorOperation::getDefinitions()});
-    vectorOperations.insert({LAST_DAY_FUNC_NAME, LastDayVectorOperation::getDefinitions()});
     vectorOperations.insert({DATE_PART_FUNC_NAME, DatePartVectorOperation::getDefinitions()});
     vectorOperations.insert({DATEPART_FUNC_NAME, DatePartVectorOperation::getDefinitions()});
     vectorOperations.insert({DATE_TRUNC_FUNC_NAME, DateTruncVectorOperation::getDefinitions()});
     vectorOperations.insert({DATETRUNC_FUNC_NAME, DateTruncVectorOperation::getDefinitions()});
+    vectorOperations.insert({DAYNAME_FUNC_NAME, DayNameVectorOperation::getDefinitions()});
     vectorOperations.insert({GREATEST_FUNC_NAME, GreatestVectorOperation::getDefinitions()});
+    vectorOperations.insert({LAST_DAY_FUNC_NAME, LastDayVectorOperation::getDefinitions()});
     vectorOperations.insert({LEAST_FUNC_NAME, LeastVectorOperation::getDefinitions()});
     vectorOperations.insert({MAKE_DATE_FUNC_NAME, MakeDateVectorOperation::getDefinitions()});
+    vectorOperations.insert({MONTHNAME_FUNC_NAME, MonthNameVectorOperation::getDefinitions()});
 }
 
 void BuiltInVectorOperations::registerTimestampOperations() {
@@ -270,28 +270,30 @@ void BuiltInVectorOperations::registerIntervalOperations() {
 }
 
 void BuiltInVectorOperations::registerStringOperations() {
-    vectorOperations.insert({CONCAT_FUNC_NAME, ConcatVectorOperation::getDefinitions()});
-    vectorOperations.insert({CONTAINS_FUNC_NAME, ContainsVectorOperation::getDefinitions()});
-    vectorOperations.insert({STARTS_WITH_FUNC_NAME, StartsWithVectorOperation::getDefinitions()});
-    vectorOperations.insert({LOWER_FUNC_NAME, LowerVectorOperation::getDefinitions()});
-    vectorOperations.insert({UPPER_FUNC_NAME, UpperVectorOperation::getDefinitions()});
-    vectorOperations.insert({UCASE_FUNC_NAME, UpperVectorOperation::getDefinitions()});
-    vectorOperations.insert({TRIM_FUNC_NAME, TrimVectorOperation::getDefinitions()});
-    vectorOperations.insert({LTRIM_FUNC_NAME, LtrimVectorOperation::getDefinitions()});
-    vectorOperations.insert({RTRIM_FUNC_NAME, RtrimVectorOperation::getDefinitions()});
-    vectorOperations.insert({LENGTH_FUNC_NAME, LengthVectorOperation::getDefinitions()});
-    vectorOperations.insert({REPEAT_FUNC_NAME, RepeatVectorOperation::getDefinitions()});
-    vectorOperations.insert({REVERSE_FUNC_NAME, ReverseVectorOperation::getDefinitions()});
-    vectorOperations.insert({LPAD_FUNC_NAME, LpadVectorOperation::getDefinitions()});
-    vectorOperations.insert({RPAD_FUNC_NAME, RpadVectorOperation::getDefinitions()});
-    vectorOperations.insert({SUBSTRING_FUNC_NAME, SubStrVectorOperation::getDefinitions()});
-    vectorOperations.insert({SUBSTR_FUNC_NAME, SubStrVectorOperation::getDefinitions()});
-    vectorOperations.insert({LEFT_FUNC_NAME, LeftVectorOperation::getDefinitions()});
-    vectorOperations.insert({RIGHT_FUNC_NAME, RightVectorOperation::getDefinitions()});
     vectorOperations.insert(
         {ARRAY_EXTRACT_FUNC_NAME, ArrayExtractVectorOperation::getDefinitions()});
+    vectorOperations.insert({CONCAT_FUNC_NAME, ConcatVectorOperation::getDefinitions()});
+    vectorOperations.insert({CONTAINS_FUNC_NAME, ContainsVectorOperation::getDefinitions()});
+    vectorOperations.insert({ENDS_WITH_FUNC_NAME, EndsWithVectorOperation::getDefinitions()});
+    vectorOperations.insert({LCASE_FUNC_NAME, LowerVectorOperation::getDefinitions()});
+    vectorOperations.insert({LEFT_FUNC_NAME, LeftVectorOperation::getDefinitions()});
+    vectorOperations.insert({LENGTH_FUNC_NAME, LengthVectorOperation::getDefinitions()});
+    vectorOperations.insert({LOWER_FUNC_NAME, LowerVectorOperation::getDefinitions()});
+    vectorOperations.insert({LPAD_FUNC_NAME, LpadVectorOperation::getDefinitions()});
+    vectorOperations.insert({LTRIM_FUNC_NAME, LtrimVectorOperation::getDefinitions()});
     vectorOperations.insert({PREFIX_FUNC_NAME, StartsWithVectorOperation::getDefinitions()});
+    vectorOperations.insert({REPEAT_FUNC_NAME, RepeatVectorOperation::getDefinitions()});
+    vectorOperations.insert({REVERSE_FUNC_NAME, ReverseVectorOperation::getDefinitions()});
+    vectorOperations.insert({RIGHT_FUNC_NAME, RightVectorOperation::getDefinitions()});
+    vectorOperations.insert({RPAD_FUNC_NAME, RpadVectorOperation::getDefinitions()});
+    vectorOperations.insert({RTRIM_FUNC_NAME, RtrimVectorOperation::getDefinitions()});
+    vectorOperations.insert({STARTS_WITH_FUNC_NAME, StartsWithVectorOperation::getDefinitions()});
+    vectorOperations.insert({SUBSTR_FUNC_NAME, SubStrVectorOperation::getDefinitions()});
+    vectorOperations.insert({SUBSTRING_FUNC_NAME, SubStrVectorOperation::getDefinitions()});
     vectorOperations.insert({SUFFIX_FUNC_NAME, EndsWithVectorOperation::getDefinitions()});
+    vectorOperations.insert({TRIM_FUNC_NAME, TrimVectorOperation::getDefinitions()});
+    vectorOperations.insert({UCASE_FUNC_NAME, UpperVectorOperation::getDefinitions()});
+    vectorOperations.insert({UPPER_FUNC_NAME, UpperVectorOperation::getDefinitions()});
 }
 
 void BuiltInVectorOperations::registerCastOperations() {

--- a/src/function/date/include/vector_date_operations.h
+++ b/src/function/date/include/vector_date_operations.h
@@ -6,18 +6,6 @@ namespace graphflow {
 namespace function {
 class VectorDateOperations : public VectorOperations {};
 
-struct DayNameVectorOperation : public VectorDateOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct MonthNameVectorOperation : public VectorDateOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct LastDayVectorOperation : public VectorDateOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
 struct DatePartVectorOperation : public VectorDateOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
@@ -26,7 +14,15 @@ struct DateTruncVectorOperation : public VectorDateOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
+struct DayNameVectorOperation : public VectorDateOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
 struct GreatestVectorOperation : public VectorDateOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct LastDayVectorOperation : public VectorDateOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -35,6 +31,10 @@ struct LeastVectorOperation : public VectorDateOperations {
 };
 
 struct MakeDateVectorOperation : public VectorDateOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct MonthNameVectorOperation : public VectorDateOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 

--- a/src/function/date/vector_date_operations.cpp
+++ b/src/function/date/vector_date_operations.cpp
@@ -5,47 +5,6 @@
 namespace graphflow {
 namespace function {
 
-vector<unique_ptr<VectorOperationDefinition>> DayNameVectorOperation::getDefinitions() {
-    vector<unique_ptr<VectorOperationDefinition>> result;
-    result.push_back(
-        make_unique<VectorOperationDefinition>(DAYNAME_FUNC_NAME, vector<DataTypeID>{DATE}, STRING,
-            UnaryExecFunction<date_t, gf_string_t, operation::DayName>));
-    result.push_back(
-        make_unique<VectorOperationDefinition>(DAYNAME_FUNC_NAME, vector<DataTypeID>{TIMESTAMP},
-            STRING, UnaryExecFunction<timestamp_t, gf_string_t, operation::DayName>));
-    result.push_back(
-        make_unique<VectorOperationDefinition>(DAYNAME_FUNC_NAME, vector<DataTypeID>{UNSTRUCTURED},
-            STRING, UnaryExecFunction<Value, gf_string_t, operation::DayName>));
-    return result;
-}
-
-vector<unique_ptr<VectorOperationDefinition>> MonthNameVectorOperation::getDefinitions() {
-    vector<unique_ptr<VectorOperationDefinition>> result;
-    result.push_back(
-        make_unique<VectorOperationDefinition>(MONTHNAME_FUNC_NAME, vector<DataTypeID>{DATE},
-            STRING, UnaryExecFunction<date_t, gf_string_t, operation::MonthName>));
-    result.push_back(
-        make_unique<VectorOperationDefinition>(MONTHNAME_FUNC_NAME, vector<DataTypeID>{TIMESTAMP},
-            STRING, UnaryExecFunction<timestamp_t, gf_string_t, operation::MonthName>));
-    result.push_back(make_unique<VectorOperationDefinition>(MONTHNAME_FUNC_NAME,
-        vector<DataTypeID>{UNSTRUCTURED}, STRING,
-        UnaryExecFunction<Value, gf_string_t, operation::MonthName>));
-    return result;
-}
-
-vector<unique_ptr<VectorOperationDefinition>> LastDayVectorOperation::getDefinitions() {
-    vector<unique_ptr<VectorOperationDefinition>> result;
-    result.push_back(make_unique<VectorOperationDefinition>(LAST_DAY_FUNC_NAME,
-        vector<DataTypeID>{DATE}, DATE, UnaryExecFunction<date_t, date_t, operation::LastDay>));
-    result.push_back(
-        make_unique<VectorOperationDefinition>(LAST_DAY_FUNC_NAME, vector<DataTypeID>{TIMESTAMP},
-            DATE, UnaryExecFunction<timestamp_t, date_t, operation::LastDay>));
-    result.push_back(
-        make_unique<VectorOperationDefinition>(LAST_DAY_FUNC_NAME, vector<DataTypeID>{UNSTRUCTURED},
-            DATE, UnaryExecFunction<Value, date_t, operation::LastDay>));
-    return result;
-}
-
 vector<unique_ptr<VectorOperationDefinition>> DatePartVectorOperation::getDefinitions() {
     vector<unique_ptr<VectorOperationDefinition>> result;
     result.push_back(make_unique<VectorOperationDefinition>(DATE_PART_FUNC_NAME,
@@ -77,6 +36,20 @@ vector<unique_ptr<VectorOperationDefinition>> DateTruncVectorOperation::getDefin
     return result;
 }
 
+vector<unique_ptr<VectorOperationDefinition>> DayNameVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> result;
+    result.push_back(
+        make_unique<VectorOperationDefinition>(DAYNAME_FUNC_NAME, vector<DataTypeID>{DATE}, STRING,
+            UnaryExecFunction<date_t, gf_string_t, operation::DayName>));
+    result.push_back(
+        make_unique<VectorOperationDefinition>(DAYNAME_FUNC_NAME, vector<DataTypeID>{TIMESTAMP},
+            STRING, UnaryExecFunction<timestamp_t, gf_string_t, operation::DayName>));
+    result.push_back(
+        make_unique<VectorOperationDefinition>(DAYNAME_FUNC_NAME, vector<DataTypeID>{UNSTRUCTURED},
+            STRING, UnaryExecFunction<Value, gf_string_t, operation::DayName>));
+    return result;
+}
+
 vector<unique_ptr<VectorOperationDefinition>> GreatestVectorOperation::getDefinitions() {
     vector<unique_ptr<VectorOperationDefinition>> result;
     result.push_back(
@@ -88,6 +61,19 @@ vector<unique_ptr<VectorOperationDefinition>> GreatestVectorOperation::getDefini
     result.push_back(make_unique<VectorOperationDefinition>(GREATEST_FUNC_NAME,
         vector<DataTypeID>{UNSTRUCTURED, UNSTRUCTURED}, UNSTRUCTURED,
         BinaryExecFunction<Value, Value, Value, operation::Greatest>));
+    return result;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> LastDayVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> result;
+    result.push_back(make_unique<VectorOperationDefinition>(LAST_DAY_FUNC_NAME,
+        vector<DataTypeID>{DATE}, DATE, UnaryExecFunction<date_t, date_t, operation::LastDay>));
+    result.push_back(
+        make_unique<VectorOperationDefinition>(LAST_DAY_FUNC_NAME, vector<DataTypeID>{TIMESTAMP},
+            DATE, UnaryExecFunction<timestamp_t, date_t, operation::LastDay>));
+    result.push_back(
+        make_unique<VectorOperationDefinition>(LAST_DAY_FUNC_NAME, vector<DataTypeID>{UNSTRUCTURED},
+            DATE, UnaryExecFunction<Value, date_t, operation::LastDay>));
     return result;
 }
 
@@ -110,6 +96,20 @@ vector<unique_ptr<VectorOperationDefinition>> MakeDateVectorOperation::getDefini
     result.push_back(make_unique<VectorOperationDefinition>(MAKE_DATE_FUNC_NAME,
         vector<DataTypeID>{INT64, INT64, INT64}, DATE,
         TernaryExecFunction<int64_t, int64_t, int64_t, date_t, operation::MakeDate>));
+    return result;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> MonthNameVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> result;
+    result.push_back(
+        make_unique<VectorOperationDefinition>(MONTHNAME_FUNC_NAME, vector<DataTypeID>{DATE},
+            STRING, UnaryExecFunction<date_t, gf_string_t, operation::MonthName>));
+    result.push_back(
+        make_unique<VectorOperationDefinition>(MONTHNAME_FUNC_NAME, vector<DataTypeID>{TIMESTAMP},
+            STRING, UnaryExecFunction<timestamp_t, gf_string_t, operation::MonthName>));
+    result.push_back(make_unique<VectorOperationDefinition>(MONTHNAME_FUNC_NAME,
+        vector<DataTypeID>{UNSTRUCTURED}, STRING,
+        UnaryExecFunction<Value, gf_string_t, operation::MonthName>));
     return result;
 }
 

--- a/src/function/string/include/vector_string_operations.h
+++ b/src/function/string/include/vector_string_operations.h
@@ -47,11 +47,15 @@ struct VectorStringOperations : public VectorOperations {
     }
 };
 
-struct ContainsVectorOperation : public VectorStringOperations {
+struct ArrayExtractVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct StartsWithVectorOperation : public VectorStringOperations {
+struct ConcatVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct ContainsVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -59,7 +63,11 @@ struct EndsWithVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct ConcatVectorOperation : public VectorStringOperations {
+struct LeftVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
+struct LengthVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -69,16 +77,8 @@ struct LowerVectorOperation : public VectorStringOperations {
     }
 };
 
-struct UpperVectorOperation : public VectorStringOperations {
-    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
-        return getUnaryStrFunctionDefintion<operation::Upper>(UPPER_FUNC_NAME);
-    }
-};
-
-struct TrimVectorOperation : public VectorStringOperations {
-    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
-        return getUnaryStrFunctionDefintion<operation::Trim>(TRIM_FUNC_NAME);
-    }
+struct LpadVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
 struct LtrimVectorOperation : public VectorStringOperations {
@@ -87,10 +87,8 @@ struct LtrimVectorOperation : public VectorStringOperations {
     }
 };
 
-struct RtrimVectorOperation : public VectorStringOperations {
-    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
-        return getUnaryStrFunctionDefintion<operation::Rtrim>(RTRIM_FUNC_NAME);
-    }
+struct RepeatVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
 struct ReverseVectorOperation : public VectorStringOperations {
@@ -99,15 +97,7 @@ struct ReverseVectorOperation : public VectorStringOperations {
     }
 };
 
-struct LengthVectorOperation : public VectorStringOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct RepeatVectorOperation : public VectorStringOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct LpadVectorOperation : public VectorStringOperations {
+struct RightVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
@@ -115,20 +105,30 @@ struct RpadVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
+struct RtrimVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Rtrim>(RTRIM_FUNC_NAME);
+    }
+};
+
+struct StartsWithVectorOperation : public VectorStringOperations {
+    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+};
+
 struct SubStrVectorOperation : public VectorStringOperations {
     static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
 };
 
-struct LeftVectorOperation : public VectorStringOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+struct TrimVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Trim>(TRIM_FUNC_NAME);
+    }
 };
 
-struct RightVectorOperation : public VectorStringOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
-};
-
-struct ArrayExtractVectorOperation : public VectorStringOperations {
-    static vector<unique_ptr<VectorOperationDefinition>> getDefinitions();
+struct UpperVectorOperation : public VectorStringOperations {
+    static inline vector<unique_ptr<VectorOperationDefinition>> getDefinitions() {
+        return getUnaryStrFunctionDefintion<operation::Upper>(UPPER_FUNC_NAME);
+    }
 };
 
 } // namespace function

--- a/src/function/string/vector_string_operations.cpp
+++ b/src/function/string/vector_string_operations.cpp
@@ -16,22 +16,30 @@
 namespace graphflow {
 namespace function {
 
+vector<unique_ptr<VectorOperationDefinition>> ArrayExtractVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> definitions;
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(ARRAY_EXTRACT_FUNC_NAME,
+        vector<DataTypeID>{STRING, INT64}, STRING,
+        BinaryExecFunction<gf_string_t, int64_t, gf_string_t, operation::ArrayExtract>,
+        false /* isVarLength */));
+    return definitions;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> ConcatVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> definitions;
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(CONCAT_FUNC_NAME,
+        vector<DataTypeID>{STRING, STRING}, STRING,
+        BinaryStringExecFunction<gf_string_t, gf_string_t, gf_string_t, operation::Concat>,
+        false /* isVarLength */));
+    return definitions;
+}
+
 vector<unique_ptr<VectorOperationDefinition>> ContainsVectorOperation::getDefinitions() {
     vector<unique_ptr<VectorOperationDefinition>> definitions;
     definitions.emplace_back(make_unique<VectorOperationDefinition>(CONTAINS_FUNC_NAME,
         vector<DataTypeID>{STRING, STRING}, BOOL,
         BinaryExecFunction<gf_string_t, gf_string_t, uint8_t, operation::Contains>,
         BinarySelectFunction<gf_string_t, gf_string_t, operation::Contains>,
-        false /* isVarLength */));
-    return definitions;
-}
-
-vector<unique_ptr<VectorOperationDefinition>> StartsWithVectorOperation::getDefinitions() {
-    vector<unique_ptr<VectorOperationDefinition>> definitions;
-    definitions.emplace_back(make_unique<VectorOperationDefinition>(STARTS_WITH_FUNC_NAME,
-        vector<DataTypeID>{STRING, STRING}, BOOL,
-        BinaryExecFunction<gf_string_t, gf_string_t, uint8_t, operation::StartsWith>,
-        BinarySelectFunction<gf_string_t, gf_string_t, operation::StartsWith>,
         false /* isVarLength */));
     return definitions;
 }
@@ -46,12 +54,12 @@ vector<unique_ptr<VectorOperationDefinition>> EndsWithVectorOperation::getDefini
     return definitions;
 }
 
-vector<unique_ptr<VectorOperationDefinition>> ConcatVectorOperation::getDefinitions() {
+vector<unique_ptr<VectorOperationDefinition>> LeftVectorOperation::getDefinitions() {
     vector<unique_ptr<VectorOperationDefinition>> definitions;
-    definitions.emplace_back(make_unique<VectorOperationDefinition>(CONCAT_FUNC_NAME,
-        vector<DataTypeID>{STRING, STRING}, STRING,
-        BinaryStringExecFunction<gf_string_t, gf_string_t, gf_string_t, operation::Concat>,
-        false /* isVarLength */));
+    definitions.emplace_back(
+        make_unique<VectorOperationDefinition>(LEFT_FUNC_NAME, vector<DataTypeID>{STRING, INT64},
+            STRING, BinaryStringExecFunction<gf_string_t, int64_t, gf_string_t, operation::Left>,
+            false /* isVarLength */));
     return definitions;
 }
 
@@ -60,15 +68,6 @@ vector<unique_ptr<VectorOperationDefinition>> LengthVectorOperation::getDefiniti
     definitions.emplace_back(
         make_unique<VectorOperationDefinition>(LENGTH_FUNC_NAME, vector<DataTypeID>{STRING}, INT64,
             UnaryExecFunction<gf_string_t, int64_t, operation::Length>, false /* isVarLength */));
-    return definitions;
-}
-
-vector<unique_ptr<VectorOperationDefinition>> RepeatVectorOperation::getDefinitions() {
-    vector<unique_ptr<VectorOperationDefinition>> definitions;
-    definitions.emplace_back(
-        make_unique<VectorOperationDefinition>(REPEAT_FUNC_NAME, vector<DataTypeID>{STRING, INT64},
-            STRING, BinaryStringExecFunction<gf_string_t, int64_t, gf_string_t, operation::Repeat>,
-            false /* isVarLength */));
     return definitions;
 }
 
@@ -81,29 +80,11 @@ vector<unique_ptr<VectorOperationDefinition>> LpadVectorOperation::getDefinition
     return definitions;
 }
 
-vector<unique_ptr<VectorOperationDefinition>> RpadVectorOperation::getDefinitions() {
-    vector<unique_ptr<VectorOperationDefinition>> definitions;
-    definitions.emplace_back(make_unique<VectorOperationDefinition>(RPAD_FUNC_NAME,
-        vector<DataTypeID>{STRING, INT64, STRING}, STRING,
-        TernaryStringExecFunction<gf_string_t, int64_t, gf_string_t, gf_string_t, operation::Rpad>,
-        false /* isVarLength */));
-    return definitions;
-}
-
-vector<unique_ptr<VectorOperationDefinition>> SubStrVectorOperation::getDefinitions() {
-    vector<unique_ptr<VectorOperationDefinition>> definitions;
-    definitions.emplace_back(make_unique<VectorOperationDefinition>(SUBSTRING_FUNC_NAME,
-        vector<DataTypeID>{STRING, INT64, INT64}, STRING,
-        TernaryStringExecFunction<gf_string_t, int64_t, int64_t, gf_string_t, operation::SubStr>,
-        false /* isVarLength */));
-    return definitions;
-}
-
-vector<unique_ptr<VectorOperationDefinition>> LeftVectorOperation::getDefinitions() {
+vector<unique_ptr<VectorOperationDefinition>> RepeatVectorOperation::getDefinitions() {
     vector<unique_ptr<VectorOperationDefinition>> definitions;
     definitions.emplace_back(
-        make_unique<VectorOperationDefinition>(LEFT_FUNC_NAME, vector<DataTypeID>{STRING, INT64},
-            STRING, BinaryStringExecFunction<gf_string_t, int64_t, gf_string_t, operation::Left>,
+        make_unique<VectorOperationDefinition>(REPEAT_FUNC_NAME, vector<DataTypeID>{STRING, INT64},
+            STRING, BinaryStringExecFunction<gf_string_t, int64_t, gf_string_t, operation::Repeat>,
             false /* isVarLength */));
     return definitions;
 }
@@ -117,11 +98,30 @@ vector<unique_ptr<VectorOperationDefinition>> RightVectorOperation::getDefinitio
     return definitions;
 }
 
-vector<unique_ptr<VectorOperationDefinition>> ArrayExtractVectorOperation::getDefinitions() {
+vector<unique_ptr<VectorOperationDefinition>> RpadVectorOperation::getDefinitions() {
     vector<unique_ptr<VectorOperationDefinition>> definitions;
-    definitions.emplace_back(make_unique<VectorOperationDefinition>(ARRAY_EXTRACT_FUNC_NAME,
-        vector<DataTypeID>{STRING, INT64}, STRING,
-        BinaryExecFunction<gf_string_t, int64_t, gf_string_t, operation::ArrayExtract>,
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(RPAD_FUNC_NAME,
+        vector<DataTypeID>{STRING, INT64, STRING}, STRING,
+        TernaryStringExecFunction<gf_string_t, int64_t, gf_string_t, gf_string_t, operation::Rpad>,
+        false /* isVarLength */));
+    return definitions;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> StartsWithVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> definitions;
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(STARTS_WITH_FUNC_NAME,
+        vector<DataTypeID>{STRING, STRING}, BOOL,
+        BinaryExecFunction<gf_string_t, gf_string_t, uint8_t, operation::StartsWith>,
+        BinarySelectFunction<gf_string_t, gf_string_t, operation::StartsWith>,
+        false /* isVarLength */));
+    return definitions;
+}
+
+vector<unique_ptr<VectorOperationDefinition>> SubStrVectorOperation::getDefinitions() {
+    vector<unique_ptr<VectorOperationDefinition>> definitions;
+    definitions.emplace_back(make_unique<VectorOperationDefinition>(SUBSTRING_FUNC_NAME,
+        vector<DataTypeID>{STRING, INT64, INT64}, STRING,
+        TernaryStringExecFunction<gf_string_t, int64_t, int64_t, gf_string_t, operation::SubStr>,
         false /* isVarLength */));
     return definitions;
 }


### PR DESCRIPTION
This PR simply reorders the functions defined in the codebase using alphabetical order, so it is easier for developers to locate a function.