### PR TITLE
Undirected query for single label Nodes/Rels

### DIFF
--- a/src/include/processor/operator/scan/generic_scan_rel_tables.h
+++ b/src/include/processor/operator/scan/generic_scan_rel_tables.h
@@ -7,22 +7,22 @@
 namespace kuzu {
 namespace processor {
 
-class RelTableCollection {
+class RelTableDataCollection {
 public:
-    RelTableCollection(std::vector<storage::DirectedRelTableData*> tables,
+    RelTableDataCollection(std::vector<storage::DirectedRelTableData*> relTableDatas,
         std::vector<std::unique_ptr<storage::RelTableScanState>> tableScanStates)
-        : tables{std::move(tables)}, tableScanStates{std::move(tableScanStates)} {}
+        : relTableDatas{std::move(relTableDatas)}, tableScanStates{std::move(tableScanStates)} {}
 
     void resetState();
-    inline uint32_t getNumTablesInCollection() { return tables.size(); }
+    inline uint32_t getNumTablesInCollection() { return relTableDatas.size(); }
 
     bool scan(common::ValueVector* inVector, const std::vector<common::ValueVector*>& outputVectors,
         transaction::Transaction* transaction);
 
-    std::unique_ptr<RelTableCollection> clone() const;
+    std::unique_ptr<RelTableDataCollection> clone() const;
 
 private:
-    std::vector<storage::DirectedRelTableData*> tables;
+    std::vector<storage::DirectedRelTableData*> relTableDatas;
     std::vector<std::unique_ptr<storage::RelTableScanState>> tableScanStates;
 
     uint32_t currentRelTableIdxToScan = UINT32_MAX;
@@ -32,7 +32,7 @@ private:
 class GenericScanRelTables : public ScanRelTable {
 public:
     GenericScanRelTables(const DataPos& inNodeIDVectorPos, std::vector<DataPos> outputVectorsPos,
-        std::unordered_map<common::table_id_t, std::unique_ptr<RelTableCollection>>
+        std::unordered_map<common::table_id_t, std::unique_ptr<RelTableDataCollection>>
             relTableCollectionPerNodeTable,
         std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
         : ScanRelTable{inNodeIDVectorPos, std::move(outputVectorsPos),
@@ -44,7 +44,7 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        std::unordered_map<common::table_id_t, std::unique_ptr<RelTableCollection>>
+        std::unordered_map<common::table_id_t, std::unique_ptr<RelTableDataCollection>>
             clonedCollections;
         for (auto& [tableID, propertyCollection] : relTableCollectionPerNodeTable) {
             clonedCollections.insert({tableID, propertyCollection->clone()});
@@ -54,13 +54,13 @@ public:
     }
 
 private:
-    bool scanCurrentRelTableCollection();
-    void initCurrentRelTableCollection(const common::nodeID_t& nodeID);
+    bool scanCurrentRelTableDataCollection();
+    void initCurrentRelTableDataCollection(const common::nodeID_t& nodeID);
 
 private:
-    std::unordered_map<common::table_id_t, std::unique_ptr<RelTableCollection>>
+    std::unordered_map<common::table_id_t, std::unique_ptr<RelTableDataCollection>>
         relTableCollectionPerNodeTable;
-    RelTableCollection* currentRelTableCollection = nullptr;
+    RelTableDataCollection* currentRelTableDataCollection = nullptr;
 };
 
 } // namespace processor

--- a/src/planner/join_order_enumerator.cpp
+++ b/src/planner/join_order_enumerator.cpp
@@ -470,8 +470,9 @@ void JoinOrderEnumerator::appendNonRecursiveExtend(std::shared_ptr<NodeExpressio
     std::shared_ptr<NodeExpression> nbrNode, std::shared_ptr<RelExpression> rel,
     ExtendDirection direction, const expression_vector& properties, LogicalPlan& plan) {
     auto hasAtMostOneNbr = extendHasAtMostOneNbrGuarantee(*rel, *boundNode, direction, catalog);
-    auto extend = make_shared<LogicalExtend>(
-        boundNode, nbrNode, rel, direction, properties, hasAtMostOneNbr, plan.getLastOperator());
+    auto extend = make_shared<LogicalExtend>(boundNode, nbrNode, rel,
+        rel->isDirected() ? direction : ExtendDirection::BOTH, properties, hasAtMostOneNbr,
+        plan.getLastOperator());
     queryPlanner->appendFlattens(extend->getGroupsPosToFlatten(), plan);
     extend->setChild(0, plan.getLastOperator());
     extend->computeFactorizedSchema();

--- a/src/processor/mapper/map_extend.cpp
+++ b/src/processor/mapper/map_extend.cpp
@@ -30,30 +30,77 @@ static std::vector<property_id_t> populatePropertyIds(
     return outputColumns;
 }
 
-static std::unique_ptr<RelTableCollection> populateRelTableCollection(table_id_t boundNodeTableID,
-    const RelExpression& rel, RelDataDirection direction, const expression_vector& properties,
-    const RelsStore& relsStore, const catalog::Catalog& catalog) {
-    std::vector<DirectedRelTableData*> tables;
+static std::pair<DirectedRelTableData*, std::unique_ptr<RelTableScanState>>
+getRelTableDataAndScanState(RelDataDirection direction, catalog::RelTableSchema* relTableSchema,
+    table_id_t boundNodeTableID, const RelsStore& relsStore, table_id_t relTableID,
+    const expression_vector& properties) {
+    if (relTableSchema->getBoundTableID(direction) != boundNodeTableID) {
+        // No data stored for given direction and boundNode.
+        return std::make_pair(nullptr, nullptr);
+    }
+    auto relData = relsStore.getRelTable(relTableID)->getDirectedTableData(direction);
+    std::vector<property_id_t> propertyIds;
+    for (auto& property : properties) {
+        auto propertyExpression = reinterpret_cast<PropertyExpression*>(property.get());
+        propertyIds.push_back(propertyExpression->hasPropertyID(relTableID) ?
+                                  propertyExpression->getPropertyID(relTableID) :
+                                  INVALID_PROPERTY_ID);
+    }
+    auto scanState = make_unique<RelTableScanState>(
+        std::move(propertyIds), relsStore.isSingleMultiplicityInDirection(direction, relTableID) ?
+                                    RelTableDataType::COLUMNS :
+                                    RelTableDataType::LISTS);
+    return std::make_pair(relData, std::move(scanState));
+}
+
+static std::unique_ptr<RelTableDataCollection> populateRelTableDataCollection(
+    table_id_t boundNodeTableID, const RelExpression& rel, ExtendDirection extendDirection,
+    const expression_vector& properties, const RelsStore& relsStore,
+    const catalog::Catalog& catalog) {
+    std::vector<DirectedRelTableData*> relTableDatas;
     std::vector<std::unique_ptr<RelTableScanState>> tableScanStates;
     for (auto relTableID : rel.getTableIDs()) {
         auto relTableSchema = catalog.getReadOnlyVersion()->getRelTableSchema(relTableID);
-        if (relTableSchema->getBoundTableID(direction) != boundNodeTableID) {
-            continue;
+        switch (extendDirection) {
+        case ExtendDirection::FWD: {
+            auto [relTableData, scanState] = getRelTableDataAndScanState(RelDataDirection::FWD,
+                relTableSchema, boundNodeTableID, relsStore, relTableID, properties);
+            if (relTableData != nullptr && scanState != nullptr) {
+                relTableDatas.push_back(relTableData);
+                tableScanStates.push_back(std::move(scanState));
+            }
+            break;
         }
-        tables.push_back(relsStore.getRelTable(relTableID)->getDirectedTableData(direction));
-        std::vector<property_id_t> propertyIds;
-        for (auto& property : properties) {
-            auto propertyExpression = reinterpret_cast<PropertyExpression*>(property.get());
-            propertyIds.push_back(propertyExpression->hasPropertyID(relTableID) ?
-                                      propertyExpression->getPropertyID(relTableID) :
-                                      INVALID_PROPERTY_ID);
+        case ExtendDirection::BWD: {
+            auto [relTableData, scanState] = getRelTableDataAndScanState(RelDataDirection::BWD,
+                relTableSchema, boundNodeTableID, relsStore, relTableID, properties);
+            if (relTableData != nullptr && scanState != nullptr) {
+                relTableDatas.push_back(relTableData);
+                tableScanStates.push_back(std::move(scanState));
+            }
+            break;
         }
-        tableScanStates.push_back(make_unique<RelTableScanState>(std::move(propertyIds),
-            relsStore.isSingleMultiplicityInDirection(direction, relTableID) ?
-                RelTableDataType::COLUMNS :
-                RelTableDataType::LISTS));
+        case ExtendDirection::BOTH: {
+            auto [relTableDataFWD, scanStateFWD] =
+                getRelTableDataAndScanState(RelDataDirection::FWD, relTableSchema, boundNodeTableID,
+                    relsStore, relTableID, properties);
+            if (relTableDataFWD != nullptr && scanStateFWD != nullptr) {
+                relTableDatas.push_back(relTableDataFWD);
+                tableScanStates.push_back(std::move(scanStateFWD));
+            }
+            auto [relTableDataBWD, scanStateBWD] =
+                getRelTableDataAndScanState(RelDataDirection::BWD, relTableSchema, boundNodeTableID,
+                    relsStore, relTableID, properties);
+            if (relTableDataBWD != nullptr && scanStateBWD != nullptr) {
+                relTableDatas.push_back(relTableDataBWD);
+                tableScanStates.push_back(std::move(scanStateBWD));
+            }
+            break;
+        }
+        }
     }
-    return std::make_unique<RelTableCollection>(std::move(tables), std::move(tableScanStates));
+    return std::make_unique<RelTableDataCollection>(
+        std::move(relTableDatas), std::move(tableScanStates));
 }
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
@@ -64,7 +111,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
     auto boundNode = extend->getBoundNode();
     auto nbrNode = extend->getNbrNode();
     auto rel = extend->getRel();
-    auto direction = getRelDataDirection(extend->getDirection());
+    auto extendDirection = extend->getDirection();
     auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
     auto inNodeIDVectorPos =
         DataPos(inSchema->getExpressionPos(*boundNode->getInternalIDProperty()));
@@ -76,28 +123,29 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
         outputVectorsPos.emplace_back(outSchema->getExpressionPos(*expression));
     }
     auto& relsStore = storageManager.getRelsStore();
-    if (!rel->isMultiLabeled() && !boundNode->isMultiLabeled()) {
+    if (!rel->isMultiLabeled() && !boundNode->isMultiLabeled() && rel->isDirected()) {
+        auto relDataDirection = getRelDataDirection(extendDirection);
         auto relTableID = rel->getSingleTableID();
-        if (relsStore.isSingleMultiplicityInDirection(direction, relTableID)) {
+        if (relsStore.isSingleMultiplicityInDirection(relDataDirection, relTableID)) {
             auto propertyIds = populatePropertyIds(relTableID, extend->getProperties());
             return make_unique<ScanRelTableColumns>(
-                relsStore.getRelTable(relTableID)->getDirectedTableData(direction),
+                relsStore.getRelTable(relTableID)->getDirectedTableData(relDataDirection),
                 std::move(propertyIds), inNodeIDVectorPos, std::move(outputVectorsPos),
                 std::move(prevOperator), getOperatorID(), extend->getExpressionsForPrinting());
         } else {
-            assert(!relsStore.isSingleMultiplicityInDirection(direction, relTableID));
+            assert(!relsStore.isSingleMultiplicityInDirection(relDataDirection, relTableID));
             auto propertyIds = populatePropertyIds(relTableID, extend->getProperties());
             return make_unique<ScanRelTableLists>(
-                relsStore.getRelTable(relTableID)->getDirectedTableData(direction),
+                relsStore.getRelTable(relTableID)->getDirectedTableData(relDataDirection),
                 std::move(propertyIds), inNodeIDVectorPos, std::move(outputVectorsPos),
                 std::move(prevOperator), getOperatorID(), extend->getExpressionsForPrinting());
         }
     } else { // map to generic extend
-        std::unordered_map<table_id_t, std::unique_ptr<RelTableCollection>>
+        std::unordered_map<table_id_t, std::unique_ptr<RelTableDataCollection>>
             relTableCollectionPerNodeTable;
         for (auto boundNodeTableID : boundNode->getTableIDs()) {
-            auto relTableCollection = populateRelTableCollection(
-                boundNodeTableID, *rel, direction, extend->getProperties(), relsStore, *catalog);
+            auto relTableCollection = populateRelTableDataCollection(boundNodeTableID, *rel,
+                extendDirection, extend->getProperties(), relsStore, *catalog);
             if (relTableCollection->getNumTablesInCollection() > 0) {
                 relTableCollectionPerNodeTable.insert(
                     {boundNodeTableID, std::move(relTableCollection)});

--- a/test/test_files/demo_db/demo_db.test
+++ b/test/test_files/demo_db/demo_db.test
@@ -222,3 +222,15 @@ Adam|30
 -QUERY MATCH (a:User) WITH a ORDER BY a.age DESC LIMIT 1 MATCH (a)-[:Follows]->(b:User) RETURN *;
 ---- 1
 (label:User, 0:3, {name:Noura, age:25})|(label:User, 0:2, {name:Zhang, age:50})
+
+-NAME Undir1
+-QUERY MATCH (a:User)-[:Follows]-(b:User) RETURN a.name, b.age;
+---- 8
+Adam|40
+Adam|50
+Karissa|50
+Zhang|25
+Karissa|30
+Zhang|30
+Zhang|40
+Noura|50

--- a/test/test_files/tinysnb/match/undirected.test
+++ b/test/test_files/tinysnb/match/undirected.test
@@ -1,0 +1,21 @@
+-NAME UndirKnows1
+-QUERY MATCH (a:person)-[:knows]-(b:person) WHERE b.fName = "Bob" RETURN a.fName;
+---- 6
+Alice
+Carol
+Dan
+Alice
+Carol
+Dan
+
+-NAME UndirKnows2
+-QUERY MATCH (a:person)-[:knows]-(b:person)-[:knows]-(c:person) WHERE a.gender = 1 AND b.gender = 2 AND c.fName = "Bob" RETURN a.fName, b.fName;
+---- 8
+Alice|Dan
+Carol|Dan
+Alice|Dan
+Carol|Dan
+Alice|Dan
+Carol|Dan
+Alice|Dan
+Carol|Dan


### PR DESCRIPTION
This PR adds support for undirected queries of the form: 
`MATCH (A)-[N]-(A) ...` 
where A and N refer to only one node / rel table, respectively. 