### PR TITLE
Int8 and Int16 bitpacking

### DIFF
--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -121,6 +121,20 @@ ColumnChunk::ColumnChunk(
             GetCompressionMetadata(std::make_unique<IntegerBitpacking<int32_t>>(), this->dataType);
         break;
     }
+    case PhysicalTypeID::INT16: {
+        flushBufferFunction =
+            CompressedFlushBuffer(std::make_unique<IntegerBitpacking<int16_t>>(), this->dataType);
+        getMetadataFunction =
+            GetCompressionMetadata(std::make_unique<IntegerBitpacking<int16_t>>(), this->dataType);
+        break;
+    }
+    case PhysicalTypeID::INT8: {
+        flushBufferFunction =
+            CompressedFlushBuffer(std::make_unique<IntegerBitpacking<int8_t>>(), this->dataType);
+        getMetadataFunction =
+            GetCompressionMetadata(std::make_unique<IntegerBitpacking<int8_t>>(), this->dataType);
+        break;
+    }
     case PhysicalTypeID::VAR_LIST:
     case PhysicalTypeID::UINT64: {
         flushBufferFunction =
@@ -134,6 +148,20 @@ ColumnChunk::ColumnChunk(
             CompressedFlushBuffer(std::make_unique<IntegerBitpacking<uint32_t>>(), this->dataType);
         getMetadataFunction =
             GetCompressionMetadata(std::make_unique<IntegerBitpacking<uint32_t>>(), this->dataType);
+        break;
+    }
+    case PhysicalTypeID::UINT16: {
+        flushBufferFunction =
+            CompressedFlushBuffer(std::make_unique<IntegerBitpacking<uint16_t>>(), this->dataType);
+        getMetadataFunction =
+            GetCompressionMetadata(std::make_unique<IntegerBitpacking<uint16_t>>(), this->dataType);
+        break;
+    }
+    case PhysicalTypeID::UINT8: {
+        flushBufferFunction =
+            CompressedFlushBuffer(std::make_unique<IntegerBitpacking<uint8_t>>(), this->dataType);
+        getMetadataFunction =
+            GetCompressionMetadata(std::make_unique<IntegerBitpacking<uint8_t>>(), this->dataType);
         break;
     }
     default: {

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -228,3 +228,43 @@ TEST(CompressionTests, IntegerPackingMultiPageUnsigned64) {
 
     integerPackingMultiPage(src);
 }
+
+TEST(CompressionTests, IntegerPackingMultiPageUnsigned16) {
+    int64_t numValues = 10000;
+    std::vector<uint16_t> src(numValues);
+    for (int i = 0; i < numValues; i++) {
+        src[i] = i;
+    }
+
+    integerPackingMultiPage(src);
+}
+
+TEST(CompressionTests, IntegerPackingMultiPage16) {
+    int64_t numValues = 10000;
+    std::vector<int16_t> src(numValues);
+    for (int i = 0; i < numValues; i++) {
+        src[i] = i;
+    }
+
+    integerPackingMultiPage(src);
+}
+
+TEST(CompressionTests, IntegerPackingMultiPage8) {
+    int64_t numValues = 10000;
+    std::vector<int8_t> src(numValues);
+    for (int i = 0; i < numValues; i++) {
+        src[i] = i % 30 - 15;
+    }
+
+    integerPackingMultiPage(src);
+}
+
+TEST(CompressionTests, IntegerPackingMultiPageUnsigned8) {
+    int64_t numValues = 10000;
+    std::vector<uint8_t> src(numValues);
+    for (int i = 0; i < numValues; i++) {
+        src[i] = i % 30;
+    }
+
+    integerPackingMultiPage(src);
+}

--- a/third_party/fastpfor/README
+++ b/third_party/fastpfor/README
@@ -2,3 +2,21 @@ https://github.com/lemire/FastPFor
 
 Modified to remove 24 and 32-bit versions of the bitpackingaligned functions since we won't need them, and to remove unneeded includes in common.h.
 Modified to replace __restrict__ with __restrict for compatibility with MSVC.
+
+Included 16-bit support from DuckDB (MIT License below):
+    https://github.com/duckdb/duckdb/commit/68abedc20f290b53a2d1073b82e5cf73aef1e9f7
+Included 8-bit support from DuckDB (MIT License below):
+    https://github.com/duckdb/duckdb/commit/bb0df14323447523aa1e8ef09ab37278f7f2db39
+    https://github.com/duckdb/duckdb/commit/29698b8b3bec89a80d6eebcd0cf49972e5280645
+
+    Copyright 2018-2023 Stichting DuckDB Foundation
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.

--- a/third_party/fastpfor/fastpfor/bitpacking.cpp
+++ b/third_party/fastpfor/fastpfor/bitpacking.cpp
@@ -5,6 +5,39 @@
 namespace {
 
 template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) < 8>::type unpack_single_out(const uint8_t *__restrict in,
+                                                                   uint8_t *__restrict out) {
+  *out = ((*in) >> SHR) % (1 << DELTA);
+}
+
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) >= 8>::type unpack_single_out(const uint8_t *__restrict &in,
+                                                                     uint8_t *__restrict out) {
+  *out = (*in) >> SHR;
+  ++in;
+
+  static const uint8_t NEXT_SHR = SHR + DELTA - 8;
+  *out |= ((*in) % (1U << NEXT_SHR)) << (8 - SHR);
+}
+
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) < 16>::type unpack_single_out(const uint16_t *__restrict in,
+                                                                    uint16_t *__restrict out) {
+  *out = ((*in) >> SHR) % (1 << DELTA);
+}
+
+template <uint8_t DELTA, uint8_t SHR>
+typename std::enable_if<(DELTA + SHR) >= 16>::type unpack_single_out(const uint16_t *__restrict &in,
+                                                                     uint16_t *__restrict out) {
+  *out = (*in) >> SHR;
+  ++in;
+
+  static const uint8_t NEXT_SHR = SHR + DELTA - 16;
+  *out |= ((*in) % (1U << NEXT_SHR)) << (16 - SHR);
+}
+
+
+template <uint8_t DELTA, uint8_t SHR>
 typename std::enable_if<(DELTA + SHR) < 32>::type unpack_single_out(
     const uint32_t *__restrict in, uint32_t *__restrict out) {
   *out = ((*in) >> SHR) % (1 << DELTA);
@@ -75,6 +108,45 @@ typename std::enable_if<DELTA + SHL >= 32>::type pack_single_in(
   }
 }
 
+template <uint16_t DELTA, uint16_t SHL, uint16_t MASK>
+typename std::enable_if < DELTA + SHL<8>::type pack_single_in(const uint8_t in, uint8_t *__restrict out) {
+  if (SHL == 0) {
+    *out = in & MASK;
+  } else {
+    *out |= (in & MASK) << SHL;
+  }
+}
+
+template <uint16_t DELTA, uint16_t SHL, uint16_t MASK>
+typename std::enable_if<DELTA + SHL >= 8>::type pack_single_in(const uint8_t in, uint8_t *__restrict &out) {
+  *out |= in << SHL;
+  ++out;
+
+  if (DELTA + SHL > 8) {
+    *out = (in & MASK) >> (8 - SHL);
+  }
+}
+
+template <uint16_t DELTA, uint16_t SHL, uint16_t MASK>
+  typename std::enable_if < DELTA + SHL<16>::type pack_single_in(const uint16_t in, uint16_t *__restrict out) {
+  if (SHL == 0) {
+	*out = in & MASK;
+  } else {
+	*out |= (in & MASK) << SHL;
+  }
+}
+
+template <uint16_t DELTA, uint16_t SHL, uint16_t MASK>
+typename std::enable_if<DELTA + SHL >= 16>::type pack_single_in(const uint16_t in, uint16_t *__restrict &out) {
+  *out |= in << SHL;
+  ++out;
+
+  if (DELTA + SHL > 16) {
+	*out = (in & MASK) >> (16 - SHL);
+  }
+}
+
+
 template <uint16_t DELTA, uint16_t SHL, uint64_t MASK>
     typename std::enable_if <
     DELTA + SHL<32>::type pack_single_in64(const uint64_t in,
@@ -116,6 +188,65 @@ typename std::enable_if<DELTA + SHL >= 64>::type pack_single_in64(
     *out = (in & MASK) >> (64 - SHL);
   }
 }
+
+template <uint16_t DELTA, uint16_t OINDEX = 0>
+struct Unroller8 {
+  static void Unpack(const uint8_t *__restrict &in, uint8_t *__restrict out) {
+    unpack_single_out<DELTA, (DELTA * OINDEX) % 8>(in, out + OINDEX);
+
+    Unroller8<DELTA, OINDEX + 1>::Unpack(in, out);
+  }
+
+  static void Pack(const uint8_t *__restrict in, uint8_t *__restrict out) {
+    pack_single_in<DELTA, (DELTA * OINDEX) % 8, (1U << DELTA) - 1>(in[OINDEX], out);
+
+    Unroller8<DELTA, OINDEX + 1>::Pack(in, out);
+  }
+
+};
+template <uint16_t DELTA>
+struct Unroller8<DELTA, 7> {
+  enum { SHIFT = (DELTA * 7) % 8 };
+
+  static void Unpack(const uint8_t *__restrict in, uint8_t *__restrict out) {
+    out[7] = (*in) >> SHIFT;
+  }
+
+  static void Pack(const uint8_t *__restrict in, uint8_t *__restrict out) {
+    *out |= (in[7] << SHIFT);
+  }
+};
+
+
+template <uint16_t DELTA, uint16_t OINDEX = 0>
+struct Unroller16 {
+  static void Unpack(const uint16_t *__restrict &in, uint16_t *__restrict out) {
+	unpack_single_out<DELTA, (DELTA * OINDEX) % 16>(in, out + OINDEX);
+
+	Unroller16<DELTA, OINDEX + 1>::Unpack(in, out);
+  }
+
+  static void Pack(const uint16_t *__restrict in, uint16_t *__restrict out) {
+	pack_single_in<DELTA, (DELTA * OINDEX) % 16, (1U << DELTA) - 1>(in[OINDEX], out);
+
+	Unroller16<DELTA, OINDEX + 1>::Pack(in, out);
+  }
+
+};
+
+template <uint16_t DELTA>
+struct Unroller16<DELTA, 15> {
+	enum { SHIFT = (DELTA * 15) % 16 };
+
+	static void Unpack(const uint16_t *__restrict in, uint16_t *__restrict out) {
+		out[15] = (*in) >> SHIFT;
+	}
+
+	static void Pack(const uint16_t *__restrict in, uint16_t *__restrict out) {
+		*out |= (in[15] << SHIFT);
+	}
+};
+
 
 template <uint16_t DELTA, uint16_t OINDEX = 0>
 struct Unroller {
@@ -214,6 +345,16 @@ struct Unroller<DELTA, 31> {
 }  // namespace
 
 // Special cases
+void __fastunpack0(const uint8_t *__restrict, uint8_t *__restrict out) {
+  for (uint8_t i = 0; i < 8; ++i)
+    *(out++) = 0;
+}
+
+void __fastunpack0(const uint16_t *__restrict, uint16_t *__restrict out) {
+  for (uint16_t i = 0; i < 16; ++i)
+	*(out++) = 0;
+}
+
 void __fastunpack0(const uint32_t *__restrict, uint32_t *__restrict out) {
   for (uint32_t i = 0; i < 32; ++i) *(out++) = 0;
 }
@@ -222,6 +363,8 @@ void __fastunpack0(const uint32_t *__restrict, uint64_t *__restrict out) {
   for (uint32_t i = 0; i < 32; ++i) *(out++) = 0;
 }
 
+void __fastpack0(const uint8_t *__restrict, uint8_t *__restrict) {}
+void __fastpack0(const uint16_t *__restrict, uint16_t *__restrict) {}
 void __fastpack0(const uint32_t *__restrict, uint32_t *__restrict) {}
 void __fastpack0(const uint64_t *__restrict, uint32_t *__restrict) {}
 
@@ -229,6 +372,118 @@ void __fastpackwithoutmask0(const uint32_t *__restrict,
                             uint32_t *__restrict) {}
 void __fastpackwithoutmask0(const uint64_t *__restrict,
                             uint32_t *__restrict) {}
+
+// fastunpack for 8 bits
+void __fastunpack1(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<1>::Unpack(in, out);
+}
+
+void __fastunpack2(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<2>::Unpack(in, out);
+}
+
+void __fastunpack3(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<3>::Unpack(in, out);
+}
+
+void __fastunpack4(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  for (uint8_t outer = 0; outer < 4; ++outer) {
+    for (uint8_t inwordpointer = 0; inwordpointer < 8; inwordpointer += 4)
+      *(out++) = ((*in) >> inwordpointer) % (1U << 4);
+    ++in;
+  }
+}
+
+void __fastunpack5(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<5>::Unpack(in, out);
+}
+
+void __fastunpack6(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<6>::Unpack(in, out);
+}
+
+void __fastunpack7(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<7>::Unpack(in, out);
+}
+
+void __fastunpack8(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  for (int k = 0; k < 8; ++k)
+    out[k] = in[k];
+}
+
+// fastunpack for 16 bits
+void __fastunpack1(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<1>::Unpack(in, out);
+}
+
+void __fastunpack2(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<2>::Unpack(in, out);
+}
+
+void __fastunpack3(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<3>::Unpack(in, out);
+}
+
+void __fastunpack4(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  for (uint16_t outer = 0; outer < 4; ++outer) {
+	for (uint16_t inwordpointer = 0; inwordpointer < 16; inwordpointer += 4)
+	  *(out++) = ((*in) >> inwordpointer) % (1U << 4);
+	++in;
+  }
+}
+
+void __fastunpack5(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<5>::Unpack(in, out);
+}
+
+void __fastunpack6(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<6>::Unpack(in, out);
+}
+
+void __fastunpack7(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<7>::Unpack(in, out);
+}
+
+void __fastunpack8(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  for (uint16_t outer = 0; outer < 8; ++outer) {
+	for (uint16_t inwordpointer = 0; inwordpointer < 16; inwordpointer += 8)
+	  *(out++) = ((*in) >> inwordpointer) % (1U << 8);
+	++in;
+  }
+}
+
+void __fastunpack9(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<9>::Unpack(in, out);
+}
+
+void __fastunpack10(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<10>::Unpack(in, out);
+}
+
+void __fastunpack11(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<11>::Unpack(in, out);
+}
+
+void __fastunpack12(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<12>::Unpack(in, out);
+}
+
+void __fastunpack13(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<13>::Unpack(in, out);
+}
+
+void __fastunpack14(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<14>::Unpack(in, out);
+}
+
+void __fastunpack15(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<15>::Unpack(in, out);
+}
+
+void __fastunpack16(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  for (int k = 0; k < 16; ++k)
+	out[k] = in[k];
+}
 
 // fastunpack for 32 bits
 void __fastunpack1(const uint32_t *__restrict in,
@@ -738,6 +993,108 @@ void __fastunpack64(const uint32_t *__restrict in,
     out[k] = in[k * 2];
     out[k] |= static_cast<uint64_t>(in[k * 2 + 1]) << 32;
   }
+}
+
+// fastpack for 8 bits
+
+void __fastpack1(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<1>::Pack(in, out);
+}
+
+void __fastpack2(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<2>::Pack(in, out);
+}
+
+void __fastpack3(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<3>::Pack(in, out);
+}
+
+void __fastpack4(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<4>::Pack(in, out);
+}
+
+void __fastpack5(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<5>::Pack(in, out);
+}
+
+void __fastpack6(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<6>::Pack(in, out);
+}
+
+void __fastpack7(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  Unroller8<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint8_t *__restrict in, uint8_t *__restrict out) {
+  for (int k = 0; k < 8; ++k)
+    out[k] = in[k];
+}
+
+// fastpack for 16 bits
+
+void __fastpack1(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<1>::Pack(in, out);
+}
+
+void __fastpack2(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<2>::Pack(in, out);
+}
+
+void __fastpack3(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<3>::Pack(in, out);
+}
+
+void __fastpack4(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<4>::Pack(in, out);
+}
+
+void __fastpack5(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<5>::Pack(in, out);
+}
+
+void __fastpack6(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<6>::Pack(in, out);
+}
+
+void __fastpack7(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<7>::Pack(in, out);
+}
+
+void __fastpack8(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<8>::Pack(in, out);
+}
+
+void __fastpack9(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<9>::Pack(in, out);
+}
+
+void __fastpack10(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<10>::Pack(in, out);
+}
+
+void __fastpack11(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<11>::Pack(in, out);
+}
+
+void __fastpack12(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<12>::Pack(in, out);
+}
+
+void __fastpack13(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<13>::Pack(in, out);
+}
+
+void __fastpack14(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<14>::Pack(in, out);
+}
+
+void __fastpack15(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  Unroller16<15>::Pack(in, out);
+}
+
+void __fastpack16(const uint16_t *__restrict in, uint16_t *__restrict out) {
+  for (int k = 0; k < 16; ++k)
+    out[k] = in[k];
 }
 
 // fastpack for 32 bits

--- a/third_party/fastpfor/fastpfor/bitpacking.h
+++ b/third_party/fastpfor/fastpfor/bitpacking.h
@@ -8,6 +8,34 @@
 #define BITPACKING_H_
 #include "common.h"
 
+void __fastunpack0(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack1(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack2(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack3(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack4(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack5(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack6(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack7(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastunpack8(const uint8_t *__restrict in, uint8_t *__restrict out);
+
+void __fastunpack0(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack1(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack2(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack3(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack4(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack5(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack6(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack7(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack8(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack9(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack10(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack11(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack12(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack13(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack14(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack15(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastunpack16(const uint16_t *__restrict in, uint16_t *__restrict out);
+
 void __fastunpack0(const uint32_t *__restrict in, uint32_t *__restrict out);
 void __fastunpack1(const uint32_t *__restrict in, uint32_t *__restrict out);
 void __fastunpack2(const uint32_t *__restrict in, uint32_t *__restrict out);
@@ -185,6 +213,34 @@ void __fastunpack63(const uint32_t *__restrict in,
                     uint64_t *__restrict out);
 void __fastunpack64(const uint32_t *__restrict in,
                     uint64_t *__restrict out);
+
+void __fastpack0(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack1(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack2(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack3(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack4(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack5(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack6(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack7(const uint8_t *__restrict in, uint8_t *__restrict out);
+void __fastpack8(const uint8_t *__restrict in, uint8_t *__restrict out);
+
+void __fastpack0(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack1(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack2(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack3(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack4(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack5(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack6(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack7(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack8(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack9(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack10(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack11(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack12(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack13(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack14(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack15(const uint16_t *__restrict in, uint16_t *__restrict out);
+void __fastpack16(const uint16_t *__restrict in, uint16_t *__restrict out);
 
 void __fastpack0(const uint32_t *__restrict in, uint32_t *__restrict out);
 void __fastpack1(const uint32_t *__restrict in, uint32_t *__restrict out);

--- a/third_party/fastpfor/fastpfor/bitpackinghelpers.h
+++ b/third_party/fastpfor/fastpfor/bitpackinghelpers.h
@@ -12,6 +12,219 @@
 
 namespace FastPForLib {
 
+// Note that this only packs 8 values
+inline void fastunpack_quarter(const uint8_t *__restrict in, uint8_t *__restrict out, const uint32_t bit) {
+  // Could have used function pointers instead of switch.
+  // Switch calls do offer the compiler more opportunities for optimization in
+  // theory. In this case, it makes no difference with a good compiler.
+  switch (bit) {
+  case 0:
+    __fastunpack0(in, out);
+    break;
+  case 1:
+    __fastunpack1(in, out);
+    break;
+  case 2:
+    __fastunpack2(in, out);
+    break;
+  case 3:
+    __fastunpack3(in, out);
+    break;
+  case 4:
+    __fastunpack4(in, out);
+    break;
+  case 5:
+    __fastunpack5(in, out);
+    break;
+  case 6:
+    __fastunpack6(in, out);
+    break;
+  case 7:
+    __fastunpack7(in, out);
+    break;
+  case 8:
+    __fastunpack8(in, out);
+    break;
+  default:
+    throw std::logic_error("Invalid bit width for bitpacking");
+  }
+}
+
+// Note that this only packs 8 values
+inline void fastpack_quarter(const uint8_t *__restrict in, uint8_t *__restrict out, const uint32_t bit) {
+  // Could have used function pointers instead of switch.
+  // Switch calls do offer the compiler more opportunities for optimization in
+  // theory. In this case, it makes no difference with a good compiler.
+  switch (bit) {
+  case 0:
+    __fastpack0(in, out);
+    break;
+  case 1:
+    __fastpack1(in, out);
+    break;
+  case 2:
+    __fastpack2(in, out);
+    break;
+  case 3:
+    __fastpack3(in, out);
+    break;
+  case 4:
+    __fastpack4(in, out);
+    break;
+  case 5:
+    __fastpack5(in, out);
+    break;
+  case 6:
+    __fastpack6(in, out);
+    break;
+  case 7:
+    __fastpack7(in, out);
+    break;
+  case 8:
+    __fastpack8(in, out);
+    break;
+  default:
+  	throw std::logic_error("Invalid bit width for bitpacking");
+  }
+}
+
+// Note that this only packs 16 values
+inline void fastunpack_half(const uint16_t *__restrict in, uint16_t *__restrict out, const uint32_t bit) {
+  // Could have used function pointers instead of switch.
+  // Switch calls do offer the compiler more opportunities for optimization in
+  // theory. In this case, it makes no difference with a good compiler.
+  switch (bit) {
+  case 0:
+    __fastunpack0(in, out);
+    break;
+  case 1:
+    __fastunpack1(in, out);
+    break;
+  case 2:
+    __fastunpack2(in, out);
+    break;
+  case 3:
+    __fastunpack3(in, out);
+    break;
+  case 4:
+    __fastunpack4(in, out);
+    break;
+  case 5:
+    __fastunpack5(in, out);
+    break;
+  case 6:
+    __fastunpack6(in, out);
+    break;
+  case 7:
+    __fastunpack7(in, out);
+    break;
+  case 8:
+    __fastunpack8(in, out);
+    break;
+  case 9:
+    __fastunpack9(in, out);
+    break;
+  case 10:
+    __fastunpack10(in, out);
+    break;
+  case 11:
+    __fastunpack11(in, out);
+    break;
+  case 12:
+    __fastunpack12(in, out);
+    break;
+  case 13:
+    __fastunpack13(in, out);
+    break;
+  case 14:
+    __fastunpack14(in, out);
+  break;
+  case 15:
+    __fastunpack15(in, out);
+    break;
+  case 16:
+    __fastunpack16(in, out);
+    break;
+  default:
+    throw std::logic_error("Invalid bit width for bitpacking");
+  }
+}
+
+// Note that this only packs 16 values
+inline void fastpack_half(const uint16_t *__restrict in, uint16_t *__restrict out, const uint32_t bit) {
+    // Could have used function pointers instead of switch.
+    // Switch calls do offer the compiler more opportunities for optimization in
+    // theory. In this case, it makes no difference with a good compiler.
+  switch (bit) {
+  case 0:
+    __fastpack0(in, out);
+    break;
+  case 1:
+    __fastpack1(in, out);
+    break;
+  case 2:
+    __fastpack2(in, out);
+    break;
+  case 3:
+    __fastpack3(in, out);
+    break;
+  case 4:
+    __fastpack4(in, out);
+    break;
+  case 5:
+    __fastpack5(in, out);
+    break;
+  case 6:
+    __fastpack6(in, out);
+    break;
+  case 7:
+    __fastpack7(in, out);
+    break;
+  case 8:
+    __fastpack8(in, out);
+    break;
+  case 9:
+    __fastpack9(in, out);
+    break;
+  case 10:
+    __fastpack10(in, out);
+    break;
+  case 11:
+    __fastpack11(in, out);
+    break;
+  case 12:
+    __fastpack12(in, out);
+    break;
+  case 13:
+    __fastpack13(in, out);
+    break;
+  case 14:
+    __fastpack14(in, out);
+    break;
+  case 15:
+    __fastpack15(in, out);
+    break;
+  case 16:
+    __fastpack16(in, out);
+    break;
+  default:
+    throw std::logic_error("Invalid bit width for bitpacking");
+  }
+}
+
+inline void fastunpack(const uint8_t *__restrict in, uint8_t *__restrict out, const uint32_t bit) {
+  for (uint8_t i = 0; i < 4; i++) {
+    fastunpack_quarter(in + (i*bit), out+(i*8), bit);
+  }
+}
+
+inline void fastunpack(const uint16_t *__restrict in,
+        		    uint16_t *__restrict out, const uint32_t bit) {
+  fastunpack_half(in, out, bit);
+  fastunpack_half(in + bit, out+16, bit);
+}
+
+
 inline void fastunpack(const uint32_t *__restrict in,
                        uint32_t *__restrict out, const uint32_t bit) {
   // Could have used function pointers instead of switch.
@@ -326,6 +539,19 @@ inline void fastunpack(const uint32_t *__restrict in,
   default:
     break;
   }
+}
+
+inline void fastpack(const uint8_t *__restrict in, uint8_t *__restrict out, const uint32_t bit) {
+  for (uint8_t i = 0; i < 4; i++) {
+    fastpack_quarter(in+(i*8), out + (i*bit), bit);
+  }
+}
+
+// Compress all 32 values
+inline void fastpack(const uint16_t *__restrict in,
+                     uint16_t *__restrict out, const uint32_t bit) {
+  fastpack_half(in, out, bit);
+  fastpack_half(in+16, out + bit, bit);
 }
 
 inline void fastpack(const uint32_t *__restrict in,


### PR DESCRIPTION
This uses the 8 and 16-bit extensions to fastunpack from duckdb (external changes to fastpfor are documented in `third_party/fastpfor/README`). fastpfor does actually include 8 and 16-bit functions, but I ran into some issues (which I didn't spend much time investigating) when I briefly tried using them before, and they use a somewhat different interface and are much less compact (~5000 lines of code).