### PR TITLE
Add list_sum and list_sort functions

### DIFF
--- a/src/function/built_in_vector_operations.cpp
+++ b/src/function/built_in_vector_operations.cpp
@@ -441,6 +441,8 @@ void BuiltInVectorOperations::registerListOperations() {
     vectorOperations.insert({ARRAY_HAS_FUNC_NAME, ListContainsVectorOperation::getDefinitions()});
     vectorOperations.insert({LIST_SLICE_FUNC_NAME, ListSliceVectorOperation::getDefinitions()});
     vectorOperations.insert({ARRAY_SLICE_FUNC_NAME, ListSliceVectorOperation::getDefinitions()});
+    vectorOperations.insert({LIST_SORT_FUNC_NAME, ListSortVectorOperation::getDefinitions()});
+    vectorOperations.insert({LIST_SUM_FUNC_NAME, ListSumVectorOperation::getDefinitions()});
 }
 
 void BuiltInVectorOperations::registerInternalIDOperation() {

--- a/src/include/common/expression_type.h
+++ b/src/include/common/expression_type.h
@@ -55,6 +55,8 @@ const std::string ARRAY_CONTAINS_FUNC_NAME = "ARRAY_CONTAINS";
 const std::string ARRAY_HAS_FUNC_NAME = "ARRAY_HAS";
 const std::string LIST_SLICE_FUNC_NAME = "LIST_SLICE";
 const std::string ARRAY_SLICE_FUNC_NAME = "ARRAY_SLICE";
+const std::string LIST_SUM_FUNC_NAME = "LIST_SUM";
+const std::string LIST_SORT_FUNC_NAME = "LIST_SORT";
 
 // struct
 const std::string STRUCT_PACK_FUNC_NAME = "STRUCT_PACK";

--- a/src/include/function/list/operations/list_sort_operation.h
+++ b/src/include/function/list/operations/list_sort_operation.h
@@ -1,0 +1,125 @@
+#pragma once
+
+#include "common/vector/value_vector.h"
+
+namespace kuzu {
+namespace function {
+namespace operation {
+
+template<typename T>
+struct ListSort {
+    static inline void operation(common::list_entry_t& input, common::list_entry_t& result,
+        common::ValueVector& inputVector, common::ValueVector& resultVector) {
+        sortValues(
+            input, result, inputVector, resultVector, true /* ascOrder */, true /* nullFirst */);
+    }
+
+    static inline void operation(common::list_entry_t& input, common::ku_string_t& sortOrder,
+        common::list_entry_t& result, common::ValueVector& inputVector,
+        common::ValueVector& valueVector, common::ValueVector& resultVector) {
+        sortValues(input, result, inputVector, resultVector, isAscOrder(sortOrder.getAsString()),
+            true /* nullFirst */);
+    }
+
+    static inline void operation(common::list_entry_t& input, common::ku_string_t& sortOrder,
+        common::ku_string_t& nullOrder, common::list_entry_t& result,
+        common::ValueVector& inputVector, common::ValueVector& resultVector) {
+        sortValues(input, result, inputVector, resultVector, isAscOrder(sortOrder.getAsString()),
+            isNullFirst(nullOrder.getAsString()));
+    }
+
+    static inline bool isAscOrder(const std::string& sortOrder) {
+        if (sortOrder == "ASC") {
+            return true;
+        } else if (sortOrder == "DESC") {
+            return false;
+        } else {
+            throw common::RuntimeException("Invalid sortOrder");
+        }
+    }
+
+    static inline bool isNullFirst(const std::string& nullOrder) {
+        if (nullOrder == "NULLS FIRST") {
+            return true;
+        } else if (nullOrder == "NULLS LAST") {
+            return false;
+        } else {
+            throw common::RuntimeException("Invalid nullOrder");
+        }
+    }
+
+    static void sortValues(common::list_entry_t& input, common::list_entry_t& result,
+        common::ValueVector& inputVector, common::ValueVector& resultVector, bool ascOrder,
+        bool nullFirst) {
+        // TODO(Ziyi) - Replace this sort implementation with radix_sort implementation:
+        //  https://github.com/kuzudb/kuzu/issues/1536.
+        auto inputValues = common::ListVector::getListValues(&inputVector, input);
+        auto inputDataVector = common::ListVector::getDataVector(&inputVector);
+
+        // Calculate null count.
+        auto nullCount = 0;
+        for (auto i = 0; i < input.size; i++) {
+            if (inputDataVector->isNull(input.offset + i)) {
+                nullCount += 1;
+            }
+        }
+
+        result = common::ListVector::addList(&resultVector, input.size);
+        auto resultValues = common::ListVector::getListValues(&resultVector, result);
+        auto resultDataVector = common::ListVector::getDataVector(&resultVector);
+        auto numBytesPerValue = resultDataVector->getNumBytesPerValue();
+
+        // Add nulls first.
+        if (nullFirst) {
+            setVectorRangeToNull(*resultDataVector, result.offset, 0, nullCount);
+            resultValues += numBytesPerValue * nullCount;
+        }
+
+        // Add actual data.
+        for (auto i = 0; i < input.size; i++) {
+            if (inputDataVector->isNull(input.offset + i)) {
+                inputValues += numBytesPerValue;
+                continue;
+            }
+            common::ValueVectorUtils::copyValue(
+                resultValues, *resultDataVector, inputValues, *inputDataVector);
+            resultValues += numBytesPerValue;
+            inputValues += numBytesPerValue;
+        }
+
+        // Add nulls in the end.
+        if (!nullFirst) {
+            setVectorRangeToNull(
+                *resultDataVector, result.offset, input.size - nullCount, input.size);
+            resultValues += numBytesPerValue * nullCount;
+        }
+
+        // Determine the starting and ending position of the data to be sorted.
+        auto sortStart = nullCount;
+        auto sortEnd = input.size;
+        if (!nullFirst) {
+            sortStart = 0;
+            sortEnd = input.size - nullCount;
+        }
+
+        // Sort the data based on order.
+        auto sortingValues =
+            reinterpret_cast<T*>(common::ListVector::getListValues(&resultVector, result));
+        if (ascOrder) {
+            std::sort(sortingValues + sortStart, sortingValues + sortEnd, std::less{});
+        } else {
+            std::sort(sortingValues + sortStart, sortingValues + sortEnd, std::greater{});
+        }
+    }
+
+    static void setVectorRangeToNull(
+        common::ValueVector& vector, uint64_t offset, uint64_t startPos, uint64_t endPos) {
+        for (auto i = startPos; i < endPos; i++) {
+            vector.setNull(offset + i, true);
+        }
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/list/operations/list_sum_operation.h
+++ b/src/include/function/list/operations/list_sum_operation.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "common/vector/value_vector.h"
+
+namespace kuzu {
+namespace function {
+namespace operation {
+
+struct ListSum {
+    template<typename T>
+    static inline void operation(common::list_entry_t& input, T& result,
+        common::ValueVector& inputVector, common::ValueVector& resultVector) {
+        auto inputValues =
+            reinterpret_cast<T*>(common::ListVector::getListValues(&inputVector, input));
+        auto inputDataVector = common::ListVector::getDataVector(&inputVector);
+        for (auto i = 0; i < input.size; i++) {
+            if (inputDataVector->isNull(input.offset + i)) {
+                continue;
+            }
+            result += inputValues[i];
+        }
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/list/vector_list_operations.h
+++ b/src/include/function/list/vector_list_operations.h
@@ -76,6 +76,14 @@ struct VectorListOperations : public VectorOperations {
         }
         return result;
     }
+
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void UnaryListExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 1);
+        UnaryOperationExecutor::executeList<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
+    }
 };
 
 struct ListCreationVectorOperation : public VectorListOperations {
@@ -123,6 +131,20 @@ struct ListContainsVectorOperation : public VectorListOperations {
 };
 
 struct ListSliceVectorOperation : public VectorListOperations {
+    static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+};
+
+struct ListSortVectorOperation : public VectorListOperations {
+    static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+    template<typename T>
+    static scalar_exec_func getExecFunction(const binder::expression_vector& arguments);
+};
+
+struct ListSumVectorOperation : public VectorListOperations {
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, FunctionDefinition* definition);

--- a/src/include/function/unary_operation_executor.h
+++ b/src/include/function/unary_operation_executor.h
@@ -28,6 +28,15 @@ struct UnaryStringOperationWrapper {
     }
 };
 
+struct UnaryListOperationWrapper {
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static inline void operation(
+        OPERAND_TYPE& input, RESULT_TYPE& result, void* leftValueVector, void* resultValueVector) {
+        FUNC::operation(input, result, *(common::ValueVector*)leftValueVector,
+            *(common::ValueVector*)resultValueVector);
+    }
+};
+
 struct UnaryCastOperationWrapper {
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
     static void operation(
@@ -104,6 +113,11 @@ struct UnaryOperationExecutor {
     static void executeString(common::ValueVector& operand, common::ValueVector& result) {
         executeSwitch<OPERAND_TYPE, RESULT_TYPE, FUNC, UnaryStringOperationWrapper>(
             operand, result);
+    }
+
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void executeList(common::ValueVector& operand, common::ValueVector& result) {
+        executeSwitch<OPERAND_TYPE, RESULT_TYPE, FUNC, UnaryListOperationWrapper>(operand, result);
     }
 
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>

--- a/test/test_files/tinysnb/function/list.test
+++ b/test/test_files/tinysnb/function/list.test
@@ -717,3 +717,113 @@ ert
 -QUERY RETURN array_contains([[100,200],[200,300],[300,400]], [100,200])
 ---- 1
 True
+
+-NAME ListSumSeq1
+-QUERY Return list_sum([1, 2, 3, NULL]);
+---- 1
+6
+
+-NAME ListSumSeq2
+-QUERY Return list_sum([1.1, 2.2, 3.3, NULL]);
+---- 1
+6.600000
+
+-NAME ListSortIntAsc
+-QUERY Return list_sort([2, 3, 1, NULL, NULL]);
+---- 1
+[,,1,2,3]
+
+-NAME ListSortIntDesc
+-QUERY Return list_sort([2, 3, 1, 5, NULL], 'DESC');
+---- 1
+[,5,3,2,1]
+
+-NAME ListSortIntDescWithNullsLast
+-QUERY Return list_sort([2, 3, 1, NULL], 'DESC', 'NULLS LAST');
+---- 1
+[3,2,1,]
+
+-NAME ListSortStringDesc
+-QUERY Return list_sort(['sss', 'sssss', 'abs', NULL], 'DESC');
+---- 1
+[,sssss,sss,abs]
+
+-NAME ListSortStringAscWithNullsLast
+-QUERY Return list_sort(['sss', 'sssss', 'abs', NULL], 'ASC', 'NULLS LAST');
+---- 1
+[abs,sss,sssss,]
+
+-NAME ListSortDoubleAscWithNullsLast
+-QUERY Return list_sort([1.1, 2.3, 4.5, NULL], 'ASC', 'NULLS LAST');
+---- 1
+[1.100000,2.300000,4.500000,]
+
+-NAME ListSortDateSeq1
+-QUERY Return list_sort([date('1992-05-03'), date('1993-05-03'), date('1994-05-03'), NULL]);
+---- 1
+[,1992-05-03,1993-05-03,1994-05-03]
+
+-NAME ListSortDateSeq2
+-QUERY Return list_sort([date('1992-05-03'), date('1993-05-03'), date('1994-05-03'), NULL], 'DESC');
+---- 1
+[,1994-05-03,1993-05-03,1992-05-03]
+
+-NAME ListSortDateSeq3
+-QUERY Return list_sort([date('1992-05-03'), date('1993-05-03'), date('1994-05-03'), NULL], 'DESC', 'NULLS LAST');
+---- 1
+[1994-05-03,1993-05-03,1992-05-03,]
+
+-NAME ListSortTimestampSeq1
+-QUERY Return list_sort([timestamp('1992-05-03 11:13:25'), timestamp('1993-05-03 11:13:25'), timestamp('1994-05-03 11:13:25'), NULL]);
+---- 1
+[,1992-05-03 11:13:25,1993-05-03 11:13:25,1994-05-03 11:13:25]
+
+-NAME ListSortTimestampSeq2
+-QUERY Return list_sort([timestamp('1992-05-03 11:13:25'), timestamp('1993-05-03 11:13:25'), timestamp('1994-05-03 11:13:25'), NULL], 'DESC');
+---- 1
+[,1994-05-03 11:13:25,1993-05-03 11:13:25,1992-05-03 11:13:25]
+
+-NAME ListSortTimestampSeq3
+-QUERY Return list_sort([timestamp('1992-05-03 11:13:25'), timestamp('1993-05-03 11:13:25'), timestamp('1994-05-03 11:13:25'), NULL], 'DESC', 'NULLS LAST');
+---- 1
+[1994-05-03 11:13:25,1993-05-03 11:13:25,1992-05-03 11:13:25,]
+
+-NAME ListSortIntervalSeq1
+-QUERY Return list_sort([interval('2 hours 3 days 20 minutes'), interval('3 hours 3 days 20 minutes'), interval('4 hours 3 days 20 minutes'), NULL]);
+---- 1
+[,3 days 02:20:00,3 days 03:20:00,3 days 04:20:00]
+
+-NAME ListSortIntervalSeq2
+-QUERY Return list_sort([interval('2 hours 3 days 20 minutes'), interval('3 hours 3 days 20 minutes'), interval('4 hours 3 days 20 minutes'), NULL], 'DESC');
+---- 1
+[,3 days 04:20:00,3 days 03:20:00,3 days 02:20:00]
+
+-NAME ListSortIntervalSeq3
+-QUERY Return list_sort([interval('2 hours 3 days 20 minutes'), interval('3 hours 3 days 20 minutes'), interval('4 hours 3 days 20 minutes'), NULL], 'DESC', 'NULLS LAST');
+---- 1
+[3 days 04:20:00,3 days 03:20:00,3 days 02:20:00,]
+
+-NAME ListSortBooleanSeq1
+-QUERY Return list_sort([true, true, false, NULL]);
+---- 1
+[,False,True,True]
+
+-NAME ListSortBooleanSeq2
+-QUERY Return list_sort([true, true, false, NULL], 'DESC');
+---- 1
+[,True,True,False]
+
+-NAME ListSortBooleanSeq3
+-QUERY Return list_sort([true, true, false, NULL], 'DESC', 'NULLS LAST');
+---- 1
+[True,True,False,]
+
+-NAME ListSumInt
+-QUERY Return list_sum([1, 2, 3, NULL]);
+---- 1
+6
+
+-NAME ListSumDouble
+-QUERY Return list_sum([1.1, 2.2, 3.3, NULL]);
+---- 1
+6.600000


### PR DESCRIPTION
Added functions:

1. `list_sort(list)`

Sorts the elements of the list.

Examples:
```
-- default sort order and default NULL sort order
Return list_sort([1, 3, NULL, 5, NULL, -5])
----
[NULL, NULL, -5, 1, 3, 5]

-- only providing the sort order
Return list_sort([1, 3, NULL, 2], 'ASC')
----
[NULL, 1, 2, 3]

-- providing the sort order and the NULL sort order
Return list_sort([1, 3, NULL, 2], 'DESC', 'NULLS FIRST')
----
[NULL, 3, 2, 1]
```

2. `list_sum(list)`

Returns the sum of all elements in the list

I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).
