### PR TITLE
Add transaction commands to the testing framework

### DIFF
--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -18,13 +18,13 @@ struct TestStatement {
     bool enumerate = false;
     bool checkOutputOrder = false;
     std::string expectedTuplesCSVFile;
-    enum class TransactionType {
+    enum class TransactionCmdType {
         NONE,
         WRITE,
         READ_ONLY,
         COMMIT,
         ROLLBACK
-    } transactionType = TransactionType::NONE;
+    } transactionCmdType = TransactionCmdType::NONE;
 };
 
 // Test group is a collection of test cases in a single file.

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -19,12 +19,12 @@ struct TestStatement {
     bool checkOutputOrder = false;
     std::string expectedTuplesCSVFile;
     enum class TransactionCmdType {
-        NONE,
-        WRITE,
-        READ_ONLY,
+        AUTO_COMMIT,
+        BEGIN_WRITE_TRX,
+        BEGIN_READ_TRX,
         COMMIT,
         ROLLBACK
-    } transactionCmdType = TransactionCmdType::NONE;
+    } transactionCmdType = TransactionCmdType::AUTO_COMMIT;
 };
 
 // Test group is a collection of test cases in a single file.

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -10,15 +10,21 @@ struct TestStatement {
     std::string query;
     uint64_t numThreads = 4;
     std::string encodedJoin;
-    uint64_t expectedNumTuples = 0;
     bool expectedError = false;
-    bool expectedOk = false;
-    std::vector<std::string> expectedTuples;
     std::string errorMessage;
+    bool expectedOk = false;
+    uint64_t expectedNumTuples = 0;
+    std::vector<std::string> expectedTuples;
     bool enumerate = false;
     bool checkOutputOrder = false;
-    bool isBeginWriteTransaction = false;
     std::string expectedTuplesCSVFile;
+    enum class TransactionType {
+        NONE,
+        WRITE,
+        READ_ONLY,
+        COMMIT,
+        ROLLBACK
+    } transactionType = TransactionType::NONE;
 };
 
 // Test group is a collection of test cases in a single file.

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -9,15 +9,17 @@ namespace kuzu {
 namespace testing {
 
 enum class TokenType {
-    /* header */
-    BEGIN_WRITE_TRANSACTION,
+    // header
     DATASET,
     GROUP,
     SKIP,
-    /* body */
+    // body
+    BEGIN_READ_ONLY_TRANSACTION,
+    BEGIN_WRITE_TRANSACTION,
     BUFFER_POOL_SIZE,
     CASE,
     CHECK_ORDER,
+    COMMIT,
     DEFINE,
     DEFINE_STATEMENT_BLOCK,
     EMPTY,
@@ -28,22 +30,25 @@ enum class TokenType {
     LOG,
     PARALLELISM,
     RESULT,
+    ROLLBACK,
     SEPARATOR,
     STATEMENT,
     _SKIP_LINE
 };
 
 const std::unordered_map<std::string, TokenType> tokenMap = {{"-GROUP", TokenType::GROUP},
-    {"-DATASET", TokenType::DATASET}, {"-CASE", TokenType::CASE},
+    {"-DATASET", TokenType::DATASET}, {"-CASE", TokenType::CASE}, {"-COMMIT", TokenType::COMMIT},
     {"-CHECK_ORDER", TokenType::CHECK_ORDER}, {"-ENCODED_JOIN", TokenType::ENCODED_JOIN},
     {"-LOG", TokenType::LOG}, {"-DEFINE_STATEMENT_BLOCK", TokenType::DEFINE_STATEMENT_BLOCK},
     {"-ENUMERATE", TokenType::ENUMERATE},
     {"-BEGIN_WRITE_TRANSACTION", TokenType::BEGIN_WRITE_TRANSACTION},
+    {"-BEGIN_READ_ONLY_TRANSACTION", TokenType::BEGIN_READ_ONLY_TRANSACTION},
     {"-PARALLELISM", TokenType::PARALLELISM}, {"-SKIP", TokenType::SKIP},
     {"-DEFINE", TokenType::DEFINE}, {"-STATEMENT", TokenType::STATEMENT},
     {"-INSERT_STATEMENT_BLOCK", TokenType::INSERT_STATEMENT_BLOCK},
-    {"-BUFFER_POOL_SIZE", TokenType::BUFFER_POOL_SIZE}, {"]", TokenType::END_OF_STATEMENT_BLOCK},
-    {"----", TokenType::RESULT}, {"--", TokenType::SEPARATOR}, {"#", TokenType::EMPTY}};
+    {"-ROLLBACK", TokenType::ROLLBACK}, {"-BUFFER_POOL_SIZE", TokenType::BUFFER_POOL_SIZE},
+    {"]", TokenType::END_OF_STATEMENT_BLOCK}, {"----", TokenType::RESULT},
+    {"--", TokenType::SEPARATOR}, {"#", TokenType::EMPTY}};
 
 class LogicToken {
 public:

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -17,7 +17,6 @@ public:
         const std::string& query, main::Connection& conn);
 
 private:
-    static void initializeConnection(TestStatement* statement, main::Connection& conn);
     static bool testStatement(
         TestStatement* statement, main::Connection& conn, std::string& databasePath);
     static bool checkLogicalPlans(std::unique_ptr<main::PreparedStatement>& preparedStatement,

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -172,7 +172,19 @@ TestStatement* TestParser::extractStatement(TestStatement* statement) {
         break;
     }
     case TokenType::BEGIN_WRITE_TRANSACTION: {
-        statement->isBeginWriteTransaction = true;
+        statement->transactionType = TestStatement::TransactionType::WRITE;
+        return statement;
+    }
+    case TokenType::BEGIN_READ_ONLY_TRANSACTION: {
+        statement->transactionType = TestStatement::TransactionType::READ_ONLY;
+        return statement;
+    }
+    case TokenType::COMMIT: {
+        statement->transactionType = TestStatement::TransactionType::COMMIT;
+        return statement;
+    }
+    case TokenType::ROLLBACK: {
+        statement->transactionType = TestStatement::TransactionType::ROLLBACK;
         return statement;
     }
     case TokenType::EMPTY: {

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -172,19 +172,19 @@ TestStatement* TestParser::extractStatement(TestStatement* statement) {
         break;
     }
     case TokenType::BEGIN_WRITE_TRANSACTION: {
-        statement->transactionType = TestStatement::TransactionType::WRITE;
+        statement->transactionCmdType = TestStatement::TransactionCmdType::WRITE;
         return statement;
     }
     case TokenType::BEGIN_READ_ONLY_TRANSACTION: {
-        statement->transactionType = TestStatement::TransactionType::READ_ONLY;
+        statement->transactionCmdType = TestStatement::TransactionCmdType::READ_ONLY;
         return statement;
     }
     case TokenType::COMMIT: {
-        statement->transactionType = TestStatement::TransactionType::COMMIT;
+        statement->transactionCmdType = TestStatement::TransactionCmdType::COMMIT;
         return statement;
     }
     case TokenType::ROLLBACK: {
-        statement->transactionType = TestStatement::TransactionType::ROLLBACK;
+        statement->transactionCmdType = TestStatement::TransactionCmdType::ROLLBACK;
         return statement;
     }
     case TokenType::EMPTY: {

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -172,11 +172,11 @@ TestStatement* TestParser::extractStatement(TestStatement* statement) {
         break;
     }
     case TokenType::BEGIN_WRITE_TRANSACTION: {
-        statement->transactionCmdType = TestStatement::TransactionCmdType::WRITE;
+        statement->transactionCmdType = TestStatement::TransactionCmdType::BEGIN_WRITE_TRX;
         return statement;
     }
     case TokenType::BEGIN_READ_ONLY_TRANSACTION: {
-        statement->transactionCmdType = TestStatement::TransactionCmdType::READ_ONLY;
+        statement->transactionCmdType = TestStatement::TransactionCmdType::BEGIN_READ_TRX;
         return statement;
     }
     case TokenType::COMMIT: {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -15,11 +15,24 @@ void TestRunner::runTest(const std::vector<std::unique_ptr<TestStatement>>& stat
     Connection& conn, std::string& databasePath) {
     for (auto& statement : statements) {
         initializeConnection(statement.get(), conn);
-        if (statement->isBeginWriteTransaction) {
+        switch (statement->transactionType) {
+        case TestStatement::TransactionType::WRITE:
             conn.beginWriteTransaction();
-            continue;
+            break;
+        case TestStatement::TransactionType::READ_ONLY:
+            conn.beginReadOnlyTransaction();
+            break;
+        case TestStatement::TransactionType::COMMIT:
+            conn.commit();
+            break;
+        case TestStatement::TransactionType::ROLLBACK:
+            conn.rollback();
+            break;
+        case TestStatement::TransactionType::NONE:
+        default:
+            ASSERT_TRUE(testStatement(statement.get(), conn, databasePath));
+            break;
         }
-        ASSERT_TRUE(testStatement(statement.get(), conn, databasePath));
     }
 }
 

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -14,32 +14,27 @@ namespace testing {
 void TestRunner::runTest(const std::vector<std::unique_ptr<TestStatement>>& statements,
     Connection& conn, std::string& databasePath) {
     for (auto& statement : statements) {
-        initializeConnection(statement.get(), conn);
-        switch (statement->transactionType) {
-        case TestStatement::TransactionType::WRITE:
+        spdlog::info("DEBUG LOG: {}", statement->logMessage);
+        spdlog::info("QUERY: {}", statement->query);
+        conn.setMaxNumThreadForExec(statement->numThreads);
+        switch (statement->transactionCmdType) {
+        case TestStatement::TransactionCmdType::WRITE:
             conn.beginWriteTransaction();
             break;
-        case TestStatement::TransactionType::READ_ONLY:
+        case TestStatement::TransactionCmdType::READ_ONLY:
             conn.beginReadOnlyTransaction();
             break;
-        case TestStatement::TransactionType::COMMIT:
+        case TestStatement::TransactionCmdType::COMMIT:
             conn.commit();
             break;
-        case TestStatement::TransactionType::ROLLBACK:
+        case TestStatement::TransactionCmdType::ROLLBACK:
             conn.rollback();
             break;
-        case TestStatement::TransactionType::NONE:
         default:
             ASSERT_TRUE(testStatement(statement.get(), conn, databasePath));
             break;
         }
     }
-}
-
-void TestRunner::initializeConnection(TestStatement* statement, Connection& conn) {
-    spdlog::info("DEBUG LOG: {}", statement->logMessage);
-    spdlog::info("QUERY: {}", statement->query);
-    conn.setMaxNumThreadForExec(statement->numThreads);
 }
 
 bool TestRunner::testStatement(

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -18,10 +18,10 @@ void TestRunner::runTest(const std::vector<std::unique_ptr<TestStatement>>& stat
         spdlog::info("QUERY: {}", statement->query);
         conn.setMaxNumThreadForExec(statement->numThreads);
         switch (statement->transactionCmdType) {
-        case TestStatement::TransactionCmdType::WRITE:
+        case TestStatement::TransactionCmdType::BEGIN_WRITE_TRX:
             conn.beginWriteTransaction();
             break;
-        case TestStatement::TransactionCmdType::READ_ONLY:
+        case TestStatement::TransactionCmdType::BEGIN_READ_TRX:
             conn.beginReadOnlyTransaction();
             break;
         case TestStatement::TransactionCmdType::COMMIT:


### PR DESCRIPTION
This commit adds the following commands to the testing framework: 

```
-BEGIN_READ_ONLY_TRANSACTION
-COMMIT
-ROLLBACK
```