### PR TITLE
Refactor FT interface

### DIFF
--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -232,7 +232,7 @@ private:
     bool hasStrCol = false;
     // Temporary arrays to hold intermediate results.
     std::shared_ptr<common::DataChunkState> hashState;
-    std::shared_ptr<common::ValueVector> hashVector;
+    std::unique_ptr<common::ValueVector> hashVector;
     std::unique_ptr<HashSlot*[]> hashSlotsToUpdateAggState;
     std::unique_ptr<uint64_t[]> tmpValueIdxes;
     std::unique_ptr<uint64_t[]> entryIdxesToInitialize;

--- a/src/include/processor/operator/aggregate/hash_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate_scan.h
@@ -42,7 +42,7 @@ public:
 private:
     std::vector<DataPos> groupByKeyVectorsPos;
     std::vector<common::DataType> groupByKeyVectorDataTypes;
-    std::vector<std::shared_ptr<common::ValueVector>> groupByKeyVectors;
+    std::vector<common::ValueVector*> groupByKeyVectors;
     std::shared_ptr<HashAggregateSharedState> sharedState;
     std::vector<uint32_t> groupByKeyVectorsColIdxes;
 };

--- a/src/include/processor/operator/cross_product.h
+++ b/src/include/processor/operator/cross_product.h
@@ -38,7 +38,7 @@ private:
     std::vector<uint32_t> colIndicesToScan;
 
     uint64_t startIdx = 0u;
-    std::vector<std::shared_ptr<common::ValueVector>> vectorsToScan;
+    std::vector<common::ValueVector*> vectorsToScan;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/hash_join/hash_join_build.h
+++ b/src/include/processor/operator/hash_join/hash_join_build.h
@@ -94,7 +94,7 @@ protected:
 protected:
     std::shared_ptr<HashJoinSharedState> sharedState;
     BuildDataInfo buildDataInfo;
-    std::vector<std::shared_ptr<common::ValueVector>> vectorsToAppend;
+    std::vector<common::ValueVector*> vectorsToAppend;
     std::unique_ptr<JoinHashTable> hashTable;
 };
 

--- a/src/include/processor/operator/hash_join/hash_join_probe.h
+++ b/src/include/processor/operator/hash_join/hash_join_probe.h
@@ -89,9 +89,9 @@ private:
     common::JoinType joinType;
 
     ProbeDataInfo probeDataInfo;
-    std::vector<std::shared_ptr<common::ValueVector>> vectorsToReadInto;
+    std::vector<common::ValueVector*> vectorsToReadInto;
     std::vector<uint32_t> columnIdxsToReadFrom;
-    std::vector<std::shared_ptr<common::ValueVector>> keyVectors;
+    std::vector<common::ValueVector*> keyVectors;
     std::shared_ptr<common::ValueVector> markVector;
     std::unique_ptr<ProbeState> probeState;
 };

--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -15,13 +15,12 @@ public:
 
     virtual ~JoinHashTable() = default;
 
-    virtual void append(const std::vector<std::shared_ptr<common::ValueVector>>& vectorsToAppend);
+    virtual void append(const std::vector<common::ValueVector*>& vectorsToAppend);
     void allocateHashSlots(uint64_t numTuples);
     void buildHashSlots();
-    void probe(const std::vector<std::shared_ptr<common::ValueVector>>& keyVectors,
-        uint8_t** probedTuples);
+    void probe(const std::vector<common::ValueVector*>& keyVectors, uint8_t** probedTuples);
 
-    inline void lookup(std::vector<std::shared_ptr<common::ValueVector>>& vectors,
+    inline void lookup(std::vector<common::ValueVector*>& vectors,
         std::vector<uint32_t>& colIdxesToScan, uint8_t** tuplesToRead, uint64_t startPos,
         uint64_t numTuplesToRead) {
         factorizedTable->lookup(vectors, colIdxesToScan, tuplesToRead, startPos, numTuplesToRead);
@@ -48,7 +47,7 @@ protected:
 
     // This function returns a boolean flag indicating if there is non-null keys after discarding.
     static bool discardNullFromKeys(
-        const std::vector<std::shared_ptr<common::ValueVector>>& vectors, uint32_t numKeyVectors);
+        const std::vector<common::ValueVector*>& vectors, uint32_t numKeyVectors);
 
 private:
     uint64_t numKeyColumns;

--- a/src/include/processor/operator/intersect/intersect.h
+++ b/src/include/processor/operator/intersect/intersect.h
@@ -54,7 +54,7 @@ private:
     std::vector<IntersectDataInfo> intersectDataInfos;
     // payloadColumnIdxesToScanFrom and payloadVectorsToScanInto are organized by each build child.
     std::vector<std::vector<uint32_t>> payloadColumnIdxesToScanFrom;
-    std::vector<std::vector<std::shared_ptr<common::ValueVector>>> payloadVectorsToScanInto;
+    std::vector<std::vector<common::ValueVector*>> payloadVectorsToScanInto;
     std::shared_ptr<common::ValueVector> outKeyVector;
     std::vector<std::shared_ptr<common::ValueVector>> probeKeyVectors;
     std::vector<std::unique_ptr<common::SelectionVector>> intersectSelVectors;

--- a/src/include/processor/operator/intersect/intersect_hash_table.h
+++ b/src/include/processor/operator/intersect/intersect_hash_table.h
@@ -11,7 +11,7 @@ public:
         storage::MemoryManager& memoryManager, std::unique_ptr<FactorizedTableSchema> tableSchema)
         : JoinHashTable{memoryManager, 1 /* numKeyColumns */, std::move(tableSchema)} {}
 
-    void append(const std::vector<std::shared_ptr<common::ValueVector>>& vectorsToAppend) override;
+    void append(const std::vector<common::ValueVector*>& vectorsToAppend) override;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/order_by/order_by.h
+++ b/src/include/processor/operator/order_by/order_by.h
@@ -131,8 +131,8 @@ private:
     OrderByDataInfo orderByDataInfo;
     std::unique_ptr<OrderByKeyEncoder> orderByKeyEncoder;
     std::unique_ptr<RadixSort> radixSorter;
-    std::vector<std::shared_ptr<common::ValueVector>> keyVectors;
-    std::vector<std::shared_ptr<common::ValueVector>> vectorsToAppend;
+    std::vector<common::ValueVector*> keyVectors;
+    std::vector<common::ValueVector*> vectorsToAppend;
     std::shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState;
     std::shared_ptr<FactorizedTable> localFactorizedTable;
 };

--- a/src/include/processor/operator/order_by/order_by_key_encoder.h
+++ b/src/include/processor/operator/order_by/order_by_key_encoder.h
@@ -45,7 +45,7 @@ using encode_function_t = std::function<void(const uint8_t*, uint8_t*, bool)>;
 class OrderByKeyEncoder {
 
 public:
-    OrderByKeyEncoder(std::vector<std::shared_ptr<common::ValueVector>>& orderByVectors,
+    OrderByKeyEncoder(std::vector<common::ValueVector*>& orderByVectors,
         std::vector<bool>& isAscOrder, storage::MemoryManager* memoryManager, uint8_t ftIdx,
         uint32_t numTuplesPerBlockInFT, uint32_t numBytesPerTuple);
 
@@ -56,6 +56,8 @@ public:
     inline uint32_t getMaxNumTuplesPerBlock() const { return maxNumTuplesPerBlock; }
 
     inline uint32_t getNumTuplesInCurBlock() const { return keyBlocks.back()->numTuples; }
+
+    static uint32_t getNumBytesPerTuple(const std::vector<common::ValueVector*>& keyVectors);
 
     static inline uint32_t getEncodedFTBlockIdx(const uint8_t* tupleInfoPtr) {
         return *(uint32_t*)tupleInfoPtr;
@@ -104,14 +106,13 @@ private:
     void flipBytesIfNecessary(
         uint32_t keyColIdx, uint8_t* tuplePtr, uint32_t numEntriesToEncode, common::DataType& type);
 
-    void encodeFlatVector(
-        std::shared_ptr<common::ValueVector> vector, uint8_t* tuplePtr, uint32_t keyColIdx);
+    void encodeFlatVector(common::ValueVector* vector, uint8_t* tuplePtr, uint32_t keyColIdx);
 
-    void encodeUnflatVector(std::shared_ptr<common::ValueVector> vector, uint8_t* tuplePtr,
-        uint32_t encodedTuples, uint32_t numEntriesToEncode, uint32_t keyColIdx);
+    void encodeUnflatVector(common ::ValueVector* vector, uint8_t* tuplePtr, uint32_t encodedTuples,
+        uint32_t numEntriesToEncode, uint32_t keyColIdx);
 
-    void encodeVector(std::shared_ptr<common::ValueVector> vector, uint8_t* tuplePtr,
-        uint32_t encodedTuples, uint32_t numEntriesToEncode, uint32_t keyColIdx);
+    void encodeVector(common::ValueVector* vector, uint8_t* tuplePtr, uint32_t encodedTuples,
+        uint32_t numEntriesToEncode, uint32_t keyColIdx);
 
     void encodeFTIdx(uint32_t numEntriesToEncode, uint8_t* tupleInfoPtr);
 
@@ -122,7 +123,7 @@ private:
 private:
     storage::MemoryManager* memoryManager;
     std::vector<std::shared_ptr<DataBlock>> keyBlocks;
-    std::vector<std::shared_ptr<common::ValueVector>>& orderByVectors;
+    std::vector<common::ValueVector*>& orderByVectors;
     std::vector<bool> isAscOrder;
     uint32_t numBytesPerTuple;
     uint32_t maxNumTuplesPerBlock;

--- a/src/include/processor/operator/order_by/order_by_scan.h
+++ b/src/include/processor/operator/order_by/order_by_scan.h
@@ -49,7 +49,7 @@ private:
 private:
     std::vector<DataPos> outVectorPos;
     std::shared_ptr<SharedFactorizedTablesAndSortedKeyBlocks> sharedState;
-    std::vector<std::shared_ptr<common::ValueVector>> vectorsToRead;
+    std::vector<common::ValueVector*> vectorsToRead;
     std::unique_ptr<MergedKeyBlockScanState> mergedKeyBlockScanState;
 };
 

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -74,7 +74,7 @@ private:
 private:
     std::vector<std::pair<DataPos, common::DataType>> payloadsPosAndType;
     std::vector<bool> isPayloadFlat;
-    std::vector<std::shared_ptr<common::ValueVector>> vectorsToCollect;
+    std::vector<common::ValueVector*> vectorsToCollect;
     std::shared_ptr<FTableSharedState> sharedState;
     std::unique_ptr<FactorizedTable> localTable;
 };

--- a/src/include/processor/operator/scan/generic_scan_rel_tables.h
+++ b/src/include/processor/operator/scan/generic_scan_rel_tables.h
@@ -16,8 +16,7 @@ public:
     void resetState();
     inline uint32_t getNumTablesInCollection() { return tables.size(); }
 
-    bool scan(const std::shared_ptr<common::ValueVector>& inVector,
-        std::vector<std::shared_ptr<common::ValueVector>>& outputVectors,
+    bool scan(common::ValueVector* inVector, const std::vector<common::ValueVector*>& outputVectors,
         transaction::Transaction* transaction);
 
     std::unique_ptr<RelTableCollection> clone() const;

--- a/src/include/processor/operator/scan/scan_columns.h
+++ b/src/include/processor/operator/scan/scan_columns.h
@@ -18,9 +18,9 @@ protected:
 
 protected:
     DataPos inputNodeIDVectorPos;
-    std::shared_ptr<common::ValueVector> inputNodeIDVector;
+    common::ValueVector* inputNodeIDVector;
     std::vector<DataPos> outPropertyVectorsPos;
-    std::vector<std::shared_ptr<common::ValueVector>> outPropertyVectors;
+    std::vector<common::ValueVector*> outPropertyVectors;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/scan/scan_rel_table.h
+++ b/src/include/processor/operator/scan/scan_rel_table.h
@@ -21,8 +21,8 @@ protected:
     DataPos inNodeIDVectorPos;
     std::vector<DataPos> outputVectorsPos;
     // vectors
-    std::shared_ptr<common::ValueVector> inNodeIDVector;
-    std::vector<std::shared_ptr<common::ValueVector>> outputVectors;
+    common::ValueVector* inNodeIDVector;
+    std::vector<common::ValueVector*> outputVectors;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/table_scan/base_table_scan.h
+++ b/src/include/processor/operator/table_scan/base_table_scan.h
@@ -45,7 +45,7 @@ protected:
     std::vector<DataPos> outVecPositions;
     std::vector<uint32_t> colIndicesToScan;
 
-    std::vector<std::shared_ptr<common::ValueVector>> vectorsToScan;
+    std::vector<common::ValueVector*> vectorsToScan;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/update/create.h
+++ b/src/include/processor/operator/update/create.h
@@ -101,9 +101,9 @@ public:
 
 private:
     struct CreateRelVectors {
-        std::shared_ptr<common::ValueVector> srcNodeIDVector;
-        std::shared_ptr<common::ValueVector> dstNodeIDVector;
-        std::vector<std::shared_ptr<common::ValueVector>> propertyVectors;
+        common::ValueVector* srcNodeIDVector;
+        common::ValueVector* dstNodeIDVector;
+        std::vector<common::ValueVector*> propertyVectors;
     };
 
 private:

--- a/src/include/processor/operator/update/delete.h
+++ b/src/include/processor/operator/update/delete.h
@@ -91,9 +91,9 @@ public:
 private:
     storage::RelsStatistics& relsStatistics;
     std::vector<std::unique_ptr<DeleteRelInfo>> deleteRelInfos;
-    std::vector<std::shared_ptr<common::ValueVector>> srcNodeVectors;
-    std::vector<std::shared_ptr<common::ValueVector>> dstNodeVectors;
-    std::vector<std::shared_ptr<common::ValueVector>> relIDVectors;
+    std::vector<common::ValueVector*> srcNodeVectors;
+    std::vector<common::ValueVector*> dstNodeVectors;
+    std::vector<common::ValueVector*> relIDVectors;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/update/set.h
+++ b/src/include/processor/operator/update/set.h
@@ -41,7 +41,7 @@ public:
 private:
     std::vector<std::unique_ptr<SetNodePropertyInfo>> infos;
 
-    std::vector<std::shared_ptr<common::ValueVector>> nodeIDVectors;
+    std::vector<common::ValueVector*> nodeIDVectors;
 };
 
 struct SetRelPropertyInfo {
@@ -49,12 +49,11 @@ struct SetRelPropertyInfo {
     DataPos srcNodePos;
     DataPos dstNodePos;
     DataPos relIDPos;
-    // TODO(Ziyi): see issue 1122 and do a typedef on our column & list idx.
-    uint64_t propertyId;
+    common::property_id_t propertyId;
     std::unique_ptr<evaluator::BaseExpressionEvaluator> evaluator;
 
     SetRelPropertyInfo(storage::RelTable* table, const DataPos& srcNodePos,
-        const DataPos& dstNodePos, const DataPos& relIDPos, uint64_t propertyId,
+        const DataPos& dstNodePos, const DataPos& relIDPos, common::property_id_t propertyId,
         std::unique_ptr<evaluator::BaseExpressionEvaluator> evaluator)
         : table{table}, srcNodePos{srcNodePos}, dstNodePos{dstNodePos}, relIDPos{relIDPos},
           propertyId{propertyId}, evaluator{std::move(evaluator)} {}
@@ -84,9 +83,9 @@ public:
 private:
     std::vector<std::unique_ptr<SetRelPropertyInfo>> infos;
 
-    std::vector<std::shared_ptr<common::ValueVector>> srcNodeVectors;
-    std::vector<std::shared_ptr<common::ValueVector>> dstNodeVectors;
-    std::vector<std::shared_ptr<common::ValueVector>> relIDVectors;
+    std::vector<common::ValueVector*> srcNodeVectors;
+    std::vector<common::ValueVector*> dstNodeVectors;
+    std::vector<common::ValueVector*> relIDVectors;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/var_length_extend/var_length_column_extend.h
+++ b/src/include/processor/operator/var_length_extend/var_length_column_extend.h
@@ -40,8 +40,7 @@ private:
     // This function resets the dfsLevelInfo at level and adds the dfsLevelInfo to the
     // dfsStack if the parent has adjacent nodes. The function returns true if the
     // parent has adjacent nodes, otherwise returns false.
-    bool addDFSLevelToStackIfParentExtends(
-        std::shared_ptr<common::ValueVector>& parentValueVector, uint8_t level);
+    bool addDFSLevelToStackIfParentExtends(common::ValueVector* parentValueVector, uint8_t level);
 };
 
 } // namespace processor

--- a/src/include/processor/operator/var_length_extend/var_length_extend.h
+++ b/src/include/processor/operator/var_length_extend/var_length_extend.h
@@ -9,11 +9,11 @@ namespace processor {
 
 struct DFSLevelInfo {
     DFSLevelInfo(uint8_t level, ExecutionContext& context)
-        : level{level}, hasBeenOutput{false}, children{std::make_shared<common::ValueVector>(
+        : level{level}, hasBeenOutput{false}, children{std::make_unique<common::ValueVector>(
                                                   common::INTERNAL_ID, context.memoryManager)} {};
     const uint8_t level;
     bool hasBeenOutput;
-    std::shared_ptr<common::ValueVector> children;
+    std::unique_ptr<common::ValueVector> children;
 };
 
 class VarLengthExtend : public PhysicalOperator {
@@ -36,8 +36,8 @@ protected:
     storage::BaseColumnOrList* storage;
     uint8_t lowerBound;
     uint8_t upperBound;
-    std::shared_ptr<common::ValueVector> boundNodeValueVector;
-    std::shared_ptr<common::ValueVector> nbrNodeValueVector;
+    common::ValueVector* boundNodeValueVector;
+    common::ValueVector* nbrNodeValueVector;
     std::stack<std::shared_ptr<DFSLevelInfo>> dfsStack;
     // The VarLenExtend has the invariant that at any point in time, there will be one DSFLevelInfo
     // in the dfsStack for each level. dfsLevelInfos is a pool of DFSLevelInfos that holds

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -179,7 +179,7 @@ public:
     FactorizedTable(
         storage::MemoryManager* memoryManager, std::unique_ptr<FactorizedTableSchema> tableSchema);
 
-    void append(const std::vector<std::shared_ptr<common::ValueVector>>& vectors);
+    void append(const std::vector<common::ValueVector*>& vectors);
 
     //! This function appends an empty tuple to the factorizedTable and returns a pointer to that
     //! tuple.
@@ -187,25 +187,24 @@ public:
 
     // This function scans numTuplesToScan of rows to vectors starting at tupleIdx. Callers are
     // responsible for making sure all the parameters are valid.
-    inline void scan(std::vector<std::shared_ptr<common::ValueVector>>& vectors,
-        ft_tuple_idx_t tupleIdx, uint64_t numTuplesToScan) const {
+    inline void scan(std::vector<common::ValueVector*>& vectors, ft_tuple_idx_t tupleIdx,
+        uint64_t numTuplesToScan) const {
         std::vector<uint32_t> colIdxes(tableSchema->getNumColumns());
         iota(colIdxes.begin(), colIdxes.end(), 0);
         scan(vectors, tupleIdx, numTuplesToScan, colIdxes);
     }
     inline bool isEmpty() const { return getNumTuples() == 0; }
-    void scan(std::vector<std::shared_ptr<common::ValueVector>>& vectors, ft_tuple_idx_t tupleIdx,
+    void scan(std::vector<common::ValueVector*>& vectors, ft_tuple_idx_t tupleIdx,
         uint64_t numTuplesToScan, std::vector<uint32_t>& colIdxToScan) const;
     // TODO(Guodong): Unify these two interfaces along with `readUnflatCol`.
-    void lookup(std::vector<std::shared_ptr<common::ValueVector>>& vectors,
-        std::vector<uint32_t>& colIdxesToScan, uint8_t** tuplesToRead, uint64_t startPos,
-        uint64_t numTuplesToRead) const;
-    void lookup(std::vector<std::shared_ptr<common::ValueVector>>& vectors,
+    void lookup(std::vector<common::ValueVector*>& vectors, std::vector<uint32_t>& colIdxesToScan,
+        uint8_t** tuplesToRead, uint64_t startPos, uint64_t numTuplesToRead) const;
+    void lookup(std::vector<common::ValueVector*>& vectors,
         const common::SelectionVector* selVector, std::vector<uint32_t>& colIdxesToScan,
         uint8_t* tupleToRead) const;
-    void lookup(std::vector<std::shared_ptr<common::ValueVector>>& vectors,
-        std::vector<uint32_t>& colIdxesToScan, std::vector<ft_tuple_idx_t>& tupleIdxesToRead,
-        uint64_t startPos, uint64_t numTuplesToRead) const;
+    void lookup(std::vector<common::ValueVector*>& vectors, std::vector<uint32_t>& colIdxesToScan,
+        std::vector<ft_tuple_idx_t>& tupleIdxesToRead, uint64_t startPos,
+        uint64_t numTuplesToRead) const;
 
     // When we merge two factorizedTables, we need to update the hasNoNullGuarantee based on
     // other factorizedTable.
@@ -253,7 +252,7 @@ public:
     }
 
     void copySingleValueToVector(ft_tuple_idx_t tupleIdx, ft_col_idx_t colIdx,
-        std::shared_ptr<common::ValueVector> valueVector, uint32_t posInVector) const;
+        common::ValueVector* valueVector, uint32_t posInVector) const;
     bool isOverflowColNull(
         const uint8_t* nullBuffer, ft_tuple_idx_t tupleIdx, ft_col_idx_t colIdx) const;
     bool isNonOverflowColNull(const uint8_t* nullBuffer, ft_col_idx_t colIdx) const;
@@ -272,7 +271,7 @@ private:
     void setOverflowColNull(uint8_t* nullBuffer, ft_col_idx_t colIdx, ft_tuple_idx_t tupleIdx);
 
     uint64_t computeNumTuplesToAppend(
-        const std::vector<std::shared_ptr<common::ValueVector>>& vectorsToAppend) const;
+        const std::vector<common::ValueVector*>& vectorsToAppend) const;
 
     inline uint8_t* getCell(
         ft_block_idx_t blockIdx, ft_block_offset_t blockOffset, ft_col_offset_t colOffset) const {

--- a/src/include/storage/storage_structure/lists/lists.h
+++ b/src/include/storage/storage_structure/lists/lists.h
@@ -79,17 +79,14 @@ public:
     virtual inline void rollbackInMemoryIfNecessary() { metadata.rollbackInMemoryIfNecessary(); }
     virtual inline bool mayContainNulls() const { return true; }
     virtual inline void setDeletedRelsIfNecessary(transaction::Transaction* transaction,
-        ListHandle& listHandle, const std::shared_ptr<common::ValueVector>& valueVector) {
+        ListHandle& listHandle, common::ValueVector* valueVector) {
         // DO NOTHING.
     }
-    virtual void readValues(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle);
-    virtual void readFromSmallList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle);
-    virtual void readFromLargeList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle);
-    void readFromList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle);
+    virtual void readValues(transaction::Transaction* transaction, common::ValueVector* valueVector,
+        ListHandle& listHandle);
+    virtual void readFromSmallList(common::ValueVector* valueVector, ListHandle& listHandle);
+    virtual void readFromLargeList(common::ValueVector* valueVector, ListHandle& listHandle);
+    void readFromList(common::ValueVector* valueVector, ListHandle& listHandle);
     uint64_t getNumElementsInPersistentStore(
         transaction::TransactionType transactionType, common::offset_t nodeOffset);
     void initListReadingState(common::offset_t nodeOffset, ListHandle& listHandle,
@@ -163,10 +160,8 @@ public:
               headers, bufferManager, wal, listsUpdatesStore} {};
 
 private:
-    void readFromLargeList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
-    void readFromSmallList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
+    void readFromLargeList(common::ValueVector* valueVector, ListHandle& listHandle) override;
+    void readFromSmallList(common::ValueVector* valueVector, ListHandle& listHandle) override;
 };
 
 class ListPropertyLists : public PropertyListsWithOverflow {
@@ -179,10 +174,8 @@ public:
               wal, listsUpdatesStore} {};
 
 private:
-    void readFromLargeList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
-    void readFromSmallList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
+    void readFromLargeList(common::ValueVector* valueVector, ListHandle& listHandle) override;
+    void readFromSmallList(common::ValueVector* valueVector, ListHandle& listHandle) override;
 };
 
 class AdjLists : public Lists {
@@ -199,8 +192,8 @@ public:
 
     inline bool mayContainNulls() const override { return false; }
 
-    void readValues(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
+    void readValues(transaction::Transaction* transaction, common::ValueVector* valueVector,
+        ListHandle& listHandle) override;
 
     // Currently, used only in copyCSV tests.
     std::unique_ptr<std::vector<common::nodeID_t>> readAdjacencyListOfNode(
@@ -217,14 +210,10 @@ public:
     }
 
 private:
-    void readFromLargeList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
-    void readFromSmallList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
-    void readFromListsUpdatesStore(
-        ListHandle& listHandle, const std::shared_ptr<common::ValueVector>& valueVector);
-    void readFromPersistentStore(
-        ListHandle& listHandle, const std::shared_ptr<common::ValueVector>& valueVector);
+    void readFromLargeList(common::ValueVector* valueVector, ListHandle& listHandle) override;
+    void readFromSmallList(common::ValueVector* valueVector, ListHandle& listHandle) override;
+    void readFromListsUpdatesStore(ListHandle& listHandle, common::ValueVector* valueVector);
+    void readFromPersistentStore(ListHandle& listHandle, common::ValueVector* valueVector);
 
 private:
     common::table_id_t nbrTableID;
@@ -241,18 +230,16 @@ public:
     }
 
     void setDeletedRelsIfNecessary(transaction::Transaction* transaction, ListHandle& listHandle,
-        const std::shared_ptr<common::ValueVector>& relIDVector) override;
+        common::ValueVector* relIDVector) override;
 
     std::unordered_set<uint64_t> getDeletedRelOffsetsInListForNodeOffset(
         common::offset_t nodeOffset);
 
     list_offset_t getListOffset(common::offset_t nodeOffset, common::offset_t relOffset);
 
-    void readFromSmallList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
+    void readFromSmallList(common::ValueVector* valueVector, ListHandle& listHandle) override;
 
-    void readFromLargeList(
-        const std::shared_ptr<common::ValueVector>& valueVector, ListHandle& listHandle) override;
+    void readFromLargeList(common::ValueVector* valueVector, ListHandle& listHandle) override;
 
 private:
     inline bool mayContainNulls() const override { return false; }

--- a/src/include/storage/storage_structure/lists/lists_update_store.h
+++ b/src/include/storage/storage_structure/lists/lists_update_store.h
@@ -46,16 +46,15 @@ public:
 
 struct ListsUpdateInfo {
 public:
-    ListsUpdateInfo(const std::shared_ptr<common::ValueVector>& propertyVector,
-        common::property_id_t propertyID, common::offset_t relOffset, uint64_t fwdListOffset,
-        uint64_t bwdListOffset)
+    ListsUpdateInfo(common::ValueVector* propertyVector, common::property_id_t propertyID,
+        common::offset_t relOffset, uint64_t fwdListOffset, uint64_t bwdListOffset)
         : propertyVector{propertyVector}, propertyID{propertyID}, relOffset{relOffset},
           fwdListOffset{fwdListOffset}, bwdListOffset{bwdListOffset} {}
 
     bool isStoredInPersistentStore() const { return fwdListOffset != -1 || bwdListOffset != -1; }
 
 public:
-    std::shared_ptr<common::ValueVector> propertyVector;
+    common::ValueVector* propertyVector;
     common::property_id_t propertyID;
     common::offset_t relOffset;
     list_offset_t fwdListOffset;
@@ -101,19 +100,18 @@ public:
 
     // If this is a one-to-one relTable, all properties are stored in columns.
     // In this case, the listsUpdatesStore should not store the insert rels in FT.
-    void insertRelIfNecessary(const std::shared_ptr<common::ValueVector>& srcNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& dstNodeIDVector,
-        const std::vector<std::shared_ptr<common::ValueVector>>& relPropertyVectors);
+    void insertRelIfNecessary(const common::ValueVector* srcNodeIDVector,
+        const common::ValueVector* dstNodeIDVector,
+        const std::vector<common::ValueVector*>& relPropertyVectors);
 
-    void deleteRelIfNecessary(const std::shared_ptr<common::ValueVector>& srcNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& dstNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& relIDVector);
+    void deleteRelIfNecessary(common::ValueVector* srcNodeIDVector,
+        common::ValueVector* dstNodeIDVector, common::ValueVector* relIDVector);
 
     uint64_t getNumInsertedRelsForNodeOffset(
         ListFileID& listFileID, common::offset_t nodeOffset) const;
 
-    void readValues(ListFileID& listFileID, ListHandle& listSyncState,
-        std::shared_ptr<common::ValueVector> valueVector) const;
+    void readValues(
+        ListFileID& listFileID, ListHandle& listSyncState, common::ValueVector* valueVector) const;
 
     bool hasAnyDeletedRelsInPersistentStore(
         ListFileID& listFileID, common::offset_t nodeOffset) const;
@@ -121,12 +119,11 @@ public:
     // This function is called ifNecessary because it only handles the updates to a propertyList.
     // If the property is stored as a column in both direction(e.g. we are updating a ONE-ONE rel
     // table), this function won't do any operations in this case.
-    void updateRelIfNecessary(const std::shared_ptr<common::ValueVector>& srcNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& dstNodeIDVector,
-        const ListsUpdateInfo& listsUpdateInfo);
+    void updateRelIfNecessary(common::ValueVector* srcNodeIDVector,
+        common::ValueVector* dstNodeIDVector, const ListsUpdateInfo& listsUpdateInfo);
 
     void readUpdatesToPropertyVectorIfExists(ListFileID& listFileID, common::offset_t nodeOffset,
-        const std::shared_ptr<common::ValueVector>& valueVector, list_offset_t startListOffset);
+        common::ValueVector* propertyVector, list_offset_t startListOffset);
 
     void readPropertyUpdateToInMemList(ListFileID& listFileID, processor::ft_tuple_idx_t ftTupleIdx,
         InMemList& inMemList, uint64_t posToWriteToInMemList, const common::DataType& dataType,

--- a/src/include/storage/storage_structure/storage_structure.h
+++ b/src/include/storage/storage_structure/storage_structure.h
@@ -77,43 +77,41 @@ protected:
         common::DataType dataType, const size_t& elementSize, BufferManager& bufferManager,
         bool hasNULLBytes, WAL* wal);
 
-    void readBySequentialCopy(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& vector, PageElementCursor& cursor,
+    void readBySequentialCopy(transaction::Transaction* transaction, common::ValueVector* vector,
+        PageElementCursor& cursor,
         const std::function<common::page_idx_t(common::page_idx_t)>& logicalToPhysicalPageMapper);
 
     void readInternalIDsBySequentialCopy(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& vector, PageElementCursor& cursor,
+        common::ValueVector* vector, PageElementCursor& cursor,
         const std::function<common::page_idx_t(common::page_idx_t)>& logicalToPhysicalPageMapper,
         common::table_id_t commonTableID, bool hasNoNullGuarantee);
 
     void readInternalIDsFromAPageBySequentialCopy(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& vector, uint64_t vectorStartPos,
-        common::page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
-        uint64_t numValuesToRead, common::table_id_t commonTableID, bool hasNoNullGuarantee);
+        common::ValueVector* vector, uint64_t vectorStartPos, common::page_idx_t physicalPageIdx,
+        uint16_t pagePosOfFirstElement, uint64_t numValuesToRead, common::table_id_t commonTableID,
+        bool hasNoNullGuarantee);
 
     void readInternalIDsBySequentialCopyWithSelState(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& vector, PageElementCursor& cursor,
+        common::ValueVector* vector, PageElementCursor& cursor,
         const std::function<common::page_idx_t(common::page_idx_t)>& logicalToPhysicalPageMapper,
         common::table_id_t commonTableID);
 
     void readBySequentialCopyWithSelState(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& vector, PageElementCursor& cursor,
+        common::ValueVector* vector, PageElementCursor& cursor,
         const std::function<common::page_idx_t(common::page_idx_t)>& logicalToPhysicalPageMapper);
 
-    void readSingleNullBit(const std::shared_ptr<common::ValueVector>& valueVector,
-        const uint8_t* frame, uint64_t elementPos, uint64_t offsetInVector) const;
+    void readSingleNullBit(common::ValueVector* valueVector, const uint8_t* frame,
+        uint64_t elementPos, uint64_t offsetInVector) const;
 
     void setNullBitOfAPosInFrame(const uint8_t* frame, uint16_t elementPos, bool isNull) const;
 
 private:
     void readAPageBySequentialCopy(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& vector, uint64_t vectorStartPos,
-        common::page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
-        uint64_t numValuesToRead);
+        common::ValueVector* vector, uint64_t vectorStartPos, common::page_idx_t physicalPageIdx,
+        uint16_t pagePosOfFirstElement, uint64_t numValuesToRead);
 
-    void readNullBitsFromAPage(const std::shared_ptr<common::ValueVector>& valueVector,
-        const uint8_t* frame, uint64_t posInPage, uint64_t posInVector,
-        uint64_t numBitsToRead) const;
+    void readNullBitsFromAPage(common::ValueVector* valueVector, const uint8_t* frame,
+        uint64_t posInPage, uint64_t posInVector, uint64_t numBitsToRead) const;
 
 public:
     common::DataType dataType;

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -26,10 +26,8 @@ public:
         nodesStatisticsAndDeletedIDs->setDeletedNodeOffsetsForMorsel(trx, vector, tableID);
     }
 
-    void scan(transaction::Transaction* transaction,
-        const std::shared_ptr<common::ValueVector>& inputIDVector,
-        const std::vector<uint32_t>& columnIdxes,
-        std::vector<std::shared_ptr<common::ValueVector>> outputVectors);
+    void scan(transaction::Transaction* transaction, common::ValueVector* inputIDVector,
+        const std::vector<uint32_t>& columnIdxes, std::vector<common::ValueVector*> outputVectors);
 
     inline Column* getPropertyColumn(common::property_id_t propertyIdx) {
         assert(propertyColumns.contains(propertyIdx));

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -96,8 +96,8 @@ public:
     Lists* getPropertyLists(common::property_id_t propertyID);
 
     inline void scan(transaction::Transaction* transaction, RelTableScanState& scanState,
-        const std::shared_ptr<common::ValueVector>& inNodeIDVector,
-        std::vector<std::shared_ptr<common::ValueVector>>& outputVectors) {
+        common::ValueVector* inNodeIDVector,
+        const std::vector<common::ValueVector*>& outputVectors) {
         if (scanState.relTableDataType == RelTableDataType::COLUMNS) {
             scanColumns(transaction, scanState, inNodeIDVector, outputVectors);
         } else {
@@ -106,13 +106,11 @@ public:
     }
     inline bool isBoundTable(common::table_id_t tableID) const { return tableID == boundTableID; }
 
-    void insertRel(const std::shared_ptr<common::ValueVector>& boundVector,
-        const std::shared_ptr<common::ValueVector>& nbrVector,
-        const std::vector<std::shared_ptr<common::ValueVector>>& relPropertyVectors);
-    void deleteRel(const std::shared_ptr<common::ValueVector>& boundVector);
-    void updateRel(const std::shared_ptr<common::ValueVector>& boundVector,
-        common::property_id_t propertyID,
-        const std::shared_ptr<common::ValueVector>& propertyVector);
+    void insertRel(common::ValueVector* boundVector, common::ValueVector* nbrVector,
+        const std::vector<common::ValueVector*>& relPropertyVectors);
+    void deleteRel(common::ValueVector* boundVector);
+    void updateRel(common::ValueVector* boundVector, common::property_id_t propertyID,
+        common::ValueVector* propertyVector);
     void performOpOnListsWithUpdates(const std::function<void(Lists*)>& opOnListsWithUpdates);
     std::unique_ptr<ListsUpdateIteratorsForDirection> getListsUpdateIteratorsForDirection();
     void removeProperty(common::property_id_t propertyID);
@@ -122,11 +120,11 @@ public:
 
 private:
     void scanColumns(transaction::Transaction* transaction, RelTableScanState& scanState,
-        const std::shared_ptr<common::ValueVector>& inNodeIDVector,
-        std::vector<std::shared_ptr<common::ValueVector>>& outputVectors);
+        common::ValueVector* inNodeIDVector,
+        const std::vector<common::ValueVector*>& outputVectors);
     void scanLists(transaction::Transaction* transaction, RelTableScanState& scanState,
-        const std::shared_ptr<common::ValueVector>& inNodeIDVector,
-        std::vector<std::shared_ptr<common::ValueVector>>& outputVectors);
+        common::ValueVector* inNodeIDVector,
+        const std::vector<common::ValueVector*>& outputVectors);
 
 private:
     // TODO(Guodong): remove the distinction between AdjColumn and Column, also AdjLists and Lists.
@@ -197,16 +195,12 @@ public:
     void checkpointInMemoryIfNecessary();
     void rollbackInMemoryIfNecessary();
 
-    void insertRel(const std::shared_ptr<common::ValueVector>& srcNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& dstNodeIDVector,
-        const std::vector<std::shared_ptr<common::ValueVector>>& relPropertyVectors);
-    void deleteRel(const std::shared_ptr<common::ValueVector>& srcNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& dstNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& relIDVector);
-    void updateRel(const std::shared_ptr<common::ValueVector>& srcNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& dstNodeIDVector,
-        const std::shared_ptr<common::ValueVector>& relIDVector,
-        const std::shared_ptr<common::ValueVector>& propertyVector, uint32_t propertyID);
+    void insertRel(common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector,
+        const std::vector<common::ValueVector*>& relPropertyVectors);
+    void deleteRel(common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector,
+        common::ValueVector* relIDVector);
+    void updateRel(common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector,
+        common::ValueVector* relIDVector, common::ValueVector* propertyVector, uint32_t propertyID);
     void initEmptyRelsForNewNode(common::nodeID_t& nodeID);
     void batchInitEmptyRelsForNewNodes(
         const catalog::RelTableSchema* relTableSchema, uint64_t numNodesInTable);

--- a/src/processor/operator/aggregate/hash_aggregate_scan.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate_scan.cpp
@@ -9,7 +9,7 @@ void HashAggregateScan::initLocalStateInternal(ResultSet* resultSet, ExecutionCo
     BaseAggregateScan::initLocalStateInternal(resultSet, context);
     for (auto& dataPos : groupByKeyVectorsPos) {
         auto valueVector = resultSet->getValueVector(dataPos);
-        groupByKeyVectors.push_back(valueVector);
+        groupByKeyVectors.push_back(valueVector.get());
     }
     groupByKeyVectorsColIdxes.resize(groupByKeyVectors.size());
     iota(groupByKeyVectorsColIdxes.begin(), groupByKeyVectorsColIdxes.end(), 0);

--- a/src/processor/operator/cross_product.cpp
+++ b/src/processor/operator/cross_product.cpp
@@ -6,7 +6,7 @@ namespace processor {
 void CrossProduct::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto pos : outVecPos) {
         auto vector = resultSet->getValueVector(pos);
-        vectorsToScan.push_back(vector);
+        vectorsToScan.push_back(vector.get());
     }
     startIdx = sharedState->getTable()->getNumTuples();
 }

--- a/src/processor/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/operator/hash_join/hash_join_build.cpp
@@ -22,12 +22,10 @@ void HashJoinSharedState::mergeLocalHashTable(JoinHashTable& localHashTable) {
 
 void HashJoinBuild::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto& [pos, dataType] : buildDataInfo.keysPosAndType) {
-        auto keyVector = resultSet->getValueVector(pos);
-        vectorsToAppend.push_back(keyVector);
+        vectorsToAppend.push_back(resultSet->getValueVector(pos).get());
     }
     for (auto& [pos, dataType] : buildDataInfo.payloadsPosAndType) {
-        auto vector = resultSet->getValueVector(pos);
-        vectorsToAppend.push_back(vector);
+        vectorsToAppend.push_back(resultSet->getValueVector(pos).get());
     }
     auto tableSchema = populateTableSchema();
     initLocalHashTable(*context->memoryManager, std::move(tableSchema));

--- a/src/processor/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/operator/hash_join/hash_join_probe.cpp
@@ -1,7 +1,6 @@
 #include "processor/operator/hash_join/hash_join_probe.h"
 
 #include "function/hash/hash_operations.h"
-#include "function/hash/vector_hash_operations.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function::operation;
@@ -12,15 +11,13 @@ namespace processor {
 void HashJoinProbe::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     probeState = std::make_unique<ProbeState>();
     for (auto& keyDataPos : probeDataInfo.keysDataPos) {
-        auto keyVector = resultSet->getValueVector(keyDataPos);
-        keyVectors.push_back(keyVector);
+        keyVectors.push_back(resultSet->getValueVector(keyDataPos).get());
     }
     if (joinType == JoinType::MARK) {
         markVector = resultSet->getValueVector(probeDataInfo.markDataPos);
     }
     for (auto& dataPos : probeDataInfo.payloadsOutPos) {
-        auto probePayloadVector = resultSet->getValueVector(dataPos);
-        vectorsToReadInto.push_back(probePayloadVector);
+        vectorsToReadInto.push_back(resultSet->getValueVector(dataPos).get());
     }
     // We only need to read nonKeys from the factorizedTable. Key columns are always kept as first k
     // columns in the factorizedTable, so we skip the first k columns.

--- a/src/processor/operator/intersect/intersect.cpp
+++ b/src/processor/operator/intersect/intersect.cpp
@@ -13,7 +13,7 @@ void Intersect::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* c
     for (auto& dataInfo : intersectDataInfos) {
         probeKeyVectors.push_back(resultSet->getValueVector(dataInfo.keyDataPos));
         std::vector<uint32_t> columnIdxesToScanFrom;
-        std::vector<std::shared_ptr<ValueVector>> vectorsToReadInto;
+        std::vector<ValueVector*> vectorsToReadInto;
         for (auto i = 0u; i < dataInfo.payloadsDataPos.size(); i++) {
             auto vector = resultSet->getValueVector(dataInfo.payloadsDataPos[i]);
             // Always skip the first two columns in the fTable: build key and intersect key.
@@ -21,7 +21,7 @@ void Intersect::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* c
             // the second column. Once this is solved, go back and refactor projection push down for
             // intersect.
             columnIdxesToScanFrom.push_back(i + 2);
-            vectorsToReadInto.push_back(vector);
+            vectorsToReadInto.push_back(vector.get());
         }
         payloadColumnIdxesToScanFrom.push_back(columnIdxesToScanFrom);
         payloadVectorsToScanInto.push_back(std::move(vectorsToReadInto));

--- a/src/processor/operator/intersect/intersect_hash_table.cpp
+++ b/src/processor/operator/intersect/intersect_hash_table.cpp
@@ -18,12 +18,12 @@ static void sortSelectedPos(ValueVector* nodeIDVector) {
     });
 }
 
-void IntersectHashTable::append(const std::vector<std::shared_ptr<ValueVector>>& vectorsToAppend) {
+void IntersectHashTable::append(const std::vector<ValueVector*>& vectorsToAppend) {
     auto numTuplesToAppend = 1;
     // Based on the way we are planning, we assume that the first and second vectors are both
     // nodeIDs from extending, while the first one is key, and the second one is payload.
     auto keyState = vectorsToAppend[0]->state.get();
-    auto payloadNodeIDVector = vectorsToAppend[1].get();
+    auto payloadNodeIDVector = vectorsToAppend[1];
     auto payloadsState = payloadNodeIDVector->state.get();
     assert(keyState->isFlat());
     if (!payloadsState->isFlat()) {

--- a/src/processor/operator/order_by/order_by.cpp
+++ b/src/processor/operator/order_by/order_by.cpp
@@ -8,7 +8,7 @@ namespace processor {
 void OrderBy::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto [dataPos, _] : orderByDataInfo.payloadsPosAndType) {
         auto vector = resultSet->getValueVector(dataPos);
-        vectorsToAppend.push_back(vector);
+        vectorsToAppend.push_back(vector.get());
     }
     // TODO(Ziyi): this is implemented differently from other sink operators. Normally we append
     // local table to global at the end of the execution. But here your encoder seem to need encode
@@ -19,8 +19,7 @@ void OrderBy::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* con
     factorizedTableIdx = sharedState->getNextFactorizedTableIdx();
     sharedState->appendFactorizedTable(factorizedTableIdx, localFactorizedTable);
     for (auto [dataPos, _] : orderByDataInfo.keysPosAndType) {
-        auto vector = resultSet->getValueVector(dataPos);
-        keyVectors.emplace_back(vector);
+        keyVectors.push_back(resultSet->getValueVector(dataPos).get());
     }
     orderByKeyEncoder = std::make_unique<OrderByKeyEncoder>(keyVectors, orderByDataInfo.isAscOrder,
         context->memoryManager, factorizedTableIdx, localFactorizedTable->getNumTuplesPerBlock(),

--- a/src/processor/operator/order_by/order_by_scan.cpp
+++ b/src/processor/operator/order_by/order_by_scan.cpp
@@ -8,7 +8,7 @@ namespace processor {
 void OrderByScan::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto dataPos : outVectorPos) {
         auto valueVector = resultSet->getValueVector(dataPos);
-        vectorsToRead.emplace_back(valueVector);
+        vectorsToRead.push_back(valueVector.get());
     }
     initMergedKeyBlockScanState();
 }

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -26,7 +26,7 @@ void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
     for (auto [dataPos, _] : payloadsPosAndType) {
         auto vector =
             resultSet->dataChunks[dataPos.dataChunkPos]->valueVectors[dataPos.valueVectorPos];
-        vectorsToCollect.push_back(vector);
+        vectorsToCollect.push_back(vector.get());
     }
     localTable = std::make_unique<FactorizedTable>(context->memoryManager, populateTableSchema());
 }

--- a/src/processor/operator/scan/generic_scan_rel_tables.cpp
+++ b/src/processor/operator/scan/generic_scan_rel_tables.cpp
@@ -12,8 +12,8 @@ void RelTableCollection::resetState() {
     nextRelTableIdxToScan = 0;
 }
 
-bool RelTableCollection::scan(const std::shared_ptr<ValueVector>& inVector,
-    std::vector<std::shared_ptr<ValueVector>>& outputVectors, Transaction* transaction) {
+bool RelTableCollection::scan(ValueVector* inVector, const std::vector<ValueVector*>& outputVectors,
+    Transaction* transaction) {
     do {
         if (tableScanStates[currentRelTableIdxToScan]->hasMoreAndSwitchSourceIfNecessary()) {
             assert(tableScanStates[currentRelTableIdxToScan]->relTableDataType ==

--- a/src/processor/operator/scan/scan_columns.cpp
+++ b/src/processor/operator/scan/scan_columns.cpp
@@ -4,10 +4,10 @@ namespace kuzu {
 namespace processor {
 
 void ScanColumns::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    inputNodeIDVector = resultSet->getValueVector(inputNodeIDVectorPos);
+    inputNodeIDVector = resultSet->getValueVector(inputNodeIDVectorPos).get();
     for (auto& dataPos : outPropertyVectorsPos) {
         auto vector = resultSet->getValueVector(dataPos);
-        outPropertyVectors.push_back(vector);
+        outPropertyVectors.push_back(vector.get());
     }
 }
 

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -4,10 +4,10 @@ namespace kuzu {
 namespace processor {
 
 void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    inNodeIDVector = resultSet->getValueVector(inNodeIDVectorPos);
+    inNodeIDVector = resultSet->getValueVector(inNodeIDVectorPos).get();
     for (auto& dataPos : outputVectorsPos) {
         auto vector = resultSet->getValueVector(dataPos);
-        outputVectors.push_back(vector);
+        outputVectors.push_back(vector.get());
     }
 }
 

--- a/src/processor/operator/table_scan/base_table_scan.cpp
+++ b/src/processor/operator/table_scan/base_table_scan.cpp
@@ -6,7 +6,7 @@ namespace processor {
 void BaseTableScan::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto& dataPos : outVecPositions) {
         auto valueVector = resultSet->getValueVector(dataPos);
-        vectorsToScan.push_back(valueVector);
+        vectorsToScan.push_back(valueVector.get());
     }
     setMaxMorselSize();
 }

--- a/src/processor/operator/update/create.cpp
+++ b/src/processor/operator/update/create.cpp
@@ -36,11 +36,13 @@ bool CreateNode::getNextTuplesInternal() {
 void CreateRel::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto& createRelInfo : createRelInfos) {
         auto createRelVectors = std::make_unique<CreateRelVectors>();
-        createRelVectors->srcNodeIDVector = resultSet->getValueVector(createRelInfo->srcNodePos);
-        createRelVectors->dstNodeIDVector = resultSet->getValueVector(createRelInfo->dstNodePos);
+        createRelVectors->srcNodeIDVector =
+            resultSet->getValueVector(createRelInfo->srcNodePos).get();
+        createRelVectors->dstNodeIDVector =
+            resultSet->getValueVector(createRelInfo->dstNodePos).get();
         for (auto& evaluator : createRelInfo->evaluators) {
             evaluator->init(*resultSet, context->memoryManager);
-            createRelVectors->propertyVectors.push_back(evaluator->resultVector);
+            createRelVectors->propertyVectors.push_back(evaluator->resultVector.get());
         }
         createRelVectorsPerRel.push_back(std::move(createRelVectors));
     }

--- a/src/processor/operator/update/delete.cpp
+++ b/src/processor/operator/update/delete.cpp
@@ -26,11 +26,11 @@ bool DeleteNode::getNextTuplesInternal() {
 void DeleteRel::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto& deleteRelInfo : deleteRelInfos) {
         auto srcNodeIDVector = resultSet->getValueVector(deleteRelInfo->srcNodePos);
-        srcNodeVectors.push_back(srcNodeIDVector);
+        srcNodeVectors.push_back(srcNodeIDVector.get());
         auto dstNodeIDVector = resultSet->getValueVector(deleteRelInfo->dstNodePos);
-        dstNodeVectors.push_back(dstNodeIDVector);
+        dstNodeVectors.push_back(dstNodeIDVector.get());
         auto relIDVector = resultSet->getValueVector(deleteRelInfo->relIDPos);
-        relIDVectors.push_back(relIDVector);
+        relIDVectors.push_back(relIDVector.get());
     }
 }
 

--- a/src/processor/operator/update/set.cpp
+++ b/src/processor/operator/update/set.cpp
@@ -6,7 +6,7 @@ namespace processor {
 void SetNodeProperty::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto& info : infos) {
         auto nodeIDVector = resultSet->getValueVector(info->nodeIDPos);
-        nodeIDVectors.push_back(nodeIDVector);
+        nodeIDVectors.push_back(nodeIDVector.get());
         info->evaluator->init(*resultSet, context->memoryManager);
     }
 }
@@ -18,7 +18,7 @@ bool SetNodeProperty::getNextTuplesInternal() {
     for (auto i = 0u; i < infos.size(); ++i) {
         auto info = infos[i].get();
         info->evaluator->evaluate();
-        info->column->writeValues(nodeIDVectors[i], info->evaluator->resultVector);
+        info->column->writeValues(nodeIDVectors[i], info->evaluator->resultVector.get());
     }
     return true;
 }
@@ -35,11 +35,11 @@ std::unique_ptr<PhysicalOperator> SetNodeProperty::clone() {
 void SetRelProperty::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto& info : infos) {
         auto srcNodeIDVector = resultSet->getValueVector(info->srcNodePos);
-        srcNodeVectors.push_back(srcNodeIDVector);
+        srcNodeVectors.push_back(srcNodeIDVector.get());
         auto dstNodeIDVector = resultSet->getValueVector(info->dstNodePos);
-        dstNodeVectors.push_back(dstNodeIDVector);
+        dstNodeVectors.push_back(dstNodeIDVector.get());
         auto relIDVector = resultSet->getValueVector(info->relIDPos);
-        relIDVectors.push_back(relIDVector);
+        relIDVectors.push_back(relIDVector.get());
         info->evaluator->init(*resultSet, context->memoryManager);
     }
 }
@@ -52,7 +52,7 @@ bool SetRelProperty::getNextTuplesInternal() {
         auto info = infos[i].get();
         info->evaluator->evaluate();
         info->table->updateRel(srcNodeVectors[i], dstNodeVectors[i], relIDVectors[i],
-            info->evaluator->resultVector, info->propertyId);
+            info->evaluator->resultVector.get(), info->propertyId);
     }
     return true;
 }

--- a/src/processor/operator/var_length_extend/var_length_adj_list_extend.cpp
+++ b/src/processor/operator/var_length_extend/var_length_adj_list_extend.cpp
@@ -85,7 +85,7 @@ bool VarLengthAdjListExtend::addDFSLevelToStackIfParentExtends(uint64_t parent, 
     ((AdjLists*)storage)
         ->initListReadingState(parent, *dfsLevelInfo->listHandle, transaction->getType());
     ((AdjLists*)storage)
-        ->readValues(transaction, dfsLevelInfo->children, *dfsLevelInfo->listHandle);
+        ->readValues(transaction, dfsLevelInfo->children.get(), *dfsLevelInfo->listHandle);
     if (dfsLevelInfo->children->state->selVector->selectedSize != 0) {
         dfsStack.emplace(std::move(dfsLevelInfo));
         return true;
@@ -96,7 +96,8 @@ bool VarLengthAdjListExtend::addDFSLevelToStackIfParentExtends(uint64_t parent, 
 bool VarLengthAdjListExtend::getNextBatchOfNbrNodes(
     std::shared_ptr<AdjListExtendDFSLevelInfo>& dfsLevel) const {
     if (dfsLevel->listHandle->hasMoreAndSwitchSourceIfNecessary()) {
-        ((AdjLists*)storage)->readValues(transaction, dfsLevel->children, *dfsLevel->listHandle);
+        ((AdjLists*)storage)
+            ->readValues(transaction, dfsLevel->children.get(), *dfsLevel->listHandle);
         return true;
     }
     return false;

--- a/src/processor/operator/var_length_extend/var_length_column_extend.cpp
+++ b/src/processor/operator/var_length_extend/var_length_column_extend.cpp
@@ -50,7 +50,8 @@ bool VarLengthColumnExtend::getNextTuplesInternal() {
                 dfsLevelInfo->hasBeenOutput = true;
                 return true;
             } else if (!dfsLevelInfo->hasBeenExtended && dfsLevelInfo->level != upperBound) {
-                addDFSLevelToStackIfParentExtends(dfsLevelInfo->children, dfsLevelInfo->level + 1);
+                addDFSLevelToStackIfParentExtends(
+                    dfsLevelInfo->children.get(), dfsLevelInfo->level + 1);
                 dfsLevelInfo->hasBeenExtended = true;
             } else {
                 dfsStack.pop();
@@ -67,10 +68,10 @@ bool VarLengthColumnExtend::getNextTuplesInternal() {
 }
 
 bool VarLengthColumnExtend::addDFSLevelToStackIfParentExtends(
-    std::shared_ptr<ValueVector>& parentValueVector, uint8_t level) {
+    common::ValueVector* parentValueVector, uint8_t level) {
     auto dfsLevelInfo = static_pointer_cast<ColumnExtendDFSLevelInfo>(dfsLevelInfos[level - 1]);
     dfsLevelInfo->reset();
-    ((Column*)storage)->read(transaction, parentValueVector, dfsLevelInfo->children);
+    ((Column*)storage)->read(transaction, parentValueVector, dfsLevelInfo->children.get());
     if (!dfsLevelInfo->children->isNull(
             parentValueVector->state->selVector->selectedPositions[0])) {
         dfsStack.emplace(std::move(dfsLevelInfo));

--- a/src/processor/operator/var_length_extend/var_length_extend.cpp
+++ b/src/processor/operator/var_length_extend/var_length_extend.cpp
@@ -4,8 +4,8 @@ namespace kuzu {
 namespace processor {
 
 void VarLengthExtend::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    boundNodeValueVector = resultSet->getValueVector(boundNodeDataPos);
-    nbrNodeValueVector = resultSet->getValueVector(nbrNodeDataPos);
+    boundNodeValueVector = resultSet->getValueVector(boundNodeDataPos).get();
+    nbrNodeValueVector = resultSet->getValueVector(nbrNodeDataPos).get();
 }
 
 } // namespace processor

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -2,7 +2,6 @@
 
 #include "processor/operator/aggregate/base_aggregate.h"
 #include "processor/operator/copy/copy.h"
-#include "processor/operator/ddl/ddl.h"
 #include "processor/operator/result_collector.h"
 #include "processor/operator/sink.h"
 #include "processor/processor_task.h"
@@ -102,7 +101,7 @@ std::shared_ptr<FactorizedTable> QueryProcessor::getFactorizedTableForOutputMsg(
     outputKUStr.set(outputMsg);
     outputMsgVector->setValue(0, outputKUStr);
     outputMsgVector->state->currIdx = 0;
-    factorizedTable->append(std::vector<std::shared_ptr<ValueVector>>{outputMsgVector});
+    factorizedTable->append(std::vector<ValueVector*>{outputMsgVector.get()});
     return factorizedTable;
 }
 

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -9,8 +9,8 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-void Column::read(Transaction* transaction, const std::shared_ptr<ValueVector>& nodeIDVector,
-    const std::shared_ptr<ValueVector>& resultVector) {
+void Column::read(Transaction* transaction, common::ValueVector* nodeIDVector,
+    common::ValueVector* resultVector) {
     if (nodeIDVector->state->isFlat()) {
         auto pos = nodeIDVector->state->selVector->selectedPositions[0];
         lookup(transaction, nodeIDVector, resultVector, pos);
@@ -31,8 +31,8 @@ void Column::read(Transaction* transaction, const std::shared_ptr<ValueVector>& 
     }
 }
 
-void Column::writeValues(const std::shared_ptr<ValueVector>& nodeIDVector,
-    const std::shared_ptr<ValueVector>& vectorToWriteFrom) {
+void Column::writeValues(
+    common::ValueVector* nodeIDVector, common::ValueVector* vectorToWriteFrom) {
     if (nodeIDVector->state->isFlat() && vectorToWriteFrom->state->isFlat()) {
         auto nodeOffset =
             nodeIDVector->readNodeOffset(nodeIDVector->state->selVector->selectedPositions[0]);
@@ -101,8 +101,8 @@ void Column::setNodeOffsetToNull(offset_t nodeOffset) {
         updatedPageInfoAndWALPageFrame, fileHandle, bufferManager, *wal);
 }
 
-void Column::lookup(Transaction* transaction, const std::shared_ptr<ValueVector>& nodeIDVector,
-    const std::shared_ptr<ValueVector>& resultVector, uint32_t vectorPos) {
+void Column::lookup(Transaction* transaction, common::ValueVector* nodeIDVector,
+    common::ValueVector* resultVector, uint32_t vectorPos) {
     if (nodeIDVector->isNull(vectorPos)) {
         resultVector->setNull(vectorPos, true);
         return;
@@ -112,8 +112,8 @@ void Column::lookup(Transaction* transaction, const std::shared_ptr<ValueVector>
     lookup(transaction, resultVector, vectorPos, pageCursor);
 }
 
-void Column::lookup(Transaction* transaction, const std::shared_ptr<ValueVector>& resultVector,
-    uint32_t vectorPos, PageElementCursor& cursor) {
+void Column::lookup(Transaction* transaction, common::ValueVector* resultVector, uint32_t vectorPos,
+    PageElementCursor& cursor) {
     auto [fileHandleToPin, pageIdxToPin] =
         StorageStructureUtils::getFileHandleAndPhysicalPageIdxToPin(
             fileHandle, cursor.pageIdx, *wal, transaction->getType());
@@ -125,8 +125,8 @@ void Column::lookup(Transaction* transaction, const std::shared_ptr<ValueVector>
     bufferManager.unpin(*fileHandleToPin, pageIdxToPin);
 }
 
-WALPageIdxPosInPageAndFrame Column::beginUpdatingPage(offset_t nodeOffset,
-    const std::shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
+WALPageIdxPosInPageAndFrame Column::beginUpdatingPage(
+    offset_t nodeOffset, common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
     auto isNull = vectorToWriteFrom->isNull(posInVectorToWriteFrom);
     auto walPageInfo = beginUpdatingPageAndWriteOnlyNullBit(nodeOffset, isNull);
     if (!isNull) {
@@ -142,16 +142,16 @@ WALPageIdxPosInPageAndFrame Column::beginUpdatingPageAndWriteOnlyNullBit(
     return walPageInfo;
 }
 
-void Column::writeValueForSingleNodeIDPosition(offset_t nodeOffset,
-    const std::shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
+void Column::writeValueForSingleNodeIDPosition(
+    offset_t nodeOffset, common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
     auto updatedPageInfoAndWALPageFrame =
         beginUpdatingPage(nodeOffset, vectorToWriteFrom, posInVectorToWriteFrom);
     StorageStructureUtils::unpinWALPageAndReleaseOriginalPageLock(
         updatedPageInfoAndWALPageFrame, fileHandle, bufferManager, *wal);
 }
 
-void StringPropertyColumn::writeValueForSingleNodeIDPosition(offset_t nodeOffset,
-    const std::shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
+void StringPropertyColumn::writeValueForSingleNodeIDPosition(
+    offset_t nodeOffset, common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
     auto updatedPageInfoAndWALPageFrame =
         beginUpdatingPage(nodeOffset, vectorToWriteFrom, posInVectorToWriteFrom);
     if (!vectorToWriteFrom->isNull(posInVectorToWriteFrom)) {
@@ -179,8 +179,8 @@ Value StringPropertyColumn::readValue(offset_t offset) {
     return Value(diskOverflowFile.readString(TransactionType::READ_ONLY, kuString));
 }
 
-void ListPropertyColumn::writeValueForSingleNodeIDPosition(offset_t nodeOffset,
-    const std::shared_ptr<ValueVector>& vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
+void ListPropertyColumn::writeValueForSingleNodeIDPosition(
+    offset_t nodeOffset, common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
     assert(vectorToWriteFrom->dataType.typeID == VAR_LIST);
     auto updatedPageInfoAndWALPageFrame =
         beginUpdatingPage(nodeOffset, vectorToWriteFrom, posInVectorToWriteFrom);

--- a/src/storage/storage_structure/lists/lists.cpp
+++ b/src/storage/storage_structure/lists/lists.cpp
@@ -14,8 +14,7 @@ namespace storage {
 // information about the last portion of v7's large list. Similarly, if nodeOffset is v3 and v3
 // has a small list then largeListHandle does not contain anything specific to v3 (it would likely
 // be containing information about the last portion of the last large list that was read).
-void Lists::readValues(Transaction* transaction, const std::shared_ptr<ValueVector>& valueVector,
-    ListHandle& listHandle) {
+void Lists::readValues(Transaction* transaction, ValueVector* valueVector, ListHandle& listHandle) {
     if (listHandle.getListSourceStore() == ListSourceStore::UPDATE_STORE) {
         listsUpdatesStore->readValues(
             storageStructureIDAndFName.storageStructureID.listFileID, listHandle, valueVector);
@@ -34,16 +33,14 @@ void Lists::readValues(Transaction* transaction, const std::shared_ptr<ValueVect
     }
 }
 
-void Lists::readFromSmallList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void Lists::readFromSmallList(common::ValueVector* valueVector, ListHandle& listHandle) {
     auto pageCursor = PageUtils::getPageElementCursorForPos(
         ListHeaders::getSmallListCSROffset(listHandle.getListHeader()), numElementsPerPage);
     readBySequentialCopy(
         Transaction::getDummyReadOnlyTrx().get(), valueVector, pageCursor, listHandle.mapper);
 }
 
-void Lists::readFromLargeList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void Lists::readFromLargeList(common::ValueVector* valueVector, ListHandle& listHandle) {
     // Assumes that the associated adjList has already updated the syncState.
     auto pageCursor =
         PageUtils::getPageElementCursorForPos(listHandle.getStartElemOffset(), numElementsPerPage);
@@ -51,7 +48,7 @@ void Lists::readFromLargeList(
         Transaction::getDummyReadOnlyTrx().get(), valueVector, pageCursor, listHandle.mapper);
 }
 
-void Lists::readFromList(const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void Lists::readFromList(common::ValueVector* valueVector, ListHandle& listHandle) {
     if (ListHeaders::isALargeList(listHandle.getListHeader())) {
         readFromLargeList(valueVector, listHandle);
     } else {
@@ -215,36 +212,32 @@ void Lists::readPropertyUpdatesToInMemListIfExists(InMemList& inMemList,
     }
 }
 
-void StringPropertyLists::readFromLargeList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void StringPropertyLists::readFromLargeList(ValueVector* valueVector, ListHandle& listHandle) {
     valueVector->resetOverflowBuffer();
     Lists::readFromLargeList(valueVector, listHandle);
     diskOverflowFile.readStringsToVector(TransactionType::READ_ONLY, *valueVector);
 }
 
-void StringPropertyLists::readFromSmallList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void StringPropertyLists::readFromSmallList(ValueVector* valueVector, ListHandle& listHandle) {
     valueVector->resetOverflowBuffer();
     Lists::readFromSmallList(valueVector, listHandle);
     diskOverflowFile.readStringsToVector(TransactionType::READ_ONLY, *valueVector);
 }
 
-void ListPropertyLists::readFromLargeList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void ListPropertyLists::readFromLargeList(ValueVector* valueVector, ListHandle& listHandle) {
     valueVector->resetOverflowBuffer();
     Lists::readFromLargeList(valueVector, listHandle);
     diskOverflowFile.readListsToVector(TransactionType::READ_ONLY, *valueVector);
 }
 
-void ListPropertyLists::readFromSmallList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void ListPropertyLists::readFromSmallList(ValueVector* valueVector, ListHandle& listHandle) {
     valueVector->resetOverflowBuffer();
     Lists::readFromSmallList(valueVector, listHandle);
     diskOverflowFile.readListsToVector(TransactionType::READ_ONLY, *valueVector);
 }
 
-void AdjLists::readValues(Transaction* transaction, const std::shared_ptr<ValueVector>& valueVector,
-    ListHandle& listHandle) {
+void AdjLists::readValues(
+    Transaction* transaction, ValueVector* valueVector, ListHandle& listHandle) {
     valueVector->state->selVector->resetSelectorToUnselected();
     if (listHandle.getListSourceStore() == ListSourceStore::UPDATE_STORE) {
         readFromListsUpdatesStore(listHandle, valueVector);
@@ -295,8 +288,7 @@ std::unique_ptr<std::vector<nodeID_t>> AdjLists::readAdjacencyListOfNode(
     return retVal;
 }
 
-void AdjLists::readFromLargeList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void AdjLists::readFromLargeList(ValueVector* valueVector, ListHandle& listHandle) {
     uint32_t nextPartBeginElemOffset =
         listHandle.hasValidRangeToRead() ? listHandle.getEndElemOffset() : 0;
     auto pageCursor =
@@ -320,8 +312,7 @@ void AdjLists::readFromLargeList(
 
 // Note: This function sets the original and selected size of the DataChunk into which it will
 // read a list of nodes and edges.
-void AdjLists::readFromSmallList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void AdjLists::readFromSmallList(ValueVector* valueVector, ListHandle& listHandle) {
     valueVector->state->initOriginalAndSelectedSize(listHandle.getNumValuesInList());
     // We store the updates for adjLists in listsUpdatesStore, however we store the
     // updates for adjColumn in the WAL version of the page. The adjColumn needs to pass a
@@ -341,8 +332,7 @@ void AdjLists::readFromSmallList(
     listHandle.setRangeToRead(0, listHandle.getNumValuesInList());
 }
 
-void AdjLists::readFromListsUpdatesStore(
-    ListHandle& listHandle, const std::shared_ptr<ValueVector>& valueVector) {
+void AdjLists::readFromListsUpdatesStore(ListHandle& listHandle, ValueVector* valueVector) {
     if (!listHandle.hasValidRangeToRead()) {
         // We have read all values from persistent store or the persistent store is empty, we should
         // reset listSyncState to indicate ranges in listsUpdatesStore and start
@@ -359,8 +349,7 @@ void AdjLists::readFromListsUpdatesStore(
         storageStructureIDAndFName.storageStructureID.listFileID, listHandle, valueVector);
 }
 
-void AdjLists::readFromPersistentStore(
-    ListHandle& listHandle, const std::shared_ptr<ValueVector>& valueVector) {
+void AdjLists::readFromPersistentStore(ListHandle& listHandle, ValueVector* valueVector) {
     // If the startElemOffset is invalid, it means that we never read from the list. As a
     // result, we need to reset the cursor and mapper.
     if (!listHandle.hasValidRangeToRead()) {
@@ -371,8 +360,8 @@ void AdjLists::readFromPersistentStore(
 
 // Note: this function will always be called right after scanRelID, so we have the
 // guarantee that the relIDVector is always unselected.
-void RelIDList::setDeletedRelsIfNecessary(Transaction* transaction, ListHandle& listHandle,
-    const std::shared_ptr<ValueVector>& relIDVector) {
+void RelIDList::setDeletedRelsIfNecessary(
+    Transaction* transaction, ListHandle& listHandle, ValueVector* relIDVector) {
     // We only need to unselect the positions for deleted rels when we are reading from the
     // persistent store in a write transaction and the current nodeOffset has deleted rels in
     // persistent store.
@@ -454,16 +443,14 @@ list_offset_t RelIDList::getListOffset(offset_t nodeOffset, offset_t relOffset) 
     return UINT64_MAX;
 }
 
-void RelIDList::readFromSmallList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void RelIDList::readFromSmallList(ValueVector* valueVector, ListHandle& listHandle) {
     auto pageCursor = PageUtils::getPageElementCursorForPos(
         ListHeaders::getSmallListCSROffset(listHandle.getListHeader()), numElementsPerPage);
     readInternalIDsBySequentialCopy(Transaction::getDummyReadOnlyTrx().get(), valueVector,
         pageCursor, listHandle.mapper, getRelTableID(), true /* hasNoNullGuarantee */);
 }
 
-void RelIDList::readFromLargeList(
-    const std::shared_ptr<ValueVector>& valueVector, ListHandle& listHandle) {
+void RelIDList::readFromLargeList(ValueVector* valueVector, ListHandle& listHandle) {
     // Assumes that the associated adjList has already updated the syncState.
     auto pageCursor =
         PageUtils::getPageElementCursorForPos(listHandle.getStartElemOffset(), numElementsPerPage);

--- a/src/storage/storage_structure/storage_structure.cpp
+++ b/src/storage/storage_structure/storage_structure.cpp
@@ -50,8 +50,8 @@ BaseColumnOrList::BaseColumnOrList(const StorageStructureIDAndFName& storageStru
     numElementsPerPage = PageUtils::getNumElementsInAPage(elementSize, hasNULLBytes);
 }
 
-void BaseColumnOrList::readBySequentialCopy(Transaction* transaction,
-    const std::shared_ptr<ValueVector>& vector, PageElementCursor& cursor,
+void BaseColumnOrList::readBySequentialCopy(Transaction* transaction, common::ValueVector* vector,
+    PageElementCursor& cursor,
     const std::function<page_idx_t(page_idx_t)>& logicalToPhysicalPageMapper) {
     uint64_t numValuesToRead = vector->state->originalSize;
     uint64_t vectorPos = 0;
@@ -67,7 +67,7 @@ void BaseColumnOrList::readBySequentialCopy(Transaction* transaction,
 }
 
 void BaseColumnOrList::readInternalIDsBySequentialCopy(Transaction* transaction,
-    const std::shared_ptr<ValueVector>& vector, PageElementCursor& cursor,
+    ValueVector* vector, PageElementCursor& cursor,
     const std::function<page_idx_t(page_idx_t)>& logicalToPhysicalPageMapper,
     table_id_t commonTableID, bool hasNoNullGuarantee) {
     uint64_t numValuesToRead = vector->state->originalSize;
@@ -84,7 +84,7 @@ void BaseColumnOrList::readInternalIDsBySequentialCopy(Transaction* transaction,
 }
 
 void BaseColumnOrList::readInternalIDsFromAPageBySequentialCopy(Transaction* transaction,
-    const std::shared_ptr<ValueVector>& vector, uint64_t vectorStartPos, page_idx_t physicalPageIdx,
+    ValueVector* vector, uint64_t vectorStartPos, page_idx_t physicalPageIdx,
     uint16_t pagePosOfFirstElement, uint64_t numValuesToRead, table_id_t commonTableID,
     bool hasNoNullGuarantee) {
     auto [fileHandleToPin, pageIdxToPin] =
@@ -108,7 +108,7 @@ void BaseColumnOrList::readInternalIDsFromAPageBySequentialCopy(Transaction* tra
 }
 
 void BaseColumnOrList::readInternalIDsBySequentialCopyWithSelState(Transaction* transaction,
-    const std::shared_ptr<common::ValueVector>& vector, PageElementCursor& cursor,
+    ValueVector* vector, PageElementCursor& cursor,
     const std::function<page_idx_t(page_idx_t)>& logicalToPhysicalPageMapper,
     table_id_t commonTableID) {
     auto selectedState = vector->state;
@@ -137,7 +137,7 @@ void BaseColumnOrList::readInternalIDsBySequentialCopyWithSelState(Transaction* 
 }
 
 void BaseColumnOrList::readBySequentialCopyWithSelState(Transaction* transaction,
-    const std::shared_ptr<ValueVector>& vector, PageElementCursor& cursor,
+    ValueVector* vector, PageElementCursor& cursor,
     const std::function<page_idx_t(page_idx_t)>& logicalToPhysicalPageMapper) {
     auto selectedState = vector->state;
     auto numValuesToRead = vector->state->originalSize;
@@ -163,16 +163,16 @@ void BaseColumnOrList::readBySequentialCopyWithSelState(Transaction* transaction
     }
 }
 
-void BaseColumnOrList::readSingleNullBit(const std::shared_ptr<ValueVector>& valueVector,
-    const uint8_t* frame, uint64_t elementPos, uint64_t offsetInVector) const {
+void BaseColumnOrList::readSingleNullBit(ValueVector* valueVector, const uint8_t* frame,
+    uint64_t elementPos, uint64_t offsetInVector) const {
     auto inputNullEntries = (uint64_t*)getNullBufferInPage(frame);
     bool isNull = NullMask::isNull(inputNullEntries, elementPos);
     valueVector->setNull(offsetInVector, isNull);
 }
 
-void BaseColumnOrList::readAPageBySequentialCopy(Transaction* transaction,
-    const std::shared_ptr<ValueVector>& vector, uint64_t vectorStartPos, page_idx_t physicalPageIdx,
-    uint16_t pagePosOfFirstElement, uint64_t numValuesToRead) {
+void BaseColumnOrList::readAPageBySequentialCopy(Transaction* transaction, ValueVector* vector,
+    uint64_t vectorStartPos, page_idx_t physicalPageIdx, uint16_t pagePosOfFirstElement,
+    uint64_t numValuesToRead) {
     auto [fileHandleToPin, pageIdxToPin] =
         StorageStructureUtils::getFileHandleAndPhysicalPageIdxToPin(
             fileHandle, physicalPageIdx, *wal, transaction->getType());
@@ -185,8 +185,8 @@ void BaseColumnOrList::readAPageBySequentialCopy(Transaction* transaction,
     bufferManager.unpin(*fileHandleToPin, pageIdxToPin);
 }
 
-void BaseColumnOrList::readNullBitsFromAPage(const std::shared_ptr<ValueVector>& valueVector,
-    const uint8_t* frame, uint64_t posInPage, uint64_t posInVector, uint64_t numBitsToRead) const {
+void BaseColumnOrList::readNullBitsFromAPage(ValueVector* valueVector, const uint8_t* frame,
+    uint64_t posInPage, uint64_t posInVector, uint64_t numBitsToRead) const {
     auto hasNullInSrcNullMask = NullMask::copyNullMask((uint64_t*)getNullBufferInPage(frame),
         posInPage, valueVector->getNullMaskData(), posInVector, numBitsToRead);
     if (hasNullInSrcNullMask) {

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -24,9 +24,8 @@ void NodeTable::initializeData(NodeTableSchema* nodeTableSchema) {
         nodeTableSchema->getPrimaryKey().dataType, bufferManager, wal);
 }
 
-void NodeTable::scan(transaction::Transaction* transaction,
-    const std::shared_ptr<ValueVector>& inputIDVector, const std::vector<uint32_t>& columnIds,
-    std::vector<std::shared_ptr<ValueVector>> outputVectors) {
+void NodeTable::scan(transaction::Transaction* transaction, ValueVector* inputIDVector,
+    const std::vector<uint32_t>& columnIds, std::vector<ValueVector*> outputVectors) {
     assert(columnIds.size() == outputVectors.size());
     for (auto i = 0u; i < columnIds.size(); i++) {
         if (columnIds[i] == UINT32_MAX) {

--- a/test/processor/order_by/key_block_merger_test.cpp
+++ b/test/processor/order_by/key_block_merger_test.cpp
@@ -72,10 +72,10 @@ public:
         }
         dataChunk->insert(0, valueVector);
 
-        std::vector<std::shared_ptr<ValueVector>> orderByVectors{
-            valueVector}; // only contains order_by columns
-        std::vector<std::shared_ptr<ValueVector>> allVectors{
-            valueVector}; // all columns including order_by and payload columns
+        std::vector<ValueVector*> orderByVectors{
+            valueVector.get()}; // only contains order_by columns
+        std::vector<ValueVector*> allVectors{
+            valueVector.get()}; // all columns including order_by and payload columns
 
         std::unique_ptr<FactorizedTableSchema> tableSchema =
             std::make_unique<FactorizedTableSchema>();
@@ -90,7 +90,7 @@ public:
             dataChunk->insert(1, payloadValueVector);
             // To test whether the orderByCol -> factorizedTableColIdx works properly, we put the
             // payload column at index 0, and the orderByCol at index 1.
-            allVectors.insert(allVectors.begin(), payloadValueVector);
+            allVectors.insert(allVectors.begin(), payloadValueVector.get());
             tableSchema->appendColumn(std::make_unique<ColumnSchema>(
                 false, 0 /* dataChunkPos */, Types::getDataTypeSize(dataTypeID)));
         }
@@ -159,9 +159,9 @@ public:
     OrderByKeyEncoder prepareMultipleOrderByColsEncoder(uint16_t factorizedTableIdx,
         std::vector<std::shared_ptr<FactorizedTable>>& factorizedTables,
         std::shared_ptr<DataChunk>& dataChunk, std::unique_ptr<FactorizedTableSchema> tableSchema) {
-        std::vector<std::shared_ptr<ValueVector>> orderByVectors;
+        std::vector<ValueVector*> orderByVectors;
         for (auto i = 0u; i < dataChunk->getNumValueVectors(); i++) {
-            orderByVectors.emplace_back(dataChunk->getValueVector(i));
+            orderByVectors.emplace_back(dataChunk->getValueVector(i).get());
         }
 
         std::vector<bool> isAscOrder(orderByVectors.size(), true);
@@ -317,12 +317,12 @@ public:
         }
 
         // The first, second, fourth columns are keyColumns.
-        std::vector<std::shared_ptr<ValueVector>> orderByVectors{dataChunk->getValueVector(0),
-            dataChunk->getValueVector(1), dataChunk->getValueVector(3)};
+        std::vector<ValueVector*> orderByVectors{dataChunk->getValueVector(0).get(),
+            dataChunk->getValueVector(1).get(), dataChunk->getValueVector(3).get()};
 
-        std::vector<std::shared_ptr<ValueVector>> allVectors{dataChunk->getValueVector(0),
-            dataChunk->getValueVector(1), dataChunk->getValueVector(2),
-            dataChunk->getValueVector(3)};
+        std::vector<ValueVector*> allVectors{dataChunk->getValueVector(0).get(),
+            dataChunk->getValueVector(1).get(), dataChunk->getValueVector(2).get(),
+            dataChunk->getValueVector(3).get()};
 
         std::unique_ptr<FactorizedTableSchema> tableSchema =
             std::make_unique<FactorizedTableSchema>();

--- a/test/processor/order_by/radix_sort_test.cpp
+++ b/test/processor/order_by/radix_sort_test.cpp
@@ -82,10 +82,10 @@ public:
             }
         }
         dataChunk->insert(0, valueVector);
-        std::vector<std::shared_ptr<ValueVector>> orderByVectors{
-            valueVector}; // only contains order_by columns
-        std::vector<std::shared_ptr<ValueVector>> allVectors{
-            valueVector}; // all columns including order_by and payload columns
+        std::vector<ValueVector*> orderByVectors{
+            valueVector.get()}; // only contains order_by columns
+        std::vector<ValueVector*> allVectors{
+            valueVector.get()}; // all columns including order_by and payload columns
         std::vector<bool> isAscOrder{isAsc};
 
         std::unique_ptr<FactorizedTableSchema> tableSchema =
@@ -103,7 +103,7 @@ public:
             dataChunk->insert(1, payloadValueVector);
             // To test whether the orderByCol -> ftIdx works properly, we put the
             // payload column at index 0, and the orderByCol at index 1.
-            allVectors.insert(allVectors.begin(), payloadValueVector);
+            allVectors.insert(allVectors.begin(), payloadValueVector.get());
             tableSchema->appendColumn(std::make_unique<ColumnSchema>(
                 false /* isUnflat */, 0 /* dataChunkPos */, Types::getDataTypeSize(dataTypeID)));
             strKeyColsInfo.emplace_back(
@@ -136,7 +136,7 @@ public:
     void multipleOrderByColSolveTieTest(std::vector<bool>& isAscOrder,
         std::vector<uint64_t>& expectedBlockOffsetOrder,
         std::vector<std::vector<std::string>>& stringValues) {
-        std::vector<std::shared_ptr<ValueVector>> orderByVectors;
+        std::vector<ValueVector*> orderByVectors;
         auto mockDataChunk = std::make_shared<DataChunk>(stringValues.size());
         mockDataChunk->state->currIdx = 0;
         std::unique_ptr<FactorizedTableSchema> tableSchema =
@@ -154,7 +154,7 @@ public:
             for (auto j = 0u; j < stringValues[i].size(); j++) {
                 stringValueVector->setValue(j, stringValues[i][j]);
             }
-            orderByVectors.emplace_back(stringValueVector);
+            orderByVectors.emplace_back(stringValueVector.get());
         }
 
         FactorizedTable factorizedTable(memoryManager.get(), std::move(tableSchema));
@@ -352,9 +352,8 @@ TEST_F(RadixSortTest, multipleOrderByColNoTieTest) {
     timestampFlatValueVector->state->currIdx = 0;
     dateFlatValueVector->state->currIdx = 0;
 
-    std::vector<std::shared_ptr<ValueVector>> orderByVectors{intFlatValueVector,
-        doubleFlatValueVector, stringFlatValueVector, timestampFlatValueVector,
-        dateFlatValueVector};
+    std::vector<ValueVector*> orderByVectors{intFlatValueVector.get(), doubleFlatValueVector.get(),
+        stringFlatValueVector.get(), timestampFlatValueVector.get(), dateFlatValueVector.get()};
     intFlatValueVector->setValue(0, (int64_t)41);
     intFlatValueVector->setValue(1, (int64_t)-132);
     intFlatValueVector->setValue(2, (int64_t)41);

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -53,7 +53,7 @@ public:
         dataChunk->insert(1, idVector);
         ((nodeID_t*)nodeIDVector->getData())[0].offset = nodeOffset;
         idVector->setNull(0, true /* is null */);
-        idColumn->writeValues(nodeIDVector, idVector);
+        idColumn->writeValues(nodeIDVector.get(), idVector.get());
         return nodeOffset;
     }
 

--- a/test/transaction/transaction_test.cpp
+++ b/test/transaction/transaction_test.cpp
@@ -64,7 +64,7 @@ public:
         dataChunk->state->currIdx = nodeOffset;
         dataChunk->state->selVector->resetSelectorToValuePosBuffer();
         dataChunk->state->selVector->selectedPositions[0] = nodeOffset;
-        personAgeColumn->read(trx, nodeVector, agePropertyVectorToReadDataInto);
+        personAgeColumn->read(trx, nodeVector.get(), agePropertyVectorToReadDataInto.get());
         if (isNull) {
             ASSERT_TRUE(agePropertyVectorToReadDataInto->isNull(dataChunk->state->currIdx));
         } else {
@@ -79,7 +79,7 @@ public:
         dataChunk->state->currIdx = nodeOffset;
         dataChunk->state->selVector->resetSelectorToValuePosBuffer();
         dataChunk->state->selVector->selectedPositions[0] = nodeOffset;
-        personEyeSightColumn->read(trx, nodeVector, eyeSightVectorToReadDataInto);
+        personEyeSightColumn->read(trx, nodeVector.get(), eyeSightVectorToReadDataInto.get());
         if (isNull) {
             ASSERT_TRUE(eyeSightVectorToReadDataInto->isNull(dataChunk->state->currIdx));
         } else {
@@ -104,7 +104,7 @@ public:
             propertyVectorToWriteDataTo->setValue(
                 dataChunk->state->currIdx, (uint64_t)expectedValue);
         }
-        personAgeColumn->writeValues(nodeVector, propertyVectorToWriteDataTo);
+        personAgeColumn->writeValues(nodeVector.get(), propertyVectorToWriteDataTo.get());
     }
 
     void writeToEyeSightPropertyNode(uint64_t nodeOffset, double expectedValue, bool isNull) {
@@ -122,7 +122,7 @@ public:
             propertyVectorToWriteDataTo->setValue(
                 dataChunk->state->currIdx, (double_t)expectedValue);
         }
-        personEyeSightColumn->writeValues(nodeVector, propertyVectorToWriteDataTo);
+        personEyeSightColumn->writeValues(nodeVector.get(), propertyVectorToWriteDataTo.get());
     }
 
     void assertOriginalAgeAndEyeSightPropertiesForNodes0And1(Transaction* transaction) {


### PR DESCRIPTION
1. This PR refactors the FT interface. Instead of taking `shared_ptr<ValueVector>` as the input parameter type, the new set of APIs now takes in `ValueVector*`.
2. Refactors the use of `shared_ptr<ValueVector>`. Instead of using `shared_ptr<ValueVector>`, we should consider using `unique_ptr<ValueVector>` for ownership and `ValueVector*` when passing around.