### PR TITLE
Sleep a bit longer in threads

### DIFF
--- a/src/common/include/configs.h
+++ b/src/common/include/configs.h
@@ -30,7 +30,7 @@ constexpr const uint32_t VAR_LENGTH_EXTEND_MAX_DEPTH = 30;
 
 // This is the default thread sleep time we use when a thread,
 // e.g., a worker thread is in TaskScheduler, needs to block.
-constexpr const uint64_t THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS = 100;
+constexpr const uint64_t THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS = 500;
 
 // The number of pages for which we maintain a lock and a page version array for. Multi version file
 // design is meant to not contain any page version arrays if a group of pages do not contain


### PR DESCRIPTION
This PR increases the thread sleep time for query processor (and other threads in the system) from 100 microseconds to 500 microseconds. 

My machine's fan is always on because of CLI being open. Let's save some energy.