### PR TITLE
tidy: enable performance checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,9 @@ Checks:
 
   modernize-use-override,
 
+  performance-*,
+  -performance-no-int-to-ptr,
+
 HeaderFilterRegex:
   src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include
 WarningsAsErrors: "*"

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -20,7 +20,7 @@ namespace kuzu {
 namespace binder {
 
 std::vector<std::unique_ptr<Property>> Binder::bindProperties(
-    std::vector<std::pair<std::string, std::string>> propertyNameDataTypes) {
+    const std::vector<std::pair<std::string, std::string>>& propertyNameDataTypes) {
     std::vector<std::unique_ptr<Property>> boundPropertyNameDataTypes;
     std::unordered_set<std::string> boundPropertyNames;
     boundPropertyNames.reserve(propertyNameDataTypes.size());
@@ -135,7 +135,11 @@ std::unique_ptr<BoundCreateTableInfo> Binder::bindCreateRelTableGroupInfo(
     auto relMultiplicity = extraInfo->relMultiplicity;
     std::vector<std::unique_ptr<BoundCreateTableInfo>> boundCreateRelTableInfos;
     for (auto& [srcTableName, dstTableName] : extraInfo->srcDstTablePairs) {
-        auto relTableName = relGroupName + "_" + srcTableName + "_" + dstTableName;
+        auto relTableName = std::string(relGroupName)
+                                .append("_")
+                                .append(srcTableName)
+                                .append("_")
+                                .append(dstTableName);
         auto relExtraInfo =
             std::make_unique<ExtraCreateRelTableInfo>(relMultiplicity, srcTableName, dstTableName);
         auto relCreateInfo = std::make_unique<CreateTableInfo>(

--- a/src/binder/bind/bind_reading_clause.cpp
+++ b/src/binder/bind/bind_reading_clause.cpp
@@ -124,7 +124,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     }
     // TODO: this is dangerous because we could match to a scan function.
     auto tableFunction = reinterpret_cast<function::TableFunction*>(
-        catalog.getBuiltInFunctions()->matchScalarFunction(std::move(funcName), inputTypes));
+        catalog.getBuiltInFunctions()->matchScalarFunction(funcName, inputTypes));
     auto bindInput = std::make_unique<function::TableFuncBindInput>();
     bindInput->inputs = std::move(inputValues);
     auto bindData =
@@ -136,7 +136,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto offset = expressionBinder.createVariableExpression(
         *LogicalType::INT64(), std::string(InternalKeyword::ROW_OFFSET));
     auto boundInQueryCall = std::make_unique<BoundInQueryCall>(
-        std::move(tableFunction), std::move(bindData), std::move(columns), offset);
+        tableFunction, std::move(bindData), std::move(columns), offset);
     if (call.hasWherePredicate()) {
         auto wherePredicate = expressionBinder.bindExpression(*call.getWherePredicate());
         boundInQueryCall->setWherePredicate(std::move(wherePredicate));

--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -59,6 +59,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfRelFrom(const Statement& /*st
     columnNames.emplace_back(rdf::PID);
     columnNames.emplace_back(InternalKeyword::DST_OFFSET);
     std::vector<std::unique_ptr<common::LogicalType>> columnTypes;
+    columnTypes.reserve(3);
     for (auto i = 0u; i < 3; ++i) {
         columnTypes.push_back(LogicalType::INT64());
     }

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -15,7 +15,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
         auto child = bindExpression(*parsedExpression.getChild(i));
         children.push_back(std::move(child));
     }
-    return bindComparisonExpression(parsedExpression.getExpressionType(), std::move(children));
+    return bindComparisonExpression(parsedExpression.getExpressionType(), children);
 }
 
 std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -183,7 +183,7 @@ std::unique_ptr<Expression> ExpressionBinder::createInternalNodeIDExpression(
 }
 
 std::shared_ptr<Expression> ExpressionBinder::bindInternalIDExpression(
-    std::shared_ptr<Expression> expression) {
+    const std::shared_ptr<Expression>& expression) {
     if (ExpressionUtil::isNodePattern(*expression)) {
         auto& node = (NodeExpression&)*expression;
         return node.getInternalID();

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -51,7 +51,7 @@ expression_vector ExpressionBinder::bindNodeOrRelPropertyStarExpression(const Ex
 }
 
 expression_vector ExpressionBinder::bindStructPropertyStarExpression(
-    std::shared_ptr<Expression> child) {
+    const std::shared_ptr<Expression>& child) {
     expression_vector result;
     auto childType = child->getDataType();
     for (auto field : StructType::getFields(&childType)) {

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -220,17 +220,14 @@ function::TableFunction* Binder::getScanFunction(common::FileType fileType, bool
             catalog.getBuiltInFunctions()->matchScalarFunction(READ_PARQUET_FUNC_NAME, inputTypes);
     } break;
     case common::FileType::NPY: {
-        func = catalog.getBuiltInFunctions()->matchScalarFunction(
-            READ_NPY_FUNC_NAME, std::move(inputTypes));
+        func = catalog.getBuiltInFunctions()->matchScalarFunction(READ_NPY_FUNC_NAME, inputTypes);
     } break;
     case common::FileType::CSV: {
         func = catalog.getBuiltInFunctions()->matchScalarFunction(
-            isParallel ? READ_CSV_PARALLEL_FUNC_NAME : READ_CSV_SERIAL_FUNC_NAME,
-            std::move(inputTypes));
+            isParallel ? READ_CSV_PARALLEL_FUNC_NAME : READ_CSV_SERIAL_FUNC_NAME, inputTypes);
     } break;
     case common::FileType::TURTLE: {
-        func = catalog.getBuiltInFunctions()->matchScalarFunction(
-            READ_RDF_FUNC_NAME, std::move(inputTypes));
+        func = catalog.getBuiltInFunctions()->matchScalarFunction(READ_RDF_FUNC_NAME, inputTypes);
     } break;
     default:
         KU_UNREACHABLE;

--- a/src/binder/bound_statement_result.cpp
+++ b/src/binder/bound_statement_result.cpp
@@ -8,7 +8,7 @@ namespace kuzu {
 namespace binder {
 
 std::unique_ptr<BoundStatementResult> BoundStatementResult::createSingleStringColumnResult(
-    std::string columnName) {
+    const std::string& columnName) {
     auto result = std::make_unique<BoundStatementResult>();
     auto value = std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, columnName);
     auto stringColumn = std::make_shared<LiteralExpression>(std::move(value), columnName);

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -58,7 +58,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindExpression(
 }
 
 std::shared_ptr<Expression> ExpressionBinder::foldExpression(
-    std::shared_ptr<Expression> expression) {
+    const std::shared_ptr<Expression>& expression) {
     auto value = evaluator::ExpressionEvaluatorUtils::evaluateConstantExpression(
         expression, binder->memoryManager);
     auto result = createLiteralExpression(std::move(value));

--- a/src/binder/query/query_graph.cpp
+++ b/src/binder/query/query_graph.cpp
@@ -151,13 +151,13 @@ void QueryGraph::addQueryNode(std::shared_ptr<NodeExpression> queryNode) {
         return;
     }
     queryNodeNameToPosMap.insert({queryNode->getUniqueName(), queryNodes.size()});
-    queryNodes.push_back(queryNode);
+    queryNodes.push_back(std::move(queryNode));
 }
 
 void QueryGraph::addQueryRel(std::shared_ptr<RelExpression> queryRel) {
     KU_ASSERT(!containsQueryRel(queryRel->getUniqueName()));
     queryRelNameToPosMap.insert({queryRel->getUniqueName(), queryRels.size()});
-    queryRels.push_back(queryRel);
+    queryRels.push_back(std::move(queryRel));
 }
 
 void QueryGraph::merge(const QueryGraph& other) {
@@ -230,8 +230,8 @@ std::unique_ptr<QueryGraphCollection> QueryGraphCollection::copy() const {
     return result;
 }
 
-void PropertyKeyValCollection::addKeyVal(
-    std::shared_ptr<Expression> variable, const std::string& propertyName, expression_pair keyVal) {
+void PropertyKeyValCollection::addKeyVal(const std::shared_ptr<Expression>& variable,
+    const std::string& propertyName, expression_pair keyVal) {
     if (!propertyKeyValMap.contains(variable)) {
         propertyKeyValMap.insert({variable, std::unordered_map<std::string, expression_pair>{}});
     }
@@ -249,7 +249,7 @@ std::vector<expression_pair> PropertyKeyValCollection::getKeyVals() const {
 }
 
 std::vector<expression_pair> PropertyKeyValCollection::getKeyVals(
-    std::shared_ptr<Expression> variable) const {
+    const std::shared_ptr<Expression>& variable) const {
     std::vector<expression_pair> result;
     if (!propertyKeyValMap.contains(variable)) {
         return result;
@@ -261,7 +261,7 @@ std::vector<expression_pair> PropertyKeyValCollection::getKeyVals(
 }
 
 bool PropertyKeyValCollection::hasKeyVal(
-    std::shared_ptr<Expression> variable, const std::string& propertyName) const {
+    const std::shared_ptr<Expression>& variable, const std::string& propertyName) const {
     if (!propertyKeyValMap.contains(variable)) {
         return false;
     }
@@ -272,7 +272,7 @@ bool PropertyKeyValCollection::hasKeyVal(
 }
 
 expression_pair PropertyKeyValCollection::getKeyVal(
-    std::shared_ptr<Expression> variable, const std::string& propertyName) const {
+    const std::shared_ptr<Expression>& variable, const std::string& propertyName) const {
     KU_ASSERT(hasKeyVal(variable, propertyName));
     return propertyKeyValMap.at(variable).at(propertyName);
 }

--- a/src/catalog/catalog_content.cpp
+++ b/src/catalog/catalog_content.cpp
@@ -128,6 +128,7 @@ table_id_t CatalogContent::addRdfGraphSchema(const BoundCreateTableInfo& info) {
 
 std::vector<TableSchema*> CatalogContent::getTableSchemas() const {
     std::vector<TableSchema*> result;
+    result.reserve(tableSchemas.size());
     for (auto&& [_, schema] : tableSchemas) {
         result.push_back(schema.get());
     }

--- a/src/common/types/int128_t.cpp
+++ b/src/common/types/int128_t.cpp
@@ -118,7 +118,7 @@ std::string Int128_t::ToString(int128_t input) {
             break;
         }
         input = divModPositive(input, 10, remainder);
-        result = std::string(1, '0' + remainder) + result;
+        result = std::string(1, '0' + remainder) + std::move(result);
     }
     if (result.empty()) {
         result = "0";

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -274,10 +274,6 @@ LogicalType::LogicalType(const LogicalType& other) {
     }
 }
 
-LogicalType::LogicalType(LogicalType&& other) noexcept
-    : typeID{other.typeID}, physicalType{other.physicalType}, extraTypeInfo{
-                                                                  std::move(other.extraTypeInfo)} {}
-
 LogicalType& LogicalType::operator=(const LogicalType& other) {
     typeID = other.typeID;
     physicalType = other.physicalType;
@@ -308,13 +304,6 @@ bool LogicalType::operator==(const LogicalType& other) const {
 
 bool LogicalType::operator!=(const LogicalType& other) const {
     return !((*this) == other);
-}
-
-LogicalType& LogicalType::operator=(LogicalType&& other) noexcept {
-    typeID = other.typeID;
-    physicalType = other.physicalType;
-    extraTypeInfo = std::move(other.extraTypeInfo);
-    return *this;
 }
 
 std::string LogicalType::toString() const {
@@ -660,6 +649,7 @@ std::string LogicalTypeUtils::toString(LogicalTypeID dataTypeID) {
 
 std::string LogicalTypeUtils::toString(const std::vector<LogicalType*>& dataTypes) {
     std::vector<LogicalTypeID> dataTypeIDs;
+    dataTypeIDs.reserve(dataTypes.size());
     for (auto& dataType : dataTypes) {
         dataTypeIDs.push_back(dataType->typeID);
     }

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -17,7 +17,7 @@ ValueVector::ValueVector(LogicalType dataType, storage::MemoryManager* memoryMan
     auxiliaryBuffer = AuxiliaryBufferFactory::getAuxiliaryBuffer(this->dataType, memoryManager);
 }
 
-void ValueVector::setState(std::shared_ptr<DataChunkState> state_) {
+void ValueVector::setState(const std::shared_ptr<DataChunkState>& state_) {
     this->state = state_;
     if (dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         auto childrenVectors = StructVector::getFieldVectors(this);

--- a/src/expression_evaluator/case_evaluator.cpp
+++ b/src/expression_evaluator/case_evaluator.cpp
@@ -68,6 +68,7 @@ bool CaseExpressionEvaluator::select(SelectionVector& selVector) {
 
 std::unique_ptr<ExpressionEvaluator> CaseExpressionEvaluator::clone() {
     std::vector<std::unique_ptr<CaseAlternativeEvaluator>> clonedAlternativeEvaluators;
+    clonedAlternativeEvaluators.reserve(alternativeEvaluators.size());
     for (auto& alternative : alternativeEvaluators) {
         clonedAlternativeEvaluators.push_back(alternative->clone());
     }

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -55,6 +55,7 @@ bool FunctionExpressionEvaluator::select(SelectionVector& selVector) {
 
 std::unique_ptr<ExpressionEvaluator> FunctionExpressionEvaluator::clone() {
     std::vector<std::unique_ptr<ExpressionEvaluator>> clonedChildren;
+    clonedChildren.reserve(children.size());
     for (auto& child : children) {
         clonedChildren.push_back(child->clone());
     }

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -12,85 +12,69 @@ using namespace kuzu::function;
 namespace kuzu {
 namespace function {
 
-std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getSumFunc(const std::string name,
+std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getSumFunc(std::string name,
     common::LogicalTypeID inputType, common::LogicalTypeID resultType, bool isDistinct) {
     switch (inputType) {
     case common::LogicalTypeID::INT128:
         return getAggFunc<SumFunction<int128_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+            std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::SERIAL:
     case common::LogicalTypeID::INT64:
-        return getAggFunc<SumFunction<int64_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<int64_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::INT32:
-        return getAggFunc<SumFunction<int32_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<int32_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::INT16:
-        return getAggFunc<SumFunction<int16_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<int16_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::INT8:
-        return getAggFunc<SumFunction<int8_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<int8_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT64:
-        return getAggFunc<SumFunction<uint64_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<uint64_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT32:
-        return getAggFunc<SumFunction<uint32_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<uint32_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT16:
-        return getAggFunc<SumFunction<uint16_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<uint16_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT8:
-        return getAggFunc<SumFunction<uint8_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<uint8_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::DOUBLE:
-        return getAggFunc<SumFunction<double_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<double_t>>(name, inputType, resultType, isDistinct);
     case common::LogicalTypeID::FLOAT:
-        return getAggFunc<SumFunction<float_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<SumFunction<float_t>>(name, inputType, resultType, isDistinct);
     default:
         KU_UNREACHABLE;
     }
 }
 
-std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getAvgFunc(const std::string name,
+std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getAvgFunc(std::string name,
     common::LogicalTypeID inputType, common::LogicalTypeID resultType, bool isDistinct) {
     switch (inputType) {
     case common::LogicalTypeID::INT128:
         return getAggFunc<AvgFunction<int128_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+            std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::SERIAL:
     case common::LogicalTypeID::INT64:
-        return getAggFunc<AvgFunction<int64_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<AvgFunction<int64_t>>(std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::INT32:
-        return getAggFunc<AvgFunction<int32_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<AvgFunction<int32_t>>(std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::INT16:
-        return getAggFunc<AvgFunction<int16_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<AvgFunction<int16_t>>(std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::INT8:
-        return getAggFunc<AvgFunction<int8_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<AvgFunction<int8_t>>(std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT64:
         return getAggFunc<AvgFunction<uint64_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+            std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT32:
         return getAggFunc<AvgFunction<uint32_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+            std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT16:
         return getAggFunc<AvgFunction<uint16_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+            std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::UINT8:
-        return getAggFunc<AvgFunction<uint8_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<AvgFunction<uint8_t>>(std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::DOUBLE:
         return getAggFunc<AvgFunction<double_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+            std::move(name), inputType, resultType, isDistinct);
     case common::LogicalTypeID::FLOAT:
-        return getAggFunc<AvgFunction<float_t>>(
-            name, std::move(inputType), std::move(resultType), isDistinct);
+        return getAggFunc<AvgFunction<float_t>>(std::move(name), inputType, resultType, isDistinct);
     default:
         KU_UNREACHABLE;
     }
@@ -109,91 +93,91 @@ std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getMaxFunc(
 }
 
 template<typename FUNC>
-std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getMinMaxFunction(const std::string name,
+std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getMinMaxFunction(std::string name,
     const common::LogicalType& inputType, common::LogicalTypeID resultType, bool isDistinct) {
     auto inputTypes = std::vector<common::LogicalTypeID>{inputType.getLogicalTypeID()};
     switch (inputType.getPhysicalType()) {
     case PhysicalTypeID::BOOL:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<bool>::initialize,
-            MinMaxFunction<bool>::updateAll<FUNC>, MinMaxFunction<bool>::updatePos<FUNC>,
-            MinMaxFunction<bool>::combine<FUNC>, MinMaxFunction<bool>::finalize, isDistinct);
+            resultType, MinMaxFunction<bool>::initialize, MinMaxFunction<bool>::updateAll<FUNC>,
+            MinMaxFunction<bool>::updatePos<FUNC>, MinMaxFunction<bool>::combine<FUNC>,
+            MinMaxFunction<bool>::finalize, isDistinct);
     case PhysicalTypeID::INT128:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<int128_t>::initialize,
+            resultType, MinMaxFunction<int128_t>::initialize,
             MinMaxFunction<int128_t>::updateAll<FUNC>, MinMaxFunction<int128_t>::updatePos<FUNC>,
             MinMaxFunction<int128_t>::combine<FUNC>, MinMaxFunction<int128_t>::finalize,
             isDistinct);
     case PhysicalTypeID::INT64:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<int64_t>::initialize,
+            resultType, MinMaxFunction<int64_t>::initialize,
             MinMaxFunction<int64_t>::updateAll<FUNC>, MinMaxFunction<int64_t>::updatePos<FUNC>,
             MinMaxFunction<int64_t>::combine<FUNC>, MinMaxFunction<int64_t>::finalize, isDistinct);
     case PhysicalTypeID::INT32:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<int32_t>::initialize,
+            resultType, MinMaxFunction<int32_t>::initialize,
             MinMaxFunction<int32_t>::updateAll<FUNC>, MinMaxFunction<int32_t>::updatePos<FUNC>,
             MinMaxFunction<int32_t>::combine<FUNC>, MinMaxFunction<int32_t>::finalize, isDistinct);
     case PhysicalTypeID::INT16:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<int16_t>::initialize,
+            resultType, MinMaxFunction<int16_t>::initialize,
             MinMaxFunction<int16_t>::updateAll<FUNC>, MinMaxFunction<int16_t>::updatePos<FUNC>,
             MinMaxFunction<int16_t>::combine<FUNC>, MinMaxFunction<int16_t>::finalize, isDistinct);
     case PhysicalTypeID::INT8:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<int8_t>::initialize,
-            MinMaxFunction<int8_t>::updateAll<FUNC>, MinMaxFunction<int8_t>::updatePos<FUNC>,
-            MinMaxFunction<int8_t>::combine<FUNC>, MinMaxFunction<int8_t>::finalize, isDistinct);
+            resultType, MinMaxFunction<int8_t>::initialize, MinMaxFunction<int8_t>::updateAll<FUNC>,
+            MinMaxFunction<int8_t>::updatePos<FUNC>, MinMaxFunction<int8_t>::combine<FUNC>,
+            MinMaxFunction<int8_t>::finalize, isDistinct);
     case PhysicalTypeID::UINT64:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<uint64_t>::initialize,
+            resultType, MinMaxFunction<uint64_t>::initialize,
             MinMaxFunction<uint64_t>::updateAll<FUNC>, MinMaxFunction<uint64_t>::updatePos<FUNC>,
             MinMaxFunction<uint64_t>::combine<FUNC>, MinMaxFunction<uint64_t>::finalize,
             isDistinct);
     case PhysicalTypeID::UINT32:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<uint32_t>::initialize,
+            resultType, MinMaxFunction<uint32_t>::initialize,
             MinMaxFunction<uint32_t>::updateAll<FUNC>, MinMaxFunction<uint32_t>::updatePos<FUNC>,
             MinMaxFunction<uint32_t>::combine<FUNC>, MinMaxFunction<uint32_t>::finalize,
             isDistinct);
     case PhysicalTypeID::UINT16:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<uint16_t>::initialize,
+            resultType, MinMaxFunction<uint16_t>::initialize,
             MinMaxFunction<uint16_t>::updateAll<FUNC>, MinMaxFunction<uint16_t>::updatePos<FUNC>,
             MinMaxFunction<uint16_t>::combine<FUNC>, MinMaxFunction<uint16_t>::finalize,
             isDistinct);
     case PhysicalTypeID::UINT8:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<uint8_t>::initialize,
+            resultType, MinMaxFunction<uint8_t>::initialize,
             MinMaxFunction<uint8_t>::updateAll<FUNC>, MinMaxFunction<uint8_t>::updatePos<FUNC>,
             MinMaxFunction<uint8_t>::combine<FUNC>, MinMaxFunction<uint8_t>::finalize, isDistinct);
     case PhysicalTypeID::DOUBLE:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<double_t>::initialize,
+            resultType, MinMaxFunction<double_t>::initialize,
             MinMaxFunction<double_t>::updateAll<FUNC>, MinMaxFunction<double_t>::updatePos<FUNC>,
             MinMaxFunction<double_t>::combine<FUNC>, MinMaxFunction<double_t>::finalize,
             isDistinct);
     case PhysicalTypeID::FLOAT:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<float_t>::initialize,
+            resultType, MinMaxFunction<float_t>::initialize,
             MinMaxFunction<float_t>::updateAll<FUNC>, MinMaxFunction<float_t>::updatePos<FUNC>,
             MinMaxFunction<float_t>::combine<FUNC>, MinMaxFunction<float_t>::finalize, isDistinct);
     case PhysicalTypeID::INTERVAL:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<interval_t>::initialize,
+            resultType, MinMaxFunction<interval_t>::initialize,
             MinMaxFunction<interval_t>::updateAll<FUNC>,
             MinMaxFunction<interval_t>::updatePos<FUNC>, MinMaxFunction<interval_t>::combine<FUNC>,
             MinMaxFunction<interval_t>::finalize, isDistinct);
     case PhysicalTypeID::STRING:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<ku_string_t>::initialize,
+            resultType, MinMaxFunction<ku_string_t>::initialize,
             MinMaxFunction<ku_string_t>::updateAll<FUNC>,
             MinMaxFunction<ku_string_t>::updatePos<FUNC>,
             MinMaxFunction<ku_string_t>::combine<FUNC>, MinMaxFunction<ku_string_t>::finalize,
             isDistinct);
     case PhysicalTypeID::INTERNAL_ID:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
-            std::move(resultType), MinMaxFunction<internalID_t>::initialize,
+            resultType, MinMaxFunction<internalID_t>::initialize,
             MinMaxFunction<internalID_t>::updateAll<FUNC>,
             MinMaxFunction<internalID_t>::updatePos<FUNC>,
             MinMaxFunction<internalID_t>::combine<FUNC>, MinMaxFunction<internalID_t>::finalize,

--- a/src/function/cast/cast_fixed_list.cpp
+++ b/src/function/cast/cast_fixed_list.cpp
@@ -124,7 +124,7 @@ void CastFixedList::fixedListToStringCastExecFunction<UnaryFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result,
     void* /*dataPtr*/) {
     KU_ASSERT(params.size() == 1);
-    auto param = params[0];
+    const auto& param = params[0];
     if (param->state->isFlat()) {
         CastFixedListToString(*param, param->state->selVector->selectedPositions[0], result,
             result.state->selVector->selectedPositions[0]);
@@ -165,7 +165,7 @@ template<>
 void CastFixedList::stringtoFixedListCastExecFunction<UnaryFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
     KU_ASSERT(params.size() == 1);
-    auto param = params[0];
+    const auto& param = params[0];
     auto csvReaderConfig = &reinterpret_cast<CastFunctionBindData*>(dataPtr)->csvConfig;
     if (param->state->isFlat()) {
         auto inputPos = param->state->selVector->selectedPositions[0];
@@ -225,7 +225,7 @@ template<>
 void CastFixedList::listToFixedListCastExecFunction<UnaryFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
     KU_ASSERT(params.size() == 1);
-    auto inputVector = params[0];
+    const auto& inputVector = params[0];
 
     for (auto i = 0u; i < inputVector->state->selVector->selectedSize; i++) {
         auto pos = inputVector->state->selVector->selectedPositions[i];
@@ -325,7 +325,7 @@ static void getFixedListChildCastFunc(
 template<>
 void CastFixedList::listToFixedListCastExecFunction<CastChildFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
-    auto inputVector = params[0];
+    const auto& inputVector = params[0];
     auto numOfEntries = reinterpret_cast<CastFunctionBindData*>(dataPtr)->numOfEntries;
 
     auto inputChildId = VarListType::getChildType(&inputVector->dataType)->getLogicalTypeID();
@@ -352,7 +352,7 @@ void CastFixedList::listToFixedListCastExecFunction<CastChildFunctionExecutor>(
 template<>
 void CastFixedList::castBetweenFixedListExecFunc<UnaryFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
-    auto inputVector = params[0];
+    const auto& inputVector = params[0];
     auto numOfEntries = inputVector->state->selVector
                             ->selectedPositions[inputVector->state->selVector->selectedSize - 1] +
                         1;
@@ -372,7 +372,7 @@ void CastFixedList::castBetweenFixedListExecFunc<CastFixedListToListFunctionExec
 template<>
 void CastFixedList::castBetweenFixedListExecFunc<CastChildFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
-    auto inputVector = params[0];
+    const auto& inputVector = params[0];
     auto numOfEntries = reinterpret_cast<CastFunctionBindData*>(dataPtr)->numOfEntries;
 
     auto inputChildId = FixedListType::getChildType(&inputVector->dataType)->getLogicalTypeID();

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -554,7 +554,7 @@ static bool tryCastStringToStruct(const char* input, uint64_t len, ValueVector* 
     uint64_t rowToAdd, const CSVReaderConfig* csvReaderConfig) {
     // default values to NULL
     auto fieldVectors = StructVector::getFieldVectors(vector);
-    for (auto fieldVector : fieldVectors) {
+    for (auto& fieldVector : fieldVectors) {
         fieldVector->setNull(rowToAdd, true);
     }
 

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -18,7 +18,7 @@ template<typename /*EXECUTOR*/ = UnaryFunctionExecutor>
 static void fixedListToListCastExecFunction(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
     KU_ASSERT(params.size() == 1);
-    auto inputVector = params[0];
+    const auto& inputVector = params[0];
 
     auto numValuesPerList = FixedListType::getNumValuesInList(&inputVector->dataType);
     for (auto i = 0u; i < inputVector->state->selVector->selectedSize; i++) {
@@ -47,7 +47,7 @@ template<>
 void fixedListToListCastExecFunction<CastChildFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
     KU_ASSERT(params.size() == 1);
-    auto inputVector = params[0];
+    const auto& inputVector = params[0];
 
     auto numOfEntries = reinterpret_cast<CastFunctionBindData*>(dataPtr)->numOfEntries;
     result.setNullFromBits(inputVector->getNullMaskData(), 0, 0, numOfEntries);
@@ -135,7 +135,7 @@ static void nestedTypesCastExecFunction(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
     KU_ASSERT(params.size() == 1);
     result.resetAuxiliaryBuffer();
-    auto inputVector = params[0];
+    const auto& inputVector = params[0];
 
     // check if all selcted list entry have the requried fixed list size
     if (CastFixedListHelper::containsListToFixedList(&inputVector->dataType, &result.dataType)) {

--- a/src/function/vector_list_functions.cpp
+++ b/src/function/vector_list_functions.cpp
@@ -43,7 +43,7 @@ void ListCreationFunction::execFunc(const std::vector<std::shared_ptr<ValueVecto
         auto resultDataVector = ListVector::getDataVector(&result);
         auto resultPos = resultEntry.offset;
         for (auto i = 0u; i < parameters.size(); i++) {
-            auto parameter = parameters[i];
+            const auto& parameter = parameters[i];
             auto paramPos = parameter->state->isFlat() ?
                                 parameter->state->selVector->selectedPositions[0] :
                                 pos;

--- a/src/function/vector_map_functions.cpp
+++ b/src/function/vector_map_functions.cpp
@@ -45,8 +45,8 @@ function_set MapExtractFunctions::getFunctionSet() {
     return functionSet;
 }
 
-static void validateKeyType(std::shared_ptr<binder::Expression> mapExpression,
-    std::shared_ptr<binder::Expression> extractKeyExpression) {
+static void validateKeyType(const std::shared_ptr<binder::Expression>& mapExpression,
+    const std::shared_ptr<binder::Expression>& extractKeyExpression) {
     auto mapKeyType = MapType::getKeyType(&mapExpression->dataType);
     if (*mapKeyType != extractKeyExpression->dataType) {
         throw RuntimeException("Unmatched map key type and extract key type");

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -119,7 +119,7 @@ private:
     std::unique_ptr<BoundStatement> bindRenameProperty(const parser::Statement& statement);
 
     std::vector<std::unique_ptr<catalog::Property>> bindProperties(
-        std::vector<std::pair<std::string, std::string>> propertyNameDataTypes);
+        const std::vector<std::pair<std::string, std::string>>& propertyNameDataTypes);
 
     /*** bind copy ***/
     std::unique_ptr<BoundStatement> bindCopyFromClause(const parser::Statement& statement);

--- a/src/include/binder/bound_standalone_call.h
+++ b/src/include/binder/bound_standalone_call.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "binder/bound_statement.h"
 #include "binder/expression/expression.h"
 #include "main/db_config.h"
@@ -12,7 +14,7 @@ public:
     BoundStandaloneCall(main::ConfigurationOption option, std::shared_ptr<Expression> optionValue)
         : BoundStatement{common::StatementType::STANDALONE_CALL,
               BoundStatementResult::createEmptyResult()},
-          option{option}, optionValue{optionValue} {}
+          option{option}, optionValue{std::move(optionValue)} {}
 
     inline main::ConfigurationOption getOption() const { return option; }
 

--- a/src/include/binder/bound_statement_result.h
+++ b/src/include/binder/bound_statement_result.h
@@ -15,7 +15,7 @@ public:
     }
 
     static std::unique_ptr<BoundStatementResult> createSingleStringColumnResult(
-        std::string columnName = "result");
+        const std::string& columnName = "result");
 
     inline void addColumn(std::shared_ptr<Expression> column) {
         columns.push_back(std::move(column));

--- a/src/include/binder/expression/subquery_expression.h
+++ b/src/include/binder/expression/subquery_expression.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "binder/query/query_graph.h"
 #include "common/enums/subquery_type.h"
 #include "expression.h"
@@ -12,7 +14,7 @@ public:
     SubqueryExpression(common::SubqueryType subqueryType, common::LogicalType dataType,
         std::unique_ptr<QueryGraphCollection> queryGraphCollection, std::string uniqueName,
         std::string rawName)
-        : Expression{common::ExpressionType::SUBQUERY, dataType, std::move(uniqueName)},
+        : Expression{common::ExpressionType::SUBQUERY, std::move(dataType), std::move(uniqueName)},
           subqueryType{subqueryType},
           queryGraphCollection{std::move(queryGraphCollection)}, rawName{std::move(rawName)} {}
 

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -25,7 +25,7 @@ public:
 
 private:
     // TODO(Xiyang): move to an expression rewriter
-    std::shared_ptr<Expression> foldExpression(std::shared_ptr<Expression> expression);
+    std::shared_ptr<Expression> foldExpression(const std::shared_ptr<Expression>& expression);
 
     // Boolean expressions.
     std::shared_ptr<Expression> bindBooleanExpression(
@@ -47,7 +47,7 @@ private:
     // Property expressions.
     expression_vector bindPropertyStarExpression(const parser::ParsedExpression& parsedExpression);
     expression_vector bindNodeOrRelPropertyStarExpression(const Expression& child);
-    expression_vector bindStructPropertyStarExpression(std::shared_ptr<Expression> child);
+    expression_vector bindStructPropertyStarExpression(const std::shared_ptr<Expression>& child);
     std::shared_ptr<Expression> bindPropertyExpression(
         const parser::ParsedExpression& parsedExpression);
     std::shared_ptr<Expression> bindNodeOrRelPropertyExpression(
@@ -71,7 +71,8 @@ private:
     std::shared_ptr<Expression> rewriteFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName);
     std::unique_ptr<Expression> createInternalNodeIDExpression(const Expression& node);
-    std::shared_ptr<Expression> bindInternalIDExpression(std::shared_ptr<Expression> expression);
+    std::shared_ptr<Expression> bindInternalIDExpression(
+        const std::shared_ptr<Expression>& expression);
     std::shared_ptr<Expression> bindLabelFunction(const Expression& expression);
     std::unique_ptr<Expression> createInternalLengthExpression(const Expression& expression);
     std::shared_ptr<Expression> bindRecursiveJoinLengthFunction(const Expression& expression);

--- a/src/include/binder/query/query_graph.h
+++ b/src/include/binder/query/query_graph.h
@@ -94,8 +94,9 @@ public:
         return queryNodes[getQueryNodePos(queryNodeName)];
     }
     inline std::vector<std::shared_ptr<NodeExpression>> getQueryNodes(
-        std::vector<uint32_t> nodePoses) const {
+        const std::vector<uint32_t>& nodePoses) const {
         std::vector<std::shared_ptr<NodeExpression>> result;
+        result.reserve(nodePoses.size());
         for (auto nodePos : nodePoses) {
             result.push_back(queryNodes[nodePos]);
         }
@@ -168,13 +169,14 @@ public:
     PropertyKeyValCollection(const PropertyKeyValCollection& other)
         : propertyKeyValMap{other.propertyKeyValMap} {}
 
-    void addKeyVal(std::shared_ptr<Expression> variable, const std::string& propertyName,
+    void addKeyVal(const std::shared_ptr<Expression>& variable, const std::string& propertyName,
         expression_pair keyVal);
     std::vector<expression_pair> getKeyVals() const;
-    std::vector<expression_pair> getKeyVals(std::shared_ptr<Expression> variable) const;
-    bool hasKeyVal(std::shared_ptr<Expression> variable, const std::string& propertyName) const;
+    std::vector<expression_pair> getKeyVals(const std::shared_ptr<Expression>& variable) const;
+    bool hasKeyVal(
+        const std::shared_ptr<Expression>& variable, const std::string& propertyName) const;
     expression_pair getKeyVal(
-        std::shared_ptr<Expression> variable, const std::string& propertyName) const;
+        const std::shared_ptr<Expression>& variable, const std::string& propertyName) const;
 
     inline std::unique_ptr<PropertyKeyValCollection> copy() const {
         return std::make_unique<PropertyKeyValCollection>(*this);

--- a/src/include/binder/query/reading_clause/bound_in_query_call.h
+++ b/src/include/binder/query/reading_clause/bound_in_query_call.h
@@ -13,7 +13,7 @@ public:
     BoundInQueryCall(function::TableFunction* tableFunc,
         std::unique_ptr<function::TableFuncBindData> bindData, expression_vector outputExpressions,
         std::shared_ptr<Expression> rowIdxExpression)
-        : BoundReadingClause{common::ClauseType::IN_QUERY_CALL}, tableFunc{std::move(tableFunc)},
+        : BoundReadingClause{common::ClauseType::IN_QUERY_CALL}, tableFunc{tableFunc},
           bindData{std::move(bindData)}, outputExpressions{std::move(outputExpressions)},
           rowIdxExpression{std::move(rowIdxExpression)} {}
 

--- a/src/include/common/copier_config/copier_config.h
+++ b/src/include/common/copier_config/copier_config.h
@@ -67,6 +67,7 @@ struct ReaderConfig {
             this->rdfReaderConfig = other.rdfReaderConfig->copy();
         }
     }
+    ReaderConfig(ReaderConfig&& other) = default;
 
     inline uint32_t getNumFiles() const { return filePaths.size(); }
 

--- a/src/include/common/task_system/task.h
+++ b/src/include/common/task_system/task.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 namespace kuzu {
@@ -66,7 +67,7 @@ public:
 
     inline void setException(std::exception_ptr exceptionPtr) {
         lock_t lck{mtx};
-        setExceptionNoLock(exceptionPtr);
+        setExceptionNoLock(std::move(exceptionPtr));
     }
 
     inline bool hasException() {
@@ -88,7 +89,7 @@ private:
 
     inline void setExceptionNoLock(std::exception_ptr exceptionPtr) {
         if (exceptionsPtr == nullptr) {
-            exceptionsPtr = exceptionPtr;
+            exceptionsPtr = std::move(exceptionPtr);
         }
     }
 

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -252,7 +252,7 @@ public:
     explicit KUZU_API LogicalType(LogicalTypeID typeID);
     KUZU_API LogicalType(LogicalTypeID typeID, std::unique_ptr<ExtraTypeInfo> extraTypeInfo);
     KUZU_API LogicalType(const LogicalType& other);
-    KUZU_API LogicalType(LogicalType&& other) noexcept;
+    KUZU_API LogicalType(LogicalType&& other) = default;
 
     KUZU_API LogicalType& operator=(const LogicalType& other);
 
@@ -260,7 +260,7 @@ public:
 
     KUZU_API bool operator!=(const LogicalType& other) const;
 
-    KUZU_API LogicalType& operator=(LogicalType&& other) noexcept;
+    KUZU_API LogicalType& operator=(LogicalType&& other) = default;
 
     KUZU_API std::string toString() const;
 

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cmath>
+#include <utility>
 
 #include "common/api.h"
 #include "common/types/date_t.h"
@@ -40,7 +41,7 @@ public:
      * @param dataType the type of the NULL value.
      * @return a NULL value of the given type.
      */
-    KUZU_API static Value createNullValue(LogicalType dataType);
+    KUZU_API static Value createNullValue(const LogicalType& dataType);
     /**
      * @param dataType the type of the non-NULL value.
      * @return a default non-NULL value of the given type.
@@ -122,17 +123,18 @@ public:
      * @param type the logical type of the value.
      * @param val_ the string value to set.
      */
-    KUZU_API explicit Value(LogicalType type, const std::string& val_);
+    KUZU_API explicit Value(const LogicalType& type, std::string val_);
     /**
      * @param dataType the logical type of the value.
      * @param children a vector of children values.
      */
-    KUZU_API explicit Value(LogicalType dataType, std::vector<std::unique_ptr<Value>> children);
+    KUZU_API explicit Value(
+        const LogicalType& dataType, std::vector<std::unique_ptr<Value>> children);
     /**
      * @param dataType the logical type of the value.
      * @param val_ the uint8_t* value to set.
      */
-    KUZU_API explicit Value(LogicalType dataType, const uint8_t* val_);
+    KUZU_API Value(LogicalType dataType, const uint8_t* val_);
     /**
      * @param other the value to copy from.
      */
@@ -212,7 +214,7 @@ public:
 
 private:
     Value();
-    explicit Value(LogicalType dataType);
+    explicit Value(const LogicalType& dataType);
 
     void copyFromFixedList(const uint8_t* fixedList);
     void copyFromVarList(ku_list_t& list, const LogicalType& childType);
@@ -720,7 +722,7 @@ KUZU_API inline Value Value::createValue(nodeID_t val) {
  */
 template<>
 KUZU_API inline Value Value::createValue(std::string val) {
-    return Value(LogicalType{LogicalTypeID::STRING}, val);
+    return Value(LogicalType{LogicalTypeID::STRING}, std::move(val));
 }
 
 /**

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <numeric>
+#include <utility>
 
 #include "common/assert.h"
 #include "common/data_chunk/data_chunk_state.h"
@@ -33,7 +34,7 @@ public:
 
     KUZU_API ~ValueVector() = default;
 
-    void setState(std::shared_ptr<DataChunkState> state_);
+    void setState(const std::shared_ptr<DataChunkState>& state_);
 
     inline void setAllNull() { nullMask->setAllNull(); }
     inline void setAllNonNull() { nullMask->setAllNonNull(); }
@@ -230,7 +231,7 @@ public:
     static inline void referenceVector(ValueVector* vector, struct_field_idx_t idx,
         std::shared_ptr<ValueVector> vectorToReference) {
         reinterpret_cast<StructAuxiliaryBuffer*>(vector->auxiliaryBuffer.get())
-            ->referenceChildVector(idx, vectorToReference);
+            ->referenceChildVector(idx, std::move(vectorToReference));
     }
 
     static inline void initializeEntries(ValueVector* vector) {
@@ -262,7 +263,7 @@ public:
     static inline void referenceVector(ValueVector* vector, union_field_idx_t fieldIdx,
         std::shared_ptr<ValueVector> vectorToReference) {
         StructVector::referenceVector(
-            vector, UnionType::getInternalFieldIdx(fieldIdx), vectorToReference);
+            vector, UnionType::getInternalFieldIdx(fieldIdx), std::move(vectorToReference));
     }
 
     static inline void setTagField(ValueVector* vector, union_field_idx_t tag) {

--- a/src/include/expression_evaluator/node_rel_evaluator.h
+++ b/src/include/expression_evaluator/node_rel_evaluator.h
@@ -18,6 +18,7 @@ public:
 
     inline std::unique_ptr<ExpressionEvaluator> clone() override {
         std::vector<std::unique_ptr<ExpressionEvaluator>> clonedChildren;
+        clonedChildren.reserve(children.size());
         for (auto& child : children) {
             clonedChildren.push_back(child->clone());
         }

--- a/src/include/expression_evaluator/path_evaluator.h
+++ b/src/include/expression_evaluator/path_evaluator.h
@@ -21,6 +21,7 @@ public:
 
     inline std::unique_ptr<ExpressionEvaluator> clone() override {
         std::vector<std::unique_ptr<ExpressionEvaluator>> clonedChildren;
+        clonedChildren.reserve(children.size());
         for (auto& child : children) {
             clonedChildren.push_back(child->clone());
         }

--- a/src/include/function/aggregate_function.h
+++ b/src/include/function/aggregate_function.h
@@ -36,7 +36,7 @@ struct AggregateFunction final : public BaseScalarFunction {
         aggr_combine_function_t combineFunc, aggr_finalize_function_t finalizeFunc, bool isDistinct,
         scalar_bind_func bindFunc = nullptr, param_rewrite_function_t paramRewriteFunc = nullptr)
         : BaseScalarFunction{FunctionType::AGGREGATE, std::move(name), std::move(parameterTypeIDs),
-              returnTypeID, bindFunc},
+              returnTypeID, std::move(bindFunc)},
           initializeFunc{std::move(initializeFunc)}, updateAllFunc{std::move(updateAllFunc)},
           updatePosFunc{std::move(updatePosFunc)}, combineFunc{std::move(combineFunc)},
           finalizeFunc{std::move(finalizeFunc)}, isDistinct{isDistinct}, paramRewriteFunc{std::move(
@@ -52,7 +52,7 @@ struct AggregateFunction final : public BaseScalarFunction {
         : AggregateFunction{std::move(name), std::move(parameterTypeIDs), returnTypeID,
               std::move(initializeFunc), std::move(updateAllFunc), std::move(updatePosFunc),
               std::move(combineFunc), std::move(finalizeFunc), isDistinct, nullptr /* bindFunc */,
-              paramRewriteFunc} {}
+              std::move(paramRewriteFunc)} {}
 
     inline uint32_t getAggregateStateSize() { return initialNullAggregateState->getStateSize(); }
 
@@ -110,12 +110,12 @@ class AggregateFunctionUtil {
 
 public:
     template<typename T>
-    static std::unique_ptr<AggregateFunction> getAggFunc(const std::string name,
+    static std::unique_ptr<AggregateFunction> getAggFunc(std::string name,
         common::LogicalTypeID inputType, common::LogicalTypeID resultType, bool isDistinct,
         param_rewrite_function_t paramRewriteFunc = nullptr) {
         return std::make_unique<AggregateFunction>(std::move(name),
-            std::vector<common::LogicalTypeID>{inputType}, std::move(resultType), T::initialize,
-            T::updateAll, T::updatePos, T::combine, T::finalize, isDistinct, paramRewriteFunc);
+            std::vector<common::LogicalTypeID>{inputType}, resultType, T::initialize, T::updateAll,
+            T::updatePos, T::combine, T::finalize, isDistinct, paramRewriteFunc);
     }
     static std::unique_ptr<AggregateFunction> getSumFunc(const std::string name,
         common::LogicalTypeID inputType, common::LogicalTypeID resultType, bool isDistinct);

--- a/src/include/function/comparison/vector_comparison_functions.h
+++ b/src/include/function/comparison/vector_comparison_functions.h
@@ -51,8 +51,8 @@ private:
     }
 
     template<typename FUNC>
-    static inline std::unique_ptr<ScalarFunction> getFunction(
-        const std::string& name, common::LogicalType leftType, common::LogicalType rightType) {
+    static inline std::unique_ptr<ScalarFunction> getFunction(const std::string& name,
+        const common::LogicalType& leftType, const common::LogicalType& rightType) {
         scalar_exec_func execFunc;
         getExecFunc<FUNC>(leftType.getPhysicalType(), rightType.getPhysicalType(), execFunc);
         scalar_select_func selectFunc;

--- a/src/include/function/list/vector_list_functions.h
+++ b/src/include/function/list/vector_list_functions.h
@@ -12,7 +12,7 @@ namespace function {
 
 struct ListFunction {
     template<typename OPERATION, typename RESULT_TYPE>
-    static scalar_exec_func getBinaryListExecFuncSwitchRight(common::LogicalType rightType) {
+    static scalar_exec_func getBinaryListExecFuncSwitchRight(const common::LogicalType& rightType) {
         scalar_exec_func execFunc;
         switch (rightType.getPhysicalType()) {
         case common::PhysicalTypeID::BOOL: {
@@ -91,7 +91,7 @@ struct ListFunction {
     }
 
     template<typename OPERATION, typename RESULT_TYPE>
-    static scalar_exec_func getBinaryListExecFuncSwitchAll(common::LogicalType type) {
+    static scalar_exec_func getBinaryListExecFuncSwitchAll(const common::LogicalType& type) {
         scalar_exec_func execFunc;
         switch (type.getPhysicalType()) {
         case common::PhysicalTypeID::INT64: {
@@ -118,7 +118,7 @@ struct ListFunction {
     }
 
     template<typename OPERATION, typename RESULT_TYPE>
-    static scalar_exec_func getTernaryListExecFuncSwitchAll(common::LogicalType type) {
+    static scalar_exec_func getTernaryListExecFuncSwitchAll(const common::LogicalType& type) {
         scalar_exec_func execFunc;
         switch (type.getPhysicalType()) {
         case common::PhysicalTypeID::INT64: {

--- a/src/include/function/string/functions/repeat_function.h
+++ b/src/include/function/string/functions/repeat_function.h
@@ -15,7 +15,7 @@ public:
         common::ku_string_t& result, common::ValueVector& resultValueVector);
 
 private:
-    static void repeatStr(char* data, std::string pattern, uint64_t count) {
+    static void repeatStr(char* data, const std::string& pattern, uint64_t count) {
         for (auto i = 0u; i < count; i++) {
             memcpy(data + i * pattern.length(), pattern.c_str(), pattern.length());
         }

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -66,8 +66,8 @@ struct TableFunction : public Function {
         table_func_init_shared_t initSharedFunc, table_func_init_local_t initLocalFunc,
         std::vector<common::LogicalTypeID> inputTypes)
         : Function{FunctionType::TABLE, std::move(name), std::move(inputTypes)},
-          tableFunc{std::move(tableFunc)}, bindFunc{std::move(bindFunc)},
-          initSharedStateFunc{initSharedFunc}, initLocalStateFunc{initLocalFunc} {}
+          tableFunc{tableFunc}, bindFunc{bindFunc}, initSharedStateFunc{initSharedFunc},
+          initLocalStateFunc{initLocalFunc} {}
 
     inline std::string signatureToString() const override {
         return common::LogicalTypeUtils::toString(parameterTypeIDs);

--- a/src/include/function/table_functions/scan_functions.h
+++ b/src/include/function/table_functions/scan_functions.h
@@ -17,7 +17,7 @@ struct BaseScanSharedState : public TableFuncSharedState {
 struct ScanSharedState : public BaseScanSharedState {
     const common::ReaderConfig readerConfig;
 
-    ScanSharedState(const common::ReaderConfig readerConfig, uint64_t numRows)
+    ScanSharedState(common::ReaderConfig readerConfig, uint64_t numRows)
         : BaseScanSharedState{numRows}, readerConfig{std::move(readerConfig)} {}
 
     std::pair<uint64_t, uint64_t> getNext();

--- a/src/include/function/udf_function.h
+++ b/src/include/function/udf_function.h
@@ -79,13 +79,13 @@ struct UDF {
 
     template<typename RESULT_TYPE, typename... Args>
     static function::scalar_exec_func createUnaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
-        std::vector<common::LogicalTypeID> /*parameterTypes*/) {
+        const std::vector<common::LogicalTypeID>& /*parameterTypes*/) {
         KU_UNREACHABLE;
     }
 
     template<typename RESULT_TYPE, typename OPERAND_TYPE>
-    static function::scalar_exec_func createUnaryExecFunc(
-        RESULT_TYPE (*udfFunc)(OPERAND_TYPE), std::vector<common::LogicalTypeID> parameterTypes) {
+    static function::scalar_exec_func createUnaryExecFunc(RESULT_TYPE (*udfFunc)(OPERAND_TYPE),
+        const std::vector<common::LogicalTypeID>& parameterTypes) {
         if (parameterTypes.size() != 1) {
             throw common::CatalogException{
                 "Expected exactly one parameter type for unary udf. Got: " +
@@ -104,14 +104,14 @@ struct UDF {
 
     template<typename RESULT_TYPE, typename... Args>
     static function::scalar_exec_func createBinaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
-        std::vector<common::LogicalTypeID> /*parameterTypes*/) {
+        const std::vector<common::LogicalTypeID>& /*parameterTypes*/) {
         KU_UNREACHABLE;
     }
 
     template<typename RESULT_TYPE, typename LEFT_TYPE, typename RIGHT_TYPE>
     static function::scalar_exec_func createBinaryExecFunc(
         RESULT_TYPE (*udfFunc)(LEFT_TYPE, RIGHT_TYPE),
-        std::vector<common::LogicalTypeID> parameterTypes) {
+        const std::vector<common::LogicalTypeID>& parameterTypes) {
         if (parameterTypes.size() != 2) {
             throw common::CatalogException{
                 "Expected exactly two parameter types for binary udf. Got: " +
@@ -131,7 +131,7 @@ struct UDF {
 
     template<typename RESULT_TYPE, typename... Args>
     static function::scalar_exec_func createTernaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
-        std::vector<common::LogicalTypeID> /*parameterTypes*/) {
+        const std::vector<common::LogicalTypeID>& /*parameterTypes*/) {
         KU_UNREACHABLE;
     }
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -60,7 +60,7 @@ public:
 
     void startTimingIfEnabled();
 
-    std::string getCurrentSetting(std::string optionName);
+    std::string getCurrentSetting(const std::string& optionName);
 
     transaction::Transaction* getActiveTransaction() const;
     transaction::TransactionContext* getTransactionContext() const;

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -147,7 +147,7 @@ private:
     std::unique_ptr<QueryResult> queryResultWithError(const std::string& errMsg);
 
     std::unique_ptr<PreparedStatement> prepareNoLock(const std::string& query,
-        bool enumerateAllPlans = false, std::string joinOrder = std::string{});
+        bool enumerateAllPlans = false, const std::string& joinOrder = std::string{});
 
     template<typename T, typename... Args>
     std::unique_ptr<QueryResult> executeWithParams(PreparedStatement* preparedStatement,
@@ -160,7 +160,7 @@ private:
     }
 
     void bindParametersNoLock(PreparedStatement* preparedStatement,
-        std::unordered_map<std::string, std::unique_ptr<common::Value>> inputParams);
+        const std::unordered_map<std::string, std::unique_ptr<common::Value>>& inputParams);
 
     std::unique_ptr<QueryResult> executeAndAutoCommitIfNecessaryNoLock(
         PreparedStatement* preparedStatement, uint32_t planIdx = 0u);

--- a/src/include/main/plan_printer.h
+++ b/src/include/main/plan_printer.h
@@ -13,7 +13,8 @@ namespace main {
 
 class OpProfileBox {
 public:
-    OpProfileBox(std::string opName, std::string paramsName, std::vector<std::string> attributes);
+    OpProfileBox(
+        std::string opName, const std::string& paramsName, std::vector<std::string> attributes);
 
     inline std::string getOpName() const { return opName; }
 

--- a/src/include/main/storage_driver.h
+++ b/src/include/main/storage_driver.h
@@ -14,7 +14,7 @@ class KUZU_API StorageDriver {
 public:
     explicit StorageDriver(Database* database);
 
-    ~StorageDriver();
+    ~StorageDriver() = default;
 
     void scan(const std::string& nodeName, const std::string& propertyName,
         common::offset_t* offsets, size_t size, uint8_t* result, size_t numThreads);

--- a/src/include/optimizer/acc_hash_join_optimizer.h
+++ b/src/include/optimizer/acc_hash_join_optimizer.h
@@ -41,9 +41,9 @@ private:
         std::vector<planner::LogicalOperator*> opsToApplySemiMask,
         std::shared_ptr<planner::LogicalOperator> child);
     std::shared_ptr<planner::LogicalOperator> appendPathSemiMasker(
-        std::shared_ptr<binder::Expression> pathExpression,
+        const std::shared_ptr<binder::Expression>& pathExpression,
         std::vector<planner::LogicalOperator*> opsToApplySemiMask,
-        std::shared_ptr<planner::LogicalOperator> child);
+        const std::shared_ptr<planner::LogicalOperator>& child);
     std::shared_ptr<planner::LogicalOperator> appendAccumulate(
         std::shared_ptr<planner::LogicalOperator> child);
 };

--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -13,10 +13,10 @@ public:
 
 private:
     std::shared_ptr<planner::LogicalOperator> visitOperator(
-        std::shared_ptr<planner::LogicalOperator> op);
+        const std::shared_ptr<planner::LogicalOperator>& op);
     // Collect predicates in FILTER
     std::shared_ptr<planner::LogicalOperator> visitFilterReplace(
-        std::shared_ptr<planner::LogicalOperator> op);
+        const std::shared_ptr<planner::LogicalOperator>& op);
     // Push primary key lookup into CROSS_PRODUCT
     // E.g.
     //      Filter(a.ID=b.ID)
@@ -24,12 +24,12 @@ private:
     //   S(a)           S(b)                            S(a)
     // This is a temporary solution in the absence of a generic hash join operator.
     std::shared_ptr<planner::LogicalOperator> visitCrossProductReplace(
-        std::shared_ptr<planner::LogicalOperator> op);
+        const std::shared_ptr<planner::LogicalOperator>& op);
 
     // Push FILTER before SCAN_NODE_PROPERTY.
     // Push index lookup into SCAN_NODE_ID.
     std::shared_ptr<planner::LogicalOperator> visitScanNodePropertyReplace(
-        std::shared_ptr<planner::LogicalOperator> op);
+        const std::shared_ptr<planner::LogicalOperator>& op);
 
     // Rewrite SCAN_NODE_ID->SCAN_NODE_PROPERTY->FILTER as
     // SCAN_NODE_ID->(SCAN_NODE_PROPERTY->FILTER)*->SCAN_NODE_PROPERTY

--- a/src/include/optimizer/remove_factorization_rewriter.h
+++ b/src/include/optimizer/remove_factorization_rewriter.h
@@ -11,7 +11,7 @@ public:
     void rewrite(planner::LogicalPlan* plan);
 
     std::shared_ptr<planner::LogicalOperator> visitOperator(
-        std::shared_ptr<planner::LogicalOperator> op);
+        const std::shared_ptr<planner::LogicalOperator>& op);
 
 private:
     std::shared_ptr<planner::LogicalOperator> visitFlattenReplace(

--- a/src/include/optimizer/remove_unnecessary_join_optimizer.h
+++ b/src/include/optimizer/remove_unnecessary_join_optimizer.h
@@ -22,7 +22,7 @@ public:
 
 private:
     std::shared_ptr<planner::LogicalOperator> visitOperator(
-        std::shared_ptr<planner::LogicalOperator> op);
+        const std::shared_ptr<planner::LogicalOperator>& op);
 
     std::shared_ptr<planner::LogicalOperator> visitHashJoinReplace(
         std::shared_ptr<planner::LogicalOperator> op) override;

--- a/src/include/optimizer/top_k_optimizer.h
+++ b/src/include/optimizer/top_k_optimizer.h
@@ -11,7 +11,7 @@ public:
     void rewrite(planner::LogicalPlan* plan);
 
     std::shared_ptr<planner::LogicalOperator> visitOperator(
-        std::shared_ptr<planner::LogicalOperator> op);
+        const std::shared_ptr<planner::LogicalOperator>& op);
 
 private:
     std::shared_ptr<planner::LogicalOperator> visitLimitReplace(

--- a/src/include/parser/transformer.h
+++ b/src/include/parser/transformer.h
@@ -37,7 +37,7 @@ private:
         CypherParser::KU_CopyFromByColumnContext& ctx);
     std::vector<std::string> transformColumnNames(CypherParser::KU_ColumnNamesContext& ctx);
     std::vector<std::string> transformFilePaths(
-        std::vector<antlr4::tree::TerminalNode*> stringLiteral);
+        const std::vector<antlr4::tree::TerminalNode*>& stringLiteral);
     std::unordered_map<std::string, std::unique_ptr<ParsedExpression>> transformParsingOptions(
         CypherParser::KU_ParsingOptionsContext& ctx);
 

--- a/src/include/planner/operator/logical_comment_on.h
+++ b/src/include/planner/operator/logical_comment_on.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "planner/operator/logical_operator.h"
 
 namespace kuzu {
@@ -9,8 +11,9 @@ class LogicalCommentOn : public LogicalOperator {
 public:
     LogicalCommentOn(std::shared_ptr<binder::Expression> outputExpression,
         common::table_id_t tableID, std::string tableName, std::string comment)
-        : LogicalOperator{LogicalOperatorType::COMMENT_ON}, outputExpression(outputExpression),
-          tableID(tableID), tableName(tableName), comment(comment) {}
+        : LogicalOperator{LogicalOperatorType::COMMENT_ON},
+          outputExpression(std::move(outputExpression)), tableID(tableID),
+          tableName(std::move(tableName)), comment(std::move(comment)) {}
 
     inline common::table_id_t getTableID() const { return tableID; }
     inline std::string getTableName() const { return tableName; }

--- a/src/include/planner/operator/logical_explain.h
+++ b/src/include/planner/operator/logical_explain.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common/enums/explain_type.h"
 #include "planner/operator/logical_operator.h"
 
@@ -11,10 +13,9 @@ public:
     LogicalExplain(std::shared_ptr<LogicalOperator> child,
         std::shared_ptr<binder::Expression> outputExpression, common::ExplainType explainType,
         binder::expression_vector outputExpressionsToExplain)
-        : LogicalOperator{LogicalOperatorType::EXPLAIN, child}, outputExpression{std::move(
-                                                                    outputExpression)},
-          explainType{explainType}, outputExpressionsToExplain{
-                                        std::move(outputExpressionsToExplain)} {}
+        : LogicalOperator{LogicalOperatorType::EXPLAIN, std::move(child)},
+          outputExpression{std::move(outputExpression)}, explainType{explainType},
+          outputExpressionsToExplain{std::move(outputExpressionsToExplain)} {}
 
     void computeSchema();
     void computeFactorizedSchema() override;

--- a/src/include/planner/operator/logical_standalone_call.h
+++ b/src/include/planner/operator/logical_standalone_call.h
@@ -10,7 +10,7 @@ class LogicalStandaloneCall : public LogicalOperator {
 public:
     LogicalStandaloneCall(
         main::ConfigurationOption option, std::shared_ptr<binder::Expression> optionValue)
-        : LogicalOperator{LogicalOperatorType::STANDALONE_CALL}, option{std::move(option)},
+        : LogicalOperator{LogicalOperatorType::STANDALONE_CALL}, option{option},
           optionValue{std::move(optionValue)} {}
 
     inline main::ConfigurationOption getOption() const { return option; }

--- a/src/include/planner/operator/logical_union.h
+++ b/src/include/planner/operator/logical_union.h
@@ -8,9 +8,9 @@ namespace planner {
 class LogicalUnion : public LogicalOperator {
 public:
     LogicalUnion(binder::expression_vector expressions,
-        std::vector<std::shared_ptr<LogicalOperator>> children)
-        : LogicalOperator{LogicalOperatorType::UNION_ALL, std::move(children)},
-          expressionsToUnion{std::move(expressions)} {}
+        const std::vector<std::shared_ptr<LogicalOperator>>& children)
+        : LogicalOperator{LogicalOperatorType::UNION_ALL, children}, expressionsToUnion{
+                                                                         std::move(expressions)} {}
 
     f_group_pos_set getGroupsPosToFlatten(uint32_t childIdx);
 

--- a/src/include/planner/operator/schema.h
+++ b/src/include/planner/operator/schema.h
@@ -62,7 +62,8 @@ public:
     inline size_t getNumFlatGroups() const { return getNumGroups(true /* isFlat */); }
     inline size_t getNumUnFlatGroups() const { return getNumGroups(false /* isFlat */); }
 
-    inline FactorizationGroup* getGroup(std::shared_ptr<binder::Expression> expression) const {
+    inline FactorizationGroup* getGroup(
+        const std::shared_ptr<binder::Expression>& expression) const {
         return getGroup(getGroupPos(expression->getUniqueName()));
     }
 

--- a/src/include/planner/query_planner.h
+++ b/src/include/planner/query_planner.h
@@ -90,7 +90,7 @@ private:
         const binder::expression_vector& predicates, LogicalPlan& leftPlan);
     void planRegularMatch(const binder::QueryGraphCollection& queryGraphCollection,
         const binder::expression_vector& predicates, LogicalPlan& leftPlan);
-    void planSubquery(std::shared_ptr<binder::Expression> subquery, LogicalPlan& outerPlan);
+    void planSubquery(const std::shared_ptr<binder::Expression>& subquery, LogicalPlan& outerPlan);
     void planSubqueryIfNecessary(
         const std::shared_ptr<binder::Expression>& expression, LogicalPlan& plan);
 
@@ -116,9 +116,10 @@ private:
     void planNodeScan(uint32_t nodePos);
     void planNodeIDScan(uint32_t nodePos);
     void planRelScan(uint32_t relPos);
-    void appendExtendAndFilter(std::shared_ptr<binder::NodeExpression> boundNode,
-        std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
-        ExtendDirection direction, const binder::expression_vector& predicates, LogicalPlan& plan);
+    void appendExtendAndFilter(const std::shared_ptr<binder::NodeExpression>& boundNode,
+        const std::shared_ptr<binder::NodeExpression>& nbrNode,
+        const std::shared_ptr<binder::RelExpression>& rel, ExtendDirection direction,
+        const binder::expression_vector& predicates, LogicalPlan& plan);
 
     // Plan dp level
     void planLevel(uint32_t level);
@@ -128,7 +129,7 @@ private:
     // Plan worst case optimal join
     void planWCOJoin(uint32_t leftLevel, uint32_t rightLevel);
     void planWCOJoin(const binder::SubqueryGraph& subgraph,
-        std::vector<std::shared_ptr<binder::RelExpression>> rels,
+        const std::vector<std::shared_ptr<binder::RelExpression>>& rels,
         const std::shared_ptr<binder::NodeExpression>& intersectNode);
 
     // Plan index-nested-loop join / hash join
@@ -138,7 +139,7 @@ private:
         const std::vector<std::shared_ptr<binder::NodeExpression>>& joinNodes);
     void planInnerHashJoin(const binder::SubqueryGraph& subgraph,
         const binder::SubqueryGraph& otherSubgraph,
-        std::vector<std::shared_ptr<binder::NodeExpression>> joinNodes, bool flipPlan);
+        const std::vector<std::shared_ptr<binder::NodeExpression>>& joinNodes, bool flipPlan);
 
     std::vector<std::unique_ptr<LogicalPlan>> planCrossProduct(
         std::vector<std::unique_ptr<LogicalPlan>> leftPlans,
@@ -184,19 +185,21 @@ private:
         LogicalPlan& plan);
 
     // Append extend operators
-    void appendNonRecursiveExtend(std::shared_ptr<binder::NodeExpression> boundNode,
-        std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
-        ExtendDirection direction, const binder::expression_vector& properties, LogicalPlan& plan);
-    void appendRecursiveExtend(std::shared_ptr<binder::NodeExpression> boundNode,
-        std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
-        ExtendDirection direction, LogicalPlan& plan);
+    void appendNonRecursiveExtend(const std::shared_ptr<binder::NodeExpression>& boundNode,
+        const std::shared_ptr<binder::NodeExpression>& nbrNode,
+        const std::shared_ptr<binder::RelExpression>& rel, ExtendDirection direction,
+        const binder::expression_vector& properties, LogicalPlan& plan);
+    void appendRecursiveExtend(const std::shared_ptr<binder::NodeExpression>& boundNode,
+        const std::shared_ptr<binder::NodeExpression>& nbrNode,
+        const std::shared_ptr<binder::RelExpression>& rel, ExtendDirection direction,
+        LogicalPlan& plan);
     void createRecursivePlan(
         const binder::RecursiveInfo& recursiveInfo, ExtendDirection direction, LogicalPlan& plan);
-    void createPathNodePropertyScanPlan(std::shared_ptr<binder::NodeExpression> node,
+    void createPathNodePropertyScanPlan(const std::shared_ptr<binder::NodeExpression>& node,
         const binder::expression_vector& properties, LogicalPlan& plan);
-    void createPathRelPropertyScanPlan(std::shared_ptr<binder::NodeExpression> boundNode,
-        std::shared_ptr<binder::NodeExpression> nbrNode,
-        std::shared_ptr<binder::RelExpression> recursiveRel, ExtendDirection direction,
+    void createPathRelPropertyScanPlan(const std::shared_ptr<binder::NodeExpression>& boundNode,
+        const std::shared_ptr<binder::NodeExpression>& nbrNode,
+        const std::shared_ptr<binder::RelExpression>& recursiveRel, ExtendDirection direction,
         const binder::expression_vector& properties, LogicalPlan& plan);
     void appendNodeLabelFilter(std::shared_ptr<binder::Expression> nodeID,
         std::unordered_set<common::table_id_t> tableIDSet, LogicalPlan& plan);

--- a/src/include/processor/data_pos.h
+++ b/src/include/processor/data_pos.h
@@ -22,8 +22,6 @@ struct DataPos {
     explicit DataPos(std::pair<data_chunk_pos_t, value_vector_pos_t> pos)
         : dataChunkPos{pos.first}, valueVectorPos{pos.second} {}
 
-    DataPos(const DataPos& other) : DataPos(other.dataChunkPos, other.valueVectorPos) {}
-
     static DataPos getInvalidPos() { return DataPos(); }
     bool isValid() const {
         return dataChunkPos != INVALID_DATA_CHUNK_POS && valueVectorPos != INVALID_VALUE_VECTOR_POS;

--- a/src/include/processor/expression_mapper.h
+++ b/src/include/processor/expression_mapper.h
@@ -22,7 +22,7 @@ private:
         const binder::Expression& expression);
 
     static std::unique_ptr<evaluator::ExpressionEvaluator> getReferenceEvaluator(
-        std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);
+        const std::shared_ptr<binder::Expression>& expression, const planner::Schema* schema);
 
     static std::unique_ptr<evaluator::ExpressionEvaluator> getCaseEvaluator(
         std::shared_ptr<binder::Expression> expression, const planner::Schema* schema);

--- a/src/include/processor/operator/call/in_query_call.h
+++ b/src/include/processor/operator/call/in_query_call.h
@@ -32,7 +32,7 @@ struct InQueryCallInfo {
         std::unique_ptr<function::TableFuncBindData> bindData, std::vector<DataPos> outputPoses,
         DataPos rowIDPos)
         : function{function}, bindData{std::move(bindData)},
-          outputPoses{std::move(outputPoses)}, rowIDPos{std::move(rowIDPos)} {}
+          outputPoses{std::move(outputPoses)}, rowIDPos{rowIDPos} {}
 
     std::unique_ptr<InQueryCallInfo> copy() {
         return std::make_unique<InQueryCallInfo>(function, bindData->copy(), outputPoses, rowIDPos);

--- a/src/include/processor/operator/call/standalone_call.h
+++ b/src/include/processor/operator/call/standalone_call.h
@@ -13,7 +13,7 @@ struct StandaloneCallInfo {
     bool hasExecuted = false;
 
     StandaloneCallInfo(main::ConfigurationOption option, const common::Value& optionValue)
-        : option{std::move(option)}, optionValue{optionValue} {}
+        : option{option}, optionValue{optionValue} {}
 
     std::unique_ptr<StandaloneCallInfo> copy() {
         return std::make_unique<StandaloneCallInfo>(option, optionValue);

--- a/src/include/processor/operator/comment_on.h
+++ b/src/include/processor/operator/comment_on.h
@@ -15,7 +15,7 @@ struct CommentOnInfo {
     CommentOnInfo(common::table_id_t tableID, std::string tableName, std::string comment,
         DataPos outputPos, catalog::Catalog* catalog)
         : tableID(tableID), tableName(std::move(tableName)), comment(std::move(comment)),
-          outputPos(std::move(outputPos)), catalog(catalog) {}
+          outputPos(outputPos), catalog(catalog) {}
 
     inline std::unique_ptr<CommentOnInfo> copy() {
         return std::make_unique<CommentOnInfo>(tableID, tableName, comment, outputPos, catalog);

--- a/src/include/processor/operator/macro/create_macro.h
+++ b/src/include/processor/operator/macro/create_macro.h
@@ -15,7 +15,7 @@ struct CreateMacroInfo {
 
     CreateMacroInfo(std::string macroName, std::unique_ptr<function::ScalarMacroFunction> macro,
         DataPos outputPos, catalog::Catalog* catalog)
-        : macroName{std::move(macroName)}, macro{std::move(macro)}, outputPos{std::move(outputPos)},
+        : macroName{std::move(macroName)}, macro{std::move(macro)}, outputPos{outputPos},
           catalog{catalog} {}
 
     inline std::unique_ptr<CreateMacroInfo> copy() {

--- a/src/include/processor/operator/order_by/sort_state.h
+++ b/src/include/processor/operator/order_by/sort_state.h
@@ -27,7 +27,7 @@ public:
     std::pair<uint64_t, FactorizedTable*> getLocalPayloadTable(
         storage::MemoryManager& memoryManager, const FactorizedTableSchema& payloadTableSchema);
 
-    void appendLocalSortedKeyBlock(std::shared_ptr<MergedKeyBlocks> mergedDataBlocks);
+    void appendLocalSortedKeyBlock(const std::shared_ptr<MergedKeyBlocks>& mergedDataBlocks);
 
     void combineFTHasNoNullGuarantee();
 

--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "processor/operator/sink.h"
 
 namespace kuzu {
@@ -55,7 +57,7 @@ struct PartitioningInfo {
     PartitioningInfo(DataPos keyDataPos, std::vector<DataPos> columnDataPositions,
         common::logical_types_t columnTypes, partitioner_func_t partitionerFunc)
         : keyDataPos{keyDataPos}, columnDataPositions{std::move(columnDataPositions)},
-          columnTypes{std::move(columnTypes)}, partitionerFunc{partitionerFunc} {}
+          columnTypes{std::move(columnTypes)}, partitionerFunc{std::move(partitionerFunc)} {}
     inline std::unique_ptr<PartitioningInfo> copy() {
         return std::make_unique<PartitioningInfo>(keyDataPos, columnDataPositions,
             common::LogicalType::copy(columnTypes), partitionerFunc);

--- a/src/include/processor/operator/persistent/copy_node.h
+++ b/src/include/processor/operator/persistent/copy_node.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "processor/operator/call/in_query_call.h"
 #include "processor/operator/sink.h"
 #include "storage/store/node_group.h"
@@ -65,8 +67,9 @@ struct CopyNodeInfo {
         std::unordered_set<storage::RelTable*> fwdRelTables,
         std::unordered_set<storage::RelTable*> bwdRelTables, std::string tableName,
         bool containsSerial, bool compressionEnabled)
-        : columnPositions{std::move(columnPositions)}, table{table}, fwdRelTables{fwdRelTables},
-          bwdRelTables{bwdRelTables}, tableName{std::move(tableName)},
+        : columnPositions{std::move(columnPositions)}, table{table}, fwdRelTables{std::move(
+                                                                         fwdRelTables)},
+          bwdRelTables{std::move(bwdRelTables)}, tableName{std::move(tableName)},
           containsSerial{containsSerial}, compressionEnabled{compressionEnabled} {}
     CopyNodeInfo(const CopyNodeInfo& other) = default;
 

--- a/src/include/processor/operator/persistent/delete_executor.h
+++ b/src/include/processor/operator/persistent/delete_executor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common/enums/delete_type.h"
 #include "processor/execution_context.h"
 #include "processor/result/result_set.h"
@@ -34,8 +36,8 @@ public:
         std::unordered_set<storage::RelTable*> fwdRelTables,
         std::unordered_set<storage::RelTable*> bwdRelTables, common::DeleteNodeType deleteType,
         const DataPos& nodeIDPos)
-        : NodeDeleteExecutor(deleteType, nodeIDPos), table{table}, fwdRelTables{fwdRelTables},
-          bwdRelTables{bwdRelTables} {}
+        : NodeDeleteExecutor(deleteType, nodeIDPos), table{table},
+          fwdRelTables{std::move(fwdRelTables)}, bwdRelTables{std::move(bwdRelTables)} {}
     SingleLabelNodeDeleteExecutor(const SingleLabelNodeDeleteExecutor& other)
         : NodeDeleteExecutor(other.deleteType, other.nodeIDPos), table{other.table},
           fwdRelTables{other.fwdRelTables}, bwdRelTables{other.bwdRelTables} {}

--- a/src/include/processor/operator/persistent/reader/csv/parallel_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/parallel_csv_reader.h
@@ -38,7 +38,7 @@ struct ParallelCSVLocalState final : public function::TableFuncLocalState {
 
 struct ParallelCSVScanSharedState final : public function::ScanSharedState {
     explicit ParallelCSVScanSharedState(
-        const common::ReaderConfig readerConfig, uint64_t numRows, uint64_t numColumns)
+        common::ReaderConfig readerConfig, uint64_t numRows, uint64_t numColumns)
         : ScanSharedState{std::move(readerConfig), numRows}, numColumns{numColumns} {}
 
     void setFileComplete(uint64_t completedFileIdx);

--- a/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
@@ -25,7 +25,7 @@ protected:
 
 struct SerialCSVScanSharedState final : public function::ScanSharedState {
     explicit SerialCSVScanSharedState(
-        const common::ReaderConfig readerConfig, uint64_t numRows, uint64_t numColumns)
+        common::ReaderConfig readerConfig, uint64_t numRows, uint64_t numColumns)
         : ScanSharedState{std::move(readerConfig), numRows}, numColumns{numColumns} {
         initReader();
     }

--- a/src/include/processor/operator/persistent/reader/parquet/callback_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/callback_column_reader.h
@@ -28,7 +28,7 @@ public:
 
 protected:
     void dictionary(
-        std::shared_ptr<ResizeableBuffer> dictionaryData, uint64_t numEntries) override {
+        const std::shared_ptr<ResizeableBuffer>& dictionaryData, uint64_t numEntries) override {
         BaseType::allocateDict(numEntries * sizeof(KU_PHYSICAL_TYPE));
         auto dictPtr = (KU_PHYSICAL_TYPE*)this->dict->ptr;
         for (auto i = 0u; i < numEntries; i++) {

--- a/src/include/processor/operator/persistent/reader/parquet/column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/column_reader.h
@@ -28,16 +28,16 @@ public:
     inline bool hasRepeats() { return maxRepeat > 0; }
     virtual inline void skip(uint64_t numValues) { pendingSkips += numValues; }
     virtual inline void dictionary(
-        std::shared_ptr<ResizeableBuffer> /*data*/, uint64_t /*num_entries*/) {
+        const std::shared_ptr<ResizeableBuffer>& /*data*/, uint64_t /*num_entries*/) {
         KU_UNREACHABLE;
     }
     virtual inline void offsets(uint32_t* /*offsets*/, uint8_t* /*defines*/, uint64_t /*numValues*/,
         parquet_filter_t& /*filter*/, uint64_t /*resultOffset*/, common::ValueVector* /*result*/) {
         KU_UNREACHABLE;
     }
-    virtual inline void plain(std::shared_ptr<ByteBuffer> /*plainData*/, uint8_t* /*defines*/,
-        uint64_t /*numValues*/, parquet_filter_t& /*filter*/, uint64_t /*resultOffset*/,
-        common::ValueVector* /*result*/) {
+    virtual inline void plain(const std::shared_ptr<ByteBuffer>& /*plainData*/,
+        uint8_t* /*defines*/, uint64_t /*numValues*/, parquet_filter_t& /*filter*/,
+        uint64_t /*resultOffset*/, common::ValueVector* /*result*/) {
         KU_UNREACHABLE;
     }
     virtual inline void resetPage() {}
@@ -64,8 +64,9 @@ public:
     void preparePage(kuzu_parquet::format::PageHeader& pageHdr);
     void prepareDataPage(kuzu_parquet::format::PageHeader& pageHdr);
     template<class VALUE_TYPE, class CONVERSION>
-    void plainTemplated(std::shared_ptr<ByteBuffer> plainData, uint8_t* defines, uint64_t numValues,
-        parquet_filter_t& filter, uint64_t resultOffset, common::ValueVector* result) {
+    void plainTemplated(const std::shared_ptr<ByteBuffer>& plainData, uint8_t* defines,
+        uint64_t numValues, parquet_filter_t& filter, uint64_t resultOffset,
+        common::ValueVector* result) {
         for (auto i = 0u; i < numValues; i++) {
             if (hasDefines() && defines[i + resultOffset] != maxDefine) {
                 result->setNull(i + resultOffset, true);

--- a/src/include/processor/operator/persistent/reader/parquet/interval_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/interval_column_reader.h
@@ -33,7 +33,7 @@ public:
 
 protected:
     void dictionary(
-        std::shared_ptr<ResizeableBuffer> dictionary_data, uint64_t num_entries) override;
+        const std::shared_ptr<ResizeableBuffer>& dictionary_data, uint64_t num_entries) override;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/persistent/reader/parquet/string_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/string_column_reader.h
@@ -29,7 +29,7 @@ public:
 
 public:
     void dictionary(
-        std::shared_ptr<ResizeableBuffer> dictionary_data, uint64_t numEntries) override;
+        const std::shared_ptr<ResizeableBuffer>& dictionary_data, uint64_t numEntries) override;
     static uint32_t verifyString(const char* strData, uint32_t strLen, const bool isVarchar);
     uint32_t verifyString(const char* strData, uint32_t strLen);
 };

--- a/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
@@ -62,14 +62,15 @@ public:
         }
     }
 
-    void plain(std::shared_ptr<ByteBuffer> plainData, uint8_t* defines, uint64_t numValues,
+    void plain(const std::shared_ptr<ByteBuffer>& plainData, uint8_t* defines, uint64_t numValues,
         parquet_filter_t& filter, uint64_t resultOffset, common::ValueVector* result) override {
         plainTemplated<VALUE_TYPE, VALUE_CONVERSION>(
-            std::move(plainData), defines, numValues, filter, resultOffset, result);
+            plainData, defines, numValues, filter, resultOffset, result);
     }
 
-    void dictionary(std::shared_ptr<ResizeableBuffer> data, uint64_t /*num_entries*/) override {
-        dict = std::move(data);
+    void dictionary(
+        const std::shared_ptr<ResizeableBuffer>& data, uint64_t /*num_entries*/) override {
+        dict = data;
     }
 };
 

--- a/src/include/processor/operator/profile.h
+++ b/src/include/processor/operator/profile.h
@@ -18,7 +18,7 @@ public:
     Profile(DataPos outputPos, ProfileInfo info, ProfileLocalState localState, uint32_t id,
         const std::string& paramsString, std::unique_ptr<PhysicalOperator> child)
         : PhysicalOperator{PhysicalOperatorType::PROFILE, std::move(child), id, paramsString},
-          outputPos{outputPos}, info{std::move(info)}, localState{std::move(localState)} {}
+          outputPos{outputPos}, info{info}, localState{localState} {}
 
     inline bool isSource() const override { return true; }
     inline bool canParallel() const final { return false; }

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "processor/operator/scan/scan_table.h"
 #include "storage/store/node_table.h"
 
@@ -26,7 +28,7 @@ public:
         std::vector<DataPos> outVectorsPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         const std::string& paramsString)
         : ScanSingleNodeTable{PhysicalOperatorType::SCAN_NODE_TABLE, std::move(info), inVectorPos,
-              outVectorsPos, std::move(child), id, paramsString} {}
+              std::move(outVectorsPos), std::move(child), id, paramsString} {}
 
     inline void initLocalStateInternal(
         ResultSet* resultSet, ExecutionContext* executionContext) final {

--- a/src/include/processor/operator/scan/scan_rel_csr_columns.h
+++ b/src/include/processor/operator/scan/scan_rel_csr_columns.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "processor/operator/scan/scan_rel_table.h"
 
 namespace kuzu {
@@ -10,8 +12,8 @@ public:
     ScanRelCSRColumns(std::unique_ptr<ScanRelTableInfo> info, const DataPos& inVectorPos,
         std::vector<DataPos> outVectorsPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         const std::string& paramsString)
-        : ScanRelTable{
-              std::move(info), inVectorPos, outVectorsPos, std::move(child), id, paramsString} {}
+        : ScanRelTable{std::move(info), inVectorPos, std::move(outVectorsPos), std::move(child), id,
+              paramsString} {}
 
     bool getNextTuplesInternal(ExecutionContext* context) final;
 

--- a/src/include/processor/operator/scan/scan_rel_regular_columns.h
+++ b/src/include/processor/operator/scan/scan_rel_regular_columns.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "processor/operator/filtering_operator.h"
 #include "processor/operator/scan/scan_rel_table.h"
 
@@ -11,8 +13,8 @@ public:
     ScanRelRegularColumns(std::unique_ptr<ScanRelTableInfo> info, const DataPos& inVectorPos,
         std::vector<DataPos> outVectorsPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         const std::string& paramsString)
-        : ScanRelTable{
-              std::move(info), inVectorPos, outVectorsPos, std::move(child), id, paramsString} {}
+        : ScanRelTable{std::move(info), inVectorPos, std::move(outVectorsPos), std::move(child), id,
+              paramsString} {}
 
     bool getNextTuplesInternal(ExecutionContext* context) final;
 

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -111,12 +111,12 @@ private:
         std::unique_ptr<PhysicalOperator> prevOperator);
     std::unique_ptr<PhysicalOperator> createFactorizedTableScan(
         const binder::expression_vector& expressions, std::vector<ft_col_idx_t> colIndices,
-        planner::Schema* schema, std::shared_ptr<FactorizedTable> table, uint64_t maxMorselSize,
-        std::unique_ptr<PhysicalOperator> prevOperator);
+        planner::Schema* schema, const std::shared_ptr<FactorizedTable>& table,
+        uint64_t maxMorselSize, std::unique_ptr<PhysicalOperator> prevOperator);
     // Assume scans all columns of table in the same order as given expressions.
     std::unique_ptr<PhysicalOperator> createFactorizedTableScanAligned(
         const binder::expression_vector& expressions, planner::Schema* schema,
-        std::shared_ptr<FactorizedTable> table, uint64_t maxMorselSize,
+        const std::shared_ptr<FactorizedTable>& table, uint64_t maxMorselSize,
         std::unique_ptr<PhysicalOperator> prevOperator);
     std::unique_ptr<HashJoinBuildInfo> createHashBuildInfo(const planner::Schema& buildSideSchema,
         const binder::expression_vector& keys, const binder::expression_vector& payloads);

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "local_table.h"
 
 namespace kuzu {
@@ -7,8 +9,8 @@ namespace storage {
 
 class LocalNodeNG final : public LocalNodeGroup {
 public:
-    LocalNodeNG(common::offset_t nodeGroupStartOffset, std::vector<common::LogicalType*> dataTypes,
-        MemoryManager* mm)
+    LocalNodeNG(common::offset_t nodeGroupStartOffset,
+        const std::vector<common::LogicalType*>& dataTypes, MemoryManager* mm)
         : LocalNodeGroup{nodeGroupStartOffset, dataTypes, mm} {
         insertInfo.resize(dataTypes.size());
         updateInfo.resize(dataTypes.size());
@@ -44,7 +46,7 @@ class LocalNodeTableData final : public LocalTableData {
 public:
     LocalNodeTableData(std::vector<common::LogicalType*> dataTypes, MemoryManager* mm,
         common::ColumnDataFormat dataFormat)
-        : LocalTableData{dataTypes, mm, dataFormat} {}
+        : LocalTableData{std::move(dataTypes), mm, dataFormat} {}
 
     void scan(common::ValueVector* nodeIDVector, const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVectors);

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common/column_data_format.h"
 #include "common/vector/value_vector.h"
 #include "storage/local_storage/local_table.h"
@@ -136,7 +138,7 @@ class LocalRelTableData final : public LocalTableData {
 public:
     LocalRelTableData(std::vector<common::LogicalType*> dataTypes, MemoryManager* mm,
         common::ColumnDataFormat dataFormat)
-        : LocalTableData{dataTypes, mm, dataFormat} {}
+        : LocalTableData{std::move(dataTypes), mm, dataFormat} {}
 
     bool insert(common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector,
         const std::vector<common::ValueVector*>& propertyVectors);

--- a/src/include/storage/storage_structure/db_file_utils.h
+++ b/src/include/storage/storage_structure/db_file_utils.h
@@ -51,7 +51,7 @@ public:
 
     static common::page_idx_t insertNewPage(
         BMFileHandle& fileHandle, DBFileID dbFileID, BufferManager& bufferManager, WAL& wal,
-        std::function<void(uint8_t*)> insertOp = [](uint8_t*) -> void {
+        const std::function<void(uint8_t*)>& insertOp = [](uint8_t*) -> void {
             // DO NOTHING.
         });
 

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "common/assert.h"
 #include "common/cast.h"
 #include "storage/index/hash_index.h"
@@ -38,7 +40,8 @@ public:
     inline void initializeReadState(transaction::Transaction* transaction,
         std::vector<common::column_id_t> columnIDs, common::ValueVector* inNodeIDVector,
         TableReadState* readState) {
-        tableData->initializeReadState(transaction, columnIDs, inNodeIDVector, readState);
+        tableData->initializeReadState(
+            transaction, std::move(columnIDs), inNodeIDVector, readState);
     }
     void read(transaction::Transaction* transaction, TableReadState& readState,
         common::ValueVector* nodeIDVector,

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -23,7 +23,7 @@ public:
         bool enableCompression);
 
     inline void initializeReadState(transaction::Transaction* transaction,
-        common::RelDataDirection direction, std::vector<common::column_id_t> columnIDs,
+        common::RelDataDirection direction, const std::vector<common::column_id_t>& columnIDs,
         common::ValueVector* inNodeIDVector, RelDataReadState* readState) {
         return direction == common::RelDataDirection::FWD ?
                    fwdRelTableData->initializeReadState(

--- a/src/include/storage/store/var_list_column.h
+++ b/src/include/storage/store/var_list_column.h
@@ -96,7 +96,8 @@ private:
 
     ListOffsetInfoInStorage getListOffsetInfoInStorage(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::offset_t startOffsetInNodeGroup,
-        common::offset_t endOffsetInNodeGroup, std::shared_ptr<common::DataChunkState> state);
+        common::offset_t endOffsetInNodeGroup,
+        const std::shared_ptr<common::DataChunkState>& state);
 
 private:
     std::unique_ptr<Column> dataColumn;

--- a/src/include/storage/wal_replayer_utils.h
+++ b/src/include/storage/wal_replayer_utils.h
@@ -27,7 +27,7 @@ private:
 
     static void fileOperationOnNodeFiles(catalog::NodeTableSchema* nodeTableSchema,
         const std::string& directory,
-        std::function<void(std::string fileName)> columnFileOperation);
+        const std::function<void(std::string fileName)>& columnFileOperation);
 };
 
 } // namespace storage

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -37,7 +37,7 @@ void ClientContext::startTimingIfEnabled() {
     }
 }
 
-std::string ClientContext::getCurrentSetting(std::string optionName) {
+std::string ClientContext::getCurrentSetting(const std::string& optionName) {
     auto option = main::DBConfig::getOptionByName(optionName);
     if (option == nullptr) {
         throw RuntimeException{"Invalid option name: " + optionName + "."};

--- a/src/main/plan_printer.cpp
+++ b/src/main/plan_printer.cpp
@@ -12,7 +12,7 @@ namespace kuzu {
 namespace main {
 
 OpProfileBox::OpProfileBox(
-    std::string opName, std::string paramsName, std::vector<std::string> attributes)
+    std::string opName, const std::string& paramsName, std::vector<std::string> attributes)
     : opName{std::move(opName)}, attributes{std::move(attributes)} {
     std::stringstream paramsStream{paramsName};
     std::string paramStr = "";
@@ -147,7 +147,7 @@ void OpProfileTree::printOpProfileBoxUpperFrame(uint32_t rowIdx, std::ostringstr
             oss << std::string(opProfileBoxWidth, ' ');
         }
     }
-    oss << std::endl;
+    oss << '\n';
 }
 
 static std::string dashedLineAccountingForIndex(uint32_t width, uint32_t indent) {
@@ -215,7 +215,7 @@ void OpProfileTree::printOpProfileBoxes(uint32_t rowIdx, std::ostringstream& oss
                 }
             }
         }
-        oss << std::endl;
+        oss << '\n';
     }
 }
 
@@ -244,20 +244,20 @@ void OpProfileTree::printOpProfileBoxLowerFrame(uint32_t rowIdx, std::ostringstr
             oss << std::string(opProfileBoxWidth, ' ');
         }
     }
-    oss << std::endl;
+    oss << '\n';
 }
 
 void OpProfileTree::prettyPrintPlanTitle(std::ostringstream& oss) const {
     const std::string physicalPlan = "Physical Plan";
-    oss << "┌" << genHorizLine(opProfileBoxWidth - 2) << "┐" << std::endl;
-    oss << "│┌" << genHorizLine(opProfileBoxWidth - 4) << "┐│" << std::endl;
+    oss << "┌" << genHorizLine(opProfileBoxWidth - 2) << "┐" << '\n';
+    oss << "│┌" << genHorizLine(opProfileBoxWidth - 4) << "┐│" << '\n';
     auto numLeftSpaces = (opProfileBoxWidth - physicalPlan.length() - 2 * (2 + INDENT_WIDTH)) / 2;
     auto numRightSpaces =
         opProfileBoxWidth - physicalPlan.length() - 2 * (2 + INDENT_WIDTH) - numLeftSpaces;
     oss << "││" << std::string(INDENT_WIDTH + numLeftSpaces, ' ') << physicalPlan
-        << std::string(INDENT_WIDTH + numRightSpaces, ' ') << "││" << std::endl;
-    oss << "│└" << genHorizLine(opProfileBoxWidth - 4) << "┘│" << std::endl;
-    oss << "└" << genHorizLine(opProfileBoxWidth - 2) << "┘" << std::endl;
+        << std::string(INDENT_WIDTH + numRightSpaces, ' ') << "││" << '\n';
+    oss << "│└" << genHorizLine(opProfileBoxWidth - 4) << "┘│" << '\n';
+    oss << "└" << genHorizLine(opProfileBoxWidth - 2) << "┘" << '\n';
 }
 
 std::string OpProfileTree::genHorizLine(uint32_t len) {

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -231,7 +231,7 @@ void QueryResult::writeToCSV(
                 }
             }
             if (surroundQuotes) {
-                csvStr = escapeCharacter + csvStr + escapeCharacter;
+                csvStr = escapeCharacter + std::move(csvStr) + escapeCharacter;
             }
             file << csvStr;
             if (idx < nextTuple->len() - 1) {

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -13,8 +13,6 @@ namespace main {
 StorageDriver::StorageDriver(Database* database)
     : catalog{database->catalog.get()}, storageManager{database->storageManager.get()} {}
 
-StorageDriver::~StorageDriver() = default;
-
 void StorageDriver::scan(const std::string& nodeName, const std::string& propertyName,
     offset_t* offsets, size_t size, uint8_t* result, size_t numThreads) {
     // Resolve files to read from

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -244,9 +244,9 @@ std::shared_ptr<planner::LogicalOperator> HashJoinSIPOptimizer::appendNodeSemiMa
 }
 
 std::shared_ptr<planner::LogicalOperator> HashJoinSIPOptimizer::appendPathSemiMasker(
-    std::shared_ptr<binder::Expression> pathExpression,
+    const std::shared_ptr<binder::Expression>& pathExpression,
     std::vector<planner::LogicalOperator*> opsToApplySemiMask,
-    std::shared_ptr<planner::LogicalOperator> child) {
+    const std::shared_ptr<planner::LogicalOperator>& child) {
     KU_ASSERT(!opsToApplySemiMask.empty());
     auto op = opsToApplySemiMask[0];
     KU_ASSERT(op->getOperatorType() == planner::LogicalOperatorType::SCAN_INTERNAL_ID);

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -20,7 +20,7 @@ void FilterPushDownOptimizer::rewrite(planner::LogicalPlan* plan) {
 }
 
 std::shared_ptr<planner::LogicalOperator> FilterPushDownOptimizer::visitOperator(
-    std::shared_ptr<planner::LogicalOperator> op) {
+    const std::shared_ptr<planner::LogicalOperator>& op) {
     switch (op->getOperatorType()) {
     case LogicalOperatorType::FILTER: {
         return visitFilterReplace(op);
@@ -44,14 +44,14 @@ std::shared_ptr<planner::LogicalOperator> FilterPushDownOptimizer::visitOperator
 }
 
 std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitFilterReplace(
-    std::shared_ptr<LogicalOperator> op) {
+    const std::shared_ptr<LogicalOperator>& op) {
     auto filter = (LogicalFilter*)op.get();
     predicateSet->addPredicate(filter->getPredicate());
     return visitOperator(filter->getChild(0));
 }
 
 std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductReplace(
-    std::shared_ptr<LogicalOperator> op) {
+    const std::shared_ptr<LogicalOperator>& op) {
     for (auto i = 0u; i < op->getNumChildren(); ++i) {
         auto optimizer = FilterPushDownOptimizer();
         op->setChild(i, optimizer.visitOperator(op->getChild(i)));
@@ -82,7 +82,7 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductRepla
 }
 
 std::shared_ptr<planner::LogicalOperator> FilterPushDownOptimizer::visitScanNodePropertyReplace(
-    std::shared_ptr<planner::LogicalOperator> op) {
+    const std::shared_ptr<planner::LogicalOperator>& op) {
     auto scan = (LogicalScanNodeProperty*)op.get();
     auto nodeID = scan->getNodeID();
     auto tableIDs = scan->getTableIDs();

--- a/src/optimizer/remove_factorization_rewriter.cpp
+++ b/src/optimizer/remove_factorization_rewriter.cpp
@@ -20,7 +20,7 @@ void RemoveFactorizationRewriter::rewrite(planner::LogicalPlan* plan) {
 }
 
 std::shared_ptr<planner::LogicalOperator> RemoveFactorizationRewriter::visitOperator(
-    std::shared_ptr<planner::LogicalOperator> op) {
+    const std::shared_ptr<planner::LogicalOperator>& op) {
     // bottom-up traversal
     for (auto i = 0; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));

--- a/src/optimizer/remove_unnecessary_join_optimizer.cpp
+++ b/src/optimizer/remove_unnecessary_join_optimizer.cpp
@@ -13,7 +13,7 @@ void RemoveUnnecessaryJoinOptimizer::rewrite(planner::LogicalPlan* plan) {
 }
 
 std::shared_ptr<planner::LogicalOperator> RemoveUnnecessaryJoinOptimizer::visitOperator(
-    std::shared_ptr<planner::LogicalOperator> op) {
+    const std::shared_ptr<planner::LogicalOperator>& op) {
     // bottom-up traversal
     for (auto i = 0; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));

--- a/src/optimizer/top_k_optimizer.cpp
+++ b/src/optimizer/top_k_optimizer.cpp
@@ -12,7 +12,8 @@ void TopKOptimizer::rewrite(planner::LogicalPlan* plan) {
     plan->setLastOperator(visitOperator(plan->getLastOperator()));
 }
 
-std::shared_ptr<LogicalOperator> TopKOptimizer::visitOperator(std::shared_ptr<LogicalOperator> op) {
+std::shared_ptr<LogicalOperator> TopKOptimizer::visitOperator(
+    const std::shared_ptr<LogicalOperator>& op) {
     // bottom-up traversal
     for (auto i = 0; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));

--- a/src/parser/transform/transform_copy.cpp
+++ b/src/parser/transform/transform_copy.cpp
@@ -48,8 +48,9 @@ std::vector<std::string> Transformer::transformColumnNames(
 }
 
 std::vector<std::string> Transformer::transformFilePaths(
-    std::vector<antlr4::tree::TerminalNode*> stringLiteral) {
+    const std::vector<antlr4::tree::TerminalNode*>& stringLiteral) {
     std::vector<std::string> csvFiles;
+    csvFiles.reserve(stringLiteral.size());
     for (auto& csvFile : stringLiteral) {
         csvFiles.push_back(transformStringLiteral(*csvFile));
     }

--- a/src/planner/operator/logical_union.cpp
+++ b/src/planner/operator/logical_union.cpp
@@ -35,6 +35,7 @@ void LogicalUnion::computeFlatSchema() {
 
 std::unique_ptr<LogicalOperator> LogicalUnion::copy() {
     std::vector<std::shared_ptr<LogicalOperator>> copiedChildren;
+    copiedChildren.reserve(getNumChildren());
     for (auto i = 0u; i < getNumChildren(); ++i) {
         copiedChildren.push_back(getChild(i)->copy());
     }

--- a/src/planner/operator/persistent/logical_delete.cpp
+++ b/src/planner/operator/persistent/logical_delete.cpp
@@ -8,6 +8,7 @@ namespace planner {
 std::vector<std::unique_ptr<LogicalDeleteNodeInfo>> LogicalDeleteNodeInfo::copy(
     const std::vector<std::unique_ptr<LogicalDeleteNodeInfo>>& infos) {
     std::vector<std::unique_ptr<LogicalDeleteNodeInfo>> result;
+    result.reserve(infos.size());
     for (auto& info : infos) {
         result.push_back(info->copy());
     }

--- a/src/planner/plan/append_delete.cpp
+++ b/src/planner/plan/append_delete.cpp
@@ -11,6 +11,7 @@ namespace planner {
 void QueryPlanner::appendDeleteNode(
     const std::vector<BoundDeleteInfo*>& boundInfos, LogicalPlan& plan) {
     std::vector<std::unique_ptr<LogicalDeleteNodeInfo>> infos;
+    infos.reserve(boundInfos.size());
     for (auto& boundInfo : boundInfos) {
         infos.push_back(std::make_unique<LogicalDeleteNodeInfo>(
             // TODO: Add kuzu_dynamic_pointer_cast, and should use that instead for safety checks.

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "binder/expression/expression_util.h"
 #include "binder/expression/property_expression.h"
 #include "binder/expression_visitor.h"
@@ -80,8 +82,8 @@ static std::unordered_set<table_id_t> getNbrNodeTableIDSet(
     return result;
 }
 
-void QueryPlanner::appendNonRecursiveExtend(std::shared_ptr<NodeExpression> boundNode,
-    std::shared_ptr<NodeExpression> nbrNode, std::shared_ptr<RelExpression> rel,
+void QueryPlanner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& boundNode,
+    const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, const expression_vector& properties, LogicalPlan& plan) {
     // Filter bound node label if we know some incoming nodes won't have any outgoing rel. This
     // cannot be done at binding time because the pruning is affected by extend direction.
@@ -133,8 +135,8 @@ void QueryPlanner::appendNonRecursiveExtend(std::shared_ptr<NodeExpression> boun
     }
 }
 
-void QueryPlanner::appendRecursiveExtend(std::shared_ptr<NodeExpression> boundNode,
-    std::shared_ptr<NodeExpression> nbrNode, std::shared_ptr<RelExpression> rel,
+void QueryPlanner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& boundNode,
+    const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, LogicalPlan& plan) {
     auto recursiveInfo = rel->getRecursiveInfo();
     appendAccumulate(AccumulateType::REGULAR, plan);
@@ -226,14 +228,14 @@ void QueryPlanner::createRecursivePlan(
     }
 }
 
-void QueryPlanner::createPathNodePropertyScanPlan(
-    std::shared_ptr<NodeExpression> node, const expression_vector& properties, LogicalPlan& plan) {
+void QueryPlanner::createPathNodePropertyScanPlan(const std::shared_ptr<NodeExpression>& node,
+    const expression_vector& properties, LogicalPlan& plan) {
     appendScanInternalID(node->getInternalID(), node->getTableIDs(), plan);
     appendScanNodeProperties(node->getInternalID(), node->getTableIDs(), properties, plan);
 }
 
-void QueryPlanner::createPathRelPropertyScanPlan(std::shared_ptr<NodeExpression> boundNode,
-    std::shared_ptr<NodeExpression> nbrNode, std::shared_ptr<RelExpression> rel,
+void QueryPlanner::createPathRelPropertyScanPlan(const std::shared_ptr<NodeExpression>& boundNode,
+    const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, const expression_vector& properties, LogicalPlan& plan) {
     appendScanInternalID(boundNode->getInternalID(), boundNode->getTableIDs(), plan);
     appendNonRecursiveExtend(boundNode, nbrNode, rel, direction, properties, plan);

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -308,8 +308,8 @@ void QueryPlanner::planRelScan(uint32_t relPos) {
     }
 }
 
-void QueryPlanner::appendExtendAndFilter(std::shared_ptr<NodeExpression> boundNode,
-    std::shared_ptr<NodeExpression> nbrNode, std::shared_ptr<RelExpression> rel,
+void QueryPlanner::appendExtendAndFilter(const std::shared_ptr<NodeExpression>& boundNode,
+    const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, const expression_vector& predicates, LogicalPlan& plan) {
     switch (rel->getRelType()) {
     case QueryRelType::NON_RECURSIVE: {
@@ -411,7 +411,7 @@ static std::unique_ptr<LogicalPlan> getWCOJBuildPlanForRel(
 }
 
 void QueryPlanner::planWCOJoin(const SubqueryGraph& subgraph,
-    std::vector<std::shared_ptr<RelExpression>> rels,
+    const std::vector<std::shared_ptr<RelExpression>>& rels,
     const std::shared_ptr<NodeExpression>& intersectNode) {
     auto newSubgraph = subgraph;
     std::vector<SubqueryGraph> prevSubgraphs;
@@ -444,6 +444,7 @@ void QueryPlanner::planWCOJoin(const SubqueryGraph& subgraph,
     for (auto& leftPlan : context->getPlans(subgraph)) {
         auto leftPlanCopy = leftPlan->shallowCopy();
         std::vector<std::unique_ptr<LogicalPlan>> rightPlansCopy;
+        rightPlansCopy.reserve(relPlans.size());
         for (auto& relPlan : relPlans) {
             rightPlansCopy.push_back(relPlan->shallowCopy());
         }
@@ -519,7 +520,7 @@ bool QueryPlanner::tryPlanINLJoin(const SubqueryGraph& subgraph, const SubqueryG
     }
     KU_ASSERT(relPos != UINT32_MAX);
     auto rel = context->queryGraph->getQueryRel(relPos);
-    auto boundNode = joinNodes[0];
+    const auto& boundNode = joinNodes[0];
     auto nbrNode =
         boundNode->getUniqueName() == rel->getSrcNodeName() ? rel->getDstNode() : rel->getSrcNode();
     auto extendDirection = ExtendDirectionUtils::getExtendDirection(*rel, *boundNode);
@@ -540,8 +541,8 @@ bool QueryPlanner::tryPlanINLJoin(const SubqueryGraph& subgraph, const SubqueryG
 }
 
 void QueryPlanner::planInnerHashJoin(const SubqueryGraph& subgraph,
-    const SubqueryGraph& otherSubgraph, std::vector<std::shared_ptr<NodeExpression>> joinNodes,
-    bool flipPlan) {
+    const SubqueryGraph& otherSubgraph,
+    const std::vector<std::shared_ptr<NodeExpression>>& joinNodes, bool flipPlan) {
     auto newSubgraph = subgraph;
     newSubgraph.addSubqueryGraph(otherSubgraph);
     auto maxCost = context->subPlansTable->getMaxCost(newSubgraph);

--- a/src/planner/plan/plan_subquery.cpp
+++ b/src/planner/plan/plan_subquery.cpp
@@ -94,7 +94,8 @@ void QueryPlanner::planRegularMatch(const QueryGraphCollection& queryGraphCollec
     }
 }
 
-void QueryPlanner::planSubquery(std::shared_ptr<Expression> expression, LogicalPlan& outerPlan) {
+void QueryPlanner::planSubquery(
+    const std::shared_ptr<Expression>& expression, LogicalPlan& outerPlan) {
     KU_ASSERT(expression->expressionType == ExpressionType::SUBQUERY);
     auto subquery = static_pointer_cast<SubqueryExpression>(expression);
     auto predicates = subquery->getPredicatesSplitOnAnd();

--- a/src/planner/query_planner.cpp
+++ b/src/planner/query_planner.cpp
@@ -24,6 +24,7 @@ static std::vector<std::vector<std::unique_ptr<LogicalPlan>>> cartesianProductCh
             } else {
                 for (auto& resultChildPlans : resultChildrenPlans) {
                     std::vector<std::unique_ptr<LogicalPlan>> logicalPlans;
+                    logicalPlans.reserve(resultChildPlans.size());
                     for (auto& resultChildPlan : resultChildPlans) {
                         logicalPlans.push_back(resultChildPlan->shallowCopy());
                     }
@@ -73,6 +74,7 @@ std::unique_ptr<LogicalPlan> QueryPlanner::createUnionPlan(
     KU_ASSERT(!childrenPlans.empty());
     auto plan = std::make_unique<LogicalPlan>();
     std::vector<std::shared_ptr<LogicalOperator>> children;
+    children.reserve(childrenPlans.size());
     for (auto& childPlan : childrenPlans) {
         children.push_back(childPlan->getLastOperator());
     }

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -1,3 +1,5 @@
+#include <utility>
+
 #include "binder/expression/expression_util.h"
 #include "processor/operator/table_scan/factorized_table_scan.h"
 #include "processor/plan_mapper.h"
@@ -11,9 +13,10 @@ namespace processor {
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createFactorizedTableScan(
     const expression_vector& expressions, std::vector<ft_col_idx_t> colIndices, Schema* schema,
-    std::shared_ptr<FactorizedTable> table, uint64_t maxMorselSize,
+    const std::shared_ptr<FactorizedTable>& table, uint64_t maxMorselSize,
     std::unique_ptr<PhysicalOperator> prevOperator) {
     std::vector<DataPos> outputPositions;
+    outputPositions.reserve(expressions.size());
     for (auto i = 0u; i < expressions.size(); ++i) {
         outputPositions.emplace_back(schema->getExpressionPos(*expressions[i]));
     }
@@ -29,9 +32,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFactorizedTableScan(
 }
 
 std::unique_ptr<PhysicalOperator> PlanMapper::createFactorizedTableScanAligned(
-    const expression_vector& expressions, Schema* schema, std::shared_ptr<FactorizedTable> table,
-    uint64_t maxMorselSize, std::unique_ptr<PhysicalOperator> prevOperator) {
+    const expression_vector& expressions, Schema* schema,
+    const std::shared_ptr<FactorizedTable>& table, uint64_t maxMorselSize,
+    std::unique_ptr<PhysicalOperator> prevOperator) {
     std::vector<ft_col_idx_t> columnIndices;
+    columnIndices.reserve(expressions.size());
     for (auto i = 0u; i < expressions.size(); ++i) {
         columnIndices.push_back(i);
     }

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -109,7 +109,7 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getParameterEvaluator(
 }
 
 std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getReferenceEvaluator(
-    std::shared_ptr<Expression> expression, const Schema* schema) {
+    const std::shared_ptr<Expression>& expression, const Schema* schema) {
     KU_ASSERT(schema != nullptr);
     auto vectorPos = DataPos(schema->getExpressionPos(*expression));
     auto expressionGroup = schema->getGroup(expression->getUniqueName());

--- a/src/processor/map/map_copy_to.cpp
+++ b/src/processor/map/map_copy_to.cpp
@@ -10,7 +10,7 @@ using namespace kuzu::storage;
 namespace kuzu {
 namespace processor {
 
-std::unique_ptr<CopyToInfo> getCopyToInfo(Schema* childSchema, const std::string& filePath,
+std::unique_ptr<CopyToInfo> getCopyToInfo(Schema* childSchema, std::string filePath,
     common::FileType fileType, std::unique_ptr<common::CSVOption> copyToOption,
     std::vector<std::string> columnNames, std::vector<std::unique_ptr<LogicalType>> columnsTypes,
     std::vector<DataPos> vectorsToCopyPos, std::vector<bool> isFlat) {
@@ -32,11 +32,11 @@ std::unique_ptr<CopyToInfo> getCopyToInfo(Schema* childSchema, const std::string
             copyToSchema->appendColumn(std::move(columnSchema));
         }
         return std::make_unique<CopyToParquetInfo>(std::move(copyToSchema), std::move(columnsTypes),
-            columnNames, vectorsToCopyPos, filePath);
+            std::move(columnNames), std::move(vectorsToCopyPos), std::move(filePath));
     }
     case FileType::CSV: {
-        return std::make_unique<CopyToCSVInfo>(
-            columnNames, vectorsToCopyPos, filePath, std::move(isFlat), std::move(copyToOption));
+        return std::make_unique<CopyToCSVInfo>(std::move(columnNames), std::move(vectorsToCopyPos),
+            std::move(filePath), std::move(isFlat), std::move(copyToOption));
     }
     default:
         KU_UNREACHABLE;

--- a/src/processor/map/map_in_query_call.cpp
+++ b/src/processor/map/map_in_query_call.cpp
@@ -17,7 +17,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapInQueryCall(
     }
     auto rowIDPos = DataPos{outSchema->getExpressionPos(*logicalInQueryCall->getRowIDExpression())};
     auto inQueryCallFuncInfo = std::make_unique<InQueryCallInfo>(logicalInQueryCall->getTableFunc(),
-        logicalInQueryCall->getBindData()->copy(), std::move(outputPoses), std::move(rowIDPos));
+        logicalInQueryCall->getBindData()->copy(), std::move(outputPoses), rowIDPos);
     return std::make_unique<InQueryCall>(std::move(inQueryCallFuncInfo),
         std::make_shared<InQueryCallSharedState>(), PhysicalOperatorType::IN_QUERY_CALL,
         getOperatorID(), logicalInQueryCall->getExpressionsForPrinting());

--- a/src/processor/map/map_insert.cpp
+++ b/src/processor/map/map_insert.cpp
@@ -46,6 +46,7 @@ std::unique_ptr<NodeInsertExecutor> PlanMapper::getNodeInsertExecutor(
     auto nodeIDPos = DataPos(outSchema.getExpressionPos(*node->getInternalID()));
     std::vector<DataPos> lhsVectorPositions = populateLhsVectorPositions(info->setItems, outSchema);
     std::vector<std::unique_ptr<ExpressionEvaluator>> evaluators;
+    evaluators.reserve(info->setItems.size());
     for (auto& [_, rhs] : info->setItems) {
         evaluators.push_back(ExpressionMapper::getEvaluator(rhs, &inSchema));
     }
@@ -79,6 +80,7 @@ std::unique_ptr<RelInsertExecutor> PlanMapper::getRelInsertExecutor(
     auto dstNodePos = DataPos(inSchema.getExpressionPos(*dstNode->getInternalID()));
     auto lhsVectorPositions = populateLhsVectorPositions(info->setItems, outSchema);
     std::vector<std::unique_ptr<ExpressionEvaluator>> evaluators;
+    evaluators.reserve(info->setItems.size());
     for (auto& [lhs, rhs] : info->setItems) {
         evaluators.push_back(ExpressionMapper::getEvaluator(rhs, &inSchema));
     }

--- a/src/processor/operator/aggregate/base_aggregate.cpp
+++ b/src/processor/operator/aggregate/base_aggregate.cpp
@@ -41,6 +41,7 @@ void BaseAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
 
 std::vector<std::unique_ptr<function::AggregateFunction>> BaseAggregate::cloneAggFunctions() {
     std::vector<std::unique_ptr<AggregateFunction>> result;
+    result.reserve(aggregateFunctions.size());
     for (auto& function : aggregateFunctions) {
         result.push_back(function->clone());
     }
@@ -49,6 +50,7 @@ std::vector<std::unique_ptr<function::AggregateFunction>> BaseAggregate::cloneAg
 
 std::vector<std::unique_ptr<AggregateInputInfo>> BaseAggregate::cloneAggInputInfos() {
     std::vector<std::unique_ptr<AggregateInputInfo>> result;
+    result.reserve(aggregateInputInfos.size());
     for (auto& info : aggregateInputInfos) {
         result.push_back(info->copy());
     }

--- a/src/processor/operator/order_by/key_block_merger.cpp
+++ b/src/processor/operator/order_by/key_block_merger.cpp
@@ -23,7 +23,7 @@ MergedKeyBlocks::MergedKeyBlocks(uint32_t numBytesPerTuple, std::shared_ptr<Data
     : numBytesPerTuple{numBytesPerTuple},
       numTuplesPerBlock{(uint32_t)(BufferPoolConstants::PAGE_256KB_SIZE / numBytesPerTuple)},
       numTuples{keyBlock->numTuples}, endTupleOffset{numTuplesPerBlock * numBytesPerTuple} {
-    keyBlocks.emplace_back(keyBlock);
+    keyBlocks.emplace_back(std::move(keyBlock));
 }
 
 uint8_t* MergedKeyBlocks::getBlockEndTuplePtr(
@@ -315,8 +315,8 @@ void KeyBlockMergeTaskDispatcher::init(MemoryManager* memoryManager,
     KU_ASSERT(this->keyBlockMerger == nullptr);
     this->memoryManager = memoryManager;
     this->sortedKeyBlocks = sortedKeyBlocks;
-    this->keyBlockMerger =
-        std::make_unique<KeyBlockMerger>(factorizedTables, strKeyColsInfo, numBytesPerTuple);
+    this->keyBlockMerger = std::make_unique<KeyBlockMerger>(
+        std::move(factorizedTables), strKeyColsInfo, numBytesPerTuple);
 }
 
 } // namespace processor

--- a/src/processor/operator/order_by/sort_state.cpp
+++ b/src/processor/operator/order_by/sort_state.cpp
@@ -31,7 +31,8 @@ std::pair<uint64_t, FactorizedTable*> SortSharedState::getLocalPayloadTable(
     return result;
 }
 
-void SortSharedState::appendLocalSortedKeyBlock(std::shared_ptr<MergedKeyBlocks> mergedDataBlocks) {
+void SortSharedState::appendLocalSortedKeyBlock(
+    const std::shared_ptr<MergedKeyBlocks>& mergedDataBlocks) {
     std::unique_lock lck{mtx};
     sortedKeyBlocks->emplace(mergedDataBlocks);
 }
@@ -82,7 +83,7 @@ void SortLocalState::finalize(kuzu::processor::SortSharedState& sharedState) {
 
 PayloadScanner::PayloadScanner(MergedKeyBlocks* keyBlockToScan,
     std::vector<FactorizedTable*> payloadTables, uint64_t skipNumber, uint64_t limitNumber)
-    : keyBlockToScan{std::move(keyBlockToScan)}, payloadTables{std::move(payloadTables)} {
+    : keyBlockToScan{keyBlockToScan}, payloadTables{std::move(payloadTables)} {
     if (this->keyBlockToScan == nullptr || this->keyBlockToScan->getNumTuples() == 0) {
         nextTupleIdxToReadInMergedKeyBlock = 0;
         endTuplesIdxToReadInMergedKeyBlock = 0;

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -202,7 +202,7 @@ bool TopKBuffer::compareBoundaryValue(const std::vector<common::ValueVector*>& k
 }
 
 bool TopKBuffer::compareFlatKeys(
-    vector_idx_t vectorIdxToCompare, const std::vector<ValueVector*> keyVectors) {
+    vector_idx_t vectorIdxToCompare, std::vector<ValueVector*> keyVectors) {
     std::shared_ptr<common::SelectionVector> selVector =
         std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
     selVector->resetSelectorToValuePosBuffer();
@@ -212,14 +212,14 @@ bool TopKBuffer::compareFlatKeys(
         return compareResult;
     } else if (equalsFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
                    *boundaryVecs[vectorIdxToCompare], *selVector)) {
-        return compareFlatKeys(vectorIdxToCompare + 1, keyVectors);
+        return compareFlatKeys(vectorIdxToCompare + 1, std::move(keyVectors));
     } else {
         return false;
     }
 }
 
 void TopKBuffer::compareUnflatKeys(
-    vector_idx_t vectorIdxToCompare, const std::vector<ValueVector*> keyVectors) {
+    vector_idx_t vectorIdxToCompare, std::vector<ValueVector*> keyVectors) {
     auto compareSelVector =
         std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
     compareSelVector->resetSelectorToValuePosBuffer();

--- a/src/processor/operator/persistent/delete.cpp
+++ b/src/processor/operator/persistent/delete.cpp
@@ -21,6 +21,7 @@ bool DeleteNode::getNextTuplesInternal(ExecutionContext* context) {
 
 std::unique_ptr<PhysicalOperator> DeleteNode::clone() {
     std::vector<std::unique_ptr<NodeDeleteExecutor>> executorsCopy;
+    executorsCopy.reserve(executors.size());
     for (auto& executor : executors) {
         executorsCopy.push_back(executor->copy());
     }
@@ -46,6 +47,7 @@ bool DeleteRel::getNextTuplesInternal(ExecutionContext* context) {
 
 std::unique_ptr<PhysicalOperator> DeleteRel::clone() {
     std::vector<std::unique_ptr<RelDeleteExecutor>> executorsCopy;
+    executorsCopy.reserve(executors.size());
     for (auto& executor : executors) {
         executorsCopy.push_back(executor->copy());
     }

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -232,7 +232,7 @@ void NpyMultiFileReader::readBlock(block_idx_t blockIdx, common::DataChunk& data
     }
 }
 
-NpyScanSharedState::NpyScanSharedState(const common::ReaderConfig readerConfig, uint64_t numRows)
+NpyScanSharedState::NpyScanSharedState(common::ReaderConfig readerConfig, uint64_t numRows)
     : ScanSharedState{std::move(readerConfig), numRows} {
     npyMultiFileReader = std::make_unique<NpyMultiFileReader>(this->readerConfig.filePaths);
 }

--- a/src/processor/operator/persistent/reader/parquet/column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/column_reader.cpp
@@ -274,7 +274,7 @@ void ColumnReader::prepareRead(parquet_filter_t& /*filter*/) {
         break;
     case PageType::DICTIONARY_PAGE:
         preparePage(pageHdr);
-        dictionary(std::move(block), pageHdr.dictionary_page_header.num_values);
+        dictionary(block, pageHdr.dictionary_page_header.num_values);
         break;
     default:
         break; // ignore INDEX page type and any other custom extensions

--- a/src/processor/operator/persistent/reader/parquet/interval_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/interval_column_reader.cpp
@@ -22,7 +22,7 @@ common::interval_t IntervalValueConversion::plainRead(
 }
 
 void IntervalColumnReader::dictionary(
-    std::shared_ptr<ResizeableBuffer> dictionary_data, uint64_t num_entries) {
+    const std::shared_ptr<ResizeableBuffer>& dictionary_data, uint64_t num_entries) {
     allocateDict(num_entries * sizeof(common::interval_t));
     auto dict_ptr = reinterpret_cast<common::interval_t*>(this->dict->ptr);
     for (auto i = 0u; i < num_entries; i++) {

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -562,8 +562,8 @@ uint64_t ParquetReader::getGroupOffset(ParquetReaderScanState& state) {
     return minOffset;
 }
 
-ParquetScanSharedState::ParquetScanSharedState(const common::ReaderConfig readerConfig,
-    storage::MemoryManager* memoryManager, uint64_t numRows)
+ParquetScanSharedState::ParquetScanSharedState(
+    common::ReaderConfig readerConfig, storage::MemoryManager* memoryManager, uint64_t numRows)
     : ScanSharedState{std::move(readerConfig), numRows}, memoryManager{memoryManager} {
     readers.push_back(
         std::make_unique<ParquetReader>(this->readerConfig.filePaths[fileIdx], memoryManager));

--- a/src/processor/operator/persistent/reader/parquet/string_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/string_column_reader.cpp
@@ -46,8 +46,9 @@ uint32_t StringColumnReader::verifyString(const char* strData, uint32_t strLen) 
         strData, strLen, getDataType()->getLogicalTypeID() == common::LogicalTypeID::STRING);
 }
 
-void StringColumnReader::dictionary(std::shared_ptr<ResizeableBuffer> data, uint64_t numEntries) {
-    dict = std::move(data);
+void StringColumnReader::dictionary(
+    const std::shared_ptr<ResizeableBuffer>& data, uint64_t numEntries) {
+    dict = data;
     dictStrs = std::unique_ptr<common::ku_string_t[]>(new common::ku_string_t[numEntries]);
     for (auto dictIdx = 0u; dictIdx < numEntries; dictIdx++) {
         uint32_t strLen;

--- a/src/processor/operator/physical_operator.cpp
+++ b/src/processor/operator/physical_operator.cpp
@@ -275,7 +275,7 @@ std::unordered_map<std::string, std::string> PhysicalOperator::getProfilerKeyVal
 std::vector<std::string> PhysicalOperator::getProfilerAttributes(Profiler& profiler) const {
     std::vector<std::string> result;
     for (auto& [key, val] : getProfilerKeyValAttributes(profiler)) {
-        result.emplace_back(key + ": " + val);
+        result.emplace_back(key + ": " + std::move(val));
     }
     return result;
 }

--- a/src/processor/operator/projection.cpp
+++ b/src/processor/operator/projection.cpp
@@ -34,6 +34,7 @@ bool Projection::getNextTuplesInternal(ExecutionContext* context) {
 
 std::unique_ptr<PhysicalOperator> Projection::clone() {
     std::vector<std::unique_ptr<ExpressionEvaluator>> rootExpressionsCloned;
+    rootExpressionsCloned.reserve(expressionEvaluators.size());
     for (auto& expressionEvaluator : expressionEvaluators) {
         rootExpressionsCloned.push_back(expressionEvaluator->clone());
     }

--- a/src/processor/result/flat_tuple.cpp
+++ b/src/processor/result/flat_tuple.cpp
@@ -51,7 +51,7 @@ std::string FlatTuple::toString(
             value = value.substr(0, maxWidth - 3) + "...";
         }
         if (colsWidth[i] != 0) {
-            value = " " + value + " ";
+            value = " " + std::move(value) + " ";
         }
         uint32_t fieldLen = 0;
         uint32_t chrIter = 0;

--- a/src/processor/result/result_set_descriptor.cpp
+++ b/src/processor/result/result_set_descriptor.cpp
@@ -18,6 +18,7 @@ ResultSetDescriptor::ResultSetDescriptor(planner::Schema* schema) {
 
 std::unique_ptr<ResultSetDescriptor> ResultSetDescriptor::copy() const {
     std::vector<std::unique_ptr<DataChunkDescriptor>> dataChunkDescriptorsCopy;
+    dataChunkDescriptorsCopy.reserve(dataChunkDescriptors.size());
     for (auto& dataChunkDescriptor : dataChunkDescriptors) {
         dataChunkDescriptorsCopy.push_back(
             std::make_unique<DataChunkDescriptor>(*dataChunkDescriptor));

--- a/src/storage/local_storage/local_table.cpp
+++ b/src/storage/local_storage/local_table.cpp
@@ -76,6 +76,7 @@ LocalTableData* LocalTable::getOrCreateLocalTableData(
     ColumnDataFormat dataFormat, vector_idx_t dataIdx) {
     if (localTableDataCollection.empty()) {
         std::vector<LogicalType*> dataTypes;
+        dataTypes.reserve(columns.size());
         for (auto& column : columns) {
             dataTypes.push_back(column->getDataType());
         }
@@ -101,6 +102,7 @@ LocalTableData* LocalTable::getOrCreateLocalTableData(
     if (!localTableDataCollection[dataIdx]) {
         KU_ASSERT(tableType == TableType::REL);
         std::vector<LogicalType*> dataTypes;
+        dataTypes.reserve(columns.size());
         for (auto& column : columns) {
             dataTypes.push_back(column->getDataType());
         }

--- a/src/storage/storage_structure/db_file_utils.cpp
+++ b/src/storage/storage_structure/db_file_utils.cpp
@@ -18,7 +18,7 @@ std::pair<BMFileHandle*, page_idx_t> DBFileUtils::getFileHandleAndPhysicalPageId
 }
 
 common::page_idx_t DBFileUtils::insertNewPage(BMFileHandle& fileHandle, DBFileID dbFileID,
-    BufferManager& bufferManager, WAL& wal, std::function<void(uint8_t*)> insertOp) {
+    BufferManager& bufferManager, WAL& wal, const std::function<void(uint8_t*)>& insertOp) {
     auto newOriginalPage = fileHandle.addNewPage();
     auto newWALPage = wal.logPageInsertRecord(dbFileID, newOriginalPage);
     auto walFrame = bufferManager.pin(

--- a/src/storage/store/var_list_column.cpp
+++ b/src/storage/store/var_list_column.cpp
@@ -159,7 +159,7 @@ offset_t VarListColumn::readOffset(
 
 ListOffsetInfoInStorage VarListColumn::getListOffsetInfoInStorage(Transaction* transaction,
     node_group_idx_t nodeGroupIdx, offset_t startOffsetInNodeGroup, offset_t endOffsetInNodeGroup,
-    std::shared_ptr<DataChunkState> state) {
+    const std::shared_ptr<DataChunkState>& state) {
     auto numOffsetsToRead = endOffsetInNodeGroup - startOffsetInNodeGroup;
     auto numOffsetVectors = numOffsetsToRead / DEFAULT_VECTOR_CAPACITY +
                             (numOffsetsToRead % DEFAULT_VECTOR_CAPACITY ? 1 : 0);

--- a/src/storage/wal_replayer_utils.cpp
+++ b/src/storage/wal_replayer_utils.cpp
@@ -44,7 +44,8 @@ void WALReplayerUtils::removeColumnFilesIfExists(const std::string& fileName) {
 }
 
 void WALReplayerUtils::fileOperationOnNodeFiles(NodeTableSchema* nodeTableSchema,
-    const std::string& directory, std::function<void(std::string fileName)> columnFileOperation) {
+    const std::string& directory,
+    const std::function<void(std::string fileName)>& columnFileOperation) {
     columnFileOperation(StorageUtils::getNodeIndexFName(
         directory, nodeTableSchema->tableID, FileVersionType::ORIGINAL));
 }

--- a/tools/benchmark/benchmark.cpp
+++ b/tools/benchmark/benchmark.cpp
@@ -38,24 +38,25 @@ std::unique_ptr<QueryResult> Benchmark::runWithProfile() const {
 
 void Benchmark::logQueryInfo(
     std::ofstream& log, uint32_t runNum, std::vector<std::string>& actualOutput) const {
-    log << "Run Num: " << runNum << std::endl;
-    log << "Status: " << (actualOutput == expectedOutput ? "pass" : "error") << std::endl;
-    log << "Query: " << query << std::endl;
-    log << "Expected output: " << std::endl;
+    log << "Run Num: " << runNum << '\n';
+    log << "Status: " << (actualOutput == expectedOutput ? "pass" : "error") << '\n';
+    log << "Query: " << query << '\n';
+    log << "Expected output: " << '\n';
     for (auto& result : expectedOutput) {
-        log << result << std::endl;
+        log << result << '\n';
     }
-    log << "Actual output: " << std::endl;
+    log << "Actual output: " << '\n';
     for (auto& result : actualOutput) {
-        log << result << std::endl;
+        log << result << '\n';
     }
+    log << std::flush;
 }
 
 void Benchmark::log(uint32_t runNum, QueryResult& queryResult) const {
     auto querySummary = queryResult.getQuerySummary();
     auto actualOutput = testing::TestHelper::convertResultToString(queryResult);
     spdlog::info("Run number: {}", // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject):
-                                   // spdlog has ab unitialized object.
+                                   // spdlog has an unitialized object.
         runNum);
     spdlog::info("Compiling time {}", querySummary->getCompilingTime());
     spdlog::info("Execution time {}", querySummary->getExecutionTime());
@@ -64,8 +65,8 @@ void Benchmark::log(uint32_t runNum, QueryResult& queryResult) const {
     if (!config.outputPath.empty()) {
         std::ofstream logFile(config.outputPath + "/" + name + "_log.txt", std::ios_base::app);
         logQueryInfo(logFile, runNum, actualOutput);
-        logFile << "Compiling time: " << querySummary->getCompilingTime() << std::endl;
-        logFile << "Execution time: " << querySummary->getExecutionTime() << std::endl << std::endl;
+        logFile << "Compiling time: " << querySummary->getCompilingTime() << '\n';
+        logFile << "Execution time: " << querySummary->getExecutionTime() << "\n\n";
         logFile.flush();
         logFile.close();
     }

--- a/tools/benchmark/benchmark_runner.cpp
+++ b/tools/benchmark/benchmark_runner.cpp
@@ -60,8 +60,9 @@ double BenchmarkRunner::computeAverageOfLastRuns(
 }
 
 void BenchmarkRunner::runBenchmark(Benchmark* benchmark) const {
-    spdlog::info("Running benchmark {} with {} thread", // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject):
-                                                        // spdlog has an unitialized object.
+    spdlog::info(
+        "Running benchmark {} with {} thread", // NOLINT(clang-analyzer-optin.cplusplus.UninitializedObject):
+                                               // spdlog has an unitialized object.
         benchmark->name, config->numThreads);
     for (auto i = 0u; i < config->numWarmups; ++i) {
         spdlog::info("Warm up");
@@ -84,7 +85,7 @@ void BenchmarkRunner::profileQueryIfEnabled(Benchmark* benchmark) const {
         auto profileInfo = benchmark->runWithProfile();
         std::ofstream profileFile(
             config->outputPath + "/" + benchmark->name + "_profile.txt", std::ios_base::app);
-        profileFile << profileInfo->getNext()->toString() << std::endl;
+        profileFile << profileInfo->getNext()->toString() << '\n';
         profileFile.flush();
         profileFile.close();
     }

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -18,7 +18,7 @@ using namespace kuzu::common;
 using namespace kuzu::processor;
 
 jobject createJavaObject(
-    JNIEnv* env, void* memAddress, std::string classPath, std::string refFieldName) {
+    JNIEnv* env, void* memAddress, const std::string& classPath, const std::string& refFieldName) {
     auto address = reinterpret_cast<uint64_t>(memAddress);
     auto ref = static_cast<jlong>(address);
 

--- a/tools/nodejs_api/src_cpp/include/node_connection.h
+++ b/tools/nodejs_api/src_cpp/include/node_connection.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <utility>
+
 #include "main/kuzu.h"
 #include "node_database.h"
 #include "node_prepared_statement.h"
@@ -64,7 +66,7 @@ public:
     ConnectionExecuteAsyncWorker(Napi::Function& callback, std::shared_ptr<Connection>& connection,
         std::shared_ptr<PreparedStatement> preparedStatement, NodeQueryResult* nodeQueryResult,
         std::unordered_map<std::string, std::unique_ptr<Value>> params)
-        : Napi::AsyncWorker(callback), preparedStatement(preparedStatement),
+        : Napi::AsyncWorker(callback), preparedStatement(std::move(preparedStatement)),
           nodeQueryResult(nodeQueryResult), connection(connection), params(std::move(params)) {}
     ~ConnectionExecuteAsyncWorker() override = default;
 

--- a/tools/python_api/src_cpp/include/py_connection.h
+++ b/tools/python_api/src_cpp/include/py_connection.h
@@ -16,7 +16,8 @@ public:
 
     void setQueryTimeout(uint64_t timeoutInMS);
 
-    std::unique_ptr<PyQueryResult> execute(PyPreparedStatement* preparedStatement, py::dict params);
+    std::unique_ptr<PyQueryResult> execute(
+        PyPreparedStatement* preparedStatement, const py::dict& params);
 
     void setMaxNumThreadForExec(uint64_t numThreads);
 

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -1,5 +1,7 @@
 #include "include/py_connection.h"
 
+#include <utility>
+
 #include "common/string_format.h"
 #include "datetime.h" // from Python
 #include "main/connection.h"
@@ -40,10 +42,10 @@ void PyConnection::setQueryTimeout(uint64_t timeoutInMS) {
 }
 
 static std::unordered_map<std::string, std::unique_ptr<Value>> transformPythonParameters(
-    py::dict params);
+    const py::dict& params);
 
 std::unique_ptr<PyQueryResult> PyConnection::execute(
-    PyPreparedStatement* preparedStatement, py::dict params) {
+    PyPreparedStatement* preparedStatement, const py::dict& params) {
     auto parameters = transformPythonParameters(params);
     py::gil_scoped_release release;
     auto queryResult =
@@ -154,7 +156,8 @@ bool PyConnection::isPandasDataframe(const py::object& object) {
 
 static Value transformPythonValue(py::handle val);
 
-std::unordered_map<std::string, std::unique_ptr<Value>> transformPythonParameters(py::dict params) {
+std::unordered_map<std::string, std::unique_ptr<Value>> transformPythonParameters(
+    const py::dict& params) {
     std::unordered_map<std::string, std::unique_ptr<Value>> result;
     for (auto& [key, value] : params) {
         if (!py::isinstance<py::str>(key)) {

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -71,7 +71,8 @@ void EmbeddedShell::updateTableNames() {
     }
 }
 
-void addTableCompletion(std::string buf, const std::string& tableName, linenoiseCompletions* lc) {
+void addTableCompletion(
+    const std::string& buf, const std::string& tableName, linenoiseCompletions* lc) {
     std::string prefix, suffix;
     auto prefixPos = buf.rfind(':') + 1;
     prefix = buf.substr(0, prefixPos);
@@ -182,8 +183,9 @@ void highlight(char* buffer, char* resultBuf, uint32_t renderWidth, uint32_t cur
                     regex_search(
                         token, std::regex("^" + keyword + "\\(", std::regex_constants::icase))) {
                     token = regex_replace(token,
-                        std::regex("^(" + keyword + ")", std::regex_constants::icase),
-                        keywordColorPrefix + "$1" + keywordResetPostfix);
+                        std::regex(std::string("^(").append(keyword).append(")"),
+                            std::regex_constants::icase),
+                        std::string(keywordColorPrefix).append("$1").append(keywordResetPostfix));
                     break;
                 }
             }
@@ -215,7 +217,7 @@ void EmbeddedShell::run() {
     while ((line = linenoise(continueLine ? ALTPROMPT : PROMPT)) != nullptr) {
         auto lineStr = std::string(line);
         if (continueLine) {
-            lineStr = currLine + lineStr;
+            lineStr = std::move(currLine) + std::move(lineStr);
             currLine = "";
             continueLine = false;
         }

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -20,7 +20,7 @@ int main(int argc, char* argv[]) {
     try {
         parser.ParseCLI(argc, argv);
     } catch (std::exception& e) {
-        std::cerr << e.what() << std::endl;
+        std::cerr << e.what() << '\n';
         std::cerr << parser;
         return 1;
     }
@@ -38,13 +38,13 @@ int main(int argc, char* argv[]) {
         systemConfig.readOnly = true;
     }
     std::cout << "Opened the database at path: " << databasePath << " in "
-              << (readOnlyMode ? "read-only mode" : "read-write mode") << "." << std::endl;
-    std::cout << "Enter \":help\" for usage hints." << std::endl;
+              << (readOnlyMode ? "read-only mode" : "read-write mode") << "." << '\n';
+    std::cout << "Enter \":help\" for usage hints." << '\n' << std::flush;
     try {
         auto shell = EmbeddedShell(databasePath, systemConfig);
         shell.run();
     } catch (std::exception& e) {
-        std::cerr << e.what() << std::endl;
+        std::cerr << e.what() << '\n';
         return 1;
     }
     return 0;


### PR DESCRIPTION
With the exception of performance-no-int-to-ptr, this change enables clang tidy's performance-based lints.

The changes made are as follows, in no particular order.

- Avoid std::endl. std::endl is confusing because it also flushes the buffer, which is often undesirable. Instead, we should just use a newline character.
- When possible, declare variables as `const T&` instead of `T`, since it avoids a copy.
- When possible, use `std::move` to avoid a copy. However, if the type is trivially copyable, `std::move` does nothing and hence should be removed. Furthermore, if the variable to be moved is constant, `std::move` simply copies, and so `std::move` is confusing and should be removed. Finally, if the variable is moved, but the function parameter type is `const T&`, then a move is unnecessary, and again, it should be removed.
- When using `push_back` in a loop, we should reserve up front for better performance.
- When concatenating strings, either we should `std::move()` the strings, or use `string::append`. Otherwise, we pay the price of creating temporary strings, instead of just pushing to a single string.
- Trivial destructors should be declared with `= default` to allow more aggressive compiler optimizations.