### PR TITLE
Added public headers explicitly to main/kuzu.h

### DIFF
--- a/src/include/main/kuzu.h
+++ b/src/include/main/kuzu.h
@@ -1,4 +1,20 @@
 #pragma once
 
-#include "connection.h" // IWYU pragma: export
-#include "database.h"   // IWYU pragma: export
+#include "common/types/date_t.h"              // IWYU pragma: export
+#include "common/types/dtime_t.h"             // IWYU pragma: export
+#include "common/types/int128_t.h"            // IWYU pragma: export
+#include "common/types/internal_id_t.h"       // IWYU pragma: export
+#include "common/types/interval_t.h"          // IWYU pragma: export
+#include "common/types/timestamp_t.h"         // IWYU pragma: export
+#include "common/types/types.h"               // IWYU pragma: export
+#include "common/types/value/node.h"          // IWYU pragma: export
+#include "common/types/value/recursive_rel.h" // IWYU pragma: export
+#include "common/types/value/rel.h"           // IWYU pragma: export
+#include "common/types/value/value.h"         // IWYU pragma: export
+#include "main/connection.h"                  // IWYU pragma: export
+#include "main/database.h"                    // IWYU pragma: export
+#include "main/prepared_statement.h"          // IWYU pragma: export
+#include "main/query_result.h"                // IWYU pragma: export
+#include "main/query_summary.h"               // IWYU pragma: export
+#include "main/storage_driver.h"              // IWYU pragma: export
+#include "processor/result/flat_tuple.h"      // IWYU pragma: export


### PR DESCRIPTION
Some things are missing from the single file header, probably as a result of reducing unnecessary includes and splitting up the headers.

This is related to an unimplemented part of #2136, that is, we should be compiling the API tests using just the single file header where possible to make sure that the public APIs are actually usable with the single file header included in the releases.

For now I've added everything I could think of (basically, most header files containing `KUZU_API`) to `main/kuzu.h`. 

I omitted the exceptions, but maybe some or all of those should also be included so that users can catch specific exceptions (it looks like at the moment, `Exception`, `InternalException`, `RuntimeException`, `BinderException` and `CatalogException` are included in the single file header since they are used inline), however exceptions during queries are turned into an error message in the `QueryResult`, so for the most part I don't think that should be necessary.