### PR TITLE
Fix serial column metadata

### DIFF
--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -185,8 +185,11 @@ public:
         KU_UNREACHABLE;
     }
 
-    void append(ColumnChunk* /*columnChunk*/, uint64_t nodeGroupIdx) override {
+    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override {
+        ColumnChunkMetadata metadata;
+        metadata.numValues = columnChunk->getNumValues();
         metadataDA->resize(nodeGroupIdx + 1);
+        metadataDA->update(nodeGroupIdx, metadata);
     }
 };
 

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -102,6 +102,7 @@ uint64_t NodeGroup::append(const std::vector<ValueVector*>& columnVectors,
     for (auto i = 0u; i < chunks.size(); i++) {
         auto chunk = chunks[i].get();
         if (chunk->getDataType().getLogicalTypeID() == common::LogicalTypeID::SERIAL) {
+            chunk->setNumValues(chunk->getNumValues() + numValuesToAppendInChunk);
             serialSkip++;
             continue;
         }

--- a/test/test_files/update_node/create_empty.test
+++ b/test/test_files/update_node/create_empty.test
@@ -89,6 +89,22 @@ foobar|
 {_ID: 0:0, _LABEL: A, pk1: 0}
 {_ID: 1:0, _LABEL: B, pk2: 0}
 
+-CASE CreateAndCopySerial
+-STATEMENT CREATE NODE TABLE A(s SERIAL, id int64, creationDate INT64, locationIP STRING, browserUsed STRING, content STRING, length INT32, PRIMARY KEY(s));
+---- ok
+-STATEMENT COPY A FROM '${KUZU_ROOT_DIRECTORY}/dataset/ldbc-sf01/Comment.csv' (HEADER=true, DELIM='|');
+---- ok
+-STATEMENT CALL STORAGE_INFO('A') WHERE column_name='s' RETURN num_values;
+---- 2
+131072
+19971
+-STATEMENT CREATE (a:A);
+---- ok
+-STATEMENT CALL STORAGE_INFO('A') WHERE column_name='s' RETURN num_values;
+---- 2
+131072
+19972
+
 -CASE CreateWithLargeStringPK
 -STATEMENT CREATE NODE TABLE test(id STRING, PRIMARY KEY(id));
 ---- ok


### PR DESCRIPTION
COPY serial column wasn't correctly setting `numValues` in column chunk metadata. This PR fixed it.