### PR TITLE
Undirected query for multi-labelled and unlabelled nodes. 

### DIFF
--- a/src/include/parser/query/graph_pattern/node_pattern.h
+++ b/src/include/parser/query/graph_pattern/node_pattern.h
@@ -30,6 +30,10 @@ public:
             propertyKeyValPairs[idx].first, propertyKeyValPairs[idx].second.get());
     }
 
+    void setTableNames(std::vector<std::string> otherTableNames) {
+        tableNames = std::move(otherTableNames);
+    }
+
 protected:
     std::string variableName;
     std::vector<std::string> tableNames;

--- a/test/test_files/demo_db/demo_db.test
+++ b/test/test_files/demo_db/demo_db.test
@@ -234,3 +234,20 @@ Karissa|30
 Zhang|30
 Zhang|40
 Noura|50
+
+-NAME Undir2
+-QUERY MATCH (a:User)-[:LivesIn]-(c:City) RETURN a.name, c.name;
+---- 8
+Adam|Waterloo
+Karissa|Waterloo
+Zhang|Kitchener
+Noura|Guelph
+Waterloo|Karissa
+Waterloo|Adam
+Kitchener|Zhang
+Guelph|Noura
+
+-NAME Undir3
+-QUERY MATCH ()-[]-() RETURN COUNT(*);
+---- 1
+16

--- a/test/test_files/tinysnb/match/undirected.test
+++ b/test/test_files/tinysnb/match/undirected.test
@@ -19,3 +19,41 @@ Alice|Dan
 Carol|Dan
 Alice|Dan
 Carol|Dan
+
+-NAME UndirMultiLabel1
+-QUERY MATCH (a:person:organisation)-[:meets|:marries|:workAt]-(b:person:organisation) RETURN COUNT(*);
+---- 1
+26
+
+-NAME UndirMultiLabel2
+-QUERY MATCH (a:person)-[:studyAt|:meets]-(b:person:organisation) RETURN COUNT(*);
+---- 1
+20
+
+-NAME UndirMultiLabel3
+-QUERY MATCH (a:person)-[:meets|:marries|:knows]-(b:person)-[:knows|:meets]-(c:person) WHERE c.fName = "Farooq" AND a.fName <> "Farooq" RETURN a.fName, b.fName;
+---- 13
+Carol|Elizabeth
+Alice|Carol
+Bob|Carol
+Dan|Carol
+Elizabeth|Carol
+Greg|Carol
+Greg|Elizabeth
+Carol|Elizabeth
+Alice|Carol
+Bob|Carol
+Dan|Carol
+Elizabeth|Carol
+Dan|Carol
+
+-NAME UndirUnlabelled
+-QUERY MATCH (a:person)-[]-() RETURN COUNT(*);
+---- 1
+60
+
+-NAME UndirPattern
+-QUERY MATCH ()-[:studyAt]-(a)-[:meets]-()-[:workAt]-() RETURN a.fName;
+---- 2
+Farooq
+Bob


### PR DESCRIPTION
This commit finishes up implementing undirected query, and includes support for queries in the form: 
`MATCH (A)-[N]-(B)`
`MATCH (A|B|C|..)-[N|M|..]-(E|F|G|..)`
`MATCH ()-[]-()`

This pertains to issue  #1522