### PR TITLE
Pass client context to binder

### DIFF
--- a/src/binder/bind/bind_comment_on.cpp
+++ b/src/binder/bind/bind_comment_on.cpp
@@ -12,7 +12,7 @@ std::unique_ptr<BoundStatement> Binder::bindCommentOn(const parser::Statement& s
     auto tableName = commentOn.getTable();
     auto comment = commentOn.getComment();
     validateTableExist(tableName);
-    auto tableID = catalog.getTableID(clientContext->getTx(), tableName);
+    auto tableID = clientContext->getCatalog()->getTableID(clientContext->getTx(), tableName);
     return std::make_unique<BoundCommentOn>(tableID, tableName, comment);
 }
 

--- a/src/binder/bind/bind_copy.cpp
+++ b/src/binder/bind/bind_copy.cpp
@@ -70,8 +70,9 @@ std::unique_ptr<BoundStatement> Binder::bindCopyFromClause(const Statement& stat
     auto tableName = copyStatement.getTableName();
     validateTableExist(tableName);
     // Bind to table schema.
-    auto tableID = catalog.getTableID(clientContext->getTx(), tableName);
-    auto tableEntry = catalog.getTableCatalogEntry(clientContext->getTx(), tableID);
+    auto catalog = clientContext->getCatalog();
+    auto tableID = catalog->getTableID(clientContext->getTx(), tableName);
+    auto tableEntry = catalog->getTableCatalogEntry(clientContext->getTx(), tableID);
     switch (tableEntry->getTableType()) {
     case TableType::REL_GROUP: {
         throw BinderException(stringFormat("Cannot copy into {} table with type {}.", tableName,
@@ -154,10 +155,11 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRelFrom(const parser::Statement&
         std::make_unique<BoundFileScanInfo>(func, std::move(bindData), columns, offset);
     auto srcTableID = relTableEntry->getSrcTableID();
     auto dstTableID = relTableEntry->getDstTableID();
+    auto catalog = clientContext->getCatalog();
     auto srcSchema = ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(
-        catalog.getTableCatalogEntry(clientContext->getTx(), srcTableID));
+        catalog->getTableCatalogEntry(clientContext->getTx(), srcTableID));
     auto dstSchema = ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(
-        catalog.getTableCatalogEntry(clientContext->getTx(), dstTableID));
+        catalog->getTableCatalogEntry(clientContext->getTx(), dstTableID));
     auto srcKey = columns[0];
     auto dstKey = columns[1];
     expression_vector propertyColumns;
@@ -240,10 +242,11 @@ void Binder::bindExpectedRelColumns(RelTableCatalogEntry* relTableEntry,
     const std::vector<std::string>& inputColumnNames, std::vector<std::string>& columnNames,
     std::vector<common::LogicalType>& columnTypes) {
     KU_ASSERT(columnNames.empty() && columnTypes.empty());
+    auto catalog = clientContext->getCatalog();
     auto srcTable = ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(
-        catalog.getTableCatalogEntry(clientContext->getTx(), relTableEntry->getSrcTableID()));
+        catalog->getTableCatalogEntry(clientContext->getTx(), relTableEntry->getSrcTableID()));
     auto dstTable = ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(
-        catalog.getTableCatalogEntry(clientContext->getTx(), relTableEntry->getDstTableID()));
+        catalog->getTableCatalogEntry(clientContext->getTx(), relTableEntry->getDstTableID()));
     columnNames.push_back("from");
     columnNames.push_back("to");
     auto srcPKColumnType = *srcTable->getPrimaryKey()->getDataType();

--- a/src/binder/bind/bind_create_macro.cpp
+++ b/src/binder/bind/bind_create_macro.cpp
@@ -16,7 +16,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateMacro(const Statement& stateme
     auto& createMacro = ku_dynamic_cast<const Statement&, const CreateMacro&>(statement);
     auto macroName = createMacro.getMacroName();
     StringUtils::toUpper(macroName);
-    if (catalog.containsMacro(clientContext->getTx(), macroName)) {
+    if (clientContext->getCatalog()->containsMacro(clientContext->getTx(), macroName)) {
         throw BinderException{stringFormat("Macro {} already exists.", macroName)};
     }
     parser::default_macro_args defaultArgs;

--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -18,7 +18,7 @@ namespace binder {
  */
 FileType Binder::bindFileType(const std::string& filePath) {
     std::filesystem::path fileName(filePath);
-    auto extension = vfs->getFileExtension(fileName);
+    auto extension = clientContext->getVFSUnsafe()->getFileExtension(fileName);
     auto fileType = FileTypeUtils::getFileTypeFromExtension(extension);
     return fileType;
 }
@@ -38,7 +38,7 @@ FileType Binder::bindFileType(const std::vector<std::string>& filePaths) {
 std::vector<std::string> Binder::bindFilePaths(const std::vector<std::string>& filePaths) {
     std::vector<std::string> boundFilePaths;
     for (auto& filePath : filePaths) {
-        auto globbedFilePaths = vfs->glob(clientContext, filePath);
+        auto globbedFilePaths = clientContext->getVFSUnsafe()->glob(clientContext, filePath);
         if (globbedFilePaths.empty()) {
             throw BinderException{
                 stringFormat("No file found that matches the pattern: {}.", filePath)};

--- a/src/binder/bind/bind_import_database.cpp
+++ b/src/binder/bind/bind_import_database.cpp
@@ -1,6 +1,9 @@
+#include <fcntl.h>
+
 #include "binder/binder.h"
 #include "binder/copy/bound_import_database.h"
 #include "common/exception/binder.h"
+#include "common/file_system/virtual_file_system.h"
 #include "parser/port_db.h"
 
 using namespace kuzu::common;
@@ -29,13 +32,14 @@ std::string getFilePath(
 std::unique_ptr<BoundStatement> Binder::bindImportDatabaseClause(const Statement& statement) {
     auto& importDatabaseStatement = ku_dynamic_cast<const Statement&, const ImportDB&>(statement);
     auto boundFilePath = importDatabaseStatement.getFilePath();
-    if (!vfs->fileOrPathExists(boundFilePath)) {
+    auto fs = clientContext->getVFSUnsafe();
+    if (!fs->fileOrPathExists(boundFilePath)) {
         throw BinderException(stringFormat("Directory {} does not exist.", boundFilePath));
     }
     std::string finalQueryStatements;
-    finalQueryStatements += getFilePath(vfs, boundFilePath, ImportDBConstants::SCHEMA_NAME);
-    finalQueryStatements += getFilePath(vfs, boundFilePath, ImportDBConstants::COPY_NAME);
-    finalQueryStatements += getFilePath(vfs, boundFilePath, ImportDBConstants::MACRO_NAME);
+    finalQueryStatements += getFilePath(fs, boundFilePath, ImportDBConstants::SCHEMA_NAME);
+    finalQueryStatements += getFilePath(fs, boundFilePath, ImportDBConstants::COPY_NAME);
+    finalQueryStatements += getFilePath(fs, boundFilePath, ImportDBConstants::MACRO_NAME);
     return std::make_unique<BoundImportDatabase>(boundFilePath, finalQueryStatements);
 }
 } // namespace binder

--- a/src/binder/bind/bind_reading_clause.cpp
+++ b/src/binder/bind/bind_reading_clause.cpp
@@ -126,8 +126,9 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     for (auto& val : inputValues) {
         inputTypes.push_back(*val.getDataType());
     }
+    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
     auto func = BuiltInFunctionsUtils::matchFunction(
-        functionExpr->getFunctionName(), inputTypes, catalog.getFunctions(clientContext->getTx()));
+        functionExpr->getFunctionName(), inputTypes, functions);
     auto tableFunc = ku_dynamic_cast<function::Function*, function::TableFunction*>(func);
     auto bindInput = std::make_unique<function::TableFuncBindInput>();
     bindInput->inputs = std::move(inputValues);
@@ -156,9 +157,9 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& re
         auto objectExpr = expressionBinder.bindVariableExpression(objectName);
         auto literalExpr =
             ku_dynamic_cast<const Expression*, const LiteralExpression*>(objectExpr.get());
-        auto func = BuiltInFunctionsUtils::matchFunction(READ_PANDAS_FUNC_NAME,
-            std::vector<LogicalType>{objectExpr->getDataType()},
-            catalog.getFunctions(clientContext->getTx()));
+        auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
+        auto func = BuiltInFunctionsUtils::matchFunction(
+            READ_PANDAS_FUNC_NAME, std::vector<LogicalType>{objectExpr->getDataType()}, functions);
         scanFunction = ku_dynamic_cast<Function*, TableFunction*>(func);
         bindInput = std::make_unique<function::TableFuncBindInput>();
         bindInput->inputs.push_back(*literalExpr->getValue());

--- a/src/binder/bind/bind_standalone_call.cpp
+++ b/src/binder/bind/bind_standalone_call.cpp
@@ -15,7 +15,8 @@ std::unique_ptr<BoundStatement> Binder::bindStandaloneCall(const parser::Stateme
         ku_dynamic_cast<const parser::Statement&, const parser::StandaloneCall&>(statement);
     main::Option* option = main::DBConfig::getOptionByName(callStatement.getOptionName());
     if (option == nullptr) {
-        option = extensionOptions->getExtensionOption(callStatement.getOptionName());
+        option =
+            clientContext->getExtensionOptions()->getExtensionOption(callStatement.getOptionName());
     }
     if (option == nullptr) {
         throw BinderException{"Invalid option name: " + callStatement.getOptionName() + "."};

--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -18,7 +18,8 @@ namespace binder {
 
 std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const parser::Statement&,
     std::unique_ptr<ReaderConfig> config, RDFGraphCatalogEntry* rdfGraphEntry) {
-    auto functions = catalog.getFunctions(clientContext->getTx());
+    auto catalog = clientContext->getCatalog();
+    auto functions = catalog->getFunctions(clientContext->getTx());
     auto offset = expressionBinder.createVariableExpression(
         *LogicalType::INT64(), InternalKeyword::ROW_OFFSET);
     auto r = expressionBinder.createVariableExpression(*LogicalType::STRING(), rdf::IRI);
@@ -50,7 +51,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const parser::Statement&
     auto rScanInfo = std::make_unique<BoundFileScanInfo>(
         rScanFunc, bindData->copy(), std::move(rColumns), offset);
     auto rTableID = rdfGraphEntry->getResourceTableID();
-    auto rSchema = catalog.getTableCatalogEntry(clientContext->getTx(), rTableID);
+    auto rSchema = catalog->getTableCatalogEntry(clientContext->getTx(), rTableID);
     auto rCopyInfo = BoundCopyFromInfo(rSchema, std::move(rScanInfo), false, nullptr);
     // Bind copy literal.
     func = inMemory ?
@@ -61,7 +62,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const parser::Statement&
     auto lScanInfo = std::make_unique<BoundFileScanInfo>(
         lScanFunc, bindData->copy(), std::move(lColumns), offset);
     auto lTableID = rdfGraphEntry->getLiteralTableID();
-    auto lSchema = catalog.getTableCatalogEntry(clientContext->getTx(), lTableID);
+    auto lSchema = catalog->getTableCatalogEntry(clientContext->getTx(), lTableID);
     auto lCopyInfo = BoundCopyFromInfo(lSchema, std::move(lScanInfo), true, nullptr);
     // Bind copy resource triples
     func = inMemory ?
@@ -73,7 +74,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const parser::Statement&
     auto rrrScanInfo =
         std::make_unique<BoundFileScanInfo>(rrrScanFunc, bindData->copy(), rrrColumns, offset);
     auto rrrTableID = rdfGraphEntry->getResourceTripleTableID();
-    auto rrrSchema = catalog.getTableCatalogEntry(clientContext->getTx(), rrrTableID);
+    auto rrrSchema = catalog->getTableCatalogEntry(clientContext->getTx(), rrrTableID);
     auto rrrExtraInfo = std::make_unique<ExtraBoundCopyRelInfo>();
     auto sLookUp = IndexLookupInfo(rTableID, sOffset, s, s->getDataType());
     auto pLookUp = IndexLookupInfo(rTableID, pOffset, p, p->getDataType());
@@ -95,7 +96,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const parser::Statement&
     auto rrlScanInfo =
         std::make_unique<BoundFileScanInfo>(rrlScanFunc, bindData->copy(), rrlColumns, offset);
     auto rrlTableID = rdfGraphEntry->getLiteralTripleTableID();
-    auto rrlSchema = catalog.getTableCatalogEntry(clientContext->getTx(), rrlTableID);
+    auto rrlSchema = catalog->getTableCatalogEntry(clientContext->getTx(), rrlTableID);
     auto rrlExtraInfo = std::make_unique<ExtraBoundCopyRelInfo>();
     rrlExtraInfo->infos.push_back(sLookUp.copy());
     rrlExtraInfo->infos.push_back(pLookUp.copy());

--- a/src/binder/bind_expression/bind_comparison_expression.cpp
+++ b/src/binder/bind_expression/bind_comparison_expression.cpp
@@ -21,15 +21,14 @@ std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::bindComparisonExpression(
     ExpressionType expressionType, const expression_vector& children) {
-    auto builtInFunctions = binder->catalog.getFunctions(binder->clientContext->getTx());
+    auto functions = context->getCatalog()->getFunctions(binder->clientContext->getTx());
     auto functionName = expressionTypeToString(expressionType);
     std::vector<LogicalType> childrenTypes;
     for (auto& child : children) {
         childrenTypes.push_back(child->dataType);
     }
     auto function = ku_dynamic_cast<function::Function*, function::ScalarFunction*>(
-        function::BuiltInFunctionsUtils::matchFunction(
-            functionName, childrenTypes, builtInFunctions));
+        function::BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, functions));
     expression_vector childrenAfterCast;
     for (auto i = 0u; i < children.size(); ++i) {
         childrenAfterCast.push_back(

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -27,7 +27,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindFunctionExpression(
         return result;
     }
     auto functionType =
-        binder->catalog.getFunctionType(binder->clientContext->getTx(), functionName);
+        context->getCatalog()->getFunctionType(binder->clientContext->getTx(), functionName);
     switch (functionType) {
     case ExpressionType::FUNCTION:
         return bindScalarFunctionExpression(parsedExpression, functionName);
@@ -57,9 +57,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     for (auto& child : children) {
         childrenTypes.push_back(child->dataType);
     }
+    auto functions = context->getCatalog()->getFunctions(context->getTx());
     auto function = ku_dynamic_cast<function::Function*, function::ScalarFunction*>(
-        function::BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes,
-            binder->catalog.getFunctions(binder->clientContext->getTx())));
+        function::BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, functions));
     expression_vector childrenAfterCast;
     std::unique_ptr<function::FunctionBindData> bindData;
     if (functionName == CAST_FUNC_NAME) {
@@ -110,8 +110,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
         childrenTypes.push_back(child->dataType);
         children.push_back(std::move(child));
     }
-    auto function = function::BuiltInFunctionsUtils::matchAggregateFunction(functionName,
-        childrenTypes, isDistinct, binder->catalog.getFunctions(binder->clientContext->getTx()))
+    auto functions = context->getCatalog()->getFunctions(context->getTx());
+    auto function = function::BuiltInFunctionsUtils::matchAggregateFunction(
+        functionName, childrenTypes, isDistinct, functions)
                         ->clone();
     if (function->paramRewriteFunc) {
         function->paramRewriteFunc(children);
@@ -134,7 +135,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::bindMacroExpression(
     const ParsedExpression& parsedExpression, const std::string& macroName) {
-    auto scalarMacroFunction = binder->catalog.getScalarMacroFunction(macroName);
+    auto scalarMacroFunction = context->getCatalog()->getScalarMacroFunction(macroName);
     auto macroExpr = scalarMacroFunction->expression->copy();
     auto parameterVals = scalarMacroFunction->getDefaultParameterVals();
     auto& parsedFuncExpr =
@@ -250,35 +251,34 @@ static std::vector<std::unique_ptr<Value>> populateLabelValues(std::vector<table
 }
 
 std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression& expression) {
+    auto catalog = context->getCatalog();
     auto listType = LogicalType::VAR_LIST(LogicalType::STRING());
     expression_vector children;
     switch (expression.getDataType().getLogicalTypeID()) {
     case LogicalTypeID::NODE: {
         auto& node = (NodeExpression&)expression;
         if (!node.isMultiLabeled()) {
-            auto labelName = binder->catalog.getTableName(
-                binder->clientContext->getTx(), node.getSingleTableID());
+            auto labelName = catalog->getTableName(context->getTx(), node.getSingleTableID());
             return createLiteralExpression(
                 std::make_unique<Value>(LogicalType::STRING(), labelName));
         }
-        auto nodeTableIDs = binder->catalog.getNodeTableIDs(binder->clientContext->getTx());
+        auto nodeTableIDs = catalog->getNodeTableIDs(context->getTx());
         children.push_back(node.getInternalID());
-        auto labelsValue = std::make_unique<Value>(std::move(listType),
-            populateLabelValues(nodeTableIDs, binder->catalog, binder->clientContext->getTx()));
+        auto labelsValue = std::make_unique<Value>(
+            std::move(listType), populateLabelValues(nodeTableIDs, *catalog, context->getTx()));
         children.push_back(createLiteralExpression(std::move(labelsValue)));
     } break;
     case LogicalTypeID::REL: {
         auto& rel = (RelExpression&)expression;
         if (!rel.isMultiLabeled()) {
-            auto labelName = binder->catalog.getTableName(
-                binder->clientContext->getTx(), rel.getSingleTableID());
+            auto labelName = catalog->getTableName(context->getTx(), rel.getSingleTableID());
             return createLiteralExpression(
                 std::make_unique<Value>(LogicalType::STRING(), labelName));
         }
-        auto relTableIDs = binder->catalog.getRelTableIDs(binder->clientContext->getTx());
+        auto relTableIDs = catalog->getRelTableIDs(context->getTx());
         children.push_back(rel.getInternalIDProperty());
-        auto labelsValue = std::make_unique<Value>(std::move(listType),
-            populateLabelValues(relTableIDs, binder->catalog, binder->clientContext->getTx()));
+        auto labelsValue = std::make_unique<Value>(
+            std::move(listType), populateLabelValues(relTableIDs, *catalog, context->getTx()));
         children.push_back(createLiteralExpression(std::move(labelsValue)));
     } break;
     default:

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -31,9 +31,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
         std::move(boundGraphPattern.queryGraphCollection), uniqueName, std::move(rawName));
     boundSubqueryExpr->setWhereExpression(boundGraphPattern.where);
     // Bind projection
-    auto function = BuiltInFunctionsUtils::matchAggregateFunction(COUNT_STAR_FUNC_NAME,
-        std::vector<LogicalType>{}, false,
-        binder->catalog.getFunctions(binder->clientContext->getTx()));
+    auto functions = context->getCatalog()->getFunctions(context->getTx());
+    auto function = BuiltInFunctionsUtils::matchAggregateFunction(
+        COUNT_STAR_FUNC_NAME, std::vector<LogicalType>{}, false, functions);
     auto bindData =
         std::make_unique<FunctionBindData>(std::make_unique<LogicalType>(function->returnTypeID));
     auto countStarExpr = std::make_shared<AggregateFunctionExpression>(COUNT_STAR_FUNC_NAME,

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -60,7 +60,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindExpression(
 std::shared_ptr<Expression> ExpressionBinder::foldExpression(
     const std::shared_ptr<Expression>& expression) {
     auto value = evaluator::ExpressionEvaluatorUtils::evaluateConstantExpression(
-        expression, binder->memoryManager);
+        expression, context->getMemoryManager());
     auto result = createLiteralExpression(std::move(value));
     // Fold result should preserve the alias original expression. E.g.
     // RETURN 2, 1 + 1 AS x

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -67,9 +67,5 @@ main::ExtensionOption* ExtensionOptions::getExtensionOption(std::string name) {
     return extensionOptions.contains(name) ? &extensionOptions.at(name) : nullptr;
 }
 
-std::unordered_map<std::string, main::ExtensionOption>& ExtensionOptions::getExtensionOptions() {
-    return extensionOptions;
-}
-
 } // namespace extension
 } // namespace kuzu

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -7,7 +7,6 @@
 #include "expression_binder.h"
 #include "parser/query/graph_pattern/pattern_element.h"
 #include "parser/query/regular_query.h"
-#include "storage/storage_manager.h"
 
 namespace kuzu {
 namespace parser {
@@ -80,12 +79,9 @@ class Binder {
     friend class ExpressionBinder;
 
 public:
-    explicit Binder(const catalog::Catalog& catalog, storage::MemoryManager* memoryManager,
-        storage::StorageManager* storageManager, common::VirtualFileSystem* vfs,
-        main::ClientContext* clientContext, extension::ExtensionOptions* extensionOptions)
-        : catalog{catalog}, memoryManager{memoryManager}, storageManager{storageManager}, vfs{vfs},
-          lastExpressionId{0}, scope{std::make_unique<BinderScope>()}, expressionBinder{this},
-          clientContext{clientContext}, extensionOptions{extensionOptions} {}
+    explicit Binder(main::ClientContext* clientContext)
+        : lastExpressionId{0}, scope{std::make_unique<BinderScope>()},
+          expressionBinder{this, clientContext}, clientContext{clientContext} {}
 
     std::unique_ptr<BoundStatement> bind(const parser::Statement& statement);
 
@@ -294,15 +290,10 @@ private:
         common::FileType fileType, const common::ReaderConfig& config);
 
 private:
-    const catalog::Catalog& catalog;
-    storage::MemoryManager* memoryManager;
-    storage::StorageManager* storageManager;
-    common::VirtualFileSystem* vfs;
     uint32_t lastExpressionId;
     std::unique_ptr<BinderScope> scope;
     ExpressionBinder expressionBinder;
     main::ClientContext* clientContext;
-    extension::ExtensionOptions* extensionOptions;
 };
 
 } // namespace binder

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -4,6 +4,10 @@
 #include "parser/expression/parsed_expression.h"
 
 namespace kuzu {
+namespace main {
+class ClientContext;
+}
+
 namespace common {
 class Value;
 }
@@ -17,7 +21,8 @@ class ExpressionBinder {
     friend class Binder;
 
 public:
-    explicit ExpressionBinder(Binder* queryBinder) : binder{queryBinder} {}
+    ExpressionBinder(Binder* queryBinder, main::ClientContext* context)
+        : binder{queryBinder}, context{context} {}
 
     std::shared_ptr<Expression> bindExpression(const parser::ParsedExpression& parsedExpression);
 
@@ -124,6 +129,7 @@ private:
 
 private:
     Binder* binder;
+    main::ClientContext* context;
     std::unordered_map<std::string, std::shared_ptr<common::Value>> parameterMap;
 };
 

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -42,8 +42,6 @@ struct ExtensionOptions {
         std::string name, common::LogicalTypeID type, common::Value defaultValue);
 
     main::ExtensionOption* getExtensionOption(std::string name);
-
-    std::unordered_map<std::string, main::ExtensionOption>& getExtensionOptions();
 };
 
 } // namespace extension

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -27,6 +27,10 @@ namespace common {
 class RandomEngine;
 }
 
+namespace extension {
+struct ExtensionOptions;
+}
+
 namespace main {
 class Database;
 
@@ -80,6 +84,7 @@ public:
 
     // Extension
     KUZU_API void setExtensionOption(std::string name, common::Value value);
+    extension::ExtensionOptions* getExtensionOptions() const;
     std::string getExtensionDir() const;
 
     // Environment.

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -120,6 +120,10 @@ void ClientContext::setExtensionOption(std::string name, common::Value value) {
     extensionOptionValues.insert_or_assign(name, std::move(value));
 }
 
+extension::ExtensionOptions* ClientContext::getExtensionOptions() const {
+    return database->extensionOptions.get();
+}
+
 std::string ClientContext::getExtensionDir() const {
     return common::stringFormat("{}/.kuzu/extension", config.homeDirectory);
 }
@@ -263,9 +267,7 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareNoLock(
             }
         }
         // binding
-        auto binder = Binder(*database->catalog, database->memoryManager.get(),
-            database->storageManager.get(), database->vfs.get(), this,
-            database->extensionOptions.get());
+        auto binder = Binder(this);
         auto boundStatement = binder.bind(*parsedStatement);
         preparedStatement->parameterMap = binder.getParameterMap();
         preparedStatement->statementResult =

--- a/test/graph_test/graph_test.cpp
+++ b/test/graph_test/graph_test.cpp
@@ -25,10 +25,7 @@ void PrivateGraphTest::validateQueryBestPlanJoinOrder(
     auto statement = parser::Parser::parseQuery(query);
     ASSERT_EQ(statement.size(), 1);
     auto parsedQuery = (parser::RegularQuery*)statement[0].get();
-    auto boundQuery =
-        Binder(*catalog, database->memoryManager.get(), database->storageManager.get(),
-            database->vfs.get(), conn->clientContext.get(), database->extensionOptions.get())
-            .bind(*parsedQuery);
+    auto boundQuery = Binder(conn->clientContext.get()).bind(*parsedQuery);
     auto planner = Planner(catalog, getStorageManager(*database));
     auto plan = planner.getBestPlan(*boundQuery);
     ASSERT_STREQ(LogicalPlanUtil::encodeJoin(*plan).c_str(), expectedJoinOrder.c_str());


### PR DESCRIPTION
This is a refactor PR to avoid passing individual database components into binder, e.g. BM, MM, etc.... Instead, we pass client context only because client context already contains all database components.