### PR TITLE
reader/csv: Use binary mode on Windows

### DIFF
--- a/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
@@ -24,7 +24,11 @@ BaseCSVReader::BaseCSVReader(const std::string& filePath, const common::ReaderCo
       buffer(nullptr), bufferSize(0), position(0), rowEmpty(false), mode(ParserMode::INVALID),
       rowToAdd(0) {
     // TODO(Ziyi): should we wrap this fd using kuzu file handler?
-    fd = open(filePath.c_str(), O_RDONLY);
+    fd = open(filePath.c_str(), O_RDONLY
+#ifdef _WIN32
+                                    | _O_BINARY
+#endif
+    );
     if (fd == -1) {
         throw CopyException(
             StringUtils::string_format("Could not open file {}: {}", filePath, strerror(errno)));


### PR DESCRIPTION
On windows, when using `open()`, files are opened in Text mode by default. This causes automatic line conversion from `\r\n` to `\n`. We don't want this behaviour, and furthermore, it messes up our computation. If the file contents are `abc\r\n` and Windows is directed to read, it will return 4 bytes, `abc\n`. However, the file position as reported by `lseek` is 5, since we are five bytes into the file. This means we can miss rows if we get really unlucky with block offsets.

Specifying `_O_BINARY` makes windows use binary mode, which is most compatible with the linux behaviour. Our CSV reader is prepared to handle carriage returns anyway.