### PR TITLE
Changed way hash formatting worked

### DIFF
--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -30,7 +30,6 @@ struct TestStatement {
     std::optional<std::string> connName;
     bool reloadDBFlag = false;
     bool expectHash = false;
-    std::string hashSortType;
     std::string expectedHashValue;
 };
 

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -24,7 +24,7 @@ private:
     static std::vector<std::string> convertResultToString(
         main::QueryResult& queryResult, bool checkOutputOrder = false);
     static std::string convertResultToMD5Hash(main::QueryResult& queryResult,
-        std::string sortType); // returns hash and number of values hashed
+        bool checkOutputOrder); // returns hash and number of values hashed
     static bool checkPlanResult(std::unique_ptr<main::QueryResult>& result,
         TestStatement* statement, const std::string& planStr, uint32_t planIndex);
 };

--- a/test/test_files/md5testing/md5.test
+++ b/test/test_files/md5testing/md5.test
@@ -22,14 +22,9 @@
 -STATEMENT CREATE (:T {VAL:100}), (:T {VAL: 50}), (:T {VAL: -10000}), (:T {VAL: 755})
 ---- ok
 -STATEMENT MATCH (v:T) return v.VAL, v.ID ORDER BY v.ID;
+-CHECK_ORDER
 ---- hash
-4 tuples hashing to 98e9f812cbfd569d8d1c3cd9bde37377
--STATEMENT MATCH (v:T) return v.VAL, v.ID;
----- hash rowsort
-4 tuples hashing to e23ff6de40c12642a8d240b3b877059f
--STATEMENT MATCH (v:T) return v.VAL, v.ID;
----- hash valuesort
-4 tuples hashing to 2d9521c989e4577889c0a7bc00f0362e
+4 tuples hashing to 0fb5957a46751ebf7ff2e38fe85179c6
 
 -CASE MD5TinyTest03
 -STATEMENT CREATE NODE TABLE Person(NAME STRING, PRIMARY KEY(NAME));
@@ -46,7 +41,7 @@
 ---- ok
 -STATEMENT MATCH (p:Person)-[]->(r:Repository) RETURN p.NAME, r.NAME;
 ---- hash
-1 tuples hashing to c440c38754246f863d3d1a662100d4a1
+1 tuples hashing to 460ab403a6a4746e3a10027f032956ed
 
 -CASE MD5NullTest
 -STATEMENT CREATE NODE TABLE Person(NAME STRING, AGE INT, PRIMARY KEY(NAME));
@@ -54,5 +49,6 @@
 -STATEMENT CREATE (:Person {NAME: "A", AGE: 20}), (:Person {NAME: "B", AGE: NULL});
 ---- ok
 -STATEMENT MATCH (p:Person) RETURN p.NAME, p.AGE ORDER BY p.AGE;
+-CHECK_ORDER
 ---- hash
-2 tuples hashing to c5c799b6e60c80fe1d2aa7355ccd7dc9
+2 tuples hashing to 25116b5dae5d1e9a1a4cbd2b96bdf227

--- a/test/test_files/shortest_path/all_shortest_path.test
+++ b/test/test_files/shortest_path/all_shortest_path.test
@@ -17,8 +17,9 @@
 
 -LOG SingleSource
 -STATEMENT MATCH (a:person)-[r:knows* ALL SHORTEST 1..30]->(b:person) WHERE a.ID = 10 RETURN b.ID, length(r), COUNT(*) ORDER BY b.ID
+-CHECK_ORDER
 ---- hash
-7 tuples hashed to 4aac03f739ba75ec2f5fdf2a418097c8
+7 tuples hashed to 11065b8084b9a2b8ebe386d22d287117
 
 #---- 7
 #0|1|1

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -111,18 +111,10 @@ void TestParser::extractExpectedResult(TestStatement* statement) {
     } else if (result.substr(0, 4) == "hash") {
         statement->expectHash = true;
         checkMinimumParams(1);
-        tokenize();
-        if (currentToken.params.size() > 2) {
-            statement->hashSortType = currentToken.params[2];
-        } else {
-            statement->hashSortType = "";
-        }
         nextLine();
         tokenize();
         statement->expectedNumTuples = stoi(currentToken.params[0]);
         statement->expectedHashValue = currentToken.params.back();
-        statement->checkOutputOrder =
-            true; // this is required because the output order is encoded in the md5 hash
     } else {
         checkMinimumParams(1);
         statement->expectedNumTuples = stoi(result);

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -102,7 +102,7 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
         TestRunner::convertResultToString(*result, statement->checkOutputOrder);
     if (statement->expectHash) {
         std::string resultHash =
-            TestRunner::convertResultToMD5Hash(*result, statement->hashSortType);
+            TestRunner::convertResultToMD5Hash(*result, statement->checkOutputOrder);
         if (resultTuples.size() == result->getNumTuples() &&
             resultHash == statement->expectedHashValue &&
             resultTuples.size() == statement->expectedNumTuples) {
@@ -145,67 +145,20 @@ std::vector<std::string> TestRunner::convertResultToString(
     }
     if (!checkOutputOrder) {
         sort(actualOutput.begin(), actualOutput.end());
+        // NOTE: If you wish to change this sorting in a
+        // way that alters its result, you may break existing
+        // hashed test cases
     }
     return actualOutput;
 }
 
-std::string TestRunner::convertResultToMD5Hash(QueryResult& queryResult, std::string sortType) {
+std::string TestRunner::convertResultToMD5Hash(QueryResult& queryResult, bool checkOutputOrder) {
     queryResult.resetIterator();
     MD5 hasher;
-    if (sortType == "nosort" || sortType == "") {
-        while (queryResult.hasNext()) {
-            const auto tuple = queryResult.getNext();
-            for (uint32_t i = 0; i < tuple->len(); i++) {
-                const auto val = tuple->getValue(i);
-                if (val->isNull()) {
-                    hasher.addToMD5("NULL\n");
-                } else {
-                    hasher.addToMD5(val->toString().c_str());
-                    hasher.addToMD5("\n");
-                }
-            }
-        }
-    } else if (sortType == "rowsort") {
-        std::vector<std::vector<std::string>> buffer;
-        while (queryResult.hasNext()) {
-            const auto tuple = queryResult.getNext();
-            buffer.push_back(std::vector<std::string>());
-            for (uint32_t i = 0; i < tuple->len(); i++) {
-                const auto val = tuple->getValue(i);
-                if (val->isNull()) {
-                    buffer.back().push_back("NULL");
-                } else {
-                    buffer.back().push_back(val->toString());
-                }
-            }
-        }
-        sort(buffer.begin(), buffer.end());
-        for (const auto& i : buffer) {
-            for (const auto& i2 : i) {
-                hasher.addToMD5(i2.c_str());
-                hasher.addToMD5("\n");
-            }
-        }
-    } else if (sortType == "valuesort") {
-        std::vector<std::string> buffer;
-        while (queryResult.hasNext()) {
-            const auto tuple = queryResult.getNext();
-            for (uint32_t i = 0; i < tuple->len(); i++) {
-                const auto val = tuple->getValue(i);
-                if (val->isNull()) {
-                    buffer.push_back("NULL");
-                } else {
-                    buffer.push_back(val->toString());
-                }
-            }
-        }
-        sort(buffer.begin(), buffer.end());
-        for (const auto& i : buffer) {
-            hasher.addToMD5(i.c_str());
-            hasher.addToMD5("\n");
-        }
-    } else {
-        return "error: invalid sort type \"" + sortType + "\"";
+    std::vector<std::string> stringRep = convertResultToString(queryResult, checkOutputOrder);
+    for (std::string line : stringRep) {
+        hasher.addToMD5(line.c_str());
+        hasher.addToMD5("\n");
     }
     return std::string(hasher.finishMD5());
 }


### PR DESCRIPTION
This change was made to avoid diverging from the established output format.

In SQLLogicTest, outputs are formatted in the following way:

Values are printed line by line. For example, a row containing the values (1, 2, 3) would be printed as
```
1
2
3
```
As opposed to how we do format our expected output in our testing framework, which is
```
1|2|3
```

Originally, the hash accounted for this, and the resulting hash was created from the first formatting method. In hindsight, this was a poor decision. Allowing for two different output formats ultimately adds no value to the testing framework outside of some compatibility with SQLLogicTest. It can also be confusing to people not familiar with the CypherLogicTest project who are trying to write their own unrelated tests. 

In this pull request, the hash no longer accounts for this new formatting. In the future, translated test cases in CypherLogicTest will all follow our own formatting rules.