### PR TITLE
tidy: force explicit constructors

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -14,12 +14,11 @@ Checks:
 
   cppcoreguidelines-virtual-class-destructor,
 
+  google-explicit-constructor
+
   misc-unused-parameters,
 
   modernize-use-override,
-
-  performance-*,
-  -performance-no-int-to-ptr,
 
 HeaderFilterRegex:
   src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include

--- a/clangd.log
+++ b/clangd.log
@@ -1,0 +1,14 @@
+cmake -B build/release  -DCMAKE_SHARED_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=lld -DCMAKE_MODULE_LINKER_FLAGS=-fuse-ld=lld -G "Ninja" -DENABLE_RUNTIME_CHECKS=TRUE -DENABLE_WERROR=TRUE -DCMAKE_BUILD_TYPE=Release  -DBUILD_BENCHMARK=TRUE -DBUILD_EXAMPLES=TRUE -DBUILD_JAVA=TRUE -DBUILD_NODEJS=TRUE -DBUILD_PYTHON=TRUE -DBUILD_SHELL=TRUE -DBUILD_TESTS=TRUE  .
+-- pybind11 v2.11.0 dev1
+-- JNI_INCLUDE_DIRS=/usr/lib/jvm/default-java/include;/usr/lib/jvm/default-java/include/linux;/usr/lib/jvm/default-java/include
+-- JNI_LIBRARIES=/usr/lib/jvm/default-java/lib/libjawt.so;/usr/lib/jvm/default-java/lib/server/libjvm.so
+-- OS_NAME=linux
+-- OS_ARCH=amd64
+-- CMake.js configurations: LIB=, INC=/home/keenan/.cmake-js/node-x64/v18.13.0/include/node, SRC=
+-- Configuring done
+-- Generating done
+-- Build files have been written to: /home/keenan/Projects/kuzu/build/release
+cmake --build build/release --target kuzu_java
+ninja: no work to do.
+run-clang-tidy -p build/release -quiet -j 100 \
+	"^/home/keenan/Projects/kuzu/src|/home/keenan/Projects/kuzu/tools/(?!shell/linenoise.cpp)|/home/keenan/Projects/kuzu/examples"

--- a/src/include/binder/bound_statement_result.h
+++ b/src/include/binder/bound_statement_result.h
@@ -8,7 +8,7 @@ namespace binder {
 class BoundStatementResult {
 public:
     BoundStatementResult() = default;
-    BoundStatementResult(expression_vector columns) : columns{std::move(columns)} {}
+    explicit BoundStatementResult(expression_vector columns) : columns{std::move(columns)} {}
 
     static std::unique_ptr<BoundStatementResult> createEmptyResult() {
         return std::make_unique<BoundStatementResult>();

--- a/src/include/binder/ddl/bound_alter.h
+++ b/src/include/binder/ddl/bound_alter.h
@@ -8,7 +8,7 @@ namespace binder {
 
 class BoundAlter : public BoundStatement {
 public:
-    BoundAlter(std::unique_ptr<BoundAlterInfo> info)
+    explicit BoundAlter(std::unique_ptr<BoundAlterInfo> info)
         : BoundStatement{common::StatementType::ALTER,
               BoundStatementResult::createSingleStringColumnResult()},
           info{std::move(info)} {}

--- a/src/include/binder/ddl/bound_create_table_info.h
+++ b/src/include/binder/ddl/bound_create_table_info.h
@@ -72,7 +72,8 @@ struct BoundExtraCreateRelTableInfo : public BoundExtraCreateTableInfo {
 struct BoundExtraCreateRelTableGroupInfo : public BoundExtraCreateTableInfo {
     std::vector<std::unique_ptr<BoundCreateTableInfo>> infos;
 
-    BoundExtraCreateRelTableGroupInfo(std::vector<std::unique_ptr<BoundCreateTableInfo>> infos)
+    explicit BoundExtraCreateRelTableGroupInfo(
+        std::vector<std::unique_ptr<BoundCreateTableInfo>> infos)
         : infos{std::move(infos)} {}
     BoundExtraCreateRelTableGroupInfo(const BoundExtraCreateRelTableGroupInfo& other)
         : infos{BoundCreateTableInfo::copy(other.infos)} {}

--- a/src/include/binder/query/query_graph_label_analyzer.h
+++ b/src/include/binder/query/query_graph_label_analyzer.h
@@ -8,7 +8,7 @@ namespace binder {
 
 class QueryGraphLabelAnalyzer {
 public:
-    QueryGraphLabelAnalyzer(const catalog::Catalog& catalog) : catalog{catalog} {}
+    explicit QueryGraphLabelAnalyzer(const catalog::Catalog& catalog) : catalog{catalog} {}
 
     void pruneLabel(const QueryGraph& graph);
 

--- a/src/include/binder/rewriter/match_clause_pattern_label_rewriter.h
+++ b/src/include/binder/rewriter/match_clause_pattern_label_rewriter.h
@@ -8,7 +8,7 @@ namespace binder {
 
 class MatchClausePatternLabelRewriter : public BoundStatementVisitor {
 public:
-    MatchClausePatternLabelRewriter(const catalog::Catalog& catalog) : analyzer{catalog} {}
+    explicit MatchClausePatternLabelRewriter(const catalog::Catalog& catalog) : analyzer{catalog} {}
 
     void visitMatch(const BoundReadingClause& readingClause) final;
 

--- a/src/include/catalog/rel_table_group_schema.h
+++ b/src/include/catalog/rel_table_group_schema.h
@@ -13,7 +13,7 @@ public:
         : TableSchema{std::move(tableName), tableID, common::TableType::REL_GROUP,
               std::vector<std::unique_ptr<Property>>{}},
           relTableIDs{std::move(relTableIDs)} {}
-    RelTableGroupSchema(std::vector<common::table_id_t> relTableIDs)
+    explicit RelTableGroupSchema(std::vector<common::table_id_t> relTableIDs)
         : TableSchema{common::InternalKeyword::ANONYMOUS, common::INVALID_TABLE_ID,
               common::TableType::REL_GROUP, std::vector<std::unique_ptr<Property>>{}},
           relTableIDs{std::move(relTableIDs)} {}

--- a/src/include/common/null_mask.h
+++ b/src/include/common/null_mask.h
@@ -78,7 +78,8 @@ public:
 
     NullMask() : NullMask{DEFAULT_NUM_NULL_ENTRIES} {}
 
-    NullMask(uint64_t numNullEntries) : mayContainNulls{false}, numNullEntries{numNullEntries} {
+    explicit NullMask(uint64_t numNullEntries)
+        : mayContainNulls{false}, numNullEntries{numNullEntries} {
         buffer = std::make_unique<uint64_t[]>(numNullEntries);
         data = buffer.get();
         std::fill(data, data + numNullEntries, NO_NULL_ENTRY);

--- a/src/include/expression_evaluator/literal_evaluator.h
+++ b/src/include/expression_evaluator/literal_evaluator.h
@@ -7,7 +7,7 @@ namespace evaluator {
 
 class LiteralExpressionEvaluator : public ExpressionEvaluator {
 public:
-    LiteralExpressionEvaluator(std::shared_ptr<common::Value> value)
+    explicit LiteralExpressionEvaluator(std::shared_ptr<common::Value> value)
         : ExpressionEvaluator{true /* isResultFlat */}, value{std::move(value)} {}
 
     ~LiteralExpressionEvaluator() override = default;

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -18,7 +18,8 @@ struct CastFunctionBindData : public FunctionBindData {
     common::CSVReaderConfig csvConfig;
     uint64_t numOfEntries;
 
-    CastFunctionBindData(common::LogicalType dataType) : FunctionBindData{std::move(dataType)} {}
+    explicit CastFunctionBindData(common::LogicalType dataType)
+        : FunctionBindData{std::move(dataType)} {}
 };
 
 struct Function;

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -41,7 +41,7 @@ struct TableFunctionInput {
 struct TableFunctionInitInput {
     TableFuncBindData* bindData;
 
-    TableFunctionInitInput(TableFuncBindData* bindData) : bindData{bindData} {}
+    explicit TableFunctionInitInput(TableFuncBindData* bindData) : bindData{bindData} {}
 
     virtual ~TableFunctionInitInput() = default;
 };

--- a/src/include/function/table_functions/call_functions.h
+++ b/src/include/function/table_functions/call_functions.h
@@ -29,7 +29,7 @@ struct CallFuncSharedState : public TableFuncSharedState {
     common::offset_t curOffset;
     std::mutex mtx;
 
-    CallFuncSharedState(common::offset_t maxOffset) : maxOffset{maxOffset}, curOffset{0} {}
+    explicit CallFuncSharedState(common::offset_t maxOffset) : maxOffset{maxOffset}, curOffset{0} {}
 
     CallFuncMorsel getMorsel();
 };

--- a/src/include/function/table_functions/scan_functions.h
+++ b/src/include/function/table_functions/scan_functions.h
@@ -11,7 +11,7 @@ struct BaseScanSharedState : public TableFuncSharedState {
     uint64_t blockIdx;
     uint64_t numRows;
 
-    BaseScanSharedState(uint64_t numRows) : fileIdx{0}, blockIdx{0}, numRows{numRows} {}
+    explicit BaseScanSharedState(uint64_t numRows) : fileIdx{0}, blockIdx{0}, numRows{numRows} {}
 };
 
 struct ScanSharedState : public BaseScanSharedState {

--- a/src/include/optimizer/correlated_subquery_unnest_solver.h
+++ b/src/include/optimizer/correlated_subquery_unnest_solver.h
@@ -7,7 +7,7 @@ namespace optimizer {
 
 class CorrelatedSubqueryUnnestSolver : public LogicalOperatorVisitor {
 public:
-    CorrelatedSubqueryUnnestSolver(planner::LogicalOperator* accumulateOp)
+    explicit CorrelatedSubqueryUnnestSolver(planner::LogicalOperator* accumulateOp)
         : accumulateOp{accumulateOp} {}
     void solve(planner::LogicalOperator* root_);
 

--- a/src/include/parser/expression/parsed_expression.h
+++ b/src/include/parser/expression/parsed_expression.h
@@ -36,7 +36,7 @@ public:
     ParsedExpression(common::ExpressionType type, std::string rawName)
         : type{type}, rawName{std::move(rawName)} {}
 
-    ParsedExpression(common::ExpressionType type) : type{type} {}
+    explicit ParsedExpression(common::ExpressionType type) : type{type} {}
 
     ParsedExpression(common::ExpressionType type, std::string alias, std::string rawName,
         parsed_expression_vector children)

--- a/src/include/parser/expression/parsed_variable_expression.h
+++ b/src/include/parser/expression/parsed_variable_expression.h
@@ -19,7 +19,7 @@ public:
               std::move(children)},
           variableName{std::move(variableName)} {}
 
-    ParsedVariableExpression(std::string variableName)
+    explicit ParsedVariableExpression(std::string variableName)
         : ParsedExpression{common::ExpressionType::VARIABLE}, variableName{
                                                                   std::move(variableName)} {}
 

--- a/src/include/parser/query/reading_clause/in_query_call_clause.h
+++ b/src/include/parser/query/reading_clause/in_query_call_clause.h
@@ -8,7 +8,7 @@ namespace parser {
 
 class InQueryCallClause : public ReadingClause {
 public:
-    InQueryCallClause(std::unique_ptr<ParsedExpression> functionExpression)
+    explicit InQueryCallClause(std::unique_ptr<ParsedExpression> functionExpression)
         : ReadingClause{common::ClauseType::IN_QUERY_CALL}, functionExpression{
                                                                 std::move(functionExpression)} {}
     ParsedExpression* getFunctionExpression() const { return functionExpression.get(); }

--- a/src/include/parser/query/updating_clause/delete_clause.h
+++ b/src/include/parser/query/updating_clause/delete_clause.h
@@ -8,7 +8,7 @@ namespace parser {
 
 class DeleteClause final : public UpdatingClause {
 public:
-    DeleteClause(common::DeleteClauseType deleteClauseType)
+    explicit DeleteClause(common::DeleteClauseType deleteClauseType)
         : UpdatingClause{common::ClauseType::DELETE_}, deleteClauseType{deleteClauseType} {};
 
     inline void addExpression(std::unique_ptr<ParsedExpression> expression) {

--- a/src/include/parser/transaction_statement.h
+++ b/src/include/parser/transaction_statement.h
@@ -8,7 +8,7 @@ namespace parser {
 
 class TransactionStatement : public Statement {
 public:
-    TransactionStatement(transaction::TransactionAction transactionAction)
+    explicit TransactionStatement(transaction::TransactionAction transactionAction)
         : Statement{common::StatementType::TRANSACTION}, transactionAction{transactionAction} {}
 
     inline transaction::TransactionAction getTransactionAction() const { return transactionAction; }

--- a/src/include/planner/operator/logical_transaction.h
+++ b/src/include/planner/operator/logical_transaction.h
@@ -8,7 +8,7 @@ namespace planner {
 
 class LogicalTransaction : public LogicalOperator {
 public:
-    LogicalTransaction(transaction::TransactionAction transactionAction)
+    explicit LogicalTransaction(transaction::TransactionAction transactionAction)
         : LogicalOperator{LogicalOperatorType::TRANSACTION}, transactionAction{transactionAction} {}
 
     inline std::string getExpressionsForPrinting() const final { return std::string(); }

--- a/src/include/planner/operator/scan/logical_expressions_scan.h
+++ b/src/include/planner/operator/scan/logical_expressions_scan.h
@@ -9,7 +9,7 @@ namespace planner {
 // LogicalExpressionsScan scans from an outer factorize table
 class LogicalExpressionsScan : public LogicalOperator {
 public:
-    LogicalExpressionsScan(binder::expression_vector expressions)
+    explicit LogicalExpressionsScan(binder::expression_vector expressions)
         : LogicalOperator{LogicalOperatorType::EXPRESSIONS_SCAN}, expressions{
                                                                       std::move(expressions)} {}
 

--- a/src/include/planner/operator/scan/logical_scan_file.h
+++ b/src/include/planner/operator/scan/logical_scan_file.h
@@ -8,7 +8,7 @@ namespace planner {
 
 class LogicalScanFile : public LogicalOperator {
 public:
-    LogicalScanFile(std::unique_ptr<binder::BoundFileScanInfo> info)
+    explicit LogicalScanFile(std::unique_ptr<binder::BoundFileScanInfo> info)
         : LogicalOperator{LogicalOperatorType::SCAN_FILE}, info{std::move(info)} {}
 
     inline std::string getExpressionsForPrinting() const override { return std::string(); }

--- a/src/include/planner/subplans_table.h
+++ b/src/include/planner/subplans_table.h
@@ -23,7 +23,7 @@ const uint64_t MAX_LEVEL_TO_PLAN_EXACTLY = 7;
 // Therefore, we try to be factorization aware when keeping optimal plans.
 class SubgraphPlans {
 public:
-    SubgraphPlans(const binder::SubqueryGraph& subqueryGraph);
+    explicit SubgraphPlans(const binder::SubqueryGraph& subqueryGraph);
 
     inline uint64_t getMaxCost() const { return maxCost; }
 

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -39,7 +39,8 @@ class TopKBuffer {
         std::function<bool(common::ValueVector&, common::ValueVector&, common::SelectionVector&)>;
 
 public:
-    TopKBuffer(const OrderByDataInfo& orderByDataInfo) : orderByDataInfo{&orderByDataInfo} {
+    explicit TopKBuffer(const OrderByDataInfo& orderByDataInfo)
+        : orderByDataInfo{&orderByDataInfo} {
         sortState = std::make_unique<TopKSortState>();
     }
 

--- a/src/include/processor/operator/persistent/copy_node.h
+++ b/src/include/processor/operator/persistent/copy_node.h
@@ -17,7 +17,7 @@ class CopyNodeSharedState {
     friend class CopyRdfResource;
 
 public:
-    CopyNodeSharedState(InQueryCallSharedState* readerSharedState)
+    explicit CopyNodeSharedState(InQueryCallSharedState* readerSharedState)
         : readerSharedState{readerSharedState}, pkIndex{nullptr}, currentNodeGroupIdx{0},
           sharedNodeGroup{nullptr} {};
 

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -14,7 +14,7 @@ class ParsingDriver {
     bool rowEmpty;
 
 public:
-    ParsingDriver(common::DataChunk& chunk);
+    explicit ParsingDriver(common::DataChunk& chunk);
     virtual ~ParsingDriver() = default;
 
     bool done(uint64_t rowNum);

--- a/src/include/processor/operator/persistent/reader/parquet/resizable_buffer.h
+++ b/src/include/processor/operator/persistent/reader/parquet/resizable_buffer.h
@@ -60,7 +60,7 @@ public:
 class ResizeableBuffer : public ByteBuffer {
 public:
     ResizeableBuffer() {}
-    ResizeableBuffer(uint64_t new_size) { resize(new_size); }
+    explicit ResizeableBuffer(uint64_t new_size) { resize(new_size); }
     void resize(uint64_t new_size) {
         len = new_size;
         if (new_size == 0) {

--- a/src/include/processor/operator/persistent/reader/parquet/thrift_tools.h
+++ b/src/include/processor/operator/persistent/reader/parquet/thrift_tools.h
@@ -47,7 +47,7 @@ struct ReadHeadComparator {
 // 1: register all ranges that will be read, merging ranges that are consecutive
 // 2: prefetch all registered ranges
 struct ReadAheadBuffer {
-    ReadAheadBuffer(common::FileInfo* handle) : handle(handle) {}
+    explicit ReadAheadBuffer(common::FileInfo* handle) : handle(handle) {}
 
     // The list of read heads
     std::list<ReadHead> read_heads;

--- a/src/include/processor/operator/persistent/writer/parquet/parquet_rle_bp_encoder.h
+++ b/src/include/processor/operator/persistent/writer/parquet/parquet_rle_bp_encoder.h
@@ -7,7 +7,7 @@ namespace processor {
 
 class RleBpEncoder {
 public:
-    RleBpEncoder(uint32_t bitWidth);
+    explicit RleBpEncoder(uint32_t bitWidth);
 
 public:
     // NOTE: Prepare is only required if a byte count is required BEFORE writing

--- a/src/include/processor/operator/recursive_extend/recursive_join.h
+++ b/src/include/processor/operator/recursive_extend/recursive_join.h
@@ -15,7 +15,7 @@ class ScanFrontier;
 struct RecursiveJoinSharedState {
     std::vector<std::unique_ptr<NodeOffsetSemiMask>> semiMasks;
 
-    RecursiveJoinSharedState(std::vector<std::unique_ptr<NodeOffsetSemiMask>> semiMasks)
+    explicit RecursiveJoinSharedState(std::vector<std::unique_ptr<NodeOffsetSemiMask>> semiMasks)
         : semiMasks{std::move(semiMasks)} {}
 };
 

--- a/src/include/processor/result/result_set_descriptor.h
+++ b/src/include/processor/result/result_set_descriptor.h
@@ -25,9 +25,10 @@ struct DataChunkDescriptor {
 struct ResultSetDescriptor {
     std::vector<std::unique_ptr<DataChunkDescriptor>> dataChunkDescriptors;
 
-    ResultSetDescriptor(std::vector<std::unique_ptr<DataChunkDescriptor>> dataChunkDescriptors)
+    explicit ResultSetDescriptor(
+        std::vector<std::unique_ptr<DataChunkDescriptor>> dataChunkDescriptors)
         : dataChunkDescriptors{std::move(dataChunkDescriptors)} {}
-    ResultSetDescriptor(planner::Schema* schema);
+    explicit ResultSetDescriptor(planner::Schema* schema);
 
     std::unique_ptr<ResultSetDescriptor> copy() const;
 };

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -39,7 +39,7 @@ struct RegularRelNGInfo final : public RelNGInfo {
     std::vector<offset_to_row_idx_t> updateInfoPerChunk; // insert info for property chunks.
     offset_set_t deleteInfo;                             // the set of deleted node offsets.
 
-    RegularRelNGInfo(common::column_id_t numChunks) {
+    explicit RegularRelNGInfo(common::column_id_t numChunks) {
         insertInfoPerChunk.resize(numChunks);
         updateInfoPerChunk.resize(numChunks);
     }
@@ -62,7 +62,7 @@ struct CSRRelNGInfo final : public RelNGInfo {
     std::vector<offset_to_offset_to_row_idx_t> updateInfoPerChunk;
     offset_to_offset_set_t deleteInfo;
 
-    CSRRelNGInfo(common::column_id_t numChunks) {
+    explicit CSRRelNGInfo(common::column_id_t numChunks) {
         insertInfoPerChunk.resize(numChunks);
         updateInfoPerChunk.resize(numChunks);
     }

--- a/src/include/storage/local_storage/local_storage.h
+++ b/src/include/storage/local_storage/local_storage.h
@@ -16,7 +16,7 @@ class MemoryManager;
 // thread-safe.
 class LocalStorage {
 public:
-    LocalStorage(storage::MemoryManager* mm);
+    explicit LocalStorage(storage::MemoryManager* mm);
 
     // This function will create the local table data if not exists.
     LocalTableData* getOrCreateLocalTableData(common::table_id_t tableID,

--- a/src/include/storage/stats/metadata_dah_info.h
+++ b/src/include/storage/stats/metadata_dah_info.h
@@ -12,7 +12,7 @@ struct MetadataDAHInfo {
     std::vector<std::unique_ptr<MetadataDAHInfo>> childrenInfos;
 
     MetadataDAHInfo() : MetadataDAHInfo{common::INVALID_PAGE_IDX, common::INVALID_PAGE_IDX} {}
-    MetadataDAHInfo(common::page_idx_t dataDAHPageIdx)
+    explicit MetadataDAHInfo(common::page_idx_t dataDAHPageIdx)
         : MetadataDAHInfo{dataDAHPageIdx, common::INVALID_PAGE_IDX} {}
     MetadataDAHInfo(common::page_idx_t dataDAHPageIdx, common::page_idx_t nullDAHPageIdx)
         : dataDAHPageIdx{dataDAHPageIdx}, nullDAHPageIdx{nullDAHPageIdx} {}

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -149,7 +149,7 @@ public:
 
 class NullColumnChunk : public BoolColumnChunk {
 public:
-    NullColumnChunk(uint64_t capacity)
+    explicit NullColumnChunk(uint64_t capacity)
         : BoolColumnChunk(capacity, false /*hasNullChunk*/), mayHaveNullValue{false} {}
     // Maybe this should be combined with BoolColumnChunk if the only difference is these functions?
     inline bool isNull(common::offset_t pos) const { return getValue<bool>(pos); }

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -23,7 +23,7 @@ struct RelDataReadState : public TableReadState {
     bool readFromLocalStorage;
     LocalRelNG* localNodeGroup;
 
-    RelDataReadState(common::ColumnDataFormat dataFormat);
+    explicit RelDataReadState(common::ColumnDataFormat dataFormat);
     inline bool isOutOfRange(common::offset_t nodeOffset) {
         return nodeOffset < startNodeOffset || nodeOffset >= (startNodeOffset + numNodes);
     }

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -29,7 +29,7 @@ enum class TransactionMode : uint8_t { AUTO = 0, MANUAL = 1 };
 
 class TransactionContext {
 public:
-    TransactionContext(main::Database* database);
+    explicit TransactionContext(main::Database* database);
     ~TransactionContext();
 
     inline bool isAutoTransaction() const { return mode == TransactionMode::AUTO; }

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -491,7 +491,7 @@ public:
 class InternalIDColumnChunk final : public ColumnChunk {
 public:
     // Physically, we only materialize offset of INTERNAL_ID, which is same as INT64,
-    InternalIDColumnChunk(uint64_t capacity)
+    explicit InternalIDColumnChunk(uint64_t capacity)
         : ColumnChunk(LogicalType::INT64(), capacity, false /* enableCompression */) {}
 
     void append(ValueVector* vector) override {

--- a/tools/nodejs_api/src_cpp/include/node_connection.h
+++ b/tools/nodejs_api/src_cpp/include/node_connection.h
@@ -18,7 +18,7 @@ class NodeConnection : public Napi::ObjectWrap<NodeConnection> {
 
 public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    NodeConnection(const Napi::CallbackInfo& info);
+    explicit NodeConnection(const Napi::CallbackInfo& info);
     ~NodeConnection() override = default;
 
 private:

--- a/tools/nodejs_api/src_cpp/include/node_database.h
+++ b/tools/nodejs_api/src_cpp/include/node_database.h
@@ -13,7 +13,7 @@ class NodeDatabase : public Napi::ObjectWrap<NodeDatabase> {
 
 public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    NodeDatabase(const Napi::CallbackInfo& info);
+    explicit NodeDatabase(const Napi::CallbackInfo& info);
     ~NodeDatabase() override = default;
 
 private:

--- a/tools/nodejs_api/src_cpp/include/node_prepared_statement.h
+++ b/tools/nodejs_api/src_cpp/include/node_prepared_statement.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "binder/bound_statement_result.h"
 #include "main/kuzu.h"
 #include "node_connection.h"
-#include "planner/operator/logical_plan.h"
-#include "processor/result/factorized_table.h"
 #include <napi.h>
 
 using namespace kuzu::main;
@@ -15,7 +12,7 @@ class NodePreparedStatement : public Napi::ObjectWrap<NodePreparedStatement> {
 
 public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    NodePreparedStatement(const Napi::CallbackInfo& info);
+    explicit NodePreparedStatement(const Napi::CallbackInfo& info);
     ~NodePreparedStatement() override = default;
 
 private:
@@ -23,7 +20,6 @@ private:
     void InitCppPreparedStatement();
     Napi::Value IsSuccess(const Napi::CallbackInfo& info);
     Napi::Value GetErrorMessage(const Napi::CallbackInfo& info);
-
 
 private:
     std::shared_ptr<PreparedStatement> preparedStatement;

--- a/tools/nodejs_api/src_cpp/include/node_query_result.h
+++ b/tools/nodejs_api/src_cpp/include/node_query_result.h
@@ -16,7 +16,7 @@ class NodeQueryResult : public Napi::ObjectWrap<NodeQueryResult> {
 
 public:
     static Napi::Object Init(Napi::Env env, Napi::Object exports);
-    NodeQueryResult(const Napi::CallbackInfo& info);
+    explicit NodeQueryResult(const Napi::CallbackInfo& info);
     void SetQueryResult(std::shared_ptr<QueryResult>& queryResult);
     ~NodeQueryResult() override = default;
 

--- a/tools/python_api/src_cpp/include/pandas/pandas_column.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_column.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
+
+#include "pybind_include.h"
 
 namespace kuzu {
 
@@ -9,7 +12,7 @@ enum class PandasColumnBackend : uint8_t { NUMPY = 0 };
 
 class PandasColumn {
 public:
-    PandasColumn(PandasColumnBackend backend) : backend(backend) {}
+    explicit PandasColumn(PandasColumnBackend backend) : backend(backend) {}
     virtual ~PandasColumn() = default;
 
 public:
@@ -23,7 +26,7 @@ protected:
 
 class PandasNumpyColumn : public PandasColumn {
 public:
-    PandasNumpyColumn(py::array array)
+    explicit PandasNumpyColumn(py::array array)
         : PandasColumn{PandasColumnBackend::NUMPY}, array{std::move(array)} {}
 
     std::unique_ptr<PandasColumn> copy() const override {

--- a/tools/python_api/src_cpp/include/pybind_include.h
+++ b/tools/python_api/src_cpp/include/pybind_include.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <pybind11/numpy.h>
-#include <pybind11/pybind11.h>
-#include <pybind11/stl.h>
+#include <pybind11/numpy.h>    // IWYU pragma: export
+#include <pybind11/pybind11.h> // IWYU pragma: export
+#include <pybind11/stl.h>      // IWYU pragma: export
 
 namespace py = pybind11;


### PR DESCRIPTION
Explicit constructors are better for performance and readability, in most cases. This check enforces them, everywhere.