### PR TITLE
fix distinct aggregation bug

### DIFF
--- a/src/processor/operator/aggregate/simple_aggregate.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate.cpp
@@ -69,7 +69,9 @@ void SimpleAggregate::execute(ExecutionContext* context) {
                         vector<ValueVector*>{}, aggVector)) {
                     if (!aggVector->isNull(aggVector->state->getPositionOfCurrIdx())) {
                         aggregateFunction->updatePosState((uint8_t*)localAggregateStates[i].get(),
-                            aggVector, resultSet->multiplicity,
+                            aggVector, 1 /* Distinct aggregate should ignore
+                                          multiplicity since they are known to be non-distinct. */
+                            ,
                             aggVector->state->getPositionOfCurrIdx());
                     }
                 }

--- a/test/test_files/tinySNB/agg/distinct_agg.test
+++ b/test/test_files/tinySNB/agg/distinct_agg.test
@@ -27,3 +27,9 @@
 2|30|130
 3|45|130
 5|20|130
+
+-NAME OneHopDistinctAggTest
+-QUERY MATCH (p:person)-[:knows]->(:person) RETURN count(distinct p.ID)
+-ENUMERATE
+---- 1
+5


### PR DESCRIPTION
This PR fixes distinct aggregation bug. 
When the distinct aggregation tries to update the agg state, the resultSet multiplicity should always be 1.
Solves issue #947 