### PR TITLE
Set CMAKE_BUILD_PARALLEL_LEVEL so that NUM_THREADS gets passed to the arrow build in CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ ROOT_DIR=$(CURDIR)
 ifndef $(NUM_THREADS)
 	NUM_THREADS=1
 endif
+export CMAKE_BUILD_PARALLEL_LEVEL=$(NUM_THREADS)
 
 ifndef $(TEST_JOBS)
 	TEST_JOBS=10
@@ -51,49 +52,49 @@ endif
 release:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release ../.. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
+	cmake --build . --config Release
 
 debug:
 	$(call mkdirp,build/debug) && cd build/debug && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Debug ../.. && \
-	cmake --build . --config Debug -- -j $(NUM_THREADS)
+	cmake --build . --config Debug
 
 all:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE ../.. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
+	cmake --build . --config Release
 
 alldebug:
 	$(call mkdirp,build/debug) && cd build/debug && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE ../.. && \
-	cmake --build . --config Debug -- -j $(NUM_THREADS)
+	cmake --build . --config Debug
 
 benchmark:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARK=TRUE ../.. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
+	cmake --build . --config Release
 
 nodejs:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_NODEJS=TRUE ../.. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
+	cmake --build . --config Release
 
 java:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA=TRUE ../.. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
+	cmake --build . --config Release
 
 test:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE ../.. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
+	cmake --build . --config Release
 	cd $(ROOT_DIR)/build/release/test && \
 	ctest --output-on-failure -j ${TEST_JOBS}
 
 lcov:
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_NODEJS=TRUE -DBUILD_LCOV=TRUE ../.. && \
-	cmake --build . --config Release -- -j $(NUM_THREADS)
+	cmake --build . --config Release
 	cd $(ROOT_DIR)/build/release/test && \
 	ctest --output-on-failure -j ${TEST_JOBS}
 

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -94,9 +94,6 @@ fn link_libraries() {
 }
 
 fn build_bundled_cmake() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
-    if let Ok(jobs) = std::env::var("NUM_THREADS") {
-        std::env::set_var("NUM_JOBS", jobs);
-    }
     let kuzu_root = {
         let root = Path::new(&std::env::var("CARGO_MANIFEST_DIR").unwrap()).join("kuzu-src");
         if root.is_symlink() || root.is_dir() {


### PR DESCRIPTION
I realised that moving the arrow build in #1752 into the configure step means that it no longer respects the number of threads set in CI. However, the number of threads used can also be configured via the `CMAKE_BUILD_PARALLEL_LEVEL` environment variable, so I've set up the makefile to set that based on the value of `NUM_THREADS`.