### PR TITLE
prepared_statement: move parameters

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -359,7 +359,6 @@ jobs:
         run: |
           ulimit -n 10240
           source /Users/runner/.cargo/env
-          cargo update -p cc --precise '1.0.83'
           make rusttest
 
       - name: Rust example

--- a/Makefile
+++ b/Makefile
@@ -128,11 +128,11 @@ nodejstest: nodejs
 javatest: java
 ifeq ($(OS),Windows_NT)
 	$(call mkdirp,tools/java_api/build/test)  && cd tools/java_api/ && \
-	javac -d build/test -cp ".;build/kuzu_java.jar;third_party/junit-platform-console-standalone-1.9.3.jar"  -sourcepath src/test/java/com/kuzudb/test/*.java && \
+	javac -d build/test -cp ".;build/kuzu_java.jar;third_party/junit-platform-console-standalone-1.9.3.jar" src/test/java/com/kuzudb/test/*.java && \
 	java -jar third_party/junit-platform-console-standalone-1.9.3.jar -cp ".;build/kuzu_java.jar;build/test/" --scan-classpath --include-package=com.kuzudb.java_test --details=verbose
 else
 	$(call mkdirp,tools/java_api/build/test)  && cd tools/java_api/ && \
-	javac -d build/test -cp ".:build/kuzu_java.jar:third_party/junit-platform-console-standalone-1.9.3.jar"  -sourcepath src/test/java/com/kuzudb/test/*.java && \
+	javac -d build/test -cp ".:build/kuzu_java.jar:third_party/junit-platform-console-standalone-1.9.3.jar" src/test/java/com/kuzudb/test/*.java && \
 	java -jar third_party/junit-platform-console-standalone-1.9.3.jar -cp ".:build/kuzu_java.jar:build/test/" --scan-classpath --include-package=com.kuzudb.java_test --details=verbose
 endif
 

--- a/src/c_api/prepared_statement.cpp
+++ b/src/c_api/prepared_statement.cpp
@@ -8,10 +8,10 @@ using namespace kuzu::common;
 using namespace kuzu::main;
 
 void kuzu_prepared_statement_bind_cpp_value(kuzu_prepared_statement* prepared_statement,
-    const char* param_name, const std::shared_ptr<Value>& value) {
-    auto* bound_values = static_cast<std::unordered_map<std::string, std::shared_ptr<Value>>*>(
+    const char* param_name, std::unique_ptr<Value> value) {
+    auto* bound_values = static_cast<std::unordered_map<std::string, std::unique_ptr<Value>>*>(
         prepared_statement->_bound_values);
-    bound_values->insert({param_name, value});
+    bound_values->insert({param_name, std::move(value)});
 }
 
 void kuzu_prepared_statement_destroy(kuzu_prepared_statement* prepared_statement) {
@@ -22,7 +22,7 @@ void kuzu_prepared_statement_destroy(kuzu_prepared_statement* prepared_statement
         delete static_cast<PreparedStatement*>(prepared_statement->_prepared_statement);
     }
     if (prepared_statement->_bound_values != nullptr) {
-        delete static_cast<std::unordered_map<std::string, std::shared_ptr<Value>>*>(
+        delete static_cast<std::unordered_map<std::string, std::unique_ptr<Value>>*>(
             prepared_statement->_bound_values);
     }
     delete prepared_statement;
@@ -48,97 +48,97 @@ char* kuzu_prepared_statement_get_error_message(kuzu_prepared_statement* prepare
 
 void kuzu_prepared_statement_bind_bool(
     kuzu_prepared_statement* prepared_statement, const char* param_name, bool value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_int64(
     kuzu_prepared_statement* prepared_statement, const char* param_name, int64_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_int32(
     kuzu_prepared_statement* prepared_statement, const char* param_name, int32_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_int16(
     kuzu_prepared_statement* prepared_statement, const char* param_name, int16_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_int8(
     kuzu_prepared_statement* prepared_statement, const char* param_name, int8_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_uint64(
     kuzu_prepared_statement* prepared_statement, const char* param_name, uint64_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_uint32(
     kuzu_prepared_statement* prepared_statement, const char* param_name, uint32_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_uint16(
     kuzu_prepared_statement* prepared_statement, const char* param_name, uint16_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_uint8(
     kuzu_prepared_statement* prepared_statement, const char* param_name, uint8_t value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_double(
     kuzu_prepared_statement* prepared_statement, const char* param_name, double value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_float(
     kuzu_prepared_statement* prepared_statement, const char* param_name, float value) {
-    auto value_ptr = std::make_shared<Value>(value);
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(value);
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_date(
     kuzu_prepared_statement* prepared_statement, const char* param_name, kuzu_date_t value) {
-    auto value_ptr = std::make_shared<Value>(date_t(value.days));
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(date_t(value.days));
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_timestamp(
     kuzu_prepared_statement* prepared_statement, const char* param_name, kuzu_timestamp_t value) {
-    auto value_ptr = std::make_shared<Value>(timestamp_t(value.value));
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(timestamp_t(value.value));
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_interval(
     kuzu_prepared_statement* prepared_statement, const char* param_name, kuzu_interval_t value) {
-    auto value_ptr = std::make_shared<Value>(interval_t(value.months, value.days, value.micros));
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(interval_t(value.months, value.days, value.micros));
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_string(
     kuzu_prepared_statement* prepared_statement, const char* param_name, const char* value) {
     auto value_ptr =
-        std::make_shared<Value>(LogicalType{LogicalTypeID::STRING}, std::string(value));
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+        std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, std::string(value));
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 
 void kuzu_prepared_statement_bind_value(
     kuzu_prepared_statement* prepared_statement, const char* param_name, kuzu_value* value) {
-    auto value_ptr = std::make_shared<Value>(*static_cast<Value*>(value->_value));
-    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, value_ptr);
+    auto value_ptr = std::make_unique<Value>(*static_cast<Value*>(value->_value));
+    kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }

--- a/src/include/common/enums/statement_type.h
+++ b/src/include/common/enums/statement_type.h
@@ -27,9 +27,9 @@ struct StatementTypeUtils {
         case StatementType::ALTER:
         case StatementType::CREATE_MACRO:
         case StatementType::COPY_FROM:
-            return true;
-        default:
             return false;
+        default:
+            return true;
         }
     }
 };

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -156,6 +156,14 @@ public:
      * @return a Value with the same value as other.
      */
     KUZU_API Value(const Value& other);
+
+    /**
+     * @param other the value to move from.
+     * @return a Value with the same value as other.
+     */
+    KUZU_API Value(Value&& other) = default;
+    KUZU_API Value& operator=(Value&& other) = default;
+
     /**
      * @brief Sets the data type of the Value.
      * @param dataType_ the data type to set to.

--- a/src/main/prepared_statement.cpp
+++ b/src/main/prepared_statement.cpp
@@ -10,7 +10,7 @@ namespace kuzu {
 namespace main {
 
 bool PreparedStatement::allowActiveTransaction() const {
-    return !StatementTypeUtils::allowActiveTransaction(preparedSummary.statementType);
+    return StatementTypeUtils::allowActiveTransaction(preparedSummary.statementType);
 }
 
 bool PreparedStatement::isTransactionStatement() const {

--- a/test/c_api/connection_test.cpp
+++ b/test/c_api/connection_test.cpp
@@ -82,7 +82,7 @@ TEST_F(CApiConnectionTest, Execute) {
     auto connection = getConnection();
     auto query = "MATCH (a:person) WHERE a.isStudent = $1 RETURN COUNT(*)";
     auto statement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_bool(statement, (char*)"1", true);
+    kuzu_prepared_statement_bind_bool(statement, "1", true);
     auto result = kuzu_connection_execute(connection, statement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);

--- a/test/c_api/prepared_statement_test.cpp
+++ b/test/c_api/prepared_statement_test.cpp
@@ -71,7 +71,7 @@ TEST_F(CApiPreparedStatementTest, BindBool) {
     auto connection = getConnection();
     auto query = "MATCH (a:person) WHERE a.isStudent = $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_bool(preparedStatement, (char*)"1", true);
+    kuzu_prepared_statement_bind_bool(preparedStatement, "1", true);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -91,7 +91,7 @@ TEST_F(CApiPreparedStatementTest, BindInt64) {
     auto connection = getConnection();
     auto query = "MATCH (a:person) WHERE a.age > $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_int64(preparedStatement, (char*)"1", 30);
+    kuzu_prepared_statement_bind_int64(preparedStatement, "1", 30);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -111,7 +111,7 @@ TEST_F(CApiPreparedStatementTest, BindInt32) {
     auto connection = getConnection();
     auto query = "MATCH (a:movies) WHERE a.length > $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_int32(preparedStatement, (char*)"1", 200);
+    kuzu_prepared_statement_bind_int32(preparedStatement, "1", 200);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -132,7 +132,7 @@ TEST_F(CApiPreparedStatementTest, BindInt16) {
     auto query =
         "MATCH (a:person) -[s:studyAt]-> (b:organisation) WHERE s.length > $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_int16(preparedStatement, (char*)"1", 10);
+    kuzu_prepared_statement_bind_int16(preparedStatement, "1", 10);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -153,7 +153,7 @@ TEST_F(CApiPreparedStatementTest, BindInt8) {
     auto query =
         "MATCH (a:person) -[s:studyAt]-> (b:organisation) WHERE s.level > $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_int8(preparedStatement, (char*)"1", 3);
+    kuzu_prepared_statement_bind_int8(preparedStatement, "1", 3);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -174,7 +174,7 @@ TEST_F(CApiPreparedStatementTest, BindUInt64) {
     auto query =
         "MATCH (a:person) -[s:studyAt]-> (b:organisation) WHERE s.code > $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_uint64(preparedStatement, (char*)"1", 100);
+    kuzu_prepared_statement_bind_uint64(preparedStatement, "1", 100);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -195,7 +195,7 @@ TEST_F(CApiPreparedStatementTest, BindUInt32) {
     auto query =
         "MATCH (a:person) -[s:studyAt]-> (b:organisation) WHERE s.temprature> $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_uint32(preparedStatement, (char*)"1", 10);
+    kuzu_prepared_statement_bind_uint32(preparedStatement, "1", 10);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -216,7 +216,7 @@ TEST_F(CApiPreparedStatementTest, BindUInt16) {
     auto query =
         "MATCH (a:person) -[s:studyAt]-> (b:organisation) WHERE s.ulength> $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_uint16(preparedStatement, (char*)"1", 100);
+    kuzu_prepared_statement_bind_uint16(preparedStatement, "1", 100);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -237,7 +237,7 @@ TEST_F(CApiPreparedStatementTest, BindUInt8) {
     auto query =
         "MATCH (a:person) -[s:studyAt]-> (b:organisation) WHERE s.ulevel> $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_uint8(preparedStatement, (char*)"1", 14);
+    kuzu_prepared_statement_bind_uint8(preparedStatement, "1", 14);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -257,7 +257,7 @@ TEST_F(CApiPreparedStatementTest, BindDouble) {
     auto connection = getConnection();
     auto query = "MATCH (a:person) WHERE a.eyeSight > $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_double(preparedStatement, (char*)"1", 4.5);
+    kuzu_prepared_statement_bind_double(preparedStatement, "1", 4.5);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -277,7 +277,7 @@ TEST_F(CApiPreparedStatementTest, BindFloat) {
     auto connection = getConnection();
     auto query = "MATCH (a:person) WHERE a.height < $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
-    kuzu_prepared_statement_bind_float(preparedStatement, (char*)"1", 1.0);
+    kuzu_prepared_statement_bind_float(preparedStatement, "1", 1.0);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -298,7 +298,7 @@ TEST_F(CApiPreparedStatementTest, BindString) {
     auto query = "MATCH (a:person) WHERE a.fName = $1 RETURN COUNT(*)";
     auto preparedStatement = kuzu_connection_prepare(connection, query);
     ASSERT_TRUE(kuzu_prepared_statement_is_success(preparedStatement));
-    kuzu_prepared_statement_bind_string(preparedStatement, (char*)"1", (char*)"Alice");
+    kuzu_prepared_statement_bind_string(preparedStatement, "1", "Alice");
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -320,7 +320,7 @@ TEST_F(CApiPreparedStatementTest, BindDate) {
     auto preparedStatement = kuzu_connection_prepare(connection, query);
     ASSERT_TRUE(kuzu_prepared_statement_is_success(preparedStatement));
     auto date = kuzu_date_t{0};
-    kuzu_prepared_statement_bind_date(preparedStatement, (char*)"1", date);
+    kuzu_prepared_statement_bind_date(preparedStatement, "1", date);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -342,7 +342,7 @@ TEST_F(CApiPreparedStatementTest, BindTimestamp) {
     auto preparedStatement = kuzu_connection_prepare(connection, query);
     ASSERT_TRUE(kuzu_prepared_statement_is_success(preparedStatement));
     auto timestamp = kuzu_timestamp_t{0};
-    kuzu_prepared_statement_bind_timestamp(preparedStatement, (char*)"1", timestamp);
+    kuzu_prepared_statement_bind_timestamp(preparedStatement, "1", timestamp);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -364,7 +364,7 @@ TEST_F(CApiPreparedStatementTest, BindInteval) {
     auto preparedStatement = kuzu_connection_prepare(connection, query);
     ASSERT_TRUE(kuzu_prepared_statement_is_success(preparedStatement));
     auto interval = kuzu_interval_t{0, 0, 0};
-    kuzu_prepared_statement_bind_interval(preparedStatement, (char*)"1", interval);
+    kuzu_prepared_statement_bind_interval(preparedStatement, "1", interval);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);
     ASSERT_NE(result->_query_result, nullptr);
@@ -387,7 +387,7 @@ TEST_F(CApiPreparedStatementTest, BindValue) {
     ASSERT_TRUE(kuzu_prepared_statement_is_success(preparedStatement));
     auto timestamp = kuzu_timestamp_t{0};
     auto timestampValue = kuzu_value_create_timestamp(timestamp);
-    kuzu_prepared_statement_bind_value(preparedStatement, (char*)"1", timestampValue);
+    kuzu_prepared_statement_bind_value(preparedStatement, "1", timestampValue);
     kuzu_value_destroy(timestampValue);
     auto result = kuzu_connection_execute(connection, preparedStatement);
     ASSERT_NE(result, nullptr);

--- a/tools/java_api/src/main/java/com/kuzudb/KuzuConnection.java
+++ b/tools/java_api/src/main/java/com/kuzudb/KuzuConnection.java
@@ -16,7 +16,8 @@ public class KuzuConnection {
     * @param db: KuzuDatabase instance.
     */
     public KuzuConnection(KuzuDatabase db) {
-        assert db != null : "Cannot create connection, database is null.";
+        if (db == null)
+            throw new AssertionError("Cannot create connection, database is null.");
         conn_ref = KuzuNative.kuzu_connection_init(db);
     }
 

--- a/tools/java_api/src/test/java/com/kuzudb/test/ConnectionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/ConnectionTest.java
@@ -256,8 +256,10 @@ public class ConnectionTest extends TestBase {
     void ConnPrepareMultiParam() throws KuzuObjectRefDestroyedException {
         String query = "MATCH (a:person) WHERE a.lastJobDuration > $1 AND a.fName = $2 RETURN COUNT(*)";
         Map<String, KuzuValue> m = new HashMap<String, KuzuValue>();
-        m.put("1", new KuzuValue(Duration.ofDays(730)));
-        m.put("2", new KuzuValue("Alice"));
+        KuzuValue v1 = new KuzuValue(Duration.ofDays(730));
+        KuzuValue v2 = new KuzuValue("Alice");
+        m.put("1", v1);
+        m.put("2", v2);
         KuzuPreparedStatement statement = conn.prepare(query);
         assertNotNull(statement);
         KuzuQueryResult result = conn.execute(statement, m);
@@ -270,6 +272,11 @@ public class ConnectionTest extends TestBase {
         assertEquals(((long) tuple.getValue(0).getValue()), 1);
         statement.destroy();
         result.destroy();
+
+        // Not strictly necessary, but this makes sure if we freed v1 or v2 in
+        // the execute() call, we segfault here.
+        v1.destroy();
+        v2.destroy();
     }
 
     @Test

--- a/tools/nodejs_api/src_cpp/include/node_util.h
+++ b/tools/nodejs_api/src_cpp/include/node_util.h
@@ -1,10 +1,6 @@
 #pragma once
 
-#include <chrono>
-#include <ctime>
-#include <iostream>
-
-#include "main/kuzu.h"
+#include "common/types/value/value.h"
 #include <napi.h>
 
 using namespace kuzu::common;
@@ -12,8 +8,9 @@ using namespace kuzu::common;
 class Util {
 public:
     static Napi::Value ConvertToNapiObject(const Value& value, Napi::Env env);
-    static std::unordered_map<std::string, std::shared_ptr<Value>> TransformParametersForExec(
-        Napi::Array params, std::unordered_map<std::string, std::shared_ptr<Value>>& parameterMap);
+    static std::unordered_map<std::string, std::unique_ptr<Value>> TransformParametersForExec(
+        Napi::Array params,
+        const std::unordered_map<std::string, std::shared_ptr<Value>>& parameterMap);
 
 private:
     static Napi::Object ConvertNodeIdToNapiObject(const nodeID_t& nodeId, Napi::Env env);

--- a/tools/nodejs_api/src_cpp/node_connection.cpp
+++ b/tools/nodejs_api/src_cpp/node_connection.cpp
@@ -75,10 +75,10 @@ Napi::Value NodeConnection::ExecuteAsync(const Napi::CallbackInfo& info) {
     auto nodeQueryResult = Napi::ObjectWrap<NodeQueryResult>::Unwrap(info[1].As<Napi::Object>());
     auto callback = info[3].As<Napi::Function>();
     try {
-        auto parameterMap = nodePreparedStatement->preparedStatement->getParameterMap();
+        const auto& parameterMap = nodePreparedStatement->preparedStatement->getParameterMap();
         auto params = Util::TransformParametersForExec(info[2].As<Napi::Array>(), parameterMap);
         auto asyncWorker = new ConnectionExecuteAsyncWorker(callback, connection,
-            nodePreparedStatement->preparedStatement, nodeQueryResult, params);
+            nodePreparedStatement->preparedStatement, nodeQueryResult, std::move(params));
         asyncWorker->Queue();
     } catch (const std::exception& exc) {
         Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();

--- a/tools/python_api/src_cpp/include/py_connection.h
+++ b/tools/python_api/src_cpp/include/py_connection.h
@@ -33,12 +33,6 @@ public:
     static bool isPandasDataframe(const py::object& object);
 
 private:
-    std::unordered_map<std::string, std::shared_ptr<kuzu::common::Value>> transformPythonParameters(
-        py::dict params);
-
-    kuzu::common::Value transformPythonValue(py::handle val);
-
-private:
     std::unique_ptr<StorageDriver> storageDriver;
     std::unique_ptr<Connection> conn;
 };

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -27,7 +27,7 @@ struct TypeListBuilder {
 std::unique_ptr<TypeListBuilder> create_type_list();
 
 struct QueryParams {
-    std::unordered_map<std::string, std::shared_ptr<kuzu::common::Value>> inputParams;
+    std::unordered_map<std::string, std::unique_ptr<kuzu::common::Value>> inputParams;
 
     void insert(const rust::Str key, std::unique_ptr<kuzu::common::Value> value) {
         inputParams.insert(std::make_pair(key, std::move(value)));

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -101,7 +101,7 @@ std::unique_ptr<kuzu::main::Connection> database_connect(kuzu::main::Database& d
 
 std::unique_ptr<kuzu::main::QueryResult> connection_execute(kuzu::main::Connection& connection,
     kuzu::main::PreparedStatement& query, std::unique_ptr<QueryParams> params) {
-    return connection.executeWithParams(&query, params->inputParams);
+    return connection.executeWithParams(&query, std::move(params->inputParams));
 }
 
 rust::String prepared_statement_error_message(const kuzu::main::PreparedStatement& statement) {


### PR DESCRIPTION
In the Java API, we had a bug where we take ownership of and free parameters passed into executeWithParams.

Inspecting the method itself, it was taking a shared_ptr, but then performing a deep copy, which is nonsense. Instead, we should take a unique_ptr, since we need to copy the parameters to guarantee that they are not modified for the duration of the query.

This commit also fixes three other issues. First, the Java tests weren't running any tests from ConnectionTest.java, which is why we didn't observe this bug. Additionally, the constructor of KuzuConnection uses an assertion, but assertions are disabled by default, which causes our tests to fail (and if the assertion is skipped, we segfault).

Also, since https://github.com/rust-lang/cc-rs/issues/900 has been fixed, we can remove the version pinning of `cc` on MacOS.