### PR TITLE
Add Python binding for NODE & REL types; output query results to NetworkX

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -22,7 +22,10 @@ jobs:
 
       - name: test
         run: CC=gcc CXX=g++ make test NUM_THREADS=32
-  
+
+      - name: python test
+        run: CC=gcc CXX=g++ make pytest NUM_THREADS=32
+
   gcc-build-test-with-asan:
     name: gcc build & test with asan
     needs: [gcc-build-test]
@@ -32,7 +35,7 @@ jobs:
       - run: pip install --user -r tools/python_api/requirements_dev.txt
 
       - name: build debug
-        run: CC=gcc CXX=g++ make NUM_THREADS=32 alldebug
+        run: CC=gcc CXX=g++ make alldebug NUM_THREADS=32
       
       - name: run test with asan
         run: ctest
@@ -62,6 +65,9 @@ jobs:
 
       - name: test
         run: CC=clang-14 CXX=clang++-14 make test NUM_THREADS=32
+      
+      - name: python test
+        run: CC=clang-14 CXX=clang++-14 make pytest NUM_THREADS=32
 
   clang-formatting-check:
     name: clang-formatting-check

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ test: arrow
 	cd $(ROOT_DIR)/build/release/test && \
 	ctest
 
+pytest: arrow
+	$(MAKE) release
+	cd $(ROOT_DIR)/tools/python_api/test && \
+	python3 -m pytest -v test_main.py
+
 clean-external:
 	rm -rf external/build
 

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -264,6 +264,14 @@ NodeVal::NodeVal(const NodeVal& other) {
     }
 }
 
+nodeID_t NodeVal::getNodeID() const {
+    return idVal->getValue<nodeID_t>();
+}
+
+string NodeVal::getLabelName() const {
+    return labelVal->getValue<string>();
+}
+
 string NodeVal::toString() const {
     std::string result = "(";
     result += idVal->toString();
@@ -279,6 +287,14 @@ RelVal::RelVal(const RelVal& other) {
     for (auto& [key, val] : other.properties) {
         addProperty(key, val->copy());
     }
+}
+
+nodeID_t RelVal::getSrcNodeID() const {
+    return srcNodeIDVal->getValue<nodeID_t>();
+}
+
+nodeID_t RelVal::getDstNodeID() const {
+    return dstNodeIDVal->getValue<nodeID_t>();
 }
 
 string RelVal::toString() const {

--- a/src/include/common/types/value.h
+++ b/src/include/common/types/value.h
@@ -109,6 +109,13 @@ public:
         properties.emplace_back(key, std::move(value));
     }
 
+    inline const vector<pair<std::string, unique_ptr<Value>>>& getProperties() const {
+        return properties;
+    }
+
+    nodeID_t getNodeID() const;
+    string getLabelName() const;
+
     inline unique_ptr<NodeVal> copy() const { return make_unique<NodeVal>(*this); }
 
     string toString() const;
@@ -129,7 +136,14 @@ public:
         properties.emplace_back(key, std::move(value));
     }
 
+    inline const vector<pair<std::string, unique_ptr<Value>>>& getProperties() const {
+        return properties;
+    }
+
     inline unique_ptr<RelVal> copy() const { return make_unique<RelVal>(*this); }
+
+    nodeID_t getSrcNodeID() const;
+    nodeID_t getDstNodeID() const;
 
     string toString() const;
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -24,17 +24,3 @@ add_subdirectory(processor)
 add_subdirectory(runner)
 add_subdirectory(storage)
 add_subdirectory(transaction)
-
-function(add_kuzu_python_api_test TEST_NAME FILE_NAME)
-    add_test(NAME PythonAPI.${TEST_NAME}
-            COMMAND ${PYTHON_EXECUTABLE} -m pytest ${PROJECT_SOURCE_DIR}/tools/python_api/test/${FILE_NAME}
-            WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tools/python_api/test)
-endfunction()
-
-add_kuzu_python_api_test(DataType test_datatype.py)
-add_kuzu_python_api_test(PandaAPI test_df.py)
-add_kuzu_python_api_test(Exception test_exception.py)
-add_kuzu_python_api_test(GetHeader test_get_header.py)
-add_kuzu_python_api_test(Main test_main.py)
-add_kuzu_python_api_test(Parameter test_parameter.py)
-add_kuzu_python_api_test(WriteToCSV test_write_to_csv.py)

--- a/tools/python_api/requirements_dev.txt
+++ b/tools/python_api/requirements_dev.txt
@@ -1,4 +1,5 @@
 pybind11>=2.6.0
 pytest
 pandas
+networkx~=3.0.0
 numpy

--- a/tools/python_api/src_cpp/include/py_query_result.h
+++ b/tools/python_api/src_cpp/include/py_query_result.h
@@ -30,6 +30,13 @@ public:
 
     py::list getColumnNames();
 
+    void resetIterator();
+
 private:
+    static py::dict getPyDictFromProperties(
+        const vector<pair<std::string, unique_ptr<Value>>>& properties);
+
+    static py::dict convertNodeIdToPyDict(const nodeID_t& nodeId);
+
     unique_ptr<QueryResult> queryResult;
 };

--- a/tools/python_api/src_cpp/py_query_result_converter.cpp
+++ b/tools/python_api/src_cpp/py_query_result_converter.cpp
@@ -49,6 +49,11 @@ void NPArrayWrapper::appendElement(Value* value) {
             ((PyObject**)dataBuffer)[numElements] = result;
             break;
         }
+        case NODE:
+        case REL: {
+            ((py::dict*)dataBuffer)[numElements] = PyQueryResult::convertValueToPyObject(*value);
+            break;
+        }
         case LIST: {
             ((py::list*)dataBuffer)[numElements] = PyQueryResult::convertValueToPyObject(*value);
             break;
@@ -76,6 +81,8 @@ py::dtype NPArrayWrapper::convertToArrayType(const DataType& type) {
         dtype = "bool";
         break;
     }
+    case NODE:
+    case REL:
     case LIST:
     case STRING: {
         dtype = "object";
@@ -104,6 +111,7 @@ QueryResultConverter::QueryResultConverter(QueryResult* queryResult) : queryResu
 }
 
 py::object QueryResultConverter::toDF() {
+    queryResult->resetIterator();
     while (queryResult->hasNext()) {
         auto flatTuple = queryResult->getNext();
         for (auto i = 0u; i < columns.size(); i++) {

--- a/tools/python_api/test/conftest.py
+++ b/tools/python_api/test/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 import pytest
 import shutil
+
 sys.path.append('../build/')
 import kuzu
 
@@ -18,18 +19,28 @@ def init_tiny_snb(tmp_path):
                  "age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration "
                  "INTERVAL, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], PRIMARY "
                  "KEY (ID))")
-    conn.execute("COPY person FROM \"../../../dataset/tinysnb/vPerson.csv\" (HEADER=true)")
+    conn.execute(
+        "COPY person FROM \"../../../dataset/tinysnb/vPerson.csv\" (HEADER=true)")
     conn.execute(
         "create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, "
         "comments STRING[], MANY_MANY);")
     conn.execute("COPY knows FROM \"../../../dataset/tinysnb/eKnows.csv\"")
+    conn.execute("create node table organisation (ID INT64, name STRING, orgCode INT64, mark DOUBLE, score INT64, history STRING, licenseValidInterval INTERVAL, rating DOUBLE, PRIMARY KEY (ID))")
+    conn.execute(
+        'COPY organisation FROM "../../../dataset/tinysnb/vOrganisation.csv" (HEADER=true)')
+    conn.execute(
+        'create rel table workAt (FROM person TO organisation, year INT64, MANY_ONE)')
+    conn.execute(
+        'COPY workAt FROM "../../../dataset/tinysnb/eWorkAt.csv" (HEADER=true)')
     return output_path
+
 
 @pytest.fixture
 def establish_connection(init_tiny_snb):
     db = kuzu.Database(init_tiny_snb, buffer_pool_size=256 * 1024 * 1024)
     conn = kuzu.Connection(db, num_threads=4)
     return conn, db
+
 
 @pytest.fixture
 def get_tmp_path(tmp_path):

--- a/tools/python_api/test/test_datatype.py
+++ b/tools/python_api/test/test_datatype.py
@@ -72,3 +72,46 @@ def test_list_wrap(establish_connection):
     assert not result.has_next()
     result.close()
 
+
+def test_node(establish_connection):
+    conn, db = establish_connection
+    result = conn.execute("MATCH (a:person) WHERE a.ID = 0 RETURN a")
+    assert result.has_next()
+    n = result.get_next()
+    assert(len(n) == 1)
+    n = n[0]
+    assert (n['_label'] == 'person')
+    assert (n['ID'] == 0)
+    assert (n['fName'] == 'Alice')
+    assert (n['gender'] == 1)
+    assert (n['isStudent'] == True)
+    assert (n['eyeSight'] == 5.0)
+    assert (n['birthdate'] == datetime.date(1900, 1, 1))
+    assert (n['registerTime'] == datetime.datetime(2011, 8, 20, 11, 25, 30))
+    assert (n['lastJobDuration'] == datetime.timedelta(
+        days=1082, seconds=46920))
+    assert (n['courseScoresPerTerm'] == [[10, 8], [6, 7, 8]])
+    assert (n['usedNames'] == ['Aida'])
+    assert not result.has_next()
+    result.close()
+
+
+def test_rel(establish_connection):
+    conn, db = establish_connection
+    result = conn.execute(
+        "MATCH (p:person)-[r:workAt]->(o:organisation) WHERE p.ID = 5 RETURN p, r, o")
+    assert result.has_next()
+    n = result.get_next()
+    assert (len(n) == 3)
+    p = n[0]
+    r = n[1]
+    o = n[2]
+    assert (p['_label'] == 'person')
+    assert (p['ID'] == 5)
+    assert (o['_label'] == 'organisation')
+    assert (o['ID'] == 6)
+    assert (r['year'] == 2010)
+    assert (r['_src'] == p['_id'])
+    assert (r['_dst'] == o['_id'])
+    assert not result.has_next()
+    result.close()

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -1,4 +1,5 @@
 import numpy as np
+import datetime
 import sys
 sys.path.append('../build/')
 import kuzu
@@ -81,3 +82,134 @@ def test_to_df(establish_connection):
 
     db.set_logging_level(kuzu.loggingLevel.err)
     _test_to_df(conn)
+
+
+def test_df_multiple_times(establish_connection):
+    conn, _ = establish_connection
+    query = "MATCH (p:person) return p.ID ORDER BY p.ID"
+    res = conn.execute(query)
+    df = res.get_as_df()
+    df_2 = res.get_as_df()
+    df_3 = res.get_as_df()
+    assert df['p.ID'].tolist() == [0, 2, 3, 5, 7, 8, 9, 10]
+    assert df_2['p.ID'].tolist() == [0, 2, 3, 5, 7, 8, 9, 10]
+    assert df_3['p.ID'].tolist() == [0, 2, 3, 5, 7, 8, 9, 10]
+
+
+def test_df_get_node(establish_connection):
+    conn, _ = establish_connection
+    query = "MATCH (p:person) return p"
+
+    res = conn.execute(query)
+    df = res.get_as_df()
+    p_list = df['p'].tolist()
+    assert len(p_list) == 8
+
+    ground_truth = {
+        'ID': [0, 2, 3, 5, 7, 8, 9, 10],
+        'fName': ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
+                  "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"],
+        'gender': [1, 2, 1, 2, 1, 2, 2, 2],
+        'isStudent': [True, True, False, False, False, True, False, False],
+        'eyeSight': [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9],
+        'birthdate': [datetime.date(1900, 1, 1), datetime.date(1900, 1, 1),
+                      datetime.date(1940, 6, 22), datetime.date(1950, 7, 23),
+                      datetime.date(1980, 10, 26), datetime.date(1980, 10, 26),
+                      datetime.date(1980, 10, 26), datetime.date(1990, 11, 27)],
+        'registerTime': [Timestamp('2011-08-20 11:25:30'),
+                         Timestamp('2008-11-03 15:25:30.000526'),
+                         Timestamp(
+            '1911-08-20 02:32:21'), Timestamp('2031-11-30 12:25:30'),
+            Timestamp('1976-12-23 11:21:42'),
+            Timestamp('1972-07-31 13:22:30.678559'),
+            Timestamp('1976-12-23 04:41:42'), Timestamp('2023-02-21 13:25:30')],
+        'lastJobDuration': [Timedelta('1082 days 13:02:00'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('2 days 00:24:11'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('2 days 00:24:11'), Timedelta(
+                                '0 days 00:18:00.024000'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('1082 days 13:02:00')],
+        'workedHours': [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
+                        [10, 11, 12, 3, 4, 5, 6, 7]],
+        'usedNames': [["Aida"], ['Bobby'], ['Carmen', 'Fred'],
+                      ['Wolfeschlegelstein', 'Daniel'], [
+                          'Ein'], ['Fesdwe'], ['Grad'],
+                      ['Ad', 'De', 'Hi', 'Kye', 'Orlan']],
+        'courseScoresPerTerm': [[[10, 8], [6, 7, 8]], [[8, 9], [9, 10]], [[8, 10]],
+                                [[7, 4], [8, 8], [9]], [
+                                    [6], [7], [8]], [[8]], [[10]],
+                                [[7], [10], [6, 7]]],
+        '_label': ['person', 'person', 'person', 'person', 'person', 'person',
+                   'person', 'person'],
+    }
+    for i in range(len(p_list)):
+        p = p_list[i]
+        for key in ground_truth:
+            assert p[key] == ground_truth[key][i]
+
+
+def test_df_get_node_rel(establish_connection):
+    conn, _ = establish_connection
+    res = conn.execute(
+        "MATCH (p:person)-[r:workAt]->(o:organisation) RETURN p, r, o")
+
+    df = res.get_as_df()
+    p_list = df['p'].tolist()
+    o_list = df['o'].tolist()
+
+    assert len(p_list) == 2
+    assert len(o_list) == 2
+
+    ground_truth_p = {
+        'ID': [5, 7],
+        'fName': ["Dan", "Elizabeth"],
+        'gender': [2, 1],
+        'isStudent': [False, False],
+        'eyeSight': [4.8, 4.7],
+        'birthdate': [datetime.date(1950, 7, 23),
+                      datetime.date(1980, 10, 26)],
+        'registerTime': [Timestamp('2031-11-30 12:25:30'),
+                         Timestamp('1976-12-23 11:21:42')
+                         ],
+        'lastJobDuration': [
+            Timedelta('3750 days 13:00:00.000024'),
+            Timedelta('2 days 00:24:11')],
+        'workedHours': [[1, 9], [2]],
+        'usedNames': [
+            ['Wolfeschlegelstein', 'Daniel'], [
+                'Ein']],
+        'courseScoresPerTerm': [
+            [[7, 4], [8, 8], [9]], [
+                [6], [7], [8]]],
+        '_label': ['person', 'person'],
+    }
+    for i in range(len(p_list)):
+        p = p_list[i]
+        for key in ground_truth_p:
+            assert p[key] == ground_truth_p[key][i]
+
+    ground_truth_o = {'ID': [6, 6],
+                      'name': ['DEsWork', 'DEsWork'],
+                      'orgCode': [824, 824],
+                      'mark': [4.1, 4.1],
+                      'score': [7, 7],
+                      'history': ['2 years 4 hours 22 us 34 minutes',
+                                  '2 years 4 hours 22 us 34 minutes'],
+                      'licenseValidInterval': [Timedelta(days=3, seconds=36000, microseconds=100000),
+                                               Timedelta(days=3, seconds=36000, microseconds=100000)],
+                      'rating': [0.52, 0.52],
+                      '_label': ['organisation', 'organisation'],
+                      }
+    for i in range(len(o_list)):
+        o = df['o'][i]
+        for key in ground_truth_o:
+            assert o[key] == ground_truth_o[key][i]
+
+    assert (df['r'][0]['year'] == 2010)
+    assert (df['r'][1]['year'] == 2015)
+
+    for i in range(len(df['r'])):
+        assert (df['r'][i]['_src'] == df['p'][i]['_id'])
+        assert (df['r'][i]['_dst'] == df['o'][i]['_id'])

--- a/tools/python_api/test/test_main.py
+++ b/tools/python_api/test/test_main.py
@@ -1,12 +1,13 @@
 import pytest
 
 from test_datatype import *
-from test_parameter import *
-from test_exception import *
 from test_df import *
-from test_write_to_csv import *
+from test_exception import *
 from test_get_header import *
+from test_networkx import *
+from test_parameter import *
 from test_query_result_close import *
+from test_write_to_csv import *
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tools/python_api/test/test_networkx.py
+++ b/tools/python_api/test/test_networkx.py
@@ -1,0 +1,228 @@
+import datetime
+from pandas import Timestamp, Timedelta
+
+
+def test_to_networkx_node(establish_connection):
+    conn, _ = establish_connection
+    query = "MATCH (p:person) return p"
+
+    res = conn.execute(query)
+    nx_graph = res.get_as_networkx()
+    nodes = list(nx_graph.nodes(data=True))
+    assert len(nodes) == 8
+
+    ground_truth = {
+        'ID': [0, 2, 3, 5, 7, 8, 9, 10],
+        'fName': ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
+                  "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"],
+        'gender': [1, 2, 1, 2, 1, 2, 2, 2],
+        'isStudent': [True, True, False, False, False, True, False, False],
+        'eyeSight': [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9],
+        'birthdate': [datetime.date(1900, 1, 1), datetime.date(1900, 1, 1),
+                      datetime.date(1940, 6, 22), datetime.date(1950, 7, 23),
+                      datetime.date(1980, 10, 26), datetime.date(1980, 10, 26),
+                      datetime.date(1980, 10, 26), datetime.date(1990, 11, 27)],
+        'registerTime': [Timestamp('2011-08-20 11:25:30'),
+                         Timestamp('2008-11-03 15:25:30.000526'),
+                         Timestamp(
+            '1911-08-20 02:32:21'), Timestamp('2031-11-30 12:25:30'),
+            Timestamp('1976-12-23 11:21:42'),
+            Timestamp('1972-07-31 13:22:30.678559'),
+            Timestamp('1976-12-23 04:41:42'), Timestamp('2023-02-21 13:25:30')],
+        'lastJobDuration': [Timedelta('1082 days 13:02:00'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('2 days 00:24:11'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('2 days 00:24:11'), Timedelta(
+                                '0 days 00:18:00.024000'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('1082 days 13:02:00')],
+        'workedHours': [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
+                        [10, 11, 12, 3, 4, 5, 6, 7]],
+        'usedNames': [["Aida"], ['Bobby'], ['Carmen', 'Fred'],
+                      ['Wolfeschlegelstein', 'Daniel'], [
+                          'Ein'], ['Fesdwe'], ['Grad'],
+                      ['Ad', 'De', 'Hi', 'Kye', 'Orlan']],
+        'courseScoresPerTerm': [[[10, 8], [6, 7, 8]], [[8, 9], [9, 10]], [[8, 10]],
+                                [[7, 4], [8, 8], [9]], [
+                                    [6], [7], [8]], [[8]], [[10]],
+                                [[7], [10], [6, 7]]],
+        '_label': ['person', 'person', 'person', 'person', 'person', 'person',
+                   'person', 'person'],
+    }
+    for i in range(len(nodes)):
+        node_id, node = nodes[i]
+        assert node_id == "%s_%d" % (node['_label'], node['_id']['offset'])
+        for key in ground_truth:
+            assert node[key] == ground_truth[key][i]
+
+
+def test_networkx_undirected(establish_connection):
+    conn, _ = establish_connection
+    res = conn.execute(
+        "MATCH (p1:person)-[r:knows]->(p2:person) WHERE p1.ID <= 3 RETURN p1, r, p2")
+
+    nx_graph = res.get_as_networkx(directed=False)
+    assert not nx_graph.is_directed()
+
+    nodes = list(nx_graph.nodes(data=True))
+    assert len(nodes) == 4
+
+    edges = list(nx_graph.edges(data=True))
+
+    ground_truth_p = {
+        'ID': [0, 2, 3, 5, 7, 8, 9, 10],
+        'fName': ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
+                  "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"],
+        'gender': [1, 2, 1, 2, 1, 2, 2, 2],
+        'isStudent': [True, True, False, False, False, True, False, False],
+        'eyeSight': [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9],
+        'birthdate': [datetime.date(1900, 1, 1), datetime.date(1900, 1, 1),
+                      datetime.date(1940, 6, 22), datetime.date(1950, 7, 23),
+                      datetime.date(1980, 10, 26), datetime.date(1980, 10, 26),
+                      datetime.date(1980, 10, 26), datetime.date(1990, 11, 27)],
+        'registerTime': [Timestamp('2011-08-20 11:25:30'),
+                         Timestamp('2008-11-03 15:25:30.000526'),
+                         Timestamp(
+            '1911-08-20 02:32:21'), Timestamp('2031-11-30 12:25:30'),
+            Timestamp('1976-12-23 11:21:42'),
+            Timestamp('1972-07-31 13:22:30.678559'),
+            Timestamp('1976-12-23 04:41:42'), Timestamp('2023-02-21 13:25:30')],
+        'lastJobDuration': [Timedelta('1082 days 13:02:00'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('2 days 00:24:11'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('2 days 00:24:11'), Timedelta(
+                                '0 days 00:18:00.024000'),
+                            Timedelta('3750 days 13:00:00.000024'),
+                            Timedelta('1082 days 13:02:00')],
+        'workedHours': [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
+                        [10, 11, 12, 3, 4, 5, 6, 7]],
+        'usedNames': [["Aida"], ['Bobby'], ['Carmen', 'Fred'],
+                      ['Wolfeschlegelstein', 'Daniel'], [
+                          'Ein'], ['Fesdwe'], ['Grad'],
+                      ['Ad', 'De', 'Hi', 'Kye', 'Orlan']],
+        'courseScoresPerTerm': [[[10, 8], [6, 7, 8]], [[8, 9], [9, 10]], [[8, 10]],
+                                [[7, 4], [8, 8], [9]], [
+                                    [6], [7], [8]], [[8]], [[10]],
+                                [[7], [10], [6, 7]]],
+        '_label': ['person', 'person', 'person', 'person', 'person', 'person',
+                   'person', 'person'],
+    }
+    for (node_id, node) in nodes:
+        assert node_id == "%s_%d" % (node['_label'], node['_id']['offset'])
+
+    for (_, node) in nodes:
+        found = False
+        for i in range(len(ground_truth_p['ID'])):
+            if node['ID'] != ground_truth_p['ID'][i]:
+                continue
+            found = True
+            for key in ground_truth_p:
+                assert node[key] == ground_truth_p[key][i]
+        assert found
+
+    assert len(edges) == 6
+    # This should be a complete graph, so we check if an edge exists between
+    # every pair of nodes and that there are no self-loops
+    for i in range(len(nodes)):
+        assert not nx_graph.has_edge(nodes[i][0], nodes[i][0])
+        for j in range(i + 1, len(nodes)):
+            assert nx_graph.has_edge(nodes[i][0], nodes[j][0])
+
+
+def test_networkx_directed(establish_connection):
+    conn, _ = establish_connection
+    res = conn.execute(
+        "MATCH (p:person)-[r:workAt]->(o:organisation) RETURN p, r, o")
+
+    nx_graph = res.get_as_networkx(directed=True)
+    assert nx_graph.is_directed()
+
+    nodes = list(nx_graph.nodes(data=True))
+    assert len(nodes) == 3
+
+    edges = list(nx_graph.edges(data=True))
+
+    ground_truth_p = {
+        'ID': [5, 7],
+        'fName': ["Dan", "Elizabeth"],
+        'gender': [2, 1],
+        'isStudent': [False, False],
+        'eyeSight': [4.8, 4.7],
+        'birthdate': [datetime.date(1950, 7, 23),
+                      datetime.date(1980, 10, 26)],
+        'registerTime': [Timestamp('2031-11-30 12:25:30'),
+                         Timestamp('1976-12-23 11:21:42')
+                         ],
+        'lastJobDuration': [
+            Timedelta('3750 days 13:00:00.000024'),
+            Timedelta('2 days 00:24:11')],
+        'workedHours': [[1, 9], [2]],
+        'usedNames': [
+            ['Wolfeschlegelstein', 'Daniel'], [
+                'Ein']],
+        'courseScoresPerTerm': [
+            [[7, 4], [8, 8], [9]], [
+                [6], [7], [8]]],
+        '_label': ['person', 'person'],
+    }
+
+    for (node_id, node) in nodes:
+        assert node_id == "%s_%d" % (node['_label'], node['_id']['offset'])
+
+    for (_, node) in nodes:
+        if 'person' not in node:
+            continue
+        found = False
+        for i in range(len(ground_truth_p['ID'])):
+            if node['ID'] != ground_truth_p['ID'][i]:
+                continue
+            found = True
+            for key in ground_truth_p:
+                assert node[key] == ground_truth_p[key][i]
+        assert found
+
+    ground_truth_o = {'ID': [6],
+                      'name': ['DEsWork'],
+                      'orgCode': [824],
+                      'mark': [4.1],
+                      'score': [7],
+                      'history': ['2 years 4 hours 22 us 34 minutes'],
+                      'licenseValidInterval': [Timedelta(days=3, seconds=36000, microseconds=100000)],
+                      'rating': [0.52],
+                      '_label': ['organisation'],
+                      }
+
+    for (_, node) in nodes:
+        if 'organisation' not in node:
+            continue
+        found = False
+        for i in range(len(ground_truth_o['ID'])):
+            if node['ID'] != ground_truth_o['ID'][i]:
+                continue
+            found = True
+            for key in ground_truth_o:
+                assert node[key] == ground_truth_o[key][i]
+        assert found
+
+    nodes_dict = dict(nx_graph.nodes(data=True))
+    edges = list(nx_graph.edges(data=True))
+    assert len(edges) == 2
+
+    years_ground_truth = [2010, 2015]
+    for (src, dst, edge) in edges:
+        assert nodes_dict[dst]['_label'] == 'organisation'
+        assert nodes_dict[dst]['ID'] == 6
+
+        assert nodes_dict[src]['_label'] == 'person'
+        assert nodes_dict[src]['ID'] in [5, 7]
+        assert edge['year'] in years_ground_truth
+
+        # If the edge is found, remove it from ground truth so we can check
+        # that all edges were found and no extra edges were found
+        del years_ground_truth[years_ground_truth.index(edge['year'])]
+        del nodes_dict[src]
+
+    assert len(years_ground_truth) == 0
+    assert len(nodes_dict) == 1  # Only the organisation node should be left


### PR DESCRIPTION
This PR does the following:
- Add Python binding for new NODE and REL type introduced in #1168. The NODE and REL types are returned as Python dicts.
- Add a new API `get_as_networkx()`, which converts the query results as NetworkX graph.
- Split C++ and Python tests.
- Fix #1173 and add a binding for the user to manually reset the iterators.