### PR TITLE
Support use of `QueryResult` as a context manager, and add a `get_schema` method

### DIFF
--- a/tools/python_api/test/test_get_header.py
+++ b/tools/python_api/test/test_get_header.py
@@ -1,26 +1,46 @@
 def test_get_column_names(establish_connection):
     conn, db = establish_connection
-    result = conn.execute("MATCH (a:person)-[e:knows]->(b:person) RETURN a.fName, e.date, b.ID;")
-    column_names = result.get_column_names()
-    assert column_names[0] == 'a.fName'
-    assert column_names[1] == 'e.date'
-    assert column_names[2] == 'b.ID'
-    result.close()
+    with conn.execute(
+        "MATCH (a:person)-[e:knows]->(b:person) RETURN a.fName, e.date, b.ID;"
+    ) as result:
+        column_names = result.get_column_names()
+        assert column_names[0] == 'a.fName'
+        assert column_names[1] == 'e.date'
+        assert column_names[2] == 'b.ID'
 
 
 def test_get_column_data_types(establish_connection):
     conn, db = establish_connection
-    result = conn.execute(
+    with conn.execute(
         "MATCH (p:person) RETURN p.ID, p.fName, p.isStudent, p.eyeSight, p.birthdate, p.registerTime, "
-        "p.lastJobDuration, p.workedHours, p.courseScoresPerTerm;")
-    column_data_types = result.get_column_data_types()
-    assert column_data_types[0] == 'INT64'
-    assert column_data_types[1] == 'STRING'
-    assert column_data_types[2] == 'BOOL'
-    assert column_data_types[3] == 'DOUBLE'
-    assert column_data_types[4] == 'DATE'
-    assert column_data_types[5] == 'TIMESTAMP'
-    assert column_data_types[6] == 'INTERVAL'
-    assert column_data_types[7] == 'INT64[]'
-    assert column_data_types[8] == 'INT64[][]'
-    result.close()
+        "p.lastJobDuration, p.workedHours, p.courseScoresPerTerm;"
+    ) as result:
+        column_data_types = result.get_column_data_types()
+        assert column_data_types[0] == 'INT64'
+        assert column_data_types[1] == 'STRING'
+        assert column_data_types[2] == 'BOOL'
+        assert column_data_types[3] == 'DOUBLE'
+        assert column_data_types[4] == 'DATE'
+        assert column_data_types[5] == 'TIMESTAMP'
+        assert column_data_types[6] == 'INTERVAL'
+        assert column_data_types[7] == 'INT64[]'
+        assert column_data_types[8] == 'INT64[][]'
+
+
+def test_get_schema(establish_connection):
+    conn, db = establish_connection
+    with conn.execute(
+        "MATCH (p:person) RETURN p.ID, p.fName, p.isStudent, p.eyeSight, p.birthdate, p.registerTime, "
+        "p.lastJobDuration, p.workedHours, p.courseScoresPerTerm;"
+    ) as result:
+        assert result.get_schema() == {
+            'p.ID': 'INT64',
+            'p.fName': 'STRING',
+            'p.isStudent': 'BOOL',
+            'p.eyeSight': 'DOUBLE',
+            'p.birthdate': 'DATE',
+            'p.registerTime': 'TIMESTAMP',
+            'p.lastJobDuration': 'INTERVAL',
+            'p.workedHours': 'INT64[]',
+            'p.courseScoresPerTerm': 'INT64[][]'
+        }

--- a/tools/python_api/test/test_query_result.py
+++ b/tools/python_api/test/test_query_result.py
@@ -24,3 +24,13 @@ def test_explain(establish_connection):
     result = conn.execute("EXPLAIN MATCH (a:person) WHERE a.ID = 0 RETURN a")
     assert result.get_num_tuples() == 1
     result.close()
+
+def test_context_manager(establish_connection):
+    conn, db = establish_connection
+    with conn.execute("MATCH (a:person) WHERE a.ID = 0 RETURN a") as result:
+        assert result.get_num_tuples() == 1
+        assert result.get_compiling_time() > 0
+
+    # context exit guarantees immediately 'close' of the underlying QueryResult
+    # (don't have to wait for __del__, which may not ever actually get called)
+    assert result.is_closed


### PR DESCRIPTION
Currently `close()` is called on `QueryResult` either manually or via `__del__` (which is not deterministic as it relies on GC being triggered and may _never_ actually be called).

A cleaner pattern is to use context manager syntax; this both guarantees immediate connection close on scope exit, and gracefully handles the case where an error is raised before the connection is manually closed.

**Note:** this syntax is optional. If you don't use it, you get the existing behaviour (it's a non-breaking addition).

# Example

### Manual:

Requires a potentially fallible call to `close()`.
```python
res = conn.execute("MATCH (a:person) WHERE a.ID = 0 RETURN a")
df = res.get_as_pl()  # <-- if this raises "close" will NOT be called
res.close()
```
### Context manager:

Scope exit guarantees that `close()` will be called successfully.
```python
with conn.execute("MATCH (a:person) WHERE a.ID = 0 RETURN a") as res:
    df = res.get_as_pl()  # <-- if this raises "close" WILL still be called
````

# Also

* Added a handy `get_schema()` method (combines `get_column_names()` and `get_column_data_types()` as a dict).
* Made the chunk_size used by `get_as_pl()` adaptive, minimising the chance that Polars needs to rechunk the result.
* Added test coverage for all of the above updates.
* Added some "See Also" docstring sections.

# CLA

I have read and agree to the terms under `CLA.md` 👌