### PR TITLE
Remove openssl linking for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ ifeq ($(OS),Windows_NT)
 	cargo test -- --test-threads=1
 else
 	cd $(ROOT_DIR)/tools/rust_api && \
-	CARGO_BUILD_JOBS=$(NUM_THREADS) KUZU_TESTING=1 cargo test -- --test-threads=1
+	CARGO_BUILD_JOBS=$(NUM_THREADS) cargo test -- --test-threads=1
 endif
 
 clean-python-api:

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -66,18 +66,10 @@ fn link_libraries() {
         }
 
         println!("cargo:rustc-link-lib=static=arrow_bundled_dependencies");
-        // arrow's bundled dependencies link against openssl when it's on the system, whether
-        // requested or not.
-        // Only seems to be necessary when building tests.
-        if env::var("KUZU_TESTING").is_ok() {
-            if cfg!(windows) {
-                find_openssl_windows();
-                println!("cargo:rustc-link-lib=dylib=libssl");
-                println!("cargo:rustc-link-lib=dylib=libcrypto");
-            } else {
-                println!("cargo:rustc-link-lib=dylib=ssl");
-                println!("cargo:rustc-link-lib=dylib=crypto");
-            }
+        if env::var("KUZU_TESTING").is_ok() && cfg!(windows) {
+            find_openssl_windows();
+            println!("cargo:rustc-link-lib=dylib=libssl");
+            println!("cargo:rustc-link-lib=dylib=libcrypto");
         }
 
         if cfg!(windows) {


### PR DESCRIPTION
No longer appears to be necessary. It will have to be partially added back in by #1582 since it needs to link against the crypto library, which is why I left the `find_openssl_windows` function.