### PR TITLE
Remove some cases of unnecessary std::move on return

### DIFF
--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -113,7 +113,7 @@ public:
 
     template<typename TR, typename... Args>
     void createScalarFunction(const std::string& name, TR (*udfFunc)(Args...)) {
-        addScalarFunction(name, std::move(function::UDF::getFunction<TR, Args...>(name, udfFunc)));
+        addScalarFunction(name, function::UDF::getFunction<TR, Args...>(name, udfFunc));
     }
 
     template<typename TR, typename... Args>

--- a/src/processor/operator/persistent/writer/parquet/basic_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/basic_column_writer.cpp
@@ -15,7 +15,7 @@ std::unique_ptr<ColumnWriterState> BasicColumnWriter::initializeWriteState(
     kuzu_parquet::format::RowGroup& rowGroup) {
     auto result = std::make_unique<BasicColumnWriterState>(rowGroup, rowGroup.columns.size());
     registerToRowGroup(rowGroup);
-    return std::move(result);
+    return result;
 }
 
 void BasicColumnWriter::prepare(ColumnWriterState& stateToPrepare, ColumnWriterState* parent,

--- a/src/processor/operator/persistent/writer/parquet/string_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/string_column_writer.cpp
@@ -49,7 +49,7 @@ void StringStatisticsState::update(const ku_string_t& val) {
 std::unique_ptr<ColumnWriterState> StringColumnWriter::initializeWriteState(RowGroup& rowGroup) {
     auto result = std::make_unique<StringColumnWriterState>(rowGroup, rowGroup.columns.size(), mm);
     registerToRowGroup(rowGroup);
-    return std::move(result);
+    return result;
 }
 
 void StringColumnWriter::analyze(ColumnWriterState& writerState, ColumnWriterState* parent,

--- a/src/processor/operator/persistent/writer/parquet/struct_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/struct_column_writer.cpp
@@ -16,7 +16,7 @@ std::unique_ptr<ColumnWriterState> StructColumnWriter::initializeWriteState(
     for (auto& child_writer : childWriters) {
         result->childStates.push_back(child_writer->initializeWriteState(rowGroup));
     }
-    return std::move(result);
+    return result;
 }
 
 bool StructColumnWriter::hasAnalyze() {

--- a/src/processor/operator/persistent/writer/parquet/var_list_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/var_list_column_writer.cpp
@@ -9,7 +9,7 @@ std::unique_ptr<ColumnWriterState> VarListColumnWriter::initializeWriteState(
     kuzu_parquet::format::RowGroup& rowGroup) {
     auto result = std::make_unique<ListColumnWriterState>(rowGroup, rowGroup.columns.size());
     result->childState = childWriter->initializeWriteState(rowGroup);
-    return std::move(result);
+    return result;
 }
 
 bool VarListColumnWriter::hasAnalyze() {

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -50,7 +50,7 @@ py::list PyQueryResult::getNext() {
     for (auto i = 0u; i < tuple->len(); ++i) {
         result[i] = convertValueToPyObject(*tuple->getValue(i));
     }
-    return std::move(result);
+    return result;
 }
 
 void PyQueryResult::writeToCSV(const py::str& filename, const py::str& delimiter,
@@ -184,7 +184,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
         for (auto i = 0u; i < NestedVal::getChildrenSize(&value); ++i) {
             list.append(convertValueToPyObject(*NestedVal::getChildVal(&value, i)));
         }
-        return std::move(list);
+        return list;
     }
     case LogicalTypeID::MAP: {
         py::dict dict;
@@ -194,7 +194,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
             auto v = convertValueToPyObject(*NestedVal::getChildVal(childVal, 1));
             dict[std::move(k)] = std::move(v);
         }
-        return std::move(dict);
+        return dict;
     }
     case LogicalTypeID::UNION: {
         return convertValueToPyObject(*NestedVal::getChildVal(&value, 0 /* idx */));
@@ -227,7 +227,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
             auto val = convertValueToPyObject(*NodeVal::getPropertyVal(&value, i));
             dict[key] = val;
         }
-        return std::move(dict);
+        return dict;
     }
     case LogicalTypeID::REL: {
         py::dict dict;
@@ -243,7 +243,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
             auto val = convertValueToPyObject(*RelVal::getPropertyVal(&value, i));
             dict[key] = val;
         }
-        return std::move(dict);
+        return dict;
     }
     case LogicalTypeID::INTERNAL_ID: {
         return convertNodeIdToPyDict(value.getValue<nodeID_t>());
@@ -278,7 +278,7 @@ py::object PyQueryResult::getArrowChunks(
     auto pyarrowLibModule = py::module::import("pyarrow").attr("lib");
     py::list batches;
     while (getNextArrowChunk(typesInfo, batches, chunkSize)) {}
-    return std::move(batches);
+    return batches;
 }
 
 kuzu::pyarrow::Table PyQueryResult::getAsArrow(std::int64_t chunkSize) {
@@ -301,7 +301,7 @@ py::list PyQueryResult::getColumnDataTypes() {
     for (auto i = 0u; i < columnDataTypes.size(); ++i) {
         result[i] = py::cast(columnDataTypes[i].toString());
     }
-    return std::move(result);
+    return result;
 }
 
 py::list PyQueryResult::getColumnNames() {
@@ -310,7 +310,7 @@ py::list PyQueryResult::getColumnNames() {
     for (auto i = 0u; i < columnNames.size(); ++i) {
         result[i] = py::cast(columnNames[i]);
     }
-    return std::move(result);
+    return result;
 }
 
 void PyQueryResult::resetIterator() {


### PR DESCRIPTION
These are all doing moves on temporary values wrapped in unique_ptr and the move is unnecessary and produces a compiler warning.

One's not actually when returning, but is a move on an in-place constructed value where it's already an rvalue.