### PR TITLE
Better error message when inserting to serial pk table with primary key

### DIFF
--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -129,11 +129,18 @@ static void validatePrimaryKeyExistence(
     auto nodeTableSchema = ku_dynamic_cast<const TableSchema*, const NodeTableSchema*>(tableSchema);
     auto primaryKey = nodeTableSchema->getPrimaryKey();
     if (*primaryKey->getDataType() == *LogicalType::SERIAL()) {
+        if (node.hasPropertyDataExpr(primaryKey->getName())) {
+            throw BinderException(
+                common::stringFormat("The primary key of {} is serial, specifying primary key "
+                                     "value is not allowed in the create statement.",
+                    tableSchema->tableName));
+        }
         return; // No input needed for SERIAL primary key.
     }
     if (!node.hasPropertyDataExpr(primaryKey->getName())) {
-        throw BinderException("Create node " + node.toString() + " expects primary key " +
-                              primaryKey->getName() + " as input.");
+        throw BinderException(
+            common::stringFormat("Create node {} expects primary key {} as input.", node.toString(),
+                primaryKey->getName()));
     }
 }
 

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -641,3 +641,10 @@ Binder exception: Cannot match a built-in function for given function +(TIMESTAM
 (INTERVAL,DATE) -> DATE
 (TIMESTAMP,INTERVAL) -> TIMESTAMP
 (INTERVAL,TIMESTAMP) -> TIMESTAMP
+
+-LOG CreateWithSerialPK
+-STATEMENT create node table Person(id serial, primary key(id));
+---- ok
+-STATEMENT create (:Person {id: 0});
+---- error
+Binder exception: The primary key of Person is serial, specifying primary key value is not allowed in the create statement.


### PR DESCRIPTION
Give error message when the user tries to create a node with primary key in the serial table.
Closes #2775 