### PR TITLE
Node map agg

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -77,7 +77,7 @@ void Binder::validateProjectionColumnNamesAreUnique(const expression_vector& exp
 }
 
 void Binder::validateProjectionColumnHasNoInternalType(const expression_vector& expressions) {
-    auto internalTypes = unordered_set<DataTypeID>{NODE, REL, NODE_ID};
+    auto internalTypes = unordered_set<DataTypeID>{NODE_ID};
     for (auto& expression : expressions) {
         if (internalTypes.contains(expression->dataType.typeID)) {
             throw BinderException("Cannot return expression " + expression->getRawName() +
@@ -108,9 +108,9 @@ void Binder::validateUnionColumnsOfTheSameType(
     if (boundSingleQueries.size() <= 1) {
         return;
     }
-    auto expressionsToProject = boundSingleQueries[0]->getExpressionsToReturn();
+    auto expressionsToProject = boundSingleQueries[0]->getExpressionsToCollect();
     for (auto i = 1u; i < boundSingleQueries.size(); i++) {
-        auto expressionsToProjectToCheck = boundSingleQueries[i]->getExpressionsToReturn();
+        auto expressionsToProjectToCheck = boundSingleQueries[i]->getExpressionsToCollect();
         if (expressionsToProject.size() != expressionsToProjectToCheck.size()) {
             throw BinderException("The number of columns to union/union all must be the same.");
         }

--- a/src/include/binder/bind/bound_copy_csv.h
+++ b/src/include/binder/bind/bound_copy_csv.h
@@ -16,8 +16,9 @@ namespace binder {
 class BoundCopyCSV : public BoundStatement {
 public:
     BoundCopyCSV(CSVDescription csvDescription, TableSchema tableSchema)
-        : BoundStatement{StatementType::COPY_CSV}, csvDescription{move(csvDescription)},
-          tableSchema{move(tableSchema)} {}
+        : BoundStatement{StatementType::COPY_CSV,
+              BoundStatementResult::createSingleStringColumnResult()},
+          csvDescription{std::move(csvDescription)}, tableSchema{std::move(tableSchema)} {}
 
     inline CSVDescription getCSVDescription() const { return csvDescription; }
 

--- a/src/include/binder/bind/bound_create_table.h
+++ b/src/include/binder/bind/bound_create_table.h
@@ -12,8 +12,9 @@ class BoundCreateTable : public BoundStatement {
 public:
     explicit BoundCreateTable(StatementType statementType, string tableName,
         vector<PropertyNameDataType> propertyNameDataTypes)
-        : BoundStatement{statementType}, tableName{move(tableName)}, propertyNameDataTypes{move(
-                                                                         propertyNameDataTypes)} {}
+        : BoundStatement{statementType, BoundStatementResult::createSingleStringColumnResult()},
+          tableName{std::move(tableName)}, propertyNameDataTypes{std::move(propertyNameDataTypes)} {
+    }
 
     inline string getTableName() const { return tableName; }
     inline vector<PropertyNameDataType> getPropertyNameDataTypes() const {

--- a/src/include/binder/bind/bound_drop_table.h
+++ b/src/include/binder/bind/bound_drop_table.h
@@ -8,7 +8,9 @@ namespace binder {
 class BoundDropTable : public BoundStatement {
 public:
     explicit BoundDropTable(TableSchema* tableSchema)
-        : BoundStatement{StatementType::DROP_TABLE}, tableSchema{tableSchema} {}
+        : BoundStatement{StatementType::DROP_TABLE,
+              BoundStatementResult::createSingleStringColumnResult()},
+          tableSchema{tableSchema} {}
 
     inline TableSchema* getTableSchema() const { return tableSchema; }
 

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -88,13 +88,12 @@ private:
 
     /*** bind projection clause ***/
     unique_ptr<BoundWithClause> bindWithClause(const WithClause& withClause);
-    unique_ptr<BoundReturnClause> bindReturnClause(
-        const ReturnClause& returnClause, unique_ptr<BoundSingleQuery>& boundSingleQuery);
+    unique_ptr<BoundReturnClause> bindReturnClause(const ReturnClause& returnClause);
 
     expression_vector bindProjectionExpressions(
         const vector<unique_ptr<ParsedExpression>>& projectionExpressions, bool containsStar);
-    // For RETURN clause, we write variable "v" as all properties of "v"
-    expression_vector rewriteProjectionExpressions(const expression_vector& expressions);
+    // Rewrite variable "v" as all properties of "v"
+    expression_vector rewriteNodeOrRelExpression(const Expression& expression);
 
     void bindOrderBySkipLimitIfNecessary(
         BoundProjectionBody& boundProjectionBody, const ProjectionBody& projectionBody);

--- a/src/include/binder/bound_statement.h
+++ b/src/include/binder/bound_statement.h
@@ -1,6 +1,8 @@
 #pragma once
+
 #include <cstdint>
 
+#include "bound_statement_result.h"
 #include "common/statement_type.h"
 
 using namespace kuzu::common;
@@ -10,14 +12,24 @@ namespace binder {
 
 class BoundStatement {
 public:
-    explicit BoundStatement(StatementType statementType) : statementType{statementType} {}
+    explicit BoundStatement(
+        StatementType statementType, unique_ptr<BoundStatementResult> statementResult)
+        : statementType{statementType}, statementResult{std::move(statementResult)} {}
 
     virtual ~BoundStatement() = default;
 
     inline StatementType getStatementType() const { return statementType; }
 
+    inline BoundStatementResult* getStatementResult() const { return statementResult.get(); }
+
+    inline bool isDDL() const { return StatementTypeUtils::isDDL(statementType); }
+    inline bool isCopyCSV() const { return StatementTypeUtils::isCopyCSV(statementType); }
+
+    virtual inline bool isReadOnly() const { return false; }
+
 private:
     StatementType statementType;
+    unique_ptr<BoundStatementResult> statementResult;
 };
 
 } // namespace binder

--- a/src/include/binder/bound_statement_result.h
+++ b/src/include/binder/bound_statement_result.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "binder/expression/expression.h"
+
+namespace kuzu {
+namespace binder {
+
+class BoundStatementResult {
+public:
+    BoundStatementResult() = default;
+    BoundStatementResult(
+        expression_vector columns, vector<expression_vector> expressionsToCollectPerColumn)
+        : columns{std::move(columns)}, expressionsToCollectPerColumn{
+                                           std::move(expressionsToCollectPerColumn)} {}
+
+    static unique_ptr<BoundStatementResult> createEmptyResult() {
+        return make_unique<BoundStatementResult>();
+    }
+
+    static unique_ptr<BoundStatementResult> createSingleStringColumnResult() {
+        auto result = make_unique<BoundStatementResult>();
+        auto stringColumn = make_shared<Expression>(LITERAL, DataType{STRING}, "outputMsg");
+        result->addColumn(stringColumn, expression_vector{stringColumn});
+        return result;
+    }
+
+    inline void addColumn(shared_ptr<Expression> column, expression_vector expressionToCollect) {
+        columns.push_back(std::move(column));
+        expressionsToCollectPerColumn.push_back(std::move(expressionToCollect));
+    }
+    inline expression_vector getColumns() const { return columns; }
+    inline vector<expression_vector> getExpressionsToCollectPerColumn() const {
+        return expressionsToCollectPerColumn;
+    }
+
+    inline expression_vector getExpressionsToCollect() {
+        expression_vector result;
+        for (auto& expressionsToCollect : expressionsToCollectPerColumn) {
+            for (auto& expression : expressionsToCollect) {
+                result.push_back(expression);
+            }
+        }
+        return result;
+    }
+
+    inline unique_ptr<BoundStatementResult> copy() {
+        return make_unique<BoundStatementResult>(columns, expressionsToCollectPerColumn);
+    }
+
+private:
+    expression_vector columns;
+    // for node and rel column, we need collect multiple properties and aggregate in json format.
+    vector<expression_vector> expressionsToCollectPerColumn;
+};
+
+} // namespace binder
+} // namespace kuzu

--- a/src/include/binder/query/bound_regular_query.h
+++ b/src/include/binder/query/bound_regular_query.h
@@ -7,30 +7,32 @@ namespace kuzu {
 namespace binder {
 
 class BoundRegularQuery : public BoundStatement {
-
 public:
-    explicit BoundRegularQuery(vector<bool> isUnionAll)
-        : BoundStatement{StatementType::QUERY}, isUnionAll{move(isUnionAll)} {}
+    explicit BoundRegularQuery(
+        vector<bool> isUnionAll, unique_ptr<BoundStatementResult> statementResult)
+        : BoundStatement{StatementType::QUERY, std::move(statementResult)}, isUnionAll{std::move(
+                                                                                isUnionAll)} {}
 
     ~BoundRegularQuery() = default;
 
-    inline void addSingleQuery(unique_ptr<NormalizedSingleQuery> singleQuery) {
-        singleQueries.push_back(move(singleQuery));
+    inline bool isReadOnly() const override {
+        for (auto& singleQuery : singleQueries) {
+            if (!singleQuery->isReadOnly()) {
+                return false;
+            }
+        }
+        return true;
     }
 
+    inline void addSingleQuery(unique_ptr<NormalizedSingleQuery> singleQuery) {
+        singleQueries.push_back(std::move(singleQuery));
+    }
     inline uint64_t getNumSingleQueries() const { return singleQueries.size(); }
-
     inline NormalizedSingleQuery* getSingleQuery(uint32_t idx) const {
         return singleQueries[idx].get();
     }
 
     inline bool getIsUnionAll(uint32_t idx) const { return isUnionAll[idx]; }
-
-    // For regular query (i.e. union of single queries), since there
-    inline expression_vector getExpressionsToReturn() const {
-        assert(!singleQueries.empty());
-        return singleQueries[0]->getExpressionsToReturn();
-    }
 
 private:
     vector<unique_ptr<NormalizedSingleQuery>> singleQueries;

--- a/src/include/binder/query/bound_single_query.h
+++ b/src/include/binder/query/bound_single_query.h
@@ -10,19 +10,18 @@ namespace binder {
  * Represents (QueryPart)* (Reading)* RETURN
  */
 class BoundSingleQuery {
-
 public:
     BoundSingleQuery() = default;
     ~BoundSingleQuery() = default;
 
     inline void addQueryPart(unique_ptr<BoundQueryPart> queryPart) {
-        queryParts.push_back(move(queryPart));
+        queryParts.push_back(std::move(queryPart));
     }
     inline uint32_t getNumQueryParts() const { return queryParts.size(); }
     inline BoundQueryPart* getQueryPart(uint32_t idx) const { return queryParts[idx].get(); }
 
     inline void addReadingClause(unique_ptr<BoundReadingClause> readingClause) {
-        readingClauses.push_back(move(readingClause));
+        readingClauses.push_back(std::move(readingClause));
     }
     inline uint32_t getNumReadingClauses() const { return readingClauses.size(); }
     inline BoundReadingClause* getReadingClause(uint32_t idx) const {
@@ -30,7 +29,7 @@ public:
     }
 
     inline void addUpdatingClause(unique_ptr<BoundUpdatingClause> updatingClause) {
-        updatingClauses.push_back(move(updatingClause));
+        updatingClauses.push_back(std::move(updatingClause));
     }
     inline uint32_t getNumUpdatingClauses() const { return updatingClauses.size(); }
     inline BoundUpdatingClause* getUpdatingClause(uint32_t idx) const {
@@ -38,13 +37,14 @@ public:
     }
 
     inline void setReturnClause(unique_ptr<BoundReturnClause> boundReturnClause) {
-        returnClause = move(boundReturnClause);
+        returnClause = std::move(boundReturnClause);
     }
     inline bool hasReturnClause() const { return returnClause != nullptr; }
     inline BoundReturnClause* getReturnClause() const { return returnClause.get(); }
 
-    inline expression_vector getExpressionsToReturn() const {
-        return returnClause->getProjectionBody()->getProjectionExpressions();
+    inline expression_vector getExpressionsToCollect() const {
+        return hasReturnClause() ? returnClause->getStatementResult()->getExpressionsToCollect() :
+                                   expression_vector{};
     }
 
 private:

--- a/src/include/binder/query/normalized_query_part.h
+++ b/src/include/binder/query/normalized_query_part.h
@@ -9,7 +9,6 @@ namespace kuzu {
 namespace binder {
 
 class NormalizedQueryPart {
-
 public:
     NormalizedQueryPart() = default;
     ~NormalizedQueryPart() = default;
@@ -50,9 +49,7 @@ public:
 
 private:
     vector<unique_ptr<BoundReadingClause>> readingClauses;
-
     vector<unique_ptr<BoundUpdatingClause>> updatingClauses;
-
     unique_ptr<BoundProjectionBody> projectionBody;
     shared_ptr<Expression> projectionBodyPredicate;
 };

--- a/src/include/binder/query/normalized_single_query.h
+++ b/src/include/binder/query/normalized_single_query.h
@@ -1,33 +1,30 @@
 #pragma once
 
+#include "binder/bound_statement_result.h"
 #include "normalized_query_part.h"
 
 namespace kuzu {
 namespace binder {
 
-/**
- * See QueryNormalizer for detailed normalization performed.
- */
 class NormalizedSingleQuery {
-
 public:
     NormalizedSingleQuery() = default;
-
     ~NormalizedSingleQuery() = default;
 
+    inline bool isReadOnly() const {
+        for (auto& queryPart : queryParts) {
+            if (queryPart->hasUpdatingClause()) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     inline void appendQueryPart(unique_ptr<NormalizedQueryPart> queryPart) {
-        queryParts.push_back(move(queryPart));
+        queryParts.push_back(std::move(queryPart));
     }
     inline uint32_t getNumQueryParts() const { return queryParts.size(); }
     inline NormalizedQueryPart* getQueryPart(uint32_t idx) const { return queryParts[idx].get(); }
-
-    inline expression_vector getExpressionsToReturn() const {
-        assert(!queryParts.empty());
-        if (queryParts.back()->hasProjectionBody()) {
-            return queryParts.back()->getProjectionBody()->getProjectionExpressions();
-        }
-        return expression_vector{};
-    }
 
     expression_vector getPropertiesToRead() const;
 

--- a/src/include/binder/query/return_with_clause/bound_projection_body.h
+++ b/src/include/binder/query/return_with_clause/bound_projection_body.h
@@ -6,7 +6,6 @@ namespace kuzu {
 namespace binder {
 
 class BoundProjectionBody {
-
 public:
     explicit BoundProjectionBody(bool isDistinct, expression_vector projectionExpressions)
         : isDistinct{isDistinct}, projectionExpressions{move(projectionExpressions)},

--- a/src/include/binder/query/return_with_clause/bound_return_clause.h
+++ b/src/include/binder/query/return_with_clause/bound_return_clause.h
@@ -1,20 +1,27 @@
 #pragma once
 
+#include "binder/bound_statement_result.h"
 #include "bound_projection_body.h"
 
 namespace kuzu {
 namespace binder {
 
 class BoundReturnClause {
-
 public:
     explicit BoundReturnClause(unique_ptr<BoundProjectionBody> projectionBody)
-        : projectionBody{move(projectionBody)} {}
+        : projectionBody{std::move(projectionBody)}, statementResult{nullptr} {}
+    BoundReturnClause(unique_ptr<BoundProjectionBody> projectionBody,
+        unique_ptr<BoundStatementResult> statementResult)
+        : projectionBody{std::move(projectionBody)}, statementResult{std::move(statementResult)} {}
+    virtual ~BoundReturnClause() = default;
 
-    inline BoundProjectionBody* getProjectionBody() const { return projectionBody.get(); }
+    inline BoundProjectionBody* getProjectionBody() { return projectionBody.get(); }
 
-private:
+    inline BoundStatementResult* getStatementResult() const { return statementResult.get(); }
+
+protected:
     unique_ptr<BoundProjectionBody> projectionBody;
+    unique_ptr<BoundStatementResult> statementResult;
 };
 
 } // namespace binder

--- a/src/include/binder/query/return_with_clause/bound_with_clause.h
+++ b/src/include/binder/query/return_with_clause/bound_with_clause.h
@@ -9,13 +9,12 @@ namespace binder {
  * BoundWithClause may not have whereExpression
  */
 class BoundWithClause : public BoundReturnClause {
-
 public:
     explicit BoundWithClause(unique_ptr<BoundProjectionBody> projectionBody)
-        : BoundReturnClause{move(projectionBody)} {}
+        : BoundReturnClause{std::move(projectionBody)} {}
 
     inline void setWhereExpression(shared_ptr<Expression> expression) {
-        whereExpression = move(expression);
+        whereExpression = std::move(expression);
     }
 
     inline bool hasWhereExpression() const { return whereExpression != nullptr; }

--- a/src/include/common/statement_type.h
+++ b/src/include/common/statement_type.h
@@ -13,5 +13,22 @@ enum class StatementType : uint8_t {
     DROP_TABLE = 4,
 };
 
+class StatementTypeUtils {
+public:
+    static bool isDDL(StatementType statementType) {
+        return statementType == StatementType::CREATE_NODE_CLAUSE ||
+               statementType == StatementType::CREATE_REL_CLAUSE ||
+               statementType == StatementType::DROP_TABLE;
+    }
+
+    static bool isCopyCSV(StatementType statementType) {
+        return statementType == StatementType::COPY_CSV;
+    }
+
+    static bool isDDLOrCopyCSV(StatementType statementType) {
+        return isDDL(statementType) || isCopyCSV(statementType);
+    }
+};
+
 } // namespace common
 } // namespace kuzu

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -157,12 +157,6 @@ protected:
         }
     }
 
-    // Used in test helper. Note: for our testing framework, we should not catch exception and
-    // instead let IDE catch these exceptions.
-    std::vector<unique_ptr<planner::LogicalPlan>> enumeratePlans(const std::string& query);
-    unique_ptr<planner::LogicalPlan> getBestPlan(const std::string& query);
-    std::unique_ptr<QueryResult> executePlan(unique_ptr<planner::LogicalPlan> logicalPlan);
-
     void beginTransactionNoLock(TransactionType type);
 
     void commitOrRollbackNoLock(bool isCommit, bool skipCheckpointForTesting = false);
@@ -172,7 +166,8 @@ protected:
     void setQuerySummaryAndPreparedStatement(
         Statement* statement, Binder& binder, PreparedStatement* preparedStatement);
 
-    std::unique_ptr<PreparedStatement> prepareNoLock(const std::string& query);
+    std::unique_ptr<PreparedStatement> prepareNoLock(
+        const std::string& query, bool enumerateAllPlans = false);
 
     template<typename T, typename... Args>
     std::unique_ptr<QueryResult> executeWithParams(PreparedStatement* preparedStatement,
@@ -188,7 +183,7 @@ protected:
         unordered_map<string, shared_ptr<Literal>>& inputParams);
 
     std::unique_ptr<QueryResult> executeAndAutoCommitIfNecessaryNoLock(
-        PreparedStatement* preparedStatement);
+        PreparedStatement* preparedStatement, uint32_t planIdx = 0u);
 
     void beginTransactionIfAutoCommit(PreparedStatement* preparedStatement);
 

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -10,29 +10,13 @@ using namespace kuzu::processor;
 namespace kuzu {
 namespace main {
 
-struct QueryResultHeader {
-
-    explicit QueryResultHeader(expression_vector expressions);
-
-    QueryResultHeader(
-        std::vector<common::DataType> columnDataTypes, std::vector<std::string> columnNames)
-        : columnDataTypes{move(columnDataTypes)}, columnNames{move(columnNames)} {}
-
-    unique_ptr<QueryResultHeader> copy() const {
-        return make_unique<QueryResultHeader>(columnDataTypes, columnNames);
-    }
-
-    std::vector<common::DataType> columnDataTypes;
-    std::vector<std::string> columnNames;
-};
-
 class QueryResult {
     friend class Connection;
 
 public:
     // Only used when we failed to prepare a query.
     QueryResult() = default;
-    explicit QueryResult(PreparedSummary preparedSummary) {
+    explicit QueryResult(const PreparedSummary& preparedSummary) {
         querySummary = make_unique<QuerySummary>();
         querySummary->setPreparedSummary(preparedSummary);
     }
@@ -40,48 +24,48 @@ public:
     inline bool isSuccess() const { return success; }
     inline string getErrorMessage() const { return errMsg; }
 
-    inline void setResultHeaderAndTable(std::unique_ptr<QueryResultHeader> header,
-        std::shared_ptr<processor::FactorizedTable> factorizedTable) {
-        this->header = move(header);
-        this->factorizedTable = move(factorizedTable);
-        resetIterator();
-    }
-
-    bool hasNext();
-
-    // TODO: this is not efficient and should be replaced by iterator
-    std::shared_ptr<processor::FlatTuple> getNext();
-
-    void writeToCSV(
-        string fileName, char delimiter = ',', char escapeCharacter = '"', char newline = '\n');
-
-    inline uint64_t getNumColumns() const { return header->columnDataTypes.size(); }
-
-    inline QuerySummary* getQuerySummary() const { return querySummary.get(); }
-
-    // TODO: interfaces below should be removed
-    // used in shell to walk the result twice (first time getting maximum column width)
-    inline void resetIterator() {
-        iterator = make_unique<FlatTupleIterator>(*factorizedTable, header->columnDataTypes);
-    }
+    inline size_t getNumColumns() const { return columnDataTypes.size(); }
+    inline vector<std::string> getColumnNames() { return columnNames; }
+    inline std::vector<common::DataType> getColumnDataTypes() { return columnDataTypes; }
 
     inline uint64_t getNumTuples() {
         return querySummary->getIsExplain() ? 0 : factorizedTable->getTotalNumFlatTuples();
     }
 
-    inline vector<std::string> getColumnNames() { return header->columnNames; }
+    inline QuerySummary* getQuerySummary() const { return querySummary.get(); }
 
-    inline std::vector<common::DataType> getColumnDataTypes() { return header->columnDataTypes; }
+    void initResultTableAndIterator(std::shared_ptr<processor::FactorizedTable> factorizedTable_,
+        const expression_vector& columns,
+        const vector<expression_vector>& expressionToCollectPerColumn);
+
+    bool hasNext();
+
+    std::shared_ptr<processor::FlatTuple> getNext();
+
+    void writeToCSV(const string& fileName, char delimiter = ',', char escapeCharacter = '"',
+        char newline = '\n');
+
+    // TODO: interfaces below should be removed
+    // used in shell to walk the result twice (first time getting maximum column width)
+    inline void resetIterator() { iterator->resetState(); }
 
 private:
     void validateQuerySucceed();
 
+private:
+    // execution status
     bool success = true;
     std::string errMsg;
 
-    std::unique_ptr<QueryResultHeader> header;
+    // header information
+    std::vector<std::string> columnNames;
+    std::vector<common::DataType> columnDataTypes;
+    // data
     std::shared_ptr<processor::FactorizedTable> factorizedTable;
     std::unique_ptr<processor::FlatTupleIterator> iterator;
+    shared_ptr<FlatTuple> tuple;
+
+    // execution statistics
     std::unique_ptr<QuerySummary> querySummary;
 };
 

--- a/src/include/main/query_summary.h
+++ b/src/include/main/query_summary.h
@@ -16,19 +16,19 @@ class QuerySummary {
     friend class PreparedStatement;
 
 public:
-    double getCompilingTime() const { return preparedSummary.compilingTime; }
+    inline double getCompilingTime() const { return preparedSummary.compilingTime; }
 
-    double getExecutionTime() const { return executionTime; }
+    inline double getExecutionTime() const { return executionTime; }
 
-    bool getIsExplain() const { return preparedSummary.isExplain; }
+    inline bool getIsExplain() const { return preparedSummary.isExplain; }
 
-    bool getIsProfile() const { return preparedSummary.isProfile; }
+    inline bool getIsProfile() const { return preparedSummary.isProfile; }
 
-    std::ostringstream& getPlanAsOstream() { return planInOstream; }
-    nlohmann::json& printPlanToJson() { return planInJson; }
+    inline std::ostringstream& getPlanAsOstream() { return planInOstream; }
+    inline nlohmann::json& printPlanToJson() { return planInJson; }
 
-    void setPreparedSummary(PreparedSummary preparedSummary) {
-        this->preparedSummary = preparedSummary;
+    inline void setPreparedSummary(PreparedSummary preparedSummary_) {
+        preparedSummary = preparedSummary_;
     }
 
 private:

--- a/src/include/parser/query/return_with_clause/projection_body.h
+++ b/src/include/parser/query/return_with_clause/projection_body.h
@@ -6,16 +6,15 @@ namespace kuzu {
 namespace parser {
 
 class ProjectionBody {
-
 public:
-    ProjectionBody(bool isDistinct, bool containsStar,
+    ProjectionBody(bool isDistinct, bool containsStar_,
         vector<unique_ptr<ParsedExpression>> projectionExpressions)
-        : isDistinct{isDistinct}, containsStar{containsStar}, projectionExpressions{
-                                                                  move(projectionExpressions)} {}
+        : isDistinct{isDistinct}, containsStar_{containsStar_}, projectionExpressions{std::move(
+                                                                    projectionExpressions)} {}
 
     inline bool getIsDistinct() const { return isDistinct; }
 
-    inline bool getContainsStar() const { return containsStar; }
+    inline bool containsStar() const { return containsStar_; }
 
     inline const vector<unique_ptr<ParsedExpression>>& getProjectionExpressions() const {
         return projectionExpressions;
@@ -23,39 +22,32 @@ public:
 
     inline void setOrderByExpressions(
         vector<unique_ptr<ParsedExpression>> expressions, vector<bool> sortOrders) {
-        orderByExpressions = move(expressions);
-        this->isAscOrders = move(sortOrders);
+        orderByExpressions = std::move(expressions);
+        isAscOrders = std::move(sortOrders);
     }
-
     inline bool hasOrderByExpressions() const { return !orderByExpressions.empty(); }
-
     inline uint32_t numOrderByExpressions() const { return orderByExpressions.size(); }
-
     inline const vector<unique_ptr<ParsedExpression>>& getOrderByExpressions() const {
         return orderByExpressions;
     }
 
-    inline const vector<bool>& getSortOrders() const { return isAscOrders; }
+    inline vector<bool> getSortOrders() const { return isAscOrders; }
 
     inline void setSkipExpression(unique_ptr<ParsedExpression> expression) {
-        skipExpression = move(expression);
+        skipExpression = std::move(expression);
     }
-
     inline bool hasSkipExpression() const { return skipExpression != nullptr; }
-
     inline ParsedExpression* getSkipExpression() const { return skipExpression.get(); }
 
     inline void setLimitExpression(unique_ptr<ParsedExpression> expression) {
-        limitExpression = move(expression);
+        limitExpression = std::move(expression);
     }
-
     inline bool hasLimitExpression() const { return limitExpression != nullptr; }
-
     inline ParsedExpression* getLimitExpression() const { return limitExpression.get(); }
 
 private:
     bool isDistinct;
-    bool containsStar;
+    bool containsStar_;
     vector<unique_ptr<ParsedExpression>> projectionExpressions;
     vector<unique_ptr<ParsedExpression>> orderByExpressions;
     vector<bool> isAscOrders;

--- a/src/include/planner/logical_plan/logical_operator/base_logical_operator.h
+++ b/src/include/planner/logical_plan/logical_operator/base_logical_operator.h
@@ -75,8 +75,6 @@ public:
 
     virtual string getExpressionsForPrinting() const = 0;
 
-    bool descendantsContainType(const unordered_set<LogicalOperatorType>& types) const;
-
     // Print the sub-plan rooted at this operator.
     virtual string toString(uint64_t depth = 0) const;
 

--- a/src/include/planner/logical_plan/logical_plan.h
+++ b/src/include/planner/logical_plan/logical_plan.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "planner/logical_plan/logical_operator/base_logical_operator.h"
-#include "planner/logical_plan/logical_operator/schema.h"
 
 namespace kuzu {
 namespace planner {
@@ -10,29 +9,9 @@ class LogicalPlan {
 public:
     LogicalPlan() : estCardinality{1}, cost{0} {}
 
-    LogicalPlan(expression_vector expressionsToCollect, uint64_t estCardinality, uint64_t cost)
-        : expressionsToCollect{std::move(expressionsToCollect)},
-          estCardinality{estCardinality}, cost{cost} {}
-
     inline void setLastOperator(shared_ptr<LogicalOperator> op) { lastOperator = std::move(op); }
 
     inline bool isEmpty() const { return lastOperator == nullptr; }
-
-    // TODO(Xiyang): check read only from parser
-    inline bool isReadOnly() const {
-        return !lastOperator->descendantsContainType(
-            unordered_set<LogicalOperatorType>{LogicalOperatorType::SET_NODE_PROPERTY,
-                LogicalOperatorType::CREATE_NODE, LogicalOperatorType::CREATE_REL,
-                LogicalOperatorType::DELETE_NODE, LogicalOperatorType::DELETE_REL,
-                LogicalOperatorType::CREATE_NODE_TABLE, LogicalOperatorType::CREATE_REL_TABLE,
-                LogicalOperatorType::COPY_CSV, LogicalOperatorType::DROP_TABLE});
-    }
-
-    inline void setExpressionsToCollect(expression_vector expressions) {
-        expressionsToCollect = std::move(expressions);
-    }
-
-    inline expression_vector getExpressionsToCollect() { return expressionsToCollect; }
 
     inline shared_ptr<LogicalOperator> getLastOperator() const { return lastOperator; }
     inline Schema* getSchema() const { return lastOperator->getSchema(); }
@@ -47,20 +26,12 @@ public:
 
     inline string toString() const { return lastOperator->toString(); }
 
-    inline bool isDDLOrCopyCSV() const {
-        return lastOperator->descendantsContainType(unordered_set<LogicalOperatorType>{
-            LogicalOperatorType::COPY_CSV, LogicalOperatorType::CREATE_NODE_TABLE,
-            LogicalOperatorType::CREATE_REL_TABLE, LogicalOperatorType::DROP_TABLE});
-    }
-
     unique_ptr<LogicalPlan> shallowCopy() const;
 
     unique_ptr<LogicalPlan> deepCopy() const;
 
 private:
     shared_ptr<LogicalOperator> lastOperator;
-    // This fields represents return columns in the same order as user input.
-    expression_vector expressionsToCollect;
     uint64_t estCardinality;
     uint64_t cost;
 };

--- a/src/include/processor/mapper/plan_mapper.h
+++ b/src/include/processor/mapper/plan_mapper.h
@@ -23,7 +23,8 @@ public:
         : storageManager{storageManager}, memoryManager{memoryManager},
           expressionMapper{}, catalog{catalog}, physicalOperatorID{0} {}
 
-    unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(LogicalPlan* logicalPlan);
+    unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(LogicalPlan* logicalPlan,
+        const expression_vector& expressionsToCollect, bool isDDLOrCopyCSV);
 
 private:
     unique_ptr<PhysicalOperator> mapLogicalOperatorToPhysical(

--- a/src/include/processor/physical_plan.h
+++ b/src/include/processor/physical_plan.h
@@ -8,29 +8,13 @@ namespace kuzu {
 namespace processor {
 
 class PhysicalPlan {
-
 public:
-    explicit PhysicalPlan(unique_ptr<PhysicalOperator> lastOperator, bool readOnly)
-        : lastOperator{move(lastOperator)}, readOnly{readOnly} {}
-
-    inline bool isReadOnly() const { return readOnly; }
-
-    inline bool isCopyCSV() const {
-        return lastOperator->getChild(0)->getOperatorType() == PhysicalOperatorType::COPY_REL_CSV ||
-               lastOperator->getChild(0)->getOperatorType() == PhysicalOperatorType::COPY_NODE_CSV;
-    }
-
-    inline bool isDDL() const {
-        return lastOperator->getChild(0)->getOperatorType() ==
-                   PhysicalOperatorType::CREATE_NODE_TABLE ||
-               lastOperator->getChild(0)->getOperatorType() ==
-                   PhysicalOperatorType::CREATE_REL_TABLE ||
-               lastOperator->getChild(0)->getOperatorType() == PhysicalOperatorType::DROP_TABLE;
-    }
+    explicit PhysicalPlan(unique_ptr<PhysicalOperator> lastOperator, bool isDDLOrCopyCSV)
+        : lastOperator{std::move(lastOperator)}, isDDLOrCopyCSV{isDDLOrCopyCSV} {}
 
 public:
     unique_ptr<PhysicalOperator> lastOperator;
-    bool readOnly;
+    bool isDDLOrCopyCSV;
 };
 
 class PhysicalPlanUtil {

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -325,14 +325,15 @@ private:
 
 class FlatTupleIterator {
 public:
-    explicit FlatTupleIterator(
-        FactorizedTable& factorizedTable, const vector<DataType>& columnDataTypes);
+    explicit FlatTupleIterator(FactorizedTable& factorizedTable, vector<Value*> values);
 
     inline bool hasNextFlatTuple() {
         return nextTupleIdx < factorizedTable.getNumTuples() || nextFlatTupleIdx < numFlatTuples;
     }
 
-    shared_ptr<FlatTuple> getNextFlatTuple();
+    void getNextFlatTuple();
+
+    void resetState();
 
 private:
     // The dataChunkPos may be not consecutive, which means some entries in the
@@ -341,9 +342,8 @@ private:
     inline bool isValidDataChunkPos(uint32_t dataChunkPos) const {
         return flatTuplePositionsInDataChunk[dataChunkPos].first != UINT64_MAX;
     }
-    inline void readValueBufferToFlatTuple(uint64_t flatTupleValIdx, const uint8_t* valueBuffer) {
-        iteratorFlatTuple->getResultValue(flatTupleValIdx)
-            ->set(valueBuffer, columnDataTypes[flatTupleValIdx]);
+    inline void readValueBufferToValue(uint64_t colIdx, const uint8_t* valueBuffer) {
+        values[colIdx]->set(valueBuffer);
     }
 
     void readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer);
@@ -376,8 +376,7 @@ private:
     // This field stores the (nextIdxToReadInDataChunk, numElementsInDataChunk) of each dataChunk.
     vector<pair<uint64_t, uint64_t>> flatTuplePositionsInDataChunk;
 
-    vector<DataType> columnDataTypes;
-    shared_ptr<FlatTuple> iteratorFlatTuple;
+    vector<Value*> values;
 };
 
 } // namespace processor

--- a/src/include/processor/result/flat_tuple.h
+++ b/src/include/processor/result/flat_tuple.h
@@ -1,118 +1,24 @@
 #pragma once
 
-#include <memory>
-
-#include "common/exception.h"
-#include "common/type_utils.h"
-#include "common/utils.h"
-
-using namespace kuzu::common;
+#include "value.h"
 
 namespace kuzu {
 namespace processor {
 
-class ResultValue {
-
-public:
-    explicit ResultValue(DataType dataType) : dataType{dataType}, isNull{false} {}
-
-    inline void setNull(bool isNull) { this->isNull = isNull; }
-
-    inline bool getBooleanVal() const {
-        errorIfTypeMismatch(BOOL);
-        return val.booleanVal;
-    }
-
-    inline int64_t getInt64Val() const {
-        errorIfTypeMismatch(INT64);
-        return val.int64Val;
-    }
-
-    inline double getDoubleVal() const {
-        errorIfTypeMismatch(DOUBLE);
-        return val.doubleVal;
-    }
-
-    inline date_t getDateVal() const {
-        errorIfTypeMismatch(DATE);
-        return val.dateVal;
-    }
-
-    inline timestamp_t getTimestampVal() const {
-        errorIfTypeMismatch(TIMESTAMP);
-        return val.timestampVal;
-    }
-
-    inline interval_t getIntervalVal() const {
-        errorIfTypeMismatch(INTERVAL);
-        return val.intervalVal;
-    }
-
-    inline string getStringVal() const {
-        errorIfTypeMismatch(STRING);
-        return stringVal;
-    }
-
-    inline vector<ResultValue> getListVal() const {
-        errorIfTypeMismatch(LIST);
-        return listVal;
-    }
-
-    inline bool isNullVal() const { return isNull; }
-
-    inline DataType getDataType() const { return dataType; }
-
-    void set(const uint8_t* value, DataType& valueType);
-
-    string toString() const;
-
-private:
-    inline void errorIfTypeMismatch(DataTypeID typeID) const {
-        if (typeID != dataType.typeID) {
-            throw RuntimeException(
-                StringUtils::string_format("Cannot get %s value from the %s result value.",
-                    Types::dataTypeToString(typeID).c_str(),
-                    Types::dataTypeToString(dataType.typeID).c_str()));
-        }
-    }
-
-    vector<ResultValue> convertKUListToVector(ku_list_t& list) const;
-
-private:
-    union Val {
-        constexpr Val() : booleanVal{false} {}
-        bool booleanVal;
-        int64_t int64Val;
-        double doubleVal;
-        date_t dateVal;
-        timestamp_t timestampVal;
-        interval_t intervalVal;
-    } val;
-    string stringVal;
-    vector<ResultValue> listVal;
-    DataType dataType;
-    bool isNull;
-};
-
 class FlatTuple {
-
 public:
-    explicit FlatTuple(const vector<DataType>& valueTypes) {
-        resultValues.resize(valueTypes.size());
-        for (auto i = 0u; i < valueTypes.size(); i++) {
-            resultValues[i] = make_unique<ResultValue>(valueTypes[i]);
-        }
-    }
+    inline void addValue(unique_ptr<Value> value) { values.push_back(std::move(value)); }
 
-    inline uint32_t len() { return resultValues.size(); }
+    inline uint32_t len() { return values.size(); }
 
-    ResultValue* getResultValue(uint32_t valIdx);
+    // TODO(Everyone): rename this to get.
+    Value* getResultValue(uint32_t idx);
 
-    string toString(const vector<uint32_t>& colsWidth, const string& delimiter = "|",
-        const uint32_t maxWidth = -1);
+    string toString(
+        const vector<uint32_t>& colsWidth, const string& delimiter = "|", uint32_t maxWidth = -1);
 
 private:
-    vector<unique_ptr<ResultValue>> resultValues;
+    vector<unique_ptr<Value>> values;
 };
 
 } // namespace processor

--- a/src/include/processor/result/value.h
+++ b/src/include/processor/result/value.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "common/exception.h"
+#include "common/type_utils.h"
+#include "common/utils.h"
+
+namespace kuzu {
+namespace processor {
+
+class Value {
+public:
+    explicit Value(common::DataType dataType) : dataType{std::move(dataType)}, isNull{false} {}
+
+    inline bool getBooleanVal() const {
+        validateType(common::BOOL);
+        return val.booleanVal;
+    }
+
+    inline int64_t getInt64Val() const {
+        validateType(common::INT64);
+        return val.int64Val;
+    }
+
+    inline double getDoubleVal() const {
+        validateType(common::DOUBLE);
+        return val.doubleVal;
+    }
+
+    inline common::date_t getDateVal() const {
+        validateType(common::DATE);
+        return val.dateVal;
+    }
+
+    inline common::timestamp_t getTimestampVal() const {
+        validateType(common::TIMESTAMP);
+        return val.timestampVal;
+    }
+
+    inline common::interval_t getIntervalVal() const {
+        validateType(common::INTERVAL);
+        return val.intervalVal;
+    }
+
+    inline std::string getStringVal() const {
+        validateType(common::STRING);
+        return stringVal;
+    }
+
+    // TODO(Xiyang): Maybe we should do copy here.
+    inline const vector<unique_ptr<Value>>& getListVal() const {
+        validateType(common::LIST);
+        return listVal;
+    }
+
+    inline void setNull(bool isNull_) { this->isNull = isNull_; }
+    inline bool isNullVal() const { return isNull; }
+
+    inline common::DataType getDataType() const { return dataType; }
+
+    void set(const uint8_t* value);
+
+    inline void addNodeOrRelProperty(const std::string& key, unique_ptr<Value> value) {
+        nodeOrRelVal.emplace_back(key, std::move(value));
+    }
+
+    string toString() const;
+
+private:
+    void validateType(common::DataTypeID typeID) const;
+
+    vector<unique_ptr<Value>> convertKUListToVector(common::ku_list_t& list) const;
+
+private:
+    union Val {
+        constexpr Val() : booleanVal{false} {}
+        bool booleanVal;
+        int64_t int64Val;
+        double doubleVal;
+        common::date_t dateVal;
+        common::timestamp_t timestampVal;
+        common::interval_t intervalVal;
+    } val;
+    std::string stringVal;
+    vector<unique_ptr<Value>> listVal;
+    vector<pair<std::string, unique_ptr<Value>>> nodeOrRelVal;
+
+    common::DataType dataType;
+    bool isNull;
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/planner/operator/base_logical_operator.cpp
+++ b/src/planner/operator/base_logical_operator.cpp
@@ -136,19 +136,6 @@ void LogicalOperator::computeSchemaRecursive() {
     computeSchema();
 }
 
-bool LogicalOperator::descendantsContainType(
-    const unordered_set<LogicalOperatorType>& types) const {
-    if (types.contains(operatorType)) {
-        return true;
-    }
-    for (auto& child : children) {
-        if (child->descendantsContainType(types)) {
-            return true;
-        }
-    }
-    return false;
-}
-
 string LogicalOperator::toString(uint64_t depth) const {
     auto padding = string(depth * 4, ' ');
     string result = padding;

--- a/src/planner/operator/logical_plan.cpp
+++ b/src/planner/operator/logical_plan.cpp
@@ -1,21 +1,23 @@
 #include "planner/logical_plan/logical_plan.h"
 
-#include <utility>
-
 namespace kuzu {
 namespace planner {
 
 unique_ptr<LogicalPlan> LogicalPlan::shallowCopy() const {
-    auto plan = make_unique<LogicalPlan>(expressionsToCollect, estCardinality, cost);
-    plan->lastOperator = lastOperator;
+    auto plan = make_unique<LogicalPlan>();
+    plan->lastOperator = lastOperator; // shallow copy sub-plan
+    plan->estCardinality = estCardinality;
+    plan->cost = cost;
     return plan;
 }
 
 unique_ptr<LogicalPlan> LogicalPlan::deepCopy() const {
     assert(!isEmpty());
-    auto plan = make_unique<LogicalPlan>(expressionsToCollect, estCardinality, cost);
-    plan->lastOperator = lastOperator->copy();
+    auto plan = make_unique<LogicalPlan>();
+    plan->lastOperator = lastOperator->copy(); // deep copy sub-plan
     plan->lastOperator->computeSchemaRecursive();
+    plan->estCardinality = estCardinality;
+    plan->cost = cost;
     return plan;
 }
 

--- a/src/planner/query_planner.cpp
+++ b/src/planner/query_planner.cpp
@@ -31,9 +31,6 @@ vector<unique_ptr<LogicalPlan>> QueryPlanner::getAllPlans(const BoundStatement& 
             resultPlans.push_back(createUnionPlan(childrenPlan, regularQuery.getIsUnionAll(0)));
         }
     }
-    for (auto& plan : resultPlans) {
-        plan->setExpressionsToCollect(regularQuery.getExpressionsToReturn());
-    }
     return resultPlans;
 }
 

--- a/src/processor/mapper/plan_mapper.cpp
+++ b/src/processor/mapper/plan_mapper.cpp
@@ -10,11 +10,12 @@ using namespace kuzu::planner;
 namespace kuzu {
 namespace processor {
 
-unique_ptr<PhysicalPlan> PlanMapper::mapLogicalPlanToPhysical(LogicalPlan* logicalPlan) {
+unique_ptr<PhysicalPlan> PlanMapper::mapLogicalPlanToPhysical(
+    LogicalPlan* logicalPlan, const expression_vector& expressionsToCollect, bool isDDLOrCopyCSV) {
     auto prevOperator = mapLogicalOperatorToPhysical(logicalPlan->getLastOperator());
     auto lastOperator = appendResultCollector(
-        logicalPlan->getExpressionsToCollect(), *logicalPlan->getSchema(), move(prevOperator));
-    return make_unique<PhysicalPlan>(move(lastOperator), logicalPlan->isReadOnly());
+        expressionsToCollect, *logicalPlan->getSchema(), std::move(prevOperator));
+    return make_unique<PhysicalPlan>(std::move(lastOperator), isDDLOrCopyCSV);
 }
 
 unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOperatorToPhysical(

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -18,13 +18,9 @@ QueryProcessor::QueryProcessor(uint64_t numThreads) {
 
 shared_ptr<FactorizedTable> QueryProcessor::execute(
     PhysicalPlan* physicalPlan, ExecutionContext* context) {
-    if (physicalPlan->isCopyCSV()) {
+    if (physicalPlan->isDDLOrCopyCSV) {
         auto copyCSV = (CopyCSV*)physicalPlan->lastOperator->getChild(0);
         auto outputMsg = copyCSV->execute(taskScheduler.get(), context);
-        return getFactorizedTableForOutputMsg(outputMsg, context->memoryManager);
-    } else if (physicalPlan->isDDL()) {
-        auto ddl = (DDL*)physicalPlan->lastOperator->getChild(0);
-        auto outputMsg = ddl->execute();
         return getFactorizedTableForOutputMsg(outputMsg, context->memoryManager);
     } else {
         auto lastOperator = physicalPlan->lastOperator.get();

--- a/src/processor/result/CMakeLists.txt
+++ b/src/processor/result/CMakeLists.txt
@@ -3,7 +3,9 @@ add_library(kuzu_processor_result
         factorized_table.cpp
         flat_tuple.cpp
         result_set.cpp
-        result_set_descriptor.cpp)
+        result_set_descriptor.cpp
+        value.cpp
+        )
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_processor_result>

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -1,11 +1,7 @@
 #include "processor/result/flat_tuple.h"
 
-#include <iomanip>
 #include <sstream>
-#include <string>
 
-#include "common/type_utils.h"
-#include "common/utils.h"
 #include "utf8proc.h"
 #include "utf8proc_wrapper.h"
 
@@ -14,97 +10,19 @@ using namespace kuzu::utf8proc;
 namespace kuzu {
 namespace processor {
 
-void ResultValue::set(const uint8_t* value, DataType& valueType) {
-    switch (valueType.typeID) {
-    case INT64: {
-        val.int64Val = *((int64_t*)value);
-    } break;
-    case BOOL: {
-        val.booleanVal = *((bool*)value);
-    } break;
-    case DOUBLE: {
-        val.doubleVal = *((double*)value);
-    } break;
-    case STRING: {
-        stringVal = ((ku_string_t*)value)->getAsString();
-    } break;
-    case DATE: {
-        val.dateVal = *((date_t*)value);
-    } break;
-    case TIMESTAMP: {
-        val.timestampVal = *((timestamp_t*)value);
-    } break;
-    case INTERVAL: {
-        val.intervalVal = *((interval_t*)value);
-    } break;
-    case LIST: {
-        listVal = convertKUListToVector(*(ku_list_t*)value);
-    } break;
-    default:
-        throw RuntimeException("Data type " + Types::dataTypeToString(valueType.typeID) +
-                               " is not supported for ResultValue::set.");
+Value* FlatTuple::getResultValue(uint32_t idx) {
+    if (idx >= len()) {
+        throw common::RuntimeException(common::StringUtils::string_format(
+            "ValIdx is out of range. Number of values in flatTuple: %d, valIdx: %d.", len(), idx));
     }
-}
-
-string ResultValue::toString() const {
-    if (isNull) {
-        return "";
-    }
-    switch (dataType.typeID) {
-    case BOOL:
-        return TypeUtils::toString(val.booleanVal);
-    case INT64:
-        return TypeUtils::toString(val.int64Val);
-    case DOUBLE:
-        return TypeUtils::toString(val.doubleVal);
-    case STRING:
-        return stringVal;
-    case DATE:
-        return TypeUtils::toString(val.dateVal);
-    case TIMESTAMP:
-        return TypeUtils::toString(val.timestampVal);
-    case INTERVAL:
-        return TypeUtils::toString(val.intervalVal);
-    case LIST: {
-        string result = "[";
-        for (auto i = 0u; i < listVal.size(); ++i) {
-            result += listVal[i].toString();
-            result += (i == listVal.size() - 1 ? "]" : ",");
-        }
-        return result;
-    }
-    default:
-        throw RuntimeException("Data type " + Types::dataTypeToString(dataType) +
-                               " is not supported for ResultValue::toString.");
-    }
-}
-
-vector<ResultValue> ResultValue::convertKUListToVector(ku_list_t& list) const {
-    vector<ResultValue> listResultValue;
-    auto numBytesPerElement = Types::getDataTypeSize(*dataType.childType);
-    for (auto i = 0; i < list.size; i++) {
-        ResultValue childResultValue{*dataType.childType};
-        childResultValue.set(reinterpret_cast<uint8_t*>(list.overflowPtr + i * numBytesPerElement),
-            *dataType.childType);
-        listResultValue.emplace_back(std::move(childResultValue));
-    }
-    return listResultValue;
-}
-
-ResultValue* FlatTuple::getResultValue(uint32_t valIdx) {
-    if (valIdx >= len()) {
-        throw RuntimeException(StringUtils::string_format(
-            "ValIdx is out of range. Number of values in flatTuple: %d, valIdx: %d.", len(),
-            valIdx));
-    }
-    return resultValues[valIdx].get();
+    return values[idx].get();
 }
 
 string FlatTuple::toString(
     const vector<uint32_t>& colsWidth, const string& delimiter, const uint32_t maxWidth) {
     ostringstream result;
-    for (auto i = 0ul; i < resultValues.size(); i++) {
-        string value = resultValues[i]->toString();
+    for (auto i = 0ul; i < values.size(); i++) {
+        string value = values[i]->toString();
         if (value.length() > maxWidth) {
             value = value.substr(0, maxWidth - 3) + "...";
         }
@@ -123,7 +41,7 @@ string FlatTuple::toString(
         } else {
             result << value;
         }
-        if (i != resultValues.size() - 1) {
+        if (i != values.size() - 1) {
             result << delimiter;
         }
     }

--- a/src/processor/result/value.cpp
+++ b/src/processor/result/value.cpp
@@ -1,0 +1,106 @@
+#include "processor/result/value.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace processor {
+
+void Value::set(const uint8_t* value) {
+    switch (dataType.typeID) {
+    case INT64: {
+        val.int64Val = *((int64_t*)value);
+    } break;
+    case BOOL: {
+        val.booleanVal = *((bool*)value);
+    } break;
+    case DOUBLE: {
+        val.doubleVal = *((double*)value);
+    } break;
+    case STRING: {
+        stringVal = ((ku_string_t*)value)->getAsString();
+    } break;
+    case DATE: {
+        val.dateVal = *((date_t*)value);
+    } break;
+    case TIMESTAMP: {
+        val.timestampVal = *((timestamp_t*)value);
+    } break;
+    case INTERVAL: {
+        val.intervalVal = *((interval_t*)value);
+    } break;
+    case LIST: {
+        listVal = convertKUListToVector(*(ku_list_t*)value);
+    } break;
+    default:
+        throw RuntimeException("Data type " + Types::dataTypeToString(dataType.typeID) +
+                               " is not supported for ResultValue::set.");
+    }
+}
+
+string Value::toString() const {
+    if (isNull) {
+        return "";
+    }
+    switch (dataType.typeID) {
+    case BOOL:
+        return TypeUtils::toString(val.booleanVal);
+    case INT64:
+        return TypeUtils::toString(val.int64Val);
+    case DOUBLE:
+        return TypeUtils::toString(val.doubleVal);
+    case STRING:
+        return stringVal;
+    case DATE:
+        return TypeUtils::toString(val.dateVal);
+    case TIMESTAMP:
+        return TypeUtils::toString(val.timestampVal);
+    case INTERVAL:
+        return TypeUtils::toString(val.intervalVal);
+    case LIST: {
+        string result = "[";
+        for (auto i = 0u; i < listVal.size(); ++i) {
+            result += listVal[i]->toString();
+            result += (i == listVal.size() - 1 ? "]" : ",");
+        }
+        return result;
+    }
+    case NODE:
+    case REL: {
+        std::string result = "({";
+        for (auto i = 0u; i < nodeOrRelVal.size(); ++i) {
+            auto& [name, value] = nodeOrRelVal[i];
+            result += name + ":" + value->toString();
+            result += (i == nodeOrRelVal.size() - 1 ? "" : ", ");
+        }
+        result += "})";
+        return result;
+    }
+    default:
+        throw RuntimeException("Data type " + Types::dataTypeToString(dataType) +
+                               " is not supported for ResultValue::toString.");
+    }
+}
+
+void Value::validateType(common::DataTypeID typeID) const {
+    if (typeID != dataType.typeID) {
+        throw common::RuntimeException(
+            common::StringUtils::string_format("Cannot get %s value from the %s result value.",
+                common::Types::dataTypeToString(typeID).c_str(),
+                common::Types::dataTypeToString(dataType.typeID).c_str()));
+    }
+}
+
+vector<unique_ptr<Value>> Value::convertKUListToVector(ku_list_t& list) const {
+    vector<unique_ptr<Value>> listResultValue;
+    auto numBytesPerElement = Types::getDataTypeSize(*dataType.childType);
+    for (auto i = 0; i < list.size; i++) {
+        auto childResultValue = make_unique<Value>(*dataType.childType);
+        childResultValue->set(
+            reinterpret_cast<uint8_t*>(list.overflowPtr + i * numBytesPerElement));
+        listResultValue.emplace_back(std::move(childResultValue));
+    }
+    return listResultValue;
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/test/demo_db/demo_db_test.cpp
+++ b/test/demo_db/demo_db_test.cpp
@@ -28,8 +28,9 @@ TEST_F(DemoDBTest, CreateAvgNullTest) {
     auto result =
         conn->query("MATCH (a:User) WITH a, avg(a.age) AS b, SUM(a.age) AS c, COUNT(a.age) AS d, "
                     "COUNT(*) AS e RETURN a, b, c,d, e ORDER BY c DESC");
-    auto groundTruth = vector<string>{"Alice||||0|1", "Zhang|50|50.000000|50|1|1",
-        "Karissa|40|40.000000|40|1|1", "Adam|30|30.000000|30|1|1", "Noura|25|25.000000|25|1|1"};
+    auto groundTruth = vector<string>{"({name:Alice, age:})|||0|1",
+        "({name:Zhang, age:50})|50.000000|50|1|1", "({name:Karissa, age:40})|40.000000|40|1|1",
+        "({name:Adam, age:30})|30.000000|30|1|1", "({name:Noura, age:25})|25.000000|25|1|1"};
     ASSERT_EQ(TestHelper::convertResultToString(*result, true /* check order */), groundTruth);
 }
 

--- a/test/runner/e2e_copy_csv_transaction_test.cpp
+++ b/test/runner/e2e_copy_csv_transaction_test.cpp
@@ -78,7 +78,9 @@ public:
         conn->beginWriteTransaction();
         auto mapper = PlanMapper(
             *getStorageManager(*database), getMemoryManager(*database), getCatalog(*database));
-        auto physicalPlan = mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlan.get());
+        auto physicalPlan =
+            mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
+                preparedStatement->getExpressionsToCollect(), preparedStatement->isDDLOrCopyCSV());
         getQueryProcessor(*database)->execute(physicalPlan.get(), executionContext.get());
         auto tableID = catalog->getReadOnlyVersion()->getNodeTableIDFromName("person");
         validateDatabaseStateBeforeCheckPointCopyNodeCSV(tableID);
@@ -160,7 +162,9 @@ public:
         conn->beginWriteTransaction();
         auto mapper = PlanMapper(
             *getStorageManager(*database), getMemoryManager(*database), getCatalog(*database));
-        auto physicalPlan = mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlan.get());
+        auto physicalPlan =
+            mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
+                preparedStatement->getExpressionsToCollect(), preparedStatement->isDDLOrCopyCSV());
         getQueryProcessor(*database)->execute(physicalPlan.get(), executionContext.get());
         auto tableID = catalog->getReadOnlyVersion()->getRelTableIDFromName("knows");
         validateDatabaseStateBeforeCheckPointCopyRelCSV(tableID);

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -284,7 +284,9 @@ public:
         conn->beginWriteTransaction();
         auto mapper = PlanMapper(
             *getStorageManager(*database), getMemoryManager(*database), getCatalog(*database));
-        auto physicalPlan = mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlan.get());
+        auto physicalPlan =
+            mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
+                preparedStatement->getExpressionsToCollect(), preparedStatement->isDDLOrCopyCSV());
         getQueryProcessor(*database)->execute(physicalPlan.get(), executionContext.get());
     }
 
@@ -342,7 +344,7 @@ TEST_F(TinySnbDDLTest, CreateNodeAfterCreateNodeTable) {
         conn->query("CREATE (university:UNIVERSITY {NAME: 'WATERLOO', WEBSITE: 'WATERLOO.CA'})");
     ASSERT_TRUE(result->isSuccess());
     result = conn->query("MATCH (a:UNIVERSITY) RETURN a;");
-    auto groundTruth = vector<string>{"WATERLOO|WATERLOO.CA"};
+    auto groundTruth = vector<string>{"({NAME:WATERLOO, WEBSITE:WATERLOO.CA})"};
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
 }
 

--- a/test/runner/e2e_update_node_test.cpp
+++ b/test/runner/e2e_update_node_test.cpp
@@ -226,7 +226,8 @@ TEST_F(TinySnbUpdateTest, InsertSingleNToNRelTest) {
         "MATCH (a:person), (b:person) WHERE a.ID = 9 AND b.ID = 10 "
         "CREATE (a)-[:knows {meetTime:timestamp('1976-12-23 11:21:42'), validInterval:interval('2 "
         "years'), comments:['A', 'k'], date:date('1997-03-22')}]->(b);");
-    auto groundTruth = vector<string>{"9|10|1997-03-22|1976-12-23 11:21:42|2 years|[A,k]|40"};
+    auto groundTruth = vector<string>{"9|10|({_id:40, date:1997-03-22, meetTime:1976-12-23 "
+                                      "11:21:42, validInterval:2 years, comments:[A,k]})|40"};
     auto result = conn->query(
         "MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 8 RETURN a.ID, b.ID, e, ID(e)");
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);
@@ -236,8 +237,9 @@ TEST_F(TinySnbUpdateTest, InsertSingleNTo1RelTest) {
     // insert studyAt edge between Greg and CsWork
     conn->query("MATCH (a:person), (b:organisation) WHERE a.ID = 9 AND b.orgCode = 934 "
                 "CREATE (a)-[:studyAt {year:2022}]->(b);");
-    auto groundTruth =
-        vector<string>{"8|325|2020|[awndsnjwejwen,isuhuwennjnuhuhuwewe]|16", "9|934|2022||40"};
+    auto groundTruth = vector<string>{
+        "8|325|({_id:16, year:2020, places:[awndsnjwejwen,isuhuwennjnuhuhuwewe]})|16",
+        "9|934|({_id:40, year:2022, places:})|40"};
     auto result = conn->query("MATCH (a:person)-[e:studyAt]->(b:organisation) WHERE a.ID > 5 "
                               "RETURN a.ID, b.orgCode, e, ID(e)");
     ASSERT_EQ(TestHelper::convertResultToString(*result), groundTruth);

--- a/test/storage/rel_insertion_test.cpp
+++ b/test/storage/rel_insertion_test.cpp
@@ -142,7 +142,7 @@ public:
                 ASSERT_EQ(tuple->getResultValue(1)->getStringVal(),
                     (containLongString ? "long long string prefix " : "") + to_string(i));
             }
-            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(),
+            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0]->getStringVal(),
                 (containLongString ? "long long string prefix " : "") + to_string(i));
         }
     }
@@ -216,7 +216,7 @@ public:
             ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), i);
             auto strVal = getStringValToValidate(1000 - i);
             ASSERT_EQ(tuple->getResultValue(1)->getStringVal(), strVal);
-            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(), strVal);
+            ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0]->getStringVal(), strVal);
             if (!isCommit) {
                 continue;
             }
@@ -233,7 +233,7 @@ public:
                     ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), dstNodeOffset * 3);
                     ASSERT_EQ(
                         tuple->getResultValue(1)->getStringVal(), to_string(dstNodeOffset - 5));
-                    ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(),
+                    ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0]->getStringVal(),
                         to_string(dstNodeOffset - 5));
                 }
             } else {
@@ -243,7 +243,7 @@ public:
                     ASSERT_EQ(tuple->getResultValue(0)->getInt64Val(), dstNodeOffset * 2);
                     ASSERT_EQ(
                         tuple->getResultValue(1)->getStringVal(), to_string(dstNodeOffset - 25));
-                    ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0].getStringVal(),
+                    ASSERT_EQ((tuple->getResultValue(2)->getListVal())[0]->getStringVal(),
                         to_string(dstNodeOffset - 25));
                 }
             }

--- a/test/test_files/copy/copy_node.test
+++ b/test/test_files/copy/copy_node.test
@@ -2,11 +2,11 @@
 -NAME SubsetTest
 -QUERY MATCH (row:tableOfTypes) WHERE row.id >= 20 AND row.id <= 24 RETURN *;
 ---- 5
-20|0|57.579280|True|1731-09-26|1731-09-26 03:30:08|OdM
-21|7|64.630960|False|1307-01-26|1307-01-26 03:31:08|AjbxHQThEtDDlOjbzMjCQSXlvGQEjcFLykESrnFHwPKX
-22|71|37.963386|True|1455-07-26|1455-07-26 03:07:03|dRvHHdyNXYfSUcicaxBoQEKQUfgex
-23|58|42.774957|False|1181-10-16|1181-10-16 18:19:43|ISImRVpUjynGMFRQyYmeIUVjM
-24|75|53.813224|False|1942-10-24|1942-10-24 09:30:16|naDlQ
+({id:20, int64Column:0, doubleColumn:57.579280, booleanColumn:True, dateColumn:1731-09-26, timestampColumn:1731-09-26 03:30:08, stringColumn:OdM})
+({id:21, int64Column:7, doubleColumn:64.630960, booleanColumn:False, dateColumn:1307-01-26, timestampColumn:1307-01-26 03:31:08, stringColumn:AjbxHQThEtDDlOjbzMjCQSXlvGQEjcFLykESrnFHwPKX})
+({id:22, int64Column:71, doubleColumn:37.963386, booleanColumn:True, dateColumn:1455-07-26, timestampColumn:1455-07-26 03:07:03, stringColumn:dRvHHdyNXYfSUcicaxBoQEKQUfgex})
+({id:23, int64Column:58, doubleColumn:42.774957, booleanColumn:False, dateColumn:1181-10-16, timestampColumn:1181-10-16 18:19:43, stringColumn:ISImRVpUjynGMFRQyYmeIUVjM})
+({id:24, int64Column:75, doubleColumn:53.813224, booleanColumn:False, dateColumn:1942-10-24, timestampColumn:1942-10-24 09:30:16, stringColumn:naDlQ})
 
 -NAME CheckNumLinesTest
 -QUERY MATCH (row:tableOfTypes) RETURN count(*)
@@ -31,7 +31,7 @@
 -NAME EmptyStringTest
 -QUERY MATCH (row:tableOfTypes) WHERE row.id = 49992 RETURN *;
 ---- 1
-49992|50|31.582059|False|1551-07-19|1551-07-19 16:28:31|
+({id:49992, int64Column:50, doubleColumn:31.582059, booleanColumn:False, dateColumn:1551-07-19, timestampColumn:1551-07-19 16:28:31, stringColumn:})
 
 -NAME FloatTest
 -QUERY MATCH (row:tableOfTypes) WHERE row.doubleColumn = 68.73718401556897 RETURN row.dateColumn;
@@ -41,7 +41,7 @@
 -NAME DateTest
 -QUERY MATCH (row:tableOfTypes) WHERE row.id = 25531 RETURN *;
 ---- 1
-25531|77|28.417543|False|1895-03-13|1895-03-13 04:31:22|XB
+({id:25531, int64Column:77, doubleColumn:28.417543, booleanColumn:False, dateColumn:1895-03-13, timestampColumn:1895-03-13 04:31:22, stringColumn:XB})
 
 -NAME IntervalTest
 -QUERY MATCH (row:tableOfTypes) WHERE 0 <= row.doubleColumn AND row.doubleColumn <= 10 AND 0 <= row.int64Column AND row.int64Column <= 10 RETURN count(*);

--- a/test/test_files/demo_db/demo_db.test
+++ b/test/test_files/demo_db/demo_db.test
@@ -27,10 +27,10 @@ Adam
 -NAME Match1
 -QUERY MATCH (a:User) RETURN a;
 ---- 4
-Adam|30
-Karissa|40
-Zhang|50
-Noura|25
+({name:Adam, age:30})
+({name:Karissa, age:40})
+({name:Noura, age:25})
+({name:Zhang, age:50})
 
 -NAME OptionalMatch1
 -QUERY MATCH (u:User) OPTIONAL MATCH (u)-[:Follows]->(u1:User) RETURN u.name, u1.name;

--- a/test/test_files/tinysnb/projection/multi_label.test
+++ b/test/test_files/tinysnb/projection/multi_label.test
@@ -16,31 +16,31 @@
 -NAME MultiLabelReturnStar
 -QUERY MATCH (a:movies:organisation) RETURN *
 ---- 6
-1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000
-4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000
-6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000
-|Roma||||||
-|Sóló cón tu párejâ||||||
-|The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie||||||
+({ID:, name:Roma, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:})
+({ID:, name:Sóló cón tu párejâ, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:})
+({ID:, name:The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:})
+({ID:1, name:ABFsUni, orgCode:325, mark:3.700000, score:-2, history:10 years 5 months 13 hours 24 us, licenseValidInterval:3 years 5 days, rating:1.000000})
+({ID:4, name:CsWork, orgCode:934, mark:4.100000, score:-100, history:2 years 4 days 10 hours, licenseValidInterval:26 years 52 days 48:00:00, rating:0.780000})
+({ID:6, name:DEsWork, orgCode:824, mark:4.100000, score:7, history:2 years 4 hours 22 us 34 minutes, licenseValidInterval:82:00:00.1, rating:0.520000})
 
 -NAME MultiLabelReturnEdge
 -QUERY MATCH (a:person)-[e:mixed|:marries]->(b:person) RETURN e
 -ENUMERATE
 ---- 10
-1930||
-1945||
-2020||
-2022||
-2066||
-2088||
-2120||
-|[toronto]|
-|[vancouver]|short str
-||long long long string
+({_id:27, year:1930, usedAddress:, note:})
+({_id:28, year:1945, usedAddress:, note:})
+({_id:29, year:2088, usedAddress:, note:})
+({_id:30, year:2066, usedAddress:, note:})
+({_id:31, year:2120, usedAddress:, note:})
+({_id:32, year:2022, usedAddress:, note:})
+({_id:33, year:2020, usedAddress:, note:})
+({_id:37, year:, usedAddress:[toronto], note:})
+({_id:38, year:, usedAddress:, note:long long long string})
+({_id:39, year:, usedAddress:[vancouver], note:short str})
 
 -NAME MultiLabelReturnTest
 -QUERY MATCH (a:person:organisation)-[e:mixed|:studyAt]->(b:person:organisation) WHERE a.fName='Alice' RETURN e, b.fName, b.name
 -ENUMERATE
 ---- 2
-1930||Bob|
-2021|[wwAewsdndweusd,wek]||ABFsUni
+({_id:14, year:2021, places:[wwAewsdndweusd,wek]})||ABFsUni
+({_id:27, year:1930, places:})|Bob|

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -38,9 +38,9 @@ False||
 -NAME OrgNodesReturnStarTest
 -QUERY MATCH (a:organisation) RETURN *
 ---- 3
-1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000
-4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000
-6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000
+({ID:1, name:ABFsUni, orgCode:325, mark:3.700000, score:-2, history:10 years 5 months 13 hours 24 us, licenseValidInterval:3 years 5 days, rating:1.000000})
+({ID:4, name:CsWork, orgCode:934, mark:4.100000, score:-100, history:2 years 4 days 10 hours, licenseValidInterval:26 years 52 days 48:00:00, rating:0.780000})
+({ID:6, name:DEsWork, orgCode:824, mark:4.100000, score:7, history:2 years 4 hours 22 us 34 minutes, licenseValidInterval:82:00:00.1, rating:0.520000})
 
 -NAME PersonNodesTestNull
 -QUERY MATCH (a:person) RETURN a.ID, a.fName STARTS WITH NULL, a.isWorker, a.isWorker AND null
@@ -331,18 +331,18 @@ Dan|Carol
 -NAME QueryOneToOneRelTable
 -QUERY MATCH (:person)-[m:marries]->(:person) RETURN m
 ---- 3
-[toronto]|
-|long long long string
-[vancouver]|short str
+({_id:37, usedAddress:[toronto], note:})
+({_id:38, usedAddress:, note:long long long string})
+({_id:39, usedAddress:[vancouver], note:short str})
 
 -NAME OneHopMixedTest
 -QUERY MATCH (a:person)-[e:mixed]->(b:person) RETURN a.ID, e, b.ID, b.fName
 -ENUMERATE
 ---- 7
-0|1930|2|Bob
-2|1945|5|Dan
-3|2088|7|Elizabeth
-7|2066|3|Carol
-8|2120|3|Carol
-9|2022|3|Carol
-10|2020|2|Bob
+0|({_id:27, year:1930})|2|Bob
+10|({_id:33, year:2020})|2|Bob
+2|({_id:28, year:1945})|5|Dan
+3|({_id:29, year:2088})|7|Elizabeth
+7|({_id:30, year:2066})|3|Carol
+8|({_id:31, year:2120})|3|Carol
+9|({_id:32, year:2022})|3|Carol

--- a/tools/join_order_pick/jo_connection.cpp
+++ b/tools/join_order_pick/jo_connection.cpp
@@ -35,8 +35,8 @@ unique_ptr<QueryResult> JOConnection::query(const string& query, const string& e
                 throw ConnectionException("Cannot find a plan matching " + encodedJoin);
             }
         }
-        preparedStatement->createResultHeader(logicalPlan->getExpressionsToCollect());
-        preparedStatement->logicalPlan = std::move(logicalPlan);
+        preparedStatement->statementResult = boundQuery->getStatementResult()->copy();
+        preparedStatement->logicalPlans.push_back(std::move(logicalPlan));
         return executeAndAutoCommitIfNecessaryNoLock(preparedStatement.get());
     } catch (Exception& exception) {
         string errMsg = exception.what();

--- a/tools/python_api/src_cpp/include/py_query_result.h
+++ b/tools/python_api/src_cpp/include/py_query_result.h
@@ -22,7 +22,7 @@ public:
 
     void close();
 
-    static py::object convertValueToPyObject(const ResultValue& value);
+    static py::object convertValueToPyObject(const Value& value);
 
     py::object getAsDF();
 

--- a/tools/python_api/src_cpp/include/py_query_result_converter.h
+++ b/tools/python_api/src_cpp/include/py_query_result_converter.h
@@ -10,7 +10,7 @@ struct NPArrayWrapper {
 public:
     NPArrayWrapper(const DataType& type, uint64_t numFlatTuple);
 
-    void appendElement(ResultValue* value);
+    void appendElement(Value* value);
 
 private:
     py::dtype convertToArrayType(const DataType& type);

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -56,7 +56,7 @@ void PyQueryResult::close() {
     queryResult.reset();
 }
 
-py::object PyQueryResult::convertValueToPyObject(const ResultValue& value) {
+py::object PyQueryResult::convertValueToPyObject(const Value& value) {
     if (value.isNullVal()) {
         return py::none();
     }
@@ -99,10 +99,10 @@ py::object PyQueryResult::convertValueToPyObject(const ResultValue& value) {
                                             py::arg("microseconds") = intervalVal.micros));
     }
     case LIST: {
-        auto listVal = value.getListVal();
+        auto& listVal = value.getListVal();
         py::list list;
         for (auto i = 0u; i < listVal.size(); ++i) {
-            list.append(convertValueToPyObject(listVal[i]));
+            list.append(convertValueToPyObject(*listVal[i]));
         }
         return move(list);
     }

--- a/tools/python_api/src_cpp/py_query_result_converter.cpp
+++ b/tools/python_api/src_cpp/py_query_result_converter.cpp
@@ -10,7 +10,7 @@ NPArrayWrapper::NPArrayWrapper(const DataType& type, uint64_t numFlatTuple)
     mask = py::array(py::dtype("bool"), numFlatTuple);
 }
 
-void NPArrayWrapper::appendElement(ResultValue* value) {
+void NPArrayWrapper::appendElement(Value* value) {
     ((uint8_t*)mask.mutable_data())[numElements] = value->isNullVal();
     if (!value->isNullVal()) {
         switch (type.typeID) {

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -8,7 +8,9 @@ def test_to_df(establish_connection):
     conn, db = establish_connection
 
     def _test_to_df(conn):
-        query = "MATCH (p:person) return * ORDER BY p.ID"
+        query = "MATCH (p:person) return " \
+                "p.ID, p.fName, p.gender, p.isStudent, p.eyeSight, p.birthdate, p.registerTime, " \
+                "p.lastJobDuration, p.workedHours, p.usedNames, p.courseScoresPerTerm ORDER BY p.ID"
         pd = conn.execute(query).get_as_df()
         assert pd['p.ID'].tolist() == [0, 2, 3, 5, 7, 8, 9, 10]
         assert str(pd['p.ID'].dtype) == "int64"


### PR DESCRIPTION
This PR allows returning node/rel as all of their properties aggregated in json format in a single column. To do so, this PR

- Add BoundStatementResult which defines the schema of how to aggregate multiple columns into a single column in json format
- Move ownership of iterate tuple from iterator to query result. So iterator only writes to a vector of flat values.

### Other changes

- Move isReadOnly, isDDL, isCopyCSV check from planning stage to binding stage
- Alter preparedStatement to take a vector of logical plans and thus remove APIs exposed only for testing framework