### PR TITLE
Prefer string_view in the API over std::string

### DIFF
--- a/src/include/function/udf_function.h
+++ b/src/include/function/udf_function.h
@@ -217,7 +217,7 @@ struct UDF {
     }
 
     template<typename TR, typename... Args>
-    static function_set getFunction(const std::string& name, TR (*udfFunc)(Args...),
+    static function_set getFunction(std::string name, TR (*udfFunc)(Args...),
         std::vector<common::LogicalTypeID> parameterTypes, common::LogicalTypeID returnType) {
         function_set definitions;
         if (returnType == common::LogicalTypeID::STRING) {
@@ -226,29 +226,29 @@ struct UDF {
         validateType<TR>(returnType);
         scalar_exec_func scalarExecFunc = getScalarExecFunc<TR, Args...>(udfFunc, parameterTypes);
         definitions.push_back(std::make_unique<function::ScalarFunction>(
-            name, std::move(parameterTypes), returnType, std::move(scalarExecFunc)));
+            std::move(name), std::move(parameterTypes), returnType, std::move(scalarExecFunc)));
         return definitions;
     }
 
     template<typename TR, typename... Args>
-    static function_set getFunction(const std::string& name, TR (*udfFunc)(Args...)) {
+    static function_set getFunction(std::string name, TR (*udfFunc)(Args...)) {
         return getFunction<TR, Args...>(
-            name, udfFunc, getParameterTypes<Args...>(), getParameterType<TR>());
+            std::move(name), udfFunc, getParameterTypes<Args...>(), getParameterType<TR>());
     }
 
     template<typename TR, typename... Args>
-    static function_set getVectorizedFunction(const std::string& name, scalar_exec_func execFunc) {
+    static function_set getVectorizedFunction(std::string name, scalar_exec_func execFunc) {
         function_set definitions;
-        definitions.push_back(std::make_unique<function::ScalarFunction>(
-            name, getParameterTypes<Args...>(), getParameterType<TR>(), std::move(execFunc)));
+        definitions.push_back(std::make_unique<function::ScalarFunction>(std::move(name),
+            getParameterTypes<Args...>(), getParameterType<TR>(), std::move(execFunc)));
         return definitions;
     }
 
-    static function_set getVectorizedFunction(const std::string& name, scalar_exec_func execFunc,
+    static function_set getVectorizedFunction(std::string name, scalar_exec_func execFunc,
         std::vector<common::LogicalTypeID> parameterTypes, common::LogicalTypeID returnType) {
         function_set definitions;
         definitions.push_back(std::make_unique<function::ScalarFunction>(
-            name, std::move(parameterTypes), returnType, std::move(execFunc)));
+            std::move(name), std::move(parameterTypes), returnType, std::move(execFunc)));
         return definitions;
     }
 };

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -62,16 +62,12 @@ class Database {
 
 public:
     /**
-     * @brief Creates a database object with default buffer pool size and max num threads.
-     * @param databasePath The path to the database.
-     */
-    KUZU_API explicit Database(std::string databasePath);
-    /**
      * @brief Creates a database object.
      * @param databasePath Database path.
      * @param systemConfig System configurations (buffer pool size and max num threads).
      */
-    KUZU_API Database(std::string databasePath, SystemConfig systemConfig);
+    KUZU_API explicit Database(
+        std::string_view databasePath, SystemConfig systemConfig = SystemConfig());
     /**
      * @brief Destructs the database object.
      */

--- a/src/include/main/query_result.h
+++ b/src/include/main/query_result.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string>
+
 #include "common/api.h"
 #include "common/arrow/arrow.h"
 #include "common/types/types.h"
@@ -90,8 +92,8 @@ public:
      * @param escapeCharacter escape character of the csv file.
      * @param newline newline character of the csv file.
      */
-    KUZU_API void writeToCSV(const std::string& fileName, char delimiter = ',',
-        char escapeCharacter = '"', char newline = '\n');
+    KUZU_API void writeToCSV(std::string fileName, char delimiter = ',', char escapeCharacter = '"',
+        char newline = '\n');
     /**
      * @brief Resets the result tuple iterator.
      */

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <memory>
-#include <string>
+#include <string_view>
 
 #include "statement.h"
 
@@ -11,7 +11,7 @@ namespace parser {
 class Parser {
 
 public:
-    static std::unique_ptr<Statement> parseQuery(const std::string& query);
+    static std::unique_ptr<Statement> parseQuery(std::string_view query);
 };
 
 } // namespace parser

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -56,10 +56,8 @@ static void getLockFileFlagsAndType(bool readOnly, bool createNew, int& flags, F
     lock = readOnly ? FileLockType::READ_LOCK : FileLockType::WRITE_LOCK;
 }
 
-Database::Database(std::string databasePath) : Database{std::move(databasePath), SystemConfig()} {}
-
-Database::Database(std::string databasePath, SystemConfig systemConfig)
-    : databasePath{std::move(databasePath)}, systemConfig{systemConfig} {
+Database::Database(std::string_view databasePath, SystemConfig systemConfig)
+    : databasePath{databasePath}, systemConfig{systemConfig} {
     initLoggers();
     logger = LoggerUtils::getLogger(LoggerConstants::LoggerEnum::DATABASE);
     vfs = std::make_unique<VirtualFileSystem>();

--- a/src/main/query_result.cpp
+++ b/src/main/query_result.cpp
@@ -186,7 +186,7 @@ std::string QueryResult::toString() {
 }
 
 void QueryResult::writeToCSV(
-    const std::string& fileName, char delimiter, char escapeCharacter, char newline) {
+    std::string fileName, char delimiter, char escapeCharacter, char newline) {
     std::ofstream file;
     file.open(fileName);
     std::shared_ptr<FlatTuple> nextTuple;

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -16,7 +16,7 @@ using namespace antlr4;
 namespace kuzu {
 namespace parser {
 
-std::unique_ptr<Statement> Parser::parseQuery(const std::string& query) {
+std::unique_ptr<Statement> Parser::parseQuery(std::string_view query) {
     auto inputStream = ANTLRInputStream(query);
     auto parserErrorListener = ParserErrorListener();
 

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -62,7 +62,8 @@ void PyQueryResult::writeToCSV(const py::str& filename, const py::str& delimiter
     KU_ASSERT(delimiterStr.size() == 1);
     KU_ASSERT(escapeCharacterStr.size() == 1);
     KU_ASSERT(newlineStr.size() == 1);
-    queryResult->writeToCSV(filename, delimiterStr[0], escapeCharacterStr[0], newlineStr[0]);
+    queryResult->writeToCSV(
+        std::string(filename), delimiterStr[0], escapeCharacterStr[0], newlineStr[0]);
 }
 
 void PyQueryResult::close() {

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -73,7 +73,7 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
     const kuzu::common::LogicalType& value);
 
 /* Database */
-std::unique_ptr<kuzu::main::Database> new_database(const std::string& databasePath,
+std::unique_ptr<kuzu::main::Database> new_database(std::string_view databasePath,
     uint64_t bufferPoolSize, uint64_t maxNumThreads, bool enableCompression, bool readOnly);
 
 void database_set_logging_level(kuzu::main::Database& database, const std::string& level);
@@ -183,5 +183,9 @@ struct ValueListBuilder {
 std::unique_ptr<kuzu::common::Value> get_list_value(
     std::unique_ptr<kuzu::common::LogicalType> typ, std::unique_ptr<ValueListBuilder> value);
 std::unique_ptr<ValueListBuilder> create_list();
+
+inline std::string_view string_view_from_str(rust::Str s) {
+    return {s.data(), s.size()};
+}
 
 } // namespace kuzu_rs

--- a/tools/rust_api/src/connection.rs
+++ b/tools/rust_api/src/connection.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 use crate::ffi::ffi;
 use crate::query_result::QueryResult;
 use crate::value::Value;
-use cxx::{let_cxx_string, UniquePtr};
+use cxx::UniquePtr;
 use std::cell::UnsafeCell;
 use std::convert::TryInto;
 
@@ -169,8 +169,8 @@ impl<'a> Connection<'a> {
     /// * `query`: The query to prepare.
     ///            See <https://kuzudb.com/docs/cypher> for details on the query format
     pub fn prepare(&self, query: &str) -> Result<PreparedStatement, Error> {
-        let_cxx_string!(query = query);
-        let statement = unsafe { (*self.conn.get()).pin_mut() }.prepare(&query)?;
+        let statement =
+            unsafe { (*self.conn.get()).pin_mut() }.prepare(ffi::StringView::new(query))?;
         if statement.isSuccess() {
             Ok(PreparedStatement { statement })
         } else {

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -64,7 +64,7 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
     return std::make_unique<std::vector<LogicalType>>(result);
 }
 
-std::unique_ptr<Database> new_database(const std::string& databasePath, uint64_t bufferPoolSize,
+std::unique_ptr<Database> new_database(std::string_view databasePath, uint64_t bufferPoolSize,
     uint64_t maxNumThreads, bool enableCompression, bool readOnly) {
     auto systemConfig = SystemConfig();
     if (bufferPoolSize > 0) {


### PR DESCRIPTION
For #2521, but it also is generally preferable over `const std::string&` since `std::string` already has a layer of indirection to refer to the owned string data.

This change doesn't really have any cost other than in `QueryResult::writeToCSV` I think (where the string_view needs to be converted to a `const char*` to pass it to `ofstream::open`, which may not work since `std::string_view` isn't necessarily null-terminated, so I have it converting it to a `std::string` to ensure that it is).

~~I also modified `Database` to store an absolute path, instead of a copy of the path passed to it, to solve a minor issue I'd noticed: that the database will try to move if you chdir after creating it using a relative path.~~ (Removed as this won't play nicely with the VFS at the moment, and integrating the changes would be more work that should probably be done separately).

This doesn't by itself fix #2521. In addition to some functions where it would be more complicated to remove the `std::string` (e.g. `QueryResult::toString`), some of the types themselves contain STL types which won't have a consistent size between the release and debug builds. To fix that, we can hide the implementations so that the Database, Connection, QueryResult, etc. are just wrappers containing a unique_ptr to internal types which contain the actual implementation (which will also keep our exposed API more concise), but that's more complicated and can be done in a separate PR.