### PR TITLE
Skip building kuzu when building docs for docs-rs

### DIFF
--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -166,6 +166,10 @@ fn build_bundled_cmake() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
 }
 
 fn main() {
+    if env::var("DOCS_RS").is_ok() {
+        // Do nothing; we're just building docs and don't need the C++ library
+        return;
+    }
     let mut build = cxx_build::bridge("src/ffi.rs");
     build.file("src/kuzu_rs.cpp");
 


### PR DESCRIPTION
[docs.rs](https://docs.rs/), which builds and hosts rust documentation, doesn't allow networked builds, however building the docs works fine if we just skip the cmake build and just build the rust code.