### PR TITLE
fix #2474: parse dataType map() with 0 or no arg aborts

### DIFF
--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -21,7 +21,7 @@ std::vector<std::string> StringUtils::splitComma(const std::string& input) {
         currentPos++;
     }
     result.push_back(input.substr(0, currentPos));
-    result.push_back(input.substr(currentPos + 1));
+    result.push_back(input.substr(currentPos == input.length() ? input.length() : currentPos + 1));
     return result;
 }
 

--- a/test/test_files/tinysnb/cast/cast_error.test
+++ b/test/test_files/tinysnb/cast/cast_error.test
@@ -798,3 +798,40 @@ Conversion exception: Unsupported casting function from INT16[2] to FLOAT[1].
 ---- error
 Runtime exception: Unsupported FIXED_LIST type: Function::getFixedListChildCastFunc
 
+-LOG InvalidNestedCast
+-STATEMENT RETURN cast({a: {b: {c: [[1, 3, 4]], d: "str"}}, e: [1, 9, NULL]}, "STRUCT(a STRUCT(b STRUCT(c INT64[2][], d STRING)), e INT128[3])");
+---- error
+Conversion exception: Unsupported casting VAR_LIST with incorrect list entry to FIXED_LIST. Expected: 2, Actual: 3.
+-STATEMENT RETURN cast({a: {b: {c: [[1, 3, 4]], d: "str"}}, e: [1, 9, NULL]}, "STRUCT(a STRUCT(b STRUCT(c INT64[3][], d STRING)), e INT128[3])");
+---- error
+Conversion exception: Cast failed. NULL is not allowed for FIXED_LIST.
+-STATEMENT RETURN cast(cast("{a: {b: {c: [[1, 3, 4]], d: {18=[3, 2]}}}, e: [1, 9, 3]}", "STRUCT(a STRUCT(b STRUCT(c INT64[3][], d MAP(INT32,INT32[]))), e FLOAT[3])"), "STRUCT(a STRUCT(b STRUCT(c INT64[3][], d MAP(INT32,INT32[5]))), e INT32[3])");
+---- error
+Conversion exception: Unsupported casting VAR_LIST with incorrect list entry to FIXED_LIST. Expected: 5, Actual: 2.
+
+-LOG InvalidNameCast
+-STATEMENT RETURN cast("nop", "STRUCT()");
+---- error
+Cannot parse dataTypeID:
+-STATEMENT RETURN cast("nop", "STRUCT(a=fds)");
+---- error
+Cannot parse dataTypeID: A=FDS
+-STATEMENT RETURN cast("nop", "STRUCT(a: )");
+---- error
+Cannot parse dataTypeID:
+-STATEMENT RETURN cast("nop", "MAP()");
+---- error
+Cannot parse dataTypeID:
+-STATEMENT RETURN cast("nop", "MAP(");
+---- error
+Cannot parse map type: MAP(
+-STATEMENT RETURN cast("nop", "UNION(a:STRING)");
+---- error
+Cannot parse dataTypeID: A:STRING
+-STATEMENT RETURN cast("nop", "MAP(int)");
+---- error
+Cannot parse dataTypeID:
+-STATEMENT RETURN cast("nop", "STRUCT(a: INT, b MAP(INT, STRING, INT))");
+---- error
+Cannot parse dataTypeID: STRING, INT
+


### PR DESCRIPTION
fix #2474 