### PR TITLE
Add aggreate key dependency optimizer

### DIFF
--- a/src/include/optimizer/agg_key_dependency_optimizer.h
+++ b/src/include/optimizer/agg_key_dependency_optimizer.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "logical_operator_visitor.h"
+#include "planner/logical_plan/logical_plan.h"
+
+namespace kuzu {
+namespace optimizer {
+
+// This optimizer analyzes the dependency between group by keys. If key2 depends on key1 (e.g. key1
+// is a primary key column) we only hash on key1 and saves key2 as a payload.
+class AggKeyDependencyOptimizer : public LogicalOperatorVisitor {
+public:
+    void rewrite(planner::LogicalPlan* plan);
+
+private:
+    void visitOperator(planner::LogicalOperator* op);
+
+    void visitAggregate(planner::LogicalOperator* op) override;
+    void visitDistinct(planner::LogicalOperator* op) override;
+
+    std::pair<binder::expression_vector, binder::expression_vector> resolveKeysAndDependentKeys(
+        const binder::expression_vector& keys);
+};
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/include/processor/mapper/plan_mapper.h
+++ b/src/include/processor/mapper/plan_mapper.h
@@ -109,23 +109,22 @@ private:
 
     inline uint32_t getOperatorID() { return physicalOperatorID++; }
 
-    std::unique_ptr<PhysicalOperator> createHashAggregate(
-        std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
-        std::vector<std::unique_ptr<AggregateInputInfo>> inputAggregateInfo,
-        std::vector<DataPos> outputAggVectorsPos,
-        const binder::expression_vector& groupByExpressions,
-        std::unique_ptr<PhysicalOperator> prevOperator, const planner::Schema& inSchema,
-        const planner::Schema& outSchema, const std::string& paramsString);
-
-    void appendGroupByExpressions(const binder::expression_vector& groupByExpressions,
-        std::vector<DataPos>& inputGroupByHashKeyVectorsPos,
-        std::vector<DataPos>& outputGroupByKeyVectorsPos, const planner::Schema& inSchema,
-        const planner::Schema& outSchema, std::vector<bool>& isInputGroupByHashKeyVectorFlat);
-
     BuildDataInfo generateBuildDataInfo(const planner::Schema& buildSideSchema,
         const binder::expression_vector& keys, const binder::expression_vector& payloads);
 
-    void mapAccHashJoin(PhysicalOperator* probe);
+    std::unique_ptr<PhysicalOperator> createHashAggregate(
+        const binder::expression_vector& keyExpressions,
+        const binder::expression_vector& dependentKeyExpressions,
+        std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
+        std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
+        std::vector<DataPos> aggregatesOutputPos, const planner::Schema& inSchema,
+        const planner::Schema& outSchema, std::unique_ptr<PhysicalOperator> prevOperator,
+        const std::string& paramsString);
+
+    static void mapAccHashJoin(PhysicalOperator* probe);
+
+    static std::vector<DataPos> getExpressionsDataPos(
+        const binder::expression_vector& expressions, const planner::Schema& schema);
 
 public:
     storage::StorageManager& storageManager;

--- a/src/optimizer/CMakeLists.txt
+++ b/src/optimizer/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(kuzu_optimizer
         OBJECT
         acc_hash_join_optimizer.cpp
+        agg_key_dependency_optimizer.cpp
         factorization_rewriter.cpp
         filter_push_down_optimizer.cpp
         logical_operator_collector.cpp

--- a/src/optimizer/agg_key_dependency_optimizer.cpp
+++ b/src/optimizer/agg_key_dependency_optimizer.cpp
@@ -1,0 +1,82 @@
+#include "optimizer/agg_key_dependency_optimizer.h"
+
+#include "binder/expression/property_expression.h"
+#include "planner/logical_plan/logical_operator/logical_aggregate.h"
+#include "planner/logical_plan/logical_operator/logical_distinct.h"
+
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace optimizer {
+
+void AggKeyDependencyOptimizer::rewrite(planner::LogicalPlan* plan) {
+    visitOperator(plan->getLastOperator().get());
+}
+
+void AggKeyDependencyOptimizer::visitOperator(planner::LogicalOperator* op) {
+    // bottom up traversal
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
+        visitOperator(op->getChild(i).get());
+    }
+    visitOperatorSwitch(op);
+}
+
+void AggKeyDependencyOptimizer::visitAggregate(planner::LogicalOperator* op) {
+    auto agg = (LogicalAggregate*)op;
+    auto [keyExpressions, payloadExpressions] =
+        resolveKeysAndDependentKeys(agg->getKeyExpressions());
+    agg->setKeyExpressions(keyExpressions);
+    agg->setDependentKeyExpressions(payloadExpressions);
+}
+
+void AggKeyDependencyOptimizer::visitDistinct(planner::LogicalOperator* op) {
+    auto distinct = (LogicalDistinct*)op;
+    auto [keyExpressions, payloadExpressions] =
+        resolveKeysAndDependentKeys(distinct->getKeyExpressions());
+    distinct->setKeyExpressions(keyExpressions);
+    distinct->setDependentKeyExpressions(payloadExpressions);
+}
+
+std::pair<binder::expression_vector, binder::expression_vector>
+AggKeyDependencyOptimizer::resolveKeysAndDependentKeys(const binder::expression_vector& keys) {
+    // Consider example RETURN a.ID, a.age, COUNT(*).
+    // We first collect a.ID into primaryKeys. Then collect "a" into primaryVarNames.
+    // Finally, we loop through all group by keys to put non-primary key properties under name "a"
+    // into dependentKeyExpressions.
+
+    // Collect primary keys from group keys.
+    std::vector<binder::PropertyExpression*> primaryKeys;
+    for (auto& expression : keys) {
+        if (expression->expressionType == common::PROPERTY) {
+            auto propertyExpression = (binder::PropertyExpression*)expression.get();
+            if (propertyExpression->isPrimaryKey() || propertyExpression->isInternalID()) {
+                primaryKeys.push_back(propertyExpression);
+            }
+        }
+    }
+    // Collect variable names whose primary key is part of group keys.
+    std::unordered_set<std::string> primaryVarNames;
+    for (auto& primaryKey : primaryKeys) {
+        primaryVarNames.insert(primaryKey->getVariableName());
+    }
+    binder::expression_vector groupExpressions;
+    binder::expression_vector dependentExpressions;
+    for (auto& expression : keys) {
+        if (expression->expressionType == common::PROPERTY) {
+            auto propertyExpression = (binder::PropertyExpression*)expression.get();
+            if (propertyExpression->isPrimaryKey() || propertyExpression->isInternalID()) {
+                groupExpressions.push_back(expression);
+            } else if (primaryVarNames.contains(propertyExpression->getVariableName())) {
+                dependentExpressions.push_back(expression);
+            } else {
+                groupExpressions.push_back(expression);
+            }
+        } else {
+            groupExpressions.push_back(expression);
+        }
+    }
+    return std::make_pair(std::move(groupExpressions), std::move(dependentExpressions));
+}
+
+} // namespace optimizer
+} // namespace kuzu

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -1,6 +1,7 @@
 #include "optimizer/optimizer.h"
 
 #include "optimizer/acc_hash_join_optimizer.h"
+#include "optimizer/agg_key_dependency_optimizer.h"
 #include "optimizer/factorization_rewriter.h"
 #include "optimizer/filter_push_down_optimizer.h"
 #include "optimizer/projection_push_down_optimizer.h"
@@ -21,7 +22,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan) {
     auto filterPushDownOptimizer = FilterPushDownOptimizer();
     filterPushDownOptimizer.rewrite(plan);
 
-    // ASP optimizer should be applied after optimizers that manipulate hash join.
+    // HashJoinSIPOptimizer should be applied after optimizers that manipulate hash join.
     auto hashJoinSIPOptimizer = HashJoinSIPOptimizer();
     hashJoinSIPOptimizer.rewrite(plan);
 
@@ -30,6 +31,11 @@ void Optimizer::optimize(planner::LogicalPlan* plan) {
 
     auto factorizationRewriter = FactorizationRewriter();
     factorizationRewriter.rewrite(plan);
+
+    // AggKeyDependencyOptimizer doesn't change factorization structure and thus can be put after
+    // FactorizationRewriter.
+    auto aggKeyDependencyOptimizer = AggKeyDependencyOptimizer();
+    aggKeyDependencyOptimizer.rewrite(plan);
 }
 
 } // namespace optimizer

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -11,28 +11,18 @@ using namespace factorization;
 void LogicalAggregate::computeFactorizedSchema() {
     createEmptySchema();
     auto groupPos = schema->createGroup();
-    for (auto& expression : expressionsToGroupBy) {
-        schema->insertToGroupAndScope(expression, groupPos);
-    }
-    for (auto& expression : expressionsToAggregate) {
-        schema->insertToGroupAndScope(expression, groupPos);
-    }
+    insertAllExpressionsToGroupAndScope(groupPos);
 }
 
 void LogicalAggregate::computeFlatSchema() {
     createEmptySchema();
     schema->createGroup();
-    for (auto& expression : expressionsToGroupBy) {
-        schema->insertToGroupAndScope(expression, 0);
-    }
-    for (auto& expression : expressionsToAggregate) {
-        schema->insertToGroupAndScope(expression, 0);
-    }
+    insertAllExpressionsToGroupAndScope(0 /* groupPos */);
 }
 
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
     f_group_pos_set dependentGroupsPos;
-    for (auto& expression : expressionsToGroupBy) {
+    for (auto& expression : getAllKeyExpressions()) {
         for (auto groupPos : children[0]->getSchema()->getDependentGroupsPos(expression)) {
             dependentGroupsPos.insert(groupPos);
         }
@@ -48,7 +38,7 @@ f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
     if (hasDistinctAggregate()) {
         f_group_pos_set dependentGroupsPos;
-        for (auto& expression : expressionsToAggregate) {
+        for (auto& expression : aggregateExpressions) {
             for (auto groupPos : children[0]->getSchema()->getDependentGroupsPos(expression)) {
                 dependentGroupsPos.insert(groupPos);
             }
@@ -60,11 +50,14 @@ f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
 
 std::string LogicalAggregate::getExpressionsForPrinting() const {
     std::string result = "Group By [";
-    for (auto& expression : expressionsToGroupBy) {
+    for (auto& expression : keyExpressions) {
+        result += expression->toString() + ", ";
+    }
+    for (auto& expression : dependentKeyExpressions) {
         result += expression->toString() + ", ";
     }
     result += "], Aggregate [";
-    for (auto& expression : expressionsToAggregate) {
+    for (auto& expression : aggregateExpressions) {
         result += expression->toString() + ", ";
     }
     result += "]";
@@ -72,13 +65,25 @@ std::string LogicalAggregate::getExpressionsForPrinting() const {
 }
 
 bool LogicalAggregate::hasDistinctAggregate() {
-    for (auto& expressionToAggregate : expressionsToAggregate) {
-        auto& functionExpression = (binder::AggregateFunctionExpression&)*expressionToAggregate;
+    for (auto& expression : aggregateExpressions) {
+        auto& functionExpression = (binder::AggregateFunctionExpression&)*expression;
         if (functionExpression.isDistinct()) {
             return true;
         }
     }
     return false;
+}
+
+void LogicalAggregate::insertAllExpressionsToGroupAndScope(f_group_pos groupPos) {
+    for (auto& expression : keyExpressions) {
+        schema->insertToGroupAndScope(expression, groupPos);
+    }
+    for (auto& expression : dependentKeyExpressions) {
+        schema->insertToGroupAndScope(expression, groupPos);
+    }
+    for (auto& expression : aggregateExpressions) {
+        schema->insertToGroupAndScope(expression, groupPos);
+    }
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -8,7 +8,7 @@ namespace planner {
 void LogicalDistinct::computeFactorizedSchema() {
     createEmptySchema();
     auto groupPos = schema->createGroup();
-    for (auto& expression : expressionsToDistinct) {
+    for (auto& expression : getAllDistinctExpressions()) {
         schema->insertToGroupAndScope(expression, groupPos);
     }
 }
@@ -16,7 +16,7 @@ void LogicalDistinct::computeFactorizedSchema() {
 void LogicalDistinct::computeFlatSchema() {
     createEmptySchema();
     schema->createGroup();
-    for (auto& expression : expressionsToDistinct) {
+    for (auto& expression : getAllDistinctExpressions()) {
         schema->insertToGroupAndScope(expression, 0);
     }
 }
@@ -24,7 +24,7 @@ void LogicalDistinct::computeFlatSchema() {
 f_group_pos_set LogicalDistinct::getGroupsPosToFlatten() {
     f_group_pos_set dependentGroupsPos;
     auto childSchema = children[0]->getSchema();
-    for (auto& expression : expressionsToDistinct) {
+    for (auto& expression : getAllDistinctExpressions()) {
         for (auto groupPos : childSchema->getDependentGroupsPos(expression)) {
             dependentGroupsPos.insert(groupPos);
         }
@@ -34,7 +34,7 @@ f_group_pos_set LogicalDistinct::getGroupsPosToFlatten() {
 
 std::string LogicalDistinct::getExpressionsForPrinting() const {
     std::string result;
-    for (auto& expression : expressionsToDistinct) {
+    for (auto& expression : getAllDistinctExpressions()) {
         result += expression->getUniqueName() + ", ";
     }
     return result;

--- a/src/processor/mapper/map_aggregate.cpp
+++ b/src/processor/mapper/map_aggregate.cpp
@@ -51,6 +51,17 @@ static std::vector<std::unique_ptr<AggregateInputInfo>> getAggregateInputInfos(
     return result;
 }
 
+static binder::expression_vector getKeyExpressions(
+    const binder::expression_vector& expressions, const Schema& schema, bool isFlat) {
+    binder::expression_vector result;
+    for (auto& expression : expressions) {
+        if (schema.getGroup(schema.getGroupPos(*expression))->isFlat() == isFlat) {
+            result.emplace_back(expression);
+        }
+    }
+    return result;
+}
+
 std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAggregateToPhysical(
     LogicalOperator* logicalOperator) {
     auto& logicalAggregate = (const LogicalAggregate&)*logicalOperator;
@@ -58,21 +69,20 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAggregateToPhysical(
     auto inSchema = logicalAggregate.getChild(0)->getSchema();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
     auto paramsString = logicalAggregate.getExpressionsForPrinting();
-    std::vector<DataPos> outputAggVectorsPos{logicalAggregate.getNumAggregateExpressions()};
-    std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions{
-        logicalAggregate.getNumAggregateExpressions()};
-    for (auto i = 0u; i < logicalAggregate.getNumAggregateExpressions(); ++i) {
-        auto expression = logicalAggregate.getAggregateExpression(i);
-        aggregateFunctions[i] =
-            ((AggregateFunctionExpression&)*expression).aggregateFunction->clone();
-        outputAggVectorsPos[i] = DataPos(outSchema->getExpressionPos(*expression));
+    std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions;
+    for (auto& expression : logicalAggregate.getAggregateExpressions()) {
+        aggregateFunctions.push_back(
+            ((AggregateFunctionExpression&)*expression).aggregateFunction->clone());
     }
-    auto aggregateInputInfos = getAggregateInputInfos(logicalAggregate.getExpressionsToGroupBy(),
-        logicalAggregate.getExpressionsToAggregate(), *inSchema);
-    if (logicalAggregate.hasExpressionsToGroupBy()) {
-        return createHashAggregate(std::move(aggregateFunctions), std::move(aggregateInputInfos),
-            outputAggVectorsPos, logicalAggregate.getExpressionsToGroupBy(),
-            std::move(prevOperator), *inSchema, *outSchema, paramsString);
+    auto aggregatesOutputPos =
+        getExpressionsDataPos(logicalAggregate.getAggregateExpressions(), *outSchema);
+    auto aggregateInputInfos = getAggregateInputInfos(logicalAggregate.getAllKeyExpressions(),
+        logicalAggregate.getAggregateExpressions(), *inSchema);
+    if (logicalAggregate.hasKeyExpressions()) {
+        return createHashAggregate(logicalAggregate.getKeyExpressions(),
+            logicalAggregate.getDependentKeyExpressions(), std::move(aggregateFunctions),
+            std::move(aggregateInputInfos), std::move(aggregatesOutputPos), *inSchema, *outSchema,
+            std::move(prevOperator), paramsString);
     } else {
         auto sharedState = make_shared<SimpleAggregateSharedState>(aggregateFunctions);
         auto aggregate =
@@ -80,72 +90,36 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalAggregateToPhysical(
                 sharedState, std::move(aggregateFunctions), std::move(aggregateInputInfos),
                 std::move(prevOperator), getOperatorID(), paramsString);
         return make_unique<SimpleAggregateScan>(
-            sharedState, outputAggVectorsPos, std::move(aggregate), getOperatorID(), paramsString);
+            sharedState, aggregatesOutputPos, std::move(aggregate), getOperatorID(), paramsString);
     }
 }
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(
-    std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions,
-    std::vector<std::unique_ptr<AggregateInputInfo>> inputAggregateInfo,
-    std::vector<DataPos> outputAggVectorsPos, const expression_vector& groupByExpressions,
-    std::unique_ptr<PhysicalOperator> prevOperator, const Schema& inSchema, const Schema& outSchema,
+    const binder::expression_vector& keyExpressions,
+    const binder::expression_vector& dependentKeyExpressions,
+    std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
+    std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
+    std::vector<DataPos> aggregatesOutputPos, const planner::Schema& inSchema,
+    const planner::Schema& outSchema, std::unique_ptr<PhysicalOperator> prevOperator,
     const std::string& paramsString) {
-    expression_vector groupByHashExpressions;
-    expression_vector groupByNonHashExpressions;
-    std::unordered_set<std::string> HashPrimaryKeysNodeId;
-    for (auto& expressionToGroupBy : groupByExpressions) {
-        if (expressionToGroupBy->expressionType == PROPERTY) {
-            auto& propertyExpression = (const PropertyExpression&)(*expressionToGroupBy);
-            if (propertyExpression.isInternalID()) {
-                groupByHashExpressions.push_back(expressionToGroupBy);
-                HashPrimaryKeysNodeId.insert(propertyExpression.getVariableName());
-            } else if (HashPrimaryKeysNodeId.contains(propertyExpression.getVariableName())) {
-                groupByNonHashExpressions.push_back(expressionToGroupBy);
-            } else {
-                groupByHashExpressions.push_back(expressionToGroupBy);
-            }
-        } else {
-            groupByHashExpressions.push_back(expressionToGroupBy);
-        }
-    }
-    std::vector<DataPos> inputGroupByHashKeyVectorsPos;
-    std::vector<DataPos> inputGroupByNonHashKeyVectorsPos;
-    std::vector<bool> isInputGroupByHashKeyVectorFlat;
-    std::vector<DataPos> outputGroupByKeyVectorsPos;
-    appendGroupByExpressions(groupByHashExpressions, inputGroupByHashKeyVectorsPos,
-        outputGroupByKeyVectorsPos, inSchema, outSchema, isInputGroupByHashKeyVectorFlat);
-    appendGroupByExpressions(groupByNonHashExpressions, inputGroupByNonHashKeyVectorsPos,
-        outputGroupByKeyVectorsPos, inSchema, outSchema, isInputGroupByHashKeyVectorFlat);
     auto sharedState = make_shared<HashAggregateSharedState>(aggregateFunctions);
+    auto flatKeyExpressions = getKeyExpressions(keyExpressions, inSchema, true /* isFlat */);
+    auto unFlatKeyExpressions = getKeyExpressions(keyExpressions, inSchema, false /* isFlat */);
     auto aggregate = make_unique<HashAggregate>(std::make_unique<ResultSetDescriptor>(inSchema),
-        sharedState, inputGroupByHashKeyVectorsPos, inputGroupByNonHashKeyVectorsPos,
-        isInputGroupByHashKeyVectorFlat, std::move(aggregateFunctions),
-        std::move(inputAggregateInfo), std::move(prevOperator), getOperatorID(), paramsString);
-    auto aggregateScan =
-        std::make_unique<HashAggregateScan>(sharedState, outputGroupByKeyVectorsPos,
-            std::move(outputAggVectorsPos), std::move(aggregate), getOperatorID(), paramsString);
-    return aggregateScan;
-}
-
-void PlanMapper::appendGroupByExpressions(const expression_vector& groupByExpressions,
-    std::vector<DataPos>& inputGroupByHashKeyVectorsPos,
-    std::vector<DataPos>& outputGroupByKeyVectorsPos, const Schema& inSchema,
-    const Schema& outSchema, std::vector<bool>& isInputGroupByHashKeyVectorFlat) {
-    for (auto& expression : groupByExpressions) {
-        if (inSchema.getGroup(expression->getUniqueName())->isFlat()) {
-            inputGroupByHashKeyVectorsPos.emplace_back(inSchema.getExpressionPos(*expression));
-            outputGroupByKeyVectorsPos.emplace_back(outSchema.getExpressionPos(*expression));
-            isInputGroupByHashKeyVectorFlat.push_back(true);
-        }
-    }
-
-    for (auto& expression : groupByExpressions) {
-        if (!inSchema.getGroup(expression->getUniqueName())->isFlat()) {
-            inputGroupByHashKeyVectorsPos.emplace_back(inSchema.getExpressionPos(*expression));
-            outputGroupByKeyVectorsPos.emplace_back(outSchema.getExpressionPos(*expression));
-            isInputGroupByHashKeyVectorFlat.push_back(false);
-        }
-    }
+        sharedState, getExpressionsDataPos(flatKeyExpressions, inSchema),
+        getExpressionsDataPos(unFlatKeyExpressions, inSchema),
+        getExpressionsDataPos(dependentKeyExpressions, inSchema), std::move(aggregateFunctions),
+        std::move(aggregateInputInfos), std::move(prevOperator), getOperatorID(), paramsString);
+    binder::expression_vector outputExpressions;
+    outputExpressions.insert(
+        outputExpressions.end(), flatKeyExpressions.begin(), flatKeyExpressions.end());
+    outputExpressions.insert(
+        outputExpressions.end(), unFlatKeyExpressions.begin(), unFlatKeyExpressions.end());
+    outputExpressions.insert(
+        outputExpressions.end(), dependentKeyExpressions.begin(), dependentKeyExpressions.end());
+    return std::make_unique<HashAggregateScan>(sharedState,
+        getExpressionsDataPos(outputExpressions, outSchema), std::move(aggregatesOutputPos),
+        std::move(aggregate), getOperatorID(), paramsString);
 }
 
 } // namespace processor

--- a/src/processor/mapper/map_distinct.cpp
+++ b/src/processor/mapper/map_distinct.cpp
@@ -12,15 +12,15 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalDistinctToPhysical(
     LogicalOperator* logicalOperator) {
     auto& logicalDistinct = (const LogicalDistinct&)*logicalOperator;
     auto outSchema = logicalDistinct.getSchema();
-    auto inSchema = logicalDistinct.getSchemaBeforeDistinct();
+    auto inSchema = logicalDistinct.getChild(0)->getSchema();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
-    std::vector<std::unique_ptr<function::AggregateFunction>> emptyAggregateFunctions;
+    std::vector<std::unique_ptr<function::AggregateFunction>> emptyAggFunctions;
     std::vector<std::unique_ptr<AggregateInputInfo>> emptyAggInputInfos;
-    std::vector<DataPos> emptyOutputAggVectorsPos;
-    return createHashAggregate(std::move(emptyAggregateFunctions), std::move(emptyAggInputInfos),
-        emptyOutputAggVectorsPos, logicalDistinct.getExpressionsToDistinct(),
-        std::move(prevOperator), *inSchema, *outSchema,
-        logicalDistinct.getExpressionsForPrinting());
+    std::vector<DataPos> emptyAggregatesOutputPos;
+    return createHashAggregate(logicalDistinct.getKeyExpressions(),
+        logicalDistinct.getDependentKeyExpressions(), std::move(emptyAggFunctions),
+        std::move(emptyAggInputInfos), std::move(emptyAggregatesOutputPos), *inSchema, *outSchema,
+        std::move(prevOperator), logicalDistinct.getExpressionsForPrinting());
 }
 
 } // namespace processor

--- a/src/processor/mapper/plan_mapper.cpp
+++ b/src/processor/mapper/plan_mapper.cpp
@@ -162,5 +162,14 @@ std::unique_ptr<ResultCollector> PlanMapper::appendResultCollector(
         binder::ExpressionUtil::toString(expressionsToCollect));
 }
 
+std::vector<DataPos> PlanMapper::getExpressionsDataPos(
+    const binder::expression_vector& expressions, const planner::Schema& schema) {
+    std::vector<DataPos> result;
+    for (auto& expression : expressions) {
+        result.emplace_back(schema.getExpressionPos(*expression));
+    }
+    return result;
+}
+
 } // namespace processor
 } // namespace kuzu

--- a/test/test_files/tinysnb/agg/multi_query_part.test
+++ b/test/test_files/tinysnb/agg/multi_query_part.test
@@ -38,3 +38,9 @@ True
 3|5|3
 7|8|2
 7|9|2
+
+-NAME GroupByMultiQueryTest3
+-QUERY MATCH (a:person) WHERE a.ID > 4 WITH a, a.age AS foo MATCH (a)-[:knows]->(b:person) RETURN a.ID, foo, COUNT(*)
+---- 2
+5|20|3
+7|20|2


### PR DESCRIPTION
This PR adds AggregateKeyDependencyOptimizer which analyzes user input group by keys' dependency and split into `keys` and `dependentKeys`. A `dependentKey` has functional dependency on a `key`. `keys` will be hashed during hash aggregate while `dependentKeys` will be directly materialized into f-table. 

Consider the following example
```
RETURN a.ID, a.age, COUNT(*)
```

Based on user input, both `a.ID` and `a.age` are stated as hash keys. However, since `a.ID` is the primary key, `a.age` has functional dependency on `a.ID` so we only need to hash `a.ID` in hash aggregate.

This optimizer is more important given Cypher grammar because the grammar itself doesn't differentiate `SELECT` and `GROUP BY` which means user cannot group by a subset of selection list. Another case is Cypher allows group by `Node` or `Rel` which by definition is to group by all properties of `Node` or `Rel`. A more reasonable solution is to only group by their internal IDs and treat properties as dependentKeys.

## Performance benchmark
Dataset: LDBC100
Machine: M1 Pro, 16GB memory, maximum 4 threads
Query: `MATCH (a:Person)-[:knows]->(b:Person) RETURN keys, COUNT(*) LIMIT 1;` (Note that Aggregate is a Sink operator that is not affected by LIMIT, LIMIT 1 is to reduce print size).

| Keys | Optimizer ON    | Optimizer OFF |
| ----- | -------- | ------- |
| ID | 207 ms  | 198 ms   |
| ID, firstName| 204 ms  | 292 ms   |
| ID, firstName, lastName | 214 ms  | 356 ms   |