### PR TITLE
Optional Compression

### DIFF
--- a/examples/c/main.c
+++ b/examples/c/main.c
@@ -3,7 +3,7 @@
 #include "c_api/kuzu.h"
 
 int main() {
-    kuzu_database* db = kuzu_database_init("" /* fill db path */, 0);
+    kuzu_database* db = kuzu_database_init("" /* fill db path */, kuzu_default_system_config());
     kuzu_connection* conn = kuzu_connection_init(db);
 
     kuzu_query_result* result;
@@ -18,8 +18,7 @@ int main() {
     kuzu_query_result_destroy(result);
 
     // Execute a simple query.
-    result = kuzu_connection_query(
-        conn, "MATCH (a:Person) RETURN a.name AS NAME, a.age AS AGE;");
+    result = kuzu_connection_query(conn, "MATCH (a:Person) RETURN a.name AS NAME, a.age AS AGE;");
 
     // Fetch each value.
     while (kuzu_query_result_has_next(result)) {

--- a/examples/rust/src/main.rs
+++ b/examples/rust/src/main.rs
@@ -1,11 +1,11 @@
-use kuzu::{Connection, Database, Error};
+use kuzu::{Connection, Database, Error, SystemConfig};
 
 fn main() -> Result<(), Error> {
     let db = Database::new(
         std::env::args()
             .nth(1)
             .expect("The first CLI argument should be the database path"),
-        0,
+        SystemConfig::default(),
     )?;
     let connection = Connection::new(&db)?;
 

--- a/src/c_api/database.cpp
+++ b/src/c_api/database.cpp
@@ -5,13 +5,13 @@
 using namespace kuzu::main;
 using namespace kuzu::common;
 
-kuzu_database* kuzu_database_init(const char* database_path, uint64_t buffer_pool_size) {
+kuzu_database* kuzu_database_init(const char* database_path, kuzu_system_config config) {
     auto database = (kuzu_database*)malloc(sizeof(kuzu_database));
     std::string database_path_str = database_path;
     try {
-        database->_database = buffer_pool_size == 0 ?
-                                  new Database(database_path_str) :
-                                  new Database(database_path_str, SystemConfig(buffer_pool_size));
+        database->_database =
+            new Database(database_path_str, SystemConfig(config.buffer_pool_size,
+                                                config.max_num_threads, config.enable_compression));
     } catch (Exception& e) {
         free(database);
         return nullptr;
@@ -31,4 +31,8 @@ void kuzu_database_destroy(kuzu_database* database) {
 
 void kuzu_database_set_logging_level(const char* logging_level) {
     Database::setLoggingLevel(logging_level);
+}
+
+kuzu_system_config kuzu_default_system_config() {
+    return {0 /*bufferPoolSize*/, 0 /*maxNumThreads*/, true /*enableCompression*/};
 }

--- a/src/include/c_api/kuzu.h
+++ b/src/include/c_api/kuzu.h
@@ -105,6 +105,20 @@ struct ArrowArray {
 #endif
 
 /**
+ * @brief Stores runtime configuration for creating or opening a Database
+ */
+KUZU_C_API typedef struct {
+    // bufferPoolSize Max size of the buffer pool in bytes.
+    // The larger the buffer pool, the more data from the database files is kept in memory,
+    // reducing the amount of File I/O
+    uint64_t buffer_pool_size;
+    // The maximum number of threads to use during query execution
+    uint64_t max_num_threads;
+    // Whether or not to compress data on-disk for supported types
+    bool enable_compression;
+} kuzu_system_config;
+
+/**
  * @brief kuzu_database manages all database components.
  */
 KUZU_C_API typedef struct { void* _database; } kuzu_database;
@@ -235,7 +249,8 @@ KUZU_C_API typedef enum {
  * @param buffer_pool_size The size of the buffer pool in bytes.
  * @return The database instance.
  */
-KUZU_C_API kuzu_database* kuzu_database_init(const char* database_path, uint64_t buffer_pool_size);
+KUZU_C_API kuzu_database* kuzu_database_init(
+    const char* database_path, kuzu_system_config system_config);
 /**
  * @brief Destroys the kuzu database instance and frees the allocated memory.
  * @param database The database instance to destroy.
@@ -247,6 +262,8 @@ KUZU_C_API void kuzu_database_destroy(kuzu_database* database);
  * "err".
  */
 KUZU_C_API void kuzu_database_set_logging_level(const char* logging_level);
+
+KUZU_C_API kuzu_system_config kuzu_default_system_config();
 
 // Connection
 /**

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -11,21 +11,23 @@ namespace kuzu {
 namespace main {
 
 /**
- * @brief Stores buffer pool size and max number of threads configurations.
+ * @brief Stores runtime configuration for creating or opening a Database
  */
 struct KUZU_API SystemConfig {
     /**
-     * @brief Creates a SystemConfig object with default buffer pool size and max num of threads.
-     */
-    explicit SystemConfig();
-    /**
      * @brief Creates a SystemConfig object.
      * @param bufferPoolSize Max size of the buffer pool in bytes.
+     *        The larger the buffer pool, the more data from the database files is kept in memory,
+     *        reducing the amount of File I/O
+     *  @param maxNumThreads The maximum number of threads to use during query execution
+     *  @param enableCompression Whether or not to compress data on-disk for supported types
      */
-    explicit SystemConfig(uint64_t bufferPoolSize);
+    explicit SystemConfig(
+        uint64_t bufferPoolSize = -1u, uint64_t maxNumThreads = 0, bool enableCompression = true);
 
     uint64_t bufferPoolSize;
     uint64_t maxNumThreads;
+    bool enableCompression;
 };
 
 /**

--- a/src/include/processor/operator/persistent/copy_node.h
+++ b/src/include/processor/operator/persistent/copy_node.h
@@ -78,8 +78,8 @@ public:
         for (auto& arrowColumnPos : copyNodeInfo.dataColumnPoses) {
             dataColumnVectors.push_back(resultSet->getValueVector(arrowColumnPos).get());
         }
-        localNodeGroup = std::make_unique<storage::NodeGroup>(
-            sharedState->tableSchema, sharedState->csvReaderConfig.get());
+        localNodeGroup = std::make_unique<storage::NodeGroup>(sharedState->tableSchema,
+            sharedState->csvReaderConfig.get(), sharedState->table->compressionEnabled());
     }
 
     inline bool canParallel() const final { return !copyNodeInfo.containsSerial; }

--- a/src/include/storage/local_storage.h
+++ b/src/include/storage/local_storage.h
@@ -33,6 +33,7 @@ private:
     std::map<common::table_id_t, std::unique_ptr<LocalTable>> tables;
     storage::NodesStore* nodesStore;
     storage::MemoryManager* mm;
+    bool enableCompression;
 };
 
 } // namespace storage

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -11,7 +11,8 @@ namespace storage {
 
 class StorageManager {
 public:
-    StorageManager(catalog::Catalog& catalog, MemoryManager& memoryManager, WAL* wal);
+    StorageManager(
+        catalog::Catalog& catalog, MemoryManager& memoryManager, WAL* wal, bool enableCompression);
 
     ~StorageManager() = default;
 
@@ -39,6 +40,8 @@ public:
     inline BMFileHandle* getDataFH() const { return dataFH.get(); }
     inline BMFileHandle* getMetadataFH() const { return metadataFH.get(); }
 
+    inline bool compressionEnabled() const { return enableCompression; }
+
 private:
     std::unique_ptr<BMFileHandle> dataFH;
     std::unique_ptr<BMFileHandle> metadataFH;
@@ -47,6 +50,7 @@ private:
     WAL* wal;
     std::unique_ptr<RelsStore> relsStore;
     std::unique_ptr<NodesStore> nodesStore;
+    bool enableCompression;
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_column.h
+++ b/src/include/storage/store/node_column.h
@@ -38,7 +38,7 @@ public:
     NodeColumn(common::LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
         BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
         transaction::Transaction* transaction, RWPropertyStats PropertyStatistics,
-        bool requireNullColumn = true);
+        bool enableCompression, bool requireNullColumn = true);
     virtual ~NodeColumn() = default;
 
     // Expose for feature store
@@ -130,6 +130,7 @@ protected:
     read_values_to_page_func_t readToPageFunc;
     batch_lookup_func_t batchLookupFunc;
     RWPropertyStats propertyStatistics;
+    bool enableCompression;
 };
 
 class BoolNodeColumn : public NodeColumn {
@@ -137,7 +138,7 @@ public:
     BoolNodeColumn(const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH,
         BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
         transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
-        bool requireNullColumn = true);
+        bool enableCompression, bool requireNullColumn = true);
 };
 
 class NullNodeColumn : public NodeColumn {
@@ -146,7 +147,8 @@ class NullNodeColumn : public NodeColumn {
 public:
     NullNodeColumn(common::page_idx_t metaDAHPageIdx, BMFileHandle* dataFH,
         BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics);
+        transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
+        bool enableCompression);
 
     void scan(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         common::ValueVector* resultVector) final;
@@ -182,7 +184,7 @@ struct NodeColumnFactory {
     static std::unique_ptr<NodeColumn> createNodeColumn(const common::LogicalType& dataType,
         const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH, BMFileHandle* metadataFH,
         BufferManager* bufferManager, WAL* wal, transaction::Transaction* transaction,
-        RWPropertyStats propertyStatistics);
+        RWPropertyStats propertyStatistics, bool enableCompression);
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -13,7 +13,8 @@ class TableData;
 
 class NodeGroup {
 public:
-    explicit NodeGroup(catalog::TableSchema* schema, common::CSVReaderConfig* csvReaderConfig);
+    explicit NodeGroup(catalog::TableSchema* schema, common::CSVReaderConfig* csvReaderConfig,
+        bool enableCompression);
     explicit NodeGroup(TableData* table);
 
     inline void setNodeGroupIdx(uint64_t nodeGroupIdx_) { this->nodeGroupIdx = nodeGroupIdx_; }

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -17,7 +17,7 @@ class NodeTable {
 public:
     NodeTable(BMFileHandle* dataFH, BMFileHandle* metadataFH,
         NodesStoreStatsAndDeletedIDs* nodesStatisticsAndDeletedIDs, BufferManager& bufferManager,
-        WAL* wal, catalog::NodeTableSchema* nodeTableSchema);
+        WAL* wal, catalog::NodeTableSchema* nodeTableSchema, bool enableCompression);
 
     void initializePKIndex(catalog::NodeTableSchema* nodeTableSchema);
 
@@ -71,6 +71,8 @@ public:
     void prepareRollback();
     void checkpointInMemory();
     void rollbackInMemory();
+
+    inline bool compressionEnabled() const { return tableData->compressionEnabled(); }
 
 private:
     void insertPK(common::ValueVector* nodeIDVector, common::ValueVector* primaryKeyVector);

--- a/src/include/storage/store/nodes_store.h
+++ b/src/include/storage/store/nodes_store.h
@@ -12,7 +12,7 @@ namespace storage {
 class NodesStore {
 public:
     NodesStore(BMFileHandle* dataFH, BMFileHandle* metadataFH, const catalog::Catalog& catalog,
-        BufferManager& bufferManager, WAL* wal);
+        BufferManager& bufferManager, WAL* wal, bool enableCompression);
 
     inline PrimaryKeyIndex* getPKIndex(common::table_id_t tableID) {
         return nodeTables[tableID]->getPKIndex();
@@ -31,7 +31,8 @@ public:
         nodeTables[tableID] = std::make_unique<NodeTable>(dataFH, metadataFH,
             nodesStatisticsAndDeletedIDs.get(), *bufferManager, wal,
             reinterpret_cast<catalog::NodeTableSchema*>(
-                catalog->getReadOnlyVersion()->getTableSchema(tableID)));
+                catalog->getReadOnlyVersion()->getTableSchema(tableID)),
+            enableCompression);
     }
     inline void removeNodeTable(common::table_id_t tableID) {
         nodeTables.erase(tableID);
@@ -72,6 +73,7 @@ private:
     WAL* wal;
     BMFileHandle* dataFH;
     BMFileHandle* metadataFH;
+    bool enableCompression;
 };
 
 } // namespace storage

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -7,8 +7,8 @@ namespace storage {
 
 class StructColumnChunk : public ColumnChunk {
 public:
-    StructColumnChunk(
-        common::LogicalType dataType, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig);
+    StructColumnChunk(common::LogicalType dataType,
+        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression);
 
 protected:
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,

--- a/src/include/storage/store/struct_node_column.h
+++ b/src/include/storage/store/struct_node_column.h
@@ -10,7 +10,8 @@ class StructNodeColumn : public NodeColumn {
 public:
     StructNodeColumn(common::LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
         BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics);
+        transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
+        bool enableCompression);
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,

--- a/src/include/storage/store/table_data.h
+++ b/src/include/storage/store/table_data.h
@@ -12,7 +12,7 @@ class TableData {
 public:
     TableData(BMFileHandle* dataFH, BMFileHandle* metadataFH, common::table_id_t tableID,
         BufferManager* bufferManager, WAL* wal, const std::vector<catalog::Property*>& properties,
-        TablesStatistics* tablesStatistics);
+        TablesStatistics* tablesStatistics, bool enableCompression);
 
     void read(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         const std::vector<common::column_id_t>& columnIDs,
@@ -46,6 +46,8 @@ public:
     void checkpointInMemory();
     void rollbackInMemory();
 
+    inline bool compressionEnabled() const { return enableCompression; }
+
 private:
     void scan(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         const std::vector<common::column_id_t>& columnIDs,
@@ -61,6 +63,7 @@ private:
     common::table_id_t tableID;
     BufferManager* bufferManager;
     WAL* wal;
+    bool enableCompression;
 };
 
 } // namespace storage

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -31,8 +31,8 @@ struct VarListDataColumnChunk {
 
 class VarListColumnChunk : public ColumnChunk {
 public:
-    VarListColumnChunk(
-        common::LogicalType dataType, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig);
+    VarListColumnChunk(common::LogicalType dataType,
+        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression);
 
     inline ColumnChunk* getDataColumnChunk() const {
         return varListDataColumnChunk.dataColumnChunk.get();

--- a/src/include/storage/store/var_list_node_column.h
+++ b/src/include/storage/store/var_list_node_column.h
@@ -46,12 +46,14 @@ class VarListNodeColumn : public NodeColumn {
 public:
     VarListNodeColumn(common::LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
         BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics)
+        transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
+        bool enableCompression)
         : NodeColumn{std::move(dataType), metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal,
-              transaction, propertyStatistics, true /* requireNullColumn */} {
-        dataNodeColumn = NodeColumnFactory::createNodeColumn(
-            *common::VarListType::getChildType(&this->dataType), *metaDAHeaderInfo.childrenInfos[0],
-            dataFH, metadataFH, bufferManager, wal, transaction, propertyStatistics);
+              transaction, propertyStatistics, enableCompression, true /* requireNullColumn */} {
+        dataNodeColumn =
+            NodeColumnFactory::createNodeColumn(*common::VarListType::getChildType(&this->dataType),
+                *metaDAHeaderInfo.childrenInfos[0], dataFH, metadataFH, bufferManager, wal,
+                transaction, propertyStatistics, enableCompression);
     }
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -10,7 +10,8 @@ namespace kuzu {
 namespace storage {
 
 LocalStorage::LocalStorage(StorageManager* storageManager, MemoryManager* mm)
-    : nodesStore{&storageManager->getNodesStore()}, mm{mm} {}
+    : nodesStore{&storageManager->getNodesStore()}, mm{mm},
+      enableCompression{storageManager->compressionEnabled()} {}
 
 void LocalStorage::scan(table_id_t tableID, ValueVector* nodeIDVector,
     const std::vector<column_id_t>& columnIDs, const std::vector<ValueVector*>& outputVectors) {
@@ -31,7 +32,8 @@ void LocalStorage::lookup(table_id_t tableID, ValueVector* nodeIDVector,
 void LocalStorage::update(table_id_t tableID, column_id_t columnID, ValueVector* nodeIDVector,
     ValueVector* propertyVector) {
     if (!tables.contains(tableID)) {
-        tables.emplace(tableID, std::make_unique<LocalTable>(nodesStore->getNodeTable(tableID)));
+        tables.emplace(tableID,
+            std::make_unique<LocalTable>(nodesStore->getNodeTable(tableID), enableCompression));
     }
     tables.at(tableID)->update(columnID, nodeIDVector, propertyVector, mm);
 }
@@ -39,7 +41,8 @@ void LocalStorage::update(table_id_t tableID, column_id_t columnID, ValueVector*
 void LocalStorage::update(table_id_t tableID, column_id_t columnID, offset_t nodeOffset,
     ValueVector* propertyVector, sel_t posInPropertyVector) {
     if (!tables.contains(tableID)) {
-        tables.emplace(tableID, std::make_unique<LocalTable>(nodesStore->getNodeTable(tableID)));
+        tables.emplace(tableID,
+            std::make_unique<LocalTable>(nodesStore->getNodeTable(tableID), enableCompression));
     }
     tables.at(tableID)->update(columnID, nodeOffset, propertyVector, posInPropertyVector, mm);
 }

--- a/src/storage/store/node_column.cpp
+++ b/src/storage/store/node_column.cpp
@@ -141,10 +141,10 @@ static batch_lookup_func_t getBatchLookupFromPageFunc(const LogicalType& logical
 NodeColumn::NodeColumn(LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
     BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
     transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
-    bool requireNullColumn)
+    bool enableCompression, bool requireNullColumn)
     : storageStructureID{StorageStructureID::newDataID()}, dataType{dataType}, dataFH{dataFH},
       metadataFH{metadataFH}, bufferManager{bufferManager},
-      propertyStatistics{propertyStatistics}, wal{wal} {
+      propertyStatistics{propertyStatistics}, wal{wal}, enableCompression{enableCompression} {
     metadataDA = std::make_unique<InMemDiskArray<ColumnChunkMetadata>>(*metadataFH,
         StorageStructureID::newMetadataID(), metaDAHeaderInfo.dataDAHPageIdx, bufferManager, wal,
         transaction);
@@ -156,7 +156,7 @@ NodeColumn::NodeColumn(LogicalType dataType, const MetadataDAHInfo& metaDAHeader
     assert(numBytesPerFixedSizedValue <= BufferPoolConstants::PAGE_4KB_SIZE);
     if (requireNullColumn) {
         nullColumn = std::make_unique<NullNodeColumn>(metaDAHeaderInfo.nullDAHPageIdx, dataFH,
-            metadataFH, bufferManager, wal, transaction, propertyStatistics);
+            metadataFH, bufferManager, wal, transaction, propertyStatistics, enableCompression);
     }
 }
 
@@ -432,7 +432,7 @@ void NodeColumn::rollbackInMemory() {
 void NodeColumn::populateWithDefaultVal(const Property& property, NodeColumn* nodeColumn,
     ValueVector* defaultValueVector, uint64_t numNodeGroups) {
     auto columnChunk = ColumnChunkFactory::createColumnChunk(
-        *property.getDataType(), nullptr /* copyDescription */);
+        *property.getDataType(), enableCompression, nullptr /* copyDescription */);
     columnChunk->populateWithDefaultVal(defaultValueVector);
     for (auto i = 0u; i < numNodeGroups; i++) {
         nodeColumn->append(columnChunk.get(), i);
@@ -456,15 +456,16 @@ static_assert(PageUtils::getNumElementsInAPage(1, false /*requireNullColumn*/) %
 
 BoolNodeColumn::BoolNodeColumn(const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH,
     BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal, Transaction* transaction,
-    RWPropertyStats propertyStatistics, bool requireNullColumn)
+    RWPropertyStats propertyStatistics, bool enableCompression, bool requireNullColumn)
     : NodeColumn{LogicalType(LogicalTypeID::BOOL), metaDAHeaderInfo, dataFH, metadataFH,
-          bufferManager, wal, transaction, propertyStatistics, requireNullColumn} {}
+          bufferManager, wal, transaction, propertyStatistics, enableCompression,
+          requireNullColumn} {}
 
 NullNodeColumn::NullNodeColumn(page_idx_t metaDAHPageIdx, BMFileHandle* dataFH,
     BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal, Transaction* transaction,
-    RWPropertyStats propertyStatistics)
+    RWPropertyStats propertyStatistics, bool enableCompression)
     : NodeColumn{LogicalType(LogicalTypeID::BOOL), MetadataDAHInfo{metaDAHPageIdx}, dataFH,
-          metadataFH, bufferManager, wal, transaction, propertyStatistics,
+          metadataFH, bufferManager, wal, transaction, propertyStatistics, enableCompression,
           false /*requireNullColumn*/} {
     readToVectorFunc = NullNodeColumnFunc::readValuesFromPageToVector;
     writeFromVectorFunc = NullNodeColumnFunc::writeValueToPage;
@@ -547,7 +548,8 @@ SerialNodeColumn::SerialNodeColumn(const MetadataDAHInfo& metaDAHeaderInfo, BMFi
     BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal, Transaction* transaction)
     : NodeColumn{LogicalType(LogicalTypeID::SERIAL), metaDAHeaderInfo, dataFH, metadataFH,
           // Serials can't be null, so they don't need PropertyStatistics
-          bufferManager, wal, transaction, RWPropertyStats::empty(), false} {}
+          bufferManager, wal, transaction, RWPropertyStats::empty(), false /* enableCompression */,
+          false /*requireNullColumn*/} {}
 
 void SerialNodeColumn::scan(
     Transaction* transaction, ValueVector* nodeIDVector, ValueVector* resultVector) {
@@ -576,11 +578,12 @@ void SerialNodeColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {
 
 std::unique_ptr<NodeColumn> NodeColumnFactory::createNodeColumn(const LogicalType& dataType,
     const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH, BMFileHandle* metadataFH,
-    BufferManager* bufferManager, WAL* wal, Transaction* transaction, RWPropertyStats stats) {
+    BufferManager* bufferManager, WAL* wal, Transaction* transaction, RWPropertyStats stats,
+    bool enableCompression) {
     switch (dataType.getLogicalTypeID()) {
     case LogicalTypeID::BOOL: {
-        return std::make_unique<BoolNodeColumn>(
-            metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal, transaction, stats);
+        return std::make_unique<BoolNodeColumn>(metaDAHeaderInfo, dataFH, metadataFH, bufferManager,
+            wal, transaction, stats, enableCompression);
     }
     case LogicalTypeID::INT64:
     case LogicalTypeID::INT32:
@@ -597,8 +600,8 @@ std::unique_ptr<NodeColumn> NodeColumnFactory::createNodeColumn(const LogicalTyp
     case LogicalTypeID::INTERVAL:
     case LogicalTypeID::INTERNAL_ID:
     case LogicalTypeID::FIXED_LIST: {
-        return std::make_unique<NodeColumn>(
-            dataType, metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal, transaction, stats);
+        return std::make_unique<NodeColumn>(dataType, metaDAHeaderInfo, dataFH, metadataFH,
+            bufferManager, wal, transaction, stats, enableCompression);
     }
     case LogicalTypeID::BLOB:
     case LogicalTypeID::STRING: {
@@ -607,13 +610,13 @@ std::unique_ptr<NodeColumn> NodeColumnFactory::createNodeColumn(const LogicalTyp
     }
     case LogicalTypeID::MAP:
     case LogicalTypeID::VAR_LIST: {
-        return std::make_unique<VarListNodeColumn>(
-            dataType, metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal, transaction, stats);
+        return std::make_unique<VarListNodeColumn>(dataType, metaDAHeaderInfo, dataFH, metadataFH,
+            bufferManager, wal, transaction, stats, enableCompression);
     }
     case LogicalTypeID::UNION:
     case LogicalTypeID::STRUCT: {
-        return std::make_unique<StructNodeColumn>(
-            dataType, metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal, transaction, stats);
+        return std::make_unique<StructNodeColumn>(dataType, metaDAHeaderInfo, dataFH, metadataFH,
+            bufferManager, wal, transaction, stats, enableCompression);
     }
     case LogicalTypeID::SERIAL: {
         return std::make_unique<SerialNodeColumn>(

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -11,20 +11,20 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-NodeGroup::NodeGroup(TableSchema* schema, CSVReaderConfig* csvReaderConfig)
+NodeGroup::NodeGroup(TableSchema* schema, CSVReaderConfig* csvReaderConfig, bool enableCompression)
     : nodeGroupIdx{UINT64_MAX}, numNodes{0} {
     chunks.reserve(schema->properties.size());
     for (auto& property : schema->properties) {
-        chunks.push_back(
-            ColumnChunkFactory::createColumnChunk(*property->getDataType(), csvReaderConfig));
+        chunks.push_back(ColumnChunkFactory::createColumnChunk(
+            *property->getDataType(), enableCompression, csvReaderConfig));
     }
 }
 
 NodeGroup::NodeGroup(TableData* table) : nodeGroupIdx{UINT64_MAX}, numNodes{0} {
     chunks.reserve(table->getNumColumns());
     for (auto columnID = 0u; columnID < table->getNumColumns(); columnID++) {
-        chunks.push_back(
-            ColumnChunkFactory::createColumnChunk(table->getColumn(columnID)->getDataType()));
+        chunks.push_back(ColumnChunkFactory::createColumnChunk(
+            table->getColumn(columnID)->getDataType(), table->compressionEnabled()));
     }
 }
 

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -14,12 +14,12 @@ namespace storage {
 
 NodeTable::NodeTable(BMFileHandle* dataFH, BMFileHandle* metadataFH,
     NodesStoreStatsAndDeletedIDs* nodesStatisticsAndDeletedIDs, BufferManager& bufferManager,
-    WAL* wal, NodeTableSchema* nodeTableSchema)
+    WAL* wal, NodeTableSchema* nodeTableSchema, bool enableCompression)
     : nodesStatisticsAndDeletedIDs{nodesStatisticsAndDeletedIDs},
       pkColumnID{nodeTableSchema->getColumnID(nodeTableSchema->getPrimaryKeyPropertyID())},
       tableID{nodeTableSchema->tableID}, bufferManager{bufferManager}, wal{wal} {
     tableData = std::make_unique<TableData>(dataFH, metadataFH, tableID, &bufferManager, wal,
-        nodeTableSchema->getProperties(), nodesStatisticsAndDeletedIDs);
+        nodeTableSchema->getProperties(), nodesStatisticsAndDeletedIDs, enableCompression);
     initializePKIndex(nodeTableSchema);
 }
 

--- a/src/storage/store/nodes_store.cpp
+++ b/src/storage/store/nodes_store.cpp
@@ -6,14 +6,15 @@ namespace kuzu {
 namespace storage {
 
 NodesStore::NodesStore(BMFileHandle* dataFH, BMFileHandle* metadataFH, const Catalog& catalog,
-    BufferManager& bufferManager, WAL* wal)
-    : wal{wal}, dataFH{dataFH}, metadataFH{metadataFH} {
+    BufferManager& bufferManager, WAL* wal, bool enableCompression)
+    : wal{wal}, dataFH{dataFH}, metadataFH{metadataFH}, enableCompression{enableCompression} {
     nodesStatisticsAndDeletedIDs =
         std::make_unique<NodesStoreStatsAndDeletedIDs>(metadataFH, &bufferManager, wal);
     for (auto& schema : catalog.getReadOnlyVersion()->getNodeTableSchemas()) {
         auto nodeTableSchema = reinterpret_cast<NodeTableSchema*>(schema);
-        nodeTables[schema->tableID] = std::make_unique<NodeTable>(dataFH, metadataFH,
-            nodesStatisticsAndDeletedIDs.get(), bufferManager, wal, nodeTableSchema);
+        nodeTables[schema->tableID] =
+            std::make_unique<NodeTable>(dataFH, metadataFH, nodesStatisticsAndDeletedIDs.get(),
+                bufferManager, wal, nodeTableSchema, enableCompression);
     }
 }
 

--- a/src/storage/store/string_node_column.cpp
+++ b/src/storage/store/string_node_column.cpp
@@ -23,7 +23,7 @@ StringNodeColumn::StringNodeColumn(LogicalType dataType, const MetadataDAHInfo& 
     BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
     transaction::Transaction* transaction, RWPropertyStats stats)
     : NodeColumn{std::move(dataType), metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal,
-          transaction, stats, true} {
+          transaction, stats, false /* enableCompression */, true /* requireNullColumn */} {
     if (this->dataType.getLogicalTypeID() == LogicalTypeID::STRING) {
         writeFromVectorFunc = StringNodeColumnFunc::writeStringValuesToPage;
     }

--- a/src/storage/store/struct_column_chunk.cpp
+++ b/src/storage/store/struct_column_chunk.cpp
@@ -13,14 +13,14 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-StructColumnChunk::StructColumnChunk(
-    LogicalType dataType, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig)
+StructColumnChunk::StructColumnChunk(LogicalType dataType,
+    std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression)
     : ColumnChunk{std::move(dataType), std::move(csvReaderConfig)} {
     auto fieldTypes = StructType::getFieldTypes(&this->dataType);
     childrenChunks.resize(fieldTypes.size());
     for (auto i = 0u; i < fieldTypes.size(); i++) {
-        childrenChunks[i] =
-            ColumnChunkFactory::createColumnChunk(*fieldTypes[i], this->csvReaderConfig.get());
+        childrenChunks[i] = ColumnChunkFactory::createColumnChunk(
+            *fieldTypes[i], enableCompression, this->csvReaderConfig.get());
     }
 }
 

--- a/src/storage/store/struct_node_column.cpp
+++ b/src/storage/store/struct_node_column.cpp
@@ -11,16 +11,16 @@ namespace storage {
 
 StructNodeColumn::StructNodeColumn(LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
     BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-    Transaction* transaction, RWPropertyStats propertyStatistics)
+    Transaction* transaction, RWPropertyStats propertyStatistics, bool enableCompression)
     : NodeColumn{std::move(dataType), metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal,
-          transaction, propertyStatistics, true} {
+          transaction, propertyStatistics, enableCompression, true} {
     auto fieldTypes = StructType::getFieldTypes(&this->dataType);
     assert(metaDAHeaderInfo.childrenInfos.size() == fieldTypes.size());
     childrenColumns.resize(fieldTypes.size());
     for (auto i = 0u; i < fieldTypes.size(); i++) {
-        childrenColumns[i] =
-            NodeColumnFactory::createNodeColumn(*fieldTypes[i], *metaDAHeaderInfo.childrenInfos[i],
-                dataFH, metadataFH, bufferManager, wal, transaction, propertyStatistics);
+        childrenColumns[i] = NodeColumnFactory::createNodeColumn(*fieldTypes[i],
+            *metaDAHeaderInfo.childrenInfos[i], dataFH, metadataFH, bufferManager, wal, transaction,
+            propertyStatistics, enableCompression);
     }
 }
 

--- a/src/storage/store/table_data.cpp
+++ b/src/storage/store/table_data.cpp
@@ -10,9 +10,9 @@ namespace storage {
 
 TableData::TableData(BMFileHandle* dataFH, BMFileHandle* metadataFH, table_id_t tableID,
     BufferManager* bufferManager, WAL* wal, const std::vector<catalog::Property*>& properties,
-    TablesStatistics* tablesStatistics)
+    TablesStatistics* tablesStatistics, bool enableCompression)
     : dataFH{dataFH}, metadataFH{metadataFH}, tableID{tableID},
-      bufferManager{bufferManager}, wal{wal} {
+      bufferManager{bufferManager}, wal{wal}, enableCompression{enableCompression} {
     columns.reserve(properties.size());
     for (auto i = 0u; i < properties.size(); i++) {
         auto property = properties[i];
@@ -22,7 +22,8 @@ TableData::TableData(BMFileHandle* dataFH, BMFileHandle* metadataFH, table_id_t 
         columns.push_back(
             NodeColumnFactory::createNodeColumn(*property->getDataType(), *metadataDAHInfo, dataFH,
                 metadataFH, bufferManager, wal, Transaction::getDummyReadOnlyTrx().get(),
-                RWPropertyStats(tablesStatistics, tableID, property->getPropertyID())));
+                RWPropertyStats(tablesStatistics, tableID, property->getPropertyID()),
+                enableCompression));
     }
 }
 
@@ -116,7 +117,7 @@ void TableData::addColumn(transaction::Transaction* transaction, const catalog::
                                ->getMetadataDAHInfo(transaction, tableID, columns.size());
     auto nodeColumn = NodeColumnFactory::createNodeColumn(*property.getDataType(), *metadataDAHInfo,
         dataFH, metadataFH, bufferManager, wal, transaction,
-        RWPropertyStats(tablesStats, tableID, property.getPropertyID()));
+        RWPropertyStats(tablesStats, tableID, property.getPropertyID()), enableCompression);
     nodeColumn->populateWithDefaultVal(
         property, nodeColumn.get(), defaultValueVector, getNumNodeGroups(transaction));
     columns.push_back(std::move(nodeColumn));

--- a/src/storage/store/var_list_column_chunk.cpp
+++ b/src/storage/store/var_list_column_chunk.cpp
@@ -24,11 +24,13 @@ void VarListDataColumnChunk::resizeBuffer(uint64_t numValues) {
     dataColumnChunk->resize(capacity);
 }
 
-VarListColumnChunk::VarListColumnChunk(
-    LogicalType dataType, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig)
-    : ColumnChunk{std::move(dataType), std::move(csvReaderConfig), true /* hasNullChunk */},
-      varListDataColumnChunk{ColumnChunkFactory::createColumnChunk(
-          *VarListType::getChildType(&this->dataType), this->csvReaderConfig.get())} {
+VarListColumnChunk::VarListColumnChunk(LogicalType dataType,
+    std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression)
+    : ColumnChunk{std::move(dataType), std::move(csvReaderConfig), enableCompression,
+          true /* hasNullChunk */},
+      varListDataColumnChunk{
+          ColumnChunkFactory::createColumnChunk(*VarListType::getChildType(&this->dataType),
+              enableCompression, this->csvReaderConfig.get())} {
     assert(this->dataType.getPhysicalType() == PhysicalTypeID::VAR_LIST);
 }
 

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -7,7 +7,7 @@ public:
 
 TEST_F(CApiDatabaseTest, CreationAndDestroy) {
     auto databasePathCStr = databasePath.c_str();
-    auto database = kuzu_database_init(databasePathCStr, 0);
+    auto database = kuzu_database_init(databasePathCStr, kuzu_default_system_config());
     ASSERT_NE(database, nullptr);
     ASSERT_NE(database->_database, nullptr);
     auto databaseCpp = static_cast<Database*>(database->_database);
@@ -17,6 +17,6 @@ TEST_F(CApiDatabaseTest, CreationAndDestroy) {
 
 TEST_F(CApiDatabaseTest, CreationInvalidPath) {
     auto databasePathCStr = (char*)"";
-    auto database = kuzu_database_init(databasePathCStr, 0);
+    auto database = kuzu_database_init(databasePathCStr, kuzu_default_system_config());
     ASSERT_EQ(database, nullptr);
 }

--- a/test/include/c_api_test/c_api_test.h
+++ b/test/include/c_api_test/c_api_test.h
@@ -28,7 +28,7 @@ public:
         database.reset();
         auto databasePath = getDatabasePath();
         auto databasePathCStr = databasePath.c_str();
-        _database = kuzu_database_init(databasePathCStr, 0);
+        _database = kuzu_database_init(databasePathCStr, kuzu_default_system_config());
         connection = kuzu_connection_init(_database);
     }
 

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -153,12 +153,15 @@ void javaMapToCPPMap(
  */
 
 JNIEXPORT jlong JNICALL Java_com_kuzudb_KuzuNative_kuzu_1database_1init(
-    JNIEnv* env, jclass, jstring database_path, jlong buffer_pool_size) {
+    JNIEnv* env, jclass, jstring database_path, jlong buffer_pool_size, jboolean enable_compression) {
 
     const char* path = env->GetStringUTFChars(database_path, JNI_FALSE);
     uint64_t buffer = static_cast<uint64_t>(buffer_pool_size);
+    SystemConfig systemConfig;
+    systemConfig.bufferPoolSize = buffer == 0 ? -1u : buffer;
+    systemConfig.enableCompression = enable_compression;
     try {
-        Database* db = buffer == 0 ? new Database(path) : new Database(path, SystemConfig(buffer));
+        Database* db = new Database(path, systemConfig);
         uint64_t address = reinterpret_cast<uint64_t>(db);
 
         env->ReleaseStringUTFChars(database_path, path);

--- a/tools/java_api/src/main/java/com/kuzudb/KuzuDatabase.java
+++ b/tools/java_api/src/main/java/com/kuzudb/KuzuDatabase.java
@@ -8,6 +8,7 @@ public class KuzuDatabase {
     long db_ref;
     String db_path;
     long buffer_size;
+    boolean enableCompression = true;
     boolean destroyed = false;
 
     /**
@@ -17,7 +18,7 @@ public class KuzuDatabase {
     public KuzuDatabase(String databasePath) {
         this.db_path = databasePath;
         this.buffer_size = 0;
-        db_ref = KuzuNative.kuzu_database_init(databasePath, 0);
+        db_ref = KuzuNative.kuzu_database_init(databasePath, 0, true);
     }
 
     /**
@@ -28,7 +29,20 @@ public class KuzuDatabase {
     public KuzuDatabase(String databasePath, long bufferPoolSize) {
         this.db_path = databasePath;
         this.buffer_size = bufferPoolSize;
-        db_ref = KuzuNative.kuzu_database_init(databasePath, bufferPoolSize);
+        db_ref = KuzuNative.kuzu_database_init(databasePath, bufferPoolSize, true);
+    }
+
+    /**
+    * Creates a database object.
+    * @param databasePath: Database path. If the database does not already exist, it will be created.
+    * @param bufferPoolSize: Max size of the buffer pool in bytes.
+    * @param enableCompression: Enable compression in storage.
+    */
+    public KuzuDatabase(String databasePath, long bufferPoolSize, boolean enableCompression) {
+        this.db_path = databasePath;
+        this.buffer_size = bufferPoolSize;
+        this.enableCompression = enableCompression;
+        db_ref = KuzuNative.kuzu_database_init(databasePath, bufferPoolSize, enableCompression);
     }
 
     /**

--- a/tools/java_api/src/main/java/com/kuzudb/KuzuNative.java
+++ b/tools/java_api/src/main/java/com/kuzudb/KuzuNative.java
@@ -56,7 +56,7 @@ public class KuzuNative {
     }
 
     // Database
-    protected static native long kuzu_database_init(String database_path, long buffer_pool_size);
+    protected static native long kuzu_database_init(String database_path, long buffer_pool_size, boolean enable_compression);
 
     protected static native void kuzu_database_destroy(KuzuDatabase db);
 

--- a/tools/nodejs_api/src_cpp/include/node_database.h
+++ b/tools/nodejs_api/src_cpp/include/node_database.h
@@ -24,6 +24,7 @@ private:
 private:
     std::string databasePath;
     size_t bufferPoolSize;
+    bool enableCompression;
     std::shared_ptr<Database> database;
 };
 

--- a/tools/nodejs_api/src_cpp/node_database.cpp
+++ b/tools/nodejs_api/src_cpp/node_database.cpp
@@ -19,6 +19,7 @@ NodeDatabase::NodeDatabase(const Napi::CallbackInfo& info) : Napi::ObjectWrap<No
     Napi::HandleScope scope(env);
     databasePath = info[0].ToString();
     bufferPoolSize = info[1].As<Napi::Number>().Int64Value();
+    enableCompression = info[2].As<Napi::Boolean>().Value();
 }
 
 Napi::Value NodeDatabase::InitAsync(const Napi::CallbackInfo& info) {
@@ -33,13 +34,14 @@ Napi::Value NodeDatabase::InitAsync(const Napi::CallbackInfo& info) {
 }
 
 void NodeDatabase::InitCppDatabase() {
+    auto systemConfig = SystemConfig();
     if (bufferPoolSize) {
-        auto systemConfig = SystemConfig();
         systemConfig.bufferPoolSize = bufferPoolSize;
-        this->database = make_shared<Database>(databasePath, systemConfig);
-    } else {
-        this->database = make_shared<Database>(databasePath);
     }
+    if (!enableCompression) {
+        systemConfig.enableCompression = enableCompression;
+    }
+    this->database = make_shared<Database>(databasePath, systemConfig);
 }
 
 void NodeDatabase::setLoggingLevel(const Napi::CallbackInfo& info) {

--- a/tools/nodejs_api/src_js/database.js
+++ b/tools/nodejs_api/src_js/database.js
@@ -13,7 +13,7 @@ class Database {
    * @param {String} databasePath path to the database file.
    * @param {Number} bufferManagerSize size of the buffer manager in bytes.
    */
-  constructor(databasePath, bufferManagerSize = 0) {
+  constructor(databasePath, bufferManagerSize = 0, enableCompression = true) {
     if (typeof databasePath !== "string") {
       throw new Error("Database path must be a string.");
     }
@@ -21,7 +21,7 @@ class Database {
       throw new Error("Buffer manager size must be a positive integer.");
     }
     bufferManagerSize = Math.floor(bufferManagerSize);
-    this._database = new KuzuNative.NodeDatabase(databasePath, bufferManagerSize);
+    this._database = new KuzuNative.NodeDatabase(databasePath, bufferManagerSize, enableCompression);
     this._isInitialized = false;
     this._initPromise = null;
   }

--- a/tools/python_api/src_cpp/include/py_database.h
+++ b/tools/python_api/src_cpp/include/py_database.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include "main/kuzu.h"
-
-#include "pybind_include.h"
 #include "main/storage_driver.h"
+#include "pybind_include.h"
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 using namespace kuzu::main;
-
 
 class PyDatabase {
     friend class PyConnection;
@@ -18,7 +16,8 @@ public:
 
     static void initialize(py::handle& m);
 
-    explicit PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize);
+    explicit PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
+        uint64_t maxNumThreads, bool compression);
 
     ~PyDatabase() = default;
 

--- a/tools/python_api/src_py/database.py
+++ b/tools/python_api/src_py/database.py
@@ -15,27 +15,29 @@ class Database:
         Set the logging level.
 
     get_torch_geometric_remote_backend(num_threads)
-        Use the database as the remote backend for torch_geometric. 
+        Use the database as the remote backend for torch_geometric.
 
     """
 
-    def __init__(self, database_path, buffer_pool_size=0, lazy_init=False):
+    def __init__(self, database_path, buffer_pool_size=0, max_num_threads=0, compression=True, lazy_init=False):
         """
         Parameters
         ----------
         database_path : str
             The path to database files
         buffer_pool_size : int
-            The maximum size of buffer pool in bytes (Optional). Default to 80% 
+            The maximum size of buffer pool in bytes (Optional). Default to 80%
             of system memory.
         lazy_init : bool
             If True, the database will not be initialized until the first query.
-            This is useful when the database is not used in the main thread or 
+            This is useful when the database is not used in the main thread or
             when the main process is forked.
             Deefault to False.
         """
         self.database_path = database_path
         self.buffer_pool_size = buffer_pool_size
+        self.max_num_threads = max_num_threads
+        self.compression = compression
         self._database = None
         if not lazy_init:
             self.init_database()
@@ -54,7 +56,7 @@ class Database:
         """
         if self._database is None:
             self._database = _kuzu.Database(self.database_path,
-                                            self.buffer_pool_size)
+                                            self.buffer_pool_size, self.max_num_threads, self.compression)
 
     def resize_buffer_manager(self, new_size):
         """

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -60,8 +60,8 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
     const kuzu::common::LogicalType& value);
 
 /* Database */
-std::unique_ptr<kuzu::main::Database> new_database(
-    const std::string& databasePath, uint64_t bufferPoolSize);
+std::unique_ptr<kuzu::main::Database> new_database(const std::string& databasePath,
+    uint64_t bufferPoolSize, uint64_t maxNumThreads, bool enableCompression);
 
 void database_set_logging_level(kuzu::main::Database& database, const std::string& level);
 

--- a/tools/rust_api/src/connection.rs
+++ b/tools/rust_api/src/connection.rs
@@ -30,10 +30,10 @@ pub struct PreparedStatement {
 /// [error](Error::FailedQuery) if another write query is in progress.
 ///
 /// ```
-/// # use kuzu::{Connection, Database, Value, Error};
+/// # use kuzu::{Connection, Database, SystemConfig, Value, Error};
 /// # fn main() -> anyhow::Result<()> {
 /// # let temp_dir = tempfile::tempdir()?;
-/// # let db = Database::new(temp_dir.path(), 0)?;
+/// # let db = Database::new(temp_dir.path(), SystemConfig::default())?;
 /// let conn = Connection::new(&db)?;
 /// conn.query("CREATE NODE TABLE Person(name STRING, age INT32, PRIMARY KEY(name));")?;
 /// // Write queries must be done sequentially
@@ -79,12 +79,12 @@ pub struct PreparedStatement {
 /// transaction, then the active transaction is rolled back.
 ///
 /// ```
-/// use kuzu::{Database, Connection};
+/// use kuzu::{Database, SystemConfig, Connection};
 /// # use anyhow::Error;
 /// # fn main() -> Result<(), Error> {
 /// # let temp_dir = tempfile::tempdir()?;
 /// # let path = temp_dir.path();
-/// let db = Database::new(path, 0)?;
+/// let db = Database::new(path, SystemConfig::default())?;
 /// let conn = Connection::new(&db)?;
 /// // AUTO_COMMIT mode
 /// conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
@@ -102,12 +102,12 @@ pub struct PreparedStatement {
 /// ```
 ///
 /// ```
-/// use kuzu::{Database, Connection};
+/// use kuzu::{Database, SystemConfig, Connection};
 /// # use anyhow::Error;
 /// # fn main() -> Result<(), Error> {
 /// # let temp_dir = tempfile::tempdir()?;
 /// # let path = temp_dir.path();
-/// let db = Database::new(path, 0)?;
+/// let db = Database::new(path, SystemConfig::default())?;
 /// let conn = Connection::new(&db)?;
 /// // AUTO_COMMIT mode
 /// conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
@@ -292,7 +292,7 @@ impl<'a> Connection<'a> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{connection::Connection, database::Database, value::Value};
+    use crate::{Connection, Database, SystemConfig, Value};
     use anyhow::{Error, Result};
     // Note: Cargo runs tests in parallel by default, however kuzu does not support
     // working with multiple databases in parallel.
@@ -301,7 +301,7 @@ mod tests {
     #[test]
     fn test_connection_threads() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let mut conn = Connection::new(&db)?;
         conn.set_max_num_threads_for_exec(5);
         assert_eq!(conn.get_max_num_threads_for_exec(), 5);
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn test_invalid_query() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -335,7 +335,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_query_result() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT16, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -352,7 +352,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_params() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT16, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -370,7 +370,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_params_invalid_type() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT16, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -395,7 +395,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_multithreaded_single_conn() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
 
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT32, PRIMARY KEY(name));")?;
@@ -427,7 +427,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_multithreaded_multiple_conn() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
 
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT32, PRIMARY KEY(name));")?;
@@ -461,7 +461,7 @@ Invalid input <MATCH (a:Person RETURN>: expected rule oC_SingleQuery (line: 1, o
     #[test]
     fn test_table_names() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT16, PRIMARY KEY(name));")?;
         conn.query("CREATE REL TABLE Follows(FROM Person TO Person, since DATE);")?;

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -82,6 +82,8 @@ pub(crate) mod ffi {
         fn new_database(
             databasePath: &CxxString,
             bufferPoolSize: u64,
+            maxNumThreads: u64,
+            enableCompression: bool,
         ) -> Result<UniquePtr<Database>>;
 
         fn database_set_logging_level(database: Pin<&mut Database>, level: &CxxString);

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -72,11 +72,16 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
     return std::make_unique<std::vector<LogicalType>>(result);
 }
 
-std::unique_ptr<Database> new_database(const std::string& databasePath, uint64_t bufferPoolSize) {
+std::unique_ptr<Database> new_database(const std::string& databasePath, uint64_t bufferPoolSize,
+    uint64_t maxNumThreads, bool enableCompression) {
     auto systemConfig = SystemConfig();
     if (bufferPoolSize > 0) {
         systemConfig.bufferPoolSize = bufferPoolSize;
     }
+    if (maxNumThreads > 0) {
+        systemConfig.maxNumThreads = maxNumThreads;
+    }
+    systemConfig.enableCompression = enableCompression;
     return std::make_unique<Database>(databasePath, systemConfig);
 }
 

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -2,13 +2,13 @@
 //!
 //! ## Example Usage
 //! ```
-//! use kuzu::{Database, Connection};
+//! use kuzu::{Database, SystemConfig, Connection};
 //! # use anyhow::Error;
 //!
 //! # fn main() -> Result<(), Error> {
 //! # let temp_dir = tempfile::tempdir()?;
 //! # let path = temp_dir.path();
-//! let db = Database::new(path, 0)?;
+//! let db = Database::new(path, SystemConfig::default())?;
 //! let conn = Connection::new(&db)?;
 //! conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
 //! conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -47,7 +47,7 @@ mod query_result;
 mod value;
 
 pub use connection::{Connection, PreparedStatement};
-pub use database::{Database, LoggingLevel};
+pub use database::{Database, LoggingLevel, SystemConfig};
 pub use error::Error;
 pub use logical_type::LogicalType;
 pub use query_result::{CSVOptions, QueryResult};

--- a/tools/rust_api/src/query_result.rs
+++ b/tools/rust_api/src/query_result.rs
@@ -223,14 +223,14 @@ impl std::fmt::Display for QueryResult {
 #[cfg(test)]
 mod tests {
     use crate::connection::Connection;
-    use crate::database::Database;
+    use crate::database::{Database, SystemConfig};
     use crate::logical_type::LogicalType;
     use crate::query_result::CSVOptions;
 
     #[test]
     fn test_query_result_metadata() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let connection = Connection::new(&db)?;
 
         // Create schema.
@@ -257,7 +257,7 @@ mod tests {
     fn test_csv() -> anyhow::Result<()> {
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path();
-        let db = Database::new(path, 0)?;
+        let db = Database::new(path, SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;
@@ -283,7 +283,7 @@ mod tests {
         use arrow::array::{Int64Array, StringArray};
         let temp_dir = tempfile::tempdir()?;
         let path = temp_dir.path();
-        let db = Database::new(path, 0)?;
+        let db = Database::new(path, SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: 'Alice', age: 25});")?;

--- a/tools/rust_api/src/value.rs
+++ b/tools/rust_api/src/value.rs
@@ -695,10 +695,7 @@ impl From<&str> for Value {
 mod tests {
     use crate::ffi::ffi;
     use crate::{
-        connection::Connection,
-        database::Database,
-        logical_type::LogicalType,
-        value::{InternalID, NodeVal, RelVal, Value},
+        Connection, Database, InternalID, LogicalType, NodeVal, RelVal, SystemConfig, Value,
     };
     use anyhow::Result;
     use std::collections::HashSet;
@@ -764,7 +761,7 @@ mod tests {
             /// Tests that passing the values through the database returns what we put in
             fn $name() -> Result<()> {
                 let temp_dir = tempfile::tempdir()?;
-                let db = Database::new(temp_dir.path(), 0)?;
+                let db = Database::new(temp_dir.path(), SystemConfig::default())?;
                 let conn = Connection::new(&db)?;
                 conn.query(&format!(
                     "CREATE NODE TABLE Person(name STRING, item {}, PRIMARY KEY(name));",
@@ -905,7 +902,7 @@ mod tests {
     /// Tests that the list value is correctly constructed
     fn test_var_list_get() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         for result in conn.query("RETURN [\"Alice\", \"Bob\"] AS l;")? {
             assert_eq!(result.len(), 1);
@@ -922,7 +919,7 @@ mod tests {
     /// Test that the timestamp round-trips through kuzu's internal timestamp
     fn test_timestamp() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query(
             "CREATE NODE TABLE Person(name STRING, registerTime TIMESTAMP, PRIMARY KEY(name));",
@@ -969,7 +966,7 @@ mod tests {
     #[test]
     fn test_node() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE (:Person {name: \"Alice\", age: 25});")?;
@@ -995,7 +992,7 @@ mod tests {
     #[test]
     fn test_recursive_rel() -> Result<()> {
         let temp_dir = tempfile::TempDir::new()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")?;
         conn.query("CREATE REL TABLE knows(FROM Person TO Person);")?;
@@ -1043,7 +1040,7 @@ mod tests {
     /// Test that null values are read correctly by the API
     fn test_null() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         let result = conn.query("RETURN null")?.next();
         let result = &result.unwrap()[0];
@@ -1056,7 +1053,7 @@ mod tests {
     /// Tests that passing the values through the database returns what we put in
     fn test_serial() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
-        let db = Database::new(temp_dir.path(), 0)?;
+        let db = Database::new(temp_dir.path(), SystemConfig::default())?;
         let conn = Connection::new(&db)?;
         conn.query("CREATE NODE TABLE Person(id SERIAL, name STRING, PRIMARY KEY(id));")?;
         conn.query("CREATE (:Person {name: \"Bob\"});")?;

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -13,6 +13,8 @@ int main(int argc, char* argv[]) {
     args::ValueFlag<uint64_t> bpSizeInMBFlag(parser, "",
         "Size of buffer pool for default and large page sizes in megabytes", {'d', "defaultBPSize"},
         -1u);
+    args::Flag disableCompression(
+        parser, "nocompression", "Disable compression", {"nocompression"});
     try {
         parser.ParseCLI(argc, argv);
     } catch (std::exception& e) {
@@ -21,14 +23,17 @@ int main(int argc, char* argv[]) {
         return 1;
     }
     auto databasePath = args::get(inputDirFlag);
-    std::cout << "Opened the database at path: " << databasePath << std::endl;
-    std::cout << "Enter \":help\" for usage hints." << std::endl;
     uint64_t bpSizeInMB = args::get(bpSizeInMBFlag);
     uint64_t bpSizeInBytes = -1u;
     if (bpSizeInMB != -1u) {
         bpSizeInBytes = bpSizeInMB << 20;
     }
     SystemConfig systemConfig(bpSizeInBytes);
+    if (disableCompression) {
+        systemConfig.enableCompression = false;
+    }
+    std::cout << "Opened the database at path: " << databasePath << std::endl;
+    std::cout << "Enter \":help\" for usage hints." << std::endl;
     try {
         auto shell = EmbeddedShell(databasePath, systemConfig);
         shell.run();


### PR DESCRIPTION
~~Not quite done since it's currently only exposed in the C++ and Rust APIs, and the option needs to be passed to NodeColumns~~.

Python and C don't currently have any sort of SystemConfig structure and only take the buffer pool size as an argument. (*Edit: Added for python and C APIs*)
It looks the same for nodejs and java (which I'm much less familiar with).

An optional argument would probably work fine for python, but since C lacks default values it should probably also have a SystemConfig struct that can be passed to `kuzu_database_init`. (*done*)