### PR TITLE
Catch exception during finalize phase

### DIFF
--- a/src/common/task_system/task.cpp
+++ b/src/common/task_system/task.cpp
@@ -18,7 +18,9 @@ void Task::deRegisterThreadAndFinalizeTaskIfNecessary() {
     lock_t lck{mtx};
     ++numThreadsFinished;
     if (!hasExceptionNoLock() && isCompletedNoLock()) {
-        finalizeIfNecessary();
+        try {
+            finalizeIfNecessary();
+        } catch (std::exception& e) { setExceptionNoLock(std::current_exception()); }
     }
 }
 

--- a/src/include/common/task_system/task.h
+++ b/src/include/common/task_system/task.h
@@ -66,9 +66,7 @@ public:
 
     inline void setException(std::exception_ptr exceptionPtr) {
         lock_t lck{mtx};
-        if (this->exceptionsPtr == nullptr) {
-            this->exceptionsPtr = exceptionPtr;
-        }
+        setExceptionNoLock(exceptionPtr);
     }
 
     inline bool hasException() {
@@ -87,6 +85,12 @@ private:
     }
 
     inline bool hasExceptionNoLock() const { return exceptionsPtr != nullptr; }
+
+    inline void setExceptionNoLock(std::exception_ptr exceptionPtr) {
+        if (exceptionsPtr == nullptr) {
+            exceptionsPtr = exceptionPtr;
+        }
+    }
 
 public:
     Task* parent = nullptr;


### PR DESCRIPTION
- Add `try/catch` for `finalizeIfNecessary`.
- Remove `waitAllTasksToCompleteOrError` and `waitUntilEnoughTasksFinish`.