### PR TITLE
Check unused `WriteInternalIDValuesToPage`, and fix copy of rel id

### DIFF
--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -43,21 +43,17 @@ private:
 
 struct WriteInternalIDValuesToPage {
     WriteInternalIDValuesToPage() : compressedWriter{LogicalType(LogicalTypeID::INTERNAL_ID)} {}
-    void operator()(uint8_t* frame, uint16_t posInFrame, const uint8_t* data, uint32_t dataOffset,
-        offset_t numValues, const CompressionMetadata& metadata) {
-        auto internalIDValues = reinterpret_cast<const internalID_t*>(data);
-
-        for (auto i = 0u; i < numValues; i++) {
-            compressedWriter(frame, posInFrame,
-                reinterpret_cast<const uint8_t*>(&internalIDValues[dataOffset + i].offset),
-                0 /*dataOffset*/, 1 /*numValues*/, metadata);
-        }
+    void operator()(uint8_t* /*frame*/, uint16_t /*posInFrame*/, const uint8_t* /*data*/,
+        uint32_t /*dataOffset*/, offset_t /*numValues*/, const CompressionMetadata& /*metadata*/) {
+        KU_ASSERT(false);
     }
     void operator()(uint8_t* frame, uint16_t posInFrame, ValueVector* vector,
         uint32_t offsetInVector, const CompressionMetadata& metadata) {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
-        compressedWriter(
-            frame, posInFrame, vector->getData(), offsetInVector, 1 /*numValues*/, metadata);
+        compressedWriter(frame, posInFrame,
+            reinterpret_cast<const uint8_t*>(
+                &vector->getValue<internalID_t>(offsetInVector).offset),
+            0 /*dataOffset*/, 1 /*numValues*/, metadata);
     }
 
 private:

--- a/test/test_files/update_rel/create_empty.test
+++ b/test/test_files/update_rel/create_empty.test
@@ -25,6 +25,41 @@
 ---- 1
 10|12
 
+-CASE CreateOneToOneInBatch
+-STATEMENT create node table animal(id int64, primary key(id));
+---- ok
+-STATEMENT create node table person(id int64, primary key(id));
+---- ok
+-STATEMENT create rel table own(from person to animal, ONE_ONE);
+---- ok
+-STATEMENT create (:person {id:1});
+---- ok
+-STATEMENT create (:animal {id:1});
+---- ok
+-STATEMENT create (:person {id:2});
+---- ok
+-STATEMENT create (:animal {id:2});
+---- ok
+-STATEMENT create (:person {id:3});
+---- ok
+-STATEMENT create (:animal {id:3});
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT match (a:animal), (p:person) where a.id=1 and p.id=1 create (p)-[e:own]->(a);
+---- ok
+-STATEMENT match (a:animal), (p:person) where a.id=2 and p.id=2 create (p)-[e:own]->(a);
+---- ok
+-STATEMENT match (a:animal), (p:person) where a.id=3 and p.id=3 create (p)-[e:own]->(a);
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT match (a)-[e]->(b) return e;
+---- 3
+(1:0)-{_LABEL: own, _ID: 2:0}->(0:0)
+(1:1)-{_LABEL: own, _ID: 2:1}->(0:1)
+(1:2)-{_LABEL: own, _ID: 2:2}->(0:2)
+
 -CASE CreateOneToOneRelOnLargeNodeTable
 -STATEMENT CREATE NODE TABLE N1(ID INT64, PRIMARY KEY(ID));
 ---- ok


### PR DESCRIPTION
`WriteInternalIDValuesToPage` is not correctly copying offsets to column pages. I added a test case that can trigger `offsetInVector` not equal to 0, which triggers incorrectly writing of rel IDs.