### PR TITLE
fix col-name and limit/skip number

### DIFF
--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -11,7 +11,8 @@ namespace main {
 QueryResultHeader::QueryResultHeader(expression_vector expressions) {
     for (auto& expression : expressions) {
         columnDataTypes.push_back(expression->getDataType());
-        columnNames.push_back(expression->getRawName());
+        columnNames.push_back(
+            expression->hasAlias() ? expression->getAlias() : expression->getRawName());
     }
 }
 

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -389,3 +389,17 @@ TEST_F(BinderErrorTest, SelfLoopRel) {
     auto input = "MATCH (a:person)-[e:knows]->(a) RETURN COUNT(*);";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
+
+TEST_F(BinderErrorTest, InvalidLimitNumberType) {
+    string expectedException =
+        "Binder exception: The number of rows to skip/limit must be a non-negative integer.";
+    auto input = "MATCH (a:person) RETURN a.age LIMIT \"abc\";";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, NegativeLimitNumber) {
+    string expectedException =
+        "Binder exception: The number of rows to skip/limit must be a non-negative integer.";
+    auto input = "MATCH (a:person) RETURN a.age LIMIT -1;";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}


### PR DESCRIPTION
1. This PR fixes the queryResultHeader name for column with alias.
2. Error when the number to limit/skip is invalid (neative or incorrect dataType)