### PR TITLE
Switch to permanent invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://codecov.io/gh/kuzudb/kuzu" >
     <img src="https://codecov.io/github/kuzudb/kuzu/branch/master/graph/badge.svg?token=N1AT6H79LM"/>
   </a>
-  <a href="https://discord.gg/cnxYf3Yc">
+  <a href="https://discord.gg/VtX2gw9Rug">
     <img src="https://img.shields.io/discord/1196510116388806837?logo=discord" alt="discord" />
   </a>
   <a href="https://twitter.com/kuzudb">


### PR DESCRIPTION
The earlier version had an in invite link to Discord which would expire in 7 days. This one never expires.