### PR TITLE
Fix nested value iteration

### DIFF
--- a/src/c_api/value.cpp
+++ b/src/c_api/value.cpp
@@ -258,19 +258,19 @@ char* kuzu_value_to_string(kuzu_value* value) {
 }
 
 kuzu_value* kuzu_node_val_get_id_val(kuzu_value* node_val) {
-    //    auto id_val = NodeVal::getNodeIDVal(static_cast<Value*>(node_val->_value));
-    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    //    c_value->_value = id_val.release();
-    //    c_value->_is_owned_by_cpp = false;
-    //    return c_value;
+    auto id_val = NodeVal::getNodeIDVal(static_cast<Value*>(node_val->_value));
+    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    c_value->_value = id_val;
+    c_value->_is_owned_by_cpp = true;
+    return c_value;
 }
 
 kuzu_value* kuzu_node_val_get_label_val(kuzu_value* node_val) {
-    //    auto label_val = NodeVal::getLabelVal(static_cast<Value*>(node_val->_value));
-    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    //    c_value->_value = label_val.release();
-    //    c_value->_is_owned_by_cpp = false;
-    //    return c_value;
+    auto label_val = NodeVal::getLabelVal(static_cast<Value*>(node_val->_value));
+    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    c_value->_value = label_val;
+    c_value->_is_owned_by_cpp = true;
+    return c_value;
 }
 
 kuzu_internal_id_t kuzu_node_val_get_id(kuzu_value* node_val) {
@@ -315,19 +315,19 @@ char* kuzu_node_val_to_string(kuzu_value* node_val) {
 }
 
 kuzu_value* kuzu_rel_val_get_src_id_val(kuzu_value* rel_val) {
-    //    auto src_id_val = RelVal::getSrcNodeIDVal(static_cast<Value*>(rel_val->_value));
-    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    //    c_value->_value = src_id_val.release();
-    //    c_value->_is_owned_by_cpp = false;
-    //    return c_value;
+    auto src_id_val = RelVal::getSrcNodeIDVal(static_cast<Value*>(rel_val->_value));
+    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    c_value->_value = src_id_val;
+    c_value->_is_owned_by_cpp = true;
+    return c_value;
 }
 
 kuzu_value* kuzu_rel_val_get_dst_id_val(kuzu_value* rel_val) {
-    //    auto dst_id_val = RelVal::getDstNodeIDVal(static_cast<Value*>(rel_val->_value));
-    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    //    c_value->_value = dst_id_val.release();
-    //    c_value->_is_owned_by_cpp = false;
-    //    return c_value;
+    auto dst_id_val = RelVal::getDstNodeIDVal(static_cast<Value*>(rel_val->_value));
+    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    c_value->_value = dst_id_val;
+    c_value->_is_owned_by_cpp = true;
+    return c_value;
 }
 
 kuzu_internal_id_t kuzu_rel_val_get_src_id(kuzu_value* rel_val) {

--- a/src/c_api/value.cpp
+++ b/src/c_api/value.cpp
@@ -127,17 +127,15 @@ void kuzu_value_destroy(kuzu_value* value) {
 }
 
 uint64_t kuzu_value_get_list_size(kuzu_value* value) {
-    auto& list_val = static_cast<Value*>(value->_value)->getListValReference();
-    return list_val.size();
+    return NestedVal::getChildrenSize(static_cast<Value*>(value->_value));
 }
 
 kuzu_value* kuzu_value_get_list_element(kuzu_value* value, uint64_t index) {
-    auto& list_val = static_cast<Value*>(value->_value)->getListValReference();
-    if (index >= list_val.size()) {
+    auto listValue = static_cast<Value*>(value->_value);
+    if (index >= NestedVal::getChildrenSize(listValue)) {
         return nullptr;
     }
-    auto& list_element = list_val[index];
-    auto val = list_element.get();
+    auto val = NestedVal::getChildVal(listValue, index);
     auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
     c_value->_value = val;
     c_value->_is_owned_by_cpp = true;
@@ -260,19 +258,19 @@ char* kuzu_value_to_string(kuzu_value* value) {
 }
 
 kuzu_value* kuzu_node_val_get_id_val(kuzu_value* node_val) {
-    auto id_val = NodeVal::getNodeIDVal(static_cast<Value*>(node_val->_value));
-    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    c_value->_value = id_val.release();
-    c_value->_is_owned_by_cpp = false;
-    return c_value;
+    //    auto id_val = NodeVal::getNodeIDVal(static_cast<Value*>(node_val->_value));
+    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    //    c_value->_value = id_val.release();
+    //    c_value->_is_owned_by_cpp = false;
+    //    return c_value;
 }
 
 kuzu_value* kuzu_node_val_get_label_val(kuzu_value* node_val) {
-    auto label_val = NodeVal::getLabelVal(static_cast<Value*>(node_val->_value));
-    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    c_value->_value = label_val.release();
-    c_value->_is_owned_by_cpp = false;
-    return c_value;
+    //    auto label_val = NodeVal::getLabelVal(static_cast<Value*>(node_val->_value));
+    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    //    c_value->_value = label_val.release();
+    //    c_value->_is_owned_by_cpp = false;
+    //    return c_value;
 }
 
 kuzu_internal_id_t kuzu_node_val_get_id(kuzu_value* node_val) {
@@ -302,7 +300,7 @@ char* kuzu_node_val_get_property_name_at(kuzu_value* node_val, uint64_t index) {
 }
 
 kuzu_value* kuzu_node_val_get_property_value_at(kuzu_value* node_val, uint64_t index) {
-    auto value = NodeVal::getPropertyValueReference(static_cast<Value*>(node_val->_value), index);
+    auto value = NodeVal::getPropertyVal(static_cast<Value*>(node_val->_value), index);
     auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
     c_value->_value = value;
     c_value->_is_owned_by_cpp = true;
@@ -317,19 +315,19 @@ char* kuzu_node_val_to_string(kuzu_value* node_val) {
 }
 
 kuzu_value* kuzu_rel_val_get_src_id_val(kuzu_value* rel_val) {
-    auto src_id_val = RelVal::getSrcNodeIDVal(static_cast<Value*>(rel_val->_value));
-    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    c_value->_value = src_id_val.release();
-    c_value->_is_owned_by_cpp = false;
-    return c_value;
+    //    auto src_id_val = RelVal::getSrcNodeIDVal(static_cast<Value*>(rel_val->_value));
+    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    //    c_value->_value = src_id_val.release();
+    //    c_value->_is_owned_by_cpp = false;
+    //    return c_value;
 }
 
 kuzu_value* kuzu_rel_val_get_dst_id_val(kuzu_value* rel_val) {
-    auto dst_id_val = RelVal::getDstNodeIDVal(static_cast<Value*>(rel_val->_value));
-    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
-    c_value->_value = dst_id_val.release();
-    c_value->_is_owned_by_cpp = false;
-    return c_value;
+    //    auto dst_id_val = RelVal::getDstNodeIDVal(static_cast<Value*>(rel_val->_value));
+    //    auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
+    //    c_value->_value = dst_id_val.release();
+    //    c_value->_is_owned_by_cpp = false;
+    //    return c_value;
 }
 
 kuzu_internal_id_t kuzu_rel_val_get_src_id(kuzu_value* rel_val) {
@@ -366,7 +364,7 @@ char* kuzu_rel_val_get_property_name_at(kuzu_value* rel_val, uint64_t index) {
 }
 
 kuzu_value* kuzu_rel_val_get_property_value_at(kuzu_value* rel_val, uint64_t index) {
-    auto value = RelVal::getPropertyValueReference(static_cast<Value*>(rel_val->_value), index);
+    auto value = RelVal::getPropertyVal(static_cast<Value*>(rel_val->_value), index);
     auto* c_value = (kuzu_value*)malloc(sizeof(kuzu_value));
     c_value->_value = value;
     c_value->_is_owned_by_cpp = true;

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -192,7 +192,7 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::VAR_LIST>(
     ArrowVector* vector, const main::DataTypeInfo& typeInfo, Value* value, std::int64_t pos) {
     vector->data.resize((pos + 2) * sizeof(std::uint32_t));
     auto offsets = (std::uint32_t*)vector->data.data();
-    auto numElements = value->nestedTypeVal.size();
+    auto numElements = value->childrenSize;
     offsets[pos + 1] = offsets[pos] + numElements;
     auto numChildElements = offsets[pos + 1] + 1;
     auto currentNumBytesForChildValidity = vector->childData[0]->validity.size();
@@ -208,8 +208,8 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::VAR_LIST>(
                                    LogicalType{typeInfo.childrenTypesInfo[0]->typeID}));
     }
     for (auto i = 0u; i < numElements; i++) {
-        appendValue(vector->childData[0].get(), *typeInfo.childrenTypesInfo[0],
-            value->nestedTypeVal[i].get());
+        appendValue(
+            vector->childData[0].get(), *typeInfo.childrenTypesInfo[0], value->children[i].get());
     }
 }
 
@@ -226,15 +226,15 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::INTERNAL_ID>(
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::NODE>(
     ArrowVector* vector, const main::DataTypeInfo& typeInfo, Value* value, std::int64_t pos) {
-    appendValue(vector->childData[0].get(), *typeInfo.childrenTypesInfo[0],
-        NodeVal::getNodeIDVal(value).get());
-    appendValue(vector->childData[1].get(), *typeInfo.childrenTypesInfo[1],
-        NodeVal::getLabelVal(value).get());
+    appendValue(
+        vector->childData[0].get(), *typeInfo.childrenTypesInfo[0], NodeVal::getNodeIDVal(value));
+    appendValue(
+        vector->childData[1].get(), *typeInfo.childrenTypesInfo[1], NodeVal::getLabelVal(value));
     std::int64_t propertyId = 2;
     auto numProperties = NodeVal::getNumProperties(value);
     for (auto i = 0u; i < numProperties; i++) {
         auto name = NodeVal::getPropertyName(value, i);
-        auto val = NodeVal::getPropertyValueReference(value, i);
+        auto val = NodeVal::getPropertyVal(value, i);
         appendValue(
             vector->childData[propertyId].get(), *typeInfo.childrenTypesInfo[propertyId], val);
         propertyId++;
@@ -244,15 +244,15 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::NODE>(
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::REL>(
     ArrowVector* vector, const main::DataTypeInfo& typeInfo, Value* value, std::int64_t pos) {
-    appendValue(vector->childData[0].get(), *typeInfo.childrenTypesInfo[0],
-        RelVal::getSrcNodeIDVal(value).get());
-    appendValue(vector->childData[1].get(), *typeInfo.childrenTypesInfo[1],
-        RelVal::getDstNodeIDVal(value).get());
+    appendValue(
+        vector->childData[0].get(), *typeInfo.childrenTypesInfo[0], RelVal::getSrcNodeIDVal(value));
+    appendValue(
+        vector->childData[1].get(), *typeInfo.childrenTypesInfo[1], RelVal::getDstNodeIDVal(value));
     std::int64_t propertyId = 2;
     auto numProperties = NodeVal::getNumProperties(value);
     for (auto i = 0u; i < numProperties; i++) {
         auto name = NodeVal::getPropertyName(value, i);
-        auto val = NodeVal::getPropertyValueReference(value, i);
+        auto val = NodeVal::getPropertyVal(value, i);
         appendValue(
             vector->childData[propertyId].get(), *typeInfo.childrenTypesInfo[propertyId], val);
         propertyId++;

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -515,6 +515,7 @@ void Value::serialize(FileInfo* fileInfo, uint64_t& offset) const {
         throw NotImplementedException{"Value::serialize"};
     }
     }
+    SerDeser::serializeValue(childrenSize, fileInfo, offset);
 }
 
 std::unique_ptr<Value> Value::deserialize(kuzu::common::FileInfo* fileInfo, uint64_t& offset) {
@@ -560,6 +561,7 @@ std::unique_ptr<Value> Value::deserialize(kuzu::common::FileInfo* fileInfo, uint
         throw NotImplementedException{"Value::deserializeValue"};
     }
     }
+    SerDeser::deserializeValue(val->childrenSize, fileInfo, offset);
     val->setNull(isNull);
     return val;
 }

--- a/src/common/types/value.cpp
+++ b/src/common/types/value.cpp
@@ -17,7 +17,7 @@ LogicalType Value::getDataType() const {
     return dataType;
 }
 
-const LogicalType& Value::getDataTypeReference() const {
+const LogicalType& Value::getDataTypeRef() const {
     return dataType;
 }
 
@@ -72,11 +72,22 @@ Value Value::createDefaultValue(const LogicalType& dataType) {
         return Value(LogicalType{LogicalTypeID::STRING}, std::string(""));
     case LogicalTypeID::FLOAT:
         return Value((float_t)0);
+    case LogicalTypeID::FIXED_LIST: {
+        std::vector<std::unique_ptr<Value>> children;
+        auto childType = FixedListType::getChildType(&dataType);
+        for (auto i = 0u; i < FixedListType::getNumElementsInList(&dataType); ++i) {
+            children.push_back(std::make_unique<Value>(createDefaultValue(*childType)));
+        }
+        return Value(dataType, std::move(children));
+    }
     case LogicalTypeID::MAP:
-    case LogicalTypeID::VAR_LIST:
-    case LogicalTypeID::FIXED_LIST:
-    case LogicalTypeID::UNION: {
+    case LogicalTypeID::VAR_LIST: {
         return Value(dataType, std::vector<std::unique_ptr<Value>>{});
+    }
+    case LogicalTypeID::UNION: {
+        std::vector<std::unique_ptr<Value>> children;
+        children.push_back(std::make_unique<Value>(createNullValue()));
+        return Value(dataType, std::move(children));
     }
     case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::STRUCT:
@@ -143,9 +154,10 @@ Value::Value(LogicalType type, const std::string& val_)
     strVal = val_;
 }
 
-Value::Value(LogicalType dataType, std::vector<std::unique_ptr<Value>> vals)
+Value::Value(LogicalType dataType, std::vector<std::unique_ptr<Value>> children)
     : dataType{std::move(dataType)}, isNull_{false} {
-    nestedTypeVal = std::move(vals);
+    this->children = std::move(children);
+    childrenSize = this->children.size();
 }
 
 Value::Value(LogicalType dataType, const uint8_t* val_)
@@ -155,6 +167,7 @@ Value::Value(LogicalType dataType, const uint8_t* val_)
 
 Value::Value(const Value& other) : dataType{other.dataType}, isNull_{other.isNull_} {
     copyValueFrom(other);
+    childrenSize = other.childrenSize;
 }
 
 void Value::copyValueFrom(const uint8_t* value) {
@@ -197,16 +210,16 @@ void Value::copyValueFrom(const uint8_t* value) {
         copyFromVarList(*(ku_list_t*)value, *VarListType::getChildType(&dataType));
     } break;
     case LogicalTypeID::FIXED_LIST: {
-        nestedTypeVal = convertKUFixedListToVector(value);
+        copyFromFixedList(value);
     } break;
     case LogicalTypeID::UNION: {
-        nestedTypeVal = convertKUUnionToVector(value);
+        copyFromUnion(value);
     } break;
     case LogicalTypeID::NODE:
     case LogicalTypeID::REL:
     case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::STRUCT: {
-        copyFromKuStruct(value);
+        copyFromStruct(value);
     } break;
     default:
         throw RuntimeException("Data type " + LogicalTypeUtils::dataTypeToString(dataType) +
@@ -252,8 +265,8 @@ void Value::copyValueFrom(const Value& other) {
     case PhysicalTypeID::VAR_LIST:
     case PhysicalTypeID::FIXED_LIST:
     case PhysicalTypeID::STRUCT: {
-        for (auto& value : other.nestedTypeVal) {
-            nestedTypeVal.push_back(value->copy());
+        for (auto& child : other.children) {
+            children.push_back(child->copy());
         }
     } break;
     default:
@@ -261,10 +274,6 @@ void Value::copyValueFrom(const Value& other) {
                                       LogicalTypeUtils::dataTypeToString(dataType) +
                                       " is not implemented.");
     }
-}
-
-const std::vector<std::unique_ptr<Value>>& Value::getListValReference() const {
-    return nestedTypeVal;
 }
 
 std::string Value::toString() const {
@@ -298,21 +307,21 @@ std::string Value::toString() const {
         return strVal;
     case LogicalTypeID::MAP: {
         std::string result = "{";
-        for (auto i = 0u; i < nestedTypeValSize; ++i) {
-            auto structVal = nestedTypeVal[i].get();
-            result += structVal->nestedTypeVal[0]->toString();
+        for (auto i = 0u; i < childrenSize; ++i) {
+            auto structVal = children[i].get();
+            result += structVal->children[0]->toString();
             result += "=";
-            result += structVal->nestedTypeVal[1]->toString();
-            result += (i == nestedTypeVal.size() - 1 ? "}" : ", ");
+            result += structVal->children[1]->toString();
+            result += (i == childrenSize - 1 ? "}" : ", ");
         }
         return result;
     }
     case LogicalTypeID::VAR_LIST:
     case LogicalTypeID::FIXED_LIST: {
         std::string result = "[";
-        for (auto i = 0u; i < nestedTypeValSize; ++i) {
-            result += nestedTypeVal[i]->toString();
-            if (i != nestedTypeVal.size() - 1) {
+        for (auto i = 0u; i < childrenSize; ++i) {
+            result += children[i]->toString();
+            if (i != childrenSize - 1) {
                 result += ",";
             }
         }
@@ -322,16 +331,16 @@ std::string Value::toString() const {
     case LogicalTypeID::UNION: {
         // Only one member in the union can be active at a time and that member is always stored
         // at index 0.
-        return nestedTypeVal[0]->toString();
+        return children[0]->toString();
     }
     case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::STRUCT: {
         std::string result = "{";
         auto fieldNames = StructType::getFieldNames(&dataType);
-        for (auto i = 0u; i < nestedTypeValSize; ++i) {
+        for (auto i = 0u; i < childrenSize; ++i) {
             result += fieldNames[i] + ": ";
-            result += nestedTypeVal[i]->toString();
-            if (i != nestedTypeVal.size() - 1) {
+            result += children[i]->toString();
+            if (i != childrenSize - 1) {
                 result += ", ";
             }
         }
@@ -341,33 +350,33 @@ std::string Value::toString() const {
     case LogicalTypeID::NODE: {
         std::string result = "{";
         auto fieldNames = StructType::getFieldNames(&dataType);
-        for (auto i = 0u; i < nestedTypeValSize; ++i) {
-            if (nestedTypeVal[i]->isNull_) {
+        for (auto i = 0u; i < childrenSize; ++i) {
+            if (children[i]->isNull_) {
                 // Avoid printing null key value pair.
                 continue;
             }
             if (i != 0) {
                 result += ", ";
             }
-            result += fieldNames[i] + ": " + nestedTypeVal[i]->toString();
+            result += fieldNames[i] + ": " + children[i]->toString();
         }
         result += "}";
         return result;
     }
     case LogicalTypeID::REL: {
-        std::string result = "(" + nestedTypeVal[0]->toString() + ")-{";
+        std::string result = "(" + children[0]->toString() + ")-{";
         auto fieldNames = StructType::getFieldNames(&dataType);
-        for (auto i = 2u; i < nestedTypeValSize; ++i) {
-            if (nestedTypeVal[i]->isNull_) {
+        for (auto i = 2u; i < childrenSize; ++i) {
+            if (children[i]->isNull_) {
                 // Avoid printing null key value pair.
                 continue;
             }
             if (i != 2) {
                 result += ", ";
             }
-            result += fieldNames[i] + ": " + nestedTypeVal[i]->toString();
+            result += fieldNames[i] + ": " + children[i]->toString();
         }
-        result += "}->(" + nestedTypeVal[1]->toString() + ")";
+        result += "}->(" + children[1]->toString() + ")";
         return result;
     }
     default:
@@ -381,82 +390,64 @@ Value::Value() : dataType{LogicalTypeID::ANY}, isNull_{true} {}
 
 Value::Value(LogicalType dataType) : dataType{std::move(dataType)}, isNull_{true} {}
 
+void Value::copyFromFixedList(const uint8_t* fixedList) {
+    auto numBytesPerElement =
+        storage::StorageUtils::getDataTypeSize(*FixedListType::getChildType(&dataType));
+    for (auto i = 0; i < childrenSize; ++i) {
+        auto childValue = children[i].get();
+        childValue->copyValueFrom(fixedList + i * numBytesPerElement);
+    }
+}
+
 void Value::copyFromVarList(kuzu::common::ku_list_t& list, const LogicalType& childType) {
-    if (list.size > nestedTypeVal.size()) {
-        nestedTypeVal.reserve(list.size);
-        for (auto i = nestedTypeVal.size(); i < list.size; ++i) {
-            nestedTypeVal.push_back(std::make_unique<Value>(createDefaultValue(childType)));
+    if (list.size > children.size()) {
+        children.reserve(list.size);
+        for (auto i = children.size(); i < list.size; ++i) {
+            children.push_back(std::make_unique<Value>(createDefaultValue(childType)));
         }
     }
-    nestedTypeValSize = list.size;
+    childrenSize = list.size;
     auto numBytesPerElement = storage::StorageUtils::getDataTypeSize(childType);
     auto listNullBytes = reinterpret_cast<uint8_t*>(list.overflowPtr);
     auto numBytesForNullValues = NullBuffer::getNumBytesForNullValues(list.size);
     auto listValues = listNullBytes + numBytesForNullValues;
     for (auto i = 0; i < list.size; i++) {
-        auto childValue = nestedTypeVal[i].get();
+        auto childValue = children[i].get();
         if (NullBuffer::isNull(listNullBytes, i)) {
-            childValue->setNull();
+            childValue->setNull(true);
         } else {
+            childValue->setNull(false);
             childValue->copyValueFrom(listValues);
         }
         listValues += numBytesPerElement;
     }
 }
 
-std::vector<std::unique_ptr<Value>> Value::convertKUFixedListToVector(
-    const uint8_t* fixedList) const {
-    auto numElementsInList = FixedListType::getNumElementsInList(&dataType);
-    std::vector<std::unique_ptr<Value>> fixedListResultVal{numElementsInList};
-    auto childType = FixedListType::getChildType(&dataType);
-    auto numBytesPerElement = storage::StorageUtils::getDataTypeSize(*childType);
-    switch (childType->getLogicalTypeID()) {
-    case LogicalTypeID::INT64: {
-        putValuesIntoVector<int64_t>(fixedListResultVal, fixedList, numBytesPerElement);
-    } break;
-    case LogicalTypeID::INT32: {
-        putValuesIntoVector<int32_t>(fixedListResultVal, fixedList, numBytesPerElement);
-    } break;
-    case LogicalTypeID::INT16: {
-        putValuesIntoVector<int16_t>(fixedListResultVal, fixedList, numBytesPerElement);
-    } break;
-    case LogicalTypeID::DOUBLE: {
-        putValuesIntoVector<double_t>(fixedListResultVal, fixedList, numBytesPerElement);
-    } break;
-    case LogicalTypeID::FLOAT: {
-        putValuesIntoVector<float_t>(fixedListResultVal, fixedList, numBytesPerElement);
-    } break;
-    default:
-        assert(false);
-    }
-    return fixedListResultVal;
-}
-
-void Value::copyFromKuStruct(const uint8_t* kuStruct) const {
-    auto numFields = nestedTypeVal.size();
+void Value::copyFromStruct(const uint8_t* kuStruct) {
+    auto numFields = childrenSize;
     auto structNullValues = kuStruct;
     auto structValues = structNullValues + NullBuffer::getNumBytesForNullValues(numFields);
     for (auto i = 0; i < numFields; i++) {
-        auto childValue = nestedTypeVal[i].get();
+        auto childValue = children[i].get();
         if (NullBuffer::isNull(structNullValues, i)) {
             childValue->setNull(true);
         } else {
+            childValue->setNull(false);
             childValue->copyValueFrom(structValues);
         }
         structValues += storage::StorageUtils::getDataTypeSize(childValue->dataType);
     }
 }
 
-std::vector<std::unique_ptr<Value>> Value::convertKUUnionToVector(const uint8_t* kuUnion) const {
-    std::vector<std::unique_ptr<Value>> unionVal;
+void Value::copyFromUnion(const uint8_t* kuUnion) {
     auto childrenTypes = StructType::getFieldTypes(&dataType);
     auto unionNullValues = kuUnion;
     auto unionValues = unionNullValues + NullBuffer::getNumBytesForNullValues(childrenTypes.size());
     // For union dataType, only one member can be active at a time. So we don't need to copy all
     // union fields into value.
     auto activeMemberIdx = UnionType::getInternalFieldIdx(*(union_field_idx_t*)unionValues);
-    auto childValue =
-        std::make_unique<Value>(Value::createDefaultValue(*childrenTypes[activeMemberIdx]));
+    auto childValue = children[0].get();
+    childValue->dataType = *childrenTypes[activeMemberIdx];
     auto curMemberIdx = 0u;
     // Seek to the current active member value.
     while (curMemberIdx < activeMemberIdx) {
@@ -466,10 +457,20 @@ std::vector<std::unique_ptr<Value>> Value::convertKUUnionToVector(const uint8_t*
     if (NullBuffer::isNull(unionNullValues, activeMemberIdx)) {
         childValue->setNull(true);
     } else {
+        childValue->setNull(false);
         childValue->copyValueFrom(unionValues);
     }
-    unionVal.emplace_back(std::move(childValue));
-    return unionVal;
+}
+
+uint32_t NestedVal::getChildrenSize(const Value* val) {
+    return val->childrenSize;
+}
+
+Value* NestedVal::getChildVal(const Value* val, uint32_t idx) {
+    if (idx > val->childrenSize) {
+        throw common::RuntimeException("NestedVal::getChildPointer index out of bound.");
+    }
+    return val->children[idx].get();
 }
 
 void Value::serialize(FileInfo* fileInfo, uint64_t& offset) const {
@@ -506,8 +507,8 @@ void Value::serialize(FileInfo* fileInfo, uint64_t& offset) const {
     case PhysicalTypeID::VAR_LIST:
     case PhysicalTypeID::FIXED_LIST:
     case PhysicalTypeID::STRUCT: {
-        for (auto& value : nestedTypeVal) {
-            value->serialize(fileInfo, offset);
+        for (auto i = 0u; i < childrenSize; ++i) {
+            children[i]->serialize(fileInfo, offset);
         }
     } break;
     default: {
@@ -553,7 +554,7 @@ std::unique_ptr<Value> Value::deserialize(kuzu::common::FileInfo* fileInfo, uint
     case PhysicalTypeID::VAR_LIST:
     case PhysicalTypeID::FIXED_LIST:
     case PhysicalTypeID::STRUCT: {
-        SerDeser::deserializeVectorOfPtrs(val->nestedTypeVal, fileInfo, offset);
+        SerDeser::deserializeVectorOfPtrs(val->children, fileInfo, offset);
     } break;
     default: {
         throw NotImplementedException{"Value::deserializeValue"};
@@ -567,59 +568,51 @@ std::vector<std::pair<std::string, std::unique_ptr<Value>>> NodeVal::getProperti
     const Value* val) {
     throwIfNotNode(val);
     std::vector<std::pair<std::string, std::unique_ptr<Value>>> properties;
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
-    auto& structVals = val->getListValReference();
-    for (auto i = 0u; i < structVals.size(); ++i) {
+    auto fieldNames = StructType::getFieldNames(&val->getDataTypeRef());
+    for (auto i = 0u; i < val->childrenSize; ++i) {
         auto currKey = fieldNames[i];
         if (currKey == InternalKeyword::ID || currKey == InternalKeyword::LABEL) {
             continue;
         }
-        auto currVal = structVals[i]->copy();
-        properties.emplace_back(currKey, std::move(currVal));
+        properties.emplace_back(currKey, val->children[i]->copy());
     }
     return properties;
 }
 
 uint64_t NodeVal::getNumProperties(const Value* val) {
     throwIfNotNode(val);
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
+    auto fieldNames = StructType::getFieldNames(&val->dataType);
     return fieldNames.size() - OFFSET;
 }
 
 std::string NodeVal::getPropertyName(const Value* val, uint64_t index) {
     throwIfNotNode(val);
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
+    auto fieldNames = StructType::getFieldNames(&val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return "";
     }
     return fieldNames[index + OFFSET];
 }
 
-Value* NodeVal::getPropertyValueReference(const Value* val, uint64_t index) {
+Value* NodeVal::getPropertyVal(const Value* val, uint64_t index) {
     throwIfNotNode(val);
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
+    auto fieldNames = StructType::getFieldNames(&val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return nullptr;
     }
-    return val->getListValReference()[index + OFFSET].get();
+    return val->children[index + OFFSET].get();
 }
 
-std::unique_ptr<Value> NodeVal::getNodeIDVal(const Value* val) {
+Value* NodeVal::getNodeIDVal(const Value* val) {
     throwIfNotNode(val);
-    auto structType = val->getDataType();
-    auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::ID);
-    return val->getListValReference()[fieldIdx]->copy();
+    auto fieldIdx = StructType::getFieldIdx(&val->dataType, InternalKeyword::ID);
+    return val->children[fieldIdx].get();
 }
 
-std::unique_ptr<Value> NodeVal::getLabelVal(const Value* val) {
+Value* NodeVal::getLabelVal(const Value* val) {
     throwIfNotNode(val);
-    auto structType = val->getDataType();
-    auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::LABEL);
-    return val->getListValReference()[fieldIdx]->copy();
+    auto fieldIdx = StructType::getFieldIdx(&val->dataType, InternalKeyword::LABEL);
+    return val->children[fieldIdx].get();
 }
 
 nodeID_t NodeVal::getNodeID(const Value* val) {
@@ -634,19 +627,14 @@ std::string NodeVal::getLabelName(const Value* val) {
     return labelVal->getValue<std::string>();
 }
 
-std::unique_ptr<Value> NodeVal::copy(const Value* val) {
-    throwIfNotNode(val);
-    return val->copy();
-}
-
 std::string NodeVal::toString(const Value* val) {
     throwIfNotNode(val);
     return val->toString();
 }
 
 void NodeVal::throwIfNotNode(const Value* val) {
-    if (val->getDataType().getLogicalTypeID() != LogicalTypeID::NODE) {
-        auto actualType = LogicalTypeUtils::dataTypeToString(val->getDataType().getLogicalTypeID());
+    if (val->dataType.getLogicalTypeID() != LogicalTypeID::NODE) {
+        auto actualType = LogicalTypeUtils::dataTypeToString(val->dataType.getLogicalTypeID());
         throw Exception(fmt::format("Expected NODE type, but got {} type", actualType));
     }
 }
@@ -655,16 +643,14 @@ std::vector<std::pair<std::string, std::unique_ptr<Value>>> RelVal::getPropertie
     const Value* val) {
     throwIfNotRel(val);
     std::vector<std::pair<std::string, std::unique_ptr<Value>>> properties;
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
-    auto& structVals = val->getListValReference();
-    for (auto i = 0u; i < structVals.size(); ++i) {
+    auto fieldNames = StructType::getFieldNames(&val->dataType);
+    for (auto i = 0u; i < val->childrenSize; ++i) {
         auto currKey = fieldNames[i];
         if (currKey == InternalKeyword::ID || currKey == InternalKeyword::LABEL ||
             currKey == InternalKeyword::SRC || currKey == InternalKeyword::DST) {
             continue;
         }
-        auto currVal = structVals[i]->copy();
+        auto currVal = val->children[i]->copy();
         properties.emplace_back(currKey, std::move(currVal));
     }
     return properties;
@@ -672,42 +658,36 @@ std::vector<std::pair<std::string, std::unique_ptr<Value>>> RelVal::getPropertie
 
 uint64_t RelVal::getNumProperties(const Value* val) {
     throwIfNotRel(val);
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
-
+    auto fieldNames = StructType::getFieldNames(&val->dataType);
     return fieldNames.size() - OFFSET;
 }
 
 std::string RelVal::getPropertyName(const Value* val, uint64_t index) {
     throwIfNotRel(val);
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
+    auto fieldNames = StructType::getFieldNames(&val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return "";
     }
     return fieldNames[index + OFFSET];
 }
 
-Value* RelVal::getPropertyValueReference(const Value* val, uint64_t index) {
+Value* RelVal::getPropertyVal(const Value* val, uint64_t index) {
     throwIfNotRel(val);
-    auto dataType = val->getDataType();
-    auto fieldNames = StructType::getFieldNames(&dataType);
+    auto fieldNames = StructType::getFieldNames(&val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return nullptr;
     }
-    return val->getListValReference()[index + OFFSET].get();
+    return val->children[index + OFFSET].get();
 }
 
-std::unique_ptr<Value> RelVal::getSrcNodeIDVal(const Value* val) {
-    auto structType = val->getDataType();
-    auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::SRC);
-    return val->getListValReference()[fieldIdx]->copy();
+Value* RelVal::getSrcNodeIDVal(const Value* val) {
+    auto fieldIdx = StructType::getFieldIdx(&val->dataType, InternalKeyword::SRC);
+    return val->children[fieldIdx].get();
 }
 
-std::unique_ptr<Value> RelVal::getDstNodeIDVal(const Value* val) {
-    auto structType = val->getDataType();
-    auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::DST);
-    return val->getListValReference()[fieldIdx]->copy();
+Value* RelVal::getDstNodeIDVal(const Value* val) {
+    auto fieldIdx = StructType::getFieldIdx(&val->dataType, InternalKeyword::DST);
+    return val->children[fieldIdx].get();
 }
 
 nodeID_t RelVal::getSrcNodeID(const Value* val) {
@@ -723,9 +703,8 @@ nodeID_t RelVal::getDstNodeID(const Value* val) {
 }
 
 std::string RelVal::getLabelName(const Value* val) {
-    auto structType = val->getDataType();
-    auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::LABEL);
-    return val->getListValReference()[fieldIdx]->getValue<std::string>();
+    auto fieldIdx = StructType::getFieldIdx(&val->dataType, InternalKeyword::LABEL);
+    return val->children[fieldIdx]->getValue<std::string>();
 }
 
 std::string RelVal::toString(const Value* val) {
@@ -733,31 +712,26 @@ std::string RelVal::toString(const Value* val) {
     return val->toString();
 }
 
-std::unique_ptr<Value> RelVal::copy(const Value* val) {
-    throwIfNotRel(val);
-    return val->copy();
-}
-
 void RelVal::throwIfNotRel(const Value* val) {
-    if (val->getDataType().getLogicalTypeID() != LogicalTypeID::REL) {
-        auto actualType = LogicalTypeUtils::dataTypeToString(val->getDataType().getLogicalTypeID());
+    if (val->dataType.getLogicalTypeID() != LogicalTypeID::REL) {
+        auto actualType = LogicalTypeUtils::dataTypeToString(val->dataType.getLogicalTypeID());
         throw Exception(fmt::format("Expected REL type, but got {} type", actualType));
     }
 }
 
 Value* RecursiveRelVal::getNodes(const Value* val) {
     throwIfNotRecursiveRel(val);
-    return val->getListValReference()[0].get();
+    return val->children[0].get();
 }
 
 Value* RecursiveRelVal::getRels(const Value* val) {
     throwIfNotRecursiveRel(val);
-    return val->getListValReference()[1].get();
+    return val->children[1].get();
 }
 
 void RecursiveRelVal::throwIfNotRecursiveRel(const Value* val) {
-    if (val->getDataType().getLogicalTypeID() != LogicalTypeID::RECURSIVE_REL) {
-        auto actualType = LogicalTypeUtils::dataTypeToString(val->getDataType().getLogicalTypeID());
+    if (val->dataType.getLogicalTypeID() != LogicalTypeID::RECURSIVE_REL) {
+        auto actualType = LogicalTypeUtils::dataTypeToString(val->dataType.getLogicalTypeID());
         throw Exception(fmt::format("Expected RECURSIVE_REL type, but got {} type", actualType));
     }
 }

--- a/src/expression_evaluator/literal_evaluator.cpp
+++ b/src/expression_evaluator/literal_evaluator.cpp
@@ -55,13 +55,13 @@ void LiteralExpressionEvaluator::copyValueToVector(
     } break;
     case common::PhysicalTypeID::VAR_LIST: {
         auto listListEntry = reinterpret_cast<common::list_entry_t*>(dstValue);
-        auto numValues = srcValue->nestedTypeVal.size();
+        auto numValues = NestedVal::getChildrenSize(srcValue);
         *listListEntry = common::ListVector::addList(dstVector, numValues);
         auto dstDataVector = common::ListVector::getDataVector(dstVector);
         auto dstElements = common::ListVector::getListValues(dstVector, *listListEntry);
         for (auto i = 0u; i < numValues; ++i) {
             copyValueToVector(dstElements + i * dstDataVector->getNumBytesPerValue(), dstDataVector,
-                srcValue->nestedTypeVal[i].get());
+                NestedVal::getChildVal(srcValue, i));
         }
     } break;
     default:

--- a/src/include/common/types/value.h
+++ b/src/include/common/types/value.h
@@ -4,6 +4,8 @@
 #include "common/exception.h"
 #include "common/type_utils.h"
 #include "common/utils.h"
+#include <stack>
+#include <utility>
 
 namespace kuzu {
 namespace common {
@@ -122,6 +124,7 @@ public:
      * @return the dataType of the value.
      */
     KUZU_API LogicalType getDataType() const;
+    const LogicalType& getDataTypeReference() const;
     /**
      * @brief Sets the null flag of the Value.
      * @param flag null value flag to set.
@@ -198,10 +201,9 @@ private:
         }
     }
 
-    std::vector<std::unique_ptr<Value>> convertKUVarListToVector(
-        ku_list_t& list, const LogicalType& childType) const;
     std::vector<std::unique_ptr<Value>> convertKUFixedListToVector(const uint8_t* fixedList) const;
-    std::vector<std::unique_ptr<Value>> convertKUStructToVector(const uint8_t* kuStruct) const;
+    void copyFromVarList(ku_list_t& list, const LogicalType& childType);
+    void copyFromKuStruct(const uint8_t* kuStruct) const;
     std::vector<std::unique_ptr<Value>> convertKUUnionToVector(const uint8_t* kuUnion) const;
 
 public:
@@ -221,6 +223,7 @@ public:
     } val;
     std::string strVal;
     std::vector<std::unique_ptr<Value>> nestedTypeVal;
+    uint32_t nestedTypeValSize;
 };
 
 /**

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -316,11 +316,11 @@ void Connection::bindParametersNoLock(PreparedStatement* preparedStatement,
             throw Exception("Parameter " + name + " not found.");
         }
         auto expectParam = parameterMap.at(name);
-        if (expectParam->dataType != value->getDataType()) {
-            throw Exception("Parameter " + name + " has data type " +
-                            LogicalTypeUtils::dataTypeToString(value->getDataType()) +
-                            " but expects " +
-                            LogicalTypeUtils::dataTypeToString(expectParam->dataType) + ".");
+        if (expectParam->getDataTypeRef() != value->getDataType()) {
+            throw Exception(
+                "Parameter " + name + " has data type " +
+                LogicalTypeUtils::dataTypeToString(value->getDataType()) + " but expects " +
+                LogicalTypeUtils::dataTypeToString(expectParam->getDataTypeRef()) + ".");
         }
         parameterMap.at(name)->copyValueFrom(*value);
     }

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -90,9 +90,9 @@ std::vector<std::unique_ptr<DataTypeInfo>> QueryResult::getColumnTypesInfo() {
             auto numProperties = NodeVal::getNumProperties(value);
             for (auto j = 0u; i < numProperties; j++) {
                 auto name = NodeVal::getPropertyName(value, j);
-                auto val = NodeVal::getPropertyValueReference(value, j);
+                auto val = NodeVal::getPropertyVal(value, j);
                 columnTypeInfo->childrenTypesInfo.push_back(
-                    DataTypeInfo::getInfoForDataType(val->dataType, name));
+                    DataTypeInfo::getInfoForDataType(val->getDataTypeRef(), name));
             }
         } else if (columnTypeInfo->typeID == common::LogicalTypeID::REL) {
             auto value = tuple->getValue(i);
@@ -103,9 +103,9 @@ std::vector<std::unique_ptr<DataTypeInfo>> QueryResult::getColumnTypesInfo() {
             auto numProperties = RelVal::getNumProperties(value);
             for (auto j = 0u; i < numProperties; j++) {
                 auto name = NodeVal::getPropertyName(value, j);
-                auto val = NodeVal::getPropertyValueReference(value, j);
+                auto val = NodeVal::getPropertyVal(value, j);
                 columnTypeInfo->childrenTypesInfo.push_back(
-                    DataTypeInfo::getInfoForDataType(val->dataType, name));
+                    DataTypeInfo::getInfoForDataType(val->getDataTypeRef(), name));
             }
         }
         result.push_back(std::move(columnTypeInfo));

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -737,7 +737,7 @@ void FlatTupleIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* v
         (overflow_value_t*)(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
     auto columnInFactorizedTable = factorizedTable.getTableSchema()->getColumn(colIdx);
     auto tupleSizeInOverflowBuffer =
-        LogicalTypeUtils::getRowLayoutSize(values[colIdx]->getDataType());
+        LogicalTypeUtils::getRowLayoutSize(values[colIdx]->getDataTypeReference());
     valueBuffer =
         overflowValue->value +
         tupleSizeInOverflowBuffer *

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -737,7 +737,7 @@ void FlatTupleIterator::readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* v
         (overflow_value_t*)(valueBuffer + factorizedTable.getTableSchema()->getColOffset(colIdx));
     auto columnInFactorizedTable = factorizedTable.getTableSchema()->getColumn(colIdx);
     auto tupleSizeInOverflowBuffer =
-        LogicalTypeUtils::getRowLayoutSize(values[colIdx]->getDataTypeReference());
+        LogicalTypeUtils::getRowLayoutSize(values[colIdx]->getDataTypeRef());
     valueBuffer =
         overflowValue->value +
         tupleSizeInOverflowBuffer *

--- a/src/storage/storage_structure/in_mem_file.cpp
+++ b/src/storage/storage_structure/in_mem_file.cpp
@@ -85,7 +85,8 @@ ku_string_t InMemOverflowFile::copyString(
 void InMemOverflowFile::copyFixedSizedValuesInList(
     const Value& listVal, PageByteCursor& overflowCursor, uint64_t numBytesOfListElement) {
     std::shared_lock lck(lock);
-    for (auto& value : listVal.getListValReference()) {
+    for (auto i = 0; i < NestedVal::getChildrenSize(&listVal); ++i) {
+        auto value = NestedVal::getChildVal(&listVal, i);
         pages[overflowCursor.pageIdx]->write(overflowCursor.offsetInPage,
             overflowCursor.offsetInPage, (uint8_t*)&value->val, numBytesOfListElement);
         overflowCursor.offsetInPage += numBytesOfListElement;
@@ -100,28 +101,31 @@ void InMemOverflowFile::copyVarSizedValuesInList(ku_list_t& resultKUList, const 
     // Reserve space for ku_list or ku_string objects.
     overflowCursor.offsetInPage += (resultKUList.size * numBytesOfListElement);
     if constexpr (DT == LogicalTypeID::STRING) {
-        std::vector<ku_string_t> kuStrings(listVal.nestedTypeVal.size());
-        for (auto i = 0u; i < listVal.nestedTypeVal.size(); i++) {
-            assert(listVal.nestedTypeVal[i]->dataType.getLogicalTypeID() == LogicalTypeID::STRING);
-            auto strVal = listVal.nestedTypeVal[i]->strVal;
+        auto listSize = NestedVal::getChildrenSize(&listVal);
+        std::vector<ku_string_t> kuStrings(listSize);
+        for (auto i = 0u; i < listSize; i++) {
+            auto child = NestedVal::getChildVal(&listVal, i);
+            assert(child->getDataTypeRef().getLogicalTypeID() == LogicalTypeID::STRING);
+            auto strVal = child->strVal;
             kuStrings[i] = copyString(strVal.c_str(), strVal.length(), overflowCursor);
         }
         std::shared_lock lck(lock);
-        for (auto i = 0u; i < listVal.nestedTypeVal.size(); i++) {
+        for (auto i = 0u; i < listSize; i++) {
             pages[overflowPageIdx]->write(overflowPageOffset + (i * numBytesOfListElement),
                 overflowPageOffset + (i * numBytesOfListElement), (uint8_t*)&kuStrings[i],
                 numBytesOfListElement);
         }
     } else {
         assert(DT == LogicalTypeID::VAR_LIST);
-        std::vector<ku_list_t> kuLists(listVal.nestedTypeVal.size());
-        for (auto i = 0u; i < listVal.nestedTypeVal.size(); i++) {
-            assert(
-                listVal.nestedTypeVal[i]->dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST);
-            kuLists[i] = copyList(*listVal.nestedTypeVal[i], overflowCursor);
+        auto listSize = NestedVal::getChildrenSize(&listVal);
+        std::vector<ku_list_t> kuLists(listSize);
+        for (auto i = 0u; i < listSize; i++) {
+            auto child = NestedVal::getChildVal(&listVal, i);
+            assert(child->getDataTypeRef().getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+            kuLists[i] = copyList(*child, overflowCursor);
         }
         std::shared_lock lck(lock);
-        for (auto i = 0u; i < listVal.nestedTypeVal.size(); i++) {
+        for (auto i = 0u; i < listSize; i++) {
             pages[overflowPageIdx]->write(overflowPageOffset + (i * numBytesOfListElement),
                 overflowPageOffset + (i * numBytesOfListElement), (uint8_t*)&kuLists[i],
                 numBytesOfListElement);
@@ -130,11 +134,11 @@ void InMemOverflowFile::copyVarSizedValuesInList(ku_list_t& resultKUList, const 
 }
 
 ku_list_t InMemOverflowFile::copyList(const Value& listValue, PageByteCursor& overflowCursor) {
-    assert(listValue.dataType.getLogicalTypeID() == LogicalTypeID::VAR_LIST);
+    assert(listValue.getDataTypeRef().getLogicalTypeID() == LogicalTypeID::VAR_LIST);
     ku_list_t resultKUList;
     auto numBytesOfListElement = storage::StorageUtils::getDataTypeSize(
-        *common::VarListType::getChildType(&listValue.dataType));
-    resultKUList.size = listValue.nestedTypeVal.size();
+        *common::VarListType::getChildType(&listValue.getDataTypeRef()));
+    resultKUList.size = NestedVal::getChildrenSize(&listValue);
     // Allocate a new page if necessary.
     if (overflowCursor.offsetInPage + (resultKUList.size * numBytesOfListElement) >=
             BufferPoolConstants::PAGE_4KB_SIZE ||
@@ -144,7 +148,7 @@ ku_list_t InMemOverflowFile::copyList(const Value& listValue, PageByteCursor& ov
     }
     TypeUtils::encodeOverflowPtr(
         resultKUList.overflowPtr, overflowCursor.pageIdx, overflowCursor.offsetInPage);
-    switch (VarListType::getChildType(&listValue.dataType)->getLogicalTypeID()) {
+    switch (VarListType::getChildType(&listValue.getDataTypeRef())->getLogicalTypeID()) {
     case LogicalTypeID::INT64:
     case LogicalTypeID::DOUBLE:
     case LogicalTypeID::BOOL:

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -773,7 +773,7 @@ JNIEXPORT void JNICALL Java_com_kuzudb_KuzuNative_kuzu_1value_1destroy(
 JNIEXPORT jlong JNICALL Java_com_kuzudb_KuzuNative_kuzu_1value_1get_1list_1size(
     JNIEnv* env, jclass, jobject thisValue) {
     Value* v = getValue(env, thisValue);
-    return static_cast<jlong>(v->getListValReference().size());
+    return static_cast<jlong>(NestedVal::getChildrenSize(v));
 }
 
 JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1value_1get_1list_1element(
@@ -781,14 +781,12 @@ JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1value_1get_1list_1ele
     Value* v = getValue(env, thisValue);
     uint64_t idx = static_cast<uint64_t>(index);
 
-    auto& list_val = v->getListValReference();
-
-    if (idx >= list_val.size()) {
+    auto size = NestedVal::getChildrenSize(v);
+    if (idx >= size) {
         return nullptr;
     }
 
-    auto& list_element = list_val[index];
-    auto val = list_element.get();
+    auto val = NestedVal::getChildVal(v, idx);
 
     jobject element = createJavaObject(env, val, "com/kuzudb/KuzuValue", "v_ref");
     jclass clazz = env->GetObjectClass(element);
@@ -951,7 +949,7 @@ JNIEXPORT jstring JNICALL Java_com_kuzudb_KuzuNative_kuzu_1node_1val_1get_1prope
 JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1node_1val_1get_1property_1value_1at(
     JNIEnv* env, jclass, jobject thisNV, jlong index) {
     auto* nv = getValue(env, thisNV);
-    auto propertyValue = NodeVal::getPropertyValueReference(nv, index);
+    auto propertyValue = NodeVal::getPropertyVal(nv, index);
     jobject ret = createJavaObject(env, propertyValue, "com/kuzudb/KuzuValue", "v_ref");
     jclass clazz = env->GetObjectClass(ret);
     jfieldID fieldID = env->GetFieldID(clazz, "isOwnedByCPP", "Z");
@@ -1014,7 +1012,7 @@ JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1rel_1val_1get_1proper
     JNIEnv* env, jclass, jobject thisRV, jlong index) {
     auto* rv = getValue(env, thisRV);
     uint64_t idx = static_cast<uint64_t>(index);
-    Value* val = RelVal::getPropertyValueReference(rv, idx);
+    Value* val = RelVal::getPropertyVal(rv, idx);
 
     jobject ret = createJavaObject(env, val, "com/kuzudb/KuzuValue", "v_ref");
     jclass clazz = env->GetObjectClass(ret);


### PR DESCRIPTION
This PR fixes the performance issue of iterating nested data types. Now we avoid creating children value objects at iteration time (LIST still have to create since the size cannot be known before iteration, but we make sure it never resize to smaller size so the performance issue should be amortized.)

Meanwhile I always remove used APIs related to `nodeVal` and `relVal`. And remove all APIs that are triggering copy constructor from `Value` class.

TODOs

- [ ] propagate change to on Rust side
- [x] propagate change to C, Java and NodeJS