### PR TITLE
Insert into the hash index builder one chunk at a time

### DIFF
--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -80,7 +80,7 @@ public:
             return common::PhysicalTypeID::INT128;
         } else if constexpr (std::is_same_v<T, interval_t>) {
             return common::PhysicalTypeID::INTERVAL;
-        } else if constexpr (std::is_same_v<T, ku_string_t>) {
+        } else if constexpr (std::same_as<T, ku_string_t> || std::same_as<T, std::string>) {
             return common::PhysicalTypeID::STRING;
         } else {
             KU_UNREACHABLE;

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -85,7 +85,7 @@ template<typename T>
 concept IndexHashable = ((std::integral<T> && !std::is_same_v<T, bool>) || std::floating_point<T> ||
                          std::is_same_v<T, common::int128_t> ||
                          std::is_same_v<T, common::ku_string_t> ||
-                         std::is_same_v<T, std::string_view>);
+                         std::is_same_v<T, std::string_view> || std::same_as<T, std::string>);
 
 enum class KUZU_API LogicalTypeID : uint8_t {
     ANY = 0,

--- a/src/include/processor/operator/persistent/index_builder.h
+++ b/src/include/processor/operator/persistent/index_builder.h
@@ -16,9 +16,6 @@
 namespace kuzu {
 namespace processor {
 
-constexpr size_t BUFFER_SIZE = 1024;
-template<typename T>
-using Buffer = common::StaticVector<std::pair<T, common::offset_t>, BUFFER_SIZE>;
 const size_t SHOULD_FLUSH_QUEUE_SIZE = 32;
 
 class IndexBuilderGlobalQueues {
@@ -28,7 +25,7 @@ public:
     void flushToDisk() const;
 
     template<typename T>
-    void insert(size_t index, Buffer<T> elem) {
+    void insert(size_t index, storage::IndexBuffer<T> elem) {
         auto& typedQueues = std::get<Queue<T>>(queues).array;
         typedQueues[index].push(std::move(elem));
         if (typedQueues[index].approxSize() < SHOULD_FLUSH_QUEUE_SIZE) {
@@ -49,7 +46,7 @@ private:
 
     template<typename T>
     struct Queue {
-        std::array<common::MPSCQueue<Buffer<T>>, storage::NUM_HASH_INDEXES> array;
+        std::array<common::MPSCQueue<storage::IndexBuffer<T>>, storage::NUM_HASH_INDEXES> array;
         // Type information to help std::visit. Value is not used
         T type;
     };
@@ -92,7 +89,7 @@ private:
 
     // These arrays are much too large to be inline.
     template<typename T>
-    using Buffers = std::array<Buffer<T>, storage::NUM_HASH_INDEXES>;
+    using Buffers = std::array<storage::IndexBuffer<T>, storage::NUM_HASH_INDEXES>;
     template<typename T>
     using UniqueBuffers = std::unique_ptr<Buffers<T>>;
     std::variant<UniqueBuffers<std::string>, UniqueBuffers<int64_t>, UniqueBuffers<int32_t>,


### PR DESCRIPTION
First part of #2938.

There is a small performance improvement, though it's obscured somewhat by the amount of variance I was seeing between runs. It was roughly 100ms improvement (copying a table with just 60 million integer primary keys, went from ~2.3 to ~2.2 seconds).

This replaces the one at a time append in `HashIndexBuilder` with an append function that takes a StaticVector (since that's what's used in the IndexBuilder's queues). Resizing the index and calculating the hashes is done on the 1024 values in the StaticVector all at once, before each value is inserted one by one.
I also removed the second type from the HashIndexBuilder since the StaticVector stores a `std::string` and it makes more sense to just hardcode places which take a `std::string`/`std::string_view` using `std::conditional` than to add more template parameters (and there is only really one variable parameter anyway).