### PR TITLE
Fix issue 2643

### DIFF
--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -59,6 +59,7 @@ public:
     std::unique_ptr<LocalVectorCollection> getStructChildVectorCollection(
         common::struct_field_idx_t idx);
 
+    // TODO(Guodong): Change this interface to take an extra `SelVector` or `DataChunkState`.
     common::row_idx_t append(common::ValueVector* vector);
 
 private:

--- a/src/storage/local_storage/local_table.cpp
+++ b/src/storage/local_storage/local_table.cpp
@@ -55,6 +55,7 @@ std::unique_ptr<LocalVectorCollection> LocalVectorCollection::getStructChildVect
     for (auto i = 0u; i < numRows; i++) {
         auto fieldVector =
             common::StructVector::getFieldVector(getLocalVector(i)->getVector(), idx);
+        fieldVector->state->selVector->selectedPositions[0] = i & (DEFAULT_VECTOR_CAPACITY - 1);
         childCollection->append(fieldVector.get());
     }
     return childCollection;

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -319,3 +319,21 @@ t2
         RETURN ret;
 ---- 1
 {_ID: 0:0, _LABEL: T, id: t1}
+
+-CASE 2643
+-STATEMENT create node table person (x SERIAL, y STRUCT(a INT64, b INT64), PRIMARY KEY(x));
+---- ok
+-STATEMENT CREATE (:person {y: {a: 1, b: 2}}), (:person {y: {a: 3, b: 4}});
+---- ok
+-STATEMENT MATCH (a:person) RETURN a.*;
+---- 2
+0|{a: 1, b: 2}
+1|{a: 3, b: 4}
+-STATEMENT create node table organisation (x INT64, y STRUCT(a INT64, b INT64), PRIMARY KEY(x));
+---- ok
+-STATEMENT CREATE (:organisation {x: 10, y: {a: 1, b: 2}}), (:organisation {x: 11, y: {a: 3, b: 4}});
+---- ok
+-STATEMENT MATCH (a:organisation) RETURN a.*;
+---- 2
+10|{a: 1, b: 2}
+11|{a: 3, b: 4}


### PR DESCRIPTION
There was a bug when collecting struct child fields from local vector collection.

In the longer term, we should revisit and refactor the use of `ValueVector`'s state in the local storage. The current usage is not intuitive.