### PR TITLE
Remove startPosInChunk from append() and fix incorrect numValues

### DIFF
--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -12,9 +12,9 @@ public:
     explicit StringColumnChunk(common::LogicalType dataType, uint64_t capacity);
 
     void resetToEmpty() final;
-    void append(common::ValueVector* vector, common::offset_t startPosInChunk) final;
+    void append(common::ValueVector* vector) final;
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
-        common::offset_t startPosInChunk, uint32_t numValuesToAppend) final;
+        uint32_t numValuesToAppend) final;
 
     void write(common::ValueVector* vector, common::offset_t startOffsetInChunk) final;
     void write(common::ValueVector* valueVector, common::ValueVector* offsetInChunkVector) final;
@@ -31,7 +31,7 @@ public:
 
 private:
     void appendStringColumnChunk(StringColumnChunk* other, common::offset_t startPosInOtherChunk,
-        common::offset_t startPosInChunk, uint32_t numValuesToAppend);
+        uint32_t numValuesToAppend);
 
     void setValueFromString(const char* value, uint64_t length, uint64_t pos);
 

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -16,8 +16,8 @@ public:
 
 protected:
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
-        common::offset_t startPosInChunk, uint32_t numValuesToAppend) final;
-    void append(common::ValueVector* vector, common::offset_t startPosInChunk) final;
+        uint32_t numValuesToAppend) final;
+    void append(common::ValueVector* vector) final;
 
     void write(common::ValueVector* vector, common::offset_t startOffsetInChunk) final;
     void write(common::ValueVector* valueVector, common::ValueVector* offsetInChunkVector) final;

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -19,7 +19,7 @@ struct VarListDataColumnChunk {
     void resizeBuffer(uint64_t numValues);
 
     inline void append(common::ValueVector* dataVector) const {
-        dataColumnChunk->append(dataVector, dataColumnChunk->getNumValues());
+        dataColumnChunk->append(dataVector);
     }
 
     inline uint64_t getNumValues() const { return dataColumnChunk->getNumValues(); }
@@ -35,7 +35,7 @@ public:
 
     void resetToEmpty() final;
 
-    void append(common::ValueVector* vector, common::offset_t startPosInChunk) final;
+    void append(common::ValueVector* vector) final;
     inline void write(common::ValueVector* /*valueVector*/,
         common::ValueVector* /*offsetInChunkVector*/) override {
         // LCOV_EXCL_START
@@ -61,7 +61,7 @@ protected:
 
 private:
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
-        common::offset_t startPosInChunk, uint32_t numValuesToAppend) final;
+        uint32_t numValuesToAppend) final;
 
     inline uint64_t getListLen(common::offset_t offset) const {
         return getListOffset(offset + 1) - getListOffset(offset);

--- a/src/storage/local_table.cpp
+++ b/src/storage/local_table.cpp
@@ -268,17 +268,17 @@ void VarListLocalColumn::prepareCommitForChunk(node_group_idx_t nodeGroupIdx) {
             if (offsetInChunk > nextOffsetToWrite) {
                 // Fill non-updated data from listColumnChunkInStorage.
                 columnChunkToUpdate->append(listColumnChunkInStorage.get(), nextOffsetToWrite,
-                    nextOffsetToWrite, offsetInChunk - nextOffsetToWrite);
+                    offsetInChunk - nextOffsetToWrite);
             }
             listVector->state->selVector->selectedPositions[0] = i;
-            columnChunkToUpdate->append(listVector, offsetInChunk);
+            columnChunkToUpdate->append(listVector);
             nextOffsetToWrite = offsetInChunk + 1;
         }
     }
 
     if (nextOffsetToWrite < numNodesInGroup) {
-        columnChunkToUpdate->append(listColumnChunkInStorage.get(), nextOffsetToWrite,
-            nextOffsetToWrite, numNodesInGroup - nextOffsetToWrite);
+        columnChunkToUpdate->append(
+            listColumnChunkInStorage.get(), nextOffsetToWrite, numNodesInGroup - nextOffsetToWrite);
     }
 
     column->append(columnChunkToUpdate.get(), nodeGroupIdx);

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -61,7 +61,7 @@ uint64_t NodeGroup::append(const std::vector<ValueVector*>& columnVectors,
             continue;
         }
         KU_ASSERT(chunk->getDataType() == columnVectors[i - serialSkip]->dataType);
-        chunk->append(columnVectors[i - serialSkip], numNodes);
+        chunk->append(columnVectors[i - serialSkip]);
     }
     columnState->selVector->selectedSize = originalSize;
     numNodes += numValuesToAppendInChunk;
@@ -73,8 +73,7 @@ offset_t NodeGroup::append(NodeGroup* other, offset_t offsetInOtherNodeGroup) {
     auto numNodesToAppend = std::min(
         other->numNodes - offsetInOtherNodeGroup, StorageConstants::NODE_GROUP_SIZE - numNodes);
     for (auto i = 0u; i < chunks.size(); i++) {
-        chunks[i]->append(
-            other->chunks[i].get(), offsetInOtherNodeGroup, numNodes, numNodesToAppend);
+        chunks[i]->append(other->chunks[i].get(), offsetInOtherNodeGroup, numNodesToAppend);
     }
     numNodes += numNodesToAppend;
     return numNodesToAppend;

--- a/src/storage/store/struct_column_chunk.cpp
+++ b/src/storage/store/struct_column_chunk.cpp
@@ -16,26 +16,25 @@ StructColumnChunk::StructColumnChunk(
     }
 }
 
-void StructColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
-    offset_t startPosInChunk, uint32_t numValuesToAppend) {
+void StructColumnChunk::append(
+    ColumnChunk* other, offset_t startPosInOtherChunk, uint32_t numValuesToAppend) {
     auto otherStructChunk = dynamic_cast<StructColumnChunk*>(other);
-    nullChunk->append(
-        other->getNullChunk(), startPosInOtherChunk, startPosInChunk, numValuesToAppend);
+    nullChunk->append(other->getNullChunk(), startPosInOtherChunk, numValuesToAppend);
     for (auto i = 0u; i < childChunks.size(); i++) {
-        childChunks[i]->append(otherStructChunk->childChunks[i].get(), startPosInOtherChunk,
-            startPosInChunk, numValuesToAppend);
+        childChunks[i]->append(
+            otherStructChunk->childChunks[i].get(), startPosInOtherChunk, numValuesToAppend);
     }
     numValues += numValuesToAppend;
 }
 
-void StructColumnChunk::append(ValueVector* vector, offset_t startPosInChunk) {
+void StructColumnChunk::append(ValueVector* vector) {
     auto numFields = StructType::getNumFields(&dataType);
     for (auto i = 0u; i < numFields; i++) {
-        childChunks[i]->append(StructVector::getFieldVector(vector, i).get(), startPosInChunk);
+        childChunks[i]->append(StructVector::getFieldVector(vector, i).get());
     }
     for (auto i = 0u; i < vector->state->selVector->selectedSize; i++) {
         nullChunk->setNull(
-            startPosInChunk + i, vector->isNull(vector->state->selVector->selectedPositions[i]));
+            numValues + i, vector->isNull(vector->state->selVector->selectedPositions[i]));
     }
     numValues += vector->state->selVector->selectedSize;
 }


### PR DESCRIPTION
Both `ColumnChunk::append` interfaces take a `startPosInChunk` as input, which is very confusing, as `append` should auto add value to its end, whose position is indicated by `numValues`. And this interface actually hides potentially annoying bugs related to incorrect setting of `numValues`.
This PR removes the param `startPosInChunk` and fix incorrect `numValues` inside NullColumnChunk.