### PR TITLE
Unified CMake Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,7 +158,21 @@ if (${USE_SYSTEM_ARROW})
 else()
     if (NOT DEFINED ARROW_INSTALL)
         message(STATUS "Configuring arrow for bundled install")
-        set(ARROW_INSTALL ${CMAKE_CURRENT_SOURCE_DIR}/external/build/arrow/install)
+        set(ARROW_INSTALL ${CMAKE_CURRENT_BINARY_DIR}/arrow-build/arrow/install)
+        set(ARROW_BUILD_DIR ${CMAKE_CURRENT_BINARY_DIR}/arrow-build)
+        file(MAKE_DIRECTORY ${ARROW_BUILD_DIR})
+        execute_process(COMMAND ${CMAKE_COMMAND}
+            ${CMAKE_CURRENT_SOURCE_DIR}/external
+            -G ${CMAKE_GENERATOR}
+            -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+            -DENABLE_ADDRESS_SANITIZER=${ENABLE_ADDRESS_SANITIZER}
+            -DENABLE_THREAD_SANITIZER=${ENABLE_THREAD_SANITIZER}
+            -DENABLE_UBSAN=${ENABLE_UBSAN}
+            -DFORCE_COLORED_OUTPUT=${FORCE_COLORED_OUTPUT}
+            WORKING_DIRECTORY ${ARROW_BUILD_DIR}
+            COMMAND_ERROR_IS_FATAL ANY)
+        execute_process(COMMAND ${CMAKE_COMMAND} --build ${ARROW_BUILD_DIR} --config ${CMAKE_BUILD_TYPE}
+            COMMAND_ERROR_IS_FATAL ANY)
     else()
         message(STATUS "Using arrow at path ${ARROW_INSTALL}")
     endif()

--- a/Makefile
+++ b/Makefile
@@ -48,48 +48,32 @@ define mkdirp
 endef
 endif
 
-arrow:
-	$(call mkdirp,external/build) && cd external/build && \
-	cmake $(FORCE_COLOR) $(SANITIZER_FLAG) $(GENERATOR) -DCMAKE_BUILD_TYPE=Release .. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
-
-arrow-debug:
-ifeq ($(OS),Windows_NT)
-	$(call mkdirp,external/build) && cd external/build && \
-	cmake $(FORCE_COLOR) $(SANITIZER_FLAG) $(GENERATOR) -DCMAKE_BUILD_TYPE=Debug .. && \
-	cmake --build . --config Debug -- -j $(NUM_THREADS)
-else
-	$(call mkdirp,external/build) && cd external/build && \
-	cmake $(FORCE_COLOR) $(SANITIZER_FLAG) $(GENERATOR) -DCMAKE_BUILD_TYPE=Release .. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
-endif
-
-release: arrow
+release:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release ../.. && \
 	cmake --build . --config Release -- -j $(NUM_THREADS)
 
-debug: arrow-debug
+debug:
 	$(call mkdirp,build/debug) && cd build/debug && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Debug ../.. && \
 	cmake --build . --config Debug -- -j $(NUM_THREADS)
 
-all: arrow
+all:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE ../.. && \
 	cmake --build . --config Release -- -j $(NUM_THREADS)
 
-alldebug: arrow
+alldebug:
 	$(call mkdirp,build/debug) && cd build/debug && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE ../.. && \
 	cmake --build . --config Debug -- -j $(NUM_THREADS)
 
-benchmark: arrow
+benchmark:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARK=TRUE ../.. && \
 	cmake --build . --config Release -- -j $(NUM_THREADS)
 
-nodejs: arrow
+nodejs:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_NODEJS=TRUE ../.. && \
 	cmake --build . --config Release -- -j $(NUM_THREADS)
@@ -99,26 +83,26 @@ java:
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA=TRUE ../.. && \
 	cmake --build . --config Release -- -j $(NUM_THREADS)
 
-test: arrow
+test:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE ../.. && \
 	cmake --build . --config Release -- -j $(NUM_THREADS)
 	cd $(ROOT_DIR)/build/release/test && \
 	ctest --output-on-failure -j ${TEST_JOBS}
 
-lcov: arrow
+lcov:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_NODEJS=TRUE -DBUILD_LCOV=TRUE ../.. && \
 	cmake --build . --config Release -- -j $(NUM_THREADS)
 	cd $(ROOT_DIR)/build/release/test && \
 	ctest --output-on-failure -j ${TEST_JOBS}
 
-pytest: arrow
+pytest:
 	$(MAKE) release
 	cd $(ROOT_DIR)/tools/python_api/test && \
 	python3 -m pytest -v test_main.py
 
-nodejstest: arrow
+nodejstest:
 	$(MAKE) nodejs
 	cd $(ROOT_DIR)/tools/nodejs_api/ && \
 	npm test
@@ -162,18 +146,9 @@ else
 	rm -rf tools/java_api/build
 endif
 
-clean-external:
-ifeq ($(OS),Windows_NT)
-	if exist external\build rmdir /s /q external\build
-else
-	rm -rf external/build
-endif
-
 clean: clean-python-api clean-java
 ifeq ($(OS),Windows_NT)
 	if exist build rmdir /s /q build
 else
 	rm -rf build
 endif
-
-clean-all: clean-external clean

--- a/external/arrow/apache_arrow.cmake
+++ b/external/arrow/apache_arrow.cmake
@@ -10,7 +10,8 @@ endif()
 
 ExternalProject_Add(apache_arrow
         GIT_REPOSITORY "https://github.com/apache/arrow"
-        GIT_TAG f10f5cfd1376fb0e602334588b3f3624d41dee7d
+        GIT_TAG apache-arrow-12.0.1
+        GIT_SHALLOW TRUE
         PREFIX "${CMAKE_BINARY_DIR}/arrow/"
         INSTALL_DIR "${CMAKE_BINARY_DIR}/arrow/install"
         CONFIGURE_COMMAND


### PR DESCRIPTION
Addresses an issue mentioned in #1736 and also #1745 by running the apache arrow cmake build during the configure step of the kuzu cmake build.

This might be a little unexpected since you don't usually expect a large and slow compilation step when running the configure step, but `USE_SYSTEM_ARROW` and `ARROW_INSTALL` can still be used to avoid building arrow by pointing it at a pre-built version.

I simplified the makefile accordingly, but didn't entirely remove it. There are some situations where it is still helpful to provide default settings, particularly in the case of Windows MSVC builds where (last I checked) the default Visual Studio generator produces build errors. The makefile targets are also being used for CI, though they could be inlined into the CI files.

Note that while this removes the distinction between `make clean` and `make clean-all`, you can still clean without removing arrow by running `make clean` inside the build directory, i.e. on the cmake generated makefile, when using the makefile generator (not quite the same as removing all the files, but it's close enough for most purposes I think).

I also took the liberty of setting `GIT_SHALLOW` on the arrow ExternalProject (cuts the download size from >100MB to ~20MB), and since it requires a named tag, also updated that to 12.0.1, which seems to work fine.