### PR TITLE
Flat schema

### DIFF
--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -37,6 +37,9 @@ private:
 
     binder::expression_vector pruneExpressions(const binder::expression_vector& expressions);
 
+    void preAppendProjection(
+        planner::LogicalOperator* op, uint32_t childIdx, binder::expression_vector expressions);
+
 private:
     binder::expression_set propertiesInUse;
 };

--- a/src/include/planner/logical_plan/logical_operator/base_logical_operator.h
+++ b/src/include/planner/logical_plan/logical_operator/base_logical_operator.h
@@ -77,7 +77,8 @@ public:
     inline LogicalOperatorType getOperatorType() const { return operatorType; }
 
     inline Schema* getSchema() const { return schema.get(); }
-    virtual void computeSchema() = 0;
+    virtual void computeFactorizedSchema() = 0;
+    virtual void computeFlatSchema() = 0;
 
     virtual std::string getExpressionsForPrinting() const = 0;
 

--- a/src/include/planner/logical_plan/logical_operator/logical_accumulate.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_accumulate.h
@@ -7,28 +7,21 @@ namespace planner {
 
 class LogicalAccumulate : public LogicalOperator {
 public:
-    LogicalAccumulate(binder::expression_vector expressions, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::ACCUMULATE, std::move(child)}, expressions{std::move(
-                                                                                  expressions)} {}
+    LogicalAccumulate(std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::ACCUMULATE, std::move(child)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override {
-        return binder::ExpressionUtil::toString(expressions);
+    inline std::string getExpressionsForPrinting() const override { return std::string{}; }
+
+    inline binder::expression_vector getExpressions() const {
+        return children[0]->getSchema()->getExpressionsInScope();
     }
-
-    inline void setExpressions(binder::expression_vector expressions_) {
-        expressions = std::move(expressions_);
-    }
-    inline binder::expression_vector getExpressions() const { return expressions; }
-    inline Schema* getSchemaBeforeSink() const { return children[0]->getSchema(); }
 
     inline std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalAccumulate>(expressions, children[0]->copy());
+        return make_unique<LogicalAccumulate>(children[0]->copy());
     }
-
-private:
-    binder::expression_vector expressions;
 };
 
 } // namespace planner

--- a/src/include/planner/logical_plan/logical_operator/logical_aggregate.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_aggregate.h
@@ -13,10 +13,11 @@ public:
           expressionsToGroupBy{std::move(expressionsToGroupBy)}, expressionsToAggregate{std::move(
                                                                      expressionsToAggregate)} {}
 
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
+
     f_group_pos_set getGroupsPosToFlattenForGroupBy();
     f_group_pos_set getGroupsPosToFlattenForAggregate();
-
-    void computeSchema() override;
 
     std::string getExpressionsForPrinting() const override;
 

--- a/src/include/planner/logical_plan/logical_operator/logical_copy.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_copy.h
@@ -15,7 +15,8 @@ public:
         : LogicalOperator{LogicalOperatorType::COPY_CSV},
           copyDescription{copyDescription}, tableID{tableID}, tableName{std::move(tableName)} {}
 
-    inline void computeSchema() override { createEmptySchema(); }
+    inline void computeFactorizedSchema() override { createEmptySchema(); }
+    inline void computeFlatSchema() override { createEmptySchema(); }
 
     inline std::string getExpressionsForPrinting() const override { return tableName; }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_create.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_create.h
@@ -14,7 +14,8 @@ public:
           primaryKeys{std::move(primaryKeys)} {}
     ~LogicalCreateNode() override = default;
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline f_group_pos_set getGroupsPosToFlatten() {
         // Flatten all inputs. E.g. MATCH (a) CREATE (b). We need to create b for each tuple in the
@@ -44,6 +45,9 @@ public:
         : LogicalUpdateRel{LogicalOperatorType::CREATE_REL, std::move(rels), std::move(child)},
           setItemsPerRel{std::move(setItemsPerRel)} {}
     ~LogicalCreateRel() override = default;
+
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
     inline f_group_pos_set getGroupsPosToFlatten() {
         auto childSchema = children[0]->getSchema();

--- a/src/include/planner/logical_plan/logical_operator/logical_cross_product.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_cross_product.h
@@ -13,7 +13,8 @@ public:
         : LogicalOperator{LogicalOperatorType::CROSS_PRODUCT, std::move(probeSideChild),
               std::move(buildSideChild)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override { return std::string(); }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_ddl.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_ddl.h
@@ -12,19 +12,15 @@ public:
         : LogicalOperator{operatorType}, tableName{std::move(tableName)},
           outputExpression{std::move(outputExpression)} {}
 
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
+
     inline std::string getTableName() const { return tableName; }
     inline std::shared_ptr<binder::Expression> getOutputExpression() const {
         return outputExpression;
     }
 
     inline std::string getExpressionsForPrinting() const override { return tableName; }
-
-    inline void computeSchema() override {
-        schema = std::make_unique<Schema>();
-        auto groupPos = schema->createGroup();
-        schema->insertToGroupAndScope(outputExpression, groupPos);
-        schema->setGroupAsSingleState(groupPos);
-    }
 
 protected:
     std::string tableName;

--- a/src/include/planner/logical_plan/logical_operator/logical_delete.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_delete.h
@@ -14,6 +14,9 @@ public:
           primaryKeys{std::move(primaryKeys)} {}
     ~LogicalDeleteNode() override = default;
 
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
+
     inline std::shared_ptr<binder::Expression> getPrimaryKey(size_t idx) const {
         return primaryKeys[idx];
     }
@@ -32,6 +35,9 @@ public:
         std::shared_ptr<LogicalOperator> child)
         : LogicalUpdateRel{LogicalOperatorType::DELETE_REL, std::move(rels), std::move(child)} {}
     ~LogicalDeleteRel() override = default;
+
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
     inline f_group_pos_set getGroupsPosToFlatten(uint32_t relIdx) {
         f_group_pos_set result;

--- a/src/include/planner/logical_plan/logical_operator/logical_distinct.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_distinct.h
@@ -13,9 +13,10 @@ public:
         : LogicalOperator{LogicalOperatorType::DISTINCT, std::move(child)},
           expressionsToDistinct{std::move(expressionsToDistinct)} {}
 
-    f_group_pos_set getGroupsPosToFlatten();
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
-    void computeSchema() override;
+    f_group_pos_set getGroupsPosToFlatten();
 
     std::string getExpressionsForPrinting() const override;
 

--- a/src/include/planner/logical_plan/logical_operator/logical_expressions_scan.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_expressions_scan.h
@@ -14,7 +14,8 @@ public:
         : LogicalOperator{LogicalOperatorType::EXPRESSIONS_SCAN}, expressions{
                                                                       std::move(expressions)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {
         return binder::ExpressionUtil::toString(expressions);

--- a/src/include/planner/logical_plan/logical_operator/logical_extend.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_extend.h
@@ -19,7 +19,8 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {
         return boundNode->toString() + (direction == common::RelDirection::FWD ? "->" : "<-") +

--- a/src/include/planner/logical_plan/logical_operator/logical_filter.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_filter.h
@@ -13,9 +13,10 @@ public:
         : LogicalOperator{LogicalOperatorType::FILTER, std::move(child)}, expression{std::move(
                                                                               expression)} {}
 
-    f_group_pos_set getGroupsPosToFlatten();
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
-    inline void computeSchema() override { copyChildSchema(0); }
+    f_group_pos_set getGroupsPosToFlatten();
 
     inline std::string getExpressionsForPrinting() const override { return expression->toString(); }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_flatten.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_flatten.h
@@ -11,7 +11,8 @@ public:
     LogicalFlatten(f_group_pos groupPos, std::shared_ptr<LogicalOperator> child)
         : LogicalOperator{LogicalOperatorType::FLATTEN, std::move(child)}, groupPos{groupPos} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override { return std::string{}; }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_ftable_scan.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_ftable_scan.h
@@ -13,7 +13,8 @@ public:
           expressionsToScan{std::move(expressionsToScan)}, schemaToScanFrom{
                                                                std::move(schemaToScanFrom)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {
         return binder::ExpressionUtil::toString(expressionsToScan);

--- a/src/include/planner/logical_plan/logical_operator/logical_intersect.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_intersect.h
@@ -7,34 +7,13 @@
 namespace kuzu {
 namespace planner {
 
-struct LogicalIntersectBuildInfo {
-    LogicalIntersectBuildInfo(
-        std::shared_ptr<binder::Expression> keyNodeID, binder::expression_vector expressions)
-        : keyNodeID{std::move(keyNodeID)}, expressionsToMaterialize{std::move(expressions)} {}
-
-    inline void setExpressionsToMaterialize(binder::expression_vector expressions) {
-        expressionsToMaterialize = std::move(expressions);
-    }
-    inline binder::expression_vector getExpressionsToMaterialize() const {
-        return expressionsToMaterialize;
-    }
-
-    inline std::unique_ptr<LogicalIntersectBuildInfo> copy() {
-        return make_unique<LogicalIntersectBuildInfo>(keyNodeID, expressionsToMaterialize);
-    }
-
-    std::shared_ptr<binder::Expression> keyNodeID;
-    binder::expression_vector expressionsToMaterialize;
-};
-
 class LogicalIntersect : public LogicalOperator {
 public:
     LogicalIntersect(std::shared_ptr<binder::Expression> intersectNodeID,
-        std::shared_ptr<LogicalOperator> probeChild,
-        std::vector<std::shared_ptr<LogicalOperator>> buildChildren,
-        std::vector<std::unique_ptr<LogicalIntersectBuildInfo>> buildInfos)
+        binder::expression_vector keyNodeIDs, std::shared_ptr<LogicalOperator> probeChild,
+        std::vector<std::shared_ptr<LogicalOperator>> buildChildren)
         : LogicalOperator{LogicalOperatorType::INTERSECT, std::move(probeChild)},
-          intersectNodeID{std::move(intersectNodeID)}, buildInfos{std::move(buildInfos)} {
+          intersectNodeID{std::move(intersectNodeID)}, keyNodeIDs{std::move(keyNodeIDs)} {
         for (auto& child : buildChildren) {
             children.push_back(std::move(child));
         }
@@ -43,23 +22,25 @@ public:
     f_group_pos_set getGroupsPosToFlattenOnProbeSide();
     f_group_pos_set getGroupsPosToFlattenOnBuildSide(uint32_t buildIdx);
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     std::string getExpressionsForPrinting() const override { return intersectNodeID->toString(); }
 
     inline std::shared_ptr<binder::Expression> getIntersectNodeID() const {
         return intersectNodeID;
     }
-    inline LogicalIntersectBuildInfo* getBuildInfo(uint32_t idx) const {
-        return buildInfos[idx].get();
+
+    inline uint32_t getNumBuilds() const { return keyNodeIDs.size(); }
+    inline std::shared_ptr<binder::Expression> getKeyNodeID(uint32_t idx) const {
+        return keyNodeIDs[idx];
     }
-    inline uint32_t getNumBuilds() const { return buildInfos.size(); }
 
     std::unique_ptr<LogicalOperator> copy() override;
 
 private:
     std::shared_ptr<binder::Expression> intersectNodeID;
-    std::vector<std::unique_ptr<LogicalIntersectBuildInfo>> buildInfos;
+    binder::expression_vector keyNodeIDs;
 };
 
 } // namespace planner

--- a/src/include/planner/logical_plan/logical_operator/logical_limit.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_limit.h
@@ -13,7 +13,8 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    inline void computeSchema() override { copyChildSchema(0); }
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
     inline std::string getExpressionsForPrinting() const override {
         return std::to_string(limitNumber);

--- a/src/include/planner/logical_plan/logical_operator/logical_multiplcity_reducer.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_multiplcity_reducer.h
@@ -10,7 +10,8 @@ public:
     explicit LogicalMultiplicityReducer(std::shared_ptr<LogicalOperator> child)
         : LogicalOperator(LogicalOperatorType::MULTIPLICITY_REDUCER, std::move(child)) {}
 
-    inline void computeSchema() override { copyChildSchema(0); }
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
     inline std::string getExpressionsForPrinting() const override { return std::string(); }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_projection.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_projection.h
@@ -13,7 +13,8 @@ public:
         : LogicalOperator{LogicalOperatorType::PROJECTION, std::move(child)}, expressions{std::move(
                                                                                   expressions)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {
         return binder::ExpressionUtil::toString(expressions);

--- a/src/include/planner/logical_plan/logical_operator/logical_scan_node.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_scan_node.h
@@ -11,7 +11,8 @@ public:
     explicit LogicalScanNode(std::shared_ptr<binder::NodeExpression> node)
         : LogicalOperator{LogicalOperatorType::SCAN_NODE}, node{std::move(node)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override { return node->toString(); }
 
@@ -32,7 +33,8 @@ public:
         : LogicalOperator{LogicalOperatorType::INDEX_SCAN_NODE, std::move(child)},
           node{std::move(node)}, indexExpression{std::move(indexExpression)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override { return node->toString(); }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_scan_node_property.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_scan_node_property.h
@@ -13,7 +13,8 @@ public:
         : LogicalOperator{LogicalOperatorType::SCAN_NODE_PROPERTY, std::move(child)},
           node{std::move(node)}, properties{std::move(properties)} {}
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override {
         return binder::ExpressionUtil::toString(properties);

--- a/src/include/planner/logical_plan/logical_operator/logical_semi_masker.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_semi_masker.h
@@ -13,7 +13,8 @@ public:
         : LogicalOperator{LogicalOperatorType::SEMI_MASKER, std::move(child)}, nodeID{std::move(
                                                                                    nodeID)} {}
 
-    inline void computeSchema() override { copyChildSchema(0); }
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
     inline std::string getExpressionsForPrinting() const override { return nodeID->toString(); }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_set.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_set.h
@@ -14,6 +14,9 @@ public:
               std::move(child)},
           setItems{std::move(setItems)} {}
 
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
+
     inline std::string getExpressionsForPrinting() const override {
         std::string result;
         for (auto& [lhs, rhs] : setItems) {
@@ -39,6 +42,9 @@ public:
         : LogicalUpdateRel{LogicalOperatorType::SET_REL_PROPERTY, std::move(rels),
               std::move(child)},
           setItems{std::move(setItems)} {}
+
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
     f_group_pos_set getGroupsPosToFlatten(uint32_t setItemIdx);
 

--- a/src/include/planner/logical_plan/logical_operator/logical_skip.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_skip.h
@@ -13,7 +13,8 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    inline void computeSchema() override { copyChildSchema(0); }
+    inline void computeFactorizedSchema() override { copyChildSchema(0); }
+    inline void computeFlatSchema() override { copyChildSchema(0); }
 
     inline std::string getExpressionsForPrinting() const override {
         return std::to_string(skipNumber);

--- a/src/include/planner/logical_plan/logical_operator/logical_union.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_union.h
@@ -14,7 +14,8 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten(uint32_t childIdx);
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::string getExpressionsForPrinting() const override { return std::string{}; }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_unwind.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_unwind.h
@@ -15,7 +15,8 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    void computeSchema() override;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     inline std::shared_ptr<binder::Expression> getExpression() { return expression; }
 

--- a/src/include/planner/logical_plan/logical_operator/logical_update.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_update.h
@@ -14,8 +14,6 @@ public:
         : LogicalOperator{operatorType, std::move(child)}, nodes{std::move(nodes)} {}
     ~LogicalUpdateNode() override = default;
 
-    inline void computeSchema() override { copyChildSchema(0); }
-
     inline std::string getExpressionsForPrinting() const override {
         binder::expression_vector expressions;
         for (auto& node : nodes) {
@@ -42,8 +40,6 @@ public:
         std::shared_ptr<LogicalOperator> child)
         : LogicalOperator{operatorType, std::move(child)}, rels{std::move(rels)} {}
     ~LogicalUpdateRel() override = default;
-
-    inline void computeSchema() override { copyChildSchema(0); }
 
     inline std::string getExpressionsForPrinting() const override {
         binder::expression_vector expressions;

--- a/src/optimizer/factorization_rewriter.cpp
+++ b/src/optimizer/factorization_rewriter.cpp
@@ -33,7 +33,7 @@ void FactorizationRewriter::visitOperator(planner::LogicalOperator* op) {
         visitOperator(op->getChild(i).get());
     }
     visitOperatorSwitch(op);
-    op->computeSchema();
+    op->computeFactorizedSchema();
 }
 
 void FactorizationRewriter::visitExtend(planner::LogicalOperator* op) {
@@ -191,7 +191,7 @@ std::shared_ptr<planner::LogicalOperator> FactorizationRewriter::appendFlattenIf
         return op;
     }
     auto flatten = std::make_shared<LogicalFlatten>(groupPos, std::move(op));
-    flatten->computeSchema();
+    flatten->computeFactorizedSchema();
     return flatten;
 }
 

--- a/src/optimizer/remove_factorization_rewriter.cpp
+++ b/src/optimizer/remove_factorization_rewriter.cpp
@@ -23,8 +23,9 @@ std::shared_ptr<planner::LogicalOperator> RemoveFactorizationRewriter::visitOper
     for (auto i = 0; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));
     }
-    assert(op->getSchema() == nullptr);
-    return visitOperatorReplaceSwitch(op);
+    auto result = visitOperatorReplaceSwitch(op);
+    result->computeFlatSchema();
+    return result;
 }
 
 std::shared_ptr<planner::LogicalOperator> RemoveFactorizationRewriter::visitFlattenReplace(

--- a/src/optimizer/remove_unnecessary_join_optimizer.cpp
+++ b/src/optimizer/remove_unnecessary_join_optimizer.cpp
@@ -17,7 +17,9 @@ std::shared_ptr<planner::LogicalOperator> RemoveUnnecessaryJoinOptimizer::visitO
     for (auto i = 0; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));
     }
-    return visitOperatorReplaceSwitch(op);
+    auto result = visitOperatorReplaceSwitch(op);
+    result->computeFlatSchema();
+    return result;
 }
 
 std::shared_ptr<planner::LogicalOperator> RemoveUnnecessaryJoinOptimizer::visitHashJoinReplace(

--- a/src/planner/asp_optimizer.cpp
+++ b/src/planner/asp_optimizer.cpp
@@ -48,7 +48,7 @@ void ASPOptimizer::applyASP(
 
 void ASPOptimizer::appendSemiMasker(const std::shared_ptr<Expression>& nodeID, LogicalPlan& plan) {
     auto semiMasker = make_shared<LogicalSemiMasker>(nodeID, plan.getLastOperator());
-    semiMasker->computeSchema();
+    semiMasker->computeFactorizedSchema();
     plan.setLastOperator(std::move(semiMasker));
 }
 

--- a/src/planner/operator/CMakeLists.txt
+++ b/src/planner/operator/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(kuzu_planner_operator
         logical_aggregate.cpp
         logical_create.cpp
         logical_cross_product.cpp
+        logical_ddl.cpp
         logical_distinct.cpp
         logical_expressions_scan.cpp
         logical_extend.cpp

--- a/src/planner/operator/logical_accumulate.cpp
+++ b/src/planner/operator/logical_accumulate.cpp
@@ -5,10 +5,14 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalAccumulate::computeSchema() {
-    auto childSchema = children[0]->getSchema();
+void LogicalAccumulate::computeFactorizedSchema() {
     createEmptySchema();
-    SinkOperatorUtil::recomputeSchema(*childSchema, expressions, *schema);
+    auto childSchema = children[0]->getSchema();
+    SinkOperatorUtil::recomputeSchema(*childSchema, getExpressions(), *schema);
+}
+
+void LogicalAccumulate::computeFlatSchema() {
+    copyChildSchema(0);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -8,6 +8,28 @@ namespace planner {
 
 using namespace factorization;
 
+void LogicalAggregate::computeFactorizedSchema() {
+    createEmptySchema();
+    auto groupPos = schema->createGroup();
+    for (auto& expression : expressionsToGroupBy) {
+        schema->insertToGroupAndScope(expression, groupPos);
+    }
+    for (auto& expression : expressionsToAggregate) {
+        schema->insertToGroupAndScope(expression, groupPos);
+    }
+}
+
+void LogicalAggregate::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    for (auto& expression : expressionsToGroupBy) {
+        schema->insertToGroupAndScope(expression, 0);
+    }
+    for (auto& expression : expressionsToAggregate) {
+        schema->insertToGroupAndScope(expression, 0);
+    }
+}
+
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
     f_group_pos_set dependentGroupsPos;
     for (auto& expression : expressionsToGroupBy) {
@@ -34,17 +56,6 @@ f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
         return FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, children[0]->getSchema());
     }
     return f_group_pos_set{};
-}
-
-void LogicalAggregate::computeSchema() {
-    createEmptySchema();
-    auto groupPos = schema->createGroup();
-    for (auto& expression : expressionsToGroupBy) {
-        schema->insertToGroupAndScope(expression, groupPos);
-    }
-    for (auto& expression : expressionsToAggregate) {
-        schema->insertToGroupAndScope(expression, groupPos);
-    }
 }
 
 std::string LogicalAggregate::getExpressionsForPrinting() const {

--- a/src/planner/operator/logical_create.cpp
+++ b/src/planner/operator/logical_create.cpp
@@ -3,12 +3,19 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalCreateNode::computeSchema() {
-    LogicalUpdateNode::computeSchema();
+void LogicalCreateNode::computeFactorizedSchema() {
+    copyChildSchema(0);
     for (auto& node : nodes) {
         auto groupPos = schema->createGroup();
         schema->setGroupAsSingleState(groupPos);
         schema->insertToGroupAndScope(node->getInternalIDProperty(), groupPos);
+    }
+}
+
+void LogicalCreateNode::computeFlatSchema() {
+    copyChildSchema(0);
+    for (auto& node : nodes) {
+        schema->insertToGroupAndScope(node->getInternalIDProperty(), 0);
     }
 }
 

--- a/src/planner/operator/logical_cross_product.cpp
+++ b/src/planner/operator/logical_cross_product.cpp
@@ -5,11 +5,21 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalCrossProduct::computeSchema() {
+void LogicalCrossProduct::computeFactorizedSchema() {
     auto probeSchema = children[0]->getSchema();
     auto buildSchema = children[1]->getSchema();
     schema = probeSchema->copy();
     SinkOperatorUtil::mergeSchema(*buildSchema, buildSchema->getExpressionsInScope(), *schema);
+}
+
+void LogicalCrossProduct::computeFlatSchema() {
+    auto probeSchema = children[0]->getSchema();
+    auto buildSchema = children[1]->getSchema();
+    schema = probeSchema->copy();
+    assert(schema->getNumGroups() == 1);
+    for (auto& expression : buildSchema->getExpressionsInScope()) {
+        schema->insertToGroupAndScope(expression, 0);
+    }
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_ddl.cpp
+++ b/src/planner/operator/logical_ddl.cpp
@@ -1,0 +1,20 @@
+#include "planner/logical_plan/logical_operator/logical_ddl.h"
+
+namespace kuzu {
+namespace planner {
+
+void LogicalDDL::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    schema->insertToGroupAndScope(outputExpression, 0);
+}
+
+void LogicalDDL::computeFactorizedSchema() {
+    createEmptySchema();
+    auto groupPos = schema->createGroup();
+    schema->insertToGroupAndScope(outputExpression, groupPos);
+    schema->setGroupAsSingleState(groupPos);
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -5,6 +5,22 @@
 namespace kuzu {
 namespace planner {
 
+void LogicalDistinct::computeFactorizedSchema() {
+    createEmptySchema();
+    auto groupPos = schema->createGroup();
+    for (auto& expression : expressionsToDistinct) {
+        schema->insertToGroupAndScope(expression, groupPos);
+    }
+}
+
+void LogicalDistinct::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    for (auto& expression : expressionsToDistinct) {
+        schema->insertToGroupAndScope(expression, 0);
+    }
+}
+
 f_group_pos_set LogicalDistinct::getGroupsPosToFlatten() {
     f_group_pos_set dependentGroupsPos;
     auto childSchema = children[0]->getSchema();
@@ -22,14 +38,6 @@ std::string LogicalDistinct::getExpressionsForPrinting() const {
         result += expression->getUniqueName() + ", ";
     }
     return result;
-}
-
-void LogicalDistinct::computeSchema() {
-    createEmptySchema();
-    auto groupPos = schema->createGroup();
-    for (auto& expression : expressionsToDistinct) {
-        schema->insertToGroupAndScope(expression, groupPos);
-    }
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_expressions_scan.cpp
+++ b/src/planner/operator/logical_expressions_scan.cpp
@@ -3,7 +3,7 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalExpressionsScan::computeSchema() {
+void LogicalExpressionsScan::computeFactorizedSchema() {
     createEmptySchema();
     auto groupPos = schema->createGroup();
     schema->setGroupAsSingleState(groupPos); // Mark group holding constant as single state.
@@ -13,6 +13,18 @@ void LogicalExpressionsScan::computeSchema() {
             continue;
         }
         schema->insertToGroupAndScope(expression, groupPos);
+    }
+}
+
+void LogicalExpressionsScan::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    for (auto& expression : expressions) {
+        // No need to insert repeated constant.
+        if (schema->isExpressionInScope(*expression)) {
+            continue;
+        }
+        schema->insertToGroupAndScope(expression, 0);
     }
 }
 

--- a/src/planner/operator/logical_extend.cpp
+++ b/src/planner/operator/logical_extend.cpp
@@ -18,7 +18,7 @@ f_group_pos_set LogicalExtend::getGroupsPosToFlatten() {
     return result;
 }
 
-void LogicalExtend::computeSchema() {
+void LogicalExtend::computeFactorizedSchema() {
     copyChildSchema(0);
     auto boundGroupPos = schema->getGroupPos(boundNode->getInternalIDPropertyName());
     uint32_t nbrGroupPos = 0u;
@@ -31,6 +31,14 @@ void LogicalExtend::computeSchema() {
     schema->insertToGroupAndScope(nbrNode->getInternalIDProperty(), nbrGroupPos);
     for (auto& property : properties) {
         schema->insertToGroupAndScope(property, nbrGroupPos);
+    }
+}
+
+void LogicalExtend::computeFlatSchema() {
+    copyChildSchema(0);
+    schema->insertToGroupAndScope(nbrNode->getInternalIDProperty(), 0);
+    for (auto& property : properties) {
+        schema->insertToGroupAndScope(property, 0);
     }
 }
 

--- a/src/planner/operator/logical_flatten.cpp
+++ b/src/planner/operator/logical_flatten.cpp
@@ -3,9 +3,13 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalFlatten::computeSchema() {
+void LogicalFlatten::computeFactorizedSchema() {
     copyChildSchema(0);
     schema->flattenGroup(groupPos);
+}
+
+void LogicalFlatten::computeFlatSchema() {
+    throw common::InternalException("LogicalFlatten::computeFlatSchema() should never be used.");
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_ftable_scan.cpp
+++ b/src/planner/operator/logical_ftable_scan.cpp
@@ -3,7 +3,7 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalFTableScan::computeSchema() {
+void LogicalFTableScan::computeFactorizedSchema() {
     createEmptySchema();
     for (auto [prevPos, expressions] : populateGroupPosToExpressionsMap()) {
         auto newPos = schema->createGroup();
@@ -11,6 +11,14 @@ void LogicalFTableScan::computeSchema() {
         if (schemaToScanFrom->getGroup(prevPos)->isFlat()) {
             schema->setGroupAsSingleState(newPos);
         }
+    }
+}
+
+void LogicalFTableScan::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    for (auto& expression : expressionsToScan) {
+        schema->insertToGroupAndScope(expression, 0);
     }
 }
 

--- a/src/planner/operator/logical_order_by.cpp
+++ b/src/planner/operator/logical_order_by.cpp
@@ -33,10 +33,18 @@ f_group_pos_set LogicalOrderBy::getGroupsPosToFlatten() {
     return f_group_pos_set{};
 }
 
-void LogicalOrderBy::computeSchema() {
-    auto childSchema = children[0]->getSchema();
-    schema = std::make_unique<Schema>();
-    SinkOperatorUtil::recomputeSchema(*childSchema, expressionsToMaterialize, *schema);
+void LogicalOrderBy::computeFactorizedSchema() {
+    createEmptySchema();
+    SinkOperatorUtil::recomputeSchema(
+        *children[0]->getSchema(), getExpressionsToMaterialize(), *schema);
+}
+
+void LogicalOrderBy::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    for (auto& expression : children[0]->getSchema()->getExpressionsInScope()) {
+        schema->insertToScope(expression, 0);
+    }
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_projection.cpp
+++ b/src/planner/operator/logical_projection.cpp
@@ -3,7 +3,7 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalProjection::computeSchema() {
+void LogicalProjection::computeFactorizedSchema() {
     auto childSchema = children[0]->getSchema();
     schema = childSchema->copy();
     schema->clearExpressionsInScope();
@@ -27,6 +27,22 @@ void LogicalProjection::computeSchema() {
                 groupPos = SchemaUtils::getLeadingGroupPos(dependentGroupPos, *childSchema);
             }
             schema->insertToGroupAndScope(expression, groupPos);
+        }
+    }
+}
+
+void LogicalProjection::computeFlatSchema() {
+    copyChildSchema(0);
+    auto childSchema = children[0]->getSchema();
+    schema->clearExpressionsInScope();
+    for (auto& expression : expressions) {
+        if (schema->isExpressionInScope(*expression)) {
+            continue;
+        }
+        if (childSchema->isExpressionInScope(*expression)) {
+            schema->insertToScope(expression, 0);
+        } else {
+            schema->insertToGroupAndScope(expression, 0);
         }
     }
 }

--- a/src/planner/operator/logical_scan_node.cpp
+++ b/src/planner/operator/logical_scan_node.cpp
@@ -3,16 +3,27 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalScanNode::computeSchema() {
+void LogicalScanNode::computeFactorizedSchema() {
     createEmptySchema();
     auto groupPos = schema->createGroup();
     schema->insertToGroupAndScope(node->getInternalIDProperty(), groupPos);
 }
 
-void LogicalIndexScanNode::computeSchema() {
+void LogicalScanNode::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    schema->insertToGroupAndScope(node->getInternalIDProperty(), 0);
+}
+
+void LogicalIndexScanNode::computeFactorizedSchema() {
     copyChildSchema(0);
     auto groupPos = schema->getGroupPos(*indexExpression);
     schema->insertToGroupAndScope(node->getInternalIDProperty(), groupPos);
+}
+
+void LogicalIndexScanNode::computeFlatSchema() {
+    copyChildSchema(0);
+    schema->insertToGroupAndScope(node->getInternalIDProperty(), 0);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_scan_node_property.cpp
+++ b/src/planner/operator/logical_scan_node_property.cpp
@@ -3,11 +3,18 @@
 namespace kuzu {
 namespace planner {
 
-void LogicalScanNodeProperty::computeSchema() {
+void LogicalScanNodeProperty::computeFactorizedSchema() {
     copyChildSchema(0);
     auto groupPos = schema->getGroupPos(node->getInternalIDPropertyName());
     for (auto& property : properties) {
         schema->insertToGroupAndScope(property, groupPos);
+    }
+}
+
+void LogicalScanNodeProperty::computeFlatSchema() {
+    copyChildSchema(0);
+    for (auto& property : properties) {
+        schema->insertToGroupAndScope(property, 0);
     }
 }
 

--- a/src/planner/operator/logical_union.cpp
+++ b/src/planner/operator/logical_union.cpp
@@ -18,11 +18,19 @@ f_group_pos_set LogicalUnion::getGroupsPosToFlatten(uint32_t childIdx) {
     return factorization::FlattenAll::getGroupsPosToFlatten(groupsPos, childSchema);
 }
 
-void LogicalUnion::computeSchema() {
+void LogicalUnion::computeFactorizedSchema() {
     auto firstChildSchema = children[0]->getSchema();
-    schema = std::make_unique<Schema>();
+    createEmptySchema();
     SinkOperatorUtil::recomputeSchema(
         *firstChildSchema, firstChildSchema->getExpressionsInScope(), *schema);
+}
+
+void LogicalUnion::computeFlatSchema() {
+    createEmptySchema();
+    schema->createGroup();
+    for (auto& expression : children[0]->getSchema()->getExpressionsInScope()) {
+        schema->insertToGroupAndScope(expression, 0);
+    }
 }
 
 std::unique_ptr<LogicalOperator> LogicalUnion::copy() {

--- a/src/planner/operator/logical_unwind.cpp
+++ b/src/planner/operator/logical_unwind.cpp
@@ -11,10 +11,16 @@ f_group_pos_set LogicalUnwind::getGroupsPosToFlatten() {
     return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
 }
 
-void LogicalUnwind::computeSchema() {
+void LogicalUnwind::computeFactorizedSchema() {
     copyChildSchema(0);
     auto groupPos = schema->createGroup();
     schema->insertToGroupAndScope(aliasExpression, groupPos);
+}
+
+void LogicalUnwind::computeFlatSchema() {
+    copyChildSchema(0);
+    schema->createGroup();
+    schema->insertToGroupAndScope(aliasExpression, 0);
 }
 
 } // namespace planner

--- a/src/planner/projection_planner.cpp
+++ b/src/planner/projection_planner.cpp
@@ -98,7 +98,7 @@ void ProjectionPlanner::appendProjection(
         QueryPlanner::appendFlattens(groupsPosToFlatten, plan);
     }
     auto projection = make_shared<LogicalProjection>(expressionsToProject, plan.getLastOperator());
-    projection->computeSchema();
+    projection->computeFactorizedSchema();
     plan.setLastOperator(std::move(projection));
 }
 
@@ -110,23 +110,22 @@ void ProjectionPlanner::appendAggregate(const expression_vector& expressionsToGr
     aggregate->setChild(0, plan.getLastOperator());
     QueryPlanner::appendFlattens(aggregate->getGroupsPosToFlattenForAggregate(), plan);
     aggregate->setChild(0, plan.getLastOperator());
-    aggregate->computeSchema();
+    aggregate->computeFactorizedSchema();
     plan.setLastOperator(std::move(aggregate));
 }
 
 void ProjectionPlanner::appendOrderBy(
     const expression_vector& expressions, const std::vector<bool>& isAscOrders, LogicalPlan& plan) {
-    auto orderBy = make_shared<LogicalOrderBy>(expressions, isAscOrders,
-        plan.getSchema()->getExpressionsInScope(), plan.getLastOperator());
+    auto orderBy = make_shared<LogicalOrderBy>(expressions, isAscOrders, plan.getLastOperator());
     QueryPlanner::appendFlattens(orderBy->getGroupsPosToFlatten(), plan);
     orderBy->setChild(0, plan.getLastOperator());
-    orderBy->computeSchema();
+    orderBy->computeFactorizedSchema();
     plan.setLastOperator(std::move(orderBy));
 }
 
 void ProjectionPlanner::appendMultiplicityReducer(LogicalPlan& plan) {
     auto multiplicityReducer = make_shared<LogicalMultiplicityReducer>(plan.getLastOperator());
-    multiplicityReducer->computeSchema();
+    multiplicityReducer->computeFactorizedSchema();
     plan.setLastOperator(std::move(multiplicityReducer));
 }
 
@@ -134,7 +133,7 @@ void ProjectionPlanner::appendLimit(uint64_t limitNumber, LogicalPlan& plan) {
     auto limit = make_shared<LogicalLimit>(limitNumber, plan.getLastOperator());
     QueryPlanner::appendFlattens(limit->getGroupsPosToFlatten(), plan);
     limit->setChild(0, plan.getLastOperator());
-    limit->computeSchema();
+    limit->computeFactorizedSchema();
     plan.setCardinality(limitNumber);
     plan.setLastOperator(std::move(limit));
 }
@@ -143,7 +142,7 @@ void ProjectionPlanner::appendSkip(uint64_t skipNumber, LogicalPlan& plan) {
     auto skip = make_shared<LogicalSkip>(skipNumber, plan.getLastOperator());
     QueryPlanner::appendFlattens(skip->getGroupsPosToFlatten(), plan);
     skip->setChild(0, plan.getLastOperator());
-    skip->computeSchema();
+    skip->computeFactorizedSchema();
     plan.setCardinality(plan.getCardinality() - skipNumber);
     plan.setLastOperator(std::move(skip));
 }

--- a/src/planner/update_planner.cpp
+++ b/src/planner/update_planner.cpp
@@ -68,7 +68,7 @@ void UpdatePlanner::appendCreateNode(
         std::move(nodes), std::move(primaryKeys), plan.getLastOperator());
     QueryPlanner::appendFlattens(createNode->getGroupsPosToFlatten(), plan);
     createNode->setChild(0, plan.getLastOperator());
-    createNode->computeSchema();
+    createNode->computeFactorizedSchema();
     plan.setLastOperator(createNode);
     appendSetNodeProperty(setNodeProperties, plan);
 }
@@ -85,7 +85,7 @@ void UpdatePlanner::appendCreateRel(
         std::move(rels), std::move(setItemsPerRel), plan.getLastOperator());
     QueryPlanner::appendFlattens(createRel->getGroupsPosToFlatten(), plan);
     createRel->setChild(0, plan.getLastOperator());
-    createRel->computeSchema();
+    createRel->computeFactorizedSchema();
     plan.setLastOperator(createRel);
 }
 
@@ -125,7 +125,7 @@ void UpdatePlanner::appendSetNodeProperty(
     }
     auto setNodeProperty = make_shared<LogicalSetNodeProperty>(
         std::move(nodes), std::move(setItems), plan.getLastOperator());
-    setNodeProperty->computeSchema();
+    setNodeProperty->computeFactorizedSchema();
     plan.setLastOperator(setNodeProperty);
 }
 
@@ -143,7 +143,7 @@ void UpdatePlanner::appendSetRelProperty(
         QueryPlanner::appendFlattens(setRelProperty->getGroupsPosToFlatten(i), plan);
         setRelProperty->setChild(0, plan.getLastOperator());
     }
-    setRelProperty->computeSchema();
+    setRelProperty->computeFactorizedSchema();
     plan.setLastOperator(setRelProperty);
 }
 
@@ -166,7 +166,7 @@ void UpdatePlanner::appendDeleteNode(
     }
     auto deleteNode = make_shared<LogicalDeleteNode>(
         std::move(nodes), std::move(primaryKeys), plan.getLastOperator());
-    deleteNode->computeSchema();
+    deleteNode->computeFactorizedSchema();
     plan.setLastOperator(std::move(deleteNode));
 }
 
@@ -177,7 +177,7 @@ void UpdatePlanner::appendDeleteRel(
         QueryPlanner::appendFlattens(deleteRel->getGroupsPosToFlatten(i), plan);
         deleteRel->setChild(0, plan.getLastOperator());
     }
-    deleteRel->computeSchema();
+    deleteRel->computeFactorizedSchema();
     plan.setLastOperator(std::move(deleteRel));
 }
 

--- a/src/processor/mapper/map_accumulate.cpp
+++ b/src/processor/mapper/map_accumulate.cpp
@@ -13,7 +13,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAccumulateToPhysical(
     LogicalOperator* logicalOperator) {
     auto logicalAccumulate = (LogicalAccumulate*)logicalOperator;
     auto outSchema = logicalAccumulate->getSchema();
-    auto inSchema = logicalAccumulate->getSchemaBeforeSink();
+    auto inSchema = logicalAccumulate->getChild(0)->getSchema();
     // append result collector
     auto prevOperator = mapLogicalOperatorToPhysical(logicalAccumulate->getChild(0));
     auto expressions = logicalAccumulate->getExpressions();

--- a/src/processor/mapper/map_hash_join.cpp
+++ b/src/processor/mapper/map_hash_join.cpp
@@ -130,7 +130,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
     LogicalOperator* logicalOperator) {
     auto hashJoin = (LogicalHashJoin*)logicalOperator;
     auto outSchema = hashJoin->getSchema();
-    auto buildSchema = hashJoin->getBuildSideSchema();
+    auto buildSchema = hashJoin->getChild(1)->getSchema();
     auto buildSidePrevOperator = mapLogicalOperatorToPhysical(hashJoin->getChild(1));
     auto probeSidePrevOperator = mapLogicalOperatorToPhysical(hashJoin->getChild(0));
     // Populate build side and probe side std::vector positions

--- a/src/processor/mapper/map_order_by.cpp
+++ b/src/processor/mapper/map_order_by.cpp
@@ -13,7 +13,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOrderByToPhysical(
     LogicalOperator* logicalOperator) {
     auto& logicalOrderBy = (LogicalOrderBy&)*logicalOperator;
     auto outSchema = logicalOrderBy.getSchema();
-    auto inSchema = logicalOrderBy.getSchemaBeforeOrderBy();
+    auto inSchema = logicalOrderBy.getChild(0)->getSchema();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOrderBy.getChild(0));
     auto paramsString = logicalOrderBy.getExpressionsForPrinting();
     std::vector<std::pair<DataPos, common::DataType>> keysPosAndType;
@@ -31,7 +31,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalOrderByToPhysical(
         outVectorPos.emplace_back(outSchema->getExpressionPos(*expression));
     }
     // See comment in planOrderBy in projectionPlanner.cpp
-    auto mayContainUnflatKey = logicalOrderBy.getSchemaBeforeOrderBy()->getNumGroups() == 1;
+    auto mayContainUnflatKey = inSchema->getNumGroups() == 1;
     auto orderByDataInfo = OrderByDataInfo(keysPosAndType, payloadsPosAndType, isPayloadFlat,
         logicalOrderBy.getIsAscOrders(), mayContainUnflatKey);
     auto orderBySharedState = std::make_shared<SharedFactorizedTablesAndSortedKeyBlocks>();


### PR DESCRIPTION
- Rename `computeSchema` to `computeFactorizedSchema`
- Add `computeFlatSchema` so that operators resolve its input schema from child. As a result, we no longer maintain `expressionsToMaterialize` as a field in sink operators.