### PR TITLE
remove counting from copy csv

### DIFF
--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -177,11 +177,6 @@ std::unique_ptr<function::TableFuncSharedState> ParallelCSVScan::initSharedState
     auto bindData = reinterpret_cast<function::ScanBindData*>(input.bindData);
     auto csvConfig = CSVReaderConfig::construct(bindData->config.options);
     common::row_idx_t numRows = 0;
-    for (const auto& path : bindData->config.filePaths) {
-        auto reader = make_unique<SerialCSVReader>(
-            path, csvConfig.option.copy(), bindData->columnNames.size(), bindData->context);
-        numRows += reader->countRows();
-    }
     return std::make_unique<ParallelCSVScanSharedState>(bindData->config.copy(), numRows,
         bindData->columnNames.size(), bindData->context, csvConfig.copy());
 }

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -99,11 +99,6 @@ std::unique_ptr<function::TableFuncSharedState> SerialCSVScan::initSharedState(
     auto bindData = reinterpret_cast<function::ScanBindData*>(input.bindData);
     auto csvConfig = CSVReaderConfig::construct(bindData->config.options);
     common::row_idx_t numRows = 0;
-    for (const auto& path : bindData->config.filePaths) {
-        auto reader = make_unique<SerialCSVReader>(
-            path, csvConfig.option.copy(), bindData->columnNames.size(), bindData->context);
-        numRows += reader->countRows();
-    }
     return std::make_unique<SerialCSVScanSharedState>(bindData->config.copy(), numRows,
         bindData->columnNames.size(), csvConfig.copy(), bindData->context);
 }


### PR DESCRIPTION
With the support of rehash, we no longer need to count the number of rows in csv files.