### PR TITLE
Avoid unnecessary rewrites of catalog and stats files

### DIFF
--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -98,9 +98,15 @@ public:
 private:
     CatalogContent* getVersion(transaction::Transaction* tx) const;
 
-    bool hasUpdates() { return readWriteVersion != nullptr; }
+    inline bool hasUpdates() const { return isUpdated; }
+
+    inline void setToUpdated() { isUpdated = true; }
+    inline void resetToNotUpdated() { isUpdated = false; }
 
 protected:
+    // The flat indicates if the readWriteVersion has been updated and is different from the
+    // readOnlyVersion.
+    bool isUpdated;
     std::unique_ptr<CatalogContent> readOnlyVersion;
     std::unique_ptr<CatalogContent> readWriteVersion;
     storage::WAL* wal;

--- a/src/include/processor/operator/persistent/copy_rel.h
+++ b/src/include/processor/operator/persistent/copy_rel.h
@@ -88,8 +88,8 @@ public:
 
 private:
     inline bool isCopyAllowed() const {
-        return sharedState->getNextRelOffset(
-                   transaction::Transaction::getDummyReadOnlyTrx().get()) == 0;
+        return sharedState->getNextRelOffset(transaction::Transaction::getDummyWriteTrx().get()) ==
+               0;
     }
 
     void prepareCSRNodeGroup(common::DataChunkCollection* partition,

--- a/src/include/storage/stats/rels_store_statistics.h
+++ b/src/include/storage/stats/rels_store_statistics.h
@@ -29,8 +29,8 @@ public:
         common::table_id_t tableID, transaction::Transaction* transaction) const {
         auto& tableStatisticPerTable =
             transaction->getType() == transaction::TransactionType::READ_ONLY ?
-                tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable :
-                tablesStatisticsContentForWriteTrx->tableStatisticPerTable;
+                readOnlyVersion->tableStatisticPerTable :
+                readWriteVersion->tableStatisticPerTable;
         KU_ASSERT(tableStatisticPerTable.contains(tableID));
         return (RelTableStats*)tableStatisticPerTable[tableID].get();
     }
@@ -71,8 +71,7 @@ protected:
     }
 
     inline void increaseNextRelOffset(common::table_id_t relTableID, uint64_t numTuples) {
-        ((RelTableStats*)tablesStatisticsContentForWriteTrx->tableStatisticPerTable.at(relTableID)
-                .get())
+        ((RelTableStats*)readWriteVersion->tableStatisticPerTable.at(relTableID).get())
             ->incrementNextRelOffset(numTuples);
     }
 };

--- a/src/storage/stats/property_statistics.cpp
+++ b/src/storage/stats/property_statistics.cpp
@@ -45,8 +45,10 @@ void RWPropertyStats::setHasNull(const transaction::Transaction& transaction) {
     // properly align properties and chunks.
     if (propertyID != common::INVALID_PROPERTY_ID) {
         KU_ASSERT(tablesStatistics);
-        tablesStatistics->getPropertyStatisticsForTable(transaction, tableID, propertyID)
-            .setHasNull();
+        auto propStats =
+            tablesStatistics->getPropertyStatisticsForTable(transaction, tableID, propertyID);
+        propStats.setHasNull();
+        tablesStatistics->setPropertyStatisticsForTable(tableID, propertyID, propStats);
     }
 }
 

--- a/src/storage/stats/table_statistics_collection.cpp
+++ b/src/storage/stats/table_statistics_collection.cpp
@@ -16,8 +16,8 @@ namespace storage {
 
 TablesStatistics::TablesStatistics(BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
     common::VirtualFileSystem* vfs)
-    : metadataFH{metadataFH}, bufferManager{bufferManager}, vfs{vfs}, wal{wal} {
-    tablesStatisticsContentForReadOnlyTrx = std::make_unique<TablesStatisticsContent>();
+    : metadataFH{metadataFH}, bufferManager{bufferManager}, vfs{vfs}, wal{wal}, isUpdated{false} {
+    readOnlyVersion = std::make_unique<TablesStatisticsContent>();
 }
 
 void TablesStatistics::readFromFile() {
@@ -28,7 +28,7 @@ void TablesStatistics::readFromFile(FileVersionType fileVersionType) {
     auto filePath = getTableStatisticsFilePath(wal->getDirectory(), fileVersionType);
     auto deser =
         Deserializer(std::make_unique<BufferedFileReader>(vfs->openFile(filePath, O_RDONLY)));
-    deser.deserializeUnorderedMap(tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable);
+    deser.deserializeUnorderedMap(readOnlyVersion->tableStatisticPerTable);
 }
 
 void TablesStatistics::saveToFile(const std::string& directory, FileVersionType fileVersionType,
@@ -37,9 +37,9 @@ void TablesStatistics::saveToFile(const std::string& directory, FileVersionType 
     auto ser = Serializer(
         std::make_unique<BufferedFileWriter>(vfs->openFile(filePath, O_WRONLY | O_CREAT)));
     auto& tablesStatisticsContent = (transactionType == transaction::TransactionType::READ_ONLY ||
-                                        tablesStatisticsContentForWriteTrx == nullptr) ?
-                                        tablesStatisticsContentForReadOnlyTrx :
-                                        tablesStatisticsContentForWriteTrx;
+                                        readWriteVersion == nullptr) ?
+                                        readOnlyVersion :
+                                        readWriteVersion;
     ser.serializeUnorderedMap(tablesStatisticsContent->tableStatisticPerTable);
 }
 
@@ -49,12 +49,10 @@ void TablesStatistics::initTableStatisticsForWriteTrx() {
 }
 
 void TablesStatistics::initTableStatisticsForWriteTrxNoLock() {
-    if (tablesStatisticsContentForWriteTrx == nullptr) {
-        tablesStatisticsContentForWriteTrx = std::make_unique<TablesStatisticsContent>();
-        for (auto& [tableID, tableStatistic] :
-            tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable) {
-            tablesStatisticsContentForWriteTrx->tableStatisticPerTable[tableID] =
-                tableStatistic->copy();
+    if (readWriteVersion == nullptr) {
+        readWriteVersion = std::make_unique<TablesStatisticsContent>();
+        for (auto& [tableID, tableStatistic] : readOnlyVersion->tableStatisticPerTable) {
+            readWriteVersion->tableStatisticPerTable[tableID] = tableStatistic->copy();
         }
     }
 }
@@ -62,15 +60,13 @@ void TablesStatistics::initTableStatisticsForWriteTrxNoLock() {
 PropertyStatistics& TablesStatistics::getPropertyStatisticsForTable(
     const transaction::Transaction& transaction, table_id_t tableID, property_id_t propertyID) {
     if (transaction.isReadOnly()) {
-        KU_ASSERT(tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable.contains(tableID));
-        auto tableStatistics =
-            tablesStatisticsContentForReadOnlyTrx->tableStatisticPerTable.at(tableID).get();
+        KU_ASSERT(readOnlyVersion->tableStatisticPerTable.contains(tableID));
+        auto tableStatistics = readOnlyVersion->tableStatisticPerTable.at(tableID).get();
         return tableStatistics->getPropertyStatistics(propertyID);
     } else {
         initTableStatisticsForWriteTrx();
-        KU_ASSERT(tablesStatisticsContentForWriteTrx->tableStatisticPerTable.contains(tableID));
-        auto tableStatistics =
-            tablesStatisticsContentForWriteTrx->tableStatisticPerTable.at(tableID).get();
+        KU_ASSERT(readWriteVersion && readWriteVersion->tableStatisticPerTable.contains(tableID));
+        auto tableStatistics = readWriteVersion->tableStatisticPerTable.at(tableID).get();
         return tableStatistics->getPropertyStatistics(propertyID);
     }
 }
@@ -78,9 +74,9 @@ PropertyStatistics& TablesStatistics::getPropertyStatisticsForTable(
 void TablesStatistics::setPropertyStatisticsForTable(
     table_id_t tableID, property_id_t propertyID, PropertyStatistics stats) {
     initTableStatisticsForWriteTrx();
-    KU_ASSERT(tablesStatisticsContentForWriteTrx->tableStatisticPerTable.contains(tableID));
-    auto tableStatistics =
-        tablesStatisticsContentForWriteTrx->tableStatisticPerTable.at(tableID).get();
+    KU_ASSERT(readWriteVersion && readWriteVersion->tableStatisticPerTable.contains(tableID));
+    setToUpdated();
+    auto tableStatistics = readWriteVersion->tableStatisticPerTable.at(tableID).get();
     tableStatistics->setPropertyStatistics(propertyID, stats);
 }
 


### PR DESCRIPTION
Currently, for each write transaction, we will always rewrite the catalog, node and rel stats file. In most cases, some of these rewrites are unnecessary. For small transactions, the rewrites cause performance degrades.