### PR TITLE
Optimize packed csr deletions

### DIFF
--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -98,6 +98,7 @@ public:
     inline uint64_t getCapacity() const { return capacity; }
     inline uint64_t getNumValues() const { return numValues; }
     void setNumValues(uint64_t numValues_);
+    virtual bool numValuesSanityCheck() const;
 
 protected:
     // Initializes the data buffer. Is (and should be) only called in constructor.

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -47,8 +47,8 @@ public:
         LocalVectorCollection* localChunk, const offset_to_row_idx_t& insertInfo,
         const offset_to_row_idx_t& updateInfo) override;
     bool canCommitInPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, common::offset_t dstOffset, ColumnChunk* chunk,
-        common::offset_t dataOffset, common::length_t length) override;
+        common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
+        ColumnChunk* chunk, common::offset_t srcOffset) override;
     void commitLocalChunkInPlace(Transaction* /*transaction*/, node_group_idx_t nodeGroupIdx,
         LocalVectorCollection* localChunk, const offset_to_row_idx_t& insertInfo,
         const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo) override;

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -68,8 +68,8 @@ private:
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
         const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo) override;
     bool canCommitInPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, common::offset_t dstOffset, ColumnChunk* chunk,
-        common::offset_t dataOffset, common::length_t length) override;
+        common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
+        ColumnChunk* chunk, common::offset_t srcOffset) override;
 
     bool canDictionaryAndIndexCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, uint64_t numNewStrings,

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -38,8 +38,8 @@ public:
         const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo,
         const offset_set_t& deleteInfo) override;
     void prepareCommitForChunk(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, common::offset_t csrOffset, ColumnChunk* chunk,
-        common::offset_t dataOffset, common::length_t numValues) override;
+        common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
+        ColumnChunk* chunk, common::offset_t startSrcOffset) override;
 
 protected:
     void scanInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
@@ -51,8 +51,8 @@ protected:
         common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
         const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo) override;
     bool canCommitInPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, common::offset_t dstOffset, ColumnChunk* chunk,
-        common::offset_t dataOffset, common::length_t length) override;
+        common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
+        ColumnChunk* chunk, common::offset_t dataOffset) override;
 
 private:
     std::vector<std::unique_ptr<Column>> childColumns;

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -28,10 +28,14 @@ protected:
         bool isCSR) final;
     void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
+    void copy(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
+        common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
     void resize(uint64_t newCapacity) final;
 
     void resetToEmpty() final;
+
+    bool numValuesSanityCheck() const override;
 
 private:
     std::vector<std::unique_ptr<ColumnChunk>> childChunks;

--- a/src/include/storage/store/var_list_column.h
+++ b/src/include/storage/store/var_list_column.h
@@ -90,9 +90,9 @@ private:
         return false;
     }
     inline bool canCommitInPlace(transaction::Transaction* /*transaction*/,
-        common::node_group_idx_t /*nodeGroupIdx*/, common::offset_t /*dstOffset*/,
-        ColumnChunk* /*chunk*/, common::offset_t /*startOffset*/,
-        common::length_t /*length*/) override {
+        common::node_group_idx_t /*nodeGroupIdx*/,
+        const std::vector<common::offset_t>& /*dstOffsets*/, ColumnChunk* /*chunk*/,
+        common::offset_t /*startOffset*/) override {
         // Always perform out-of-place commit for VAR_LIST columns.
         return false;
     }

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -356,6 +356,13 @@ void ColumnChunk::setNumValues(uint64_t numValues_) {
     }
 }
 
+bool ColumnChunk::numValuesSanityCheck() const {
+    if (nullChunk) {
+        return numValues == nullChunk->getNumValues();
+    }
+    return numValues <= capacity;
+}
+
 ColumnChunkMetadata ColumnChunk::getMetadataToFlush() const {
     KU_ASSERT(numValues <= capacity);
     if (enableCompression) {
@@ -522,8 +529,7 @@ public:
         }
     }
 
-    void write(common::ValueVector* vector, common::offset_t offsetInVector,
-        common::offset_t offsetInChunk) final {
+    void write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) final {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::FIXED_LIST);
         KU_ASSERT(offsetInChunk < capacity);
         nullChunk->write(vector, offsetInVector, offsetInChunk);

--- a/test/test_files/transaction/delete_rel/delete_all_rels_from_large_list.test
+++ b/test/test_files/transaction/delete_rel/delete_all_rels_from_large_list.test
@@ -56,7 +56,6 @@
 <FILE>:delete_rels.txt
 
 -CASE detachDeleteNodeWithLageList
--SKIP
 -STATEMENT MATCH (p:person)-[e:knows]->(:person) RETURN COUNT(*);
 ---- 1
 2351

--- a/test/test_files/transaction/delete_rel/delete_large_num_rels_from_large_list.test
+++ b/test/test_files/transaction/delete_rel/delete_large_num_rels_from_large_list.test
@@ -1,6 +1,5 @@
 -GROUP DeleteRelTest_deleteLargeNumRelsFromLargeList
 -DATASET CSV rel-update-tests
--SKIP
 --
 
 -CASE deleteLargeNumRelsFromLargeListCommitNormalExecution

--- a/test/test_files/transaction/delete_rel/delete_multiple_rels.test
+++ b/test/test_files/transaction/delete_rel/delete_multiple_rels.test
@@ -1,6 +1,5 @@
 -GROUP DeleteRelTest
 -DATASET CSV rel-update-tests
--SKIP
 --
 
 -CASE deleteMultipleRelsCommitNormalExecution

--- a/test/test_files/update_node/create_empty.test
+++ b/test/test_files/update_node/create_empty.test
@@ -21,6 +21,7 @@
 ---- 1
 {age: 10, isTrue: True, name: A}
 
+#FIX-ME: This case is due to the bug of reading under write transaction. #2647
 -CASE CreateStructWithWriteTransaction
 -SKIP
 -STATEMENT CREATE NODE TABLE test(id INT64, prop STRUCT(age INT64, name STRING), PRIMARY KEY(id));

--- a/test/test_files/update_rel/create_read_tinysnb.test
+++ b/test/test_files/update_rel/create_read_tinysnb.test
@@ -2,9 +2,7 @@
 -DATASET CSV tinysnb
 --
 
-#FIX-ME: Failed on Windows
 -CASE CreateRelRead1
--SKIP
 -STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 0 AND b.ID = 2 CREATE (a)-[e:knows {date:date('2023-03-03')}]->(b) RETURN id(e), e.date;
 ---- 1
 0:14|2023-03-03

--- a/test/test_files/update_rel/delete_tinysnb.test
+++ b/test/test_files/update_rel/delete_tinysnb.test
@@ -2,6 +2,26 @@
 -DATASET CSV tinysnb
 --
 
+-CASE DeleteFromKnows1
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 RETURN COUNT(*)
+---- 1
+3
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 AND b.ID=3 DELETE e
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 AND b.ID=3 RETURN COUNT(*)
+---- 1
+0
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 RETURN COUNT(*)
+---- 1
+2
+
+-CASE DeleteFromKnows2
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 AND b.ID>=3 DELETE e
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 RETURN COUNT(*)
+---- 1
+1
+
 -CASE DeleteRelMultiLabel1
 -STATEMENT MATCH (a:person)-[e]->(b:person) WHERE a.ID = 0 RETURN COUNT(*)
 ---- 1


### PR DESCRIPTION
This PR optimizes the logic of applying deletions to columns. Specifically, it removes the logic of `prepareCommitForChunk` for each nodeOffset, which can result into one out-of-place commits per nodeOffset. After the change, we first figure out the slides need to be done, then only call `prepareCommitForChunk` once for each column.

Several delete tests are un-skipped after the changes. 