### PR TITLE
Rust Union support

### DIFF
--- a/src/storage/store/struct_node_column.cpp
+++ b/src/storage/store/struct_node_column.cpp
@@ -60,7 +60,7 @@ void StructNodeColumn::writeInternal(
 
 void StructNodeColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {
     NodeColumn::append(columnChunk, nodeGroupIdx);
-    assert(columnChunk->getDataType().getLogicalTypeID() == LogicalTypeID::STRUCT);
+    assert(columnChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
     auto structColumnChunk = static_cast<StructColumnChunk*>(columnChunk);
     for (auto i = 0u; i < childColumns.size(); i++) {
         childColumns[i]->append(structColumnChunk->getChild(i), nodeGroupIdx);

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -42,7 +42,8 @@ std::unique_ptr<kuzu::common::LogicalType> create_logical_type_var_list(
 std::unique_ptr<kuzu::common::LogicalType> create_logical_type_fixed_list(
     std::unique_ptr<kuzu::common::LogicalType> childType, uint64_t numElements);
 std::unique_ptr<kuzu::common::LogicalType> create_logical_type_struct(
-    const rust::Vec<rust::String>& fieldNames, std::unique_ptr<TypeListBuilder> fieldTypes);
+    kuzu::common::LogicalTypeID typeID, const rust::Vec<rust::String>& fieldNames,
+    std::unique_ptr<TypeListBuilder> fieldTypes);
 std::unique_ptr<kuzu::common::LogicalType> create_logical_type_map(
     std::unique_ptr<kuzu::common::LogicalType> keyType,
     std::unique_ptr<kuzu::common::LogicalType> valueType);

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -192,6 +192,7 @@ pub(crate) mod ffi {
             num_elements: u64,
         ) -> UniquePtr<LogicalType>;
         fn create_logical_type_struct(
+            type_id: LogicalTypeID,
             field_names: &Vec<String>,
             types: UniquePtr<TypeListBuilder>,
         ) -> UniquePtr<LogicalType>;

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<LogicalType> create_logical_type_fixed_list(
         std::make_unique<FixedListTypeInfo>(std::move(childType), numElements));
 }
 
-std::unique_ptr<kuzu::common::LogicalType> create_logical_type_struct(
+std::unique_ptr<kuzu::common::LogicalType> create_logical_type_struct(LogicalTypeID typeID,
     const rust::Vec<rust::String>& fieldNames, std::unique_ptr<TypeListBuilder> fieldTypes) {
     std::vector<std::unique_ptr<StructField>> fields;
     for (auto i = 0u; i < fieldNames.size(); i++) {
@@ -41,7 +41,7 @@ std::unique_ptr<kuzu::common::LogicalType> create_logical_type_struct(
             std::string(fieldNames[i]), std::move(fieldTypes->types[i])));
     }
     return std::make_unique<LogicalType>(
-        LogicalTypeID::STRUCT, std::make_unique<kuzu::common::StructTypeInfo>(std::move(fields)));
+        typeID, std::make_unique<kuzu::common::StructTypeInfo>(std::move(fields)));
 }
 
 std::unique_ptr<kuzu::common::LogicalType> create_logical_type_map(


### PR DESCRIPTION
I encountered a minor issue after rebasing onto the most recent commits: that the StructNodeColumn was asserting that the logical type is `STRUCT`, while that code is also being used for unions.

I also updated the documentation links in the rust-doc to the new locations.