### PR TITLE
Fix issue-2779

### DIFF
--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -206,6 +206,9 @@ void Binder::bindInsertRel(
         pNode->addPropertyDataExpr(
             std::string(rdf::IRI), rel->getPropertyDataExpr(std::string(rdf::IRI)));
         bindInsertNode(pNode, infos);
+        auto nodeInsertInfo = &infos[infos.size() - 1];
+        KU_ASSERT(nodeInsertInfo->columnExprs.size() == 1);
+        nodeInsertInfo->iriReplaceExpr = rel->getPropertyExpression(std::string(rdf::IRI));
         // Insert triple rel.
         auto relInsertInfo = BoundInsertInfo(TableType::REL, rel);
         std::unordered_map<std::string, std::shared_ptr<Expression>> relPropertyRhsExpr;

--- a/src/include/binder/query/updating_clause/bound_insert_info.h
+++ b/src/include/binder/query/updating_clause/bound_insert_info.h
@@ -12,6 +12,14 @@ struct BoundInsertInfo {
     std::shared_ptr<Expression> pattern;
     expression_vector columnExprs;
     expression_vector columnDataExprs;
+    // When we insert RDF triples through create statement,
+    // e.g. CREATE (s {iri:a})-[p {iri:b}]->(o {iri:c})
+    // We will compile 3 iri insertions to resource table. They are s.iri, o.iri
+    // and p'.iri (note this is not p.iri because we are inserting iri to rel table)
+    // followed by 1 insertion to triple table.
+    // When we need to RETURN p.iri after insertion. We need to replace all p'.iri with p.iri.
+    // Otherwise, no operator can p.iri into scope.
+    std::shared_ptr<Expression> iriReplaceExpr;
     common::ConflictAction conflictAction;
 
     BoundInsertInfo(common::TableType tableType, std::shared_ptr<Expression> pattern)
@@ -22,7 +30,8 @@ struct BoundInsertInfo {
 private:
     BoundInsertInfo(const BoundInsertInfo& other)
         : tableType{other.tableType}, pattern{other.pattern}, columnExprs{other.columnExprs},
-          columnDataExprs{other.columnDataExprs}, conflictAction{other.conflictAction} {}
+          columnDataExprs{other.columnDataExprs}, iriReplaceExpr{other.iriReplaceExpr},
+          conflictAction{other.conflictAction} {}
 };
 
 } // namespace binder

--- a/src/planner/plan/append_insert.cpp
+++ b/src/planner/plan/append_insert.cpp
@@ -11,11 +11,23 @@ namespace planner {
 std::unique_ptr<LogicalInsertInfo> Planner::createLogicalInsertInfo(const BoundInsertInfo* info) {
     auto insertInfo = std::make_unique<LogicalInsertInfo>(info->tableType, info->pattern,
         info->columnExprs, info->columnDataExprs, info->conflictAction);
+    if (info->iriReplaceExpr != nullptr) { // See bound_insert_info.h for explanation.
+        insertInfo->columnExprs = expression_vector{info->iriReplaceExpr};
+        KU_ASSERT(insertInfo->columnExprs.size() == 1);
+        auto projectIri = false;
+        for (auto& property : propertiesToScan) {
+            if (*property == *info->iriReplaceExpr) {
+                projectIri = true;
+            }
+        }
+        insertInfo->isReturnColumnExprs.push_back(projectIri);
+        return insertInfo;
+    }
     binder::expression_set propertyExprSet;
     for (auto& expr : getProperties(*info->pattern)) {
         propertyExprSet.insert(expr);
     }
-    for (auto& expr : info->columnExprs) {
+    for (auto& expr : insertInfo->columnExprs) {
         insertInfo->isReturnColumnExprs.push_back(propertyExprSet.contains(expr));
     }
     return insertInfo;

--- a/test/test_files/rdf/tinysnb.test
+++ b/test/test_files/rdf/tinysnb.test
@@ -1,0 +1,56 @@
+-GROUP TinySnbReadTest
+-DATASET CSV tinysnb
+
+--
+
+-CASE RdfAndPropertyGraph
+
+-STATEMENT CREATE RDFGraph R;
+---- ok
+-STATEMENT CREATE (a:R_r {iri: "a"})-[e:R_rt {iri: "b"}]->(b:R_r {iri: "c"}) RETURN a.iri, e.iri, b.iri;
+---- 1
+a|b|c
+-STATEMENT MATCH (a)-[e:knows|:R]->(b) RETURN *;
+---- error
+Binder exception: Relationship pattern e contains both property graph relationship label knows and RDFGraph label R. Mixing two tables in the same relationship pattern is not supported.
+-STATEMENT MATCH (a)-[:marries|:R*]->(b) RETURN *;
+---- error
+Binder exception: Relationship pattern  contains both property graph relationship label marries and RDFGraph label R. Mixing two tables in the same relationship pattern is not supported.
+-STATEMENT MATCH (a:person:R_r) RETURN a.fName, a.iri;
+---- 11
+Alice|
+Bob|
+Carol|
+Dan|
+Elizabeth|
+Farooq|
+Greg|
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|
+|a
+|b
+|c
+-STATEMENT MATCH (a:person:R_r)-[e:knows]->(b:person:R_r) RETURN a.fName, a.iri, b.fName, b.iri;
+---- 14
+Alice||Bob|
+Alice||Carol|
+Alice||Dan|
+Bob||Alice|
+Bob||Carol|
+Bob||Dan|
+Carol||Alice|
+Carol||Bob|
+Carol||Dan|
+Dan||Alice|
+Dan||Bob|
+Dan||Carol|
+Elizabeth||Farooq|
+Elizabeth||Greg|
+-STATEMENT MATCH (a:person:R_r)-[e:R_rt]->(b:person:R_r) RETURN a.fName, a.iri, e.iri, b.fName, b.iri;
+---- 1
+|a|b||c
+-STATEMENT MATCH (a:R_r)-[e:R]->(b:R_r) DELETE e RETURN a.iri, e.iri, b.iri;
+---- 1
+a|b|c
+-STATEMENT MATCH (a:R_r)-[e:R]->(b:R_r) RETURN COUNT(*)
+---- 1
+0


### PR DESCRIPTION
Fix issue #2779. 

Disable mixing labels of rdf rel table and property graph rel table. This should at least avoid the segfault in #2798 