### PR TITLE
common: add copy constructor macros

### DIFF
--- a/src/common/copy_constructors.h
+++ b/src/common/copy_constructors.h
@@ -1,0 +1,49 @@
+// This file defines many macros for controlling copy constructors and move constructors on classes.
+
+#define DELETE_COPY(Object) Object(const Object& other) = delete
+
+#define DELETE_COPY_ASSN(Object) Object& operator=(const Object& other) = delete
+
+#define DELETE_MOVE(Object)                                                                        \
+    Object(Object&& other) = delete;                                                               \
+    Object& operator=(Object&& other) = delete
+
+#define ENABLE_MOVE(Object)                                                                        \
+    Object(Object&& other) = default;                                                              \
+    Object& operator=(Object&& other) = default
+
+#define EXPLICIT_COPY_METHOD(Object)                                                               \
+    Object copy() const { return *this; }
+
+// EXPLICIT_COPY should be the default choice. It expects a PRIVATE copy constructor to be defined,
+// which will be used by an explicit `copy()` method. For instance:
+//
+//   private:
+//     MyClass(const MyClass& other) : field(other.field.copy()) {}
+//
+//   public:
+//     EXPLICIT_COPY(MyClass);
+//
+// Now:
+//
+// MyClass o1;
+// MyClass o2 = o1; // Compile error, copy assignment deleted.
+// MyClass o2 = o1.copy(); // OK.
+// MyClass o2(o1); // Compile error, copy constructor is private.
+#define EXPLICIT_COPY(Object)                                                                      \
+    DELETE_COPY_ASSN(Object);                                                                      \
+    ENABLE_MOVE(Object);                                                                           \
+    EXPLICIT_COPY_METHOD(Object)
+
+// NO_COPY should be used for objects that for whatever reason, should never be copied.
+#define NO_COPY(Object)                                                                            \
+    DELETE_COPY(Object);                                                                           \
+    DELETE_COPY_ASSN(Object);                                                                      \
+    ENABLE_MOVE(Object)
+
+// NO_MOVE_OR_COPY exists solely for explicitness, when an object cannot be moved nor copied. Any
+// object containing a lock cannot be moved or copied.
+#define NO_MOVE_OR_COPY(Object)                                                                    \
+    DELETE_COPY(Object);                                                                           \
+    DELETE_COPY_ASSN(Object);                                                                      \
+    DELETE_MOVE(Object)


### PR DESCRIPTION
Instead of using std::unique_ptr all over the place to prevent copies, we can delete copy constructors. To enable this, this change adds three macros: EXPLICIT_COPY, NO_COPY, and NO_COPY_OR_MOVE. They should be added to any non-trivial class to define how copying and moving should be done.

By default, move constructors and move assignment operators are enabled, unless disabled with NO_COPY_OR_MOVE. EXPLICIT_COPY adds a `.copy()` method, which can be used for explicit copying, making it clear when we are paying the price of a full copy.

Future work could be done to ensure these macros are always added.