### PR TITLE
Add support to struct of list

### DIFF
--- a/src/common/data_chunk/data_chunk.cpp
+++ b/src/common/data_chunk/data_chunk.cpp
@@ -4,7 +4,7 @@ namespace kuzu {
 namespace common {
 
 void DataChunk::insert(uint32_t pos, std::shared_ptr<ValueVector> valueVector) {
-    valueVector->setState(this->state);
+    valueVector->setState(state);
     assert(valueVectors.size() > pos);
     valueVectors[pos] = std::move(valueVector);
 }

--- a/src/expression_evaluator/base_evaluator.cpp
+++ b/src/expression_evaluator/base_evaluator.cpp
@@ -16,13 +16,13 @@ void BaseExpressionEvaluator::resolveResultStateFromChildren(
     for (auto& input : inputEvaluators) {
         if (!input->isResultFlat()) {
             isResultFlat_ = false;
-            resultVector->state = input->resultVector->state;
+            resultVector->setState(input->resultVector->state);
             return;
         }
     }
     // All children are flat.
     isResultFlat_ = true;
-    resultVector->state = common::DataChunkState::getSingleValueDataChunkState();
+    resultVector->setState(common::DataChunkState::getSingleValueDataChunkState());
 }
 
 } // namespace evaluator

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -78,15 +78,11 @@ void FunctionExpressionEvaluator::resolveResultVector(
         // If the resultVector and inputVector are in different dataChunks, we should create a new
         // child valueVector, which shares the state with the resultVector, instead of reusing the
         // inputVector.
-        for (auto& inputEvaluator : inputEvaluators) {
-            if (inputEvaluator->resultVector->state != resultVector->state) {
-                auto structFieldVector = std::make_shared<common::ValueVector>(
-                    inputEvaluator->resultVector->dataType, memoryManager);
-                structFieldVector->state = resultVector->state;
-                common::StructVector::addChildVector(resultVector.get(), structFieldVector);
-            } else {
-                common::StructVector::addChildVector(
-                    resultVector.get(), inputEvaluator->resultVector);
+        for (auto i = 0u; i < inputEvaluators.size(); i++) {
+            auto inputEvaluator = inputEvaluators[i];
+            if (inputEvaluator->resultVector->state == resultVector->state) {
+                common::StructVector::referenceVector(
+                    resultVector.get(), i, inputEvaluator->resultVector);
             }
         }
     }

--- a/src/function/vector_list_operation.cpp
+++ b/src/function/vector_list_operation.cpp
@@ -51,10 +51,6 @@ std::unique_ptr<FunctionBindData> ListCreationVectorOperation::bindFunc(
         throw BinderException(
             "Cannot resolve child data type for " + LIST_CREATION_FUNC_NAME + ".");
     }
-    // TODO(Ziyi): Support list of structs.
-    if (arguments[0]->getDataType().getTypeID() == common::STRUCT) {
-        throw BinderException("Cannot create a list of structs.");
-    }
     for (auto i = 1u; i < arguments.size(); i++) {
         if (arguments[i]->getDataType() != arguments[0]->getDataType()) {
             throw BinderException(getListFunctionIncompatibleChildrenTypeErrorMsg(

--- a/src/include/common/data_chunk/data_chunk.h
+++ b/src/include/common/data_chunk/data_chunk.h
@@ -27,10 +27,6 @@ public:
 
     void insert(uint32_t pos, std::shared_ptr<ValueVector> valueVector);
 
-    inline void addValueVector(std::shared_ptr<ValueVector> valueVector) {
-        valueVectors.push_back(valueVector);
-    }
-
     inline uint32_t getNumValueVectors() const { return valueVectors.size(); }
 
     inline std::shared_ptr<ValueVector> getValueVector(uint64_t valueVectorPos) {

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -32,6 +32,7 @@ using vector_idx_t = uint32_t;
 constexpr vector_idx_t INVALID_VECTOR_IDX = UINT32_MAX;
 using block_idx_t = uint64_t;
 using field_idx_t = uint64_t;
+using struct_entry_t = int64_t;
 
 // System representation for a variable-sized overflow value.
 struct overflow_value_t {

--- a/src/include/common/vector/auxiliary_buffer.h
+++ b/src/include/common/vector/auxiliary_buffer.h
@@ -29,10 +29,11 @@ private:
 
 class StructAuxiliaryBuffer : public AuxiliaryBuffer {
 public:
-    StructAuxiliaryBuffer() = default;
+    StructAuxiliaryBuffer(const DataType& type, storage::MemoryManager* memoryManager);
 
-    inline void addChildVector(std::shared_ptr<ValueVector> valueVector) {
-        childrenVectors.emplace_back(std::move(valueVector));
+    inline void referenceChildVector(
+        vector_idx_t idx, std::shared_ptr<ValueVector> vectorToReference) {
+        childrenVectors[idx] = std::move(vectorToReference);
     }
     inline const std::vector<std::shared_ptr<ValueVector>>& getChildrenVectors() const {
         return childrenVectors;
@@ -51,7 +52,7 @@ private:
 // contiguous subsequence of elements in this vector.
 class ListAuxiliaryBuffer : public AuxiliaryBuffer {
 public:
-    ListAuxiliaryBuffer(DataType& dataVectorType, storage::MemoryManager* memoryManager);
+    ListAuxiliaryBuffer(const DataType& dataVectorType, storage::MemoryManager* memoryManager);
 
     inline ValueVector* getDataVector() const { return dataVector.get(); }
 

--- a/src/include/common/vector/value_vector_utils.h
+++ b/src/include/common/vector/value_vector_utils.h
@@ -19,9 +19,6 @@ public:
 private:
     static void copyNonNullDataWithSameType(const DataType& dataType, const uint8_t* srcData,
         uint8_t* dstData, InMemOverflowBuffer& inMemOverflowBuffer);
-    static ku_list_t convertListEntryToKuList(
-        const ValueVector& srcVector, uint64_t pos, InMemOverflowBuffer& dstOverflowBuffer);
-    static void copyKuListToVector(ValueVector& dstVector, uint64_t pos, const ku_list_t& srcList);
 };
 
 } // namespace common

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -508,7 +508,8 @@ overflow_value_t FactorizedTable::appendVectorToUnflatTupleBlocks(
     const ValueVector& vector, ft_col_idx_t colIdx) {
     assert(!vector.state->isFlat());
     auto numFlatTuplesInVector = vector.state->selVector->selectedSize;
-    auto numBytesForData = vector.getNumBytesPerValue() * numFlatTuplesInVector;
+    auto numBytesPerValue = Types::getDataTypeSize(vector.dataType);
+    auto numBytesForData = numBytesPerValue * numFlatTuplesInVector;
     auto overflowBlockBuffer = allocateUnflatTupleBlock(
         numBytesForData + FactorizedTableSchema::getNumBytesForNullBuffer(numFlatTuplesInVector));
     if (vector.state->selVector->isUnfiltered()) {
@@ -517,7 +518,7 @@ overflow_value_t FactorizedTable::appendVectorToUnflatTupleBlocks(
             for (auto i = 0u; i < numFlatTuplesInVector; i++) {
                 ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(
                     vector, i, dstDataBuffer, *inMemOverflowBuffer);
-                dstDataBuffer += vector.getNumBytesPerValue();
+                dstDataBuffer += numBytesPerValue;
             }
         } else {
             auto dstDataBuffer = overflowBlockBuffer;
@@ -528,7 +529,7 @@ overflow_value_t FactorizedTable::appendVectorToUnflatTupleBlocks(
                     ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(
                         vector, i, dstDataBuffer, *inMemOverflowBuffer);
                 }
-                dstDataBuffer += vector.getNumBytesPerValue();
+                dstDataBuffer += numBytesPerValue;
             }
         }
     } else {
@@ -538,7 +539,7 @@ overflow_value_t FactorizedTable::appendVectorToUnflatTupleBlocks(
                 ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(vector,
                     vector.state->selVector->selectedPositions[i], dstDataBuffer,
                     *inMemOverflowBuffer);
-                dstDataBuffer += vector.getNumBytesPerValue();
+                dstDataBuffer += numBytesPerValue;
             }
         } else {
             auto dstDataBuffer = overflowBlockBuffer;
@@ -550,7 +551,7 @@ overflow_value_t FactorizedTable::appendVectorToUnflatTupleBlocks(
                     ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(
                         vector, pos, dstDataBuffer, *inMemOverflowBuffer);
                 }
-                dstDataBuffer += vector.getNumBytesPerValue();
+                dstDataBuffer += numBytesPerValue;
             }
         }
     }

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -509,12 +509,6 @@ TEST_F(BinderErrorTest, MissingStructFields) {
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
-TEST_F(BinderErrorTest, ListCreationOfStruct) {
-    std::string expectedException = "Binder exception: Cannot create a list of structs.";
-    auto input = "RETURN [{a: 5, b: 3}]";
-    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
-}
-
 TEST_F(BinderErrorTest, NonPKSerialType) {
     std::string expectedException =
         "Binder exception: Serial property in node table must be the primary key.";

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -469,3 +469,33 @@ Dan|Carol
 {DESCRIPTION: {GENDER: 2, AGE: 30}, NAME: Bob}
 {DESCRIPTION: {GENDER: 2, AGE: 40}, NAME: Greg}
 {DESCRIPTION: {GENDER: 2, AGE: 83}, NAME: Hubert Blaine Wolfeschlegelsteinhausenbergerdorff}
+
+-NAME ReturnNestedListOfStructLiteral
+-QUERY MATCH (p:person) return [{description: {propA: p.gender, propB: [p.age, 10]}, name: p.fName}, {description: {propA: p.ID, propB: [p.gender, 20]}, name: p.fName}]
+---- 8
+[{DESCRIPTION: {PROPA: 1, PROPB: [35,10]}, NAME: Alice},{DESCRIPTION: {PROPA: 0, PROPB: [1,20]}, NAME: Alice}]
+[{DESCRIPTION: {PROPA: 2, PROPB: [30,10]}, NAME: Bob},{DESCRIPTION: {PROPA: 2, PROPB: [2,20]}, NAME: Bob}]
+[{DESCRIPTION: {PROPA: 1, PROPB: [45,10]}, NAME: Carol},{DESCRIPTION: {PROPA: 3, PROPB: [1,20]}, NAME: Carol}]
+[{DESCRIPTION: {PROPA: 2, PROPB: [20,10]}, NAME: Dan},{DESCRIPTION: {PROPA: 5, PROPB: [2,20]}, NAME: Dan}]
+[{DESCRIPTION: {PROPA: 1, PROPB: [20,10]}, NAME: Elizabeth},{DESCRIPTION: {PROPA: 7, PROPB: [1,20]}, NAME: Elizabeth}]
+[{DESCRIPTION: {PROPA: 2, PROPB: [25,10]}, NAME: Farooq},{DESCRIPTION: {PROPA: 8, PROPB: [2,20]}, NAME: Farooq}]
+[{DESCRIPTION: {PROPA: 2, PROPB: [40,10]}, NAME: Greg},{DESCRIPTION: {PROPA: 9, PROPB: [2,20]}, NAME: Greg}]
+[{DESCRIPTION: {PROPA: 2, PROPB: [83,10]}, NAME: Hubert Blaine Wolfeschlegelsteinhausenbergerdorff},{DESCRIPTION: {PROPA: 10, PROPB: [2,20]}, NAME: Hubert Blaine Wolfeschlegelsteinhausenbergerdorff}]
+
+-NAME ReturnNestedListOfStructWithUnflatFlatChildren
+-QUERY MATCH (p1:person)-[e:knows]->(p2:person) return [{description: {propA: [p1.gender, p2.gender], propB: e.date}, name: p1.fName}, {description: {propA: [p1.ID, p2.ID], propB: p1.birthdate}, name: p2.fName}]
+---- 14
+[{DESCRIPTION: {PROPA: [1,2], PROPB: 2021-06-30}, NAME: Alice},{DESCRIPTION: {PROPA: [0,2], PROPB: 1900-01-01}, NAME: Bob}]
+[{DESCRIPTION: {PROPA: [1,1], PROPB: 2021-06-30}, NAME: Alice},{DESCRIPTION: {PROPA: [0,3], PROPB: 1900-01-01}, NAME: Carol}]
+[{DESCRIPTION: {PROPA: [1,2], PROPB: 2021-06-30}, NAME: Alice},{DESCRIPTION: {PROPA: [0,5], PROPB: 1900-01-01}, NAME: Dan}]
+[{DESCRIPTION: {PROPA: [2,1], PROPB: 2021-06-30}, NAME: Bob},{DESCRIPTION: {PROPA: [2,0], PROPB: 1900-01-01}, NAME: Alice}]
+[{DESCRIPTION: {PROPA: [2,1], PROPB: 1950-05-14}, NAME: Bob},{DESCRIPTION: {PROPA: [2,3], PROPB: 1900-01-01}, NAME: Carol}]
+[{DESCRIPTION: {PROPA: [2,2], PROPB: 1950-05-14}, NAME: Bob},{DESCRIPTION: {PROPA: [2,5], PROPB: 1900-01-01}, NAME: Dan}]
+[{DESCRIPTION: {PROPA: [1,1], PROPB: 2021-06-30}, NAME: Carol},{DESCRIPTION: {PROPA: [3,0], PROPB: 1940-06-22}, NAME: Alice}]
+[{DESCRIPTION: {PROPA: [1,2], PROPB: 1950-05-14}, NAME: Carol},{DESCRIPTION: {PROPA: [3,2], PROPB: 1940-06-22}, NAME: Bob}]
+[{DESCRIPTION: {PROPA: [1,2], PROPB: 2000-01-01}, NAME: Carol},{DESCRIPTION: {PROPA: [3,5], PROPB: 1940-06-22}, NAME: Dan}]
+[{DESCRIPTION: {PROPA: [2,1], PROPB: 2021-06-30}, NAME: Dan},{DESCRIPTION: {PROPA: [5,0], PROPB: 1950-07-23}, NAME: Alice}]
+[{DESCRIPTION: {PROPA: [2,2], PROPB: 1950-05-14}, NAME: Dan},{DESCRIPTION: {PROPA: [5,2], PROPB: 1950-07-23}, NAME: Bob}]
+[{DESCRIPTION: {PROPA: [2,1], PROPB: 2000-01-01}, NAME: Dan},{DESCRIPTION: {PROPA: [5,3], PROPB: 1950-07-23}, NAME: Carol}]
+[{DESCRIPTION: {PROPA: [1,2], PROPB: 1905-12-12}, NAME: Elizabeth},{DESCRIPTION: {PROPA: [7,8], PROPB: 1980-10-26}, NAME: Farooq}]
+[{DESCRIPTION: {PROPA: [1,2], PROPB: 1905-12-12}, NAME: Elizabeth},{DESCRIPTION: {PROPA: [7,9], PROPB: 1980-10-26}, NAME: Greg}]


### PR DESCRIPTION
This PR adds support to struct of list.
1. When we are constructing the structValueVector, we should also create the corresponding children ValueVectors based on the children dataType. 
2. When we set the state of the structValueVector, we should also set the children state. => This guarantees that the children's vector state is always consistent with the parent's vector state.
3. Refactors the ValueVectorUtils