### PR TITLE
Update rust API to use new value interface

### DIFF
--- a/src/include/common/types/value.h
+++ b/src/include/common/types/value.h
@@ -231,7 +231,7 @@ public:
     /**
      * @return all properties of the NodeVal.
      * @note this function copies all the properties into a vector, which is not efficient. use
-     * `getPropertyName` and `getPropertyValueReference` instead if possible.
+     * `getPropertyName` and `getPropertyVal` instead if possible.
      */
     KUZU_API static std::vector<std::pair<std::string, std::unique_ptr<Value>>> getProperties(
         const Value* val);
@@ -285,7 +285,7 @@ public:
     /**
      * @return all properties of the RelVal.
      * @note this function copies all the properties into a vector, which is not efficient. use
-     * `getPropertyName` and `getPropertyValueReference` instead if possible.
+     * `getPropertyName` and `getPropertyVal` instead if possible.
      */
     KUZU_API static std::vector<std::pair<std::string, std::unique_ptr<Value>>> getProperties(
         const Value* val);

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -48,15 +48,6 @@ rust::Vec<rust::String> logical_type_get_struct_field_names(const kuzu::common::
 std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_field_types(
     const kuzu::common::LogicalType& value);
 
-// Simple wrapper for vector of unique_ptr since cxx doesn't support functions returning a vector of
-// unique_ptr
-struct ValueList {
-    ValueList(const std::vector<std::unique_ptr<kuzu::common::Value>>& values) : values(values) {}
-    const std::vector<std::unique_ptr<kuzu::common::Value>>& values;
-    uint64_t size() const { return values.size(); }
-    const std::unique_ptr<kuzu::common::Value>& get(uint64_t index) const { return values[index]; }
-};
-
 /* Database */
 std::unique_ptr<kuzu::main::Database> new_database(
     const std::string& databasePath, uint64_t bufferPoolSize);
@@ -91,29 +82,19 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> query_result_column_data
 rust::Vec<rust::String> query_result_column_names(const kuzu::main::QueryResult& query_result);
 
 /* NodeVal/RelVal */
-template<typename T>
-struct PropertyList {
-    const kuzu::common::Value& value;
-
-    size_t size() const { return T::getNumProperties(&value); }
-    rust::String get_name(size_t index) const {
-        return rust::String(T::getPropertyName(&value, index));
-    }
-    const kuzu::common::Value& get_value(size_t index) const {
-        return *T::getPropertyValueReference(&value, index);
-    }
-
-    PropertyList(const kuzu::common::Value& value) : value(value) {}
-};
-
-using NodeValuePropertyList = PropertyList<kuzu::common::NodeVal>;
-using RelValuePropertyList = PropertyList<kuzu::common::RelVal>;
-
 rust::String node_value_get_label_name(const kuzu::common::Value& val);
 rust::String rel_value_get_label_name(const kuzu::common::Value& val);
 
-std::unique_ptr<NodeValuePropertyList> node_value_get_properties(const kuzu::common::Value& val);
-std::unique_ptr<RelValuePropertyList> rel_value_get_properties(const kuzu::common::Value& val);
+size_t node_value_get_num_properties(const kuzu::common::Value& value);
+size_t rel_value_get_num_properties(const kuzu::common::Value& value);
+
+rust::String node_value_get_property_name(const kuzu::common::Value& value, size_t index);
+rust::String rel_value_get_property_name(const kuzu::common::Value& value, size_t index);
+
+const kuzu::common::Value& node_value_get_property_value(
+    const kuzu::common::Value& value, size_t index);
+const kuzu::common::Value& rel_value_get_property_value(
+    const kuzu::common::Value& value, size_t index);
 
 /* NodeVal */
 std::array<uint64_t, 2> node_value_get_node_id(const kuzu::common::Value& val);
@@ -123,8 +104,8 @@ std::array<uint64_t, 2> rel_value_get_src_id(const kuzu::common::Value& val);
 std::array<uint64_t, 2> rel_value_get_dst_id(const kuzu::common::Value& val);
 
 /* RecursiveRel */
-const kuzu::common::Value &recursive_rel_get_nodes(const kuzu::common::Value &val);
-const kuzu::common::Value &recursive_rel_get_rels(const kuzu::common::Value &val);
+const kuzu::common::Value& recursive_rel_get_nodes(const kuzu::common::Value& val);
+const kuzu::common::Value& recursive_rel_get_rels(const kuzu::common::Value& val);
 
 /* FlatTuple */
 const kuzu::common::Value& flat_tuple_get_value(
@@ -143,9 +124,10 @@ int32_t value_get_interval_micros(const kuzu::common::Value& value);
 int32_t value_get_date_days(const kuzu::common::Value& value);
 int64_t value_get_timestamp_micros(const kuzu::common::Value& value);
 std::array<uint64_t, 2> value_get_internal_id(const kuzu::common::Value& value);
-std::unique_ptr<ValueList> value_get_list(const kuzu::common::Value& value);
+uint32_t value_get_children_size(const kuzu::common::Value& value);
+const kuzu::common::Value& value_get_child(const kuzu::common::Value& value, uint32_t index);
 kuzu::common::LogicalTypeID value_get_data_type_id(const kuzu::common::Value& value);
-std::unique_ptr<kuzu::common::LogicalType> value_get_data_type(const kuzu::common::Value& value);
+const kuzu::common::LogicalType& value_get_data_type(const kuzu::common::Value& value);
 rust::String value_to_string(const kuzu::common::Value& val);
 
 std::unique_ptr<kuzu::common::Value> create_value_string(

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -167,14 +167,6 @@ pub(crate) mod ffi {
 
     #[namespace = "kuzu_rs"]
     unsafe extern "C++" {
-        type ValueList<'a>;
-
-        fn size<'a>(&'a self) -> u64;
-        fn get<'a>(&'a self, index: u64) -> &'a UniquePtr<Value>;
-    }
-
-    #[namespace = "kuzu_rs"]
-    unsafe extern "C++" {
         #[namespace = "kuzu::common"]
         type LogicalType;
 
@@ -251,10 +243,12 @@ pub(crate) mod ffi {
         fn value_get_timestamp_micros(value: &Value) -> i64;
         fn value_get_date_days(value: &Value) -> i32;
         fn value_get_internal_id(value: &Value) -> [u64; 2];
-        fn value_get_list(value: &Value) -> UniquePtr<ValueList>;
 
         fn value_get_data_type_id(value: &Value) -> LogicalTypeID;
-        fn value_get_data_type(value: &Value) -> UniquePtr<LogicalType>;
+        fn value_get_data_type(value: &Value) -> &LogicalType;
+
+        fn value_get_children_size(value: &Value) -> u32;
+        fn value_get_child(value: &Value, index: u32) -> &Value;
 
         fn isNull(&self) -> bool;
 
@@ -278,35 +272,23 @@ pub(crate) mod ffi {
         fn create_value_interval(months: i32, days: i32, micros: i64) -> UniquePtr<Value>;
         fn create_value_internal_id(offset: u64, table: u64) -> UniquePtr<Value>;
 
-        fn node_value_get_properties(node_value: &Value) -> UniquePtr<NodeValuePropertyList>;
         fn node_value_get_node_id(value: &Value) -> [u64; 2];
         fn node_value_get_label_name(value: &Value) -> String;
 
-        fn rel_value_get_properties(node_value: &Value) -> UniquePtr<RelValuePropertyList>;
+        fn node_value_get_num_properties(value: &Value) -> usize;
+        fn node_value_get_property_name(value: &Value, index: usize) -> String;
+        fn node_value_get_property_value(value: &Value, index: usize) -> &Value;
+
         fn rel_value_get_label_name(value: &Value) -> String;
 
         fn rel_value_get_src_id(value: &Value) -> [u64; 2];
         fn rel_value_get_dst_id(value: &Value) -> [u64; 2];
 
+        fn rel_value_get_num_properties(value: &Value) -> usize;
+        fn rel_value_get_property_name(value: &Value, index: usize) -> String;
+        fn rel_value_get_property_value(value: &Value, index: usize) -> &Value;
+
         fn recursive_rel_get_nodes(value: &Value) -> &Value;
         fn recursive_rel_get_rels(value: &Value) -> &Value;
-    }
-
-    #[namespace = "kuzu_rs"]
-    unsafe extern "C++" {
-        type NodeValuePropertyList<'a>;
-
-        fn size<'a>(&'a self) -> usize;
-        fn get_name<'a>(&'a self, index: usize) -> String;
-        fn get_value<'a>(&'a self, index: usize) -> &'a Value;
-    }
-
-    #[namespace = "kuzu_rs"]
-    unsafe extern "C++" {
-        type RelValuePropertyList<'a>;
-
-        fn size<'a>(&'a self) -> usize;
-        fn get_name<'a>(&'a self, index: usize) -> String;
-        fn get_value<'a>(&'a self, index: usize) -> &'a Value;
     }
 }

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -4,6 +4,8 @@ using kuzu::common::FixedListTypeInfo;
 using kuzu::common::Interval;
 using kuzu::common::LogicalType;
 using kuzu::common::LogicalTypeID;
+using kuzu::common::NodeVal;
+using kuzu::common::RelVal;
 using kuzu::common::StructField;
 using kuzu::common::Value;
 using kuzu::common::VarListTypeInfo;
@@ -142,19 +144,33 @@ rust::Vec<rust::String> query_result_column_names(const kuzu::main::QueryResult&
     return names;
 }
 
-std::unique_ptr<NodeValuePropertyList> node_value_get_properties(const Value& val) {
-    return std::make_unique<NodeValuePropertyList>(val);
-}
-std::unique_ptr<RelValuePropertyList> rel_value_get_properties(const Value& val) {
-    return std::make_unique<RelValuePropertyList>(val);
-}
-
 rust::String node_value_get_label_name(const kuzu::common::Value& val) {
     return rust::String(kuzu::common::NodeVal::getLabelName(&val));
 }
 
 rust::String rel_value_get_label_name(const kuzu::common::Value& val) {
     return rust::String(kuzu::common::RelVal::getLabelName(&val));
+}
+
+size_t node_value_get_num_properties(const Value& value) {
+    return NodeVal::getNumProperties(&value);
+}
+size_t rel_value_get_num_properties(const Value& value) {
+    return RelVal::getNumProperties(&value);
+}
+
+rust::String node_value_get_property_name(const Value& value, size_t index) {
+    return rust::String(NodeVal::getPropertyName(&value, index));
+}
+rust::String rel_value_get_property_name(const Value& value, size_t index) {
+    return rust::String(RelVal::getPropertyName(&value, index));
+}
+
+const kuzu::common::Value& node_value_get_property_value(const Value& value, size_t index) {
+    return *NodeVal::getPropertyVal(&value, index);
+}
+const kuzu::common::Value& rel_value_get_property_value(const Value& value, size_t index) {
+    return *RelVal::getPropertyVal(&value, index);
 }
 
 std::array<uint64_t, 2> node_value_get_node_id(const kuzu::common::Value& val) {
@@ -208,14 +224,20 @@ std::array<uint64_t, 2> value_get_internal_id(const kuzu::common::Value& value) 
     return std::array{internalID.offset, internalID.tableID};
 }
 
-std::unique_ptr<ValueList> value_get_list(const kuzu::common::Value& value) {
-    return std::make_unique<ValueList>(value.getListValReference());
+uint32_t value_get_children_size(const kuzu::common::Value& value) {
+    return kuzu::common::NestedVal::getChildrenSize(&value);
 }
+
+const Value& value_get_child(const kuzu::common::Value& value, uint32_t index) {
+    return *kuzu::common::NestedVal::getChildVal(&value, index);
+}
+
 kuzu::common::LogicalTypeID value_get_data_type_id(const kuzu::common::Value& value) {
-    return value.getDataType().getLogicalTypeID();
+    return value.getDataType()->getLogicalTypeID();
 }
-std::unique_ptr<LogicalType> value_get_data_type(const kuzu::common::Value& value) {
-    return std::make_unique<LogicalType>(value.getDataType());
+
+const LogicalType& value_get_data_type(const kuzu::common::Value& value) {
+    return *value.getDataType();
 }
 
 std::unique_ptr<kuzu::common::Value> create_value_string(
@@ -255,10 +277,10 @@ std::unique_ptr<TypeListBuilder> create_type_list() {
     return std::make_unique<TypeListBuilder>();
 }
 
-const kuzu::common::Value &recursive_rel_get_nodes(const kuzu::common::Value &val) {
+const kuzu::common::Value& recursive_rel_get_nodes(const kuzu::common::Value& val) {
     return *kuzu::common::RecursiveRelVal::getNodes(&val);
 }
-const kuzu::common::Value &recursive_rel_get_rels(const kuzu::common::Value &val) {
+const kuzu::common::Value& recursive_rel_get_rels(const kuzu::common::Value& val) {
     return *kuzu::common::RecursiveRelVal::getRels(&val);
 }
 

--- a/tools/rust_api/src/logical_type.rs
+++ b/tools/rust_api/src/logical_type.rs
@@ -56,7 +56,7 @@ pub enum LogicalType {
 
 impl From<&ffi::Value> for LogicalType {
     fn from(value: &ffi::Value) -> Self {
-        ffi::value_get_data_type(value).as_ref().unwrap().into()
+        ffi::value_get_data_type(value).into()
     }
 }
 

--- a/tools/rust_api/src/value.rs
+++ b/tools/rust_api/src/value.rs
@@ -352,11 +352,7 @@ impl TryFrom<&ffi::Value> for Value {
             LogicalTypeID::DOUBLE => Ok(Value::Double(value.get_value_double())),
             LogicalTypeID::STRING => Ok(Value::String(ffi::value_get_string(value).to_string())),
             LogicalTypeID::BLOB => Ok(Value::Blob(
-                ffi::value_get_string(value)
-                    .as_bytes()
-                    .iter()
-                    .cloned()
-                    .collect(),
+                ffi::value_get_string(value).as_bytes().to_vec(),
             )),
             LogicalTypeID::INTERVAL => Ok(Value::Interval(time::Duration::new(
                 ffi::value_get_interval_secs(value),
@@ -379,10 +375,9 @@ impl TryFrom<&ffi::Value> for Value {
                     .ok_or(ConversionError::Timestamp(us))
             }
             LogicalTypeID::VAR_LIST => {
-                let list = ffi::value_get_list(value);
                 let mut result = vec![];
-                for index in 0..list.size() {
-                    let value: Value = list.get(index).as_ref().unwrap().try_into()?;
+                for index in 0..ffi::value_get_children_size(value) {
+                    let value: Value = ffi::value_get_child(value, index).try_into()?;
                     result.push(value);
                 }
                 if let LogicalType::VarList { child_type } = value.into() {
@@ -392,10 +387,9 @@ impl TryFrom<&ffi::Value> for Value {
                 }
             }
             LogicalTypeID::FIXED_LIST => {
-                let list = ffi::value_get_list(value);
                 let mut result = vec![];
-                for index in 0..list.size() {
-                    let value: Value = list.get(index).as_ref().unwrap().try_into()?;
+                for index in 0..ffi::value_get_children_size(value) {
+                    let value: Value = ffi::value_get_child(value, index).try_into()?;
                     result.push(value);
                 }
                 if let LogicalType::FixedList { child_type, .. } = value.into() {
@@ -407,13 +401,14 @@ impl TryFrom<&ffi::Value> for Value {
             LogicalTypeID::STRUCT => {
                 // Data is a list of field values in the value itself (same as list),
                 // with the field names stored in the DataType
-                let field_names = ffi::logical_type_get_struct_field_names(
-                    ffi::value_get_data_type(value).as_ref().unwrap(),
-                );
-                let list = ffi::value_get_list(value);
+                let field_names =
+                    ffi::logical_type_get_struct_field_names(ffi::value_get_data_type(value));
                 let mut result = vec![];
-                for (name, index) in field_names.into_iter().zip(0..list.size()) {
-                    let value: Value = list.get(index).as_ref().unwrap().try_into()?;
+                for (name, index) in field_names
+                    .into_iter()
+                    .zip(0..ffi::value_get_children_size(value))
+                {
+                    let value: Value = ffi::value_get_child(value, index).try_into()?;
                     result.push((name, value));
                 }
                 Ok(Value::Struct(result))
@@ -426,11 +421,10 @@ impl TryFrom<&ffi::Value> for Value {
                 };
                 let label = ffi::node_value_get_label_name(value);
                 let mut node_val = NodeVal::new(id, label);
-                let properties = ffi::node_value_get_properties(value);
-                for i in 0..properties.size() {
+                for i in 0..ffi::node_value_get_num_properties(value) {
                     node_val.add_property(
-                        properties.get_name(i),
-                        TryInto::<Value>::try_into(properties.get_value(i))?,
+                        ffi::node_value_get_property_name(value, i),
+                        TryInto::<Value>::try_into(ffi::node_value_get_property_value(value, i))?,
                     );
                 }
                 Ok(Value::Node(node_val))
@@ -448,10 +442,11 @@ impl TryFrom<&ffi::Value> for Value {
                 };
                 let label = ffi::rel_value_get_label_name(value);
                 let mut rel_val = RelVal::new(src_node, dst_node, label);
-                let properties = ffi::rel_value_get_properties(value);
-                for i in 0..properties.size() {
-                    rel_val
-                        .add_property(properties.get_name(i), properties.get_value(i).try_into()?);
+                for i in 0..ffi::rel_value_get_num_properties(value) {
+                    rel_val.add_property(
+                        ffi::rel_value_get_property_name(value, i),
+                        ffi::rel_value_get_property_value(value, i).try_into()?,
+                    );
                 }
                 Ok(Value::Rel(rel_val))
             }


### PR DESCRIPTION
Following up #1845 and #1852.

I also cleaned up a few things on the rust side and fixed a doc comment in value.h which referred to a function that was renamed in #1845.