### PR TITLE
tidy: check for non-virtual destructors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,6 +12,8 @@ Checks:
 
   concurrency-*,
 
+  cppcoreguidelines-virtual-class-destructor,
+
   misc-unused-parameters,
 
   modernize-use-override,

--- a/src/include/processor/operator/aggregate/base_aggregate.h
+++ b/src/include/processor/operator/aggregate/base_aggregate.h
@@ -14,7 +14,7 @@ protected:
 
     virtual std::pair<uint64_t, uint64_t> getNextRangeToRead() = 0;
 
-    virtual ~BaseAggregateSharedState() {}
+    ~BaseAggregateSharedState() {}
 
 protected:
     std::mutex mtx;

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace processor {
 
-class HashAggregateSharedState : public BaseAggregateSharedState {
+class HashAggregateSharedState final : public BaseAggregateSharedState {
 
 public:
     explicit HashAggregateSharedState(

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace processor {
 
-class SimpleAggregateSharedState : public BaseAggregateSharedState {
+class SimpleAggregateSharedState final : public BaseAggregateSharedState {
 public:
     explicit SimpleAggregateSharedState(
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions);

--- a/src/include/processor/operator/filtering_operator.h
+++ b/src/include/processor/operator/filtering_operator.h
@@ -11,6 +11,7 @@ public:
         currentSelVector =
             std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
     }
+    virtual ~SelVectorOverWriter() = default;
 
 protected:
     void restoreSelVector(std::shared_ptr<common::SelectionVector>& selVector);

--- a/src/include/processor/operator/mask.h
+++ b/src/include/processor/operator/mask.h
@@ -66,6 +66,7 @@ private:
 class NodeSemiMask {
 public:
     explicit NodeSemiMask(storage::NodeTable* nodeTable) : nodeTable{nodeTable} {}
+    virtual ~NodeSemiMask() = default;
 
     virtual void init(transaction::Transaction* trx) = 0;
 

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -15,6 +15,7 @@ class ParsingDriver {
 
 public:
     ParsingDriver(common::DataChunk& chunk);
+    virtual ~ParsingDriver() = default;
 
     bool done(uint64_t rowNum);
     void addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);

--- a/src/include/storage/buffer_manager/bm_file_handle.h
+++ b/src/include/storage/buffer_manager/bm_file_handle.h
@@ -141,7 +141,7 @@ public:
     BMFileHandle(const std::string& path, uint8_t flags, BufferManager* bm,
         common::PageSizeClass pageSizeClass, FileVersionedType fileVersionedType);
 
-    ~BMFileHandle();
+    ~BMFileHandle() override;
 
     // This function assumes the page is already LOCKED.
     inline void setLockedPageDirty(common::page_idx_t pageIdx) {

--- a/src/include/storage/file_handle.h
+++ b/src/include/storage/file_handle.h
@@ -28,6 +28,7 @@ public:
     constexpr static uint8_t O_IN_MEM_TEMP_FILE{0b0000'0011};
 
     FileHandle(const std::string& path, uint8_t flags);
+    virtual ~FileHandle() = default;
 
     common::page_idx_t addNewPage();
     common::page_idx_t addNewPages(common::page_idx_t numPages);


### PR DESCRIPTION
The check implements [this guideline][1]. A base class' destructor should either be public and virtual, meaning that the object can be destroyed through a pointer to the base class (e.g. a unique_ptr<Base>), or protected and non-virtual, meaning that the destructor cannot be invoked on a pointer to the base class. Private destructors would mean that children can't invoke the parent destructor, which is undesirable.

  [1]: http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rc-dtor-virtual