### PR TITLE
Include functions from arrow feature in docs.rs rust docs

### DIFF
--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -48,3 +48,6 @@ time = {version="0.3", features=["macros"]}
 [features]
 default = []
 arrow = ["dep:arrow"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
The arrow feature currently shows up on docs.rs (https://docs.rs/crate/kuzu/0.0.7/features), but the `iter_arrow` function it provides doesn't, since the arrow feature is disabled by default. However you can set the features used to build the docs on docs.rs via [a docs.rs-specific table in Cargo.toml](https://docs.rs/about/metadata).  

This won't have any effect until the next release, but the docs can be built manually with the arrow feature (e.g. `DOCS_RS=1 cargo build --features arrow` (setting the DOCS_RS env variable skips building the kuzu C++ library since it's not needed for documentation)).