### PR TITLE
Add win32 access violation handler to buffer manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ if(MSVC)
     add_compile_definitions(_AMD64_)
     # Non-english windows system may use other encodings other than utf-8 (e.g. Chinese use GBK).
     add_compile_options("/utf-8")
+    # Enables support for custom hardware exception handling
+    add_compile_options("/EHa")
+    # Remove the default to avoid warnings
+    STRING(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
+    STRING(REPLACE "/EHs" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS})
 endif()
 if(CMAKE_BUILD_TYPE MATCHES Release)
     if(MSVC)

--- a/src/include/storage/buffer_manager/vm_region.h
+++ b/src/include/storage/buffer_manager/vm_region.h
@@ -25,6 +25,10 @@ public:
     // Use `MADV_DONTNEED` to release physical memory associated with this frame.
     void releaseFrame(common::frame_idx_t frameIdx);
 
+    // Returns true if the memory address is within the reserved virtual memory region
+    bool contains(const uint8_t* address) const {
+        return address >= region && address < region + getMaxRegionSize();
+    }
 #ifdef _WIN32
     uint8_t* getFrame(common::frame_idx_t frameIdx);
 #else


### PR DESCRIPTION
Windows will produce an access violation hardware exception (a.k.a. segfault) when attempting to read from de-committed memory, something which may occur in the buffer manager if another thread releases memory which was about to be read from. On linux/unix this isn't an issue since the kernel will allow the memory to be accessed and just provide empty data.

I've worked around this by enabling the `/EHa` compiler flag, which turns on custom exception handling for hardware exceptions. There are two downsides to this: 
1.  **`catch (...)` will now catch hardware exceptions on windows**, which is bad (note that the `...` is explicit here). There are no instances of this in our code, but there are a few in `third_party`. One in spdlog which is just used to log information and re-throw (which should be fine), one in antlr4_runtime in a function we are not using, and a few in pybind11, which might affect the python library on windows.
2. There is a slight performance penalty since the compiler now has to assume that every single try/catch might catch an exception, where with the default `/EHs` (only catches C++ exceptions) it can optimize away try/catch blocks when there are no exceptions that could be thrown. I don't think this is very significant.

The custom exception handler raises a custom exception if the exception is a segfault, and the memory location of the segfault is checked to make sure it occurred within the buffer manager's reserved virtual memory to avoid catching other segfaults within the same scope (silently ignoring those would be a major issue).

The one thing I'm not sure about, is that the use of `catch (...)` in pybind11 seems to be in the code that handles translating c++ exceptions into python exceptions (i.e. it will cover all exceptions thrown by our c++ code), and [it looks like it's turning arbitrary non-standard exceptions into a python RuntimeError](https://github.com/kuzudb/kuzu/blob/727840cdf79ecce60723deb653543aa45861b4ec/third_party/pybind11/include/pybind11/detail/internals.h#L402-L405), which seems like a bad way of reporting hardware exceptions like segfaults in the C++ extension. 