### PR TITLE
Clean up node_column.h and column_chunk.h

### DIFF
--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -227,39 +227,6 @@ protected:
     bool mayHaveNullValue;
 };
 
-class FixedListColumnChunk : public ColumnChunk {
-public:
-    FixedListColumnChunk(common::LogicalType dataType,
-        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression)
-        : ColumnChunk(std::move(dataType), std::move(csvReaderConfig), enableCompression,
-              true /* hasNullChunk */) {}
-
-    void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
-        common::offset_t startPosInChunk, uint32_t numValuesToAppend) final;
-
-    void write(const common::Value& fixedListVal, uint64_t posToWrite) final;
-
-    void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk) final;
-
-private:
-    uint64_t getBufferSize() const final;
-};
-
-class SerialColumnChunk : public ColumnChunk {
-public:
-    SerialColumnChunk()
-        : ColumnChunk{common::LogicalType(common::LogicalTypeID::SERIAL),
-              nullptr /* copyDescription */, false /*enableCompression*/,
-              false /* hasNullChunk */} {}
-
-    inline void initialize(common::offset_t numValues) final {
-        numBytesPerValue = 0;
-        bufferSize = 0;
-        // Each byte defaults to 0, indicating everything is non-null
-        buffer = std::make_unique<uint8_t[]>(bufferSize);
-    }
-};
-
 struct ColumnChunkFactory {
     static std::unique_ptr<ColumnChunk> createColumnChunk(const common::LogicalType& dataType,
         bool enableCompression, common::CSVReaderConfig* csvReaderConfig = nullptr);

--- a/src/include/storage/store/node_column.h
+++ b/src/include/storage/store/node_column.h
@@ -133,53 +133,6 @@ protected:
     bool enableCompression;
 };
 
-class BoolNodeColumn : public NodeColumn {
-public:
-    BoolNodeColumn(const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH,
-        BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
-        bool enableCompression, bool requireNullColumn = true);
-};
-
-class NullNodeColumn : public NodeColumn {
-    friend StructNodeColumn;
-
-public:
-    NullNodeColumn(common::page_idx_t metaDAHPageIdx, BMFileHandle* dataFH,
-        BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
-        bool enableCompression);
-
-    void scan(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) final;
-    void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0) final;
-    void scan(common::node_group_idx_t nodeGroupIdx, ColumnChunk* columnChunk) final;
-
-    void lookup(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) final;
-    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) final;
-    void setNull(common::offset_t nodeOffset) final;
-
-protected:
-    void writeInternal(common::offset_t nodeOffset, common::ValueVector* vectorToWriteFrom,
-        uint32_t posInVectorToWriteFrom) final;
-};
-
-class SerialNodeColumn : public NodeColumn {
-public:
-    SerialNodeColumn(const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH,
-        BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction);
-
-    void scan(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) final;
-    void lookup(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) final;
-    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) final;
-};
-
 struct NodeColumnFactory {
     static std::unique_ptr<NodeColumn> createNodeColumn(const common::LogicalType& dataType,
         const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH, BMFileHandle* metadataFH,


### PR DESCRIPTION
Some of the classes can be moved into the source files as they are only used by the factories. BoolNodeColumn was no longer needed and was removed.

NullColumnChunk is referenced elsewhere, but otherwise the specific variants of ColumnChunk and NodeColumn are all now defined within the source files.

That said, node_column.cpp and column_chunk.cpp are now getting a little large.