### PR TITLE
Remove the constraint on HashIndexBuilder's template parameter

### DIFF
--- a/src/include/storage/index/hash_index_builder.h
+++ b/src/include/storage/index/hash_index_builder.h
@@ -2,7 +2,6 @@
 
 #include "common/static_vector.h"
 #include "common/type_utils.h"
-#include "common/types/internal_id_t.h"
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
 #include "storage/index/hash_index_header.h"
@@ -54,7 +53,7 @@ using IndexBuffer = common::StaticVector<std::pair<T, common::offset_t>, BUFFER_
 // T is the key type stored in the slots.
 // For strings this is different than the type used when inserting/searching
 // (see BufferKeyType and Key)
-template<common::IndexHashable T>
+template<typename T>
 class HashIndexBuilder final : public InMemHashIndex {
     static_assert(getSlotCapacity<T>() <= SlotHeader::FINGERPRINT_CAPACITY);
     // Size of the validity mask
@@ -177,7 +176,7 @@ public:
     common::PhysicalTypeID keyTypeID() const { return keyDataTypeID; }
 
 private:
-    template<common::IndexHashable T>
+    template<typename T>
     using HashIndexType =
         typename std::conditional<std::same_as<T, std::string_view> || std::same_as<T, std::string>,
             common::ku_string_t, T>::type;

--- a/src/storage/index/hash_index_builder.cpp
+++ b/src/storage/index/hash_index_builder.cpp
@@ -16,7 +16,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-template<IndexHashable T>
+template<typename T>
 HashIndexBuilder<T>::HashIndexBuilder(const std::shared_ptr<FileHandle>& fileHandle,
     OverflowFileHandle* overflowFileHandle, uint64_t indexPos, PhysicalTypeID keyDataType)
     : fileHandle(fileHandle), overflowFileHandle(overflowFileHandle) {
@@ -31,7 +31,7 @@ HashIndexBuilder<T>::HashIndexBuilder(const std::shared_ptr<FileHandle>& fileHan
     allocatePSlots(1u << this->indexHeader->currentLevel);
 }
 
-template<IndexHashable T>
+template<typename T>
 void HashIndexBuilder<T>::bulkReserve(uint32_t numEntries_) {
     slot_id_t numRequiredEntries =
         HashIndexUtils::getNumRequiredEntries(this->indexHeader->numEntries, numEntries_);
@@ -51,7 +51,7 @@ void HashIndexBuilder<T>::bulkReserve(uint32_t numEntries_) {
     }
 }
 
-template<common::IndexHashable T>
+template<typename T>
 void HashIndexBuilder<T>::copy(const uint8_t* oldEntry, slot_id_t newSlotId, uint8_t fingerprint) {
     SlotIterator iter(newSlotId, this);
     do {
@@ -77,7 +77,7 @@ void HashIndexBuilder<T>::copy(const uint8_t* oldEntry, slot_id_t newSlotId, uin
     newOvfSlot->header.setEntryValid(newEntryPos, fingerprint);
 }
 
-template<common::IndexHashable T>
+template<typename T>
 void HashIndexBuilder<T>::splitSlot(HashIndexHeader& header) {
     // Add new slot
     allocatePSlots(1);
@@ -105,7 +105,7 @@ void HashIndexBuilder<T>::splitSlot(HashIndexHeader& header) {
     header.incrementNextSplitSlotId();
 }
 
-template<IndexHashable T>
+template<typename T>
 size_t HashIndexBuilder<T>::append(const IndexBuffer<BufferKeyType>& buffer) {
     slot_id_t numRequiredEntries =
         HashIndexUtils::getNumRequiredEntries(this->indexHeader->numEntries, buffer.size());
@@ -127,7 +127,7 @@ size_t HashIndexBuilder<T>::append(const IndexBuffer<BufferKeyType>& buffer) {
     return buffer.size();
 }
 
-template<IndexHashable T>
+template<typename T>
 bool HashIndexBuilder<T>::appendInternal(Key key, common::offset_t value, common::hash_t hash) {
     auto fingerprint = HashIndexUtils::getFingerprintForHash(hash);
     auto slotID = HashIndexUtils::getPrimarySlotIdForHash(*this->indexHeader, hash);
@@ -155,7 +155,7 @@ bool HashIndexBuilder<T>::appendInternal(Key key, common::offset_t value, common
     return true;
 }
 
-template<IndexHashable T>
+template<typename T>
 bool HashIndexBuilder<T>::lookup(Key key, offset_t& result) {
     auto hashValue = HashIndexUtils::hash(key);
     auto fingerprint = HashIndexUtils::getFingerprintForHash(hashValue);
@@ -176,7 +176,7 @@ bool HashIndexBuilder<T>::lookup(Key key, offset_t& result) {
     return false;
 }
 
-template<IndexHashable T>
+template<typename T>
 uint32_t HashIndexBuilder<T>::allocatePSlots(uint32_t numSlotsToAllocate) {
     auto oldNumSlots = pSlots->getNumElements();
     auto newNumSlots = oldNumSlots + numSlotsToAllocate;
@@ -184,7 +184,7 @@ uint32_t HashIndexBuilder<T>::allocatePSlots(uint32_t numSlotsToAllocate) {
     return oldNumSlots;
 }
 
-template<IndexHashable T>
+template<typename T>
 uint32_t HashIndexBuilder<T>::allocateAOSlot() {
     auto oldNumSlots = oSlots->getNumElements();
     auto newNumSlots = oldNumSlots + 1;
@@ -192,7 +192,7 @@ uint32_t HashIndexBuilder<T>::allocateAOSlot() {
     return oldNumSlots;
 }
 
-template<IndexHashable T>
+template<typename T>
 Slot<T>* HashIndexBuilder<T>::getSlot(const SlotInfo& slotInfo) {
     if (slotInfo.slotType == SlotType::PRIMARY) {
         return &pSlots->operator[](slotInfo.slotId);
@@ -201,7 +201,7 @@ Slot<T>* HashIndexBuilder<T>::getSlot(const SlotInfo& slotInfo) {
     }
 }
 
-template<IndexHashable T>
+template<typename T>
 void HashIndexBuilder<T>::flush() {
     headerArray->resize(1, true /* setToZero */);
     headerArray->operator[](0) = *this->indexHeader;
@@ -210,7 +210,7 @@ void HashIndexBuilder<T>::flush() {
     oSlots->saveToDisk();
 }
 
-template<IndexHashable T>
+template<typename T>
 inline void HashIndexBuilder<T>::insertToNewOvfSlot(
     Key key, Slot<T>* previousSlot, common::offset_t offset, uint8_t fingerprint) {
     auto newSlotId = allocateAOSlot();
@@ -229,7 +229,7 @@ void HashIndexBuilder<ku_string_t>::insert(std::string_view key, Slot<ku_string_
     slot->header.setEntryValid(entryPos, fingerprint);
 }
 
-template<IndexHashable T>
+template<typename T>
 common::hash_t HashIndexBuilder<T>::hashStored(const T& key) const {
     return HashIndexUtils::hash(key);
 }


### PR DESCRIPTION
The constraint seems to cause issues with MSVC 19.27 (#3022), and I don't think it's necessary any more.

This fixes the compilation failure (see https://github.com/kuzudb/kuzu/actions/runs/8250693752), however there are now some tests failing on the VS2019 job, I'm not really sure why.

~~I've pulled a change to the typing (merging the two template parameters) out of #2997 as I didn't really want to modify the template parameters twice.~~