### PR TITLE
Add exception message for updating rel property

### DIFF
--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -99,6 +99,9 @@ unique_ptr<BoundUpdatingClause> Binder::bindSetClause(const UpdatingClause& upda
     for (auto i = 0u; i < setClause.getNumSetItems(); ++i) {
         auto setItem = setClause.getSetItem(i);
         auto boundLhs = expressionBinder.bindExpression(*setItem->origin);
+        if (boundLhs->getChild(0)->dataType.typeID != NODE) {
+            throw BinderException("Only updating node properties is supported.");
+        }
         auto boundRhs = expressionBinder.bindExpression(*setItem->target);
         boundRhs = ExpressionBinder::implicitCastIfNecessary(boundRhs, boundLhs->dataType);
         boundSetClause->addSetItem(make_pair(boundLhs, boundRhs));

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -434,3 +434,9 @@ TEST_F(BinderErrorTest, ReturnInternalType) {
     auto input = "match (p:person) return ID(p);";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
+
+TEST_F(BinderErrorTest, UpdateRelProperty) {
+    string expectedException = "Binder exception: Only updating node properties is supported.";
+    auto input = "match (p:person)-[e:knows]->(:person) set e.knowsdate = 2025";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}


### PR DESCRIPTION
Currently, we don't support updating/setting rel properties but the binder doesn't check whether the user tries to update/set a rel property.
This PR adds a check to binder, so it throws an exception if the user tries to update/set rel property.