### PR TITLE
Fix Hash index split slot ID when reserving a number of slots which are a power of two

### DIFF
--- a/src/include/common/case_insensitive_map.h
+++ b/src/include/common/case_insensitive_map.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_map>
 


### PR DESCRIPTION
E.g.
When reserving 64 slots, numSlotsOfCurrentLevel will be 32 instead of 64, and the nextSplitSlotId will be 32, instead of 0. 

This shouldn't cause any issues, but the behaviour wasn't what I was expecting and it does some unnecessary work.
1. Since the levelHashMask is 31, all slots calculated using it will be less than the nextSplitSlotId (in getPrimarySlotIdForHash) and use the higherLevelHashMask (which is the same if we had instead increased the level by one and reset nextSplitSlotId to 0).
2. The first time `splitSlot` is called it will split slot 32, but entries used the higherLevelHashMask when inserting into it originally,  so all the entries get hashed back into the same slot, and then the level will be incremented and nextSplitSlotId will be reset to 0.

(Also added a missing include that's necessary with newer versions of gcc because `<string>` no longer implicitly includes it)