### PR TITLE
Database access mode

### DIFF
--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -95,6 +95,7 @@ struct StorageConstants {
     static constexpr char CATALOG_FILE_NAME_FOR_WAL[] = "catalog.kz.wal";
     static constexpr char DATA_FILE_NAME[] = "data.kz";
     static constexpr char METADATA_FILE_NAME[] = "metadata.kz";
+    static constexpr char LOCK_FILE_NAME[] = ".lock";
 
     // The number of pages that we add at one time when we need to grow a file.
     static constexpr uint64_t PAGE_GROUP_SIZE_LOG2 = 10;

--- a/src/include/common/file_utils.h
+++ b/src/include/common/file_utils.h
@@ -15,6 +15,8 @@
 namespace kuzu {
 namespace common {
 
+enum class FileLockType : uint8_t { NO_LOCK = 0, READ_LOCK = 1, WRITE_LOCK = 2 };
+
 struct FileInfo {
 #ifdef _WIN32
     FileInfo(std::string path, const void* handle) : path{std::move(path)}, handle{handle} {}
@@ -36,7 +38,8 @@ struct FileInfo {
 
 class FileUtils {
 public:
-    static std::unique_ptr<FileInfo> openFile(const std::string& path, int flags);
+    static std::unique_ptr<FileInfo> openFile(
+        const std::string& path, int flags, FileLockType lock_type = FileLockType::NO_LOCK);
 
     static void readFromFile(
         FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position);

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -141,7 +141,7 @@ public:
         addScalarFunction(name, std::move(definitions));
     }
 
-protected:
+private:
     std::unique_ptr<QueryResult> query(const std::string& query, const std::string& encodedJoin);
 
     std::unique_ptr<QueryResult> queryResultWithError(const std::string& errMsg);
@@ -168,7 +168,9 @@ protected:
     KUZU_API void addScalarFunction(
         std::string name, function::vector_function_definitions definitions);
 
-protected:
+    void checkPreparedStatementAccessMode(PreparedStatement* preparedStatement);
+
+private:
     Database* database;
     std::unique_ptr<ClientContext> clientContext;
     std::mutex mtx;

--- a/src/include/main/kuzu_fwd.h
+++ b/src/include/main/kuzu_fwd.h
@@ -30,6 +30,7 @@ class Catalog;
 namespace common {
 enum class StatementType : uint8_t;
 class Value;
+struct FileInfo;
 } // namespace common
 
 namespace storage {

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -277,6 +277,10 @@ public:
                            common::StorageConstants::CATALOG_FILE_NAME_FOR_WAL);
     }
 
+    static inline std::string getLockFilePath(const std::string& directory) {
+        return common::FileUtils::joinPath(directory, common::StorageConstants::LOCK_FILE_NAME);
+    }
+
     // Note: This is a relatively slow function because of division and mod and making std::pair.
     // It is not meant to be used in performance critical code path.
     static inline std::pair<uint64_t, uint64_t> getQuotientRemainder(uint64_t i, uint64_t divisor) {

--- a/test/main/CMakeLists.txt
+++ b/test/main/CMakeLists.txt
@@ -1,12 +1,26 @@
-add_kuzu_api_test(main_test
-        arrow_test.cpp
-        config_test.cpp
-        connection_test.cpp
-        csv_output_test.cpp
-        prepare_test.cpp
-        result_value_test.cpp
-        storage_driver_test.cpp
-        udf_test.cpp)
+if(MSVC)
+    add_kuzu_api_test(main_test
+            arrow_test.cpp
+            config_test.cpp
+            connection_test.cpp
+            csv_output_test.cpp
+            prepare_test.cpp
+            result_value_test.cpp
+            storage_driver_test.cpp
+            udf_test.cpp)
+else()
+    add_kuzu_api_test(main_test
+            access_mode_test.cpp
+            arrow_test.cpp
+            config_test.cpp
+            connection_test.cpp
+            csv_output_test.cpp
+            db_locking_test.cpp
+            prepare_test.cpp
+            result_value_test.cpp
+            storage_driver_test.cpp
+            udf_test.cpp)
+endif()
 
 # Also tested for coverage in connection_test.cpp
 # but full testing requires some private APIs

--- a/test/main/access_mode_test.cpp
+++ b/test/main/access_mode_test.cpp
@@ -1,0 +1,25 @@
+#include "main_test_helper/main_test_helper.h"
+
+using namespace kuzu::common;
+using namespace kuzu::testing;
+using namespace kuzu::main;
+
+class AccessModeTest : public ApiTest {};
+
+TEST_F(AccessModeTest, testReadWrite) {
+    systemConfig->accessMode = AccessMode::READ_WRITE;
+    auto db = std::make_unique<Database>(databasePath, *systemConfig);
+    auto con = std::make_unique<Connection>(db.get());
+    ASSERT_TRUE(con->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name))")
+                    ->isSuccess());
+    ASSERT_TRUE(con->query("CREATE (:Person {name: 'Alice', age: 25})")->isSuccess());
+    ASSERT_TRUE(con->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+    db.reset();
+    systemConfig->accessMode = AccessMode::READ_ONLY;
+    std::unique_ptr<Database> db2;
+    std::unique_ptr<Connection> con2;
+    EXPECT_NO_THROW(db2 = std::make_unique<Database>(databasePath, *systemConfig));
+    EXPECT_NO_THROW(con2 = std::make_unique<Connection>(db2.get()));
+    EXPECT_ANY_THROW(con2->query("DROP TABLE Person"));
+    EXPECT_NO_THROW(con2->query("MATCH (:Person) RETURN COUNT(*)"));
+}

--- a/test/main/db_locking_test.cpp
+++ b/test/main/db_locking_test.cpp
@@ -1,0 +1,130 @@
+#include <signal.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "main_test_helper/main_test_helper.h"
+
+using namespace kuzu::testing;
+using namespace kuzu::common;
+using namespace kuzu::main;
+
+class DBLockingTest : public ApiTest {
+    void SetUp() override { BaseGraphTest::SetUp(); }
+};
+
+TEST_F(DBLockingTest, testReadLock) {
+    uint64_t* count = (uint64_t*)mmap(
+        NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+    *count = 0;
+    // create db
+    EXPECT_NO_THROW(createDBAndConn());
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+    database.reset();
+    // test read write db
+    pid_t pid = fork();
+    if (pid == 0) {
+        systemConfig->accessMode = AccessMode::READ_ONLY;
+        EXPECT_NO_THROW(createDBAndConn());
+        (*count)++;
+        ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+        while (true) {
+            usleep(100);
+            ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+        }
+    } else if (pid > 0) {
+        while (*count == 0) {
+            usleep(100);
+        }
+        systemConfig->accessMode = AccessMode::READ_WRITE;
+        // try to open db for writing, this should fail
+        EXPECT_ANY_THROW(createDBAndConn());
+        // but opening db for reading should work
+        systemConfig->accessMode = AccessMode::READ_ONLY;
+        EXPECT_NO_THROW(createDBAndConn());
+        ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+        // kill the child
+        if (kill(pid, SIGKILL) != 0) {
+            FAIL();
+        }
+    }
+}
+
+TEST_F(DBLockingTest, testWriteLock) {
+    uint64_t* count = (uint64_t*)mmap(
+        NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+    *count = 0;
+    // test write lock
+    // fork away a child
+    pid_t pid = fork();
+    if (pid == 0) {
+        // child process
+        // open db for writing
+        systemConfig->accessMode = AccessMode::READ_WRITE;
+        EXPECT_NO_THROW(createDBAndConn());
+        // opened db for writing
+        // insert some values
+        (*count)++;
+        ASSERT_TRUE(
+            conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+                ->isSuccess());
+        ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+        while (true) {
+            ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+            usleep(100);
+        }
+    } else if (pid > 0) {
+        // parent process
+        // sleep a bit to wait for child process
+        while (*count == 0) {
+            usleep(100);
+        }
+        // try to open db for writing, this should fail
+        systemConfig->accessMode = AccessMode::READ_WRITE;
+        EXPECT_ANY_THROW(createDBAndConn());
+        // try to open db for reading, this should fail
+        systemConfig->accessMode = AccessMode::READ_ONLY;
+        EXPECT_ANY_THROW(createDBAndConn());
+        // kill the child
+        if (kill(pid, SIGKILL) != 0) {
+            FAIL();
+        }
+    }
+}
+
+TEST_F(DBLockingTest, testReadOnly) {
+    uint64_t* count = (uint64_t*)mmap(
+        NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+    *count = 0;
+    // cannot create a read-only database in a new directory
+    systemConfig->accessMode = AccessMode::READ_ONLY;
+    EXPECT_ANY_THROW(createDBAndConn());
+
+    // create the database file and initialize it with data
+    pid_t create_pid = fork();
+    if (create_pid == 0) {
+        systemConfig->accessMode = AccessMode::READ_WRITE;
+        EXPECT_NO_THROW(createDBAndConn());
+        ASSERT_TRUE(
+            conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+                ->isSuccess());
+        ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+        exit(0);
+    }
+    waitpid(create_pid, NULL, 0);
+
+    // now connect in read-only mode
+    systemConfig->accessMode = AccessMode::READ_ONLY;
+    EXPECT_NO_THROW(createDBAndConn());
+    // we can query the database
+    ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+    // however, we can't perform DDL statements
+    EXPECT_ANY_THROW(conn->query("CREATE NODE TABLE university(ID INT64, PRIMARY KEY(ID))"));
+    EXPECT_ANY_THROW(conn->query("ALTER TABLE Peron DROP name"));
+    EXPECT_ANY_THROW(conn->query("DROP TABLE Peron"));
+    // neither can we insert/update/delete data
+    EXPECT_ANY_THROW(conn->query("CREATE (:Person {name: 'Bob', age: 25});"));
+    EXPECT_ANY_THROW(conn->query("MATCH (p:Person) WHERE p.name='Alice' SET p.age=26;"));
+    EXPECT_ANY_THROW(conn->query("MATCH (p:Person) WHERE name='Alice' DELETE p;"));
+}

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -15,6 +15,8 @@ int main(int argc, char* argv[]) {
         -1u);
     args::Flag disableCompression(
         parser, "nocompression", "Disable compression", {"nocompression"});
+    args::Flag readOnlyMode(
+        parser, "readOnly", "Open database at read-only mode.", {'r', "readOnly"});
     try {
         parser.ParseCLI(argc, argv);
     } catch (std::exception& e) {
@@ -32,7 +34,14 @@ int main(int argc, char* argv[]) {
     if (disableCompression) {
         systemConfig.enableCompression = false;
     }
+    if (readOnlyMode) {
+        systemConfig.accessMode = AccessMode::READ_ONLY;
+    }
     std::cout << "Opened the database at path: " << databasePath << std::endl;
+    std::cout << "Opened the database at path: " << databasePath << " under "
+              << (systemConfig.accessMode == AccessMode::READ_ONLY ? "READ_ONLY mode" :
+                                                                     "READ_WRITE mode")
+              << "." << std::endl;
     std::cout << "Enter \":help\" for usage hints." << std::endl;
     try {
         auto shell = EmbeddedShell(databasePath, systemConfig);


### PR DESCRIPTION
This PR is aimed at solving [issue #921](https://github.com/kuzudb/kuzu/issues/921) on non-Windows platforms.

Steps:
- Add a file `.lock` in each database directory.  Use this file to check the status of the database.
- When a database is started with an access mode referring to as` READ_ONLY` or `READ_WRITE` (note I use `READ_WRITE`  when the access mode is not specified), lock the `.lock` using the function` fcntl`.

Limitation
- ` fcntl` can only solve the read-write lock during different processes.  So we cannot solve the read-write lock in the same process.