### PR TITLE
Hide catalog content

### DIFF
--- a/src/binder/bind/bind_comment_on.cpp
+++ b/src/binder/bind/bind_comment_on.cpp
@@ -1,5 +1,6 @@
 #include "binder/binder.h"
 #include "binder/bound_comment_on.h"
+#include "main/client_context.h"
 #include "parser/comment_on.h"
 
 namespace kuzu {
@@ -9,11 +10,8 @@ std::unique_ptr<BoundStatement> Binder::bindCommentOn(const parser::Statement& s
     auto& commentOnStatement = reinterpret_cast<const parser::CommentOn&>(statement);
     auto tableName = commentOnStatement.getTable();
     auto comment = commentOnStatement.getComment();
-
     validateTableExist(tableName);
-    auto catalogContent = catalog.getReadOnlyVersion();
-    auto tableID = catalogContent->getTableID(tableName);
-
+    auto tableID = catalog.getTableID(clientContext->getTx(), tableName);
     return std::make_unique<BoundCommentOn>(tableID, tableName, comment);
 }
 

--- a/src/binder/bind/bind_create_macro.cpp
+++ b/src/binder/bind/bind_create_macro.cpp
@@ -3,6 +3,7 @@
 #include "common/exception/binder.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
+#include "main/client_context.h"
 #include "parser/create_macro.h"
 
 using namespace kuzu::common;
@@ -15,7 +16,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateMacro(const Statement& stateme
     auto& createMacro = reinterpret_cast<const CreateMacro&>(statement);
     auto macroName = createMacro.getMacroName();
     StringUtils::toUpper(macroName);
-    if (catalog.getReadOnlyVersion()->containMacro(macroName)) {
+    if (catalog.containsMacro(clientContext->getTx(), macroName)) {
         throw BinderException{stringFormat("Macro {} already exists.", macroName)};
     }
     parser::default_macro_args defaultArgs;

--- a/src/binder/bind/bind_reading_clause.cpp
+++ b/src/binder/bind/bind_reading_clause.cpp
@@ -127,8 +127,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
         catalog.getBuiltInFunctions()->matchScalarFunction(funcName, inputTypes));
     auto bindInput = std::make_unique<function::TableFuncBindInput>();
     bindInput->inputs = std::move(inputValues);
-    auto bindData =
-        tableFunction->bindFunc(clientContext, bindInput.get(), catalog.getReadOnlyVersion());
+    auto bindData = tableFunction->bindFunc(clientContext, bindInput.get(), (Catalog*)&catalog);
     expression_vector columns;
     for (auto i = 0u; i < bindData->columnTypes.size(); i++) {
         columns.push_back(createVariable(bindData->columnNames[i], *bindData->columnTypes[i]));
@@ -175,8 +174,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(
         getScanFunction(readerConfig->fileType, readerConfig->csvReaderConfig->parallel);
     auto bindInput = std::make_unique<function::ScanTableFuncBindInput>(memoryManager,
         *readerConfig, std::move(expectedColumnNames), std::move(expectedColumnTypes));
-    auto bindData =
-        scanFunction->bindFunc(clientContext, bindInput.get(), catalog.getReadOnlyVersion());
+    auto bindData = scanFunction->bindFunc(clientContext, bindInput.get(), (Catalog*)&catalog);
     expression_vector columns;
     for (auto i = 0u; i < bindData->columnTypes.size(); i++) {
         columns.push_back(createVariable(bindData->columnNames[i], *bindData->columnTypes[i]));

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -9,6 +9,7 @@
 #include "common/assert.h"
 #include "common/exception/binder.h"
 #include "common/string_format.h"
+#include "main/client_context.h"
 #include "parser/query/updating_clause/delete_clause.h"
 #include "parser/query/updating_clause/insert_clause.h"
 #include "parser/query/updating_clause/merge_clause.h"
@@ -149,7 +150,7 @@ std::unique_ptr<BoundInsertInfo> Binder::bindInsertNodeInfo(
             "Create node " + node->toString() + " with multiple node labels is not supported.");
     }
     auto tableID = node->getSingleTableID();
-    auto tableSchema = catalog.getReadOnlyVersion()->getTableSchema(tableID);
+    auto tableSchema = catalog.getTableSchema(clientContext->getTx(), tableID);
     validatePrimaryKeyExistence(collection, tableSchema, node);
     auto setItems = bindSetItems(collection, tableSchema, node);
     return std::make_unique<BoundInsertInfo>(
@@ -168,7 +169,7 @@ std::unique_ptr<BoundInsertInfo> Binder::bindInsertRelInfo(
             common::stringFormat("Cannot create recursive rel {}.", rel->toString()));
     }
     auto relTableID = rel->getSingleTableID();
-    auto tableSchema = catalog.getReadOnlyVersion()->getTableSchema(relTableID);
+    auto tableSchema = catalog.getTableSchema(clientContext->getTx(), relTableID);
     auto setItems = bindSetItems(collection, tableSchema, rel);
     return std::make_unique<BoundInsertInfo>(
         UpdateTableType::REL, std::move(rel), std::move(setItems));

--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfNodeFrom(const Statement& /*s
     }
     auto bindInput = std::make_unique<function::ScanTableFuncBindInput>(
         memoryManager, *config, columnNames, std::move(columnTypes));
-    auto bindData = func->bindFunc(clientContext, bindInput.get(), catalog.getReadOnlyVersion());
+    auto bindData = func->bindFunc(clientContext, bindInput.get(), (Catalog*)&catalog);
     expression_vector columns;
     for (auto i = 0u; i < bindData->columnTypes.size(); i++) {
         columns.push_back(createVariable(bindData->columnNames[i], *bindData->columnTypes[i]));
@@ -75,7 +75,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfRelFrom(const Statement& /*st
     }
     auto bindInput = std::make_unique<function::ScanTableFuncBindInput>(
         memoryManager, *config, columnNames, std::move(columnTypes));
-    auto bindData = func->bindFunc(clientContext, bindInput.get(), catalog.getReadOnlyVersion());
+    auto bindData = func->bindFunc(clientContext, bindInput.get(), (Catalog*)&catalog);
     expression_vector columns;
     for (auto i = 0u; i < bindData->columnTypes.size(); i++) {
         columns.push_back(createVariable(bindData->columnNames[i], *bindData->columnTypes[i]));

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -4,6 +4,7 @@
 #include "common/exception/binder.h"
 #include "common/string_format.h"
 #include "function/table_functions.h"
+#include "main/client_context.h"
 
 using namespace kuzu::common;
 using namespace kuzu::parser;
@@ -63,11 +64,10 @@ std::shared_ptr<Expression> Binder::bindWhereExpression(const ParsedExpression& 
 }
 
 common::table_id_t Binder::bindTableID(const std::string& tableName) const {
-    auto catalogContent = catalog.getReadOnlyVersion();
-    if (!catalogContent->containsTable(tableName)) {
+    if (!catalog.containsTable(clientContext->getTx(), tableName)) {
         throw BinderException(common::stringFormat("Table {} does not exist.", tableName));
     }
-    return catalogContent->getTableID(tableName);
+    return catalog.getTableID(clientContext->getTx(), tableName);
 }
 
 std::shared_ptr<Expression> Binder::createVariable(
@@ -186,13 +186,13 @@ void Binder::validateReadNotFollowUpdate(const NormalizedSingleQuery& singleQuer
 }
 
 void Binder::validateTableType(table_id_t tableID, TableType expectedTableType) {
-    if (catalog.getReadOnlyVersion()->getTableSchema(tableID)->tableType != expectedTableType) {
+    if (catalog.getTableSchema(clientContext->getTx(), tableID)->tableType != expectedTableType) {
         throw BinderException("aa");
     }
 }
 
 void Binder::validateTableExist(const std::string& tableName) {
-    if (!catalog.getReadOnlyVersion()->containsTable(tableName)) {
+    if (!catalog.containsTable(clientContext->getTx(), tableName)) {
         throw BinderException("Table " + tableName + " does not exist.");
     }
 }

--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -3,9 +3,11 @@
 #include "catalog/rel_table_schema.h"
 #include "common/exception/binder.h"
 #include "common/string_format.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
+using namespace kuzu::transaction;
 
 namespace kuzu {
 namespace binder {
@@ -32,7 +34,7 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
             if (isSrcConnect || isDstConnect) {
                 for (auto relTableID : queryRel->getTableIDs()) {
                     auto relTableSchema = reinterpret_cast<RelTableSchema*>(
-                        catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                        catalog.getTableSchema(&DUMMY_READ_TRANSACTION, relTableID));
                     candidates.insert(relTableSchema->getSrcTableID());
                     candidates.insert(relTableSchema->getDstTableID());
                 }
@@ -41,13 +43,13 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
             if (isSrcConnect) {
                 for (auto relTableID : queryRel->getTableIDs()) {
                     auto relTableSchema = reinterpret_cast<RelTableSchema*>(
-                        catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                        catalog.getTableSchema(&DUMMY_READ_TRANSACTION, relTableID));
                     candidates.insert(relTableSchema->getSrcTableID());
                 }
             } else if (isDstConnect) {
                 for (auto relTableID : queryRel->getTableIDs()) {
                     auto relTableSchema = reinterpret_cast<RelTableSchema*>(
-                        catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                        catalog.getTableSchema(&DUMMY_READ_TRANSACTION, relTableID));
                     candidates.insert(relTableSchema->getDstTableID());
                 }
             }
@@ -86,7 +88,7 @@ void QueryGraphLabelAnalyzer::pruneRel(RelExpression& rel) {
         }
         for (auto& relTableID : rel.getTableIDs()) {
             auto relTableSchema = reinterpret_cast<RelTableSchema*>(
-                catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                catalog.getTableSchema(&DUMMY_READ_TRANSACTION, relTableID));
             auto srcTableID = relTableSchema->getSrcTableID();
             auto dstTableID = relTableSchema->getDstTableID();
             if (!boundTableIDSet.contains(srcTableID) || !boundTableIDSet.contains(dstTableID)) {
@@ -99,7 +101,7 @@ void QueryGraphLabelAnalyzer::pruneRel(RelExpression& rel) {
         auto dstTableIDSet = rel.getDstNode()->getTableIDsSet();
         for (auto& relTableID : rel.getTableIDs()) {
             auto relTableSchema = reinterpret_cast<RelTableSchema*>(
-                catalog.getReadOnlyVersion()->getTableSchema(relTableID));
+                catalog.getTableSchema(&DUMMY_READ_TRANSACTION, relTableID));
             auto srcTableID = relTableSchema->getSrcTableID();
             auto dstTableID = relTableSchema->getDstTableID();
             if (!srcTableIDSet.contains(srcTableID) || !dstTableIDSet.contains(dstTableID)) {

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -2,6 +2,7 @@
 
 #include "catalog/rel_table_group_schema.h"
 #include "storage/wal/wal.h"
+#include "transaction/transaction.h"
 #include "transaction/transaction_action.h"
 
 using namespace kuzu::common;
@@ -12,118 +13,196 @@ namespace kuzu {
 namespace catalog {
 
 Catalog::Catalog() : wal{nullptr} {
-    catalogContentForReadOnlyTrx = std::make_unique<CatalogContent>();
+    readOnlyVersion = std::make_unique<CatalogContent>();
 }
 
 Catalog::Catalog(WAL* wal) : wal{wal} {
-    catalogContentForReadOnlyTrx = std::make_unique<CatalogContent>(wal->getDirectory());
+    readOnlyVersion = std::make_unique<CatalogContent>(wal->getDirectory());
+}
+
+uint64_t Catalog::getTableCount(Transaction* tx) const {
+    return getVersion(tx)->getTableCount();
+}
+
+bool Catalog::containsNodeTable(Transaction* tx) const {
+    return getVersion(tx)->containsTable(TableType::NODE);
+}
+
+bool Catalog::containsRelTable(Transaction* tx) const {
+    return getVersion(tx)->containsTable(TableType::REL);
+}
+
+bool Catalog::containsRdfGraph(Transaction* tx) const {
+    return getVersion(tx)->containsTable(TableType::RDF);
+}
+
+bool Catalog::containsTable(Transaction* tx, const std::string& tableName) const {
+    return getVersion(tx)->containsTable(tableName);
+}
+
+table_id_t Catalog::getTableID(Transaction* tx, const std::string& tableName) const {
+    return getVersion(tx)->getTableID(tableName);
+}
+
+std::vector<common::table_id_t> Catalog::getNodeTableIDs(Transaction* tx) const {
+    return getVersion(tx)->getTableIDs(TableType::NODE);
+}
+
+std::vector<common::table_id_t> Catalog::getRelTableIDs(Transaction* tx) const {
+    return getVersion(tx)->getTableIDs(TableType::REL);
+}
+
+std::vector<common::table_id_t> Catalog::getRdfGraphIDs(Transaction* tx) const {
+    return getVersion(tx)->getTableIDs(TableType::RDF);
+}
+
+std::string Catalog::getTableName(Transaction* tx, table_id_t tableID) const {
+    return getVersion(tx)->getTableName(tableID);
+}
+
+TableSchema* Catalog::getTableSchema(Transaction* tx, table_id_t tableID) const {
+    return getVersion(tx)->getTableSchema(tableID);
+}
+
+std::vector<TableSchema*> Catalog::getNodeTableSchemas(Transaction* tx) const {
+    return getVersion(tx)->getTableSchemas(TableType::NODE);
+}
+
+std::vector<TableSchema*> Catalog::getRelTableSchemas(Transaction* tx) const {
+    return getVersion(tx)->getTableSchemas(TableType::REL);
+}
+
+std::vector<TableSchema*> Catalog::getRelTableGroupSchemas(Transaction* tx) const {
+    return getVersion(tx)->getTableSchemas(TableType::REL_GROUP);
+}
+
+std::vector<TableSchema*> Catalog::getTableSchemas(Transaction* tx) const {
+    std::vector<TableSchema*> result;
+    for (auto& [_, schema] : getVersion(tx)->tableSchemas) {
+        result.push_back(schema.get());
+    }
+    return result;
+}
+
+std::vector<TableSchema*> Catalog::getTableSchemas(
+    Transaction* tx, const table_id_vector_t& tableIDs) const {
+    std::vector<TableSchema*> result;
+    for (auto tableID : tableIDs) {
+        result.push_back(getVersion(tx)->getTableSchema(tableID));
+    }
+    return result;
 }
 
 void Catalog::prepareCommitOrRollback(TransactionAction action) {
     if (hasUpdates()) {
         wal->logCatalogRecord();
         if (action == TransactionAction::COMMIT) {
-            catalogContentForWriteTrx->saveToFile(
-                wal->getDirectory(), FileVersionType::WAL_VERSION);
+            readWriteVersion->saveToFile(wal->getDirectory(), FileVersionType::WAL_VERSION);
         }
     }
 }
 
 void Catalog::checkpointInMemory() {
     if (hasUpdates()) {
-        catalogContentForReadOnlyTrx = std::move(catalogContentForWriteTrx);
+        readOnlyVersion = std::move(readWriteVersion);
     }
 }
 
 ExpressionType Catalog::getFunctionType(const std::string& name) const {
-    return catalogContentForReadOnlyTrx->getFunctionType(name);
+    return readOnlyVersion->getFunctionType(name);
 }
 
 table_id_t Catalog::addNodeTableSchema(const binder::BoundCreateTableInfo& info) {
-    initCatalogContentForWriteTrxIfNecessary();
-    return catalogContentForWriteTrx->addNodeTableSchema(info);
+    KU_ASSERT(readWriteVersion != nullptr);
+    return readWriteVersion->addNodeTableSchema(info);
 }
 
 table_id_t Catalog::addRelTableSchema(const binder::BoundCreateTableInfo& info) {
-    initCatalogContentForWriteTrxIfNecessary();
-    auto tableID = catalogContentForWriteTrx->addRelTableSchema(info);
-    return tableID;
+    KU_ASSERT(readWriteVersion != nullptr);
+    return readWriteVersion->addRelTableSchema(info);
 }
 
 common::table_id_t Catalog::addRelTableGroupSchema(const binder::BoundCreateTableInfo& info) {
-    initCatalogContentForWriteTrxIfNecessary();
-    auto tableID = catalogContentForWriteTrx->addRelTableGroupSchema(info);
+    KU_ASSERT(readWriteVersion != nullptr);
+    auto tableID = readWriteVersion->addRelTableGroupSchema(info);
     return tableID;
 }
 
 table_id_t Catalog::addRdfGraphSchema(const binder::BoundCreateTableInfo& info) {
-    initCatalogContentForWriteTrxIfNecessary();
-    return catalogContentForWriteTrx->addRdfGraphSchema(info);
+    KU_ASSERT(readWriteVersion != nullptr);
+    return readWriteVersion->addRdfGraphSchema(info);
 }
 
 void Catalog::dropTableSchema(table_id_t tableID) {
-    initCatalogContentForWriteTrxIfNecessary();
-    auto tableSchema = catalogContentForWriteTrx->getTableSchema(tableID);
+    KU_ASSERT(readWriteVersion != nullptr);
+    auto tableSchema = readWriteVersion->getTableSchema(tableID);
     switch (tableSchema->tableType) {
     case TableType::REL_GROUP: {
         auto relTableGroupSchema = reinterpret_cast<RelTableGroupSchema*>(tableSchema);
         auto relTableIDs = relTableGroupSchema->getRelTableIDs();
-        catalogContentForWriteTrx->dropTableSchema(tableID);
+        readWriteVersion->dropTableSchema(tableID);
         for (auto relTableID : relTableIDs) {
             wal->logDropTableRecord(relTableID);
         }
     } break;
     default: {
-        catalogContentForWriteTrx->dropTableSchema(tableID);
+        readWriteVersion->dropTableSchema(tableID);
         wal->logDropTableRecord(tableID);
     }
     }
 }
 
 void Catalog::renameTable(table_id_t tableID, const std::string& newName) {
-    initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->renameTable(tableID, newName);
+    KU_ASSERT(readWriteVersion != nullptr);
+    readWriteVersion->renameTable(tableID, newName);
 }
 
 void Catalog::addNodeProperty(
     table_id_t tableID, const std::string& propertyName, std::unique_ptr<LogicalType> dataType) {
-    initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->getTableSchema(tableID)->addNodeProperty(
-        propertyName, std::move(dataType));
+    KU_ASSERT(readWriteVersion != nullptr);
+    readWriteVersion->getTableSchema(tableID)->addNodeProperty(propertyName, std::move(dataType));
 }
 
 void Catalog::addRelProperty(
     table_id_t tableID, const std::string& propertyName, std::unique_ptr<LogicalType> dataType) {
-    initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->getTableSchema(tableID)->addRelProperty(
-        propertyName, std::move(dataType));
+    KU_ASSERT(readWriteVersion != nullptr);
+    readWriteVersion->getTableSchema(tableID)->addRelProperty(propertyName, std::move(dataType));
 }
 
 void Catalog::dropProperty(table_id_t tableID, property_id_t propertyID) {
-    initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->getTableSchema(tableID)->dropProperty(propertyID);
+    KU_ASSERT(readWriteVersion != nullptr);
+    readWriteVersion->getTableSchema(tableID)->dropProperty(propertyID);
     wal->logDropPropertyRecord(tableID, propertyID);
 }
 
 void Catalog::renameProperty(
     table_id_t tableID, property_id_t propertyID, const std::string& newName) {
-    initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->getTableSchema(tableID)->renameProperty(propertyID, newName);
+    KU_ASSERT(readWriteVersion != nullptr);
+    readWriteVersion->getTableSchema(tableID)->renameProperty(propertyID, newName);
 }
 
 void Catalog::addFunction(std::string name, function::function_set functionSet) {
-    catalogContentForReadOnlyTrx->addFunction(std::move(name), std::move(functionSet));
+    readOnlyVersion->addFunction(std::move(name), std::move(functionSet));
+}
+
+bool Catalog::containsMacro(Transaction* tx, const std::string& macroName) const {
+    return getVersion(tx)->containMacro(macroName);
 }
 
 void Catalog::addScalarMacroFunction(
     std::string name, std::unique_ptr<function::ScalarMacroFunction> macro) {
-    initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->addScalarMacroFunction(std::move(name), std::move(macro));
+    KU_ASSERT(readWriteVersion != nullptr);
+    readWriteVersion->addScalarMacroFunction(std::move(name), std::move(macro));
 }
 
 void Catalog::setTableComment(table_id_t tableID, const std::string& comment) {
-    initCatalogContentForWriteTrxIfNecessary();
-    catalogContentForWriteTrx->getTableSchema(tableID)->setComment(comment);
+    KU_ASSERT(readWriteVersion != nullptr);
+    readWriteVersion->getTableSchema(tableID)->setComment(comment);
+}
+
+CatalogContent* Catalog::getVersion(Transaction* tx) const {
+    return tx->getType() == TransactionType::READ_ONLY ? readOnlyVersion.get() :
+                                                         readWriteVersion.get();
 }
 
 } // namespace catalog

--- a/src/include/catalog/catalog_content.h
+++ b/src/include/catalog/catalog_content.h
@@ -3,7 +3,6 @@
 #include "binder/ddl/bound_create_table_info.h"
 #include "function/built_in_function.h"
 #include "function/scalar_macro_function.h"
-#include "storage/storage_info.h"
 #include "table_schema.h"
 
 namespace kuzu {
@@ -31,104 +30,45 @@ public:
           nextTableID{nextTableID}, builtInFunctions{std::move(builtInFunctions)}, macros{std::move(
                                                                                        macros)} {}
 
-    /*
-     * Single schema lookup.
-     * */
-    inline bool containsTable(const std::string& tableName) const {
-        return tableNameToIDMap.contains(tableName);
-    }
-    inline bool containsNodeTable(const std::string& tableName) const {
-        return containsTable(tableName, common::TableType::NODE);
-    }
-    inline bool containsRelTable(const std::string& tableName) const {
-        return containsTable(tableName, common::TableType::REL);
-    }
-    inline std::string getTableName(common::table_id_t tableID) const {
-        KU_ASSERT(tableSchemas.contains(tableID));
-        return getTableSchema(tableID)->tableName;
-    }
-    inline TableSchema* getTableSchema(common::table_id_t tableID) const {
-        KU_ASSERT(tableSchemas.contains(tableID));
-        return tableSchemas.at(tableID).get();
-    }
-    inline common::table_id_t getTableID(const std::string& tableName) const {
-        KU_ASSERT(tableNameToIDMap.contains(tableName));
-        return tableNameToIDMap.at(tableName);
-    }
-
-    /*
-     * Batch schema lookup.
-     * */
-    inline uint64_t getTableCount() const { return tableSchemas.size(); }
-    inline bool containsNodeTable() const { return containsTable(common::TableType::NODE); }
-    inline bool containsRelTable() const { return containsTable(common::TableType::REL); }
-    inline bool containsRdfGraph() const { return containsTable(common::TableType::RDF); }
-    inline std::vector<common::table_id_t> getNodeTableIDs() const {
-        return getTableIDs(common::TableType::NODE);
-    }
-    inline std::vector<common::table_id_t> getRelTableIDs() const {
-        return getTableIDs(common::TableType::REL);
-    }
-    inline std::vector<common::table_id_t> getRdfGraphIDs() const {
-        return getTableIDs(common::TableType::RDF);
-    }
-    inline std::vector<TableSchema*> getNodeTableSchemas() const {
-        return getTableSchemas(common::TableType::NODE);
-    }
-    inline std::vector<TableSchema*> getRelTableSchemas() const {
-        return getTableSchemas(common::TableType::REL);
-    }
-    inline std::vector<TableSchema*> getRelTableGroupSchemas() const {
-        return getTableSchemas(common::TableType::REL_GROUP);
-    }
-
-    std::vector<TableSchema*> getTableSchemas() const;
-    std::vector<TableSchema*> getTableSchemas(
-        const std::vector<common::table_id_t>& tableIDs) const;
-
-    /**
-     * Add schema.
-     */
-    common::table_id_t addNodeTableSchema(const binder::BoundCreateTableInfo& info);
-    common::table_id_t addRelTableSchema(const binder::BoundCreateTableInfo& info);
-    common::table_id_t addRelTableGroupSchema(const binder::BoundCreateTableInfo& info);
-    common::table_id_t addRdfGraphSchema(const binder::BoundCreateTableInfo& info);
-
-    inline bool containMacro(const std::string& macroName) const {
-        return macros.contains(macroName);
-    }
-
-    void dropTableSchema(common::table_id_t tableID);
-
-    void renameTable(common::table_id_t tableID, const std::string& newName);
-
     void saveToFile(const std::string& directory, common::FileVersionType dbFileType);
     void readFromFile(const std::string& directory, common::FileVersionType dbFileType);
-
-    common::ExpressionType getFunctionType(const std::string& name) const;
-
-    void addFunction(std::string name, function::function_set definitions);
-
-    void addScalarMacroFunction(
-        std::string name, std::unique_ptr<function::ScalarMacroFunction> macro);
 
     std::unique_ptr<CatalogContent> copy() const;
 
 private:
-    inline common::table_id_t assignNextTableID() { return nextTableID++; }
-
-    static void validateStorageVersion(storage::storage_version_t savedStorageVersion);
-
-    static void validateMagicBytes(common::Deserializer& deserializer);
-
-    static void writeMagicBytes(common::Serializer& serializer);
+    // ----------------------------- Functions ----------------------------
+    common::ExpressionType getFunctionType(const std::string& name) const;
 
     void registerBuiltInFunctions();
 
-    bool containsTable(const std::string& tableName, common::TableType tableType) const;
+    inline bool containMacro(const std::string& macroName) const {
+        return macros.contains(macroName);
+    }
+    void addFunction(std::string name, function::function_set definitions);
+    void addScalarMacroFunction(
+        std::string name, std::unique_ptr<function::ScalarMacroFunction> macro);
+
+    // ----------------------------- Table Schemas ----------------------------
+    inline common::table_id_t assignNextTableID() { return nextTableID++; }
+    inline uint64_t getTableCount() const { return tableSchemas.size(); }
+
+    bool containsTable(const std::string& tableName) const;
     bool containsTable(common::TableType tableType) const;
+
+    std::string getTableName(common::table_id_t tableID) const;
+
+    TableSchema* getTableSchema(common::table_id_t tableID) const;
     std::vector<TableSchema*> getTableSchemas(common::TableType tableType) const;
+
+    common::table_id_t getTableID(const std::string& tableName) const;
     std::vector<common::table_id_t> getTableIDs(common::TableType tableType) const;
+
+    common::table_id_t addNodeTableSchema(const binder::BoundCreateTableInfo& info);
+    common::table_id_t addRelTableSchema(const binder::BoundCreateTableInfo& info);
+    common::table_id_t addRelTableGroupSchema(const binder::BoundCreateTableInfo& info);
+    common::table_id_t addRdfGraphSchema(const binder::BoundCreateTableInfo& info);
+    void dropTableSchema(common::table_id_t tableID);
+    void renameTable(common::table_id_t tableID, const std::string& newName);
 
 private:
     // TODO(Guodong): I don't think it's necessary to keep separate maps for node and rel tables.

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -5,7 +5,7 @@
 
 namespace kuzu {
 namespace catalog {
-class CatalogContent;
+class Catalog;
 } // namespace catalog
 namespace common {
 class ValueVector;
@@ -46,8 +46,8 @@ struct TableFunctionInitInput {
     virtual ~TableFunctionInitInput() = default;
 };
 
-typedef std::unique_ptr<TableFuncBindData> (*table_func_bind_t)(main::ClientContext* /*context*/,
-    TableFuncBindInput* /*input*/, catalog::CatalogContent* /*catalog*/);
+typedef std::unique_ptr<TableFuncBindData> (*table_func_bind_t)(
+    main::ClientContext* /*context*/, TableFuncBindInput* /*input*/, catalog::Catalog* /*catalog*/);
 typedef void (*table_func_t)(TableFunctionInput& data, common::DataChunk& output);
 typedef std::unique_ptr<TableFuncSharedState> (*table_func_init_shared_t)(
     TableFunctionInitInput& input);

--- a/src/include/function/table_functions/call_functions.h
+++ b/src/include/function/table_functions/call_functions.h
@@ -72,8 +72,8 @@ struct CurrentSettingFunction : public CallFunction {
 
     static void tableFunc(TableFunctionInput& data, common::DataChunk& outputChunk);
 
-    static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
-        TableFuncBindInput* input, catalog::CatalogContent* /*catalog*/);
+    static std::unique_ptr<TableFuncBindData> bindFunc(
+        main::ClientContext* context, TableFuncBindInput* input, catalog::Catalog* /*catalog*/);
 };
 
 struct DBVersionFunction : public CallFunction {
@@ -82,7 +82,7 @@ struct DBVersionFunction : public CallFunction {
     static void tableFunc(TableFunctionInput& input, common::DataChunk& outputChunk);
 
     static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        TableFuncBindInput* /*input*/, catalog::CatalogContent* /*catalog*/);
+        TableFuncBindInput* /*input*/, catalog::Catalog* /*catalog*/);
 };
 
 struct ShowTablesBindData : public CallTableFuncBindData {
@@ -105,8 +105,8 @@ struct ShowTablesFunction : public CallFunction {
 
     static void tableFunc(TableFunctionInput& input, common::DataChunk& outputChunk);
 
-    static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        TableFuncBindInput* /*input*/, catalog::CatalogContent* catalog);
+    static std::unique_ptr<TableFuncBindData> bindFunc(
+        main::ClientContext* /*context*/, TableFuncBindInput* /*input*/, catalog::Catalog* catalog);
 };
 
 struct TableInfoBindData : public CallTableFuncBindData {
@@ -129,14 +129,14 @@ struct TableInfoFunction : public CallFunction {
 
     static void tableFunc(TableFunctionInput& input, common::DataChunk& outputChunk);
 
-    static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        TableFuncBindInput* input, catalog::CatalogContent* catalog);
+    static std::unique_ptr<TableFuncBindData> bindFunc(
+        main::ClientContext* /*context*/, TableFuncBindInput* input, catalog::Catalog* catalog);
 };
 
 struct ShowConnectionBindData : public TableInfoBindData {
-    catalog::CatalogContent* catalog;
+    catalog::Catalog* catalog;
 
-    ShowConnectionBindData(catalog::CatalogContent* catalog, catalog::TableSchema* tableSchema,
+    ShowConnectionBindData(catalog::Catalog* catalog, catalog::TableSchema* tableSchema,
         std::vector<std::unique_ptr<common::LogicalType>> returnTypes,
         std::vector<std::string> returnColumnNames, common::offset_t maxOffset)
         : catalog{catalog}, TableInfoBindData{tableSchema, std::move(returnTypes),
@@ -152,13 +152,13 @@ struct ShowConnectionFunction : public CallFunction {
     static function_set getFunctionSet();
 
     static void outputRelTableConnection(common::ValueVector* srcTableNameVector,
-        common::ValueVector* dstTableNameVector, uint64_t outputPos,
-        catalog::CatalogContent* catalog, common::table_id_t tableID);
+        common::ValueVector* dstTableNameVector, uint64_t outputPos, catalog::Catalog* catalog,
+        common::table_id_t tableID);
 
     static void tableFunc(TableFunctionInput& input, common::DataChunk& outputChunk);
 
-    static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        TableFuncBindInput* input, catalog::CatalogContent* catalog);
+    static std::unique_ptr<TableFuncBindData> bindFunc(
+        main::ClientContext* /*context*/, TableFuncBindInput* input, catalog::Catalog* catalog);
 };
 
 } // namespace function

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -61,7 +61,7 @@ public:
 
     std::string getCurrentSetting(const std::string& optionName);
 
-    transaction::Transaction* getActiveTransaction() const;
+    transaction::Transaction* getTx() const;
     transaction::TransactionContext* getTransactionContext() const;
 
     inline void setReplaceFunc(replace_func_t replaceFunc) {

--- a/src/include/parser/statement.h
+++ b/src/include/parser/statement.h
@@ -13,12 +13,8 @@ public:
 
     inline common::StatementType getStatementType() const { return statementType; }
 
-    inline void enableProfile() { profile = true; }
-    inline bool isProfile() const { return profile; }
-
 private:
     common::StatementType statementType;
-    bool profile = false;
 };
 
 } // namespace parser

--- a/src/include/processor/operator/ddl/add_node_property.h
+++ b/src/include/processor/operator/ddl/add_node_property.h
@@ -5,7 +5,7 @@
 namespace kuzu {
 namespace processor {
 
-class AddNodeProperty : public AddProperty {
+class AddNodeProperty final : public AddProperty {
 public:
     AddNodeProperty(catalog::Catalog* catalog, common::table_id_t tableID, std::string propertyName,
         std::unique_ptr<common::LogicalType> dataType,
@@ -15,7 +15,7 @@ public:
         : AddProperty{catalog, tableID, std::move(propertyName), std::move(dataType),
               std::move(defaultValueEvaluator), storageManager, outputPos, id, paramsString} {}
 
-    void executeDDLInternal() final;
+    void executeDDLInternal(ExecutionContext* context) final;
 
     std::unique_ptr<PhysicalOperator> clone() override {
         return make_unique<AddNodeProperty>(catalog, tableID, propertyName, dataType->copy(),

--- a/src/include/processor/operator/ddl/add_property.h
+++ b/src/include/processor/operator/ddl/add_property.h
@@ -23,7 +23,7 @@ public:
         defaultValueEvaluator->init(*resultSet, context->memoryManager);
     }
 
-    void executeDDLInternal() override = 0;
+    void executeDDLInternal(ExecutionContext* context) override = 0;
 
     std::string getOutputMsg() override { return {"Add Succeed."}; }
 

--- a/src/include/processor/operator/ddl/add_rel_property.h
+++ b/src/include/processor/operator/ddl/add_rel_property.h
@@ -5,9 +5,7 @@
 namespace kuzu {
 namespace processor {
 
-class AddRelProperty;
-
-class AddRelProperty : public AddProperty {
+class AddRelProperty final : public AddProperty {
 public:
     AddRelProperty(catalog::Catalog* catalog, common::table_id_t tableID, std::string propertyName,
         std::unique_ptr<common::LogicalType> dataType,
@@ -17,7 +15,7 @@ public:
         : AddProperty(catalog, tableID, std::move(propertyName), std::move(dataType),
               std::move(expressionEvaluator), storageManager, outputPos, id, paramsString) {}
 
-    void executeDDLInternal() override;
+    void executeDDLInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
         return make_unique<AddRelProperty>(catalog, tableID, propertyName, dataType->copy(),

--- a/src/include/processor/operator/ddl/create_node_table.h
+++ b/src/include/processor/operator/ddl/create_node_table.h
@@ -13,7 +13,7 @@ public:
         : DDL{PhysicalOperatorType::CREATE_NODE_TABLE, catalog, outputPos, id, paramsString},
           storageManager{storageManager}, info{std::move(info)} {}
 
-    void executeDDLInternal() final;
+    void executeDDLInternal(ExecutionContext* context) final;
 
     std::string getOutputMsg() final;
 

--- a/src/include/processor/operator/ddl/create_rdf_graph.h
+++ b/src/include/processor/operator/ddl/create_rdf_graph.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace processor {
 
-class CreateRdfGraph : public DDL {
+class CreateRdfGraph final : public DDL {
 public:
     CreateRdfGraph(catalog::Catalog* catalog, storage::StorageManager* storageManager,
         std::unique_ptr<binder::BoundCreateTableInfo> info, const DataPos& outputPos, uint32_t id,
@@ -16,11 +16,11 @@ public:
           nodesStatistics{storageManager->getNodesStatisticsAndDeletedIDs()},
           relsStatistics{storageManager->getRelsStatistics()}, info{std::move(info)} {}
 
-    void executeDDLInternal() final;
+    void executeDDLInternal(ExecutionContext* context) override;
 
-    std::string getOutputMsg() final;
+    std::string getOutputMsg() override;
 
-    inline std::unique_ptr<PhysicalOperator> clone() final {
+    inline std::unique_ptr<PhysicalOperator> clone() override {
         return std::make_unique<CreateRdfGraph>(
             catalog, storageManager, info->copy(), outputPos, id, paramsString);
     }

--- a/src/include/processor/operator/ddl/create_rel_table.h
+++ b/src/include/processor/operator/ddl/create_rel_table.h
@@ -5,7 +5,7 @@
 namespace kuzu {
 namespace processor {
 
-class CreateRelTable : public DDL {
+class CreateRelTable final : public DDL {
 public:
     CreateRelTable(catalog::Catalog* catalog, storage::StorageManager* storageManager,
         std::unique_ptr<binder::BoundCreateTableInfo> info, const DataPos& outputPos, uint32_t id,
@@ -13,7 +13,7 @@ public:
         : DDL{PhysicalOperatorType::CREATE_REL_TABLE, catalog, outputPos, id, paramsString},
           storageManager{storageManager}, info{std::move(info)} {}
 
-    void executeDDLInternal() override;
+    void executeDDLInternal(ExecutionContext* context) override;
 
     std::string getOutputMsg() override;
 

--- a/src/include/processor/operator/ddl/create_rel_table_group.h
+++ b/src/include/processor/operator/ddl/create_rel_table_group.h
@@ -13,7 +13,7 @@ public:
         : DDL{PhysicalOperatorType::CREATE_REL_TABLE, catalog, outputPos, id, paramsString},
           info{std::move(info)}, storageManager{storageManager} {}
 
-    void executeDDLInternal() override;
+    void executeDDLInternal(ExecutionContext* context) override;
 
     std::string getOutputMsg() override;
 

--- a/src/include/processor/operator/ddl/ddl.h
+++ b/src/include/processor/operator/ddl/ddl.h
@@ -22,7 +22,7 @@ public:
 
 protected:
     virtual std::string getOutputMsg() = 0;
-    virtual void executeDDLInternal() = 0;
+    virtual void executeDDLInternal(ExecutionContext* context) = 0;
 
 protected:
     catalog::Catalog* catalog;

--- a/src/include/processor/operator/ddl/drop_property.h
+++ b/src/include/processor/operator/ddl/drop_property.h
@@ -14,7 +14,7 @@ public:
         : DDL{PhysicalOperatorType::DROP_PROPERTY, catalog, outputPos, id, paramsString},
           storageManager{storageManager}, tableID{tableID}, propertyID{propertyID} {}
 
-    void executeDDLInternal() final;
+    void executeDDLInternal(ExecutionContext* context) final;
 
     std::string getOutputMsg() final { return {"Drop succeed."}; }
 

--- a/src/include/processor/operator/ddl/drop_table.h
+++ b/src/include/processor/operator/ddl/drop_table.h
@@ -7,20 +7,21 @@ namespace processor {
 
 class DropTable : public DDL {
 public:
-    DropTable(catalog::Catalog* catalog, common::table_id_t tableID, const DataPos& outputPos,
-        uint32_t id, const std::string& paramsString)
+    DropTable(catalog::Catalog* catalog, std::string tableName, common::table_id_t tableID,
+        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
         : DDL{PhysicalOperatorType::DROP_TABLE, catalog, outputPos, id, paramsString},
-          tableID{tableID} {}
+          tableName{std::move(tableName)}, tableID{tableID} {}
 
-    void executeDDLInternal() override;
+    void executeDDLInternal(ExecutionContext* context) override;
 
     std::string getOutputMsg() override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<DropTable>(catalog, tableID, outputPos, id, paramsString);
+        return make_unique<DropTable>(catalog, tableName, tableID, outputPos, id, paramsString);
     }
 
 protected:
+    std::string tableName;
     common::table_id_t tableID;
 };
 

--- a/src/include/processor/operator/ddl/rename_property.h
+++ b/src/include/processor/operator/ddl/rename_property.h
@@ -13,7 +13,9 @@ public:
         : DDL{PhysicalOperatorType::RENAME_PROPERTY, catalog, outputPos, id, paramsString},
           tableID{tableID}, propertyID{propertyID}, newName{std::move(newName)} {}
 
-    void executeDDLInternal() override { catalog->renameProperty(tableID, propertyID, newName); }
+    void executeDDLInternal(ExecutionContext* /*context*/) override {
+        catalog->renameProperty(tableID, propertyID, newName);
+    }
 
     std::string getOutputMsg() override { return "Property renamed"; }
 

--- a/src/include/processor/operator/ddl/rename_table.h
+++ b/src/include/processor/operator/ddl/rename_table.h
@@ -5,14 +5,16 @@
 namespace kuzu {
 namespace processor {
 
-class RenameTable : public DDL {
+class RenameTable final : public DDL {
 public:
     RenameTable(catalog::Catalog* catalog, common::table_id_t tableID, std::string newName,
         const DataPos& outputPos, uint32_t id, const std::string& paramsString)
         : DDL{PhysicalOperatorType::RENAME_TABLE, catalog, outputPos, id, paramsString},
           tableID{tableID}, newName{std::move(newName)} {}
 
-    void executeDDLInternal() override { catalog->renameTable(tableID, newName); }
+    void executeDDLInternal(ExecutionContext* /*context*/) override {
+        catalog->renameTable(tableID, newName);
+    }
 
     std::string getOutputMsg() override { return "Table renamed"; }
 

--- a/src/include/processor/operator/persistent/reader/csv/parallel_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/parallel_csv_reader.h
@@ -52,7 +52,7 @@ struct ParallelCSVScan {
     static void tableFunc(function::TableFunctionInput& input, common::DataChunk& outputChunk);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        function::TableFuncBindInput* input, catalog::CatalogContent* /*catalog*/);
+        function::TableFuncBindInput* input, catalog::Catalog* /*catalog*/);
 
     static std::unique_ptr<function::TableFuncSharedState> initSharedState(
         function::TableFunctionInitInput& input);

--- a/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
@@ -44,7 +44,7 @@ struct SerialCSVScan {
     static void tableFunc(function::TableFunctionInput& input, common::DataChunk& outputChunk);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        function::TableFuncBindInput* input, catalog::CatalogContent* /*catalog*/);
+        function::TableFuncBindInput* input, catalog::Catalog* /*catalog*/);
 
     static std::unique_ptr<function::TableFuncSharedState> initSharedState(
         function::TableFunctionInitInput& input);

--- a/src/include/processor/operator/persistent/reader/npy/npy_reader.h
+++ b/src/include/processor/operator/persistent/reader/npy/npy_reader.h
@@ -71,7 +71,7 @@ struct NpyScanFunction {
     static void tableFunc(function::TableFunctionInput& input, common::DataChunk& outputChunk);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        function::TableFuncBindInput* input, catalog::CatalogContent* catalog);
+        function::TableFuncBindInput* input, catalog::Catalog* catalog);
 
     static std::unique_ptr<function::TableFuncSharedState> initSharedState(
         function::TableFunctionInitInput& input);

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -113,7 +113,7 @@ struct ParquetScanFunction {
     static void tableFunc(function::TableFunctionInput& input, common::DataChunk& outputChunk);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        function::TableFuncBindInput* input, catalog::CatalogContent* catalog);
+        function::TableFuncBindInput* input, catalog::Catalog* catalog);
 
     static std::unique_ptr<function::TableFuncSharedState> initSharedState(
         function::TableFunctionInitInput& input);

--- a/src/include/processor/operator/persistent/reader/rdf/rdf_reader.h
+++ b/src/include/processor/operator/persistent/reader/rdf/rdf_reader.h
@@ -60,7 +60,7 @@ struct RdfScan {
     static void tableFunc(function::TableFunctionInput& input, common::DataChunk& outputChunk);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        function::TableFuncBindInput* input, catalog::CatalogContent* /*catalog*/);
+        function::TableFuncBindInput* input, catalog::Catalog* /*catalog*/);
 
     static std::unique_ptr<function::TableFuncSharedState> initSharedState(
         function::TableFunctionInitInput& input);

--- a/src/include/processor/operator/scan_node_id.h
+++ b/src/include/processor/operator/scan_node_id.h
@@ -74,7 +74,7 @@ public:
 
 private:
     inline void initGlobalStateInternal(ExecutionContext* context) override {
-        sharedState->initialize(context->clientContext->getActiveTransaction());
+        sharedState->initialize(context->clientContext->getTx());
     }
 
     void setSelVector(

--- a/src/include/storage/stats/table_statistics_collection.h
+++ b/src/include/storage/stats/table_statistics_collection.h
@@ -65,6 +65,8 @@ public:
     static std::unique_ptr<MetadataDAHInfo> createMetadataDAHInfo(
         const common::LogicalType& dataType, BMFileHandle& metadataFH, BufferManager* bm, WAL* wal);
 
+    void initTableStatisticsForWriteTrx();
+
 protected:
     virtual std::unique_ptr<TableStatistics> constructTableStatistic(
         catalog::TableSchema* tableSchema) = 0;
@@ -81,7 +83,6 @@ protected:
     void saveToFile(const std::string& directory, common::FileVersionType dbFileType,
         transaction::TransactionType transactionType);
 
-    void initTableStatisticsForWriteTrx();
     void initTableStatisticsForWriteTrxNoLock();
 
 protected:

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -16,7 +16,8 @@ public:
     StorageManager(bool readOnly, const catalog::Catalog& catalog, MemoryManager& memoryManager,
         WAL* wal, bool enableCompression);
 
-    void createTable(common::table_id_t tableID, catalog::Catalog* catalog);
+    void createTable(common::table_id_t tableID, catalog::Catalog* catalog,
+        transaction::Transaction* transaction);
     void dropTable(common::table_id_t tableID);
 
     void prepareCommit(transaction::Transaction* transaction);
@@ -41,6 +42,10 @@ public:
     inline WAL* getWAL() const { return wal; }
     inline BMFileHandle* getDataFH() const { return dataFH.get(); }
     inline BMFileHandle* getMetadataFH() const { return metadataFH.get(); }
+    inline void initStatistics() {
+        nodesStatisticsAndDeletedIDs->initTableStatisticsForWriteTrx();
+        relsStatistics->initTableStatisticsForWriteTrx();
+    }
     inline NodesStoreStatsAndDeletedIDs* getNodesStatisticsAndDeletedIDs() {
         return nodesStatisticsAndDeletedIDs.get();
     }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -43,7 +43,7 @@ std::string ClientContext::getCurrentSetting(const std::string& optionName) {
     return option->getSetting(this);
 }
 
-Transaction* ClientContext::getActiveTransaction() const {
+transaction::Transaction* ClientContext::getTx() const {
     return transactionContext->getActiveTransaction();
 }
 

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -16,9 +16,9 @@ StorageDriver::StorageDriver(Database* database)
 void StorageDriver::scan(const std::string& nodeName, const std::string& propertyName,
     offset_t* offsets, size_t size, uint8_t* result, size_t numThreads) {
     // Resolve files to read from
-    auto catalogContent = catalog->getReadOnlyVersion();
-    auto nodeTableID = catalogContent->getTableID(nodeName);
-    auto propertyID = catalogContent->getTableSchema(nodeTableID)->getPropertyID(propertyName);
+    auto nodeTableID = catalog->getTableID(&DUMMY_READ_TRANSACTION, nodeName);
+    auto propertyID =
+        catalog->getTableSchema(&DUMMY_READ_TRANSACTION, nodeTableID)->getPropertyID(propertyName);
     auto nodeTable = storageManager->getNodeTable(nodeTableID);
     auto column = nodeTable->getColumn(propertyID);
     auto current_buffer = result;
@@ -40,8 +40,7 @@ void StorageDriver::scan(const std::string& nodeName, const std::string& propert
 }
 
 uint64_t StorageDriver::getNumNodes(const std::string& nodeName) {
-    auto catalogContent = catalog->getReadOnlyVersion();
-    auto nodeTableID = catalogContent->getTableID(nodeName);
+    auto nodeTableID = catalog->getTableID(&DUMMY_READ_TRANSACTION, nodeName);
     auto nodeStatistics =
         storageManager->getNodesStatisticsAndDeletedIDs()->getNodeStatisticsAndDeletedIDs(
             nodeTableID);
@@ -49,8 +48,7 @@ uint64_t StorageDriver::getNumNodes(const std::string& nodeName) {
 }
 
 uint64_t StorageDriver::getNumRels(const std::string& relName) {
-    auto catalogContent = catalog->getReadOnlyVersion();
-    auto relTableID = catalogContent->getTableID(relName);
+    auto relTableID = catalog->getTableID(&DUMMY_READ_TRANSACTION, relName);
     auto relStatistics = storageManager->getRelsStatistics()->getRelStatistics(
         relTableID, Transaction::getDummyReadOnlyTrx().get());
     return relStatistics->getNumTuples();

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -9,10 +9,12 @@
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/logical_node_label_filter.h"
 #include "planner/query_planner.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
 using namespace kuzu::catalog;
+using namespace kuzu::transaction;
 
 namespace kuzu {
 namespace planner {
@@ -30,7 +32,7 @@ static bool extendHasAtMostOneNbrGuarantee(RelExpression& rel, NodeExpression& b
     }
     auto relDirection = ExtendDirectionUtils::getRelDataDirection(direction);
     auto relTableSchema = reinterpret_cast<RelTableSchema*>(
-        catalog.getReadOnlyVersion()->getTableSchema(rel.getSingleTableID()));
+        catalog.getTableSchema(&DUMMY_READ_TRANSACTION, rel.getSingleTableID()));
     return relTableSchema->isSingleMultiplicityInDirection(relDirection);
 }
 
@@ -39,7 +41,7 @@ static std::unordered_set<table_id_t> getBoundNodeTableIDSet(
     std::unordered_set<table_id_t> result;
     for (auto tableID : rel.getTableIDs()) {
         auto tableSchema = reinterpret_cast<RelTableSchema*>(
-            catalog.getReadOnlyVersion()->getTableSchema(tableID));
+            catalog.getTableSchema(&DUMMY_READ_TRANSACTION, tableID));
         switch (extendDirection) {
         case ExtendDirection::FWD: {
             result.insert(tableSchema->getBoundTableID(RelDataDirection::FWD));
@@ -63,7 +65,7 @@ static std::unordered_set<table_id_t> getNbrNodeTableIDSet(
     std::unordered_set<table_id_t> result;
     for (auto tableID : rel.getTableIDs()) {
         auto tableSchema = reinterpret_cast<RelTableSchema*>(
-            catalog.getReadOnlyVersion()->getTableSchema(tableID));
+            catalog.getTableSchema(&DUMMY_READ_TRANSACTION, tableID));
         switch (extendDirection) {
         case ExtendDirection::FWD: {
             result.insert(tableSchema->getNbrTableID(RelDataDirection::FWD));

--- a/src/processor/map/map_insert.cpp
+++ b/src/processor/map/map_insert.cpp
@@ -2,6 +2,7 @@
 #include "planner/operator/persistent/logical_insert.h"
 #include "processor/operator/persistent/insert.h"
 #include "processor/plan_mapper.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::evaluator;
 using namespace kuzu::planner;
@@ -32,7 +33,7 @@ std::unique_ptr<NodeInsertExecutor> PlanMapper::getNodeInsertExecutor(
     auto table = storageManager.getNodeTable(nodeTableID);
     std::unordered_set<RelTable*> fwdRelTablesToInit;
     std::unordered_set<RelTable*> bwdRelTablesToInit;
-    auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(nodeTableID);
+    auto tableSchema = catalog->getTableSchema(&transaction::DUMMY_READ_TRANSACTION, nodeTableID);
     auto nodeTableSchema =
         common::ku_dynamic_cast<catalog::TableSchema*, catalog::NodeTableSchema*>(tableSchema);
     auto fwdRelTableIDs = nodeTableSchema->getFwdRelTableIDSet();

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -1,6 +1,7 @@
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "processor/operator/recursive_extend/recursive_join.h"
 #include "processor/plan_mapper.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::planner;
@@ -48,7 +49,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(
         pathPos = DataPos(outSchema->getExpressionPos(*rel));
     }
     std::unordered_map<common::table_id_t, std::string> tableIDToName;
-    for (auto& schema : catalog->getReadOnlyVersion()->getTableSchemas()) {
+    for (auto& schema : catalog->getTableSchemas(&transaction::DUMMY_READ_TRANSACTION)) {
         tableIDToName.insert({schema->getTableID(), schema->tableName});
     }
     auto dataInfo = std::make_unique<RecursiveJoinDataInfo>(boundNodeIDPos, nbrNodeIDPos,

--- a/src/processor/map/map_scan_node_property.cpp
+++ b/src/processor/map/map_scan_node_property.cpp
@@ -2,6 +2,7 @@
 #include "planner/operator/scan/logical_scan_node_property.h"
 #include "processor/operator/scan/scan_multi_node_tables.h"
 #include "processor/plan_mapper.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -32,8 +33,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeProperty(
                     columns.push_back(UINT32_MAX);
                 } else {
                     columns.push_back(
-                        catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(
-                            property->getPropertyID(tableID)));
+                        catalog->getTableSchema(&transaction::DUMMY_READ_TRANSACTION, tableID)
+                            ->getColumnID(property->getPropertyID(tableID)));
                 }
             }
             tables.insert({tableID, std::make_unique<ScanNodeTableInfo>(
@@ -44,7 +45,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeProperty(
             scanProperty.getExpressionsForPrinting());
     } else {
         auto tableID = tableIDs[0];
-        auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(tableID);
+        auto tableSchema = catalog->getTableSchema(&transaction::DUMMY_READ_TRANSACTION, tableID);
         std::vector<column_id_t> columnIDs;
         for (auto& expression : scanProperty.getProperties()) {
             auto property = static_pointer_cast<PropertyExpression>(expression);

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -3,11 +3,13 @@
 #include "planner/operator/persistent/logical_set.h"
 #include "processor/operator/persistent/set.h"
 #include "processor/plan_mapper.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
 using namespace kuzu::planner;
 using namespace kuzu::evaluator;
+using namespace kuzu::transaction;
 
 namespace kuzu {
 namespace processor {
@@ -31,7 +33,7 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
             auto propertyID = property->getPropertyID(tableID);
             auto table = storageManager.getNodeTable(tableID);
             auto columnID =
-                catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(propertyID);
+                catalog->getTableSchema(&DUMMY_READ_TRANSACTION, tableID)->getColumnID(propertyID);
             tableIDToSetInfo.insert({tableID, NodeSetInfo{table, columnID}});
         }
         return std::make_unique<MultiLabelNodeSetExecutor>(
@@ -43,7 +45,7 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
         if (property->hasPropertyID(tableID)) {
             auto propertyID = property->getPropertyID(tableID);
             columnID =
-                catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(propertyID);
+                catalog->getTableSchema(&DUMMY_READ_TRANSACTION, tableID)->getColumnID(propertyID);
         }
         return std::make_unique<SingleLabelNodeSetExecutor>(
             NodeSetInfo{table, columnID}, nodeIDPos, propertyPos, std::move(evaluator));
@@ -84,7 +86,7 @@ std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(
             auto table = storageManager.getRelTable(tableID);
             auto propertyID = property->getPropertyID(tableID);
             auto columnID =
-                catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(propertyID);
+                catalog->getTableSchema(&DUMMY_READ_TRANSACTION, tableID)->getColumnID(propertyID);
             tableIDToTableAndColumnID.insert({tableID, std::make_pair(table, columnID)});
         }
         return std::make_unique<MultiLabelRelSetExecutor>(std::move(tableIDToTableAndColumnID),
@@ -96,7 +98,7 @@ std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(
         if (property->hasPropertyID(tableID)) {
             auto propertyID = property->getPropertyID(tableID);
             columnID =
-                catalog->getReadOnlyVersion()->getTableSchema(tableID)->getColumnID(propertyID);
+                catalog->getTableSchema(&DUMMY_READ_TRANSACTION, tableID)->getColumnID(propertyID);
         }
         return std::make_unique<SingleLabelRelSetExecutor>(
             table, columnID, srcNodePos, dstNodePos, relIDPos, propertyPos, std::move(evaluator));

--- a/src/processor/operator/ddl/add_node_property.cpp
+++ b/src/processor/operator/ddl/add_node_property.cpp
@@ -3,9 +3,9 @@
 namespace kuzu {
 namespace processor {
 
-void AddNodeProperty::executeDDLInternal() {
+void AddNodeProperty::executeDDLInternal(ExecutionContext* context) {
     catalog->addNodeProperty(tableID, propertyName, std::move(dataType));
-    auto schema = catalog->getWriteVersion()->getTableSchema(tableID);
+    auto schema = catalog->getTableSchema(context->clientContext->getTx(), tableID);
     auto addedPropID = schema->getPropertyID(propertyName);
     auto addedProp = schema->getProperty(addedPropID);
     storageManager.getNodeTable(tableID)->addColumn(transaction, *addedProp, getDefaultValVector());

--- a/src/processor/operator/ddl/add_rel_property.cpp
+++ b/src/processor/operator/ddl/add_rel_property.cpp
@@ -7,12 +7,11 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-void AddRelProperty::executeDDLInternal() {
+void AddRelProperty::executeDDLInternal(ExecutionContext* context) {
     catalog->addRelProperty(tableID, propertyName, dataType->copy());
-    auto tableSchema = catalog->getWriteVersion()->getTableSchema(tableID);
+    auto tableSchema = catalog->getTableSchema(context->clientContext->getTx(), tableID);
     auto addedPropertyID = tableSchema->getPropertyID(propertyName);
-    auto addedProp =
-        catalog->getWriteVersion()->getTableSchema(tableID)->getProperty(addedPropertyID);
+    auto addedProp = tableSchema->getProperty(addedPropertyID);
     storageManager.getRelTable(tableID)->addColumn(transaction, *addedProp, getDefaultValVector());
     storageManager.getWAL()->logAddPropertyRecord(tableID, addedProp->getPropertyID());
 }

--- a/src/processor/operator/ddl/create_node_table.cpp
+++ b/src/processor/operator/ddl/create_node_table.cpp
@@ -10,10 +10,10 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-void CreateNodeTable::executeDDLInternal() {
+void CreateNodeTable::executeDDLInternal(ExecutionContext* context) {
     auto newTableID = catalog->addNodeTableSchema(*info);
-    auto newNodeTableSchema =
-        reinterpret_cast<NodeTableSchema*>(catalog->getWriteVersion()->getTableSchema(newTableID));
+    auto newNodeTableSchema = reinterpret_cast<NodeTableSchema*>(
+        catalog->getTableSchema(context->clientContext->getTx(), newTableID));
     storageManager->getNodesStatisticsAndDeletedIDs()->addNodeStatisticsAndDeletedIDs(
         newNodeTableSchema);
     storageManager->getWAL()->logCreateNodeTableRecord(newTableID);

--- a/src/processor/operator/ddl/create_rdf_graph.cpp
+++ b/src/processor/operator/ddl/create_rdf_graph.cpp
@@ -9,26 +9,26 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace processor {
 
-void CreateRdfGraph::executeDDLInternal() {
+void CreateRdfGraph::executeDDLInternal(ExecutionContext* context) {
+    auto tx = context->clientContext->getTx();
     auto newRdfGraphID = catalog->addRdfGraphSchema(*info);
-    auto writeCatalog = catalog->getWriteVersion();
     auto rdfGraphSchema =
-        reinterpret_cast<RdfGraphSchema*>(writeCatalog->getTableSchema(newRdfGraphID));
+        reinterpret_cast<RdfGraphSchema*>(catalog->getTableSchema(tx, newRdfGraphID));
     auto resourceTableID = rdfGraphSchema->getResourceTableID();
     auto resourceTableSchema =
-        reinterpret_cast<NodeTableSchema*>(writeCatalog->getTableSchema(resourceTableID));
+        reinterpret_cast<NodeTableSchema*>(catalog->getTableSchema(tx, resourceTableID));
     nodesStatistics->addNodeStatisticsAndDeletedIDs(resourceTableSchema);
     auto literalTableID = rdfGraphSchema->getLiteralTableID();
     auto literalTableSchema =
-        reinterpret_cast<NodeTableSchema*>(writeCatalog->getTableSchema(literalTableID));
+        reinterpret_cast<NodeTableSchema*>(catalog->getTableSchema(tx, literalTableID));
     nodesStatistics->addNodeStatisticsAndDeletedIDs(literalTableSchema);
     auto resourceTripleTableID = rdfGraphSchema->getResourceTripleTableID();
     auto resourceTripleTableSchema =
-        reinterpret_cast<RelTableSchema*>(writeCatalog->getTableSchema(resourceTripleTableID));
+        reinterpret_cast<RelTableSchema*>(catalog->getTableSchema(tx, resourceTripleTableID));
     relsStatistics->addTableStatistic(resourceTripleTableSchema);
     auto literalTripleTableID = rdfGraphSchema->getLiteralTripleTableID();
     auto literalTripleTableSchema =
-        reinterpret_cast<RelTableSchema*>(writeCatalog->getTableSchema(literalTripleTableID));
+        reinterpret_cast<RelTableSchema*>(catalog->getTableSchema(tx, literalTripleTableID));
     relsStatistics->addTableStatistic(literalTripleTableSchema);
     storageManager->getWAL()->logRdfGraphRecord(newRdfGraphID, resourceTableID, literalTableID,
         resourceTripleTableID, literalTripleTableID);

--- a/src/processor/operator/ddl/create_rel_table.cpp
+++ b/src/processor/operator/ddl/create_rel_table.cpp
@@ -11,10 +11,10 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace processor {
 
-void CreateRelTable::executeDDLInternal() {
+void CreateRelTable::executeDDLInternal(ExecutionContext* context) {
     auto newRelTableID = catalog->addRelTableSchema(*info);
     auto newRelTableSchema = reinterpret_cast<RelTableSchema*>(
-        catalog->getWriteVersion()->getTableSchema(newRelTableID));
+        catalog->getTableSchema(context->clientContext->getTx(), newRelTableID));
     storageManager->getRelsStatistics()->addTableStatistic(newRelTableSchema);
     storageManager->getWAL()->logCreateRelTableRecord(newRelTableID);
 }

--- a/src/processor/operator/ddl/create_rel_table_group.cpp
+++ b/src/processor/operator/ddl/create_rel_table_group.cpp
@@ -11,13 +11,13 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace processor {
 
-void CreateRelTableGroup::executeDDLInternal() {
+void CreateRelTableGroup::executeDDLInternal(ExecutionContext* context) {
     auto newRelTableGroupID = catalog->addRelTableGroupSchema(*info);
-    auto writeCatalog = catalog->getWriteVersion();
+    auto tx = context->clientContext->getTx();
     auto newRelTableGroupSchema =
-        (RelTableGroupSchema*)writeCatalog->getTableSchema(newRelTableGroupID);
+        reinterpret_cast<RelTableGroupSchema*>(catalog->getTableSchema(tx, newRelTableGroupID));
     for (auto& relTableID : newRelTableGroupSchema->getRelTableIDs()) {
-        auto newRelTableSchema = writeCatalog->getTableSchema(relTableID);
+        auto newRelTableSchema = catalog->getTableSchema(tx, relTableID);
         storageManager->getRelsStatistics()->addTableStatistic((RelTableSchema*)newRelTableSchema);
     }
     // TODO(Ziyi): remove this when we can log variable size record. See also wal_record.h

--- a/src/processor/operator/ddl/ddl.cpp
+++ b/src/processor/operator/ddl/ddl.cpp
@@ -7,12 +7,12 @@ void DDL::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* /*conte
     outputVector = resultSet->getValueVector(outputPos).get();
 }
 
-bool DDL::getNextTuplesInternal(ExecutionContext* /*context*/) {
+bool DDL::getNextTuplesInternal(ExecutionContext* context) {
     if (hasExecuted) {
         return false;
     }
     hasExecuted = true;
-    executeDDLInternal();
+    executeDDLInternal(context);
     outputVector->setValue<std::string>(0, getOutputMsg());
     metrics->numOutputTuple.increase(1);
     return true;

--- a/src/processor/operator/ddl/drop_property.cpp
+++ b/src/processor/operator/ddl/drop_property.cpp
@@ -3,15 +3,16 @@
 namespace kuzu {
 namespace processor {
 
-void DropProperty::executeDDLInternal() {
-    auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(tableID);
+void DropProperty::executeDDLInternal(ExecutionContext* context) {
+    auto tableSchema = catalog->getTableSchema(context->clientContext->getTx(), tableID);
+    auto columnID = tableSchema->getColumnID(propertyID);
     catalog->dropProperty(tableID, propertyID);
     if (tableSchema->tableType == common::TableType::NODE) {
         auto nodesStats = storageManager.getNodesStatisticsAndDeletedIDs();
-        nodesStats->removeMetadataDAHInfo(tableID, tableSchema->getColumnID(propertyID));
+        nodesStats->removeMetadataDAHInfo(tableID, columnID);
     } else {
         auto relsStats = storageManager.getRelsStatistics();
-        relsStats->removeMetadataDAHInfo(tableID, tableSchema->getColumnID(propertyID));
+        relsStats->removeMetadataDAHInfo(tableID, columnID);
     }
 }
 

--- a/src/processor/operator/ddl/drop_table.cpp
+++ b/src/processor/operator/ddl/drop_table.cpp
@@ -8,14 +8,12 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-void DropTable::executeDDLInternal() {
+void DropTable::executeDDLInternal(ExecutionContext* /*context*/) {
     catalog->dropTableSchema(tableID);
 }
 
 std::string DropTable::getOutputMsg() {
-    auto tableSchema = catalog->getReadOnlyVersion()->getTableSchema(tableID);
-    return stringFormat("{} table: {} has been dropped.",
-        tableSchema->tableType == TableType::NODE ? "Node" : "Rel", tableSchema->tableName);
+    return stringFormat("Table: {} has been dropped.", tableName);
 }
 
 } // namespace processor

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -15,7 +15,7 @@ bool IndexLookup::getNextTuplesInternal(ExecutionContext* context) {
     }
     for (auto& info : infos) {
         KU_ASSERT(info);
-        indexLookup(context->clientContext->getActiveTransaction(), *info);
+        indexLookup(context->clientContext->getTx(), *info);
     }
     return true;
 }

--- a/src/processor/operator/persistent/copy_node.cpp
+++ b/src/processor/operator/persistent/copy_node.cpp
@@ -169,12 +169,12 @@ void CopyNode::finalize(ExecutionContext* context) {
     sharedState->table->getNodeStatisticsAndDeletedIDs()->setNumTuplesForTable(
         sharedState->table->getTableID(), numNodes);
     for (auto relTable : info->fwdRelTables) {
-        relTable->resizeColumns(context->clientContext->getActiveTransaction(),
-            RelDataDirection::FWD, sharedState->getCurNodeGroupIdx());
+        relTable->resizeColumns(context->clientContext->getTx(), RelDataDirection::FWD,
+            sharedState->getCurNodeGroupIdx());
     }
     for (auto relTable : info->bwdRelTables) {
-        relTable->resizeColumns(context->clientContext->getActiveTransaction(),
-            RelDataDirection::BWD, sharedState->getCurNodeGroupIdx());
+        relTable->resizeColumns(context->clientContext->getTx(), RelDataDirection::BWD,
+            sharedState->getCurNodeGroupIdx());
     }
     auto outputMsg = stringFormat(
         "{} number of tuples has been copied to table: {}.", numNodes, info->tableName.c_str());

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -25,12 +25,12 @@ static void deleteFromRelTable(ExecutionContext* context, DeleteNodeType deleteT
     RelDetachDeleteState* detachDeleteState) {
     switch (deleteType) {
     case DeleteNodeType::DETACH_DELETE: {
-        relTable->detachDelete(context->clientContext->getActiveTransaction(), direction,
-            nodeIDVector, detachDeleteState);
+        relTable->detachDelete(
+            context->clientContext->getTx(), direction, nodeIDVector, detachDeleteState);
     } break;
     case DeleteNodeType::DELETE: {
         if (relTable->checkIfNodeHasRels(
-                context->clientContext->getActiveTransaction(), direction, nodeIDVector)) {
+                context->clientContext->getTx(), direction, nodeIDVector)) {
             throw RuntimeException(
                 stringFormat("Deleted nodes has connected edges in the {} direction.",
                     RelDataDirectionUtils::relDirectionToString(direction)));
@@ -57,7 +57,7 @@ void SingleLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
         deleteFromRelTable(context, deleteType, RelDataDirection::BWD, relTable, nodeIDVector,
             detachDeleteState.get());
     }
-    table->delete_(context->clientContext->getActiveTransaction(), nodeIDVector, pkVector.get());
+    table->delete_(context->clientContext->getTx(), nodeIDVector, pkVector.get());
 }
 
 void MultiLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
@@ -88,8 +88,8 @@ void MultiLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
         deleteFromRelTable(context, deleteType, RelDataDirection::BWD, relTable, nodeIDVector,
             detachDeleteState.get());
     }
-    table->delete_(context->clientContext->getActiveTransaction(), nodeIDVector,
-        pkVectors.at(nodeID.tableID).get());
+    table->delete_(
+        context->clientContext->getTx(), nodeIDVector, pkVectors.at(nodeID.tableID).get());
 }
 
 void RelDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* /*context*/) {
@@ -99,8 +99,7 @@ void RelDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* /*context*/
 }
 
 void SingleLabelRelDeleteExecutor::delete_(ExecutionContext* context) {
-    table->delete_(context->clientContext->getActiveTransaction(), srcNodeIDVector, dstNodeIDVector,
-        relIDVector);
+    table->delete_(context->clientContext->getTx(), srcNodeIDVector, dstNodeIDVector, relIDVector);
 }
 
 void MultiLabelRelDeleteExecutor::delete_(ExecutionContext* context) {
@@ -109,8 +108,7 @@ void MultiLabelRelDeleteExecutor::delete_(ExecutionContext* context) {
     auto relID = relIDVector->getValue<internalID_t>(pos);
     KU_ASSERT(tableIDToTableMap.contains(relID.tableID));
     auto table = tableIDToTableMap.at(relID.tableID);
-    table->delete_(context->clientContext->getActiveTransaction(), srcNodeIDVector, dstNodeIDVector,
-        relIDVector);
+    table->delete_(context->clientContext->getTx(), srcNodeIDVector, dstNodeIDVector, relIDVector);
 }
 
 } // namespace processor

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -159,7 +159,7 @@ void ParallelCSVScan::tableFunc(TableFunctionInput& input, common::DataChunk& ou
 
 std::unique_ptr<function::TableFuncBindData> ParallelCSVScan::bindFunc(
     main::ClientContext* /*context*/, function::TableFuncBindInput* input,
-    catalog::CatalogContent* /*catalog*/) {
+    catalog::Catalog* /*catalog*/) {
     auto scanInput = reinterpret_cast<function::ScanTableFuncBindInput*>(input);
     std::vector<std::string> detectedColumnNames;
     std::vector<std::unique_ptr<common::LogicalType>> detectedColumnTypes;

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -81,7 +81,7 @@ void SerialCSVScan::tableFunc(TableFunctionInput& input, DataChunk& outputChunk)
 
 std::unique_ptr<function::TableFuncBindData> SerialCSVScan::bindFunc(
     main::ClientContext* /*context*/, function::TableFuncBindInput* input,
-    catalog::CatalogContent* /*catalog*/) {
+    catalog::Catalog* /*catalog*/) {
     auto scanInput = reinterpret_cast<function::ScanTableFuncBindInput*>(input);
     std::vector<std::string> detectedColumnNames;
     std::vector<std::unique_ptr<common::LogicalType>> detectedColumnTypes;

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -252,7 +252,7 @@ void NpyScanFunction::tableFunc(TableFunctionInput& input, DataChunk& outputChun
 
 std::unique_ptr<function::TableFuncBindData> NpyScanFunction::bindFunc(
     main::ClientContext* /*context*/, function::TableFuncBindInput* input,
-    catalog::CatalogContent* /*catalog*/) {
+    catalog::Catalog* /*catalog*/) {
     auto scanInput = reinterpret_cast<function::ScanTableFuncBindInput*>(input);
 
     std::vector<std::string> detectedColumnNames;

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -622,7 +622,7 @@ void ParquetScanFunction::tableFunc(TableFunctionInput& input, DataChunk& output
 
 std::unique_ptr<function::TableFuncBindData> ParquetScanFunction::bindFunc(
     main::ClientContext* /*context*/, function::TableFuncBindInput* input,
-    catalog::CatalogContent* /*catalog*/) {
+    catalog::Catalog* /*catalog*/) {
     auto scanInput = reinterpret_cast<function::ScanTableFuncBindInput*>(input);
     std::vector<std::string> detectedColumnNames;
     std::vector<std::unique_ptr<common::LogicalType>> detectedColumnTypes;

--- a/src/processor/operator/persistent/reader/rdf/rdf_reader.cpp
+++ b/src/processor/operator/persistent/reader/rdf/rdf_reader.cpp
@@ -289,7 +289,7 @@ void RdfScan::tableFunc(function::TableFunctionInput& input, common::DataChunk& 
 }
 
 std::unique_ptr<function::TableFuncBindData> RdfScan::bindFunc(main::ClientContext* /*context*/,
-    function::TableFuncBindInput* input, catalog::CatalogContent* /*catalog*/) {
+    function::TableFuncBindInput* input, catalog::Catalog* /*catalog*/) {
     auto scanInput = reinterpret_cast<function::ScanTableFuncBindInput*>(input);
     return std::make_unique<function::ScanBindData>(
         common::LogicalType::copy(scanInput->expectedColumnTypes), scanInput->expectedColumnNames,

--- a/src/processor/operator/persistent/set_executor.cpp
+++ b/src/processor/operator/persistent/set_executor.cpp
@@ -52,7 +52,7 @@ void SingleLabelNodeSetExecutor::set(ExecutionContext* context) {
     auto lhsPos = nodeIDVector->state->selVector->selectedPositions[0];
     auto rhsPos = rhsVector->state->selVector->selectedPositions[0];
     setInfo.table->update(
-        context->clientContext->getActiveTransaction(), setInfo.columnID, nodeIDVector, rhsVector);
+        context->clientContext->getTx(), setInfo.columnID, nodeIDVector, rhsVector);
     if (lhsVector != nullptr) {
         writeToPropertyVector(nodeIDVector, lhsVector, lhsPos, rhsVector, rhsPos);
     }
@@ -73,7 +73,7 @@ void MultiLabelNodeSetExecutor::set(ExecutionContext* context) {
     auto rhsPos = rhsVector->state->selVector->selectedPositions[0];
     auto& setInfo = tableIDToSetInfo.at(nodeID.tableID);
     setInfo.table->update(
-        context->clientContext->getActiveTransaction(), setInfo.columnID, nodeIDVector, rhsVector);
+        context->clientContext->getTx(), setInfo.columnID, nodeIDVector, rhsVector);
     if (lhsVector != nullptr) {
         KU_ASSERT(lhsVector->state->selVector->selectedSize == 1);
         writeToPropertyVector(nodeIDVector, lhsVector, lhsPos, rhsVector, rhsPos);
@@ -120,8 +120,8 @@ void SingleLabelRelSetExecutor::set(ExecutionContext* context) {
         return;
     }
     evaluator->evaluate();
-    table->update(context->clientContext->getActiveTransaction(), columnID, srcNodeIDVector,
-        dstNodeIDVector, relIDVector, rhsVector);
+    table->update(context->clientContext->getTx(), columnID, srcNodeIDVector, dstNodeIDVector,
+        relIDVector, rhsVector);
     if (lhsVector != nullptr) {
         writeToPropertyVector(relIDVector, lhsVector, rhsVector);
     }
@@ -139,8 +139,8 @@ void MultiLabelRelSetExecutor::set(ExecutionContext* context) {
         return;
     }
     auto [table, propertyID] = tableIDToTableAndColumnID.at(relID.tableID);
-    table->update(context->clientContext->getActiveTransaction(), propertyID, srcNodeIDVector,
-        dstNodeIDVector, relIDVector, rhsVector);
+    table->update(context->clientContext->getTx(), propertyID, srcNodeIDVector, dstNodeIDVector,
+        relIDVector, rhsVector);
     if (lhsVector != nullptr) {
         writeToPropertyVector(relIDVector, lhsVector, rhsVector);
     }

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -240,7 +240,7 @@ void PhysicalOperator::initLocalState(ResultSet* resultSet_, ExecutionContext* c
     if (!isSource()) {
         children[0]->initLocalState(resultSet_, context);
     }
-    transaction = context->clientContext->getActiveTransaction();
+    transaction = context->clientContext->getTx();
     resultSet = resultSet_;
     registerProfilingMetrics(context->profiler);
     initLocalStateInternal(resultSet_, context);

--- a/src/processor/operator/scan/scan_rel_csr_columns.cpp
+++ b/src/processor/operator/scan/scan_rel_csr_columns.cpp
@@ -5,7 +5,7 @@ namespace processor {
 
 bool ScanRelCSRColumns::getNextTuplesInternal(ExecutionContext* context) {
     while (true) {
-        if (scanState->hasMoreToRead(context->clientContext->getActiveTransaction())) {
+        if (scanState->hasMoreToRead(context->clientContext->getTx())) {
             info->table->read(transaction, *scanState, inVector, outVectors);
             return true;
         }

--- a/src/transaction/transaction_context.cpp
+++ b/src/transaction/transaction_context.cpp
@@ -32,7 +32,9 @@ void TransactionContext::beginWriteTransaction() {
 }
 
 void TransactionContext::beginAutoTransaction(bool readOnlyStatement) {
-    KU_ASSERT(!hasActiveTransaction() && mode == TransactionMode::AUTO);
+    if (mode == TransactionMode::AUTO && hasActiveTransaction()) {
+        activeTransaction.reset();
+    }
     beginTransactionInternal(
         readOnlyStatement ? TransactionType::READ_ONLY : TransactionType::WRITE);
 }

--- a/test/test_files/ddl/ddl.test
+++ b/test/test_files/ddl/ddl.test
@@ -42,10 +42,10 @@ Node table: university has been created.
 Rel table: nearTo has been created.
 -STATEMENT DROP TABLE nearTo;
 ---- 1
-Rel table: nearTo has been dropped.
+Table: nearTo has been dropped.
 -STATEMENT DROP TABLE university
 ---- 1
-Node table: university has been dropped.
+Table: university has been dropped.
 -STATEMENT ALTER TABLE person DROP fName
 ---- 1
 Drop succeed.

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -29,7 +29,7 @@ struct PandasScanFunction {
     static void tableFunc(function::TableFunctionInput& input, common::DataChunk& outputChunk);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        function::TableFuncBindInput* input, catalog::CatalogContent* catalog);
+        function::TableFuncBindInput* input, catalog::Catalog* catalog);
 
     static std::unique_ptr<function::TableFuncSharedState> initSharedState(
         function::TableFunctionInitInput& input);

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -20,7 +20,7 @@ function_set PandasScanFunction::getFunctionSet() {
 }
 
 std::unique_ptr<function::TableFuncBindData> PandasScanFunction::bindFunc(
-    main::ClientContext* /*context*/, TableFuncBindInput* input, CatalogContent* /*catalog*/) {
+    main::ClientContext* /*context*/, TableFuncBindInput* input, Catalog* /*catalog*/) {
     py::gil_scoped_acquire acquire;
     py::handle df(reinterpret_cast<PyObject*>(input->inputs[0]->getValue<uint8_t*>()));
     std::vector<std::unique_ptr<PandasColumnBindData>> columnBindData;

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -74,6 +74,8 @@ class Connection:
         """
         self.init_connection()
         if type(parameters) != dict:
+            # TODO(Chang): remove ROLLBACK once we can guarantee database is deleted after conn
+            self._connection.execute(self.prepare("ROLLBACK")._prepared_statement, {})
             raise RuntimeError("Parameters must be a dict")
         prepared_statement = self.prepare(
             query) if type(query) == str else query

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -10,6 +10,7 @@
 #include "common/string_utils.h"
 #include "utf8proc.h"
 #include "utf8proc_wrapper.h"
+#include "transaction/transaction.h"
 
 using namespace kuzu::common;
 using namespace kuzu::utf8proc;
@@ -63,10 +64,10 @@ static Connection* globalConnection;
 void EmbeddedShell::updateTableNames() {
     nodeTableNames.clear();
     relTableNames.clear();
-    for (auto& tableSchema : database->catalog->getReadOnlyVersion()->getNodeTableSchemas()) {
+    for (auto& tableSchema : database->catalog->getNodeTableSchemas(&transaction::DUMMY_READ_TRANSACTION)) {
         nodeTableNames.push_back(tableSchema->tableName);
     }
-    for (auto& tableSchema : database->catalog->getReadOnlyVersion()->getRelTableSchemas()) {
+    for (auto& tableSchema : database->catalog->getRelTableSchemas(&transaction::DUMMY_READ_TRANSACTION)) {
         relTableNames.push_back(tableSchema->tableName);
     }
 }


### PR DESCRIPTION
This PR hides as many interfaces as possible for CatalogContent. All access to catalog information should directly go through catalog with a transaction pointer. See changes in `catalog.h` & `catalog_content.h`. This PR also takes us one step closer to support manual transaction over DDL.

Note that since we were not passing transaction pointer properly for DDL code path, I have to use `DUMMY_READ_TRANSACTION` in many places, specifically `Planner & WAL`.

Also I'm commenting out DDL transaction test. We should no longer maintain end2end test through cpp code.