### PR TITLE
srcDstTableID refactor

### DIFF
--- a/dataset/tinysnb/eBelongs.csv
+++ b/dataset/tinysnb/eBelongs.csv
@@ -1,0 +1,3 @@
+person,0,organisation,1
+person,3,organisation,1
+organisation,4,country,0

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -31,15 +31,13 @@ unique_ptr<BoundStatement> Binder::bindCreateRelClause(const Statement& statemen
     auto propertyNameDataTypes =
         bindPropertyNameDataTypes(createRelClause.getPropertyNameDataTypes());
     auto relMultiplicity = getRelMultiplicityFromString(createRelClause.getRelMultiplicity());
-    unordered_set<table_id_t> srcTableIDs, dstTableIDs;
-    for (auto& srcTableName : createRelClause.getRelConnection().srcTableNames) {
-        for (auto& dstTableName : createRelClause.getRelConnection().dstTableNames) {
-            srcTableIDs.insert(bindNodeTable(srcTableName));
-            dstTableIDs.insert(bindNodeTable(dstTableName));
-        }
+    auto relConnections = createRelClause.getRelConnections();
+    vector<pair<table_id_t, table_id_t>> srcDstTableIDs;
+    for (auto& [srcTableName, dstTableName] : relConnections) {
+        srcDstTableIDs.emplace_back(bindNodeTable(srcTableName), bindNodeTable(dstTableName));
     }
-    return make_unique<BoundCreateRelClause>(tableName, move(propertyNameDataTypes),
-        relMultiplicity, SrcDstTableIDs(move(srcTableIDs), move(dstTableIDs)));
+    return make_unique<BoundCreateRelClause>(
+        tableName, move(propertyNameDataTypes), relMultiplicity, srcDstTableIDs);
 }
 
 unique_ptr<BoundStatement> Binder::bindDropTable(const Statement& statement) {

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -54,12 +54,10 @@ void Binder::bindQueryRel(const RelPattern& relPattern, const shared_ptr<NodeExp
     }
     // bind node to rel
     auto isLeftNodeSrc = RIGHT == relPattern.getDirection();
-    validateNodeAndRelTableIsConnected(
-        catalog, tableID, leftNode->getTableID(), isLeftNodeSrc ? FWD : BWD);
-    validateNodeAndRelTableIsConnected(
-        catalog, tableID, rightNode->getTableID(), isLeftNodeSrc ? BWD : FWD);
     auto srcNode = isLeftNodeSrc ? leftNode : rightNode;
     auto dstNode = isLeftNodeSrc ? rightNode : leftNode;
+    validateNodeAndRelTableIsConnected(
+        catalog, tableID, srcNode->getTableID(), dstNode->getTableID());
     if (srcNode->getUniqueName() == dstNode->getUniqueName()) {
         throw BinderException("Self-loop rel " + parsedName + " is not supported.");
     }

--- a/src/binder/bound_ddl/include/bound_create_rel_clause.h
+++ b/src/binder/bound_ddl/include/bound_create_rel_clause.h
@@ -9,18 +9,18 @@ class BoundCreateRelClause : public BoundCreateTable {
 public:
     explicit BoundCreateRelClause(string tableName,
         vector<PropertyNameDataType> propertyNameDataTypes, RelMultiplicity relMultiplicity,
-        SrcDstTableIDs srcDstTableIDs)
+        vector<pair<table_id_t, table_id_t>> srcDstTableIDs)
         : BoundCreateTable{StatementType::CREATE_REL_CLAUSE, move(tableName),
               move(propertyNameDataTypes)},
           relMultiplicity{relMultiplicity}, srcDstTableIDs{move(srcDstTableIDs)} {}
 
     RelMultiplicity getRelMultiplicity() const { return relMultiplicity; }
 
-    SrcDstTableIDs getSrcDstTableIDs() const { return srcDstTableIDs; }
+    vector<pair<table_id_t, table_id_t>> getSrcDstTableIDs() const { return srcDstTableIDs; }
 
 private:
     RelMultiplicity relMultiplicity;
-    SrcDstTableIDs srcDstTableIDs;
+    vector<pair<table_id_t, table_id_t>> srcDstTableIDs;
 };
 
 } // namespace binder

--- a/src/binder/include/binder.h
+++ b/src/binder/include/binder.h
@@ -120,7 +120,7 @@ private:
 
     // E.g. MATCH (:person)-[:studyAt]->(:person) ...
     static void validateNodeAndRelTableIsConnected(const Catalog& catalog_, table_id_t relTableID,
-        table_id_t nodeTableID, RelDirection direction);
+        table_id_t srcTableID, table_id_t dstTableID);
 
     // E.g. ... RETURN a, b AS a
     static void validateProjectionColumnNamesAreUnique(const expression_vector& expressions);

--- a/src/catalog/catalog_structs.cpp
+++ b/src/catalog/catalog_structs.cpp
@@ -58,9 +58,40 @@ vector<Property> NodeTableSchema::getAllNodeProperties() const {
 
 unordered_set<table_id_t> RelTableSchema::getAllNodeTableIDs() const {
     unordered_set<table_id_t> allNodeTableIDs;
-    allNodeTableIDs.insert(srcDstTableIDs.srcTableIDs.begin(), srcDstTableIDs.srcTableIDs.end());
-    allNodeTableIDs.insert(srcDstTableIDs.dstTableIDs.begin(), srcDstTableIDs.dstTableIDs.end());
+    for (auto& [srcTableID, dstTableID] : srcDstTableIDs) {
+        allNodeTableIDs.insert(srcTableID);
+        allNodeTableIDs.insert(dstTableID);
+    }
     return allNodeTableIDs;
+}
+
+unordered_set<table_id_t> RelTableSchema::getUniqueSrcTableIDs() const {
+    unordered_set<table_id_t> srcTableIDs;
+    for (auto& [srcTableID, dstTableID] : srcDstTableIDs) {
+        srcTableIDs.insert(srcTableID);
+    }
+    return srcTableIDs;
+}
+
+unordered_set<table_id_t> RelTableSchema::getUniqueDstTableIDs() const {
+    unordered_set<table_id_t> dstTableIDs;
+    for (auto& [srcTableID, dstTableID] : srcDstTableIDs) {
+        dstTableIDs.insert(dstTableID);
+    }
+    return dstTableIDs;
+}
+
+unordered_set<table_id_t> RelTableSchema::getUniqueNbrTableIDsForBoundTableIDDirection(
+    RelDirection direction, table_id_t boundTableID) const {
+    unordered_set<table_id_t> nbrTableIDs;
+    for (auto& [srcTableID, dstTableID] : srcDstTableIDs) {
+        if (direction == FWD && srcTableID == boundTableID) {
+            nbrTableIDs.insert(dstTableID);
+        } else if (direction == BWD && dstTableID == boundTableID) {
+            nbrTableIDs.insert(srcTableID);
+        }
+    }
+    return nbrTableIDs;
 }
 
 } // namespace catalog

--- a/src/catalog/include/catalog.h
+++ b/src/catalog/include/catalog.h
@@ -45,7 +45,8 @@ public:
         vector<PropertyNameDataType> structuredPropertyDefinitions);
 
     table_id_t addRelTableSchema(string tableName, RelMultiplicity relMultiplicity,
-        vector<PropertyNameDataType> structuredPropertyDefinitions, SrcDstTableIDs srcDstTableIDs);
+        vector<PropertyNameDataType> structuredPropertyDefinitions,
+        vector<pair<table_id_t, table_id_t>> srcDstTableIDs);
 
     virtual inline string getNodeTableName(table_id_t tableID) const {
         return nodeTableSchemas.at(tableID)->tableName;
@@ -57,11 +58,9 @@ public:
     inline NodeTableSchema* getNodeTableSchema(table_id_t tableID) const {
         return nodeTableSchemas.at(tableID).get();
     }
-    inline RelTableSchema* getRelTableSchema(table_id_t tableID) const {
+    virtual inline RelTableSchema* getRelTableSchema(table_id_t tableID) const {
         return relTableSchemas.at(tableID).get();
     }
-
-    inline uint64_t getNumNodeTables() const { return nodeTableSchemas.size(); }
 
     virtual inline bool containNodeTable(const string& tableName) const {
         return end(nodeTableNameToIDMap) != nodeTableNameToIDMap.find(tableName);
@@ -96,9 +95,6 @@ public:
     const Property& getNodePrimaryKeyProperty(table_id_t tableID) const;
 
     vector<Property> getAllNodeProperties(table_id_t tableID) const;
-    inline const vector<Property>& getStructuredNodeProperties(table_id_t tableID) const {
-        return nodeTableSchemas.at(tableID)->structuredProperties;
-    }
     inline const vector<Property>& getUnstructuredNodeProperties(table_id_t tableID) const {
         return nodeTableSchemas.at(tableID)->unstructuredProperties;
     }
@@ -115,6 +111,12 @@ public:
     inline unordered_map<table_id_t, unique_ptr<RelTableSchema>>& getRelTableSchemas() {
         return relTableSchemas;
     }
+    inline const unordered_set<table_id_t> getNodeTableIDsForRelTableDirection(
+        table_id_t relTableID, RelDirection direction) const {
+        auto relTableSchema = getRelTableSchema(relTableID);
+        return direction == FWD ? relTableSchema->getUniqueSrcTableIDs() :
+                                  relTableSchema->getUniqueDstTableIDs();
+    }
 
     void removeTableSchema(TableSchema* tableSchema);
 
@@ -122,8 +124,6 @@ public:
      * Graph topology functions.
      */
 
-    const unordered_set<table_id_t>& getNodeTableIDsForRelTableDirection(
-        table_id_t tableID, RelDirection direction) const;
     virtual const unordered_set<table_id_t>& getRelTableIDsForNodeTableDirection(
         table_id_t tableID, RelDirection direction) const;
 
@@ -188,7 +188,8 @@ public:
         vector<PropertyNameDataType> structuredPropertyDefinitions);
 
     table_id_t addRelTableSchema(string tableName, RelMultiplicity relMultiplicity,
-        vector<PropertyNameDataType> structuredPropertyDefinitions, SrcDstTableIDs srcDstTableIDs);
+        vector<PropertyNameDataType> structuredPropertyDefinitions,
+        vector<pair<table_id_t, table_id_t>> srcDstTableIDs);
 
     inline void setUnstructuredPropertiesOfNodeTableSchema(
         vector<string>& unstructuredProperties, table_id_t tableID) {

--- a/src/parser/ddl/include/create_rel_clause.h
+++ b/src/parser/ddl/include/create_rel_clause.h
@@ -7,28 +7,21 @@ namespace parser {
 
 using namespace std;
 
-struct RelConnection {
-    RelConnection(vector<string> srcTableNames, vector<string> dstTableNames)
-        : srcTableNames{move(srcTableNames)}, dstTableNames{move(dstTableNames)} {}
-    vector<string> srcTableNames;
-    vector<string> dstTableNames;
-};
-
 class CreateRelClause : public CreateTable {
 public:
     explicit CreateRelClause(string tableName, vector<pair<string, string>> propertyNameDataTypes,
-        string relMultiplicity, RelConnection relConnection)
+        string relMultiplicity, vector<pair<string, string>> relConnections)
         : CreateTable{StatementType::CREATE_REL_CLAUSE, move(tableName),
               move(propertyNameDataTypes)},
-          relMultiplicity{move(relMultiplicity)}, relConnection{move(relConnection)} {}
+          relMultiplicity{move(relMultiplicity)}, relConnections{move(relConnections)} {}
 
     inline string getRelMultiplicity() const { return relMultiplicity; }
 
-    inline RelConnection getRelConnection() const { return relConnection; }
+    inline vector<pair<string, string>> getRelConnections() const { return relConnections; }
 
 private:
     string relMultiplicity;
-    RelConnection relConnection;
+    vector<pair<string, string>> relConnections;
 };
 
 } // namespace parser

--- a/src/parser/include/transformer.h
+++ b/src/parser/include/transformer.h
@@ -194,7 +194,8 @@ private:
     vector<pair<string, string>> transformPropertyDefinitions(
         CypherParser::KU_PropertyDefinitionsContext& ctx);
 
-    RelConnection transformRelConnection(CypherParser::KU_RelConnectionsContext& ctx);
+    vector<pair<string, string>> transformRelConnections(
+        CypherParser::KU_RelConnectionsContext& ctx);
 
     vector<string> transformNodeLabels(CypherParser::KU_NodeLabelsContext& ctx);
 

--- a/src/planner/logical_plan/logical_operator/include/logical_create_rel_table.h
+++ b/src/planner/logical_plan/logical_operator/include/logical_create_rel_table.h
@@ -10,7 +10,7 @@ class LogicalCreateRelTable : public LogicalDDL {
 
 public:
     LogicalCreateRelTable(string tableName, vector<PropertyNameDataType> propertyNameDataTypes,
-        RelMultiplicity relMultiplicity, SrcDstTableIDs srcDstTableIDs)
+        RelMultiplicity relMultiplicity, vector<pair<table_id_t, table_id_t>> srcDstTableIDs)
         : LogicalDDL{move(tableName), move(propertyNameDataTypes)},
           relMultiplicity{relMultiplicity}, srcDstTableIDs{move(srcDstTableIDs)} {}
 
@@ -20,7 +20,7 @@ public:
 
     inline RelMultiplicity getRelMultiplicity() const { return relMultiplicity; }
 
-    inline SrcDstTableIDs getSrcDstTableIDs() const { return srcDstTableIDs; }
+    inline vector<pair<table_id_t, table_id_t>> getSrcDstTableIDs() const { return srcDstTableIDs; }
 
     inline unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalCreateRelTable>(
@@ -29,7 +29,7 @@ public:
 
 private:
     RelMultiplicity relMultiplicity;
-    SrcDstTableIDs srcDstTableIDs;
+    vector<pair<table_id_t, table_id_t>> srcDstTableIDs;
 };
 
 } // namespace planner

--- a/src/processor/operator/ddl/include/create_rel_table.h
+++ b/src/processor/operator/ddl/include/create_rel_table.h
@@ -11,8 +11,8 @@ class CreateRelTable : public CreateTable {
 public:
     CreateRelTable(Catalog* catalog, string tableName,
         vector<PropertyNameDataType> propertyNameDataTypes, RelMultiplicity relMultiplicity,
-        SrcDstTableIDs srcDstTableIDs, uint32_t id, const string& paramsString,
-        RelsStatistics* relsStatistics)
+        vector<pair<table_id_t, table_id_t>> srcDstTableIDs, uint32_t id,
+        const string& paramsString, RelsStatistics* relsStatistics)
         : CreateTable{catalog, move(tableName), move(propertyNameDataTypes), id, paramsString},
           relMultiplicity{relMultiplicity}, srcDstTableIDs{move(srcDstTableIDs)},
           relsStatistics{relsStatistics} {}
@@ -28,7 +28,7 @@ public:
 
 private:
     RelMultiplicity relMultiplicity;
-    SrcDstTableIDs srcDstTableIDs;
+    vector<pair<table_id_t, table_id_t>> srcDstTableIDs;
     RelsStatistics* relsStatistics;
 };
 

--- a/src/storage/in_mem_csv_copier/include/in_mem_rel_csv_copier.h
+++ b/src/storage/in_mem_csv_copier/include/in_mem_rel_csv_copier.h
@@ -103,7 +103,7 @@ private:
     map<table_id_t, unique_ptr<PrimaryKeyIndex>> pkIndexes;
     vector<map<table_id_t, unique_ptr<atomic_uint64_vec_t>>> directionTableListSizes{2};
     vector<map<table_id_t, atomic<uint64_t>>> directionNumRelsPerTable{2};
-    vector<NodeIDCompressionScheme> directionNodeIDCompressionScheme{2};
+    vector<map<table_id_t, NodeIDCompressionScheme>> directionNodeIDCompressionScheme{2};
     vector<table_adj_in_mem_columns_map_t> directionTableAdjColumns{2};
     vector<table_property_in_mem_columns_map_t> directionTablePropertyColumns{2};
     vector<table_adj_in_mem_lists_map_t> directionTableAdjLists{2};

--- a/src/storage/include/wal_replayer_utils.h
+++ b/src/storage/include/wal_replayer_utils.h
@@ -53,13 +53,11 @@ private:
 
     static void createEmptyDBFilesForColumns(const unordered_set<table_id_t>& nodeTableIDs,
         const map<table_id_t, uint64_t>& maxNodeOffsetsPerTable, RelDirection relDirection,
-        const string& directory, const NodeIDCompressionScheme& directionNodeIDCompressionScheme,
-        RelTableSchema* relTableSchema);
+        const string& directory, RelTableSchema* relTableSchema);
 
-    static void createEmptyDBFilesForLists(const unordered_set<table_id_t>& nodeTableIDs,
+    static void createEmptyDBFilesForLists(const unordered_set<table_id_t>& boundTableIDs,
         const map<table_id_t, uint64_t>& maxNodeOffsetsPerTable, RelDirection relDirection,
-        const string& directory, const NodeIDCompressionScheme& directionNodeIDCompressionScheme,
-        RelTableSchema* relTableSchema);
+        const string& directory, RelTableSchema* relTableSchema);
 
     static void replaceOriginalColumnFilesWithWALVersionIfExists(string originalColFileName);
 

--- a/src/storage/storage_structure/lists/adj_and_property_lists_update_store.cpp
+++ b/src/storage/storage_structure/lists/adj_and_property_lists_update_store.cpp
@@ -133,14 +133,15 @@ uint32_t AdjAndPropertyListsUpdateStore::getColIdxInFT(ListFileID& listFileID) c
 
 void AdjAndPropertyListsUpdateStore::initListUpdatesPerTablePerDirection() {
     listUpdatesPerTablePerDirection.clear();
-    auto srcDstTableIDs = relTableSchema.getSrcDstTableIDs();
     for (auto direction : REL_DIRECTIONS) {
         listUpdatesPerTablePerDirection.push_back(map<table_id_t, ListUpdatesPerChunk>{});
-        auto tableIDs = direction == RelDirection::FWD ? srcDstTableIDs.srcTableIDs :
-                                                         srcDstTableIDs.dstTableIDs;
+        auto boundTableIDs = direction == RelDirection::FWD ?
+                                 relTableSchema.getUniqueSrcTableIDs() :
+                                 relTableSchema.getUniqueDstTableIDs();
         if (relTableSchema.isStoredAsLists(direction)) {
-            for (auto tableID : tableIDs) {
-                listUpdatesPerTablePerDirection[direction].emplace(tableID, ListUpdatesPerChunk{});
+            for (auto boundTableID : boundTableIDs) {
+                listUpdatesPerTablePerDirection[direction].emplace(
+                    boundTableID, ListUpdatesPerChunk{});
             }
         }
     }

--- a/src/storage/store/include/rels_statistics.h
+++ b/src/storage/store/include/rels_statistics.h
@@ -17,7 +17,7 @@ public:
         uint64_t numRels, vector<unordered_map<table_id_t, uint64_t>> numRelsPerDirectionBoundTable)
         : TableStatistics{numRels}, numRelsPerDirectionBoundTable{
                                         move(numRelsPerDirectionBoundTable)} {}
-    RelStatistics(SrcDstTableIDs srcDstTableIDs);
+    RelStatistics(vector<pair<table_id_t, table_id_t>> srcDstTableIDs);
 
     inline uint64_t getNumRelsForDirectionBoundTable(
         RelDirection relDirection, table_id_t boundNodeTableID) const {

--- a/src/storage/store/rels_statistics.cpp
+++ b/src/storage/store/rels_statistics.cpp
@@ -3,12 +3,11 @@
 namespace kuzu {
 namespace storage {
 
-RelStatistics::RelStatistics(SrcDstTableIDs srcDstTableIDs) : TableStatistics{0} {
+RelStatistics::RelStatistics(vector<pair<table_id_t, table_id_t>> srcDstTableIDs)
+    : TableStatistics{0} {
     numRelsPerDirectionBoundTable.resize(2);
-    for (auto srcTableID : srcDstTableIDs.srcTableIDs) {
+    for (auto& [srcTableID, dstTableID] : srcDstTableIDs) {
         numRelsPerDirectionBoundTable[RelDirection::FWD].emplace(srcTableID, 0);
-    }
-    for (auto dstTableID : srcDstTableIDs.dstTableIDs) {
         numRelsPerDirectionBoundTable[RelDirection::BWD].emplace(dstTableID, 0);
     }
 }

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -34,7 +34,7 @@ TEST_F(BinderErrorTest, NodeTableNotExist) {
 
 TEST_F(BinderErrorTest, NodeRelNotConnect) {
     string expectedException =
-        "Binder exception: Node table person doesn't connect to rel table workAt.";
+        "Binder exception: Node table person doesn't connect to person through rel table workAt.";
     auto input = "MATCH (a:person)-[e1:workAt]->(b:person) RETURN COUNT(*);";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }

--- a/test/catalog/catalog_test.cpp
+++ b/test/catalog/catalog_test.cpp
@@ -49,7 +49,7 @@ public:
         knowsProperties.emplace_back("validInterval", INTERVAL);
         KNOWS_TABLE_ID =
             catalog->getReadOnlyVersion()->addRelTableSchema("knows", MANY_MANY, knowsProperties,
-                SrcDstTableIDs{unordered_set<table_id_t>{0}, unordered_set<table_id_t>{0}});
+                vector<pair<table_id_t, table_id_t>>{{0 /* srcTableID */, 0 /* dstTableID */}});
     }
 
 public:

--- a/test/mock/mock_catalog.h
+++ b/test/mock/mock_catalog.h
@@ -59,6 +59,7 @@ public:
     MOCK_METHOD(string, getNodeTableName, (table_id_t tableID), (const, override));
     MOCK_METHOD(string, getRelTableName, (table_id_t tableID), (const, override));
     MOCK_METHOD(uint64_t, getNumNodes, (table_id_t tableID), (const override));
+    MOCK_METHOD(RelTableSchema*, getRelTableSchema, (table_id_t tableID), (const override));
 };
 
 /**
@@ -73,8 +74,8 @@ public:
     void setUp() {
         setSrcNodeTableToRelTables();
         setDstNodeTableToRelTables();
+        setRelTableSchemas();
         setProperties();
-
         setActionForContainNodeProperty();
         setActionForContainRelProperty();
         secActionForGetNodeProperty();
@@ -87,6 +88,7 @@ public:
         setActionForGetRelTableFromString();
         setActionForGetNodeTableName();
         setActionForGetRelTableName();
+        setActionForGetRelTableSchema();
     }
 
 private:
@@ -190,6 +192,13 @@ private:
         ON_CALL(*this, getRelTableName(WORKAT_TABLE_ID)).WillByDefault(Return(WORKAT_TABLE_STR));
     }
 
+    void setActionForGetRelTableSchema() {
+        ON_CALL(*this, getRelTableSchema(KNOWS_TABLE_ID))
+            .WillByDefault(Return(knowsTableSchema.get()));
+        ON_CALL(*this, getRelTableSchema(WORKAT_TABLE_ID))
+            .WillByDefault(Return(workAtTableSchema.get()));
+    }
+
     void setSrcNodeTableToRelTables() {
         unordered_set<table_id_t> personToRelTableIDs = {KNOWS_TABLE_ID, WORKAT_TABLE_ID};
         unordered_set<table_id_t> organisationToRelTableIDs = {};
@@ -226,9 +235,20 @@ private:
             knowsDatePropertyDefinition, KNOWSDATE_PROPERTY_KEY_ID, KNOWS_TABLE_ID);
     }
 
+    void setRelTableSchemas() {
+        knowsTableSchema =
+            make_unique<RelTableSchema>("knows", KNOWS_TABLE_ID, MANY_MANY, vector<Property>{},
+                vector<pair<table_id_t, table_id_t>>{{PERSON_TABLE_ID, PERSON_TABLE_ID}});
+        workAtTableSchema =
+            make_unique<RelTableSchema>("workAt", WORKAT_TABLE_ID, MANY_ONE, vector<Property>{},
+                vector<pair<table_id_t, table_id_t>>{{PERSON_TABLE_ID, ORGANISATION_TABLE_ID}});
+    }
+
     vector<unordered_set<table_id_t>> srcNodeIDToRelIDs, dstNodeIDToRelIDs;
     Property ageProperty, nameProperty, descriptionProperty, birthDateProperty,
         registerTimeProperty, knowsDateProperty;
+    unique_ptr<RelTableSchema> knowsTableSchema;
+    unique_ptr<RelTableSchema> workAtTableSchema;
 };
 
 class TinySnbCatalog : public Catalog {

--- a/test/test_utility/test_helper.cpp
+++ b/test/test_utility/test_helper.cpp
@@ -168,25 +168,25 @@ void BaseGraphTest::validateNodeColumnAndListFilesExistence(
 void BaseGraphTest::validateRelColumnAndListFilesExistence(
     RelTableSchema* relTableSchema, DBFileType dbFileType, bool existence) {
     for (auto relDirection : REL_DIRECTIONS) {
-        unordered_set<table_id_t> nodeTableIDs = relDirection == FWD ?
-                                                     relTableSchema->srcDstTableIDs.srcTableIDs :
-                                                     relTableSchema->srcDstTableIDs.dstTableIDs;
+        unordered_set<table_id_t> boundTableIDs = relDirection == FWD ?
+                                                      relTableSchema->getUniqueSrcTableIDs() :
+                                                      relTableSchema->getUniqueDstTableIDs();
         if (relTableSchema->relMultiplicity) {
-            for (auto nodeTableID : nodeTableIDs) {
+            for (auto boundTableID : boundTableIDs) {
                 validateColumnFilesExistence(
                     StorageUtils::getAdjColumnFName(databaseConfig->databasePath,
-                        relTableSchema->tableID, nodeTableID, relDirection, dbFileType),
+                        relTableSchema->tableID, boundTableID, relDirection, dbFileType),
                     existence, false /* hasOverflow */);
-                validateRelPropertyFiles(relTableSchema, nodeTableID, relDirection,
+                validateRelPropertyFiles(relTableSchema, boundTableID, relDirection,
                     true /* isColumnProperty */, dbFileType, existence);
             }
         } else {
-            for (auto nodeTableID : nodeTableIDs) {
+            for (auto boundTableID : boundTableIDs) {
                 validateListFilesExistence(
                     StorageUtils::getAdjListsFName(databaseConfig->databasePath,
-                        relTableSchema->tableID, nodeTableID, relDirection, dbFileType),
+                        relTableSchema->tableID, boundTableID, relDirection, dbFileType),
                     existence, false /* hasOverflow */, true /* hasHeader */);
-                validateRelPropertyFiles(relTableSchema, nodeTableID, relDirection,
+                validateRelPropertyFiles(relTableSchema, boundTableID, relDirection,
                     false /* isColumnProperty */, dbFileType, existence);
             }
         }


### PR DESCRIPTION
This PR refactors the srcDstTableID. 
Instead of storing two unordered sets of src/dst tableIDs, we now store a vector of <srcTableID, dstTableID> pairs.
With the new  design of srcDstTableID, we now can support more generic relations. (eg. we can have a manages rel table whose relation is: president->manager, manager->worker).