### PR TITLE
Rename rdf keyword

### DIFF
--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(
     auto offset = expressionBinder.createVariableExpression(
         *LogicalType::INT64(), InternalKeyword::ROW_OFFSET);
     auto r = expressionBinder.createVariableExpression(*LogicalType::STRING(), rdf::IRI);
-    auto l = expressionBinder.createVariableExpression(*RdfVariantType::getType(), rdf::IRI);
+    auto l = expressionBinder.createVariableExpression(*RdfVariantType::getType(), rdf::VAL);
     auto s = expressionBinder.createVariableExpression(*LogicalType::STRING(), rdf::SUBJECT);
     auto p = expressionBinder.createVariableExpression(*LogicalType::STRING(), rdf::PREDICATE);
     auto o = expressionBinder.createVariableExpression(*LogicalType::STRING(), rdf::OBJECT);

--- a/src/binder/bind/ddl/bind_create_rdf_graph.cpp
+++ b/src/binder/bind/ddl/bind_create_rdf_graph.cpp
@@ -46,7 +46,7 @@ std::unique_ptr<BoundCreateTableInfo> Binder::bindCreateRdfGraphInfo(const Creat
     literalProperties.push_back(
         std::make_unique<Property>(std::string(rdf::ID), serialType.copy()));
     literalProperties.push_back(
-        std::make_unique<Property>(std::string(rdf::IRI), RdfVariantType::getType()));
+        std::make_unique<Property>(std::string(rdf::VAL), RdfVariantType::getType()));
     auto literalExtraInfo = std::make_unique<BoundExtraCreateNodeTableInfo>(
         0 /* primaryKeyIdx */, std::move(literalProperties));
     auto literalCreateInfo = std::make_unique<BoundCreateTableInfo>(

--- a/src/include/common/keyword/rdf_keyword.h
+++ b/src/include/common/keyword/rdf_keyword.h
@@ -7,18 +7,16 @@ namespace common {
 namespace rdf {
 
 static constexpr std::string_view IRI = "iri";
+static constexpr std::string_view VAL = "val";
 static constexpr std::string_view ID = "id";
 static constexpr std::string_view PID = "pid"; // TODO: rename
 static constexpr std::string_view SUBJECT = "subject";
 static constexpr std::string_view PREDICATE = "predicate";
 static constexpr std::string_view OBJECT = "object";
-static constexpr std::string_view SUBJECT_OFFSET = "subject_offset";
-static constexpr std::string_view PREDICATE_OFFSET = "predicate_offset";
-static constexpr std::string_view OBJECT_OFFSET = "object_offset";
-static constexpr std::string_view RESOURCE_TABLE_SUFFIX = "_resource_t";
-static constexpr std::string_view LITERAL_TABLE_SUFFIX = "_literal_t";
-static constexpr std::string_view RESOURCE_TRIPLE_TABLE_SUFFIX = "_resource_triples_t";
-static constexpr std::string_view LITERAL_TRIPLE_TABLE_SUFFIX = "_literal_triples_t";
+static constexpr std::string_view RESOURCE_TABLE_SUFFIX = "_r";
+static constexpr std::string_view LITERAL_TABLE_SUFFIX = "_l";
+static constexpr std::string_view RESOURCE_TRIPLE_TABLE_SUFFIX = "_rt";
+static constexpr std::string_view LITERAL_TRIPLE_TABLE_SUFFIX = "_lt";
 
 // Common RDF prefix
 static constexpr std::string_view XSD = "http://www.w3.org/2001/XMLSchema#";

--- a/src/processor/operator/persistent/copy_node.cpp
+++ b/src/processor/operator/persistent/copy_node.cpp
@@ -171,10 +171,7 @@ void CopyNodeSharedState::calculateNumTuples() {
 
 void CopyNode::finalize(ExecutionContext* context) {
     sharedState->calculateNumTuples();
-    //    uint64_t numNodes =
-    //    StorageUtils::getStartOffsetOfNodeGroup(sharedState->getCurNodeGroupIdx());
     if (sharedState->sharedNodeGroup) {
-        //        numNodes += sharedState->sharedNodeGroup->getNumRows();
         auto nodeGroupIdx = sharedState->getNextNodeGroupIdx();
         writeAndResetNodeGroup(nodeGroupIdx, sharedState->indexBuilder.get(),
             sharedState->pkColumnIdx, sharedState->table, sharedState->sharedNodeGroup.get());

--- a/test/test_files/copy/copy_rdf.test
+++ b/test/test_files/copy/copy_rdf.test
@@ -7,12 +7,12 @@
 -CASE CopyRDFTest
 
 -LOG CountRDFNodeTable
--STATEMENT MATCH (s:taxonomy_resource_t) RETURN COUNT(s.iri)
+-STATEMENT MATCH (s:taxonomy_r) RETURN COUNT(s.iri)
 ---- 1
 1138441
 
 -LOG QueryRDFNodeTable
--STATEMENT MATCH (s:taxonomy_resource_t) RETURN s.iri ORDER BY s.iri LIMIT 5
+-STATEMENT MATCH (s:taxonomy_r) RETURN s.iri ORDER BY s.iri LIMIT 5
 ---- 5
 http://dbpedia.org/class/yago/'hood108641944
 http://dbpedia.org/class/yago/14July115200493
@@ -21,7 +21,7 @@ http://dbpedia.org/class/yago/16PF106475933
 http://dbpedia.org/class/yago/1750s115149933
 
 -LOG QueryRDFRelTable
--STATEMENT MATCH (s:taxonomy_resource_t)-[p:taxonomy]->(o:taxonomy_resource_t) RETURN s.iri, o.iri ORDER BY s.iri LIMIT 2
+-STATEMENT MATCH (s:taxonomy_r)-[p:taxonomy]->(o:taxonomy_r) RETURN s.iri, o.iri ORDER BY s.iri LIMIT 2
 ---- 2
 http://dbpedia.org/class/yago/'hood108641944|http://dbpedia.org/class/yago/Vicinity108641113
 http://dbpedia.org/class/yago/14July115200493|http://dbpedia.org/class/yago/LegalHoliday115199592

--- a/test/test_files/rdf/rdfox_example.test
+++ b/test/test_files/rdf/rdfox_example.test
@@ -7,13 +7,13 @@
 
 -STATEMENT CALL SHOW_TABLES() RETURN *;
 ---- 5
-example_literal_triples_t|REL|
-example_literal_t|NODE|
-example_resource_triples_t|REL|
-example_resource_t|NODE|
+example_lt|REL|
+example_l|NODE|
+example_rt|REL|
+example_r|NODE|
 example|RDF|
 
--STATEMENT MATCH (s:example_resource_t) RETURN s.iri ORDER BY offset(id(s));
+-STATEMENT MATCH (s:example_r) RETURN s.iri ORDER BY offset(id(s));
 ---- 14
 :andy
 :literal
@@ -31,7 +31,7 @@ http://www.w3.org/1999/02/22-rdf-syntax-ns#type
 :brian
 
 
--STATEMENT MATCH (s:example_literal_t) RETURN s.iri ORDER BY s.id ;
+-STATEMENT MATCH (s:example_l) RETURN s.val ORDER BY s.id ;
 -CHECK_ORDER
 ---- 16
 12
@@ -51,12 +51,12 @@ Stewie
 male
 Brian
 
--STATEMENT MATCH (s:example_literal_t) RETURN s.iri,
-        to_int64(s.iri) + 1, to_int32(s.iri), to_int16(s.iri), to_int8(s.iri) * 2,
-        to_uint64(s.iri), to_uint32(s.iri), to_uint16(s.iri), to_uint8(s.iri),
-        to_double(s.iri), to_float(s.iri), to_bool(s.iri), to_blob(s.iri),
-        date(s.iri), timestamp(s.iri), cast(s.iri, "TIMESTAMP_NS"), cast(s.iri, "TIMESTAMP_MS"),
-        cast(s.iri, "TIMESTAMP_SEC"), cast(s.iri, "TIMESTAMP_TZ"), interval(s.iri), to_string(s.iri)
+-STATEMENT MATCH (s:example_l) RETURN s.val,
+        to_int64(s.val) + 1, to_int32(s.val), to_int16(s.val), to_int8(s.val) * 2,
+        to_uint64(s.val), to_uint32(s.val), to_uint16(s.val), to_uint8(s.val),
+        to_double(s.val), to_float(s.val), to_bool(s.val), to_blob(s.val),
+        date(s.val), timestamp(s.val), cast(s.val, "TIMESTAMP_NS"), cast(s.val, "TIMESTAMP_MS"),
+        cast(s.val, "TIMESTAMP_SEC"), cast(s.val, "TIMESTAMP_TZ"), interval(s.val), to_string(s.val)
         ORDER BY s.id LIMIT 6;
 -CHECK_ORDER
 ---- 6
@@ -67,7 +67,7 @@ True|||||||||||True|||||||||True
 1999-08-16|||||||||||||1999-08-16|||||||1999-08-16
 Peter||||||||||||||||||||Peter
 
--STATEMENT MATCH (s:example_literal_t) RETURN s.iri +1, s.iri * 2, s.iri * 2.0, s.iri = true, dayname(s.iri), concat(s.iri, 'a')
+-STATEMENT MATCH (s:example_l) RETURN s.val +1, s.val * 2, s.val * 2.0, s.val = true, dayname(s.val), concat(s.val, 'a')
         ORDER BY s.id LIMIT 6;
 -CHECK_ORDER
 ---- 6
@@ -78,7 +78,7 @@ Peter||||||||||||||||||||Peter
 ||||Monday|1999-08-16a
 |||||Petera
 
--STATEMENT MATCH (a:example_resource_t)-[e:example]->(b:example_resource_t) RETURN a.iri, e.iri, b.iri
+-STATEMENT MATCH (a:example_r)-[e:example]->(b:example_r) RETURN a.iri, e.iri, b.iri
 ---- 10
 :peter|http://www.w3.org/1999/02/22-rdf-syntax-ns#type|:Person
 :peter|:marriedTo|:lois
@@ -91,7 +91,7 @@ Peter||||||||||||||||||||Peter
 :stewie|http://www.w3.org/1999/02/22-rdf-syntax-ns#type|:Person
 :stewie|:hasParent|:lois
 
--STATEMENT MATCH (a:example_resource_t)-[e:example]->(b:example_literal_t) RETURN a.iri, e.iri, b.iri
+-STATEMENT MATCH (a:example_r)-[e:example]->(b:example_l) RETURN a.iri, e.iri, b.val
 ---- 16
 :andy|:literal|12
 :andy|:literal|-14.900000
@@ -109,3 +109,32 @@ Peter||||||||||||||||||||Peter
 :stewie|:forename|Stewie
 :stewie|:gender|male
 :brian|:forename|Brian
+
+-STATEMENT MATCH (a)-[e]->(b) RETURN a.iri, e.iri, b.iri, b.val
+---- 26
+:andy|:literal||-14.900000
+:andy|:literal||0.016630
+:andy|:literal||12
+:andy|:literal||1999-08-16
+:andy|:literal||True
+:brian|:forename||Brian
+:chris|:forename||Chris
+:chris|:gender||male
+:chris|:hasParent|:peter|
+:chris|http://www.w3.org/1999/02/22-rdf-syntax-ns#type|:Person|
+:lois|:forename||Lois
+:lois|:gender||female
+:lois|http://www.w3.org/1999/02/22-rdf-syntax-ns#type|:Person|
+:meg|:forename||Meg
+:meg|:gender||female
+:meg|:hasParent|:lois|
+:meg|:hasParent|:peter|
+:meg|http://www.w3.org/1999/02/22-rdf-syntax-ns#type|:Person|
+:peter|:forename||Peter
+:peter|:gender||male
+:peter|:marriedTo|:lois|
+:peter|http://www.w3.org/1999/02/22-rdf-syntax-ns#type|:Person|
+:stewie|:forename||Stewie
+:stewie|:gender||male
+:stewie|:hasParent|:lois|
+:stewie|http://www.w3.org/1999/02/22-rdf-syntax-ns#type|:Person|

--- a/test/test_files/rdf/spb1k.test
+++ b/test/test_files/rdf/spb1k.test
@@ -5,12 +5,15 @@
 
 -CASE SPB
 
--STATEMENT MATCH (s:spb_resource_t) RETURN COUNT(*);
+-STATEMENT MATCH (s:spb_r) RETURN COUNT(*);
 ---- 1
 567
--STATEMENT MATCH (s:spb_resource_t)-[]->(:spb_resource_t) WHERE s.iri = "http://www.bbc.co.uk/things/3#id" RETURN COUNT(*);
+-STATEMENT MATCH (s:spb_r)-[]->(:spb_r) WHERE s.iri = "http://www.bbc.co.uk/things/3#id" RETURN COUNT(*);
 ---- 1
 16
--STATEMENT MATCH (s:spb_resource_t)-[]->(:spb_literal_t) WHERE s.iri = "http://www.bbc.co.uk/things/3#id" RETURN COUNT(*);
+-STATEMENT MATCH (s:spb_r)-[]->(:spb_l) WHERE s.iri = "http://www.bbc.co.uk/things/3#id" RETURN COUNT(*);
 ---- 1
 7
+-STATEMENT MATCH (s)-[]->() WHERE s.iri = "http://www.bbc.co.uk/things/3#id" RETURN COUNT(*);
+---- 1
+23


### PR DESCRIPTION
- Rename RDF table names for simplicity.
- Rename RDF literal table iri column to val column so that it doesn't conflict with resource table iri column.