### PR TITLE
Fix benchmark query

### DIFF
--- a/benchmark/queries/ldbc-sf100/aggregation/q28.benchmark
+++ b/benchmark/queries/ldbc-sf100/aggregation/q28.benchmark
@@ -1,9 +1,9 @@
 -NAME q28
 -COMPARE_RESULT 1
--QUERY MATCH(comment:Comment) RETURN comment.ID, count(comment.length) limit 5
+-QUERY MATCH(comment:Comment) WHERE comment.ID < 33980465466560 RETURN comment.ID as ID, count(comment.length) order by ID LIMIT 5;
 ---- 5
-39582418599937|1
-39582418599938|1
-65970697666565|1
-65970697666566|1
-65970697666567|1
+4196|1
+4197|1
+4198|1
+4199|1
+4200|1


### PR DESCRIPTION
Added `order by` clause to benchmark query to ensure we get same result in multi-threading environment.