### PR TITLE
Continue benchmark in same dir on benchmark failure

### DIFF
--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -28,7 +28,12 @@ void BenchmarkRunner::registerBenchmarks(const string& path) {
 
 void BenchmarkRunner::runAllBenchmarks() {
     for (auto& benchmark : benchmarks) {
-        runBenchmark(benchmark.get());
+        try {
+            runBenchmark(benchmark.get());
+        } catch (exception& e) {
+            spdlog::error(
+                "Error encountered while running benchmark {}: {}.", benchmark->name, e.what());
+        }
     }
 }
 

--- a/tools/benchmark/main.cpp
+++ b/tools/benchmark/main.cpp
@@ -1,5 +1,6 @@
 #include "benchmark_runner.h"
 #include "common/utils.h"
+#include "spdlog/spdlog.h"
 
 using namespace kuzu::benchmark;
 
@@ -50,7 +51,10 @@ int main(int argc, char** argv) {
     auto runner = BenchmarkRunner(datasetPath, std::move(config));
     try {
         runner.registerBenchmarks(benchmarkPath);
-        runner.runAllBenchmarks();
-    } catch (exception& e) { printf("Error encountered during benchmarking. %s", e.what()); }
+    } catch (exception& e) {
+        spdlog::error(
+            "Error encountered while registering benchmark in {}: {}.", benchmarkPath, e.what());
+    }
+    runner.runAllBenchmarks();
     return 0;
 }


### PR DESCRIPTION
Currently the benchmark script will not run the remaining benchmarks from a directory if one of the benchmarks in that directory fail to run because the exceptional handler is defined for `runAllBenchmarks`. This PR changes the exceptional handler to handle individual benchmark failure and keep running benchmarks from the directory if one benchmark fails.