### PR TITLE
Solve format string vulnerability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(Kuzu VERSION 0.0.3 LANGUAGES CXX)
+project(Kuzu VERSION 0.0.4 LANGUAGES CXX)
 
 find_package(Threads REQUIRED)
 

--- a/benchmark/queries/ldbc-sf100/fixed_size_expr_evaluator/q13.benchmark
+++ b/benchmark/queries/ldbc-sf100/fixed_size_expr_evaluator/q13.benchmark
@@ -2,4 +2,4 @@
 -COMPARE_RESULT 1
 -QUERY MATCH (comment:Comment) RETURN MIN(gamma(comment.length % 2 + 2))
 ---- 1
-1
+1.000000

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -129,12 +129,12 @@ std::vector<PropertyNameDataType> Binder::bindPropertyNameDataTypes(
     for (auto& propertyNameDataType : propertyNameDataTypes) {
         if (boundPropertyNames.contains(propertyNameDataType.first)) {
             throw BinderException(StringUtils::string_format(
-                "Duplicated column name: %s, column name must be unique.",
-                propertyNameDataType.first.c_str()));
+                "Duplicated column name: {}, column name must be unique.",
+                propertyNameDataType.first));
         } else if (TableSchema::isReservedPropertyName(propertyNameDataType.first)) {
             throw BinderException(
-                StringUtils::string_format("PropertyName: %s is an internal reserved propertyName.",
-                    propertyNameDataType.first.c_str()));
+                StringUtils::string_format("PropertyName: {} is an internal reserved propertyName.",
+                    propertyNameDataType.first));
         }
         StringUtils::toUpper(propertyNameDataType.second);
         auto dataType = bindDataType(propertyNameDataType.second);

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -180,8 +180,8 @@ void Binder::validateNodeTableHasNoEdge(const Catalog& _catalog, table_id_t tabl
     for (auto& tableIDSchema : _catalog.getReadOnlyVersion()->getRelTableSchemas()) {
         if (tableIDSchema.second->isSrcOrDstTable(tableID)) {
             throw BinderException(StringUtils::string_format(
-                "Cannot delete a node table with edges. It is on the edges of rel: %s.",
-                tableIDSchema.second->tableName.c_str()));
+                "Cannot delete a node table with edges. It is on the edges of rel: {}.",
+                tableIDSchema.second->tableName));
         }
     }
 }

--- a/src/catalog/catalog_structs.cpp
+++ b/src/catalog/catalog_structs.cpp
@@ -47,8 +47,8 @@ std::string TableSchema::getPropertyName(property_id_t propertyID) const {
             return property.name;
         }
     }
-    throw common::RuntimeException(common::StringUtils::string_format(
-        "Table: %s doesn't have a property with propertyID=%d.", tableName.c_str(), propertyID));
+    throw common::RuntimeException(StringUtils::string_format(
+        "Table: {} doesn't have a property with propertyID={}.", tableName, propertyID));
 }
 
 property_id_t TableSchema::getPropertyID(const std::string& propertyName) const {
@@ -57,9 +57,8 @@ property_id_t TableSchema::getPropertyID(const std::string& propertyName) const 
             return property.propertyID;
         }
     }
-    throw common::RuntimeException(common::StringUtils::string_format(
-        "Table: %s doesn't have a property with propertyName=%s.", tableName.c_str(),
-        propertyName.c_str()));
+    throw common::RuntimeException(StringUtils::string_format(
+        "Table: {} doesn't have a property with propertyName={}.", tableName, propertyName));
 }
 
 Property TableSchema::getProperty(property_id_t propertyID) const {
@@ -68,8 +67,8 @@ Property TableSchema::getProperty(property_id_t propertyID) const {
             return property;
         }
     }
-    throw common::RuntimeException(common::StringUtils::string_format(
-        "Table: %s doesn't have a property with propertyID=%d.", tableName.c_str(), propertyID));
+    throw common::RuntimeException(StringUtils::string_format(
+        "Table: {} doesn't have a property with propertyID={}.", tableName, propertyID));
 }
 
 void TableSchema::renameProperty(property_id_t propertyID, const std::string& newName) {
@@ -80,7 +79,7 @@ void TableSchema::renameProperty(property_id_t propertyID, const std::string& ne
         }
     }
     throw common::InternalException(
-        "Property with id=" + std::to_string(propertyID) + " not found.");
+        StringUtils::string_format("Property with id={} not found.", propertyID));
 }
 
 } // namespace catalog

--- a/src/common/assert.cpp
+++ b/src/common/assert.cpp
@@ -11,7 +11,7 @@ void kuAssertInternal(bool condition, const char* condition_name, const char* fi
         return;
     }
     throw InternalException(StringUtils::string_format(
-        "Assertion triggered in file \"%s\" on line %d: %s", file, linenr, condition_name));
+        "Assertion triggered in file \"{}\" on line {}: {}", file, linenr, condition_name));
 }
 
 } // namespace common

--- a/src/common/csv_reader/csv_reader.cpp
+++ b/src/common/csv_reader/csv_reader.cpp
@@ -210,7 +210,7 @@ bool CSVReader::hasNextTokenOrError() {
     if (!hasNextToken()) {
         throw ReaderException(
             StringUtils::string_format("CSV Reader was expecting more tokens but the line does not "
-                                       "have any tokens left. Last token: %s",
+                                       "have any tokens left. Last token: {}",
                 line + linePtrStart));
     }
     return true;
@@ -311,7 +311,7 @@ std::unique_ptr<Value> CSVReader::getList(const DataType& dataType) {
     auto numBytesOfOverflow = listVal.size() * Types::getDataTypeSize(dataType.typeID);
     if (numBytesOfOverflow >= BufferPoolConstants::DEFAULT_PAGE_SIZE) {
         throw ReaderException(StringUtils::string_format(
-            "Maximum num bytes of a LIST is %d. Input list's num bytes is %d.",
+            "Maximum num bytes of a LIST is {}. Input list's num bytes is {}.",
             BufferPoolConstants::DEFAULT_PAGE_SIZE, numBytesOfOverflow));
     }
     return std::make_unique<Value>(

--- a/src/common/file_utils.cpp
+++ b/src/common/file_utils.cpp
@@ -18,7 +18,7 @@ void FileUtils::writeToFile(
     FileInfo* fileInfo, uint8_t* buffer, uint64_t numBytes, uint64_t offset) {
     auto fileSize = getFileSize(fileInfo->fd);
     if (fileSize == -1) {
-        throw Exception(StringUtils::string_format("File %s not open.", fileInfo->path.c_str()));
+        throw Exception(StringUtils::string_format("File {} not open.", fileInfo->path));
     }
     uint64_t remainingNumBytesToWrite = numBytes;
     uint64_t bufferOffset = 0;
@@ -30,9 +30,9 @@ void FileUtils::writeToFile(
             pwrite(fileInfo->fd, buffer + bufferOffset, numBytesToWrite, offset);
         if (numBytesWritten != numBytesToWrite) {
             throw Exception(StringUtils::string_format(
-                "Cannot write to file. path: %s fileDescriptor: %d offsetToWrite: %llu "
-                "numBytesToWrite: %llu numBytesWritten: %llu",
-                fileInfo->path.c_str(), fileInfo->fd, offset, numBytesToWrite, numBytesWritten));
+                "Cannot write to file. path: {} fileDescriptor: {} offsetToWrite: {} "
+                "numBytesToWrite: {} numBytesWritten: {}",
+                fileInfo->path, fileInfo->fd, offset, numBytesToWrite, numBytesWritten));
         }
         remainingNumBytesToWrite -= numBytesWritten;
         offset += numBytesWritten;
@@ -46,8 +46,8 @@ void FileUtils::overwriteFile(const std::string& from, const std::string& to) {
     std::error_code errorCode;
     if (!std::filesystem::copy_file(
             from, to, std::filesystem::copy_options::overwrite_existing, errorCode)) {
-        throw Exception(StringUtils::string_format("Error copying file %s to %s.  ErrorMessage: %s",
-            from.c_str(), to.c_str(), errorCode.message().c_str()));
+        throw Exception(StringUtils::string_format(
+            "Error copying file {} to {}.  ErrorMessage: {}", from, to, errorCode.message()));
     }
 }
 
@@ -56,25 +56,24 @@ void FileUtils::readFromFile(
     auto numBytesRead = pread(fileInfo->fd, buffer, numBytes, position);
     if (numBytesRead != numBytes && getFileSize(fileInfo->fd) != position + numBytesRead) {
         throw Exception(
-            StringUtils::string_format("Cannot read from file: %s fileDescriptor: %d "
-                                       "numBytesRead: %llu numBytesToRead: %llu position: %llu",
-                fileInfo->path.c_str(), fileInfo->fd, numBytesRead, numBytes, position));
+            StringUtils::string_format("Cannot read from file: {} fileDescriptor: {} "
+                                       "numBytesRead: {} numBytesToRead: {} position: {}",
+                fileInfo->path, fileInfo->fd, numBytesRead, numBytes, position));
     }
 }
 
 void FileUtils::createDir(const std::string& dir) {
     try {
         if (std::filesystem::exists(dir)) {
-            throw Exception(
-                StringUtils::string_format("Directory %s already exists.", dir.c_str()));
+            throw Exception(StringUtils::string_format("Directory {} already exists.", dir));
         }
         if (!std::filesystem::create_directory(dir)) {
             throw Exception(StringUtils::string_format(
-                "Directory %s cannot be created. Check if it exists and remove it.", dir.c_str()));
+                "Directory {} cannot be created. Check if it exists and remove it.", dir));
         }
     } catch (std::exception& e) {
-        throw Exception(StringUtils::string_format(
-            "Failed to create directory %s due to: %s", dir.c_str(), e.what()));
+        throw Exception(
+            StringUtils::string_format("Failed to create directory {} due to: {}", dir, e.what()));
     }
 }
 
@@ -83,9 +82,8 @@ void FileUtils::removeDir(const std::string& dir) {
     if (!fileOrPathExists(dir))
         return;
     if (!std::filesystem::remove_all(dir, removeErrorCode)) {
-        throw Exception(
-            StringUtils::string_format("Error removing directory %s.  Error Message: %s",
-                dir.c_str(), removeErrorCode.message().c_str()));
+        throw Exception(StringUtils::string_format(
+            "Error removing directory {}.  Error Message: {}", dir, removeErrorCode.message()));
     }
 }
 
@@ -97,8 +95,8 @@ void FileUtils::renameFileIfExists(const std::string& oldName, const std::string
     std::filesystem::rename(oldName, newName, errorCode);
     if (errorCode.value() != 0) {
         throw Exception(
-            StringUtils::string_format("Error replacing file %s to %s.  ErrorMessage: %s",
-                oldName.c_str(), newName.c_str(), errorCode.message().c_str()));
+            StringUtils::string_format("Error replacing file {} to {}.  ErrorMessage: {}", oldName,
+                newName, errorCode.message()));
     }
 }
 
@@ -107,7 +105,7 @@ void FileUtils::removeFileIfExists(const std::string& path) {
         return;
     if (remove(path.c_str()) != 0) {
         throw Exception(StringUtils::string_format(
-            "Error removing directory or file %s.  Error Message: ", path.c_str()));
+            "Error removing directory or file {}.  Error Message: ", path));
     }
 }
 

--- a/src/common/logging_level_utils.cpp
+++ b/src/common/logging_level_utils.cpp
@@ -15,7 +15,7 @@ spdlog::level::level_enum LoggingLevelUtils::convertStrToLevelEnum(std::string l
         return spdlog::level::level_enum::err;
     } else {
         throw ConversionException(
-            StringUtils::string_format("Unsupported logging level: %s.", loggingLevel.c_str()));
+            StringUtils::string_format("Unsupported logging level: {}.", loggingLevel));
     }
 }
 

--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -11,7 +11,7 @@ uint32_t TypeUtils::convertToUint32(const char* data) {
     uint32_t val;
     if (!(iss >> val)) {
         throw ConversionException(
-            StringUtils::string_format("Failed to convert %s to uint32_t", data));
+            StringUtils::string_format("Failed to convert {} to uint32_t", data));
     }
     return val;
 }

--- a/src/common/types/date_t.cpp
+++ b/src/common/types/date_t.cpp
@@ -229,7 +229,7 @@ date_t Date::FromDate(int32_t year, int32_t month, int32_t day) {
     int32_t n = 0;
     if (!Date::IsValid(year, month, day)) {
         throw ConversionException(
-            StringUtils::string_format("Date out of range: %d-%d-%d.", year, month, day));
+            StringUtils::string_format("Date out of range: {}-{}-{}.", year, month, day));
     }
     while (year < 1970) {
         year += Date::YEAR_INTERVAL;

--- a/src/common/types/dtime_t.cpp
+++ b/src/common/types/dtime_t.cpp
@@ -131,9 +131,10 @@ dtime_t Time::FromCString(const char* buf, uint64_t len) {
     dtime_t result;
     uint64_t pos;
     if (!Time::TryConvertTime(buf, len, pos, result)) {
-        throw ConversionException(StringUtils::string_format(
-            "Error occurred during parsing time. Given: \"" + std::string(buf, len) +
-            "\". Expected format: (hh:mm:ss[.zzzzzz])."));
+        throw ConversionException(
+            StringUtils::string_format("Error occurred during parsing time. Given: \"{}\". "
+                                       "Expected format: (hh:mm:ss[.zzzzzz]).",
+                std::string(buf, len)));
     }
     return result;
 }
@@ -160,7 +161,7 @@ bool Time::IsValid(int32_t hour, int32_t minute, int32_t second, int32_t microse
 dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
     if (!Time::IsValid(hour, minute, second, microseconds)) {
         throw ConversionException(StringUtils::string_format(
-            "Time field value out of range: %d:%d:%d[.%d].", hour, minute, second, microseconds));
+            "Time field value out of range: {}:{}:{}[.{}].", hour, minute, second, microseconds));
     }
     int64_t result;
     result = hour;                                             // hours

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -156,6 +156,9 @@ void Value::copyValueFrom(const uint8_t* value) {
     case DOUBLE: {
         val.doubleVal = *((double*)value);
     } break;
+    case FLOAT: {
+        val.floatVal = *((float_t*)value);
+    } break;
     case DATE: {
         val.dateVal = *((date_t*)value);
     } break;
@@ -176,9 +179,6 @@ void Value::copyValueFrom(const uint8_t* value) {
     } break;
     case FIXED_LIST: {
         listVal = convertKUFixedListToVector(value);
-    } break;
-    case FLOAT: {
-        val.floatVal = *((float_t*)value);
     } break;
     default:
         throw RuntimeException(
@@ -209,6 +209,9 @@ void Value::copyValueFrom(const Value& other) {
     case DOUBLE: {
         val.doubleVal = other.val.doubleVal;
     } break;
+    case FLOAT: {
+        val.floatVal = other.val.floatVal;
+    } break;
     case DATE: {
         val.dateVal = other.val.dateVal;
     } break;
@@ -236,9 +239,6 @@ void Value::copyValueFrom(const Value& other) {
     case REL: {
         relVal = other.relVal->copy();
     } break;
-    case FLOAT: {
-        val.floatVal = other.val.floatVal;
-    } break;
     default:
         throw NotImplementedException("Value::Value(const Value&) for type " +
                                       Types::dataTypeToString(dataType) + " is not implemented.");
@@ -264,6 +264,8 @@ std::string Value::toString() const {
         return TypeUtils::toString(val.int16Val);
     case DOUBLE:
         return TypeUtils::toString(val.doubleVal);
+    case FLOAT:
+        return TypeUtils::toString(val.floatVal);
     case DATE:
         return TypeUtils::toString(val.dateVal);
     case TIMESTAMP:
@@ -287,8 +289,6 @@ std::string Value::toString() const {
         return nodeVal->toString();
     case REL:
         return relVal->toString();
-    case FLOAT:
-        return TypeUtils::toString(val.floatVal);
     default:
         throw NotImplementedException("Value::toString for type " +
                                       Types::dataTypeToString(dataType) + " is not implemented.");
@@ -306,8 +306,8 @@ void Value::validateType(DataTypeID typeID) const {
 void Value::validateType(const DataType& type) const {
     if (type != dataType) {
         throw RuntimeException(
-            StringUtils::string_format("Cannot get %s value from the %s result value.",
-                Types::dataTypeToString(type).c_str(), Types::dataTypeToString(dataType).c_str()));
+            StringUtils::string_format("Cannot get {} value from the {} result value.",
+                Types::dataTypeToString(type), Types::dataTypeToString(dataType)));
     }
 }
 

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -11,6 +11,7 @@
 
 #include "common/constants.h"
 #include "exception.h"
+#include "spdlog/fmt/fmt.h"
 
 namespace spdlog {
 class logger;
@@ -33,6 +34,11 @@ private:
 class StringUtils {
 
 public:
+    template<typename... Args>
+    inline static std::string string_format(const std::string& format, Args... args) {
+        return fmt::format(fmt::runtime(format), args...);
+    }
+
     static std::vector<std::string> split(const std::string& input, const std::string& delimiter);
 
     static void toUpper(std::string& input) {
@@ -48,23 +54,11 @@ public:
     }
 
     static bool CharacterIsDigit(char c) { return c >= '0' && c <= '9'; }
-    template<typename... Args>
-    static std::string string_format(const std::string& format, Args... args) {
-        int size_s = snprintf(nullptr, 0, format.c_str(), args...) + 1; // Extra space for '\0'
-        if (size_s <= 0) {
-            throw Exception("Error during formatting.");
-        }
-        auto size = static_cast<size_t>(size_s);
-        auto buf = std::make_unique<char[]>(size);
-        snprintf(buf.get(), size, format.c_str(), args...);
-        return {buf.get(), buf.get() + size - 1}; // We don't want the '\0' inside
-    }
 
     static std::string getLongStringErrorMessage(
         const char* strToInsert, uint64_t maxAllowedStrSize) {
-        return StringUtils::string_format(
-            "Maximum length of strings is %d. Input string's length is %d.", maxAllowedStrSize,
-            strlen(strToInsert), strToInsert);
+        return string_format("Maximum length of strings is {}. Input string's length is {}.",
+            maxAllowedStrSize, strlen(strToInsert), strToInsert);
     }
 };
 

--- a/src/include/function/arithmetic/vector_arithmetic_operations.h
+++ b/src/include/function/arithmetic/vector_arithmetic_operations.h
@@ -12,7 +12,7 @@ public:
     template<typename FUNC>
     static std::unique_ptr<VectorOperationDefinition> getUnaryDefinition(
         std::string name, common::DataTypeID operandTypeID) {
-        return make_unique<VectorOperationDefinition>(std::move(name),
+        return std::make_unique<VectorOperationDefinition>(std::move(name),
             std::vector<common::DataTypeID>{operandTypeID}, operandTypeID,
             getUnaryExecFunc<FUNC>(operandTypeID));
     }
@@ -20,7 +20,7 @@ public:
     template<typename FUNC, typename OPERAND_TYPE, typename RETURN_TYPE = OPERAND_TYPE>
     static std::unique_ptr<VectorOperationDefinition> getUnaryDefinition(
         std::string name, common::DataTypeID operandTypeID, common::DataTypeID resultTypeID) {
-        return make_unique<VectorOperationDefinition>(std::move(name),
+        return std::make_unique<VectorOperationDefinition>(std::move(name),
             std::vector<common::DataTypeID>{operandTypeID}, resultTypeID,
             VectorArithmeticOperations::UnaryExecFunction<OPERAND_TYPE, RETURN_TYPE, FUNC>);
     }
@@ -28,7 +28,7 @@ public:
     template<typename FUNC>
     static inline std::unique_ptr<VectorOperationDefinition> getBinaryDefinition(
         std::string name, common::DataTypeID operandTypeID) {
-        return make_unique<VectorOperationDefinition>(std::move(name),
+        return std::make_unique<VectorOperationDefinition>(std::move(name),
             std::vector<common::DataTypeID>{operandTypeID, operandTypeID}, operandTypeID,
             getBinaryExecFunc<FUNC>(operandTypeID));
     }
@@ -36,7 +36,7 @@ public:
     template<typename FUNC, typename OPERAND_TYPE, typename RETURN_TYPE = OPERAND_TYPE>
     static inline std::unique_ptr<VectorOperationDefinition> getBinaryDefinition(
         std::string name, common::DataTypeID operandTypeID, common::DataTypeID resultTypeID) {
-        return make_unique<VectorOperationDefinition>(std::move(name),
+        return std::make_unique<VectorOperationDefinition>(std::move(name),
             std::vector<common::DataTypeID>{operandTypeID, operandTypeID}, resultTypeID,
             VectorArithmeticOperations::BinaryExecFunction<OPERAND_TYPE, OPERAND_TYPE, RETURN_TYPE,
                 FUNC>);

--- a/src/include/function/cast/vector_cast_operations.h
+++ b/src/include/function/cast/vector_cast_operations.h
@@ -22,7 +22,7 @@ public:
     inline static std::unique_ptr<VectorOperationDefinition> bindVectorOperation(
         const std::string& funcName, common::DataTypeID sourceTypeID,
         common::DataTypeID targetTypeID) {
-        return make_unique<VectorOperationDefinition>(funcName,
+        return std::make_unique<VectorOperationDefinition>(funcName,
             std::vector<common::DataTypeID>{sourceTypeID}, targetTypeID,
             VectorOperations::UnaryExecFunction<SOURCE_TYPE, TARGET_TYPE, FUNC>);
     }

--- a/src/include/function/comparison/vector_comparison_operations.h
+++ b/src/include/function/comparison/vector_comparison_operations.h
@@ -32,7 +32,7 @@ private:
         const std::string& name, common::DataTypeID leftTypeID, common::DataTypeID rightTypeID) {
         auto execFunc = getExecFunc<FUNC>(leftTypeID, rightTypeID);
         auto selectFunc = getSelectFunc<FUNC>(leftTypeID, rightTypeID);
-        return make_unique<VectorOperationDefinition>(name,
+        return std::make_unique<VectorOperationDefinition>(name,
             std::vector<common::DataTypeID>{leftTypeID, rightTypeID}, common::BOOL, execFunc,
             selectFunc);
     }

--- a/src/include/function/hash/hash_operations.h
+++ b/src/include/function/hash/hash_operations.h
@@ -24,7 +24,7 @@ struct Hash {
     template<class T>
     static inline void operation(const T& key, common::hash_t& result) {
         throw common::RuntimeException(common::StringUtils::string_format(
-            "Hash type: %s is not supported.", typeid(T).name()));
+            "Hash type: {} is not supported.", typeid(T).name()));
     }
 
     template<class T>

--- a/src/include/function/interval/vector_interval_operations.h
+++ b/src/include/function/interval/vector_interval_operations.h
@@ -12,7 +12,7 @@ public:
     static inline std::vector<std::unique_ptr<VectorOperationDefinition>>
     getUnaryIntervalFunctionDefintion(std::string funcName) {
         std::vector<std::unique_ptr<VectorOperationDefinition>> result;
-        result.push_back(make_unique<VectorOperationDefinition>(funcName,
+        result.push_back(std::make_unique<VectorOperationDefinition>(funcName,
             std::vector<common::DataTypeID>{common::INT64}, common::INTERVAL,
             UnaryExecFunction<int64_t, common::interval_t, OPERATION>));
         return result;

--- a/src/include/function/string/vector_string_operations.h
+++ b/src/include/function/string/vector_string_operations.h
@@ -43,7 +43,7 @@ struct VectorStringOperations : public VectorOperations {
     static inline std::vector<std::unique_ptr<VectorOperationDefinition>>
     getUnaryStrFunctionDefintion(std::string funcName) {
         std::vector<std::unique_ptr<VectorOperationDefinition>> definitions;
-        definitions.emplace_back(make_unique<VectorOperationDefinition>(funcName,
+        definitions.emplace_back(std::make_unique<VectorOperationDefinition>(funcName,
             std::vector<common::DataTypeID>{common::STRING}, common::STRING,
             UnaryStringExecFunction<common::ku_string_t, common::ku_string_t, OPERATION>,
             false /* isVarLength */));

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -67,7 +67,7 @@ class StorageUtils {
 public:
     static inline std::string getNodeIndexFName(const std::string& directory,
         const common::table_id_t& tableID, common::DBFileType dbFileType) {
-        auto fName = common::StringUtils::string_format("n-%d", tableID);
+        auto fName = common::StringUtils::string_format("n-{}", tableID);
         return appendWALFileSuffixIfNecessary(
             common::FileUtils::joinPath(
                 directory, fName + common::StorageConstants::INDEX_FILE_SUFFIX),
@@ -76,7 +76,7 @@ public:
 
     static inline std::string getNodePropertyColumnFName(const std::string& directory,
         const common::table_id_t& tableID, uint32_t propertyID, common::DBFileType dbFileType) {
-        auto fName = common::StringUtils::string_format("n-%d-%d", tableID, propertyID);
+        auto fName = common::StringUtils::string_format("n-{}-{}", tableID, propertyID);
         return appendWALFileSuffixIfNecessary(
             common::FileUtils::joinPath(
                 directory, fName + common::StorageConstants::COLUMN_FILE_SUFFIX),
@@ -121,7 +121,7 @@ public:
     static inline std::string getAdjColumnFName(const std::string& directory,
         const common::table_id_t& relTableID, const common::RelDirection& relDirection,
         common::DBFileType dbFileType) {
-        auto fName = common::StringUtils::string_format("r-%d-%d", relTableID, relDirection);
+        auto fName = common::StringUtils::string_format("r-{}-{}", relTableID, relDirection);
         return appendWALFileSuffixIfNecessary(
             common::FileUtils::joinPath(
                 directory, fName + common::StorageConstants::COLUMN_FILE_SUFFIX),
@@ -140,7 +140,7 @@ public:
     static inline std::string getAdjListsFName(const std::string& directory,
         const common::table_id_t& relTableID, const common::RelDirection& relDirection,
         common::DBFileType dbFileType) {
-        auto fName = common::StringUtils::string_format("r-%d-%d", relTableID, relDirection);
+        auto fName = common::StringUtils::string_format("r-{}-{}", relTableID, relDirection);
         return appendWALFileSuffixIfNecessary(
             common::FileUtils::joinPath(
                 directory, fName + common::StorageConstants::LISTS_FILE_SUFFIX),
@@ -151,7 +151,7 @@ public:
         const common::table_id_t& relTableID, const common::RelDirection& relDirection,
         const uint32_t propertyID, common::DBFileType dbFileType) {
         auto fName =
-            common::StringUtils::string_format("r-%d-%d-%d", relTableID, relDirection, propertyID);
+            common::StringUtils::string_format("r-{}-{}-{}", relTableID, relDirection, propertyID);
         return appendWALFileSuffixIfNecessary(
             common::FileUtils::joinPath(
                 directory, fName + common::StorageConstants::COLUMN_FILE_SUFFIX),
@@ -172,7 +172,7 @@ public:
         const common::table_id_t& relTableID, const common::RelDirection& relDirection,
         const uint32_t propertyID, common::DBFileType dbFileType) {
         auto fName =
-            common::StringUtils::string_format("r-%d-%d-%d", relTableID, relDirection, propertyID);
+            common::StringUtils::string_format("r-{}-{}-{}", relTableID, relDirection, propertyID);
         return appendWALFileSuffixIfNecessary(
             common::FileUtils::joinPath(
                 directory, fName + common::StorageConstants::LISTS_FILE_SUFFIX),

--- a/src/processor/operator/copy/copy.cpp
+++ b/src/processor/operator/copy/copy.cpp
@@ -18,7 +18,7 @@ std::string Copy::execute(TaskScheduler* taskScheduler, ExecutionContext* execut
 }
 
 std::string Copy::getOutputMsg(uint64_t numTuplesCopied) {
-    return StringUtils::string_format("%d number of tuples has been copied to table: %s.",
+    return StringUtils::string_format("{} number of tuples has been copied to table: {}.",
         numTuplesCopied, catalog->getReadOnlyVersion()->getTableName(tableID).c_str());
 }
 

--- a/src/processor/operator/ddl/create_node_table.cpp
+++ b/src/processor/operator/ddl/create_node_table.cpp
@@ -12,7 +12,7 @@ void CreateNodeTable::executeDDLInternal() {
 }
 
 std::string CreateNodeTable::getOutputMsg() {
-    return StringUtils::string_format("NodeTable: %s has been created.", tableName.c_str());
+    return StringUtils::string_format("NodeTable: {} has been created.", tableName);
 }
 
 } // namespace processor

--- a/src/processor/operator/ddl/create_rel_table.cpp
+++ b/src/processor/operator/ddl/create_rel_table.cpp
@@ -12,7 +12,7 @@ void CreateRelTable::executeDDLInternal() {
 }
 
 std::string CreateRelTable::getOutputMsg() {
-    return StringUtils::string_format("RelTable: %s has been created.", tableName.c_str());
+    return StringUtils::string_format("RelTable: {} has been created.", tableName);
 }
 
 } // namespace processor

--- a/src/processor/operator/ddl/drop_table.cpp
+++ b/src/processor/operator/ddl/drop_table.cpp
@@ -11,8 +11,8 @@ void DropTable::executeDDLInternal() {
 
 std::string DropTable::getOutputMsg() {
     auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(tableID);
-    return StringUtils::string_format("%sTable: %s has been dropped.",
-        tableSchema->isNodeTable ? "Node" : "Rel", tableSchema->tableName.c_str());
+    return StringUtils::string_format("{}Table: {} has been dropped.",
+        tableSchema->isNodeTable ? "Node" : "Rel", tableSchema->tableName);
 }
 
 } // namespace processor

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -25,7 +25,7 @@ OrderByKeyEncoder::OrderByKeyEncoder(std::vector<std::shared_ptr<ValueVector>>& 
     maxNumTuplesPerBlock = BufferPoolConstants::LARGE_PAGE_SIZE / numBytesPerTuple;
     if (maxNumTuplesPerBlock <= 0) {
         throw RuntimeException(StringUtils::string_format(
-            "TupleSize(%d bytes) is larger than the LARGE_PAGE_SIZE(%d bytes)", numBytesPerTuple,
+            "TupleSize({} bytes) is larger than the LARGE_PAGE_SIZE({} bytes)", numBytesPerTuple,
             BufferPoolConstants::LARGE_PAGE_SIZE));
     }
     encodeFunctions.resize(orderByVectors.size());

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -19,7 +19,7 @@ uint32_t FlatTuple::len() {
 common::Value* FlatTuple::getValue(uint32_t idx) {
     if (idx >= len()) {
         throw common::RuntimeException(common::StringUtils::string_format(
-            "ValIdx is out of range. Number of values in flatTuple: %d, valIdx: %d.", len(), idx));
+            "ValIdx is out of range. Number of values in flatTuple: {}, valIdx: {}.", len(), idx));
     }
     return values[idx].get();
 }

--- a/src/storage/buffer_manager/file_handle.cpp
+++ b/src/storage/buffer_manager/file_handle.cpp
@@ -63,7 +63,7 @@ bool FileHandle::acquirePageLock(page_idx_t pageIdx, bool block) {
 bool FileHandle::acquire(page_idx_t pageIdx) {
     if (pageIdx >= pageLocks.size()) {
         throw RuntimeException(
-            StringUtils::string_format("pageIdx %d is >= pageLocks.size()", pageIdx));
+            StringUtils::string_format("pageIdx {} is >= pageLocks.size()", pageIdx));
     }
     auto retVal = !pageLocks[pageIdx]->test_and_set(std::memory_order_acquire);
     return retVal;

--- a/src/storage/copy_arrow/copy_node_arrow.cpp
+++ b/src/storage/copy_arrow/copy_node_arrow.cpp
@@ -77,10 +77,10 @@ void CopyNodeArrow::initializeColumnsAndList() {
 template<typename T>
 arrow::Status CopyNodeArrow::populateColumns() {
     logger->info("Populating properties");
-    auto pkIndex =
-        make_unique<HashIndexBuilder<T>>(StorageUtils::getNodeIndexFName(this->outputDirectory,
-                                             nodeTableSchema->tableID, DBFileType::WAL_VERSION),
-            nodeTableSchema->getPrimaryKey().dataType);
+    auto pkIndex = std::make_unique<HashIndexBuilder<T>>(
+        StorageUtils::getNodeIndexFName(
+            this->outputDirectory, nodeTableSchema->tableID, DBFileType::WAL_VERSION),
+        nodeTableSchema->getPrimaryKey().dataType);
     pkIndex->bulkReserve(numRows);
 
     arrow::Status status;

--- a/src/storage/copy_arrow/copy_rel_arrow.cpp
+++ b/src/storage/copy_arrow/copy_rel_arrow.cpp
@@ -68,7 +68,7 @@ void CopyRelArrow::initializeColumnsAndLists() {
 void CopyRelArrow::initializeColumns(RelDirection relDirection) {
     auto boundTableID = relTableSchema->getBoundTableID(relDirection);
     auto numNodes = maxNodeOffsetsPerTable.at(boundTableID) + 1;
-    adjColumnsPerDirection[relDirection] = make_unique<InMemAdjColumn>(
+    adjColumnsPerDirection[relDirection] = std::make_unique<InMemAdjColumn>(
         StorageUtils::getAdjColumnFName(
             outputDirectory, relTableSchema->tableID, relDirection, DBFileType::WAL_VERSION),
         numNodes);
@@ -87,7 +87,7 @@ void CopyRelArrow::initializeColumns(RelDirection relDirection) {
 void CopyRelArrow::initializeLists(RelDirection relDirection) {
     auto boundTableID = relTableSchema->getBoundTableID(relDirection);
     auto numNodes = maxNodeOffsetsPerTable.at(boundTableID) + 1;
-    adjListsPerDirection[relDirection] = make_unique<InMemAdjLists>(
+    adjListsPerDirection[relDirection] = std::make_unique<InMemAdjLists>(
         StorageUtils::getAdjListsFName(
             outputDirectory, relTableSchema->tableID, relDirection, DBFileType::WAL_VERSION),
         numNodes);
@@ -273,13 +273,12 @@ void CopyRelArrow::populateAdjColumnsAndCountRelsInAdjListsTask(uint64_t blockId
                 if (!copier->adjColumnsPerDirection[relDirection]->isNullAtNodeOffset(nodeOffset)) {
                     auto relTableSchema = copier->relTableSchema;
                     throw CopyException(StringUtils::string_format(
-                        "RelTable %s is a %s table, but node(nodeOffset: %d, tableName: %s) has "
-                        "more than one neighbour in the %s direction.",
-                        relTableSchema->tableName.c_str(),
-                        getRelMultiplicityAsString(relTableSchema->relMultiplicity).c_str(),
-                        nodeOffset,
-                        copier->catalog.getReadOnlyVersion()->getTableName(tableID).c_str(),
-                        getRelDirectionAsString(relDirection).c_str()));
+                        "RelTable {} is a {} table, but node(nodeOffset: {}, tableName: {}) has "
+                        "more than one neighbour in the {} direction.",
+                        relTableSchema->tableName,
+                        getRelMultiplicityAsString(relTableSchema->relMultiplicity), nodeOffset,
+                        copier->catalog.getReadOnlyVersion()->getTableName(tableID),
+                        getRelDirectionAsString(relDirection)));
                 }
                 copier->adjColumnsPerDirection[relDirection]->setElement(
                     nodeOffset, (uint8_t*)&nodeIDs[!relDirection]);

--- a/src/storage/copy_arrow/copy_structures_arrow.cpp
+++ b/src/storage/copy_arrow/copy_structures_arrow.cpp
@@ -318,7 +318,7 @@ std::unique_ptr<Value> CopyStructuresArrow::getArrowVarList(std::string& l, int6
     auto numBytesOfOverflow = values.size() * Types::getDataTypeSize(childDataType.typeID);
     if (numBytesOfOverflow >= BufferPoolConstants::DEFAULT_PAGE_SIZE) {
         throw ReaderException(StringUtils::string_format(
-            "Maximum num bytes of a LIST is %d. Input list's num bytes is %d.",
+            "Maximum num bytes of a LIST is {}. Input list's num bytes is {}.",
             BufferPoolConstants::DEFAULT_PAGE_SIZE, numBytesOfOverflow));
     }
     return make_unique<Value>(
@@ -372,7 +372,7 @@ std::unique_ptr<uint8_t[]> CopyStructuresArrow::getArrowFixedList(std::string& l
     }
     if (numElementsRead != dataType.fixedNumElementsInList) {
         throw ReaderException(StringUtils::string_format(
-            "Each fixed list should have fixed number of elements. Expected: %d, Actual: %d.",
+            "Each fixed list should have fixed number of elements. Expected: {}, Actual: {}.",
             dataType.fixedNumElementsInList, numElementsRead));
     }
     return listVal;

--- a/src/storage/storage_structure/disk_array.cpp
+++ b/src/storage/storage_structure/disk_array.cpp
@@ -69,7 +69,7 @@ void BaseDiskArray<U>::checkOutOfBoundAccess(TransactionType trxType, uint64_t i
     auto currentNumElements = getNumElementsNoLock(trxType);
     if (idx >= currentNumElements) {
         throw RuntimeException(StringUtils::string_format(
-            "idx: %d of the DiskArray to be accessed is >= numElements in DiskArray%d.", idx,
+            "idx: {} of the DiskArray to be accessed is >= numElements in DiskArray{}.", idx,
             currentNumElements));
     }
 }

--- a/src/storage/store/nodes_statistics_and_deleted_ids.cpp
+++ b/src/storage/store/nodes_statistics_and_deleted_ids.cpp
@@ -54,15 +54,15 @@ void NodeStatisticsAndDeletedIDs::deleteNode(offset_t nodeOffset) {
     auto maxNodeOffset = getMaxNodeOffset();
     if (maxNodeOffset == UINT64_MAX || nodeOffset > maxNodeOffset) {
         throw RuntimeException(
-            StringUtils::string_format("Cannot delete nodeOffset %d in nodeTable %d. maxNodeOffset "
-                                       "is either -1 or nodeOffset is > maxNodeOffset: %d.",
+            StringUtils::string_format("Cannot delete nodeOffset {} in nodeTable {}. maxNodeOffset "
+                                       "is either -1 or nodeOffset is > maxNodeOffset: {}.",
                 nodeOffset, tableID, maxNodeOffset));
     }
     auto morselIdxAndOffset =
         StorageUtils::getQuotientRemainder(nodeOffset, DEFAULT_VECTOR_CAPACITY);
     if (isDeleted(nodeOffset, morselIdxAndOffset.first)) {
         throw RuntimeException(
-            StringUtils::string_format("Node with offset %d is already deleted.", nodeOffset));
+            StringUtils::string_format("Node with offset {} is already deleted.", nodeOffset));
     }
     errorIfNodeHasEdges(nodeOffset);
     if (!hasDeletedNodesPerMorsel[morselIdxAndOffset.first]) {
@@ -128,8 +128,8 @@ void NodeStatisticsAndDeletedIDs::errorIfNodeHasEdges(offset_t nodeOffset) {
             adjList->getTotalNumElementsInList(transaction::TransactionType::WRITE, nodeOffset);
         if (numElementsInList != 0) {
             throw RuntimeException(StringUtils::string_format(
-                "Currently deleting a node with edges is not supported. node table %d nodeOffset "
-                "%d has %d (one-to-many or many-to-many) edges for edge file: %s.",
+                "Currently deleting a node with edges is not supported. node table {} nodeOffset "
+                "{} has {} (one-to-many or many-to-many) edges for edge file: {}.",
                 tableID, nodeOffset, numElementsInList,
                 adjList->getFileHandle()->getFileInfo()->path.c_str()));
         }
@@ -137,8 +137,8 @@ void NodeStatisticsAndDeletedIDs::errorIfNodeHasEdges(offset_t nodeOffset) {
     for (AdjColumn* adjColumn : adjListsAndColumns.second) {
         if (!adjColumn->isNull(nodeOffset, transaction::Transaction::getDummyWriteTrx().get())) {
             throw RuntimeException(StringUtils::string_format(
-                "Currently deleting a node with edges is not supported. node table %d nodeOffset "
-                "%d  has a 1-1 edge for edge file: %s.",
+                "Currently deleting a node with edges is not supported. node table {} nodeOffset "
+                "{}  has a 1-1 edge for edge file: {}.",
                 tableID, nodeOffset, adjColumn->getFileHandle()->getFileInfo()->path.c_str()));
         }
     }

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -136,12 +136,12 @@ void DirectedRelTableData::insertRel(const std::shared_ptr<ValueVector>& boundVe
     // TODO(Guodong): We should pass a write transaction pointer down.
     if (!adjColumn->isNull(nodeOffset, transaction::Transaction::getDummyWriteTrx().get())) {
         throw RuntimeException(
-            StringUtils::string_format("Node(nodeOffset: %d, tableID: %d) in RelTable %d cannot "
-                                       "have more than one neighbour in the %s direction.",
+            StringUtils::string_format("Node(nodeOffset: {}, tableID: {}) in RelTable {} cannot "
+                                       "have more than one neighbour in the {} direction.",
                 nodeOffset,
                 boundVector->getValue<nodeID_t>(boundVector->state->selVector->selectedPositions[0])
                     .tableID,
-                tableID, getRelDirectionAsString(direction).c_str()));
+                tableID, getRelDirectionAsString(direction)));
     }
     adjColumn->writeValues(boundVector, nbrVector);
     for (auto i = 0u; i < relPropertyVectors.size(); i++) {

--- a/test/graph_test/graph_test.cpp
+++ b/test/graph_test/graph_test.cpp
@@ -118,8 +118,8 @@ void TestHelper::executeScript(const std::string& cypherScript, Connection& conn
     }
     std::ifstream file(cypherScript);
     if (!file.is_open()) {
-        throw Exception(StringUtils::string_format(
-            "Error opening file: %s, errno: %d.", cypherScript.c_str(), errno));
+        throw Exception(
+            StringUtils::string_format("Error opening file: {}, errno: {}.", cypherScript, errno));
     }
     std::string line;
     while (getline(file, line)) {
@@ -133,9 +133,8 @@ void TestHelper::executeScript(const std::string& cypherScript, Connection& conn
         auto result = conn.query(line);
         std::cout << "Executed query: " << line << std::endl;
         if (!result->isSuccess()) {
-            throw Exception(
-                StringUtils::string_format("Failed to execute statement: %s.\nError: %s",
-                    line.c_str(), result->getErrorMessage().c_str()));
+            throw Exception(StringUtils::string_format(
+                "Failed to execute statement: {}.\nError: {}", line, result->getErrorMessage()));
         }
     }
 }

--- a/test/processor/order_by/order_by_key_encoder_test.cpp
+++ b/test/processor/order_by/order_by_key_encoder_test.cpp
@@ -587,8 +587,8 @@ TEST_F(OrderByKeyEncoderTest, largeNumBytesPerTupleErrorTest) {
         FAIL();
     } catch (Exception& e) {
         ASSERT_STREQ(e.what(),
-            StringUtils::string_format("Runtime exception: TupleSize(%d bytes) is larger than "
-                                       "the LARGE_PAGE_SIZE(%d bytes)",
+            StringUtils::string_format("Runtime exception: TupleSize({} bytes) is larger than "
+                                       "the LARGE_PAGE_SIZE({} bytes)",
                 9 * numOfOrderByCols + 8, BufferPoolConstants::LARGE_PAGE_SIZE)
                 .c_str());
     } catch (std::exception& e) { FAIL(); }

--- a/test/runner/e2e_create_rel_test.cpp
+++ b/test/runner/e2e_create_rel_test.cpp
@@ -59,7 +59,7 @@ public:
         // in the original list.
         for (auto i = 1; i < 2301; i++) {
             expectedResult.push_back(
-                kuzu::common::StringUtils::string_format("%d|%d|[%d]", i, 3000 - i, 3000 - i));
+                kuzu::common::StringUtils::string_format("{}|{}|[{}]", i, 3000 - i, 3000 - i));
         }
         if (isCommit) {
             // We can only see newly inserted rels only if we commit the transaction.
@@ -82,7 +82,7 @@ public:
         for (auto i = 51; i < 1500; i++) {
             insertRel("person" /* srcNode */, 1 /* srcPK */, "person" /* dstNode */, i /* dstPK */,
                 "knows" /* relation */,
-                kuzu::common::StringUtils::string_format("{length: %d, place: '%d', tag: ['%d']}",
+                kuzu::common::StringUtils::string_format("{{length: {}, place: '{}', tag: ['{}']}}",
                     i, 1000 - i, 1000 - i) /* propertyValues */);
         }
         commitOrRollbackConnectionAndInitDBIfNecessary(isCommit, transactionTestType);
@@ -94,13 +94,13 @@ public:
         // in the original list.
         for (auto i = 0; i <= 50; i++) {
             expectedResult.push_back(
-                kuzu::common::StringUtils::string_format("%d|%d|[%d]", i, 1000 - i, 1000 - i));
+                kuzu::common::StringUtils::string_format("{}|{}|[{}]", i, 1000 - i, 1000 - i));
         }
         if (isCommit) {
             // We can only see newly inserted rels only if we commit the transaction.
             for (auto i = 51; i < 1500; i++) {
                 expectedResult.push_back(
-                    kuzu::common::StringUtils::string_format("%d|%d|[%d]", i, 1000 - i, 1000 - i));
+                    kuzu::common::StringUtils::string_format("{}|{}|[{}]", i, 1000 - i, 1000 - i));
             }
         }
         sortAndCheckTestResults(actualResult, expectedResult);

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -385,7 +385,7 @@ public:
     void addPropertyToPersonTableWithoutDefaultValue(
         std::string propertyType, TransactionTestType transactionTestType) {
         executeQueryWithoutCommit(
-            StringUtils::string_format("ALTER TABLE person ADD random %s", propertyType.c_str()));
+            StringUtils::string_format("ALTER TABLE person ADD random {}", propertyType));
         auto tableSchema = catalog->getWriteVersion()->getTableSchema(personTableID);
         auto propertyID = tableSchema->getPropertyID("random");
         auto hasOverflow =
@@ -449,7 +449,7 @@ public:
     void addPropertyToStudyAtTableWithoutDefaultValue(
         std::string propertyType, TransactionTestType transactionTestType) {
         executeQueryWithoutCommit(
-            StringUtils::string_format("ALTER TABLE studyAt ADD random %s", propertyType.c_str()));
+            StringUtils::string_format("ALTER TABLE studyAt ADD random {}", propertyType));
         auto tableSchema = catalog->getWriteVersion()->getTableSchema(studyAtTableID);
         auto propertyID = tableSchema->getPropertyID("random");
         auto hasOverflow =
@@ -489,8 +489,8 @@ public:
 
     void addPropertyToStudyAtTableWithDefaultValue(
         std::string propertyType, std::string defaultVal, TransactionTestType transactionTestType) {
-        executeQueryWithoutCommit(
-            "ALTER TABLE studyAt ADD random " + propertyType + " DEFAULT " + defaultVal);
+        executeQueryWithoutCommit(StringUtils::string_format(
+            "ALTER TABLE studyAt ADD random {} DEFAULT {}", propertyType, defaultVal));
         auto relTableSchema = catalog->getWriteVersion()->getTableSchema(studyAtTableID);
         auto propertyID = relTableSchema->getPropertyID("random");
         auto hasOverflow =

--- a/test/runner/e2e_delete_rel_test.cpp
+++ b/test/runner/e2e_delete_rel_test.cpp
@@ -11,25 +11,25 @@ public:
     std::string getDeleteKnowsRelQuery(
         std::string srcTable, std::string dstTable, int64_t srcID, int64_t dstID) {
         return StringUtils::string_format(
-            "MATCH (p1:%s)-[e:knows]->(p2:%s) WHERE p1.ID = %d AND p2.ID = %d delete e;",
-            srcTable.c_str(), dstTable.c_str(), srcID, dstID);
+            "MATCH (p1:{})-[e:knows]->(p2:{}) WHERE p1.ID = {} AND p2.ID = {} delete e;", srcTable,
+            dstTable, srcID, dstID);
     }
     std::string getInsertKnowsRelQuery(
         std::string srcTable, std::string dstTable, int64_t srcID, int64_t dstID) {
-        return StringUtils::string_format("MATCH (p1:%s), (p2:%s) WHERE p1.ID = %d AND p2.ID "
-                                          "= %d create (p1)-[:knows {length: %d}]->(p2);",
-            srcTable.c_str(), dstTable.c_str(), srcID, dstID, dstID);
+        return StringUtils::string_format("MATCH (p1:{}), (p2:{}) WHERE p1.ID = {} AND p2.ID "
+                                          "= {} create (p1)-[:knows {{length: {}}}]->(p2);",
+            srcTable, dstTable, srcID, dstID, dstID);
     }
 
     std::string getDeleteTeachesRelQuery(int64_t srcID, int64_t dstID) {
         return StringUtils::string_format(
-            "MATCH (p1:person)-[t:teaches]->(p2:person) WHERE p1.ID = %d AND p2.ID = %d delete t;",
+            "MATCH (p1:person)-[t:teaches]->(p2:person) WHERE p1.ID = {} AND p2.ID = {} delete t;",
             srcID, dstID);
     }
 
     std::string getDeleteHasOwnerRelQuery(int64_t srcID, int64_t dstID) {
         return StringUtils::string_format(
-            "MATCH (a:animal)-[h:hasOwner]->(p:person) WHERE a.ID = %d AND p.ID = %d delete h;",
+            "MATCH (a:animal)-[h:hasOwner]->(p:person) WHERE a.ID = {} AND p.ID = {} delete h;",
             srcID, dstID);
     }
 

--- a/test/runner/e2e_update_rel_test.cpp
+++ b/test/runner/e2e_update_rel_test.cpp
@@ -10,21 +10,23 @@ public:
     }
     std::string getUpdateRelQuery(std::string srcTable, std::string dstTable, std::string relation,
         int64_t srcID, int64_t dstID, std::string setPropertyClause) {
-        return StringUtils::string_format(
-            "MATCH (p1:%s)-[e:%s]->(p2:%s) WHERE p1.ID = %d AND p2.ID = %d " + setPropertyClause,
-            srcTable.c_str(), relation.c_str(), dstTable.c_str(), srcID, dstID);
+        return kuzu::common::StringUtils::string_format(
+                   "MATCH (p1:{})-[e:{}]->(p2:{}) WHERE p1.ID = {} AND p2.ID = {} ", srcTable,
+                   relation, dstTable, srcID, dstID) +
+               setPropertyClause;
     }
     std::string getInsertKnowsRelQuery(std::string srcTable, std::string dstTable, int64_t srcID,
         int64_t dstID, int64_t lengthProp) {
-        return StringUtils::string_format("MATCH (p1:%s), (p2:%s) WHERE p1.ID = %d AND p2.ID "
-                                          "= %d create (p1)-[:knows {length: %d}]->(p2);",
-            srcTable.c_str(), dstTable.c_str(), srcID, dstID, lengthProp);
+        return kuzu::common::StringUtils::string_format(
+            "MATCH (p1:{}), (p2:{}) WHERE p1.ID = {} AND p2.ID = {} create "
+            "(p1)-[:knows {{length: {}}}]->(p2);",
+            srcTable, dstTable, srcID, dstID, lengthProp);
     }
     std::string getDeleteKnowsRelQuery(
         std::string srcTable, std::string dstTable, int64_t srcID, int64_t dstID) {
-        return StringUtils::string_format(
-            "MATCH (p1:%s)-[e:knows]->(p2:%s) WHERE p1.ID = %d AND p2.ID = %d DELETE e",
-            srcTable.c_str(), dstTable.c_str(), srcID, dstID);
+        return kuzu::common::StringUtils::string_format(
+            "MATCH (p1:{})-[e:knows]->(p2:{}) WHERE p1.ID = {} AND p2.ID = {} DELETE e", srcTable,
+            dstTable, srcID, dstID);
     }
 
     void updateIntProp(bool isCommit, TransactionTestType transactionTestType) {

--- a/test/test_helper/test_helper.cpp
+++ b/test/test_helper/test_helper.cpp
@@ -111,8 +111,7 @@ bool TestHelper::testQuery(TestQueryConfig* config, Connection& conn) {
     }
     auto numPassedPlans = 0u;
     for (auto i = 0u; i < numPlans; ++i) {
-        auto plan = preparedStatement->logicalPlans[i].get();
-        auto planStr = plan->toString();
+        auto planStr = preparedStatement->logicalPlans[i]->toString();
         auto result = conn.executeAndAutoCommitIfNecessaryNoLock(preparedStatement.get(), i);
         assert(result->isSuccess());
         std::vector<std::string> resultTuples =


### PR DESCRIPTION
This PR solves format string vulnerability #1306 by replacing the `snprintf` with `format`.
