### PR TITLE
Fix shell

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -224,11 +224,11 @@ void EmbeddedShell::run() {
             currLine = "";
             continueLine = false;
         }
-        if (line == shellCommand.HELP) {
+        if (lineStr == shellCommand.HELP) {
             printHelp();
-        } else if (line == shellCommand.CLEAR) {
+        } else if (lineStr == shellCommand.CLEAR) {
             linenoiseClearScreen();
-        } else if (line == shellCommand.QUIT) {
+        } else if (lineStr == shellCommand.QUIT) {
             free(line);
             break;
         } else if (lineStr.rfind(shellCommand.THREAD) == 0) {


### PR DESCRIPTION
line and shellCommand.HELP are both pointers to the string. We should compare the content of the two strings rather than the pointer values.
