### PR TITLE
Factorization rewriter

### DIFF
--- a/src/include/optimizer/factorization_rewriter.h
+++ b/src/include/optimizer/factorization_rewriter.h
@@ -1,0 +1,38 @@
+#include "planner/logical_plan/logical_plan.h"
+
+namespace kuzu {
+namespace optimizer {
+
+class FactorizationRewriter {
+public:
+    void rewrite(planner::LogicalPlan* plan);
+
+private:
+    void visitOperator(planner::LogicalOperator* op);
+    void visitExtend(planner::LogicalOperator* op);
+    void visitHashJoin(planner::LogicalOperator* op);
+    void visitIntersect(planner::LogicalOperator* op);
+    void visitProjection(planner::LogicalOperator* op);
+    void visitAggregate(planner::LogicalOperator* op);
+    void visitOrderBy(planner::LogicalOperator* op);
+    void visitSkip(planner::LogicalOperator* op);
+    void visitLimit(planner::LogicalOperator* op);
+    void visitDistinct(planner::LogicalOperator* op);
+    void visitUnwind(planner::LogicalOperator* op);
+    void visitUnion(planner::LogicalOperator* op);
+    void visitFilter(planner::LogicalOperator* op);
+    void visitSetNodeProperty(planner::LogicalOperator* op);
+    void visitSetRelProperty(planner::LogicalOperator* op);
+    void visitDeleteRel(planner::LogicalOperator* op);
+    void visitCreateNode(planner::LogicalOperator* op);
+    void visitCreateRel(planner::LogicalOperator* op);
+
+    std::shared_ptr<planner::LogicalOperator> appendFlattens(
+        std::shared_ptr<planner::LogicalOperator> op,
+        const std::unordered_set<planner::f_group_pos>& groupsPos);
+    std::shared_ptr<planner::LogicalOperator> appendFlattenIfNecessary(
+        std::shared_ptr<planner::LogicalOperator> op, planner::f_group_pos groupPos);
+};
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/include/optimizer/remove_factorization_rewriter.h
+++ b/src/include/optimizer/remove_factorization_rewriter.h
@@ -1,0 +1,18 @@
+#include "planner/logical_plan/logical_plan.h"
+
+namespace kuzu {
+namespace optimizer {
+
+class RemoveFactorizationRewriter {
+public:
+    void rewrite(planner::LogicalPlan* plan);
+
+private:
+    std::shared_ptr<planner::LogicalOperator> rewriteOperator(
+        std::shared_ptr<planner::LogicalOperator> op);
+
+    bool subPlanHasFlatten(planner::LogicalOperator* op);
+};
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/include/planner/join_order_enumerator.h
+++ b/src/include/planner/join_order_enumerator.h
@@ -113,8 +113,6 @@ private:
     void appendIndexScanNode(std::shared_ptr<NodeExpression>& node,
         std::shared_ptr<Expression> indexExpression, LogicalPlan& plan);
 
-    bool needFlatInput(
-        RelExpression& rel, NodeExpression& boundNode, common::RelDirection direction);
     bool needExtendToNewGroup(
         RelExpression& rel, NodeExpression& boundNode, common::RelDirection direction);
     void appendExtend(std::shared_ptr<NodeExpression> boundNode,
@@ -129,8 +127,8 @@ private:
     static void appendMarkJoin(const binder::expression_vector& joinNodeIDs,
         const std::shared_ptr<Expression>& mark, bool isProbeAcc, LogicalPlan& probePlan,
         LogicalPlan& buildPlan);
-    static void appendIntersect(const std::shared_ptr<NodeExpression>& intersectNode,
-        std::vector<std::shared_ptr<NodeExpression>>& boundNodes, LogicalPlan& probePlan,
+    static void appendIntersect(const std::shared_ptr<Expression>& intersectNodeID,
+        binder::expression_vector& boundNodeIDs, LogicalPlan& probePlan,
         std::vector<std::unique_ptr<LogicalPlan>>& buildPlans);
     static void appendCrossProduct(LogicalPlan& probePlan, LogicalPlan& buildPlan);
 

--- a/src/include/planner/logical_plan/logical_operator/base_logical_operator.h
+++ b/src/include/planner/logical_plan/logical_operator/base_logical_operator.h
@@ -69,6 +69,7 @@ public:
     // Used for operators with more than two children e.g. Union
     inline void addChild(std::shared_ptr<LogicalOperator> op) { children.push_back(std::move(op)); }
     inline std::shared_ptr<LogicalOperator> getChild(uint64_t idx) const { return children[idx]; }
+    inline std::vector<std::shared_ptr<LogicalOperator>> getChildren() const { return children; }
     inline void setChild(uint64_t idx, std::shared_ptr<LogicalOperator> child) {
         children[idx] = std::move(child);
     }

--- a/src/include/planner/logical_plan/logical_operator/flatten_resolver.h
+++ b/src/include/planner/logical_plan/logical_operator/flatten_resolver.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "planner/logical_plan/logical_operator/base_logical_operator.h"
+
+namespace kuzu {
+namespace planner {
+namespace factorization {
+
+struct FlattenAllButOne {
+    static f_group_pos_set getGroupsPosToFlatten(const f_group_pos_set& groupsPos, Schema* schema);
+};
+
+struct FlattenAll {
+    static f_group_pos_set getGroupsPosToFlatten(const f_group_pos_set& groupsPos, Schema* schema);
+};
+
+} // namespace factorization
+} // namespace planner
+} // namespace kuzu

--- a/src/include/planner/logical_plan/logical_operator/logical_aggregate.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_aggregate.h
@@ -13,6 +13,9 @@ public:
           expressionsToGroupBy{std::move(expressionsToGroupBy)}, expressionsToAggregate{std::move(
                                                                      expressionsToAggregate)} {}
 
+    f_group_pos_set getGroupsPosToFlattenForGroupBy();
+    f_group_pos_set getGroupsPosToFlattenForAggregate();
+
     void computeSchema() override;
 
     std::string getExpressionsForPrinting() const override;
@@ -30,6 +33,9 @@ public:
         return make_unique<LogicalAggregate>(
             expressionsToGroupBy, expressionsToAggregate, children[0]->copy());
     }
+
+private:
+    bool hasDistinctAggregate();
 
 private:
     binder::expression_vector expressionsToGroupBy;

--- a/src/include/planner/logical_plan/logical_operator/logical_create.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_create.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "flatten_resolver.h"
 #include "logical_update.h"
 
 namespace kuzu {
@@ -14,6 +15,14 @@ public:
     ~LogicalCreateNode() override = default;
 
     void computeSchema() override;
+
+    inline f_group_pos_set getGroupsPosToFlatten() {
+        // Flatten all inputs. E.g. MATCH (a) CREATE (b). We need to create b for each tuple in the
+        // match clause. This is to simplify operator implementation.
+        auto childSchema = children[0]->getSchema();
+        return factorization::FlattenAll::getGroupsPosToFlatten(
+            childSchema->getGroupsPosInScope(), childSchema);
+    }
 
     inline std::shared_ptr<binder::Expression> getPrimaryKey(size_t idx) const {
         return primaryKeys[idx];
@@ -35,6 +44,12 @@ public:
         : LogicalUpdateRel{LogicalOperatorType::CREATE_REL, std::move(rels), std::move(child)},
           setItemsPerRel{std::move(setItemsPerRel)} {}
     ~LogicalCreateRel() override = default;
+
+    inline f_group_pos_set getGroupsPosToFlatten() {
+        auto childSchema = children[0]->getSchema();
+        return factorization::FlattenAll::getGroupsPosToFlatten(
+            childSchema->getGroupsPosInScope(), childSchema);
+    }
 
     inline std::vector<binder::expression_pair> getSetItems(uint32_t idx) const {
         return setItemsPerRel[idx];

--- a/src/include/planner/logical_plan/logical_operator/logical_distinct.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_distinct.h
@@ -13,6 +13,8 @@ public:
         : LogicalOperator{LogicalOperatorType::DISTINCT, std::move(child)},
           expressionsToDistinct{std::move(expressionsToDistinct)} {}
 
+    f_group_pos_set getGroupsPosToFlatten();
+
     void computeSchema() override;
 
     std::string getExpressionsForPrinting() const override;

--- a/src/include/planner/logical_plan/logical_operator/logical_extend.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_extend.h
@@ -17,6 +17,8 @@ public:
           nbrNode{std::move(nbrNode)}, rel{std::move(rel)}, direction{direction},
           properties{std::move(properties)}, extendToNewGroup{extendToNewGroup} {}
 
+    f_group_pos_set getGroupsPosToFlatten();
+
     void computeSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {

--- a/src/include/planner/logical_plan/logical_operator/logical_filter.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_filter.h
@@ -13,6 +13,8 @@ public:
         : LogicalOperator{LogicalOperatorType::FILTER, std::move(child)}, expression{std::move(
                                                                               expression)} {}
 
+    f_group_pos_set getGroupsPosToFlatten();
+
     inline void computeSchema() override { copyChildSchema(0); }
 
     inline std::string getExpressionsForPrinting() const override {

--- a/src/include/planner/logical_plan/logical_operator/logical_flatten.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_flatten.h
@@ -8,25 +8,21 @@ namespace planner {
 
 class LogicalFlatten : public LogicalOperator {
 public:
-    LogicalFlatten(
-        std::shared_ptr<binder::Expression> expression, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::FLATTEN, std::move(child)}, expression{std::move(
-                                                                               expression)} {}
+    LogicalFlatten(f_group_pos groupPos, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::FLATTEN, std::move(child)}, groupPos{groupPos} {}
 
     void computeSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override {
-        return expression->getUniqueName();
-    }
+    inline std::string getExpressionsForPrinting() const override { return std::string{}; }
 
-    inline std::shared_ptr<binder::Expression> getExpression() const { return expression; }
+    inline f_group_pos getGroupPos() const { return groupPos; }
 
     inline std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalFlatten>(expression, children[0]->copy());
+        return make_unique<LogicalFlatten>(groupPos, children[0]->copy());
     }
 
 private:
-    std::shared_ptr<binder::Expression> expression;
+    f_group_pos groupPos;
 };
 
 } // namespace planner

--- a/src/include/planner/logical_plan/logical_operator/logical_intersect.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_intersect.h
@@ -33,6 +33,9 @@ public:
         }
     }
 
+    f_group_pos_set getGroupsPosToFlattenOnProbeSide();
+    f_group_pos_set getGroupsPosToFlattenOnBuildSide(uint32_t buildIdx);
+
     void computeSchema() override;
 
     std::string getExpressionsForPrinting() const override { return intersectNodeID->getRawName(); }

--- a/src/include/planner/logical_plan/logical_operator/logical_limit.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_limit.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "base_logical_operator.h"
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
 
 namespace kuzu {
 namespace planner {
@@ -9,6 +10,8 @@ class LogicalLimit : public LogicalOperator {
 public:
     LogicalLimit(uint64_t limitNumber, std::shared_ptr<LogicalOperator> child)
         : LogicalOperator{LogicalOperatorType::LIMIT, std::move(child)}, limitNumber{limitNumber} {}
+
+    f_group_pos_set getGroupsPosToFlatten();
 
     inline void computeSchema() override { copyChildSchema(0); }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_order_by.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_order_by.h
@@ -13,6 +13,8 @@ public:
           expressionsToOrderBy{std::move(expressionsToOrderBy)}, isAscOrders{std::move(sortOrders)},
           expressionsToMaterialize{std::move(expressionsToMaterialize)} {}
 
+    f_group_pos_set getGroupsPosToFlatten();
+
     void computeSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {

--- a/src/include/planner/logical_plan/logical_operator/logical_set.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_set.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "logical_update.h"
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
 
 namespace kuzu {
 namespace planner {
@@ -38,6 +39,8 @@ public:
         : LogicalUpdateRel{LogicalOperatorType::SET_REL_PROPERTY, std::move(rels),
               std::move(child)},
           setItems{std::move(setItems)} {}
+
+    f_group_pos_set getGroupsPosToFlatten(uint32_t setItemIdx);
 
     inline std::string getExpressionsForPrinting() const override {
         std::string result;

--- a/src/include/planner/logical_plan/logical_operator/logical_skip.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_skip.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "base_logical_operator.h"
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
 
 namespace kuzu {
 namespace planner {
@@ -9,6 +10,8 @@ class LogicalSkip : public LogicalOperator {
 public:
     LogicalSkip(uint64_t skipNumber, std::shared_ptr<LogicalOperator> child)
         : LogicalOperator(LogicalOperatorType::SKIP, std::move(child)), skipNumber{skipNumber} {}
+
+    f_group_pos_set getGroupsPosToFlatten();
 
     inline void computeSchema() override { copyChildSchema(0); }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_union.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_union.h
@@ -12,15 +12,22 @@ public:
         : LogicalOperator{LogicalOperatorType::UNION_ALL, std::move(children)},
           expressionsToUnion{std::move(expressions)} {}
 
+    f_group_pos_set getGroupsPosToFlatten(uint32_t childIdx);
+
     void computeSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override { return std::string(); }
+    inline std::string getExpressionsForPrinting() const override { return std::string{}; }
 
     inline binder::expression_vector getExpressionsToUnion() { return expressionsToUnion; }
 
     inline Schema* getSchemaBeforeUnion(uint32_t idx) { return children[idx]->getSchema(); }
 
     std::unique_ptr<LogicalOperator> copy() override;
+
+private:
+    // If an expression to union has different flat/unflat state in different child, we
+    // need to flatten that expression in all the single queries.
+    bool requireFlatExpression(uint32_t expressionIdx);
 
 private:
     binder::expression_vector expressionsToUnion;

--- a/src/include/planner/logical_plan/logical_operator/logical_unwind.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_unwind.h
@@ -13,6 +13,8 @@ public:
         : LogicalOperator{LogicalOperatorType::UNWIND, std::move(childOperator)},
           expression{std::move(expression)}, aliasExpression{std::move(aliasExpression)} {}
 
+    f_group_pos_set getGroupsPosToFlatten();
+
     void computeSchema() override;
 
     inline std::shared_ptr<binder::Expression> getExpression() { return expression; }

--- a/src/include/planner/logical_plan/logical_operator/schema.h
+++ b/src/include/planner/logical_plan/logical_operator/schema.h
@@ -8,6 +8,7 @@ namespace kuzu {
 namespace planner {
 
 typedef uint32_t f_group_pos;
+typedef std::unordered_set<f_group_pos> f_group_pos_set;
 constexpr f_group_pos INVALID_F_GROUP_POS = UINT32_MAX;
 
 class FactorizationGroup {

--- a/src/include/planner/query_planner.h
+++ b/src/include/planner/query_planner.h
@@ -60,18 +60,8 @@ private:
 
     static void appendUnwind(BoundUnwindClause& boundUnwindClause, LogicalPlan& plan);
 
-    static void appendFlattens(const std::unordered_set<uint32_t>& groupsPos, LogicalPlan& plan);
-    // return position of the only unFlat group
-    // or position of any flat group if there is no unFlat group.
-    static uint32_t appendFlattensButOne(
-        const std::unordered_set<uint32_t>& groupsPos, LogicalPlan& plan);
-    static void appendFlattenIfNecessary(
-        const std::shared_ptr<Expression>& expression, LogicalPlan& plan);
-    static inline void appendFlattenIfNecessary(uint32_t groupPos, LogicalPlan& plan) {
-        auto expressions = plan.getSchema()->getExpressionsInScope(groupPos);
-        assert(!expressions.empty());
-        appendFlattenIfNecessary(expressions[0], plan);
-    }
+    static void appendFlattens(const f_group_pos_set& groupsPos, LogicalPlan& plan);
+    static void appendFlattenIfNecessary(f_group_pos groupPos, LogicalPlan& plan);
 
     void appendFilter(const std::shared_ptr<Expression>& expression, LogicalPlan& plan);
 

--- a/src/include/planner/update_planner.h
+++ b/src/include/planner/update_planner.h
@@ -43,8 +43,6 @@ private:
         LogicalPlan& plan);
     void appendDeleteRel(
         const std::vector<std::shared_ptr<binder::RelExpression>>& deleteRels, LogicalPlan& plan);
-
-    void flattenRel(const binder::RelExpression& rel, LogicalPlan& plan);
 };
 
 } // namespace planner

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -1,7 +1,9 @@
 add_library(kuzu_optimizer
         OBJECT
+        factorization_rewriter.cpp
         index_nested_loop_join_optimizer.cpp
-        optimizer.cpp)
+        optimizer.cpp
+        remove_factorization_rewriter.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_optimizer>

--- a/src/optimizer/factorization_rewriter.cpp
+++ b/src/optimizer/factorization_rewriter.cpp
@@ -1,0 +1,253 @@
+#include "optimizer/factorization_rewriter.h"
+
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+#include "planner/logical_plan/logical_operator/logical_aggregate.h"
+#include "planner/logical_plan/logical_operator/logical_create.h"
+#include "planner/logical_plan/logical_operator/logical_delete.h"
+#include "planner/logical_plan/logical_operator/logical_distinct.h"
+#include "planner/logical_plan/logical_operator/logical_extend.h"
+#include "planner/logical_plan/logical_operator/logical_filter.h"
+#include "planner/logical_plan/logical_operator/logical_flatten.h"
+#include "planner/logical_plan/logical_operator/logical_hash_join.h"
+#include "planner/logical_plan/logical_operator/logical_intersect.h"
+#include "planner/logical_plan/logical_operator/logical_limit.h"
+#include "planner/logical_plan/logical_operator/logical_order_by.h"
+#include "planner/logical_plan/logical_operator/logical_projection.h"
+#include "planner/logical_plan/logical_operator/logical_set.h"
+#include "planner/logical_plan/logical_operator/logical_skip.h"
+#include "planner/logical_plan/logical_operator/logical_union.h"
+#include "planner/logical_plan/logical_operator/logical_unwind.h"
+
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace optimizer {
+
+void FactorizationRewriter::rewrite(planner::LogicalPlan* plan) {
+    visitOperator(plan->getLastOperator().get());
+}
+
+void FactorizationRewriter::visitOperator(planner::LogicalOperator* op) {
+    // bottom-up traversal
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
+        visitOperator(op->getChild(i).get());
+    }
+    switch (op->getOperatorType()) {
+    case LogicalOperatorType::EXTEND: {
+        visitExtend(op);
+    } break;
+    case LogicalOperatorType::HASH_JOIN: {
+        visitHashJoin(op);
+    } break;
+    case LogicalOperatorType::INTERSECT: {
+        visitIntersect(op);
+    } break;
+    case LogicalOperatorType::PROJECTION: {
+        visitProjection(op);
+    } break;
+    case LogicalOperatorType::AGGREGATE: {
+        visitAggregate(op);
+    } break;
+    case LogicalOperatorType::ORDER_BY: {
+        visitOrderBy(op);
+    } break;
+    case LogicalOperatorType::SKIP: {
+        visitSkip(op);
+    } break;
+    case LogicalOperatorType::LIMIT: {
+        visitLimit(op);
+    } break;
+    case LogicalOperatorType::DISTINCT: {
+        visitDistinct(op);
+    } break;
+    case LogicalOperatorType::UNWIND: {
+        visitUnwind(op);
+    } break;
+    case LogicalOperatorType::UNION_ALL: {
+        visitUnion(op);
+    } break;
+    case LogicalOperatorType::FILTER: {
+        visitFilter(op);
+    } break;
+    case LogicalOperatorType::SET_NODE_PROPERTY: {
+        visitSetNodeProperty(op);
+    } break;
+    case LogicalOperatorType::SET_REL_PROPERTY: {
+        visitSetRelProperty(op);
+    } break;
+    case LogicalOperatorType::DELETE_REL: {
+        visitDeleteRel(op);
+    } break;
+    case LogicalOperatorType::CREATE_NODE: {
+        visitCreateNode(op);
+    } break;
+    case LogicalOperatorType::CREATE_REL: {
+        visitCreateRel(op);
+    } break;
+    default:
+        break;
+    }
+    op->computeSchema();
+}
+
+void FactorizationRewriter::visitExtend(planner::LogicalOperator* op) {
+    auto extend = (LogicalExtend*)op;
+    auto groupsPosToFlatten = extend->getGroupsPosToFlatten();
+    extend->setChild(0, appendFlattens(extend->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitHashJoin(planner::LogicalOperator* op) {
+    auto hashJoin = (LogicalHashJoin*)op;
+    auto groupsPosToFlattenOnProbeSide = hashJoin->getGroupsPosToFlattenOnProbeSide();
+    hashJoin->setChild(0, appendFlattens(hashJoin->getChild(0), groupsPosToFlattenOnProbeSide));
+    auto groupsPosToFlattenOnBuildSide = hashJoin->getGroupsPosToFlattenOnBuildSide();
+    hashJoin->setChild(1, appendFlattens(hashJoin->getChild(1), groupsPosToFlattenOnBuildSide));
+}
+
+void FactorizationRewriter::visitIntersect(planner::LogicalOperator* op) {
+    auto intersect = (LogicalIntersect*)op;
+    auto groupsPosToFlattenOnProbeSide = intersect->getGroupsPosToFlattenOnProbeSide();
+    intersect->setChild(0, appendFlattens(intersect->getChild(0), groupsPosToFlattenOnProbeSide));
+    for (auto i = 0u; i < intersect->getNumBuilds(); ++i) {
+        auto groupPosToFlatten = intersect->getGroupsPosToFlattenOnBuildSide(i);
+        auto childIdx = i + 1; // skip probe
+        intersect->setChild(
+            childIdx, appendFlattens(intersect->getChild(childIdx), groupPosToFlatten));
+    }
+}
+
+void FactorizationRewriter::visitProjection(planner::LogicalOperator* op) {
+    auto projection = (LogicalProjection*)op;
+    for (auto& expression : projection->getExpressionsToProject()) {
+        auto dependentGroupsPos = op->getChild(0)->getSchema()->getDependentGroupsPos(expression);
+        auto groupsPosToFlatten = factorization::FlattenAllButOne::getGroupsPosToFlatten(
+            dependentGroupsPos, op->getChild(0)->getSchema());
+        projection->setChild(0, appendFlattens(projection->getChild(0), groupsPosToFlatten));
+    }
+}
+
+void FactorizationRewriter::visitAggregate(planner::LogicalOperator* op) {
+    auto aggregate = (LogicalAggregate*)op;
+    auto groupsPosToFlattenForGroupBy = aggregate->getGroupsPosToFlattenForGroupBy();
+    aggregate->setChild(0, appendFlattens(aggregate->getChild(0), groupsPosToFlattenForGroupBy));
+    auto groupsPosToFlattenForAggregate = aggregate->getGroupsPosToFlattenForAggregate();
+    aggregate->setChild(0, appendFlattens(aggregate->getChild(0), groupsPosToFlattenForAggregate));
+}
+
+void FactorizationRewriter::visitOrderBy(planner::LogicalOperator* op) {
+    auto orderBy = (LogicalOrderBy*)op;
+    auto groupsPosToFlatten = orderBy->getGroupsPosToFlatten();
+    orderBy->setChild(0, appendFlattens(orderBy->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitSkip(planner::LogicalOperator* op) {
+    auto skip = (LogicalSkip*)op;
+    auto groupsPosToFlatten = skip->getGroupsPosToFlatten();
+    skip->setChild(0, appendFlattens(skip->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitLimit(planner::LogicalOperator* op) {
+    auto limit = (LogicalLimit*)op;
+    auto groupsPosToFlatten = limit->getGroupsPosToFlatten();
+    limit->setChild(0, appendFlattens(limit->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitDistinct(planner::LogicalOperator* op) {
+    auto distinct = (LogicalDistinct*)op;
+    auto groupsPosToFlatten = distinct->getGroupsPosToFlatten();
+    distinct->setChild(0, appendFlattens(distinct->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitUnwind(planner::LogicalOperator* op) {
+    auto unwind = (LogicalUnwind*)op;
+    auto groupsPosToFlatten = unwind->getGroupsPosToFlatten();
+    unwind->setChild(0, appendFlattens(unwind->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitUnion(planner::LogicalOperator* op) {
+    auto union_ = (LogicalUnion*)op;
+    for (auto i = 0u; i < union_->getNumChildren(); ++i) {
+        auto groupsPosToFlatten = union_->getGroupsPosToFlatten(i);
+        union_->setChild(i, appendFlattens(union_->getChild(i), groupsPosToFlatten));
+    }
+}
+
+void FactorizationRewriter::visitFilter(planner::LogicalOperator* op) {
+    auto filter = (LogicalFilter*)op;
+    auto groupsPosToFlatten = filter->getGroupsPosToFlatten();
+    filter->setChild(0, appendFlattens(filter->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitSetNodeProperty(planner::LogicalOperator* op) {
+    auto setNodeProperty = (LogicalSetNodeProperty*)op;
+    for (auto i = 0u; i < setNodeProperty->getNumNodes(); ++i) {
+        auto lhsNodeID = setNodeProperty->getNode(i)->getInternalIDProperty();
+        auto rhs = setNodeProperty->getSetItem(i).second;
+        // flatten rhs
+        auto rhsDependentGroupsPos = op->getChild(0)->getSchema()->getDependentGroupsPos(rhs);
+        auto rhsGroupsPosToFlatten = factorization::FlattenAllButOne::getGroupsPosToFlatten(
+            rhsDependentGroupsPos, op->getChild(0)->getSchema());
+        setNodeProperty->setChild(
+            0, appendFlattens(setNodeProperty->getChild(0), rhsGroupsPosToFlatten));
+        // flatten lhs if needed
+        auto lhsGroupPos = op->getChild(0)->getSchema()->getGroupPos(*lhsNodeID);
+        auto rhsLeadingGroupPos =
+            SchemaUtils::getLeadingGroupPos(rhsDependentGroupsPos, *op->getChild(0)->getSchema());
+        if (lhsGroupPos != rhsLeadingGroupPos) {
+            setNodeProperty->setChild(
+                0, appendFlattenIfNecessary(setNodeProperty->getChild(0), lhsGroupPos));
+        }
+    }
+}
+
+void FactorizationRewriter::visitSetRelProperty(planner::LogicalOperator* op) {
+    auto setRelProperty = (LogicalSetRelProperty*)op;
+    for (auto i = 0u; i < setRelProperty->getNumRels(); ++i) {
+        auto groupsPosToFlatten = setRelProperty->getGroupsPosToFlatten(i);
+        setRelProperty->setChild(
+            0, appendFlattens(setRelProperty->getChild(0), groupsPosToFlatten));
+    }
+}
+
+void FactorizationRewriter::visitDeleteRel(planner::LogicalOperator* op) {
+    auto deleteRel = (LogicalDeleteRel*)op;
+    for (auto i = 0u; i < deleteRel->getNumRels(); ++i) {
+        auto groupsPosToFlatten = deleteRel->getGroupsPosToFlatten(i);
+        deleteRel->setChild(0, appendFlattens(deleteRel->getChild(0), groupsPosToFlatten));
+    }
+}
+
+void FactorizationRewriter::visitCreateNode(planner::LogicalOperator* op) {
+    auto createNode = (LogicalCreateNode*)op;
+    auto groupsPosToFlatten = createNode->getGroupsPosToFlatten();
+    createNode->setChild(0, appendFlattens(createNode->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitCreateRel(planner::LogicalOperator* op) {
+    auto createRel = (LogicalCreateRel*)op;
+    auto groupsPosToFlatten = createRel->getGroupsPosToFlatten();
+    createRel->setChild(0, appendFlattens(createRel->getChild(0), groupsPosToFlatten));
+}
+
+std::shared_ptr<planner::LogicalOperator> FactorizationRewriter::appendFlattens(
+    std::shared_ptr<planner::LogicalOperator> op,
+    const std::unordered_set<f_group_pos>& groupsPos) {
+    auto currentChild = std::move(op);
+    for (auto groupPos : groupsPos) {
+        currentChild = appendFlattenIfNecessary(std::move(currentChild), groupPos);
+    }
+    return currentChild;
+}
+
+std::shared_ptr<planner::LogicalOperator> FactorizationRewriter::appendFlattenIfNecessary(
+    std::shared_ptr<planner::LogicalOperator> op, planner::f_group_pos groupPos) {
+    if (op->getSchema()->getGroup(groupPos)->isFlat()) {
+        return op;
+    }
+    auto flatten = std::make_shared<LogicalFlatten>(groupPos, std::move(op));
+    flatten->computeSchema();
+    return flatten;
+}
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/optimizer/index_nested_loop_join_optimizer.cpp
+++ b/src/optimizer/index_nested_loop_join_optimizer.cpp
@@ -18,7 +18,6 @@ std::shared_ptr<planner::LogicalOperator> IndexNestedLoopJoinOptimizer::rewrite(
     for (auto i = 0u; i < op->getNumChildren(); ++i) {
         op->setChild(i, rewrite(op->getChild(i)));
     }
-    op->computeSchema();
     return op;
 }
 
@@ -50,11 +49,6 @@ std::shared_ptr<LogicalOperator> IndexNestedLoopJoinOptimizer::rewriteFilter(
         return op;
     }
     auto currentOp = op->getChild(0);
-    // Match flatten. TODO(Xiyang): remove flatten as a logical operator.
-    if (currentOp->getOperatorType() != LogicalOperatorType::FLATTEN) {
-        return op;
-    }
-    currentOp = currentOp->getChild(0);
     // Match cross product
     if (currentOp->getOperatorType() != LogicalOperatorType::CROSS_PRODUCT) {
         return op;
@@ -92,7 +86,6 @@ std::shared_ptr<LogicalOperator> IndexNestedLoopJoinOptimizer::rewriteCrossProdu
         rightOp = rightOp->getChild(0);
     }
     auto newRoot = op->getChild(1);
-    newRoot->computeSchemaRecursive();
     return newRoot;
 }
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -1,12 +1,20 @@
 #include "optimizer/optimizer.h"
 
+#include "optimizer/factorization_rewriter.h"
 #include "optimizer/index_nested_loop_join_optimizer.h"
+#include "optimizer/remove_factorization_rewriter.h"
 
 namespace kuzu {
 namespace optimizer {
 
 void Optimizer::optimize(planner::LogicalPlan* plan) {
+    auto removeFactorizationRewriter = RemoveFactorizationRewriter();
+    removeFactorizationRewriter.rewrite(plan);
+
     IndexNestedLoopJoinOptimizer::rewrite(plan->getLastOperator());
+
+    auto factorizationRewriter = FactorizationRewriter();
+    factorizationRewriter.rewrite(plan);
 }
 
 } // namespace optimizer

--- a/src/optimizer/remove_factorization_rewriter.cpp
+++ b/src/optimizer/remove_factorization_rewriter.cpp
@@ -1,0 +1,43 @@
+#include "optimizer/remove_factorization_rewriter.h"
+
+#include "common/exception.h"
+
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace optimizer {
+
+void RemoveFactorizationRewriter::rewrite(planner::LogicalPlan* plan) {
+    auto root = plan->getLastOperator();
+    rewriteOperator(root);
+    if (subPlanHasFlatten(root.get())) {
+        throw common::InternalException("Remove factorization rewriter failed.");
+    }
+}
+
+std::shared_ptr<planner::LogicalOperator> RemoveFactorizationRewriter::rewriteOperator(
+    std::shared_ptr<planner::LogicalOperator> op) {
+    // bottom-up traversal
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
+        op->setChild(i, rewriteOperator(op->getChild(i)));
+    }
+    if (op->getOperatorType() == planner::LogicalOperatorType::FLATTEN) {
+        return op->getChild(0);
+    }
+    return op;
+}
+
+bool RemoveFactorizationRewriter::subPlanHasFlatten(planner::LogicalOperator* op) {
+    if (op->getOperatorType() == planner::LogicalOperatorType::FLATTEN) {
+        return true;
+    }
+    for (auto& child : op->getChildren()) {
+        if (subPlanHasFlatten(child.get())) {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/planner/operator/CMakeLists.txt
+++ b/src/planner/operator/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(kuzu_planner_operator
         OBJECT
         base_logical_operator.cpp
+        flatten_resolver.cpp
         logical_accumulate.cpp
         logical_aggregate.cpp
         logical_create.cpp
@@ -20,6 +21,7 @@ add_library(kuzu_planner_operator
         logical_projection.cpp
         logical_scan_node.cpp
         logical_scan_node_property.cpp
+        logical_set.cpp
         logical_skip.cpp
         logical_union.cpp
         logical_unwind.cpp

--- a/src/planner/operator/flatten_resolver.cpp
+++ b/src/planner/operator/flatten_resolver.cpp
@@ -1,0 +1,36 @@
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+
+namespace kuzu {
+namespace planner {
+namespace factorization {
+
+f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(
+    const f_group_pos_set& groupsPos, Schema* schema) {
+    std::vector<f_group_pos> unFlatGroupsPos;
+    for (auto groupPos : groupsPos) {
+        if (!schema->getGroup(groupPos)->isFlat()) {
+            unFlatGroupsPos.push_back(groupPos);
+        }
+    }
+    f_group_pos_set result;
+    // Keep the first group as unFlat.
+    for (auto i = 1u; i < unFlatGroupsPos.size(); ++i) {
+        result.insert(unFlatGroupsPos[i]);
+    }
+    return result;
+}
+
+f_group_pos_set FlattenAll::getGroupsPosToFlatten(
+    const f_group_pos_set& groupsPos, Schema* schema) {
+    f_group_pos_set result;
+    for (auto groupPos : groupsPos) {
+        if (!schema->getGroup(groupPos)->isFlat()) {
+            result.insert(groupPos);
+        }
+    }
+    return result;
+}
+
+} // namespace factorization
+} // namespace planner
+} // namespace kuzu

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -1,7 +1,20 @@
 #include "planner/logical_plan/logical_operator/logical_distinct.h"
 
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+
 namespace kuzu {
 namespace planner {
+
+f_group_pos_set LogicalDistinct::getGroupsPosToFlatten() {
+    f_group_pos_set dependentGroupsPos;
+    auto childSchema = children[0]->getSchema();
+    for (auto& expression : expressionsToDistinct) {
+        for (auto groupPos : childSchema->getDependentGroupsPos(expression)) {
+            dependentGroupsPos.insert(groupPos);
+        }
+    }
+    return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+}
 
 std::string LogicalDistinct::getExpressionsForPrinting() const {
     std::string result;

--- a/src/planner/operator/logical_extend.cpp
+++ b/src/planner/operator/logical_extend.cpp
@@ -1,7 +1,22 @@
 #include "planner/logical_plan/logical_operator/logical_extend.h"
 
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+
 namespace kuzu {
 namespace planner {
+
+f_group_pos_set LogicalExtend::getGroupsPosToFlatten() {
+    f_group_pos_set result;
+    auto requireFlatBoundNode = extendToNewGroup || rel->isVariableLength();
+    if (requireFlatBoundNode) {
+        auto inSchema = children[0]->getSchema();
+        auto boundNodeGroupPos = inSchema->getGroupPos(*boundNode->getInternalIDProperty());
+        if (!inSchema->getGroup(boundNodeGroupPos)->isFlat()) {
+            result.insert(boundNodeGroupPos);
+        }
+    }
+    return result;
+}
 
 void LogicalExtend::computeSchema() {
     copyChildSchema(0);

--- a/src/planner/operator/logical_filter.cpp
+++ b/src/planner/operator/logical_filter.cpp
@@ -1,7 +1,15 @@
 #include "planner/logical_plan/logical_operator/logical_filter.h"
 
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+
 namespace kuzu {
 namespace planner {
+
+f_group_pos_set LogicalFilter::getGroupsPosToFlatten() {
+    auto childSchema = children[0]->getSchema();
+    auto dependentGroupsPos = childSchema->getDependentGroupsPos(expression);
+    return factorization::FlattenAllButOne::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+}
 
 f_group_pos LogicalFilter::getGroupPosToSelect() const {
     auto childSchema = children[0]->getSchema();

--- a/src/planner/operator/logical_flatten.cpp
+++ b/src/planner/operator/logical_flatten.cpp
@@ -5,7 +5,6 @@ namespace planner {
 
 void LogicalFlatten::computeSchema() {
     copyChildSchema(0);
-    auto groupPos = schema->getGroupPos(expression->getUniqueName());
     schema->flattenGroup(groupPos);
 }
 

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -1,9 +1,32 @@
 #include "planner/logical_plan/logical_operator/logical_hash_join.h"
 
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+#include "planner/logical_plan/logical_operator/logical_scan_node.h"
 #include "planner/logical_plan/logical_operator/sink_util.h"
 
 namespace kuzu {
 namespace planner {
+
+f_group_pos_set LogicalHashJoin::getGroupsPosToFlattenOnProbeSide() {
+    f_group_pos_set result;
+    if (!requireFlatProbeKeys()) {
+        return result;
+    }
+    auto probeSchema = children[0]->getSchema();
+    for (auto& joinNodeID : joinNodeIDs) {
+        result.insert(probeSchema->getGroupPos(*joinNodeID));
+    }
+    return result;
+}
+
+f_group_pos_set LogicalHashJoin::getGroupsPosToFlattenOnBuildSide() {
+    auto buildSchema = children[1]->getSchema();
+    f_group_pos_set joinNodesGroupPos;
+    for (auto& joinNodeID : joinNodeIDs) {
+        joinNodesGroupPos.insert(buildSchema->getGroupPos(*joinNodeID));
+    }
+    return factorization::FlattenAllButOne::getGroupsPosToFlatten(joinNodesGroupPos, buildSchema);
+}
 
 void LogicalHashJoin::computeSchema() {
     auto probeSchema = children[0]->getSchema();
@@ -54,6 +77,42 @@ void LogicalHashJoin::computeSchema() {
         auto markPos = *probeSideKeyGroupPositions.begin();
         schema->insertToGroupAndScope(mark, markPos);
     }
+}
+
+bool LogicalHashJoin::requireFlatProbeKeys() {
+    if (joinNodeIDs.size() > 1) {
+        return true;
+    }
+    auto joinNodeID = joinNodeIDs[0].get();
+    return !isJoinKeyUniqueOnBuildSide(*joinNodeID);
+}
+
+bool LogicalHashJoin::isJoinKeyUniqueOnBuildSide(const binder::Expression& joinNodeID) {
+    auto buildSchema = children[1]->getSchema();
+    auto numGroupsInScope = buildSchema->getGroupsPosInScope().size();
+    bool hasProjectedOutGroups = buildSchema->getNumGroups() > numGroupsInScope;
+    if (numGroupsInScope > 1 || hasProjectedOutGroups) {
+        return false;
+    }
+    // Now there is a single factorization group, we need to further make sure joinNodeID comes from
+    // ScanNodeID operator. Because if joinNodeID comes from a ColExtend we cannot guarantee the
+    // reverse mapping is still many-to-one. We look for the most simple pattern where build plan is
+    // linear.
+    auto op = children[1].get();
+    while (op->getNumChildren() != 0) {
+        if (op->getNumChildren() > 1) {
+            return false;
+        }
+        op = op->getChild(0).get();
+    }
+    if (op->getOperatorType() != LogicalOperatorType::SCAN_NODE) {
+        return false;
+    }
+    auto scanNodeID = (LogicalScanNode*)op;
+    if (scanNodeID->getNode()->getInternalIDPropertyName() != joinNodeID.getUniqueName()) {
+        return false;
+    }
+    return true;
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_intersect.cpp
+++ b/src/planner/operator/logical_intersect.cpp
@@ -3,6 +3,21 @@
 namespace kuzu {
 namespace planner {
 
+f_group_pos_set LogicalIntersect::getGroupsPosToFlattenOnProbeSide() {
+    f_group_pos_set result;
+    for (auto& buildInfo : buildInfos) {
+        result.insert(children[0]->getSchema()->getGroupPos(*buildInfo->keyNodeID));
+    }
+    return result;
+}
+
+f_group_pos_set LogicalIntersect::getGroupsPosToFlattenOnBuildSide(uint32_t buildIdx) {
+    f_group_pos_set result;
+    auto childIdx = buildIdx + 1; // skip probe
+    result.insert(children[childIdx]->getSchema()->getGroupPos(*buildInfos[buildIdx]->keyNodeID));
+    return result;
+}
+
 void LogicalIntersect::computeSchema() {
     auto probeSchema = children[0]->getSchema();
     schema = probeSchema->copy();

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -3,6 +3,12 @@
 namespace kuzu {
 namespace planner {
 
+f_group_pos_set LogicalLimit::getGroupsPosToFlatten() {
+    auto childSchema = children[0]->getSchema();
+    return factorization::FlattenAllButOne::getGroupsPosToFlatten(
+        childSchema->getGroupsPosInScope(), childSchema);
+}
+
 f_group_pos LogicalLimit::getGroupPosToSelect() const {
     auto childSchema = children[0]->getSchema();
     auto groupsPosInScope = childSchema->getGroupsPosInScope();

--- a/src/planner/operator/logical_order_by.cpp
+++ b/src/planner/operator/logical_order_by.cpp
@@ -1,9 +1,37 @@
 #include "planner/logical_plan/logical_operator/logical_order_by.h"
 
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
 #include "planner/logical_plan/logical_operator/sink_util.h"
 
 namespace kuzu {
 namespace planner {
+
+f_group_pos_set LogicalOrderBy::getGroupsPosToFlatten() {
+    // We only allow orderby key(s) to be unflat, if they are all part of the same factorization
+    // group and there is no other factorized group in the schema, so any payload is also unflat
+    // and part of the same factorization group. The rationale for this limitation is this: (1)
+    // to keep both the frontend and orderby operators simpler, we want order by to not change
+    // the schema, so the input and output of order by should have the same factorization
+    // structure. (2) Because orderby needs to flatten the keys to sort, if a key column that is
+    // unflat is the input, we need to somehow flatten it in the factorized table. However
+    // whenever we can we want to avoid adding an explicit flatten operator as this makes us
+    // fall back to tuple-at-a-time processing. However in the specified limited case, we can
+    // give factorized table a set of unflat vectors (all in the same datachunk/factorization
+    // group), sort the table, and scan into unflat vectors, so the schema remains the same. In
+    // more complicated cases, e.g., when there are 2 factorization groups, FactorizedTable
+    // cannot read back a flat column into an unflat std::vector.
+    auto childSchema = children[0]->getSchema();
+    if (childSchema->getNumGroups() > 1) {
+        f_group_pos_set dependentGroupsPos;
+        for (auto& expression : expressionsToOrderBy) {
+            for (auto groupPos : childSchema->getDependentGroupsPos(expression)) {
+                dependentGroupsPos.insert(groupPos);
+            }
+        }
+        return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+    }
+    return f_group_pos_set{};
+}
 
 void LogicalOrderBy::computeSchema() {
     auto childSchema = children[0]->getSchema();

--- a/src/planner/operator/logical_set.cpp
+++ b/src/planner/operator/logical_set.cpp
@@ -1,0 +1,22 @@
+#include "planner/logical_plan/logical_operator/logical_set.h"
+
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+
+namespace kuzu {
+namespace planner {
+
+f_group_pos_set LogicalSetRelProperty::getGroupsPosToFlatten(uint32_t setItemIdx) {
+    f_group_pos_set result;
+    auto rel = rels[setItemIdx];
+    auto rhs = setItems[setItemIdx].second;
+    auto childSchema = children[0]->getSchema();
+    result.insert(childSchema->getGroupPos(*rel->getSrcNode()->getInternalIDProperty()));
+    result.insert(childSchema->getGroupPos(*rel->getDstNode()->getInternalIDProperty()));
+    for (auto groupPos : childSchema->getDependentGroupsPos(rhs)) {
+        result.insert(groupPos);
+    }
+    return factorization::FlattenAll::getGroupsPosToFlatten(result, childSchema);
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/src/planner/operator/logical_skip.cpp
+++ b/src/planner/operator/logical_skip.cpp
@@ -3,6 +3,12 @@
 namespace kuzu {
 namespace planner {
 
+f_group_pos_set LogicalSkip::getGroupsPosToFlatten() {
+    auto childSchema = children[0]->getSchema();
+    return factorization::FlattenAllButOne::getGroupsPosToFlatten(
+        childSchema->getGroupsPosInScope(), childSchema);
+}
+
 f_group_pos LogicalSkip::getGroupPosToSelect() const {
     auto childSchema = children[0]->getSchema();
     auto groupsPosInScope = childSchema->getGroupsPosInScope();

--- a/src/planner/operator/logical_union.cpp
+++ b/src/planner/operator/logical_union.cpp
@@ -1,9 +1,22 @@
 #include "planner/logical_plan/logical_operator/logical_union.h"
 
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
 #include "planner/logical_plan/logical_operator/sink_util.h"
 
 namespace kuzu {
 namespace planner {
+
+f_group_pos_set LogicalUnion::getGroupsPosToFlatten(uint32_t childIdx) {
+    f_group_pos_set groupsPos;
+    auto childSchema = children[childIdx]->getSchema();
+    for (auto i = 0u; i < expressionsToUnion.size(); ++i) {
+        if (requireFlatExpression(i)) {
+            auto expression = childSchema->getExpressionsInScope()[i];
+            groupsPos.insert(childSchema->getGroupPos(*expression));
+        }
+    }
+    return factorization::FlattenAll::getGroupsPosToFlatten(groupsPos, childSchema);
+}
 
 void LogicalUnion::computeSchema() {
     auto firstChildSchema = children[0]->getSchema();
@@ -18,6 +31,17 @@ std::unique_ptr<LogicalOperator> LogicalUnion::copy() {
         copiedChildren.push_back(getChild(i)->copy());
     }
     return make_unique<LogicalUnion>(expressionsToUnion, std::move(copiedChildren));
+}
+
+bool LogicalUnion::requireFlatExpression(uint32_t expressionIdx) {
+    for (auto& child : children) {
+        auto childSchema = child->getSchema();
+        auto expression = childSchema->getExpressionsInScope()[expressionIdx];
+        if (childSchema->getGroup(expression)->isFlat()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_unwind.cpp
+++ b/src/planner/operator/logical_unwind.cpp
@@ -1,7 +1,15 @@
 #include "planner/logical_plan/logical_operator/logical_unwind.h"
 
+#include "planner/logical_plan/logical_operator/flatten_resolver.h"
+
 namespace kuzu {
 namespace planner {
+
+f_group_pos_set LogicalUnwind::getGroupsPosToFlatten() {
+    auto childSchema = children[0]->getSchema();
+    auto dependentGroupsPos = childSchema->getDependentGroupsPos(expression);
+    return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+}
 
 void LogicalUnwind::computeSchema() {
     copyChildSchema(0);

--- a/src/processor/mapper/map_flatten.cpp
+++ b/src/processor/mapper/map_flatten.cpp
@@ -10,11 +10,9 @@ namespace processor {
 std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalFlattenToPhysical(
     LogicalOperator* logicalOperator) {
     auto flatten = (LogicalFlatten*)logicalOperator;
-    auto inSchema = flatten->getChild(0)->getSchema();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
-    auto dataChunkPos = inSchema->getExpressionPos(*flatten->getExpression()).first;
-    return make_unique<Flatten>(
-        dataChunkPos, move(prevOperator), getOperatorID(), flatten->getExpressionsForPrinting());
+    return make_unique<Flatten>(flatten->getGroupPos(), std::move(prevOperator), getOperatorID(),
+        flatten->getExpressionsForPrinting());
 }
 
 } // namespace processor

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -132,6 +132,19 @@ False
 [[10]]
 [[7],[10],[6,7]]
 
+-NAME CrossProductReturn
+-QUERY MATCH (a:organisation), (b:organisation) RETURN a.orgCode = b.orgCode
+---- 9
+False
+False
+False
+False
+False
+False
+True
+True
+True
+
 -NAME KnowsOneHopTest1
 -QUERY MATCH (a:person)-[e:knows]->(b:person) WHERE b.age=20 RETURN b.age
 ---- 3


### PR DESCRIPTION
This PR adds remove_factorization_rewriter and factorization_rewriter to decouple optimizer and planner

- remove_factorization_rewriter
  - remove flatten operator from the logical plan
  - clear factorization schema
- factorization_rewriter 
  - insert flatten back to logical plan
  - recompute factorization schema 

