### PR TITLE
Scan and parse test files only once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bazel-*
 .clwb
 .cache
 .bazelrc
+test/test_files/test_list
 
 test_temp/
 build/

--- a/test/include/test_helper/test_helper.h
+++ b/test/include/test_helper/test_helper.h
@@ -43,6 +43,9 @@ public:
     static constexpr char PARQUET_TEMP_DATASET_PATH[] = "dataset/parquet_temp/";
 
     static std::string getTmpTestDir() { return appendKuzuRootPath("test/unittest_temp/"); }
+    static std::string getTestListFile() {
+        return appendKuzuRootPath(std::string(E2E_TEST_FILES_DIRECTORY) + "/test_list");
+    }
 
     static std::string appendParquetDatasetTempDir(const std::string& dataset) {
         return TestHelper::appendKuzuRootPath(TestHelper::PARQUET_TEMP_DATASET_PATH + dataset);

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -1,3 +1,4 @@
+#include "common/string_utils.h"
 #include "graph_test/graph_test.h"
 #include "test_runner/csv_to_parquet_converter.h"
 #include "test_runner/test_parser.h"
@@ -20,6 +21,11 @@ public:
         initGraph();
     }
 
+    void TearDown() override {
+        FileUtils::removeDir(TestHelper::appendKuzuRootPath(TestHelper::PARQUET_TEMP_DATASET_PATH));
+        FileUtils::removeDir(TestHelper::getTmpTestDir());
+    }
+
     std::string getInputDir() override { return dataset + "/"; }
 
     void TestBody() override { runTest(testStatements); }
@@ -30,7 +36,7 @@ private:
     std::vector<std::unique_ptr<TestStatement>> testStatements;
 };
 
-void parseAndRegisterTestGroup(const std::string& path) {
+void parseAndRegisterTestGroup(const std::string& path, bool generateTestList = false) {
     auto testParser = std::make_unique<TestParser>(path);
     auto testGroup = std::move(testParser->parseTestFile());
     if (testGroup->isValid() && testGroup->hasStatements()) {
@@ -43,6 +49,10 @@ void parseAndRegisterTestGroup(const std::string& path) {
             dataset = TestHelper::appendKuzuRootPath("dataset/" + dataset);
         }
         for (auto& [testCaseName, testStatements] : testCases) {
+            if (generateTestList) {
+                std::ofstream testList(TestHelper::getTestListFile(), std::ios_base::app);
+                testList << testGroup->group + "." + testCaseName + " " + path + "\n";
+            }
             testing::RegisterTest(testGroup->group.c_str(), testCaseName.c_str(), nullptr, nullptr,
                 __FILE__, __LINE__,
                 [dataset, bufferPoolSize,
@@ -56,6 +66,11 @@ void parseAndRegisterTestGroup(const std::string& path) {
 }
 
 void scanTestFiles(const std::string& path) {
+    std::string testListFile = TestHelper::appendKuzuRootPath(
+        FileUtils::joinPath(TestHelper::E2E_TEST_FILES_DIRECTORY, "test_list"));
+    FileUtils::removeFileIfExists(testListFile);
+    FileUtils::createDirIfNotExists(
+        TestHelper::appendKuzuRootPath(TestHelper::PARQUET_TEMP_DATASET_PATH));
     if (std::filesystem::is_regular_file(path)) {
         parseAndRegisterTestGroup(path);
         return;
@@ -63,25 +78,52 @@ void scanTestFiles(const std::string& path) {
     for (const auto& entry : std::filesystem::recursive_directory_iterator(path)) {
         if (!entry.is_regular_file() || FileUtils::getFileExtension(entry) != ".test")
             continue;
-        parseAndRegisterTestGroup(entry.path().string());
+        parseAndRegisterTestGroup(entry.path().string(), true);
+    }
+}
+
+std::string findTestFile(std::string testCase) {
+    std::ifstream infile(TestHelper::getTestListFile());
+    std::string line;
+    while (std::getline(infile, line)) {
+        std::vector token = StringUtils::splitBySpace(line);
+        if (token[0] == testCase) {
+            return token[1];
+        }
+    }
+    return "";
+}
+
+void checkCtestParams(int argc, char** argv) {
+    if (argc > 1) {
+        std::string argument = argv[1];
+        bool runFromCTest = false;
+        if (argument == "--gtest_list_tests") {
+            scanTestFiles(TestHelper::appendKuzuRootPath(TestHelper::E2E_TEST_FILES_DIRECTORY));
+        }
+        if (argument.starts_with("--gtest_filter=")) {
+            FileUtils::createDirIfNotExists(
+                TestHelper::appendKuzuRootPath(TestHelper::PARQUET_TEMP_DATASET_PATH));
+            std::string testCaseFile = findTestFile(argument.substr(15));
+            if (testCaseFile.empty()) {
+                scanTestFiles(TestHelper::appendKuzuRootPath(TestHelper::E2E_TEST_FILES_DIRECTORY));
+            } else {
+                parseAndRegisterTestGroup(testCaseFile);
+            }
+        }
     }
 }
 
 int main(int argc, char** argv) {
+    checkCtestParams(argc, argv);
     testing::InitGoogleTest(&argc, argv);
-    std::string path = TestHelper::E2E_TEST_FILES_DIRECTORY;
     if (argc > 1) {
-        path = FileUtils::joinPath(path, argv[1]);
+        auto path = TestHelper::appendKuzuRootPath(
+            FileUtils::joinPath(TestHelper::E2E_TEST_FILES_DIRECTORY, argv[1]));
+        if (!FileUtils::fileOrPathExists(path)) {
+            throw TestException("Test path not exists [" + path + "].");
+        }
+        scanTestFiles(path);
     }
-    path = TestHelper::appendKuzuRootPath(path);
-    if (!FileUtils::fileOrPathExists(path)) {
-        throw TestException("Test path not exists [" + path + "].");
-    }
-    auto parquetDatasetTempDir =
-        TestHelper::appendKuzuRootPath(TestHelper::PARQUET_TEMP_DATASET_PATH);
-    FileUtils::createDirIfNotExists(parquetDatasetTempDir);
-    scanTestFiles(path);
-    auto result = RUN_ALL_TESTS();
-    FileUtils::removeDir(parquetDatasetTempDir);
-    return result;
+    return RUN_ALL_TESTS();
 }


### PR DESCRIPTION
This PR implements scanning and parsing the test files only once instead of every `e2e_test` run.

closes #1651 