### PR TITLE
Rework var list finalize

### DIFF
--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -99,8 +99,7 @@ public:
     }
 
     void populateWithDefaultVal(common::ValueVector* defaultValueVector);
-    virtual std::unique_ptr<ColumnChunk> finalize() {
-        return nullptr; // Nothing to be finalized.
+    virtual void finalize() { // DO NOTHING.
     }
 
     inline uint64_t getCapacity() const { return capacity; }
@@ -211,8 +210,7 @@ protected:
 
 struct ColumnChunkFactory {
     static std::unique_ptr<ColumnChunk> createColumnChunk(const common::LogicalType& dataType,
-        bool enableCompression, bool needFinalize = false,
-        uint64_t capacity = common::StorageConstants::NODE_GROUP_SIZE);
+        bool enableCompression, uint64_t capacity = common::StorageConstants::NODE_GROUP_SIZE);
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -12,7 +12,7 @@ class Column;
 class NodeGroup {
 public:
     NodeGroup(const std::vector<std::unique_ptr<common::LogicalType>>& columnTypes,
-        bool enableCompression, bool needFinalize, uint64_t capacity);
+        bool enableCompression, uint64_t capacity);
     explicit NodeGroup(const std::vector<std::unique_ptr<Column>>& columns, bool enableCompression);
     virtual ~NodeGroup() = default;
 
@@ -44,10 +44,10 @@ private:
 class CSRNodeGroup : public NodeGroup {
 public:
     CSRNodeGroup(const std::vector<std::unique_ptr<common::LogicalType>>& columnTypes,
-        bool enableCompression, bool needFinalize)
+        bool enableCompression)
         // By default, initialize all column chunks except for the csrOffsetChunk to empty, as they
         // should be resized after csr offset calculation (e.g., during CopyRel).
-        : NodeGroup{columnTypes, enableCompression, needFinalize, 0 /* capacity */} {
+        : NodeGroup{columnTypes, enableCompression, 0 /* capacity */} {
         csrOffsetChunk = ColumnChunkFactory::createColumnChunk(
             common::LogicalType{common::LogicalTypeID::INT64}, enableCompression);
     }
@@ -61,8 +61,7 @@ private:
 struct NodeGroupFactory {
     static std::unique_ptr<NodeGroup> createNodeGroup(common::ColumnDataFormat dataFormat,
         const std::vector<std::unique_ptr<common::LogicalType>>& columnTypes,
-        bool enableCompression, bool needFinalize = false,
-        uint64_t capacity = common::StorageConstants::NODE_GROUP_SIZE);
+        bool enableCompression, uint64_t capacity = common::StorageConstants::NODE_GROUP_SIZE);
 };
 
 } // namespace storage

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -13,6 +13,7 @@ public:
         KU_ASSERT(childIdx < childChunks.size());
         return childChunks[childIdx].get();
     }
+    void finalize();
 
 protected:
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,

--- a/src/processor/operator/persistent/copy_rel.cpp
+++ b/src/processor/operator/persistent/copy_rel.cpp
@@ -31,8 +31,8 @@ void CopyRelSharedState::logCopyRelWALRecord(WAL* wal) {
 
 void CopyRel::initLocalStateInternal(ResultSet* /*resultSet_*/, ExecutionContext* /*context*/) {
     localState = std::make_unique<CopyRelLocalState>();
-    localState->nodeGroup = NodeGroupFactory::createNodeGroup(info->dataFormat,
-        sharedState->columnTypes, info->compressionEnabled, true /* needFinalize */);
+    localState->nodeGroup = NodeGroupFactory::createNodeGroup(
+        info->dataFormat, sharedState->columnTypes, info->compressionEnabled);
 }
 
 void CopyRel::initGlobalStateInternal(ExecutionContext* /*context*/) {

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -459,7 +459,7 @@ public:
 };
 
 std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
-    const LogicalType& dataType, bool enableCompression, bool needFinalize, uint64_t capacity) {
+    const LogicalType& dataType, bool enableCompression, uint64_t capacity) {
     switch (dataType.getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
         return std::make_unique<BoolColumnChunk>(capacity);
@@ -477,8 +477,8 @@ std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
     case PhysicalTypeID::FLOAT:
     case PhysicalTypeID::INTERVAL: {
         if (dataType.getLogicalTypeID() == LogicalTypeID::SERIAL) {
-            return std::make_unique<ColumnChunk>(LogicalType(LogicalTypeID::SERIAL), capacity,
-                false /*enableCompression*/, false /* hasNullChunk */);
+            return std::make_unique<ColumnChunk>(
+                dataType, capacity, false /*enableCompression*/, false /* hasNullChunk */);
         } else {
             return std::make_unique<ColumnChunk>(dataType, capacity, enableCompression);
         }
@@ -495,11 +495,7 @@ std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
         return std::make_unique<StringColumnChunk>(dataType, capacity);
     }
     case PhysicalTypeID::VAR_LIST: {
-        if (needFinalize) {
-            return std::make_unique<AuxVarListColumnChunk>(dataType, capacity, enableCompression);
-        } else {
-            return std::make_unique<VarListColumnChunk>(dataType, capacity, enableCompression);
-        }
+        return std::make_unique<VarListColumnChunk>(dataType, capacity, enableCompression);
     }
     case PhysicalTypeID::STRUCT: {
         return std::make_unique<StructColumnChunk>(dataType, capacity, enableCompression);

--- a/src/storage/store/struct_column_chunk.cpp
+++ b/src/storage/store/struct_column_chunk.cpp
@@ -12,7 +12,13 @@ StructColumnChunk::StructColumnChunk(
     childChunks.resize(fieldTypes.size());
     for (auto i = 0u; i < fieldTypes.size(); i++) {
         childChunks[i] =
-            ColumnChunkFactory::createColumnChunk(*fieldTypes[i], capacity, enableCompression);
+            ColumnChunkFactory::createColumnChunk(*fieldTypes[i], enableCompression, capacity);
+    }
+}
+
+void StructColumnChunk::finalize() {
+    for (auto& childChunk : childChunks) {
+        childChunk->finalize();
     }
 }
 


### PR DESCRIPTION
`VarListColumnChunk::write` is expected to write a var list value to a given position inside the column chunk, and there is no enforcement of the order of given positions. For example, `write` can take `[10,20]` to pos 5, `[1,2,8]` to pos 1, etc.
However, the layout of var list column requires `offsets` to be sorted based on positions in the column chunk.

This PR introduces an extra indices column chunk to handle the ordering difference. During `write`, an extra index is recorded into `indices` to track where the var list value is stored. And `finalize` is called after `write`s are done, which re-append var list values according to their position in the column chunk.