### PR TITLE
Added deployment workflow for rust API

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -205,6 +205,33 @@ jobs:
         with:
           password: ${{ secrets.PYPI_TOKEN }}
 
+  deploy-rust:
+    runs-on: kuzu-self-hosted-testing
+    env:
+      CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Update Cargo.toml version
+        run: python3 update_version.py
+        working-directory: tools/rust_api
+
+      - name: Deploy crate to Crates.io
+        run: cargo publish --allow-dirty
+        if: ${{ github.event.inputs.isDeploy == 'true' }}
+        working-directory: tools/rust_api
+
+      - name: Test publishing crate
+        run: cargo publish --dry-run --allow-dirty
+        if: ${{ github.event.inputs.isDeploy != 'true' }}
+        working-directory: tools/rust_api
+
+      - name: Upload crate
+        uses: actions/upload-artifact@v3
+        with:
+          name: kuzu-deploy-crate
+          path: tools/rust_api/target/package/*.crate
+
   build-precompiled-bin-mac:
     uses: ./.github/workflows/mac-precompiled-bin-workflow.yml
     secrets: inherit

--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kuzu"
-version = "0.0.4"
+version = "0.0.5"
 description = "An in-process property graph database management system built for query speed and scalability"
 # Note: 1.63 required for building tests
 rust-version = "1.51"

--- a/tools/rust_api/update_version.py
+++ b/tools/rust_api/update_version.py
@@ -1,0 +1,42 @@
+"""Updates the version in Cargo.toml to match the version in the main CMakeLists.txt"""
+
+import os
+import re
+from pathlib import Path
+
+KUZU_RS_ROOT = Path(__file__).parent
+KUZU_ROOT = KUZU_RS_ROOT.parent.parent
+
+
+def get_kuzu_version():
+    cmake_file = KUZU_ROOT / "CMakeLists.txt"
+    with open(cmake_file) as f:
+        for line in f:
+            if line.startswith("project(Kuzu VERSION"):
+                return line.split(" ")[2].strip()
+
+
+if __name__ == "__main__":
+    version = get_kuzu_version()
+    version_changed = False
+    with open(KUZU_RS_ROOT / "Cargo.toml", encoding="utf-8") as file:
+        data = file.readlines()
+        section = None
+        for index, line in enumerate(data):
+            if line.startswith("["):
+                section = line.strip().strip("[]")
+            if line.startswith("version = ") and section == "package":
+                toml_version = re.match('version = "(.*)"', line).group(1)
+                if toml_version != version:
+                    version_changed = True
+                    print(
+                        f"Updating version in Cargo.toml from {toml_version} to {version}"
+                    )
+                    data[index] = re.sub(
+                        'version = ".*"', f'version = "{version}"', line
+                    )
+                    break
+
+    if version_changed:
+        with open("Cargo.toml", "w", encoding="utf-8") as file:
+            file.writelines(data)


### PR DESCRIPTION
Note that this will publish the version as recorded in `tools/rust_api/Cargo.toml`, so that will need to be updated before the deployment pipeline is triggered.

Alternatively we could have a script which detects the version and rewrites the file to use the most up to date version, but it would be helpful to keep the version up to date so that anyone adding kuzu as a git dependency sees a meaningful version.