### PR TITLE
Refactor node table to take in columnID instead of propertyID

### DIFF
--- a/src/catalog/table_schema.cpp
+++ b/src/catalog/table_schema.cpp
@@ -5,7 +5,6 @@
 #include "catalog/rel_table_group_schema.h"
 #include "catalog/rel_table_schema.h"
 #include "common/constants.h"
-#include "common/exception/catalog.h"
 #include "common/exception/internal.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
@@ -48,6 +47,16 @@ property_id_t TableSchema::getPropertyID(const std::string& propertyName) const 
     }
     throw RuntimeException(StringUtils::string_format(
         "Table: {} doesn't have a property with propertyName={}.", tableName, propertyName));
+}
+
+// TODO(Guodong): Instead of looping over properties, cache a map between propertyID and columnID.
+column_id_t TableSchema::getColumnID(const property_id_t propertyID) const {
+    for (auto i = 0u; i < properties.size(); i++) {
+        if (properties[i]->getPropertyID() == propertyID) {
+            return i;
+        }
+    }
+    return INVALID_COLUMN_ID;
 }
 
 Property* TableSchema::getProperty(property_id_t propertyID) const {

--- a/src/include/catalog/table_schema.h
+++ b/src/include/catalog/table_schema.h
@@ -66,6 +66,7 @@ public:
     std::string getPropertyName(common::property_id_t propertyID) const;
 
     common::property_id_t getPropertyID(const std::string& propertyName) const;
+    common::column_id_t getColumnID(common::property_id_t propertyID) const;
 
     Property* getProperty(common::property_id_t propertyID) const;
 

--- a/src/include/processor/operator/mask.h
+++ b/src/include/processor/operator/mask.h
@@ -23,8 +23,10 @@ struct MaskData {
         std::fill(data, data + size, 0);
     }
 
-    inline void setMask(uint64_t pos, uint8_t maskValue) { data[pos] = maskValue; }
-    inline bool isMasked(uint64_t pos, uint8_t trueMaskVal) { return data[pos] == trueMaskVal; }
+    inline void setMask(uint64_t pos, uint8_t maskValue) const { data[pos] = maskValue; }
+    inline bool isMasked(uint64_t pos, uint8_t trueMaskVal) const {
+        return data[pos] == trueMaskVal;
+    }
 
 private:
     std::unique_ptr<uint8_t[]> dataBuffer;
@@ -63,7 +65,7 @@ private:
 
 class NodeSemiMask {
 public:
-    NodeSemiMask(storage::NodeTable* nodeTable) : nodeTable{nodeTable} {}
+    explicit NodeSemiMask(storage::NodeTable* nodeTable) : nodeTable{nodeTable} {}
 
     virtual void init(transaction::Transaction* trx) = 0;
 
@@ -72,7 +74,7 @@ public:
     virtual uint8_t getNumMasks() const = 0;
     virtual void incrementNumMasks() = 0;
 
-    inline bool isEnabled() { return getNumMasks() > 0; }
+    inline bool isEnabled() const { return getNumMasks() > 0; }
     inline storage::NodeTable* getNodeTable() const { return nodeTable; }
 
 protected:
@@ -81,7 +83,7 @@ protected:
 
 class NodeOffsetSemiMask : public NodeSemiMask {
 public:
-    NodeOffsetSemiMask(storage::NodeTable* nodeTable) : NodeSemiMask{nodeTable} {
+    explicit NodeOffsetSemiMask(storage::NodeTable* nodeTable) : NodeSemiMask{nodeTable} {
         offsetMask = std::make_unique<MaskCollection>();
     }
 
@@ -110,7 +112,7 @@ private:
 
 class NodeOffsetAndMorselSemiMask : public NodeSemiMask {
 public:
-    NodeOffsetAndMorselSemiMask(storage::NodeTable* nodeTable) : NodeSemiMask{nodeTable} {
+    explicit NodeOffsetAndMorselSemiMask(storage::NodeTable* nodeTable) : NodeSemiMask{nodeTable} {
         offsetMask = std::make_unique<MaskCollection>();
         morselMask = std::make_unique<MaskCollection>();
     }

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -12,12 +12,10 @@ class NodeInsertExecutor {
 public:
     NodeInsertExecutor(storage::NodeTable* table, std::vector<storage::RelTable*> relTablesToInit,
         const DataPos& nodeIDVectorPos, std::vector<DataPos> propertyLhsPositions,
-        std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> propertyRhsEvaluators,
-        std::unordered_map<common::property_id_t, common::vector_idx_t> propertyIDToVectorIdx)
+        std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> propertyRhsEvaluators)
         : table{table}, relTablesToInit{std::move(relTablesToInit)},
           nodeIDVectorPos{nodeIDVectorPos}, propertyLhsPositions{std::move(propertyLhsPositions)},
-          propertyRhsEvaluators{std::move(propertyRhsEvaluators)}, propertyIDToVectorIdx{std::move(
-                                                                       propertyIDToVectorIdx)} {}
+          propertyRhsEvaluators{std::move(propertyRhsEvaluators)}, nodeIDVector{nullptr} {}
     NodeInsertExecutor(const NodeInsertExecutor& other);
 
     void init(ResultSet* resultSet, ExecutionContext* context);
@@ -37,8 +35,6 @@ private:
     DataPos nodeIDVectorPos;
     std::vector<DataPos> propertyLhsPositions;
     std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> propertyRhsEvaluators;
-    // TODO(Guodong): remove this.
-    std::unordered_map<common::property_id_t, common::vector_idx_t> propertyIDToVectorIdx;
 
     common::ValueVector* nodeIDVector;
     std::vector<common::ValueVector*> propertyLhsVectors;
@@ -53,7 +49,8 @@ public:
         std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> propertyRhsEvaluators)
         : relsStatistics{relsStatistics}, table{table}, srcNodePos{srcNodePos},
           dstNodePos{dstNodePos}, propertyLhsPositions{std::move(propertyLhsPositions)},
-          propertyRhsEvaluators{std::move(propertyRhsEvaluators)} {}
+          propertyRhsEvaluators{std::move(propertyRhsEvaluators)}, srcNodeIDVector{nullptr},
+          dstNodeIDVector{nullptr} {}
     RelInsertExecutor(const RelInsertExecutor& other);
 
     void init(ResultSet* resultSet, ExecutionContext* context);
@@ -75,8 +72,8 @@ private:
     std::vector<DataPos> propertyLhsPositions;
     std::vector<std::unique_ptr<evaluator::ExpressionEvaluator>> propertyRhsEvaluators;
 
-    common::ValueVector* srcNodeIDVector = nullptr;
-    common::ValueVector* dstNodeIDVector = nullptr;
+    common::ValueVector* srcNodeIDVector;
+    common::ValueVector* dstNodeIDVector;
     std::vector<common::ValueVector*> propertyLhsVectors;
     std::vector<common::ValueVector*> propertyRhsVectors;
 };

--- a/src/include/processor/operator/persistent/set_executor.h
+++ b/src/include/processor/operator/persistent/set_executor.h
@@ -39,7 +39,7 @@ protected:
 
 struct NodeSetInfo {
     storage::NodeTable* table;
-    common::property_id_t propertyID;
+    common::column_id_t columnID;
 };
 
 class SingleLabelNodeSetExecutor : public NodeSetExecutor {

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -9,30 +9,31 @@ namespace processor {
 class ScanSingleNodeTable : public ScanColumns {
 public:
     ScanSingleNodeTable(const DataPos& inVectorPos, std::vector<DataPos> outVectorsPos,
-        storage::NodeTable* table, std::vector<uint32_t> propertyColumnIds,
+        storage::NodeTable* table, std::vector<common::column_id_t> columnIDs,
         std::unique_ptr<PhysicalOperator> prevOperator, uint32_t id,
         const std::string& paramsString)
         : ScanColumns{inVectorPos, std::move(outVectorsPos), std::move(prevOperator), id,
               paramsString},
-          table{table}, propertyColumnIds{std::move(propertyColumnIds)} {}
+          table{table}, columnIDs{std::move(columnIDs)} {}
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     inline std::unique_ptr<PhysicalOperator> clone() override {
         return make_unique<ScanSingleNodeTable>(inputNodeIDVectorPos, outPropertyVectorsPos, table,
-            propertyColumnIds, children[0]->clone(), id, paramsString);
+            columnIDs, children[0]->clone(), id, paramsString);
     }
 
 private:
     storage::NodeTable* table;
-    std::vector<uint32_t> propertyColumnIds;
+    std::vector<common::column_id_t> columnIDs;
 };
 
 class ScanMultiNodeTables : public ScanColumns {
 public:
     ScanMultiNodeTables(const DataPos& inVectorPos, std::vector<DataPos> outVectorsPos,
         std::unordered_map<common::table_id_t, storage::NodeTable*> tables,
-        std::unordered_map<common::table_id_t, std::vector<uint32_t>> tableIDToScanColumnIds,
+        std::unordered_map<common::table_id_t, std::vector<common::column_id_t>>
+            tableIDToScanColumnIds,
         std::unique_ptr<PhysicalOperator> prevOperator, uint32_t id,
         const std::string& paramsString)
         : ScanColumns{inVectorPos, std::move(outVectorsPos), std::move(prevOperator), id,
@@ -48,7 +49,7 @@ public:
 
 private:
     std::unordered_map<common::table_id_t, storage::NodeTable*> tables;
-    std::unordered_map<common::table_id_t, std::vector<uint32_t>> tableIDToScanColumnIds;
+    std::unordered_map<common::table_id_t, std::vector<common::column_id_t>> tableIDToScanColumnIds;
 };
 
 } // namespace processor

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -130,7 +130,7 @@ private:
 
     std::unique_ptr<NodeInsertExecutor> getNodeInsertExecutor(storage::NodesStore* nodesStore,
         storage::RelsStore* relsStore, planner::LogicalCreateNodeInfo* info,
-        const planner::Schema& inSchema, const planner::Schema& outSchema);
+        const planner::Schema& inSchema, const planner::Schema& outSchema) const;
     std::unique_ptr<RelInsertExecutor> getRelInsertExecutor(storage::RelsStore* relsStore,
         planner::LogicalCreateRelInfo* info, const planner::Schema& inSchema,
         const planner::Schema& outSchema);

--- a/src/include/storage/copier/node_group.h
+++ b/src/include/storage/copier/node_group.h
@@ -18,8 +18,9 @@ public:
     inline void setNodeGroupIdx(uint64_t nodeGroupIdx_) { this->nodeGroupIdx = nodeGroupIdx_; }
     inline uint64_t getNodeGroupIdx() const { return nodeGroupIdx; }
     inline common::offset_t getNumNodes() const { return numNodes; }
-    inline ColumnChunk* getColumnChunk(common::property_id_t propertyID) {
-        return chunks.contains(propertyID) ? chunks.at(propertyID).get() : nullptr;
+    inline ColumnChunk* getColumnChunk(common::column_id_t columnID) {
+        assert(columnID < chunks.size());
+        return chunks[columnID].get();
     }
     inline bool isFull() const { return numNodes == common::StorageConstants::NODE_GROUP_SIZE; }
 
@@ -33,7 +34,7 @@ public:
 private:
     uint64_t nodeGroupIdx;
     common::offset_t numNodes;
-    std::unordered_map<common::property_id_t, std::unique_ptr<ColumnChunk>> chunks;
+    std::vector<std::unique_ptr<ColumnChunk>> chunks;
 };
 
 } // namespace storage

--- a/src/include/storage/local_storage.h
+++ b/src/include/storage/local_storage.h
@@ -20,9 +20,9 @@ public:
     void lookup(common::table_id_t tableID, common::ValueVector* nodeIDVector,
         const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVectors);
-    void update(common::table_id_t tableID, common::property_id_t propertyID,
+    void update(common::table_id_t tableID, common::column_id_t columnID,
         common::ValueVector* nodeIDVector, common::ValueVector* propertyVector);
-    void update(common::table_id_t tableID, common::property_id_t propertyID,
+    void update(common::table_id_t tableID, common::column_id_t columnID,
         common::offset_t nodeOffset, common::ValueVector* propertyVector,
         common::sel_t posInPropertyVector);
 

--- a/src/include/storage/local_table.h
+++ b/src/include/storage/local_table.h
@@ -145,15 +145,15 @@ public:
     void lookup(common::ValueVector* nodeIDVector,
         const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVectors);
-    void update(common::property_id_t propertyID, common::ValueVector* nodeIDVector,
+    void update(common::column_id_t columnID, common::ValueVector* nodeIDVector,
         common::ValueVector* propertyVector, MemoryManager* mm);
-    void update(common::property_id_t propertyID, common::offset_t nodeOffset,
+    void update(common::column_id_t columnID, common::offset_t nodeOffset,
         common::ValueVector* propertyVector, common::sel_t posInPropertyVector, MemoryManager* mm);
 
     void prepareCommit();
 
 private:
-    std::map<common::property_id_t, std::unique_ptr<LocalColumn>> columns;
+    std::map<common::column_id_t, std::unique_ptr<LocalColumn>> columns;
     NodeTable* table;
 };
 

--- a/src/include/storage/store/nodes_store.h
+++ b/src/include/storage/store/nodes_store.h
@@ -16,7 +16,7 @@ public:
 
     inline NodeColumn* getNodePropertyColumn(
         common::table_id_t tableID, uint64_t propertyIdx) const {
-        return nodeTables.at(tableID)->getPropertyColumn(propertyIdx);
+        return nodeTables.at(tableID)->getColumn(propertyIdx);
     }
     inline PrimaryKeyIndex* getPKIndex(common::table_id_t tableID) {
         return nodeTables[tableID]->getPKIndex();

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -20,7 +20,7 @@ void StorageDriver::scan(const std::string& nodeName, const std::string& propert
     auto nodeTableID = catalogContent->getTableID(nodeName);
     auto propertyID = catalogContent->getTableSchema(nodeTableID)->getPropertyID(propertyName);
     auto nodeTable = storageManager->getNodesStore().getNodeTable(nodeTableID);
-    auto column = nodeTable->getPropertyColumn(propertyID);
+    auto column = nodeTable->getColumn(propertyID);
     auto current_buffer = result;
     std::vector<std::thread> threads;
     auto numElementsPerThread = size / numThreads + 1;

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -29,16 +29,19 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(storage::NodesSt
             }
             auto propertyID = property->getPropertyID(tableID);
             auto table = store->getNodeTable(tableID);
-            tableIDToSetInfo.insert({tableID, NodeSetInfo{table, propertyID}});
+            auto columnID =
+                catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(propertyID);
+            tableIDToSetInfo.insert({tableID, NodeSetInfo{table, columnID}});
         }
         return std::make_unique<MultiLabelNodeSetExecutor>(
             std::move(tableIDToSetInfo), nodeIDPos, propertyPos, std::move(evaluator));
     } else {
         auto tableID = node->getSingleTableID();
         auto table = store->getNodeTable(tableID);
+        auto columnID = catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(
+            property->getPropertyID(tableID));
         return std::make_unique<SingleLabelNodeSetExecutor>(
-            NodeSetInfo{table, property->getPropertyID(tableID)}, nodeIDPos, propertyPos,
-            std::move(evaluator));
+            NodeSetInfo{table, columnID}, nodeIDPos, propertyPos, std::move(evaluator));
     }
 }
 

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -13,7 +13,7 @@ void NodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
 void SingleLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
     NodeDeleteExecutor::init(resultSet, context);
     deleteState = std::make_unique<NodeTable::DeleteState>();
-    auto pkDataType = table->getPropertyColumn(table->getPKPropertyID())->getDataType();
+    auto pkDataType = table->getColumn(table->getPKColumnID())->getDataType();
     deleteState->pkVector = std::make_unique<ValueVector>(pkDataType, context->memoryManager);
     deleteState->pkVector->state = nodeIDVector->state;
 }
@@ -26,7 +26,7 @@ void MultiLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* 
     NodeDeleteExecutor::init(resultSet, context);
     for (auto& [tableID, table] : tableIDToTableMap) {
         deleteStates[tableID] = std::make_unique<NodeTable::DeleteState>();
-        auto pkDataType = table->getPropertyColumn(table->getPKPropertyID())->getDataType();
+        auto pkDataType = table->getColumn(table->getPKColumnID())->getDataType();
         deleteStates[tableID]->pkVector =
             std::make_unique<ValueVector>(pkDataType, context->memoryManager);
         deleteStates[tableID]->pkVector->state = nodeIDVector->state;

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -8,7 +8,7 @@ namespace processor {
 NodeInsertExecutor::NodeInsertExecutor(const NodeInsertExecutor& other)
     : table{other.table}, relTablesToInit{other.relTablesToInit},
       nodeIDVectorPos{other.nodeIDVectorPos}, propertyLhsPositions{other.propertyLhsPositions},
-      propertyIDToVectorIdx{other.propertyIDToVectorIdx} {
+      nodeIDVector{nullptr} {
     for (auto& evaluator : other.propertyRhsEvaluators) {
         propertyRhsEvaluators.push_back(evaluator->clone());
     }
@@ -55,7 +55,7 @@ void NodeInsertExecutor::insert(transaction::Transaction* transaction) {
     for (auto& evaluator : propertyRhsEvaluators) {
         evaluator->evaluate();
     }
-    table->insert(transaction, nodeIDVector, propertyRhsVectors, propertyIDToVectorIdx);
+    table->insert(transaction, nodeIDVector, propertyRhsVectors);
     for (auto& relTable : relTablesToInit) {
         relTable->initEmptyRelsForNewNode(nodeIDVector);
     }
@@ -74,7 +74,8 @@ std::vector<std::unique_ptr<NodeInsertExecutor>> NodeInsertExecutor::copy(
 
 RelInsertExecutor::RelInsertExecutor(const RelInsertExecutor& other)
     : relsStatistics{other.relsStatistics}, table{other.table}, srcNodePos{other.srcNodePos},
-      dstNodePos{other.dstNodePos}, propertyLhsPositions{other.propertyLhsPositions} {
+      dstNodePos{other.dstNodePos}, propertyLhsPositions{other.propertyLhsPositions},
+      srcNodeIDVector{nullptr}, dstNodeIDVector{nullptr} {
     for (auto& evaluator : other.propertyRhsEvaluators) {
         propertyRhsEvaluators.push_back(evaluator->clone());
     }

--- a/src/processor/operator/persistent/set_executor.cpp
+++ b/src/processor/operator/persistent/set_executor.cpp
@@ -36,8 +36,8 @@ static void writeToPropertyVector(ValueVector* propertyVector, uint32_t property
 
 void SingleLabelNodeSetExecutor::set(ExecutionContext* context) {
     evaluator->evaluate();
-    setInfo.table->update(context->clientContext->getActiveTransaction(), setInfo.propertyID,
-        nodeIDVector, rhsVector);
+    setInfo.table->update(
+        context->clientContext->getActiveTransaction(), setInfo.columnID, nodeIDVector, rhsVector);
     for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
         auto lhsPos = nodeIDVector->state->selVector->selectedPositions[i];
         auto rhsPos = lhsPos;
@@ -66,7 +66,7 @@ void MultiLabelNodeSetExecutor::set(ExecutionContext* context) {
             rhsPos = rhsVector->state->selVector->selectedPositions[0];
         }
         auto& setInfo = tableIDToSetInfo.at(nodeID.tableID);
-        setInfo.table->update(context->clientContext->getActiveTransaction(), setInfo.propertyID,
+        setInfo.table->update(context->clientContext->getActiveTransaction(), setInfo.columnID,
             nodeID.offset, rhsVector, rhsPos);
         if (lhsVector != nullptr) {
             writeToPropertyVector(lhsVector, lhsPos, rhsVector, rhsPos);

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -12,7 +12,7 @@ bool ScanSingleNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     for (auto& outputVector : outPropertyVectors) {
         outputVector->resetAuxiliaryBuffer();
     }
-    table->read(transaction, inputNodeIDVector, propertyColumnIds, outPropertyVectors);
+    table->read(transaction, inputNodeIDVector, columnIDs, outPropertyVectors);
     return true;
 }
 

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -28,20 +28,20 @@ void LocalStorage::lookup(table_id_t tableID, ValueVector* nodeIDVector,
     tables.at(tableID)->lookup(nodeIDVector, columnIDs, outputVectors);
 }
 
-void LocalStorage::update(table_id_t tableID, property_id_t propertyID, ValueVector* nodeIDVector,
+void LocalStorage::update(table_id_t tableID, column_id_t columnID, ValueVector* nodeIDVector,
     ValueVector* propertyVector) {
     if (!tables.contains(tableID)) {
         tables.emplace(tableID, std::make_unique<LocalTable>(nodesStore->getNodeTable(tableID)));
     }
-    tables.at(tableID)->update(propertyID, nodeIDVector, propertyVector, mm);
+    tables.at(tableID)->update(columnID, nodeIDVector, propertyVector, mm);
 }
 
-void LocalStorage::update(table_id_t tableID, property_id_t propertyID, offset_t nodeOffset,
+void LocalStorage::update(table_id_t tableID, column_id_t columnID, offset_t nodeOffset,
     ValueVector* propertyVector, sel_t posInPropertyVector) {
     if (!tables.contains(tableID)) {
         tables.emplace(tableID, std::make_unique<LocalTable>(nodesStore->getNodeTable(tableID)));
     }
-    tables.at(tableID)->update(propertyID, nodeOffset, propertyVector, posInPropertyVector, mm);
+    tables.at(tableID)->update(columnID, nodeOffset, propertyVector, posInPropertyVector, mm);
 }
 
 void LocalStorage::prepareCommit() {

--- a/src/storage/local_table.cpp
+++ b/src/storage/local_table.cpp
@@ -366,22 +366,22 @@ void LocalTable::lookup(ValueVector* nodeIDVector, const std::vector<column_id_t
     }
 }
 
-void LocalTable::update(property_id_t propertyID, ValueVector* nodeIDVector,
+void LocalTable::update(column_id_t columnID, ValueVector* nodeIDVector,
     ValueVector* propertyVector, MemoryManager* mm) {
-    if (!columns.contains(propertyID)) {
-        columns.emplace(propertyID,
-            LocalColumnFactory::createLocalColumn(table->getPropertyColumn(propertyID)));
+    if (!columns.contains(columnID)) {
+        columns.emplace(
+            columnID, LocalColumnFactory::createLocalColumn(table->getColumn(columnID)));
     }
-    columns.at(propertyID)->update(nodeIDVector, propertyVector, mm);
+    columns.at(columnID)->update(nodeIDVector, propertyVector, mm);
 }
 
-void LocalTable::update(property_id_t propertyID, offset_t nodeOffset, ValueVector* propertyVector,
+void LocalTable::update(column_id_t columnID, offset_t nodeOffset, ValueVector* propertyVector,
     sel_t posInPropertyVector, MemoryManager* mm) {
-    if (!columns.contains(propertyID)) {
-        columns.emplace(propertyID,
-            LocalColumnFactory::createLocalColumn(table->getPropertyColumn(propertyID)));
+    if (!columns.contains(columnID)) {
+        columns.emplace(
+            columnID, LocalColumnFactory::createLocalColumn(table->getColumn(columnID)));
     }
-    columns.at(propertyID)->update(nodeOffset, propertyVector, posInPropertyVector, mm);
+    columns.at(columnID)->update(nodeOffset, propertyVector, posInPropertyVector, mm);
 }
 
 void LocalTable::prepareCommit() {

--- a/src/storage/store/node_column.cpp
+++ b/src/storage/store/node_column.cpp
@@ -4,7 +4,6 @@
 #include "storage/store/property_statistics.h"
 #include "storage/store/string_node_column.h"
 #include "storage/store/struct_node_column.h"
-#include "storage/store/table_statistics.h"
 #include "storage/store/var_list_node_column.h"
 #include "transaction/transaction.h"
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -16,7 +16,8 @@ NodeTable::NodeTable(BMFileHandle* dataFH, BMFileHandle* metadataFH,
     NodesStatisticsAndDeletedIDs* nodesStatisticsAndDeletedIDs, BufferManager& bufferManager,
     WAL* wal, NodeTableSchema* nodeTableSchema)
     : nodesStatisticsAndDeletedIDs{nodesStatisticsAndDeletedIDs}, dataFH{dataFH},
-      metadataFH{metadataFH}, pkPropertyID{nodeTableSchema->getPrimaryKey()->getPropertyID()},
+      metadataFH{metadataFH}, pkColumnID{nodeTableSchema->getColumnID(
+                                  nodeTableSchema->getPrimaryKeyPropertyID())},
       tableID{nodeTableSchema->tableID}, bufferManager{bufferManager}, wal{wal} {
     initializeData(nodeTableSchema);
 }
@@ -27,11 +28,12 @@ void NodeTable::initializeData(NodeTableSchema* nodeTableSchema) {
 }
 
 void NodeTable::initializeColumns(NodeTableSchema* nodeTableSchema) {
+    columns.reserve(nodeTableSchema->getNumProperties());
     for (auto& property : nodeTableSchema->getProperties()) {
-        propertyColumns[property->getPropertyID()] = NodeColumnFactory::createNodeColumn(*property,
-            dataFH, metadataFH, &bufferManager, wal, Transaction::getDummyReadOnlyTrx().get(),
+        columns.push_back(NodeColumnFactory::createNodeColumn(*property, dataFH, metadataFH,
+            &bufferManager, wal, Transaction::getDummyReadOnlyTrx().get(),
             RWPropertyStats(getNodeStatisticsAndDeletedIDs(), property->getTableID(),
-                property->getPropertyID()));
+                property->getPropertyID())));
     }
 }
 
@@ -54,18 +56,19 @@ void NodeTable::read(Transaction* transaction, ValueVector* nodeIDVector,
 }
 
 void NodeTable::scan(Transaction* transaction, ValueVector* nodeIDVector,
-    const std::vector<column_id_t>& columnIds, const std::vector<ValueVector*>& outputVectors) {
-    assert(columnIds.size() == outputVectors.size() && !nodeIDVector->state->isFlat());
-    for (auto i = 0u; i < columnIds.size(); i++) {
-        if (columnIds[i] == INVALID_COLUMN_ID) {
+    const std::vector<column_id_t>& columnIDs, const std::vector<ValueVector*>& outputVectors) {
+    assert(columnIDs.size() == outputVectors.size() && !nodeIDVector->state->isFlat());
+    for (auto i = 0u; i < columnIDs.size(); i++) {
+        if (columnIDs[i] == INVALID_COLUMN_ID) {
             outputVectors[i]->setAllNull();
         } else {
-            propertyColumns.at(columnIds[i])->scan(transaction, nodeIDVector, outputVectors[i]);
+            assert(columnIDs[i] < columns.size());
+            columns[columnIDs[i]]->scan(transaction, nodeIDVector, outputVectors[i]);
         }
     }
     if (transaction->isWriteTransaction()) {
         auto localStorage = transaction->getLocalStorage();
-        localStorage->scan(tableID, nodeIDVector, columnIds, outputVectors);
+        localStorage->scan(tableID, nodeIDVector, columnIDs, outputVectors);
     }
 }
 
@@ -77,7 +80,8 @@ void NodeTable::lookup(Transaction* transaction, ValueVector* nodeIDVector,
         if (columnID == INVALID_COLUMN_ID) {
             outputVectors[i]->setNull(pos, true);
         } else {
-            propertyColumns.at(columnIDs[i])->lookup(transaction, nodeIDVector, outputVectors[i]);
+            assert(columnIDs[i] < columns.size());
+            columns[columnIDs[i]]->lookup(transaction, nodeIDVector, outputVectors[i]);
         }
     }
     if (transaction->isWriteTransaction()) {
@@ -86,8 +90,7 @@ void NodeTable::lookup(Transaction* transaction, ValueVector* nodeIDVector,
 }
 
 void NodeTable::insert(Transaction* transaction, ValueVector* nodeIDVector,
-    const std::vector<common::ValueVector*>& propertyVectors,
-    const std::unordered_map<common::property_id_t, common::vector_idx_t>& propertyIDToVectorIdx) {
+    const std::vector<common::ValueVector*>& propertyVectors) {
     // We assume that offsets are given in the ascending order, thus lastOffset is the max one.
     offset_t lastOffset;
     for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; i++) {
@@ -98,8 +101,7 @@ void NodeTable::insert(Transaction* transaction, ValueVector* nodeIDVector,
         lastOffset = offset;
     }
     if (pkIndex) {
-        assert(propertyIDToVectorIdx.contains(pkPropertyID));
-        insertPK(nodeIDVector, propertyVectors[propertyIDToVectorIdx.at(pkPropertyID)]);
+        insertPK(nodeIDVector, propertyVectors[pkColumnID]);
     }
     auto currentNumNodeGroups = getNumNodeGroups(transaction);
     if (lastOffset >= StorageUtils::getStartOffsetOfNodeGroup(currentNumNodeGroups)) {
@@ -107,33 +109,31 @@ void NodeTable::insert(Transaction* transaction, ValueVector* nodeIDVector,
         newNodeGroup->setNodeGroupIdx(currentNumNodeGroups);
         append(newNodeGroup.get());
     }
-    for (auto& [propertyID, column] : propertyColumns) {
-        if (column->getDataType().getLogicalTypeID() == LogicalTypeID::SERIAL) {
+    for (auto columnID = 0u; columnID < columns.size(); columnID++) {
+        if (columns[columnID]->getDataType().getLogicalTypeID() == LogicalTypeID::SERIAL) {
             continue;
         }
-        assert(propertyIDToVectorIdx.contains(propertyID));
-        transaction->getLocalStorage()->update(tableID, propertyID, nodeIDVector,
-            propertyVectors[propertyIDToVectorIdx.at(propertyID)]);
+        transaction->getLocalStorage()->update(
+            tableID, columnID, nodeIDVector, propertyVectors[columnID]);
     }
     wal->addToUpdatedNodeTables(tableID);
 }
 
-void NodeTable::update(Transaction* transaction, property_id_t propertyID,
-    ValueVector* nodeIDVector, ValueVector* vectorToWriteFrom) {
-    assert(propertyColumns.contains(propertyID));
-    transaction->getLocalStorage()->update(tableID, propertyID, nodeIDVector, vectorToWriteFrom);
+void NodeTable::update(Transaction* transaction, column_id_t columnID, ValueVector* nodeIDVector,
+    ValueVector* vectorToWriteFrom) {
+    assert(columnID < columns.size());
+    transaction->getLocalStorage()->update(tableID, columnID, nodeIDVector, vectorToWriteFrom);
 }
 
-void NodeTable::update(Transaction* transaction, property_id_t propertyID, offset_t nodeOffset,
-    ValueVector* propertyVector, sel_t posInPropertyVector) {
-    assert(propertyColumns.contains(propertyID));
+void NodeTable::update(Transaction* transaction, column_id_t columnID, offset_t nodeOffset,
+    ValueVector* propertyVector, sel_t posInPropertyVector) const {
     transaction->getLocalStorage()->update(
-        tableID, propertyID, nodeOffset, propertyVector, posInPropertyVector);
+        tableID, columnID, nodeOffset, propertyVector, posInPropertyVector);
 }
 
 void NodeTable::delete_(
     Transaction* transaction, ValueVector* nodeIDVector, DeleteState* deleteState) {
-    read(transaction, nodeIDVector, {pkPropertyID}, {deleteState->pkVector.get()});
+    read(transaction, nodeIDVector, {pkColumnID}, {deleteState->pkVector.get()});
     if (pkIndex) {
         pkIndex->delete_(deleteState->pkVector.get());
     }
@@ -145,25 +145,17 @@ void NodeTable::delete_(
 }
 
 void NodeTable::append(NodeGroup* nodeGroup) {
-    for (auto& [propertyID, column] : propertyColumns) {
-        auto columnChunk = nodeGroup->getColumnChunk(propertyID);
+    for (auto columnID = 0u; columnID < columns.size(); columnID++) {
+        auto columnChunk = nodeGroup->getColumnChunk(columnID);
         auto numPages = columnChunk->getNumPages();
         auto startPageIdx = dataFH->addNewPages(numPages);
-        column->append(columnChunk, startPageIdx, nodeGroup->getNodeGroupIdx());
+        assert(columnID < columns.size());
+        columns[columnID]->append(columnChunk, startPageIdx, nodeGroup->getNodeGroupIdx());
     }
-}
-
-std::unordered_set<property_id_t> NodeTable::getPropertyIDs() const {
-    std::unordered_set<property_id_t> propertyIDs;
-    for (auto& [propertyID, _] : propertyColumns) {
-        propertyIDs.insert(propertyID);
-    }
-    return propertyIDs;
 }
 
 void NodeTable::addColumn(const catalog::Property& property,
     common::ValueVector* defaultValueVector, transaction::Transaction* transaction) {
-    assert(!propertyColumns.contains(property.getPropertyID()));
     nodesStatisticsAndDeletedIDs->setPropertyStatisticsForTable(property.getTableID(),
         property.getPropertyID(), PropertyStatistics(!defaultValueVector->hasNoNullsGuarantee()));
     auto nodeColumn = NodeColumnFactory::createNodeColumn(property, dataFH, metadataFH,
@@ -172,7 +164,7 @@ void NodeTable::addColumn(const catalog::Property& property,
             nodesStatisticsAndDeletedIDs, property.getTableID(), property.getPropertyID()));
     nodeColumn->populateWithDefaultVal(
         property, nodeColumn.get(), defaultValueVector, getNumNodeGroups(transaction));
-    propertyColumns.emplace(property.getPropertyID(), std::move(nodeColumn));
+    columns.push_back(std::move(nodeColumn));
     wal->addToUpdatedNodeTables(tableID);
 }
 
@@ -189,7 +181,7 @@ void NodeTable::prepareRollback() {
 }
 
 void NodeTable::checkpointInMemory() {
-    for (auto& [_, column] : propertyColumns) {
+    for (auto& column : columns) {
         column->checkpointInMemory();
     }
     if (pkIndex) {
@@ -198,7 +190,7 @@ void NodeTable::checkpointInMemory() {
 }
 
 void NodeTable::rollbackInMemory() {
-    for (auto& [_, column] : propertyColumns) {
+    for (auto& column : columns) {
         column->rollbackInMemory();
     }
     if (pkIndex) {

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -422,7 +422,8 @@ void WALReplayer::replayDropPropertyRecord(const kuzu::storage::WALRecord& walRe
             auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(tableID);
             switch (tableSchema->getTableType()) {
             case TableType::NODE: {
-                storageManager->getNodesStore().getNodeTable(tableID)->dropColumn(propertyID);
+                storageManager->getNodesStore().getNodeTable(tableID)->dropColumn(
+                    tableSchema->getColumnID(propertyID));
                 // TODO(Guodong): Do nothing for now. Should remove meta disk array and node groups.
             } break;
             case TableType::REL: {
@@ -505,7 +506,8 @@ void WALReplayer::replayAddPropertyRecord(const kuzu::storage::WALRecord& walRec
         auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(tableID);
         switch (tableSchema->getTableType()) {
         case TableType::NODE: {
-            storageManager->getNodesStore().getNodeTable(tableID)->dropColumn(propertyID);
+            storageManager->getNodesStore().getNodeTable(tableID)->dropColumn(
+                tableSchema->getColumnID(propertyID));
         } break;
         case TableType::REL: {
             // Nothing to undo.


### PR DESCRIPTION
Now node table takes in columnID instead propertyID to access a column. Internally node table stores all columns in a vector  (instead of a map), which is aligned with its tableSchema (we skip INTERNAL_ID column).
The front-end (or mapper currently) is responsible for aligning scanned columns in node table with properties in schema.