### PR TITLE
Fix copy invalid filepath

### DIFF
--- a/src/binder/bind/bind_copy.cpp
+++ b/src/binder/bind/bind_copy.cpp
@@ -40,6 +40,10 @@ std::vector<std::string> Binder::bindFilePaths(const std::vector<std::string>& f
     std::vector<std::string> boundFilePaths;
     for (auto& filePath : filePaths) {
         auto globbedFilePaths = FileUtils::globFilePath(filePath);
+        if (globbedFilePaths.empty()) {
+            throw BinderException{StringUtils::string_format(
+                "No file found that matches the pattern: {}.", filePath)};
+        }
         boundFilePaths.insert(
             boundFilePaths.end(), globbedFilePaths.begin(), globbedFilePaths.end());
     }

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -343,3 +343,11 @@ TEST_F(CopyMultipleFilesTest, CopyFilesWithWildcardPattern) {
             ->isSuccess());
     validateKnowsTableAfterCopying();
 }
+
+TEST_F(CopyMultipleFilesTest, CopyFilesWithWrongPath) {
+    auto result = conn->query(StringUtils::string_format(R"(COPY person FROM ["1.csv", "{}"])",
+        TestHelper::appendKuzuRootPath("dataset/copy-multiple-files-test/vPerson?.csv")));
+    ASSERT_FALSE(result->isSuccess());
+    ASSERT_EQ(result->getErrorMessage(),
+        "Binder exception: No file found that matches the pattern: 1.csv.");
+}


### PR DESCRIPTION
When copying files to node/rel tables, if the given filepath is invalid we should throw an exception.