### PR TITLE
Re-write partitioner to use ColumnChunks instead of ValueVectors

### DIFF
--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "common/data_chunk/data_chunk_collection.h"
 #include "processor/operator/sink.h"
+#include "storage/store/column_chunk.h"
 
 namespace kuzu {
 namespace storage {
@@ -20,7 +20,14 @@ struct PartitionerFunctions {
 // partitioning methods. For example, copy of rel tables require partitioning on both FWD and BWD
 // direction. Each partitioning method corresponds to a PartitioningState.
 struct PartitioningBuffer {
-    std::vector<std::unique_ptr<common::DataChunkCollection>> partitions;
+    using ColumnChunkCollection = std::vector<std::unique_ptr<storage::ColumnChunk>>;
+    struct Partition {
+        // One chunk for each column, grouped into a list
+        // so that groups from different threads can be quickly merged without copying
+        // E.g. [(a,b,c), (a,b,c)] where a is a chunk for column a, b for column b, etc.
+        std::vector<ColumnChunkCollection> chunks;
+    };
+    std::vector<Partition> partitions;
 
     void merge(std::unique_ptr<PartitioningBuffer> localPartitioningStates);
 };
@@ -49,11 +56,11 @@ struct PartitionerSharedState {
     void resetState();
     void merge(std::vector<std::unique_ptr<PartitioningBuffer>> localPartitioningStates);
 
-    inline common::DataChunkCollection* getPartitionBuffer(
+    inline PartitioningBuffer::Partition& getPartitionBuffer(
         common::vector_idx_t partitioningIdx, common::partition_idx_t partitionIdx) {
         KU_ASSERT(partitioningIdx < partitioningBuffers.size());
         KU_ASSERT(partitionIdx < partitioningBuffers[partitioningIdx]->partitions.size());
-        return partitioningBuffers[partitioningIdx]->partitions[partitionIdx].get();
+        return partitioningBuffers[partitioningIdx]->partitions[partitionIdx];
     }
 };
 
@@ -102,7 +109,7 @@ public:
 
     static void initializePartitioningStates(
         std::vector<std::unique_ptr<PartitioningBuffer>>& partitioningBuffers,
-        std::vector<common::partition_idx_t> numPartitions, storage::MemoryManager* mm);
+        std::vector<common::partition_idx_t> numPartitions);
 
 private:
     // TODO: For now, RelBatchInsert will guarantee all data are inside one data chunk. Should be
@@ -111,6 +118,9 @@ private:
         common::partition_idx_t partitioningIdx, common::DataChunk* chunkToCopyFrom);
 
 private:
+    // Same size as a value vector. Each thread will allocate a chunk for each node group,
+    // so this should be kept relatively small to avoid allocating more memory than is needed
+    static const uint64_t CHUNK_SIZE = 2048;
     std::vector<std::unique_ptr<PartitioningInfo>> infos;
     std::shared_ptr<PartitionerSharedState> sharedState;
     std::unique_ptr<PartitionerLocalState> localState;

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -3,6 +3,7 @@
 #include "common/enums/rel_direction.h"
 #include "processor/operator/partitioner.h"
 #include "processor/operator/persistent/batch_insert.h"
+#include "storage/store/column_chunk.h"
 #include "storage/store/node_group.h"
 
 namespace kuzu {
@@ -60,20 +61,20 @@ public:
     }
 
 private:
-    void prepareCSRNodeGroup(common::DataChunkCollection* partition,
+    void prepareCSRNodeGroup(PartitioningBuffer::Partition& partition,
         common::offset_t startNodeOffset, common::vector_idx_t offsetVectorIdx,
         common::offset_t numNodes);
 
     static common::length_t getGapSize(common::length_t length);
     static std::vector<common::offset_t> populateStartCSROffsetsAndLengths(
         storage::CSRHeaderChunks& csrHeader, common::offset_t numNodes,
-        common::DataChunkCollection* partition, common::vector_idx_t offsetVectorIdx);
+        PartitioningBuffer::Partition& partition, common::vector_idx_t offsetVectorIdx);
     static void populateEndCSROffsets(
         storage::CSRHeaderChunks& csrHeader, std::vector<common::offset_t>& gaps);
     static void setOffsetToWithinNodeGroup(
-        common::ValueVector* vector, common::offset_t startOffset);
+        storage::ColumnChunk& chunk, common::offset_t startOffset);
     static void setOffsetFromCSROffsets(
-        common::ValueVector* offsetVector, storage::ColumnChunk* offsetChunk);
+        storage::ColumnChunk* nodeOffsetChunk, storage::ColumnChunk* csrOffsetChunk);
 
     // We only check rel multiplcity constraint (MANY_ONE, ONE_ONE) for now.
     std::optional<common::offset_t> checkRelMultiplicityConstraint(

--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "common/assert.h"
+#include "common/types/types.h"
+#include "storage/store/column_chunk.h"
 #include "storage/store/dictionary_chunk.h"
 
 namespace kuzu {
@@ -8,17 +10,18 @@ namespace storage {
 
 class StringColumnChunk : public ColumnChunk {
 public:
-    StringColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression);
+    StringColumnChunk(
+        common::LogicalType dataType, uint64_t capacity, bool enableCompression, bool inMemory);
 
     void resetToEmpty() final;
     void append(common::ValueVector* vector) final;
+    void appendOne(common::ValueVector* vector, common::vector_idx_t pos) final;
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) final;
 
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) final;
-    void write(common::ValueVector* valueVector, common::ValueVector* offsetInChunkVector,
-        bool isCSR) final;
+    void write(ColumnChunk* chunk, ColumnChunk* dstOffsets, bool isCSR) final;
     void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
     void copy(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
@@ -43,7 +46,7 @@ private:
     void appendStringColumnChunk(StringColumnChunk* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend);
 
-    void setValueFromString(const char* value, uint64_t length, uint64_t pos);
+    void setValueFromString(std::string_view value, uint64_t pos);
 
 private:
     std::unique_ptr<DictionaryChunk> dictionaryChunk;

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "common/types/internal_id_t.h"
+#include "common/types/types.h"
 #include "storage/store/column_chunk.h"
 
 namespace kuzu {
@@ -7,7 +9,8 @@ namespace storage {
 
 class StructColumnChunk : public ColumnChunk {
 public:
-    StructColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression);
+    StructColumnChunk(
+        common::LogicalType dataType, uint64_t capacity, bool enableCompression, bool inMemory);
 
     inline ColumnChunk* getChild(common::vector_idx_t childIdx) {
         KU_ASSERT(childIdx < childChunks.size());
@@ -20,11 +23,11 @@ protected:
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) final;
     void append(common::ValueVector* vector) final;
+    void appendOne(common::ValueVector* vector, common::vector_idx_t pos) final;
 
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) final;
-    void write(common::ValueVector* valueVector, common::ValueVector* offsetInChunkVector,
-        bool isCSR) final;
+    void write(ColumnChunk* chunk, ColumnChunk* dstOffsets, bool isCSR) final;
     void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
     void copy(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -27,7 +27,8 @@ struct VarListDataColumnChunk {
 class VarListColumnChunk : public ColumnChunk {
 
 public:
-    VarListColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression);
+    VarListColumnChunk(
+        common::LogicalType dataType, uint64_t capacity, bool enableCompression, bool inMemory);
 
     inline ColumnChunk* getDataColumnChunk() const {
         return varListDataColumnChunk->dataColumnChunk.get();
@@ -36,11 +37,11 @@ public:
     void resetToEmpty() final;
 
     void append(common::ValueVector* vector) final;
+    void appendOne(common::ValueVector* vector, common::vector_idx_t pos) final;
     // Note: `write` assumes that no `append` will be called afterward.
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) final;
-    void write(common::ValueVector* valueVector, common::ValueVector* offsetInChunkVector,
-        bool isCSR) final;
+    void write(ColumnChunk* chunk, ColumnChunk* dstOffsets, bool isCSR) final;
     void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
     void copy(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -1,5 +1,10 @@
 #include "processor/operator/partitioner.h"
 
+#include <cstdint>
+
+#include "common/constants.h"
+#include "processor/execution_context.h"
+#include "storage/store/column_chunk.h"
 #include "storage/store/node_table.h"
 
 using namespace kuzu::common;
@@ -42,7 +47,7 @@ void PartitionerSharedState::initialize() {
     numPartitions.resize(2);
     numPartitions[0] = getNumPartitions(maxNodeOffsets[0]);
     numPartitions[1] = getNumPartitions(maxNodeOffsets[1]);
-    Partitioner::initializePartitioningStates(partitioningBuffers, numPartitions, mm);
+    Partitioner::initializePartitioningStates(partitioningBuffers, numPartitions);
 }
 
 partition_idx_t PartitionerSharedState::getNextPartition(vector_idx_t partitioningIdx) {
@@ -71,9 +76,13 @@ void PartitionerSharedState::merge(
 void PartitioningBuffer::merge(std::unique_ptr<PartitioningBuffer> localPartitioningState) {
     KU_ASSERT(partitions.size() == localPartitioningState->partitions.size());
     for (auto partitionIdx = 0u; partitionIdx < partitions.size(); partitionIdx++) {
-        auto sharedPartition = partitions[partitionIdx].get();
-        auto localPartition = localPartitioningState->partitions[partitionIdx].get();
-        sharedPartition->merge(localPartition);
+        auto& sharedPartition = partitions[partitionIdx];
+        auto& localPartition = localPartitioningState->partitions[partitionIdx];
+        sharedPartition.chunks.reserve(
+            sharedPartition.chunks.size() + localPartition.chunks.size());
+        for (auto j = 0u; j < localPartition.chunks.size(); j++) {
+            sharedPartition.chunks.push_back(std::move(localPartition.chunks[j]));
+        }
     }
 }
 
@@ -91,10 +100,9 @@ void Partitioner::initGlobalStateInternal(ExecutionContext* /*context*/) {
     sharedState->initialize();
 }
 
-void Partitioner::initLocalStateInternal(ResultSet* /*resultSet*/, ExecutionContext* context) {
+void Partitioner::initLocalStateInternal(ResultSet* /*resultSet*/, ExecutionContext* /*context*/) {
     localState = std::make_unique<PartitionerLocalState>();
-    initializePartitioningStates(localState->partitioningBuffers, sharedState->numPartitions,
-        context->clientContext->getMemoryManager());
+    initializePartitioningStates(localState->partitioningBuffers, sharedState->numPartitions);
 }
 
 static void constructDataChunk(DataChunk* dataChunk, const std::vector<DataPos>& columnPositions,
@@ -114,14 +122,14 @@ static void constructDataChunk(DataChunk* dataChunk, const std::vector<DataPos>&
 
 void Partitioner::initializePartitioningStates(
     std::vector<std::unique_ptr<PartitioningBuffer>>& partitioningBuffers,
-    std::vector<common::partition_idx_t> numPartitions, MemoryManager* mm) {
+    std::vector<common::partition_idx_t> numPartitions) {
     partitioningBuffers.resize(numPartitions.size());
     for (auto partitioningIdx = 0u; partitioningIdx < numPartitions.size(); partitioningIdx++) {
         auto numPartition = numPartitions[partitioningIdx];
         auto partitioningBuffer = std::make_unique<PartitioningBuffer>();
         partitioningBuffer->partitions.reserve(numPartition);
         for (auto i = 0u; i < numPartition; i++) {
-            partitioningBuffer->partitions.push_back(std::make_unique<DataChunkCollection>(mm));
+            partitioningBuffer->partitions.emplace_back();
         }
         partitioningBuffers[partitioningIdx] = std::move(partitioningBuffer);
     }
@@ -146,18 +154,28 @@ void Partitioner::executeInternal(ExecutionContext* context) {
 
 void Partitioner::copyDataToPartitions(
     partition_idx_t partitioningIdx, DataChunk* chunkToCopyFrom) {
-    auto originalChunkState = chunkToCopyFrom->state;
-    chunkToCopyFrom->state = std::make_shared<DataChunkState>(1 /* capacity */);
-    chunkToCopyFrom->state->selVector->resetSelectorToValuePosBufferWithSize(1 /* size */);
-    for (auto i = 0u; i < originalChunkState->selVector->selectedSize; i++) {
-        auto posToCopyFrom = originalChunkState->selVector->selectedPositions[i];
+    for (auto i = 0u; i < chunkToCopyFrom->state->selVector->selectedSize; i++) {
+        auto posToCopyFrom = chunkToCopyFrom->state->selVector->selectedPositions[i];
         auto partitionIdx = partitionIdxes->getValue<partition_idx_t>(posToCopyFrom);
         KU_ASSERT(
             partitionIdx < localState->getPartitioningBuffer(partitioningIdx)->partitions.size());
-        auto partition =
-            localState->getPartitioningBuffer(partitioningIdx)->partitions[partitionIdx].get();
-        chunkToCopyFrom->state->selVector->selectedPositions[0] = posToCopyFrom;
-        partition->append(*chunkToCopyFrom);
+        auto& partition =
+            localState->getPartitioningBuffer(partitioningIdx)->partitions[partitionIdx];
+        if (partition.chunks.empty() || partition.chunks.back()[0]->getNumValues() + 1 >
+                                            partition.chunks.back()[0]->getCapacity()) {
+            partition.chunks.emplace_back();
+            partition.chunks.back().reserve(chunkToCopyFrom->getNumValueVectors());
+            for (auto i = 0u; i < chunkToCopyFrom->getNumValueVectors(); i++) {
+                partition.chunks.back().emplace_back(ColumnChunkFactory::createColumnChunk(
+                    chunkToCopyFrom->getValueVector(i)->dataType, false /*enableCompression*/,
+                    Partitioner::CHUNK_SIZE));
+            }
+        }
+        KU_ASSERT(partition.chunks.back().size() == chunkToCopyFrom->getNumValueVectors());
+        for (auto i = 0u; i < chunkToCopyFrom->getNumValueVectors(); i++) {
+            partition.chunks.back()[i]->appendOne(
+                chunkToCopyFrom->getValueVector(i).get(), posToCopyFrom);
+        }
     }
 }
 

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -3,7 +3,9 @@
 #include "common/exception/copy.h"
 #include "common/exception/message.h"
 #include "common/string_format.h"
+#include "processor/operator/partitioner.h"
 #include "processor/result/factorized_table.h"
+#include "storage/store/column_chunk.h"
 #include "storage/store/rel_table.h"
 
 using namespace kuzu::common;
@@ -37,12 +39,11 @@ void RelBatchInsert::executeInternal(ExecutionContext* /*context*/) {
             break;
         }
         // Read the whole partition, and set to node group.
-        auto partitioningBuffer = partitionerSharedState->getPartitionBuffer(
+        auto& partitioningBuffer = partitionerSharedState->getPartitionBuffer(
             relInfo->partitioningIdx, relLocalState->nodeGroupIdx);
         auto startNodeOffset = StorageUtils::getStartOffsetOfNodeGroup(relLocalState->nodeGroupIdx);
-        for (auto dataChunk : partitioningBuffer->getChunks()) {
-            setOffsetToWithinNodeGroup(
-                dataChunk->getValueVector(relInfo->offsetVectorIdx).get(), startNodeOffset);
+        for (auto& columns : partitioningBuffer.chunks) {
+            setOffsetToWithinNodeGroup(*columns[relInfo->offsetVectorIdx], startNodeOffset);
         }
         // Calculate num of source nodes in this node group.
         // This will be used to set the num of values of the node group.
@@ -50,8 +51,8 @@ void RelBatchInsert::executeInternal(ExecutionContext* /*context*/) {
             partitionerSharedState->maxNodeOffsets[relInfo->partitioningIdx] - startNodeOffset + 1);
         prepareCSRNodeGroup(
             partitioningBuffer, startNodeOffset, relInfo->offsetVectorIdx, numNodes);
-        for (auto dataChunk : partitioningBuffer->getChunks()) {
-            localState->nodeGroup->write(dataChunk, relInfo->offsetVectorIdx);
+        for (auto& chunk : partitioningBuffer.chunks) {
+            localState->nodeGroup->write(chunk, relInfo->offsetVectorIdx);
         }
         localState->nodeGroup->finalize(relLocalState->nodeGroupIdx);
         // Flush node group to table.
@@ -61,7 +62,7 @@ void RelBatchInsert::executeInternal(ExecutionContext* /*context*/) {
     }
 }
 
-void RelBatchInsert::prepareCSRNodeGroup(DataChunkCollection* partition,
+void RelBatchInsert::prepareCSRNodeGroup(PartitioningBuffer::Partition& partition,
     common::offset_t startNodeOffset, vector_idx_t offsetVectorIdx, offset_t numNodes) {
     auto relInfo = ku_dynamic_cast<BatchInsertInfo*, RelBatchInsertInfo*>(info.get());
     auto csrNodeGroup = ku_dynamic_cast<NodeGroup*, CSRNodeGroup*>(localState->nodeGroup.get());
@@ -79,9 +80,9 @@ void RelBatchInsert::prepareCSRNodeGroup(DataChunkCollection* partition,
     offset_t csrChunkCapacity =
         csrHeader.getEndCSROffset(numNodes - 1) + csrHeader.getCSRLength(numNodes - 1);
     localState->nodeGroup->resizeChunks(csrChunkCapacity);
-    for (auto dataChunk : partition->getChunks()) {
-        auto offsetVector = dataChunk->getValueVector(offsetVectorIdx).get();
-        setOffsetFromCSROffsets(offsetVector, csrHeader.offset.get());
+    for (auto& dataChunk : partition.chunks) {
+        auto offsetChunk = dataChunk[offsetVectorIdx].get();
+        setOffsetFromCSROffsets(offsetChunk, csrHeader.offset.get());
     }
     populateEndCSROffsets(csrHeader, gaps);
 }
@@ -104,7 +105,7 @@ length_t RelBatchInsert::getGapSize(length_t length) {
 }
 
 std::vector<offset_t> RelBatchInsert::populateStartCSROffsetsAndLengths(CSRHeaderChunks& csrHeader,
-    offset_t numNodes, DataChunkCollection* partition, vector_idx_t offsetVectorIdx) {
+    offset_t numNodes, PartitioningBuffer::Partition& partition, vector_idx_t offsetVectorIdx) {
     KU_ASSERT(numNodes == csrHeader.length->getNumValues() &&
               numNodes == csrHeader.offset->getNumValues());
     std::vector<offset_t> gaps;
@@ -113,11 +114,10 @@ std::vector<offset_t> RelBatchInsert::populateStartCSROffsetsAndLengths(CSRHeade
     auto csrLengths = (length_t*)csrHeader.length->getData();
     std::fill(csrLengths, csrLengths + numNodes, 0);
     // Calculate length for each node. Store the num of tuples of node i at csrLengths[i].
-    for (auto chunk : partition->getChunks()) {
-        auto offsetVector = chunk->getValueVector(offsetVectorIdx);
-        for (auto i = 0u; i < offsetVector->state->selVector->selectedSize; i++) {
-            auto pos = offsetVector->state->selVector->selectedPositions[i];
-            auto nodeOffset = offsetVector->getValue<offset_t>(pos);
+    for (auto& chunk : partition.chunks) {
+        auto& offsetChunk = chunk[offsetVectorIdx];
+        for (auto i = 0u; i < offsetChunk->getNumValues(); i++) {
+            auto nodeOffset = offsetChunk->getValue<offset_t>(i);
             KU_ASSERT(nodeOffset < numNodes);
             csrLengths[nodeOffset]++;
         }
@@ -134,23 +134,22 @@ std::vector<offset_t> RelBatchInsert::populateStartCSROffsetsAndLengths(CSRHeade
     return gaps;
 }
 
-void RelBatchInsert::setOffsetToWithinNodeGroup(ValueVector* vector, offset_t startOffset) {
-    KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::INT64 &&
-              vector->state->selVector->isUnfiltered());
-    auto offsets = (offset_t*)vector->getData();
-    for (auto i = 0u; i < vector->state->selVector->selectedSize; i++) {
+void RelBatchInsert::setOffsetToWithinNodeGroup(ColumnChunk& chunk, offset_t startOffset) {
+    KU_ASSERT(chunk.getDataType().getPhysicalType() == PhysicalTypeID::INT64);
+    auto offsets = (offset_t*)chunk.getData();
+    for (auto i = 0u; i < chunk.getNumValues(); i++) {
         offsets[i] -= startOffset;
     }
 }
 
-void RelBatchInsert::setOffsetFromCSROffsets(ValueVector* offsetVector, ColumnChunk* offsetChunk) {
-    KU_ASSERT(offsetVector->dataType.getPhysicalType() == PhysicalTypeID::INT64 &&
-              offsetVector->state->selVector->isUnfiltered());
-    for (auto i = 0u; i < offsetVector->state->selVector->selectedSize; i++) {
-        auto nodeOffset = offsetVector->getValue<offset_t>(i);
-        auto csrOffset = offsetChunk->getValue<offset_t>(nodeOffset);
-        offsetVector->setValue<offset_t>(i, csrOffset);
-        offsetChunk->setValue<offset_t>(csrOffset + 1, nodeOffset);
+void RelBatchInsert::setOffsetFromCSROffsets(
+    ColumnChunk* nodeOffsetChunk, ColumnChunk* csrOffsetChunk) {
+    KU_ASSERT(nodeOffsetChunk->getDataType().getPhysicalType() == PhysicalTypeID::INT64);
+    for (auto i = 0u; i < nodeOffsetChunk->getNumValues(); i++) {
+        auto nodeOffset = nodeOffsetChunk->getValue<offset_t>(i);
+        auto csrOffset = csrOffsetChunk->getValue<offset_t>(nodeOffset);
+        nodeOffsetChunk->setValue<offset_t>(csrOffset, i);
+        csrOffsetChunk->setValue<offset_t>(csrOffset + 1, nodeOffset);
     }
 }
 


### PR DESCRIPTION
ValueVectors have high memory fragmentation, and allocate strings in 256KB chunks for only 2048 strings.
ColumnChunks can have a much larger capacity, and also support string de-duplication.

Fixes #2863 (peak memory usage when copying [the dataset](https://github.com/saschamcdonald/ch_06_kuzudb_tests) was 13GB (36GB before I enabled string de-duplication in the partitioner's column chunks).
Fixes #2957 

I'm not sure if we should leave string compression enabled in the Partitioner, as it can increase memory usage for datasets with little duplication. At the least it should probably follow the global compression setting (which I don't think is easily accessible to the Partitioner).