### PR TITLE
Add storage version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(Kuzu VERSION 0.0.3.1 LANGUAGES CXX)
+project(Kuzu VERSION 0.0.3 LANGUAGES CXX)
 
 find_package(Threads REQUIRED)
 
@@ -78,6 +78,7 @@ function(add_kuzu_test TEST_NAME)
 endfunction()
 
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
+add_definitions(-DKUZU_STORAGE_VERSION="${CMAKE_PROJECT_VERSION}")
 
 set(ARROW_INSTALL ${CMAKE_CURRENT_SOURCE_DIR}/external/build/arrow/install)
 find_library(ARROW_DEPS_PATH arrow_bundled_dependencies HINTS ${ARROW_INSTALL}/lib ${ARROW_INSTALL}/lib64)

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -11,6 +11,7 @@
 #include "common/utils.h"
 #include "function/aggregate/built_in_aggregate_functions.h"
 #include "function/built_in_vector_operations.h"
+#include "storage/storage_info.h"
 #include "storage/wal/wal.h"
 
 namespace spdlog {
@@ -132,6 +133,12 @@ public:
 
 private:
     inline common::table_id_t assignNextTableID() { return nextTableID++; }
+
+    void validateStorageVersion(storage::storage_version_t savedStorageVersion) const;
+
+    void validateMagicBytes(common::FileInfo* fileInfo, common::offset_t& offset) const;
+
+    void writeMagicBytes(common::FileInfo* fileInfo, common::offset_t& offset) const;
 
 private:
     std::shared_ptr<spdlog::logger> logger;

--- a/src/include/storage/storage_info.h
+++ b/src/include/storage/storage_info.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "exception"
+#include <string>
+
+#include "common/utils.h"
+
+namespace kuzu {
+namespace storage {
+
+using storage_version_t = uint64_t;
+
+struct StorageVersionInfo {
+    static std::unordered_map<std::string, storage_version_t> getStorageVersionInfo() {
+        return {{"0.0.3", 1}};
+    }
+
+    static storage_version_t getStorageVersion() {
+        auto storageVersionInfo = getStorageVersionInfo();
+        if (!storageVersionInfo.contains(KUZU_STORAGE_VERSION)) {
+            throw common::RuntimeException(common::StringUtils::string_format(
+                "Invalid storage version name: {}", KUZU_STORAGE_VERSION));
+        }
+        return storageVersionInfo.at(KUZU_STORAGE_VERSION);
+    }
+
+    static constexpr const char* MAGIC_BYTES = "KUZU";
+};
+
+} // namespace storage
+} // namespace kuzu


### PR DESCRIPTION
# Implement storage version info
1. When starting database, the catalog will check whether the storage version number stored in the file matches the one in the current build. If not, an exception will be thrown.
2. When writing catalog to disk, we also save the storage version number to the header of the catalog file.