### PR TITLE
Fix bugs in Connection::interrupt

### DIFF
--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -15,6 +15,8 @@ struct ActiveQuery {
     explicit ActiveQuery();
     std::atomic<bool> interrupted;
     common::Timer timer;
+
+    void reset();
 };
 
 /**
@@ -33,12 +35,12 @@ public:
 
     ~ClientContext() = default;
 
-    inline void interrupt() { activeQuery->interrupted = true; }
+    inline void interrupt() { activeQuery.interrupted = true; }
 
-    bool isInterrupted() const { return activeQuery->interrupted; }
+    bool isInterrupted() const { return activeQuery.interrupted; }
 
     inline bool isTimeOut() {
-        return isTimeOutEnabled() && activeQuery->timer.getElapsedTimeInMS() > timeoutInMS;
+        return isTimeOutEnabled() && activeQuery.timer.getElapsedTimeInMS() > timeoutInMS;
     }
 
     inline bool isTimeOutEnabled() const { return timeoutInMS != 0; }
@@ -48,8 +50,10 @@ public:
     std::string getCurrentSetting(std::string optionName);
 
 private:
+    inline void resetActiveQuery() { activeQuery.reset(); }
+
     uint64_t numThreadsForExecution;
-    std::unique_ptr<ActiveQuery> activeQuery;
+    ActiveQuery activeQuery;
     uint64_t timeoutInMS;
 };
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -10,13 +10,18 @@ namespace main {
 
 ActiveQuery::ActiveQuery() : interrupted{false} {}
 
+void ActiveQuery::reset() {
+    interrupted = false;
+    timer = common::Timer();
+}
+
 ClientContext::ClientContext()
     : numThreadsForExecution{std::thread::hardware_concurrency()},
       timeoutInMS{common::ClientContextConstants::TIMEOUT_IN_MS} {}
 
 void ClientContext::startTimingIfEnabled() {
     if (isTimeOutEnabled()) {
-        activeQuery->timer.start();
+        activeQuery.timer.start();
     }
 }
 

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -280,7 +280,7 @@ std::string Connection::getRelPropertyNames(const std::string& relTableName) {
 }
 
 void Connection::interrupt() {
-    clientContext->activeQuery->interrupted = true;
+    clientContext->interrupt();
 }
 
 void Connection::setQueryTimeOut(uint64_t timeoutInMS) {
@@ -328,7 +328,7 @@ void Connection::bindParametersNoLock(PreparedStatement* preparedStatement,
 
 std::unique_ptr<QueryResult> Connection::executeAndAutoCommitIfNecessaryNoLock(
     PreparedStatement* preparedStatement, uint32_t planIdx) {
-    clientContext->activeQuery = std::make_unique<ActiveQuery>();
+    clientContext->resetActiveQuery();
     clientContext->startTimingIfEnabled();
     auto mapper = PlanMapper(
         *database->storageManager, database->memoryManager.get(), database->catalog.get());

--- a/test/runner/e2e_copy_transaction_test.cpp
+++ b/test/runner/e2e_copy_transaction_test.cpp
@@ -80,7 +80,7 @@ public:
         auto physicalPlan =
             mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
                 preparedStatement->statementResult->getColumns());
-        clientContext->activeQuery = std::make_unique<ActiveQuery>();
+        clientContext->resetActiveQuery();
         getQueryProcessor(*database)->execute(physicalPlan.get(), executionContext.get());
         auto tableID = catalog->getReadOnlyVersion()->getTableID("person");
         validateDatabaseStateBeforeCheckPointCopyNode(tableID);
@@ -159,7 +159,7 @@ public:
         auto physicalPlan =
             mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
                 preparedStatement->statementResult->getColumns());
-        clientContext->activeQuery = std::make_unique<ActiveQuery>();
+        clientContext->resetActiveQuery();
         getQueryProcessor(*database)->execute(physicalPlan.get(), executionContext.get());
         auto tableID = catalog->getReadOnlyVersion()->getTableID("knows");
         validateDatabaseStateBeforeCheckPointCopyRel(tableID);

--- a/test/runner/e2e_ddl_test.cpp
+++ b/test/runner/e2e_ddl_test.cpp
@@ -277,7 +277,7 @@ public:
         auto physicalPlan =
             mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
                 preparedStatement->statementResult->getColumns());
-        executionContext->clientContext->activeQuery = std::make_unique<ActiveQuery>();
+        executionContext->clientContext->resetActiveQuery();
         getQueryProcessor(*database)->execute(physicalPlan.get(), executionContext.get());
     }
 


### PR DESCRIPTION
This is related to one of the failing tests in #1825, `CApiConnectionTest.Interrupt`. ~~But this still doesn't seem to fix it as I'm still getting a hung process when running it with asan locally.~~ (Fixed) However it was originally also sometimes segfaulting when I tested it locally, and that doesn't happen any more.

Previously, interrupting before a query has executed would mean the activeQuery would be null when interrupt tries to set its interrupted flag.
Additionally, the detached thread in the test might not call the interrupt function until after the connection has been destroyed.

~~I removed the activeQuery entirely since assigning to a `unique_ptr` is not atomic, so attempting to interrupt when a query starts might cause it to write to the old memory location after it has been deleted and replaced with a new activeQuery object (unlikely, but I think is possible if a context switch occurs at the wrong time). And it only seemed to be used to initialize the interrupted flag and the timer, which could be done from a simple function instead without the possibility of memory errors.~~ (re-added following feedback on slack)

Note that it's still possible for there to be a data race if you interrupt at around the same time the interrupted field gets reset when the query starts. That could probably be handled by providing a return value indicating if the interruption occurred when the query is actually running.