### PR TITLE
Expose kuzu version and storage version in the rust API

### DIFF
--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -11,6 +11,7 @@
 #include "common/types/value/rel.h"
 #include "common/types/value/value.h"
 #include "main/kuzu.h"
+#include "storage/storage_info.h"
 #else
 #include <kuzu.hpp>
 #endif
@@ -206,6 +207,10 @@ inline rust::Vec<uint8_t> get_blob_from_bytes(const rust::Vec<uint8_t>& value) {
         result.push_back(c);
     }
     return result;
+}
+
+inline kuzu::storage::storage_version_t get_storage_version() {
+    return kuzu::storage::StorageVersionInfo::getStorageVersion();
 }
 
 } // namespace kuzu_rs

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -364,4 +364,9 @@ pub(crate) mod ffi {
 
         fn get_blob_from_bytes(value: &Vec<u8>) -> Vec<u8>;
     }
+
+    #[namespace = "kuzu_rs"]
+    unsafe extern "C++" {
+        fn get_storage_version() -> u64;
+    }
 }

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -57,3 +57,10 @@ pub use value::{InternalID, NodeVal, RelVal, Value};
 
 #[cfg(feature = "arrow")]
 pub use query_result::ArrowIterator;
+
+/// The version of the Kùzu crate as reported by Cargo's CARGO_PKG_VERSION environment variable
+pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+/// Returns the storage version of the Kùzu library
+pub fn get_storage_version() -> u64 {
+    crate::ffi::ffi::get_storage_version()
+}


### PR DESCRIPTION
Rust API for #2954 

The version is being pulled from `Cargo.toml` at compile-time since that's simpler.