### PR TITLE
Refactor cast functions

### DIFF
--- a/src/binder/bind/bind_query.cpp
+++ b/src/binder/bind/bind_query.cpp
@@ -36,7 +36,7 @@ void validateIsAllUnionOrUnionAll(const BoundRegularQuery& regularQuery) {
     }
     if ((0 < unionAllExpressionCounter) &&
         (unionAllExpressionCounter < regularQuery.getNumSingleQueries() - 1)) {
-        throw BinderException("Union and union all can't be used together.");
+        throw BinderException("Union and union all can not be used together.");
     }
 }
 

--- a/src/function/built_in_function_utils.cpp
+++ b/src/function/built_in_function_utils.cpp
@@ -92,9 +92,6 @@ Function* BuiltInFunctionsUtils::matchFunction(const std::string& name,
     uint32_t minCost = UINT32_MAX;
     for (auto& function : functionSet) {
         auto func = reinterpret_cast<Function*>(function.get());
-        if (name == CAST_FUNC_NAME) {
-            return func;
-        }
         auto cost = getFunctionCost(inputTypes, func, isOverload);
         if (cost == UINT32_MAX) {
             continue;

--- a/src/function/cast/cast_fixed_list.cpp
+++ b/src/function/cast/cast_fixed_list.cpp
@@ -155,7 +155,7 @@ void CastFixedList::stringtoFixedListCastExecFunction<UnaryFunctionExecutor>(
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
     KU_ASSERT(params.size() == 1);
     const auto& param = params[0];
-    auto option = &reinterpret_cast<CastFunctionBindData*>(dataPtr)->csvConfig.option;
+    auto option = &reinterpret_cast<CastFunctionBindData*>(dataPtr)->option;
     if (param->state->isFlat()) {
         auto inputPos = param->state->selVector->selectedPositions[0];
         auto resultPos = result.state->selVector->selectedPositions[0];
@@ -197,7 +197,7 @@ void CastFixedList::stringtoFixedListCastExecFunction<CastChildFunctionExecutor>
     const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result, void* dataPtr) {
     KU_ASSERT(params.size() == 1);
     auto numOfEntries = reinterpret_cast<CastFunctionBindData*>(dataPtr)->numOfEntries;
-    auto option = &reinterpret_cast<CastFunctionBindData*>(dataPtr)->csvConfig.option;
+    auto option = &reinterpret_cast<CastFunctionBindData*>(dataPtr)->option;
     auto inputVector = params[0].get();
     for (auto i = 0u; i < numOfEntries; i++) {
         result.setNull(i, inputVector->isNull(i));

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -823,144 +823,143 @@ void CastString::operation(const ku_string_t& input, union_entry_t& result,
 }
 
 void CastString::copyStringToVector(
-    ValueVector* vector, uint64_t rowToAdd, std::string_view strVal, const CSVOption* option) {
+    ValueVector* vector, uint64_t vectorPos, std::string_view strVal, const CSVOption* option) {
     auto& type = vector->dataType;
-
     if (strVal.empty() || isNull(strVal)) {
-        vector->setNull(rowToAdd, true /* isNull */);
+        vector->setNull(vectorPos, true /* isNull */);
         return;
-    } else {
-        vector->setNull(rowToAdd, false /* isNull */);
     }
+    vector->setNull(vectorPos, false /* isNull */);
     switch (type.getLogicalTypeID()) {
     case LogicalTypeID::INT128: {
         int128_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::INT64: {
         int64_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::INT32: {
         int32_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::INT16: {
         int16_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::INT8: {
         int8_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::UINT64: {
         uint64_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::UINT32: {
         uint32_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::UINT16: {
         uint16_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::UINT8: {
         uint8_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::FLOAT: {
         float val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::DOUBLE: {
         double val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::BOOL: {
         bool val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::BLOB: {
         blob_t val;
-        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, rowToAdd, option);
+        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, vectorPos, option);
     } break;
     case LogicalTypeID::UUID: {
         ku_uuid_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val.value);
+        vector->setValue(vectorPos, val.value);
     } break;
     case LogicalTypeID::STRING: {
         if (!utf8proc::Utf8Proc::isValid(strVal.data(), strVal.length())) {
             throw CopyException{"Invalid UTF8-encoded string."};
         }
-        StringVector::addString(vector, rowToAdd, strVal.data(), strVal.length());
+        StringVector::addString(vector, vectorPos, strVal.data(), strVal.length());
     } break;
     case LogicalTypeID::DATE: {
         date_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::TIMESTAMP_NS: {
         timestamp_ns_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::TIMESTAMP_MS: {
         timestamp_ms_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::TIMESTAMP_SEC: {
         timestamp_sec_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::TIMESTAMP_TZ: {
         timestamp_tz_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::TIMESTAMP: {
         timestamp_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::INTERVAL: {
         interval_t val;
         CastStringHelper::cast(strVal.data(), strVal.length(), val);
-        vector->setValue(rowToAdd, val);
+        vector->setValue(vectorPos, val);
     } break;
     case LogicalTypeID::MAP: {
         map_entry_t val;
-        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, rowToAdd, option);
+        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, vectorPos, option);
     } break;
     case LogicalTypeID::VAR_LIST: {
         list_entry_t val;
-        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, rowToAdd, option);
+        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, vectorPos, option);
     } break;
     case LogicalTypeID::FIXED_LIST: {
-        CastStringHelper::castToFixedList(strVal.data(), strVal.length(), vector, rowToAdd, option);
+        CastStringHelper::castToFixedList(
+            strVal.data(), strVal.length(), vector, vectorPos, option);
     } break;
     case LogicalTypeID::STRUCT: {
         struct_entry_t val;
-        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, rowToAdd, option);
+        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, vectorPos, option);
     } break;
     case LogicalTypeID::UNION: {
         union_entry_t val;
-        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, rowToAdd, option);
+        CastStringHelper::cast(strVal.data(), strVal.length(), val, vector, vectorPos, option);
     } break;
     default: {
         KU_UNREACHABLE;

--- a/src/include/function/cast/cast_function_bind_data.h
+++ b/src/include/function/cast/cast_function_bind_data.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "common/copier_config/csv_reader_config.h"
+#include "function/function.h"
+
+namespace kuzu {
+namespace function {
+
+struct CastFunctionBindData : public FunctionBindData {
+    // We don't allow configuring delimiters, ... in CAST function.
+    // For performance purpose, we generate a default option object during binding time.
+    common::CSVOption option;
+    // TODO(Mahn): the following field should be removed once we refactor fixed list.
+    uint64_t numOfEntries;
+
+    explicit CastFunctionBindData(std::unique_ptr<common::LogicalType> dataType)
+        : FunctionBindData{std::move(dataType)} {}
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/cast/functions/cast_from_string_functions.h
+++ b/src/include/function/cast/functions/cast_from_string_functions.h
@@ -14,7 +14,7 @@ namespace function {
 
 struct CastString {
     static void copyStringToVector(
-        ValueVector* vector, uint64_t rowToAdd, std::string_view strVal, const CSVOption* option);
+        ValueVector* vector, uint64_t vectorPos, std::string_view strVal, const CSVOption* option);
 
     template<typename T>
     static inline bool tryCast(const ku_string_t& input, T& result) {

--- a/src/include/function/cast/vector_cast_functions.h
+++ b/src/include/function/cast/vector_cast_functions.h
@@ -98,8 +98,6 @@ struct CastToUInt8Function {
 };
 
 struct CastAnyFunction {
-    static std::unique_ptr<FunctionBindData> bindFunc(
-        const binder::expression_vector& arguments, Function* function);
     static function_set getFunctionSet();
 };
 

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "binder/expression/expression.h"
-#include "common/copier_config/csv_reader_config.h"
 
 namespace kuzu {
 namespace function {
@@ -13,14 +12,6 @@ struct FunctionBindData {
         : resultType{std::move(dataType)} {}
 
     virtual ~FunctionBindData() = default;
-};
-
-struct CastFunctionBindData : public FunctionBindData {
-    common::CSVReaderConfig csvConfig;
-    uint64_t numOfEntries;
-
-    explicit CastFunctionBindData(std::unique_ptr<common::LogicalType> dataType)
-        : FunctionBindData{std::move(dataType)} {}
 };
 
 struct Function;

--- a/src/include/function/unary_function_executor.h
+++ b/src/include/function/unary_function_executor.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "common/vector/value_vector.h"
-#include "function/function.h"
+#include "function/cast/cast_function_bind_data.h"
 
 namespace kuzu {
 namespace function {
@@ -41,7 +41,7 @@ struct UnaryCastStringFunctionWrapper {
         auto resultVector_ = (common::ValueVector*)resultVector;
         FUNC::operation(inputVector_.getValue<OPERAND_TYPE>(inputPos),
             resultVector_->getValue<RESULT_TYPE>(resultPos), resultVector_, inputPos,
-            &reinterpret_cast<CastFunctionBindData*>(dataPtr)->csvConfig.option);
+            &reinterpret_cast<CastFunctionBindData*>(dataPtr)->option);
     }
 };
 

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -239,7 +239,7 @@ Binder exception: p1.age has data type INT64 but (STRING) was expected.
 -LOG UnionAndUnionAllInSingleQuery
 -STATEMENT MATCH (p:person) RETURN p.age UNION ALL MATCH (p1:person) RETURN p1.age UNION MATCH (p1:person) RETURN p1.age
 ---- error
-Binder exception: Union and union all can't be used together.
+Binder exception: Union and union all can not be used together.
 
 -LOG ReadAfterUpdate
 -STATEMENT MATCH (a:person) SET a.age = 35 WITH a MATCH (a)-[:knows]->(b:person) RETURN a.age
@@ -587,10 +587,12 @@ Binder exception: COPY TO currently only supports csv and parquet files.
 -LOG InvalidArgCast
 -STATEMENT RETURN cast("[sdf, fsd, fad]", "STRING[]", "3rd arg");
 ---- error
-Binder exception: Invalid number of arguments for given function CAST. Expected: 2, Actual: 3.
+Binder exception: Cannot match a built-in function for given function CAST(STRING,STRING,STRING). Supported inputs are
+(ANY,STRING) -> ANY
 -STATEMENT RETURN cast("[sdf, fsd, fad]");
 ---- error
-Binder exception: Invalid number of arguments for given function CAST. Expected: 2, Actual: 1.
+Binder exception: Cannot match a built-in function for given function CAST(STRING). Supported inputs are
+(ANY,STRING) -> ANY
 
 -LOG InvalidImplicitCast
 -STATEMENT RETURN timestamp("2019-11-21") + "ok";


### PR DESCRIPTION
Remove some `if function name == CAST` checking. The goal is to bind `CAST` as a regular scalar function. But some infrastructure is still missing.