### PR TITLE
Shell Search Improvements

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -37,7 +37,7 @@ struct ShellCommand {
 
 const char* TAB = "    ";
 
-const std::array<const char*, 104> keywordList = {"CALL", "CREATE", "DELETE", "DETACH", "EXISTS",
+const std::array<const char*, 103> keywordList = {"CALL", "CREATE", "DELETE", "DETACH", "EXISTS",
     "FOREACH", "LOAD", "MATCH", "MERGE", "OPTIONAL", "REMOVE", "RETURN", "SET", "START", "UNION",
     "UNWIND", "WITH", "LIMIT", "ORDER", "SKIP", "WHERE", "YIELD", "ASC", "ASCENDING", "ASSERT",
     "BY", "CSV", "DESC", "DESCENDING", "ON", "ALL", "CASE", "ELSE", "END", "THEN", "WHEN", "AND",
@@ -45,7 +45,7 @@ const std::array<const char*, 104> keywordList = {"CALL", "CREATE", "DELETE", "D
     "CONSTRAINT", "DROP", "EXISTS", "INDEX", "NODE", "KEY", "UNIQUE", "INDEX", "JOIN", "PERIODIC",
     "COMMIT", "SCAN", "USING", "FALSE", "NULL", "TRUE", "ADD", "DO", "FOR", "MANDATORY", "OF",
     "REQUIRE", "SCALAR", "EXPLAIN", "PROFILE", "HEADERS", "FROM", "FIELDTERMINATOR", "STAR",
-    "MINUS", "COUNT", "PRIMARY", "COPY", "RDF", "GRAPH", "ALTER", "RENAME", "COMMENT", "MACRO",
+    "MINUS", "COUNT", "PRIMARY", "COPY", "RDFGRAPH", "ALTER", "RENAME", "COMMENT", "MACRO",
     "GLOB", "COLUMN", "GROUP", "DEFAULT", "TO", "BEGIN", "TRANSACTION", "READ", "ONLY", "WRITE",
     "COMMIT_SKIP_CHECKPOINT", "ROLLBACK", "ROLLBACK_SKIP_CHECKPOINT", "INSTALL", "EXTENSION", "SHORTEST"};
 

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -192,6 +192,8 @@ using namespace kuzu::utf8proc;
 
 #define LINENOISE_DEFAULT_HISTORY_MAX_LEN 100
 #define LINENOISE_MAX_LINE 4096
+#define LINENOISE_HISTORY_NEXT 0
+#define LINENOISE_HISTORY_PREV 1
 static const char* unsupported_term[] = {"dumb", "cons25", "emacs", NULL};
 static linenoiseCompletionCallback* completionCallback = NULL;
 static linenoiseHintsCallback* hintsCallback = NULL;
@@ -236,6 +238,7 @@ struct linenoiseState {
     std::string search_buf;                  //! The search buffer
     std::vector<searchMatch> search_matches; //! The set of search matches in our history
     std::string prev_search_match;           //! The previous search match
+    int prev_search_match_history_index;     //! The previous search match history index
     size_t search_index;                     //! The current match index
 };
 
@@ -256,6 +259,7 @@ enum KEY_ACTION {
     CTRL_N = 14,    /* Ctrl-n */
     CTRL_P = 16,    /* Ctrl-p */
     CTRL_R = 18,    /* Ctrl-r */
+    CTRL_S = 19,
     CTRL_T = 20,    /* Ctrl-t */
     CTRL_U = 21,    /* Ctrl+u */
     CTRL_W = 23,    /* Ctrl+w */
@@ -266,6 +270,7 @@ enum KEY_ACTION {
 static void linenoiseAtExit(void);
 int linenoiseHistoryAdd(const char* line);
 static void refreshLine(struct linenoiseState* l);
+void linenoiseEditHistoryNext(struct linenoiseState* l, int dir);
 
 std::string oldInput = "";
 bool inputLeft;
@@ -1154,6 +1159,7 @@ static void refreshSearch(struct linenoiseState* l) {
     bool no_matches = l->search_index >= l->search_matches.size();
     if (l->search_buf.empty()) {
         l->prev_search_match = l->buf;
+        l->prev_search_match_history_index = history_len - 1 - l->history_index;
         search_prompt = "bck-i-search: _";
     } else {
         std::string search_text;
@@ -1177,7 +1183,7 @@ static void refreshSearch(struct linenoiseState* l) {
 
     linenoiseState clone = *l;
     l->plen = search_prompt.size();
-    if (no_matches || l->search_buf.empty()) {
+    if (no_matches) {
         // if there are no matches render the no_matches_text
         l->buf = (char*)no_matches_text.c_str();
         l->len = no_matches_text.size();
@@ -1191,6 +1197,7 @@ static void refreshSearch(struct linenoiseState* l) {
         l->len = strlen(history[history_index]);
         l->pos = cursor_position;
         l->prev_search_match = l->buf;
+        l->prev_search_match_history_index = history_index;
     }
     refreshSearchMultiLine(l, search_prompt.c_str());
 
@@ -1210,6 +1217,10 @@ static void cancelSearch(linenoiseState* l) {
     l->len = strlen(tempBuf);
     l->pos = l->len;
 
+    history_len--;
+    free(history[history_len]);
+    linenoiseHistoryAdd("");
+
     l->search = false;
     l->search_buf = std::string();
     l->search_matches.clear();
@@ -1218,17 +1229,31 @@ static void cancelSearch(linenoiseState* l) {
 }
 
 static char acceptSearch(linenoiseState* l, char nextCommand) {
-    auto history_entry = (char*) l->prev_search_match.c_str();
-    l->pos = strlen(history_entry);
+    int history_index = l->prev_search_match_history_index;
     if (l->search_index < l->search_matches.size()) {
         // if there is a match - copy it into the buffer
         auto match = l->search_matches[l->search_index];
-        history_entry = history[match.history_index];
-        l->pos = match.match_end;
+        history_index = match.history_index;
     }
-    auto history_len = strlen(history_entry);
-    memcpy(l->buf, history_entry, history_len);
-    l->buf[history_len] = '\0';
+
+    while (history_len > 1 && history_index != (history_len - 1 - l->history_index)) {
+        /* Update the current history entry before to
+            * overwrite it with the next one. */
+        free(history[history_len - 1 - l->history_index]);
+        history[history_len - 1 - l->history_index] = strdup(l->buf);
+        /* Show the new entry */
+        l->history_index += (history_index < (history_len - 1 - l->history_index)) ? 1 : -1;
+        if (l->history_index < 0) {
+            l->history_index = 0;
+            break;
+        } else if (l->history_index >= history_len) {
+            l->history_index = history_len - 1;
+            break;
+        }
+        strncpy(l->buf, history[history_len - 1 - l->history_index], l->buflen);
+        l->buf[l->buflen - 1] = '\0';
+        l->len = l->pos = strlen(l->buf);
+    }
 
     cancelSearch(l);
     return nextCommand;
@@ -1242,46 +1267,58 @@ static void performSearch(linenoiseState* l) {
     }
     l->search_matches.clear();
     l->search_index = 0;
-    if (l->search_buf.empty()) {
-        return;
-    }
     std::unordered_set<std::string> matches;
-    auto lsearch = l->search_buf;
-    kuzu::common::StringUtils::toLower(lsearch);
-    for (size_t i = history_len; i > 0; i--) {
-        size_t history_index = i - 1;
-        auto lhistory = std::string(history[history_index]);
-        kuzu::common::StringUtils::toLower(lhistory);
-        if (matches.find(lhistory) != matches.end()) {
-            continue;
-        }
-        matches.insert(lhistory);
-        auto entry = lhistory.find(lsearch);
-        if (entry != std::string::npos) {
-            if (history_index == current_match) {
-                l->search_index = l->search_matches.size();
+    if (l->search_buf.empty()) {
+        // we match everything if search_buf is empty
+        for (size_t i = history_len; i > 0; i--) {
+            size_t history_index = i - 1;
+            auto lhistory = std::string(history[history_index]);
+            kuzu::common::StringUtils::toLower(lhistory);
+            if (matches.find(lhistory) != matches.end()) {
+                continue;
             }
+            matches.insert(lhistory);
             searchMatch match;
             match.history_index = history_index;
-            match.match_start = entry;
-            match.match_end = entry + lsearch.size();
+            match.match_start = 0;
+            match.match_end = 0;
             l->search_matches.push_back(match);
         }
-    }
+    } else {
+        auto lsearch = l->search_buf;
+        kuzu::common::StringUtils::toLower(lsearch);
+        for (size_t i = history_len; i > 0; i--) {
+            size_t history_index = i - 1;
+            auto lhistory = std::string(history[history_index]);
+            kuzu::common::StringUtils::toLower(lhistory);
+            if (matches.find(lhistory) != matches.end()) {
+                continue;
+            }
+            matches.insert(lhistory);
+            auto entry = lhistory.find(lsearch);
+            if (entry != std::string::npos) {
+                if (history_index == current_match) {
+                    l->search_index = l->search_matches.size();
+                }
+                searchMatch match;
+                match.history_index = history_index;
+                match.match_start = entry;
+                match.match_end = entry + lsearch.size();
+                l->search_matches.push_back(match);
+            }
+        }
+    }    
 }
 
 static void searchPrev(linenoiseState* l) {
     if (l->search_index > 0) {
         l->search_index--;
-    } else if (l->search_matches.size() > 0) {
-        l->search_index = l->search_matches.size() - 1;
     }
 }
 
 static void searchNext(linenoiseState* l) {
-    l->search_index += 1;
-    if (l->search_index >= l->search_matches.size()) {
-        l->search_index = 0;
+    if (l->search_index < l->search_matches.size() - 1) {
+        l->search_index += 1;
     }
 }
 
@@ -1296,6 +1333,10 @@ static char linenoiseSearch(linenoiseState *l, char c) {
 		// move to the next match index
 		searchNext(l);
 		break;
+    case CTRL_S:
+        // move to the prev match index
+        searchPrev(l);
+        break;
 	case ESC: /* escape sequence */
 		/* Read the next two bytes representing the escape sequence.
 		 * Use two calls to handle slow terminals returning the two
@@ -1337,11 +1378,15 @@ static char linenoiseSearch(linenoiseState *l, char c) {
 			} else {
 				switch (seq[1]) {
 				case 'A': /* Up */
-					searchPrev(l);
-					break;
+                    // accepts search without any additional command
+                    c = acceptSearch(l, 0);
+                    linenoiseEditHistoryNext(l, LINENOISE_HISTORY_PREV);
+					return c;
 				case 'B': /* Down */
-					searchNext(l);
-					break;
+                    // accepts search without any additional command
+                    c = acceptSearch(l, 0);
+                    linenoiseEditHistoryNext(l, LINENOISE_HISTORY_NEXT);
+                    return c;
 				case 'D': /* Left */
 					return acceptSearch(l, CTRL_B);
 				case 'C': /* Right */
@@ -1396,6 +1441,9 @@ static char linenoiseSearch(linenoiseState *l, char c) {
 	case CTRL_C:
 	case CTRL_G:
 		// abort search
+        l->buf[0] = '\0';
+        l->len = 0;
+        l->pos = 0;
 		cancelSearch(l);
 		return 0;
 	case BACKSPACE: /* backspace */
@@ -1546,8 +1594,6 @@ void linenoiseEditMoveEnd(struct linenoiseState* l) {
 
 /* Substitute the currently edited line with the next or previous history
  * entry as specified by 'dir'. */
-#define LINENOISE_HISTORY_NEXT 0
-#define LINENOISE_HISTORY_PREV 1
 void linenoiseEditHistoryNext(struct linenoiseState* l, int dir) {
     if (history_len > 1) {
         /* Update the current history entry before to
@@ -1798,12 +1844,18 @@ static int linenoiseEdit(
         case CTRL_N: /* ctrl-n */
             linenoiseEditHistoryNext(&l, LINENOISE_HISTORY_NEXT);
             break;
+        case CTRL_S:
         case CTRL_R: /* ctrl-r */ {
             // initiate reverse search
             l.search = true;
             l.search_buf = std::string();
             l.search_matches.clear();
             l.search_index = 0;
+            l.prev_search_match_history_index = history_len - 1 - l.history_index;
+            history_len--;
+            free(history[history_len]);
+            linenoiseHistoryAdd(l.buf);
+            performSearch(&l);
             refreshSearch(&l);
             break;
         }


### PR DESCRIPTION
I have read and agree to the CLA of the Kuzu repository.

* Consecutive Ctrl+R's goes to previous commands when no search has been typed
* Up and down arrows navigates to next and prev commands from search result
* Rdfgraph is highlighted instead of rdf and graph