### PR TITLE
First-pass lint/format for Python `shell` tests

### DIFF
--- a/tools/shell/test/test_helper.py
+++ b/tools/shell/test/test_helper.py
@@ -1,49 +1,60 @@
 import os
-from pathlib import Path
 import sys
 from enum import Enum
+from pathlib import Path
 
 KUZU_ROOT = Path(__file__).parent.parent.parent.parent
 if sys.platform == "win32":
     # \ in paths is not supported by kuzu's parser
-    KUZU_ROOT=str(KUZU_ROOT).replace("\\", "/")
+    KUZU_ROOT = str(KUZU_ROOT).replace("\\", "/")
 
-KUZU_EXEC_PATH = os.path.join(KUZU_ROOT, 'build', 'release', 'tools', 'shell', 'kuzu_shell')
+KUZU_EXEC_PATH = os.path.join(
+    KUZU_ROOT,
+    "build",
+    "release",
+    "tools",
+    "shell",
+    "kuzu_shell",
+)
+
 
 def _get_kuzu_version():
-    cmake_file = os.path.join(KUZU_ROOT, 'CMakeLists.txt')
+    cmake_file = os.path.join(KUZU_ROOT, "CMakeLists.txt")
     with open(cmake_file) as f:
         for line in f:
-            if line.startswith('project(Kuzu VERSION'):
-                return line.split(' ')[2].strip()
+            if line.startswith("project(Kuzu VERSION"):
+                return line.split(" ")[2].strip()
+        return None
+
 
 KUZU_VERSION = _get_kuzu_version()
 
-class KEY_ACTION(Enum):
-    KEY_NULL = '\0'      # NULL 
-    CTRL_A = 'a'         # Ctrl-a 
-    CTRL_B = 'b'         # Ctrl-b 
-    CTRL_C = 'c'         # Ctrl-c 
-    CTRL_D = 'd'         # Ctrl-d 
-    CTRL_E = 'e'         # Ctrl-e 
-    CTRL_F = 'f'         # Ctrl-f 
-    CTRL_G = 'g'         # Ctrl-g 
-    CTRL_H = chr(8)      # Ctrl-h 
-    TAB = '\t'           # Tab 
-    CTRL_K = 'k'         # Ctrl-k 
-    CTRL_L = 'l'         # Ctrl-l 
-    ENTER = '\r'         # Enter 
-    CTRL_N = 'n'         # Ctrl-n 
-    CTRL_P = 'p'         # Ctrl-p 
-    CTRL_R = 'r'         # Ctrl-r 
-    CTRL_S = 's'         # Ctrl-s
-    CTRL_T = 't'         # Ctrl-t 
-    CTRL_U = 'u'         # Ctrl-u 
-    CTRL_W = chr(23)     # Ctrl-w 
-    ESC = '\27'          # Escape 
-    BACKSPACE = chr(127) # Backspace 
-    
 
-def deleteIfExists(file):
+class KEY_ACTION(Enum):
+    KEY_NULL = "\0"  # NULL
+    CTRL_A = "a"  # Ctrl-a
+    CTRL_B = "b"  # Ctrl-b
+    CTRL_C = "c"  # Ctrl-c
+    CTRL_D = "d"  # Ctrl-d
+    CTRL_E = "e"  # Ctrl-e
+    CTRL_F = "f"  # Ctrl-f
+    CTRL_G = "g"  # Ctrl-g
+    CTRL_H = chr(8)  # Ctrl-h
+    TAB = "\t"  # Tab
+    CTRL_K = "k"  # Ctrl-k
+    CTRL_L = "l"  # Ctrl-l
+    ENTER = "\r"  # Enter
+    CTRL_N = "n"  # Ctrl-n
+    CTRL_P = "p"  # Ctrl-p
+    CTRL_R = "r"  # Ctrl-r
+    CTRL_S = "s"  # Ctrl-s
+    CTRL_T = "t"  # Ctrl-t
+    CTRL_U = "u"  # Ctrl-u
+    CTRL_W = chr(23)  # Ctrl-w
+    ESC = "\27"  # Escape
+    BACKSPACE = chr(127)  # Backspace
+
+
+def deleteIfExists(file) -> None:
     if os.path.exists(file):
         os.remove(file)

--- a/tools/shell/test/test_shell_basics.py
+++ b/tools/shell/test/test_shell_basics.py
@@ -1,47 +1,37 @@
+import os
+
 import pytest
-from test_helper import *
 from conftest import ShellTest
+from test_helper import deleteIfExists
 
 
-def test_basic(temp_db):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement('RETURN "databases rule" AS a;')
-    )
+def test_basic(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db).statement('RETURN "databases rule" AS a;')
     result = test.run()
     result.check_stdout("databases rule")
 
 
-def test_range(temp_db):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement('RETURN RANGE(0, 10) AS a;')
-    )
+def test_range(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db).statement("RETURN RANGE(0, 10) AS a;")
     result = test.run()
     result.check_stdout("[0,1,2,3,4,5,6,7,8,9,10]")
 
 
 @pytest.mark.parametrize(
-    ["input", "output"],
+    ("input", "output"),
     [
         ("RETURN LIST_CREATION(1,2);", "[1,2]"),
         ("RETURN STRUCT_PACK(x:=2,y:=3);", "{x: 2, y: 3}"),
         ("RETURN STRUCT_PACK(x:=2,y:=LIST_CREATION(1,2));", "{x: 2, y: [1,2]}"),
     ],
 )
-def test_nested_types(temp_db, input, output):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement(input)
-    )
+def test_nested_types(temp_db, input, output) -> None:
+    test = ShellTest().add_argument(temp_db).statement(input)
     result = test.run()
     result.check_stdout(output)
-    
 
-def test_invalid_cast(temp_db):
+
+def test_invalid_cast(temp_db) -> None:
     test = (
         ShellTest()
         .add_argument(temp_db)
@@ -50,10 +40,12 @@ def test_invalid_cast(temp_db):
         .statement('MATCH (t:a) RETURN CAST(t.i, "INT8");')
     )
     result = test.run()
-    result.check_stdout('Error: Conversion exception: Cast failed. Could not convert "****" to INT8.')
-    
+    result.check_stdout(
+        'Error: Conversion exception: Cast failed. Could not convert "****" to INT8.',
+    )
 
-def test_multiline(temp_db):
+
+def test_multiline(temp_db) -> None:
     test = (
         ShellTest()
         .add_argument(temp_db)
@@ -65,62 +57,50 @@ def test_multiline(temp_db):
     )
     result = test.run()
     result.check_stdout("databases rule")
-    
 
-def test_multi_queries_one_line(temp_db):
+
+def test_multi_queries_one_line(temp_db) -> None:
     # two successful queries
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement('RETURN "databases rule" AS a; RETURN "kuzu is cool" AS b;')
-    )
-    result = test.run()
-    result.check_stdout("databases rule") 
-    result.check_stdout("kuzu is cool")
-    
-    # one success one failure
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement('RETURN "databases rule" AS a;      ;')
-    )
+    test = ShellTest().add_argument(temp_db).statement('RETURN "databases rule" AS a; RETURN "kuzu is cool" AS b;')
     result = test.run()
     result.check_stdout("databases rule")
-    result.check_stdout(["Error: Parser exception: mismatched input '<EOF>' expecting {CALL, COMMENT, COPY, EXPORT, DROP, ALTER, BEGIN, COMMIT, COMMIT_SKIP_CHECKPOINT, ROLLBACK, ROLLBACK_SKIP_CHECKPOINT, INSTALL, LOAD, OPTIONAL, MATCH, UNWIND, CREATE, MERGE, SET, DETACH, DELETE, WITH, RETURN} (line: 1, offset: 6)", 
-                         '"      "'])
-    
-    # two failing queries
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement('RETURN "databases rule" S a;      ;')
-    )
+    result.check_stdout("kuzu is cool")
+
+    # one success one failure
+    test = ShellTest().add_argument(temp_db).statement('RETURN "databases rule" AS a;      ;')
     result = test.run()
-    result.check_stdout(["Error: Parser exception: Invalid input < S>: expected rule ku_Statements (line: 1, offset: 24)", 
-                         '"RETURN "databases rule" S a"',
-                         "                         ^",
-                         "Error: Parser exception: mismatched input '<EOF>' expecting {CALL, COMMENT, COPY, EXPORT, DROP, ALTER, BEGIN, COMMIT, COMMIT_SKIP_CHECKPOINT, ROLLBACK, ROLLBACK_SKIP_CHECKPOINT, INSTALL, LOAD, OPTIONAL, MATCH, UNWIND, CREATE, MERGE, SET, DETACH, DELETE, WITH, RETURN} (line: 1, offset: 6)",
-                         '"      "'])
-
-
-def test_row_truncation(temp_db, csv_path):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement(f'LOAD FROM "{csv_path}" (HEADER=true) RETURN id;')
+    result.check_stdout("databases rule")
+    result.check_stdout(
+        [
+            "Error: Parser exception: mismatched input '<EOF>' expecting {CALL, COMMENT, COPY, EXPORT, DROP, ALTER, BEGIN, COMMIT, COMMIT_SKIP_CHECKPOINT, ROLLBACK, ROLLBACK_SKIP_CHECKPOINT, INSTALL, LOAD, OPTIONAL, MATCH, UNWIND, CREATE, MERGE, SET, DETACH, DELETE, WITH, RETURN} (line: 1, offset: 6)",
+            '"      "',
+        ],
     )
+
+    # two failing queries
+    test = ShellTest().add_argument(temp_db).statement('RETURN "databases rule" S a;      ;')
+    result = test.run()
+    result.check_stdout(
+        [
+            "Error: Parser exception: Invalid input < S>: expected rule ku_Statements (line: 1, offset: 24)",
+            '"RETURN "databases rule" S a"',
+            "                         ^",
+            "Error: Parser exception: mismatched input '<EOF>' expecting {CALL, COMMENT, COPY, EXPORT, DROP, ALTER, BEGIN, COMMIT, COMMIT_SKIP_CHECKPOINT, ROLLBACK, ROLLBACK_SKIP_CHECKPOINT, INSTALL, LOAD, OPTIONAL, MATCH, UNWIND, CREATE, MERGE, SET, DETACH, DELETE, WITH, RETURN} (line: 1, offset: 6)",
+            '"      "',
+        ],
+    )
+
+
+def test_row_truncation(temp_db, csv_path) -> None:
+    test = ShellTest().add_argument(temp_db).statement(f'LOAD FROM "{csv_path}" (HEADER=true) RETURN id;')
     result = test.run()
     result.check_stdout("(21 tuples, 20 shown)")
     result.check_stdout(["|  . |", "|  . |", "|  . |"])
-    
 
-def test_column_truncation(temp_db, csv_path):
+
+def test_column_truncation(temp_db, csv_path) -> None:
     # width when running test is 80
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement(f'LOAD FROM "{csv_path}" (HEADER=true) RETURN *;')
-    )
+    test = ShellTest().add_argument(temp_db).statement(f'LOAD FROM "{csv_path}" (HEADER=true) RETURN *;')
     result = test.run()
     result.check_stdout("-" * 80)
     result.check_not_stdout("-" * 81)
@@ -128,18 +108,14 @@ def test_column_truncation(temp_db, csv_path):
     result.check_stdout("(13 columns, 4 shown)")
 
 
-def long_messages(temp_db):
-    long_message = '-' * 4096
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement(f'RETURN "{long_message}" AS a;')
-    )
+def long_messages(temp_db) -> None:
+    long_message = "-" * 4096
+    test = ShellTest().add_argument(temp_db).statement(f'RETURN "{long_message}" AS a;')
     result = test.run()
     result.check_stdout(long_message)
 
 
-def test_history_consecutive_repeats(temp_db, history_path):
+def test_history_consecutive_repeats(temp_db, history_path) -> None:
     test = (
         ShellTest()
         .add_argument(temp_db)
@@ -150,11 +126,9 @@ def test_history_consecutive_repeats(temp_db, history_path):
     )
     result = test.run()
     result.check_stdout("| databases rule |")
-    
-    f = open(os.path.join(history_path, "history.txt"))
-    assert f.readline() == 'RETURN "databases rule" AS a;\n'
-    assert f.readline() == ''
-    f.close()
-    
-    deleteIfExists(os.path.join(history_path, 'history.txt'))
-    
+
+    with open(os.path.join(history_path, "history.txt")) as f:
+        assert f.readline() == 'RETURN "databases rule" AS a;\n'
+        assert f.readline() == ""
+
+    deleteIfExists(os.path.join(history_path, "history.txt"))

--- a/tools/shell/test/test_shell_commands.py
+++ b/tools/shell/test/test_shell_commands.py
@@ -1,49 +1,39 @@
-from test_helper import *
 from conftest import ShellTest
 
 
-def test_help(temp_db):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement(":help")
-    )
+def test_help(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db).statement(":help")
     result = test.run()
-    result.check_stdout(["    :help     get command list", 
-                         "    :clear     clear shell", 
-                         "    :quit     exit from shell",
-                         "    :max_rows [max_rows]     set maximum number of rows for display (default: 20)",
-                         "    :max_width [max_width]     set maximum width in characters for display",
-                         "",
-                         "    Note: you can change and see several system configurations, such as num-threads, ",
-                         "          timeout, and logging_level using Cypher CALL statements.",
-                         "          e.g. CALL THREADS=5; or CALL current_setting('threads') return *;",
-                         "          See: https://kuzudb.com/docusaurus/cypher/configuration"])
-    
-
-def test_clear(temp_db):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement(":clear")
+    result.check_stdout(
+        [
+            "    :help     get command list",
+            "    :clear     clear shell",
+            "    :quit     exit from shell",
+            "    :max_rows [max_rows]     set maximum number of rows for display (default: 20)",
+            "    :max_width [max_width]     set maximum width in characters for display",
+            "",
+            "    Note: you can change and see several system configurations, such as num-threads, ",
+            "          timeout, and logging_level using Cypher CALL statements.",
+            "          e.g. CALL THREADS=5; or CALL current_setting('threads') return *;",
+            "          See: https://kuzudb.com/docusaurus/cypher/configuration",
+        ],
     )
+
+
+def test_clear(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db).statement(":clear")
     result = test.run()
     result.check_stdout("\x1b[H\x1b[2J")
-    
 
-def test_quit(temp_db):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement(":quit")
-        .statement('RETURN RANGE(0,10) AS a;')
-    )
+
+def test_quit(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db).statement(":quit").statement("RETURN RANGE(0,10) AS a;")
     result = test.run()
     # check to make sure the return query did not execute
     result.check_not_stdout("[0,1,2,3,4,5,6,7,8,9,10]")
-    
 
-def test_max_rows(temp_db, csv_path):
+
+def test_max_rows(temp_db, csv_path) -> None:
     # test all rows shown
     test = (
         ShellTest()
@@ -54,8 +44,8 @@ def test_max_rows(temp_db, csv_path):
     result = test.run()
     result.check_stdout("(21 tuples)")
     result.check_not_stdout(["|  . |", "|  . |", "|  . |"])
-    
-    # test 1 row shown 
+
+    # test 1 row shown
     test = (
         ShellTest()
         .add_argument(temp_db)
@@ -65,7 +55,7 @@ def test_max_rows(temp_db, csv_path):
     result = test.run()
     result.check_stdout("(21 tuples, 1 shown)")
     result.check_stdout(["|  . |", "|  . |", "|  . |"])
-    
+
     # test setting back to default
     test = (
         ShellTest()
@@ -78,7 +68,7 @@ def test_max_rows(temp_db, csv_path):
     result.check_stdout(["|  . |", "|  . |", "|  . |"])
 
 
-def test_max_width(temp_db, csv_path):
+def test_max_width(temp_db, csv_path) -> None:
     # test all columns shown
     test = (
         ShellTest()
@@ -91,7 +81,7 @@ def test_max_width(temp_db, csv_path):
     result.check_not_stdout("-" * 267)
     result.check_not_stdout("| ... |")
     result.check_stdout("(13 columns)")
-    
+
     # test 2 columns shown
     test = (
         ShellTest()
@@ -105,7 +95,7 @@ def test_max_width(temp_db, csv_path):
     result.check_not_stdout("-" * 35)
     result.check_stdout("| ... |")
     result.check_stdout("(13 columns, 2 shown)")
-    
+
     # test too small to display (back to terminal width)
     test = (
         ShellTest()
@@ -119,32 +109,31 @@ def test_max_width(temp_db, csv_path):
     result.check_not_stdout("-" * 81)
     result.check_stdout("| ... |")
     result.check_stdout("(13 columns, 4 shown)")
-    
+
     # test result tuples unaffected by width
     test = (
         ShellTest()
         .add_argument(temp_db)
         .statement(":max_width 2")
-        .statement('CREATE NODE TABLE LANGUAGE_CODE(alpha2 STRING, English STRING, PRIMARY KEY (alpha2));')
+        .statement(
+            "CREATE NODE TABLE LANGUAGE_CODE(alpha2 STRING, English STRING, PRIMARY KEY (alpha2));",
+        )
     )
     result = test.run()
     # terminal width when running test is 80
     result.check_stdout("Node table: LANGUAGE_CODE has been created.")
     result.check_not_stdout("| ... |")
     result.check_stdout("(1 column)")
-    
 
-    def test_bad_command(temp_db):
-        test = (
-            ShellTest()
-            .add_argument(temp_db)
-            .statement(":maxrows")
-            .statement(":quiy")
-            .statement("clearr;")
-        )
+    def test_bad_command(temp_db) -> None:
+        test = ShellTest().add_argument(temp_db).statement(":maxrows").statement(":quiy").statement("clearr;")
         result = test.run()
-        result.check_stdout('Error: Unknown command: ":maxrows". Enter ":help" for help')
+        result.check_stdout(
+            'Error: Unknown command: ":maxrows". Enter ":help" for help',
+        )
         result.check_stdout('Did you mean: ":max_rows"?')
         result.check_stdout('Error: Unknown command: ":quiy". Enter ":help" for help')
         result.check_stdout('Did you mean: ":quit"?')
-        result.check_stdout('Error: "clearr;" is not a valid Cypher query. Did you mean to issue a CLI command, e.g., ":clear"?')
+        result.check_stdout(
+            'Error: "clearr;" is not a valid Cypher query. Did you mean to issue a CLI command, e.g., ":clear"?',
+        )

--- a/tools/shell/test/test_shell_control_edit.py
+++ b/tools/shell/test/test_shell_control_edit.py
@@ -1,24 +1,26 @@
-import pytest
+import os
+
 import pexpect
-from test_helper import *
+import pytest
 from conftest import ShellTest
+from test_helper import KEY_ACTION, deleteIfExists
 
 
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.CTRL_C.value),
-        (KEY_ACTION.CTRL_G.value),
+        KEY_ACTION.CTRL_C.value,
+        KEY_ACTION.CTRL_G.value,
     ],
 )
-def test_sigint(temp_db, key):
+def test_sigint(temp_db, key) -> None:
     # test two consecutive signit required to exit shell
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_control_statement(key)
     test.send_control_statement(key)
     assert test.shell_process.expect_exact(["kuzu", pexpect.EOF]) == 1
-    
+
     # test sending line interupts the two signits to quit
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -28,49 +30,49 @@ def test_sigint(temp_db, key):
     test.send_control_statement(key)
     test.send_control_statement(key)
     assert test.shell_process.expect_exact(["kuzu", pexpect.EOF]) == 1
-    
+
     # test sigint cancels the query
     test = ShellTest().add_argument(temp_db)
     test.start()
-    test.send_statement('CREATE NODE TABLE t0(i STRING, PRIMARY KEY(i));')
+    test.send_statement("CREATE NODE TABLE t0(i STRING, PRIMARY KEY(i));")
     test.send_control_statement(key)
     test.send_finished_statement("MATCH (a:t0) RETURN *;\r")
-    assert test.shell_process.expect_exact(["Error: Binder exception: Table t0 does not exist.", pexpect.EOF]) == 0
-    
+    assert (
+        test.shell_process.expect_exact(
+            ["Error: Binder exception: Table t0 does not exist.", pexpect.EOF],
+        )
+        == 0
+    )
+
 
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.ENTER.value),
-        ('\n'),
+        KEY_ACTION.ENTER.value,
+        "\n",
     ],
 )
-def test_enter(temp_db, key, history_path):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("-p")
-        .add_argument(history_path)
-    )
+def test_enter(temp_db, key, history_path) -> None:
+    test = ShellTest().add_argument(temp_db).add_argument("-p").add_argument(history_path)
     test.start()
     test.send_statement('RETURN "databases rule" AS a;')
     test.send_finished_statement(key)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
     assert test.shell_process.expect_exact(["kuzu", pexpect.EOF]) == 0
-    f = open(os.path.join(history_path, "history.txt"))
-    assert f.readline() == 'RETURN "databases rule" AS a;\n'
-    f.close()
-    deleteIfExists(os.path.join(history_path, 'history.txt'))
-    
+
+    with open(os.path.join(history_path, "history.txt")) as f:
+        assert f.readline() == 'RETURN "databases rule" AS a;\n'
+    deleteIfExists(os.path.join(history_path, "history.txt"))
+
 
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.BACKSPACE.value),
-        (KEY_ACTION.CTRL_H.value),
+        KEY_ACTION.BACKSPACE.value,
+        KEY_ACTION.CTRL_H.value,
     ],
 )
-def test_backspace(temp_db, key):
+def test_backspace(temp_db, key) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a;abc')
@@ -79,7 +81,7 @@ def test_backspace(temp_db, key):
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_d(temp_db):
+def test_ctrl_d(temp_db) -> None:
     # ctrl d acts as EOF when line is empty
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -90,46 +92,46 @@ def test_ctrl_d(temp_db):
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a;abc')
-    test.send_statement("\x1b[D" * 3) # move cursor to the left
+    test.send_statement("\x1b[D" * 3)  # move cursor to the left
     for _ in range(4):
         test.send_control_statement(KEY_ACTION.CTRL_D.value)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_ctrl_t(temp_db):
+
+def test_ctrl_t(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS ;a')
-    test.send_statement("\x1b[D") # move cursor to the left
+    test.send_statement("\x1b[D")  # move cursor to the left
     test.send_control_statement(KEY_ACTION.CTRL_T.value)
-    test.shell_process.sendcontrol(KEY_ACTION.CTRL_T.value) # line does not refresh 
+    test.shell_process.sendcontrol(KEY_ACTION.CTRL_T.value)  # line does not refresh
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_ctrl_b(temp_db):
+
+def test_ctrl_b(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
-    test.send_statement(';')
+    test.send_statement(";")
     test.send_control_statement(KEY_ACTION.CTRL_B.value)
-    test.shell_process.sendcontrol(KEY_ACTION.CTRL_B.value) # line does not refresh 
+    test.shell_process.sendcontrol(KEY_ACTION.CTRL_B.value)  # line does not refresh
     test.send_finished_statement('RETURN "databases rule" AS a\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_ctrl_f(temp_db):
+
+def test_ctrl_f(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a')
-    test.send_statement("\x1b[D") # move cursor to the left
+    test.send_statement("\x1b[D")  # move cursor to the left
     test.send_control_statement(KEY_ACTION.CTRL_F.value)
-    test.shell_process.sendcontrol(KEY_ACTION.CTRL_F.value) # line does not refresh 
-    test.send_finished_statement(';\r')
+    test.shell_process.sendcontrol(KEY_ACTION.CTRL_F.value)  # line does not refresh
+    test.send_finished_statement(";\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-   
-    
-def test_ctrl_p(temp_db):
+
+
+def test_ctrl_p(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
@@ -137,36 +139,36 @@ def test_ctrl_p(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_P.value)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_ctrl_n(temp_db):
+
+def test_ctrl_n(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "kuzu is cool" AS b;\r')
     assert test.shell_process.expect_exact(["| kuzu is cool |", pexpect.EOF]) == 0
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    test.send_statement("\x1b[A" * 2) # move up in history
+    test.send_statement("\x1b[A" * 2)  # move up in history
     test.send_control_statement(KEY_ACTION.CTRL_N.value)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
 
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.CTRL_R.value),
-        (KEY_ACTION.CTRL_S.value),
+        KEY_ACTION.CTRL_R.value,
+        KEY_ACTION.CTRL_S.value,
     ],
 )
-def test_search(temp_db, key, history_path):
+def test_search(temp_db, key, history_path) -> None:
     # test search opens
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_control_statement(key)
     assert test.shell_process.expect_exact(["kuzu", pexpect.EOF]) == 0
     assert test.shell_process.expect_exact(["bck-i-search: _", pexpect.EOF]) == 0
-    
+
     # test successful search
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -175,30 +177,25 @@ def test_search(temp_db, key, history_path):
     test.send_finished_statement('RETURN "kuzu is cool" AS b;\r')
     assert test.shell_process.expect_exact(["| kuzu is cool |", pexpect.EOF]) == 0
     test.send_control_statement(key)
-    test.send_statement('databases')
+    test.send_statement("databases")
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
     # test failing search
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("-p")
-        .add_argument(history_path)
-    )
+    test = ShellTest().add_argument(temp_db).add_argument("-p").add_argument(history_path)
     test.start()
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
     test.send_finished_statement('RETURN "kuzu is cool" AS b;\r')
     assert test.shell_process.expect_exact(["| kuzu is cool |", pexpect.EOF]) == 0
     test.send_control_statement(key)
-    test.send_statement('databases*******************')
+    test.send_statement("databases*******************")
     assert test.shell_process.expect_exact(["failing-bck-i-search:", pexpect.EOF]) == 0
     # enter should process last match
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    deleteIfExists(os.path.join(history_path, 'history.txt'))
-    
+    deleteIfExists(os.path.join(history_path, "history.txt"))
+
     # test starting search with text inputted already
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -208,92 +205,102 @@ def test_search(temp_db, key, history_path):
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_u(temp_db):
+def test_ctrl_u(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
-    test.send_statement('CREATE NODE TABLE t0(i STRING, PRIMARY KEY(i));')
+    test.send_statement("CREATE NODE TABLE t0(i STRING, PRIMARY KEY(i));")
     test.send_control_statement(KEY_ACTION.CTRL_U.value)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     test.send_finished_statement("MATCH (a:t0) RETURN *;\r")
-    assert test.shell_process.expect_exact(["Error: Binder exception: Table t0 does not exist.", pexpect.EOF]) == 0
+    assert (
+        test.shell_process.expect_exact(
+            ["Error: Binder exception: Table t0 does not exist.", pexpect.EOF],
+        )
+        == 0
+    )
 
 
-def test_ctrl_k(temp_db):
+def test_ctrl_k(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a;abc')
-    test.send_statement("\x1b[D" * 3) # move cursor to the left
+    test.send_statement("\x1b[D" * 3)  # move cursor to the left
     test.send_control_statement(KEY_ACTION.CTRL_K.value)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_a(temp_db):
+def test_ctrl_a(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('ETURN "databases rule" AS a;')
     test.send_control_statement(KEY_ACTION.CTRL_A.value)
-    test.send_finished_statement('R\r')
+    test.send_finished_statement("R\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_e(temp_db):
+def test_ctrl_e(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a')
-    test.send_statement("\x1b[H") # move cursor to the front
+    test.send_statement("\x1b[H")  # move cursor to the front
     test.send_control_statement(KEY_ACTION.CTRL_E.value)
-    test.send_finished_statement(';\r')
+    test.send_finished_statement(";\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_l(temp_db):
+def test_ctrl_l(temp_db) -> None:
     # clear screen with empty line
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_control_statement(KEY_ACTION.CTRL_L.value)
     assert test.shell_process.expect_exact(["\x1b[H\x1b[2J", pexpect.EOF]) == 0
-    
+
     # clear screen with non empty line
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a')
     test.send_control_statement(KEY_ACTION.CTRL_L.value)
     assert test.shell_process.expect_exact(["\x1b[H\x1b[2J", pexpect.EOF]) == 0
-    test.send_finished_statement(';\r')
+    test.send_finished_statement(";\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_w(temp_db):
+def test_ctrl_w(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a; abc def ghi ')
     test.send_statement(KEY_ACTION.CTRL_W.value * 3)
-    test.send_statement("\x1b[H") # move cursor to the front
+    test.send_statement("\x1b[H")  # move cursor to the front
     test.send_statement(KEY_ACTION.CTRL_W.value)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_tab(temp_db):
+def test_tab(temp_db) -> None:
     # tab is interpreted as four psaces when pasting input
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases\trule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases    rule |", pexpect.EOF]) == 0
-    
+
     # tab completion
     test = ShellTest().add_argument(temp_db)
     test.start()
-    test.send_statement('CRE')
+    test.send_statement("CRE")
     test.send_statement(KEY_ACTION.TAB.value)
-    test.send_statement(' N')
-    test.send_statement(KEY_ACTION.TAB.value)
-    test.send_statement(KEY_ACTION.TAB.value)
-    test.send_statement(' TAB')
+    test.send_statement(" N")
     test.send_statement(KEY_ACTION.TAB.value)
     test.send_statement(KEY_ACTION.TAB.value)
-    test.send_statement('LE t0(i STRING, PRIMARY KEY(i));')
+    test.send_statement(" TAB")
+    test.send_statement(KEY_ACTION.TAB.value)
+    test.send_statement(KEY_ACTION.TAB.value)
+    test.send_statement("LE t0(i STRING, PRIMARY KEY(i));")
     test.send_statement(KEY_ACTION.TAB.value)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
-    assert test.shell_process.expect_exact(["| Node table: t0 has been created. |", pexpect.EOF]) == 0
+    assert (
+        test.shell_process.expect_exact(
+            ["| Node table: t0 has been created. |", pexpect.EOF],
+        )
+        == 0
+    )

--- a/tools/shell/test/test_shell_control_search.py
+++ b/tools/shell/test/test_shell_control_search.py
@@ -1,10 +1,12 @@
-import pytest
+import os
+
 import pexpect
-from test_helper import *
+import pytest
 from conftest import ShellTest
+from test_helper import KEY_ACTION, deleteIfExists
 
 
-def set_up_search(test):
+def set_up_search(test) -> None:
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
     test.send_finished_statement('RETURN "kuzu is cool" AS b;\r')
@@ -17,27 +19,27 @@ def set_up_search(test):
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.ENTER.value),
-        ('\n'),
+        KEY_ACTION.ENTER.value,
+        "\n",
     ],
 )
-def test_enter(temp_db, key):
+def test_enter(temp_db, key) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     set_up_search(test)
     test.send_statement("databases")
     test.send_finished_statement(key)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
 
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.CTRL_R.value),
-        (KEY_ACTION.CTRL_N.value),
+        KEY_ACTION.CTRL_R.value,
+        KEY_ACTION.CTRL_N.value,
     ],
 )
-def test_search_next(temp_db, key, history_path):
+def test_search_next(temp_db, key, history_path) -> None:
     # test search next once
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -45,31 +47,26 @@ def test_search_next(temp_db, key, history_path):
     test.send_control_statement(key)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| the shell is fun |", pexpect.EOF]) == 0
-    
+
     # test search next until top of history
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("-p")
-        .add_argument(history_path)
-    )
+    test = ShellTest().add_argument(temp_db).add_argument("-p").add_argument(history_path)
     test.start()
     set_up_search(test)
     for _ in range(4):
         test.send_control_statement(key)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    deleteIfExists(os.path.join(history_path, 'history.txt'))
+    deleteIfExists(os.path.join(history_path, "history.txt"))
 
 
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.CTRL_S.value),
-        (KEY_ACTION.CTRL_P.value),
+        KEY_ACTION.CTRL_S.value,
+        KEY_ACTION.CTRL_P.value,
     ],
 )
-def test_search_prev(temp_db, key):
+def test_search_prev(temp_db, key) -> None:
     # test search prev once
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -79,7 +76,7 @@ def test_search_prev(temp_db, key):
     test.send_control_statement(key)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| the shell is fun |", pexpect.EOF]) == 0
-    
+
     # test search prev until bottom of history
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -96,13 +93,21 @@ def test_search_prev(temp_db, key):
         test.send_control_statement(key)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| searching history |", pexpect.EOF]) == 0
-    
 
-def test_ctrl_a(temp_db):
+
+def test_ctrl_a(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('"databases rule" AS a;\r')
-    assert test.shell_process.expect_exact(['Error: Parser exception: extraneous input \'"databases rule"\'', pexpect.EOF]) == 0
+    assert (
+        test.shell_process.expect_exact(
+            [
+                "Error: Parser exception: extraneous input '\"databases rule\"'",
+                pexpect.EOF,
+            ],
+        )
+        == 0
+    )
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("databases")
     test.send_control_statement(KEY_ACTION.CTRL_A.value)
@@ -111,7 +116,7 @@ def test_ctrl_a(temp_db):
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_tab(temp_db):
+def test_tab(temp_db) -> None:
     # test tab becomes space when part of pasted input
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -119,34 +124,44 @@ def test_tab(temp_db):
     test.send_statement("databases\trule")
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
     # test tab complete search and go to end of line
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases ;\r')
-    assert test.shell_process.expect_exact(['Error: Parser exception: Invalid input <RETURN ">:', pexpect.EOF]) == 0
+    assert (
+        test.shell_process.expect_exact(
+            ['Error: Parser exception: Invalid input <RETURN ">:', pexpect.EOF],
+        )
+        == 0
+    )
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("databases")
     test.send_statement(KEY_ACTION.TAB.value)
-    test.send_statement(KEY_ACTION.BACKSPACE.value) # remove semicolon
+    test.send_statement(KEY_ACTION.BACKSPACE.value)  # remove semicolon
     test.send_finished_statement('rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_ctrl_e(temp_db):
+
+def test_ctrl_e(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases ;\r')
-    assert test.shell_process.expect_exact(['Error: Parser exception: Invalid input <RETURN ">:', pexpect.EOF]) == 0
+    assert (
+        test.shell_process.expect_exact(
+            ['Error: Parser exception: Invalid input <RETURN ">:', pexpect.EOF],
+        )
+        == 0
+    )
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("databases")
     test.send_control_statement(KEY_ACTION.CTRL_E.value)
-    test.send_statement(KEY_ACTION.BACKSPACE.value) # remove semicolon
+    test.send_statement(KEY_ACTION.BACKSPACE.value)  # remove semicolon
     test.send_finished_statement('rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_ctrl_b(temp_db):
+
+def test_ctrl_b(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databasesrule" AS a;\r')
@@ -154,11 +169,11 @@ def test_ctrl_b(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("databasesr")
     test.send_control_statement(KEY_ACTION.CTRL_B.value)
-    test.send_finished_statement(' \r')
+    test.send_finished_statement(" \r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_f(temp_db):
+def test_ctrl_f(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databasesrule" AS a;\r')
@@ -166,11 +181,11 @@ def test_ctrl_f(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("database")
     test.send_control_statement(KEY_ACTION.CTRL_F.value)
-    test.send_finished_statement(' \r')
+    test.send_finished_statement(" \r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_t(temp_db):
+def test_ctrl_t(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "database srule" AS a;\r')
@@ -178,11 +193,11 @@ def test_ctrl_t(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("database ")
     test.send_control_statement(KEY_ACTION.CTRL_T.value)
-    test.send_finished_statement('\r')
+    test.send_finished_statement("\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_u(temp_db):
+def test_ctrl_u(temp_db) -> None:
     # check if line was cleared
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -193,7 +208,7 @@ def test_ctrl_u(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_U.value)
     test.send_finished_statement('RETURN "kuzu is cool" AS a;\r')
     assert test.shell_process.expect_exact(["| kuzu is cool |", pexpect.EOF]) == 0
-    
+
     # check if position in history was maintained
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -201,11 +216,11 @@ def test_ctrl_u(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("is cool")
     test.send_control_statement(KEY_ACTION.CTRL_U.value)
-    test.send_finished_statement("\x1b[A\r") # move up in history
+    test.send_finished_statement("\x1b[A\r")  # move up in history
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_k(temp_db):
+def test_ctrl_k(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases rule" AS aabc;\r')
@@ -213,21 +228,21 @@ def test_ctrl_k(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("As a")
     test.send_control_statement(KEY_ACTION.CTRL_K.value)
-    test.send_finished_statement(';\r')
+    test.send_finished_statement(";\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_d(temp_db):
+def test_ctrl_d(temp_db) -> None:
     # ctrl d accepts search and acts as EOF when line is empty
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_control_statement(KEY_ACTION.CTRL_D.value)
-    #search gets accepted
+    # search gets accepted
     assert test.shell_process.expect_exact(["kuzu", pexpect.EOF]) == 0
     # acts as EOF
     assert test.shell_process.expect_exact(["kuzu", pexpect.EOF]) == 1
-    
+
     # test accepts search and delete
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -240,8 +255,8 @@ def test_ctrl_d(temp_db):
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_ctrl_l(temp_db):
-    #clear screen with empty line
+def test_ctrl_l(temp_db) -> None:
+    # clear screen with empty line
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
@@ -252,7 +267,7 @@ def test_ctrl_l(temp_db):
     test.send_statement("databases")
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
     # clear screen with non empty line
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -262,16 +277,16 @@ def test_ctrl_l(temp_db):
     assert test.shell_process.expect_exact(["\x1b[H\x1b[2J", pexpect.EOF]) == 0
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
 
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.CTRL_C.value),
-        (KEY_ACTION.CTRL_G.value),
-    ]
+        KEY_ACTION.CTRL_C.value,
+        KEY_ACTION.CTRL_G.value,
+    ],
 )
-def test_cancel_search(temp_db, key):
+def test_cancel_search(temp_db, key) -> None:
     # check if line is cleared
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -282,7 +297,7 @@ def test_cancel_search(temp_db, key):
     test.send_control_statement(key)
     test.send_finished_statement('RETURN "kuzu is cool" AS a;\r')
     assert test.shell_process.expect_exact(["| kuzu is cool |", pexpect.EOF]) == 0
-    
+
     # check if position in history was maintained
     test = ShellTest().add_argument(temp_db)
     test.start()
@@ -290,7 +305,7 @@ def test_cancel_search(temp_db, key):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("is cool")
     test.send_control_statement(KEY_ACTION.CTRL_U.value)
-    test.send_statement("\x1b[B") # move down in history
+    test.send_statement("\x1b[B")  # move down in history
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
@@ -298,12 +313,12 @@ def test_cancel_search(temp_db, key):
 @pytest.mark.parametrize(
     "key",
     [
-        (KEY_ACTION.CTRL_H.value),
-        (KEY_ACTION.BACKSPACE.value),
-        (KEY_ACTION.CTRL_W.value)
-    ]
+        KEY_ACTION.CTRL_H.value,
+        KEY_ACTION.BACKSPACE.value,
+        KEY_ACTION.CTRL_W.value,
+    ],
 )
-def test_backspace(temp_db, key):
+def test_backspace(temp_db, key) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases rule" AS a;\r')

--- a/tools/shell/test/test_shell_esc_edit.py
+++ b/tools/shell/test/test_shell_esc_edit.py
@@ -1,37 +1,37 @@
-import pytest
 import pexpect
-from test_helper import *
+import pytest
 from conftest import ShellTest
+from test_helper import KEY_ACTION
 
 
 @pytest.mark.parametrize(
     "esc",
     [
-        ("\x1bb"),
-        ("\x1b[1;5D"),
+        "\x1bb",
+        "\x1b[1;5D",
     ],
 )
-def test_move_word_left(temp_db, esc):
+def test_move_word_left(temp_db, esc) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement("RETURN AS a;")
     test.send_statement(esc * 3)
     test.send_finished_statement(' "databases rule"\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
 
 @pytest.mark.parametrize(
     "esc",
     [
-        ("\x1bf"),
-        ("\x1b[1;5C"),
+        "\x1bf",
+        "\x1b[1;5C",
     ],
 )
-def test_move_word_right(temp_db, esc):
+def test_move_word_right(temp_db, esc) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases a;')
-    test.send_control_statement(KEY_ACTION.CTRL_A.value) # move cursor to front of line
+    test.send_control_statement(KEY_ACTION.CTRL_A.value)  # move cursor to front of line
     test.send_statement(esc * 3)
     test.send_finished_statement(' rule" AS\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
@@ -40,21 +40,21 @@ def test_move_word_right(temp_db, esc):
 @pytest.mark.parametrize(
     "esc",
     [
-        ("\x1b[H"),
-        ("\x1b[1~"),
-        ("\x1bOH"),
-    ]
+        "\x1b[H",
+        "\x1b[1~",
+        "\x1bOH",
+    ],
 )
-def test_move_home(temp_db, esc):
+def test_move_home(temp_db, esc) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('ETURN "databases rule" AS a;')
     test.send_statement(esc)
-    test.send_finished_statement('R\r')
+    test.send_finished_statement("R\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_delete(temp_db):
+
+def test_delete(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a;abc')
@@ -63,27 +63,27 @@ def test_delete(temp_db):
     test.send_statement("\x1b[3~" * 4)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
 
 @pytest.mark.parametrize(
     "esc",
     [
-        ("\x1b[F"),
-        ("\x1b[4~"),
-        ("\x1bOF"),
-    ]
+        "\x1b[F",
+        "\x1b[4~",
+        "\x1bOF",
+    ],
 )
-def test_move_end(temp_db, esc):
+def test_move_end(temp_db, esc) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a')
-    test.send_control_statement(KEY_ACTION.CTRL_A.value) # move cursor to front of line
+    test.send_control_statement(KEY_ACTION.CTRL_A.value)  # move cursor to front of line
     test.send_statement(esc)
-    test.send_finished_statement(';\r')
+    test.send_finished_statement(";\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_next_history(temp_db):
+def test_next_history(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
@@ -91,37 +91,37 @@ def test_next_history(temp_db):
     test.send_statement("\x1b[A")
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_prev_history(temp_db):
+
+def test_prev_history(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "kuzu is cool" AS b;\r')
     assert test.shell_process.expect_exact(["| kuzu is cool |", pexpect.EOF]) == 0
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    test.send_control_statement(KEY_ACTION.CTRL_P.value) # move up in history
-    test.send_control_statement(KEY_ACTION.CTRL_P.value) # move up in history
+    test.send_control_statement(KEY_ACTION.CTRL_P.value)  # move up in history
+    test.send_control_statement(KEY_ACTION.CTRL_P.value)  # move up in history
     test.send_statement("\x1b[B")
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_move_left(temp_db):
+
+def test_move_left(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
-    test.send_statement(' a;')
+    test.send_statement(" a;")
     test.send_statement("\x1b[D" * 4)
     test.send_finished_statement('RETURN "databases rule" AS\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_move_right(temp_db):
+
+def test_move_right(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_statement('RETURN "databases rule" AS a')
     for _ in range(3):
-        test.send_control_statement(KEY_ACTION.CTRL_B.value) # move cursor to the left 
-    test.send_statement("\x1b[C" * 4) 
-    test.send_finished_statement(';\r')
+        test.send_control_statement(KEY_ACTION.CTRL_B.value)  # move cursor to the left
+    test.send_statement("\x1b[C" * 4)
+    test.send_finished_statement(";\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0

--- a/tools/shell/test/test_shell_esc_search.py
+++ b/tools/shell/test/test_shell_esc_search.py
@@ -1,10 +1,10 @@
-import pytest
 import pexpect
-from test_helper import *
+import pytest
 from conftest import ShellTest
+from test_helper import KEY_ACTION
 
 
-def set_up_search(test):
+def set_up_search(test) -> None:
     test.send_finished_statement('RETURN "databases rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
     test.send_finished_statement('RETURN "kuzu is cool" AS b;\r')
@@ -12,9 +12,9 @@ def set_up_search(test):
     test.send_finished_statement('RETURN "the shell is fun" AS c;\r')
     assert test.shell_process.expect_exact(["| the shell is fun |", pexpect.EOF]) == 0
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
-    
 
-def test_accept_search(temp_db):
+
+def test_accept_search(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases" AS a;\r')
@@ -24,21 +24,29 @@ def test_accept_search(temp_db):
     test.send_statement("\x1b\x1b")
     test.send_finished_statement(" rule\r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
+
 
 @pytest.mark.parametrize(
     "esc",
     [
-        ("\x1b[H"),
-        ("\x1b[1~"),
-        ("\x1bOH"),
-    ]
+        "\x1b[H",
+        "\x1b[1~",
+        "\x1bOH",
+    ],
 )
-def test_accept_move_home(temp_db, esc):
+def test_accept_move_home(temp_db, esc) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('"databases rule" AS a;\r')
-    assert test.shell_process.expect_exact(['Error: Parser exception: extraneous input \'"databases rule"\'', pexpect.EOF]) == 0
+    assert (
+        test.shell_process.expect_exact(
+            [
+                "Error: Parser exception: extraneous input '\"databases rule\"'",
+                pexpect.EOF,
+            ],
+        )
+        == 0
+    )
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("databases")
     test.send_statement(esc)
@@ -50,26 +58,31 @@ def test_accept_move_home(temp_db, esc):
 @pytest.mark.parametrize(
     "esc",
     [
-        ("\x1b[4~"),
-        ("\x1b[8~"),
-        ("\x1b[F"),
-        ("\x1bOF"),
-    ]        
+        "\x1b[4~",
+        "\x1b[8~",
+        "\x1b[F",
+        "\x1bOF",
+    ],
 )
-def test_accept_move_end(temp_db, esc):
+def test_accept_move_end(temp_db, esc) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databases ;\r')
-    assert test.shell_process.expect_exact(['Error: Parser exception: Invalid input <RETURN ">:', pexpect.EOF]) == 0
+    assert (
+        test.shell_process.expect_exact(
+            ['Error: Parser exception: Invalid input <RETURN ">:', pexpect.EOF],
+        )
+        == 0
+    )
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("databases")
     test.send_statement(esc)
-    test.send_statement(KEY_ACTION.BACKSPACE.value) # remove semicolon
+    test.send_statement(KEY_ACTION.BACKSPACE.value)  # remove semicolon
     test.send_finished_statement('rule" AS a;\r')
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_next_history(temp_db):
+def test_next_history(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     set_up_search(test)
@@ -78,9 +91,9 @@ def test_next_history(temp_db):
     test.send_statement("\x1b[A" * 2)
     test.send_finished_statement(KEY_ACTION.ENTER.value)
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
-    
 
-def test_prev_history(temp_db):
+
+def test_prev_history(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     set_up_search(test)
@@ -91,7 +104,7 @@ def test_prev_history(temp_db):
     assert test.shell_process.expect_exact(["| the shell is fun |", pexpect.EOF]) == 0
 
 
-def test_move_left(temp_db):
+def test_move_left(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databasesrule" AS a;\r')
@@ -99,11 +112,11 @@ def test_move_left(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("databasesr")
     test.send_statement("\x1b[D")
-    test.send_finished_statement(' \r')
+    test.send_finished_statement(" \r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0
 
 
-def test_move_right(temp_db):
+def test_move_right(temp_db) -> None:
     test = ShellTest().add_argument(temp_db)
     test.start()
     test.send_finished_statement('RETURN "databasesrule" AS a;\r')
@@ -111,5 +124,5 @@ def test_move_right(temp_db):
     test.send_control_statement(KEY_ACTION.CTRL_R.value)
     test.send_statement("database")
     test.send_statement("\x1b[C")
-    test.send_finished_statement(' \r')
+    test.send_finished_statement(" \r")
     assert test.shell_process.expect_exact(["| databases rule |", pexpect.EOF]) == 0

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -1,115 +1,79 @@
-import pytest
-from test_helper import *
-from conftest import ShellTest
 import os
 
+import pytest
+from conftest import ShellTest
+from test_helper import KUZU_VERSION, deleteIfExists
 
-def test_database_path(temp_db):
+
+def test_database_path(temp_db) -> None:
     # no database path
-    test = (
-        ShellTest()
-        .statement('RETURN "databases rule" AS a;')
-    )
+    test = ShellTest().statement('RETURN "databases rule" AS a;')
     result = test.run()
     result.check_stderr("Option 'databasePath' is required")
-    
+
     # invalid database path
-    test = (
-        ShellTest()
-        .add_argument("///////")
-        .statement('RETURN "databases rule" AS a;')
-    )
+    test = ShellTest().add_argument("///////").statement('RETURN "databases rule" AS a;')
     result = test.run()
     result.check_stderr("Cannot open file ///////.lock: Permission denied")
-    
+
     # valid database path
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .statement('RETURN "databases rule" AS a;')
-    )
+    test = ShellTest().add_argument(temp_db).statement('RETURN "databases rule" AS a;')
     result = test.run()
     result.check_stdout("databases rule")
 
 
 @pytest.mark.parametrize(
     "flag",
-    [
-        ("-h"),
-        ("--help"),
-    ],
+    ["-h", "--help"],
 )
-def test_help(temp_db, flag):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument(flag)
-    )
+def test_help(temp_db, flag) -> None:
+    test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
     result.check_stderr("help")
-    
+
 
 @pytest.mark.parametrize(
     "flag",
     [
-        ("-d"),
-        ("--defaultBPSize"),
+        "-d",
+        "--defaultBPSize",
     ],
 )
-def test_default_bp_size(temp_db, flag):
+def test_default_bp_size(temp_db, flag) -> None:
     # empty flag argument
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument(flag)
-    )
+    test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
-    result.check_stderr(f"Flag '{flag.replace('-', '')}' requires an argument but received none")
-    
-    # flag argument is not a number
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument(flag)
-        .add_argument("kuzu")
+    result.check_stderr(
+        f"Flag '{flag.replace('-', '')}' requires an argument but received none",
     )
+
+    # flag argument is not a number
+    test = ShellTest().add_argument(temp_db).add_argument(flag).add_argument("kuzu")
     result = test.run()
     result.check_stderr("Argument '' received invalid value type 'kuzu'")
-    
-    # successful flag
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument(flag)
-        .add_argument("1000")
-    )
-    result = test.run()
-    result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
-    
 
-def test_no_compression(temp_db):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("--nocompression")
-    )
+    # successful flag
+    test = ShellTest().add_argument(temp_db).add_argument(flag).add_argument("1000")
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
-    
+
+
+def test_no_compression(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db).add_argument("--nocompression")
+    result = test.run()
+    result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
+
 
 @pytest.mark.parametrize(
     "flag",
     [
-        ("-r"),
-        ("--readOnly"),
+        "-r",
+        "--readOnly",
     ],
 )
-def test_read_only(temp_db, flag):
+def test_read_only(temp_db, flag) -> None:
     # cannot open an empty database in read only mode so initialize database
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-    )
+    test = ShellTest().add_argument(temp_db)
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
 
@@ -125,30 +89,23 @@ def test_read_only(temp_db, flag):
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-only mode.")
     result.check_stdout("databases rule")
-    result.check_stdout("Error: Cannot execute write operations in a read-only database!")
-    result.check_stdout("kuzu is cool")
-    
-
-def test_history_path(temp_db, history_path):
-    # empty flag argument
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("-p")
+    result.check_stdout(
+        "Error: Cannot execute write operations in a read-only database!",
     )
+    result.check_stdout("kuzu is cool")
+
+
+def test_history_path(temp_db, history_path) -> None:
+    # empty flag argument
+    test = ShellTest().add_argument(temp_db).add_argument("-p")
     result = test.run()
     result.check_stderr("Flag 'p' requires an argument but received none")
-    
+
     # invalid path
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("-p")
-        .add_argument("///////")
-    )
+    test = ShellTest().add_argument(temp_db).add_argument("-p").add_argument("///////")
     result = test.run()
     result.check_stderr("Invalid path to directory for history file")
-    
+
     # valid path, file doesn't exist
     test = (
         ShellTest()
@@ -159,10 +116,9 @@ def test_history_path(temp_db, history_path):
     )
     result = test.run()
     result.check_stdout("databases rule")
-    f = open(os.path.join(history_path, "history.txt"))
-    assert f.readline() == 'RETURN "databases rule" AS a;\n'
-    f.close()
-    
+    with open(os.path.join(history_path, "history.txt")) as f:
+        assert f.readline() == 'RETURN "databases rule" AS a;\n'
+
     # valid path, file exists
     test = (
         ShellTest()
@@ -172,44 +128,31 @@ def test_history_path(temp_db, history_path):
         .statement('RETURN "kuzu is cool" AS b;')
     )
     result = test.run()
-    f = open(os.path.join(history_path, "history.txt"))
-    assert f.readline() == 'RETURN "databases rule" AS a;\n'
-    assert f.readline() == 'RETURN "kuzu is cool" AS b;\n'
-    f.close()
-    
-    deleteIfExists(os.path.join(history_path, 'history.txt'))
-        
+    with open(os.path.join(history_path, "history.txt")) as f:
+        assert f.readline() == 'RETURN "databases rule" AS a;\n'
+        assert f.readline() == 'RETURN "kuzu is cool" AS b;\n'
+
+    deleteIfExists(os.path.join(history_path, "history.txt"))
+
 
 @pytest.mark.parametrize(
     "flag",
     [
-        ("-v"),
-        ("--version"),
+        "-v",
+        "--version",
     ],
 )
-def test_version(temp_db, flag):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument(flag)
-    )
+def test_version(temp_db, flag) -> None:
+    test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
     result.check_stdout(KUZU_VERSION)
-    
 
-def test_bad_flag(temp_db):
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("-b")
-    )
+
+def test_bad_flag(temp_db) -> None:
+    test = ShellTest().add_argument(temp_db).add_argument("-b")
     result = test.run()
-    result.check_stderr(f"Flag could not be matched: 'b'")
-    
-    test = (
-        ShellTest()
-        .add_argument(temp_db)
-        .add_argument("--badflag")
-    )
+    result.check_stderr("Flag could not be matched: 'b'")
+
+    test = ShellTest().add_argument(temp_db).add_argument("--badflag")
     result = test.run()
-    result.check_stderr(f"Flag could not be matched: badflag")
+    result.check_stderr("Flag could not be matched: badflag")


### PR DESCRIPTION
Along the same lines as https://github.com/kuzudb/kuzu/pull/3023.

* Applies formatting and a subset of the lint rules (a follow-up can handle the remaining lint).
* Does not apply any function signature or return  typing yet.
