### PR TITLE
Combine append(ValueVector) with appendOne

### DIFF
--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -3,6 +3,7 @@
 #include <functional>
 
 #include "common/constants.h"
+#include "common/data_chunk/sel_vector.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "storage/buffer_manager/bm_file_handle.h"
@@ -54,8 +55,7 @@ public:
     // Note that the startPageIdx is not known, so it will always be common::INVALID_PAGE_IDX
     virtual ColumnChunkMetadata getMetadataToFlush() const;
 
-    virtual void append(common::ValueVector* vector);
-    virtual void appendOne(common::ValueVector* vector, common::vector_idx_t pos);
+    virtual void append(common::ValueVector* vector, common::SelectionVector& selVector);
     virtual void append(
         ColumnChunk* other, common::offset_t startPosInOtherChunk, uint32_t numValuesToAppend);
 
@@ -109,7 +109,8 @@ protected:
 
     common::offset_t getOffsetInBuffer(common::offset_t pos) const;
 
-    virtual void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk);
+    virtual void copyVectorToBuffer(common::ValueVector* vector, common::offset_t startPosInChunk,
+        common::SelectionVector& selVector);
 
 private:
     uint64_t getBufferSize(uint64_t capacity_) const;
@@ -150,8 +151,7 @@ public:
               // Booleans are always bitpacked, but this can also enable constant compression
               enableCompression, hasNullChunk) {}
 
-    void append(common::ValueVector* vector) final;
-    void appendOne(common::ValueVector* vector, common::vector_idx_t pos) final;
+    void append(common::ValueVector* vector, common::SelectionVector& sel) final;
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) override;
     void write(common::ValueVector* vector, common::offset_t offsetInVector,

--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/assert.h"
+#include "common/data_chunk/sel_vector.h"
 #include "common/types/types.h"
 #include "storage/store/column_chunk.h"
 #include "storage/store/dictionary_chunk.h"
@@ -14,8 +15,7 @@ public:
         common::LogicalType dataType, uint64_t capacity, bool enableCompression, bool inMemory);
 
     void resetToEmpty() final;
-    void append(common::ValueVector* vector) final;
-    void appendOne(common::ValueVector* vector, common::vector_idx_t pos) final;
+    void append(common::ValueVector* vector, common::SelectionVector& selVector) final;
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) final;
 

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/data_chunk/sel_vector.h"
 #include "common/types/internal_id_t.h"
 #include "common/types/types.h"
 #include "storage/store/column_chunk.h"
@@ -22,8 +23,7 @@ public:
 protected:
     void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) final;
-    void append(common::ValueVector* vector) final;
-    void appendOne(common::ValueVector* vector, common::vector_idx_t pos) final;
+    void append(common::ValueVector* vector, common::SelectionVector& selVector) final;
 
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) final;

--- a/src/include/storage/store/var_list_column_chunk.h
+++ b/src/include/storage/store/var_list_column_chunk.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/data_chunk/sel_vector.h"
 #include "storage/store/column_chunk.h"
 
 namespace kuzu {
@@ -17,8 +18,8 @@ struct VarListDataColumnChunk {
 
     void resizeBuffer(uint64_t numValues);
 
-    inline void append(common::ValueVector* dataVector) const {
-        dataColumnChunk->append(dataVector);
+    inline void append(common::ValueVector* dataVector, common::SelectionVector& selVector) const {
+        dataColumnChunk->append(dataVector, selVector);
     }
 
     inline uint64_t getNumValues() const { return dataColumnChunk->getNumValues(); }
@@ -36,8 +37,7 @@ public:
 
     void resetToEmpty() final;
 
-    void append(common::ValueVector* vector) final;
-    void appendOne(common::ValueVector* vector, common::vector_idx_t pos) final;
+    void append(common::ValueVector* vector, common::SelectionVector& selVector) final;
     // Note: `write` assumes that no `append` will be called afterward.
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) final;

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -106,8 +106,10 @@ uint64_t NodeGroup::append(const std::vector<ValueVector*>& columnVectors,
             serialSkip++;
             continue;
         }
-        KU_ASSERT(chunk->getDataType() == columnVectors[i - serialSkip]->dataType);
-        chunk->append(columnVectors[i - serialSkip]);
+        KU_ASSERT((i - serialSkip) < columnVectors.size());
+        auto columnVector = columnVectors[i - serialSkip];
+        KU_ASSERT(chunk->getDataType() == columnVector->dataType);
+        chunk->append(columnVector, *columnVector->state->selVector);
     }
     columnState->selVector->selectedSize = originalSize;
     numRows += numValuesToAppendInChunk;


### PR DESCRIPTION
Combine following two interfaces in `ColumnChunk`
```cpp
    virtual void append(common::ValueVector* vector);
    virtual void appendOne(common::ValueVector* vector, common::vector_idx_t pos);
```

into
```cpp
    virtual void append(common::ValueVector* vector, common::SelectionVector& selVector);
```