### PR TITLE
Rename keys in agg hash table

### DIFF
--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -63,6 +63,7 @@ private:
     std::vector<common::ValueVector*> flatKeyVectors;
     std::vector<common::ValueVector*> unFlatKeyVectors;
     std::vector<common::ValueVector*> dependentKeyVectors;
+    common::DataChunkState* leadingState;
 
     std::shared_ptr<HashAggregateSharedState> sharedState;
     std::unique_ptr<AggregateHashTable> localAggregateHashTable;

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -66,6 +66,8 @@ void HashAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
         dependentKeyVectors.push_back(vector);
         payloadDataTypes.push_back(vector->dataType);
     }
+    leadingState = unFlatKeyVectors.empty() ? flatKeyVectors[0]->state.get() :
+                                              unFlatKeyVectors[0]->state.get();
     localAggregateHashTable = make_unique<AggregateHashTable>(
         *context->memoryManager, keyDataTypes, payloadDataTypes, aggregateFunctions, 0);
 }
@@ -73,7 +75,7 @@ void HashAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
 void HashAggregate::executeInternal(ExecutionContext* context) {
     while (children[0]->getNextTuple(context)) {
         localAggregateHashTable->append(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors,
-            aggregateInputs, resultSet->multiplicity);
+            leadingState, aggregateInputs, resultSet->multiplicity);
     }
     sharedState->appendAggregateHashTable(std::move(localAggregateHashTable));
 }


### PR DESCRIPTION
Rename groupByXXXHashKeys -> XXXKeys.

Passing in a leading dataChunk state to remove code like

` groupByUnFlatHashKeyVectors.empty() ? 1: groupByUnFlatHashKeyVectors[0]->state->selVector->selectedSize`.