### PR TITLE
cmake: enable Wextra

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(CMAKE_BUILD_TYPE MATCHES Release)
     endif()
 endif()
 if(NOT MSVC)
-    add_compile_options(-Wall)
+    add_compile_options(-Wall -Wextra)
 endif()
 
 if(${ENABLE_THREAD_SANITIZER})

--- a/src/binder/bind/bind_reading_clause.cpp
+++ b/src/binder/bind/bind_reading_clause.cpp
@@ -56,7 +56,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindMatchClause(const ReadingClause&
     // e.g. rewrite (a)-[e]->(a) as [a]-[e]->(b) WHERE id(a) = id(b)
     expression_vector selfLoopEdgePredicates;
     auto graphCollection = boundMatchClause->getQueryGraphCollection();
-    for (auto i = 0; i < graphCollection->getNumQueryGraphs(); ++i) {
+    for (auto i = 0u; i < graphCollection->getNumQueryGraphs(); ++i) {
         auto queryGraph = graphCollection->getQueryGraph(i);
         for (auto& queryRel : queryGraph->getQueryRels()) {
             if (!queryRel->isSelfLoop()) {

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -206,7 +206,7 @@ static std::vector<std::unique_ptr<Value>> populateLabelValues(std::vector<table
     table_id_t maxTableID = *std::max_element(tableIDsSet.begin(), tableIDsSet.end());
     std::vector<std::unique_ptr<Value>> labels;
     labels.resize(maxTableID + 1);
-    for (auto i = 0; i < labels.size(); ++i) {
+    for (auto i = 0u; i < labels.size(); ++i) {
         if (tableIDsSet.contains(i)) {
             labels[i] = std::make_unique<Value>(
                 LogicalType{LogicalTypeID::STRING}, catalog.getTableName(tx, i));

--- a/src/binder/rewriter/with_clause_projection_rewriter.cpp
+++ b/src/binder/rewriter/with_clause_projection_rewriter.cpp
@@ -47,7 +47,7 @@ void WithClauseProjectionRewriter::visitSingleQuery(const NormalizedSingleQuery&
     auto propertyCollector = PropertyCollector();
     propertyCollector.visitSingleQuery(singleQuery);
     auto properties = propertyCollector.getProperties();
-    for (auto i = 0; i < singleQuery.getNumQueryParts() - 1; ++i) {
+    for (auto i = 0u; i < singleQuery.getNumQueryParts() - 1; ++i) {
         auto queryPart = singleQuery.getQueryPart(i);
         auto projectionBody = queryPart->getProjectionBody();
         auto newProjectionExpressions =

--- a/src/common/data_chunk/data_chunk_collection.cpp
+++ b/src/common/data_chunk/data_chunk_collection.cpp
@@ -8,7 +8,7 @@ DataChunkCollection::DataChunkCollection(storage::MemoryManager* mm) : mm{mm} {}
 void DataChunkCollection::append(DataChunk& chunk) {
     auto numTuplesToAppend = chunk.state->selVector->selectedSize;
     auto chunkToAppendInfo = chunks.empty() ? allocateChunk(chunk) : chunks.back().get();
-    auto numTuplesAppended = 0;
+    auto numTuplesAppended = 0u;
     while (numTuplesAppended < numTuplesToAppend) {
         if (chunkToAppendInfo->state->selVector->selectedSize == DEFAULT_VECTOR_CAPACITY) {
             chunkToAppendInfo = allocateChunk(chunk);

--- a/src/common/types/blob.cpp
+++ b/src/common/types/blob.cpp
@@ -27,7 +27,7 @@ uint64_t Blob::getBlobSize(const ku_string_t& blob) {
     uint64_t blobSize = 0;
     auto length = blob.len;
     auto blobStr = blob.getData();
-    for (auto i = 0; i < length; i++) {
+    for (auto i = 0u; i < length; i++) {
         if (blobStr[i] == '\\') {
             validateHexCode(blobStr, length, i);
             blobSize++;

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -496,7 +496,7 @@ Value::Value(const LogicalType& dataType_) : isNull_{true} {
 void Value::copyFromFixedList(const uint8_t* fixedList) {
     auto numBytesPerElement =
         storage::StorageUtils::getDataTypeSize(*FixedListType::getChildType(dataType.get()));
-    for (auto i = 0; i < childrenSize; ++i) {
+    for (auto i = 0u; i < childrenSize; ++i) {
         auto childValue = children[i].get();
         childValue->copyValueFrom(fixedList + i * numBytesPerElement);
     }
@@ -514,7 +514,7 @@ void Value::copyFromVarList(ku_list_t& list, const LogicalType& childType) {
     auto listNullBytes = reinterpret_cast<uint8_t*>(list.overflowPtr);
     auto numBytesForNullValues = NullBuffer::getNumBytesForNullValues(list.size);
     auto listValues = listNullBytes + numBytesForNullValues;
-    for (auto i = 0; i < list.size; i++) {
+    for (auto i = 0u; i < list.size; i++) {
         auto childValue = children[i].get();
         if (NullBuffer::isNull(listNullBytes, i)) {
             childValue->setNull(true);
@@ -530,7 +530,7 @@ void Value::copyFromStruct(const uint8_t* kuStruct) {
     auto numFields = childrenSize;
     auto structNullValues = kuStruct;
     auto structValues = structNullValues + NullBuffer::getNumBytesForNullValues(numFields);
-    for (auto i = 0; i < numFields; i++) {
+    for (auto i = 0u; i < numFields; i++) {
         auto childValue = children[i].get();
         if (NullBuffer::isNull(structNullValues, i)) {
             childValue->setNull(true);

--- a/src/expression_evaluator/path_evaluator.cpp
+++ b/src/expression_evaluator/path_evaluator.cpp
@@ -84,7 +84,7 @@ void PathExpressionEvaluator::evaluate() {
         child->evaluate();
     }
     auto selVector = resultVector->state->selVector;
-    for (auto i = 0; i < selVector->selectedSize; ++i) {
+    for (auto i = 0u; i < selVector->selectedSize; ++i) {
         auto pos = selVector->selectedPositions[i];
         auto numRels = copyRels(pos);
         copyNodes(pos, numRels == 0);
@@ -101,7 +101,7 @@ static inline uint32_t getCurrentPos(ValueVector* vector, uint32_t pos) {
 void PathExpressionEvaluator::copyNodes(sel_t resultPos, bool isEmptyRels) {
     auto listSize = 0u;
     // Calculate list size.
-    for (auto i = 0; i < expression->getNumChildren(); ++i) {
+    for (auto i = 0u; i < expression->getNumChildren(); ++i) {
         auto child = expression->getChild(i).get();
         switch (child->dataType.getLogicalTypeID()) {
         case LogicalTypeID::NODE: {
@@ -125,7 +125,7 @@ void PathExpressionEvaluator::copyNodes(sel_t resultPos, bool isEmptyRels) {
     // Copy field vectors
     offset_t resultDataPos = entry.offset;
     auto numChildrenToCopy = isEmptyRels ? 1 : expression->getNumChildren();
-    for (auto i = 0; i < numChildrenToCopy; ++i) {
+    for (auto i = 0u; i < numChildrenToCopy; ++i) {
         auto child = expression->getChild(i).get();
         auto vectors = inputVectorsPerChild[i].get();
         auto inputPos = getCurrentPos(vectors->input, resultPos);
@@ -136,7 +136,7 @@ void PathExpressionEvaluator::copyNodes(sel_t resultPos, bool isEmptyRels) {
         } break;
         case LogicalTypeID::RECURSIVE_REL: {
             auto& listEntry = vectors->nodesInput->getValue<list_entry_t>(inputPos);
-            for (auto j = 0; j < listEntry.size; ++j) {
+            for (auto j = 0u; j < listEntry.size; ++j) {
                 copyFieldVectors(listEntry.offset + j, vectors->nodeFieldVectors, resultDataPos,
                     resultNodesFieldVectors);
             }
@@ -150,7 +150,7 @@ void PathExpressionEvaluator::copyNodes(sel_t resultPos, bool isEmptyRels) {
 uint64_t PathExpressionEvaluator::copyRels(sel_t resultPos) {
     auto listSize = 0u;
     // Calculate list size.
-    for (auto i = 0; i < expression->getNumChildren(); ++i) {
+    for (auto i = 0u; i < expression->getNumChildren(); ++i) {
         auto child = expression->getChild(i).get();
         switch (child->dataType.getLogicalTypeID()) {
         case LogicalTypeID::REL: {
@@ -170,7 +170,7 @@ uint64_t PathExpressionEvaluator::copyRels(sel_t resultPos) {
     resultRelsVector->setValue(resultPos, entry);
     // Copy field vectors
     offset_t resultDataPos = entry.offset;
-    for (auto i = 0; i < expression->getNumChildren(); ++i) {
+    for (auto i = 0u; i < expression->getNumChildren(); ++i) {
         auto child = expression->getChild(i).get();
         auto vectors = inputVectorsPerChild[i].get();
         auto inputPos = getCurrentPos(vectors->input, resultPos);
@@ -181,7 +181,7 @@ uint64_t PathExpressionEvaluator::copyRels(sel_t resultPos) {
         } break;
         case LogicalTypeID::RECURSIVE_REL: {
             auto& listEntry = vectors->relsInput->getValue<list_entry_t>(inputPos);
-            for (auto j = 0; j < listEntry.size; ++j) {
+            for (auto j = 0u; j < listEntry.size; ++j) {
                 copyFieldVectors(listEntry.offset + j, vectors->relFieldVectors, resultDataPos,
                     resultRelsFieldVectors);
             }

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -401,7 +401,7 @@ Function* BuiltInFunctions::getBestMatch(std::vector<Function*>& functionsToMatc
     Function* result = nullptr;
     auto cost = UNDEFINED_CAST_COST;
     for (auto& function : functionsToMatch) {
-        auto currentCost = 0;
+        auto currentCost = 0u;
         std::unordered_set<LogicalTypeID> distinctParameterTypes;
         for (auto& parameterTypeID : function->parameterTypeIDs) {
             if (parameterTypeID != LogicalTypeID::STRING) {

--- a/src/function/table_functions/call_functions.cpp
+++ b/src/function/table_functions/call_functions.cpp
@@ -229,7 +229,7 @@ void ShowConnectionFunction::tableFunc(TableFunctionInput& input, DataChunk& out
     auto tableSchema = showConnectionBindData->tableSchema;
     auto numRelationsToOutput = morsel.endOffset - morsel.startOffset;
     auto catalog = showConnectionBindData->catalog;
-    auto vectorPos = 0;
+    auto vectorPos = 0u;
     switch (tableSchema->getTableType()) {
     case TableType::REL: {
         outputRelTableConnection(outputChunk.getValueVector(0).get(),

--- a/src/include/binder/bound_statement_visitor.h
+++ b/src/include/binder/bound_statement_visitor.h
@@ -16,32 +16,32 @@ public:
     virtual void visitSingleQuery(const NormalizedSingleQuery& singleQuery);
 
 protected:
-    virtual void visitCreateTable(const BoundStatement& statement) {}
-    virtual void visitDropTable(const BoundStatement& statement) {}
-    virtual void visitAlter(const BoundStatement& statement) {}
-    virtual void visitCopyFrom(const BoundStatement& statement) {}
-    virtual void visitCopyTo(const BoundStatement& statement) {}
-    virtual void visitStandaloneCall(const BoundStatement& statement) {}
-    virtual void visitCommentOn(const BoundStatement& statement) {}
-    virtual void visitExplain(const BoundStatement& statement);
-    virtual void visitCreateMacro(const BoundStatement& statement) {}
-    virtual void visitTransaction(const BoundStatement& statement) {}
+    virtual void visitCreateTable(const BoundStatement& /*statement*/) {}
+    virtual void visitDropTable(const BoundStatement& /*statement*/) {}
+    virtual void visitAlter(const BoundStatement& /*statement*/) {}
+    virtual void visitCopyFrom(const BoundStatement& /*statement*/) {}
+    virtual void visitCopyTo(const BoundStatement& /*statement*/) {}
+    virtual void visitStandaloneCall(const BoundStatement& /*statement*/) {}
+    virtual void visitCommentOn(const BoundStatement& /*statement*/) {}
+    virtual void visitExplain(const BoundStatement& /*statement*/);
+    virtual void visitCreateMacro(const BoundStatement& /*statement*/) {}
+    virtual void visitTransaction(const BoundStatement& /*statement*/) {}
 
     virtual void visitRegularQuery(const BoundStatement& statement);
     virtual void visitQueryPart(const NormalizedQueryPart& queryPart);
     void visitReadingClause(const BoundReadingClause& readingClause);
-    virtual void visitMatch(const BoundReadingClause& readingClause) {}
-    virtual void visitUnwind(const BoundReadingClause& readingClause) {}
-    virtual void visitInQueryCall(const BoundReadingClause& statement) {}
-    virtual void visitLoadFrom(const BoundReadingClause& statement) {}
+    virtual void visitMatch(const BoundReadingClause& /*readingClause*/) {}
+    virtual void visitUnwind(const BoundReadingClause& /*readingClause*/) {}
+    virtual void visitInQueryCall(const BoundReadingClause& /*statement*/) {}
+    virtual void visitLoadFrom(const BoundReadingClause& /*statement*/) {}
     void visitUpdatingClause(const BoundUpdatingClause& updatingClause);
-    virtual void visitSet(const BoundUpdatingClause& updatingClause) {}
-    virtual void visitDelete(const BoundUpdatingClause& updatingClause) {}
-    virtual void visitInsert(const BoundUpdatingClause& updatingClause) {}
-    virtual void visitMerge(const BoundUpdatingClause& updatingClause) {}
+    virtual void visitSet(const BoundUpdatingClause& /*updatingClause*/) {}
+    virtual void visitDelete(const BoundUpdatingClause& /* updatingClause*/) {}
+    virtual void visitInsert(const BoundUpdatingClause& /* updatingClause*/) {}
+    virtual void visitMerge(const BoundUpdatingClause& /* updatingClause*/) {}
 
-    virtual void visitProjectionBody(const BoundProjectionBody& projectionBody) {}
-    virtual void visitProjectionBodyPredicate(const std::shared_ptr<Expression>& predicate) {}
+    virtual void visitProjectionBody(const BoundProjectionBody& /* projectionBody*/) {}
+    virtual void visitProjectionBodyPredicate(const std::shared_ptr<Expression>& /* predicate*/) {}
 };
 
 } // namespace binder

--- a/src/include/common/arrow/arrow_row_batch.h
+++ b/src/include/common/arrow/arrow_row_batch.h
@@ -21,7 +21,7 @@ namespace common {
 //  5) an optional dictionary for dictionary-encoded arrays.
 // See https://arrow.apache.org/docs/format/Columnar.html for more details.
 
-static inline std::int64_t getNumBytesForBits(std::int64_t numBits) {
+static inline uint64_t getNumBytesForBits(uint64_t numBits) {
     return (numBits + 7) / 8;
 }
 

--- a/src/include/common/file_utils.h
+++ b/src/include/common/file_utils.h
@@ -26,7 +26,7 @@ struct FileInfo {
 
     ~FileInfo();
 
-    int64_t getFileSize();
+    uint64_t getFileSize();
 
     const std::string path;
 #ifdef _WIN32

--- a/src/include/common/timer.h
+++ b/src/include/common/timer.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <string>
 
+#include "common/assert.h"
 #include "exception/exception.h"
 
 namespace kuzu {
@@ -29,10 +30,12 @@ public:
         throw Exception("Timer is still running.");
     }
 
-    int64_t getElapsedTimeInMS() {
+    uint64_t getElapsedTimeInMS() {
         auto now = std::chrono::high_resolution_clock::now();
         auto duration = now - startTime;
-        return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+        auto count = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+        KU_ASSERT(count >= 0);
+        return count;
     }
 
 private:

--- a/src/include/function/aggregate/base_count.h
+++ b/src/include/function/aggregate/base_count.h
@@ -30,7 +30,7 @@ struct BaseCountFunction {
         state->count += otherState->count;
     }
 
-    static void finalize(uint8_t* state_) {}
+    static void finalize(uint8_t* /*state_*/) {}
 };
 
 } // namespace function

--- a/src/include/function/aggregate/collect.h
+++ b/src/include/function/aggregate/collect.h
@@ -95,7 +95,7 @@ struct CollectFunction {
         otherState->factorizedTable.reset();
     }
 
-    static void finalize(uint8_t* state_) {}
+    static void finalize(uint8_t* /*state_*/) {}
 
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, Function* definition) {

--- a/src/include/function/aggregate/min_max.h
+++ b/src/include/function/aggregate/min_max.h
@@ -87,7 +87,7 @@ struct MinMaxFunction {
         otherState->overflowBuffer.reset();
     }
 
-    static void finalize(uint8_t* state_) {}
+    static void finalize(uint8_t* /*state_*/) {}
 };
 
 template<>

--- a/src/include/function/aggregate/sum.h
+++ b/src/include/function/aggregate/sum.h
@@ -74,7 +74,7 @@ struct SumFunction {
         }
     }
 
-    static void finalize(uint8_t* state_) {}
+    static void finalize(uint8_t* /*state_*/) {}
 };
 
 } // namespace function

--- a/src/include/function/cast/functions/cast_string_non_nested_functions.h
+++ b/src/include/function/cast/functions/cast_string_non_nested_functions.h
@@ -54,11 +54,11 @@ void castStringToBool(const char* input, uint64_t len, bool& result);
 // TODO(Kebing): support exponent + decimal
 template<typename T, bool NEGATIVE, bool ALLOW_EXPONENT = false, class OP>
 inline bool integerCastLoop(const char* input, uint64_t len, T& result) {
-    int64_t start_pos = 0;
+    auto start_pos = 0u;
     if (NEGATIVE) {
         start_pos = 1;
     }
-    int64_t pos = start_pos;
+    auto pos = start_pos;
     while (pos < len) {
         if (!StringUtils::CharacterIsDigit(input[pos])) {
             return false;

--- a/src/include/function/list/functions/base_list_sort_function.h
+++ b/src/include/function/list/functions/base_list_sort_function.h
@@ -41,7 +41,7 @@ public:
 
         // Calculate null count.
         auto nullCount = 0;
-        for (auto i = 0; i < input.size; i++) {
+        for (auto i = 0u; i < input.size; i++) {
             if (inputDataVector->isNull(input.offset + i)) {
                 nullCount += 1;
             }
@@ -58,7 +58,7 @@ public:
         }
 
         // Add actual data.
-        for (auto i = 0; i < input.size; i++) {
+        for (auto i = 0u; i < input.size; i++) {
             if (inputDataVector->isNull(inputPos)) {
                 inputPos++;
                 continue;

--- a/src/include/function/list/functions/list_any_value_function.h
+++ b/src/include/function/list/functions/list_any_value_function.h
@@ -13,7 +13,7 @@ struct ListAnyValue {
         auto inputDataVector = common::ListVector::getDataVector(&inputVector);
         auto numBytesPerValue = inputDataVector->getNumBytesPerValue();
 
-        for (auto i = 0; i < input.size; i++) {
+        for (auto i = 0u; i < input.size; i++) {
             if (!(inputDataVector->isNull(input.offset + i))) {
                 resultVector.copyFromVectorData(
                     reinterpret_cast<uint8_t*>(&result), inputDataVector, inputValues);

--- a/src/include/function/list/functions/list_distinct_function.h
+++ b/src/include/function/list/functions/list_distinct_function.h
@@ -16,7 +16,7 @@ struct ListDistinct {
             reinterpret_cast<T*>(common::ListVector::getListValues(&inputVector, input));
         auto inputDataVector = common::ListVector::getDataVector(&inputVector);
 
-        for (auto i = 0; i < input.size; i++) {
+        for (auto i = 0u; i < input.size; i++) {
             if (inputDataVector->isNull(input.offset + i)) {
                 continue;
             }

--- a/src/include/function/list/functions/list_len_function.h
+++ b/src/include/function/list/functions/list_len_function.h
@@ -20,7 +20,7 @@ template<>
 inline void ListLen::operation(common::ku_string_t& input, int64_t& result) {
     auto totalByteLength = input.len;
     auto inputString = input.getAsString();
-    for (auto i = 0; i < totalByteLength; i++) {
+    for (auto i = 0u; i < totalByteLength; i++) {
         if (inputString[i] & 0x80) {
             int64_t length = 0;
             // Use grapheme iterator to identify bytes of utf8 char and increment once for each

--- a/src/include/function/list/functions/list_product_function.h
+++ b/src/include/function/list/functions/list_product_function.h
@@ -11,7 +11,7 @@ struct ListProduct {
         common::ValueVector& inputVector, common::ValueVector& /*resultVector*/) {
         auto inputDataVector = common::ListVector::getDataVector(&inputVector);
         result = 1;
-        for (auto i = 0; i < input.size; i++) {
+        for (auto i = 0u; i < input.size; i++) {
             if (inputDataVector->isNull(input.offset + i)) {
                 continue;
             }

--- a/src/include/function/list/functions/list_sum_function.h
+++ b/src/include/function/list/functions/list_sum_function.h
@@ -11,7 +11,7 @@ struct ListSum {
         common::ValueVector& inputVector, common::ValueVector& /*resultVector*/) {
         auto inputDataVector = common::ListVector::getDataVector(&inputVector);
         result = 0;
-        for (auto i = 0; i < input.size; i++) {
+        for (auto i = 0u; i < input.size; i++) {
             if (inputDataVector->isNull(input.offset + i)) {
                 continue;
             }

--- a/src/include/function/list/functions/list_unique_function.h
+++ b/src/include/function/list/functions/list_unique_function.h
@@ -16,7 +16,7 @@ struct ListUnique {
             reinterpret_cast<T*>(common::ListVector::getListValues(&inputVector, input));
         auto inputDataVector = common::ListVector::getDataVector(&inputVector);
 
-        for (auto i = 0; i < input.size; i++) {
+        for (auto i = 0u; i < input.size; i++) {
             if (inputDataVector->isNull(input.offset + i)) {
                 continue;
             }

--- a/src/include/function/path/path_function_executor.h
+++ b/src/include/function/path/path_function_executor.h
@@ -9,7 +9,7 @@ namespace function {
 static bool isAllInternalIDDistinct(common::ValueVector* dataVector, common::offset_t startOffset,
     uint64_t size, std::unordered_set<common::internalID_t, InternalIDHasher>& internalIDSet) {
     internalIDSet.clear();
-    for (auto i = 0; i < size; ++i) {
+    for (auto i = 0u; i < size; ++i) {
         auto& internalID = dataVector->getValue<common::internalID_t>(startOffset + i);
         if (internalIDSet.contains(internalID)) {
             return false;
@@ -72,14 +72,14 @@ private:
             common::StructVector::getFieldVector(listDataVector, fieldIdx).get();
         std::unordered_set<common::nodeID_t, InternalIDHasher> internalIDSet;
         if (inputSelVector.isUnfiltered()) {
-            for (auto i = 0; i < inputSelVector.selectedSize; ++i) {
+            for (auto i = 0u; i < inputSelVector.selectedSize; ++i) {
                 auto& listEntry = listVector.getValue<common::list_entry_t>(i);
                 bool isTrail = isAllInternalIDDistinct(
                     internalIDsVector, listEntry.offset, listEntry.size, internalIDSet);
                 result.setValue<bool>(i, isTrail);
             }
         } else {
-            for (auto i = 0; i < inputSelVector.selectedSize; ++i) {
+            for (auto i = 0u; i < inputSelVector.selectedSize; ++i) {
                 auto pos = inputSelVector.selectedPositions[i];
                 auto& listEntry = listVector.getValue<common::list_entry_t>(pos);
                 bool isTrail = isAllInternalIDDistinct(
@@ -101,7 +101,7 @@ private:
         auto numSelectedValues = 0u;
         auto buffer = selectionVector.getSelectedPositionsBuffer();
         if (inputSelVector.isUnfiltered()) {
-            for (auto i = 0; i < inputSelVector.selectedSize; ++i) {
+            for (auto i = 0u; i < inputSelVector.selectedSize; ++i) {
                 auto& listEntry = listVector.getValue<common::list_entry_t>(i);
                 bool isTrail = isAllInternalIDDistinct(
                     internalIDsVector, listEntry.offset, listEntry.size, internalIDSet);
@@ -109,7 +109,7 @@ private:
                 numSelectedValues += isTrail;
             }
         } else {
-            for (auto i = 0; i < inputSelVector.selectedSize; ++i) {
+            for (auto i = 0u; i < inputSelVector.selectedSize; ++i) {
                 auto pos = inputSelVector.selectedPositions[i];
                 auto& listEntry = listVector.getValue<common::list_entry_t>(pos);
                 bool isTrail = isAllInternalIDDistinct(

--- a/src/include/function/string/functions/base_pad_function.h
+++ b/src/include/function/string/functions/base_pad_function.h
@@ -41,7 +41,7 @@ public:
         auto padData = pad.getData();
         auto padSize = pad.len;
         uint32_t padByteCount = 0;
-        for (auto i = 0; i < charCount; i++) {
+        for (auto i = 0u; i < charCount; i++) {
             if (padByteCount >= padSize) {
                 result.insert(result.end(), (char*)padData, (char*)(padData + padByteCount));
                 padByteCount = 0;

--- a/src/include/function/string/functions/substr_function.h
+++ b/src/include/function/string/functions/substr_function.h
@@ -18,7 +18,7 @@ public:
         auto startPos = start - 1;
         auto endPos = std::min(srcStr.size(), (size_t)(startPos + len));
         // 1 character more than length has to be scanned for diatrics case: y + ˘ = ў.
-        for (auto i = 0; i < std::min(srcStr.size(), endPos + 1); i++) {
+        for (auto i = 0u; i < std::min(srcStr.size(), endPos + 1); i++) {
             // UTF-8 character encountered.
             if (srcStr[i] & 0x80) {
                 isAscii = false;
@@ -33,7 +33,7 @@ public:
                 srcStr.c_str(), srcStr.size(), [&](int64_t gstart, int64_t /*gend*/) {
                     if (characterCount == startPos) {
                         startBytePos = gstart;
-                    } else if (characterCount == endPos) {
+                    } else if ((uint64_t)characterCount == endPos) {
                         endBytePos = gstart;
                         return false;
                     }

--- a/src/include/optimizer/logical_operator_visitor.h
+++ b/src/include/optimizer/logical_operator_visitor.h
@@ -15,157 +15,157 @@ protected:
     std::shared_ptr<planner::LogicalOperator> visitOperatorReplaceSwitch(
         std::shared_ptr<planner::LogicalOperator> op);
 
-    virtual void visitFlatten(planner::LogicalOperator* op) {}
+    virtual void visitFlatten(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitFlattenReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitExpressionsScan(planner::LogicalOperator* op) {}
+    virtual void visitExpressionsScan(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitExpressionsScanReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitScanInternalID(planner::LogicalOperator* op) {}
+    virtual void visitScanInternalID(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitScanInternalIDReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitIndexScanNode(planner::LogicalOperator* op) {}
+    virtual void visitIndexScanNode(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitIndexScanNodeReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitExtend(planner::LogicalOperator* op) {}
+    virtual void visitExtend(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitExtendReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitRecursiveExtend(planner::LogicalOperator* op) {}
+    virtual void visitRecursiveExtend(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitRecursiveExtendReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitPathPropertyProbe(planner::LogicalOperator* op) {}
+    virtual void visitPathPropertyProbe(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitPathPropertyProbeReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitHashJoin(planner::LogicalOperator* op) {}
+    virtual void visitHashJoin(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitHashJoinReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitIntersect(planner::LogicalOperator* op) {}
+    virtual void visitIntersect(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitIntersectReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitProjection(planner::LogicalOperator* op) {}
+    virtual void visitProjection(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitProjectionReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitAggregate(planner::LogicalOperator* op) {}
+    virtual void visitAggregate(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitAggregateReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitOrderBy(planner::LogicalOperator* op) {}
+    virtual void visitOrderBy(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitOrderByReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitLimit(planner::LogicalOperator* op) {}
+    virtual void visitLimit(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitLimitReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitAccumulate(planner::LogicalOperator* op) {}
+    virtual void visitAccumulate(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitAccumulateReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitDistinct(planner::LogicalOperator* op) {}
+    virtual void visitDistinct(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitDistinctReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitUnwind(planner::LogicalOperator* op) {}
+    virtual void visitUnwind(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitUnwindReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitUnion(planner::LogicalOperator* op) {}
+    virtual void visitUnion(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitUnionReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitFilter(planner::LogicalOperator* op) {}
+    virtual void visitFilter(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitFilterReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitSetNodeProperty(planner::LogicalOperator* op) {}
+    virtual void visitSetNodeProperty(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitSetNodePropertyReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitSetRelProperty(planner::LogicalOperator* op) {}
+    virtual void visitSetRelProperty(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitSetRelPropertyReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitDeleteNode(planner::LogicalOperator* op) {}
+    virtual void visitDeleteNode(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitDeleteNodeReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitDeleteRel(planner::LogicalOperator* op) {}
+    virtual void visitDeleteRel(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitDeleteRelReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitInsertNode(planner::LogicalOperator* op) {}
+    virtual void visitInsertNode(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitInsertNodeReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitInsertRel(planner::LogicalOperator* op) {}
+    virtual void visitInsertRel(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitInsertRelReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitMerge(planner::LogicalOperator* op) {}
+    virtual void visitMerge(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitMergeReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitCopyTo(planner::LogicalOperator* op) {}
+    virtual void visitCopyTo(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitCopyToReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;

--- a/src/include/parser/expression/parsed_expression.h
+++ b/src/include/parser/expression/parsed_expression.h
@@ -72,7 +72,7 @@ protected:
     parsed_expression_vector copyChildren() const;
 
 private:
-    virtual inline void serializeInternal(common::Serializer& serializer) const {}
+    virtual inline void serializeInternal(common::Serializer& /*serializer*/) const {}
 
 protected:
     common::ExpressionType type;

--- a/src/include/parser/parsed_statement_visitor.h
+++ b/src/include/parser/parsed_statement_visitor.h
@@ -25,28 +25,28 @@ private:
     virtual void visitSingleQuery(const SingleQuery* singleQuery);
     virtual void visitQueryPart(const QueryPart* queryPart);
     virtual void visitReadingClause(const ReadingClause* readingClause);
-    virtual void visitMatch(const ReadingClause* readingClause) {}
-    virtual void visitUnwind(const ReadingClause* readingClause) {}
-    virtual void visitInQueryCall(const ReadingClause* readingClause) {}
-    virtual void visitLoadFrom(const ReadingClause* readingClause) {}
-    virtual void visitUpdatingClause(const UpdatingClause* updatingClause);
-    virtual void visitSet(const UpdatingClause* updatingClause) {}
-    virtual void visitDelete(const UpdatingClause* updatingClause) {}
-    virtual void visitInsert(const UpdatingClause* updatingClause) {}
-    virtual void visitMerge(const UpdatingClause* updatingClause) {}
-    virtual void visitWithClause(const WithClause* withClause) {}
-    virtual void visitReturnClause(const ReturnClause* returnClause) {}
+    virtual void visitMatch(const ReadingClause* /*readingClause*/) {}
+    virtual void visitUnwind(const ReadingClause* /*readingClause*/) {}
+    virtual void visitInQueryCall(const ReadingClause* /*readingClause*/) {}
+    virtual void visitLoadFrom(const ReadingClause* /*readingClause*/) {}
+    virtual void visitUpdatingClause(const UpdatingClause* /*updatingClause*/);
+    virtual void visitSet(const UpdatingClause* /*updatingClause*/) {}
+    virtual void visitDelete(const UpdatingClause* /*updatingClause*/) {}
+    virtual void visitInsert(const UpdatingClause* /*updatingClause*/) {}
+    virtual void visitMerge(const UpdatingClause* /*updatingClause*/) {}
+    virtual void visitWithClause(const WithClause* /*withClause*/) {}
+    virtual void visitReturnClause(const ReturnClause* /*returnClause*/) {}
 
-    virtual void visitCreateTable(const Statement& statement) {}
-    virtual void visitDropTable(const Statement& statement) {}
-    virtual void visitAlter(const Statement& statement) {}
-    virtual void visitCopyFrom(const Statement& statement) {}
-    virtual void visitCopyTo(const Statement& statement) {}
-    virtual void visitStandaloneCall(const Statement& statement) {}
-    virtual void visitExplain(const Statement& statement);
-    virtual void visitCreateMacro(const Statement& statement) {}
-    virtual void visitCommentOn(const Statement& statement) {}
-    virtual void visitTransaction(const Statement& statement) {}
+    virtual void visitCreateTable(const Statement& /*statement*/) {}
+    virtual void visitDropTable(const Statement& /*statement*/) {}
+    virtual void visitAlter(const Statement& /*statement*/) {}
+    virtual void visitCopyFrom(const Statement& /*statement*/) {}
+    virtual void visitCopyTo(const Statement& /*statement*/) {}
+    virtual void visitStandaloneCall(const Statement& /*statement*/) {}
+    virtual void visitExplain(const Statement& /*statement*/);
+    virtual void visitCreateMacro(const Statement& /*statement*/) {}
+    virtual void visitCommentOn(const Statement& /*statement*/) {}
+    virtual void visitTransaction(const Statement& /*statement*/) {}
     // LCOV_EXCL_STOP
 };
 

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -65,7 +65,7 @@ private:
     }
     inline const kuzu_parquet::format::RowGroup& getGroup(ParquetReaderScanState& state) {
         KU_ASSERT(
-            state.currentGroup >= 0 && (int64_t)state.currentGroup < state.groupIdxList.size());
+            state.currentGroup >= 0 && (uint64_t)state.currentGroup < state.groupIdxList.size());
         KU_ASSERT(state.groupIdxList[state.currentGroup] >= 0 &&
                   state.groupIdxList[state.currentGroup] < metadata->row_groups.size());
         return metadata->row_groups[state.groupIdxList[state.currentGroup]];

--- a/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
@@ -47,7 +47,7 @@ public:
     void offsets(uint32_t* offsets, uint8_t* defines, uint64_t numValues, parquet_filter_t& filter,
         uint64_t resultOffset, common::ValueVector* result) override {
         uint64_t offsetIdx = 0;
-        for (auto rowIdx = 0; rowIdx < numValues; rowIdx++) {
+        for (auto rowIdx = 0u; rowIdx < numValues; rowIdx++) {
             if (hasDefines() && defines[rowIdx + resultOffset] != maxDefine) {
                 result->setNull(rowIdx + resultOffset, true);
                 continue;

--- a/src/include/processor/operator/persistent/writer/parquet/basic_column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/basic_column_writer.h
@@ -62,7 +62,7 @@ protected:
 
     // Flushes the writer for a specific page. Only used for scalar types.
     virtual void flushPageState(
-        common::Serializer& bufferedSerializer, ColumnWriterPageState* state) {}
+        common::Serializer& /*bufferedSerializer*/, ColumnWriterPageState* /*state*/) {}
 
     // Retrieves the row size of a vector at the specified location. Only used for scalar types.
     virtual uint64_t getRowSize(

--- a/src/include/processor/operator/physical_operator.h
+++ b/src/include/processor/operator/physical_operator.h
@@ -146,8 +146,8 @@ public:
     virtual std::unique_ptr<PhysicalOperator> clone() = 0;
 
 protected:
-    virtual void initGlobalStateInternal(ExecutionContext* context) {}
-    virtual void initLocalStateInternal(ResultSet* resultSet_, ExecutionContext* context) {}
+    virtual void initGlobalStateInternal(ExecutionContext* /*context*/) {}
+    virtual void initLocalStateInternal(ResultSet* /*resultSet_*/, ExecutionContext* /*context*/) {}
     // Return false if no more tuples to pull, otherwise return true
     virtual bool getNextTuplesInternal(ExecutionContext* context) = 0;
 

--- a/src/include/processor/operator/sink.h
+++ b/src/include/processor/operator/sink.h
@@ -30,7 +30,7 @@ public:
         metrics->executionTime.stop();
     }
 
-    virtual void finalize(ExecutionContext* context){};
+    virtual void finalize(ExecutionContext* /*context*/){};
 
     std::unique_ptr<PhysicalOperator> clone() override = 0;
 

--- a/src/include/storage/wal/wal_record.h
+++ b/src/include/storage/wal/wal_record.h
@@ -31,11 +31,12 @@ std::string dbFileTypeToString(DBFileType dbFileType);
 struct DBFileID {
     DBFileType dbFileType;
     bool isOverflow;
-    union {
-        NodeIndexID nodeIndexID;
-    };
+    NodeIndexID nodeIndexID;
 
-    bool operator==(const DBFileID& rhs) const;
+    DBFileID() = default;
+    explicit DBFileID(DBFileType dbFileType)
+        : dbFileType(dbFileType), isOverflow(false), nodeIndexID(common::INVALID_TABLE_ID) {}
+    bool operator==(const DBFileID& rhs) const = default;
 
     static DBFileID newDataFileID();
     static DBFileID newMetadataFileID();

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -113,7 +113,7 @@ void HashJoinSIPOptimizer::visitIntersect(planner::LogicalOperator* op) {
     auto hasSemiMaskApplied = false;
     for (auto& nodeID : intersect->getKeyNodeIDs()) {
         std::vector<planner::LogicalOperator*> ops;
-        for (auto i = 1; i < intersect->getNumChildren(); ++i) {
+        for (auto i = 1u; i < intersect->getNumChildren(); ++i) {
             auto buildRoot = intersect->getChild(1);
             for (auto& op_ : resolveOperatorsToApplySemiMask(*nodeID, buildRoot.get())) {
                 ops.push_back(op_);

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -33,7 +33,7 @@ void ProjectionPushDownOptimizer::visitOperator(LogicalOperator* op) {
         return;
     }
     // top-down traversal
-    for (auto i = 0; i < op->getNumChildren(); ++i) {
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
         visitOperator(op->getChild(i).get());
     }
     op->computeFlatSchema();

--- a/src/optimizer/remove_factorization_rewriter.cpp
+++ b/src/optimizer/remove_factorization_rewriter.cpp
@@ -22,7 +22,7 @@ void RemoveFactorizationRewriter::rewrite(planner::LogicalPlan* plan) {
 std::shared_ptr<planner::LogicalOperator> RemoveFactorizationRewriter::visitOperator(
     const std::shared_ptr<planner::LogicalOperator>& op) {
     // bottom-up traversal
-    for (auto i = 0; i < op->getNumChildren(); ++i) {
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));
     }
     auto result = visitOperatorReplaceSwitch(op);

--- a/src/optimizer/remove_unnecessary_join_optimizer.cpp
+++ b/src/optimizer/remove_unnecessary_join_optimizer.cpp
@@ -15,7 +15,7 @@ void RemoveUnnecessaryJoinOptimizer::rewrite(planner::LogicalPlan* plan) {
 std::shared_ptr<planner::LogicalOperator> RemoveUnnecessaryJoinOptimizer::visitOperator(
     const std::shared_ptr<planner::LogicalOperator>& op) {
     // bottom-up traversal
-    for (auto i = 0; i < op->getNumChildren(); ++i) {
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));
     }
     auto result = visitOperatorReplaceSwitch(op);

--- a/src/optimizer/top_k_optimizer.cpp
+++ b/src/optimizer/top_k_optimizer.cpp
@@ -15,7 +15,7 @@ void TopKOptimizer::rewrite(planner::LogicalPlan* plan) {
 std::shared_ptr<LogicalOperator> TopKOptimizer::visitOperator(
     const std::shared_ptr<LogicalOperator>& op) {
     // bottom-up traversal
-    for (auto i = 0; i < op->getNumChildren(); ++i) {
+    for (auto i = 0u; i < op->getNumChildren(); ++i) {
         op->setChild(i, visitOperator(op->getChild(i)));
     }
     auto result = visitOperatorReplaceSwitch(op);

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -49,7 +49,7 @@ void LogicalHashJoin::computeFactorizedSchema() {
         }
         // Resolve expressions to materialize in each group
         binder::expression_vector expressionsToMaterializeInNonKeyGroups;
-        for (auto groupIdx = 0; groupIdx < buildSchema->getNumGroups(); ++groupIdx) {
+        for (auto groupIdx = 0u; groupIdx < buildSchema->getNumGroups(); ++groupIdx) {
             auto expressions = buildSchema->getExpressionsInScope(groupIdx);
             bool isKeyGroup = buildToProbeKeyGroupPositionMap.contains(groupIdx);
             if (isKeyGroup) { // merge key group

--- a/src/planner/operator/logical_intersect.cpp
+++ b/src/planner/operator/logical_intersect.cpp
@@ -24,7 +24,7 @@ void LogicalIntersect::computeFactorizedSchema() {
     // Write intersect node and rels into a new group regardless of whether rel is n-n.
     auto outGroupPos = schema->createGroup();
     schema->insertToGroupAndScope(intersectNodeID, outGroupPos);
-    for (auto i = 1; i < children.size(); ++i) {
+    for (auto i = 1u; i < children.size(); ++i) {
         auto buildSchema = children[i]->getSchema();
         auto keyNodeID = keyNodeIDs[i - 1];
         // Write rel properties into output group.
@@ -43,7 +43,7 @@ void LogicalIntersect::computeFlatSchema() {
     schema = probeSchema->copy();
     schema->createGroup();
     schema->insertToGroupAndScope(intersectNodeID, 0);
-    for (auto i = 1; i < children.size(); ++i) {
+    for (auto i = 1u; i < children.size(); ++i) {
         auto buildSchema = children[i]->getSchema();
         auto keyNodeID = keyNodeIDs[i - 1];
         for (auto& expression : buildSchema->getExpressionsInScope()) {

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -82,7 +82,7 @@ std::vector<std::unique_ptr<LogicalPlan>> QueryPlanner::enumerateQueryGraphColle
                 context->correlatedExpressions, queryGraph, predicatesToEvaluate);
         } break;
         case SubqueryType::CORRELATED: {
-            if (i == queryGraphIdxToPlanExpressionsScan) {
+            if (i == (uint32_t)queryGraphIdxToPlanExpressionsScan) {
                 // Plan ExpressionsScan with current query graph.
                 plans = enumerateQueryGraph(SubqueryType::CORRELATED,
                     context->correlatedExpressions, queryGraph, predicatesToEvaluate);
@@ -467,7 +467,7 @@ static bool needPruneImplicitJoins(
     const SubqueryGraph& leftSubgraph, const SubqueryGraph& rightSubgraph, uint32_t numJoinNodes) {
     auto leftNodePositions = leftSubgraph.getNodePositionsIgnoringNodeSelector();
     auto rightNodePositions = rightSubgraph.getNodePositionsIgnoringNodeSelector();
-    auto intersectionSize = 0;
+    auto intersectionSize = 0u;
     for (auto& pos : leftNodePositions) {
         if (rightNodePositions.contains(pos)) {
             intersectionSize++;

--- a/src/planner/subplans_table.cpp
+++ b/src/planner/subplans_table.cpp
@@ -45,7 +45,7 @@ std::bitset<MAX_NUM_QUERY_VARIABLES> SubgraphPlans::encodePlan(const LogicalPlan
     auto schema = plan.getSchema();
     std::bitset<MAX_NUM_QUERY_VARIABLES> result;
     result.reset();
-    for (auto i = 0; i < nodeIDsToEncode.size(); ++i) {
+    for (auto i = 0u; i < nodeIDsToEncode.size(); ++i) {
         result[i] = schema->getGroup(schema->getGroupPos(*nodeIDsToEncode[i]))->isFlat();
     }
     return result;

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -51,7 +51,7 @@ static void getRelColumnNamesInCopyOrder(
     columnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::INT64));
     columnTypes.emplace_back(std::make_unique<LogicalType>(LogicalTypeID::INT64));
     auto properties = tableSchema->getProperties();
-    for (auto i = 1; i < properties.size(); ++i) { // skip internal ID
+    for (auto i = 1u; i < properties.size(); ++i) { // skip internal ID
         columnNames.push_back(properties[i]->getName());
         columnTypes.push_back(properties[i]->getDataType()->copy());
     }

--- a/src/processor/operator/filter.cpp
+++ b/src/processor/operator/filter.cpp
@@ -44,7 +44,7 @@ bool NodeLabelFiler::getNextTuplesInternal(ExecutionContext* context) {
         saveSelVector(nodeIDVector->state->selVector);
         numSelectValue = 0;
         auto buffer = nodeIDVector->state->selVector->getSelectedPositionsBuffer();
-        for (auto i = 0; i < nodeIDVector->state->selVector->selectedSize; ++i) {
+        for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
             auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             buffer[numSelectValue] = pos;
             numSelectValue +=

--- a/src/processor/operator/index_scan.cpp
+++ b/src/processor/operator/index_scan.cpp
@@ -20,7 +20,7 @@ bool IndexScan::getNextTuplesInternal(ExecutionContext* context) {
         }
         saveSelVector(outVector->state->selVector);
         numSelectedValues = 0u;
-        for (auto i = 0; i < indexVector->state->selVector->selectedSize; ++i) {
+        for (auto i = 0u; i < indexVector->state->selVector->selectedSize; ++i) {
             auto pos = indexVector->state->selVector->selectedPositions[i];
             outVector->state->selVector->getSelectedPositionsBuffer()[numSelectedValues] = pos;
             offset_t nodeOffset = INVALID_OFFSET;

--- a/src/processor/operator/order_by/key_block_merger.cpp
+++ b/src/processor/operator/order_by/key_block_merger.cpp
@@ -124,9 +124,9 @@ std::unique_ptr<KeyBlockMergeMorsel> KeyBlockMergeTask::getMorsel() {
 
         auto keyBlockMergeMorsel = std::make_unique<KeyBlockMergeMorsel>(leftKeyBlockStartIdx,
             std::min(leftKeyBlockNextIdx, leftKeyBlock->getNumTuples()), rightKeyBlockNextIdx,
-            rightEndIdx == -1 ? rightKeyBlockNextIdx : ++rightEndIdx);
+            rightEndIdx == (uint64_t)-1 ? rightKeyBlockNextIdx : ++rightEndIdx);
 
-        if (rightEndIdx != -1) {
+        if (rightEndIdx != (uint64_t)-1) {
             rightKeyBlockNextIdx = rightEndIdx;
         }
         return keyBlockMergeMorsel;
@@ -155,7 +155,7 @@ void KeyBlockMerger::mergeKeyBlocks(KeyBlockMergeMorsel& keyBlockMergeMorsel) co
             std::min(std::min(leftBlockPtrInfo.getNumBytesLeftInCurBlock(),
                          rightBlockPtrInfo.getNumBytesLeftInCurBlock()),
                 resultBlockPtrInfo.getNumBytesLeftInCurBlock());
-        for (auto i = 0; i < nextNumBytesToMerge; i += numBytesPerTuple) {
+        for (auto i = 0u; i < nextNumBytesToMerge; i += numBytesPerTuple) {
             if (compareTuplePtr(leftBlockPtrInfo.curTuplePtr, rightBlockPtrInfo.curTuplePtr)) {
                 memcpy(resultBlockPtrInfo.curTuplePtr, rightBlockPtrInfo.curTuplePtr,
                     numBytesPerTuple);
@@ -255,7 +255,7 @@ void KeyBlockMerger::copyRemainingBlockDataToResult(
     while (blockToCopy.curBlockIdx <= blockToCopy.endBlockIdx) {
         uint64_t nextNumBytesToMerge = std::min(
             blockToCopy.getNumBytesLeftInCurBlock(), resultBlock.getNumBytesLeftInCurBlock());
-        for (int i = 0; i < nextNumBytesToMerge; i += numBytesPerTuple) {
+        for (auto i = 0u; i < nextNumBytesToMerge; i += numBytesPerTuple) {
             memcpy(resultBlock.curTuplePtr, blockToCopy.curTuplePtr, numBytesPerTuple);
             blockToCopy.curTuplePtr += numBytesPerTuple;
             resultBlock.curTuplePtr += numBytesPerTuple;

--- a/src/processor/operator/order_by/sort_state.cpp
+++ b/src/processor/operator/order_by/sort_state.cpp
@@ -127,7 +127,7 @@ uint64_t PayloadScanner::scan(std::vector<common::ValueVector*> vectorsToRead) {
         } else {
             auto numTuplesToRead = std::min(DEFAULT_VECTOR_CAPACITY,
                 endTuplesIdxToReadInMergedKeyBlock - nextTupleIdxToReadInMergedKeyBlock);
-            auto numTuplesRead = 0;
+            auto numTuplesRead = 0u;
             while (numTuplesRead < numTuplesToRead) {
                 auto numTuplesToReadInCurBlock = std::min(
                     numTuplesToRead - numTuplesRead, blockPtrInfo->getNumTuplesLeftInCurBlock());

--- a/src/processor/operator/persistent/copy_node.cpp
+++ b/src/processor/operator/persistent/copy_node.cpp
@@ -68,7 +68,7 @@ void CopyNode::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* /*
         }
     }
     KU_ASSERT(state != nullptr);
-    for (auto i = 0; i < info->columnPositions.size(); ++i) {
+    for (auto i = 0u; i < info->columnPositions.size(); ++i) {
         auto pos = info->columnPositions[i];
         if (pos.isValid()) {
             columnVectors.push_back(resultSet->getValueVector(pos).get());

--- a/src/processor/operator/persistent/copy_to_csv.cpp
+++ b/src/processor/operator/persistent/copy_to_csv.cpp
@@ -109,7 +109,7 @@ void CopyToCSVLocalState::writeString(
     }
     if (forceQuote) {
         bool requiresEscape = false;
-        for (auto i = 0; i < strLen; i++) {
+        for (auto i = 0u; i < strLen; i++) {
             if (strData[i] == copyToCsvInfo->copyToOption->quoteChar ||
                 strData[i] == copyToCsvInfo->copyToOption->escapeChar) {
                 requiresEscape = true;
@@ -151,7 +151,7 @@ void CopyToCSVLocalState::writeRows(CopyToCSVInfo* copyToCsvInfo) {
             numRowsToWrite = vectorToCast->state->selVector->selectedSize;
         }
     }
-    for (auto i = 0; i < numRowsToWrite; i++) {
+    for (auto i = 0u; i < numRowsToWrite; i++) {
         for (auto j = 0u; j < castVectors.size(); j++) {
             if (j != 0) {
                 serializer->writeBufferData(copyToCsvInfo->copyToOption->delimiter);

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -133,7 +133,7 @@ void RelInsertExecutor::insert(transaction::Transaction* tx) {
     auto offset = relsStatistics.getNextRelOffset(tx, table->getTableID());
     propertyRhsVectors[0]->setValue(0, offset); // internal ID property
     propertyRhsVectors[0]->setNull(0, false);
-    for (auto i = 1; i < propertyRhsEvaluators.size(); ++i) {
+    for (auto i = 1u; i < propertyRhsEvaluators.size(); ++i) {
         propertyRhsEvaluators[i]->evaluate();
     }
     table->insert(tx, srcNodeIDVector, dstNodeIDVector, propertyRhsVectors);

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -118,7 +118,7 @@ void SerialCSVScan::bindColumns(const ReaderConfig& readerConfig,
     std::vector<std::string>& columnNames, std::vector<std::unique_ptr<LogicalType>>& columnTypes) {
     KU_ASSERT(readerConfig.getNumFiles() > 0);
     bindColumns(readerConfig, 0, columnNames, columnTypes);
-    for (auto i = 1; i < readerConfig.getNumFiles(); ++i) {
+    for (auto i = 1u; i < readerConfig.getNumFiles(); ++i) {
         std::vector<std::string> tmpColumnNames;
         std::vector<std::unique_ptr<LogicalType>> tmpColumnTypes;
         bindColumns(readerConfig, i, tmpColumnNames, tmpColumnTypes);

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -293,7 +293,7 @@ void NpyScanFunction::bindColumns(const common::ReaderConfig& readerConfig,
     std::vector<std::unique_ptr<common::LogicalType>>& columnTypes) {
     KU_ASSERT(readerConfig.getNumFiles() > 0);
     bindColumns(readerConfig, 0, columnNames, columnTypes);
-    for (auto i = 1; i < readerConfig.getNumFiles(); ++i) {
+    for (auto i = 1u; i < readerConfig.getNumFiles(); ++i) {
         std::vector<std::string> tmpColumnNames;
         std::vector<std::unique_ptr<LogicalType>> tmpColumnTypes;
         bindColumns(readerConfig, i, tmpColumnNames, tmpColumnTypes);

--- a/src/processor/operator/persistent/reader/parquet/list_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/list_column_reader.cpp
@@ -120,7 +120,7 @@ uint64_t ListColumnReader::read(uint64_t numValues, parquet_filter_t& /*filter*/
             common::ListVector::sliceDataVector(vectorToRead.get(), childIdx, childActualNumValues);
             overflowChildCount = childActualNumValues - childIdx;
             // move values in the child repeats and defines *backward* by child_idx
-            for (auto repdefIdx = 0; repdefIdx < overflowChildCount; repdefIdx++) {
+            for (auto repdefIdx = 0u; repdefIdx < overflowChildCount; repdefIdx++) {
                 childDefinesPtr[repdefIdx] = childDefinesPtr[childIdx + repdefIdx];
                 childRepeatsPtr[repdefIdx] = childRepeatsPtr[childIdx + repdefIdx];
             }

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -666,7 +666,7 @@ void ParquetScanFunction::bindColumns(const common::ReaderConfig& readerConfig,
     std::vector<std::unique_ptr<common::LogicalType>>& columnTypes) {
     KU_ASSERT(readerConfig.getNumFiles() > 0);
     bindColumns(readerConfig, 0, mm, columnNames, columnTypes);
-    for (auto i = 1; i < readerConfig.getNumFiles(); ++i) {
+    for (auto i = 1u; i < readerConfig.getNumFiles(); ++i) {
         std::vector<std::string> tmpColumnNames;
         std::vector<std::unique_ptr<LogicalType>> tmpColumnTypes;
         bindColumns(readerConfig, i, mm, tmpColumnNames, tmpColumnTypes);

--- a/src/processor/operator/persistent/reader/reader_bind_utils.cpp
+++ b/src/processor/operator/persistent/reader/reader_bind_utils.cpp
@@ -22,7 +22,7 @@ void ReaderBindUtils::validateColumnTypes(const std::vector<std::string>& column
     const std::vector<std::unique_ptr<common::LogicalType>>& expectedColumnTypes,
     const std::vector<std::unique_ptr<common::LogicalType>>& detectedColumnTypes) {
     KU_ASSERT(expectedColumnTypes.size() == detectedColumnTypes.size());
-    for (auto i = 0; i < expectedColumnTypes.size(); ++i) {
+    for (auto i = 0u; i < expectedColumnTypes.size(); ++i) {
         if (*expectedColumnTypes[i] != *detectedColumnTypes[i]) {
             throw common::BinderException(common::stringFormat(
                 "Column `{}` type mismatch. Expected {} but got {}.", columnNames[i],

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -29,7 +29,7 @@ struct ParquetInt128Operator {
     }
 
     template<class SRC, class TGT>
-    static void handleStats(ColumnWriterStatistics* stats, SRC source, TGT target) {}
+    static void handleStats(ColumnWriterStatistics* /*stats*/, SRC /*source*/, TGT /*target*/) {}
 };
 
 struct ParquetTimestampNSOperator : public BaseParquetOperator {

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -220,7 +220,7 @@ void ParquetWriter::prepareRowGroup(FactorizedTable& ft, PreparedRowGroup& resul
         }
     }
 
-    for (auto i = 0; i < columnWriters.size(); i++) {
+    for (auto i = 0u; i < columnWriters.size(); i++) {
         columnWriters[i]->beginWrite(*writerStates[i]);
     }
 

--- a/src/processor/operator/persistent/writer/parquet/var_list_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/var_list_column_writer.cpp
@@ -64,7 +64,7 @@ void VarListColumnWriter::prepare(ColumnWriterState& writerState, ColumnWriterSt
                 state.isEmpty.push_back(false);
             }
             state.repetitionLevels.push_back(firstRepeatLevel);
-            for (auto k = 1; k < listEntry.size; k++) {
+            for (auto k = 1u; k < listEntry.size; k++) {
                 state.repetitionLevels.push_back(maxRepeat + 1);
                 state.definitionLevels.push_back(common::ParquetConstants::PARQUET_DEFINE_VALID);
                 state.isEmpty.push_back(false);

--- a/src/processor/operator/recursive_extend/frontier_scanner.cpp
+++ b/src/processor/operator/recursive_extend/frontier_scanner.cpp
@@ -42,7 +42,7 @@ void BaseFrontierScanner::resetState(const BaseBFSState& bfsState) {
     lastFrontierCursor = 0;
     currentDstNodeID = {INVALID_OFFSET, INVALID_TABLE_ID};
     frontiers.clear();
-    for (auto i = 0; i < bfsState.getNumFrontiers(); ++i) {
+    for (auto i = 0u; i < bfsState.getNumFrontiers(); ++i) {
         frontiers.push_back(bfsState.getFrontier(i));
     }
 }
@@ -59,7 +59,7 @@ void PathScanner::scanFromDstOffset(RecursiveJoinVectors* vectors, sel_t& vector
     while (!nbrsStack.empty()) {
         auto& cursor = cursorStack.top();
         cursor++;
-        if (cursor < nbrsStack.top()->size()) { // Found a new nbr
+        if ((uint64_t)cursor < nbrsStack.top()->size()) { // Found a new nbr
             auto& nbr = nbrsStack.top()->at(cursor);
             nodeIDs[level] = nbr.first;
             relIDs[level] = nbr.second;

--- a/src/processor/result/factorized_table.cpp
+++ b/src/processor/result/factorized_table.cpp
@@ -322,10 +322,8 @@ uint64_t FactorizedTable::computeNumTuplesToAppend(
             // The caller is not allowed to append multiple unflat columns from different
             // datachunks to multiple flat columns in the factorizedTable.
             if (!tableSchema->getColumn(i)->isFlat()) {
-                if (unflatDataChunkPos != -1 &&
-                    tableSchema->getColumn(i)->getDataChunkPos() != unflatDataChunkPos) {
-                    KU_ASSERT(false);
-                }
+                KU_ASSERT(unflatDataChunkPos == (uint64_t)-1 ||
+                          tableSchema->getColumn(i)->getDataChunkPos() != unflatDataChunkPos);
                 unflatDataChunkPos = tableSchema->getColumn(i)->getDataChunkPos();
             }
             numTuplesToAppend = vectorsToAppend[i]->state->selVector->selectedSize;

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -185,7 +185,7 @@ template<typename T>
 BitpackHeader IntegerBitpacking<T>::getBitWidth(
     const uint8_t* srcBuffer, uint64_t numValues) const {
     T max = std::numeric_limits<T>::min(), min = std::numeric_limits<T>::max();
-    for (int i = 0; i < numValues; i++) {
+    for (auto i = 0u; i < numValues; i++) {
         T value = ((T*)srcBuffer)[i];
         if (value > max) {
             max = value;
@@ -350,7 +350,7 @@ uint64_t IntegerBitpacking<T>::compressNextPage(const uint8_t*& srcBuffer,
         U tmp[CHUNK_SIZE];
         auto lastFullChunkEnd = numValuesToCompress - numValuesToCompress % CHUNK_SIZE;
         for (auto i = 0ull; i < lastFullChunkEnd; i += CHUNK_SIZE) {
-            for (int j = 0; j < CHUNK_SIZE; j++) {
+            for (auto j = 0u; j < CHUNK_SIZE; j++) {
                 tmp[j] = (U)(((T*)srcBuffer)[i + j] - (T)header.offset);
             }
             fastpack(tmp, dstBuffer + i * bitWidth / 8, bitWidth);
@@ -359,7 +359,7 @@ uint64_t IntegerBitpacking<T>::compressNextPage(const uint8_t*& srcBuffer,
         auto remainingValues = numValuesToCompress % CHUNK_SIZE;
         if (remainingValues > 0) {
             memcpy(tmp, (const U*)srcBuffer + lastFullChunkEnd, remainingValues * sizeof(U));
-            for (int i = 0; i < remainingValues; i++) {
+            for (auto i = 0u; i < remainingValues; i++) {
                 tmp[i] = (U)((T)tmp[i] - (T)header.offset);
             }
             memset(tmp + remainingValues, 0, CHUNK_SIZE - remainingValues);
@@ -400,7 +400,7 @@ void IntegerBitpacking<T>::decompressFromPage(const uint8_t* srcBuffer, uint64_t
             SignExtend<T, U, CHUNK_SIZE>(dstBuffer + dstIndex * sizeof(U), header.bitWidth);
         }
         if (header.offset != 0) {
-            for (int i = 0; i < CHUNK_SIZE; i++) {
+            for (auto i = 0u; i < CHUNK_SIZE; i++) {
                 ((T*)dstBuffer)[dstIndex + i] += (T)header.offset;
             }
         }
@@ -425,7 +425,7 @@ template class IntegerBitpacking<uint64_t>;
 void BooleanBitpacking::setValuesFromUncompressed(const uint8_t* srcBuffer, offset_t srcOffset,
     uint8_t* dstBuffer, offset_t dstOffset, offset_t numValues,
     const CompressionMetadata& /*metadata*/) const {
-    for (auto i = 0; i < numValues; i++) {
+    for (auto i = 0u; i < numValues; i++) {
         NullMask::setNull((uint64_t*)dstBuffer, dstOffset + i, ((bool*)srcBuffer)[srcOffset + i]);
     }
 }

--- a/src/storage/index/hash_index_builder.cpp
+++ b/src/storage/index/hash_index_builder.cpp
@@ -46,7 +46,7 @@ void HashIndexBuilder<T>::bulkReserve(uint32_t numEntries_) {
     // Build from scratch.
     slotCapacity = getSlotCapacity<T>();
     auto numRequiredSlots = (numRequiredEntries + slotCapacity - 1) / slotCapacity;
-    auto numSlotsOfCurrentLevel = 1 << indexHeader->currentLevel;
+    auto numSlotsOfCurrentLevel = 1u << indexHeader->currentLevel;
     while ((numSlotsOfCurrentLevel << 1) < numRequiredSlots) {
         indexHeader->incrementLevel();
         numSlotsOfCurrentLevel <<= 1;

--- a/src/storage/local_storage/local_table.cpp
+++ b/src/storage/local_storage/local_table.cpp
@@ -52,7 +52,7 @@ std::unique_ptr<LocalVectorCollection> LocalVectorCollection::getStructChildVect
     auto childCollection = std::make_unique<LocalVectorCollection>(
         StructType::getField(dataType.get(), idx)->getType()->copy(), mm);
 
-    for (int i = 0; i < numRows; i++) {
+    for (auto i = 0u; i < numRows; i++) {
         auto fieldVector =
             common::StructVector::getFieldVector(getLocalVector(i)->getVector(), idx);
         childCollection->append(fieldVector.get());

--- a/src/storage/stats/node_table_statistics.cpp
+++ b/src/storage/stats/node_table_statistics.cpp
@@ -115,7 +115,7 @@ void NodeTableStatsAndDeletedIDs::setDeletedNodeOffsetsForMorsel(
         auto itr = deletedNodeOffsets.begin();
         sel_t nextDeletedNodeOffset = *itr - morselBeginOffset;
         uint64_t nextSelectedPosition = 0;
-        for (auto pos = 0; pos < nodeOffsetVector->state->getOriginalSize(); ++pos) {
+        for (auto pos = 0u; pos < nodeOffsetVector->state->getOriginalSize(); ++pos) {
             if (pos == nextDeletedNodeOffset) {
                 itr++;
                 if (itr == deletedNodeOffsets.end()) {

--- a/src/storage/storage_structure/disk_array.cpp
+++ b/src/storage/storage_structure/disk_array.cpp
@@ -478,7 +478,7 @@ template<typename T>
 void InMemDiskArrayBuilder<T>::saveToDisk() {
     // save the header and pips.
     this->header.saveToDisk(this->fileHandle, this->headerPageIdx);
-    for (int i = 0; i < this->pips.size(); ++i) {
+    for (auto i = 0u; i < this->pips.size(); ++i) {
         this->fileHandle.writePage(
             reinterpret_cast<uint8_t*>(&this->pips[i].pipContents), this->pips[i].pipPageIdx);
     }

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -41,7 +41,7 @@ struct InternalIDColumnFunc {
     static void writeValuesToPage(uint8_t* frame, uint16_t posInFrame, const uint8_t* data,
         uint32_t dataOffset, offset_t numValues, const CompressionMetadata& /*metadata*/) {
         auto internalIDs = ((internalID_t*)data);
-        for (int i = 0; i < numValues; i++) {
+        for (auto i = 0u; i < numValues; i++) {
             memcpy(frame + posInFrame * sizeof(offset_t), &internalIDs[dataOffset + i].offset,
                 sizeof(offset_t));
         }
@@ -84,7 +84,7 @@ struct BoolColumnFunc {
         // Otherwise, it could read off the end of the page.
         //
         // Currently, the frame stores bitpacked bools, but the value_vector does not
-        for (auto i = 0; i < numValuesToRead; i++) {
+        for (auto i = 0u; i < numValuesToRead; i++) {
             resultVector->setValue(
                 posInVector + i, NullMask::isNull((uint64_t*)frame, pageCursor.elemPosInPage + i));
         }
@@ -117,7 +117,7 @@ struct BoolColumnFunc {
     static void batchLookupFromPage(uint8_t* frame, PageElementCursor& pageCursor, uint8_t* result,
         uint32_t startPosInResult, uint64_t numValuesToRead,
         const CompressionMetadata& /*metadata*/) {
-        for (auto i = 0; i < numValuesToRead; i++) {
+        for (auto i = 0u; i < numValuesToRead; i++) {
             result[startPosInResult + i] =
                 NullMask::isNull((uint64_t*)frame, pageCursor.elemPosInPage + i);
         }

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -48,7 +48,7 @@ public:
         auto valuesRemaining = metadata.numValues;
         const uint8_t* bufferStart = buffer;
         auto compressedBuffer = std::make_unique<uint8_t[]>(BufferPoolConstants::PAGE_4KB_SIZE);
-        auto numPages = 0;
+        auto numPages = 0u;
         auto numValuesPerPage =
             metadata.compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType);
         KU_ASSERT(numValuesPerPage * metadata.numPages >= metadata.numValues);

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -44,7 +44,7 @@ void NodeTable::read(Transaction* transaction, TableReadState& readState, ValueV
 
 offset_t NodeTable::insert(Transaction* transaction, ValueVector* nodeIDVector,
     const std::vector<common::ValueVector*>& propertyVectors) {
-    auto maxNodeOffset = 0;
+    auto maxNodeOffset = 0u;
     for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; i++) {
         auto pos = nodeIDVector->state->selVector->selectedPositions[i];
         auto offset =
@@ -85,7 +85,7 @@ void NodeTable::delete_(
     }
     // TODO(Guodong): We actually have flatten the input here. But the code is left unchanged for
     // now, so we can remove the flattenAll logic later.
-    for (auto i = 0; i < nodeIDVector->state->selVector->selectedSize; i++) {
+    for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; i++) {
         auto pos = nodeIDVector->state->selVector->selectedPositions[i];
         if (nodeIDVector->isNull(pos)) {
             continue;

--- a/src/storage/store/node_table_data.cpp
+++ b/src/storage/store/node_table_data.cpp
@@ -119,7 +119,7 @@ void NodeTableData::append(kuzu::storage::NodeGroup* nodeGroup) {
 void NodeTableData::prepareLocalTableToCommit(
     Transaction* transaction, LocalTableData* localTable) {
     for (auto& [nodeGroupIdx, nodeGroup] : localTable->nodeGroups) {
-        for (auto columnID = 0; columnID < columns.size(); columnID++) {
+        for (auto columnID = 0u; columnID < columns.size(); columnID++) {
             auto column = columns[columnID].get();
             auto columnChunk = nodeGroup->getLocalColumnChunk(columnID);
             if (columnChunk->getNumRows() == 0) {

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -61,7 +61,7 @@ void RelDataReadState::populateCSRListEntries() {
     auto csrOffsets = (offset_t*)csrOffsetChunk->getData();
     csrListEntries[0].offset = 0;
     csrListEntries[0].size = csrOffsets[0];
-    for (auto i = 1; i < numNodes; i++) {
+    for (auto i = 1u; i < numNodes; i++) {
         csrListEntries[i].offset = csrOffsets[i - 1];
         csrListEntries[i].size = csrOffsets[i] - csrOffsets[i - 1];
     }
@@ -318,7 +318,7 @@ void RelTableData::append(NodeGroup* nodeGroup) {
         csrOffsetColumn->append(csrNodeGroup->getCSROffsetChunk(), nodeGroup->getNodeGroupIdx());
     }
     adjColumn->append(nodeGroup->getColumnChunk(0), nodeGroup->getNodeGroupIdx());
-    for (auto columnID = 0; columnID < columns.size(); columnID++) {
+    for (auto columnID = 0u; columnID < columns.size(); columnID++) {
         columns[columnID]->append(
             nodeGroup->getColumnChunk(columnID + 1), nodeGroup->getNodeGroupIdx());
     }
@@ -499,7 +499,7 @@ std::unique_ptr<ColumnChunk> RelTableData::slideCSROffsetChunk(
     int64_t currentCSROffset = 0;
     auto currentNumSrcNodesInNG = csrOffsetChunk->getNumValues();
     auto newNumSrcNodesInNG = currentNumSrcNodesInNG;
-    for (auto offsetInNG = 0; offsetInNG < currentNumSrcNodesInNG; offsetInNG++) {
+    for (auto offsetInNG = 0u; offsetInNG < currentNumSrcNodesInNG; offsetInNG++) {
         int64_t numRowsInCSR = offsetInNG == 0 ?
                                    csrOffsets[offsetInNG] :
                                    csrOffsets[offsetInNG] - csrOffsets[offsetInNG - 1];
@@ -556,7 +556,7 @@ std::unique_ptr<ColumnChunk> RelTableData::slideCSRColumnChunk(Transaction* tran
     auto currentNumSrcNodesInNG = csrOffsetChunk->getNumValues();
     auto csrOffsets = (offset_t*)csrOffsetChunk->getData();
     auto relIDs = (offset_t*)relIDChunk->getData();
-    for (auto offsetInNG = 0; offsetInNG < currentNumSrcNodesInNG; offsetInNG++) {
+    for (auto offsetInNG = 0u; offsetInNG < currentNumSrcNodesInNG; offsetInNG++) {
         auto [startCSROffset, endCSROffset] = getCSRStartAndEndOffset(offsetInNG, csrOffsets);
         auto hasDeletions = deleteInfo.contains(offsetInNG);
         auto hasUpdates = updateInfo.contains(offsetInNG);

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -186,8 +186,7 @@ void StringColumn::scanValuesToVector(Transaction* transaction, node_group_idx_t
     scanOffsets(transaction, offsetState, offsets.data(), firstOffsetToScan, numOffsetsToScan,
         dataState.metadata.numValues);
 
-    auto pos = 0;
-    for (; pos < offsetsToScan.size(); pos++) {
+    for (auto pos = 0u; pos < offsetsToScan.size(); pos++) {
         auto startOffset = offsets[offsetsToScan[pos].first - firstOffsetToScan];
         auto endOffset = offsets[offsetsToScan[pos].first - firstOffsetToScan + 1];
         scanValueToVector(transaction, dataState, startOffset, endOffset, resultVector,

--- a/src/storage/store/string_column_chunk.cpp
+++ b/src/storage/store/string_column_chunk.cpp
@@ -167,7 +167,7 @@ void StringColumnChunk::finalize() {
     // We re-write the source buffer as we go over it.
     // Each index is replaced by a new one for the de-duplicated data in the new data buffer
     auto outIndices = (string_index_t*)buffer.get();
-    for (int i = 0; i < numValues; i++) {
+    for (auto i = 0u; i < numValues; i++) {
         if (nullChunk->isNull(i)) {
             continue;
         }

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -132,7 +132,7 @@ void StructColumn::prepareCommitForChunk(Transaction* transaction, node_group_id
         nullColumn->commitLocalChunkInPlace(
             transaction, nodeGroupIdx, localColumnChunk, insertInfo, updateInfo, deleteInfo);
         // Update each child column separately
-        for (int i = 0; i < childColumns.size(); i++) {
+        for (auto i = 0u; i < childColumns.size(); i++) {
             const auto& childColumn = childColumns[i];
             auto childLocalColumnChunk = localColumnChunk->getStructChildVectorCollection(i);
 

--- a/src/storage/store/var_list_column_chunk.cpp
+++ b/src/storage/store/var_list_column_chunk.cpp
@@ -133,7 +133,7 @@ void VarListColumnChunk::write(
 
 void VarListColumnChunk::copyListValues(const list_entry_t& entry, ValueVector* dataVector) {
     auto numListValuesToCopy = entry.size;
-    auto numListValuesCopied = 0;
+    auto numListValuesCopied = 0u;
     while (numListValuesCopied < numListValuesToCopy) {
         auto numListValuesToCopyInBatch =
             std::min<uint64_t>(numListValuesToCopy - numListValuesCopied, DEFAULT_VECTOR_CAPACITY);

--- a/src/storage/wal/wal_record.cpp
+++ b/src/storage/wal/wal_record.cpp
@@ -5,20 +5,6 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-bool DBFileID::operator==(const DBFileID& rhs) const {
-    if (dbFileType != rhs.dbFileType || isOverflow != rhs.isOverflow) {
-        return false;
-    }
-    switch (dbFileType) {
-    case DBFileType::NODE_INDEX: {
-        return nodeIndexID == rhs.nodeIndexID;
-    }
-    default: {
-        KU_UNREACHABLE;
-    }
-    }
-}
-
 std::string dbFileTypeToString(DBFileType dbFileType) {
     switch (dbFileType) {
     case DBFileType::DATA: {
@@ -37,13 +23,11 @@ std::string dbFileTypeToString(DBFileType dbFileType) {
 }
 
 DBFileID DBFileID::newDataFileID() {
-    DBFileID retVal{DBFileType::DATA, false};
-    return retVal;
+    return DBFileID{DBFileType::DATA};
 }
 
 DBFileID DBFileID::newMetadataFileID() {
-    DBFileID retVal{DBFileType::METADATA, false};
-    return retVal;
+    return DBFileID{DBFileType::METADATA};
 }
 
 DBFileID DBFileID::newPKIndexFileID(common::table_id_t tableID) {

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -100,7 +100,7 @@ private:
         return static_cast<bool>(getline(fileStream, line));
     }
 
-    inline void checkMinimumParams(int minimumParams) {
+    inline void checkMinimumParams(uint64_t minimumParams) {
         if (currentToken.params.size() - 1 < minimumParams) {
             throw common::TestException("Minimum number of parameters is " +
                                         std::to_string(minimumParams) + ". [" + path + ":" + line +

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -32,7 +32,7 @@ void test_compression(CompressionAlg& alg, std::vector<T> src) {
     EXPECT_EQ(decompressed, src);
     EXPECT_EQ(decompressed[1], value);
 
-    for (int i = 0; i < src.size(); i++) {
+    for (auto i = 0u; i < src.size(); i++) {
         alg.decompressFromPage(
             dest.data(), i, (uint8_t*)decompressed.data(), i, 1 /*numValues*/, metadata);
         EXPECT_EQ(decompressed[i], src[i]);
@@ -150,7 +150,7 @@ void integerPackingMultiPage(const std::vector<T>& src) {
         numValuesRemaining -= numValuesPerPage;
     }
     ASSERT_EQ(srcCursor, (uint8_t*)(src.data() + src.size()));
-    for (int i = 0; i < src.size(); i++) {
+    for (auto i = 0u; i < src.size(); i++) {
         auto page = i / numValuesPerPage;
         auto indexInPage = i % numValuesPerPage;
         T value;
@@ -160,7 +160,7 @@ void integerPackingMultiPage(const std::vector<T>& src) {
         EXPECT_EQ(src[i], value);
     }
     std::vector<T> decompressed(src.size());
-    for (int i = 0; i < src.size(); i += numValuesPerPage) {
+    for (auto i = 0u; i < src.size(); i += numValuesPerPage) {
         auto page = i / numValuesPerPage;
         alg.decompressFromPage(dest[page].data(), 0, (uint8_t*)decompressed.data(), i,
             std::min(numValuesPerPage, (uint64_t)src.size() - i), metadata);

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -84,7 +84,7 @@ TEST_F(NodeInsertionDeletionTests, DeleteAddMixedTest) {
 
 TEST_F(NodeInsertionDeletionTests, InsertManyNodesTest) {
     auto preparedStatement = conn->prepare("CREATE (:person {ID:$id});");
-    for (int64_t i = 0; i < BufferPoolConstants::PAGE_4KB_SIZE; i++) {
+    for (int64_t i = 0; i < (int64_t)BufferPoolConstants::PAGE_4KB_SIZE; i++) {
         auto result =
             conn->execute(preparedStatement.get(), std::make_pair(std::string("id"), 10000 + i));
         ASSERT_TRUE(result->isSuccess()) << result->toString();

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -1,3 +1,7 @@
+if(NOT MSVC)
+    add_compile_options(-Wno-extra)
+endif()
+
 add_subdirectory(antlr4_cypher)
 add_subdirectory(antlr4_runtime)
 add_subdirectory(fast_float)

--- a/third_party/antlr4_cypher/include/cypher_parser.h
+++ b/third_party/antlr4_cypher/include/cypher_parser.h
@@ -2299,12 +2299,12 @@ public:
 
 private:
 
-      virtual void notifyQueryNotConcludeWithReturn(antlr4::Token* startToken) {};
-      virtual void notifyNodePatternWithoutParentheses(std::string nodeName, antlr4::Token* startToken) {};
-      virtual void notifyInvalidNotEqualOperator(antlr4::Token* startToken) {};
-      virtual void notifyEmptyToken(antlr4::Token* startToken) {};
-      virtual void notifyReturnNotAtEnd(antlr4::Token* startToken) {};
-      virtual void notifyNonBinaryComparison(antlr4::Token* startToken) {};
+      virtual void notifyQueryNotConcludeWithReturn(antlr4::Token* /*startToken*/) {};
+      virtual void notifyNodePatternWithoutParentheses(std::string /*nodeName*/, antlr4::Token* /*startToken*/) {};
+      virtual void notifyInvalidNotEqualOperator(antlr4::Token* /*startToken*/) {};
+      virtual void notifyEmptyToken(antlr4::Token* /*startToken*/) {};
+      virtual void notifyReturnNotAtEnd(antlr4::Token* /*startToken*/) {};
+      virtual void notifyNonBinaryComparison(antlr4::Token* /*startToken*/) {};
 
 };
 

--- a/third_party/miniparquet/src/thrift/transport/TTransportException.h
+++ b/third_party/miniparquet/src/thrift/transport/TTransportException.h
@@ -62,7 +62,7 @@ public:
   TTransportException(TTransportExceptionType type, const std::string& message)
     : kuzu_apache::thrift::TException(message), type_(type) {}
 
-  TTransportException(TTransportExceptionType type, const std::string& message, int errno_copy)
+  TTransportException(TTransportExceptionType type, const std::string& message, int /*errno_copy*/)
     : kuzu_apache::thrift::TException(message), type_(type) {}
 
   ~TTransportException() noexcept override = default;

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -1094,7 +1094,7 @@ JNIEXPORT jstring JNICALL Java_com_kuzudb_KuzuNative_kuzu_1value_1get_1struct_1f
     auto* sv = getValue(env, thisSV);
     auto dataType = sv->getDataType();
     auto fieldNames = StructType::getFieldNames(dataType);
-    if (index >= fieldNames.size() || index < 0) {
+    if ((uint64_t)index >= fieldNames.size() || index < 0) {
         return nullptr;
     }
     auto name = fieldNames[index];

--- a/tools/nodejs_api/src_cpp/include/node_query_result.h
+++ b/tools/nodejs_api/src_cpp/include/node_query_result.h
@@ -98,7 +98,7 @@ public:
         Napi::Object nodeTuple = Napi::Object::New(env);
         try {
             auto columnNames = nodeQueryResult->queryResult->getColumnNames();
-            for (auto i = 0; i < cppTuple->len(); ++i) {
+            for (auto i = 0u; i < cppTuple->len(); ++i) {
                 Napi::Value value = Util::ConvertToNapiObject(*cppTuple->getValue(i), env);
                 nodeTuple.Set(columnNames[i], value);
             }


### PR DESCRIPTION
Primarily these warnings fall into two categories:
- Unused parameter (that clang-tidy didn't catch).
- Mismatch sign comparison. Generally this happens in loops, and the correct fix is `auto i = 0u`. This gives `i` the type of `unsigned`, and so we must be careful that `i` cannot overflow 2^32.

Wextra is disabled when building third_party code.