### PR TITLE
Factorization aware dp

### DIFF
--- a/src/binder/query/query_graph.cpp
+++ b/src/binder/query/query_graph.cpp
@@ -59,8 +59,7 @@ std::unordered_set<uint32_t> SubqueryGraph::getRelNbrPositions() const {
     return result;
 }
 
-std::unordered_set<SubqueryGraph, SubqueryGraphHasher> SubqueryGraph::getNbrSubgraphs(
-    uint32_t size) const {
+subquery_graph_set_t SubqueryGraph::getNbrSubgraphs(uint32_t size) const {
     auto result = getBaseNbrSubgraph();
     for (auto i = 1u; i < size; ++i) {
         std::unordered_set<SubqueryGraph, SubqueryGraphHasher> tmp;
@@ -106,8 +105,8 @@ std::unordered_set<uint32_t> SubqueryGraph::getNodePositionsIgnoringNodeSelector
     return result;
 }
 
-std::unordered_set<SubqueryGraph, SubqueryGraphHasher> SubqueryGraph::getBaseNbrSubgraph() const {
-    std::unordered_set<SubqueryGraph, SubqueryGraphHasher> result;
+subquery_graph_set_t SubqueryGraph::getBaseNbrSubgraph() const {
+    subquery_graph_set_t result;
     for (auto& nodePos : getNodeNbrPositions()) {
         auto nbr = SubqueryGraph(queryGraph);
         nbr.addQueryNode(nodePos);
@@ -121,9 +120,8 @@ std::unordered_set<SubqueryGraph, SubqueryGraphHasher> SubqueryGraph::getBaseNbr
     return result;
 }
 
-std::unordered_set<SubqueryGraph, SubqueryGraphHasher> SubqueryGraph::getNextNbrSubgraphs(
-    const SubqueryGraph& prevNbr) const {
-    std::unordered_set<SubqueryGraph, SubqueryGraphHasher> result;
+subquery_graph_set_t SubqueryGraph::getNextNbrSubgraphs(const SubqueryGraph& prevNbr) const {
+    subquery_graph_set_t result;
     for (auto& nodePos : prevNbr.getNodeNbrPositions()) {
         if (queryNodesSelector[nodePos]) {
             continue;

--- a/src/include/binder/query/reading_clause/query_graph.h
+++ b/src/include/binder/query/reading_clause/query_graph.h
@@ -12,6 +12,10 @@ const uint8_t MAX_NUM_VARIABLES = 64;
 
 class QueryGraph;
 struct SubqueryGraph;
+struct SubqueryGraphHasher;
+using subquery_graph_set_t = std::unordered_set<SubqueryGraph, SubqueryGraphHasher>;
+template<typename T>
+using subquery_graph_V_map_t = std::unordered_map<SubqueryGraph, T, SubqueryGraphHasher>;
 
 // hash on node bitset if subgraph has no rel
 struct SubqueryGraphHasher {
@@ -51,7 +55,7 @@ struct SubqueryGraph {
 
     std::unordered_set<uint32_t> getNodeNbrPositions() const;
     std::unordered_set<uint32_t> getRelNbrPositions() const;
-    std::unordered_set<SubqueryGraph, SubqueryGraphHasher> getNbrSubgraphs(uint32_t size) const;
+    subquery_graph_set_t getNbrSubgraphs(uint32_t size) const;
     std::vector<uint32_t> getConnectedNodePos(const SubqueryGraph& nbr) const;
 
     // E.g. query graph (a)-[e1]->(b) and subgraph (a)-[e1], although (b) is not in subgraph, we
@@ -65,9 +69,8 @@ struct SubqueryGraph {
     }
 
 private:
-    std::unordered_set<SubqueryGraph, SubqueryGraphHasher> getBaseNbrSubgraph() const;
-    std::unordered_set<SubqueryGraph, SubqueryGraphHasher> getNextNbrSubgraphs(
-        const SubqueryGraph& prevNbr) const;
+    subquery_graph_set_t getBaseNbrSubgraph() const;
+    subquery_graph_set_t getNextNbrSubgraphs(const SubqueryGraph& prevNbr) const;
 };
 
 // QueryGraph represents a connected pattern specified in MATCH clause.

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -24,6 +24,7 @@ using frame_group_idx_t = page_group_idx_t;
 using list_header_t = uint32_t;
 using property_id_t = uint32_t;
 constexpr property_id_t INVALID_PROPERTY_ID = UINT32_MAX;
+using vector_idx_t = uint32_t;
 
 // System representation for a variable-sized overflow value.
 struct overflow_value_t {

--- a/src/include/planner/logical_plan/logical_plan.h
+++ b/src/include/planner/logical_plan/logical_plan.h
@@ -5,6 +5,8 @@
 namespace kuzu {
 namespace planner {
 
+class LogicalPlan;
+
 class LogicalPlan {
 public:
     LogicalPlan() : estCardinality{1}, cost{0} {}

--- a/src/include/planner/subplans_table.h
+++ b/src/include/planner/subplans_table.h
@@ -13,13 +13,13 @@ namespace kuzu {
 namespace planner {
 
 const uint64_t MAX_LEVEL_TO_PLAN_EXACTLY = 7;
-const uint64_t MAX_NUM_SUBGRAPHS_PER_LEVEL = 100;
+const uint64_t MAX_NUM_SUBGRAPHS_PER_LEVEL = 50;
 const uint64_t MAX_NUM_PLANS_PER_SUBGRAPH = 50;
 
 class SubPlansTable {
-    typedef std::unordered_map<SubqueryGraph, std::vector<std::unique_ptr<LogicalPlan>>,
-        SubqueryGraphHasher>
-        SubqueryGraphPlansMap;
+    struct PlanSet;
+    // Each dp level is a map from sub query graph to a set of plans
+    using dp_level_t = subquery_graph_V_map_t<std::unique_ptr<PlanSet>>;
 
 public:
     void resize(uint32_t newSize);
@@ -31,12 +31,25 @@ public:
     std::vector<SubqueryGraph> getSubqueryGraphs(uint32_t level);
 
     void addPlan(const SubqueryGraph& subqueryGraph, std::unique_ptr<LogicalPlan> plan);
-    void finalizeLevel(uint32_t level);
 
     void clear();
 
 private:
-    std::vector<std::unique_ptr<SubqueryGraphPlansMap>> subPlans;
+    struct PlanSet {
+        std::vector<std::unique_ptr<LogicalPlan>> plans;
+        schema_map_t<common::vector_idx_t> schemaToPlanIdx;
+
+        inline std::vector<std::unique_ptr<LogicalPlan>>& getPlans() { return plans; }
+
+        void addPlan(std::unique_ptr<LogicalPlan> plan);
+    };
+
+    dp_level_t* getDPLevel(const SubqueryGraph& subqueryGraph) const {
+        return dpLevels[subqueryGraph.getTotalNumVariables()].get();
+    }
+
+private:
+    std::vector<std::unique_ptr<dp_level_t>> dpLevels;
 };
 
 } // namespace planner

--- a/src/planner/join_order_enumerator.cpp
+++ b/src/planner/join_order_enumerator.cpp
@@ -104,7 +104,6 @@ void JoinOrderEnumerator::planLevel(uint32_t level) {
     } else {
         planLevelExactly(level);
     }
-    context->subPlansTable->finalizeLevel(level);
 }
 
 void JoinOrderEnumerator::planLevelExactly(uint32_t level) {

--- a/src/planner/operator/schema.cpp
+++ b/src/planner/operator/schema.cpp
@@ -99,6 +99,51 @@ void Schema::clear() {
     clearExpressionsInScope();
 }
 
+size_t Schema::getNumGroups(bool isFlat) const {
+    auto result = 0u;
+    for (auto groupPos : getGroupsPosInScope()) {
+        result += groups[groupPos]->isFlat() == isFlat;
+    }
+    return result;
+}
+
+std::size_t SchemaHasher::operator()(const Schema* const& schema) const {
+    return std::hash<size_t>{}(schema->getNumFlatGroups()) ^
+           std::hash<size_t>{}(schema->getNumUnFlatGroups());
+}
+
+// We use this equality in join order enumeration to make sure at each DP level, we don't just keep
+// the best plan, but keep best plan for each unique factorization schema.
+// In order to balance enumeration time, we use an approximate equality check to reduce computation.
+// We check the following
+// - number of factorization groups
+// - number of unFlat factorization groups
+// - number of expressions
+// - if an expression has the same flat/unFlat flag in both schemas
+bool SchemaApproximateEquality::operator()(
+    const Schema* const& left, const Schema* const& right) const {
+    if (left->getNumGroups() != right->getNumGroups()) {
+        return false;
+    }
+    if (left->getNumUnFlatGroups() != right->getNumUnFlatGroups()) {
+        return false;
+    }
+    if (left->getExpressionsInScope().size() != right->getExpressionsInScope().size()) {
+        return false;
+    }
+    for (auto& expression : left->getExpressionsInScope()) {
+        if (!right->isExpressionInScope(*expression)) {
+            return false;
+        }
+        auto leftGroupPos = left->getGroupPos(*expression);
+        auto rightGroupPos = right->getGroupPos(*expression);
+        if (left->getGroup(leftGroupPos)->isFlat() != right->getGroup(rightGroupPos)->isFlat()) {
+            return false;
+        }
+    }
+    return true;
+}
+
 std::vector<binder::expression_vector> SchemaUtils::getExpressionsPerGroup(
     const binder::expression_vector& expressions, const Schema& schema) {
     std::vector<binder::expression_vector> result;

--- a/src/processor/mapper/map_intersect.cpp
+++ b/src/processor/mapper/map_intersect.cpp
@@ -11,6 +11,7 @@ namespace processor {
 std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
     LogicalOperator* logicalOperator) {
     auto logicalIntersect = (LogicalIntersect*)logicalOperator;
+    auto intersectNodeID = logicalIntersect->getIntersectNodeID();
     auto outSchema = logicalIntersect->getSchema();
     std::vector<std::unique_ptr<PhysicalOperator>> children;
     children.resize(logicalOperator->getNumChildren());
@@ -22,17 +23,19 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalIntersectToPhysical(
         auto buildSchema = logicalIntersect->getChild(i)->getSchema();
         auto buildSidePrevOperator = mapLogicalOperatorToPhysical(logicalIntersect->getChild(i));
         std::vector<DataPos> payloadsDataPos;
-        auto buildDataInfo =
-            generateBuildDataInfo(*buildSchema, {keyNodeID}, buildSchema->getExpressionsInScope());
-        for (auto& [dataPos, _] : buildDataInfo.payloadsPosAndType) {
-            auto expression = buildSchema->getGroup(dataPos.dataChunkPos)
-                                  ->getExpressions()[dataPos.valueVectorPos];
-            if (expression->getUniqueName() ==
-                logicalIntersect->getIntersectNodeID()->getUniqueName()) {
+        binder::expression_vector expressionsToMaterialize;
+        expressionsToMaterialize.push_back(keyNodeID);
+        expressionsToMaterialize.push_back(intersectNodeID);
+        for (auto& expression : buildSchema->getExpressionsInScope()) {
+            if (expression->getUniqueName() == keyNodeID->getUniqueName() ||
+                expression->getUniqueName() == intersectNodeID->getUniqueName()) {
                 continue;
             }
+            expressionsToMaterialize.push_back(expression);
             payloadsDataPos.emplace_back(outSchema->getExpressionPos(*expression));
         }
+        auto buildDataInfo =
+            generateBuildDataInfo(*buildSchema, {keyNodeID}, expressionsToMaterialize);
         auto sharedState = std::make_shared<IntersectSharedState>();
         sharedStates.push_back(sharedState);
         children[i] = make_unique<IntersectBuild>(

--- a/src/processor/operator/intersect/intersect.cpp
+++ b/src/processor/operator/intersect/intersect.cpp
@@ -17,9 +17,8 @@ void Intersect::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* c
         for (auto i = 0u; i < dataInfo.payloadsDataPos.size(); i++) {
             auto vector = resultSet->getValueVector(dataInfo.payloadsDataPos[i]);
             // Always skip the first two columns in the fTable: build key and intersect key.
-            // TODO(Guodong): this is a potential bug because you cannot guarantee intersect key is
-            // the second column. Once this is solved, go back and refactor projection push down for
-            // intersect.
+            // TODO(Guodong): Remove this assumption so that keys can be stored in any order. Change
+            // mapping logic too so that we don't need to maintain this order explicitly.
             columnIdxesToScanFrom.push_back(i + 2);
             vectorsToReadInto.push_back(vector.get());
         }
@@ -147,7 +146,7 @@ void Intersect::populatePayloads(
     const std::vector<uint8_t*>& tuples, const std::vector<uint32_t>& listIdxes) {
     for (auto i = 0u; i < listIdxes.size(); i++) {
         auto listIdx = listIdxes[i];
-        sharedHTs[i]->getHashTable()->getFactorizedTable()->lookup(
+        sharedHTs[listIdx]->getHashTable()->getFactorizedTable()->lookup(
             payloadVectorsToScanInto[listIdx], intersectSelVectors[i].get(),
             payloadColumnIdxesToScanFrom[listIdx], tuples[listIdx]);
     }

--- a/test/test_files/tinysnb/cyclic/multi_label.test
+++ b/test/test_files/tinysnb/cyclic/multi_label.test
@@ -3,10 +3,8 @@
 ---- 1
 3
 
-# TODO(Guodong): generic extend sames to give correct output but not getting correct final result
-# Also remember to add one with edge filter
-#-NAME MultiLabelTriangleTest
-#-QUERY MATCH (a:person)-[:knows]->(b:person)-[:studyAt|:mixed]->(c:organisation), (a)-[:studyAt]->(c) RETURN COUNT(*)
-#-ENUMERATE
-#---- 1
-#2
+-NAME MultiLabelTriangleTest
+-QUERY MATCH (a:person)-[:knows]->(b:person)-[:studyAt|:meets]->(c:organisation:person), (a)-[:studyAt|:meets]->(c) RETURN COUNT(*)
+-ENUMERATE
+---- 1
+4

--- a/test/test_files/tinysnb/cyclic/single_label.test
+++ b/test/test_files/tinysnb/cyclic/single_label.test
@@ -58,6 +58,13 @@ Dan|1950-05-14|Bob|1950-05-14|Carol|2000-01-01
 -ENUMERATE
 ---- 0
 
+-NAME TriangleTest6
+-QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:knows]->(c:person), (a)-[e3:knows]->(c) WHERE a.fName='Alice' AND e1.meetTime=timestamp('1986-10-21 21:08:31.521') RETURN b.fName, c.fName
+-ENUMERATE
+---- 2
+Bob|Carol
+Bob|Dan
+
 -NAME TriangleWithProjectionTest
 -QUERY MATCH (a:person)-[e1:knows]->(b:person)-[e2:studyAt]->(c:organisation), (a)-[e3:studyAt]->(c) RETURN a.fName, e1.date, b.fName, e2.year, c.name, e3.year
 -ENUMERATE


### PR DESCRIPTION
This PR changes the set of plans that kept in DP table during enumeration. Previous, we only keep plans with top K (K=50) lowest cost. This PR keeps plans with top 1 lowest cost for each different factorization structure.

The rationale is 
```
Consider a triangle + an edge
MATCH (a)->(b)->(c), (a)->(c), (c)->(d)
First it make sense to close the cycle as early as possible, so (a)->(b)->(c), (a)->(c)  will be handled first with WCOJ. The output factorization structures
[a, b] * [c] , [b, c] * [a] , [a, c] * [b]  (where the second group is unFlat) are considered as homogeneous. So any one could be picked in the DP level 3 for subgraph `(a)->(b)->(c), (a)->(c)`
But then at the next level, there is a clear disadvantage for [a, b] * [c] because further extension undermines the factorization.
```

This PR also fixes issue #1098 and #1371 