### PR TITLE
Add RDFVariant support to the Rust API

### DIFF
--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -26,8 +26,6 @@ links = "kuzu"
 
 [dependencies]
 cxx = "1.0"
-num-derive = "0.3"
-num-traits = "0.2"
 time = "0.3"
 arrow = {version="43", optional=true, default-features=false, features=["ffi"]}
 uuid = "1.6"

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -121,6 +121,9 @@ fn build_ffi(
     if bundled {
         build.define("KUZU_BUNDLED", None);
     }
+    if get_target() == "debug" {
+        build.define("ENABLE_RUNTIME_CHECKS", "1");
+    }
     if link_mode() == "static" {
         build.define("KUZU_STATIC_DEFINE", None);
     }

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -41,6 +41,7 @@ pub(crate) mod ffi {
     // From types.h
     // Note: cxx will check if values change, but not if they are added.
     #[namespace = "kuzu::common"]
+    #[repr(u8)]
     #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     enum LogicalTypeID {
         ANY = 0,
@@ -82,6 +83,7 @@ pub(crate) mod ffi {
         STRUCT = 53,
         MAP = 54,
         UNION = 55,
+        RDF_VARIANT = 56,
 
         UUID = 58,
     }
@@ -241,6 +243,8 @@ pub(crate) mod ffi {
         fn logical_type_get_struct_field_types(
             value: &LogicalType,
         ) -> UniquePtr<CxxVector<LogicalType>>;
+
+        fn create_logical_type_rdf_variant() -> UniquePtr<LogicalType>;
     }
 
     #[namespace = "kuzu_rs"]
@@ -345,7 +349,7 @@ pub(crate) mod ffi {
         fn create_value_timestamp_ns(value: i64) -> UniquePtr<Value>;
         fn create_value_timestamp_ms(value: i64) -> UniquePtr<Value>;
         fn create_value_timestamp_sec(value: i64) -> UniquePtr<Value>;
-        fn create_value_date(value: i64) -> UniquePtr<Value>;
+        fn create_value_date(value: i32) -> UniquePtr<Value>;
         fn create_value_interval(months: i32, days: i32, micros: i64) -> UniquePtr<Value>;
         fn create_value_int128_t(high: i64, low: u64) -> UniquePtr<Value>;
         fn create_value_uuid_t(high: i64, low: u64) -> UniquePtr<Value>;
@@ -369,5 +373,7 @@ pub(crate) mod ffi {
 
         fn recursive_rel_get_nodes(value: &Value) -> &Value;
         fn recursive_rel_get_rels(value: &Value) -> &Value;
+
+        fn get_blob_from_bytes(value: &Vec<u8>) -> Vec<u8>;
     }
 }

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -262,9 +262,6 @@ std::unique_ptr<kuzu::common::Value> create_value_timestamp_ms(const int64_t tim
 std::unique_ptr<kuzu::common::Value> create_value_timestamp_sec(const int64_t timestamp) {
     return std::make_unique<kuzu::common::Value>(kuzu::common::timestamp_sec_t(timestamp));
 }
-std::unique_ptr<kuzu::common::Value> create_value_date(const int64_t date) {
-    return std::make_unique<kuzu::common::Value>(kuzu::common::date_t(date));
-}
 std::unique_ptr<kuzu::common::Value> create_value_interval(
     const int32_t months, const int32_t days, const int64_t micros) {
     return std::make_unique<kuzu::common::Value>(kuzu::common::interval_t(months, days, micros));

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -44,6 +44,7 @@ mod error;
 mod ffi;
 mod logical_type;
 mod query_result;
+mod rdf_variant;
 mod value;
 
 pub use connection::{Connection, PreparedStatement};
@@ -51,6 +52,7 @@ pub use database::{Database, LoggingLevel, SystemConfig};
 pub use error::Error;
 pub use logical_type::LogicalType;
 pub use query_result::{CSVOptions, QueryResult};
+pub use rdf_variant::RDFVariant;
 pub use value::{InternalID, NodeVal, RelVal, Value};
 
 #[cfg(feature = "arrow")]

--- a/tools/rust_api/src/logical_type.rs
+++ b/tools/rust_api/src/logical_type.rs
@@ -81,6 +81,7 @@ pub enum LogicalType {
         types: Vec<(String, LogicalType)>,
     },
     UUID,
+    RDFVariant,
 }
 
 impl From<&ffi::Value> for LogicalType {
@@ -174,6 +175,7 @@ impl From<&ffi::LogicalType> for LogicalType {
                 }
             }
             LogicalTypeID::UUID => LogicalType::UUID,
+            LogicalTypeID::RDF_VARIANT => LogicalType::RDFVariant,
             // Should be unreachable, as cxx will check that the LogicalTypeID enum matches the one
             // on the C++ side.
             x => panic!("Unsupported type {:?}", x),
@@ -243,6 +245,7 @@ impl From<&LogicalType> for cxx::UniquePtr<ffi::LogicalType> {
                 key_type,
                 value_type,
             } => ffi::create_logical_type_map(key_type.as_ref().into(), value_type.as_ref().into()),
+            LogicalType::RDFVariant => ffi::create_logical_type_rdf_variant(),
         }
     }
 }
@@ -284,6 +287,7 @@ impl LogicalType {
             LogicalType::Map { .. } => LogicalTypeID::MAP,
             LogicalType::Union { .. } => LogicalTypeID::UNION,
             LogicalType::UUID => LogicalTypeID::UUID,
+            LogicalType::RDFVariant => LogicalTypeID::RDF_VARIANT,
         }
     }
 }

--- a/tools/rust_api/src/rdf_variant.rs
+++ b/tools/rust_api/src/rdf_variant.rs
@@ -1,0 +1,69 @@
+use crate::ffi::ffi;
+use std::fmt;
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum RDFVariant {
+    Bool(bool),
+    Int64(i64),
+    Int32(i32),
+    Int16(i16),
+    Int8(i8),
+    UInt64(u64),
+    UInt32(u32),
+    UInt16(u16),
+    UInt8(u8),
+    Double(f64),
+    Float(f32),
+    Date(time::Date),
+    Interval(time::Duration),
+    Timestamp(time::OffsetDateTime),
+    String(String),
+    Blob(Vec<u8>),
+}
+
+impl fmt::Display for RDFVariant {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            RDFVariant::Bool(true) => write!(f, "True"),
+            RDFVariant::Bool(false) => write!(f, "False"),
+            RDFVariant::Int8(x) => write!(f, "{x}"),
+            RDFVariant::Int16(x) => write!(f, "{x}"),
+            RDFVariant::Int32(x) => write!(f, "{x}"),
+            RDFVariant::Int64(x) => write!(f, "{x}"),
+            RDFVariant::UInt8(x) => write!(f, "{x}"),
+            RDFVariant::UInt16(x) => write!(f, "{x}"),
+            RDFVariant::UInt32(x) => write!(f, "{x}"),
+            RDFVariant::UInt64(x) => write!(f, "{x}"),
+            RDFVariant::Double(x) => write!(f, "{x}"),
+            RDFVariant::Float(x) => write!(f, "{x}"),
+            RDFVariant::Date(x) => write!(f, "{x}"),
+            RDFVariant::Interval(x) => write!(f, "{x}"),
+            RDFVariant::Timestamp(x) => write!(f, "{x}"),
+            RDFVariant::String(x) => write!(f, "{x}"),
+            RDFVariant::Blob(x) => write!(f, "{x:x?}"),
+        }
+    }
+}
+
+impl From<&RDFVariant> for ffi::LogicalTypeID {
+    fn from(item: &RDFVariant) -> Self {
+        match item {
+            RDFVariant::Bool(_) => ffi::LogicalTypeID::BOOL,
+            RDFVariant::Int8(_) => ffi::LogicalTypeID::INT8,
+            RDFVariant::Int16(_) => ffi::LogicalTypeID::INT16,
+            RDFVariant::Int32(_) => ffi::LogicalTypeID::INT32,
+            RDFVariant::Int64(_) => ffi::LogicalTypeID::INT64,
+            RDFVariant::UInt8(_) => ffi::LogicalTypeID::UINT8,
+            RDFVariant::UInt16(_) => ffi::LogicalTypeID::UINT16,
+            RDFVariant::UInt32(_) => ffi::LogicalTypeID::UINT32,
+            RDFVariant::UInt64(_) => ffi::LogicalTypeID::UINT64,
+            RDFVariant::Double(_) => ffi::LogicalTypeID::DOUBLE,
+            RDFVariant::Float(_) => ffi::LogicalTypeID::FLOAT,
+            RDFVariant::Date(_) => ffi::LogicalTypeID::DATE,
+            RDFVariant::Timestamp(_) => ffi::LogicalTypeID::TIMESTAMP,
+            RDFVariant::Interval(_) => ffi::LogicalTypeID::INTERVAL,
+            RDFVariant::String(_) => ffi::LogicalTypeID::STRING,
+            RDFVariant::Blob(_) => ffi::LogicalTypeID::BLOB,
+        }
+    }
+}


### PR DESCRIPTION
~~Blobs aren't working. The variant storing a `blob_t` instead of the actual blob data is a little weird from an ownership perspective, but that still shouldn't prevent reading them.~~ Update: short string blobs are working, but long ones seem to be broken (and I don't think are tested elsewhere).

But the rest works, so I thought I'd get this PR going anyway.