### PR TITLE
Reduce number of test query threads

### DIFF
--- a/test/include/graph_test/base_graph_test.h
+++ b/test/include/graph_test/base_graph_test.h
@@ -32,7 +32,8 @@ class BaseGraphTest : public Test {
 public:
     void SetUp() override {
         systemConfig = std::make_unique<main::SystemConfig>(
-            common::BufferPoolConstants::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING);
+            common::BufferPoolConstants::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING,
+            2 /*numThreadsForExec*/);
         setDatabasePath();
         removeDir(databasePath);
     }


### PR DESCRIPTION
Seems to significantly slow down our tests as they work with many small operations on systems with many processors. Particularly when running many tests in parallel, it seems unnecessary to use the default number of threads.

~~Testing to see what the speedup is for CI~~ Seems like an improvement compared to the last time CI was this quiet; oddly windows doesn't seem any different from the previous run, but that machine doesn't have as many threads, and is running much faster since I stopped the antivirus from scanning the test database files anyway.