### PR TITLE
Append FTableScan before RecursiveJoin

### DIFF
--- a/src/include/processor/operator/cross_product.h
+++ b/src/include/processor/operator/cross_product.h
@@ -5,39 +5,60 @@
 namespace kuzu {
 namespace processor {
 
+class CrossProduct;
+class CrossProductLocalState {
+    friend class CrossProduct;
+
+public:
+    CrossProductLocalState(std::shared_ptr<FactorizedTable> table, uint64_t maxMorselSize)
+        : table{std::move(table)}, maxMorselSize{maxMorselSize}, startIdx{0} {}
+
+    void init() { startIdx = table->getNumTuples(); }
+
+    inline std::unique_ptr<CrossProductLocalState> copy() const {
+        return std::make_unique<CrossProductLocalState>(table, maxMorselSize);
+    }
+
+private:
+    std::shared_ptr<FactorizedTable> table;
+    uint64_t maxMorselSize;
+    uint64_t startIdx = 0u;
+};
+
 class CrossProduct : public PhysicalOperator {
 public:
-    CrossProduct(std::shared_ptr<FTableSharedState> sharedState, std::vector<DataPos> outVecPos,
-        std::vector<uint32_t> colIndicesToScan, std::unique_ptr<PhysicalOperator> probeChild,
-        std::unique_ptr<PhysicalOperator> buildChild, uint32_t id, const std::string& paramsString)
+    CrossProduct(std::vector<DataPos> outVecPos, std::vector<uint32_t> colIndicesToScan,
+        std::unique_ptr<CrossProductLocalState> localState,
+        std::unique_ptr<PhysicalOperator> probeChild, std::unique_ptr<PhysicalOperator> buildChild,
+        uint32_t id, const std::string& paramsString)
         : PhysicalOperator{PhysicalOperatorType::CROSS_PRODUCT, std::move(probeChild),
               std::move(buildChild), id, paramsString},
-          sharedState{std::move(sharedState)}, outVecPos{std::move(outVecPos)},
-          colIndicesToScan{std::move(colIndicesToScan)} {}
+          outVecPos{std::move(outVecPos)}, colIndicesToScan{std::move(colIndicesToScan)},
+          localState{std::move(localState)} {}
 
     // Clone only.
-    CrossProduct(std::shared_ptr<FTableSharedState> sharedState, std::vector<DataPos> outVecPos,
-        std::vector<uint32_t> colIndicesToScan, std::unique_ptr<PhysicalOperator> child,
+    CrossProduct(std::vector<DataPos> outVecPos, std::vector<uint32_t> colIndicesToScan,
+        std::unique_ptr<CrossProductLocalState> localState, std::unique_ptr<PhysicalOperator> child,
         uint32_t id, const std::string& paramsString)
         : PhysicalOperator{PhysicalOperatorType::CROSS_PRODUCT, std::move(child), id, paramsString},
-          sharedState{std::move(sharedState)}, outVecPos{std::move(outVecPos)},
-          colIndicesToScan{std::move(colIndicesToScan)} {}
+          outVecPos{std::move(outVecPos)}, colIndicesToScan{std::move(colIndicesToScan)},
+          localState{std::move(localState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return std::make_unique<CrossProduct>(
-            sharedState, outVecPos, colIndicesToScan, children[0]->clone(), id, paramsString);
+        return std::make_unique<CrossProduct>(outVecPos, colIndicesToScan, localState->copy(),
+            children[0]->clone(), id, paramsString);
     }
 
 private:
-    std::shared_ptr<FTableSharedState> sharedState;
     std::vector<DataPos> outVecPos;
     std::vector<uint32_t> colIndicesToScan;
 
-    uint64_t startIdx = 0u;
+    std::unique_ptr<CrossProductLocalState> localState;
+
     std::vector<common::ValueVector*> vectorsToScan;
 };
 

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -7,7 +7,6 @@ namespace kuzu {
 namespace processor {
 
 struct FTableScanMorsel {
-
     FTableScanMorsel(FactorizedTable* table, uint64_t startTupleIdx, uint64_t numTuples)
         : table{table}, startTupleIdx{startTupleIdx}, numTuples{numTuples} {}
 
@@ -18,8 +17,18 @@ struct FTableScanMorsel {
 
 class FTableSharedState {
 public:
-    void initTable(
-        storage::MemoryManager* memoryManager, std::unique_ptr<FactorizedTableSchema> tableSchema);
+    FTableSharedState(std::shared_ptr<FactorizedTable> table, uint64_t maxMorselSize)
+        : table{std::move(table)}, maxMorselSize{maxMorselSize} {}
+    FTableSharedState(storage::MemoryManager* memoryManager,
+        std::unique_ptr<FactorizedTableSchema> tableSchema, uint64_t maxMorselSize)
+        : maxMorselSize{maxMorselSize}, nextTupleIdxToScan{0} {
+        table = std::make_shared<FactorizedTable>(memoryManager, std::move(tableSchema));
+    }
+
+    // We want to control the granularity of morsel, e.g. in recursive join pipeline, we always want
+    // to scan 1 src at a time.
+    inline void setMaxMorselSize(uint64_t size) { maxMorselSize = size; }
+    inline uint64_t getMaxMorselSize() const { return maxMorselSize; }
 
     inline void mergeLocalTable(FactorizedTable& localTable) {
         std::lock_guard<std::mutex> lck{mtx};
@@ -28,17 +37,12 @@ public:
 
     inline std::shared_ptr<FactorizedTable> getTable() { return table; }
 
-    inline void setTable(std::shared_ptr<FactorizedTable> other) { table = other; }
-
-    inline uint64_t getMaxMorselSize() {
-        std::lock_guard<std::mutex> lck{mtx};
-        return table->hasUnflatCol() ? 1 : common::DEFAULT_VECTOR_CAPACITY;
-    }
-    std::unique_ptr<FTableScanMorsel> getMorsel(uint64_t maxMorselSize);
+    std::unique_ptr<FTableScanMorsel> getMorsel();
 
 private:
     std::mutex mtx;
     std::shared_ptr<FactorizedTable> table;
+    uint64_t maxMorselSize;
 
     uint64_t nextTupleIdxToScan = 0u;
 };
@@ -46,37 +50,32 @@ private:
 class ResultCollector : public Sink {
 public:
     ResultCollector(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        std::vector<std::pair<DataPos, common::LogicalType>> payloadsPosAndType,
-        std::vector<bool> isPayloadFlat, std::shared_ptr<FTableSharedState> sharedState,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
+        std::unique_ptr<FactorizedTableSchema> tableSchema, std::vector<DataPos> payloadsPos,
+        std::shared_ptr<FTableSharedState> sharedState, std::unique_ptr<PhysicalOperator> child,
+        uint32_t id, const std::string& paramsString)
         : Sink{std::move(resultSetDescriptor), PhysicalOperatorType::RESULT_COLLECTOR,
               std::move(child), id, paramsString},
-          payloadsPosAndType{std::move(payloadsPosAndType)},
-          isPayloadFlat{std::move(isPayloadFlat)}, sharedState{std::move(sharedState)} {}
+          tableSchema{std::move(tableSchema)}, payloadsPos{std::move(payloadsPos)},
+          sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     void executeInternal(ExecutionContext* context) override;
-
-    std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ResultCollector>(resultSetDescriptor->copy(), payloadsPosAndType,
-            isPayloadFlat, sharedState, children[0]->clone(), id, paramsString);
-    }
 
     inline std::shared_ptr<FTableSharedState> getSharedState() { return sharedState; }
     inline std::shared_ptr<FactorizedTable> getResultFactorizedTable() {
         return sharedState->getTable();
     }
 
-private:
-    void initGlobalStateInternal(ExecutionContext* context) override;
+    std::unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<ResultCollector>(resultSetDescriptor->copy(), tableSchema->copy(),
+            payloadsPos, sharedState, children[0]->clone(), id, paramsString);
+    }
 
-    std::unique_ptr<FactorizedTableSchema> populateTableSchema();
-
 private:
-    std::vector<std::pair<DataPos, common::LogicalType>> payloadsPosAndType;
-    std::vector<bool> isPayloadFlat;
-    std::vector<common::ValueVector*> vectorsToCollect;
+    std::unique_ptr<FactorizedTableSchema> tableSchema;
+    std::vector<DataPos> payloadsPos;
+    std::vector<common::ValueVector*> payloadVectors;
     std::shared_ptr<FTableSharedState> sharedState;
     std::unique_ptr<FactorizedTable> localTable;
 };

--- a/src/include/processor/operator/table_scan/base_table_scan.h
+++ b/src/include/processor/operator/table_scan/base_table_scan.h
@@ -11,14 +11,14 @@ protected:
     BaseTableScan(PhysicalOperatorType operatorType, std::vector<DataPos> outVecPositions,
         std::vector<uint32_t> colIndicesToScan, std::unique_ptr<PhysicalOperator> child,
         uint32_t id, const std::string& paramsString)
-        : PhysicalOperator{operatorType, std::move(child), id, paramsString}, maxMorselSize{0},
+        : PhysicalOperator{operatorType, std::move(child), id, paramsString},
           outVecPositions{std::move(outVecPositions)}, colIndicesToScan{
                                                            std::move(colIndicesToScan)} {}
 
     // For factorized table scan of some columns
     BaseTableScan(PhysicalOperatorType operatorType, std::vector<DataPos> outVecPositions,
         std::vector<uint32_t> colIndicesToScan, uint32_t id, const std::string& paramsString)
-        : PhysicalOperator{operatorType, id, paramsString}, maxMorselSize{0},
+        : PhysicalOperator{operatorType, id, paramsString},
           outVecPositions{std::move(outVecPositions)}, colIndicesToScan{
                                                            std::move(colIndicesToScan)} {}
 
@@ -27,13 +27,12 @@ protected:
         std::vector<uint32_t> colIndicesToScan,
         std::vector<std::unique_ptr<PhysicalOperator>> children, uint32_t id,
         const std::string& paramsString)
-        : PhysicalOperator{operatorType, std::move(children), id, paramsString}, maxMorselSize{0},
+        : PhysicalOperator{operatorType, std::move(children), id, paramsString},
           outVecPositions{std::move(outVecPositions)}, colIndicesToScan{
                                                            std::move(colIndicesToScan)} {}
 
     inline bool isSource() const override { return true; }
 
-    virtual void setMaxMorselSize() = 0;
     virtual std::unique_ptr<FTableScanMorsel> getMorsel() = 0;
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
@@ -41,7 +40,6 @@ protected:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
 protected:
-    uint64_t maxMorselSize;
     std::vector<DataPos> outVecPositions;
     std::vector<uint32_t> colIndicesToScan;
 

--- a/src/include/processor/operator/table_scan/factorized_table_scan.h
+++ b/src/include/processor/operator/table_scan/factorized_table_scan.h
@@ -29,16 +29,11 @@ public:
               std::move(colIndicesToScan), id, paramsString},
           sharedState{std::move(sharedState)} {}
 
-    inline void setSharedState(std::shared_ptr<FTableSharedState> state) {
-        sharedState = std::move(state);
-    }
-    inline void setMaxMorselSize() override { maxMorselSize = sharedState->getMaxMorselSize(); }
     inline std::unique_ptr<FTableScanMorsel> getMorsel() override {
-        return sharedState->getMorsel(maxMorselSize);
+        return sharedState->getMorsel();
     }
 
     inline std::unique_ptr<PhysicalOperator> clone() override {
-        assert(sharedState != nullptr);
         return make_unique<FactorizedTableScan>(
             outVecPositions, colIndicesToScan, sharedState, id, paramsString);
     }

--- a/src/include/processor/operator/table_scan/union_all_scan.h
+++ b/src/include/processor/operator/table_scan/union_all_scan.h
@@ -12,8 +12,7 @@ public:
         std::vector<std::shared_ptr<FTableSharedState>> fTableSharedStates)
         : fTableSharedStates{std::move(fTableSharedStates)}, fTableToScanIdx{0} {}
 
-    uint64_t getMaxMorselSize() const;
-    std::unique_ptr<FTableScanMorsel> getMorsel(uint64_t maxMorselSize);
+    std::unique_ptr<FTableScanMorsel> getMorsel();
 
 private:
     std::mutex mtx;
@@ -39,9 +38,8 @@ public:
               std::move(colIndicesToScan), id, paramsString},
           sharedState{std::move(sharedState)} {}
 
-    inline void setMaxMorselSize() override { maxMorselSize = sharedState->getMaxMorselSize(); }
     inline std::unique_ptr<FTableScanMorsel> getMorsel() override {
-        return sharedState->getMorsel(maxMorselSize);
+        return sharedState->getMorsel();
     }
 
     std::unique_ptr<PhysicalOperator> clone() override {

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -155,6 +155,10 @@ public:
     bool operator==(const FactorizedTableSchema& other) const;
     inline bool operator!=(const FactorizedTableSchema& other) const { return !(*this == other); }
 
+    inline std::unique_ptr<FactorizedTableSchema> copy() const {
+        return std::make_unique<FactorizedTableSchema>(*this);
+    }
+
 private:
     std::vector<std::unique_ptr<ColumnSchema>> columns;
     uint32_t numBytesForDataPerTuple = 0;

--- a/src/processor/mapper/CMakeLists.txt
+++ b/src/processor/mapper/CMakeLists.txt
@@ -19,6 +19,7 @@ add_library(kuzu_processor_mapper
         map_multiplicity_reducer.cpp
         map_order_by.cpp
         map_projection.cpp
+        map_recursive_extend.cpp
         map_scan_frontier.cpp
         map_scan_node.cpp
         map_scan_node_property.cpp

--- a/src/processor/mapper/map_cross_product.cpp
+++ b/src/processor/mapper/map_cross_product.cpp
@@ -26,8 +26,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalCrossProductToPhysical(
         outVecPos.emplace_back(outSchema->getExpressionPos(*expression));
         colIndicesToScan.push_back(i);
     }
-    return make_unique<CrossProduct>(resultCollector->getSharedState(), std::move(outVecPos),
-        std::move(colIndicesToScan), std::move(probeSidePrevOperator), std::move(resultCollector),
+    auto sharedState = resultCollector->getSharedState();
+    auto localState = std::make_unique<CrossProductLocalState>(
+        sharedState->getTable(), sharedState->getMaxMorselSize());
+    return make_unique<CrossProduct>(std::move(outVecPos), std::move(colIndicesToScan),
+        std::move(localState), std::move(probeSidePrevOperator), std::move(resultCollector),
         getOperatorID(), logicalCrossProduct->getExpressionsForPrinting());
 }
 

--- a/src/processor/mapper/map_ddl.cpp
+++ b/src/processor/mapper/map_ddl.cpp
@@ -105,8 +105,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalCopyNodeToPhysical(Logic
         // The new pipeline only contains a factorizedTableScan and a resultCollector.
         auto outputExpression = copy->getOutputExpression();
         auto outputVectorPos = DataPos(outSchema->getExpressionPos(*outputExpression));
-        auto ftSharedState = std::make_shared<FTableSharedState>();
-        ftSharedState->setTable(copyNodeSharedState->table);
+        auto ftSharedState = std::make_shared<FTableSharedState>(
+            copyNodeSharedState->table, common::DEFAULT_VECTOR_CAPACITY);
         return std::make_unique<FactorizedTableScan>(std::vector<DataPos>{outputVectorPos},
             std::vector<uint32_t>{0} /* colIndicesToScan */, ftSharedState, std::move(copyNode),
             getOperatorID(), copy->getExpressionsForPrinting());

--- a/src/processor/mapper/map_expressions_scan.cpp
+++ b/src/processor/mapper/map_expressions_scan.cpp
@@ -15,8 +15,6 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExpressionsScanToPhysica
     auto outSchema = logicalExpressionsScan.getSchema();
     auto inSchema = std::make_unique<Schema>();
     auto expressions = logicalExpressionsScan.getExpressions();
-    auto sharedState = std::make_shared<FTableSharedState>();
-    // populate static table
     auto tableSchema = std::make_unique<FactorizedTableSchema>();
     // TODO(Ziyi): remove vectors when we have done the refactor of dataChunk.
     std::vector<std::shared_ptr<ValueVector>> vectors;
@@ -32,7 +30,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExpressionsScanToPhysica
         vectors.push_back(expressionEvaluator->resultVector);
         vectorsToAppend.push_back(expressionEvaluator->resultVector.get());
     }
-    sharedState->initTable(memoryManager, std::move(tableSchema));
+    auto sharedState = std::make_shared<FTableSharedState>(
+        memoryManager, tableSchema->copy(), common::DEFAULT_VECTOR_CAPACITY);
     auto table = sharedState->getTable();
     table->append(vectorsToAppend);
     // map factorized table scan

--- a/src/processor/mapper/map_extend.cpp
+++ b/src/processor/mapper/map_extend.cpp
@@ -1,7 +1,5 @@
 #include "planner/logical_plan/logical_operator/logical_extend.h"
-#include "planner/logical_plan/logical_operator/logical_recursive_extend.h"
 #include "processor/mapper/plan_mapper.h"
-#include "processor/operator/recursive_extend/recursive_join.h"
 #include "processor/operator/scan/generic_scan_rel_tables.h"
 #include "processor/operator/scan/scan_rel_table_columns.h"
 #include "processor/operator/scan/scan_rel_table_lists.h"
@@ -149,72 +147,6 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalExtendToPhysical(
             std::move(relTableCollectionPerNodeTable), std::move(prevOperator), getOperatorID(),
             extend->getExpressionsForPrinting());
     }
-}
-
-std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalRecursiveExtendToPhysical(
-    planner::LogicalOperator* logicalOperator) {
-    auto extend = (LogicalRecursiveExtend*)logicalOperator;
-    auto boundNode = extend->getBoundNode();
-    auto nbrNode = extend->getNbrNode();
-    auto rel = extend->getRel();
-    auto recursiveNode = rel->getRecursiveNode();
-    auto lengthExpression = rel->getLengthExpression();
-    // map recursive plan
-    auto logicalRecursiveRoot = extend->getRecursivePlanRoot();
-    auto recursiveRoot = mapLogicalOperatorToPhysical(logicalRecursiveRoot);
-    auto recursivePlanSchema = logicalRecursiveRoot->getSchema();
-    auto recursivePlanResultSetDescriptor =
-        std::make_unique<ResultSetDescriptor>(recursivePlanSchema);
-    auto recursiveDstNodeIDPos =
-        DataPos(recursivePlanSchema->getExpressionPos(*recursiveNode->getInternalIDProperty()));
-    auto recursiveEdgeIDPos =
-        DataPos(recursivePlanSchema->getExpressionPos(*rel->getInternalIDProperty()));
-    // map child plan
-    auto outSchema = extend->getSchema();
-    auto inSchema = extend->getChild(0)->getSchema();
-    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
-    auto boundNodeIDVectorPos =
-        DataPos(inSchema->getExpressionPos(*boundNode->getInternalIDProperty()));
-    auto nbrNodeIDVectorPos =
-        DataPos(outSchema->getExpressionPos(*nbrNode->getInternalIDProperty()));
-    auto lengthVectorPos = DataPos(outSchema->getExpressionPos(*lengthExpression));
-    auto expressions = inSchema->getExpressionsInScope();
-    auto resultCollector = appendResultCollector(expressions, inSchema, std::move(prevOperator));
-    auto sharedInputFTable = resultCollector->getSharedState();
-    std::vector<DataPos> outDataPoses;
-    std::vector<uint32_t> colIndicesToScan;
-    for (auto i = 0u; i < expressions.size(); ++i) {
-        outDataPoses.emplace_back(outSchema->getExpressionPos(*expressions[i]));
-        colIndicesToScan.push_back(i);
-    }
-    // Generate RecursiveJoinDataInfo
-    std::unique_ptr<RecursiveJoinDataInfo> dataInfo;
-    switch (extend->getJoinType()) {
-    case planner::RecursiveJoinType::TRACK_PATH: {
-        auto pathVectorPos = DataPos(outSchema->getExpressionPos(*rel));
-        dataInfo = std::make_unique<RecursiveJoinDataInfo>(outDataPoses, colIndicesToScan,
-            boundNodeIDVectorPos, nbrNodeIDVectorPos, nbrNode->getTableIDsSet(), lengthVectorPos,
-            std::move(recursivePlanResultSetDescriptor), recursiveDstNodeIDPos,
-            recursiveNode->getTableIDsSet(), recursiveEdgeIDPos, pathVectorPos);
-    } break;
-    case planner::RecursiveJoinType::TRACK_NONE: {
-        dataInfo = std::make_unique<RecursiveJoinDataInfo>(outDataPoses, colIndicesToScan,
-            boundNodeIDVectorPos, nbrNodeIDVectorPos, nbrNode->getTableIDsSet(), lengthVectorPos,
-            std::move(recursivePlanResultSetDescriptor), recursiveDstNodeIDPos,
-            recursiveNode->getTableIDsSet(), recursiveEdgeIDPos);
-    } break;
-    default:
-        throw common::NotImplementedException("PlanMapper::mapLogicalRecursiveExtendToPhysical");
-    }
-    std::vector<storage::NodeTable*> nodeTables;
-    for (auto tableID : nbrNode->getTableIDs()) {
-        nodeTables.push_back(storageManager.getNodesStore().getNodeTable(tableID));
-    }
-    auto sharedState = std::make_shared<RecursiveJoinSharedState>(sharedInputFTable, nodeTables);
-    return std::make_unique<RecursiveJoin>(rel->getLowerBound(), rel->getUpperBound(),
-        rel->getRelType(), extend->getJoinType(), sharedState, std::move(dataInfo),
-        std::move(resultCollector), getOperatorID(), extend->getExpressionsForPrinting(),
-        std::move(recursiveRoot));
 }
 
 } // namespace processor

--- a/src/processor/mapper/map_recursive_extend.cpp
+++ b/src/processor/mapper/map_recursive_extend.cpp
@@ -1,0 +1,81 @@
+#include "planner/logical_plan/logical_operator/logical_recursive_extend.h"
+#include "processor/mapper/plan_mapper.h"
+#include "processor/operator/recursive_extend/recursive_join.h"
+#include "processor/operator/table_scan/factorized_table_scan.h"
+
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace processor {
+
+std::unique_ptr<PhysicalOperator> PlanMapper::mapLogicalRecursiveExtendToPhysical(
+    planner::LogicalOperator* logicalOperator) {
+    auto extend = (LogicalRecursiveExtend*)logicalOperator;
+    auto boundNode = extend->getBoundNode();
+    auto nbrNode = extend->getNbrNode();
+    auto rel = extend->getRel();
+    auto recursiveNode = rel->getRecursiveNode();
+    auto lengthExpression = rel->getLengthExpression();
+    // map recursive plan
+    auto logicalRecursiveRoot = extend->getRecursivePlanRoot();
+    auto recursiveRoot = mapLogicalOperatorToPhysical(logicalRecursiveRoot);
+    auto recursivePlanSchema = logicalRecursiveRoot->getSchema();
+    auto recursivePlanResultSetDescriptor =
+        std::make_unique<ResultSetDescriptor>(recursivePlanSchema);
+    auto recursiveDstNodeIDPos =
+        DataPos(recursivePlanSchema->getExpressionPos(*recursiveNode->getInternalIDProperty()));
+    auto recursiveEdgeIDPos =
+        DataPos(recursivePlanSchema->getExpressionPos(*rel->getInternalIDProperty()));
+    // map child plan
+    auto outSchema = extend->getSchema();
+    auto inSchema = extend->getChild(0)->getSchema();
+    auto prevOperator = mapLogicalOperatorToPhysical(logicalOperator->getChild(0));
+    auto expressions = inSchema->getExpressionsInScope();
+    auto resultCollector = appendResultCollector(expressions, inSchema, std::move(prevOperator));
+    auto sharedFTable = resultCollector->getSharedState();
+    sharedFTable->setMaxMorselSize(1);
+    std::vector<DataPos> outDataPoses;
+    std::vector<uint32_t> colIndicesToScan;
+    for (auto i = 0u; i < expressions.size(); ++i) {
+        outDataPoses.emplace_back(outSchema->getExpressionPos(*expressions[i]));
+        colIndicesToScan.push_back(i);
+    }
+    auto fTableScan = make_unique<FactorizedTableScan>(std::move(outDataPoses),
+        std::move(colIndicesToScan), sharedFTable, std::move(resultCollector), getOperatorID(), "");
+    // Generate RecursiveJoinDataInfo
+    auto boundNodeIDVectorPos =
+        DataPos(inSchema->getExpressionPos(*boundNode->getInternalIDProperty()));
+    auto nbrNodeIDVectorPos =
+        DataPos(outSchema->getExpressionPos(*nbrNode->getInternalIDProperty()));
+    auto lengthVectorPos = DataPos(outSchema->getExpressionPos(*lengthExpression));
+    std::unique_ptr<RecursiveJoinDataInfo> dataInfo;
+    switch (extend->getJoinType()) {
+    case planner::RecursiveJoinType::TRACK_PATH: {
+        auto pathVectorPos = DataPos(outSchema->getExpressionPos(*rel));
+        dataInfo = std::make_unique<RecursiveJoinDataInfo>(boundNodeIDVectorPos, nbrNodeIDVectorPos,
+            nbrNode->getTableIDsSet(), lengthVectorPos, std::move(recursivePlanResultSetDescriptor),
+            recursiveDstNodeIDPos, recursiveNode->getTableIDsSet(), recursiveEdgeIDPos,
+            pathVectorPos);
+    } break;
+    case planner::RecursiveJoinType::TRACK_NONE: {
+        dataInfo = std::make_unique<RecursiveJoinDataInfo>(boundNodeIDVectorPos, nbrNodeIDVectorPos,
+            nbrNode->getTableIDsSet(), lengthVectorPos, std::move(recursivePlanResultSetDescriptor),
+            recursiveDstNodeIDPos, recursiveNode->getTableIDsSet(), recursiveEdgeIDPos);
+    } break;
+    default:
+        throw common::NotImplementedException("PlanMapper::mapLogicalRecursiveExtendToPhysical");
+    }
+    std::vector<std::unique_ptr<NodeOffsetSemiMask>> semiMasks;
+    for (auto tableID : nbrNode->getTableIDs()) {
+        auto nodeTable = storageManager.getNodesStore().getNodeTable(tableID);
+        semiMasks.push_back(std::make_unique<NodeOffsetSemiMask>(nodeTable));
+    }
+    auto sharedState = std::make_shared<RecursiveJoinSharedState>(std::move(semiMasks));
+    return std::make_unique<RecursiveJoin>(rel->getLowerBound(), rel->getUpperBound(),
+        rel->getRelType(), extend->getJoinType(), sharedState, std::move(dataInfo),
+        std::move(fTableScan), getOperatorID(), extend->getExpressionsForPrinting(),
+        std::move(recursiveRoot));
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/operator/cross_product.cpp
+++ b/src/processor/operator/cross_product.cpp
@@ -4,31 +4,30 @@ namespace kuzu {
 namespace processor {
 
 void CrossProduct::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    for (auto pos : outVecPos) {
-        auto vector = resultSet->getValueVector(pos);
-        vectorsToScan.push_back(vector.get());
+    for (auto& pos : outVecPos) {
+        vectorsToScan.push_back(resultSet->getValueVector(pos).get());
     }
-    startIdx = sharedState->getTable()->getNumTuples();
+    localState->init();
 }
 
 bool CrossProduct::getNextTuplesInternal(ExecutionContext* context) {
     // Note: we should NOT morselize right table scanning (i.e. calling sharedState.getMorsel)
     // because every thread should scan its own table.
-    auto table = sharedState->getTable();
+    auto table = localState->table.get();
     if (table->getNumTuples() == 0) {
         return false;
     }
-    if (startIdx == table->getNumTuples()) {       // no more to scan from right
-        if (!children[0]->getNextTuple(context)) { // fetch a new left tuple
+    if (localState->startIdx == table->getNumTuples()) { // no more to scan from right
+        if (!children[0]->getNextTuple(context)) {       // fetch a new left tuple
             return false;
         }
-        startIdx = 0; // reset right table scanning for a new left tuple
+        localState->startIdx = 0; // reset right table scanning for a new left tuple
     }
     // scan from right table if there is tuple left
-    auto maxNumTuplesToScan = table->hasUnflatCol() ? 1 : common::DEFAULT_VECTOR_CAPACITY;
-    auto numTuplesToScan = std::min(maxNumTuplesToScan, table->getNumTuples() - startIdx);
-    table->scan(vectorsToScan, startIdx, numTuplesToScan, colIndicesToScan);
-    startIdx += numTuplesToScan;
+    auto numTuplesToScan =
+        std::min(localState->maxMorselSize, table->getNumTuples() - localState->startIdx);
+    table->scan(vectorsToScan, localState->startIdx, numTuplesToScan, colIndicesToScan);
+    localState->startIdx += numTuplesToScan;
     metrics->numOutputTuple.increase(numTuplesToScan);
     return true;
 }

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -6,14 +6,7 @@ using namespace kuzu::storage;
 namespace kuzu {
 namespace processor {
 
-void FTableSharedState::initTable(
-    MemoryManager* memoryManager, std::unique_ptr<FactorizedTableSchema> tableSchema) {
-    assert(table == nullptr);
-    nextTupleIdxToScan = 0u;
-    table = std::make_unique<FactorizedTable>(memoryManager, std::move(tableSchema));
-}
-
-std::unique_ptr<FTableScanMorsel> FTableSharedState::getMorsel(uint64_t maxMorselSize) {
+std::unique_ptr<FTableScanMorsel> FTableSharedState::getMorsel() {
     std::lock_guard<std::mutex> lck{mtx};
     auto numTuplesToScan = std::min(maxMorselSize, table->getNumTuples() - nextTupleIdxToScan);
     auto morsel =
@@ -23,41 +16,24 @@ std::unique_ptr<FTableScanMorsel> FTableSharedState::getMorsel(uint64_t maxMorse
 }
 
 void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    for (auto [dataPos, _] : payloadsPosAndType) {
-        auto vector =
-            resultSet->dataChunks[dataPos.dataChunkPos]->valueVectors[dataPos.valueVectorPos];
-        vectorsToCollect.push_back(vector.get());
+    payloadVectors.reserve(payloadsPos.size());
+    for (auto& pos : payloadsPos) {
+        payloadVectors.push_back(resultSet->getValueVector(pos).get());
     }
-    localTable = std::make_unique<FactorizedTable>(context->memoryManager, populateTableSchema());
+    localTable = std::make_unique<FactorizedTable>(context->memoryManager, tableSchema->copy());
 }
 
 void ResultCollector::executeInternal(ExecutionContext* context) {
     while (children[0]->getNextTuple(context)) {
-        if (!vectorsToCollect.empty()) {
+        if (!payloadVectors.empty()) {
             for (auto i = 0u; i < resultSet->multiplicity; i++) {
-                localTable->append(vectorsToCollect);
+                localTable->append(payloadVectors);
             }
         }
     }
-    if (!vectorsToCollect.empty()) {
+    if (!payloadVectors.empty()) {
         sharedState->mergeLocalTable(*localTable);
     }
-}
-
-void ResultCollector::initGlobalStateInternal(ExecutionContext* context) {
-    sharedState->initTable(context->memoryManager, populateTableSchema());
-}
-
-std::unique_ptr<FactorizedTableSchema> ResultCollector::populateTableSchema() {
-    std::unique_ptr<FactorizedTableSchema> tableSchema = std::make_unique<FactorizedTableSchema>();
-    for (auto i = 0u; i < payloadsPosAndType.size(); ++i) {
-        auto [dataPos, dataType] = payloadsPosAndType[i];
-        tableSchema->appendColumn(
-            std::make_unique<ColumnSchema>(!isPayloadFlat[i], dataPos.dataChunkPos,
-                isPayloadFlat[i] ? FactorizedTable::getDataTypeSize(dataType) :
-                                   (uint32_t)sizeof(overflow_value_t)));
-    }
-    return tableSchema;
 }
 
 } // namespace processor

--- a/src/processor/operator/table_scan/base_table_scan.cpp
+++ b/src/processor/operator/table_scan/base_table_scan.cpp
@@ -7,7 +7,6 @@ void BaseTableScan::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
     for (auto& dataPos : outVecPositions) {
         vectorsToScan.push_back(resultSet->getValueVector(dataPos).get());
     }
-    setMaxMorselSize();
 }
 
 bool BaseTableScan::getNextTuplesInternal(ExecutionContext* context) {

--- a/src/processor/operator/table_scan/union_all_scan.cpp
+++ b/src/processor/operator/table_scan/union_all_scan.cpp
@@ -5,25 +5,19 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-uint64_t UnionAllScanSharedState::getMaxMorselSize() const {
-    assert(!fTableSharedStates.empty());
-    auto table = fTableSharedStates[0]->getTable();
-    return table->hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
-}
-
-std::unique_ptr<FTableScanMorsel> UnionAllScanSharedState::getMorsel(uint64_t maxMorselSize) {
+std::unique_ptr<FTableScanMorsel> UnionAllScanSharedState::getMorsel() {
     std::lock_guard<std::mutex> lck{mtx};
     if (fTableToScanIdx == fTableSharedStates.size()) { // No more to scan.
         return std::make_unique<FTableScanMorsel>(nullptr, 0, 0);
     }
-    auto morsel = fTableSharedStates[fTableToScanIdx]->getMorsel(maxMorselSize);
+    auto morsel = fTableSharedStates[fTableToScanIdx]->getMorsel();
     // Fetch next table if current table has nothing to scan.
     while (morsel->numTuples == 0) {
         fTableToScanIdx++;
         if (fTableToScanIdx == fTableSharedStates.size()) { // No more to scan.
             return std::make_unique<FTableScanMorsel>(nullptr, 0, 0);
         }
-        morsel = fTableSharedStates[fTableToScanIdx]->getMorsel(maxMorselSize);
+        morsel = fTableSharedStates[fTableToScanIdx]->getMorsel();
     }
     return morsel;
 }

--- a/test/test_files/tinysnb/var_length_extend/n_1.test
+++ b/test/test_files/tinysnb/var_length_extend/n_1.test
@@ -11,7 +11,7 @@
 
 --
 
--CASE VarLengthExtendTests
+-CASE VarLengthExtendN1Tests
 
 -NAME meetsOneToTwoHopTest
 -QUERY MATCH (a:person)-[:meets*1..2]->(b:person) RETURN COUNT(*)

--- a/test/test_files/tinysnb/var_length_extend/n_n.test
+++ b/test/test_files/tinysnb/var_length_extend/n_n.test
@@ -12,10 +12,11 @@
 
 --
 
--CASE VarLengthExtendTests
+-CASE VarLengthExtendNNTests
 
 -NAME KnowsThreeHopMinLenEqualsMaxLen
 -QUERY MATCH (a:person)-[e:knows*3..3]->(b:person) RETURN COUNT(*)
+-PARALLELISM 1
 ---- 1
 108
 


### PR DESCRIPTION
This PR adds a FTableScan before RecursiveJoin. Previously the same logic is written in RecrusiveJoin.

This Pr also solves issue #1347 