### PR TITLE
List field name to idx cache

### DIFF
--- a/src/function/vector_struct_operations.cpp
+++ b/src/function/vector_struct_operations.cpp
@@ -96,14 +96,13 @@ std::unique_ptr<FunctionBindData> StructExtractVectorOperations::bindFunc(
     auto key = ((binder::LiteralExpression&)*arguments[1]).getValue()->getValue<std::string>();
     common::StringUtils::toUpper(key);
     assert(definition->returnTypeID == common::ANY);
-    auto childrenTypes = typeInfo->getChildrenTypes();
-    auto childrenNames = typeInfo->getChildrenNames();
-    for (auto i = 0u; i < childrenNames.size(); ++i) {
-        if (childrenNames[i] == key) {
-            return std::make_unique<StructExtractBindData>(*childrenTypes[i], i);
-        }
+    auto childIdx = typeInfo->getStructFieldIdx(key);
+    if (childIdx == common::INVALID_STRUCT_FIELD_IDX) {
+        throw common::BinderException(
+            common::StringUtils::string_format("Invalid struct field name: {}.", key));
     }
-    throw common::BinderException("Cannot find key " + key + " for struct_extract.");
+    return std::make_unique<StructExtractBindData>(
+        *typeInfo->getChildrenTypes()[childIdx], childIdx);
 }
 
 } // namespace function

--- a/src/include/storage/in_mem_storage_structure/in_mem_column_chunk.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_column_chunk.h
@@ -118,9 +118,6 @@ public:
     uint64_t getMinNumValuesLeftOnPage(common::offset_t nodeOffset);
 
 private:
-    static common::field_idx_t getStructFieldIdx(
-        std::vector<std::string> structFieldNames, std::string structFieldName);
-
     void copyValueToStructColumnField(common::offset_t nodeOffset,
         common::field_idx_t structFieldIdx, const std::string& structFieldValue,
         const common::DataType& dataType);

--- a/test/binder/binder_error_test.cpp
+++ b/test/binder/binder_error_test.cpp
@@ -94,7 +94,7 @@ TEST_F(BinderErrorTest, BindPropertyNotExist2) {
 }
 
 TEST_F(BinderErrorTest, BindPropertyNotExist3) {
-    std::string expectedException = "Binder exception: Cannot find key B for struct_extract.";
+    std::string expectedException = "Binder exception: Invalid struct field name: B.";
     auto input = "WITH {a: 1} AS s RETURN s.b;";
     ASSERT_STREQ(expectedException.c_str(), getBindingError(input).c_str());
 }


### PR DESCRIPTION
This PR adds the `std::unordered_map<std::string, struct_field_idx_t> fieldNameToIdxMap;` cache to the structTypeInfo.
Binder/loader can use this cache to quickly get the fieldIdx of a given fieldName.