### PR TITLE
Example Fix and CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -13,6 +13,9 @@ jobs:
     name: gcc build & test
     needs: [clang-formatting-check]
     runs-on: kuzu-self-hosted-testing
+    env:
+      # Share build cache when building rust API and the example project
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
     steps:
       - uses: actions/checkout@v3
 
@@ -50,6 +53,26 @@ jobs:
         with:
           file: cover.info
           functionalities: 'search'
+
+      - name: C Example
+        working-directory: examples/c
+        run: |
+          mkdir build -p
+          cd build
+          CC=gcc CXX=g++ cmake ..
+          cmake --build .
+
+      - name: C++ Example
+        working-directory: examples/cpp
+        run: |
+          mkdir build -p
+          cd build
+          CC=gcc CXX=g++ cmake ..
+          cmake --build .
+
+      - name: Rust example
+        working-directory: examples/rust
+        run: CC=gcc CXX=g++ cargo build
 
   gcc-build-test-with-asan:
     name: gcc build & test with asan


### PR DESCRIPTION
I'd noticed that the C++ example doesn't compile any more (`json_fwd.hpp` has been added into one of the includes, presumably since that example was written). I've fixed it, and added CI jobs for the examples, since while they aren't essential parts of the software, they are less helpful if they get out of date and fail to build when someone tries them out.