### PR TITLE
Improve functionality of CString-to-Interval parser

### DIFF
--- a/extension/httpfs/src/s3fs.cpp
+++ b/extension/httpfs/src/s3fs.cpp
@@ -579,7 +579,7 @@ std::string getDateTimeHeader(const timestamp_t& timestamp) {
     auto time = Timestamp::getTime(timestamp);
     formatStr += "T";
     int32_t hours, minutes, seconds, micros;
-    Time::Convert(time, hours, minutes, seconds, micros);
+    Time::convert(time, hours, minutes, seconds, micros);
     if (hours < 10) {
         formatStr += "0";
     }

--- a/src/common/types/dtime_t.cpp
+++ b/src/common/types/dtime_t.cpp
@@ -53,9 +53,7 @@ bool dtime_t::operator>=(const dtime_t& rhs) const {
     return micros >= rhs.micros;
 }
 
-// string format is hh:mm:ss[.mmmmmm] (ISO 8601) (m represent microseconds)
-// microseconds is optional, timezone is currently not supported
-bool Time::TryConvertTime(const char* buf, uint64_t len, uint64_t& pos, dtime_t& result) {
+bool Time::tryConvertInternal(const char* buf, uint64_t len, uint64_t& pos, dtime_t& result) {
     int32_t hour = -1, min = -1, sec = -1, micros = -1;
     pos = 0;
 
@@ -78,8 +76,14 @@ bool Time::TryConvertTime(const char* buf, uint64_t len, uint64_t& pos, dtime_t&
         return false;
     }
 
-    if (!Date::parseDoubleDigit(buf, len, pos, hour)) {
-        return false;
+    // Allow up to 9 digit hours to support intervals
+    hour = 0;
+    for (int32_t digits = 9; pos < len && isdigit(buf[pos]); ++pos) {
+        if (digits-- > 0) {
+            hour = hour * 10 + (buf[pos] - '0');
+        } else {
+            return false;
+        }
     }
 
     if (pos >= len) {
@@ -96,6 +100,9 @@ bool Time::TryConvertTime(const char* buf, uint64_t len, uint64_t& pos, dtime_t&
     if (!Date::parseDoubleDigit(buf, len, pos, min)) {
         return false;
     }
+    if (min < 0 || min >= 60) {
+        return false;
+    }
 
     if (pos >= len) {
         return false;
@@ -106,6 +113,9 @@ bool Time::TryConvertTime(const char* buf, uint64_t len, uint64_t& pos, dtime_t&
     }
 
     if (!Date::parseDoubleDigit(buf, len, pos, sec)) {
+        return false;
+    }
+    if (sec < 0 || sec >= 60) {
         return false;
     }
 
@@ -121,18 +131,39 @@ bool Time::TryConvertTime(const char* buf, uint64_t len, uint64_t& pos, dtime_t&
         }
     }
 
-    if (!IsValid(hour, min, sec, micros)) {
-        return false;
-    }
-
-    result = Time::FromTime(hour, min, sec, micros);
+    result = Time::fromTimeInternal(hour, min, sec, micros);
     return true;
 }
 
-dtime_t Time::FromCString(const char* buf, uint64_t len) {
+bool Time::tryConvertInterval(const char* buf, uint64_t len, uint64_t& pos, dtime_t& result) {
+    if (!Time::tryConvertInternal(buf, len, pos, result)) {
+        return false;
+    }
+    // check remaining string for non-space characters
+    // skip trailing spaces
+    while (pos < len && isspace(buf[pos])) {
+        pos++;
+    }
+    // check position. if end was not reached, non-space chars remaining
+    if (pos < len) {
+        return false;
+    }
+    return true;
+}
+
+// string format is hh:mm:ss[.mmmmmm] (ISO 8601) (m represent microseconds)
+// microseconds is optional, timezone is currently not supported
+bool Time::tryConvertTime(const char* buf, uint64_t len, uint64_t& pos, dtime_t& result) {
+    if (!Time::tryConvertInternal(buf, len, pos, result)) {
+        return false;
+    }
+    return result.micros < Interval::MICROS_PER_DAY;
+}
+
+dtime_t Time::fromCString(const char* buf, uint64_t len) {
     dtime_t result;
     uint64_t pos;
-    if (!Time::TryConvertTime(buf, len, pos, result)) {
+    if (!Time::tryConvertTime(buf, len, pos, result)) {
         throw ConversionException(stringFormat("Error occurred during parsing time. Given: \"{}\". "
                                                "Expected format: (hh:mm:ss[.zzzzzz]).",
             std::string(buf, len)));
@@ -142,7 +173,7 @@ dtime_t Time::FromCString(const char* buf, uint64_t len) {
 
 std::string Time::toString(dtime_t time) {
     int32_t time_units[4];
-    Time::Convert(time, time_units[0], time_units[1], time_units[2], time_units[3]);
+    Time::convert(time, time_units[0], time_units[1], time_units[2], time_units[3]);
 
     char micro_buffer[6];
     auto length = TimeToStringCast::Length(time_units, micro_buffer);
@@ -151,7 +182,7 @@ std::string Time::toString(dtime_t time) {
     return std::string(buffer.get(), length);
 }
 
-bool Time::IsValid(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
+bool Time::isValid(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
     if (hour > 23 || hour < 0 || minute > 59 || minute < 0 || second > 59 || second < 0 ||
         microseconds > 999999 || microseconds < 0) {
         return false;
@@ -159,11 +190,7 @@ bool Time::IsValid(int32_t hour, int32_t minute, int32_t second, int32_t microse
     return true;
 }
 
-dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
-    if (!Time::IsValid(hour, minute, second, microseconds)) {
-        throw ConversionException(stringFormat(
-            "Time field value out of range: {}:{}:{}[.{}].", hour, minute, second, microseconds));
-    }
+dtime_t Time::fromTimeInternal(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
     int64_t result;
     result = hour;                                             // hours
     result = result * Interval::MINS_PER_HOUR + minute;        // hours -> minutes
@@ -172,7 +199,15 @@ dtime_t Time::FromTime(int32_t hour, int32_t minute, int32_t second, int32_t mic
     return dtime_t(result);
 }
 
-void Time::Convert(dtime_t dtime, int32_t& hour, int32_t& min, int32_t& sec, int32_t& micros) {
+dtime_t Time::fromTime(int32_t hour, int32_t minute, int32_t second, int32_t microseconds) {
+    if (!Time::isValid(hour, minute, second, microseconds)) {
+        throw ConversionException(stringFormat(
+            "Time field value out of range: {}:{}:{}[.{}].", hour, minute, second, microseconds));
+    }
+    return Time::fromTimeInternal(hour, minute, second, microseconds);
+}
+
+void Time::convert(dtime_t dtime, int32_t& hour, int32_t& min, int32_t& sec, int32_t& micros) {
     int64_t time = dtime.micros;
     hour = int32_t(time / Interval::MICROS_PER_HOUR);
     time -= int64_t(hour) * Interval::MICROS_PER_HOUR;

--- a/src/common/types/interval_t.cpp
+++ b/src/common/types/interval_t.cpp
@@ -2,9 +2,14 @@
 
 #include "common/assert.h"
 #include "common/exception/conversion.h"
+#include "common/exception/overflow.h"
 #include "common/string_utils.h"
 #include "common/types/cast_helpers.h"
 #include "common/types/timestamp_t.h"
+#include "function/arithmetic/add.h"
+#include "function/arithmetic/multiply.h"
+#include "function/cast/functions/cast_from_string_functions.h"
+#include "function/cast/functions/cast_functions.h"
 
 namespace kuzu {
 namespace common {
@@ -97,50 +102,229 @@ void Interval::addition(interval_t& result, uint64_t number, std::string specifi
     }
 }
 
-void Interval::parseIntervalField(
-    std::string buf, uint64_t& pos, uint64_t len, interval_t& result) {
-    uint64_t number;
-    uint64_t offset = 0;
-    // parse digits
-    number = std::stoi(buf.c_str() + pos, reinterpret_cast<size_t*>(&offset));
-    pos += offset;
-    // skip spaces
-    while (pos < len && isspace(buf[pos])) {
-        pos++;
+template<class T>
+T intervalTryCastInteger(int64_t input) {
+    if (std::is_same<T, int8_t>()) {
+        int8_t result;
+        function::CastToInt8::operation<int64_t>(input, result);
+        return result;
+    } else if (std::is_same<T, int16_t>()) {
+        int16_t result;
+        function::CastToInt16::operation<int64_t>(input, result);
+        return result;
+    } else if (std::is_same<T, int32_t>()) {
+        int32_t result;
+        function::CastToInt32::operation<int64_t>(input, result);
+        return result;
+    } else if (std::is_same<T, int64_t>()) {
+        int64_t result;
+        function::CastToInt64::operation<int64_t>(input, result);
+        return result;
+    } else {
+        throw ConversionException("The destination is not an integer");
     }
-    if (pos == len) {
-        throw ConversionException("Error occurred during parsing interval. Field name is missing.");
+}
+
+template<class T>
+void intervalTryAddition(T& target, int64_t input, int64_t multiplier, int64_t fraction = 0) {
+    int64_t addition;
+    try {
+        function::Multiply::operation(input, multiplier, addition);
+    } catch (const OverflowException& e) {
+        throw OverflowException{"Interval value is out of range"};
     }
-    // Parse intervalPartSpecifier (eg. hours, dates, minutes)
-    uint64_t spacePos = std::string(buf).find(' ', pos);
-    if (spacePos == std::string::npos) {
-        spacePos = len;
+    T additionBase = intervalTryCastInteger<T>(addition);
+    try {
+        function::Add::operation(target, additionBase, target);
+    } catch (const OverflowException& e) {
+        throw OverflowException{"Interval value is out of range"};
     }
-    std::string specifierStr = buf.substr(pos, spacePos - pos);
-    pos = spacePos;
-    addition(result, number, specifierStr);
+    if (fraction) {
+        //	Add in (fraction * multiplier) / MICROS_PER_SEC
+        //	This is always in range
+        addition = (fraction * multiplier) / Interval::MICROS_PER_SEC;
+        additionBase = intervalTryCastInteger<T>(addition);
+        try {
+            function::Add::operation(target, additionBase, target);
+        } catch (const OverflowException& e) {
+            throw OverflowException{"Interval fraction is out of range"};
+        }
+    }
 }
 
 interval_t Interval::fromCString(const char* str, uint64_t len) {
-    std::string intervalStr = std::string(str, len);
     interval_t result;
     uint64_t pos = 0;
+    uint64_t startPos;
+    bool foundAny = false;
+    int64_t number = 0;
+    int64_t fraction = 0;
+    DatePartSpecifier specifier;
+    std::string specifierStr;
+
     result.days = 0;
     result.micros = 0;
     result.months = 0;
 
-    if (intervalStr[pos] == '@') {
+    if (len == 0) {
+        throw ConversionException("Error occurred during parsing interval. Given empty string.");
+    }
+
+    if (str[pos] == '@') {
         pos++;
     }
 
-    while (pos < len) {
-        if (isdigit(intervalStr[pos])) {
-            parseIntervalField(intervalStr, pos, len, result);
-        } else if (!isspace(intervalStr[pos])) {
-            throw ConversionException(
-                "Error occurred during parsing interval. Given: \"" + intervalStr + "\".");
+parse_interval:
+    for (; pos < len; pos++) {
+        char c = str[pos];
+        if (isspace(c)) {
+            // skip spaces
+            continue;
+        } else if (isdigit(c)) {
+            // start parsing a number
+            goto interval_parse_number;
+        } else {
+            // unrecognized character, expected a number or end of string
+            throw ConversionException("Error occurred during parsing interval. Given: \"" +
+                                      std::string(str, len) + "\".");
         }
-        pos++;
+    }
+    goto end_of_string;
+
+interval_parse_number:
+    startPos = pos;
+    for (; pos < len; pos++) {
+        char c = str[pos];
+        if (isdigit(c)) {
+            // the number continues
+            continue;
+        } else if (c == ':') {
+            // colon: we are parsing a time
+            goto interval_parse_time;
+        } else {
+            // finished the number, parse it from the string
+            function::CastString::operation(ku_string_t{str + startPos, pos - startPos}, number);
+            fraction = 0;
+            if (c == '.') {
+                // we expect some microseconds
+                int32_t mult = 100000;
+                for (++pos; pos < len && isdigit(str[pos]); ++pos, mult /= 10) {
+                    if (mult > 0) {
+                        fraction += int64_t(str[pos] - '0') * mult;
+                    }
+                }
+            }
+            goto interval_parse_identifier;
+        }
+    }
+    goto interval_parse_identifier;
+
+interval_parse_time : {
+    // parse the remainder of the time as a Time type
+    dtime_t time;
+    uint64_t tmpPos;
+    if (!Time::tryConvertInterval(str + startPos, len - startPos, tmpPos, time)) {
+        throw ConversionException("Error occurred during parsing time. Given: \"" +
+                                  std::string(str + startPos, len - startPos) + "\".");
+    }
+    result.micros += time.micros;
+    foundAny = true;
+    goto end_of_string;
+}
+
+interval_parse_identifier:
+    for (; pos < len; pos++) {
+        char c = str[pos];
+        if (isspace(c)) {
+            // skip spaces at the start
+            continue;
+        } else {
+            break;
+        }
+    }
+    // now parse the identifier
+    startPos = pos;
+    for (; pos < len; pos++) {
+        char c = str[pos];
+        if (!isspace(c)) {
+            // keep parsing the string
+            continue;
+        } else {
+            break;
+        }
+    }
+    specifierStr = std::string(str + startPos, pos - startPos);
+
+    // Specifier string is empty, missing field name
+    if (specifierStr.empty()) {
+        throw ConversionException("Error occurred during parsing interval. Field name is missing.");
+    }
+
+    tryGetDatePartSpecifier(specifierStr, specifier);
+
+    switch (specifier) {
+    case DatePartSpecifier::MILLENNIUM:
+        intervalTryAddition<int32_t>(result.months, number, MONTHS_PER_MILLENIUM, fraction);
+        break;
+    case DatePartSpecifier::CENTURY:
+        intervalTryAddition<int32_t>(result.months, number, MONTHS_PER_CENTURY, fraction);
+        break;
+    case DatePartSpecifier::DECADE:
+        intervalTryAddition<int32_t>(result.months, number, MONTHS_PER_DECADE, fraction);
+        break;
+    case DatePartSpecifier::YEAR:
+        intervalTryAddition<int32_t>(result.months, number, MONTHS_PER_YEAR, fraction);
+        break;
+    case DatePartSpecifier::QUARTER:
+        intervalTryAddition<int32_t>(result.months, number, MONTHS_PER_QUARTER, fraction);
+        // Reduce to fraction of a month
+        fraction *= MONTHS_PER_QUARTER;
+        fraction %= MICROS_PER_SEC;
+        intervalTryAddition<int32_t>(result.days, 0, DAYS_PER_MONTH, fraction);
+        break;
+    case DatePartSpecifier::MONTH:
+        intervalTryAddition<int32_t>(result.months, number, 1);
+        intervalTryAddition<int32_t>(result.days, 0, DAYS_PER_MONTH, fraction);
+        break;
+    case DatePartSpecifier::DAY:
+        intervalTryAddition<int32_t>(result.days, number, 1);
+        intervalTryAddition<int64_t>(result.micros, 0, MICROS_PER_DAY, fraction);
+        break;
+    case DatePartSpecifier::WEEK:
+        intervalTryAddition<int32_t>(result.days, number, DAYS_PER_WEEK, fraction);
+        // Reduce to fraction of a day
+        fraction *= DAYS_PER_WEEK;
+        fraction %= MICROS_PER_SEC;
+        intervalTryAddition<int64_t>(result.micros, 0, MICROS_PER_DAY, fraction);
+        break;
+    case DatePartSpecifier::HOUR:
+        intervalTryAddition<int64_t>(result.micros, number, MICROS_PER_HOUR, fraction);
+        break;
+    case DatePartSpecifier::MINUTE:
+        intervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MINUTE, fraction);
+        break;
+    case DatePartSpecifier::SECOND:
+        intervalTryAddition<int64_t>(result.micros, number, MICROS_PER_SEC, fraction);
+        break;
+    case DatePartSpecifier::MILLISECOND:
+        intervalTryAddition<int64_t>(result.micros, number, MICROS_PER_MSEC, fraction);
+        break;
+    case DatePartSpecifier::MICROSECOND:
+        // Round the fraction
+        number += (fraction * 2) / MICROS_PER_SEC;
+        intervalTryAddition<int64_t>(result.micros, number, 1);
+        break;
+    default:
+        throw ConversionException("Unrecognized interval specifier string: " + specifierStr + ".");
+    }
+
+    foundAny = true;
+    goto parse_interval;
+
+end_of_string:
+    if (!foundAny) {
+        throw ConversionException(
+            "Error occurred during parsing interval. Given: \"" + std::string(str, len) + "\".");
     }
     return result;
 }
@@ -187,7 +371,8 @@ bool Interval::greaterThan(const interval_t& left, const interval_t& right) {
 
 void Interval::tryGetDatePartSpecifier(std::string specifier, DatePartSpecifier& result) {
     StringUtils::toLower(specifier);
-    if (specifier == "year" || specifier == "y" || specifier == "years") {
+    if (specifier == "year" || specifier == "yr" || specifier == "y" || specifier == "years" ||
+        specifier == "yrs") {
         result = DatePartSpecifier::YEAR;
     } else if (specifier == "month" || specifier == "mon" || specifier == "months" ||
                specifier == "mons") {
@@ -195,28 +380,41 @@ void Interval::tryGetDatePartSpecifier(std::string specifier, DatePartSpecifier&
     } else if (specifier == "day" || specifier == "days" || specifier == "d" ||
                specifier == "dayofmonth") {
         result = DatePartSpecifier::DAY;
-    } else if (specifier == "decade" || specifier == "decades") {
+    } else if (specifier == "decade" || specifier == "dec" || specifier == "decades" ||
+               specifier == "decs") {
         result = DatePartSpecifier::DECADE;
-    } else if (specifier == "century" || specifier == "centuries") {
+    } else if (specifier == "century" || specifier == "cent" || specifier == "centuries" ||
+               specifier == "c") {
         result = DatePartSpecifier::CENTURY;
-    } else if (specifier == "millennium" || specifier == "millennia" || specifier == "millenium") {
+    } else if (specifier == "millennium" || specifier == "mil" || specifier == "millenniums" ||
+               specifier == "millennia" || specifier == "mils" || specifier == "millenium") {
         result = DatePartSpecifier::MILLENNIUM;
+    } else if (specifier == "microseconds" || specifier == "microsecond" || specifier == "us" ||
+               specifier == "usec" || specifier == "usecs" || specifier == "usecond" ||
+               specifier == "useconds") {
+        result = DatePartSpecifier::MICROSECOND;
+    } else if (specifier == "milliseconds" || specifier == "millisecond" || specifier == "ms" ||
+               specifier == "msec" || specifier == "msecs" || specifier == "msecond" ||
+               specifier == "mseconds") {
+        result = DatePartSpecifier::MILLISECOND;
+    } else if (specifier == "second" || specifier == "sec" || specifier == "seconds" ||
+               specifier == "secs" || specifier == "s") {
+        result = DatePartSpecifier::SECOND;
+    } else if (specifier == "minute" || specifier == "min" || specifier == "minutes" ||
+               specifier == "mins" || specifier == "m") {
+        result = DatePartSpecifier::MINUTE;
+    } else if (specifier == "hour" || specifier == "hr" || specifier == "hours" ||
+               specifier == "hrs" || specifier == "h") {
+        result = DatePartSpecifier::HOUR;
+    } else if (specifier == "week" || specifier == "weeks" || specifier == "w" ||
+               specifier == "weekofyear") {
+        // ISO week number
+        result = DatePartSpecifier::WEEK;
     } else if (specifier == "quarter" || specifier == "quarters") {
         // quarter of the year (1-4)
         result = DatePartSpecifier::QUARTER;
-    } else if (specifier == "microseconds" || specifier == "microsecond") {
-        result = DatePartSpecifier::MICROSECOND;
-    } else if (specifier == "milliseconds" || specifier == "millisecond" || specifier == "ms" ||
-               specifier == "msec" || specifier == "msecs") {
-        result = DatePartSpecifier::MILLISECOND;
-    } else if (specifier == "second" || specifier == "seconds" || specifier == "s") {
-        result = DatePartSpecifier::SECOND;
-    } else if (specifier == "minute" || specifier == "minutes" || specifier == "m") {
-        result = DatePartSpecifier::MINUTE;
-    } else if (specifier == "hour" || specifier == "hours" || specifier == "h") {
-        result = DatePartSpecifier::HOUR;
     } else {
-        throw Exception("Invalid partSpecifier specifier: " + specifier);
+        throw ConversionException("Unrecognized interval specifier string: " + specifier + ".");
     }
 }
 

--- a/src/common/types/timestamp_t.cpp
+++ b/src/common/types/timestamp_t.cpp
@@ -140,7 +140,7 @@ bool Timestamp::tryConvertTimestamp(const char* str, uint64_t len, timestamp_t& 
         pos++;
     }
     uint64_t time_pos = 0;
-    if (!Time::TryConvertTime(str + pos, len - pos, time_pos, time)) {
+    if (!Time::tryConvertTime(str + pos, len - pos, time_pos, time)) {
         return false;
     }
     pos += time_pos;
@@ -246,8 +246,8 @@ timestamp_t Timestamp::fromDateTime(date_t date, dtime_t time) {
     timestamp_t result;
     int32_t year, month, day, hour, minute, second, microsecond = -1;
     Date::convert(date, year, month, day);
-    Time::Convert(time, hour, minute, second, microsecond);
-    if (!Date::isValid(year, month, day) || !Time::IsValid(hour, minute, second, microsecond)) {
+    Time::convert(time, hour, minute, second, microsecond);
+    if (!Date::isValid(year, month, day) || !Time::isValid(hour, minute, second, microsecond)) {
         throw ConversionException("Invalid date or time format");
     }
     result.value = date.days * Interval::MICROS_PER_DAY + time.micros;
@@ -308,21 +308,21 @@ timestamp_t Timestamp::trunc(DatePartSpecifier specifier, timestamp_t& timestamp
     date_t date;
     dtime_t time;
     Timestamp::convert(timestamp, date, time);
-    Time::Convert(time, hour, min, sec, micros);
+    Time::convert(time, hour, min, sec, micros);
     switch (specifier) {
     case DatePartSpecifier::MICROSECOND:
         return timestamp;
     case DatePartSpecifier::MILLISECOND:
         micros -= micros % Interval::MICROS_PER_MSEC;
-        return Timestamp::fromDateTime(date, Time::FromTime(hour, min, sec, micros));
+        return Timestamp::fromDateTime(date, Time::fromTime(hour, min, sec, micros));
     case DatePartSpecifier::SECOND:
-        return Timestamp::fromDateTime(date, Time::FromTime(hour, min, sec, 0 /* microseconds */));
+        return Timestamp::fromDateTime(date, Time::fromTime(hour, min, sec, 0 /* microseconds */));
     case DatePartSpecifier::MINUTE:
         return Timestamp::fromDateTime(
-            date, Time::FromTime(hour, min, 0 /* seconds */, 0 /* microseconds */));
+            date, Time::fromTime(hour, min, 0 /* seconds */, 0 /* microseconds */));
     case DatePartSpecifier::HOUR:
         return Timestamp::fromDateTime(
-            date, Time::FromTime(hour, 0 /* minutes */, 0 /* seconds */, 0 /* microseconds */));
+            date, Time::fromTime(hour, 0 /* minutes */, 0 /* seconds */, 0 /* microseconds */));
     default:
         date_t date = getDate(timestamp);
         return fromDateTime(Date::trunc(specifier, date), dtime_t(0));

--- a/src/include/common/types/dtime_t.h
+++ b/src/include/common/types/dtime_t.h
@@ -38,22 +38,29 @@ struct KUZU_API dtime_t {
 class Time {
 public:
     // Convert a string in the format "hh:mm:ss" to a time object
-    KUZU_API static dtime_t FromCString(const char* buf, uint64_t len);
-    KUZU_API static bool TryConvertTime(
+    KUZU_API static dtime_t fromCString(const char* buf, uint64_t len);
+    KUZU_API static bool tryConvertInterval(
+        const char* buf, uint64_t len, uint64_t& pos, dtime_t& result);
+    KUZU_API static bool tryConvertTime(
         const char* buf, uint64_t len, uint64_t& pos, dtime_t& result);
 
     // Convert a time object to a string in the format "hh:mm:ss"
     KUZU_API static std::string toString(dtime_t time);
 
-    KUZU_API static dtime_t FromTime(
+    KUZU_API static dtime_t fromTime(
         int32_t hour, int32_t minute, int32_t second, int32_t microseconds = 0);
 
     // Extract the time from a given timestamp object
-    KUZU_API static void Convert(
+    KUZU_API static void convert(
         dtime_t time, int32_t& out_hour, int32_t& out_min, int32_t& out_sec, int32_t& out_micros);
 
-    KUZU_API static bool IsValid(
+    KUZU_API static bool isValid(
         int32_t hour, int32_t minute, int32_t second, int32_t milliseconds);
+
+private:
+    static bool tryConvertInternal(const char* buf, uint64_t len, uint64_t& pos, dtime_t& result);
+    static dtime_t fromTimeInternal(
+        int32_t hour, int32_t minute, int32_t second, int32_t microseconds = 0);
 };
 
 } // namespace common

--- a/src/include/common/types/interval_t.h
+++ b/src/include/common/types/interval_t.h
@@ -24,6 +24,7 @@ enum class KUZU_API DatePartSpecifier : uint8_t {
     SECOND,
     MINUTE,
     HOUR,
+    WEEK,
 };
 
 struct KUZU_API interval_t {
@@ -59,30 +60,40 @@ struct KUZU_API interval_t {
 // The Interval class is a static class that holds helper functions for the Interval type.
 class Interval {
 public:
-    KUZU_API static constexpr const int32_t MONTHS_PER_YEAR = 12;
-    KUZU_API static constexpr const int64_t MSECS_PER_SEC = 1000;
-    KUZU_API static constexpr const int32_t SECS_PER_MINUTE = 60;
-    KUZU_API static constexpr const int32_t MINS_PER_HOUR = 60;
-    KUZU_API static constexpr const int32_t HOURS_PER_DAY = 24;
-    // only used for interval comparison/ordering purposes, in which case a month counts as 30 days
-    KUZU_API static constexpr const int64_t DAYS_PER_MONTH = 30;
-    KUZU_API static constexpr const int64_t MONTHS_PER_QUARTER = 3;
-    KUZU_API static constexpr const int64_t MONTHS_PER_MILLENIUM = 12000;
-    KUZU_API static constexpr const int64_t MONTHS_PER_CENTURY = 1200;
-    KUZU_API static constexpr const int64_t MONTHS_PER_DECADE = 120;
+    static constexpr const int32_t MONTHS_PER_MILLENIUM = 12000;
+    static constexpr const int32_t MONTHS_PER_CENTURY = 1200;
+    static constexpr const int32_t MONTHS_PER_DECADE = 120;
+    static constexpr const int32_t MONTHS_PER_YEAR = 12;
+    static constexpr const int32_t MONTHS_PER_QUARTER = 3;
+    static constexpr const int32_t DAYS_PER_WEEK = 7;
+    //! only used for interval comparison/ordering purposes, in which case a month counts as 30 days
+    static constexpr const int64_t DAYS_PER_MONTH = 30;
+    static constexpr const int64_t DAYS_PER_YEAR = 365;
+    static constexpr const int64_t MSECS_PER_SEC = 1000;
+    static constexpr const int32_t SECS_PER_MINUTE = 60;
+    static constexpr const int32_t MINS_PER_HOUR = 60;
+    static constexpr const int32_t HOURS_PER_DAY = 24;
+    static constexpr const int32_t SECS_PER_HOUR = SECS_PER_MINUTE * MINS_PER_HOUR;
+    static constexpr const int32_t SECS_PER_DAY = SECS_PER_HOUR * HOURS_PER_DAY;
+    static constexpr const int32_t SECS_PER_WEEK = SECS_PER_DAY * DAYS_PER_WEEK;
 
-    KUZU_API static constexpr const int64_t MICROS_PER_MSEC = 1000;
-    KUZU_API static constexpr const int64_t MICROS_PER_SEC = MICROS_PER_MSEC * MSECS_PER_SEC;
-    KUZU_API static constexpr const int64_t MICROS_PER_MINUTE = MICROS_PER_SEC * SECS_PER_MINUTE;
-    KUZU_API static constexpr const int64_t MICROS_PER_HOUR = MICROS_PER_MINUTE * MINS_PER_HOUR;
-    KUZU_API static constexpr const int64_t MICROS_PER_DAY = MICROS_PER_HOUR * HOURS_PER_DAY;
-    KUZU_API static constexpr const int64_t MICROS_PER_MONTH = MICROS_PER_DAY * DAYS_PER_MONTH;
+    static constexpr const int64_t MICROS_PER_MSEC = 1000;
+    static constexpr const int64_t MICROS_PER_SEC = MICROS_PER_MSEC * MSECS_PER_SEC;
+    static constexpr const int64_t MICROS_PER_MINUTE = MICROS_PER_SEC * SECS_PER_MINUTE;
+    static constexpr const int64_t MICROS_PER_HOUR = MICROS_PER_MINUTE * MINS_PER_HOUR;
+    static constexpr const int64_t MICROS_PER_DAY = MICROS_PER_HOUR * HOURS_PER_DAY;
+    static constexpr const int64_t MICROS_PER_WEEK = MICROS_PER_DAY * DAYS_PER_WEEK;
+    static constexpr const int64_t MICROS_PER_MONTH = MICROS_PER_DAY * DAYS_PER_MONTH;
 
-    KUZU_API static constexpr const int64_t NANOS_PER_MICRO = 1000;
+    static constexpr const int64_t NANOS_PER_MICRO = 1000;
+    static constexpr const int64_t NANOS_PER_MSEC = NANOS_PER_MICRO * MICROS_PER_MSEC;
+    static constexpr const int64_t NANOS_PER_SEC = NANOS_PER_MSEC * MSECS_PER_SEC;
+    static constexpr const int64_t NANOS_PER_MINUTE = NANOS_PER_SEC * SECS_PER_MINUTE;
+    static constexpr const int64_t NANOS_PER_HOUR = NANOS_PER_MINUTE * MINS_PER_HOUR;
+    static constexpr const int64_t NANOS_PER_DAY = NANOS_PER_HOUR * HOURS_PER_DAY;
+    static constexpr const int64_t NANOS_PER_WEEK = NANOS_PER_DAY * DAYS_PER_WEEK;
 
     KUZU_API static void addition(interval_t& result, uint64_t number, std::string specifierStr);
-    KUZU_API static void parseIntervalField(
-        std::string buf, uint64_t& pos, uint64_t len, interval_t& result);
     KUZU_API static interval_t fromCString(const char* str, uint64_t len);
     KUZU_API static std::string toString(interval_t interval);
     KUZU_API static bool greaterThan(const interval_t& left, const interval_t& right);

--- a/test/common/interval_test.cpp
+++ b/test/common/interval_test.cpp
@@ -24,6 +24,16 @@ TEST(IntervalTests, FromCString) {
     EXPECT_EQ(result.months, 92);
     EXPECT_EQ(result.days, 84);
     EXPECT_EQ(result.micros, 174720000280);
+    result = Interval::fromCString("2 years 4 months 21 days 03:04:00.000028",
+        strlen("2 years 4 months 21 days 03:04:00.000028"));
+    EXPECT_EQ(result.months, 28);
+    EXPECT_EQ(result.days, 21);
+    EXPECT_EQ(result.micros, 11040000028);
+    result = Interval::fromCString(
+        "2 years 4 months 21 days 03:04:00", strlen("2 years 4 months 21 days 03:04:00"));
+    EXPECT_EQ(result.months, 28);
+    EXPECT_EQ(result.days, 21);
+    EXPECT_EQ(result.micros, 11040000000);
 }
 
 TEST(IntervalTests, toString) {

--- a/test/common/time_test.cpp
+++ b/test/common/time_test.cpp
@@ -7,7 +7,7 @@ using namespace kuzu::common;
 TEST(TimeTests, FromTime) {
     // Hour out of range
     try {
-        Time::FromTime(25, 24, 32, 231321);
+        Time::fromTime(25, 24, 32, 231321);
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(
@@ -16,7 +16,7 @@ TEST(TimeTests, FromTime) {
 
     // Minute out of range
     try {
-        Time::FromTime(21, 60, 22, 212322);
+        Time::fromTime(21, 60, 22, 212322);
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(
@@ -25,7 +25,7 @@ TEST(TimeTests, FromTime) {
 
     // Second out of range
     try {
-        Time::FromTime(14, 22, 61);
+        Time::fromTime(14, 22, 61);
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(
@@ -34,35 +34,46 @@ TEST(TimeTests, FromTime) {
 
     // Microsecond out of range
     try {
-        Time::FromTime(14, 22, 42, 1000001);
+        Time::fromTime(14, 22, 42, 1000001);
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(
             e.what(), "Conversion exception: Time field value out of range: 14:22:42[.1000001].");
     } catch (std::exception& e) { FAIL(); }
 
-    EXPECT_EQ(80052000000, Time::FromTime(22, 14, 12).micros);
-    EXPECT_EQ(58991000024, Time::FromTime(16, 23, 11, 24).micros);
+    EXPECT_EQ(80052000000, Time::fromTime(22, 14, 12).micros);
+    EXPECT_EQ(58991000024, Time::fromTime(16, 23, 11, 24).micros);
 }
 
 TEST(TimeTests, FromCString) {
     // Hour out of range
     try {
-        Time::FromCString("25:12:00", strlen("25:12:00"));
+        Time::fromCString("25:12:00", strlen("25:12:00"));
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(e.what(), "Conversion exception: Error occurred during parsing time. Given: "
                                "\"25:12:00\". Expected format: (hh:mm:ss[.zzzzzz]).");
     } catch (std::exception& e) { FAIL(); }
-    EXPECT_EQ(83531000000, Time::FromCString("23:12:11", strlen("23:12:11")).micros);
-    EXPECT_EQ(46792122311, Time::FromCString("12:59:52.122311", strlen("12:59:52.122311")).micros);
-    EXPECT_EQ(11561200, Time::FromCString("00:00:11.5612", strlen("00:00:11.5612")).micros);
+
+    // Hour out of range
+    try {
+        Time::fromCString("24:00:00", strlen("24:00:00"));
+        FAIL();
+    } catch (ConversionException& e) {
+        ASSERT_STREQ(e.what(), "Conversion exception: Error occurred during parsing time. Given: "
+                               "\"24:00:00\". Expected format: (hh:mm:ss[.zzzzzz]).");
+    } catch (std::exception& e) { FAIL(); }
+
+    EXPECT_EQ(83531000000, Time::fromCString("23:12:11", strlen("23:12:11")).micros);
+    EXPECT_EQ(46792122311, Time::fromCString("12:59:52.122311", strlen("12:59:52.122311")).micros);
+    EXPECT_EQ(11561200, Time::fromCString("00:00:11.5612", strlen("00:00:11.5612")).micros);
+    EXPECT_EQ(11561200, Time::fromCString(" 00:00:11.5612", strlen(" 00:00:11.5612")).micros);
 }
 
 TEST(TimeTests, Convert) {
     // 46792122311 micro seconds from 1970-01-01, which is 12:59:52.122311
     int32_t hour, minute, second, microsecond = 0;
-    Time::Convert(dtime_t(46792122311), hour, minute, second, microsecond);
+    Time::convert(dtime_t(46792122311), hour, minute, second, microsecond);
     EXPECT_EQ(hour, 12);
     EXPECT_EQ(minute, 59);
     EXPECT_EQ(second, 52);

--- a/test/common/timestamp_test.cpp
+++ b/test/common/timestamp_test.cpp
@@ -8,7 +8,7 @@ using namespace kuzu::common;
 TEST(TimestampTests, FromDatetime) {
     // day is out of range
     try {
-        Timestamp::fromDateTime(Date::fromDate(1968, 12, 42), Time::FromTime(21, 32, 51));
+        Timestamp::fromDateTime(Date::fromDate(1968, 12, 42), Time::fromTime(21, 32, 51));
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(e.what(), "Conversion exception: Date out of range: 1968-12-42.");
@@ -16,7 +16,7 @@ TEST(TimestampTests, FromDatetime) {
 
     // 2021 is not a leap year, February only has 28 days.
     try {
-        Timestamp::fromDateTime(Date::fromDate(2021, 2, 29), Time::FromTime(21, 32, 51));
+        Timestamp::fromDateTime(Date::fromDate(2021, 2, 29), Time::fromTime(21, 32, 51));
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(e.what(), "Conversion exception: Date out of range: 2021-2-29.");
@@ -24,7 +24,7 @@ TEST(TimestampTests, FromDatetime) {
 
     // hour is out of range
     try {
-        Timestamp::fromDateTime(Date::fromDate(1968, 12, 22), Time::FromTime(25, 32, 51));
+        Timestamp::fromDateTime(Date::fromDate(1968, 12, 22), Time::fromTime(25, 32, 51));
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(
@@ -33,7 +33,7 @@ TEST(TimestampTests, FromDatetime) {
 
     // second is out of range
     try {
-        Timestamp::fromDateTime(Date::fromDate(2021, 2, 28), Time::FromTime(5, 52, 70));
+        Timestamp::fromDateTime(Date::fromDate(2021, 2, 28), Time::fromTime(5, 52, 70));
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(e.what(), "Conversion exception: Time field value out of range: 5:52:70[.0].");
@@ -41,7 +41,7 @@ TEST(TimestampTests, FromDatetime) {
 
     // microsecond is out of rarnge
     try {
-        Timestamp::fromDateTime(Date::fromDate(2021, 2, 28), Time::FromTime(5, 52, 42, 1000002));
+        Timestamp::fromDateTime(Date::fromDate(2021, 2, 28), Time::fromTime(5, 52, 42, 1000002));
         FAIL();
     } catch (ConversionException& e) {
         ASSERT_STREQ(
@@ -49,9 +49,9 @@ TEST(TimestampTests, FromDatetime) {
     } catch (std::exception& e) { FAIL(); }
 
     EXPECT_EQ(
-        Timestamp::fromDateTime(Date::fromDate(2020, 10, 22), Time::FromTime(21, 32, 51)).value,
+        Timestamp::fromDateTime(Date::fromDate(2020, 10, 22), Time::fromTime(21, 32, 51)).value,
         1603402371000000);
-    EXPECT_EQ(Timestamp::fromDateTime(Date::fromDate(1978, 5, 22), Time::FromTime(00, 54, 32, 7891))
+    EXPECT_EQ(Timestamp::fromDateTime(Date::fromDate(1978, 5, 22), Time::fromTime(00, 54, 32, 7891))
                   .value,
         264646472007891);
 }

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -68,7 +68,7 @@ TEST_F(ApiTest, PrepareTimestamp) {
     auto preparedStatement =
         conn->prepare("MATCH (a:person) WHERE a.registerTime = $n RETURN COUNT(*)");
     auto date = Date::fromDate(2011, 8, 20);
-    auto time = Time::FromTime(11, 25, 30);
+    auto time = Time::fromTime(11, 25, 30);
     auto result = conn->execute(preparedStatement.get(),
         std::make_pair(std::string("n"), Timestamp::fromDateTime(date, time)));
     ASSERT_TRUE(result->hasNext());

--- a/test/test_files/common/types/interval.test
+++ b/test/test_files/common/types/interval.test
@@ -1,0 +1,181 @@
+-GROUP IntervalTests
+-DATASET CSV empty
+
+--
+
+-CASE DifferentTypesCheck
+-STATEMENT RETURN INTERVAL("3 millisecond");
+---- 1
+00:00:00.003
+
+-STATEMENT RETURN INTERVAL("3 microsecond");
+---- 1
+00:00:00.000003
+
+-STATEMENT RETURN INTERVAL("3 week");
+---- 1
+21 days
+
+-STATEMENT RETURN INTERVAL("3 quarter");
+---- 1
+9 months
+
+-STATEMENT RETURN INTERVAL("3 decade");
+---- 1
+30 years
+
+-STATEMENT RETURN INTERVAL("3 century");
+---- 1
+300 years
+
+-STATEMENT RETURN INTERVAL("3 millennium");
+---- 1
+3000 years
+
+
+-CASE FractionalCheck
+-STATEMENT RETURN INTERVAL("1.5 microsecond");
+---- 1
+00:00:00.000002
+
+-STATEMENT RETURN INTERVAL("1.5 millisecond");
+---- 1
+00:00:00.0015
+
+-STATEMENT RETURN INTERVAL("1.5 second");
+---- 1
+00:00:01.5
+
+-STATEMENT RETURN INTERVAL("1.5 minute");
+---- 1
+00:01:30
+
+-STATEMENT RETURN INTERVAL("1.5 hour");
+---- 1
+01:30:00
+
+-STATEMENT RETURN INTERVAL("1.5 day");
+---- 1
+1 day 12:00:00
+
+-STATEMENT RETURN INTERVAL("1.5 week");
+---- 1
+10 days 12:00:00
+
+-STATEMENT RETURN INTERVAL("1.5 month");
+---- 1
+1 month 15 days
+
+-STATEMENT RETURN INTERVAL("1.5 quarter");
+---- 1
+4 months 15 days
+
+-STATEMENT RETURN INTERVAL("1.5 year");
+---- 1
+1 year 6 months
+
+-STATEMENT RETURN INTERVAL("1.5 decade");
+---- 1
+15 years
+
+-STATEMENT RETURN INTERVAL("1.5 century");
+---- 1
+150 years
+
+-STATEMENT RETURN INTERVAL("1.5 millennium");
+---- 1
+1500 years
+
+
+-CASE BasicUsageCheck
+-STATEMENT RETURN INTERVAL("05:12:34.567890");
+---- 1
+05:12:34.56789
+
+-STATEMENT RETURN INTERVAL("35:10:00");
+---- 1
+35:10:00
+
+-STATEMENT RETURN INTERVAL("876:54:32.101234");
+---- 1
+876:54:32.101234
+
+-STATEMENT RETURN INTERVAL("999999999:54:32.101234");
+---- 1
+999999999:54:32.101234
+
+-STATEMENT RETURN INTERVAL("9999999999:54:32.101234");
+---- error
+Conversion exception: Error occurred during parsing time. Given: "9999999999:54:32.101234".
+
+-STATEMENT RETURN INTERVAL("");
+---- error
+Conversion exception: Error occurred during parsing interval. Given empty string.
+
+-STATEMENT RETURN INTERVAL(" ");
+---- error
+Conversion exception: Error occurred during parsing interval. Given: " ".
+
+-STATEMENT RETURN INTERVAL("years");
+---- error
+Conversion exception: Error occurred during parsing interval. Given: "years".
+
+-STATEMENT RETURN INTERVAL("100000000000000000year");
+---- error
+Overflow exception: Value 1200000000000000000 is not within INT32 range
+
+-STATEMENT RETURN INTERVAL("4294967296months");
+---- error
+Overflow exception: Value 4294967296 is not within INT32 range
+
+-STATEMENT RETURN INTERVAL("1294967296months");
+---- 1
+107913941 years 4 months
+
+-STATEMENT RETURN INTERVAL("100000000000000000days");
+---- error
+Overflow exception: Value 100000000000000000 is not within INT32 range
+
+-STATEMENT RETURN INTERVAL("100000000000000000000msecs");
+---- error
+Conversion exception: Cast failed. Could not convert "100000000000000000000" to INT64.
+
+-STATEMENT RETURN INTERVAL("100000000000000000hours");
+---- error
+Overflow exception: Interval value is out of range
+
+-STATEMENT RETURN INTERVAL("2562047788 hours");
+---- 1
+2562047788:00:00
+
+-STATEMENT RETURN INTERVAL("12");
+---- error
+Conversion exception: Error occurred during parsing interval. Field name is missing.
+
+-STATEMENT RETURN INTERVAL("12 13");
+---- error
+Conversion exception: Unrecognized interval specifier string: 13.
+
+-STATEMENT RETURN INTERVAL("2147483647 months 1 months");
+---- error
+Overflow exception: Interval value is out of range
+
+-STATEMENT RETURN INTERVAL("2147483647 days 0.1 months");
+---- error
+Overflow exception: Interval fraction is out of range
+
+-STATEMENT RETURN INTERVAL("1 month") <= INTERVAL("30 days");
+---- 1
+True
+
+-STATEMENT RETURN INTERVAL("1 year") <> INTERVAL("12 months");
+---- 1
+False
+
+-STATEMENT RETURN INTERVAL("1 year 12:00:00  ");
+---- 1
+1 year 12:00:00
+
+-STATEMENT RETURN INTERVAL("1 year 12:00:00 abcd");
+---- error
+Conversion exception: Error occurred during parsing time. Given: "12:00:00 abcd".

--- a/test/test_files/tinysnb/exception/interval.test
+++ b/test/test_files/tinysnb/exception/interval.test
@@ -20,7 +20,7 @@ Conversion exception: Error occurred during parsing interval. Given: "20 years 3
 ---- error
 Conversion exception: Unrecognized interval specifier string: minutes20.
 
--LOG UnrecognizedSpecifierStringMillseconds)
+-LOG UnrecognizedSpecifierStringMillseconds
 -STATEMENT MATCH (a:person) return interval("10 years 2 days 48 hours 28 seconds 12 millseconds")
 ---- error
 Conversion exception: Unrecognized interval specifier string: millseconds.

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -199,7 +199,7 @@ Value transformPythonValue(py::handle val) {
         auto second = PyDateTime_DATE_GET_SECOND(ptr);
         auto micros = PyDateTime_DATE_GET_MICROSECOND(ptr);
         auto date = Date::fromDate(year, month, day);
-        auto time = Time::FromTime(hour, minute, second, micros);
+        auto time = Time::fromTime(hour, minute, second, micros);
         return Value::createValue<timestamp_t>(Timestamp::fromDateTime(date, time));
     } else if (py::isinstance(val, datetime_date)) {
         auto ptr = val.ptr();

--- a/tools/python_api/src_cpp/py_conversion.cpp
+++ b/tools/python_api/src_cpp/py_conversion.cpp
@@ -87,7 +87,7 @@ void transformPythonValue(common::ValueVector* outputVector, uint64_t pos, py::h
         auto seconds = PyDateTime_DATE_GET_SECOND(ele.ptr());
         auto microseconds = PyDateTime_DATE_GET_MICROSECOND(ele.ptr());
         auto date = common::Date::fromDate(years, month, day);
-        auto time = common::Time::FromTime(hours, minutes, seconds, microseconds);
+        auto time = common::Time::fromTime(hours, minutes, seconds, microseconds);
         outputVector->setValue(pos, common::Timestamp::fromDateTime(date, time));
     } break;
     case PythonObjectType::Date: {

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -64,7 +64,7 @@ static py::object converTimestampToPyObject(timestamp_t& timestamp) {
     dtime_t time;
     Timestamp::convert(timestamp, date, time);
     Date::convert(date, year, month, day);
-    Time::Convert(time, hour, min, sec, micros);
+    Time::convert(time, hour, min, sec, micros);
     return py::cast<py::object>(
         PyDateTime_FromDateAndTime(year, month, day, hour, min, sec, micros));
 }
@@ -213,7 +213,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
         dtime_t time;
         Timestamp::convert(timestampVal, date, time);
         Date::convert(date, year, month, day);
-        Time::Convert(time, hour, min, sec, micros);
+        Time::convert(time, hour, min, sec, micros);
 
         return py::cast<py::object>(PyDateTimeTZ_FromDateAndTime(
             year, month, day, hour, min, sec, micros, PyDateTime_TimeZone_UTC));


### PR DESCRIPTION
This pull request addressed problem #2882 by modifying the way time is imported within Intervals. The problem is because the time is exported in the format of ```hh:mm:ss```, which the parser couldn't handle during import.  The modifications include adapting ```Interval::fromCString``` to accommodate this format. Additionally, the updated parser now supports new date specifiers such as ```millennium```, ```century```, ```decade```, ```quarter``` and ```week```, along with partial numbers for time values.