### PR TITLE
Add query timeout mechanism

### DIFF
--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -133,5 +133,10 @@ struct EnumeratorKnobs {
     static constexpr double FLAT_PROBE_PENALTY = 10;
 };
 
+struct ClientContextConstants {
+    // We disable query timeout by default.
+    static constexpr uint64_t TIMEOUT_IN_MS = 0;
+};
+
 } // namespace common
 } // namespace kuzu

--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -93,7 +93,7 @@ public:
 
 class InterruptException : public Exception {
 public:
-    explicit InterruptException() : Exception("Interrupted by the user."){};
+    explicit InterruptException() : Exception("Interrupted."){};
 };
 
 } // namespace common

--- a/src/include/common/task_system/task_scheduler.h
+++ b/src/include/common/task_system/task_scheduler.h
@@ -6,6 +6,7 @@
 
 #include "common/task_system/task.h"
 #include "common/utils.h"
+#include "processor/execution_context.h"
 
 namespace kuzu {
 namespace common {
@@ -57,7 +58,8 @@ public:
     // whether or not the given task or one of its dependencies errors, when this function
     // returns, no task related to the given task will be in the task queue. Further no worker
     // thread will be working on the given task.
-    void scheduleTaskAndWaitOrError(const std::shared_ptr<Task>& task);
+    void scheduleTaskAndWaitOrError(
+        const std::shared_ptr<Task>& task, processor::ExecutionContext* context);
 
     // If a user, e.g., currently the copier, adds a set of tasks T1, ..., Tk, to the task scheduler
     // without waiting for them to finish, the user needs to call waitAllTasksToCompleteOrError() if
@@ -93,6 +95,8 @@ private:
     // Functions to launch worker threads and for the worker threads to use to grab task from queue.
     void runWorkerThread();
     std::shared_ptr<ScheduledTask> getTaskAndRegister();
+
+    void interruptTaskIfTimeOutNoLock(processor::ExecutionContext* context);
 
 private:
     std::shared_ptr<spdlog::logger> logger;

--- a/src/include/common/timer.h
+++ b/src/include/common/timer.h
@@ -31,6 +31,12 @@ public:
         throw Exception("Timer is still running.");
     }
 
+    int64_t getElapsedTimeInMS() {
+        auto now = std::chrono::high_resolution_clock::now();
+        auto duration = now - startTime;
+        return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+    }
+
 private:
     std::chrono::time_point<std::chrono::high_resolution_clock> startTime;
     std::chrono::time_point<std::chrono::high_resolution_clock> stopTime;

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -136,6 +136,12 @@ public:
      */
     KUZU_API void interrupt();
 
+    /**
+     * @brief sets the query timeout value of the current connection. A value of zero (the default)
+     * disables the timeout.
+     */
+    KUZU_API void setQueryTimeOut(uint64_t timeoutInMS);
+
 protected:
     ConnectionTransactionMode getTransactionMode();
     void setTransactionModeNoLock(ConnectionTransactionMode newTransactionMode);

--- a/src/include/main/kuzu_fwd.h
+++ b/src/include/main/kuzu_fwd.h
@@ -7,6 +7,8 @@ class ApiTest;
 class BaseGraphTest;
 class TestHelper;
 class TestHelper;
+class TinySnbDDLTest;
+class TinySnbCopyCSVTransactionTest;
 } // namespace testing
 
 namespace benchmark {
@@ -51,8 +53,6 @@ namespace transaction {
 class Transaction;
 enum class TransactionType : uint8_t;
 class TransactionManager;
-class TinySnbDDLTest;
-class TinySnbCopyCSVTransactionTest;
 } // namespace transaction
 
 } // namespace kuzu

--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -13,9 +13,9 @@ namespace main {
  */
 class PreparedStatement {
     friend class Connection;
-    friend class kuzu::testing::TestHelper;
-    friend class kuzu::transaction::TinySnbDDLTest;
-    friend class kuzu::transaction::TinySnbCopyCSVTransactionTest;
+    friend class testing::TestHelper;
+    friend class testing::TinySnbDDLTest;
+    friend class testing::TinySnbCopyCSVTransactionTest;
 
 public:
     /**

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -2,11 +2,22 @@
 
 #include <thread>
 
+#include "common/constants.h"
+
 namespace kuzu {
 namespace main {
 
+ActiveQuery::ActiveQuery() : interrupted{false} {}
+
 ClientContext::ClientContext()
-    : numThreadsForExecution{std::thread::hardware_concurrency()}, interrupted{false} {}
+    : numThreadsForExecution{std::thread::hardware_concurrency()},
+      timeoutInMS{common::ClientContextConstants::TIMEOUT_IN_MS} {}
+
+void ClientContext::startTimingIfEnabled() {
+    if (isTimeOutEnabled()) {
+        activeQuery->timer.start();
+    }
+}
 
 } // namespace main
 } // namespace kuzu

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<FactorizedTable> QueryProcessor::execute(
         // one.
         auto task = std::make_shared<ProcessorTask>(resultCollector, context);
         decomposePlanIntoTasks(lastOperator, nullptr, task.get(), context);
-        taskScheduler->scheduleTaskAndWaitOrError(task);
+        taskScheduler->scheduleTaskAndWaitOrError(task, context);
         return resultCollector->getResultFactorizedTable();
     }
 }

--- a/test/include/main_test_helper/main_test_helper.h
+++ b/test/include/main_test_helper/main_test_helper.h
@@ -31,7 +31,7 @@ public:
     static void executeLongRunningQuery(Connection* conn) {
         auto result = conn->query("MATCH (a:person)-[:knows*1..28]->(b:person) RETURN COUNT(*)");
         ASSERT_FALSE(result->isSuccess());
-        ASSERT_EQ(result->getErrorMessage(), "Interrupted by the user.");
+        ASSERT_EQ(result->getErrorMessage(), "Interrupted.");
     }
 };
 

--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -144,3 +144,10 @@ TEST_F(ApiTest, Interrupt) {
     conn->interrupt();
     longRunningQueryThread.join();
 }
+
+TEST_F(ApiTest, TimeOut) {
+    conn->setQueryTimeOut(1000 /* timeoutInMS */);
+    auto result = conn->query("MATCH (a:person)-[:knows*1..28]->(b:person) RETURN COUNT(*);");
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_EQ(result->getErrorMessage(), "Interrupted.");
+}

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -9,7 +9,7 @@ using namespace kuzu::storage;
 using namespace kuzu::testing;
 
 namespace kuzu {
-namespace transaction {
+namespace testing {
 
 class PrimaryKeyTest : public EmptyDBTest {
 public:
@@ -365,6 +365,7 @@ public:
         auto physicalPlan =
             mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
                 preparedStatement->getExpressionsToCollect(), preparedStatement->statementType);
+        executionContext->clientContext->activeQuery = std::make_unique<ActiveQuery>();
         getQueryProcessor(*database)->execute(physicalPlan.get(), executionContext.get());
     }
 
@@ -933,5 +934,5 @@ TEST_F(TinySnbDDLTest, RenamePropertyRecovery) {
     renameProperty(TransactionTestType::RECOVERY);
 }
 
-} // namespace transaction
+} // namespace testing
 } // namespace kuzu

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -36,8 +36,9 @@ struct ShellCommand {
     const std::string SHOW_NODE = ":show_node";
     const std::string SHOW_REL = ":show_rel";
     const std::string LOGGING_LEVEL = ":logging_level";
-    const std::vector<std::string> commandList = {
-        HELP, CLEAR, QUIT, THREAD, LIST_NODES, LIST_RELS, SHOW_NODE, SHOW_REL, LOGGING_LEVEL};
+    const std::string QUERY_TIMEOUT = ":timeout";
+    const std::vector<std::string> commandList = {HELP, CLEAR, QUIT, THREAD, LIST_NODES, LIST_RELS,
+        SHOW_NODE, SHOW_REL, LOGGING_LEVEL, QUERY_TIMEOUT};
 } shellCommand;
 
 const char* TAB = "    ";
@@ -240,6 +241,8 @@ void EmbeddedShell::run() {
             printRelSchema(lineStr.substr(shellCommand.SHOW_REL.length()));
         } else if (lineStr.rfind(shellCommand.LOGGING_LEVEL) == 0) {
             setLoggingLevel(lineStr.substr(shellCommand.LOGGING_LEVEL.length()));
+        } else if (lineStr.rfind(shellCommand.QUERY_TIMEOUT) == 0) {
+            setQueryTimeout(lineStr.substr(shellCommand.QUERY_TIMEOUT.length()));
         } else if (!lineStr.empty()) {
             ss.clear();
             ss.str(lineStr);
@@ -312,6 +315,8 @@ void EmbeddedShell::printHelp() {
     printf("%s%s [logging_level] %sset logging level of database, available options: debug, info, "
            "err\n",
         TAB, shellCommand.LOGGING_LEVEL.c_str(), TAB);
+    printf("%s%s [query_timeout] %sset query timeout in ms\n", TAB,
+        shellCommand.QUERY_TIMEOUT.c_str(), TAB);
     printf("%s%s %slist all node tables\n", TAB, shellCommand.LIST_NODES.c_str(), TAB);
     printf("%s%s %slist all rel tables\n", TAB, shellCommand.LIST_RELS.c_str(), TAB);
     printf("%s%s %s[table_name] show node schema\n", TAB, shellCommand.SHOW_NODE.c_str(), TAB);
@@ -401,6 +406,12 @@ void EmbeddedShell::setLoggingLevel(const std::string& loggingLevel) {
         database->setLoggingLevel(level);
         printf("logging level has been set to: %s.\n", level.c_str());
     } catch (Exception& e) { printf("%s", e.what()); }
+}
+
+void EmbeddedShell::setQueryTimeout(const std::string& timeoutInMS) {
+    auto queryTimeOutVal = std::stoull(ltrim(timeoutInMS));
+    conn->setQueryTimeOut(queryTimeOutVal);
+    printf("query timeout value has been set to: %llu ms.\n", queryTimeOutVal);
 }
 
 } // namespace main

--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -32,6 +32,8 @@ private:
 
     void setLoggingLevel(const std::string& loggingLevel);
 
+    void setQueryTimeout(const std::string& timeoutInMS);
+
 private:
     std::unique_ptr<Database> database;
     std::unique_ptr<Connection> conn;


### PR DESCRIPTION
## 1. Query timeout mechanism: 
a. The system will abort queries which execute longer than the time_out limit.
b. The default timeout value is 120000MS(2 minutes) and query timeout is disabled by default.
## 2. Added two APIs to connection:
a. `void setQueryTimeOut(uint64_t timeoutInMS)`: sets the query timeout value of the current connection.
b. `void setQueryTimeOutEnabled(bool isEnabled)`: enables/disabled the query timeout of the current connection.