### PR TITLE
Arrow schema fixes

### DIFF
--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -6,7 +6,7 @@ namespace kuzu {
 namespace common {
 
 static void releaseArrowSchema(ArrowSchema* schema) {
-    if (!schema || schema->release) {
+    if (!schema || !schema->release) {
         return;
     }
     schema->release = nullptr;

--- a/test/main/CMakeLists.txt
+++ b/test/main/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_kuzu_test(main_test
+        arrow_test.cpp
         config_test.cpp
         connection_test.cpp
         csv_output_test.cpp

--- a/test/main/arrow_test.cpp
+++ b/test/main/arrow_test.cpp
@@ -1,0 +1,27 @@
+#include "main_test_helper/main_test_helper.h"
+
+using namespace kuzu::common;
+using namespace kuzu::testing;
+
+class ArrowTest : public ApiTest {};
+
+TEST_F(ArrowTest, getArrowResult) {
+    auto query = "MATCH (a:person) WHERE a.fName = 'Bob' RETURN a.fName";
+    auto result = conn->query(query);
+    auto arrowArray = result->getNextArrowChunk(1);
+    ASSERT_EQ(arrowArray->length, 1);
+    ASSERT_EQ(arrowArray->null_count, 0);
+    ASSERT_EQ(arrowArray->n_children, 1);
+    // FIXME: Not sure where the length of the string is stored
+    ASSERT_EQ(std::string((const char*)arrowArray->children[0]->buffers[2], 3), "Bob");
+    arrowArray->release(arrowArray.get());
+}
+
+TEST_F(ArrowTest, getArrowSchema) {
+    auto query = "MATCH (a:person) RETURN a.fName as NAME";
+    auto result = conn->query(query);
+    auto schema = result->getArrowSchema();
+    ASSERT_EQ(schema->n_children, 1);
+    ASSERT_EQ(std::string(schema->children[0]->name), "NAME");
+    schema->release(schema.get());
+}


### PR DESCRIPTION
Fixes #2005.

There were two different memory errors in the arrow schemer converter:

1. Property names weren't being copied into the owned data part of the schema object and were just pointing to the DataTypeInfo object, which is temporary.
2. The arrow schema wasn't getting released since it was skipping releasing the data if the release function was non-null instead of if it was null.

I've added a couple of relatively simple tests to do some basic validation of the data as well as to make sure that the address sanitizer checks those functions.