### PR TITLE
NPY loader fix

### DIFF
--- a/src/include/storage/in_mem_storage_structure/in_mem_column.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_column.h
@@ -22,6 +22,10 @@ public:
             return std::make_unique<InMemColumnChunkWithOverflow>(
                 dataType, startNodeOffset, endNodeOffset, copyDescription, inMemOverflowFile.get());
         }
+        case common::LogicalTypeID::FIXED_LIST: {
+            return std::make_unique<InMemFixedListColumnChunk>(
+                dataType, startNodeOffset, endNodeOffset, copyDescription);
+        }
         case common::LogicalTypeID::STRUCT: {
             auto inMemStructColumnChunk = std::make_unique<InMemStructColumnChunk>(
                 dataType, startNodeOffset, endNodeOffset, copyDescription);

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -52,10 +52,17 @@ struct PageUtils {
     // This function returns the page pageIdx of the page where element will be found and the pos of
     // the element in the page as the offset.
     static inline PageElementCursor getPageElementCursorForPos(
-        const uint64_t& elementPos, const uint32_t numElementsPerPage) {
+        uint64_t elementPos, uint32_t numElementsPerPage) {
         assert((elementPos / numElementsPerPage) < UINT32_MAX);
         return PageElementCursor{(common::page_idx_t)(elementPos / numElementsPerPage),
             (uint16_t)(elementPos % numElementsPerPage)};
+    }
+
+    static inline PageByteCursor getPageByteCursorForPos(
+        uint64_t elementPos, uint32_t numElementsPerPage, uint64_t elementSize) {
+        assert((elementPos / numElementsPerPage) < UINT32_MAX);
+        return PageByteCursor{(common::page_idx_t)(elementPos / numElementsPerPage),
+            (uint16_t)(elementPos % numElementsPerPage * elementSize)};
     }
 };
 

--- a/src/storage/copier/node_copier.cpp
+++ b/src/storage/copier/node_copier.cpp
@@ -200,10 +200,10 @@ void NPYNodeCopier::executeInternal(std::unique_ptr<NodeCopyMorsel> morsel) {
     auto endNodeOffset = morsel->nodeOffset + morsel->numNodes - 1;
     // For NPY files, we can only read one column at a time.
     std::vector<std::unique_ptr<InMemColumnChunk>> columnChunks(1);
-    columnChunks[0] = std::make_unique<InMemColumnChunk>(
-        properties[columnToCopy].dataType, morsel->nodeOffset, endNodeOffset, &copyDesc);
+    columnChunks[0] =
+        columns[columnToCopy]->getInMemColumnChunk(morsel->nodeOffset, endNodeOffset, &copyDesc);
     for (auto i = 0u; i < morsel->numNodes; i++) {
-        columnChunks[0]->setValue(reader->getPointerToRow(morsel->nodeOffset + i), i);
+        columnChunks[0]->setValueAtPos(reader->getPointerToRow(morsel->nodeOffset + i), i);
     }
     flushChunksAndPopulatePKIndex(columnChunks, morsel->nodeOffset, endNodeOffset, columnToCopy);
 }

--- a/src/storage/copier/rel_copy_executor.cpp
+++ b/src/storage/copier/rel_copy_executor.cpp
@@ -644,7 +644,7 @@ void RelCopyExecutor::populateAdjColumnsAndCountRelsInAdjListsTask(uint64_t bloc
                         copier->catalog.getReadOnlyVersion()->getTableName(tableID),
                         RelDataDirectionUtils::relDataDirectionToString(relDirection)));
                 }
-                copier->adjColumnChunksPerDirection[relDirection]->setValue(
+                copier->adjColumnChunksPerDirection[relDirection]->setValueAtPos(
                     (uint8_t*)&nodeIDs[!relDirection].offset, nodeOffset);
             } else {
                 InMemListsUtils::incrementListSize(
@@ -769,7 +769,7 @@ void RelCopyExecutor::putValueIntoColumns(uint64_t propertyID,
         auto propertyColumnChunk =
             directionTablePropertyColumnChunks[relDirection][propertyID].get();
         auto nodeOffset = nodeIDs[relDirection].offset;
-        propertyColumnChunk->setValue(val, nodeOffset);
+        propertyColumnChunk->setValueAtPos(val, nodeOffset);
     }
 }
 

--- a/test/copy/copy_npy_test.cpp
+++ b/test/copy/copy_npy_test.cpp
@@ -222,37 +222,36 @@ TEST_F(CopyThreeDimensionalNpyTest, CopyThreeDimensionalNpyIntoTwoDimensionaTest
     ASSERT_EQ(listVal[11]->val.int16Val, 24);
 }
 
-// TEST_F(CopyLargeNpyTest, CopyLargeNpyTest) {
-//    auto storageManager = getStorageManager(*database);
-//    auto catalog = getCatalog(*database);
-//    auto tableID = catalog->getReadOnlyVersion()->getTableID("npytable");
-//    auto property = catalog->getReadOnlyVersion()->getNodeProperty(tableID, "id");
-//    auto col = storageManager->getNodesStore().getNodePropertyColumn(tableID,
-//    property.propertyID); for (size_t i = 0; i < 20000; ++i) {
-//        ASSERT_EQ(col->readValueForTestingOnly(i).val.int64Val, i);
-//    }
-//    property = catalog->getReadOnlyVersion()->getNodeProperty(tableID, "f32");
-//    col = storageManager->getNodesStore().getNodePropertyColumn(tableID, property.propertyID);
-//    for (auto rowIdx = 0u; rowIdx < 20000; rowIdx++) {
-//        auto row = col->readValueForTestingOnly(rowIdx);
-//        for (auto colIdx = 0u; colIdx < 10; colIdx++) {
-//            if (row.nestedTypeVal[colIdx]->val.floatVal != (float)(rowIdx * 10 + colIdx)) {
-//                std::cout << "rowIdx: " << rowIdx << " colIdx: " << colIdx << std::endl;
-//            }
-//            ASSERT_EQ(row.nestedTypeVal[colIdx]->val.floatVal, (float)(rowIdx * 10 + colIdx));
-//        }
-//    }
-//    for (auto i = 0u; i < 200000; ++i) {
-//        size_t rowIdx = i / 10;
-//        size_t colIdx = i % 10;
-//        if (col->readValueForTestingOnly(rowIdx).nestedTypeVal[colIdx]->val.floatVal != (float)i)
-//        {
-//            std::cout << "rowIdx: " << rowIdx << " colIdx: " << colIdx << std::endl;
-//        }
-//        ASSERT_EQ(
-//            col->readValueForTestingOnly(rowIdx).nestedTypeVal[colIdx]->val.floatVal, (float)i);
-//    }
-//}
+TEST_F(CopyLargeNpyTest, CopyLargeNpyTest) {
+    auto storageManager = getStorageManager(*database);
+    auto catalog = getCatalog(*database);
+    auto tableID = catalog->getReadOnlyVersion()->getTableID("npytable");
+    auto property = catalog->getReadOnlyVersion()->getNodeProperty(tableID, "id");
+    auto col = storageManager->getNodesStore().getNodePropertyColumn(tableID, property.propertyID);
+    for (size_t i = 0; i < 20000; ++i) {
+        ASSERT_EQ(col->readValueForTestingOnly(i).val.int64Val, i);
+    }
+    property = catalog->getReadOnlyVersion()->getNodeProperty(tableID, "f32");
+    col = storageManager->getNodesStore().getNodePropertyColumn(tableID, property.propertyID);
+    for (auto rowIdx = 0u; rowIdx < 20000; rowIdx++) {
+        auto row = col->readValueForTestingOnly(rowIdx);
+        for (auto colIdx = 0u; colIdx < 10; colIdx++) {
+            if (row.nestedTypeVal[colIdx]->val.floatVal != (float)(rowIdx * 10 + colIdx)) {
+                std::cout << "rowIdx: " << rowIdx << " colIdx: " << colIdx << std::endl;
+            }
+            ASSERT_EQ(row.nestedTypeVal[colIdx]->val.floatVal, (float)(rowIdx * 10 + colIdx));
+        }
+    }
+    for (size_t i = 0; i < 200000; ++i) {
+        size_t rowIdx = i / 10;
+        size_t colIdx = i % 10;
+        if (col->readValueForTestingOnly(rowIdx).nestedTypeVal[colIdx]->val.floatVal != (float)i) {
+            std::cout << "rowIdx: " << rowIdx << " colIdx: " << colIdx << std::endl;
+        }
+        ASSERT_EQ(
+            col->readValueForTestingOnly(rowIdx).nestedTypeVal[colIdx]->val.floatVal, (float)i);
+    }
+}
 
 TEST_F(CopyNpyFaultTest, CopyNpyInsufficientNumberOfProperties) {
     conn->query("create node table npytable (id INT64,i64 INT64[12],PRIMARY KEY(id));");


### PR DESCRIPTION
## NPY Loader Fix
**BUG**: A problem arises when the tensor's size isn't a power of 2. The tensor may end up being stored across two pages, leading to inconsistencies when retrieving data from these pages.
**Solution**:  During the process of writing tensors to the InMemColumnChunk, we now compute the page index and offset for each tensor. This calculated position allows us to avoid storing a tensor accross two pages.