### PR TITLE
Move child chunks and columns to struct

### DIFF
--- a/src/include/storage/store/node_column.h
+++ b/src/include/storage/store/node_column.h
@@ -49,7 +49,7 @@ public:
         common::ValueVector* resultVector);
     virtual void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0);
+        common::ValueVector* resultVector, uint64_t offsetInVector);
     virtual void scan(common::node_group_idx_t nodeGroupIdx, ColumnChunk* columnChunk);
     virtual void lookup(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         common::ValueVector* resultVector);
@@ -63,16 +63,12 @@ public:
     inline uint64_t getNumNodeGroups(transaction::Transaction* transaction) const {
         return metadataDA->getNumElements(transaction->getType());
     }
-    inline NodeColumn* getChildColumn(common::vector_idx_t childIdx) {
-        assert(childIdx < childrenColumns.size());
-        return childrenColumns[childIdx].get();
-    }
 
     virtual void checkpointInMemory();
     virtual void rollbackInMemory();
 
     void populateWithDefaultVal(const catalog::Property& property, NodeColumn* nodeColumn,
-        common::ValueVector* defaultValueVector, uint64_t numNodeGroups);
+        common::ValueVector* defaultValueVector, uint64_t numNodeGroups) const;
 
     inline CompressionMetadata getCompressionMetadata(
         common::node_group_idx_t nodeGroupIdx, transaction::TransactionType transaction) const {
@@ -124,7 +120,6 @@ protected:
     WAL* wal;
     std::unique_ptr<InMemDiskArray<ColumnChunkMetadata>> metadataDA;
     std::unique_ptr<NodeColumn> nullColumn;
-    std::vector<std::unique_ptr<NodeColumn>> childrenColumns;
     read_values_to_vector_func_t readToVectorFunc;
     write_values_from_vector_func_t writeFromVectorFunc;
     read_values_to_page_func_t readToPageFunc;

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -13,8 +13,7 @@ class TableData;
 
 class NodeGroup {
 public:
-    explicit NodeGroup(catalog::TableSchema* schema, common::CSVReaderConfig* csvReaderConfig,
-        bool enableCompression);
+    NodeGroup(catalog::TableSchema* schema, bool enableCompression);
     explicit NodeGroup(TableData* table);
 
     inline void setNodeGroupIdx(uint64_t nodeGroupIdx_) { this->nodeGroupIdx = nodeGroupIdx_; }

--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -9,8 +9,7 @@ namespace storage {
 
 class StringColumnChunk : public ColumnChunk {
 public:
-    StringColumnChunk(
-        common::LogicalType dataType, std::unique_ptr<common::CSVReaderConfig> csvReaderConfig);
+    explicit StringColumnChunk(common::LogicalType dataType);
 
     void resetToEmpty() final;
     void append(common::ValueVector* vector, common::offset_t startPosInChunk) final;

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -7,16 +7,25 @@ namespace storage {
 
 class StructColumnChunk : public ColumnChunk {
 public:
-    StructColumnChunk(common::LogicalType dataType,
-        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression);
+    StructColumnChunk(common::LogicalType dataType, bool enableCompression);
+
+    inline ColumnChunk* getChild(common::vector_idx_t childIdx) {
+        assert(childIdx < childChunks.size());
+        return childChunks[childIdx].get();
+    }
 
 protected:
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
         common::offset_t startPosInChunk, uint32_t numValuesToAppend) final;
     void append(common::ValueVector* vector, common::offset_t startPosInChunk) final;
 
+    void resize(uint64_t newCapacity) final;
+
 private:
     void write(const common::Value& val, uint64_t posToWrite) final;
+
+private:
+    std::vector<std::unique_ptr<ColumnChunk>> childChunks;
 };
 
 } // namespace storage

--- a/src/include/storage/store/struct_node_column.h
+++ b/src/include/storage/store/struct_node_column.h
@@ -15,7 +15,17 @@ public:
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0) final;
+        common::ValueVector* resultVector, uint64_t offsetInVector) final;
+
+    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) final;
+
+    void checkpointInMemory() final;
+    void rollbackInMemory() final;
+
+    inline NodeColumn* getChild(common::vector_idx_t childIdx) {
+        assert(childIdx < childColumns.size());
+        return childColumns[childIdx].get();
+    }
 
 protected:
     void scanInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
@@ -24,6 +34,9 @@ protected:
         common::ValueVector* resultVector) final;
     void writeInternal(common::offset_t nodeOffset, common::ValueVector* vectorToWriteFrom,
         uint32_t posInVectorToWriteFrom) final;
+
+private:
+    std::vector<std::unique_ptr<NodeColumn>> childColumns;
 };
 
 } // namespace storage

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -14,7 +14,7 @@ struct VarListDataColumnChunk {
         : dataColumnChunk{std::move(dataChunk)}, capacity{
                                                      common::StorageConstants::NODE_GROUP_SIZE} {}
 
-    void reset();
+    void reset() const;
 
     void resizeBuffer(uint64_t numValues);
 
@@ -31,8 +31,7 @@ struct VarListDataColumnChunk {
 
 class VarListColumnChunk : public ColumnChunk {
 public:
-    VarListColumnChunk(common::LogicalType dataType,
-        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression);
+    VarListColumnChunk(common::LogicalType dataType, bool enableCompression);
 
     inline ColumnChunk* getDataColumnChunk() const {
         return varListDataColumnChunk.dataColumnChunk.get();

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -44,9 +44,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyNodeFrom(
     // Map copy node.
     auto nodeTable = storageManager.getNodesStore().getNodeTable(tableSchema->tableID);
     bool isCopyRdf = readerConfig->fileType == FileType::TURTLE;
-    auto copyNodeSharedState = std::make_shared<CopyNodeSharedState>(
-        reader->getSharedState()->getNumRowsRef(), tableSchema, nodeTable, memoryManager, isCopyRdf,
-        readerConfig->csvReaderConfig->copy());
+    auto copyNodeSharedState =
+        std::make_shared<CopyNodeSharedState>(reader->getSharedState()->getNumRowsRef(),
+            tableSchema, nodeTable, memoryManager, isCopyRdf);
     CopyNodeInfo copyNodeDataInfo{readerInfo->dataColumnsPos, nodeTable,
         &storageManager.getRelsStore(), catalog, storageManager.getWAL(),
         copyFromInfo->containsSerial};

--- a/src/processor/operator/persistent/copy_node.cpp
+++ b/src/processor/operator/persistent/copy_node.cpp
@@ -14,10 +14,9 @@ namespace kuzu {
 namespace processor {
 
 CopyNodeSharedState::CopyNodeSharedState(uint64_t& numRows, NodeTableSchema* tableSchema,
-    NodeTable* table, MemoryManager* memoryManager, bool isCopyRdf,
-    std::unique_ptr<common::CSVReaderConfig> csvReaderConfig)
+    NodeTable* table, MemoryManager* memoryManager, bool isCopyRdf)
     : numRows{numRows}, tableSchema{tableSchema}, table{table}, pkColumnID{0}, hasLoggedWAL{false},
-      currentNodeGroupIdx{0}, isCopyRdf{isCopyRdf}, csvReaderConfig{std::move(csvReaderConfig)} {
+      currentNodeGroupIdx{0}, isCopyRdf{isCopyRdf} {
     auto ftTableSchema = std::make_unique<FactorizedTableSchema>();
     ftTableSchema->appendColumn(
         std::make_unique<ColumnSchema>(false /* flat */, 0 /* dataChunkPos */,

--- a/src/storage/local_table.cpp
+++ b/src/storage/local_table.cpp
@@ -290,12 +290,13 @@ void VarListLocalColumn::prepareCommitForChunk(node_group_idx_t nodeGroupIdx) {
 StructLocalColumn::StructLocalColumn(NodeColumn* column, bool enableCompression)
     : LocalColumn{column, enableCompression} {
     assert(column->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto dataType = column->getDataType();
+    auto structColumn = static_cast<StructNodeColumn*>(column);
+    auto dataType = structColumn->getDataType();
     auto structFields = StructType::getFields(&dataType);
     fields.resize(structFields.size());
     for (auto i = 0u; i < structFields.size(); i++) {
         fields[i] =
-            LocalColumnFactory::createLocalColumn(column->getChildColumn(i), enableCompression);
+            LocalColumnFactory::createLocalColumn(structColumn->getChild(i), enableCompression);
     }
 }
 

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -14,129 +14,6 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-void BoolColumnChunk::initialize(common::offset_t capacity) {
-    numBytesPerValue = 0;
-    bufferSize = numBytesForValues(capacity);
-    this->capacity = capacity;
-    buffer = std::make_unique<uint8_t[]>(bufferSize);
-    if (nullChunk) {
-        static_cast<BoolColumnChunk*>(nullChunk.get())->initialize(capacity);
-    }
-}
-
-void BoolColumnChunk::resize(uint64_t capacity) {
-    auto numBytesAfterResize = numBytesForValues(capacity);
-    assert(numBytesAfterResize > bufferSize);
-    auto reservedBuffer = std::make_unique<uint8_t[]>(numBytesAfterResize);
-    memset(reservedBuffer.get(), 0 /* non null */, numBytesAfterResize);
-    memcpy(reservedBuffer.get(), buffer.get(), bufferSize);
-    buffer = std::move(reservedBuffer);
-    bufferSize = numBytesAfterResize;
-    this->capacity = numValues;
-    if (nullChunk) {
-        nullChunk->resize(capacity);
-    }
-}
-
-void NullColumnChunk::append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
-    common::offset_t startPosInChunk, uint32_t numValuesToAppend) {
-    copyFromBuffer((uint64_t*)static_cast<NullColumnChunk*>(other)->buffer.get(),
-        startPosInOtherChunk, startPosInChunk, numValuesToAppend);
-}
-
-class FixedListColumnChunk : public ColumnChunk {
-public:
-    FixedListColumnChunk(common::LogicalType dataType,
-        std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression)
-        : ColumnChunk(std::move(dataType), std::move(csvReaderConfig), enableCompression,
-              true /* hasNullChunk */) {}
-
-    void append(ColumnChunk* other, offset_t startPosInOtherChunk, common::offset_t startPosInChunk,
-        uint32_t numValuesToAppend) final {
-        auto otherChunk = (FixedListColumnChunk*)other;
-        if (nullChunk) {
-            nullChunk->append(otherChunk->nullChunk.get(), startPosInOtherChunk, startPosInChunk,
-                numValuesToAppend);
-        }
-        // TODO(Guodong): This can be optimized to not copy one by one.
-        for (auto i = 0u; i < numValuesToAppend; i++) {
-            memcpy(buffer.get() + getOffsetInBuffer(startPosInChunk + i),
-                otherChunk->buffer.get() + getOffsetInBuffer(startPosInOtherChunk + i),
-                numBytesPerValue);
-        }
-        numValues += numValuesToAppend;
-    }
-
-    void write(const Value& fixedListVal, uint64_t posToWrite) final {
-        assert(fixedListVal.getDataType()->getPhysicalType() == PhysicalTypeID::FIXED_LIST);
-        nullChunk->setNull(posToWrite, fixedListVal.isNull());
-        if (fixedListVal.isNull()) {
-            return;
-        }
-        auto numValues = NestedVal::getChildrenSize(&fixedListVal);
-        auto childType = FixedListType::getChildType(fixedListVal.getDataType());
-        auto numBytesPerValueInList = getDataTypeSizeInChunk(*childType);
-        auto bufferToWrite = buffer.get() + posToWrite * numBytesPerValue;
-        for (auto i = 0u; i < numValues; i++) {
-            auto val = NestedVal::getChildVal(&fixedListVal, i);
-            switch (childType->getPhysicalType()) {
-            case PhysicalTypeID::INT64: {
-                memcpy(bufferToWrite, &val->getValueReference<int64_t>(), numBytesPerValueInList);
-            } break;
-            case PhysicalTypeID::INT32: {
-                memcpy(bufferToWrite, &val->getValueReference<int32_t>(), numBytesPerValueInList);
-            } break;
-            case PhysicalTypeID::INT16: {
-                memcpy(bufferToWrite, &val->getValueReference<int16_t>(), numBytesPerValueInList);
-            } break;
-            case PhysicalTypeID::DOUBLE: {
-                memcpy(bufferToWrite, &val->getValueReference<double_t>(), numBytesPerValueInList);
-            } break;
-            case PhysicalTypeID::FLOAT: {
-                memcpy(bufferToWrite, &val->getValueReference<float_t>(), numBytesPerValueInList);
-            } break;
-            default: {
-                throw NotImplementedException{"FixedListColumnChunk::write"};
-            }
-            }
-            bufferToWrite += numBytesPerValueInList;
-        }
-    }
-
-    void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk) final {
-        auto vectorDataToWriteFrom = vector->getData();
-        for (auto i = 0u; i < vector->state->selVector->selectedSize; i++) {
-            auto pos = vector->state->selVector->selectedPositions[i];
-            nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
-            memcpy(buffer.get() + getOffsetInBuffer(startPosInChunk + i),
-                vectorDataToWriteFrom + pos * numBytesPerValue, numBytesPerValue);
-        }
-    }
-
-private:
-    uint64_t getBufferSize() const final {
-        auto numElementsInAPage =
-            PageUtils::getNumElementsInAPage(numBytesPerValue, false /* hasNull */);
-        auto numPages = capacity / numElementsInAPage + (capacity % numElementsInAPage ? 1 : 0);
-        return common::BufferPoolConstants::PAGE_4KB_SIZE * numPages;
-    }
-};
-
-class SerialColumnChunk : public ColumnChunk {
-public:
-    SerialColumnChunk()
-        : ColumnChunk{common::LogicalType(common::LogicalTypeID::SERIAL),
-              nullptr /* copyDescription */, false /*enableCompression*/,
-              false /* hasNullChunk */} {}
-
-    inline void initialize(common::offset_t numValues) final {
-        numBytesPerValue = 0;
-        bufferSize = 0;
-        // Each byte defaults to 0, indicating everything is non-null
-        buffer = std::make_unique<uint8_t[]>(bufferSize);
-    }
-};
-
 ColumnChunkMetadata fixedSizedFlushBuffer(const uint8_t* buffer, uint64_t bufferSize,
     BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
     FileUtils::writeToFile(dataFH->getFileInfo(), buffer, bufferSize,
@@ -147,15 +24,14 @@ ColumnChunkMetadata fixedSizedFlushBuffer(const uint8_t* buffer, uint64_t buffer
 
 ColumnChunkMetadata fixedSizedGetMetadata(
     const uint8_t* buffer, uint64_t bufferSize, uint64_t capacity, uint64_t numValues) {
-    return ColumnChunkMetadata(common::INVALID_PAGE_IDX,
-        ColumnChunk::getNumPagesForBytes(bufferSize), numValues, CompressionMetadata());
+    return ColumnChunkMetadata(INVALID_PAGE_IDX, ColumnChunk::getNumPagesForBytes(bufferSize),
+        numValues, CompressionMetadata());
 }
 
 ColumnChunkMetadata booleanGetMetadata(
     const uint8_t* buffer, uint64_t bufferSize, uint64_t capacity, uint64_t numValues) {
-    return ColumnChunkMetadata(common::INVALID_PAGE_IDX,
-        ColumnChunk::getNumPagesForBytes(bufferSize), numValues,
-        CompressionMetadata(CompressionType::BOOLEAN_BITPACKING));
+    return ColumnChunkMetadata(INVALID_PAGE_IDX, ColumnChunk::getNumPagesForBytes(bufferSize),
+        numValues, CompressionMetadata(CompressionType::BOOLEAN_BITPACKING));
 }
 
 class CompressedFlushBuffer {
@@ -170,7 +46,7 @@ public:
 
     ColumnChunkMetadata operator()(const uint8_t* buffer, uint64_t bufferSize, BMFileHandle* dataFH,
         page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
-        int64_t valuesRemaining = metadata.numValues;
+        auto valuesRemaining = metadata.numValues;
         const uint8_t* bufferStart = buffer;
         auto compressedBuffer = std::make_unique<uint8_t[]>(BufferPoolConstants::PAGE_4KB_SIZE);
         auto numPages = 0;
@@ -210,7 +86,7 @@ public:
         auto metadata = alg->getCompressionMetadata(buffer, numValues);
         auto numValuesPerPage = metadata.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType);
         auto numPages = capacity / numValuesPerPage + (capacity % numValuesPerPage == 0 ? 0 : 1);
-        return ColumnChunkMetadata(common::INVALID_PAGE_IDX, numPages, numValues, metadata);
+        return ColumnChunkMetadata(INVALID_PAGE_IDX, numPages, numValues, metadata);
     }
 };
 
@@ -251,14 +127,27 @@ static std::shared_ptr<CompressionAlg> getCompression(
     }
 }
 
-ColumnChunk::ColumnChunk(LogicalType dataType, std::unique_ptr<CSVReaderConfig> csvReaderConfig,
-    bool enableCompression, bool hasNullChunk)
-    : dataType{std::move(dataType)}, numBytesPerValue{getDataTypeSizeInChunk(this->dataType)},
-      csvReaderConfig{std::move(csvReaderConfig)}, numValues{0} {
+ColumnChunk::ColumnChunk(LogicalType dataType, bool enableCompression, bool hasNullChunk)
+    : dataType{std::move(dataType)},
+      numBytesPerValue{getDataTypeSizeInChunk(this->dataType)}, numValues{0} {
     if (hasNullChunk) {
         nullChunk = std::make_unique<NullColumnChunk>();
     }
+    initializeBuffer(StorageConstants::NODE_GROUP_SIZE);
+    initializeFunction(enableCompression);
+}
 
+void ColumnChunk::initializeBuffer(offset_t capacity_) {
+    numBytesPerValue = getDataTypeSizeInChunk(dataType);
+    capacity = capacity_;
+    bufferSize = getBufferSize();
+    buffer = std::make_unique<uint8_t[]>(bufferSize);
+    if (nullChunk) {
+        static_cast<ColumnChunk*>(nullChunk.get())->initializeBuffer(capacity);
+    }
+}
+
+void ColumnChunk::initializeFunction(bool enableCompression) {
     switch (this->dataType.getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
         // Since we compress into memory, storage is the same as fixed-sized values,
@@ -288,15 +177,6 @@ ColumnChunk::ColumnChunk(LogicalType dataType, std::unique_ptr<CSVReaderConfig> 
     }
 }
 
-void ColumnChunk::initialize(offset_t capacity) {
-    this->capacity = capacity;
-    bufferSize = getBufferSize();
-    buffer = std::make_unique<uint8_t[]>(bufferSize);
-    if (nullChunk) {
-        static_cast<ColumnChunk*>(nullChunk.get())->initialize(capacity);
-    }
-}
-
 void ColumnChunk::resetToEmpty() {
     if (nullChunk) {
         nullChunk->resetNullBuffer();
@@ -304,32 +184,9 @@ void ColumnChunk::resetToEmpty() {
     numValues = 0;
 }
 
-void ColumnChunk::append(common::ValueVector* vector, common::offset_t startPosInChunk) {
-    switch (vector->dataType.getPhysicalType()) {
-    case PhysicalTypeID::INT64:
-    case PhysicalTypeID::INT32:
-    case PhysicalTypeID::INT16:
-    case PhysicalTypeID::INT8:
-    case PhysicalTypeID::UINT64:
-    case PhysicalTypeID::UINT32:
-    case PhysicalTypeID::UINT16:
-    case PhysicalTypeID::UINT8:
-    case PhysicalTypeID::DOUBLE:
-    case PhysicalTypeID::FLOAT:
-    case PhysicalTypeID::INTERVAL:
-    case PhysicalTypeID::FIXED_LIST: {
-        copyVectorToBuffer(vector, startPosInChunk);
-    } break;
-    default: {
-        throw NotImplementedException{"ColumnChunk::append"};
-    }
-    }
+void ColumnChunk::append(ValueVector* vector, offset_t startPosInChunk) {
+    copyVectorToBuffer(vector, startPosInChunk);
     numValues += vector->state->selVector->selectedSize;
-}
-
-void ColumnChunk::append(
-    ValueVector* vector, offset_t startPosInChunk, uint32_t numValuesToAppend) {
-    append(vector, startPosInChunk);
 }
 
 void ColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
@@ -386,155 +243,44 @@ void ColumnChunk::write(const Value& val, uint64_t posToWrite) {
     case PhysicalTypeID::INTERVAL: {
         setValue(val.getValue<interval_t>(), posToWrite);
     } break;
-    case PhysicalTypeID::INTERNAL_ID: {
-        setValue(val.getValue<internalID_t>(), posToWrite);
-    } break;
     default: {
         throw NotImplementedException{"ColumnChunk::write"};
     }
     }
 }
 
-void ColumnChunk::resize(uint64_t numValues) {
-    auto numBytesAfterResize = numValues * numBytesPerValue;
+void ColumnChunk::resize(uint64_t newCapacity) {
+    capacity = newCapacity;
+    auto numBytesAfterResize = getBufferSize();
+    assert(numBytesAfterResize > bufferSize);
     auto resizedBuffer = std::make_unique<uint8_t[]>(numBytesAfterResize);
+    if (dataType.getPhysicalType() == common::PhysicalTypeID::BOOL) {
+        memset(resizedBuffer.get(), 0 /* non null */, numBytesAfterResize);
+    }
     memcpy(resizedBuffer.get(), buffer.get(), bufferSize);
     bufferSize = numBytesAfterResize;
     buffer = std::move(resizedBuffer);
-    this->capacity = numValues;
     if (nullChunk) {
-        nullChunk->resize(numValues);
-    }
-    for (auto& child : childrenChunks) {
-        child->resize(numValues);
+        nullChunk->resize(newCapacity);
     }
 }
 
-void ColumnChunk::populateWithDefaultVal(common::ValueVector* defaultValueVector) {
-    defaultValueVector->setState(std::make_shared<common::DataChunkState>());
+void ColumnChunk::populateWithDefaultVal(ValueVector* defaultValueVector) {
+    defaultValueVector->setState(std::make_shared<DataChunkState>());
     auto valPos = defaultValueVector->state->selVector->selectedPositions[0];
     defaultValueVector->state->selVector->resetSelectorToValuePosBufferWithSize(
-        common::DEFAULT_VECTOR_CAPACITY);
+        DEFAULT_VECTOR_CAPACITY);
     for (auto i = 0u; i < defaultValueVector->state->selVector->selectedSize; i++) {
         defaultValueVector->state->selVector->selectedPositions[i] = valPos;
     }
     auto numValuesAppended = 0u;
-    while (numValuesAppended < common::StorageConstants::NODE_GROUP_SIZE) {
-        auto numValuesToAppend = std::min(common::DEFAULT_VECTOR_CAPACITY,
-            common::StorageConstants::NODE_GROUP_SIZE - numValuesAppended);
+    while (numValuesAppended < StorageConstants::NODE_GROUP_SIZE) {
+        auto numValuesToAppend = std::min(
+            DEFAULT_VECTOR_CAPACITY, StorageConstants::NODE_GROUP_SIZE - numValuesAppended);
         defaultValueVector->state->selVector->selectedSize = numValuesToAppend;
         append(defaultValueVector, numValuesAppended);
         numValuesAppended += numValuesToAppend;
     }
-}
-
-ColumnChunkMetadata ColumnChunk::getMetadataToFlush() const {
-    return getMetadataFunction(buffer.get(), bufferSize, capacity, numValues);
-}
-
-ColumnChunkMetadata ColumnChunk::flushBuffer(
-    BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
-    return flushBufferFunction(buffer.get(), bufferSize, dataFH, startPageIdx, metadata);
-}
-
-uint32_t ColumnChunk::getDataTypeSizeInChunk(LogicalType& dataType) {
-    switch (dataType.getLogicalTypeID()) {
-    case LogicalTypeID::STRUCT: {
-        return 0;
-    }
-    case LogicalTypeID::STRING: {
-        return sizeof(ku_string_t);
-    }
-    case LogicalTypeID::INTERNAL_ID:
-    case LogicalTypeID::VAR_LIST: {
-        return sizeof(offset_t);
-    }
-    case LogicalTypeID::SERIAL: {
-        return sizeof(int64_t);
-    }
-    // Used by NodeColumnn to represent the de-compressed size of booleans in-memory
-    // Does not reflect the size of booleans on-disk in BoolColumnChunk
-    case LogicalTypeID::BOOL: {
-        return 1;
-    }
-    default: {
-        return StorageUtils::getDataTypeSize(dataType);
-    }
-    }
-}
-
-void BoolColumnChunk::append(common::ValueVector* vector, common::offset_t startPosInChunk) {
-    assert(vector->dataType.getPhysicalType() == PhysicalTypeID::BOOL);
-    for (auto i = 0u; i < vector->state->selVector->selectedSize; i++) {
-        auto pos = vector->state->selVector->selectedPositions[i];
-        nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
-        common::NullMask::setNull(
-            (uint64_t*)buffer.get(), startPosInChunk + i, vector->getValue<bool>(pos));
-    }
-    numValues += vector->state->selVector->selectedSize;
-}
-
-void BoolColumnChunk::append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
-    common::offset_t startPosInChunk, uint32_t numValuesToAppend) {
-    NullMask::copyNullMask((uint64_t*)static_cast<BoolColumnChunk*>(other)->buffer.get(),
-        startPosInOtherChunk, (uint64_t*)buffer.get(), startPosInChunk, numValuesToAppend);
-
-    if (nullChunk) {
-        nullChunk->append(
-            other->getNullChunk(), startPosInOtherChunk, startPosInChunk, numValuesToAppend);
-    }
-    numValues += numValuesToAppend;
-}
-
-std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
-    const LogicalType& dataType, bool enableCompression, CSVReaderConfig* csvReaderConfig) {
-    auto csvReaderConfigCopy = csvReaderConfig ? csvReaderConfig->copy() : nullptr;
-    std::unique_ptr<ColumnChunk> chunk;
-    switch (dataType.getPhysicalType()) {
-    case PhysicalTypeID::BOOL: {
-        chunk = std::make_unique<BoolColumnChunk>(std::move(csvReaderConfigCopy));
-    } break;
-    case PhysicalTypeID::INT64:
-    case PhysicalTypeID::INT32:
-    case PhysicalTypeID::INT16:
-    case PhysicalTypeID::INT8:
-    case PhysicalTypeID::UINT64:
-    case PhysicalTypeID::UINT32:
-    case PhysicalTypeID::UINT16:
-    case PhysicalTypeID::UINT8:
-    case PhysicalTypeID::DOUBLE:
-    case PhysicalTypeID::FLOAT:
-    case PhysicalTypeID::INTERVAL: {
-        if (dataType.getLogicalTypeID() == LogicalTypeID::SERIAL) {
-            chunk = std::make_unique<SerialColumnChunk>();
-        } else {
-            chunk = std::make_unique<ColumnChunk>(
-                dataType, std::move(csvReaderConfigCopy), enableCompression);
-        }
-    } break;
-    case PhysicalTypeID::FIXED_LIST: {
-        chunk = std::make_unique<FixedListColumnChunk>(
-            dataType, std::move(csvReaderConfigCopy), enableCompression);
-    } break;
-    case PhysicalTypeID::STRING: {
-        chunk = std::make_unique<StringColumnChunk>(dataType, std::move(csvReaderConfigCopy));
-    } break;
-    case PhysicalTypeID::VAR_LIST: {
-        chunk = std::make_unique<VarListColumnChunk>(
-            dataType, std::move(csvReaderConfigCopy), enableCompression);
-    } break;
-    case PhysicalTypeID::STRUCT: {
-        chunk = std::make_unique<StructColumnChunk>(
-            dataType, std::move(csvReaderConfigCopy), enableCompression);
-    } break;
-    default: {
-        throw NotImplementedException("ColumnChunkFactory::createColumnChunk for data type " +
-                                      LogicalTypeUtils::dataTypeToString(dataType) +
-                                      " is not supported.");
-    }
-    }
-    chunk->initialize(StorageConstants::NODE_GROUP_SIZE);
-    return chunk;
 }
 
 offset_t ColumnChunk::getOffsetInBuffer(offset_t pos) const {
@@ -547,8 +293,7 @@ offset_t ColumnChunk::getOffsetInBuffer(offset_t pos) const {
     return offsetInBuffer;
 }
 
-void ColumnChunk::copyVectorToBuffer(
-    common::ValueVector* vector, common::offset_t startPosInChunk) {
+void ColumnChunk::copyVectorToBuffer(ValueVector* vector, offset_t startPosInChunk) {
     auto bufferToWrite = buffer.get() + startPosInChunk * numBytesPerValue;
     auto vectorDataToWriteFrom = vector->getData();
     if (vector->state->selVector->isUnfiltered()) {
@@ -581,6 +326,199 @@ void ColumnChunk::update(ValueVector* vector, vector_idx_t vectorIdx) {
             numValues = pos + 1;
         }
     }
+}
+
+ColumnChunkMetadata ColumnChunk::getMetadataToFlush() const {
+    return getMetadataFunction(buffer.get(), bufferSize, capacity, numValues);
+}
+
+ColumnChunkMetadata ColumnChunk::flushBuffer(
+    BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
+    return flushBufferFunction(buffer.get(), bufferSize, dataFH, startPageIdx, metadata);
+}
+
+uint32_t ColumnChunk::getDataTypeSizeInChunk(LogicalType& dataType) {
+    switch (dataType.getLogicalTypeID()) {
+    case LogicalTypeID::SERIAL:
+    case LogicalTypeID::STRUCT: {
+        return 0;
+    }
+    case LogicalTypeID::STRING: {
+        return sizeof(ku_string_t);
+    }
+    case LogicalTypeID::VAR_LIST:
+    case LogicalTypeID::INTERNAL_ID: {
+        return sizeof(offset_t);
+    }
+    // Used by NodeColumn to represent the de-compressed size of booleans in-memory
+    // Does not reflect the size of booleans on-disk in BoolColumnChunk
+    case LogicalTypeID::BOOL: {
+        return 1;
+    }
+    default: {
+        return StorageUtils::getDataTypeSize(dataType);
+    }
+    }
+}
+
+uint64_t ColumnChunk::getBufferSize() const {
+    switch (dataType.getLogicalTypeID()) {
+    case LogicalTypeID::BOOL: {
+        // 8 values per byte, and we need a buffer size which is a multiple of 8 bytes.
+        return ceil(capacity / 8.0 / 8.0) * 8;
+    }
+    case LogicalTypeID::FIXED_LIST: {
+        auto numElementsInAPage =
+            PageUtils::getNumElementsInAPage(numBytesPerValue, false /* hasNull */);
+        auto numPages = capacity / numElementsInAPage + (capacity % numElementsInAPage ? 1 : 0);
+        return BufferPoolConstants::PAGE_4KB_SIZE * numPages;
+    }
+    default: {
+        return numBytesPerValue * capacity;
+    }
+    }
+}
+
+void BoolColumnChunk::append(ValueVector* vector, offset_t startPosInChunk) {
+    assert(vector->dataType.getPhysicalType() == PhysicalTypeID::BOOL);
+    for (auto i = 0u; i < vector->state->selVector->selectedSize; i++) {
+        auto pos = vector->state->selVector->selectedPositions[i];
+        nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
+        NullMask::setNull(
+            (uint64_t*)buffer.get(), startPosInChunk + i, vector->getValue<bool>(pos));
+    }
+    numValues += vector->state->selVector->selectedSize;
+}
+
+void BoolColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
+    offset_t startPosInChunk, uint32_t numValuesToAppend) {
+    NullMask::copyNullMask((uint64_t*)static_cast<BoolColumnChunk*>(other)->buffer.get(),
+        startPosInOtherChunk, (uint64_t*)buffer.get(), startPosInChunk, numValuesToAppend);
+    if (nullChunk) {
+        nullChunk->append(
+            other->getNullChunk(), startPosInOtherChunk, startPosInChunk, numValuesToAppend);
+    }
+    numValues += numValuesToAppend;
+}
+
+void NullColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
+    offset_t startPosInChunk, uint32_t numValuesToAppend) {
+    copyFromBuffer((uint64_t*)static_cast<NullColumnChunk*>(other)->buffer.get(),
+        startPosInOtherChunk, startPosInChunk, numValuesToAppend);
+}
+
+class FixedListColumnChunk : public ColumnChunk {
+public:
+    FixedListColumnChunk(LogicalType dataType, bool enableCompression)
+        : ColumnChunk(std::move(dataType), enableCompression, true /* hasNullChunk */) {}
+
+    void append(ColumnChunk* other, offset_t startPosInOtherChunk, offset_t startPosInChunk,
+        uint32_t numValuesToAppend) final {
+        auto otherChunk = (FixedListColumnChunk*)other;
+        if (nullChunk) {
+            nullChunk->append(otherChunk->nullChunk.get(), startPosInOtherChunk, startPosInChunk,
+                numValuesToAppend);
+        }
+        // TODO(Guodong): This can be optimized to not copy one by one.
+        for (auto i = 0u; i < numValuesToAppend; i++) {
+            memcpy(buffer.get() + getOffsetInBuffer(startPosInChunk + i),
+                otherChunk->buffer.get() + getOffsetInBuffer(startPosInOtherChunk + i),
+                numBytesPerValue);
+        }
+        numValues += numValuesToAppend;
+    }
+
+    void write(const Value& fixedListVal, uint64_t posToWrite) final {
+        assert(fixedListVal.getDataType()->getPhysicalType() == PhysicalTypeID::FIXED_LIST);
+        nullChunk->setNull(posToWrite, fixedListVal.isNull());
+        if (fixedListVal.isNull()) {
+            return;
+        }
+        auto numValues = NestedVal::getChildrenSize(&fixedListVal);
+        auto childType = FixedListType::getChildType(fixedListVal.getDataType());
+        auto numBytesPerValueInList = getDataTypeSizeInChunk(*childType);
+        auto bufferToWrite = buffer.get() + posToWrite * numBytesPerValue;
+        for (auto i = 0u; i < numValues; i++) {
+            auto val = NestedVal::getChildVal(&fixedListVal, i);
+            switch (childType->getPhysicalType()) {
+            case PhysicalTypeID::INT64: {
+                memcpy(bufferToWrite, &val->getValueReference<int64_t>(), numBytesPerValueInList);
+            } break;
+            case PhysicalTypeID::INT32: {
+                memcpy(bufferToWrite, &val->getValueReference<int32_t>(), numBytesPerValueInList);
+            } break;
+            case PhysicalTypeID::INT16: {
+                memcpy(bufferToWrite, &val->getValueReference<int16_t>(), numBytesPerValueInList);
+            } break;
+            case PhysicalTypeID::DOUBLE: {
+                memcpy(bufferToWrite, &val->getValueReference<double_t>(), numBytesPerValueInList);
+            } break;
+            case PhysicalTypeID::FLOAT: {
+                memcpy(bufferToWrite, &val->getValueReference<float_t>(), numBytesPerValueInList);
+            } break;
+            default: {
+                throw NotImplementedException{"FixedListColumnChunk::write"};
+            }
+            }
+            bufferToWrite += numBytesPerValueInList;
+        }
+    }
+
+    void copyVectorToBuffer(ValueVector* vector, offset_t startPosInChunk) final {
+        auto vectorDataToWriteFrom = vector->getData();
+        for (auto i = 0u; i < vector->state->selVector->selectedSize; i++) {
+            auto pos = vector->state->selVector->selectedPositions[i];
+            nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
+            memcpy(buffer.get() + getOffsetInBuffer(startPosInChunk + i),
+                vectorDataToWriteFrom + pos * numBytesPerValue, numBytesPerValue);
+        }
+    }
+};
+
+std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
+    const LogicalType& dataType, bool enableCompression) {
+    std::unique_ptr<ColumnChunk> chunk;
+    switch (dataType.getPhysicalType()) {
+    case PhysicalTypeID::BOOL: {
+        chunk = std::make_unique<BoolColumnChunk>();
+    } break;
+    case PhysicalTypeID::INT64:
+    case PhysicalTypeID::INT32:
+    case PhysicalTypeID::INT16:
+    case PhysicalTypeID::INT8:
+    case PhysicalTypeID::UINT64:
+    case PhysicalTypeID::UINT32:
+    case PhysicalTypeID::UINT16:
+    case PhysicalTypeID::UINT8:
+    case PhysicalTypeID::DOUBLE:
+    case PhysicalTypeID::FLOAT:
+    case PhysicalTypeID::INTERVAL: {
+        if (dataType.getLogicalTypeID() == LogicalTypeID::SERIAL) {
+            chunk = std::make_unique<ColumnChunk>(LogicalType(LogicalTypeID::SERIAL),
+                false /*enableCompression*/, false /* hasNullChunk */);
+        } else {
+            chunk = std::make_unique<ColumnChunk>(dataType, enableCompression);
+        }
+    } break;
+    case PhysicalTypeID::FIXED_LIST: {
+        chunk = std::make_unique<FixedListColumnChunk>(dataType, enableCompression);
+    } break;
+    case PhysicalTypeID::STRING: {
+        chunk = std::make_unique<StringColumnChunk>(dataType);
+    } break;
+    case PhysicalTypeID::VAR_LIST: {
+        chunk = std::make_unique<VarListColumnChunk>(dataType, enableCompression);
+    } break;
+    case PhysicalTypeID::STRUCT: {
+        chunk = std::make_unique<StructColumnChunk>(dataType, enableCompression);
+    } break;
+    default: {
+        throw NotImplementedException("ColumnChunkFactory::createColumnChunk for data type " +
+                                      LogicalTypeUtils::dataTypeToString(dataType) +
+                                      " is not supported.");
+    }
+    }
+    return chunk;
 }
 
 } // namespace storage

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -11,12 +11,12 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-NodeGroup::NodeGroup(TableSchema* schema, CSVReaderConfig* csvReaderConfig, bool enableCompression)
+NodeGroup::NodeGroup(TableSchema* schema, bool enableCompression)
     : nodeGroupIdx{UINT64_MAX}, numNodes{0} {
     chunks.reserve(schema->properties.size());
     for (auto& property : schema->properties) {
-        chunks.push_back(ColumnChunkFactory::createColumnChunk(
-            *property->getDataType(), enableCompression, csvReaderConfig));
+        chunks.push_back(
+            ColumnChunkFactory::createColumnChunk(*property->getDataType(), enableCompression));
     }
 }
 
@@ -52,7 +52,7 @@ uint64_t NodeGroup::append(
             continue;
         }
         auto dataPos = dataPoses[i - serialSkip];
-        chunk->append(resultSet->getValueVector(dataPos).get(), numNodes, numValuesToAppendInChunk);
+        chunk->append(resultSet->getValueVector(dataPos).get(), numNodes);
     }
     resultSet->getDataChunk(dataPoses[0].dataChunkPos)->state->selVector->selectedSize =
         originalVectorSize;

--- a/src/storage/store/string_column_chunk.cpp
+++ b/src/storage/store/string_column_chunk.cpp
@@ -10,9 +10,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-StringColumnChunk::StringColumnChunk(
-    LogicalType dataType, std::unique_ptr<CSVReaderConfig> csvReaderConfig)
-    : ColumnChunk{std::move(dataType), std::move(csvReaderConfig)} {
+StringColumnChunk::StringColumnChunk(LogicalType dataType) : ColumnChunk{std::move(dataType)} {
     overflowFile = std::make_unique<InMemOverflowFile>();
     overflowCursor.pageIdx = 0;
     overflowCursor.offsetInPage = 0;
@@ -24,7 +22,7 @@ void StringColumnChunk::resetToEmpty() {
     overflowCursor.resetValue();
 }
 
-void StringColumnChunk::append(common::ValueVector* vector, common::offset_t startPosInChunk) {
+void StringColumnChunk::append(ValueVector* vector, offset_t startPosInChunk) {
     assert(vector->dataType.getPhysicalType() == PhysicalTypeID::STRING);
     ColumnChunk::copyVectorToBuffer(vector, startPosInChunk);
     auto stringsToSetOverflow = (ku_string_t*)(buffer.get() + startPosInChunk * numBytesPerValue);

--- a/src/storage/store/var_list_column_chunk.cpp
+++ b/src/storage/store/var_list_column_chunk.cpp
@@ -10,7 +10,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-void VarListDataColumnChunk::reset() {
+void VarListDataColumnChunk::reset() const {
     dataColumnChunk->resetToEmpty();
 }
 
@@ -24,13 +24,10 @@ void VarListDataColumnChunk::resizeBuffer(uint64_t numValues) {
     dataColumnChunk->resize(capacity);
 }
 
-VarListColumnChunk::VarListColumnChunk(LogicalType dataType,
-    std::unique_ptr<common::CSVReaderConfig> csvReaderConfig, bool enableCompression)
-    : ColumnChunk{std::move(dataType), std::move(csvReaderConfig), enableCompression,
-          true /* hasNullChunk */},
-      varListDataColumnChunk{
-          ColumnChunkFactory::createColumnChunk(*VarListType::getChildType(&this->dataType),
-              enableCompression, this->csvReaderConfig.get())} {
+VarListColumnChunk::VarListColumnChunk(LogicalType dataType, bool enableCompression)
+    : ColumnChunk{std::move(dataType), enableCompression, true /* hasNullChunk */},
+      varListDataColumnChunk{ColumnChunkFactory::createColumnChunk(
+          *VarListType::getChildType(&this->dataType), enableCompression)} {
     assert(this->dataType.getPhysicalType() == PhysicalTypeID::VAR_LIST);
 }
 

--- a/src/storage/store/var_list_node_column.cpp
+++ b/src/storage/store/var_list_node_column.cpp
@@ -110,7 +110,7 @@ void VarListNodeColumn::scanUnfiltered(Transaction* transaction, node_group_idx_
     auto startListOffsetInStorage = listOffsetInfoInStorage.getListOffset(0);
     auto endListOffsetInStorage = listOffsetInfoInStorage.getListOffset(numValuesToScan);
     dataNodeColumn->scan(transaction, nodeGroupIdx, startListOffsetInStorage,
-        endListOffsetInStorage, ListVector::getDataVector(resultVector));
+        endListOffsetInStorage, ListVector::getDataVector(resultVector), 0 /* offsetInVector */);
 }
 
 void VarListNodeColumn::scanFiltered(Transaction* transaction, node_group_idx_t nodeGroupIdx,
@@ -175,7 +175,7 @@ ListOffsetInfoInStorage VarListNodeColumn::getListOffsetInfoInStorage(Transactio
         offsetVector->setState(state);
         NodeColumn::scan(transaction, nodeGroupIdx, startOffsetInNodeGroup + numOffsetsRead,
             startOffsetInNodeGroup + numOffsetsRead + numOffsetsToReadInCurBatch,
-            offsetVector.get());
+            offsetVector.get(), 0 /* offsetInVector */);
         offsetVectors.push_back(std::move(offsetVector));
         numOffsetsRead += numOffsetsToReadInCurBatch;
     }


### PR DESCRIPTION
- Remove `CSVReaderConfig` from ColumnChunk.
- Move child chunks and columns into struct specific data structures.
- Merge `initialize` and `resize` logic in BooleanColumnChunk into ColumnChunk.