### PR TITLE
Add more types to arrow export

### DIFF
--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<LogicalType> Binder::bindDataType(const std::string& dataType) {
     if (boundType.getLogicalTypeID() == LogicalTypeID::FIXED_LIST) {
         auto validNumericTypes = LogicalTypeUtils::getNumericalLogicalTypeIDs();
         auto childType = FixedListType::getChildType(&boundType);
-        auto numElementsInList = FixedListType::getNumElementsInList(&boundType);
+        auto numElementsInList = FixedListType::getNumValuesInList(&boundType);
         if (find(validNumericTypes.begin(), validNumericTypes.end(),
                 childType->getLogicalTypeID()) == validNumericTypes.end()) {
             throw BinderException("The child type of a fixed list must be a numeric type. Given: " +

--- a/src/c_api/data_type.cpp
+++ b/src/c_api/data_type.cpp
@@ -56,5 +56,5 @@ uint64_t kuzu_data_type_get_fixed_num_elements_in_list(kuzu_logical_type* data_t
     if (parent_type->getLogicalTypeID() != LogicalTypeID::FIXED_LIST) {
         return 0;
     }
-    return FixedListType::getNumElementsInList(static_cast<LogicalType*>(data_type->_data_type));
+    return FixedListType::getNumValuesInList(static_cast<LogicalType*>(data_type->_data_type));
 }

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -331,7 +331,7 @@ std::string LogicalType::toString() const {
     case LogicalTypeID::FIXED_LIST: {
         auto fixedListTypeInfo = reinterpret_cast<FixedListTypeInfo*>(extraTypeInfo.get());
         return fixedListTypeInfo->getChildType()->toString() + "[" +
-               std::to_string(fixedListTypeInfo->getNumElementsInList()) + "]";
+               std::to_string(fixedListTypeInfo->getNumValuesInList()) + "]";
     }
     case LogicalTypeID::UNION: {
         auto unionTypeInfo = reinterpret_cast<StructTypeInfo*>(extraTypeInfo.get());
@@ -685,7 +685,7 @@ uint32_t LogicalTypeUtils::getRowLayoutSize(const LogicalType& type) {
     }
     case PhysicalTypeID::FIXED_LIST: {
         return getRowLayoutSize(*FixedListType::getChildType(&type)) *
-               FixedListType::getNumElementsInList(&type);
+               FixedListType::getNumValuesInList(&type);
     }
     case PhysicalTypeID::VAR_LIST: {
         return sizeof(ku_list_t);

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -86,7 +86,7 @@ Value Value::createDefaultValue(const LogicalType& dataType) {
     case LogicalTypeID::FIXED_LIST: {
         std::vector<std::unique_ptr<Value>> children;
         auto childType = FixedListType::getChildType(&dataType);
-        for (auto i = 0u; i < FixedListType::getNumElementsInList(&dataType); ++i) {
+        for (auto i = 0u; i < FixedListType::getNumValuesInList(&dataType); ++i) {
             children.push_back(std::make_unique<Value>(createDefaultValue(*childType)));
         }
         return Value(dataType, std::move(children));

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -292,7 +292,7 @@ std::unique_ptr<Value> ValueVector::getAsValue(uint64_t pos) {
     } break;
     case PhysicalTypeID::FIXED_LIST: {
         auto childDataType = FixedListType::getChildType(&dataType);
-        auto numElements = FixedListType::getNumElementsInList(&dataType);
+        auto numElements = FixedListType::getNumValuesInList(&dataType);
         std::vector<std::unique_ptr<Value>> children;
         children.reserve(numElements);
         switch (childDataType->getPhysicalType()) {
@@ -366,7 +366,7 @@ uint32_t ValueVector::getDataTypeSize(const LogicalType& type) {
     }
     case PhysicalTypeID::FIXED_LIST: {
         return getDataTypeSize(*FixedListType::getChildType(&type)) *
-               FixedListType::getNumElementsInList(&type);
+               FixedListType::getNumValuesInList(&type);
     }
     case PhysicalTypeID::STRUCT: {
         return sizeof(struct_entry_t);

--- a/src/function/cast_string_to_functions.cpp
+++ b/src/function/cast_string_to_functions.cpp
@@ -341,7 +341,7 @@ struct SplitStringFixedListOperation {
 };
 
 static void validateNumElementsInList(uint64_t numElementsRead, const LogicalType& type) {
-    auto numElementsInList = FixedListType::getNumElementsInList(&type);
+    auto numElementsInList = FixedListType::getNumValuesInList(&type);
     if (numElementsRead != numElementsInList) {
         throw CopyException(stringFormat(
             "Each fixed list should have fixed number of elements. Expected: {}, Actual: {}.",

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -20,7 +20,7 @@ static void castFixedListToString(
         return;
     }
     std::string result = "[";
-    auto numValuesPerList = FixedListType::getNumElementsInList(&param.dataType);
+    auto numValuesPerList = FixedListType::getNumValuesInList(&param.dataType);
     auto childType = FixedListType::getChildType(&param.dataType);
     auto values = param.getData() + pos * param.getNumBytesPerValue();
     for (auto i = 0u; i < numValuesPerList - 1; ++i) {

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -176,7 +176,7 @@ public:
     explicit FixedListTypeInfo(
         std::unique_ptr<LogicalType> childType, uint64_t fixedNumElementsInList)
         : VarListTypeInfo{std::move(childType)}, fixedNumElementsInList{fixedNumElementsInList} {}
-    inline uint64_t getNumElementsInList() const { return fixedNumElementsInList; }
+    inline uint64_t getNumValuesInList() const { return fixedNumElementsInList; }
     bool operator==(const FixedListTypeInfo& other) const;
     static std::unique_ptr<ExtraTypeInfo> deserialize(Deserializer& deserializer);
     std::unique_ptr<ExtraTypeInfo> copy() const override;
@@ -306,10 +306,10 @@ struct FixedListType {
         return fixedListTypeInfo->getChildType();
     }
 
-    static inline uint64_t getNumElementsInList(const LogicalType* type) {
+    static inline uint64_t getNumValuesInList(const LogicalType* type) {
         KU_ASSERT(type->getLogicalTypeID() == LogicalTypeID::FIXED_LIST);
         auto fixedListTypeInfo = reinterpret_cast<FixedListTypeInfo*>(type->extraTypeInfo.get());
-        return fixedListTypeInfo->getNumElementsInList();
+        return fixedListTypeInfo->getNumValuesInList();
     }
 };
 

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -13,11 +13,13 @@ namespace main {
 struct DataTypeInfo {
 public:
     DataTypeInfo(common::LogicalTypeID typeID, std::string name)
-        : typeID{typeID}, name{std::move(name)} {}
+        : typeID{typeID}, name{std::move(name)}, numValuesPerList{0} {}
 
     common::LogicalTypeID typeID;
     std::string name;
     std::vector<std::unique_ptr<DataTypeInfo>> childrenTypesInfo;
+    // Used by fixedList only.
+    uint64_t numValuesPerList;
 
     static std::unique_ptr<DataTypeInfo> getInfoForDataType(
         const common::LogicalType& type, const std::string& name);

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -30,6 +30,20 @@ std::unique_ptr<DataTypeInfo> DataTypeInfo::getInfoForDataType(
         auto childType = VarListType::getChildType(&type);
         parentTypeInfo->childrenTypesInfo.push_back(getInfoForDataType(*childType, ""));
     } break;
+    case LogicalTypeID::FIXED_LIST: {
+        auto parentTypeInfo = columnTypeInfo.get();
+        parentTypeInfo->numValuesPerList = FixedListType::getNumValuesInList(&type);
+        auto childType = FixedListType::getChildType(&type);
+        parentTypeInfo->childrenTypesInfo.push_back(getInfoForDataType(*childType, ""));
+    } break;
+    case LogicalTypeID::STRUCT: {
+        auto parentTypeInfo = columnTypeInfo.get();
+        for (auto i = 0u; i < StructType::getNumFields(&type); i++) {
+            auto structField = StructType::getField(&type, i);
+            parentTypeInfo->childrenTypesInfo.push_back(
+                getInfoForDataType(*structField->getType(), structField->getName()));
+        }
+    } break;
     default: {
         // DO NOTHING
     }

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -194,7 +194,7 @@ void NpyReader::validate(const LogicalType& type_, offset_t numRows) {
                                              "match the expected type.",
                 filePath));
         }
-        if (getNumElementsPerRow() != FixedListType::getNumElementsInList(&type_)) {
+        if (getNumElementsPerRow() != FixedListType::getNumValuesInList(&type_)) {
             throw CopyException(
                 stringFormat("The shape of {} does not match {}.", filePath, type_.toString()));
         }

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -51,7 +51,7 @@ uint32_t StorageUtils::getDataTypeSize(const LogicalType& type) {
     }
     case PhysicalTypeID::FIXED_LIST: {
         return getDataTypeSize(*FixedListType::getChildType(&type)) *
-               FixedListType::getNumElementsInList(&type);
+               FixedListType::getNumValuesInList(&type);
     }
     case PhysicalTypeID::VAR_LIST: {
         return sizeof(ku_list_t);

--- a/test/c_api/data_type_test.cpp
+++ b/test/c_api/data_type_test.cpp
@@ -21,7 +21,7 @@ TEST(CApiDataTypeTest, Create) {
     auto dataTypeCpp3 = (LogicalType*)dataType3->_data_type;
     ASSERT_EQ(dataTypeCpp3->getLogicalTypeID(), LogicalTypeID::FIXED_LIST);
     // ASSERT_EQ(dataTypeCpp3->getChildType()->getLogicalTypeID(), LogicalTypeID::INT64);
-    ASSERT_EQ(FixedListType::getNumElementsInList(dataTypeCpp3), 100);
+    ASSERT_EQ(FixedListType::getNumValuesInList(dataTypeCpp3), 100);
 
     // Since child type is copied, we should be able to destroy the original type without an error.
     kuzu_data_type_destroy(dataType);

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -623,7 +623,7 @@ Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1get_1fixed_1num_1elements_1in_1list
     if (dt->getLogicalTypeID() != LogicalTypeID::FIXED_LIST) {
         return 0;
     }
-    return static_cast<jlong>(FixedListType::getNumElementsInList(dt));
+    return static_cast<jlong>(FixedListType::getNumValuesInList(dt));
 }
 
 /**

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -226,6 +226,7 @@ bool PyQueryResult::getNextArrowChunk(const std::vector<std::unique_ptr<DataType
     ArrowArray data;
     ArrowConverter::toArrowArray(*queryResult, &data, chunkSize);
 
+    // TODO(Ziyi): use import cache to improve performance.
     auto pyarrowLibModule = py::module::import("pyarrow").attr("lib");
     auto batchImportFunc = pyarrowLibModule.attr("RecordBatch").attr("_import_from_c");
     auto schema = ArrowConverter::toArrowSchema(typesInfo);

--- a/tools/python_api/test/test_arrow.py
+++ b/tools/python_api/test/test_arrow.py
@@ -1,47 +1,59 @@
 import sys
+import time
 
 sys.path.append('../build/')
 import kuzu
 import pyarrow as pa
 import datetime
 import ground_truth
+from decimal import Decimal
 
 
 def test_to_arrow(establish_connection):
     conn, db = establish_connection
 
-    def _test_primitive_data_types(_conn):
-        query = "MATCH (a:person) RETURN a.age, to_int32(a.age), to_int16(a.age), a.isStudent, a.eyeSight, a.birthdate, a.registerTime," \
-                " a.lastJobDuration, a.fName ORDER BY a.ID"
+    def _test_person_table(_conn):
+        query = "MATCH (a:person) RETURN a.* ORDER BY a.ID"
         arrow_tbl = _conn.execute(query).get_as_arrow(8)
-        assert arrow_tbl.num_columns == 9
+        assert arrow_tbl.num_columns == 15
 
-        age_col = arrow_tbl.column(0)
-        assert age_col.type == pa.int64()
-        assert age_col.length() == 8
-        assert age_col.to_pylist() == [35, 30, 45, 20, 20, 25, 40, 83]
+        id_col = arrow_tbl.column(0)
+        assert id_col.type == pa.int64()
+        assert id_col.length() == 8
+        assert id_col.to_pylist() == [0, 2, 3, 5, 7, 8, 9, 10]
 
-        age_32_col = arrow_tbl.column(1)
-        assert age_32_col.type == pa.int32()
-        assert age_32_col.length() == 8
-        assert age_32_col.to_pylist() == [35, 30, 45, 20, 20, 25, 40, 83]
+        f_name_col = arrow_tbl.column(1)
+        assert f_name_col.type == pa.string()
+        assert f_name_col.length() == 8
+        assert f_name_col.to_pylist() == ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
+                                          "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
 
-        age_16_col = arrow_tbl.column(2)
-        assert age_16_col.type == pa.int16()
-        assert age_16_col.length() == 8
-        assert age_16_col.to_pylist() == [35, 30, 45, 20, 20, 25, 40, 83]
+        f_gender_col = arrow_tbl.column(2)
+        assert f_gender_col.type == pa.int64()
+        assert f_gender_col.length() == 8
+        assert f_gender_col.to_pylist() == [1, 2, 1, 2, 1, 2, 2, 2]
 
         is_student_col = arrow_tbl.column(3)
         assert is_student_col.type == pa.bool_()
         assert is_student_col.length() == 8
         assert is_student_col.to_pylist() == [True, True, False, False, False, True, False, False]
 
-        eye_sight_col = arrow_tbl.column(4)
+        is_worker_col = arrow_tbl.column(4)
+        assert is_worker_col.type == pa.bool_()
+        assert is_worker_col.length() == 8
+        assert is_worker_col.to_pylist() == [False, False, True, True, True, False, False, True]
+
+        age_col = arrow_tbl.column(5)
+        assert age_col.type == pa.int64()
+        assert age_col.length() == 8
+        assert age_col.to_pylist() == [35, 30, 45, 20, 20, 25, 40, 83]
+
+        eye_sight_col = arrow_tbl.column(6)
         assert eye_sight_col.type == pa.float64()
         assert eye_sight_col.length() == 8
         assert eye_sight_col.to_pylist() == [5.0, 5.1, 5.0, 4.8, 4.7, 4.5, 4.9, 4.9]
 
-        birthdate_col = arrow_tbl.column(5)
+        birthdate_col = arrow_tbl.column(7)
         assert birthdate_col.type == pa.date32()
         assert birthdate_col.length() == 8
         assert birthdate_col.to_pylist() == [datetime.date(1900, 1, 1), datetime.date(1900, 1, 1),
@@ -49,7 +61,7 @@ def test_to_arrow(establish_connection):
                                              datetime.date(1980, 10, 26), datetime.date(1980, 10, 26),
                                              datetime.date(1980, 10, 26), datetime.date(1990, 11, 27)]
 
-        register_time_col = arrow_tbl.column(6)
+        register_time_col = arrow_tbl.column(8)
         assert register_time_col.type == pa.timestamp('us')
         assert register_time_col.length() == 8
         assert register_time_col.to_pylist() == [
@@ -58,7 +70,7 @@ def test_to_arrow(establish_connection):
             datetime.datetime(1976, 12, 23, 11, 21, 42), datetime.datetime(1972, 7, 31, 13, 22, 30, 678559),
             datetime.datetime(1976, 12, 23, 4, 41, 42), datetime.datetime(2023, 2, 21, 13, 25, 30)]
 
-        last_job_duration_col = arrow_tbl.column(7)
+        last_job_duration_col = arrow_tbl.column(9)
         assert last_job_duration_col.type == pa.duration('ms')
         assert last_job_duration_col.length() == 8
         assert last_job_duration_col.to_pylist() == [datetime.timedelta(days=99, seconds=36334, microseconds=628000),
@@ -70,111 +82,206 @@ def test_to_arrow(establish_connection):
                                                      datetime.timedelta(microseconds=125000),
                                                      datetime.timedelta(days=541, seconds=57600, microseconds=24000)]
 
-        f_name_col = arrow_tbl.column(8)
-        assert f_name_col.type == pa.string()
-        assert f_name_col.length() == 8
-        assert f_name_col.to_pylist() == ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
-                                          "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
+        worked_hours_col = arrow_tbl.column(10)
+        assert worked_hours_col.type == pa.list_(pa.int64())
+        assert worked_hours_col.length() == 8
+        assert worked_hours_col.to_pylist() == [[10, 5], [12, 8], [4, 5], [1, 9], [2], [3, 4, 5, 6, 7], [1],
+                                                [10, 11, 12, 3, 4, 5, 6, 7]]
 
-    def _test_utf8_string(_conn):
-        query = "MATCH (m:movies) RETURN m.name"
-        query_result = _conn.execute(query)
+        used_names_col = arrow_tbl.column(11)
+        assert used_names_col.type == pa.list_(pa.string())
+        assert used_names_col.length() == 8
+        assert used_names_col.to_pylist() == [["Aida"], ["Bobby"], ["Carmen", "Fred"], ["Wolfeschlegelstein", "Daniel"],
+                                              ["Ein"], ["Fesdwe"], ["Grad"], ["Ad", "De", "Hi", "Kye", "Orlan"]]
 
-        arrow_tbl = query_result.get_as_arrow(3)
-        assert arrow_tbl.num_columns == 1
-        name_col = arrow_tbl.column(0)
-        assert name_col.type == pa.string()
-        assert name_col.length() == 3
-        assert name_col.to_pylist() == ["Sóló cón tu párejâ", "The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie", "Roma"]
+        used_names_col = arrow_tbl.column(12)
+        assert used_names_col.type == pa.list_(pa.list_(pa.int64()))
+        assert used_names_col.length() == 8
+        assert used_names_col.to_pylist() == [[[10, 8], [6, 7, 8]], [[8, 9], [9, 10]], [[8, 10]], [[7, 4], [8, 8], [9]],
+                                              [[6], [7], [8]], [[8]], [[10]], [[7], [10], [6, 7]]]
 
-    def _test_in_small_chunk_size(_conn):
-        query = "MATCH (a:person) RETURN a.age, a.fName ORDER BY a.ID"
-        query_result = _conn.execute(query)
+        grades_col = arrow_tbl.column(13)
+        assert grades_col.type == pa.list_(pa.int64(), 4)
+        assert grades_col.length() == 8
+        assert grades_col.to_pylist() == [[96, 54, 86, 92], [98, 42, 93, 88], [91, 75, 21, 95], [76, 88, 99, 89],
+                                          [96, 59, 65, 88], [80, 78, 34, 83], [43, 83, 67, 43], [77, 64, 100, 54]]
 
-        arrow_tbl = query_result.get_as_arrow(4)
+    def _test_movies_table(_conn):
+        query = "MATCH (a:movies) RETURN a.length, a.description ORDER BY a.length"
+        arrow_tbl = _conn.execute(query).get_as_arrow(8)
         assert arrow_tbl.num_columns == 2
-        age_col = arrow_tbl.column(0)
-        assert age_col.type == pa.int64()
-        assert age_col.length() == 8
-        f_name_col = arrow_tbl.column(1)
-        assert f_name_col.type == pa.string()
-        assert f_name_col.length() == 8
 
-        assert age_col.to_pylist() == [35, 30, 45, 20, 20, 25, 40, 83]
-        assert f_name_col.to_pylist() == ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
-                                          "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
+        length_col = arrow_tbl.column(0)
+        assert length_col.type == pa.int32()
+        assert length_col.length() == 3
+        assert length_col.to_pylist() == [126, 298, 2544]
 
-    def _test_with_nulls(_conn):
-        query = "MATCH (a:person:organisation) RETURN label(a), a.fName, a.orgCode ORDER BY a.ID"
-        query_result = _conn.execute(query)
-        arrow_tbl = query_result.get_as_arrow(12)
+        description_col = arrow_tbl.column(1)
+        assert description_col.type == pa.struct(
+            [('rating', pa.float64()), ('stars', pa.int8()), ('views', pa.int64()), ('release', pa.timestamp('us')),
+             ('film', pa.date32()), ('u8', pa.uint8()), ('u16', pa.uint16()), ('u32', pa.uint32()),
+             ('u64', pa.uint64()), ('hugedata', pa.decimal128(38, 0))])
+        assert description_col.length() == 3
+        assert description_col.to_pylist() == [{
+            'rating': 5.3,
+            'stars': 2,
+            'views': 152,
+            'release': datetime.datetime(2011, 8, 20, 11, 25, 30),
+            'film': datetime.date(2012, 5, 11),
+            'u8': 220,
+            'u16': 20,
+            'u32': 1,
+            'u64': 180,
+            'hugedata': Decimal(1844674407370955161811111111)
+        }, {
+            'rating': 1223,
+            'stars': 100,
+            'views': 10003,
+            'release': datetime.datetime(2011, 2, 11, 16, 44, 22),
+            'film': datetime.date(2013, 2, 22),
+            'u8': 1,
+            'u16': 15,
+            'u32': 200,
+            'u64': 4,
+            'hugedata': Decimal(-15)
+        }, {
+            'rating': 7,
+            'stars': 10,
+            'views': 982,
+            'release': datetime.datetime(2018, 11, 13, 13, 33, 11),
+            'film': datetime.date(2014, 9, 12),
+            'u8': 12,
+            'u16': 120,
+            'u32': 55,
+            'u64': 1,
+            'hugedata': Decimal(-1844674407370955161511)
+        }]
+
+        def _test_utf8_string(_conn):
+            query = "MATCH (m:movies) RETURN m.name"
+            query_result = _conn.execute(query)
+
+            arrow_tbl = query_result.get_as_arrow(3)
+            assert arrow_tbl.num_columns == 1
+            name_col = arrow_tbl.column(0)
+            assert name_col.type == pa.string()
+            assert name_col.length() == 3
+            assert name_col.to_pylist() == ["Sóló cón tu párejâ", "The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie", "Roma"]
+
+        def _test_in_small_chunk_size(_conn):
+            query = "MATCH (a:person) RETURN a.age, a.fName ORDER BY a.ID"
+            query_result = _conn.execute(query)
+
+            arrow_tbl = query_result.get_as_arrow(4)
+            assert arrow_tbl.num_columns == 2
+            age_col = arrow_tbl.column(0)
+            assert age_col.type == pa.int64()
+            assert age_col.length() == 8
+            f_name_col = arrow_tbl.column(1)
+            assert f_name_col.type == pa.string()
+            assert f_name_col.length() == 8
+
+            assert age_col.to_pylist() == [35, 30, 45, 20, 20, 25, 40, 83]
+            assert f_name_col.to_pylist() == ["Alice", "Bob", "Carol", "Dan", "Elizabeth", "Farooq", "Greg",
+                                              "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
+
+        def _test_with_nulls(_conn):
+            query = "MATCH (a:person:organisation) RETURN label(a), a.fName, a.orgCode ORDER BY a.ID"
+            query_result = _conn.execute(query)
+            arrow_tbl = query_result.get_as_arrow(12)
+            assert arrow_tbl.num_columns == 3
+            label_col = arrow_tbl.column(0)
+            assert label_col.type == pa.string()
+            assert label_col.length() == 11
+            assert label_col.to_pylist() == ["person", "organisation", "person", "person", "organisation", "person",
+                                             "organisation", "person", "person", "person", "person"]
+
+            f_name_col = arrow_tbl.column(1)
+            assert f_name_col.type == pa.string()
+            assert f_name_col.length() == 11
+            assert f_name_col.to_pylist() == ["Alice", None, "Bob", "Carol", None, "Dan", None, "Elizabeth", "Farooq",
+                                              "Greg", "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
+
+            org_code_col = arrow_tbl.column(2)
+            assert org_code_col.type == pa.int64()
+            assert org_code_col.length() == 11
+            assert org_code_col.to_pylist() == [None, 325, None, None, 934, None, 824, None, None, None, None]
+
+        _test_person_table(conn)
+        _test_movies_table(conn)
+        _test_utf8_string(conn)
+        _test_in_small_chunk_size(conn)
+        _test_with_nulls(conn)
+
+    def _test_marries_table(_conn):
+        query = "MATCH (:person)-[e:marries]->(:person) RETURN e.*"
+        arrow_tbl = _conn.execute(query).get_as_arrow(8)
         assert arrow_tbl.num_columns == 3
-        label_col = arrow_tbl.column(0)
-        assert label_col.type == pa.string()
-        assert label_col.length() == 11
-        assert label_col.to_pylist() == ["person", "organisation", "person", "person", "organisation", "person",
-                                         "organisation", "person", "person", "person", "person"]
 
-        f_name_col = arrow_tbl.column(1)
-        assert f_name_col.type == pa.string()
-        assert f_name_col.length() == 11
-        assert f_name_col.to_pylist() == ["Alice", None, "Bob", "Carol", None, "Dan", None, "Elizabeth", "Farooq",
-                                          "Greg", "Hubert Blaine Wolfeschlegelsteinhausenbergerdorff"]
+        used_addr_col = arrow_tbl.column(0)
+        assert used_addr_col.type == pa.list_(pa.string())
+        assert used_addr_col.length() == 3
+        assert used_addr_col.to_pylist() == [['toronto'], None, None]
 
-        org_code_col = arrow_tbl.column(2)
-        assert org_code_col.type == pa.int64()
-        assert org_code_col.length() == 11
-        assert org_code_col.to_pylist() == [None, 325, None, None, 934, None, 824, None, None, None, None]
+        addr_col = arrow_tbl.column(1)
+        assert used_addr_col.type == pa.list_(pa.int16(), 2)
+        assert used_addr_col.length() == 3
+        assert used_addr_col.to_pylist() == [[4, 5], [2, 5], [3, 9]]
 
-    _test_primitive_data_types(conn)
-    _test_utf8_string(conn)
-    _test_in_small_chunk_size(conn)
-    _test_with_nulls(conn)
+        note_col = arrow_tbl.column(2)
+        assert used_addr_col.type == pa.string()
+        assert used_addr_col.length() == 3
+        assert used_addr_col.to_pylist() == [None, "long long long string", "short str"]
 
+    def test_to_arrow_complex(establish_connection):
+        conn, db = establish_connection
 
-# TODO: enable this test once we support fixed_size_list
-# def test_to_arrow_complex(establish_connection):
-#     conn, db = establish_connection
-#
-#     def _test_node(_conn):
-#         query = "MATCH (p:person) RETURN p ORDER BY p.ID"
-#         query_result = _conn.execute(query)
-#         arrow_tbl = query_result.get_as_arrow(12)
-#         p_col = arrow_tbl.column(0)
-#
-#         assert p_col.to_pylist() == [ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[0],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[2],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[3],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[5],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[7],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[8],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[9],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[10]]
-#
-#     def _test_node_rel(_conn):
-#         query = "MATCH (a:person)-[e:workAt]->(b:organisation) RETURN a, e, b;"
-#         query_result = _conn.execute(query)
-#         arrow_tbl = query_result.get_as_arrow(12)
-#         assert arrow_tbl.num_columns == 3
-#         a_col = arrow_tbl.column(0)
-#         assert a_col.length() == 3
-#         e_col = arrow_tbl.column(1)
-#         assert a_col.length() == 3
-#         b_col = arrow_tbl.column(2)
-#         assert a_col.length() == 3
-#         assert a_col.to_pylist() == [ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[3],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[5],
-#                                      ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[7]]
-#         assert e_col.to_pylist() == [
-#             {'_src': {'offset': 2, 'tableID': 0}, '_dst': {'offset': 1, 'tableID': 2},
-#              '_id': {'offset': 0, 'tableID': 4}, 'year': 2015},
-#             {'_src': {'offset': 3, 'tableID': 0}, '_dst': {'offset': 2, 'tableID': 2},
-#              '_id': {'offset': 1, 'tableID': 4}, 'year': 2010},
-#             {'_src': {'offset': 4, 'tableID': 0}, '_dst': {'offset': 2, 'tableID': 2},
-#              '_id': {'offset': 2, 'tableID': 4}, 'year': 2015}]
-#         assert b_col.to_pylist() == [ground_truth.TINY_SNB_ORGANISATIONS_GROUND_TRUTH[4],
-#                                      ground_truth.TINY_SNB_ORGANISATIONS_GROUND_TRUTH[6],
-#                                      ground_truth.TINY_SNB_ORGANISATIONS_GROUND_TRUTH[6]]
-#
-#     _test_node(conn)
-#     _test_node_rel(conn)
+        def _test_node(_conn):
+            query = "MATCH (p:person) RETURN p ORDER BY p.ID"
+            query_result = _conn.execute(query)
+            arrow_tbl = query_result.get_as_arrow(12)
+            p_col = arrow_tbl.column(0)
+
+            assert p_col.to_pylist() == [ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[0],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[2],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[3],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[5],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[7],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[8],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[9],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[10]]
+
+        def _test_node_rel(_conn):
+            query = "MATCH (a:person)-[e:workAt]->(b:organisation) RETURN a, e, b;"
+            query_result = _conn.execute(query)
+            arrow_tbl = query_result.get_as_arrow(12)
+            assert arrow_tbl.num_columns == 3
+            a_col = arrow_tbl.column(0)
+            assert a_col.length() == 3
+            e_col = arrow_tbl.column(1)
+            assert a_col.length() == 3
+            b_col = arrow_tbl.column(2)
+            assert a_col.length() == 3
+            assert a_col.to_pylist() == [ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[3],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[5],
+                                         ground_truth.TINY_SNB_PERSONS_GROUND_TRUTH[7]]
+            assert e_col.to_pylist() == [
+                {'_src': {'offset': 2, 'tableID': 0}, '_dst': {'offset': 1, 'tableID': 2},
+                 '_id': {'offset': 0, 'tableID': 4}, 'year': 2015},
+                {'_src': {'offset': 3, 'tableID': 0}, '_dst': {'offset': 2, 'tableID': 2},
+                 '_id': {'offset': 1, 'tableID': 4}, 'year': 2010},
+                {'_src': {'offset': 4, 'tableID': 0}, '_dst': {'offset': 2, 'tableID': 2},
+                 '_id': {'offset': 2, 'tableID': 4}, 'year': 2015}]
+            assert b_col.to_pylist() == [ground_truth.TINY_SNB_ORGANISATIONS_GROUND_TRUTH[4],
+                                         ground_truth.TINY_SNB_ORGANISATIONS_GROUND_TRUTH[6],
+                                         ground_truth.TINY_SNB_ORGANISATIONS_GROUND_TRUTH[6]]
+
+        _test_node(conn)
+        _test_node_rel(conn)
+        _test_marries_table(conn)
+
+    def test_to_arrow1(establish_connection):
+        conn, db = establish_connection
+        query = "MATCH (a:person)-[e:knows]->(:person) RETURN e.summary"
+        arrow_tbl = conn.execute(query).get_as_arrow(8)
+        assert arrow_tbl == []

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -56,7 +56,7 @@ const LogicalType& logical_type_get_fixed_list_child_type(const LogicalType& log
     return *kuzu::common::FixedListType::getChildType(&logicalType);
 }
 uint64_t logical_type_get_fixed_list_num_elements(const LogicalType& logicalType) {
-    return kuzu::common::FixedListType::getNumElementsInList(&logicalType);
+    return kuzu::common::FixedListType::getNumValuesInList(&logicalType);
 }
 
 rust::Vec<rust::String> logical_type_get_struct_field_names(


### PR DESCRIPTION
This PR adds the following types to arrow export:
INT128, INT8, UINT64, UINT32, UINT16, UINT8, FIXED_LIST, STRUCT