### PR TITLE
reader/csv: avoid lseek for getting offset

### DIFF
--- a/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
@@ -73,6 +73,7 @@ protected:
     std::unique_ptr<char[]> buffer;
     uint64_t bufferSize;
     uint64_t position;
+    uint64_t osFileOffset;
 
     bool rowEmpty = false;
 };

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -60,6 +60,7 @@ void ParallelCSVReader::seekToBlockStart() {
             currentBlockIdx, filePath, posixErrMessage()));
         // LCOV_EXCL_STOP
     }
+    osFileOffset = currentBlockIdx * CopyConstants::PARALLEL_BLOCK_SIZE;
 
     if (currentBlockIdx == 0) {
         // First block doesn't search for a newline.


### PR DESCRIPTION
Currently we use lseek() after every row in the parallel CSV reader to get the file offset. I thought this would be very cheap, and figured it was easier than tracking it ourselves. However, it is not cheap at all, as demonstrated by a flamegraph, and it is not hard to track ourselves either.