### PR TITLE
add transaction to add property statement

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -387,7 +387,9 @@ void Catalog::dropProperty(table_id_t tableID, property_id_t propertyID) {
 void Catalog::addProperty(table_id_t tableID, string propertyName, DataType dataType) {
     initCatalogContentForWriteTrxIfNecessary();
     catalogContentForWriteTrx->getTableSchema(tableID)->addProperty(
-        std::move(propertyName), std::move(dataType));
+        propertyName, std::move(dataType));
+    wal->logAddPropertyRecord(tableID,
+        catalogContentForWriteTrx->getTableSchema(tableID)->getPropertyID(std::move(propertyName)));
 }
 
 } // namespace catalog

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -132,7 +132,7 @@ public:
     unique_ptr<ListsUpdateIteratorsForDirection> getListsUpdateIteratorsForDirection(
         table_id_t boundNodeTableID);
     void removeProperty(property_id_t propertyID);
-    void addProperty(Property& property, table_id_t tableID, WAL* wal);
+    void addProperty(Property& property, WAL* wal);
 
 private:
     void scanColumns(Transaction* transaction, RelTableScanState& scanState,
@@ -218,7 +218,7 @@ public:
         const shared_ptr<ValueVector>& dstNodeIDVector, const shared_ptr<ValueVector>& relIDVector,
         const shared_ptr<ValueVector>& propertyVector, uint32_t propertyID);
     void initEmptyRelsForNewNode(nodeID_t& nodeID);
-    void addProperty(Property property, table_id_t tableID);
+    void addProperty(Property property);
 
 private:
     inline void addToUpdatedRelTables() { wal->addToUpdatedRelTables(tableID); }

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -29,8 +29,8 @@ protected:
     BaseWALAndWALIterator() : BaseWALAndWALIterator(nullptr) {}
 
     explicit BaseWALAndWALIterator(shared_ptr<FileHandle> fileHandle)
-        : fileHandle{move(fileHandle)}, offsetInCurrentHeaderPage{INT64_MAX}, currentHeaderPageIdx{
-                                                                                  INT32_MAX} {
+        : fileHandle{std::move(fileHandle)}, offsetInCurrentHeaderPage{INT64_MAX},
+          currentHeaderPageIdx{INT32_MAX} {
         currentHeaderPageBuffer = make_unique<uint8_t[]>(WAL_HEADER_PAGE_SIZE);
     }
 
@@ -117,6 +117,8 @@ public:
     void logDropTableRecord(table_id_t tableID);
 
     void logDropPropertyRecord(table_id_t tableID, property_id_t propertyID);
+
+    void logAddPropertyRecord(table_id_t tableID, property_id_t propertyID);
 
     // Removes the contents of WAL file.
     void clearWAL();

--- a/src/include/storage/wal_replayer_utils.h
+++ b/src/include/storage/wal_replayer_utils.h
@@ -46,6 +46,12 @@ public:
             directory, tableID, propertyID, DBFileType::ORIGINAL));
     }
 
+    static inline void renameDBFilesForNodeProperty(
+        const string& directory, table_id_t tableID, property_id_t propertyID) {
+        replaceOriginalColumnFilesWithWALVersionIfExists(StorageUtils::getNodePropertyColumnFName(
+            directory, tableID, propertyID, DBFileType::ORIGINAL));
+    }
+
     static void removeDBFilesForRelProperty(
         const string& directory, RelTableSchema* relTableSchema, property_id_t propertyID);
 
@@ -54,6 +60,9 @@ public:
 
     static void createEmptyDBFilesForNewNodeTable(
         NodeTableSchema* nodeTableSchema, const string& directory);
+
+    static void renameDBFilesForRelProperty(
+        const string& directory, RelTableSchema* relTableSchema, property_id_t propertyID);
 
 private:
     static inline void removeColumnFilesForPropertyIfExists(const string& directory,

--- a/src/processor/operator/ddl/add_node_property.cpp
+++ b/src/processor/operator/ddl/add_node_property.cpp
@@ -11,7 +11,6 @@ void AddNodeProperty::executeDDLInternal() {
         property, getDefaultVal(), isDefaultValueNull(),
         storageManager.getNodesStore().getNodesStatisticsAndDeletedIDs().getNumTuplesForTable(
             tableID));
-    storageManager.getNodesStore().getNodeTable(tableID)->addProperty(property);
 }
 
 } // namespace processor

--- a/src/processor/operator/ddl/add_rel_property.cpp
+++ b/src/processor/operator/ddl/add_rel_property.cpp
@@ -6,11 +6,9 @@ namespace processor {
 void AddRelProperty::executeDDLInternal() {
     AddProperty::executeDDLInternal();
     auto tableSchema = catalog->getWriteVersion()->getRelTableSchema(tableID);
-    auto propertyID = tableSchema->getPropertyID(propertyName);
-    auto property = tableSchema->getProperty(propertyID);
+    auto property = tableSchema->getProperty(tableSchema->getPropertyID(propertyName));
     StorageUtils::createFileForRelPropertyWithDefaultVal(
         tableSchema, property, getDefaultVal(), isDefaultValueNull(), storageManager);
-    storageManager.getRelsStore().getRelTable(tableID)->addProperty(property, tableID);
 }
 
 } // namespace processor

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -108,7 +108,7 @@ void StorageUtils::createFileForNodePropertyWithDefaultVal(table_id_t tableID,
     bool isDefaultValNull, uint64_t numNodes) {
     auto inMemColumn = InMemColumnFactory::getInMemPropertyColumn(
         StorageUtils::getNodePropertyColumnFName(
-            directory, tableID, property.propertyID, DBFileType::ORIGINAL),
+            directory, tableID, property.propertyID, DBFileType::WAL_VERSION),
         property.dataType, numNodes);
     if (!isDefaultValNull) {
         inMemColumn->fillWithDefaultVal(defaultVal, numNodes, property.dataType);
@@ -135,7 +135,7 @@ void StorageUtils::createFileForRelColumnPropertyWithDefaultVal(table_id_t relTa
     uint8_t* defaultVal, bool isDefaultValNull, StorageManager& storageManager) {
     auto inMemColumn = InMemColumnFactory::getInMemPropertyColumn(
         StorageUtils::getRelPropertyColumnFName(storageManager.getDirectory(), relTableID,
-            boundTableID, direction, property.propertyID, DBFileType::ORIGINAL),
+            boundTableID, direction, property.propertyID, DBFileType::WAL_VERSION),
         property.dataType,
         storageManager.getRelsStore().getRelsStatistics().getNumTuplesForTable(relTableID));
     if (!isDefaultValNull) {
@@ -152,7 +152,7 @@ void StorageUtils::createFileForRelListsPropertyWithDefaultVal(table_id_t relTab
     uint8_t* defaultVal, bool isDefaultValNull, StorageManager& storageManager) {
     auto inMemList = InMemListsFactory::getInMemPropertyLists(
         StorageUtils::getRelPropertyListsFName(storageManager.getDirectory(), relTableID,
-            boundTableID, direction, property.propertyID, DBFileType::ORIGINAL),
+            boundTableID, direction, property.propertyID, DBFileType::WAL_VERSION),
         property.dataType,
         storageManager.getRelsStore().getRelsStatistics().getNumTuplesForTable(relTableID));
     // Note: we need the listMetadata to get the num of elements in a large list, and headers to

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -340,9 +340,9 @@ void RelTable::initEmptyRelsForNewNode(nodeID_t& nodeID) {
     listsUpdatesStore->initNewlyAddedNodes(nodeID);
 }
 
-void RelTable::addProperty(Property property, table_id_t tableID) {
-    fwdRelTableData->addProperty(property, tableID, wal);
-    bwdRelTableData->addProperty(property, tableID, wal);
+void RelTable::addProperty(Property property) {
+    fwdRelTableData->addProperty(property, wal);
+    bwdRelTableData->addProperty(property, wal);
 }
 
 void RelTable::appendInMemListToLargeListOP(
@@ -391,7 +391,7 @@ void DirectedRelTableData::removeProperty(property_id_t propertyID) {
     }
 }
 
-void DirectedRelTableData::addProperty(Property& property, table_id_t tableID, WAL* wal) {
+void DirectedRelTableData::addProperty(Property& property, WAL* wal) {
     for (auto& [boundTableID, propertyColumnsPerBoundTable] : propertyColumns) {
         propertyColumnsPerBoundTable.emplace(property.propertyID,
             ColumnFactory::getColumn(

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -96,6 +96,12 @@ void WAL::logDropPropertyRecord(table_id_t tableID, property_id_t propertyID) {
     addNewWALRecordNoLock(walRecord);
 }
 
+void WAL::logAddPropertyRecord(table_id_t tableID, property_id_t propertyID) {
+    lock_t lck{mtx};
+    WALRecord walRecord = WALRecord::newAddPropertyRecord(tableID, propertyID);
+    addNewWALRecordNoLock(walRecord);
+}
+
 void WAL::clearWAL() {
     bufferManager.removeFilePagesFromFrames(*fileHandle);
     fileHandle->resetToZeroPagesAndPageCapacity();

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -211,6 +211,13 @@ WALRecord WALRecord::newDropPropertyRecord(table_id_t tableID, property_id_t pro
     return retVal;
 }
 
+WALRecord WALRecord::newAddPropertyRecord(table_id_t tableID, property_id_t propertyID) {
+    WALRecord retVal;
+    retVal.recordType = WALRecordType::ADD_PROPERTY_RECORD;
+    retVal.addPropertyRecord = AddPropertyRecord(tableID, propertyID);
+    return retVal;
+}
+
 void WALRecord::constructWALRecordFromBytes(WALRecord& retVal, uint8_t* bytes, uint64_t& offset) {
     ((WALRecord*)&retVal)[0] = ((WALRecord*)(bytes + offset))[0];
     offset += sizeof(WALRecord);

--- a/src/storage/wal_replayer_utils.cpp
+++ b/src/storage/wal_replayer_utils.cpp
@@ -62,6 +62,23 @@ void WALReplayerUtils::createEmptyDBFilesForNewNodeTable(
     }
 }
 
+void WALReplayerUtils::renameDBFilesForRelProperty(const std::string& directory,
+    kuzu::catalog::RelTableSchema* relTableSchema, kuzu::common::property_id_t propertyID) {
+    for (auto direction : REL_DIRECTIONS) {
+        for (auto boundTableID : relTableSchema->getUniqueBoundTableIDs(direction)) {
+            if (relTableSchema->isSingleMultiplicityInDirection(direction)) {
+                replaceOriginalColumnFilesWithWALVersionIfExists(
+                    StorageUtils::getRelPropertyColumnFName(directory, relTableSchema->tableID,
+                        boundTableID, direction, propertyID, DBFileType::ORIGINAL));
+            } else {
+                replaceOriginalListFilesWithWALVersionIfExists(
+                    StorageUtils::getRelPropertyListsFName(directory, relTableSchema->tableID,
+                        boundTableID, direction, propertyID, DBFileType::ORIGINAL));
+            }
+        }
+    }
+}
+
 void WALReplayerUtils::initLargeListPageListsAndSaveToFile(InMemLists* inMemLists) {
     inMemLists->getListsMetadataBuilder()->initLargeListPageLists(0 /* largeListIdx */);
     inMemLists->saveToFile();


### PR DESCRIPTION
This PR adds transaction support to add property statement.
1. The physical operator will call the appropriate storageUtil functions to create the wal version of the database file for the newly added property.
2. During checkpointing, the walReplayer will rename the wal version of the database file to the original version. If the database crashes before committing, the walReplayer will delete the WAL version of the new property file.