### PR TITLE
logger-level change

### DIFF
--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -67,7 +67,9 @@ void Connection::setQuerySummaryAndPreparedStatement(
 std::unique_ptr<PreparedStatement> Connection::prepareNoLock(const string& query) {
     auto preparedStatement = make_unique<PreparedStatement>();
     if (query.empty()) {
-        throw Exception("Input query is empty.");
+        preparedStatement->success = false;
+        preparedStatement->errMsg = "Connection Exception: Query is empty.";
+        return preparedStatement;
     }
     auto compilingTimer = TimeMetric(true /* enable */);
     compilingTimer.start();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -55,6 +55,7 @@ void Database::initLoggers() {
     LoggerUtils::getOrCreateLogger("storage");
     LoggerUtils::getOrCreateLogger("transaction_manager");
     LoggerUtils::getOrCreateLogger("wal");
+    spdlog::set_level(spdlog::level::err);
 }
 
 void Database::resizeBufferManager(uint64_t newSize) {

--- a/test/main/config_test.cpp
+++ b/test/main/config_test.cpp
@@ -4,6 +4,7 @@ using namespace kuzu::testing;
 
 TEST_F(ApiTest, DatabaseConfig) {
     auto db = make_unique<Database>(DatabaseConfig(TestHelper::TEMP_TEST_DIR));
+    spdlog::set_level(spdlog::level::debug);
     ASSERT_NO_THROW(db->resizeBufferManager(StorageConfig::DEFAULT_BUFFER_POOL_SIZE * 2));
     ASSERT_EQ(getDefaultBMSize(*db), (uint64_t)(StorageConfig::DEFAULT_BUFFER_POOL_SIZE * 2 *
                                                 StorageConfig::DEFAULT_PAGES_BUFFER_RATIO));
@@ -13,6 +14,7 @@ TEST_F(ApiTest, DatabaseConfig) {
 
 TEST_F(ApiTest, ClientConfig) {
     auto db = make_unique<Database>(DatabaseConfig(TestHelper::TEMP_TEST_DIR));
+    spdlog::set_level(spdlog::level::debug);
     auto conn = make_unique<Connection>(db.get());
     ASSERT_NO_THROW(conn->setMaxNumThreadForExec(2));
     ASSERT_EQ(conn->getMaxNumThreadForExec(), 2);

--- a/test/runner/e2e_exception_test.cpp
+++ b/test/runner/e2e_exception_test.cpp
@@ -191,3 +191,8 @@ TEST_F(TinySnbExceptionTest, ParserError) {
     auto result = conn->query("MATCH");
     ASSERT_STREQ(result->getErrorMessage().c_str(), "basic_string::_M_construct null not valid");
 }
+
+TEST_F(TinySnbExceptionTest, EmptyQuery) {
+    auto result = conn->query("");
+    ASSERT_STREQ(result->getErrorMessage().c_str(), "Connection Exception: Query is empty.");
+}

--- a/test/test_utility/include/test_helper.h
+++ b/test/test_utility/include/test_helper.h
@@ -64,6 +64,7 @@ public:
     inline void createDBAndConn() {
         database = make_unique<Database>(*databaseConfig, *systemConfig);
         conn = make_unique<Connection>(database.get());
+        spdlog::set_level(spdlog::level::debug);
     }
 
     void initGraph();

--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -13,6 +13,7 @@ BenchmarkRunner::BenchmarkRunner(const string& datasetPath, unique_ptr<Benchmark
     : config{move(config)} {
     database = make_unique<Database>(DatabaseConfig(datasetPath, this->config->isInMemoryMode),
         SystemConfig(this->config->bufferPoolSize));
+    spdlog::set_level(spdlog::level::debug);
 }
 
 void BenchmarkRunner::registerBenchmarks(const string& path) {

--- a/tools/join_order_pick/test/test.cpp
+++ b/tools/join_order_pick/test/test.cpp
@@ -13,6 +13,7 @@ public:
         database = make_unique<Database>(*databaseConfig, *systemConfig);
         conn = make_unique<JOConnection>(database.get());
         initDB();
+        spdlog::set_level(spdlog::level::debug);
     }
 
     void TearDown() override { FileUtils::removeDir(TEMP_DIR); }

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -28,7 +28,6 @@ int main(int argc, char* argv[]) {
     cout << "Enter \":help\" for usage hints." << endl;
     SystemConfig systemConfig(bpSizeInMB << 20);
     DatabaseConfig databaseConfig(databasePath, inMemoryFlag);
-    spdlog::set_level(spdlog::level::err);
     auto shell = EmbeddedShell(databaseConfig, systemConfig);
     shell.run();
     return 0;


### PR DESCRIPTION
1. Changes the logger level to ERROR by default. For testing, we will still use the debug log level.
2. Catches the exception if the query is empty.