### PR TITLE
Replace getRawName with toString

### DIFF
--- a/src/binder/CMakeLists.txt
+++ b/src/binder/CMakeLists.txt
@@ -6,6 +6,7 @@ add_subdirectory(query)
 add_library(kuzu_binder
         OBJECT
         binder.cpp
+        bound_statement_result.cpp
         expression_binder.cpp
         query_normalizer.cpp)
 

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -58,8 +58,8 @@ static void validateNodeRelConnectivity(const Catalog& catalog_, const RelExpres
             }
         }
     }
-    throw BinderException("Nodes " + srcNode.getRawName() + " and " + dstNode.getRawName() +
-                          " are not connected through rel " + rel.getRawName() + ".");
+    throw BinderException("Nodes " + srcNode.toString() + " and " + dstNode.toString() +
+                          " are not connected through rel " + rel.toString() + ".");
 }
 
 static std::vector<std::pair<std::string, std::vector<Property>>> getPropertyNameAndSchemasPairs(
@@ -126,10 +126,9 @@ void Binder::bindQueryRel(const RelPattern& relPattern,
     }
     // bind variable length
     auto [lowerBound, upperBound] = bindVariableLengthRelBound(relPattern);
-    auto queryRel = make_shared<RelExpression>(
-        getUniqueExpressionName(parsedName), tableIDs, srcNode, dstNode, lowerBound, upperBound);
+    auto queryRel = make_shared<RelExpression>(getUniqueExpressionName(parsedName), parsedName,
+        tableIDs, srcNode, dstNode, lowerBound, upperBound);
     queryRel->setAlias(parsedName);
-    queryRel->setRawName(parsedName);
     validateNodeRelConnectivity(catalog, *queryRel, *srcNode, *dstNode);
     // resolve properties associate with rel table
     std::vector<RelTableSchema*> relTableSchemas;
@@ -205,9 +204,9 @@ std::shared_ptr<NodeExpression> Binder::bindQueryNode(
 std::shared_ptr<NodeExpression> Binder::createQueryNode(const NodePattern& nodePattern) {
     auto parsedName = nodePattern.getVariableName();
     auto tableIDs = bindNodeTableIDs(nodePattern.getTableNames());
-    auto queryNode = make_shared<NodeExpression>(getUniqueExpressionName(parsedName), tableIDs);
+    auto queryNode =
+        make_shared<NodeExpression>(getUniqueExpressionName(parsedName), parsedName, tableIDs);
     queryNode->setAlias(parsedName);
-    queryNode->setRawName(parsedName);
     queryNode->setInternalIDProperty(expressionBinder.createInternalNodeIDExpression(*queryNode));
     // resolve properties associate with node table
     std::vector<NodeTableSchema*> nodeTableSchemas;

--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -128,7 +128,7 @@ expression_vector Binder::bindOrderByExpressions(
     for (auto& expression : orderByExpressions) {
         auto boundExpression = expressionBinder.bindExpression(*expression);
         if (boundExpression->dataType.typeID == NODE || boundExpression->dataType.typeID == REL) {
-            throw BinderException("Cannot order by " + boundExpression->getRawName() +
+            throw BinderException("Cannot order by " + boundExpression->toString() +
                                   ". Order by node or rel is not supported.");
         }
         boundOrderByExpressions.push_back(std::move(boundExpression));
@@ -151,7 +151,7 @@ uint64_t Binder::bindSkipLimitExpression(const ParsedExpression& expression) {
 void Binder::addExpressionsToScope(const expression_vector& projectionExpressions) {
     for (auto& expression : projectionExpressions) {
         // In RETURN clause, if expression is not aliased, its input name will serve its alias.
-        auto alias = expression->hasAlias() ? expression->getAlias() : expression->getRawName();
+        auto alias = expression->hasAlias() ? expression->getAlias() : expression->toString();
         variablesInScope.insert({alias, expression});
     }
 }

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -40,13 +40,13 @@ std::unique_ptr<BoundUpdatingClause> Binder::bindCreateClause(
         auto queryGraph = queryGraphCollection->getQueryGraph(i);
         for (auto j = 0u; j < queryGraph->getNumQueryNodes(); ++j) {
             auto node = queryGraph->getQueryNode(j);
-            if (!prevVariablesInScope.contains(node->getRawName())) {
+            if (!prevVariablesInScope.contains(node->toString())) {
                 boundCreateClause->addCreateNode(bindCreateNode(node, *propertyCollection));
             }
         }
         for (auto j = 0u; j < queryGraph->getNumQueryRels(); ++j) {
             auto rel = queryGraph->getQueryRel(j);
-            if (!prevVariablesInScope.contains(rel->getRawName())) {
+            if (!prevVariablesInScope.contains(rel->toString())) {
                 boundCreateClause->addCreateRel(bindCreateRel(rel, *propertyCollection));
             }
         }
@@ -58,7 +58,7 @@ std::unique_ptr<BoundCreateNode> Binder::bindCreateNode(
     std::shared_ptr<NodeExpression> node, const PropertyKeyValCollection& collection) {
     if (node->isMultiLabeled()) {
         throw BinderException(
-            "Create node " + node->getRawName() + " with multiple node labels is not supported.");
+            "Create node " + node->toString() + " with multiple node labels is not supported.");
     }
     auto nodeTableID = node->getSingleTableID();
     auto nodeTableSchema = catalog.getReadOnlyVersion()->getNodeTableSchema(nodeTableID);
@@ -73,7 +73,7 @@ std::unique_ptr<BoundCreateNode> Binder::bindCreateNode(
         setItems.emplace_back(key, val);
     }
     if (primaryKeyExpression == nullptr) {
-        throw BinderException("Create node " + node->getRawName() + " expects primary key " +
+        throw BinderException("Create node " + node->toString() + " expects primary key " +
                               primaryKey.name + " as input.");
     }
     return std::make_unique<BoundCreateNode>(
@@ -84,7 +84,7 @@ std::unique_ptr<BoundCreateRel> Binder::bindCreateRel(
     std::shared_ptr<RelExpression> rel, const PropertyKeyValCollection& collection) {
     if (rel->isMultiLabeled() || rel->isBoundByMultiLabeledNode()) {
         throw BinderException(
-            "Create rel " + rel->getRawName() +
+            "Create rel " + rel->toString() +
             " with multiple rel labels or bound by multiple node labels is not supported.");
     }
     auto relTableID = rel->getSingleTableID();
@@ -133,7 +133,7 @@ std::unique_ptr<BoundUpdatingClause> Binder::bindSetClause(const UpdatingClause&
 std::unique_ptr<BoundSetNodeProperty> Binder::bindSetNodeProperty(
     std::shared_ptr<NodeExpression> node, std::pair<ParsedExpression*, ParsedExpression*> setItem) {
     if (node->isMultiLabeled()) {
-        throw BinderException("Set property of node " + node->getRawName() +
+        throw BinderException("Set property of node " + node->toString() +
                               " with multiple node labels is not supported.");
     }
     return std::make_unique<BoundSetNodeProperty>(std::move(node), bindSetItem(setItem));
@@ -142,7 +142,7 @@ std::unique_ptr<BoundSetNodeProperty> Binder::bindSetNodeProperty(
 std::unique_ptr<BoundSetRelProperty> Binder::bindSetRelProperty(
     std::shared_ptr<RelExpression> rel, std::pair<ParsedExpression*, ParsedExpression*> setItem) {
     if (rel->isMultiLabeled() || rel->isBoundByMultiLabeledNode()) {
-        throw BinderException("Set property of rel " + rel->getRawName() +
+        throw BinderException("Set property of rel " + rel->toString() +
                               " with multiple rel labels or bound by multiple node labels "
                               "is not supported.");
     }
@@ -183,7 +183,7 @@ std::unique_ptr<BoundDeleteNode> Binder::bindDeleteNode(
     const std::shared_ptr<NodeExpression>& node) {
     if (node->isMultiLabeled()) {
         throw BinderException(
-            "Delete node " + node->getRawName() + " with multiple node labels is not supported.");
+            "Delete node " + node->toString() + " with multiple node labels is not supported.");
     }
     auto nodeTableID = node->getSingleTableID();
     auto nodeTableSchema = catalog.getReadOnlyVersion()->getNodeTableSchema(nodeTableID);
@@ -195,7 +195,7 @@ std::unique_ptr<BoundDeleteNode> Binder::bindDeleteNode(
 std::shared_ptr<RelExpression> Binder::bindDeleteRel(std::shared_ptr<RelExpression> rel) {
     if (rel->isMultiLabeled() || rel->isBoundByMultiLabeledNode()) {
         throw BinderException(
-            "Delete rel " + rel->getRawName() +
+            "Delete rel " + rel->toString() +
             " with multiple rel labels or bound by multiple node labels is not supported.");
     }
     return rel;

--- a/src/binder/bind_expression/bind_boolean_expression.cpp
+++ b/src/binder/bind_expression/bind_boolean_expression.cpp
@@ -30,7 +30,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindBooleanExpression(
         function::VectorBooleanOperations::bindSelectFunction(expressionType, childrenAfterCast);
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(functionName, childrenAfterCast);
-    return make_shared<ScalarFunctionExpression>(expressionType, DataType(BOOL),
+    return make_shared<ScalarFunctionExpression>(functionName, expressionType, DataType(BOOL),
         std::move(childrenAfterCast), std::move(execFunc), std::move(selectFunc),
         uniqueExpressionName);
 }

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     }
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(function->name, childrenAfterCast);
-    return make_shared<ScalarFunctionExpression>(expressionType,
+    return make_shared<ScalarFunctionExpression>(functionName, expressionType,
         common::DataType(function->returnTypeID), std::move(childrenAfterCast), function->execFunc,
         function->selectFunc, uniqueExpressionName);
 }

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -60,8 +60,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     }
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(function->name, childrenAfterCast);
-    return make_shared<ScalarFunctionExpression>(FUNCTION, returnType, std::move(childrenAfterCast),
-        function->execFunc, function->selectFunc, uniqueExpressionName);
+    return make_shared<ScalarFunctionExpression>(functionName, FUNCTION, returnType,
+        std::move(childrenAfterCast), function->execFunc, function->selectFunc,
+        uniqueExpressionName);
 }
 
 std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
@@ -91,7 +92,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
     } else {
         returnType = DataType(function->returnTypeID);
     }
-    return make_shared<AggregateFunctionExpression>(returnType, std::move(children),
+    return make_shared<AggregateFunctionExpression>(functionName, returnType, std::move(children),
         function->aggregateFunction->clone(), uniqueExpressionName);
 }
 
@@ -186,8 +187,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindNodeLabelFunction(const Expres
     children.push_back(createLiteralExpression(std::move(labelsValue)));
     auto execFunc = function::LabelVectorOperation::execFunction;
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(LABEL_FUNC_NAME, children);
-    return make_shared<ScalarFunctionExpression>(
-        FUNCTION, DataType(STRING), std::move(children), execFunc, nullptr, uniqueExpressionName);
+    return make_shared<ScalarFunctionExpression>(LABEL_FUNC_NAME, FUNCTION, DataType(STRING),
+        std::move(children), execFunc, nullptr, uniqueExpressionName);
 }
 
 std::shared_ptr<Expression> ExpressionBinder::bindRelLabelFunction(const Expression& expression) {
@@ -206,8 +207,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindRelLabelFunction(const Express
     children.push_back(createLiteralExpression(std::move(labelsValue)));
     auto execFunc = function::LabelVectorOperation::execFunction;
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(LABEL_FUNC_NAME, children);
-    return make_shared<ScalarFunctionExpression>(
-        FUNCTION, DataType(STRING), std::move(children), execFunc, nullptr, uniqueExpressionName);
+    return make_shared<ScalarFunctionExpression>(LABEL_FUNC_NAME, FUNCTION, DataType(STRING),
+        std::move(children), execFunc, nullptr, uniqueExpressionName);
 }
 
 } // namespace binder

--- a/src/binder/bind_expression/bind_null_operator_expression.cpp
+++ b/src/binder/bind_expression/bind_null_operator_expression.cpp
@@ -18,8 +18,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindNullOperatorExpression(
     auto execFunc = function::VectorNullOperations::bindExecFunction(expressionType, children);
     auto selectFunc = function::VectorNullOperations::bindSelectFunction(expressionType, children);
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(functionName, children);
-    return make_shared<ScalarFunctionExpression>(expressionType, common::DataType(common::BOOL),
-        std::move(children), std::move(execFunc), std::move(selectFunc), uniqueExpressionName);
+    return make_shared<ScalarFunctionExpression>(functionName, expressionType,
+        common::DataType(common::BOOL), std::move(children), std::move(execFunc),
+        std::move(selectFunc), uniqueExpressionName);
 }
 
 } // namespace binder

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindNodePropertyExpression(
     auto& nodeOrRel = (NodeOrRelExpression&)expression;
     if (!nodeOrRel.hasPropertyExpression(propertyName)) {
         throw BinderException(
-            "Cannot find property " + propertyName + " for " + expression.getRawName() + ".");
+            "Cannot find property " + propertyName + " for " + expression.toString() + ".");
     }
     return nodeOrRel.getPropertyExpression(propertyName);
 }
@@ -63,11 +63,11 @@ std::shared_ptr<Expression> ExpressionBinder::bindRelPropertyExpression(
     auto& rel = (RelExpression&)expression;
     if (rel.isVariableLength()) {
         throw BinderException(
-            "Cannot read property of variable length rel " + rel.getRawName() + ".");
+            "Cannot read property of variable length rel " + rel.toString() + ".");
     }
     if (!rel.hasPropertyExpression(propertyName)) {
         throw BinderException(
-            "Cannot find property " + propertyName + " for " + expression.getRawName() + ".");
+            "Cannot find property " + propertyName + " for " + expression.toString() + ".");
     }
     return rel.getPropertyExpression(propertyName);
 }
@@ -77,7 +77,7 @@ std::unique_ptr<Expression> ExpressionBinder::createPropertyExpression(
     assert(!properties.empty());
     auto anchorProperty = properties[0];
     validatePropertiesWithSameDataType(
-        properties, anchorProperty.dataType, anchorProperty.name, nodeOrRel.getRawName());
+        properties, anchorProperty.dataType, anchorProperty.name, nodeOrRel.toString());
     return make_unique<PropertyExpression>(anchorProperty.dataType, anchorProperty.name, nodeOrRel,
         populatePropertyIDPerTable(properties), isPrimaryKey);
 }

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -13,9 +13,10 @@ std::shared_ptr<Expression> ExpressionBinder::bindExistentialSubqueryExpression(
     auto& subqueryExpression = (ParsedSubqueryExpression&)parsedExpression;
     auto prevVariablesInScope = binder->enterSubquery();
     auto [queryGraph, _] = binder->bindGraphPattern(subqueryExpression.getPatternElements());
-    auto name = binder->getUniqueExpressionName(parsedExpression.getRawName());
-    auto boundSubqueryExpression =
-        make_shared<ExistentialSubqueryExpression>(std::move(queryGraph), std::move(name));
+    auto rawName = parsedExpression.getRawName();
+    auto uniqueName = binder->getUniqueExpressionName(rawName);
+    auto boundSubqueryExpression = make_shared<ExistentialSubqueryExpression>(
+        std::move(queryGraph), std::move(uniqueName), std::move(rawName));
     if (subqueryExpression.hasWhereClause()) {
         boundSubqueryExpression->setWhereExpression(
             binder->bindWhereExpression(*subqueryExpression.getWhereClause()));

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -1,5 +1,7 @@
 #include "binder/binder.h"
 
+#include "binder/expression/variable_expression.h"
+
 using namespace kuzu::common;
 using namespace kuzu::parser;
 using namespace kuzu::catalog;
@@ -67,8 +69,7 @@ std::shared_ptr<Expression> Binder::createVariable(
         throw BinderException("Variable " + name + " already exists.");
     }
     auto uniqueName = getUniqueExpressionName(name);
-    auto variable = make_shared<Expression>(ExpressionType::VARIABLE, dataType, uniqueName);
-    variable->setRawName(name);
+    auto variable = make_shared<VariableExpression>(dataType, uniqueName, name);
     variable->setAlias(name);
     variablesInScope.insert({name, variable});
     return variable;
@@ -83,8 +84,7 @@ void Binder::validateFirstMatchIsNotOptional(const SingleQuery& singleQuery) {
 void Binder::validateProjectionColumnNamesAreUnique(const expression_vector& expressions) {
     auto existColumnNames = std::unordered_set<std::string>();
     for (auto& expression : expressions) {
-        auto columnName =
-            expression->hasAlias() ? expression->getAlias() : expression->getRawName();
+        auto columnName = expression->hasAlias() ? expression->getAlias() : expression->toString();
         if (existColumnNames.contains(columnName)) {
             throw BinderException(
                 "Multiple result column with the same name " + columnName + " are not supported.");

--- a/src/binder/bound_statement_result.cpp
+++ b/src/binder/bound_statement_result.cpp
@@ -1,0 +1,28 @@
+#include "binder/bound_statement_result.h"
+
+#include "binder/expression/literal_expression.h"
+
+namespace kuzu {
+namespace binder {
+
+std::unique_ptr<BoundStatementResult> BoundStatementResult::createSingleStringColumnResult() {
+    auto result = std::make_unique<BoundStatementResult>();
+    auto columnName = std::string("outputMsg");
+    auto value = std::make_unique<common::Value>(columnName);
+    auto stringColumn = std::make_shared<LiteralExpression>(std::move(value), columnName);
+    result->addColumn(stringColumn, expression_vector{stringColumn});
+    return result;
+}
+
+expression_vector BoundStatementResult::getExpressionsToCollect() {
+    expression_vector result;
+    for (auto& expressionsToCollect : expressionsToCollectPerColumn) {
+        for (auto& expression : expressionsToCollect) {
+            result.push_back(expression);
+        }
+    }
+    return result;
+}
+
+} // namespace binder
+} // namespace kuzu

--- a/src/binder/expression/CMakeLists.txt
+++ b/src/binder/expression/CMakeLists.txt
@@ -3,7 +3,8 @@ add_library(
         OBJECT
         case_expression.cpp
         existential_subquery_expression.cpp
-        expression.cpp)
+        expression.cpp
+        function_expression.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_binder_expression>

--- a/src/binder/expression/case_expression.cpp
+++ b/src/binder/expression/case_expression.cpp
@@ -13,5 +13,15 @@ expression_vector CaseExpression::getChildren() const {
     return result;
 }
 
+std::string CaseExpression::toString() const {
+    std::string result = "CASE ";
+    for (auto& caseAlternative : caseAlternatives) {
+        result += "WHEN " + caseAlternative->whenExpression->toString() + " THEN " +
+                  caseAlternative->thenExpression->toString();
+    }
+    result += " ELSE " + elseExpression->toString();
+    return result;
+}
+
 } // namespace binder
 } // namespace kuzu

--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -102,9 +102,9 @@ std::string ExpressionUtil::toString(const expression_vector& expressions) {
     if (expressions.empty()) {
         return std::string{};
     }
-    auto result = expressions[0]->getRawName();
+    auto result = expressions[0]->toString();
     for (auto i = 1u; i < expressions.size(); ++i) {
-        result += "," + expressions[i]->getRawName();
+        result += "," + expressions[i]->toString();
     }
     return result;
 }

--- a/src/binder/expression/function_expression.cpp
+++ b/src/binder/expression/function_expression.cpp
@@ -1,0 +1,47 @@
+#include "binder/expression/function_expression.h"
+
+namespace kuzu {
+namespace binder {
+
+std::string ScalarFunctionExpression::getUniqueName(
+    const std::string& functionName, kuzu::binder::expression_vector& children) {
+    auto result = functionName + "(";
+    for (auto& child : children) {
+        result += child->getUniqueName() + ", ";
+    }
+    result += ")";
+    return result;
+}
+
+std::string ScalarFunctionExpression::toString() const {
+    auto result = functionName + "(";
+    result += ExpressionUtil::toString(children);
+    result += ")";
+    return result;
+}
+
+std::string AggregateFunctionExpression::getUniqueName(
+    const std::string& functionName, kuzu::binder::expression_vector& children, bool isDistinct) {
+    auto result = functionName + "(";
+    if (isDistinct) {
+        result += "DISTINCT ";
+    }
+    for (auto& child : children) {
+        result += child->getUniqueName() + ", ";
+    }
+    result += ")";
+    return result;
+}
+
+std::string AggregateFunctionExpression::toString() const {
+    auto result = functionName + "(";
+    if (isDistinct()) {
+        result += "DISTINCT ";
+    }
+    result += ExpressionUtil::toString(children);
+    result += ")";
+    return result;
+}
+
+} // namespace binder
+} // namespace kuzu

--- a/src/function/vector_cast_operations.cpp
+++ b/src/function/vector_cast_operations.cpp
@@ -28,6 +28,17 @@ scalar_exec_func VectorCastOperations::bindExecFunc(
     }
 }
 
+std::string VectorCastOperations::bindCastFunctionName(common::DataTypeID targetTypeID) {
+    switch (targetTypeID) {
+    case common::DOUBLE: {
+        return CAST_TO_DOUBLE_FUNC_NAME;
+    }
+    default:
+        throw common::InternalException("Cannot bind function name for cast to " +
+                                        common::Types::dataTypeToString(targetTypeID));
+    }
+}
+
 std::vector<std::unique_ptr<VectorOperationDefinition>>
 CastToDateVectorOperation::getDefinitions() {
     std::vector<std::unique_ptr<VectorOperationDefinition>> result;

--- a/src/include/binder/bound_statement_result.h
+++ b/src/include/binder/bound_statement_result.h
@@ -17,13 +17,7 @@ public:
         return std::make_unique<BoundStatementResult>();
     }
 
-    static std::unique_ptr<BoundStatementResult> createSingleStringColumnResult() {
-        auto result = std::make_unique<BoundStatementResult>();
-        auto stringColumn = std::make_shared<Expression>(
-            common::LITERAL, common::DataType{common::STRING}, "outputMsg");
-        result->addColumn(stringColumn, expression_vector{stringColumn});
-        return result;
-    }
+    static std::unique_ptr<BoundStatementResult> createSingleStringColumnResult();
 
     inline void addColumn(
         std::shared_ptr<Expression> column, expression_vector expressionToCollect) {
@@ -35,15 +29,7 @@ public:
         return expressionsToCollectPerColumn;
     }
 
-    inline expression_vector getExpressionsToCollect() {
-        expression_vector result;
-        for (auto& expressionsToCollect : expressionsToCollectPerColumn) {
-            for (auto& expression : expressionsToCollect) {
-                result.push_back(expression);
-            }
-        }
-        return result;
-    }
+    expression_vector getExpressionsToCollect();
 
     inline std::shared_ptr<Expression> getSingleExpressionToCollect() {
         auto expressionsToCollect = getExpressionsToCollect();

--- a/src/include/binder/expression/case_expression.h
+++ b/src/include/binder/expression/case_expression.h
@@ -34,6 +34,8 @@ public:
 
     expression_vector getChildren() const override;
 
+    std::string toString() const override;
+
 private:
     std::vector<std::unique_ptr<CaseAlternative>> caseAlternatives;
     std::shared_ptr<Expression> elseExpression;

--- a/src/include/binder/expression/existential_subquery_expression.h
+++ b/src/include/binder/expression/existential_subquery_expression.h
@@ -8,10 +8,10 @@ namespace binder {
 
 class ExistentialSubqueryExpression : public Expression {
 public:
-    ExistentialSubqueryExpression(
-        std::unique_ptr<QueryGraphCollection> queryGraphCollection, const std::string& name)
-        : Expression{common::EXISTENTIAL_SUBQUERY, common::BOOL, name},
-          queryGraphCollection{std::move(queryGraphCollection)} {}
+    ExistentialSubqueryExpression(std::unique_ptr<QueryGraphCollection> queryGraphCollection,
+        std::string uniqueName, std::string rawName)
+        : Expression{common::EXISTENTIAL_SUBQUERY, common::BOOL, std::move(uniqueName)},
+          queryGraphCollection{std::move(queryGraphCollection)}, rawName{std::move(rawName)} {}
 
     inline QueryGraphCollection* getQueryGraphCollection() const {
         return queryGraphCollection.get();
@@ -25,9 +25,12 @@ public:
 
     expression_vector getChildren() const override;
 
+    std::string toString() const override { return rawName; }
+
 private:
     std::unique_ptr<QueryGraphCollection> queryGraphCollection;
     std::shared_ptr<Expression> whereExpression;
+    std::string rawName;
 };
 
 } // namespace binder

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -31,33 +31,33 @@ public:
     // Create binary expression.
     Expression(common::ExpressionType expressionType, common::DataType dataType,
         const std::shared_ptr<Expression>& left, const std::shared_ptr<Expression>& right,
-        const std::string& uniqueName)
-        : Expression{
-              expressionType, std::move(dataType), expression_vector{left, right}, uniqueName} {}
+        std::string uniqueName)
+        : Expression{expressionType, std::move(dataType), expression_vector{left, right},
+              std::move(uniqueName)} {}
 
     // Create unary expression.
     Expression(common::ExpressionType expressionType, common::DataType dataType,
-        const std::shared_ptr<Expression>& child, const std::string& uniqueName)
-        : Expression{expressionType, std::move(dataType), expression_vector{child}, uniqueName} {}
+        const std::shared_ptr<Expression>& child, std::string uniqueName)
+        : Expression{expressionType, std::move(dataType), expression_vector{child},
+              std::move(uniqueName)} {}
 
     // Create leaf expression
-    Expression(common::ExpressionType expressionType, common::DataType dataType,
-        const std::string& uniqueName)
-        : Expression{expressionType, std::move(dataType), expression_vector{}, uniqueName} {}
+    Expression(
+        common::ExpressionType expressionType, common::DataType dataType, std::string uniqueName)
+        : Expression{
+              expressionType, std::move(dataType), expression_vector{}, std::move(uniqueName)} {}
 
     virtual ~Expression() = default;
 
 protected:
     Expression(common::ExpressionType expressionType, common::DataTypeID dataTypeID,
-        const std::string& uniqueName)
-        : Expression{expressionType, common::DataType(dataTypeID), uniqueName} {
+        std::string uniqueName)
+        : Expression{expressionType, common::DataType(dataTypeID), std::move(uniqueName)} {
         assert(dataTypeID != common::VAR_LIST);
     }
 
 public:
     inline void setAlias(const std::string& name) { alias = name; }
-
-    inline void setRawName(const std::string& name) { rawName = name; }
 
     inline std::string getUniqueName() const {
         assert(!uniqueName.empty());
@@ -69,8 +69,6 @@ public:
     inline bool hasAlias() const { return !alias.empty(); }
 
     inline std::string getAlias() const { return alias; }
-
-    inline std::string getRawName() const { return rawName; }
 
     inline uint32_t getNumChildren() const { return children.size(); }
 
@@ -94,6 +92,8 @@ public:
 
     expression_vector splitOnAND();
 
+    virtual std::string toString() const = 0;
+
     virtual std::unique_ptr<Expression> copy() const {
         throw common::InternalException("Unimplemented expression copy().");
     }
@@ -108,12 +108,8 @@ public:
 
 protected:
     // Name that serves as the unique identifier.
-    // NOTE: an expression must have a unique name
     std::string uniqueName;
     std::string alias;
-    // Name that matches user input.
-    // NOTE: an expression may not have a rawName since it is generated internally e.g. casting
-    std::string rawName;
     expression_vector children;
 };
 

--- a/src/include/binder/expression/literal_expression.h
+++ b/src/include/binder/expression/literal_expression.h
@@ -21,6 +21,8 @@ public:
 
     inline common::Value* getValue() const { return value.get(); }
 
+    std::string toString() const override { return value->toString(); }
+
 public:
     std::unique_ptr<common::Value> value;
 };

--- a/src/include/binder/expression/node_expression.h
+++ b/src/include/binder/expression/node_expression.h
@@ -8,8 +8,10 @@ namespace binder {
 
 class NodeExpression : public NodeOrRelExpression {
 public:
-    NodeExpression(const std::string& uniqueName, std::vector<common::table_id_t> tableIDs)
-        : NodeOrRelExpression{common::NODE, uniqueName, std::move(tableIDs)} {}
+    NodeExpression(
+        std::string uniqueName, std::string variableName, std::vector<common::table_id_t> tableIDs)
+        : NodeOrRelExpression{
+              common::NODE, std::move(uniqueName), std::move(variableName), std::move(tableIDs)} {}
 
     inline void setInternalIDProperty(std::unique_ptr<Expression> expression) {
         internalIDExpression = std::move(expression);

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -9,10 +9,11 @@ namespace binder {
 
 class NodeOrRelExpression : public Expression {
 public:
-    NodeOrRelExpression(common::DataTypeID dataTypeID, const std::string& uniqueName,
-        std::vector<common::table_id_t> tableIDs)
-        : Expression{common::VARIABLE, dataTypeID, uniqueName}, tableIDs{std::move(tableIDs)} {}
-    ~NodeOrRelExpression() override = default;
+    NodeOrRelExpression(common::DataTypeID dataTypeID, std::string uniqueName,
+        std::string variableName, std::vector<common::table_id_t> tableIDs)
+        : Expression{common::VARIABLE, dataTypeID, std::move(uniqueName)},
+          variableName(std::move(variableName)), tableIDs{std::move(tableIDs)} {}
+    virtual ~NodeOrRelExpression() override = default;
 
     inline void addTableIDs(const std::vector<common::table_id_t>& tableIDsToAdd) {
         auto tableIDsMap = std::unordered_set<common::table_id_t>(tableIDs.begin(), tableIDs.end());
@@ -47,7 +48,10 @@ public:
         return properties;
     }
 
+    std::string toString() const override { return variableName; }
+
 protected:
+    std::string variableName;
     std::vector<common::table_id_t> tableIDs;
     std::unordered_map<std::string, size_t> propertyNameToIdx;
     std::vector<std::unique_ptr<Expression>> properties;

--- a/src/include/binder/expression/parameter_expression.h
+++ b/src/include/binder/expression/parameter_expression.h
@@ -7,10 +7,11 @@ namespace kuzu {
 namespace binder {
 
 class ParameterExpression : public Expression {
-
 public:
-    explicit ParameterExpression(const std::string& parameterName, std::shared_ptr<common::Value> value)
-        : Expression{common::PARAMETER, common::ANY, "$" + parameterName /* add $ to avoid conflict between parameter name and variable name */}, value{std::move(value)} {}
+    explicit ParameterExpression(
+        const std::string& parameterName, std::shared_ptr<common::Value> value)
+        : Expression{common::PARAMETER, common::ANY, createUniqueName(parameterName)},
+          parameterName(parameterName), value{std::move(value)} {}
 
     inline void setDataType(const common::DataType& targetType) {
         assert(dataType.typeID == common::ANY);
@@ -20,7 +21,13 @@ public:
 
     inline std::shared_ptr<common::Value> getLiteral() const { return value; }
 
+    std::string toString() const override { return "$" + parameterName; }
+
 private:
+    inline static std::string createUniqueName(const std::string& input) { return "$" + input; }
+
+private:
+    std::string parameterName;
     std::shared_ptr<common::Value> value;
 };
 

--- a/src/include/binder/expression/property_expression.h
+++ b/src/include/binder/expression/property_expression.h
@@ -15,22 +15,20 @@ public:
         : Expression{common::PROPERTY, std::move(dataType),
               nodeOrRel.getUniqueName() + "." + propertyName},
           isPrimaryKey_{isPrimaryKey_}, propertyName{propertyName},
-          variableName{nodeOrRel.getUniqueName()}, propertyIDPerTable{
-                                                       std::move(propertyIDPerTable)} {
-        rawName = nodeOrRel.getRawName() + "." + propertyName;
-    }
+          uniqueVariableName{nodeOrRel.getUniqueName()}, rawVariableName{nodeOrRel.toString()},
+          propertyIDPerTable{std::move(propertyIDPerTable)} {}
+
     PropertyExpression(const PropertyExpression& other)
         : Expression{common::PROPERTY, other.dataType, other.uniqueName},
           isPrimaryKey_{other.isPrimaryKey_}, propertyName{other.propertyName},
-          variableName{other.variableName}, propertyIDPerTable{other.propertyIDPerTable} {
-        rawName = other.rawName;
-    }
+          uniqueVariableName{other.uniqueVariableName}, rawVariableName{other.rawVariableName},
+          propertyIDPerTable{other.propertyIDPerTable} {}
 
     inline bool isPrimaryKey() const { return isPrimaryKey_; }
 
     inline std::string getPropertyName() const { return propertyName; }
 
-    inline std::string getVariableName() const { return variableName; }
+    inline std::string getVariableName() const { return uniqueVariableName; }
 
     inline bool hasPropertyID(common::table_id_t tableID) const {
         return propertyIDPerTable.contains(tableID);
@@ -46,11 +44,15 @@ public:
         return make_unique<PropertyExpression>(*this);
     }
 
+    inline std::string toString() const override { return rawVariableName + "." + propertyName; }
+
 private:
     bool isPrimaryKey_ = false;
     std::string propertyName;
-    // reference to a node/rel table
-    std::string variableName;
+    // unique identifier references to a node/rel table.
+    std::string uniqueVariableName;
+    // printable identifier references to a node/rel table.
+    std::string rawVariableName;
     std::unordered_map<common::table_id_t, common::property_id_t> propertyIDPerTable;
 };
 

--- a/src/include/binder/expression/rel_expression.h
+++ b/src/include/binder/expression/rel_expression.h
@@ -8,12 +8,13 @@ namespace binder {
 
 class RelExpression : public NodeOrRelExpression {
 public:
-    RelExpression(const std::string& uniqueName, std::vector<common::table_id_t> tableIDs,
-        std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
-        uint64_t lowerBound, uint64_t upperBound)
-        : NodeOrRelExpression{common::REL, uniqueName, std::move(tableIDs)}, srcNode{std::move(
-                                                                                 srcNode)},
-          dstNode{std::move(dstNode)}, lowerBound{lowerBound}, upperBound{upperBound} {}
+    RelExpression(std::string uniqueName, std::string variableName,
+        std::vector<common::table_id_t> tableIDs, std::shared_ptr<NodeExpression> srcNode,
+        std::shared_ptr<NodeExpression> dstNode, uint64_t lowerBound, uint64_t upperBound)
+        : NodeOrRelExpression{common::REL, std::move(uniqueName), std::move(variableName),
+              std::move(tableIDs)},
+          srcNode{std::move(srcNode)}, dstNode{std::move(dstNode)}, lowerBound{lowerBound},
+          upperBound{upperBound} {}
 
     inline bool isBoundByMultiLabeledNode() const {
         return srcNode->isMultiLabeled() || dstNode->isMultiLabeled();

--- a/src/include/binder/expression/variable_expression.h
+++ b/src/include/binder/expression/variable_expression.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "expression.h"
+
+namespace kuzu {
+namespace binder {
+
+class VariableExpression : public Expression {
+public:
+    VariableExpression(common::DataType dataType, std::string uniqueName, std::string variableName)
+        : Expression{common::VARIABLE, dataType, std::move(uniqueName)}, variableName{std::move(
+                                                                             variableName)} {}
+
+    std::string toString() const override { return variableName; }
+
+private:
+    std::string variableName;
+};
+
+} // namespace binder
+} // namespace kuzu

--- a/src/include/function/cast/vector_cast_operations.h
+++ b/src/include/function/cast/vector_cast_operations.h
@@ -23,6 +23,8 @@ public:
 
     static scalar_exec_func bindExecFunc(
         common::DataTypeID sourceTypeID, common::DataTypeID targetTypeID);
+
+    static std::string bindCastFunctionName(common::DataTypeID targetTypeID);
 };
 
 struct CastToDateVectorOperation : public VectorCastOperations {

--- a/src/include/planner/logical_plan/logical_operator/logical_extend.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_extend.h
@@ -22,8 +22,8 @@ public:
     void computeSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {
-        return boundNode->getRawName() + (direction == common::RelDirection::FWD ? "->" : "<-") +
-               nbrNode->getRawName();
+        return boundNode->toString() + (direction == common::RelDirection::FWD ? "->" : "<-") +
+               nbrNode->toString();
     }
 
     inline std::shared_ptr<binder::NodeExpression> getBoundNode() const { return boundNode; }

--- a/src/include/planner/logical_plan/logical_operator/logical_filter.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_filter.h
@@ -17,9 +17,7 @@ public:
 
     inline void computeSchema() override { copyChildSchema(0); }
 
-    inline std::string getExpressionsForPrinting() const override {
-        return expression->getRawName();
-    }
+    inline std::string getExpressionsForPrinting() const override { return expression->toString(); }
 
     inline std::shared_ptr<binder::Expression> getPredicate() const { return expression; }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_intersect.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_intersect.h
@@ -38,7 +38,7 @@ public:
 
     void computeSchema() override;
 
-    std::string getExpressionsForPrinting() const override { return intersectNodeID->getRawName(); }
+    std::string getExpressionsForPrinting() const override { return intersectNodeID->toString(); }
 
     inline std::shared_ptr<binder::Expression> getIntersectNodeID() const {
         return intersectNodeID;

--- a/src/include/planner/logical_plan/logical_operator/logical_scan_node.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_scan_node.h
@@ -13,7 +13,7 @@ public:
 
     void computeSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override { return node->getRawName(); }
+    inline std::string getExpressionsForPrinting() const override { return node->toString(); }
 
     inline std::shared_ptr<binder::NodeExpression> getNode() const { return node; }
 
@@ -34,7 +34,7 @@ public:
 
     void computeSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override { return node->getRawName(); }
+    inline std::string getExpressionsForPrinting() const override { return node->toString(); }
 
     inline std::shared_ptr<binder::NodeExpression> getNode() const { return node; }
     inline std::shared_ptr<binder::Expression> getIndexExpression() const {

--- a/src/include/planner/logical_plan/logical_operator/logical_semi_masker.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_semi_masker.h
@@ -15,7 +15,7 @@ public:
 
     inline void computeSchema() override { copyChildSchema(0); }
 
-    inline std::string getExpressionsForPrinting() const override { return nodeID->getRawName(); }
+    inline std::string getExpressionsForPrinting() const override { return nodeID->toString(); }
 
     inline std::shared_ptr<binder::Expression> getNodeID() const { return nodeID; }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_set.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_set.h
@@ -17,7 +17,7 @@ public:
     inline std::string getExpressionsForPrinting() const override {
         std::string result;
         for (auto& [lhs, rhs] : setItems) {
-            result += lhs->getRawName() + " = " + rhs->getRawName() + ",";
+            result += lhs->toString() + " = " + rhs->toString() + ",";
         }
         return result;
     }
@@ -45,7 +45,7 @@ public:
     inline std::string getExpressionsForPrinting() const override {
         std::string result;
         for (auto& [lhs, rhs] : setItems) {
-            result += lhs->getRawName() + " = " + rhs->getRawName() + ",";
+            result += lhs->toString() + " = " + rhs->toString() + ",";
         }
         return result;
     }

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -117,7 +117,7 @@ void QueryResult::initResultTableAndIterator(
     for (auto i = 0u; i < columns.size(); ++i) {
         auto column = columns[i].get();
         auto columnType = column->getDataType();
-        auto columnName = column->hasAlias() ? column->getAlias() : column->getRawName();
+        auto columnName = column->hasAlias() ? column->getAlias() : column->toString();
         columnDataTypes.push_back(columnType);
         columnNames.push_back(columnName);
         auto expressionsToCollect = expressionToCollectPerColumn[i];

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -50,11 +50,11 @@ void LogicalAggregate::computeSchema() {
 std::string LogicalAggregate::getExpressionsForPrinting() const {
     std::string result = "Group By [";
     for (auto& expression : expressionsToGroupBy) {
-        result += expression->getUniqueName() + ", ";
+        result += expression->toString() + ", ";
     }
     result += "], Aggregate [";
     for (auto& expression : expressionsToAggregate) {
-        result += expression->getUniqueName() + ", ";
+        result += expression->toString() + ", ";
     }
     result += "]";
     return result;

--- a/src/planner/operator/logical_plan_util.cpp
+++ b/src/planner/operator/logical_plan_util.cpp
@@ -95,7 +95,7 @@ void LogicalPlanUtil::encodeCrossProduct(
 
 void LogicalPlanUtil::encodeIntersect(LogicalOperator* logicalOperator, std::string& encodeString) {
     auto logicalIntersect = (LogicalIntersect*)logicalOperator;
-    encodeString += "I(" + logicalIntersect->getIntersectNodeID()->getRawName() + ")";
+    encodeString += "I(" + logicalIntersect->getIntersectNodeID()->toString() + ")";
 }
 
 void LogicalPlanUtil::encodeHashJoin(LogicalOperator* logicalOperator, std::string& encodeString) {
@@ -106,13 +106,13 @@ void LogicalPlanUtil::encodeHashJoin(LogicalOperator* logicalOperator, std::stri
 
 void LogicalPlanUtil::encodeExtend(LogicalOperator* logicalOperator, std::string& encodeString) {
     auto logicalExtend = (LogicalExtend*)logicalOperator;
-    encodeString += "E(" + logicalExtend->getNbrNode()->getRawName() + ")";
+    encodeString += "E(" + logicalExtend->getNbrNode()->toString() + ")";
 }
 
 void LogicalPlanUtil::encodeScanNodeID(
     LogicalOperator* logicalOperator, std::string& encodeString) {
     auto logicalScanNode = (LogicalScanNode*)logicalOperator;
-    encodeString += "S(" + logicalScanNode->getNode()->getRawName() + ")";
+    encodeString += "S(" + logicalScanNode->getNode()->toString() + ")";
 }
 
 } // namespace planner

--- a/src/processor/mapper/map_intersect.cpp
+++ b/src/processor/mapper/map_intersect.cpp
@@ -38,7 +38,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
         sharedStates.push_back(sharedState);
         children.push_back(make_unique<IntersectBuild>(
             std::make_unique<ResultSetDescriptor>(*buildSchema), sharedState, buildDataInfo,
-            std::move(buildSidePrevOperator), getOperatorID(), buildInfo->keyNodeID->getRawName()));
+            std::move(buildSidePrevOperator), getOperatorID(), buildInfo->keyNodeID->toString()));
         IntersectDataInfo info{
             DataPos(outSchema->getExpressionPos(*buildInfo->keyNodeID)), payloadsDataPos};
         intersectDataInfos.push_back(info);

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -50,7 +50,7 @@ TEST_F(BinderErrorTest, BindToDifferentVariableType1) {
 
 TEST_F(BinderErrorTest, BindToDifferentVariableType2) {
     std::string expectedException =
-        "Binder exception: a.age + 1 has data type INT64. (NODE) was expected.";
+        "Binder exception: +(a.age,1) has data type INT64. (NODE) was expected.";
     auto input = "MATCH (a:person)-[e1:knows]->(b:person) WITH a.age + 1 AS a MATCH (a) RETURN *;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
@@ -76,7 +76,7 @@ TEST_F(BinderErrorTest, BindVariableNotInScope2) {
 
 TEST_F(BinderErrorTest, BindPropertyLookUpOnExpression) {
     std::string expectedException =
-        "Binder exception: a.age + 2 has data type INT64. (REL,NODE) was expected.";
+        "Binder exception: +(a.age,2) has data type INT64. (REL,NODE) was expected.";
     auto input = "MATCH (a:person)-[e1:knows]->(b:person) RETURN (a.age + 2).age;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
@@ -220,7 +220,7 @@ TEST_F(BinderErrorTest, VarLenExtendZeroLowerBound) {
 
 TEST_F(BinderErrorTest, SetDataTypeMisMatch) {
     std::string expectedException =
-        "Binder exception: Expression 'hh' has data type STRING but expect "
+        "Binder exception: Expression hh has data type STRING but expect "
         "INT64. Implicit cast is not supported.";
     auto input = "MATCH (a:person) SET a.age = 'hh'";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
@@ -228,7 +228,7 @@ TEST_F(BinderErrorTest, SetDataTypeMisMatch) {
 
 TEST_F(BinderErrorTest, CreateNodeDataTypeMisMatch) {
     std::string expectedException =
-        "Binder exception: Expression 'hh' has data type STRING but expect "
+        "Binder exception: Expression hh has data type STRING but expect "
         "INT64. Implicit cast is not supported.";
     auto input = "CREATE (a:person {age:'hh'})";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
@@ -393,7 +393,7 @@ TEST_F(BinderErrorTest, MaxNodeID) {
 
 TEST_F(BinderErrorTest, OrderByNodeID) {
     std::string expectedException =
-        "Binder exception: Cannot order by x. Order by node or rel is not supported.";
+        "Binder exception: Cannot order by p. Order by node or rel is not supported.";
     auto input = "match (p:person) with p as x order by x skip 1 return x;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
@@ -424,7 +424,7 @@ TEST_F(BinderErrorTest, AddPropertyDuplicateName) {
 
 TEST_F(BinderErrorTest, AddPropertyUnmatchedDefaultValueType) {
     std::string expectedException =
-        "Binder exception: Expression 3.2 has data type DOUBLE but expect "
+        "Binder exception: Expression 3.200000 has data type DOUBLE but expect "
         "INT64. Implicit cast is not supported.";
     auto input = "alter table person add intCol INT64 DEFAULT 3.2";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());

--- a/test/runner/e2e_exception_test.cpp
+++ b/test/runner/e2e_exception_test.cpp
@@ -140,7 +140,8 @@ TEST_F(TinySnbExceptionTest, CastStrToIntervalError) {
 TEST_F(TinySnbExceptionTest, SetListPropertyError) {
     auto result = conn->query("MATCH (a:person) SET a.workedHours=['A', 'B']");
     ASSERT_STREQ(result->getErrorMessage().c_str(),
-        "Binder exception: Expression ['A', 'B'] has data type STRING[] but expect INT64[]. "
+        "Binder exception: Expression LIST_CREATION(A,B) has data type STRING[] but expect "
+        "INT64[]. "
         "Implicit cast is not supported.");
 }
 


### PR DESCRIPTION
This PR removes rawName field from expression. This field has been creating problems because we either

- forget to set this field (or a bulk expression constructor if we want to ensure rawName to be always set); or
- don't have this field because some expression is added by us (e.g. casting); 

This leads to weird behaviour e.g. some operator prints empty parameter info.

This PR replace rawName with a getString virtual function so that the string of current expression can be inferred from its children expressions. 