### PR TITLE
Fix set number threads

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -279,6 +279,7 @@ void EmbeddedShell::setNumThreads(const std::string& numThreadsString) {
     } catch (std::exception& e) {
         printf(
             "Cannot parse '%s' as number of threads. Expect integer.\n", numThreadsString.c_str());
+        return;
     }
     try {
         conn->setMaxNumThreadForExec(numThreads);


### PR DESCRIPTION
If an exception occurs while parsing the number of threads in the shell, we should return after printing out the error message.