### PR TITLE
Don't use bitpacking for the full bit width

### DIFF
--- a/src/include/storage/compression/sign_extend.h
+++ b/src/include/storage/compression/sign_extend.h
@@ -20,6 +20,8 @@
 #include <cstdint>
 #include <type_traits>
 
+#include "common/assert.h"
+
 namespace kuzu {
 namespace storage {
 
@@ -38,6 +40,7 @@ T Load(const uint8_t* ptr) {
 // Sign bit extension
 template<class T, class T_U = typename std::make_unsigned<T>::type, uint64_t CHUNK_SIZE>
 static void SignExtend(uint8_t* dst, uint8_t width) {
+    KU_ASSERT(width < sizeof(T) * 8);
     T const mask = T_U(1) << (width - 1);
     for (uint64_t i = 0; i < CHUNK_SIZE; ++i) {
         T value = Load<T>(dst + i * sizeof(T));

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -434,6 +434,13 @@ template<typename T>
 uint64_t IntegerBitpacking<T>::compressNextPage(const uint8_t*& srcBuffer,
     uint64_t numValuesRemaining, uint8_t* dstBuffer, uint64_t dstBufferSize,
     const struct CompressionMetadata& metadata) const {
+    // TODO(bmwinger): this is hacky; we need a better system for dynamically choosing between
+    // algorithms when compressing
+    if (metadata.compression == CompressionType::UNCOMPRESSED) {
+        return Uncompressed(sizeof(T)).compressNextPage(
+            srcBuffer, numValuesRemaining, dstBuffer, dstBufferSize, metadata);
+    }
+    KU_ASSERT(metadata.compression == CompressionType::INTEGER_BITPACKING);
     auto header = BitpackHeader::readHeader(metadata.data);
     auto bitWidth = header.bitWidth;
 

--- a/test/test_files/update_node/create_empty.test
+++ b/test/test_files/update_node/create_empty.test
@@ -99,3 +99,78 @@ foobar|
 ---- 2
 fe38f9dc-f761-4184-8b8b
 foobar-ewe-j323-8nd*-ewew
+
+-CASE CreateInt8MaxWidth
+-STATEMENT CREATE NODE TABLE test(id SERIAL, value INT8, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {value: 127})
+---- ok
+-STATEMENT CREATE (t:test {value: 0})
+---- ok
+-STATEMENT CREATE (t:test {value: -128})
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.value
+---- 3
+127
+0
+-128
+
+-CASE CreateInt16MaxWidth
+-STATEMENT CREATE NODE TABLE test(id SERIAL, value INT16, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {value: 32767})
+---- ok
+-STATEMENT CREATE (t:test {value: 0})
+---- ok
+-STATEMENT CREATE (t:test {value: -32768})
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.value
+---- 3
+32767
+0
+-32768
+
+-CASE CreateInt32MaxWidth
+-STATEMENT CREATE NODE TABLE test(id SERIAL, value INT32, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {value:2147483647})
+---- ok
+-STATEMENT CREATE (t:test {value: 0})
+---- ok
+-STATEMENT CREATE (t:test {value: -2147483648})
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.value
+---- 3
+2147483647
+0
+-2147483648
+
+-CASE CreateInt64MaxWidth
+-STATEMENT CREATE NODE TABLE test(id SERIAL, value INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {value:9223372036854775807})
+---- ok
+-STATEMENT CREATE (t:test {value: 0})
+---- ok
+-STATEMENT CREATE (t:test {value: -9223372036854775808})
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.value
+---- 3
+9223372036854775807
+0
+-9223372036854775808
+
+-CASE CreateInt128MaxWidth
+-STATEMENT CREATE NODE TABLE test(id SERIAL, value INT128, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {value:170141183460469231731687303715884105727})
+---- ok
+-STATEMENT CREATE (t:test {value: 0})
+---- ok
+-STATEMENT CREATE (t:test {value: -170141183460469231731687303715884105727})
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.value
+---- 3
+170141183460469231731687303715884105727
+0
+-170141183460469231731687303715884105727


### PR DESCRIPTION
SignExtend produces undefined behaviour if the bitwidth is equal to the size of the type in bits, and it's also somewhat slower than treating the data as uncompressed.

I've just added it as a special case in the IntegerBitpacking compression code since that was simple. Decompression already uses the metadata to determine how to decompress, but we should probably have something similar for compression, in addition to a more generic way of determining the type of compression to use rather than just having algorithm-specific functions.

Fixes #2711 (or at least, it avoids calling SignExtend under those circumstances; it's better for performance reasons to treat the data as uncompressed anyway).