### PR TITLE
Adjust test framework to handle single line result

### DIFF
--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -23,7 +23,7 @@ private:
         TestStatement* statement, main::Connection& conn);
     static bool checkLogicalPlan(std::unique_ptr<main::PreparedStatement>& preparedStatement,
         TestStatement* statement, main::Connection& conn, uint32_t planIdx);
-    static std::tuple <int64_t, std::vector<std::string>> convertResultToString(
+    static std::tuple<int64_t, std::vector<std::string>> convertResultToString(
         main::QueryResult& queryResult, bool checkOutputOrder = false);
     static bool checkPlanResult(std::unique_ptr<main::QueryResult>& result,
         TestStatement* statement, const std::string& planStr, uint32_t planIndex);

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -23,7 +23,7 @@ private:
         TestStatement* statement, main::Connection& conn);
     static bool checkLogicalPlan(std::unique_ptr<main::PreparedStatement>& preparedStatement,
         TestStatement* statement, main::Connection& conn, uint32_t planIdx);
-    static std::vector<std::string> convertResultToString(
+    static std::tuple <int64_t, std::vector<std::string>> convertResultToString(
         main::QueryResult& queryResult, bool checkOutputOrder = false);
     static bool checkPlanResult(std::unique_ptr<main::QueryResult>& result,
         TestStatement* statement, const std::string& planStr, uint32_t planIndex);

--- a/test/test_files/tinysnb/explain/explain.test
+++ b/test/test_files/tinysnb/explain/explain.test
@@ -6,19 +6,101 @@
 -CASE Explain
 
 -LOG ExplainDDL
+-CHECK_ORDER
 -STATEMENT EXPLAIN create node table npytable (id INT64,i32 INT32, PRIMARY KEY(id));
----- ok
+---- 15
+┌─────────────────────────────┐
+│┌───────────────────────────┐│
+││       Physical Plan       ││
+│└───────────────────────────┘│
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│      CREATE_NODE_TABLE      │
+│   -----------------------   │
+│          npytable           │
+│   -----------------------   │
+│     NumOutputTuples: 0      │
+│   -----------------------   │
+│   ExecutionTime: 0.000000   │
+└─────────────────────────────┘
+
 
 -LOG ExplainCopy
 -STATEMENT create node table npytable (id INT64,i32 INT32, PRIMARY KEY(id));
 ---- ok
+-CHECK_ORDER
 -STATEMENT EXPLAIN copy npytable from ("${KUZU_ROOT_DIRECTORY}/dataset/npy-20k/id_int64.npy", "${KUZU_ROOT_DIRECTORY}/dataset/npy-20k/two_dim_float.npy") BY COLUMN;
----- ok
+---- 15
+┌─────────────────────────────┐
+│┌───────────────────────────┐│
+││       Physical Plan       ││
+│└───────────────────────────┘│
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│          COPY_NPY           │
+│   -----------------------   │
+│          npytable           │
+│   -----------------------   │
+│     NumOutputTuples: 0      │
+│   -----------------------   │
+│   ExecutionTime: 0.000000   │
+└─────────────────────────────┘
+
 
 -LOG ExplainCall
+-CHECK_ORDER
 -STATEMENT EXPLAIN CALL threads=5
----- ok
+---- 15
+┌─────────────────────────────┐
+│┌───────────────────────────┐│
+││       Physical Plan       ││
+│└───────────────────────────┘│
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│       STANDALONE_CALL       │
+│   -----------------------   │
+│           threads           │
+│   -----------------------   │
+│     NumOutputTuples: 0      │
+│   -----------------------   │
+│   ExecutionTime: 0.000000   │
+└─────────────────────────────┘
+
 
 -LOG ExplainQuery
+-CHECK_ORDER
 -STATEMENT EXPLAIN MATCH (p:npytable) RETURN p.id
----- ok
+---- 33
+┌─────────────────────────────┐
+│┌───────────────────────────┐│
+││       Physical Plan       ││
+│└───────────────────────────┘│
+└─────────────────────────────┘
+┌─────────────────────────────┐
+│         PROJECTION          │
+│   -----------------------   │
+│            p.id             │
+│   -----------------------   │
+│     NumOutputTuples: 0      │
+│   -----------------------   │
+│   ExecutionTime: 0.000000   │
+└──────────────┬──────────────┘
+┌──────────────┴──────────────┐
+│     SCAN_NODE_PROPERTY      │
+│   -----------------------   │
+│            p.id             │
+│   -----------------------   │
+│     NumOutputTuples: 0      │
+│   -----------------------   │
+│   ExecutionTime: 0.000000   │
+└──────────────┬──────────────┘
+┌──────────────┴──────────────┐
+│        SCAN_NODE_ID         │
+│   -----------------------   │
+│              p              │
+│   -----------------------   │
+│     NumOutputTuples: 0      │
+│   -----------------------   │
+│   ExecutionTime: 0.000000   │
+└─────────────────────────────┘
+

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -79,7 +79,7 @@ bool TestRunner::checkLogicalPlan(std::unique_ptr<PreparedStatement>& preparedSt
 
 bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestStatement* statement,
     const std::string& planStr, uint32_t planIdx) {
-    std::tuple <int64_t, std::vector<std::string>> resultTuples =
+    std::tuple<int64_t, std::vector<std::string>> resultTuples =
         TestRunner::convertResultToString(*result, statement->checkOutputOrder);
     if (!statement->expectedTuplesCSVFile.empty()) {
         std::ifstream expectedTuplesFile(statement->expectedTuplesCSVFile);
@@ -110,7 +110,7 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
     return false;
 }
 
-std::tuple <int64_t, std::vector<std::string>> TestRunner::convertResultToString(
+std::tuple<int64_t, std::vector<std::string>> TestRunner::convertResultToString(
     QueryResult& queryResult, bool checkOutputOrder) {
     std::vector<std::string> actualOutput;
     int64_t actualSize = 0;

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -123,6 +123,7 @@ std::tuple<int64_t, std::vector<std::string>> TestRunner::convertResultToString(
             actualOutput.push_back(tupleStr);
         } else {
             for (auto& line : lines) {
+                StringUtils::replaceAll(line, "\r", "");
                 actualOutput.push_back(line);
             }
         }


### PR DESCRIPTION
Adjust the test framework to deal with single-line results that include new lines. This is necessary to test the results from `EXPLAIN` statements.