### PR TITLE
Fix copy options case

### DIFF
--- a/dataset/tinysnb/copy.cypher
+++ b/dataset/tinysnb/copy.cypher
@@ -1,8 +1,8 @@
-COPY person FROM "dataset/tinysnb/vPerson.csv" (HEADER=true);
+COPY person FROM "dataset/tinysnb/vPerson.csv" (HeaDER=true, deLim=',');
 COPY organisation FROM "dataset/tinysnb/vOrganisation.csv";
 COPY movies FROM "dataset/tinysnb/vMovies.csv";
 COPY knows FROM "dataset/tinysnb/eKnows.csv";
-COPY studyAt FROM "dataset/tinysnb/eStudyAt.csv" (HEADER=true);
+COPY studyAt FROM "dataset/tinysnb/eStudyAt.csv" (HEADeR=true);
 COPY workAt FROM "dataset/tinysnb/eWorkAt.csv"
 COPY meets FROM "dataset/tinysnb/eMeets.csv"
 COPY marries FROM "dataset/tinysnb/eMarries.csv"

--- a/src/binder/bind/bind_copy.cpp
+++ b/src/binder/bind/bind_copy.cpp
@@ -76,6 +76,7 @@ CSVReaderConfig Binder::bindParsingOptions(
     CSVReaderConfig csvReaderConfig;
     for (auto& parsingOption : *parsingOptions) {
         auto copyOptionName = parsingOption.first;
+        StringUtils::toUpper(copyOptionName);
         bool isValidStringParsingOption = validateStringParsingOptionName(copyOptionName);
         auto copyOptionExpression = parsingOption.second.get();
         auto boundCopyOptionExpression = expressionBinder.bindExpression(*copyOptionExpression);

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -229,7 +229,7 @@ std::string Connection::getNodePropertyNames(const std::string& tableName) {
     lock_t lck{mtx};
     auto catalog = database->catalog.get();
     if (!catalog->getReadOnlyVersion()->containNodeTable(tableName)) {
-        throw Exception("Cannot find node table " + tableName);
+        throw RuntimeException("Cannot find node table " + tableName);
     }
     std::string result = tableName + " properties: \n";
     auto tableID = catalog->getReadOnlyVersion()->getTableID(tableName);
@@ -246,7 +246,7 @@ std::string Connection::getRelPropertyNames(const std::string& relTableName) {
     lock_t lck{mtx};
     auto catalog = database->catalog.get();
     if (!catalog->getReadOnlyVersion()->containRelTable(relTableName)) {
-        throw Exception("Cannot find rel table " + relTableName);
+        throw RuntimeException("Cannot find rel table " + relTableName);
     }
     auto relTableID = catalog->getReadOnlyVersion()->getTableID(relTableName);
     auto srcTableID =

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -296,7 +296,7 @@ TEST_F(BinderErrorTest, CreateNodeTableDuplicatedColumnName) {
 }
 
 TEST_F(BinderErrorTest, CopyCSVInvalidParsingOption) {
-    std::string expectedException = "Binder exception: Unrecognized parsing csv option: pk.";
+    std::string expectedException = "Binder exception: Unrecognized parsing csv option: PK.";
     auto input = R"(COPY person FROM "person_0_0.csv" (pk=","))";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }


### PR DESCRIPTION
Ignores the case of COPY options. (escapeChar/delimiter/quoteChar/listBeginChar/listEndChar) both upper case and lower case are allowed. #1446 