### PR TITLE
Add typed literal casting, rework typed literal casting

### DIFF
--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -722,6 +722,7 @@ bool LogicalTypeUtils::isNested(kuzu::common::LogicalTypeID logicalTypeID) {
     case LogicalTypeID::NODE:
     case LogicalTypeID::REL:
     case LogicalTypeID::RECURSIVE_REL:
+    case LogicalTypeID::RDF_VARIANT:
         return true;
     default:
         return false;
@@ -767,7 +768,7 @@ std::vector<LogicalType> LogicalTypeUtils::getAllValidLogicTypes() {
         LogicalType{LogicalTypeID::MAP}, LogicalType{LogicalTypeID::FLOAT},
         LogicalType{LogicalTypeID::SERIAL}, LogicalType{LogicalTypeID::NODE},
         LogicalType{LogicalTypeID::REL}, LogicalType{LogicalTypeID::STRUCT},
-        LogicalType{LogicalTypeID::UNION}};
+        LogicalType{LogicalTypeID::UNION}, LogicalType{LogicalTypeID::RDF_VARIANT}};
 }
 
 std::vector<std::string> LogicalTypeUtils::parseStructFields(const std::string& structTypeStr) {

--- a/src/function/CMakeLists.txt
+++ b/src/function/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(aggregate)
+add_subdirectory(cast)
 add_subdirectory(table_functions)
 
 add_library(kuzu_function

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -119,6 +119,9 @@ uint32_t BuiltInFunctions::getCastCost(LogicalTypeID inputTypeID, LogicalTypeID 
         case LogicalTypeID::ANY:
             // ANY type can be any type
             return 0;
+        case LogicalTypeID::RDF_VARIANT:
+            // RDF_VARIANT can be cast to any type.
+            return 1;
         case LogicalTypeID::INT64:
             return castInt64(targetTypeID);
         case LogicalTypeID::INT32:

--- a/src/function/cast/CMakeLists.txt
+++ b/src/function/cast/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(kuzu_function_cast
+        OBJECT
+        cast_rdf_variant.cpp)
+
+set(ALL_OBJECT_FILES
+        ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_function_cast>
+        PARENT_SCOPE)

--- a/src/function/cast/cast_rdf_variant.cpp
+++ b/src/function/cast/cast_rdf_variant.cpp
@@ -1,0 +1,170 @@
+#include "function/cast/functions/cast_rdf_variant.h"
+
+#include "common/types/blob.h"
+#include "function/cast/functions/cast_functions.h"
+#include "function/cast/functions/numeric_cast.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace function {
+
+template<typename T>
+static void castToNumeric(common::ValueVector& inputVector, uint64_t inputPos, T& result,
+    common::ValueVector& resultVector, uint64_t resultPos) {
+    auto typeVector = StructVector::getFieldVector(&inputVector, 0).get();
+    auto blobVector = StructVector::getFieldVector(&inputVector, 1).get();
+    auto type = static_cast<LogicalTypeID>(typeVector->getValue<uint8_t>(inputPos));
+    switch (type) {
+    case LogicalTypeID::INT64: {
+        auto val = Blob::getValue<int64_t>(blobVector->getValue<blob_t>(inputPos));
+        if (!tryCastWithOverflowCheck(val, result)) {
+            resultVector.setNull(resultPos, true);
+        }
+    } break;
+    case LogicalTypeID::DOUBLE: {
+        auto val = Blob::getValue<double_t>(blobVector->getValue<blob_t>(inputPos));
+        if (!tryCastWithOverflowCheck(val, result)) {
+            resultVector.setNull(resultPos, true);
+        }
+    } break;
+    default:
+        resultVector.setNull(resultPos, true);
+    }
+}
+
+// TODO(Xiyang): add cast to int128
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    int64_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    int32_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    int16_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    int8_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    uint64_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    uint32_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    uint16_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    uint8_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    double_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    float_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castToNumeric(inputVector, inputPos, result, resultVector, resultPos);
+}
+
+template<typename T>
+static void castFromString(common::ValueVector& /*inputVector*/, uint64_t /*inputPos*/,
+    T& /*result*/, common::ValueVector& resultVector, uint64_t resultPos) {
+    resultVector.setNull(resultPos, true);
+}
+
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    blob_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castFromString(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    bool& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    auto typeVector = StructVector::getFieldVector(&inputVector, 0).get();
+    auto blobVector = StructVector::getFieldVector(&inputVector, 1).get();
+    auto type = static_cast<LogicalTypeID>(typeVector->getValue<uint8_t>(inputPos));
+    switch (type) {
+    case LogicalTypeID::BOOL: {
+        result = Blob::getValue<bool>(blobVector->getValue<blob_t>(inputPos));
+    } break;
+    default:
+        resultVector.setNull(resultPos, true);
+    }
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    date_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    auto typeVector = StructVector::getFieldVector(&inputVector, 0).get();
+    auto blobVector = StructVector::getFieldVector(&inputVector, 1).get();
+    auto type = static_cast<LogicalTypeID>(typeVector->getValue<uint8_t>(inputPos));
+    switch (type) {
+    case LogicalTypeID::DATE: {
+        result = Blob::getValue<date_t>(blobVector->getValue<blob_t>(inputPos));
+    } break;
+    default:
+        resultVector.setNull(resultPos, true);
+    }
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    timestamp_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castFromString(inputVector, inputPos, result, resultVector, resultPos);
+}
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    interval_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    castFromString(inputVector, inputPos, result, resultVector, resultPos);
+}
+
+template<>
+void CastFromRdfVariant::operation(common::ValueVector& inputVector, uint64_t inputPos,
+    ku_string_t& result, common::ValueVector& resultVector, uint64_t resultPos) {
+    auto typeVector = StructVector::getFieldVector(&inputVector, 0).get();
+    auto blobVector = StructVector::getFieldVector(&inputVector, 1).get();
+    auto type = static_cast<LogicalTypeID>(typeVector->getValue<uint8_t>(inputPos));
+    switch (type) {
+    case LogicalTypeID::INT64: {
+        int64_t val = Blob::getValue<int64_t>(blobVector->getValue<blob_t>(inputPos));
+        CastToString::operation(val, result, inputVector, resultVector);
+    } break;
+    case LogicalTypeID::DOUBLE: {
+        auto val = Blob::getValue<double_t>(blobVector->getValue<blob_t>(inputPos));
+        CastToString::operation(val, result, inputVector, resultVector);
+    } break;
+    case LogicalTypeID::BOOL: {
+        auto val = Blob::getValue<bool>(blobVector->getValue<blob_t>(inputPos));
+        CastToString::operation(val, result, inputVector, resultVector);
+    } break;
+    case LogicalTypeID::DATE: {
+        auto val = Blob::getValue<date_t>(blobVector->getValue<blob_t>(inputPos));
+        CastToString::operation(val, result, inputVector, resultVector);
+    } break;
+    case LogicalTypeID::STRING: {
+        result = blobVector->getValue<blob_t>(inputPos).value;
+    } break;
+    default:
+        resultVector.setNull(resultPos, true);
+    }
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/common/types/blob.h
+++ b/src/include/common/types/blob.h
@@ -35,8 +35,8 @@ struct Blob {
     static uint64_t fromString(const char* str, uint64_t length, uint8_t* resultBuffer);
 
     template<typename T>
-    static inline T getValue(blob_t data) {
-        return *reinterpret_cast<T*>(data.value.getData());
+    static inline T getValue(const blob_t& data) {
+        return *reinterpret_cast<const T*>(data.value.getData());
     }
     template<typename T>
     static inline T getValue(char* data) {

--- a/src/include/function/cast/functions/cast_rdf_variant.h
+++ b/src/include/function/cast/functions/cast_rdf_variant.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "common/vector/value_vector.h"
+
+namespace kuzu {
+namespace function {
+
+struct CastFromRdfVariant {
+    template<typename T>
+    static void operation(common::ValueVector& inputVector, uint64_t inputPos, T& result,
+        common::ValueVector& resultVector, uint64_t resultPos);
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/cast/vector_cast_functions.h
+++ b/src/include/function/cast/vector_cast_functions.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include "common/exception/not_implemented.h"
-#include "function/cast/functions/cast_string_to_functions.h"
 #include "function/scalar_function.h"
 
 namespace kuzu {
@@ -17,89 +15,9 @@ struct CastFunction {
     // The expression binder should consider reusing the existing matchFunction() API.
     static bool hasImplicitCast(
         const common::LogicalType& srcType, const common::LogicalType& dstType);
-    static std::string bindImplicitCastFuncName(const common::LogicalType& dstType);
-    static void bindImplicitCastFunc(common::LogicalTypeID sourceTypeID,
-        common::LogicalTypeID targetTypeID, scalar_exec_func& func);
 
-    template<typename TARGET_TYPE, typename FUNC>
-    inline static std::unique_ptr<ScalarFunction> bindNumericCastFunction(
-        const std::string& funcName, common::LogicalTypeID sourceTypeID,
-        common::LogicalTypeID targetTypeID) {
-        scalar_exec_func func;
-        bindImplicitNumericalCastFunc<TARGET_TYPE, FUNC>(sourceTypeID, func);
-        return std::make_unique<ScalarFunction>(
-            funcName, std::vector<common::LogicalTypeID>{sourceTypeID}, targetTypeID, func);
-    }
-
-    template<typename DST_TYPE, typename OP>
-    static void bindImplicitNumericalCastFunc(
-        common::LogicalTypeID srcTypeID, scalar_exec_func& func) {
-        switch (srcTypeID) {
-        case common::LogicalTypeID::INT8: {
-            func = ScalarFunction::UnaryExecFunction<int8_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::INT16: {
-            func = ScalarFunction::UnaryExecFunction<int16_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::INT32: {
-            func = ScalarFunction::UnaryExecFunction<int32_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::SERIAL:
-        case common::LogicalTypeID::INT64: {
-            func = ScalarFunction::UnaryExecFunction<int64_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::UINT8: {
-            func = ScalarFunction::UnaryExecFunction<uint8_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::UINT16: {
-            func = ScalarFunction::UnaryExecFunction<uint16_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::UINT32: {
-            func = ScalarFunction::UnaryExecFunction<uint32_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::UINT64: {
-            func = ScalarFunction::UnaryExecFunction<uint64_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::INT128: {
-            func = ScalarFunction::UnaryExecFunction<common::int128_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::FLOAT: {
-            func = ScalarFunction::UnaryExecFunction<float_t, DST_TYPE, OP>;
-            return;
-        }
-        case common::LogicalTypeID::DOUBLE: {
-            func = ScalarFunction::UnaryExecFunction<double_t, DST_TYPE, OP>;
-            return;
-        }
-        default:
-            throw common::NotImplementedException(
-                "Unimplemented casting Function from " +
-                common::LogicalTypeUtils::dataTypeToString(srcTypeID) + " to numeric.");
-        }
-    }
-
-    static void getNumericalCastFunc(
-        common::LogicalTypeID srcTypeID, common::LogicalTypeID dstTypeID, scalar_exec_func& func);
-
-    static void getCastStringExecFunc(common::LogicalTypeID dstTypeID, scalar_exec_func& func);
-
-    template<typename TARGET_TYPE>
-    inline static std::unique_ptr<ScalarFunction> bindCastStringToFunction(
-        const std::string& funcName, common::LogicalTypeID targetTypeID) {
-        return std::make_unique<ScalarFunction>(funcName,
-            std::vector<common::LogicalTypeID>{common::LogicalTypeID::STRING}, targetTypeID,
-            ScalarFunction::UnaryCastStringExecFunction<common::ku_string_t, TARGET_TYPE,
-                CastString>);
-    }
+    static std::unique_ptr<ScalarFunction> bindCastFunction(const std::string& functionName,
+        common::LogicalTypeID sourceTypeID, common::LogicalTypeID targetTypeID);
 };
 
 struct CastToDateFunction {
@@ -115,8 +33,6 @@ struct CastToIntervalFunction {
 };
 
 struct CastToStringFunction {
-    static void getUnaryCastToStringExecFunction(
-        common::LogicalTypeID typeID, scalar_exec_func& func);
     static function_set getFunctionSet();
 };
 
@@ -177,8 +93,6 @@ struct CastToUInt8Function {
 };
 
 struct CastAnyFunction {
-    static void getUnaryCastExecFunction(
-        common::LogicalTypeID srcTypeID, common::LogicalTypeID dstTypeID, scalar_exec_func& func);
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, Function* function);
     static function_set getFunctionSet();

--- a/src/include/function/scalar_function.h
+++ b/src/include/function/scalar_function.h
@@ -96,7 +96,8 @@ struct ScalarFunction : public BaseScalarFunction {
     static void UnaryExecFunction(const std::vector<std::shared_ptr<common::ValueVector>>& params,
         common::ValueVector& result, void* /*dataPtr*/) {
         KU_ASSERT(params.size() == 1);
-        UnaryFunctionExecutor::execute<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
+        UnaryFunctionExecutor::executeSwitch<OPERAND_TYPE, RESULT_TYPE, FUNC, UnaryFunctionWrapper>(
+            *params[0], result, nullptr /* dataPtr */);
     }
 
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
@@ -104,7 +105,8 @@ struct ScalarFunction : public BaseScalarFunction {
         const std::vector<std::shared_ptr<common::ValueVector>>& params,
         common::ValueVector& result, void* /*dataPtr*/ = nullptr) {
         KU_ASSERT(params.size() == 1);
-        UnaryFunctionExecutor::executeString<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
+        UnaryFunctionExecutor::executeSwitch<OPERAND_TYPE, RESULT_TYPE, FUNC,
+            UnaryStringFunctionWrapper>(*params[0], result, nullptr /* dataPtr */);
     }
 
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
@@ -121,7 +123,26 @@ struct ScalarFunction : public BaseScalarFunction {
         const std::vector<std::shared_ptr<common::ValueVector>>& params,
         common::ValueVector& result, void* /*dataPtr*/ = nullptr) {
         KU_ASSERT(params.size() == 1);
-        UnaryFunctionExecutor::executeCast<OPERAND_TYPE, RESULT_TYPE, FUNC>(*params[0], result);
+        UnaryFunctionExecutor::executeSwitch<OPERAND_TYPE, RESULT_TYPE, FUNC,
+            UnaryCastFunctionWrapper>(*params[0], result, nullptr /* dataPtr */);
+    }
+
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void UnaryTryCastExecFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result, void* /*dataPtr*/ = nullptr) {
+        KU_ASSERT(params.size() == 1);
+        UnaryFunctionExecutor::executeSwitch<OPERAND_TYPE, RESULT_TYPE, FUNC,
+            UnaryTryCastFunctionWrapper>(*params[0], result, nullptr /* dataPtr */);
+    }
+
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
+    static void UnaryExecListStructFunction(
+        const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        common::ValueVector& result, void* /*dataPtr*/ = nullptr) {
+        KU_ASSERT(params.size() == 1);
+        UnaryFunctionExecutor::executeSwitch<OPERAND_TYPE, RESULT_TYPE, FUNC,
+            UnaryListFunctionWrapper>(*params[0], result, nullptr /* dataPtr */);
     }
 
     template<typename RESULT_TYPE, typename FUNC>
@@ -148,15 +169,6 @@ struct ScalarFunction : public BaseScalarFunction {
         KU_ASSERT(params.size() == 2);
         BinaryFunctionExecutor::executeListStruct<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
             *params[0], *params[1], result);
-    }
-
-    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC>
-    static void UnaryExecListStructFunction(
-        const std::vector<std::shared_ptr<common::ValueVector>>& params,
-        common::ValueVector& result, void* /*dataPtr*/ = nullptr) {
-        KU_ASSERT(params.size() == 1);
-        UnaryFunctionExecutor::executeListStruct<OPERAND_TYPE, RESULT_TYPE, FUNC>(
-            *params[0], result);
     }
 
     scalar_exec_func execFunc;

--- a/src/processor/operator/persistent/copy_to_csv.cpp
+++ b/src/processor/operator/persistent/copy_to_csv.cpp
@@ -30,8 +30,9 @@ void CopyToCSVLocalState::init(CopyToInfo* info, MemoryManager* mm, ResultSet* r
     castFuncs.resize(info->dataPoses.size());
     for (auto i = 0u; i < info->dataPoses.size(); i++) {
         auto vectorToCast = resultSet->getValueVector(info->dataPoses[i]);
-        function::CastToStringFunction::getUnaryCastToStringExecFunction(
-            vectorToCast->dataType.getLogicalTypeID(), castFuncs[i]);
+        castFuncs[i] = function::CastFunction::bindCastFunction(
+            "cast", vectorToCast->dataType.getLogicalTypeID(), LogicalTypeID::STRING)
+                           ->execFunc;
         vectorsToCast.push_back(std::move(vectorToCast));
         auto castVector = std::make_unique<ValueVector>(LogicalTypeID::STRING, mm);
         castVectors.push_back(castVector.get());

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -196,12 +196,14 @@ Binder exception: Cannot match a built-in function for given function +(TIMESTAM
 ---- error
 Binder exception: Cannot match a built-in function for given function DATE. Supported inputs are
 (STRING) -> DATE
+(RDF_VARIANT) -> DATE
 
 -LOG BindFunctionWithWrongParamType
 -STATEMENT MATCH (a:person) WHERE date(2012) < 2 RETURN COUNT(*);
 ---- error
 Binder exception: Cannot match a built-in function for given function DATE(INT64). Supported inputs are
 (STRING) -> DATE
+(RDF_VARIANT) -> DATE
 
 -LOG OrderByVariableNotInScope
 -STATEMENT MATCH (a:person)-[e1:knows]->(b:person) RETURN SUM(a.age) ORDER BY a.ID;

--- a/test/test_files/rdf/rdfox_example.test
+++ b/test/test_files/rdf/rdfox_example.test
@@ -5,7 +5,6 @@
 
 -CASE Basic
 
-
 -STATEMENT CALL SHOW_TABLES() RETURN *;
 ---- 5
 example_literal_triples_t|REL|
@@ -33,7 +32,7 @@ http://www.w3.org/1999/02/22-rdf-syntax-ns#type
 :brian
 
 
--STATEMENT MATCH (s:example_literal_t) RETURN s.iri ORDER BY s.id;
+-STATEMENT MATCH (s:example_literal_t) RETURN s.iri ORDER BY s.id ;
 -CHECK_ORDER
 ---- 16
 12
@@ -52,6 +51,32 @@ male
 Stewie
 male
 Brian
+
+-STATEMENT MATCH (s:example_literal_t) RETURN s.iri,
+        to_int64(s.iri) + 1, to_int32(s.iri), to_int16(s.iri), to_int8(s.iri) * 2,
+        to_uint64(s.iri), to_uint32(s.iri), to_uint16(s.iri), to_uint8(s.iri),
+        to_double(s.iri), to_float(s.iri), to_bool(s.iri), to_blob(s.iri),
+        date(s.iri), timestamp(s.iri), interval(s.iri), to_string(s.iri)
+        ORDER BY s.id LIMIT 6;
+-CHECK_ORDER
+---- 6
+12|13|12|12|24|12|12|12|12|12.000000|12.000000||||||12
+-14.900000|-14|-15|-15|-30|||||-14.900000|-14.900000||||||-14.900000
+True|||||||||||True|||||True
+0.016630|1|0|0|0|0|0|0|0|0.016630|0.016630||||||0.016630
+1999-08-16|||||||||||||1999-08-16|||1999-08-16
+Peter||||||||||||||||Peter
+
+-STATEMENT MATCH (s:example_literal_t) RETURN s.iri +1, s.iri * 2, s.iri * 2.0, s.iri = true, dayname(s.iri), concat(s.iri, 'a')
+        ORDER BY s.id LIMIT 6;
+-CHECK_ORDER
+---- 6
+13|24|24.000000|||12a
+-14|-30|-29.800000|||-14.900000a
+|||True||Truea
+1|0|0.033260|||0.016630a
+||||Monday|1999-08-16a
+|||||Petera
 
 -CASE tmp
 -SKIP

--- a/test/test_files/tinysnb/cast/cast_error.test
+++ b/test/test_files/tinysnb/cast/cast_error.test
@@ -583,7 +583,7 @@ Conversion exception: Cast failed. [[231|4324] is not in INT64[][] range.
 Binder exception: Invalid number of arguments for given function CAST.
 -STATEMENT MATCH (:person)-[e:studyAt]->(:organisation) return cast(e, "INT64");
 ---- error
-Unimplemented casting Function from REL to numeric.
+Unimplemented casting function from REL to INT64.
 -STATEMENT RETURN cast("dfsdfasdgv", "INTERNAL_ID");
 ---- error
-Unimplemented casting Function from string to INTERNAL_ID.
+Unimplemented casting function from STRING to INTERNAL_ID.


### PR DESCRIPTION
This PR contains the following changes

- Add casting function to RDF_VARIANT, RDF_VARIANT can be casted to any data type. On casting failure, instead of throwing runtime exception, we set casting result to NULL.
- Rework casting framework. We now only expose one `bindCastFunction` interface which returns a casting function for a given pair of src and dst type.