### PR TITLE
Add functions exposing conversion to Arrow ArrayData

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -72,15 +72,20 @@ jobs:
       # Share build cache when building rust API and the example project
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       CARGO_BUILD_JOBS: 32
+      CC: gcc
+      CXX: g++
     steps:
       - uses: actions/checkout@v3
 
       - name: Rust test
-        run: CC=gcc CXX=g++ make rusttest NUM_THREADS=32
+        working-directory: tools/rust_api
+        run: |
+          cargo update -p half@2.3.1 --precise '2.2.1'
+          cargo test --features arrow -- --test-threads=1
 
       - name: Rust example
         working-directory: examples/rust
-        run: CC=gcc CXX=g++ cargo build
+        run: cargo build
 
   gcc-build-test-with-asan:
     name: gcc build & test with asan
@@ -155,6 +160,10 @@ jobs:
     name: msvc build & test
     needs: [clang-formatting-check]
     runs-on: self-hosted-windows
+    env:
+      # Shorten build path as much as possible
+      CARGO_TARGET_DIR: ${{ github.workspace }}/rs
+      CARGO_BUILD_JOBS: 18
     steps:
       - uses: actions/checkout@v3
 
@@ -166,12 +175,16 @@ jobs:
 
       - name: Rust test
         shell: cmd
+        working-directory: tools/rust_api
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
-          set CARGO_TARGET_DIR=%cd%/rustb
-          make rusttest NUM_THREADS=18
-      
+          set KUZU_TESTING=1
+          set CFLAGS=/MDd
+          set CXXFLAGS=/MDd /std:c++20
+          cargo update -p half@2.3.1 --precise 2.2.1
+          cargo test -- --test-threads=1
+
       - name: Java test
         shell: cmd
         run: |

--- a/Makefile
+++ b/Makefile
@@ -127,10 +127,10 @@ ifeq ($(OS),Windows_NT)
 	set KUZU_TESTING=1 && \
 	set CFLAGS=/MDd && \
 	set CXXFLAGS=/MDd /std:c++20 && \
-	cargo test -- --test-threads=1
+	cargo test --features arrow -- --test-threads=1
 else
 	cd $(ROOT_DIR)/tools/rust_api && \
-	CARGO_BUILD_JOBS=$(NUM_THREADS) cargo test -- --test-threads=1
+	CARGO_BUILD_JOBS=$(NUM_THREADS) cargo test --features arrow -- --test-threads=1
 endif
 
 clean-python-api:

--- a/src/c_api/query_result.cpp
+++ b/src/c_api/query_result.cpp
@@ -95,3 +95,12 @@ void kuzu_query_result_write_to_csv(kuzu_query_result* query_result, const char*
 void kuzu_query_result_reset_iterator(kuzu_query_result* query_result) {
     static_cast<QueryResult*>(query_result->_query_result)->resetIterator();
 }
+
+struct ArrowSchema kuzu_query_result_get_arrow_schema(kuzu_query_result* query_result) {
+    return *static_cast<QueryResult*>(query_result->_query_result)->getArrowSchema();
+}
+
+struct ArrowArray kuzu_query_result_get_next_arrow_chunk(
+    kuzu_query_result* query_result, int64_t chunk_size) {
+    return *static_cast<QueryResult*>(query_result->_query_result)->getNextArrowChunk(chunk_size);
+}

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/api.h"
+#include "common/arrow/arrow.h"
 #include "common/types/types.h"
 #include "kuzu_fwd.h"
 #include "processor/result/flat_tuple.h"
@@ -69,7 +70,7 @@ public:
      */
     KUZU_API QuerySummary* getQuerySummary() const;
 
-    std::vector<std::unique_ptr<DataTypeInfo>> getColumnTypesInfo();
+    std::vector<std::unique_ptr<DataTypeInfo>> getColumnTypesInfo() const;
     /**
      * @return whether there are more tuples to read.
      */
@@ -95,6 +96,25 @@ public:
     KUZU_API void resetIterator();
 
     processor::FactorizedTable* getTable() { return factorizedTable.get(); }
+
+    /**
+     * @return datatypes of the columns as an arrow schema
+     *
+     * It is the caller's responsibility to call the release function to release the underlying data
+     * If converting to another arrow type, this this is usually handled automatically.
+     */
+    std::unique_ptr<ArrowSchema> getArrowSchema() const;
+
+    /**
+     * @return An arrow array representation of the next chunkSize tuples of the query result.
+     *
+     * The ArrowArray internally stores an arrow struct with fields for each of the columns.
+     * This can be converted to a RecordBatch with arrow's ImportRecordBatch function
+     *
+     * It is the caller's responsibility to call the release function to release the underlying data
+     * If converting to another arrow type, this this is usually handled automatically.
+     */
+    std::unique_ptr<ArrowArray> getNextArrowChunk(int64_t chunkSize);
 
 private:
     void initResultTableAndIterator(std::shared_ptr<processor::FactorizedTable> factorizedTable_,

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -4,6 +4,7 @@
 
 #include "binder/expression/node_rel_expression.h"
 #include "binder/expression/property_expression.h"
+#include "common/arrow/arrow_converter.h"
 #include "json.hpp"
 #include "processor/result/factorized_table.h"
 #include "processor/result/flat_tuple.h"
@@ -77,7 +78,7 @@ void QueryResult::resetIterator() {
     iterator->resetState();
 }
 
-std::vector<std::unique_ptr<DataTypeInfo>> QueryResult::getColumnTypesInfo() {
+std::vector<std::unique_ptr<DataTypeInfo>> QueryResult::getColumnTypesInfo() const {
     std::vector<std::unique_ptr<DataTypeInfo>> result;
     for (auto i = 0u; i < columnDataTypes.size(); i++) {
         auto columnTypeInfo = DataTypeInfo::getInfoForDataType(columnDataTypes[i], columnNames[i]);
@@ -234,6 +235,16 @@ void QueryResult::validateQuerySucceed() const {
     if (!success) {
         throw Exception(errMsg);
     }
+}
+
+std::unique_ptr<ArrowSchema> QueryResult::getArrowSchema() const {
+    return kuzu::common::ArrowConverter::toArrowSchema(getColumnTypesInfo());
+}
+
+std::unique_ptr<ArrowArray> QueryResult::getNextArrowChunk(int64_t chunkSize) {
+    auto data = std::make_unique<ArrowArray>();
+    kuzu::common::ArrowConverter::toArrowArray(*this, data.get(), chunkSize);
+    return data;
 }
 
 } // namespace main

--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -31,6 +31,7 @@ cxx = "1.0"
 num-derive = "0.3"
 num-traits = "0.2"
 time = "0.3"
+arrow = {version="43", optional=true, default-features=false, features=["ffi"]}
 
 [build-dependencies]
 cxx-build = "1.0"
@@ -43,3 +44,7 @@ which = "4"
 tempfile = "3"
 anyhow = "1"
 time = {version="0.3", features=["macros"]}
+
+[features]
+default = []
+arrow = ["dep:arrow"]

--- a/tools/rust_api/include/kuzu_arrow.h
+++ b/tools/rust_api/include/kuzu_arrow.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "rust/cxx.h"
+#ifdef KUZU_BUNDLED
+#include "main/kuzu.h"
+#else
+#include <kuzu.hpp>
+#endif
+
+namespace kuzu_arrow {
+
+ArrowSchema query_result_get_arrow_schema(const kuzu::main::QueryResult& result);
+ArrowArray query_result_get_next_arrow_chunk(kuzu::main::QueryResult& result, uint64_t chunkSize);
+
+} // namespace kuzu_arrow

--- a/tools/rust_api/src/error.rs
+++ b/tools/rust_api/src/error.rs
@@ -10,6 +10,8 @@ pub enum Error {
     FailedPreparedStatement(String),
     /// Message produced when you attempt to pass read-only types over the FFI boundary
     ReadOnlyType(LogicalType),
+    #[cfg(feature = "arrow")]
+    ArrowError(arrow::error::ArrowError),
 }
 
 impl std::fmt::Display for Error {
@@ -20,6 +22,8 @@ impl std::fmt::Display for Error {
             FailedQuery(message) => write!(f, "Query execution failed: {message}"),
             FailedPreparedStatement(message) => write!(f, "Query execution failed: {message}"),
             ReadOnlyType(typ) => write!(f, "Attempted to pass read only type {:?} over ffi!", typ),
+            #[cfg(feature = "arrow")]
+            ArrowError(err) => write!(f, "{}", err),
         }
     }
 }
@@ -43,5 +47,12 @@ impl std::error::Error for Error {
 impl From<cxx::Exception> for Error {
     fn from(item: cxx::Exception) -> Self {
         Error::CxxException(item)
+    }
+}
+
+#[cfg(feature = "arrow")]
+impl From<arrow::error::ArrowError> for Error {
+    fn from(item: arrow::error::ArrowError) -> Self {
+        Error::ArrowError(item)
     }
 }

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -1,3 +1,6 @@
+#[cfg(feature = "arrow")]
+pub(crate) mod arrow;
+
 #[allow(clippy::module_inception)]
 #[cxx::bridge]
 pub(crate) mod ffi {

--- a/tools/rust_api/src/ffi/arrow.rs
+++ b/tools/rust_api/src/ffi/arrow.rs
@@ -1,0 +1,42 @@
+#[repr(transparent)]
+pub struct ArrowArray(pub arrow::ffi::FFI_ArrowArray);
+
+#[repr(transparent)]
+pub struct ArrowSchema(pub arrow::ffi::FFI_ArrowSchema);
+
+unsafe impl cxx::ExternType for ArrowArray {
+    type Id = cxx::type_id!("ArrowArray");
+    type Kind = cxx::kind::Trivial;
+}
+
+unsafe impl cxx::ExternType for ArrowSchema {
+    type Id = cxx::type_id!("ArrowSchema");
+    type Kind = cxx::kind::Trivial;
+}
+
+#[cxx::bridge]
+pub(crate) mod ffi_arrow {
+    unsafe extern "C++" {
+        include!("kuzu/include/kuzu_arrow.h");
+
+        #[namespace = "kuzu::main"]
+        type QueryResult = crate::ffi::ffi::QueryResult;
+    }
+
+    unsafe extern "C++" {
+        type ArrowArray = crate::ffi::arrow::ArrowArray;
+
+        #[namespace = "kuzu_arrow"]
+        fn query_result_get_next_arrow_chunk(
+            result: Pin<&mut QueryResult>,
+            chunk_size: u64,
+        ) -> Result<ArrowArray>;
+    }
+
+    unsafe extern "C++" {
+        type ArrowSchema = crate::ffi::arrow::ArrowSchema;
+
+        #[namespace = "kuzu_arrow"]
+        fn query_result_get_arrow_schema(result: &QueryResult) -> Result<ArrowSchema>;
+    }
+}

--- a/tools/rust_api/src/kuzu_arrow.cpp
+++ b/tools/rust_api/src/kuzu_arrow.cpp
@@ -1,0 +1,15 @@
+#include "kuzu_arrow.h"
+
+namespace kuzu_arrow {
+
+ArrowSchema query_result_get_arrow_schema(const kuzu::main::QueryResult& result) {
+    // Could use directly, except that we can't (yet) mark ArrowSchema as being safe to store in a
+    // cxx::UniquePtr
+    return *result.getArrowSchema();
+}
+
+ArrowArray query_result_get_next_arrow_chunk(kuzu::main::QueryResult& result, uint64_t chunkSize) {
+    return *result.getNextArrowChunk(chunkSize);
+}
+
+} // namespace kuzu_arrow

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -52,3 +52,6 @@ pub use error::Error;
 pub use logical_type::LogicalType;
 pub use query_result::{CSVOptions, QueryResult};
 pub use value::{InternalID, NodeVal, RelVal, Value};
+
+#[cfg(feature = "arrow")]
+pub use query_result::ArrowIterator;


### PR DESCRIPTION
Fixes #1804

I've added functions to the C and C++ API which allow conversion of query result data to the structures defined in the [Arrow C Data Interface](https://arrow.apache.org/docs/format/CDataInterface.html#structure-definitions).

The rust API takes this a step further and, similarly to the python API, converts it to the `arrow::array::ArrayData` type (which seems a little difficult to use by itself, but converting it to more ergonomic types requires a lot of copying and probably has poor performance, so I thought it best to leave it as ArrayData and let the user decide if they want to use it directly or convert it).
The arrow conversion is hidden behind an `arrow` feature to avoid pulling in the large arrow crate by default.

Rust test will probably fail with the arrow feature. Testing locally the latest version of one of the arrow-rs dependencies requires rust 1.70, which is very recent; I had to manually force it to use an earlier version to get it to build on rust 1.69.
