### PR TITLE
Ignore imports and exports in the static rust build

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -184,7 +184,9 @@ jobs:
           make javatest NUM_THREADS=18
 
       - name: C and C++ Examples
+        shell: cmd
         run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
           make example NUM_THREADS=32
 
   header-include-guard-check:

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -1,4 +1,10 @@
 #pragma once
+
+// We're linking against the static library, so we want to ignore exports/imports
+#ifndef KUZU_STATIC_DEFINE
+#define KUZU_STATIC_DEFINE
+#endif
+
 #include <memory>
 
 #include "rust/cxx.h"


### PR DESCRIPTION
Should fix the rust build failure. The rust build can ignore the imports/exports since it's not using the shared library, but without the define the rust shim is treated as third-party software importing the headers for use with the shared library.