### PR TITLE
Restructure build pipeline with the new free M1 runner

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -109,8 +109,7 @@ jobs:
       - name: Install OpenSSL
         run: |
           brew install openssl@3
-          OPENSSL_BIN_PATH=$(readlink -f /opt/homebrew/Cellar/openssl@3/*/bin/openssl)
-          OPENSSL_ROOT=dirname $(dirname $OPENSSL_BIN_PATH)
+          OPENSSL_ROOT=$(readlink -f /opt/homebrew/Cellar/openssl@3/*/)
           echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT" >> $GITHUB_ENV
 
       - name: Build precompiled extensions

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -109,7 +109,7 @@ jobs:
       - name: Install OpenSSL
         run: |
           brew install openssl@3
-          OPENSSL_BIN_PATH=$(readlink -f /opt/homebrew/bin/openssl)
+          OPENSSL_BIN_PATH=$(readlink -f /opt/homebrew/Cellar/openssl@3/*/bin/openssl)
           OPENSSL_ROOT=dirname $(dirname $OPENSSL_BIN_PATH)
           echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT" >> $GITHUB_ENV
 

--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -102,16 +102,22 @@ jobs:
         run: docker stop kuzu-x86
 
   build-mac-extensions-arm64:
-    runs-on: self-hosted-mac-arm
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
+
+      - name: Install OpenSSL
+        run: |
+          brew install openssl@3
+          OPENSSL_BIN_PATH=$(readlink -f /opt/homebrew/bin/openssl)
+          OPENSSL_ROOT=dirname $(dirname $OPENSSL_BIN_PATH)
+          echo "OPENSSL_ROOT_DIR=$OPENSSL_ROOT" >> $GITHUB_ENV
 
       - name: Build precompiled extensions
         run: make extension-release LTO=1 NUM_THREADS=$(nproc)
         env:
           MACOSX_DEPLOYMENT_TARGET: 11.0
           CMAKE_OSX_ARCHITECTURES: "arm64"
-          OPENSSL_ROOT_DIR: /opt/homebrew/Cellar/openssl@3/3.2.0_1/
 
       - name: Collect built artifacts
         run: |

--- a/.github/workflows/linux-wheel-workflow.yml
+++ b/.github/workflows/linux-wheel-workflow.yml
@@ -33,7 +33,8 @@ jobs:
           path: ./scripts/pip-package/wheelhouse/*manylinux2014_x86_64.whl
 
   build-linux-wheels-aarch64:
-    runs-on: kuzu-self-hosted-linux-building-aarch64
+    # Make sure this job runs on the larger self-hosted Linux ARM64 machine
+    runs-on: [kuzu-self-hosted-linux-building-aarch64, ac3]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/mac-java-workflow.yml
+++ b/.github/workflows/mac-java-workflow.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-mac-java-arm:
-    runs-on: self-hosted-mac-arm
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/mac-nodejs-workflow.yml
+++ b/.github/workflows/mac-nodejs-workflow.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-mac-nodejs-arm64:
-    runs-on: self-hosted-mac-arm
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/mac-precompiled-bin-workflow.yml
+++ b/.github/workflows/mac-precompiled-bin-workflow.yml
@@ -6,12 +6,9 @@ on:
 
 jobs:
   build-precompiled-bin-arm64:
-    runs-on: self-hosted-mac-arm
+    runs-on: macos-14
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install networkx
-        run: python3 -m pip install networkx --user
 
       - name: Build precompiled binaries for Apple Silicon
         run: |
@@ -52,9 +49,6 @@ jobs:
     runs-on: self-hosted-mac-x64
     steps:
       - uses: actions/checkout@v3
-
-      - name: Install networkx
-        run: python3 -m pip install networkx --user
 
       - name: Build precompiled binaries for Intel
         run: |

--- a/.github/workflows/mac-wheel-workflow.yml
+++ b/.github/workflows/mac-wheel-workflow.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-wheels-arm64:
-    runs-on: self-hosted-mac-arm
+    runs-on: self-hosted-mac-x64
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/windows-precompiled-bin-workflow.yml
+++ b/.github/workflows/windows-precompiled-bin-workflow.yml
@@ -10,9 +10,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Install networkx
-        run: python.exe -m pip install networkx --user
-
       - name: Build precompiled binaries
         shell: cmd
         run: |


### PR DESCRIPTION
GitHub has recently launched the [new free Apple M1 runner](https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/). In this PR, I restructure the build pipeline by utilizing this new free resource in order to make the build process more efficient.

Changes:
- Move ARM64 macOS build jobs to the free Apple M1 runner as much as possible.
- For Python wheel builld on macOS, move the job to the self-hosted Mac Pro runner.
- With the changes above, the self-hosted ARM64 Mac runner is now freed up, and is repurposed as a Linux ARM64 builder.

By utilizing the new free Apple M1 runner and restructuring the build pipeline, now the end-to-end time for running the entire build pipeline decreased from ~1 hour 30 minutes to ~37 minutes (2.4x improvement 🎉).

The changes are verified by: https://github.com/kuzudb/kuzu/actions/runs/7766578441/