### PR TITLE
Add recursive rel logical type

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -157,11 +157,8 @@ void Binder::bindQueryRel(const RelPattern& relPattern,
     // bind variable length
     auto [lowerBound, upperBound] = bindVariableLengthRelBound(relPattern);
     auto isVariableLength = !(lowerBound == 1 && upperBound == 1);
-    auto dataType = isVariableLength ?
-                        common::LogicalType(LogicalTypeID::VAR_LIST,
-                            std::make_unique<VarListTypeInfo>(
-                                std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID))) :
-                        common::LogicalType(common::LogicalTypeID::REL);
+    auto dataType = isVariableLength ? common::LogicalType(common::LogicalTypeID::RECURSIVE_REL) :
+                                       common::LogicalType(common::LogicalTypeID::REL);
     auto queryRel = make_shared<RelExpression>(std::move(dataType),
         getUniqueExpressionName(parsedName), parsedName, tableIDs, srcNode, dstNode,
         relPattern.getDirection() != BOTH, relPattern.getRelType(), lowerBound, upperBound);

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -69,14 +69,6 @@ static std::unordered_map<table_id_t, property_id_t> populatePropertyIDPerTable(
 std::shared_ptr<Expression> ExpressionBinder::bindRelPropertyExpression(
     const Expression& expression, const std::string& propertyName) {
     auto& rel = (RelExpression&)expression;
-    switch (rel.getRelType()) {
-    case common::QueryRelType::VARIABLE_LENGTH:
-    case common::QueryRelType::SHORTEST:
-        throw BinderException(
-            "Cannot read property of variable length rel " + rel.toString() + ".");
-    default:
-        break;
-    }
     if (!rel.hasPropertyExpression(propertyName)) {
         throw BinderException(
             "Cannot find property " + propertyName + " for " + expression.toString() + ".");

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -304,6 +304,7 @@ std::string LogicalTypeUtils::dataTypeToString(const LogicalType& dataType) {
     case LogicalTypeID::ANY:
     case LogicalTypeID::NODE:
     case LogicalTypeID::REL:
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::INTERNAL_ID:
     case LogicalTypeID::BOOL:
     case LogicalTypeID::INT64:
@@ -317,8 +318,7 @@ std::string LogicalTypeUtils::dataTypeToString(const LogicalType& dataType) {
     case LogicalTypeID::STRING:
         return dataTypeToString(dataType.typeID);
     default:
-        throw NotImplementedException(
-            "Unsupported DataType: " + LogicalTypeUtils::dataTypeToString(dataType) + ".");
+        throw NotImplementedException("LogicalTypeUtils::dataTypeToString.");
     }
 }
 
@@ -330,6 +330,8 @@ std::string LogicalTypeUtils::dataTypeToString(LogicalTypeID dataTypeID) {
         return "NODE";
     case LogicalTypeID::REL:
         return "REL";
+    case LogicalTypeID::RECURSIVE_REL:
+        return "RECURSIVE_REL";
     case LogicalTypeID::INTERNAL_ID:
         return "INTERNAL_ID";
     case LogicalTypeID::BOOL:
@@ -361,8 +363,7 @@ std::string LogicalTypeUtils::dataTypeToString(LogicalTypeID dataTypeID) {
     case LogicalTypeID::SERIAL:
         return "SERIAL";
     default:
-        throw NotImplementedException(
-            "Unsupported DataType: " + LogicalTypeUtils::dataTypeToString(dataTypeID) + ".");
+        throw NotImplementedException("LogicalTypeUtils::dataTypeToString.");
     }
 }
 
@@ -460,6 +461,7 @@ void LogicalType::setPhysicalType() {
     case LogicalTypeID::STRING: {
         physicalType = PhysicalTypeID::STRING;
     } break;
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::VAR_LIST: {
         physicalType = PhysicalTypeID::VAR_LIST;
     } break;

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -51,6 +51,9 @@ std::unique_ptr<AuxiliaryBuffer> AuxiliaryBufferFactory::getAuxiliaryBuffer(
         return std::make_unique<StringAuxiliaryBuffer>(memoryManager);
     case LogicalTypeID::STRUCT:
         return std::make_unique<StructAuxiliaryBuffer>(type, memoryManager);
+    case LogicalTypeID::RECURSIVE_REL:
+        return std::make_unique<ListAuxiliaryBuffer>(
+            common::LogicalType(common::LogicalTypeID::INTERNAL_ID), memoryManager);
     case LogicalTypeID::VAR_LIST:
         return std::make_unique<ListAuxiliaryBuffer>(
             *VarListType::getChildType(&type), memoryManager);

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -68,6 +68,7 @@ uint32_t ValueVector::getDataTypeSize(const LogicalType& type) {
     case LogicalTypeID::STRUCT: {
         return sizeof(struct_entry_t);
     }
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::VAR_LIST: {
         return sizeof(list_entry_t);
     }

--- a/src/common/vector/value_vector_utils.cpp
+++ b/src/common/vector/value_vector_utils.cpp
@@ -25,6 +25,7 @@ void ValueVectorUtils::copyNonNullDataWithSameTypeIntoPos(
             structValues += processor::FactorizedTable::getDataTypeSize(structField->dataType);
         }
     } break;
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::VAR_LIST: {
         auto srcKuList = *(ku_list_t*)srcData;
         auto srcNullBytes = reinterpret_cast<uint8_t*>(srcKuList.overflowPtr);
@@ -76,6 +77,7 @@ void ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(const ValueVector& 
             structValues += processor::FactorizedTable::getDataTypeSize(structField->dataType);
         }
     } break;
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::VAR_LIST: {
         auto srcListEntry = srcVector.getValue<list_entry_t>(pos);
         auto srcListDataVector = common::ListVector::getDataVector(&srcVector);
@@ -114,6 +116,7 @@ void ValueVectorUtils::copyNonNullDataWithSameTypeOutFromPos(const ValueVector& 
 void ValueVectorUtils::copyValue(uint8_t* dstValue, common::ValueVector& dstVector,
     const uint8_t* srcValue, const common::ValueVector& srcVector) {
     switch (srcVector.dataType.getLogicalTypeID()) {
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::VAR_LIST: {
         auto srcList = reinterpret_cast<const common::list_entry_t*>(srcValue);
         auto dstList = reinterpret_cast<common::list_entry_t*>(dstValue);

--- a/src/function/vector_list_operation.cpp
+++ b/src/function/vector_list_operation.cpp
@@ -105,6 +105,9 @@ std::vector<std::unique_ptr<VectorOperationDefinition>> ListLenVectorOperation::
     result.push_back(std::make_unique<VectorOperationDefinition>(LIST_LEN_FUNC_NAME,
         std::vector<LogicalTypeID>{LogicalTypeID::VAR_LIST}, LogicalTypeID::INT64, execFunc,
         true /* isVarlength*/));
+    result.push_back(std::make_unique<VectorOperationDefinition>(LIST_LEN_FUNC_NAME,
+        std::vector<LogicalTypeID>{LogicalTypeID::RECURSIVE_REL}, LogicalTypeID::INT64, execFunc,
+        true /* isVarlength*/));
     return result;
 }
 

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -56,9 +56,10 @@ KUZU_API enum class LogicalTypeID : uint8_t {
     ANY = 0,
     NODE = 10,
     REL = 11,
+    RECURSIVE_REL = 12,
     // SERIAL is a special data type that is used to represent a sequence of INT64 values that are
     // incremented by 1 starting from 0.
-    SERIAL = 12,
+    SERIAL = 13,
 
     // fixed size types
     BOOL = 22,
@@ -232,7 +233,8 @@ private:
 
 struct VarListType {
     static inline LogicalType* getChildType(const LogicalType* type) {
-        assert(type->getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+        assert(type->getLogicalTypeID() == LogicalTypeID::VAR_LIST ||
+               type->getLogicalTypeID() == LogicalTypeID::RECURSIVE_REL);
         auto varListTypeInfo = reinterpret_cast<VarListTypeInfo*>(type->extraTypeInfo.get());
         return varListTypeInfo->getChildType();
     }

--- a/src/include/common/types/value.h
+++ b/src/include/common/types/value.h
@@ -193,7 +193,8 @@ private:
         }
     }
 
-    std::vector<std::unique_ptr<Value>> convertKUVarListToVector(ku_list_t& list) const;
+    std::vector<std::unique_ptr<Value>> convertKUVarListToVector(
+        ku_list_t& list, const LogicalType& childType) const;
     std::vector<std::unique_ptr<Value>> convertKUFixedListToVector(const uint8_t* fixedList) const;
     std::vector<std::unique_ptr<Value>> convertKUStructToVector(const uint8_t* kuStruct) const;
 

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -106,28 +106,33 @@ public:
 class ListVector {
 public:
     static inline ValueVector* getDataVector(const ValueVector* vector) {
-        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST ||
+               vector->dataType.getLogicalTypeID() == LogicalTypeID::RECURSIVE_REL);
         return reinterpret_cast<ListAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
             ->getDataVector();
     }
     static inline uint8_t* getListValues(const ValueVector* vector, const list_entry_t& listEntry) {
-        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST ||
+               vector->dataType.getLogicalTypeID() == LogicalTypeID::RECURSIVE_REL);
         auto dataVector = getDataVector(vector);
         return dataVector->getData() + dataVector->getNumBytesPerValue() * listEntry.offset;
     }
     static inline uint8_t* getListValuesWithOffset(const ValueVector* vector,
         const list_entry_t& listEntry, common::offset_t elementOffsetInList) {
-        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST ||
+               vector->dataType.getLogicalTypeID() == LogicalTypeID::RECURSIVE_REL);
         return getListValues(vector, listEntry) +
                elementOffsetInList * getDataVector(vector)->getNumBytesPerValue();
     }
     static inline list_entry_t addList(ValueVector* vector, uint64_t listSize) {
-        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST ||
+               vector->dataType.getLogicalTypeID() == LogicalTypeID::RECURSIVE_REL);
         return reinterpret_cast<ListAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
             ->addList(listSize);
     }
     static inline void resetListAuxiliaryBuffer(ValueVector* vector) {
-        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+        assert(vector->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST ||
+               vector->dataType.getLogicalTypeID() == LogicalTypeID::RECURSIVE_REL);
         reinterpret_cast<ListAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())->resetSize();
     }
 };

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -340,6 +340,7 @@ uint32_t FactorizedTable::getDataTypeSize(const common::LogicalType& type) {
         return getDataTypeSize(*FixedListType::getChildType(&type)) *
                FixedListType::getNumElementsInList(&type);
     }
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::VAR_LIST: {
         return sizeof(ku_list_t);
     }
@@ -682,6 +683,7 @@ void FactorizedTable::copyOverflowIfNecessary(
                 *stringToWriteFrom, *(ku_string_t*)dst);
         }
     } break;
+    case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::VAR_LIST: {
         diskOverflowFile->writeListOverflowAndUpdateOverflowPtr(
             *(ku_list_t*)src, *(ku_list_t*)dst, type);

--- a/test/runner/e2e_exception_test.cpp
+++ b/test/runner/e2e_exception_test.cpp
@@ -13,14 +13,14 @@ public:
 
 TEST_F(TinySnbExceptionTest, ReadVarlengthRelPropertyTest1) {
     auto result = conn->query("MATCH (a:person)-[e:knows*1..3]->(b:person) RETURN e.age;");
-    ASSERT_STREQ("Binder exception: e has data type VAR_LIST. (STRUCT,REL,NODE) was expected.",
+    ASSERT_STREQ("Binder exception: e has data type RECURSIVE_REL. (STRUCT,REL,NODE) was expected.",
         result->getErrorMessage().c_str());
 }
 
 TEST_F(TinySnbExceptionTest, ReadVarlengthRelPropertyTest2) {
     auto result =
         conn->query("MATCH (a:person)-[e:knows*1..3]->(b:person) WHERE ID(e) = 0 RETURN COUNT(*);");
-    ASSERT_STREQ("Binder exception: e has data type VAR_LIST. (REL,NODE) was expected.",
+    ASSERT_STREQ("Binder exception: e has data type RECURSIVE_REL. (REL,NODE) was expected.",
         result->getErrorMessage().c_str());
 }
 


### PR DESCRIPTION
This PR changes the data type of recursive rel from VAR_LIST to RECURSIVE_REL. This is because we are adding functions that work only for RECURSIVE_REL but not for list.