### PR TITLE
Use cmake project version number in code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,5 @@
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
+add_compile_definitions(KUZU_CMAKE_VERSION=v${CMAKE_PROJECT_VERSION})
 # Avoid the import annotation when building on windows
 # Really this should be set per target,
 # but the targets are split among many files and only the object files are linked against here

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#define TO_STRING(ARG) #ARG
+
 #include <cstdint>
 
 namespace kuzu {
 namespace common {
 
-constexpr char KUZU_VERSION[] = "v0.0.12.1";
+constexpr char KUZU_VERSION[] = TO_STRING(KUZU_CMAKE_VERSION);
 
 constexpr uint64_t DEFAULT_VECTOR_CAPACITY_LOG_2 = 11;
 constexpr uint64_t DEFAULT_VECTOR_CAPACITY = (uint64_t)1 << DEFAULT_VECTOR_CAPACITY_LOG_2;

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -125,7 +125,7 @@ private:
     // Example: ${KUZU_ROOT_DIRECTORY} will be replaced by
     // KUZU_ROOT_DIRECTORY
     std::unordered_map<std::string, std::string> variableMap = {
-        {"KUZU_ROOT_DIRECTORY", KUZU_ROOT_DIRECTORY}};
+        {"KUZU_ROOT_DIRECTORY", KUZU_ROOT_DIRECTORY}, {"KUZU_VERSION", common::KUZU_VERSION}};
 };
 
 } // namespace testing

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -144,7 +144,7 @@ height
 -LOG ReturnDBVersion
 -STATEMENT CALL db_version() RETURN version
 ---- 1
-v0.0.12.1
+${KUZU_VERSION}
 
 -LOG ReturnTableConnection
 -STATEMENT CALL show_connection('knows') RETURN *


### PR DESCRIPTION
To reduce the number of places we need to update the version number, I've set up cmake to pass it as a compiler definition so it can be re-used in the C++ code.