### PR TITLE
Revert arrow patch

### DIFF
--- a/external/arrow/apache_arrow.cmake
+++ b/external/arrow/apache_arrow.cmake
@@ -7,9 +7,6 @@ ExternalProject_Add(apache_arrow
         GIT_TAG f10f5cfd1376fb0e602334588b3f3624d41dee7d
         PREFIX "${CMAKE_BINARY_DIR}/arrow/"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/arrow/install"
-        PATCH_COMMAND 
-                sed "s| URL_HASH \"SHA256=.*\"||g" "./cpp/cmake_modules/ThirdpartyToolchain.cmake" > "./cpp/cmake_modules/ThirdpartyToolchain.cmake.new" 
-                && mv "./cpp/cmake_modules/ThirdpartyToolchain.cmake.new" "./cpp/cmake_modules/ThirdpartyToolchain.cmake"
         CONFIGURE_COMMAND
         ${CMAKE_COMMAND} -G${CMAKE_GENERATOR} -DCMAKE_BUILD_TYPE=Release
         -DBUILD_WARNING_LEVEL=PRODUCTION -DARROW_DEPENDENCY_SOURCE=BUNDLED


### PR DESCRIPTION
Since GitHub has [reverted the change](https://github.blog/changelog/2023-01-30-git-archive-checksums-may-change/), we revert the patch for now.