### PR TITLE
Cardinality est

### DIFF
--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -133,7 +133,7 @@ struct LoggerConstants {
 struct EnumeratorKnobs {
     static constexpr double NON_EQUALITY_PREDICATE_SELECTIVITY = 0.1;
     static constexpr double EQUALITY_PREDICATE_SELECTIVITY = 0.01;
-    static constexpr double FLAT_PROBE_PENALTY = 10;
+    static constexpr uint64_t BUILD_PENALTY = 2;
 };
 
 struct ClientContextConstants {

--- a/src/include/planner/join_order/cardinality_estimator.h
+++ b/src/include/planner/join_order/cardinality_estimator.h
@@ -1,0 +1,48 @@
+#include "binder/query/reading_clause/query_graph.h"
+#include "planner/logical_plan/logical_plan.h"
+#include "storage/store/nodes_statistics_and_deleted_ids.h"
+#include "storage/store/rels_statistics.h"
+
+namespace kuzu {
+namespace planner {
+
+class CardinalityEstimator {
+public:
+    CardinalityEstimator(const storage::NodesStatisticsAndDeletedIDs& nodesStatistics,
+        const storage::RelsStatistics& relsStatistics)
+        : nodesStatistics{nodesStatistics}, relsStatistics{relsStatistics} {}
+
+    void initNodeIDDom(binder::QueryGraph* queryGraph);
+
+    uint64_t estimateScanNode(LogicalOperator* op);
+    uint64_t estimateHashJoin(const binder::expression_vector& joinNodeIDs,
+        const LogicalPlan& probePlan, const LogicalPlan& buildPlan);
+    uint64_t estimateCrossProduct(const LogicalPlan& probePlan, const LogicalPlan& buildPlan);
+    uint64_t estimateIntersect(const binder::expression_vector& joinNodeIDs,
+        const LogicalPlan& probePlan, const std::vector<std::unique_ptr<LogicalPlan>>& buildPlans);
+    uint64_t estimateFlatten(const LogicalPlan& childPlan, f_group_pos groupPosToFlatten);
+    uint64_t estimateFilter(const LogicalPlan& childPlan, const binder::Expression& predicate);
+
+    double getExtensionRate(
+        const binder::RelExpression& rel, const binder::NodeExpression& boundNode);
+
+private:
+    inline uint64_t atLeastOne(uint64_t x) { return x == 0 ? 1 : x; }
+
+    uint64_t getNodeIDDom(const std::string& nodeIDName) {
+        assert(nodeIDName2dom.contains(nodeIDName));
+        return nodeIDName2dom.at(nodeIDName);
+    }
+    uint64_t getNumNodes(const binder::NodeExpression& node);
+
+    uint64_t getNumRels(const binder::RelExpression& rel);
+
+private:
+    const storage::NodesStatisticsAndDeletedIDs& nodesStatistics;
+    const storage::RelsStatistics& relsStatistics;
+    // The domain of nodeID is defined as the number of unique value of nodeID, i.e. num nodes.
+    std::unordered_map<std::string, uint64_t> nodeIDName2dom;
+};
+
+} // namespace planner
+} // namespace kuzu

--- a/src/include/planner/join_order/cost_model.h
+++ b/src/include/planner/join_order/cost_model.h
@@ -1,0 +1,18 @@
+#include "planner/logical_plan/logical_plan.h"
+
+namespace kuzu {
+namespace planner {
+
+class CostModel {
+public:
+    static uint64_t computeExtendCost(const LogicalPlan& childPlan);
+    static uint64_t computeHashJoinCost(const binder::expression_vector& joinNodeIDs,
+        const LogicalPlan& probe, const LogicalPlan& build);
+    static uint64_t computeMarkJoinCost(const binder::expression_vector& joinNodeIDs,
+        const LogicalPlan& probe, const LogicalPlan& build);
+    static uint64_t computeIntersectCost(
+        const LogicalPlan& probePlan, const std::vector<std::unique_ptr<LogicalPlan>>& buildPlans);
+};
+
+} // namespace planner
+} // namespace kuzu

--- a/src/include/planner/logical_plan/logical_operator/schema.h
+++ b/src/include/planner/logical_plan/logical_operator/schema.h
@@ -13,6 +13,7 @@ constexpr f_group_pos INVALID_F_GROUP_POS = UINT32_MAX;
 
 class FactorizationGroup {
     friend class Schema;
+    friend class CardinalityEstimator;
 
 public:
     FactorizationGroup() : flat{false}, singleState{false}, cardinalityMultiplier{1} {}
@@ -33,8 +34,8 @@ public:
     }
     inline bool isSingleState() const { return singleState; }
 
-    inline void setMultiplier(uint64_t multiplier) { cardinalityMultiplier = multiplier; }
-    inline uint64_t getMultiplier() const { return cardinalityMultiplier; }
+    inline void setMultiplier(double multiplier) { cardinalityMultiplier = multiplier; }
+    inline double getMultiplier() const { return cardinalityMultiplier; }
 
     inline void insertExpression(const std::shared_ptr<binder::Expression>& expression) {
         assert(!expressionNameToPos.contains(expression->getUniqueName()));
@@ -50,7 +51,7 @@ public:
 private:
     bool flat;
     bool singleState;
-    uint64_t cardinalityMultiplier;
+    double cardinalityMultiplier;
     binder::expression_vector expressions;
     std::unordered_map<std::string, uint32_t> expressionNameToPos;
 };

--- a/src/include/planner/logical_plan/logical_plan.h
+++ b/src/include/planner/logical_plan/logical_plan.h
@@ -5,9 +5,10 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalPlan;
-
 class LogicalPlan {
+    friend class CardinalityEstimator;
+    friend class CostModel;
+
 public:
     LogicalPlan() : estCardinality{1}, cost{0} {}
 
@@ -20,12 +21,10 @@ public:
     inline std::shared_ptr<LogicalOperator> getLastOperator() const { return lastOperator; }
     inline Schema* getSchema() const { return lastOperator->getSchema(); }
 
-    inline void multiplyCardinality(uint64_t factor) { estCardinality *= factor; }
     inline void setCardinality(uint64_t cardinality) { estCardinality = cardinality; }
     inline uint64_t getCardinality() const { return estCardinality; }
 
-    inline void multiplyCost(uint64_t factor) { cost *= factor; }
-    inline void increaseCost(uint64_t costToIncrease) { cost += costToIncrease; }
+    inline void setCost(uint64_t cost_) { cost = cost_; }
     inline uint64_t getCost() const { return cost; }
 
     inline std::string toString() const { return lastOperator->toString(); }

--- a/src/include/planner/update_planner.h
+++ b/src/include/planner/update_planner.h
@@ -10,9 +10,11 @@
 namespace kuzu {
 namespace planner {
 
+class QueryPlanner;
+
 class UpdatePlanner {
 public:
-    UpdatePlanner() = default;
+    UpdatePlanner(QueryPlanner* queryPlanner) : queryPlanner{queryPlanner} {};
 
     inline void planUpdatingClause(binder::BoundUpdatingClause& updatingClause,
         std::vector<std::unique_ptr<LogicalPlan>>& plans) {
@@ -43,6 +45,9 @@ private:
         LogicalPlan& plan);
     void appendDeleteRel(
         const std::vector<std::shared_ptr<binder::RelExpression>>& deleteRels, LogicalPlan& plan);
+
+private:
+    QueryPlanner* queryPlanner;
 };
 
 } // namespace planner

--- a/src/planner/CMakeLists.txt
+++ b/src/planner/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_subdirectory(join_order)
 add_subdirectory(operator)
 
 add_library(kuzu_planner

--- a/src/planner/join_order/CMakeLists.txt
+++ b/src/planner/join_order/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(kuzu_planner_join_order
+        OBJECT
+        cardinality_estimator.cpp
+        cost_model.cpp)
+
+set(ALL_OBJECT_FILES
+        ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_planner_join_order>
+        PARENT_SCOPE)

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -1,0 +1,128 @@
+#include "planner/join_order/cardinality_estimator.h"
+
+#include "planner/logical_plan/logical_operator/logical_extend.h"
+#include "planner/logical_plan/logical_operator/logical_scan_node.h"
+
+namespace kuzu {
+namespace planner {
+
+void CardinalityEstimator::initNodeIDDom(binder::QueryGraph* queryGraph) {
+    for (auto i = 0u; i < queryGraph->getNumQueryNodes(); ++i) {
+        auto node = queryGraph->getQueryNode(i);
+        if (!nodeIDName2dom.contains(node->getInternalIDPropertyName())) {
+            nodeIDName2dom.insert({node->getInternalIDPropertyName(), getNumNodes(*node)});
+        }
+    }
+}
+
+uint64_t CardinalityEstimator::estimateScanNode(LogicalOperator* op) {
+    auto scanNode = (LogicalScanNode*)op;
+    return atLeastOne(getNodeIDDom(scanNode->getNode()->getInternalIDPropertyName()));
+}
+
+// Although we may not flatten join key in Build operator computation. We do need to calculate join
+// cardinality based on flat join key cardinality.
+static uint64_t getJoinKeysFlatCardinality(
+    const binder::expression_vector& joinNodeIDs, const LogicalPlan& buildPlan) {
+    auto schema = buildPlan.getSchema();
+    f_group_pos_set unFlatGroupsPos;
+    for (auto& joinID : joinNodeIDs) {
+        auto groupPos = schema->getGroupPos(*joinID);
+        if (!schema->getGroup(groupPos)->isFlat()) {
+            unFlatGroupsPos.insert(groupPos);
+        }
+    }
+    auto cardinality = buildPlan.getCardinality();
+    for (auto groupPos : unFlatGroupsPos) {
+        cardinality *= schema->getGroup(groupPos)->getMultiplier();
+    }
+    return cardinality;
+}
+
+uint64_t CardinalityEstimator::estimateHashJoin(const binder::expression_vector& joinNodeIDs,
+    const LogicalPlan& probePlan, const LogicalPlan& buildPlan) {
+    auto denominator = 1u;
+    for (auto& joinNodeID : joinNodeIDs) {
+        denominator *= getNodeIDDom(joinNodeID->getUniqueName());
+    }
+    return atLeastOne(probePlan.estCardinality *
+                      getJoinKeysFlatCardinality(joinNodeIDs, buildPlan) / denominator);
+}
+
+uint64_t CardinalityEstimator::estimateCrossProduct(
+    const LogicalPlan& probePlan, const LogicalPlan& buildPlan) {
+    return atLeastOne(probePlan.estCardinality * buildPlan.estCardinality);
+}
+
+uint64_t CardinalityEstimator::estimateIntersect(const binder::expression_vector& joinNodeIDs,
+    const LogicalPlan& probePlan, const std::vector<std::unique_ptr<LogicalPlan>>& buildPlans) {
+    // Formula 1: treat intersect as a Filter on probe side.
+    uint64_t estCardinality1 =
+        probePlan.estCardinality * common::EnumeratorKnobs::NON_EQUALITY_PREDICATE_SELECTIVITY;
+    // Formula 2: assume independence on join conditions.
+    auto denominator = 1u;
+    for (auto& joinNodeID : joinNodeIDs) {
+        denominator *= getNodeIDDom(joinNodeID->getUniqueName());
+    }
+    auto numerator = probePlan.estCardinality;
+    for (auto& buildPlan : buildPlans) {
+        numerator *= buildPlan->estCardinality;
+    }
+    auto estCardinality2 = numerator / denominator;
+    // Pick minimum between the two formulas.
+    return atLeastOne(std::min<uint64_t>(estCardinality1, estCardinality2));
+}
+
+uint64_t CardinalityEstimator::estimateFlatten(
+    const LogicalPlan& childPlan, f_group_pos groupPosToFlatten) {
+    auto group = childPlan.getSchema()->getGroup(groupPosToFlatten);
+    return atLeastOne(childPlan.estCardinality * group->cardinalityMultiplier);
+}
+
+static bool isPrimaryKey(const binder::Expression& expression) {
+    if (expression.expressionType != common::ExpressionType::PROPERTY) {
+        return false;
+    }
+    return ((binder::PropertyExpression&)expression).isPrimaryKey();
+}
+
+uint64_t CardinalityEstimator::estimateFilter(
+    const LogicalPlan& childPlan, const binder::Expression& predicate) {
+    if (predicate.expressionType == common::EQUALS) {
+        if (isPrimaryKey(*predicate.getChild(0)) || isPrimaryKey(*predicate.getChild(1))) {
+            return 1;
+        } else {
+            return atLeastOne(
+                childPlan.estCardinality * common::EnumeratorKnobs::EQUALITY_PREDICATE_SELECTIVITY);
+        }
+    } else {
+        return atLeastOne(
+            childPlan.estCardinality * common::EnumeratorKnobs::NON_EQUALITY_PREDICATE_SELECTIVITY);
+    }
+}
+
+uint64_t CardinalityEstimator::getNumNodes(const binder::NodeExpression& node) {
+    auto numNodes = 0u;
+    for (auto& tableID : node.getTableIDs()) {
+        numNodes += nodesStatistics.getNodeStatisticsAndDeletedIDs(tableID)->getNumTuples();
+    }
+    return atLeastOne(numNodes);
+}
+
+uint64_t CardinalityEstimator::getNumRels(const binder::RelExpression& rel) {
+    auto numRels = 0u;
+    for (auto tableID : rel.getTableIDs()) {
+        numRels += relsStatistics.getRelStatistics(tableID)->getNumTuples();
+    }
+    return atLeastOne(numRels);
+}
+
+double CardinalityEstimator::getExtensionRate(
+    const binder::RelExpression& rel, const binder::NodeExpression& boundNode) {
+    auto numBoundNodes = (double)getNumNodes(boundNode);
+    auto numRels = (double)getNumRels(rel);
+    return numRels / numBoundNodes;
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/src/planner/join_order/cost_model.cpp
+++ b/src/planner/join_order/cost_model.cpp
@@ -1,0 +1,41 @@
+#include "planner/join_order/cost_model.h"
+
+#include "common/constants.h"
+
+namespace kuzu {
+namespace planner {
+
+uint64_t CostModel::computeExtendCost(const LogicalPlan& childPlan) {
+    return childPlan.estCardinality;
+}
+
+uint64_t CostModel::computeHashJoinCost(const binder::expression_vector& joinNodeIDs,
+    const LogicalPlan& probe, const LogicalPlan& build) {
+    auto cost = 0u;
+    cost += probe.getCost();
+    cost += build.getCost();
+    cost += probe.getCardinality();
+    cost += common::EnumeratorKnobs::BUILD_PENALTY * build.getCardinality();
+    return cost;
+}
+
+uint64_t CostModel::computeMarkJoinCost(const binder::expression_vector& joinNodeIDs,
+    const LogicalPlan& probe, const LogicalPlan& build) {
+    return computeHashJoinCost(joinNodeIDs, probe, build);
+}
+
+uint64_t CostModel::computeIntersectCost(const kuzu::planner::LogicalPlan& probePlan,
+    const std::vector<std::unique_ptr<LogicalPlan>>& buildPlans) {
+    auto cost = 0u;
+    cost += probePlan.getCost();
+    // TODO(Xiyang): think of how to calculate intersect cost such that it will be picked in worst
+    // case.
+    cost += probePlan.getCardinality();
+    for (auto& buildPlan : buildPlans) {
+        cost += buildPlan->getCost();
+    }
+    return cost;
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/test/runner/e2e_update_node_test.cpp
+++ b/test/runner/e2e_update_node_test.cpp
@@ -273,7 +273,6 @@ TEST_F(TinySnbUpdateTest, InsertRepeatedNToNRelTest) {
 TEST_F(TinySnbUpdateTest, InsertMixedRelTest) {
     conn->query(
         "MATCH (a:person), (b:person), (c:organisation) WHERE a.ID = 0 AND b.ID = 9 AND c.ID = 4 "
-        "MATCH (a:person), (b:person), (c:organisation) WHERE a.ID = 0 AND b.ID = 9 AND c.ID = 4 "
         "CREATE (b)-[:studyAt]->(c), (a)<-[:knows]-(b)");
     auto groundTruth = std::vector<std::string>{"9"};
     auto result = conn->query(


### PR DESCRIPTION
This PR introduces basic cardinality estimator, for primary-foreign key join we simply use the following equation
```
|LEFT| * |RIGHT| / domain(primary key)
```
This equation should be widely applicable to joins between node and rel.

For predicate cardinality estimation we rely on magic numbers. All cardinality estimations are based on factorized tuples.

For cost model, we simply use the sum of all intermediate result size.