### PR TITLE
Fix non-bundled rust build

### DIFF
--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -186,6 +186,9 @@ fn build_ffi(
     if bundled {
         build.define("KUZU_BUNDLED", None);
     }
+    if link_mode() == "static" {
+        build.define("KUZU_STATIC_DEFINE", None);
+    }
 
     build.includes(include_paths);
 

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -1,10 +1,5 @@
 #pragma once
 
-// We're linking against the static library, so we want to ignore exports/imports
-#ifndef KUZU_STATIC_DEFINE
-#define KUZU_STATIC_DEFINE
-#endif
-
 #include <memory>
 
 #include "rust/cxx.h"


### PR DESCRIPTION
Only set `KUZU_STATIC_DEFINE` in the rust build if linking statically. If linking dynamically against the release binaries it should use the default "import" mode for the headers. It should also be possible to link against a pre-built static library, which this also preserves support for.

We're not testing the non-bundled build at the moment, so that's something that could be added to the list of things to test when setting up the other tests of the single file headers.