### PR TITLE
make: remove shell target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -148,9 +148,6 @@ benchmark:
 example:
 	$(call run-cmake-release, -DBUILD_EXAMPLES=TRUE)
 
-shell:
-	$(call run-cmake-release, -DBUILD_SHELL=TRUE)
-
 
 # Clang-related tools and checks
 


### PR DESCRIPTION
The shell is built by default, so this target doesn't make sense.