### PR TITLE
Constant compression

### DIFF
--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -40,8 +40,8 @@ public:
     inline void setAllNonNull() { nullMask->setAllNonNull(); }
     // On return true, there are no null. On return false, there may or may not be nulls.
     inline bool hasNoNullsGuarantee() const { return nullMask->hasNoNullsGuarantee(); }
-    inline void setRangeNonNull(uint32_t startPos, uint32_t len) {
-        nullMask->setNullFromRange(startPos, len, false);
+    inline void setNullRange(uint32_t startPos, uint32_t len, bool value) {
+        nullMask->setNullFromRange(startPos, len, value);
     }
     inline const uint64_t* getNullMaskData() { return nullMask->getData(); }
     KUZU_API void setNull(uint32_t pos, bool isNull);

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -243,6 +243,9 @@ public:
 
     void decompressFromPage(const uint8_t* srcBuffer, uint64_t srcOffset, uint8_t* dstBuffer,
         uint64_t dstOffset, uint64_t numValues, const CompressionMetadata& metadata) const final;
+
+    void copyFromPage(const uint8_t* srcBuffer, uint64_t srcOffset, uint8_t* dstBuffer,
+        uint64_t dstOffset, uint64_t numValues, const CompressionMetadata& metadata) const;
 };
 
 class CompressedFunctor {

--- a/src/include/storage/storage_structure/disk_overflow_file.h
+++ b/src/include/storage/storage_structure/disk_overflow_file.h
@@ -58,8 +58,8 @@ private:
     // that will be written to. The position of the value, which determines the original page to
     // update, is computed from the given elementOffset and numElementsPerPage argument. Obtains
     // *and does not release* the lock original page. Pins and updates the WAL version of the
-    // page. Note that caller must ensure to unpin and release the WAL version of the page by
-    // calling StorageStructureUtils::unpinWALPageAndReleaseOriginalPageLock.
+    // page. The original page lock will be released when the WALPageIdxPosInPageAndFrame goes out
+    // of scope
     WALPageIdxPosInPageAndFrame createWALVersionOfPageIfNecessaryForElement(
         uint64_t elementOffset, uint64_t numElementsPerPage);
 

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -135,15 +135,16 @@ protected:
     WALPageIdxPosInPageAndFrame createWALVersionOfPageForValue(
         common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk);
 
+    virtual void commitLocalChunkInPlace(transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
+        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo,
+        const offset_set_t& deleteInfo);
+
 private:
     static bool containsVarList(common::LogicalType& dataType);
     virtual bool canCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
         const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo);
-    void commitLocalChunkInPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
-        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo,
-        const offset_set_t& deleteInfo);
     void commitLocalChunkOutOfPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
         bool isNewNodeGroup, const offset_to_row_idx_t& insertInfo,
@@ -158,6 +159,8 @@ private:
     static inline bool isInRange(uint64_t val, uint64_t start, uint64_t end) {
         return val >= start && val < end;
     }
+
+    virtual std::unique_ptr<ColumnChunk> getEmptyChunkForCommit();
 
 protected:
     DBFileID dbFileID;

--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -66,7 +66,6 @@ private:
     std::unique_ptr<ColumnChunk> stringDataChunk;
     std::unique_ptr<ColumnChunk> offsetChunk;
     std::unordered_map<std::string, string_index_t, string_hash, std::equal_to<>> indexTable;
-    bool enableCompression;
     // If we never update a value, we don't need to prune unused strings in finalize
     bool needFinalize;
 };

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -64,7 +64,7 @@ private:
 
     inline void initializeIndices() {
         indicesColumnChunk = ColumnChunkFactory::createColumnChunk(
-            common::LogicalType::INT64(), false /* enableCompression */);
+            common::LogicalType::INT64(), false /*enableCompression*/);
         indicesColumnChunk->getNullChunk()->resetToAllNull();
         for (auto i = 0u; i < numValues; i++) {
             indicesColumnChunk->setValue<common::offset_t>(i, i);
@@ -83,7 +83,6 @@ private:
     void appendNullList();
 
 protected:
-    bool enableCompression;
     std::unique_ptr<VarListDataColumnChunk> varListDataColumnChunk;
     // The following is needed to write var list to random positions in the column chunk.
     // We first append var list to the end of the column chunk. Then use indicesColumnChunk to track

--- a/src/storage/storage_structure/db_file_utils.cpp
+++ b/src/storage/storage_structure/db_file_utils.cpp
@@ -85,8 +85,10 @@ void DBFileUtils::unpinWALPageAndReleaseOriginalPageLock(WALPageIdxAndFrame& wal
 
 void DBFileUtils::unpinPageIdxInWALAndReleaseOriginalPageLock(page_idx_t pageIdxInWAL,
     page_idx_t originalPageIdx, BMFileHandle& fileHandle, BufferManager& bufferManager, WAL& wal) {
-    bufferManager.unpin(*wal.fileHandle, pageIdxInWAL);
-    fileHandle.releaseWALPageIdxLock(originalPageIdx);
+    if (originalPageIdx != INVALID_PAGE_IDX) {
+        bufferManager.unpin(*wal.fileHandle, pageIdxInWAL);
+        fileHandle.releaseWALPageIdxLock(originalPageIdx);
+    }
 }
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/storage_structure/disk_overflow_file.cpp
+++ b/src/storage/storage_structure/disk_overflow_file.cpp
@@ -56,8 +56,6 @@ void DiskOverflowFile::setStringOverflowWithoutLock(
     TypeUtils::encodeOverflowPtr(diskDstString.overflowPtr,
         updatedPageInfoAndWALPageFrame.originalPageIdx, updatedPageInfoAndWALPageFrame.posInPage);
     nextBytePosToWriteTo += len;
-    DBFileUtils::unpinWALPageAndReleaseOriginalPageLock(
-        updatedPageInfoAndWALPageFrame, *fileHandle, *bufferManager, *wal);
 }
 
 ku_string_t DiskOverflowFile::writeString(const char* rawString) {

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -75,72 +75,12 @@ struct NullColumnFunc {
     }
 };
 
-struct BoolColumnFunc {
-    static void readValuesFromPageToVector(uint8_t* frame, PageElementCursor& pageCursor,
-        ValueVector* resultVector, uint32_t posInVector, uint32_t numValuesToRead,
-        const CompressionMetadata& /*metadata*/) {
-        // Read bit-packed null flags from the frame into the result vector
-        // Casting to uint64_t should be safe as long as the page size is a multiple of 8 bytes.
-        // Otherwise, it could read off the end of the page.
-        //
-        // Currently, the frame stores bitpacked bools, but the value_vector does not
-        for (auto i = 0u; i < numValuesToRead; i++) {
-            resultVector->setValue(
-                posInVector + i, NullMask::isNull((uint64_t*)frame, pageCursor.elemPosInPage + i));
-        }
-    }
-
-    static void writeValueToPageFromVector(uint8_t* frame, uint16_t posInFrame, ValueVector* vector,
-        uint32_t posInVector, const CompressionMetadata& /*metadata*/) {
-        // Casting to uint64_t should be safe as long as the page size is a multiple of 8 bytes.
-        // Otherwise, it could read/write off the end of the page.
-        NullMask::setNull((uint64_t*)frame, posInFrame, vector->getValue<bool>(posInVector));
-    }
-
-    static void writeValuesToPage(uint8_t* frame, uint16_t posInFrame, const uint8_t* data,
-        offset_t dataOffset, offset_t numValues, const CompressionMetadata& /*metadata*/) {
-        // Casting to uint64_t should be safe as long as the page size is a multiple of 8 bytes.
-        // Otherwise, it could read/write off the end of the page.
-        for (offset_t i = 0; i < numValues; i++) {
-            NullMask::setNull(
-                (uint64_t*)frame, posInFrame, NullMask::isNull((uint64_t*)data, dataOffset));
-        }
-    }
-
-    static void copyValuesFromPage(uint8_t* frame, PageElementCursor& pageCursor, uint8_t* result,
-        uint32_t startPosInResult, uint64_t numValuesToRead,
-        const CompressionMetadata& /*metadata*/) {
-        NullMask::copyNullMask((uint64_t*)frame, pageCursor.elemPosInPage, (uint64_t*)result,
-            startPosInResult, numValuesToRead);
-    }
-
-    static void batchLookupFromPage(uint8_t* frame, PageElementCursor& pageCursor, uint8_t* result,
-        uint32_t startPosInResult, uint64_t numValuesToRead,
-        const CompressionMetadata& /*metadata*/) {
-        for (auto i = 0u; i < numValuesToRead; i++) {
-            result[startPosInResult + i] =
-                NullMask::isNull((uint64_t*)frame, pageCursor.elemPosInPage + i);
-        }
-    }
-};
-
 static read_values_to_vector_func_t getReadValuesToVectorFunc(const LogicalType& logicalType) {
     switch (logicalType.getLogicalTypeID()) {
     case LogicalTypeID::INTERNAL_ID:
         return InternalIDColumnFunc::readValuesFromPageToVector;
-    case LogicalTypeID::BOOL:
-        return BoolColumnFunc::readValuesFromPageToVector;
     default:
         return ReadCompressedValuesFromPageToVector(logicalType);
-    }
-}
-
-static read_values_to_page_func_t getReadValuesToPageFunc(const LogicalType& logicalType) {
-    switch (logicalType.getLogicalTypeID()) {
-    case LogicalTypeID::BOOL:
-        return BoolColumnFunc::copyValuesFromPage;
-    default:
-        return ReadCompressedValuesFromPage(logicalType);
     }
 }
 
@@ -148,8 +88,6 @@ static write_values_from_vector_func_t getWriteValueFromVectorFunc(const Logical
     switch (logicalType.getLogicalTypeID()) {
     case LogicalTypeID::INTERNAL_ID:
         return InternalIDColumnFunc::writeValueToPageFromVector;
-    case LogicalTypeID::BOOL:
-        return BoolColumnFunc::writeValueToPageFromVector;
     default:
         return WriteCompressedValueToPageFromVector(logicalType);
     }
@@ -159,20 +97,8 @@ static write_values_func_t getWriteValuesFunc(const LogicalType& logicalType) {
     switch (logicalType.getLogicalTypeID()) {
     case LogicalTypeID::INTERNAL_ID:
         return InternalIDColumnFunc::writeValuesToPage;
-    case LogicalTypeID::BOOL:
-        return BoolColumnFunc::writeValuesToPage;
     default:
         return WriteCompressedValuesToPage(logicalType);
-    }
-}
-
-static batch_lookup_func_t getBatchLookupFromPageFunc(const LogicalType& logicalType) {
-    switch (logicalType.getLogicalTypeID()) {
-    case LogicalTypeID::BOOL:
-        return BoolColumnFunc::batchLookupFromPage;
-    default: {
-        return ReadCompressedValuesFromPage(logicalType);
-    }
     }
 }
 
@@ -249,31 +175,24 @@ public:
 
     bool isNull(transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx,
         offset_t offsetInChunk) override {
-        auto cursor = getPageCursorForOffset(transaction->getType(), nodeGroupIdx, offsetInChunk);
-        auto chunkMeta = metadataDA->get(nodeGroupIdx, transaction->getType());
-        if (offsetInChunk >= chunkMeta.numValues) {
+        auto state = getReadState(transaction->getType(), nodeGroupIdx);
+        uint64_t result = false;
+        if (offsetInChunk >= state.metadata.numValues) {
             return true;
         }
-        KU_ASSERT(cursor.pageIdx < chunkMeta.pageIdx + chunkMeta.numPages);
-        bool result = false;
-        readFromPage(transaction, cursor.pageIdx, [&](uint8_t* frame) -> void {
-            result = NullMask::isNull((uint64_t*)frame, cursor.elemPosInPage);
-        });
+        // Must be aligned to an 8-byte chunk for NullMask read to not overflow
+        Column::scan(transaction, state, offsetInChunk, offsetInChunk + 1,
+            reinterpret_cast<uint8_t*>(&result));
         return result;
     }
 
     void setNull(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk) override {
-        auto walPageInfo = createWALVersionOfPageForValue(nodeGroupIdx, offsetInChunk);
-        try {
-            propertyStatistics.setHasNull(DUMMY_WRITE_TRANSACTION);
-            NullMask::setNull((uint64_t*)walPageInfo.frame, walPageInfo.posInPage, true);
-        } catch (Exception& e) {
-            bufferManager->unpin(*wal->fileHandle, walPageInfo.pageIdxInWAL);
-            dataFH->releaseWALPageIdxLock(walPageInfo.originalPageIdx);
-            throw;
-        }
-        bufferManager->unpin(*wal->fileHandle, walPageInfo.pageIdxInWAL);
-        dataFH->releaseWALPageIdxLock(walPageInfo.originalPageIdx);
+        auto chunkMeta = metadataDA->get(nodeGroupIdx, TransactionType::WRITE);
+        propertyStatistics.setHasNull(DUMMY_WRITE_TRANSACTION);
+        // Must be aligned to an 8-byte chunk for NullMask read to not overflow
+        uint64_t value = true;
+        writeValue(
+            chunkMeta, nodeGroupIdx, offsetInChunk, reinterpret_cast<const uint8_t*>(&value));
     }
 
     void write(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk,
@@ -349,8 +268,8 @@ Column::Column(std::unique_ptr<LogicalType> dataType, const MetadataDAHInfo& met
         transaction);
     numBytesPerFixedSizedValue = getDataTypeSizeInChunk(*this->dataType);
     readToVectorFunc = getReadValuesToVectorFunc(*this->dataType);
-    readToPageFunc = getReadValuesToPageFunc(*this->dataType);
-    batchLookupFunc = getBatchLookupFromPageFunc(*this->dataType);
+    readToPageFunc = ReadCompressedValuesFromPage(*this->dataType);
+    batchLookupFunc = ReadCompressedValuesFromPage(*this->dataType);
     writeFromVectorFunc = getWriteValueFromVectorFunc(*this->dataType);
     writeFunc = getWriteValuesFunc(*this->dataType);
     KU_ASSERT(numBytesPerFixedSizedValue <= BufferPoolConstants::PAGE_4KB_SIZE);

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -145,12 +145,13 @@ static std::shared_ptr<CompressionAlg> getCompression(
 ColumnChunk::ColumnChunk(std::unique_ptr<LogicalType> dataType, uint64_t capacity,
     bool enableCompression, bool hasNullChunk)
     : dataType{std::move(dataType)},
-      numBytesPerValue{getDataTypeSizeInChunk(*this->dataType)}, numValues{0} {
+      numBytesPerValue{getDataTypeSizeInChunk(*this->dataType)}, numValues{0},
+      enableCompression(enableCompression) {
     if (hasNullChunk) {
-        nullChunk = std::make_unique<NullColumnChunk>(capacity);
+        nullChunk = std::make_unique<NullColumnChunk>(capacity, enableCompression);
     }
     initializeBuffer(capacity);
-    initializeFunction(enableCompression);
+    initializeFunction();
 }
 
 void ColumnChunk::initializeBuffer(offset_t capacity_) {
@@ -163,7 +164,7 @@ void ColumnChunk::initializeBuffer(offset_t capacity_) {
     }
 }
 
-void ColumnChunk::initializeFunction(bool enableCompression) {
+void ColumnChunk::initializeFunction() {
     switch (this->dataType->getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
         // Since we compress into memory, storage is the same as fixed-sized values,
@@ -248,8 +249,7 @@ void ColumnChunk::write(ValueVector* vector, ValueVector* offsetsInChunk, bool i
 }
 
 // NOTE: This function is only called in LocalTable right now when performing out-of-place
-// committing. While BOOL never triggers that, overriding of this function in BoolColumnChunk is
-// skipped. Also, VAR_LIST has a different logic for handling out-of-place committing as it has to
+// committing. VAR_LIST has a different logic for handling out-of-place committing as it has to
 // be slided. However, this is unsafe, as this function can also be used for other purposes later.
 // Thus, an assertion is added at the first line.
 void ColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
@@ -337,12 +337,22 @@ void ColumnChunk::setNumValues(uint64_t numValues_) {
 
 ColumnChunkMetadata ColumnChunk::getMetadataToFlush() const {
     KU_ASSERT(numValues <= capacity);
+    if (enableCompression) {
+        // Determine if we can make use of constant compression
+        auto constantMetadata = ConstantCompression::analyze(*this);
+        if (constantMetadata) {
+            return ColumnChunkMetadata(INVALID_PAGE_IDX, 0, numValues, *constantMetadata);
+        }
+    }
     return getMetadataFunction(buffer.get(), bufferSize, capacity, numValues);
 }
 
 ColumnChunkMetadata ColumnChunk::flushBuffer(
     BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
-    return flushBufferFunction(buffer.get(), bufferSize, dataFH, startPageIdx, metadata);
+    if (!metadata.compMeta.isConstant()) {
+        return flushBufferFunction(buffer.get(), bufferSize, dataFH, startPageIdx, metadata);
+    }
+    return metadata;
 }
 
 uint64_t ColumnChunk::getBufferSize() const {
@@ -394,10 +404,10 @@ void BoolColumnChunk::write(
         auto offsetInChunk = offsets[offsetInChunkVector->state->selVector->selectedPositions[i]];
         KU_ASSERT(offsetInChunk < capacity);
         auto offsetInVector = valueVector->state->selVector->selectedPositions[i];
-        NullMask::copyNullMask((uint64_t*)valueVector->getData(), offsetInVector,
-            (uint64_t*)buffer.get(), offsetInChunk, 1);
+        NullMask::setNull(
+            (uint64_t*)buffer.get(), offsetInChunk, valueVector->getValue<bool>(offsetInVector));
         if (nullChunk) {
-            nullChunk->setNull(offsetInChunk, valueVector->isNull(offsetInVector));
+            nullChunk->write(valueVector, offsetInVector, offsetInChunk);
         }
         numValues = offsetInChunk >= numValues ? offsetInChunk + 1 : numValues;
     }
@@ -406,11 +416,15 @@ void BoolColumnChunk::write(
 void BoolColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::BOOL);
     KU_ASSERT(offsetInChunk < capacity);
-    NullMask::copyNullMask(
-        (uint64_t*)vector->getData(), offsetInVector, (uint64_t*)buffer.get(), offsetInChunk, 1);
+    setValue(vector->getValue<bool>(offsetInVector), offsetInChunk);
     if (nullChunk) {
-        nullChunk->setNull(offsetInChunk, vector->isNull(offsetInVector));
+        nullChunk->write(vector, offsetInVector, offsetInChunk);
     }
+    numValues = offsetInChunk >= numValues ? offsetInChunk + 1 : numValues;
+}
+
+void NullColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
+    setNull(offsetInChunk, vector->isNull(offsetInVector));
     numValues = offsetInChunk >= numValues ? offsetInChunk + 1 : numValues;
 }
 
@@ -453,7 +467,7 @@ public:
                 offsets[offsetInChunkVector->state->selVector->selectedPositions[i]];
             KU_ASSERT(offsetInChunk < capacity);
             auto offsetInVector = valueVector->state->selVector->selectedPositions[i];
-            nullChunk->setNull(offsetInChunk, valueVector->isNull(offsetInVector));
+            nullChunk->write(valueVector, offsetInVector, offsetInChunk);
             if (!valueVector->isNull(offsetInVector)) {
                 memcpy(buffer.get() + getOffsetInBuffer(offsetInChunk),
                     valueVector->getData() + offsetInVector * numBytesPerValue, numBytesPerValue);
@@ -466,7 +480,7 @@ public:
         common::offset_t offsetInChunk) final {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::FIXED_LIST);
         KU_ASSERT(offsetInChunk < capacity);
-        nullChunk->setNull(offsetInChunk, vector->isNull(offsetInVector));
+        nullChunk->write(vector, offsetInVector, offsetInChunk);
         if (!vector->isNull(offsetInVector)) {
             memcpy(buffer.get() + getOffsetInBuffer(offsetInChunk),
                 vector->getData() + offsetInVector * numBytesPerValue, numBytesPerValue);
@@ -489,7 +503,7 @@ class InternalIDColumnChunk final : public ColumnChunk {
 public:
     // Physically, we only materialize offset of INTERNAL_ID, which is same as INT64,
     explicit InternalIDColumnChunk(uint64_t capacity)
-        : ColumnChunk(LogicalType::INT64(), capacity, false /* enableCompression */) {}
+        : ColumnChunk(LogicalType::INT64(), capacity, false /*enableCompression*/) {}
 
     void append(ValueVector* vector) override {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
@@ -512,7 +526,7 @@ std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(
     std::unique_ptr<LogicalType> dataType, bool enableCompression, uint64_t capacity) {
     switch (dataType->getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
-        return std::make_unique<BoolColumnChunk>(capacity);
+        return std::make_unique<BoolColumnChunk>(capacity, enableCompression);
     }
     case PhysicalTypeID::INT64:
     case PhysicalTypeID::INT32:

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -270,9 +270,6 @@ void ColumnChunk::resize(uint64_t newCapacity) {
     auto numBytesAfterResize = getBufferSize();
     if (numBytesAfterResize > bufferSize) {
         auto resizedBuffer = std::make_unique<uint8_t[]>(numBytesAfterResize);
-        if (dataType->getPhysicalType() == PhysicalTypeID::BOOL) {
-            memset(resizedBuffer.get(), 0 /* non null */, numBytesAfterResize);
-        }
         memcpy(resizedBuffer.get(), buffer.get(), bufferSize);
         bufferSize = numBytesAfterResize;
         buffer = std::move(resizedBuffer);

--- a/src/storage/store/string_column_chunk.cpp
+++ b/src/storage/store/string_column_chunk.cpp
@@ -18,10 +18,10 @@ static const uint64_t OFFSET_CHUNK_INITIAL_CAPACITY = StorageConstants::NODE_GRO
 
 StringColumnChunk::StringColumnChunk(
     std::unique_ptr<LogicalType> dataType, uint64_t capacity, bool enableCompression)
-    : ColumnChunk{std::move(dataType), capacity, enableCompression},
-      enableCompression(enableCompression), needFinalize{false} {
+    : ColumnChunk{std::move(dataType), capacity, enableCompression}, needFinalize{false} {
     // Bitpacking might save 1 bit per value with regular ascii compared to UTF-8
-    stringDataChunk = ColumnChunkFactory::createColumnChunk(LogicalType::UINT8(), false);
+    stringDataChunk =
+        ColumnChunkFactory::createColumnChunk(LogicalType::UINT8(), false /*enableCompression*/);
     offsetChunk = ColumnChunkFactory::createColumnChunk(
         LogicalType::UINT64(), enableCompression, OFFSET_CHUNK_INITIAL_CAPACITY);
 }

--- a/src/storage/store/var_list_column_chunk.cpp
+++ b/src/storage/store/var_list_column_chunk.cpp
@@ -26,7 +26,7 @@ void VarListDataColumnChunk::resizeBuffer(uint64_t numValues) {
 VarListColumnChunk::VarListColumnChunk(
     std::unique_ptr<LogicalType> dataType, uint64_t capacity, bool enableCompression)
     : ColumnChunk{std::move(dataType), capacity, enableCompression, true /* hasNullChunk */},
-      enableCompression{enableCompression}, needFinalize{false} {
+      needFinalize{false} {
     varListDataColumnChunk =
         std::make_unique<VarListDataColumnChunk>(ColumnChunkFactory::createColumnChunk(
             VarListType::getChildType(this->dataType.get())->copy(), enableCompression,


### PR DESCRIPTION
Constant compressed columns use `INVALID_PAGE_IDX` as their page index in the metadata, and reading from them uses the normal functions, but there's a special case for when we try to read from an `INVALID_PAGE_IDX`.

To get it working for nulls I had to set up out of place commits for the null column. This always happens when the parent column does an out of place commit (unnecessary, but it would take a lot of work to de-couple that I think), but we may now need to do an out-of-place commit for the null column when doing an in-place commit on its parent column. As such, I've removed in-place updates to the null column when we do in-place updates to the parent column, and have it otherwise doing an out-of-place update on the null column only if the main column does an in-place update to avoid duplicating work.

I'd added some bounds checking, and more fine-grained control over the compression choices at the ColumChunk level when debugging, which I've left in, but could be removed since I was able to get it working for every fixed-sized type.