### PR TITLE
Fix issue-2675

### DIFF
--- a/test/test_files/issue/play.test
+++ b/test/test_files/issue/play.test
@@ -1,0 +1,18 @@
+-GROUP IssueTest
+-DATASET CSV empty
+
+--
+
+-CASE 2675
+-STATEMENT CREATE NODE TABLE V1 (id STRING, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE NODE TABLE V2 (id STRING, PRIMARY KEY (id));
+---- ok
+-STATEMENT CREATE REL TABLE E(FROM V1 TO V2);
+---- ok
+-STATEMENT CREATE (v21: V2 {id: "v21"})-[:E]->(v11:V1 {id: "v11"});
+---- error
+Binder exception: Query node v21 violates schema. Expected labels are V1.
+-STATEMENT CREATE (v22:V2 {id: "v22"})-[:E]->(v23: V2 {id: "v23"});
+---- error
+Binder exception: Query node v22 violates schema. Expected labels are V1.

--- a/test/test_files/tck/match/match3.test
+++ b/test/test_files/tck/match/match3.test
@@ -91,7 +91,7 @@
 ---- ok
 -STATEMENT CREATE (a)-[:T]->(b1), (a)-[:T]->(b2)
 ---- error
-Binder exception: Create node a with multiple node labels is not supported.
+Binder exception: Create node b2 with multiple node labels is not supported.
 
 # Matching nodes with many labels
 #-CASE Scenario7

--- a/test/test_files/tck/match/match4.test
+++ b/test/test_files/tck/match/match4.test
@@ -153,8 +153,7 @@ Binder exception: Bind relationship r to relationship with same name is not supp
 -STATEMENT CREATE (a:A), (b:B), (c:C)
            CREATE (a)-[:Y]->(b),
                   (b)-[:Y]->(c)
----- error
-Binder exception: Create rel  with multiple rel labels or bound by multiple node labels is not supported.
+---- ok
 -STATEMENT  MATCH ()-[r1]->()-[r2]->()
             WITH [r1, r2] AS rs
             LIMIT 1

--- a/test/test_files/tinysnb/exception/multi_label_update.test
+++ b/test/test_files/tinysnb/exception/multi_label_update.test
@@ -8,6 +8,6 @@
 ---- error
 Binder exception: Create node a with multiple node labels is not supported.
 
--STATEMENT MATCH (a:person), (b:person:organisation) CREATE (a)-[e:knows]->(b)
+-STATEMENT MATCH (a:person), (b:organisation) CREATE (a)-[e:studyAt|:workAt]->(b)
 ---- error
 Binder exception: Create rel e with multiple rel labels or bound by multiple node labels is not supported.

--- a/test/test_files/tinysnb/match/multi_label.test
+++ b/test/test_files/tinysnb/match/multi_label.test
@@ -61,4 +61,4 @@
 -LOG MultiLabelNodePruning
 -STATEMENT MATCH (a:person)-[:knows]->(b)<-[:studyAt]-(c) RETURN COUNT(*)
 ---- error
-Binder exception: Cannot find a label for node b that connects to all of its neighbour relationships.
+Binder exception: Query node b violates schema. Expected labels are organisation.


### PR DESCRIPTION
Fix issue #2675.

The bug is because insertion didn't check query graph pattern against schema constraint. It makes me think the storage backend should assert inserted data (specifically `table_id`) while inserting.

This PR also improves error message to be more readable.