### PR TITLE
fix shell printing

### DIFF
--- a/src/main/include/plan_printer.h
+++ b/src/main/include/plan_printer.h
@@ -51,7 +51,7 @@ private:
 
     void printOpProfileBoxLowerFrame(uint32_t rowIdx, ostringstream& oss) const;
 
-    void prettyPrintPlanTitle() const;
+    void prettyPrintPlanTitle(ostringstream& oss) const;
 
     static string genHorizLine(uint32_t len);
 

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -76,8 +76,8 @@ void printSpaceIfNecessary(uint32_t idx, ostringstream& oss) {
 }
 
 ostringstream OpProfileTree::printPlanToOstream() const {
-    prettyPrintPlanTitle();
     ostringstream oss;
+    prettyPrintPlanTitle(oss);
     for (auto i = 0u; i < opProfileBoxes.size(); i++) {
         printOpProfileBoxUpperFrame(i, oss);
         printOpProfileBoxes(i, oss);
@@ -233,19 +233,17 @@ void OpProfileTree::printOpProfileBoxLowerFrame(uint32_t rowIdx, ostringstream& 
     oss << endl;
 }
 
-void OpProfileTree::prettyPrintPlanTitle() const {
-    ostringstream title;
+void OpProfileTree::prettyPrintPlanTitle(ostringstream& oss) const {
     const string physicalPlan = "Physical Plan";
-    title << "┌" << genHorizLine(opProfileBoxWidth - 2) << "┐" << endl;
-    title << "│┌" << genHorizLine(opProfileBoxWidth - 4) << "┐│" << endl;
+    oss << "┌" << genHorizLine(opProfileBoxWidth - 2) << "┐" << endl;
+    oss << "│┌" << genHorizLine(opProfileBoxWidth - 4) << "┐│" << endl;
     auto numLeftSpaces = (opProfileBoxWidth - physicalPlan.length() - 2 * (2 + INDENT_WIDTH)) / 2;
     auto numRightSpaces =
         opProfileBoxWidth - physicalPlan.length() - 2 * (2 + INDENT_WIDTH) - numLeftSpaces;
-    title << "││" << string(INDENT_WIDTH + numLeftSpaces, ' ') << physicalPlan
-          << string(INDENT_WIDTH + numRightSpaces, ' ') << "││" << endl;
-    title << "│└" << genHorizLine(opProfileBoxWidth - 4) << "┘│" << endl;
-    title << "└" << genHorizLine(opProfileBoxWidth - 2) << "┘" << endl;
-    printf("%s", title.str().c_str());
+    oss << "││" << string(INDENT_WIDTH + numLeftSpaces, ' ') << physicalPlan
+        << string(INDENT_WIDTH + numRightSpaces, ' ') << "││" << endl;
+    oss << "│└" << genHorizLine(opProfileBoxWidth - 4) << "┘│" << endl;
+    oss << "└" << genHorizLine(opProfileBoxWidth - 2) << "┘" << endl;
 }
 
 string OpProfileTree::genHorizLine(uint32_t len) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -310,7 +310,7 @@ void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
         lineSeparator = string(lineSeparatorLen, '-');
         printf("%s\n", lineSeparator.c_str());
 
-        if (queryResult.getColumnNames()[0] != "") {
+        if (queryResult.getNumColumns() != 0 && queryResult.getColumnNames()[0] != "") {
             for (auto i = 0u; i < colsWidth.size(); i++) {
                 printf("| %s", queryResult.getColumnNames()[i].c_str());
                 printf(


### PR DESCRIPTION
1. This PR fixes a bug in the physical plan printing. Instead of printing the physical plan directly to stdout, we should print it to the ostringstream.
2. If a queryResult doesn't have a header, we shouldn't try to output the header in the shell.