### PR TITLE
fix prepareStatment multiple execution

### DIFF
--- a/src/main/include/connection.h
+++ b/src/main/include/connection.h
@@ -172,8 +172,8 @@ protected:
 
     unique_ptr<QueryResult> queryResultWithError(std::string& errMsg);
 
-    void setQuerySummaryAndPreparedStatement(Statement* statement, Binder& binder,
-        QuerySummary* querySummary, PreparedStatement* preparedStatement);
+    void setQuerySummaryAndPreparedStatement(
+        Statement* statement, Binder& binder, PreparedStatement* preparedStatement);
 
     std::unique_ptr<PreparedStatement> prepareNoLock(const std::string& query);
 

--- a/src/main/include/plan_printer.h
+++ b/src/main/include/plan_printer.h
@@ -36,7 +36,7 @@ class OpProfileTree {
 public:
     OpProfileTree(PhysicalOperator* opProfileBoxes, Profiler& profiler);
 
-    void prettyPrintToShell() const;
+    ostringstream printPlanToOstream() const;
 
 private:
     static void calculateNumRowsAndColsForOp(
@@ -86,15 +86,15 @@ private:
 class PlanPrinter {
 
 public:
-    PlanPrinter(unique_ptr<PhysicalPlan> physicalPlan, unique_ptr<Profiler> profiler)
-        : physicalPlan{move(physicalPlan)}, profiler{move(profiler)} {}
+    PlanPrinter(PhysicalPlan* physicalPlan, unique_ptr<Profiler> profiler)
+        : physicalPlan{physicalPlan}, profiler{move(profiler)} {}
 
     inline nlohmann::json printPlanToJson() {
         return toJson(physicalPlan->lastOperator.get(), *profiler);
     }
 
-    inline void printPlanToShell() {
-        OpProfileTree(physicalPlan->lastOperator.get(), *profiler).prettyPrintToShell();
+    inline ostringstream printPlanToOstream() {
+        return OpProfileTree(physicalPlan->lastOperator.get(), *profiler).printPlanToOstream();
     }
 
     static inline string getOperatorName(PhysicalOperator* physicalOperator) {
@@ -109,7 +109,7 @@ private:
     nlohmann::json toJson(PhysicalOperator* physicalOperator, Profiler& profiler);
 
 private:
-    unique_ptr<PhysicalPlan> physicalPlan;
+    PhysicalPlan* physicalPlan;
     unique_ptr<Profiler> profiler;
 };
 

--- a/src/main/include/prepared_statement.h
+++ b/src/main/include/prepared_statement.h
@@ -21,18 +21,11 @@ class PreparedStatement {
     friend class graphflow::transaction::TinySnbCopyCSVTransactionTest;
 
 public:
-    PreparedStatement() { querySummary = make_unique<QuerySummary>(); }
-    ~PreparedStatement() = default;
-
     inline bool isSuccess() const { return success; }
     inline string getErrorMessage() const { return errMsg; }
 
     inline void createResultHeader(expression_vector expressions) {
         resultHeader = make_unique<QueryResultHeader>(move(expressions));
-    }
-
-    inline void createPlanPrinter(unique_ptr<Profiler> profiler) {
-        querySummary->planPrinter = make_unique<PlanPrinter>(move(physicalPlan), move(profiler));
     }
 
     inline bool isReadOnly() { return physicalPlan->isReadOnly(); }
@@ -41,8 +34,7 @@ private:
     bool allowActiveTransaction;
     bool success = true;
     string errMsg;
-
-    unique_ptr<QuerySummary> querySummary;
+    PreparedSummary preparedSummary;
     unordered_map<string, shared_ptr<Literal>> parameterMap;
     unique_ptr<QueryResultHeader> resultHeader;
     unique_ptr<PhysicalPlan> physicalPlan;

--- a/src/main/include/query_result.h
+++ b/src/main/include/query_result.h
@@ -15,6 +15,14 @@ struct QueryResultHeader {
 
     explicit QueryResultHeader(expression_vector expressions);
 
+    QueryResultHeader(
+        std::vector<common::DataType> columnDataTypes, std::vector<std::string> columnNames)
+        : columnDataTypes{move(columnDataTypes)}, columnNames{move(columnNames)} {}
+
+    unique_ptr<QueryResultHeader> copy() const {
+        return make_unique<QueryResultHeader>(columnDataTypes, columnNames);
+    }
+
     std::vector<common::DataType> columnDataTypes;
     std::vector<std::string> columnNames;
 };
@@ -23,8 +31,12 @@ class QueryResult {
     friend class Connection;
 
 public:
+    // Only used when we failed to prepare a query.
     QueryResult() = default;
-    ~QueryResult() = default;
+    explicit QueryResult(PreparedSummary preparedSummary) {
+        querySummary = make_unique<QuerySummary>();
+        querySummary->setPreparedSummary(preparedSummary);
+    }
 
     inline bool isSuccess() const { return success; }
     inline string getErrorMessage() const { return errMsg; }

--- a/src/main/include/query_summary.h
+++ b/src/main/include/query_summary.h
@@ -5,28 +5,37 @@
 namespace graphflow {
 namespace main {
 
+struct PreparedSummary {
+    double compilingTime = 0;
+    bool isExplain = false;
+    bool isProfile = false;
+};
+
 class QuerySummary {
     friend class Connection;
     friend class PreparedStatement;
 
 public:
-    double getCompilingTime() const { return compilingTime; }
+    double getCompilingTime() const { return preparedSummary.compilingTime; }
 
     double getExecutionTime() const { return executionTime; }
 
-    bool getIsExplain() const { return isExplain; }
+    bool getIsExplain() const { return preparedSummary.isExplain; }
 
-    bool getIsProfile() const { return isProfile; }
+    bool getIsProfile() const { return preparedSummary.isProfile; }
 
-    void printPlanToStdOut() { planPrinter->printPlanToShell(); }
-    nlohmann::json printPlanToJson() { return planPrinter->printPlanToJson(); }
+    ostringstream& getPlanAsOstream() { return planInOstream; }
+    nlohmann::json& printPlanToJson() { return planInJson; }
+
+    void setPreparedSummary(PreparedSummary preparedSummary) {
+        this->preparedSummary = preparedSummary;
+    }
 
 private:
-    double compilingTime = 0;
     double executionTime = 0;
-    bool isExplain = false;
-    bool isProfile = false;
-    std::unique_ptr<PlanPrinter> planPrinter;
+    PreparedSummary preparedSummary;
+    nlohmann::json planInJson;
+    ostringstream planInOstream;
 };
 
 } // namespace main

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -75,7 +75,7 @@ void printSpaceIfNecessary(uint32_t idx, ostringstream& oss) {
     }
 }
 
-void OpProfileTree::prettyPrintToShell() const {
+ostringstream OpProfileTree::printPlanToOstream() const {
     prettyPrintPlanTitle();
     ostringstream oss;
     for (auto i = 0u; i < opProfileBoxes.size(); i++) {
@@ -83,7 +83,7 @@ void OpProfileTree::prettyPrintToShell() const {
         printOpProfileBoxes(i, oss);
         printOpProfileBoxLowerFrame(i, oss);
     }
-    printf("%s", oss.str().c_str());
+    return oss;
 }
 
 void OpProfileTree::calculateNumRowsAndColsForOp(

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -112,3 +112,9 @@ TEST_F(ApiTest, ParamTypeError) {
     ASSERT_STREQ(
         "Parameter n has data type INT64 but expect STRING.", result->getErrorMessage().c_str());
 }
+
+TEST_F(ApiTest, MultipleExecutionOfPreparedStatement) {
+    auto preparedStatement = conn->prepare("MATCH (o:organisation) RETURN 2 + $a");
+    ASSERT_TRUE(conn->execute(preparedStatement.get(), make_pair(string("a"), (int64_t)1)));
+    ASSERT_TRUE(conn->execute(preparedStatement.get(), make_pair(string("a"), (int64_t)2)));
+}

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -279,7 +279,8 @@ void EmbeddedShell::printHelp() {
 void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
     auto querySummary = queryResult.getQuerySummary();
     if (querySummary->getIsExplain()) {
-        querySummary->printPlanToStdOut();
+        auto& oss = querySummary->getPlanAsOstream();
+        printf("%s", oss.str().c_str());
     } else {
         auto numTuples = queryResult.getNumTuples();
         // print query result (numFlatTuples & tuples)
@@ -333,7 +334,7 @@ void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
             printf("=============== Profiler Summary =============\n");
             printf("==============================================\n");
             printf(">> plan\n");
-            querySummary->printPlanToStdOut();
+            printf("%s", querySummary->getPlanAsOstream().str().c_str());
         }
     }
 }


### PR DESCRIPTION
This PR solves issue: #665.
This PR refactors the queryResult. querySummary, preparedStatement and introduced a new class: preparedStatementSummary
1. Instead of saving the querySummary in preparedStatement, we now save the new class `preparedStatementSummary` which contains the follow informaton: `isExplain` `isProfile` `compiling time`. 
2. We no longer save the planPrinter in the queryResult. Instead, we always print out the json and ostream format of the plan and save them in the queryResult. 