### PR TITLE
Pin the time crate to 0.3.23

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -81,6 +81,7 @@ jobs:
         working-directory: tools/rust_api
         run: |
           cargo update -p half@2.3.1 --precise '2.2.1'
+          cargo update -p time --precise '0.3.23'
           cargo test --features arrow -- --test-threads=1
 
       - name: Rust example
@@ -183,6 +184,7 @@ jobs:
           set CFLAGS=/MDd
           set CXXFLAGS=/MDd /std:c++20
           cargo update -p half@2.3.1 --precise 2.2.1
+          cargo update -p time --precise '0.3.23'
           cargo test -- --test-threads=1
 
       - name: Java test


### PR DESCRIPTION
time moves quickly, faster than our CI rust version does. The latest version bumped the minimum rust version to 1.67, which is newer than the rustc provided by our Ubuntu 22.04-based CI images.

I suspect the only reason it's not a problem on the windows CI test is that there it looks like it's caching the build directory, so the presence of a Cargo.lock (untracked) meant it didn't update to a new version.