### PR TITLE
Patch: copy var lists and strings

### DIFF
--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -65,7 +65,7 @@ private:
 
     inline void initializeIndices() {
         indicesColumnChunk = ColumnChunkFactory::createColumnChunk(
-            *common::LogicalType::INT64(), false /*enableCompression*/);
+            *common::LogicalType::INT64(), false /*enableCompression*/, capacity);
         indicesColumnChunk->getNullChunk()->resetToAllNull();
         for (auto i = 0u; i < numValues; i++) {
             indicesColumnChunk->setValue<common::offset_t>(i, i);

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -200,6 +200,7 @@ void ColumnChunk::resetToEmpty() {
     if (nullChunk) {
         nullChunk->resetToEmpty();
     }
+    memset(buffer.get(), 0, bufferSize);
     numValues = 0;
 }
 

--- a/src/storage/store/var_list_column_chunk.cpp
+++ b/src/storage/store/var_list_column_chunk.cpp
@@ -115,14 +115,14 @@ void VarListColumnChunk::write(
         auto posInChunk = offsetInChunkVector->getValue<offset_t>(
             offsetInChunkVector->state->selVector->selectedPositions[i]);
         KU_ASSERT(posInChunk < capacity);
-        indicesColumnChunk->setValue(currentIndex++, posInChunk);
+        indicesColumnChunk->setValue<int64_t>(currentIndex++, posInChunk);
         indicesColumnChunk->getNullChunk()->setNull(posInChunk, false);
         if (indicesColumnChunk->getNumValues() <= posInChunk) {
             indicesColumnChunk->setNumValues(posInChunk + 1);
         }
     }
     KU_ASSERT(currentIndex == numValues &&
-              indicesColumnChunk->getNumValues() < indicesColumnChunk->getCapacity());
+              indicesColumnChunk->getNumValues() <= indicesColumnChunk->getCapacity());
 }
 
 void VarListColumnChunk::write(


### PR DESCRIPTION
Two fixes:
- indices column chunk is not initialized with correct capacity;
- ColumnChunks are reused during copy rel, but we didn't reset column chunk's buffer during `resetToEmpty`. Now we leave gaps in rel csr arrays, and gapped values will be filled with old data from previous "chunks", and this can corrupt `finalize` for strings. (index can be insane values, leading to out-of-bound read from dictionary chunk).