### PR TITLE
solve multi-thread logger creation bug

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -182,11 +182,11 @@ namespace graphflow {
 namespace catalog {
 
 CatalogContent::CatalogContent() : nextTableID{0} {
-    logger = LoggerUtils::getOrCreateSpdLogger("storage");
+    logger = LoggerUtils::getOrCreateLogger("catalog");
 }
 
 CatalogContent::CatalogContent(const string& directory) {
-    logger = LoggerUtils::getOrCreateSpdLogger("storage");
+    logger = LoggerUtils::getOrCreateLogger("catalog");
     logger->info("Initializing catalog.");
     readFromFile(directory, DBFileType::ORIGINAL);
     logger->info("Initializing catalog done.");

--- a/src/common/include/csv_reader/csv_reader.h
+++ b/src/common/include/csv_reader/csv_reader.h
@@ -46,14 +46,12 @@ class CSVReader {
 
 public:
     // Initializes to read a block in file.
-    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig, uint64_t blockId,
-        shared_ptr<spdlog::logger> logger);
+    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig, uint64_t blockId);
     // Initializes to read the complete file.
-    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig,
-        shared_ptr<spdlog::logger> logger);
+    CSVReader(const string& fname, const CSVReaderConfig& csvReaderConfig);
     // Initializes to read a part of a line.
-    CSVReader(char* line, uint64_t lineLen, int64_t linePtrStart,
-        const CSVReaderConfig& csvReaderConfig, shared_ptr<spdlog::logger> logger);
+    CSVReader(
+        char* line, uint64_t lineLen, int64_t linePtrStart, const CSVReaderConfig& csvReaderConfig);
 
     ~CSVReader();
 

--- a/src/common/include/utils.h
+++ b/src/common/include/utils.h
@@ -20,9 +20,9 @@ namespace graphflow {
 namespace common {
 
 class LoggerUtils {
-
 public:
-    static shared_ptr<spdlog::logger> getOrCreateSpdLogger(const string& loggerName);
+    // Note: create logger is not thread safe.
+    static shared_ptr<spdlog::logger> getOrCreateLogger(const string& loggerName);
 };
 
 class StringUtils {

--- a/src/common/task_system/task_scheduler.cpp
+++ b/src/common/task_system/task_scheduler.cpp
@@ -10,7 +10,7 @@ namespace graphflow {
 namespace common {
 
 TaskScheduler::TaskScheduler(uint64_t numThreads)
-    : logger{LoggerUtils::getOrCreateSpdLogger("taskscheduler")}, nextScheduledTaskID{0} {
+    : logger{LoggerUtils::getOrCreateLogger("processor")}, nextScheduledTaskID{0} {
     for (auto n = 0u; n < numThreads; ++n) {
         threads.emplace_back([&] { runWorkerThread(); });
     }

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -6,7 +6,7 @@
 namespace graphflow {
 namespace common {
 
-shared_ptr<spdlog::logger> LoggerUtils::getOrCreateSpdLogger(const string& loggerName) {
+shared_ptr<spdlog::logger> LoggerUtils::getOrCreateLogger(const std::string& loggerName) {
     shared_ptr<spdlog::logger> logger = spdlog::get(loggerName);
     if (!logger) {
         logger = spdlog::stdout_logger_mt(loggerName);

--- a/src/main/include/database.h
+++ b/src/main/include/database.h
@@ -24,7 +24,6 @@ namespace graphflow {
 namespace main {
 
 struct SystemConfig {
-
     explicit SystemConfig(uint64_t bufferPoolSize = StorageConfig::DEFAULT_BUFFER_POOL_SIZE)
         : defaultPageBufferPoolSize{(uint64_t)(
               bufferPoolSize * StorageConfig::DEFAULT_PAGES_BUFFER_RATIO)},
@@ -38,7 +37,6 @@ struct SystemConfig {
 };
 
 struct DatabaseConfig {
-
     explicit DatabaseConfig(std::string databasePath, bool inMemoryMode = false)
         : databasePath{std::move(databasePath)}, inMemoryMode{inMemoryMode} {}
 
@@ -59,8 +57,6 @@ public:
     explicit Database(const DatabaseConfig& databaseConfig, const SystemConfig& systemConfig);
 
     ~Database() = default;
-
-    void initDBDirAndCoreFilesIfNecessary();
 
     void resizeBufferManager(uint64_t newSize);
 
@@ -87,74 +83,13 @@ public:
     // either replaying the WAL and either redoing or undoing and in either case at the end WAL is
     // cleared.
     // skipCheckpointForTestingRecovery is used to simulate a failure before checkpointing in tests.
-    inline void commitAndCheckpointOrRollback(transaction::Transaction* writeTransaction,
-        bool isCommit, bool skipCheckpointForTestingRecovery = false) {
-        // Irrespective of whether we are checkpointing or rolling back we add a
-        // nodesStatisticsAndDeletedIDs/relStatistics record if there has been updates to
-        // nodesStatisticsAndDeletedIDs/relStatistics. This is because we need to commit or rollback
-        // the in-memory state of NodesStatisticsAndDeletedIDs/relStatistics, which is done during
-        // wal replaying and committing/rollingback each record, so a TABLE_STATISTICS_RECORD needs
-        // to appear in the log.
-        bool nodeTableHasUpdates =
-            storageManager->getNodesStore().getNodesStatisticsAndDeletedIDs().hasUpdates();
-        bool relTableHasUpdates = storageManager->getRelsStore().getRelsStatistics().hasUpdates();
-        if (nodeTableHasUpdates || relTableHasUpdates) {
-            wal->logTableStatisticsRecord(nodeTableHasUpdates /* isNodeTable */);
-            // If we are committing, we also need to write the WAL file for
-            // NodesStatisticsAndDeletedIDs/relStatistics.
-            if (isCommit) {
-                if (nodeTableHasUpdates) {
-                    storageManager->getNodesStore()
-                        .getNodesStatisticsAndDeletedIDs()
-                        .writeTablesStatisticsFileForWALRecord(databaseConfig.databasePath);
-                } else {
-                    storageManager->getRelsStore()
-                        .getRelsStatistics()
-                        .writeTablesStatisticsFileForWALRecord(databaseConfig.databasePath);
-                }
-            }
-        }
-        if (catalog->hasUpdates()) {
-            wal->logCatalogRecord();
-            // If we are committing, we also need to write the WAL file for catalog.
-            if (isCommit) {
-                catalog->writeCatalogForWALRecord(databaseConfig.databasePath);
-            }
-        }
-        storageManager->prepareCommitOrRollbackIfNecessary(isCommit);
-
-        if (isCommit) {
-            // Note: It is enough to stop and wait transactions to leave the system instead of
-            // for example checking on the query processor's task scheduler. This is because the
-            // first and last steps that a connection performs when executing a query is to
-            // start and comming/rollback transaction. The query processor also ensures that it
-            // will only return results or error after all threads working on the tasks of a
-            // query stop working on the tasks of the query and these tasks are removed from the
-            // query.
-            transactionManager->stopNewTransactionsAndWaitUntilAllReadTransactionsLeave();
-            // Note: committing and stopping new transactions can be done in any order. This
-            // order allows us to throw exceptions if we have to wait a lot to stop.
-            transactionManager->commitButKeepActiveWriteTransaction(writeTransaction);
-            wal->flushAllPages();
-            if (skipCheckpointForTestingRecovery) {
-                transactionManager->allowReceivingNewTransactions();
-                return;
-            }
-            checkpointAndClearWAL();
-        } else {
-            if (skipCheckpointForTestingRecovery) {
-                wal->flushAllPages();
-                return;
-            }
-            rollbackAndClearWAL();
-        }
-        transactionManager->manuallyClearActiveWriteTransaction(writeTransaction);
-        if (isCommit) {
-            transactionManager->allowReceivingNewTransactions();
-        }
-    }
+    void commitAndCheckpointOrRollback(transaction::Transaction* writeTransaction, bool isCommit,
+        bool skipCheckpointForTestingRecovery = false);
 
 private:
+    void initDBDirAndCoreFilesIfNecessary();
+    void initLoggers();
+
     inline void checkpointAndClearWAL() {
         checkpointOrRollbackAndClearWAL(false /* is not recovering */, true /* isCheckpoint */);
     }

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -12,7 +12,7 @@ namespace graphflow {
 namespace storage {
 
 BufferManager::BufferManager(uint64_t maxSizeForDefaultPagePool, uint64_t maxSizeForLargePagePool)
-    : logger{LoggerUtils::getOrCreateSpdLogger("buffer_manager")},
+    : logger{LoggerUtils::getOrCreateLogger("buffer_manager")},
       bufferPoolDefaultPages(make_unique<BufferPool>(DEFAULT_PAGE_SIZE, maxSizeForDefaultPagePool)),
       bufferPoolLargePages(make_unique<BufferPool>(LARGE_PAGE_SIZE, maxSizeForLargePagePool)) {
     logger->info("Done Initializing Buffer Manager.");

--- a/src/storage/buffer_manager/buffer_pool.cpp
+++ b/src/storage/buffer_manager/buffer_pool.cpp
@@ -42,7 +42,7 @@ bool Frame::acquireFrameLock(bool block) {
 }
 
 BufferPool::BufferPool(uint64_t pageSize, uint64_t maxSize)
-    : logger{LoggerUtils::getOrCreateSpdLogger("buffer_manager")}, pageSize{pageSize}, clockHand{0},
+    : logger{LoggerUtils::getOrCreateLogger("buffer_manager")}, pageSize{pageSize}, clockHand{0},
       numFrames((page_idx_t)(ceil((double)maxSize / (double)pageSize))) {
     assert(pageSize == DEFAULT_PAGE_SIZE || pageSize == LARGE_PAGE_SIZE);
     for (auto i = 0u; i < numFrames; ++i) {

--- a/src/storage/buffer_manager/file_handle.cpp
+++ b/src/storage/buffer_manager/file_handle.cpp
@@ -11,7 +11,7 @@ namespace graphflow {
 namespace storage {
 
 FileHandle::FileHandle(const string& path, uint8_t flags)
-    : logger{LoggerUtils::getOrCreateSpdLogger("storage")}, flags(flags) {
+    : logger{LoggerUtils::getOrCreateLogger("storage")}, flags(flags) {
     logger->trace("FileHandle: Path {}", path);
     if (!isNewTmpFile()) {
         constructExistingFileHandle(path);

--- a/src/storage/in_mem_csv_copier/in_mem_node_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_node_csv_copier.cpp
@@ -155,8 +155,8 @@ void InMemNodeCSVCopier::populateColumnsAndCountUnstrPropertyListSizesTask(uint6
     uint64_t blockId, uint64_t startOffset, HashIndexBuilder* IDIndex, InMemNodeCSVCopier* copier) {
     copier->logger->trace("Start: path={0} blkIdx={1}", copier->csvDescription.filePath, blockId);
     vector<PageByteCursor> overflowCursors(copier->nodeTableSchema->getNumStructuredProperties());
-    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
-        blockId, copier->logger);
+    CSVReader reader(
+        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     auto bufferOffset = 0u;
     while (reader.hasNextLine()) {
@@ -234,8 +234,8 @@ void InMemNodeCSVCopier::populateUnstrPropertyLists() {
 void InMemNodeCSVCopier::populateUnstrPropertyListsTask(
     uint64_t blockId, node_offset_t nodeOffsetStart, InMemNodeCSVCopier* copier) {
     copier->logger->trace("Start: path={0} blkIdx={1}", copier->csvDescription.filePath, blockId);
-    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
-        blockId, copier->logger);
+    CSVReader reader(
+        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     auto bufferOffset = 0u;
     PageByteCursor inMemOverflowFileCursor;

--- a/src/storage/in_mem_csv_copier/in_mem_rel_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_rel_csv_copier.cpp
@@ -176,8 +176,8 @@ void InMemRelCSVCopier::skipFirstRowIfNecessary(
 void InMemRelCSVCopier::populateAdjColumnsAndCountRelsInAdjListsTask(
     uint64_t blockId, uint64_t blockStartRelID, InMemRelCSVCopier* copier) {
     copier->logger->debug("Start: path=`{0}` blkIdx={1}", copier->csvDescription.filePath, blockId);
-    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
-        blockId, copier->logger);
+    CSVReader reader(
+        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     vector<bool> requireToReadTableLabels{true, true};
     vector<nodeID_t> nodeIDs{2};
@@ -507,8 +507,8 @@ void InMemRelCSVCopier::populateAdjAndPropertyLists() {
 void InMemRelCSVCopier::populateAdjAndPropertyListsTask(
     uint64_t blockId, uint64_t blockStartRelID, InMemRelCSVCopier* copier) {
     copier->logger->trace("Start: path=`{0}` blkIdx={1}", copier->csvDescription.filePath, blockId);
-    CSVReader reader(copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig,
-        blockId, copier->logger);
+    CSVReader reader(
+        copier->csvDescription.filePath, copier->csvDescription.csvReaderConfig, blockId);
     skipFirstRowIfNecessary(blockId, copier->csvDescription, reader);
     vector<bool> requireToReadTableLabels{true, true};
     vector<nodeID_t> nodeIDs{2};

--- a/src/storage/in_mem_csv_copier/in_mem_structures_csv_copier.cpp
+++ b/src/storage/in_mem_csv_copier/in_mem_structures_csv_copier.cpp
@@ -10,7 +10,7 @@ namespace storage {
 
 InMemStructuresCSVCopier::InMemStructuresCSVCopier(CSVDescription& csvDescription,
     string outputDirectory, TaskScheduler& taskScheduler, Catalog& catalog)
-    : logger{LoggerUtils::getOrCreateSpdLogger("CopyCSV")}, csvDescription{csvDescription},
+    : logger{LoggerUtils::getOrCreateLogger("loader")}, csvDescription{csvDescription},
       outputDirectory{move(outputDirectory)}, numBlocks{0},
       taskScheduler{taskScheduler}, catalog{catalog} {}
 
@@ -56,7 +56,7 @@ void InMemStructuresCSVCopier::countNumLinesAndUnstrPropertiesPerBlockTask(const
     uint64_t blockId, InMemStructuresCSVCopier* copier, uint64_t numTokensToSkip,
     unordered_set<string>* unstrPropertyNames) {
     copier->logger->trace("Start: path=`{0}` blkIdx={1}", fName, blockId);
-    CSVReader reader(fName, copier->csvDescription.csvReaderConfig, blockId, copier->logger);
+    CSVReader reader(fName, copier->csvDescription.csvReaderConfig, blockId);
     copier->numLinesPerBlock[blockId] = 0ull;
     while (reader.hasNextLine()) {
         copier->numLinesPerBlock[blockId]++;

--- a/src/storage/include/storage_manager.h
+++ b/src/storage/include/storage_manager.h
@@ -19,7 +19,7 @@ public:
     StorageManager(catalog::Catalog& catalog, BufferManager& bufferManager,
         MemoryManager& memoryManager, bool isInMemoryMode, WAL* wal);
 
-    virtual ~StorageManager();
+    ~StorageManager() = default;
 
     inline RelsStore& getRelsStore() const { return *relsStore; }
     inline NodesStore& getNodesStore() const { return *nodesStore; }

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -12,16 +12,12 @@ namespace storage {
 
 StorageManager::StorageManager(catalog::Catalog& catalog, BufferManager& bufferManager,
     MemoryManager& memoryManager, bool isInMemoryMode, WAL* wal)
-    : logger{LoggerUtils::getOrCreateSpdLogger("storage")}, catalog{catalog}, wal{wal} {
+    : logger{LoggerUtils::getOrCreateLogger("storage")}, catalog{catalog}, wal{wal} {
     logger->info("Initializing StorageManager from directory: " + wal->getDirectory());
     nodesStore = make_unique<NodesStore>(catalog, bufferManager, isInMemoryMode, wal);
     relsStore = make_unique<RelsStore>(catalog, bufferManager, memoryManager, isInMemoryMode, wal);
     nodesStore->getNodesStatisticsAndDeletedIDs().setAdjListsAndColumns(relsStore.get());
     logger->info("Done.");
-}
-
-StorageManager::~StorageManager() {
-    spdlog::drop("storage");
 }
 
 } // namespace storage

--- a/src/storage/storage_structure/include/lists/lists_metadata.h
+++ b/src/storage/storage_structure/include/lists/lists_metadata.h
@@ -26,7 +26,7 @@ public:
     static constexpr uint64_t LARGE_LIST_IDX_TO_PAGE_LIST_HEAD_IDX_MAP_HEADER_PAGE_IDX = 1;
     static constexpr uint64_t CHUNK_PAGE_LIST_HEADER_PAGE_IDX = 2;
 
-    explicit BaseListsMetadata() { logger = LoggerUtils::getOrCreateSpdLogger("storage"); }
+    explicit BaseListsMetadata() { logger = LoggerUtils::getOrCreateLogger("storage"); }
 
     inline static std::function<uint32_t(uint32_t)> getIdxInPageListToListPageIdxMapper(
         BaseInMemDiskArray<page_idx_t>* pageLists, uint32_t pageListsHead) {

--- a/src/storage/storage_structure/include/storage_structure.h
+++ b/src/storage/storage_structure/include/storage_structure.h
@@ -24,7 +24,7 @@ class StorageStructure {
 public:
     StorageStructure(const StorageStructureIDAndFName& storageStructureIDAndFName,
         BufferManager& bufferManager, bool isInMemory, WAL* wal)
-        : logger{LoggerUtils::getOrCreateSpdLogger("storage")},
+        : logger{LoggerUtils::getOrCreateLogger("storage")},
           fileHandle{storageStructureIDAndFName, FileHandle::O_PERSISTENT_FILE_NO_CREATE},
           bufferManager{bufferManager}, isInMemory_{isInMemory}, wal{wal} {
         if (isInMemory) {

--- a/src/storage/storage_structure/lists/list_headers.cpp
+++ b/src/storage/storage_structure/lists/list_headers.cpp
@@ -8,7 +8,7 @@ namespace graphflow {
 namespace storage {
 
 BaseListHeaders::BaseListHeaders() {
-    logger = LoggerUtils::getOrCreateSpdLogger("storage");
+    logger = LoggerUtils::getOrCreateLogger("storage");
 }
 
 ListHeadersBuilder::ListHeadersBuilder(const string& baseListFName, uint64_t numElements)

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -9,7 +9,7 @@ namespace storage {
 
 RelTable::RelTable(const Catalog& catalog, table_id_t tableID, BufferManager& bufferManager,
     MemoryManager& memoryManager, bool isInMemoryMode, WAL* wal)
-    : logger{LoggerUtils::getOrCreateSpdLogger("storage")}, tableID{tableID},
+    : logger{LoggerUtils::getOrCreateLogger("storage")}, tableID{tableID},
       isInMemoryMode{isInMemoryMode},
       adjAndPropertyListsUpdateStore{make_unique<AdjAndPropertyListsUpdateStore>(
           memoryManager, *catalog.getReadOnlyVersion()->getRelTableSchema(tableID))},

--- a/src/storage/store/table_statistics.cpp
+++ b/src/storage/store/table_statistics.cpp
@@ -6,7 +6,7 @@ namespace graphflow {
 namespace storage {
 
 TablesStatistics::TablesStatistics() {
-    logger = LoggerUtils::getOrCreateSpdLogger("storage");
+    logger = LoggerUtils::getOrCreateLogger("storage");
     tablesStatisticsContentForReadOnlyTrx = make_unique<TablesStatisticsContent>();
 }
 

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -9,7 +9,7 @@ namespace graphflow {
 namespace storage {
 
 WAL::WAL(const string& directory, BufferManager& bufferManager)
-    : logger{LoggerUtils::getOrCreateSpdLogger("wal")}, directory{directory},
+    : logger{LoggerUtils::getOrCreateLogger("wal")}, directory{directory},
       bufferManager{bufferManager}, isLastLoggedRecordCommit_{false} {
     fileHandle = WAL::createWALFileHandle(directory);
     initCurrentPage();

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -19,7 +19,7 @@ WALReplayer::WALReplayer(WAL* wal, StorageManager* storageManager, BufferManager
 }
 
 void WALReplayer::init() {
-    logger = LoggerUtils::getOrCreateSpdLogger("storage");
+    logger = LoggerUtils::getOrCreateLogger("storage");
     walFileHandle = WAL::createWALFileHandle(wal->getDirectory());
     pageBuffer = make_unique<uint8_t[]>(DEFAULT_PAGE_SIZE);
 }

--- a/src/transaction/include/transaction_manager.h
+++ b/src/transaction/include/transaction_manager.h
@@ -19,7 +19,7 @@ class TransactionManager {
 
 public:
     TransactionManager(storage::WAL& wal)
-        : logger{LoggerUtils::getOrCreateSpdLogger("transaction_manager")}, wal{wal},
+        : logger{LoggerUtils::getOrCreateLogger("transaction_manager")}, wal{wal},
           activeWriteTransactionID{INT64_MAX}, lastTransactionID{0}, lastCommitID{0} {};
     unique_ptr<Transaction> beginWriteTransaction();
     unique_ptr<Transaction> beginReadOnlyTransaction();

--- a/test/copy_csv/copy_csv_test.cpp
+++ b/test/copy_csv/copy_csv_test.cpp
@@ -142,7 +142,7 @@ TEST_F(CopyNodeCSVPropertyTest, NodeStructuredStringPropertyTest) {
         graph->getNodesStore().getNodePropertyColumn(tableID, propertyIdx.propertyID));
     string fName = "dataset/copy-csv-node-property-test/vPerson.csv";
     CSVReaderConfig config;
-    CSVReader csvReader(fName, config, LoggerUtils::getOrCreateSpdLogger("copyNodeCSVTest"));
+    CSVReader csvReader(fName, config);
     int lineIdx = 0;
     uint64_t count = 0;
     auto dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();


### PR DESCRIPTION
We cannot remove getOrCreateLogger as stated in issue #954 because 

- Some of the uint tests only starts a database component e.g. buffer_manager in which case logger cannot be found if we rely on database to create logger
- Multiple database instances might be created.