### PR TITLE
async I/O: finish prototype of io_uring 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,26 @@ project(Kuzu VERSION 0.1.0.1 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 
+# ---------------------------------------------------------------------------
+# Uring
+# ---------------------------------------------------------------------------
+
+find_path(LIBURING_INCLUDE_DIR NAMES liburing.h)
+mark_as_advanced(LIBURING_INCLUDE_DIR)
+
+find_library(LIBURING_LIBRARY NAMES uring)
+mark_as_advanced(LIBURING_LIBRARY)
+
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(
+        LIBURING
+        REQUIRED_VARS LIBURING_LIBRARY LIBURING_INCLUDE_DIR)
+
+if(LIBURING_FOUND)
+    set(LIBURING_LIBRARIES ${LIBURING_LIBRARY})
+    set(LIBURING_INCLUDE_DIRS ${LIBURING_INCLUDE_DIR})
+endif()
+
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED TRUE)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ add_subdirectory(transaction)
 add_library(kuzu STATIC ${ALL_OBJECT_FILES})
 add_library(kuzu_shared SHARED ${ALL_OBJECT_FILES})
 
-set(KUZU_LIBRARIES antlr4_cypher antlr4_runtime fast_float utf8proc re2 serd Threads::Threads fastpfor miniparquet zstd miniz)
+set(KUZU_LIBRARIES antlr4_cypher antlr4_runtime fast_float utf8proc re2 serd ${LIBURING_LIBRARY} Threads::Threads fastpfor miniparquet zstd miniz)
 target_link_libraries(kuzu PUBLIC ${KUZU_LIBRARIES})
 target_link_libraries(kuzu_shared PUBLIC ${KUZU_LIBRARIES})
 unset(KUZU_LIBRARIES)

--- a/src/include/common/file_utils.h
+++ b/src/include/common/file_utils.h
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #endif
 
+#include <liburing.h>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -36,6 +37,18 @@ struct FileInfo {
 #endif
 };
 
+struct NodeGroupInfo {
+    uint64_t byteSize = 0;
+    uint8_t idx;
+    uint64_t totalReq = 0;
+
+    uint64_t receivedSize = 0;
+    uint64_t receivedReq = 0;
+
+    NodeGroupInfo(uint8_t i): idx{i}
+    {}
+};
+
 class FileUtils {
 public:
     static std::unique_ptr<FileInfo> openFile(
@@ -45,6 +58,8 @@ public:
         FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position);
     static void writeToFile(
         FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset);
+    static void writeToFileAsync(
+        FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset, io_uring* ring, NodeGroupInfo* info);
     // This function is a no-op if either file, from or to, does not exist.
     static void overwriteFile(const std::string& from, const std::string& to);
     static void copyFile(const std::string& from, const std::string& to,
@@ -74,6 +89,7 @@ public:
         return path.extension().string();
     }
 };
+
 
 } // namespace common
 } // namespace kuzu

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -61,6 +61,7 @@ public:
         common::ValueVector* resultVector);
 
     virtual void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx);
+    virtual void appendAsync(ColumnChunk* columnChunk, uint64_t nodeGroupIdx, io_uring* ring, common::NodeGroupInfo* info);
 
     virtual bool isNull(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk);
@@ -101,6 +102,7 @@ public:
 
     ReadState getReadState(
         transaction::TransactionType transactionType, common::node_group_idx_t nodeGroupIdx) const;
+    inline int getColumnDataFd() { return dataFH->getFileInfo()->fd; }
 
 protected:
     virtual void scanInternal(transaction::Transaction* transaction,

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -8,11 +8,13 @@
 #include "storage/buffer_manager/bm_file_handle.h"
 #include "storage/compression/compression.h"
 
+
 namespace kuzu {
 namespace storage {
 
 class NullColumnChunk;
 class CompressionAlg;
+
 
 struct ColumnChunkMetadata {
     common::page_idx_t pageIdx;
@@ -59,6 +61,8 @@ public:
 
     ColumnChunkMetadata flushBuffer(
         BMFileHandle* dataFH, common::page_idx_t startPageIdx, const ColumnChunkMetadata& metadata);
+    ColumnChunkMetadata flushBufferAsync(BMFileHandle* dataFH, common::page_idx_t startPageIdx,
+        const ColumnChunkMetadata& metadata, io_uring* ring, common::NodeGroupInfo* info);
 
     static inline common::page_idx_t getNumPagesForBytes(uint64_t numBytes) {
         return (numBytes + common::BufferPoolConstants::PAGE_4KB_SIZE - 1) /
@@ -113,7 +117,7 @@ protected:
     std::unique_ptr<NullColumnChunk> nullChunk;
     uint64_t numValues;
     std::function<ColumnChunkMetadata(
-        const uint8_t*, uint64_t, BMFileHandle*, common::page_idx_t, const ColumnChunkMetadata&)>
+        const uint8_t*, uint64_t, BMFileHandle*, common::page_idx_t, const ColumnChunkMetadata&, io_uring*, common::NodeGroupInfo*)>
         flushBufferFunction;
     std::function<ColumnChunkMetadata(const uint8_t*, uint64_t, uint64_t, uint64_t)>
         getMetadataFunction;

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -23,6 +23,7 @@ public:
         return chunks[columnID].get();
     }
     inline bool isFull() const { return numRows == common::StorageConstants::NODE_GROUP_SIZE; }
+    inline bool isEmpty() const { return numRows == 0; }
 
     void resetToEmpty();
     void setAllNull();

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -56,11 +56,13 @@ public:
     void delete_(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         common::ValueVector* pkVector);
     inline void append(NodeGroup* nodeGroup) { tableData->append(nodeGroup); }
+    inline void appendAsync(NodeGroup* nodeGroup, io_uring* ring, common::NodeGroupInfo* info) { tableData->appendAsync(nodeGroup, ring, info); }
 
     inline common::column_id_t getNumColumns() const { return tableData->getNumColumns(); }
     inline Column* getColumn(common::column_id_t columnID) {
         return tableData->getColumn(columnID);
     }
+    inline int getColumnDataFd() { return tableData->getColumn(0)->getColumnDataFd(); }
     inline common::column_id_t getPKColumnID() const { return pkColumnID; }
     inline PrimaryKeyIndex* getPKIndex() const { return pkIndex.get(); }
     inline NodesStoreStatsAndDeletedIDs* getNodeStatisticsAndDeletedIDs() const {

--- a/src/include/storage/store/node_table_data.h
+++ b/src/include/storage/store/node_table_data.h
@@ -34,6 +34,7 @@ public:
     void delete_(transaction::Transaction* transaction, common::ValueVector* nodeIDVector);
 
     void append(NodeGroup* nodeGroup) override;
+    void appendAsync(NodeGroup* nodeGroup, io_uring* ring, common::NodeGroupInfo* info);
 
     void prepareLocalTableToCommit(
         transaction::Transaction* transaction, LocalTableData* localTable) override;

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -19,6 +19,8 @@ public:
         common::ValueVector* resultVector, uint64_t offsetInVector) override;
 
     void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;
+    void appendAsync(ColumnChunk* columnChunk, uint64_t nodeGroupIdx, uv_loop_t* ring,
+        common::NodeGroupInfo* info) override;
 
     void checkpointInMemory() override;
     void rollbackInMemory() override;

--- a/src/include/storage/store/var_list_column.h
+++ b/src/include/storage/store/var_list_column.h
@@ -71,6 +71,8 @@ protected:
         common::ValueVector* resultVector, uint32_t posInVector) final;
 
     void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;
+    void appendAsync(ColumnChunk* columnChunk, uint64_t nodeGroupIdx, uv_loop_t* ring,
+        common::NodeGroupInfo* info) override;
 
 private:
     inline common::offset_t readListOffsetInStorage(transaction::Transaction* transaction,

--- a/src/processor/processor.cpp
+++ b/src/processor/processor.cpp
@@ -22,7 +22,7 @@ std::shared_ptr<FactorizedTable> QueryProcessor::execute(
     lastOperator->initGlobalState(context);
     auto resultCollector = reinterpret_cast<ResultCollector*>(lastOperator);
     // The root pipeline(task) consists of operators and its prevOperator only, because we
-    // expect to have linear plans. For binary operators, e.g., HashJoin, we  keep probe and its
+    // expect to have linear plans. For binary operators, e.g., HashJoin, we keep probe and its
     // prevOperator in the same pipeline, and decompose build and its prevOperator into another
     // one.
     auto task = std::make_shared<ProcessorTask>(resultCollector, context);

--- a/src/storage/store/node_table_data.cpp
+++ b/src/storage/store/node_table_data.cpp
@@ -116,6 +116,18 @@ void NodeTableData::append(kuzu::storage::NodeGroup* nodeGroup) {
     }
 }
 
+void NodeTableData::appendAsync(kuzu::storage::NodeGroup* nodeGroup, io_uring* ring, NodeGroupInfo* info) {
+    for (auto columnID = 0u; columnID < columns.size(); columnID++) {
+        auto columnChunk = nodeGroup->getColumnChunk(columnID);
+        KU_ASSERT(columnID < columns.size());
+        columns[columnID]->appendAsync(columnChunk, nodeGroup->getNodeGroupIdx(), ring, info);
+    	auto ret = io_uring_submit(ring);
+        if (ret < 0) {
+            throw Exception("cqe full");
+        }
+    }
+}
+
 void NodeTableData::prepareLocalTableToCommit(
     Transaction* transaction, LocalTableData* localTable) {
     for (auto& [nodeGroupIdx, nodeGroup] : localTable->nodeGroups) {

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -99,6 +99,16 @@ void StructColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {
     }
 }
 
+void StructColumn::appendAsync(ColumnChunk* columnChunk, uint64_t nodeGroupIdx, uv_loop_t* ring,
+    common::NodeGroupInfo* info) {
+    Column::append(columnChunk, nodeGroupIdx);
+    KU_ASSERT(columnChunk->getDataType()->getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structColumnChunk = static_cast<StructColumnChunk*>(columnChunk);
+    for (auto i = 0u; i < childColumns.size(); i++) {
+        childColumns[i]->appendAsync(structColumnChunk->getChild(i), nodeGroupIdx, ring, info);
+    }
+}
+
 void StructColumn::checkpointInMemory() {
     Column::checkpointInMemory();
     for (const auto& childColumn : childColumns) {

--- a/src/storage/store/var_list_column.cpp
+++ b/src/storage/store/var_list_column.cpp
@@ -96,6 +96,14 @@ void VarListColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {
     dataColumn->append(dataColumnChunk, nodeGroupIdx);
 }
 
+void VarListColumn::appendAsync(ColumnChunk* columnChunk, uint64_t nodeGroupIdx, uv_loop_t* ring,
+    common::NodeGroupInfo* info) {
+    Column::append(columnChunk, nodeGroupIdx);
+    auto dataColumnChunk =
+        ku_dynamic_ptr_cast<ColumnChunk, VarListColumnChunk>(columnChunk)->getDataColumnChunk();
+    dataColumn->appendAsync(dataColumnChunk, nodeGroupIdx, ring, info);
+}
+
 void VarListColumn::scanUnfiltered(Transaction* transaction, node_group_idx_t nodeGroupIdx,
     ValueVector* resultVector, const ListOffsetInfoInStorage& listOffsetInfoInStorage) {
     auto numValuesToScan = resultVector->state->selVector->selectedSize;


### PR DESCRIPTION
To compile need to download package liburing-dev

<h3> after optimization </h3>

- no hash
- ldbc30 csv

|thread |sync | io_uring with 2 node group | pre-register file descriptor |  poll submition q |  poll completion q + O_direct |
| -------------| -----| ----------| --------------| ------ | --------| 
| 1 |  146049.83 | 132645.55 |   135376.99      |   132708.45     |133957.91 |
|  2 |  82968.22  | 76450.06 |    76187.99       |    75707.94        |  75516.52|
|4 | 50270.95  | 47792.60 |   46758.18      |  47213.54   |47163.57|
|8 |  36591.26  |33318.96 |   32505.07       |  31316.46     |32704.62|
|16|  32072.70  |25570.51 |       24910.53   |  25763.88   |27843.10|
|32 |   32072.70  | 25115.66 |      24521.98       |    24964.38     | 30758.74|
|64 |    35424.46  | 28117.51 |      27599.58      |   27390.94    |33949.79|
|128|   37865.80 |  32531.37|    31617.87      |     55850.11      |  47424.39|


- ldbc100 csv

 |thread | sync | most optimized io_uring |
| -------------| -----|  -----|
| 1 |  484050.26    |    427798.50 |
|  2 |  273538.73   |   2522808.78   |          
|4 | 168219.41  |     155881.84   |          
|8 | 119475.36 |      105169.90    |    
|16| 105457.83  |      81703.30    |  
|32 | 102754.81    |          75578.68   |    
|64 |    110581.74   |   79384.24   |  
|128|   115542.25   | 85742.40 |      


parquet file:
row number: 21865k
columns: 6
row groups: 178

- file cache cleared
- database directory deleted after every run
- calculate the avg of 5 runs

|thread |  sync with no hash | io_uring with node group 4 with no hash | sync with hash | io_uring with hash|
| ---- |-------| --------| -------| ----- |
| 1  |   28879.59   |  20393.78    | 38957.48 | 31281.09|
| 2  |   16572.06   |    13274.35     | 21553.55  | 16563.03 |
| 4 |  11381.32  |     7878.30  | 12566.63    | 12418.41|
|8 |     9722.36  |   6849.69  |  14017.52 | 12888.77 |
|16 |  9864.58  | 8196.22    |  13573.49 | 14096.11 |
|32 | 11937.29  |   10800.25 | 16104.27 |  17562.16 |
|64 |  17613.32    | 19001.48  |  22499.45 | 26024.70 |
|128 | 27418.79    |   30678.06   |  35013.45 | 39928.92 |
|200 | 27428.94  |  31207.96  |  34939.86 | 38936.54 |

Conclusion:
- io_uring performs much better when there are small number of threads
- overhead: might be on init queue 

Other testing parameters:
- max node group
- node group size
- direct I/O
- hardware interrupts vs Polling
- request queue size
- page size
- sqe submit after 1 whole node group is fed into submission queue
- initialize queue with 700 slots (690 request per node group in atucal)

<h3> tunning node group size </h3>
- no hash

|thread | node group = 1  |  node group = 2 | node group = 3 | node group = 8 | 
| ----- | -------|  --------| --------| -------|
|  1     | 24541.10 |  21231.40 |  20716.19 |  21973.39  |
|   2   |  |11778.49 |  11838.34 | 14012.29 |
|4     |  |7650.20 |  7851.48 | 9081.34 |
| 8 |  |6373.91 | 7146.09 | 8536.60 |
|  16 | | 7887.53 | 7526.23 | 10923.65 |
| 64  |  |17346.89 | 17295.50  | 20389.01 |

- node group = 2 gives the best performance

<h3> Direct I/O </h3>
- submition queue 200
- node group = 2

| thread | O_DIRECT | no O_DIRECT |
| ------ | -------|  -------- |
|  1 |  21995.75 | 21867.5 |
|   2  |  12223.34   |   11964.37 |
|   4  |  7992.09  | 7910.41 |
 |  8  |  7084.83 | 6431.97 |
| 16 | 7746.00 |    7887.53  |
| 64 |   16082.52 | 17346.89 |

<h3> FIO test </h3>
- write to one file
- test max bandwitdh

For sync I/O:
`fio --name=randomwrite --filename=sync-write --size=16Gb --rw=randwrite --bs=4K --numjobs=1 --group_reporting --runtime=60`

For io_uring:
`fio --name=randomwrite --filename=async-write --ioengine=io_uring --size=16Gb --iodepth=100 -
-rw=randwrite --bs=4K --numjobs=128 --group_reporting --runtime=60`

|thread | sync | io_uring|
| ------- | -----| -------|
| 1   | 526MB/s | 328MB/s |
| 2   |  922MB/s|628MB/s |
|  4  |  777MB/s | 404MB/s |
| 8 | 583MB/s | 381MB/s |
|16 |    524MB/s   |  347MB/s |
| 32  |  460MB/s |   315MB/s    |
|64 |  370MB/s  |    273MB/s |
|128 | 283MB/s|     212MB/s |



<h3> BCC I/O monitoring tools </h3>

![image](https://github.com/kuzudb/kuzu/assets/77596290/6198ea6f-37f6-4a42-828a-907974dc60a4)

