### PR TITLE
Sink subset of expressions

### DIFF
--- a/src/include/planner/logical_plan/logical_operator/logical_hash_join.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_hash_join.h
@@ -14,28 +14,27 @@ using namespace kuzu::binder;
 class LogicalHashJoin : public LogicalOperator {
 public:
     // Inner and left join.
-    LogicalHashJoin(vector<shared_ptr<NodeExpression>> joinNodes, JoinType joinType,
-        bool isProbeAcc, expression_vector expressionsToMaterialize,
-        shared_ptr<LogicalOperator> probeSideChild, shared_ptr<LogicalOperator> buildSideChild)
-        : LogicalHashJoin{std::move(joinNodes), joinType, nullptr, UINT32_MAX, isProbeAcc,
+    LogicalHashJoin(expression_vector joinNodeIDs, JoinType joinType, bool isProbeAcc,
+        expression_vector expressionsToMaterialize, shared_ptr<LogicalOperator> probeSideChild,
+        shared_ptr<LogicalOperator> buildSideChild)
+        : LogicalHashJoin{std::move(joinNodeIDs), joinType, nullptr, UINT32_MAX, isProbeAcc,
               std::move(expressionsToMaterialize), std::move(probeSideChild),
               std::move(buildSideChild)} {}
 
     // Mark join.
-    LogicalHashJoin(vector<shared_ptr<NodeExpression>> joinNodes, shared_ptr<Expression> mark,
-        uint32_t markPos, bool isProbeAcc, shared_ptr<LogicalOperator> probeSideChild,
+    LogicalHashJoin(expression_vector joinNodeIDs, shared_ptr<Expression> mark, uint32_t markPos,
+        bool isProbeAcc, shared_ptr<LogicalOperator> probeSideChild,
         shared_ptr<LogicalOperator> buildSideChild)
-        : LogicalHashJoin{std::move(joinNodes), JoinType::MARK, std::move(mark), markPos,
+        : LogicalHashJoin{std::move(joinNodeIDs), JoinType::MARK, std::move(mark), markPos,
               isProbeAcc, expression_vector{} /* expressionsToMaterialize */,
               std::move(probeSideChild), std::move(buildSideChild)} {}
 
-    LogicalHashJoin(vector<shared_ptr<NodeExpression>> joinNodes, JoinType joinType,
-        shared_ptr<Expression> mark, uint32_t markPos, bool isProbeAcc,
-        expression_vector expressionsToMaterialize, shared_ptr<LogicalOperator> probeSideChild,
-        shared_ptr<LogicalOperator> buildSideChild)
+    LogicalHashJoin(expression_vector joinNodeIDs, JoinType joinType, shared_ptr<Expression> mark,
+        uint32_t markPos, bool isProbeAcc, expression_vector expressionsToMaterialize,
+        shared_ptr<LogicalOperator> probeSideChild, shared_ptr<LogicalOperator> buildSideChild)
         : LogicalOperator{LogicalOperatorType::HASH_JOIN, std::move(probeSideChild),
               std::move(buildSideChild)},
-          joinNodes(std::move(joinNodes)), joinType{joinType}, mark{std::move(mark)},
+          joinNodeIDs(std::move(joinNodeIDs)), joinType{joinType}, mark{std::move(mark)},
           markPos{markPos}, isProbeAcc{isProbeAcc}, expressionsToMaterialize{
                                                         std::move(expressionsToMaterialize)} {}
 
@@ -46,7 +45,7 @@ public:
     inline expression_vector getExpressionsToMaterialize() const {
         return expressionsToMaterialize;
     }
-    inline vector<shared_ptr<NodeExpression>> getJoinNodes() const { return joinNodes; }
+    inline expression_vector getJoinNodeIDs() const { return joinNodeIDs; }
     inline JoinType getJoinType() const { return joinType; }
 
     inline shared_ptr<Expression> getMark() const {
@@ -57,12 +56,12 @@ public:
     inline Schema* getBuildSideSchema() const { return children[1]->getSchema(); }
 
     inline unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalHashJoin>(joinNodes, joinType, mark, markPos, isProbeAcc,
+        return make_unique<LogicalHashJoin>(joinNodeIDs, joinType, mark, markPos, isProbeAcc,
             expressionsToMaterialize, children[0]->copy(), children[1]->copy());
     }
 
 private:
-    vector<shared_ptr<NodeExpression>> joinNodes;
+    expression_vector joinNodeIDs;
     JoinType joinType;
     shared_ptr<Expression> mark; // when joinType is Mark
     uint32_t markPos;

--- a/src/include/planner/logical_plan/logical_operator/logical_intersect.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_intersect.h
@@ -8,24 +8,24 @@ namespace kuzu {
 namespace planner {
 
 struct LogicalIntersectBuildInfo {
-    LogicalIntersectBuildInfo(shared_ptr<NodeExpression> key, expression_vector expressions)
-        : key{std::move(key)}, expressionsToMaterialize{std::move(expressions)} {}
+    LogicalIntersectBuildInfo(shared_ptr<Expression> keyNodeID, expression_vector expressions)
+        : keyNodeID{std::move(keyNodeID)}, expressionsToMaterialize{std::move(expressions)} {}
 
     inline unique_ptr<LogicalIntersectBuildInfo> copy() {
-        return make_unique<LogicalIntersectBuildInfo>(key, expressionsToMaterialize);
+        return make_unique<LogicalIntersectBuildInfo>(keyNodeID, expressionsToMaterialize);
     }
 
-    shared_ptr<NodeExpression> key;
+    shared_ptr<Expression> keyNodeID;
     expression_vector expressionsToMaterialize;
 };
 
 class LogicalIntersect : public LogicalOperator {
 public:
-    LogicalIntersect(shared_ptr<NodeExpression> intersectNode,
-        shared_ptr<LogicalOperator> probeChild, vector<shared_ptr<LogicalOperator>> buildChildren,
+    LogicalIntersect(shared_ptr<Expression> intersectNodeID, shared_ptr<LogicalOperator> probeChild,
+        vector<shared_ptr<LogicalOperator>> buildChildren,
         vector<unique_ptr<LogicalIntersectBuildInfo>> buildInfos)
         : LogicalOperator{LogicalOperatorType::INTERSECT, std::move(probeChild)},
-          intersectNode{std::move(intersectNode)}, buildInfos{std::move(buildInfos)} {
+          intersectNodeID{std::move(intersectNodeID)}, buildInfos{std::move(buildInfos)} {
         for (auto& child : buildChildren) {
             children.push_back(std::move(child));
         }
@@ -33,9 +33,9 @@ public:
 
     void computeSchema() override;
 
-    string getExpressionsForPrinting() const override { return intersectNode->getRawName(); }
+    string getExpressionsForPrinting() const override { return intersectNodeID->getRawName(); }
 
-    inline shared_ptr<NodeExpression> getIntersectNode() const { return intersectNode; }
+    inline shared_ptr<Expression> getIntersectNodeID() const { return intersectNodeID; }
     inline LogicalIntersectBuildInfo* getBuildInfo(uint32_t idx) const {
         return buildInfos[idx].get();
     }
@@ -44,7 +44,7 @@ public:
     unique_ptr<LogicalOperator> copy() override;
 
 private:
-    shared_ptr<NodeExpression> intersectNode;
+    shared_ptr<Expression> intersectNodeID;
     vector<unique_ptr<LogicalIntersectBuildInfo>> buildInfos;
 };
 

--- a/src/include/planner/logical_plan/logical_operator/logical_order_by.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_order_by.h
@@ -15,7 +15,9 @@ public:
 
     void computeSchema() override;
 
-    string getExpressionsForPrinting() const override;
+    inline string getExpressionsForPrinting() const override {
+        return ExpressionUtil::toString(expressionsToOrderBy);
+    }
 
     inline expression_vector getExpressionsToOrderBy() const { return expressionsToOrderBy; }
     inline vector<bool> getIsAscOrders() const { return isAscOrders; }

--- a/src/include/planner/logical_plan/logical_operator/logical_union.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_union.h
@@ -7,11 +7,9 @@ namespace planner {
 
 class LogicalUnion : public LogicalOperator {
 public:
-    LogicalUnion(expression_vector expressions, vector<unique_ptr<Schema>> schemasBeforeUnion,
-        vector<shared_ptr<LogicalOperator>> children)
+    LogicalUnion(expression_vector expressions, vector<shared_ptr<LogicalOperator>> children)
         : LogicalOperator{LogicalOperatorType::UNION_ALL, std::move(children)},
-          expressionsToUnion{std::move(expressions)}, schemasBeforeUnion{
-                                                          std::move(schemasBeforeUnion)} {}
+          expressionsToUnion{std::move(expressions)} {}
 
     void computeSchema() override;
 
@@ -19,13 +17,12 @@ public:
 
     inline expression_vector getExpressionsToUnion() { return expressionsToUnion; }
 
-    inline Schema* getSchemaBeforeUnion(uint32_t idx) { return schemasBeforeUnion[idx].get(); }
+    inline Schema* getSchemaBeforeUnion(uint32_t idx) { return children[idx]->getSchema(); }
 
     unique_ptr<LogicalOperator> copy() override;
 
 private:
     expression_vector expressionsToUnion;
-    vector<unique_ptr<Schema>> schemasBeforeUnion;
 };
 
 } // namespace planner

--- a/src/include/planner/logical_plan/logical_operator/schema.h
+++ b/src/include/planner/logical_plan/logical_operator/schema.h
@@ -10,6 +10,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace planner {
 
+typedef uint32_t f_group_pos;
+
 class FactorizationGroup {
     friend class Schema;
 
@@ -56,7 +58,7 @@ private:
 
 class Schema {
 public:
-    inline uint32_t getNumGroups() const { return groups.size(); }
+    inline f_group_pos getNumGroups() const { return groups.size(); }
 
     inline FactorizationGroup* getGroup(shared_ptr<Expression> expression) const {
         return getGroup(getGroupPos(expression->getUniqueName()));
@@ -68,7 +70,7 @@ public:
 
     inline FactorizationGroup* getGroup(uint32_t pos) const { return groups[pos].get(); }
 
-    uint32_t createGroup();
+    f_group_pos createGroup();
 
     void insertToScope(const shared_ptr<Expression>& expression, uint32_t groupPos);
 
@@ -76,28 +78,28 @@ public:
 
     void insertToGroupAndScope(const expression_vector& expressions, uint32_t groupPos);
 
-    inline uint32_t getGroupPos(const Expression& expression) const {
+    inline f_group_pos getGroupPos(const Expression& expression) const {
         return getGroupPos(expression.getUniqueName());
     }
 
-    inline uint32_t getGroupPos(const string& expressionName) const {
+    inline f_group_pos getGroupPos(const string& expressionName) const {
         assert(expressionNameToGroupPos.contains(expressionName));
         return expressionNameToGroupPos.at(expressionName);
     }
 
-    inline pair<uint32_t, uint32_t> getExpressionPos(const Expression& expression) const {
+    inline pair<f_group_pos, uint32_t> getExpressionPos(const Expression& expression) const {
         auto groupPos = getGroupPos(expression);
         return make_pair(groupPos, groups[groupPos]->getExpressionPos(expression));
     }
 
-    inline void flattenGroup(uint32_t pos) { groups[pos]->setFlat(); }
-    inline void setGroupAsSingleState(uint32_t pos) { groups[pos]->setSingleState(); }
+    inline void flattenGroup(f_group_pos pos) { groups[pos]->setFlat(); }
+    inline void setGroupAsSingleState(f_group_pos pos) { groups[pos]->setSingleState(); }
 
     bool isExpressionInScope(const Expression& expression) const;
 
     inline expression_vector getExpressionsInScope() const { return expressionsInScope; }
 
-    expression_vector getExpressionsInScope(uint32_t pos) const;
+    expression_vector getExpressionsInScope(f_group_pos pos) const;
 
     expression_vector getSubExpressionsInScope(const shared_ptr<Expression>& expression);
 
@@ -109,7 +111,7 @@ public:
     }
 
     // Get the group positions containing at least one expression in scope.
-    unordered_set<uint32_t> getGroupsPosInScope() const;
+    unordered_set<f_group_pos> getGroupsPosInScope() const;
 
     unique_ptr<Schema> copy() const;
 
@@ -121,6 +123,12 @@ private:
     // Our projection doesn't explicitly remove expressions. Instead, we keep track of what
     // expressions are in scope (i.e. being projected).
     expression_vector expressionsInScope;
+};
+
+class SchemaUtils {
+public:
+    static vector<expression_vector> getExpressionsPerGroup(
+        const expression_vector& expressions, const Schema& schema);
 };
 
 } // namespace planner

--- a/src/include/planner/logical_plan/logical_operator/sink_util.h
+++ b/src/include/planner/logical_plan/logical_operator/sink_util.h
@@ -4,39 +4,22 @@
 
 namespace kuzu {
 namespace planner {
-using namespace kuzu::binder;
 
-// This class contains the logic for re-computing factorization structure after
+// This class contains the logic for re-computing factorization structure after sinking
 class SinkOperatorUtil {
 public:
-    static void mergeSchema(const Schema& inputSchema, Schema& result, const vector<string>& keys);
+    static void mergeSchema(const Schema& inputSchema, const expression_vector& expressionsToMerge,
+        Schema& resultSchema);
 
-    static void mergeSchema(const Schema& inputSchema, Schema& result);
-
-    static void recomputeSchema(const Schema& inputSchema, Schema& result);
-
-    static unordered_set<uint32_t> getGroupsPosIgnoringKeyGroups(
-        const Schema& schema, const vector<string>& keys);
+    static void recomputeSchema(const Schema& inputSchema,
+        const expression_vector& expressionsToMerge, Schema& resultSchema);
 
 private:
-    static void mergeKeyGroup(const Schema& inputSchema, Schema& resultSchema, uint32_t keyGroupPos,
-        const vector<string>& keysInGroup);
+    static unordered_map<f_group_pos, expression_vector> getUnFlatPayloadsPerGroup(
+        const Schema& schema, const expression_vector& payloads);
 
-    static inline expression_vector getFlatPayloadsIgnoringKeyGroup(
-        const Schema& schema, const vector<string>& keys) {
-        return getFlatPayloads(schema, getGroupsPosIgnoringKeyGroups(schema, keys));
-    }
-    static inline expression_vector getFlatPayloads(const Schema& schema) {
-        return getFlatPayloads(schema, schema.getGroupsPosInScope());
-    }
     static expression_vector getFlatPayloads(
-        const Schema& schema, const unordered_set<uint32_t>& payloadGroupsPos);
-
-    static inline bool hasUnFlatPayload(const Schema& schema) {
-        return hasUnFlatPayload(schema, schema.getGroupsPosInScope());
-    }
-    static bool hasUnFlatPayload(
-        const Schema& schema, const unordered_set<uint32_t>& payloadGroupsPos);
+        const Schema& schema, const expression_vector& payloads);
 
     static uint32_t appendPayloadsToNewGroup(Schema& schema, expression_vector& payloads);
 };

--- a/src/include/processor/mapper/plan_mapper.h
+++ b/src/include/processor/mapper/plan_mapper.h
@@ -88,7 +88,7 @@ private:
         const Schema& outSchema, vector<bool>& isInputGroupByHashKeyVectorFlat);
 
     static BuildDataInfo generateBuildDataInfo(const Schema& buildSideSchema,
-        const vector<shared_ptr<NodeExpression>>& keys, const expression_vector& payloads);
+        const expression_vector& keys, const expression_vector& payloads);
 
 public:
     StorageManager& storageManager;

--- a/src/include/processor/operator/scan_node_id.h
+++ b/src/include/processor/operator/scan_node_id.h
@@ -118,15 +118,14 @@ private:
 
 class ScanNodeID : public PhysicalOperator {
 public:
-    ScanNodeID(string nodeName, const DataPos& outDataPos,
+    ScanNodeID(string nodeID, const DataPos& outDataPos,
         shared_ptr<ScanNodeIDSharedState> sharedState, uint32_t id, const string& paramsString)
         : PhysicalOperator{PhysicalOperatorType::SCAN_NODE_ID, id, paramsString},
-          nodeName{std::move(nodeName)}, outDataPos{outDataPos}, sharedState{
-                                                                     std::move(sharedState)} {}
+          nodeID{std::move(nodeID)}, outDataPos{outDataPos}, sharedState{std::move(sharedState)} {}
 
     bool isSource() const override { return true; }
 
-    inline string getNodeName() const { return nodeName; }
+    inline string getNodeID() const { return nodeID; }
     inline ScanNodeIDSharedState* getSharedState() const { return sharedState.get(); }
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
@@ -134,7 +133,7 @@ public:
     bool getNextTuplesInternal() override;
 
     inline unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ScanNodeID>(nodeName, outDataPos, sharedState, id, paramsString);
+        return make_unique<ScanNodeID>(nodeID, outDataPos, sharedState, id, paramsString);
     }
 
 private:
@@ -144,7 +143,7 @@ private:
         ScanTableNodeIDSharedState* tableState, node_offset_t startOffset, node_offset_t endOffset);
 
 private:
-    string nodeName;
+    string nodeID;
     DataPos outDataPos;
     shared_ptr<ScanNodeIDSharedState> sharedState;
 

--- a/src/planner/operator/logical_accumulate.cpp
+++ b/src/planner/operator/logical_accumulate.cpp
@@ -8,7 +8,7 @@ namespace planner {
 void LogicalAccumulate::computeSchema() {
     auto childSchema = children[0]->getSchema();
     createEmptySchema();
-    SinkOperatorUtil::recomputeSchema(*childSchema, *schema);
+    SinkOperatorUtil::recomputeSchema(*childSchema, expressions, *schema);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_cross_product.cpp
+++ b/src/planner/operator/logical_cross_product.cpp
@@ -9,7 +9,7 @@ void LogicalCrossProduct::computeSchema() {
     auto probeSchema = children[0]->getSchema();
     auto buildSchema = children[1]->getSchema();
     schema = probeSchema->copy();
-    SinkOperatorUtil::mergeSchema(*buildSchema, *schema);
+    SinkOperatorUtil::mergeSchema(*buildSchema, buildSchema->getExpressionsInScope(), *schema);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -10,22 +10,50 @@ void LogicalHashJoin::computeSchema() {
     auto buildSchema = children[1]->getSchema();
     schema = probeSchema->copy();
     if (joinType != JoinType::MARK) {
-        vector<string> keys;
-        for (auto& joinNode : joinNodes) {
-            keys.push_back(joinNode->getInternalIDPropertyName());
+        // resolve key groups
+        unordered_map<f_group_pos, unordered_set<string>> keyGroupPosToKeys;
+        for (auto& joinNodeID : joinNodeIDs) {
+            auto groupPos = buildSchema->getGroupPos(*joinNodeID);
+            if (!keyGroupPosToKeys.contains(groupPos)) {
+                keyGroupPosToKeys.insert({groupPos, unordered_set<string>()});
+            }
+            keyGroupPosToKeys.at(groupPos).insert(joinNodeID->getUniqueName());
         }
-        SinkOperatorUtil::mergeSchema(*buildSchema, *schema, keys);
+        // resolve expressions to materialize in each group
+        auto expressionsToMaterializePerGroup =
+            SchemaUtils::getExpressionsPerGroup(expressionsToMaterialize, *buildSchema);
+        expression_vector expressionsToMaterializeInNonKeyGroups;
+        for (auto i = 0; i < buildSchema->getNumGroups(); ++i) {
+            auto expressions = expressionsToMaterializePerGroup[i];
+            bool isKeyGroup = keyGroupPosToKeys.contains(i);
+            if (isKeyGroup) { // merge key group
+                auto keys = keyGroupPosToKeys.at(i);
+                auto resultGroupPos = schema->getGroupPos(*keys.begin());
+                for (auto& expression : expressions) {
+                    if (keys.contains(expression->getUniqueName())) {
+                        continue;
+                    }
+                    schema->insertToGroupAndScope(expression, resultGroupPos);
+                }
+            } else {
+                for (auto& expression : expressions) {
+                    expressionsToMaterializeInNonKeyGroups.push_back(expression);
+                }
+            }
+        }
+        SinkOperatorUtil::mergeSchema(
+            *buildSchema, expressionsToMaterializeInNonKeyGroups, *schema);
     } else {
         schema->insertToGroupAndScope(mark, markPos);
     }
 }
 
 string LogicalHashJoin::getExpressionsForPrinting() const {
-    expression_vector expressions;
-    for (auto& joinNode : joinNodes) {
-        expressions.push_back(joinNode);
+    expression_vector joinNodes;
+    for (auto& joinNodeID : joinNodeIDs) {
+        joinNodes.push_back(joinNodeID->getChild(0));
     }
-    return ExpressionUtil::toString(expressions);
+    return ExpressionUtil::toString(joinNodes);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_intersect.cpp
+++ b/src/planner/operator/logical_intersect.cpp
@@ -8,14 +8,14 @@ void LogicalIntersect::computeSchema() {
     schema = probeSchema->copy();
     // Write intersect node and rels into a new group regardless of whether rel is n-n.
     auto outGroupPos = schema->createGroup();
-    schema->insertToGroupAndScope(intersectNode->getInternalIDProperty(), outGroupPos);
+    schema->insertToGroupAndScope(intersectNodeID, outGroupPos);
     for (auto i = 1; i < children.size(); ++i) {
         auto buildSchema = children[i]->getSchema();
         auto buildInfo = buildInfos[i - 1].get();
         // Write rel properties into output group.
         for (auto& expression : buildSchema->getExpressionsInScope()) {
-            if (expression->getUniqueName() == intersectNode->getInternalIDPropertyName() ||
-                expression->getUniqueName() == buildInfo->key->getInternalIDPropertyName()) {
+            if (expression->getUniqueName() == intersectNodeID->getUniqueName() ||
+                expression->getUniqueName() == buildInfo->keyNodeID->getUniqueName()) {
                 continue;
             }
             schema->insertToGroupAndScope(expression, outGroupPos);
@@ -31,7 +31,7 @@ unique_ptr<LogicalOperator> LogicalIntersect::copy() {
         buildInfos_.push_back(buildInfos[i - 1]->copy());
     }
     auto result = make_unique<LogicalIntersect>(
-        intersectNode, children[0]->copy(), std::move(buildChildren), std::move(buildInfos_));
+        intersectNodeID, children[0]->copy(), std::move(buildChildren), std::move(buildInfos_));
     return result;
 }
 

--- a/src/planner/operator/logical_order_by.cpp
+++ b/src/planner/operator/logical_order_by.cpp
@@ -8,15 +8,7 @@ namespace planner {
 void LogicalOrderBy::computeSchema() {
     auto childSchema = children[0]->getSchema();
     schema = make_unique<Schema>();
-    SinkOperatorUtil::recomputeSchema(*childSchema, *schema);
-}
-
-string LogicalOrderBy::getExpressionsForPrinting() const {
-    auto result = string();
-    for (auto& expression : expressionsToOrderBy) {
-        result += expression->getUniqueName() + ", ";
-    }
-    return result;
+    SinkOperatorUtil::recomputeSchema(*childSchema, expressionsToMaterialize, *schema);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_plan_util.cpp
+++ b/src/planner/operator/logical_plan_util.cpp
@@ -91,7 +91,7 @@ void LogicalPlanUtil::encodeCrossProduct(LogicalOperator* logicalOperator, strin
 
 void LogicalPlanUtil::encodeIntersect(LogicalOperator* logicalOperator, string& encodeString) {
     auto logicalIntersect = (LogicalIntersect*)logicalOperator;
-    encodeString += "I(" + logicalIntersect->getIntersectNode()->getRawName() + ")";
+    encodeString += "I(" + logicalIntersect->getIntersectNodeID()->getRawName() + ")";
 }
 
 void LogicalPlanUtil::encodeHashJoin(LogicalOperator* logicalOperator, string& encodeString) {

--- a/src/planner/operator/logical_union.cpp
+++ b/src/planner/operator/logical_union.cpp
@@ -8,18 +8,16 @@ namespace planner {
 void LogicalUnion::computeSchema() {
     auto firstChildSchema = children[0]->getSchema();
     schema = make_unique<Schema>();
-    SinkOperatorUtil::recomputeSchema(*firstChildSchema, *schema);
+    SinkOperatorUtil::recomputeSchema(
+        *firstChildSchema, firstChildSchema->getExpressionsInScope(), *schema);
 }
 
 unique_ptr<LogicalOperator> LogicalUnion::copy() {
-    vector<unique_ptr<Schema>> copiedSchemas;
     vector<shared_ptr<LogicalOperator>> copiedChildren;
     for (auto i = 0u; i < getNumChildren(); ++i) {
-        copiedSchemas.push_back(schemasBeforeUnion[i]->copy());
         copiedChildren.push_back(getChild(i)->copy());
     }
-    return make_unique<LogicalUnion>(
-        expressionsToUnion, std::move(copiedSchemas), std::move(copiedChildren));
+    return make_unique<LogicalUnion>(expressionsToUnion, std::move(copiedChildren));
 }
 
 } // namespace planner

--- a/src/planner/query_planner.cpp
+++ b/src/planner/query_planner.cpp
@@ -397,16 +397,13 @@ unique_ptr<LogicalPlan> QueryPlanner::createUnionPlan(
     }
     // we compute the schema based on first child
     auto plan = make_unique<LogicalPlan>();
-    vector<unique_ptr<Schema>> schemaBeforeUnion;
     vector<shared_ptr<LogicalOperator>> children;
     for (auto& childPlan : childrenPlans) {
         plan->increaseCost(childPlan->getCost());
-        schemaBeforeUnion.push_back(childPlan->getSchema()->copy());
         children.push_back(childPlan->getLastOperator());
     }
-    auto logicalUnion =
-        make_shared<LogicalUnion>(childrenPlans[0]->getSchema()->getExpressionsInScope(),
-            std::move(schemaBeforeUnion), std::move(children));
+    auto logicalUnion = make_shared<LogicalUnion>(
+        childrenPlans[0]->getSchema()->getExpressionsInScope(), std::move(children));
     logicalUnion->computeSchema();
     plan->setLastOperator(logicalUnion);
     if (!isUnionAll) {

--- a/src/processor/mapper/map_intersect.cpp
+++ b/src/processor/mapper/map_intersect.cpp
@@ -20,34 +20,32 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
     // Map build side children.
     for (auto i = 1u; i < logicalIntersect->getNumChildren(); i++) {
         auto buildInfo = logicalIntersect->getBuildInfo(i - 1);
-        auto buildKey = buildInfo->key->getInternalIDPropertyName();
         auto buildSchema = logicalIntersect->getChild(i)->getSchema();
         auto buildSidePrevOperator = mapLogicalOperatorToPhysical(logicalIntersect->getChild(i));
         vector<DataPos> payloadsDataPos;
         auto buildDataInfo = generateBuildDataInfo(
-            *buildSchema, {buildInfo->key}, buildInfo->expressionsToMaterialize);
+            *buildSchema, {buildInfo->keyNodeID}, buildInfo->expressionsToMaterialize);
         for (auto& [dataPos, _] : buildDataInfo.payloadsPosAndType) {
             auto expression = buildSchema->getGroup(dataPos.dataChunkPos)
                                   ->getExpressions()[dataPos.valueVectorPos];
             if (expression->getUniqueName() ==
-                logicalIntersect->getIntersectNode()->getInternalIDPropertyName()) {
+                logicalIntersect->getIntersectNodeID()->getUniqueName()) {
                 continue;
             }
             payloadsDataPos.emplace_back(outSchema->getExpressionPos(*expression));
         }
         auto sharedState = make_shared<IntersectSharedState>();
         sharedStates.push_back(sharedState);
-        children.push_back(
-            make_unique<IntersectBuild>(make_unique<ResultSetDescriptor>(*buildSchema), sharedState,
-                buildDataInfo, std::move(buildSidePrevOperator), getOperatorID(), buildKey));
+        children.push_back(make_unique<IntersectBuild>(
+            make_unique<ResultSetDescriptor>(*buildSchema), sharedState, buildDataInfo,
+            std::move(buildSidePrevOperator), getOperatorID(), buildInfo->keyNodeID->getRawName()));
         IntersectDataInfo info{
-            DataPos(outSchema->getExpressionPos(*buildInfo->key->getInternalIDProperty())),
-            payloadsDataPos};
+            DataPos(outSchema->getExpressionPos(*buildInfo->keyNodeID)), payloadsDataPos};
         intersectDataInfos.push_back(info);
     }
     // Map intersect.
-    auto outputDataPos = DataPos(outSchema->getExpressionPos(
-        *logicalIntersect->getIntersectNode()->getInternalIDProperty()));
+    auto outputDataPos =
+        DataPos(outSchema->getExpressionPos(*logicalIntersect->getIntersectNodeID()));
     return make_unique<Intersect>(outputDataPos, intersectDataInfos, sharedStates,
         std::move(children), getOperatorID(), logicalIntersect->getExpressionsForPrinting());
 }

--- a/src/processor/mapper/map_scan_node.cpp
+++ b/src/processor/mapper/map_scan_node.cpp
@@ -19,8 +19,8 @@ unique_ptr<PhysicalOperator> PlanMapper::mapLogicalScanNodeToPhysical(
         auto nodeTable = nodesStore.getNodeTable(tableID);
         sharedState->addTableState(nodeTable);
     }
-    return make_unique<ScanNodeID>(node->getUniqueName(), dataPos, sharedState, getOperatorID(),
-        logicalScan->getExpressionsForPrinting());
+    return make_unique<ScanNodeID>(node->getInternalIDPropertyName(), dataPos, sharedState,
+        getOperatorID(), logicalScan->getExpressionsForPrinting());
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIndexScanNodeToPhysical(


### PR DESCRIPTION
This is the first PR for adding column-lifetime optimizer. 

We change the sink operator interface to take an additional expressionsToMaterialize argument instead of materializing all expressions in current scope.

This PR also directly stores joinNodeID as the join condition instead of joinNode.