### PR TITLE
Change hash index concurrent build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(Kuzu VERSION 0.0.3.4 LANGUAGES CXX)
+project(Kuzu VERSION 0.0.3.5 LANGUAGES CXX)
 
 find_package(Threads REQUIRED)
 

--- a/src/binder/bound_statement_result.cpp
+++ b/src/binder/bound_statement_result.cpp
@@ -7,7 +7,7 @@ namespace binder {
 
 std::unique_ptr<BoundStatementResult> BoundStatementResult::createSingleStringColumnResult() {
     auto result = std::make_unique<BoundStatementResult>();
-    auto columnName = std::string("outputMsg");
+    auto columnName = std::string("result");
     auto value = std::make_unique<common::Value>(columnName);
     auto stringColumn = std::make_shared<LiteralExpression>(std::move(value), columnName);
     result->addColumn(stringColumn, expression_vector{stringColumn});

--- a/src/include/storage/index/hash_index_builder.h
+++ b/src/include/storage/index/hash_index_builder.h
@@ -107,17 +107,6 @@ private:
     uint32_t allocatePSlots(uint32_t numSlotsToAllocate);
     uint32_t allocateAOSlot();
 
-    inline void lockSlot(SlotInfo& slotInfo) {
-        assert(slotInfo.slotType == SlotType::PRIMARY);
-        std::shared_lock sLck{pSlotSharedMutex};
-        pSlotsMutexes[slotInfo.slotId]->lock();
-    }
-    inline void unlockSlot(const SlotInfo& slotInfo) {
-        assert(slotInfo.slotType == SlotType::PRIMARY);
-        std::shared_lock sLck{pSlotSharedMutex};
-        pSlotsMutexes[slotInfo.slotId]->unlock();
-    }
-
 private:
     std::unique_ptr<FileHandle> fileHandle;
     std::unique_ptr<InMemDiskArrayBuilder<HashIndexHeader>> headerArray;
@@ -150,6 +139,10 @@ public:
         }
         }
     }
+
+    inline void lock() { mtx.lock(); }
+
+    inline void unlock() { mtx.unlock(); }
 
     inline void bulkReserve(uint32_t numEntries) {
         keyDataTypeID == common::LogicalTypeID::INT64 ?
@@ -189,6 +182,7 @@ public:
     }
 
 private:
+    std::mutex mtx;
     common::LogicalTypeID keyDataTypeID;
     std::unique_ptr<HashIndexBuilder<int64_t>> hashIndexBuilderForInt64;
     std::unique_ptr<HashIndexBuilder<common::ku_string_t>> hashIndexBuilderForString;

--- a/src/include/storage/storage_info.h
+++ b/src/include/storage/storage_info.h
@@ -12,7 +12,8 @@ using storage_version_t = uint64_t;
 
 struct StorageVersionInfo {
     static std::unordered_map<std::string, storage_version_t> getStorageVersionInfo() {
-        return {{"0.0.3.4", 5}, {"0.0.3.3", 4}, {"0.0.3.2", 3}, {"0.0.3.1", 2}, {"0.0.3", 1}};
+        return {{"0.0.3.5", 6}, {"0.0.3.4", 5}, {"0.0.3.3", 4}, {"0.0.3.2", 3}, {"0.0.3.1", 2},
+            {"0.0.3", 1}};
     }
 
     static storage_version_t getStorageVersion();

--- a/src/storage/copier/node_copier.cpp
+++ b/src/storage/copier/node_copier.cpp
@@ -100,6 +100,7 @@ void NodeCopier::populatePKIndex(InMemColumnChunk* chunk, InMemOverflowFile* ove
         }
     }
     // No nulls, so we can populate the index with actual values.
+    pkIndex->lock();
     switch (chunk->getDataType().getLogicalTypeID()) {
     case LogicalTypeID::INT64: {
         appendToPKIndex<int64_t>(chunk, startOffset, numValues);
@@ -112,6 +113,7 @@ void NodeCopier::populatePKIndex(InMemColumnChunk* chunk, InMemOverflowFile* ove
         throw CopyException("Primary key must be either INT64, STRING or SERIAL.");
     }
     }
+    pkIndex->unlock();
 }
 
 template<>

--- a/src/storage/copier/node_copy_executor.cpp
+++ b/src/storage/copier/node_copy_executor.cpp
@@ -27,7 +27,6 @@ static column_id_t getPKColumnID(
 }
 
 void NodeCopyExecutor::populateColumns(processor::ExecutionContext* executionContext) {
-    logger->info("Populating properties");
     auto primaryKey = reinterpret_cast<NodeTableSchema*>(tableSchema)->getPrimaryKey();
     std::unique_ptr<PrimaryKeyIndexBuilder> pkIndex;
     if (primaryKey.dataType.getLogicalTypeID() != common::LogicalTypeID::SERIAL) {
@@ -80,7 +79,6 @@ void NodeCopyExecutor::populateColumns(processor::ExecutionContext* executionCon
     for (auto& task : tasks) {
         taskScheduler.scheduleTaskAndWaitOrError(task, executionContext);
     }
-    logger->info("Done populating properties, constructing the pk index.");
 }
 
 } // namespace storage


### PR DESCRIPTION
Our hash index builder is not scalable. We need to rework on that.
Currently, I'm putting locks each time a thread flushes into the index. This can improve copying. On my local M1 Air laptop, it improves copying of ldbc10 comment csv files from ~28s to ~12s, and parquet files from ~22.4s to 5.6s.