### PR TITLE
Issue 2269

### DIFF
--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -707,12 +707,19 @@ bool LogicalTypeUtils::isNumerical(const LogicalType& dataType) {
 }
 
 bool LogicalTypeUtils::isNested(const LogicalType& dataType) {
-    switch (dataType.typeID) {
+    return isNested(dataType.typeID);
+}
+
+bool LogicalTypeUtils::isNested(kuzu::common::LogicalTypeID logicalTypeID) {
+    switch (logicalTypeID) {
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::VAR_LIST:
     case LogicalTypeID::FIXED_LIST:
     case LogicalTypeID::UNION:
     case LogicalTypeID::MAP:
+    case LogicalTypeID::NODE:
+    case LogicalTypeID::REL:
+    case LogicalTypeID::RECURSIVE_REL:
         return true;
     default:
         return false;

--- a/src/function/vector_struct_functions.cpp
+++ b/src/function/vector_struct_functions.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<FunctionBindData> StructPackFunctions::bindFunc(
     for (auto& argument : arguments) {
         if (argument->getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
             binder::ExpressionBinder::resolveAnyDataType(
-                *argument, LogicalType{LogicalTypeID::INT64});
+                *argument, LogicalType{LogicalTypeID::STRING});
         }
         fields.emplace_back(
             std::make_unique<StructField>(argument->getAlias(), argument->getDataType().copy()));

--- a/src/function/vector_union_functions.cpp
+++ b/src/function/vector_union_functions.cpp
@@ -1,5 +1,6 @@
 #include "function/union/vector_union_functions.h"
 
+#include "binder/expression_binder.h"
 #include "function/struct/vector_struct_functions.h"
 #include "function/union/functions/union_tag.h"
 
@@ -23,8 +24,12 @@ std::unique_ptr<FunctionBindData> UnionValueFunction::bindFunc(
     // TODO(Ziy): Use UINT8 to represent tag value.
     fields.push_back(std::make_unique<StructField>(
         UnionType::TAG_FIELD_NAME, std::make_unique<LogicalType>(UnionType::TAG_FIELD_TYPE)));
+    if (arguments[0]->getDataType().getLogicalTypeID() == common::LogicalTypeID::ANY) {
+        binder::ExpressionBinder::resolveAnyDataType(
+            *arguments[0], LogicalType(LogicalTypeID::STRING));
+    }
     fields.push_back(std::make_unique<StructField>(
-        arguments[0]->getAlias(), std::make_unique<LogicalType>(arguments[0]->getDataType())));
+        arguments[0]->getAlias(), arguments[0]->getDataType().copy()));
     auto resultType =
         LogicalType(LogicalTypeID::UNION, std::make_unique<StructTypeInfo>(std::move(fields)));
     return std::make_unique<FunctionBindData>(resultType);

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -99,15 +99,10 @@ private:
         const parser::ParsedExpression& parsedExpression);
 
     /****** cast *****/
-    // Note: we expose two implicitCastIfNecessary interfaces.
-    // For function binding we cast with data type ID because function definition cannot be
-    // recursively generated, e.g. list_extract(param) we only declare param with type LIST but do
-    // not specify its child type.
-    // For the rest, i.e. set clause binding, we cast with data type. For example, a.list = $1.
-    static std::shared_ptr<Expression> implicitCastIfNecessary(
-        const std::shared_ptr<Expression>& expression, const common::LogicalType& targetType);
     static std::shared_ptr<Expression> implicitCastIfNecessary(
         const std::shared_ptr<Expression>& expression, common::LogicalTypeID targetTypeID);
+    static std::shared_ptr<Expression> implicitCastIfNecessary(
+        const std::shared_ptr<Expression>& expression, const common::LogicalType& targetType);
     static std::shared_ptr<Expression> implicitCast(
         const std::shared_ptr<Expression>& expression, const common::LogicalType& targetType);
 

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -269,6 +269,7 @@ public:
 
     inline PhysicalTypeID getPhysicalType() const { return physicalType; }
 
+    inline bool hasExtraTypeInfo() const { return extraTypeInfo != nullptr; }
     inline void setExtraTypeInfo(std::unique_ptr<ExtraTypeInfo> typeInfo) {
         extraTypeInfo = std::move(typeInfo);
     }
@@ -432,6 +433,7 @@ public:
     static uint32_t getRowLayoutSize(const LogicalType& logicalType);
     static bool isNumerical(const LogicalType& dataType);
     static bool isNested(const LogicalType& dataType);
+    static bool isNested(LogicalTypeID logicalTypeID);
     static std::vector<LogicalType> getAllValidComparableLogicalTypes();
     static std::vector<LogicalTypeID> getNumericalLogicalTypeIDs();
     static std::vector<LogicalTypeID> getIntegerLogicalTypeIDs();

--- a/test/test_files/copy/copy_to_csv.test
+++ b/test/test_files/copy/copy_to_csv.test
@@ -55,11 +55,11 @@ Roma|298|the movie is very interesting and funny|{rating: 1223.000000, stars: 10
 7|9|[96,59,65,88]|[43,83,67,43]
 
 -CASE CopyToWithNullAndEmptyList
--STATEMENT COPY (RETURN NULL,[],[1,3,NULL,5],[[2,3],[],NULL,[1,5,6]]) TO "${DATABASE_PATH}/nullAndEmptyList.csv"
+-STATEMENT COPY (RETURN NULL,[],[1,3,NULL,5],[[2,3],[2],NULL,[1,5,6]], [['a'], []]) TO "${DATABASE_PATH}/nullAndEmptyList.csv"
 ---- ok
 -STATEMENT load from "${DATABASE_PATH}/nullAndEmptyList.csv" return *
 ---- 1
-|[]|[1,3,,5]|[[2,3],[],,[1,5,6]]
+|[]|[1,3,,5]|[[2,3],[2],,[1,5,6]]|[[a],[]]
 
 -CASE StringEscapeCopyTo
 -STATEMENT COPY (RETURN 100,'a string with "quotes"',5.6,'","',',') TO "${DATABASE_PATH}/string.csv"

--- a/test/test_files/copy/copy_to_parquet.test
+++ b/test/test_files/copy/copy_to_parquet.test
@@ -29,11 +29,11 @@
 6|{revenue: 558, location: ['very long city name', 'new york'], stock: {price: [22], volume: 99}}
 
 -LOG CopyEmptyListToParquet
--STATEMENT COPY (RETURN null,[], [1,null,3], [[],null,[3,4,5]]) TO "${DATABASE_PATH}/emptyList.parquet"
+-STATEMENT COPY (RETURN null,[], [1,null,3], [[1],null,[3,4,5]], [[], ["a"]]) TO "${DATABASE_PATH}/emptyList.parquet"
 ---- ok
 -STATEMENT LOAD FROM "${DATABASE_PATH}/emptyList.parquet" RETURN *;
 ---- 1
-|[]|[1,,3]|[[],,[3,4,5]]
+|[]|[1,,3]|[[1],,[3,4,5]]|[[],[a]]
 
 -LOG CopyToParquetFlatUnflat
 -STATEMENT COPY (MATCH (p:person)-[:knows]->(p1:person) return p.ID, p1.ID) TO "${DATABASE_PATH}/flatUnflat.parquet"

--- a/test/test_files/exceptions/binder/empty_db_binder_error.test
+++ b/test/test_files/exceptions/binder/empty_db_binder_error.test
@@ -62,4 +62,4 @@ Binder exception: Expected literal input as the second argument for PROPERTIES()
 Binder exception: Invalid property name: abc.
 -STATEMENT MATCH path = (p:person)-[:follows* SHORTEST]-(q:person) RETURN properties([], "abc")
 ---- error
-Binder exception: Cannot extract properties from INT64[].
+Binder exception: Cannot extract properties from STRING[].

--- a/test/test_files/tinysnb/exception/list.test
+++ b/test/test_files/tinysnb/exception/list.test
@@ -25,6 +25,6 @@ Binder exception: Cannot bind LIST_CONCAT with parameter type INT64[] and STRING
 Binder exception: Cannot bind LIST_CREATION with parameter type INT64 and STRING.
 
 -CASE ListPrepareError
--STATEMENT MATCH (a:person) RETURN size($1)
+-STATEMENT MATCH (a:person) RETURN list_sort($1)
 ---- error
 Binder exception: Cannot resolve recursive data type for expression $1.

--- a/test/test_files/tinysnb/function/list.test
+++ b/test/test_files/tinysnb/function/list.test
@@ -31,7 +31,7 @@ Binder exception: Cannot bind LIST_CREATION with parameter type INT64 and STRING
 [,]
 -STATEMENT RETURN ['a', , []];
 ---- error
-Binder exception: Cannot bind LIST_CREATION with parameter type STRING and INT64[].
+Binder exception: Cannot bind LIST_CREATION with parameter type STRING and STRING[].
 -STATEMENT RETURN [[], , []];
 ---- 1
 [[],,[]]
@@ -411,12 +411,12 @@ ad
 []
 
 -LOG ListConcatINT64AndNull
--STATEMENT RETURN LIST_CONCAT([1,2,NULL], [NULL])
+-STATEMENT RETURN LIST_CONCAT([1,2,NULL], [to_int64(NULL)])
 ---- 1
 [1,2,,]
 
 -LOG ListConcatNullAndINT64
--STATEMENT RETURN LIST_CONCAT([NULL], [NULL, 1, 3])
+-STATEMENT RETURN LIST_CONCAT([to_int64(NULL)], [NULL, 1, 3])
 ---- 1
 [,,1,3]
 
@@ -1798,7 +1798,7 @@ Ad
 8.066667
 
 -LOG ListProductSeq3
--STATEMENT Return list_product([NULL, NULL, NULL, NULL]);
+-STATEMENT Return list_product([to_int64(NULL), NULL, NULL, NULL]);
 ---- 1
 1
 # different from cypher standard: should return NULL

--- a/test/test_files/tinysnb/function/map.test
+++ b/test/test_files/tinysnb/function/map.test
@@ -76,8 +76,11 @@
 
 -LOG MapKeys
 -STATEMENT RETURN map_keys(map([[5], [28, 75, 32], [], [33, 11, 66, 33]], ['a', 'b', 'd', 'e']));
+---- error
+Binder exception: Cannot bind LIST_CREATION with parameter type INT64[] and STRING[].
+-STATEMENT RETURN map_keys(map([[5], [28, 75, 32], [1], [33, 11, 66, 33]], ['a', 'b', 'd', 'e']));
 ---- 1
-[[5],[28,75,32],[],[33,11,66,33]]
+[[5],[28,75,32],[1],[33,11,66,33]]
 
 -LOG EmptyMapKeys
 -STATEMENT RETURN map_keys(map([], []));


### PR DESCRIPTION
Fix issue #2269 

As suggested by @OTooleMichael, when data type can not be resolved for parameters, using STRING as default type is preferable over INT64 because STRING is the most permissible type and can be casted to any other types.

This PR applies this change from two aspects

- For primitive functions, when overloading is available, select STRING input over other inputs. E.g. `to_int64($1)` will expect `$1` to have type STRING.
- For nested functions, if child type is not available, use STRING as default. E.g. `[$1]` will have type STRING[].


### Note
We might still miss default case for some functions. I hope to solve this with fuzzy testing rather than checking each function manually. Meanwhile, since the default input of casting functions has been changed to STRING. User can always use `to_x($1)` to get the expected type from STRING input. I think this is good enough for now.