### PR TITLE
Expression Constant Folding

### DIFF
--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -80,7 +80,6 @@ std::shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
     } else if (ExpressionUtil::isRelVariable(*child)) {
         return bindRelPropertyExpression(*child, propertyName);
     } else {
-        assert(child->expressionType == FUNCTION);
         return bindStructPropertyExpression(child, propertyName);
     }
 }

--- a/src/binder/expression/case_expression.cpp
+++ b/src/binder/expression/case_expression.cpp
@@ -3,7 +3,7 @@
 namespace kuzu {
 namespace binder {
 
-std::string CaseExpression::toString() const {
+std::string CaseExpression::toStringInternal() const {
     std::string result = "CASE ";
     for (auto& caseAlternative : caseAlternatives) {
         result += "WHEN " + caseAlternative->whenExpression->toString() + " THEN " +

--- a/src/binder/expression/function_expression.cpp
+++ b/src/binder/expression/function_expression.cpp
@@ -15,7 +15,7 @@ std::string ScalarFunctionExpression::getUniqueName(
     return result;
 }
 
-std::string ScalarFunctionExpression::toString() const {
+std::string ScalarFunctionExpression::toStringInternal() const {
     auto result = functionName + "(";
     result += ExpressionUtil::toString(children);
     result += ")";
@@ -35,7 +35,7 @@ std::string AggregateFunctionExpression::getUniqueName(
     return result;
 }
 
-std::string AggregateFunctionExpression::toString() const {
+std::string AggregateFunctionExpression::toStringInternal() const {
     auto result = functionName + "(";
     if (isDistinct()) {
         result += "DISTINCT ";

--- a/src/expression_evaluator/CMakeLists.txt
+++ b/src/expression_evaluator/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(kuzu_expression_evaluator
         OBJECT
-        base_evaluator.cpp
         case_evaluator.cpp
+        expression_evaluator.cpp
+        expression_evaluator_utils.cpp
         function_evaluator.cpp
         literal_evaluator.cpp
         node_rel_evaluator.cpp

--- a/src/expression_evaluator/expression_evaluator.cpp
+++ b/src/expression_evaluator/expression_evaluator.cpp
@@ -1,4 +1,4 @@
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 
 using namespace kuzu::common;
 

--- a/src/expression_evaluator/expression_evaluator_utils.cpp
+++ b/src/expression_evaluator/expression_evaluator_utils.cpp
@@ -1,0 +1,23 @@
+#include "expression_evaluator/expression_evaluator_utils.h"
+
+#include "processor/expression_mapper.h"
+
+using namespace kuzu::common;
+using namespace kuzu::processor;
+
+namespace kuzu {
+namespace evaluator {
+
+std::unique_ptr<Value> ExpressionEvaluatorUtils::evaluateConstantExpression(
+    const std::shared_ptr<binder::Expression>& expression, storage::MemoryManager* memoryManager) {
+    auto evaluator = ExpressionMapper::getConstantEvaluator(expression);
+    auto emptyResultSet = std::make_unique<ResultSet>(0);
+    evaluator->init(*emptyResultSet, memoryManager);
+    evaluator->evaluate();
+    auto selVector = evaluator->resultVector->state->selVector.get();
+    assert(selVector->selectedSize == 1);
+    return evaluator->resultVector->getAsValue(selVector->selectedPositions[0]);
+}
+
+} // namespace evaluator
+} // namespace kuzu

--- a/src/expression_evaluator/path_evaluator.cpp
+++ b/src/expression_evaluator/path_evaluator.cpp
@@ -40,8 +40,9 @@ void PathExpressionEvaluator::init(
     for (auto& fieldVector : StructVector::getFieldVectors(resultRelsDataVector)) {
         resultRelsFieldVectors.push_back(fieldVector.get());
     }
-    for (auto i = 0u; i < pathExpression->getNumChildren(); ++i) {
-        auto child = pathExpression->getChild(i).get();
+    auto pathExpression = (PathExpression*)expression.get();
+    for (auto i = 0u; i < expression->getNumChildren(); ++i) {
+        auto child = expression->getChild(i).get();
         auto vectors = std::make_unique<InputVectors>();
         vectors->input = children[i]->resultVector.get();
         switch (child->dataType.getLogicalTypeID()) {
@@ -99,8 +100,8 @@ static inline uint32_t getCurrentPos(ValueVector* vector, uint32_t pos) {
 void PathExpressionEvaluator::copyNodes(sel_t resultPos) {
     auto listSize = 0u;
     // Calculate list size.
-    for (auto i = 0; i < pathExpression->getNumChildren(); ++i) {
-        auto child = pathExpression->getChild(i).get();
+    for (auto i = 0; i < expression->getNumChildren(); ++i) {
+        auto child = expression->getChild(i).get();
         switch (child->dataType.getLogicalTypeID()) {
         case LogicalTypeID::NODE: {
             listSize++;
@@ -119,8 +120,8 @@ void PathExpressionEvaluator::copyNodes(sel_t resultPos) {
     resultNodesVector->setValue(resultPos, entry);
     // Copy field vectors
     offset_t resultDataPos = entry.offset;
-    for (auto i = 0; i < pathExpression->getNumChildren(); ++i) {
-        auto child = pathExpression->getChild(i).get();
+    for (auto i = 0; i < expression->getNumChildren(); ++i) {
+        auto child = expression->getChild(i).get();
         auto vectors = inputVectorsPerChild[i].get();
         auto inputPos = getCurrentPos(vectors->input, resultPos);
         switch (child->dataType.getLogicalTypeID()) {
@@ -144,8 +145,8 @@ void PathExpressionEvaluator::copyNodes(sel_t resultPos) {
 void PathExpressionEvaluator::copyRels(sel_t resultPos) {
     auto listSize = 0u;
     // Calculate list size.
-    for (auto i = 0; i < pathExpression->getNumChildren(); ++i) {
-        auto child = pathExpression->getChild(i).get();
+    for (auto i = 0; i < expression->getNumChildren(); ++i) {
+        auto child = expression->getChild(i).get();
         switch (child->dataType.getLogicalTypeID()) {
         case LogicalTypeID::REL: {
             listSize++;
@@ -164,8 +165,8 @@ void PathExpressionEvaluator::copyRels(sel_t resultPos) {
     resultRelsVector->setValue(resultPos, entry);
     // Copy field vectors
     offset_t resultDataPos = entry.offset;
-    for (auto i = 0; i < pathExpression->getNumChildren(); ++i) {
-        auto child = pathExpression->getChild(i).get();
+    for (auto i = 0; i < expression->getNumChildren(); ++i) {
+        auto child = expression->getChild(i).get();
         auto vectors = inputVectorsPerChild[i].get();
         auto inputPos = getCurrentPos(vectors->input, resultPos);
         switch (child->dataType.getLogicalTypeID()) {
@@ -206,7 +207,7 @@ void PathExpressionEvaluator::copyFieldVectors(offset_t inputVectorPos,
 
 void PathExpressionEvaluator::resolveResultVector(
     const processor::ResultSet& resultSet, storage::MemoryManager* memoryManager) {
-    resultVector = std::make_shared<ValueVector>(pathExpression->getDataType(), memoryManager);
+    resultVector = std::make_shared<ValueVector>(expression->getDataType(), memoryManager);
     std::vector<ExpressionEvaluator*> inputEvaluators;
     inputEvaluators.reserve(children.size());
     for (auto& child : children) {

--- a/src/function/built_in_vector_functions.cpp
+++ b/src/function/built_in_vector_functions.cpp
@@ -38,17 +38,6 @@ void BuiltInVectorFunctions::registerVectorFunctions() {
     registerBlobFunctions();
 }
 
-bool BuiltInVectorFunctions::canApplyStaticEvaluation(
-    const std::string& functionName, const binder::expression_vector& children) {
-    if ((functionName == CAST_TO_DATE_FUNC_NAME || functionName == CAST_TO_TIMESTAMP_FUNC_NAME ||
-            functionName == CAST_TO_INTERVAL_FUNC_NAME) &&
-        children[0]->expressionType == LITERAL &&
-        children[0]->dataType.getLogicalTypeID() == LogicalTypeID::STRING) {
-        return true; // bind as literal
-    }
-    return false;
-}
-
 VectorFunctionDefinition* BuiltInVectorFunctions::matchVectorFunction(
     const std::string& name, const std::vector<LogicalType>& inputTypes) {
     auto& functionDefinitions = vectorFunctions.at(name);

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -57,9 +57,11 @@ class Binder {
     friend class ExpressionBinder;
 
 public:
-    explicit Binder(const catalog::Catalog& catalog, main::ClientContext* clientContext)
-        : catalog{catalog}, lastExpressionId{0}, scope{std::make_unique<BinderScope>()},
-          expressionBinder{this}, clientContext{clientContext} {}
+    explicit Binder(const catalog::Catalog& catalog, storage::MemoryManager* memoryManager,
+        main::ClientContext* clientContext)
+        : catalog{catalog}, memoryManager{memoryManager}, lastExpressionId{0},
+          scope{std::make_unique<BinderScope>()}, expressionBinder{this}, clientContext{
+                                                                              clientContext} {}
 
     std::unique_ptr<BoundStatement> bind(const parser::Statement& statement);
 
@@ -241,6 +243,7 @@ private:
 
 private:
     const catalog::Catalog& catalog;
+    storage::MemoryManager* memoryManager;
     uint32_t lastExpressionId;
     std::unique_ptr<BinderScope> scope;
     ExpressionBinder expressionBinder;

--- a/src/include/binder/expression/case_expression.h
+++ b/src/include/binder/expression/case_expression.h
@@ -32,7 +32,7 @@ public:
 
     inline std::shared_ptr<Expression> getElseExpression() const { return elseExpression; }
 
-    std::string toString() const override;
+    std::string toStringInternal() const final;
 
 private:
     std::vector<std::unique_ptr<CaseAlternative>> caseAlternatives;

--- a/src/include/binder/expression/existential_subquery_expression.h
+++ b/src/include/binder/expression/existential_subquery_expression.h
@@ -27,7 +27,7 @@ public:
         return hasWhereExpression() ? whereExpression->splitOnAND() : expression_vector{};
     }
 
-    std::string toString() const override { return rawName; }
+    std::string toStringInternal() const final { return rawName; }
 
 private:
     std::unique_ptr<QueryGraphCollection> queryGraphCollection;

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -33,29 +33,24 @@ public:
         expression_vector children, std::string uniqueName)
         : expressionType{expressionType}, dataType{std::move(dataType)},
           uniqueName{std::move(uniqueName)}, children{std::move(children)} {}
-
     // Create binary expression.
     Expression(common::ExpressionType expressionType, common::LogicalType dataType,
         const std::shared_ptr<Expression>& left, const std::shared_ptr<Expression>& right,
         std::string uniqueName)
         : Expression{expressionType, std::move(dataType), expression_vector{left, right},
               std::move(uniqueName)} {}
-
     // Create unary expression.
     Expression(common::ExpressionType expressionType, common::LogicalType dataType,
         const std::shared_ptr<Expression>& child, std::string uniqueName)
         : Expression{expressionType, std::move(dataType), expression_vector{child},
               std::move(uniqueName)} {}
-
     // Create leaf expression
     Expression(
         common::ExpressionType expressionType, common::LogicalType dataType, std::string uniqueName)
         : Expression{
               expressionType, std::move(dataType), expression_vector{}, std::move(uniqueName)} {}
-
     virtual ~Expression() = default;
 
-public:
     inline void setAlias(const std::string& name) { alias = name; }
 
     inline std::string getUniqueName() const {
@@ -67,14 +62,13 @@ public:
     inline common::LogicalType& getDataTypeReference() { return dataType; }
 
     inline bool hasAlias() const { return !alias.empty(); }
-
     inline std::string getAlias() const { return alias; }
 
     inline uint32_t getNumChildren() const { return children.size(); }
-
     inline std::shared_ptr<Expression> getChild(common::vector_idx_t idx) const {
         return children[idx];
     }
+    inline expression_vector getChildren() const { return children; }
     inline void setChild(common::vector_idx_t idx, std::shared_ptr<Expression> child) {
         children[idx] = std::move(child);
     }
@@ -83,11 +77,14 @@ public:
 
     inline bool operator==(const Expression& rhs) const { return uniqueName == rhs.uniqueName; }
 
-    virtual std::string toString() const = 0;
+    std::string toString() const { return hasAlias() ? alias : toStringInternal(); }
 
     virtual std::unique_ptr<Expression> copy() const {
         throw common::InternalException("Unimplemented expression copy().");
     }
+
+protected:
+    virtual std::string toStringInternal() const = 0;
 
 public:
     common::ExpressionType expressionType;

--- a/src/include/binder/expression/function_expression.h
+++ b/src/include/binder/expression/function_expression.h
@@ -31,7 +31,7 @@ public:
     inline std::string getFunctionName() const { return functionName; }
     inline function::FunctionBindData* getBindData() const { return bindData.get(); }
 
-    std::string toString() const override = 0;
+    std::string toStringInternal() const override = 0;
 
 protected:
     std::string functionName;
@@ -59,7 +59,7 @@ public:
 
     static std::string getUniqueName(const std::string& functionName, expression_vector& children);
 
-    std::string toString() const override;
+    std::string toStringInternal() const final;
 
 public:
     function::scalar_exec_func execFunc;
@@ -89,7 +89,7 @@ public:
 
     inline bool isDistinct() const { return aggregateFunction->isFunctionDistinct(); }
 
-    std::string toString() const override;
+    std::string toStringInternal() const final;
 
 public:
     std::unique_ptr<function::AggregateFunction> aggregateFunction;

--- a/src/include/binder/expression/literal_expression.h
+++ b/src/include/binder/expression/literal_expression.h
@@ -21,7 +21,7 @@ public:
 
     inline common::Value* getValue() const { return value.get(); }
 
-    std::string toString() const override { return value->toString(); }
+    std::string toStringInternal() const final { return value->toString(); }
 
 public:
     std::unique_ptr<common::Value> value;

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -59,7 +59,7 @@ public:
     }
     inline std::shared_ptr<Expression> getLabelExpression() const { return labelExpression; }
 
-    std::string toString() const override { return variableName; }
+    inline std::string toStringInternal() const final { return variableName; }
 
 protected:
     std::string variableName;

--- a/src/include/binder/expression/parameter_expression.h
+++ b/src/include/binder/expression/parameter_expression.h
@@ -22,7 +22,7 @@ public:
 
     inline std::shared_ptr<common::Value> getLiteral() const { return value; }
 
-    std::string toString() const override { return "$" + parameterName; }
+    inline std::string toStringInternal() const final { return "$" + parameterName; }
 
 private:
     inline static std::string createUniqueName(const std::string& input) { return "$" + input; }

--- a/src/include/binder/expression/path_expression.h
+++ b/src/include/binder/expression/path_expression.h
@@ -18,7 +18,7 @@ public:
     inline std::shared_ptr<NodeExpression> getNode() const { return node; }
     inline std::shared_ptr<RelExpression> getRel() const { return rel; }
 
-    inline std::string toString() const override { return variableName; }
+    inline std::string toStringInternal() const final { return variableName; }
 
 private:
     std::string variableName;

--- a/src/include/binder/expression/property_expression.h
+++ b/src/include/binder/expression/property_expression.h
@@ -44,7 +44,9 @@ public:
         return make_unique<PropertyExpression>(*this);
     }
 
-    inline std::string toString() const override { return rawVariableName + "." + propertyName; }
+    inline std::string toStringInternal() const final {
+        return rawVariableName + "." + propertyName;
+    }
 
 private:
     bool isPrimaryKey_ = false;

--- a/src/include/binder/expression/variable_expression.h
+++ b/src/include/binder/expression/variable_expression.h
@@ -12,7 +12,7 @@ public:
         : Expression{common::VARIABLE, dataType, std::move(uniqueName)}, variableName{std::move(
                                                                              variableName)} {}
 
-    std::string toString() const override { return variableName; }
+    inline std::string toStringInternal() const final { return variableName; }
 
 private:
     std::string variableName;

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -22,6 +22,9 @@ public:
     static void resolveAnyDataType(Expression& expression, const common::LogicalType& targetType);
 
 private:
+    // TODO(Xiyang): move to an expression rewriter
+    std::shared_ptr<Expression> foldExpression(std::shared_ptr<Expression> expression);
+
     // Boolean expressions.
     std::shared_ptr<Expression> bindBooleanExpression(
         const parser::ParsedExpression& parsedExpression);
@@ -67,8 +70,6 @@ private:
         bool isDistinct);
     std::shared_ptr<Expression> bindMacroExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& macroName);
-    std::shared_ptr<Expression> staticEvaluate(
-        const std::string& functionName, const expression_vector& children);
 
     std::shared_ptr<Expression> rewriteFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName);

--- a/src/include/binder/expression_visitor.h
+++ b/src/include/binder/expression_visitor.h
@@ -21,20 +21,28 @@ private:
 
 class ExpressionVisitor {
 public:
-    static bool hasAggregateExpression(const Expression& expression) {
-        return hasExpression(expression, [&](const Expression& expression) {
+    static inline bool hasAggregate(const Expression& expression) {
+        return satisfyAny(expression, [&](const Expression& expression) {
             return common::isExpressionAggregate(expression.expressionType);
         });
     }
 
-    static bool hasSubqueryExpression(const Expression& expression) {
-        return hasExpression(expression, [&](const Expression& expression) {
+    static inline bool hasSubquery(const Expression& expression) {
+        return satisfyAny(expression, [&](const Expression& expression) {
             return common::isExpressionSubquery(expression.expressionType);
         });
     }
 
+    static inline bool needFold(const Expression& expression) {
+        return expression.expressionType == common::ExpressionType::LITERAL ?
+                   false :
+                   isConstant(expression);
+    }
+
+    static bool isConstant(const Expression& expression);
+
 private:
-    static bool hasExpression(
+    static bool satisfyAny(
         const Expression& expression, const std::function<bool(const Expression&)>& condition);
 };
 

--- a/src/include/common/types/value.h
+++ b/src/include/common/types/value.h
@@ -17,6 +17,7 @@ class FileInfo;
 class NestedVal;
 class RecursiveRelVal;
 class ArrowRowBatch;
+class ValueVector;
 
 class Value {
     friend class NodeVal;
@@ -24,6 +25,7 @@ class Value {
     friend class NestedVal;
     friend class RecursiveRelVal;
     friend class ArrowRowBatch;
+    friend class ValueVector;
 
 public:
     /**

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -69,6 +69,7 @@ public:
     void copyFromVectorData(uint64_t dstPos, const ValueVector* srcVector, uint64_t srcPos);
 
     void copyFromValue(uint64_t pos, const Value& value);
+    std::unique_ptr<Value> getAsValue(uint64_t pos);
 
     inline uint8_t* getData() const { return valueBuffer.get(); }
 

--- a/src/include/expression_evaluator/case_evaluator.h
+++ b/src/include/expression_evaluator/case_evaluator.h
@@ -2,8 +2,8 @@
 
 #include <bitset>
 
-#include "base_evaluator.h"
 #include "common/exception.h"
+#include "expression_evaluator.h"
 
 namespace kuzu {
 namespace evaluator {

--- a/src/include/expression_evaluator/expression_evaluator.h
+++ b/src/include/expression_evaluator/expression_evaluator.h
@@ -13,10 +13,8 @@ public:
     ExpressionEvaluator() = default;
     // Leaf evaluators (reference or literal)
     explicit ExpressionEvaluator(bool isResultFlat) : isResultFlat_{isResultFlat} {}
-
     explicit ExpressionEvaluator(std::vector<std::unique_ptr<ExpressionEvaluator>> children)
         : children{std::move(children)} {}
-
     virtual ~ExpressionEvaluator() = default;
 
     inline bool isResultFlat() const { return isResultFlat_; }

--- a/src/include/expression_evaluator/expression_evaluator_utils.h
+++ b/src/include/expression_evaluator/expression_evaluator_utils.h
@@ -1,0 +1,14 @@
+#include "binder/expression/expression.h"
+#include "expression_evaluator.h"
+
+namespace kuzu {
+namespace evaluator {
+
+struct ExpressionEvaluatorUtils {
+    static std::unique_ptr<common::Value> evaluateConstantExpression(
+        const std::shared_ptr<binder::Expression>& expression,
+        storage::MemoryManager* memoryManager);
+};
+
+} // namespace evaluator
+} // namespace kuzu

--- a/src/include/expression_evaluator/function_evaluator.h
+++ b/src/include/expression_evaluator/function_evaluator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "base_evaluator.h"
+#include "expression_evaluator.h"
 #include "function/vector_functions.h"
 
 namespace kuzu {

--- a/src/include/expression_evaluator/literal_evaluator.h
+++ b/src/include/expression_evaluator/literal_evaluator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "base_evaluator.h"
+#include "expression_evaluator.h"
 
 namespace kuzu {
 namespace evaluator {

--- a/src/include/expression_evaluator/node_rel_evaluator.h
+++ b/src/include/expression_evaluator/node_rel_evaluator.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "base_evaluator.h"
 #include "binder/expression/expression.h"
+#include "expression_evaluator.h"
 
 namespace kuzu {
 namespace evaluator {

--- a/src/include/expression_evaluator/path_evaluator.h
+++ b/src/include/expression_evaluator/path_evaluator.h
@@ -1,16 +1,15 @@
 #pragma once
 
-#include "base_evaluator.h"
-#include "binder/expression/path_expression.h"
+#include "expression_evaluator.h"
 
 namespace kuzu {
 namespace evaluator {
 
 class PathExpressionEvaluator : public ExpressionEvaluator {
 public:
-    PathExpressionEvaluator(std::shared_ptr<binder::PathExpression> pathExpression,
+    PathExpressionEvaluator(std::shared_ptr<binder::Expression> expression,
         std::vector<std::unique_ptr<ExpressionEvaluator>> children)
-        : ExpressionEvaluator{std::move(children)}, pathExpression{std::move(pathExpression)} {}
+        : ExpressionEvaluator{std::move(children)}, expression{std::move(expression)} {}
 
     void init(const processor::ResultSet& resultSet, storage::MemoryManager* memoryManager) final;
 
@@ -25,7 +24,7 @@ public:
         for (auto& child : children) {
             clonedChildren.push_back(child->clone());
         }
-        return make_unique<PathExpressionEvaluator>(pathExpression, std::move(clonedChildren));
+        return make_unique<PathExpressionEvaluator>(expression, std::move(clonedChildren));
     }
 
 private:
@@ -57,7 +56,7 @@ private:
         const std::vector<common::ValueVector*>& resultFieldVectors);
 
 private:
-    std::shared_ptr<binder::PathExpression> pathExpression;
+    std::shared_ptr<binder::Expression> expression;
     std::vector<std::unique_ptr<InputVectors>> inputVectorsPerChild;
     common::ValueVector* resultNodesVector; // LIST[NODE]
     common::ValueVector* resultRelsVector;  // LIST[REL]

--- a/src/include/expression_evaluator/reference_evaluator.h
+++ b/src/include/expression_evaluator/reference_evaluator.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "base_evaluator.h"
+#include "expression_evaluator.h"
 
 namespace kuzu {
 namespace evaluator {

--- a/src/include/function/built_in_vector_functions.h
+++ b/src/include/function/built_in_vector_functions.h
@@ -14,13 +14,6 @@ public:
         return vectorFunctions.contains(functionName);
     }
 
-    /**
-     * Certain function can be evaluated statically and thus avoid runtime execution.
-     * E.g. date("2021-01-01") can be evaluated as date literal statically.
-     */
-    bool canApplyStaticEvaluation(
-        const std::string& functionName, const binder::expression_vector& children);
-
     VectorFunctionDefinition* matchVectorFunction(
         const std::string& name, const std::vector<common::LogicalType>& inputTypes);
 

--- a/src/include/processor/expression_mapper.h
+++ b/src/include/processor/expression_mapper.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "binder/expression/expression.h"
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "processor/execution_context.h"
 #include "processor/result/result_set.h"
 #include "processor/result/result_set_descriptor.h"
@@ -9,38 +9,40 @@
 namespace kuzu {
 namespace processor {
 
-class PlanMapper;
-
 class ExpressionMapper {
-
 public:
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapExpression(
-        const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getEvaluator(
+        const std::shared_ptr<binder::Expression>& expression, const planner::Schema* schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getConstantEvaluator(
+        const std::shared_ptr<binder::Expression>& expression);
 
 private:
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapLiteralExpression(
-        const std::shared_ptr<binder::Expression>& expression);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getLiteralEvaluator(
+        const binder::Expression& expression);
 
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapParameterExpression(
-        const std::shared_ptr<binder::Expression>& expression);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getParameterEvaluator(
+        const binder::Expression& expression);
 
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapReferenceExpression(
-        const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getReferenceEvaluator(
+        std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);
 
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapCaseExpression(
-        const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getCaseEvaluator(
+        std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);
 
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapFunctionExpression(
-        const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getFunctionEvaluator(
+        std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);
 
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapNodeExpression(
-        const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getNodeEvaluator(
+        std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);
 
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapRelExpression(
-        const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getRelEvaluator(
+        std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);
 
-    std::unique_ptr<evaluator::ExpressionEvaluator> mapPathExpression(
-        const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema);
+    static std::unique_ptr<evaluator::ExpressionEvaluator> getPathEvaluator(
+        std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);
+
+    static std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> getEvaluators(
+        const binder::expression_vector& expressions, const planner::Schema* schema);
 };
 
 } // namespace processor

--- a/src/include/processor/operator/ddl/add_property.h
+++ b/src/include/processor/operator/ddl/add_property.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "ddl.h"
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "storage/storage_manager.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/filter.h
+++ b/src/include/processor/operator/filter.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "processor/operator/filtering_operator.h"
 #include "processor/operator/physical_operator.h"
 

--- a/src/include/processor/operator/index_scan.h
+++ b/src/include/processor/operator/index_scan.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "physical_operator.h"
 #include "processor/operator/filtering_operator.h"
 #include "storage/index/hash_index.h"

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "processor/execution_context.h"
 #include "storage/store/node_table.h"
 

--- a/src/include/processor/operator/persistent/set_executor.h
+++ b/src/include/processor/operator/persistent/set_executor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "processor/execution_context.h"
 #include "processor/result/result_set.h"
 #include "storage/store/node_table.h"

--- a/src/include/processor/operator/projection.h
+++ b/src/include/processor/operator/projection.h
@@ -2,7 +2,7 @@
 
 #include <cassert>
 
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "processor/operator/physical_operator.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/unwind.h
+++ b/src/include/processor/operator/unwind.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "binder/expression/expression.h"
-#include "expression_evaluator/base_evaluator.h"
+#include "expression_evaluator/expression_evaluator.h"
 #include "processor/operator/physical_operator.h"
 #include "processor/result/result_set.h"
 

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -161,7 +161,8 @@ std::unique_ptr<PreparedStatement> Connection::prepareNoLock(
         // parsing
         auto statement = Parser::parseQuery(query);
         // binding
-        auto binder = Binder(*database->catalog, clientContext.get());
+        auto binder =
+            Binder(*database->catalog, database->memoryManager.get(), clientContext.get());
         auto boundStatement = binder.bind(*statement);
         preparedStatement->preparedSummary.statementType = boundStatement->getStatementType();
         preparedStatement->readOnly =

--- a/src/planner/plan/plan_subquery.cpp
+++ b/src/planner/plan/plan_subquery.cpp
@@ -121,7 +121,7 @@ void QueryPlanner::planExistsSubquery(
 
 void QueryPlanner::planSubqueryIfNecessary(
     const std::shared_ptr<Expression>& expression, LogicalPlan& plan) {
-    if (ExpressionVisitor::hasSubqueryExpression(*expression)) {
+    if (ExpressionVisitor::hasSubquery(*expression)) {
         auto expressionCollector = std::make_unique<ExpressionCollector>();
         for (auto& expr : expressionCollector->collectTopLevelSubqueryExpressions(expression)) {
             planExistsSubquery(expr, plan);

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -6,6 +6,8 @@
 #include "binder/expression/parameter_expression.h"
 #include "binder/expression/path_expression.h"
 #include "binder/expression/rel_expression.h"
+#include "binder/expression_visitor.h"
+#include "common/string_utils.h"
 #include "expression_evaluator/case_evaluator.h"
 #include "expression_evaluator/function_evaluator.h"
 #include "expression_evaluator/literal_evaluator.h"
@@ -22,108 +24,160 @@ using namespace kuzu::planner;
 namespace kuzu {
 namespace processor {
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapExpression(
-    const std::shared_ptr<Expression>& expression, const Schema& schema) {
-    auto expressionType = expression->expressionType;
-    if (schema.isExpressionInScope(*expression)) {
-        return mapReferenceExpression(expression, schema);
-    } else if (isExpressionLiteral(expressionType)) {
-        return mapLiteralExpression(expression);
-    } else if (ExpressionUtil::isNodeVariable(*expression)) {
-        return mapNodeExpression(expression, schema);
-    } else if (ExpressionUtil::isRelVariable(*expression)) {
-        return mapRelExpression(expression, schema);
-    } else if (expressionType == ExpressionType::PATH) {
-        return mapPathExpression(expression, schema);
-    } else if (expressionType == ExpressionType::PARAMETER) {
-        return mapParameterExpression(expression);
-    } else if (CASE_ELSE == expressionType) {
-        return mapCaseExpression(expression, schema);
-    } else {
-        return mapFunctionExpression(expression, schema);
+static bool canEvaluateAsFunction(ExpressionType expressionType) {
+    switch (expressionType) {
+    case ExpressionType::OR:
+    case ExpressionType::XOR:
+    case ExpressionType::AND:
+    case ExpressionType::NOT:
+    case ExpressionType::EQUALS:
+    case ExpressionType::NOT_EQUALS:
+    case ExpressionType::GREATER_THAN:
+    case ExpressionType::GREATER_THAN_EQUALS:
+    case ExpressionType::LESS_THAN:
+    case ExpressionType::LESS_THAN_EQUALS:
+    case ExpressionType::IS_NULL:
+    case ExpressionType::IS_NOT_NULL:
+    case ExpressionType::FUNCTION:
+        return true;
+    default:
+        return false;
     }
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapLiteralExpression(
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getEvaluator(
+    const std::shared_ptr<Expression>& expression, const Schema* schema) {
+    if (schema == nullptr) {
+        return getConstantEvaluator(expression);
+    }
+    auto expressionType = expression->expressionType;
+    if (schema->isExpressionInScope(*expression)) {
+        return getReferenceEvaluator(expression, schema);
+    } else if (isExpressionLiteral(expressionType)) {
+        return getLiteralEvaluator(*expression);
+    } else if (ExpressionUtil::isNodeVariable(*expression)) {
+        return getNodeEvaluator(expression, schema);
+    } else if (ExpressionUtil::isRelVariable(*expression)) {
+        return getRelEvaluator(expression, schema);
+    } else if (expressionType == ExpressionType::PATH) {
+        return getPathEvaluator(expression, schema);
+    } else if (expressionType == ExpressionType::PARAMETER) {
+        return getParameterEvaluator(*expression);
+    } else if (CASE_ELSE == expressionType) {
+        return getCaseEvaluator(expression, schema);
+    } else if (canEvaluateAsFunction(expressionType)) {
+        return getFunctionEvaluator(expression, schema);
+    } else {
+        throw NotImplementedException(StringUtils::string_format(
+            "Cannot evaluate expression with type {}.", expressionTypeToString(expressionType)));
+    }
+}
+
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getConstantEvaluator(
     const std::shared_ptr<Expression>& expression) {
-    auto& literalExpression = (LiteralExpression&)*expression;
+    assert(ExpressionVisitor::isConstant(*expression));
+    auto expressionType = expression->expressionType;
+    if (isExpressionLiteral(expressionType)) {
+        return getLiteralEvaluator(*expression);
+    } else if (CASE_ELSE == expressionType) {
+        return getCaseEvaluator(expression, nullptr);
+    } else if (canEvaluateAsFunction(expressionType)) {
+        return getFunctionEvaluator(expression, nullptr);
+    } else {
+        throw NotImplementedException(StringUtils::string_format(
+            "Cannot evaluate expression with type {}.", expressionTypeToString(expressionType)));
+    }
+}
+
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getLiteralEvaluator(
+    const Expression& expression) {
+    auto& literalExpression = (LiteralExpression&)expression;
     return std::make_unique<LiteralExpressionEvaluator>(
         std::make_shared<Value>(*literalExpression.getValue()));
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapParameterExpression(
-    const std::shared_ptr<binder::Expression>& expression) {
-    auto& parameterExpression = (ParameterExpression&)*expression;
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getParameterEvaluator(
+    const Expression& expression) {
+    auto& parameterExpression = (ParameterExpression&)expression;
     assert(parameterExpression.getLiteral() != nullptr);
     return std::make_unique<LiteralExpressionEvaluator>(parameterExpression.getLiteral());
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapReferenceExpression(
-    const std::shared_ptr<binder::Expression>& expression, const Schema& schema) {
-    auto vectorPos = DataPos(schema.getExpressionPos(*expression));
-    auto expressionGroup = schema.getGroup(expression->getUniqueName());
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getReferenceEvaluator(
+    std::shared_ptr<Expression> expression, const Schema* schema) {
+    assert(schema != nullptr);
+    auto vectorPos = DataPos(schema->getExpressionPos(*expression));
+    auto expressionGroup = schema->getGroup(expression->getUniqueName());
     return std::make_unique<ReferenceExpressionEvaluator>(vectorPos, expressionGroup->isFlat());
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapCaseExpression(
-    const std::shared_ptr<binder::Expression>& expression, const Schema& schema) {
-    auto& caseExpression = (CaseExpression&)*expression;
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getCaseEvaluator(
+    std::shared_ptr<Expression> expression, const Schema* schema) {
+    auto caseExpression = reinterpret_cast<CaseExpression*>(expression.get());
     std::vector<std::unique_ptr<CaseAlternativeEvaluator>> alternativeEvaluators;
-    for (auto i = 0u; i < caseExpression.getNumCaseAlternatives(); ++i) {
-        auto alternative = caseExpression.getCaseAlternative(i);
-        auto whenEvaluator = mapExpression(alternative->whenExpression, schema);
-        auto thenEvaluator = mapExpression(alternative->thenExpression, schema);
+    for (auto i = 0u; i < caseExpression->getNumCaseAlternatives(); ++i) {
+        auto alternative = caseExpression->getCaseAlternative(i);
+        auto whenEvaluator = getEvaluator(alternative->whenExpression, schema);
+        auto thenEvaluator = getEvaluator(alternative->thenExpression, schema);
         alternativeEvaluators.push_back(std::make_unique<CaseAlternativeEvaluator>(
             std::move(whenEvaluator), std::move(thenEvaluator)));
     }
-    auto elseEvaluator = mapExpression(caseExpression.getElseExpression(), schema);
+    auto elseEvaluator = getEvaluator(caseExpression->getElseExpression(), schema);
     return std::make_unique<CaseExpressionEvaluator>(
-        expression, std::move(alternativeEvaluators), std::move(elseEvaluator));
+        std::move(expression), std::move(alternativeEvaluators), std::move(elseEvaluator));
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapFunctionExpression(
-    const std::shared_ptr<binder::Expression>& expression, const Schema& schema) {
-    std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> children;
-    for (auto i = 0u; i < expression->getNumChildren(); ++i) {
-        children.push_back(mapExpression(expression->getChild(i), schema));
-    }
-    return std::make_unique<FunctionExpressionEvaluator>(expression, std::move(children));
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getFunctionEvaluator(
+    std::shared_ptr<Expression> expression, const Schema* schema) {
+    auto childrenEvaluators = getEvaluators(expression->getChildren(), schema);
+    return std::make_unique<FunctionExpressionEvaluator>(
+        std::move(expression), std::move(childrenEvaluators));
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapNodeExpression(
-    const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema) {
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getNodeEvaluator(
+    std::shared_ptr<Expression> expression, const Schema* schema) {
     auto node = (NodeExpression*)expression.get();
-    std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> children;
-    children.push_back(mapExpression(node->getInternalIDProperty(), schema));
-    children.push_back(mapExpression(node->getLabelExpression(), schema));
+    expression_vector children;
+    children.push_back(node->getInternalIDProperty());
+    children.push_back(node->getLabelExpression());
     for (auto& property : node->getPropertyExpressions()) {
-        children.push_back(mapExpression(property->copy(), schema));
+        children.push_back(property->copy());
     }
-    return std::make_unique<NodeRelExpressionEvaluator>(expression, std::move(children));
+    auto childrenEvaluators = getEvaluators(children, schema);
+    return std::make_unique<NodeRelExpressionEvaluator>(
+        std::move(expression), std::move(childrenEvaluators));
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapRelExpression(
-    const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema) {
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getRelEvaluator(
+    std::shared_ptr<Expression> expression, const Schema* schema) {
     auto rel = (RelExpression*)expression.get();
-    std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> children;
-    children.push_back(mapExpression(rel->getSrcNode()->getInternalIDProperty(), schema));
-    children.push_back(mapExpression(rel->getDstNode()->getInternalIDProperty(), schema));
-    children.push_back(mapExpression(rel->getLabelExpression(), schema));
+    expression_vector children;
+    children.push_back(rel->getSrcNode()->getInternalIDProperty());
+    children.push_back(rel->getDstNode()->getInternalIDProperty());
+    children.push_back(rel->getLabelExpression());
     for (auto& property : rel->getPropertyExpressions()) {
-        children.push_back(mapExpression(property->copy(), schema));
+        children.push_back(property->copy());
     }
-    return std::make_unique<NodeRelExpressionEvaluator>(expression, std::move(children));
+    auto childrenEvaluators = getEvaluators(children, schema);
+    return std::make_unique<NodeRelExpressionEvaluator>(
+        std::move(expression), std::move(childrenEvaluators));
 }
 
-std::unique_ptr<evaluator::ExpressionEvaluator> ExpressionMapper::mapPathExpression(
-    const std::shared_ptr<binder::Expression>& expression, const planner::Schema& schema) {
-    auto pathExpression = std::static_pointer_cast<binder::PathExpression>(expression);
-    std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> children;
-    children.reserve(pathExpression->getNumChildren());
-    for (auto i = 0u; i < pathExpression->getNumChildren(); ++i) {
-        children.push_back(mapExpression(pathExpression->getChild(i), schema));
+std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getPathEvaluator(
+    std::shared_ptr<Expression> expression, const Schema* schema) {
+    auto childrenEvaluators = getEvaluators(expression->getChildren(), schema);
+    return std::make_unique<PathExpressionEvaluator>(
+        std::move(expression), std::move(childrenEvaluators));
+}
+
+std::vector<std::unique_ptr<ExpressionEvaluator>> ExpressionMapper::getEvaluators(
+    const binder::expression_vector& expressions, const Schema* schema) {
+    std::vector<std::unique_ptr<ExpressionEvaluator>> evaluators;
+    evaluators.reserve(expressions.size());
+    for (auto& expression : expressions) {
+        evaluators.push_back(getEvaluator(expression, schema));
     }
-    return std::make_unique<PathExpressionEvaluator>(pathExpression, std::move(children));
+    return evaluators;
 }
 
 } // namespace processor

--- a/src/processor/map/map_create.cpp
+++ b/src/processor/map/map_create.cpp
@@ -44,7 +44,7 @@ std::unique_ptr<NodeInsertExecutor> PlanMapper::getNodeInsertExecutor(
     for (auto i = 0u; i < info->setItems.size(); ++i) {
         auto& [lhs, rhs] = info->setItems[i];
         auto propertyExpression = (binder::PropertyExpression*)lhs.get();
-        evaluators.push_back(expressionMapper.mapExpression(rhs, inSchema));
+        evaluators.push_back(ExpressionMapper::getEvaluator(rhs, &inSchema));
         propertyIDToVectorIdx.insert({propertyExpression->getPropertyID(nodeTableID), i});
     }
     return std::make_unique<NodeInsertExecutor>(table, std::move(relTablesToInit), nodeIDPos,
@@ -78,7 +78,7 @@ std::unique_ptr<RelInsertExecutor> PlanMapper::getRelInsertExecutor(storage::Rel
     auto lhsVectorPositions = populateLhsVectorPositions(info->setItems, outSchema);
     std::vector<std::unique_ptr<ExpressionEvaluator>> evaluators;
     for (auto& [lhs, rhs] : info->setItems) {
-        evaluators.push_back(expressionMapper.mapExpression(rhs, inSchema));
+        evaluators.push_back(ExpressionMapper::getEvaluator(rhs, &inSchema));
     }
     return std::make_unique<RelInsertExecutor>(relsStore->getRelsStatistics(), table, srcNodePos,
         dstNodePos, std::move(lhsVectorPositions), std::move(evaluators));

--- a/src/processor/map/map_ddl.cpp
+++ b/src/processor/map/map_ddl.cpp
@@ -67,7 +67,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRenameTable(LogicalOperator* lo
 std::unique_ptr<PhysicalOperator> PlanMapper::mapAddProperty(LogicalOperator* logicalOperator) {
     auto addProperty = (LogicalAddProperty*)logicalOperator;
     auto expressionEvaluator =
-        expressionMapper.mapExpression(addProperty->getDefaultValue(), *addProperty->getSchema());
+        ExpressionMapper::getEvaluator(addProperty->getDefaultValue(), addProperty->getSchema());
     auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(addProperty->getTableID());
     switch (tableSchema->getTableType()) {
     case catalog::TableType::NODE:

--- a/src/processor/map/map_dummy_scan.cpp
+++ b/src/processor/map/map_dummy_scan.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapDummyScan(LogicalOperator* logi
     tableSchema->appendColumn(
         std::make_unique<ColumnSchema>(false, 0 /* all expressions are in the same datachunk */,
             LogicalTypeUtils::getRowLayoutSize(expression->dataType)));
-    auto expressionEvaluator = expressionMapper.mapExpression(expression, *inSchema);
+    auto expressionEvaluator = ExpressionMapper::getEvaluator(expression, inSchema.get());
     // expression can be evaluated statically and does not require an actual resultset to init
     expressionEvaluator->init(ResultSet(0) /* dummy resultset */, memoryManager);
     expressionEvaluator->evaluate();

--- a/src/processor/map/map_filter.cpp
+++ b/src/processor/map/map_filter.cpp
@@ -11,7 +11,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapFilter(LogicalOperator* logical
     auto& logicalFilter = (const LogicalFilter&)*logicalOperator;
     auto inSchema = logicalFilter.getChild(0)->getSchema();
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
-    auto physicalRootExpr = expressionMapper.mapExpression(logicalFilter.getPredicate(), *inSchema);
+    auto physicalRootExpr = ExpressionMapper::getEvaluator(logicalFilter.getPredicate(), inSchema);
     return make_unique<Filter>(std::move(physicalRootExpr), logicalFilter.getGroupPosToSelect(),
         std::move(prevOperator), getOperatorID(), logicalFilter.getExpressionsForPrinting());
 }

--- a/src/processor/map/map_projection.cpp
+++ b/src/processor/map/map_projection.cpp
@@ -15,7 +15,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapProjection(LogicalOperator* log
     std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> expressionEvaluators;
     std::vector<DataPos> expressionsOutputPos;
     for (auto& expression : logicalProjection.getExpressionsToProject()) {
-        expressionEvaluators.push_back(expressionMapper.mapExpression(expression, *inSchema));
+        expressionEvaluators.push_back(ExpressionMapper::getEvaluator(expression, inSchema));
         expressionsOutputPos.emplace_back(outSchema->getExpressionPos(*expression));
     }
     return make_unique<Projection>(std::move(expressionEvaluators), std::move(expressionsOutputPos),

--- a/src/processor/map/map_scan_node.cpp
+++ b/src/processor/map/map_scan_node.cpp
@@ -31,7 +31,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIndexScanNode(LogicalOperator* 
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     auto nodeTable = storageManager.getNodesStore().getNodeTable(node->getSingleTableID());
     auto evaluator =
-        expressionMapper.mapExpression(logicalIndexScan->getIndexExpression(), *inSchema);
+        ExpressionMapper::getEvaluator(logicalIndexScan->getIndexExpression(), inSchema);
     auto outDataPos = DataPos(outSchema->getExpressionPos(*node->getInternalIDProperty()));
     return make_unique<IndexScan>(nodeTable->getTableID(), nodeTable->getPKIndex(),
         std::move(evaluator), outDataPos, std::move(prevOperator), getOperatorID(),

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -20,7 +20,7 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(storage::NodesSt
     if (inSchema.isExpressionInScope(*property)) {
         propertyPos = DataPos(inSchema.getExpressionPos(*property));
     }
-    auto evaluator = expressionMapper.mapExpression(info->setItem.second, inSchema);
+    auto evaluator = ExpressionMapper::getEvaluator(info->setItem.second, &inSchema);
     if (node->isMultiLabeled()) {
         std::unordered_map<table_id_t, NodeSetInfo> tableIDToSetInfo;
         for (auto tableID : node->getTableIDs()) {
@@ -68,7 +68,7 @@ std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(storage::RelsStore
     if (inSchema.isExpressionInScope(*property)) {
         propertyPos = DataPos(inSchema.getExpressionPos(*property));
     }
-    auto evaluator = expressionMapper.mapExpression(info->setItem.second, inSchema);
+    auto evaluator = ExpressionMapper::getEvaluator(info->setItem.second, &inSchema);
     if (rel->isMultiLabeled()) {
         std::unordered_map<table_id_t, std::pair<storage::RelTable*, property_id_t>>
             tableIDToTableAndPropertyID;

--- a/src/processor/map/map_unwind.cpp
+++ b/src/processor/map/map_unwind.cpp
@@ -15,7 +15,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapUnwind(LogicalOperator* logical
     auto inSchema = unwind->getChild(0)->getSchema();
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     auto dataPos = DataPos(outSchema->getExpressionPos(*unwind->getAliasExpression()));
-    auto expressionEvaluator = expressionMapper.mapExpression(unwind->getExpression(), *inSchema);
+    auto expressionEvaluator = ExpressionMapper::getEvaluator(unwind->getExpression(), inSchema);
     return std::make_unique<Unwind>(*VarListType::getChildType(&unwind->getExpression()->dataType),
         dataPos, std::move(expressionEvaluator), std::move(prevOperator), getOperatorID(),
         unwind->getExpressionsForPrinting());

--- a/test/graph_test/graph_test.cpp
+++ b/test/graph_test/graph_test.cpp
@@ -72,7 +72,8 @@ void BaseGraphTest::validateQueryBestPlanJoinOrder(
     auto catalog = getCatalog(*database);
     auto statement = parser::Parser::parseQuery(query);
     auto parsedQuery = (parser::RegularQuery*)statement.get();
-    auto boundQuery = Binder(*catalog, conn->clientContext.get()).bind(*parsedQuery);
+    auto boundQuery = Binder(*catalog, database->memoryManager.get(), conn->clientContext.get())
+                          .bind(*parsedQuery);
     auto plan = Planner::getBestPlan(*catalog,
         getStorageManager(*database)->getNodesStore().getNodesStatisticsAndDeletedIDs(),
         getStorageManager(*database)->getRelsStore().getRelsStatistics(), *boundQuery);

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -38,12 +38,12 @@ Binder exception: Expression in WITH must be aliased (use AS).
 -LOG BindToDifferentVariableType1
 -STATEMENT MATCH (a:person)-[e1:knows]->(b:person) WITH e1 AS a MATCH (a) RETURN *
 ---- error
-Binder exception: e1 has data type REL. (NODE) was expected.
+Binder exception: a has data type REL. (NODE) was expected.
 
 -LOG BindToDifferentVariableType2
 -STATEMENT MATCH (a:person)-[e1:knows]->(b:person) WITH a.age + 1 AS a MATCH (a) RETURN *
 ---- error
-Binder exception: +(a.age,1) has data type INT64. (NODE) was expected.
+Binder exception: a has data type INT64. (NODE) was expected.
 
 -LOG BindEmptyStar
 -STATEMENT RETURN *

--- a/test/test_files/tck/match/match1.test
+++ b/test/test_files/tck/match/match1.test
@@ -327,22 +327,22 @@ Binder exception: r has data type RECURSIVE_REL. (NODE) was expected.
 ---- ok
 -STATEMENT WITH true AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: True has data type BOOL. (NODE) was expected.
+Binder exception: n has data type BOOL. (NODE) was expected.
 -STATEMENT WITH 123 AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: 123 has data type INT64. (NODE) was expected.
+Binder exception: n has data type INT64. (NODE) was expected.
 -STATEMENT WITH 123.4 AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: 123.400000 has data type DOUBLE. (NODE) was expected.
+Binder exception: n has data type DOUBLE. (NODE) was expected.
 -STATEMENT WITH 'foo' AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: foo has data type STRING. (NODE) was expected.
+Binder exception: n has data type STRING. (NODE) was expected.
 -STATEMENT WITH [10] AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: LIST_CREATION(10) has data type VAR_LIST. (NODE) was expected.
+Binder exception: n has data type VAR_LIST. (NODE) was expected.
 -STATEMENT WITH {x: 1} AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: STRUCT_PACK(1) has data type STRUCT. (NODE) was expected.
+Binder exception: n has data type STRUCT. (NODE) was expected.
 -STATEMENT WITH {x: [1]} AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: STRUCT_PACK(LIST_CREATION(1)) has data type STRUCT. (NODE) was expected.
+Binder exception: n has data type STRUCT. (NODE) was expected.

--- a/test/test_files/tck/match/match2.test
+++ b/test/test_files/tck/match/match2.test
@@ -369,22 +369,22 @@ Binder exception: Bind relationship r to relationship with same name is not supp
 ---- ok
 -STATEMENT WITH true AS r MATCH ()-[r]-() RETURN r;
 ---- error
-Binder exception: True has data type BOOL. (REL) was expected.
+Binder exception: r has data type BOOL. (REL) was expected.
 -STATEMENT WITH 123 AS r MATCH ()-[r]-() RETURN r;
 ---- error
-Binder exception: 123 has data type INT64. (REL) was expected.
+Binder exception: r has data type INT64. (REL) was expected.
 -STATEMENT WITH 123.4 AS r MATCH ()-[r]-() RETURN r;
 ---- error
-Binder exception: 123.400000 has data type DOUBLE. (REL) was expected.
+Binder exception: r has data type DOUBLE. (REL) was expected.
 -STATEMENT WITH 'foo' AS r MATCH ()-[r]-() RETURN r;
 ---- error
-Binder exception: foo has data type STRING. (REL) was expected.
+Binder exception: r has data type STRING. (REL) was expected.
 -STATEMENT WITH [10] AS r MATCH ()-[r]-() RETURN r;
 ---- error
-Binder exception: LIST_CREATION(10) has data type VAR_LIST. (REL) was expected.
+Binder exception: r has data type VAR_LIST. (REL) was expected.
 -STATEMENT WITH {x: 1} AS r MATCH ()-[r]-() RETURN r;
 ---- error
-Binder exception: STRUCT_PACK(1) has data type STRUCT. (REL) was expected.
+Binder exception: r has data type STRUCT. (REL) was expected.
 -STATEMENT WITH {x: [1]} AS r MATCH ()-[r]-() RETURN r;
 ---- error
-Binder exception: STRUCT_PACK(LIST_CREATION(1)) has data type STRUCT. (REL) was expected.
+Binder exception: r has data type STRUCT. (REL) was expected.

--- a/test/test_files/tinysnb/function/union.test
+++ b/test/test_files/tinysnb/function/union.test
@@ -11,7 +11,7 @@
 36
 
 -LOG UnionValueOnExpr
--STATEMENT MATCH (p:person)-[:knows]->(p1:person) return union_value(age := p.age), union_value(age := p1.age)
+-STATEMENT MATCH (p:person)-[:knows]->(p1:person) return union_value(age := p.age) AS u1, union_value(age := p1.age) AS u2
 ---- 14
 35|30
 35|45
@@ -74,7 +74,7 @@ age|PERSON_id
 100
 
 -LOG UnionExtractOnFlatUnflatExpr
--STATEMENT MATCH (p:person)-[:knows]->(p1:person) return union_extract(union_value(age := p.age), 'age'), union_extract(union_value(age := p1.age), 'age')
+-STATEMENT MATCH (p:person)-[:knows]->(p1:person) return union_extract(union_value(age := p.age), 'age') AS a, union_extract(union_value(age := p1.age), 'age') AS b
 ---- 14
 35|30
 35|45

--- a/test/test_files/tinysnb/projection/skip_limit.test
+++ b/test/test_files/tinysnb/projection/skip_limit.test
@@ -34,6 +34,13 @@ Farooq
 Greg
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 
+-LOG BasicLimitTest3
+-STATEMENT MATCH (a:person) RETURN a.fName ORDER BY a.fName LIMIT 1 + 1
+-CHECK_ORDER
+---- 2
+Alice
+Bob
+
 -LOG BasicSkipLimitTest
 -STATEMENT MATCH (a:person) RETURN a.fName SKIP 1 LIMIT 2
 ---- 2


### PR DESCRIPTION
This PR adds the base infrastructure for constant expression folding. 

We now have the capability to evaluate a constant expression (e.g. 1 + 1) and compile time through `ExpressionEvaluatorUtils` and return back a `Value`.

As a consequence

- We reduce the depth of expression evaluator at runtime e.g. `a + 1 + 1` will be evaluated as `a + 2`
- We now have the capability to expand literal binding as constant expression binding, e.g. we now support `LIMIT 1 + 1`