### PR TITLE
Implement map functions

### DIFF
--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -87,7 +87,7 @@ std::string TypeUtils::toString(const struct_entry_t& val, void* valVector) {
     auto fields = StructType::getFields(&structVector->dataType);
     for (auto i = 0u; i < fields.size(); ++i) {
         auto field = fields[i];
-        auto fieldVector = StructVector::getChildVector(structVector, i);
+        auto fieldVector = StructVector::getFieldVector(structVector, i);
         auto value = fieldVector->getData() + fieldVector->getNumBytesPerValue() * val.pos;
         result += castValueToString(*field->getType(), value, fieldVector.get());
         result += (fields.size() - 1 == i ? "}" : ",");
@@ -109,104 +109,203 @@ bool TypeUtils::isValueEqual(
     if (leftVector->dataType != rightVector->dataType || leftEntry.size != rightEntry.size) {
         return false;
     }
-    auto leftValues = ListVector::getListValues(leftVector, leftEntry);
-    auto rightValues = ListVector::getListValues(rightVector, rightEntry);
-    switch (VarListType::getChildType(&leftVector->dataType)->getLogicalTypeID()) {
-    case LogicalTypeID::BOOL: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<uint8_t*>(leftValues)[i],
-                    reinterpret_cast<uint8_t*>(rightValues)[i], left, right)) {
+    auto leftDataVector = ListVector::getDataVector(leftVector);
+    auto rightDataVector = ListVector::getDataVector(rightVector);
+    for (auto i = 0u; i < leftEntry.size; i++) {
+        auto leftPos = leftEntry.offset + i;
+        auto rightPos = rightEntry.offset + i;
+        if (leftDataVector->isNull(leftPos) && rightDataVector->isNull(rightPos)) {
+            continue;
+        } else if (leftDataVector->isNull(leftPos) != rightDataVector->isNull(rightPos)) {
+            return false;
+        }
+        switch (leftDataVector->dataType.getPhysicalType()) {
+        case PhysicalTypeID::BOOL: {
+            if (!isValueEqual(leftDataVector->getValue<uint8_t>(leftPos),
+                    rightDataVector->getValue<uint8_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::INT64: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<int64_t*>(leftValues)[i],
-                    reinterpret_cast<int64_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::INT64: {
+            if (!isValueEqual(leftDataVector->getValue<int64_t>(leftPos),
+                    rightDataVector->getValue<int64_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::INT32: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<int32_t*>(leftValues)[i],
-                    reinterpret_cast<int32_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::INT32: {
+            if (!isValueEqual(leftDataVector->getValue<int32_t>(leftPos),
+                    rightDataVector->getValue<int32_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::INT16: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<int16_t*>(leftValues)[i],
-                    reinterpret_cast<int16_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::INT16: {
+            if (!isValueEqual(leftDataVector->getValue<int16_t>(leftPos),
+                    rightDataVector->getValue<int16_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::DOUBLE: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<double_t*>(leftValues)[i],
-                    reinterpret_cast<double_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::DOUBLE: {
+            if (!isValueEqual(leftDataVector->getValue<double_t>(leftPos),
+                    rightDataVector->getValue<double_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::FLOAT: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<float*>(leftValues)[i],
-                    reinterpret_cast<float*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::FLOAT: {
+            if (!isValueEqual(leftDataVector->getValue<float_t>(leftPos),
+                    rightDataVector->getValue<float_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::STRING: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<ku_string_t*>(leftValues)[i],
-                    reinterpret_cast<ku_string_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::STRING: {
+            if (!isValueEqual(leftDataVector->getValue<ku_string_t>(leftPos),
+                    rightDataVector->getValue<ku_string_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::DATE: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<date_t*>(leftValues)[i],
-                    reinterpret_cast<date_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::INTERVAL: {
+            if (!isValueEqual(leftDataVector->getValue<interval_t>(leftPos),
+                    rightDataVector->getValue<interval_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::TIMESTAMP: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<timestamp_t*>(leftValues)[i],
-                    reinterpret_cast<timestamp_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::INTERNAL_ID: {
+            if (!isValueEqual(leftDataVector->getValue<internalID_t>(leftPos),
+                    rightDataVector->getValue<internalID_t>(rightPos), nullptr /* left */,
+                    nullptr /* right */)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::INTERVAL: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<interval_t*>(leftValues)[i],
-                    reinterpret_cast<interval_t*>(rightValues)[i], left, right)) {
+        } break;
+        case PhysicalTypeID::VAR_LIST: {
+            if (!isValueEqual(leftDataVector->getValue<list_entry_t>(leftPos),
+                    rightDataVector->getValue<list_entry_t>(rightPos), leftDataVector,
+                    rightDataVector)) {
                 return false;
             }
-        }
-    } break;
-    case LogicalTypeID::VAR_LIST: {
-        for (auto i = 0u; i < leftEntry.size; i++) {
-            if (!isValueEqual(reinterpret_cast<list_entry_t*>(leftValues)[i],
-                    reinterpret_cast<list_entry_t*>(rightValues)[i],
-                    ListVector::getDataVector(leftVector),
-                    ListVector::getDataVector(rightVector))) {
+        } break;
+        case PhysicalTypeID::STRUCT: {
+            if (!isValueEqual(leftDataVector->getValue<struct_entry_t>(leftPos),
+                    rightDataVector->getValue<struct_entry_t>(rightPos), leftDataVector,
+                    rightDataVector)) {
                 return false;
             }
+        } break;
+        default: {
+            throw NotImplementedException("TypeUtils::isValueEqual");
         }
-    } break;
-    default: {
-        throw RuntimeException("Unsupported data type " +
-                               LogicalTypeUtils::dataTypeToString(leftVector->dataType) +
-                               " for TypeUtils::isValueEqual.");
+        }
     }
+    return true;
+}
+
+template<>
+bool TypeUtils::isValueEqual(common::struct_entry_t& leftEntry, common::struct_entry_t& rightEntry,
+    void* left, void* right) {
+    auto leftVector = (ValueVector*)left;
+    auto rightVector = (ValueVector*)right;
+    if (leftVector->dataType != rightVector->dataType) {
+        return false;
+    }
+    auto leftStructFields = common::StructVector::getFieldVectors(leftVector);
+    auto rightStructFields = common::StructVector::getFieldVectors(rightVector);
+    for (auto i = 0u; i < leftStructFields.size(); i++) {
+        auto leftStructField = leftStructFields[i];
+        auto rightStructField = rightStructFields[i];
+        if (leftStructField->isNull(leftEntry.pos) && rightStructField->isNull(rightEntry.pos)) {
+            continue;
+        } else if (leftStructField->isNull(leftEntry.pos) !=
+                   rightStructField->isNull(rightEntry.pos)) {
+            return false;
+        }
+        switch (leftStructFields[i]->dataType.getPhysicalType()) {
+        case PhysicalTypeID::BOOL: {
+            if (!isValueEqual(leftStructField->getValue<uint8_t>(leftEntry.pos),
+                    rightStructField->getValue<uint8_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::INT64: {
+            if (!isValueEqual(leftStructField->getValue<int64_t>(leftEntry.pos),
+                    rightStructField->getValue<int64_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::INT32: {
+            if (!isValueEqual(leftStructField->getValue<int32_t>(leftEntry.pos),
+                    rightStructField->getValue<int32_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::INT16: {
+            if (!isValueEqual(leftStructField->getValue<int16_t>(leftEntry.pos),
+                    rightStructField->getValue<int16_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::DOUBLE: {
+            if (!isValueEqual(leftStructField->getValue<double_t>(leftEntry.pos),
+                    rightStructField->getValue<double_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::FLOAT: {
+            if (!isValueEqual(leftStructField->getValue<float_t>(leftEntry.pos),
+                    rightStructField->getValue<float_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::STRING: {
+            if (!isValueEqual(leftStructField->getValue<ku_string_t>(leftEntry.pos),
+                    rightStructField->getValue<ku_string_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::INTERVAL: {
+            if (!isValueEqual(leftStructField->getValue<interval_t>(leftEntry.pos),
+                    rightStructField->getValue<interval_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::INTERNAL_ID: {
+            if (!isValueEqual(leftStructField->getValue<internalID_t>(leftEntry.pos),
+                    rightStructField->getValue<internalID_t>(rightEntry.pos), nullptr /* left */,
+                    nullptr /* right */)) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::VAR_LIST: {
+            if (!isValueEqual(leftStructField->getValue<list_entry_t>(leftEntry.pos),
+                    rightStructField->getValue<list_entry_t>(rightEntry.pos), leftStructField.get(),
+                    rightStructField.get())) {
+                return false;
+            }
+        } break;
+        case PhysicalTypeID::STRUCT: {
+            if (!isValueEqual(leftStructField->getValue<struct_entry_t>(leftEntry.pos),
+                    rightStructField->getValue<struct_entry_t>(rightEntry.pos),
+                    leftStructField.get(), rightStructField.get())) {
+                return false;
+            }
+        } break;
+        default: {
+            throw NotImplementedException("TypeUtils::isValueEqual");
+        }
+        }
     }
     return true;
 }

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -64,7 +64,7 @@ StructField::StructField(std::string name, std::unique_ptr<LogicalType> type)
 }
 
 bool StructField::operator==(const kuzu::common::StructField& other) const {
-    return name == other.name && *type == *other.type;
+    return *type == *other.type;
 }
 
 std::unique_ptr<StructField> StructField::copy() const {

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -74,11 +74,11 @@ void ValueVector::resetAuxiliaryBuffer() {
 uint32_t ValueVector::getDataTypeSize(const LogicalType& type) {
     switch (type.getPhysicalType()) {
     case PhysicalTypeID::STRING: {
-        return sizeof(common::ku_string_t);
+        return sizeof(ku_string_t);
     }
     case PhysicalTypeID::FIXED_LIST: {
-        return getDataTypeSize(*common::FixedListType::getChildType(&type)) *
-               common::FixedListType::getNumElementsInList(&type);
+        return getDataTypeSize(*FixedListType::getChildType(&type)) *
+               FixedListType::getNumElementsInList(&type);
     }
     case PhysicalTypeID::STRUCT: {
         return sizeof(struct_entry_t);
@@ -104,8 +104,7 @@ void ValueVector::initializeValueBuffer() {
     }
 }
 
-void ArrowColumnVector::setArrowColumn(
-    kuzu::common::ValueVector* vector, std::shared_ptr<arrow::Array> column) {
+void ArrowColumnVector::setArrowColumn(ValueVector* vector, std::shared_ptr<arrow::Array> column) {
     auto arrowColumnBuffer =
         reinterpret_cast<ArrowColumnAuxiliaryBuffer*>(vector->auxiliaryBuffer.get());
     arrowColumnBuffer->column = std::move(column);

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -64,7 +64,7 @@ void FunctionExpressionEvaluator::resolveResultVector(
     if (functionExpression.getFunctionName() == STRUCT_EXTRACT_FUNC_NAME) {
         auto& bindData = (function::StructExtractBindData&)*functionExpression.getBindData();
         resultVector =
-            StructVector::getChildVector(children[0]->resultVector.get(), bindData.childIdx);
+            StructVector::getFieldVector(children[0]->resultVector.get(), bindData.childIdx);
     } else {
         resultVector = std::make_shared<ValueVector>(expression->dataType, memoryManager);
     }

--- a/src/function/built_in_vector_operations.cpp
+++ b/src/function/built_in_vector_operations.cpp
@@ -487,7 +487,13 @@ void BuiltInVectorOperations::registerStructOperations() {
 }
 
 void BuiltInVectorOperations::registerMapOperations() {
-    vectorOperations.insert({MAP_CREATION_FUNC_NAME, MapVectorOperations::getDefinitions()});
+    vectorOperations.insert(
+        {MAP_CREATION_FUNC_NAME, MapCreationVectorOperations::getDefinitions()});
+    vectorOperations.insert({MAP_EXTRACT_FUNC_NAME, MapExtractVectorOperations::getDefinitions()});
+    vectorOperations.insert({ELEMENT_AT_FUNC_NAME, MapExtractVectorOperations::getDefinitions()});
+    vectorOperations.insert({CARDINALITY_FUNC_NAME, ListLenVectorOperation::getDefinitions()});
+    vectorOperations.insert({MAP_KEYS_FUNC_NAME, MapKeysVectorOperations::getDefinitions()});
+    vectorOperations.insert({MAP_VALUES_FUNC_NAME, MapValuesVectorOperations::getDefinitions()});
 }
 
 } // namespace function

--- a/src/function/vector_map_operation.cpp
+++ b/src/function/vector_map_operation.cpp
@@ -1,22 +1,25 @@
 #include "function/list/vector_list_operations.h"
-#include "function/map/operations/map_operation.h"
+#include "function/map/operations/map_creation_operation.h"
+#include "function/map/operations/map_extract_operation.h"
+#include "function/map/operations/map_keys_operation.h"
+#include "function/map/operations/map_values_operation.h"
 #include "function/map/vector_map_operations.h"
 
 namespace kuzu {
 namespace function {
 
-vector_operation_definitions MapVectorOperations::getDefinitions() {
+vector_operation_definitions MapCreationVectorOperations::getDefinitions() {
+    auto execFunc = VectorListOperations::BinaryListExecFunction<common::list_entry_t,
+        common::list_entry_t, common::list_entry_t, operation::MapCreation>;
     vector_operation_definitions definitions;
-    auto excFunct = VectorListOperations::BinaryListExecFunction<common::list_entry_t,
-        common::list_entry_t, common::list_entry_t, operation::Map>;
     definitions.push_back(make_unique<VectorOperationDefinition>(common::MAP_CREATION_FUNC_NAME,
         std::vector<common::LogicalTypeID>{
             common::LogicalTypeID::VAR_LIST, common::LogicalTypeID::VAR_LIST},
-        common::LogicalTypeID::MAP, excFunct, nullptr, bindFunc, false /* isVarLength */));
+        common::LogicalTypeID::MAP, execFunc, nullptr, bindFunc, false /* isVarLength */));
     return definitions;
 }
 
-std::unique_ptr<FunctionBindData> MapVectorOperations::bindFunc(
+std::unique_ptr<FunctionBindData> MapCreationVectorOperations::bindFunc(
     const binder::expression_vector& arguments, kuzu::function::FunctionDefinition* definition) {
     auto keyType = common::VarListType::getChildType(&arguments[0]->dataType);
     auto valueType = common::VarListType::getChildType(&arguments[1]->dataType);
@@ -30,6 +33,74 @@ std::unique_ptr<FunctionBindData> MapVectorOperations::bindFunc(
     auto resultType = common::LogicalType(common::LogicalTypeID::MAP,
         std::make_unique<common::VarListTypeInfo>(std::move(mapStructType)));
     return std::make_unique<FunctionBindData>(resultType);
+}
+
+vector_operation_definitions MapExtractVectorOperations::getDefinitions() {
+    vector_operation_definitions definitions;
+    definitions.push_back(make_unique<VectorOperationDefinition>(common::MAP_EXTRACT_FUNC_NAME,
+        std::vector<common::LogicalTypeID>{common::LogicalTypeID::MAP, common::LogicalTypeID::ANY},
+        common::LogicalTypeID::VAR_LIST, nullptr, nullptr, bindFunc, false /* isVarLength */));
+    return definitions;
+}
+
+static void validateKeyType(std::shared_ptr<binder::Expression> mapExpression,
+    std::shared_ptr<binder::Expression> extractKeyExpression) {
+    auto mapKeyType = common::MapType::getKeyType(&mapExpression->dataType);
+    if (*mapKeyType != extractKeyExpression->dataType) {
+        throw common::RuntimeException("Unmatched map key type and extract key type");
+    }
+}
+
+std::unique_ptr<FunctionBindData> MapExtractVectorOperations::bindFunc(
+    const binder::expression_vector& arguments, kuzu::function::FunctionDefinition* definition) {
+    validateKeyType(arguments[0], arguments[1]);
+    auto vectorOperationDefinition = reinterpret_cast<VectorOperationDefinition*>(definition);
+    vectorOperationDefinition->execFunc =
+        VectorListOperations::getBinaryListExecFunc<operation::MapExtract, common::list_entry_t>(
+            arguments[1]->getDataType());
+    auto returnListInfo =
+        std::make_unique<common::VarListTypeInfo>(std::make_unique<common::LogicalType>(
+            *common::MapType::getValueType(&arguments[0]->dataType)));
+    return std::make_unique<FunctionBindData>(
+        common::LogicalType(common::LogicalTypeID::VAR_LIST, std::move(returnListInfo)));
+}
+
+vector_operation_definitions MapKeysVectorOperations::getDefinitions() {
+    auto execFunc = VectorListOperations::UnaryListExecFunction<common::list_entry_t,
+        common::list_entry_t, operation::MapKeys>;
+    vector_operation_definitions definitions;
+    definitions.push_back(make_unique<VectorOperationDefinition>(common::MAP_KEYS_FUNC_NAME,
+        std::vector<common::LogicalTypeID>{common::LogicalTypeID::MAP},
+        common::LogicalTypeID::VAR_LIST, execFunc, nullptr, bindFunc, false /* isVarLength */));
+    return definitions;
+}
+
+std::unique_ptr<FunctionBindData> MapKeysVectorOperations::bindFunc(
+    const binder::expression_vector& arguments, kuzu::function::FunctionDefinition* definition) {
+    auto returnListInfo =
+        std::make_unique<common::VarListTypeInfo>(std::make_unique<common::LogicalType>(
+            *common::MapType::getKeyType(&arguments[0]->dataType)));
+    return std::make_unique<FunctionBindData>(
+        common::LogicalType(common::LogicalTypeID::VAR_LIST, std::move(returnListInfo)));
+}
+
+vector_operation_definitions MapValuesVectorOperations::getDefinitions() {
+    auto execFunc = VectorListOperations::UnaryListExecFunction<common::list_entry_t,
+        common::list_entry_t, operation::MapValues>;
+    vector_operation_definitions definitions;
+    definitions.push_back(make_unique<VectorOperationDefinition>(common::MAP_VALUES_FUNC_NAME,
+        std::vector<common::LogicalTypeID>{common::LogicalTypeID::MAP},
+        common::LogicalTypeID::VAR_LIST, execFunc, nullptr, bindFunc, false /* isVarLength */));
+    return definitions;
+}
+
+std::unique_ptr<FunctionBindData> MapValuesVectorOperations::bindFunc(
+    const binder::expression_vector& arguments, kuzu::function::FunctionDefinition* definition) {
+    auto returnListInfo =
+        std::make_unique<common::VarListTypeInfo>(std::make_unique<common::LogicalType>(
+            *common::MapType::getValueType(&arguments[0]->dataType)));
+    return std::make_unique<FunctionBindData>(
+        common::LogicalType(common::LogicalTypeID::VAR_LIST, std::move(returnListInfo)));
 }
 
 } // namespace function

--- a/src/function/vector_struct_operations.cpp
+++ b/src/function/vector_struct_operations.cpp
@@ -43,7 +43,7 @@ void StructPackVectorOperations::execFunc(
         // If the parameter's state is inconsistent with the result's state, we need to copy the
         // parameter's value to the corresponding child vector.
         copyParameterValueToStructFieldVector(
-            parameter.get(), common::StructVector::getChildVector(&result, i).get());
+            parameter.get(), common::StructVector::getFieldVector(&result, i).get());
     }
 }
 

--- a/src/include/common/expression_type.h
+++ b/src/include/common/expression_type.h
@@ -68,6 +68,11 @@ const std::string STRUCT_EXTRACT_FUNC_NAME = "STRUCT_EXTRACT";
 
 // map
 const std::string MAP_CREATION_FUNC_NAME = "MAP";
+const std::string MAP_EXTRACT_FUNC_NAME = "MAP_EXTRACT";
+const std::string ELEMENT_AT_FUNC_NAME = "ELEMENT_AT"; // alias of MAP_EXTRACT
+const std::string CARDINALITY_FUNC_NAME = "CARDINALITY";
+const std::string MAP_KEYS_FUNC_NAME = "MAP_KEYS";
+const std::string MAP_VALUES_FUNC_NAME = "MAP_VALUES";
 
 // comparison
 const std::string EQUALS_FUNC_NAME = "EQUALS";

--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -72,5 +72,9 @@ template<>
 bool TypeUtils::isValueEqual(
     list_entry_t& left, list_entry_t& right, void* leftVector, void* rightVector);
 
+template<>
+bool TypeUtils::isValueEqual(
+    struct_entry_t& left, struct_entry_t& right, void* leftVector, void* rightVector);
+
 } // namespace common
 } // namespace kuzu

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -285,6 +285,18 @@ struct StructType {
     }
 };
 
+struct MapType {
+    static inline LogicalType* getKeyType(const LogicalType* type) {
+        assert(type->getLogicalTypeID() == LogicalTypeID::MAP);
+        return common::StructType::getFieldTypes(common::VarListType::getChildType(type))[0];
+    }
+
+    static inline LogicalType* getValueType(const LogicalType* type) {
+        assert(type->getLogicalTypeID() == LogicalTypeID::MAP);
+        return common::StructType::getFieldTypes(common::VarListType::getChildType(type))[1];
+    }
+};
+
 class LogicalTypeUtils {
 public:
     KUZU_API static std::string dataTypeToString(const LogicalType& dataType);

--- a/src/include/function/list/operations/list_position_operation.h
+++ b/src/include/function/list/operations/list_position_operation.h
@@ -23,8 +23,8 @@ struct ListPosition {
         auto listElements =
             reinterpret_cast<T*>(common::ListVector::getListValues(&listVector, list));
         for (auto i = 0u; i < list.size; i++) {
-            if (common::TypeUtils::isValueEqual(listElements[i], element, nullptr /* leftVector */,
-                    nullptr /* rightVector */)) {
+            if (common::TypeUtils::isValueEqual(listElements[i], element,
+                    common::ListVector::getDataVector(&listVector), &elementVector)) {
                 result = i + 1;
                 return;
             }
@@ -32,26 +32,6 @@ struct ListPosition {
         result = 0;
     }
 };
-
-template<>
-void ListPosition::operation(common::list_entry_t& list, common::list_entry_t& element,
-    int64_t& result, common::ValueVector& listVector, common::ValueVector& elementVector,
-    common::ValueVector& resultVector) {
-    if (*common::VarListType::getChildType(&listVector.dataType) != elementVector.dataType) {
-        result = 0;
-        return;
-    }
-    auto listElements = reinterpret_cast<common::list_entry_t*>(
-        common::ListVector::getListValues(&listVector, list));
-    for (auto i = 0u; i < list.size; i++) {
-        if (common::TypeUtils::isValueEqual(listElements[i], element,
-                common::ListVector::getDataVector(&listVector), &elementVector)) {
-            result = i + 1;
-            return;
-        }
-    }
-    result = 0;
-}
 
 } // namespace operation
 } // namespace function

--- a/src/include/function/map/operations/base_map_extract_operation.h
+++ b/src/include/function/map/operations/base_map_extract_operation.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "common/vector/value_vector.h"
+#include "common/vector/value_vector_utils.h"
+
+namespace kuzu {
+namespace function {
+namespace operation {
+
+struct BaseMapExtract {
+    static void operation(common::list_entry_t& resultEntry, common::ValueVector& resultVector,
+        uint8_t* srcValues, common::ValueVector* srcVector, uint64_t numValuesToCopy) {
+        resultEntry = common::ListVector::addList(&resultVector, numValuesToCopy);
+        auto dstValues = common::ListVector::getListValues(&resultVector, resultEntry);
+        auto dstDataVector = common::ListVector::getDataVector(&resultVector);
+        for (auto i = 0u; i < numValuesToCopy; i++) {
+            common::ValueVectorUtils::copyValue(dstValues, *dstDataVector, srcValues, *srcVector);
+            dstValues += dstDataVector->getNumBytesPerValue();
+            srcValues += srcVector->getNumBytesPerValue();
+        }
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/map/operations/map_creation_operation.h
+++ b/src/include/function/map/operations/map_creation_operation.h
@@ -1,8 +1,5 @@
 #pragma once
 
-#include <cassert>
-#include <cstring>
-
 #include "common/vector/value_vector.h"
 #include "common/vector/value_vector_utils.h"
 
@@ -10,7 +7,7 @@ namespace kuzu {
 namespace function {
 namespace operation {
 
-struct Map {
+struct MapCreation {
     static void operation(common::list_entry_t& keyEntry, common::list_entry_t& valueEntry,
         common::list_entry_t& resultEntry, common::ValueVector& keyVector,
         common::ValueVector& valueVector, common::ValueVector& resultVector) {
@@ -20,10 +17,10 @@ struct Map {
         resultEntry = common::ListVector::addList(&resultVector, keyEntry.size);
         auto resultStructVector = common::ListVector::getDataVector(&resultVector);
         copyListEntry(resultEntry,
-            common::StructVector::getChildVector(resultStructVector, 0 /* keyVector */).get(),
+            common::StructVector::getFieldVector(resultStructVector, 0 /* keyVector */).get(),
             keyEntry, &keyVector);
         copyListEntry(resultEntry,
-            common::StructVector::getChildVector(resultStructVector, 1 /* valueVector */).get(),
+            common::StructVector::getFieldVector(resultStructVector, 1 /* valueVector */).get(),
             valueEntry, &valueVector);
     }
 

--- a/src/include/function/map/operations/map_extract_operation.h
+++ b/src/include/function/map/operations/map_extract_operation.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "common/vector/value_vector.h"
+#include "common/vector/value_vector_utils.h"
+
+namespace kuzu {
+namespace function {
+namespace operation {
+
+struct MapExtract {
+    template<typename T>
+    static void operation(common::list_entry_t& listEntry, T& key,
+        common::list_entry_t& resultEntry, common::ValueVector& listVector,
+        common::ValueVector& keyVector, common::ValueVector& resultVector) {
+        auto mapKeyVector = common::MapVector::getKeyVector(&listVector);
+        auto mapKeyValues = common::MapVector::getMapKeys(&listVector, listEntry);
+        auto mapValVector = common::MapVector::getValueVector(&listVector);
+        auto mapValValues = common::MapVector::getMapValues(&listVector, listEntry);
+        for (auto i = 0u; i < listEntry.size; i++) {
+            if (common::TypeUtils::isValueEqual(
+                    *reinterpret_cast<T*>(mapKeyValues), key, mapKeyVector, &keyVector)) {
+                resultEntry = common::ListVector::addList(&resultVector, 1 /* size */);
+                common::ValueVectorUtils::copyValue(
+                    common::ListVector::getListValues(&resultVector, resultEntry),
+                    *common::ListVector::getDataVector(&resultVector), mapValValues, *mapValVector);
+                return;
+            }
+            mapKeyValues += mapKeyVector->getNumBytesPerValue();
+            mapValValues += mapValVector->getNumBytesPerValue();
+        }
+        // If the key is not found, return an empty list.
+        resultEntry = common::ListVector::addList(&resultVector, 0 /* size */);
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/map/operations/map_keys_operation.h
+++ b/src/include/function/map/operations/map_keys_operation.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "function/map/operations/base_map_extract_operation.h"
+
+namespace kuzu {
+namespace function {
+namespace operation {
+
+struct MapKeys : public BaseMapExtract {
+    static void operation(common::list_entry_t& listEntry, common::list_entry_t& resultEntry,
+        common::ValueVector& listVector, common::ValueVector& resultVector) {
+        auto mapKeyVector = common::MapVector::getKeyVector(&listVector);
+        auto mapKeyValues = common::MapVector::getMapKeys(&listVector, listEntry);
+        BaseMapExtract::operation(
+            resultEntry, resultVector, mapKeyValues, mapKeyVector, listEntry.size);
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/map/operations/map_values_operation.h
+++ b/src/include/function/map/operations/map_values_operation.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "common/vector/value_vector.h"
+#include "common/vector/value_vector_utils.h"
+
+namespace kuzu {
+namespace function {
+namespace operation {
+
+struct MapValues : public BaseMapExtract {
+    static void operation(common::list_entry_t& listEntry, common::list_entry_t& resultEntry,
+        common::ValueVector& listVector, common::ValueVector& resultVector) {
+        auto mapValueVector = common::MapVector::getValueVector(&listVector);
+        auto mapValueValues = common::MapVector::getMapValues(&listVector, listEntry);
+        BaseMapExtract::operation(
+            resultEntry, resultVector, mapValueValues, mapValueVector, listEntry.size);
+    }
+};
+
+} // namespace operation
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/map/vector_map_operations.h
+++ b/src/include/function/map/vector_map_operations.h
@@ -6,7 +6,25 @@
 namespace kuzu {
 namespace function {
 
-struct MapVectorOperations {
+struct MapCreationVectorOperations {
+    static vector_operation_definitions getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+};
+
+struct MapExtractVectorOperations {
+    static vector_operation_definitions getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+};
+
+struct MapKeysVectorOperations {
+    static vector_operation_definitions getDefinitions();
+    static std::unique_ptr<FunctionBindData> bindFunc(
+        const binder::expression_vector& arguments, FunctionDefinition* definition);
+};
+
+struct MapValuesVectorOperations {
     static vector_operation_definitions getDefinitions();
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, FunctionDefinition* definition);

--- a/src/storage/storage_structure/column.cpp
+++ b/src/storage/storage_structure/column.cpp
@@ -321,7 +321,7 @@ void StructPropertyColumn::read(Transaction* transaction, common::ValueVector* n
     resultVector->setAllNonNull();
     for (auto i = 0u; i < structFieldColumns.size(); i++) {
         structFieldColumns[i]->read(
-            transaction, nodeIDVector, common::StructVector::getChildVector(resultVector, i).get());
+            transaction, nodeIDVector, common::StructVector::getFieldVector(resultVector, i).get());
     }
 }
 

--- a/test/test_files/tinysnb/function/map.test
+++ b/test/test_files/tinysnb/function/map.test
@@ -1,0 +1,95 @@
+-GROUP TinySnbReadTest
+-DATASET CSV tinysnb
+
+--
+
+-CASE FunctionMap
+
+-NAME MapExtractBool
+-QUERY RETURN map_extract(map([4,5,7], [true, false, true]), 5)
+---- 1
+[False]
+
+-NAME MapExtractInt64
+-QUERY RETURN map_extract(map(['a', 'c', 'e'], [4, 3, 1]), 'c')
+---- 1
+[3]
+
+-NAME MapExtractInt32
+-QUERY RETURN map_extract(map([[1,3], [2,4]], [to_int32(3), to_int32(5)]), [2,4])
+---- 1
+[5]
+
+-NAME MapExtractInt16
+-QUERY RETURN map_extract(map([4, 1, 3, 5], [to_int16(1), to_int16(4), to_int16(99), to_int16(11)]), 5)
+---- 1
+[11]
+
+-NAME MapExtractDouble
+-QUERY RETURN map_extract(map([{a: 3, b: [1, 2, 5]}, {a: 6, b: [1,3]}], [4.3, 5.2]), {b: 3, a: [1,2,5]})
+---- 1
+[4.300000]
+
+-NAME MapExtractFloat
+-QUERY RETURN map_extract(map([1, 88], [to_float(3.2), to_float(3.1)]), 1)
+---- 1
+[3.200000]
+
+-NAME MapExtractVarList
+-QUERY RETURN element_at(map([1, 88], [[4,5], [2,3,1]]), 1)
+---- 1
+[[4,5]]
+
+-NAME MapExtractInternalID
+-QUERY MATCH (a:person) RETURN map_extract(map([a.age], [id(a)]), 20)
+---- 8
+[]
+[]
+[]
+[0:3]
+[0:4]
+[]
+[]
+[]
+
+-NAME MapExtractString
+-QUERY MATCH (a:person) RETURN element_at(map([a.age], [a.fName]), 20)
+---- 8
+[]
+[]
+[]
+[Dan]
+[Elizabeth]
+[]
+[]
+[]
+
+-NAME MapExtractStruct
+-QUERY RETURN map_extract(map([{a: 5, b: {length: 30, age: 20, size: [20, 10]}}, {a: 7, b: {length: 22, age: 145, size: [20,15, 10]}}], [30 ,50]), {a1: 7, b2: {length1: 22, age1: 145, size: [20,15, 10]}})
+---- 1
+[50]
+
+-NAME MapCardinality
+-QUERY RETURN cardinality(map([4, 2, 100, 20], ['a', 'b', 'd', 'e']));
+---- 1
+4
+
+-NAME MapKeys
+-QUERY RETURN map_keys(map([[5], [28, 75, 32], [], [33, 11, 66, 33]], ['a', 'b', 'd', 'e']));
+---- 1
+[[5],[28,75,32],[],[33,11,66,33]]
+
+-NAME EmptyMapKeys
+-QUERY RETURN map_keys(map([], []));
+---- 1
+[]
+
+-NAME MapValues
+-QUERY RETURN map_values(map([23, 57, 1444], [{a: 5, c: [3, 4, 13]}, {d: 7, e: [1, 2, 3]}, {f: 9, g: [1, 2, 3, 4]}]));
+---- 1
+[{A: 5, C: [3,4,13]},{A: 7, C: [1,2,3]},{A: 9, C: [1,2,3,4]}]
+
+-NAME EmptyMapValues
+-QUERY RETURN map_values(map([], []));
+---- 1
+[]

--- a/tools/nodejs_api/test/test_data_type.js
+++ b/tools/nodejs_api/test/test_data_type.js
@@ -199,7 +199,7 @@ describe("STRUCT", function () {
     assert.equal(typeof result[0]["o.state"], "object");
     assert.deepEqual(result[0]["o.state"], {
       REVENUE: 138,
-      LOCATION: ["'toronto'", " 'montr", "eal'"],
+      LOCATION: ["'toronto'", " 'montr,eal'"],
       STOCK: { PRICE: [96, 56], VOLUME: 1000 },
     });
   });


### PR DESCRIPTION
1. Implement the following map functions:
a. MAP_EXTRACT: Return a list containing the value for a given key or an empty list if the key is not contained in the map. The type of the key provided in the second parameter must match the type of the map’s keys else an error is returned.	
b.CARDINALITY: Return the size of the map (or the number of entries in the map).	
c. MAP_KEYS: Return a list of all keys in the map.	
d. MAP_VALUES: Return a list of all values in the map.	
2. Fixed list parsing bug.


