### PR TITLE
Move the initialization of metadada disk arrays to wal-based transaction mechanism

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -70,10 +70,19 @@ void Catalog::renameTable(table_id_t tableID, const std::string& newName) {
     catalogContentForWriteTrx->renameTable(tableID, newName);
 }
 
-void Catalog::addProperty(
+void Catalog::addNodeProperty(table_id_t tableID, const std::string& propertyName,
+    std::unique_ptr<LogicalType> dataType, std::unique_ptr<MetadataDAHInfo> metadataDAHInfo) {
+    initCatalogContentForWriteTrxIfNecessary();
+    catalogContentForWriteTrx->getTableSchema(tableID)->addNodeProperty(
+        propertyName, std::move(dataType), std::move(metadataDAHInfo));
+    wal->logAddPropertyRecord(
+        tableID, catalogContentForWriteTrx->getTableSchema(tableID)->getPropertyID(propertyName));
+}
+
+void Catalog::addRelProperty(
     table_id_t tableID, const std::string& propertyName, std::unique_ptr<LogicalType> dataType) {
     initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->getTableSchema(tableID)->addProperty(
+    catalogContentForWriteTrx->getTableSchema(tableID)->addRelProperty(
         propertyName, std::move(dataType));
     wal->logAddPropertyRecord(
         tableID, catalogContentForWriteTrx->getTableSchema(tableID)->getPropertyID(propertyName));

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -66,7 +66,10 @@ public:
 
     void renameTable(common::table_id_t tableID, const std::string& newName);
 
-    void addProperty(common::table_id_t tableID, const std::string& propertyName,
+    void addNodeProperty(common::table_id_t tableID, const std::string& propertyName,
+        std::unique_ptr<common::LogicalType> dataType,
+        std::unique_ptr<MetadataDAHInfo> metadataDAHInfo);
+    void addRelProperty(common::table_id_t tableID, const std::string& propertyName,
         std::unique_ptr<common::LogicalType> dataType);
 
     void dropProperty(common::table_id_t tableID, common::property_id_t propertyID);

--- a/src/include/catalog/table_schema.h
+++ b/src/include/catalog/table_schema.h
@@ -58,7 +58,13 @@ public:
 
     std::vector<Property*> getProperties() const;
 
-    inline void addProperty(
+    inline void addNodeProperty(std::string propertyName,
+        std::unique_ptr<common::LogicalType> dataType,
+        std::unique_ptr<MetadataDAHInfo> metadataDAHInfo) {
+        properties.push_back(std::make_unique<Property>(std::move(propertyName),
+            std::move(dataType), increaseNextPropertyID(), tableID, std::move(metadataDAHInfo)));
+    }
+    inline void addRelProperty(
         std::string propertyName, std::unique_ptr<common::LogicalType> dataType) {
         properties.push_back(std::make_unique<Property>(
             std::move(propertyName), std::move(dataType), increaseNextPropertyID(), tableID));

--- a/src/include/processor/operator/ddl/add_property.h
+++ b/src/include/processor/operator/ddl/add_property.h
@@ -23,7 +23,7 @@ public:
         defaultValueEvaluator->init(*resultSet, context->memoryManager);
     }
 
-    void executeDDLInternal() override;
+    void executeDDLInternal() override = 0;
 
     std::string getOutputMsg() override { return {"Add Succeed."}; }
 

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -39,13 +39,14 @@ public:
     inline BMFileHandle* getDataFH() const { return dataFH.get(); }
     inline BMFileHandle* getMetadataFH() const { return metadataFH.get(); }
 
-    std::unique_ptr<catalog::MetadataDAHInfo> initMetadataDAHInfo(
+    std::unique_ptr<catalog::MetadataDAHInfo> createMetadataDAHInfo(
         const common::LogicalType& dataType);
 
 private:
     std::unique_ptr<BMFileHandle> dataFH;
     std::unique_ptr<BMFileHandle> metadataFH;
     catalog::Catalog& catalog;
+    MemoryManager& memoryManager;
     WAL* wal;
     std::unique_ptr<RelsStore> relsStore;
     std::unique_ptr<NodesStore> nodesStore;

--- a/src/include/storage/storage_structure/disk_array.h
+++ b/src/include/storage/storage_structure/disk_array.h
@@ -231,6 +231,14 @@ public:
     InMemDiskArray(FileHandle& fileHandle, StorageStructureID storageStructureID,
         common::page_idx_t headerPageIdx, BufferManager* bufferManager, WAL* wal);
 
+    static inline common::page_idx_t addDAHPageToFile(BMFileHandle& fileHandle,
+        StorageStructureID storageStructureID, BufferManager* bufferManager, WAL* wal) {
+        DiskArrayHeader daHeader(sizeof(T));
+        return StorageStructureUtils::insertNewPage(fileHandle,
+            StorageStructureID{StorageStructureType::METADATA}, *bufferManager, *wal,
+            [&](uint8_t* frame) -> void { memcpy(frame, &daHeader, sizeof(DiskArrayHeader)); });
+    }
+
     inline void checkpointInMemoryIfNecessary() override {
         std::unique_lock xlock{this->diskArraySharedMtx};
         checkpointOrRollbackInMemoryIfNecessaryNoLock(true /* is checkpoint */);

--- a/src/include/storage/storage_structure/storage_structure.h
+++ b/src/include/storage/storage_structure/storage_structure.h
@@ -47,8 +47,6 @@ public:
     }
 
 protected:
-    void addNewPageToFileHandle();
-
     // If necessary creates a second version (backed by the WAL) of a page that contains the value
     // that will be written to. The position of the value, which determines the original page to
     // update, is computed from the given elementOffset and numElementsPerPage argument. Obtains

--- a/src/include/storage/storage_structure/storage_structure_utils.h
+++ b/src/include/storage/storage_structure/storage_structure_utils.h
@@ -52,6 +52,13 @@ public:
     static void readWALVersionOfPage(BMFileHandle& fileHandle, common::page_idx_t originalPageIdx,
         BufferManager& bufferManager, WAL& wal, const std::function<void(uint8_t*)>& readOp);
 
+    static common::page_idx_t insertNewPage(
+        BMFileHandle& fileHandle, StorageStructureID storageStructureID,
+        BufferManager& bufferManager, WAL& wal,
+        std::function<void(uint8_t*)> insertOp = [](uint8_t*) -> void {
+            // DO NOTHING.
+        });
+
     // Note: This function updates a page "transactionally", i.e., creates the WAL version of the
     // page if it doesn't exist. For the original page to be updated, the current WRITE trx needs to
     // commit and checkpoint.

--- a/src/include/storage/store/node_column.h
+++ b/src/include/storage/store/node_column.h
@@ -101,9 +101,6 @@ protected:
     void writeValue(common::offset_t nodeOffset, common::ValueVector* vectorToWriteFrom,
         uint32_t posInVectorToWriteFrom);
 
-    // TODO(Guodong): This is mostly duplicated with StorageStructure::addNewPageToFileHandle().
-    // Should be cleaned up later.
-    void addNewPageToDataFH();
     // TODO(Guodong): This is mostly duplicated with
     // StorageStructure::createWALVersionOfPageIfNecessaryForElement(). Should be cleared later.
     WALPageIdxPosInPageAndFrame createWALVersionOfPageForValue(common::offset_t nodeOffset);

--- a/src/include/storage/wal_replayer_utils.h
+++ b/src/include/storage/wal_replayer_utils.h
@@ -13,17 +13,6 @@ namespace storage {
 
 class WALReplayerUtils {
 public:
-    static inline void initPropertyMetadataDAsOnDisk(
-        catalog::Property& property, BMFileHandle* metadataFH) {
-        saveMetaDAs(metadataFH, *property.getMetadataDAHInfo());
-    }
-    static inline void initTableMetadataDAsOnDisk(
-        catalog::NodeTableSchema* tableSchema, BMFileHandle* metadataFH) {
-        for (auto& property : tableSchema->properties) {
-            initPropertyMetadataDAsOnDisk(*property, metadataFH);
-        }
-    }
-
     static inline void removeHashIndexFile(
         catalog::NodeTableSchema* tableSchema, const std::string& directory) {
         fileOperationOnNodeFiles(
@@ -51,19 +40,6 @@ public:
         catalog::RelTableSchema* relTableSchema, common::property_id_t propertyID);
 
 private:
-    static inline void saveMetaDAs(
-        BMFileHandle* metadataFH, const catalog::MetadataDAHInfo& metaDAHeaderInfo) {
-        std::make_unique<InMemDiskArrayBuilder<ColumnChunkMetadata>>(
-            *reinterpret_cast<FileHandle*>(metadataFH), metaDAHeaderInfo.dataDAHPageIdx, 0)
-            ->saveToDisk();
-        std::make_unique<InMemDiskArrayBuilder<ColumnChunkMetadata>>(
-            *reinterpret_cast<FileHandle*>(metadataFH), metaDAHeaderInfo.nullDAHPageIdx, 0)
-            ->saveToDisk();
-        for (auto& childMetaDAHeaderInfo : metaDAHeaderInfo.childrenInfos) {
-            saveMetaDAs(metadataFH, *childMetaDAHeaderInfo);
-        }
-    }
-
     static inline void removeColumnFilesForPropertyIfExists(const std::string& directory,
         common::table_id_t relTableID, common::table_id_t boundTableID,
         common::RelDataDirection relDirection, common::property_id_t propertyID,

--- a/src/processor/operator/ddl/add_node_property.cpp
+++ b/src/processor/operator/ddl/add_node_property.cpp
@@ -4,9 +4,9 @@ namespace kuzu {
 namespace processor {
 
 void AddNodeProperty::executeDDLInternal() {
-    AddProperty::executeDDLInternal();
-    auto property = catalog->getWriteVersion()->getNodeProperty(tableID, propertyName);
-    property->setMetadataDAHInfo(storageManager.initMetadataDAHInfo(*dataType));
+    auto metadataDAHInfo = storageManager.createMetadataDAHInfo(*dataType);
+    catalog->addNodeProperty(
+        tableID, propertyName, std::move(dataType), std::move(metadataDAHInfo));
 }
 
 } // namespace processor

--- a/src/processor/operator/ddl/add_property.cpp
+++ b/src/processor/operator/ddl/add_property.cpp
@@ -3,12 +3,8 @@
 namespace kuzu {
 namespace processor {
 
-void AddProperty::executeDDLInternal() {
-    defaultValueEvaluator->evaluate();
-    catalog->addProperty(tableID, propertyName, dataType->copy());
-}
-
 uint8_t* AddProperty::getDefaultVal() {
+    defaultValueEvaluator->evaluate();
     auto expressionVector = defaultValueEvaluator->resultVector;
     assert(defaultValueEvaluator->resultVector->dataType == *dataType);
     auto posInExpressionVector = expressionVector->state->selVector->selectedPositions[0];

--- a/src/processor/operator/ddl/add_rel_property.cpp
+++ b/src/processor/operator/ddl/add_rel_property.cpp
@@ -6,7 +6,7 @@ namespace kuzu {
 namespace processor {
 
 void AddRelProperty::executeDDLInternal() {
-    AddProperty::executeDDLInternal();
+    catalog->addRelProperty(tableID, propertyName, dataType->copy());
     auto tableSchema = catalog->getWriteVersion()->getRelTableSchema(tableID);
     auto property = tableSchema->getProperty(tableSchema->getPropertyID(propertyName));
     StorageUtils::createFileForRelPropertyWithDefaultVal(

--- a/src/processor/operator/ddl/create_node_table.cpp
+++ b/src/processor/operator/ddl/create_node_table.cpp
@@ -10,14 +10,13 @@ namespace kuzu {
 namespace processor {
 
 void CreateNodeTable::executeDDLInternal() {
-    auto newTableID = catalog->addNodeTableSchema(
-        tableName, primaryKeyIdx, catalog::Property::copyProperties(properties));
+    for (auto& property : properties) {
+        property->setMetadataDAHInfo(
+            storageManager.createMetadataDAHInfo(*property->getDataType()));
+    }
+    auto newTableID = catalog->addNodeTableSchema(tableName, primaryKeyIdx, std::move(properties));
     nodesStatistics->addNodeStatisticsAndDeletedIDs(
         catalog->getWriteVersion()->getNodeTableSchema(newTableID));
-    auto tableSchema = catalog->getWriteVersion()->getNodeTableSchema(newTableID);
-    for (auto& property : tableSchema->properties) {
-        property->setMetadataDAHInfo(storageManager.initMetadataDAHInfo(*property->getDataType()));
-    }
 }
 
 std::string CreateNodeTable::getOutputMsg() {

--- a/src/storage/storage_structure/disk_overflow_file.cpp
+++ b/src/storage/storage_structure/disk_overflow_file.cpp
@@ -178,7 +178,7 @@ void DiskOverflowFile::addNewPageIfNecessaryWithoutLock(uint32_t numBytesToAppen
         // Note that if byteCursor.pos is already 0 the next operation keeps the nextBytePos
         // where it is.
         nextBytePosToWriteTo = (fileHandle->getNumPages() * BufferPoolConstants::PAGE_4KB_SIZE);
-        addNewPageToFileHandle();
+        StorageStructureUtils::insertNewPage(*fileHandle, storageStructureID, *bufferManager, *wal);
     }
 }
 


### PR DESCRIPTION
This is a follow up fix to #1802 .
Header pages of metadata DAs are initialized through wal.

Additionally, this PR rewrites some ddl and copy tests that are testing output message and running auto commit inside write transaction.