### PR TITLE
Avoid moving DictionaryChunks

### DIFF
--- a/src/include/storage/store/dictionary_chunk.h
+++ b/src/include/storage/store/dictionary_chunk.h
@@ -11,6 +11,9 @@ public:
     using string_index_t = uint32_t;
 
     DictionaryChunk(uint64_t capacity, bool enableCompression);
+    // A pointer to the dictionary chunk is stored in the StringOps for the indexTable
+    // and can't be modified easily. Moving would invalidate that pointer
+    DictionaryChunk(DictionaryChunk&& other) = delete;
 
     void resetToEmpty();
 

--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -31,11 +31,11 @@ public:
 
     uint64_t getStringLength(common::offset_t pos) const {
         auto index = ColumnChunk::getValue<DictionaryChunk::string_index_t>(pos);
-        return dictionaryChunk.getStringLength(index);
+        return dictionaryChunk->getStringLength(index);
     }
 
-    inline DictionaryChunk& getDictionaryChunk() { return dictionaryChunk; }
-    inline const DictionaryChunk& getDictionaryChunk() const { return dictionaryChunk; }
+    inline DictionaryChunk& getDictionaryChunk() { return *dictionaryChunk; }
+    inline const DictionaryChunk& getDictionaryChunk() const { return *dictionaryChunk; }
 
     void finalize() final;
 
@@ -46,7 +46,7 @@ private:
     void setValueFromString(const char* value, uint64_t length, uint64_t pos);
 
 private:
-    DictionaryChunk dictionaryChunk;
+    std::unique_ptr<DictionaryChunk> dictionaryChunk;
     // If we never update a value, we don't need to prune unused strings in finalize
     bool needFinalize;
 };


### PR DESCRIPTION
There was a regression in #2994 which wasn't caught by our test suite. On some datasets it was causing a segfault when copying rel tables.

`DictionaryChunk` now stores pointers in its internal cache which would be invalidated when moving and can't be easily updated (which is understandable, changing the hash function and equals functions in an unordered_set usually would be expected to break things, even if in this case it would be safe).