### PR TITLE
Integrate C and C++ examples into the main build so that they link properly

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -48,21 +48,9 @@ jobs:
           file: cover.info
           functionalities: 'search'
 
-      - name: C Example
-        working-directory: examples/c
+      - name: C and C++ Examples
         run: |
-          mkdir build -p
-          cd build
-          CC=gcc CXX=g++ cmake ..
-          cmake --build .
-
-      - name: C++ Example
-        working-directory: examples/cpp
-        run: |
-          mkdir build -p
-          cd build
-          CC=gcc CXX=g++ cmake ..
-          cmake --build .
+          CC=gcc CXX=g++ make example NUM_THREADS=32
 
   rust-build-test:
     name: rust build & test
@@ -194,6 +182,10 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
           make javatest NUM_THREADS=18
+
+      - name: C and C++ Examples
+        run: |
+          make example NUM_THREADS=32
 
   header-include-guard-check:
     name: header include guard check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.11)
 
-project(Kuzu VERSION 0.0.8.11 LANGUAGES CXX)
+project(Kuzu VERSION 0.0.8.11 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 
@@ -124,6 +124,7 @@ option(BUILD_PYTHON_API "Build Python API." TRUE)
 option(BUILD_SHELL "Build Interactive Shell" TRUE)
 option(BUILD_TESTS "Build C++ and Python tests." FALSE)
 option(BUILD_BENCHMARK "Build benchmarks." FALSE)
+option(BUILD_EXAMPLES "Build examples." FALSE)
 
 option(BUILD_LCOV "Build coverage report." FALSE)
 if(${BUILD_LCOV})
@@ -232,3 +233,8 @@ elseif (${BUILD_BENCHMARK})
     add_subdirectory(test/test_helper)
 endif()
 add_subdirectory(tools)
+
+if (${BUILD_EXAMPLES})
+    add_subdirectory(examples/c)
+    add_subdirectory(examples/cpp)
+endif()

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,12 @@ debug:
 
 all:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE ../.. && \
+	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE -DBUILD_EXAMPLES=TRUE ../.. && \
+	cmake --build . --config Release
+
+example:
+	$(call mkdirp,build/release) && cd build/release && \
+	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=TRUE ../.. && \
 	cmake --build . --config Release
 
 alldebug:

--- a/examples/c/CMakeLists.txt
+++ b/examples/c/CMakeLists.txt
@@ -1,8 +1,2 @@
-cmake_minimum_required(VERSION 3.11)
-project(example-c)
-
-include_directories(../../src/include)
-link_directories(../../build/release/src)
-
 add_executable(example-c main.c)
-target_link_libraries(example-c kuzu)
+target_link_libraries(example-c kuzu_shared)

--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,10 +1,2 @@
-cmake_minimum_required(VERSION 3.11)
-project(example-cpp)
-
-set(CMAKE_CXX_STANDARD 20)
-
-include_directories(../../src/include)
-link_directories(../../build/release/src)
-
 add_executable(example-cpp main.cpp)
-target_link_libraries(example-cpp kuzu)
+target_link_libraries(example-cpp kuzu_shared)


### PR DESCRIPTION
I think this should fix #2017 and #2018. I've added them to the msvc workflow.