### PR TITLE
Add access mode option to Rust API

### DIFF
--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -49,7 +49,6 @@ static void getLockFileFlagsAndType(
     AccessMode accessMode, bool createNew, int& flags, FileLockType& lock) {
     flags = accessMode == AccessMode::READ_ONLY ? O_RDONLY : O_RDWR;
     if (createNew) {
-        assert(flags == O_RDWR);
         flags |= O_CREAT;
     }
     lock = accessMode == AccessMode::READ_ONLY ? FileLockType::READ_LOCK : FileLockType::WRITE_LOCK;

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -60,7 +60,8 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
 
 /* Database */
 std::unique_ptr<kuzu::main::Database> new_database(const std::string& databasePath,
-    uint64_t bufferPoolSize, uint64_t maxNumThreads, bool enableCompression);
+    uint64_t bufferPoolSize, uint64_t maxNumThreads, bool enableCompression,
+    kuzu::main::AccessMode accessMode);
 
 void database_set_logging_level(kuzu::main::Database& database, const std::string& level);
 

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -46,9 +46,22 @@ pub(crate) mod ffi {
         MAP = 54,
         UNION = 55,
     }
+
     #[namespace = "kuzu::common"]
     unsafe extern "C++" {
         type LogicalTypeID;
+    }
+
+    #[namespace = "kuzu::main"]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum AccessMode {
+        READ_ONLY = 0,
+        READ_WRITE = 1,
+    }
+
+    #[namespace = "kuzu::main"]
+    unsafe extern "C++" {
+        type AccessMode;
     }
 
     #[namespace = "kuzu::main"]
@@ -84,6 +97,7 @@ pub(crate) mod ffi {
             bufferPoolSize: u64,
             maxNumThreads: u64,
             enableCompression: bool,
+            access_mode: AccessMode,
         ) -> Result<UniquePtr<Database>>;
 
         fn database_set_logging_level(database: Pin<&mut Database>, level: &CxxString);

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -78,7 +78,7 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
 }
 
 std::unique_ptr<Database> new_database(const std::string& databasePath, uint64_t bufferPoolSize,
-    uint64_t maxNumThreads, bool enableCompression) {
+    uint64_t maxNumThreads, bool enableCompression, kuzu::main::AccessMode accessMode) {
     auto systemConfig = SystemConfig();
     if (bufferPoolSize > 0) {
         systemConfig.bufferPoolSize = bufferPoolSize;
@@ -86,6 +86,7 @@ std::unique_ptr<Database> new_database(const std::string& databasePath, uint64_t
     if (maxNumThreads > 0) {
         systemConfig.maxNumThreads = maxNumThreads;
     }
+    systemConfig.accessMode = accessMode;
     systemConfig.enableCompression = enableCompression;
     return std::make_unique<Database>(databasePath, systemConfig);
 }

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -47,7 +47,7 @@ mod query_result;
 mod value;
 
 pub use connection::{Connection, PreparedStatement};
-pub use database::{Database, LoggingLevel, SystemConfig};
+pub use database::{AccessMode, Database, LoggingLevel, SystemConfig};
 pub use error::Error;
 pub use logical_type::LogicalType;
 pub use query_result::{CSVOptions, QueryResult};


### PR DESCRIPTION
Fixes #2230.

I removed an assert which is (in debug mode) unnecessarily masking the exception thrown when attempting to create a database in read only mode.