### PR TITLE
Fix hash index slot alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(Kuzu VERSION 0.0.4 LANGUAGES CXX)
+project(Kuzu VERSION 0.0.3.1 LANGUAGES CXX)
 
 find_package(Threads REQUIRED)
 

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -89,8 +89,7 @@ struct ListsMetadataConstants {
 
 // Hash Index Configurations
 struct HashIndexConstants {
-    static constexpr uint8_t SLOT_CAPACITY_LOG_2 = 2;
-    static constexpr uint8_t SLOT_CAPACITY = (uint64_t)1 << SLOT_CAPACITY_LOG_2;
+    static constexpr uint8_t SLOT_CAPACITY = 3;
 };
 
 struct CopyConstants {


### PR DESCRIPTION
Hash index slot size is not aligned with 2^n, while DiskArray assumes that elements' sizes are aligned with 2^n to make the best use of page space.