### PR TITLE
Add windows precompiled binary workflow and shared library to pre-compiled binary archive

### DIFF
--- a/.github/workflows/windows-precompiled-bin-workflow.yml
+++ b/.github/workflows/windows-precompiled-bin-workflow.yml
@@ -1,0 +1,42 @@
+name: Build-Windows-Precompiled-Binaries
+
+on:
+  workflow_dispatch:
+    inputs:
+      packageVersion:
+        description: "Version of output package"
+        required: true
+        default: "0.0.1"
+
+env:
+  PACKAGE_VERSION: ${{ github.event.inputs.packageVersion }}
+
+jobs:
+  build-precompiled-bin:
+    runs-on: self-hosted-windows
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install networkx
+        run: python.exe -m pip install networkx --user
+
+      - name: Build precompiled binaries
+        run: python.exe build.py
+        working-directory: ./scripts/pre-compiled-bins/
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: libkuzu-${{ github.event.inputs.packageVersion }}-windows-x86_64
+          path: |
+            ./scripts/pre-compiled-bins/kuzu.h
+            ./scripts/pre-compiled-bins/kuzu.hpp
+            ./scripts/pre-compiled-bins/kuzu_shared.dll
+            ./scripts/pre-compiled-bins/kuzu_shared.lib
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: kuzu_cli-${{ github.event.inputs.packageVersion }}-windows-x86_64
+          path: ./scripts/pre-compiled-bins/kuzu.exe
+
+      - name: Clean up
+        run: rm -rf ./scripts/pre-compiled-bins/kuzu ./scripts/pre-compiled-bins/headers ./scripts/pre-compiled-bins/kuzu_shared.dll ./scripts/pre-compiled-bins/kuzu_shared.lib ./scripts/pre-compiled-bins/kuzu.h ./scripts/pre-compiled-bins/kuzu.hpp

--- a/scripts/pre-compiled-bins/build.py
+++ b/scripts/pre-compiled-bins/build.py
@@ -102,23 +102,45 @@ def collect_binaries():
         sys.exit(1)
     shutil.copy(c_header_path, os.path.join(base_dir, "kuzu.h"))
     logging.info("Copied kuzu.h")
-    so_exists = os.path.exists(so_path)
-    dylib_exists = os.path.exists(dylib_path)
-    if not so_exists and not dylib_exists:
-        logging.error("No shared object file found")
-        sys.exit(1)
-    if so_exists:
-        shutil.copy(so_path, os.path.join(base_dir, "libkuzu.so"))
-        logging.info("Copied libkuzu.so")
-    if dylib_exists:
-        shutil.copy(dylib_path, os.path.join(base_dir, "libkuzu.dylib"))
-        logging.info("Copied libkuzu.so")
-    shell_path = os.path.join(workspace_root, "build",
-                              "release", "tools", "shell", "kuzu_shell")
-    if not os.path.exists(shell_path):
-        logging.error("No shell binary found")
-        sys.exit(1)
-    shutil.copy(shell_path, os.path.join(base_dir, "kuzu"))
+    if sys.platform == "win32":
+        dll_path = os.path.join(workspace_root, "build",
+                                "release", "src", "kuzu_shared.dll")
+        lib_path = os.path.join(workspace_root, "build",
+                                "release", "src", "kuzu_shared.lib")
+        if not os.path.exists(dll_path):
+            logging.error("No dll found")
+            sys.exit(1)
+        if not os.path.exists(lib_path):
+            logging.error("No import library found")
+            sys.exit(1)
+        shutil.copy(dll_path, os.path.join(base_dir, "kuzu_shared.dll"))
+        logging.info("Copied kuzu_shared.dll")
+        shutil.copy(lib_path, os.path.join(base_dir, "kuzu_shared.lib"))
+        logging.info("Copied kuzu_shared.lib")
+        shell_path = os.path.join(workspace_root, "build", "release",
+                                  "tools", "shell", "kuzu_shell.exe")
+        if not os.path.exists(shell_path):
+            logging.error("No shell binary found")
+            sys.exit(1)
+        shutil.copy(shell_path, os.path.join(base_dir, "kuzu.exe"))
+    else:
+        so_exists = os.path.exists(so_path)
+        dylib_exists = os.path.exists(dylib_path)
+        if not so_exists and not dylib_exists:
+            logging.error("No shared object file found")
+            sys.exit(1)
+        if so_exists:
+            shutil.copy(so_path, os.path.join(base_dir, "libkuzu.so"))
+            logging.info("Copied libkuzu.so")
+        if dylib_exists:
+            shutil.copy(dylib_path, os.path.join(base_dir, "libkuzu.dylib"))
+            logging.info("Copied libkuzu.so")
+        shell_path = os.path.join(workspace_root, "build",
+                                  "release", "tools", "shell", "kuzu_shell")
+        if not os.path.exists(shell_path):
+            logging.error("No shell binary found")
+            sys.exit(1)
+        shutil.copy(shell_path, os.path.join(base_dir, "kuzu"))
     logging.info("Copied kuzu")
     logging.info("Binaries collected")
 

--- a/scripts/pre-compiled-bins/collect_files.py
+++ b/scripts/pre-compiled-bins/collect_files.py
@@ -36,7 +36,7 @@ def collect_header_file_path_recurse(start_point):
         for line in f.readlines():
             if not line.startswith('#include "'):
                 continue
-            header_path = line.split('"')[1]
+            header_path = os.path.normpath(line.split('"')[1])
             header_real_path = None
             # Special case for json_fwd.hpp
             if header_path == 'json_fwd.hpp':

--- a/scripts/pre-compiled-bins/merge_headers.py
+++ b/scripts/pre-compiled-bins/merge_headers.py
@@ -24,7 +24,7 @@ def build_dependency_graph():
             for line in f.readlines():
                 if not line.startswith('#include "'):
                     continue
-                contained_header_name = line.split('"')[1]
+                contained_header_name = Path(line.split('"')[1]).name
                 graph.add_edge(header_name, contained_header_name)
     return graph
 


### PR DESCRIPTION
I also modified the script which produces the pre-compiled binaries so that it includes both the shared library `.dll` and the import library `.lib` (needed for linking stuff against the `dll`; the `dll` is only needed at runtime as far as I know). The last release just included a libkuzu.lib (presumably just the static library? I didn't check; the pre-compiled-bin script wasn't working, so I'm guessing that was created manually).

One question though: should the libraries be `kuzu_shared.dll` and `kuzu_shared.lib` (to distinguish them from kuzu.lib, which is the name of the static library), or just be `kuzu.dll` and `kuzu.lib`?