### PR TITLE
Don't self-initialize schema comments

### DIFF
--- a/src/include/catalog/table_schema.h
+++ b/src/include/catalog/table_schema.h
@@ -17,8 +17,7 @@ public:
         std::vector<std::unique_ptr<Property>> properties)
         : tableName{std::move(tableName)}, tableID{tableID}, tableType{tableType},
           properties{std::move(properties)},
-          nextPropertyID{(common::property_id_t)this->properties.size()}, comment{
-                                                                              std::move(comment)} {}
+          nextPropertyID{(common::property_id_t)this->properties.size()}, comment{} {}
     TableSchema(common::TableType tableType, std::string tableName, common::table_id_t tableID,
         std::vector<std::unique_ptr<Property>> properties, std::string comment,
         common::property_id_t nextPropertyID)


### PR DESCRIPTION
I was getting tons of segfaults on my computer when running tests. It turned out that the new comment field in the TableSchema is being initialized to itself in one of the constructors.

Is the comment supposed to be passed as an argument to this constructor? I just default-initialized it instead, which fixed the crashes.