### PR TITLE
tidy: add makefile command

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -167,17 +167,8 @@ jobs:
       - name: Java test
         run: make javatest
 
-      - name: Create compilation commands database
-        run: make clang-tidy-ci
-
-      - name: Run clang-tidy on src
-        run: run-clang-tidy -p build/release -quiet -j 32 "^$(realpath src)"
-
-      - name: Run clang-tidy on tools
-        run: run-clang-tidy -p build/release -quiet -j 32 "^$(realpath tools)/(?!shell/linenoise.cpp)"
-
-      - name: Run clang-tidy on examples
-        run: run-clang-tidy -p build/release -quiet -j 32 "^$(realpath examples)"
+      - name: Run clang-tidy
+        run: make tidy
 
   msvc-build-test:
     name: msvc build & test

--- a/Makefile
+++ b/Makefile
@@ -95,14 +95,12 @@ lcov:
 	ctest --output-on-failure -j ${TEST_JOBS}
 
 clangd:
-	$(call mkdirp,build/clangd) && cd build/clangd && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=TRUE \
-		-DBUILD_BENCHMARK=TRUE -DBUILD_JAVA=TRUE -DBUILD_NODEJS=TRUE -DBUILD_TESTS=TRUE ../..
-
-clang-tidy-ci:
-	# For CI: export compile commands for the built items.
 	$(call mkdirp,build/release) && cd build/release && \
 	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ../..
+
+tidy: clangd
+	run-clang-tidy -p build/release -quiet -j $(NUM_THREADS) \
+		"^$(realpath src)|$(realpath tools)/(?!shell/linenoise.cpp)|$(realpath examples)"
 
 pytest: release
 	cd $(ROOT_DIR)/tools/python_api/test && \


### PR DESCRIPTION
Instead of embedding the clang-tidy command in the workflow file, we should put it in a make subcommand.

Also, this change removes the `build/clangd` generator, since when `make clangd` is run but the `clangd` target is not built, clang-tidy gives false-positives about the java api. Instead, `make clangd` now simply enables exporting compile commands for the `build/release` directory.