### PR TITLE
Fix typo in WALReplayer::replayRelTableRecord

### DIFF
--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -197,7 +197,7 @@ void WALReplayer::replayRelTableRecord(const kuzu::storage::WALRecord& walRecord
         if (!isRecovering) {
             // See comments for NODE_TABLE_RECORD.
             storageManager->getRelsStore().createRelTable(
-                walRecord.nodeTableRecord.tableID, catalogForCheckpointing.get(), memoryManager);
+                walRecord.relTableRecord.tableID, catalogForCheckpointing.get(), memoryManager);
             storageManager->getNodesStore().getNodesStatisticsAndDeletedIDs().setAdjListsAndColumns(
                 &storageManager->getRelsStore());
         }


### PR DESCRIPTION
This won't lead to a bug because when we set `WalRecord.relTableRecord` to some value, then `WalRecord.nodeTableRecord` will also return the same value since they both store "int" at the same address due to union datatype (`WalRecord`). However, it's still incorrect from a code perspective.

For example:
```
struct TestUnion
{
    enum{CHAR, INT} tag;
    union
    {
        int a;
        int b;
    };
};

TEST {
    TestUnion t;
    t.tag = TestUnion::CHAR;
    t.a = 4;
    printf("%d", t.b); // returns 4 because same type as "a" and at that address 4 is stored.
}
```

I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).