### PR TITLE
Use a different schema for each RecordBatch in python getAsArrow

### DIFF
--- a/tools/python_api/requirements_dev.txt
+++ b/tools/python_api/requirements_dev.txt
@@ -3,7 +3,7 @@ pytest
 pandas
 networkx~=3.0.0
 numpy
-pyarrow~=10.0.0
+pyarrow~=13.0.0
 torch-cluster~=1.6.0
 torch-geometric~=2.2.0
 torch-scatter~=2.1.0

--- a/tools/python_api/src_cpp/include/py_query_result.h
+++ b/tools/python_api/src_cpp/include/py_query_result.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <vector>
+#include <memory>
+
 #include "arrow_array.h"
 #include "common/arrow/arrow.h"
 #include "common/types/internal_id_t.h"
@@ -49,8 +52,9 @@ public:
 private:
     static py::dict convertNodeIdToPyDict(const kuzu::common::nodeID_t& nodeId);
 
-    bool getNextArrowChunk(const ArrowSchema& schema, py::list& batches, std::int64_t chunk_size);
-    py::object getArrowChunks(const ArrowSchema& schema, std::int64_t chunkSize);
+    bool getNextArrowChunk(const std::vector<std::unique_ptr<DataTypeInfo>>& typesInfo, py::list& batches, std::int64_t chunk_size);
+    py::object getArrowChunks(
+        const std::vector<std::unique_ptr<DataTypeInfo>>& typesInfo, std::int64_t chunkSize);
 
 private:
     std::unique_ptr<QueryResult> queryResult;


### PR DESCRIPTION
Fixes #2037.

I also bumped the version of pyarrow used in CI so that the new memory release check that was catching this issue gets used in CI.