### PR TITLE
third_party/re2: fix is_pod deprecation warning

### DIFF
--- a/third_party/re2/include/pod_array.h
+++ b/third_party/re2/include/pod_array.h
@@ -14,7 +14,7 @@ namespace regex {
 template<typename T>
 class PODArray {
 public:
-    static_assert(std::is_pod<T>::value, "T must be POD");
+    static_assert(std::is_trivial<T>::value && std::is_standard_layout<T>::value, "T must be POD");
 
     PODArray() : ptr_() {}
     explicit PODArray(int len) : ptr_(std::allocator<T>().allocate(len), Deleter(len)) {}


### PR DESCRIPTION
std::is_pod is deprecated in C++20. This was the noisiest of the warnings in our codebase.