### PR TITLE
Remove glob cmake file

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(antlr4_runtime)
 add_subdirectory(antlr4_cypher)
+add_subdirectory(glob)
 add_subdirectory(utf8proc)
 add_subdirectory(pybind11)
 add_subdirectory(re2)
-add_subdirectory(glob)

--- a/third_party/glob/CMakeLists.txt
+++ b/third_party/glob/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(Glob INTERFACE glob/glob.hpp)
+add_library(Glob INTERFACE)
 
 target_include_directories(Glob INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
The use of INTERFACE here in glob requires a pretty high cmake version 3.19.
This PR simplified glob lib to not create an interface library, same as `concurrentqueue`, `nlohmann_json`, etc.