### PR TITLE
tidy: add const checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -25,6 +25,10 @@ Checks:
 
   modernize-use-override,
 
+  readability-const-return-type,
+  readability-make-member-function-const,
+  readability-non-const-parameter,
+
 HeaderFilterRegex:
   src/include|tools/benchmark/include|tools/nodejs_api/src_cpp/include|tools/python_api/src_cpp/include|tools/rust_api/include|tools/shell/include
 WarningsAsErrors: "*"

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -396,6 +396,7 @@ struct SplitStringMapOperation {
     uint64_t& offset;
     ValueVector* resultVector;
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
     inline bool handleKey(const char* start, const char* end, const CSVOption* option) {
         trimRightWhitespace(start, end);
         CastString::copyStringToVector(StructVector::getFieldVector(resultVector, 0).get(), offset,

--- a/src/include/common/data_chunk/data_chunk_state.h
+++ b/src/include/common/data_chunk/data_chunk_state.h
@@ -26,7 +26,7 @@ public:
         selVector->selectedSize = size;
     }
     inline void setOriginalSize(uint64_t size) { originalSize = size; }
-    inline uint64_t getOriginalSize() { return originalSize; }
+    inline uint64_t getOriginalSize() const { return originalSize; }
     inline bool isFlat() const { return fStateType == FStateType::FLAT; }
     inline void setToFlat() { fStateType = FStateType::FLAT; }
     inline void setToUnflat() { fStateType = FStateType::UNFLAT; }

--- a/src/include/common/serializer/buffered_serializer.h
+++ b/src/include/common/serializer/buffered_serializer.h
@@ -27,9 +27,9 @@ public:
     // Retrieves the data after the writing has been completed.
     inline BinaryData getData() { return std::move(blob); }
 
-    inline uint64_t getSize() { return blob.size; }
+    inline uint64_t getSize() const { return blob.size; }
 
-    inline uint8_t* getBlobData() { return blob.data.get(); }
+    inline uint8_t* getBlobData() const { return blob.data.get(); }
 
     inline void reset() { blob.size = 0; }
 

--- a/src/include/common/types/blob.h
+++ b/src/include/common/types/blob.h
@@ -39,6 +39,7 @@ struct Blob {
         return *reinterpret_cast<const T*>(data.value.getData());
     }
     template<typename T>
+    // NOLINTNEXTLINE(readability-non-const-parameter): Would cast away qualifiers.
     static inline T getValue(char* data) {
         return *reinterpret_cast<T*>(data);
     }

--- a/src/include/function/aggregate/avg.h
+++ b/src/include/function/aggregate/avg.h
@@ -26,7 +26,7 @@ struct AvgFunction {
 
     static void updateAll(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,
         storage::MemoryManager* /*memoryManager*/) {
-        auto state = reinterpret_cast<AvgState*>(state_);
+        auto* state = reinterpret_cast<AvgState*>(state_);
         KU_ASSERT(!input->state->isFlat());
         if (input->hasNoNullsGuarantee()) {
             for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
@@ -64,11 +64,11 @@ struct AvgFunction {
 
     static void combine(
         uint8_t* state_, uint8_t* otherState_, storage::MemoryManager* /*memoryManager*/) {
-        auto otherState = reinterpret_cast<AvgState*>(otherState_);
+        auto* otherState = reinterpret_cast<AvgState*>(otherState_);
         if (otherState->isNull) {
             return;
         }
-        auto state = reinterpret_cast<AvgState*>(state_);
+        auto* state = reinterpret_cast<AvgState*>(state_);
         if (state->isNull) {
             state->sum = otherState->sum;
             state->isNull = false;
@@ -79,7 +79,7 @@ struct AvgFunction {
     }
 
     static void finalize(uint8_t* state_) {
-        auto state = reinterpret_cast<AvgState*>(state_);
+        auto* state = reinterpret_cast<AvgState*>(state_);
         if (!state->isNull) {
             state->avg = state->sum / (double_t)state->count;
         }

--- a/src/include/function/aggregate/count.h
+++ b/src/include/function/aggregate/count.h
@@ -10,6 +10,7 @@ struct CountFunction : public BaseCountFunction {
     static void updateAll(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,
         storage::MemoryManager* memoryManager);
 
+    // NOLINTNEXTLINE(readability-non-const-parameter): Would cast away qualifiers.
     static inline void updatePos(uint8_t* state_, common::ValueVector* /*input*/,
         uint64_t multiplicity, uint32_t /*pos*/, storage::MemoryManager* /*memoryManager*/) {
         reinterpret_cast<CountState*>(state_)->count += multiplicity;

--- a/src/include/function/aggregate/min_max.h
+++ b/src/include/function/aggregate/min_max.h
@@ -26,7 +26,7 @@ struct MinMaxFunction {
     static void updateAll(uint8_t* state_, common::ValueVector* input, uint64_t /*multiplicity*/,
         storage::MemoryManager* memoryManager) {
         KU_ASSERT(!input->state->isFlat());
-        auto state = reinterpret_cast<MinMaxState*>(state_);
+        auto* state = reinterpret_cast<MinMaxState*>(state_);
         if (input->hasNoNullsGuarantee()) {
             for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
                 auto pos = input->state->selVector->selectedPositions[i];
@@ -68,11 +68,11 @@ struct MinMaxFunction {
     template<class OP>
     static void combine(
         uint8_t* state_, uint8_t* otherState_, storage::MemoryManager* memoryManager) {
-        auto otherState = reinterpret_cast<MinMaxState*>(otherState_);
+        auto* otherState = reinterpret_cast<MinMaxState*>(otherState_);
         if (otherState->isNull) {
             return;
         }
-        auto state = reinterpret_cast<MinMaxState*>(state_);
+        auto* state = reinterpret_cast<MinMaxState*>(state_);
         if (state->isNull) {
             state->setVal(otherState->val, memoryManager);
             state->isNull = false;

--- a/src/include/function/aggregate/sum.h
+++ b/src/include/function/aggregate/sum.h
@@ -24,7 +24,7 @@ struct SumFunction {
     static void updateAll(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,
         storage::MemoryManager* /*memoryManager*/) {
         KU_ASSERT(!input->state->isFlat());
-        auto state = reinterpret_cast<SumState*>(state_);
+        auto* state = reinterpret_cast<SumState*>(state_);
         if (input->hasNoNullsGuarantee()) {
             for (auto i = 0u; i < input->state->selVector->selectedSize; ++i) {
                 auto pos = input->state->selVector->selectedPositions[i];
@@ -42,7 +42,7 @@ struct SumFunction {
 
     static inline void updatePos(uint8_t* state_, common::ValueVector* input, uint64_t multiplicity,
         uint32_t pos, storage::MemoryManager* /*memoryManager*/) {
-        auto state = reinterpret_cast<SumState*>(state_);
+        auto* state = reinterpret_cast<SumState*>(state_);
         updateSingleValue(state, input, pos, multiplicity);
     }
 
@@ -61,11 +61,11 @@ struct SumFunction {
 
     static void combine(
         uint8_t* state_, uint8_t* otherState_, storage::MemoryManager* /*memoryManager*/) {
-        auto otherState = reinterpret_cast<SumState*>(otherState_);
+        auto* otherState = reinterpret_cast<SumState*>(otherState_);
         if (otherState->isNull) {
             return;
         }
-        auto state = reinterpret_cast<SumState*>(state_);
+        auto* state = reinterpret_cast<SumState*>(state_);
         if (state->isNull) {
             state->sum = otherState->sum;
             state->isNull = false;

--- a/src/include/function/aggregate_function.h
+++ b/src/include/function/aggregate_function.h
@@ -54,32 +54,35 @@ struct AggregateFunction final : public BaseScalarFunction {
               std::move(combineFunc), std::move(finalizeFunc), isDistinct, nullptr /* bindFunc */,
               std::move(paramRewriteFunc)} {}
 
-    inline uint32_t getAggregateStateSize() { return initialNullAggregateState->getStateSize(); }
+    inline uint32_t getAggregateStateSize() const {
+        return initialNullAggregateState->getStateSize();
+    }
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Returns a non-const pointer.
     inline AggregateState* getInitialNullAggregateState() {
         return initialNullAggregateState.get();
     }
 
-    inline std::unique_ptr<AggregateState> createInitialNullAggregateState() {
+    inline std::unique_ptr<AggregateState> createInitialNullAggregateState() const {
         return initializeFunc();
     }
 
     inline void updateAllState(uint8_t* state, common::ValueVector* input, uint64_t multiplicity,
-        storage::MemoryManager* memoryManager) {
+        storage::MemoryManager* memoryManager) const {
         return updateAllFunc(state, input, multiplicity, memoryManager);
     }
 
     inline void updatePosState(uint8_t* state, common::ValueVector* input, uint64_t multiplicity,
-        uint32_t pos, storage::MemoryManager* memoryManager) {
+        uint32_t pos, storage::MemoryManager* memoryManager) const {
         return updatePosFunc(state, input, multiplicity, pos, memoryManager);
     }
 
     inline void combineState(
-        uint8_t* state, uint8_t* otherState, storage::MemoryManager* memoryManager) {
+        uint8_t* state, uint8_t* otherState, storage::MemoryManager* memoryManager) const {
         return combineFunc(state, otherState, memoryManager);
     }
 
-    inline void finalizeState(uint8_t* state) { return finalizeFunc(state); }
+    inline void finalizeState(uint8_t* state) const { return finalizeFunc(state); }
 
     inline bool isFunctionDistinct() const { return isDistinct; }
 

--- a/src/include/processor/operator/order_by/key_block_merger.h
+++ b/src/include/processor/operator/order_by/key_block_merger.h
@@ -135,7 +135,7 @@ public:
     }
 
 private:
-    uint64_t findRightKeyBlockIdx(uint8_t* leftEndTuplePtr);
+    uint64_t findRightKeyBlockIdx(uint8_t* leftEndTuplePtr) const;
 
 public:
     static const uint32_t batch_size = 10000;

--- a/src/include/processor/operator/order_by/order_by_scan.h
+++ b/src/include/processor/operator/order_by/order_by_scan.h
@@ -13,6 +13,7 @@ struct OrderByScanLocalState {
     void init(
         std::vector<DataPos>& outVectorPos, SortSharedState& sharedState, ResultSet& resultSet);
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Updates vectorsToRead.
     inline uint64_t scan() { return payloadScanner->scan(vectorsToRead); }
 };
 

--- a/src/include/processor/operator/order_by/radix_sort.h
+++ b/src/include/processor/operator/order_by/radix_sort.h
@@ -40,7 +40,7 @@ private:
         uint32_t numBytesToSort);
 
     std::vector<TieRange> findTies(uint8_t* keyBlockPtr, uint32_t numTuplesToFindTies,
-        uint32_t numBytesToSort, uint32_t baseTupleIdx);
+        uint32_t numBytesToSort, uint32_t baseTupleIdx) const;
 
     void fillTmpTuplePtrSortingBlock(TieRange& keyBlockTie, uint8_t* keyBlockPtr);
 

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -17,11 +17,11 @@ public:
 
     void finalize();
 
-    inline uint64_t getNumTuples() { return numTuples; }
+    inline uint64_t getNumTuples() const { return numTuples; }
 
     inline SortSharedState* getSharedState() { return orderBySharedState.get(); }
 
-    std::unique_ptr<PayloadScanner> getScanner(uint64_t skip, uint64_t limit) {
+    std::unique_ptr<PayloadScanner> getScanner(uint64_t skip, uint64_t limit) const {
         return std::make_unique<PayloadScanner>(orderBySharedState->getMergedKeyBlock(),
             orderBySharedState->getPayloadTables(), skip, limit);
     }
@@ -51,11 +51,12 @@ public:
 
     void reduce();
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
     inline void finalize() { sortState->finalize(); }
 
     void merge(TopKBuffer* other);
 
-    inline std::unique_ptr<PayloadScanner> getScanner() {
+    inline std::unique_ptr<PayloadScanner> getScanner() const {
         return sortState->getScanner(skip, limit);
     }
 
@@ -110,6 +111,7 @@ public:
     void append(const std::vector<common::ValueVector*>& keyVectors,
         const std::vector<common::ValueVector*>& payloadVectors);
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
     inline void finalize() { buffer->finalize(); }
 
     std::unique_ptr<TopKBuffer> buffer;
@@ -128,6 +130,7 @@ public:
         buffer->merge(localState->buffer.get());
     }
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
     inline void finalize() { buffer->finalize(); }
 
     std::unique_ptr<TopKBuffer> buffer;

--- a/src/include/processor/operator/order_by/top_k_scanner.h
+++ b/src/include/processor/operator/order_by/top_k_scanner.h
@@ -12,6 +12,7 @@ struct TopKLocalScanState {
     void init(
         std::vector<DataPos>& outVectorPos, TopKSharedState& sharedState, ResultSet& resultSet);
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
     inline uint64_t scan() { return payloadScanner->scan(vectorsToScan); }
 };
 

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -65,7 +65,7 @@ struct SniffCSVColumnCountDriver {
     bool emptyRow = true;
     uint64_t numColumns = 0;
 
-    bool done(uint64_t rowNum);
+    bool done(uint64_t rowNum) const;
     void addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);
     bool addRow(uint64_t rowNum, common::column_id_t columntCount);
 };

--- a/src/include/processor/operator/persistent/reader/parquet/column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/column_reader.h
@@ -24,8 +24,8 @@ public:
         uint64_t maxRepeat);
     virtual ~ColumnReader() = default;
     inline common::LogicalType* getDataType() const { return type.get(); }
-    inline bool hasDefines() { return maxDefine > 0; }
-    inline bool hasRepeats() { return maxRepeat > 0; }
+    inline bool hasDefines() const { return maxDefine > 0; }
+    inline bool hasRepeats() const { return maxRepeat > 0; }
     virtual inline void skip(uint64_t numValues) { pendingSkips += numValues; }
     virtual inline void dictionary(
         const std::shared_ptr<ResizeableBuffer>& /*data*/, uint64_t /*num_entries*/) {
@@ -64,7 +64,7 @@ public:
     void preparePage(kuzu_parquet::format::PageHeader& pageHdr);
     void prepareDataPage(kuzu_parquet::format::PageHeader& pageHdr);
     template<class VALUE_TYPE, class CONVERSION>
-    void plainTemplated(const std::shared_ptr<ByteBuffer>& plainData, uint8_t* defines,
+    void plainTemplated(const std::shared_ptr<ByteBuffer>& plainData, const uint8_t* defines,
         uint64_t numValues, parquet_filter_t& filter, uint64_t resultOffset,
         common::ValueVector* result) {
         for (auto i = 0u; i < numValues; i++) {

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_dbp_decoder.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_dbp_decoder.h
@@ -39,7 +39,7 @@ public:
 
     template<typename T>
     void GetBatch(uint8_t* values_target_ptr, uint32_t batch_size) {
-        auto values = reinterpret_cast<T*>(values_target_ptr);
+        auto* values = reinterpret_cast<T*>(values_target_ptr);
 
         if (batch_size == 0) {
             return;
@@ -106,7 +106,7 @@ public:
         GetBatch<uint32_t>(reinterpret_cast<uint8_t*>(data.get()), values_left_in_miniblock);
     }
 
-    uint64_t TotalValues() { return total_value_count; }
+    uint64_t TotalValues() const { return total_value_count; }
 
 private:
     ByteBuffer buffer_;

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_rle_bp_decoder.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_rle_bp_decoder.h
@@ -22,7 +22,7 @@ public:
 
     template<typename T>
     void GetBatch(uint8_t* values_target_ptr, uint32_t batch_size) {
-        auto values = reinterpret_cast<T*>(values_target_ptr);
+        auto* values = reinterpret_cast<T*>(values_target_ptr);
         uint32_t values_read = 0;
 
         while (values_read < batch_size) {

--- a/src/include/processor/operator/persistent/reader/parquet/resizable_buffer.h
+++ b/src/include/processor/operator/persistent/reader/parquet/resizable_buffer.h
@@ -43,14 +43,15 @@ public:
         return val;
     }
 
-    void copyTo(char* dest, uint64_t len) {
+    void copyTo(char* dest, uint64_t len) const {
         available(len);
         std::memcpy(dest, ptr, len);
     }
 
+    // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
     void zero() { std::memset(ptr, 0, len); }
 
-    void available(uint64_t req_len) {
+    void available(uint64_t req_len) const {
         if (req_len > len) {
             throw std::runtime_error("Out of buffer");
         }

--- a/src/include/processor/operator/persistent/reader/parquet/thrift_tools.h
+++ b/src/include/processor/operator/persistent/reader/parquet/thrift_tools.h
@@ -180,7 +180,7 @@ public:
 
     void SetLocation(uint64_t location_p) { location = location_p; }
 
-    uint64_t GetLocation() { return location; }
+    uint64_t GetLocation() const { return location; }
     uint64_t GetSize() { return handle->getFileSize(); }
 
 private:

--- a/src/include/processor/operator/persistent/writer/parquet/boolean_column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/boolean_column_writer.h
@@ -13,7 +13,7 @@ public:
     bool max;
 
 public:
-    bool hasStats() { return !(min && !max); }
+    bool hasStats() const { return !(min && !max); }
 
     std::string getMin() override { return getMinValue(); }
     std::string getMax() override { return getMaxValue(); }

--- a/src/include/processor/operator/persistent/writer/parquet/parquet_rle_bp_encoder.h
+++ b/src/include/processor/operator/persistent/writer/parquet/parquet_rle_bp_encoder.h
@@ -21,7 +21,7 @@ public:
     void writeValue(common::Serializer& writer, uint32_t value);
     void finishWrite(common::Serializer& writer);
 
-    uint64_t getByteCount();
+    uint64_t getByteCount() const;
 
     static uint8_t getVarintSize(uint32_t val);
 

--- a/src/include/processor/operator/persistent/writer/parquet/string_column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/string_column_writer.h
@@ -26,7 +26,7 @@ public:
     std::string max;
 
 public:
-    bool hasValidStats() { return hasStats; }
+    bool hasValidStats() const { return hasStats; }
 
     void update(const common::ku_string_t& val);
 
@@ -54,7 +54,7 @@ public:
     // key_bit_width== 0 signifies the chunk is written in plain encoding
     uint32_t keyBitWidth;
 
-    bool isDictionaryEncoded() { return keyBitWidth != 0; }
+    bool isDictionaryEncoded() const { return keyBitWidth != 0; }
 };
 
 class StringWriterPageState : public ColumnWriterPageState {
@@ -64,7 +64,7 @@ public:
         KU_ASSERT(isDictionaryEncoded() || (bitWidth == 0 && dictionary.empty()));
     }
 
-    inline bool isDictionaryEncoded() { return bitWidth != 0; }
+    inline bool isDictionaryEncoded() const { return bitWidth != 0; }
     // If 0, we're writing a plain page.
     uint32_t bitWidth;
     const string_map_t<uint32_t>& dictionary;

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -134,9 +134,9 @@ private:
     std::unique_ptr<RelInsertExecutor> getRelInsertExecutor(planner::LogicalInsertRelInfo* info,
         const planner::Schema& inSchema, const planner::Schema& outSchema);
     std::unique_ptr<NodeSetExecutor> getNodeSetExecutor(
-        planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema);
+        planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const;
     std::unique_ptr<RelSetExecutor> getRelSetExecutor(
-        planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema);
+        planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const;
 
     std::shared_ptr<FactorizedTable> getSingleStringColumnFTable();
 

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -32,7 +32,7 @@ struct EvictionCandidate {
     // The version of the corresponding page at the time the candidate is enqueued.
     uint64_t pageVersion = -1u;
 
-    inline bool operator==(const EvictionCandidate& other) {
+    inline bool operator==(const EvictionCandidate& other) const {
         return fileHandle == other.fileHandle && pageIdx == other.pageIdx &&
                pageState == other.pageState && pageVersion == other.pageVersion;
     }

--- a/src/include/storage/compression/sign_extend.h
+++ b/src/include/storage/compression/sign_extend.h
@@ -29,7 +29,7 @@ void Store(const T& val, uint8_t* ptr) {
 }
 
 template<typename T>
-const T Load(const uint8_t* ptr) {
+T Load(const uint8_t* ptr) {
     T ret;
     memcpy(&ret, ptr, sizeof(ret));
     return ret;

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -31,7 +31,7 @@ public:
     void append(common::ValueVector* valueVector);
 
     inline common::ValueVector* getVector() { return vector.get(); }
-    inline bool isFull() { return numValues == common::DEFAULT_VECTOR_CAPACITY; }
+    inline bool isFull() const { return numValues == common::DEFAULT_VECTOR_CAPACITY; }
 
 private:
     std::unique_ptr<common::ValueVector> vector;
@@ -49,7 +49,7 @@ public:
 
     void read(common::row_idx_t rowIdx, common::ValueVector* outputVector,
         common::sel_t posInOutputVector);
-    inline uint64_t getNumRows() { return numRows; }
+    inline uint64_t getNumRows() const { return numRows; }
     inline LocalVector* getLocalVector(common::row_idx_t rowIdx) {
         auto vectorIdx = rowIdx >> common::DEFAULT_VECTOR_CAPACITY_LOG_2;
         KU_ASSERT(vectorIdx < vectors.size());

--- a/src/include/storage/stats/property_statistics.h
+++ b/src/include/storage/stats/property_statistics.h
@@ -12,14 +12,10 @@ class PropertyStatistics {
 public:
     PropertyStatistics() = default;
     explicit PropertyStatistics(bool mayHaveNullValue) : mayHaveNullValue{mayHaveNullValue} {}
-    PropertyStatistics(const PropertyStatistics& other) {
-        this->mayHaveNullValue = other.mayHaveNullValue;
-    }
 
     inline bool mayHaveNull() const { return mayHaveNullValue; }
-    PropertyStatistics(PropertyStatistics& other) = default;
 
-    void serialize(common::Serializer& serializer);
+    void serialize(common::Serializer& serializer) const;
     static std::unique_ptr<PropertyStatistics> deserialize(common::Deserializer& deserializer);
 
     inline void setHasNull() { mayHaveNullValue = true; }

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -24,7 +24,7 @@ struct RelDataReadState : public TableReadState {
     LocalRelNG* localNodeGroup;
 
     explicit RelDataReadState(common::ColumnDataFormat dataFormat);
-    inline bool isOutOfRange(common::offset_t nodeOffset) {
+    inline bool isOutOfRange(common::offset_t nodeOffset) const {
         return nodeOffset < startNodeOffset || nodeOffset >= (startNodeOffset + numNodes);
     }
     bool hasMoreToRead(transaction::Transaction* transaction);
@@ -34,7 +34,7 @@ struct RelDataReadState : public TableReadState {
     inline bool hasMoreToReadInPersistentStorage() {
         return posInCurrentCSR < csrListEntries[(currentNodeOffset - startNodeOffset)].size;
     }
-    bool hasMoreToReadFromLocalStorage();
+    bool hasMoreToReadFromLocalStorage() const;
     bool trySwitchToLocalStorage();
 };
 

--- a/src/include/storage/wal/wal_record.h
+++ b/src/include/storage/wal/wal_record.h
@@ -248,7 +248,7 @@ struct WALRecord {
     static void constructWALRecordFromBytes(WALRecord& retVal, uint8_t* bytes, uint64_t& offset);
     // This functions assumes that the caller ensures there is enough space in the bytes pointer
     // to write the record. This should be checked by calling numBytesToWrite.
-    void writeWALRecordToBytes(uint8_t* bytes, uint64_t& offset);
+    void writeWALRecordToBytes(uint8_t* bytes, uint64_t& offset) const;
 
 private:
     static WALRecord newPageInsertOrUpdateRecord(

--- a/src/include/transaction/transaction_manager.h
+++ b/src/include/transaction/transaction_manager.h
@@ -48,7 +48,9 @@ public:
     }
 
 private:
-    inline bool hasActiveWriteTransactionNoLock() { return activeWriteTransactionID != INT64_MAX; }
+    inline bool hasActiveWriteTransactionNoLock() const {
+        return activeWriteTransactionID != INT64_MAX;
+    }
     inline void clearActiveWriteTransactionIfWriteTransactionNoLock(Transaction* transaction) {
         if (transaction->isWriteTransaction()) {
             activeWriteTransactionID = INT64_MAX;

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -15,7 +15,7 @@ namespace kuzu {
 namespace processor {
 
 std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
-    planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) {
+    planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const {
     auto node = (NodeExpression*)info->nodeOrRel.get();
     auto nodeIDPos = DataPos(inSchema.getExpressionPos(*node->getInternalID()));
     auto property = (PropertyExpression*)info->setItem.first.get();
@@ -65,7 +65,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSetNodeProperty(LogicalOperator
 }
 
 std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(
-    planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) {
+    planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const {
     auto rel = (RelExpression*)info->nodeOrRel.get();
     auto srcNodePos = DataPos(inSchema.getExpressionPos(*rel->getSrcNode()->getInternalID()));
     auto dstNodePos = DataPos(inSchema.getExpressionPos(*rel->getDstNode()->getInternalID()));

--- a/src/processor/operator/order_by/key_block_merger.cpp
+++ b/src/processor/operator/order_by/key_block_merger.cpp
@@ -62,7 +62,7 @@ void BlockPtrInfo::updateTuplePtrIfNecessary() {
     }
 }
 
-uint64_t KeyBlockMergeTask::findRightKeyBlockIdx(uint8_t* leftEndTuplePtr) {
+uint64_t KeyBlockMergeTask::findRightKeyBlockIdx(uint8_t* leftEndTuplePtr) const {
     // Find a tuple in the right memory block such that:
     // 1. The value of the current tuple is smaller than the value in leftEndTuple.
     // 2. Either the value of next tuple is larger than the value in leftEndTuple or

--- a/src/processor/operator/order_by/radix_sort.cpp
+++ b/src/processor/operator/order_by/radix_sort.cpp
@@ -97,7 +97,7 @@ void RadixSort::radixSort(uint8_t* keyBlockPtr, uint32_t numTuplesToSort, uint32
 }
 
 std::vector<TieRange> RadixSort::findTies(uint8_t* keyBlockPtr, uint32_t numTuplesToFindTies,
-    uint32_t numBytesToSort, uint32_t baseTupleIdx) {
+    uint32_t numBytesToSort, uint32_t baseTupleIdx) const {
     std::vector<TieRange> newTiesInKeyBlock;
     auto iTuplePtr = keyBlockPtr;
     for (auto i = 0u; i < numTuplesToFindTies - 1; i++) {

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -255,6 +255,7 @@ void TopKLocalState::init(const OrderByDataInfo& orderByDataInfo,
     buffer->init(memoryManager, skipNumber, limitNumber);
 }
 
+// NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
 void TopKLocalState::append(const std::vector<common::ValueVector*>& keyVectors,
     const std::vector<common::ValueVector*>& payloadVectors) {
     buffer->append(keyVectors, payloadVectors);

--- a/src/processor/operator/persistent/copy_rel.cpp
+++ b/src/processor/operator/persistent/copy_rel.cpp
@@ -24,6 +24,7 @@ CopyRelSharedState::CopyRelSharedState(table_id_t tableID, RelTable* table,
     fTable = std::make_shared<FactorizedTable>(memoryManager, std::move(ftTableSchema));
 }
 
+// NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
 void CopyRelSharedState::logCopyRelWALRecord(WAL* wal) {
     wal->logCopyTableRecord(tableID, TableType::REL);
     wal->flushAllPages();

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -105,7 +105,7 @@ bool SniffCSVNameAndTypeDriver::addRow(uint64_t, common::column_id_t) {
     return true;
 }
 
-bool SniffCSVColumnCountDriver::done(uint64_t) {
+bool SniffCSVColumnCountDriver::done(uint64_t) const {
     return !emptyRow;
 }
 

--- a/src/processor/operator/persistent/writer/parquet/parquet_rle_bp_encoder.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_rle_bp_encoder.cpp
@@ -57,7 +57,7 @@ void RleBpEncoder::finishPrepare() {
     finishRun();
 }
 
-uint64_t RleBpEncoder::getByteCount() {
+uint64_t RleBpEncoder::getByteCount() const {
     KU_ASSERT(byteCount != uint64_t(-1));
     return byteCount;
 }

--- a/src/storage/stats/property_statistics.cpp
+++ b/src/storage/stats/property_statistics.cpp
@@ -7,7 +7,7 @@
 namespace kuzu {
 namespace storage {
 
-void PropertyStatistics::serialize(common::Serializer& serializer) {
+void PropertyStatistics::serialize(common::Serializer& serializer) const {
     serializer.serializeValue(mayHaveNullValue);
 }
 

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -19,7 +19,7 @@ namespace kuzu {
 namespace storage {
 
 struct InternalIDColumnFunc {
-    static void readValuesFromPageToVector(uint8_t* frame, PageElementCursor& pageCursor,
+    static void readValuesFromPageToVector(const uint8_t* frame, PageElementCursor& pageCursor,
         ValueVector* resultVector, uint32_t posInVector, uint32_t numValuesToRead,
         const CompressionMetadata& /*metadata*/) {
         KU_ASSERT(resultVector->dataType.getPhysicalType() == PhysicalTypeID::INTERNAL_ID);

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -20,7 +20,7 @@ RelDataReadState::RelDataReadState(ColumnDataFormat dataFormat)
         ColumnChunkFactory::createColumnChunk(LogicalType::INT64(), false /* enableCompression */);
 }
 
-bool RelDataReadState::hasMoreToReadFromLocalStorage() {
+bool RelDataReadState::hasMoreToReadFromLocalStorage() const {
     KU_ASSERT(localNodeGroup);
     return posInCurrentCSR < localNodeGroup->getRelNGInfo()->getNumInsertedTuples(
                                  currentNodeOffset - startNodeOffset);
@@ -423,7 +423,7 @@ static std::pair<offset_t, offset_t> getCSRStartAndEndOffset(
 }
 
 static uint64_t findPosOfRelIDFromArray(
-    offset_t* relIDArray, uint64_t startPos, uint64_t endPos, offset_t relOffset) {
+    const offset_t* relIDArray, uint64_t startPos, uint64_t endPos, offset_t relOffset) {
     for (auto i = startPos; i < endPos; i++) {
         if (relIDArray[i] == relOffset) {
             return i;

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -243,7 +243,7 @@ void WALRecord::constructWALRecordFromBytes(WALRecord& retVal, uint8_t* bytes, u
     offset += sizeof(WALRecord);
 }
 
-void WALRecord::writeWALRecordToBytes(uint8_t* bytes, uint64_t& offset) {
+void WALRecord::writeWALRecordToBytes(uint8_t* bytes, uint64_t& offset) const {
     ((WALRecord*)(bytes + offset))[0] = *this;
     offset += sizeof(WALRecord);
 }


### PR DESCRIPTION
This change implements checking for when methods can be made const, when pointers can be made const, and when returning const objects. Many functions are explicitly excluded from this, since they do not perserve logical constness, since they mutate a pointer member.