### PR TITLE
Add setValue and getValue for ValueVector

### DIFF
--- a/src/common/types/include/ku_list.h
+++ b/src/common/types/include/ku_list.h
@@ -16,7 +16,7 @@ public:
 private:
     friend class InMemOverflowBufferUtils;
 
-    void set(const vector<uint8_t*>& parameters, DataTypeID childTypeId);
+    void set(const std::vector<uint8_t*>& parameters, DataTypeID childTypeId);
 
 public:
     uint64_t size;

--- a/src/common/types/include/types.h
+++ b/src/common/types/include/types.h
@@ -8,8 +8,6 @@
 #include <string>
 #include <vector>
 
-using namespace std;
-
 namespace kuzu {
 namespace common {
 
@@ -60,22 +58,23 @@ public:
     explicit DataType(DataTypeID typeID) : typeID{typeID}, childType{nullptr} {
         assert(typeID != LIST);
     }
-    DataType(DataTypeID typeID, unique_ptr<DataType> childType)
-        : typeID{typeID}, childType{move(childType)} {
+    DataType(DataTypeID typeID, std::unique_ptr<DataType> childType)
+        : typeID{typeID}, childType{std::move(childType)} {
         assert(typeID == LIST);
     }
 
     DataType(const DataType& other);
-    DataType(DataType&& other) noexcept : typeID{other.typeID}, childType{move(other.childType)} {}
+    DataType(DataType&& other) noexcept
+        : typeID{other.typeID}, childType{std::move(other.childType)} {}
 
-    static inline vector<DataTypeID> getNumericalTypeIDs() {
-        return vector<DataTypeID>{INT64, DOUBLE};
+    static inline std::vector<DataTypeID> getNumericalTypeIDs() {
+        return std::vector<DataTypeID>{INT64, DOUBLE};
     }
-    static inline vector<DataTypeID> getNumericalAndUnstructuredTypeIDs() {
-        return vector<DataTypeID>{INT64, DOUBLE, UNSTRUCTURED};
+    static inline std::vector<DataTypeID> getNumericalAndUnstructuredTypeIDs() {
+        return std::vector<DataTypeID>{INT64, DOUBLE, UNSTRUCTURED};
     }
-    static inline vector<DataTypeID> getAllValidTypeIDs() {
-        return vector<DataTypeID>{
+    static inline std::vector<DataTypeID> getAllValidTypeIDs() {
+        return std::vector<DataTypeID>{
             NODE_ID, BOOL, INT64, DOUBLE, STRING, UNSTRUCTURED, DATE, TIMESTAMP, INTERVAL, LIST};
     }
 
@@ -87,39 +86,39 @@ public:
 
     inline DataType& operator=(DataType&& other) noexcept {
         typeID = other.typeID;
-        childType = move(other.childType);
+        childType = std::move(other.childType);
         return *this;
     }
 
 public:
     DataTypeID typeID;
-    unique_ptr<DataType> childType;
+    std::unique_ptr<DataType> childType;
 
 private:
-    unique_ptr<DataType> copy();
+    std::unique_ptr<DataType> copy();
 };
 
 class Types {
 public:
-    static string dataTypeToString(const DataType& dataType);
-    static string dataTypeToString(DataTypeID dataTypeID);
-    static string dataTypesToString(const vector<DataType>& dataTypes);
-    static string dataTypesToString(const vector<DataTypeID>& dataTypeIDs);
-    static DataType dataTypeFromString(const string& dataTypeString);
-    static const uint32_t getDataTypeSize(DataTypeID dataTypeID);
-    static inline const uint32_t getDataTypeSize(const DataType& dataType) {
+    static std::string dataTypeToString(const DataType& dataType);
+    static std::string dataTypeToString(DataTypeID dataTypeID);
+    static std::string dataTypesToString(const std::vector<DataType>& dataTypes);
+    static std::string dataTypesToString(const std::vector<DataTypeID>& dataTypeIDs);
+    static DataType dataTypeFromString(const std::string& dataTypeString);
+    static uint32_t getDataTypeSize(DataTypeID dataTypeID);
+    static inline uint32_t getDataTypeSize(const DataType& dataType) {
         return getDataTypeSize(dataType.typeID);
     }
 
 private:
-    static DataTypeID dataTypeIDFromString(const string& dataTypeIDString);
+    static DataTypeID dataTypeIDFromString(const std::string& dataTypeIDString);
 };
 
 // RelDirection
 enum RelDirection : uint8_t { FWD = 0, BWD = 1 };
-const vector<RelDirection> REL_DIRECTIONS = {FWD, BWD};
+const std::vector<RelDirection> REL_DIRECTIONS = {FWD, BWD};
 RelDirection operator!(RelDirection& direction);
-string getRelDirectionAsString(RelDirection relDirection);
+std::string getRelDirectionAsString(RelDirection relDirection);
 
 enum class DBFileType : uint8_t { ORIGINAL = 0, WAL_VERSION = 1 };
 

--- a/src/common/types/ku_list.cpp
+++ b/src/common/types/ku_list.cpp
@@ -10,7 +10,7 @@ void ku_list_t::set(const uint8_t* values, const DataType& dataType) const {
         size * Types::getDataTypeSize(*dataType.childType));
 }
 
-void ku_list_t::set(const vector<uint8_t*>& parameters, DataTypeID childTypeId) {
+void ku_list_t::set(const std::vector<uint8_t*>& parameters, DataTypeID childTypeId) {
     this->size = parameters.size();
     auto numBytesOfListElement = Types::getDataTypeSize(childTypeId);
     for (auto i = 0u; i < parameters.size(); i++) {

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -140,7 +140,7 @@ string Types::dataTypesToString(const vector<DataTypeID>& dataTypeIDs) {
     return result;
 }
 
-const uint32_t Types::getDataTypeSize(DataTypeID dataTypeID) {
+uint32_t Types::getDataTypeSize(DataTypeID dataTypeID) {
     switch (dataTypeID) {
     case NODE_ID:
         return sizeof(nodeID_t);

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -7,10 +7,9 @@ namespace kuzu {
 namespace common {
 
 ValueVector::ValueVector(DataType dataType, MemoryManager* memoryManager)
-    : dataType{move(dataType)} {
+    : dataType{std::move(dataType)} {
     valueBuffer =
         make_unique<uint8_t[]>(Types::getDataTypeSize(this->dataType) * DEFAULT_VECTOR_CAPACITY);
-    values = valueBuffer.get();
     if (needOverflowBuffer()) {
         assert(memoryManager != nullptr);
         inMemOverflowBuffer = make_unique<InMemOverflowBuffer>(memoryManager);
@@ -19,15 +18,11 @@ ValueVector::ValueVector(DataType dataType, MemoryManager* memoryManager)
     numBytesPerValue = Types::getDataTypeSize(this->dataType);
 }
 
-void ValueVector::addString(uint64_t pos, char* value, uint64_t len) const {
+void ValueVector::addString(uint32_t pos, char* value, uint64_t len) const {
     assert(dataType.typeID == STRING);
-    auto vectorData = (ku_string_t*)values;
+    auto vectorData = (ku_string_t*)valueBuffer.get();
     auto& result = vectorData[pos];
     InMemOverflowBufferUtils::copyString(value, len, result, *inMemOverflowBuffer);
-}
-
-void ValueVector::addString(uint64_t pos, string value) const {
-    addString(pos, value.data(), value.length());
 }
 
 bool NodeIDVector::discardNull(ValueVector& vector) {
@@ -56,6 +51,28 @@ bool NodeIDVector::discardNull(ValueVector& vector) {
         }
     }
 }
+
+template<typename T>
+void ValueVector::setValue(uint32_t pos, T val) {
+    ((T*)valueBuffer.get())[pos] = val;
+}
+
+template<>
+void ValueVector::setValue(uint32_t pos, string val) {
+    addString(pos, val.data(), val.length());
+}
+
+template void ValueVector::setValue<nodeID_t>(uint32_t pos, nodeID_t val);
+template void ValueVector::setValue<bool>(uint32_t pos, bool val);
+template void ValueVector::setValue<int64_t>(uint32_t pos, int64_t val);
+template void ValueVector::setValue<hash_t>(uint32_t pos, hash_t val);
+template void ValueVector::setValue<double_t>(uint32_t pos, double_t val);
+template void ValueVector::setValue<date_t>(uint32_t pos, date_t val);
+template void ValueVector::setValue<timestamp_t>(uint32_t pos, timestamp_t val);
+template void ValueVector::setValue<interval_t>(uint32_t pos, interval_t val);
+template void ValueVector::setValue<ku_string_t>(uint32_t pos, ku_string_t val);
+template void ValueVector::setValue<ku_list_t>(uint32_t pos, ku_list_t val);
+template void ValueVector::setValue<Value>(uint32_t pos, Value val);
 
 } // namespace common
 } // namespace kuzu

--- a/src/common/vector/value_vector_utils.cpp
+++ b/src/common/vector/value_vector_utils.cpp
@@ -14,25 +14,25 @@ void ValueVectorUtils::addLiteralToStructuredVector(
     }
     switch (literal.dataType.typeID) {
     case INT64: {
-        ((int64_t*)resultVector.values)[pos] = literal.val.int64Val;
+        resultVector.setValue(pos, literal.val.int64Val);
     } break;
     case DOUBLE: {
-        ((double_t*)resultVector.values)[pos] = literal.val.doubleVal;
+        resultVector.setValue(pos, literal.val.doubleVal);
     } break;
     case BOOL: {
-        ((bool*)resultVector.values)[pos] = literal.val.booleanVal;
+        resultVector.setValue(pos, literal.val.booleanVal);
     } break;
     case DATE: {
-        ((date_t*)resultVector.values)[pos] = literal.val.dateVal;
+        resultVector.setValue(pos, literal.val.dateVal);
     } break;
     case TIMESTAMP: {
-        ((timestamp_t*)resultVector.values)[pos] = literal.val.timestampVal;
+        resultVector.setValue(pos, literal.val.timestampVal);
     } break;
     case INTERVAL: {
-        ((interval_t*)resultVector.values)[pos] = literal.val.intervalVal;
+        resultVector.setValue(pos, literal.val.intervalVal);
     } break;
     case STRING: {
-        resultVector.addString(pos, literal.strVal);
+        resultVector.setValue(pos, literal.strVal);
     } break;
     default:
         assert(false);
@@ -42,14 +42,14 @@ void ValueVectorUtils::addLiteralToStructuredVector(
 void ValueVectorUtils::copyNonNullDataWithSameTypeIntoPos(
     ValueVector& resultVector, uint64_t pos, const uint8_t* srcData) {
     copyNonNullDataWithSameType(resultVector.dataType, srcData,
-        resultVector.values + pos * resultVector.getNumBytesPerValue(),
+        resultVector.getData() + pos * resultVector.getNumBytesPerValue(),
         resultVector.getOverflowBuffer());
 }
 
 void ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(const ValueVector& srcVector,
     uint64_t pos, uint8_t* dstData, InMemOverflowBuffer& dstOverflowBuffer) {
     copyNonNullDataWithSameType(srcVector.dataType,
-        srcVector.values + pos * srcVector.getNumBytesPerValue(), dstData, dstOverflowBuffer);
+        srcVector.getData() + pos * srcVector.getNumBytesPerValue(), dstData, dstOverflowBuffer);
 }
 
 void ValueVectorUtils::copyNonNullDataWithSameType(const DataType& dataType, const uint8_t* srcData,

--- a/src/expression_evaluator/literal_evaluator.cpp
+++ b/src/expression_evaluator/literal_evaluator.cpp
@@ -13,9 +13,10 @@ void LiteralExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager*
 }
 
 bool LiteralExpressionEvaluator::select(SelectionVector& selVector) {
+    assert(resultVector->dataType.typeID == BOOL); // TODO(Guodong): Is this expected here?
     auto pos = resultVector->state->getPositionOfCurrIdx();
     assert(pos == 0u);
-    return resultVector->values[pos] == true && (!resultVector->isNull(pos));
+    return resultVector->getValue<bool>(pos) == true && (!resultVector->isNull(pos));
 }
 
 } // namespace evaluator

--- a/src/expression_evaluator/reference_evaluator.cpp
+++ b/src/expression_evaluator/reference_evaluator.cpp
@@ -5,7 +5,7 @@ namespace evaluator {
 
 inline static bool isTrue(ValueVector& vector, uint64_t pos) {
     assert(vector.dataType.typeID == BOOL);
-    return !vector.isNull(pos) && ((bool*)vector.values)[pos];
+    return !vector.isNull(pos) && vector.getValue<bool>(pos);
 }
 
 void ReferenceExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager* memoryManager) {

--- a/src/function/aggregate/include/avg.h
+++ b/src/function/aggregate/include/avg.h
@@ -49,13 +49,13 @@ struct AvgFunction {
 
     static void updateSingleValue(
         AvgState* state, ValueVector* input, uint32_t pos, uint64_t multiplicity) {
-        auto inputValues = (T*)input->values;
+        T val = input->getValue<T>(pos);
         for (auto i = 0u; i < multiplicity; ++i) {
             if (state->isNull) {
-                state->sum = inputValues[pos];
+                state->sum = val;
                 state->isNull = false;
             } else {
-                Add::operation(state->sum, inputValues[pos], state->sum);
+                Add::operation(state->sum, val, state->sum);
             }
         }
         state->count += multiplicity;

--- a/src/function/aggregate/include/min_max.h
+++ b/src/function/aggregate/include/min_max.h
@@ -48,14 +48,14 @@ struct MinMaxFunction {
 
     template<class OP>
     static void updateSingleValue(MinMaxState* state, ValueVector* input, uint32_t pos) {
-        auto inputValues = (T*)input->values;
+        T val = input->getValue<T>(pos);
         if (state->isNull) {
-            state->val = inputValues[pos];
+            state->val = val;
             state->isNull = false;
         } else {
             uint8_t compare_result;
-            OP::template operation<T, T>(inputValues[pos], state->val, compare_result);
-            state->val = compare_result ? inputValues[pos] : state->val;
+            OP::template operation<T, T>(val, state->val, compare_result);
+            state->val = compare_result ? val : state->val;
         }
     }
 

--- a/src/function/aggregate/include/sum.h
+++ b/src/function/aggregate/include/sum.h
@@ -47,13 +47,13 @@ struct SumFunction {
 
     static void updateSingleValue(
         SumState* state, ValueVector* input, uint32_t pos, uint64_t multiplicity) {
-        auto inputValues = (T*)input->values;
+        T val = input->getValue<T>(pos);
         for (auto j = 0u; j < multiplicity; ++j) {
             if (state->isNull) {
-                state->sum = inputValues[pos];
+                state->sum = val;
                 state->isNull = false;
             } else {
-                Add::operation(state->sum, inputValues[pos], state->sum);
+                Add::operation(state->sum, val, state->sum);
             }
         }
     }

--- a/src/function/hash/include/vector_hash_operations.h
+++ b/src/function/hash/include/vector_hash_operations.h
@@ -10,41 +10,44 @@ struct UnaryHashOperationExecutor {
     template<typename OPERAND_TYPE, typename RESULT_TYPE>
     static void execute(ValueVector& operand, ValueVector& result) {
         result.state = operand.state;
-        auto resultValues = (RESULT_TYPE*)result.values;
-        auto operandValues = (OPERAND_TYPE*)operand.values;
+        auto resultValues = (RESULT_TYPE*)result.getData();
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             if (!operand.isNull(pos)) {
-                operation::Hash::operation(operandValues[pos], resultValues[pos]);
+                operation::Hash::operation(operand.getValue<OPERAND_TYPE>(pos), resultValues[pos]);
             } else {
-                resultValues[pos] = operation::NULL_HASH;
+                result.setValue(pos, operation::NULL_HASH);
             }
         } else {
             if (operand.hasNoNullsGuarantee()) {
                 if (operand.state->selVector->isUnfiltered()) {
                     for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
-                        operation::Hash::operation(operandValues[i], resultValues[i]);
+                        operation::Hash::operation(
+                            operand.getValue<OPERAND_TYPE>(i), resultValues[i]);
                     }
                 } else {
                     for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                         auto pos = operand.state->selVector->selectedPositions[i];
-                        operation::Hash::operation(operandValues[pos], resultValues[pos]);
+                        operation::Hash::operation(
+                            operand.getValue<OPERAND_TYPE>(pos), resultValues[pos]);
                     }
                 }
             } else {
                 if (operand.state->selVector->isUnfiltered()) {
                     for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                         if (!operand.isNull(i)) {
-                            operation::Hash::operation(operandValues[i], resultValues[i]);
+                            operation::Hash::operation(
+                                operand.getValue<OPERAND_TYPE>(i), resultValues[i]);
                         } else {
-                            resultValues[i] = operation::NULL_HASH;
+                            result.setValue(i, operation::NULL_HASH);
                         }
                     }
                 } else {
                     for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                         auto pos = operand.state->selVector->selectedPositions[i];
                         if (!operand.isNull(pos)) {
-                            operation::Hash::operation(operandValues[pos], resultValues[pos]);
+                            operation::Hash::operation(
+                                operand.getValue<OPERAND_TYPE>(pos), resultValues[pos]);
                         } else {
                             resultValues[pos] = operation::NULL_HASH;
                         }

--- a/src/function/include/binary_operation_executor.h
+++ b/src/function/include/binary_operation_executor.h
@@ -45,8 +45,8 @@ struct BinaryOperationExecutor {
     static inline void executeOnValue(ValueVector& left, ValueVector& right,
         ValueVector& resultValueVector, uint64_t lPos, uint64_t rPos, uint64_t resPos) {
         OP_WRAPPER::template operation<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
-            ((LEFT_TYPE*)left.values)[lPos], ((RIGHT_TYPE*)right.values)[rPos],
-            ((RESULT_TYPE*)resultValueVector.values)[resPos], (void*)&left, (void*)&right,
+            ((LEFT_TYPE*)left.getData())[lPos], ((RIGHT_TYPE*)right.getData())[rPos],
+            ((RESULT_TYPE*)resultValueVector.getData())[resPos], (void*)&left, (void*)&right,
             (void*)&resultValueVector);
     }
 
@@ -231,10 +231,9 @@ struct BinaryOperationExecutor {
     template<class LEFT_TYPE, class RIGHT_TYPE, class FUNC>
     static void selectOnValue(ValueVector& left, ValueVector& right, uint64_t lPos, uint64_t rPos,
         uint64_t resPos, uint64_t& numSelectedValues, sel_t* selectedPositionsBuffer) {
-        auto lValues = (LEFT_TYPE*)left.values;
-        auto rValues = (RIGHT_TYPE*)right.values;
         uint8_t resultValue = 0;
-        FUNC::operation(lValues[lPos], rValues[rPos], resultValue);
+        FUNC::operation(
+            ((LEFT_TYPE*)left.getData())[lPos], ((RIGHT_TYPE*)right.getData())[rPos], resultValue);
         selectedPositionsBuffer[numSelectedValues] = resPos;
         numSelectedValues += (resultValue == true);
     }
@@ -243,11 +242,10 @@ struct BinaryOperationExecutor {
     static uint64_t selectBothFlat(ValueVector& left, ValueVector& right) {
         auto lPos = left.state->getPositionOfCurrIdx();
         auto rPos = right.state->getPositionOfCurrIdx();
-        auto lValues = (LEFT_TYPE*)left.values;
-        auto rValues = (RIGHT_TYPE*)right.values;
         uint8_t resultValue = 0;
         if (!left.isNull(lPos) && !right.isNull(rPos)) {
-            FUNC::operation(lValues[lPos], rValues[rPos], resultValue);
+            FUNC::operation(((LEFT_TYPE*)left.getData())[lPos],
+                ((RIGHT_TYPE*)right.getData())[rPos], resultValue);
         }
         return resultValue == true;
     }

--- a/src/function/include/const_operation_executor.h
+++ b/src/function/include/const_operation_executor.h
@@ -12,7 +12,7 @@ struct ConstOperationExecutor {
     template<typename RESULT_TYPE, typename OP>
     static void execute(ValueVector& result) {
         assert(result.state->isFlat());
-        auto resultValues = (RESULT_TYPE*)result.values;
+        auto resultValues = (RESULT_TYPE*)result.getData();
         auto idx = result.state->getPositionOfCurrIdx();
         assert(idx == 0);
         OP::operation(resultValues[idx]);

--- a/src/function/include/ternary_operation_executor.h
+++ b/src/function/include/ternary_operation_executor.h
@@ -30,12 +30,10 @@ struct TernaryOperationExecutor {
         typename OP_WRAPPER>
     static void executeOnValue(ValueVector& a, ValueVector& b, ValueVector& c, ValueVector& result,
         uint64_t aPos, uint64_t bPos, uint64_t cPos, uint64_t resPos) {
-        auto aValues = (A_TYPE*)a.values;
-        auto bValues = (B_TYPE*)b.values;
-        auto cValues = (C_TYPE*)c.values;
-        auto resValues = (RESULT_TYPE*)result.values;
+        auto resValues = (RESULT_TYPE*)result.getData();
         OP_WRAPPER::template operation<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(
-            aValues[aPos], bValues[bPos], cValues[cPos], resValues[resPos], (void*)&result);
+            ((A_TYPE*)a.getData())[aPos], ((B_TYPE*)b.getData())[bPos],
+            ((C_TYPE*)c.getData())[cPos], resValues[resPos], (void*)&result);
     }
 
     template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC,

--- a/src/function/include/unary_operation_executor.h
+++ b/src/function/include/unary_operation_executor.h
@@ -40,16 +40,16 @@ struct UnaryOperationExecutor {
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC, typename OP_WRAPPER>
     static void executeOnValue(ValueVector& operand, uint64_t operandPos, RESULT_TYPE& resultValue,
         ValueVector& resultValueVector) {
-        auto operandValues = (OPERAND_TYPE*)operand.values;
         OP_WRAPPER::template operation<OPERAND_TYPE, RESULT_TYPE, FUNC>(
-            operandValues[operandPos], resultValue, (void*)&resultValueVector, operand.dataType);
+            ((OPERAND_TYPE*)operand.getData())[operandPos], resultValue, (void*)&resultValueVector,
+            operand.dataType);
     }
 
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC, typename OP_WRAPPER>
     static void executeSwitch(ValueVector& operand, ValueVector& result) {
         result.resetOverflowBuffer();
         result.state = operand.state;
-        auto resultValues = (RESULT_TYPE*)result.values;
+        auto resultValues = (RESULT_TYPE*)result.getData();
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             result.setNull(pos, operand.isNull(pos));

--- a/src/function/include/vector_operations.h
+++ b/src/function/include/vector_operations.h
@@ -27,22 +27,23 @@ struct VectorOperationDefinition : public FunctionDefinition {
 
     VectorOperationDefinition(string name, vector<DataTypeID> parameterTypeIDs,
         DataTypeID returnTypeID, scalar_exec_func execFunc, bool isVarLength = false)
-        : VectorOperationDefinition{move(name), move(parameterTypeIDs), returnTypeID,
-              move(execFunc), nullptr, isVarLength} {}
+        : VectorOperationDefinition{std::move(name), std::move(parameterTypeIDs), returnTypeID,
+              std::move(execFunc), nullptr, isVarLength} {}
 
     VectorOperationDefinition(string name, vector<DataTypeID> parameterTypeIDs,
         DataTypeID returnTypeID, scalar_exec_func execFunc, scalar_select_func selectFunc,
         bool isVarLength = false)
-        : FunctionDefinition{move(name), move(parameterTypeIDs), returnTypeID}, execFunc{move(
-                                                                                    execFunc)},
-          selectFunc(move(selectFunc)), isVarLength{isVarLength} {}
+        : FunctionDefinition{std::move(name), std::move(parameterTypeIDs), returnTypeID},
+          execFunc{std::move(execFunc)},
+          selectFunc(std::move(selectFunc)), isVarLength{isVarLength} {}
 
     VectorOperationDefinition(string name, vector<DataTypeID> parameterTypeIDs,
         DataTypeID returnTypeID, scalar_exec_func execFunc, scalar_select_func selectFunc,
         scalar_bind_func bindFunc, bool isVarLength = false)
-        : FunctionDefinition{move(name), move(parameterTypeIDs), returnTypeID}, execFunc{move(
-                                                                                    execFunc)},
-          selectFunc(move(selectFunc)), bindFunc{move(bindFunc)}, isVarLength{isVarLength} {}
+        : FunctionDefinition{std::move(name), std::move(parameterTypeIDs), returnTypeID},
+          execFunc{std::move(execFunc)},
+          selectFunc(std::move(selectFunc)), bindFunc{std::move(bindFunc)}, isVarLength{
+                                                                                isVarLength} {}
 
     scalar_exec_func execFunc;
     scalar_select_func selectFunc;

--- a/src/function/list/vector_list_operation.cpp
+++ b/src/function/list/vector_list_operation.cpp
@@ -35,11 +35,12 @@ void VectorListOperations::ListCreation(
     auto elements = make_unique<uint8_t[]>(parameters.size() * numBytesOfListElement);
     if (result.state->isFlat()) {
         auto pos = result.state->getPositionOfCurrIdx();
-        auto& kuList = ((ku_list_t*)result.values)[pos];
+        auto& kuList = ((ku_list_t*)result.getData())[pos];
         for (auto paramIdx = 0u; paramIdx < parameters.size(); paramIdx++) {
             assert(parameters[paramIdx]->state->isFlat());
             memcpy(elements.get() + paramIdx * numBytesOfListElement,
-                parameters[paramIdx]->values + pos * numBytesOfListElement, numBytesOfListElement);
+                parameters[paramIdx]->getData() + pos * numBytesOfListElement,
+                numBytesOfListElement);
         }
         ku_list_t tmpList(parameters.size(), (uint64_t)elements.get());
         InMemOverflowBufferUtils::copyListRecursiveIfNested(
@@ -48,13 +49,13 @@ void VectorListOperations::ListCreation(
         for (auto selectedPos = 0u; selectedPos < result.state->selVector->selectedSize;
              ++selectedPos) {
             auto pos = result.state->selVector->selectedPositions[selectedPos];
-            auto& kuList = ((ku_list_t*)result.values)[pos];
+            auto& kuList = ((ku_list_t*)result.getData())[pos];
             for (auto paramIdx = 0u; paramIdx < parameters.size(); paramIdx++) {
                 auto parameterPos = parameters[paramIdx]->state->isFlat() ?
                                         parameters[paramIdx]->state->getPositionOfCurrIdx() :
                                         pos;
                 memcpy(elements.get() + paramIdx * numBytesOfListElement,
-                    parameters[paramIdx]->values + parameterPos * numBytesOfListElement,
+                    parameters[paramIdx]->getData() + parameterPos * numBytesOfListElement,
                     numBytesOfListElement);
             }
             ku_list_t tmpList(parameters.size(), (uint64_t)elements.get());

--- a/src/function/null/include/null_operation_executor.h
+++ b/src/function/null/include/null_operation_executor.h
@@ -11,21 +11,22 @@ struct NullOperationExecutor {
     static void execute(ValueVector& operand, ValueVector& result) {
         assert(result.dataType.typeID == BOOL);
         result.state = operand.state;
-        auto operandValues = (uint8_t*)operand.values;
-        auto resultValues = (uint8_t*)result.values;
+        auto resultValues = (uint8_t*)result.getData();
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
-            FUNC::operation(operandValues[pos], (bool)operand.isNull(pos), resultValues[pos]);
+            FUNC::operation(
+                operand.getValue<uint8_t>(pos), (bool)operand.isNull(pos), resultValues[pos]);
         } else {
             if (operand.state->selVector->isUnfiltered()) {
                 for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
-                    FUNC::operation(operandValues[i], (bool)operand.isNull(i), resultValues[i]);
+                    FUNC::operation(
+                        operand.getValue<uint8_t>(i), (bool)operand.isNull(i), resultValues[i]);
                 }
             } else {
                 for (auto i = 0u; i < operand.state->selVector->selectedSize; i++) {
                     auto pos = operand.state->selVector->selectedPositions[i];
-                    FUNC::operation(
-                        operandValues[pos], (bool)operand.isNull(pos), resultValues[pos]);
+                    FUNC::operation(operand.getValue<uint8_t>(pos), (bool)operand.isNull(pos),
+                        resultValues[pos]);
                 }
             }
         }
@@ -36,7 +37,7 @@ struct NullOperationExecutor {
         if (operand.state->isFlat()) {
             auto pos = operand.state->getPositionOfCurrIdx();
             uint8_t resultValue = 0;
-            FUNC::operation(operand.values[pos], operand.isNull(pos), resultValue);
+            FUNC::operation(operand.getValue<uint8_t>(pos), operand.isNull(pos), resultValue);
             return resultValue == true;
         } else {
             uint64_t numSelectedValues = 0;
@@ -54,8 +55,8 @@ struct NullOperationExecutor {
     static void selectOnValue(ValueVector& operand, uint64_t operandPos,
         uint64_t& numSelectedValues, sel_t* selectedPositionsBuffer) {
         uint8_t resultValue = 0;
-        auto operandValues = operand.values;
-        FUNC::operation(operandValues[operandPos], operand.isNull(operandPos), resultValue);
+        FUNC::operation(
+            operand.getValue<uint8_t>(operandPos), operand.isNull(operandPos), resultValue);
         selectedPositionsBuffer[numSelectedValues] = operandPos;
         numSelectedValues += resultValue == true;
     }

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -13,8 +13,8 @@ namespace processor {
 AggregateHashTable::AggregateHashTable(MemoryManager& memoryManager,
     vector<DataType> groupByHashKeysDataTypes, vector<DataType> groupByNonHashKeysDataTypes,
     const vector<unique_ptr<AggregateFunction>>& aggregateFunctions, uint64_t numEntriesToAllocate)
-    : BaseHashTable{memoryManager}, groupByHashKeysDataTypes{move(groupByHashKeysDataTypes)},
-      groupByNonHashKeysDataTypes{move(groupByNonHashKeysDataTypes)} {
+    : BaseHashTable{memoryManager}, groupByHashKeysDataTypes{std::move(groupByHashKeysDataTypes)},
+      groupByNonHashKeysDataTypes{std::move(groupByNonHashKeysDataTypes)} {
     initializeFT(aggregateFunctions);
     initializeHashTable(numEntriesToAllocate);
     distinctHashTables = AggregateHashTableUtils::createDistinctHashTables(
@@ -52,10 +52,9 @@ bool AggregateHashTable::isAggregateValueDistinctForGroupByKeys(
         VectorHashOperations::computeHash(aggregateVector, tmpHashResultVector.get());
         VectorHashOperations::combineHash(
             hashVector.get(), tmpHashResultVector.get(), tmpHashCombineResultVector.get());
-        hashVector = move(tmpHashResultVector);
+        hashVector = std::move(tmpHashResultVector);
     }
-    hash_t hash = *(hash_t*)(hashVector->values + hashVector->getNumBytesPerValue() *
-                                                      hashVector->state->getPositionOfCurrIdx());
+    hash_t hash = hashVector->getValue<hash_t>(hashVector->state->getPositionOfCurrIdx());
     auto distinctHTEntry = findEntryInDistinctHT(distinctKeyVectors, hash);
     if (distinctHTEntry == nullptr) {
         createEntryInDistinctHT(distinctKeyVectors, hash);
@@ -165,7 +164,7 @@ void AggregateHashTable::initializeFT(const vector<unique_ptr<AggregateFunction>
     tableSchema->appendColumn(make_unique<ColumnSchema>(isUnflat, dataChunkPos, sizeof(hash_t)));
     hashColIdxInFT = aggStateColIdxInFT + aggFuncs.size();
     hashColOffsetInFT = tableSchema->getColOffset(hashColIdxInFT);
-    factorizedTable = make_unique<FactorizedTable>(&memoryManager, move(tableSchema));
+    factorizedTable = make_unique<FactorizedTable>(&memoryManager, std::move(tableSchema));
 }
 
 void AggregateHashTable::initializeHashTable(uint64_t numEntriesToAllocate) {
@@ -291,7 +290,7 @@ void AggregateHashTable::initializeFTEntries(const vector<ValueVector*>& groupBy
         fillEntryWithInitialNullAggregateState(entry);
         // Fill the hashValue in the ftEntry.
         factorizedTable->updateFlatCellNoNull(entry, hashColIdxInFT,
-            hashVector->values + hashVector->getNumBytesPerValue() * entryIdx);
+            hashVector->getData() + hashVector->getNumBytesPerValue() * entryIdx);
     }
 }
 
@@ -315,10 +314,9 @@ void AggregateHashTable::increaseSlotIdx(uint64_t& slotIdx) const {
 }
 
 void AggregateHashTable::initTmpHashSlotsAndIdxes() {
-    auto hashVal = (hash_t*)hashVector->values;
     if (hashVector->state->isFlat()) {
         auto pos = hashVector->state->getPositionOfCurrIdx();
-        auto slotIdx = getSlotIdxForHash(hashVal[pos]);
+        auto slotIdx = getSlotIdxForHash(hashVector->getValue<hash_t>(pos));
         tmpSlotIdxes[pos] = slotIdx;
         hashSlotsToUpdateAggState[pos] = getHashSlot(slotIdx);
         tmpValueIdxes[0] = pos;
@@ -326,14 +324,14 @@ void AggregateHashTable::initTmpHashSlotsAndIdxes() {
         if (hashVector->state->selVector->isUnfiltered()) {
             for (auto i = 0u; i < hashVector->state->selVector->selectedSize; i++) {
                 tmpValueIdxes[i] = i;
-                tmpSlotIdxes[i] = getSlotIdxForHash(hashVal[i]);
+                tmpSlotIdxes[i] = getSlotIdxForHash(hashVector->getValue<hash_t>(i));
                 hashSlotsToUpdateAggState[i] = getHashSlot(tmpSlotIdxes[i]);
             }
         } else {
             for (auto i = 0u; i < hashVector->state->selVector->selectedSize; i++) {
                 auto pos = hashVector->state->selVector->selectedPositions[i];
                 tmpValueIdxes[i] = pos;
-                tmpSlotIdxes[pos] = getSlotIdxForHash(hashVal[pos]);
+                tmpSlotIdxes[pos] = getSlotIdxForHash(hashVector->getValue<hash_t>(pos));
                 hashSlotsToUpdateAggState[pos] = getHashSlot(tmpSlotIdxes[pos]);
             }
         }
@@ -362,7 +360,7 @@ void AggregateHashTable::findHashSlots(const vector<ValueVector*>& groupByFlatHa
         uint64_t numNoMatches = 0;
         for (auto i = 0u; i < numEntriesToFindHashSlots; i++) {
             auto idx = tmpValueIdxes[i];
-            auto hash = ((hash_t*)hashVector->values)[idx];
+            auto hash = hashVector->getValue<hash_t>(idx);
             auto slot = hashSlotsToUpdateAggState[idx];
             if (slot->entry == nullptr) {
                 entryIdxesToInitialize[numFTEntriesToUpdate++] = idx;
@@ -393,7 +391,7 @@ void AggregateHashTable::computeAndCombineVecHash(
         VectorHashOperations::computeHash(keyVector, tmpHashResultVector.get());
         VectorHashOperations::combineHash(
             hashVector.get(), tmpHashResultVector.get(), tmpHashCombineResultVector.get());
-        hashVector = move(tmpHashCombineResultVector);
+        hashVector = std::move(tmpHashCombineResultVector);
     }
 }
 
@@ -480,7 +478,7 @@ bool AggregateHashTable::matchFlatGroupByKeys(
         auto keyVector = keyVectors[i];
         assert(keyVector->state->isFlat());
         auto pos = keyVector->state->getPositionOfCurrIdx();
-        auto keyValue = keyVector->values + pos * keyVector->getNumBytesPerValue();
+        auto keyValue = keyVector->getData() + pos * keyVector->getNumBytesPerValue();
         auto isKeyVectorNull = keyVector->isNull(pos);
         auto isEntryKeyNull = factorizedTable->isNonOverflowColNull(
             entry + factorizedTable->getTableSchema()->getNullMapOffset(), i);
@@ -508,7 +506,7 @@ uint64_t AggregateHashTable::matchUnflatVecWithFTColumn(
         if (factorizedTable->hasNoNullGuarantee(colIdx)) {
             for (auto i = 0u; i < numMayMatches; i++) {
                 auto idx = mayMatchIdxes[i];
-                if (compareFuncs[colIdx](vector->values + idx * vector->getNumBytesPerValue(),
+                if (compareFuncs[colIdx](vector->getData() + idx * vector->getNumBytesPerValue(),
                         hashSlotsToUpdateAggState[idx]->entry + colOffset)) {
                     mayMatchIdxes[mayMatchIdx++] = idx;
                 } else {
@@ -518,7 +516,7 @@ uint64_t AggregateHashTable::matchUnflatVecWithFTColumn(
         } else {
             for (auto i = 0u; i < numMayMatches; i++) {
                 auto idx = mayMatchIdxes[i];
-                auto value = vector->values + idx * vector->getNumBytesPerValue();
+                auto value = vector->getData() + idx * vector->getNumBytesPerValue();
                 auto isEntryKeyNull = factorizedTable->isNonOverflowColNull(
                     hashSlotsToUpdateAggState[idx]->entry +
                         factorizedTable->getTableSchema()->getNullMapOffset(),
@@ -538,7 +536,7 @@ uint64_t AggregateHashTable::matchUnflatVecWithFTColumn(
     } else {
         for (auto i = 0u; i < numMayMatches; i++) {
             auto idx = mayMatchIdxes[i];
-            auto value = vector->values + idx * vector->getNumBytesPerValue();
+            auto value = vector->getData() + idx * vector->getNumBytesPerValue();
             auto isKeyVectorNull = vector->isNull(idx);
             auto isEntryKeyNull = factorizedTable->isNonOverflowColNull(
                 hashSlotsToUpdateAggState[idx]->entry +
@@ -569,7 +567,7 @@ uint64_t AggregateHashTable::matchFlatVecWithFTColumn(
     uint64_t mayMatchIdx = 0;
     auto pos = vector->state->getPositionOfCurrIdx();
     auto isVectorNull = vector->isNull(pos);
-    auto value = vector->values + pos * vector->getNumBytesPerValue();
+    auto value = vector->getData() + pos * vector->getNumBytesPerValue();
     for (auto i = 0u; i < numMayMatches; i++) {
         auto idx = mayMatchIdxes[i];
         auto isEntryKeyNull = factorizedTable->isNonOverflowColNull(
@@ -881,9 +879,9 @@ vector<unique_ptr<AggregateHashTable>> AggregateHashTableUtils::createDistinctHa
             distinctKeysDataTypes[groupByKeyDataTypes.size()] =
                 aggregateFunction->getInputDataType();
             vector<unique_ptr<AggregateFunction>> emptyFunctions;
-            auto ht = make_unique<AggregateHashTable>(memoryManager, move(distinctKeysDataTypes),
-                emptyFunctions, 0 /* numEntriesToAllocate */);
-            distinctHTs.push_back(move(ht));
+            auto ht = make_unique<AggregateHashTable>(memoryManager,
+                std::move(distinctKeysDataTypes), emptyFunctions, 0 /* numEntriesToAllocate */);
+            distinctHTs.push_back(std::move(ht));
         } else {
             distinctHTs.push_back(nullptr);
         }

--- a/src/processor/operator/aggregate/base_aggregate_scan.cpp
+++ b/src/processor/operator/aggregate/base_aggregate_scan.cpp
@@ -20,8 +20,8 @@ void BaseAggregateScan::writeAggregateResultToVector(
     if (aggregateState->isNull) {
         vector.setNull(pos, true);
     } else {
-        memcpy(vector.values + pos * Types::getDataTypeSize(vector.dataType),
-            aggregateState->getResult(), Types::getDataTypeSize(vector.dataType));
+        memcpy(vector.getData() + pos * vector.getNumBytesPerValue(), aggregateState->getResult(),
+            vector.getNumBytesPerValue());
     }
 }
 

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -14,7 +14,7 @@ JoinHashTable::JoinHashTable(MemoryManager& memoryManager, uint64_t numKeyColumn
     slotIdxInBlockMask = BitmaskUtils::all1sMaskForLeastSignificantBits(numSlotsPerBlockLog2);
     // Prev pointer is always the last column in the table.
     colOffsetOfPrevPtrInTuple = tableSchema->getColOffset(tableSchema->getNumColumns() - 1);
-    factorizedTable = make_unique<FactorizedTable>(&memoryManager, move(tableSchema));
+    factorizedTable = make_unique<FactorizedTable>(&memoryManager, std::move(tableSchema));
 }
 
 bool JoinHashTable::discardNullFromKeys(
@@ -94,12 +94,11 @@ void JoinHashTable::probe(
         function::VectorHashOperations::combineHash(
             hashVector.get(), tmpHashVector.get(), hashVector.get());
     }
-    auto hashes = (hash_t*)hashVector->values;
     auto startIdx = hashVector->state->isFlat() ? hashVector->state->currIdx : 0;
     auto numValues = hashVector->state->isFlat() ? 1 : hashVector->state->selVector->selectedSize;
     for (auto i = 0u; i < numValues; i++) {
         auto pos = hashVector->state->selVector->selectedPositions[i + startIdx];
-        probedTuples[i] = getTupleForHash(hashes[pos]);
+        probedTuples[i] = getTupleForHash(hashVector->getValue<hash_t>(pos));
     }
 }
 

--- a/src/processor/operator/index_scan.cpp
+++ b/src/processor/operator/index_scan.cpp
@@ -32,9 +32,8 @@ bool IndexScan::getNextTuples() {
     metrics->executionTime.stop();
     if (isSuccessfulLookup) {
         hasExecuted = true;
-        auto nodeIDValues = (nodeID_t*)outVector->values;
-        nodeIDValues[0].tableID = tableID;
-        nodeIDValues[0].offset = nodeOffset;
+        nodeID_t nodeID{nodeOffset, tableID};
+        outVector->setValue<nodeID_t>(0, nodeID);
     }
     return isSuccessfulLookup;
 }

--- a/src/processor/operator/intersect/intersect_hash_table.cpp
+++ b/src/processor/operator/intersect/intersect_hash_table.cpp
@@ -12,7 +12,7 @@ static void sortSelectedPos(const shared_ptr<ValueVector>& nodeIDVector) {
         selVector->resetSelectorToValuePosBuffer();
     }
     sort(selectedPos, selectedPos + size, [nodeIDVector](sel_t left, sel_t right) {
-        return ((nodeID_t*)nodeIDVector->values)[left] < ((nodeID_t*)nodeIDVector->values)[right];
+        return nodeIDVector->getValue<nodeID_t>(left) < nodeIDVector->getValue<nodeID_t>(right);
     });
 }
 

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -103,8 +103,8 @@ void OrderByKeyEncoder::encodeFlatVector(
         }
     } else {
         *tuplePtr = 0;
-        encodeFunctions[keyColIdx](
-            vector->values + vector->state->getPositionOfCurrIdx() * vector->getNumBytesPerValue(),
+        encodeFunctions[keyColIdx](vector->getData() + vector->state->getPositionOfCurrIdx() *
+                                                           vector->getNumBytesPerValue(),
             tuplePtr + 1, swapBytes);
     }
 }
@@ -112,7 +112,7 @@ void OrderByKeyEncoder::encodeFlatVector(
 void OrderByKeyEncoder::encodeUnflatVector(shared_ptr<ValueVector> vector, uint8_t* tuplePtr,
     uint32_t encodedTuples, uint32_t numEntriesToEncode, uint32_t keyColIdx) {
     if (vector->state->selVector->isUnfiltered()) {
-        auto value = vector->values + encodedTuples * vector->getNumBytesPerValue();
+        auto value = vector->getData() + encodedTuples * vector->getNumBytesPerValue();
         if (vector->hasNoNullsGuarantee()) {
             for (auto i = 0u; i < numEntriesToEncode; i++) {
                 *tuplePtr = 0;
@@ -139,7 +139,7 @@ void OrderByKeyEncoder::encodeUnflatVector(shared_ptr<ValueVector> vector, uint8
             for (auto i = 0u; i < numEntriesToEncode; i++) {
                 *tuplePtr = 0;
                 encodeFunctions[keyColIdx](
-                    vector->values +
+                    vector->getData() +
                         vector->state->selVector->selectedPositions[i + encodedTuples] *
                             vector->getNumBytesPerValue(),
                     tuplePtr + 1, swapBytes);
@@ -154,8 +154,9 @@ void OrderByKeyEncoder::encodeUnflatVector(shared_ptr<ValueVector> vector, uint8
                     }
                 } else {
                     *tuplePtr = 0;
-                    encodeFunctions[keyColIdx](vector->values + pos * vector->getNumBytesPerValue(),
-                        tuplePtr + 1, swapBytes);
+                    encodeFunctions[keyColIdx](
+                        vector->getData() + pos * vector->getNumBytesPerValue(), tuplePtr + 1,
+                        swapBytes);
                 }
                 tuplePtr += numBytesPerTuple;
             }

--- a/src/processor/operator/scan_node_id.cpp
+++ b/src/processor/operator/scan_node_id.cpp
@@ -65,7 +65,7 @@ bool ScanNodeID::getNextTuples() {
             metrics->executionTime.stop();
             return false;
         }
-        auto nodeIDValues = (nodeID_t*)(outValueVector->values);
+        auto nodeIDValues = (nodeID_t*)(outValueVector->getData());
         auto size = endOffset - startOffset;
         for (auto i = 0u; i < size; ++i) {
             nodeIDValues[i].offset = startOffset + i;

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -17,13 +17,13 @@ bool SemiMasker::getNextTuples() {
         metrics->executionTime.stop();
         return false;
     }
-    auto values = (nodeID_t*)keyValueVector->values;
     auto startIdx = keyValueVector->state->isFlat() ? keyValueVector->state->currIdx : 0;
     auto numValues =
         keyValueVector->state->isFlat() ? 1 : keyValueVector->state->selVector->selectedSize;
     for (auto i = 0u; i < numValues; i++) {
         auto pos = keyValueVector->state->selVector->selectedPositions[i + startIdx];
-        scanNodeIDSharedState->getSemiMask()->setMask(values[pos].offset, maskerIdx);
+        scanNodeIDSharedState->getSemiMask()->setMask(
+            keyValueVector->getValue<nodeID_t>(pos).offset, maskerIdx);
     }
     metrics->executionTime.stop();
     metrics->numOutputTuple.increase(

--- a/src/processor/operator/unwind.cpp
+++ b/src/processor/operator/unwind.cpp
@@ -45,7 +45,7 @@ bool Unwind::getNextTuples() {
             outValueVector->state->selVector->selectedSize = 0;
             continue;
         }
-        inputList = ((ku_list_t*)(expressionEvaluator->resultVector->values))[pos];
+        inputList = expressionEvaluator->resultVector->getValue<ku_list_t>(pos);
         startIndex = 0;
         auto totalElementsCopy = min(DEFAULT_VECTOR_CAPACITY, inputList.size);
         copyTuplesToOutVector(0, totalElementsCopy);

--- a/src/processor/operator/var_length_extend/var_length_adj_list_extend.cpp
+++ b/src/processor/operator/var_length_extend/var_length_adj_list_extend.cpp
@@ -42,7 +42,7 @@ bool VarLengthAdjListExtend::getNextTuples() {
                 !dfsLevelInfo->hasBeenOutput) {
                 // It is impossible for the children to have a null value, so we don't need
                 // to copy the null mask to the nbrNodeValueVector.
-                memcpy(nbrNodeValueVector->values, dfsLevelInfo->children->values,
+                memcpy(nbrNodeValueVector->getData(), dfsLevelInfo->children->getData(),
                     dfsLevelInfo->children->state->selVector->selectedSize *
                         Types::getDataTypeSize(dfsLevelInfo->children->dataType));
                 nbrNodeValueVector->state->selVector->selectedSize =
@@ -86,7 +86,7 @@ bool VarLengthAdjListExtend::addDFSLevelToStackIfParentExtends(uint64_t parent, 
         ->initListReadingState(parent, *dfsLevelInfo->listHandle, transaction->getType());
     ((AdjLists*)storage)->readValues(dfsLevelInfo->children, *dfsLevelInfo->listHandle);
     if (dfsLevelInfo->children->state->selVector->selectedSize != 0) {
-        dfsStack.emplace(move(dfsLevelInfo));
+        dfsStack.emplace(std::move(dfsLevelInfo));
         return true;
     }
     return false;

--- a/src/processor/operator/var_length_extend/var_length_column_extend.cpp
+++ b/src/processor/operator/var_length_extend/var_length_column_extend.cpp
@@ -21,7 +21,7 @@ shared_ptr<ResultSet> VarLengthColumnExtend::init(ExecutionContext* context) {
         // We can't add the dfsLevelInfo->children to the boundNodeValueVector's dataChunk in the
         // constructor, because the boundNodeValueVector hasn't been initialized in the constructor.
         dfsLevelInfo->children->state = boundNodeValueVector->state;
-        dfsLevelInfos[i] = move(dfsLevelInfo);
+        dfsLevelInfos[i] = std::move(dfsLevelInfo);
     }
     return resultSet;
 }
@@ -39,9 +39,9 @@ bool VarLengthColumnExtend::getNextTuples() {
                 // It is impossible for the children to have a null value, so we don't need
                 // to copy the null mask to the nbrNodeValueVector.
                 auto elementSize = Types::getDataTypeSize(dfsLevelInfo->children->dataType);
-                memcpy(nbrNodeValueVector->values +
+                memcpy(nbrNodeValueVector->getData() +
                            elementSize * nbrNodeValueVector->state->getPositionOfCurrIdx(),
-                    dfsLevelInfo->children->values +
+                    dfsLevelInfo->children->getData() +
                         elementSize * dfsLevelInfo->children->state->getPositionOfCurrIdx(),
                     elementSize);
                 dfsLevelInfo->hasBeenOutput = true;
@@ -71,7 +71,7 @@ bool VarLengthColumnExtend::addDFSLevelToStackIfParentExtends(
     dfsLevelInfo->reset();
     ((Column*)storage)->read(transaction, parentValueVector, dfsLevelInfo->children);
     if (!dfsLevelInfo->children->isNull(parentValueVector->state->getPositionOfCurrIdx())) {
-        dfsStack.emplace(move(dfsLevelInfo));
+        dfsStack.emplace(std::move(dfsLevelInfo));
         return true;
     }
     return false;

--- a/src/storage/include/node_id_compression_scheme.h
+++ b/src/storage/include/node_id_compression_scheme.h
@@ -21,7 +21,7 @@ public:
     inline table_id_t getCommonTableID() const { return commonTableID; }
 
     void readNodeID(uint8_t* data, nodeID_t* nodeID) const;
-    void writeNodeID(uint8_t* data, nodeID_t* nodeID) const;
+    void writeNodeID(uint8_t* data, const nodeID_t& nodeID) const;
 
 private:
     table_id_t commonTableID;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -464,11 +464,11 @@ bool PrimaryKeyIndex::lookup(
     Transaction* trx, ValueVector* keyVector, uint64_t vectorPos, node_offset_t& result) {
     assert(!keyVector->isNull(vectorPos));
     if (keyDataTypeID == INT64) {
-        auto key = ((int64_t*)keyVector->values)[vectorPos];
+        auto key = keyVector->getValue<int64_t>(vectorPos);
         return hashIndexForInt64->lookupInternal(
             trx, reinterpret_cast<const uint8_t*>(&key), result);
     } else {
-        auto key = ((ku_string_t*)keyVector->values)[vectorPos].getAsString();
+        auto key = keyVector->getValue<ku_string_t>(vectorPos).getAsString();
         return hashIndexForString->lookupInternal(
             trx, reinterpret_cast<const uint8_t*>(key.c_str()), result);
     }
@@ -477,10 +477,10 @@ bool PrimaryKeyIndex::lookup(
 void PrimaryKeyIndex::deleteKey(ValueVector* keyVector, uint64_t vectorPos) {
     assert(!keyVector->isNull(vectorPos));
     if (keyDataTypeID == INT64) {
-        auto key = ((int64_t*)keyVector->values)[vectorPos];
+        auto key = keyVector->getValue<int64_t>(vectorPos);
         hashIndexForInt64->deleteInternal(reinterpret_cast<const uint8_t*>(&key));
     } else {
-        auto key = ((ku_string_t*)keyVector->values)[vectorPos].getAsString();
+        auto key = keyVector->getValue<ku_string_t>(vectorPos).getAsString();
         hashIndexForString->deleteInternal(reinterpret_cast<const uint8_t*>(key.c_str()));
     }
 }
@@ -488,10 +488,10 @@ void PrimaryKeyIndex::deleteKey(ValueVector* keyVector, uint64_t vectorPos) {
 bool PrimaryKeyIndex::insert(ValueVector* keyVector, uint64_t vectorPos, node_offset_t value) {
     assert(!keyVector->isNull(vectorPos));
     if (keyDataTypeID == INT64) {
-        auto key = ((int64_t*)keyVector->values)[vectorPos];
+        auto key = keyVector->getValue<int64_t>(vectorPos);
         return hashIndexForInt64->insertInternal(reinterpret_cast<const uint8_t*>(&key), value);
     } else {
-        auto key = ((ku_string_t*)keyVector->values)[vectorPos].getAsString();
+        auto key = keyVector->getValue<ku_string_t>(vectorPos).getAsString();
         return hashIndexForString->insertInternal(
             reinterpret_cast<const uint8_t*>(key.c_str()), value);
     }

--- a/src/storage/node_id_compression_scheme.cpp
+++ b/src/storage/node_id_compression_scheme.cpp
@@ -5,18 +5,18 @@ namespace common {
 
 void NodeIDCompressionScheme::readNodeID(uint8_t* data, nodeID_t* nodeID) const {
     if (commonTableID == UINT64_MAX) {
-        memcpy(&*nodeID, data, Types::getDataTypeSize(NODE_ID));
+        memcpy(&*nodeID, data, sizeof(nodeID_t));
     } else {
         nodeID->tableID = commonTableID;
         memcpy(&nodeID->offset, data, sizeof(node_offset_t));
     }
 }
 
-void NodeIDCompressionScheme::writeNodeID(uint8_t* data, nodeID_t* nodeID) const {
+void NodeIDCompressionScheme::writeNodeID(uint8_t* data, const nodeID_t& nodeID) const {
     if (commonTableID == UINT64_MAX) {
-        memcpy(data, nodeID, Types::getDataTypeSize(NODE_ID));
+        memcpy(data, &nodeID, sizeof(nodeID_t));
     } else {
-        memcpy(data, &nodeID->offset, sizeof(node_offset_t));
+        memcpy(data, &nodeID.offset, sizeof(node_offset_t));
     }
 }
 

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -115,7 +115,7 @@ void Column::lookup(Transaction* transaction, const shared_ptr<ValueVector>& res
     auto frame = bufferManager.pin(*fileHandleToPin, pageIdxToPin);
     auto vectorBytesOffset = vectorPos * elementSize;
     auto frameBytesOffset = cursor.elemPosInPage * elementSize;
-    memcpy(resultVector->values + vectorBytesOffset, frame + frameBytesOffset, elementSize);
+    memcpy(resultVector->getData() + vectorBytesOffset, frame + frameBytesOffset, elementSize);
     readSingleNullBit(resultVector, frame, cursor.elemPosInPage, vectorPos);
     bufferManager.unpin(*fileHandleToPin, pageIdxToPin);
 }
@@ -153,7 +153,7 @@ void StringPropertyColumn::writeValueForSingleNodeIDPosition(node_offset_t nodeO
         auto stringToWriteTo =
             ((ku_string_t*)(updatedPageInfoAndWALPageFrame.frame +
                             mapElementPosToByteOffset(updatedPageInfoAndWALPageFrame.posInPage)));
-        auto stringToWriteFrom = ((ku_string_t*)vectorToWriteFrom->values)[posInVectorToWriteFrom];
+        auto stringToWriteFrom = vectorToWriteFrom->getValue<ku_string_t>(posInVectorToWriteFrom);
         // If the string we write is a long string, it's overflowPtr is currently pointing to
         // the overflow buffer of vectorToWriteFrom. We need to move it to storage.
         if (!ku_string_t::isShortString(stringToWriteFrom.len)) {
@@ -183,7 +183,7 @@ void ListPropertyColumn::writeValueForSingleNodeIDPosition(node_offset_t nodeOff
         auto kuListToWriteTo =
             ((ku_list_t*)(updatedPageInfoAndWALPageFrame.frame +
                           mapElementPosToByteOffset(updatedPageInfoAndWALPageFrame.posInPage)));
-        auto kuListToWriteFrom = ((ku_list_t*)vectorToWriteFrom->values)[posInVectorToWriteFrom];
+        auto kuListToWriteFrom = vectorToWriteFrom->getValue<ku_list_t>(posInVectorToWriteFrom);
         diskOverflowFile.writeListOverflowAndUpdateOverflowPtr(
             kuListToWriteFrom, *kuListToWriteTo, vectorToWriteFrom->dataType);
     }

--- a/src/storage/storage_structure/disk_overflow_file.cpp
+++ b/src/storage/storage_structure/disk_overflow_file.cpp
@@ -16,7 +16,7 @@ void DiskOverflowFile::readStringsToVector(TransactionType trxType, ValueVector&
             continue;
         }
         readStringToVector(
-            trxType, ((ku_string_t*)valueVector.values)[pos], valueVector.getOverflowBuffer());
+            trxType, ((ku_string_t*)valueVector.getData())[pos], valueVector.getOverflowBuffer());
     }
 }
 
@@ -45,7 +45,7 @@ void DiskOverflowFile::scanSequentialStringOverflow(TransactionType trxType, Val
         if (vector.isNull(pos)) {
             continue;
         }
-        auto& kuString = ((ku_string_t*)vector.values)[pos];
+        auto& kuString = ((ku_string_t*)vector.getData())[pos];
         if (ku_string_t::isShortString(kuString.len)) {
             continue;
         }
@@ -82,8 +82,8 @@ void DiskOverflowFile::readListsToVector(TransactionType trxType, ValueVector& v
     for (auto i = 0u; i < valueVector.state->selVector->selectedSize; i++) {
         auto pos = valueVector.state->selVector->selectedPositions[i];
         if (!valueVector.isNull(pos)) {
-            readListToVector(trxType, ((ku_list_t*)valueVector.values)[pos], valueVector.dataType,
-                valueVector.getOverflowBuffer());
+            readListToVector(trxType, ((ku_list_t*)valueVector.getData())[pos],
+                valueVector.dataType, valueVector.getOverflowBuffer());
         }
     }
 }

--- a/src/storage/storage_structure/in_mem_page.cpp
+++ b/src/storage/storage_structure/in_mem_page.cpp
@@ -33,7 +33,7 @@ void InMemPage::setElementAtPosToNonNull(uint32_t pos) {
 
 uint8_t* InMemPage::writeNodeID(nodeID_t* nodeID, uint32_t byteOffsetInPage, uint32_t elemPosInPage,
     const NodeIDCompressionScheme& nodeIDCompressionScheme) {
-    nodeIDCompressionScheme.writeNodeID(data + byteOffsetInPage, nodeID);
+    nodeIDCompressionScheme.writeNodeID(data + byteOffsetInPage, *nodeID);
     if (nullMask) {
         nullMask[elemPosInPage] = false;
     }

--- a/src/storage/storage_structure/include/column.h
+++ b/src/storage/storage_structure/include/column.h
@@ -62,7 +62,7 @@ private:
     virtual inline void writeToPage(WALPageIdxPosInPageAndFrame& walPageInfo,
         const shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
         memcpy(walPageInfo.frame + mapElementPosToByteOffset(walPageInfo.posInPage),
-            vectorToWriteFrom->values + posInVectorToWriteFrom * elementSize, elementSize);
+            vectorToWriteFrom->getData() + posInVectorToWriteFrom * elementSize, elementSize);
     }
     // If necessary creates a second version (backed by the WAL) of a page that contains the fixed
     // length part of the value that will be written to.
@@ -196,9 +196,7 @@ private:
         uint32_t posInVectorToWriteFrom) override {
         nodeIDCompressionScheme.writeNodeID(
             walPageInfo.frame + mapElementPosToByteOffset(walPageInfo.posInPage),
-            (nodeID_t*)(vectorToWriteFrom->values +
-                        posInVectorToWriteFrom *
-                            Types::getDataTypeSize(vectorToWriteFrom->dataType)));
+            vectorToWriteFrom->getValue<nodeID_t>(posInVectorToWriteFrom));
     }
 
 private:

--- a/src/storage/storage_structure/include/disk_overflow_file.h
+++ b/src/storage/storage_structure/include/disk_overflow_file.h
@@ -52,14 +52,14 @@ public:
     inline void scanSingleStringOverflow(
         TransactionType trxType, ValueVector& vector, uint64_t vectorPos) {
         assert(vector.dataType.typeID == STRING && !vector.isNull(vectorPos));
-        auto& kuString = ((ku_string_t*)vector.values)[vectorPos];
+        auto& kuString = ((ku_string_t*)vector.getData())[vectorPos];
         readStringToVector(trxType, kuString, vector.getOverflowBuffer());
     }
     void scanSequentialStringOverflow(TransactionType trxType, ValueVector& vector);
     inline void scanSingleListOverflow(
         TransactionType trxType, ValueVector& vector, uint64_t vectorPos) {
         assert(vector.dataType.typeID == LIST && !vector.isNull(vectorPos));
-        auto& kuList = ((ku_list_t*)vector.values)[vectorPos];
+        auto& kuList = ((ku_list_t*)vector.getData())[vectorPos];
         readListToVector(trxType, kuList, vector.dataType, vector.getOverflowBuffer());
     }
 

--- a/src/storage/storage_structure/include/lists/unstructured_property_lists_utils.h
+++ b/src/storage/storage_structure/include/lists/unstructured_property_lists_utils.h
@@ -17,10 +17,10 @@ struct UnstructuredPropertyKeyDataType {
 
 struct UnstrPropListWrapper {
 
-    UnstrPropListWrapper(unique_ptr<uint8_t[]> data, uint64_t size, uint64_t capacity)
-        : data{move(data)}, size{size}, capacity{capacity} {}
+    UnstrPropListWrapper(std::unique_ptr<uint8_t[]> data, uint64_t size, uint64_t capacity)
+        : data{std::move(data)}, size{size}, capacity{capacity} {}
 
-    unique_ptr<uint8_t[]> data;
+    std::unique_ptr<uint8_t[]> data;
     uint64_t size;
     uint64_t capacity;
 
@@ -38,7 +38,7 @@ class UnstrPropListIterator {
 
 public:
     UnstrPropListIterator() : UnstrPropListIterator(nullptr) {}
-    UnstrPropListIterator(UnstrPropListWrapper* unstrPropListWrapper)
+    explicit UnstrPropListIterator(UnstrPropListWrapper* unstrPropListWrapper)
         : unstrPropListWrapper{unstrPropListWrapper}, curOff{0} {}
 
     inline bool hasNext() { return curOff < unstrPropListWrapper->size; }
@@ -47,14 +47,14 @@ public:
 
     void skipValue();
 
-    inline uint64_t getCurOff() { return curOff; }
+    inline uint64_t getCurOff() const { return curOff; }
 
-    inline uint64_t getDataTypeSizeOfCurrProp() {
+    inline uint64_t getDataTypeSizeOfCurrProp() const {
         assert(propKeyDataTypeForRetVal.keyIdx != UINT32_MAX);
         return Types::getDataTypeSize(propKeyDataTypeForRetVal.dataTypeID);
     }
 
-    inline uint64_t getOffsetAtBeginningOfCurrProp() {
+    inline uint64_t getOffsetAtBeginningOfCurrProp() const {
         assert(propKeyDataTypeForRetVal.keyIdx != UINT32_MAX);
         return curOff - StorageConfig::UNSTR_PROP_HEADER_LEN;
     }

--- a/src/storage/storage_structure/lists/adj_and_property_lists_update_store.cpp
+++ b/src/storage/storage_structure/lists/adj_and_property_lists_update_store.cpp
@@ -26,7 +26,8 @@ AdjAndPropertyListsUpdateStore::AdjAndPropertyListsUpdateStore(
     nodeDataChunk->insert(0 /* pos */, srcNodeVector);
     dstNodeVector = make_shared<ValueVector>(NODE_ID, &memoryManager);
     nodeDataChunk->insert(1 /* pos */, dstNodeVector);
-    factorizedTable = make_unique<FactorizedTable>(&memoryManager, move(factorizedTableSchema));
+    factorizedTable =
+        make_unique<FactorizedTable>(&memoryManager, std::move(factorizedTableSchema));
     initListUpdatesPerTablePerDirection();
 }
 
@@ -45,7 +46,7 @@ bool AdjAndPropertyListsUpdateStore::isListEmptyInPersistentStore(
 
 bool AdjAndPropertyListsUpdateStore::hasUpdates() const {
     for (auto relDirection : REL_DIRECTIONS) {
-        for (auto listUpdatesPerTable : listUpdatesPerTablePerDirection[relDirection]) {
+        for (const auto& listUpdatesPerTable : listUpdatesPerTablePerDirection[relDirection]) {
             if (!listUpdatesPerTable.second.empty()) {
                 return true;
             }
@@ -67,13 +68,9 @@ void AdjAndPropertyListsUpdateStore::readInsertionsToList(ListFileID& listFileID
 void AdjAndPropertyListsUpdateStore::insertRelIfNecessary(shared_ptr<ValueVector>& srcNodeIDVector,
     shared_ptr<ValueVector>& dstNodeIDVector, vector<shared_ptr<ValueVector>>& relPropertyVectors) {
     auto srcNodeID =
-        ((nodeID_t*)srcNodeIDVector
-                ->values)[srcNodeIDVector->state->selVector
-                              ->selectedPositions[srcNodeIDVector->state->getPositionOfCurrIdx()]];
+        srcNodeIDVector->getValue<nodeID_t>(srcNodeIDVector->state->getPositionOfCurrIdx());
     auto dstNodeID =
-        ((nodeID_t*)dstNodeIDVector
-                ->values)[dstNodeIDVector->state->selVector
-                              ->selectedPositions[dstNodeIDVector->state->getPositionOfCurrIdx()]];
+        dstNodeIDVector->getValue<nodeID_t>(dstNodeIDVector->state->getPositionOfCurrIdx());
     bool hasInsertedToFT = false;
     auto vectorsToAppendToFT = vector<shared_ptr<ValueVector>>{srcNodeIDVector, dstNodeIDVector};
     vectorsToAppendToFT.insert(

--- a/src/storage/storage_structure/lists/unstructured_property_lists_utils.cpp
+++ b/src/storage/storage_structure/lists/unstructured_property_lists_utils.cpp
@@ -8,11 +8,11 @@ void UnstrPropListWrapper::increaseCapacityIfNeeded(uint64_t requiredCapacity) {
         return;
     }
     uint64_t newCapacity =
-        max(requiredCapacity, (uint64_t)(capacity * StorageConfig::ARRAY_RESIZING_FACTOR));
-    unique_ptr<uint8_t[]> newData = make_unique<uint8_t[]>(newCapacity);
+        std::max(requiredCapacity, (uint64_t)(capacity * StorageConfig::ARRAY_RESIZING_FACTOR));
+    std::unique_ptr<uint8_t[]> newData = std::make_unique<uint8_t[]>(newCapacity);
     memcpy(newData.get(), data.get(), capacity);
     data.reset();
-    data = move(newData);
+    data = std::move(newData);
     capacity = newCapacity;
 }
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -41,8 +41,8 @@ node_offset_t NodeTable::addNodeAndResetProperties(ValueVector* primaryKeyVector
             primaryKeyVector, primaryKeyVector->state->getPositionOfCurrIdx(), nodeOffset)) {
         auto pkValPos = primaryKeyVector->state->getPositionOfCurrIdx();
         string pkStr = primaryKeyVector->dataType.typeID == INT64 ?
-                           to_string(((int64_t*)(primaryKeyVector->values))[pkValPos]) :
-                           (((ku_string_t*)primaryKeyVector->values))[pkValPos].getAsString();
+                           to_string(primaryKeyVector->getValue<int64_t>(pkValPos)) :
+                           primaryKeyVector->getValue<ku_string_t>(pkValPos).getAsString();
         throw RuntimeException(Exception::getExistedPKExceptionMsg(pkStr));
     }
     for (auto& column : propertyColumns) {

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -74,15 +74,9 @@ void RelTable::insertRels(shared_ptr<ValueVector>& srcNodeIDVector,
     assert(srcNodeIDVector->state->isFlat());
     assert(dstNodeIDVector->state->isFlat());
     auto srcTableID =
-        ((nodeID_t*)srcNodeIDVector
-                ->values)[srcNodeIDVector->state->selVector
-                              ->selectedPositions[srcNodeIDVector->state->getPositionOfCurrIdx()]]
-            .tableID;
+        srcNodeIDVector->getValue<nodeID_t>(srcNodeIDVector->state->getPositionOfCurrIdx()).tableID;
     auto dstTableID =
-        ((nodeID_t*)dstNodeIDVector
-                ->values)[dstNodeIDVector->state->selVector
-                              ->selectedPositions[dstNodeIDVector->state->getPositionOfCurrIdx()]]
-            .tableID;
+        dstNodeIDVector->getValue<nodeID_t>(dstNodeIDVector->state->getPositionOfCurrIdx()).tableID;
     for (auto direction : REL_DIRECTIONS) {
         auto boundTableID = (direction == RelDirection::FWD ? srcTableID : dstTableID);
         auto boundVector = (direction == RelDirection::FWD ? srcNodeIDVector : dstNodeIDVector);

--- a/test/common/vector/operations/vector_arithmetic_operations_test.cpp
+++ b/test/common/vector/operations/vector_arithmetic_operations_test.cpp
@@ -22,11 +22,9 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto lVectorData = (int64_t*)vector1->values;
-        auto rVectorData = (int64_t*)vector2->values;
         for (int i = 0; i < NUM_TUPLES; i++) {
-            lVectorData[i] = i;
-            rVectorData[i] = 110 - i;
+            vector1->setValue(i, (int64_t)i);
+            vector2->setValue(i, (int64_t)(110 - i));
         }
     }
 };
@@ -41,11 +39,9 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto lVectorData = (int64_t*)vector1->values;
-        auto rVectorData = (int64_t*)vector2->values;
         for (int i = 0; i < NUM_TUPLES; i++) {
-            lVectorData[i] = i;
-            rVectorData[i] = 110 - i;
+            vector1->setValue(i, (int64_t)i);
+            vector2->setValue(i, (int64_t)(110 - i));
         }
     }
 };
@@ -63,12 +59,11 @@ public:
 TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatNoNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (int64_t*)result->values;
 
     UnaryOperationExecutor::execute<int64_t, int64_t, operation::Negate>(*lVector, *result);
 
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], -i);
+        ASSERT_EQ(result->getValue<int64_t>(i), -i);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -76,7 +71,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], 110);
+        ASSERT_EQ(result->getValue<int64_t>(i), 110);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -84,7 +79,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Subtract,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], 2 * i - 110);
+        ASSERT_EQ(result->getValue<int64_t>(i), 2 * i - 110);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -92,7 +87,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Multiply,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i * (110 - i));
+        ASSERT_EQ(result->getValue<int64_t>(i), i * (110 - i));
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -100,7 +95,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Divide,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
-        ASSERT_EQ(resultData[i], i / (110 - i));
+        ASSERT_EQ(result->getValue<int64_t>(i), i / (110 - i));
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -108,18 +103,17 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Modulo,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (auto i = 0u; i < dataChunk->state->selVector->selectedSize; i++) {
-        ASSERT_EQ(resultData[i], i % (110 - i));
+        ASSERT_EQ(result->getValue<int64_t>(i), i % (110 - i));
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
 
     result = make_shared<ValueVector>(DOUBLE, memoryManager.get());
     dataChunk->insert(0, result);
-    auto resultDataAsDoubleArr = (double_t*)result->values;
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, double_t, operation::Power,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultDataAsDoubleArr[i], pow(i, 110 - i));
+        ASSERT_EQ(result->getValue<double_t>(i), pow(i, 110 - i));
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -129,7 +123,6 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatN
 TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatWithNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (int64_t*)result->values;
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
         rVector->setNull(i, (i % 2) == 1);
@@ -138,7 +131,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatW
     UnaryOperationExecutor::execute<int64_t, int64_t, operation::Negate>(*rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
-            ASSERT_EQ(resultData[i], -(110 - i));
+            ASSERT_EQ(result->getValue<int64_t>(i), -(110 - i));
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -150,7 +143,7 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatW
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
-            ASSERT_EQ(resultData[i], 110);
+            ASSERT_EQ(result->getValue<int64_t>(i), 110);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -163,15 +156,13 @@ TEST_F(Int64ArithmeticOperandsInSameDataChunkTest, Int64UnaryAndBinaryAllUnflatW
 TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUnflatNoNulls) {
     // Flatten dataChunkWithVector1, which holds vector1
     dataChunkWithVector1->state->currIdx = 80;
-    // Recall vector2 and result are in the same data chunk
-    auto resultData = (uint64_t*)result->values;
 
     // Test 1: Left flat and right is unflat.
     // The addition is 80 + [110, 109, ...., 8, 9]. The results are: [190, 189, ...., 88, 89]
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
         BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], 190 - i);
+        ASSERT_EQ(result->getValue<uint64_t>(i), 190 - i);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -180,7 +171,7 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, int64_t, operation::Add,
         BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], 190 - i);
+        ASSERT_EQ(result->getValue<uint64_t>(i), 190 - i);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -190,7 +181,6 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
 TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUnflatWithNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (int64_t*)result->values;
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
         rVector->setNull(i, (i % 2) == 1);
@@ -204,7 +194,7 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
         BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
-            ASSERT_EQ(resultData[i], 190 - i);
+            ASSERT_EQ(result->getValue<int64_t>(i), 190 - i);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -217,7 +207,7 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
         BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
-            ASSERT_EQ(resultData[i], 190 - i);
+            ASSERT_EQ(result->getValue<int64_t>(i), 190 - i);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -229,91 +219,85 @@ TEST_F(Int64ArithmeticOperandsInDifferentDataChunksTest, Int64BinaryOneFlatOneUn
 TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt64Test) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto lData = (Value*)lVector->values;
-    auto rData = (Value*)rVector->values;
-    auto resultData = (Value*)result->values;
 
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
-        lData[i] = Value((int64_t)i);
-        rData[i] = Value((int64_t)110 - i);
+        lVector->setValue(i, Value((int64_t)i));
+        rVector->setValue(i, Value((int64_t)110 - i));
     }
 
     UnaryOperationExecutor::execute<Value, Value, operation::Negate>(*lVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.int64Val, -i);
+        ASSERT_EQ(result->getValue<Value>(i).val.int64Val, -i);
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Add,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.int64Val, 110);
+        ASSERT_EQ(result->getValue<Value>(i).val.int64Val, 110);
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Subtract,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.int64Val, 2 * i - 110);
+        ASSERT_EQ(result->getValue<Value>(i).val.int64Val, 2 * i - 110);
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Multiply,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.int64Val, i * (110 - i));
+        ASSERT_EQ(result->getValue<Value>(i).val.int64Val, i * (110 - i));
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Divide,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.int64Val, i / (110 - i));
+        ASSERT_EQ(result->getValue<Value>(i).val.int64Val, i / (110 - i));
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Modulo,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.int64Val, i % (110 - i));
+        ASSERT_EQ(result->getValue<Value>(i).val.int64Val, i % (110 - i));
     }
 }
 
 TEST_F(UnstructuredArithmeticOperandsInSameDataChunkTest, UnstructuredInt32AndDoubleTest) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto lData = (Value*)lVector->values;
-    auto rData = (Value*)rVector->values;
-    auto resultData = (Value*)result->values;
 
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
-        lData[i] = Value((double)i);
-        rData[i] = Value((int64_t)110 - i);
+        lVector->setValue(i, Value((double)i));
+        rVector->setValue(i, Value((int64_t)(110 - i)));
     }
 
     UnaryOperationExecutor::execute<Value, Value, operation::Negate>(*lVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.doubleVal, (double)-i);
+        ASSERT_EQ(result->getValue<Value>(i).val.doubleVal, (double)-i);
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Add,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.doubleVal, (double)110);
+        ASSERT_EQ(result->getValue<Value>(i).val.doubleVal, (double)110);
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Subtract,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.doubleVal, (double)(2 * i - 110));
+        ASSERT_EQ(result->getValue<Value>(i).val.doubleVal, (double)(2 * i - 110));
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Multiply,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.doubleVal, (double)(i * (110 - i)));
+        ASSERT_EQ(result->getValue<Value>(i).val.doubleVal, (double)(i * (110 - i)));
     }
 
     BinaryOperationExecutor::executeSwitch<Value, Value, Value, operation::Divide,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].val.doubleVal, (double)i / (110 - i));
+        ASSERT_EQ(result->getValue<Value>(i).val.doubleVal, (double)i / (110 - i));
     }
 }

--- a/test/common/vector/operations/vector_boolean_operations_test.cpp
+++ b/test/common/vector/operations/vector_boolean_operations_test.cpp
@@ -23,11 +23,9 @@ using namespace std;
  * */
 static void setValuesInVectors(const shared_ptr<ValueVector>& lVector,
     const shared_ptr<ValueVector>& rVector, uint32_t numTuples) {
-    auto lVectorData = (bool*)lVector->values;
-    auto rVectorData = (bool*)rVector->values;
     for (auto i = 0u; i < numTuples; i++) {
-        lVectorData[i] = i % 2 == 0;
-        rVectorData[i] = (i >> 1) % 2 == 0;
+        lVector->setValue(i, (bool)(i % 2 == 0));
+        rVector->setValue(i, (bool)((i >> 1) % 2 == 0));
     }
 }
 
@@ -93,12 +91,11 @@ public:
 
 static void checkResultVectorNoNulls(const shared_ptr<ValueVector>& result,
     const function<bool(uint32_t)>& idxOfTrueValueFunc, uint32_t numTuples) {
-    auto resultData = (bool*)result->values;
     for (auto i = 0u; i < numTuples; i++) {
         if (idxOfTrueValueFunc(i)) {
-            ASSERT_TRUE(resultData[i]);
+            ASSERT_TRUE(result->getValue<bool>(i));
         } else {
-            ASSERT_FALSE(resultData[i]);
+            ASSERT_FALSE(result->getValue<bool>(i));
         }
         ASSERT_FALSE(result->isNull(i));
     }
@@ -135,13 +132,12 @@ TEST_F(BoolOperandsInSameDataChunkTest, BoolUnaryAndBinaryAllUnflatNoNulls) {
 static void checkResultVectorWithNulls(const shared_ptr<ValueVector>& result,
     const unordered_set<uint32_t>& idxOfTrueValuePer16Elements,
     const unordered_set<uint32_t>& idxOfFalseValuePer16Elements, uint32_t numTuples) {
-    auto resultData = (bool*)result->values;
     for (auto i = 0u; i < numTuples; i++) {
         if (idxOfTrueValuePer16Elements.contains(i % 16)) {
-            ASSERT_TRUE(resultData[i]);
+            ASSERT_TRUE(result->getValue<bool>(i));
             ASSERT_FALSE(result->isNull(i));
         } else if (idxOfFalseValuePer16Elements.contains(i % 16)) {
-            ASSERT_FALSE(resultData[i]);
+            ASSERT_FALSE(result->getValue<bool>(i));
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));

--- a/test/common/vector/operations/vector_comparison_operations_test.cpp
+++ b/test/common/vector/operations/vector_comparison_operations_test.cpp
@@ -17,12 +17,10 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto vector1Data = (int64_t*)vector1->values;
-        auto vector2Data = (int64_t*)vector2->values;
 
         for (int i = 0; i < NUM_TUPLES; i++) {
-            vector1Data[i] = i;
-            vector2Data[i] = 90 - i;
+            vector1->setValue(i, (int64_t)i);
+            vector2->setValue(i, (int64_t)(90 - i));
         }
     }
 };
@@ -37,12 +35,10 @@ public:
 
     void SetUp() override {
         initDataChunk();
-        auto vector1Data = (int64_t*)vector1->values;
-        auto vector2Data = (int64_t*)vector2->values;
 
         for (int i = 0; i < NUM_TUPLES; i++) {
-            vector1Data[i] = i;
-            vector2Data[i] = 90 - i;
+            vector1->setValue(i, (int64_t)i);
+            vector2->setValue(i, (int64_t)(90 - i));
         }
     }
 };
@@ -50,12 +46,11 @@ public:
 TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = result->values;
 
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::Equals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i == 45 ? true : false);
+        ASSERT_EQ(result->getValue<bool>(i), i == 45 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -63,7 +58,7 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::NotEquals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i == 45 ? false : true);
+        ASSERT_EQ(result->getValue<bool>(i), i == 45 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -71,7 +66,7 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 45 ? true : false);
+        ASSERT_EQ(result->getValue<bool>(i), i < 45 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -79,7 +74,7 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThanEquals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 46 ? true : false);
+        ASSERT_EQ(result->getValue<bool>(i), i < 46 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -87,7 +82,7 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::GreaterThan,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 46 ? false : true);
+        ASSERT_EQ(result->getValue<bool>(i), i < 46 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -95,7 +90,7 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::GreaterThanEquals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 45 ? false : true);
+        ASSERT_EQ(result->getValue<bool>(i), i < 45 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -105,7 +100,6 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatNoNulls) {
 TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatWithNulls) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = result->values;
     // We set every odd value in vector 2 to NULL.
     for (int i = 0; i < NUM_TUPLES; ++i) {
         vector2->setNull(i, (i % 2) == 1);
@@ -115,7 +109,7 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatWithNulls) {
         BinaryOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if (i % 2 == 0) {
-            ASSERT_EQ(resultData[i], i < 45 ? true : false);
+            ASSERT_EQ(result->getValue<bool>(i), i < 45 ? true : false);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -128,8 +122,6 @@ TEST_F(Int64ComparisonOperandsInSameDataChunkTest, Int64TwoUnflatWithNulls) {
 TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNoNulls) {
     // Flatten dataChunkWithVector1, which holds vector1
     dataChunkWithVector1->state->currIdx = 80;
-    // Recall vector2 and result are in the same data chunk
-    auto resultData = result->values;
 
     // Test 1: Left flat and right is unflat.
     // The comparison ins 80 < [90, 89, ...., -9]. The first 10 (90, ..., 81) the result is true,
@@ -137,7 +129,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNo
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
         BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 10 ? true : false);
+        ASSERT_EQ(result->getValue<bool>(i), i < 10 ? true : false);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -148,7 +140,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatNo
     BinaryOperationExecutor::executeSwitch<int64_t, int64_t, uint8_t, operation::LessThan,
         BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i], i < 11 ? false : true);
+        ASSERT_EQ(result->getValue<bool>(i), i < 11 ? false : true);
         ASSERT_FALSE(result->isNull(i));
     }
     ASSERT_TRUE(result->hasNoNullsGuarantee());
@@ -162,8 +154,6 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
     for (int i = 0; i < NUM_TUPLES; ++i) {
         vector2->setNull(i, (i % 2) == 1);
     }
-    // Recall vector2 and result are in the same data chunk
-    auto resultData = result->values;
 
     // Test 1: Left flat and right is unflat.
     // The comparison ins 80 < [90, NULL, 88, NULL ...., -8, NULL]. The first 10 (90, ..., 81) the
@@ -173,7 +163,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
         BinaryOperationWrapper>(*vector1, *vector2, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if ((i % 2) == 0) {
-            ASSERT_EQ(resultData[i], i < 10 ? true : false);
+            ASSERT_EQ(result->getValue<bool>(i), i < 10 ? true : false);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -193,7 +183,7 @@ TEST_F(Int64ComparisonOperandsInDifferentDataChunksTest, Int64OneFlatOneUnflatWi
         BinaryOperationWrapper>(*vector2, *vector1, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
         if ((i % 2) == 0) {
-            ASSERT_EQ(resultData[i], i < 11 ? false : true);
+            ASSERT_EQ(result->getValue<bool>(i), i < 11 ? false : true);
             ASSERT_FALSE(result->isNull(i));
         } else {
             ASSERT_TRUE(result->isNull(i));
@@ -214,15 +204,14 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
 
     auto lVector = make_shared<ValueVector>(STRING, memoryManager.get());
     dataChunk->insert(0, lVector);
-    auto lData = ((ku_string_t*)lVector->values);
+    auto lData = ((ku_string_t*)lVector->getData());
 
     auto rVector = make_shared<ValueVector>(STRING, memoryManager.get());
     dataChunk->insert(1, rVector);
-    auto rData = ((ku_string_t*)rVector->values);
+    auto rData = ((ku_string_t*)rVector->getData());
 
     auto result = make_shared<ValueVector>(BOOL, memoryManager.get());
     dataChunk->insert(2, result);
-    auto resultData = result->values;
 
     string value = "abcdefgh";
     lData[0].len = 8;
@@ -236,49 +225,49 @@ TEST(VectorCmpTests, cmpTwoShortStrings) {
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::Equals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     rData[0].data[3] = 'i';
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::Equals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::NotEquals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::LessThan,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     rData[0].data[3] = 'a';
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::LessThan,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 }
 
 TEST(VectorCmpTests, cmpTwoLongStrings) {
@@ -293,15 +282,14 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
 
     auto lVector = make_shared<ValueVector>(STRING, memoryManager.get());
     dataChunk->insert(0, lVector);
-    auto lData = ((ku_string_t*)lVector->values);
+    auto lData = ((ku_string_t*)lVector->getData());
 
     auto rVector = make_shared<ValueVector>(STRING, memoryManager.get());
     dataChunk->insert(1, rVector);
-    auto rData = ((ku_string_t*)rVector->values);
+    auto rData = ((ku_string_t*)rVector->getData());
 
     auto result = make_shared<ValueVector>(BOOL, memoryManager.get());
     dataChunk->insert(2, result);
-    auto resultData = result->values;
 
     string value = "abcdefghijklmnopqrstuvwxy"; // 25.
     lData[0].len = 25;
@@ -318,47 +306,47 @@ TEST(VectorCmpTests, cmpTwoLongStrings) {
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::Equals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     rOverflow[overflowLen - 1] = 'z';
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::Equals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::NotEquals,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::LessThan,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     rOverflow[overflowLen - 1] = 'a';
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t, operation::LessThan,
         BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::LessThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], false);
+    ASSERT_EQ(result->getValue<bool>(0), false);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThan, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, uint8_t,
         operation::GreaterThanEquals, BinaryOperationWrapper>(*lVector, *rVector, *result);
-    ASSERT_EQ(resultData[0], true);
+    ASSERT_EQ(result->getValue<bool>(0), true);
 }

--- a/test/common/vector/operations/vector_string_operations_test.cpp
+++ b/test/common/vector/operations/vector_string_operations_test.cpp
@@ -19,34 +19,33 @@ public:
 TEST_F(StringArithmeticOperandsInSameDataChunkTest, StringTest) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (ku_string_t*)result->values;
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
-        lVector->addString(i, to_string(i));
-        rVector->addString(i, to_string(110 - i));
+        lVector->setValue(i, to_string(i));
+        rVector->setValue(i, to_string(110 - i));
     }
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, ku_string_t, operation::Concat,
         BinaryStringAndListOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].getAsString(), to_string(i) + to_string(110 - i));
+        ASSERT_EQ(
+            result->getValue<ku_string_t>(i).getAsString(), to_string(i) + to_string(110 - i));
     }
 }
 
 TEST_F(StringArithmeticOperandsInSameDataChunkTest, BigStringTest) {
     auto lVector = vector1;
     auto rVector = vector2;
-    auto resultData = (ku_string_t*)result->values;
     // Fill values before the comparison.
     for (int i = 0; i < NUM_TUPLES; i++) {
-        lVector->addString(i, to_string(i) + "abcdefabcdefqwert");
-        rVector->addString(i, to_string(110 - i) + "abcdefabcdefqwert");
+        lVector->setValue(i, to_string(i) + "abcdefabcdefqwert");
+        rVector->setValue(i, to_string(110 - i) + "abcdefabcdefqwert");
     }
 
     BinaryOperationExecutor::executeSwitch<ku_string_t, ku_string_t, ku_string_t, operation::Concat,
         BinaryStringAndListOperationWrapper>(*lVector, *rVector, *result);
     for (int i = 0; i < NUM_TUPLES; i++) {
-        ASSERT_EQ(resultData[i].getAsString(),
+        ASSERT_EQ(result->getValue<ku_string_t>(i).getAsString(),
             to_string(i) + "abcdefabcdefqwert" + to_string(110 - i) + "abcdefabcdefqwert");
     }
 }

--- a/test/common/vector/value_vector_test.cpp
+++ b/test/common/vector/value_vector_test.cpp
@@ -17,7 +17,7 @@ TEST(ValueVectorTests, TestDefaultHasNull) {
     valueVector.setState(dataChunkState);
     valueVector.state->selVector->selectedSize = 3;
     for (int i = 0; i < 3; ++i) {
-        ((uint64_t*)valueVector.values)[i] = i;
+        valueVector.setValue(i, (uint64_t)i);
     }
     // Test that initially the vector does not contain any NULLs.
     EXPECT_TRUE(valueVector.hasNoNullsGuarantee());

--- a/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
+++ b/test/expression_evaluator/aggregate_expression_evaluation_test.cpp
@@ -25,14 +25,11 @@ public:
         stringValueVector = make_shared<ValueVector>(STRING, memoryManager.get());
         unStrValueVector = make_shared<ValueVector>(UNSTRUCTURED, memoryManager.get());
         dataChunk = make_shared<DataChunk>(4);
-        auto int64Values = (int64_t*)int64ValueVector->values;
-        auto doubleValues = (double_t*)doubleValueVector->values;
-        auto unStrValues = (Value*)unStrValueVector->values;
         for (auto i = 0u; i < 100; i++) {
-            int64Values[i] = i;
-            doubleValues[i] = (double)i * 1.5;
-            stringValueVector->addString(i, to_string(i));
-            unStrValues[i] = Value((int64_t)i);
+            int64ValueVector->setValue(i, (int64_t)i);
+            doubleValueVector->setValue(i, (double_t)(i * 1.5));
+            unStrValueVector->setValue(i, Value((int64_t)i));
+            stringValueVector->setValue(i, to_string(i));
             if (i % 2 == 0) {
                 int64ValueVector->setNull(i, true /* isNull */);
                 doubleValueVector->setNull(i, true /* isNull */);

--- a/test/expression_evaluator/operation_executor_test.cpp
+++ b/test/expression_evaluator/operation_executor_test.cpp
@@ -55,17 +55,19 @@ public:
 
     void validateStringResultValueVector(
         shared_ptr<ValueVector>& valueVector, const vector<string>& expectedValues) {
-        auto actualValues = (ku_string_t*)valueVector->values;
         if (valueVector->state->isFlat()) {
             assert(expectedValues.size() == 1);
-            ASSERT_EQ(actualValues[valueVector->state->getPositionOfCurrIdx()].getAsString(),
+            ASSERT_EQ(valueVector->getValue<ku_string_t>(valueVector->state->getPositionOfCurrIdx())
+                          .getAsString(),
                 expectedValues[0]);
         } else {
             for (auto i = 0u; i < expectedValues.size(); i++) {
                 if (expectedValues[i] == "") {
                     ASSERT_EQ(valueVector->isNull(i), true);
                 } else {
-                    ASSERT_EQ(actualValues[valueVector->state->selVector->selectedPositions[i]]
+                    ASSERT_EQ(valueVector
+                                  ->getValue<ku_string_t>(
+                                      valueVector->state->selVector->selectedPositions[i])
                                   .getAsString(),
                         expectedValues[i]);
                 }
@@ -75,13 +77,14 @@ public:
 
     void validateBoolResultValueVector(
         shared_ptr<ValueVector>& valueVector, const vector<bool>& expectedValues) {
-        auto actualValues = (bool*)valueVector->values;
         if (valueVector->state->isFlat()) {
             assert(expectedValues.size() == 1);
-            ASSERT_EQ(actualValues[valueVector->state->getPositionOfCurrIdx()], expectedValues[0]);
+            ASSERT_EQ(valueVector->getValue<bool>(valueVector->state->getPositionOfCurrIdx()),
+                expectedValues[0]);
         } else {
             for (auto i = 0u; i < expectedValues.size(); i++) {
-                ASSERT_EQ(actualValues[valueVector->state->selVector->selectedPositions[i]],
+                ASSERT_EQ(valueVector->getValue<bool>(
+                              valueVector->state->selVector->selectedPositions[i]),
                     expectedValues[i]);
             }
         }
@@ -132,19 +135,18 @@ public:
 private:
     shared_ptr<ValueVector> getStringValueVector() {
         auto valueVector = make_shared<ValueVector>(STRING, memoryManager.get());
-        valueVector->addString(0, "This is a long string1");
-        valueVector->addString(1, "This is another long string");
-        valueVector->addString(2, "Substring test");
+        valueVector->setValue<string>(0, "This is a long string1");
+        valueVector->setValue<string>(1, "This is another long string");
+        valueVector->setValue<string>(2, "Substring test");
         return valueVector;
     }
     shared_ptr<ValueVector> getInt64ValueVector(bool isStartPosVector) {
         auto valueVector = make_shared<ValueVector>(INT64, memoryManager.get());
-        auto values = (int64_t*)valueVector->values;
         vector<int64_t> data =
             isStartPosVector ? vector<int64_t>{2, 1, 3} : vector<int64_t>{7, 10, 12};
-        values[0] = data[0];
-        values[1] = data[1];
-        values[2] = data[2];
+        valueVector->setValue(0, data[0]);
+        valueVector->setValue(1, data[1]);
+        valueVector->setValue(2, data[2]);
         return valueVector;
     }
 

--- a/test/processor/physical_plan/hash_table/aggregate_hash_table_test.cpp
+++ b/test/processor/physical_plan/hash_table/aggregate_hash_table_test.cpp
@@ -22,18 +22,13 @@ public:
         group3Vector = make_shared<ValueVector>(INT64, memoryManager.get());
         aggr1Vector = make_shared<ValueVector>(INT64, memoryManager.get());
         aggr2Vector = make_shared<ValueVector>(INT64, memoryManager.get());
-        auto group1Values = (int64_t*)group1Vector->values;
-        auto group2Values = (int64_t*)group2Vector->values;
-        auto group3Values = (int64_t*)group3Vector->values;
-        auto aggr1Values = (int64_t*)aggr1Vector->values;
-        auto aggr2Values = (int64_t*)aggr2Vector->values;
         for (auto i = 0u; i < 100; i++) {
-            group1Values[i] = i % 4;
-            group2Values[i] = i;
-            aggr1Values[i] = i * 2;
-            aggr2Values[i] = i * 2;
+            group1Vector->setValue(i, (int64_t)(i % 4));
+            group2Vector->setValue(i, (int64_t)i);
+            aggr1Vector->setValue(i, (int64_t)(i * 2));
+            aggr2Vector->setValue(i, (int64_t)(i * 2));
         }
-        group3Values[0] = 20;
+        group3Vector->setValue(0, (int64_t)20);
         dataChunk = make_shared<DataChunk>(4);
         dataChunk->state->selVector->selectedSize = 100;
         dataChunk->state->currIdx = 0;
@@ -55,11 +50,11 @@ public:
         auto sumAggregate = AggregateFunctionUtil::getSumFunction(DataType(INT64), false);
         auto countState = countAggregate->createInitialNullAggregateState();
         auto sumState = sumAggregate->createInitialNullAggregateState();
-        aggregates.push_back(move(countAggregate));
-        aggregates.push_back(move(sumAggregate));
+        aggregates.push_back(std::move(countAggregate));
+        aggregates.push_back(std::move(sumAggregate));
         auto groupByVectorsDataType = vector<DataType>{DataType(INT64)};
-        auto ht = make_unique<AggregateHashTable>(
-            *memoryManager, move(groupByVectorsDataType), aggregates, 0 /* numEntriesToAllocate */);
+        auto ht = make_unique<AggregateHashTable>(*memoryManager, std::move(groupByVectorsDataType),
+            aggregates, 0 /* numEntriesToAllocate */);
         vector<ValueVector*> groupVectors, aggregateVectors;
         groupVectors.push_back(group1Vector.get());
         aggregateVectors.push_back(nullptr);
@@ -97,12 +92,12 @@ public:
         auto avgAggregate = AggregateFunctionUtil::getAvgFunction(DataType(INT64), false);
         auto count1State = countAggregate->createInitialNullAggregateState();
         auto count2State = avgAggregate->createInitialNullAggregateState();
-        aggregates.push_back(move(countAggregate));
-        aggregates.push_back(move(avgAggregate));
+        aggregates.push_back(std::move(countAggregate));
+        aggregates.push_back(std::move(avgAggregate));
 
         auto groupByVectorsDataType = vector<DataType>{DataType(INT64), DataType(INT64)};
-        auto ht = make_unique<AggregateHashTable>(
-            *memoryManager, move(groupByVectorsDataType), aggregates, 0 /* numEntriesToAllocate */);
+        auto ht = make_unique<AggregateHashTable>(*memoryManager, std::move(groupByVectorsDataType),
+            aggregates, 0 /* numEntriesToAllocate */);
         vector<ValueVector*> flatGroupByVector, unflatGroupByVector, aggregateVectors;
 
         aggregateVectors.push_back(aggr1Vector.get());

--- a/test/processor/physical_plan/operator/orderBy/order_by_key_encoder_test.cpp
+++ b/test/processor/physical_plan/operator/orderBy/order_by_key_encoder_test.cpp
@@ -52,9 +52,8 @@ public:
         for (auto i = 0u; i < numOfOrderByCols; i++) {
             shared_ptr<ValueVector> valueVector =
                 make_shared<ValueVector>(INT64, memoryManager.get());
-            auto intValuePtr = (int64_t*)valueVector->values;
             for (auto j = 0u; j < numOfElementsPerCol; j++) {
-                intValuePtr[j] = 5;
+                valueVector->setValue(j, (int64_t)5);
             }
             dataChunk->insert(i, valueVector);
             valueVector->state->currIdx = flatCol ? 0 : -1;
@@ -129,13 +128,12 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     dataChunk->state->selVector->selectedSize = 6;
     shared_ptr<ValueVector> int64ValueVector = make_shared<ValueVector>(INT64, memoryManager.get());
-    auto int64Values = (int64_t*)int64ValueVector->values;
-    int64Values[0] = 73; // positive number
+    int64ValueVector->setValue(0, (int64_t)73); // positive number
     int64ValueVector->setNull(1, true);
-    int64Values[2] = -132;  // negative 1 byte number
-    int64Values[3] = -5242; // negative 2 bytes number
-    int64Values[4] = INT64_MAX;
-    int64Values[5] = INT64_MIN;
+    int64ValueVector->setValue(2, (int64_t)-132);  // negative 1 byte number
+    int64ValueVector->setValue(3, (int64_t)-5242); // negative 2 bytes number
+    int64ValueVector->setValue(4, (int64_t)INT64_MAX);
+    int64ValueVector->setValue(5, (int64_t)INT64_MIN);
     dataChunk->insert(0, int64ValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(int64ValueVector);
@@ -196,10 +194,9 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatWithFilterTest) {
     // valueVector.
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     shared_ptr<ValueVector> int64ValueVector = make_shared<ValueVector>(INT64, memoryManager.get());
-    auto int64Values = (int64_t*)int64ValueVector->values;
-    int64Values[0] = 73;
-    int64Values[1] = -52;
-    int64Values[2] = -132;
+    int64ValueVector->setValue(0, (int64_t)73);
+    int64ValueVector->setValue(1, (int64_t)-52);
+    int64ValueVector->setValue(2, (int64_t)-132);
     dataChunk->insert(0, int64ValueVector);
     // Only the first and the third value is selected, so the encoder should
     // not encode the second value.
@@ -238,9 +235,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColBoolUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     dataChunk->state->selVector->selectedSize = 3;
     shared_ptr<ValueVector> boolValueVector = make_shared<ValueVector>(BOOL, memoryManager.get());
-    auto boolValues = (bool*)boolValueVector->values;
-    boolValues[0] = true;
-    boolValues[1] = false;
+    boolValueVector->setValue(0, true);
+    boolValueVector->setValue(1, false);
     boolValueVector->setNull(2, true);
     dataChunk->insert(0, boolValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
@@ -269,10 +265,11 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColDateUnflatTest) {
     shared_ptr<DataChunk> dataChunk = make_shared<DataChunk>(1);
     dataChunk->state->selVector->selectedSize = 3;
     shared_ptr<ValueVector> dateValueVector = make_shared<ValueVector>(DATE, memoryManager.get());
-    auto dateValues = (date_t*)dateValueVector->values;
-    dateValues[0] = Date::FromCString("2035-07-04", strlen("2035-07-04")); // date after 1970-01-01
+    dateValueVector->setValue(
+        0, Date::FromCString("2035-07-04", strlen("2035-07-04"))); // date after 1970-01-01
     dateValueVector->setNull(1, true);
-    dateValues[2] = Date::FromCString("1949-10-01", strlen("1949-10-01")); // date before 1970-01-01
+    dateValueVector->setValue(
+        2, Date::FromCString("1949-10-01", strlen("1949-10-01"))); // date before 1970-01-01
     dataChunk->insert(0, dateValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(dateValueVector);
@@ -307,14 +304,13 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColTimestampUnflatTest) {
     dataChunk->state->selVector->selectedSize = 3;
     shared_ptr<ValueVector> timestampValueVector =
         make_shared<ValueVector>(TIMESTAMP, memoryManager.get());
-    auto timestampValues = (timestamp_t*)timestampValueVector->values;
     // timestamp before 1970-01-01
-    timestampValues[0] =
-        Timestamp::FromCString("1962-04-07 11:12:35.123", strlen("1962-04-07 11:12:35.123"));
+    timestampValueVector->setValue(
+        0, Timestamp::FromCString("1962-04-07 11:12:35.123", strlen("1962-04-07 11:12:35.123")));
     timestampValueVector->setNull(1, true);
     // timestamp after 1970-01-01
-    timestampValues[2] =
-        Timestamp::FromCString("2035-07-01 11:14:33", strlen("2035-07-01 11:14:33"));
+    timestampValueVector->setValue(
+        2, Timestamp::FromCString("2035-07-01 11:14:33", strlen("2035-07-01 11:14:33")));
     dataChunk->insert(0, timestampValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(timestampValueVector);
@@ -359,9 +355,9 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColIntervalUnflatTest) {
     dataChunk->state->selVector->selectedSize = 2;
     shared_ptr<ValueVector> intervalValueVector =
         make_shared<ValueVector>(INTERVAL, memoryManager.get());
-    auto intervalValues = (interval_t*)intervalValueVector->values;
-    intervalValues[0] = Interval::FromCString("18 hours 55 days 13 years 8 milliseconds 3 months",
-        strlen("18 hours 55 days 13 years 8 milliseconds 3 months"));
+    intervalValueVector->setValue(
+        0, Interval::FromCString("18 hours 55 days 13 years 8 milliseconds 3 months",
+               strlen("18 hours 55 days 13 years 8 milliseconds 3 months")));
     intervalValueVector->setNull(1, true);
     dataChunk->insert(0, intervalValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
@@ -406,10 +402,12 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColStringUnflatTest) {
     dataChunk->state->selVector->selectedSize = 4;
     shared_ptr<ValueVector> stringValueVector =
         make_shared<ValueVector>(STRING, memoryManager.get());
-    stringValueVector->addString(0, "short str"); // short string
+    stringValueVector->setValue<string>(0, "short str"); // short string
     stringValueVector->setNull(1, true);
-    stringValueVector->addString(2, "commonprefix string1"); // long string(encoding: commonprefix)
-    stringValueVector->addString(3, "commonprefix string2"); // long string(encoding: commonprefix)
+    stringValueVector->setValue<string>(
+        2, "commonprefix string1"); // long string(encoding: commonprefix)
+    stringValueVector->setValue<string>(
+        3, "commonprefix string2"); // long string(encoding: commonprefix)
     dataChunk->insert(0, stringValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(stringValueVector);
@@ -479,13 +477,12 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColDoubleUnflatTest) {
     dataChunk->state->selVector->selectedSize = 6;
     shared_ptr<ValueVector> doubleValueVector =
         make_shared<ValueVector>(DOUBLE, memoryManager.get());
-    auto doubleValues = (double*)doubleValueVector->values;
-    doubleValues[0] = 3.452; // small positive number
+    doubleValueVector->setValue(0, (double_t)3.452); // small positive number
     doubleValueVector->setNull(1, true);
-    doubleValues[2] = -0.00031213;     // very small negative number
-    doubleValues[3] = -5.42113;        // small negative number
-    doubleValues[4] = 92931312341415;  // large positive number
-    doubleValues[5] = -31234142783434; // large negative number
+    doubleValueVector->setValue(2, (double_t)-0.00031213);     // very small negative number
+    doubleValueVector->setValue(3, (double_t)-5.42113);        // small negative number
+    doubleValueVector->setValue(4, (double_t)92931312341415);  // large positive number
+    doubleValueVector->setValue(5, (double_t)-31234142783434); // large negative number
     dataChunk->insert(0, doubleValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(doubleValueVector);
@@ -566,13 +563,12 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColUnstrUnflatTest) {
     dataChunk->state->selVector->selectedSize = 5;
     shared_ptr<ValueVector> unstrValueVector =
         make_shared<ValueVector>(UNSTRUCTURED, memoryManager.get());
-    auto unstrValues = (Value*)unstrValueVector->values;
-    unstrValues[0] = Value(38.22);
+    unstrValueVector->setValue(0, Value(38.22));
     unstrValueVector->setNull(1, true);
-    unstrValues[2] =
-        Value(Timestamp::FromCString("1962-04-07 11:12:35.123", strlen("1962-04-07 11:12:35.123")));
-    unstrValues[3] = Value(int64_t(-97874221));
-    unstrValues[4] = Value(string("test str"));
+    unstrValueVector->setValue(2, Value(Timestamp::FromCString("1962-04-07 11:12:35.123",
+                                      strlen("1962-04-07 11:12:35.123"))));
+    unstrValueVector->setValue(3, Value(int64_t(-97874221)));
+    unstrValueVector->setValue(4, Value(string("test str")));
     dataChunk->insert(0, unstrValueVector);
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(unstrValueVector);
@@ -654,11 +650,6 @@ TEST_F(OrderByKeyEncoderTest, multipleOrderByColSingleBlockTest) {
     mockDataChunk->insert(3, timestampFlatValueVector);
     mockDataChunk->insert(4, dateFlatValueVector);
 
-    auto intValues = (int64_t*)intFlatValueVector->values;
-    auto doubleValues = (double*)doubleFlatValueVector->values;
-    auto timestampValues = (timestamp_t*)timestampFlatValueVector->values;
-    auto dateValues = (date_t*)dateFlatValueVector->values;
-
     intFlatValueVector->state->currIdx = 0;
     doubleFlatValueVector->state->currIdx = 0;
     stringFlatValueVector->state->currIdx = 0;
@@ -676,22 +667,22 @@ TEST_F(OrderByKeyEncoderTest, multipleOrderByColSingleBlockTest) {
         valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
-    intValues[0] = 73;
-    intValues[1] = -132;
-    intValues[2] = -412414;
-    doubleValues[0] = 53.421;
-    doubleValues[1] = -415.23;
+    intFlatValueVector->setValue(0, (int64_t)73);
+    intFlatValueVector->setValue(1, (int64_t)-132);
+    intFlatValueVector->setValue(2, (int64_t)-412414);
+    doubleFlatValueVector->setValue(0, (double_t)53.421);
+    doubleFlatValueVector->setValue(1, (double_t)-415.23);
     doubleFlatValueVector->setNull(2, true);
     stringFlatValueVector->setNull(0, true);
-    stringFlatValueVector->addString(1, "this is a test string!!");
-    stringFlatValueVector->addString(2, "short str");
-    timestampValues[0] =
-        Timestamp::FromCString("2008-08-08 20:20:20", strlen("2008-08-08 20:20:20"));
-    timestampValues[1] =
-        Timestamp::FromCString("1962-04-07 11:12:35.123", strlen("1962-04-07 11:12:35.123"));
+    stringFlatValueVector->setValue<string>(1, "this is a test string!!");
+    stringFlatValueVector->setValue<string>(2, "short str");
+    timestampFlatValueVector->setValue(
+        0, Timestamp::FromCString("2008-08-08 20:20:20", strlen("2008-08-08 20:20:20")));
+    timestampFlatValueVector->setValue(
+        1, Timestamp::FromCString("1962-04-07 11:12:35.123", strlen("1962-04-07 11:12:35.123")));
     timestampFlatValueVector->setNull(2, true);
-    dateValues[0] = Date::FromCString("1978-09-12", strlen("1978-09-12"));
-    dateValues[1] = Date::FromCString("2035-07-04", strlen("2035-07-04"));
+    dateFlatValueVector->setValue(0, Date::FromCString("1978-09-12", strlen("1978-09-12")));
+    dateFlatValueVector->setValue(1, Date::FromCString("2035-07-04", strlen("2035-07-04")));
     dateFlatValueVector->setNull(2, true);
     for (auto i = 0u; i < 3; i++) {
         orderByKeyEncoder.encodeKeys();

--- a/test/runner/e2e_exception_test.cpp
+++ b/test/runner/e2e_exception_test.cpp
@@ -187,11 +187,6 @@ TEST_F(TinySnbExceptionTest, ModuloBy0Error) {
     ASSERT_STREQ(result->getErrorMessage().c_str(), "Runtime exception: Modulo by zero.");
 }
 
-TEST_F(TinySnbExceptionTest, ParserError) {
-    auto result = conn->query("MATCH");
-    ASSERT_STREQ(result->getErrorMessage().c_str(), "basic_string::_M_construct null not valid");
-}
-
 TEST_F(TinySnbExceptionTest, EmptyQuery) {
     auto result = conn->query("");
     ASSERT_STREQ(result->getErrorMessage().c_str(), "Connection Exception: Query is empty.");

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -48,7 +48,7 @@ public:
         dataChunk->insert(0, nodeIDVector);
         auto idVector = make_shared<ValueVector>(INT64, getMemoryManager(*database));
         dataChunk->insert(1, idVector);
-        ((nodeID_t*)nodeIDVector->values)[0].offset = nodeOffset;
+        ((nodeID_t*)nodeIDVector->getData())[0].offset = nodeOffset;
         idVector->setNull(0, true /* is null */);
         idColumn->writeValues(nodeIDVector, idVector);
         return nodeOffset;

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -35,8 +35,8 @@ public:
         dataChunk = make_shared<DataChunk>(3);
         nodeVector = make_shared<ValueVector>(NODE_ID, getMemoryManager(*database));
         dataChunk->insert(0, nodeVector);
-        ((nodeID_t*)nodeVector->values)[0].offset = 0;
-        ((nodeID_t*)nodeVector->values)[1].offset = 1;
+        ((nodeID_t*)nodeVector->getData())[0].offset = 0;
+        ((nodeID_t*)nodeVector->getData())[1].offset = 1;
 
         agePropertyVectorToReadDataInto =
             make_shared<ValueVector>(INT64, getMemoryManager(*database));
@@ -61,7 +61,7 @@ public:
         } else {
             ASSERT_FALSE(agePropertyVectorToReadDataInto->isNull(dataChunk->state->currIdx));
             ASSERT_EQ(expectedValue,
-                ((uint64_t*)agePropertyVectorToReadDataInto->values)[dataChunk->state->currIdx]);
+                agePropertyVectorToReadDataInto->getValue<uint64_t>(dataChunk->state->currIdx));
         }
     }
 
@@ -74,7 +74,7 @@ public:
         } else {
             ASSERT_FALSE(eyeSightVectorToReadDataInto->isNull(dataChunk->state->currIdx));
             ASSERT_EQ(expectedValue,
-                ((double*)eyeSightVectorToReadDataInto->values)[dataChunk->state->currIdx]);
+                eyeSightVectorToReadDataInto->getValue<double_t>(dataChunk->state->currIdx));
         }
     }
 
@@ -88,8 +88,8 @@ public:
         } else {
             propertyVectorToWriteDataTo->setNull(
                 dataChunk->state->currIdx, false /* is not null */);
-            ((uint64_t*)propertyVectorToWriteDataTo->values)[dataChunk->state->currIdx] =
-                expectedValue;
+            propertyVectorToWriteDataTo->setValue(
+                dataChunk->state->currIdx, (uint64_t)expectedValue);
         }
         personAgeColumn->writeValues(nodeVector, propertyVectorToWriteDataTo);
     }
@@ -104,8 +104,8 @@ public:
         } else {
             propertyVectorToWriteDataTo->setNull(
                 dataChunk->state->currIdx, false /* is not null */);
-            ((double*)propertyVectorToWriteDataTo->values)[dataChunk->state->currIdx] =
-                expectedValue;
+            propertyVectorToWriteDataTo->setValue(
+                dataChunk->state->currIdx, (double_t)expectedValue);
         }
         personEyeSightColumn->writeValues(nodeVector, propertyVectorToWriteDataTo);
     }


### PR DESCRIPTION
- Removed `values` in `ValueVector`, instead: (1) expose templated get/setValue interface with a given data type; (2) expose getData() for cases we need access to raw pointers, e.g., need to reference a value inside the vector; memcpy values into/out of the ValueVector, etc.

- Removed `using namespace std` from `types.h`.
- Removed the exception test for "MATCH", which crashes on MacOS due to error signals.