### PR TITLE
Scan rel ID blindly

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -97,6 +97,9 @@ void Binder::bindQueryRel(const RelPattern& relPattern, const shared_ptr<NodeExp
     }
     auto queryRel = make_shared<RelExpression>(
         getUniqueExpressionName(parsedName), tableID, srcNode, dstNode, lowerBound, upperBound);
+    if (!queryRel->isVariableLength()) {
+        queryRel->setInternalIDProperty(expressionBinder.bindInternalIDExpression(queryRel));
+    }
     queryRel->setAlias(parsedName);
     queryRel->setRawName(parsedName);
     if (!parsedName.empty()) {
@@ -141,6 +144,7 @@ shared_ptr<NodeExpression> Binder::createQueryNode(const NodePattern& nodePatter
     auto parsedName = nodePattern.getVariableName();
     auto tableIDs = bindNodeTableIDs(nodePattern.getTableNames());
     auto queryNode = make_shared<NodeExpression>(getUniqueExpressionName(parsedName), tableIDs);
+    queryNode->setInternalIDProperty(expressionBinder.bindInternalIDExpression(queryNode));
     queryNode->setAlias(parsedName);
     queryNode->setRawName(parsedName);
     if (!parsedName.empty()) {

--- a/src/binder/expression/existential_subquery_expression.cpp
+++ b/src/binder/expression/existential_subquery_expression.cpp
@@ -17,8 +17,8 @@ unordered_set<string> ExistentialSubqueryExpression::getDependentVariableNames()
 // expressions from predicates and return clause. Plus nodeID expressions from query graph.
 expression_vector ExistentialSubqueryExpression::getChildren() const {
     expression_vector result;
-    for (auto& nodeIDExpression : queryGraphCollection->getNodeIDExpressions()) {
-        result.push_back(nodeIDExpression);
+    for (auto& node : queryGraphCollection->getQueryNodes()) {
+        result.push_back(node->getInternalIDProperty());
     }
     if (hasWhereExpression()) {
         result.push_back(whereExpression);

--- a/src/binder/query/bound_delete_clause.cpp
+++ b/src/binder/query/bound_delete_clause.cpp
@@ -8,6 +8,11 @@ expression_vector BoundDeleteClause::getPropertiesToRead() const {
     for (auto& deleteNode : deleteNodes) {
         result.push_back(deleteNode->getPrimaryKeyExpression());
     }
+    for (auto& deleteRel : deleteRels) {
+        if (deleteRel->hasInternalIDProperty()) {
+            result.push_back(deleteRel->getInternalIDProperty());
+        }
+    }
     return result;
 }
 

--- a/src/binder/query/query_graph.cpp
+++ b/src/binder/query/query_graph.cpp
@@ -187,14 +187,6 @@ bool QueryGraph::isConnected(const QueryGraph& other) {
     return false;
 }
 
-vector<shared_ptr<Expression>> QueryGraph::getNodeIDExpressions() const {
-    vector<shared_ptr<Expression>> result;
-    for (auto& queryNode : queryNodes) {
-        result.push_back(queryNode->getNodeIDPropertyExpression());
-    }
-    return result;
-}
-
 void QueryGraphCollection::addAndMergeQueryGraphIfConnected(
     unique_ptr<QueryGraph> queryGraphToAdd) {
     bool isMerged = false;
@@ -209,11 +201,21 @@ void QueryGraphCollection::addAndMergeQueryGraphIfConnected(
     }
 }
 
-expression_vector QueryGraphCollection::getNodeIDExpressions() const {
-    expression_vector result;
+vector<shared_ptr<NodeExpression>> QueryGraphCollection::getQueryNodes() const {
+    vector<shared_ptr<NodeExpression>> result;
     for (auto& queryGraph : queryGraphs) {
-        for (auto& nodeID : queryGraph->getNodeIDExpressions()) {
-            result.push_back(nodeID);
+        for (auto& node : queryGraph->getQueryNodes()) {
+            result.push_back(node);
+        }
+    }
+    return result;
+}
+
+vector<shared_ptr<RelExpression>> QueryGraphCollection::getQueryRels() const {
+    vector<shared_ptr<RelExpression>> result;
+    for (auto& queryGraph : queryGraphs) {
+        for (auto& rel : queryGraph->getQueryRels()) {
+            result.push_back(rel);
         }
     }
     return result;

--- a/src/include/binder/expression/node_expression.h
+++ b/src/include/binder/expression/node_expression.h
@@ -20,19 +20,20 @@ public:
         return *tableIDs.begin();
     }
 
-    inline string getIDProperty() const { return uniqueName + "." + INTERNAL_ID_SUFFIX; }
-
-    inline shared_ptr<Expression> getNodeIDPropertyExpression() {
-        unordered_map<table_id_t, property_id_t> propertyIDPerTable;
-        for (auto tableID : tableIDs) {
-            propertyIDPerTable.insert({tableID, INVALID_PROPERTY_ID});
-        }
-        return make_unique<PropertyExpression>(DataType(NODE_ID), INTERNAL_ID_SUFFIX,
-            std::move(propertyIDPerTable), shared_from_this());
+    inline void setInternalIDProperty(shared_ptr<Expression> expression) {
+        internalIDExpression = std::move(expression);
+    }
+    inline shared_ptr<Expression> getInternalIDProperty() const {
+        assert(internalIDExpression != nullptr);
+        return internalIDExpression;
+    }
+    inline string getInternalIDPropertyName() const {
+        return internalIDExpression->getUniqueName();
     }
 
 private:
     unordered_set<table_id_t> tableIDs;
+    shared_ptr<Expression> internalIDExpression;
 };
 
 } // namespace binder

--- a/src/include/binder/expression/rel_expression.h
+++ b/src/include/binder/expression/rel_expression.h
@@ -1,17 +1,17 @@
 #pragma once
 
+#include "common/exception.h"
 #include "node_expression.h"
 
 namespace kuzu {
 namespace binder {
 
 class RelExpression : public Expression {
-
 public:
     RelExpression(const string& uniqueName, table_id_t tableID, shared_ptr<NodeExpression> srcNode,
         shared_ptr<NodeExpression> dstNode, uint64_t lowerBound, uint64_t upperBound)
-        : Expression{VARIABLE, REL, uniqueName}, tableID{tableID}, srcNode{move(srcNode)},
-          dstNode{move(dstNode)}, lowerBound{lowerBound}, upperBound{upperBound} {}
+        : Expression{VARIABLE, REL, uniqueName}, tableID{tableID}, srcNode{std::move(srcNode)},
+          dstNode{std::move(dstNode)}, lowerBound{lowerBound}, upperBound{upperBound} {}
 
     inline table_id_t getTableID() const { return tableID; }
 
@@ -29,12 +29,25 @@ public:
 
     inline bool isVariableLength() const { return !(lowerBound == 1 && upperBound == 1); }
 
+    inline void setInternalIDProperty(shared_ptr<Expression> expression) {
+        internalIDExpression = std::move(expression);
+    }
+    inline bool hasInternalIDProperty() const { return internalIDExpression != nullptr; }
+    inline shared_ptr<Expression> getInternalIDProperty() const {
+        if (!hasInternalIDProperty()) {
+            throw NotImplementedException(
+                "Cannot read internal ID property for variable length rel " + getRawName());
+        }
+        return internalIDExpression;
+    }
+
 private:
     table_id_t tableID;
     shared_ptr<NodeExpression> srcNode;
     shared_ptr<NodeExpression> dstNode;
     uint64_t lowerBound;
     uint64_t upperBound;
+    shared_ptr<Expression> internalIDExpression;
 };
 
 } // namespace binder

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -54,6 +54,8 @@ private:
 
     shared_ptr<Expression> bindInternalIDExpression(const ParsedExpression& parsedExpression);
     shared_ptr<Expression> bindInternalIDExpression(shared_ptr<Expression> nodeOrRel);
+    shared_ptr<Expression> bindInternalNodeIDExpression(shared_ptr<Expression> node);
+    shared_ptr<Expression> bindInternalRelIDExpression(shared_ptr<Expression> rel);
 
     shared_ptr<Expression> bindParameterExpression(const ParsedExpression& parsedExpression);
 

--- a/src/include/binder/query/reading_clause/bound_match_clause.h
+++ b/src/include/binder/query/reading_clause/bound_match_clause.h
@@ -41,6 +41,11 @@ public:
 
     inline expression_vector getSubPropertyExpressions() const override {
         expression_vector expressions;
+        for (auto& rel : queryGraphCollection->getQueryRels()) {
+            if (rel->hasInternalIDProperty()) {
+                expressions.push_back(rel->getInternalIDProperty());
+            }
+        }
         if (this->hasWhereExpression()) {
             for (auto& property : this->getWhereExpression()->getSubPropertyExpressions()) {
                 expressions.push_back(property);

--- a/src/include/binder/query/reading_clause/query_graph.h
+++ b/src/include/binder/query/reading_clause/query_graph.h
@@ -87,6 +87,7 @@ public:
     inline bool containsQueryNode(const string& queryNodeName) const {
         return queryNodeNameToPosMap.contains(queryNodeName);
     }
+    inline vector<shared_ptr<NodeExpression>> getQueryNodes() const { return queryNodes; }
     inline shared_ptr<NodeExpression> getQueryNode(const string& queryNodeName) const {
         return queryNodes[getQueryNodePos(queryNodeName)];
     }
@@ -112,6 +113,7 @@ public:
     inline bool containsQueryRel(const string& queryRelName) const {
         return queryRelNameToPosMap.contains(queryRelName);
     }
+    inline vector<shared_ptr<RelExpression>> getQueryRels() const { return queryRels; }
     inline shared_ptr<RelExpression> getQueryRel(const string& queryRelName) const {
         return queryRels.at(queryRelNameToPosMap.at(queryRelName));
     }
@@ -128,8 +130,6 @@ public:
     bool isConnected(const QueryGraph& other);
 
     void merge(const QueryGraph& other);
-
-    vector<shared_ptr<Expression>> getNodeIDExpressions() const;
 
     inline unique_ptr<QueryGraph> copy() const { return make_unique<QueryGraph>(*this); }
 
@@ -150,7 +150,8 @@ public:
     inline uint32_t getNumQueryGraphs() const { return queryGraphs.size(); }
     inline QueryGraph* getQueryGraph(uint32_t idx) const { return queryGraphs[idx].get(); }
 
-    expression_vector getNodeIDExpressions() const;
+    vector<shared_ptr<NodeExpression>> getQueryNodes() const;
+    vector<shared_ptr<RelExpression>> getQueryRels() const;
 
     unique_ptr<QueryGraphCollection> copy() const;
 

--- a/src/include/planner/logical_plan/logical_operator/logical_extend.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_extend.h
@@ -26,7 +26,7 @@ public:
     }
 
     inline void computeSchema(Schema& schema) {
-        auto boundGroupPos = schema.getGroupPos(boundNode->getIDProperty());
+        auto boundGroupPos = schema.getGroupPos(boundNode->getInternalIDPropertyName());
         uint32_t nbrGroupPos = 0u;
         if (isColumn) {
             nbrGroupPos = boundGroupPos;
@@ -34,7 +34,7 @@ public:
             assert(schema.getGroup(boundGroupPos)->getIsFlat());
             nbrGroupPos = schema.createGroup();
         }
-        schema.insertToGroupAndScope(nbrNode->getNodeIDPropertyExpression(), nbrGroupPos);
+        schema.insertToGroupAndScope(nbrNode->getInternalIDProperty(), nbrGroupPos);
     }
 
     inline shared_ptr<NodeExpression> getBoundNodeExpression() const { return boundNode; }

--- a/src/include/planner/logical_plan/logical_operator/logical_scan_node.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_scan_node.h
@@ -19,7 +19,7 @@ public:
 
     inline virtual void computeSchema(Schema& schema) {
         auto groupPos = schema.createGroup();
-        schema.insertToGroupAndScope(node->getNodeIDPropertyExpression(), groupPos);
+        schema.insertToGroupAndScope(node->getInternalIDProperty(), groupPos);
     }
 
     inline shared_ptr<NodeExpression> getNode() const { return node; }
@@ -43,7 +43,7 @@ public:
 
     inline void computeSchema(Schema& schema) override {
         LogicalScanNode::computeSchema(schema);
-        auto groupPos = schema.getGroupPos(node->getIDProperty());
+        auto groupPos = schema.getGroupPos(node->getInternalIDPropertyName());
         schema.getGroup(groupPos)->setIsFlat(true);
     }
 

--- a/src/include/processor/operator/update/delete.h
+++ b/src/include/processor/operator/update/delete.h
@@ -56,15 +56,16 @@ struct DeleteRelInfo {
     table_id_t srcNodeTableID;
     DataPos dstNodePos;
     table_id_t dstNodeTableID;
+    DataPos relIDPos;
 
     DeleteRelInfo(RelTable* table, const DataPos& srcNodePos, table_id_t srcNodeTableID,
-        const DataPos& dstNodePos, table_id_t dstNodeTableID)
+        const DataPos& dstNodePos, table_id_t dstNodeTableID, const DataPos& relIDPos)
         : table{table}, srcNodePos{srcNodePos}, srcNodeTableID{srcNodeTableID},
-          dstNodePos{dstNodePos}, dstNodeTableID{dstNodeTableID} {}
+          dstNodePos{dstNodePos}, dstNodeTableID{dstNodeTableID}, relIDPos{relIDPos} {}
 
     inline unique_ptr<DeleteRelInfo> clone() {
         return make_unique<DeleteRelInfo>(
-            table, srcNodePos, srcNodeTableID, dstNodePos, dstNodeTableID);
+            table, srcNodePos, srcNodeTableID, dstNodePos, dstNodeTableID, relIDPos);
     }
 };
 
@@ -95,7 +96,9 @@ public:
 private:
     RelsStatistics& relsStatistics;
     vector<unique_ptr<DeleteRelInfo>> deleteRelInfos;
-    vector<pair<ValueVector*, ValueVector*>> srcDstNodeIDVectorPairs;
+    vector<ValueVector*> srcNodeVectors;
+    vector<ValueVector*> dstNodeVectors;
+    vector<ValueVector*> relIDVectors;
 };
 
 } // namespace processor

--- a/src/planner/query_planner.cpp
+++ b/src/planner/query_planner.cpp
@@ -154,9 +154,9 @@ static expression_vector getCorrelatedExpressions(
             result.push_back(expression);
         }
     }
-    for (auto& nodeIDExpression : collection.getNodeIDExpressions()) {
-        if (outerSchema->isExpressionInScope(*nodeIDExpression)) {
-            result.push_back(nodeIDExpression);
+    for (auto& node : collection.getQueryNodes()) {
+        if (outerSchema->isExpressionInScope(*node->getInternalIDProperty())) {
+            result.push_back(node->getInternalIDProperty());
         }
     }
     return result;
@@ -191,7 +191,7 @@ void QueryPlanner::planOptionalMatch(const QueryGraphCollection& queryGraphColle
         auto bestInnerPlan = getBestPlan(std::move(innerPlans));
         joinOrderEnumerator.exitSubquery(std::move(prevContext));
         for (auto& joinNode : joinNodes) {
-            appendFlattenIfNecessary(joinNode->getNodeIDPropertyExpression(), outerPlan);
+            appendFlattenIfNecessary(joinNode->getInternalIDProperty(), outerPlan);
         }
         JoinOrderEnumerator::planLeftHashJoin(joinNodes, outerPlan, *bestInnerPlan);
     } else {
@@ -380,7 +380,7 @@ void QueryPlanner::appendScanNodePropIfNecessary(const expression_vector& proper
     shared_ptr<NodeExpression> node, LogicalPlan& plan) {
     auto schema = plan.getSchema();
     expression_vector propertyExpressionToScan;
-    auto groupPos = schema->getGroupPos(node->getIDProperty());
+    auto groupPos = schema->getGroupPos(node->getInternalIDPropertyName());
     for (auto& propertyExpression : propertyExpressions) {
         if (schema->isExpressionInScope(*propertyExpression)) {
             continue;
@@ -413,7 +413,7 @@ void QueryPlanner::appendScanRelPropIfNecessary(shared_ptr<Expression>& expressi
     auto scanProperty = make_shared<LogicalScanRelProperty>(boundNode, nbrNode, relTableID,
         direction, property->getUniqueName(), property->getPropertyID(relTableID), isColumn,
         plan.getLastOperator());
-    auto groupPos = schema->getGroupPos(nbrNode->getIDProperty());
+    auto groupPos = schema->getGroupPos(nbrNode->getInternalIDPropertyName());
     schema->insertToGroupAndScope(property, groupPos);
     plan.setLastOperator(move(scanProperty));
 }

--- a/src/planner/update_planner.cpp
+++ b/src/planner/update_planner.cpp
@@ -47,7 +47,7 @@ void UpdatePlanner::planSetItem(expression_pair setItem, LogicalPlan& plan) {
     // Check LHS
     assert(lhs->getChild(0)->dataType.typeID == NODE);
     auto nodeExpression = static_pointer_cast<NodeExpression>(lhs->getChild(0));
-    auto lhsGroupPos = schema->getGroupPos(nodeExpression->getIDProperty());
+    auto lhsGroupPos = schema->getGroupPos(nodeExpression->getInternalIDPropertyName());
     auto isLhsFlat = schema->getGroup(lhsGroupPos)->getIsFlat();
     // Check RHS
     auto rhsDependentGroupsPos = schema->getDependentGroupsPos(rhs);
@@ -83,7 +83,7 @@ void UpdatePlanner::appendCreateNode(
     for (auto& createNode : createNodes) {
         auto node = createNode->getNode();
         auto groupPos = schema->createGroup();
-        schema->insertToGroupAndScope(node->getNodeIDPropertyExpression(), groupPos);
+        schema->insertToGroupAndScope(node->getInternalIDProperty(), groupPos);
         schema->flattenGroup(groupPos); // create output is always flat
         nodeAndPrimaryKeyPairs.emplace_back(node, createNode->getPrimaryKeyExpression());
         for (auto& setItem : createNode->getSetItems()) {
@@ -144,9 +144,9 @@ void UpdatePlanner::appendDeleteRel(
     const vector<shared_ptr<RelExpression>>& deleteRels, LogicalPlan& plan) {
     // Delete one rel at a time so we flatten for each rel.
     for (auto& rel : deleteRels) {
-        auto srcNodeID = rel->getSrcNode()->getNodeIDPropertyExpression();
+        auto srcNodeID = rel->getSrcNode()->getInternalIDProperty();
         QueryPlanner::appendFlattenIfNecessary(srcNodeID, plan);
-        auto dstNodeID = rel->getDstNode()->getNodeIDPropertyExpression();
+        auto dstNodeID = rel->getDstNode()->getInternalIDProperty();
         QueryPlanner::appendFlattenIfNecessary(dstNodeID, plan);
     }
     auto deleteRel = make_shared<LogicalDeleteRel>(deleteRels, plan.getLastOperator());

--- a/src/processor/mapper/map_create.cpp
+++ b/src/processor/mapper/map_create.cpp
@@ -23,7 +23,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalCreateNodeToPhysical(
                 relTablesToInit.push_back(storageManager.getRelsStore().getRelTable(relTableID));
             }
         }
-        auto outDataPos = mapperContext.getDataPos(node->getIDProperty());
+        auto outDataPos = mapperContext.getDataPos(node->getInternalIDPropertyName());
         createNodeInfos.push_back(make_unique<CreateNodeInfo>(
             table, std::move(primaryKeyEvaluator), relTablesToInit, outDataPos));
     }
@@ -40,9 +40,9 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalCreateRelToPhysical(
     for (auto i = 0u; i < logicalCreateRel->getNumRels(); ++i) {
         auto rel = logicalCreateRel->getRel(i);
         auto table = relStore.getRelTable(rel->getTableID());
-        auto srcNodePos = mapperContext.getDataPos(rel->getSrcNode()->getIDProperty());
+        auto srcNodePos = mapperContext.getDataPos(rel->getSrcNode()->getInternalIDPropertyName());
         auto srcNodeTableID = rel->getSrcNode()->getTableID();
-        auto dstNodePos = mapperContext.getDataPos(rel->getDstNode()->getIDProperty());
+        auto dstNodePos = mapperContext.getDataPos(rel->getDstNode()->getInternalIDPropertyName());
         auto dstNodeTableID = rel->getDstNode()->getTableID();
         vector<unique_ptr<BaseExpressionEvaluator>> evaluators;
         uint32_t relIDEvaluatorIdx = UINT32_MAX;

--- a/src/processor/mapper/map_delete.cpp
+++ b/src/processor/mapper/map_delete.cpp
@@ -14,7 +14,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalDeleteNodeToPhysical(
     vector<unique_ptr<DeleteNodeInfo>> deleteNodeInfos;
     for (auto& [node, primaryKey] : logicalDeleteNode->getNodeAndPrimaryKeys()) {
         auto nodeTable = nodesStore.getNodeTable(node->getTableID());
-        auto nodeIDPos = mapperContext.getDataPos(node->getIDProperty());
+        auto nodeIDPos = mapperContext.getDataPos(node->getInternalIDPropertyName());
         auto primaryKeyPos = mapperContext.getDataPos(primaryKey->getUniqueName());
         deleteNodeInfos.push_back(make_unique<DeleteNodeInfo>(nodeTable, nodeIDPos, primaryKeyPos));
     }
@@ -31,12 +31,13 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalDeleteRelToPhysical(
     for (auto i = 0u; i < logicalDeleteRel->getNumRels(); ++i) {
         auto rel = logicalDeleteRel->getRel(i);
         auto table = relStore.getRelTable(rel->getTableID());
-        auto srcNodePos = mapperContext.getDataPos(rel->getSrcNode()->getIDProperty());
+        auto srcNodePos = mapperContext.getDataPos(rel->getSrcNode()->getInternalIDPropertyName());
         auto srcNodeTableID = rel->getSrcNode()->getTableID();
-        auto dstNodePos = mapperContext.getDataPos(rel->getDstNode()->getIDProperty());
+        auto dstNodePos = mapperContext.getDataPos(rel->getDstNode()->getInternalIDPropertyName());
         auto dstNodeTableID = rel->getDstNode()->getTableID();
+        auto relIDPos = mapperContext.getDataPos(rel->getInternalIDProperty()->getUniqueName());
         createRelInfos.push_back(make_unique<DeleteRelInfo>(
-            table, srcNodePos, srcNodeTableID, dstNodePos, dstNodeTableID));
+            table, srcNodePos, srcNodeTableID, dstNodePos, dstNodeTableID, relIDPos));
     }
     return make_unique<DeleteRel>(relStore.getRelsStatistics(), std::move(createRelInfos),
         std::move(prevOperator), getOperatorID(), logicalOperator->getExpressionsForPrinting());

--- a/src/processor/mapper/map_extend.cpp
+++ b/src/processor/mapper/map_extend.cpp
@@ -14,9 +14,9 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
     auto boundNode = extend->getBoundNodeExpression();
     auto nbrNode = extend->getNbrNodeExpression();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
-    auto inDataPos = mapperContext.getDataPos(boundNode->getIDProperty());
-    auto outDataPos = mapperContext.getDataPos(nbrNode->getIDProperty());
-    mapperContext.addComputedExpressions(nbrNode->getIDProperty());
+    auto inDataPos = mapperContext.getDataPos(boundNode->getInternalIDPropertyName());
+    auto outDataPos = mapperContext.getDataPos(nbrNode->getInternalIDPropertyName());
+    mapperContext.addComputedExpressions(nbrNode->getInternalIDPropertyName());
     auto& relsStore = storageManager.getRelsStore();
     auto lowerBound = extend->getLowerBound();
     auto upperBound = extend->getUpperBound();

--- a/src/processor/mapper/map_hash_join.cpp
+++ b/src/processor/mapper/map_hash_join.cpp
@@ -99,7 +99,7 @@ BuildDataInfo PlanMapper::generateBuildDataInfo(MapperContext& mapperContext,
         buildSideMapperContext.getResultSetDescriptor()->getNumDataChunks(), false);
     unordered_set<string> joinNodeIDs;
     for (auto& key : keys) {
-        auto nodeID = key->getIDProperty();
+        auto nodeID = key->getInternalIDPropertyName();
         auto buildSideKeyPos = buildSideMapperContext.getDataPos(nodeID);
         isBuildDataChunkContainKeys[buildSideKeyPos.dataChunkPos] = true;
         buildKeysDataPos.push_back(buildSideMapperContext.getDataPos(nodeID));
@@ -137,7 +137,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
     vector<DataPos> probeKeysDataPos, probePayloadsDataPos;
     vector<DataType> payloadsDataTypes;
     for (auto& joinNode : hashJoin->getJoinNodes()) {
-        auto joinNodeID = joinNode->getIDProperty();
+        auto joinNodeID = joinNode->getInternalIDPropertyName();
         probeKeysDataPos.push_back(mapperContext.getDataPos(joinNodeID));
     }
     for (auto& dataPos : buildDataInfo.payloadsDataPos) {
@@ -177,7 +177,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalSemiMaskerToPhysical(
     auto logicalSemiMasker = (LogicalSemiMasker*)logicalOperator;
     auto node = logicalSemiMasker->getNode();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
-    auto keyDataPos = mapperContext.getDataPos(node->getIDProperty());
+    auto keyDataPos = mapperContext.getDataPos(node->getInternalIDPropertyName());
     return make_unique<SemiMasker>(keyDataPos, std::move(prevOperator), getOperatorID(),
         logicalSemiMasker->getExpressionsForPrinting());
 }

--- a/src/processor/mapper/map_intersect.cpp
+++ b/src/processor/mapper/map_intersect.cpp
@@ -19,7 +19,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
     // Map build side children.
     for (auto i = 1u; i < logicalIntersect->getNumChildren(); i++) {
         auto buildInfo = logicalIntersect->getBuildInfo(i - 1);
-        auto buildKey = buildInfo->key->getIDProperty();
+        auto buildKey = buildInfo->key->getInternalIDPropertyName();
         auto buildSideSchema = buildInfo->schema.get();
         auto buildSideMapperContext =
             MapperContext(make_unique<ResultSetDescriptor>(*buildSideSchema));
@@ -33,7 +33,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
             auto expression = buildSideSchema->getGroup(dataPos.dataChunkPos)
                                   ->getExpressions()[dataPos.valueVectorPos];
             if (expression->getUniqueName() ==
-                logicalIntersect->getIntersectNode()->getIDProperty()) {
+                logicalIntersect->getIntersectNode()->getInternalIDPropertyName()) {
                 continue;
             }
             payloadsDataPos.push_back(mapperContext.getDataPos(expression->getUniqueName()));
@@ -49,7 +49,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
     }
     // Map intersect.
     auto outputDataPos =
-        mapperContext.getDataPos(logicalIntersect->getIntersectNode()->getIDProperty());
+        mapperContext.getDataPos(logicalIntersect->getIntersectNode()->getInternalIDPropertyName());
     return make_unique<Intersect>(outputDataPos, intersectDataInfos, sharedStates, move(children),
         getOperatorID(), logicalIntersect->getExpressionsForPrinting());
 }

--- a/src/processor/mapper/map_scan_node.cpp
+++ b/src/processor/mapper/map_scan_node.cpp
@@ -13,8 +13,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodeToPhysical(
     auto node = logicalScan->getNode();
     auto& nodesStore = storageManager.getNodesStore();
 
-    auto dataPos = mapperContext.getDataPos(node->getIDProperty());
-    mapperContext.addComputedExpressions(node->getIDProperty());
+    auto dataPos = mapperContext.getDataPos(node->getInternalIDPropertyName());
+    mapperContext.addComputedExpressions(node->getInternalIDPropertyName());
     auto sharedState = make_shared<ScanNodeIDSharedState>();
     for (auto& tableID : node->getTableIDs()) {
         auto nodeTable = nodesStore.getNodeTable(tableID);
@@ -30,10 +30,10 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIndexScanNodeToPhysical(
     auto logicalIndexScan = (LogicalIndexScanNode*)logicalOperator;
     auto node = logicalIndexScan->getNode();
     auto nodeTable = storageManager.getNodesStore().getNodeTable(node->getTableID());
-    auto dataPos = mapperContext.getDataPos(node->getIDProperty());
+    auto dataPos = mapperContext.getDataPos(node->getInternalIDPropertyName());
     auto evaluator =
         expressionMapper.mapExpression(logicalIndexScan->getIndexExpression(), mapperContext);
-    mapperContext.addComputedExpressions(node->getIDProperty());
+    mapperContext.addComputedExpressions(node->getInternalIDPropertyName());
     return make_unique<IndexScan>(mapperContext.getResultSetDescriptor()->copy(),
         nodeTable->getTableID(), nodeTable->getPKIndex(), std::move(evaluator), dataPos,
         getOperatorID(), logicalIndexScan->getExpressionsForPrinting());

--- a/src/processor/mapper/map_scan_node_property.cpp
+++ b/src/processor/mapper/map_scan_node_property.cpp
@@ -10,7 +10,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodePropertyToPhysical(
     auto& scanProperty = (const LogicalScanNodeProperty&)*logicalOperator;
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
     auto node = scanProperty.getNode();
-    auto inputNodeIDVectorPos = mapperContext.getDataPos(node->getIDProperty());
+    auto inputNodeIDVectorPos = mapperContext.getDataPos(node->getInternalIDPropertyName());
     auto& nodeStore = storageManager.getNodesStore();
     vector<DataPos> outVectorsPos;
     vector<DataType> outDataTypes;

--- a/src/processor/mapper/map_scan_rel_property.cpp
+++ b/src/processor/mapper/map_scan_rel_property.cpp
@@ -11,7 +11,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanRelPropertyToPhysical(
     auto scanRelProperty = (LogicalScanRelProperty*)logicalOperator;
     auto boundNode = scanRelProperty->getBoundNodeExpression();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0), mapperContext);
-    auto inputNodeIDVectorPos = mapperContext.getDataPos(boundNode->getIDProperty());
+    auto inputNodeIDVectorPos = mapperContext.getDataPos(boundNode->getInternalIDPropertyName());
     auto propertyName = scanRelProperty->getPropertyName();
     auto propertyID = scanRelProperty->getPropertyID();
     auto outputPropertyVectorPos = mapperContext.getDataPos(propertyName);

--- a/src/processor/mapper/map_set.cpp
+++ b/src/processor/mapper/map_set.cpp
@@ -24,7 +24,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalSetToPhysical(
     for (auto& [expr, _] : setItems) {
         auto property = static_pointer_cast<PropertyExpression>(expr);
         auto node = static_pointer_cast<NodeExpression>(property->getChild(0));
-        nodeIDVectorPositions.push_back(mapperContext.getDataPos(node->getIDProperty()));
+        nodeIDVectorPositions.push_back(
+            mapperContext.getDataPos(node->getInternalIDPropertyName()));
         propertyColumns.push_back(nodeStore.getNodePropertyColumn(
             node->getTableID(), property->getPropertyID(node->getTableID())));
     }

--- a/test/include/mock_catalog/mock_catalog.h
+++ b/test/include/mock_catalog/mock_catalog.h
@@ -111,6 +111,8 @@ private:
             .WillByDefault(Return(true));
         ON_CALL(*this, containRelProperty(KNOWS_TABLE_ID, KNOWSDATE_PROPERTY_KEY_STR))
             .WillByDefault(Return(true));
+        ON_CALL(*this, containRelProperty(KNOWS_TABLE_ID, KNOWSDATE_PROPERTY_KEY_STR))
+            .WillByDefault(Return(true));
         ON_CALL(*this, containRelProperty(1, _)).WillByDefault(Return(false));
     }
 
@@ -219,12 +221,16 @@ private:
     }
 
     void setRelTableSchemas() {
-        knowsTableSchema =
-            make_unique<RelTableSchema>("knows", KNOWS_TABLE_ID, MANY_MANY, vector<Property>{},
-                vector<pair<table_id_t, table_id_t>>{{PERSON_TABLE_ID, PERSON_TABLE_ID}});
-        workAtTableSchema =
-            make_unique<RelTableSchema>("workAt", WORKAT_TABLE_ID, MANY_ONE, vector<Property>{},
-                vector<pair<table_id_t, table_id_t>>{{PERSON_TABLE_ID, ORGANISATION_TABLE_ID}});
+        auto knowsID = Property::constructRelProperty(
+            PropertyNameDataType(INTERNAL_ID_SUFFIX, INT64), 0, KNOWS_TABLE_ID);
+        knowsTableSchema = make_unique<RelTableSchema>("knows", KNOWS_TABLE_ID, MANY_MANY,
+            vector<Property>{knowsID},
+            vector<pair<table_id_t, table_id_t>>{{PERSON_TABLE_ID, PERSON_TABLE_ID}});
+        auto workAtID = Property::constructRelProperty(
+            PropertyNameDataType(INTERNAL_ID_SUFFIX, INT64), 0, WORKAT_TABLE_ID);
+        workAtTableSchema = make_unique<RelTableSchema>("workAt", WORKAT_TABLE_ID, MANY_ONE,
+            vector<Property>{workAtID},
+            vector<pair<table_id_t, table_id_t>>{{PERSON_TABLE_ID, ORGANISATION_TABLE_ID}});
     }
 
     vector<unordered_set<table_id_t>> srcNodeIDToRelIDs, dstNodeIDToRelIDs;


### PR DESCRIPTION
Since we are supporting rel deletion and property setting, we need to scan rel ID (unique identifier) blindly to make sure we can scan local store property. 

This PR adds rel ID scanning for each rel extend by storing internal ID with node/rel variable together. This helps us to move towards a principal that all property binding (i.e. column binding) should happen in binder. No other components is allowed to perform any kind of binding. 