### PR TITLE
Fix use of PreparedStatement in releases

### DIFF
--- a/src/include/main/prepared_statement.h
+++ b/src/include/main/prepared_statement.h
@@ -43,6 +43,7 @@ public:
     inline std::unordered_map<std::string, std::shared_ptr<common::Value>> getParameterMap() {
         return parameterMap;
     }
+    ~PreparedStatement();
 
 private:
     common::StatementType statementType;

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -2,6 +2,7 @@
 
 #include "binder/bound_statement_result.h"
 #include "common/statement_type.h"
+#include "planner/logical_plan/logical_plan.h"
 
 namespace kuzu {
 namespace main {
@@ -25,6 +26,8 @@ bool PreparedStatement::isReadOnly() const {
 binder::expression_vector PreparedStatement::getExpressionsToCollect() {
     return statementResult->getExpressionsToCollect();
 }
+
+PreparedStatement::~PreparedStatement() = default;
 
 } // namespace main
 } // namespace kuzu

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -3,12 +3,6 @@
 
 #include "main/kuzu.h"
 #include "rust/cxx.h"
-// Need to explicitly import some types.
-// The generated C++ wrapper code needs to be able to call sizeof on PreparedStatement,
-// which it can't do when it only sees forward declarations of its components.
-#include <binder/bound_statement.h>
-#include <main/prepared_statement.h>
-#include <planner/logical_plan/logical_plan.h>
 
 namespace kuzu_rs {
 


### PR DESCRIPTION
~~Instead of using forward declarations.
The forward declarations prevent using `unique_ptr<PreparedStatement>` without extra includes since the type is incomplete, and the necessary header files are unavailable in the single-file header included in the releases.~~

This is necessary both to compile the rust API against the releases, as well as to use the `Connection::prepare` function in the C++ API from the releases.

~~Were forward declarations being used to try and keep BoundStatementResult and LogicalPlan out of the public API, or was it just to try and reduce the number of includes/deal with cyclic includes?~~

Edit: Explicitly declaring the default destructor fixes the issue without changing the includes.