### PR TITLE
Fix issue 1323

### DIFF
--- a/dataset/copy-fault-tests/null-pk/schema.cypher
+++ b/dataset/copy-fault-tests/null-pk/schema.cypher
@@ -1,0 +1,1 @@
+create node table person (fName STRING, PRIMARY KEY (fName));

--- a/dataset/copy-fault-tests/null-pk/vPerson.csv
+++ b/dataset/copy-fault-tests/null-pk/vPerson.csv
@@ -1,0 +1,3 @@
+alice
+
+bob

--- a/dataset/copy-special-char-test/vPerson.csv
+++ b/dataset/copy-special-char-test/vPerson.csv
@@ -5,3 +5,4 @@
 4|-only one ## should be recognized-|2013-05-01
 5|this is a ##plain## #string|2013-05-01
 6|this is another ##plain## #string with \|2013-05-01
+7|NA|2022-01-11

--- a/src/storage/copy_arrow/copy_node_arrow.cpp
+++ b/src/storage/copy_arrow/copy_node_arrow.cpp
@@ -200,6 +200,9 @@ void CopyNodeArrow::populatePKIndex(
     InMemColumn* column, HashIndexBuilder<T>* pkIndex, offset_t startOffset, uint64_t numValues) {
     for (auto i = 0u; i < numValues; i++) {
         auto offset = i + startOffset;
+        if (column->isNullAtNodeOffset(offset)) {
+            throw ReaderException("Primary key cannot be null.");
+        }
         if constexpr (std::is_same<T, int64_t>::value) {
             auto key = (int64_t*)column->getElement(offset);
             if (!pkIndex->append(*key, offset)) {
@@ -257,7 +260,7 @@ void CopyNodeArrow::putPropsOfLineIntoColumns(
                 column->setElement(nodeOffset, reinterpret_cast<uint8_t*>(&val));
             } break;
             case DOUBLE: {
-                double_t val = TypeUtils::convertStringToNumber<double_t>(data);
+                auto val = TypeUtils::convertStringToNumber<double_t>(data);
                 column->setElement(nodeOffset, reinterpret_cast<uint8_t*>(&val));
             } break;
             case FLOAT: {
@@ -265,7 +268,7 @@ void CopyNodeArrow::putPropsOfLineIntoColumns(
                 column->setElement(nodeOffset, reinterpret_cast<uint8_t*>(&val));
             } break;
             case BOOL: {
-                bool val = TypeUtils::convertToBoolean(data);
+                auto val = TypeUtils::convertToBoolean(data);
                 column->setElement(nodeOffset, reinterpret_cast<uint8_t*>(&val));
             } break;
             case DATE: {

--- a/src/storage/copy_arrow/copy_structures_arrow.cpp
+++ b/src/storage/copy_arrow/copy_structures_arrow.cpp
@@ -187,19 +187,21 @@ arrow::Status CopyStructuresArrow::initCSVReader(
     ARROW_ASSIGN_OR_RAISE(arrow_input_stream, arrow::io::ReadableFile::Open(filePath));
     auto arrowRead = arrow::csv::ReadOptions::Defaults();
     arrowRead.block_size = CopyConstants::CSV_READING_BLOCK_SIZE;
-
     if (!copyDescription.csvReaderConfig->hasHeader) {
         arrowRead.autogenerate_column_names = true;
     }
 
     auto arrowConvert = arrow::csv::ConvertOptions::Defaults();
     arrowConvert.strings_can_be_null = true;
+    // Only the empty string is treated as NULL.
+    arrowConvert.null_values = {""};
     arrowConvert.quoted_strings_can_be_null = false;
 
     auto arrowParse = arrow::csv::ParseOptions::Defaults();
     arrowParse.delimiter = copyDescription.csvReaderConfig->delimiter;
     arrowParse.escape_char = copyDescription.csvReaderConfig->escapeChar;
     arrowParse.quote_char = copyDescription.csvReaderConfig->quoteChar;
+    arrowParse.ignore_empty_lines = false;
     arrowParse.escaping = true;
 
     ARROW_ASSIGN_OR_RAISE(

--- a/test/copy/copy_fault_test.cpp
+++ b/test/copy/copy_fault_test.cpp
@@ -42,6 +42,12 @@ class CopyInvalidNumberTest : public CopyFaultTest {
     }
 };
 
+class CopyNullPKTest : public CopyFaultTest {
+    std::string getInputDir() override {
+        return TestHelper::appendKuzuRootPath("dataset/copy-fault-tests/null-pk/");
+    }
+};
+
 TEST_F(CopyDuplicateIDTest, DuplicateIDsError) {
     validateCopyException(
         "COPY person FROM \"" +
@@ -153,4 +159,11 @@ TEST_F(CopyInvalidNumberTest, InvalidNumberError) {
         "COPY person FROM \"" +
             TestHelper::appendKuzuRootPath("dataset/copy-fault-tests/invalid-number/vMovie.csv\""),
         "Invalid number: 312abc.");
+}
+
+TEST_F(CopyNullPKTest, NullPKErrpr) {
+    validateCopyException(
+        "COPY person FROM \"" +
+            TestHelper::appendKuzuRootPath("dataset/copy-fault-tests/null-pk/vPerson.csv\""),
+        "Reader exception: Primary key cannot be null.");
 }

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -221,6 +221,7 @@ TEST_F(CopySpecialCharTest, CopySpecialChars) {
     EXPECT_EQ("only one # should be recognized", col->readValue(4).strVal);
     EXPECT_EQ("this is a #plain# string", col->readValue(5).strVal);
     EXPECT_EQ("this is another #plain# string with \\", col->readValue(6).strVal);
+    EXPECT_EQ("NA", col->readValue(7).strVal);
 
     tableID = catalog->getReadOnlyVersion()->getTableID("organisation");
     propertyIdx = catalog->getReadOnlyVersion()->getNodeProperty(tableID, "name");


### PR DESCRIPTION
1. Fix #1323 by resetting the null_values.
2. Fix empty line bugs:
If a csv file with one column has an empty line, the arrow reader will skip that line instead of treating it as null value.