### PR TITLE
Hash Index parallel strings

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -132,6 +132,7 @@ jobs:
         run: |
           cargo update -p half@2.3.1 --precise '2.2.1'
           cargo update -p time --precise '0.3.23'
+          cargo update -p ahash --precise '0.8.7'
           cargo test --features arrow -- --test-threads=1
 
       - name: Rust example

--- a/src/include/storage/storage_structure/in_mem_file.h
+++ b/src/include/storage/storage_structure/in_mem_file.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <atomic>
+
+#include "common/constants.h"
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
 #include "storage/storage_structure/in_mem_page.h"
@@ -15,29 +18,38 @@ namespace storage {
 // InMemFile holds a collection of in-memory page in the memory.
 class InMemFile {
 public:
-    explicit InMemFile(std::string filePath, common::VirtualFileSystem* vfs);
+    explicit InMemFile(std::string filePath, common::VirtualFileSystem* vfs,
+        std::atomic<common::page_idx_t>& pageCounter);
 
-    uint32_t addANewPage(bool setToZero = false);
+    void addANewPage();
 
-    inline InMemPage* getPage(common::page_idx_t pageIdx) const { return pages[pageIdx].get(); }
+    inline InMemPage* getPage(common::page_idx_t pageIdx) const { return pages.at(pageIdx).get(); }
 
     // This function appends a string if the length of the string is larger than SHORT_STR_LENGTH,
     // otherwise, construct the ku_string for the rawString and return it.
     // Note that this function is not thread safe.
-    common::ku_string_t appendString(std::string_view rawString);
-    inline common::ku_string_t appendString(const char* rawString) {
-        return appendString(std::string_view(rawString));
+    void appendString(std::string_view rawString, common::ku_string_t& result);
+    inline void appendString(const char* rawString, common::ku_string_t& result) {
+        appendString(std::string_view(rawString), result);
     }
 
     std::string readString(common::ku_string_t* strInInMemOvfFile) const;
+    bool equals(std::string_view keyToLookup, const common::ku_string_t& keyInEntry) const;
 
     void flush();
 
+    inline common::page_idx_t getNextPageIndex(common::page_idx_t currentPageIndex) const {
+        return *(common::page_idx_t*)(getPage(currentPageIndex)->data + END_OF_PAGE);
+    }
+
 private:
+    static const uint64_t END_OF_PAGE =
+        common::BufferPoolConstants::PAGE_4KB_SIZE - sizeof(common::page_idx_t);
     std::string filePath;
     std::unique_ptr<common::FileInfo> fileInfo;
-    std::vector<std::unique_ptr<InMemPage>> pages;
+    std::unordered_map<common::page_idx_t, std::unique_ptr<InMemPage>> pages;
     PageCursor nextPosToAppend;
+    std::atomic<common::page_idx_t>& pageCounter;
 };
 
 } // namespace storage


### PR DESCRIPTION
Allows string primary keys to be written in parallel without locking.
Fixes #2626

Instead of a single shared `InMemFile` used to store the string data, each of the concurrent hash indexes stores its own `InMemFile`, and a shared atomic counter is used to reserve pages. Each page stores the next page from that particular index in the last four bytes at the end so that strings split across pages can be pieced together. The `InMemFile` stores pages in an `std::unordered_map` since they are no longer contiguous by index and we need to be able to lookup the pages by their on-disk index when doing in-memory comparisons (this leads to a slight performance decrease compared to the initial test I'd reported in #2626, but not very significant).

A small amount of space is wasted due to how the `DiskOverflowFile` currently works, as it appends new strings starting at the beginning of a fresh page, so the empty space in the 256 partial pages written during the copy will be lost (similar to before, but it's now 256 pages instead of 1). This could be a bit of a bloating issue on small databases (#2625) (though on very small databases not all 256 `InMemFile`s will be used), but it's <1MB, so on large databases it's not too significant.

Performance is very good compared to before, giving speedups of about 5.5x-15x on the 12-core machine I was testing on (and it should scale well on machines with more parallelism). Using the same tests mentioned in https://github.com/kuzudb/kuzu/issues/2626#issuecomment-1934522147, that is, a CSV with 60M lines and a table with just a primary key column, copy takes:
- ~5.5 seconds for a dataset of only short strings (which don't touch the overflow file, but before still used the lock), compared to ~30 seconds on master
- ~16 seconds for a dataset of only long strings (~29 characters long) compared to ~239 seconds on master.