### PR TITLE
Fix pandas scan bug

### DIFF
--- a/tools/python_api/src_cpp/include/pandas/pandas_bind.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_bind.h
@@ -27,6 +27,7 @@ struct PandasColumnBindData {
         : npType{npType}, pandasCol{std::move(pandasCol)}, mask{std::move(mask)} {}
 
     std::unique_ptr<PandasColumnBindData> copy() {
+        py::gil_scoped_acquire acquire;
         return std::make_unique<PandasColumnBindData>(npType, pandasCol->copy(),
             mask == nullptr ? nullptr : std::make_unique<RegisteredArray>(mask->npArray));
     }

--- a/tools/python_api/src_cpp/include/pandas/pandas_column.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_column.h
@@ -27,6 +27,7 @@ public:
         : PandasColumn{PandasColumnBackend::NUMPY}, array{std::move(array)} {}
 
     std::unique_ptr<PandasColumn> copy() const override {
+        py::gil_scoped_acquire acquire;
         return std::make_unique<PandasNumpyColumn>(array);
     }
 


### PR DESCRIPTION
`Do you have any pybind11 objects that are members of other C++ structures? One commonly overlooked requirement is that pybind11 objects have to increase their reference count whenever their copy constructor is called. Thus, you need to be holding the GIL to invoke the copy constructor of any C++ class that has a pybind11 member. This can sometimes be very tricky to track for complicated programs Think carefully when you make a pybind11 object a member in another struct.`

According to the pybind11 doc, we should grab the GIL in the copy constructor of any class who has a memeber of pybind11 objects.