### PR TITLE
Add init global state interface

### DIFF
--- a/src/include/processor/operator/hash_join/hash_join_probe.h
+++ b/src/include/processor/operator/hash_join/hash_join_probe.h
@@ -27,21 +27,23 @@ struct ProbeState {
 };
 
 struct ProbeDataInfo {
-
 public:
-    ProbeDataInfo(vector<DataPos> keysDataPos, vector<DataPos> payloadsOutputDataPos)
+    ProbeDataInfo(
+        vector<DataPos> keysDataPos, vector<pair<DataPos, DataType>> payloadsOutPosAndType)
         : keysDataPos{std::move(keysDataPos)},
-          payloadsOutputDataPos{std::move(payloadsOutputDataPos)}, markDataPos{
+          payloadsOutPosAndType{std::move(payloadsOutPosAndType)}, markDataPos{
                                                                        UINT32_MAX, UINT32_MAX} {}
 
     ProbeDataInfo(const ProbeDataInfo& other)
-        : ProbeDataInfo{other.keysDataPos, other.payloadsOutputDataPos} {
+        : ProbeDataInfo{other.keysDataPos, other.payloadsOutPosAndType} {
         markDataPos = other.markDataPos;
     }
 
+    inline uint32_t getNumPayloads() const { return payloadsOutPosAndType.size(); }
+
 public:
     vector<DataPos> keysDataPos;
-    vector<DataPos> payloadsOutputDataPos;
+    vector<pair<DataPos, DataType>> payloadsOutPosAndType;
     DataPos markDataPos;
 };
 

--- a/src/include/processor/operator/intersect/intersect_build.h
+++ b/src/include/processor/operator/intersect/intersect_build.h
@@ -8,10 +8,9 @@ namespace processor {
 
 class IntersectSharedState : public HashJoinSharedState {
 public:
-    explicit IntersectSharedState(vector<DataType> payloadDataTypes)
-        : HashJoinSharedState{move(payloadDataTypes)} {}
+    IntersectSharedState() = default;
 
-    void initEmptyHashTableIfNecessary(MemoryManager& memoryManager, uint64_t numKeyColumns,
+    void initEmptyHashTable(MemoryManager& memoryManager, uint64_t numKeyColumns,
         unique_ptr<FactorizedTableSchema> tableSchema) override;
 };
 
@@ -30,7 +29,7 @@ public:
     }
 
 protected:
-    void initHashTable(
+    void initLocalHashTable(
         MemoryManager& memoryManager, unique_ptr<FactorizedTableSchema> tableSchema) override;
 };
 

--- a/src/include/processor/operator/order_by/key_block_merger.h
+++ b/src/include/processor/operator/order_by/key_block_merger.h
@@ -14,8 +14,7 @@ struct KeyBlockMergeMorsel;
 // This struct stores the string key column information. We can utilize the
 // pre-computed indexes and offsets to expedite the tuple comparison in merge sort.
 struct StrKeyColInfo {
-    StrKeyColInfo(
-        uint32_t colOffsetInFT, uint32_t colOffsetInEncodedKeyBlock, bool isAscOrder, bool isStrCol)
+    StrKeyColInfo(uint32_t colOffsetInFT, uint32_t colOffsetInEncodedKeyBlock, bool isAscOrder)
         : colOffsetInFT{colOffsetInFT}, colOffsetInEncodedKeyBlock{colOffsetInEncodedKeyBlock},
           isAscOrder{isAscOrder} {}
 
@@ -192,9 +191,8 @@ public:
     void doneMorsel(unique_ptr<KeyBlockMergeMorsel> morsel);
 
     // This function is used to initialize the columns of keyBlockMergeTaskDispatcher based on
-    // sharedFactorizedTablesAndSortedKeyBlocks. If the class is already initialized, then it
-    // just returns.
-    void initIfNecessary(MemoryManager* memoryManager,
+    // sharedFactorizedTablesAndSortedKeyBlocks.
+    void init(MemoryManager* memoryManager,
         shared_ptr<queue<shared_ptr<MergedKeyBlocks>>> sortedKeyBlocks,
         vector<shared_ptr<FactorizedTable>>& factorizedTables,
         vector<StrKeyColInfo>& strKeyColsInfo, uint64_t numBytesPerTuple);
@@ -202,7 +200,6 @@ public:
 private:
     mutex mtx;
 
-    bool isInitialized = false;
     MemoryManager* memoryManager;
     shared_ptr<queue<shared_ptr<MergedKeyBlocks>>> sortedKeyBlocks;
     vector<shared_ptr<KeyBlockMergeTask>> activeKeyBlockMergeTasks;

--- a/src/include/processor/operator/order_by/order_by_key_encoder.h
+++ b/src/include/processor/operator/order_by/order_by_key_encoder.h
@@ -47,7 +47,8 @@ class OrderByKeyEncoder {
 
 public:
     OrderByKeyEncoder(vector<shared_ptr<ValueVector>>& orderByVectors, vector<bool>& isAscOrder,
-        MemoryManager* memoryManager, uint8_t ftIdx, uint32_t numTuplesPerBlockInFT);
+        MemoryManager* memoryManager, uint8_t ftIdx, uint32_t numTuplesPerBlockInFT,
+        uint32_t numBytesPerTuple);
 
     inline vector<shared_ptr<DataBlock>>& getKeyBlocks() { return keyBlocks; }
 
@@ -78,6 +79,8 @@ public:
     static inline bool isLongStr(const uint8_t* strBuffer, bool isAsc) {
         return *(strBuffer + 13) == (isAsc ? UINT8_MAX : 0);
     }
+
+    static uint32_t getNumBytesPerTuple(const vector<shared_ptr<ValueVector>>& keyVectors);
 
     static uint32_t getEncodingSize(const DataType& dataType);
 

--- a/src/include/processor/operator/order_by/order_by_scan.h
+++ b/src/include/processor/operator/order_by/order_by_scan.h
@@ -20,23 +20,24 @@ struct MergedKeyBlockScanState {
 // To preserve the ordering of tuples, the orderByScan operator will only
 // be executed in single-thread mode.
 class OrderByScan : public PhysicalOperator, public SourceOperator {
-
 public:
     OrderByScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        const vector<DataPos>& outDataPoses,
+        vector<pair<DataPos, DataType>> outVectorPosAndTypes,
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState,
         unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(child), id, paramsString}, SourceOperator{move(
-                                                               resultSetDescriptor)},
-          outDataPoses{outDataPoses}, sharedState{move(sharedState)} {}
+        : PhysicalOperator{std::move(child), id, paramsString}, SourceOperator{std::move(
+                                                                    resultSetDescriptor)},
+          outVectorPosAndTypes{std::move(outVectorPosAndTypes)}, sharedState{
+                                                                     std::move(sharedState)} {}
 
     // This constructor is used for cloning only.
     OrderByScan(unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        const vector<DataPos>& outDataPoses,
+        vector<pair<DataPos, DataType>> outVectorPosAndTypes,
         shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState, uint32_t id,
         const string& paramsString)
-        : PhysicalOperator{id, paramsString}, SourceOperator{move(resultSetDescriptor)},
-          outDataPoses{outDataPoses}, sharedState{move(sharedState)} {}
+        : PhysicalOperator{id, paramsString}, SourceOperator{std::move(resultSetDescriptor)},
+          outVectorPosAndTypes{std::move(outVectorPosAndTypes)}, sharedState{
+                                                                     std::move(sharedState)} {}
 
     PhysicalOperatorType getOperatorType() override { return ORDER_BY_SCAN; }
 
@@ -46,7 +47,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<OrderByScan>(
-            resultSetDescriptor->copy(), outDataPoses, sharedState, id, paramsString);
+            resultSetDescriptor->copy(), outVectorPosAndTypes, sharedState, id, paramsString);
     }
 
     inline double getExecutionTime(Profiler& profiler) const override {
@@ -54,10 +55,10 @@ public:
     }
 
 private:
-    void initMergedKeyBlockScanStateIfNecessary();
+    void initMergedKeyBlockScanState();
 
 private:
-    vector<DataPos> outDataPoses;
+    vector<pair<DataPos, DataType>> outVectorPosAndTypes;
     shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState;
     vector<shared_ptr<ValueVector>> vectorsToRead;
     unique_ptr<MergedKeyBlockScanState> mergedKeyBlockScanState;

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -98,7 +98,11 @@ public:
 
     virtual PhysicalOperatorType getOperatorType() = 0;
 
+    // Local state is initialized for each thread.
     virtual shared_ptr<ResultSet> init(ExecutionContext* context);
+
+    // Global state is initialized once.
+    void initGlobalState(ExecutionContext* context);
 
     inline bool getNextTuple() {
         metrics->executionTime.start();
@@ -122,6 +126,7 @@ public:
     inline string getParamsString() const { return paramsString; }
 
 protected:
+    virtual void initGlobalStateInternal(ExecutionContext* context) {}
     // Return false if no more tuples to pull, otherwise return true
     virtual bool getNextTuplesInternal() = 0;
 

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -28,7 +28,8 @@ public:
 
     inline shared_ptr<FactorizedTable> getTable() { return table; }
 
-    inline uint64_t getMaxMorselSize() const {
+    inline uint64_t getMaxMorselSize() {
+        lock_guard<mutex> lck{mtx};
         return table->hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
     }
     unique_ptr<FTableScanMorsel> getMorsel(uint64_t maxMorselSize);
@@ -41,13 +42,13 @@ private:
 };
 
 class ResultCollector : public Sink {
-
 public:
-    ResultCollector(vector<pair<DataPos, bool>> vectorsToCollectInfo,
+    ResultCollector(vector<pair<DataPos, DataType>> payloadsPosAndType, vector<bool> isPayloadFlat,
         shared_ptr<FTableSharedState> sharedState, unique_ptr<PhysicalOperator> child, uint32_t id,
         const string& paramsString)
-        : Sink{move(child), id, paramsString}, vectorsToCollectInfo{move(vectorsToCollectInfo)},
-          sharedState{move(sharedState)} {}
+        : Sink{std::move(child), id, paramsString}, payloadsPosAndType{std::move(
+                                                        payloadsPosAndType)},
+          isPayloadFlat{std::move(isPayloadFlat)}, sharedState{std::move(sharedState)} {}
 
     PhysicalOperatorType getOperatorType() override { return RESULT_COLLECTOR; }
 
@@ -57,7 +58,7 @@ public:
 
     unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ResultCollector>(
-            vectorsToCollectInfo, sharedState, children[0]->clone(), id, paramsString);
+            payloadsPosAndType, isPayloadFlat, sharedState, children[0]->clone(), id, paramsString);
     }
 
     inline shared_ptr<FTableSharedState> getSharedState() { return sharedState; }
@@ -66,7 +67,13 @@ public:
     }
 
 private:
-    vector<pair<DataPos, bool>> vectorsToCollectInfo;
+    void initGlobalStateInternal(ExecutionContext* context) override;
+
+    unique_ptr<FactorizedTableSchema> populateTableSchema();
+
+private:
+    vector<pair<DataPos, DataType>> payloadsPosAndType;
+    vector<bool> isPayloadFlat;
     vector<shared_ptr<ValueVector>> vectorsToCollect;
     shared_ptr<FTableSharedState> sharedState;
     unique_ptr<FactorizedTable> localTable;

--- a/src/include/processor/operator/semi_masker.h
+++ b/src/include/processor/operator/semi_masker.h
@@ -35,6 +35,9 @@ public:
     inline unique_ptr<PhysicalOperator> clone() override { return make_unique<SemiMasker>(*this); }
 
 private:
+    void initGlobalStateInternal(ExecutionContext* context) override;
+
+private:
     DataPos keyDataPos;
     // Multiple maskers can point to the same scanNodeID, thus we associate each masker with an idx
     // to indicate the execution sequence of its pipeline. Also, the maskerIdx is used as a flag to

--- a/src/include/processor/operator/sink.h
+++ b/src/include/processor/operator/sink.h
@@ -7,8 +7,9 @@ namespace processor {
 
 class Sink : public PhysicalOperator {
 public:
+    Sink(uint32_t id, const string& paramsString) : PhysicalOperator{id, paramsString} {}
     Sink(unique_ptr<PhysicalOperator> child, uint32_t id, const string& paramsString)
-        : PhysicalOperator{move(child), id, paramsString} {}
+        : PhysicalOperator{std::move(child), id, paramsString} {}
 
     PhysicalOperatorType getOperatorType() override = 0;
 

--- a/src/include/processor/processor_task.h
+++ b/src/include/processor/processor_task.h
@@ -9,16 +9,15 @@ namespace kuzu {
 namespace processor {
 
 class ProcessorTask : public Task {
-
 public:
-    ProcessorTask(Sink* sinkOp, ExecutionContext* executionContext)
-        : Task{executionContext->numThreads}, sinkOp{sinkOp}, executionContext{executionContext} {}
+    ProcessorTask(Sink* sink, ExecutionContext* executionContext)
+        : Task{executionContext->numThreads}, sink{sink}, executionContext{executionContext} {}
 
     void run() override;
     void finalizeIfNecessary() override;
 
 private:
-    Sink* sinkOp;
+    Sink* sink;
     ExecutionContext* executionContext;
 };
 

--- a/src/processor/mapper/map_intersect.cpp
+++ b/src/processor/mapper/map_intersect.cpp
@@ -29,7 +29,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
         vector<DataPos> payloadsDataPos;
         auto buildDataInfo = generateBuildDataInfo(mapperContext, buildInfo->schema.get(),
             {buildInfo->key}, buildInfo->expressionsToMaterialize);
-        for (auto& dataPos : buildDataInfo.payloadsDataPos) {
+        for (auto& [dataPos, _] : buildDataInfo.payloadsPosAndType) {
             auto expression = buildSideSchema->getGroup(dataPos.dataChunkPos)
                                   ->getExpressions()[dataPos.valueVectorPos];
             if (expression->getUniqueName() ==
@@ -39,7 +39,7 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
             payloadsDataPos.push_back(mapperContext.getDataPos(expression->getUniqueName()));
             payloadsDataTypes.push_back(expression->getDataType());
         }
-        auto sharedState = make_shared<IntersectSharedState>(payloadsDataTypes);
+        auto sharedState = make_shared<IntersectSharedState>();
         sharedStates.push_back(sharedState);
         children.push_back(make_unique<IntersectBuild>(sharedState, buildDataInfo,
             std::move(buildSidePrevOperator), getOperatorID(), buildKey));

--- a/src/processor/mapper/map_order_by.cpp
+++ b/src/processor/mapper/map_order_by.cpp
@@ -13,35 +13,41 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOrderByToPhysical(
     auto& schemaBeforeOrderBy = *logicalOrderBy.getSchemaBeforeOrderBy();
     auto mapperContextBeforeOrderBy =
         MapperContext(make_unique<ResultSetDescriptor>(schemaBeforeOrderBy));
-    auto orderByPrevOperator =
+    auto prevOperator =
         mapLogicalOperatorToPhysical(logicalOrderBy.getChild(0), mapperContextBeforeOrderBy);
     auto paramsString = logicalOrderBy.getExpressionsForPrinting();
-    vector<DataPos> keyDataPoses;
+    vector<pair<DataPos, DataType>> keysPosAndType;
     for (auto& expression : logicalOrderBy.getExpressionsToOrderBy()) {
-        keyDataPoses.emplace_back(
-            mapperContextBeforeOrderBy.getDataPos(expression->getUniqueName()));
+        keysPosAndType.emplace_back(
+            mapperContextBeforeOrderBy.getDataPos(expression->getUniqueName()),
+            expression->dataType);
     }
-    vector<DataPos> inputDataPoses;
-    vector<bool> isInputVectorFlat;
-    vector<DataPos> outputDataPoses;
+    vector<pair<DataPos, DataType>> payloadsPosAndType;
+    vector<bool> isPayloadFlat;
+    vector<pair<DataPos, DataType>> outVectorPosAndTypes;
     for (auto& expression : logicalOrderBy.getExpressionsToMaterialize()) {
         auto expressionName = expression->getUniqueName();
-        inputDataPoses.push_back(mapperContextBeforeOrderBy.getDataPos(expressionName));
-        isInputVectorFlat.push_back(schemaBeforeOrderBy.getGroup(expressionName)->getIsFlat());
-        outputDataPoses.push_back(mapperContext.getDataPos(expressionName));
+        payloadsPosAndType.emplace_back(
+            mapperContextBeforeOrderBy.getDataPos(expressionName), expression->dataType);
+        isPayloadFlat.push_back(schemaBeforeOrderBy.getGroup(expressionName)->getIsFlat());
+        outVectorPosAndTypes.emplace_back(
+            mapperContext.getDataPos(expressionName), expression->dataType);
         mapperContext.addComputedExpressions(expressionName);
     }
-
-    auto orderByDataInfo = OrderByDataInfo(
-        keyDataPoses, inputDataPoses, isInputVectorFlat, logicalOrderBy.getIsAscOrders());
+    // See comment in planOrderBy in projectionPlanner.cpp
+    auto mayContainUnflatKey = logicalOrderBy.getSchemaBeforeOrderBy()->getNumGroups() == 1;
+    auto orderByDataInfo = OrderByDataInfo(keysPosAndType, payloadsPosAndType, isPayloadFlat,
+        logicalOrderBy.getIsAscOrders(), mayContainUnflatKey);
     auto orderBySharedState = make_shared<SharedFactorizedTablesAndSortedKeyBlocks>();
 
     auto orderBy = make_unique<OrderBy>(orderByDataInfo, orderBySharedState,
-        move(orderByPrevOperator), getOperatorID(), paramsString);
-    auto orderByMerge =
-        make_unique<OrderByMerge>(orderBySharedState, move(orderBy), getOperatorID(), paramsString);
+        std::move(prevOperator), getOperatorID(), paramsString);
+    auto dispatcher = make_shared<KeyBlockMergeTaskDispatcher>();
+    auto orderByMerge = make_unique<OrderByMerge>(orderBySharedState, std::move(dispatcher),
+        std::move(orderBy), getOperatorID(), paramsString);
     auto orderByScan = make_unique<OrderByScan>(mapperContext.getResultSetDescriptor()->copy(),
-        outputDataPoses, orderBySharedState, move(orderByMerge), getOperatorID(), paramsString);
+        outVectorPosAndTypes, orderBySharedState, std::move(orderByMerge), getOperatorID(),
+        paramsString);
     return orderByScan;
 }
 

--- a/src/processor/mapper/plan_mapper.cpp
+++ b/src/processor/mapper/plan_mapper.cpp
@@ -133,20 +133,18 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOperatorToPhysical(
 unique_ptr<ResultCollector> PlanMapper::appendResultCollector(
     const expression_vector& expressionsToCollect, const Schema& schema,
     unique_ptr<PhysicalOperator> prevOperator, MapperContext& mapperContext) {
-    vector<pair<DataPos, bool>> valueVectorsToCollectInfo;
+    vector<pair<DataPos, DataType>> payloadsPosAndType;
+    vector<bool> isPayloadFlat;
     for (auto& expression : expressionsToCollect) {
         auto expressionName = expression->getUniqueName();
         auto dataPos = mapperContext.getDataPos(expressionName);
         auto isFlat = schema.getGroup(expressionName)->getIsFlat();
-        valueVectorsToCollectInfo.emplace_back(dataPos, isFlat);
-    }
-    auto paramsString = string();
-    for (auto& expression : expressionsToCollect) {
-        paramsString += expression->getUniqueName() + ", ";
+        payloadsPosAndType.emplace_back(dataPos, expression->dataType);
+        isPayloadFlat.push_back(isFlat);
     }
     auto sharedState = make_shared<FTableSharedState>();
-    return make_unique<ResultCollector>(
-        valueVectorsToCollectInfo, sharedState, move(prevOperator), getOperatorID(), paramsString);
+    return make_unique<ResultCollector>(payloadsPosAndType, isPayloadFlat, sharedState,
+        std::move(prevOperator), getOperatorID(), ExpressionUtil::toString(expressionsToCollect));
 }
 
 } // namespace processor

--- a/src/processor/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/operator/hash_join/hash_join_build.cpp
@@ -5,58 +5,67 @@
 namespace kuzu {
 namespace processor {
 
-void HashJoinSharedState::initEmptyHashTableIfNecessary(MemoryManager& memoryManager,
-    uint64_t numKeyColumns, unique_ptr<FactorizedTableSchema> tableSchema) {
-    unique_lock lck(hashJoinSharedStateMutex);
-    if (hashTable == nullptr) {
-        hashTable = make_unique<JoinHashTable>(memoryManager, numKeyColumns, move(tableSchema));
-    }
+void HashJoinSharedState::initEmptyHashTable(MemoryManager& memoryManager, uint64_t numKeyColumns,
+    unique_ptr<FactorizedTableSchema> tableSchema) {
+    assert(hashTable == nullptr);
+    hashTable = make_unique<JoinHashTable>(memoryManager, numKeyColumns, std::move(tableSchema));
 }
 
 void HashJoinSharedState::mergeLocalHashTable(JoinHashTable& localHashTable) {
-    unique_lock lck(hashJoinSharedStateMutex);
+    unique_lock lck(mtx);
     hashTable->merge(localHashTable);
 }
 
 shared_ptr<ResultSet> HashJoinBuild::init(ExecutionContext* context) {
     resultSet = PhysicalOperator::init(context);
-    unique_ptr<FactorizedTableSchema> tableSchema = make_unique<FactorizedTableSchema>();
-    for (auto& keyDataPos : buildDataInfo.keysDataPos) {
-        auto keyVector = resultSet->getValueVector(keyDataPos);
-        tableSchema->appendColumn(make_unique<ColumnSchema>(false /* is flat */,
-            keyDataPos.dataChunkPos, Types::getDataTypeSize(keyVector->dataType)));
+    for (auto& [pos, dataType] : buildDataInfo.keysPosAndType) {
+        auto keyVector = resultSet->getValueVector(pos);
         vectorsToAppend.push_back(keyVector);
     }
-    for (auto i = 0u; i < buildDataInfo.payloadsDataPos.size(); ++i) {
-        auto dataChunkPos = buildDataInfo.payloadsDataPos[i].dataChunkPos;
-        auto dataChunk = resultSet->dataChunks[dataChunkPos];
-        auto vectorPos = buildDataInfo.payloadsDataPos[i].valueVectorPos;
-        auto vector = dataChunk->valueVectors[vectorPos];
+    for (auto& [pos, dataType] : buildDataInfo.payloadsPosAndType) {
+        auto dataChunk = resultSet->dataChunks[pos.dataChunkPos];
+        auto vector = dataChunk->valueVectors[pos.valueVectorPos];
+        vectorsToAppend.push_back(vector);
+    }
+    auto tableSchema = populateTableSchema();
+    initLocalHashTable(*context->memoryManager, std::move(tableSchema));
+    return resultSet;
+}
+
+unique_ptr<FactorizedTableSchema> HashJoinBuild::populateTableSchema() {
+    unique_ptr<FactorizedTableSchema> tableSchema = make_unique<FactorizedTableSchema>();
+    for (auto& [pos, dataType] : buildDataInfo.keysPosAndType) {
+        tableSchema->appendColumn(make_unique<ColumnSchema>(
+            false /* is flat */, pos.dataChunkPos, Types::getDataTypeSize(dataType)));
+    }
+    for (auto i = 0u; i < buildDataInfo.payloadsPosAndType.size(); ++i) {
+        auto [pos, dataType] = buildDataInfo.payloadsPosAndType[i];
         if (buildDataInfo.isPayloadsInKeyChunk[i]) {
             tableSchema->appendColumn(make_unique<ColumnSchema>(
-                false /* is flat */, dataChunkPos, Types::getDataTypeSize(vector->dataType)));
+                false /* is flat */, pos.dataChunkPos, Types::getDataTypeSize(dataType)));
         } else {
             auto isVectorFlat = buildDataInfo.isPayloadsFlat[i];
-            tableSchema->appendColumn(make_unique<ColumnSchema>(!isVectorFlat, dataChunkPos,
-                isVectorFlat ? Types::getDataTypeSize(vector->dataType) :
+            tableSchema->appendColumn(make_unique<ColumnSchema>(!isVectorFlat, pos.dataChunkPos,
+                isVectorFlat ? Types::getDataTypeSize(dataType) :
                                (uint32_t)sizeof(overflow_value_t)));
         }
-        vectorsToAppend.push_back(vector);
     }
     // The prev pointer column.
     tableSchema->appendColumn(make_unique<ColumnSchema>(false /* is flat */,
         UINT32_MAX /* For now, we just put UINT32_MAX for prev pointer */,
         Types::getDataTypeSize(INT64)));
-    initHashTable(*context->memoryManager, move(tableSchema));
-    return resultSet;
+    return tableSchema;
 }
 
-void HashJoinBuild::initHashTable(
+void HashJoinBuild::initGlobalStateInternal(ExecutionContext* context) {
+    sharedState->initEmptyHashTable(
+        *context->memoryManager, buildDataInfo.getNumKeys(), populateTableSchema());
+}
+
+void HashJoinBuild::initLocalHashTable(
     MemoryManager& memoryManager, unique_ptr<FactorizedTableSchema> tableSchema) {
-    hashTable = make_unique<JoinHashTable>(memoryManager, buildDataInfo.keysDataPos.size(),
+    hashTable = make_unique<JoinHashTable>(memoryManager, buildDataInfo.getNumKeys(),
         make_unique<FactorizedTableSchema>(*tableSchema));
-    sharedState->initEmptyHashTableIfNecessary(
-        memoryManager, buildDataInfo.keysDataPos.size(), std::move(tableSchema));
 }
 
 void HashJoinBuild::finalize(ExecutionContext* context) {

--- a/src/processor/operator/intersect/intersect_build.cpp
+++ b/src/processor/operator/intersect/intersect_build.cpp
@@ -3,21 +3,16 @@
 namespace kuzu {
 namespace processor {
 
-void IntersectSharedState::initEmptyHashTableIfNecessary(MemoryManager& memoryManager,
-    uint64_t numKeyColumns, unique_ptr<FactorizedTableSchema> tableSchema) {
-    unique_lock lck(hashJoinSharedStateMutex);
-    assert(numKeyColumns == 1);
-    if (hashTable == nullptr) {
-        hashTable = make_unique<IntersectHashTable>(memoryManager, move(tableSchema));
-    }
+void IntersectSharedState::initEmptyHashTable(MemoryManager& memoryManager, uint64_t numKeyColumns,
+    unique_ptr<FactorizedTableSchema> tableSchema) {
+    assert(hashTable == nullptr && numKeyColumns == 1);
+    hashTable = make_unique<IntersectHashTable>(memoryManager, std::move(tableSchema));
 }
 
-void IntersectBuild::initHashTable(
+void IntersectBuild::initLocalHashTable(
     MemoryManager& memoryManager, unique_ptr<FactorizedTableSchema> tableSchema) {
     hashTable = make_unique<IntersectHashTable>(
         memoryManager, make_unique<FactorizedTableSchema>(*tableSchema));
-    sharedState->initEmptyHashTableIfNecessary(
-        memoryManager, buildDataInfo.keysDataPos.size(), std::move(tableSchema));
 }
 
 } // namespace processor

--- a/src/processor/operator/order_by/key_block_merger.cpp
+++ b/src/processor/operator/order_by/key_block_merger.cpp
@@ -293,15 +293,11 @@ void KeyBlockMergeTaskDispatcher::doneMorsel(unique_ptr<KeyBlockMergeMorsel> mor
     }
 }
 
-void KeyBlockMergeTaskDispatcher::initIfNecessary(MemoryManager* memoryManager,
+void KeyBlockMergeTaskDispatcher::init(MemoryManager* memoryManager,
     shared_ptr<queue<shared_ptr<MergedKeyBlocks>>> sortedKeyBlocks,
     vector<shared_ptr<FactorizedTable>>& factorizedTables, vector<StrKeyColInfo>& strKeyColsInfo,
     uint64_t numBytesPerTuple) {
-    lock_guard<mutex> keyBlockMergeDispatcherLock{mtx};
-    if (isInitialized) {
-        return;
-    }
-    isInitialized = true;
+    assert(this->keyBlockMerger == nullptr);
     this->memoryManager = memoryManager;
     this->sortedKeyBlocks = sortedKeyBlocks;
     this->keyBlockMerger =

--- a/src/processor/operator/order_by/order_by.cpp
+++ b/src/processor/operator/order_by/order_by.cpp
@@ -5,73 +5,73 @@ namespace processor {
 
 shared_ptr<ResultSet> OrderBy::init(ExecutionContext* context) {
     resultSet = PhysicalOperator::init(context);
-
-    // FactorizedTable, numBytesPerTuple, strKeyColInfo are constructed
-    // here because they need the data type information, which is contained in the value vectors.
-    unique_ptr<FactorizedTableSchema> tableSchema = make_unique<FactorizedTableSchema>();
-    vector<DataType> dataTypes;
-    // Loop through all columns to initialize the factorizedTable.
-    // We need to store all columns(including keys and payload) in the factorizedTable.
-    for (auto i = 0u; i < orderByDataInfo.allDataPoses.size(); ++i) {
-        auto dataChunkPos = orderByDataInfo.allDataPoses[i].dataChunkPos;
-        auto dataChunk = this->resultSet->dataChunks[dataChunkPos];
-        auto vectorPos = orderByDataInfo.allDataPoses[i].valueVectorPos;
-        auto vector = dataChunk->valueVectors[vectorPos];
-        bool flattenAllColumnsInFactorizedTable = false;
-        // The orderByKeyEncoder requires that the orderByKey columns are flat in the
-        // factorizedTable. If there is only one unflat dataChunk, we need to flatten the payload
-        // columns in factorizedTable because the payload and key columns are in the same
-        // dataChunk.
-        if (resultSet->dataChunks.size() == 1) {
-            flattenAllColumnsInFactorizedTable = true;
-        }
-        bool isUnflat = !orderByDataInfo.isVectorFlat[i] && !flattenAllColumnsInFactorizedTable;
-        tableSchema->appendColumn(make_unique<ColumnSchema>(isUnflat, dataChunkPos,
-            isUnflat ? (uint32_t)sizeof(overflow_value_t) : vector->getNumBytesPerValue()));
-        dataTypes.push_back(vector->dataType);
+    for (auto [dataPos, _] : orderByDataInfo.payloadsPosAndType) {
+        auto dataChunk = this->resultSet->dataChunks[dataPos.dataChunkPos];
+        auto vector = dataChunk->valueVectors[dataPos.valueVectorPos];
         vectorsToAppend.push_back(vector);
     }
-
-    // Create a factorizedTable and append it to sharedState.
-    localFactorizedTable = make_shared<FactorizedTable>(context->memoryManager, move(tableSchema));
+    // TODO(Ziyi): this is implemented differently from other sink operators. Normally we append
+    // local table to global at the end of the execution. But here your encoder seem to need encode
+    // tableIdx which closely associated with the execution order of thread. We prefer a unified
+    // design pattern for sink operators.
+    localFactorizedTable =
+        make_shared<FactorizedTable>(context->memoryManager, populateTableSchema());
     factorizedTableIdx = sharedState->getNextFactorizedTableIdx();
     sharedState->appendFactorizedTable(factorizedTableIdx, localFactorizedTable);
-    sharedState->setDataTypes(dataTypes);
-    // Loop through all key columns and calculate the offsets for string columns.
-    auto encodedKeyBlockColOffset = 0ul;
-    for (auto i = 0u; i < orderByDataInfo.keyDataPoses.size(); i++) {
-        auto keyDataPos = orderByDataInfo.keyDataPoses[i];
-        auto dataChunkPos = keyDataPos.dataChunkPos;
-        auto dataChunk = resultSet->dataChunks[dataChunkPos];
-        auto vectorPos = keyDataPos.valueVectorPos;
-        auto vector = dataChunk->valueVectors[vectorPos];
+    for (auto [dataPos, dataType] : orderByDataInfo.keysPosAndType) {
+        auto dataChunk = resultSet->dataChunks[dataPos.dataChunkPos];
+        auto vector = dataChunk->valueVectors[dataPos.valueVectorPos];
         keyVectors.emplace_back(vector);
-        if (STRING == vector->dataType.typeID) {
+    }
+    orderByKeyEncoder = make_unique<OrderByKeyEncoder>(keyVectors, orderByDataInfo.isAscOrder,
+        context->memoryManager, factorizedTableIdx, localFactorizedTable->getNumTuplesPerBlock(),
+        sharedState->numBytesPerTuple);
+    radixSorter = make_unique<RadixSort>(context->memoryManager, *localFactorizedTable,
+        *orderByKeyEncoder, sharedState->strKeyColsInfo);
+    return resultSet;
+}
+
+unique_ptr<FactorizedTableSchema> OrderBy::populateTableSchema() {
+    unique_ptr<FactorizedTableSchema> tableSchema = make_unique<FactorizedTableSchema>();
+    // The orderByKeyEncoder requires that the orderByKey columns are flat in the
+    // factorizedTable. If there is only one unflat dataChunk, we need to flatten the payload
+    // columns in factorizedTable because the payload and key columns are in the same
+    // dataChunk.
+    for (auto i = 0u; i < orderByDataInfo.payloadsPosAndType.size(); ++i) {
+        auto [dataPos, dataType] = orderByDataInfo.payloadsPosAndType[i];
+        bool isUnflat = !orderByDataInfo.isPayloadFlat[i] && !orderByDataInfo.mayContainUnflatKey;
+        tableSchema->appendColumn(make_unique<ColumnSchema>(isUnflat, dataPos.dataChunkPos,
+            isUnflat ? (uint32_t)sizeof(overflow_value_t) : Types::getDataTypeSize(dataType)));
+    }
+    return tableSchema;
+}
+
+void OrderBy::initGlobalStateInternal(kuzu::processor::ExecutionContext* context) {
+    vector<StrKeyColInfo> strKeyColInfo;
+    auto encodedKeyBlockColOffset = 0ul;
+    auto tableSchema = populateTableSchema();
+    for (auto i = 0u; i < orderByDataInfo.keysPosAndType.size(); ++i) {
+        auto [dataPos, dataType] = orderByDataInfo.keysPosAndType[i];
+        if (STRING == dataType.typeID) {
             // If this is a string column, we need to find the factorizedTable offset for this
             // column.
             auto factorizedTableColIdx = 0ul;
-            for (auto j = 0u; j < orderByDataInfo.allDataPoses.size(); j++) {
-                if (orderByDataInfo.allDataPoses[j] == keyDataPos) {
+            for (auto j = 0u; j < orderByDataInfo.payloadsPosAndType.size(); j++) {
+                auto [payloadDataPos, _] = orderByDataInfo.payloadsPosAndType[j];
+                if (payloadDataPos == dataPos) {
                     factorizedTableColIdx = j;
                 }
             }
-            strKeyColInfo.emplace_back(StrKeyColInfo(
-                localFactorizedTable->getTableSchema()->getColOffset(factorizedTableColIdx),
-                encodedKeyBlockColOffset, orderByDataInfo.isAscOrder[i],
-                STRING == vector->dataType.typeID));
+            strKeyColInfo.emplace_back(
+                StrKeyColInfo(tableSchema->getColOffset(factorizedTableColIdx),
+                    encodedKeyBlockColOffset, orderByDataInfo.isAscOrder[i]));
         }
-        encodedKeyBlockColOffset += OrderByKeyEncoder::getEncodingSize(vector->dataType);
+        encodedKeyBlockColOffset += OrderByKeyEncoder::getEncodingSize(dataType);
     }
-
-    // Prepare the orderByEncoder, and radix sorter
-    orderByKeyEncoder = make_unique<OrderByKeyEncoder>(keyVectors, orderByDataInfo.isAscOrder,
-        context->memoryManager, factorizedTableIdx, localFactorizedTable->getNumTuplesPerBlock());
-    radixSorter = make_unique<RadixSort>(
-        context->memoryManager, *localFactorizedTable, *orderByKeyEncoder, strKeyColInfo);
-
     sharedState->setStrKeyColInfo(strKeyColInfo);
-    sharedState->setNumBytesPerTuple(orderByKeyEncoder->getNumBytesPerTuple());
-    return resultSet;
+    // TODO(Ziyi): comment about +8
+    auto numBytesPerTuple = encodedKeyBlockColOffset + 8;
+    sharedState->setNumBytesPerTuple(numBytesPerTuple);
 }
 
 void OrderBy::executeInternal(ExecutionContext* context) {

--- a/src/processor/operator/order_by/order_by_merge.cpp
+++ b/src/processor/operator/order_by/order_by_merge.cpp
@@ -9,28 +9,27 @@ shared_ptr<ResultSet> OrderByMerge::init(ExecutionContext* context) {
     resultSet = PhysicalOperator::init(context);
     // OrderByMerge is the only sink operator in a pipeline and only modifies the
     // sharedState by merging sortedKeyBlocks, So we don't need to initialize the resultSet.
-    keyBlockMerger =
-        make_unique<KeyBlockMerger>(sharedFactorizedTablesAndSortedKeyBlocks->factorizedTables,
-            sharedFactorizedTablesAndSortedKeyBlocks->strKeyColsInfo,
-            sharedFactorizedTablesAndSortedKeyBlocks->numBytesPerTuple);
-    keyBlockMergeTaskDispatcher->initIfNecessary(context->memoryManager,
-        sharedFactorizedTablesAndSortedKeyBlocks->sortedKeyBlocks,
-        sharedFactorizedTablesAndSortedKeyBlocks->factorizedTables,
-        sharedFactorizedTablesAndSortedKeyBlocks->strKeyColsInfo,
-        sharedFactorizedTablesAndSortedKeyBlocks->numBytesPerTuple);
+    localMerger = make_unique<KeyBlockMerger>(
+        sharedState->factorizedTables, sharedState->strKeyColsInfo, sharedState->numBytesPerTuple);
     return resultSet;
 }
 
 void OrderByMerge::executeInternal(ExecutionContext* context) {
-    while (!keyBlockMergeTaskDispatcher->isDoneMerge()) {
-        auto keyBlockMergeMorsel = keyBlockMergeTaskDispatcher->getMorsel();
+    while (!sharedDispatcher->isDoneMerge()) {
+        auto keyBlockMergeMorsel = sharedDispatcher->getMorsel();
         if (keyBlockMergeMorsel == nullptr) {
             this_thread::sleep_for(chrono::microseconds(THREAD_SLEEP_TIME_WHEN_WAITING_IN_MICROS));
             continue;
         }
-        keyBlockMerger->mergeKeyBlocks(*keyBlockMergeMorsel);
-        keyBlockMergeTaskDispatcher->doneMorsel(move(keyBlockMergeMorsel));
+        localMerger->mergeKeyBlocks(*keyBlockMergeMorsel);
+        sharedDispatcher->doneMorsel(move(keyBlockMergeMorsel));
     }
+}
+
+void OrderByMerge::initGlobalStateInternal(ExecutionContext* context) {
+    // TODO(Ziyi): directly feed sharedState to merger and dispatcher.
+    sharedDispatcher->init(context->memoryManager, sharedState->sortedKeyBlocks,
+        sharedState->factorizedTables, sharedState->strKeyColsInfo, sharedState->numBytesPerTuple);
 }
 
 } // namespace processor

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -42,6 +42,13 @@ shared_ptr<ResultSet> PhysicalOperator::init(ExecutionContext* context) {
     return resultSet;
 }
 
+void PhysicalOperator::initGlobalState(ExecutionContext* context) {
+    for (auto& child : children) {
+        child->initGlobalState(context);
+    }
+    initGlobalStateInternal(context);
+}
+
 void PhysicalOperator::registerProfilingMetrics(Profiler* profiler) {
     auto executionTime = profiler->registerTimeMetric(getTimeMetricKey());
     auto numOutputTuple = profiler->registerNumericMetric(getNumTupleMetricKey());

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -5,7 +5,6 @@ namespace processor {
 
 shared_ptr<ResultSet> SemiMasker::init(ExecutionContext* context) {
     resultSet = PhysicalOperator::init(context);
-    scanTableNodeIDSharedState->initSemiMask(context->transaction);
     keyValueVector = resultSet->getValueVector(keyDataPos);
     assert(keyValueVector->dataType.typeID == NODE_ID);
     return resultSet;
@@ -26,6 +25,10 @@ bool SemiMasker::getNextTuplesInternal() {
     metrics->numOutputTuple.increase(
         keyValueVector->state->isFlat() ? 1 : keyValueVector->state->selVector->selectedSize);
     return true;
+}
+
+void SemiMasker::initGlobalStateInternal(ExecutionContext* context) {
+    scanTableNodeIDSharedState->initSemiMask(context->transaction);
 }
 
 } // namespace processor

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -28,6 +28,9 @@ shared_ptr<FactorizedTable> QueryProcessor::execute(
         return getFactorizedTableForOutputMsg(outputMsg, context->memoryManager);
     } else {
         auto lastOperator = physicalPlan->lastOperator.get();
+        // Init global state before decompose into pipelines. Otherwise, each pipeline will try to
+        // init global state. Result in global state being initialized multiple times.
+        lastOperator->initGlobalState(context);
         auto resultCollector = reinterpret_cast<ResultCollector*>(lastOperator);
         // The root pipeline(task) consists of operators and its prevOperator only, because we
         // expect to have linear plans. For binary operators, e.g., HashJoin, we  keep probe and its

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -7,14 +7,14 @@ void ProcessorTask::run() {
     // We need the lock when cloning because multiple threads can be accessing to clone,
     // which is not thread safe
     lock_t lck{mtx};
-    unique_ptr<PhysicalOperator> lastOp = sinkOp->clone();
+    auto clonedPipeline = sink->clone();
     lck.unlock();
-    auto& sink = (Sink&)*lastOp;
-    sink.execute(executionContext);
+    auto clonedSink = (Sink*)clonedPipeline.get();
+    clonedSink->execute(executionContext);
 }
 
 void ProcessorTask::finalizeIfNecessary() {
-    sinkOp->finalize(executionContext);
+    sink->finalize(executionContext);
 }
 
 } // namespace processor

--- a/test/processor/order_by/order_by_key_encoder_test.cpp
+++ b/test/processor/order_by/order_by_key_encoder_test.cpp
@@ -97,8 +97,8 @@ public:
         uint64_t numOfElements = 2000;
         auto valueVectors = getInt64TestValueVector(numOfElements, 1, isFlat);
         auto isAscOrder = vector<bool>(1, false);
-        auto orderByKeyEncoder = OrderByKeyEncoder(
-            valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+        auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(),
+            ftIdx, numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
         if (isFlat) {
             for (auto i = 0u; i < numOfElements; i++) {
                 orderByKeyEncoder.encodeKeys();
@@ -136,8 +136,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(int64ValueVector);
     auto isAscOrder = vector<bool>(1, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -205,8 +205,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColInt64UnflatWithFilterTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(int64ValueVector);
     auto isAscOrder = vector<bool>(1, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -240,8 +240,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColBoolUnflatTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(boolValueVector);
     auto isAscOrder = vector<bool>(1, false);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -272,8 +272,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColDateUnflatTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(dateValueVector);
     auto isAscOrder = vector<bool>(1, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -313,8 +313,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColTimestampUnflatTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(timestampValueVector);
     auto isAscOrder = vector<bool>(1, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -361,8 +361,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColIntervalUnflatTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(intervalValueVector);
     auto isAscOrder = vector<bool>(1, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -410,8 +410,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColStringUnflatTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(stringValueVector);
     auto isAscOrder = vector<bool>(1, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -485,8 +485,8 @@ TEST_F(OrderByKeyEncoderTest, singleOrderByColDoubleUnflatTest) {
     vector<shared_ptr<ValueVector>> valueVectors;
     valueVectors.emplace_back(doubleValueVector);
     auto isAscOrder = vector<bool>(1, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     orderByKeyEncoder.encodeKeys();
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
@@ -562,8 +562,8 @@ TEST_F(OrderByKeyEncoderTest, largeNumBytesPerTupleErrorTest) {
     auto valueVectors = getInt64TestValueVector(1, numOfOrderByCols, true);
     auto isAscOrder = vector<bool>(numOfOrderByCols, true);
     try {
-        auto orderByKeyEncoder = OrderByKeyEncoder(
-            valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+        auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(),
+            ftIdx, numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
         FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(),
@@ -579,8 +579,8 @@ TEST_F(OrderByKeyEncoderTest, singleTuplePerBlockTest) {
     uint32_t numOfElementsPerCol = 10;
     auto valueVectors = getInt64TestValueVector(numOfElementsPerCol, numOfOrderByCols, true);
     auto isAscOrder = vector<bool>(numOfOrderByCols, false);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     for (auto i = 0u; i < numOfElementsPerCol; i++) {
         orderByKeyEncoder.encodeKeys();
         valueVectors[0]->state->currIdx++;
@@ -626,8 +626,8 @@ TEST_F(OrderByKeyEncoderTest, multipleOrderByColSingleBlockTest) {
     valueVectors.emplace_back(timestampFlatValueVector);
     valueVectors.emplace_back(dateFlatValueVector);
 
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     uint8_t* keyBlockPtr = orderByKeyEncoder.getKeyBlocks()[0]->getData();
 
     intFlatValueVector->setValue(0, (int64_t)73);
@@ -790,8 +790,8 @@ TEST_F(OrderByKeyEncoderTest, multipleOrderByColMultiBlockTest) {
     const auto numOfElementsPerCol = 2000;
     auto valueVectors = getInt64TestValueVector(numOfElementsPerCol, numOfOrderByCols, true);
     auto isAscOrder = vector<bool>(numOfOrderByCols, true);
-    auto orderByKeyEncoder = OrderByKeyEncoder(
-        valueVectors, isAscOrder, memoryManager.get(), ftIdx, numTuplesPerBlockInFT);
+    auto orderByKeyEncoder = OrderByKeyEncoder(valueVectors, isAscOrder, memoryManager.get(), ftIdx,
+        numTuplesPerBlockInFT, OrderByKeyEncoder::getNumBytesPerTuple(valueVectors));
     for (auto i = 0u; i < numOfElementsPerCol; i++) {
         orderByKeyEncoder.encodeKeys();
         valueVectors[0]->state->currIdx++;


### PR DESCRIPTION
This PR differentiate the initialization between global and local state. Global state should be only initialized once while local state is initialized for each thread.

Remove following code pattern in global state
```
if (!initialized)
    initialize
initialized = true
```

Other change
We used to rely on vectors to get input data type. This design is bad since it requires first generate vector (i.e. initialize local state) before accessing data type. This PR also changes this by giving data type during construction.