### PR TITLE
Add LTO Support

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -287,7 +287,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build
-        run: make benchmark
+        run: make benchmark LTO=1
 
       - name: Benchmark
         run: python3 benchmark/benchmark_runner.py --dataset ldbc-sf100 --thread 10

--- a/.github/workflows/linux-java-workflow.yml
+++ b/.github/workflows/linux-java-workflow.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Build Java lib for Linux
         run: |
           source /opt/rh/devtoolset-11/enable
-          make java NUM_THREADS=$(nproc)
+          make java LTO=1 NUM_THREADS=$(nproc)
 
       - uses: actions/upload-artifact@v3
         with:
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Build Java lib for Linux
-        run: make java NUM_THREADS=$(nproc)
+        run: make java LTO=1 NUM_THREADS=$(nproc)
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/mac-java-workflow.yml
+++ b/.github/workflows/mac-java-workflow.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Build Java lib for Apple Silicon
         run: |
-          arch -arm64 env JAVA_HOME=$(/usr/libexec/java_home) make java NUM_THREADS=8
+          arch -arm64 env JAVA_HOME=$(/usr/libexec/java_home) make java LTO=1 NUM_THREADS=8
         env:
           MACOSX_DEPLOYMENT_TARGET: 11.0
           ARCHFLAGS: "-arch arm64"
@@ -28,7 +28,7 @@ jobs:
 
       - name: Build Java lib for Intel
         run: |
-          env JAVA_HOME=$(/usr/libexec/java_home) make java NUM_THREADS=48
+          env JAVA_HOME=$(/usr/libexec/java_home) make java LTO=1 NUM_THREADS=48
         env:
           MACOSX_DEPLOYMENT_TARGET: 10.15
           ARCHFLAGS: "-arch x86_64"

--- a/.github/workflows/windows-java-workflow.yml
+++ b/.github/workflows/windows-java-workflow.yml
@@ -14,7 +14,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-          make java NUM_THREADS=48
+          make java LTO=1 NUM_THREADS=48
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/windows-nodejs-workflow.yml
+++ b/.github/workflows/windows-nodejs-workflow.yml
@@ -19,7 +19,7 @@ jobs:
         shell: cmd
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-          make nodejs NUM_THREADS=48
+          make nodejs LTO=1 NUM_THREADS=48
 
       - name: Move Node.js native module
         working-directory: tools/nodejs_api/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(Kuzu VERSION 0.1.0 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 
-set(CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS TRUE)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 set(CMAKE_C_VISIBILITY_PRESET hidden)
+set(CMAKE_FIND_PACKAGE_RESOLVE_SYMLINKS TRUE)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_VISIBILITY_INLINES_HIDDEN ON)
 
 option(ENABLE_WERROR "Treat all warnings as errors" FALSE)
@@ -76,6 +76,7 @@ option(ENABLE_ADDRESS_SANITIZER "Enable address sanitizer." FALSE)
 option(ENABLE_THREAD_SANITIZER "Enable thread sanitizer." FALSE)
 option(ENABLE_UBSAN "Enable undefined behavior sanitizer." FALSE)
 option(ENABLE_RUNTIME_CHECKS "Enable runtime coherency checks (e.g. asserts)" FALSE)
+option(ENABLE_LTO "Enable Link-Time Optimization" FALSE)
 if(MSVC)
     # Required for M_PI on Windows
     add_compile_definitions(_USE_MATH_DEFINES)
@@ -131,6 +132,10 @@ endif()
 
 if(${ENABLE_RUNTIME_CHECKS})
     add_compile_definitions(KUZU_RUNTIME_CHECKS)
+endif()
+
+if(${ENABLE_LTO})
+    set(CMAKE_INTERPROCEDURAL_OPTIMIZATION TRUE)
 endif()
 
 option(BUILD_BENCHMARK "Build benchmarks." FALSE)

--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,11 @@
 .PHONY: release debug test benchmark all alldebug clean clean-all
 
 CLANGD_DIAGNOSTIC_INSTANCES ?= 4
-GENERATOR=
 NUM_THREADS ?= 1
 PREFIX ?= install
 ROOT_DIR=$(CURDIR)
-RUNTIME_CHECK_FLAG=
 SANITIZER_FLAG=
 TEST_JOBS ?= 10
-WERROR_FLAG=
 
 export CMAKE_BUILD_PARALLEL_LEVEL=$(NUM_THREADS)
 
@@ -19,7 +16,7 @@ ifeq ($(OS),Windows_NT)
 endif
 
 ifeq ($(GEN),ninja)
-	GENERATOR=-G "Ninja"
+	CMAKE_FLAGS += -G "Ninja"
 endif
 
 ifeq ($(ASAN), 1)
@@ -33,10 +30,13 @@ ifeq ($(UBSAN), 1)
 endif
 
 ifeq ($(RUNTIME_CHECKS), 1)
-	RUNTIME_CHECK_FLAG=-DENABLE_RUNTIME_CHECKS=TRUE
+	CMAKE_FLAGS += -DENABLE_RUNTIME_CHECKS=TRUE
 endif
 ifeq ($(WERROR), 1)
-	WERROR_FLAG=-DENABLE_WERROR=TRUE
+	CMAKE_FLAGS += -DENABLE_WERROR=TRUE
+endif
+ifeq ($(LTO), 1)
+	CMAKE_FLAGS += -DENABLE_LTO=TRUE
 endif
 
 ifeq ($(OS),Windows_NT)
@@ -51,61 +51,61 @@ endif
 
 release:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release ../.. && \
 	cmake --build . --config Release
 
 debug:
 	$(call mkdirp,build/debug) && cd build/debug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Debug ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug ../.. && \
 	cmake --build . --config Debug
 
 all:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE -DBUILD_EXAMPLES=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE -DBUILD_EXAMPLES=TRUE ../.. && \
 	cmake --build . --config Release
 
 example:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_EXAMPLES=TRUE ../.. && \
 	cmake --build . --config Release
 
 alldebug:
 	$(call mkdirp,build/debug) && cd build/debug && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE -DBUILD_EXAMPLES=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=TRUE -DBUILD_BENCHMARK=TRUE -DBUILD_NODEJS=TRUE -DBUILD_EXAMPLES=TRUE ../.. && \
 	cmake --build . --config Debug
 
 benchmark:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARK=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_BENCHMARK=TRUE ../.. && \
 	cmake --build . --config Release
 
 nodejs:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_NODEJS=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_NODEJS=TRUE ../.. && \
 	cmake --build . --config Release
 
 java:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_JAVA=TRUE ../.. && \
 	cmake --build . --config Release
 
 test:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE ../.. && \
 	cmake --build . --config Release
 	cd $(ROOT_DIR)/build/release/test && \
 	ctest --output-on-failure -j ${TEST_JOBS}
 
 lcov:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_NODEJS=TRUE -DBUILD_LCOV=TRUE ../.. && \
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTS=TRUE -DBUILD_NODEJS=TRUE -DBUILD_LCOV=TRUE ../.. && \
 	cmake --build . --config Release
 	cd $(ROOT_DIR)/build/release/test && \
 	ctest --output-on-failure -j ${TEST_JOBS}
 
 clangd:
 	$(call mkdirp,build/release) && cd build/release && \
-	cmake $(GENERATOR) $(FORCE_COLOR) $(SANITIZER_FLAG) $(WERROR_FLAG) $(RUNTIME_CHECK_FLAG) -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ../..
+	cmake $(SANITIZER_FLAG) $(CMAKE_FLAGS) -DCMAKE_EXPORT_COMPILE_COMMANDS=1 ../..
 
 tidy: clangd
 	run-clang-tidy -p build/release -quiet -j $(NUM_THREADS) \

--- a/scripts/pip-package/package_tar.py
+++ b/scripts/pip-package/package_tar.py
@@ -47,7 +47,7 @@ if __name__ == "__main__":
 
         with tarfile.open(os.path.join(tempdir, "kuzu-source.tar")) as tar:
             tar.extractall(path=os.path.join(tempdir, "kuzu-source"))
-        
+
         os.remove(os.path.join(tempdir, "kuzu-source.tar"))
 
         os.makedirs(os.path.join(tempdir, "kuzu"))

--- a/scripts/pip-package/setup.py
+++ b/scripts/pip-package/setup.py
@@ -80,7 +80,7 @@ class CMakeBuild(build_ext):
         subprocess.run(['make', 'clean'], check=True, cwd=build_dir)
 
         # Build the native extension.
-        full_cmd = ['make', 'release', 'NUM_THREADS=%d' % num_cores]
+        full_cmd = ['make', 'release', 'LTO=1', 'NUM_THREADS=%d' % num_cores]
         subprocess.run(full_cmd, cwd=build_dir, check=True, env=env_vars)
         self.announce("Done building native extension.")
         self.announce("Copying native extension...")

--- a/scripts/pre-compiled-bins/build.py
+++ b/scripts/pre-compiled-bins/build.py
@@ -63,7 +63,7 @@ def build():
                          deploy_target)
             env_vars['CMAKE_OSX_DEPLOYMENT_TARGET'] = deploy_target
 
-    full_cmd = ['make', 'release', 'NUM_THREADS=%d' % concurrency]
+    full_cmd = ['make', 'release', 'LTO=1', 'NUM_THREADS=%d' % concurrency]
     logging.info("Running command: %s" % full_cmd)
     try:
         subprocess.run(full_cmd, cwd=workspace_root,

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,22 +1,9 @@
-include(FetchContent)
+add_subdirectory(gtest)
 
-# Disable WERROR for gtest
-if(ENABLE_WERROR)
-        set(CMAKE_COMPILE_WARNING_AS_ERROR FALSE)
-endif()
-FetchContent_Declare(
-        googletest
-        GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.13.0
-)
-set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+# Make gtest available to subdirectories.
 add_library(GTest::GTest INTERFACE IMPORTED)
 target_link_libraries(GTest::GTest INTERFACE gtest_main)
 target_link_libraries(GTest::GTest INTERFACE gmock_main)
-if(ENABLE_WERROR)
-        set(CMAKE_COMPILE_WARNING_AS_ERROR TRUE)
-endif()
 
 enable_testing()
 add_subdirectory(test_helper)

--- a/test/gtest/CMakeLists.txt
+++ b/test/gtest/CMakeLists.txt
@@ -1,0 +1,14 @@
+include(FetchContent)
+
+# Disable WERROR for gtest.
+set(CMAKE_COMPILE_WARNING_AS_ERROR FALSE)
+# Disable LTO for gtest, since it uses an older version of CMake.
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION FALSE)
+
+FetchContent_Declare(
+        googletest
+        GIT_REPOSITORY https://github.com/google/googletest.git
+        GIT_TAG v1.13.0
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)

--- a/third_party/antlr4_runtime/CMakeLists.txt
+++ b/third_party/antlr4_runtime/CMakeLists.txt
@@ -319,14 +319,7 @@ target_include_directories(${ANTLR4_RUNTIME} PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-if (WIN32)
-    target_compile_definitions(${ANTLR4_RUNTIME} PRIVATE
-        -DANTLR4CPP_EXPORTS
-        -DANTLR4CPP_STATIC
-    )
-    set_property(TARGET ${ANTLR4_RUNTIME} PROPERTY CXX_STANDARD 17)
-endif()
-
+target_compile_definitions(${ANTLR4_RUNTIME} PUBLIC -DANTLR4CPP_STATIC)
 
 if ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug")
     if(MSVC)

--- a/third_party/re2/CMakeLists.txt
+++ b/third_party/re2/CMakeLists.txt
@@ -12,6 +12,10 @@ if(POLICY CMP0063)
     cmake_policy(SET CMP0063 NEW)
 endif()
 
+if(POLICY CMP0069)
+    cmake_policy(SET CMP0069 NEW)
+endif()
+
 project(RE2 CXX)
 
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/third_party/serd/CMakeLists.txt
+++ b/third_party/serd/CMakeLists.txt
@@ -11,6 +11,10 @@ if(POLICY CMP0063)
     cmake_policy(SET CMP0063 NEW)
 endif()
 
+if(POLICY CMP0069)
+    cmake_policy(SET CMP0069 NEW)
+endif()
+
 project(serd C)
 
 set(CMAKE_C_STANDARD 11)

--- a/tools/nodejs_api/install.js
+++ b/tools/nodejs_api/install.js
@@ -112,7 +112,7 @@ if (process.platform === "win32") {
   );
 }
 
-childProcess.execSync("make nodejs NUM_THREADS=" + THREADS, {
+childProcess.execSync("make nodejs LTO=1 NUM_THREADS=" + THREADS, {
   env,
   cwd: path.join(__dirname, "kuzu-source"),
   stdio: "inherit",


### PR DESCRIPTION
    Link-Time Optimization is a technique whereby the linker performs
    optimizations at the final step, right before generating the final
    executable or shared library. This provides significant performance and
    binary size optimizations, since the linker has access to all the
    context needed, unlike the individual optimizer passes, but in exchange
    linking takes a lot of time and memory.
    
    Based on some reading and some experimentation, Unity Builds, though
    they can offer similar benefits, are not nearly as good for
    optimization, and instead are primarily used for speeding up compile
    times. Additionally, Unity builds are harder to get right and harder to
    debug. LTO on the other hand is a very simple change, and seems to be
    the main area of focus right now.
    
    Closes #2036.