### PR TITLE
enable asserts by default in debug mode

### DIFF
--- a/src/include/common/assert.h
+++ b/src/include/common/assert.h
@@ -13,7 +13,7 @@ namespace common {
     // LCOV_EXCL_END
 }
 
-#ifdef KUZU_RUNTIME_CHECKS
+#if defined(KUZU_RUNTIME_CHECKS) || !defined(NDEBUG)
 #define KU_ASSERT(condition)                                                                       \
     if (!(condition)) {                                                                            \
         [[unlikely]] kuzu::common::kuAssertFailureInternal(#condition, __FILE__, __LINE__);        \


### PR DESCRIPTION
Disabling asserts by default in debug mode is counter-intuitive.