### PR TITLE
Validate file header for LOAD and COPY

### DIFF
--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -162,6 +162,18 @@ private:
         const parser::ReadingClause& readingClause);
     std::unique_ptr<BoundReadingClause> bindInQueryCall(const parser::ReadingClause& readingClause);
     std::unique_ptr<BoundReadingClause> bindLoadFrom(const parser::ReadingClause& readingClause);
+    expression_vector createColumnExpressions(common::ReaderConfig& readerConfig,
+        const std::vector<std::string>& columnNames,
+        const std::vector<std::unique_ptr<common::LogicalType>>& columnTypes);
+    void sniffFiles(const common::ReaderConfig& readerConfig, std::vector<std::string>& columnNames,
+        std::vector<std::unique_ptr<common::LogicalType>>& columnTypes);
+    void sniffFile(const common::ReaderConfig& readerConfig, uint32_t fileIdx,
+        std::vector<std::string>& columnNames,
+        std::vector<std::unique_ptr<common::LogicalType>>& columnTypes);
+    static void validateNumColumns(uint32_t expectedNumber, uint32_t detectedNumber);
+    static void validateColumnTypes(const std::vector<std::string>& expectedColumnNames,
+        const std::vector<std::unique_ptr<common::LogicalType>>& expectedColumnTypes,
+        const std::vector<std::unique_ptr<common::LogicalType>>& detectedColumnTypes);
 
     /*** bind updating clause ***/
     // TODO(Guodong/Xiyang): Is update clause an accurate name? How about (data)modificationClause?

--- a/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
@@ -29,9 +29,6 @@ protected:
     void addValue(Driver&, uint64_t rowNum, common::column_id_t columnIdx, std::string_view strVal,
         std::vector<uint64_t>& escapePositions);
 
-    template<typename Driver>
-    bool addRow(Driver&, uint64_t rowNum, common::column_id_t column_count);
-
     //! Read BOM and header.
     void handleFirstBlock();
 

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -62,6 +62,7 @@ struct SniffCSVNameAndTypeDriver {
 };
 
 struct SniffCSVColumnCountDriver {
+    bool emptyRow = true;
     uint64_t numColumns = 0;
 
     bool done(uint64_t rowNum);

--- a/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
@@ -158,11 +158,6 @@ void BaseCSVReader::addValue(Driver& driver, uint64_t rowNum, column_id_t column
     }
 }
 
-template<typename Driver>
-bool BaseCSVReader::addRow(Driver& driver, uint64_t rowNum, column_id_t column) {
-    return driver.addRow(rowNum, column);
-}
-
 void BaseCSVReader::handleFirstBlock() {
     readBOM();
     if (csvReaderConfig.hasHeader) {
@@ -308,7 +303,7 @@ add_row : {
         std::string_view(buffer.get() + start, position - start - hasQuotes), escapePositions);
     column++;
 
-    rowNum += addRow(driver, rowNum, column);
+    rowNum += driver.addRow(rowNum, column);
 
     column = 0;
     position++;
@@ -423,7 +418,7 @@ final_state:
         column++;
     }
     if (column > 0) {
-        rowNum += addRow(driver, rowNum, column);
+        rowNum += driver.addRow(rowNum, column);
     }
     return rowNum;
 }

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -612,14 +612,24 @@ bool SniffCSVNameAndTypeDriver::addRow(uint64_t, common::column_id_t) {
 }
 
 bool SniffCSVColumnCountDriver::done(uint64_t) {
-    return true;
+    return !emptyRow;
 }
 
-void SniffCSVColumnCountDriver::addValue(uint64_t, common::column_id_t, std::string_view value) {
+void SniffCSVColumnCountDriver::addValue(
+    uint64_t, common::column_id_t columnIdx, std::string_view value) {
+    if (value != "" || columnIdx > 0) {
+        emptyRow = false;
+    }
     numColumns++;
 }
 
 bool SniffCSVColumnCountDriver::addRow(uint64_t, common::column_id_t) {
+    if (emptyRow) {
+        // If this is the last row, we just return zero: we don't know how many columns there are
+        // supposed to be.
+        numColumns = 0;
+        return false;
+    }
     return true;
 }
 

--- a/test/test_files/exceptions/copy/wrong_header.test
+++ b/test/test_files/exceptions/copy/wrong_header.test
@@ -3,6 +3,78 @@
 
 --
 
+-CASE CSVHeaderMismatch
+-STATEMENT CREATE NODE TABLE person (ID INT64, fName STRING, PRIMARY KEY (ID))
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPerson.csv" (HEADER=true)
+---- ok
+-STATEMENT CREATE NODE TABLE person1 (ID STRING, fName STRING, PRIMARY KEY (ID))
+---- ok
+-STATEMENT CREATE NODE TABLE person2 (ID STRING, fName INT64, PRIMARY KEY (ID));
+---- ok
+-STATEMENT CREATE NODE TABLE person3 (ID STRING, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person1 FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPerson.csv" (HEADER=true)
+---- ok
+-STATEMENT MATCH (a:person1) RETURN a.ID STARTS WITH '1';
+---- 3
+False
+False
+True
+-STATEMENT COPY person2 FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPerson.csv" (HEADER=true)
+---- error
+Conversion exception: Cast failed. Guodong is not in INT64 range.
+-STATEMENT COPY person3 FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPerson.csv" (HEADER=true)
+---- error
+Binder exception: Number of columns mismatch. Expected 1 but got 2.
+-STATEMENT COPY person FROM
+       ["${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPerson.csv",
+        "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPersonMissingColumn.csv"] (HEADER=true)
+---- error
+Binder exception: Number of columns mismatch. Expected 2 but got 1.
+-STATEMENT CREATE REL TABLE knows (FROM person TO person, prop1 INTERVAL);
+---- ok
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/eKnowsWrongColumnName.csv" (HEADER=true)
+---- error
+Binder exception: Number of columns mismatch. Expected 3 but got 4.
+-STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/eKnowsMissingColumn.csv" (HEADER=true)
+---- error
+Conversion exception: Error occurred during parsing interval. Field name is missing.
+
+-CASE ParquetHeaderMismatch
+-STATEMENT CREATE NODE TABLE User(name STRING, age INT64, PRIMARY KEY (name));
+---- ok
+-STATEMENT CREATE NODE TABLE User1(name INT64, age INT64, PRIMARY KEY (name));
+---- ok
+-STATEMENT CREATE NODE TABLE User2(name INT64, age INT64, dummy INT32[], PRIMARY KEY (name));
+---- ok
+-STATEMENT CREATE NODE TABLE User3(name STRING, age INT16[], PRIMARY KEY (name));
+---- ok
+-STATEMENT COPY User FROM "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/user.parquet";
+---- ok
+-STATEMENT COPY User1 FROM "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/user.parquet";
+---- error
+Binder exception: Column `name` type mismatch. Expected INT64 but got STRING.
+-STATEMENT COPY User1 FROM ["${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/user.parquet",
+                            "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/lives-in.parquet"];
+---- error
+Binder exception: Column `f1` type mismatch. Expected INT64 but got STRING.
+-STATEMENT COPY User2 FROM "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/user.parquet";
+---- error
+Binder exception: Number of columns mismatch. Expected 3 but got 2.
+-STATEMENT COPY User3 FROM "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/user.parquet";
+---- error
+Binder exception: Column `age` type mismatch. Expected INT16[] but got INT64.
+-STATEMENT CREATE REL TABLE Follows1(FROM User TO User, since INT64[]);
+---- ok
+-STATEMENT COPY Follows1 FROM "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/follows.parquet";
+---- error
+Binder exception: Column `since` type mismatch. Expected INT64[] but got INT64.
+-STATEMENT COPY Follows1 FROM ["${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/follows.parquet",
+                               "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/lives-in.parquet"];
+---- error
+Binder exception: Number of columns mismatch. Expected 3 but got 2.
+
 -CASE UnMatchedColumnTypeError
 -STATEMENT create node table person (ID INT64, fName INT64, gender INT64, isStudent BOOLEAN,
                                      isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE,
@@ -43,16 +115,14 @@ Copy exception: COPY commands can only be executed once on a table.
 ---- ok
 -STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/eKnowsMissingColumn.csv" (HEADER=true)
 ---- error
-Copy exception: Invalid: CSV parse error: Expected 4 columns, got 3: 10,24,1
+Binder exception: Number of columns mismatch. Expected 4 but got 3.
 
 -CASE NodeUnmatchedNumColumns
--SKIP
-#binder needs to check the number of columns
 -STATEMENT create node table person (ID1 SERIAL, ID INT64, fName INT64, age INT64, PRIMARY KEY (ID1))
 ---- ok
 -STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/types_50k_1.parquet" (HEADER=true)
 ---- error
-Copy exception: Unmatched number of columns in parquet file. Expect: 3, got: 13.
+Binder exception: Number of columns mismatch. Expected 3 but got 10.
 
 -CASE RelUnmatchedNumColumns
 -STATEMENT create node table person (ID1 SERIAL, ID INT64, fName INT64, age INT64, PRIMARY KEY (ID1))
@@ -61,4 +131,4 @@ Copy exception: Unmatched number of columns in parquet file. Expect: 3, got: 13.
 ---- ok
 -STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/follows.parquet" (HEADER=true)
 ---- error
-Copy exception: Unmatched number of columns in parquet file. Expect: 4, got: 3.
+Binder exception: Number of columns mismatch. Expected 4 but got 3.

--- a/test/test_files/tinysnb/cast/cast_string_to_other_type.test
+++ b/test/test_files/tinysnb/cast/cast_string_to_other_type.test
@@ -50,7 +50,7 @@ Conversion exception: Cast failed. "((hello),(bdfadf),)" is not in STRING[][] ra
 Conversion exception: Cast failed. (() is not in STRING[][] range.
 -STATEMENT LOAD WITH HEADERS (list INT32[]) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/quote_fail.csv" RETURN * ;
 ---- error
-Binder exception: Number of columns mismatch. Detect 3 but expect 1.
+Binder exception: Number of columns mismatch. Expected 1 but got 3.
 -STATEMENT LOAD WITH HEADERS (list STRING[]) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/single_quote.csv" RETURN *;
 ---- error
 Conversion exception: Cast failed. ['fdsfdsfe werw] is not in STRING[] range.

--- a/test/test_files/tinysnb/load_from/load_from.test
+++ b/test/test_files/tinysnb/load_from/load_from.test
@@ -4,7 +4,6 @@
 --
 
 -CASE LoadFromNpyTest
--SKIP
 -STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/npy-1d/one_dim_double.npy" RETURN * ORDER BY column0 LIMIT 5;
 ---- 3
 1.000000
@@ -21,18 +20,17 @@
 [7,8,9]
 
 -CASE LoadFromParquetTest
--SKIP
 -STATEMENT LOAD WITH HEADERS (id INT64) FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/types_50k_0.parquet" RETURN *;
 ---- error
-Binder exception: Number of columns mismatch. Detect 10 but expect 1.
+Binder exception: Number of columns mismatch. Expected 1 but got 10.
 -STATEMENT LOAD WITH HEADERS (id INT64, int64Column INT64, doubleColumn DOUBLE, booleanColumn BOOLEAN, dateColumn DATE, stringColumn STRING, listOfInt64 INT64[], listOfString STRING[], listOfListOfInt64 INT64[][], structColumn STRUCT(ID int64, name STRING))
             FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/types_50k_0.parquet" RETURN id, dateColumn ORDER BY id LIMIT 1;
 ---- 1
 0|1994-01-12
 -STATEMENT LOAD WITH HEADERS (id INT64, int64Column INT64, doubleColumn INT64, booleanColumn INT64, dateColumn INT64, stringColumn INT64, listOfInt64 INT64, listOfString INT64, listOfListOfInt64 INT64, structColumn INT64)
             FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/types_50k_0.parquet" RETURN * ORDER BY id LIMIT 1;
----- 1
-Binder exception: Column doubleColumn data type mismatch. Detect DOUBLE but expect INT64.
+---- error
+Binder exception: Column `doubleColumn` type mismatch. Expected INT64 but got DOUBLE.
 -STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/types_50k_0.parquet" RETURN * ORDER BY id LIMIT 5;
 ---- 5
 0|73|3.258507|True|1994-01-12|FrPZkcHFuepVxcAiMwyAsRqDlRtQx|[65,25]|[4deQc5]|[[163,237],[28,60,77,31,137],[286,186,249,206]]|{id: 764, name: CwFRaCoEp}
@@ -63,12 +61,19 @@ Greg|0|1994-01-12
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0|1994-01-12
 -STATEMENT LOAD FROM  "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/rdf/taxonomy.ttl" RETURN COUNT(*)
 ---- error
-Binder exception: Load from TURTLE file is not supported.
+Binder exception: Cannot sniff header of file type TURTLE
+-STATEMENT LOAD WITH HEADERS (a INT64, b INT64) FROM "${KUZU_ROOT_DIRECTORY}/dataset/demo-db/parquet/user.parquet" RETURN *;
+---- error
+Binder exception: Column `a` type mismatch. Expected INT64 but got STRING.
+-STATEMENT LOAD WITH HEADERS (id INT64, int64Column INT64, doubleColumn DOUBLE, booleanColumn BOOLEAN, dateColumn INT32, stringColumn STRING, listOfInt64 INT64[], listOfString STRING[], listOfListOfInt64 INT64[][], structColumn STRUCT(ID int64, name STRING))
+       FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/parquet/types_50k_0.parquet" RETURN *;
+---- error
+Binder exception: Column `dateColumn` type mismatch. Expected INT32 but got DATE.
 
 -CASE LoadFromCSVTest
 -STATEMENT LOAD WITH HEADERS (a INT64) FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/eStudyAt.csv" (HEADER=True) RETURN `from`, `to`, YEAR, Places;
 ---- error
-Binder exception: Number of columns mismatch. Detect 10 but expect 1.
+Binder exception: Number of columns mismatch. Expected 1 but got 10.
 -STATEMENT LOAD WITH HEADERS (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], grades INT64[4], height float) FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" (HEADER=True)
             RETURN fName, gender, birthdate;
 ---- 8


### PR DESCRIPTION
This PR partially solves issue #2139.

We add several validation to COPY and LOAD FROM 

- number of columns should match DDL or specified header.
- for parquet, column type should match DDL or specified header. Note that this is not the final solution. Eventually we should allow casting inside parquet reader.