### PR TITLE
Port bundled linenoise to windows

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,4 @@
-if(NOT WIN32)
-    add_subdirectory(shell)
-endif()
+add_subdirectory(shell)
 if(${BUILD_NODEJS})
     add_subdirectory(nodejs_api)
 endif()

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -7,8 +7,8 @@
 
 #include "catalog/catalog.h"
 #include "common/logging_level_utils.h"
-#include "common/type_utils.h"
 #include "common/string_utils.h"
+#include "common/type_utils.h"
 #include "json.hpp"
 #include "processor/result/factorized_table.h"
 #include "utf8proc.h"
@@ -183,6 +183,7 @@ void highlight(char* buffer, char* resultBuf, uint32_t maxLen, uint32_t cursorPo
     }
     tokenList.emplace_back(word);
     for (std::string& token : tokenList) {
+#ifndef _WIN32
         if (token.find(' ') == std::string::npos) {
             for (const std::string& keyword : keywordList) {
                 if (regex_search(
@@ -196,6 +197,7 @@ void highlight(char* buffer, char* resultBuf, uint32_t maxLen, uint32_t cursorPo
                 }
             }
         }
+#endif
         highlightBuffer << token;
     }
     strcpy(resultBuf, highlightBuffer.str().c_str());


### PR DESCRIPTION
Adapted from https://github.com/microsoftarchive/redis/blob/3.0/deps/linenoise/linenoise.c and https://github.com/LuaDist-testing/linenoise-windows/blob/master/linenoise-windows/linenoise.c.

Those also make some more changes which I'm not sure are necessary, but (linenoise-windows replaces some control characters with windows API calls; which may be necessary with older versions of windows since it sounds like the ANSI control code support is recent, but I tried to keep this as small as possible rather than blindly copying stuff, particularly since linenoise-windows is for an older version of linenoise which is missing a bunch of stuff).

Generally it seems to work. I tested the basic functionality and most of the control codes (one thing I had to fix myself; the ports linked above tried had special handling to read the control codes which seemed to be broken, but it works without the special case).

I had to disable highlighting on windows, which was badly broken. According to https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences it should be possible to use colour codes if you set the `ENABLE_VIRTUAL_TERMINAL_PROCESSING` console mode flag, but setting that always failed on the terminal I was testing with. Even without that the colour codes had an effect (it did seem to turn text green), but behaved badly. There are windows API calls which can be used to control the formatting instead, but I don't think that would work very well with the current way highlighting is done since I think they all write directly to the console, rather than to a buffer (since they don't use special characters I guess).

There are also some alternative libraries which are cross-platform, but this seemed like the most straightforward way of getting it working.
- [Crossline](https://github.com/jcwangxp/Crossline): Not very active, but small and simple. It doesn't support unicode.
- [linenoise-ng](https://github.com/arangodb/linenoise-ng): A somewhat more modern version of linenoise which supports unicode, but is unmaintained and has been inactive for 6 years.
- [replxx](https://github.com/AmokHuginnsson/replxx): Seems like the most active and feature-rich, though nothing has been merged for 1.5 years.