### PR TITLE
fix IMPORT_DATABASE path

### DIFF
--- a/src/catalog/catalog_entry/node_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/node_table_catalog_entry.cpp
@@ -1,7 +1,5 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 
-#include <sstream>
-
 namespace kuzu {
 namespace catalog {
 
@@ -44,11 +42,8 @@ std::unique_ptr<CatalogEntry> NodeTableCatalogEntry::copy() const {
 }
 
 std::string NodeTableCatalogEntry::toCypher(main::ClientContext* /*clientContext*/) const {
-    std::stringstream ss;
-    ss << "CREATE NODE TABLE " << getName() << "(";
-    Property::toCypher(getPropertiesRef(), ss);
-    ss << " PRIMARY KEY(" << getPrimaryKey()->getName() << "));";
-    return ss.str();
+    return common::stringFormat("CREATE NODE TABLE {} ({} PRIMARY KEY({}));", getName(),
+        Property::toCypher(getPropertiesRef()), getPrimaryKey()->getName());
 }
 
 } // namespace catalog

--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -83,12 +83,12 @@ std::string RelTableCatalogEntry::toCypher(main::ClientContext* clientContext) c
     auto catalog = clientContext->getCatalog();
     auto srcTableName = catalog->getTableName(clientContext->getTx(), srcTableID);
     auto dstTableName = catalog->getTableName(clientContext->getTx(), dstTableID);
-    ss << "CREATE REL TABLE " << getName() << "( FROM " << srcTableName << " TO " << dstTableName
-       << ", ";
-    Property::toCypher(getPropertiesRef(), ss);
-    auto srcMultiStr = srcMultiplicity == RelMultiplicity::MANY ? "MANY" : "ONE";
-    auto dstMultiStr = dstMultiplicity == RelMultiplicity::MANY ? "MANY" : "ONE";
-    ss << srcMultiStr << "_" << dstMultiStr << ");";
+    auto srcMultiStr = srcMultiplicity == common::RelMultiplicity::MANY ? "MANY" : "ONE";
+    auto dstMultiStr = dstMultiplicity == common::RelMultiplicity::MANY ? "MANY" : "ONE";
+    std::string tableInfo =
+        stringFormat("CREATE REL TABLE {} (FROM {} TO {}, ", getName(), srcTableName, dstTableName);
+    ss << tableInfo << Property::toCypher(getPropertiesRef()) << srcMultiStr << "_" << dstMultiStr
+       << ");";
     return ss.str();
 }
 

--- a/src/catalog/property.cpp
+++ b/src/catalog/property.cpp
@@ -29,8 +29,8 @@ Property Property::deserialize(Deserializer& deserializer) {
     return Property(name, std::move(dataType), propertyID, tableID);
 }
 
-void Property::toCypher(
-    const std::vector<kuzu::catalog::Property>& properties, std::stringstream& ss) {
+std::string Property::toCypher(const std::vector<kuzu::catalog::Property>& properties) {
+    std::stringstream ss;
     for (auto& prop : properties) {
         if (prop.getDataType()->getPhysicalType() == PhysicalTypeID::INTERNAL_ID) {
             continue;
@@ -42,6 +42,7 @@ void Property::toCypher(
         }
         ss << prop.getName() << " " << propStr << ",";
     }
+    return ss.str();
 }
 
 } // namespace catalog

--- a/src/function/scalar_macro_function.cpp
+++ b/src/function/scalar_macro_function.cpp
@@ -1,9 +1,8 @@
 #include "function/scalar_macro_function.h"
 
-#include <sstream>
-
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
+#include "common/string_format.h"
 #include "common/string_utils.h"
 
 using namespace kuzu::common;
@@ -59,7 +58,6 @@ std::unique_ptr<ScalarMacroFunction> ScalarMacroFunction::deserialize(Deserializ
 }
 
 std::string ScalarMacroFunction::toCypher(const std::string& name) const {
-    std::stringstream ss;
     std::vector<std::string> paramStrings;
     for (auto& param : positionalArgs) {
         paramStrings.push_back(param);
@@ -67,9 +65,8 @@ std::string ScalarMacroFunction::toCypher(const std::string& name) const {
     for (auto& defaultParam : defaultArgs) {
         paramStrings.push_back(defaultParam.first + ":=" + defaultParam.second->toString());
     }
-    ss << "CREATE MACRO " << name << "(" << StringUtils::join(paramStrings, ",") << ") AS "
-       << expression->toString();
-    return ss.str();
+    return stringFormat("CREATE MACRO {} ({}) AS {}", name, StringUtils::join(paramStrings, ","),
+        expression->toString());
 }
 } // namespace function
 } // namespace kuzu

--- a/src/include/catalog/property.h
+++ b/src/include/catalog/property.h
@@ -35,8 +35,7 @@ public:
     void serialize(common::Serializer& serializer) const;
     static Property deserialize(common::Deserializer& deserializer);
 
-    static void toCypher(
-        const std::vector<kuzu::catalog::Property>& properties, std::stringstream& ss);
+    static std::string toCypher(const std::vector<kuzu::catalog::Property>& properties);
 
 private:
     Property(const Property& other)

--- a/src/include/common/copier_config/csv_reader_config.h
+++ b/src/include/common/copier_config/csv_reader_config.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <sstream>
-
 #include "common/constants.h"
 #include "common/copy_constructors.h"
 #include "common/types/value/value.h"
@@ -23,16 +21,11 @@ struct CSVOption {
           hasHeader{CopyConstants::DEFAULT_CSV_HAS_HEADER} {}
     EXPLICIT_COPY_DEFAULT_MOVE(CSVOption);
 
+    // TODO: COPY FROM and COPY TO should support transform special options, like '\'.
     std::string toCypher() const {
-        std::stringstream ss;
-        ss << " (escape = '\\" << escapeChar << "' , delim = '" << delimiter << "' , quote = '\\"
-           << quoteChar << "', header=";
-        if (hasHeader) {
-            ss << "true);";
-        } else {
-            ss << "false);";
-        }
-        return ss.str();
+        std::string header = hasHeader ? "true" : "false";
+        return stringFormat("(escape ='\\{}', delim ='{}', quote='\\{}', header={})", escapeChar,
+            delimiter, quoteChar, header);
     }
 
 private:

--- a/src/processor/operator/persistent/export_db.cpp
+++ b/src/processor/operator/persistent/export_db.cpp
@@ -29,13 +29,11 @@ static void writeStringStreamToFile(
 
 static void writeCopyStatement(
     stringstream& ss, std::string tableName, ReaderConfig* boundFileInfo) {
-    ss << "COPY ";
-    ss << tableName << " FROM \"" << boundFileInfo->filePaths[0] << "/" << tableName;
     auto fileTypeStr = FileTypeUtils::toString(boundFileInfo->fileType);
     StringUtils::toLower(fileTypeStr);
-    ss << "." << fileTypeStr;
     auto csvConfig = common::CSVReaderConfig::construct(boundFileInfo->options);
-    ss << "\"" << csvConfig.option.toCypher() << std::endl;
+    ss << stringFormat("COPY {} FROM \"{}.{}\" {};\n", tableName, tableName, fileTypeStr,
+        csvConfig.option.toCypher());
 }
 
 std::string getSchemaCypher(main::ClientContext* clientContext, transaction::Transaction* tx) {


### PR DESCRIPTION
When we execute the export database statement `"export database 'path1' "`, we will export data in a directory `'path1'`, along with csv cyphers, data cyphers, and macro cyphers for import database later. The copy statement is just like `copy xx from path1/tablename`. Assume we move this exported data directory to other directories, or to other platforms, and then want to import it with `import database 'path2'.` Then the path1 in copy statement is not correct. This PR is to replace the path in copy statements with path2, i.e., the bounded import file path. 