### PR TITLE
Remove CompressionAlg::getValue

### DIFF
--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -56,11 +56,6 @@ public:
         uint8_t* dstBuffer, common::offset_t dstOffset, common::offset_t numValues,
         const CompressionMetadata& metadata) const = 0;
 
-    // Reads a value from the buffer at the given position and stores it at the given memory address
-    // dst should point to an uncompressed value
-    virtual inline void getValue(const uint8_t* buffer, common::offset_t posInBuffer, uint8_t* dst,
-        common::offset_t posInDst, const CompressionMetadata& metadata) const = 0;
-
     // Returns compression metadata, including any relevant parameters specific to this dataset
     // which will need to be passed to compressNextPage. Since this may need to scan the entire
     // buffer, which is slow, it should only be called once for each set of data to compress.
@@ -107,12 +102,6 @@ public:
         const CompressionMetadata& /*metadata*/) const final {
         memcpy(dstBuffer + dstOffset * numBytesPerValue, srcBuffer + srcOffset * numBytesPerValue,
             numBytesPerValue * numValues);
-    }
-
-    inline void getValue(const uint8_t* buffer, common::offset_t posInBuffer, uint8_t* dst,
-        common::offset_t posInDst, const CompressionMetadata& /*metadata*/) const override {
-        memcpy(dst + posInDst * numBytesPerValue, buffer + posInBuffer * numBytesPerValue,
-            numBytesPerValue);
     }
 
     static inline uint64_t numValues(uint64_t dataSize, const common::LogicalType& logicalType) {
@@ -189,10 +178,6 @@ public:
         uint8_t* dstBuffer, common::offset_t dstOffset, common::offset_t numValues,
         const CompressionMetadata& metadata) const final;
 
-    // Read a single value from the buffer
-    void getValue(const uint8_t* buffer, common::offset_t posInBuffer, uint8_t* dst,
-        common::offset_t posInDst, const CompressionMetadata& metadata) const final;
-
     BitpackHeader getBitWidth(const uint8_t* srcBuffer, uint64_t numValues) const;
 
     static inline uint64_t numValues(uint64_t dataSize, const BitpackHeader& header) {
@@ -245,9 +230,6 @@ public:
     void setValuesFromUncompressed(const uint8_t* srcBuffer, common::offset_t srcOffset,
         uint8_t* dstBuffer, common::offset_t dstOffset, common::offset_t numValues,
         const CompressionMetadata& metadata) const final;
-
-    void getValue(const uint8_t* buffer, common::offset_t posInBuffer, uint8_t* dst,
-        common::offset_t posInDst, const CompressionMetadata& metadata) const final;
 
     static inline uint64_t numValues(uint64_t dataSize) { return dataSize * 8; }
 

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -316,14 +316,6 @@ void IntegerBitpacking<T>::getValues(const uint8_t* chunkStart, uint8_t pos, uin
 }
 
 template<typename T>
-void IntegerBitpacking<T>::getValue(const uint8_t* buffer, offset_t posInBuffer, uint8_t* dst,
-    offset_t posInDst, const CompressionMetadata& metadata) const {
-    auto header = BitpackHeader::readHeader(metadata.data);
-    auto chunkStart = getChunkStart(buffer, posInBuffer, header.bitWidth);
-    getValues(chunkStart, posInBuffer % CHUNK_SIZE, dst + posInDst * sizeof(T), 1, header);
-}
-
-template<typename T>
 uint64_t IntegerBitpacking<T>::compressNextPage(const uint8_t*& srcBuffer,
     uint64_t numValuesRemaining, uint8_t* dstBuffer, uint64_t dstBufferSize,
     const struct CompressionMetadata& metadata) const {
@@ -436,11 +428,6 @@ void BooleanBitpacking::setValuesFromUncompressed(const uint8_t* srcBuffer, offs
     for (auto i = 0; i < numValues; i++) {
         NullMask::setNull((uint64_t*)dstBuffer, dstOffset + i, ((bool*)srcBuffer)[srcOffset + i]);
     }
-}
-
-void BooleanBitpacking::getValue(const uint8_t* buffer, offset_t posInBuffer, uint8_t* dst,
-    offset_t posInDst, const CompressionMetadata& /*metadata*/) const {
-    *(dst + posInDst) = NullMask::isNull((uint64_t*)buffer, posInBuffer);
 }
 
 uint64_t BooleanBitpacking::compressNextPage(const uint8_t*& srcBuffer, uint64_t numValuesRemaining,

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -33,7 +33,8 @@ void test_compression(CompressionAlg& alg, std::vector<T> src) {
     EXPECT_EQ(decompressed[1], value);
 
     for (int i = 0; i < src.size(); i++) {
-        alg.getValue(dest.data(), i, (uint8_t*)decompressed.data(), i, metadata);
+        alg.decompressFromPage(
+            dest.data(), i, (uint8_t*)decompressed.data(), i, 1 /*numValues*/, metadata);
         EXPECT_EQ(decompressed[i], src[i]);
     }
     EXPECT_EQ(decompressed, src);
@@ -153,7 +154,8 @@ void integerPackingMultiPage(const std::vector<T>& src) {
         auto page = i / numValuesPerPage;
         auto indexInPage = i % numValuesPerPage;
         T value;
-        alg.getValue(dest[page].data(), indexInPage, (uint8_t*)&value, 0, metadata);
+        alg.decompressFromPage(
+            dest[page].data(), indexInPage, (uint8_t*)&value, 0, 1 /*numValues*/, metadata);
         EXPECT_EQ(src[i] - value, 0);
         EXPECT_EQ(src[i], value);
     }


### PR DESCRIPTION
It wasn't being used since it's functionally equivalent to decompressFromPage for a single value.