### PR TITLE
Fix empty csr list bug

### DIFF
--- a/test/runner/e2e_delete_create_transaction_test.cpp
+++ b/test/runner/e2e_delete_create_transaction_test.cpp
@@ -752,3 +752,12 @@ TEST_F(CreateRelTrxTest, ViolateOneOneMultiplicityError) {
         "Runtime exception: RelTable 4 is a ONE_ONE table, but node(nodeOffset: 10, tableID: 0) "
         "has more than one neighbour in the forward direction.");
 }
+
+TEST_F(CreateRelTrxTest, CreateRelToEmptyRelTable) {
+    conn->query("create node table student(id INT64, PRIMARY KEY(id))");
+    conn->query("create rel table follows(FROM student TO student)");
+    conn->query("CREATE (s:student {id: 1})");
+    ASSERT_EQ(TestHelper::convertResultToString(
+                  *conn->query("match (s:student)-[:follows]->(:student) return count(s.id)"))[0],
+        to_string(0));
+}


### PR DESCRIPTION
This PR fixes the bug in update empty list.
1. We shouldn't create a dummy header with csrOffset=0,length=0. If a user simply adds a node with empty adjList, the header for that node is also csroffset=0, length=0. This causes a collision.
2. If the listLen is 0, we still need to update metadata.