### PR TITLE
Add remove unnecessary join optimizer

### DIFF
--- a/src/catalog/catalog_structs.cpp
+++ b/src/catalog/catalog_structs.cpp
@@ -3,6 +3,8 @@
 #include "common/exception.h"
 #include "common/utils.h"
 
+using namespace kuzu::common;
+
 namespace kuzu {
 namespace catalog {
 

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -16,15 +16,18 @@ public:
     virtual ~NodeOrRelExpression() override = default;
 
     inline void addTableIDs(const std::vector<common::table_id_t>& tableIDsToAdd) {
-        auto tableIDsMap = std::unordered_set<common::table_id_t>(tableIDs.begin(), tableIDs.end());
+        auto tableIDsSet = getTableIDsSet();
         for (auto tableID : tableIDsToAdd) {
-            if (!tableIDsMap.contains(tableID)) {
+            if (!tableIDsSet.contains(tableID)) {
                 tableIDs.push_back(tableID);
             }
         }
     }
     inline bool isMultiLabeled() const { return tableIDs.size() > 1; }
     inline std::vector<common::table_id_t> getTableIDs() const { return tableIDs; }
+    inline std::unordered_set<common::table_id_t> getTableIDsSet() const {
+        return {tableIDs.begin(), tableIDs.end()};
+    }
     inline common::table_id_t getSingleTableID() const {
         assert(tableIDs.size() == 1);
         return tableIDs[0];

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -34,36 +34,36 @@ public:
     /**
      * Node and Rel table functions.
      */
-    table_id_t addNodeTableSchema(std::string tableName, property_id_t primaryKeyId,
+    common::table_id_t addNodeTableSchema(std::string tableName, common::property_id_t primaryKeyId,
         std::vector<PropertyNameDataType> propertyDefinitions);
 
-    table_id_t addRelTableSchema(std::string tableName, RelMultiplicity relMultiplicity,
-        const std::vector<PropertyNameDataType>& propertyDefinitions, table_id_t srcTableID,
-        table_id_t dstTableID);
+    common::table_id_t addRelTableSchema(std::string tableName, RelMultiplicity relMultiplicity,
+        const std::vector<PropertyNameDataType>& propertyDefinitions, common::table_id_t srcTableID,
+        common::table_id_t dstTableID);
 
-    inline bool containNodeTable(table_id_t tableID) const {
+    inline bool containNodeTable(common::table_id_t tableID) const {
         return nodeTableSchemas.contains(tableID);
     }
-    inline bool containRelTable(table_id_t tableID) const {
+    inline bool containRelTable(common::table_id_t tableID) const {
         return relTableSchemas.contains(tableID);
     }
     inline bool containTable(const std::string& name) const {
         return containNodeTable(name) || containRelTable(name);
     }
 
-    inline std::string getTableName(table_id_t tableID) const {
+    inline std::string getTableName(common::table_id_t tableID) const {
         return getTableSchema(tableID)->tableName;
     }
 
-    inline NodeTableSchema* getNodeTableSchema(table_id_t tableID) const {
+    inline NodeTableSchema* getNodeTableSchema(common::table_id_t tableID) const {
         assert(containNodeTable(tableID));
         return nodeTableSchemas.at(tableID).get();
     }
-    inline RelTableSchema* getRelTableSchema(table_id_t tableID) const {
+    inline RelTableSchema* getRelTableSchema(common::table_id_t tableID) const {
         assert(containRelTable(tableID));
         return relTableSchemas.at(tableID).get();
     }
-    inline TableSchema* getTableSchema(table_id_t tableID) const {
+    inline TableSchema* getTableSchema(common::table_id_t tableID) const {
         assert(containRelTable(tableID) || containNodeTable(tableID));
         return nodeTableSchemas.contains(tableID) ?
                    (TableSchema*)nodeTableSchemas.at(tableID).get() :
@@ -77,11 +77,12 @@ public:
         return relTableNameToIDMap.contains(tableName);
     }
 
-    inline table_id_t getTableID(const std::string& tableName) const {
+    inline common::table_id_t getTableID(const std::string& tableName) const {
         return nodeTableNameToIDMap.contains(tableName) ? nodeTableNameToIDMap.at(tableName) :
                                                           relTableNameToIDMap.at(tableName);
     }
-    inline bool isSingleMultiplicityInDirection(table_id_t tableID, RelDirection direction) const {
+    inline bool isSingleMultiplicityInDirection(
+        common::table_id_t tableID, common::RelDirection direction) const {
         return relTableSchemas.at(tableID)->isSingleMultiplicityInDirection(direction);
     }
 
@@ -90,53 +91,57 @@ public:
      */
     // getNodeProperty and getRelProperty should be called after checking if property exists
     // (containNodeProperty and containRelProperty).
-    const Property& getNodeProperty(table_id_t tableID, const std::string& propertyName) const;
-    const Property& getRelProperty(table_id_t tableID, const std::string& propertyName) const;
+    const Property& getNodeProperty(
+        common::table_id_t tableID, const std::string& propertyName) const;
+    const Property& getRelProperty(
+        common::table_id_t tableID, const std::string& propertyName) const;
 
-    std::vector<Property> getAllNodeProperties(table_id_t tableID) const;
-    inline const std::vector<Property>& getRelProperties(table_id_t tableID) const {
+    std::vector<Property> getAllNodeProperties(common::table_id_t tableID) const;
+    inline const std::vector<Property>& getRelProperties(common::table_id_t tableID) const {
         return relTableSchemas.at(tableID)->properties;
     }
-    inline std::vector<table_id_t> getNodeTableIDs() const {
-        std::vector<table_id_t> nodeTableIDs;
+    inline std::vector<common::table_id_t> getNodeTableIDs() const {
+        std::vector<common::table_id_t> nodeTableIDs;
         for (auto& [tableID, _] : nodeTableSchemas) {
             nodeTableIDs.push_back(tableID);
         }
         return nodeTableIDs;
     }
-    inline std::vector<table_id_t> getRelTableIDs() const {
-        std::vector<table_id_t> relTableIDs;
+    inline std::vector<common::table_id_t> getRelTableIDs() const {
+        std::vector<common::table_id_t> relTableIDs;
         for (auto& [tableID, _] : relTableSchemas) {
             relTableIDs.push_back(tableID);
         }
         return relTableIDs;
     }
-    inline std::unordered_map<table_id_t, std::unique_ptr<NodeTableSchema>>& getNodeTableSchemas() {
+    inline std::unordered_map<common::table_id_t, std::unique_ptr<NodeTableSchema>>&
+    getNodeTableSchemas() {
         return nodeTableSchemas;
     }
-    inline std::unordered_map<table_id_t, std::unique_ptr<RelTableSchema>>& getRelTableSchemas() {
+    inline std::unordered_map<common::table_id_t, std::unique_ptr<RelTableSchema>>&
+    getRelTableSchemas() {
         return relTableSchemas;
     }
 
-    void dropTableSchema(table_id_t tableID);
+    void dropTableSchema(common::table_id_t tableID);
 
-    void renameTable(table_id_t tableID, std::string newName);
+    void renameTable(common::table_id_t tableID, std::string newName);
 
     void saveToFile(const std::string& directory, common::DBFileType dbFileType);
     void readFromFile(const std::string& directory, common::DBFileType dbFileType);
 
 private:
-    inline table_id_t assignNextTableID() { return nextTableID++; }
+    inline common::table_id_t assignNextTableID() { return nextTableID++; }
 
 private:
     std::shared_ptr<spdlog::logger> logger;
-    std::unordered_map<table_id_t, std::unique_ptr<NodeTableSchema>> nodeTableSchemas;
-    std::unordered_map<table_id_t, std::unique_ptr<RelTableSchema>> relTableSchemas;
+    std::unordered_map<common::table_id_t, std::unique_ptr<NodeTableSchema>> nodeTableSchemas;
+    std::unordered_map<common::table_id_t, std::unique_ptr<RelTableSchema>> relTableSchemas;
     // These two maps are maintained as caches. They are not serialized to the catalog file, but
     // is re-constructed when reading from the catalog file.
-    std::unordered_map<std::string, table_id_t> nodeTableNameToIDMap;
-    std::unordered_map<std::string, table_id_t> relTableNameToIDMap;
-    table_id_t nextTableID;
+    std::unordered_map<std::string, common::table_id_t> nodeTableNameToIDMap;
+    std::unordered_map<std::string, common::table_id_t> relTableNameToIDMap;
+    common::table_id_t nextTableID;
 };
 
 class Catalog {
@@ -180,25 +185,27 @@ public:
 
     common::ExpressionType getFunctionType(const std::string& name) const;
 
-    table_id_t addNodeTableSchema(std::string tableName, property_id_t primaryKeyId,
+    common::table_id_t addNodeTableSchema(std::string tableName, common::property_id_t primaryKeyId,
         std::vector<PropertyNameDataType> propertyDefinitions);
 
-    table_id_t addRelTableSchema(std::string tableName, RelMultiplicity relMultiplicity,
-        const std::vector<PropertyNameDataType>& propertyDefinitions, table_id_t srcTableID,
-        table_id_t dstTableID);
+    common::table_id_t addRelTableSchema(std::string tableName, RelMultiplicity relMultiplicity,
+        const std::vector<PropertyNameDataType>& propertyDefinitions, common::table_id_t srcTableID,
+        common::table_id_t dstTableID);
 
-    void dropTableSchema(table_id_t tableID);
+    void dropTableSchema(common::table_id_t tableID);
 
-    void renameTable(table_id_t tableID, std::string newName);
+    void renameTable(common::table_id_t tableID, std::string newName);
 
-    void addProperty(table_id_t tableID, std::string propertyName, DataType dataType);
+    void addProperty(
+        common::table_id_t tableID, std::string propertyName, common::DataType dataType);
 
-    void dropProperty(table_id_t tableID, property_id_t propertyID);
+    void dropProperty(common::table_id_t tableID, common::property_id_t propertyID);
 
-    void renameProperty(table_id_t tableID, property_id_t propertyID, std::string newName);
+    void renameProperty(
+        common::table_id_t tableID, common::property_id_t propertyID, std::string newName);
 
     std::unordered_set<RelTableSchema*> getAllRelTableSchemasContainBoundTable(
-        table_id_t boundTableID);
+        common::table_id_t boundTableID);
 
 protected:
     std::unique_ptr<function::BuiltInVectorOperations> builtInVectorOperations;

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "planner/logical_plan/logical_operator/base_logical_operator.h"
 #include "planner/logical_plan/logical_plan.h"
 
 namespace kuzu {

--- a/src/include/optimizer/remove_unnecessary_join_optimizer.h
+++ b/src/include/optimizer/remove_unnecessary_join_optimizer.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "planner/logical_plan/logical_plan.h"
+
+namespace kuzu {
+namespace optimizer {
+
+// Due to the nature of graph pattern, a (node)-[rel]-(node) is always interpreted as two joins.
+// However, in many cases, a single join is sufficient.
+// E.g. MATCH (a)-[e]->(b) RETURN e.date
+// Our planner will generate a plan where the HJ is redundant.
+//      HJ
+//     /  \
+//   E(e) S(b)
+//    |
+//   S(a)
+// This optimizer prunes such redundant joins.
+class RemoveUnnecessaryJoinOptimizer {
+public:
+    static void rewrite(planner::LogicalPlan* plan);
+
+private:
+    static std::shared_ptr<planner::LogicalOperator> visitOperator(
+        std::shared_ptr<planner::LogicalOperator> op);
+    static std::shared_ptr<planner::LogicalOperator> visitHashJoin(
+        std::shared_ptr<planner::LogicalOperator> op);
+};
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/include/planner/logical_plan/logical_operator/logical_create_rel_table.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_create_rel_table.h
@@ -10,8 +10,8 @@ class LogicalCreateRelTable : public LogicalCreateTable {
 public:
     LogicalCreateRelTable(std::string tableName,
         std::vector<catalog::PropertyNameDataType> propertyNameDataTypes,
-        catalog::RelMultiplicity relMultiplicity, catalog::table_id_t srcTableID,
-        catalog::table_id_t dstTableID, std::shared_ptr<binder::Expression> outputExpression)
+        catalog::RelMultiplicity relMultiplicity, common::table_id_t srcTableID,
+        common::table_id_t dstTableID, std::shared_ptr<binder::Expression> outputExpression)
         : LogicalCreateTable{LogicalOperatorType::CREATE_REL_TABLE, std::move(tableName),
               std::move(propertyNameDataTypes), std::move(outputExpression)},
           relMultiplicity{relMultiplicity}, srcTableID{srcTableID}, dstTableID{dstTableID} {}

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -4,7 +4,8 @@ add_library(kuzu_optimizer
         index_nested_loop_join_optimizer.cpp
         optimizer.cpp
         projection_push_down_optimizer.cpp
-        remove_factorization_rewriter.cpp)
+        remove_factorization_rewriter.cpp
+        remove_unnecessary_join_optimizer.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_optimizer>

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -4,6 +4,7 @@
 #include "optimizer/index_nested_loop_join_optimizer.h"
 #include "optimizer/projection_push_down_optimizer.h"
 #include "optimizer/remove_factorization_rewriter.h"
+#include "optimizer/remove_unnecessary_join_optimizer.h"
 
 namespace kuzu {
 namespace optimizer {
@@ -11,6 +12,8 @@ namespace optimizer {
 void Optimizer::optimize(planner::LogicalPlan* plan) {
     auto removeFactorizationRewriter = RemoveFactorizationRewriter();
     removeFactorizationRewriter.rewrite(plan);
+
+    RemoveUnnecessaryJoinOptimizer::rewrite(plan);
 
     IndexNestedLoopJoinOptimizer::rewrite(plan);
 

--- a/src/optimizer/remove_unnecessary_join_optimizer.cpp
+++ b/src/optimizer/remove_unnecessary_join_optimizer.cpp
@@ -1,0 +1,56 @@
+#include "optimizer/remove_unnecessary_join_optimizer.h"
+
+#include "planner/logical_plan/logical_operator/logical_hash_join.h"
+
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace optimizer {
+
+void RemoveUnnecessaryJoinOptimizer::rewrite(planner::LogicalPlan* plan) {
+    visitOperator(plan->getLastOperator());
+}
+
+std::shared_ptr<planner::LogicalOperator> RemoveUnnecessaryJoinOptimizer::visitOperator(
+    std::shared_ptr<planner::LogicalOperator> op) {
+    for (auto i = 0; i < op->getNumChildren(); ++i) {
+        op->setChild(i, visitOperator(op->getChild(i)));
+    }
+    switch (op->getOperatorType()) {
+    case LogicalOperatorType::HASH_JOIN: {
+        return visitHashJoin(op);
+    }
+    default:
+        return op;
+    }
+}
+
+std::shared_ptr<planner::LogicalOperator> RemoveUnnecessaryJoinOptimizer::visitHashJoin(
+    std::shared_ptr<planner::LogicalOperator> op) {
+    auto hashJoin = (LogicalHashJoin*)op.get();
+    switch (hashJoin->getJoinType()) {
+    case common::JoinType::MARK:
+    case common::JoinType::LEFT: {
+        // Do not prune no-trivial join type
+        return op;
+    }
+    default:
+        break;
+    }
+    if (op->getChild(1)->getOperatorType() == LogicalOperatorType::SCAN_NODE) {
+        // Build side is trivial. Prune build side.
+        if (op->getChild(0)->getOperatorType() == planner::LogicalOperatorType::ACCUMULATE) {
+            // TODO(Xiyang): Revisit this once we have an ASP optimizer.
+            return op;
+        }
+        return op->getChild(0);
+    }
+    if (op->getChild(0)->getOperatorType() == LogicalOperatorType::SCAN_NODE) {
+        // Probe side is trivial. Prune probe side.
+        return op->getChild(1);
+    }
+    return op;
+}
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -80,7 +80,13 @@ void LogicalHashJoin::computeSchema() {
 }
 
 bool LogicalHashJoin::requireFlatProbeKeys() {
+    // Flatten for multiple join keys.
     if (joinNodeIDs.size() > 1) {
+        return true;
+    }
+    // Flatten for left join.
+    // TODO(Guodong): fix this.
+    if (joinType == common::JoinType::LEFT) {
         return true;
     }
     auto joinNodeID = joinNodeIDs[0].get();

--- a/src/storage/store/rels_store.cpp
+++ b/src/storage/store/rels_store.cpp
@@ -1,6 +1,7 @@
 #include "storage/store/rels_store.h"
 
 using namespace kuzu::catalog;
+using namespace kuzu::common;
 
 namespace kuzu {
 namespace storage {

--- a/test/test_files/tinysnb/agg/multi_label.test
+++ b/test/test_files/tinysnb/agg/multi_label.test
@@ -4,6 +4,6 @@
 7:2|2|1905-12-12
 
 -NAME MultiLabelAggTest2
--QUERY MATCH (a:person)-[e1:marries|studyAt]->(b:person) RETURN e1.year, COUNT(*)
+-QUERY MATCH (a:person)-[e1:marries|studyAt]->(b:person) RETURN NULL, COUNT(*)
 ---- 1
 |3


### PR DESCRIPTION
This PR adds remove unnecessary join optimizer that aims to prune join in the following case

```
MATCH (a)-[e]->(b) RETURN e.date
```

```
           HJ
         /     \
       E(b)   S(b)
        |
       S(a)
```
The last join is unnecessary since we don't read any properties on b table. After pruning, we should get the following plan.

```
 E(b)
   |
 S(a)
```
