### PR TITLE
Fix bounds of data read in VarList updates

### DIFF
--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -80,10 +80,10 @@ protected:
         common::ValueVector* nodeIDVector, common::ValueVector* resultVector);
     void scanUnfiltered(transaction::Transaction* transaction, PageElementCursor& pageCursor,
         uint64_t numValuesToScan, common::ValueVector* resultVector,
-        const CompressionMetadata& compMeta, uint64_t startPosInVector = 0);
+        const ColumnChunkMetadata& chunkMeta, uint64_t startPosInVector = 0);
     void scanFiltered(transaction::Transaction* transaction, PageElementCursor& pageCursor,
         common::ValueVector* nodeIDVector, common::ValueVector* resultVector,
-        const CompressionMetadata& compMeta);
+        const ColumnChunkMetadata& chunkMeta);
     virtual void lookupInternal(transaction::Transaction* transaction,
         common::ValueVector* nodeIDVector, common::ValueVector* resultVector);
     virtual void lookupValue(transaction::Transaction* transaction, common::offset_t nodeOffset,

--- a/src/storage/store/var_list_column.cpp
+++ b/src/storage/store/var_list_column.cpp
@@ -51,10 +51,10 @@ void VarListColumn::scan(node_group_idx_t nodeGroupIdx, kuzu::storage::ColumnChu
         varListColumnChunk->setNumValues(0);
     } else {
         Column::scan(nodeGroupIdx, columnChunk);
-        auto metadata = metadataDA->get(nodeGroupIdx, transaction::TransactionType::READ_ONLY);
-        varListColumnChunk->setNumValues(metadata.numValues);
+        auto dataColumnMetadata =
+            dataColumn->getMetadata(nodeGroupIdx, transaction::TransactionType::WRITE);
         varListColumnChunk->resizeDataColumnChunk(
-            metadata.numPages * BufferPoolConstants::PAGE_4KB_SIZE);
+            dataColumnMetadata.numPages * BufferPoolConstants::PAGE_4KB_SIZE);
         dataColumn->scan(nodeGroupIdx, varListColumnChunk->getDataColumnChunk());
     }
 }


### PR DESCRIPTION
When updating we are reading the size of the var list data column using the offset column's metadata.