### PR TITLE
Refactor: separate insertions and updates in rel table local storage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.3.2.1 LANGUAGES CXX C)
+project(Kuzu VERSION 0.3.2.2 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -2,12 +2,14 @@
 
 #include "catalog/catalog.h"
 
+using namespace kuzu::common;
+
 namespace kuzu {
 namespace catalog {
 
-RelTableCatalogEntry::RelTableCatalogEntry(std::string name, common::table_id_t tableID,
+RelTableCatalogEntry::RelTableCatalogEntry(std::string name, table_id_t tableID,
     common::RelMultiplicity srcMultiplicity, common::RelMultiplicity dstMultiplicity,
-    common::table_id_t srcTableID, common::table_id_t dstTableID)
+    table_id_t srcTableID, table_id_t dstTableID)
     : TableCatalogEntry{CatalogEntryType::REL_TABLE_ENTRY, std::move(name), tableID},
       srcMultiplicity{srcMultiplicity}, dstMultiplicity{dstMultiplicity}, srcTableID{srcTableID},
       dstTableID{dstTableID} {}
@@ -20,27 +22,32 @@ RelTableCatalogEntry::RelTableCatalogEntry(const RelTableCatalogEntry& other)
     dstTableID = other.dstTableID;
 }
 
-bool RelTableCatalogEntry::isParent(common::table_id_t tableID) {
+bool RelTableCatalogEntry::isParent(table_id_t tableID) {
     return srcTableID == tableID || dstTableID == tableID;
 }
 
-bool RelTableCatalogEntry::isSingleMultiplicity(common::RelDataDirection direction) const {
-    return getMultiplicity(direction) == common::RelMultiplicity::ONE;
-}
-common::RelMultiplicity RelTableCatalogEntry::getMultiplicity(
-    common::RelDataDirection direction) const {
-    return direction == common::RelDataDirection::FWD ? dstMultiplicity : srcMultiplicity;
-}
-common::table_id_t RelTableCatalogEntry::getBoundTableID(
-    common::RelDataDirection relDirection) const {
-    return relDirection == common::RelDataDirection::FWD ? srcTableID : dstTableID;
-}
-common::table_id_t RelTableCatalogEntry::getNbrTableID(
-    common::RelDataDirection relDirection) const {
-    return relDirection == common::RelDataDirection::FWD ? dstTableID : srcTableID;
+column_id_t RelTableCatalogEntry::getColumnID(property_id_t propertyID) const {
+    auto it = std::find_if(properties.begin(), properties.end(),
+        [&propertyID](const auto& property) { return property.getPropertyID() == propertyID; });
+    // Skip the first column in the rel table, which is reserved for nbrID.
+    return it == properties.end() ? common::INVALID_COLUMN_ID :
+                                    std::distance(properties.begin(), it) + 1;
 }
 
-void RelTableCatalogEntry::serialize(common::Serializer& serializer) const {
+bool RelTableCatalogEntry::isSingleMultiplicity(RelDataDirection direction) const {
+    return getMultiplicity(direction) == common::RelMultiplicity::ONE;
+}
+common::RelMultiplicity RelTableCatalogEntry::getMultiplicity(RelDataDirection direction) const {
+    return direction == RelDataDirection::FWD ? dstMultiplicity : srcMultiplicity;
+}
+table_id_t RelTableCatalogEntry::getBoundTableID(RelDataDirection relDirection) const {
+    return relDirection == RelDataDirection::FWD ? srcTableID : dstTableID;
+}
+table_id_t RelTableCatalogEntry::getNbrTableID(RelDataDirection relDirection) const {
+    return relDirection == RelDataDirection::FWD ? dstTableID : srcTableID;
+}
+
+void RelTableCatalogEntry::serialize(Serializer& serializer) const {
     TableCatalogEntry::serialize(serializer);
     serializer.write(srcMultiplicity);
     serializer.write(dstMultiplicity);
@@ -49,11 +56,11 @@ void RelTableCatalogEntry::serialize(common::Serializer& serializer) const {
 }
 
 std::unique_ptr<RelTableCatalogEntry> RelTableCatalogEntry::deserialize(
-    common::Deserializer& deserializer) {
+    Deserializer& deserializer) {
     common::RelMultiplicity srcMultiplicity;
     common::RelMultiplicity dstMultiplicity;
-    common::table_id_t srcTableID;
-    common::table_id_t dstTableID;
+    table_id_t srcTableID;
+    table_id_t dstTableID;
     deserializer.deserializeValue(srcMultiplicity);
     deserializer.deserializeValue(dstMultiplicity);
     deserializer.deserializeValue(srcTableID);

--- a/src/common/data_chunk/data_chunk_collection.cpp
+++ b/src/common/data_chunk/data_chunk_collection.cpp
@@ -7,35 +7,35 @@ DataChunkCollection::DataChunkCollection(storage::MemoryManager* mm) : mm{mm} {}
 
 void DataChunkCollection::append(DataChunk& chunk) {
     auto numTuplesToAppend = chunk.state->selVector->selectedSize;
-    auto chunkToAppendInfo = chunks.empty() ? allocateChunk(chunk) : chunks.back().get();
     auto numTuplesAppended = 0u;
     while (numTuplesAppended < numTuplesToAppend) {
-        if (chunkToAppendInfo->state->selVector->selectedSize == DEFAULT_VECTOR_CAPACITY) {
-            chunkToAppendInfo = allocateChunk(chunk);
+        if (chunks.empty() ||
+            chunks.back().state->selVector->selectedSize == DEFAULT_VECTOR_CAPACITY) {
+            allocateChunk(chunk);
         }
+        auto& chunkToAppend = chunks.back();
         auto numTuplesToCopy = std::min(numTuplesToAppend - numTuplesAppended,
-            DEFAULT_VECTOR_CAPACITY - chunkToAppendInfo->state->selVector->selectedSize);
+            DEFAULT_VECTOR_CAPACITY - chunkToAppend.state->selVector->selectedSize);
         for (auto vectorIdx = 0u; vectorIdx < chunk.getNumValueVectors(); vectorIdx++) {
             for (auto i = 0u; i < numTuplesToCopy; i++) {
                 auto srcPos = chunk.state->selVector->selectedPositions[numTuplesAppended + i];
-                auto dstPos = chunkToAppendInfo->state->selVector->selectedSize + i;
-                chunkToAppendInfo->getValueVector(vectorIdx)->copyFromVectorData(
+                auto dstPos = chunkToAppend.state->selVector->selectedSize + i;
+                chunkToAppend.getValueVector(vectorIdx)->copyFromVectorData(
                     dstPos, chunk.getValueVector(vectorIdx).get(), srcPos);
             }
         }
-        chunkToAppendInfo->state->selVector->selectedSize += numTuplesToCopy;
+        chunkToAppend.state->selVector->selectedSize += numTuplesToCopy;
         numTuplesAppended += numTuplesToCopy;
     }
 }
 
-void DataChunkCollection::append(std::unique_ptr<DataChunk> chunk) {
-    KU_ASSERT(chunk);
+void DataChunkCollection::merge(DataChunk chunk) {
     if (chunks.empty()) {
-        initTypes(*chunk);
+        initTypes(chunk);
     }
-    KU_ASSERT(chunk->getNumValueVectors() == types.size());
-    for (auto vectorIdx = 0u; vectorIdx < chunk->getNumValueVectors(); vectorIdx++) {
-        KU_ASSERT(chunk->getValueVector(vectorIdx)->dataType == types[vectorIdx]);
+    KU_ASSERT(chunk.getNumValueVectors() == types.size());
+    for (auto vectorIdx = 0u; vectorIdx < chunk.getNumValueVectors(); vectorIdx++) {
+        KU_ASSERT(chunk.getValueVector(vectorIdx)->dataType == types[vectorIdx]);
     }
     chunks.push_back(std::move(chunk));
 }
@@ -47,28 +47,18 @@ void DataChunkCollection::initTypes(DataChunk& chunk) {
     }
 }
 
-std::vector<common::DataChunk*> DataChunkCollection::getChunks() const {
-    std::vector<common::DataChunk*> ret;
-    ret.reserve(chunks.size());
-    for (auto& chunk : chunks) {
-        ret.push_back(chunk.get());
-    }
-    return ret;
-}
-
-DataChunk* DataChunkCollection::allocateChunk(DataChunk& chunk) {
+void DataChunkCollection::allocateChunk(DataChunk& chunk) {
     if (chunks.empty()) {
         types.reserve(chunk.getNumValueVectors());
         for (auto vectorIdx = 0u; vectorIdx < chunk.getNumValueVectors(); vectorIdx++) {
             types.push_back(chunk.getValueVector(vectorIdx)->dataType);
         }
     }
-    auto newChunk = std::make_unique<DataChunk>(types.size(), std::make_shared<DataChunkState>());
+    DataChunk newChunk(types.size(), std::make_shared<DataChunkState>());
     for (auto i = 0u; i < types.size(); i++) {
-        newChunk->insert(i, std::make_shared<ValueVector>(types[i], mm));
+        newChunk.insert(i, std::make_shared<ValueVector>(types[i], mm));
     }
     chunks.push_back(std::move(newChunk));
-    return chunks.back().get();
 }
 
 } // namespace common

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -451,6 +451,15 @@ std::vector<LogicalType> LogicalType::copy(const std::vector<LogicalType>& types
     return typesCopy;
 }
 
+std::vector<LogicalType> LogicalType::copy(const std::vector<LogicalType*>& types) {
+    std::vector<LogicalType> typesCopy;
+    typesCopy.reserve(types.size());
+    for (auto& type : types) {
+        typesCopy.push_back(*type->copy());
+    }
+    return typesCopy;
+}
+
 PhysicalTypeID LogicalType::getPhysicalType(LogicalTypeID typeID) {
     switch (typeID) {
     case LogicalTypeID::ANY: {

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -48,8 +48,6 @@ private:
             columns.push_back(relTable->getCSRLengthColumn(RelDataDirection::FWD));
             columns.push_back(relTable->getCSROffsetColumn(RelDataDirection::BWD));
             columns.push_back(relTable->getCSRLengthColumn(RelDataDirection::BWD));
-            columns.push_back(relTable->getAdjColumn(RelDataDirection::FWD));
-            columns.push_back(relTable->getAdjColumn(RelDataDirection::BWD));
             for (auto columnID = 0u; columnID < relTable->getNumColumns(); columnID++) {
                 auto column = relTable->getColumn(columnID, RelDataDirection::FWD);
                 auto collectedColumns = collectColumns(column);
@@ -167,10 +165,10 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     while (true) {
         if (localState->currChunkIdx < localState->dataChunkCollection->getNumChunks()) {
             // Copy from local state chunk.
-            auto chunk = localState->dataChunkCollection->getChunk(localState->currChunkIdx);
-            auto numValuesToOutput = chunk->state->selVector->selectedSize;
+            auto& chunk = localState->dataChunkCollection->getChunkUnsafe(localState->currChunkIdx);
+            auto numValuesToOutput = chunk.state->selVector->selectedSize;
             for (auto columnIdx = 0u; columnIdx < dataChunk.getNumValueVectors(); columnIdx++) {
-                auto localVector = chunk->getValueVector(columnIdx);
+                auto localVector = chunk.getValueVector(columnIdx);
                 auto outputVector = dataChunk.getValueVector(columnIdx);
                 for (auto i = 0u; i < numValuesToOutput; i++) {
                     outputVector->copyFromVectorData(i, localVector.get(), i);

--- a/src/include/catalog/catalog_entry/rel_table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/rel_table_catalog_entry.h
@@ -23,6 +23,7 @@ public:
     //===--------------------------------------------------------------------===//
     bool isParent(common::table_id_t tableID) override;
     common::TableType getTableType() const override { return common::TableType::REL; }
+    common::column_id_t getColumnID(common::property_id_t propertyID) const override;
     common::table_id_t getSrcTableID() const { return srcTableID; }
     common::table_id_t getDstTableID() const { return dstTableID; }
     bool isSingleMultiplicity(common::RelDataDirection direction) const;

--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -39,7 +39,7 @@ public:
     bool containProperty(const std::string& propertyName) const;
     common::property_id_t getPropertyID(const std::string& propertyName) const;
     const Property* getProperty(common::property_id_t propertyID) const;
-    common::column_id_t getColumnID(common::property_id_t propertyID) const;
+    virtual common::column_id_t getColumnID(common::property_id_t propertyID) const;
     bool containPropertyType(const common::LogicalType& logicalType) const;
     void addProperty(std::string propertyName, std::unique_ptr<common::LogicalType> dataType);
     void dropProperty(common::property_id_t propertyID);
@@ -52,7 +52,7 @@ public:
     static std::unique_ptr<TableCatalogEntry> deserialize(
         common::Deserializer& deserializer, CatalogEntryType type);
 
-private:
+protected:
     common::table_id_t tableID;
     std::string comment;
     common::property_id_t nextPID;

--- a/src/include/common/column_data_format.h
+++ b/src/include/common/column_data_format.h
@@ -7,5 +7,5 @@ namespace common {
 
 enum class ColumnDataFormat : uint8_t { REGULAR = 0, CSR = 1 };
 
-}
+} // namespace common
 } // namespace kuzu

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -302,6 +302,7 @@ public:
     static std::vector<std::unique_ptr<LogicalType>> copy(
         const std::vector<std::unique_ptr<LogicalType>>& types);
     static std::vector<LogicalType> copy(const std::vector<LogicalType>& types);
+    static std::vector<LogicalType> copy(const std::vector<LogicalType*>& types);
 
     static std::unique_ptr<LogicalType> ANY() {
         return std::make_unique<LogicalType>(LogicalTypeID::ANY);

--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -112,10 +112,13 @@ public:
         std::vector<common::partition_idx_t> numPartitions);
 
 private:
+    common::DataChunk constructDataChunk(const std::vector<DataPos>& columnPositions,
+        const std::vector<common::LogicalType>& columnTypes, const ResultSet& resultSet,
+        const std::shared_ptr<common::DataChunkState>& state);
     // TODO: For now, RelBatchInsert will guarantee all data are inside one data chunk. Should be
     //  generalized to resultSet later if needed.
     void copyDataToPartitions(
-        common::partition_idx_t partitioningIdx, common::DataChunk* chunkToCopyFrom);
+        common::partition_idx_t partitioningIdx, common::DataChunk chunkToCopyFrom);
 
 private:
     // Same size as a value vector. Each thread will allocate a chunk for each node group,

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -11,35 +11,26 @@ class LocalNodeNG final : public LocalNodeGroup {
 public:
     LocalNodeNG(common::offset_t nodeGroupStartOffset,
         const std::vector<common::LogicalType*>& dataTypes, MemoryManager* mm)
-        : LocalNodeGroup{nodeGroupStartOffset, dataTypes, mm} {
-        insertInfo.resize(dataTypes.size());
-        updateInfo.resize(dataTypes.size());
-    }
+        : LocalNodeGroup{nodeGroupStartOffset, dataTypes, mm} {}
 
     void scan(common::ValueVector* nodeIDVector, const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVectors);
     void lookup(common::offset_t nodeOffset, common::column_id_t columnID,
         common::ValueVector* outputVector, common::sel_t posInOutputVector);
-    void insert(common::ValueVector* nodeIDVector,
-        const std::vector<common::ValueVector*>& propertyVectors);
-    void update(common::ValueVector* nodeIDVector, common::column_id_t columnID,
-        common::ValueVector* propertyVector);
-    void delete_(common::ValueVector* nodeIDVector);
 
-    common::row_idx_t getRowIdx(common::column_id_t columnID, common::offset_t nodeOffset);
+    bool insert(std::vector<common::ValueVector*> nodeIDVectors,
+        std::vector<common::ValueVector*> propertyVectors) override;
+    bool update(std::vector<common::ValueVector*> nodeIDVectors, common::column_id_t columnID,
+        common::ValueVector* propertyVector) override;
+    bool delete_(
+        common::ValueVector* nodeIDVector, common::ValueVector* /*extraVector*/ = nullptr) override;
 
-    inline const offset_to_row_idx_t& getInsertInfoRef(common::column_id_t columnID) {
-        KU_ASSERT(columnID < insertInfo.size());
-        return insertInfo[columnID];
+    inline const offset_to_row_idx_t& getInsertInfoRef() {
+        return insertChunks.getOffsetToRowIdx();
     }
     inline const offset_to_row_idx_t& getUpdateInfoRef(common::column_id_t columnID) {
-        KU_ASSERT(columnID < updateInfo.size());
-        return updateInfo[columnID];
+        return getUpdateChunks(columnID).getOffsetToRowIdx();
     }
-
-private:
-    std::vector<offset_to_row_idx_t> insertInfo;
-    std::vector<offset_to_row_idx_t> updateInfo;
 };
 
 class LocalNodeTableData final : public LocalTableData {
@@ -52,11 +43,6 @@ public:
     void lookup(common::ValueVector* nodeIDVector,
         const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVectors);
-    void insert(common::ValueVector* nodeIDVector,
-        const std::vector<common::ValueVector*>& propertyVectors);
-    void update(common::ValueVector* nodeIDVector, common::column_id_t columnID,
-        common::ValueVector* propertyVector);
-    void delete_(common::ValueVector* nodeIDVector);
 
 private:
     LocalNodeGroup* getOrCreateLocalNodeGroup(common::ValueVector* nodeIDVector) override;

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -7,89 +7,46 @@
 namespace kuzu {
 namespace storage {
 
-static constexpr common::column_id_t REL_ID_COLUMN_ID = 0;
-
-// Info of node groups with CSR chunks for rel tables.
-// Note that srcNodeOffset here are the relative offset within each node group.
-struct RelNGInfo {
-    update_insert_info_t adjInsertInfo;
-    std::vector<update_insert_info_t> insertInfoPerChunk;
-    std::vector<update_insert_info_t> updateInfoPerChunk;
-    delete_info_t deleteInfo;
-    common::RelMultiplicity multiplicity;
-
-    RelNGInfo(common::RelMultiplicity multiplicity, common::column_id_t numChunks)
-        : multiplicity{multiplicity} {
-        insertInfoPerChunk.resize(numChunks);
-        updateInfoPerChunk.resize(numChunks);
-    }
-
-    bool insert(common::offset_t srcOffsetInChunk, common::offset_t relOffset,
-        common::row_idx_t adjNodeRowIdx, const std::vector<common::row_idx_t>& propertyNodesRowIdx);
-    void update(common::offset_t srcOffsetInChunk, common::offset_t relOffset,
-        common::column_id_t columnID, common::row_idx_t rowIdx);
-    bool delete_(common::offset_t srcOffsetInChunk, common::offset_t relOffset);
-
-    bool hasUpdates();
-
-    uint64_t getNumInsertedTuples(common::offset_t srcOffsetInChunk);
-
-    const update_insert_info_t& getUpdateInfo(common::column_id_t columnID) {
-        KU_ASSERT(columnID == common::INVALID_COLUMN_ID || columnID < updateInfoPerChunk.size());
-        return columnID == common::INVALID_COLUMN_ID ? getEmptyInfo() :
-                                                       updateInfoPerChunk[columnID];
-    }
-    const update_insert_info_t& getInsertInfo(common::column_id_t columnID) {
-        KU_ASSERT(columnID == common::INVALID_COLUMN_ID || columnID < insertInfoPerChunk.size());
-        return columnID == common::INVALID_COLUMN_ID ? adjInsertInfo : insertInfoPerChunk[columnID];
-    }
-    const delete_info_t& getDeleteInfo() const { return deleteInfo; }
-
-    const update_insert_info_t& getEmptyInfo();
-
-private:
-    inline static bool contains(
-        const std::unordered_set<common::offset_t>& set, common::offset_t value) {
-        return set.find(value) != set.end();
-    }
-};
+static constexpr common::column_id_t LOCAL_NBR_ID_COLUMN_ID = 0;
+static constexpr common::column_id_t LOCAL_REL_ID_COLUMN_ID = 1;
 
 class LocalRelNG final : public LocalNodeGroup {
+    friend class RelTableData;
+
 public:
     LocalRelNG(common::offset_t nodeGroupStartOffset, std::vector<common::LogicalType*> dataTypes,
         MemoryManager* mm, common::RelMultiplicity multiplicity);
 
-    common::row_idx_t scanCSR(common::offset_t srcOffsetInChunk,
-        common::offset_t posToReadForOffset, const std::vector<common::column_id_t>& columnIDs,
+    common::row_idx_t scanCSR(common::offset_t srcOffset, common::offset_t posToReadForOffset,
+        const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVector);
     // For CSR, we need to apply updates and deletions here, while insertions are handled by
     // `scanCSR`.
-    void applyLocalChangesForCSRColumns(common::offset_t srcOffsetInChunk,
+    void applyLocalChangesToScannedVectors(common::offset_t srcOffset,
         const std::vector<common::column_id_t>& columnIDs, common::ValueVector* relIDVector,
         const std::vector<common::ValueVector*>& outputVectors);
 
-    bool insert(common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector,
-        const std::vector<common::ValueVector*>& propertyVectors);
-    void update(common::ValueVector* srcNodeIDVector, common::ValueVector* relIDVector,
-        common::column_id_t columnID, common::ValueVector* propertyVector);
-    bool delete_(common::ValueVector* srcNodeIDVector, common::ValueVector* relIDVector);
+    bool insert(std::vector<common::ValueVector*> nodeIDVectors,
+        std::vector<common::ValueVector*> vectors) override;
+    bool update(std::vector<common::ValueVector*> nodeIDVectors, common::column_id_t columnID,
+        common::ValueVector* propertyVector) override;
+    bool delete_(common::ValueVector* srcNodeVector, common::ValueVector* relIDVector) override;
 
-    inline LocalVectorCollection* getAdjChunk() { return adjChunk.get(); }
-    inline LocalVectorCollection* getPropertyChunk(common::column_id_t columnID) {
-        KU_ASSERT(columnID < chunks.size());
-        return chunks[columnID].get();
+    common::offset_t getNumInsertedRels(common::offset_t srcOffset) const;
+    void getChangesPerCSRSegment(
+        std::vector<int64_t>& sizeChangesPerSegment, std::vector<bool>& hasChangesPerSegment);
+
+private:
+    static common::vector_idx_t getSegmentIdx(common::offset_t offset) {
+        return offset >> common::StorageConstants::CSR_SEGMENT_SIZE_LOG2;
     }
-    inline RelNGInfo* getRelNGInfo() { return relNGInfo.get(); }
+
+    void applyCSRUpdates(common::column_id_t columnID, common::ValueVector* relIDVector,
+        common::ValueVector* outputVector);
+    void applyCSRDeletions(common::offset_t srcOffsetInChunk, common::ValueVector* relIDVector);
 
 private:
-    void applyCSRUpdates(common::offset_t srcOffsetInChunk, common::column_id_t columnID,
-        common::ValueVector* relIDVector, common::ValueVector* outputVector);
-    void applyCSRDeletions(common::offset_t srcOffsetInChunk, const delete_info_t& deleteInfo,
-        common::ValueVector* relIDVector);
-
-private:
-    std::unique_ptr<LocalVectorCollection> adjChunk;
-    std::unique_ptr<RelNGInfo> relNGInfo;
+    common::RelMultiplicity multiplicity;
 };
 
 class LocalRelTableData final : public LocalTableData {
@@ -99,13 +56,6 @@ public:
     LocalRelTableData(common::RelMultiplicity multiplicity,
         std::vector<common::LogicalType*> dataTypes, MemoryManager* mm)
         : LocalTableData{std::move(dataTypes), mm}, multiplicity{multiplicity} {}
-
-    bool insert(common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector,
-        const std::vector<common::ValueVector*>& propertyVectors);
-    void update(common::ValueVector* srcNodeIDVector, common::ValueVector* relIDVector,
-        common::column_id_t columnID, common::ValueVector* propertyVector);
-    bool delete_(common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector,
-        common::ValueVector* relIDVector);
 
 private:
     LocalNodeGroup* getOrCreateLocalNodeGroup(common::ValueVector* nodeIDVector) override;

--- a/src/include/storage/stats/rel_table_statistics.h
+++ b/src/include/storage/stats/rel_table_statistics.h
@@ -30,12 +30,12 @@ public:
 
     inline void addMetadataDAHInfoForColumn(
         std::unique_ptr<MetadataDAHInfo> metadataDAHInfo, common::RelDataDirection direction) {
-        auto& metadataDAHInfos = getDirectedPropertyMetadataDAHInfosRef(direction);
+        auto& metadataDAHInfos = getDirectedMetadataDAHInfosRef(direction);
         metadataDAHInfos.push_back(std::move(metadataDAHInfo));
     }
     inline void removeMetadataDAHInfoForColumn(
         common::column_id_t columnID, common::RelDataDirection direction) {
-        auto& metadataDAHInfos = getDirectedPropertyMetadataDAHInfosRef(direction);
+        auto& metadataDAHInfos = getDirectedMetadataDAHInfosRef(direction);
         KU_ASSERT(columnID < metadataDAHInfos.size());
         metadataDAHInfos.erase(metadataDAHInfos.begin() + columnID);
     }
@@ -47,13 +47,9 @@ public:
         return direction == common::RelDataDirection::FWD ? fwdCSRLengthMetadataDAHInfo.get() :
                                                             bwdCSRLengthMetadataDAHInfo.get();
     }
-    inline MetadataDAHInfo* getAdjMetadataDAHInfo(common::RelDataDirection direction) {
-        return direction == common::RelDataDirection::FWD ? fwdAdjMetadataDAHInfo.get() :
-                                                            bwdAdjMetadataDAHInfo.get();
-    }
-    inline MetadataDAHInfo* getPropertyMetadataDAHInfo(
+    inline MetadataDAHInfo* getColumnMetadataDAHInfo(
         common::column_id_t columnID, common::RelDataDirection direction) {
-        auto& metadataDAHInfos = getDirectedPropertyMetadataDAHInfosRef(direction);
+        auto& metadataDAHInfos = getDirectedMetadataDAHInfosRef(direction);
         KU_ASSERT(columnID < metadataDAHInfos.size());
         return metadataDAHInfos[columnID].get();
     }
@@ -67,10 +63,10 @@ public:
     }
 
 private:
-    inline std::vector<std::unique_ptr<MetadataDAHInfo>>& getDirectedPropertyMetadataDAHInfosRef(
+    inline std::vector<std::unique_ptr<MetadataDAHInfo>>& getDirectedMetadataDAHInfosRef(
         common::RelDataDirection direction) {
-        return direction == common::RelDataDirection::FWD ? fwdPropertyMetadataDAHInfos :
-                                                            bwdPropertyMetadataDAHInfos;
+        return direction == common::RelDataDirection::FWD ? fwdMetadataDAHInfos :
+                                                            bwdMetadataDAHInfos;
     }
 
 private:
@@ -80,10 +76,8 @@ private:
     std::unique_ptr<MetadataDAHInfo> bwdCSROffsetMetadataDAHInfo;
     std::unique_ptr<MetadataDAHInfo> fwdCSRLengthMetadataDAHInfo;
     std::unique_ptr<MetadataDAHInfo> bwdCSRLengthMetadataDAHInfo;
-    std::unique_ptr<MetadataDAHInfo> fwdAdjMetadataDAHInfo;
-    std::unique_ptr<MetadataDAHInfo> bwdAdjMetadataDAHInfo;
-    std::vector<std::unique_ptr<MetadataDAHInfo>> fwdPropertyMetadataDAHInfos;
-    std::vector<std::unique_ptr<MetadataDAHInfo>> bwdPropertyMetadataDAHInfos;
+    std::vector<std::unique_ptr<MetadataDAHInfo>> fwdMetadataDAHInfos;
+    std::vector<std::unique_ptr<MetadataDAHInfo>> bwdMetadataDAHInfos;
 };
 
 } // namespace storage

--- a/src/include/storage/stats/rels_store_statistics.h
+++ b/src/include/storage/stats/rels_store_statistics.h
@@ -48,9 +48,7 @@ public:
         common::table_id_t tableID, common::RelDataDirection direction);
     MetadataDAHInfo* getCSRLengthMetadataDAHInfo(transaction::Transaction* transaction,
         common::table_id_t tableID, common::RelDataDirection direction);
-    MetadataDAHInfo* getAdjMetadataDAHInfo(transaction::Transaction* transaction,
-        common::table_id_t tableID, common::RelDataDirection direction);
-    MetadataDAHInfo* getPropertyMetadataDAHInfo(transaction::Transaction* transaction,
+    MetadataDAHInfo* getColumnMetadataDAHInfo(transaction::Transaction* transaction,
         common::table_id_t tableID, common::column_id_t columnID,
         common::RelDataDirection direction);
 

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -69,9 +69,8 @@ public:
         DATA = 3,   // This is used for data columns in VAR_LIST and STRING columns.
         CSR_OFFSET = 4,
         CSR_LENGTH = 5,
-        ADJ = 6,
-        STRUCT_CHILD = 7,
-        NULL_MASK = 8,
+        STRUCT_CHILD = 6,
+        NULL_MASK = 7,
     };
 
     // TODO: Constrain T1 and T2 to numerics.

--- a/src/include/storage/store/node_table_data.h
+++ b/src/include/storage/store/node_table_data.h
@@ -27,13 +27,15 @@ public:
         common::ValueVector* nodeIDVector,
         const std::vector<common::ValueVector*>& outputVectors) override;
 
-    // These two interfaces are node table specific, as rel table requires also relIDVector.
+    // These interfaces are node table specific, as rel table requires also relIDVector.
+    // insert/update/delete_ keeps changes inside the local storage.
     void insert(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         const std::vector<common::ValueVector*>& propertyVectors);
     void update(transaction::Transaction* transaction, common::column_id_t columnID,
         common::ValueVector* nodeIDVector, common::ValueVector* propertyVector);
     void delete_(transaction::Transaction* transaction, common::ValueVector* nodeIDVector);
 
+    // Flush the nodeGroup to disk and update metadataDAs.
     void append(NodeGroup* nodeGroup) override;
 
     void prepareLocalTableToCommit(
@@ -43,6 +45,12 @@ public:
         transaction::Transaction* transaction) const override {
         return columns[0]->getNumNodeGroups(transaction);
     }
+
+private:
+    void append(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+        LocalNodeGroup* localNodeGroup);
+    void merge(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+        LocalNodeGroup* nodeGroup);
 };
 
 } // namespace storage

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -44,16 +44,20 @@ public:
         ColumnChunk* data, common::offset_t dataOffset, common::length_t numValues) override;
 
     bool canCommitInPlace(Transaction* transaction, node_group_idx_t nodeGroupIdx,
-        LocalVectorCollection* localChunk, const offset_to_row_idx_t& insertInfo,
+        const LocalVectorCollection& localInsertChunk, const offset_to_row_idx_t& insertInfo,
+        const LocalVectorCollection& localUpdateChunk,
         const offset_to_row_idx_t& updateInfo) override;
     bool canCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
         ColumnChunk* chunk, common::offset_t srcOffset) override;
-    void commitLocalChunkInPlace(Transaction* /*transaction*/, node_group_idx_t nodeGroupIdx,
-        LocalVectorCollection* localChunk, const offset_to_row_idx_t& insertInfo,
-        const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo) override;
+    void commitLocalChunkInPlace(Transaction* transaction, node_group_idx_t nodeGroupIdx,
+        const LocalVectorCollection& localInsertChunk, const offset_to_row_idx_t& insertInfo,
+        const LocalVectorCollection& localUpdateChunk, const offset_to_row_idx_t& updateInfo,
+        const offset_set_t& deleteInfo) override;
 
 private:
+    bool checkUpdateInPlace(const ColumnChunkMetadata& metadata,
+        const LocalVectorCollection& localChunk, const offset_to_row_idx_t& writeInfo);
     std::unique_ptr<ColumnChunk> getEmptyChunkForCommit(uint64_t capacity) override {
         return ColumnChunkFactory::createNullColumnChunk(enableCompression, capacity);
     }

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -54,10 +54,6 @@ public:
         fwdRelTableData->dropColumn(columnID);
         bwdRelTableData->dropColumn(columnID);
     }
-    inline Column* getAdjColumn(common::RelDataDirection direction) {
-        return direction == common::RelDataDirection::FWD ? fwdRelTableData->getAdjColumn() :
-                                                            bwdRelTableData->getAdjColumn();
-    }
     inline Column* getCSROffsetColumn(common::RelDataDirection direction) {
         return direction == common::RelDataDirection::FWD ? fwdRelTableData->getCSROffsetColumn() :
                                                             bwdRelTableData->getCSROffsetColumn();

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -49,14 +49,19 @@ protected:
 
 private:
     bool canCommitInPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
-        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo) override;
+        common::node_group_idx_t nodeGroupIdx, const LocalVectorCollection& localInsertChunk,
+        const offset_to_row_idx_t& insertInfo, const LocalVectorCollection& localUpdateChunk,
+        const offset_to_row_idx_t& updateInfo) override;
     bool canCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
         ColumnChunk* chunk, common::offset_t srcOffset) override;
 
     bool canIndexCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, uint64_t numStrings, common::offset_t maxOffset);
+
+    bool checkUpdateInPlace(transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx, const LocalVectorCollection& localChunk,
+        const offset_to_row_idx_t& writeInfo);
 
 private:
     // Main column stores indices of values in the dictionary

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -34,9 +34,9 @@ public:
         ColumnChunk* data, common::offset_t dataOffset, common::length_t numValues) override;
 
     void prepareCommitForChunk(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localColumnChunk,
-        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo,
-        const offset_set_t& deleteInfo) override;
+        common::node_group_idx_t nodeGroupIdx, const LocalVectorCollection& localInsertChunk,
+        const offset_to_row_idx_t& insertInfo, const LocalVectorCollection& localUpdateChunk,
+        const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo) override;
     void prepareCommitForChunk(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
         ColumnChunk* chunk, common::offset_t startSrcOffset) override;
@@ -48,8 +48,9 @@ protected:
         common::ValueVector* resultVector) override;
 
     bool canCommitInPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
-        const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo) override;
+        common::node_group_idx_t nodeGroupIdx, const LocalVectorCollection& localInsertChunk,
+        const offset_to_row_idx_t& insertInfo, const LocalVectorCollection& localUpdateChunk,
+        const offset_to_row_idx_t& updateInfo) override;
     bool canCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
         ColumnChunk* chunk, common::offset_t dataOffset) override;

--- a/src/include/storage/store/table_data.h
+++ b/src/include/storage/store/table_data.h
@@ -35,8 +35,8 @@ public:
         TablesStatistics* tableStats);
 
     inline common::vector_idx_t getNumColumns() const { return columns.size(); }
-    inline virtual Column* getColumn(common::column_id_t columnID) {
-        KU_ASSERT(columnID < columns.size());
+    inline Column* getColumn(common::column_id_t columnID) {
+        KU_ASSERT(columnID < columns.size() && columnID != common::INVALID_COLUMN_ID);
         return columns[columnID].get();
     }
 

--- a/src/include/storage/store/var_list_column.h
+++ b/src/include/storage/store/var_list_column.h
@@ -82,10 +82,9 @@ private:
     void scanFiltered(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::ValueVector* offsetVector, const ListOffsetInfoInStorage& listOffsetInfoInStorage);
 
-    inline bool canCommitInPlace(transaction::Transaction* /*transaction*/,
-        common::node_group_idx_t /*nodeGroupIdx*/, LocalVectorCollection* /*localChunk*/,
-        const offset_to_row_idx_t& /*insertInfo*/,
-        const offset_to_row_idx_t& /*updateInfo*/) override {
+    inline bool canCommitInPlace(transaction::Transaction*, common::node_group_idx_t,
+        const LocalVectorCollection&, const offset_to_row_idx_t&, const LocalVectorCollection&,
+        const offset_to_row_idx_t&) override {
         // Always perform out-of-place commit for VAR_LIST columns.
         return false;
     }

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -82,6 +82,12 @@ void MultiLabelNodeDeleteExecutor::delete_(ExecutionContext* context) {
             detachDeleteState.get());
     }
     for (auto& relTable : bwdRelTables) {
+        // TODO(Guodong): For detach delete, there can possibly be a case where the same relTable is
+        // in both fwd and bwd rel tables set. the rels can be deleted twice. This is a temporary
+        // hack.
+        if (deleteType == DeleteNodeType::DETACH_DELETE && fwdRelTables.contains(relTable)) {
+            continue;
+        }
         deleteFromRelTable(context, deleteType, RelDataDirection::BWD, relTable, nodeIDVector,
             detachDeleteState.get());
     }

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -36,9 +36,9 @@ void RelBatchInsert::executeInternal(ExecutionContext* /*context*/) {
         relLocalState->nodeGroupIdx =
             partitionerSharedState->getNextPartition(relInfo->partitioningIdx);
         if (relLocalState->nodeGroupIdx == INVALID_PARTITION_IDX) {
+            // No more partitions left in the partitioning buffer.
             break;
         }
-        // Read the whole partition, and set to node group.
         auto& partitioningBuffer = partitionerSharedState->getPartitionBuffer(
             relInfo->partitioningIdx, relLocalState->nodeGroupIdx);
         auto startNodeOffset = StorageUtils::getStartOffsetOfNodeGroup(relLocalState->nodeGroupIdx);

--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -13,7 +13,6 @@ void LocalNodeNG::scan(ValueVector* nodeIDVector, const std::vector<column_id_t>
     KU_ASSERT(columnIDs.size() == outputVectors.size());
     for (auto i = 0u; i < columnIDs.size(); i++) {
         auto columnID = columnIDs[i];
-        KU_ASSERT(columnID < chunks.size());
         for (auto pos = 0u; pos < nodeIDVector->state->selVector->selectedSize; pos++) {
             auto nodeIDPos = nodeIDVector->state->selVector->selectedPositions[pos];
             auto nodeOffset = nodeIDVector->getValue<nodeID_t>(nodeIDPos).offset;
@@ -25,73 +24,71 @@ void LocalNodeNG::scan(ValueVector* nodeIDVector, const std::vector<column_id_t>
 
 void LocalNodeNG::lookup(
     offset_t nodeOffset, column_id_t columnID, ValueVector* outputVector, sel_t posInOutputVector) {
-    KU_ASSERT(columnID < chunks.size());
-    row_idx_t rowIdx = getRowIdx(columnID, nodeOffset - nodeGroupStartOffset);
-    if (rowIdx != INVALID_ROW_IDX) {
-        chunks[columnID]->read(rowIdx, outputVector, posInOutputVector);
-    }
-}
-
-void LocalNodeNG::insert(
-    ValueVector* nodeIDVector, const std::vector<ValueVector*>& propertyVectors) {
-    KU_ASSERT(propertyVectors.size() == chunks.size() &&
-              nodeIDVector->state->selVector->selectedSize == 1);
-    auto nodeIDPos = nodeIDVector->state->selVector->selectedPositions[0];
-    if (nodeIDVector->isNull(nodeIDPos)) {
+    if (deleteInfo.containsOffset(nodeOffset)) {
+        // Node has been deleted.
         return;
     }
-    auto nodeOffset = nodeIDVector->getValue<nodeID_t>(nodeIDPos).offset - nodeGroupStartOffset;
-    KU_ASSERT(nodeOffset < StorageConstants::NODE_GROUP_SIZE);
-    for (auto columnID = 0u; columnID < chunks.size(); columnID++) {
-        auto rowIdx = chunks[columnID]->append(propertyVectors[columnID]);
-        KU_ASSERT(!updateInfo[columnID].contains(nodeOffset));
-        insertInfo[columnID][nodeOffset] = rowIdx;
-    }
-}
-
-void LocalNodeNG::update(
-    ValueVector* nodeIDVector, column_id_t columnID, ValueVector* propertyVector) {
-    KU_ASSERT(columnID < chunks.size() && nodeIDVector->state->selVector->selectedSize == 1);
-    auto nodeIDPos = nodeIDVector->state->selVector->selectedPositions[0];
-    if (nodeIDVector->isNull(nodeIDPos)) {
+    if (insertChunks.read(nodeOffset, columnID, outputVector, posInOutputVector)) {
+        // Node has been newly inserted.
         return;
     }
-    auto nodeOffset = nodeIDVector->getValue<nodeID_t>(nodeIDPos).offset - nodeGroupStartOffset;
-    KU_ASSERT(nodeOffset < StorageConstants::NODE_GROUP_SIZE);
-    auto rowIdx = chunks[columnID]->append(propertyVector);
-    if (insertInfo[columnID].contains(nodeOffset)) {
-        // This node is in local storage, and had been newly inserted.
-        insertInfo.at(columnID)[nodeOffset] = rowIdx;
-    } else {
-        updateInfo[columnID][nodeOffset] = rowIdx;
-    }
+    updateChunks[columnID].read(nodeOffset, 0 /*columnID*/, outputVector, posInOutputVector);
 }
 
-void LocalNodeNG::delete_(ValueVector* nodeIDVector) {
+bool LocalNodeNG::insert(std::vector<common::ValueVector*> nodeIDVectors,
+    std::vector<common::ValueVector*> propertyVectors) {
+    KU_ASSERT(nodeIDVectors.size() == 1);
+    auto nodeIDVector = nodeIDVectors[0];
     KU_ASSERT(nodeIDVector->state->selVector->selectedSize == 1);
     auto nodeIDPos = nodeIDVector->state->selVector->selectedPositions[0];
     if (nodeIDVector->isNull(nodeIDPos)) {
-        return;
+        return false;
+    }
+    // The nodeOffset here should be the offset within the node group.
+    auto nodeOffset = nodeIDVector->getValue<nodeID_t>(nodeIDPos).offset - nodeGroupStartOffset;
+    KU_ASSERT(nodeOffset < StorageConstants::NODE_GROUP_SIZE);
+    insertChunks.append(nodeOffset, propertyVectors);
+    return true;
+}
+
+bool LocalNodeNG::update(std::vector<common::ValueVector*> nodeIDVectors,
+    common::column_id_t columnID, common::ValueVector* propertyVector) {
+    KU_ASSERT(nodeIDVectors.size() == 1);
+    auto nodeIDVector = nodeIDVectors[0];
+    KU_ASSERT(nodeIDVector->state->selVector->selectedSize == 1);
+    auto nodeIDPos = nodeIDVector->state->selVector->selectedPositions[0];
+    if (nodeIDVector->isNull(nodeIDPos)) {
+        return false;
+    }
+    auto nodeOffset = nodeIDVector->getValue<nodeID_t>(nodeIDPos).offset - nodeGroupStartOffset;
+    KU_ASSERT(nodeOffset < StorageConstants::NODE_GROUP_SIZE && columnID < updateChunks.size());
+    // Check if the node is newly inserted or in persistent storage.
+    if (insertChunks.hasOffset(nodeOffset)) {
+        insertChunks.update(nodeOffset, columnID, propertyVector);
+    } else {
+        updateChunks[columnID].append(nodeOffset, {propertyVector});
+    }
+    return true;
+}
+
+bool LocalNodeNG::delete_(common::ValueVector* nodeIDVector, common::ValueVector* /*extraVector*/) {
+    KU_ASSERT(nodeIDVector->state->selVector->selectedSize == 1);
+    auto nodeIDPos = nodeIDVector->state->selVector->selectedPositions[0];
+    if (nodeIDVector->isNull(nodeIDPos)) {
+        return false;
     }
     auto nodeOffset = nodeIDVector->getValue<nodeID_t>(nodeIDPos).offset - nodeGroupStartOffset;
     KU_ASSERT(nodeOffset < StorageConstants::NODE_GROUP_SIZE);
-    for (auto i = 0u; i < chunks.size(); i++) {
-        insertInfo[i].erase(nodeOffset);
-        updateInfo[i].erase(nodeOffset);
-    }
-}
-
-row_idx_t LocalNodeNG::getRowIdx(column_id_t columnID, offset_t offsetInChunk) {
-    KU_ASSERT(columnID < chunks.size());
-    if (updateInfo[columnID].contains(offsetInChunk)) {
-        // This node is in persistent storage, and had been updated.
-        return updateInfo[columnID][offsetInChunk];
-    } else if (insertInfo[columnID].contains(offsetInChunk)) {
-        // This node is in local storage, and had been newly inserted.
-        return insertInfo[columnID][offsetInChunk];
+    // Check if the node is newly inserted or in persistent storage.
+    if (insertChunks.hasOffset(nodeOffset)) {
+        insertChunks.remove(nodeOffset);
     } else {
-        return INVALID_ROW_IDX;
+        for (auto i = 0u; i < updateChunks.size(); i++) {
+            updateChunks[i].remove(nodeOffset);
+        }
+        deleteInfo.deleteOffset(nodeOffset);
     }
+    return true;
 }
 
 void LocalNodeTableData::scan(ValueVector* nodeIDVector, const std::vector<column_id_t>& columnIDs,
@@ -123,35 +120,6 @@ void LocalNodeTableData::lookup(ValueVector* nodeIDVector,
             localNodeGroup->lookup(nodeOffset, columnID, outputVector, outputVectorPos);
         }
     }
-}
-
-void LocalNodeTableData::insert(
-    ValueVector* nodeIDVector, const std::vector<ValueVector*>& propertyVectors) {
-    KU_ASSERT(nodeIDVector->state->selVector->selectedSize == 1);
-    auto localNodeGroup =
-        ku_dynamic_cast<LocalNodeGroup*, LocalNodeNG*>(getOrCreateLocalNodeGroup(nodeIDVector));
-    KU_ASSERT(localNodeGroup);
-    localNodeGroup->insert(nodeIDVector, propertyVectors);
-}
-
-void LocalNodeTableData::update(
-    ValueVector* nodeIDVector, column_id_t columnID, ValueVector* propertyVector) {
-    auto localNodeGroup =
-        ku_dynamic_cast<LocalNodeGroup*, LocalNodeNG*>(getOrCreateLocalNodeGroup(nodeIDVector));
-    KU_ASSERT(localNodeGroup);
-    localNodeGroup->update(nodeIDVector, columnID, propertyVector);
-}
-
-void LocalNodeTableData::delete_(ValueVector* nodeIDVector) {
-    auto nodeIDPos = nodeIDVector->state->selVector->selectedPositions[0];
-    auto nodeOffset = nodeIDVector->getValue<nodeID_t>(nodeIDPos).offset;
-    auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeOffset);
-    if (!nodeGroups.contains(nodeGroupIdx)) {
-        return;
-    }
-    auto localNodeGroup =
-        ku_dynamic_cast<LocalNodeGroup*, LocalNodeNG*>(nodeGroups.at(nodeGroupIdx).get());
-    localNodeGroup->delete_(nodeIDVector);
 }
 
 LocalNodeGroup* LocalNodeTableData::getOrCreateLocalNodeGroup(common::ValueVector* nodeIDVector) {

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -1,6 +1,5 @@
 #include "storage/local_storage/local_rel_table.h"
 
-#include "common/cast.h"
 #include "storage/storage_utils.h"
 
 using namespace kuzu::common;
@@ -8,181 +7,69 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-bool RelNGInfo::insert(offset_t srcOffsetInChunk, offset_t relOffset, row_idx_t adjNodeRowIdx,
-    const std::vector<row_idx_t>& propertyNodesRowIdx) {
-    KU_ASSERT(propertyNodesRowIdx.size() == insertInfoPerChunk.size());
-    if (deleteInfo.contains(srcOffsetInChunk) &&
-        contains(deleteInfo.at(srcOffsetInChunk), relOffset)) {
-        deleteInfo.at(srcOffsetInChunk).erase(relOffset);
-    }
-    if (adjInsertInfo.contains(srcOffsetInChunk)) {
-        if (multiplicity == RelMultiplicity::ONE) {
-            throw RuntimeException("Inserting multiple edges to a single node in a "
-                                   "ONE_ONE/MANY_ONE relationship is not allowed.");
-        }
-        adjInsertInfo.at(srcOffsetInChunk)[relOffset] = adjNodeRowIdx;
-    } else {
-        adjInsertInfo[srcOffsetInChunk] = {{relOffset, adjNodeRowIdx}};
-    }
-    for (auto i = 0u; i < propertyNodesRowIdx.size(); ++i) {
-        if (insertInfoPerChunk[i].contains(srcOffsetInChunk)) {
-            insertInfoPerChunk[i].at(srcOffsetInChunk)[relOffset] = propertyNodesRowIdx[i];
-        } else {
-            insertInfoPerChunk[i][srcOffsetInChunk] = {{relOffset, propertyNodesRowIdx[i]}};
-        }
-    }
-    return false;
-}
-
-void RelNGInfo::update(
-    offset_t srcOffsetInChunk, offset_t relOffset, column_id_t columnID, row_idx_t rowIdx) {
-    // REL_ID_COLUMN_ID is immutable.
-    KU_ASSERT(columnID != REL_ID_COLUMN_ID && columnID < updateInfoPerChunk.size());
-    if (deleteInfo.contains(srcOffsetInChunk) &&
-        contains(deleteInfo.at(srcOffsetInChunk), relOffset)) {
-        // We choose to ignore the update operation if the node is deleted.
-        return;
-    }
-    if (insertInfoPerChunk[columnID].contains(srcOffsetInChunk) &&
-        insertInfoPerChunk[columnID].at(srcOffsetInChunk).contains(relOffset)) {
-        // Update newly inserted value.
-        insertInfoPerChunk[columnID].at(srcOffsetInChunk)[relOffset] = rowIdx;
-    } else {
-        if (updateInfoPerChunk[columnID].contains(srcOffsetInChunk)) {
-            updateInfoPerChunk[columnID].at(srcOffsetInChunk)[relOffset] = rowIdx;
-        } else {
-            updateInfoPerChunk[columnID][srcOffsetInChunk] = {{relOffset, rowIdx}};
-        }
-    }
-}
-
-bool RelNGInfo::delete_(offset_t srcOffsetInChunk, offset_t relOffset) {
-    if (adjInsertInfo.contains(srcOffsetInChunk) &&
-        adjInsertInfo.at(srcOffsetInChunk).contains(relOffset)) {
-        // Delete newly inserted tuple.
-        adjInsertInfo.at(srcOffsetInChunk).erase(relOffset);
-        for (auto& insertInfo : insertInfoPerChunk) {
-            insertInfo.at(srcOffsetInChunk).erase(relOffset);
-        }
-    } else {
-        if (deleteInfo.contains(srcOffsetInChunk)) {
-            if (deleteInfo.at(srcOffsetInChunk).contains(relOffset)) {
-                // The node is already deleted.
-                return false;
-            } else {
-                deleteInfo.at(srcOffsetInChunk).insert(relOffset);
-            }
-        } else {
-            deleteInfo[srcOffsetInChunk] = {relOffset};
-        }
-    }
-    return true;
-}
-
-bool RelNGInfo::hasUpdates() {
-    for (auto& updateInfo : updateInfoPerChunk) {
-        if (!updateInfo.empty()) {
-            return true;
-        }
-    }
-    return false;
-}
-
-const update_insert_info_t& RelNGInfo::getEmptyInfo() {
-    static update_insert_info_t emptyInfo;
-    return emptyInfo;
-}
-
-uint64_t RelNGInfo::getNumInsertedTuples(offset_t srcOffsetInChunk) {
-    return adjInsertInfo.contains(srcOffsetInChunk) ? adjInsertInfo.at(srcOffsetInChunk).size() : 0;
-}
-
 LocalRelNG::LocalRelNG(offset_t nodeGroupStartOffset, std::vector<LogicalType*> dataTypes,
-    MemoryManager* mm, common::RelMultiplicity multiplicity)
-    : LocalNodeGroup{nodeGroupStartOffset, std::move(dataTypes), mm} {
-    relNGInfo = std::make_unique<RelNGInfo>(multiplicity, chunks.size());
-    adjChunk = std::make_unique<LocalVectorCollection>(*LogicalType::INTERNAL_ID(), mm);
-}
+    MemoryManager* mm, RelMultiplicity multiplicity)
+    : LocalNodeGroup{nodeGroupStartOffset, std::move(dataTypes), mm}, multiplicity{multiplicity} {}
 
-// TODO(Guodong): We should change the map between relID and rowIdx to a vector of pairs, which is
-// more friendly for scan.
 row_idx_t LocalRelNG::scanCSR(offset_t srcOffsetInChunk, offset_t posToReadForOffset,
     const std::vector<column_id_t>& columnIDs, const std::vector<ValueVector*>& outputVectors) {
-    KU_ASSERT(columnIDs.size() + 1 == outputVectors.size());
-    KU_ASSERT(relNGInfo->adjInsertInfo.contains(srcOffsetInChunk));
-    uint64_t posInVector = 0;
-    auto iteratorIdx = 0u;
-    for (auto& [relID, rowIdx] : relNGInfo->adjInsertInfo.at(srcOffsetInChunk)) {
-        if (iteratorIdx++ < posToReadForOffset) {
-            continue;
+    KU_ASSERT(columnIDs.size() == outputVectors.size());
+    std::vector<row_idx_t> rowIdxesToRead;
+    rowIdxesToRead.reserve(DEFAULT_VECTOR_CAPACITY);
+    auto& insertedRelOffsets = insertChunks.getRelOffsetsFromSrcOffset(srcOffsetInChunk);
+    for (auto i = posToReadForOffset; i < insertedRelOffsets.size(); i++) {
+        if (rowIdxesToRead.size() == DEFAULT_VECTOR_CAPACITY) {
+            break;
         }
-        auto posInLocalVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
-        outputVectors[0]->copyFromVectorData(
-            posInVector++, adjChunk->getLocalVector(rowIdx)->getVector(), posInLocalVector);
+        rowIdxesToRead.push_back(insertChunks.getRowIdxFromOffset(insertedRelOffsets[i]));
     }
-    for (auto i = 0u; i < columnIDs.size(); ++i) {
-        auto columnID = columnIDs[i];
-        posInVector = 0;
-        iteratorIdx = 0u;
-        auto& insertInfo = relNGInfo->insertInfoPerChunk[columnID];
-        KU_ASSERT(insertInfo.contains(srcOffsetInChunk));
-        for (auto& [relID, rowIdx] : insertInfo.at(srcOffsetInChunk)) {
-            if (iteratorIdx++ < posToReadForOffset) {
-                continue;
-            }
-            auto posInLocalVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
-            outputVectors[i + 1]->copyFromVectorData(posInVector++,
-                chunks[columnID]->getLocalVector(rowIdx)->getVector(), posInLocalVector);
+    for (auto i = 0u; i < columnIDs.size(); i++) {
+        uint64_t posInOutputVector = 0;
+        for (auto rowIdx : rowIdxesToRead) {
+            insertChunks.readValueAtRowIdx(
+                rowIdx, columnIDs[i], outputVectors[i], posInOutputVector++);
         }
     }
-    outputVectors[0]->state->selVector->resetSelectorToUnselectedWithSize(posInVector);
-    return posInVector;
+    auto numRelsRead = rowIdxesToRead.size();
+    outputVectors[0]->state->selVector->resetSelectorToUnselectedWithSize(numRelsRead);
+    return numRelsRead;
 }
 
-void LocalRelNG::applyLocalChangesForCSRColumns(offset_t srcOffsetInChunk,
+void LocalRelNG::applyLocalChangesToScannedVectors(offset_t srcOffset,
     const std::vector<column_id_t>& columnIDs, ValueVector* relIDVector,
     const std::vector<ValueVector*>& outputVectors) {
-    KU_ASSERT(columnIDs.size() + 1 == outputVectors.size());
+    KU_ASSERT(columnIDs.size() == outputVectors.size());
     // Apply updates first, as applying deletions might change selected state.
     for (auto i = 0u; i < columnIDs.size(); ++i) {
-        applyCSRUpdates(srcOffsetInChunk, columnIDs[i], relIDVector, outputVectors[i + 1]);
+        applyCSRUpdates(columnIDs[i], relIDVector, outputVectors[i]);
     }
     // Apply deletions and update selVector if necessary.
-    if (relNGInfo->deleteInfo.contains(srcOffsetInChunk) &&
-        relNGInfo->deleteInfo.at(srcOffsetInChunk).size() > 0) {
-        applyCSRDeletions(srcOffsetInChunk, relNGInfo->deleteInfo, relIDVector);
-    }
+    applyCSRDeletions(srcOffset, relIDVector);
 }
 
-void LocalRelNG::applyCSRUpdates(offset_t srcOffsetInChunk, column_id_t columnID,
-    ValueVector* relIDVector, ValueVector* outputVector) {
-    auto updateInfo = relNGInfo->updateInfoPerChunk[columnID];
-    if (!updateInfo.contains(srcOffsetInChunk) || updateInfo.at(srcOffsetInChunk).empty()) {
-        return;
-    }
-    auto& updateInfoForOffset = updateInfo.at(srcOffsetInChunk);
+void LocalRelNG::applyCSRUpdates(
+    column_id_t columnID, ValueVector* relIDVector, ValueVector* outputVector) {
+    auto& updateChunk = updateChunks[columnID];
     for (auto i = 0u; i < relIDVector->state->selVector->selectedSize; i++) {
         auto pos = relIDVector->state->selVector->selectedPositions[i];
         auto relOffset = relIDVector->getValue<relID_t>(pos).offset;
-        if (updateInfoForOffset.contains(relOffset)) {
-            auto rowIdx = updateInfoForOffset.at(relOffset);
-            auto posInLocalVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
-            outputVector->copyFromVectorData(
-                pos, chunks[columnID]->getLocalVector(rowIdx)->getVector(), posInLocalVector);
+        if (updateChunk.hasOffset(relOffset)) {
+            updateChunk.read(relOffset, 0, outputVector, pos);
         }
     }
 }
 
-void LocalRelNG::applyCSRDeletions(
-    offset_t srcOffsetInChunk, const delete_info_t& deleteInfo, ValueVector* relIDVector) {
-    auto& deleteInfoForOffset = deleteInfo.at(srcOffsetInChunk);
+void LocalRelNG::applyCSRDeletions(offset_t srcOffset, ValueVector* relIDVector) {
+    if (deleteInfo.isEmpty(srcOffset)) {
+        return;
+    }
     auto selectPos = 0u;
     auto selVector = std::make_unique<SelectionVector>(DEFAULT_VECTOR_CAPACITY);
     selVector->resetSelectorToValuePosBuffer();
     for (auto i = 0u; i < relIDVector->state->selVector->selectedSize; i++) {
         auto relIDPos = relIDVector->state->selVector->selectedPositions[i];
         auto relOffset = relIDVector->getValue<relID_t>(relIDPos).offset;
-        if (deleteInfoForOffset.contains(relOffset)) {
+        if (deleteInfo.containsOffset(relOffset)) {
             continue;
         }
         selVector->selectedPositions[selectPos++] = relIDPos;
@@ -195,49 +82,12 @@ void LocalRelNG::applyCSRDeletions(
     }
 }
 
-bool LocalRelNG::insert(ValueVector* srcNodeIDVector, ValueVector* dstNodeIDVector,
-    const std::vector<ValueVector*>& propertyVectors) {
-    KU_ASSERT(propertyVectors.size() == chunks.size() && propertyVectors.size() >= 1);
-    auto adjNodeIDRowIdx = adjChunk->append(dstNodeIDVector);
-    std::vector<row_idx_t> propertyValuesRowIdx;
-    propertyValuesRowIdx.reserve(propertyVectors.size());
-    for (auto i = 0u; i < propertyVectors.size(); ++i) {
-        propertyValuesRowIdx.push_back(chunks[i]->append(propertyVectors[i]));
-    }
-    auto srcNodeIDPos = srcNodeIDVector->state->selVector->selectedPositions[0];
-    auto srcNodeOffset =
-        srcNodeIDVector->getValue<nodeID_t>(srcNodeIDPos).offset - nodeGroupStartOffset;
-    KU_ASSERT(srcNodeOffset < StorageConstants::NODE_GROUP_SIZE);
-    auto relIDPos = propertyVectors[REL_ID_COLUMN_ID]->state->selVector->selectedPositions[0];
-    auto relOffset = propertyVectors[REL_ID_COLUMN_ID]->getValue<relID_t>(relIDPos).offset;
-    return relNGInfo->insert(srcNodeOffset, relOffset, adjNodeIDRowIdx, propertyValuesRowIdx);
-}
-
-void LocalRelNG::update(ValueVector* srcNodeIDVector, ValueVector* relIDVector,
-    column_id_t columnID, ValueVector* propertyVector) {
-    KU_ASSERT(columnID < chunks.size());
-    auto rowIdx = chunks[columnID]->append(propertyVector);
-    auto srcNodeIDPos = srcNodeIDVector->state->selVector->selectedPositions[0];
-    auto srcNodeOffset =
-        srcNodeIDVector->getValue<nodeID_t>(srcNodeIDPos).offset - nodeGroupStartOffset;
-    KU_ASSERT(srcNodeOffset < StorageConstants::NODE_GROUP_SIZE);
-    auto relIDPos = relIDVector->state->selVector->selectedPositions[0];
-    auto relOffset = relIDVector->getValue<relID_t>(relIDPos).offset;
-    relNGInfo->update(srcNodeOffset, relOffset, columnID, rowIdx);
-}
-
-bool LocalRelNG::delete_(ValueVector* srcNodeIDVector, ValueVector* relIDVector) {
-    auto srcNodeIDPos = srcNodeIDVector->state->selVector->selectedPositions[0];
-    auto srcNodeOffset =
-        srcNodeIDVector->getValue<nodeID_t>(srcNodeIDPos).offset - nodeGroupStartOffset;
-    KU_ASSERT(srcNodeOffset < StorageConstants::NODE_GROUP_SIZE);
-    auto relIDPos = relIDVector->state->selVector->selectedPositions[0];
-    auto relOffset = relIDVector->getValue<relID_t>(relIDPos).offset;
-    return relNGInfo->delete_(srcNodeOffset, relOffset);
-}
-
-bool LocalRelTableData::insert(ValueVector* srcNodeIDVector, ValueVector* dstNodeIDVector,
-    const std::vector<ValueVector*>& propertyVectors) {
+// nodeIDVectors: srcNodeIDVector, dstNodeIDVector.
+bool LocalRelNG::insert(
+    std::vector<ValueVector*> nodeIDVectors, std::vector<ValueVector*> propertyVectors) {
+    KU_ASSERT(nodeIDVectors.size() == 2);
+    auto srcNodeIDVector = nodeIDVectors[0];
+    auto dstNodeIDVector = nodeIDVectors[1];
     KU_ASSERT(srcNodeIDVector->state->selVector->selectedSize == 1 &&
               dstNodeIDVector->state->selVector->selectedSize == 1);
     auto srcNodeIDPos = srcNodeIDVector->state->selVector->selectedPositions[0];
@@ -245,38 +95,103 @@ bool LocalRelTableData::insert(ValueVector* srcNodeIDVector, ValueVector* dstNod
     if (srcNodeIDVector->isNull(srcNodeIDPos) || dstNodeIDVector->isNull(dstNodeIDPos)) {
         return false;
     }
-    auto localNodeGroup =
-        ku_dynamic_cast<LocalNodeGroup*, LocalRelNG*>(getOrCreateLocalNodeGroup(srcNodeIDVector));
-    return localNodeGroup->insert(srcNodeIDVector, dstNodeIDVector, propertyVectors);
+    auto srcNodeOffset =
+        srcNodeIDVector->getValue<nodeID_t>(srcNodeIDPos).offset - nodeGroupStartOffset;
+    KU_ASSERT(srcNodeOffset < StorageConstants::NODE_GROUP_SIZE);
+    std::vector<ValueVector*> vectorsToInsert;
+    vectorsToInsert.push_back(dstNodeIDVector);
+    for (auto i = 0u; i < propertyVectors.size(); i++) {
+        vectorsToInsert.push_back(propertyVectors[i]);
+    }
+    auto relIDPos = vectorsToInsert[LOCAL_REL_ID_COLUMN_ID]->state->selVector->selectedPositions[0];
+    auto relOffset = vectorsToInsert[LOCAL_REL_ID_COLUMN_ID]->getValue<relID_t>(relIDPos).offset;
+    insertChunks.append(srcNodeOffset, relOffset, vectorsToInsert);
+    return true;
 }
 
-void LocalRelTableData::update(ValueVector* srcNodeIDVector, ValueVector* relIDVector,
-    column_id_t columnID, ValueVector* propertyVector) {
+// IDVectors: srcNodeIDVector, relIDVector.
+bool LocalRelNG::update(
+    std::vector<ValueVector*> IDVectors, column_id_t columnID, ValueVector* propertyVector) {
+    KU_ASSERT(IDVectors.size() == 2);
+    auto srcNodeIDVector = IDVectors[0];
+    auto relIDVector = IDVectors[1];
     KU_ASSERT(srcNodeIDVector->state->selVector->selectedSize == 1 &&
               relIDVector->state->selVector->selectedSize == 1);
     auto srcNodeIDPos = srcNodeIDVector->state->selVector->selectedPositions[0];
     auto relIDPos = relIDVector->state->selVector->selectedPositions[0];
     if (srcNodeIDVector->isNull(srcNodeIDPos) || relIDVector->isNull(relIDPos)) {
-        return;
-    }
-    auto localNodeGroup =
-        ku_dynamic_cast<LocalNodeGroup*, LocalRelNG*>(getOrCreateLocalNodeGroup(srcNodeIDVector));
-    localNodeGroup->update(srcNodeIDVector, relIDVector, columnID, propertyVector);
-}
-
-bool LocalRelTableData::delete_(
-    ValueVector* srcNodeIDVector, ValueVector* dstNodeIDVector, ValueVector* relIDVector) {
-    KU_ASSERT(srcNodeIDVector->state->selVector->selectedSize == 1 &&
-              dstNodeIDVector->state->selVector->selectedSize == 1 &&
-              relIDVector->state->selVector->selectedSize == 1);
-    auto srcNodeIDPos = srcNodeIDVector->state->selVector->selectedPositions[0];
-    auto dstNodeIDPos = dstNodeIDVector->state->selVector->selectedPositions[0];
-    if (srcNodeIDVector->isNull(srcNodeIDPos) || dstNodeIDVector->isNull(dstNodeIDPos)) {
         return false;
     }
-    auto localNodeGroup =
-        ku_dynamic_cast<LocalNodeGroup*, LocalRelNG*>(getOrCreateLocalNodeGroup(srcNodeIDVector));
-    return localNodeGroup->delete_(srcNodeIDVector, relIDVector);
+    auto srcNodeOffset =
+        srcNodeIDVector->getValue<nodeID_t>(srcNodeIDPos).offset - nodeGroupStartOffset;
+    KU_ASSERT(srcNodeOffset < StorageConstants::NODE_GROUP_SIZE && columnID < updateChunks.size());
+    auto relOffset = relIDVector->getValue<relID_t>(relIDPos).offset;
+    // Check if the rel is newly inserted or in persistent storage.
+    if (insertChunks.hasOffset(relOffset)) {
+        insertChunks.update(relOffset, columnID, propertyVector);
+    } else {
+        updateChunks[columnID].append(srcNodeOffset, relOffset, {propertyVector});
+    }
+    return true;
+}
+
+bool LocalRelNG::delete_(ValueVector* srcNodeVector, ValueVector* relIDVector) {
+    KU_ASSERT(srcNodeVector->state->selVector->selectedSize == 1 &&
+              relIDVector->state->selVector->selectedSize == 1);
+    auto srcNodePos = srcNodeVector->state->selVector->selectedPositions[0];
+    auto relIDPos = relIDVector->state->selVector->selectedPositions[0];
+    if (srcNodeVector->isNull(srcNodePos) || relIDVector->isNull(relIDPos)) {
+        return false;
+    }
+    auto srcNodeOffset =
+        srcNodeVector->getValue<nodeID_t>(srcNodePos).offset - nodeGroupStartOffset;
+    auto relOffset = relIDVector->getValue<relID_t>(relIDPos).offset;
+    // If the rel is newly inserted, remove the rel from insertChunks.
+    if (insertChunks.hasOffset(relOffset)) {
+        insertChunks.remove(srcNodeOffset, relOffset);
+        return true;
+    }
+    // If the rel is updated, remove the rel from updateChunks if exists.
+    for (auto i = 0u; i < updateChunks.size(); i++) {
+        if (updateChunks[i].hasOffset(relOffset)) {
+            updateChunks[i].remove(srcNodeOffset, relOffset);
+        }
+    }
+    if (!deleteInfo.deleteOffset(relOffset)) {
+        return false;
+    }
+    deleteInfo.deleteRelAux(srcNodeOffset, relOffset);
+    return true;
+}
+
+offset_t LocalRelNG::getNumInsertedRels(offset_t srcOffset) const {
+    if (!insertChunks.hasRelOffsetsFromSrcOffset(srcOffset)) {
+        return 0;
+    }
+    return insertChunks.getNumRelsFromSrcOffset(srcOffset);
+}
+
+void LocalRelNG::getChangesPerCSRSegment(
+    std::vector<int64_t>& sizeChangesPerSegment, std::vector<bool>& hasChangesPerSegment) {
+    auto numSegments = StorageConstants::NODE_GROUP_SIZE / StorageConstants::CSR_SEGMENT_SIZE;
+    sizeChangesPerSegment.resize(numSegments, 0 /*initValue*/);
+    hasChangesPerSegment.resize(numSegments, false /*initValue*/);
+    for (auto& [srcOffset, insertions] : insertChunks.getSrcNodeOffsetToRelOffsets()) {
+        auto segmentIdx = getSegmentIdx(srcOffset);
+        sizeChangesPerSegment[segmentIdx] += insertions.size();
+        hasChangesPerSegment[segmentIdx] = true;
+    }
+    for (auto& [srcOffset, deletions] : deleteInfo.getSrcNodeOffsetToRelOffsetVec()) {
+        auto segmentIdx = getSegmentIdx(srcOffset);
+        sizeChangesPerSegment[segmentIdx] -= deletions.size();
+        hasChangesPerSegment[segmentIdx] = true;
+    }
+    for (auto& updateChunk : updateChunks) {
+        for (auto& [srcOffset, _] : updateChunk.getSrcNodeOffsetToRelOffsets()) {
+            auto segmentIdx = getSegmentIdx(srcOffset);
+            hasChangesPerSegment[segmentIdx] = true;
+        }
+    }
 }
 
 LocalNodeGroup* LocalRelTableData::getOrCreateLocalNodeGroup(ValueVector* nodeIDVector) {

--- a/src/storage/stats/property_statistics.cpp
+++ b/src/storage/stats/property_statistics.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<PropertyStatistics> PropertyStatistics::deserialize(
 bool RWPropertyStats::mayHaveNull(const transaction::Transaction& transaction) {
     // Columns internal to the storage, i.e., not mapping to a property in table schema, are not
     // tracked in statistics. For example, offset of var list column, csr offset column, etc.
-    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have a column, i.e., adjColumn,
+    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have a column, i.e., nbrIDColumn,
     // not exposed as property in table schema, but still have nullColumn. Should be fixed once we
     // properly align properties and chunks.
     if (propertyID == common::INVALID_PROPERTY_ID) {
@@ -40,7 +40,7 @@ bool RWPropertyStats::mayHaveNull(const transaction::Transaction& transaction) {
 }
 
 void RWPropertyStats::setHasNull(const transaction::Transaction& transaction) {
-    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have a column, i.e., adjColumn,
+    // TODO(Guodong): INVALID_PROPERTY_ID is used here because we have a column, i.e., nbrIDColumn,
     // not exposed as property in table schema, but still have nullColumn. Should be fixed once we
     // properly align properties and chunks.
     if (propertyID != common::INVALID_PROPERTY_ID) {

--- a/src/storage/stats/rel_table_statistics.cpp
+++ b/src/storage/stats/rel_table_statistics.cpp
@@ -22,18 +22,17 @@ RelTableStats::RelTableStats(BMFileHandle* metadataFH, const catalog::TableCatal
         LogicalType{LogicalTypeID::INT64}, *metadataFH, bufferManager, wal);
     bwdCSRLengthMetadataDAHInfo = TablesStatistics::createMetadataDAHInfo(
         LogicalType{LogicalTypeID::INT64}, *metadataFH, bufferManager, wal);
-    fwdAdjMetadataDAHInfo = TablesStatistics::createMetadataDAHInfo(
-        LogicalType{LogicalTypeID::INTERNAL_ID}, *metadataFH, bufferManager, wal);
-    bwdAdjMetadataDAHInfo = TablesStatistics::createMetadataDAHInfo(
-        LogicalType{LogicalTypeID::INTERNAL_ID}, *metadataFH, bufferManager, wal);
-    fwdPropertyMetadataDAHInfos.clear();
-    bwdPropertyMetadataDAHInfos.clear();
-    fwdPropertyMetadataDAHInfos.reserve(tableEntry.getNumProperties());
-    bwdPropertyMetadataDAHInfos.reserve(tableEntry.getNumProperties());
+    KU_ASSERT(fwdMetadataDAHInfos.empty() && bwdMetadataDAHInfos.empty());
+    fwdMetadataDAHInfos.reserve(tableEntry.getNumProperties() + 1);
+    bwdMetadataDAHInfos.reserve(tableEntry.getNumProperties() + 1);
+    fwdMetadataDAHInfos.push_back(TablesStatistics::createMetadataDAHInfo(
+        LogicalType{LogicalTypeID::INTERNAL_ID}, *metadataFH, bufferManager, wal));
+    bwdMetadataDAHInfos.push_back(TablesStatistics::createMetadataDAHInfo(
+        LogicalType{LogicalTypeID::INTERNAL_ID}, *metadataFH, bufferManager, wal));
     for (auto& property : tableEntry.getPropertiesRef()) {
-        fwdPropertyMetadataDAHInfos.push_back(TablesStatistics::createMetadataDAHInfo(
+        fwdMetadataDAHInfos.push_back(TablesStatistics::createMetadataDAHInfo(
             *property.getDataType(), *metadataFH, bufferManager, wal));
-        bwdPropertyMetadataDAHInfos.push_back(TablesStatistics::createMetadataDAHInfo(
+        bwdMetadataDAHInfos.push_back(TablesStatistics::createMetadataDAHInfo(
             *property.getDataType(), *metadataFH, bufferManager, wal));
     }
 }
@@ -48,17 +47,15 @@ RelTableStats::RelTableStats(const RelTableStats& other) : TableStatistics{other
         bwdCSROffsetMetadataDAHInfo = other.bwdCSROffsetMetadataDAHInfo->copy();
         bwdCSRLengthMetadataDAHInfo = other.bwdCSRLengthMetadataDAHInfo->copy();
     }
-    fwdAdjMetadataDAHInfo = other.fwdAdjMetadataDAHInfo->copy();
-    bwdAdjMetadataDAHInfo = other.bwdAdjMetadataDAHInfo->copy();
-    fwdPropertyMetadataDAHInfos.clear();
-    fwdPropertyMetadataDAHInfos.reserve(other.fwdPropertyMetadataDAHInfos.size());
-    for (auto& metadataDAHInfo : other.fwdPropertyMetadataDAHInfos) {
-        fwdPropertyMetadataDAHInfos.push_back(metadataDAHInfo->copy());
+    fwdMetadataDAHInfos.clear();
+    fwdMetadataDAHInfos.reserve(other.fwdMetadataDAHInfos.size());
+    for (auto& metadataDAHInfo : other.fwdMetadataDAHInfos) {
+        fwdMetadataDAHInfos.push_back(metadataDAHInfo->copy());
     }
-    bwdPropertyMetadataDAHInfos.clear();
-    bwdPropertyMetadataDAHInfos.reserve(other.bwdPropertyMetadataDAHInfos.size());
-    for (auto& metadataDAHInfo : other.bwdPropertyMetadataDAHInfos) {
-        bwdPropertyMetadataDAHInfos.push_back(metadataDAHInfo->copy());
+    bwdMetadataDAHInfos.clear();
+    bwdMetadataDAHInfos.reserve(other.bwdMetadataDAHInfos.size());
+    for (auto& metadataDAHInfo : other.bwdMetadataDAHInfos) {
+        bwdMetadataDAHInfos.push_back(metadataDAHInfo->copy());
     }
 }
 
@@ -68,10 +65,8 @@ void RelTableStats::serializeInternal(Serializer& serializer) {
     serializer.serializeOptionalValue(bwdCSROffsetMetadataDAHInfo);
     serializer.serializeOptionalValue(fwdCSRLengthMetadataDAHInfo);
     serializer.serializeOptionalValue(bwdCSRLengthMetadataDAHInfo);
-    fwdAdjMetadataDAHInfo->serialize(serializer);
-    bwdAdjMetadataDAHInfo->serialize(serializer);
-    serializer.serializeVectorOfPtrs(fwdPropertyMetadataDAHInfos);
-    serializer.serializeVectorOfPtrs(bwdPropertyMetadataDAHInfos);
+    serializer.serializeVectorOfPtrs(fwdMetadataDAHInfos);
+    serializer.serializeVectorOfPtrs(bwdMetadataDAHInfos);
 }
 
 std::unique_ptr<RelTableStats> RelTableStats::deserialize(
@@ -84,8 +79,6 @@ std::unique_ptr<RelTableStats> RelTableStats::deserialize(
     deserializer.deserializeOptionalValue(bwdCSROffsetMetadataDAHInfo);
     deserializer.deserializeOptionalValue(fwdCSRLengthMetadataDAHInfo);
     deserializer.deserializeOptionalValue(bwdCSRLengthMetadataDAHInfo);
-    auto fwdNbrIDMetadataDAHInfo = MetadataDAHInfo::deserialize(deserializer);
-    auto bwdNbrIDMetadataDAHInfo = MetadataDAHInfo::deserialize(deserializer);
     std::vector<std::unique_ptr<MetadataDAHInfo>> fwdPropertyMetadataDAHInfos;
     std::vector<std::unique_ptr<MetadataDAHInfo>> bwdPropertyMetadataDAHInfos;
     deserializer.deserializeVectorOfPtrs(fwdPropertyMetadataDAHInfos);
@@ -95,10 +88,8 @@ std::unique_ptr<RelTableStats> RelTableStats::deserialize(
     result->bwdCSROffsetMetadataDAHInfo = std::move(bwdCSROffsetMetadataDAHInfo);
     result->fwdCSRLengthMetadataDAHInfo = std::move(fwdCSRLengthMetadataDAHInfo);
     result->bwdCSRLengthMetadataDAHInfo = std::move(bwdCSRLengthMetadataDAHInfo);
-    result->fwdAdjMetadataDAHInfo = std::move(fwdNbrIDMetadataDAHInfo);
-    result->bwdAdjMetadataDAHInfo = std::move(bwdNbrIDMetadataDAHInfo);
-    result->fwdPropertyMetadataDAHInfos = std::move(fwdPropertyMetadataDAHInfos);
-    result->bwdPropertyMetadataDAHInfos = std::move(bwdPropertyMetadataDAHInfos);
+    result->fwdMetadataDAHInfos = std::move(fwdPropertyMetadataDAHInfos);
+    result->bwdMetadataDAHInfos = std::move(bwdPropertyMetadataDAHInfos);
     return result;
 }
 

--- a/src/storage/stats/rels_store_statistics.cpp
+++ b/src/storage/stats/rels_store_statistics.cpp
@@ -34,6 +34,7 @@ void RelsStoreStats::updateNumRelsByValue(table_id_t relTableID, int64_t value) 
     setToUpdated();
     auto relStatistics = (RelTableStats*)readWriteVersion->tableStatisticPerTable[relTableID].get();
     auto numRelsBeforeUpdate = relStatistics->getNumTuples();
+    (void)numRelsBeforeUpdate; // Avoid unused variable warning.
     KU_ASSERT(!(numRelsBeforeUpdate == 0 && value < 0));
     auto numRelsAfterUpdate = relStatistics->getNumTuples() + value;
     relStatistics->setNumTuples(numRelsAfterUpdate);
@@ -93,22 +94,13 @@ MetadataDAHInfo* RelsStoreStats::getCSRLengthMetadataDAHInfo(
     return tableStats->getCSRLengthMetadataDAHInfo(direction);
 }
 
-MetadataDAHInfo* RelsStoreStats::getAdjMetadataDAHInfo(
-    Transaction* transaction, table_id_t tableID, RelDataDirection direction) {
-    if (transaction->isWriteTransaction()) {
-        initTableStatisticsForWriteTrx();
-    }
-    auto tableStats = getRelStatistics(tableID, transaction);
-    return tableStats->getAdjMetadataDAHInfo(direction);
-}
-
-MetadataDAHInfo* RelsStoreStats::getPropertyMetadataDAHInfo(transaction::Transaction* transaction,
-    table_id_t tableID, column_id_t columnID, RelDataDirection direction) {
+MetadataDAHInfo* RelsStoreStats::getColumnMetadataDAHInfo(transaction::Transaction* transaction,
+    common::table_id_t tableID, common::column_id_t columnID, common::RelDataDirection direction) {
     if (transaction->isWriteTransaction()) {
         initTableStatisticsForWriteTrx();
     }
     auto relTableStats = getRelStatistics(tableID, transaction);
-    return relTableStats->getPropertyMetadataDAHInfo(columnID, direction);
+    return relTableStats->getColumnMetadataDAHInfo(columnID, direction);
 }
 
 } // namespace storage

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -37,8 +37,10 @@ static void setCommonTableIDToRdfRelTable(
     for (auto rdfEntry : rdfEntries) {
         if (rdfEntry->isParent(relTable->getTableID())) {
             std::vector<Column*> columns;
-            columns.push_back(relTable->getDirectedTableData(RelDataDirection::FWD)->getColumn(1));
-            columns.push_back(relTable->getDirectedTableData(RelDataDirection::BWD)->getColumn(1));
+            // TODO(Guodong): This is a hack. We should not use constant 2 and should move the
+            // setting logic inside RelTableData.
+            columns.push_back(relTable->getDirectedTableData(RelDataDirection::FWD)->getColumn(2));
+            columns.push_back(relTable->getDirectedTableData(RelDataDirection::BWD)->getColumn(2));
             for (auto& column : columns) {
                 ku_dynamic_cast<storage::Column*, storage::InternalIDColumn*>(column)
                     ->setCommonTableID(rdfEntry->getResourceTableID());

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -37,9 +37,6 @@ std::string StorageUtils::getColumnName(
     case StorageUtils::ColumnType::CSR_LENGTH: {
         return stringFormat("{}_csr_length", prefix);
     }
-    case StorageUtils::ColumnType::ADJ: {
-        return stringFormat("{}_adj", prefix);
-    }
     case StorageUtils::ColumnType::STRUCT_CHILD: {
         return stringFormat("{}_{}_child", propertyName, prefix);
     }

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -170,28 +170,27 @@ void StringColumn::lookupInternal(
 }
 
 bool StringColumn::canCommitInPlace(transaction::Transaction* transaction,
-    node_group_idx_t nodeGroupIdx, LocalVectorCollection* localChunk,
-    const offset_to_row_idx_t& insertInfo, const offset_to_row_idx_t& updateInfo) {
-    std::vector<row_idx_t> rowIdxesToRead;
-    for (auto& [offset, rowIdx] : updateInfo) {
-        rowIdxesToRead.push_back(rowIdx);
+    node_group_idx_t nodeGroupIdx, const LocalVectorCollection& localInsertChunk,
+    const offset_to_row_idx_t& insertInfo, const LocalVectorCollection& localUpdateChunk,
+    const offset_to_row_idx_t& updateInfo) {
+    auto strLenToAdd = 0u;
+    for (auto& [_, rowIdx] : updateInfo) {
+        auto localVector = localUpdateChunk.getLocalVector(rowIdx);
+        auto offsetInVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
+        auto kuStr = localVector->getValue<ku_string_t>(offsetInVector);
+        strLenToAdd += kuStr.len;
     }
     offset_t maxOffset = 0u;
     for (auto& [offset, rowIdx] : insertInfo) {
-        rowIdxesToRead.push_back(rowIdx);
         if (offset > maxOffset) {
             maxOffset = offset;
         }
-    }
-    std::sort(rowIdxesToRead.begin(), rowIdxesToRead.end());
-    auto strLenToAdd = 0u;
-    for (auto rowIdx : rowIdxesToRead) {
-        auto localVector = localChunk->getLocalVector(rowIdx);
+        auto localVector = localInsertChunk.getLocalVector(rowIdx);
         auto offsetInVector = rowIdx & (DEFAULT_VECTOR_CAPACITY - 1);
-        auto kuStr = localVector->getVector()->getValue<ku_string_t>(offsetInVector);
+        auto kuStr = localVector->getValue<ku_string_t>(offsetInVector);
         strLenToAdd += kuStr.len;
     }
-    auto numStrings = rowIdxesToRead.size();
+    auto numStrings = insertInfo.size() + updateInfo.size();
     if (!dictionary.canCommitInPlace(transaction, nodeGroupIdx, numStrings, strLenToAdd)) {
         return false;
     }

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -94,7 +94,7 @@ void WALReplayer::replayWALRecord(WALRecord& walRecord) {
     }
 }
 
-void WALReplayer::replayPageUpdateOrInsertRecord(const kuzu::storage::WALRecord& walRecord) {
+void WALReplayer::replayPageUpdateOrInsertRecord(const WALRecord& walRecord) {
     // 1. As the first step we copy over the page on disk, regardless of if we are recovering
     // (and checkpointing) or checkpointing while during regular execution.
     auto dbFileID = walRecord.pageInsertOrUpdateRecord.dbFileID;
@@ -119,7 +119,7 @@ void WALReplayer::replayPageUpdateOrInsertRecord(const kuzu::storage::WALRecord&
     }
 }
 
-void WALReplayer::replayTableStatisticsRecord(const kuzu::storage::WALRecord& walRecord) {
+void WALReplayer::replayTableStatisticsRecord(const WALRecord& walRecord) {
     if (isCheckpoint) {
         if (walRecord.tableStatisticsRecord.isNodeTable) {
             auto walFilePath = StorageUtils::getNodesStatisticsAndDeletedIDsFilePath(
@@ -187,7 +187,7 @@ void WALReplayer::replayRdfGraphRecord(const WALRecord& walRecord) {
     replayCreateTableRecord(literalTripleTableWALRecord);
 }
 
-void WALReplayer::replayCopyTableRecord(const kuzu::storage::WALRecord& walRecord) {
+void WALReplayer::replayCopyTableRecord(const WALRecord& walRecord) {
     auto tableID = walRecord.copyTableRecord.tableID;
     if (isCheckpoint) {
         if (!isRecovering) {
@@ -217,7 +217,7 @@ void WALReplayer::replayCopyTableRecord(const kuzu::storage::WALRecord& walRecor
     }
 }
 
-void WALReplayer::replayDropTableRecord(const kuzu::storage::WALRecord& walRecord) {
+void WALReplayer::replayDropTableRecord(const WALRecord& walRecord) {
     if (isCheckpoint) {
         auto tableID = walRecord.dropTableRecord.tableID;
         if (!isRecovering) {
@@ -266,7 +266,7 @@ void WALReplayer::replayDropTableRecord(const kuzu::storage::WALRecord& walRecor
     }
 }
 
-void WALReplayer::replayDropPropertyRecord(const kuzu::storage::WALRecord& walRecord) {
+void WALReplayer::replayDropPropertyRecord(const WALRecord& walRecord) {
     if (isCheckpoint) {
         auto tableID = walRecord.dropPropertyRecord.tableID;
         auto propertyID = walRecord.dropPropertyRecord.propertyID;
@@ -299,7 +299,7 @@ void WALReplayer::replayDropPropertyRecord(const kuzu::storage::WALRecord& walRe
     }
 }
 
-void WALReplayer::replayAddPropertyRecord(const kuzu::storage::WALRecord& walRecord) {
+void WALReplayer::replayAddPropertyRecord(const WALRecord& walRecord) {
     auto tableID = walRecord.addPropertyRecord.tableID;
     auto propertyID = walRecord.addPropertyRecord.propertyID;
     if (!isCheckpoint) {

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -198,7 +198,7 @@ Binder exception: Cannot evaluate a.fName as a literal.
 37
 -STATEMENT CALL storage_info('knows') RETURN COUNT(*)
 ---- 1
-82
+84
 -STATEMENT CALL storage_info('workAt') RETURN COUNT(*)
 ---- 1
-22
+24

--- a/test/test_files/update_node/set_tinysnb.test
+++ b/test/test_files/update_node/set_tinysnb.test
@@ -3,86 +3,86 @@
 
 --
 
-#-CASE SetNodeInt64PropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.age=20 + 50
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
-#---- 1
-#70
-#
-#-CASE SetNodeInt32PropTest
-#-STATEMENT MATCH (a:movies) WHERE a.name='Roma' SET a.length=2.2
-#---- ok
-#-STATEMENT MATCH (a:movies) WHERE a.name='Roma' RETURN a.length
-#---- 1
-#2
-#
-#-CASE SetNodeDoublePropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.eyeSight=1.0
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.eyeSight
-#---- 1
-#1.000000
-#
-#-CASE SetNodeFloatPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.height=12
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.height
-#---- 1
-#12.000000
-#
-#-CASE SetNodeBoolPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.isStudent=false
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.isStudent
-#---- 1
-#False
-#
-#-CASE SetNodeDatePropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.birthdate=date('2200-10-10')
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.birthdate
-#---- 1
-#2200-10-10
-#
-#-CASE SetNodeTimestampPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.registerTime=timestamp('2200-10-10 12:01:01')
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.registerTime
-#---- 1
-#2200-10-10 12:01:01
-#
-#-CASE SetNodeEmptyStringPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName=''
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName
-#---- 1
-#
-## end of SetNodeEmptyStringPropTest
-#
-#-CASE SetNodeShortStringPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName=string(22)
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName
-#---- 1
-#22
-#
-#-CASE SetNodeLongStringPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdefghijklmnopqrstuvwxyz'
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName
-#---- 1
-#abcdefghijklmnopqrstuvwxyz
-#
-#-CASE SetLongListTest
-#-DEFINE STRING_EXCEEDS_PAGE ARANGE 0 5990
-#-STATEMENT BEGIN TRANSACTION
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName="${STRING_EXCEEDS_PAGE}"
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName;
-#---- 1
-#${STRING_EXCEEDS_PAGE}
+-CASE SetNodeInt64PropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.age=20 + 50
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
+---- 1
+70
+
+-CASE SetNodeInt32PropTest
+-STATEMENT MATCH (a:movies) WHERE a.name='Roma' SET a.length=2.2
+---- ok
+-STATEMENT MATCH (a:movies) WHERE a.name='Roma' RETURN a.length
+---- 1
+2
+
+-CASE SetNodeDoublePropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.eyeSight=1.0
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.eyeSight
+---- 1
+1.000000
+
+-CASE SetNodeFloatPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.height=12
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.height
+---- 1
+12.000000
+
+-CASE SetNodeBoolPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.isStudent=false
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.isStudent
+---- 1
+False
+
+-CASE SetNodeDatePropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.birthdate=date('2200-10-10')
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.birthdate
+---- 1
+2200-10-10
+
+-CASE SetNodeTimestampPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.registerTime=timestamp('2200-10-10 12:01:01')
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.registerTime
+---- 1
+2200-10-10 12:01:01
+
+-CASE SetNodeEmptyStringPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName=''
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName
+---- 1
+
+# end of SetNodeEmptyStringPropTest
+
+-CASE SetNodeShortStringPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName=string(22)
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName
+---- 1
+22
+
+-CASE SetNodeLongStringPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName='abcdefghijklmnopqrstuvwxyz'
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName
+---- 1
+abcdefghijklmnopqrstuvwxyz
+
+-CASE SetLongListTest
+-DEFINE STRING_EXCEEDS_PAGE ARANGE 0 5990
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName="${STRING_EXCEEDS_PAGE}"
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.fName;
+---- 1
+${STRING_EXCEEDS_PAGE}
 
 -CASE SetVeryLongListErrorsTest
 -DEFINE STRING_EXCEEDS_MEMORY_MANAGER_LIMIT ARANGE 0 50000
@@ -95,245 +95,245 @@
 ---- hash
 1 1c6f2aee653d75dfc2361ff73d5807f7
 
-#-CASE SetNodeIntervalPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.lastJobDuration=interval('1 years 1 days')
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.lastJobDuration
-#---- 1
-#1 year 1 day
-#
-#-CASE SetNodePropNullTest
-#-STATEMENT MATCH (a:person) SET a.age=null
-#---- ok
-#-STATEMENT MATCH (a:person) RETURN a.age
-#---- 8
-#
-#
-#
-#
-#
-#
-#
-#
-## end of SetNodePropNullTest. Empty lines represent the expected null values
-#
-#-CASE SetBothUnflatTest
-#-STATEMENT MATCH (a:person) SET a.age=a.ID
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID < 4 RETURN a.ID, a.age
-#---- 3
-#0|0
-#2|2
-#3|3
-#
-#-CASE SetFlatUnFlatTest
-#-STATEMENT MATCH (a:person)-[:knows]->(b:person) WHERE a.ID=0 SET a.age=b.age
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID < 4 RETURN a.ID, a.age
-#---- 3
-#0|20
-#2|30
-#3|45
-#
-#-CASE SetUnFlatFlatTest
-#-STATEMENT MATCH (a:person)-[:knows]->(b:person) WHERE b.ID=2 AND a.ID = 0 SET b.age=a.age
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID < 4 RETURN a.ID, a.age
-#---- 3
-#0|35
-#2|35
-#3|45
-#
-#-CASE SetTwoHopTest
-#-STATEMENT MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE b.ID=0 AND c.fName = 'Bob' SET a.age=c.age
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.age
-#---- 4
-#0|35
-#2|30
-#3|30
-#5|30
-#
-#-CASE SetTwoHopNullTest
-#-STATEMENT MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) SET a.age=null
-#---- ok
-#-STATEMENT MATCH (a:person) RETURN a.ID, a.age
-#---- 8
-#0|
-#10|83
-#2|
-#3|
-#5|
-#7|20
-#8|25
-#9|40
-#
-#-CASE SetIndexNestedLoopJoinTest
-#-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = b.ID SET a.age=b.gender
-#---- ok
-#-STATEMENT MATCH (a:person) RETURN a.ID, a.age
-#---- 8
-#0|1
-#10|2
-#2|2
-#3|1
-#5|2
-#7|1
-#8|2
-#9|2
-#
-#-CASE SetRelInt16PropTest
-#-STATEMENT MATCH (a:person)-[e:studyAt]->(b:organisation) WHERE a.ID = 0 SET e.length=99
-#---- ok
-#-STATEMENT MATCH (a:person)-[e:studyAt]->(b:organisation) RETURN e.length
-#---- 3
-#22
-#55
-#99
-#
-#-CASE SetNodeListOfIntPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.workedHours=[10,20]
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.workedHours
-#---- 1
-#[10,20]
-#
-#-CASE SetNodeListOfShortStringPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['intel','microsoft']
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames
-#---- 1
-#[intel,microsoft]
-#
-#-CASE SetNodeListOfLongStringPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames
-#---- 1
-#[abcndwjbwesdsd,microsofthbbjuwgedsd]
-#
-#-CASE SetNodeListofListPropTest
-#-STATEMENT MATCH (a:person) WHERE a.ID=8 SET a.courseScoresPerTerm=[[10,20],[0,0,0]]
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=8 RETURN a.courseScoresPerTerm
-#---- 1
-#[[10,20],[0,0,0]]
-#
-#-CASE SETMultiLabelNodePropTest
-#-STATEMENT MATCH (a) WHERE a.ID < 2 SET a.age = 1;
-#---- ok
-#-STATEMENT MATCH (a) WHERE a.ID < 2 RETURN a.ID, a.age;
-#---- 2
-#0|1
-#1|
-#-STATEMENT CREATE NODE TABLE play(ID INT64, name STRING, PRIMARY KEY(ID));
-#---- ok
-#-STATEMENT CREATE (a:play {ID: 0, name: 'AA'});
-#---- ok
-#-STATEMENT MATCH (a:organisation:play) RETURN a.ID, a.name;
-#---- 4
-#0|AA
-#1|ABFsUni
-#4|CsWork
-#6|DEsWork
-#-STATEMENT MATCH (a:organisation:play) WHERE a.ID < 2 SET a.name = string(a.ID * 10);
-#---- ok
-#-STATEMENT MATCH (a:organisation:play) WHERE a.ID < 2 RETURN a.ID, a.name;
-#---- 2
-#0|0
-#1|10
-#
-#-CASE SETMultiLabelWithPruning
-#-STATEMENT MATCH (a:person)-[:knows]->(b) WHERE a.ID=0 SET b.name = "a", b.fName = "XX" RETURN b.name, b.fName;
-#---- 3
-#|XX
-#|XX
-#|XX
-#-STATEMENT MATCH (b) RETURN b.name, b.fName
-#---- 14
-#ABFsUni|
-#CsWork|
-#DEsWork|
-#Roma|
-#Sóló cón tu párejâ|
-#The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie|
-#|Alice
-#|Elizabeth
-#|Farooq
-#|Greg
-#|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
-#|XX
-#|XX
-#|XX
-#-STATEMENT MATCH (a:person)-[e:knows|:studyAt]->(b:person) WHERE a.ID=0 SET e.year = 2023, e.date = date("2023-11-11") RETURN e.year, e.date;
-#---- 3
-#|2023-11-11
-#|2023-11-11
-#|2023-11-11
-#-STATEMENT MATCH (a:person)-[e:knows|:studyAt]->(b:person:organisation) WHERE a.ID=0 RETURN e.year, e.date;
-#---- 4
-#2021|
-#|2023-11-11
-#|2023-11-11
-#|2023-11-11
-#
-#-CASE SetNonNullValueWithWriteTransaction
-#-STATEMENT BEGIN TRANSACTION
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
-#---- 1
-#35
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.age=70
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
-#---- 1
-#70
-#
-#-CASE SetNullValueWithWriteTransaction
-#-STATEMENT BEGIN TRANSACTION
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
-#---- 1
-#35
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.age=NULL
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
-#---- 1
-#
-#-CASE MultipleSetListValue
-#-STATEMENT BEGIN TRANSACTION
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=10 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=5 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=2 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=3 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
-#---- ok
-#-STATEMENT COMMIT
-#---- ok
-#-STATEMENT MATCH (a:person) WHERE a.ID=10 RETURN a.usedNames
-#---- 1
-#[abcndwjbwesdsd,microsofthbbjuwgedsd]
-#-STATEMENT MATCH (a:person) WHERE a.ID=5 RETURN a.usedNames
-#---- 1
-#[abcndwjbwesdsd,microsofthbbjuwgedsd]
-#
-#
-#-CASE OptionalSET
-#-STATEMENT OPTIONAL MATCH (a:person) WHERE a.ID > 100 SET a.fName = 'a' RETURN a.fName;
-#---- 1
-#
-#-STATEMENT MATCH (a:person) WHERE a.ID < 3 RETURN a.fName;
-#---- 2
-#Alice
-#Bob
-#-STATEMENT OPTIONAL MATCH (a) WHERE a.ID > 100 SET a.name, a.fName;
-#----1
-#
-#-STATEMENT MATCH (a)  WHERE a.ID < 3 RETURN a.name, a.fName;
-#---- 3
-#ABFsUni|
-#|Alice
-#|Bob
+-CASE SetNodeIntervalPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.lastJobDuration=interval('1 years 1 days')
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.lastJobDuration
+---- 1
+1 year 1 day
+
+-CASE SetNodePropNullTest
+-STATEMENT MATCH (a:person) SET a.age=null
+---- ok
+-STATEMENT MATCH (a:person) RETURN a.age
+---- 8
+
+
+
+
+
+
+
+
+# end of SetNodePropNullTest. Empty lines represent the expected null values
+
+-CASE SetBothUnflatTest
+-STATEMENT MATCH (a:person) SET a.age=a.ID
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID < 4 RETURN a.ID, a.age
+---- 3
+0|0
+2|2
+3|3
+
+-CASE SetFlatUnFlatTest
+-STATEMENT MATCH (a:person)-[:knows]->(b:person) WHERE a.ID=0 SET a.age=b.age
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID < 4 RETURN a.ID, a.age
+---- 3
+0|20
+2|30
+3|45
+
+-CASE SetUnFlatFlatTest
+-STATEMENT MATCH (a:person)-[:knows]->(b:person) WHERE b.ID=2 AND a.ID = 0 SET b.age=a.age
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID < 4 RETURN a.ID, a.age
+---- 3
+0|35
+2|35
+3|45
+
+-CASE SetTwoHopTest
+-STATEMENT MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) WHERE b.ID=0 AND c.fName = 'Bob' SET a.age=c.age
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.age
+---- 4
+0|35
+2|30
+3|30
+5|30
+
+-CASE SetTwoHopNullTest
+-STATEMENT MATCH (a:person)-[:knows]->(b:person)-[:knows]->(c:person) SET a.age=null
+---- ok
+-STATEMENT MATCH (a:person) RETURN a.ID, a.age
+---- 8
+0|
+10|83
+2|
+3|
+5|
+7|20
+8|25
+9|40
+
+-CASE SetIndexNestedLoopJoinTest
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = b.ID SET a.age=b.gender
+---- ok
+-STATEMENT MATCH (a:person) RETURN a.ID, a.age
+---- 8
+0|1
+10|2
+2|2
+3|1
+5|2
+7|1
+8|2
+9|2
+
+-CASE SetRelInt16PropTest
+-STATEMENT MATCH (a:person)-[e:studyAt]->(b:organisation) WHERE a.ID = 0 SET e.length=99
+---- ok
+-STATEMENT MATCH (a:person)-[e:studyAt]->(b:organisation) RETURN e.length
+---- 3
+22
+55
+99
+
+-CASE SetNodeListOfIntPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.workedHours=[10,20]
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.workedHours
+---- 1
+[10,20]
+
+-CASE SetNodeListOfShortStringPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['intel','microsoft']
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames
+---- 1
+[intel,microsoft]
+
+-CASE SetNodeListOfLongStringPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.usedNames
+---- 1
+[abcndwjbwesdsd,microsofthbbjuwgedsd]
+
+-CASE SetNodeListofListPropTest
+-STATEMENT MATCH (a:person) WHERE a.ID=8 SET a.courseScoresPerTerm=[[10,20],[0,0,0]]
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=8 RETURN a.courseScoresPerTerm
+---- 1
+[[10,20],[0,0,0]]
+
+-CASE SETMultiLabelNodePropTest
+-STATEMENT MATCH (a) WHERE a.ID < 2 SET a.age = 1;
+---- ok
+-STATEMENT MATCH (a) WHERE a.ID < 2 RETURN a.ID, a.age;
+---- 2
+0|1
+1|
+-STATEMENT CREATE NODE TABLE play(ID INT64, name STRING, PRIMARY KEY(ID));
+---- ok
+-STATEMENT CREATE (a:play {ID: 0, name: 'AA'});
+---- ok
+-STATEMENT MATCH (a:organisation:play) RETURN a.ID, a.name;
+---- 4
+0|AA
+1|ABFsUni
+4|CsWork
+6|DEsWork
+-STATEMENT MATCH (a:organisation:play) WHERE a.ID < 2 SET a.name = string(a.ID * 10);
+---- ok
+-STATEMENT MATCH (a:organisation:play) WHERE a.ID < 2 RETURN a.ID, a.name;
+---- 2
+0|0
+1|10
+
+-CASE SETMultiLabelWithPruning
+-STATEMENT MATCH (a:person)-[:knows]->(b) WHERE a.ID=0 SET b.name = "a", b.fName = "XX" RETURN b.name, b.fName;
+---- 3
+|XX
+|XX
+|XX
+-STATEMENT MATCH (b) RETURN b.name, b.fName
+---- 14
+ABFsUni|
+CsWork|
+DEsWork|
+Roma|
+Sóló cón tu párejâ|
+The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie|
+|Alice
+|Elizabeth
+|Farooq
+|Greg
+|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+|XX
+|XX
+|XX
+-STATEMENT MATCH (a:person)-[e:knows|:studyAt]->(b:person) WHERE a.ID=0 SET e.year = 2023, e.date = date("2023-11-11") RETURN e.year, e.date;
+---- 3
+|2023-11-11
+|2023-11-11
+|2023-11-11
+-STATEMENT MATCH (a:person)-[e:knows|:studyAt]->(b:person:organisation) WHERE a.ID=0 RETURN e.year, e.date;
+---- 4
+2021|
+|2023-11-11
+|2023-11-11
+|2023-11-11
+
+-CASE SetNonNullValueWithWriteTransaction
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
+---- 1
+35
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.age=70
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
+---- 1
+70
+
+-CASE SetNullValueWithWriteTransaction
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
+---- 1
+35
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.age=NULL
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age
+---- 1
+
+-CASE MultipleSetListValue
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=10 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=5 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=2 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=3 SET a.usedNames=['abcndwjbwesdsd','microsofthbbjuwgedsd']
+---- ok
+-STATEMENT COMMIT
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID=10 RETURN a.usedNames
+---- 1
+[abcndwjbwesdsd,microsofthbbjuwgedsd]
+-STATEMENT MATCH (a:person) WHERE a.ID=5 RETURN a.usedNames
+---- 1
+[abcndwjbwesdsd,microsofthbbjuwgedsd]
+
+
+-CASE OptionalSET
+-STATEMENT OPTIONAL MATCH (a:person) WHERE a.ID > 100 SET a.fName = 'a' RETURN a.fName;
+---- 1
+
+-STATEMENT MATCH (a:person) WHERE a.ID < 3 RETURN a.fName;
+---- 2
+Alice
+Bob
+-STATEMENT OPTIONAL MATCH (a) WHERE a.ID > 100 SET a.name, a.fName;
+----1
+
+-STATEMENT MATCH (a)  WHERE a.ID < 3 RETURN a.name, a.fName;
+---- 3
+ABFsUni|
+|Alice
+|Bob

--- a/test/test_files/update_rel/create_empty.test
+++ b/test/test_files/update_rel/create_empty.test
@@ -182,6 +182,9 @@
 ---- ok
 -STATEMENT MATCH (n1:N1), (n2:N2) WHERE n1.ID=10 AND n2.ID=12 CREATE (n1)-[r:Rel1]->(n2)
 ---- ok
+-STATEMENT MATCH (n1:N1)-[r:Rel1]->(n2:N2) WHERE n1.ID=10 AND n2.ID=12 RETURN r
+---- 1
+(0:0)-{_LABEL: Rel1, _ID: 0:0}->(1:0)
 -STATEMENT MATCH (n1:N1)-[r:Rel1]->(n2:N2) WHERE n1.ID=10 AND n2.ID=12 DELETE r
 ---- ok
 -STATEMENT MATCH (n:N1)-[r:Rel1]->(m:N2) RETURN n.ID, m.ID


### PR DESCRIPTION
In the middle of reworking local storage. This PR is mainly separating the storage of insertions and updates in local storage.
```cpp
    LocalDataChunkCollection insertChunks;
    LocalDeletionInfo deleteInfo;
    std::vector<LocalDataChunkCollection> updateChunks;
```
Note that the following PR will replace the use of DataChunk with a vector of ColumnChunks.

This PR is becoming a bit messy as I did some other refactoring alongside:
- unify nbrID column with property columns in RelTableData.
- clean up unnecessary `unique_ptr` use of `LogicalType` and `DataChunk`.

NOTE: This PR breaks storage compatibility as it changes the layout of statistics. 