### PR TITLE
fix ctest for python

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,7 @@ debug:
 
 test:
 	cd $(ROOT_DIR)/build/release/test && \
-	ctest && \
-	cd $(ROOT_DIR)/tools/python_api/test && \
-	pytest
+	ctest
 
 clean:
 	rm -rf build

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -81,8 +81,8 @@ void TransactionManager::allowReceivingNewTransactions() {
 }
 
 void TransactionManager::stopNewTransactionsAndWaitUntilAllReadTransactionsLeave() {
-    lock_t lck{mtxForSerializingPublicFunctionCalls};
     mtxForStartingNewTransactions.lock();
+    lock_t lck{mtxForSerializingPublicFunctionCalls};
     uint64_t numTimesWaited = 0;
     while (true) {
         if (!activeReadOnlyTransactionIDs.empty()) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,3 +24,17 @@ add_subdirectory(processor)
 add_subdirectory(runner)
 add_subdirectory(storage)
 add_subdirectory(transaction)
+
+function(add_kuzu_python_api_test TEST_NAME FILE_NAME)
+    add_test(NAME PythonAPI.${TEST_NAME}
+            COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tools/python_api/test/${FILE_NAME}
+            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools/python_api/test)
+endfunction()
+
+add_kuzu_python_api_test(DataType test_datatype.py)
+add_kuzu_python_api_test(PandaAPI test_df.py)
+add_kuzu_python_api_test(Exception test_exception.py)
+add_kuzu_python_api_test(GetHeader test_get_header.py)
+add_kuzu_python_api_test(Main test_main.py)
+add_kuzu_python_api_test(Parameter test_parameter.py)
+add_kuzu_python_api_test(WriteToCSV test_write_to_csv.py)


### PR DESCRIPTION
1. Integrate pytest with cmake ctest.
2. Fixes a potential dead lock in transactionManager.