### PR TITLE
Clean up execution context

### DIFF
--- a/extension/httpfs/src/httpfs_extension.cpp
+++ b/extension/httpfs/src/httpfs_extension.cpp
@@ -12,9 +12,10 @@ void HttpfsExtension::load(main::Database& db) {
     db.registerFileSystem(std::make_unique<S3FileSystem>());
     db.addExtensionOption("s3_access_key_id", common::LogicalTypeID::STRING, common::Value{""});
     db.addExtensionOption("s3_secret_access_key", common::LogicalTypeID::STRING, common::Value{""});
-    db.addExtensionOption("s3_endpoint", common::LogicalTypeID::STRING, common::Value{""});
-    db.addExtensionOption("s3_url_style", common::LogicalTypeID::STRING, common::Value{""});
-    db.addExtensionOption("s3_region", common::LogicalTypeID::STRING, common::Value{""});
+    db.addExtensionOption(
+        "s3_endpoint", common::LogicalTypeID::STRING, common::Value{"s3.amazonaws.com"});
+    db.addExtensionOption("s3_url_style", common::LogicalTypeID::STRING, common::Value{"vhost"});
+    db.addExtensionOption("s3_region", common::LogicalTypeID::STRING, common::Value{"us-east-1"});
 }
 
 } // namespace httpfs

--- a/extension/httpfs/src/include/httpfs.h
+++ b/extension/httpfs/src/include/httpfs.h
@@ -45,7 +45,7 @@ struct HTTPParams {
 };
 
 struct HTTPFileInfo : public common::FileInfo {
-    HTTPFileInfo(std::string path, common::FileSystem* fileSystem, int flags);
+    HTTPFileInfo(std::string path, const common::FileSystem* fileSystem, int flags);
 
     virtual void initialize();
 
@@ -71,23 +71,23 @@ class HTTPFileSystem : public common::FileSystem {
 public:
     std::unique_ptr<common::FileInfo> openFile(const std::string& path, int flags,
         main::ClientContext* context = nullptr,
-        common::FileLockType lock_type = common::FileLockType::NO_LOCK) override;
+        common::FileLockType lock_type = common::FileLockType::NO_LOCK) const override;
 
-    std::vector<std::string> glob(const std::string& path) override;
+    std::vector<std::string> glob(const std::string& path) const override;
 
-    bool canHandleFile(const std::string& path) override;
+    bool canHandleFile(const std::string& path) const override;
 
     static std::unique_ptr<httplib::Client> getClient(const std::string& host);
 
 protected:
-    void readFromFile(
-        common::FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) override;
+    void readFromFile(common::FileInfo* fileInfo, void* buffer, uint64_t numBytes,
+        uint64_t position) const override;
 
-    int64_t readFile(common::FileInfo* fileInfo, void* buf, size_t numBytes) override;
+    int64_t readFile(common::FileInfo* fileInfo, void* buf, size_t numBytes) const override;
 
-    int64_t seek(common::FileInfo* fileInfo, uint64_t offset, int whence) override;
+    int64_t seek(common::FileInfo* fileInfo, uint64_t offset, int whence) const override;
 
-    uint64_t getFileSize(common::FileInfo* fileInfo) override;
+    uint64_t getFileSize(common::FileInfo* fileInfo) const override;
 
     static void parseUrl(const std::string& url, std::string& hostPath, std::string& host);
 
@@ -98,11 +98,11 @@ protected:
         std::string method, const std::function<void(void)>& retry = {});
 
     virtual std::unique_ptr<HTTPResponse> headRequest(
-        common::FileInfo* fileInfo, std::string url, HeaderMap headerMap);
+        common::FileInfo* fileInfo, std::string url, HeaderMap headerMap) const;
 
     virtual std::unique_ptr<HTTPResponse> getRangeRequest(common::FileInfo* fileInfo,
         const std::string& url, HeaderMap headerMap, uint64_t fileOffset, char* buffer,
-        uint64_t bufferLen);
+        uint64_t bufferLen) const;
 };
 
 } // namespace httpfs

--- a/extension/httpfs/src/include/s3fs.h
+++ b/extension/httpfs/src/include/s3fs.h
@@ -13,7 +13,7 @@ struct S3AuthParams {
 
 class S3FileInfo final : public HTTPFileInfo {
 public:
-    S3FileInfo(std::string path, common::FileSystem* fileSystem, int flags,
+    S3FileInfo(std::string path, const common::FileSystem* fileSystem, int flags,
         const S3AuthParams& authParams);
 
     void initializeClient() override;
@@ -44,9 +44,9 @@ private:
 public:
     std::unique_ptr<common::FileInfo> openFile(const std::string& path, int flags,
         main::ClientContext* context = nullptr,
-        common::FileLockType lock_type = common::FileLockType::NO_LOCK) override;
+        common::FileLockType lock_type = common::FileLockType::NO_LOCK) const override;
 
-    bool canHandleFile(const std::string& path) override;
+    bool canHandleFile(const std::string& path) const override;
 
     static std::string encodeURL(const std::string& input, bool encodeSlash = false);
 
@@ -54,11 +54,11 @@ public:
 
 protected:
     std::unique_ptr<HTTPResponse> headRequest(
-        common::FileInfo* fileInfo, std::string url, HeaderMap headerMap) override;
+        common::FileInfo* fileInfo, std::string url, HeaderMap headerMap) const override;
 
     std::unique_ptr<HTTPResponse> getRangeRequest(common::FileInfo* fileInfo,
         const std::string& url, HeaderMap headerMap, uint64_t fileOffset, char* buffer,
-        uint64_t bufferLen) override;
+        uint64_t bufferLen) const override;
 
 private:
     static HeaderMap createS3Header(std::string url, std::string query, std::string host,

--- a/extension/httpfs/test/test_files/s3.test
+++ b/extension/httpfs/test/test_files/s3.test
@@ -57,16 +57,12 @@ Zhang|Noura|2022
 ---- ok
 -STATEMENT CALL s3_secret_access_key='${AWS_S3_SECRET_ACCESS_KEY}'
 ---- ok
--STATEMENT CALL s3_endpoint='s3.amazonaws.com'
----- ok
 ]
 
 -CASE ScanFromDifferentAWSS3File
 -SKIP
 -INSERT_STATEMENT_BLOCK AWS_S3_SETUP
 -STATEMENT CALL s3_url_style='path'
----- ok
--STATEMENT CALL s3_region='us-east-1'
 ---- ok
 -STATEMENT load from 's3://kuzu-dataset-us/user.csv' return *;
 ---- 4

--- a/src/common/file_system/file_system.cpp
+++ b/src/common/file_system/file_system.cpp
@@ -3,19 +3,19 @@
 namespace kuzu {
 namespace common {
 
-void FileSystem::overwriteFile(const std::string& /*from*/, const std::string& /*to*/) {
+void FileSystem::overwriteFile(const std::string& /*from*/, const std::string& /*to*/) const {
     KU_UNREACHABLE;
 }
 
-void FileSystem::createDir(const std::string& /*dir*/) {
+void FileSystem::createDir(const std::string& /*dir*/) const {
     KU_UNREACHABLE;
 }
 
-void FileSystem::removeFileIfExists(const std::string& /*path*/) {
+void FileSystem::removeFileIfExists(const std::string& /*path*/) const {
     KU_UNREACHABLE;
 }
 
-bool FileSystem::fileOrPathExists(const std::string& /*path*/) {
+bool FileSystem::fileOrPathExists(const std::string& /*path*/) const {
     KU_UNREACHABLE;
 }
 
@@ -27,12 +27,12 @@ std::string FileSystem::getFileExtension(const std::filesystem::path& path) {
     return path.extension().string();
 }
 
-void FileSystem::writeFile(
-    FileInfo* /*fileInfo*/, const uint8_t* /*buffer*/, uint64_t /*numBytes*/, uint64_t /*offset*/) {
+void FileSystem::writeFile(FileInfo* /*fileInfo*/, const uint8_t* /*buffer*/, uint64_t /*numBytes*/,
+    uint64_t /*offset*/) const {
     KU_UNREACHABLE;
 }
 
-void FileSystem::truncate(FileInfo* /*fileInfo*/, uint64_t /*size*/) {
+void FileSystem::truncate(FileInfo* /*fileInfo*/, uint64_t /*size*/) const {
     KU_UNREACHABLE;
 }
 

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -36,8 +36,8 @@ LocalFileInfo::~LocalFileInfo() {
 #endif
 }
 
-std::unique_ptr<FileInfo> LocalFileSystem::openFile(
-    const std::string& path, int flags, main::ClientContext* /*context*/, FileLockType lock_type) {
+std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, int flags,
+    main::ClientContext* /*context*/, FileLockType lock_type) const {
 #if defined(_WIN32)
     auto dwDesiredAccess = 0ul;
     auto dwCreationDisposition = (flags & O_CREAT) ? OPEN_ALWAYS : OPEN_EXISTING;
@@ -89,7 +89,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(
 #endif
 }
 
-std::vector<std::string> LocalFileSystem::glob(const std::string& path) {
+std::vector<std::string> LocalFileSystem::glob(const std::string& path) const {
     std::vector<std::string> result;
     for (auto& resultPath : glob::glob(path)) {
         result.emplace_back(resultPath.string());
@@ -97,7 +97,7 @@ std::vector<std::string> LocalFileSystem::glob(const std::string& path) {
     return result;
 }
 
-void LocalFileSystem::overwriteFile(const std::string& from, const std::string& to) {
+void LocalFileSystem::overwriteFile(const std::string& from, const std::string& to) const {
     if (!fileOrPathExists(from) || !fileOrPathExists(to))
         return;
     std::error_code errorCode;
@@ -110,7 +110,7 @@ void LocalFileSystem::overwriteFile(const std::string& from, const std::string& 
     }
 }
 
-void LocalFileSystem::createDir(const std::string& dir) {
+void LocalFileSystem::createDir(const std::string& dir) const {
     try {
         if (std::filesystem::exists(dir)) {
             // LCOV_EXCL_START
@@ -130,7 +130,7 @@ void LocalFileSystem::createDir(const std::string& dir) {
     }
 }
 
-void LocalFileSystem::removeFileIfExists(const std::string& path) {
+void LocalFileSystem::removeFileIfExists(const std::string& path) const {
     if (!fileOrPathExists(path))
         return;
     if (remove(path.c_str()) != 0) {
@@ -141,12 +141,12 @@ void LocalFileSystem::removeFileIfExists(const std::string& path) {
     }
 }
 
-bool LocalFileSystem::fileOrPathExists(const std::string& path) {
+bool LocalFileSystem::fileOrPathExists(const std::string& path) const {
     return std::filesystem::exists(path);
 }
 
 void LocalFileSystem::readFromFile(
-    FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) {
+    FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) const {
     auto localFileInfo = ku_dynamic_cast<FileInfo*, LocalFileInfo*>(fileInfo);
 #if defined(_WIN32)
     DWORD numBytesRead;
@@ -179,7 +179,7 @@ void LocalFileSystem::readFromFile(
 #endif
 }
 
-int64_t LocalFileSystem::readFile(FileInfo* fileInfo, void* buf, size_t nbyte) {
+int64_t LocalFileSystem::readFile(FileInfo* fileInfo, void* buf, size_t nbyte) const {
     auto localFileInfo = ku_dynamic_cast<FileInfo*, LocalFileInfo*>(fileInfo);
 #if defined(_WIN32)
     DWORD numBytesRead;
@@ -191,7 +191,7 @@ int64_t LocalFileSystem::readFile(FileInfo* fileInfo, void* buf, size_t nbyte) {
 }
 
 void LocalFileSystem::writeFile(
-    FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset) {
+    FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset) const {
     auto localFileInfo = ku_dynamic_cast<FileInfo*, LocalFileInfo*>(fileInfo);
     uint64_t remainingNumBytesToWrite = numBytes;
     uint64_t bufferOffset = 0;
@@ -233,7 +233,7 @@ void LocalFileSystem::writeFile(
     }
 }
 
-int64_t LocalFileSystem::seek(FileInfo* fileInfo, uint64_t offset, int whence) {
+int64_t LocalFileSystem::seek(FileInfo* fileInfo, uint64_t offset, int whence) const {
     auto localFileInfo = ku_dynamic_cast<FileInfo*, LocalFileInfo*>(fileInfo);
 #if defined(_WIN32)
     LARGE_INTEGER result;
@@ -246,7 +246,7 @@ int64_t LocalFileSystem::seek(FileInfo* fileInfo, uint64_t offset, int whence) {
 #endif
 }
 
-void LocalFileSystem::truncate(FileInfo* fileInfo, uint64_t size) {
+void LocalFileSystem::truncate(FileInfo* fileInfo, uint64_t size) const {
     auto localFileInfo = ku_dynamic_cast<FileInfo*, LocalFileInfo*>(fileInfo);
 #if defined(_WIN32)
     auto offsetHigh = (LONG)(size >> 32);
@@ -278,7 +278,7 @@ void LocalFileSystem::truncate(FileInfo* fileInfo, uint64_t size) {
 #endif
 }
 
-uint64_t LocalFileSystem::getFileSize(kuzu::common::FileInfo* fileInfo) {
+uint64_t LocalFileSystem::getFileSize(kuzu::common::FileInfo* fileInfo) const {
     auto localFileInfo = ku_dynamic_cast<FileInfo*, LocalFileInfo*>(fileInfo);
 #ifdef _WIN32
     LARGE_INTEGER size;

--- a/src/common/file_system/virtual_file_system.cpp
+++ b/src/common/file_system/virtual_file_system.cpp
@@ -15,64 +15,64 @@ void VirtualFileSystem::registerFileSystem(std::unique_ptr<FileSystem> fileSyste
     subSystems.push_back(std::move(fileSystem));
 }
 
-FileSystem* VirtualFileSystem::findFileSystem(const std::string& path) {
+std::unique_ptr<FileInfo> VirtualFileSystem::openFile(
+    const std::string& path, int flags, main::ClientContext* context, FileLockType lockType) const {
+    return findFileSystem(path)->openFile(path, flags, context, lockType);
+}
+
+std::vector<std::string> VirtualFileSystem::glob(const std::string& path) const {
+    return findFileSystem(path)->glob(path);
+}
+
+void VirtualFileSystem::overwriteFile(const std::string& from, const std::string& to) const {
+    findFileSystem(from)->overwriteFile(from, to);
+}
+
+void VirtualFileSystem::createDir(const std::string& dir) const {
+    findFileSystem(dir)->createDir(dir);
+}
+
+void VirtualFileSystem::removeFileIfExists(const std::string& path) const {
+    findFileSystem(path)->removeFileIfExists(path);
+}
+
+bool VirtualFileSystem::fileOrPathExists(const std::string& path) const {
+    return findFileSystem(path)->fileOrPathExists(path);
+}
+
+void VirtualFileSystem::readFromFile(
+    FileInfo* /*fileInfo*/, void* /*buffer*/, uint64_t /*numBytes*/, uint64_t /*position*/) const {
+    KU_UNREACHABLE;
+}
+
+int64_t VirtualFileSystem::readFile(FileInfo* /*fileInfo*/, void* /*buf*/, size_t /*nbyte*/) const {
+    KU_UNREACHABLE;
+}
+
+void VirtualFileSystem::writeFile(FileInfo* /*fileInfo*/, const uint8_t* /*buffer*/,
+    uint64_t /*numBytes*/, uint64_t /*offset*/) const {
+    KU_UNREACHABLE;
+}
+
+int64_t VirtualFileSystem::seek(FileInfo* /*fileInfo*/, uint64_t /*offset*/, int /*whence*/) const {
+    KU_UNREACHABLE;
+}
+
+void VirtualFileSystem::truncate(FileInfo* /*fileInfo*/, uint64_t /*size*/) const {
+    KU_UNREACHABLE;
+}
+
+uint64_t VirtualFileSystem::getFileSize(kuzu::common::FileInfo* /*fileInfo*/) const {
+    KU_UNREACHABLE;
+}
+
+FileSystem* VirtualFileSystem::findFileSystem(const std::string& path) const {
     for (auto& subSystem : subSystems) {
         if (subSystem->canHandleFile(path)) {
             return subSystem.get();
         }
     }
     return defaultFS.get();
-}
-
-std::unique_ptr<FileInfo> VirtualFileSystem::openFile(
-    const std::string& path, int flags, main::ClientContext* context, FileLockType lockType) {
-    return findFileSystem(path)->openFile(path, flags, context, lockType);
-}
-
-std::vector<std::string> VirtualFileSystem::glob(const std::string& path) {
-    return findFileSystem(path)->glob(path);
-}
-
-void VirtualFileSystem::overwriteFile(const std::string& from, const std::string& to) {
-    findFileSystem(from)->overwriteFile(from, to);
-}
-
-void VirtualFileSystem::createDir(const std::string& dir) {
-    findFileSystem(dir)->createDir(dir);
-}
-
-void VirtualFileSystem::removeFileIfExists(const std::string& path) {
-    findFileSystem(path)->removeFileIfExists(path);
-}
-
-bool VirtualFileSystem::fileOrPathExists(const std::string& path) {
-    return findFileSystem(path)->fileOrPathExists(path);
-}
-
-void VirtualFileSystem::readFromFile(
-    FileInfo* /*fileInfo*/, void* /*buffer*/, uint64_t /*numBytes*/, uint64_t /*position*/) {
-    KU_UNREACHABLE;
-}
-
-int64_t VirtualFileSystem::readFile(FileInfo* /*fileInfo*/, void* /*buf*/, size_t /*nbyte*/) {
-    KU_UNREACHABLE;
-}
-
-void VirtualFileSystem::writeFile(
-    FileInfo* /*fileInfo*/, const uint8_t* /*buffer*/, uint64_t /*numBytes*/, uint64_t /*offset*/) {
-    KU_UNREACHABLE;
-}
-
-int64_t VirtualFileSystem::seek(FileInfo* /*fileInfo*/, uint64_t /*offset*/, int /*whence*/) {
-    KU_UNREACHABLE;
-}
-
-void VirtualFileSystem::truncate(FileInfo* /*fileInfo*/, uint64_t /*size*/) {
-    KU_UNREACHABLE;
-}
-
-uint64_t VirtualFileSystem::getFileSize(kuzu::common::FileInfo* /*fileInfo*/) {
-    KU_UNREACHABLE;
 }
 
 } // namespace common

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -2,7 +2,6 @@
 
 #include "common/string_format.h"
 #include "common/string_utils.h"
-#include "main/database.h"
 
 namespace kuzu {
 namespace extension {
@@ -34,10 +33,6 @@ std::string getArch() {
 
 std::string getPlatform() {
     return getOS() + "_" + getArch();
-}
-
-std::string ExtensionUtils::getExtensionDir(kuzu::main::Database* database) {
-    return common::stringFormat("{}/extension", database->databasePath);
 }
 
 std::string ExtensionUtils::getExtensionPath(

--- a/src/function/table_functions/call_functions.cpp
+++ b/src/function/table_functions/call_functions.cpp
@@ -74,8 +74,9 @@ std::unique_ptr<TableFuncBindData> CurrentSettingFunction::bindFunc(ClientContex
     std::vector<std::unique_ptr<LogicalType>> returnTypes;
     returnColumnNames.emplace_back(optionName);
     returnTypes.push_back(LogicalType::STRING());
-    return std::make_unique<CurrentSettingBindData>(context->getCurrentSetting(optionName),
-        std::move(returnTypes), std::move(returnColumnNames), 1 /* one row result */);
+    return std::make_unique<CurrentSettingBindData>(
+        context->getCurrentSetting(optionName).toString(), std::move(returnTypes),
+        std::move(returnColumnNames), 1 /* one row result */);
 }
 
 function_set DBVersionFunction::getFunctionSet() {

--- a/src/include/common/file_system/file_info.h
+++ b/src/include/common/file_system/file_info.h
@@ -11,7 +11,7 @@ namespace common {
 class FileSystem;
 
 struct KUZU_API FileInfo {
-    FileInfo(std::string path, FileSystem* fileSystem)
+    FileInfo(std::string path, const FileSystem* fileSystem)
         : path{std::move(path)}, fileSystem{fileSystem} {}
 
     virtual ~FileInfo() = default;
@@ -30,7 +30,7 @@ struct KUZU_API FileInfo {
 
     const std::string path;
 
-    FileSystem* fileSystem;
+    const FileSystem* fileSystem;
 };
 
 } // namespace common

--- a/src/include/common/file_system/file_system.h
+++ b/src/include/common/file_system/file_system.h
@@ -22,38 +22,39 @@ public:
     virtual ~FileSystem() = default;
 
     virtual std::unique_ptr<FileInfo> openFile(const std::string& path, int flags,
-        main::ClientContext* context = nullptr, FileLockType lock_type = FileLockType::NO_LOCK) = 0;
+        main::ClientContext* context = nullptr,
+        FileLockType lock_type = FileLockType::NO_LOCK) const = 0;
 
-    virtual std::vector<std::string> glob(const std::string& path) = 0;
+    virtual std::vector<std::string> glob(const std::string& path) const = 0;
 
-    virtual void overwriteFile(const std::string& from, const std::string& to);
+    virtual void overwriteFile(const std::string& from, const std::string& to) const;
 
-    virtual void createDir(const std::string& dir);
+    virtual void createDir(const std::string& dir) const;
 
-    virtual void removeFileIfExists(const std::string& path);
+    virtual void removeFileIfExists(const std::string& path) const;
 
-    virtual bool fileOrPathExists(const std::string& path);
+    virtual bool fileOrPathExists(const std::string& path) const;
 
     static std::string joinPath(const std::string& base, const std::string& part);
 
     static std::string getFileExtension(const std::filesystem::path& path);
 
-    virtual bool canHandleFile(const std::string& /*path*/) { KU_UNREACHABLE; }
+    virtual bool canHandleFile(const std::string& /*path*/) const { KU_UNREACHABLE; }
 
 protected:
     virtual void readFromFile(
-        FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) = 0;
+        FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) const = 0;
 
-    virtual int64_t readFile(FileInfo* fileInfo, void* buf, size_t nbyte) = 0;
+    virtual int64_t readFile(FileInfo* fileInfo, void* buf, size_t nbyte) const = 0;
 
     virtual void writeFile(
-        FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset);
+        FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset) const;
 
-    virtual int64_t seek(FileInfo* fileInfo, uint64_t offset, int whence) = 0;
+    virtual int64_t seek(FileInfo* fileInfo, uint64_t offset, int whence) const = 0;
 
-    virtual void truncate(FileInfo* fileInfo, uint64_t size);
+    virtual void truncate(FileInfo* fileInfo, uint64_t size) const;
 
-    virtual uint64_t getFileSize(FileInfo* fileInfo) = 0;
+    virtual uint64_t getFileSize(FileInfo* fileInfo) const = 0;
 };
 
 } // namespace common

--- a/src/include/common/file_system/local_file_system.h
+++ b/src/include/common/file_system/local_file_system.h
@@ -9,10 +9,10 @@ namespace common {
 
 struct LocalFileInfo : public FileInfo {
 #ifdef _WIN32
-    LocalFileInfo(std::string path, const void* handle, FileSystem* fileSystem)
+    LocalFileInfo(std::string path, const void* handle, const FileSystem* fileSystem)
         : FileInfo{std::move(path), fileSystem}, handle{handle} {}
 #else
-    LocalFileInfo(std::string path, const int fd, FileSystem* fileSystem)
+    LocalFileInfo(std::string path, const int fd, const FileSystem* fileSystem)
         : FileInfo{std::move(path), fileSystem}, fd{fd} {}
 #endif
 
@@ -29,32 +29,32 @@ class LocalFileSystem final : public FileSystem {
 public:
     std::unique_ptr<FileInfo> openFile(const std::string& path, int flags,
         main::ClientContext* context = nullptr,
-        FileLockType lock_type = FileLockType::NO_LOCK) override;
+        FileLockType lock_type = FileLockType::NO_LOCK) const override;
 
-    std::vector<std::string> glob(const std::string& path) override;
+    std::vector<std::string> glob(const std::string& path) const override;
 
-    void overwriteFile(const std::string& from, const std::string& to) override;
+    void overwriteFile(const std::string& from, const std::string& to) const override;
 
-    void createDir(const std::string& dir) override;
+    void createDir(const std::string& dir) const override;
 
-    void removeFileIfExists(const std::string& path) override;
+    void removeFileIfExists(const std::string& path) const override;
 
-    bool fileOrPathExists(const std::string& path) override;
+    bool fileOrPathExists(const std::string& path) const override;
 
 protected:
     void readFromFile(
-        FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) override;
+        FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) const override;
 
-    int64_t readFile(FileInfo* fileInfo, void* buf, size_t nbyte) override;
+    int64_t readFile(FileInfo* fileInfo, void* buf, size_t nbyte) const override;
 
-    void writeFile(
-        FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset) override;
+    void writeFile(FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes,
+        uint64_t offset) const override;
 
-    int64_t seek(FileInfo* fileInfo, uint64_t offset, int whence) override;
+    int64_t seek(FileInfo* fileInfo, uint64_t offset, int whence) const override;
 
-    void truncate(FileInfo* fileInfo, uint64_t size) override;
+    void truncate(FileInfo* fileInfo, uint64_t size) const override;
 
-    uint64_t getFileSize(FileInfo* fileInfo) override;
+    uint64_t getFileSize(FileInfo* fileInfo) const override;
 };
 
 } // namespace common

--- a/src/include/common/file_system/virtual_file_system.h
+++ b/src/include/common/file_system/virtual_file_system.h
@@ -17,35 +17,35 @@ public:
 
     std::unique_ptr<FileInfo> openFile(const std::string& path, int flags,
         main::ClientContext* context = nullptr,
-        FileLockType lockType = FileLockType::NO_LOCK) override;
+        FileLockType lockType = FileLockType::NO_LOCK) const override;
 
-    std::vector<std::string> glob(const std::string& path) override;
+    std::vector<std::string> glob(const std::string& path) const override;
 
-    void overwriteFile(const std::string& from, const std::string& to) override;
+    void overwriteFile(const std::string& from, const std::string& to) const override;
 
-    void createDir(const std::string& dir) override;
+    void createDir(const std::string& dir) const override;
 
-    void removeFileIfExists(const std::string& path) override;
+    void removeFileIfExists(const std::string& path) const override;
 
-    bool fileOrPathExists(const std::string& path) override;
+    bool fileOrPathExists(const std::string& path) const override;
 
 protected:
     void readFromFile(
-        FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) override;
+        FileInfo* fileInfo, void* buffer, uint64_t numBytes, uint64_t position) const override;
 
-    int64_t readFile(FileInfo* fileInfo, void* buf, size_t nbyte) override;
+    int64_t readFile(FileInfo* fileInfo, void* buf, size_t nbyte) const override;
 
-    void writeFile(
-        FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes, uint64_t offset) override;
+    void writeFile(FileInfo* fileInfo, const uint8_t* buffer, uint64_t numBytes,
+        uint64_t offset) const override;
 
-    int64_t seek(FileInfo* fileInfo, uint64_t offset, int whence) override;
+    int64_t seek(FileInfo* fileInfo, uint64_t offset, int whence) const override;
 
-    void truncate(FileInfo* fileInfo, uint64_t size) override;
+    void truncate(FileInfo* fileInfo, uint64_t size) const override;
 
-    uint64_t getFileSize(FileInfo* fileInfo) override;
+    uint64_t getFileSize(FileInfo* fileInfo) const override;
 
 private:
-    FileSystem* findFileSystem(const std::string& path);
+    FileSystem* findFileSystem(const std::string& path) const;
 
 private:
     std::vector<std::unique_ptr<FileSystem>> subSystems;

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -28,8 +28,6 @@ struct ExtensionUtils {
     static constexpr const char* EXTENSION_REPO =
         "http://extension.kuzudb.com/v{}/{}/lib{}.kuzu_extension";
 
-    static std::string getExtensionDir(main::Database* database);
-
     static std::string getExtensionPath(const std::string& extensionDir, const std::string& name);
 
     static bool isFullPath(const std::string& extension);

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -66,18 +66,24 @@ public:
 
     void startTimingIfEnabled();
 
-    KUZU_API std::string getCurrentSetting(const std::string& optionName);
+    KUZU_API common::Value getCurrentSetting(const std::string& optionName);
 
     transaction::Transaction* getTx() const;
     transaction::TransactionContext* getTransactionContext() const;
 
-    inline void setReplaceFunc(replace_func_t replaceFunc) {
-        this->replaceFunc = std::move(replaceFunc);
-    }
+    void setReplaceFunc(replace_func_t replaceFunc) { this->replaceFunc = std::move(replaceFunc); }
 
     void setExtensionOption(std::string name, common::Value value);
 
-    inline common::RandomEngine* getRandomEngine() { return randomEngine.get(); }
+    common::RandomEngine* getRandomEngine() { return randomEngine.get(); }
+
+    const common::VirtualFileSystem* getVFS() const;
+
+    std::string getExtensionDir() const;
+
+    Database* getDatabase() const { return database; }
+
+    storage::MemoryManager* getMemoryManager();
 
 private:
     inline void resetActiveQuery() { activeQuery.reset(); }
@@ -91,6 +97,7 @@ private:
     replace_func_t replaceFunc;
     std::unordered_map<std::string, common::Value> extensionOptionValues;
     std::unique_ptr<common::RandomEngine> randomEngine;
+    Database* database;
 };
 
 } // namespace main

--- a/src/include/main/db_config.h
+++ b/src/include/main/db_config.h
@@ -8,7 +8,7 @@ namespace kuzu {
 namespace main {
 
 typedef void (*set_context)(ClientContext* context, const common::Value& parameter);
-typedef std::string (*get_setting)(ClientContext* context);
+typedef common::Value (*get_setting)(ClientContext* context);
 
 enum class OptionType : uint8_t { CONFIGURATION = 0, EXTENSION = 1 };
 

--- a/src/include/main/settings.h
+++ b/src/include/main/settings.h
@@ -13,8 +13,8 @@ struct ThreadsSetting {
         KU_ASSERT(parameter.getDataType()->getLogicalTypeID() == common::LogicalTypeID::INT64);
         context->numThreadsForExecution = parameter.getValue<int64_t>();
     }
-    static std::string getSetting(ClientContext* context) {
-        return std::to_string(context->numThreadsForExecution);
+    static common::Value getSetting(ClientContext* context) {
+        return common::Value(context->numThreadsForExecution);
     }
 };
 
@@ -26,8 +26,8 @@ struct TimeoutSetting {
         context->timeoutInMS = parameter.getValue<int64_t>();
         context->startTimingIfEnabled();
     }
-    static std::string getSetting(ClientContext* context) {
-        return std::to_string(context->timeoutInMS);
+    static common::Value getSetting(ClientContext* context) {
+        return common::Value(context->timeoutInMS);
     }
 };
 
@@ -38,8 +38,8 @@ struct VarLengthExtendMaxDepthSetting {
         KU_ASSERT(parameter.getDataType()->getLogicalTypeID() == common::LogicalTypeID::INT64);
         context->varLengthExtendMaxDepth = parameter.getValue<int64_t>();
     }
-    static std::string getSetting(ClientContext* context) {
-        return std::to_string(context->varLengthExtendMaxDepth);
+    static common::Value getSetting(ClientContext* context) {
+        return common::Value(context->varLengthExtendMaxDepth);
     }
 };
 
@@ -50,8 +50,8 @@ struct EnableSemiMaskSetting {
         KU_ASSERT(parameter.getDataType()->getLogicalTypeID() == common::LogicalTypeID::BOOL);
         context->enableSemiMask = parameter.getValue<bool>();
     }
-    static std::string getSetting(ClientContext* context) {
-        return context->enableSemiMask ? "true" : "false";
+    static common::Value getSetting(ClientContext* context) {
+        return common::Value(context->enableSemiMask);
     }
 };
 

--- a/src/include/processor/execution_context.h
+++ b/src/include/processor/execution_context.h
@@ -2,28 +2,16 @@
 
 #include "common/profiler.h"
 #include "main/client_context.h"
-#include "storage/buffer_manager/buffer_manager.h"
-#include "storage/buffer_manager/memory_manager.h"
 
 namespace kuzu {
 namespace processor {
 
 struct ExecutionContext {
-    uint64_t numThreads;
     common::Profiler* profiler;
-    storage::MemoryManager* memoryManager;
-    storage::BufferManager* bufferManager;
     main::ClientContext* clientContext;
-    common::VirtualFileSystem* vfs;
-    main::Database* database;
 
-    ExecutionContext(uint64_t numThreads, common::Profiler* profiler,
-        storage::MemoryManager* memoryManager, storage::BufferManager* bufferManager,
-        main::ClientContext* clientContext, common::VirtualFileSystem* vfs,
-        main::Database* database)
-        : numThreads{numThreads}, profiler{profiler}, memoryManager{memoryManager},
-          bufferManager{bufferManager}, clientContext{clientContext}, vfs{vfs}, database{database} {
-    }
+    ExecutionContext(common::Profiler* profiler, main::ClientContext* clientContext)
+        : profiler{profiler}, clientContext{clientContext} {}
 };
 
 } // namespace processor

--- a/src/include/processor/operator/ddl/add_property.h
+++ b/src/include/processor/operator/ddl/add_property.h
@@ -20,7 +20,7 @@ public:
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override {
         DDL::initLocalStateInternal(resultSet, context);
-        defaultValueEvaluator->init(*resultSet, context->memoryManager);
+        defaultValueEvaluator->init(*resultSet, context->clientContext->getMemoryManager());
     }
 
     void executeDDLInternal(ExecutionContext* context) override = 0;

--- a/src/include/processor/operator/install_extension.h
+++ b/src/include/processor/operator/install_extension.h
@@ -23,10 +23,9 @@ public:
 private:
     std::string tryDownloadExtension();
 
-    void saveExtensionToLocalFile(
-        const std::string& extensionData, common::VirtualFileSystem* vfs, main::Database* database);
+    void saveExtensionToLocalFile(const std::string& extensionData, main::ClientContext* context);
 
-    void installExtension(common::VirtualFileSystem* vfs, main::Database* database);
+    void installExtension(main::ClientContext* context);
 
 private:
     std::string name;

--- a/src/include/processor/operator/order_by/top_k.h
+++ b/src/include/processor/operator/order_by/top_k.h
@@ -153,7 +153,8 @@ public:
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
     inline void initGlobalStateInternal(ExecutionContext* context) override {
-        sharedState->init(*info, context->memoryManager, skipNumber, limitNumber);
+        sharedState->init(
+            *info, context->clientContext->getMemoryManager(), skipNumber, limitNumber);
     }
 
     void executeInternal(ExecutionContext* context) override;

--- a/src/include/processor/operator/persistent/copy_to.h
+++ b/src/include/processor/operator/persistent/copy_to.h
@@ -37,7 +37,7 @@ public:
     virtual ~CopyToSharedState() = default;
 
     virtual void init(
-        CopyToInfo* info, storage::MemoryManager* mm, common::VirtualFileSystem* vfs) = 0;
+        CopyToInfo* info, storage::MemoryManager* mm, const common::VirtualFileSystem* vfs) = 0;
 
     virtual void finalize() = 0;
 };

--- a/src/include/processor/operator/persistent/copy_to_csv.h
+++ b/src/include/processor/operator/persistent/copy_to_csv.h
@@ -55,8 +55,8 @@ private:
 
 class CopyToCSVSharedState final : public CopyToSharedState {
 public:
-    void init(
-        CopyToInfo* info, storage::MemoryManager* mm, common::VirtualFileSystem* vfs) override;
+    void init(CopyToInfo* info, storage::MemoryManager* mm,
+        const common::VirtualFileSystem* vfs) override;
 
     void finalize() override {}
 

--- a/src/include/processor/operator/persistent/copy_to_parquet.h
+++ b/src/include/processor/operator/persistent/copy_to_parquet.h
@@ -41,8 +41,8 @@ private:
 
 class CopyToParquetSharedState final : public CopyToSharedState {
 public:
-    void init(
-        CopyToInfo* info, storage::MemoryManager* mm, common::VirtualFileSystem* vfs) override;
+    void init(CopyToInfo* info, storage::MemoryManager* mm,
+        const common::VirtualFileSystem* vfs) override;
 
     void finalize() override;
 

--- a/src/include/processor/operator/persistent/writer/parquet/parquet_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/parquet_writer.h
@@ -41,7 +41,7 @@ class ParquetWriter {
 public:
     ParquetWriter(std::string fileName, std::vector<std::unique_ptr<common::LogicalType>> types,
         std::vector<std::string> names, kuzu_parquet::format::CompressionCodec::type codec,
-        storage::MemoryManager* mm, common::VirtualFileSystem* vfs);
+        storage::MemoryManager* mm, const common::VirtualFileSystem* vfs);
 
     inline common::offset_t getOffset() const { return fileOffset; }
     inline void write(const uint8_t* buf, uint32_t len) {

--- a/src/include/processor/processor_task.h
+++ b/src/include/processor/processor_task.h
@@ -10,9 +10,7 @@ class ProcessorTask : public common::Task {
     friend class QueryProcessor;
 
 public:
-    ProcessorTask(Sink* sink, ExecutionContext* executionContext)
-        : Task{executionContext->numThreads}, sharedStateInitialized{false}, sink{sink},
-          executionContext{executionContext} {}
+    ProcessorTask(Sink* sink, ExecutionContext* executionContext);
 
     void run() override;
     void finalizeIfNecessary() override;

--- a/src/include/storage/file_handle.h
+++ b/src/include/storage/file_handle.h
@@ -31,7 +31,7 @@ public:
     constexpr static uint8_t O_PERSISTENT_FILE_CREATE_NOT_EXISTS{0b0000'0100};
     constexpr static uint8_t O_IN_MEM_TEMP_FILE{0b0000'0011};
 
-    FileHandle(const std::string& path, uint8_t flags, common::VirtualFileSystem* vfs);
+    FileHandle(const std::string& path, uint8_t flags, const common::VirtualFileSystem* vfs);
     virtual ~FileHandle() = default;
 
     common::page_idx_t addNewPage();
@@ -60,7 +60,7 @@ public:
 
 protected:
     virtual common::page_idx_t addNewPageWithoutLock();
-    void constructExistingFileHandle(const std::string& path, common::VirtualFileSystem* vfs);
+    void constructExistingFileHandle(const std::string& path, const common::VirtualFileSystem* vfs);
     void constructNewFileHandle(const std::string& path);
 
 protected:

--- a/src/include/storage/index/hash_index_builder.h
+++ b/src/include/storage/index/hash_index_builder.h
@@ -117,7 +117,7 @@ private:
 class PrimaryKeyIndexBuilder {
 public:
     PrimaryKeyIndexBuilder(const std::string& fName, const common::LogicalType& keyDataType,
-        common::VirtualFileSystem* vfs);
+        const common::VirtualFileSystem* vfs);
 
     void bulkReserve(uint32_t numEntries);
 

--- a/src/include/storage/storage_structure/in_mem_file.h
+++ b/src/include/storage/storage_structure/in_mem_file.h
@@ -15,7 +15,7 @@ namespace storage {
 // InMemFile holds a collection of in-memory page in the memory.
 class InMemFile {
 public:
-    explicit InMemFile(std::string filePath, common::VirtualFileSystem* vfs);
+    explicit InMemFile(std::string filePath, const common::VirtualFileSystem* vfs);
 
     uint32_t addANewPage(bool setToZero = false);
 

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -90,7 +90,7 @@ public:
         return std::make_pair(nodeGroupIdx, offsetInChunk);
     }
 
-    static std::string getNodeIndexFName(common::VirtualFileSystem* vfs,
+    static std::string getNodeIndexFName(const common::VirtualFileSystem* vfs,
         const std::string& directory, const common::table_id_t& tableID,
         common::FileVersionType dbFileType);
 

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -252,9 +252,7 @@ std::unique_ptr<QueryResult> Connection::executeAndAutoCommitIfNecessaryNoLock(
     }
     auto queryResult = std::make_unique<QueryResult>(preparedStatement->preparedSummary);
     auto profiler = std::make_unique<Profiler>();
-    auto executionContext = std::make_unique<ExecutionContext>(
-        clientContext->numThreadsForExecution, profiler.get(), database->memoryManager.get(),
-        database->bufferManager.get(), clientContext.get(), database->vfs.get(), database);
+    auto executionContext = std::make_unique<ExecutionContext>(profiler.get(), clientContext.get());
     profiler->enabled = preparedStatement->isProfile();
     auto executingTimer = TimeMetric(true /* enable */);
     executingTimer.start();

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -68,8 +68,9 @@ void HashAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
     }
     leadingState = unFlatKeyVectors.empty() ? flatKeyVectors[0]->state.get() :
                                               unFlatKeyVectors[0]->state.get();
-    localAggregateHashTable = make_unique<AggregateHashTable>(
-        *context->memoryManager, keyDataTypes, payloadDataTypes, aggregateFunctions, 0);
+    localAggregateHashTable =
+        make_unique<AggregateHashTable>(*context->clientContext->getMemoryManager(), keyDataTypes,
+            payloadDataTypes, aggregateFunctions, 0);
 }
 
 void HashAggregate::executeInternal(ExecutionContext* context) {
@@ -81,7 +82,7 @@ void HashAggregate::executeInternal(ExecutionContext* context) {
 }
 
 void HashAggregate::finalize(ExecutionContext* context) {
-    sharedState->combineAggregateHashTable(*context->memoryManager);
+    sharedState->combineAggregateHashTable(*context->clientContext->getMemoryManager());
     sharedState->finalizeAggregateHashTable();
 }
 

--- a/src/processor/operator/call/in_query_call.cpp
+++ b/src/processor/operator/call/in_query_call.cpp
@@ -27,8 +27,8 @@ void InQueryCall::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*
     }
     localState->rowIDVector = resultSet->getValueVector(inQueryCallInfo->rowIDPos).get();
     function::TableFunctionInitInput tableFunctionInitInput{inQueryCallInfo->bindData.get()};
-    localState->localState = inQueryCallInfo->function->initLocalStateFunc(
-        tableFunctionInitInput, sharedState->sharedState.get(), context->memoryManager);
+    localState->localState = inQueryCallInfo->function->initLocalStateFunc(tableFunctionInitInput,
+        sharedState->sharedState.get(), context->clientContext->getMemoryManager());
     localState->tableFunctionInput = function::TableFunctionInput{inQueryCallInfo->bindData.get(),
         localState->localState.get(), sharedState->sharedState.get()};
 }

--- a/src/processor/operator/filter.cpp
+++ b/src/processor/operator/filter.cpp
@@ -6,7 +6,7 @@ namespace kuzu {
 namespace processor {
 
 void Filter::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    expressionEvaluator->init(*resultSet, context->memoryManager);
+    expressionEvaluator->init(*resultSet, context->clientContext->getMemoryManager());
     KU_ASSERT(dataChunkToSelectPos != INVALID_DATA_CHUNK_POS);
     dataChunkToSelect = resultSet->dataChunks[dataChunkToSelectPos];
 }

--- a/src/processor/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/operator/hash_join/hash_join_build.cpp
@@ -27,8 +27,8 @@ void HashJoinBuild::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
     for (auto& pos : info->payloadsPos) {
         payloadVectors.push_back(resultSet->getValueVector(pos).get());
     }
-    hashTable = std::make_unique<JoinHashTable>(
-        *context->memoryManager, std::move(keyTypes), info->tableSchema->copy());
+    hashTable = std::make_unique<JoinHashTable>(*context->clientContext->getMemoryManager(),
+        std::move(keyTypes), info->tableSchema->copy());
 }
 
 void HashJoinBuild::setKeyState(common::DataChunkState* state) {

--- a/src/processor/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/operator/hash_join/hash_join_probe.cpp
@@ -23,9 +23,11 @@ void HashJoinProbe::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
     columnIdxsToReadFrom.resize(probeDataInfo.getNumPayloads());
     iota(
         columnIdxsToReadFrom.begin(), columnIdxsToReadFrom.end(), probeDataInfo.keysDataPos.size());
-    hashVector = std::make_unique<ValueVector>(LogicalTypeID::INT64, context->memoryManager);
+    hashVector = std::make_unique<ValueVector>(
+        LogicalTypeID::INT64, context->clientContext->getMemoryManager());
     if (keyVectors.size() > 1) {
-        tmpHashVector = std::make_unique<ValueVector>(LogicalTypeID::INT64, context->memoryManager);
+        tmpHashVector = std::make_unique<ValueVector>(
+            LogicalTypeID::INT64, context->clientContext->getMemoryManager());
     }
 }
 

--- a/src/processor/operator/index_scan.cpp
+++ b/src/processor/operator/index_scan.cpp
@@ -6,7 +6,7 @@ namespace kuzu {
 namespace processor {
 
 void IndexScan::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    indexEvaluator->init(*resultSet, context->memoryManager);
+    indexEvaluator->init(*resultSet, context->clientContext->getMemoryManager());
     indexVector = indexEvaluator->resultVector.get();
     outVector = resultSet->getValueVector(outDataPos).get();
 }

--- a/src/processor/operator/install_extension.cpp
+++ b/src/processor/operator/install_extension.cpp
@@ -16,7 +16,7 @@ using namespace kuzu::extension;
 bool InstallExtension::getNextTuplesInternal(ExecutionContext* context) {
     if (!hasExecuted) {
         hasExecuted = true;
-        installExtension(context->vfs, context->database);
+        installExtension(context->clientContext);
     }
     return false;
 }
@@ -44,9 +44,10 @@ std::string InstallExtension::tryDownloadExtension() {
 }
 
 void InstallExtension::saveExtensionToLocalFile(
-    const std::string& extensionData, VirtualFileSystem* vfs, main::Database* database) {
-    auto extensionDir = ExtensionUtils::getExtensionDir(database);
+    const std::string& extensionData, main::ClientContext* context) {
+    auto extensionDir = context->getExtensionDir();
     auto extensionPath = ExtensionUtils::getExtensionPath(extensionDir, name);
+    auto vfs = context->getVFS();
     if (!vfs->fileOrPathExists(extensionDir)) {
         vfs->createDir(extensionDir);
     }
@@ -55,9 +56,9 @@ void InstallExtension::saveExtensionToLocalFile(
         extensionData.size(), 0 /* offset */);
 }
 
-void InstallExtension::installExtension(VirtualFileSystem* vfs, main::Database* database) {
+void InstallExtension::installExtension(main::ClientContext* context) {
     auto extensionData = tryDownloadExtension();
-    saveExtensionToLocalFile(extensionData, vfs, database);
+    saveExtensionToLocalFile(extensionData, context);
 }
 
 } // namespace processor

--- a/src/processor/operator/load_extension.cpp
+++ b/src/processor/operator/load_extension.cpp
@@ -59,8 +59,7 @@ bool LoadExtension::getNextTuplesInternal(ExecutionContext* context) {
     }
     hasExecuted = true;
     if (!extension::ExtensionUtils::isFullPath(path)) {
-        path = ExtensionUtils::getExtensionPath(
-            ExtensionUtils::getExtensionDir(context->database), path);
+        path = ExtensionUtils::getExtensionPath(context->clientContext->getExtensionDir(), path);
     }
     auto libHdl = dlopen(path.c_str(), RTLD_NOW | RTLD_LOCAL);
     if (libHdl == nullptr) {
@@ -73,7 +72,7 @@ bool LoadExtension::getNextTuplesInternal(ExecutionContext* context) {
             stringFormat("Extension \"{}\" does not have a valid init function.\nError: {}", path,
                 dlErrMessage()));
     }
-    (*load)(*context->database);
+    (*load)(*context->clientContext->getDatabase());
     return true;
 }
 

--- a/src/processor/operator/order_by/order_by.cpp
+++ b/src/processor/operator/order_by/order_by.cpp
@@ -7,7 +7,7 @@ namespace processor {
 
 void OrderBy::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     localState = std::make_unique<SortLocalState>();
-    localState->init(*info, *sharedState, context->memoryManager);
+    localState->init(*info, *sharedState, context->clientContext->getMemoryManager());
     for (auto& dataPos : info->payloadsPos) {
         payloadVectors.push_back(resultSet->getValueVector(dataPos).get());
     }

--- a/src/processor/operator/order_by/order_by_merge.cpp
+++ b/src/processor/operator/order_by/order_by_merge.cpp
@@ -31,9 +31,9 @@ void OrderByMerge::executeInternal(ExecutionContext* /*context*/) {
 
 void OrderByMerge::initGlobalStateInternal(ExecutionContext* context) {
     // TODO(Ziyi): directly feed sharedState to merger and dispatcher.
-    sharedDispatcher->init(context->memoryManager, sharedState->getSortedKeyBlocks(),
-        sharedState->getPayloadTables(), sharedState->getStrKeyColInfo(),
-        sharedState->getNumBytesPerTuple());
+    sharedDispatcher->init(context->clientContext->getMemoryManager(),
+        sharedState->getSortedKeyBlocks(), sharedState->getPayloadTables(),
+        sharedState->getStrKeyColInfo(), sharedState->getNumBytesPerTuple());
 }
 
 } // namespace processor

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -272,7 +272,8 @@ void TopKLocalState::append(const std::vector<common::ValueVector*>& keyVectors,
 
 void TopK::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     localState = std::make_unique<TopKLocalState>();
-    localState->init(*info, context->memoryManager, *resultSet, skipNumber, limitNumber);
+    localState->init(
+        *info, context->clientContext->getMemoryManager(), *resultSet, skipNumber, limitNumber);
     for (auto& dataPos : info->payloadsPos) {
         payloadVectors.push_back(resultSet->getValueVector(dataPos).get());
     }

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -91,8 +91,8 @@ void Partitioner::initGlobalStateInternal(ExecutionContext* /*context*/) {
 
 void Partitioner::initLocalStateInternal(ResultSet* /*resultSet*/, ExecutionContext* context) {
     localState = std::make_unique<PartitionerLocalState>();
-    initializePartitioningStates(
-        localState->partitioningBuffers, sharedState->numPartitions, context->memoryManager);
+    initializePartitioningStates(localState->partitioningBuffers, sharedState->numPartitions,
+        context->clientContext->getMemoryManager());
 }
 
 static void constructDataChunk(DataChunk* dataChunk, const std::vector<DataPos>& columnPositions,

--- a/src/processor/operator/persistent/copy_node.cpp
+++ b/src/processor/operator/persistent/copy_node.cpp
@@ -17,9 +17,10 @@ void CopyNodeSharedState::init(ExecutionContext* context) {
     wal->logCopyTableRecord(table->getTableID(), TableType::NODE);
     wal->flushAllPages();
     if (pkType != *LogicalType::SERIAL()) {
-        auto indexFName = StorageUtils::getNodeIndexFName(
-            context->vfs, wal->getDirectory(), table->getTableID(), FileVersionType::ORIGINAL);
-        pkIndex = std::make_unique<PrimaryKeyIndexBuilder>(indexFName, pkType, context->vfs);
+        auto indexFName = StorageUtils::getNodeIndexFName(context->clientContext->getVFS(),
+            wal->getDirectory(), table->getTableID(), FileVersionType::ORIGINAL);
+        pkIndex = std::make_unique<PrimaryKeyIndexBuilder>(
+            indexFName, pkType, context->clientContext->getVFS());
         uint64_t numRows;
         if (readerSharedState != nullptr) {
             KU_ASSERT(distinctSharedState == nullptr);
@@ -166,7 +167,7 @@ void CopyNode::finalize(ExecutionContext* context) {
     auto outputMsg = stringFormat("{} number of tuples has been copied to table: {}.",
         sharedState->numTuples, info->tableName.c_str());
     FactorizedTableUtils::appendStringToTable(
-        sharedState->fTable.get(), outputMsg, context->memoryManager);
+        sharedState->fTable.get(), outputMsg, context->clientContext->getMemoryManager());
 }
 
 void CopyNode::copyToNodeGroup() {

--- a/src/processor/operator/persistent/copy_rdf.cpp
+++ b/src/processor/operator/persistent/copy_rdf.cpp
@@ -9,7 +9,7 @@ namespace processor {
 void CopyRdf::finalize(ExecutionContext* context) {
     auto outputMsg = common::stringFormat("Done copy rdf graph.");
     FactorizedTableUtils::appendStringToTable(
-        sharedState->fTable.get(), outputMsg, context->memoryManager);
+        sharedState->fTable.get(), outputMsg, context->clientContext->getMemoryManager());
 }
 
 } // namespace processor

--- a/src/processor/operator/persistent/copy_rel.cpp
+++ b/src/processor/operator/persistent/copy_rel.cpp
@@ -149,7 +149,7 @@ void CopyRel::finalize(ExecutionContext* context) {
         auto outputMsg = stringFormat("{} number of tuples has been copied to table {}.",
             sharedState->numRows.load(), info->schema->tableName);
         FactorizedTableUtils::appendStringToTable(
-            sharedState->fTable.get(), outputMsg, context->memoryManager);
+            sharedState->fTable.get(), outputMsg, context->clientContext->getMemoryManager());
     }
     sharedState->numRows.store(0);
     partitionerSharedState->resetState();

--- a/src/processor/operator/persistent/copy_to.cpp
+++ b/src/processor/operator/persistent/copy_to.cpp
@@ -4,11 +4,12 @@ namespace kuzu {
 namespace processor {
 
 void CopyTo::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    localState->init(info.get(), context->memoryManager, resultSet);
+    localState->init(info.get(), context->clientContext->getMemoryManager(), resultSet);
 }
 
 void CopyTo::initGlobalStateInternal(ExecutionContext* context) {
-    sharedState->init(info.get(), context->memoryManager, context->vfs);
+    sharedState->init(
+        info.get(), context->clientContext->getMemoryManager(), context->clientContext->getVFS());
 }
 
 void CopyTo::finalize(ExecutionContext* /*context*/) {

--- a/src/processor/operator/persistent/copy_to_csv.cpp
+++ b/src/processor/operator/persistent/copy_to_csv.cpp
@@ -176,7 +176,8 @@ void CopyToCSVLocalState::writeRows(CopyToCSVInfo* copyToCsvInfo) {
     }
 }
 
-void CopyToCSVSharedState::init(CopyToInfo* info, MemoryManager* /*mm*/, VirtualFileSystem* vfs) {
+void CopyToCSVSharedState::init(
+    CopyToInfo* info, MemoryManager* /*mm*/, const VirtualFileSystem* vfs) {
     fileInfo = vfs->openFile(info->fileName, O_WRONLY | O_CREAT | O_TRUNC);
     writeHeader(info);
 }

--- a/src/processor/operator/persistent/copy_to_parquet.cpp
+++ b/src/processor/operator/persistent/copy_to_parquet.cpp
@@ -28,7 +28,8 @@ void CopyToParquetLocalState::finalize(CopyToSharedState* sharedState) {
     reinterpret_cast<CopyToParquetSharedState*>(sharedState)->flush(*ft);
 }
 
-void CopyToParquetSharedState::init(CopyToInfo* info, MemoryManager* mm, VirtualFileSystem* vfs) {
+void CopyToParquetSharedState::init(
+    CopyToInfo* info, MemoryManager* mm, const VirtualFileSystem* vfs) {
     auto parquetInfo = reinterpret_cast<CopyToParquetInfo*>(info);
     writer = std::make_unique<ParquetWriter>(parquetInfo->fileName,
         LogicalType::copy(parquetInfo->types), parquetInfo->names, parquetInfo->codec, mm, vfs);

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -16,7 +16,8 @@ void NodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* /*context*
 void SingleLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
     NodeDeleteExecutor::init(resultSet, context);
     auto pkDataType = table->getColumn(table->getPKColumnID())->getDataType();
-    pkVector = std::make_unique<ValueVector>(*pkDataType, context->memoryManager);
+    pkVector =
+        std::make_unique<ValueVector>(*pkDataType, context->clientContext->getMemoryManager());
     pkVector->state = nodeIDVector->state;
 }
 
@@ -64,7 +65,8 @@ void MultiLabelNodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext* 
     NodeDeleteExecutor::init(resultSet, context);
     for (auto& [tableID, table] : tableIDToTableMap) {
         auto pkDataType = table->getColumn(table->getPKColumnID())->getDataType();
-        pkVectors[tableID] = std::make_unique<ValueVector>(*pkDataType, context->memoryManager);
+        pkVectors[tableID] =
+            std::make_unique<ValueVector>(*pkDataType, context->clientContext->getMemoryManager());
         pkVectors[tableID]->state = nodeIDVector->state;
     }
 }

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -28,7 +28,7 @@ void NodeInsertExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
         }
     }
     for (auto& evaluator : columnDataEvaluators) {
-        evaluator->init(*resultSet, context->memoryManager);
+        evaluator->init(*resultSet, context->clientContext->getMemoryManager());
         columnDataVectors.push_back(evaluator->resultVector.get());
     }
 }
@@ -111,7 +111,7 @@ void RelInsertExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
         }
     }
     for (auto& evaluator : columnDataEvaluators) {
-        evaluator->init(*resultSet, context->memoryManager);
+        evaluator->init(*resultSet, context->clientContext->getMemoryManager());
         columnDataVectors.push_back(evaluator->resultVector.get());
     }
 }

--- a/src/processor/operator/persistent/set_executor.cpp
+++ b/src/processor/operator/persistent/set_executor.cpp
@@ -10,7 +10,7 @@ void NodeSetExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
     if (lhsVectorPos.dataChunkPos != INVALID_DATA_CHUNK_POS) {
         lhsVector = resultSet->getValueVector(lhsVectorPos).get();
     }
-    evaluator->init(*resultSet, context->memoryManager);
+    evaluator->init(*resultSet, context->clientContext->getMemoryManager());
     rhsVector = evaluator->resultVector.get();
 }
 
@@ -87,7 +87,7 @@ void RelSetExecutor::init(ResultSet* resultSet, ExecutionContext* context) {
     if (lhsVectorPos.dataChunkPos != INVALID_DATA_CHUNK_POS) {
         lhsVector = resultSet->getValueVector(lhsVectorPos).get();
     }
-    evaluator->init(*resultSet, context->memoryManager);
+    evaluator->init(*resultSet, context->clientContext->getMemoryManager());
     rhsVector = evaluator->resultVector.get();
 }
 

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -15,7 +15,7 @@ using namespace kuzu::common;
 ParquetWriter::ParquetWriter(std::string fileName,
     std::vector<std::unique_ptr<common::LogicalType>> types, std::vector<std::string> columnNames,
     kuzu_parquet::format::CompressionCodec::type codec, storage::MemoryManager* mm,
-    VirtualFileSystem* vfs)
+    const VirtualFileSystem* vfs)
     : fileName{std::move(fileName)}, types{std::move(types)},
       columnNames{std::move(columnNames)}, codec{codec}, fileOffset{0}, mm{mm} {
     fileInfo = vfs->openFile(this->fileName, O_WRONLY | O_CREAT | O_TRUNC);

--- a/src/processor/operator/projection.cpp
+++ b/src/processor/operator/projection.cpp
@@ -8,7 +8,7 @@ namespace processor {
 void Projection::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     for (auto i = 0u; i < expressionEvaluators.size(); ++i) {
         auto& expressionEvaluator = *expressionEvaluators[i];
-        expressionEvaluator.init(*resultSet, context->memoryManager);
+        expressionEvaluator.init(*resultSet, context->clientContext->getMemoryManager());
         auto [outDataChunkPos, outValueVectorPos] = expressionsOutputPos[i];
         auto dataChunk = resultSet->dataChunks[outDataChunkPos];
         dataChunk->valueVectors[outValueVectorPos] = expressionEvaluator.resultVector;

--- a/src/processor/operator/recursive_extend/recursive_join.cpp
+++ b/src/processor/operator/recursive_extend/recursive_join.cpp
@@ -213,7 +213,7 @@ void RecursiveJoin::initLocalRecursivePlan(ExecutionContext* context) {
     }
     scanFrontier = (ScanFrontier*)op;
     localResultSet = std::make_unique<ResultSet>(
-        dataInfo->localResultSetDescriptor.get(), context->memoryManager);
+        dataInfo->localResultSetDescriptor.get(), context->clientContext->getMemoryManager());
     vectors->recursiveDstNodeIDVector =
         localResultSet->getValueVector(dataInfo->recursiveDstNodeIDPos).get();
     vectors->recursiveEdgeIDVector =

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -11,8 +11,8 @@ void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
     for (auto& pos : info->payloadPositions) {
         payloadVectors.push_back(resultSet->getValueVector(pos).get());
     }
-    localTable =
-        std::make_unique<FactorizedTable>(context->memoryManager, info->tableSchema->copy());
+    localTable = std::make_unique<FactorizedTable>(
+        context->clientContext->getMemoryManager(), info->tableSchema->copy());
 }
 
 void ResultCollector::executeInternal(ExecutionContext* context) {

--- a/src/processor/operator/unwind.cpp
+++ b/src/processor/operator/unwind.cpp
@@ -6,7 +6,7 @@ namespace kuzu {
 namespace processor {
 
 void Unwind::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    expressionEvaluator->init(*resultSet, context->memoryManager);
+    expressionEvaluator->init(*resultSet, context->clientContext->getMemoryManager());
     outValueVector = resultSet->getValueVector(outDataPos);
 }
 

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -12,7 +12,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-FileHandle::FileHandle(const std::string& path, uint8_t flags, VirtualFileSystem* vfs)
+FileHandle::FileHandle(const std::string& path, uint8_t flags, const VirtualFileSystem* vfs)
     : flags{flags} {
     if (!isNewTmpFile()) {
         constructExistingFileHandle(path, vfs);
@@ -21,7 +21,8 @@ FileHandle::FileHandle(const std::string& path, uint8_t flags, VirtualFileSystem
     }
 }
 
-void FileHandle::constructExistingFileHandle(const std::string& path, VirtualFileSystem* vfs) {
+void FileHandle::constructExistingFileHandle(
+    const std::string& path, const VirtualFileSystem* vfs) {
     int openFlags;
     if (isReadOnlyFile()) {
         openFlags = O_RDONLY;

--- a/src/storage/index/hash_index_builder.cpp
+++ b/src/storage/index/hash_index_builder.cpp
@@ -178,7 +178,7 @@ template class HashIndexBuilder<int64_t>;
 template class HashIndexBuilder<ku_string_t>;
 
 PrimaryKeyIndexBuilder::PrimaryKeyIndexBuilder(
-    const std::string& fName, const LogicalType& keyDataType, VirtualFileSystem* vfs)
+    const std::string& fName, const LogicalType& keyDataType, const VirtualFileSystem* vfs)
     : keyDataTypeID{keyDataType.getLogicalTypeID()} {
     auto fileHandle =
         std::make_shared<FileHandle>(fName, FileHandle::O_PERSISTENT_FILE_CREATE_NOT_EXISTS, vfs);

--- a/src/storage/storage_structure/in_mem_file.cpp
+++ b/src/storage/storage_structure/in_mem_file.cpp
@@ -14,7 +14,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-InMemFile::InMemFile(std::string filePath, common::VirtualFileSystem* vfs)
+InMemFile::InMemFile(std::string filePath, const common::VirtualFileSystem* vfs)
     : filePath{std::move(filePath)}, nextPosToAppend(0, 0) {
     fileInfo = vfs->openFile(this->filePath, O_CREAT | O_WRONLY);
     addANewPage();

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -51,8 +51,8 @@ std::string StorageUtils::getColumnName(
     }
 }
 
-std::string StorageUtils::getNodeIndexFName(VirtualFileSystem* vfs, const std::string& directory,
-    const table_id_t& tableID, FileVersionType fileVersionType) {
+std::string StorageUtils::getNodeIndexFName(const VirtualFileSystem* vfs,
+    const std::string& directory, const table_id_t& tableID, FileVersionType fileVersionType) {
     auto fName = stringFormat("n-{}", tableID);
     return appendWALFileSuffixIfNecessary(
         vfs->joinPath(directory, fName + StorageConstants::INDEX_FILE_SUFFIX), fileVersionType);

--- a/test/copy/e2e_copy_transaction_test.cpp
+++ b/test/copy/e2e_copy_transaction_test.cpp
@@ -25,9 +25,8 @@ public:
         createDBAndConn();
         catalog = getCatalog(*database);
         profiler = std::make_unique<Profiler>();
-        executionContext = std::make_unique<ExecutionContext>(1 /* numThreads */, profiler.get(),
-            getMemoryManager(*database), getBufferManager(*database), getClientContext(*conn),
-            getFileSystem(*database), database.get());
+        executionContext =
+            std::make_unique<ExecutionContext>(profiler.get(), getClientContext(*conn));
     }
 
     void initWithoutLoadingGraph() {

--- a/test/ddl/e2e_ddl_test.cpp
+++ b/test/ddl/e2e_ddl_test.cpp
@@ -25,9 +25,8 @@ public:
             BufferPoolConstants::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING);
         memoryManager =
             std::make_unique<MemoryManager>(bufferManager.get(), getFileSystem(*database));
-        executionContext = std::make_unique<ExecutionContext>(1 /* numThreads */, profiler.get(),
-            memoryManager.get(), bufferManager.get(), conn->clientContext.get(),
-            getFileSystem(*database), database.get());
+        executionContext =
+            std::make_unique<ExecutionContext>(profiler.get(), conn->clientContext.get());
         personTableID = catalog->getTableID(&DUMMY_READ_TRANSACTION, "person");
         studyAtTableID = catalog->getTableID(&DUMMY_READ_TRANSACTION, "studyAt");
     }

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -47,12 +47,12 @@ Binder exception: Upper bound of rel  exceeds maximum: 10.
 ---- ok
 -STATEMENT CALL current_setting('enable_semi_mask') RETURN *
 ---- 1
-true
+True
 -STATEMENT CALL enable_semi_mask=false
 ---- ok
 -STATEMENT CALL current_setting('enable_semi_mask') RETURN *
 ---- 1
-false
+False
 
 -LOG CallTransaction
 -STATEMENT BEGIN TRANSACTION READ ONLY;


### PR DESCRIPTION
Removes the following fileds from executionContext:
```
    uint64_t numThreads;
    storage::MemoryManager* memoryManager;
    storage::BufferManager* bufferManager;
    common::VirtualFileSystem* vfs;
    main::Database* database;
```
Saves the database inside the clientContext.