### PR TITLE
Replace slack with discord for community page

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
   <a href="https://codecov.io/gh/kuzudb/kuzu" >
     <img src="https://codecov.io/github/kuzudb/kuzu/branch/master/graph/badge.svg?token=N1AT6H79LM"/>
   </a>
-  <a href="https://join.slack.com/t/kuzudb/shared_invite/zt-1w0thj6s7-0bLaU8Sb~4fDMKJ~oejG_g">
-    <img src="https://img.shields.io/badge/Slack-chat%20with%20us-informational?logo=slack" alt="slack" />
+  <a href="https://discord.gg/cnxYf3Yc">
+    <img src="https://img.shields.io/discord/1196510116388806837?logo=discord" alt="discord" />
   </a>
   <a href="https://twitter.com/kuzudb">
     <img src="https://img.shields.io/badge/follow-@kuzudb-1DA1F2?logo=twitter" alt="twitter">
@@ -95,4 +95,4 @@ You can use the following BibTeX citation:
 ```
 
 ## Contact Us
-You can contact us at [contact@kuzudb.com](mailto:contact@kuzudb.com) or [join our Slack workspace](https://join.slack.com/t/kuzudb/shared_invite/zt-1w0thj6s7-0bLaU8Sb~4fDMKJ~oejG_g).
+You can contact us at [contact@kuzudb.com](mailto:contact@kuzudb.com) or [join our Discord community](https://discord.gg/cnxYf3Yc).


### PR DESCRIPTION
Now that we have a Discord server up and running, this PR replaces slack with discord for community page.
@ray6080 @mewim 