### PR TITLE
Add option -SKIP to skip test cases

### DIFF
--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -33,8 +33,6 @@ struct TestGroup {
     std::unordered_map<std::string, std::vector<std::unique_ptr<TestStatement>>>
         testCasesStatementBlocks;
 
-    bool skipTest = false;
-
     bool isValid() const { return !group.empty() && !dataset.empty(); }
 
     bool hasStatements() const { return !testCases.empty(); }

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -30,7 +30,7 @@ enum class TokenType {
     SEPARATOR,
     STATEMENT,
     STATEMENT_BLOCK,
-    _SKIP
+    _SKIP_LINE
 };
 
 const std::unordered_map<std::string, TokenType> tokenMap = {{"-GROUP", TokenType::GROUP},

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -29,7 +29,8 @@ enum class TokenType {
     RESULT,
     SEPARATOR,
     STATEMENT,
-    STATEMENT_BLOCK
+    STATEMENT_BLOCK,
+    _SKIP
 };
 
 const std::unordered_map<std::string, TokenType> tokenMap = {{"-GROUP", TokenType::GROUP},

--- a/test/test_files/tinysnb/update_node/create.test
+++ b/test/test_files/tinysnb/update_node/create.test
@@ -121,3 +121,20 @@
 -QUERY MATCH (a:person)-[e1:studyAt]->(b:organisation), (a)-[e2:workAt]->(b) RETURN a.ID, b.ID, ID(e1), ID(e2)
 ---- 1
 100|50|4:3|5:3
+
+-CASE InsertNodeWithListTest
+-SKIP
+-BEGIN_WRITE_TRANSACTION
+-STATEMENT CREATE (:person {ID:11, workedHours:[1,2,3], usedNames:['A', 'this is a long name']})
+---- ok
+-QUERY MATCH (a:person) WHERE a.ID > 8 RETURN a.ID, a.workedHours,a.usedNames
+---- 3
+10|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]
+11|[1,2,3]|[A,this is a long name]
+9|[1]|[Grad]
+# -COMMIT
+-QUERY MATCH (a:person) WHERE a.ID > 8 RETURN a.ID, a.workedHours,a.usedNames
+---- 3
+10|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]
+11|[1,2,3]|[A,this is a long name]
+9|[1]|[Grad]

--- a/test/test_files/tinysnb/update_node/set.test
+++ b/test/test_files/tinysnb/update_node/set.test
@@ -176,3 +176,36 @@ Runtime exception: Maximum length of strings is 4096. Input string's length is 2
 22
 55
 99
+
+# TBD
+-CASE SetNodeListOfIntPropTest
+-SKIP
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.workedHours=[10,20]
+---- ok
+-QUERY MATCH (a:person) WHERE a.ID=0 RETURN a.workedHours
+---- 1
+[10,20]
+
+-CASE SetNodeListOfShortStringPropTest
+-SKIP
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['intel','microsoft']
+---- ok
+-QUERY MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames
+---- 1
+[intel,microsoft]
+
+-CASE SetNodeListOfLongStringPropTest
+-SKIP
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
+---- ok
+-QUERY MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames
+---- 1
+[abcndwjbwesdsd,microsofthbbjuwgedsd]
+
+-CASE SetNodeListofListPropTest
+-SKIP
+-STATEMENT MATCH (a:person) WHERE a.ID=8 SET a.courseScoresPerTerm=[[10,20],[0,0,0]]
+---- ok
+-QUERY MATCH (a:person) WHERE a.ID=8 RETURN a.courseScoresPerTerm
+---- 1
+[[10,20],[0,0,0]]

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -87,7 +87,7 @@ std::string TestParser::extractTextBeforeNextStatement() {
     std::string text;
     while (nextLine()) {
         tokenize();
-        if (currentToken.type != TokenType::_SKIP) {
+        if (currentToken.type != TokenType::_SKIP_LINE) {
             setCursorToPreviousLine();
             break;
         }
@@ -258,7 +258,7 @@ TokenType getTokenType(const std::string& input) {
     if (iter != tokenMap.end()) {
         return iter->second;
     } else {
-        return TokenType::_SKIP;
+        return TokenType::_SKIP_LINE;
     }
 }
 

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -12,9 +12,6 @@ namespace testing {
 std::unique_ptr<TestGroup> TestParser::parseTestFile() {
     openFile();
     parseHeader();
-    if (testGroup->skipTest) {
-        return std::move(testGroup);
-    }
     if (!testGroup->isValid()) {
         throw TestException("Invalid test header [" + path + "].");
     }
@@ -45,8 +42,8 @@ void TestParser::parseHeader() {
             break;
         }
         case TokenType::SKIP: {
-            testGroup->skipTest = true;
-            return;
+            testGroup->group = "DISABLED_" + testGroup->group;
+            break;
         }
         case TokenType::SEPARATOR: {
             return;
@@ -90,7 +87,7 @@ std::string TestParser::extractTextBeforeNextStatement() {
     std::string text;
     while (nextLine()) {
         tokenize();
-        if (currentToken.type != TokenType::SKIP) {
+        if (currentToken.type != TokenType::_SKIP) {
             setCursorToPreviousLine();
             break;
         }
@@ -221,6 +218,10 @@ void TestParser::parseBody() {
             addStatementBlock(currentToken.params[1], testCaseName);
             break;
         }
+        case TokenType::SKIP: {
+            testCaseName = "DISABLED_" + testCaseName;
+            break;
+        }
         case TokenType::EMPTY: {
             break;
         }
@@ -257,7 +258,7 @@ TokenType getTokenType(const std::string& input) {
     if (iter != tokenMap.end()) {
         return iter->second;
     } else {
-        return TokenType::SKIP;
+        return TokenType::_SKIP;
     }
 }
 


### PR DESCRIPTION
This PR implements `-SKIP` capability to be added in the test header or an individual test case. It follows the GTest framework by adding the prefix `DISABLED_` above the test name.

Example:
```
# To skip the whole file, add -SKIP in any place after -GROUP and before the end of the header --
-GROUP TinySnbUpdateTest
-DATASET tinysnb
-SKIP

# or to skip test cases individually, add -SKIP below -CASE

-CASE SetNodeListOfLongStringPropTest
-SKIP
-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
---- ok
-QUERY MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames
---- 1
[abcndwjbwesdsd,microsofthbbjuwgedsd]
```

Will be shown in the test report:

```
...
527/686 Test #527: TinySnbUpdateTest.SetNodeListofListPropTest .....................................................................***Not Run (Disabled)   0.00 sec
...
100% tests passed, 0 tests failed out of 680

Total Test time (real) = 136.72 sec

The following tests did not run:
	490 - TinySnbUpdateTest.InsertNodeWithListTest (Disabled)
	505 - TinySnbUpdateTest.SetNodeListOfLongStringPropTest (Disabled)
	506 - TinySnbUpdateTest.SetNodeListOfShortStringPropTest (Disabled)
	508 - TinySnbUpdateTest.SetNodeListOfIntPropTest (Disabled)
	527 - TinySnbUpdateTest.SetNodeListofListPropTest (Disabled)
```