### PR TITLE
Added CHECK_ORDER and PARALLELISM 1 to IC12 Test

### DIFF
--- a/test/test_files/ldbc/ldbc-interactive/interactive-complex.test
+++ b/test/test_files/ldbc/ldbc-interactive/interactive-complex.test
@@ -162,25 +162,26 @@ Euripides|1
 2199023256689|Ferenc|Kovacs|CityLine_Hungary|2006
 28587302323430|János|Mészáros|Malév_Hungarian_Airlines|2008
 
-# There's currently a bug with the order on the CI test runner, so commenting this out for now.
 # IC12 should be changed to use Kleene Star relationship once that is implemented
-# -NAME IC12
-# -QUERY MATCH (tag:Tag)-[:Tag_hasType_TagClass|:TagClass_isSubclassOf_TagClass*1..20]->(baseTagClass:TagClass)
-#        WHERE tag.name = "Monarch" OR baseTagClass.name = "Monarch"
-#        WITH collect(tag.id) as tags
-#        MATCH (:Person {id: 6597069767300 })-[:Person_knows_Person]-(friend:Person)<-[:Comment_hasCreator_Person]-(comment:Comment)-[:Comment_replyOf_Post]->(:Post)-[:Post_hasTag_Tag]->(tag:Tag)
-#        WHERE list_contains(tags, tag.id)
-#        RETURN friend.id AS personId, friend.firstName AS personFirstName, friend.lastName AS personLastName, collect(DISTINCT tag.name) AS tagNames, count(DISTINCT comment) AS replyCount
-#        ORDER BY replyCount DESC, personId ASC
-#        LIMIT 20;
-# ---- 7
-# 8796093022764|Zheng|Xu|[Mahmud_of_Ghazni,Ashoka,Tiberius,Marcus_Aurelius,Genghis_Khan,Justinian_I,Hadrian,Timur]|13
-# 10995116278353|Otto|Muller|[Tiberius,Genghis_Khan,Justinian_I,Constantine_the_Great,Trajan]|11
-# 17592186044994|Jie|Wang|[Genghis_Khan,David]|7
-# 13194139534548|Bing|Zheng|[Genghis_Khan,Hadrian,Solomon]|6
-# 13194139533500|Otto|Becker|[Tiberius,Genghis_Khan,Julius_Caesar,David,Alexander_the_Great]|5
-# 28587302322537|Anh|Nguyen|[Mahmud_of_Ghazni,Trajan]|3
-# 30786325578932|Alexander|Hleb|[Mahmud_of_Ghazni,David]|3
+-NAME IC12
+-CHECK_ORDER
+-PARALLELISM 1
+-QUERY MATCH (tag:Tag)-[:Tag_hasType_TagClass|:TagClass_isSubclassOf_TagClass*1..20]->(baseTagClass:TagClass)
+       WHERE tag.name = "Monarch" OR baseTagClass.name = "Monarch"
+       WITH collect(tag.id) as tags
+       MATCH (:Person {id: 6597069767300 })-[:Person_knows_Person]-(friend:Person)<-[:Comment_hasCreator_Person]-(comment:Comment)-[:Comment_replyOf_Post]->(:Post)-[:Post_hasTag_Tag]->(tag:Tag)
+       WHERE list_contains(tags, tag.id)
+       RETURN friend.id AS personId, friend.firstName AS personFirstName, friend.lastName AS personLastName, collect(DISTINCT tag.name) AS tagNames, count(DISTINCT comment) AS replyCount
+       ORDER BY replyCount DESC, personId ASC
+       LIMIT 20;
+---- 7
+8796093022764|Zheng|Xu|[Mahmud_of_Ghazni,Ashoka,Tiberius,Marcus_Aurelius,Genghis_Khan,Justinian_I,Hadrian,Timur]|13
+10995116278353|Otto|Muller|[Tiberius,Genghis_Khan,Justinian_I,Constantine_the_Great,Trajan]|11
+17592186044994|Jie|Wang|[Genghis_Khan,David]|7
+13194139534548|Bing|Zheng|[Genghis_Khan,Hadrian,Solomon]|6
+13194139533500|Otto|Becker|[Tiberius,Genghis_Khan,Julius_Caesar,David,Alexander_the_Great]|5
+28587302322537|Anh|Nguyen|[Mahmud_of_Ghazni,Trajan]|3
+30786325578932|Alexander|Hleb|[Mahmud_of_Ghazni,David]|3
 
 # To be completely correct, this query needs to have
 # (i) Unbounded shortest path


### PR DESCRIPTION
What happens is: since we use multiple threads for the results, we might get different order. To solve this issue, we sort the results in the test runner.

The expected result is sorted:
```
[2023-06-15 12:07:41.256] [info] RESULT:

[2023-06-15 12:07:41.256] [info] 10995116278353|Otto|Muller|[Tiberius,Genghis_Khan,Justinian_I,Constantine_the_Great,Trajan]|11
[2023-06-15 12:07:41.256] [info] 13194139533500|Otto|Becker|[Tiberius,Genghis_Khan,Julius_Caesar,Alexander_the_Great,David]|5
[2023-06-15 12:07:41.256] [info] 13194139534548|Bing|Zheng|[Genghis_Khan,Hadrian,Solomon]|6
[2023-06-15 12:07:41.256] [info] 17592186044994|Jie|Wang|[Genghis_Khan,David]|7
[2023-06-15 12:07:41.256] [info] 28587302322537|Anh|Nguyen|[Mahmud_of_Ghazni,Trajan]|3
[2023-06-15 12:07:41.256] [info] 30786325578932|Alexander|Hleb|[Mahmud_of_Ghazni,David]|3
[2023-06-15 12:07:41.256] [info] 8796093022764|Zheng|Xu|[Mahmud_of_Ghazni,Ashoka,Tiberius,Marcus_Aurelius,Genghis_Khan,Justinian_I,Hadrian,Timur]|13
```

There are two ways to fix this:

1. You can use sorted results in the test file if the order doesn't matter; or
2. You can add `-CHECK_ORDER` to disable sorting the results and enforce using only one thread with `-PARALLELISM 1`
```
-NAME IC12
-CHECK_ORDER
-PARALLELISM 1
-QUERY MATCH ...
...
```

Related to #1668