### PR TITLE
Encapsulate templatizing of `HashIndexBuilder` inside `PrimaryKeyIndexBuilder`

### DIFF
--- a/src/include/common/exception.h
+++ b/src/include/common/exception.h
@@ -40,11 +40,6 @@ public:
     explicit ConversionException(const std::string& msg) : Exception(msg){};
 };
 
-class ReaderException : public Exception {
-public:
-    explicit ReaderException(const std::string& msg) : Exception("Reader exception: " + msg){};
-};
-
 class CopyException : public Exception {
 public:
     explicit CopyException(const std::string& msg) : Exception("Copy exception: " + msg){};
@@ -53,6 +48,12 @@ public:
 class CatalogException : public Exception {
 public:
     explicit CatalogException(const std::string& msg) : Exception("Catalog exception: " + msg){};
+};
+
+class HashIndexException : public Exception {
+public:
+    explicit HashIndexException(const std::string& msg)
+        : Exception("HashIndex exception: " + msg){};
 };
 
 class StorageException : public Exception {

--- a/src/include/storage/copier/node_copier.h
+++ b/src/include/storage/copier/node_copier.h
@@ -63,7 +63,6 @@ public:
     common::offset_t nodeOffset;
 
 protected:
-    // todo: do we need this?
     std::unordered_map<std::string, TableCopyExecutor::FileBlockInfo> fileBlockInfos;
     common::block_idx_t blockIdx;
     std::mutex mtx;
@@ -87,15 +86,14 @@ private:
     std::shared_ptr<arrow::csv::StreamingReader> reader;
 };
 
-template<typename T>
 class NodeCopier {
 public:
-    NodeCopier(std::shared_ptr<NodeCopySharedState> sharedState, HashIndexBuilder<T>* pkIndex,
+    NodeCopier(std::shared_ptr<NodeCopySharedState> sharedState, PrimaryKeyIndexBuilder* pkIndex,
         const common::CopyDescription& copyDesc, std::vector<InMemNodeColumn*> columns,
         common::column_id_t pkColumnID)
         : sharedState{std::move(sharedState)}, pkIndex{pkIndex}, copyDesc{copyDesc},
-          columns{columns}, pkColumnID{pkColumnID} {
-        overflowCursors.resize(columns.size());
+          columns{std::move(columns)}, pkColumnID{pkColumnID} {
+        overflowCursors.resize(this->columns.size());
     }
     virtual ~NodeCopier() = default;
 
@@ -109,23 +107,28 @@ public:
 
 protected:
     virtual void executeInternal(std::unique_ptr<NodeCopyMorsel> morsel) {
-        throw std::runtime_error("Not implemented");
+        throw common::CopyException("executeInternal not implemented");
     }
 
-    static void copyArrayIntoColumnChunk(InMemColumnChunk* columnChunk, InMemNodeColumn* column,
+    void copyArrayIntoColumnChunk(InMemColumnChunk* columnChunk, common::column_id_t columnID,
         arrow::Array& arrowArray, common::offset_t startNodeOffset,
-        common::CopyDescription& copyDescription, PageByteCursor& overflowCursor);
-    static void populatePKIndex(InMemColumnChunk* chunk, InMemOverflowFile* overflowFile,
-        common::NullMask* nullMask, HashIndexBuilder<T>* pkIndex, common::offset_t startOffset,
-        uint64_t numValues);
-    static void appendPKIndex(InMemColumnChunk* chunk, InMemOverflowFile* overflowFile,
-        common::offset_t offset, HashIndexBuilder<T>* pkIndex) {
-        assert(false);
+        common::CopyDescription& copyDescription);
+    void populatePKIndex(InMemColumnChunk* chunk, InMemOverflowFile* overflowFile,
+        common::NullMask* nullMask, common::offset_t startOffset, uint64_t numValues);
+
+    void flushChunksAndPopulatePKIndex(
+        const std::vector<std::unique_ptr<InMemColumnChunk>>& columnChunks,
+        common::offset_t startNodeOffset, common::offset_t endNodeOffset);
+
+    template<typename T, typename... Args>
+    void appendToPKIndex(
+        InMemColumnChunk* chunk, common::offset_t startOffset, uint64_t numValues, Args... args) {
+        throw common::CopyException("appendToPKIndex not implemented");
     }
 
 protected:
     std::shared_ptr<NodeCopySharedState> sharedState;
-    HashIndexBuilder<T>* pkIndex;
+    PrimaryKeyIndexBuilder* pkIndex;
     common::CopyDescription copyDesc;
     std::vector<InMemNodeColumn*> columns;
     common::column_id_t pkColumnID;
@@ -133,23 +136,22 @@ protected:
 };
 
 template<>
-void NodeCopier<int64_t>::appendPKIndex(InMemColumnChunk* chunk, InMemOverflowFile* overflowFile,
-    common::offset_t offset, HashIndexBuilder<int64_t>* pkIndex);
+void NodeCopier::appendToPKIndex<int64_t>(
+    kuzu::storage::InMemColumnChunk* chunk, common::offset_t startOffset, uint64_t numValues);
 template<>
-void NodeCopier<common::ku_string_t>::appendPKIndex(InMemColumnChunk* chunk,
-    InMemOverflowFile* overflowFile, common::offset_t offset,
-    HashIndexBuilder<common::ku_string_t>* pkIndex);
+void NodeCopier::appendToPKIndex<common::ku_string_t, storage::InMemOverflowFile*>(
+    kuzu::storage::InMemColumnChunk* chunk, common::offset_t startOffset, uint64_t numValues,
+    storage::InMemOverflowFile* overflowFile);
 
-template<typename T>
-class CSVNodeCopier : public NodeCopier<T> {
+class CSVNodeCopier : public NodeCopier {
 public:
-    CSVNodeCopier(std::shared_ptr<NodeCopySharedState> sharedState, HashIndexBuilder<T>* pkIndex,
+    CSVNodeCopier(std::shared_ptr<NodeCopySharedState> sharedState, PrimaryKeyIndexBuilder* pkIndex,
         const common::CopyDescription& copyDesc, std::vector<InMemNodeColumn*> columns,
         common::column_id_t pkColumnID)
-        : NodeCopier<T>{std::move(sharedState), pkIndex, copyDesc, columns, pkColumnID} {}
+        : NodeCopier{std::move(sharedState), pkIndex, copyDesc, std::move(columns), pkColumnID} {}
 
-    inline std::unique_ptr<NodeCopier<T>> clone() const override {
-        return std::make_unique<CSVNodeCopier<T>>(
+    inline std::unique_ptr<NodeCopier> clone() const override {
+        return std::make_unique<CSVNodeCopier>(
             this->sharedState, this->pkIndex, this->copyDesc, this->columns, this->pkColumnID);
     }
 
@@ -157,16 +159,15 @@ protected:
     void executeInternal(std::unique_ptr<NodeCopyMorsel> morsel) override;
 };
 
-template<typename T>
-class ParquetNodeCopier : public NodeCopier<T> {
+class ParquetNodeCopier : public NodeCopier {
 public:
     ParquetNodeCopier(std::shared_ptr<NodeCopySharedState> sharedState,
-        HashIndexBuilder<T>* pkIndex, const common::CopyDescription& copyDesc,
+        PrimaryKeyIndexBuilder* pkIndex, const common::CopyDescription& copyDesc,
         std::vector<InMemNodeColumn*> columns, common::column_id_t pkColumnID)
-        : NodeCopier<T>{std::move(sharedState), pkIndex, copyDesc, columns, pkColumnID} {}
+        : NodeCopier{std::move(sharedState), pkIndex, copyDesc, std::move(columns), pkColumnID} {}
 
-    inline std::unique_ptr<NodeCopier<T>> clone() const override {
-        return std::make_unique<ParquetNodeCopier<T>>(
+    inline std::unique_ptr<NodeCopier> clone() const override {
+        return std::make_unique<ParquetNodeCopier>(
             this->sharedState, this->pkIndex, this->copyDesc, this->columns, this->pkColumnID);
     }
 
@@ -178,18 +179,16 @@ private:
     std::string filePath;
 };
 
-template<typename T>
-class NPYNodeCopier : public NodeCopier<T> {
+class NPYNodeCopier : public NodeCopier {
 public:
-    NPYNodeCopier(std::shared_ptr<NodeCopySharedState> sharedState, HashIndexBuilder<T>* pkIndex,
+    NPYNodeCopier(std::shared_ptr<NodeCopySharedState> sharedState, PrimaryKeyIndexBuilder* pkIndex,
         const common::CopyDescription& copyDesc, std::vector<InMemNodeColumn*> columns,
-        common::column_id_t columnID, common::column_id_t pkColumnID)
-        : NodeCopier<T>{std::move(sharedState), pkIndex, copyDesc, columns, pkColumnID},
-          columnID{columnID} {}
+        common::column_id_t pkColumnID)
+        : NodeCopier{std::move(sharedState), pkIndex, copyDesc, std::move(columns), pkColumnID} {}
 
-    inline std::unique_ptr<NodeCopier<T>> clone() const override {
-        return std::make_unique<NPYNodeCopier<T>>(this->sharedState, this->pkIndex, this->copyDesc,
-            this->columns, columnID, this->pkColumnID);
+    inline std::unique_ptr<NodeCopier> clone() const override {
+        return std::make_unique<NPYNodeCopier>(
+            this->sharedState, this->pkIndex, this->copyDesc, this->columns, this->pkColumnID);
     }
 
     inline void finalize() override {
@@ -203,16 +202,14 @@ protected:
 
 private:
     std::unique_ptr<NpyReader> reader;
-    common::column_id_t columnID;
 };
 
 // Note: This is a temporary class used specially in the node copier. NodeCopyTask mimics the
 // behaviour of ProcessorTask. Eventually, we shouldn't have both CopyTask and NodeCopyTask.
-template<typename T>
 class NodeCopyTask : public common::Task {
 public:
     NodeCopyTask(
-        std::unique_ptr<NodeCopier<T>> nodeCopier, processor::ExecutionContext* executionContext)
+        std::unique_ptr<NodeCopier> nodeCopier, processor::ExecutionContext* executionContext)
         : Task{executionContext->numThreads}, nodeCopier{std::move(nodeCopier)},
           executionContext{executionContext} {};
 
@@ -226,7 +223,7 @@ public:
 
 private:
     std::mutex mtx;
-    std::unique_ptr<NodeCopier<T>> nodeCopier;
+    std::unique_ptr<NodeCopier> nodeCopier;
     processor::ExecutionContext* executionContext;
 };
 

--- a/src/include/storage/copier/node_copy_executor.h
+++ b/src/include/storage/copier/node_copy_executor.h
@@ -22,14 +22,13 @@ protected:
 
     void populateColumnsAndLists(processor::ExecutionContext* executionContext) override;
 
-    // todo: do we need this? should go to finalize.
+    // TODO(Guodong): do we need this? should go to finalize.
     void saveToFile() override;
 
     std::unordered_map<common::property_id_t, common::column_id_t> propertyIDToColumnIDMap;
     std::vector<std::unique_ptr<InMemNodeColumn>> columns;
 
 private:
-    template<typename T>
     void populateColumns(processor::ExecutionContext* executionContext);
 };
 

--- a/src/include/storage/in_mem_storage_structure/in_mem_column_chunk.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_column_chunk.h
@@ -31,6 +31,7 @@ public:
         auto elemPosInPageInBytes = cursor.elemPosInPage * numBytesForElement;
         return getPage(cursor.pageIdx) + elemPosInPageInBytes;
     }
+    inline common::DataType getDataType() const { return dataType; }
 
     template<typename T, typename... Args>
     void templateCopyValuesToPage(const PageElementCursor& pageCursor, arrow::Array& array,

--- a/src/storage/copier/table_copy_executor.cpp
+++ b/src/storage/copier/table_copy_executor.cpp
@@ -242,15 +242,15 @@ std::unique_ptr<Value> TableCopyExecutor::getArrowVarList(const std::string& l, 
                 *dataType.getChildType(), copyDescription);
         } break;
         default:
-            throw ReaderException("Unsupported data type " +
-                                  Types::dataTypeToString(dataType.getChildType()->typeID) +
-                                  " inside LIST");
+            throw CopyException("Unsupported data type " +
+                                Types::dataTypeToString(dataType.getChildType()->typeID) +
+                                " inside LIST");
         }
         values.push_back(std::move(value));
     }
     auto numBytesOfOverflow = values.size() * Types::getDataTypeSize(childDataType.typeID);
     if (numBytesOfOverflow >= BufferPoolConstants::PAGE_4KB_SIZE) {
-        throw ReaderException(StringUtils::string_format(
+        throw CopyException(StringUtils::string_format(
             "Maximum num bytes of a LIST is {}. Input list's num bytes is {}.",
             BufferPoolConstants::PAGE_4KB_SIZE, numBytesOfOverflow));
     }
@@ -297,15 +297,15 @@ std::unique_ptr<uint8_t[]> TableCopyExecutor::getArrowFixedList(const std::strin
             numElementsRead++;
         } break;
         default: {
-            throw ReaderException("Unsupported data type " +
-                                  Types::dataTypeToString(dataType.getChildType()->typeID) +
-                                  " inside FIXED_LIST");
+            throw CopyException("Unsupported data type " +
+                                Types::dataTypeToString(dataType.getChildType()->typeID) +
+                                " inside FIXED_LIST");
         }
         }
     }
     auto extraTypeInfo = reinterpret_cast<FixedListTypeInfo*>(dataType.getExtraTypeInfo());
     if (numElementsRead != extraTypeInfo->getFixedNumElementsInList()) {
-        throw ReaderException(StringUtils::string_format(
+        throw CopyException(StringUtils::string_format(
             "Each fixed list should have fixed number of elements. Expected: {}, Actual: {}.",
             extraTypeInfo->getFixedNumElementsInList(), numElementsRead));
     }

--- a/test/copy/copy_fault_test.cpp
+++ b/test/copy/copy_fault_test.cpp
@@ -52,7 +52,7 @@ TEST_F(CopyDuplicateIDTest, DuplicateIDsError) {
     validateCopyException(
         "COPY person FROM \"" +
             TestHelper::appendKuzuRootPath("dataset/copy-fault-tests/duplicate-ids/vPerson.csv\""),
-        "Copy exception: " + Exception::getExistedPKExceptionMsg("10"));
+        "HashIndex exception: " + Exception::getExistedPKExceptionMsg("10"));
 }
 
 TEST_F(CopyNodeUnmatchedColumnTypeTest, UnMatchedColumnTypeError) {


### PR DESCRIPTION
This is a rework to get rid of lots of template functions due to the templatizing of HashIndexBuilder. Similar to `PrimaryKeyIndex`, this PR moves the templatizing logic inside `PrimaryKeyIndexBuilder`.