### PR TITLE
add logger-level option

### DIFF
--- a/src/common/BUILD.bazel
+++ b/src/common/BUILD.bazel
@@ -226,3 +226,18 @@ cc_library(
     ],
     visibility = ["//visibility:public"],
 )
+
+cc_library(
+    name = "logging_level_util",
+    srcs = [
+        "logging_level_utils.cpp",
+    ],
+    hdrs = [
+        "include/logging_level_utils.h",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        "utils",
+        "@gabime_spdlog",
+    ],
+)

--- a/src/common/include/logging_level_utils.h
+++ b/src/common/include/logging_level_utils.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "spdlog/spdlog.h"
+
+using namespace std;
+
+namespace kuzu {
+namespace common {
+
+class LoggingLevelUtils {
+public:
+    static spdlog::level::level_enum convertStrToLevelEnum(string loggingLevel);
+
+    static string convertLevelEnumToStr(spdlog::level::level_enum levelEnum);
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/common/logging_level_utils.cpp
+++ b/src/common/logging_level_utils.cpp
@@ -1,0 +1,50 @@
+#include "src/common/include/logging_level_utils.h"
+
+#include "src/common/include/utils.h"
+
+namespace kuzu {
+namespace common {
+
+spdlog::level::level_enum LoggingLevelUtils::convertStrToLevelEnum(string loggingLevel) {
+    StringUtils::toLower(loggingLevel);
+    if (loggingLevel == "info") {
+        return spdlog::level::level_enum::info;
+    } else if (loggingLevel == "debug") {
+        return spdlog::level::level_enum::debug;
+    } else if (loggingLevel == "err") {
+        return spdlog::level::level_enum::err;
+    }
+    throw ConversionException(
+        StringUtils::string_format("Unsupported logging level: %s.", loggingLevel.c_str()));
+}
+
+string LoggingLevelUtils::convertLevelEnumToStr(spdlog::level::level_enum levelEnum) {
+    switch (levelEnum) {
+    case spdlog::level::level_enum::trace: {
+        return "trace";
+    }
+    case spdlog::level::level_enum::debug: {
+        return "debug";
+    }
+    case spdlog::level::level_enum::info: {
+        return "info";
+    }
+    case spdlog::level::level_enum::warn: {
+        return "warn";
+    }
+    case spdlog::level::level_enum::err: {
+        return "err";
+    }
+    case spdlog::level::level_enum::critical: {
+        return "critical";
+    }
+    case spdlog::level::level_enum::off: {
+        return "off";
+    }
+    default:
+        assert(false);
+    }
+}
+
+} // namespace common
+} // namespace kuzu

--- a/src/main/BUILD.bazel
+++ b/src/main/BUILD.bazel
@@ -13,6 +13,7 @@ cc_library(
     ],
     deps = [
         "//src/binder",
+        "//src/common:logging_level_util",
         "//src/parser",
         "//src/planner:enumerator",
         "//src/processor",

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -3,6 +3,7 @@
 #include "spdlog/spdlog.h"
 
 #include "src/common/include/configs.h"
+#include "src/common/include/logging_level_utils.h"
 #include "src/storage/include/wal_replayer.h"
 
 namespace kuzu {
@@ -56,6 +57,17 @@ void Database::initLoggers() {
     LoggerUtils::getOrCreateLogger("transaction_manager");
     LoggerUtils::getOrCreateLogger("wal");
     spdlog::set_level(spdlog::level::err);
+}
+
+void Database::setLoggingLevel(spdlog::level::level_enum loggingLevel) {
+    if (loggingLevel != spdlog::level::level_enum::debug &&
+        loggingLevel != spdlog::level::level_enum::info &&
+        loggingLevel != spdlog::level::level_enum::err) {
+        printf("Unsupported logging level: %s.",
+            LoggingLevelUtils::convertLevelEnumToStr(loggingLevel).c_str());
+        return;
+    }
+    spdlog::set_level(loggingLevel);
 }
 
 void Database::resizeBufferManager(uint64_t newSize) {

--- a/src/main/include/database.h
+++ b/src/main/include/database.h
@@ -55,9 +55,11 @@ public:
 
     explicit Database(const DatabaseConfig& databaseConfig, const SystemConfig& systemConfig);
 
-    ~Database() = default;
+    void setLoggingLevel(spdlog::level::level_enum loggingLevel);
 
     void resizeBufferManager(uint64_t newSize);
+
+    ~Database() = default;
 
 private:
     // TODO(Semih): This is refactored here for now to be able to test transaction behavior

--- a/tools/python_api/include/py_database.h
+++ b/tools/python_api/include/py_database.h
@@ -10,6 +10,10 @@ class PyDatabase {
     friend class PyConnection;
 
 public:
+    inline void setLoggingLevel(spdlog::level::level_enum logging_level) {
+        database->setLoggingLevel(logging_level);
+    }
+
     static void initialize(py::handle& m);
 
     explicit PyDatabase(const string& databasePath, uint64_t bufferPoolSize);

--- a/tools/python_api/kuzu_binding.cpp
+++ b/tools/python_api/kuzu_binding.cpp
@@ -1,8 +1,16 @@
 #include "include/py_connection.h"
 #include "include/py_database.h"
-#include "include/py_query_result_converter.h"
+
+void bindEnumTypes(py::module& m) {
+    py::enum_<spdlog::level::level_enum>(m, "loggingLevel")
+        .value("debug", spdlog::level::level_enum::debug)
+        .value("info", spdlog::level::level_enum::info)
+        .value("err", spdlog::level::level_enum::err)
+        .export_values();
+}
 
 void bind(py::module& m) {
+    bindEnumTypes(m);
     PyDatabase::initialize(m);
     PyConnection::initialize(m);
     PyQueryResult::initialize(m);

--- a/tools/python_api/py_database.cpp
+++ b/tools/python_api/py_database.cpp
@@ -4,7 +4,8 @@ void PyDatabase::initialize(py::handle& m) {
     py::class_<PyDatabase>(m, "database")
         .def(py::init<const string&, uint64_t>(), py::arg("database_path"),
             py::arg("buffer_pool_size") = 0)
-        .def("resize_buffer_manager", &PyDatabase::resizeBufferManager, py::arg("new_size"));
+        .def("resize_buffer_manager", &PyDatabase::resizeBufferManager, py::arg("new_size"))
+        .def("set_logging_level", &PyDatabase::setLoggingLevel, py::arg("logging_level"));
 }
 
 PyDatabase::PyDatabase(const string& databasePath, uint64_t bufferPoolSize) {

--- a/tools/python_api/test/conftest.py
+++ b/tools/python_api/test/conftest.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from tools.python_api import _kuzu as gdb
+from tools.python_api import _kuzu as kuzu
 
 
 # Note conftest is the default file name for sharing fixture through multiple test files. Do not change file name.
@@ -11,8 +11,8 @@ def init_tiny_snb(tmp_path):
     if os.path.exists(tmp_path):
         os.rmdir(tmp_path)
     output_path = str(tmp_path)
-    db = gdb.database(output_path)
-    conn = gdb.connection(db)
+    db = kuzu.database(output_path)
+    conn = kuzu.connection(db)
     conn.execute("CREATE NODE TABLE person (ID INT64, fName STRING, gender INT64, isStudent BOOLEAN, isWorker BOOLEAN, "
                  "age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration "
                  "INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], PRIMARY "
@@ -27,6 +27,6 @@ def init_tiny_snb(tmp_path):
 
 @pytest.fixture
 def establish_connection(init_tiny_snb):
-    db = gdb.database(init_tiny_snb, buffer_pool_size=256 * 1024 * 1024)
-    conn = gdb.connection(db, num_threads=4)
+    db = kuzu.database(init_tiny_snb, buffer_pool_size=256 * 1024 * 1024)
+    conn = kuzu.connection(db, num_threads=4)
     return conn, db

--- a/tools/python_api/test/example.py
+++ b/tools/python_api/test/example.py
@@ -1,11 +1,10 @@
-from tools.python_api import _kuzu as gdb
+from tools.python_api import _kuzu as kuzu
 
-
-databaseDir = "path_to_serialized_database"
-db = gdb.database(databaseDir)
-conn = gdb.connection(db)
+databaseDir = "path to database file"
+db = kuzu.database(databaseDir)
+conn = kuzu.connection(db)
 query = "MATCH (a:person) RETURN *;"
-result = conn.query(query)
+result = conn.execute(query)
 while result.hasNext():
     print(result.getNext())
 result.close()

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from pandas import Timestamp, Timedelta, isna
+from tools.python_api import _kuzu as kuzu
 
 
 def test_to_df(establish_connection):
@@ -76,4 +77,13 @@ def test_to_df(establish_connection):
 
     db.resize_buffer_manager(512 * 1024 * 1024)
     conn.set_max_threads_for_exec(4)
+    _test_to_df(conn)
+
+    db.set_logging_level(kuzu.loggingLevel.debug)
+    _test_to_df(conn)
+
+    db.set_logging_level(kuzu.loggingLevel.info)
+    _test_to_df(conn)
+
+    db.set_logging_level(kuzu.loggingLevel.err)
     _test_to_df(conn)

--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -31,6 +31,8 @@ private:
 
     void updateTableNames();
 
+    void setLoggingLevel(const string& loggingLevel);
+
 private:
     unique_ptr<Database> database;
     unique_ptr<Connection> conn;


### PR DESCRIPTION
This PR adds the `void Database::setLoggingLevel(spdlog::level::level_enum loggingLevel)` API to database. It allows user to set the logging level of the database. 
Currently supported logging levels: INFO, DEBUG, ERR.
