### PR TITLE
Import cache fix

### DIFF
--- a/tools/python_api/src_cpp/include/py_database.h
+++ b/tools/python_api/src_cpp/include/py_database.h
@@ -2,6 +2,7 @@
 
 #include "main/kuzu.h"
 #include "main/storage_driver.h"
+#include "cached_import/py_cached_import.h"
 #include "pybind_include.h" // IWYU pragma: keep (used for py:: namespace)
 #define PYBIND11_DETAILED_ERROR_MESSAGES
 using namespace kuzu::main;

--- a/tools/python_api/src_cpp/kuzu_binding.cpp
+++ b/tools/python_api/src_cpp/kuzu_binding.cpp
@@ -1,3 +1,4 @@
+#include "include/cached_import/py_cached_import.h"
 #include "include/py_connection.h"
 #include "include/py_database.h"
 #include "include/py_prepared_statement.h"
@@ -8,6 +9,10 @@ void bind(py::module& m) {
     PyConnection::initialize(m);
     PyPreparedStatement::initialize(m);
     PyQueryResult::initialize(m);
+    auto cleanImportCache = []() {
+        kuzu::importCache.reset();
+    };
+    m.add_object("_clean_import_cache", py::capsule(cleanImportCache));
 }
 
 PYBIND11_MODULE(_kuzu, m) {

--- a/tools/python_api/src_cpp/py_database.cpp
+++ b/tools/python_api/src_cpp/py_database.cpp
@@ -38,12 +38,13 @@ PyDatabase::PyDatabase(const std::string& databasePath, uint64_t bufferPoolSize,
     database = std::make_unique<Database>(databasePath, systemConfig);
     database->addBuiltInFunction(READ_PANDAS_FUNC_NAME, kuzu::PandasScanFunction::getFunctionSet());
     storageDriver = std::make_unique<kuzu::main::StorageDriver>(database.get());
-    kuzu::importCache = std::make_shared<kuzu::PythonCachedImport>();
+    py::gil_scoped_acquire acquire;
+    if (kuzu::importCache.get() == nullptr) {
+        kuzu::importCache = std::make_shared<kuzu::PythonCachedImport>();
+    }
 }
 
-PyDatabase::~PyDatabase() {
-    kuzu::importCache.reset();
-}
+PyDatabase::~PyDatabase() {}
 
 template<class T>
 void PyDatabase::scanNodeTable(const std::string& tableName, const std::string& propName,


### PR DESCRIPTION
Draft PR to run CI.

Fixes issues that occur when calling PyDatabase constructor/destructors in the middle of execution. 

