### PR TITLE
Add graph pattern label pruning

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -53,7 +53,7 @@ std::unique_ptr<BoundStatement> Binder::bind(const Statement& statement) {
     default:
         throw NotImplementedException("Binder::bind");
     }
-    BoundStatementRewriter::rewrite(*boundStatement);
+    BoundStatementRewriter::rewrite(*boundStatement, catalog);
     return boundStatement;
 }
 

--- a/src/binder/bound_statement_rewriter.cpp
+++ b/src/binder/bound_statement_rewriter.cpp
@@ -1,13 +1,18 @@
 #include "binder/bound_statement_rewriter.h"
 
+#include "binder/rewriter/match_clause_pattern_label_rewriter.h"
 #include "binder/rewriter/with_clause_projection_rewriter.h"
 
 namespace kuzu {
 namespace binder {
 
-void BoundStatementRewriter::rewrite(BoundStatement& boundStatement) {
+void BoundStatementRewriter::rewrite(
+    BoundStatement& boundStatement, const catalog::Catalog& catalog) {
     auto withClauseProjectionRewriter = WithClauseProjectionRewriter();
     withClauseProjectionRewriter.visit(boundStatement);
+
+    auto matchClausePatternLabelRewriter = MatchClausePatternLabelRewriter(catalog);
+    matchClausePatternLabelRewriter.visit(boundStatement);
 }
 
 } // namespace binder

--- a/src/binder/query/CMakeLists.txt
+++ b/src/binder/query/CMakeLists.txt
@@ -5,7 +5,8 @@ add_library(
         bound_delete_clause.cpp
         bound_merge_clause.cpp
         bound_set_clause.cpp
-        query_graph.cpp)
+        query_graph.cpp
+        query_graph_label_analyzer.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_binder_query>

--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -1,0 +1,124 @@
+#include "binder/query/query_graph_label_analyzer.h"
+
+#include "catalog/rel_table_schema.h"
+#include "common/exception/binder.h"
+#include "common/string_format.h"
+
+using namespace kuzu::common;
+using namespace kuzu::catalog;
+
+namespace kuzu {
+namespace binder {
+
+void QueryGraphLabelAnalyzer::pruneLabel(const QueryGraph& graph) {
+    for (auto i = 0u; i < graph.getNumQueryNodes(); ++i) {
+        pruneNode(graph, *graph.getQueryNode(i));
+    }
+    for (auto i = 0u; i < graph.getNumQueryRels(); ++i) {
+        pruneRel(*graph.getQueryRel(i));
+    }
+}
+
+void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression& node) {
+    for (auto i = 0u; i < graph.getNumQueryRels(); ++i) {
+        auto queryRel = graph.getQueryRel(i);
+        if (queryRel->isRecursive()) {
+            continue;
+        }
+        common::table_id_set_t candidates;
+        auto isSrcConnect = *queryRel->getSrcNode() == node;
+        auto isDstConnect = *queryRel->getDstNode() == node;
+        if (queryRel->getDirectionType() == RelDirectionType::BOTH) {
+            if (isSrcConnect || isDstConnect) {
+                for (auto relTableID : queryRel->getTableIDs()) {
+                    auto relTableSchema = reinterpret_cast<RelTableSchema*>(
+                        catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                    candidates.insert(relTableSchema->getSrcTableID());
+                    candidates.insert(relTableSchema->getDstTableID());
+                }
+            }
+        } else {
+            if (isSrcConnect) {
+                for (auto relTableID : queryRel->getTableIDs()) {
+                    auto relTableSchema = reinterpret_cast<RelTableSchema*>(
+                        catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                    candidates.insert(relTableSchema->getSrcTableID());
+                }
+            } else if (isDstConnect) {
+                for (auto relTableID : queryRel->getTableIDs()) {
+                    auto relTableSchema = reinterpret_cast<RelTableSchema*>(
+                        catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                    candidates.insert(relTableSchema->getDstTableID());
+                }
+            }
+        }
+        if (candidates.empty()) {
+            return;
+        }
+        common::table_id_vector_t prunedTableIDs;
+        for (auto tableID : node.getTableIDs()) {
+            if (!candidates.contains(tableID)) {
+                continue;
+            }
+            prunedTableIDs.push_back(tableID);
+        }
+        if (prunedTableIDs.empty()) {
+            throw BinderException(stringFormat("Cannot find a label for node {} that connects to "
+                                               "all of its neighbour relationships.",
+                node.toString()));
+        }
+        node.setTableIDs(std::move(prunedTableIDs));
+    }
+}
+
+void QueryGraphLabelAnalyzer::pruneRel(RelExpression& rel) {
+    if (rel.isRecursive()) {
+        return;
+    }
+    common::table_id_vector_t prunedTableIDs;
+    if (rel.getDirectionType() == RelDirectionType::BOTH) {
+        common::table_id_set_t boundTableIDSet;
+        for (auto tableID : rel.getSrcNode()->getTableIDs()) {
+            boundTableIDSet.insert(tableID);
+        }
+        for (auto tableID : rel.getDstNode()->getTableIDs()) {
+            boundTableIDSet.insert(tableID);
+        }
+        for (auto& relTableID : rel.getTableIDs()) {
+            auto relTableSchema = reinterpret_cast<RelTableSchema*>(
+                catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+            auto srcTableID = relTableSchema->getSrcTableID();
+            auto dstTableID = relTableSchema->getDstTableID();
+            if (!boundTableIDSet.contains(srcTableID) || !boundTableIDSet.contains(dstTableID)) {
+                continue;
+            }
+            prunedTableIDs.push_back(relTableID);
+        }
+    } else {
+        auto srcTableIDSet = rel.getSrcNode()->getTableIDsSet();
+        auto dstTableIDSet = rel.getDstNode()->getTableIDsSet();
+        for (auto& relTableID : rel.getTableIDs()) {
+            auto relTableSchema = reinterpret_cast<RelTableSchema*>(
+                catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+            auto srcTableID = relTableSchema->getSrcTableID();
+            auto dstTableID = relTableSchema->getDstTableID();
+            if (!srcTableIDSet.contains(srcTableID) || !dstTableIDSet.contains(dstTableID)) {
+                continue;
+            }
+            prunedTableIDs.push_back(relTableID);
+        }
+    }
+    // Note the pruning for node should guarantee the following exception won't be triggered.
+    // For safety (and consistency) reason, we still write the check but skip coverage check.
+    // LCOV_EXEL_START
+    if (prunedTableIDs.empty()) {
+        throw BinderException(stringFormat(
+            "Cannot find a label for relationship {} that connects to all of its neighbour nodes.",
+            rel.toString()));
+    }
+    // LCOV_EXEL_STOP
+    rel.setTableIDs(std::move(prunedTableIDs));
+}
+
+} // namespace binder
+} // namespace kuzu

--- a/src/binder/rewriter/CMakeLists.txt
+++ b/src/binder/rewriter/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(
         kuzu_binder_rewriter
         OBJECT
+        match_clause_pattern_label_rewriter.cpp
         with_clause_projection_rewriter.cpp)
 
 set(ALL_OBJECT_FILES

--- a/src/binder/rewriter/match_clause_pattern_label_rewriter.cpp
+++ b/src/binder/rewriter/match_clause_pattern_label_rewriter.cpp
@@ -1,0 +1,22 @@
+#include "binder/rewriter/match_clause_pattern_label_rewriter.h"
+
+#include "binder/query/reading_clause/bound_match_clause.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace binder {
+
+void MatchClausePatternLabelRewriter::visitMatch(const BoundReadingClause& readingClause) {
+    auto matchClause = reinterpret_cast<const BoundMatchClause&>(readingClause);
+    if (matchClause.getMatchClauseType() == MatchClauseType::OPTIONAL_MATCH) {
+        return;
+    }
+    auto collection = matchClause.getQueryGraphCollection();
+    for (auto i = 0u; i < collection->getNumQueryGraphs(); ++i) {
+        analyzer.pruneLabel(*collection->getQueryGraph(i));
+    }
+}
+
+} // namespace binder
+} // namespace kuzu

--- a/src/include/binder/bound_statement_rewriter.h
+++ b/src/include/binder/bound_statement_rewriter.h
@@ -1,13 +1,15 @@
 #pragma once
 
 #include "bound_statement.h"
+#include "catalog/catalog.h"
 
 namespace kuzu {
 namespace binder {
 
+// Perform semantic rewrite over bound statement.
 class BoundStatementRewriter {
 public:
-    static void rewrite(BoundStatement& boundStatement);
+    static void rewrite(BoundStatement& boundStatement, const catalog::Catalog& catalog);
 };
 
 } // namespace binder

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -17,7 +17,10 @@ public:
 
     inline std::string getVariableName() const { return variableName; }
 
-    inline void addTableIDs(const std::vector<common::table_id_t>& tableIDsToAdd) {
+    inline void setTableIDs(common::table_id_vector_t tableIDs) {
+        this->tableIDs = std::move(tableIDs);
+    }
+    inline void addTableIDs(const common::table_id_vector_t& tableIDsToAdd) {
         auto tableIDsSet = getTableIDsSet();
         for (auto tableID : tableIDsToAdd) {
             if (!tableIDsSet.contains(tableID)) {
@@ -25,6 +28,7 @@ public:
             }
         }
     }
+
     inline bool isMultiLabeled() const { return tableIDs.size() > 1; }
     inline uint32_t getNumTableIDs() const { return tableIDs.size(); }
     inline std::vector<common::table_id_t> getTableIDs() const { return tableIDs; }

--- a/src/include/binder/expression/rel_expression.h
+++ b/src/include/binder/expression/rel_expression.h
@@ -67,6 +67,10 @@ public:
           srcNode{std::move(srcNode)}, dstNode{std::move(dstNode)},
           directionType{directionType}, relType{relType} {}
 
+    inline bool isRecursive() const {
+        return dataType.getLogicalTypeID() == common::LogicalTypeID::RECURSIVE_REL;
+    }
+
     inline bool isBoundByMultiLabeledNode() const {
         return srcNode->isMultiLabeled() || dstNode->isMultiLabeled();
     }

--- a/src/include/binder/query/query_graph_label_analyzer.h
+++ b/src/include/binder/query/query_graph_label_analyzer.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "catalog/catalog.h"
+#include "query_graph.h"
+
+namespace kuzu {
+namespace binder {
+
+class QueryGraphLabelAnalyzer {
+public:
+    QueryGraphLabelAnalyzer(const catalog::Catalog& catalog) : catalog{catalog} {}
+
+    void pruneLabel(const QueryGraph& graph);
+
+private:
+    void pruneNode(const QueryGraph& graph, NodeExpression& node);
+    void pruneRel(RelExpression& rel);
+
+private:
+    const catalog::Catalog& catalog;
+};
+
+} // namespace binder
+} // namespace kuzu

--- a/src/include/binder/rewriter/match_clause_pattern_label_rewriter.h
+++ b/src/include/binder/rewriter/match_clause_pattern_label_rewriter.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "binder/bound_statement_visitor.h"
+#include "binder/query/query_graph_label_analyzer.h"
+
+namespace kuzu {
+namespace binder {
+
+class MatchClausePatternLabelRewriter : public BoundStatementVisitor {
+public:
+    MatchClausePatternLabelRewriter(const catalog::Catalog& catalog) : analyzer{catalog} {}
+
+    void visitMatch(const BoundReadingClause& readingClause) final;
+
+private:
+    QueryGraphLabelAnalyzer analyzer;
+};
+
+} // namespace binder
+} // namespace kuzu

--- a/src/include/common/types/internal_id_t.h
+++ b/src/include/common/types/internal_id_t.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <cstdint>
+#include <unordered_set>
+#include <vector>
 
 #include "common/api.h"
 
@@ -12,6 +14,8 @@ using nodeID_t = internalID_t;
 using relID_t = internalID_t;
 
 using table_id_t = uint64_t;
+using table_id_vector_t = std::vector<table_id_t>;
+using table_id_set_t = std::unordered_set<table_id_t>;
 using offset_t = uint64_t;
 constexpr table_id_t INVALID_TABLE_ID = UINT64_MAX;
 constexpr offset_t INVALID_OFFSET = UINT64_MAX;

--- a/src/processor/map/map_scan_node_property.cpp
+++ b/src/processor/map/map_scan_node_property.cpp
@@ -49,7 +49,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeProperty(
         std::vector<column_id_t> columnIDs;
         for (auto& expression : scanProperty.getProperties()) {
             auto property = static_pointer_cast<PropertyExpression>(expression);
-            columnIDs.push_back(tableSchema->getColumnID(property->getPropertyID(tableID)));
+            if (property->hasPropertyID(tableID)) {
+                columnIDs.push_back(tableSchema->getColumnID(property->getPropertyID(tableID)));
+            } else {
+                columnIDs.push_back(UINT32_MAX);
+            }
         }
         return std::make_unique<ScanSingleNodeTable>(inputNodeIDVectorPos, std::move(outVectorsPos),
             nodeStore.getNodeTable(tableID), std::move(columnIDs), std::move(prevOperator),

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -38,8 +38,12 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(storage::NodesSt
     } else {
         auto tableID = node->getSingleTableID();
         auto table = store->getNodeTable(tableID);
-        auto columnID = catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(
-            property->getPropertyID(tableID));
+        auto columnID = INVALID_COLUMN_ID;
+        if (property->hasPropertyID(tableID)) {
+            auto propertyID = property->getPropertyID(tableID);
+            columnID =
+                catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(propertyID);
+        }
         return std::make_unique<SingleLabelNodeSetExecutor>(
             NodeSetInfo{table, columnID}, nodeIDPos, propertyPos, std::move(evaluator));
     }
@@ -86,7 +90,10 @@ std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(storage::RelsStore
     } else {
         auto tableID = rel->getSingleTableID();
         auto table = store->getRelTable(tableID);
-        auto propertyID = property->getPropertyID(tableID);
+        auto propertyID = common::INVALID_PROPERTY_ID;
+        if (property->hasPropertyID(tableID)) {
+            propertyID = property->getPropertyID(tableID);
+        }
         return std::make_unique<SingleLabelRelSetExecutor>(
             table, propertyID, srcNodePos, dstNodePos, relIDPos, propertyPos, std::move(evaluator));
     }

--- a/src/processor/operator/persistent/set_executor.cpp
+++ b/src/processor/operator/persistent/set_executor.cpp
@@ -35,6 +35,15 @@ static void writeToPropertyVector(ValueVector* propertyVector, uint32_t property
 }
 
 void SingleLabelNodeSetExecutor::set(ExecutionContext* context) {
+    if (setInfo.columnID == common::INVALID_COLUMN_ID) {
+        if (lhsVector != nullptr) {
+            for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
+                auto lhsPos = nodeIDVector->state->selVector->selectedPositions[i];
+                lhsVector->setNull(lhsPos, true);
+            }
+        }
+        return;
+    }
     evaluator->evaluate();
     setInfo.table->update(
         context->clientContext->getActiveTransaction(), setInfo.columnID, nodeIDVector, rhsVector);
@@ -105,6 +114,13 @@ static void writeToPropertyVector(ValueVector* propertyVector, ValueVector* rhsV
 }
 
 void SingleLabelRelSetExecutor::set() {
+    if (propertyID == INVALID_PROPERTY_ID) {
+        if (lhsVector != nullptr) {
+            auto pos = relIDVector->state->selVector->selectedPositions[0];
+            lhsVector->setNull(pos, true);
+        }
+        return;
+    }
     evaluator->evaluate();
     table->updateRel(srcNodeIDVector, dstNodeIDVector, relIDVector, rhsVector, propertyID);
     if (lhsVector != nullptr) {

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -36,30 +36,6 @@ void NodeGroup::resetToEmpty() {
     }
 }
 
-// uint64_t NodeGroup::append(
-//    ResultSet* resultSet, std::vector<DataPos> dataPoses, uint64_t numValuesToAppend) {
-//    auto numValuesToAppendInChunk =
-//        std::min(numValuesToAppend, StorageConstants::NODE_GROUP_SIZE - numNodes);
-//    auto serialSkip = 0u;
-//    auto originalVectorSize =
-//        resultSet->getDataChunk(dataPoses[0].dataChunkPos)->state->selVector->selectedSize;
-//    resultSet->getDataChunk(dataPoses[0].dataChunkPos)->state->selVector->selectedSize =
-//        numValuesToAppendInChunk;
-//    for (auto i = 0u; i < chunks.size(); i++) {
-//        auto chunk = chunks[i].get();
-//        if (chunk->getDataType().getLogicalTypeID() == common::LogicalTypeID::SERIAL) {
-//            serialSkip++;
-//            continue;
-//        }
-//        auto dataPos = dataPoses[i - serialSkip];
-//        chunk->append(resultSet->getValueVector(dataPos).get(), numNodes);
-//    }
-//    resultSet->getDataChunk(dataPoses[0].dataChunkPos)->state->selVector->selectedSize =
-//        originalVectorSize;
-//    numNodes += numValuesToAppendInChunk;
-//    return numValuesToAppendInChunk;
-//}
-
 uint64_t NodeGroup::append(const std::vector<ValueVector*>& columnVectors,
     DataChunkState* columnState, uint64_t numValuesToAppend) {
     auto numValuesToAppendInChunk =

--- a/test/test_files/tck/match/match3.test
+++ b/test/test_files/tck/match/match3.test
@@ -308,8 +308,8 @@ a
 -STATEMENT CREATE REL TABLE GROUP T(FROM A TO B, FROM A TO C);
 ---- ok
 -STATEMENT CREATE (a:A), (b:B), (c:C)
-           CREATE (a)-[:T]->(b),
-                  (a)-[:T]->(c);
+           CREATE (a)-[:T_A_B]->(b),
+                  (a)-[:T_A_C]->(c);
 ---- ok
 -STATEMENT MATCH (a)-->(b)
            MATCH (c)-->(d)

--- a/test/test_files/tck/match/match4.test
+++ b/test/test_files/tck/match/match4.test
@@ -187,20 +187,20 @@
                   (n0101:D {name: 'n0101'}),
                   (n0110:D {name: 'n0110'}),
                   (n0111:D {name: 'n0111'})
-           CREATE (n0)-[:LIKES]->(n00),
-                  (n0)-[:LIKES]->(n01),
-                  (n00)-[:LIKES]->(n000),
-                  (n00)-[:LIKES]->(n001),
-                  (n01)-[:LIKES]->(n010),
-                  (n01)-[:LIKES]->(n011),
-                  (n000)-[:LIKES]->(n0000),
-                  (n000)-[:LIKES]->(n0001),
-                  (n001)-[:LIKES]->(n0010),
-                  (n001)-[:LIKES]->(n0011),
-                  (n010)-[:LIKES]->(n0100),
-                  (n010)-[:LIKES]->(n0101),
-                  (n011)-[:LIKES]->(n0110),
-                  (n011)-[:LIKES]->(n0111);
+           CREATE (n0)-[:LIKES_A_B]->(n00),
+                  (n0)-[:LIKES_A_B]->(n01),
+                  (n00)-[:LIKES_B_C]->(n000),
+                  (n00)-[:LIKES_B_C]->(n001),
+                  (n01)-[:LIKES_B_C]->(n010),
+                  (n01)-[:LIKES_B_C]->(n011),
+                  (n000)-[:LIKES_C_D]->(n0000),
+                  (n000)-[:LIKES_C_D]->(n0001),
+                  (n001)-[:LIKES_C_D]->(n0010),
+                  (n001)-[:LIKES_C_D]->(n0011),
+                  (n010)-[:LIKES_C_D]->(n0100),
+                  (n010)-[:LIKES_C_D]->(n0101),
+                  (n011)-[:LIKES_C_D]->(n0110),
+                  (n011)-[:LIKES_C_D]->(n0111);
 ---- ok
 -STATEMENT  MATCH (a:A)
             MATCH (a)-[:LIKES..]->(c)

--- a/test/test_files/tinysnb/match/multi_label.test
+++ b/test/test_files/tinysnb/match/multi_label.test
@@ -26,10 +26,15 @@
 ---- 1
 704
 
--LOG UnLabelOneHopTest
+-LOG UnLabelTest1
 -STATEMENT MATCH ()-[]->() RETURN COUNT(*)
 ---- 1
 30
+
+-LOG UnLabelTest2
+-STATEMENT MATCH (a)-[:knows|:studyAt]->(b)-[:knows|:studyAt]->(c) RETURN COUNT(*)
+---- 1
+43
 
 -LOG MultiLabelOneHopTest1
 -STATEMENT MATCH (a:person)-[e:knows|:marries]->(b:person) RETURN COUNT(*)
@@ -52,3 +57,8 @@
 -ENUMERATE
 ---- 1
 17
+
+-LOG MultiLabelNodePruning
+-STATEMENT MATCH (a:person)-[:knows]->(b)<-[:studyAt]-(c) RETURN COUNT(*)
+---- error
+Binder exception: Cannot find a label for node b that connects to all of its neighbour relationships.

--- a/test/test_files/tinysnb/match/undirected.test
+++ b/test/test_files/tinysnb/match/undirected.test
@@ -65,6 +65,11 @@ Dan|Carol
 ---- 1
 54
 
+-LOG UndirLabelPruning
+-STATEMENT MATCH (a:person)-[:knows|:studyAt|:workAt]-(b:person) RETURN COUNT(*);
+---- 1
+28
+
 -LOG UndirPattern
 -STATEMENT MATCH ()-[:studyAt]-(a)-[:meets]-()-[:workAt]-() RETURN a.fName;
 -ENUMERATE

--- a/test/test_files/update_node/set_tinysnb.test
+++ b/test/test_files/update_node/set_tinysnb.test
@@ -230,6 +230,40 @@ Runtime exception: Maximum length of strings is 4096. Input string's length is 2
 0|0
 1|10
 
+-CASE SETMultiLabelWithPruning
+-STATEMENT MATCH (a:person)-[:knows]->(b) WHERE a.ID=0 SET b.name = "a", b.fName = "XX" RETURN b.name, b.fName;
+---- 3
+|XX
+|XX
+|XX
+-STATEMENT MATCH (b) RETURN b.name, b.fName
+---- 14
+ABFsUni|
+CsWork|
+DEsWork|
+Roma|
+Sóló cón tu párejâ|
+The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie|
+|Alice
+|Elizabeth
+|Farooq
+|Greg
+|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+|XX
+|XX
+|XX
+-STATEMENT MATCH (a:person)-[e:knows|:studyAt]->(b:person) WHERE a.ID=0 SET e.year = 2023, e.date = date("2023-11-11") RETURN e.year, e.date;
+---- 3
+|2023-11-11
+|2023-11-11
+|2023-11-11
+-STATEMENT MATCH (a:person)-[e:knows|:studyAt]->(b:person:organisation) WHERE a.ID=0 RETURN e.year, e.date;
+---- 4
+2021|
+|2023-11-11
+|2023-11-11
+|2023-11-11
+
 -CASE SetNonNullValueWithWriteTransaction
 -STATEMENT BEGIN TRANSACTION
 ---- ok


### PR DESCRIPTION
This PR replace our previous naive rel pattern label pruning with a new pruning class that prune both node and relationship labels based on topology. 

### Primary use case
In RDF processing, since a join can only happen on resource node, the following query
```
MATCH (a)-[e1]->(b)-[e2]->(c)
```
can be pruned as
```
MATCH (a:resource)-[e1:resource_triple]->(b:resource)-[e2:resource_triple|literal_triple]->(c:resource|literal)
```
The join over `e1,b` will benefit from pruning.

And of course general multi label query will also benefit from this PR.

### Minutia
Technically speaking, label pruning should be performed iteratively until the algorithm converge. Though I don't think it make much difference in practice, plus we want the compilation to be fast. So the current implementation only perform pruning once over each node and rel.
