### PR TITLE
Fix rust CI on windows

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -213,7 +213,6 @@ jobs:
         working-directory: tools/rust_api
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-          set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set KUZU_TESTING=1
           set CFLAGS=/MDd
           set CXXFLAGS=/MDd /std:c++20

--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -35,8 +35,6 @@ arrow = {version="43", optional=true, default-features=false, features=["ffi"]}
 cxx-build = "1.0"
 num_cpus = "1.0"
 cmake = "0.1"
-[target.'cfg(windows)'.build-dependencies]
-which = "4"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -9,37 +9,6 @@ fn link_mode() -> &'static str {
     }
 }
 
-fn find_openssl_windows() {
-    // Find openssl library relative to the path of the openssl executable
-    // Or fall back to OPENSSL_DIR
-    #[cfg(windows)]
-    {
-        let openssl_dir = if let Ok(mut path) = which::which("openssl") {
-            path.pop();
-            path.pop();
-            path
-        } else if let Ok(path) = env::var("OPENSSL_CONF") {
-            Path::new(&path)
-                .parent()
-                .unwrap()
-                .parent()
-                .unwrap()
-                .to_path_buf()
-        } else if let Ok(path) = env::var("OPENSSL_DIR") {
-            Path::new(&path).to_path_buf()
-        } else {
-            panic!(
-                "OPENSSL_DIR must be set if the openssl library cannot be found \
-                            using the path of the openssl executable"
-            )
-        };
-        println!(
-            "cargo:rustc-link-search=native={}/lib",
-            openssl_dir.display()
-        );
-    }
-}
-
 fn get_target() -> String {
     if cfg!(windows) && std::env::var("CXXFLAGS").is_err() {
         "release".to_string()
@@ -63,12 +32,6 @@ fn link_libraries() {
             println!("cargo:rustc-link-lib=dylib=c++");
         } else {
             println!("cargo:rustc-link-lib=dylib=stdc++");
-        }
-
-        if env::var("KUZU_TESTING").is_ok() && cfg!(windows) {
-            find_openssl_windows();
-            println!("cargo:rustc-link-lib=dylib=libssl");
-            println!("cargo:rustc-link-lib=dylib=libcrypto");
         }
 
         println!("cargo:rustc-link-lib=static=utf8proc");


### PR DESCRIPTION
This removes openssl linking on windows. I think it's no longer necessary as it was an arrow dependency (I thought there was another reason, but I'm not sure).