### PR TITLE
Persistent hash index performance improvements

### DIFF
--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -117,7 +117,7 @@ struct StorageConstants {
 
 // Hash Index Configurations
 struct HashIndexConstants {
-    static constexpr uint8_t SLOT_CAPACITY_BYTES = 240;
+    static constexpr uint16_t SLOT_CAPACITY_BYTES = 256;
     static constexpr double MAX_LOAD_FACTOR = 0.8;
 };
 

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -107,7 +107,8 @@ private:
     void copyAndUpdateSlotHeader(
         Slot<S>& slot, entry_pos_t entryPos, K key, common::offset_t value) {
         if constexpr (isCopyEntry) {
-            memcpy(slot.entries[entryPos].data, &key, this->indexHeader->numBytesPerEntry);
+            memcpy(
+                slot.entries[entryPos].data, &key, this->indexHeaderForWriteTrx->numBytesPerEntry);
         } else {
             insert(key, slot.entries[entryPos].data, value);
         }
@@ -182,7 +183,8 @@ private:
     std::unique_ptr<BaseDiskArray<Slot<S>>> oSlots;
     std::shared_ptr<DiskOverflowFile> diskOverflowFile;
     std::unique_ptr<HashIndexLocalStorage<T, LocalStorageType>> localStorage;
-    std::unique_ptr<HashIndexHeader> indexHeader;
+    std::unique_ptr<HashIndexHeader> indexHeaderForReadTrx;
+    std::unique_ptr<HashIndexHeader> indexHeaderForWriteTrx;
 };
 
 template<>

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -75,8 +75,8 @@ private:
     void insertIntoPersistentIndex(T key, common::offset_t value);
     void deleteFromPersistentIndex(T key);
 
-    entry_pos_t findMatchedEntryInSlot(
-        transaction::TransactionType trxType, const Slot<S>& slot, T key) const;
+    entry_pos_t findMatchedEntryInSlot(transaction::TransactionType trxType, const Slot<S>& slot,
+        T key, uint8_t fingerprint) const;
 
     inline void updateSlot(const SlotInfo& slotInfo, const Slot<S>& slot) {
         slotInfo.slotType == SlotType::PRIMARY ? pSlots->update(slotInfo.slotId, slot) :
@@ -105,15 +105,14 @@ private:
     }
     template<typename K, bool isCopyEntry>
     void copyAndUpdateSlotHeader(
-        Slot<S>& slot, entry_pos_t entryPos, K key, common::offset_t value) {
+        Slot<S>& slot, entry_pos_t entryPos, K key, common::offset_t value, uint8_t fingerprint) {
         if constexpr (isCopyEntry) {
             memcpy(
                 slot.entries[entryPos].data, &key, this->indexHeaderForWriteTrx->numBytesPerEntry);
         } else {
             insert(key, slot.entries[entryPos].data, value);
         }
-        slot.header.setEntryValid(entryPos);
-        slot.header.numEntries++;
+        slot.header.setEntryValid(entryPos, fingerprint);
     }
 
     inline void insert(T key, uint8_t* entry, common::offset_t offset) {
@@ -147,19 +146,20 @@ private:
     std::vector<std::pair<SlotInfo, Slot<S>>> getChainedSlots(slot_id_t pSlotId);
 
     template<typename K, bool isCopyEntry>
-    void copyKVOrEntryToSlot(
-        const SlotInfo& slotInfo, Slot<S>& slot, K key, common::offset_t value) {
-        if (slot.header.numEntries == getSlotCapacity<S>()) {
+    void copyKVOrEntryToSlot(const SlotInfo& slotInfo, Slot<S>& slot, K key, common::offset_t value,
+        uint8_t fingerprint) {
+        if (slot.header.numEntries() == getSlotCapacity<S>()) {
             // Allocate a new oSlot, insert the entry to the new oSlot, and update slot's
             // nextOvfSlotId.
             Slot<S> newSlot;
             auto entryPos = 0u; // Always insert to the first entry when there is a new slot.
-            copyAndUpdateSlotHeader<K, isCopyEntry>(newSlot, entryPos, key, value);
+            copyAndUpdateSlotHeader<K, isCopyEntry>(newSlot, entryPos, key, value, fingerprint);
             slot.header.nextOvfSlotId = appendOverflowSlot(std::move(newSlot));
         } else {
             for (auto entryPos = 0u; entryPos < getSlotCapacity<S>(); entryPos++) {
                 if (!slot.header.isEntryValid(entryPos)) {
-                    copyAndUpdateSlotHeader<K, isCopyEntry>(slot, entryPos, key, value);
+                    copyAndUpdateSlotHeader<K, isCopyEntry>(
+                        slot, entryPos, key, value, fingerprint);
                     break;
                 }
             }
@@ -167,7 +167,7 @@ private:
         updateSlot(slotInfo, slot);
     }
 
-    void copyEntryToSlot(slot_id_t slotId, const S& entry);
+    void copyEntryToSlot(slot_id_t slotId, const S& entry, uint8_t fingerprint);
 
 private:
     // Local Storage for strings stores an std::string, but still takes std::string_view as keys to

--- a/src/include/storage/index/hash_index_slot.h
+++ b/src/include/storage/index/hash_index_slot.h
@@ -4,6 +4,7 @@
 
 #include "common/constants.h"
 #include "common/types/internal_id_t.h"
+#include <bit>
 
 namespace kuzu {
 namespace storage {
@@ -14,11 +15,15 @@ using slot_id_t = uint64_t;
 class SlotHeader {
 public:
     static const entry_pos_t INVALID_ENTRY_POS = UINT8_MAX;
+    // For a header of 32 bytes.
+    // This is smaller than the possible number of entries with an 1-byte key like uint8_t,
+    // but the additional size would limit the number of entries for 8-byte keys, so we
+    // instead restrict the capacity to 20
+    static constexpr uint8_t FINGERPRINT_CAPACITY = 20;
 
-    SlotHeader() : numEntries{0}, validityMask{0}, nextOvfSlotId{0} {}
+    SlotHeader() : validityMask{0}, nextOvfSlotId{0} {}
 
     void reset() {
-        numEntries = 0;
         validityMask = 0;
         nextOvfSlotId = 0;
     }
@@ -26,13 +31,18 @@ public:
     inline bool isEntryValid(uint32_t entryPos) const {
         return validityMask & ((uint32_t)1 << entryPos);
     }
-    inline void setEntryValid(entry_pos_t entryPos) { validityMask |= ((uint32_t)1 << entryPos); }
+    inline void setEntryValid(entry_pos_t entryPos, uint8_t fingerprint) {
+        validityMask |= ((uint32_t)1 << entryPos);
+        fingerprints[entryPos] = fingerprint;
+    }
     inline void setEntryInvalid(entry_pos_t entryPos) {
         validityMask &= ~((uint32_t)1 << entryPos);
     }
 
+    inline entry_pos_t numEntries() const { return std::popcount(validityMask); }
+
 public:
-    entry_pos_t numEntries;
+    uint8_t fingerprints[FINGERPRINT_CAPACITY];
     uint32_t validityMask;
     slot_id_t nextOvfSlotId;
 };
@@ -44,7 +54,9 @@ struct SlotEntry {
 
 template<typename T>
 static constexpr uint8_t getSlotCapacity() {
-    return common::HashIndexConstants::SLOT_CAPACITY_BYTES / (sizeof(T) + sizeof(common::offset_t));
+    return std::min((common::HashIndexConstants::SLOT_CAPACITY_BYTES - sizeof(SlotHeader)) /
+                        sizeof(SlotEntry<T>),
+        static_cast<size_t>(SlotHeader::FINGERPRINT_CAPACITY));
 }
 
 template<typename T>

--- a/src/include/storage/index/hash_index_utils.h
+++ b/src/include/storage/index/hash_index_utils.h
@@ -63,9 +63,13 @@ public:
         return hash;
     }
 
-    template<common::IndexHashable T>
-    inline static slot_id_t getPrimarySlotIdForKey(const HashIndexHeader& indexHeader, T key) {
-        auto hash = HashIndexUtils::hash(key);
+    inline static uint8_t getFingerprintForHash(common::hash_t hash) {
+        // Last 8 bits before the bits used to calculate the hash index position is the fingerprint
+        return (hash >> (64 - NUM_HASH_INDEXES_LOG2 - 8)) & 255;
+    }
+
+    inline static slot_id_t getPrimarySlotIdForHash(
+        const HashIndexHeader& indexHeader, common::hash_t hash) {
         auto slotId = hash & indexHeader.levelHashMask;
         if (slotId < indexHeader.nextSplitSlotId) {
             slotId = hash & indexHeader.higherLevelHashMask;

--- a/src/include/storage/storage_structure/disk_array.h
+++ b/src/include/storage/storage_structure/disk_array.h
@@ -166,7 +166,7 @@ protected:
     }
 
 private:
-    void checkOutOfBoundAccess(transaction::TransactionType trxType, uint64_t idx);
+    bool checkOutOfBoundAccess(transaction::TransactionType trxType, uint64_t idx);
     bool hasPIPUpdatesNoLock(uint64_t pipIdx);
 
     uint64_t readUInt64HeaderFieldNoLock(

--- a/src/storage/index/hash_index_builder.cpp
+++ b/src/storage/index/hash_index_builder.cpp
@@ -6,6 +6,7 @@
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
 #include "storage/index/hash_index_slot.h"
+#include "storage/index/hash_index_utils.h"
 #include "storage/storage_structure/in_mem_file.h"
 
 using namespace kuzu::common;
@@ -49,7 +50,8 @@ void HashIndexBuilder<T, S>::bulkReserve(uint32_t numEntries_) {
 }
 
 template<common::IndexHashable T, typename S>
-void HashIndexBuilder<T, S>::copy(const uint8_t* oldEntry, slot_id_t newSlotId) {
+void HashIndexBuilder<T, S>::copy(
+    const uint8_t* oldEntry, slot_id_t newSlotId, uint8_t fingerprint) {
     SlotIterator iter(newSlotId, this);
     do {
         for (auto newEntryPos = 0u; newEntryPos < getSlotCapacity<S>(); newEntryPos++) {
@@ -60,7 +62,7 @@ void HashIndexBuilder<T, S>::copy(const uint8_t* oldEntry, slot_id_t newSlotId) 
                     memcpy(iter.slot->entries[newEntryPos].data, oldEntry,
                         this->indexHeader->numBytesPerEntry);
                 }
-                updateForNewEntry(iter.slot, newEntryPos);
+                iter.slot->header.setEntryValid(newEntryPos, fingerprint);
                 return;
             }
         }
@@ -71,7 +73,7 @@ void HashIndexBuilder<T, S>::copy(const uint8_t* oldEntry, slot_id_t newSlotId) 
     auto newOvfSlot = getSlot(SlotInfo{newOvfSlotId, SlotType::OVF});
     auto newEntryPos = 0u; // Always insert to the first entry when there is a new slot.
     memcpy(newOvfSlot->entries[newEntryPos].data, oldEntry, this->indexHeader->numBytesPerEntry);
-    updateForNewEntry(newOvfSlot, newEntryPos);
+    newOvfSlot->header.setEntryValid(newEntryPos, fingerprint);
 }
 
 template<common::IndexHashable T, typename S>
@@ -93,8 +95,9 @@ void HashIndexBuilder<T, S>::splitSlot(HashIndexHeader& header) {
             }
             const auto* data = (iter.slot->entries[entryPos].data);
             hash_t hash = this->hashStored(*reinterpret_cast<const S*>(data));
+            auto fingerprint = HashIndexUtils::getFingerprintForHash(hash);
             auto newSlotId = hash & header.higherLevelHashMask;
-            copy(data, newSlotId);
+            copy(data, newSlotId, fingerprint);
         }
     } while (nextChainedSlot(iter));
 
@@ -110,7 +113,9 @@ bool HashIndexBuilder<T, S>::append(T key, offset_t value) {
     }
     // Do both searches after splitting. Returning early if the key already exists isn't a
     // particular concern and doing both after splitting allows the slotID to be reused
-    auto slotID = HashIndexUtils::getPrimarySlotIdForKey(*this->indexHeader, key);
+    auto hashValue = HashIndexUtils::hash(key);
+    auto fingerprint = HashIndexUtils::getFingerprintForHash(hashValue);
+    auto slotID = HashIndexUtils::getPrimarySlotIdForHash(*this->indexHeader, hashValue);
     SlotIterator iter(slotID, this);
     do {
         for (auto entryPos = 0u; entryPos < getSlotCapacity<S>(); entryPos++) {
@@ -119,27 +124,32 @@ bool HashIndexBuilder<T, S>::append(T key, offset_t value) {
                 // The builder never keeps holes and doesn't support deletions, so this must be the
                 // end of the valid entries in this primary slot and the entry does not already
                 // exist
-                insert(key, iter.slot, entryPos, value);
+                insert(key, iter.slot, entryPos, value, fingerprint);
                 this->indexHeader->numEntries++;
                 return true;
-            } else if (equals(key, *(S*)iter.slot->entries[entryPos].data)) {
+            } else if (iter.slot->header.fingerprints[entryPos] == fingerprint &&
+                       equals(key, *(S*)iter.slot->entries[entryPos].data)) {
                 // Value already exists
                 return false;
             }
         }
     } while (nextChainedSlot(iter));
     // Didn't find an available slot. Insert a new one
-    insertToNewOvfSlot(key, iter.slot, value);
+    insertToNewOvfSlot(key, iter.slot, value, fingerprint);
     this->indexHeader->numEntries++;
     return true;
 }
 
 template<IndexHashable T, typename S>
 bool HashIndexBuilder<T, S>::lookup(T key, offset_t& result) {
-    SlotIterator iter(HashIndexUtils::getPrimarySlotIdForKey(*this->indexHeader, key), this);
+    auto hashValue = HashIndexUtils::hash(key);
+    auto fingerprint = HashIndexUtils::getFingerprintForHash(hashValue);
+    auto slotId = HashIndexUtils::getPrimarySlotIdForHash(*this->indexHeader, hashValue);
+    SlotIterator iter(slotId, this);
     do {
         for (auto entryPos = 0u; entryPos < getSlotCapacity<S>(); entryPos++) {
             if (iter.slot->header.isEntryValid(entryPos) &&
+                iter.slot->header.fingerprints[entryPos] == fingerprint &&
                 equals(key, *(S*)iter.slot->entries[entryPos].data)) {
                 // Value already exists
                 result = *(common::offset_t*)(iter.slot->entries[entryPos].data +
@@ -190,21 +200,21 @@ void HashIndexBuilder<T, S>::flush() {
 
 template<IndexHashable T, typename S>
 inline void HashIndexBuilder<T, S>::insertToNewOvfSlot(
-    T key, Slot<S>* previousSlot, common::offset_t offset) {
+    T key, Slot<S>* previousSlot, common::offset_t offset, uint8_t fingerprint) {
     auto newSlotId = allocateAOSlot();
     previousSlot->header.nextOvfSlotId = newSlotId;
     auto newSlot = getSlot(SlotInfo{newSlotId, SlotType::OVF});
     auto entryPos = 0u; // Always insert to the first entry when there is a new slot.
-    insert(key, newSlot, entryPos, offset);
+    insert(key, newSlot, entryPos, offset, fingerprint);
 }
 
 template<>
-void HashIndexBuilder<std::string_view, ku_string_t>::insert(
-    std::string_view key, Slot<ku_string_t>* slot, uint8_t entryPos, offset_t offset) {
+void HashIndexBuilder<std::string_view, ku_string_t>::insert(std::string_view key,
+    Slot<ku_string_t>* slot, uint8_t entryPos, offset_t offset, uint8_t fingerprint) {
     auto entry = slot->entries[entryPos].data;
     inMemOverflowFile->appendString(key, *(ku_string_t*)entry);
     memcpy(entry + NUM_BYTES_FOR_STRING_KEY, &offset, sizeof(common::offset_t));
-    updateForNewEntry(slot, entryPos);
+    slot->header.setEntryValid(entryPos, fingerprint);
 }
 
 template<IndexHashable T, typename S>


### PR DESCRIPTION
This adds the fingerprinting optimization mentioned in #2287. In some isolated and not very general tests, fingerprinting improved lookup times by about 10% for INT64, 20% for short strings (roughly the same length and with a common prefix) and 40% for long strings (about 24 characters, all roughly the same length and with a common prefix, so close to worst case for string comparison short of making the strings longer).

I also made a couple of other small optimizations:
1. Disk array bounds checking has been changed to only occur with runtime checks enabled (disk array performance is a major bottleneck for the on-disk hash index).
2. The hash index header is cached in memory for write transactions like it is for read transactions, and only written to the disk array/buffer manager at the end of `prepareCommit` (to reduce unnecessary load on the buffer manager for a small piece of fixed-sized data).