### PR TITLE
Fix transaction test

### DIFF
--- a/test/include/main_test_helper/private_main_test_helper.h
+++ b/test/include/main_test_helper/private_main_test_helper.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace testing {
 
-class PrivateApiTest : public BaseGraphTest {
+class PrivateApiTest : public DBTest {
 public:
     void SetUp() override {
         BaseGraphTest::SetUp();

--- a/test/main/CMakeLists.txt
+++ b/test/main/CMakeLists.txt
@@ -10,4 +10,4 @@ add_kuzu_api_test(main_test
 
 # Also tested for coverage in connection_test.cpp
 # but full testing requires some private APIs
-add_kuzu_test(transaction_test.cpp)
+add_kuzu_test(transaction_test transaction_test.cpp)


### PR DESCRIPTION
When moving this to a separate test file, I forgot to add the test name, so it produced an empty test called `transaction_test.cpp`. The test was also broken following some refactoring of #2153.