### PR TITLE
tidy: splitup main from analyzer

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,4 @@
 # Bugprone exception escape is super unhelpful.
-# NewDeleteLeaks has many false positives w.r.t smart pointers.
 Checks:
   -*,
 
@@ -10,9 +9,6 @@ Checks:
   -bugprone-implicit-widening-of-multiplication-result,
   -bugprone-narrowing-conversions,
   -bugprone-signed-char-misuse,
-
-  clang-analyzer-*,
-  -clang-analyzer-cplusplus.NewDeleteLeaks,
 
   concurrency-*,
 

--- a/.clang-tidy-analyzer
+++ b/.clang-tidy-analyzer
@@ -1,0 +1,10 @@
+# NewDeleteLeaks has many false positives w.r.t smart pointers.
+Checks:
+  -*,
+
+  clang-analyzer-*,
+  -clang-analyzer-cplusplus.NewDeleteLeaks,
+
+HeaderFilterRegex:
+  src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include
+WarningsAsErrors: "*"

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -248,6 +248,9 @@ jobs:
       - name: Run clang-tidy
         run: make tidy
 
+      - name: Run clang-tidy analyzer
+        run: make tidy-analyzer
+
   include-guard-and-no-std-assert:
     name: include guard & no std::assert check
     runs-on: ubuntu-22.04

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,10 @@ tidy: | allconfig java_native_header
 	run-clang-tidy -p build/release -quiet -j $(NUM_THREADS) \
 		"^$(realpath src)|$(realpath tools)/(?!shell/linenoise.cpp)|$(realpath examples)"
 
+tidy-analyzer: | allconfig java_native_header
+	run-clang-tidy -config-file .clang-tidy-analyzer -p build/release -quiet -j $(NUM_THREADS) \
+		"^$(realpath src)|$(realpath tools)/(?!shell/linenoise.cpp)|$(realpath examples)"
+
 clangd-diagnostics: | allconfig java_native_header
 	find src -name *.h -or -name *.cpp | xargs \
 		./scripts/get-clangd-diagnostics.py --compile-commands-dir build/release \


### PR DESCRIPTION
Clang tidy has many checks, most of which are very simple. These are very fast to run. However, we also have clang-analyzer checks enabled. These are useful since they are much more complex, which means they may catch more subtle bugs. However, they are much slower.

This change splits the main simple checks from the analyzer checks. The former are still invoked with `make tidy`, the latter with `make tidy-analyzer`.