### PR TITLE
Fix issue 2587

### DIFF
--- a/src/storage/storage_structure/disk_overflow_file.cpp
+++ b/src/storage/storage_structure/disk_overflow_file.cpp
@@ -53,6 +53,8 @@ void DiskOverflowFile::setStringOverflowWithoutLock(
         nextBytePosToWriteTo, BufferPoolConstants::PAGE_4KB_SIZE);
     memcpy(updatedPageInfoAndWALPageFrame.frame + updatedPageInfoAndWALPageFrame.posInPage,
         srcRawString, len);
+    DBFileUtils::unpinWALPageAndReleaseOriginalPageLock(
+        updatedPageInfoAndWALPageFrame, *fileHandle, *bufferManager, *wal);
     TypeUtils::encodeOverflowPtr(diskDstString.overflowPtr,
         updatedPageInfoAndWALPageFrame.originalPageIdx, updatedPageInfoAndWALPageFrame.posInPage);
     nextBytePosToWriteTo += len;

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -227,3 +227,24 @@ True|True|True
 [t2,t21]
 [t2,t22]
 [t3]
+
+-CASE 2587
+-STATEMENT CREATE NODE TABLE T (id STRING, descr STRING, PRIMARY KEY (id));
+---- ok
+-STATEMENT CREATE (:T {id: "foo"});
+---- ok
+-STATEMENT CREATE (:T {id: "123456789012"});
+---- ok
+-STATEMENT CREATE (:T {id: "bar", descr: "fe38f9dc-f761-4184-8b8b-ec9a1b5ffb83"});
+---- ok
+-STATEMENT CREATE (:T {id: "ge38f9dc-f751-4174-8b8b-ec9a1b6gab83"});
+---- ok
+-STATEMENT CREATE (:T {id: "1234567890123"});
+---- ok
+-STATEMENT MATCH (t:T) RETURN t.*;
+---- 5
+foo|
+123456789012|
+bar|fe38f9dc-f761-4184-8b8b-ec9a1b5ffb83
+ge38f9dc-f751-4174-8b8b-ec9a1b6gab83|
+1234567890123|

--- a/test/test_files/update_node/create_empty.test
+++ b/test/test_files/update_node/create_empty.test
@@ -86,3 +86,15 @@ foobar|
 ---- 2
 {_ID: 0:0, _LABEL: A, pk1: 0}
 {_ID: 1:0, _LABEL: B, pk2: 0}
+
+-CASE CreateWithLargeStringPK
+-STATEMENT CREATE NODE TABLE test(id STRING, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {id:"fe38f9dc-f761-4184-8b8b"});
+---- ok
+-STATEMENT CREATE (t:test {id:"foobar-ewe-j323-8nd*-ewew"});
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.*;
+---- 2
+fe38f9dc-f761-4184-8b8b
+foobar-ewe-j323-8nd*-ewew


### PR DESCRIPTION
This fixes issue #2587. Also added the case to our test suite.

Also, we should refactor `WALPageIdxAndFrame` to be able to unpin and unlock itself when it is out of scope later.