### PR TITLE
Remove friend classes and clean up write functions in NodeColumn

### DIFF
--- a/src/include/storage/local_table.h
+++ b/src/include/storage/local_table.h
@@ -64,7 +64,7 @@ struct LocalVectorFactory {
 
 class LocalColumnChunk {
 public:
-    explicit LocalColumnChunk(common::LogicalType& dataType, MemoryManager* mm)
+    explicit LocalColumnChunk(const common::LogicalType& dataType, MemoryManager* mm)
         : dataType{dataType}, mm{mm} {};
 
     void scan(common::vector_idx_t vectorIdx, common::ValueVector* resultVector);

--- a/src/include/storage/store/struct_node_column.h
+++ b/src/include/storage/store/struct_node_column.h
@@ -26,14 +26,14 @@ public:
         assert(childIdx < childColumns.size());
         return childColumns[childIdx].get();
     }
+    void write(common::offset_t nodeOffset, common::ValueVector* vectorToWriteFrom,
+        uint32_t posInVectorToWriteFrom) final;
 
 protected:
     void scanInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         common::ValueVector* resultVector) final;
     void lookupInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         common::ValueVector* resultVector) final;
-    void writeInternal(common::offset_t nodeOffset, common::ValueVector* vectorToWriteFrom,
-        uint32_t posInVectorToWriteFrom) final;
 
 private:
     std::vector<std::unique_ptr<NodeColumn>> childColumns;

--- a/src/storage/local_table.cpp
+++ b/src/storage/local_table.cpp
@@ -159,7 +159,7 @@ void LocalColumn::update(offset_t nodeOffset, ValueVector* propertyVector,
     sel_t posInPropertyVector, MemoryManager* mm) {
     auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeOffset);
     if (!chunks.contains(nodeGroupIdx)) {
-        chunks.emplace(nodeGroupIdx, std::make_unique<LocalColumnChunk>(column->dataType, mm));
+        chunks.emplace(nodeGroupIdx, std::make_unique<LocalColumnChunk>(column->getDataType(), mm));
     }
     auto chunk = chunks.at(nodeGroupIdx).get();
     auto [vectorIdxInChunk, offsetInVector] =
@@ -177,7 +177,7 @@ void LocalColumn::prepareCommitForChunk(node_group_idx_t nodeGroupIdx) {
     assert(chunks.contains(nodeGroupIdx));
     auto chunk = chunks.at(nodeGroupIdx).get();
     // Figure out if the chunk needs to be re-compressed
-    auto metadata = column->getCompressionMetadata(nodeGroupIdx, TransactionType::WRITE);
+    auto metadata = column->getMetadata(nodeGroupIdx, TransactionType::WRITE).compMeta;
     if (!metadata.canAlwaysUpdateInPlace()) {
         for (auto& [vectorIdx, vector] : chunk->vectors) {
             for (auto i = 0u; i < vector->vector->state->selVector->selectedSize; i++) {
@@ -252,9 +252,9 @@ void VarListLocalColumn::prepareCommitForChunk(node_group_idx_t nodeGroupIdx) {
     varListColumn->scan(nodeGroupIdx, listColumnChunkInStorage.get());
     offset_t nextOffsetToWrite = 0;
     auto numNodesInGroup =
-        nodeGroupIdx >= column->metadataDA->getNumElements() ?
+        nodeGroupIdx >= column->getNumNodeGroups(&DUMMY_READ_TRANSACTION) ?
             0 :
-            column->metadataDA->get(nodeGroupIdx, TransactionType::READ_ONLY).numValues;
+            column->getMetadata(nodeGroupIdx, TransactionType::READ_ONLY).numValues;
     for (auto& [vectorIdx, localVector] : chunk->vectors) {
         auto startOffsetInChunk = StorageUtils::getStartOffsetOfVectorInChunk(vectorIdx);
         auto listVector = localVector->vector.get();

--- a/src/storage/store/struct_node_column.cpp
+++ b/src/storage/store/struct_node_column.cpp
@@ -53,9 +53,9 @@ void StructNodeColumn::lookupInternal(
     }
 }
 
-void StructNodeColumn::writeInternal(
+void StructNodeColumn::write(
     offset_t nodeOffset, ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
-    nullColumn->writeInternal(nodeOffset, vectorToWriteFrom, posInVectorToWriteFrom);
+    nullColumn->write(nodeOffset, vectorToWriteFrom, posInVectorToWriteFrom);
 }
 
 void StructNodeColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {


### PR DESCRIPTION
A few things I noticed could be cleaned up.

- `NodeColumn::write(ValueVector* nodeIDVector, ValueVector* vectorToWriteFrom)` was only used in a function which was removed. 
- The remaining `write` function was equivalent to `writeInternal`, and there didn't really seem to be much of a reason to have that be protected.
-  The four NodeColumn friend classes were just using fields which are otherwise exposed by public functions (or could be, in the case of `getMetadata` and `write`)
- Removed a couple of unused headers.