### PR TITLE
Fix return functor windows compatibility

### DIFF
--- a/src/binder/bind_expression/bind_boolean_expression.cpp
+++ b/src/binder/bind_expression/bind_boolean_expression.cpp
@@ -24,10 +24,12 @@ std::shared_ptr<Expression> ExpressionBinder::bindBooleanExpression(
         childrenAfterCast.push_back(implicitCastIfNecessary(child, LogicalTypeID::BOOL));
     }
     auto functionName = expressionTypeToString(expressionType);
-    auto execFunc =
-        function::VectorBooleanOperations::bindExecFunction(expressionType, childrenAfterCast);
-    auto selectFunc =
-        function::VectorBooleanOperations::bindSelectFunction(expressionType, childrenAfterCast);
+    function::scalar_exec_func execFunc;
+    function::VectorBooleanOperations::bindExecFunction(
+        expressionType, childrenAfterCast, execFunc);
+    function::scalar_select_func selectFunc;
+    function::VectorBooleanOperations::bindSelectFunction(
+        expressionType, childrenAfterCast, selectFunc);
     auto bindData = std::make_unique<function::FunctionBindData>(LogicalType(LogicalTypeID::BOOL));
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(functionName, childrenAfterCast);

--- a/src/binder/bind_expression/bind_null_operator_expression.cpp
+++ b/src/binder/bind_expression/bind_null_operator_expression.cpp
@@ -15,8 +15,10 @@ std::shared_ptr<Expression> ExpressionBinder::bindNullOperatorExpression(
     }
     auto expressionType = parsedExpression.getExpressionType();
     auto functionName = expressionTypeToString(expressionType);
-    auto execFunc = function::VectorNullOperations::bindExecFunction(expressionType, children);
-    auto selectFunc = function::VectorNullOperations::bindSelectFunction(expressionType, children);
+    function::scalar_exec_func execFunc;
+    function::VectorNullOperations::bindExecFunction(expressionType, children, execFunc);
+    function::scalar_select_func selectFunc;
+    function::VectorNullOperations::bindSelectFunction(expressionType, children, selectFunc);
     auto bindData = std::make_unique<function::FunctionBindData>(
         common::LogicalType(common::LogicalTypeID::BOOL));
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(functionName, children);

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -87,12 +87,13 @@ std::shared_ptr<Expression> ExpressionBinder::implicitCast(
         auto functionName = VectorCastOperations::bindImplicitCastFuncName(targetType);
         auto children = expression_vector{expression};
         auto bindData = std::make_unique<FunctionBindData>(targetType);
+        function::scalar_exec_func execFunc;
+        VectorCastOperations::bindImplicitCastFunc(
+            expression->dataType.getLogicalTypeID(), targetType.getLogicalTypeID(), execFunc);
         auto uniqueName = ScalarFunctionExpression::getUniqueName(functionName, children);
         return std::make_shared<ScalarFunctionExpression>(functionName, FUNCTION,
-            std::move(bindData), std::move(children),
-            VectorCastOperations::bindImplicitCastFunc(
-                expression->dataType.getLogicalTypeID(), targetType.getLogicalTypeID()),
-            nullptr /* selectFunc */, std::move(uniqueName));
+            std::move(bindData), std::move(children), execFunc, nullptr /* selectFunc */,
+            std::move(uniqueName));
     } else {
         throw common::BinderException(
             "Expression " + expression->toString() + " has data type " +

--- a/src/function/vector_boolean_operations.cpp
+++ b/src/function/vector_boolean_operations.cpp
@@ -7,28 +7,28 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace function {
 
-scalar_exec_func VectorBooleanOperations::bindExecFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorBooleanOperations::bindExecFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_exec_func& func) {
     if (isExpressionBinary(expressionType)) {
-        return bindBinaryExecFunction(expressionType, children);
+        bindBinaryExecFunction(expressionType, children, func);
     } else {
         assert(isExpressionUnary(expressionType));
-        return bindUnaryExecFunction(expressionType, children);
+        bindUnaryExecFunction(expressionType, children, func);
     }
 }
 
-scalar_select_func VectorBooleanOperations::bindSelectFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorBooleanOperations::bindSelectFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_select_func& func) {
     if (isExpressionBinary(expressionType)) {
-        return bindBinarySelectFunction(expressionType, children);
+        bindBinarySelectFunction(expressionType, children, func);
     } else {
         assert(isExpressionUnary(expressionType));
-        return bindUnarySelectFunction(expressionType, children);
+        bindUnarySelectFunction(expressionType, children, func);
     }
 }
 
-scalar_exec_func VectorBooleanOperations::bindBinaryExecFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorBooleanOperations::bindBinaryExecFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_exec_func& func) {
     assert(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
@@ -36,13 +36,16 @@ scalar_exec_func VectorBooleanOperations::bindBinaryExecFunction(
            rightType.getLogicalTypeID() == LogicalTypeID::BOOL);
     switch (expressionType) {
     case AND: {
-        return &BinaryBooleanExecFunction<operation::And>;
+        func = &BinaryBooleanExecFunction<operation::And>;
+        return;
     }
     case OR: {
-        return &BinaryBooleanExecFunction<operation::Or>;
+        func = &BinaryBooleanExecFunction<operation::Or>;
+        return;
     }
     case XOR: {
-        return &BinaryBooleanExecFunction<operation::Xor>;
+        func = &BinaryBooleanExecFunction<operation::Xor>;
+        return;
     }
     default:
         throw RuntimeException("Invalid expression type " + expressionTypeToString(expressionType) +
@@ -50,8 +53,8 @@ scalar_exec_func VectorBooleanOperations::bindBinaryExecFunction(
     }
 }
 
-scalar_select_func VectorBooleanOperations::bindBinarySelectFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorBooleanOperations::bindBinarySelectFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_select_func& func) {
     assert(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
@@ -59,13 +62,16 @@ scalar_select_func VectorBooleanOperations::bindBinarySelectFunction(
            rightType.getLogicalTypeID() == LogicalTypeID::BOOL);
     switch (expressionType) {
     case AND: {
-        return &BinaryBooleanSelectFunction<operation::And>;
+        func = &BinaryBooleanSelectFunction<operation::And>;
+        return;
     }
     case OR: {
-        return &BinaryBooleanSelectFunction<operation::Or>;
+        func = &BinaryBooleanSelectFunction<operation::Or>;
+        return;
     }
     case XOR: {
-        return &BinaryBooleanSelectFunction<operation::Xor>;
+        func = &BinaryBooleanSelectFunction<operation::Xor>;
+        return;
     }
     default:
         throw RuntimeException("Invalid expression type " + expressionTypeToString(expressionType) +
@@ -73,12 +79,13 @@ scalar_select_func VectorBooleanOperations::bindBinarySelectFunction(
     }
 }
 
-scalar_exec_func VectorBooleanOperations::bindUnaryExecFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorBooleanOperations::bindUnaryExecFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_exec_func& func) {
     assert(children.size() == 1 && children[0]->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     switch (expressionType) {
     case NOT: {
-        return &UnaryBooleanExecFunction<operation::Not>;
+        func = &UnaryBooleanExecFunction<operation::Not>;
+        return;
     }
     default:
         throw RuntimeException("Invalid expression type " + expressionTypeToString(expressionType) +
@@ -86,12 +93,13 @@ scalar_exec_func VectorBooleanOperations::bindUnaryExecFunction(
     }
 }
 
-scalar_select_func VectorBooleanOperations::bindUnarySelectFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorBooleanOperations::bindUnarySelectFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_select_func& func) {
     assert(children.size() == 1 && children[0]->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     switch (expressionType) {
     case NOT: {
-        return &UnaryBooleanSelectFunction<operation::Not>;
+        func = &UnaryBooleanSelectFunction<operation::Not>;
+        return;
     }
     default:
         throw RuntimeException("Invalid expression type " + expressionTypeToString(expressionType) +

--- a/src/function/vector_cast_operations.cpp
+++ b/src/function/vector_cast_operations.cpp
@@ -55,35 +55,43 @@ std::string VectorCastOperations::bindImplicitCastFuncName(const common::Logical
     }
 }
 
-scalar_exec_func VectorCastOperations::bindImplicitCastFunc(
-    common::LogicalTypeID sourceTypeID, common::LogicalTypeID targetTypeID) {
+void VectorCastOperations::bindImplicitCastFunc(common::LogicalTypeID sourceTypeID,
+    common::LogicalTypeID targetTypeID, scalar_exec_func& func) {
     switch (targetTypeID) {
     case common::LogicalTypeID::INT16: {
-        return bindImplicitNumericalCastFunc<int16_t, operation::CastToInt16>(sourceTypeID);
+        bindImplicitNumericalCastFunc<int16_t, operation::CastToInt16>(sourceTypeID, func);
+        return;
     }
     case common::LogicalTypeID::INT32: {
-        return bindImplicitNumericalCastFunc<int32_t, operation::CastToInt32>(sourceTypeID);
+        bindImplicitNumericalCastFunc<int32_t, operation::CastToInt32>(sourceTypeID, func);
+        return;
     }
     case common::LogicalTypeID::INT64: {
-        return bindImplicitNumericalCastFunc<int64_t, operation::CastToInt64>(sourceTypeID);
+        bindImplicitNumericalCastFunc<int64_t, operation::CastToInt64>(sourceTypeID, func);
+        return;
     }
     case common::LogicalTypeID::FLOAT: {
-        return bindImplicitNumericalCastFunc<float_t, operation::CastToFloat>(sourceTypeID);
+        bindImplicitNumericalCastFunc<float_t, operation::CastToFloat>(sourceTypeID, func);
+        return;
     }
     case common::LogicalTypeID::DOUBLE: {
-        return bindImplicitNumericalCastFunc<double_t, operation::CastToDouble>(sourceTypeID);
+        bindImplicitNumericalCastFunc<double_t, operation::CastToDouble>(sourceTypeID, func);
+        return;
     }
     case common::LogicalTypeID::DATE: {
         assert(sourceTypeID == common::LogicalTypeID::STRING);
-        return &UnaryExecFunction<ku_string_t, date_t, operation::CastStringToDate>;
+        func = &UnaryExecFunction<ku_string_t, date_t, operation::CastStringToDate>;
+        return;
     }
     case common::LogicalTypeID::TIMESTAMP: {
         assert(sourceTypeID == common::LogicalTypeID::STRING);
-        return &UnaryExecFunction<ku_string_t, timestamp_t, operation::CastStringToTimestamp>;
+        func = &UnaryExecFunction<ku_string_t, timestamp_t, operation::CastStringToTimestamp>;
+        return;
     }
     case common::LogicalTypeID::INTERVAL: {
         assert(sourceTypeID == common::LogicalTypeID::STRING);
-        return &UnaryExecFunction<ku_string_t, interval_t, operation::CastStringToInterval>;
+        func = &UnaryExecFunction<ku_string_t, interval_t, operation::CastStringToInterval>;
+        return;
     }
     default:
         throw common::NotImplementedException(

--- a/src/function/vector_list_operation.cpp
+++ b/src/function/vector_list_operation.cpp
@@ -356,34 +356,34 @@ std::unique_ptr<FunctionBindData> ListSortVectorOperation::bindFunc(
     auto vectorOperationDefinition = reinterpret_cast<VectorOperationDefinition*>(definition);
     switch (VarListType::getChildType(&arguments[0]->dataType)->getLogicalTypeID()) {
     case LogicalTypeID::INT64: {
-        vectorOperationDefinition->execFunc = getExecFunction<int64_t>(arguments);
+        getExecFunction<int64_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::INT32: {
-        vectorOperationDefinition->execFunc = getExecFunction<int32_t>(arguments);
+        getExecFunction<int32_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::INT16: {
-        vectorOperationDefinition->execFunc = getExecFunction<int16_t>(arguments);
+        getExecFunction<int16_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::DOUBLE: {
-        vectorOperationDefinition->execFunc = getExecFunction<double_t>(arguments);
+        getExecFunction<double_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::FLOAT: {
-        vectorOperationDefinition->execFunc = getExecFunction<float_t>(arguments);
+        getExecFunction<float_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::BOOL: {
-        vectorOperationDefinition->execFunc = getExecFunction<uint8_t>(arguments);
+        getExecFunction<uint8_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::STRING: {
-        vectorOperationDefinition->execFunc = getExecFunction<ku_string_t>(arguments);
+        getExecFunction<ku_string_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::DATE: {
-        vectorOperationDefinition->execFunc = getExecFunction<date_t>(arguments);
+        getExecFunction<date_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::TIMESTAMP: {
-        vectorOperationDefinition->execFunc = getExecFunction<timestamp_t>(arguments);
+        getExecFunction<timestamp_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::INTERVAL: {
-        vectorOperationDefinition->execFunc = getExecFunction<interval_t>(arguments);
+        getExecFunction<interval_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     default: {
         throw common::NotImplementedException("ListSortVectorOperation::bindFunc");
@@ -393,16 +393,19 @@ std::unique_ptr<FunctionBindData> ListSortVectorOperation::bindFunc(
 }
 
 template<typename T>
-scalar_exec_func ListSortVectorOperation::getExecFunction(
-    const binder::expression_vector& arguments) {
+void ListSortVectorOperation::getExecFunction(
+    const binder::expression_vector& arguments, scalar_exec_func& func) {
     if (arguments.size() == 1) {
-        return UnaryListExecFunction<list_entry_t, list_entry_t, operation::ListSort<T>>;
+        func = UnaryListExecFunction<list_entry_t, list_entry_t, operation::ListSort<T>>;
+        return;
     } else if (arguments.size() == 2) {
-        return BinaryListExecFunction<list_entry_t, ku_string_t, list_entry_t,
-            operation::ListSort<T>>;
+        func =
+            BinaryListExecFunction<list_entry_t, ku_string_t, list_entry_t, operation::ListSort<T>>;
+        return;
     } else if (arguments.size() == 3) {
-        return TernaryListExecFunction<list_entry_t, ku_string_t, ku_string_t, list_entry_t,
+        func = TernaryListExecFunction<list_entry_t, ku_string_t, ku_string_t, list_entry_t,
             operation::ListSort<T>>;
+        return;
     } else {
         throw common::RuntimeException("Invalid number of arguments");
     }
@@ -425,34 +428,34 @@ std::unique_ptr<FunctionBindData> ListReverseSortVectorOperation::bindFunc(
     auto vectorOperationDefinition = reinterpret_cast<VectorOperationDefinition*>(definition);
     switch (VarListType::getChildType(&arguments[0]->dataType)->getLogicalTypeID()) {
     case LogicalTypeID::INT64: {
-        vectorOperationDefinition->execFunc = getExecFunction<int64_t>(arguments);
+        getExecFunction<int64_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::INT32: {
-        vectorOperationDefinition->execFunc = getExecFunction<int32_t>(arguments);
+        getExecFunction<int32_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::INT16: {
-        vectorOperationDefinition->execFunc = getExecFunction<int16_t>(arguments);
+        getExecFunction<int16_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::DOUBLE: {
-        vectorOperationDefinition->execFunc = getExecFunction<double_t>(arguments);
+        getExecFunction<double_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::FLOAT: {
-        vectorOperationDefinition->execFunc = getExecFunction<float_t>(arguments);
+        getExecFunction<float_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::BOOL: {
-        vectorOperationDefinition->execFunc = getExecFunction<uint8_t>(arguments);
+        getExecFunction<uint8_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::STRING: {
-        vectorOperationDefinition->execFunc = getExecFunction<ku_string_t>(arguments);
+        getExecFunction<ku_string_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::DATE: {
-        vectorOperationDefinition->execFunc = getExecFunction<date_t>(arguments);
+        getExecFunction<date_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::TIMESTAMP: {
-        vectorOperationDefinition->execFunc = getExecFunction<timestamp_t>(arguments);
+        getExecFunction<timestamp_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     case LogicalTypeID::INTERVAL: {
-        vectorOperationDefinition->execFunc = getExecFunction<interval_t>(arguments);
+        getExecFunction<interval_t>(arguments, vectorOperationDefinition->execFunc);
     } break;
     default: {
         throw common::NotImplementedException("ListReverseSortVectorOperation::bindFunc");
@@ -462,13 +465,15 @@ std::unique_ptr<FunctionBindData> ListReverseSortVectorOperation::bindFunc(
 }
 
 template<typename T>
-scalar_exec_func ListReverseSortVectorOperation::getExecFunction(
-    const binder::expression_vector& arguments) {
+void ListReverseSortVectorOperation::getExecFunction(
+    const binder::expression_vector& arguments, scalar_exec_func& func) {
     if (arguments.size() == 1) {
-        return UnaryListExecFunction<list_entry_t, list_entry_t, operation::ListReverseSort<T>>;
+        func = UnaryListExecFunction<list_entry_t, list_entry_t, operation::ListReverseSort<T>>;
+        return;
     } else if (arguments.size() == 2) {
-        return BinaryListExecFunction<list_entry_t, ku_string_t, list_entry_t,
+        func = BinaryListExecFunction<list_entry_t, ku_string_t, list_entry_t,
             operation::ListReverseSort<T>>;
+        return;
     } else {
         throw common::RuntimeException("Invalid number of arguments");
     }

--- a/src/function/vector_null_operations.cpp
+++ b/src/function/vector_null_operations.cpp
@@ -7,27 +7,17 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace function {
 
-scalar_exec_func VectorNullOperations::bindExecFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
-    assert(children.size() == 1);
-    return bindUnaryExecFunction(expressionType, children);
-}
-
-scalar_select_func VectorNullOperations::bindSelectFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
-    assert(children.size() == 1);
-    return bindUnarySelectFunction(expressionType, children);
-}
-
-scalar_exec_func VectorNullOperations::bindUnaryExecFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorNullOperations::bindExecFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_exec_func& func) {
     assert(children.size() == 1);
     switch (expressionType) {
     case IS_NULL: {
-        return UnaryNullExecFunction<operation::IsNull>;
+        func = UnaryNullExecFunction<operation::IsNull>;
+        return;
     }
     case IS_NOT_NULL: {
-        return UnaryNullExecFunction<operation::IsNotNull>;
+        func = UnaryNullExecFunction<operation::IsNotNull>;
+        return;
     }
     default:
         throw RuntimeException("Invalid expression type " + expressionTypeToString(expressionType) +
@@ -35,15 +25,17 @@ scalar_exec_func VectorNullOperations::bindUnaryExecFunction(
     }
 }
 
-scalar_select_func VectorNullOperations::bindUnarySelectFunction(
-    ExpressionType expressionType, const binder::expression_vector& children) {
+void VectorNullOperations::bindSelectFunction(ExpressionType expressionType,
+    const binder::expression_vector& children, scalar_select_func& func) {
     assert(children.size() == 1);
     switch (expressionType) {
     case IS_NULL: {
-        return &UnaryNullSelectFunction<operation::IsNull>;
+        func = UnaryNullSelectFunction<operation::IsNull>;
+        return;
     }
     case IS_NOT_NULL: {
-        return &UnaryNullSelectFunction<operation::IsNotNull>;
+        func = UnaryNullSelectFunction<operation::IsNotNull>;
+        return;
     }
     default:
         throw RuntimeException("Invalid expression type " + expressionTypeToString(expressionType) +

--- a/src/include/function/arithmetic/vector_arithmetic_operations.h
+++ b/src/include/function/arithmetic/vector_arithmetic_operations.h
@@ -6,15 +6,15 @@
 namespace kuzu {
 namespace function {
 
-class VectorArithmeticOperations {
-
+class VectorArithmeticOperations : public VectorOperations {
 public:
     template<typename FUNC>
     static std::unique_ptr<VectorOperationDefinition> getUnaryDefinition(
         std::string name, common::LogicalTypeID operandTypeID) {
+        function::scalar_exec_func execFunc;
+        getUnaryExecFunc<FUNC>(operandTypeID, execFunc);
         return std::make_unique<VectorOperationDefinition>(std::move(name),
-            std::vector<common::LogicalTypeID>{operandTypeID}, operandTypeID,
-            getUnaryExecFunc<FUNC>(operandTypeID));
+            std::vector<common::LogicalTypeID>{operandTypeID}, operandTypeID, execFunc);
     }
 
     template<typename FUNC, typename OPERAND_TYPE, typename RETURN_TYPE = OPERAND_TYPE>
@@ -28,9 +28,11 @@ public:
     template<typename FUNC>
     static inline std::unique_ptr<VectorOperationDefinition> getBinaryDefinition(
         std::string name, common::LogicalTypeID operandTypeID) {
+        function::scalar_exec_func execFunc;
+        getBinaryExecFunc<FUNC>(operandTypeID, execFunc);
         return std::make_unique<VectorOperationDefinition>(std::move(name),
             std::vector<common::LogicalTypeID>{operandTypeID, operandTypeID}, operandTypeID,
-            getBinaryExecFunc<FUNC>(operandTypeID));
+            execFunc);
     }
 
     template<typename FUNC, typename OPERAND_TYPE, typename RETURN_TYPE = OPERAND_TYPE>
@@ -43,23 +45,27 @@ public:
 
 private:
     template<typename FUNC>
-    static scalar_exec_func getUnaryExecFunc(common::LogicalTypeID operandTypeID) {
+    static void getUnaryExecFunc(common::LogicalTypeID operandTypeID, scalar_exec_func& func) {
         switch (operandTypeID) {
         case common::LogicalTypeID::INT64: {
-            return &UnaryExecFunction<int64_t, int64_t, FUNC>;
+            func = UnaryExecFunction<int64_t, int64_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT32: {
-            return &UnaryExecFunction<int32_t, int32_t, FUNC>;
+            func = UnaryExecFunction<int32_t, int32_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT16: {
-            return &UnaryExecFunction<int16_t, int16_t, FUNC>;
+            func = UnaryExecFunction<int16_t, int16_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::DOUBLE: {
-            return &UnaryExecFunction<double_t, double_t, FUNC>;
+            func = UnaryExecFunction<double_t, double_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::FLOAT: {
-            return &UnaryExecFunction<float_t, float_t, FUNC>;
-            ;
+            func = UnaryExecFunction<float_t, float_t, FUNC>;
+            return;
         }
         default:
             throw common::RuntimeException(
@@ -70,22 +76,27 @@ private:
     }
 
     template<typename FUNC>
-    static scalar_exec_func getBinaryExecFunc(common::LogicalTypeID operandTypeID) {
+    static void getBinaryExecFunc(common::LogicalTypeID operandTypeID, scalar_exec_func& func) {
         switch (operandTypeID) {
         case common::LogicalTypeID::INT64: {
-            return &BinaryExecFunction<int64_t, int64_t, int64_t, FUNC>;
+            func = BinaryExecFunction<int64_t, int64_t, int64_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT32: {
-            return &BinaryExecFunction<int32_t, int32_t, int32_t, FUNC>;
+            func = BinaryExecFunction<int32_t, int32_t, int32_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT16: {
-            return &BinaryExecFunction<int16_t, int16_t, int16_t, FUNC>;
+            func = BinaryExecFunction<int16_t, int16_t, int16_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::DOUBLE: {
-            return &BinaryExecFunction<double_t, double_t, double_t, FUNC>;
+            func = BinaryExecFunction<double_t, double_t, double_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::FLOAT: {
-            return &BinaryExecFunction<float_t, float_t, float_t, FUNC>;
+            func = BinaryExecFunction<float_t, float_t, float_t, FUNC>;
+            return;
         }
         default:
             throw common::RuntimeException(

--- a/src/include/function/boolean/vector_boolean_operations.h
+++ b/src/include/function/boolean/vector_boolean_operations.h
@@ -6,57 +6,58 @@
 namespace kuzu {
 namespace function {
 
-template<typename FUNC>
-static void BinaryBooleanExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 2);
-    BinaryBooleanOperationExecutor::execute<FUNC>(*params[0], *params[1], result);
-}
-
-template<typename FUNC>
-static bool BinaryBooleanSelectFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params,
-    common::SelectionVector& selVector) {
-    assert(params.size() == 2);
-    return BinaryBooleanOperationExecutor::select<FUNC>(*params[0], *params[1], selVector);
-}
-
-template<typename FUNC>
-static void UnaryBooleanExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 1);
-    UnaryBooleanOperationExecutor::execute<FUNC>(*params[0], result);
-}
-
-template<typename FUNC>
-static bool UnaryBooleanSelectFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params,
-    common::SelectionVector& selVector) {
-    assert(params.size() == 1);
-    return UnaryBooleanOperationExecutor::select<FUNC>(*params[0], selVector);
-}
-
 class VectorBooleanOperations {
-
 public:
-    static scalar_exec_func bindExecFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    static void bindExecFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_exec_func& func);
 
-    static scalar_select_func bindSelectFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    static void bindSelectFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_select_func& func);
 
 private:
-    static scalar_exec_func bindBinaryExecFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    template<typename FUNC>
+    static void BinaryBooleanExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 2);
+        BinaryBooleanOperationExecutor::execute<FUNC>(*params[0], *params[1], result);
+    }
 
-    static scalar_select_func bindBinarySelectFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    template<typename FUNC>
+    static bool BinaryBooleanSelectFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::SelectionVector& selVector) {
+        assert(params.size() == 2);
+        return BinaryBooleanOperationExecutor::select<FUNC>(*params[0], *params[1], selVector);
+    }
 
-    static scalar_exec_func bindUnaryExecFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    template<typename FUNC>
+    static void UnaryBooleanExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 1);
+        UnaryBooleanOperationExecutor::execute<FUNC>(*params[0], result);
+    }
 
-    static scalar_select_func bindUnarySelectFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    template<typename FUNC>
+    static bool UnaryBooleanSelectFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::SelectionVector& selVector) {
+        assert(params.size() == 1);
+        return UnaryBooleanOperationExecutor::select<FUNC>(*params[0], selVector);
+    }
+
+    static void bindBinaryExecFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_exec_func& func);
+
+    static void bindBinarySelectFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_select_func& func);
+
+    static void bindUnaryExecFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_exec_func& func);
+
+    static void bindUnarySelectFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_select_func& func);
 };
 
 } // namespace function

--- a/src/include/function/comparison/vector_comparison_operations.h
+++ b/src/include/function/comparison/vector_comparison_operations.h
@@ -7,8 +7,7 @@
 namespace kuzu {
 namespace function {
 
-class VectorComparisonOperations {
-
+class VectorComparisonOperations : public VectorOperations {
 protected:
     template<typename FUNC>
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions(
@@ -34,51 +33,60 @@ private:
     template<typename FUNC>
     static inline std::unique_ptr<VectorOperationDefinition> getDefinition(const std::string& name,
         common::LogicalTypeID leftTypeID, common::LogicalTypeID rightTypeID) {
-        auto execFunc = getExecFunc<FUNC>(leftTypeID, rightTypeID);
-        auto selectFunc = getSelectFunc<FUNC>(leftTypeID, rightTypeID);
+        scalar_exec_func execFunc;
+        getExecFunc<FUNC>(leftTypeID, rightTypeID, execFunc);
+        scalar_select_func selectFunc;
+        getSelectFunc<FUNC>(leftTypeID, rightTypeID, selectFunc);
         return std::make_unique<VectorOperationDefinition>(name,
             std::vector<common::LogicalTypeID>{leftTypeID, rightTypeID},
             common::LogicalTypeID::BOOL, execFunc, selectFunc);
     }
 
     template<typename FUNC>
-    static scalar_exec_func getExecFunc(
-        common::LogicalTypeID leftTypeID, common::LogicalTypeID rightTypeID) {
+    static void getExecFunc(common::LogicalTypeID leftTypeID, common::LogicalTypeID rightTypeID,
+        scalar_exec_func& func) {
         switch (leftTypeID) {
         case common::LogicalTypeID::INT64: {
-            return &BinaryExecFunction<int64_t, int64_t, uint8_t, FUNC>;
+            func = BinaryExecFunction<int64_t, int64_t, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT32: {
-            return &BinaryExecFunction<int32_t, int32_t, uint8_t, FUNC>;
+            func = BinaryExecFunction<int32_t, int32_t, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT16: {
-            return &BinaryExecFunction<int16_t, int16_t, uint8_t, FUNC>;
+            func = BinaryExecFunction<int16_t, int16_t, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::DOUBLE: {
-            return &BinaryExecFunction<double, double, uint8_t, FUNC>;
+            func = BinaryExecFunction<double, double, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::FLOAT: {
-            return &BinaryExecFunction<float, float, uint8_t, FUNC>;
+            func = BinaryExecFunction<float, float, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::BOOL: {
-            assert(rightTypeID == common::LogicalTypeID::BOOL);
-            return &BinaryExecFunction<uint8_t, uint8_t, uint8_t, FUNC>;
+            func = BinaryExecFunction<uint8_t, uint8_t, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::STRING: {
-            assert(rightTypeID == common::LogicalTypeID::STRING);
-            return &BinaryExecFunction<common::ku_string_t, common::ku_string_t, uint8_t, FUNC>;
+            func = BinaryExecFunction<common::ku_string_t, common::ku_string_t, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INTERNAL_ID: {
-            assert(rightTypeID == common::LogicalTypeID::INTERNAL_ID);
-            return &BinaryExecFunction<common::nodeID_t, common::nodeID_t, uint8_t, FUNC>;
+            func = BinaryExecFunction<common::nodeID_t, common::nodeID_t, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::DATE: {
             switch (rightTypeID) {
             case common::LogicalTypeID::DATE: {
-                return &BinaryExecFunction<common::date_t, common::date_t, uint8_t, FUNC>;
+                func = BinaryExecFunction<common::date_t, common::date_t, uint8_t, FUNC>;
+                return;
             }
             case common::LogicalTypeID::TIMESTAMP: {
-                return &BinaryExecFunction<common::date_t, common::timestamp_t, uint8_t, FUNC>;
+                func = BinaryExecFunction<common::date_t, common::timestamp_t, uint8_t, FUNC>;
+                return;
             }
             default:
                 throw common::RuntimeException(
@@ -90,10 +98,12 @@ private:
         case common::LogicalTypeID::TIMESTAMP: {
             switch (rightTypeID) {
             case common::LogicalTypeID::DATE: {
-                return &BinaryExecFunction<common::timestamp_t, common::date_t, uint8_t, FUNC>;
+                func = BinaryExecFunction<common::timestamp_t, common::date_t, uint8_t, FUNC>;
+                return;
             }
             case common::LogicalTypeID::TIMESTAMP: {
-                return &BinaryExecFunction<common::timestamp_t, common::timestamp_t, uint8_t, FUNC>;
+                func = BinaryExecFunction<common::timestamp_t, common::timestamp_t, uint8_t, FUNC>;
+                return;
             }
             default:
                 throw common::RuntimeException(
@@ -103,8 +113,8 @@ private:
             }
         }
         case common::LogicalTypeID::INTERVAL: {
-            assert(rightTypeID == common::LogicalTypeID::INTERVAL);
-            return &BinaryExecFunction<common::interval_t, common::interval_t, uint8_t, FUNC>;
+            func = BinaryExecFunction<common::interval_t, common::interval_t, uint8_t, FUNC>;
+            return;
         }
         default:
             throw common::RuntimeException(
@@ -115,43 +125,50 @@ private:
     }
 
     template<typename FUNC>
-    static scalar_select_func getSelectFunc(
-        common::LogicalTypeID leftTypeID, common::LogicalTypeID rightTypeID) {
+    static void getSelectFunc(common::LogicalTypeID leftTypeID, common::LogicalTypeID rightTypeID,
+        scalar_select_func& func) {
         switch (leftTypeID) {
         case common::LogicalTypeID::INT64: {
-            return &BinarySelectFunction<int64_t, int64_t, FUNC>;
+            func = BinarySelectFunction<int64_t, int64_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT32: {
-            return &BinarySelectFunction<int32_t, int32_t, FUNC>;
+            func = BinarySelectFunction<int32_t, int32_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INT16: {
-            return &BinarySelectFunction<int16_t, int16_t, FUNC>;
+            func = BinarySelectFunction<int16_t, int16_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::DOUBLE: {
-            return &BinarySelectFunction<double_t, double_t, FUNC>;
+            func = BinarySelectFunction<double_t, double_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::FLOAT: {
-            return &BinarySelectFunction<float_t, float_t, FUNC>;
+            func = BinarySelectFunction<float_t, float_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::BOOL: {
-            assert(rightTypeID == common::LogicalTypeID::BOOL);
-            return &BinarySelectFunction<uint8_t, uint8_t, FUNC>;
+            func = BinarySelectFunction<uint8_t, uint8_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::STRING: {
-            assert(rightTypeID == common::LogicalTypeID::STRING);
-            return &BinarySelectFunction<common::ku_string_t, common::ku_string_t, FUNC>;
+            func = BinarySelectFunction<common::ku_string_t, common::ku_string_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::INTERNAL_ID: {
-            assert(rightTypeID == common::LogicalTypeID::INTERNAL_ID);
-            return &BinarySelectFunction<common::nodeID_t, common::nodeID_t, FUNC>;
+            func = BinarySelectFunction<common::nodeID_t, common::nodeID_t, FUNC>;
+            return;
         }
         case common::LogicalTypeID::DATE: {
             switch (rightTypeID) {
             case common::LogicalTypeID::DATE: {
-                return &BinarySelectFunction<common::date_t, common::date_t, FUNC>;
+                func = BinarySelectFunction<common::date_t, common::date_t, FUNC>;
+                return;
             }
             case common::LogicalTypeID::TIMESTAMP: {
-                return &BinarySelectFunction<common::date_t, common::timestamp_t, FUNC>;
+                func = BinarySelectFunction<common::date_t, common::timestamp_t, FUNC>;
+                return;
             }
             default:
                 throw common::RuntimeException(
@@ -164,10 +181,12 @@ private:
         case common::LogicalTypeID::TIMESTAMP: {
             switch (rightTypeID) {
             case common::LogicalTypeID::DATE: {
-                return &BinarySelectFunction<common::timestamp_t, common::date_t, FUNC>;
+                func = BinarySelectFunction<common::timestamp_t, common::date_t, FUNC>;
+                return;
             }
             case common::LogicalTypeID::TIMESTAMP: {
-                return &BinarySelectFunction<common::timestamp_t, common::timestamp_t, FUNC>;
+                func = BinarySelectFunction<common::timestamp_t, common::timestamp_t, FUNC>;
+                return;
             }
             default:
                 throw common::RuntimeException(
@@ -178,8 +197,8 @@ private:
             }
         }
         case common::LogicalTypeID::INTERVAL: {
-            assert(rightTypeID == common::LogicalTypeID::INTERVAL);
-            return &BinarySelectFunction<common::interval_t, common::interval_t, FUNC>;
+            func = BinarySelectFunction<common::interval_t, common::interval_t, FUNC>;
+            return;
         }
         default:
             throw common::RuntimeException(

--- a/src/include/function/date/vector_date_operations.h
+++ b/src/include/function/date/vector_date_operations.h
@@ -4,7 +4,7 @@
 
 namespace kuzu {
 namespace function {
-class VectorDateOperations {};
+class VectorDateOperations : public VectorOperations {};
 
 struct DatePartVectorOperation : public VectorDateOperations {
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();

--- a/src/include/function/interval/vector_interval_operations.h
+++ b/src/include/function/interval/vector_interval_operations.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace function {
 
-class VectorIntervalOperations {
+class VectorIntervalOperations : public VectorOperations {
 public:
     template<class OPERATION>
     static inline std::vector<std::unique_ptr<VectorOperationDefinition>>

--- a/src/include/function/list/vector_list_operations.h
+++ b/src/include/function/list/vector_list_operations.h
@@ -5,30 +5,33 @@
 namespace kuzu {
 namespace function {
 
-template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
-static void TernaryListExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 3);
-    TernaryOperationExecutor::executeList<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(
-        *params[0], *params[1], *params[2], result);
-}
+struct VectorListOperations : public VectorOperations {
+    template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void TernaryListExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 3);
+        TernaryOperationExecutor::executeList<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(
+            *params[0], *params[1], *params[2], result);
+    }
 
-template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
-static void BinaryListExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 2);
-    BinaryOperationExecutor::executeList<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
-        *params[0], *params[1], result);
-}
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void BinaryListExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 2);
+        BinaryOperationExecutor::executeList<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+            *params[0], *params[1], result);
+    }
 
-template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
-static void UnaryListExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 1);
-    UnaryOperationExecutor::executeList<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
-}
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void UnaryListExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 1);
+        UnaryOperationExecutor::executeList<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
+    }
 
-struct VectorListOperations {
     template<typename OPERATION, typename RESULT_TYPE>
     static std::vector<std::unique_ptr<VectorOperationDefinition>>
     getBinaryListOperationDefinitions(std::string funcName, common::LogicalTypeID resultTypeID) {
@@ -139,7 +142,7 @@ struct ListSortVectorOperation : public VectorListOperations {
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, FunctionDefinition* definition);
     template<typename T>
-    static scalar_exec_func getExecFunction(const binder::expression_vector& arguments);
+    static void getExecFunction(const binder::expression_vector& arguments, scalar_exec_func& func);
 };
 
 struct ListReverseSortVectorOperation : public VectorListOperations {
@@ -147,7 +150,7 @@ struct ListReverseSortVectorOperation : public VectorListOperations {
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, FunctionDefinition* definition);
     template<typename T>
-    static scalar_exec_func getExecFunction(const binder::expression_vector& arguments);
+    static void getExecFunction(const binder::expression_vector& arguments, scalar_exec_func& func);
 };
 
 struct ListSumVectorOperation : public VectorListOperations {

--- a/src/include/function/null/vector_null_operations.h
+++ b/src/include/function/null/vector_null_operations.h
@@ -6,35 +6,30 @@
 namespace kuzu {
 namespace function {
 
-template<typename FUNC>
-static void UnaryNullExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 1);
-    NullOperationExecutor::execute<FUNC>(*params[0], result);
-}
-
-template<typename FUNC>
-static bool UnaryNullSelectFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
-    common::SelectionVector& selVector) {
-    assert(params.size() == 1);
-    return NullOperationExecutor::select<FUNC>(*params[0], selVector);
-}
-
 class VectorNullOperations {
-
 public:
-    static scalar_exec_func bindExecFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    static void bindExecFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_exec_func& func);
 
-    static scalar_select_func bindSelectFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    static void bindSelectFunction(common::ExpressionType expressionType,
+        const binder::expression_vector& children, scalar_select_func& func);
 
 private:
-    static scalar_exec_func bindUnaryExecFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    template<typename FUNC>
+    static void UnaryNullExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 1);
+        NullOperationExecutor::execute<FUNC>(*params[0], result);
+    }
 
-    static scalar_select_func bindUnarySelectFunction(
-        common::ExpressionType expressionType, const binder::expression_vector& children);
+    template<typename FUNC>
+    static bool UnaryNullSelectFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::SelectionVector& selVector) {
+        assert(params.size() == 1);
+        return NullOperationExecutor::select<FUNC>(*params[0], selVector);
+    }
 };
 
 } // namespace function

--- a/src/include/function/string/vector_string_operations.h
+++ b/src/include/function/string/vector_string_operations.h
@@ -11,7 +11,7 @@
 namespace kuzu {
 namespace function {
 
-struct VectorStringOperations {
+struct VectorStringOperations : public VectorOperations {
 
     template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
     static void TernaryStringExecFunction(

--- a/src/include/function/timestamp/vector_timestamp_operations.h
+++ b/src/include/function/timestamp/vector_timestamp_operations.h
@@ -4,7 +4,7 @@
 
 namespace kuzu {
 namespace function {
-class VectorTimestampOperations {};
+class VectorTimestampOperations : public VectorOperations {};
 
 struct CenturyVectorOperation : public VectorTimestampOperations {
     static std::vector<std::unique_ptr<VectorOperationDefinition>> getDefinitions();

--- a/src/include/function/vector_operations.h
+++ b/src/include/function/vector_operations.h
@@ -10,7 +10,6 @@
 namespace kuzu {
 namespace function {
 
-// Forward declaration of VectorOperationDefinition.
 struct VectorOperationDefinition;
 
 using scalar_exec_func = std::function<void(
@@ -47,45 +46,46 @@ struct VectorOperationDefinition : public FunctionDefinition {
     bool isVarLength;
 };
 
-// Note: Previously part of a VectorOperations class, but MSVC is unable to resolve references to
-// the function within subclasses.
-template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
-static void TernaryExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 3);
-    TernaryOperationExecutor::execute<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(
-        *params[0], *params[1], *params[2], result);
-}
+struct VectorOperations {
+    template<typename A_TYPE, typename B_TYPE, typename C_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void TernaryExecFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 3);
+        TernaryOperationExecutor::execute<A_TYPE, B_TYPE, C_TYPE, RESULT_TYPE, FUNC>(
+            *params[0], *params[1], *params[2], result);
+    }
 
-template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
-static void BinaryExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 2);
-    BinaryOperationExecutor::execute<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
-        *params[0], *params[1], result);
-}
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void BinaryExecFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 2);
+        BinaryOperationExecutor::execute<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
+            *params[0], *params[1], result);
+    }
 
-template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
-static bool BinarySelectFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
-    common::SelectionVector& selVector) {
-    assert(params.size() == 2);
-    return BinaryOperationExecutor::select<LEFT_TYPE, RIGHT_TYPE, FUNC>(
-        *params[0], *params[1], selVector);
-}
+    template<typename LEFT_TYPE, typename RIGHT_TYPE, typename FUNC>
+    static bool BinarySelectFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::SelectionVector& selVector) {
+        assert(params.size() == 2);
+        return BinaryOperationExecutor::select<LEFT_TYPE, RIGHT_TYPE, FUNC>(
+            *params[0], *params[1], selVector);
+    }
 
-template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
-static void UnaryExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 1);
-    UnaryOperationExecutor::execute<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
-}
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void UnaryExecFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 1);
+        UnaryOperationExecutor::execute<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
+    }
 
-template<typename RESULT_TYPE, typename FUNC>
-static void ConstExecFunction(
-    const std::vector<std::shared_ptr<common::ValueVector>>& params, common::ValueVector& result) {
-    assert(params.size() == 0);
-    ConstOperationExecutor::execute<RESULT_TYPE, FUNC>(result);
-}
+    template<typename RESULT_TYPE, typename FUNC>
+    static void ConstExecFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result) {
+        assert(params.size() == 0);
+        ConstOperationExecutor::execute<RESULT_TYPE, FUNC>(result);
+    }
+};
 
 } // namespace function
 } // namespace kuzu

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -9,13 +9,6 @@
 namespace kuzu {
 namespace processor {
 
-template<typename type>
-bool compareEntryWithKeys(const uint8_t* keyValue, const uint8_t* entry) {
-    uint8_t result;
-    kuzu::function::operation::Equals::operation(*(type*)keyValue, *(type*)entry, result);
-    return result != 0;
-}
-
 struct HashSlot {
     common::hash_t hash; // 8 bytes for hashVector.
     uint8_t* entry;      // pointer to the factorizedTable entry which stores [groupKey1, ...
@@ -185,7 +178,14 @@ private:
 
     void resizeHashTableIfNecessary(uint32_t maxNumDistinctHashKeys);
 
-    static compare_function_t getCompareEntryWithKeysFunc(common::LogicalTypeID typeId);
+    template<typename type>
+    static bool compareEntryWithKeys(const uint8_t* keyValue, const uint8_t* entry) {
+        uint8_t result;
+        kuzu::function::operation::Equals::operation(*(type*)keyValue, *(type*)entry, result);
+        return result != 0;
+    }
+
+    static void getCompareEntryWithKeysFunc(common::LogicalTypeID typeId, compare_function_t& func);
 
     void updateNullAggVectorState(
         const std::vector<common::ValueVector*>& groupByFlatHashKeyVectors,

--- a/src/include/processor/operator/order_by/order_by_key_encoder.h
+++ b/src/include/processor/operator/order_by/order_by_key_encoder.h
@@ -88,12 +88,17 @@ public:
 
     void encodeKeys();
 
+private:
+    template<typename type>
+    static inline void encodeTemplate(const uint8_t* data, uint8_t* resultPtr, bool swapBytes) {
+        OrderByKeyEncoder::encodeData(*(type*)data, resultPtr, swapBytes);
+    }
+
     template<typename type>
     static void encodeData(type data, uint8_t* resultPtr, bool swapBytes) {
         assert(false);
     }
 
-private:
     static inline uint8_t flipSign(uint8_t key_byte) { return key_byte ^ 128; }
 
     void flipBytesIfNecessary(uint32_t keyColIdx, uint8_t* tuplePtr, uint32_t numEntriesToEncode,
@@ -111,7 +116,7 @@ private:
 
     void allocateMemoryIfFull();
 
-    static encode_function_t getEncodingFunction(common::PhysicalTypeID physicalType);
+    static void getEncodingFunction(common::PhysicalTypeID physicalType, encode_function_t& func);
 
 private:
     storage::MemoryManager* memoryManager;
@@ -133,9 +138,5 @@ private:
     std::vector<encode_function_t> encodeFunctions;
 };
 
-template<typename type>
-static inline void encodeTemplate(const uint8_t* data, uint8_t* resultPtr, bool swapBytes) {
-    OrderByKeyEncoder::encodeData(*(type*)data, resultPtr, swapBytes);
-}
 } // namespace processor
 } // namespace kuzu

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -144,7 +144,7 @@ void AggregateHashTable::initializeFT(
         auto size = FactorizedTable::getDataTypeSize(dataType);
         tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnflat, dataChunkPos, size));
         hasStrCol = hasStrCol || dataType.getLogicalTypeID() == LogicalTypeID::STRING;
-        compareFuncs[colIdx] = getCompareEntryWithKeysFunc(dataType.getLogicalTypeID());
+        getCompareEntryWithKeysFunc(dataType.getLogicalTypeID(), compareFuncs[colIdx]);
         numBytesForKeys += size;
         colIdx++;
     }
@@ -152,7 +152,7 @@ void AggregateHashTable::initializeFT(
         auto size = FactorizedTable::getDataTypeSize(dataType);
         tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnflat, dataChunkPos, size));
         hasStrCol = hasStrCol || dataType.getLogicalTypeID() == LogicalTypeID::STRING;
-        compareFuncs[colIdx] = getCompareEntryWithKeysFunc(dataType.getLogicalTypeID());
+        getCompareEntryWithKeysFunc(dataType.getLogicalTypeID(), compareFuncs[colIdx]);
         numBytesForDependentKeys += size;
         colIdx++;
     }
@@ -665,40 +665,52 @@ void AggregateHashTable::resizeHashTableIfNecessary(uint32_t maxNumDistinctHashK
     }
 }
 
-compare_function_t AggregateHashTable::getCompareEntryWithKeysFunc(LogicalTypeID typeId) {
+void AggregateHashTable::getCompareEntryWithKeysFunc(
+    LogicalTypeID typeId, compare_function_t& func) {
     switch (typeId) {
     case LogicalTypeID::INTERNAL_ID: {
-        return compareEntryWithKeys<nodeID_t>;
+        func = compareEntryWithKeys<nodeID_t>;
+        return;
     }
     case LogicalTypeID::BOOL: {
-        return compareEntryWithKeys<bool>;
+        func = compareEntryWithKeys<bool>;
+        return;
     }
     case LogicalTypeID::INT64: {
-        return compareEntryWithKeys<int64_t>;
+        func = compareEntryWithKeys<int64_t>;
+        return;
     }
     case LogicalTypeID::INT32: {
-        return compareEntryWithKeys<int32_t>;
+        func = compareEntryWithKeys<int32_t>;
+        return;
     }
     case LogicalTypeID::INT16: {
-        return compareEntryWithKeys<int16_t>;
+        func = compareEntryWithKeys<int16_t>;
+        return;
     }
     case LogicalTypeID::DOUBLE: {
-        return compareEntryWithKeys<double_t>;
+        func = compareEntryWithKeys<double_t>;
+        return;
     }
     case LogicalTypeID::FLOAT: {
-        return compareEntryWithKeys<float_t>;
+        func = compareEntryWithKeys<float_t>;
+        return;
     }
     case LogicalTypeID::STRING: {
-        return compareEntryWithKeys<ku_string_t>;
+        func = compareEntryWithKeys<ku_string_t>;
+        return;
     }
     case LogicalTypeID::DATE: {
-        return compareEntryWithKeys<date_t>;
+        func = compareEntryWithKeys<date_t>;
+        return;
     }
     case LogicalTypeID::TIMESTAMP: {
-        return compareEntryWithKeys<timestamp_t>;
+        func = compareEntryWithKeys<timestamp_t>;
+        return;
     }
     case LogicalTypeID::INTERVAL: {
-        return compareEntryWithKeys<interval_t>;
+        func = compareEntryWithKeys<interval_t>;
+        return;
     }
     default: {
         throw RuntimeException(

--- a/src/processor/operator/order_by/order_by_key_encoder.cpp
+++ b/src/processor/operator/order_by/order_by_key_encoder.cpp
@@ -32,7 +32,7 @@ OrderByKeyEncoder::OrderByKeyEncoder(std::vector<ValueVector*>& orderByVectors,
     }
     encodeFunctions.resize(orderByVectors.size());
     for (auto i = 0u; i < orderByVectors.size(); i++) {
-        encodeFunctions[i] = getEncodingFunction(orderByVectors[i]->dataType.getPhysicalType());
+        getEncodingFunction(orderByVectors[i]->dataType.getPhysicalType(), encodeFunctions[i]);
     }
 }
 
@@ -197,31 +197,39 @@ void OrderByKeyEncoder::allocateMemoryIfFull() {
     }
 }
 
-encode_function_t OrderByKeyEncoder::getEncodingFunction(PhysicalTypeID physicalType) {
+void OrderByKeyEncoder::getEncodingFunction(PhysicalTypeID physicalType, encode_function_t& func) {
     switch (physicalType) {
     case PhysicalTypeID::BOOL: {
-        return &encodeTemplate<bool>;
+        func = encodeTemplate<bool>;
+        return;
     }
     case PhysicalTypeID::INT64: {
-        return &encodeTemplate<int64_t>;
+        func = encodeTemplate<int64_t>;
+        return;
     }
     case PhysicalTypeID::INT32: {
-        return &encodeTemplate<int32_t>;
+        func = encodeTemplate<int32_t>;
+        return;
     }
     case PhysicalTypeID::INT16: {
-        return &encodeTemplate<int16_t>;
+        func = encodeTemplate<int16_t>;
+        return;
     }
     case PhysicalTypeID::DOUBLE: {
-        return &encodeTemplate<double_t>;
+        func = encodeTemplate<double_t>;
+        return;
     }
     case PhysicalTypeID::FLOAT: {
-        return &encodeTemplate<float_t>;
+        func = encodeTemplate<float_t>;
+        return;
     }
     case PhysicalTypeID::STRING: {
-        return &encodeTemplate<ku_string_t>;
+        func = encodeTemplate<ku_string_t>;
+        return;
     }
     case PhysicalTypeID::INTERVAL: {
-        return &encodeTemplate<interval_t>;
+        func = encodeTemplate<interval_t>;
+        return;
     }
     default: {
         throw RuntimeException("Cannot encode data with physical type: " +

--- a/src/storage/storage_structure/lists/lists_update_store.cpp
+++ b/src/storage/storage_structure/lists/lists_update_store.cpp
@@ -272,7 +272,7 @@ void ListsUpdatesStore::initNewlyAddedNodes(nodeID_t& nodeID) {
             nodeID.tableID == relTableSchema.getBoundTableID(direction)) {
             auto& listsUpdatesPerNode =
                 listsUpdatesPerDirection[direction][StorageUtils::getListChunkIdx(nodeID.offset)];
-            if (!listsUpdatesPerNode.count(nodeID.offset) > 0) {
+            if (listsUpdatesPerNode.count(nodeID.offset) == 0) {
                 listsUpdatesPerNode.emplace(
                     nodeID.offset, std::make_unique<ListsUpdatesForNodeOffset>(relTableSchema));
             }
@@ -329,7 +329,7 @@ ListsUpdatesForNodeOffset* ListsUpdatesStore::getOrCreateListsUpdatesForNodeOffs
     auto nodeOffset = nodeID.offset;
     auto& listsUpdatesPerNodeOffset =
         listsUpdatesPerDirection[relDirection][StorageUtils::getListChunkIdx(nodeOffset)];
-    if (!listsUpdatesPerNodeOffset.count(nodeOffset) > 0) {
+    if (listsUpdatesPerNodeOffset.count(nodeOffset) == 0) {
         listsUpdatesPerNodeOffset.emplace(
             nodeOffset, std::make_shared<ListsUpdatesForNodeOffset>(relTableSchema));
     }
@@ -341,8 +341,8 @@ ListsUpdatesForNodeOffset* ListsUpdatesStore::getListsUpdatesForNodeOffsetIfExis
     auto relNodeTableAndDir = getRelNodeTableAndDirFromListFileID(listFileID);
     auto& listsUpdatesPerChunk = listsUpdatesPerDirection[relNodeTableAndDir.dir];
     auto chunkIdx = StorageUtils::getListChunkIdx(nodeOffset);
-    if (!listsUpdatesPerChunk.count(chunkIdx) > 0 ||
-        !listsUpdatesPerChunk.at(chunkIdx).count(nodeOffset) > 0) {
+    if (listsUpdatesPerChunk.count(chunkIdx) == 0 ||
+        listsUpdatesPerChunk.at(chunkIdx).count(nodeOffset) == 0) {
         return nullptr;
     }
     return listsUpdatesPerChunk.at(chunkIdx).at(nodeOffset).get();


### PR DESCRIPTION
Windows doesn't have a good support to return function pointer. Previously we had to expose static functions in header files in order to return their pointer. 

This PR changes return function pointer to set a functor reference. So we can wrap static functions inside class.