### PR TITLE
Export query result (fixed sized values only) to arrow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,13 @@ pytest: arrow
 	cd $(ROOT_DIR)/tools/python_api/test && \
 	python3 -m pytest -v test_main.py
 
+clean-python-api:
+	rm -rf tools/python_api/build
+
 clean-external:
 	rm -rf external/build
 
-clean:
+clean: clean-python-api
 	rm -rf build
 
 clean-all: clean-external clean

--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(arrow)
 add_subdirectory(csv_reader)
 add_subdirectory(data_chunk)
 add_subdirectory(task_system)

--- a/src/common/arrow/CMakeLists.txt
+++ b/src/common/arrow/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(kuzu_common_arrow
+        OBJECT
+        arrow_row_batch.cpp
+        arrow_converter.cpp)
+
+set(ALL_OBJECT_FILES
+        ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_common_arrow>
+        PARENT_SCOPE)

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -1,0 +1,100 @@
+#include "common/arrow/arrow_converter.h"
+
+#include "common/arrow/arrow_row_batch.h"
+
+namespace kuzu {
+namespace common {
+
+struct ArrowSchemaHolder {
+    vector<ArrowSchema> children;
+    vector<ArrowSchema*> childrenPtrs;
+    vector<unique_ptr<char[]>> ownedTypeNames;
+};
+
+static void releaseArrowSchema(ArrowSchema* schema) {
+    if (!schema || schema->release) {
+        return;
+    }
+    schema->release = nullptr;
+    auto holder = static_cast<ArrowSchemaHolder*>(schema->private_data);
+    delete holder;
+}
+
+static void initializeChild(ArrowSchema& child, const string& name = "") {
+    //! Child is cleaned up by parent
+    child.private_data = nullptr;
+    child.release = releaseArrowSchema;
+
+    //! Store the child schema
+    child.flags = ARROW_FLAG_NULLABLE;
+    child.name = name.c_str();
+    child.n_children = 0;
+    child.children = nullptr;
+    child.metadata = nullptr;
+    child.dictionary = nullptr;
+}
+
+static void setArrowFormat(ArrowSchema& child, const DataType& type) {
+    switch (type.typeID) {
+    case DataTypeID::BOOL: {
+        child.format = "b";
+    } break;
+    case DataTypeID::INT64: {
+        child.format = "l";
+    } break;
+    case DataTypeID::DOUBLE: {
+        child.format = "g";
+    } break;
+    case DataTypeID::DATE: {
+        child.format = "tdD";
+    } break;
+    case DataTypeID::TIMESTAMP: {
+        child.format = "tsu:";
+    } break;
+    case DataTypeID::INTERVAL: {
+        child.format = "tDm";
+    } break;
+    default:
+        throw InternalException("Unsupported Arrow type " + Types::dataTypeToString(type));
+    }
+}
+
+void ArrowConverter::toArrowSchema(
+    ArrowSchema* outSchema, std::vector<DataType>& types, std::vector<std::string>& names) {
+    assert(outSchema && types.size() == names.size());
+    auto rootHolder = make_unique<ArrowSchemaHolder>();
+
+    auto columnCount = (int64_t)names.size();
+    rootHolder->children.resize(columnCount);
+    rootHolder->childrenPtrs.resize(columnCount);
+    for (auto i = 0u; i < columnCount; i++) {
+        rootHolder->childrenPtrs[i] = &rootHolder->children[i];
+    }
+    outSchema->children = rootHolder->childrenPtrs.data();
+    outSchema->n_children = columnCount;
+
+    outSchema->format = "+s"; // struct apparently
+    outSchema->flags = 0;
+    outSchema->metadata = nullptr;
+    outSchema->name = "kuzu_query_result";
+    outSchema->dictionary = nullptr;
+
+    for (auto i = 0u; i < columnCount; i++) {
+        auto& child = rootHolder->children[i];
+        initializeChild(child, names[i]);
+        setArrowFormat(child, types[i]);
+    }
+
+    outSchema->private_data = rootHolder.release();
+    outSchema->release = releaseArrowSchema;
+}
+
+void ArrowConverter::toArrowArray(
+    main::QueryResult& queryResult, ArrowArray* outArray, std::int64_t chunkSize) {
+    auto types = queryResult.getColumnDataTypes();
+    auto rowBatch = make_unique<ArrowRowBatch>(types, chunkSize);
+    *outArray = rowBatch->append(queryResult, chunkSize);
+}
+
+} // namespace common
+} // namespace kuzu

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -1,0 +1,147 @@
+#include "common/arrow/arrow_row_batch.h"
+
+ArrowRowBatch::ArrowRowBatch(std::vector<DataType> types, std::int64_t capacity)
+    : types{std::move(types)} {
+    auto numVectors = this->types.size();
+    vectors.resize(numVectors);
+    for (auto i = 0u; i < numVectors; i++) {
+        vectors[i] = make_unique<ArrowVector>();
+        initializeArrowVector(vectors[i].get(), this->types[i], capacity);
+    }
+}
+
+void ArrowRowBatch::initializeArrowVector(
+    ArrowVector* vector, const DataType& type, std::int64_t capacity) {
+    auto numBytesForValidity = getNumBytesForBits(capacity);
+    vector->validity.resize(numBytesForValidity, 0xFF);
+    std::int64_t numBytesForData = 0;
+    if (type.typeID == BOOL) {
+        numBytesForData = getNumBytesForBits(capacity);
+    } else {
+        numBytesForData = Types::getDataTypeSize(type) * capacity;
+    }
+    vector->data.reserve(numBytesForData);
+}
+
+static void getBitPosition(std::int64_t pos, std::int64_t& bytePos, std::int64_t& bitOffset) {
+    bytePos = pos / 8;
+    bitOffset = pos % 8;
+}
+
+static void setBitToZero(std::uint8_t* data, std::int64_t pos) {
+    std::int64_t bytePos, bitOffset;
+    getBitPosition(pos, bytePos, bitOffset);
+    data[bytePos] &= ~((std::uint64_t)1 << bitOffset);
+}
+
+static void setBitToOne(std::uint8_t* data, std::int64_t pos) {
+    std::int64_t bytePos, bitOffset;
+    getBitPosition(pos, bytePos, bitOffset);
+    data[bytePos] |= ((std::uint64_t)1 << bitOffset);
+}
+
+void ArrowRowBatch::setValue(ArrowVector* vector, Value* value, std::int64_t pos) {
+    if (value->isNull_) {
+        setBitToZero(vector->validity.data(), pos);
+        vector->numNulls++;
+        return;
+    }
+    switch (value->dataType.typeID) {
+    case BOOL: {
+        if (value->val.booleanVal) {
+            setBitToOne(vector->data.data(), pos);
+        } else {
+            setBitToZero(vector->data.data(), pos);
+        }
+    } break;
+    case INT64: {
+        ((std::int64_t*)vector->data.data())[pos] = value->val.int64Val;
+    } break;
+    case DOUBLE: {
+        ((std::double_t*)vector->data.data())[pos] = value->val.doubleVal;
+    } break;
+    case DATE: {
+        ((date_t*)vector->data.data())[pos] = value->val.dateVal;
+    } break;
+    case TIMESTAMP: {
+        ((timestamp_t*)vector->data.data())[pos] = value->val.timestampVal;
+    } break;
+    case INTERVAL: {
+        ((interval_t*)vector->data.data())[pos] = value->val.intervalVal;
+    } break;
+    default: {
+        throw RuntimeException("Data type " + Types::dataTypeToString(value->dataType) +
+                               " is not supported for arrow exportation.");
+    }
+    }
+}
+
+static void releaseArrowVector(ArrowArray* array) {
+    if (!array || !array->release) {
+        return;
+    }
+    array->release = nullptr;
+    auto holder = static_cast<ArrowVector*>(array->private_data);
+    delete holder;
+}
+
+ArrowArray* ArrowRowBatch::finalizeArrowChild(const DataType& type, ArrowVector& vector) {
+    auto result = make_unique<ArrowArray>();
+
+    result->private_data = nullptr;
+    result->release = releaseArrowVector;
+    result->n_children = 0;
+    result->offset = 0;
+    result->dictionary = nullptr;
+    result->buffers = vector.buffers.data();
+    result->null_count = vector.numNulls;
+    result->length = vector.numValues;
+    result->buffers[0] = vector.validity.data();
+    result->buffers[1] = vector.data.data();
+    result->n_buffers = 2;
+
+    vector.array = std::move(result);
+    return vector.array.get();
+}
+
+ArrowArray ArrowRowBatch::finalize() {
+    auto rootHolder = make_unique<ArrowVector>();
+    ArrowArray result;
+    rootHolder->childPointers.resize(types.size());
+    result.children = rootHolder->childPointers.data();
+    result.n_children = (std::int64_t)types.size();
+    result.length = numRows;
+    result.n_buffers = 1;
+    result.buffers = rootHolder->buffers.data(); // no actual buffer
+    result.offset = 0;
+    result.null_count = 0;
+    result.dictionary = nullptr;
+    rootHolder->childData = std::move(vectors);
+    for (auto i = 0u; i < rootHolder->childData.size(); i++) {
+        rootHolder->childPointers[i] = finalizeArrowChild(types[i], *rootHolder->childData[i]);
+    }
+
+    result.private_data = rootHolder.release();
+    result.release = releaseArrowVector;
+    return result;
+}
+
+ArrowArray ArrowRowBatch::append(main::QueryResult& queryResult, std::int64_t chunkSize) {
+    std::int64_t numTuples = 0;
+    auto numColumns = queryResult.getColumnNames().size();
+    while (numTuples < chunkSize) {
+        if (!queryResult.hasNext()) {
+            break;
+        }
+        auto tuple = queryResult.getNext();
+        for (auto i = 0u; i < numColumns; i++) {
+            setValue(vectors[i].get(), tuple->getValue(i), numTuples);
+        }
+        numTuples++;
+    }
+    for (auto i = 0u; i < numColumns; i++) {
+        vectors[i]->numValues = numTuples;
+    }
+    numRows = numTuples;
+    return finalize();
+}

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -27,11 +27,5 @@ vector<string> StringUtils::split(const string& input, const string& delimiter) 
     return result;
 }
 
-string ThreadUtils::getThreadIDString() {
-    std::ostringstream oss;
-    oss << std::this_thread::get_id();
-    return oss.str();
-}
-
 } // namespace common
 } // namespace kuzu

--- a/src/include/common/arrow/arrow.h
+++ b/src/include/common/arrow/arrow.h
@@ -1,0 +1,56 @@
+#pragma once
+
+// The Arrow C data interface.
+// https://arrow.apache.org/docs/format/CDataInterface.html
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef ARROW_C_DATA_INTERFACE
+#define ARROW_C_DATA_INTERFACE
+
+#define ARROW_FLAG_DICTIONARY_ORDERED 1
+#define ARROW_FLAG_NULLABLE 2
+#define ARROW_FLAG_MAP_KEYS_SORTED 4
+
+struct ArrowSchema {
+    // Array type description
+    const char* format;
+    const char* name;
+    const char* metadata;
+    int64_t flags;
+    int64_t n_children;
+    struct ArrowSchema** children;
+    struct ArrowSchema* dictionary;
+
+    // Release callback
+    void (*release)(struct ArrowSchema*);
+    // Opaque producer-specific data
+    void* private_data;
+};
+
+struct ArrowArray {
+    // Array data description
+    int64_t length;
+    int64_t null_count;
+    int64_t offset;
+    int64_t n_buffers;
+    int64_t n_children;
+    const void** buffers;
+    struct ArrowArray** children;
+    struct ArrowArray* dictionary;
+
+    // Release callback
+    void (*release)(struct ArrowArray*);
+    // Opaque producer-specific data
+    void* private_data;
+};
+
+#endif // ARROW_C_DATA_INTERFACE
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/include/common/arrow/arrow_buffer.h
+++ b/src/include/common/arrow/arrow_buffer.h
@@ -1,0 +1,83 @@
+#pragma once
+
+#include "common/utils.h"
+
+struct ArrowSchema;
+
+namespace kuzu {
+namespace common {
+
+struct ArrowBuffer {
+    ArrowBuffer() : dataptr(nullptr), count(0), capacity(0) {}
+    ~ArrowBuffer() {
+        if (!dataptr) {
+            return;
+        }
+        free(dataptr);
+        dataptr = nullptr;
+        count = 0;
+        capacity = 0;
+    }
+    // disable copy constructors
+    ArrowBuffer(const ArrowBuffer& other) = delete;
+    ArrowBuffer& operator=(const ArrowBuffer&) = delete;
+    //! enable move constructors
+    ArrowBuffer(ArrowBuffer&& other) noexcept {
+        std::swap(dataptr, other.dataptr);
+        std::swap(count, other.count);
+        std::swap(capacity, other.capacity);
+    }
+    ArrowBuffer& operator=(ArrowBuffer&& other) noexcept {
+        std::swap(dataptr, other.dataptr);
+        std::swap(count, other.count);
+        std::swap(capacity, other.capacity);
+        return *this;
+    }
+
+    void reserve(uint64_t bytes) { // NOLINT
+        auto new_capacity = nextPowerOfTwo(bytes);
+        if (new_capacity <= capacity) {
+            return;
+        }
+        reserveInternal(new_capacity);
+    }
+
+    void resize(uint64_t bytes) { // NOLINT
+        reserve(bytes);
+        count = bytes;
+    }
+
+    void resize(uint64_t bytes, uint8_t value) { // NOLINT
+        reserve(bytes);
+        for (uint64_t i = count; i < bytes; i++) {
+            dataptr[i] = value;
+        }
+        count = bytes;
+    }
+
+    uint64_t size() { // NOLINT
+        return count;
+    }
+
+    uint8_t* data() { // NOLINT
+        return dataptr;
+    }
+
+private:
+    void reserveInternal(uint64_t bytes) {
+        if (dataptr) {
+            dataptr = (uint8_t*)realloc(dataptr, bytes);
+        } else {
+            dataptr = (uint8_t*)malloc(bytes);
+        }
+        capacity = bytes;
+    }
+
+private:
+    uint8_t* dataptr = nullptr;
+    uint64_t count = 0;
+    uint64_t capacity = 0;
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/include/common/arrow/arrow_converter.h
+++ b/src/include/common/arrow/arrow_converter.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "common/arrow/arrow.h"
+#include "common/types/types.h"
+#include "main/query_result.h"
+
+struct ArrowSchema;
+
+namespace kuzu {
+namespace common {
+
+struct ArrowConverter {
+    static void toArrowSchema(
+        ArrowSchema* out_schema, std::vector<DataType>& types, std::vector<std::string>& names);
+    static void toArrowArray(
+        main::QueryResult& queryResult, ArrowArray* out_array, std::int64_t chunkSize);
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/include/common/arrow/arrow_row_batch.h
+++ b/src/include/common/arrow/arrow_row_batch.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <array>
+#include <vector>
+
+#include "common/arrow/arrow.h"
+#include "common/arrow/arrow_buffer.h"
+#include "common/types/types.h"
+#include "main/query_result.h"
+
+struct ArrowSchema;
+
+namespace kuzu {
+namespace common {
+
+// An Arrow Vector(i.e., Array) is defined by a few pieces of metadata and data:
+//  1) a logical data type;
+//  2) a sequence of buffers: validity bitmaps, data buffer, offsets(optional), children(optional).
+//  3) a length as a 64-bit signed integer;
+//  4) a null count as a 64-bit signed integer;
+//  5) an optional dictionary for dictionary-encoded arrays.
+// See https://arrow.apache.org/docs/format/Columnar.html for more details.
+
+static inline std::int64_t getNumBytesForBits(std::int64_t numBits) {
+    return (numBits + 7) / 8;
+}
+
+struct ArrowVector {
+    ArrowBuffer data;
+    ArrowBuffer validity;
+
+    std::int64_t numValues = 0;
+    std::int64_t numNulls = 0;
+
+    std::vector<std::unique_ptr<ArrowVector>> childData;
+
+    // The arrow array C API data, only set after Finalize
+    std::unique_ptr<ArrowArray> array;
+    std::array<const void*, 3> buffers = {{nullptr, nullptr, nullptr}};
+    std::vector<ArrowArray*> childPointers;
+};
+
+// An arrow data chunk consisting of N rows in columnar format.
+class ArrowRowBatch {
+public:
+    ArrowRowBatch(std::vector<DataType> types, std::int64_t capacity);
+
+    //! Append a data chunk to the underlying arrow array
+    ArrowArray append(main::QueryResult& queryResult, std::int64_t chunkSize);
+
+private:
+    static void initializeArrowVector(
+        ArrowVector* vector, const DataType& type, std::int64_t capacity);
+    static void setValue(ArrowVector* vector, Value* value, std::int64_t pos);
+    static ArrowArray* finalizeArrowChild(const DataType& type, ArrowVector& rowBatch);
+
+    ArrowArray finalize();
+
+private:
+    std::vector<DataType> types;
+    std::vector<std::unique_ptr<ArrowVector>> vectors;
+    std::int64_t numRows = 0;
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/include/common/csv_reader/csv_reader.h
+++ b/src/include/common/csv_reader/csv_reader.h
@@ -48,9 +48,7 @@ struct CopyDescription {
     FileType fileType;
 };
 
-// TODO(Guodong): we should add a csv reader test to test edge cases and error messages.
-// Iterator-like interface to read one block in a CSV file line-by-line while parsing into primitive
-// dataTypes.
+// TODO(Guodong): Remove this class and file and related code.
 class CSVReader {
 
 public:

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -10,8 +10,6 @@
 
 #include "exception.h"
 
-using namespace std;
-
 namespace spdlog {
 class logger;
 }
@@ -80,27 +78,17 @@ public:
     }
 };
 
-class ThreadUtils {
-
-public:
-    static string getThreadIDString();
-};
-
-class HashTableUtils {
-
-public:
-    static uint64_t nextPowerOfTwo(uint64_t v) {
-        v--;
-        v |= v >> 1;
-        v |= v >> 2;
-        v |= v >> 4;
-        v |= v >> 8;
-        v |= v >> 16;
-        v |= v >> 32;
-        v++;
-        return v;
-    }
-};
+static uint64_t nextPowerOfTwo(uint64_t v) {
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
+    v |= v >> 32;
+    v++;
+    return v;
+}
 
 } // namespace common
 } // namespace kuzu

--- a/src/include/processor/result/flat_tuple.h
+++ b/src/include/processor/result/flat_tuple.h
@@ -11,8 +11,7 @@ public:
 
     inline uint32_t len() { return values.size(); }
 
-    // TODO(Everyone): rename this to get.
-    common::Value* getResultValue(uint32_t idx);
+    common::Value* getValue(uint32_t idx);
 
     string toString(
         const vector<uint32_t>& colsWidth, const string& delimiter = "|", uint32_t maxWidth = -1);

--- a/src/include/processor/result/result_set.h
+++ b/src/include/processor/result/result_set.h
@@ -5,9 +5,6 @@
 #include "common/data_chunk/data_chunk.h"
 #include "processor/data_pos.h"
 
-using namespace kuzu::common;
-using namespace kuzu::storage;
-
 namespace kuzu {
 namespace processor {
 

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -99,10 +99,9 @@ void QueryResult::writeToCSV(
     while (hasNext()) {
         nextTuple = getNext();
         for (auto idx = 0ul; idx < nextTuple->len(); idx++) {
-            string resultVal = nextTuple->getResultValue(idx)->toString();
+            string resultVal = nextTuple->getValue(idx)->toString();
             bool isStringList = false;
-            if (Types::dataTypeToString(nextTuple->getResultValue(idx)->getDataType()) ==
-                "STRING[]") {
+            if (Types::dataTypeToString(nextTuple->getValue(idx)->getDataType()) == "STRING[]") {
                 isStringList = true;
             }
             bool surroundQuotes = false;

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -168,11 +168,10 @@ void AggregateHashTable::initializeFT(const vector<unique_ptr<AggregateFunction>
 }
 
 void AggregateHashTable::initializeHashTable(uint64_t numEntriesToAllocate) {
-    maxNumHashSlots = HashTableUtils::nextPowerOfTwo(
-        max(LARGE_PAGE_SIZE / sizeof(HashSlot), numEntriesToAllocate));
+    maxNumHashSlots = nextPowerOfTwo(max(LARGE_PAGE_SIZE / sizeof(HashSlot), numEntriesToAllocate));
     bitmask = maxNumHashSlots - 1;
     auto numHashSlotsPerBlock = LARGE_PAGE_SIZE / sizeof(HashSlot);
-    assert(numHashSlotsPerBlock == HashTableUtils::nextPowerOfTwo(numHashSlotsPerBlock));
+    assert(numHashSlotsPerBlock == nextPowerOfTwo(numHashSlotsPerBlock));
     numSlotsPerBlockLog2 = log2(numHashSlotsPerBlock);
     slotIdxInBlockMask = BitmaskUtils::all1sMaskForLeastSignificantBits(numSlotsPerBlockLog2);
     auto numDataBlocks =

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -6,20 +6,20 @@ namespace processor {
 void HashAggregateSharedState::appendAggregateHashTable(
     unique_ptr<AggregateHashTable> aggregateHashTable) {
     auto lck = acquireLock();
-    localAggregateHashTables.push_back(move(aggregateHashTable));
+    localAggregateHashTables.push_back(std::move(aggregateHashTable));
 }
 
 void HashAggregateSharedState::combineAggregateHashTable(MemoryManager& memoryManager) {
     auto lck = acquireLock();
     if (localAggregateHashTables.size() == 1) {
-        globalAggregateHashTable = move(localAggregateHashTables[0]);
+        globalAggregateHashTable = std::move(localAggregateHashTables[0]);
     } else {
         auto numEntries = 0u;
         for (auto& ht : localAggregateHashTables) {
             numEntries += ht->getNumEntries();
         }
-        localAggregateHashTables[0]->resize(HashTableUtils::nextPowerOfTwo(numEntries));
-        globalAggregateHashTable = move(localAggregateHashTables[0]);
+        localAggregateHashTables[0]->resize(nextPowerOfTwo(numEntries));
+        globalAggregateHashTable = std::move(localAggregateHashTables[0]);
         for (auto i = 1u; i < localAggregateHashTables.size(); i++) {
             globalAggregateHashTable->merge(*localAggregateHashTables[i]);
         }
@@ -70,7 +70,7 @@ void HashAggregate::executeInternal(ExecutionContext* context) {
         localAggregateHashTable->append(groupByFlatHashKeyVectors, groupByUnflatHashKeyVectors,
             groupByNonHashKeyVectors, aggregateVectors, resultSet->multiplicity);
     }
-    sharedState->appendAggregateHashTable(move(localAggregateHashTable));
+    sharedState->appendAggregateHashTable(std::move(localAggregateHashTable));
 }
 
 void HashAggregate::finalize(ExecutionContext* context) {

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -9,7 +9,7 @@ JoinHashTable::JoinHashTable(MemoryManager& memoryManager, uint64_t numKeyColumn
     unique_ptr<FactorizedTableSchema> tableSchema)
     : BaseHashTable{memoryManager}, numKeyColumns{numKeyColumns} {
     auto numSlotsPerBlock = LARGE_PAGE_SIZE / sizeof(uint8_t*);
-    assert(numSlotsPerBlock == HashTableUtils::nextPowerOfTwo(numSlotsPerBlock));
+    assert(numSlotsPerBlock == nextPowerOfTwo(numSlotsPerBlock));
     numSlotsPerBlockLog2 = log2(numSlotsPerBlock);
     slotIdxInBlockMask = BitmaskUtils::all1sMaskForLeastSignificantBits(numSlotsPerBlockLog2);
     // Prev pointer is always the last column in the table.
@@ -55,7 +55,7 @@ void JoinHashTable::append(const vector<shared_ptr<ValueVector>>& vectorsToAppen
 }
 
 void JoinHashTable::allocateHashSlots(uint64_t numTuples) {
-    maxNumHashSlots = HashTableUtils::nextPowerOfTwo(numTuples * 2);
+    maxNumHashSlots = nextPowerOfTwo(numTuples * 2);
     bitmask = maxNumHashSlots - 1;
     auto numSlotsPerBlock = (uint64_t)1 << numSlotsPerBlockLog2;
     auto numBlocksNeeded = (maxNumHashSlots + numSlotsPerBlock - 1) / numSlotsPerBlock;

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -8,7 +8,7 @@ using namespace kuzu::utf8proc;
 namespace kuzu {
 namespace processor {
 
-common::Value* FlatTuple::getResultValue(uint32_t idx) {
+common::Value* FlatTuple::getValue(uint32_t idx) {
     if (idx >= len()) {
         throw common::RuntimeException(common::StringUtils::string_format(
             "ValIdx is out of range. Number of values in flatTuple: %d, valIdx: %d.", len(), idx));

--- a/test/include/main_test_helper/main_test_helper.h
+++ b/test/include/main_test_helper/main_test_helper.h
@@ -22,7 +22,7 @@ public:
         auto result = conn->query("MATCH (a:person) RETURN COUNT(*)");
         ASSERT_TRUE(result->hasNext());
         auto tuple = result->getNext();
-        ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 8);
+        ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 8);
         ASSERT_FALSE(result->hasNext());
     }
 };

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -9,7 +9,7 @@ TEST_F(ApiTest, MultiParamsPrepare) {
         preparedStatement.get(), make_pair(string("n"), "A"), make_pair(string("xx"), "ooq"));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 2);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 2);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -19,7 +19,7 @@ TEST_F(ApiTest, PrepareBool) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("1"), true));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 3);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 3);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -28,7 +28,7 @@ TEST_F(ApiTest, PrepareInt) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("1"), (int64_t)10));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 45);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 45);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -38,7 +38,7 @@ TEST_F(ApiTest, PrepareDouble) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("1"), (double_t)10.5));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<double>(), 15.5);
+    ASSERT_EQ(tuple->getValue(0)->getValue<double>(), 15.5);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -48,7 +48,7 @@ TEST_F(ApiTest, PrepareString) {
     auto result = conn->execute(preparedStatement.get(), make_pair(string("n"), "A"));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 1);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 1);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -59,7 +59,7 @@ TEST_F(ApiTest, PrepareDate) {
         conn->execute(preparedStatement.get(), make_pair(string("n"), Date::FromDate(1900, 1, 1)));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 2);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 2);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -72,7 +72,7 @@ TEST_F(ApiTest, PrepareTimestamp) {
         preparedStatement.get(), make_pair(string("n"), Timestamp::FromDatetime(date, time)));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 1);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 1);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -84,7 +84,7 @@ TEST_F(ApiTest, PrepareInterval) {
         make_pair(string("n"), Interval::FromCString(intervalStr.c_str(), intervalStr.length())));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 2);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 2);
     ASSERT_FALSE(result->hasNext());
 }
 
@@ -94,7 +94,7 @@ TEST_F(ApiTest, DefaultParam) {
         make_pair(string("2"), (int64_t)1.4));
     ASSERT_TRUE(result->hasNext());
     auto tuple = result->getNext();
-    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 8);
+    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 8);
     ASSERT_FALSE(result->hasNext());
 }
 

--- a/test/main/result_value_test.cpp
+++ b/test/main/result_value_test.cpp
@@ -26,7 +26,7 @@ TEST_F(ResultValueTest, getResultValueException) {
     auto result = conn->query(query);
     auto flatTuple = result->getNext();
     try {
-        flatTuple->getResultValue(100);
+        flatTuple->getValue(100);
         FAIL();
     } catch (RuntimeException& exception) {
         ASSERT_STREQ("Runtime exception: ValIdx is out of range. Number of values in flatTuple: 1, "
@@ -42,7 +42,7 @@ TEST_F(ResultValueTest, getResultValueWrongTypeException) {
     auto result = conn->query(query);
     auto flatTuple = result->getNext();
     try {
-        flatTuple->getResultValue(0)->getValue<bool>();
+        flatTuple->getValue(0)->getValue<bool>();
         FAIL();
     } catch (RuntimeException& exception) {
         ASSERT_STREQ("Runtime exception: Cannot get BOOL value from the STRING result value.",

--- a/test/runner/e2e_copy_transaction_test.cpp
+++ b/test/runner/e2e_copy_transaction_test.cpp
@@ -31,7 +31,7 @@ public:
         auto queryResult = conn->query("match (p:person) return p.age");
         while (queryResult->hasNext()) {
             auto tuple = queryResult->getNext();
-            actualResult.insert(tuple->getResultValue(0)->getValue<int64_t>());
+            actualResult.insert(tuple->getValue(0)->getValue<int64_t>());
         }
         ASSERT_EQ(expectedResult, actualResult);
     }
@@ -117,7 +117,7 @@ public:
         auto queryResult = conn->query("match (:person)-[e:knows]->(:person) return e.date");
         while (queryResult->hasNext()) {
             auto tuple = queryResult->getNext();
-            actualResult.insert(tuple->getResultValue(0)->getValue<date_t>());
+            actualResult.insert(tuple->getValue(0)->getValue<date_t>());
         }
         ASSERT_EQ(expectedResult, actualResult);
     }

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -38,9 +38,9 @@ public:
         // Edge is from 0->1, and when the primary key is firstIntCol, we expect to find 1 result.
         // If key is secondIntCol we expect to find 0 result.
         if (pkColName == "firstIntCol") {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 1);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 1);
         } else {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 0);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 0);
         }
         tuple = conn->query("MATCH (a:Person)-[e:Knows]->(b:Person) WHERE a.firstIntCol = 1 "
                             "RETURN COUNT(*)")
@@ -48,9 +48,9 @@ public:
         // Edge is from 0->1, and when the primary key is firstIntCol, we expect to find 0 result.
         // If key is secondIntCol we expect to find 1 result.
         if (pkColName == "firstIntCol") {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 0);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 0);
         } else {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 1);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 1);
         }
     }
 };
@@ -79,9 +79,9 @@ public:
         // Edge is from "Alice"->"Bob", and when the primary key is firstStrCol, we expect to find 1
         // result. If key is secondStrCol we expect to find 0 result.
         if (pkColName == "firstStrCol") {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 1);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 1);
         } else {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 0);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 0);
         }
         tuple = conn->query("MATCH (a:Person)-[e:Knows]->(b:Person) WHERE a.firstStrCol = \"Bob\" "
                             "RETURN COUNT(*)")
@@ -89,9 +89,9 @@ public:
         // Edge is from "Alice"->"Bob", and when the primary key is firstStrCol, we expect to find 0
         // result. If key is secondStrCol we expect to find 1 result.
         if (pkColName == "firstStrCol") {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 0);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 0);
         } else {
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), 1);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), 1);
         }
     }
 };
@@ -396,7 +396,7 @@ public:
                 ->isSuccess());
         auto result = conn->query(StringUtils::string_format("MATCH (p:person) return p.random"));
         while (result->hasNext()) {
-            ASSERT_TRUE(result->getNext()->getResultValue(0 /* idx */)->isNull());
+            ASSERT_TRUE(result->getNext()->getValue(0 /* idx */)->isNull());
         }
     }
 
@@ -407,7 +407,7 @@ public:
         auto result = conn->query(
             StringUtils::string_format("MATCH (:person)-[e:knows]->(:person) return e.random"));
         while (result->hasNext()) {
-            ASSERT_TRUE(result->getNext()->getResultValue(0 /* idx */)->isNull());
+            ASSERT_TRUE(result->getNext()->getValue(0 /* idx */)->isNull());
         }
     }
 

--- a/test/runner/e2e_delete_create_transaction_test.cpp
+++ b/test/runner/e2e_delete_create_transaction_test.cpp
@@ -64,7 +64,7 @@ public:
     }
     static int64_t getCount(Connection* connection, const string& queryPrefix) {
         auto result = connection->query(queryPrefix + " RETURN COUNT(*)");
-        return result->getNext()->getResultValue(0)->getValue<int64_t>();
+        return result->getNext()->getValue(0)->getValue<int64_t>();
     }
     int64_t getNumNodes(Connection* connection) { return getCount(connection, "MATCH (:person)"); }
     void validateNodesExistOrNot(

--- a/test/runner/e2e_set_transaction_test.cpp
+++ b/test/runner/e2e_set_transaction_test.cpp
@@ -43,7 +43,7 @@ public:
                               to_string(numWriteQueries) + "))");
         }
         auto result = connection->query("MATCH (a:person) WHERE a.ID=2 RETURN a.fName");
-        ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<string>(),
+        ASSERT_EQ(result->getNext()->getValue(0)->getValue<string>(),
             "abcdefghijklmnopqrstuvwxyz" + to_string(numWriteQueries + 2));
     }
 };
@@ -153,7 +153,7 @@ TEST_F(SetNodeStructuredPropTransactionTest, SetNodeLongStringPropRollbackTest) 
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdefghijklmnopqrstuvwxyz'");
     conn->rollback();
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<string>(), "Alice");
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<string>(), "Alice");
 }
 
 TEST_F(SetNodeStructuredPropTransactionTest, SetVeryLongStringErrorsTest) {
@@ -171,7 +171,7 @@ TEST_F(SetNodeStructuredPropTransactionTest, SetManyNodeLongStringPropCommitTest
     insertLongStrings1000TimesAndVerify(conn.get());
     conn->commit();
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<string>(),
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<string>(),
         "abcdefghijklmnopqrstuvwxyz" + to_string(1000));
 }
 
@@ -180,5 +180,5 @@ TEST_F(SetNodeStructuredPropTransactionTest, SetManyNodeLongStringPropRollbackTe
     insertLongStrings1000TimesAndVerify(conn.get());
     conn->rollback();
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<string>(), "Alice");
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<string>(), "Alice");
 }

--- a/test/runner/e2e_update_node_test.cpp
+++ b/test/runner/e2e_update_node_test.cpp
@@ -22,66 +22,64 @@ public:
 TEST_F(TinySnbUpdateTest, SetNodeIntPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.age=20 + 50");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.age");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<int64_t>(), 70);
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 70);
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeDoublePropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.eyeSight=1.0");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.eyeSight");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<double>(), 1.0);
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<double>(), 1.0);
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeBoolPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.isStudent=false");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.isStudent");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<bool>(), false);
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<bool>(), false);
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeDatePropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.birthdate=date('2200-10-10')");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.birthdate");
-    ASSERT_EQ(
-        result->getNext()->getResultValue(0)->getValue<date_t>(), Date::FromDate(2200, 10, 10));
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<date_t>(), Date::FromDate(2200, 10, 10));
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeTimestampPropTest) {
     conn->query(
         "MATCH (a:person) WHERE a.ID=0 SET a.registerTime=timestamp('2200-10-10 12:01:01')");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.registerTime");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<timestamp_t>(),
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<timestamp_t>(),
         Timestamp::FromDatetime(Date::FromDate(2200, 10, 10), Time::FromTime(12, 1, 1)));
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeEmptyStringPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName=''");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<string>(), "");
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<string>(), "");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeShortStringPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdef'");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<string>(), "abcdef");
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<string>(), "abcdef");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeLongStringPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdefghijklmnopqrstuvwxyz'");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.fName");
-    ASSERT_EQ(
-        result->getNext()->getResultValue(0)->getValue<string>(), "abcdefghijklmnopqrstuvwxyz");
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<string>(), "abcdefghijklmnopqrstuvwxyz");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeListOfIntPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.workedHours=[10,20]");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.workedHours");
-    auto value = result->getNext()->getResultValue(0);
+    auto value = result->getNext()->getValue(0);
     ASSERT_EQ(value->toString(), "[10,20]");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeListOfShortStringPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['intel','microsoft']");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames");
-    auto value = result->getNext()->getResultValue(0);
+    auto value = result->getNext()->getValue(0);
     ASSERT_EQ(value->toString(), "[intel,microsoft]");
 }
 
@@ -89,14 +87,14 @@ TEST_F(TinySnbUpdateTest, SetNodeListOfLongStringPropTest) {
     conn->query(
         "MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames");
-    auto value = result->getNext()->getResultValue(0);
+    auto value = result->getNext()->getValue(0);
     ASSERT_EQ(value->toString(), "[abcndwjbwesdsd,microsofthbbjuwgedsd]");
 }
 
 TEST_F(TinySnbUpdateTest, SetNodeListofListPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=8 SET a.courseScoresPerTerm=[[10,20],[0,0,0]]");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=8 RETURN a.courseScoresPerTerm");
-    auto value = result->getNext()->getResultValue(0);
+    auto value = result->getNext()->getValue(0);
     ASSERT_EQ(value->toString(), "[[10,20],[0,0,0]]");
 }
 
@@ -111,7 +109,7 @@ TEST_F(TinySnbUpdateTest, SetNodeIntervalPropTest) {
     conn->query("MATCH (a:person) WHERE a.ID=0 SET a.lastJobDuration=interval('1 years 1 days')");
     auto result = conn->query("MATCH (a:person) WHERE a.ID=0 RETURN a.lastJobDuration");
     string intervalStr = "1 years 1 days";
-    ASSERT_EQ(result->getNext()->getResultValue(0)->getValue<interval_t>(),
+    ASSERT_EQ(result->getNext()->getValue(0)->getValue<interval_t>(),
         Interval::FromCString(intervalStr.c_str(), intervalStr.length()));
 }
 

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -89,34 +89,34 @@ TEST_F(NodeInsertionDeletionTests, DeleteAddMixedTest) {
     }
 
     string query = "MATCH (a:person) RETURN count(*)";
-    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 10010);
-    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 10000);
+    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 10010);
+    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 10000);
     conn->commit();
     conn->beginWriteTransaction();
-    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 10010);
-    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 10010);
+    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 10010);
+    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 10010);
 
     for (node_offset_t nodeOffset = 0; nodeOffset < 10010; ++nodeOffset) {
         personNodeTable->getNodeStatisticsAndDeletedIDs()->deleteNode(
             personNodeTable->getTableID(), nodeOffset);
     }
 
-    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 0);
-    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 10010);
+    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 0);
+    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 10010);
     conn->commit();
     conn->beginWriteTransaction();
-    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 0);
-    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 0);
+    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 0);
+    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 0);
 
     for (int i = 0; i < 5000; ++i) {
         auto nodeOffset = addNode();
         ASSERT_TRUE(nodeOffset >= 0 && nodeOffset < 10010);
     }
 
-    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 5000);
-    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 0);
+    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 5000);
+    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 0);
     conn->commit();
     conn->beginWriteTransaction();
-    ASSERT_EQ(conn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 5000);
-    ASSERT_EQ(readConn->query(query)->getNext()->getResultValue(0)->getValue<int64_t>(), 5000);
+    ASSERT_EQ(conn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 5000);
+    ASSERT_EQ(readConn->query(query)->getNext()->getValue(0)->getValue<int64_t>(), 5000);
 }

--- a/test/storage/rel_insertion_test.cpp
+++ b/test/storage/rel_insertion_test.cpp
@@ -125,16 +125,16 @@ public:
         bool containNullValues, bool containLongString) {
         for (auto i = 0u; i < numInsertedRels; i++) {
             auto tuple = queryResult->getNext();
-            ASSERT_EQ(tuple->getResultValue(0)->isNull(), containNullValues && (i % 2 != 0));
+            ASSERT_EQ(tuple->getValue(0)->isNull(), containNullValues && (i % 2 != 0));
             if (!containNullValues || i % 2 == 0) {
-                ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), i);
+                ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), i);
             }
-            ASSERT_EQ(tuple->getResultValue(1)->isNull(), containNullValues);
+            ASSERT_EQ(tuple->getValue(1)->isNull(), containNullValues);
             if (!containNullValues) {
-                ASSERT_EQ(tuple->getResultValue(1)->getValue<string>(),
+                ASSERT_EQ(tuple->getValue(1)->getValue<string>(),
                     (containLongString ? "long long string prefix " : "") + to_string(i));
             }
-            ASSERT_EQ((tuple->getResultValue(2)->getListValReference())[0]->getValue<string>(),
+            ASSERT_EQ((tuple->getValue(2)->getListValReference())[0]->getValue<string>(),
                 (containLongString ? "long long string prefix " : "") + to_string(i));
         }
     }
@@ -205,11 +205,10 @@ public:
         for (auto i = 0u; i < 50; i++) {
             auto tuple = result->getNext();
             // Check rels stored in the persistent store.
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), i);
+            ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), i);
             auto strVal = getStringValToValidate(1000 - i);
-            ASSERT_EQ(tuple->getResultValue(1)->getValue<string>(), strVal);
-            ASSERT_EQ(
-                (tuple->getResultValue(2)->getListValReference())[0]->getValue<string>(), strVal);
+            ASSERT_EQ(tuple->getValue(1)->getValue<string>(), strVal);
+            ASSERT_EQ((tuple->getValue(2)->getListValReference())[0]->getValue<string>(), strVal);
             if (!isCommit) {
                 continue;
             }
@@ -223,22 +222,19 @@ public:
                 for (auto j = 0u; j < 100; j++) {
                     tuple = result->getNext();
                     auto dstNodeOffset = 700 + i + j;
-                    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), dstNodeOffset * 3);
-                    ASSERT_EQ(
-                        tuple->getResultValue(1)->getValue<string>(), to_string(dstNodeOffset - 5));
-                    ASSERT_EQ(
-                        (tuple->getResultValue(2)->getListValReference())[0]->getValue<string>(),
+                    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), dstNodeOffset * 3);
+                    ASSERT_EQ(tuple->getValue(1)->getValue<string>(), to_string(dstNodeOffset - 5));
+                    ASSERT_EQ((tuple->getValue(2)->getListValReference())[0]->getValue<string>(),
                         to_string(dstNodeOffset - 5));
                 }
             } else {
                 for (auto j = 0u; j < 1000; j++) {
                     tuple = result->getNext();
                     auto dstNodeOffset = 500 + i + j;
-                    ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), dstNodeOffset * 2);
-                    ASSERT_EQ(tuple->getResultValue(1)->getValue<string>(),
-                        to_string(dstNodeOffset - 25));
+                    ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), dstNodeOffset * 2);
                     ASSERT_EQ(
-                        (tuple->getResultValue(2)->getListValReference())[0]->getValue<string>(),
+                        tuple->getValue(1)->getValue<string>(), to_string(dstNodeOffset - 25));
+                    ASSERT_EQ((tuple->getValue(2)->getListValReference())[0]->getValue<string>(),
                         to_string(dstNodeOffset - 25));
                 }
             }
@@ -276,12 +272,11 @@ public:
     void validateSmallListAfterBecomingLarge(QueryResult* queryResult, uint64_t numValuesToInsert) {
         for (auto i = 0u; i < 10; i++) {
             auto tuple = queryResult->getNext();
-            ASSERT_EQ(
-                tuple->getResultValue(0)->getValue<string>(), to_string(i + 1) + to_string(i + 1));
+            ASSERT_EQ(tuple->getValue(0)->getValue<string>(), to_string(i + 1) + to_string(i + 1));
         }
         for (auto i = 0u; i < numValuesToInsert; i++) {
             auto tuple = queryResult->getNext();
-            ASSERT_EQ(tuple->getResultValue(0)->getValue<string>(), to_string(i));
+            ASSERT_EQ(tuple->getValue(0)->getValue<string>(), to_string(i));
         }
     }
 
@@ -335,13 +330,13 @@ public:
             // is an inserted edge(checked by i % 10) and the srcNodeOffset is not a multiple of
             // 20(checked by i % 20).
             auto isNull = i % 10 == 0 && (testNull && i % 20);
-            ASSERT_EQ(tuple->getResultValue(0)->isNull(), isNull);
+            ASSERT_EQ(tuple->getValue(0)->isNull(), isNull);
             if (!isNull) {
                 // If this is an inserted edge(checked by i % 10), the length property value
                 // is i / 10. Otherwise, the length property value is i.
-                ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), i % 10 ? i : i / 10);
+                ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), i % 10 ? i : i / 10);
             }
-            ASSERT_EQ(tuple->getResultValue(1)->isNull(), isNull);
+            ASSERT_EQ(tuple->getValue(1)->isNull(), isNull);
             if (!isNull) {
                 // If this is an inserted edge(checked by i % 10), the place property value
                 // is prefix(if we are testing long strings) + i / 10. Otherwise,
@@ -353,7 +348,7 @@ public:
                                  to_string(2000 - i) + to_string(2000 - i) + to_string(2000 - i)) :
                         ((testLongString && i % 20 ? "long string prefix " : "") +
                             to_string(i / 10));
-                ASSERT_EQ(tuple->getResultValue(1)->getValue<string>(), strVal);
+                ASSERT_EQ(tuple->getValue(1)->getValue<string>(), strVal);
             }
         }
     }
@@ -407,7 +402,7 @@ public:
                     tuple = queryResult->getNext();
                 }
                 // The length property's value is equal to the srcPerson's ID.
-                ASSERT_EQ(tuple->getResultValue(0)->getValue<int64_t>(), i * 10 + j);
+                ASSERT_EQ(tuple->getValue(0)->getValue<int64_t>(), i * 10 + j);
             }
         }
     }

--- a/tools/python_api/requirements_dev.txt
+++ b/tools/python_api/requirements_dev.txt
@@ -3,3 +3,4 @@ pytest
 pandas
 networkx~=3.0.0
 numpy
+pyarrow~=10.0.0

--- a/tools/python_api/src_cpp/include/arrow_array.h
+++ b/tools/python_api/src_cpp/include/arrow_array.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "pybind_include.h"
+
+namespace kuzu {
+namespace pyarrow {
+
+class Table : public py::object {
+public:
+    explicit Table(const py::object& o) : py::object(o, borrowed_t{}) {}
+
+public:
+    static bool check_(const py::handle& object) { return !py::none().is(object); }
+};
+} // namespace pyarrow
+} // namespace kuzu

--- a/tools/python_api/src_cpp/include/py_query_result.h
+++ b/tools/python_api/src_cpp/include/py_query_result.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "arrow_array.h"
 #include "main/kuzu.h"
 #include "pybind_include.h"
 
@@ -18,13 +19,16 @@ public:
 
     py::list getNext();
 
-    void writeToCSV(py::str filename, py::str delimiter, py::str escapeCharacter, py::str newline);
+    void writeToCSV(const py::str& filename, const py::str& delimiter,
+        const py::str& escapeCharacter, const py::str& newline);
 
     void close();
 
     static py::object convertValueToPyObject(const Value& value);
 
     py::object getAsDF();
+
+    kuzu::pyarrow::Table getAsArrow(std::int64_t chunkSize);
 
     py::list getColumnDataTypes();
 
@@ -38,5 +42,9 @@ private:
 
     static py::dict convertNodeIdToPyDict(const nodeID_t& nodeId);
 
+    bool getNextArrowChunk(py::list& batches, std::int64_t chunk_size);
+    py::object getArrowChunks(std::int64_t chunkSize);
+
+private:
     unique_ptr<QueryResult> queryResult;
 };

--- a/tools/python_api/src_cpp/py_query_result_converter.cpp
+++ b/tools/python_api/src_cpp/py_query_result_converter.cpp
@@ -115,7 +115,7 @@ py::object QueryResultConverter::toDF() {
     while (queryResult->hasNext()) {
         auto flatTuple = queryResult->getNext();
         for (auto i = 0u; i < columns.size(); i++) {
-            columns[i]->appendElement(flatTuple->getResultValue(i));
+            columns[i]->appendElement(flatTuple->getValue(i));
         }
     }
     py::dict result;

--- a/tools/python_api/src_py/query_result.py
+++ b/tools/python_api/src_py/query_result.py
@@ -23,10 +23,10 @@ class QueryResult:
         self.check_for_query_result_close()
         return self._query_result.getNext()
 
-    def write_to_csv(self, filename, delimiter=',', escapeCharacter='"', newline='\n'):
+    def write_to_csv(self, filename, delimiter=',', escape_character='"', newline='\n'):
         self.check_for_query_result_close()
         self._query_result.writeToCSV(
-            filename, delimiter, escapeCharacter, newline)
+            filename, delimiter, escape_character, newline)
 
     def close(self):
         if self.is_closed:
@@ -40,6 +40,10 @@ class QueryResult:
     def get_as_df(self):
         self.check_for_query_result_close()
         return self._query_result.getAsDF()
+
+    def get_as_arrow(self, chunk_size):
+        self.check_for_query_result_close()
+        return self._query_result.getAsArrow(chunk_size)
 
     def get_column_data_types(self):
         self.check_for_query_result_close()

--- a/tools/python_api/test/test_arrow.py
+++ b/tools/python_api/test/test_arrow.py
@@ -1,0 +1,60 @@
+import sys
+
+sys.path.append('../build/')
+import kuzu
+import pyarrow as pa
+import datetime
+
+
+def test_to_arrow(establish_connection):
+    conn, db = establish_connection
+
+    def _test_to_arrow(conn):
+        query = "MATCH (a:person) RETURN a.age, a.isStudent, a.eyeSight, a.birthdate, a.registerTime, a.lastJobDuration ORDER BY a.ID"
+        arrow_tbl = conn.execute(query).get_as_arrow(8)
+        assert arrow_tbl.num_columns == 6
+
+        age_col = arrow_tbl.column(0)
+        assert age_col.type == pa.int64()
+        assert age_col.length() == 8
+        assert age_col.to_pylist() == [35, 30, 45, 20, 20, 25, 40, 83]
+
+        is_student_col = arrow_tbl.column(1)
+        assert is_student_col.type == pa.bool_()
+        assert is_student_col.length() == 8
+        assert is_student_col.to_pylist() == [True, True, False, False, False, True, False, False]
+
+        eye_sight_col = arrow_tbl.column(2)
+        assert eye_sight_col.type == pa.float64()
+        assert eye_sight_col.length() == 8
+        assert eye_sight_col.to_pylist() == [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9]
+
+        birthdate_col = arrow_tbl.column(3)
+        assert birthdate_col.type == pa.date32()
+        assert birthdate_col.length() == 8
+        assert birthdate_col.to_pylist() == [datetime.date(1900, 1, 1), datetime.date(1900, 1, 1),
+                                           datetime.date(1940, 6, 22), datetime.date(1950, 7, 23),
+                                           datetime.date(1980, 10, 26), datetime.date(1980, 10, 26),
+                                           datetime.date(1980, 10, 26), datetime.date(1990, 11, 27)]
+
+        register_time_col = arrow_tbl.column(4)
+        assert register_time_col.type == pa.timestamp('us')
+        assert register_time_col.length() == 8
+        assert register_time_col.to_pylist() == [
+            datetime.datetime(2011, 8, 20, 11, 25, 30), datetime.datetime(2008, 11, 3, 15, 25, 30, 526),
+            datetime.datetime(1911, 8, 20, 2, 32, 21), datetime.datetime(2031, 11, 30, 12, 25, 30),
+            datetime.datetime(1976, 12, 23, 11, 21, 42), datetime.datetime(1972, 7, 31, 13, 22, 30, 678559),
+            datetime.datetime(1976, 12, 23, 4, 41, 42), datetime.datetime(2023, 2, 21, 13, 25, 30)]
+
+        last_job_duration_col = arrow_tbl.column(5)
+        assert last_job_duration_col.type == pa.duration('ms')
+        assert last_job_duration_col.length() == 8
+        assert last_job_duration_col.to_pylist() == [datetime.timedelta(days=99, seconds=36334, microseconds=628000),
+                                                   datetime.timedelta(days=543, seconds=4800),
+                                                   datetime.timedelta(microseconds=125000),
+                                                   datetime.timedelta(days=541, seconds=57600, microseconds=24000),
+                                                   datetime.timedelta(0), datetime.timedelta(days=2016, seconds=68600),
+                                                   datetime.timedelta(microseconds=125000),
+                                                   datetime.timedelta(days=541, seconds=57600, microseconds=24000)]
+
+    _test_to_arrow(conn)

--- a/tools/python_api/test/test_main.py
+++ b/tools/python_api/test/test_main.py
@@ -8,6 +8,7 @@ from test_networkx import *
 from test_parameter import *
 from test_query_result_close import *
 from test_write_to_csv import *
+from test_arrow import *
 
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__]))

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -338,10 +338,10 @@ void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {
         while (queryResult.hasNext()) {
             auto tuple = queryResult.getNext();
             for (auto i = 0u; i < colsWidth.size(); i++) {
-                if (tuple->getResultValue(i)->isNull()) {
+                if (tuple->getValue(i)->isNull()) {
                     continue;
                 }
-                string tupleString = tuple->getResultValue(i)->toString();
+                string tupleString = tuple->getValue(i)->toString();
                 uint32_t fieldLen = 0;
                 uint32_t chrIter = 0;
                 while (chrIter < tupleString.length()) {


### PR DESCRIPTION
- add `get_as_arrow()`, support BOOL, INT64, DOUBLE, DATE, TIMESTAMP, INTERVAL.
- rename `getResultValue` to `getValue`.