### PR TITLE
Fix issue-2343

### DIFF
--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -108,7 +108,7 @@ std::unique_ptr<CSVReaderConfig> Binder::bindParsingOptions(
 
         auto copyOptionExpression = parsingOption.second.get();
         auto boundCopyOptionExpression = expressionBinder.bindExpression(*copyOptionExpression);
-        KU_ASSERT(boundCopyOptionExpression->expressionType == LITERAL);
+        KU_ASSERT(boundCopyOptionExpression->expressionType == ExpressionType::LITERAL);
         if (isValidBoolParsingOption) {
             if (boundCopyOptionExpression->dataType.getLogicalTypeID() != LogicalTypeID::BOOL) {
                 throw BinderException(

--- a/src/binder/bind_expression/bind_boolean_expression.cpp
+++ b/src/binder/bind_expression/bind_boolean_expression.cpp
@@ -44,7 +44,8 @@ std::shared_ptr<Expression> ExpressionBinder::combineConjunctiveExpressions(
     } else if (right == nullptr) {
         return left;
     } else {
-        return bindBooleanExpression(AND, expression_vector{std::move(left), std::move(right)});
+        return bindBooleanExpression(
+            ExpressionType::AND, expression_vector{std::move(left), std::move(right)});
     }
 }
 

--- a/src/binder/bind_expression/bind_case_expression.cpp
+++ b/src/binder/bind_expression/bind_case_expression.cpp
@@ -33,8 +33,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindCaseExpression(
             auto boundWhen = bindExpression(*caseAlternative->whenExpression);
             boundWhen = implicitCastIfNecessary(boundWhen, boundCase->dataType);
             // rewrite "CASE a.age WHEN 1" as "CASE WHEN a.age = 1"
-            boundWhen = bindComparisonExpression(
-                EQUALS, std::vector<std::shared_ptr<Expression>>{boundCase, boundWhen});
+            boundWhen = bindComparisonExpression(ExpressionType::EQUALS,
+                std::vector<std::shared_ptr<Expression>>{boundCase, boundWhen});
             auto boundThen = bindExpression(*caseAlternative->thenExpression);
             boundThen = implicitCastIfNecessary(boundThen, outDataType);
             boundCaseExpression->addCaseAlternative(boundWhen, boundThen);

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -44,7 +44,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::createEqualityComparisonExpression(
     std::shared_ptr<Expression> left, std::shared_ptr<Expression> right) {
-    return bindComparisonExpression(EQUALS, expression_vector{std::move(left), std::move(right)});
+    return bindComparisonExpression(
+        ExpressionType::EQUALS, expression_vector{std::move(left), std::move(right)});
 }
 
 } // namespace binder

--- a/src/binder/expression/expression.cpp
+++ b/src/binder/expression/expression.cpp
@@ -7,7 +7,7 @@ namespace binder {
 
 expression_vector Expression::splitOnAND() {
     expression_vector result;
-    if (AND == expressionType) {
+    if (ExpressionType::AND == expressionType) {
         for (auto& child : children) {
             for (auto& exp : child->splitOnAND()) {
                 result.push_back(exp);

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -1,5 +1,7 @@
 #include "binder/expression/expression_util.h"
 
+using namespace kuzu::common;
+
 namespace kuzu {
 namespace binder {
 
@@ -95,6 +97,21 @@ expression_vector ExpressionUtil::removeDuplication(const expression_vector& exp
         expressionSet.insert(expression);
     }
     return result;
+}
+
+bool ExpressionUtil::isNodePattern(const Expression& expression) {
+    return expression.expressionType == ExpressionType::PATTERN &&
+           expression.dataType.getLogicalTypeID() == LogicalTypeID::NODE;
+};
+
+bool ExpressionUtil::isRelPattern(const Expression& expression) {
+    return expression.expressionType == ExpressionType::PATTERN &&
+           expression.dataType.getLogicalTypeID() == LogicalTypeID::REL;
+}
+
+bool ExpressionUtil::isRecursiveRelPattern(const kuzu::binder::Expression& expression) {
+    return expression.expressionType == ExpressionType::PATTERN &&
+           expression.dataType.getLogicalTypeID() == LogicalTypeID::RECURSIVE_REL;
 }
 
 } // namespace binder

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -27,19 +27,19 @@ std::shared_ptr<Expression> ExpressionBinder::bindExpression(
         expression = bindComparisonExpression(parsedExpression);
     } else if (isExpressionNullOperator(expressionType)) {
         expression = bindNullOperatorExpression(parsedExpression);
-    } else if (FUNCTION == expressionType) {
+    } else if (ExpressionType::FUNCTION == expressionType) {
         expression = bindFunctionExpression(parsedExpression);
-    } else if (PROPERTY == expressionType) {
+    } else if (ExpressionType::PROPERTY == expressionType) {
         expression = bindPropertyExpression(parsedExpression);
-    } else if (PARAMETER == expressionType) {
+    } else if (ExpressionType::PARAMETER == expressionType) {
         expression = bindParameterExpression(parsedExpression);
     } else if (isExpressionLiteral(expressionType)) {
         expression = bindLiteralExpression(parsedExpression);
-    } else if (VARIABLE == expressionType) {
+    } else if (ExpressionType::VARIABLE == expressionType) {
         expression = bindVariableExpression(parsedExpression);
-    } else if (EXISTENTIAL_SUBQUERY == expressionType) {
+    } else if (ExpressionType::EXISTENTIAL_SUBQUERY == expressionType) {
         expression = bindExistentialSubqueryExpression(parsedExpression);
-    } else if (CASE_ELSE == expressionType) {
+    } else if (ExpressionType::CASE_ELSE == expressionType) {
         expression = bindCaseExpression(parsedExpression);
     } else {
         throw NotImplementedException(
@@ -119,7 +119,7 @@ std::shared_ptr<Expression> ExpressionBinder::implicitCast(
         auto scalarFunction = CastFunction::bindCastFunction(
             functionName, expression->dataType.getLogicalTypeID(), targetType.getLogicalTypeID());
         auto uniqueName = ScalarFunctionExpression::getUniqueName(functionName, children);
-        return std::make_shared<ScalarFunctionExpression>(functionName, FUNCTION,
+        return std::make_shared<ScalarFunctionExpression>(functionName, ExpressionType::FUNCTION,
             std::move(bindData), std::move(children), scalarFunction->execFunc,
             nullptr /* selectFunc */, std::move(uniqueName));
     } else {
@@ -128,10 +128,10 @@ std::shared_ptr<Expression> ExpressionBinder::implicitCast(
 }
 
 void ExpressionBinder::resolveAnyDataType(Expression& expression, const LogicalType& targetType) {
-    if (expression.expressionType == PARAMETER) { // expression is parameter
+    if (expression.expressionType == ExpressionType::PARAMETER) { // expression is parameter
         ((ParameterExpression&)expression).setDataType(targetType);
     } else { // expression is null literal
-        KU_ASSERT(expression.expressionType == LITERAL);
+        KU_ASSERT(expression.expressionType == ExpressionType::LITERAL);
         ((LiteralExpression&)expression).setDataType(targetType);
     }
 }

--- a/src/binder/expression_visitor.cpp
+++ b/src/binder/expression_visitor.cpp
@@ -19,7 +19,7 @@ expression_vector ExpressionChildrenCollector::collectChildren(const Expression&
     case ExpressionType::EXISTENTIAL_SUBQUERY: {
         return collectExistentialSubqueryChildren(expression);
     }
-    case ExpressionType::VARIABLE: {
+    case ExpressionType::PATTERN: {
         switch (expression.dataType.getLogicalTypeID()) {
         case LogicalTypeID::NODE: {
             return collectNodeChildren(expression);
@@ -118,6 +118,7 @@ std::unordered_set<std::string> ExpressionCollector::getDependentVariableNames(
     KU_ASSERT(expressions.empty());
     collectExpressionsInternal(expression, [&](const Expression& expression) {
         return expression.expressionType == ExpressionType::PROPERTY ||
+               expression.expressionType == ExpressionType::PATTERN ||
                expression.expressionType == ExpressionType::VARIABLE;
     });
     std::unordered_set<std::string> result;
@@ -126,7 +127,6 @@ std::unordered_set<std::string> ExpressionCollector::getDependentVariableNames(
             auto property = (PropertyExpression*)expr.get();
             result.insert(property->getVariableName());
         } else {
-            KU_ASSERT(expr->expressionType == ExpressionType::VARIABLE);
             result.insert(expr->getUniqueName());
         }
     }

--- a/src/binder/rewriter/with_clause_projection_rewriter.cpp
+++ b/src/binder/rewriter/with_clause_projection_rewriter.cpp
@@ -25,7 +25,7 @@ static expression_vector rewriteExpressions(
     const expression_vector& expressions, const expression_vector& properties) {
     expression_set distinctResult;
     for (auto& expression : expressions) {
-        if (expression->expressionType != common::PROPERTY) {
+        if (expression->expressionType != common::ExpressionType::PROPERTY) {
             distinctResult.insert(expression);
             continue;
         }

--- a/src/catalog/catalog_content.cpp
+++ b/src/catalog/catalog_content.cpp
@@ -206,7 +206,7 @@ void CatalogContent::readFromFile(const std::string& directory, FileVersionType 
 ExpressionType CatalogContent::getFunctionType(const std::string& name) const {
     auto upperCaseName = StringUtils::getUpper(name);
     if (macros.contains(upperCaseName)) {
-        return MACRO;
+        return ExpressionType::MACRO;
     } else if (!builtInFunctions->containsFunction(name)) {
         throw CatalogException(name + " function does not exist.");
     } else {
@@ -214,9 +214,9 @@ ExpressionType CatalogContent::getFunctionType(const std::string& name) const {
         auto funcType = builtInFunctions->getFunctionType(upperCaseName);
         switch (funcType) {
         case function::FunctionType::SCALAR:
-            return FUNCTION;
+            return ExpressionType::FUNCTION;
         case function::FunctionType::AGGREGATE:
-            return AGGREGATE_FUNCTION;
+            return ExpressionType::AGGREGATE_FUNCTION;
         default:
             // LCOV_EXCL_START
             throw NotImplementedException("CatalogContent::getFunctionType");

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -6,82 +6,88 @@ namespace kuzu {
 namespace common {
 
 bool isExpressionUnary(ExpressionType type) {
-    return NOT == type || IS_NULL == type || IS_NOT_NULL == type;
+    return ExpressionType::NOT == type || ExpressionType::IS_NULL == type ||
+           ExpressionType::IS_NOT_NULL == type;
 }
 
 bool isExpressionBinary(ExpressionType type) {
-    return isExpressionComparison(type) || OR == type || XOR == type || AND == type;
+    return isExpressionComparison(type) || ExpressionType::OR == type ||
+           ExpressionType::XOR == type || ExpressionType::AND == type;
 }
 
 bool isExpressionBoolConnection(ExpressionType type) {
-    return OR == type || XOR == type || AND == type || NOT == type;
+    return ExpressionType::OR == type || ExpressionType::XOR == type ||
+           ExpressionType::AND == type || ExpressionType::NOT == type;
 }
 
 bool isExpressionComparison(ExpressionType type) {
-    return EQUALS == type || NOT_EQUALS == type || GREATER_THAN == type ||
-           GREATER_THAN_EQUALS == type || LESS_THAN == type || LESS_THAN_EQUALS == type;
+    return ExpressionType::EQUALS == type || ExpressionType::NOT_EQUALS == type ||
+           ExpressionType::GREATER_THAN == type || ExpressionType::GREATER_THAN_EQUALS == type ||
+           ExpressionType::LESS_THAN == type || ExpressionType::LESS_THAN_EQUALS == type;
 }
 
 bool isExpressionNullOperator(ExpressionType type) {
-    return IS_NULL == type || IS_NOT_NULL == type;
+    return ExpressionType::IS_NULL == type || ExpressionType::IS_NOT_NULL == type;
 }
 
 bool isExpressionLiteral(ExpressionType type) {
-    return LITERAL == type;
+    return ExpressionType::LITERAL == type;
 }
 
 bool isExpressionAggregate(ExpressionType type) {
-    return AGGREGATE_FUNCTION == type;
+    return ExpressionType::AGGREGATE_FUNCTION == type;
 }
 
 bool isExpressionSubquery(ExpressionType type) {
-    return EXISTENTIAL_SUBQUERY == type;
+    return ExpressionType::EXISTENTIAL_SUBQUERY == type;
 }
 
 // LCOV_EXCL_START
 std::string expressionTypeToString(ExpressionType type) {
     switch (type) {
-    case OR:
+    case ExpressionType::OR:
         return "OR";
-    case XOR:
+    case ExpressionType::XOR:
         return "XOR";
-    case AND:
+    case ExpressionType::AND:
         return "AND";
-    case NOT:
+    case ExpressionType::NOT:
         return "NOT";
-    case EQUALS:
+    case ExpressionType::EQUALS:
         return EQUALS_FUNC_NAME;
-    case NOT_EQUALS:
+    case ExpressionType::NOT_EQUALS:
         return NOT_EQUALS_FUNC_NAME;
-    case GREATER_THAN:
+    case ExpressionType::GREATER_THAN:
         return GREATER_THAN_FUNC_NAME;
-    case GREATER_THAN_EQUALS:
+    case ExpressionType::GREATER_THAN_EQUALS:
         return GREATER_THAN_EQUALS_FUNC_NAME;
-    case LESS_THAN:
+    case ExpressionType::LESS_THAN:
         return LESS_THAN_FUNC_NAME;
-    case LESS_THAN_EQUALS:
+    case ExpressionType::LESS_THAN_EQUALS:
         return LESS_THAN_EQUALS_FUNC_NAME;
-    case IS_NULL:
+    case ExpressionType::IS_NULL:
         return "IS_NULL";
-    case IS_NOT_NULL:
+    case ExpressionType::IS_NOT_NULL:
         return "IS_NOT_NULL";
-    case PROPERTY:
+    case ExpressionType::PROPERTY:
         return "PROPERTY";
-    case LITERAL:
+    case ExpressionType::LITERAL:
         return "LITERAL";
-    case STAR:
+    case ExpressionType::STAR:
         return "STAR";
-    case VARIABLE:
+    case ExpressionType::VARIABLE:
         return "VARIABLE";
-    case PATH:
+    case ExpressionType::PATH:
         return "PATH";
-    case PARAMETER:
+    case ExpressionType::PATTERN:
+        return "PATTERN";
+    case ExpressionType::PARAMETER:
         return "PARAMETER";
-    case FUNCTION:
+    case ExpressionType::FUNCTION:
         return "SCALAR_FUNCTION";
-    case AGGREGATE_FUNCTION:
+    case ExpressionType::AGGREGATE_FUNCTION:
         return "AGGREGATE_FUNCTION";
-    case EXISTENTIAL_SUBQUERY:
+    case ExpressionType::EXISTENTIAL_SUBQUERY:
         return "EXISTENTIAL_SUBQUERY";
     default:
         KU_UNREACHABLE;

--- a/src/function/aggregate/count.cpp
+++ b/src/function/aggregate/count.cpp
@@ -30,10 +30,10 @@ void CountFunction::updateAll(
 
 void CountFunction::paramRewriteFunc(binder::expression_vector& arguments) {
     KU_ASSERT(arguments.size() == 1);
-    if (ExpressionUtil::isNodeVariable(*arguments[0])) {
+    if (ExpressionUtil::isNodePattern(*arguments[0])) {
         auto node = (NodeExpression*)arguments[0].get();
         arguments[0] = node->getInternalID();
-    } else if (ExpressionUtil::isRelVariable(*arguments[0])) {
+    } else if (ExpressionUtil::isRelPattern(*arguments[0])) {
         auto rel = (RelExpression*)arguments[0].get();
         arguments[0] = rel->getInternalIDProperty();
     }

--- a/src/function/vector_boolean_functions.cpp
+++ b/src/function/vector_boolean_functions.cpp
@@ -35,15 +35,15 @@ void VectorBooleanFunction::bindBinaryExecFunction(ExpressionType expressionType
     KU_ASSERT(leftType.getLogicalTypeID() == LogicalTypeID::BOOL &&
               rightType.getLogicalTypeID() == LogicalTypeID::BOOL);
     switch (expressionType) {
-    case AND: {
+    case ExpressionType::AND: {
         func = &BinaryBooleanExecFunction<And>;
         return;
     }
-    case OR: {
+    case ExpressionType::OR: {
         func = &BinaryBooleanExecFunction<Or>;
         return;
     }
-    case XOR: {
+    case ExpressionType::XOR: {
         func = &BinaryBooleanExecFunction<Xor>;
         return;
     }
@@ -61,15 +61,15 @@ void VectorBooleanFunction::bindBinarySelectFunction(ExpressionType expressionTy
     KU_ASSERT(leftType.getLogicalTypeID() == LogicalTypeID::BOOL &&
               rightType.getLogicalTypeID() == LogicalTypeID::BOOL);
     switch (expressionType) {
-    case AND: {
+    case ExpressionType::AND: {
         func = &BinaryBooleanSelectFunction<And>;
         return;
     }
-    case OR: {
+    case ExpressionType::OR: {
         func = &BinaryBooleanSelectFunction<Or>;
         return;
     }
-    case XOR: {
+    case ExpressionType::XOR: {
         func = &BinaryBooleanSelectFunction<Xor>;
         return;
     }
@@ -85,7 +85,7 @@ void VectorBooleanFunction::bindUnaryExecFunction(ExpressionType expressionType,
         children.size() == 1 && children[0]->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     (void)children;
     switch (expressionType) {
-    case NOT: {
+    case ExpressionType::NOT: {
         func = &UnaryBooleanExecFunction<Not>;
         return;
     }
@@ -101,7 +101,7 @@ void VectorBooleanFunction::bindUnarySelectFunction(ExpressionType expressionTyp
         children.size() == 1 && children[0]->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     (void)children;
     switch (expressionType) {
-    case NOT: {
+    case ExpressionType::NOT: {
         func = &UnaryBooleanSelectFunction<Not>;
         return;
     }

--- a/src/function/vector_null_functions.cpp
+++ b/src/function/vector_null_functions.cpp
@@ -10,11 +10,11 @@ namespace function {
 void VectorNullFunction::bindExecFunction(ExpressionType expressionType,
     const binder::expression_vector& /*children*/, scalar_exec_func& func) {
     switch (expressionType) {
-    case IS_NULL: {
+    case ExpressionType::IS_NULL: {
         func = UnaryNullExecFunction<IsNull>;
         return;
     }
-    case IS_NOT_NULL: {
+    case ExpressionType::IS_NOT_NULL: {
         func = UnaryNullExecFunction<IsNotNull>;
         return;
     }
@@ -29,11 +29,11 @@ void VectorNullFunction::bindSelectFunction(ExpressionType expressionType,
     KU_ASSERT(children.size() == 1);
     (void)children;
     switch (expressionType) {
-    case IS_NULL: {
+    case ExpressionType::IS_NULL: {
         func = UnaryNullSelectFunction<IsNull>;
         return;
     }
-    case IS_NOT_NULL: {
+    case ExpressionType::IS_NOT_NULL: {
         func = UnaryNullSelectFunction<IsNotNull>;
         return;
     }

--- a/src/function/vector_struct_functions.cpp
+++ b/src/function/vector_struct_functions.cpp
@@ -95,7 +95,7 @@ function_set StructExtractFunctions::getFunctionSet() {
 std::unique_ptr<FunctionBindData> StructExtractFunctions::bindFunc(
     const binder::expression_vector& arguments, Function* /*function*/) {
     auto structType = arguments[0]->getDataType();
-    if (arguments[1]->expressionType != LITERAL) {
+    if (arguments[1]->expressionType != ExpressionType::LITERAL) {
         throw BinderException("Key name for struct/union extract must be STRING literal.");
     }
     auto key = ((binder::LiteralExpression&)*arguments[1]).getValue()->getValue<std::string>();

--- a/src/include/binder/expression/case_expression.h
+++ b/src/include/binder/expression/case_expression.h
@@ -18,8 +18,8 @@ class CaseExpression : public Expression {
 public:
     CaseExpression(common::LogicalType dataType, std::shared_ptr<Expression> elseExpression,
         const std::string& name)
-        : Expression{common::CASE_ELSE, std::move(dataType), name}, elseExpression{std::move(
-                                                                        elseExpression)} {}
+        : Expression{common::ExpressionType::CASE_ELSE, std::move(dataType), name},
+          elseExpression{std::move(elseExpression)} {}
 
     inline void addCaseAlternative(
         std::shared_ptr<Expression> when, std::shared_ptr<Expression> then) {

--- a/src/include/binder/expression/existential_subquery_expression.h
+++ b/src/include/binder/expression/existential_subquery_expression.h
@@ -10,8 +10,8 @@ class ExistentialSubqueryExpression : public Expression {
 public:
     ExistentialSubqueryExpression(std::unique_ptr<QueryGraphCollection> queryGraphCollection,
         std::string uniqueName, std::string rawName)
-        : Expression{common::EXISTENTIAL_SUBQUERY, common::LogicalType(common::LogicalTypeID::BOOL),
-              std::move(uniqueName)},
+        : Expression{common::ExpressionType::EXISTENTIAL_SUBQUERY,
+              common::LogicalType(common::LogicalTypeID::BOOL), std::move(uniqueName)},
           queryGraphCollection{std::move(queryGraphCollection)}, rawName{std::move(rawName)} {}
 
     inline QueryGraphCollection* getQueryGraphCollection() const {

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -23,23 +23,14 @@ struct ExpressionUtil {
     static expression_vector excludeExpressions(
         const expression_vector& expressions, const expression_vector& expressionsToExclude);
 
-    inline static bool isNodeVariable(const Expression& expression) {
-        return expression.expressionType == common::ExpressionType::VARIABLE &&
-               expression.dataType.getLogicalTypeID() == common::LogicalTypeID::NODE;
-    }
-    inline static bool isRelVariable(const Expression& expression) {
-        return expression.expressionType == common::ExpressionType::VARIABLE &&
-               expression.dataType.getLogicalTypeID() == common::LogicalTypeID::REL;
-    }
-    inline static bool isRecursiveRelVariable(const Expression& expression) {
-        return expression.expressionType == common::ExpressionType::VARIABLE &&
-               expression.dataType.getLogicalTypeID() == common::LogicalTypeID::RECURSIVE_REL;
-    }
-
     static std::vector<std::unique_ptr<common::LogicalType>> getDataTypes(
         const expression_vector& expressions);
 
     static expression_vector removeDuplication(const expression_vector& expressions);
+
+    static bool isNodePattern(const Expression& expression);
+    static bool isRelPattern(const Expression& expression);
+    static bool isRecursiveRelPattern(const Expression& expression);
 };
 
 } // namespace binder

--- a/src/include/binder/expression/function_expression.h
+++ b/src/include/binder/expression/function_expression.h
@@ -81,7 +81,7 @@ public:
         std::unique_ptr<function::FunctionBindData> bindData, expression_vector children,
         std::unique_ptr<function::AggregateFunction> aggregateFunction,
         const std::string& uniqueName)
-        : FunctionExpression{std::move(functionName), common::AGGREGATE_FUNCTION,
+        : FunctionExpression{std::move(functionName), common::ExpressionType::AGGREGATE_FUNCTION,
               std::move(bindData), std::move(children), uniqueName},
           aggregateFunction{std::move(aggregateFunction)} {}
 

--- a/src/include/binder/expression/literal_expression.h
+++ b/src/include/binder/expression/literal_expression.h
@@ -9,7 +9,8 @@ namespace binder {
 class LiteralExpression : public Expression {
 public:
     LiteralExpression(std::unique_ptr<common::Value> value, const std::string& uniqueName)
-        : Expression{common::LITERAL, *value->getDataType(), uniqueName}, value{std::move(value)} {}
+        : Expression{common::ExpressionType::LITERAL, *value->getDataType(), uniqueName},
+          value{std::move(value)} {}
 
     inline bool isNull() const { return value->isNull(); }
 

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -11,7 +11,7 @@ class NodeOrRelExpression : public Expression {
 public:
     NodeOrRelExpression(common::LogicalType dataType, std::string uniqueName,
         std::string variableName, std::vector<common::table_id_t> tableIDs)
-        : Expression{common::VARIABLE, std::move(dataType), std::move(uniqueName)},
+        : Expression{common::ExpressionType::PATTERN, std::move(dataType), std::move(uniqueName)},
           variableName(std::move(variableName)), tableIDs{std::move(tableIDs)} {}
     virtual ~NodeOrRelExpression() override = default;
 

--- a/src/include/binder/expression/parameter_expression.h
+++ b/src/include/binder/expression/parameter_expression.h
@@ -10,8 +10,8 @@ class ParameterExpression : public Expression {
 public:
     explicit ParameterExpression(
         const std::string& parameterName, std::shared_ptr<common::Value> value)
-        : Expression{common::PARAMETER, common::LogicalType(common::LogicalTypeID::ANY),
-              createUniqueName(parameterName)},
+        : Expression{common::ExpressionType::PARAMETER,
+              common::LogicalType(common::LogicalTypeID::ANY), createUniqueName(parameterName)},
           parameterName(parameterName), value{std::move(value)} {}
 
     inline void setDataType(const common::LogicalType& targetType) {

--- a/src/include/binder/expression/path_expression.h
+++ b/src/include/binder/expression/path_expression.h
@@ -10,7 +10,8 @@ public:
     PathExpression(common::LogicalType dataType, std::string uniqueName, std::string variableName,
         std::unique_ptr<common::LogicalType> nodeType, std::unique_ptr<common::LogicalType> relType,
         expression_vector children)
-        : Expression{common::PATH, std::move(dataType), std::move(children), std::move(uniqueName)},
+        : Expression{common::ExpressionType::PATH, std::move(dataType), std::move(children),
+              std::move(uniqueName)},
           variableName{std::move(variableName)}, nodeType{std::move(nodeType)}, relType{std::move(
                                                                                     relType)} {}
 

--- a/src/include/binder/expression/property_expression.h
+++ b/src/include/binder/expression/property_expression.h
@@ -13,14 +13,14 @@ public:
         const std::string& uniqueVariableName, const std::string& rawVariableName,
         std::unordered_map<common::table_id_t, common::property_id_t> propertyIDPerTable,
         bool isPrimaryKey_)
-        : Expression{common::PROPERTY, std::move(dataType),
+        : Expression{common::ExpressionType::PROPERTY, std::move(dataType),
               uniqueVariableName + "." + propertyName},
           isPrimaryKey_{isPrimaryKey_}, propertyName{propertyName},
           uniqueVariableName{uniqueVariableName}, rawVariableName{rawVariableName},
           propertyIDPerTable{std::move(propertyIDPerTable)} {}
 
     PropertyExpression(const PropertyExpression& other)
-        : Expression{common::PROPERTY, other.dataType, other.uniqueName},
+        : Expression{common::ExpressionType::PROPERTY, other.dataType, other.uniqueName},
           isPrimaryKey_{other.isPrimaryKey_}, propertyName{other.propertyName},
           uniqueVariableName{other.uniqueVariableName}, rawVariableName{other.rawVariableName},
           propertyIDPerTable{other.propertyIDPerTable} {}

--- a/src/include/binder/expression/variable_expression.h
+++ b/src/include/binder/expression/variable_expression.h
@@ -9,7 +9,7 @@ class VariableExpression : public Expression {
 public:
     VariableExpression(
         common::LogicalType dataType, std::string uniqueName, std::string variableName)
-        : Expression{common::VARIABLE, std::move(dataType), std::move(uniqueName)},
+        : Expression{common::ExpressionType::VARIABLE, std::move(dataType), std::move(uniqueName)},
           variableName{std::move(variableName)} {}
 
     inline std::string toStringInternal() const final { return variableName; }

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -46,8 +46,7 @@ private:
         const parser::ParsedExpression& parsedExpression);
     // Property expressions.
     expression_vector bindPropertyStarExpression(const parser::ParsedExpression& parsedExpression);
-    expression_vector bindNodePropertyStarExpression(const Expression& child);
-    expression_vector bindRelPropertyStarExpression(const Expression& child);
+    expression_vector bindNodeOrRelPropertyStarExpression(const Expression& child);
     expression_vector bindStructPropertyStarExpression(std::shared_ptr<Expression> child);
     std::shared_ptr<Expression> bindPropertyExpression(
         const parser::ParsedExpression& parsedExpression);

--- a/src/include/common/enums/expression_type.h
+++ b/src/include/common/enums/expression_type.h
@@ -228,7 +228,7 @@ const std::string CURRENT_SETTING_FUNC_NAME = "CURRENT_SETTING";
 const std::string SHOW_TABLES_FUNC_NAME = "SHOW_TABLES";
 const std::string SHOW_CONNECTION_FUNC_NAME = "SHOW_CONNECTION";
 
-enum ExpressionType : uint8_t {
+enum class ExpressionType : uint8_t {
 
     // Boolean Connection Expressions
     OR = 0,
@@ -256,6 +256,7 @@ enum ExpressionType : uint8_t {
 
     VARIABLE = 90,
     PATH = 91,
+    PATTERN = 92, // Node & Rel pattern
 
     PARAMETER = 100,
 

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -45,7 +45,7 @@ private:
 
 private:
     binder::expression_set propertiesInUse;
-    binder::expression_set variablesInUse;
+    binder::expression_set patternInUse;
 };
 
 } // namespace optimizer

--- a/src/include/parser/expression/parsed_case_expression.h
+++ b/src/include/parser/expression/parsed_case_expression.h
@@ -32,13 +32,13 @@ class ParsedCaseExpression : public ParsedExpression {
 
 public:
     explicit ParsedCaseExpression(std::string raw)
-        : ParsedExpression{common::CASE_ELSE, std::move(raw)} {};
+        : ParsedExpression{common::ExpressionType::CASE_ELSE, std::move(raw)} {};
 
     ParsedCaseExpression(std::string alias, std::string rawName, parsed_expression_vector children,
         std::unique_ptr<ParsedExpression> caseExpression,
         std::vector<std::unique_ptr<ParsedCaseAlternative>> caseAlternatives,
         std::unique_ptr<ParsedExpression> elseExpression)
-        : ParsedExpression{common::CASE_ELSE, std::move(alias), std::move(rawName),
+        : ParsedExpression{common::ExpressionType::CASE_ELSE, std::move(alias), std::move(rawName),
               std::move(children)},
           caseExpression{std::move(caseExpression)}, caseAlternatives{std::move(caseAlternatives)},
           elseExpression{std::move(elseExpression)} {}
@@ -46,7 +46,8 @@ public:
     ParsedCaseExpression(std::unique_ptr<ParsedExpression> caseExpression,
         std::vector<std::unique_ptr<ParsedCaseAlternative>> caseAlternatives,
         std::unique_ptr<ParsedExpression> elseExpression)
-        : ParsedExpression{common::CASE_ELSE}, caseExpression{std::move(caseExpression)},
+        : ParsedExpression{common::ExpressionType::CASE_ELSE}, caseExpression{std::move(
+                                                                   caseExpression)},
           caseAlternatives{std::move(caseAlternatives)}, elseExpression{std::move(elseExpression)} {
     }
 

--- a/src/include/parser/expression/parsed_function_expression.h
+++ b/src/include/parser/expression/parsed_function_expression.h
@@ -8,28 +8,29 @@ namespace parser {
 class ParsedFunctionExpression : public ParsedExpression {
 public:
     ParsedFunctionExpression(std::string functionName, std::string rawName, bool isDistinct = false)
-        : ParsedExpression{common::FUNCTION, std::move(rawName)}, isDistinct{isDistinct},
-          functionName{std::move(functionName)} {}
+        : ParsedExpression{common::ExpressionType::FUNCTION, std::move(rawName)},
+          isDistinct{isDistinct}, functionName{std::move(functionName)} {}
 
     ParsedFunctionExpression(std::string functionName, std::unique_ptr<ParsedExpression> child,
         std::string rawName, bool isDistinct = false)
-        : ParsedExpression{common::FUNCTION, std::move(child), std::move(rawName)},
+        : ParsedExpression{common::ExpressionType::FUNCTION, std::move(child), std::move(rawName)},
           isDistinct{isDistinct}, functionName{std::move(functionName)} {}
 
     ParsedFunctionExpression(std::string functionName, std::unique_ptr<ParsedExpression> left,
         std::unique_ptr<ParsedExpression> right, std::string rawName, bool isDistinct = false)
-        : ParsedExpression{common::FUNCTION, std::move(left), std::move(right), std::move(rawName)},
+        : ParsedExpression{common::ExpressionType::FUNCTION, std::move(left), std::move(right),
+              std::move(rawName)},
           isDistinct{isDistinct}, functionName{std::move(functionName)} {}
 
     ParsedFunctionExpression(std::string alias, std::string rawName,
         parsed_expression_vector children, bool isDistinct, std::string functionName)
-        : ParsedExpression{common::FUNCTION, std::move(alias), std::move(rawName),
+        : ParsedExpression{common::ExpressionType::FUNCTION, std::move(alias), std::move(rawName),
               std::move(children)},
           isDistinct{isDistinct}, functionName{std::move(functionName)} {}
 
     ParsedFunctionExpression(bool isDistinct, std::string functionName)
-        : ParsedExpression{common::FUNCTION}, isDistinct{isDistinct}, functionName{std::move(
-                                                                          functionName)} {}
+        : ParsedExpression{common::ExpressionType::FUNCTION}, isDistinct{isDistinct},
+          functionName{std::move(functionName)} {}
 
     inline bool getIsDistinct() const { return isDistinct; }
 

--- a/src/include/parser/expression/parsed_literal_expression.h
+++ b/src/include/parser/expression/parsed_literal_expression.h
@@ -9,7 +9,8 @@ namespace parser {
 class ParsedLiteralExpression : public ParsedExpression {
 public:
     ParsedLiteralExpression(std::unique_ptr<common::Value> value, std::string raw)
-        : ParsedExpression{common::LITERAL, std::move(raw)}, value{std::move(value)} {}
+        : ParsedExpression{common::ExpressionType::LITERAL, std::move(raw)}, value{std::move(
+                                                                                 value)} {}
 
     ParsedLiteralExpression(std::string alias, std::string rawName,
         parsed_expression_vector children, std::unique_ptr<common::Value> value)

--- a/src/include/parser/expression/parsed_parameter_expression.h
+++ b/src/include/parser/expression/parsed_parameter_expression.h
@@ -9,8 +9,8 @@ namespace parser {
 class ParsedParameterExpression : public ParsedExpression {
 public:
     explicit ParsedParameterExpression(std::string parameterName, std::string raw)
-        : ParsedExpression{common::PARAMETER, std::move(raw)}, parameterName{
-                                                                   std::move(parameterName)} {}
+        : ParsedExpression{common::ExpressionType::PARAMETER, std::move(raw)},
+          parameterName{std::move(parameterName)} {}
 
     inline std::string getParameterName() const { return parameterName; }
 

--- a/src/include/parser/expression/parsed_subquery_expression.h
+++ b/src/include/parser/expression/parsed_subquery_expression.h
@@ -11,7 +11,7 @@ class ParsedSubqueryExpression : public ParsedExpression {
 public:
     ParsedSubqueryExpression(
         std::vector<std::unique_ptr<PatternElement>> patternElements, std::string rawName)
-        : ParsedExpression{common::EXISTENTIAL_SUBQUERY, std::move(rawName)},
+        : ParsedExpression{common::ExpressionType::EXISTENTIAL_SUBQUERY, std::move(rawName)},
           patternElements{std::move(patternElements)} {}
 
     ParsedSubqueryExpression(common::ExpressionType type, std::string alias, std::string rawName,

--- a/src/include/parser/expression/parsed_variable_expression.h
+++ b/src/include/parser/expression/parsed_variable_expression.h
@@ -10,17 +10,18 @@ namespace parser {
 class ParsedVariableExpression : public ParsedExpression {
 public:
     ParsedVariableExpression(std::string variableName, std::string raw)
-        : ParsedExpression{common::VARIABLE, std::move(raw)}, variableName{
-                                                                  std::move(variableName)} {}
+        : ParsedExpression{common::ExpressionType::VARIABLE, std::move(raw)},
+          variableName{std::move(variableName)} {}
 
     ParsedVariableExpression(std::string alias, std::string rawName,
         parsed_expression_vector children, std::string variableName)
-        : ParsedExpression{common::VARIABLE, std::move(alias), std::move(rawName),
+        : ParsedExpression{common::ExpressionType::VARIABLE, std::move(alias), std::move(rawName),
               std::move(children)},
           variableName{std::move(variableName)} {}
 
     ParsedVariableExpression(std::string variableName)
-        : ParsedExpression{common::VARIABLE}, variableName{std::move(variableName)} {}
+        : ParsedExpression{common::ExpressionType::VARIABLE}, variableName{
+                                                                  std::move(variableName)} {}
 
     inline std::string getVariableName() const { return variableName; }
 

--- a/src/optimizer/agg_key_dependency_optimizer.cpp
+++ b/src/optimizer/agg_key_dependency_optimizer.cpp
@@ -48,7 +48,7 @@ AggKeyDependencyOptimizer::resolveKeysAndDependentKeys(const expression_vector& 
     // Collect primary variables from keys.
     std::unordered_set<std::string> primaryVarNames;
     for (auto& key : inputKeys) {
-        if (key->expressionType == PROPERTY) {
+        if (key->expressionType == ExpressionType::PROPERTY) {
             auto property = (PropertyExpression*)key.get();
             if (property->isPrimaryKey() || property->isInternalID()) {
                 primaryVarNames.insert(property->getVariableName());
@@ -59,7 +59,7 @@ AggKeyDependencyOptimizer::resolveKeysAndDependentKeys(const expression_vector& 
     binder::expression_vector keys;
     binder::expression_vector dependentKeys;
     for (auto& key : inputKeys) {
-        if (key->expressionType == PROPERTY) {
+        if (key->expressionType == ExpressionType::PROPERTY) {
             auto property = (PropertyExpression*)key.get();
             if (property->isPrimaryKey() ||
                 property->isInternalID()) { // NOLINT(bugprone-branch-clone): Collapsing
@@ -73,7 +73,7 @@ AggKeyDependencyOptimizer::resolveKeysAndDependentKeys(const expression_vector& 
             } else {
                 keys.push_back(key);
             }
-        } else if (ExpressionUtil::isNodeVariable(*key) || ExpressionUtil::isRelVariable(*key)) {
+        } else if (ExpressionUtil::isNodePattern(*key) || ExpressionUtil::isRelPattern(*key)) {
             if (primaryVarNames.contains(key->getUniqueName())) {
                 // e.g. a depends on a._id
                 dependentKeys.push_back(key);

--- a/src/parser/parsed_expression_visitor.cpp
+++ b/src/parser/parsed_expression_visitor.cpp
@@ -1,6 +1,5 @@
 #include "parser/parsed_expression_visitor.h"
 
-#include "common/exception/not_implemented.h"
 #include "parser/expression/parsed_case_expression.h"
 
 using namespace kuzu::common;
@@ -14,19 +13,13 @@ std::vector<ParsedExpression*> ParsedExpressionChildrenVisitor::collectChildren(
     case ExpressionType::CASE_ELSE: {
         return collectCaseChildren(expression);
     }
-    case ExpressionType::FUNCTION:
-    case ExpressionType::LITERAL:
-    case ExpressionType::PROPERTY:
-    case ExpressionType::VARIABLE: {
+    default: {
         std::vector<ParsedExpression*> parsedExpressions;
         parsedExpressions.reserve(expression.getNumChildren());
         for (auto& child : expression.children) {
             parsedExpressions.push_back(child.get());
         }
         return parsedExpressions;
-    }
-    default: {
-        throw NotImplementedException{"ParsedExpressionChildrenCollector::collectChildren"};
     }
     }
 }
@@ -37,14 +30,8 @@ void ParsedExpressionChildrenVisitor::setChild(kuzu::parser::ParsedExpression& e
     case ExpressionType::CASE_ELSE: {
         setCaseChild(expression, idx, std::move(expressionToSet));
     } break;
-    case ExpressionType::FUNCTION:
-    case ExpressionType::LITERAL:
-    case ExpressionType::PROPERTY:
-    case ExpressionType::VARIABLE: {
-        expression.children[idx] = std::move(expressionToSet);
-    } break;
     default: {
-        throw NotImplementedException{"ParsedExpressionChildrenVisitor::setChild"};
+        expression.children[idx] = std::move(expressionToSet);
     }
     }
 }

--- a/src/planner/join_order/cardinality_estimator.cpp
+++ b/src/planner/join_order/cardinality_estimator.cpp
@@ -90,7 +90,7 @@ static bool isPrimaryKey(const Expression& expression) {
 
 uint64_t CardinalityEstimator::estimateFilter(
     const LogicalPlan& childPlan, const Expression& predicate) {
-    if (predicate.expressionType == EQUALS) {
+    if (predicate.expressionType == ExpressionType::EQUALS) {
         if (isPrimaryKey(*predicate.getChild(0)) || isPrimaryKey(*predicate.getChild(1))) {
             return 1;
         } else {

--- a/src/planner/plan/plan_subquery.cpp
+++ b/src/planner/plan/plan_subquery.cpp
@@ -97,7 +97,7 @@ void QueryPlanner::planRegularMatch(const QueryGraphCollection& queryGraphCollec
 
 void QueryPlanner::planExistsSubquery(
     std::shared_ptr<Expression> expression, LogicalPlan& outerPlan) {
-    KU_ASSERT(expression->expressionType == EXISTENTIAL_SUBQUERY);
+    KU_ASSERT(expression->expressionType == ExpressionType::EXISTENTIAL_SUBQUERY);
     auto subquery = static_pointer_cast<ExistentialSubqueryExpression>(expression);
     auto predicates = subquery->getPredicatesSplitOnAnd();
     auto correlatedExpressions = outerPlan.getSchema()->getSubExpressionsInScope(subquery);

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -55,15 +55,15 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getEvaluator(
         return getReferenceEvaluator(expression, schema);
     } else if (isExpressionLiteral(expressionType)) {
         return getLiteralEvaluator(*expression);
-    } else if (ExpressionUtil::isNodeVariable(*expression)) {
+    } else if (ExpressionUtil::isNodePattern(*expression)) {
         return getNodeEvaluator(expression, schema);
-    } else if (ExpressionUtil::isRelVariable(*expression)) {
+    } else if (ExpressionUtil::isRelPattern(*expression)) {
         return getRelEvaluator(expression, schema);
     } else if (expressionType == ExpressionType::PATH) {
         return getPathEvaluator(expression, schema);
     } else if (expressionType == ExpressionType::PARAMETER) {
         return getParameterEvaluator(*expression);
-    } else if (CASE_ELSE == expressionType) {
+    } else if (ExpressionType::CASE_ELSE == expressionType) {
         return getCaseEvaluator(expression, schema);
     } else if (canEvaluateAsFunction(expressionType)) {
         return getFunctionEvaluator(expression, schema);
@@ -81,7 +81,7 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getConstantEvaluator(
     auto expressionType = expression->expressionType;
     if (isExpressionLiteral(expressionType)) {
         return getLiteralEvaluator(*expression);
-    } else if (CASE_ELSE == expressionType) {
+    } else if (ExpressionType::CASE_ELSE == expressionType) {
         return getCaseEvaluator(expression, nullptr);
     } else if (canEvaluateAsFunction(expressionType)) {
         return getFunctionEvaluator(expression, nullptr);

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -17,7 +17,7 @@ static std::pair<std::vector<struct_field_idx_t>, std::vector<ft_col_idx_t>> get
     const expression_vector& payloads, uint32_t numKeys, const LogicalType& structType) {
     std::unordered_map<std::string, ft_col_idx_t> propertyNameToColumnIdx;
     for (auto i = 0u; i < payloads.size(); ++i) {
-        KU_ASSERT(payloads[i]->expressionType == PROPERTY);
+        KU_ASSERT(payloads[i]->expressionType == ExpressionType::PROPERTY);
         auto propertyName = ((PropertyExpression*)payloads[i].get())->getPropertyName();
         StringUtils::toUpper(propertyName);
         propertyNameToColumnIdx.insert({propertyName, i + numKeys});

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -38,12 +38,12 @@ Binder exception: Expression in WITH must be aliased (use AS).
 -LOG BindToDifferentVariableType1
 -STATEMENT MATCH (a:person)-[e1:knows]->(b:person) WITH e1 AS a MATCH (a) RETURN *
 ---- error
-Binder exception: a has data type REL but (NODE) was expected.
+Binder exception: Cannot bind a as node pattern.
 
 -LOG BindToDifferentVariableType2
 -STATEMENT MATCH (a:person)-[e1:knows]->(b:person) WITH a.age + 1 AS a MATCH (a) RETURN *
 ---- error
-Binder exception: a has data type INT64 but (NODE) was expected.
+Binder exception: Cannot bind a as node pattern.
 
 -LOG BindEmptyStar
 -STATEMENT RETURN *
@@ -261,7 +261,7 @@ Binder exception: Expression 12 has data type INT64 but expected DATE. Implicit 
 -LOG DeleteNodeProperty
 -STATEMENT MATCH (a:person) DELETE a.age
 ---- error
-Binder exception: Delete PROPERTY is not supported.
+Binder exception: Cannot delete expression a.age with type PROPERTY. Expect node or rel pattern.
 
 -LOG CreateNodeTableUsedName
 -STATEMENT CREATE NODE TABLE person(NAME STRING, ID INT64, PRIMARY KEY(NAME))

--- a/test/test_files/tck/match/match1.test
+++ b/test/test_files/tck/match/match1.test
@@ -84,37 +84,37 @@ Parser exception: Invalid input <MATCH (n $>: expected rule oC_SingleQuery (line
 ---- ok
 -STATEMENT MATCH ()-[r]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]->() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()<-[r]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), ()-[r]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]-(), () MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-(), ()-[r]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[r]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[]-(), ()-[r]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[]-(), ()-[r]-(), () MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[]-(), (), ()-[r]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), (a)-[q]-(b), (s), (s)-[r]->(t)<-[]-(b) MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 
 # Fail when a path has the same variable in a preceding MATCH
 -CASE Scenario8
@@ -124,52 +124,52 @@ Binder exception: r has data type REL but (NODE) was expected.
 ---- ok
 -STATEMENT MATCH r = ()-[]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[]->() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()<-[]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[*1..30]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[*1..30]->() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[]->() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()<-[]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[*1..30]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[*1..30]->() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-(), r = ()-[]-(), () MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[]-(), ()-[]-(), () MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()<-[]-(), r = ()-[]-() MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), r = (a)-[q]-(b), (s)-[p]-(t)-[]-(b) MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), (a)-[q]-(b), r = (s)-[p]-(t)-[]-(b) MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), (a)-[q]-(b), r = (s)-[p]->(t)<-[]-(b) MATCH (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 
 
 # Fail when a relationship has the same variable in the same pattern
@@ -189,70 +189,70 @@ Binder exception: r has data type NODE but (REL) was expected.
 Binder exception: r has data type NODE but (REL) was expected.
 -STATEMENT MATCH ()-[r]-()-[]-(r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r*1..30]-()-[]-(r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]->(), (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()<-[r]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]-(), (r)-[]-() RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]-(), ()-[]-(r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (s)-[r]-(t), (r)-[]-(t) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (s)-[r]-(t), (s)-[]-(r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), ()-[r]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]-(), (), (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[r]-(), (r), () RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-(), ()-[r]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[r]-(), ()-[]-(r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[]-(), ()-[r]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[r]-(), (r), ()-[]-() RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[r]-(), (), (r)-[]-() RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()-[r*1..30]-(), (r), ()-[]-() RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[*1..30]-()-[r]-(), (), (r)-[]-() RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[*1..30]-()-[r]-(), (), (r)-[*1..30]-() RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[*1..30]-()-[r]-(), (), ()-[*1..30]-(r) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), (a)-[r]-(b), (s), (s)-[]->(r)<-[]-(b) RETURN r;
 ---- error
-Binder exception: r has data type REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 
 # Fail when a path has the same variable in the same pattern
 -CASE Scenario10
@@ -262,64 +262,64 @@ Binder exception: r has data type REL but (NODE) was expected.
 ---- ok
 -STATEMENT MATCH r = ()-[]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[]->(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()<-[]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[*1..30]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[*1..30]->(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[]->(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()<-[]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[*1..30]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (), r = ()-[*1..30]->(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-(), r = ()-[]-(), (), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH r = ()-[]-(), ()-[]-(), (), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH ()-[]-()<-[]-(), r = ()-[]-(), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), r = (a)-[q]-(b), (s)-[p]-(t)-[]-(b), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), (a)-[q]-(b), r = (s)-[p]-(t)-[]-(b), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), (a)-[q]-(b), r = (s)-[p]->(t)<-[]-(b), (r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), r = (s)-[p]-(t)-[]-(b), (r), (a)-[q]-(b) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), r = (s)-[p]->(t)<-[]-(b), (r), (a)-[q]-(b) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), r = (s)-[p]-(t)-[]-(b), (a)-[q]-(r) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 -STATEMENT MATCH (x), r = (s)-[p]->(t)<-[]-(b), (r)-[q]-(b) RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
+Binder exception: Cannot bind r as node pattern.
 
 # Fail when a path has the same variable in the same pattern
 -CASE Scenario11
@@ -327,22 +327,22 @@ Binder exception: r has data type RECURSIVE_REL but (NODE) was expected.
 ---- ok
 -STATEMENT WITH true AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: n has data type BOOL but (NODE) was expected.
+Binder exception: Cannot bind n as node pattern.
 -STATEMENT WITH 123 AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: n has data type INT64 but (NODE) was expected.
+Binder exception: Cannot bind n as node pattern.
 -STATEMENT WITH 123.4 AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: n has data type DOUBLE but (NODE) was expected.
+Binder exception: Cannot bind n as node pattern.
 -STATEMENT WITH 'foo' AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: n has data type STRING but (NODE) was expected.
+Binder exception: Cannot bind n as node pattern.
 -STATEMENT WITH [10] AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: n has data type VAR_LIST but (NODE) was expected.
+Binder exception: Cannot bind n as node pattern.
 -STATEMENT WITH {x: 1} AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: n has data type STRUCT but (NODE) was expected.
+Binder exception: Cannot bind n as node pattern.
 -STATEMENT WITH {x: [1]} AS n MATCH (n) RETURN n;
 ---- error
-Binder exception: n has data type STRUCT but (NODE) was expected.
+Binder exception: Cannot bind n as node pattern.

--- a/test/test_files/tck/match/match3.test
+++ b/test/test_files/tck/match/match3.test
@@ -428,6 +428,6 @@ Binder exception: Bind relationship r to relationship with same name is not supp
            MATCH (users)-->(messages)
            RETURN messages;
 ---- error
-Binder exception: users has data type VAR_LIST but (NODE) was expected.
+Binder exception: Cannot bind users as node pattern.
 
 

--- a/test/test_files/tinysnb/unwind/unwind.test
+++ b/test/test_files/tinysnb/unwind/unwind.test
@@ -6,6 +6,68 @@
 -CASE Unwind
 -DEFINE UNWIND_LIST ARANGE 1 4001
 
+-STATEMENT MATCH p = (a:person)-[e:knows*1..2]->(b:person) UNWIND nodes(p) AS n MATCH (a)-[]->(n) RETURN COUNT(*);
+---- error
+Binder exception: Cannot bind n as node pattern.
+-STATEMENT MATCH p = (a:person)-[e:knows*1..2]->(b:person) UNWIND nodes(p) AS n SET n.fName = 'Alice';
+---- error
+Binder exception: Cannot set expression n with type VARIABLE. Expect node or rel pattern.
+-STATEMENT MATCH p = (a:person)-[e:knows*1..2]->(b:person) UNWIND nodes(p) AS n DELETE n;
+---- error
+Binder exception: Cannot delete expression n with type VARIABLE. Expect node or rel pattern.
+
+-LOG unwind14
+-STATEMENT MATCH (a:person) WITH collect(a) as b UNWIND b AS d RETURN d;
+---- 8
+{_ID: 0:0, _LABEL: person, ID: 0, fName: Alice, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000}
+{_ID: 0:1, _LABEL: person, ID: 2, fName: Bob, gender: 2, isStudent: True, isWorker: False, age: 30, eyeSight: 5.100000, birthdate: 1900-01-01, registerTime: 2008-11-03 15:25:30.000526, lastJobDuration: 10 years 5 months 13:00:00.000024, workedHours: [12,8], usedNames: [Bobby], courseScoresPerTerm: [[8,9],[9,10]], grades: [98,42,93,88], height: 0.990000}
+{_ID: 0:2, _LABEL: person, ID: 3, fName: Carol, gender: 1, isStudent: False, isWorker: True, age: 45, eyeSight: 5.000000, birthdate: 1940-06-22, registerTime: 1911-08-20 02:32:21, lastJobDuration: 48:24:11, workedHours: [4,5], usedNames: [Carmen,Fred], courseScoresPerTerm: [[8,10]], grades: [91,75,21,95], height: 1.000000}
+{_ID: 0:3, _LABEL: person, ID: 5, fName: Dan, gender: 2, isStudent: False, isWorker: True, age: 20, eyeSight: 4.800000, birthdate: 1950-07-23, registerTime: 2031-11-30 12:25:30, lastJobDuration: 10 years 5 months 13:00:00.000024, workedHours: [1,9], usedNames: [Wolfeschlegelstein,Daniel], courseScoresPerTerm: [[7,4],[8,8],[9]], grades: [76,88,99,89], height: 1.300000}
+{_ID: 0:4, _LABEL: person, ID: 7, fName: Elizabeth, gender: 1, isStudent: False, isWorker: True, age: 20, eyeSight: 4.700000, birthdate: 1980-10-26, registerTime: 1976-12-23 11:21:42, lastJobDuration: 48:24:11, workedHours: [2], usedNames: [Ein], courseScoresPerTerm: [[6],[7],[8]], grades: [96,59,65,88], height: 1.463000}
+{_ID: 0:5, _LABEL: person, ID: 8, fName: Farooq, gender: 2, isStudent: True, isWorker: False, age: 25, eyeSight: 4.500000, birthdate: 1980-10-26, registerTime: 1972-07-31 13:22:30.678559, lastJobDuration: 00:18:00.024, workedHours: [3,4,5,6,7], usedNames: [Fesdwe], courseScoresPerTerm: [[8]], grades: [80,78,34,83], height: 1.510000}
+{_ID: 0:6, _LABEL: person, ID: 9, fName: Greg, gender: 2, isStudent: False, isWorker: False, age: 40, eyeSight: 4.900000, birthdate: 1980-10-26, registerTime: 1976-12-23 04:41:42, lastJobDuration: 10 years 5 months 13:00:00.000024, workedHours: [1], usedNames: [Grad], courseScoresPerTerm: [[10]], grades: [43,83,67,43], height: 1.600000}
+{_ID: 0:7, _LABEL: person, ID: 10, fName: Hubert Blaine Wolfeschlegelsteinhausenbergerdorff, gender: 2, isStudent: False, isWorker: True, age: 83, eyeSight: 4.900000, birthdate: 1990-11-27, registerTime: 2023-02-21 13:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,11,12,3,4,5,6,7], usedNames: [Ad,De,Hi,Kye,Orlan], courseScoresPerTerm: [[7],[10],[6,7]], grades: [77,64,100,54], height: 1.323000}
+-STATEMENT MATCH (a:person) WITH collect(a) as b UNWIND b AS d RETURN d.*;
+---- 8
+0:0|person|0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|[96,54,86,92]|1.731000
+0:1|person|2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|[[8,9],[9,10]]|[98,42,93,88]|0.990000
+0:2|person|3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|[91,75,21,95]|1.000000
+0:3|person|5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|[76,88,99,89]|1.300000
+0:4|person|7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|[96,59,65,88]|1.463000
+0:5|person|8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|[80,78,34,83]|1.510000
+0:6|person|9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 04:41:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|[43,83,67,43]|1.600000
+0:7|person|10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|[77,64,100,54]|1.323000
+-STATEMENT MATCH (a:person) WITH collect(a) as b UNWIND b AS d RETURN d._id, d.ID, d.fName, d.age + 3, substr(d.fName, 1, 3);
+---- 8
+0:0|0|Alice|38|Ali
+0:1|2|Bob|33|Bob
+0:2|3|Carol|48|Car
+0:3|5|Dan|23|Dan
+0:4|7|Elizabeth|23|Eli
+0:5|8|Farooq|28|Far
+0:6|9|Greg|43|Gre
+0:7|10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|86|Hub
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 7 WITH a, collect(e) AS es UNWIND es AS e RETURN a.fName, e._ID, e.date, e.comments
+---- 2
+Elizabeth|3:12|1905-12-12|[ahu2333333333333,12weeeeeeeeeeeeeeeeee]
+Elizabeth|3:13|1905-12-12|[peweeeeeeeeeeeeeeeee,kowje9w0eweeeeeeeee]
+-STATEMENT MATCH p = (a:person)-[e:knows]->(b:person) WHERE a.ID = 0 UNWIND nodes(p) AS n RETURN n.ID, n.fName;
+---- 6
+0|Alice
+0|Alice
+0|Alice
+2|Bob
+3|Carol
+5|Dan
+-STATEMENT MATCH p = (a:person)-[e:knows*1..2]->(b:person) WHERE a.ID = 0 AND b.ID = 2 UNWIND rels(p) AS er RETURN er._ID, er.date
+---- 5
+3:0|2021-06-30
+3:10|1950-05-14
+3:1|2021-06-30
+3:2|2021-06-30
+3:7|1950-05-14
+
+
 -LOG unwind1
 -STATEMENT UNWIND [1, 2, 3, 4] AS x RETURN x
 ---- 4
@@ -100,3 +162,4 @@ Aida|Alice|Bob|Dan
 ---- 2
 1
 2
+


### PR DESCRIPTION
Fix issue #2343 

The problem is because we use `LogicalType` to check if a variable is a `Node/RelExpression` or not. This is no longer true for the case of `UNWIND`, e.g. `MATCH (a) WITH collect(a) AS b UNWIND b AS c RETURN c`, c has `LogicalType NODE` but is not a `NodeExpression`.

In this PR we introduce `PATTERN` expression type to differentiate the above case. With this PR, `a` will be treated as an expression with `ExpressionType PATTERN and LogicalType NODE` while `c` will be treated as an expression with `ExpressionType VARIABLE and LogicalType NODE`.

In addition, we use `enum class` for `ExpressionType`