### PR TITLE
make: rewrite makefile

### DIFF
--- a/scripts/pre-compiled-bins/build.py
+++ b/scripts/pre-compiled-bins/build.py
@@ -24,7 +24,7 @@ elif sys.platform == "darwin":
 def cleanup():
     logging.info("Cleaning up workspace...")
     try:
-        subprocess.run(['make', 'clean-all'], cwd=workspace_root,
+        subprocess.run(['make', 'clean'], cwd=workspace_root,
                        check=True, env=env_vars)
         shutil.rmtree(os.path.join(base_dir, "headers"), ignore_errors=True)
         for f in ["kuzu", "kuzu.hpp", "kuzu.h", "libkuzu.so", "libkuzu.dylib"]:

--- a/tools/nodejs_api/install.js
+++ b/tools/nodejs_api/install.js
@@ -144,7 +144,7 @@ console.log("Cleaning up...");
 childProcess.execSync("npm run clean-all", {
   cwd: path.join(__dirname, "kuzu-source", "tools", "nodejs_api"),
 });
-childProcess.execSync("make clean-all", {
+childProcess.execSync("make clean", {
   cwd: path.join(__dirname, "kuzu-source"),
 });
 console.log("Done!");


### PR DESCRIPTION
    The makefile has adopted various technical debt over time. This commit
    rewrites it, with the following major changes:
    
    - Consistent marking of PHONY targets. This is most important for
      `install`, since it matches the name of a directory.
    - Use of `.ONESHELL`. This means that all commands are invoked in the
      same shell, and as such, `cd` is valid without using `&&`. To make
      sure that any failure is fatal, we pass the `-e` flag to the shell.
    - Makes use of `run-cmake-release` to drastically reduce duplication
      throughout the file.
    - Make sure the all target correctly builds everything.
    - Organize targets into sections.
    - Add python and rust target.
    - Remove $(ROOT_DIR) since it is never important. All recipes implicitly
      require the current directory to be the project root.
    
    Also, replaced all instances of `clean-all` with `clean`. `clean-all`
    doesn't exist anymore.