### PR TITLE
fix concat-null

### DIFF
--- a/src/expression_evaluator/case_evaluator.cpp
+++ b/src/expression_evaluator/case_evaluator.cpp
@@ -93,9 +93,7 @@ void CaseExpressionEvaluator::fillEntry(sel_t resultPos, const ValueVector& then
         if (thenVector.dataType.getLogicalTypeID() == common::LogicalTypeID::VAR_LIST) {
             auto srcListEntry = thenVector.getValue<list_entry_t>(thenPos);
             list_entry_t resultEntry = ListVector::addList(resultVector.get(), srcListEntry.size);
-            resultVector->copyFromVectorData(reinterpret_cast<uint8_t*>(&resultEntry), &thenVector,
-                reinterpret_cast<uint8_t*>(&srcListEntry));
-            resultVector->setValue(resultPos, resultEntry);
+            resultVector->copyFromVectorData(resultPos, &thenVector, thenPos);
         } else {
             auto val = thenVector.getValue<T>(thenPos);
             resultVector->setValue<T>(resultPos, val);

--- a/src/function/vector_struct_operations.cpp
+++ b/src/function/vector_struct_operations.cpp
@@ -67,28 +67,14 @@ void StructPackVectorOperations::copyParameterValueToStructFieldVector(
     // If the parameter is unFlat, then its state must be consistent with the result's state.
     // Thus, we don't need to copy values to structFieldVector.
     assert(parameter->state->isFlat());
-    auto srcPos = parameter->state->selVector->selectedPositions[0];
-    auto srcValue = parameter->getData() + parameter->getNumBytesPerValue() * srcPos;
-    bool isSrcValueNull = parameter->isNull(srcPos);
+    auto paramPos = parameter->state->selVector->selectedPositions[0];
     if (structField->state->isFlat()) {
         auto pos = structField->state->selVector->selectedPositions[0];
-        if (isSrcValueNull) {
-            structField->setNull(pos, true /* isNull */);
-        } else {
-            structField->copyFromVectorData(
-                structField->getData() + structField->getNumBytesPerValue() * pos, parameter,
-                srcValue);
-        }
+        structField->copyFromVectorData(pos, parameter, paramPos);
     } else {
-        for (auto j = 0u; j < structField->state->selVector->selectedSize; j++) {
-            auto pos = structField->state->selVector->selectedPositions[j];
-            if (isSrcValueNull) {
-                structField->setNull(pos, true /* isNull */);
-            } else {
-                structField->copyFromVectorData(
-                    structField->getData() + structField->getNumBytesPerValue() * pos, parameter,
-                    srcValue);
-            }
+        for (auto i = 0u; i < structField->state->selVector->selectedSize; i++) {
+            auto pos = structField->state->selVector->selectedPositions[i];
+            structField->copyFromVectorData(pos, parameter, paramPos);
         }
     }
 }

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -56,11 +56,13 @@ public:
     void setValue(uint32_t pos, T val);
     // copyFromRowData assumes rowData is non-NULL.
     void copyFromRowData(uint32_t pos, const uint8_t* rowData);
-    // copyFromVectorData assumes srcVectorData is non-NULL.
+    // copyToRowData assumes srcVectorData is non-NULL.
     void copyToRowData(
         uint32_t pos, uint8_t* rowData, InMemOverflowBuffer* rowOverflowBuffer) const;
+    // copyFromVectorData assumes srcVectorData is non-NULL.
     void copyFromVectorData(
         uint8_t* dstData, const ValueVector* srcVector, const uint8_t* srcVectorData);
+    void copyFromVectorData(uint64_t posToCopy, const ValueVector* srcVector, uint64_t srcPos);
 
     inline uint8_t* getData() const { return valueBuffer.get(); }
 

--- a/src/include/function/list/operations/list_append_operation.h
+++ b/src/include/function/list/operations/list_append_operation.h
@@ -16,18 +16,16 @@ struct ListAppend {
         common::list_entry_t& result, common::ValueVector& listVector,
         common::ValueVector& valueVector, common::ValueVector& resultVector) {
         result = common::ListVector::addList(&resultVector, listEntry.size + 1);
-        auto listValues = common::ListVector::getListValues(&listVector, listEntry);
         auto listDataVector = common::ListVector::getDataVector(&listVector);
-        auto resultValues = common::ListVector::getListValues(&resultVector, result);
+        auto listPos = listEntry.offset;
         auto resultDataVector = common::ListVector::getDataVector(&resultVector);
-        auto numBytesPerValue = resultDataVector->getNumBytesPerValue();
+        auto resultPos = result.offset;
         for (auto i = 0u; i < listEntry.size; i++) {
-            resultDataVector->copyFromVectorData(resultValues, listDataVector, listValues);
-            listValues += numBytesPerValue;
-            resultValues += numBytesPerValue;
+            resultDataVector->copyFromVectorData(resultPos++, listDataVector, listPos++);
         }
         resultDataVector->copyFromVectorData(
-            resultValues, &valueVector, reinterpret_cast<uint8_t*>(&value));
+            resultDataVector->getData() + resultPos * resultDataVector->getNumBytesPerValue(),
+            &valueVector, reinterpret_cast<uint8_t*>(&value));
     }
 };
 

--- a/src/include/function/list/operations/list_concat_operation.h
+++ b/src/include/function/list/operations/list_concat_operation.h
@@ -15,22 +15,17 @@ public:
         common::list_entry_t& result, common::ValueVector& leftVector,
         common::ValueVector& rightVector, common::ValueVector& resultVector) {
         result = common::ListVector::addList(&resultVector, left.size + right.size);
-        auto leftValues = common::ListVector::getListValues(&leftVector, left);
-        auto leftDataVector = common::ListVector::getDataVector(&leftVector);
-        auto resultValues = common::ListVector::getListValues(&resultVector, result);
         auto resultDataVector = common::ListVector::getDataVector(&resultVector);
-        auto numBytesPerValue = resultDataVector->getNumBytesPerValue();
+        auto resultPos = result.offset;
+        auto leftDataVector = common::ListVector::getDataVector(&leftVector);
+        auto leftPos = left.offset;
         for (auto i = 0u; i < left.size; i++) {
-            resultDataVector->copyFromVectorData(resultValues, leftDataVector, leftValues);
-            resultValues += numBytesPerValue;
-            leftValues += numBytesPerValue;
+            resultDataVector->copyFromVectorData(resultPos++, leftDataVector, leftPos++);
         }
-        auto rightValues = common::ListVector::getListValues(&rightVector, right);
         auto rightDataVector = common::ListVector::getDataVector(&rightVector);
+        auto rightPos = right.offset;
         for (auto i = 0u; i < right.size; i++) {
-            resultDataVector->copyFromVectorData(resultValues, rightDataVector, rightValues);
-            resultValues += numBytesPerValue;
-            rightValues += numBytesPerValue;
+            resultDataVector->copyFromVectorData(resultPos++, rightDataVector, rightPos++);
         }
     }
 };

--- a/src/include/function/list/operations/list_prepend_operation.h
+++ b/src/include/function/list/operations/list_prepend_operation.h
@@ -15,18 +15,15 @@ struct ListPrepend {
         common::list_entry_t& result, common::ValueVector& valueVector,
         common::ValueVector& listVector, common::ValueVector& resultVector) {
         result = common::ListVector::addList(&resultVector, listEntry.size + 1);
-        auto listValues = common::ListVector::getListValues(&listVector, listEntry);
-        auto listDataVector = common::ListVector::getDataVector(&listVector);
-        auto resultValues = common::ListVector::getListValues(&resultVector, result);
         auto resultDataVector = common::ListVector::getDataVector(&resultVector);
-        auto numBytesPerValue = resultDataVector->getNumBytesPerValue();
         resultDataVector->copyFromVectorData(
-            resultValues, &valueVector, reinterpret_cast<uint8_t*>(&value));
-        resultValues += numBytesPerValue;
+            common::ListVector::getListValues(&resultVector, result), &valueVector,
+            reinterpret_cast<uint8_t*>(&value));
+        auto resultPos = result.offset + 1;
+        auto listDataVector = common::ListVector::getDataVector(&listVector);
+        auto listPos = listEntry.offset;
         for (auto i = 0u; i < listEntry.size; i++) {
-            resultDataVector->copyFromVectorData(resultValues, listDataVector, listValues);
-            listValues += numBytesPerValue;
-            resultValues += numBytesPerValue;
+            resultDataVector->copyFromVectorData(resultPos++, listDataVector, listPos++);
         }
     }
 };

--- a/src/include/function/list/operations/list_slice_operation.h
+++ b/src/include/function/list/operations/list_slice_operation.h
@@ -18,17 +18,12 @@ struct ListSlice {
         int64_t startIdx = (begin == 0) ? 1 : begin;
         int64_t endIdx = (end == 0) ? listEntry.size : end;
         result = common::ListVector::addList(&resultVector, endIdx - startIdx);
-        auto srcValues =
-            common::ListVector::getListValuesWithOffset(&listVector, listEntry, startIdx - 1);
-        auto dstValues = common::ListVector::getListValues(&resultVector, result);
-        auto numBytesPerValue =
-            common::ListVector::getDataVector(&listVector)->getNumBytesPerValue();
         auto srcDataVector = common::ListVector::getDataVector(&listVector);
+        auto srcPos = listEntry.offset + startIdx - 1;
         auto dstDataVector = common::ListVector::getDataVector(&resultVector);
-        for (auto i = startIdx; i < endIdx; i++) {
-            dstDataVector->copyFromVectorData(dstValues, srcDataVector, srcValues);
-            srcValues += numBytesPerValue;
-            dstValues += numBytesPerValue;
+        auto dstPos = result.offset;
+        for (auto i = 0u; i < endIdx - startIdx; i++) {
+            dstDataVector->copyFromVectorData(dstPos++, srcDataVector, srcPos++);
         }
     }
 

--- a/src/include/function/map/operations/map_creation_operation.h
+++ b/src/include/function/map/operations/map_creation_operation.h
@@ -25,14 +25,11 @@ struct MapCreation {
 
     static void copyListEntry(common::list_entry_t& resultEntry, common::ValueVector* resultVector,
         common::list_entry_t& srcEntry, common::ValueVector* srcVector) {
-        auto resultValues =
-            resultVector->getData() + resultVector->getNumBytesPerValue() * resultEntry.offset;
-        auto srcValues = common::ListVector::getListValues(srcVector, srcEntry);
+        auto resultPos = resultEntry.offset;
         auto srcDataVector = common::ListVector::getDataVector(srcVector);
+        auto srcPos = srcEntry.offset;
         for (auto i = 0u; i < srcEntry.size; i++) {
-            resultVector->copyFromVectorData(resultValues, srcDataVector, srcValues);
-            srcValues += srcDataVector->getNumBytesPerValue();
-            resultValues += resultVector->getNumBytesPerValue();
+            resultVector->copyFromVectorData(resultPos++, srcDataVector, srcPos++);
         }
     }
 };

--- a/src/include/function/map/operations/map_extract_operation.h
+++ b/src/include/function/map/operations/map_extract_operation.h
@@ -14,7 +14,7 @@ struct MapExtract {
         auto mapKeyVector = common::MapVector::getKeyVector(&listVector);
         auto mapKeyValues = common::MapVector::getMapKeys(&listVector, listEntry);
         auto mapValVector = common::MapVector::getValueVector(&listVector);
-        auto mapValValues = common::MapVector::getMapValues(&listVector, listEntry);
+        auto mapValPos = listEntry.offset;
         uint8_t comparisonResult;
         for (auto i = 0u; i < listEntry.size; i++) {
             Equals::operation(*reinterpret_cast<T*>(mapKeyValues), key, comparisonResult,
@@ -22,13 +22,11 @@ struct MapExtract {
             if (comparisonResult) {
                 resultEntry = common::ListVector::addList(&resultVector, 1 /* size */);
                 common::ListVector::getDataVector(&resultVector)
-                    ->copyFromVectorData(
-                        common::ListVector::getListValues(&resultVector, resultEntry), mapValVector,
-                        mapValValues);
+                    ->copyFromVectorData(resultEntry.offset, mapValVector, mapValPos);
                 return;
             }
             mapKeyValues += mapKeyVector->getNumBytesPerValue();
-            mapValValues += mapValVector->getNumBytesPerValue();
+            mapValPos++;
         }
         // If the key is not found, return an empty list.
         resultEntry = common::ListVector::addList(&resultVector, 0 /* size */);

--- a/src/processor/operator/unwind.cpp
+++ b/src/processor/operator/unwind.cpp
@@ -15,15 +15,11 @@ bool Unwind::hasMoreToRead() const {
 }
 
 void Unwind::copyTuplesToOutVector(uint64_t startPos, uint64_t endPos) const {
-    auto listValues = common::ListVector::getListValuesWithOffset(
-        expressionEvaluator->resultVector.get(), listEntry, startPos);
     auto listDataVector =
         common::ListVector::getDataVector(expressionEvaluator->resultVector.get());
-    for (auto pos = startPos; pos < endPos; pos++) {
-        outValueVector->copyFromVectorData(
-            outValueVector->getData() + outValueVector->getNumBytesPerValue() * (pos - startPos),
-            listDataVector, listValues);
-        listValues += listDataVector->getNumBytesPerValue();
+    auto listPos = listEntry.offset + startPos;
+    for (auto i = 0u; i < endPos - startPos; i++) {
+        outValueVector->copyFromVectorData(i, listDataVector, listPos++);
     }
 }
 

--- a/test/test_files/tinysnb/function/list.test
+++ b/test/test_files/tinysnb/function/list.test
@@ -280,6 +280,41 @@ ad
 [[10],[40,40],[2]]
 [[7],[10],[6,7],[83,83],[2]]
 
+-LOG ListConcatEmpty
+-STATEMENT RETURN LIST_CONCAT([], [])
+---- 1
+[]
+
+-LOG ListConcatEmptyAndNull
+-STATEMENT RETURN LIST_CONCAT([], [NULL])
+---- 1
+[]
+
+-LOG ListConcatNullAndEmpty
+-STATEMENT RETURN LIST_CONCAT([NULL], [])
+---- 1
+[]
+
+-LOG ListConcatNullAndNull
+-STATEMENT RETURN LIST_CONCAT([NULL], [NULL])
+---- 1
+[,]
+
+-LOG ListConcatEmptyAndEmpty
+-STATEMENT RETURN LIST_CONCAT([], [])
+---- 1
+[]
+
+-LOG ListConcatINT64AndNull
+-STATEMENT RETURN LIST_CONCAT([1,2,NULL], [NULL])
+---- 1
+[1,2,,]
+
+-LOG ListConcatNullAndINT64
+-STATEMENT RETURN LIST_CONCAT([NULL], [NULL, 1, 3])
+---- 1
+[,,1,3]
+
 -LOG ListAppendListOfINT64
 -STATEMENT MATCH (a:person) RETURN list_append(a.workedHours, a.age)
 ---- 8


### PR DESCRIPTION
1. Fix concat-null function bug.
2. Added 
```
void ValueVector::copyFromVectorData(
    uint64_t posToCopy, const ValueVector* srcVector, uint64_t srcPos)
```
which removes the assumption that the srcValue must be null