### PR TITLE
Fix top-k flat/unflat bug

### DIFF
--- a/src/include/processor/operator/order_by/sort_state.h
+++ b/src/include/processor/operator/order_by/sort_state.h
@@ -71,7 +71,12 @@ public:
     uint64_t scan(std::vector<common::ValueVector*> vectorsToRead);
 
 private:
-    bool scanSingleTuple;
+    bool scanSingleTuple(std::vector<common::ValueVector*> vectorsToRead) const;
+
+    void applyLimitOnResultVectors(std::vector<common::ValueVector*> vectorsToRead);
+
+private:
+    bool hasUnflatColInPayload;
     uint32_t payloadIdxOffset;
     std::vector<uint32_t> colsToScan;
     std::unique_ptr<uint8_t*[]> tuplesToRead;
@@ -80,6 +85,7 @@ private:
     uint32_t nextTupleIdxToReadInMergedKeyBlock;
     uint64_t endTuplesIdxToReadInMergedKeyBlock;
     std::vector<FactorizedTable*> payloadTables;
+    uint64_t limitNumber;
 };
 
 } // namespace processor

--- a/test/test_files/tinysnb/order_by/single_label.test
+++ b/test/test_files/tinysnb/order_by/single_label.test
@@ -298,3 +298,31 @@ Elizabeth
 2021
 2020
 2020
+
+-LOG OrderByFlatUnflat
+-STATEMENT MATCH (p:person)-[:knows]->(p1:person) return p.ID, p1.ID ORDER BY p.ID, p1.ID limit 13
+-CHECK_ORDER
+-ENUMERATE
+---- 13
+0|2
+0|3
+0|5
+2|0
+2|3
+2|5
+3|0
+3|2
+3|5
+5|0
+5|2
+5|3
+7|8
+
+-LOG OrderByFlatUnflat1
+-STATEMENT MATCH (p:person)-[:knows]->(p1:person) return p.ID, p1.ID ORDER BY p.ID limit 3
+-CHECK_ORDER
+-ENUMERATE
+---- 3
+0|2
+0|3
+0|5


### PR DESCRIPTION
close #2648 
This PR solves a flat/unflat bug in top-k.
## Bug:
Assume we are planning to read two columns(a, b) from a factorized table to two unflat vectors ,  where `a` is a flat column and `b` is an unflat column. We don't duplicate the values in column `a` as the number of `b` values when reading from the factorized table.
E.g. a: 2, b: [1,4,5]
The result vector a, b should look like:
a: [2,2,2] (2 is duplicated 3 times in a)
b: [1,4,5]
## Solution:
Instead of blindly creating unflat vectors when reading from flat columns, we now create flat vectors.
