### PR TITLE
Struct planning

### DIFF
--- a/src/binder/bind_expression/bind_boolean_expression.cpp
+++ b/src/binder/bind_expression/bind_boolean_expression.cpp
@@ -28,9 +28,10 @@ std::shared_ptr<Expression> ExpressionBinder::bindBooleanExpression(
         function::VectorBooleanOperations::bindExecFunction(expressionType, childrenAfterCast);
     auto selectFunc =
         function::VectorBooleanOperations::bindSelectFunction(expressionType, childrenAfterCast);
+    auto bindData = std::make_unique<function::FunctionBindData>(DataType(BOOL));
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(functionName, childrenAfterCast);
-    return make_shared<ScalarFunctionExpression>(functionName, expressionType, DataType(BOOL),
+    return make_shared<ScalarFunctionExpression>(functionName, expressionType, std::move(bindData),
         std::move(childrenAfterCast), std::move(execFunc), std::move(selectFunc),
         uniqueExpressionName);
 }

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -31,11 +31,13 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
         childrenAfterCast.push_back(
             implicitCastIfNecessary(children[i], function->parameterTypeIDs[i]));
     }
+    auto bindData =
+        std::make_unique<function::FunctionBindData>(common::DataType(function->returnTypeID));
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(function->name, childrenAfterCast);
-    return make_shared<ScalarFunctionExpression>(functionName, expressionType,
-        common::DataType(function->returnTypeID), std::move(childrenAfterCast), function->execFunc,
-        function->selectFunc, uniqueExpressionName);
+    return make_shared<ScalarFunctionExpression>(functionName, expressionType, std::move(bindData),
+        std::move(childrenAfterCast), function->execFunc, function->selectFunc,
+        uniqueExpressionName);
 }
 
 } // namespace binder

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -35,17 +35,24 @@ std::shared_ptr<Expression> ExpressionBinder::bindFunctionExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     const ParsedExpression& parsedExpression, const std::string& functionName) {
-    auto builtInFunctions = binder->catalog.getBuiltInScalarFunctions();
-    std::vector<DataType> childrenTypes;
     expression_vector children;
     for (auto i = 0u; i < parsedExpression.getNumChildren(); ++i) {
         auto child = bindExpression(*parsedExpression.getChild(i));
-        childrenTypes.push_back(child->dataType);
         children.push_back(std::move(child));
+    }
+    return bindScalarFunctionExpression(children, functionName);
+}
+
+std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
+    const expression_vector& children, const std::string& functionName) {
+    auto builtInFunctions = binder->catalog.getBuiltInScalarFunctions();
+    std::vector<DataType> childrenTypes;
+    for (auto& child : children) {
+        childrenTypes.push_back(child->dataType);
     }
     auto function = builtInFunctions->matchFunction(functionName, childrenTypes);
     if (builtInFunctions->canApplyStaticEvaluation(functionName, children)) {
-        return staticEvaluate(functionName, parsedExpression, children);
+        return staticEvaluate(functionName, children);
     }
     expression_vector childrenAfterCast;
     for (auto i = 0u; i < children.size(); ++i) {
@@ -53,15 +60,15 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
             function->isVarLength ? function->parameterTypeIDs[0] : function->parameterTypeIDs[i];
         childrenAfterCast.push_back(implicitCastIfNecessary(children[i], targetType));
     }
-    DataType returnType;
+    std::unique_ptr<function::FunctionBindData> bindData;
     if (function->bindFunc) {
-        function->bindFunc(childrenAfterCast, function, returnType);
+        bindData = function->bindFunc(childrenAfterCast, function);
     } else {
-        returnType = DataType(function->returnTypeID);
+        bindData = std::make_unique<function::FunctionBindData>(DataType(function->returnTypeID));
     }
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(function->name, childrenAfterCast);
-    return make_shared<ScalarFunctionExpression>(functionName, FUNCTION, returnType,
+    return make_shared<ScalarFunctionExpression>(functionName, FUNCTION, std::move(bindData),
         std::move(childrenAfterCast), function->execFunc, function->selectFunc,
         uniqueExpressionName);
 }
@@ -87,18 +94,18 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
     if (children.empty()) {
         uniqueExpressionName = binder->getUniqueExpressionName(uniqueExpressionName);
     }
-    DataType returnType;
+    std::unique_ptr<function::FunctionBindData> bindData;
     if (function->bindFunc) {
-        function->bindFunc(children, function, returnType);
+        bindData = function->bindFunc(children, function);
     } else {
-        returnType = DataType(function->returnTypeID);
+        bindData = std::make_unique<function::FunctionBindData>(DataType(function->returnTypeID));
     }
-    return make_shared<AggregateFunctionExpression>(functionName, returnType, std::move(children),
-        function->aggregateFunction->clone(), uniqueExpressionName);
+    return make_shared<AggregateFunctionExpression>(functionName, std::move(bindData),
+        std::move(children), function->aggregateFunction->clone(), uniqueExpressionName);
 }
 
-std::shared_ptr<Expression> ExpressionBinder::staticEvaluate(const std::string& functionName,
-    const ParsedExpression& parsedExpression, const expression_vector& children) {
+std::shared_ptr<Expression> ExpressionBinder::staticEvaluate(
+    const std::string& functionName, const expression_vector& children) {
     assert(children[0]->expressionType == common::LITERAL);
     auto strVal = ((LiteralExpression*)children[0].get())->getValue()->getValue<std::string>();
     std::unique_ptr<Value> value;
@@ -187,8 +194,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindNodeLabelFunction(const Expres
             populateLabelValues(nodeTableIDs, *catalogContent));
     children.push_back(createLiteralExpression(std::move(labelsValue)));
     auto execFunc = function::LabelVectorOperation::execFunction;
+    auto bindData = std::make_unique<function::FunctionBindData>(DataType(STRING));
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(LABEL_FUNC_NAME, children);
-    return make_shared<ScalarFunctionExpression>(LABEL_FUNC_NAME, FUNCTION, DataType(STRING),
+    return make_shared<ScalarFunctionExpression>(LABEL_FUNC_NAME, FUNCTION, std::move(bindData),
         std::move(children), execFunc, nullptr, uniqueExpressionName);
 }
 
@@ -207,8 +215,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindRelLabelFunction(const Express
             populateLabelValues(relTableIDs, *catalogContent));
     children.push_back(createLiteralExpression(std::move(labelsValue)));
     auto execFunc = function::LabelVectorOperation::execFunction;
+    auto bindData = std::make_unique<function::FunctionBindData>(DataType(STRING));
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(LABEL_FUNC_NAME, children);
-    return make_shared<ScalarFunctionExpression>(LABEL_FUNC_NAME, FUNCTION, DataType(STRING),
+    return make_shared<ScalarFunctionExpression>(LABEL_FUNC_NAME, FUNCTION, std::move(bindData),
         std::move(children), execFunc, nullptr, uniqueExpressionName);
 }
 

--- a/src/binder/bind_expression/bind_null_operator_expression.cpp
+++ b/src/binder/bind_expression/bind_null_operator_expression.cpp
@@ -17,10 +17,10 @@ std::shared_ptr<Expression> ExpressionBinder::bindNullOperatorExpression(
     auto functionName = expressionTypeToString(expressionType);
     auto execFunc = function::VectorNullOperations::bindExecFunction(expressionType, children);
     auto selectFunc = function::VectorNullOperations::bindSelectFunction(expressionType, children);
+    auto bindData = std::make_unique<function::FunctionBindData>(common::DataType(common::BOOL));
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(functionName, children);
-    return make_shared<ScalarFunctionExpression>(functionName, expressionType,
-        common::DataType(common::BOOL), std::move(children), std::move(execFunc),
-        std::move(selectFunc), uniqueExpressionName);
+    return make_shared<ScalarFunctionExpression>(functionName, expressionType, std::move(bindData),
+        std::move(children), std::move(execFunc), std::move(selectFunc), uniqueExpressionName);
 }
 
 } // namespace binder

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -85,9 +85,10 @@ std::shared_ptr<Expression> ExpressionBinder::implicitCast(
     if (VectorCastOperations::hasImplicitCast(expression->dataType, targetType)) {
         auto functionName = VectorCastOperations::bindImplicitCastFuncName(targetType);
         auto children = expression_vector{expression};
+        auto bindData = std::make_unique<FunctionBindData>(targetType);
         auto uniqueName = ScalarFunctionExpression::getUniqueName(functionName, children);
         return std::make_shared<ScalarFunctionExpression>(functionName, FUNCTION,
-            DataType{targetType.typeID}, std::move(children),
+            std::move(bindData), std::move(children),
             VectorCastOperations::bindImplicitCastFunc(
                 expression->dataType.typeID, targetType.typeID),
             nullptr /* selectFunc */, std::move(uniqueName));

--- a/src/function/built_in_vector_operations.cpp
+++ b/src/function/built_in_vector_operations.cpp
@@ -447,11 +447,9 @@ void BuiltInVectorOperations::registerInternalIDOperation() {
 }
 
 void BuiltInVectorOperations::registerStructOperation() {
-    std::vector<std::unique_ptr<VectorOperationDefinition>> definitions;
-    definitions.push_back(make_unique<VectorOperationDefinition>(STRUCT_PACK_FUNC_NAME,
-        std::vector<DataTypeID>{ANY}, STRUCT, VectorStructOperations::StructPack, nullptr,
-        StructPackVectorOperations::structPackBindFunc, true /* isVarLength */));
-    vectorOperations.insert({STRUCT_PACK_FUNC_NAME, std::move(definitions)});
+    vectorOperations.insert({STRUCT_PACK_FUNC_NAME, StructPackVectorOperations::getDefinitions()});
+    vectorOperations.insert(
+        {STRUCT_EXTRACT_FUNC_NAME, StructExtractVectorOperations::getDefinitions()});
 }
 
 } // namespace function

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -46,12 +46,14 @@ private:
         const parser::ParsedExpression& parsedExpression);
     std::shared_ptr<Expression> bindScalarFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName);
+    std::shared_ptr<Expression> bindScalarFunctionExpression(
+        const expression_vector& children, const std::string& functionName);
     std::shared_ptr<Expression> bindAggregateFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName,
         bool isDistinct);
 
-    std::shared_ptr<Expression> staticEvaluate(const std::string& functionName,
-        const parser::ParsedExpression& parsedExpression, const expression_vector& children);
+    std::shared_ptr<Expression> staticEvaluate(
+        const std::string& functionName, const expression_vector& children);
 
     std::shared_ptr<Expression> bindInternalIDExpression(
         const parser::ParsedExpression& parsedExpression);

--- a/src/include/common/expression_type.h
+++ b/src/include/common/expression_type.h
@@ -58,6 +58,7 @@ const std::string ARRAY_SLICE_FUNC_NAME = "ARRAY_SLICE";
 
 // struct
 const std::string STRUCT_PACK_FUNC_NAME = "STRUCT_PACK";
+const std::string STRUCT_EXTRACT_FUNC_NAME = "STRUCT_EXTRACT";
 
 // comparison
 const std::string EQUALS_FUNC_NAME = "EQUALS";

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -136,13 +136,15 @@ public:
     explicit StructTypeInfo(std::vector<std::unique_ptr<StructField>> fields)
         : fields{std::move(fields)} {}
     StructTypeInfo() = default;
+
     inline void addChildType(const std::string& name, const DataType& type) {
         fields.emplace_back(std::make_unique<StructField>(name, std::make_unique<DataType>(type)));
     }
-    bool operator==(const kuzu::common::StructTypeInfo& other) const;
-    std::unique_ptr<ExtraTypeInfo> copy() const override;
     std::vector<DataType*> getChildrenTypes() const;
     std::vector<std::string> getChildrenNames() const;
+
+    bool operator==(const kuzu::common::StructTypeInfo& other) const;
+    std::unique_ptr<ExtraTypeInfo> copy() const override;
 
 private:
     std::vector<std::unique_ptr<StructField>> fields;

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -69,11 +69,13 @@ public:
     }
 
     inline void addChildVector(std::shared_ptr<ValueVector> valueVector) {
-        childrenVectors.emplace_back(valueVector);
+        childrenVectors.emplace_back(std::move(valueVector));
     }
-
-    inline std::vector<std::shared_ptr<ValueVector>> getChildrenVectors() const {
+    inline const std::vector<std::shared_ptr<ValueVector>>& getChildrenVectors() const {
         return childrenVectors;
+    }
+    inline std::shared_ptr<ValueVector> getChildVector(vector_idx_t idx) const {
+        return childrenVectors[idx];
     }
 
 private:

--- a/src/include/function/aggregate/collect.h
+++ b/src/include/function/aggregate/collect.h
@@ -122,13 +122,14 @@ struct CollectFunction {
 
     static void finalize(uint8_t* state_) {}
 
-    static void bindFunc(const binder::expression_vector& argumentTypes,
-        FunctionDefinition* definition, common::DataType& returnType) {
-        assert(argumentTypes.size() == 1);
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition) {
+        assert(arguments.size() == 1);
         auto aggFuncDefinition = reinterpret_cast<AggregateFunctionDefinition*>(definition);
-        aggFuncDefinition->aggregateFunction->setInputDataType(argumentTypes[0]->dataType);
-        returnType = common::DataType(
-            common::VAR_LIST, std::make_unique<common::DataType>(argumentTypes[0]->dataType));
+        aggFuncDefinition->aggregateFunction->setInputDataType(arguments[0]->dataType);
+        auto returnType = common::DataType(
+            common::VAR_LIST, std::make_unique<common::DataType>(arguments[0]->dataType));
+        return std::make_unique<FunctionBindData>(returnType);
     }
 };
 

--- a/src/include/function/function_definition.h
+++ b/src/include/function/function_definition.h
@@ -6,14 +6,18 @@
 namespace kuzu {
 namespace function {
 
-// Forward declaration of FunctionDefinition.
+struct FunctionBindData {
+    common::DataType resultType;
+
+    explicit FunctionBindData(common::DataType dataType) : resultType{std::move(dataType)} {}
+};
+
 struct FunctionDefinition;
 
-using scalar_bind_func =
-    std::function<void(const binder::expression_vector&, FunctionDefinition*, common::DataType&)>;
+using scalar_bind_func = std::function<std::unique_ptr<FunctionBindData>(
+    const binder::expression_vector&, FunctionDefinition* definition)>;
 
 struct FunctionDefinition {
-
     FunctionDefinition(std::string name, std::vector<common::DataTypeID> parameterTypeIDs,
         common::DataTypeID returnTypeID)
         : name{std::move(name)}, parameterTypeIDs{std::move(parameterTypeIDs)}, returnTypeID{

--- a/src/include/function/list/vector_list_operations.h
+++ b/src/include/function/list/vector_list_operations.h
@@ -34,9 +34,6 @@ struct VectorListOperations : public VectorOperations {
             *params[0], *params[1], result);
     }
 
-    static void ListCreation(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
-        common::ValueVector& result);
-
     template<typename OPERATION, typename RESULT_TYPE>
     static std::vector<std::unique_ptr<VectorOperationDefinition>>
     getBinaryListOperationDefinitions(std::string funcName, common::DataTypeID resultTypeID) {
@@ -92,8 +89,10 @@ struct VectorListOperations : public VectorOperations {
 
 struct ListCreationVectorOperation : public VectorListOperations {
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
-    static void listCreationBindFunc(const binder::expression_vector& argumentTypes,
-        FunctionDefinition* definition, common::DataType& actualReturnType);
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+    static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
+        common::ValueVector& result);
 };
 
 struct ListLenVectorOperation : public VectorListOperations {
@@ -102,24 +101,26 @@ struct ListLenVectorOperation : public VectorListOperations {
 
 struct ListExtractVectorOperation : public VectorListOperations {
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
-    static void listExtractBindFunc(const binder::expression_vector& argumentTypes,
-        FunctionDefinition* definition, common::DataType& returnType);
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
 };
 
 struct ListConcatVectorOperation : public VectorListOperations {
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
 };
 
 struct ListAppendVectorOperation : public VectorListOperations {
-    static void listAppendBindFunc(const binder::expression_vector& argumentTypes,
-        FunctionDefinition* definition, common::DataType& returnType);
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
 };
 
 struct ListPrependVectorOperation : public VectorListOperations {
-    static void listPrependBindFunc(const binder::expression_vector& argumentTypes,
-        FunctionDefinition* definition, common::DataType& returnType);
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
 };
 
 struct ListPositionVectorOperation : public VectorListOperations {
@@ -132,6 +133,8 @@ struct ListContainsVectorOperation : public VectorListOperations {
 
 struct ListSliceVectorOperation : public VectorListOperations {
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
 };
 
 } // namespace function

--- a/src/include/function/struct/vector_struct_operations.h
+++ b/src/include/function/struct/vector_struct_operations.h
@@ -5,14 +5,27 @@
 namespace kuzu {
 namespace function {
 
-struct VectorStructOperations : public VectorOperations {
-    static void StructPack(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
-        common::ValueVector& result);
+struct StructPackVectorOperations : public VectorOperations {
+    static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+    static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
+        common::ValueVector& result) {} // Evaluate at compile time
 };
 
-struct StructPackVectorOperations : public VectorStructOperations {
-    static void structPackBindFunc(const binder::expression_vector& arguments,
-        FunctionDefinition* definition, common::DataType& actualReturnType);
+struct StructExtractBindData : public FunctionBindData {
+    common::vector_idx_t childIdx;
+
+    StructExtractBindData(common::DataType dataType, common::vector_idx_t childIdx)
+        : FunctionBindData{std::move(dataType)}, childIdx{childIdx} {}
+};
+
+struct StructExtractVectorOperations : public VectorOperations {
+    static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+    static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& parameters,
+        common::ValueVector& result) {} // Evaluate at compile time
 };
 
 } // namespace function

--- a/src/include/processor/processor_task.h
+++ b/src/include/processor/processor_task.h
@@ -18,10 +18,6 @@ private:
     static std::unique_ptr<ResultSet> populateResultSet(
         Sink* op, storage::MemoryManager* memoryManager);
 
-    // TODO(Xiyang): Move this function to front end.
-    static void addStructFieldsVectors(common::ValueVector* structVector,
-        common::DataChunk* dataChunk, storage::MemoryManager* memoryManager);
-
 private:
     Sink* sink;
     ExecutionContext* executionContext;

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -18,6 +18,16 @@ void ProcessorTask::finalizeIfNecessary() {
     sink->finalize(executionContext);
 }
 
+static void addStructFieldsVectors(common::ValueVector* structVector, common::DataChunk* dataChunk,
+    storage::MemoryManager* memoryManager) {
+    auto structTypeInfo =
+        reinterpret_cast<common::StructTypeInfo*>(structVector->dataType.getExtraTypeInfo());
+    for (auto& childType : structTypeInfo->getChildrenTypes()) {
+        auto childVector = std::make_shared<common::ValueVector>(*childType, memoryManager);
+        structVector->addChildVector(childVector);
+    }
+}
+
 std::unique_ptr<ResultSet> ProcessorTask::populateResultSet(
     Sink* op, storage::MemoryManager* memoryManager) {
     auto resultSetDescriptor = op->getResultSetDescriptor();
@@ -46,17 +56,6 @@ std::unique_ptr<ResultSet> ProcessorTask::populateResultSet(
         resultSet->insert(i, std::move(dataChunk));
     }
     return resultSet;
-}
-
-void ProcessorTask::addStructFieldsVectors(common::ValueVector* structVector,
-    common::DataChunk* dataChunk, storage::MemoryManager* memoryManager) {
-    auto structTypeInfo =
-        reinterpret_cast<common::StructTypeInfo*>(structVector->dataType.getExtraTypeInfo());
-    for (auto& childType : structTypeInfo->getChildrenTypes()) {
-        auto childVector = std::make_shared<common::ValueVector>(*childType, memoryManager);
-        dataChunk->addValueVector(childVector);
-        structVector->addChildVector(childVector);
-    }
 }
 
 } // namespace processor

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -76,7 +76,7 @@ TEST_F(BinderErrorTest, BindVariableNotInScope2) {
 
 TEST_F(BinderErrorTest, BindPropertyLookUpOnExpression) {
     std::string expectedException =
-        "Binder exception: +(a.age,2) has data type INT64. (REL,NODE) was expected.";
+        "Binder exception: +(a.age,2) has data type INT64. (STRUCT,REL,NODE) was expected.";
     auto input = "MATCH (a:person)-[e1:knows]->(b:person) RETURN (a.age + 2).age;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
@@ -90,6 +90,12 @@ TEST_F(BinderErrorTest, BindPropertyNotExist) {
 TEST_F(BinderErrorTest, BindPropertyNotExist2) {
     std::string expectedException = "Binder exception: Cannot find property foo for a.";
     auto input = "Create (a:person {foo:'x'});";
+    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
+}
+
+TEST_F(BinderErrorTest, BindPropertyNotExist3) {
+    std::string expectedException = "Binder exception: Cannot find key b for struct_extract.";
+    auto input = "WITH {a: 1} AS s RETURN s.b;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -427,3 +427,8 @@ Dan|Carol
 -QUERY RETURN {weight: 1.8, age: 42, name: "Mark", grades: [1,2,3]}
 ---- 1
 {weight: 1.800000, age: 42, name: Mark, grades: [1,2,3]}
+
+-NAME ReturnStructLiteral2
+-QUERY WITH {a: '1', b: 2, c: [4,5,6]} AS st RETURN st.a, st.b * 5, (st.c)[1:3]
+---- 1
+1|10|[4,5]


### PR DESCRIPTION
- Add struct_extract function
- Bind struct.prop as struct_extract function
- Introduce FunctionBindData to holds function binding information
  - Always contains result type (in case need to resolve recursive result type e.g. list_extract)
  - For struct_extract functions, it further resolves string property access as idx access.
- Resolve struct_pack and struct_extract at compile time