### PR TITLE
Rework hashjoin

### DIFF
--- a/src/include/planner/logical_plan/logical_operator/logical_hash_join.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_hash_join.h
@@ -59,7 +59,6 @@ public:
             joinNodeIDs, joinType, mark, children[0]->copy(), children[1]->copy());
     }
 
-private:
     // Flat probe side key group in either of the following two cases:
     // 1. there are multiple join nodes;
     // 2. if the build side contains more than one group or the build side has projected out data
@@ -69,6 +68,7 @@ private:
     // flattening probe key, instead duplicating keys as in vectorized processing if necessary.
     bool requireFlatProbeKeys();
 
+private:
     bool isJoinKeyUniqueOnBuildSide(const binder::Expression& joinNodeID);
 
 private:

--- a/src/processor/mapper/map_hash_join.cpp
+++ b/src/processor/mapper/map_hash_join.cpp
@@ -77,8 +77,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalHashJoinToPhysical(
         probeDataInfo.markDataPos = markOutputPos;
     }
     auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState, hashJoin->getJoinType(),
-        probeDataInfo, std::move(probeSidePrevOperator), std::move(hashJoinBuild), getOperatorID(),
-        paramsString);
+        hashJoin->requireFlatProbeKeys(), probeDataInfo, std::move(probeSidePrevOperator),
+        std::move(hashJoinBuild), getOperatorID(), paramsString);
     if (hashJoin->getSIP() == planner::SidewaysInfoPassing::PROBE_TO_BUILD) {
         mapAccHashJoin(hashJoinProbe.get());
     }


### PR DESCRIPTION
This PR separates HJ implementation into 2 cases

- we probe for a batch if we know each key has at most one match
- we probe one tuple at a time and also ship one tuple at a time in the general case