### PR TITLE
cmake: make header creation depend on libkuzu

### DIFF
--- a/examples/cpp/CMakeLists.txt
+++ b/examples/cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_executable(example_cpp main.cpp)
 target_link_libraries(example_cpp kuzu_shared)
-target_include_directories(example_cpp PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/src)
+target_include_directories(example_cpp PRIVATE ${CMAKE_BINARY_DIR}/src)
 add_dependencies(example_cpp single_file_header)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,8 +50,7 @@ add_custom_command(
         COMMAND
                 ${Python3_EXECUTABLE} ${PROJECT_SOURCE_DIR}/scripts/collect-single-file-header.py
         DEPENDS
-                ${PROJECT_SOURCE_DIR}/scripts/collect-single-file-header.py
-                ${CMAKE_CURRENT_SOURCE_DIR}/include/main/kuzu.h)
+                ${PROJECT_SOURCE_DIR}/scripts/collect-single-file-header.py kuzu_shared)
 add_custom_target(single_file_header ALL DEPENDS kuzu.hpp)
 
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kuzu.hpp ${CMAKE_CURRENT_SOURCE_DIR}/include/c_api/kuzu.h TYPE INCLUDE)


### PR DESCRIPTION
CMake doesn't correctly detect when headers are changed. The IMPLICIT_DEPENDS property, which would solve our issues, is supported for Makefile generators only.

Instead, we can build kuzu.hpp after all of kuzu is built. Additionally, the example should depend on the correct include directory. I'm not sure why this compiled before.