### PR TITLE
Use lockfile to pin all versions used by rust build in main pipeline

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -123,21 +123,14 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Rust share build
-        # Share build cache when building rust API and the example project
-        run: echo $'[workspace]\nmembers = ["tools/rust_api","examples/rust"]' > Cargo.toml
-
       - name: Rust test
         working-directory: tools/rust_api
         run: |
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
-          cargo update -p ahash --precise '0.8.7'
-          cargo test --features arrow -- --test-threads=1
+          cargo test --locked --features arrow -- --test-threads=1
 
       - name: Rust example
         working-directory: examples/rust
-        run: cargo build --features arrow
+        run: cargo build --locked --features arrow
 
   gcc-build-test-with-asan:
     name: gcc build & test with asan
@@ -283,9 +276,7 @@ jobs:
           set KUZU_TESTING=1
           set CFLAGS=/MDd
           set CXXFLAGS=/MDd /std:c++20
-          cargo update -p half@2.3.1 --precise 2.2.1
-          cargo update -p time --precise '0.3.23'
-          cargo test -- --test-threads=1
+          cargo test --locked -- --test-threads=1
 
       - name: Java test
         shell: cmd
@@ -466,10 +457,6 @@ jobs:
           ulimit -n 10240
           make javatest
 
-      - name: Rust share build
-        # Share build cache when building rust API and the example project
-        run: echo $'[workspace]\nmembers = ["tools/rust_api","examples/rust"]' > Cargo.toml
-
       - name: Rust test
         run: |
           ulimit -n 10240
@@ -481,4 +468,4 @@ jobs:
         run: |
           ulimit -n 10240
           source /Users/runner/.cargo/env
-          cargo build --features arrow
+          cargo build --locked --features arrow

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -60,8 +60,6 @@ jobs:
       - name: Rust test
         working-directory: tools/rust_api
         run: |
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
           cargo test --release --features arrow -- --test-threads=1
 
       - name: Rust example
@@ -118,8 +116,6 @@ jobs:
       - name: Rust test
         working-directory: tools/rust_api
         run: |
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
           cargo test --release --features arrow -- --test-threads=1
 
       - name: Rust example
@@ -202,8 +198,6 @@ jobs:
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set CXXFLAGS=/std:c++20
           set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
           cargo test --release --features arrow -- --test-threads=1
 
       - name: Rust example
@@ -280,8 +274,6 @@ jobs:
       - name: Rust test
         working-directory: tools/rust_api
         run: |
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
           cargo test --release --features arrow -- --test-threads=1
 
       - name: Rust example
@@ -377,8 +369,6 @@ jobs:
       - name: Rust test
         working-directory: tools/rust_api
         run: |
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
           cargo test --release --features arrow -- --test-threads=1
 
       - name: Rust example
@@ -452,8 +442,6 @@ jobs:
       - name: Rust test
         working-directory: tools/rust_api
         run: |
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
           cargo test --release --features arrow -- --test-threads=1
 
       - name: Rust example
@@ -519,8 +507,6 @@ jobs:
       - name: Rust test
         working-directory: tools/rust_api
         run: |
-          cargo update -p half@2.3.1 --precise '2.2.1'
-          cargo update -p time --precise '0.3.23'
           cargo test --release --features arrow -- --test-threads=1
 
       - name: Rust example

--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ pytest: python
 	cmake -E env PYTHONPATH=tools/python_api/build python3 -m pytest -v tools/python_api/test
 
 rusttest: rust
-	cd tools/rust_api && cargo test --all-features -- --test-threads=1
+	cd tools/rust_api && cargo test --locked --all-features -- --test-threads=1
 
 # Other misc build targets
 benchmark:

--- a/tools/rust_api/.gitignore
+++ b/tools/rust_api/.gitignore
@@ -1,2 +1,1 @@
 target
-Cargo.lock

--- a/tools/rust_api/Cargo.lock
+++ b/tools/rust_api/Cargo.lock
@@ -41,6 +41,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
+
+[[package]]
 name = "arrow"
 version = "43.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +344,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
+
+[[package]]
 name = "getrandom"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,21 +428,15 @@ dependencies = [
 name = "kuzu"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "cmake",
  "cxx",
  "cxx-build",
  "num_cpus",
+ "tempfile",
  "time",
  "uuid",
-]
-
-[[package]]
-name = "kuzu-rust-example"
-version = "0.1.0"
-dependencies = [
- "arrow",
- "kuzu",
 ]
 
 [[package]]
@@ -507,6 +523,12 @@ checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
 
 [[package]]
 name = "log"
@@ -666,6 +688,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
+name = "rustix"
+version = "0.38.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea3e1a662af26cd7a3ba09c0297a31af215563ecf42817c98df621387f4e949"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "scratch"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -709,6 +744,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a365e8cd18e44762ef95d87f284f4b5cd04107fec2ff3052bd6a3e6069669e67"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -725,6 +772,7 @@ checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
 dependencies = [
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -732,6 +780,15 @@ name = "time-core"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+dependencies = [
+ "time-core",
+]
 
 [[package]]
 name = "tiny-keccak"
@@ -862,6 +919,15 @@ name = "windows-core"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
  "windows-targets",
 ]

--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -2,8 +2,8 @@
 name = "kuzu"
 version = "0.1.0"
 description = "An in-process property graph database management system built for query speed and scalability"
-# Note: 1.63 required for building tests
-rust-version = "1.51"
+# Note: 1.72 required for testing due to latest dependencies of the arrow feature
+rust-version = "1.60"
 readme = "kuzu-src/README.md"
 homepage = "http://kuzudb.com/"
 repository = "https://github.com/kuzudb/kuzu"

--- a/tools/rust_api/src/query_result.rs
+++ b/tools/rust_api/src/query_result.rs
@@ -191,7 +191,7 @@ impl<'qr> Iterator for ArrowIterator<'qr> {
             )
             .expect("Failed to get next recordbatch");
             let struct_array: arrow::array::StructArray =
-                arrow::ffi::from_ffi(array.0, &self.schema)
+                unsafe { arrow::ffi::from_ffi(array.0, &self.schema) }
                     .expect("Failed to convert ArrowArray from C data")
                     .into();
             Some(struct_array.into())


### PR DESCRIPTION
Also removed pinning from the other jobs, and bumped MSRV to 1.60 (required for features with the dep: prefix).

I've removed the workspace insertion to share build directories between the example and the rust API since that necessarily moves the lock file into the root. I think the better solution may be to move the example into `tools/rust_api`, and maybe symlink `examples/rust` to that, so that the workspace can exist permanently in `tools/rust_api`.

As far as I can tell, ignoring dependency MSRVs ours should be 1.60. Without the arrow feature, the latest version of our dependencies will require 1.65, and with the arrow feature that increases to 1.72. I think it might be appropriate to leave 1.60 as the MSRV listed in `Cargo.toml`, but to internally treat it as 1.72, mark this in a comment, and make sure all the CI machines use at least that version. Anyone using kuzu will see error messages such as `ahash v0.8.8 cannot be built because it requires rustc 1.72.0 or newer...`, which is easy to understand.

I'm going to leave the arrow dependency at version 43, since newer than that requires rust 1.70 explicitly. When we've updated CI we can bump that to version 50 (the latest).