### PR TITLE
Fix bounds check in integer bitpacking

### DIFF
--- a/src/storage/store/compression.cpp
+++ b/src/storage/store/compression.cpp
@@ -294,7 +294,7 @@ void IntegerBitpacking<T>::decompressFromPage(const uint8_t* srcBuffer, uint64_t
     }
 
     // Use fastunpack to directly unpack the full-sized chunks
-    for (; dstIndex < dstOffset + numValues - numValues % CHUNK_SIZE; dstIndex += CHUNK_SIZE) {
+    for (; dstIndex + CHUNK_SIZE <= dstOffset + numValues; dstIndex += CHUNK_SIZE) {
         FastPForLib::fastunpack(
             (const uint32_t*)srcCursor, (U*)dstBuffer + dstIndex, header.bitWidth);
         if (header.hasNegative) {


### PR DESCRIPTION
Fixes #2087

The incorrect logic in this comparison was causing an overflow in the output buffer when decompressing (though the values up to the overflow would still be correct).

Most of the tests use far fewer values than the default capacity (node group size), so this isn't well covered by our test suite. I'm not positive why the ASAN CI is passing, except that it may be related to differences between gcc (used by CI) and clang (used in #2087).