### PR TITLE
Rdf test fix

### DIFF
--- a/src/binder/bind/ddl/bind_create_rdf_graph.cpp
+++ b/src/binder/bind/ddl/bind_create_rdf_graph.cpp
@@ -49,6 +49,7 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     // Resource triple table.
     auto resourceTripleTableName = getRdfResourceTripleTableName(rdfGraphName);
     std::vector<PropertyInfo> resourceTripleProperties;
+    resourceTripleProperties.emplace_back(InternalKeyword::ID, *LogicalType::INTERNAL_ID());
     resourceTripleProperties.emplace_back(std::string(rdf::PID), *LogicalType::INTERNAL_ID());
     auto boundResourceTripleExtraInfo =
         std::make_unique<BoundExtraCreateRelTableInfo>(RelMultiplicity::MANY, RelMultiplicity::MANY,
@@ -58,6 +59,7 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     // Literal triple table.
     auto literalTripleTableName = getRdfLiteralTripleTableName(rdfGraphName);
     std::vector<PropertyInfo> literalTripleProperties;
+    literalTripleProperties.emplace_back(InternalKeyword::ID, *LogicalType::INTERNAL_ID());
     literalTripleProperties.emplace_back(std::string(rdf::PID), *LogicalType::INTERNAL_ID());
     auto boundLiteralTripleExtraInfo =
         std::make_unique<BoundExtraCreateRelTableInfo>(RelMultiplicity::MANY, RelMultiplicity::MANY,

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -78,7 +78,7 @@ void IndexLookup::fillOffsetArraysFromVector(transaction::Transaction* transacti
             for (auto i = 0u; i < numKeys; i++) {
                 auto pos = keyVector->state->selVector->selectedPositions[i];
                 auto key = keyVector->getValue<int64_t>(pos);
-                if (!info.copyNodeSharedState->indexBuilder->lookup(key, offsets[i])) {
+                if (!info.copyNodeSharedState->pkIndex->lookup(key, offsets[i])) {
                     throw RuntimeException(
                         ExceptionMessage::nonExistPKException(std::to_string(key)));
                 }
@@ -99,7 +99,7 @@ void IndexLookup::fillOffsetArraysFromVector(transaction::Transaction* transacti
             for (auto i = 0u; i < numKeys; i++) {
                 auto key = keyVector->getValue<ku_string_t>(
                     keyVector->state->selVector->selectedPositions[i]);
-                if (!info.copyNodeSharedState->indexBuilder->lookup(
+                if (!info.copyNodeSharedState->pkIndex->lookup(
                         key.getAsString().c_str(), offsets[i])) {
                     throw RuntimeException(
                         ExceptionMessage::nonExistPKException(key.getAsString()));

--- a/test/test_files/copy/copy_rdf.test
+++ b/test/test_files/copy/copy_rdf.test
@@ -1,7 +1,6 @@
 -GROUP CopyRDFTest
 -DATASET CSV copy-test/rdf
 -BUFFER_POOL_SIZE 536870912
--SKIP
 
 --
 

--- a/test/test_files/rdf/rdfox_example.test
+++ b/test/test_files/rdf/rdfox_example.test
@@ -1,6 +1,5 @@
 -GROUP RdfoxExample
 -DATASET TTL rdf/rdfox_example
--SKIP
 
 --
 

--- a/test/test_files/rdf/rdfox_example_in_memory.test
+++ b/test/test_files/rdf/rdfox_example_in_memory.test
@@ -1,6 +1,5 @@
 -GROUP RdfoxExampleInMemory
 -DATASET TTL EMPTY
--SKIP
 
 --
 

--- a/test/test_files/rdf/spb1k.test
+++ b/test/test_files/rdf/spb1k.test
@@ -1,6 +1,5 @@
 -GROUP RdfoxExample
 -DATASET TTL rdf/spb1k
--SKIP
 
 --
 

--- a/test/test_files/rdf/spb1k_in_memory.test
+++ b/test/test_files/rdf/spb1k_in_memory.test
@@ -1,6 +1,5 @@
 -GROUP Spb1kInMemory
 -DATASET TTL EMPTY
--SKIP
 
 --
 


### PR DESCRIPTION
- Fix rdf test
- Differentiate local global index builder. 
   - Global index builder: created during `initGlobalState` and stored in shared state. Responsible for 
      -  creating `IndexBuilderSharedState`
      -  inserting and flushing last node group during finalize 
   - Local index builder: created during `initLocalState` and stored in operator. Responsible for
     -   local inserting and flushing
 - Move copy node finalize logic to shared state.