### PR TITLE
Cleanup reading from bool columns

### DIFF
--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -243,6 +243,9 @@ public:
 
     void decompressFromPage(const uint8_t* srcBuffer, uint64_t srcOffset, uint8_t* dstBuffer,
         uint64_t dstOffset, uint64_t numValues, const CompressionMetadata& metadata) const final;
+
+    void copyFromPage(const uint8_t* srcBuffer, uint64_t srcOffset, uint8_t* dstBuffer,
+        uint64_t dstOffset, uint64_t numValues, const CompressionMetadata& metadata) const;
 };
 
 class CompressedFunctor {

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -270,9 +270,6 @@ void ColumnChunk::resize(uint64_t newCapacity) {
     auto numBytesAfterResize = getBufferSize();
     if (numBytesAfterResize > bufferSize) {
         auto resizedBuffer = std::make_unique<uint8_t[]>(numBytesAfterResize);
-        if (dataType->getPhysicalType() == PhysicalTypeID::BOOL) {
-            memset(resizedBuffer.get(), 0 /* non null */, numBytesAfterResize);
-        }
         memcpy(resizedBuffer.get(), buffer.get(), bufferSize);
         bufferSize = numBytesAfterResize;
         buffer = std::move(resizedBuffer);


### PR DESCRIPTION
Removed various dedicated functions in place of using the compression interfaces.

One thing I don't entirely like is that it was necessary to modify the `ReadCompressedValuesFromPage` functor to not de-compress bools when reading so that they can be copied directly into the in-place compressed BoolColumnChunk. We could also simplify ColumnChunk somewhat by not compressing bools in-place, which would remove that interface quirk and further simplify things, but that will probably slow down copies a little and increase memory usage.