### PR TITLE
Fix Rust deployment

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -219,7 +219,6 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-      MSRV: 1.67
     steps:
       - uses: actions/checkout@v3
 
@@ -227,20 +226,13 @@ jobs:
         run: python3 update_version.py
         working-directory: tools/rust_api
 
-      - name: Update rust version
-        run: |
-          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
-          ~/.cargo/bin/rustup install ${MSRV} --profile minimal
-          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-        working-directory: tools/rust_api
-
       - name: Deploy crate to Crates.io
-        run: rustup run ${MSRV} cargo publish --allow-dirty
+        run: cargo publish --allow-dirty
         if: ${{ github.event.inputs.isDeploy == 'true' }}
         working-directory: tools/rust_api
 
       - name: Test publishing crate
-        run: rustup run ${MSRV} cargo publish --dry-run --allow-dirty
+        run: cargo publish --dry-run --allow-dirty
         if: ${{ github.event.inputs.isDeploy != 'true' }}
         working-directory: tools/rust_api
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -219,6 +219,7 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      MSRV: 1.67
     steps:
       - uses: actions/checkout@v3
 
@@ -226,13 +227,20 @@ jobs:
         run: python3 update_version.py
         working-directory: tools/rust_api
 
+      - name: Update rust version
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
+          ~/.cargo/bin/rustup install ${MSRV} --profile minimal
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        working-directory: tools/rust_api
+
       - name: Deploy crate to Crates.io
-        run: cargo publish --allow-dirty
+        run: rustup run ${MSRV} cargo publish --allow-dirty
         if: ${{ github.event.inputs.isDeploy == 'true' }}
         working-directory: tools/rust_api
 
       - name: Test publishing crate
-        run: cargo publish --dry-run --allow-dirty
+        run: rustup run ${MSRV} cargo publish --dry-run --allow-dirty
         if: ${{ github.event.inputs.isDeploy != 'true' }}
         working-directory: tools/rust_api
 

--- a/scripts/dockerized-ci-tests-runner/Dockerfile
+++ b/scripts/dockerized-ci-tests-runner/Dockerfile
@@ -17,9 +17,9 @@ RUN /home/runner/.cargo/bin/rustup toolchain install 1.67
 
 RUN mkdir /home/runner/actions-runner
 WORKDIR /home/runner/actions-runner
-RUN curl -o actions-runner-linux-x64-2.306.0.tar.gz -L https://github.com/actions/runner/releases/download/v2.306.0/actions-runner-linux-x64-2.306.0.tar.gz
-RUN echo "b0a090336f0d0a439dac7505475a1fb822f61bbb36420c7b3b3fe6b1bdc4dbaa  actions-runner-linux-x64-2.306.0.tar.gz" | shasum -a 256 -c
-RUN tar xzf ./actions-runner-linux-x64-2.306.0.tar.gz
+RUN curl -o actions-runner-linux-x64-2.307.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.307.1/actions-runner-linux-x64-2.307.1.tar.gz
+RUN echo "038c9e98b3912c5fd6d0b277f2e4266b2a10accc1ff8ff981b9971a8e76b5441  actions-runner-linux-x64-2.307.1.tar.gz" | shasum -a 256 -c
+RUN tar xzf ./actions-runner-linux-x64-2.307.1.tar.gz
 
 COPY --chown=runner:runner start.sh start.sh
 RUN chmod +x start.sh

--- a/scripts/dockerized-ci-tests-runner/Dockerfile
+++ b/scripts/dockerized-ci-tests-runner/Dockerfile
@@ -4,11 +4,16 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends apt-utils curl ca-certificates apt-transport-https gnupg software-properties-common
 RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get update && apt-get install -y g++ gcc clang-14 python3-dev python3-pip python-is-python3 cmake nodejs jq curl sudo git clang-format-11 lsb-release wget lcov libssl-dev libcurl4-openssl-dev rustfmt rustc cargo openjdk-17-jdk
+RUN apt-get update && apt-get install -y g++ gcc clang-14 python3-dev python3-pip python-is-python3 cmake nodejs jq curl sudo git clang-format-11 lsb-release wget lcov libssl-dev libcurl4-openssl-dev openjdk-17-jdk
 
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 RUN useradd --create-home runner
 USER runner
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-update-default-toolchain
+ENV PATH="/home/runner/.cargo/bin:${PATH}"
+RUN /home/runner/.cargo/bin/rustup toolchain install 1.67
+
 
 RUN mkdir /home/runner/actions-runner
 WORKDIR /home/runner/actions-runner

--- a/tools/rust_api/update_version.py
+++ b/tools/rust_api/update_version.py
@@ -13,7 +13,12 @@ def get_kuzu_version():
     with open(cmake_file) as f:
         for line in f:
             if line.startswith("project(Kuzu VERSION"):
-                return line.split(" ")[2].strip()
+                version = line.split(" ")[2].strip()
+                # Make version semver-compatible
+                components = version.split(".")
+                if len(components) >= 4:
+                    version = ".".join(components[0:3]) + "-" + ".".join(components[3:])
+                return version
 
 
 if __name__ == "__main__":
@@ -38,5 +43,5 @@ if __name__ == "__main__":
                     break
 
     if version_changed:
-        with open("Cargo.toml", "w", encoding="utf-8") as file:
+        with open(KUZU_RS_ROOT / "Cargo.toml", "w", encoding="utf-8") as file:
             file.writelines(data)


### PR DESCRIPTION
Fixes #1927.

The rustup install should probably be added to the dockerfile instead of included in the workflow, but I thought it would be easier to test it this way.

I've tested it and it's working: https://github.com/kuzudb/kuzu/actions/runs/5858238195/job/15881791303

I also had to fix the version parsing since` 0.0.6.5` is not a valid [semantic version](https://semver.org/) (so I made the fourth component be turned into a pre-release version, e.g. `0.0.6-5`).