### PR TITLE
antlr4: suppress unused parameters

### DIFF
--- a/src/include/parser/antlr_parser/kuzu_cypher_parser.h
+++ b/src/include/parser/antlr_parser/kuzu_cypher_parser.h
@@ -1,6 +1,10 @@
 #pragma once
 
+// ANTLR4 generates code with unused parameters.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "cypher_parser.h"
+#pragma GCC diagnostic pop
 
 namespace kuzu {
 namespace parser {

--- a/src/include/parser/transformer.h
+++ b/src/include/parser/transformer.h
@@ -1,6 +1,11 @@
 #pragma once
 
+// ANTLR4 generates code with unused parameters.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "cypher_parser.h"
+#pragma GCC diagnostic pop
+
 #include "expression/parsed_expression.h"
 #include "statement.h"
 

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -1,6 +1,11 @@
 #include "parser/parser.h"
 
+// ANTLR4 generates code with unused parameters.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-parameter"
 #include "cypher_lexer.h"
+#pragma GCC diagnostic pop
+
 #include "parser/antlr_parser/kuzu_cypher_parser.h"
 #include "parser/antlr_parser/parser_error_listener.h"
 #include "parser/antlr_parser/parser_error_strategy.h"

--- a/third_party/antlr4_cypher/include/cypher_parser.h
+++ b/third_party/antlr4_cypher/include/cypher_parser.h
@@ -2299,12 +2299,12 @@ public:
 
 private:
 
-      virtual void notifyQueryNotConcludeWithReturn(antlr4::Token* /*startToken*/) {};
-      virtual void notifyNodePatternWithoutParentheses(std::string /*nodeName*/, antlr4::Token* /*startToken*/) {};
-      virtual void notifyInvalidNotEqualOperator(antlr4::Token* /*startToken*/) {};
-      virtual void notifyEmptyToken(antlr4::Token* /*startToken*/) {};
-      virtual void notifyReturnNotAtEnd(antlr4::Token* /*startToken*/) {};
-      virtual void notifyNonBinaryComparison(antlr4::Token* /*startToken*/) {};
+      virtual void notifyQueryNotConcludeWithReturn(antlr4::Token* startToken) {};
+      virtual void notifyNodePatternWithoutParentheses(std::string nodeName, antlr4::Token* startToken) {};
+      virtual void notifyInvalidNotEqualOperator(antlr4::Token* startToken) {};
+      virtual void notifyEmptyToken(antlr4::Token* startToken) {};
+      virtual void notifyReturnNotAtEnd(antlr4::Token* startToken) {};
+      virtual void notifyNonBinaryComparison(antlr4::Token* startToken) {};
 
 };
 


### PR DESCRIPTION
ANTLR4 generates code with unused parameters, which is incompatible with our recently added `-Wextra`. To combat this, we simply suppress the `-Wunused-parameter` warning when including the headers, since they are included so few times.