### PR TITLE
Fix incorrect cast int16 func name

### DIFF
--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -513,7 +513,6 @@ ArrowArray ArrowRowBatch::append(main::QueryResult& queryResult, std::int64_t ch
             break;
         }
         auto tuple = queryResult.getNext();
-        std::vector<std::uint32_t> colWidths(numColumns, 10);
         for (auto i = 0u; i < numColumns; i++) {
             appendValue(vectors[i].get(), *typesInfo[i], tuple->getValue(i));
         }

--- a/src/function/vector_cast_operations.cpp
+++ b/src/function/vector_cast_operations.cpp
@@ -217,13 +217,13 @@ CastToInt16VectorOperation::getDefinitions() {
     std::vector<std::unique_ptr<VectorOperationDefinition>> result;
     // down cast
     result.push_back(bindVectorOperation<int32_t, int16_t, operation::CastToInt16>(
-        CAST_TO_INT32_FUNC_NAME, INT32, INT16));
+        CAST_TO_INT16_FUNC_NAME, INT32, INT16));
     result.push_back(bindVectorOperation<int64_t, int16_t, operation::CastToInt16>(
-        CAST_TO_INT32_FUNC_NAME, INT64, INT16));
+        CAST_TO_INT16_FUNC_NAME, INT64, INT16));
     result.push_back(bindVectorOperation<float_t, int16_t, operation::CastToInt16>(
-        CAST_TO_INT32_FUNC_NAME, FLOAT, INT16));
+        CAST_TO_INT16_FUNC_NAME, FLOAT, INT16));
     result.push_back(bindVectorOperation<double_t, int16_t, operation::CastToInt16>(
-        CAST_TO_INT32_FUNC_NAME, DOUBLE, INT16));
+        CAST_TO_INT16_FUNC_NAME, DOUBLE, INT16));
     return result;
 }
 


### PR DESCRIPTION
This incorrect naming leads to weird behaviours.
An example on tinysnb:
```
match (p:person) return to_int16(p.age), to_int32(p.age), p.age;
```
will produce wrong result for `to_int16(p.age)`.
@andyfengHKU or @acquamarin should take a further look.
I would propose to add a function validity check mechanism in catalog when we register any functions, so probably we can avoid this kind of mistakes later.