### PR TITLE
Fix stdint includes

### DIFF
--- a/src/include/common/exception/message.h
+++ b/src/include/common/exception/message.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace kuzu {

--- a/src/processor/operator/persistent/writer/parquet/CMakeLists.txt
+++ b/src/processor/operator/persistent/writer/parquet/CMakeLists.txt
@@ -12,3 +12,5 @@ add_library(kuzu_processor_operator_parquet_writer
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_processor_operator_parquet_writer>
         PARENT_SCOPE)
+
+target_link_libraries(kuzu_processor_operator_parquet_writer PUBLIC miniparquet)

--- a/third_party/miniparquet/CMakeLists.txt
+++ b/third_party/miniparquet/CMakeLists.txt
@@ -21,8 +21,6 @@ include_directories(src/parquet
         src/snappy
         src/thrift)
 
-add_compile_definitions(HAVE_STDINT_H)
-
 add_library(miniparquet STATIC
         src/parquet/parquet_constants.cpp
         src/parquet/parquet_types.cpp
@@ -32,6 +30,7 @@ add_library(miniparquet STATIC
         src/snappy/snappy.cc
         src/snappy/snappy-sinksource.cc)
 
+target_compile_definitions(miniparquet PUBLIC HAVE_STDINT_H)
 target_include_directories(
         miniparquet
         PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)


### PR DESCRIPTION
`<string>` sometimes does not include `<cstdint>` and the `HAVE_STDINT_H` definition needs to be propagated to everything that includes miniparquet (which I think was also being obscured by things including `<string>`).