### PR TITLE
Set null values when scanning serial columns

### DIFF
--- a/src/function/table_functions/call_functions.cpp
+++ b/src/function/table_functions/call_functions.cpp
@@ -340,7 +340,9 @@ void StorageInfoSharedState::collectColumns(Table* table) {
 std::vector<Column*> StorageInfoSharedState::collectColumns(Column* column) {
     std::vector<Column*> result;
     result.push_back(column);
-    result.push_back(column->getNullColumn());
+    if (column->getNullColumn()) {
+        result.push_back(column->getNullColumn());
+    }
     switch (column->getDataType()->getPhysicalType()) {
     case PhysicalTypeID::STRUCT: {
         auto structColumn = ku_dynamic_cast<Column*, StructColumn*>(column);

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -300,7 +300,7 @@ public:
         for (auto i = 0ul; i < nodeIDVector->state->selVector->selectedSize; i++) {
             auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             auto offset = nodeIDVector->readNodeOffset(pos);
-            KU_ASSERT(!resultVector->isNull(pos));
+            resultVector->setNull(pos, false);
             resultVector->setValue<offset_t>(pos, offset);
         }
     }
@@ -311,6 +311,7 @@ public:
         for (auto i = 0ul; i < nodeIDVector->state->selVector->selectedSize; i++) {
             auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             auto offset = nodeIDVector->readNodeOffset(pos);
+            resultVector->setNull(pos, false);
             resultVector->setValue<offset_t>(pos, offset);
         }
     }

--- a/test/test_files/update_node/create_empty.test
+++ b/test/test_files/update_node/create_empty.test
@@ -70,3 +70,19 @@
 ---- 2
 foo|
 foobar|
+
+-CASE CreateSerial
+-STATEMENT CREATE NODE TABLE A(pk1 SERIAL, PRIMARY KEY(pk1));
+---- ok
+-STATEMENT CREATE NODE TABLE B(pk2 SERIAL, PRIMARY KEY(pk2));
+---- ok
+-STATEMENT CREATE NODE TABLE C(pk3 SERIAL, PRIMARY KEY(pk3));
+---- ok
+-STATEMENT CREATE (:A);
+---- ok
+-STATEMENT CREATE (:B);
+---- ok
+-STATEMENT MATCH (n) RETURN n;
+---- 2
+{_ID: 0:0, _LABEL: A, pk1: 0}
+{_ID: 1:0, _LABEL: B, pk2: 0}


### PR DESCRIPTION
Fixes #2402 by setting values as non-null when scanning serials instead of assuming that the result vectors are already set as non-null.

I've also fixed `storage_info` for serials, which was breaking since serial columns don't have null columns, while the storage_info code assumes that all parent columns do (not that there's much interesting information in a serial column).

~~TODO: add test using example from #2402~~ Done