### PR TITLE
Add loader and storage support for struct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ __pycache__/
 *$py.class
 cmake-build-debug/
 test/unittest_temp/
+tools/python_api/test/test_PYTHON_CSV.csv
 
 # antlr4 jar
 scripts/antlr4/antlr4.jar

--- a/dataset/tinysnb/schema.cypher
+++ b/dataset/tinysnb/schema.cypher
@@ -1,6 +1,6 @@
 create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float, PRIMARY KEY (ID));
 create node table organisation (ID INT64, name STRING, orgCode INT64, mark DOUBLE, score INT64, history STRING, licenseValidInterval INTERVAL, rating DOUBLE, PRIMARY KEY (ID));
-create node table movies (name STRING, length INT32, note STRING, PRIMARY KEY (name));
+create node table movies (name STRING, length INT32, note STRING, description STRUCT(rating DOUBLE, views INT64, release TIMESTAMP, film DATE), PRIMARY KEY (name));
 create rel table knows (FROM person TO person, date DATE, meetTime TIMESTAMP, validInterval INTERVAL, comments STRING[], MANY_MANY);
 create rel table studyAt (FROM person TO organisation, year INT64, places STRING[], length INT16,MANY_ONE);
 create rel table workAt (FROM person TO organisation, year INT64, grading DOUBLE[2], rating float, MANY_ONE);

--- a/dataset/tinysnb/vMovies.csv
+++ b/dataset/tinysnb/vMovies.csv
@@ -1,3 +1,3 @@
-Sóló cón tu párejâ,126, this is a very very good movie
-The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie,2544, the movie is very very good
-Roma,298,the movie is very interesting and funny
+Sóló cón tu párejâ,126, this is a very very good movie,"{rating: 5.3, views: 152, release: 2011-08-20 11:25:30, film: 2012-05-11}"
+The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie,2544, the movie is very very good,"{rating: 7, views: 982, release: 2018-11-13 13:33:11, film: 2014-09-12}"
+Roma,298,the movie is very interesting and funny,"{rating: 1223, views: 10003, release: 2011-02-11 16:44:22, film: 2013-02-22}"

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -189,9 +189,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindNodeLabelFunction(const Expres
     auto nodeTableIDs = catalogContent->getNodeTableIDs();
     expression_vector children;
     children.push_back(node.getInternalIDProperty());
-    auto labelsValue =
-        std::make_unique<Value>(DataType(VAR_LIST, std::make_unique<DataType>(STRING)),
-            populateLabelValues(nodeTableIDs, *catalogContent));
+    auto labelsValue = std::make_unique<Value>(DataType(std::make_unique<DataType>(STRING)),
+        populateLabelValues(nodeTableIDs, *catalogContent));
     children.push_back(createLiteralExpression(std::move(labelsValue)));
     auto execFunc = function::LabelVectorOperation::execFunction;
     auto bindData = std::make_unique<function::FunctionBindData>(DataType(STRING));
@@ -210,9 +209,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindRelLabelFunction(const Express
     auto relTableIDs = catalogContent->getRelTableIDs();
     expression_vector children;
     children.push_back(rel.getInternalIDProperty());
-    auto labelsValue =
-        std::make_unique<Value>(DataType(VAR_LIST, std::make_unique<DataType>(STRING)),
-            populateLabelValues(relTableIDs, *catalogContent));
+    auto labelsValue = std::make_unique<Value>(DataType(std::make_unique<DataType>(STRING)),
+        populateLabelValues(relTableIDs, *catalogContent));
     children.push_back(createLiteralExpression(std::move(labelsValue)));
     auto execFunc = function::LabelVectorOperation::execFunction;
     auto bindData = std::make_unique<function::FunctionBindData>(DataType(STRING));

--- a/src/c_api/data_type.cpp
+++ b/src/c_api/data_type.cpp
@@ -15,11 +15,9 @@ kuzu_data_type* kuzu_data_type_create(
     } else {
         auto child_type_pty =
             std::make_unique<DataType>(*static_cast<DataType*>(child_type->_data_type));
-        data_type =
-            fixed_num_elements_in_list > 0 ?
-                new DataType(static_cast<DataTypeID>(data_type_id_u8), std::move(child_type_pty),
-                    fixed_num_elements_in_list) :
-                new DataType(static_cast<DataTypeID>(data_type_id_u8), std::move(child_type_pty));
+        data_type = fixed_num_elements_in_list > 0 ?
+                        new DataType(std::move(child_type_pty), fixed_num_elements_in_list) :
+                        new DataType(std::move(child_type_pty));
     }
     c_data_type->_data_type = data_type;
     return c_data_type;

--- a/src/common/types/timestamp_t.cpp
+++ b/src/common/types/timestamp_t.cpp
@@ -1,6 +1,7 @@
 #include "common/types/timestamp_t.h"
 
 #include "common/exception.h"
+#include "common/string_utils.h"
 
 namespace kuzu {
 namespace common {
@@ -120,10 +121,13 @@ timestamp_t Timestamp::FromCString(const char* str, uint64_t len) {
 
     // Find the string len for date
     uint32_t dateStrLen = 0;
+    // Skip leading spaces.
+    while (common::StringUtils::CharacterIsSpace(str[dateStrLen])) {
+        dateStrLen++;
+    }
     while (dateStrLen < len && str[dateStrLen] != ' ' && str[dateStrLen] != 'T') {
         dateStrLen++;
     }
-
     if (!Date::TryConvertDate(str, dateStrLen, pos, date)) {
         throw ConversionException(getTimestampConversionExceptionMsg(str, len));
     }

--- a/src/function/built_in_aggregate_functions.cpp
+++ b/src/function/built_in_aggregate_functions.cpp
@@ -85,8 +85,8 @@ void BuiltInAggregateFunctions::registerCountStar() {
 void BuiltInAggregateFunctions::registerCount() {
     std::vector<std::unique_ptr<AggregateFunctionDefinition>> definitions;
     for (auto& typeID : DataType::getAllValidTypeIDs()) {
-        auto inputType = (typeID == VAR_LIST ? DataType(VAR_LIST, std::make_unique<DataType>(ANY)) :
-                                               DataType(typeID));
+        auto inputType =
+            (typeID == VAR_LIST ? DataType(std::make_unique<DataType>(ANY)) : DataType(typeID));
         for (auto isDistinct : std::vector<bool>{true, false}) {
             definitions.push_back(std::make_unique<AggregateFunctionDefinition>(COUNT_FUNC_NAME,
                 std::vector<DataTypeID>{typeID}, INT64,

--- a/src/function/vector_list_operation.cpp
+++ b/src/function/vector_list_operation.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<FunctionBindData> ListCreationVectorOperation::bindFunc(
                 LIST_CREATION_FUNC_NAME, arguments[0]->getDataType(), arguments[i]->getDataType()));
         }
     }
-    auto resultType = DataType(VAR_LIST, std::make_unique<DataType>(arguments[0]->getDataType()));
+    auto resultType = DataType(std::make_unique<DataType>(arguments[0]->getDataType()));
     return std::make_unique<FunctionBindData>(resultType);
 }
 

--- a/src/function/vector_struct_operations.cpp
+++ b/src/function/vector_struct_operations.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<FunctionBindData> StructPackVectorOperations::bindFunc(
         fields.emplace_back(std::make_unique<common::StructField>(
             argument->getAlias(), argument->getDataType().copy()));
     }
-    auto resultType = common::DataType(common::STRUCT, std::move(fields));
+    auto resultType = common::DataType(std::move(fields));
     return std::make_unique<FunctionBindData>(resultType);
 }
 
@@ -43,6 +43,7 @@ std::unique_ptr<FunctionBindData> StructExtractVectorOperations::bindFunc(
         throw common::BinderException("Key name for struct_extract must be STRING literal.");
     }
     auto key = ((binder::LiteralExpression&)*arguments[1]).getValue()->getValue<std::string>();
+    common::StringUtils::toUpper(key);
     assert(definition->returnTypeID == common::ANY);
     auto childrenTypes = typeInfo->getChildrenTypes();
     auto childrenNames = typeInfo->getChildrenNames();

--- a/src/include/common/ser_deser.h
+++ b/src/include/common/ser_deser.h
@@ -102,9 +102,13 @@ public:
 
 template<>
 uint64_t SerDeser::serializeValue(const DataType& value, FileInfo* fileInfo, uint64_t offset);
+template<>
+uint64_t SerDeser::serializeValue(const std::string& value, FileInfo* fileInfo, uint64_t offset);
 
 template<>
 uint64_t SerDeser::deserializeValue(DataType& value, FileInfo* fileInfo, uint64_t offset);
+template<>
+uint64_t SerDeser::deserializeValue(std::string& value, FileInfo* fileInfo, uint64_t offset);
 
 } // namespace common
 } // namespace kuzu

--- a/src/include/function/aggregate/collect.h
+++ b/src/include/function/aggregate/collect.h
@@ -127,8 +127,8 @@ struct CollectFunction {
         assert(arguments.size() == 1);
         auto aggFuncDefinition = reinterpret_cast<AggregateFunctionDefinition*>(definition);
         aggFuncDefinition->aggregateFunction->setInputDataType(arguments[0]->dataType);
-        auto returnType = common::DataType(
-            common::VAR_LIST, std::make_unique<common::DataType>(arguments[0]->dataType));
+        auto returnType =
+            common::DataType(std::make_unique<common::DataType>(arguments[0]->dataType));
         return std::make_unique<FunctionBindData>(returnType);
     }
 };

--- a/src/include/storage/copier/table_copy_executor.h
+++ b/src/include/storage/copier/table_copy_executor.h
@@ -44,12 +44,12 @@ public:
     uint64_t copy(processor::ExecutionContext* executionContext);
 
     static void throwCopyExceptionIfNotOK(const arrow::Status& status);
-
     static std::unique_ptr<common::Value> getArrowVarList(const std::string& l, int64_t from,
-        int64_t to, const common::DataType& dataType, common::CopyDescription& copyDescription);
+        int64_t to, const common::DataType& dataType,
+        const common::CopyDescription& copyDescription);
     static std::unique_ptr<uint8_t[]> getArrowFixedList(const std::string& l, int64_t from,
-        int64_t to, const common::DataType& dataType, common::CopyDescription& copyDescription);
-
+        int64_t to, const common::DataType& dataType,
+        const common::CopyDescription& copyDescription);
     static std::shared_ptr<arrow::csv::StreamingReader> createCSVReader(const std::string& filePath,
         common::CSVReaderConfig* csvReaderConfig, catalog::TableSchema* tableSchema);
     static std::unique_ptr<parquet::arrow::FileReader> createParquetReader(
@@ -72,14 +72,18 @@ protected:
 
     void countNumLinesNpy(const std::vector<std::string>& filePaths);
 
-    static std::vector<std::pair<int64_t, int64_t>> getListElementPos(
-        const std::string& l, int64_t from, int64_t to, common::CopyDescription& copyDescription);
+    static std::vector<std::pair<int64_t, int64_t>> getListElementPos(const std::string& l,
+        int64_t from, int64_t to, const common::CopyDescription& copyDescription);
 
     inline void updateTableStatistics() {
         tablesStatistics->setNumTuplesForTable(tableSchema->tableID, numRows);
     }
 
     static std::shared_ptr<arrow::DataType> toArrowDataType(const common::DataType& dataType);
+
+private:
+    static std::unique_ptr<common::Value> convertStringToValue(std::string element,
+        const common::DataType& type, const common::CopyDescription& copyDescription);
 
 protected:
     std::shared_ptr<spdlog::logger> logger;

--- a/src/include/storage/in_mem_storage_structure/in_mem_column.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_column.h
@@ -16,6 +16,8 @@ using fill_in_mem_column_function_t = std::function<void(InMemColumn* inMemColum
 class InMemColumn {
 
 public:
+    InMemColumn() = default;
+
     // For property columns.
     InMemColumn(std::string fName, common::DataType dataType, uint64_t numBytesForElement,
         uint64_t numElements);
@@ -124,6 +126,17 @@ public:
         : InMemColumnWithOverflow{std::move(fName), std::move(dataType), numElements} {
         assert(this->dataType.typeID == common::VAR_LIST);
     };
+};
+
+class InMemStructColumn : public InMemColumn {
+
+public:
+    InMemStructColumn(std::string fName, common::DataType dataType, uint64_t numElements);
+
+    void saveToFile() override;
+
+private:
+    std::vector<std::unique_ptr<InMemColumn>> structFieldsColumns;
 };
 
 class InMemColumnFactory {

--- a/src/include/storage/in_mem_storage_structure/in_mem_node_column.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_node_column.h
@@ -8,8 +8,8 @@ namespace storage {
 // solution for now to allow gradual refactorings. Eventually, we should only have InMemColumn.
 class InMemNodeColumn {
 public:
-    InMemNodeColumn(std::string filePath, common::DataType dataType, uint16_t numBytesForElement,
-        uint64_t numElements);
+    InMemNodeColumn() = default;
+    InMemNodeColumn(std::string filePath, common::DataType dataType, uint64_t numElements);
     virtual ~InMemNodeColumn() = default;
 
     // Encode and flush null bits.
@@ -18,8 +18,12 @@ public:
     inline common::DataType getDataType() { return dataType; }
 
     // Flush pages which holds nodeOffsets in the range [startOffset, endOffset] (inclusive).
-    void flushChunk(
+    virtual void flushChunk(
         InMemColumnChunk* chunk, common::offset_t startOffset, common::offset_t endOffset);
+
+    virtual inline void setNull(common::offset_t nodeOffset, bool isNull) {
+        nullMask->setNull(nodeOffset, isNull);
+    }
 
     void setElementInChunk(InMemColumnChunk* chunk, common::offset_t offset, const uint8_t* val);
 
@@ -49,10 +53,9 @@ protected:
 class NodeInMemColumnWithOverflow : public InMemNodeColumn {
 
 public:
-    NodeInMemColumnWithOverflow(std::string filePath, common::DataType dataType,
-        uint16_t numBytesForElement, uint64_t numElements)
-        : InMemNodeColumn{
-              std::move(filePath), std::move(dataType), numBytesForElement, numElements} {
+    NodeInMemColumnWithOverflow(
+        std::string filePath, common::DataType dataType, uint64_t numElements)
+        : InMemNodeColumn{std::move(filePath), std::move(dataType), numElements} {
         assert(
             this->dataType.typeID == common::STRING || this->dataType.typeID == common::VAR_LIST);
         inMemOverflowFile =
@@ -70,10 +73,24 @@ protected:
     std::unique_ptr<InMemOverflowFile> inMemOverflowFile;
 };
 
+class NodeInMemStructColumn : public InMemNodeColumn {
+
+public:
+    NodeInMemStructColumn(std::string filePath, common::DataType dataType, uint64_t numElements);
+
+    void saveToFile() override;
+
+    void flushChunk(
+        InMemColumnChunk* chunk, common::offset_t startOffset, common::offset_t endOffset) override;
+
+private:
+    std::vector<std::unique_ptr<InMemNodeColumn>> fields;
+};
+
 class NodeInMemColumnFactory {
 public:
     static std::unique_ptr<InMemNodeColumn> getNodeInMemColumn(
-        const std::string& filePath, const common::DataType& dataType, uint64_t numElements) {
+        std::string filePath, const common::DataType& dataType, uint64_t numElements) {
         switch (dataType.typeID) {
         case common::INT64:
         case common::INT32:
@@ -85,12 +102,12 @@ public:
         case common::TIMESTAMP:
         case common::INTERVAL:
         case common::FIXED_LIST:
-            return make_unique<InMemNodeColumn>(
-                filePath, dataType, common::Types::getDataTypeSize(dataType), numElements);
+            return make_unique<InMemNodeColumn>(filePath, dataType, numElements);
         case common::STRING:
         case common::VAR_LIST:
-            return make_unique<NodeInMemColumnWithOverflow>(
-                filePath, dataType, common::Types::getDataTypeSize(dataType), numElements);
+            return make_unique<NodeInMemColumnWithOverflow>(filePath, dataType, numElements);
+        case common::STRUCT:
+            return make_unique<NodeInMemStructColumn>(filePath, dataType, numElements);
         default:
             throw common::CopyException("Invalid type for property column creation.");
         }

--- a/src/include/storage/storage_structure/disk_overflow_file.h
+++ b/src/include/storage/storage_structure/disk_overflow_file.h
@@ -18,7 +18,7 @@ class DiskOverflowFile : public StorageStructure {
 
 public:
     DiskOverflowFile(const StorageStructureIDAndFName& storageStructureIDAndFNameOfMainDBFile,
-        BufferManager& bufferManager, WAL* wal)
+        BufferManager* bufferManager, WAL* wal)
         : StorageStructure(
               constructOverflowStorageStructureIDAndFName(storageStructureIDAndFNameOfMainDBFile),
               bufferManager, wal),

--- a/src/include/storage/storage_structure/lists/lists.h
+++ b/src/include/storage/storage_structure/lists/lists.h
@@ -46,7 +46,7 @@ class Lists : public BaseColumnOrList {
 public:
     Lists(const StorageStructureIDAndFName& storageStructureIDAndFName,
         const common::DataType& dataType, const size_t& elementSize,
-        std::shared_ptr<ListHeaders> headers, BufferManager& bufferManager, WAL* wal,
+        std::shared_ptr<ListHeaders> headers, BufferManager* bufferManager, WAL* wal,
         ListsUpdatesStore* listsUpdatesStore)
         : Lists{storageStructureIDAndFName, dataType, elementSize, std::move(headers),
               bufferManager, true /*hasNULLBytes*/, wal, listsUpdatesStore} {};
@@ -108,12 +108,12 @@ protected:
     virtual inline DiskOverflowFile* getDiskOverflowFileIfExists() { return nullptr; }
     Lists(const StorageStructureIDAndFName& storageStructureIDAndFName,
         const common::DataType& dataType, const size_t& elementSize,
-        std::shared_ptr<ListHeaders> headers, BufferManager& bufferManager, bool hasNULLBytes,
+        std::shared_ptr<ListHeaders> headers, BufferManager* bufferManager, bool hasNULLBytes,
         WAL* wal, ListsUpdatesStore* listsUpdatesStore)
         : BaseColumnOrList{storageStructureIDAndFName, dataType, elementSize, bufferManager,
               hasNULLBytes, wal},
           storageStructureIDAndFName{storageStructureIDAndFName},
-          metadata{storageStructureIDAndFName, &bufferManager, wal}, headers{std::move(headers)},
+          metadata{storageStructureIDAndFName, bufferManager, wal}, headers{std::move(headers)},
           listsUpdatesStore{listsUpdatesStore} {};
 
 private:
@@ -138,7 +138,7 @@ class PropertyListsWithOverflow : public Lists {
 public:
     PropertyListsWithOverflow(const StorageStructureIDAndFName& storageStructureIDAndFName,
         const common::DataType& dataType, std::shared_ptr<ListHeaders> headers,
-        BufferManager& bufferManager, WAL* wal, ListsUpdatesStore* listsUpdatesStore)
+        BufferManager* bufferManager, WAL* wal, ListsUpdatesStore* listsUpdatesStore)
         : Lists{storageStructureIDAndFName, dataType, common::Types::getDataTypeSize(dataType),
               std::move(headers), bufferManager, wal, listsUpdatesStore},
           diskOverflowFile{storageStructureIDAndFName, bufferManager, wal} {}
@@ -154,7 +154,7 @@ class StringPropertyLists : public PropertyListsWithOverflow {
 
 public:
     StringPropertyLists(const StorageStructureIDAndFName& storageStructureIDAndFName,
-        const std::shared_ptr<ListHeaders>& headers, BufferManager& bufferManager, WAL* wal,
+        const std::shared_ptr<ListHeaders>& headers, BufferManager* bufferManager, WAL* wal,
         ListsUpdatesStore* listsUpdatesStore)
         : PropertyListsWithOverflow{storageStructureIDAndFName, common::DataType{common::STRING},
               headers, bufferManager, wal, listsUpdatesStore} {};
@@ -169,7 +169,7 @@ class ListPropertyLists : public PropertyListsWithOverflow {
 public:
     ListPropertyLists(const StorageStructureIDAndFName& storageStructureIDAndFName,
         const common::DataType& dataType, const std::shared_ptr<ListHeaders>& headers,
-        BufferManager& bufferManager, WAL* wal, ListsUpdatesStore* listsUpdatesStore)
+        BufferManager* bufferManager, WAL* wal, ListsUpdatesStore* listsUpdatesStore)
         : PropertyListsWithOverflow{storageStructureIDAndFName, dataType, headers, bufferManager,
               wal, listsUpdatesStore} {};
 
@@ -182,11 +182,11 @@ class AdjLists : public Lists {
 
 public:
     AdjLists(const StorageStructureIDAndFName& storageStructureIDAndFName,
-        common::table_id_t nbrTableID, BufferManager& bufferManager, WAL* wal,
+        common::table_id_t nbrTableID, BufferManager* bufferManager, WAL* wal,
         ListsUpdatesStore* listsUpdatesStore)
         : Lists{storageStructureIDAndFName, common::DataType(common::INTERNAL_ID),
               sizeof(common::offset_t),
-              std::make_shared<ListHeaders>(storageStructureIDAndFName, &bufferManager, wal),
+              std::make_shared<ListHeaders>(storageStructureIDAndFName, bufferManager, wal),
               bufferManager, false /* hasNullBytes */, wal, listsUpdatesStore},
           nbrTableID{nbrTableID} {};
 
@@ -223,7 +223,7 @@ class RelIDList : public Lists {
 
 public:
     RelIDList(const StorageStructureIDAndFName& storageStructureIDAndFName,
-        std::shared_ptr<ListHeaders> headers, BufferManager& bufferManager, WAL* wal,
+        std::shared_ptr<ListHeaders> headers, BufferManager* bufferManager, WAL* wal,
         ListsUpdatesStore* listsUpdatesStore)
         : Lists{storageStructureIDAndFName, common::DataType{common::INTERNAL_ID},
               sizeof(common::offset_t), std::move(headers), bufferManager, wal, listsUpdatesStore} {
@@ -255,7 +255,7 @@ class ListsFactory {
 public:
     static std::unique_ptr<Lists> getLists(const StorageStructureIDAndFName& structureIDAndFName,
         const common::DataType& dataType, const std::shared_ptr<ListHeaders>& adjListsHeaders,
-        BufferManager& bufferManager, WAL* wal, ListsUpdatesStore* listsUpdatesStore) {
+        BufferManager* bufferManager, WAL* wal, ListsUpdatesStore* listsUpdatesStore) {
         assert(listsUpdatesStore != nullptr);
         switch (dataType.typeID) {
         case common::INT64:

--- a/src/include/storage/storage_structure/storage_structure.h
+++ b/src/include/storage/storage_structure/storage_structure.h
@@ -21,12 +21,14 @@ class StorageStructure {
     friend class ListsUpdateIterator;
 
 public:
+    StorageStructure() = default;
+
     StorageStructure(const StorageStructureIDAndFName& storageStructureIDAndFName,
-        BufferManager& bufferManager, WAL* wal)
+        BufferManager* bufferManager, WAL* wal)
         : logger{common::LoggerUtils::getLogger(common::LoggerConstants::LoggerEnum::STORAGE)},
           storageStructureID{storageStructureIDAndFName.storageStructureID},
           bufferManager{bufferManager}, wal{wal} {
-        fileHandle = bufferManager.getBMFileHandle(storageStructureIDAndFName.fName,
+        fileHandle = bufferManager->getBMFileHandle(storageStructureIDAndFName.fName,
             FileHandle::O_PERSISTENT_FILE_NO_CREATE,
             BMFileHandle::FileVersionedType::VERSIONED_FILE);
     }
@@ -51,7 +53,7 @@ protected:
     std::shared_ptr<spdlog::logger> logger;
     StorageStructureID storageStructureID;
     std::unique_ptr<BMFileHandle> fileHandle;
-    BufferManager& bufferManager;
+    BufferManager* bufferManager;
     WAL* wal;
 };
 
@@ -62,6 +64,8 @@ protected:
 class BaseColumnOrList : public StorageStructure {
 
 public:
+    BaseColumnOrList() = default;
+
     // Maps the position of element in page to its byte offset in page.
     // TODO(Everyone): we should slowly get rid of this function.
     inline uint16_t mapElementPosToByteOffset(uint16_t pageElementPos) const {
@@ -78,7 +82,7 @@ protected:
     }
 
     BaseColumnOrList(const StorageStructureIDAndFName& storageStructureIDAndFName,
-        common::DataType dataType, const size_t& elementSize, BufferManager& bufferManager,
+        common::DataType dataType, const size_t& elementSize, BufferManager* bufferManager,
         bool hasNULLBytes, WAL* wal);
 
     void readBySequentialCopy(transaction::Transaction* transaction, common::ValueVector* vector,

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -82,6 +82,8 @@ public:
     static std::string getNodePropertyColumnFName(const std::string& directory,
         const common::table_id_t& tableID, uint32_t propertyID, common::DBFileType dbFileType);
 
+    static std::string appendStructFieldName(std::string filePath, std::string structFieldName);
+
     static inline StorageStructureIDAndFName getNodePropertyColumnStructureIDAndFName(
         const std::string& directory, const catalog::Property& property) {
         auto fName = getNodePropertyColumnFName(

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -47,7 +47,7 @@ public:
         propertyColumns.emplace(property.propertyID,
             ColumnFactory::getColumn(StorageUtils::getNodePropertyColumnStructureIDAndFName(
                                          wal->getDirectory(), property),
-                property.dataType, bufferManager, wal));
+                property.dataType, &bufferManager, wal));
     }
 
     common::offset_t addNodeAndResetProperties(common::ValueVector* primaryKeyVector);

--- a/src/processor/processor_task.cpp
+++ b/src/processor/processor_task.cpp
@@ -24,6 +24,7 @@ static void addStructFieldsVectors(common::ValueVector* structVector, common::Da
         reinterpret_cast<common::StructTypeInfo*>(structVector->dataType.getExtraTypeInfo());
     for (auto& childType : structTypeInfo->getChildrenTypes()) {
         auto childVector = std::make_shared<common::ValueVector>(*childType, memoryManager);
+        childVector->state = dataChunk->state;
         structVector->addChildVector(childVector);
     }
 }

--- a/src/storage/in_mem_storage_structure/in_mem_column_chunk.cpp
+++ b/src/storage/in_mem_storage_structure/in_mem_column_chunk.cpp
@@ -1,5 +1,7 @@
 #include "storage/in_mem_storage_structure/in_mem_column_chunk.h"
 
+#include <regex>
+
 #include "common/types/types.h"
 
 namespace kuzu {
@@ -74,6 +76,22 @@ void InMemColumnChunk::templateCopyValuesToPage<std::string, InMemOverflowFile*,
 }
 
 template<>
+void InMemColumnChunk::templateCopyValuesToPage<std::string, common::CopyDescription&,
+    common::offset_t>(const PageElementCursor& pageCursor, arrow::Array& array, uint64_t posInArray,
+    uint64_t numValues, common::CopyDescription& copyDesc, common::offset_t nodeOffset) {
+    copyStructValueToFields(array, posInArray, copyDesc, nodeOffset, numValues);
+}
+
+template<>
+void InMemColumnChunk::setValueFromString<bool>(
+    const char* value, uint64_t length, common::page_idx_t pageIdx, uint64_t posInPage) {
+    std::istringstream boolStream{std::string(value)};
+    bool booleanVal;
+    boolStream >> std::boolalpha >> booleanVal;
+    copyValue(pageIdx, posInPage, (uint8_t*)&booleanVal);
+}
+
+template<>
 void InMemColumnChunk::setValueFromString<common::ku_string_t, InMemOverflowFile*, PageByteCursor&>(
     const char* value, uint64_t length, common::page_idx_t pageIdx, uint64_t posInPage,
     InMemOverflowFile* overflowFile, PageByteCursor& overflowCursor) {
@@ -125,6 +143,139 @@ void InMemColumnChunk::setValueFromString<common::timestamp_t>(
     const char* value, uint64_t length, common::page_idx_t pageIdx, uint64_t posInPage) {
     auto val = common::Timestamp::FromCString(value, length);
     copyValue(pageIdx, posInPage, (uint8_t*)&val);
+}
+
+InMemStructColumnChunk::InMemStructColumnChunk(
+    common::DataType dataType, common::offset_t startOffset, common::offset_t endOffset) {
+    this->dataType = std::move(dataType);
+    auto childrenTypes =
+        reinterpret_cast<common::StructTypeInfo*>(this->dataType.getExtraTypeInfo())
+            ->getChildrenTypes();
+    for (auto& childType : childrenTypes) {
+        inMemColumnChunksForFields.push_back(InMemColumnChunkFactory::getInMemColumnChunk(
+            *childType, startOffset, endOffset, common::Types::getDataTypeSize(*childType),
+            common::BufferPoolConstants::PAGE_4KB_SIZE /
+                common::Types::getDataTypeSize(*childType)));
+    }
+}
+
+void InMemStructColumnChunk::copyStructValueToFields(arrow::Array& array, uint64_t posInArray,
+    const common::CopyDescription& copyDescription, common::offset_t startOffset,
+    uint64_t numValues) {
+    // TODO(Ziyi): support null values in struct.
+    for (auto i = 0u; i < numValues; i++) {
+        auto& stringArray = (arrow::StringArray&)array;
+        auto structView = stringArray.GetView(i + posInArray);
+        auto structTypeInfo =
+            reinterpret_cast<common::StructTypeInfo*>(dataType.getExtraTypeInfo());
+        auto structFieldTypes = structTypeInfo->getChildrenTypes();
+        auto structFieldNames = structTypeInfo->getChildrenNames();
+        std::regex whiteSpacePattern{"\\s"};
+        // Removes the leading and trailing '{', '}';
+        auto structString =
+            std::string(structView.data(), structView.length()).substr(1, structView.length() - 2);
+        auto structFields = common::StringUtils::split(structString, ",");
+        for (auto& structField : structFields) {
+            auto delimPos = structField.find(':');
+            auto structFieldName =
+                std::regex_replace(structField.substr(0, delimPos), whiteSpacePattern, "");
+            auto structFieldIdx = getStructFieldIdx(structFieldNames, structFieldName);
+            auto structFieldValue = structField.substr(delimPos + 1);
+            copyValueToStructColumnField(i + startOffset, structFieldIdx, structFieldValue,
+                *structFieldTypes[structFieldIdx]);
+        }
+    }
+}
+
+std::vector<InMemColumnChunk*> InMemStructColumnChunk::getInMemColumnChunksForFields() {
+    std::vector<InMemColumnChunk*> columnChunksForFields;
+    for (auto& inMemColumnChunksForField : inMemColumnChunksForFields) {
+        columnChunksForFields.push_back(inMemColumnChunksForField.get());
+    }
+    return columnChunksForFields;
+}
+
+uint64_t InMemStructColumnChunk::getMinNumValuesLeftOnPage(common::offset_t nodeOffset) {
+    auto minNumValuesLeftOnPage = UINT64_MAX;
+    for (auto& inMemColumnChunkForField : inMemColumnChunksForFields) {
+        auto fieldPageCursor = CursorUtils::getPageElementCursor(
+            nodeOffset, inMemColumnChunkForField->getNumElementsInAPage());
+        minNumValuesLeftOnPage = std::min(minNumValuesLeftOnPage,
+            inMemColumnChunkForField->getNumElementsInAPage() - fieldPageCursor.elemPosInPage);
+    }
+    return minNumValuesLeftOnPage;
+}
+
+common::field_idx_t InMemStructColumnChunk::getStructFieldIdx(
+    std::vector<std::string> structFieldNames, std::string structFieldName) {
+    common::StringUtils::toUpper(structFieldName);
+    auto it = std::find_if(structFieldNames.begin(), structFieldNames.end(),
+        [structFieldName](const std::string& name) { return name == structFieldName; });
+    if (it == structFieldNames.end()) {
+        throw common::ConversionException{
+            common::StringUtils::string_format("Invalid struct field name: {}.", structFieldName)};
+    }
+    return std::distance(structFieldNames.begin(), it);
+}
+
+void InMemStructColumnChunk::copyValueToStructColumnField(common::offset_t nodeOffset,
+    common::field_idx_t structFieldIdx, const std::string& structFieldValue,
+    const common::DataType& dataType) {
+    auto inMemColumnChunkForField = inMemColumnChunksForFields[structFieldIdx].get();
+    auto pageCursor = CursorUtils::getPageElementCursor(
+        nodeOffset, inMemColumnChunkForField->getNumElementsInAPage());
+    switch (dataType.typeID) {
+    case common::INT64: {
+        inMemColumnChunkForField->setValueFromString<int64_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::INT32: {
+        inMemColumnChunkForField->setValueFromString<int32_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::INT16: {
+        inMemColumnChunkForField->setValueFromString<int16_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::DOUBLE: {
+        inMemColumnChunkForField->setValueFromString<double_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::FLOAT: {
+        inMemColumnChunkForField->setValueFromString<float_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::BOOL: {
+        inMemColumnChunkForField->setValueFromString<bool>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::DATE: {
+        inMemColumnChunkForField->setValueFromString<common::date_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::TIMESTAMP: {
+        inMemColumnChunkForField->setValueFromString<common::timestamp_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    case common::INTERVAL: {
+        inMemColumnChunkForField->setValueFromString<common::interval_t>(structFieldValue.c_str(),
+            structFieldValue.length(), pageCursor.pageIdx, pageCursor.elemPosInPage);
+    } break;
+    default:
+        assert(false);
+    }
+}
+
+std::unique_ptr<InMemColumnChunk> InMemColumnChunkFactory::getInMemColumnChunk(
+    common::DataType dataType, common::offset_t startOffset, common::offset_t endOffset,
+    uint16_t numBytesForElement, uint64_t numElementsInAPage) {
+    if (dataType.typeID == common::STRUCT) {
+        return std::make_unique<InMemStructColumnChunk>(
+            std::move(dataType), startOffset, endOffset);
+    } else {
+        return std::make_unique<InMemColumnChunk>(
+            std::move(dataType), startOffset, endOffset, numBytesForElement, numElementsInAPage);
+    }
 }
 
 } // namespace storage

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -144,7 +144,7 @@ HashIndex<T>::HashIndex(const StorageStructureIDAndFName& storageStructureIDAndF
     keyEqualsFunc = HashIndexUtils::initializeEqualsFunc(indexHeader->keyDataTypeID);
     localStorage = std::make_unique<HashIndexLocalStorage>(keyDataType);
     if (keyDataType.typeID == STRING) {
-        diskOverflowFile = std::make_unique<DiskOverflowFile>(storageStructureIDAndFName, bm, wal);
+        diskOverflowFile = std::make_unique<DiskOverflowFile>(storageStructureIDAndFName, &bm, wal);
     }
 }
 

--- a/src/storage/storage_structure/lists/lists.cpp
+++ b/src/storage/storage_structure/lists/lists.cpp
@@ -134,7 +134,7 @@ void Lists::fillInMemListsFromPersistentStore(offset_t nodeOffset,
         auto numElementsToReadInCurPage = std::min(numElementsToRead - numElementsRead,
             (uint64_t)(numElementsPerPage - pageCursor.elemPosInPage));
         auto physicalPageIdx = pageMapper(pageCursor.pageIdx);
-        bufferManager.optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) {
+        bufferManager->optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) {
             fillInMemListsFromFrame(inMemList, frame, pageCursor.elemPosInPage,
                 numElementsToReadInCurPage, deletedRelOffsetsInList, numElementsRead,
                 nextPosToWriteToInMemList, updatedPersistentListOffsets);
@@ -265,7 +265,7 @@ std::unique_ptr<std::vector<nodeID_t>> AdjLists::readAdjacencyListOfNode(
         auto sizeToCopyInPage =
             std::min(((uint64_t)(numElementsPerPage - pageCursor.elemPosInPage) * elementSize),
                 sizeLeftToCopy);
-        bufferManager.optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) {
+        bufferManager->optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) {
             memcpy(bufferPtr, frame + mapElementPosToByteOffset(pageCursor.elemPosInPage),
                 sizeToCopyInPage);
         });
@@ -397,7 +397,7 @@ std::unordered_set<uint64_t> RelIDList::getDeletedRelOffsetsInListForNodeOffset(
         auto numElementsToReadInCurPage = std::min(numElementsInPersistentStore - numElementsRead,
             (uint64_t)(numElementsPerPage - pageCursor.elemPosInPage));
         auto physicalPageIdx = pageMapper(pageCursor.pageIdx);
-        bufferManager.optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) -> void {
+        bufferManager->optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) -> void {
             auto buffer = frame + getElemByteOffset(pageCursor.elemPosInPage);
             for (auto i = 0u; i < numElementsToReadInCurPage; i++) {
                 auto relID = *(int64_t*)buffer;
@@ -426,7 +426,7 @@ list_offset_t RelIDList::getListOffset(offset_t nodeOffset, offset_t relOffset) 
         auto numElementsToReadInCurPage = std::min(numElementsInPersistentStore - numElementsRead,
             (uint64_t)(numElementsPerPage - pageCursor.elemPosInPage));
         auto physicalPageIdx = pageMapper(pageCursor.pageIdx);
-        bufferManager.optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) -> void {
+        bufferManager->optimisticRead(*fileHandle, physicalPageIdx, [&](uint8_t* frame) -> void {
             auto buffer = frame + getElemByteOffset(pageCursor.elemPosInPage);
             for (auto i = 0u; i < numElementsToReadInCurPage; i++) {
                 auto relIDInList = *(int64_t*)buffer;

--- a/src/storage/storage_structure/lists/lists_update_iterator.cpp
+++ b/src/storage/storage_structure/lists/lists_update_iterator.cpp
@@ -315,7 +315,7 @@ void ListsUpdateIterator::writeAtOffset(InMemList& inMemList, page_idx_t pageLis
         uint64_t numElementsToWriteToCurrentPage = std::min(
             remainingNumElementsToWrite, lists->numElementsPerPage - elementOffsetInListPage);
         StorageStructureUtils::updatePage(*(lists->getFileHandle()), lists->storageStructureID,
-            listPageIdx, insertingNewPage, lists->bufferManager, *(lists->wal),
+            listPageIdx, insertingNewPage, *lists->bufferManager, *(lists->wal),
             [&inMemList, &elementOffsetInListPage, &numElementsToWriteToCurrentPage, &elementSize,
                 &numUpdatedElements, this](uint8_t* frame) -> void {
                 auto dataToFill = inMemList.getListData() + numUpdatedElements * elementSize;

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -27,6 +27,13 @@ std::string StorageUtils::getNodePropertyColumnFName(const std::string& director
         dbFileType);
 }
 
+std::string StorageUtils::appendStructFieldName(std::string filePath, std::string structFieldName) {
+    // Naming rules for a struct field column is: n-[tableID]-[propertyID]-[fieldName].col.
+    auto posToInsertFieldName = filePath.find('.');
+    filePath.insert(posToInsertFieldName - 1, "-" + structFieldName);
+    return filePath;
+}
+
 std::string StorageUtils::getAdjListsFName(const std::string& directory,
     const common::table_id_t& relTableID, const common::RelDirection& relDirection,
     common::DBFileType dbFileType) {

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -17,7 +17,7 @@ void NodeTable::initializeData(NodeTableSchema* nodeTableSchema) {
     for (auto& property : nodeTableSchema->getAllNodeProperties()) {
         propertyColumns[property.propertyID] = ColumnFactory::getColumn(
             StorageUtils::getNodePropertyColumnStructureIDAndFName(wal->getDirectory(), property),
-            property.dataType, bufferManager, wal);
+            property.dataType, &bufferManager, wal);
     }
     pkIndex = std::make_unique<PrimaryKeyIndex>(
         StorageUtils::getNodeIndexIDAndFName(wal->getDirectory(), tableID),

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -54,12 +54,12 @@ void DirectedRelTableData::initializeColumns(
     adjColumn =
         std::make_unique<AdjColumn>(StorageUtils::getAdjColumnStructureIDAndFName(
                                         wal->getDirectory(), tableSchema->tableID, direction),
-            tableSchema->getNbrTableID(direction), bufferManager, wal);
+            tableSchema->getNbrTableID(direction), &bufferManager, wal);
     for (auto& property : tableSchema->properties) {
         propertyColumns[property.propertyID] = ColumnFactory::getColumn(
             StorageUtils::getRelPropertyColumnStructureIDAndFName(
                 wal->getDirectory(), tableSchema->tableID, direction, property.propertyID),
-            property.dataType, bufferManager, wal);
+            property.dataType, &bufferManager, wal);
     }
 }
 
@@ -67,12 +67,12 @@ void DirectedRelTableData::initializeLists(
     RelTableSchema* tableSchema, BufferManager& bufferManager, WAL* wal) {
     adjLists = std::make_unique<AdjLists>(StorageUtils::getAdjListsStructureIDAndFName(
                                               wal->getDirectory(), tableSchema->tableID, direction),
-        tableSchema->getNbrTableID(direction), bufferManager, wal, listsUpdatesStore);
+        tableSchema->getNbrTableID(direction), &bufferManager, wal, listsUpdatesStore);
     for (auto& property : tableSchema->properties) {
         propertyLists[property.propertyID] = ListsFactory::getLists(
             StorageUtils::getRelPropertyListsStructureIDAndFName(
                 wal->getDirectory(), tableSchema->tableID, direction, property),
-            property.dataType, adjLists->getHeaders(), bufferManager, wal, listsUpdatesStore);
+            property.dataType, adjLists->getHeaders(), &bufferManager, wal, listsUpdatesStore);
     }
 }
 
@@ -367,12 +367,12 @@ void DirectedRelTableData::addProperty(Property& property, WAL* wal) {
             ColumnFactory::getColumn(
                 StorageUtils::getRelPropertyColumnStructureIDAndFName(
                     wal->getDirectory(), tableID, direction, property.propertyID),
-                property.dataType, bufferManager, wal));
+                property.dataType, &bufferManager, wal));
     } else {
         propertyLists.emplace(property.propertyID,
             ListsFactory::getLists(StorageUtils::getRelPropertyListsStructureIDAndFName(
                                        wal->getDirectory(), tableID, direction, property),
-                property.dataType, adjLists->getHeaders(), bufferManager, wal, listsUpdatesStore));
+                property.dataType, adjLists->getHeaders(), &bufferManager, wal, listsUpdatesStore));
     }
 }
 

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -94,7 +94,7 @@ TEST_F(BinderErrorTest, BindPropertyNotExist2) {
 }
 
 TEST_F(BinderErrorTest, BindPropertyNotExist3) {
-    std::string expectedException = "Binder exception: Cannot find key b for struct_extract.";
+    std::string expectedException = "Binder exception: Cannot find key B for struct_extract.";
     auto input = "WITH {a: 1} AS s RETURN s.b;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }

--- a/test/c_api/connection_test.cpp
+++ b/test/c_api/connection_test.cpp
@@ -171,7 +171,8 @@ TEST_F(CApiConnectionTest, GetNodePropertyNames) {
     ASSERT_EQ(resultString, "movies properties: \n"
                             "\tname STRING(PRIMARY KEY)\n"
                             "\tlength INT32\n"
-                            "\tnote STRING\n");
+                            "\tnote STRING\n"
+                            "\tdescription STRUCT(DOUBLE,INT64,TIMESTAMP,DATE)\n");
     free(result);
 }
 

--- a/test/test_files/tinysnb/projection/multi_label.test
+++ b/test/test_files/tinysnb/projection/multi_label.test
@@ -23,9 +23,9 @@
 -NAME MultiLabelReturnStar
 -QUERY MATCH (a:movies:organisation) RETURN *
 ---- 6
-(label:organisation, 1:0, {ID:1, name:ABFsUni, orgCode:325, mark:3.700000, score:-2, history:10 years 5 months 13 hours 24 us, licenseValidInterval:3 years 5 days, rating:1.000000, length:, note:})
-(label:organisation, 1:1, {ID:4, name:CsWork, orgCode:934, mark:4.100000, score:-100, history:2 years 4 days 10 hours, licenseValidInterval:26 years 52 days 48:00:00, rating:0.780000, length:, note:})
-(label:organisation, 1:2, {ID:6, name:DEsWork, orgCode:824, mark:4.100000, score:7, history:2 years 4 hours 22 us 34 minutes, licenseValidInterval:82:00:00.1, rating:0.520000, length:, note:})
-(label:movies, 2:0, {ID:, name:Sóló cón tu párejâ, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:, length:126, note: this is a very very good movie})
-(label:movies, 2:1, {ID:, name:The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:, length:2544, note: the movie is very very good})
-(label:movies, 2:2, {ID:, name:Roma, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:, length:298, note:the movie is very interesting and funny})
+(label:movies, 2:0, {ID:, name:Sóló cón tu párejâ, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:, length:126, note: this is a very very good movie, description:{RATING: 5.300000, VIEWS: 152, RELEASE: 2011-08-20 11:25:30, FILM: 2012-05-11}})
+(label:movies, 2:1, {ID:, name:The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:, length:2544, note: the movie is very very good, description:{RATING: 7.000000, VIEWS: 982, RELEASE: 2018-11-13 13:33:11, FILM: 2014-09-12}})
+(label:movies, 2:2, {ID:, name:Roma, orgCode:, mark:, score:, history:, licenseValidInterval:, rating:, length:298, note:the movie is very interesting and funny, description:{RATING: 1223.000000, VIEWS: 10003, RELEASE: 2011-02-11 16:44:22, FILM: 2013-02-22}})
+(label:organisation, 1:0, {ID:1, name:ABFsUni, orgCode:325, mark:3.700000, score:-2, history:10 years 5 months 13 hours 24 us, licenseValidInterval:3 years 5 days, rating:1.000000, length:, note:, description:})
+(label:organisation, 1:1, {ID:4, name:CsWork, orgCode:934, mark:4.100000, score:-100, history:2 years 4 days 10 hours, licenseValidInterval:26 years 52 days 48:00:00, rating:0.780000, length:, note:, description:})
+(label:organisation, 1:2, {ID:6, name:DEsWork, orgCode:824, mark:4.100000, score:7, history:2 years 4 hours 22 us 34 minutes, licenseValidInterval:82:00:00.1, rating:0.520000, length:, note:, description:})

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -426,9 +426,16 @@ Dan|Carol
 -NAME ReturnStructLiteral
 -QUERY RETURN {weight: 1.8, age: 42, name: "Mark", grades: [1,2,3]}
 ---- 1
-{weight: 1.800000, age: 42, name: Mark, grades: [1,2,3]}
+{WEIGHT: 1.800000, AGE: 42, NAME: Mark, GRADES: [1,2,3]}
 
 -NAME ReturnStructLiteral2
 -QUERY WITH {a: '1', b: 2, c: [4,5,6]} AS st RETURN st.a, st.b * 5, (st.c)[1:3]
 ---- 1
 1|10|[4,5]
+
+-NAME ReturnStruct
+-QUERY MATCH (m:movies) RETURN m.description
+---- 3
+{RATING: 1223.000000, VIEWS: 10003, RELEASE: 2011-02-11 16:44:22, FILM: 2013-02-22}
+{RATING: 5.300000, VIEWS: 152, RELEASE: 2011-08-20 11:25:30, FILM: 2012-05-11}
+{RATING: 7.000000, VIEWS: 982, RELEASE: 2018-11-13 13:33:11, FILM: 2014-09-12}

--- a/tools/python_api/test/conftest.py
+++ b/tools/python_api/test/conftest.py
@@ -26,7 +26,8 @@ def init_tiny_snb(tmp_path):
     conn.execute("create node table organisation (ID INT64, name STRING, orgCode INT64, mark DOUBLE, score INT64, "
                  "history STRING, licenseValidInterval INTERVAL, rating DOUBLE, PRIMARY KEY (ID))")
     conn.execute('COPY organisation FROM "../../../dataset/tinysnb/vOrganisation.csv"')
-    conn.execute('CREATE NODE TABLE movies (name STRING, length INT32, note STRING, PRIMARY KEY (name))')
+    conn.execute('CREATE NODE TABLE movies (name STRING, length INT32, note STRING, description STRUCT(rating DOUBLE, '
+                 'views INT64, release TIMESTAMP, film DATE), PRIMARY KEY (name))')
     conn.execute('COPY movies FROM "../../../dataset/tinysnb/vMovies.csv"')
     conn.execute('create rel table workAt (FROM person TO organisation, year INT64, grading DOUBLE[2], rating float,'
                  ' MANY_ONE)')

--- a/tools/python_api/test/test_PYTHON_CSV.csv
+++ b/tools/python_api/test/test_PYTHON_CSV.csv
@@ -1,1 +1,0 @@
-Alice|[10,5]|[''Aida'']~Bob|[12,8]|[''Bobby'']~Carol|[4,5]|[''Carmen'',''Fred'']~Dan|[1,9]|[''Wolfeschlegelstein'',''Daniel'']~Elizabeth|[2]|[''Ein'']~Farooq|[3,4,5,6,7]|[''Fesdwe'']~Greg|[1]|[''Grad'']~Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|[10,11,12,3,4,5,6,7]|[''Ad'',''De'',''Hi'',''Kye'',''Orlan'']~


### PR DESCRIPTION
This PR adds basic loader and storage support for struct dataType.
Unresolved struct dataType issues:
1. Null struct value and null struct field value.
2. Improves the loader for struct so that we can support more field types.
3. Solves `Match (m:movies) return m.description.rating` exception bug.
4. Query processing for unflat/flat struct field valuevectors.
5. Implements lookup/write API for struct column.