### PR TITLE
Add UUID support to rust API

### DIFF
--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -250,7 +250,7 @@ template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UUID>(
     ArrowVector* vector, const main::DataTypeInfo& /*typeInfo*/, Value* value, std::int64_t pos) {
     auto offsets = (std::uint32_t*)vector->data.data();
-    auto str = UUID::toString(value->val.int128Val);
+    auto str = uuid_t::toString(value->val.int128Val);
     auto strLength = str.length();
     offsets[pos + 1] = offsets[pos] + strLength;
     vector->overflow.resize(offsets[pos + 1]);

--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -125,7 +125,7 @@ std::string TypeUtils::toString(const blob_t& val, void* /*valueVector*/) {
 // LCOV_EXCL_START
 template<>
 std::string TypeUtils::toString(const uuid_t& val, void* /*valueVector*/) {
-    return UUID::toString(val.value);
+    return val.toString();
 }
 // LCOV_EXCL_STOP
 

--- a/src/common/types/uuid.cpp
+++ b/src/common/types/uuid.cpp
@@ -3,12 +3,12 @@
 namespace kuzu {
 namespace common {
 
-void UUID::byteToHex(char byteVal, char* buf, uint64_t& pos) {
+void uuid_t::byteToHex(char byteVal, char* buf, uint64_t& pos) {
     buf[pos++] = HEX_DIGITS[(byteVal >> 4) & 0xf];
     buf[pos++] = HEX_DIGITS[byteVal & 0xf];
 }
 
-unsigned char UUID::hex2Char(char ch) {
+unsigned char uuid_t::hex2Char(char ch) {
     if (ch >= '0' && ch <= '9') {
         return ch - '0';
     }
@@ -21,7 +21,7 @@ unsigned char UUID::hex2Char(char ch) {
     return 0;
 };
 
-bool UUID::fromString(std::string str, int128_t& result) {
+bool uuid_t::fromString(std::string str, int128_t& result) {
     if (str.empty()) {
         return false;
     }
@@ -57,7 +57,7 @@ bool UUID::fromString(std::string str, int128_t& result) {
     return count == 32;
 }
 
-void UUID::toString(int128_t input, char* buf) {
+void uuid_t::toString(int128_t input, char* buf) {
     // Flip back before convert to string
     int64_t high = input.high ^ (int64_t(1) << 63);
     uint64_t pos = 0;

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -181,6 +181,11 @@ Value::Value(int128_t val_) : isNull_{false} {
     val.int128Val = val_;
 }
 
+Value::Value(uuid_t val_) : isNull_{false} {
+    dataType = LogicalType::UUID();
+    val.int128Val = val_.value;
+}
+
 Value::Value(float_t val_) : isNull_{false} {
     dataType = LogicalType::FLOAT();
     val.floatVal = val_;
@@ -314,7 +319,7 @@ void Value::copyValueFrom(const uint8_t* value) {
     } break;
     case LogicalTypeID::UUID: {
         val.int128Val = ((uuid_t*)value)->value;
-        strVal = UUID::toString(val.int128Val);
+        strVal = uuid_t::toString(val.int128Val);
     } break;
     case LogicalTypeID::STRING: {
         strVal = ((ku_string_t*)value)->getAsString();
@@ -460,7 +465,7 @@ std::string Value::toString() const {
     case LogicalTypeID::BLOB:
         return Blob::toString(reinterpret_cast<const uint8_t*>(strVal.c_str()), strVal.length());
     case LogicalTypeID::UUID:
-        return UUID::toString(val.int128Val);
+        return uuid_t::toString(val.int128Val);
     case LogicalTypeID::STRING:
         return strVal;
     case LogicalTypeID::RDF_VARIANT: {

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -163,14 +163,14 @@ void CastStringHelper::cast(const char* input, uint64_t len, blob_t& /*result*/,
 template<>
 void CastString::operation(const ku_string_t& input, uuid_t& result, ValueVector* /*result_vector*/,
     uint64_t /*rowToAdd*/, const CSVOption* /*option*/) {
-    result.value = UUID::fromString(input.getAsString());
+    result.value = uuid_t::fromString(input.getAsString());
 }
 
 // LCOV_EXCL_START
 template<>
 void CastStringHelper::cast(const char* input, uint64_t len, uuid_t& result,
     ValueVector* /*vector*/, uint64_t /*rowToAdd*/, const CSVOption* /*option*/) {
-    result.value = UUID::fromCString(input, len);
+    result.value = uuid_t::fromCString(input, len);
 }
 // LCOV_EXCL_STOP
 

--- a/src/include/common/types/uuid.h
+++ b/src/include/common/types/uuid.h
@@ -1,4 +1,7 @@
 #pragma once
+// pragma once doesn't appear to work properly on MSVC for this file
+#ifndef KUZU_COMMON_TYPES_UUID
+#define KUZU_COMMON_TYPES_UUID
 
 #include "common/types/int128_t.h"
 
@@ -6,10 +9,6 @@ namespace kuzu {
 namespace common {
 
 struct uuid_t {
-    int128_t value;
-};
-
-struct UUID {
     constexpr static uint8_t UUID_STRING_LENGTH = 36;
     constexpr static char HEX_DIGITS[] = "0123456789abcdef";
     static void byteToHex(char byteVal, char* buf, uint64_t& pos);
@@ -39,7 +38,11 @@ struct UUID {
         toString(input, buff);
         return std::string(buff, UUID_STRING_LENGTH);
     }
+    inline std::string toString() const { return toString(value); }
+
+    int128_t value;
 };
 
 } // namespace common
 } // namespace kuzu
+#endif

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -10,6 +10,7 @@
 #include "common/types/interval_t.h"
 #include "common/types/ku_list.h"
 #include "common/types/timestamp_t.h"
+#include "common/types/uuid.h"
 
 namespace kuzu {
 namespace common {
@@ -87,6 +88,10 @@ public:
      * @param val_ the int128_t value to set.
      */
     KUZU_API explicit Value(int128_t val_);
+    /**
+     * @param val_ the UUID value to set.
+     */
+    KUZU_API explicit Value(uuid_t val_);
     /**
      * @param val_ the double value to set.
      */

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -141,7 +141,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
     }
     case LogicalTypeID::UUID: {
         kuzu::common::int128_t result = value.getValue<kuzu::common::int128_t>();
-        std::string uuidString = kuzu::common::UUID::toString(result);
+        std::string uuidString = kuzu::common::uuid_t::toString(result);
         py::object UUID = py::module_::import("uuid").attr("UUID");
         return UUID(uuidString);
     }

--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -30,6 +30,7 @@ num-derive = "0.3"
 num-traits = "0.2"
 time = "0.3"
 arrow = {version="43", optional=true, default-features=false, features=["ffi"]}
+uuid = "1.6"
 
 [build-dependencies]
 cxx-build = "1.0"

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -169,6 +169,11 @@ std::unique_ptr<kuzu::common::Value> create_value_null(
 std::unique_ptr<kuzu::common::Value> create_value_int128_t(int64_t high, uint64_t low);
 std::unique_ptr<kuzu::common::Value> create_value_internal_id(uint64_t offset, uint64_t table);
 
+inline std::unique_ptr<kuzu::common::Value> create_value_uuid_t(int64_t high, uint64_t low) {
+    return std::make_unique<kuzu::common::Value>(
+        kuzu::common::uuid_t{kuzu::common::int128_t(low, high)});
+}
+
 template<typename T>
 std::unique_ptr<kuzu::common::Value> create_value(const T value) {
     return std::make_unique<kuzu::common::Value>(value);

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -82,6 +82,8 @@ pub(crate) mod ffi {
         STRUCT = 53,
         MAP = 54,
         UNION = 55,
+
+        UUID = 58,
     }
 
     #[namespace = "kuzu::common"]
@@ -346,6 +348,7 @@ pub(crate) mod ffi {
         fn create_value_date(value: i64) -> UniquePtr<Value>;
         fn create_value_interval(months: i32, days: i32, micros: i64) -> UniquePtr<Value>;
         fn create_value_int128_t(high: i64, low: u64) -> UniquePtr<Value>;
+        fn create_value_uuid_t(high: i64, low: u64) -> UniquePtr<Value>;
         fn create_value_internal_id(offset: u64, table: u64) -> UniquePtr<Value>;
 
         fn node_value_get_node_id(value: &Value) -> &Value;

--- a/tools/rust_api/src/logical_type.rs
+++ b/tools/rust_api/src/logical_type.rs
@@ -80,6 +80,7 @@ pub enum LogicalType {
     Union {
         types: Vec<(String, LogicalType)>,
     },
+    UUID,
 }
 
 impl From<&ffi::Value> for LogicalType {
@@ -172,6 +173,7 @@ impl From<&ffi::LogicalType> for LogicalType {
                         .collect(),
                 }
             }
+            LogicalTypeID::UUID => LogicalType::UUID,
             // Should be unreachable, as cxx will check that the LogicalTypeID enum matches the one
             // on the C++ side.
             x => panic!("Unsupported type {:?}", x),
@@ -208,7 +210,8 @@ impl From<&LogicalType> for cxx::UniquePtr<ffi::LogicalType> {
             | LogicalType::Blob
             | LogicalType::Node
             | LogicalType::Rel
-            | LogicalType::RecursiveRel => ffi::create_logical_type(typ.id()),
+            | LogicalType::RecursiveRel
+            | LogicalType::UUID => ffi::create_logical_type(typ.id()),
             LogicalType::VarList { child_type } => {
                 ffi::create_logical_type_var_list(child_type.as_ref().into())
             }
@@ -280,6 +283,7 @@ impl LogicalType {
             LogicalType::RecursiveRel => LogicalTypeID::RECURSIVE_REL,
             LogicalType::Map { .. } => LogicalTypeID::MAP,
             LogicalType::Union { .. } => LogicalTypeID::UNION,
+            LogicalType::UUID => LogicalTypeID::UUID,
         }
     }
 }


### PR DESCRIPTION
I added a `Value` constructor for UUIDs, as that was missing, and passing UUIDs as parameters in queries does otherwise appear to be supported.
That said, I'm seeing some inconsistencies between our UUID handling and the rust uuid crate. I think it's caused by this line: https://github.com/kuzudb/kuzu/blob/6c851234c2e7fbbc1e92e66d98c96f63e08528f6/src/common/types/uuid.cpp#L61-L62, which I guess is supposed to reverse the flip in fromString: https://github.com/kuzudb/kuzu/blob/6c851234c2e7fbbc1e92e66d98c96f63e08528f6/src/common/types/uuid.cpp#L55-L56
However, the rust API is passing and receiving values directly as int128_t. While flipping the same bit when passing the values to C++ fixes those issues, I'm wary that this isn't consistent with the way UUIDs can be constructed through the C++ API. E.g. you could create a uuid with the same numerical value via the C++ and rust APIs and you'd get different results when querying the value, or indeed just between creating the values in the C++ API from int128_t compared to using the fromString method, as I gather that uuids have [a standardized layout and string representation](https://datatracker.ietf.org/doc/html/rfc4122). ~~If keeping the adjustment to the format on disk is necessary (I don't really understand the purpose),~~ *(Update: we store uuids as int128 instead of uint128, so the order is off as values which should be in the large half are negative instead)* we could hide the implementation more and make sure that the bit flip is done even when creating uuids from integers.

Also fixed a bug in how negative int128 values are passed from C++ to Rust code and vice versa, as that was exposed by the test UUID values.