### PR TITLE
Disallow user to execute copy commands twice on a relt able

### DIFF
--- a/src/include/processor/operator/copy/copy.h
+++ b/src/include/processor/operator/copy/copy.h
@@ -26,14 +26,14 @@ public:
     }
 
 protected:
-    void errorIfTableIsNonEmpty();
-
     std::string getOutputMsg(uint64_t numTuplesCopied);
 
     virtual uint64_t executeInternal(
         common::TaskScheduler* taskScheduler, ExecutionContext* executionContext) = 0;
 
     virtual uint64_t getNumTuplesInTable() = 0;
+
+    virtual bool allowCopyCSV() = 0;
 
 protected:
     catalog::Catalog* catalog;

--- a/src/include/processor/operator/copy/copy_node.h
+++ b/src/include/processor/operator/copy/copy_node.h
@@ -28,6 +28,11 @@ protected:
     uint64_t getNumTuplesInTable() override;
 
 private:
+    inline bool allowCopyCSV() override {
+        return nodesStatistics->getNodeStatisticsAndDeletedIDs(tableID)->getNumTuples() == 0;
+    }
+
+private:
     storage::NodesStatisticsAndDeletedIDs* nodesStatistics;
     storage::RelsStore& relsStore;
 };

--- a/src/include/processor/operator/copy/copy_rel.h
+++ b/src/include/processor/operator/copy/copy_rel.h
@@ -28,6 +28,11 @@ protected:
     uint64_t getNumTuplesInTable() override;
 
 private:
+    inline bool allowCopyCSV() override {
+        return relsStatistics->getRelStatistics(tableID)->getNextRelOffset() == 0;
+    }
+
+private:
     storage::NodesStatisticsAndDeletedIDs* nodesStatistics;
     storage::RelsStatistics* relsStatistics;
 };

--- a/test/demo_db/demo_db_test.cpp
+++ b/test/demo_db/demo_db_test.cpp
@@ -79,3 +79,12 @@ TEST_F(DemoDBTest, SetNodeTest) {
     groundTruth = std::vector<std::string>{""};
     ASSERT_EQ(TestHelper::convertResultToString(*result, true /* check order */), groundTruth);
 }
+
+TEST_F(DemoDBTest, CopyRelToNonEmptyTableErrorTest) {
+    ASSERT_TRUE(conn->query("MATCH (:User)-[f:Follows]->(:User) DELETE f")->isSuccess());
+    auto result = conn->query("COPY Follows FROM \"" +
+                              TestHelper::appendKuzuRootPath("/dataset/demo-db/csv/follows.csv\""));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_EQ(result->getErrorMessage(),
+        "Copy exception: COPY commands can only be executed once on a table.");
+}


### PR DESCRIPTION
This PR prevents the user to execute multiple copy commands on the same rel table.
Since numTuples will decrease as we delete tuples from relTable, we shouldn't use numTuples to check whether we can copy   
csv to a rel table or not. Instead, we should use the next relOffset to determine whether we can do copy on a rel table.