### PR TITLE
Rework Column write interface

### DIFF
--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -87,28 +87,14 @@ public:
         common::node_group_idx_t nodeGroupIdx) {
         return nodeGroupIdx << common::StorageConstants::NODE_GROUP_SIZE_LOG2;
     }
-    static inline common::offset_t getStartOffsetOfVectorInChunk(common::vector_idx_t vectorIdx) {
-        return vectorIdx << common::DEFAULT_VECTOR_CAPACITY_LOG_2;
-    }
     static inline common::node_group_idx_t getNodeGroupIdx(common::offset_t nodeOffset) {
         return nodeOffset >> common::StorageConstants::NODE_GROUP_SIZE_LOG2;
     }
-
-    static inline common::vector_idx_t getVectorIdx(common::offset_t offsetInChunk) {
-        return offsetInChunk >> common::DEFAULT_VECTOR_CAPACITY_LOG_2;
-    }
-    static inline common::vector_idx_t getVectorIdxInChunk(
-        common::offset_t nodeOffset, common::node_group_idx_t nodeGroupIdx) {
-        return (nodeOffset - StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx)) >>
-               common::DEFAULT_VECTOR_CAPACITY_LOG_2;
-    }
-    static inline std::pair<common::vector_idx_t, common::offset_t>
-    getVectorIdxInChunkAndOffsetInVector(
-        common::offset_t nodeOffset, common::node_group_idx_t nodeGroupIdx) {
-        auto startOffsetOfNodeGroup = StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx);
-        auto offsetInChunk = nodeOffset - startOffsetOfNodeGroup;
-        auto vectorIdx = getVectorIdx(offsetInChunk);
-        return std::make_pair(vectorIdx, offsetInChunk - getStartOffsetOfVectorInChunk(vectorIdx));
+    static inline std::pair<common::node_group_idx_t, common::offset_t>
+    getNodeGroupIdxAndOffsetInChunk(common::offset_t nodeOffset) {
+        auto nodeGroupIdx = getNodeGroupIdx(nodeOffset);
+        auto offsetInChunk = nodeOffset - getStartOffsetOfNodeGroup(nodeGroupIdx);
+        return std::make_pair(nodeGroupIdx, offsetInChunk);
     }
 
     static std::string getNodeIndexFName(const std::string& directory,

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -16,24 +16,25 @@ public:
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0);
+        common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        ColumnChunk* columnChunk);
+        ColumnChunk* columnChunk) override;
 
-    void append(ColumnChunk* columnChunk, common::node_group_idx_t nodeGroupIdx);
+    void append(ColumnChunk* columnChunk, common::node_group_idx_t nodeGroupIdx) override;
 
-    void writeValue(const ColumnChunkMetadata& chunkMeta, common::offset_t nodeOffset,
-        common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom);
+    void writeValue(const ColumnChunkMetadata& chunkMeta, common::node_group_idx_t nodeGroupIdx,
+        common::offset_t offsetInChunk, common::ValueVector* vectorToWriteFrom,
+        uint32_t posInVectorToWriteFrom) override;
 
     inline Column* getDataColumn() { return dataColumn.get(); }
     inline Column* getOffsetColumn() { return offsetColumn.get(); }
 
-    void checkpointInMemory();
-    void rollbackInMemory();
+    void checkpointInMemory() override;
+    void rollbackInMemory() override;
 
 protected:
     void scanInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector);
+        common::ValueVector* resultVector) override;
     void scanUnfiltered(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::offset_t startOffsetInGroup,
         common::offset_t endOffsetInGroup, common::ValueVector* resultVector,
@@ -43,7 +44,7 @@ protected:
         common::ValueVector* resultVector);
 
     void lookupInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector);
+        common::ValueVector* resultVector) override;
 
     void scanValueToVector(transaction::Transaction* transaction, const ReadState& dataState,
         uint64_t startOffset, uint64_t endOffset, common::ValueVector* resultVector,
@@ -54,7 +55,7 @@ protected:
 private:
     bool canCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
-        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo);
+        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo) override;
 
 private:
     // Main column stores indices of values in the dictionary

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -27,9 +27,9 @@ public:
         KU_ASSERT(childIdx < childColumns.size());
         return childColumns[childIdx].get();
     }
-    void write(common::offset_t nodeOffset, common::ValueVector* vectorToWriteFrom,
-        uint32_t posInVectorToWriteFrom) override;
-    void setNull(common::offset_t nodeOffset) override;
+    void write(common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk,
+        common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
+    void setNull(common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk) override;
 
     void prepareCommitForChunk(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localColumnChunk,

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -89,20 +89,17 @@ void StringColumn::append(ColumnChunk* columnChunk, node_group_idx_t nodeGroupId
     offsetColumn->append(stringColumnChunk->getOffsetChunk(), nodeGroupIdx);
 }
 
-void StringColumn::writeValue(const ColumnChunkMetadata& chunkMeta, offset_t nodeOffset,
-    ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
+void StringColumn::writeValue(const ColumnChunkMetadata& chunkMeta, node_group_idx_t nodeGroupIdx,
+    offset_t offsetInChunk, ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
     auto& kuStr = vectorToWriteFrom->getValue<ku_string_t>(posInVectorToWriteFrom);
     // Write string data to end of dataColumn
-    auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeOffset);
     auto startOffset =
         dataColumn->appendValues(nodeGroupIdx, (const uint8_t*)kuStr.getData(), kuStr.len);
-
     // Write offset
     string_index_t index =
         offsetColumn->appendValues(nodeGroupIdx, (const uint8_t*)&startOffset, 1);
-
     // Write index to main column
-    Column::writeValue(chunkMeta, nodeOffset, (uint8_t*)&index);
+    Column::writeValue(chunkMeta, nodeGroupIdx, offsetInChunk, (uint8_t*)&index);
 }
 
 void StringColumn::checkpointInMemory() {

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -70,25 +70,25 @@ void StructColumn::lookupInternal(
     }
 }
 
-void StructColumn::write(
-    offset_t nodeOffset, ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
+void StructColumn::write(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk,
+    ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
     KU_ASSERT(vectorToWriteFrom->dataType.getPhysicalType() == PhysicalTypeID::STRUCT);
     if (vectorToWriteFrom->isNull(posInVectorToWriteFrom)) {
-        setNull(posInVectorToWriteFrom);
+        setNull(nodeGroupIdx, offsetInChunk);
         return;
     }
-    nullColumn->write(nodeOffset, vectorToWriteFrom, posInVectorToWriteFrom);
+    nullColumn->write(nodeGroupIdx, offsetInChunk, vectorToWriteFrom, posInVectorToWriteFrom);
     KU_ASSERT(childColumns.size() == StructVector::getFieldVectors(vectorToWriteFrom).size());
     for (auto i = 0u; i < childColumns.size(); i++) {
         auto fieldVector = StructVector::getFieldVector(vectorToWriteFrom, i).get();
-        childColumns[i]->write(nodeOffset, fieldVector, posInVectorToWriteFrom);
+        childColumns[i]->write(nodeGroupIdx, offsetInChunk, fieldVector, posInVectorToWriteFrom);
     }
 }
 
-void StructColumn::setNull(common::offset_t nodeOffset) {
-    nullColumn->setNull(nodeOffset);
+void StructColumn::setNull(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk) {
+    nullColumn->setNull(nodeGroupIdx, offsetInChunk);
     for (const auto& childColumn : childColumns) {
-        childColumn->setNull(nodeOffset);
+        childColumn->setNull(nodeGroupIdx, offsetInChunk);
     }
 }
 


### PR DESCRIPTION
Rework the Column write interface to take in both nodeGroupIdx and offsetInChunk, instead of the global nodeOffset.
This is need by rel table writes, which doesn't always calculate nodeGroupIdx in the same way as node table columns.