### PR TITLE
common/assert: make KU_ASSERT an expression

### DIFF
--- a/src/common/copier_config/copier_config.cpp
+++ b/src/common/copier_config/copier_config.cpp
@@ -1,7 +1,7 @@
 #include "common/copier_config/copier_config.h"
 
-#include "common/assert.h"
 #include "common/exception/copy.h"
+#include "common/exception/not_implemented.h"
 
 namespace kuzu {
 namespace common {
@@ -34,11 +34,11 @@ std::string FileTypeUtils::toString(FileType fileType) {
     case FileType::TURTLE: {
         return "TURTLE";
     }
-        // LCOV_EXCL_START
     default: {
-        KU_ASSERT(false)
-    }
+        // LCOV_EXCL_START
+        throw NotImplementedException("Unknown file type in FileTypeUtils::toString");
         // LCOV_EXCL_END
+    }
     }
 }
 

--- a/src/include/common/assert.h
+++ b/src/include/common/assert.h
@@ -13,13 +13,15 @@ namespace common {
     // LCOV_EXCL_END
 }
 
+// Roughly copy the definition in <assert.h>. Specifically, we make `assert` an expression that
+// evaluates to void(0).
 #if defined(KUZU_RUNTIME_CHECKS) || !defined(NDEBUG)
 #define KU_ASSERT(condition)                                                                       \
-    if (!(condition)) {                                                                            \
-        [[unlikely]] kuzu::common::kuAssertFailureInternal(#condition, __FILE__, __LINE__);        \
-    }
+    static_cast<bool>(condition) ?                                                                 \
+        void(0) :                                                                                  \
+        kuzu::common::kuAssertFailureInternal(#condition, __FILE__, __LINE__)
 #else
-#define KU_ASSERT(condition)
+#define KU_ASSERT(condition) void(0)
 #endif
 
 } // namespace common

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -38,7 +38,7 @@ void NodeGroup::resetToEmpty() {
 }
 
 void NodeGroup::setChunkToAllNull(common::vector_idx_t chunkIdx) {
-    KU_ASSERT(chunkIdx < chunks.size())
+    KU_ASSERT(chunkIdx < chunks.size());
     chunks[chunkIdx]->getNullChunk()->resetToAllNull();
 }
 


### PR DESCRIPTION
This is compliant with the behaviour of std::assert, and avoids warnings about redundant semicolons and potentionally some about duplicate parantheses.