### PR TITLE
Replace CopyDescription with CSVReaderConfig for storage classes.

### DIFF
--- a/src/include/common/copier_config/copier_config.h
+++ b/src/include/common/copier_config/copier_config.h
@@ -11,6 +11,13 @@ namespace kuzu {
 namespace common {
 
 struct CSVReaderConfig {
+    char escapeChar;
+    char delimiter;
+    char quoteChar;
+    char listBeginChar;
+    char listEndChar;
+    bool hasHeader;
+
     CSVReaderConfig()
         : escapeChar{CopyConstants::DEFAULT_CSV_ESCAPE_CHAR},
           delimiter{CopyConstants::DEFAULT_CSV_DELIMITER},
@@ -18,13 +25,14 @@ struct CSVReaderConfig {
           listBeginChar{CopyConstants::DEFAULT_CSV_LIST_BEGIN_CHAR},
           listEndChar{CopyConstants::DEFAULT_CSV_LIST_END_CHAR},
           hasHeader{CopyConstants::DEFAULT_CSV_HAS_HEADER} {}
+    CSVReaderConfig(const CSVReaderConfig& other)
+        : escapeChar{other.escapeChar}, delimiter{other.delimiter}, quoteChar{other.quoteChar},
+          listBeginChar{other.listBeginChar},
+          listEndChar{other.listEndChar}, hasHeader{other.hasHeader} {}
 
-    char escapeChar;
-    char delimiter;
-    char quoteChar;
-    char listBeginChar;
-    char listEndChar;
-    bool hasHeader;
+    inline std::unique_ptr<CSVReaderConfig> copy() const {
+        return std::make_unique<CSVReaderConfig>(*this);
+    }
 };
 
 struct CopyDescription {

--- a/src/include/processor/operator/persistent/copy_node.h
+++ b/src/include/processor/operator/persistent/copy_node.h
@@ -72,8 +72,8 @@ public:
         for (auto& arrowColumnPos : copyNodeInfo.dataColumnPoses) {
             dataColumnVectors.push_back(resultSet->getValueVector(arrowColumnPos).get());
         }
-        localNodeGroup =
-            std::make_unique<storage::NodeGroup>(sharedState->tableSchema, &sharedState->copyDesc);
+        localNodeGroup = std::make_unique<storage::NodeGroup>(
+            sharedState->tableSchema, sharedState->copyDesc.csvReaderConfig.get());
     }
 
     void initGlobalStateInternal(ExecutionContext* context) final;

--- a/src/include/storage/copier/node_group.h
+++ b/src/include/storage/copier/node_group.h
@@ -12,8 +12,7 @@ class NodeTable;
 
 class NodeGroup {
 public:
-    explicit NodeGroup(
-        catalog::TableSchema* schema, common::CopyDescription* copyDescription = nullptr);
+    explicit NodeGroup(catalog::TableSchema* schema, common::CSVReaderConfig* csvReaderConfig);
     explicit NodeGroup(NodeTable* table);
 
     inline void setNodeGroupIdx(uint64_t nodeGroupIdx_) { this->nodeGroupIdx = nodeGroupIdx_; }

--- a/src/include/storage/copier/string_column_chunk.h
+++ b/src/include/storage/copier/string_column_chunk.h
@@ -9,7 +9,8 @@ namespace storage {
 
 class StringColumnChunk : public ColumnChunk {
 public:
-    StringColumnChunk(common::LogicalType dataType, common::CopyDescription* copyDescription);
+    StringColumnChunk(
+        common::LogicalType dataType, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig);
 
     void resetToEmpty() final;
     void append(common::ValueVector* vector, common::offset_t startPosInChunk) final;

--- a/src/include/storage/copier/struct_column_chunk.h
+++ b/src/include/storage/copier/struct_column_chunk.h
@@ -7,7 +7,8 @@ namespace storage {
 
 class StructColumnChunk : public ColumnChunk {
 public:
-    StructColumnChunk(common::LogicalType dataType, common::CopyDescription* copyDescription);
+    StructColumnChunk(
+        common::LogicalType dataType, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig);
 
 protected:
     void append(

--- a/src/include/storage/in_mem_storage_structure/in_mem_column.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_column.h
@@ -15,20 +15,21 @@ public:
     void flushChunk(InMemColumnChunk* chunk);
 
     std::unique_ptr<InMemColumnChunk> createInMemColumnChunk(common::offset_t startNodeOffset,
-        common::offset_t endNodeOffset, std::unique_ptr<common::CopyDescription> copyDescription) {
+        common::offset_t endNodeOffset, common::CSVReaderConfig* csvReaderConfig) {
+        auto csvReaderConfigCopy = csvReaderConfig ? csvReaderConfig->copy() : nullptr;
         switch (dataType.getPhysicalType()) {
         case common::PhysicalTypeID::STRING:
         case common::PhysicalTypeID::VAR_LIST: {
             return std::make_unique<InMemColumnChunkWithOverflow>(dataType, startNodeOffset,
-                endNodeOffset, std::move(copyDescription), inMemOverflowFile.get());
+                endNodeOffset, std::move(csvReaderConfigCopy), inMemOverflowFile.get());
         }
         case common::PhysicalTypeID::FIXED_LIST: {
             return std::make_unique<InMemFixedListColumnChunk>(
-                dataType, startNodeOffset, endNodeOffset, std::move(copyDescription));
+                dataType, startNodeOffset, endNodeOffset, std::move(csvReaderConfigCopy));
         }
         default: {
             return std::make_unique<InMemColumnChunk>(
-                dataType, startNodeOffset, endNodeOffset, std::move(copyDescription));
+                dataType, startNodeOffset, endNodeOffset, std::move(csvReaderConfigCopy));
         }
         }
     }

--- a/src/include/storage/in_mem_storage_structure/in_mem_column_chunk.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_column_chunk.h
@@ -19,7 +19,7 @@ struct PropertyCopyState {
 class InMemColumnChunk {
 public:
     InMemColumnChunk(common::LogicalType dataType, common::offset_t startNodeOffset,
-        common::offset_t endNodeOffset, std::unique_ptr<common::CopyDescription> copyDescription,
+        common::offset_t endNodeOffset, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig,
         bool requireNullBits = true);
 
     virtual ~InMemColumnChunk() = default;
@@ -81,16 +81,16 @@ protected:
     std::uint64_t numBytes;
     std::unique_ptr<uint8_t[]> buffer;
     std::unique_ptr<InMemColumnChunk> nullChunk;
-    std::unique_ptr<common::CopyDescription> copyDescription;
+    std::unique_ptr<common::CSVReaderConfig> csvReaderConfig;
 };
 
 class InMemColumnChunkWithOverflow : public InMemColumnChunk {
 public:
     InMemColumnChunkWithOverflow(common::LogicalType dataType, common::offset_t startNodeOffset,
-        common::offset_t endNodeOffset, std::unique_ptr<common::CopyDescription> copyDescription,
+        common::offset_t endNodeOffset, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig,
         InMemOverflowFile* inMemOverflowFile)
         : InMemColumnChunk{std::move(dataType), startNodeOffset, endNodeOffset,
-              std::move(copyDescription)},
+              std::move(csvReaderConfig)},
           inMemOverflowFile{inMemOverflowFile}, blobBuffer{std::make_unique<uint8_t[]>(
                                                     common::BufferPoolConstants::PAGE_4KB_SIZE)} {}
 
@@ -123,7 +123,7 @@ private:
 class InMemFixedListColumnChunk : public InMemColumnChunk {
 public:
     InMemFixedListColumnChunk(common::LogicalType dataType, common::offset_t startNodeOffset,
-        common::offset_t endNodeOffset, std::unique_ptr<common::CopyDescription> copyDescription);
+        common::offset_t endNodeOffset, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig);
 
     void flush(common::FileInfo* walFileInfo) override;
 

--- a/src/include/storage/in_mem_storage_structure/in_mem_lists.h
+++ b/src/include/storage/in_mem_storage_structure/in_mem_lists.h
@@ -37,9 +37,9 @@ class InMemLists {
 public:
     InMemLists(std::string fName, common::LogicalType dataType, uint64_t numBytesForElement,
         uint64_t numNodes, std::shared_ptr<ListHeadersBuilder> listHeadersBuilder,
-        std::unique_ptr<common::CopyDescription> copyDescription, bool hasNullBytes)
+        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool hasNullBytes)
         : InMemLists{std::move(fName), numBytesForElement, std::move(dataType), numNodes,
-              std::move(copyDescription), hasNullBytes} {
+              std::move(csvReaderConfig), hasNullBytes} {
         this->listHeadersBuilder = std::move(listHeadersBuilder);
     }
     virtual ~InMemLists() = default;
@@ -75,7 +75,7 @@ public:
 
 protected:
     InMemLists(std::string fName, uint64_t numBytesForElement, common::LogicalType dataType,
-        uint64_t numNodes, std::unique_ptr<common::CopyDescription> copyDescription,
+        uint64_t numNodes, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig,
         bool hasNullBytes);
 
 private:
@@ -111,7 +111,7 @@ protected:
     uint64_t numElementsInAPage;
     std::unique_ptr<ListsMetadataBuilder> listsMetadataBuilder;
     std::shared_ptr<ListHeadersBuilder> listHeadersBuilder;
-    std::unique_ptr<common::CopyDescription> copyDescription;
+    std::unique_ptr<common::CSVReaderConfig> csvReaderConfig;
 };
 
 class InMemRelIDLists : public InMemLists {
@@ -127,7 +127,7 @@ class InMemListsWithOverflow : public InMemLists {
 protected:
     InMemListsWithOverflow(std::string fName, common::LogicalType dataType, uint64_t numNodes,
         std::shared_ptr<ListHeadersBuilder> listHeadersBuilder,
-        std::unique_ptr<common::CopyDescription> copyDescription);
+        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig);
 
     void copyArrowArray(arrow::Array* boundNodeOffsets, arrow::Array* posInRelLists,
         arrow::Array* array, PropertyCopyState* copyState) final;
@@ -182,16 +182,16 @@ class InMemListLists : public InMemListsWithOverflow {
 public:
     InMemListLists(std::string fName, common::LogicalType dataType, uint64_t numNodes,
         std::shared_ptr<ListHeadersBuilder> listHeadersBuilder,
-        std::unique_ptr<common::CopyDescription> copyDescription)
+        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig)
         : InMemListsWithOverflow{std::move(fName), std::move(dataType), numNodes,
-              std::move(listHeadersBuilder), std::move(copyDescription)} {};
+              std::move(listHeadersBuilder), std::move(csvReaderConfig)} {};
 };
 
 class InMemListsFactory {
 public:
     static std::unique_ptr<InMemLists> getInMemPropertyLists(const std::string& fName,
         const common::LogicalType& dataType, uint64_t numNodes,
-        std::unique_ptr<common::CopyDescription> copyDescription,
+        common::CSVReaderConfig* csvReaderConfig,
         std::shared_ptr<ListHeadersBuilder> listHeadersBuilder = nullptr);
 };
 

--- a/src/storage/copier/node_group.cpp
+++ b/src/storage/copier/node_group.cpp
@@ -11,11 +11,11 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-NodeGroup::NodeGroup(TableSchema* schema, CopyDescription* copyDescription)
+NodeGroup::NodeGroup(TableSchema* schema, CSVReaderConfig* csvReaderConfig)
     : nodeGroupIdx{UINT64_MAX}, numNodes{0} {
     for (auto& property : schema->properties) {
         chunks[property->getPropertyID()] =
-            ColumnChunkFactory::createColumnChunk(*property->getDataType(), copyDescription);
+            ColumnChunkFactory::createColumnChunk(*property->getDataType(), csvReaderConfig);
     }
 }
 

--- a/src/storage/copier/string_column_chunk.cpp
+++ b/src/storage/copier/string_column_chunk.cpp
@@ -10,8 +10,9 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-StringColumnChunk::StringColumnChunk(LogicalType dataType, CopyDescription* copyDescription)
-    : ColumnChunk{std::move(dataType), copyDescription} {
+StringColumnChunk::StringColumnChunk(
+    LogicalType dataType, std::unique_ptr<CSVReaderConfig> csvReaderConfig)
+    : ColumnChunk{std::move(dataType), std::move(csvReaderConfig)} {
     overflowFile = std::make_unique<InMemOverflowFile>();
     overflowCursor.pageIdx = 0;
     overflowCursor.offsetInPage = 0;

--- a/src/storage/in_mem_storage_structure/in_mem_column_chunk.cpp
+++ b/src/storage/in_mem_storage_structure/in_mem_column_chunk.cpp
@@ -13,14 +13,14 @@ namespace kuzu {
 namespace storage {
 
 InMemColumnChunk::InMemColumnChunk(LogicalType dataType, offset_t startNodeOffset,
-    offset_t endNodeOffset, std::unique_ptr<CopyDescription> copyDescription, bool requireNullBits)
-    : dataType{std::move(dataType)}, startNodeOffset{startNodeOffset}, copyDescription{std::move(
-                                                                           copyDescription)} {
+    offset_t endNodeOffset, std::unique_ptr<CSVReaderConfig> csvReaderConfig, bool requireNullBits)
+    : dataType{std::move(dataType)}, startNodeOffset{startNodeOffset}, csvReaderConfig{std::move(
+                                                                           csvReaderConfig)} {
     numBytesPerValue = getDataTypeSizeInColumn(this->dataType);
     numBytes = numBytesPerValue * (endNodeOffset - startNodeOffset + 1);
     buffer = std::make_unique<uint8_t[]>(numBytes);
     if (requireNullBits) {
-        auto copyDescCloned = this->copyDescription ? this->copyDescription->copy() : nullptr;
+        auto copyDescCloned = this->csvReaderConfig ? this->csvReaderConfig->copy() : nullptr;
         nullChunk = std::make_unique<InMemColumnChunk>(LogicalType{LogicalTypeID::BOOL},
             startNodeOffset, endNodeOffset, std::move(copyDescCloned), false /* hasNull */);
         memset(nullChunk->getData(), true, nullChunk->getNumBytes());
@@ -369,16 +369,16 @@ void InMemColumnChunkWithOverflow::setValWithOverflow<blob_t>(
 template<>
 void InMemColumnChunkWithOverflow::setValWithOverflow<ku_list_t>(
     PageByteCursor& overflowCursor, const char* value, uint64_t length, uint64_t pos) {
-    auto varListVal = TableCopyUtils::getVarListValue(
-        value, 1, length - 2, dataType, *copyDescription->csvReaderConfig);
+    auto varListVal =
+        TableCopyUtils::getVarListValue(value, 1, length - 2, dataType, *csvReaderConfig);
     auto val = inMemOverflowFile->copyList(*varListVal, overflowCursor);
     setValue(val, pos);
 }
 
 InMemFixedListColumnChunk::InMemFixedListColumnChunk(LogicalType dataType, offset_t startNodeOffset,
-    offset_t endNodeOffset, std::unique_ptr<CopyDescription> copyDescription)
+    offset_t endNodeOffset, std::unique_ptr<CSVReaderConfig> csvReaderConfig)
     : InMemColumnChunk{
-          std::move(dataType), startNodeOffset, endNodeOffset, std::move(copyDescription)} {
+          std::move(dataType), startNodeOffset, endNodeOffset, std::move(csvReaderConfig)} {
     numElementsInAPage = PageUtils::getNumElementsInAPage(numBytesPerValue, false /* hasNull */);
     auto startNodeOffsetCursor =
         PageUtils::getPageByteCursorForPos(startNodeOffset, numElementsInAPage, numBytesPerValue);
@@ -426,8 +426,8 @@ void InMemColumnChunk::setValueFromString<bool>(const char* value, uint64_t leng
 template<>
 void InMemColumnChunk::setValueFromString<uint8_t*>(
     const char* value, uint64_t length, uint64_t pos) {
-    auto fixedListVal = TableCopyUtils::getArrowFixedList(
-        value, 1, length - 2, dataType, *copyDescription->csvReaderConfig);
+    auto fixedListVal =
+        TableCopyUtils::getArrowFixedList(value, 1, length - 2, dataType, *csvReaderConfig);
     // TODO(Guodong): Keep value size as a class field.
     memcpy(buffer.get() + pos * storage::StorageUtils::getDataTypeSize(dataType),
         fixedListVal.get(), storage::StorageUtils::getDataTypeSize(dataType));


### PR DESCRIPTION
We are storing copyDescription* in many storage classes. This is bad because

- life cycle is not guaranteed.
- logic itself should be handled at reader level instead of propagating to storage.

I'm refactoring copyDescription and it touches quite a lot of files. I'm splitting refactor into multiple PRs.

In this PR we replace all copyDescription* with unique_ptr<CSVReaderConfig>