### PR TITLE
Add missing headers which are required with gcc 13

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -11,6 +11,8 @@
 
 #include <fcntl.h>
 
+#include <cstring>
+
 #include "common/assert.h"
 #include "common/exception/exception.h"
 #include "common/string_format.h"

--- a/src/include/common/file_system/file_info.h
+++ b/src/include/common/file_system/file_info.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace kuzu {


### PR DESCRIPTION
The string header coincidentally includes cstdint and cstring in earlier versions.

Documented here: https://gcc.gnu.org/gcc-13/porting_to.html.