### PR TITLE
Fix hash node rel

### DIFF
--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -127,6 +127,8 @@ std::unique_ptr<BoundProjectionBody> Binder::bindProjectionBody(
         }
     }
     if (!groupByExpressions.empty()) {
+        // TODO(Xiyang): we can remove augment group by. But make sure we test sufficient including
+        // edge case and bug before release.
         expression_vector augmentedGroupByExpressions = groupByExpressions;
         for (auto& expression : groupByExpressions) {
             if (ExpressionUtil::isNodeVariable(*expression)) {

--- a/src/function/vector_hash_functions.cpp
+++ b/src/function/vector_hash_functions.cpp
@@ -53,6 +53,19 @@ void VectorHashFunction::computeHash(ValueVector* operand, ValueVector* result) 
     case PhysicalTypeID::INTERVAL: {
         UnaryHashFunctionExecutor::execute<interval_t, hash_t>(*operand, *result);
     } break;
+    case PhysicalTypeID::STRUCT: {
+        if (operand->dataType.getLogicalTypeID() == LogicalTypeID::NODE) {
+            assert(0 == common::StructType::getFieldIdx(&operand->dataType, InternalKeyword::ID));
+            UnaryHashFunctionExecutor::execute<internalID_t, hash_t>(
+                *StructVector::getFieldVector(operand, 0), *result);
+            break;
+        } else if (operand->dataType.getLogicalTypeID() == LogicalTypeID::REL) {
+            assert(3 == StructType::getFieldIdx(&operand->dataType, InternalKeyword::ID));
+            UnaryHashFunctionExecutor::execute<internalID_t, hash_t>(
+                *StructVector::getFieldVector(operand, 3), *result);
+            break;
+        }
+    }
     default: {
         throw RuntimeException(
             "Cannot hash data type " +

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -32,7 +32,7 @@ struct HashSlot {
  *
  */
 class AggregateHashTable;
-using compare_function_t = std::function<bool(const uint8_t*, const uint8_t*)>;
+using compare_function_t = std::function<bool(common::ValueVector*, uint32_t, const uint8_t*)>;
 using update_agg_function_t =
     std::function<void(AggregateHashTable*, const std::vector<common::ValueVector*>&,
         const std::vector<common::ValueVector*>&, std::unique_ptr<function::AggregateFunction>&,
@@ -181,16 +181,8 @@ private:
 
     void resizeHashTableIfNecessary(uint32_t maxNumDistinctHashKeys);
 
-    template<typename type>
-    static bool compareEntryWithKeys(const uint8_t* keyValue, const uint8_t* entry) {
-        uint8_t result;
-        kuzu::function::Equals::operation(*(type*)keyValue, *(type*)entry, result,
-            nullptr /* leftVector */, nullptr /* rightVector */);
-        return result != 0;
-    }
-
     static void getCompareEntryWithKeysFunc(
-        common::PhysicalTypeID physicalType, compare_function_t& func);
+        const common::LogicalType& logicalType, compare_function_t& func);
 
     void updateNullAggVectorState(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors,

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -27,3 +27,38 @@
 -STATEMENT MATCH (t:Test) RETURN t;
 ---- 1
 {_ID: 0:0, _LABEL: Test, id: 0, content: mycontent}
+
+-CASE Kind-Of-Fruit
+-STATEMENT CREATE NODE TABLE T(name STRING, PRIMARY KEY(name));
+---- ok
+-STATEMENT CREATE NODE TABLE Fruit(name STRING, PRIMARY KEY(name));
+---- ok
+-STATEMENT CREATE REL TABLE LIKES(FROM T TO Fruit);
+---- ok
+-STATEMENT CREATE REL TABLE KIND_OF(FROM T TO T);
+---- ok
+-STATEMENT CREATE
+        (t1:T {name: "T1"}),
+        (t2:T {name: "T2"}),
+        (t3:T {name: "T3"}),
+        (f1:Fruit {name: "Banana"}),
+        (f2:Fruit {name: "Orange"}),
+        (f3:Fruit {name: "Apple"}),
+        (t1)-[:LIKES]->(f1),
+        (t2)-[:LIKES]->(f2),
+        (t3)-[:LIKES]->(f3),
+        (t1)-[:KIND_OF]->(t2),
+        (t2)-[:KIND_OF]->(t3);
+---- ok
+-STATEMENT MATCH (t1:T)-[:KIND_OF*]->(t2:T), (t1)-[:LIKES]->(f1:Fruit), (t2)-[:LIKES]->(f2:Fruit)
+            WHERE f1.name = "Apple" and f2.name = "Banana" OR f1.name = "Banana" and f2.name = "Apple" return t1 as t
+---- 1
+{_ID: 0:0, _LABEL: T, name: T1}
+-STATEMENT MATCH (t:T)-[:LIKES]->(:Fruit {name: "Apple"}), (t)-[:LIKES]->(:Fruit {name: "Banana"}) return t;
+---- 0
+-STATEMENT MATCH (t1:T)-[:KIND_OF*]->(t2:T), (t1)-[:LIKES]->(f1:Fruit), (t2)-[:LIKES]->(f2:Fruit)
+            WHERE f1.name = "Apple" and f2.name = "Banana" OR f1.name = "Banana" and f2.name = "Apple" return t1 as t
+           UNION
+           MATCH (t:T)-[:LIKES]->(:Fruit {name: "Apple"}), (t)-[:LIKES]->(:Fruit {name: "Banana"}) return t;
+---- 1
+{_ID: 0:0, _LABEL: T, name: T1}

--- a/test/test_files/tinysnb/agg/distinct_agg.test
+++ b/test/test_files/tinysnb/agg/distinct_agg.test
@@ -41,3 +41,25 @@
 ---- 2
 1|[True,False]
 2|[True,False]
+
+-STATEMENT MATCH (p:person)-[:knows]->(b:person)-[:knows]->(c:person) RETURN DISTINCT c;
+---- 4
+{_ID: 0:0, _LABEL: person, ID: 0, fName: Alice, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000}
+{_ID: 0:1, _LABEL: person, ID: 2, fName: Bob, gender: 2, isStudent: True, isWorker: False, age: 30, eyeSight: 5.100000, birthdate: 1900-01-01, registerTime: 2008-11-03 15:25:30.000526, lastJobDuration: 10 years 5 months 13:00:00.000024, workedHours: [12,8], usedNames: [Bobby], courseScoresPerTerm: [[8,9],[9,10]], grades: [98,42,93,88], height: 0.990000}
+{_ID: 0:2, _LABEL: person, ID: 3, fName: Carol, gender: 1, isStudent: False, isWorker: True, age: 45, eyeSight: 5.000000, birthdate: 1940-06-22, registerTime: 1911-08-20 02:32:21, lastJobDuration: 48:24:11, workedHours: [4,5], usedNames: [Carmen,Fred], courseScoresPerTerm: [[8,10]], grades: [91,75,21,95], height: 1.000000}
+{_ID: 0:3, _LABEL: person, ID: 5, fName: Dan, gender: 2, isStudent: False, isWorker: True, age: 20, eyeSight: 4.800000, birthdate: 1950-07-23, registerTime: 2031-11-30 12:25:30, lastJobDuration: 10 years 5 months 13:00:00.000024, workedHours: [1,9], usedNames: [Wolfeschlegelstein,Daniel], courseScoresPerTerm: [[7,4],[8,8],[9]], grades: [76,88,99,89], height: 1.300000}
+
+-STATEMENT MATCH (p:person)-[:knows]->(b:person)-[e:knows]->(c:person)-[:knows]->(:person) RETURN DISTINCT e;
+---- 12
+(0:0)-{_LABEL: knows, _ID: 3:0, date: 2021-06-30, meetTime: 1986-10-21 21:08:31.521, validInterval: 10 years 5 months 13:00:00.000024, comments: [rnme,m8sihsdnf2990nfiwf]}->(0:1)
+(0:0)-{_LABEL: knows, _ID: 3:1, date: 2021-06-30, meetTime: 1946-08-25 19:07:22, validInterval: 20 years 30 days 48:00:00, comments: [njnojppo9u0jkmf,fjiojioh9h9h89hph]}->(0:2)
+(0:0)-{_LABEL: knows, _ID: 3:2, date: 2021-06-30, meetTime: 2012-12-11 20:07:22, validInterval: 10 days, comments: [ioji232,jifhe8w99u43434]}->(0:3)
+(0:1)-{_LABEL: knows, _ID: 3:3, date: 2021-06-30, meetTime: 1946-08-25 19:07:22, validInterval: 10 years 5 months 13:00:00.000024, comments: [2huh9y89fsfw23,23nsihufhw723]}->(0:0)
+(0:1)-{_LABEL: knows, _ID: 3:4, date: 1950-05-14, meetTime: 1946-08-25 19:07:22, validInterval: 00:23:00, comments: [fwehu9h9832wewew,23u9h989sdfsss]}->(0:2)
+(0:1)-{_LABEL: knows, _ID: 3:5, date: 1950-05-14, meetTime: 2012-12-11 20:07:22, validInterval: 20 years 30 days 48:00:00, comments: [fwh9y81232uisuiehuf,ewnuihxy8dyf232]}->(0:3)
+(0:2)-{_LABEL: knows, _ID: 3:6, date: 2021-06-30, meetTime: 2002-07-31 11:42:53.12342, validInterval: 40 days 30:00:00, comments: [fnioh8323aeweae34d,osd89e2ejshuih12]}->(0:0)
+(0:2)-{_LABEL: knows, _ID: 3:7, date: 1950-05-14, meetTime: 2007-02-12 12:11:42.123, validInterval: 00:28:00.03, comments: [fwh983-sdjisdfji,ioh89y32r2huir]}->(0:1)
+(0:2)-{_LABEL: knows, _ID: 3:8, date: 2000-01-01, meetTime: 1998-10-02 13:09:22.423, validInterval: 00:00:00.3, comments: [psh989823oaaioe,nuiuah1nosndfisf]}->(0:3)
+(0:3)-{_LABEL: knows, _ID: 3:10, date: 1950-05-14, meetTime: 1982-11-11 13:12:05.123, validInterval: 00:23:00, comments: [fewh9182912e3,h9y8y89soidfsf,nuhudf78w78efw,hioshe0f9023sdsd]}->(0:1)
+(0:3)-{_LABEL: knows, _ID: 3:11, date: 2000-01-01, meetTime: 1999-04-21 15:12:11.42, validInterval: 48:00:00.052, comments: [23h9sdslnfowhu2932,shuhf98922323sf]}->(0:2)
+(0:3)-{_LABEL: knows, _ID: 3:9, date: 2021-06-30, meetTime: 1936-11-02 11:02:01, validInterval: 00:00:00.00048, comments: [fwewe]}->(0:0)


### PR DESCRIPTION
This PR fixes the bug when hashing NODE/REL where there is no dependent key.

We don't support hashing STRUCT, so hashing NODE/REL we always rewrite as hashing INTERNAL_ID and treat NODE/REL as dependent key i.e. payload. This rewrite fails for UNION because we don't have a way to rewrite the projection list of each subquery under UNION (technically we can but this is not the right way to approach the problem).

This PR adds hash function and compare function for NODE/REL data type.