### PR TITLE
common: add MPSC Queue

### DIFF
--- a/src/include/common/copy_constructors.h
+++ b/src/include/common/copy_constructors.h
@@ -2,29 +2,37 @@
 
 // This file defines many macros for controlling copy constructors and move constructors on classes.
 
-#define DELETE_COPY(Object) Object(const Object& other) = delete
-
+#define DELETE_COPY_CONSTRUCT(Object) Object(const Object& other) = delete
 #define DELETE_COPY_ASSN(Object) Object& operator=(const Object& other) = delete
+#define DELETE_MOVE_CONSTRUCT(Object) Object(Object&& other) = delete
+#define DELETE_MOVE_ASSN(Object) Object& operator=(Object&& other) = delete
 
-#define DELETE_MOVE(Object)                                                                        \
-    Object(Object&& other) = delete;                                                               \
-    Object& operator=(Object&& other) = delete
+#define DELETE_BOTH_COPY(Object)                                                                   \
+    DELETE_COPY_CONSTRUCT(Object);                                                                 \
+    DELETE_COPY_ASSN(Object)
 
-#define ENABLE_MOVE(Object)                                                                        \
-    Object(Object&& other) = default;                                                              \
-    Object& operator=(Object&& other) = default
+#define DELETE_BOTH_MOVE(Object)                                                                   \
+    DELETE_MOVE_CONSTRUCT(Object);                                                                 \
+    DELETE_MOVE_ASSN(Object)
+
+#define DEFAULT_MOVE_CONSTRUCT(Object) Object(Object&& other) = default
+#define DEFAULT_MOVE_ASSN(Object) Object& operator=(Object&& other) = default
+
+#define DEFAULT_BOTH_MOVE(Object)                                                                  \
+    DEFAULT_MOVE_CONSTRUCT(Object);                                                                \
+    DEFAULT_MOVE_ASSN(Object)
 
 #define EXPLICIT_COPY_METHOD(Object)                                                               \
     Object copy() const { return *this; }
 
-// EXPLICIT_COPY should be the default choice. It expects a PRIVATE copy constructor to be defined,
-// which will be used by an explicit `copy()` method. For instance:
+// EXPLICIT_COPY_DEFAULT_MOVE should be the default choice. It expects a PRIVATE copy constructor to
+// be defined, which will be used by an explicit `copy()` method. For instance:
 //
 //   private:
 //     MyClass(const MyClass& other) : field(other.field.copy()) {}
 //
 //   public:
-//     EXPLICIT_COPY(MyClass);
+//     EXPLICIT_COPY_DEFAULT_MOVE(MyClass);
 //
 // Now:
 //
@@ -32,20 +40,19 @@
 // MyClass o2 = o1; // Compile error, copy assignment deleted.
 // MyClass o2 = o1.copy(); // OK.
 // MyClass o2(o1); // Compile error, copy constructor is private.
-#define EXPLICIT_COPY(Object)                                                                      \
+#define EXPLICIT_COPY_DEFAULT_MOVE(Object)                                                         \
     DELETE_COPY_ASSN(Object);                                                                      \
-    ENABLE_MOVE(Object);                                                                           \
+    DEFAULT_BOTH_MOVE(Object);                                                                     \
     EXPLICIT_COPY_METHOD(Object)
 
-// NO_COPY should be used for objects that for whatever reason, should never be copied.
-#define NO_COPY(Object)                                                                            \
-    DELETE_COPY(Object);                                                                           \
-    DELETE_COPY_ASSN(Object);                                                                      \
-    ENABLE_MOVE(Object)
+// NO_COPY should be used for objects that for whatever reason, should never be copied, but can be
+// moved.
+#define DELETE_COPY_DEFAULT_MOVE(Object)                                                           \
+    DELETE_BOTH_COPY(Object);                                                                      \
+    DEFAULT_BOTH_MOVE(Object)
 
 // NO_MOVE_OR_COPY exists solely for explicitness, when an object cannot be moved nor copied. Any
 // object containing a lock cannot be moved or copied.
-#define NO_MOVE_OR_COPY(Object)                                                                    \
-    DELETE_COPY(Object);                                                                           \
-    DELETE_COPY_ASSN(Object);                                                                      \
-    DELETE_MOVE(Object)
+#define DELETE_COPY_AND_MOVE(Object)                                                               \
+    DELETE_BOTH_COPY(Object);                                                                      \
+    DELETE_BOTH_MOVE(Object)

--- a/src/include/common/mpsc_queue.h
+++ b/src/include/common/mpsc_queue.h
@@ -1,0 +1,107 @@
+#pragma once
+
+// Based on the following design:
+// https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue
+
+#include <atomic>
+
+#include "common/assert.h"
+#include "common/copy_constructors.h"
+
+namespace kuzu {
+namespace common {
+
+// Producers are completely wait-free.
+template<typename T>
+class MPSCQueue {
+    struct Node {
+        T data;
+        std::atomic<Node*> next;
+
+        explicit Node(T data) : data(std::move(data)), next(nullptr) {}
+    };
+
+public:
+    MPSCQueue() : head(nullptr), tail(nullptr), _approxSize(0) {
+        // Allocate a dummy element.
+        Node* stub = new Node(T());
+        head = stub;
+
+        // Ordering doesn't matter.
+        tail.store(stub, std::memory_order_relaxed);
+    }
+    DELETE_BOTH_COPY(MPSCQueue);
+    MPSCQueue(MPSCQueue&& other)
+        : head(other.head), tail(other.tail.exchange(nullptr, std::memory_order_relaxed)),
+          _approxSize(other._approxSize.load(std::memory_order_relaxed)) {
+        other.head = nullptr;
+    }
+    // If this method existed, it wouldn't be atomic, and so would be rather error-prone. Maybe
+    // there's a valid future use case.
+    DELETE_MOVE_ASSN(MPSCQueue);
+
+    // NOTE: It is NOT guaranteed that the result of a push() is accessible to a thread that calls
+    // pop() after the push(), because of implementation details. See the body of the function for
+    // details.
+    void push(T elem) {
+        Node* node = new Node(std::move(elem));
+        _approxSize.fetch_add(1, std::memory_order_relaxed);
+        // ORDERING: must acquire any updates to prev before modifying it, and release our updates
+        // to node for other producers.
+        Node* prev = tail.exchange(node, std::memory_order_acq_rel);
+        // NOTE: If the thread is suspended here, then ALL FUTURE push() calls will be INACCESSIBLE
+        // by pop() calls until the next line runs. In order to guarantee that a push() is visible
+        // to a thread that calls pop(), ALL push() calls must have completed.
+        // ORDERING: must make updates visible to consumers.
+        prev->next.store(node, std::memory_order_release);
+    }
+
+    // NOTE: It is NOT safe to call pop() from multiple threads without synchronization.
+    bool pop(T& elem) {
+        // ORDERING: Acquire any updates made by producers.
+        // Note that head is accessed only by the single consumer, so accesses to it need not be
+        // synchronized.
+        Node* next = head->next.load(std::memory_order_acquire);
+        if (next == nullptr) {
+            return false;
+        }
+        // Free the old element.
+        delete head;
+        head = next;
+        elem = std::move(head->data);
+        _approxSize.fetch_sub(1, std::memory_order_relaxed);
+        // Now the current head has dummy data in it again (i.e., whatever was leftover after the
+        // move()).
+        return true;
+    }
+
+    // Return an approximation of the number of elements in the queue.
+    // Due to implementation details, this number must not be relied on. However, it can be used to
+    // get a rough estimate for the size of the queue.
+    size_t approxSize() const { return _approxSize.load(std::memory_order_relaxed); }
+
+    // Drain the queue. All operations on the queue MUST have finished. I.e., there must be NO
+    // push() or pop() operations in progress of any kind.
+    ~MPSCQueue() {
+        // If we were moved out of, return.
+        if (!head) {
+            return;
+        }
+
+        T dummy;
+        while (pop(dummy)) {}
+        KU_ASSERT(head == tail.load(std::memory_order_relaxed));
+        delete head;
+    }
+
+private:
+    // Head is always present, but always has dummy data. This ensures that it is always easy to
+    // append to the list, without branching in the methods.
+    Node* head;
+    std::atomic<Node*> tail;
+
+    std::atomic<size_t> _approxSize;
+};
+
+} // namespace common
+} // namespace kuzu

--- a/src/include/common/mutex.h
+++ b/src/include/common/mutex.h
@@ -15,7 +15,7 @@ class MutexGuard {
     MutexGuard(T& data, std::unique_lock<std::mutex> lck) : data(&data), lck(std::move(lck)) {}
 
 public:
-    NO_COPY(MutexGuard);
+    DELETE_COPY_DEFAULT_MOVE(MutexGuard);
 
     T* operator->() & { return data; }
     T& operator*() & { return *data; }
@@ -37,7 +37,7 @@ class Mutex {
 public:
     Mutex() : data() {}
     explicit Mutex(T data) : data(std::move(data)) {}
-    NO_MOVE_OR_COPY(Mutex);
+    DELETE_COPY_AND_MOVE(Mutex);
 
     MutexGuard<T> lock() {
         std::unique_lock lck{mtx};


### PR DESCRIPTION
This queue is core to the new parallel hash index. It implements the design in this [blog][1], which is also used by Rust. The design is quite simple, and producers are wait-free. The main disadvantage is it is non-blocking, but adding blocking pop() support is tricky, and currently not needed.

  [1]: https://www.1024cores.net/home/lock-free-algorithms/queues/non-intrusive-mpsc-node-based-queue