### PR TITLE
Issue 951

### DIFF
--- a/src/include/planner/logical_plan/logical_operator/logical_aggregate.h
+++ b/src/include/planner/logical_plan/logical_operator/logical_aggregate.h
@@ -25,10 +25,14 @@ public:
     inline binder::expression_vector getExpressionsToGroupBy() const {
         return expressionsToGroupBy;
     }
+    inline size_t getNumAggregateExpressions() const { return expressionsToAggregate.size(); }
+    inline std::shared_ptr<binder::Expression> getAggregateExpression(
+        common::vector_idx_t idx) const {
+        return expressionsToAggregate[idx];
+    }
     inline binder::expression_vector getExpressionsToAggregate() const {
         return expressionsToAggregate;
     }
-    inline Schema* getSchemaBeforeAggregate() const { return children[0]->getSchema(); }
 
     inline std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalAggregate>(

--- a/src/include/processor/data_pos.h
+++ b/src/include/processor/data_pos.h
@@ -3,14 +3,24 @@
 #include <cstdint>
 #include <utility>
 
+#include "common/types/types.h"
+
 namespace kuzu {
 namespace processor {
 
+using data_chunk_pos_t = common::vector_idx_t;
+constexpr data_chunk_pos_t INVALID_DATA_CHUNK_POS = common::INVALID_VECTOR_IDX;
+using value_vector_pos_t = common::vector_idx_t;
+constexpr value_vector_pos_t INVALID_VALUE_VECTOR_POS = common::INVALID_VECTOR_IDX;
+
 struct DataPos {
-public:
-    explicit DataPos(uint32_t dataChunkPos, uint32_t valueVectorPos)
+    data_chunk_pos_t dataChunkPos;
+    value_vector_pos_t valueVectorPos;
+
+    DataPos() : dataChunkPos{INVALID_DATA_CHUNK_POS}, valueVectorPos{INVALID_VALUE_VECTOR_POS} {}
+    explicit DataPos(data_chunk_pos_t dataChunkPos, value_vector_pos_t valueVectorPos)
         : dataChunkPos{dataChunkPos}, valueVectorPos{valueVectorPos} {}
-    explicit DataPos(std::pair<uint32_t, uint32_t> pos)
+    explicit DataPos(std::pair<data_chunk_pos_t, value_vector_pos_t> pos)
         : dataChunkPos{pos.first}, valueVectorPos{pos.second} {}
 
     DataPos(const DataPos& other) : DataPos(other.dataChunkPos, other.valueVectorPos) {}
@@ -18,10 +28,6 @@ public:
     inline bool operator==(const DataPos& rhs) const {
         return (dataChunkPos == rhs.dataChunkPos) && (valueVectorPos == rhs.valueVectorPos);
     }
-
-public:
-    uint32_t dataChunkPos;
-    uint32_t valueVectorPos;
 };
 
 } // namespace processor

--- a/src/include/processor/mapper/plan_mapper.h
+++ b/src/include/processor/mapper/plan_mapper.h
@@ -13,6 +13,7 @@ namespace kuzu {
 namespace processor {
 
 struct BuildDataInfo;
+struct AggregateInputInfo;
 
 class PlanMapper {
 public:
@@ -110,18 +111,16 @@ private:
 
     std::unique_ptr<PhysicalOperator> createHashAggregate(
         std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
-        std::vector<DataPos> inputAggVectorsPos, std::vector<DataPos> outputAggVectorsPos,
-        std::vector<common::DataType> outputAggVectorsDataType,
+        std::vector<std::unique_ptr<AggregateInputInfo>> inputAggregateInfo,
+        std::vector<DataPos> outputAggVectorsPos,
         const binder::expression_vector& groupByExpressions,
         std::unique_ptr<PhysicalOperator> prevOperator, const planner::Schema& inSchema,
         const planner::Schema& outSchema, const std::string& paramsString);
 
     void appendGroupByExpressions(const binder::expression_vector& groupByExpressions,
         std::vector<DataPos>& inputGroupByHashKeyVectorsPos,
-        std::vector<DataPos>& outputGroupByKeyVectorsPos,
-        std::vector<common::DataType>& outputGroupByKeyVectorsDataTypes,
-        const planner::Schema& inSchema, const planner::Schema& outSchema,
-        std::vector<bool>& isInputGroupByHashKeyVectorFlat);
+        std::vector<DataPos>& outputGroupByKeyVectorsPos, const planner::Schema& inSchema,
+        const planner::Schema& outSchema, std::vector<bool>& isInputGroupByHashKeyVectorFlat);
 
     BuildDataInfo generateBuildDataInfo(const planner::Schema& buildSideSchema,
         const binder::expression_vector& keys, const binder::expression_vector& payloads);

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "aggregate_input.h"
 #include "function/aggregate/aggregate_function.h"
 #include "function/comparison/comparison_operations.h"
 #include "processor/operator/base_hash_table.h"
@@ -40,7 +41,7 @@ using update_agg_function_t =
 class AggregateHashTable : public BaseHashTable {
 public:
     // Used by distinct aggregate hash table only.
-    inline AggregateHashTable(storage::MemoryManager& memoryManager,
+    AggregateHashTable(storage::MemoryManager& memoryManager,
         const std::vector<common::DataType>& groupByHashKeysDataTypes,
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
         uint64_t numEntriesToAllocate)
@@ -61,16 +62,18 @@ public:
 
     inline void append(const std::vector<common::ValueVector*>& groupByFlatKeyVectors,
         const std::vector<common::ValueVector*>& groupByUnFlatHashKeyVectors,
-        const std::vector<common::ValueVector*>& aggregateVectors, uint64_t multiplicity) {
+        const std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs,
+        uint64_t resultSetMultiplicity) {
         append(groupByFlatKeyVectors, groupByUnFlatHashKeyVectors,
-            std::vector<common::ValueVector*>(), aggregateVectors, multiplicity);
+            std::vector<common::ValueVector*>(), aggregateInputs, resultSetMultiplicity);
     }
 
     //! update aggregate states for an input
     void append(const std::vector<common::ValueVector*>& groupByFlatKeyVectors,
         const std::vector<common::ValueVector*>& groupByUnFlatHashKeyVectors,
         const std::vector<common::ValueVector*>& groupByNonHashKeyVectors,
-        const std::vector<common::ValueVector*>& aggregateVectors, uint64_t multiplicity);
+        const std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs,
+        uint64_t resultSetMultiplicity);
 
     bool isAggregateValueDistinctForGroupByKeys(
         const std::vector<common::ValueVector*>& groupByKeyVectors,
@@ -139,7 +142,8 @@ private:
 
     void updateAggStates(const std::vector<common::ValueVector*>& groupByFlatHashKeyVectors,
         const std::vector<common::ValueVector*>& groupByUnFlatHashKeyVectors,
-        const std::vector<common::ValueVector*>& aggregateVectors, uint64_t multiplicity);
+        const std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs,
+        uint64_t resultSetMultiplicity);
 
     // ! This function will only be used by distinct aggregate, which assumes that all keyVectors
     // are flat.

--- a/src/include/processor/operator/aggregate/aggregate_input.h
+++ b/src/include/processor/operator/aggregate/aggregate_input.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "common/data_chunk/data_chunk.h"
+#include "processor/result/result_set_descriptor.h"
+
+namespace kuzu {
+namespace processor {
+
+struct AggregateInputInfo {
+    DataPos aggregateVectorPos;
+    std::vector<data_chunk_pos_t> multiplicityChunksPos;
+
+    AggregateInputInfo(
+        const DataPos& vectorPos, std::vector<data_chunk_pos_t> multiplicityChunksPos)
+        : aggregateVectorPos{vectorPos}, multiplicityChunksPos{std::move(multiplicityChunksPos)} {}
+    AggregateInputInfo(const AggregateInputInfo& other)
+        : AggregateInputInfo(other.aggregateVectorPos, other.multiplicityChunksPos) {}
+    inline std::unique_ptr<AggregateInputInfo> copy() {
+        return std::make_unique<AggregateInputInfo>(*this);
+    }
+};
+
+struct AggregateInput {
+    common::ValueVector* aggregateVector;
+    std::vector<common::DataChunk*> multiplicityChunks;
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/include/processor/operator/aggregate/base_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/base_aggregate_scan.h
@@ -8,20 +8,16 @@ namespace processor {
 
 class BaseAggregateScan : public PhysicalOperator {
 public:
-    BaseAggregateScan(std::vector<DataPos> aggregatesPos,
-        std::vector<common::DataType> aggregateDataTypes, std::unique_ptr<PhysicalOperator> child,
+    BaseAggregateScan(std::vector<DataPos> aggregatesPos, std::unique_ptr<PhysicalOperator> child,
         uint32_t id, const std::string& paramsString)
         : PhysicalOperator{PhysicalOperatorType::AGGREGATE_SCAN, std::move(child), id,
               paramsString},
-          aggregatesPos{std::move(aggregatesPos)}, aggregateDataTypes{
-                                                       std::move(aggregateDataTypes)} {}
+          aggregatesPos{std::move(aggregatesPos)} {}
 
-    BaseAggregateScan(std::vector<DataPos> aggregatesPos,
-        std::vector<common::DataType> aggregateDataTypes, uint32_t id,
-        const std::string& paramsString)
+    BaseAggregateScan(
+        std::vector<DataPos> aggregatesPos, uint32_t id, const std::string& paramsString)
         : PhysicalOperator{PhysicalOperatorType::AGGREGATE_SCAN, id, paramsString},
-          aggregatesPos{std::move(aggregatesPos)}, aggregateDataTypes{
-                                                       std::move(aggregateDataTypes)} {}
+          aggregatesPos{std::move(aggregatesPos)} {}
 
     bool isSource() const override { return true; }
 
@@ -37,7 +33,6 @@ protected:
 
 protected:
     std::vector<DataPos> aggregatesPos;
-    std::vector<common::DataType> aggregateDataTypes;
     std::vector<std::shared_ptr<common::ValueVector>> aggregateVectors;
 };
 

--- a/src/include/processor/operator/aggregate/hash_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate_scan.h
@@ -9,39 +9,30 @@ namespace processor {
 class HashAggregateScan : public BaseAggregateScan {
 public:
     HashAggregateScan(std::shared_ptr<HashAggregateSharedState> sharedState,
-        std::vector<DataPos> groupByKeyVectorsPos,
-        std::vector<common::DataType> groupByKeyVectorDataTypes, std::vector<DataPos> aggregatesPos,
-        std::vector<common::DataType> aggregateDataTypes, std::unique_ptr<PhysicalOperator> child,
-        uint32_t id, const std::string& paramsString)
-        : BaseAggregateScan{std::move(aggregatesPos), std::move(aggregateDataTypes),
-              std::move(child), id, paramsString},
-          groupByKeyVectorsPos{std::move(groupByKeyVectorsPos)},
-          groupByKeyVectorDataTypes{std::move(groupByKeyVectorDataTypes)}, sharedState{std::move(
-                                                                               sharedState)} {}
+        std::vector<DataPos> groupByKeyVectorsPos, std::vector<DataPos> aggregatesPos,
+        std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
+        : BaseAggregateScan{std::move(aggregatesPos), std::move(child), id, paramsString},
+          groupByKeyVectorsPos{std::move(groupByKeyVectorsPos)}, sharedState{
+                                                                     std::move(sharedState)} {}
 
     HashAggregateScan(std::shared_ptr<HashAggregateSharedState> sharedState,
-        std::vector<DataPos> groupByKeyVectorsPos,
-        std::vector<common::DataType> groupByKeyVectorDataTypes, std::vector<DataPos> aggregatesPos,
-        std::vector<common::DataType> aggregateDataTypes, uint32_t id,
+        std::vector<DataPos> groupByKeyVectorsPos, std::vector<DataPos> aggregatesPos, uint32_t id,
         const std::string& paramsString)
-        : BaseAggregateScan{std::move(aggregatesPos), std::move(aggregateDataTypes), id,
-              paramsString},
-          groupByKeyVectorsPos{std::move(groupByKeyVectorsPos)},
-          groupByKeyVectorDataTypes{std::move(groupByKeyVectorDataTypes)}, sharedState{std::move(
-                                                                               sharedState)} {}
+        : BaseAggregateScan{std::move(aggregatesPos), id, paramsString},
+          groupByKeyVectorsPos{std::move(groupByKeyVectorsPos)}, sharedState{
+                                                                     std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return std::make_unique<HashAggregateScan>(sharedState, groupByKeyVectorsPos,
-            groupByKeyVectorDataTypes, aggregatesPos, aggregateDataTypes, id, paramsString);
+        return std::make_unique<HashAggregateScan>(
+            sharedState, groupByKeyVectorsPos, aggregatesPos, id, paramsString);
     }
 
 private:
     std::vector<DataPos> groupByKeyVectorsPos;
-    std::vector<common::DataType> groupByKeyVectorDataTypes;
     std::vector<common::ValueVector*> groupByKeyVectors;
     std::shared_ptr<HashAggregateSharedState> sharedState;
     std::vector<uint32_t> groupByKeyVectorsColIdxes;

--- a/src/include/processor/operator/aggregate/simple_aggregate_scan.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate_scan.h
@@ -7,21 +7,17 @@ namespace kuzu {
 namespace processor {
 
 class SimpleAggregateScan : public BaseAggregateScan {
-
 public:
     SimpleAggregateScan(std::shared_ptr<SimpleAggregateSharedState> sharedState,
-        std::vector<DataPos> aggregatesPos, std::vector<common::DataType> aggregateDataTypes,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
-        : BaseAggregateScan{std::move(aggregatesPos), std::move(aggregateDataTypes),
-              std::move(child), id, paramsString},
+        std::vector<DataPos> aggregatesPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        const std::string& paramsString)
+        : BaseAggregateScan{std::move(aggregatesPos), std::move(child), id, paramsString},
           sharedState{std::move(sharedState)}, outDataChunk{nullptr} {}
 
     // This constructor is used for cloning only.
     SimpleAggregateScan(std::shared_ptr<SimpleAggregateSharedState> sharedState,
-        std::vector<DataPos> aggregatesPos, std::vector<common::DataType> aggregateDataTypes,
-        uint32_t id, const std::string& paramsString)
-        : BaseAggregateScan{std::move(aggregatesPos), std::move(aggregateDataTypes), id,
-              paramsString},
+        std::vector<DataPos> aggregatesPos, uint32_t id, const std::string& paramsString)
+        : BaseAggregateScan{std::move(aggregatesPos), id, paramsString},
           sharedState{std::move(sharedState)}, outDataChunk{nullptr} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
@@ -30,8 +26,7 @@ public:
 
     // SimpleAggregateScan is the source operator of a pipeline, so it should not clone its child.
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<SimpleAggregateScan>(
-            sharedState, aggregatesPos, aggregateDataTypes, id, paramsString);
+        return make_unique<SimpleAggregateScan>(sharedState, aggregatesPos, id, paramsString);
     }
 
 private:

--- a/src/include/processor/result/result_set.h
+++ b/src/include/processor/result/result_set.h
@@ -17,6 +17,9 @@ public:
         dataChunks[pos] = std::move(dataChunk);
     }
 
+    inline std::shared_ptr<common::DataChunk> getDataChunk(data_chunk_pos_t dataChunkPos) {
+        return dataChunks[dataChunkPos];
+    }
     inline std::shared_ptr<common::ValueVector> getValueVector(const DataPos& dataPos) {
         return dataChunks[dataPos.dataChunkPos]->valueVectors[dataPos.valueVectorPos];
     }

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -46,7 +46,7 @@ f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
 }
 
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
-    if (hasDistinctAggregate() || expressionsToAggregate.size() > 1) {
+    if (hasDistinctAggregate()) {
         f_group_pos_set dependentGroupsPos;
         for (auto& expression : expressionsToAggregate) {
             for (auto groupPos : children[0]->getSchema()->getDependentGroupsPos(expression)) {

--- a/src/processor/mapper/map_aggregate.cpp
+++ b/src/processor/mapper/map_aggregate.cpp
@@ -14,56 +14,82 @@ using namespace kuzu::planner;
 namespace kuzu {
 namespace processor {
 
+static std::vector<std::unique_ptr<AggregateInputInfo>> getAggregateInputInfos(
+    const expression_vector& groupByExpressions, const expression_vector& aggregateExpressions,
+    const Schema& schema) {
+    // Collect unFlat groups from
+    std::unordered_set<f_group_pos> groupByGroupPosSet;
+    for (auto& expression : groupByExpressions) {
+        groupByGroupPosSet.insert(schema.getGroupPos(*expression));
+    }
+    std::unordered_set<f_group_pos> unFlatAggregateGroupPosSet;
+    for (auto groupPos : schema.getGroupsPosInScope()) {
+        if (groupByGroupPosSet.contains(groupPos)) {
+            continue;
+        }
+        if (schema.getGroup(groupPos)->isFlat()) {
+            continue;
+        }
+        unFlatAggregateGroupPosSet.insert(groupPos);
+    }
+    std::vector<std::unique_ptr<AggregateInputInfo>> result;
+    for (auto& expression : aggregateExpressions) {
+        DataPos aggregateVectorPos{};
+        if (expression->getNumChildren() != 0) { // COUNT(*) has no children
+            auto child = expression->getChild(0);
+            aggregateVectorPos = DataPos{schema.getExpressionPos(*child)};
+        }
+        std::vector<data_chunk_pos_t> multiplicityChunksPos;
+        for (auto& groupPos : unFlatAggregateGroupPosSet) {
+            if (groupPos != aggregateVectorPos.dataChunkPos) {
+                multiplicityChunksPos.push_back(groupPos);
+            }
+        }
+        result.emplace_back(std::make_unique<AggregateInputInfo>(
+            aggregateVectorPos, std::move(multiplicityChunksPos)));
+    }
+    return result;
+}
+
 std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAggregateToPhysical(
     LogicalOperator* logicalOperator) {
     auto& logicalAggregate = (const LogicalAggregate&)*logicalOperator;
     auto outSchema = logicalAggregate.getSchema();
-    auto inSchema = logicalAggregate.getSchemaBeforeAggregate();
+    auto inSchema = logicalAggregate.getChild(0)->getSchema();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
     auto paramsString = logicalAggregate.getExpressionsForPrinting();
-    std::vector<DataPos> inputAggVectorsPos;
-    std::vector<DataPos> outputAggVectorsPos;
-    std::vector<DataType> outputAggVectorsDataTypes;
-    std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions;
-    for (auto& expression : logicalAggregate.getExpressionsToAggregate()) {
-        if (expression->getNumChildren() == 0) {
-            inputAggVectorsPos.emplace_back(UINT32_MAX, UINT32_MAX);
-        } else {
-            auto child = expression->getChild(0);
-            inputAggVectorsPos.emplace_back(inSchema->getExpressionPos(*child));
-        }
-        aggregateFunctions.push_back(
-            ((AggregateFunctionExpression&)*expression).aggregateFunction->clone());
-        outputAggVectorsPos.emplace_back(outSchema->getExpressionPos(*expression));
-        outputAggVectorsDataTypes.push_back(expression->dataType);
+    std::vector<DataPos> outputAggVectorsPos{logicalAggregate.getNumAggregateExpressions()};
+    std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions{
+        logicalAggregate.getNumAggregateExpressions()};
+    for (auto i = 0u; i < logicalAggregate.getNumAggregateExpressions(); ++i) {
+        auto expression = logicalAggregate.getAggregateExpression(i);
+        aggregateFunctions[i] =
+            ((AggregateFunctionExpression&)*expression).aggregateFunction->clone();
+        outputAggVectorsPos[i] = DataPos(outSchema->getExpressionPos(*expression));
     }
+    auto aggregateInputInfos = getAggregateInputInfos(logicalAggregate.getExpressionsToGroupBy(),
+        logicalAggregate.getExpressionsToAggregate(), *inSchema);
     if (logicalAggregate.hasExpressionsToGroupBy()) {
-        return createHashAggregate(std::move(aggregateFunctions), inputAggVectorsPos,
-            outputAggVectorsPos, outputAggVectorsDataTypes,
-            logicalAggregate.getExpressionsToGroupBy(), std::move(prevOperator), *inSchema,
-            *outSchema, paramsString);
+        return createHashAggregate(std::move(aggregateFunctions), std::move(aggregateInputInfos),
+            outputAggVectorsPos, logicalAggregate.getExpressionsToGroupBy(),
+            std::move(prevOperator), *inSchema, *outSchema, paramsString);
     } else {
         auto sharedState = make_shared<SimpleAggregateSharedState>(aggregateFunctions);
-        auto aggregate = make_unique<SimpleAggregate>(
-            std::make_unique<ResultSetDescriptor>(*inSchema), sharedState, inputAggVectorsPos,
-            std::move(aggregateFunctions), std::move(prevOperator), getOperatorID(), paramsString);
-        auto aggregateScan = make_unique<SimpleAggregateScan>(sharedState, outputAggVectorsPos,
-            outputAggVectorsDataTypes, std::move(aggregate), getOperatorID(), paramsString);
-        return aggregateScan;
+        auto aggregate =
+            make_unique<SimpleAggregate>(std::make_unique<ResultSetDescriptor>(*inSchema),
+                sharedState, std::move(aggregateFunctions), std::move(aggregateInputInfos),
+                std::move(prevOperator), getOperatorID(), paramsString);
+        return make_unique<SimpleAggregateScan>(
+            sharedState, outputAggVectorsPos, std::move(aggregate), getOperatorID(), paramsString);
     }
 }
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(
     std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions,
-    std::vector<DataPos> inputAggVectorsPos, std::vector<DataPos> outputAggVectorsPos,
-    std::vector<DataType> outputAggVectorsDataType, const expression_vector& groupByExpressions,
+    std::vector<std::unique_ptr<AggregateInputInfo>> inputAggregateInfo,
+    std::vector<DataPos> outputAggVectorsPos, const expression_vector& groupByExpressions,
     std::unique_ptr<PhysicalOperator> prevOperator, const Schema& inSchema, const Schema& outSchema,
     const std::string& paramsString) {
-    std::vector<DataPos> inputGroupByHashKeyVectorsPos;
-    std::vector<DataPos> inputGroupByNonHashKeyVectorsPos;
-    std::vector<bool> isInputGroupByHashKeyVectorFlat;
-    std::vector<DataPos> outputGroupByKeyVectorsPos;
-    std::vector<DataType> outputGroupByKeyVectorsDataTypeId;
     expression_vector groupByHashExpressions;
     expression_vector groupByNonHashExpressions;
     std::unordered_set<std::string> HashPrimaryKeysNodeId;
@@ -82,34 +108,33 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(
             groupByHashExpressions.push_back(expressionToGroupBy);
         }
     }
+    std::vector<DataPos> inputGroupByHashKeyVectorsPos;
+    std::vector<DataPos> inputGroupByNonHashKeyVectorsPos;
+    std::vector<bool> isInputGroupByHashKeyVectorFlat;
+    std::vector<DataPos> outputGroupByKeyVectorsPos;
     appendGroupByExpressions(groupByHashExpressions, inputGroupByHashKeyVectorsPos,
-        outputGroupByKeyVectorsPos, outputGroupByKeyVectorsDataTypeId, inSchema, outSchema,
-        isInputGroupByHashKeyVectorFlat);
+        outputGroupByKeyVectorsPos, inSchema, outSchema, isInputGroupByHashKeyVectorFlat);
     appendGroupByExpressions(groupByNonHashExpressions, inputGroupByNonHashKeyVectorsPos,
-        outputGroupByKeyVectorsPos, outputGroupByKeyVectorsDataTypeId, inSchema, outSchema,
-        isInputGroupByHashKeyVectorFlat);
+        outputGroupByKeyVectorsPos, inSchema, outSchema, isInputGroupByHashKeyVectorFlat);
     auto sharedState = make_shared<HashAggregateSharedState>(aggregateFunctions);
     auto aggregate = make_unique<HashAggregate>(std::make_unique<ResultSetDescriptor>(inSchema),
         sharedState, inputGroupByHashKeyVectorsPos, inputGroupByNonHashKeyVectorsPos,
-        isInputGroupByHashKeyVectorFlat, std::move(inputAggVectorsPos),
-        std::move(aggregateFunctions), std::move(prevOperator), getOperatorID(), paramsString);
-    auto aggregateScan = std::make_unique<HashAggregateScan>(sharedState,
-        outputGroupByKeyVectorsPos, outputGroupByKeyVectorsDataTypeId,
-        std::move(outputAggVectorsPos), std::move(outputAggVectorsDataType), std::move(aggregate),
-        getOperatorID(), paramsString);
+        isInputGroupByHashKeyVectorFlat, std::move(aggregateFunctions),
+        std::move(inputAggregateInfo), std::move(prevOperator), getOperatorID(), paramsString);
+    auto aggregateScan =
+        std::make_unique<HashAggregateScan>(sharedState, outputGroupByKeyVectorsPos,
+            std::move(outputAggVectorsPos), std::move(aggregate), getOperatorID(), paramsString);
     return aggregateScan;
 }
 
 void PlanMapper::appendGroupByExpressions(const expression_vector& groupByExpressions,
     std::vector<DataPos>& inputGroupByHashKeyVectorsPos,
-    std::vector<DataPos>& outputGroupByKeyVectorsPos,
-    std::vector<DataType>& outputGroupByKeyVectorsDataTypes, const Schema& inSchema,
+    std::vector<DataPos>& outputGroupByKeyVectorsPos, const Schema& inSchema,
     const Schema& outSchema, std::vector<bool>& isInputGroupByHashKeyVectorFlat) {
     for (auto& expression : groupByExpressions) {
         if (inSchema.getGroup(expression->getUniqueName())->isFlat()) {
             inputGroupByHashKeyVectorsPos.emplace_back(inSchema.getExpressionPos(*expression));
             outputGroupByKeyVectorsPos.emplace_back(outSchema.getExpressionPos(*expression));
-            outputGroupByKeyVectorsDataTypes.push_back(expression->dataType);
             isInputGroupByHashKeyVectorFlat.push_back(true);
         }
     }
@@ -118,7 +143,6 @@ void PlanMapper::appendGroupByExpressions(const expression_vector& groupByExpres
         if (!inSchema.getGroup(expression->getUniqueName())->isFlat()) {
             inputGroupByHashKeyVectorsPos.emplace_back(inSchema.getExpressionPos(*expression));
             outputGroupByKeyVectorsPos.emplace_back(outSchema.getExpressionPos(*expression));
-            outputGroupByKeyVectorsDataTypes.push_back(expression->dataType);
             isInputGroupByHashKeyVectorFlat.push_back(false);
         }
     }

--- a/src/processor/mapper/map_distinct.cpp
+++ b/src/processor/mapper/map_distinct.cpp
@@ -1,5 +1,6 @@
 #include "planner/logical_plan/logical_operator/logical_distinct.h"
 #include "processor/mapper/plan_mapper.h"
+#include "processor/operator/aggregate/aggregate_input.h"
 
 using namespace kuzu::common;
 using namespace kuzu::planner;
@@ -14,12 +15,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalDistinctToPhysical(
     auto inSchema = logicalDistinct.getSchemaBeforeDistinct();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
     std::vector<std::unique_ptr<function::AggregateFunction>> emptyAggregateFunctions;
-    std::vector<DataPos> emptyInputAggVectorsPos;
+    std::vector<std::unique_ptr<AggregateInputInfo>> emptyAggInputInfos;
     std::vector<DataPos> emptyOutputAggVectorsPos;
-    std::vector<DataType> emptyOutputAggVectorsDataTypes;
-    return createHashAggregate(std::move(emptyAggregateFunctions), emptyInputAggVectorsPos,
-        emptyOutputAggVectorsPos, emptyOutputAggVectorsDataTypes,
-        logicalDistinct.getExpressionsToDistinct(), std::move(prevOperator), *inSchema, *outSchema,
+    return createHashAggregate(std::move(emptyAggregateFunctions), std::move(emptyAggInputInfos),
+        emptyOutputAggVectorsPos, logicalDistinct.getExpressionsToDistinct(),
+        std::move(prevOperator), *inSchema, *outSchema,
         logicalDistinct.getExpressionsForPrinting());
 }
 


### PR DESCRIPTION
This PR partially solves #951 to avoid flattening when multiple aggregate function presents.

The idea is that when evaluating an aggregate function, we input not only the aggregate vector but also other unFlat state to obtain a correct multiplicity.

E.g.
```
MATCH (a), (b) RETURN COUNT(a), COUNT(b);
```

During aggregating, COUNT(a) will take vector "a" and also the state of vector "b" to figure the actual count.

At implementation level, we use `AggregateInput` (which wraps aggregate vector and unFlat data chunks) to replace `AggregateVector`