### PR TITLE
Remove spdlog include from buffer_manager.cpp

### DIFF
--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -2,12 +2,13 @@
 
 #include "common/constants.h"
 #include "common/exception/buffer_manager.h"
-#include "spdlog/spdlog.h"
 
 #if defined(_WIN32)
 #include <exception>
 
 #include <eh.h>
+#include <windows.h>
+#include <winnt.h>
 #endif
 
 using namespace kuzu::common;


### PR DESCRIPTION
Fixes #2286

As far as I can tell it just needs to have windows.h included before winnt.h