### PR TITLE
Rework a part of column interfaces

### DIFF
--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "storage/store/column.h"
+
+using namespace kuzu::common;
+using namespace kuzu::transaction;
+
+namespace kuzu {
+namespace storage {
+
+class NullColumn final : public Column {
+    friend StructColumn;
+
+public:
+    // Page size must be aligned to 8 byte chunks for the 64-bit NullMask algorithms to work
+    // without the possibility of memory errors from reading/writing off the end of a page.
+    static_assert(PageUtils::getNumElementsInAPage(1, false /*requireNullColumn*/) % 8 == 0);
+
+    NullColumn(std::string name, page_idx_t metaDAHPageIdx, BMFileHandle* dataFH,
+        BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal, Transaction* transaction,
+        RWPropertyStats propertyStatistics, bool enableCompression);
+
+    void scan(
+        Transaction* transaction, ValueVector* nodeIDVector, ValueVector* resultVector) override;
+    void scan(transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx,
+        offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
+        uint64_t offsetInVector) override;
+    void scan(transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx,
+        ColumnChunk* columnChunk, common::offset_t startOffset = 0,
+        common::offset_t endOffset = common::INVALID_OFFSET) override;
+
+    void lookup(
+        Transaction* transaction, ValueVector* nodeIDVector, ValueVector* resultVector) override;
+
+    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;
+
+    bool isNull(transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx,
+        offset_t offsetInChunk);
+    void setNull(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk);
+
+    void write(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk,
+        ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
+
+    bool canCommitInPlace(Transaction* transaction, node_group_idx_t nodeGroupIdx,
+        LocalVectorCollection* localChunk, const offset_to_row_idx_t& insertInfo,
+        const offset_to_row_idx_t& updateInfo) override;
+    void commitLocalChunkInPlace(Transaction* /*transaction*/, node_group_idx_t nodeGroupIdx,
+        LocalVectorCollection* localChunk, const offset_to_row_idx_t& insertInfo,
+        const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo) override;
+
+private:
+    std::unique_ptr<ColumnChunk> getEmptyChunkForCommit() override {
+        return ColumnChunkFactory::createNullColumnChunk(enableCompression);
+    }
+};
+
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -18,7 +18,8 @@ public:
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        ColumnChunk* columnChunk) override;
+        ColumnChunk* columnChunk, common::offset_t startOffset = 0,
+        common::offset_t endOffset = common::INVALID_OFFSET) override;
 
     void append(ColumnChunk* columnChunk, common::node_group_idx_t nodeGroupIdx) override;
 

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -13,7 +13,8 @@ public:
         RWPropertyStats propertyStatistics, bool enableCompression);
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        ColumnChunk* columnChunk) override;
+        ColumnChunk* columnChunk, common::offset_t startOffset = 0,
+        common::offset_t endOffset = common::INVALID_OFFSET) override;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) override;
@@ -29,7 +30,6 @@ public:
     }
     void write(common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk,
         common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
-    void setNull(common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk) override;
 
     void prepareCommitForChunk(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localColumnChunk,
@@ -41,6 +41,10 @@ protected:
         common::ValueVector* resultVector) override;
     void lookupInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         common::ValueVector* resultVector) override;
+
+    bool canCommitInPlace(transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
+        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo) override;
 
 private:
     std::vector<std::unique_ptr<Column>> childColumns;

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -55,6 +55,10 @@ public:
 
     void finalize() final;
 
+    inline common::offset_t getListOffset(common::offset_t offset) const {
+        return offset == 0 ? 0 : getValue<uint64_t>(offset - 1);
+    }
+
 protected:
     void copyListValues(const common::list_entry_t& entry, common::ValueVector* dataVector);
 
@@ -74,9 +78,6 @@ private:
     }
     inline uint64_t getListLen(common::offset_t offset) const {
         return getListOffset(offset + 1) - getListOffset(offset);
-    }
-    inline common::offset_t getListOffset(common::offset_t offset) const {
-        return offset == 0 ? 0 : getValue<uint64_t>(offset - 1);
     }
 
     void resetFromOtherChunk(VarListColumnChunk* other);

--- a/src/storage/store/CMakeLists.txt
+++ b/src/storage/store/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(kuzu_storage_store
         node_group.cpp
         node_table.cpp
         node_table_data.cpp
+        null_column.cpp
         rel_table.cpp
         rel_table_data.cpp
         string_column_chunk.cpp

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -1,0 +1,196 @@
+#include "storage/store/null_column.h"
+
+namespace kuzu {
+namespace storage {
+
+struct NullColumnFunc {
+    static void readValuesFromPageToVector(const uint8_t* frame, PageCursor& pageCursor,
+        ValueVector* resultVector, uint32_t posInVector, uint32_t numValuesToRead,
+        const CompressionMetadata& metadata) {
+        // Read bit-packed null flags from the frame into the result vector
+        // Casting to uint64_t should be safe as long as the page size is a multiple of 8 bytes.
+        // Otherwise, it could read off the end of the page.
+        if (metadata.isConstant()) {
+            auto value = ConstantCompression::getValue<bool>(metadata);
+            resultVector->setNullRange(posInVector, numValuesToRead, value);
+        } else {
+            resultVector->setNullFromBits(
+                (uint64_t*)frame, pageCursor.elemPosInPage, posInVector, numValuesToRead);
+        }
+    }
+
+    static void writeValueToPageFromVector(uint8_t* frame, uint16_t posInFrame, ValueVector* vector,
+        uint32_t posInVector, const CompressionMetadata& metadata) {
+        if (metadata.isConstant()) {
+            // Value to write is identical to the constant value
+            return;
+        }
+        // Casting to uint64_t should be safe as long as the page size is a multiple of 8 bytes.
+        // Otherwise, it could read off the end of the page.
+        NullMask::setNull((uint64_t*)frame, posInFrame, vector->isNull(posInVector));
+    }
+};
+
+NullColumn::NullColumn(std::string name, page_idx_t metaDAHPageIdx, BMFileHandle* dataFH,
+    BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal, Transaction* transaction,
+    RWPropertyStats propertyStatistics, bool enableCompression)
+    : Column{name, LogicalType::BOOL(), MetadataDAHInfo{metaDAHPageIdx}, dataFH, metadataFH,
+          bufferManager, wal, transaction, propertyStatistics, enableCompression,
+          false /*requireNullColumn*/} {
+    readToVectorFunc = NullColumnFunc::readValuesFromPageToVector;
+    writeFromVectorFunc = NullColumnFunc::writeValueToPageFromVector;
+    // Should never be used
+    batchLookupFunc = nullptr;
+}
+
+void NullColumn::scan(
+    Transaction* transaction, ValueVector* nodeIDVector, ValueVector* resultVector) {
+    if (propertyStatistics.mayHaveNull(*transaction)) {
+        scanInternal(transaction, nodeIDVector, resultVector);
+    } else {
+        resultVector->setAllNonNull();
+    }
+}
+
+void NullColumn::scan(transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx,
+    offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
+    uint64_t offsetInVector) {
+    if (propertyStatistics.mayHaveNull(*transaction)) {
+        Column::scan(transaction, nodeGroupIdx, startOffsetInGroup, endOffsetInGroup, resultVector,
+            offsetInVector);
+    } else {
+        resultVector->setNullRange(
+            offsetInVector, endOffsetInGroup - startOffsetInGroup, false /*set non-null*/);
+    }
+}
+
+void NullColumn::scan(transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx,
+    ColumnChunk* columnChunk, offset_t startOffset, offset_t endOffset) {
+    if (propertyStatistics.mayHaveNull(DUMMY_WRITE_TRANSACTION)) {
+        Column::scan(transaction, nodeGroupIdx, columnChunk, startOffset, endOffset);
+    } else {
+        static_cast<NullColumnChunk*>(columnChunk)->resetToNoNull();
+        if (nodeGroupIdx >= metadataDA->getNumElements(transaction->getType())) {
+            columnChunk->setNumValues(0);
+        } else {
+            auto chunkMetadata = metadataDA->get(nodeGroupIdx, transaction->getType());
+            auto numValues = chunkMetadata.numValues == 0 ?
+                                 0 :
+                                 std::min(endOffset, chunkMetadata.numValues - 1) - startOffset + 1;
+            columnChunk->setNumValues(numValues);
+        }
+    }
+}
+
+void NullColumn::lookup(
+    Transaction* transaction, ValueVector* nodeIDVector, ValueVector* resultVector) {
+    if (propertyStatistics.mayHaveNull(*transaction)) {
+        lookupInternal(transaction, nodeIDVector, resultVector);
+    } else {
+        for (auto i = 0ul; i < nodeIDVector->state->selVector->selectedSize; i++) {
+            auto pos = nodeIDVector->state->selVector->selectedPositions[i];
+            resultVector->setNull(pos, false);
+        }
+    }
+}
+
+void NullColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {
+    auto preScanMetadata = columnChunk->getMetadataToFlush();
+    auto startPageIdx = dataFH->addNewPages(preScanMetadata.numPages);
+    auto metadata = columnChunk->flushBuffer(dataFH, startPageIdx, preScanMetadata);
+    metadataDA->resize(nodeGroupIdx + 1);
+    metadataDA->update(nodeGroupIdx, metadata);
+    if (static_cast<NullColumnChunk*>(columnChunk)->mayHaveNull()) {
+        propertyStatistics.setHasNull(DUMMY_WRITE_TRANSACTION);
+    }
+}
+
+bool NullColumn::isNull(
+    transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx, offset_t offsetInChunk) {
+    auto state = getReadState(transaction->getType(), nodeGroupIdx);
+    uint64_t result = false;
+    if (offsetInChunk >= state.metadata.numValues) {
+        return true;
+    }
+    // Must be aligned to an 8-byte chunk for NullMask read to not overflow
+    Column::scan(
+        transaction, state, offsetInChunk, offsetInChunk + 1, reinterpret_cast<uint8_t*>(&result));
+    return result;
+}
+
+void NullColumn::setNull(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk) {
+    auto chunkMeta = metadataDA->get(nodeGroupIdx, TransactionType::WRITE);
+    propertyStatistics.setHasNull(DUMMY_WRITE_TRANSACTION);
+    // Must be aligned to an 8-byte chunk for NullMask read to not overflow
+    uint64_t value = true;
+    writeValue(chunkMeta, nodeGroupIdx, offsetInChunk, reinterpret_cast<const uint8_t*>(&value));
+    if (offsetInChunk >= chunkMeta.numValues) {
+        chunkMeta.numValues = offsetInChunk + 1;
+        metadataDA->update(nodeGroupIdx, chunkMeta);
+    }
+}
+
+void NullColumn::write(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk,
+    ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) {
+    auto chunkMeta = metadataDA->get(nodeGroupIdx, TransactionType::WRITE);
+    writeValue(chunkMeta, nodeGroupIdx, offsetInChunk, vectorToWriteFrom, posInVectorToWriteFrom);
+    if (vectorToWriteFrom->isNull(posInVectorToWriteFrom)) {
+        propertyStatistics.setHasNull(DUMMY_WRITE_TRANSACTION);
+    }
+    if (offsetInChunk >= chunkMeta.numValues) {
+        chunkMeta.numValues = offsetInChunk + 1;
+        metadataDA->update(nodeGroupIdx, chunkMeta);
+    }
+}
+
+bool NullColumn::canCommitInPlace(Transaction* transaction, node_group_idx_t nodeGroupIdx,
+    LocalVectorCollection* localChunk, const offset_to_row_idx_t& insertInfo,
+    const offset_to_row_idx_t& updateInfo) {
+    auto metadata = getMetadata(nodeGroupIdx, transaction->getType());
+    if (metadata.compMeta.canAlwaysUpdateInPlace()) {
+        return true;
+    }
+    std::vector<row_idx_t> rowIdxesToRead;
+    for (auto& [_, rowIdx] : updateInfo) {
+        rowIdxesToRead.push_back(rowIdx);
+    }
+    for (auto& [_, rowIdx] : insertInfo) {
+        rowIdxesToRead.push_back(rowIdx);
+    }
+    std::sort(rowIdxesToRead.begin(), rowIdxesToRead.end());
+    for (auto rowIdx : rowIdxesToRead) {
+        auto localVector = localChunk->getLocalVector(rowIdx);
+        auto offsetInVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
+        bool value = localVector->getVector()->isNull(offsetInVector);
+        if (!metadata.compMeta.canUpdateInPlace(
+                reinterpret_cast<const uint8_t*>(&value), 0, dataType->getPhysicalType())) {
+            return false;
+        }
+    }
+    return true;
+}
+
+void NullColumn::commitLocalChunkInPlace(Transaction* /*transaction*/,
+    node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
+    const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo,
+    const offset_set_t& deleteInfo) {
+    for (auto& [offsetInChunk, rowIdx] : updateInfo) {
+        auto localVector = localChunk->getLocalVector(rowIdx);
+        auto offsetInVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
+        write(nodeGroupIdx, offsetInChunk, localVector->getVector(), offsetInVector);
+    }
+    for (auto& [offsetInChunk, rowIdx] : insertInfo) {
+        auto localVector = localChunk->getLocalVector(rowIdx);
+        auto offsetInVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
+        write(nodeGroupIdx, offsetInChunk, localVector->getVector(), offsetInVector);
+    }
+    // Set nulls based on deleteInfo. Note that this code path actually only gets executed when
+    // the column is a regular format one. This is not a good design, should be unified with csr
+    // one in the future.
+    for (auto offsetInChunk : deleteInfo) {
+        setNull(nodeGroupIdx, offsetInChunk);
+    }
+}
+
+} // namespace storage
+} // namespace kuzu

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -1,5 +1,6 @@
 #include "storage/store/string_column.h"
 
+#include "storage/store/null_column.h"
 #include "storage/store/string_column_chunk.h"
 #include <bit>
 
@@ -61,9 +62,9 @@ void StringColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,
         offsetInVector);
 }
 
-void StringColumn::scan(
-    Transaction* transaction, node_group_idx_t nodeGroupIdx, ColumnChunk* columnChunk) {
-    Column::scan(transaction, nodeGroupIdx, columnChunk);
+void StringColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,
+    ColumnChunk* columnChunk, offset_t startOffset, offset_t endOffset) {
+    Column::scan(transaction, nodeGroupIdx, columnChunk, startOffset, endOffset);
     if (columnChunk->getNumValues() == 0) {
         return;
     }


### PR DESCRIPTION
- remove `isNull` and `setNull` from `Column`.
- separate `NullColumn` for better readability. Eventually, I think we should simplify functions in `Column` to get rid of the special `if` checks for `nullColumn`. One possible way is to have a `BaseColumn` and abstract common logic of reading/writing data / null pages into `BaseColumn`. Then we can let `Column` and `NullColumn` extend `BaseColumn` separately, thus removing the recursion of nullColumn in Column.
- add `startOffset` and `endOffset` to `Column::scan` for scanning into a column chunk. This will be used for packed csr.
- rework `canCommitInPlace` to simplify checks on struct and var list.