### PR TITLE
Rust value tests

### DIFF
--- a/extension/duckdb/src/duckdb_type_converter.cpp
+++ b/extension/duckdb/src/duckdb_type_converter.cpp
@@ -65,9 +65,6 @@ common::LogicalType DuckDBTypeConverter::convertDuckDBType(std::string typeStr) 
         return LogicalType::STRUCT(parseStructTypeInfo(typeStr));
     } else if (typeStr.starts_with("UNION")) {
         auto unionFields = parseStructTypeInfo(typeStr);
-        auto unionTagField =
-            StructField(UnionType::TAG_FIELD_NAME, LogicalType(UnionType::TAG_FIELD_TYPE));
-        unionFields.insert(unionFields.begin(), std::move(unionTagField));
         return LogicalType::UNION(std::move(unionFields));
     } else if (typeStr.starts_with("MAP")) {
         auto leftBracketPos = typeStr.find('(');

--- a/src/common/arrow/arrow_type.cpp
+++ b/src/common/arrow/arrow_type.cpp
@@ -121,7 +121,6 @@ LogicalType ArrowConverter::fromArrowSchema(const ArrowSchema* schema) {
             return LogicalType::MAP(LogicalType(fromArrowSchema(schema->children[0]->children[0])),
                 LogicalType(fromArrowSchema(schema->children[0]->children[1])));
         case 'u': {
-            structFields.emplace_back(UnionType::TAG_FIELD_NAME, LogicalType::INT8());
             for (int64_t i = 0; i < schema->n_children; i++) {
                 structFields.emplace_back(std::to_string(i),
                     LogicalType(fromArrowSchema(schema->children[i])));

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1248,11 +1248,7 @@ LogicalType parseMapType(const std::string& trimmedStr) {
 }
 
 LogicalType parseUnionType(const std::string& trimmedStr) {
-    auto unionFields = parseStructTypeInfo(trimmedStr);
-    auto unionTagField =
-        StructField(UnionType::TAG_FIELD_NAME, LogicalType(UnionType::TAG_FIELD_TYPE));
-    unionFields.insert(unionFields.begin(), std::move(unionTagField));
-    return LogicalType::UNION(std::move(unionFields));
+    return LogicalType::UNION(parseStructTypeInfo(trimmedStr));
 }
 
 LogicalType parseDecimalType(const std::string& trimmedStr) {
@@ -1311,6 +1307,9 @@ LogicalType LogicalType::RDF_VARIANT() {
 }
 
 LogicalType LogicalType::UNION(std::vector<StructField>&& fields) {
+    // TODO(Ziy): Use UINT8 to represent tag value.
+    fields.insert(fields.begin(),
+        StructField(UnionType::TAG_FIELD_NAME, LogicalType(UnionType::TAG_FIELD_TYPE)));
     return LogicalType(LogicalTypeID::UNION, std::make_unique<StructTypeInfo>(std::move(fields)));
 }
 

--- a/src/common/types/value/nested.cpp
+++ b/src/common/types/value/nested.cpp
@@ -12,7 +12,7 @@ uint32_t NestedVal::getChildrenSize(const Value* val) {
 
 Value* NestedVal::getChildVal(const Value* val, uint32_t idx) {
     if (idx > val->childrenSize) {
-        throw RuntimeException("NestedVal::getChildPointer index out of bound.");
+        throw RuntimeException("NestedVal::getChildVal index out of bound.");
     }
     return val->children[idx].get();
 }

--- a/src/function/union/union_value_function.cpp
+++ b/src/function/union/union_value_function.cpp
@@ -10,8 +10,6 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     Function* /*function*/) {
     KU_ASSERT(arguments.size() == 1);
     std::vector<StructField> fields;
-    // TODO(Ziy): Use UINT8 to represent tag value.
-    fields.emplace_back(UnionType::TAG_FIELD_NAME, LogicalType(UnionType::TAG_FIELD_TYPE));
     if (arguments[0]->getDataType().getLogicalTypeID() == common::LogicalTypeID::ANY) {
         arguments[0]->cast(LogicalType::STRING());
     }

--- a/tools/rust_api/src/logical_type.rs
+++ b/tools/rust_api/src/logical_type.rs
@@ -240,8 +240,6 @@ impl From<&LogicalType> for cxx::UniquePtr<ffi::LogicalType> {
             LogicalType::Union { types } => {
                 let mut builder = ffi::create_type_list();
                 let mut names = vec![];
-                names.push("tag".to_string());
-                builder.pin_mut().insert((&LogicalType::Int64).into());
                 for (name, typ) in types {
                     names.push(name.clone());
                     builder.pin_mut().insert(typ.into());


### PR DESCRIPTION
I've re-enabled some rust tests which had been disabled due to them not being fully supported as they now appear to be working.
Passing unions as parameters still doesn't seem to be supported, however I noticed a change to how union tags are handled which hadn't been propagated to the rust API, so I moved the tag type details into the `LogicalType::UNION` function to handle them all in one place.