### PR TITLE
Cleanup logical type construction

### DIFF
--- a/src/binder/bind_expression/bind_boolean_expression.cpp
+++ b/src/binder/bind_expression/bind_boolean_expression.cpp
@@ -29,7 +29,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindBooleanExpression(
     function::scalar_select_func selectFunc;
     function::VectorBooleanFunction::bindSelectFunction(
         expressionType, childrenAfterCast, selectFunc);
-    auto bindData = std::make_unique<function::FunctionBindData>(LogicalType(LogicalTypeID::BOOL));
+    auto bindData = std::make_unique<function::FunctionBindData>(LogicalType::BOOL());
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(functionName, childrenAfterCast);
     return make_shared<ScalarFunctionExpression>(functionName, expressionType, std::move(bindData),

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -33,8 +33,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
         childrenAfterCast.push_back(
             implicitCastIfNecessary(children[i], function->parameterTypeIDs[i]));
     }
-    auto bindData =
-        std::make_unique<function::FunctionBindData>(LogicalType(function->returnTypeID));
+    auto bindData = std::make_unique<function::FunctionBindData>(
+        std::make_unique<LogicalType>(function->returnTypeID));
     auto uniqueExpressionName =
         ScalarFunctionExpression::getUniqueName(function->name, childrenAfterCast);
     return make_shared<ScalarFunctionExpression>(functionName, expressionType, std::move(bindData),

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -74,8 +74,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
         if (function->bindFunc) {
             bindData = function->bindFunc(childrenAfterCast, function);
         } else {
-            bindData =
-                std::make_unique<function::FunctionBindData>(LogicalType(function->returnTypeID));
+            bindData = std::make_unique<function::FunctionBindData>(
+                std::make_unique<LogicalType>(function->returnTypeID));
         }
     }
     auto uniqueExpressionName =
@@ -114,8 +114,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
     if (function->bindFunc) {
         bindData = function->bindFunc(children, function.get());
     } else {
-        bindData =
-            std::make_unique<function::FunctionBindData>(LogicalType(function->returnTypeID));
+        bindData = std::make_unique<function::FunctionBindData>(
+            std::make_unique<LogicalType>(function->returnTypeID));
     }
     return make_shared<AggregateFunctionExpression>(functionName, std::move(bindData),
         std::move(children), std::move(function), uniqueExpressionName);
@@ -193,8 +193,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindInternalIDExpression(
         return bindNodeOrRelPropertyExpression(*expression, InternalKeyword::ID);
     }
     KU_ASSERT(expression->dataType.getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto stringValue =
-        std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, InternalKeyword::ID);
+    auto stringValue = std::make_unique<Value>(LogicalType::STRING(), InternalKeyword::ID);
     return bindScalarFunctionExpression(
         expression_vector{expression, createLiteralExpression(std::move(stringValue))},
         STRUCT_EXTRACT_FUNC_NAME);
@@ -208,21 +207,17 @@ static std::vector<std::unique_ptr<Value>> populateLabelValues(std::vector<table
     labels.resize(maxTableID + 1);
     for (auto i = 0u; i < labels.size(); ++i) {
         if (tableIDsSet.contains(i)) {
-            labels[i] = std::make_unique<Value>(
-                LogicalType{LogicalTypeID::STRING}, catalog.getTableName(tx, i));
+            labels[i] = std::make_unique<Value>(LogicalType::STRING(), catalog.getTableName(tx, i));
         } else {
             // TODO(Xiyang/Guodong): change to null literal once we support null in LIST type.
-            labels[i] =
-                std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, std::string(""));
+            labels[i] = std::make_unique<Value>(LogicalType::STRING(), std::string(""));
         }
     }
     return labels;
 }
 
 std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression& expression) {
-    auto varListTypeInfo = std::make_unique<VarListTypeInfo>(LogicalType::STRING());
-    auto listType =
-        std::make_unique<LogicalType>(LogicalTypeID::VAR_LIST, std::move(varListTypeInfo));
+    auto listType = LogicalType::VAR_LIST(LogicalType::STRING());
     expression_vector children;
     switch (expression.getDataType().getLogicalTypeID()) {
     case LogicalTypeID::NODE: {
@@ -231,11 +226,11 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
             auto labelName = binder->catalog.getTableName(
                 binder->clientContext->getTx(), node.getSingleTableID());
             return createLiteralExpression(
-                std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, labelName));
+                std::make_unique<Value>(LogicalType::STRING(), labelName));
         }
         auto nodeTableIDs = binder->catalog.getNodeTableIDs(binder->clientContext->getTx());
         children.push_back(node.getInternalID());
-        auto labelsValue = std::make_unique<Value>(*listType,
+        auto labelsValue = std::make_unique<Value>(std::move(listType),
             populateLabelValues(nodeTableIDs, binder->catalog, binder->clientContext->getTx()));
         children.push_back(createLiteralExpression(std::move(labelsValue)));
     } break;
@@ -245,11 +240,11 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
             auto labelName = binder->catalog.getTableName(
                 binder->clientContext->getTx(), rel.getSingleTableID());
             return createLiteralExpression(
-                std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, labelName));
+                std::make_unique<Value>(LogicalType::STRING(), labelName));
         }
         auto relTableIDs = binder->catalog.getRelTableIDs(binder->clientContext->getTx());
         children.push_back(rel.getInternalIDProperty());
-        auto labelsValue = std::make_unique<Value>(*listType,
+        auto labelsValue = std::make_unique<Value>(std::move(listType),
             populateLabelValues(relTableIDs, binder->catalog, binder->clientContext->getTx()));
         children.push_back(createLiteralExpression(std::move(labelsValue)));
     } break;
@@ -257,8 +252,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
         KU_UNREACHABLE;
     }
     auto execFunc = function::LabelFunction::execFunction;
-    auto bindData =
-        std::make_unique<function::FunctionBindData>(LogicalType(LogicalTypeID::STRING));
+    auto bindData = std::make_unique<function::FunctionBindData>(LogicalType::STRING());
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(LABEL_FUNC_NAME, children);
     return std::make_shared<ScalarFunctionExpression>(LABEL_FUNC_NAME, ExpressionType::FUNCTION,
         std::move(bindData), std::move(children), execFunc, nullptr, uniqueExpressionName);

--- a/src/binder/bind_expression/bind_literal_expression.cpp
+++ b/src/binder/bind_expression/bind_literal_expression.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<Expression> ExpressionBinder::createLiteralExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::createStringLiteralExpression(
     const std::string& strVal) {
-    auto value = std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, strVal);
+    auto value = std::make_unique<Value>(LogicalType::STRING(), strVal);
     return createLiteralExpression(std::move(value));
 }
 

--- a/src/binder/bind_expression/bind_null_operator_expression.cpp
+++ b/src/binder/bind_expression/bind_null_operator_expression.cpp
@@ -20,7 +20,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindNullOperatorExpression(
     function::VectorNullFunction::bindExecFunction(expressionType, children, execFunc);
     function::scalar_select_func selectFunc;
     function::VectorNullFunction::bindSelectFunction(expressionType, children, selectFunc);
-    auto bindData = std::make_unique<function::FunctionBindData>(LogicalType(LogicalTypeID::BOOL));
+    auto bindData = std::make_unique<function::FunctionBindData>(LogicalType::BOOL());
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(functionName, children);
     return make_shared<ScalarFunctionExpression>(functionName, expressionType, std::move(bindData),
         std::move(children), std::move(execFunc), std::move(selectFunc), uniqueExpressionName);

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -32,7 +32,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
     // Bind projection
     auto function = binder->catalog.getBuiltInFunctions()->matchAggregateFunction(
         COUNT_STAR_FUNC_NAME, std::vector<LogicalType*>{}, false);
-    auto bindData = std::make_unique<FunctionBindData>(LogicalType(function->returnTypeID));
+    auto bindData =
+        std::make_unique<FunctionBindData>(std::make_unique<LogicalType>(function->returnTypeID));
     auto countStarExpr = std::make_shared<AggregateFunctionExpression>(COUNT_STAR_FUNC_NAME,
         std::move(bindData), expression_vector{}, function->clone(),
         binder->getUniqueExpressionName(COUNT_STAR_FUNC_NAME));

--- a/src/binder/bound_statement_result.cpp
+++ b/src/binder/bound_statement_result.cpp
@@ -10,7 +10,7 @@ namespace binder {
 std::unique_ptr<BoundStatementResult> BoundStatementResult::createSingleStringColumnResult(
     const std::string& columnName) {
     auto result = std::make_unique<BoundStatementResult>();
-    auto value = std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, columnName);
+    auto value = std::make_unique<Value>(LogicalType::STRING(), columnName);
     auto stringColumn = std::make_shared<LiteralExpression>(std::move(value), columnName);
     result->addColumn(stringColumn);
     return result;

--- a/src/binder/expression/function_expression.cpp
+++ b/src/binder/expression/function_expression.cpp
@@ -20,7 +20,7 @@ std::string ScalarFunctionExpression::toStringInternal() const {
     result += ExpressionUtil::toString(children);
     if (functionName == "CAST") {
         result += ", ";
-        result += bindData->resultType.toString();
+        result += bindData->resultType->toString();
     }
     result += ")";
     return result;

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -115,7 +115,7 @@ std::shared_ptr<Expression> ExpressionBinder::implicitCast(
     if (CastFunction::hasImplicitCast(expression->dataType, targetType)) {
         auto functionName = stringFormat("CAST_TO({})", targetType.toString());
         auto children = expression_vector{expression};
-        auto bindData = std::make_unique<FunctionBindData>(targetType);
+        auto bindData = std::make_unique<FunctionBindData>(targetType.copy());
         auto scalarFunction = CastFunction::bindCastFunction(
             functionName, expression->dataType.getLogicalTypeID(), targetType.getLogicalTypeID());
         auto uniqueName = ScalarFunctionExpression::getUniqueName(functionName, children);

--- a/src/c_api/data_type.cpp
+++ b/src/c_api/data_type.cpp
@@ -3,6 +3,15 @@
 
 using namespace kuzu::common;
 
+namespace kuzu::common {
+struct CAPIHelper {
+    static inline LogicalType* createLogicalType(
+        LogicalTypeID typeID, std::unique_ptr<ExtraTypeInfo> extraTypeInfo) {
+        return new LogicalType(typeID, std::move(extraTypeInfo));
+    }
+};
+} // namespace kuzu::common
+
 kuzu_logical_type* kuzu_data_type_create(
     kuzu_data_type_id id, kuzu_logical_type* child_type, uint64_t fixed_num_elements_in_list) {
     auto* c_data_type = (kuzu_logical_type*)malloc(sizeof(kuzu_logical_type));
@@ -18,7 +27,7 @@ kuzu_logical_type* kuzu_data_type_create(
                                  std::make_unique<FixedListTypeInfo>(
                                      std::move(child_type_pty), fixed_num_elements_in_list) :
                                  std::make_unique<VarListTypeInfo>(std::move(child_type_pty));
-        data_type = new LogicalType(logicalTypeID, std::move(extraTypeInfo));
+        data_type = CAPIHelper::createLogicalType(logicalTypeID, std::move(extraTypeInfo));
     }
     c_data_type->_data_type = data_type;
     return c_data_type;

--- a/src/c_api/prepared_statement.cpp
+++ b/src/c_api/prepared_statement.cpp
@@ -156,8 +156,7 @@ void kuzu_prepared_statement_bind_interval(
 
 void kuzu_prepared_statement_bind_string(
     kuzu_prepared_statement* prepared_statement, const char* param_name, const char* value) {
-    auto value_ptr =
-        std::make_unique<Value>(LogicalType{LogicalTypeID::STRING}, std::string(value));
+    auto value_ptr = std::make_unique<Value>(LogicalType::STRING(), std::string(value));
     kuzu_prepared_statement_bind_cpp_value(prepared_statement, param_name, std::move(value_ptr));
 }
 

--- a/src/common/types/rdf_variant_type.cpp
+++ b/src/common/types/rdf_variant_type.cpp
@@ -4,11 +4,11 @@ namespace kuzu {
 namespace common {
 
 std::unique_ptr<LogicalType> RdfVariantType::getType() {
-    std::vector<std::unique_ptr<StructField>> fields;
-    fields.push_back(std::make_unique<StructField>("_type", LogicalType::UINT8()));
-    fields.push_back(std::make_unique<StructField>("_value", LogicalType::BLOB()));
+    std::vector<StructField> fields;
+    fields.emplace_back("_type", LogicalType::UINT8());
+    fields.emplace_back("_value", LogicalType::BLOB());
     auto extraInfo = std::make_unique<StructTypeInfo>(std::move(fields));
-    return std::make_unique<LogicalType>(LogicalTypeID::RDF_VARIANT, std::move(extraInfo));
+    return LogicalType::RDF_VARIANT(std::move(extraInfo));
 }
 
 } // namespace common

--- a/src/function/aggregate_function.cpp
+++ b/src/function/aggregate_function.cpp
@@ -81,22 +81,22 @@ std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getAvgFunc(std::string
 }
 
 std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getMinFunc(
-    const LogicalType& inputType, bool isDistinct) {
+    LogicalTypeID inputType, bool isDistinct) {
     return AggregateFunctionUtil::getMinMaxFunction<LessThan>(
-        MIN_FUNC_NAME, inputType, inputType.getLogicalTypeID(), isDistinct);
+        MIN_FUNC_NAME, inputType, inputType, isDistinct);
 }
 
 std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getMaxFunc(
-    const LogicalType& inputType, bool isDistinct) {
+    LogicalTypeID inputType, bool isDistinct) {
     return AggregateFunctionUtil::getMinMaxFunction<GreaterThan>(
-        MAX_FUNC_NAME, inputType, inputType.getLogicalTypeID(), isDistinct);
+        MAX_FUNC_NAME, inputType, inputType, isDistinct);
 }
 
 template<typename FUNC>
 std::unique_ptr<AggregateFunction> AggregateFunctionUtil::getMinMaxFunction(std::string name,
-    const common::LogicalType& inputType, common::LogicalTypeID resultType, bool isDistinct) {
-    auto inputTypes = std::vector<common::LogicalTypeID>{inputType.getLogicalTypeID()};
-    switch (inputType.getPhysicalType()) {
+    common::LogicalTypeID inputType, common::LogicalTypeID resultType, bool isDistinct) {
+    auto inputTypes = std::vector<common::LogicalTypeID>{inputType};
+    switch (LogicalType::getPhysicalType(inputType)) {
     case PhysicalTypeID::BOOL:
         return std::make_unique<AggregateFunction>(std::move(name), std::move(inputTypes),
             resultType, MinMaxFunction<bool>::initialize, MinMaxFunction<bool>::updateAll<FUNC>,

--- a/src/function/built_in_functions.cpp
+++ b/src/function/built_in_functions.cpp
@@ -710,8 +710,7 @@ void BuiltInFunctions::registerCount() {
     for (auto& type : LogicalTypeUtils::getAllValidLogicTypes()) {
         for (auto isDistinct : std::vector<bool>{true, false}) {
             functionSet.push_back(AggregateFunctionUtil::getAggFunc<CountFunction>(COUNT_FUNC_NAME,
-                type.getLogicalTypeID(), LogicalTypeID::INT64, isDistinct,
-                CountFunction::paramRewriteFunc));
+                type, LogicalTypeID::INT64, isDistinct, CountFunction::paramRewriteFunc));
         }
     }
     functions.insert({COUNT_FUNC_NAME, std::move(functionSet)});

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -756,8 +756,8 @@ function_set CastToStringFunction::getFunctionSet() {
     function_set result;
     result.reserve(LogicalTypeUtils::getAllValidLogicTypes().size());
     for (auto& type : LogicalTypeUtils::getAllValidLogicTypes()) {
-        result.push_back(CastFunction::bindCastFunction(
-            CAST_TO_STRING_FUNC_NAME, type.getLogicalTypeID(), LogicalTypeID::STRING));
+        result.push_back(
+            CastFunction::bindCastFunction(CAST_TO_STRING_FUNC_NAME, type, LogicalTypeID::STRING));
     }
     return result;
 }
@@ -955,7 +955,7 @@ std::unique_ptr<FunctionBindData> CastAnyFunction::bindFunc(
     func->execFunc =
         CastFunction::bindCastFunction(func->name, inputTypeID, outputType->getLogicalTypeID())
             ->execFunc;
-    return std::make_unique<function::CastFunctionBindData>(*outputType);
+    return std::make_unique<function::CastFunctionBindData>(std::move(outputType));
 }
 
 function_set CastAnyFunction::getFunctionSet() {

--- a/src/function/vector_list_functions.cpp
+++ b/src/function/vector_list_functions.cpp
@@ -82,9 +82,8 @@ std::unique_ptr<FunctionBindData> ListCreationFunction::bindFunc(
             }
         }
     }
-    auto varListTypeInfo = std::make_unique<VarListTypeInfo>(childType.copy());
-    auto resultType = LogicalType{LogicalTypeID::VAR_LIST, std::move(varListTypeInfo)};
-    return std::make_unique<FunctionBindData>(resultType);
+    auto resultType = LogicalType::VAR_LIST(childType.copy());
+    return std::make_unique<FunctionBindData>(std::move(resultType));
 }
 
 function_set ListCreationFunction::getFunctionSet() {
@@ -98,10 +97,9 @@ function_set ListCreationFunction::getFunctionSet() {
 std::unique_ptr<FunctionBindData> ListRangeFunction::bindFunc(
     const binder::expression_vector& arguments, Function* /*function*/) {
     KU_ASSERT(arguments[0]->dataType == arguments[1]->dataType);
-    auto varListTypeInfo = std::make_unique<VarListTypeInfo>(
+    auto resultType = LogicalType::VAR_LIST(
         std::make_unique<LogicalType>(arguments[0]->dataType.getLogicalTypeID()));
-    auto resultType = LogicalType{LogicalTypeID::VAR_LIST, std::move(varListTypeInfo)};
-    return std::make_unique<FunctionBindData>(resultType);
+    return std::make_unique<FunctionBindData>(std::move(resultType));
 }
 
 function_set ListRangeFunction::getFunctionSet() {
@@ -221,7 +219,7 @@ std::unique_ptr<FunctionBindData> ListExtractFunction::bindFunc(
         KU_UNREACHABLE;
     }
     }
-    return std::make_unique<FunctionBindData>(*resultType);
+    return std::make_unique<FunctionBindData>(resultType->copy());
 }
 
 function_set ListExtractFunction::getFunctionSet() {
@@ -253,7 +251,7 @@ std::unique_ptr<FunctionBindData> ListConcatFunction::bindFunc(
         throw BinderException(getListFunctionIncompatibleChildrenTypeErrorMsg(
             LIST_CONCAT_FUNC_NAME, arguments[0]->getDataType(), arguments[1]->getDataType()));
     }
-    return std::make_unique<FunctionBindData>(arguments[0]->getDataType());
+    return std::make_unique<FunctionBindData>(arguments[0]->getDataType().copy());
 }
 
 std::unique_ptr<FunctionBindData> ListAppendFunction::bindFunc(
@@ -267,7 +265,7 @@ std::unique_ptr<FunctionBindData> ListAppendFunction::bindFunc(
     scalarFunction->execFunc =
         ListFunction::getBinaryListExecFuncSwitchRight<ListAppend, list_entry_t>(
             arguments[1]->getDataType());
-    return std::make_unique<FunctionBindData>(resultType);
+    return std::make_unique<FunctionBindData>(resultType.copy());
 }
 
 function_set ListAppendFunction::getFunctionSet() {
@@ -290,7 +288,7 @@ std::unique_ptr<FunctionBindData> ListPrependFunction::bindFunc(
     scalarFunction->execFunc =
         ListFunction::getBinaryListExecFuncSwitchRight<ListPrepend, list_entry_t>(
             arguments[1]->getDataType());
-    return std::make_unique<FunctionBindData>(resultType);
+    return std::make_unique<FunctionBindData>(resultType.copy());
 }
 
 function_set ListPrependFunction::getFunctionSet() {
@@ -315,7 +313,7 @@ std::unique_ptr<FunctionBindData> ListPositionFunction::bindFunc(
     scalarFunction->execFunc =
         ListFunction::getBinaryListExecFuncSwitchRight<ListPosition, int64_t>(
             arguments[1]->getDataType());
-    return std::make_unique<FunctionBindData>(LogicalType{LogicalTypeID::INT64});
+    return std::make_unique<FunctionBindData>(LogicalType::INT64());
 }
 
 function_set ListContainsFunction::getFunctionSet() {
@@ -332,7 +330,7 @@ std::unique_ptr<FunctionBindData> ListContainsFunction::bindFunc(
     scalarFunction->execFunc =
         ListFunction::getBinaryListExecFuncSwitchRight<ListContains, uint8_t>(
             arguments[1]->getDataType());
-    return std::make_unique<FunctionBindData>(LogicalType{LogicalTypeID::BOOL});
+    return std::make_unique<FunctionBindData>(LogicalType::BOOL());
 }
 
 function_set ListSliceFunction::getFunctionSet() {
@@ -356,7 +354,7 @@ function_set ListSliceFunction::getFunctionSet() {
 
 std::unique_ptr<FunctionBindData> ListSliceFunction::bindFunc(
     const binder::expression_vector& arguments, Function* /*function*/) {
-    return std::make_unique<FunctionBindData>(arguments[0]->getDataType());
+    return std::make_unique<FunctionBindData>(arguments[0]->getDataType().copy());
 }
 
 function_set ListSortFunction::getFunctionSet() {
@@ -443,7 +441,7 @@ std::unique_ptr<FunctionBindData> ListSortFunction::bindFunc(
         KU_UNREACHABLE;
     }
     }
-    return std::make_unique<FunctionBindData>(arguments[0]->getDataType());
+    return std::make_unique<FunctionBindData>(arguments[0]->getDataType().copy());
 }
 
 template<typename T>
@@ -545,7 +543,7 @@ std::unique_ptr<FunctionBindData> ListReverseSortFunction::bindFunc(
         KU_UNREACHABLE;
     }
     }
-    return std::make_unique<FunctionBindData>(arguments[0]->getDataType());
+    return std::make_unique<FunctionBindData>(arguments[0]->getDataType().copy());
 }
 
 template<typename T>
@@ -681,7 +679,7 @@ std::unique_ptr<FunctionBindData> ListDistinctFunction::bindFunc(
         KU_UNREACHABLE;
     }
     }
-    return std::make_unique<FunctionBindData>(arguments[0]->getDataType());
+    return std::make_unique<FunctionBindData>(arguments[0]->getDataType().copy());
 }
 
 function_set ListUniqueFunction::getFunctionSet() {
@@ -785,7 +783,7 @@ std::unique_ptr<FunctionBindData> ListUniqueFunction::bindFunc(
         KU_UNREACHABLE;
     }
     }
-    return std::make_unique<FunctionBindData>(LogicalType(LogicalTypeID::INT64));
+    return std::make_unique<FunctionBindData>(LogicalType::INT64());
 }
 
 function_set ListAnyValueFunction::getFunctionSet() {
@@ -894,7 +892,7 @@ std::unique_ptr<FunctionBindData> ListAnyValueFunction::bindFunc(
         KU_UNREACHABLE;
     }
     }
-    return std::make_unique<FunctionBindData>(*resultType);
+    return std::make_unique<FunctionBindData>(resultType->copy());
 }
 
 } // namespace function

--- a/src/function/vector_map_functions.cpp
+++ b/src/function/vector_map_functions.cpp
@@ -25,16 +25,8 @@ std::unique_ptr<FunctionBindData> MapCreationFunctions::bindFunc(
     const binder::expression_vector& arguments, kuzu::function::Function* /*function*/) {
     auto keyType = VarListType::getChildType(&arguments[0]->dataType);
     auto valueType = VarListType::getChildType(&arguments[1]->dataType);
-    std::vector<std::unique_ptr<StructField>> structFields;
-    structFields.emplace_back(std::make_unique<StructField>(
-        InternalKeyword::MAP_KEY, std::make_unique<LogicalType>(*keyType)));
-    structFields.emplace_back(std::make_unique<StructField>(
-        InternalKeyword::MAP_VALUE, std::make_unique<LogicalType>(*valueType)));
-    auto mapStructType = std::make_unique<LogicalType>(
-        LogicalTypeID::STRUCT, std::make_unique<StructTypeInfo>(std::move(structFields)));
-    auto resultType = LogicalType(
-        LogicalTypeID::MAP, std::make_unique<VarListTypeInfo>(std::move(mapStructType)));
-    return std::make_unique<FunctionBindData>(resultType);
+    auto resultType = LogicalType::MAP(*keyType, *valueType);
+    return std::make_unique<FunctionBindData>(std::move(resultType));
 }
 
 function_set MapExtractFunctions::getFunctionSet() {
@@ -60,10 +52,8 @@ std::unique_ptr<FunctionBindData> MapExtractFunctions::bindFunc(
     scalarFunction->execFunc =
         ListFunction::getBinaryListExecFuncSwitchRight<MapExtract, list_entry_t>(
             arguments[1]->getDataType());
-    auto returnListInfo = std::make_unique<VarListTypeInfo>(
-        std::make_unique<LogicalType>(*MapType::getValueType(&arguments[0]->dataType)));
-    return std::make_unique<FunctionBindData>(
-        LogicalType(LogicalTypeID::VAR_LIST, std::move(returnListInfo)));
+    return std::make_unique<FunctionBindData>(LogicalType::VAR_LIST(
+        std::make_unique<LogicalType>(*MapType::getValueType(&arguments[0]->dataType))));
 }
 
 function_set MapKeysFunctions::getFunctionSet() {
@@ -78,10 +68,8 @@ function_set MapKeysFunctions::getFunctionSet() {
 
 std::unique_ptr<FunctionBindData> MapKeysFunctions::bindFunc(
     const binder::expression_vector& arguments, kuzu::function::Function* /*function*/) {
-    auto returnListInfo = std::make_unique<VarListTypeInfo>(
-        std::make_unique<LogicalType>(*MapType::getKeyType(&arguments[0]->dataType)));
-    return std::make_unique<FunctionBindData>(
-        LogicalType(LogicalTypeID::VAR_LIST, std::move(returnListInfo)));
+    return std::make_unique<FunctionBindData>(LogicalType::VAR_LIST(
+        std::make_unique<LogicalType>(*MapType::getKeyType(&arguments[0]->dataType))));
 }
 
 function_set MapValuesFunctions::getFunctionSet() {
@@ -96,10 +84,8 @@ function_set MapValuesFunctions::getFunctionSet() {
 
 std::unique_ptr<FunctionBindData> MapValuesFunctions::bindFunc(
     const binder::expression_vector& arguments, kuzu::function::Function* /*function*/) {
-    auto returnListInfo = std::make_unique<VarListTypeInfo>(
-        std::make_unique<LogicalType>(*MapType::getValueType(&arguments[0]->dataType)));
-    return std::make_unique<FunctionBindData>(
-        LogicalType(LogicalTypeID::VAR_LIST, std::move(returnListInfo)));
+    return std::make_unique<FunctionBindData>(LogicalType::VAR_LIST(
+        std::make_unique<LogicalType>(*MapType::getValueType(&arguments[0]->dataType))));
 }
 
 } // namespace function

--- a/src/function/vector_path_functions.cpp
+++ b/src/function/vector_path_functions.cpp
@@ -24,7 +24,7 @@ std::unique_ptr<FunctionBindData> NodesFunction::bindFunc(
     auto structType = arguments[0]->getDataType();
     auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::NODES);
     return std::make_unique<StructExtractBindData>(
-        *(StructType::getFieldTypes(&structType))[fieldIdx], fieldIdx);
+        StructType::getFieldTypes(&structType)[fieldIdx]->copy(), fieldIdx);
 }
 
 function_set RelsFunction::getFunctionSet() {
@@ -40,7 +40,7 @@ std::unique_ptr<FunctionBindData> RelsFunction::bindFunc(
     auto structType = arguments[0]->getDataType();
     auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::RELS);
     return std::make_unique<StructExtractBindData>(
-        *(StructType::getFieldTypes(&structType))[fieldIdx], fieldIdx);
+        StructType::getFieldTypes(&structType)[fieldIdx]->copy(), fieldIdx);
 }
 
 function_set PropertiesFunction::getFunctionSet() {
@@ -72,9 +72,8 @@ std::unique_ptr<FunctionBindData> PropertiesFunction::bindFunc(
             stringFormat("Cannot extract properties from {}.", listType.toString()));
     }
     auto field = StructType::getField(childType, fieldIdx);
-    auto returnType = std::make_unique<LogicalType>(
-        LogicalTypeID::VAR_LIST, std::make_unique<VarListTypeInfo>(field->getType()->copy()));
-    return std::make_unique<PropertiesBindData>(*returnType, fieldIdx);
+    auto returnType = LogicalType::VAR_LIST(field->getType()->copy());
+    return std::make_unique<PropertiesBindData>(std::move(returnType), fieldIdx);
 }
 
 void PropertiesFunction::compileFunc(FunctionBindData* bindData,

--- a/src/function/vector_string_functions.cpp
+++ b/src/function/vector_string_functions.cpp
@@ -314,8 +314,7 @@ function_set RegexpExtractAllFunction::getFunctionSet() {
 
 std::unique_ptr<FunctionBindData> RegexpExtractAllFunction::bindFunc(
     const binder::expression_vector& /*arguments*/, Function* /*definition*/) {
-    return std::make_unique<FunctionBindData>(LogicalType(
-        LogicalTypeID::VAR_LIST, std::make_unique<VarListTypeInfo>(LogicalType::STRING())));
+    return std::make_unique<FunctionBindData>(LogicalType::VAR_LIST(LogicalType::STRING()));
 }
 
 } // namespace function

--- a/src/function/vector_struct_functions.cpp
+++ b/src/function/vector_struct_functions.cpp
@@ -21,18 +21,16 @@ function_set StructPackFunctions::getFunctionSet() {
 
 std::unique_ptr<FunctionBindData> StructPackFunctions::bindFunc(
     const binder::expression_vector& arguments, Function* /*function*/) {
-    std::vector<std::unique_ptr<StructField>> fields;
+    std::vector<StructField> fields;
     for (auto& argument : arguments) {
         if (argument->getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
             binder::ExpressionBinder::resolveAnyDataType(
                 *argument, LogicalType{LogicalTypeID::STRING});
         }
-        fields.emplace_back(
-            std::make_unique<StructField>(argument->getAlias(), argument->getDataType().copy()));
+        fields.emplace_back(argument->getAlias(), argument->getDataType().copy());
     }
-    auto resultType =
-        LogicalType(LogicalTypeID::STRUCT, std::make_unique<StructTypeInfo>(std::move(fields)));
-    return std::make_unique<FunctionBindData>(resultType);
+    auto resultType = LogicalType::STRUCT(std::move(fields));
+    return std::make_unique<FunctionBindData>(std::move(resultType));
 }
 
 void StructPackFunctions::execFunc(const std::vector<std::shared_ptr<ValueVector>>& parameters,
@@ -104,7 +102,7 @@ std::unique_ptr<FunctionBindData> StructExtractFunctions::bindFunc(
         throw BinderException(stringFormat("Invalid struct field name: {}.", key));
     }
     return std::make_unique<StructExtractBindData>(
-        *(StructType::getFieldTypes(&structType))[fieldIdx], fieldIdx);
+        (StructType::getFieldTypes(&structType))[fieldIdx]->copy(), fieldIdx);
 }
 
 void StructExtractFunctions::compileFunc(FunctionBindData* bindData,

--- a/src/function/vector_union_functions.cpp
+++ b/src/function/vector_union_functions.cpp
@@ -20,19 +20,17 @@ function_set UnionValueFunction::getFunctionSet() {
 std::unique_ptr<FunctionBindData> UnionValueFunction::bindFunc(
     const binder::expression_vector& arguments, kuzu::function::Function* /*function*/) {
     KU_ASSERT(arguments.size() == 1);
-    std::vector<std::unique_ptr<StructField>> fields;
+    std::vector<StructField> fields;
     // TODO(Ziy): Use UINT8 to represent tag value.
-    fields.push_back(std::make_unique<StructField>(
-        UnionType::TAG_FIELD_NAME, std::make_unique<LogicalType>(UnionType::TAG_FIELD_TYPE)));
+    fields.emplace_back(
+        UnionType::TAG_FIELD_NAME, std::make_unique<LogicalType>(UnionType::TAG_FIELD_TYPE));
     if (arguments[0]->getDataType().getLogicalTypeID() == common::LogicalTypeID::ANY) {
         binder::ExpressionBinder::resolveAnyDataType(
             *arguments[0], LogicalType(LogicalTypeID::STRING));
     }
-    fields.push_back(std::make_unique<StructField>(
-        arguments[0]->getAlias(), arguments[0]->getDataType().copy()));
-    auto resultType =
-        LogicalType(LogicalTypeID::UNION, std::make_unique<StructTypeInfo>(std::move(fields)));
-    return std::make_unique<FunctionBindData>(resultType);
+    fields.emplace_back(arguments[0]->getAlias(), arguments[0]->getDataType().copy());
+    auto resultType = LogicalType::UNION(std::move(fields));
+    return std::make_unique<FunctionBindData>(std::move(resultType));
 }
 
 void UnionValueFunction::execFunc(const std::vector<std::shared_ptr<ValueVector>>& /*parameters*/,

--- a/src/include/binder/expression/function_expression.h
+++ b/src/include/binder/expression/function_expression.h
@@ -11,19 +11,19 @@ class FunctionExpression : public Expression {
 public:
     FunctionExpression(std::string functionName, common::ExpressionType expressionType,
         std::unique_ptr<function::FunctionBindData> bindData, const std::string& uniqueName)
-        : Expression{expressionType, bindData->resultType, uniqueName},
+        : Expression{expressionType, *bindData->resultType, uniqueName},
           functionName{std::move(functionName)}, bindData{std::move(bindData)} {}
 
     FunctionExpression(std::string functionName, common::ExpressionType expressionType,
         std::unique_ptr<function::FunctionBindData> bindData,
         const std::shared_ptr<Expression>& child, const std::string& uniqueName)
-        : Expression{expressionType, bindData->resultType, child, uniqueName},
+        : Expression{expressionType, *bindData->resultType, child, uniqueName},
           functionName{std::move(functionName)}, bindData{std::move(bindData)} {}
 
     FunctionExpression(std::string functionName, common::ExpressionType expressionType,
         std::unique_ptr<function::FunctionBindData> bindData, expression_vector children,
         const std::string& uniqueName)
-        : Expression{expressionType, bindData->resultType, std::move(children), uniqueName},
+        : Expression{expressionType, *bindData->resultType, std::move(children), uniqueName},
           functionName{std::move(functionName)}, bindData{std::move(bindData)} {}
 
     ~FunctionExpression() override = default;

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -10,6 +10,9 @@
 #include "common/types/internal_id_t.h"
 
 namespace kuzu {
+namespace processor {
+class ParquetReader;
+};
 namespace common {
 
 class Serializer;
@@ -159,8 +162,6 @@ public:
     VarListTypeInfo() = default;
     explicit VarListTypeInfo(std::unique_ptr<LogicalType> childType)
         : childType{std::move(childType)} {}
-    explicit VarListTypeInfo(LogicalTypeID childTypeID)
-        : childType{std::make_unique<LogicalType>(childTypeID)} {}
     inline LogicalType* getChildType() const { return childType.get(); }
     bool operator==(const VarListTypeInfo& other) const;
     std::unique_ptr<ExtraTypeInfo> copy() const override;
@@ -206,9 +207,9 @@ public:
 
     void serialize(Serializer& serializer) const;
 
-    static std::unique_ptr<StructField> deserialize(Deserializer& deserializer);
+    static StructField deserialize(Deserializer& deserializer);
 
-    std::unique_ptr<StructField> copy() const;
+    StructField copy() const;
 
 private:
     std::string name;
@@ -218,18 +219,18 @@ private:
 class StructTypeInfo : public ExtraTypeInfo {
 public:
     StructTypeInfo() = default;
-    explicit StructTypeInfo(std::vector<std::unique_ptr<StructField>> fields);
+    explicit StructTypeInfo(std::vector<StructField>&& fields);
     StructTypeInfo(const std::vector<std::string>& fieldNames,
         const std::vector<std::unique_ptr<LogicalType>>& fieldTypes);
 
     bool hasField(const std::string& fieldName) const;
     struct_field_idx_t getStructFieldIdx(std::string fieldName) const;
-    StructField* getStructField(struct_field_idx_t idx) const;
-    StructField* getStructField(const std::string& fieldName) const;
+    const StructField* getStructField(struct_field_idx_t idx) const;
+    const StructField* getStructField(const std::string& fieldName) const;
     LogicalType* getChildType(struct_field_idx_t idx) const;
     std::vector<LogicalType*> getChildrenTypes() const;
     std::vector<std::string> getChildrenNames() const;
-    std::vector<StructField*> getStructFields() const;
+    std::vector<const StructField*> getStructFields() const;
     bool operator==(const kuzu::common::StructTypeInfo& other) const;
 
     static std::unique_ptr<ExtraTypeInfo> deserialize(Deserializer& deserializer);
@@ -239,7 +240,7 @@ private:
     void serializeInternal(Serializer& serializer) const override;
 
 private:
-    std::vector<std::unique_ptr<StructField>> fields;
+    std::vector<StructField> fields;
     std::unordered_map<std::string, struct_field_idx_t> fieldNameToIdxMap;
 };
 
@@ -251,10 +252,9 @@ class LogicalType {
 
 public:
     KUZU_API LogicalType() : typeID{LogicalTypeID::ANY}, extraTypeInfo{nullptr} {
-        setPhysicalType();
+        physicalType = getPhysicalType(this->typeID);
     };
     explicit KUZU_API LogicalType(LogicalTypeID typeID);
-    KUZU_API LogicalType(LogicalTypeID typeID, std::unique_ptr<ExtraTypeInfo> extraTypeInfo);
     KUZU_API LogicalType(const LogicalType& other);
     KUZU_API LogicalType(LogicalType&& other) = default;
 
@@ -271,6 +271,7 @@ public:
     KUZU_API inline LogicalTypeID getLogicalTypeID() const { return typeID; }
 
     inline PhysicalTypeID getPhysicalType() const { return physicalType; }
+    static PhysicalTypeID getPhysicalType(LogicalTypeID logicalType);
 
     inline bool hasExtraTypeInfo() const { return extraTypeInfo != nullptr; }
     inline void setExtraTypeInfo(std::unique_ptr<ExtraTypeInfo> typeInfo) {
@@ -358,9 +359,42 @@ public:
     static std::unique_ptr<LogicalType> POINTER() {
         return std::make_unique<LogicalType>(LogicalTypeID::POINTER);
     }
+    static KUZU_API std::unique_ptr<LogicalType> STRUCT(std::vector<StructField>&& fields);
+
+    static KUZU_API std::unique_ptr<LogicalType> RECURSIVE_REL(
+        std::unique_ptr<StructTypeInfo> typeInfo);
+
+    static KUZU_API std::unique_ptr<LogicalType> NODE(std::unique_ptr<StructTypeInfo> typeInfo);
+
+    static KUZU_API std::unique_ptr<LogicalType> REL(std::unique_ptr<StructTypeInfo> typeInfo);
+
+    static KUZU_API std::unique_ptr<LogicalType> RDF_VARIANT(
+        std::unique_ptr<StructTypeInfo> typeInfo);
+
+    static KUZU_API std::unique_ptr<LogicalType> UNION(std::vector<StructField>&& fields);
+
+    static KUZU_API std::unique_ptr<LogicalType> VAR_LIST(std::unique_ptr<LogicalType> childType);
+    template<class T>
+    static inline std::unique_ptr<LogicalType> VAR_LIST(T&& childType) {
+        return LogicalType::VAR_LIST(std::make_unique<LogicalType>(std::forward<T>(childType)));
+    }
+
+    static KUZU_API std::unique_ptr<LogicalType> MAP(
+        std::unique_ptr<LogicalType> keyType, std::unique_ptr<LogicalType> valueType);
+    template<class T>
+    static inline std::unique_ptr<LogicalType> MAP(T&& keyType, T&& valueType) {
+        return LogicalType::MAP(std::make_unique<LogicalType>(std::forward<T>(keyType)),
+            std::make_unique<LogicalType>(std::forward<T>(valueType)));
+    }
+
+    static KUZU_API std::unique_ptr<LogicalType> FIXED_LIST(
+        std::unique_ptr<LogicalType> childType, uint64_t fixedNumElementsInList);
 
 private:
-    void setPhysicalType();
+    friend struct CAPIHelper;
+    friend struct JavaAPIHelper;
+    friend class kuzu::processor::ParquetReader;
+    explicit LogicalType(LogicalTypeID typeID, std::unique_ptr<ExtraTypeInfo> extraTypeInfo);
 
 private:
     LogicalTypeID typeID;
@@ -426,7 +460,7 @@ struct StructType {
         return getFieldTypes(type).size();
     }
 
-    static inline std::vector<StructField*> getFields(const LogicalType* type) {
+    static inline std::vector<const StructField*> getFields(const LogicalType* type) {
         KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
         auto structTypeInfo = reinterpret_cast<StructTypeInfo*>(type->extraTypeInfo.get());
         return structTypeInfo->getStructFields();
@@ -438,13 +472,13 @@ struct StructType {
         return structTypeInfo->hasField(key);
     }
 
-    static inline StructField* getField(const LogicalType* type, struct_field_idx_t idx) {
+    static inline const StructField* getField(const LogicalType* type, struct_field_idx_t idx) {
         KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
         auto structTypeInfo = reinterpret_cast<StructTypeInfo*>(type->extraTypeInfo.get());
         return structTypeInfo->getStructField(idx);
     }
 
-    static inline StructField* getField(const LogicalType* type, const std::string& key) {
+    static inline const StructField* getField(const LogicalType* type, const std::string& key) {
         KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
         auto structTypeInfo = reinterpret_cast<StructTypeInfo*>(type->extraTypeInfo.get());
         return structTypeInfo->getStructField(key);
@@ -458,8 +492,6 @@ struct StructType {
 };
 
 struct MapType {
-    static std::unique_ptr<LogicalType> createMapType(
-        std::unique_ptr<LogicalType> keyType, std::unique_ptr<LogicalType> valueType);
     static inline LogicalType* getKeyType(const LogicalType* type) {
         KU_ASSERT(type->getLogicalTypeID() == LogicalTypeID::MAP);
         return StructType::getFieldTypes(VarListType::getChildType(type))[0];
@@ -511,18 +543,17 @@ public:
     static bool isNumerical(const LogicalType& dataType);
     static bool isNested(const LogicalType& dataType);
     static bool isNested(LogicalTypeID logicalTypeID);
-    static std::vector<LogicalType> getAllValidComparableLogicalTypes();
+    static std::vector<LogicalTypeID> getAllValidComparableLogicalTypes();
     static std::vector<LogicalTypeID> getNumericalLogicalTypeIDs();
     static std::vector<LogicalTypeID> getIntegerLogicalTypeIDs();
-    static std::vector<LogicalType> getAllValidLogicTypes();
+    static std::vector<LogicalTypeID> getAllValidLogicTypes();
 
 private:
     static LogicalTypeID dataTypeIDFromString(const std::string& trimmedStr);
     static std::vector<std::string> parseStructFields(const std::string& structTypeStr);
     static std::unique_ptr<LogicalType> parseVarListType(const std::string& trimmedStr);
     static std::unique_ptr<LogicalType> parseFixedListType(const std::string& trimmedStr);
-    static std::vector<std::unique_ptr<StructField>> parseStructTypeInfo(
-        const std::string& structTypeStr);
+    static std::vector<StructField> parseStructTypeInfo(const std::string& structTypeStr);
     static std::unique_ptr<LogicalType> parseStructType(const std::string& trimmedStr);
     static std::unique_ptr<LogicalType> parseMapType(const std::string& trimmedStr);
     static std::unique_ptr<LogicalType> parseUnionType(const std::string& trimmedStr);

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -139,18 +139,13 @@ public:
      * @param type the logical type of the value.
      * @param val_ the string value to set.
      */
-    KUZU_API explicit Value(const LogicalType& type, std::string val_);
+    KUZU_API explicit Value(std::unique_ptr<LogicalType> type, std::string val_);
     /**
      * @param dataType the logical type of the value.
      * @param children a vector of children values.
      */
     KUZU_API explicit Value(
-        const LogicalType& dataType, std::vector<std::unique_ptr<Value>> children);
-    /**
-     * @param dataType the logical type of the value.
-     * @param val_ the uint8_t* value to set.
-     */
-    KUZU_API Value(LogicalType dataType, const uint8_t* val_);
+        std::unique_ptr<LogicalType> dataType, std::vector<std::unique_ptr<Value>> children);
     /**
      * @param other the value to copy from.
      */
@@ -810,7 +805,7 @@ KUZU_API inline Value Value::createValue(nodeID_t val) {
  */
 template<>
 KUZU_API inline Value Value::createValue(std::string val) {
-    return Value(LogicalType{LogicalTypeID::STRING}, std::move(val));
+    return Value(LogicalType::STRING(), std::move(val));
 }
 
 /**
@@ -819,7 +814,7 @@ KUZU_API inline Value Value::createValue(std::string val) {
  */
 template<>
 KUZU_API inline Value Value::createValue(const char* value) {
-    return Value(LogicalType{LogicalTypeID::STRING}, std::string(value));
+    return Value(LogicalType::STRING(), std::string(value));
 }
 
 /**

--- a/src/include/function/aggregate/collect.h
+++ b/src/include/function/aggregate/collect.h
@@ -102,11 +102,9 @@ struct CollectFunction {
         KU_ASSERT(arguments.size() == 1);
         auto aggFuncDefinition = reinterpret_cast<AggregateFunction*>(definition);
         aggFuncDefinition->parameterTypeIDs[0] = arguments[0]->dataType.getLogicalTypeID();
-        auto varListTypeInfo = std::make_unique<common::VarListTypeInfo>(
+        auto returnType = common::LogicalType::VAR_LIST(
             std::make_unique<common::LogicalType>(arguments[0]->dataType));
-        auto returnType =
-            common::LogicalType(common::LogicalTypeID::VAR_LIST, std::move(varListTypeInfo));
-        return std::make_unique<FunctionBindData>(returnType);
+        return std::make_unique<FunctionBindData>(std::move(returnType));
     }
 };
 

--- a/src/include/function/aggregate_function.h
+++ b/src/include/function/aggregate_function.h
@@ -123,12 +123,12 @@ public:
     static std::unique_ptr<AggregateFunction> getAvgFunc(const std::string name,
         common::LogicalTypeID inputType, common::LogicalTypeID resultType, bool isDistinct);
     static std::unique_ptr<AggregateFunction> getMinFunc(
-        const common::LogicalType& inputType, bool isDistinct);
+        common::LogicalTypeID inputType, bool isDistinct);
     static std::unique_ptr<AggregateFunction> getMaxFunc(
-        const common::LogicalType& inputType, bool isDistinct);
+        common::LogicalTypeID inputType, bool isDistinct);
     template<typename FUNC>
     static std::unique_ptr<AggregateFunction> getMinMaxFunction(const std::string name,
-        const common::LogicalType& inputType, common::LogicalTypeID resultType, bool isDistinct);
+        common::LogicalTypeID inputType, common::LogicalTypeID resultType, bool isDistinct);
 };
 
 } // namespace function

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -7,9 +7,10 @@ namespace kuzu {
 namespace function {
 
 struct FunctionBindData {
-    common::LogicalType resultType;
+    std::unique_ptr<common::LogicalType> resultType;
 
-    explicit FunctionBindData(common::LogicalType dataType) : resultType{std::move(dataType)} {}
+    explicit FunctionBindData(std::unique_ptr<common::LogicalType> dataType)
+        : resultType{std::move(dataType)} {}
 
     virtual ~FunctionBindData() = default;
 };
@@ -18,7 +19,7 @@ struct CastFunctionBindData : public FunctionBindData {
     common::CSVReaderConfig csvConfig;
     uint64_t numOfEntries;
 
-    explicit CastFunctionBindData(common::LogicalType dataType)
+    explicit CastFunctionBindData(std::unique_ptr<common::LogicalType> dataType)
         : FunctionBindData{std::move(dataType)} {}
 };
 

--- a/src/include/function/list/vector_list_functions.h
+++ b/src/include/function/list/vector_list_functions.h
@@ -212,7 +212,7 @@ struct ListFunction {
                     common::LogicalTypeUtils::toString(resultType->getLogicalTypeID())));
         }
         }
-        return std::make_unique<FunctionBindData>(*resultType);
+        return std::make_unique<FunctionBindData>(resultType->copy());
     }
 };
 

--- a/src/include/function/path/vector_path_functions.h
+++ b/src/include/function/path/vector_path_functions.h
@@ -20,7 +20,7 @@ struct RelsFunction {
 struct PropertiesBindData : public FunctionBindData {
     common::vector_idx_t childIdx;
 
-    PropertiesBindData(common::LogicalType dataType, common::vector_idx_t childIdx)
+    PropertiesBindData(std::unique_ptr<common::LogicalType> dataType, common::vector_idx_t childIdx)
         : FunctionBindData{std::move(dataType)}, childIdx{childIdx} {}
 };
 

--- a/src/include/function/struct/vector_struct_functions.h
+++ b/src/include/function/struct/vector_struct_functions.h
@@ -23,7 +23,8 @@ struct StructPackFunctions {
 struct StructExtractBindData : public FunctionBindData {
     common::vector_idx_t childIdx;
 
-    StructExtractBindData(common::LogicalType dataType, common::vector_idx_t childIdx)
+    StructExtractBindData(
+        std::unique_ptr<common::LogicalType> dataType, common::vector_idx_t childIdx)
         : FunctionBindData{std::move(dataType)}, childIdx{childIdx} {}
 };
 

--- a/src/parser/transform/transform_expression.cpp
+++ b/src/parser/transform/transform_expression.cpp
@@ -403,7 +403,7 @@ std::unique_ptr<ParsedExpression> Transformer::transformLiteral(
     } else if (ctx.StringLiteral()) {
         return std::make_unique<ParsedLiteralExpression>(
             std::make_unique<Value>(
-                LogicalType{LogicalTypeID::STRING}, transformStringLiteral(*ctx.StringLiteral())),
+                LogicalType::STRING(), transformStringLiteral(*ctx.StringLiteral())),
             ctx.getText());
     } else if (ctx.NULL_()) {
         return std::make_unique<ParsedLiteralExpression>(

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -311,8 +311,7 @@ static std::unique_ptr<LogicalType> bindFixedListType(
     }
     auto childShape = std::vector<size_t>{shape.begin() + 1, shape.end()};
     auto childType = bindFixedListType(childShape, typeID);
-    auto extraInfo = std::make_unique<FixedListTypeInfo>(std::move(childType), (uint32_t)shape[0]);
-    return std::make_unique<LogicalType>(LogicalTypeID::FIXED_LIST, std::move(extraInfo));
+    return LogicalType::FIXED_LIST(std::move(childType), (uint32_t)shape[0]);
 }
 
 void NpyScanFunction::bindColumns(const common::ReaderConfig& readerConfig, uint32_t fileIdx,

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -535,6 +535,15 @@ JNIEXPORT jstring JNICALL Java_com_kuzudb_KuzuNative_kuzu_1flat_1tuple_1to_1stri
  * All DataType native functions
  */
 
+namespace kuzu::common {
+struct JavaAPIHelper {
+    static inline LogicalType* createLogicalType(
+        LogicalTypeID typeID, std::unique_ptr<ExtraTypeInfo> extraTypeInfo) {
+        return new LogicalType(typeID, std::move(extraTypeInfo));
+    }
+};
+} // namespace kuzu::common
+
 JNIEXPORT jlong JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1create(
     JNIEnv* env, jclass, jobject id, jobject child_type, jlong fixed_num_elements_in_list) {
     jclass javaIDClass = env->GetObjectClass(id);
@@ -552,7 +561,7 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1create(
                                  std::make_unique<FixedListTypeInfo>(
                                      std::move(child_type_pty), fixed_num_elements_in_list) :
                                  std::make_unique<VarListTypeInfo>(std::move(child_type_pty));
-        data_type = new LogicalType(logicalTypeID, std::move(extraTypeInfo));
+        data_type = JavaAPIHelper::createLogicalType(logicalTypeID, std::move(extraTypeInfo));
     }
     uint64_t address = reinterpret_cast<uint64_t>(data_type);
     return static_cast<jlong>(address);

--- a/tools/nodejs_api/src_cpp/node_util.cpp
+++ b/tools/nodejs_api/src_cpp/node_util.cpp
@@ -266,7 +266,7 @@ Value Util::TransformNapiValue(
     }
     case LogicalTypeID::STRING: {
         std::string val = napiValue.ToString().Utf8Value();
-        return Value(LogicalType{LogicalTypeID::STRING}, val);
+        return Value(LogicalType::STRING(), val);
     }
     case LogicalTypeID::DATE: {
         if (!napiValue.IsDate()) {

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -41,9 +41,23 @@ std::unique_ptr<kuzu::common::LogicalType> create_logical_type_var_list(
     std::unique_ptr<kuzu::common::LogicalType> childType);
 std::unique_ptr<kuzu::common::LogicalType> create_logical_type_fixed_list(
     std::unique_ptr<kuzu::common::LogicalType> childType, uint64_t numElements);
-std::unique_ptr<kuzu::common::LogicalType> create_logical_type_struct(
-    kuzu::common::LogicalTypeID typeID, const rust::Vec<rust::String>& fieldNames,
-    std::unique_ptr<TypeListBuilder> fieldTypes);
+
+inline std::unique_ptr<kuzu::common::LogicalType> create_logical_type_struct(
+    const rust::Vec<rust::String>& fieldNames, std::unique_ptr<TypeListBuilder> fieldTypes) {
+    std::vector<kuzu::common::StructField> fields;
+    for (auto i = 0u; i < fieldNames.size(); i++) {
+        fields.emplace_back(std::string(fieldNames[i]), std::move(fieldTypes->types[i]));
+    }
+    return kuzu::common::LogicalType::STRUCT(std::move(fields));
+}
+inline std::unique_ptr<kuzu::common::LogicalType> create_logical_type_union(
+    const rust::Vec<rust::String>& fieldNames, std::unique_ptr<TypeListBuilder> fieldTypes) {
+    std::vector<kuzu::common::StructField> fields;
+    for (auto i = 0u; i < fieldNames.size(); i++) {
+        fields.emplace_back(std::string(fieldNames[i]), std::move(fieldTypes->types[i]));
+    }
+    return kuzu::common::LogicalType::UNION(std::move(fields));
+}
 std::unique_ptr<kuzu::common::LogicalType> create_logical_type_map(
     std::unique_ptr<kuzu::common::LogicalType> keyType,
     std::unique_ptr<kuzu::common::LogicalType> valueType);

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -188,7 +188,10 @@ pub(crate) mod ffi {
             num_elements: u64,
         ) -> UniquePtr<LogicalType>;
         fn create_logical_type_struct(
-            type_id: LogicalTypeID,
+            field_names: &Vec<String>,
+            types: UniquePtr<TypeListBuilder>,
+        ) -> UniquePtr<LogicalType>;
+        fn create_logical_type_union(
             field_names: &Vec<String>,
             types: UniquePtr<TypeListBuilder>,
         ) -> UniquePtr<LogicalType>;

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -23,30 +23,17 @@ std::unique_ptr<LogicalType> create_logical_type(kuzu::common::LogicalTypeID id)
     return std::make_unique<LogicalType>(id);
 }
 std::unique_ptr<LogicalType> create_logical_type_var_list(std::unique_ptr<LogicalType> childType) {
-    return std::make_unique<LogicalType>(
-        LogicalTypeID::VAR_LIST, std::make_unique<VarListTypeInfo>(std::move(childType)));
+    return LogicalType::VAR_LIST(std::move(childType));
 }
 
 std::unique_ptr<LogicalType> create_logical_type_fixed_list(
     std::unique_ptr<LogicalType> childType, uint64_t numElements) {
-    return std::make_unique<LogicalType>(LogicalTypeID::FIXED_LIST,
-        std::make_unique<FixedListTypeInfo>(std::move(childType), numElements));
-}
-
-std::unique_ptr<kuzu::common::LogicalType> create_logical_type_struct(LogicalTypeID typeID,
-    const rust::Vec<rust::String>& fieldNames, std::unique_ptr<TypeListBuilder> fieldTypes) {
-    std::vector<std::unique_ptr<StructField>> fields;
-    for (auto i = 0u; i < fieldNames.size(); i++) {
-        fields.push_back(std::make_unique<StructField>(
-            std::string(fieldNames[i]), std::move(fieldTypes->types[i])));
-    }
-    return std::make_unique<LogicalType>(
-        typeID, std::make_unique<kuzu::common::StructTypeInfo>(std::move(fields)));
+    return LogicalType::FIXED_LIST(std::move(childType), numElements);
 }
 
 std::unique_ptr<kuzu::common::LogicalType> create_logical_type_map(
     std::unique_ptr<LogicalType> keyType, std::unique_ptr<LogicalType> valueType) {
-    return kuzu::common::MapType::createMapType(std::move(keyType), std::move(valueType));
+    return LogicalType::MAP(std::move(keyType), std::move(valueType));
 }
 
 const LogicalType& logical_type_get_var_list_child_type(const LogicalType& logicalType) {
@@ -258,7 +245,7 @@ const LogicalType& value_get_data_type(const kuzu::common::Value& value) {
 std::unique_ptr<kuzu::common::Value> create_value_string(
     LogicalTypeID typ, const rust::Slice<const unsigned char> value) {
     return std::make_unique<kuzu::common::Value>(
-        LogicalType(typ), std::string((const char*)value.data(), value.size()));
+        std::make_unique<LogicalType>(typ), std::string((const char*)value.data(), value.size()));
 }
 std::unique_ptr<kuzu::common::Value> create_value_timestamp(const int64_t timestamp) {
     return std::make_unique<kuzu::common::Value>(kuzu::common::timestamp_t(timestamp));
@@ -296,7 +283,7 @@ std::unique_ptr<kuzu::common::Value> create_value_int128_t(int64_t high, uint64_
 
 std::unique_ptr<kuzu::common::Value> get_list_value(
     std::unique_ptr<kuzu::common::LogicalType> typ, std::unique_ptr<ValueListBuilder> value) {
-    return std::make_unique<kuzu::common::Value>(std::move(*typ.get()), std::move(value->values));
+    return std::make_unique<kuzu::common::Value>(std::move(typ), std::move(value->values));
 }
 
 std::unique_ptr<ValueListBuilder> create_list() {

--- a/tools/rust_api/src/logical_type.rs
+++ b/tools/rust_api/src/logical_type.rs
@@ -223,7 +223,7 @@ impl From<&LogicalType> for cxx::UniquePtr<ffi::LogicalType> {
                     names.push(name.clone());
                     builder.pin_mut().insert(typ.into());
                 }
-                ffi::create_logical_type_struct(ffi::LogicalTypeID::STRUCT, &names, builder)
+                ffi::create_logical_type_struct(&names, builder)
             }
             LogicalType::Union { types } => {
                 let mut builder = ffi::create_type_list();
@@ -234,7 +234,7 @@ impl From<&LogicalType> for cxx::UniquePtr<ffi::LogicalType> {
                     names.push(name.clone());
                     builder.pin_mut().insert(typ.into());
                 }
-                ffi::create_logical_type_struct(ffi::LogicalTypeID::UNION, &names, builder)
+                ffi::create_logical_type_union(&names, builder)
             }
             LogicalType::Map {
                 key_type,


### PR DESCRIPTION
This reduces the amount of boiler-plate code that has to be written when creating logical types by moving that into `types.cpp` and providing more specific static methods to create the complex types, particularly since this is part of our public API and users don't really need to handle `ExtraTypeInfo` directly.

E.g. `LogicalType::VAR_LIST(childType);` instead of `LogicalType(LogicalTypeID::VAR_LIST, std::make_unique<VarListTypeInfo>(childType));`.

I'd also cleaned up a couple places where `LogicalType` was being used where `LogicalTypeID` could have been used instead, and removed some indirection from `StructField` to simplify it.

Ideally I think the `ExtraTypeInfo` implementations could be hidden inside `types.cpp`, however there are some more complex places, particularly for `NODE`, `REL` and `RECURSIVE_REL`, which I'd left alone.

One part I'm not sure about is the return types of the `LogicalType` static methods. The simple types all return `unique_ptr` (and the regular constructor is used in places where a unique_ptr is not wanted), but the complex types also need both, and it's a choice between:
1. Provide a separate method for each. E.g. `LogicalType::VAR_LIST_P` to produce a unique_ptr (or a separate method not to, for consistency with the simple types?).
2. Provide just a method which produces a `LogicalType` (what's implemented here), and if you want a unique_ptr wrap it with `make_unique<LogicalType>(...)` to move the object into the `unique_ptr` using the move constructor.
3. Provide just a method which produces a `unique_ptr<LogicalType>` and use `std::move(*LogicalType::VAR_LIST(...))` to move the data out of the `unique_ptr` if you want (unlike (2) this adds an unnecessary heap allocation).