### PR TITLE
fix copy-csv-loader logger bug

### DIFF
--- a/src/common/include/csv_reader/csv_reader.h
+++ b/src/common/include/csv_reader/csv_reader.h
@@ -46,12 +46,14 @@ class CSVReader {
 
 public:
     // Initializes to read a block in file.
-    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig, uint64_t blockId);
+    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig, uint64_t blockId,
+        shared_ptr<spdlog::logger> logger);
     // Initializes to read the complete file.
-    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig);
+    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig,
+        shared_ptr<spdlog::logger> logger);
     // Initializes to read a part of a line.
-    CSVReader(
-        char* line, uint64_t lineLen, int64_t linePtrStart, const CSVReaderConfig& csvReaderConfig);
+    CSVReader(char* line, uint64_t lineLen, int64_t linePtrStart,
+        const CSVReaderConfig& csvReaderConfig, shared_ptr<spdlog::logger> logger);
 
     ~CSVReader();
 

--- a/src/storage/in_mem_csv_copier/in_mem_node_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_node_csv_copier.cpp
@@ -155,8 +155,8 @@ void InMemNodeCSVCopier::populateColumnsAndCountUnstrPropertyListSizesTask(uint6
     uint64_t blockId, uint64_t startOffset, HashIndexBuilder* IDIndex, InMemNodeCSVCopier* copier) {
     copier->logger->trace("Start: path={0} blkIdx={1}", copier->csvDescription.filePath, blockId);
     vector<PageByteCursor> overflowCursors(copier->nodeTableSchema->getNumStructuredProperties());
-    CSVReader reader(
-        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
+    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
+        blockId, copier->logger);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     auto bufferOffset = 0u;
     while (reader.hasNextLine()) {
@@ -234,8 +234,8 @@ void InMemNodeCSVCopier::populateUnstrPropertyLists() {
 void InMemNodeCSVCopier::populateUnstrPropertyListsTask(
     uint64_t blockId, node_offset_t nodeOffsetStart, InMemNodeCSVCopier* copier) {
     copier->logger->trace("Start: path={0} blkIdx={1}", copier->csvDescription.filePath, blockId);
-    CSVReader reader(
-        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
+    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
+        blockId, copier->logger);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     auto bufferOffset = 0u;
     PageByteCursor inMemOverflowFileCursor;

--- a/src/storage/in_mem_csv_copier/in_mem_rel_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_rel_csv_copier.cpp
@@ -176,8 +176,8 @@ void InMemRelCSVCopier::skipFirstRowIfNecessary(
 void InMemRelCSVCopier::populateAdjColumnsAndCountRelsInAdjListsTask(
     uint64_t blockId, uint64_t blockStartRelID, InMemRelCSVCopier* copier) {
     copier->logger->debug("Start: path=`{0}` blkIdx={1}", copier->csvDescription.filePath, blockId);
-    CSVReader reader(
-        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
+    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
+        blockId, copier->logger);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     vector<bool> requireToReadTableLabels{true, true};
     vector<nodeID_t> nodeIDs{2};
@@ -507,8 +507,8 @@ void InMemRelCSVCopier::populateAdjAndPropertyLists() {
 void InMemRelCSVCopier::populateAdjAndPropertyListsTask(
     uint64_t blockId, uint64_t blockStartRelID, InMemRelCSVCopier* copier) {
     copier->logger->trace("Start: path=`{0}` blkIdx={1}", copier->csvDescription.filePath, blockId);
-    CSVReader reader(
-        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
+    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
+        blockId, copier->logger);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     vector<bool> requireToReadTableLabels{true, true};
     vector<nodeID_t> nodeIDs{2};

--- a/src/storage/in_mem_csv_copier/in_mem_structures_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_structures_csv_copier.cpp
@@ -56,7 +56,7 @@ void InMemStructuresCSVCopier::countNumLinesAndUnstrPropertiesPerBlockTask(const
     uint64_t blockId, InMemStructuresCSVCopier* copier, uint64_t numTokensToSkip,
     unordered_set<string>* unstrPropertyNames) {
     copier->logger->trace("Start: path=`{0}` blkIdx={1}", fName, blockId);
-    CSVReader reader(fName, copier->csvDescription.csvReaderConfig, blockId);
+    CSVReader reader(fName, copier->csvDescription.csvReaderConfig, blockId, copier->logger);
     copier->numLinesPerBlock[blockId] = 0ull;
     while (reader.hasNextLine()) {
         copier->numLinesPerBlock[blockId]++;

--- a/test/copy_csv/copy_csv_test.cpp
+++ b/test/copy_csv/copy_csv_test.cpp
@@ -142,7 +142,7 @@ TEST_F(CopyNodeCSVPropertyTest, NodeStructuredStringPropertyTest) {
         graph->getNodesStore().getNodePropertyColumn(tableID, propertyIdx.propertyID));
     string fName = "dataset/copy-csv-node-property-test/vPerson.csv";
     CSVReaderConfig config;
-    CSVReader csvReader(fName, config);
+    CSVReader csvReader(fName, config, LoggerUtils::getOrCreateSpdLogger("copyNodeCSVTest"));
     int lineIdx = 0;
     uint64_t count = 0;
     auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();


### PR DESCRIPTION
We used to create or get SPD logger in the constructor of csvReader. If we are constructing multiple csv readers concurrently, it may lead to a race condition. 
This PR solves this race condition by passing a logger from inMemCSVCopier to csvReader, so csvReader no longer needs to create its own logger. Solved issue: #950 
Opened issue: 954