### PR TITLE
Populate by column

### DIFF
--- a/src/include/storage/copier/node_copier.h
+++ b/src/include/storage/copier/node_copier.h
@@ -8,20 +8,19 @@
 namespace kuzu {
 namespace storage {
 
+using set_element_func_t = std::function<void(NodeInMemColumn* column,
+    InMemColumnChunk* columnChunk, common::offset_t nodeOffset, const std::string& data)>;
+
 class NodeCopier : public TableCopier {
 
 public:
     NodeCopier(common::CopyDescription& copyDescription, std::string outputDirectory,
         common::TaskScheduler& taskScheduler, catalog::Catalog& catalog, common::table_id_t tableID,
         NodesStatisticsAndDeletedIDs* nodesStatisticsAndDeletedIDs)
-        : TableCopier{copyDescription, std::move(outputDirectory), taskScheduler, catalog, tableID},
-          nodesStatisticsAndDeletedIDs{nodesStatisticsAndDeletedIDs} {}
+        : TableCopier{copyDescription, std::move(outputDirectory), taskScheduler, catalog, tableID,
+              nodesStatisticsAndDeletedIDs} {}
 
 protected:
-    inline void updateTableStatistics() override {
-        nodesStatisticsAndDeletedIDs->setNumTuplesForTable(tableSchema->tableID, numRows);
-    }
-
     void initializeColumnsAndLists() override;
 
     void populateColumnsAndLists() override;
@@ -46,13 +45,10 @@ private:
     arrow::Status populateColumnsFromParquet(std::unique_ptr<HashIndexBuilder<T>>& pkIndex);
 
     template<typename T>
-    static void putPropsOfLineIntoColumns(
-        std::unordered_map<uint64_t, std::unique_ptr<InMemColumnChunk>>& chunks,
-        std::unordered_map<common::property_id_t, std::unique_ptr<NodeInMemColumn>>&
-            propertyColumns,
-        std::vector<PageByteCursor>& overflowCursors,
-        const std::vector<std::shared_ptr<T>>& arrow_columns, common::offset_t nodeOffset,
-        uint64_t blockOffset, common::CopyDescription& copyDescription);
+    static void putPropsOfLinesIntoColumns(InMemColumnChunk* columnChunk, NodeInMemColumn* column,
+        std::shared_ptr<T> arrowArray, common::offset_t startNodeOffset,
+        uint64_t numLinesInCurBlock, common::CopyDescription& copyDescription,
+        PageByteCursor& overflowCursor);
 
     // Concurrent tasks.
     // Note that primaryKeyPropertyIdx is *NOT* the property ID of the primary key property.
@@ -77,8 +73,52 @@ private:
         assert(false);
     }
 
-private:
-    NodesStatisticsAndDeletedIDs* nodesStatisticsAndDeletedIDs;
+    static set_element_func_t getSetElementFunc(common::DataTypeID typeID,
+        common::CopyDescription& copyDescription, PageByteCursor& pageByteCursor);
+
+    template<typename T>
+    inline static void setNumericElement(NodeInMemColumn* column, InMemColumnChunk* columnChunk,
+        common::offset_t nodeOffset, const std::string& data) {
+        auto val = common::TypeUtils::convertStringToNumber<T>(data.c_str());
+        column->setElementInChunk(columnChunk, nodeOffset, reinterpret_cast<const uint8_t*>(&val));
+    }
+
+    inline static void setBoolElement(NodeInMemColumn* column, InMemColumnChunk* columnChunk,
+        common::offset_t nodeOffset, const std::string& data) {
+        auto val = common::TypeUtils::convertToBoolean(data.c_str());
+        column->setElementInChunk(columnChunk, nodeOffset, reinterpret_cast<const uint8_t*>(&val));
+    }
+
+    template<typename T>
+    inline static void setTimeElement(NodeInMemColumn* column, InMemColumnChunk* columnChunk,
+        common::offset_t nodeOffset, const std::string& data) {
+        auto val = T::FromCString(data.c_str(), data.length());
+        column->setElementInChunk(columnChunk, nodeOffset, reinterpret_cast<const uint8_t*>(&val));
+    }
+
+    inline static void setStringElement(NodeInMemColumn* column, InMemColumnChunk* columnChunk,
+        common::offset_t nodeOffset, const std::string& data, PageByteCursor& overflowCursor) {
+        auto val = column->getInMemOverflowFile()->copyString(
+            data.substr(0, common::BufferPoolConstants::PAGE_4KB_SIZE).c_str(), overflowCursor);
+        column->setElementInChunk(columnChunk, nodeOffset, reinterpret_cast<uint8_t*>(&val));
+    }
+
+    inline static void setVarListElement(NodeInMemColumn* column, InMemColumnChunk* columnChunk,
+        common::offset_t nodeOffset, const std::string& data,
+        common::CopyDescription& copyDescription, PageByteCursor& overflowCursor) {
+        auto varListVal =
+            getArrowVarList(data, 1, data.length() - 2, column->getDataType(), copyDescription);
+        auto kuList = column->getInMemOverflowFile()->copyList(*varListVal, overflowCursor);
+        column->setElementInChunk(columnChunk, nodeOffset, reinterpret_cast<uint8_t*>(&kuList));
+    }
+
+    inline static void setFixedListElement(NodeInMemColumn* column, InMemColumnChunk* columnChunk,
+        common::offset_t nodeOffset, const std::string& data,
+        common::CopyDescription& copyDescription) {
+        auto fixedListVal =
+            getArrowFixedList(data, 1, data.length() - 2, column->getDataType(), copyDescription);
+        column->setElementInChunk(columnChunk, nodeOffset, fixedListVal.get());
+    }
 };
 
 } // namespace storage

--- a/src/include/storage/copier/rel_copier.h
+++ b/src/include/storage/copier/rel_copier.h
@@ -22,10 +22,6 @@ public:
 private:
     static std::string getTaskTypeName(PopulateTaskType populateTaskType);
 
-    inline void updateTableStatistics() override {
-        relsStatistics->setNumRelsForTable(tableSchema->tableID, numRows);
-    }
-
     void initializeColumnsAndLists() override;
 
     void populateColumnsAndLists() override;
@@ -145,7 +141,6 @@ private:
 
 private:
     const std::map<common::table_id_t, common::offset_t> maxNodeOffsetsPerTable;
-    RelsStatistics* relsStatistics;
     std::unique_ptr<transaction::Transaction> dummyReadOnlyTrx;
     std::map<common::table_id_t, std::unique_ptr<PrimaryKeyIndex>> pkIndexes;
     std::atomic<uint64_t> numRels = 0;

--- a/src/include/storage/store/nodes_statistics_and_deleted_ids.h
+++ b/src/include/storage/store/nodes_statistics_and_deleted_ids.h
@@ -108,7 +108,7 @@ public:
             directory, common::DBFileType::ORIGINAL, transaction::TransactionType::READ_ONLY);
     }
 
-    inline void setNumTuplesForTable(common::table_id_t tableID, uint64_t numTuples) {
+    inline void setNumTuplesForTable(common::table_id_t tableID, uint64_t numTuples) override {
         initTableStatisticPerTableForWriteTrxIfNecessary();
         ((NodeStatisticsAndDeletedIDs*)tablesStatisticsContentForWriteTrx
                 ->tableStatisticPerTable[tableID]

--- a/src/include/storage/store/rels_statistics.h
+++ b/src/include/storage/store/rels_statistics.h
@@ -52,7 +52,7 @@ public:
         return (RelStatistics*)tableStatisticPerTable[tableID].get();
     }
 
-    void setNumRelsForTable(common::table_id_t relTableID, uint64_t numRels);
+    void setNumTuplesForTable(common::table_id_t relTableID, uint64_t numRels) override;
 
     void updateNumRelsByValue(common::table_id_t relTableID, int64_t value);
 

--- a/src/include/storage/store/table_statistics.h
+++ b/src/include/storage/store/table_statistics.h
@@ -50,6 +50,8 @@ public:
 
     virtual ~TablesStatistics() = default;
 
+    virtual void setNumTuplesForTable(common::table_id_t tableID, uint64_t numTuples) = 0;
+
     inline void writeTablesStatisticsFileForWALRecord(const std::string& directory) {
         saveToFile(directory, common::DBFileType::WAL_VERSION, transaction::TransactionType::WRITE);
     }

--- a/src/storage/copier/rel_copier.cpp
+++ b/src/storage/copier/rel_copier.cpp
@@ -14,9 +14,9 @@ RelCopier::RelCopier(CopyDescription& copyDescription, std::string outputDirecto
     TaskScheduler& taskScheduler, Catalog& catalog,
     std::map<table_id_t, offset_t> maxNodeOffsetsPerNodeTable, BufferManager* bufferManager,
     table_id_t tableID, RelsStatistics* relsStatistics)
-    : TableCopier{copyDescription, std::move(outputDirectory), taskScheduler, catalog, tableID},
-      maxNodeOffsetsPerTable{std::move(maxNodeOffsetsPerNodeTable)}, relsStatistics{
-                                                                         relsStatistics} {
+    : TableCopier{copyDescription, std::move(outputDirectory), taskScheduler, catalog, tableID,
+          relsStatistics},
+      maxNodeOffsetsPerTable{std::move(maxNodeOffsetsPerNodeTable)} {
     dummyReadOnlyTrx = Transaction::getDummyReadOnlyTrx();
     auto relTableSchema = reinterpret_cast<RelTableSchema*>(tableSchema);
     initializePkIndexes(relTableSchema->srcTableID, *bufferManager);

--- a/src/storage/store/rels_statistics.cpp
+++ b/src/storage/store/rels_statistics.cpp
@@ -6,7 +6,7 @@ namespace kuzu {
 namespace storage {
 
 // We should only call this function after we call setNumRelsPerDirectionBoundTableID.
-void RelsStatistics::setNumRelsForTable(table_id_t relTableID, uint64_t numRels) {
+void RelsStatistics::setNumTuplesForTable(table_id_t relTableID, uint64_t numRels) {
     lock_t lck{mtx};
     initTableStatisticPerTableForWriteTrxIfNecessary();
     assert(tablesStatisticsContentForWriteTrx->tableStatisticPerTable.contains(relTableID));


### PR DESCRIPTION
This PR refactors the logic of populating inMemColumn while loading a node table. Instead of populating a row at a time, we populate a column at a time.