### PR TITLE
Rework Column and ColumnChunk's dataType field to std::unique_ptr

### DIFF
--- a/src/binder/bind/bind_copy.cpp
+++ b/src/binder/bind/bind_copy.cpp
@@ -218,11 +218,11 @@ void Binder::bindExpectedRelColumns(catalog::TableSchema* tableSchema,
     columnNames.push_back(dstColumnName);
     auto srcPKColumnType = srcTable->getPrimaryKey()->getDataType()->copy();
     if (srcPKColumnType->getLogicalTypeID() == LogicalTypeID::SERIAL) {
-        srcPKColumnType = std::make_unique<LogicalType>(LogicalTypeID::INT64);
+        srcPKColumnType = LogicalType::INT64();
     }
     auto dstPKColumnType = dstTable->getPrimaryKey()->getDataType()->copy();
     if (dstPKColumnType->getLogicalTypeID() == LogicalTypeID::SERIAL) {
-        dstPKColumnType = std::make_unique<LogicalType>(LogicalTypeID::INT64);
+        dstPKColumnType = LogicalType::INT64();
     }
     columnTypes.push_back(std::move(srcPKColumnType));
     columnTypes.push_back(std::move(dstPKColumnType));

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -248,8 +248,8 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
     std::vector<std::unique_ptr<LogicalType>> fieldTypes;
     fieldNames.emplace_back(InternalKeyword::SRC);
     fieldNames.emplace_back(InternalKeyword::DST);
-    fieldTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID));
-    fieldTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID));
+    fieldTypes.push_back(LogicalType::INTERNAL_ID());
+    fieldTypes.push_back(LogicalType::INTERNAL_ID());
     // Bind internal expressions.
     queryRel->setLabelExpression(expressionBinder.bindLabelFunction(*queryRel));
     fieldNames.emplace_back(InternalKeyword::LABEL);
@@ -360,10 +360,10 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
     relFieldNames.emplace_back(InternalKeyword::DST);
     relFieldNames.emplace_back(InternalKeyword::LABEL);
     relFieldNames.emplace_back(InternalKeyword::ID);
-    relFieldTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID));
-    relFieldTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID));
+    relFieldTypes.push_back(LogicalType::INTERNAL_ID());
+    relFieldTypes.push_back(LogicalType::INTERNAL_ID());
     relFieldTypes.push_back(rel->getLabelExpression()->getDataType().copy());
-    relFieldTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID));
+    relFieldTypes.push_back(LogicalType::INTERNAL_ID());
     bindRecursiveRelProjectionList(relProjectionList, relFieldNames, relFieldTypes);
     auto relExtraInfo = std::make_unique<StructTypeInfo>(relFieldNames, relFieldTypes);
     rel->getDataTypeReference().setExtraTypeInfo(std::move(relExtraInfo));

--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -58,7 +58,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfRelFrom(function::TableFuncti
     for (auto i = 0u; i < 3; ++i) {
         auto columnName = std::string(InternalKeyword::ANONYMOUS) + std::to_string(i);
         columnNames.push_back(columnName);
-        columnTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INT64));
+        columnTypes.push_back(LogicalType::INT64());
     }
     auto relTableSchema = reinterpret_cast<RelTableSchema*>(tableSchema);
     auto resourceTableID = relTableSchema->getSrcTableID();

--- a/src/binder/bind/ddl/bind_create_rdf_graph.cpp
+++ b/src/binder/bind/ddl/bind_create_rdf_graph.cpp
@@ -54,8 +54,8 @@ std::unique_ptr<BoundCreateTableInfo> Binder::bindCreateRdfGraphInfo(const Creat
     // Resource triple table.
     auto resourceTripleTableName = getRdfResourceTripleTableName(rdfGraphName);
     std::vector<std::unique_ptr<Property>> resourceTripleProperties;
-    resourceTripleProperties.push_back(std::make_unique<Property>(
-        std::string(rdf::PID), std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID)));
+    resourceTripleProperties.push_back(
+        std::make_unique<Property>(std::string(rdf::PID), LogicalType::INTERNAL_ID()));
     auto boundResourceTripleExtraInfo =
         std::make_unique<BoundExtraCreateRelTableInfo>(RelMultiplicity::MANY_MANY, INVALID_TABLE_ID,
             INVALID_TABLE_ID, std::move(resourceTripleProperties));
@@ -64,8 +64,8 @@ std::unique_ptr<BoundCreateTableInfo> Binder::bindCreateRdfGraphInfo(const Creat
     // Literal triple table.
     auto literalTripleTableName = getRdfLiteralTripleTableName(rdfGraphName);
     std::vector<std::unique_ptr<Property>> literalTripleProperties;
-    literalTripleProperties.push_back(std::make_unique<Property>(
-        std::string(rdf::PID), std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID)));
+    literalTripleProperties.push_back(
+        std::make_unique<Property>(std::string(rdf::PID), LogicalType::INTERNAL_ID()));
     auto boundLiteralTripleExtraInfo =
         std::make_unique<BoundExtraCreateRelTableInfo>(RelMultiplicity::MANY_MANY, INVALID_TABLE_ID,
             INVALID_TABLE_ID, std::move(literalTripleProperties));

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -220,8 +220,7 @@ static std::vector<std::unique_ptr<Value>> populateLabelValues(
 
 std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression& expression) {
     auto catalogContent = binder->catalog.getReadOnlyVersion();
-    auto varListTypeInfo =
-        std::make_unique<VarListTypeInfo>(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    auto varListTypeInfo = std::make_unique<VarListTypeInfo>(LogicalType::STRING());
     auto listType =
         std::make_unique<LogicalType>(LogicalTypeID::VAR_LIST, std::move(varListTypeInfo));
     expression_vector children;

--- a/src/catalog/catalog_content.cpp
+++ b/src/catalog/catalog_content.cpp
@@ -51,8 +51,8 @@ table_id_t CatalogContent::addNodeTableSchema(const BoundCreateTableInfo& info) 
 
 // TODO(Xiyang): move this to binding stage
 static void addRelInternalIDProperty(std::vector<std::unique_ptr<Property>>& properties) {
-    auto relInternalIDProperty = std::make_unique<Property>(
-        InternalKeyword::ID, std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID));
+    auto relInternalIDProperty =
+        std::make_unique<Property>(InternalKeyword::ID, LogicalType::INTERNAL_ID());
     properties.insert(properties.begin(), std::move(relInternalIDProperty));
 }
 

--- a/src/common/types/rdf_variant_type.cpp
+++ b/src/common/types/rdf_variant_type.cpp
@@ -5,10 +5,8 @@ namespace common {
 
 std::unique_ptr<LogicalType> RdfVariantType::getType() {
     std::vector<std::unique_ptr<StructField>> fields;
-    fields.push_back(std::make_unique<StructField>(
-        "_type", std::make_unique<LogicalType>(LogicalTypeID::UINT8)));
-    fields.push_back(std::make_unique<StructField>(
-        "_value", std::make_unique<LogicalType>(LogicalTypeID::BLOB)));
+    fields.push_back(std::make_unique<StructField>("_type", LogicalType::UINT8()));
+    fields.push_back(std::make_unique<StructField>("_value", LogicalType::BLOB()));
     auto extraInfo = std::make_unique<StructTypeInfo>(std::move(fields));
     return std::make_unique<LogicalType>(LogicalTypeID::RDF_VARIANT, std::move(extraInfo));
 }

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -117,92 +117,92 @@ Value Value::createDefaultValue(const LogicalType& dataType) {
 }
 
 Value::Value(bool val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::BOOL);
+    dataType = LogicalType::BOOL();
     val.booleanVal = val_;
 }
 
 Value::Value(int8_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::INT8);
+    dataType = LogicalType::INT8();
     val.int8Val = val_;
 }
 
 Value::Value(int16_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::INT16);
+    dataType = LogicalType::INT16();
     val.int16Val = val_;
 }
 
 Value::Value(int32_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::INT32);
+    dataType = LogicalType::INT32();
     val.int32Val = val_;
 }
 
 Value::Value(int64_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::INT64);
+    dataType = LogicalType::INT64();
     val.int64Val = val_;
 }
 
 Value::Value(uint8_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::UINT8);
+    dataType = LogicalType::UINT8();
     val.uint8Val = val_;
 }
 
 Value::Value(uint16_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::UINT16);
+    dataType = LogicalType::UINT16();
     val.uint16Val = val_;
 }
 
 Value::Value(uint32_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::UINT32);
+    dataType = LogicalType::UINT32();
     val.uint32Val = val_;
 }
 
 Value::Value(uint64_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::UINT64);
+    dataType = LogicalType::UINT64();
     val.uint64Val = val_;
 }
 
 Value::Value(int128_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::INT128);
+    dataType = LogicalType::INT128();
     val.int128Val = val_;
 }
 
 Value::Value(float_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::FLOAT);
+    dataType = LogicalType::FLOAT();
     val.floatVal = val_;
 }
 
 Value::Value(double val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::DOUBLE);
+    dataType = LogicalType::DOUBLE();
     val.doubleVal = val_;
 }
 
 Value::Value(date_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::DATE);
+    dataType = LogicalType::DATE();
     val.int32Val = val_.days;
 }
 
 Value::Value(timestamp_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::TIMESTAMP);
+    dataType = LogicalType::TIMESTAMP();
     val.int64Val = val_.value;
 }
 
 Value::Value(interval_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::INTERVAL);
+    dataType = LogicalType::INTERVAL();
     val.intervalVal = val_;
 }
 
 Value::Value(internalID_t val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID);
+    dataType = LogicalType::INTERNAL_ID();
     val.internalIDVal = val_;
 }
 
 Value::Value(const char* val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::STRING);
+    dataType = LogicalType::STRING();
     strVal = std::string(val_);
 }
 
 Value::Value(uint8_t* val_) : isNull_{false} {
-    dataType = std::make_unique<LogicalType>(LogicalTypeID::POINTER);
+    dataType = LogicalType::POINTER();
     val.pointer = val_;
 }
 

--- a/src/function/table_functions/call_functions.cpp
+++ b/src/function/table_functions/call_functions.cpp
@@ -61,7 +61,7 @@ std::unique_ptr<TableFuncBindData> CurrentSettingFunction::bindFunc(
     std::vector<std::string> returnColumnNames;
     std::vector<std::unique_ptr<LogicalType>> returnTypes;
     returnColumnNames.emplace_back(optionName);
-    returnTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.push_back(LogicalType::STRING());
     return std::make_unique<CurrentSettingBindData>(context->getCurrentSetting(optionName),
         std::move(returnTypes), std::move(returnColumnNames), 1 /* one row result */);
 }
@@ -91,7 +91,7 @@ std::unique_ptr<TableFuncBindData> DBVersionFunction::bindFunc(
     std::vector<std::string> returnColumnNames;
     std::vector<std::unique_ptr<LogicalType>> returnTypes;
     returnColumnNames.emplace_back("version");
-    returnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.emplace_back(LogicalType::STRING());
     return std::make_unique<CallTableFuncBindData>(
         std::move(returnTypes), std::move(returnColumnNames), 1 /* one row result */);
 }
@@ -127,11 +127,11 @@ std::unique_ptr<TableFuncBindData> ShowTablesFunction::bindFunc(
     std::vector<std::string> returnColumnNames;
     std::vector<std::unique_ptr<LogicalType>> returnTypes;
     returnColumnNames.emplace_back("name");
-    returnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.emplace_back(LogicalType::STRING());
     returnColumnNames.emplace_back("type");
-    returnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.emplace_back(LogicalType::STRING());
     returnColumnNames.emplace_back("comment");
-    returnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.emplace_back(LogicalType::STRING());
     return std::make_unique<ShowTablesBindData>(catalog->getTableSchemas(), std::move(returnTypes),
         std::move(returnColumnNames), catalog->getTableCount());
 }
@@ -181,14 +181,14 @@ std::unique_ptr<TableFuncBindData> TableInfoFunction::bindFunc(
     auto tableID = catalog->getTableID(tableName);
     auto schema = catalog->getTableSchema(tableID);
     returnColumnNames.emplace_back("property id");
-    returnTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INT64));
+    returnTypes.push_back(LogicalType::INT64());
     returnColumnNames.emplace_back("name");
-    returnTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.push_back(LogicalType::STRING());
     returnColumnNames.emplace_back("type");
-    returnTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.push_back(LogicalType::STRING());
     if (schema->tableType == TableType::NODE) {
         returnColumnNames.emplace_back("primary key");
-        returnTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::BOOL));
+        returnTypes.push_back(LogicalType::BOOL());
     }
     return std::make_unique<TableInfoBindData>(
         schema, std::move(returnTypes), std::move(returnColumnNames), schema->getNumProperties());
@@ -257,9 +257,9 @@ std::unique_ptr<TableFuncBindData> ShowConnectionFunction::bindFunc(
         throw BinderException{"Show connection can only be called on a rel table!"};
     }
     returnColumnNames.emplace_back("source table name");
-    returnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.emplace_back(LogicalType::STRING());
     returnColumnNames.emplace_back("destination table name");
-    returnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::STRING));
+    returnTypes.emplace_back(LogicalType::STRING());
     return std::make_unique<ShowConnectionBindData>(catalog, schema, std::move(returnTypes),
         std::move(returnColumnNames),
         schema->tableType == TableType::REL ?

--- a/src/function/vector_string_functions.cpp
+++ b/src/function/vector_string_functions.cpp
@@ -314,8 +314,8 @@ function_set RegexpExtractAllFunction::getFunctionSet() {
 
 std::unique_ptr<FunctionBindData> RegexpExtractAllFunction::bindFunc(
     const binder::expression_vector& /*arguments*/, Function* /*definition*/) {
-    return std::make_unique<FunctionBindData>(LogicalType(LogicalTypeID::VAR_LIST,
-        std::make_unique<VarListTypeInfo>(std::make_unique<LogicalType>(LogicalTypeID::STRING))));
+    return std::make_unique<FunctionBindData>(LogicalType(
+        LogicalTypeID::VAR_LIST, std::make_unique<VarListTypeInfo>(LogicalType::STRING())));
 }
 
 } // namespace function

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -282,6 +282,67 @@ public:
     static std::vector<std::unique_ptr<LogicalType>> copy(
         const std::vector<std::unique_ptr<LogicalType>>& types);
 
+    static std::unique_ptr<LogicalType> BOOL() {
+        return std::make_unique<LogicalType>(LogicalTypeID::BOOL);
+    }
+    static std::unique_ptr<LogicalType> INT64() {
+        return std::make_unique<LogicalType>(LogicalTypeID::INT64);
+    }
+    static std::unique_ptr<LogicalType> INT32() {
+        return std::make_unique<LogicalType>(LogicalTypeID::INT32);
+    }
+    static std::unique_ptr<LogicalType> INT16() {
+        return std::make_unique<LogicalType>(LogicalTypeID::INT16);
+    }
+    static std::unique_ptr<LogicalType> INT8() {
+        return std::make_unique<LogicalType>(LogicalTypeID::INT8);
+    }
+    static std::unique_ptr<LogicalType> UINT64() {
+        return std::make_unique<LogicalType>(LogicalTypeID::UINT64);
+    }
+    static std::unique_ptr<LogicalType> UINT32() {
+        return std::make_unique<LogicalType>(LogicalTypeID::UINT32);
+    }
+    static std::unique_ptr<LogicalType> UINT16() {
+        return std::make_unique<LogicalType>(LogicalTypeID::UINT16);
+    }
+    static std::unique_ptr<LogicalType> UINT8() {
+        return std::make_unique<LogicalType>(LogicalTypeID::UINT8);
+    }
+    static std::unique_ptr<LogicalType> INT128() {
+        return std::make_unique<LogicalType>(LogicalTypeID::INT128);
+    }
+    static std::unique_ptr<LogicalType> DOUBLE() {
+        return std::make_unique<LogicalType>(LogicalTypeID::DOUBLE);
+    }
+    static std::unique_ptr<LogicalType> FLOAT() {
+        return std::make_unique<LogicalType>(LogicalTypeID::FLOAT);
+    }
+    static std::unique_ptr<LogicalType> DATE() {
+        return std::make_unique<LogicalType>(LogicalTypeID::DATE);
+    }
+    static std::unique_ptr<LogicalType> TIMESTAMP() {
+        return std::make_unique<LogicalType>(LogicalTypeID::TIMESTAMP);
+    }
+    static std::unique_ptr<LogicalType> INTERVAL() {
+        return std::make_unique<LogicalType>(LogicalTypeID::INTERVAL);
+    }
+    static std::unique_ptr<LogicalType> INTERNAL_ID() {
+        return std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID);
+    }
+    static std::unique_ptr<LogicalType> SERIAL() {
+        return std::make_unique<LogicalType>(LogicalTypeID::SERIAL);
+    }
+    static std::unique_ptr<LogicalType> STRING() {
+        return std::make_unique<LogicalType>(LogicalTypeID::STRING);
+    }
+    static std::unique_ptr<LogicalType> BLOB() {
+        return std::make_unique<LogicalType>(LogicalTypeID::BLOB);
+    }
+    static std::unique_ptr<LogicalType> POINTER() {
+        return std::make_unique<LogicalType>(LogicalTypeID::POINTER);
+    }
+
 private:
     void setPhysicalType();
 

--- a/src/include/storage/stats/property_statistics.h
+++ b/src/include/storage/stats/property_statistics.h
@@ -38,7 +38,10 @@ public:
     RWPropertyStats(TablesStatistics* tablesStatistics, common::table_id_t tableID,
         common::property_id_t propertyID);
 
-    static RWPropertyStats empty() { return RWPropertyStats(nullptr, 0, 0); }
+    // This is used for columns that don't have nullColumn. For example, the serial column.
+    inline static RWPropertyStats empty() {
+        return RWPropertyStats(nullptr, common::INVALID_PROPERTY_ID, common::INVALID_PROPERTY_ID);
+    }
 
     bool mayHaveNull(const transaction::Transaction& transaction);
     void setHasNull(const transaction::Transaction& transaction);

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -32,7 +32,7 @@ class Column {
     friend class StructColumn;
 
 public:
-    Column(common::LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
+    Column(std::unique_ptr<common::LogicalType> dataType, const MetadataDAHInfo& metaDAHeaderInfo,
         BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
         transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
         bool enableCompression, bool requireNullColumn = true);
@@ -55,7 +55,7 @@ public:
 
     virtual void setNull(common::offset_t nodeOffset);
 
-    inline const common::LogicalType& getDataType() const { return dataType; }
+    inline common::LogicalType* getDataType() const { return dataType.get(); }
     inline uint32_t getNumBytesPerValue() const { return numBytesPerFixedSizedValue; }
     inline uint64_t getNumNodeGroups(transaction::Transaction* transaction) const {
         return metadataDA->getNumElements(transaction->getType());
@@ -123,7 +123,7 @@ private:
 
 protected:
     DBFileID dbFileID;
-    common::LogicalType dataType;
+    std::unique_ptr<common::LogicalType> dataType;
     // TODO(bmwinger): Remove. Only used by var_list_column_chunk for something which should be
     // rewritten
     uint32_t numBytesPerFixedSizedValue;
@@ -178,7 +178,7 @@ private:
 };
 
 struct ColumnFactory {
-    static std::unique_ptr<Column> createColumn(const common::LogicalType& dataType,
+    static std::unique_ptr<Column> createColumn(std::unique_ptr<common::LogicalType> dataType,
         const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH, BMFileHandle* metadataFH,
         BufferManager* bufferManager, WAL* wal, transaction::Transaction* transaction,
         RWPropertyStats propertyStatistics, bool enableCompression);

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -53,7 +53,7 @@ public:
 
     // ColumnChunks must be initialized after construction, so this constructor should only be used
     // through the ColumnChunkFactory
-    explicit ColumnChunk(common::LogicalType dataType, uint64_t capacity,
+    ColumnChunk(std::unique_ptr<common::LogicalType> dataType, uint64_t capacity,
         bool enableCompression = true, bool hasNullChunk = true);
 
     virtual ~ColumnChunk() = default;
@@ -64,7 +64,7 @@ public:
     }
 
     inline NullColumnChunk* getNullChunk() { return nullChunk.get(); }
-    inline common::LogicalType getDataType() const { return dataType; }
+    inline common::LogicalType* getDataType() const { return dataType.get(); }
 
     virtual void resetToEmpty();
 
@@ -124,7 +124,7 @@ private:
     static uint32_t getDataTypeSizeInChunk(common::LogicalType& dataType);
 
 protected:
-    common::LogicalType dataType;
+    std::unique_ptr<common::LogicalType> dataType;
     uint32_t numBytesPerValue;
     uint64_t bufferSize;
     uint64_t capacity;
@@ -154,7 +154,7 @@ inline bool ColumnChunk::getValue(common::offset_t pos) const {
 class BoolColumnChunk : public ColumnChunk {
 public:
     explicit BoolColumnChunk(uint64_t capacity, bool hasNullChunk = true)
-        : ColumnChunk(common::LogicalType(common::LogicalTypeID::BOOL), capacity,
+        : ColumnChunk(common::LogicalType::BOOL(), capacity,
               // Booleans are always compressed
               false /* enableCompression */, hasNullChunk) {}
 
@@ -214,8 +214,9 @@ protected:
 };
 
 struct ColumnChunkFactory {
-    static std::unique_ptr<ColumnChunk> createColumnChunk(const common::LogicalType& dataType,
-        bool enableCompression, uint64_t capacity = common::StorageConstants::NODE_GROUP_SIZE);
+    static std::unique_ptr<ColumnChunk> createColumnChunk(
+        std::unique_ptr<common::LogicalType> dataType, bool enableCompression,
+        uint64_t capacity = common::StorageConstants::NODE_GROUP_SIZE);
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -48,8 +48,8 @@ public:
         // By default, initialize all column chunks except for the csrOffsetChunk to empty, as they
         // should be resized after csr offset calculation (e.g., during CopyRel).
         : NodeGroup{columnTypes, enableCompression, 0 /* capacity */} {
-        csrOffsetChunk = ColumnChunkFactory::createColumnChunk(
-            common::LogicalType{common::LogicalTypeID::INT64}, enableCompression);
+        csrOffsetChunk =
+            ColumnChunkFactory::createColumnChunk(common::LogicalType::INT64(), enableCompression);
     }
 
     inline ColumnChunk* getCSROffsetChunk() { return csrOffsetChunk.get(); }

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -7,9 +7,10 @@ namespace storage {
 
 class StringColumn : public Column {
 public:
-    StringColumn(common::LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
-        BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics);
+    StringColumn(std::unique_ptr<common::LogicalType> dataType,
+        const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH, BMFileHandle* metadataFH,
+        BufferManager* bufferManager, WAL* wal, transaction::Transaction* transaction,
+        RWPropertyStats propertyStatistics);
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,

--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -8,7 +8,7 @@ namespace storage {
 
 class StringColumnChunk : public ColumnChunk {
 public:
-    explicit StringColumnChunk(common::LogicalType dataType, uint64_t capacity);
+    explicit StringColumnChunk(std::unique_ptr<common::LogicalType> dataType, uint64_t capacity);
 
     void resetToEmpty() final;
     void append(common::ValueVector* vector) final;

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -7,10 +7,10 @@ namespace storage {
 
 class StructColumn : public Column {
 public:
-    StructColumn(common::LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
-        BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
-        bool enableCompression);
+    StructColumn(std::unique_ptr<common::LogicalType> dataType,
+        const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH, BMFileHandle* metadataFH,
+        BufferManager* bufferManager, WAL* wal, transaction::Transaction* transaction,
+        RWPropertyStats propertyStatistics, bool enableCompression);
 
     void scan(common::node_group_idx_t nodeGroupIdx, ColumnChunk* columnChunk) final;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -7,7 +7,8 @@ namespace storage {
 
 class StructColumnChunk : public ColumnChunk {
 public:
-    StructColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression);
+    StructColumnChunk(
+        std::unique_ptr<common::LogicalType> dataType, uint64_t capacity, bool enableCompression);
 
     inline ColumnChunk* getChild(common::vector_idx_t childIdx) {
         KU_ASSERT(childIdx < childChunks.size());

--- a/src/include/storage/store/var_list_column.h
+++ b/src/include/storage/store/var_list_column.h
@@ -44,16 +44,16 @@ class VarListColumn : public Column {
     friend class VarListLocalColumn;
 
 public:
-    VarListColumn(common::LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
-        BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats propertyStatistics,
-        bool enableCompression)
+    VarListColumn(std::unique_ptr<common::LogicalType> dataType,
+        const MetadataDAHInfo& metaDAHeaderInfo, BMFileHandle* dataFH, BMFileHandle* metadataFH,
+        BufferManager* bufferManager, WAL* wal, transaction::Transaction* transaction,
+        RWPropertyStats propertyStatistics, bool enableCompression)
         : Column{std::move(dataType), metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal,
               transaction, propertyStatistics, enableCompression, true /* requireNullColumn */} {
-        dataColumn =
-            ColumnFactory::createColumn(*common::VarListType::getChildType(&this->dataType),
-                *metaDAHeaderInfo.childrenInfos[0], dataFH, metadataFH, bufferManager, wal,
-                transaction, propertyStatistics, enableCompression);
+        dataColumn = ColumnFactory::createColumn(
+            common::VarListType::getChildType(this->dataType.get())->copy(),
+            *metaDAHeaderInfo.childrenInfos[0], dataFH, metadataFH, bufferManager, wal, transaction,
+            propertyStatistics, enableCompression);
     }
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -27,7 +27,8 @@ struct VarListDataColumnChunk {
 class VarListColumnChunk : public ColumnChunk {
 
 public:
-    VarListColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression);
+    VarListColumnChunk(
+        std::unique_ptr<common::LogicalType> dataType, uint64_t capacity, bool enableCompression);
 
     inline ColumnChunk* getDataColumnChunk() const {
         return varListDataColumnChunk->dataColumnChunk.get();
@@ -62,7 +63,7 @@ private:
 
     inline void initializeIndices() {
         indicesColumnChunk = ColumnChunkFactory::createColumnChunk(
-            common::LogicalType{common::LogicalTypeID::INT64}, false /* enableCompression */);
+            common::LogicalType::INT64(), false /* enableCompression */);
         indicesColumnChunk->getNullChunk()->resetToAllNull();
         for (auto i = 0u; i < numValues; i++) {
             indicesColumnChunk->setValue<common::offset_t>(i, i);

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -134,7 +134,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyRelFrom(
     partitionerSharedState->numPartitions.resize(2);
     std::vector<std::unique_ptr<LogicalType>> columnTypes;
     // TODO(Xiyang): Move binding of column types to binder.
-    columnTypes.push_back(std::make_unique<LogicalType>(LogicalTypeID::INTERNAL_ID)); // ADJ COLUMN.
+    columnTypes.push_back(LogicalType::INTERNAL_ID()); // ADJ COLUMN.
     for (auto& property : tableSchema->properties) {
         columnTypes.push_back(property->getDataType()->copy());
     }

--- a/src/processor/operator/persistent/copy_node.cpp
+++ b/src/processor/operator/persistent/copy_node.cpp
@@ -97,7 +97,7 @@ void CopyNode::populatePKIndex(
     std::string errorPKValueStr;
     pkIndex->lock();
     try {
-        switch (chunk->getDataType().getPhysicalType()) {
+        switch (chunk->getDataType()->getPhysicalType()) {
         case PhysicalTypeID::INT64: {
             auto numAppendedNodes = appendToPKIndex<int64_t>(pkIndex, chunk, startOffset, numNodes);
             if (numAppendedNodes < numNodes) {
@@ -114,7 +114,7 @@ void CopyNode::populatePKIndex(
             }
         } break;
         default: {
-            throw CopyException(ExceptionMessage::invalidPKType(chunk->getDataType().toString()));
+            throw CopyException(ExceptionMessage::invalidPKType(chunk->getDataType()->toString()));
         }
         }
     } catch (Exception& e) {

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -13,7 +13,7 @@ void NodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* /*context*
 void SingleLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
     NodeDeleteExecutor::init(resultSet, context);
     auto pkDataType = table->getColumn(table->getPKColumnID())->getDataType();
-    pkVector = std::make_unique<ValueVector>(pkDataType, context->memoryManager);
+    pkVector = std::make_unique<ValueVector>(*pkDataType, context->memoryManager);
     pkVector->state = nodeIDVector->state;
 }
 
@@ -27,7 +27,7 @@ void MultiLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* 
     NodeDeleteExecutor::init(resultSet, context);
     for (auto& [tableID, table] : tableIDToTableMap) {
         auto pkDataType = table->getColumn(table->getPKColumnID())->getDataType();
-        pkVectors[tableID] = std::make_unique<ValueVector>(pkDataType, context->memoryManager);
+        pkVectors[tableID] = std::make_unique<ValueVector>(*pkDataType, context->memoryManager);
         pkVectors[tableID]->state = nodeIDVector->state;
     }
 }

--- a/src/storage/local_storage.cpp
+++ b/src/storage/local_storage.cpp
@@ -50,7 +50,7 @@ void LocalStorage::initializeLocalTable(
     if (!tables.contains(tableID)) {
         std::vector<std::unique_ptr<LogicalType>> dataTypes;
         for (auto& column : columns) {
-            dataTypes.emplace_back(column->getDataType().copy());
+            dataTypes.emplace_back(column->getDataType()->copy());
         }
         tables.emplace(tableID, std::make_unique<LocalTable>(tableID, std::move(dataTypes), mm));
     }

--- a/src/storage/stats/property_statistics.cpp
+++ b/src/storage/stats/property_statistics.cpp
@@ -25,20 +25,26 @@ std::unique_ptr<PropertyStatistics> PropertyStatistics::deserialize(
 // Read/write statistics cannot be cached since functions like checkpointInMemoryIfNecessary may
 // overwrite them and invalidate the reference
 bool RWPropertyStats::mayHaveNull(const transaction::Transaction& transaction) {
-    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have some columns not exposed as
-    // property in table schema. Should be fixed once we properly align properties and columns.
+    // Columns internal to the storage, i.e., not mapping to a property in table schema, are not
+    // tracked in statistics. For example, offset of var list column, csr offset column, etc.
+    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have a column, i.e., adjColumn,
+    // not exposed as property in table schema, but still have nullColumn. Should be fixed once we
+    // properly align properties and columns.
     if (propertyID == common::INVALID_PROPERTY_ID) {
         return true;
     }
+    KU_ASSERT(tablesStatistics);
     auto statistics =
         tablesStatistics->getPropertyStatisticsForTable(transaction, tableID, propertyID);
     return statistics.mayHaveNull();
 }
 
 void RWPropertyStats::setHasNull(const transaction::Transaction& transaction) {
-    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have some columns not exposed as
-    // property in table schema. Should be fixed once we properly align properties and columns.
+    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have a column, i.e., adjColumn,
+    // not exposed as property in table schema, but still have nullColumn. Should be fixed once we
+    // properly align properties and columns.
     if (propertyID != common::INVALID_PROPERTY_ID) {
+        KU_ASSERT(tablesStatistics);
         tablesStatistics->getPropertyStatisticsForTable(transaction, tableID, propertyID)
             .setHasNull();
     }

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -122,10 +122,10 @@ static std::shared_ptr<CompressionAlg> getCompression(
     }
 }
 
-ColumnChunk::ColumnChunk(
-    LogicalType dataType, uint64_t capacity, bool enableCompression, bool hasNullChunk)
+ColumnChunk::ColumnChunk(std::unique_ptr<LogicalType> dataType, uint64_t capacity,
+    bool enableCompression, bool hasNullChunk)
     : dataType{std::move(dataType)},
-      numBytesPerValue{getDataTypeSizeInChunk(this->dataType)}, numValues{0} {
+      numBytesPerValue{getDataTypeSizeInChunk(*this->dataType)}, numValues{0} {
     if (hasNullChunk) {
         nullChunk = std::make_unique<NullColumnChunk>(capacity);
     }
@@ -134,7 +134,7 @@ ColumnChunk::ColumnChunk(
 }
 
 void ColumnChunk::initializeBuffer(offset_t capacity_) {
-    numBytesPerValue = getDataTypeSizeInChunk(dataType);
+    numBytesPerValue = getDataTypeSizeInChunk(*dataType);
     capacity = capacity_;
     bufferSize = getBufferSize();
     buffer = std::make_unique<uint8_t[]>(bufferSize);
@@ -144,7 +144,7 @@ void ColumnChunk::initializeBuffer(offset_t capacity_) {
 }
 
 void ColumnChunk::initializeFunction(bool enableCompression) {
-    switch (this->dataType.getPhysicalType()) {
+    switch (this->dataType->getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
         // Since we compress into memory, storage is the same as fixed-sized values,
         // but we need to mark it as being boolean compressed.
@@ -162,9 +162,9 @@ void ColumnChunk::initializeFunction(bool enableCompression) {
     case PhysicalTypeID::UINT16:
     case PhysicalTypeID::UINT8:
     case PhysicalTypeID::INT128: {
-        auto compression = getCompression(this->dataType, enableCompression);
-        flushBufferFunction = CompressedFlushBuffer(compression, this->dataType);
-        getMetadataFunction = GetCompressionMetadata(compression, this->dataType);
+        auto compression = getCompression(*this->dataType, enableCompression);
+        flushBufferFunction = CompressedFlushBuffer(compression, *this->dataType);
+        getMetadataFunction = GetCompressionMetadata(compression, *this->dataType);
         break;
     }
     default: {
@@ -182,14 +182,14 @@ void ColumnChunk::resetToEmpty() {
 }
 
 void ColumnChunk::append(ValueVector* vector) {
-    KU_ASSERT(vector->dataType.getPhysicalType() == dataType.getPhysicalType());
+    KU_ASSERT(vector->dataType.getPhysicalType() == dataType->getPhysicalType());
     copyVectorToBuffer(vector, numValues);
     numValues += vector->state->selVector->selectedSize;
 }
 
 void ColumnChunk::append(
     ColumnChunk* other, offset_t startPosInOtherChunk, uint32_t numValuesToAppend) {
-    KU_ASSERT(other->dataType.getPhysicalType() == dataType.getPhysicalType());
+    KU_ASSERT(other->dataType->getPhysicalType() == dataType->getPhysicalType());
     if (nullChunk) {
         KU_ASSERT(nullChunk->getNumValues() == getNumValues());
         nullChunk->append(other->nullChunk.get(), startPosInOtherChunk, numValuesToAppend);
@@ -202,7 +202,7 @@ void ColumnChunk::append(
 
 void ColumnChunk::write(ValueVector* vector, ValueVector* offsetsInChunk) {
     KU_ASSERT(
-        vector->dataType.getPhysicalType() == dataType.getPhysicalType() &&
+        vector->dataType.getPhysicalType() == dataType->getPhysicalType() &&
         offsetsInChunk->dataType.getPhysicalType() == PhysicalTypeID::INT64 &&
         vector->state->selVector->selectedSize == offsetsInChunk->state->selVector->selectedSize);
     auto offsets = (offset_t*)offsetsInChunk->getData();
@@ -227,8 +227,8 @@ void ColumnChunk::write(ValueVector* vector, ValueVector* offsetsInChunk) {
 // be slided. However, this is unsafe, as this function can also be used for other purposes later.
 // Thus, an assertion is added at the first line.
 void ColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
-    KU_ASSERT(dataType.getPhysicalType() != PhysicalTypeID::BOOL &&
-              dataType.getPhysicalType() != PhysicalTypeID::VAR_LIST);
+    KU_ASSERT(dataType->getPhysicalType() != PhysicalTypeID::BOOL &&
+              dataType->getPhysicalType() != PhysicalTypeID::VAR_LIST);
     nullChunk->setNull(offsetInChunk, vector->isNull(offsetInVector));
     if (!vector->isNull(offsetInVector)) {
         memcpy(buffer.get() + offsetInChunk * numBytesPerValue,
@@ -244,7 +244,7 @@ void ColumnChunk::resize(uint64_t newCapacity) {
     auto numBytesAfterResize = getBufferSize();
     if (numBytesAfterResize > bufferSize) {
         auto resizedBuffer = std::make_unique<uint8_t[]>(numBytesAfterResize);
-        if (dataType.getPhysicalType() == PhysicalTypeID::BOOL) {
+        if (dataType->getPhysicalType() == PhysicalTypeID::BOOL) {
             memset(resizedBuffer.get(), 0 /* non null */, numBytesAfterResize);
         }
         memcpy(resizedBuffer.get(), buffer.get(), bufferSize);
@@ -339,7 +339,7 @@ uint32_t ColumnChunk::getDataTypeSizeInChunk(LogicalType& dataType) {
 }
 
 uint64_t ColumnChunk::getBufferSize() const {
-    switch (dataType.getLogicalTypeID()) {
+    switch (dataType->getLogicalTypeID()) {
     case LogicalTypeID::BOOL: {
         // 8 values per byte, and we need a buffer size which is a multiple of 8 bytes.
         return ceil(capacity / 8.0 / 8.0) * 8;
@@ -415,7 +415,8 @@ void NullColumnChunk::append(
 
 class FixedListColumnChunk : public ColumnChunk {
 public:
-    FixedListColumnChunk(LogicalType dataType, uint64_t capacity, bool enableCompression)
+    FixedListColumnChunk(
+        std::unique_ptr<LogicalType> dataType, uint64_t capacity, bool enableCompression)
         : ColumnChunk(std::move(dataType), capacity, enableCompression, true /* hasNullChunk */) {}
 
     void append(
@@ -477,8 +478,8 @@ public:
 };
 
 std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
-    const LogicalType& dataType, bool enableCompression, uint64_t capacity) {
-    switch (dataType.getPhysicalType()) {
+    std::unique_ptr<LogicalType> dataType, bool enableCompression, uint64_t capacity) {
+    switch (dataType->getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
         return std::make_unique<BoolColumnChunk>(capacity);
     }
@@ -494,29 +495,32 @@ std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
     case PhysicalTypeID::DOUBLE:
     case PhysicalTypeID::FLOAT:
     case PhysicalTypeID::INTERVAL: {
-        if (dataType.getLogicalTypeID() == LogicalTypeID::SERIAL) {
-            return std::make_unique<ColumnChunk>(
-                dataType, capacity, false /*enableCompression*/, false /* hasNullChunk */);
+        if (dataType->getLogicalTypeID() == LogicalTypeID::SERIAL) {
+            return std::make_unique<ColumnChunk>(std::move(dataType), capacity,
+                false /*enableCompression*/, false /* hasNullChunk */);
         } else {
-            return std::make_unique<ColumnChunk>(dataType, capacity, enableCompression);
+            return std::make_unique<ColumnChunk>(std::move(dataType), capacity, enableCompression);
         }
     }
         // Physically, we only materialize offset of INTERNAL_ID, which is same as INT64,
     case PhysicalTypeID::INTERNAL_ID: {
         return std::make_unique<ColumnChunk>(
-            LogicalType(LogicalTypeID::INT64), capacity, false /* enableCompression */);
+            LogicalType::INT64(), capacity, false /* enableCompression */);
     }
     case PhysicalTypeID::FIXED_LIST: {
-        return std::make_unique<FixedListColumnChunk>(dataType, capacity, enableCompression);
+        return std::make_unique<FixedListColumnChunk>(
+            std::move(dataType), capacity, enableCompression);
     }
     case PhysicalTypeID::STRING: {
-        return std::make_unique<StringColumnChunk>(dataType, capacity);
+        return std::make_unique<StringColumnChunk>(std::move(dataType), capacity);
     }
     case PhysicalTypeID::VAR_LIST: {
-        return std::make_unique<VarListColumnChunk>(dataType, capacity, enableCompression);
+        return std::make_unique<VarListColumnChunk>(
+            std::move(dataType), capacity, enableCompression);
     }
     case PhysicalTypeID::STRUCT: {
-        return std::make_unique<StructColumnChunk>(dataType, capacity, enableCompression);
+        return std::make_unique<StructColumnChunk>(
+            std::move(dataType), capacity, enableCompression);
     }
     default:
         KU_UNREACHABLE;

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -140,7 +140,7 @@ void NodeTable::rollbackInMemory() {
 void NodeTable::updatePK(Transaction* transaction, column_id_t columnID,
     common::ValueVector* keyVector, common::ValueVector* payloadVector) {
     auto pkVector =
-        std::make_unique<ValueVector>(getColumn(pkColumnID)->getDataType(), memoryManager);
+        std::make_unique<ValueVector>(*getColumn(pkColumnID)->getDataType(), memoryManager);
     pkVector->state = keyVector->state;
     auto readState = std::make_unique<storage::TableReadState>();
     initializeReadState(transaction, {columnID}, keyVector, readState.get());

--- a/src/storage/store/node_table_data.cpp
+++ b/src/storage/store/node_table_data.cpp
@@ -19,8 +19,8 @@ NodeTableData::NodeTableData(BMFileHandle* dataFH, BMFileHandle* metadataFH, tab
         auto property = properties[i];
         auto metadataDAHInfo = dynamic_cast<NodesStoreStatsAndDeletedIDs*>(tablesStatistics)
                                    ->getMetadataDAHInfo(&DUMMY_WRITE_TRANSACTION, tableID, i);
-        columns.push_back(ColumnFactory::createColumn(*property->getDataType(), *metadataDAHInfo,
-            dataFH, metadataFH, bufferManager, wal, &DUMMY_WRITE_TRANSACTION,
+        columns.push_back(ColumnFactory::createColumn(property->getDataType()->copy(),
+            *metadataDAHInfo, dataFH, metadataFH, bufferManager, wal, &DUMMY_WRITE_TRANSACTION,
             RWPropertyStats(tablesStatistics, tableID, property->getPropertyID()),
             enableCompression));
     }

--- a/src/storage/store/string_column_chunk.cpp
+++ b/src/storage/store/string_column_chunk.cpp
@@ -8,7 +8,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-StringColumnChunk::StringColumnChunk(LogicalType dataType, uint64_t capacity)
+StringColumnChunk::StringColumnChunk(std::unique_ptr<LogicalType> dataType, uint64_t capacity)
     : ColumnChunk{std::move(dataType), capacity} {
     overflowFile = std::make_unique<InMemOverflowFile>();
     overflowCursor.pageIdx = 0;
@@ -39,7 +39,7 @@ void StringColumnChunk::append(
     ColumnChunk* other, offset_t startPosInOtherChunk, uint32_t numValuesToAppend) {
     auto otherChunk = reinterpret_cast<StringColumnChunk*>(other);
     nullChunk->append(otherChunk->getNullChunk(), startPosInOtherChunk, numValuesToAppend);
-    switch (dataType.getLogicalTypeID()) {
+    switch (dataType->getLogicalTypeID()) {
     case LogicalTypeID::BLOB:
     case LogicalTypeID::STRING: {
         appendStringColumnChunk(otherChunk, startPosInOtherChunk, numValuesToAppend);

--- a/src/storage/store/table_data.cpp
+++ b/src/storage/store/table_data.cpp
@@ -9,8 +9,8 @@ namespace storage {
 void TableData::addColumn(Transaction* transaction, InMemDiskArray<ColumnChunkMetadata>* metadataDA,
     const MetadataDAHInfo& metadataDAHInfo, const catalog::Property& property,
     ValueVector* defaultValueVector, TablesStatistics* tablesStats) {
-    auto column = ColumnFactory::createColumn(*property.getDataType(), metadataDAHInfo, dataFH,
-        metadataFH, bufferManager, wal, transaction,
+    auto column = ColumnFactory::createColumn(property.getDataType()->copy(), metadataDAHInfo,
+        dataFH, metadataFH, bufferManager, wal, transaction,
         RWPropertyStats(tablesStats, tableID, property.getPropertyID()), enableCompression);
     column->populateWithDefaultVal(
         property, column.get(), metadataDA, defaultValueVector, getNumNodeGroups(transaction));

--- a/src/storage/store/var_list_column.cpp
+++ b/src/storage/store/var_list_column.cpp
@@ -149,7 +149,7 @@ offset_t VarListColumn::readOffset(
     offsetVector->state = DataChunkState::getSingleValueDataChunkState();
     auto chunkMeta = metadataDA->get(nodeGroupIdx, transaction->getType());
     auto pageCursor = PageUtils::getPageElementCursorForPos(offsetInNodeGroup,
-        chunkMeta.compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType));
+        chunkMeta.compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, *dataType));
     pageCursor.pageIdx += chunkMeta.pageIdx;
     readFromPage(transaction, pageCursor.pageIdx, [&](uint8_t* frame) -> void {
         readToVectorFunc(frame, pageCursor, offsetVector.get(), 0 /* posInVector */,


### PR DESCRIPTION
As described in the title. This simplifies the implicit copy and life cycle problems related to LogicalType. We should change the one inside ValueVector too.

Also, added some syntax sugars inside `LogicalType`, such as `LogicalType::BOOL()`, `LogicalType::INT64()` to avoid `std::make_unique(...)`.

Another minor change is to make `csrOffsetColumn` and `adjColumn` to reuse `RWPropertyStats::empty()` for constructing the rw property stats inside their constructors.