### PR TITLE
fix multi-line query slow pasting issue

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -707,7 +707,7 @@ int linenoiseEditInsert(struct linenoiseState* l, char c) {
                 if (write(l->ofd, &d, 1) == -1)
                     return -1;
             }
-            if (!pastedInput(l->ifd)) {
+            if (!pastedInput(l->ifd) && !inputLeft) {
                 refreshLine(l);
             }
         } else {


### PR DESCRIPTION
Fixed a small issue with pasting multi-line queries. When pasting a multi-line query, if the lines after the first are long enough, it pastes the lines slowly. e.g.

`MATCH`
`(a:person) RETURN a.ID, a.fName, a.workedHours, a.usedNames, a.isStudent, a.isWorker, a.age, a.eyeSight, a.birthdate;`

This fix will make copying and pasting files with a lot of cypher statements faster