### PR TITLE
Correcting the set of numValues for column chunk in CopyRel and fix writing null struct entry

### DIFF
--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -29,6 +29,7 @@ public:
     }
     void write(common::offset_t nodeOffset, common::ValueVector* vectorToWriteFrom,
         uint32_t posInVectorToWriteFrom) override;
+    void setNull(common::offset_t nodeOffset) override;
 
     void prepareCommitForChunk(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localColumnChunk,

--- a/src/processor/operator/persistent/copy_node.cpp
+++ b/src/processor/operator/persistent/copy_node.cpp
@@ -42,7 +42,7 @@ void CopyNodeSharedState::appendLocalNodeGroup(std::unique_ptr<NodeGroup> localN
         CopyNode::writeAndResetNodeGroup(
             nodeGroupIdx, pkIndex.get(), pkColumnIdx, table, sharedNodeGroup.get());
     }
-    if (numNodesAppended < localNodeGroup->getNumNodes()) {
+    if (numNodesAppended < localNodeGroup->getNumRows()) {
         sharedNodeGroup->append(localNodeGroup.get(), numNodesAppended);
     }
 }
@@ -92,7 +92,7 @@ void CopyNode::executeInternal(ExecutionContext* context) {
         copyToNodeGroup();
         columnState->selVector = std::move(originalSelVector);
     }
-    if (localNodeGroup->getNumNodes() > 0) {
+    if (localNodeGroup->getNumRows() > 0) {
         sharedState->appendLocalNodeGroup(std::move(localNodeGroup));
     }
 }
@@ -104,7 +104,7 @@ void CopyNode::writeAndResetNodeGroup(node_group_idx_t nodeGroupIdx,
     auto startOffset = StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx);
     if (pkIndex) {
         populatePKIndex(pkIndex, nodeGroup->getColumnChunk(pkColumnID), startOffset,
-            nodeGroup->getNumNodes() /* startPageIdx */);
+            nodeGroup->getNumRows() /* startPageIdx */);
     }
     table->append(nodeGroup);
     nodeGroup->resetToEmpty();
@@ -158,7 +158,7 @@ void CopyNode::checkNonNullConstraint(NullColumnChunk* nullChunk, offset_t numNo
 void CopyNode::finalize(ExecutionContext* context) {
     uint64_t numNodes = StorageUtils::getStartOffsetOfNodeGroup(sharedState->getCurNodeGroupIdx());
     if (sharedState->sharedNodeGroup) {
-        numNodes += sharedState->sharedNodeGroup->getNumNodes();
+        numNodes += sharedState->sharedNodeGroup->getNumRows();
         auto nodeGroupIdx = sharedState->getNextNodeGroupIdx();
         writeAndResetNodeGroup(nodeGroupIdx, sharedState->pkIndex.get(), sharedState->pkColumnIdx,
             sharedState->table, sharedState->sharedNodeGroup.get());

--- a/src/processor/operator/persistent/copy_rdf_resource.cpp
+++ b/src/processor/operator/persistent/copy_rdf_resource.cpp
@@ -47,7 +47,7 @@ void CopyRdfResource::executeInternal(ExecutionContext* context) {
         copyToNodeGroup(vector);
         columnState->selVector = std::move(originalSelVector);
     }
-    if (localNodeGroup->getNumNodes() > 0) {
+    if (localNodeGroup->getNumRows() > 0) {
         sharedState->appendLocalNodeGroup(std::move(localNodeGroup));
     }
 }
@@ -55,7 +55,7 @@ void CopyRdfResource::executeInternal(ExecutionContext* context) {
 void CopyRdfResource::finalize(ExecutionContext* context) {
     uint64_t numNodes = StorageUtils::getStartOffsetOfNodeGroup(sharedState->getCurNodeGroupIdx());
     if (sharedState->sharedNodeGroup) {
-        numNodes += sharedState->sharedNodeGroup->getNumNodes();
+        numNodes += sharedState->sharedNodeGroup->getNumRows();
         auto nodeGroupIdx = sharedState->getNextNodeGroupIdx();
         writeNodeGroup(nodeGroupIdx, sharedState->table, sharedState->sharedNodeGroup.get());
     }
@@ -76,7 +76,7 @@ void CopyRdfResource::insertIndex(ValueVector* vector) {
     common::sel_t nextPos = 0;
     common::offset_t result;
     auto offset = StorageUtils::getStartOffsetOfNodeGroup(sharedState->getCurNodeGroupIdx()) +
-                  localNodeGroup->getNumNodes();
+                  localNodeGroup->getNumRows();
     for (auto i = 0u; i < vector->state->getNumSelectedValues(); i++) {
         auto uriStr = vector->getValue<common::ku_string_t>(i).getAsString();
         if (!sharedState->pkIndex->lookup(uriStr.c_str(), result)) {

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -11,7 +11,7 @@ namespace storage {
 
 NodeGroup::NodeGroup(const std::vector<std::unique_ptr<common::LogicalType>>& columnTypes,
     bool enableCompression, uint64_t capacity)
-    : nodeGroupIdx{UINT64_MAX}, numNodes{0} {
+    : nodeGroupIdx{UINT64_MAX}, numRows{0} {
     chunks.reserve(columnTypes.size());
     for (auto& type : columnTypes) {
         chunks.push_back(
@@ -20,7 +20,7 @@ NodeGroup::NodeGroup(const std::vector<std::unique_ptr<common::LogicalType>>& co
 }
 
 NodeGroup::NodeGroup(const std::vector<std::unique_ptr<Column>>& columns, bool enableCompression)
-    : nodeGroupIdx{UINT64_MAX}, numNodes{0} {
+    : nodeGroupIdx{UINT64_MAX}, numRows{0} {
     chunks.reserve(columns.size());
     for (auto columnID = 0u; columnID < columns.size(); columnID++) {
         chunks.push_back(ColumnChunkFactory::createColumnChunk(
@@ -29,16 +29,23 @@ NodeGroup::NodeGroup(const std::vector<std::unique_ptr<Column>>& columns, bool e
 }
 
 void NodeGroup::resetToEmpty() {
-    numNodes = 0;
+    numRows = 0;
     nodeGroupIdx = UINT64_MAX;
     for (auto& chunk : chunks) {
         chunk->resetToEmpty();
     }
 }
 
-void NodeGroup::setChunkToAllNull(common::vector_idx_t chunkIdx) {
-    KU_ASSERT(chunkIdx < chunks.size());
-    chunks[chunkIdx]->getNullChunk()->resetToAllNull();
+void NodeGroup::setAllNull() {
+    for (auto& chunk : chunks) {
+        chunk->getNullChunk()->resetToAllNull();
+    }
+}
+
+void NodeGroup::setNumValues(common::offset_t numValues) {
+    for (auto& chunk : chunks) {
+        chunk->setNumValues(numValues);
+    }
 }
 
 void NodeGroup::resizeChunks(uint64_t newSize) {
@@ -50,7 +57,7 @@ void NodeGroup::resizeChunks(uint64_t newSize) {
 uint64_t NodeGroup::append(const std::vector<ValueVector*>& columnVectors,
     DataChunkState* columnState, uint64_t numValuesToAppend) {
     auto numValuesToAppendInChunk =
-        std::min(numValuesToAppend, StorageConstants::NODE_GROUP_SIZE - numNodes);
+        std::min(numValuesToAppend, StorageConstants::NODE_GROUP_SIZE - numRows);
     auto serialSkip = 0u;
     auto originalSize = columnState->selVector->selectedSize;
     columnState->selVector->selectedSize = numValuesToAppendInChunk;
@@ -64,18 +71,18 @@ uint64_t NodeGroup::append(const std::vector<ValueVector*>& columnVectors,
         chunk->append(columnVectors[i - serialSkip]);
     }
     columnState->selVector->selectedSize = originalSize;
-    numNodes += numValuesToAppendInChunk;
+    numRows += numValuesToAppendInChunk;
     return numValuesToAppendInChunk;
 }
 
 offset_t NodeGroup::append(NodeGroup* other, offset_t offsetInOtherNodeGroup) {
     KU_ASSERT(other->chunks.size() == chunks.size());
     auto numNodesToAppend = std::min(
-        other->numNodes - offsetInOtherNodeGroup, StorageConstants::NODE_GROUP_SIZE - numNodes);
+        other->numRows - offsetInOtherNodeGroup, StorageConstants::NODE_GROUP_SIZE - numRows);
     for (auto i = 0u; i < chunks.size(); i++) {
         chunks[i]->append(other->chunks[i].get(), offsetInOtherNodeGroup, numNodesToAppend);
     }
-    numNodes += numNodesToAppend;
+    numRows += numNodesToAppend;
     return numNodesToAppend;
 }
 
@@ -91,7 +98,7 @@ void NodeGroup::write(DataChunk* dataChunk, vector_idx_t offsetVectorIdx) {
         KU_ASSERT(vectorIdx < dataChunk->getNumValueVectors());
         chunks[chunkIdx++]->write(dataChunk->getValueVector(vectorIdx++).get(), offsetVector);
     }
-    numNodes += offsetVector->state->selVector->selectedSize;
+    numRows += offsetVector->state->selVector->selectedSize;
 }
 
 void NodeGroup::finalize(uint64_t nodeGroupIdx_) {
@@ -99,14 +106,6 @@ void NodeGroup::finalize(uint64_t nodeGroupIdx_) {
     for (auto i = 0u; i < chunks.size(); i++) {
         chunks[i]->finalize();
     }
-}
-
-std::unique_ptr<NodeGroup> NodeGroupFactory::createNodeGroup(common::ColumnDataFormat dataFormat,
-    const std::vector<std::unique_ptr<common::LogicalType>>& columnTypes, bool enableCompression,
-    uint64_t capacity) {
-    return dataFormat == ColumnDataFormat::REGULAR ?
-               std::make_unique<NodeGroup>(columnTypes, enableCompression, capacity) :
-               std::make_unique<CSRNodeGroup>(columnTypes, enableCompression);
 }
 
 } // namespace storage

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -73,11 +73,22 @@ void StructColumn::lookupInternal(
 void StructColumn::write(
     offset_t nodeOffset, ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
     KU_ASSERT(vectorToWriteFrom->dataType.getPhysicalType() == PhysicalTypeID::STRUCT);
+    if (vectorToWriteFrom->isNull(posInVectorToWriteFrom)) {
+        setNull(posInVectorToWriteFrom);
+        return;
+    }
     nullColumn->write(nodeOffset, vectorToWriteFrom, posInVectorToWriteFrom);
     KU_ASSERT(childColumns.size() == StructVector::getFieldVectors(vectorToWriteFrom).size());
     for (auto i = 0u; i < childColumns.size(); i++) {
         auto fieldVector = StructVector::getFieldVector(vectorToWriteFrom, i).get();
         childColumns[i]->write(nodeOffset, fieldVector, posInVectorToWriteFrom);
+    }
+}
+
+void StructColumn::setNull(common::offset_t nodeOffset) {
+    nullColumn->setNull(nodeOffset);
+    for (const auto& childColumn : childColumns) {
+        childColumn->setNull(nodeOffset);
     }
 }
 


### PR DESCRIPTION
1. numValues of the csrOffsetColumnChunk / adjColumnChunk should be set according to numNodes from source node table that falls into this node group.
2. when a struct entry is null, writing it would trigger unnecessary out-of-place commits for children fields, due to that the input Vector doesn't guarantee its child vector are all set to null. fix this by skipping writing values of children fields, instead setting them all to null.