### PR TITLE
Add arrow feature to rust example so that it can re-use the test build in CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Rust example
         working-directory: examples/rust
-        run: cargo build
+        run: cargo build --features arrow
 
   gcc-build-test-with-asan:
     name: gcc build & test with asan

--- a/examples/rust/Cargo.toml
+++ b/examples/rust/Cargo.toml
@@ -5,3 +5,7 @@ edition = "2021"
 
 [dependencies]
 kuzu = {path="../../tools/rust_api"}
+arrow = {version="43", optional=true, default-features=false, features=[]}
+
+[features]
+arrow = ["kuzu/arrow", "dep:arrow"]


### PR DESCRIPTION
Following up #1995, this should let the rust example use the previously built version of the kuzu crate in CI, as they'll now use the same features.

I'm tempted to also actually include an example of using the arrow data in the example, but it makes the example a lot more complex and I'm not sure if it really helps provide a good example of kuzu's interfaces as most of it would be dealing with arrow types.