### PR TITLE
Allow passing a test as an argument to e2e_read_test

### DIFF
--- a/src/common/file_utils.cpp
+++ b/src/common/file_utils.cpp
@@ -129,6 +129,7 @@ std::vector<std::string> FileUtils::globFilePath(const std::string& path) {
 
 std::vector<std::string> FileUtils::findAllDirectories(const std::string& path) {
     std::vector<std::string> directories;
+    directories.push_back(path);
     for (const auto& entry : std::filesystem::recursive_directory_iterator(path)) {
         if (entry.is_directory()) {
             directories.push_back(entry.path().string());

--- a/test/runner/e2e_read_test.cpp
+++ b/test/runner/e2e_read_test.cpp
@@ -54,7 +54,15 @@ void scanTestFiles(const std::string& path, std::vector<TestConfig>& configs) {
 int main(int argc, char** argv) {
     testing::InitGoogleTest(&argc, argv);
     std::vector<TestConfig> configs;
-    scanTestFiles(TestHelper::appendKuzuRootPath("test/test_files"), configs);
+    std::string path = "test/test_files";
+    if (argc > 1) {
+        path = argv[1];
+    }
+    path = TestHelper::appendKuzuRootPath(path);
+    if (!FileUtils::fileOrPathExists(path)) {
+        throw Exception("Test directory not exists! [" + path + "].");
+    }
+    scanTestFiles(path, configs);
     registerTests(configs);
     return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This commit adds support to use e2e_read_test to scan a single directory that contains a suite of tests and test.group file. Example:
`(runner dir) ./e2e_read_test test/test_files/shortest_path`