### PR TITLE
Support null values in list

### DIFF
--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -19,6 +19,8 @@ public:
 
     std::shared_ptr<Expression> bindExpression(const parser::ParsedExpression& parsedExpression);
 
+    static void resolveAnyDataType(Expression& expression, const common::DataType& targetType);
+
 private:
     std::shared_ptr<Expression> bindBooleanExpression(
         const parser::ParsedExpression& parsedExpression);
@@ -91,7 +93,6 @@ private:
         const std::shared_ptr<Expression>& expression, const common::DataType& targetType);
     static std::shared_ptr<Expression> implicitCastIfNecessary(
         const std::shared_ptr<Expression>& expression, common::DataTypeID targetTypeID);
-    static void resolveAnyDataType(Expression& expression, const common::DataType& targetType);
     static std::shared_ptr<Expression> implicitCast(
         const std::shared_ptr<Expression>& expression, const common::DataType& targetType);
 

--- a/src/include/common/null_bytes.h
+++ b/src/include/common/null_bytes.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kuzu {
+namespace common {
+
+class NullBuffer {
+
+public:
+    constexpr static const uint64_t NUM_NULL_MASKS_PER_BYTE = 8;
+
+    static inline bool isNull(const uint8_t* nullBytes, uint64_t valueIdx) {
+        return nullBytes[valueIdx / NUM_NULL_MASKS_PER_BYTE] &
+               (1 << (valueIdx % NUM_NULL_MASKS_PER_BYTE));
+    }
+
+    static inline void setNull(uint8_t* nullBytes, uint64_t valueIdx) {
+        nullBytes[valueIdx / NUM_NULL_MASKS_PER_BYTE] |=
+            (1 << (valueIdx % NUM_NULL_MASKS_PER_BYTE));
+    }
+
+    static inline uint64_t getNumBytesForNullValues(uint64_t numValues) {
+        return (numValues + NUM_NULL_MASKS_PER_BYTE - 1) / NUM_NULL_MASKS_PER_BYTE;
+    }
+
+    static inline void initNullBytes(uint8_t* nullBytes, uint64_t numValues) {
+        memset(nullBytes, 0 /* value */, getNumBytesForNullValues(numValues));
+    }
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -149,10 +149,6 @@ public:
         columns[idx]->setMayContainsNullsToTrue();
     }
 
-    static inline uint32_t getNumBytesForNullBuffer(uint32_t numColumns) {
-        return (numColumns >> 3) + ((numColumns & 7) != 0); // &7 is the same as %8;
-    }
-
     inline bool isEmpty() const { return columns.empty(); }
 
     bool operator==(const FactorizedTableSchema& other) const;
@@ -264,8 +260,6 @@ public:
     int64_t findValueInFlatColumn(ft_col_idx_t colIdx, int64_t value) const;
 
 private:
-    static bool isNull(const uint8_t* nullMapBuffer, ft_col_idx_t idx);
-    void setNull(uint8_t* nullBuffer, ft_col_idx_t idx);
     void setOverflowColNull(uint8_t* nullBuffer, ft_col_idx_t colIdx, ft_tuple_idx_t tupleIdx);
 
     uint64_t computeNumTuplesToAppend(

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -468,13 +468,6 @@ TEST_F(BinderErrorTest, RenamePropertyDuplicateName) {
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }
 
-TEST_F(BinderErrorTest, EmptyList) {
-    std::string expectedException =
-        "Binder exception: Cannot resolve child data type for LIST_CREATION.";
-    auto input = "RETURN []";
-    ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
-}
-
 TEST_F(BinderErrorTest, InvalidFixedListChildType) {
     std::string expectedException =
         "Binder exception: The child type of a fixed list must be a numeric type. Given: STRING.";

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -132,6 +132,26 @@ False
 [[10]]
 [[7],[10],[6,7]]
 
+-NAME ListWithNullValues
+-QUERY RETURN [5, null, 100, null, null]
+---- 1
+[5,,100,,]
+
+-NAME NestedListWithNullValues
+-QUERY RETURN [[78, null, 100, null, null], null, [null, 5, null, 100, null]]
+---- 1
+[[78,,100,,],,[,5,,100,]]
+
+-NAME EmptyList
+-QUERY RETURN []
+---- 1
+[]
+
+-NAME NestedEmptyList
+-QUERY RETURN [[],[]]
+---- 1
+[[],[]]
+
 -NAME CrossProductReturn
 -QUERY MATCH (a:organisation), (b:organisation) RETURN a.orgCode = b.orgCode
 ---- 9


### PR DESCRIPTION
1. Adds support to null values within a list:
    a. For valueVectors, we store the nullMasks for each value in the ListDataVector.
    b. For ku_list_t, we store the nullMasks at the start of the overflow buffer.
2. Adds support to return an empty list: 
If a list contains no elements, the list dataType will be INT64[]