### PR TITLE
Always write a whole page at a time when writing compressed data

### DIFF
--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -67,7 +67,8 @@ public:
             }
             KU_ASSERT(numPages < metadata.numPages);
             KU_ASSERT(dataFH->getNumPages() > startPageIdx + numPages);
-            FileUtils::writeToFile(dataFH->getFileInfo(), compressedBuffer.get(), compressedSize,
+            FileUtils::writeToFile(dataFH->getFileInfo(), compressedBuffer.get(),
+                BufferPoolConstants::PAGE_4KB_SIZE,
                 (startPageIdx + numPages) * BufferPoolConstants::PAGE_4KB_SIZE);
             numPages++;
         }


### PR DESCRIPTION
A fix from #2408 which ended up breaking windows CI in #2304.

If data is compressed to 0 bytes, it would end up writing nothing, and if the data is at the end of the file the next time the file is opened it will read the number of pages as one less, triggering exceptions when attempting to read the last page.

Ideally we shouldn't be reading at all when data is compressed to nothing, but that can be addressed later.