### PR TITLE
BM optimistic reads

### DIFF
--- a/src/include/storage/storage_structure/disk_overflow_file.h
+++ b/src/include/storage/storage_structure/disk_overflow_file.h
@@ -89,6 +89,9 @@ private:
     void setListRecursiveIfNestedWithoutLock(const common::ku_list_t& inMemSrcList,
         common::ku_list_t& diskDstList, const common::DataType& dataType);
     void logNewOverflowFileNextBytePosRecordIfNecessaryWithoutLock();
+    void readValuesInList(transaction::TransactionType trxType, const common::DataType& dataType,
+        std::vector<std::unique_ptr<common::Value>>& retValues, uint32_t numBytesOfSingleValue,
+        uint64_t numValuesInList, PageByteCursor& cursor, uint8_t* frame);
     void pinOverflowPageCache(BMFileHandle* bmFileHandleToPin, common::page_idx_t pageIdxToPin,
         OverflowPageCache& overflowPageCache);
     void unpinOverflowPageCache(OverflowPageCache& overflowPageCache);

--- a/src/storage/buffer_manager/bm_file_handle.cpp
+++ b/src/storage/buffer_manager/bm_file_handle.cpp
@@ -7,27 +7,6 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-void PageState::setInFrame(common::page_idx_t pageIdx_) {
-    pageIdx = 0;
-    pageIdx = pageIdx_;
-    pageIdx |= IS_IN_FRAME_MASK;
-}
-
-bool PageState::acquireLock(LockMode lockMode) {
-    if (lockMode == LockMode::SPIN) {
-        while (lock.test_and_set()) // spinning
-            ;
-        return true;
-    }
-    return !lock.test_and_set();
-}
-
-void PageState::resetState() {
-    pageIdx = 0;
-    pinCount = 0;
-    evictionTimestamp = 0;
-}
-
 WALPageIdxGroup::WALPageIdxGroup() {
     walPageIdxes.resize(common::StorageConstants::PAGE_GROUP_SIZE, common::INVALID_PAGE_IDX);
     walPageIdxLocks.resize(common::StorageConstants::PAGE_GROUP_SIZE);

--- a/src/storage/storage_structure/disk_array.cpp
+++ b/src/storage/storage_structure/disk_array.cpp
@@ -82,9 +82,9 @@ U BaseDiskArray<U>::get(uint64_t idx, TransactionType trxType) {
     auto& bmFileHandle = (BMFileHandle&)fileHandle;
     if (trxType == TransactionType::READ_ONLY || !hasTransactionalUpdates ||
         !bmFileHandle.hasWALPageVersionNoWALPageIdxLock(apPageIdx)) {
-        auto frame = bufferManager->pin(bmFileHandle, apPageIdx);
-        auto retVal = *(U*)(frame + apCursor.offsetInPage);
-        bufferManager->unpin(bmFileHandle, apPageIdx);
+        U retVal;
+        bufferManager->optimisticRead(bmFileHandle, apPageIdx,
+            [&](const uint8_t* frame) -> void { retVal = *(U*)(frame + apCursor.offsetInPage); });
         return retVal;
     } else {
         U retVal;

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -696,9 +696,9 @@ TEST_F(TinySnbDDLTest, DropNodeTablePropertyNormalExecution) {
     dropNodeTableProperty(TransactionTestType::NORMAL_EXECUTION);
 }
 
-// TEST_F(TinySnbDDLTest, DropNodeTablePropertyRecovery) {
-//    dropNodeTableProperty(TransactionTestType::RECOVERY);
-//}
+TEST_F(TinySnbDDLTest, DropNodeTablePropertyRecovery) {
+    dropNodeTableProperty(TransactionTestType::RECOVERY);
+}
 
 TEST_F(TinySnbDDLTest, DropRelTablePropertyNormalExecution) {
     dropRelTableProperty(TransactionTestType::NORMAL_EXECUTION);


### PR DESCRIPTION
This PR adds `optimisticRead` interface to BM following the [VMCache design](https://www.cs.cit.tum.de/fileadmin/w00cfj/dis/_my_direct_uploads/vmcache.pdf).  Any writes to file pages should go through `pin`/`unpin`, and reads can go through `optimisticRead`, which lifts the read-read lock contentions.

### Page states and versions
Pages managed by BM now have four states: a) Locked, b) Unlocked, c) Marked, d) Evicted.
Every page is initialized as in the Evicted state. When a page is pinned, it transits to the Locked state.
When the caller finishes changes to the page, it calls `unpin`, which releases the lock on the page, thus, the page transits to the Unlocked state.
Any optimistic reads on Unlocked pages should not make any changes to the page, and reads on Marked pages will first set their states to Unlocked, and then read the page optimistically. For Evicted pages, optimistic reads will trigger pin and unpin to read pages from disk into frames.

Besides the page state, each page also has a version number. The version number is used to identify any potential writes on the page. Each time a page transits from Locked to Unlocked state, it will increment its version. When a page is pinned, then unpinned, it will transit from Locked to the Unlocked state, and its version will be incremented. During the pin and unpin, we assume the page's content in its corresponding frame might have changed, thus, we increment the version number to forbid stale reads on it.

### Eviction
We still use queue-based eviction strategy.
To track pages that can potentially be evicted, we push unlocked pages into the eviction queue, and set their states to Marked, which means they are ready to be evicted.
After the candidate was enqueued:
1) if the page's version has changed, which indicates that the page was pinned and unpinned again, the candidate should be discarded. Due to that there should be another candidate pointing to the same page in the queue.
2) if the page's state is Unlocked, but its version hasn't changed, which indicates that the page was optimistically read, the page should be set to Marked and the candidate should be moved back to the queue.