### PR TITLE
More efficient ColumnChunk string dictionary caching

### DIFF
--- a/src/include/storage/store/dictionary_chunk.h
+++ b/src/include/storage/store/dictionary_chunk.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "common/string_utils.h"
 #include "storage/store/column_chunk.h"
 
 namespace kuzu {
@@ -32,9 +31,38 @@ private:
     // of characters stored.
     std::unique_ptr<ColumnChunk> stringDataChunk;
     std::unique_ptr<ColumnChunk> offsetChunk;
-    std::unordered_map<std::string, string_index_t, common::StringUtils::string_hash,
-        std::equal_to<>>
-        indexTable;
+
+    struct DictionaryEntry {
+        string_index_t index;
+
+        std::string_view get(const DictionaryChunk& dict) const { return dict.getString(index); }
+    };
+
+    struct StringOps {
+        explicit StringOps(const DictionaryChunk* dict) : dict(dict) {}
+        const DictionaryChunk* dict;
+        using hash_type = std::hash<std::string_view>;
+        using is_transparent = void;
+
+        std::size_t operator()(const DictionaryEntry& entry) const {
+            return std::hash<std::string_view>()(entry.get(*dict));
+        }
+        std::size_t operator()(const char* str) const { return hash_type{}(str); }
+        std::size_t operator()(std::string_view str) const { return hash_type{}(str); }
+        std::size_t operator()(std::string const& str) const { return hash_type{}(str); }
+
+        bool operator()(const DictionaryEntry& lhs, const DictionaryEntry& rhs) const {
+            return lhs.get(*dict) == rhs.get(*dict);
+        }
+        bool operator()(const DictionaryEntry& lhs, std::string_view rhs) const {
+            return lhs.get(*dict) == rhs;
+        }
+        bool operator()(std::string_view lhs, const DictionaryEntry& rhs) const {
+            return lhs == rhs.get(*dict);
+        }
+    };
+
+    std::unordered_set<DictionaryEntry, StringOps /*hash*/, StringOps /*equals*/> indexTable;
 };
 } // namespace storage
 } // namespace kuzu


### PR DESCRIPTION
Something from #2979 when I was testing in-memory compression, as the original implementation of the DictionaryChunk's index performed poorly on that dataset (largely due to the size and number of the chunks in the partitioner magnifying the overhead of the dictionary's cache).

This changes the storage of the DictionaryChunk's indexTable to store just the index and use custom comparison and hashing functions instead of storing a second copy of the string. In addition to removing one extra copy of the string data, it reduces the memory overhead of the cache from 32 bytes per entry (`sizeof(std::string)`, though this may also include the string data for short strings, so this change won't necessarily reduce memory by `>=28` bytes per string in the dictionary) to just 4 bytes per entry (plus whatever overhead is required for `std::unordered_set`, but that hasn't really changed).

I did a few benchmarks, and when copying 60000000 strings with random numbers, performance improved from ~25s to ~16s for long strings (~20 characters long), and 12s to 10s for short strings (both should have no duplication, so this tests the worst case where all entries get added to the dictionary; the table has one string column with a serial primary key).