### PR TITLE
Remove DatabaseConfig

### DIFF
--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -32,20 +32,7 @@ KUZU_API struct SystemConfig {
 };
 
 /**
- * @brief Stores databasePath.
- */
-KUZU_API struct DatabaseConfig {
-    /**
-     * @brief Creates a DatabaseConfig object.
-     * @param databasePath Path to store the database files.
-     */
-    explicit DatabaseConfig(std::string databasePath);
-
-    std::string databasePath;
-};
-
-/**
- * @brief Database class is the main class of the KuzuDB. It manages all database components.
+ * @brief Database class is the main class of KùzuDB. It manages all database components.
  */
 class Database {
     friend class EmbeddedShell;
@@ -56,17 +43,17 @@ class Database {
 public:
     /**
      * @brief Creates a database object with default buffer pool size and max num threads.
-     * @param databaseConfig Database configurations(database path).
+     * @param databaseConfig Database path.
      */
-    KUZU_API explicit Database(DatabaseConfig databaseConfig);
+    KUZU_API explicit Database(std::string databasePath);
     /**
      * @brief Creates a database object.
-     * @param databaseConfig Database configurations(database path).
-     * @param systemConfig System configurations(buffer pool size and max num threads).
+     * @param databasePath Database path.
+     * @param systemConfig System configurations (buffer pool size and max num threads).
      */
-    KUZU_API Database(DatabaseConfig databaseConfig, SystemConfig systemConfig);
+    KUZU_API Database(std::string databasePath, SystemConfig systemConfig);
     /**
-     * @brief Deconstructs the database object.
+     * @brief Destructs the database object.
      */
     KUZU_API ~Database();
 
@@ -102,7 +89,7 @@ private:
     void checkpointOrRollbackAndClearWAL(bool isRecovering, bool isCheckpoint);
 
 private:
-    DatabaseConfig databaseConfig;
+    std::string databasePath;
     SystemConfig systemConfig;
     std::unique_ptr<storage::MemoryManager> memoryManager;
     std::unique_ptr<processor::QueryProcessor> queryProcessor;

--- a/test/graph_test/graph_test.cpp
+++ b/test/graph_test/graph_test.cpp
@@ -41,13 +41,12 @@ void BaseGraphTest::validateListFilesExistence(
 void BaseGraphTest::validateNodeColumnFilesExistence(
     NodeTableSchema* nodeTableSchema, DBFileType dbFileType, bool existence) {
     for (auto& property : nodeTableSchema->properties) {
-        validateColumnFilesExistence(
-            StorageUtils::getNodePropertyColumnFName(databaseConfig->databasePath,
-                nodeTableSchema->tableID, property.propertyID, dbFileType),
+        validateColumnFilesExistence(StorageUtils::getNodePropertyColumnFName(databasePath,
+                                         nodeTableSchema->tableID, property.propertyID, dbFileType),
             existence, containsOverflowFile(property.dataType.typeID));
     }
-    validateColumnFilesExistence(StorageUtils::getNodeIndexFName(databaseConfig->databasePath,
-                                     nodeTableSchema->tableID, dbFileType),
+    validateColumnFilesExistence(
+        StorageUtils::getNodeIndexFName(databasePath, nodeTableSchema->tableID, dbFileType),
         existence, containsOverflowFile(nodeTableSchema->getPrimaryKey().dataType.typeID));
 }
 
@@ -55,15 +54,14 @@ void BaseGraphTest::validateRelColumnAndListFilesExistence(
     RelTableSchema* relTableSchema, DBFileType dbFileType, bool existence) {
     for (auto relDirection : REL_DIRECTIONS) {
         if (relTableSchema->relMultiplicity) {
-            validateColumnFilesExistence(
-                StorageUtils::getAdjColumnFName(databaseConfig->databasePath,
-                    relTableSchema->tableID, relDirection, dbFileType),
+            validateColumnFilesExistence(StorageUtils::getAdjColumnFName(databasePath,
+                                             relTableSchema->tableID, relDirection, dbFileType),
                 existence, false /* hasOverflow */);
             validateRelPropertyFiles(
                 relTableSchema, relDirection, true /* isColumnProperty */, dbFileType, existence);
 
         } else {
-            validateListFilesExistence(StorageUtils::getAdjListsFName(databaseConfig->databasePath,
+            validateListFilesExistence(StorageUtils::getAdjListsFName(databasePath,
                                            relTableSchema->tableID, relDirection, dbFileType),
                 existence, false /* hasOverflow */, true /* hasHeader */);
             validateRelPropertyFiles(
@@ -100,13 +98,13 @@ void BaseGraphTest::validateRelPropertyFiles(catalog::RelTableSchema* relTableSc
         auto hasOverflow = containsOverflowFile(property.dataType.typeID);
         if (isColumnProperty) {
             validateColumnFilesExistence(
-                StorageUtils::getRelPropertyColumnFName(databaseConfig->databasePath,
-                    relTableSchema->tableID, relDirection, property.propertyID, dbFileType),
+                StorageUtils::getRelPropertyColumnFName(databasePath, relTableSchema->tableID,
+                    relDirection, property.propertyID, dbFileType),
                 existence, hasOverflow);
         } else {
             validateListFilesExistence(
-                StorageUtils::getRelPropertyListsFName(databaseConfig->databasePath,
-                    relTableSchema->tableID, relDirection, property.propertyID, dbFileType),
+                StorageUtils::getRelPropertyListsFName(databasePath, relTableSchema->tableID,
+                    relDirection, property.propertyID, dbFileType),
                 existence, hasOverflow, false /* hasHeader */);
         }
     }
@@ -143,7 +141,7 @@ void BaseGraphTest::createDBAndConn() {
     if (database != nullptr) {
         database.reset();
     }
-    database = std::make_unique<main::Database>(*databaseConfig, *systemConfig);
+    database = std::make_unique<main::Database>(databasePath, *systemConfig);
     conn = std::make_unique<main::Connection>(database.get());
     spdlog::set_level(spdlog::level::info);
 }

--- a/test/include/graph_test/graph_test.h
+++ b/test/include/graph_test/graph_test.h
@@ -28,7 +28,7 @@ public:
         if (common::FileUtils::fileOrPathExists(TestHelper::getTmpTestDir())) {
             common::FileUtils::removeDir(TestHelper::getTmpTestDir());
         }
-        databaseConfig = make_unique<main::DatabaseConfig>(TestHelper::getTmpTestDir());
+        databasePath = TestHelper::getTmpTestDir();
     }
 
     virtual std::string getInputDir() = 0;
@@ -138,8 +138,8 @@ private:
         bool existence);
 
 public:
+    std::string databasePath;
     std::unique_ptr<main::SystemConfig> systemConfig;
-    std::unique_ptr<main::DatabaseConfig> databaseConfig;
     std::unique_ptr<main::Database> database;
     std::unique_ptr<main::Connection> conn;
 };

--- a/test/main/config_test.cpp
+++ b/test/main/config_test.cpp
@@ -21,7 +21,7 @@ TEST_F(ApiTest, ClientConfig) {
 TEST_F(ApiTest, DatabasePathIncorrect) {
     spdlog::set_level(spdlog::level::debug);
     try {
-        std::make_unique<Database>(DatabaseConfig("/\\0:* /? \" < > |"));
+        std::make_unique<Database>("0:* /? \" < > |");
         FAIL();
     } catch (Exception& e) {
         ASSERT_TRUE(std::string(e.what()).find("Failed to create directory") != std::string::npos);

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -276,9 +276,8 @@ public:
     void dropNodeTableProperty(TransactionTestType transactionTestType) {
         auto propertyToDrop =
             catalog->getReadOnlyVersion()->getNodeProperty(personTableID, "gender");
-        auto propertyFileName =
-            StorageUtils::getNodePropertyColumnFName(databaseConfig->databasePath, personTableID,
-                propertyToDrop.propertyID, DBFileType::ORIGINAL);
+        auto propertyFileName = StorageUtils::getNodePropertyColumnFName(
+            databasePath, personTableID, propertyToDrop.propertyID, DBFileType::ORIGINAL);
         bool hasOverflowFile = containsOverflowFile(propertyToDrop.dataType.typeID);
         executeQueryWithoutCommit("ALTER TABLE person DROP gender");
         validateColumnFilesExistence(propertyFileName, true /* existence */, hasOverflowFile);
@@ -311,12 +310,10 @@ public:
             catalog->getReadOnlyVersion()->getRelProperty(studyAtTableID, "places");
         // Note: studyAt is a MANY-ONE rel table. Properties are stored as columns in the fwd
         // direction and stored as lists in the bwd direction.
-        auto propertyFWDColumnFileName =
-            StorageUtils::getRelPropertyColumnFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::FWD, propertyToDrop.propertyID, DBFileType::ORIGINAL);
-        auto propertyBWDListFileName =
-            StorageUtils::getRelPropertyListsFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::BWD, propertyToDrop.propertyID, DBFileType::ORIGINAL);
+        auto propertyFWDColumnFileName = StorageUtils::getRelPropertyColumnFName(databasePath,
+            studyAtTableID, RelDirection::FWD, propertyToDrop.propertyID, DBFileType::ORIGINAL);
+        auto propertyBWDListFileName = StorageUtils::getRelPropertyListsFName(databasePath,
+            studyAtTableID, RelDirection::BWD, propertyToDrop.propertyID, DBFileType::ORIGINAL);
         bool hasOverflowFile = containsOverflowFile(propertyToDrop.dataType.typeID);
         executeQueryWithoutCommit("ALTER TABLE studyAt DROP places");
         validateColumnFilesExistence(
@@ -392,9 +389,9 @@ public:
         auto hasOverflow =
             containsOverflowFile(tableSchema->getProperty(propertyID).dataType.typeID);
         auto columnOriginalVersionFileName = StorageUtils::getNodePropertyColumnFName(
-            databaseConfig->databasePath, personTableID, propertyID, DBFileType::ORIGINAL);
+            databasePath, personTableID, propertyID, DBFileType::ORIGINAL);
         auto columnWALVersionFileName = StorageUtils::getNodePropertyColumnFName(
-            databaseConfig->databasePath, personTableID, propertyID, DBFileType::WAL_VERSION);
+            databasePath, personTableID, propertyID, DBFileType::WAL_VERSION);
         validateDatabaseFileBeforeCheckpointAddProperty(
             columnOriginalVersionFileName, columnWALVersionFileName, hasOverflow);
         if (transactionTestType == TransactionTestType::RECOVERY) {
@@ -423,9 +420,9 @@ public:
         auto hasOverflow =
             containsOverflowFile(tableSchema->getProperty(propertyID).dataType.typeID);
         auto columnOriginalVersionFileName = StorageUtils::getNodePropertyColumnFName(
-            databaseConfig->databasePath, personTableID, propertyID, DBFileType::ORIGINAL);
+            databasePath, personTableID, propertyID, DBFileType::ORIGINAL);
         auto columnWALVersionFileName = StorageUtils::getNodePropertyColumnFName(
-            databaseConfig->databasePath, personTableID, propertyID, DBFileType::WAL_VERSION);
+            databasePath, personTableID, propertyID, DBFileType::WAL_VERSION);
         validateDatabaseFileBeforeCheckpointAddProperty(
             columnOriginalVersionFileName, columnWALVersionFileName, hasOverflow);
         // The convertResultToString function will remove the single quote around the result
@@ -455,18 +452,14 @@ public:
         auto propertyID = tableSchema->getPropertyID("random");
         auto hasOverflow =
             containsOverflowFile(tableSchema->getProperty(propertyID).dataType.typeID);
-        auto fwdColumnOriginalVersionFileName =
-            StorageUtils::getRelPropertyColumnFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::FWD, propertyID, DBFileType::ORIGINAL);
-        auto fwdColumnWALVersionFileName =
-            StorageUtils::getRelPropertyColumnFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::FWD, propertyID, DBFileType::WAL_VERSION);
-        auto bwdListOriginalVersionFileName =
-            StorageUtils::getRelPropertyListsFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::BWD, propertyID, DBFileType::ORIGINAL);
-        auto bwdListWALVersionFileName =
-            StorageUtils::getRelPropertyListsFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::BWD, propertyID, DBFileType::WAL_VERSION);
+        auto fwdColumnOriginalVersionFileName = StorageUtils::getRelPropertyColumnFName(
+            databasePath, studyAtTableID, RelDirection::FWD, propertyID, DBFileType::ORIGINAL);
+        auto fwdColumnWALVersionFileName = StorageUtils::getRelPropertyColumnFName(
+            databasePath, studyAtTableID, RelDirection::FWD, propertyID, DBFileType::WAL_VERSION);
+        auto bwdListOriginalVersionFileName = StorageUtils::getRelPropertyListsFName(
+            databasePath, studyAtTableID, RelDirection::BWD, propertyID, DBFileType::ORIGINAL);
+        auto bwdListWALVersionFileName = StorageUtils::getRelPropertyListsFName(
+            databasePath, studyAtTableID, RelDirection::BWD, propertyID, DBFileType::WAL_VERSION);
         validateDatabaseFileBeforeCheckpointAddProperty(
             fwdColumnOriginalVersionFileName, fwdColumnWALVersionFileName, hasOverflow);
         validateDatabaseFileBeforeCheckpointAddProperty(
@@ -501,18 +494,14 @@ public:
         auto propertyID = relTableSchema->getPropertyID("random");
         auto hasOverflow =
             containsOverflowFile(relTableSchema->getProperty(propertyID).dataType.typeID);
-        auto fwdColumnOriginalVersionFileName =
-            StorageUtils::getRelPropertyColumnFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::FWD, propertyID, DBFileType::ORIGINAL);
-        auto fwdColumnWALVersionFileName =
-            StorageUtils::getRelPropertyColumnFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::FWD, propertyID, DBFileType::WAL_VERSION);
-        auto bwdListOriginalVersionFileName =
-            StorageUtils::getRelPropertyListsFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::BWD, propertyID, DBFileType::ORIGINAL);
-        auto bwdListWALVersionFileName =
-            StorageUtils::getRelPropertyListsFName(databaseConfig->databasePath, studyAtTableID,
-                RelDirection::BWD, propertyID, DBFileType::WAL_VERSION);
+        auto fwdColumnOriginalVersionFileName = StorageUtils::getRelPropertyColumnFName(
+            databasePath, studyAtTableID, RelDirection::FWD, propertyID, DBFileType::ORIGINAL);
+        auto fwdColumnWALVersionFileName = StorageUtils::getRelPropertyColumnFName(
+            databasePath, studyAtTableID, RelDirection::FWD, propertyID, DBFileType::WAL_VERSION);
+        auto bwdListOriginalVersionFileName = StorageUtils::getRelPropertyListsFName(
+            databasePath, studyAtTableID, RelDirection::BWD, propertyID, DBFileType::ORIGINAL);
+        auto bwdListWALVersionFileName = StorageUtils::getRelPropertyListsFName(
+            databasePath, studyAtTableID, RelDirection::BWD, propertyID, DBFileType::WAL_VERSION);
         validateDatabaseFileBeforeCheckpointAddProperty(
             fwdColumnOriginalVersionFileName, fwdColumnWALVersionFileName, hasOverflow);
         validateDatabaseFileBeforeCheckpointAddProperty(

--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -14,8 +14,7 @@ const std::string BENCHMARK_SUFFIX = ".benchmark";
 BenchmarkRunner::BenchmarkRunner(
     const std::string& datasetPath, std::unique_ptr<BenchmarkConfig> config)
     : config{std::move(config)} {
-    database = std::make_unique<Database>(
-        DatabaseConfig(datasetPath), SystemConfig(this->config->bufferPoolSize));
+    database = std::make_unique<Database>(datasetPath, SystemConfig(this->config->bufferPoolSize));
     spdlog::set_level(spdlog::level::debug);
 }
 

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -18,7 +18,7 @@ PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize)
         systemConfig.largePageBufferPoolSize =
             bufferPoolSize * StorageConfig::LARGE_PAGES_BUFFER_RATIO;
     }
-    database = std::make_unique<Database>(DatabaseConfig(databasePath), systemConfig);
+    database = std::make_unique<Database>(databasePath, systemConfig);
 }
 
 void PyDatabase::resizeBufferManager(uint64_t newSize) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -198,12 +198,11 @@ void highlight(char* buffer, char* resultBuf, uint32_t maxLen, uint32_t cursorPo
     strcpy(resultBuf, highlightBuffer.str().c_str());
 }
 
-EmbeddedShell::EmbeddedShell(
-    const DatabaseConfig& databaseConfig, const SystemConfig& systemConfig) {
+EmbeddedShell::EmbeddedShell(const std::string& databasePath, const SystemConfig& systemConfig) {
     linenoiseHistoryLoad(HISTORY_PATH);
     linenoiseSetCompletionCallback(completion);
     linenoiseSetHighlightCallback(highlight);
-    database = std::make_unique<Database>(databaseConfig, systemConfig);
+    database = std::make_unique<Database>(databasePath, systemConfig);
     conn = std::make_unique<Connection>(database.get());
     updateTableNames();
 }

--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -12,7 +12,7 @@ namespace main {
 class EmbeddedShell {
 
 public:
-    EmbeddedShell(const DatabaseConfig& databaseConfig, const SystemConfig& systemConfig);
+    EmbeddedShell(const std::string& databasePath, const SystemConfig& systemConfig);
 
     void run();
 

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -29,9 +29,8 @@ int main(int argc, char* argv[]) {
         bpSizeInBytes = bpSizeInMB << 20;
     }
     SystemConfig systemConfig(bpSizeInBytes);
-    DatabaseConfig databaseConfig(databasePath);
     try {
-        auto shell = EmbeddedShell(databaseConfig, systemConfig);
+        auto shell = EmbeddedShell(databasePath, systemConfig);
         shell.run();
     } catch (std::exception& e) {
         std::cerr << e.what() << std::endl;


### PR DESCRIPTION
For usability, directly pass `std::string databasePath` is easier than wrapping it around a `DatabaseConfig` object.