### PR TITLE
Store nulls as densely packed bitfields

### DIFF
--- a/src/common/null_mask.cpp
+++ b/src/common/null_mask.cpp
@@ -5,14 +5,13 @@
 namespace kuzu {
 namespace common {
 
-void NullMask::setNull(uint32_t pos, bool isNull) {
+void NullMask::setNull(uint64_t* nullEntries, uint32_t pos, bool isNull) {
     auto entryPos = pos >> NUM_BITS_PER_NULL_ENTRY_LOG2;
     auto bitPosInEntry = pos - (entryPos << NUM_BITS_PER_NULL_ENTRY_LOG2);
     if (isNull) {
-        data[entryPos] |= NULL_BITMASKS_WITH_SINGLE_ONE[bitPosInEntry];
-        mayContainNulls = true;
+        nullEntries[entryPos] |= NULL_BITMASKS_WITH_SINGLE_ONE[bitPosInEntry];
     } else {
-        data[entryPos] &= NULL_BITMASKS_WITH_SINGLE_ZERO[bitPosInEntry];
+        nullEntries[entryPos] &= NULL_BITMASKS_WITH_SINGLE_ZERO[bitPosInEntry];
     }
 }
 
@@ -85,6 +84,57 @@ void NullMask::resize(uint64_t capacity) {
     buffer = std::move(resizedBuffer);
     data = buffer.get();
     numNullEntries = capacity;
+}
+
+bool NullMask::copyFromNullBits(const uint64_t* srcNullEntries, uint64_t srcOffset,
+    uint64_t dstOffset, uint64_t numBitsToCopy) {
+    if (copyNullMask(srcNullEntries, srcOffset, this->data, dstOffset, numBitsToCopy)) {
+        this->mayContainNulls = true;
+        return true;
+    }
+    return false;
+}
+
+void NullMask::setNullRange(
+    uint64_t* nullEntries, uint64_t offset, uint64_t numBitsToSet, bool isNull) {
+    auto [firstEntryPos, firstBitPos] = getNullEntryAndBitPos(offset);
+    auto [lastEntryPos, lastBitPos] = getNullEntryAndBitPos(offset + numBitsToSet);
+
+    // If the range spans multiple entries, set the entries in the middle to the appropriate value
+    // with std::fill
+    if (lastEntryPos > firstEntryPos + 1) {
+        std::fill(nullEntries + firstEntryPos + 1, nullEntries + lastEntryPos,
+            isNull ? ALL_NULL_ENTRY : NO_NULL_ENTRY);
+    }
+
+    if (firstEntryPos == lastEntryPos) {
+        if (isNull) {
+            // Set bits between the first and the last bit pos to true
+            nullEntries[firstEntryPos] |= (~NULL_LOWER_MASKS[firstBitPos] &
+                                           ~NULL_HIGH_MASKS[NUM_BITS_PER_NULL_ENTRY - lastBitPos]);
+        } else {
+            // Set bits between the first and the last bit pos to false
+            nullEntries[firstEntryPos] &= (NULL_LOWER_MASKS[firstBitPos] |
+                                           NULL_HIGH_MASKS[NUM_BITS_PER_NULL_ENTRY - lastBitPos]);
+        }
+    } else {
+        if (isNull) {
+            // Set bits including and after the first bit pos to true
+            nullEntries[firstEntryPos] |= ~NULL_HIGH_MASKS[firstBitPos];
+            if (lastBitPos > 0) {
+                // Set bits before the last bit pos to true
+                nullEntries[lastEntryPos] |=
+                    ~NULL_LOWER_MASKS[NUM_BITS_PER_NULL_ENTRY - lastBitPos];
+            }
+        } else {
+            // Set bits including and after the first bit pos to false
+            nullEntries[firstEntryPos] &= NULL_LOWER_MASKS[firstBitPos];
+            if (lastBitPos > 0) {
+                // Set bits before the last bit pos to false
+                nullEntries[lastEntryPos] &= NULL_HIGH_MASKS[NUM_BITS_PER_NULL_ENTRY - lastBitPos];
+            }
+        }
+    }
 }
 
 } // namespace common

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -312,6 +312,9 @@ void LogicalType::setPhysicalType() {
     case LogicalTypeID::BOOL: {
         physicalType = PhysicalTypeID::BOOL;
     } break;
+    case LogicalTypeID::NULL_: {
+        physicalType = PhysicalTypeID::NULL_;
+    } break;
     case LogicalTypeID::TIMESTAMP:
     case LogicalTypeID::SERIAL:
     case LogicalTypeID::INT64: {

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -48,6 +48,11 @@ bool NodeIDVector::discardNull(ValueVector& vector) {
     }
 }
 
+bool ValueVector::setNullFromBits(const uint64_t* srcNullEntries, uint64_t srcOffset,
+    uint64_t dstOffset, uint64_t numBitsToCopy) {
+    return nullMask->copyFromNullBits(srcNullEntries, srcOffset, dstOffset, numBitsToCopy);
+}
+
 template<typename T>
 void ValueVector::setValue(uint32_t pos, T val) {
     ((T*)valueBuffer.get())[pos] = val;

--- a/src/include/common/null_mask.h
+++ b/src/include/common/null_mask.h
@@ -96,10 +96,15 @@ public:
         mayContainNulls = true;
     }
 
-    inline void setMayContainNulls() { mayContainNulls = true; }
     inline bool hasNoNullsGuarantee() const { return !mayContainNulls; }
 
-    void setNull(uint32_t pos, bool isNull);
+    static void setNull(uint64_t* nullEntries, uint32_t pos, bool isNull);
+    inline void setNull(uint32_t pos, bool isNull) {
+        setNull(data, pos, isNull);
+        if (isNull) {
+            mayContainNulls = true;
+        }
+    }
 
     static inline bool isNull(const uint64_t* nullEntries, uint32_t pos) {
         auto [entryPos, bitPosInEntry] = getNullEntryAndBitPos(pos);
@@ -108,17 +113,31 @@ public:
 
     inline bool isNull(uint32_t pos) const { return isNull(data, pos); }
 
-    inline uint64_t* getData() { return data; }
+    // const because updates to the data must set mayContainNulls if any value
+    // becomes non-null
+    // Modifying the underlying data shuld be done with setNull or copyFromNullData
+    inline const uint64_t* getData() { return data; }
 
     static inline uint64_t getNumNullEntries(uint64_t numNullBits) {
         return (numNullBits >> NUM_BITS_PER_NULL_ENTRY_LOG2) +
                ((numNullBits - (numNullBits << NUM_BITS_PER_NULL_ENTRY_LOG2)) == 0 ? 0 : 1);
     }
 
-    // This function returns true if we have copied a nullBit with value 1 (indicate a null
-    // value) to dstNullEntries.
+    // Copies bitpacked null flags from one buffer to another, starting at an arbitrary bit
+    // offset and preserving adjacent bits.
+    //
+    // returns true if we have copied a nullBit with value 1 (indicates a null value) to
+    // dstNullEntries.
     static bool copyNullMask(const uint64_t* srcNullEntries, uint64_t srcOffset,
         uint64_t* dstNullEntries, uint64_t dstOffset, uint64_t numBitsToCopy);
+
+    bool copyFromNullBits(const uint64_t* srcNullEntries, uint64_t srcOffset, uint64_t dstOffset,
+        uint64_t numBitsToCopy);
+
+    // Sets the given number of bits to null (if isNull is true) or non-null (if isNull is false),
+    // starting at the offset
+    static void setNullRange(
+        uint64_t* nullEntries, uint64_t offset, uint64_t numBitsToSet, bool isNull);
 
     void resize(uint64_t capacity);
 

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -74,6 +74,7 @@ KUZU_API enum class LogicalTypeID : uint8_t {
     SERIAL = 13,
 
     // fixed size types
+    NULL_ = 21,
     BOOL = 22,
     INT64 = 23,
     INT32 = 24,
@@ -110,6 +111,7 @@ enum class PhysicalTypeID : uint8_t {
     INTERVAL = 7,
     INTERNAL_ID = 9,
     ARROW_COLUMN = 10,
+    NULL_ = 11,
 
     // Variable size types.
     STRING = 20,

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -33,7 +33,6 @@ public:
 
     inline void setAllNull() { nullMask->setAllNull(); }
     inline void setAllNonNull() { nullMask->setAllNonNull(); }
-    inline void setMayContainNulls() { nullMask->setMayContainNulls(); }
     // On return true, there are no null. On return false, there may or may not be nulls.
     inline bool hasNoNullsGuarantee() const { return nullMask->hasNoNullsGuarantee(); }
     inline void setRangeNonNull(uint32_t startPos, uint32_t len) {
@@ -41,13 +40,16 @@ public:
             setNull(startPos + i, false);
         }
     }
-    inline uint64_t* getNullMaskData() { return nullMask->getData(); }
+    inline const uint64_t* getNullMaskData() { return nullMask->getData(); }
     inline void setNull(uint32_t pos, bool isNull) { nullMask->setNull(pos, isNull); }
     inline uint8_t isNull(uint32_t pos) const { return nullMask->isNull(pos); }
     inline void setAsSingleNullEntry() {
         state->selVector->selectedSize = 1;
         setNull(state->selVector->selectedPositions[0], true);
     }
+
+    bool setNullFromBits(const uint64_t* srcNullEntries, uint64_t srcOffset, uint64_t dstOffset,
+        uint64_t numBitsToCopy);
 
     inline uint32_t getNumBytesPerValue() const { return numBytesPerValue; }
 

--- a/src/include/storage/storage_structure/lists/lists.h
+++ b/src/include/storage/storage_structure/lists/lists.h
@@ -20,7 +20,7 @@ struct InMemList {
 
     inline uint8_t* getListData() const { return listData.get(); }
     inline bool hasNullBuffer() const { return nullMask != nullptr; }
-    inline uint64_t* getNullMask() const { return nullMask->getData(); }
+    inline common::NullMask* getNullMask() const { return nullMask.get(); }
 
     uint64_t numElements;
     std::unique_ptr<uint8_t[]> listData;

--- a/src/storage/storage_structure/lists/lists.cpp
+++ b/src/storage/storage_structure/lists/lists.cpp
@@ -140,7 +140,7 @@ void Lists::fillInMemListsFromFrame(InMemList& inMemList, const uint8_t* frame,
     if (deletedRelOffsetsInList.empty()) {
         memcpy(listData, frameData, numElementsToReadInCurPage * elementSize);
         if (inMemList.hasNullBuffer()) {
-            NullMask::copyNullMask(nullBufferInPage, elemPosInPage, inMemList.getNullMask(),
+            inMemList.getNullMask()->copyFromNullBits(nullBufferInPage, elemPosInPage,
                 nextPosToWriteToInMemList, numElementsToReadInCurPage);
         }
         readPropertyUpdatesToInMemListIfExists(inMemList, updatedPersistentListOffsets,
@@ -164,9 +164,8 @@ void Lists::fillInMemListsFromFrame(InMemList& inMemList, const uint8_t* frame,
                     // Otherwise, we can directly read from persistentStore.
                     memcpy(listData, frameData, elementSize);
                     if (inMemList.hasNullBuffer()) {
-                        NullMask::copyNullMask(nullBufferInPage, elemPosInPage,
-                            inMemList.getNullMask(), nextPosToWriteToInMemList,
-                            1 /* numBitsToCopy */);
+                        inMemList.getNullMask()->copyFromNullBits(nullBufferInPage, elemPosInPage,
+                            nextPosToWriteToInMemList, 1 /* numBitsToCopy */);
                     }
                 }
                 listData += elementSize;

--- a/src/storage/storage_structure/lists/lists_update_iterator.cpp
+++ b/src/storage/storage_structure/lists/lists_update_iterator.cpp
@@ -247,7 +247,7 @@ void ListsUpdateIterator::writeAtOffset(InMemList& inMemList, page_idx_t pageLis
                 memcpy(frame + lists->getElemByteOffset(elementOffsetInListPage), dataToFill,
                     numElementsToWriteToCurrentPage * elementSize);
                 if (inMemList.hasNullBuffer()) {
-                    NullMask::copyNullMask(inMemList.getNullMask(), numUpdatedElements,
+                    NullMask::copyNullMask(inMemList.getNullMask()->getData(), numUpdatedElements,
                         (uint64_t*)lists->getNullBufferInPage(frame), elementOffsetInListPage,
                         numElementsToWriteToCurrentPage);
                 }

--- a/src/storage/storage_structure/storage_structure.cpp
+++ b/src/storage/storage_structure/storage_structure.cpp
@@ -102,11 +102,8 @@ void BaseColumnOrList::readInternalIDsFromAPageBySequentialCopy(Transaction* tra
 
 void BaseColumnOrList::readNullBitsFromAPage(ValueVector* valueVector, const uint8_t* frame,
     uint64_t posInPage, uint64_t posInVector, uint64_t numBitsToRead) const {
-    auto hasNullInSrcNullMask = NullMask::copyNullMask((uint64_t*)getNullBufferInPage(frame),
-        posInPage, valueVector->getNullMaskData(), posInVector, numBitsToRead);
-    if (hasNullInSrcNullMask) {
-        valueVector->setMayContainNulls();
-    }
+    valueVector->setNullFromBits(
+        (uint64_t*)getNullBufferInPage(frame), posInPage, posInVector, numBitsToRead);
 }
 
 void BaseColumnOrList::readAPageBySequentialCopy(Transaction* transaction, ValueVector* vector,

--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_kuzu_test(types_test
         date_test.cpp
         interval_test.cpp
+        null_mask_test.cpp
         string_test.cpp
         time_test.cpp
         timestamp_test.cpp

--- a/test/common/null_mask_test.cpp
+++ b/test/common/null_mask_test.cpp
@@ -1,0 +1,24 @@
+#include "common/null_mask.h"
+#include "gtest/gtest.h"
+
+using namespace kuzu::common;
+
+TEST(NullMaskTests, TestRangeSingleEntry) {
+    std::vector<uint64_t> data{NullMask::NO_NULL_ENTRY};
+    NullMask::setNullRange(data.data(), 5, 5, true);
+    ASSERT_EQ(data[0], 0b1111100000);
+
+    data[0] = NullMask::ALL_NULL_ENTRY;
+    NullMask::setNullRange(data.data(), 5, 5, false);
+    ASSERT_EQ(data[0], ~0b1111100000);
+}
+
+TEST(NullMaskTests, TestRangeMultipleEntries) {
+    std::vector<uint64_t> data{
+        NullMask::ALL_NULL_ENTRY, NullMask::ALL_NULL_ENTRY, NullMask::ALL_NULL_ENTRY};
+    NullMask::setNullRange(data.data(), 5, 150, false);
+    ASSERT_EQ(data[0], 0b11111);
+    ASSERT_EQ(data[1], 0);
+    ASSERT_FALSE(NullMask::isNull(data.data(), 154));
+    ASSERT_TRUE(NullMask::isNull(data.data(), 155));
+}


### PR DESCRIPTION
Instead of one value per byte.

I also modified NullMask so that modification is only possible through its functions, not via direct access to the underlying data, so that the mayContainNulls is always set if a non-null bit is copied into the data with `NullMask::copyNullMask` (which had caused issues since I had missed that requirement initially).

The possibility of values with sizes smaller than one byte breaks a lot of assumptions in the storage logic (a lot of parts rely on the idea of the number of bytes per value), but for this at least the fallout of that isn't too large. In NullNodeColumn I was able to just adjust the numValuesPerPage variable after it has been initially set in NodeColumn to an incorrect value based on the size of each value in bytes, but in ColumnChunk that wasn't possible, since the size is immediately used to create a buffer. Instead I adjusted the value size logic to use bits instead of bytes. It's a little messy right now, but while I'd prefer to keep the null-related specifics inside NullColumnChunk, I imagine that an overhaul of that logic will be necessary anyway once we introduce more complex compression schemes.

A `NULL_` logical/physical type was introduced since nulls are now stored differently from bools, but that can be removed again when bools are stored in the same way.