### PR TITLE
Fix UDF checkpoint logic

### DIFF
--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -100,7 +100,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
         children.push_back(std::move(child));
     }
     auto function =
-        builtInFunctions->matchAggregateFunction(functionName, childrenTypes, isDistinct)->copy();
+        builtInFunctions->matchAggregateFunction(functionName, childrenTypes, isDistinct)->clone();
     if (function->paramRewriteFunc) {
         function->paramRewriteFunc(children);
     }

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -33,7 +33,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
         COUNT_STAR_FUNC_NAME, std::vector<LogicalType*>{}, false);
     auto bindData = std::make_unique<FunctionBindData>(LogicalType(function->returnTypeID));
     auto countStarExpr = std::make_shared<AggregateFunctionExpression>(COUNT_STAR_FUNC_NAME,
-        std::move(bindData), expression_vector{}, function->copy(),
+        std::move(bindData), expression_vector{}, function->clone(),
         binder->getUniqueExpressionName(COUNT_STAR_FUNC_NAME));
     boundSubqueryExpr->setCountStarExpr(countStarExpr);
     std::shared_ptr<Expression> projectionExpr;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -1,8 +1,6 @@
 #include "catalog/catalog.h"
 
-#include "catalog/node_table_schema.h"
 #include "catalog/rel_table_group_schema.h"
-#include "catalog/rel_table_schema.h"
 #include "storage/wal/wal.h"
 #include "transaction/transaction_action.h"
 
@@ -111,22 +109,6 @@ void Catalog::renameProperty(
     table_id_t tableID, property_id_t propertyID, const std::string& newName) {
     initCatalogContentForWriteTrxIfNecessary();
     catalogContentForWriteTrx->getTableSchema(tableID)->renameProperty(propertyID, newName);
-}
-
-std::unordered_set<TableSchema*> Catalog::getAllRelTableSchemasContainBoundTable(
-    table_id_t boundTableID) const {
-    std::unordered_set<TableSchema*> relTableSchemas;
-    auto nodeTableSchema =
-        reinterpret_cast<NodeTableSchema*>(getReadOnlyVersion()->getTableSchema(boundTableID));
-    for (auto& fwdRelTableID : nodeTableSchema->getFwdRelTableIDSet()) {
-        relTableSchemas.insert(
-            reinterpret_cast<RelTableSchema*>(getReadOnlyVersion()->getTableSchema(fwdRelTableID)));
-    }
-    for (auto& bwdRelTableID : nodeTableSchema->getBwdRelTableIDSet()) {
-        relTableSchemas.insert(
-            reinterpret_cast<RelTableSchema*>(getReadOnlyVersion()->getTableSchema(bwdRelTableID)));
-    }
-    return relTableSchemas;
 }
 
 void Catalog::addFunction(std::string name, function::function_set functionSet) {

--- a/src/catalog/catalog_content.cpp
+++ b/src/catalog/catalog_content.cpp
@@ -242,8 +242,8 @@ std::unique_ptr<CatalogContent> CatalogContent::copy() const {
     for (auto& macro : macros) {
         macrosToCopy.emplace(macro.first, macro.second->copy());
     }
-    return std::make_unique<CatalogContent>(
-        std::move(tableSchemasToCopy), tableNameToIDMap, nextTableID, std::move(macrosToCopy));
+    return std::make_unique<CatalogContent>(std::move(tableSchemasToCopy), tableNameToIDMap,
+        nextTableID, builtInFunctions->copy(), std::move(macrosToCopy));
 }
 
 void CatalogContent::validateStorageVersion(storage_version_t savedStorageVersion) {

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -194,6 +194,18 @@ void BuiltInFunctions::validateNonEmptyCandidateFunctions(
     }
 }
 
+std::unique_ptr<BuiltInFunctions> BuiltInFunctions::copy() {
+    auto result = std::make_unique<BuiltInFunctions>();
+    for (auto& [name, functionSet] : functions) {
+        std::vector<std::unique_ptr<Function>> functionSetToCopy;
+        for (auto& function : functionSet) {
+            functionSetToCopy.push_back(function->copy());
+        }
+        result->functions.emplace(name, std::move(functionSetToCopy));
+    }
+    return result;
+}
+
 uint32_t BuiltInFunctions::getTargetTypeCost(LogicalTypeID typeID) {
     switch (typeID) {
     case LogicalTypeID::INT16:

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -61,9 +61,6 @@ public:
     void renameProperty(
         common::table_id_t tableID, common::property_id_t propertyID, const std::string& newName);
 
-    std::unordered_set<TableSchema*> getAllRelTableSchemasContainBoundTable(
-        common::table_id_t boundTableID) const;
-
     void addFunction(std::string name, function::function_set functionSet);
 
     void addScalarMacroFunction(

--- a/src/include/catalog/catalog_content.h
+++ b/src/include/catalog/catalog_content.h
@@ -25,11 +25,11 @@ public:
         std::unordered_map<common::table_id_t, std::unique_ptr<TableSchema>> tableSchemas,
         std::unordered_map<std::string, common::table_id_t> tableNameToIDMap,
         common::table_id_t nextTableID,
+        std::unique_ptr<function::BuiltInFunctions> builtInFunctions,
         std::unordered_map<std::string, std::unique_ptr<function::ScalarMacroFunction>> macros)
         : tableSchemas{std::move(tableSchemas)}, tableNameToIDMap{std::move(tableNameToIDMap)},
-          nextTableID{nextTableID}, macros{std::move(macros)} {
-        registerBuiltInFunctions();
-    }
+          nextTableID{nextTableID}, builtInFunctions{std::move(builtInFunctions)}, macros{std::move(
+                                                                                       macros)} {}
 
     /*
      * Single schema lookup.

--- a/src/include/function/aggregate_function.h
+++ b/src/include/function/aggregate_function.h
@@ -29,7 +29,7 @@ using aggr_combine_function_t =
     std::function<void(uint8_t* state, uint8_t* otherState, storage::MemoryManager* memoryManager)>;
 using aggr_finalize_function_t = std::function<void(uint8_t* state)>;
 
-struct AggregateFunction : public BaseScalarFunction {
+struct AggregateFunction final : public BaseScalarFunction {
     AggregateFunction(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs,
         common::LogicalTypeID returnTypeID, aggr_initialize_function_t initializeFunc,
         aggr_update_all_function_t updateAllFunc, aggr_update_pos_function_t updatePosFunc,
@@ -83,7 +83,13 @@ struct AggregateFunction : public BaseScalarFunction {
 
     inline bool isFunctionDistinct() const { return isDistinct; }
 
-    inline std::unique_ptr<AggregateFunction> copy() {
+    inline std::unique_ptr<Function> copy() const override {
+        return std::make_unique<AggregateFunction>(name, parameterTypeIDs, returnTypeID,
+            initializeFunc, updateAllFunc, updatePosFunc, combineFunc, finalizeFunc, isDistinct,
+            bindFunc, paramRewriteFunc);
+    }
+
+    inline std::unique_ptr<AggregateFunction> clone() const {
         return std::make_unique<AggregateFunction>(name, parameterTypeIDs, returnTypeID,
             initializeFunc, updateAllFunc, updatePosFunc, combineFunc, finalizeFunc, isDistinct,
             bindFunc, paramRewriteFunc);

--- a/src/include/function/built_in_function.h
+++ b/src/include/function/built_in_function.h
@@ -40,6 +40,8 @@ public:
         const std::string& name, const std::vector<common::LogicalType*>& inputTypes,
         bool isDistinct);
 
+    std::unique_ptr<BuiltInFunctions> copy();
+
 private:
     static uint32_t getTargetTypeCost(common::LogicalTypeID typeID);
 

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -36,6 +36,8 @@ struct Function {
 
     virtual std::string signatureToString() const = 0;
 
+    virtual std::unique_ptr<Function> copy() const = 0;
+
     // TODO(Ziyi): Move to catalog entry once we have implemented the catalog entry.
     FunctionType type;
     std::string name;

--- a/src/include/function/scalar_function.h
+++ b/src/include/function/scalar_function.h
@@ -20,7 +20,7 @@ using scalar_select_func = std::function<bool(
     const std::vector<std::shared_ptr<common::ValueVector>>&, common::SelectionVector&)>;
 using function_set = std::vector<std::unique_ptr<Function>>;
 
-struct ScalarFunction : public BaseScalarFunction {
+struct ScalarFunction final : public BaseScalarFunction {
 
     ScalarFunction(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs,
         common::LogicalTypeID returnTypeID, scalar_exec_func execFunc, bool isVarLength = false)
@@ -173,6 +173,10 @@ struct ScalarFunction : public BaseScalarFunction {
         KU_ASSERT(params.size() == 2);
         BinaryFunctionExecutor::executeListStruct<LEFT_TYPE, RIGHT_TYPE, RESULT_TYPE, FUNC>(
             *params[0], *params[1], result);
+    }
+
+    std::unique_ptr<Function> copy() const override {
+        return std::make_unique<ScalarFunction>(*this);
     }
 
     scalar_exec_func execFunc;

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -72,6 +72,10 @@ struct TableFunction : public Function {
     inline std::string signatureToString() const override {
         return common::LogicalTypeUtils::toString(parameterTypeIDs);
     }
+
+    std::unique_ptr<Function> copy() const override {
+        return std::make_unique<TableFunction>(*this);
+    }
 };
 
 } // namespace function

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -76,7 +76,8 @@ public:
 
     // TODO(Ziyi): Instead of exposing a dedicated API for adding a new function, we should consider
     // add function through the extension module.
-    void addFunction(std::string name, std::vector<std::unique_ptr<function::Function>> tableFunc);
+    void addBuiltInFunction(
+        std::string name, std::vector<std::unique_ptr<function::Function>> functionSet);
 
 private:
     void openLockFile();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -84,7 +84,7 @@ void Database::setLoggingLevel(std::string loggingLevel) {
     spdlog::set_level(LoggingLevelUtils::convertStrToLevelEnum(std::move(loggingLevel)));
 }
 
-void Database::addFunction(std::string name, function::function_set functionSet) {
+void Database::addBuiltInFunction(std::string name, function::function_set functionSet) {
     catalog->addFunction(std::move(name), std::move(functionSet));
 }
 

--- a/src/processor/map/map_aggregate.cpp
+++ b/src/processor/map/map_aggregate.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAggregate(LogicalOperator* logi
     std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions;
     for (auto& expression : logicalAggregate.getAggregateExpressions()) {
         aggregateFunctions.push_back(
-            ((AggregateFunctionExpression&)*expression).aggregateFunction->copy());
+            ((AggregateFunctionExpression&)*expression).aggregateFunction->clone());
     }
     auto aggregatesOutputPos =
         getExpressionsDataPos(logicalAggregate.getAggregateExpressions(), *outSchema);

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -151,16 +151,16 @@ void AggregateHashTable::initializeFT(
     }
     aggStateColOffsetInFT = numBytesForKeys + numBytesForDependentKeys;
 
-    aggregateFunctions.resize(aggFuncs.size());
-    updateAggFuncs.resize(aggFuncs.size());
+    aggregateFunctions.reserve(aggFuncs.size());
+    updateAggFuncs.reserve(aggFuncs.size());
     for (auto i = 0u; i < aggFuncs.size(); i++) {
         auto& aggFunc = aggFuncs[i];
         tableSchema->appendColumn(std::make_unique<ColumnSchema>(
             isUnflat, dataChunkPos, aggFunc->getAggregateStateSize()));
-        aggregateFunctions[i] = aggFunc->copy();
-        updateAggFuncs[i] = aggFunc->isFunctionDistinct() ?
-                                &AggregateHashTable::updateDistinctAggState :
-                                &AggregateHashTable::updateAggState;
+        aggregateFunctions.push_back(aggFunc->clone());
+        updateAggFuncs.push_back(aggFunc->isFunctionDistinct() ?
+                                     &AggregateHashTable::updateDistinctAggState :
+                                     &AggregateHashTable::updateAggState);
     }
     tableSchema->appendColumn(
         std::make_unique<ColumnSchema>(isUnflat, dataChunkPos, sizeof(hash_t)));

--- a/src/processor/operator/aggregate/base_aggregate.cpp
+++ b/src/processor/operator/aggregate/base_aggregate.cpp
@@ -9,7 +9,7 @@ BaseAggregateSharedState::BaseAggregateSharedState(
     const std::vector<std::unique_ptr<AggregateFunction>>& aggregateFunctions)
     : currentOffset{0} {
     for (auto& aggregateFunction : aggregateFunctions) {
-        this->aggregateFunctions.push_back(aggregateFunction->copy());
+        this->aggregateFunctions.push_back(aggregateFunction->clone());
     }
 }
 
@@ -42,7 +42,7 @@ void BaseAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
 std::vector<std::unique_ptr<function::AggregateFunction>> BaseAggregate::cloneAggFunctions() {
     std::vector<std::unique_ptr<AggregateFunction>> result;
     for (auto& function : aggregateFunctions) {
-        result.push_back(function->copy());
+        result.push_back(function->clone());
     }
     return result;
 }

--- a/test/main/udf_test.cpp
+++ b/test/main/udf_test.cpp
@@ -12,6 +12,8 @@ static int32_t add5(int32_t x) {
 
 TEST_F(ApiTest, UnaryUDFInt64) {
     conn->createScalarFunction("add5", &add5);
+    // Dummy query to ensure the add5 function is persistent after a write transaction.
+    conn->query("CREATE NODE TABLE PERSON1(ID INT64, PRIMARY KEY(ID))");
     auto actualResult = TestHelper::convertResultToString(
         *conn->query("MATCH (p:person) return add5(to_int32(p.age))"));
     auto expectedResult = std::vector<std::string>{"40", "35", "50", "25", "25", "30", "45", "88"};

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -35,7 +35,7 @@ PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
     uint64_t maxNumThreads, bool compression, bool readOnly) {
     auto systemConfig = SystemConfig(bufferPoolSize, maxNumThreads, compression, readOnly);
     database = std::make_unique<Database>(databasePath, systemConfig);
-    database->addFunction(READ_PANDAS_FUNC_NAME,kuzu::PandasScanFunction::getFunctionSet());
+    database->addBuiltInFunction(READ_PANDAS_FUNC_NAME, kuzu::PandasScanFunction::getFunctionSet());
     storageDriver = std::make_unique<kuzu::main::StorageDriver>(database.get());
 }
 

--- a/tools/python_api/test/test_scan_pandas.py
+++ b/tools/python_api/test/test_scan_pandas.py
@@ -62,6 +62,8 @@ def test_scan_pandas_with_filter(get_tmp_path):
         'weight': np.array([23.2, 31.7, 42.9], dtype=np.float64)
     }
     df = pd.DataFrame(data)
+    # Dummy query to ensure the READ_PANDAS function is persistent after a write transaction.
+    conn.execute("CREATE NODE TABLE PERSON1(ID INT64, PRIMARY KEY(ID))")
     results = conn.execute("CALL READ_PANDAS('df') WHERE id > 20 RETURN id + 5, weight")
     assert results.get_next() == [27, 23.2]
     assert results.get_next() == [105, 42.9]


### PR DESCRIPTION
When initializing the write version of the catalogContent, we simply create a new catalogContent and regenerate the built-in funcionts. However, this discards all UDFs since all functions are not copied.
This PR correctly copies all functions when initializing the write version of the catalogContent 