### PR TITLE
Allow writing test queries in multiple lines

### DIFF
--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -63,7 +63,7 @@ private:
     std::string line;
     std::string name;
     std::unique_ptr<TestGroup> testGroup;
-    std::string extractTextBeforeNextStatement();
+    std::string extractTextBeforeNextStatement(bool ignoreLineBreak = false);
     std::string parseCommand();
     std::string parseCommandArange();
     LogicToken currentToken;
@@ -72,7 +72,7 @@ private:
     void tokenize();
     void parseHeader();
     void parseBody();
-    void extractExpectedResult(TestStatement* currentStatement);
+    void extractExpectedResult(TestStatement* statement);
     void extractStatementBlock();
     void addStatementBlock(const std::string& blockName, const std::string& testGroupName);
     void replaceVariables(std::string& str);

--- a/test/test_files/ldbc/ldbc-interactive/interactive-short.test
+++ b/test/test_files/ldbc/ldbc-interactive/interactive-short.test
@@ -7,7 +7,16 @@
 -CASE LDBCInteractiveShort
 
 -NAME IS1
--QUERY MATCH (n:Person {id: 933})-[:Person_isLocatedIn_Place]->(p:Place) WHERE p.label = "City" RETURN n.firstName AS firstName, n.lastName AS lastName, n.birthday AS birthday, n.locationIP AS locationIP, n.browserUsed AS browserUsed, p.id AS cityId, n.gender AS gender, n.creationDate AS creationDate;
+-QUERY MATCH (n:Person {id: 933})-[:Person_isLocatedIn_Place]->(p:Place)
+       WHERE p.label = "City"
+       RETURN n.firstName AS firstName,
+              n.lastName AS lastName,
+              n.birthday AS birthday,
+              n.locationIP AS locationIP,
+              n.browserUsed AS browserUsed,
+              p.id AS cityId,
+              n.gender AS gender,
+              n.creationDate AS creationDate;
 ---- 1
 Mahinda|Perera|19891203|119.235.7.103|Firefox|1353|male|20100214153210447
 
@@ -39,7 +48,12 @@ Mahinda|Perera|19891203|119.235.7.103|Firefox|1353|male|20100214153210447
 #1030792343986|fine|20120810030544084|1030792343978|21990232556837|Bing|Li
 
 -NAME IS3
--QUERY MATCH (n:Person {id: 1129})-[r:Person_knows_Person]-(friend) RETURN friend.id AS personId, friend.firstName AS firstName, friend.lastName AS lastName, r.creationDate AS friendshipCreationDate ORDER BY friendshipCreationDate DESC, personId ASC;
+-QUERY MATCH (n:Person {id: 1129})-[r:Person_knows_Person]-(friend)
+       RETURN friend.id AS personId,
+              friend.firstName AS firstName,
+              friend.lastName AS lastName,
+              r.creationDate AS friendshipCreationDate
+       ORDER BY friendshipCreationDate DESC, personId ASC
 ---- 7
 32985348834375|Alfred|Hoffmann|20120803220915016
 30786325578932|Alexander|Hleb|20120529180010845
@@ -51,12 +65,20 @@ Mahinda|Perera|19891203|119.235.7.103|Firefox|1353|male|20100214153210447
 
 # The 'Case When' statement in query IS4 should be supported as coalesce()
 -NAME IS4
--QUERY MATCH (m:Post:Comment {id: 481036337190}) RETURN m.creationDate as messageCreationDate, CASE WHEN m.content is NULL THEN m.imageFile ELSE m.content END AS messageContent;
+-QUERY MATCH (m:Post:Comment {id: 481036337190})
+       RETURN m.creationDate as messageCreationDate,
+       CASE WHEN m.content is NULL
+            THEN m.imageFile
+            ELSE m.content
+       END AS messageContent;
 ---- 1
 20110407210642051|photo481036337190.jpg
 
 -NAME IS5
--QUERY MATCH (m:Post:Comment {id: 1030792151050})-[:Post_hasCreator_Person|:Comment_hasCreator_Person]->(p:Person) RETURN p.id AS personId, p.firstName AS firstName, p.lastName AS lastName;
+-QUERY MATCH (m:Post:Comment {id: 1030792151050})-[:Post_hasCreator_Person|:Comment_hasCreator_Person]->(p:Person)
+       RETURN p.id AS personId,
+              p.firstName AS firstName,
+              p.lastName AS lastName;
 ---- 1
 2199023256077|Ibrahim Bare|Ousmane
 
@@ -74,7 +96,18 @@ Mahinda|Perera|19891203|119.235.7.103|Firefox|1353|male|20100214153210447
 # 687194767491|Wall of Faisal Malik|21990232556585|Faisal|Malik
 
 -NAME IS7
--QUERY MATCH (m:Post:Comment {id: 962072971887})<-[:Comment_replyOf_Comment|:Comment_replyOf_Post]-(c:Comment)-[:Comment_hasCreator_Person]->(p:Person) OPTIONAL MATCH (m)-[:Comment_hasCreator_Person|:Post_hasCreator_Person]->(a:Person)-[r:Person_knows_Person]-(p) RETURN c.id AS commentId, c.content AS commentContent, c.creationDate AS commentCreationDate, p.id AS replyAuthorId, p.firstName AS replyAuthorFirstName, p.lastName AS replyAuthorLastName, CASE WHEN ID(r) IS NULL THEN False ELSE True END AS replyAuthorKnowsOriginalMessageAuthor;
+-QUERY MATCH (m:Post:Comment {id: 962072971887})<-[:Comment_replyOf_Comment|:Comment_replyOf_Post]-(c:Comment)-[:Comment_hasCreator_Person]->(p:Person)
+             OPTIONAL MATCH (m)-[:Comment_hasCreator_Person|:Post_hasCreator_Person]->(a:Person)-[r:Person_knows_Person]-(p)
+             RETURN c.id AS commentId,
+                    c.content AS commentContent,
+                    c.creationDate AS commentCreationDate,
+                    p.id AS replyAuthorId,
+                    p.firstName AS replyAuthorFirstName,
+                    p.lastName AS replyAuthorLastName,
+                    CASE WHEN ID(r) IS NULL
+                        THEN False
+                        ELSE True
+                    END AS replyAuthorKnowsOriginalMessageAuthor;
 ---- 9
 962072971888|right|20120530134931973|4398046511734|Camila|Alves|True
 962072971889|LOL|20120530114547280|24189255811663|Chris|Hall|True

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -86,20 +86,21 @@ void TestParser::extractExpectedResult(TestStatement* statement) {
     }
 }
 
-std::string TestParser::extractTextBeforeNextStatement() {
-    std::string text;
+std::string TestParser::extractTextBeforeNextStatement(bool ignoreLineBreak) {
+    std::string extractedText;
+    const std::string delimiter = ignoreLineBreak ? " " : "\n";
     while (nextLine()) {
         tokenize();
         if (currentToken.type != TokenType::SKIP) {
             setCursorToPreviousLine();
             break;
         }
-        if (!text.empty()) {
-            text += "\n";
+        if (!extractedText.empty()) {
+            extractedText += delimiter;
         }
-        text += StringUtils::ltrim(line);
+        extractedText += StringUtils::ltrim(line);
     }
-    return text;
+    return extractedText;
 }
 
 TestStatement* TestParser::extractStatement(TestStatement* statement) {
@@ -116,6 +117,7 @@ TestStatement* TestParser::extractStatement(TestStatement* statement) {
     case TokenType::STATEMENT:
     case TokenType::QUERY: {
         std::string query = paramsToString(1);
+        query += extractTextBeforeNextStatement(true);
         replaceVariables(query);
         statement->query = query;
         break;


### PR DESCRIPTION
This PR allows writing queries in multiple lines in the test file. Example:

```
-QUERY MATCH (n:Person {id: 1129})-[r:Person_knows_Person]-(friend)
       RETURN friend.id AS personId,
              friend.firstName AS firstName,
              friend.lastName AS lastName,
              r.creationDate AS friendshipCreationDate
       ORDER BY friendshipCreationDate DESC, personId ASC
---- 7
```

**Notes:**

1. line breaks will be replaced by a single space
2. The next line doesn't need to be necessarily `----`. Any valid token will consider the query is finished (ie `-CHECK_ORDER`)