### PR TITLE
Boolean bitpacking

### DIFF
--- a/src/common/null_mask.cpp
+++ b/src/common/null_mask.cpp
@@ -16,7 +16,7 @@ void NullMask::setNull(uint64_t* nullEntries, uint32_t pos, bool isNull) {
 }
 
 bool NullMask::copyNullMask(const uint64_t* srcNullEntries, uint64_t srcOffset,
-    uint64_t* dstNullEntries, uint64_t dstOffset, uint64_t numBitsToCopy) {
+    uint64_t* dstNullEntries, uint64_t dstOffset, uint64_t numBitsToCopy, bool invert) {
     auto [srcNullEntryPos, srcNullBitPos] = getNullEntryAndBitPos(srcOffset);
     auto [dstNullEntryPos, dstNullBitPos] = getNullEntryAndBitPos(dstOffset);
     uint64_t bitPos = 0;
@@ -25,7 +25,8 @@ bool NullMask::copyNullMask(const uint64_t* srcNullEntries, uint64_t srcOffset,
         auto curDstNullEntryPos = dstNullEntryPos;
         auto curDstNullBitPos = dstNullBitPos;
         uint64_t numBitsToReadInCurrentEntry;
-        uint64_t srcNullMaskEntry = srcNullEntries[srcNullEntryPos];
+        uint64_t srcNullMaskEntry =
+            invert ? ~srcNullEntries[srcNullEntryPos] : srcNullEntries[srcNullEntryPos];
         if (dstNullBitPos < srcNullBitPos) {
             numBitsToReadInCurrentEntry =
                 std::min(NullMask::NUM_BITS_PER_NULL_ENTRY - srcNullBitPos, numBitsToCopy - bitPos);

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -312,9 +312,6 @@ void LogicalType::setPhysicalType() {
     case LogicalTypeID::BOOL: {
         physicalType = PhysicalTypeID::BOOL;
     } break;
-    case LogicalTypeID::NULL_: {
-        physicalType = PhysicalTypeID::NULL_;
-    } break;
     case LogicalTypeID::TIMESTAMP:
     case LogicalTypeID::SERIAL:
     case LogicalTypeID::INT64: {

--- a/src/include/common/null_mask.h
+++ b/src/include/common/null_mask.h
@@ -129,7 +129,7 @@ public:
     // returns true if we have copied a nullBit with value 1 (indicates a null value) to
     // dstNullEntries.
     static bool copyNullMask(const uint64_t* srcNullEntries, uint64_t srcOffset,
-        uint64_t* dstNullEntries, uint64_t dstOffset, uint64_t numBitsToCopy);
+        uint64_t* dstNullEntries, uint64_t dstOffset, uint64_t numBitsToCopy, bool invert = false);
 
     bool copyFromNullBits(const uint64_t* srcNullEntries, uint64_t srcOffset, uint64_t dstOffset,
         uint64_t numBitsToCopy);

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -74,7 +74,6 @@ KUZU_API enum class LogicalTypeID : uint8_t {
     SERIAL = 13,
 
     // fixed size types
-    NULL_ = 21,
     BOOL = 22,
     INT64 = 23,
     INT32 = 24,
@@ -111,7 +110,6 @@ enum class PhysicalTypeID : uint8_t {
     INTERVAL = 7,
     INTERNAL_ID = 9,
     ARROW_COLUMN = 10,
-    NULL_ = 11,
 
     // Variable size types.
     STRING = 20,

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -266,19 +266,6 @@ std::string StorageUtils::appendSuffixOrInsertBeforeWALSuffix(
     }
 }
 
-uint32_t PageUtils::getNumElementsInAPage(uint32_t elementSize, bool hasNull) {
-    assert(elementSize > 0);
-    auto numBytesPerNullEntry = NullMask::NUM_BITS_PER_NULL_ENTRY >> 3;
-    auto numNullEntries =
-        hasNull ? (uint32_t)ceil(
-                      (double)BufferPoolConstants::PAGE_4KB_SIZE /
-                      (double)(((uint64_t)elementSize << NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2) +
-                               numBytesPerNullEntry)) :
-                  0;
-    return (BufferPoolConstants::PAGE_4KB_SIZE - (numNullEntries * numBytesPerNullEntry)) /
-           elementSize;
-}
-
 void StorageUtils::initializeListsHeaders(table_id_t relTableID, uint64_t numNodesInTable,
     const std::string& directory, RelDataDirection relDirection) {
     auto listHeadersBuilder = make_unique<ListHeadersBuilder>(

--- a/test/common/null_mask_test.cpp
+++ b/test/common/null_mask_test.cpp
@@ -1,3 +1,5 @@
+#include <vector>
+
 #include "common/null_mask.h"
 #include "gtest/gtest.h"
 
@@ -21,4 +23,59 @@ TEST(NullMaskTests, TestRangeMultipleEntries) {
     ASSERT_EQ(data[1], 0);
     ASSERT_FALSE(NullMask::isNull(data.data(), 154));
     ASSERT_TRUE(NullMask::isNull(data.data(), 155));
+}
+
+TEST(NullMaskTests, CopyNullMaskAll) {
+    const int size = 10;
+    std::vector<uint64_t> source(size);
+    source[0] = 0xffff;
+    source[5] = 0xfbff;
+    std::vector<uint64_t> dest(size);
+    NullMask::copyNullMask(source.data(), 0, dest.data(), 0, size * 64);
+    ASSERT_EQ(source, dest);
+}
+
+TEST(NullMaskTests, CopyNullMaskOffset) {
+    const int size = 10;
+    std::vector<uint64_t> source(size);
+    source[0] = 0xffff;
+    source[5] = 0xfbff;
+    std::vector<uint64_t> dest(size);
+    // Copy first word, except the first bit
+    NullMask::copyNullMask(source.data(), 1, dest.data(), 1, 63);
+    ASSERT_NE(source, dest);
+    ASSERT_EQ(dest[0] & ~1, source[0] & ~1);
+    ASSERT_EQ(dest[1] & 1, 0);
+
+    // Copy word 4 and first bit of word 5
+    NullMask::copyNullMask(source.data(), 4 * 64, dest.data(), 4 * 64, 65);
+    // First bit should be set in destination
+    ASSERT_EQ(dest[5] & 1, 1);
+    // No other bit in word 5 should be set
+    ASSERT_EQ(dest[5] & ~1, 0);
+    // word 4 should be empty, like the source
+    ASSERT_EQ(dest[4], 0);
+}
+
+TEST(NullMaskTests, CopyNullMaskOffsetInvert) {
+    const int size = 10;
+    std::vector<uint64_t> source(size);
+    source[0] = 0xffff;
+    source[5] = 0xfbff;
+    std::vector<uint64_t> dest(size);
+    // Copy first word, except the first bit, and invert copied bits
+    NullMask::copyNullMask(source.data(), 1, dest.data(), 1, 63, true);
+    ASSERT_NE(source, dest);
+    // Dest word should match source word, with the exclusion of the first bit (but inverted)
+    ASSERT_EQ(dest[0] & ~1, ~source[0] & ~1);
+    ASSERT_EQ(dest[1] & 1, 0);
+
+    // Copy word 4 and first bit of word 5
+    NullMask::copyNullMask(source.data(), 4 * 64, dest.data(), 4 * 64, 65, true);
+    // First bit should be set and inverted in destination
+    ASSERT_EQ(dest[5] & 1, 0);
+    // No other bit in word 5 should be set
+    ASSERT_EQ(dest[5] & ~1, 0);
+    // word 4 should be all set, as the inverted source
+    ASSERT_EQ(dest[4], ~0);
 }


### PR DESCRIPTION
Implements boolean bitpacking for on-disk booleans and unpacks them when reading into ValueVectors.
Requires #1862.

I also optimized `ColumnChunk::templateCopyArrowArray<bool>` to use copyNullMask instead of setting the bits individually. Arrow's null bits are flipped in comparison to kuzu's, so I modified the copy function to allow the result to be inverted.