### PR TITLE
Copy table function instead of passing raw pointer

### DIFF
--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<BoundBaseScanSource> Binder::bindScanSource(BaseScanSource* sour
         auto func = getScanFunction(config->fileType, *config);
         auto bindInput = std::make_unique<ScanTableFuncBindInput>(config->copy(),
             std::move(expectedColumnNames), std::move(expectedColumnTypes), clientContext);
-        auto bindData = func->bindFunc(clientContext, bindInput.get());
+        auto bindData = func.bindFunc(clientContext, bindInput.get());
         // Bind input columns
         expression_vector inputColumns;
         for (auto i = 0u; i < bindData->columnTypes.size(); i++) {

--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -57,7 +57,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(
                BuiltInFunctionsUtils::matchFunction(READ_RDF_RESOURCE_FUNC_NAME, functions);
     auto rScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
     auto rColumns = expression_vector{r};
-    auto rFileScanInfo = BoundFileScanInfo(rScanFunc, bindData->copy(), std::move(rColumns));
+    auto rFileScanInfo = BoundFileScanInfo(*rScanFunc, bindData->copy(), std::move(rColumns));
     auto rSource = std::make_unique<BoundFileScanSource>(std::move(rFileScanInfo));
     auto rTableID = rdfGraphEntry->getResourceTableID();
     auto rEntry = catalog->getTableCatalogEntry(clientContext->getTx(), rTableID);
@@ -68,7 +68,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(
                BuiltInFunctionsUtils::matchFunction(READ_RDF_LITERAL_FUNC_NAME, functions);
     auto lScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
     auto lColumns = expression_vector{l, lang};
-    auto lFileScanInfo = BoundFileScanInfo(lScanFunc, bindData->copy(), std::move(lColumns));
+    auto lFileScanInfo = BoundFileScanInfo(*lScanFunc, bindData->copy(), std::move(lColumns));
     auto lSource = std::make_unique<BoundFileScanSource>(std::move(lFileScanInfo));
     auto lTableID = rdfGraphEntry->getLiteralTableID();
     auto lEntry = catalog->getTableCatalogEntry(clientContext->getTx(), lTableID);
@@ -80,7 +80,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(
                BuiltInFunctionsUtils::matchFunction(READ_RDF_RESOURCE_TRIPLE_FUNC_NAME, functions);
     auto rrrScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
     auto rrrColumns = expression_vector{s, p, o};
-    auto rrrFileScanInfo = BoundFileScanInfo(rrrScanFunc, bindData->copy(), rrrColumns);
+    auto rrrFileScanInfo = BoundFileScanInfo(*rrrScanFunc, bindData->copy(), rrrColumns);
     auto rrrSource = std::make_unique<BoundFileScanSource>(std::move(rrrFileScanInfo));
     auto rrrTableID = rdfGraphEntry->getResourceTripleTableID();
     auto rrrEntry = catalog->getTableCatalogEntry(clientContext->getTx(), rrrTableID);
@@ -102,7 +102,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(
                BuiltInFunctionsUtils::matchFunction(READ_RDF_LITERAL_TRIPLE_FUNC_NAME, functions);
     auto rrlScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
     auto rrlColumns = expression_vector{s, p, oOffset};
-    auto rrlFileScanInfo = BoundFileScanInfo(rrlScanFunc, bindData->copy(), rrlColumns);
+    auto rrlFileScanInfo = BoundFileScanInfo(*rrlScanFunc, bindData->copy(), rrlColumns);
     auto rrlSource = std::make_unique<BoundFileScanSource>(std::move(rrlFileScanInfo));
     auto rrlTableID = rdfGraphEntry->getLiteralTripleTableID();
     auto rrlEntry = catalog->getTableCatalogEntry(clientContext->getTx(), rrlTableID);
@@ -119,7 +119,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(
         std::move(rCopyInfo), std::move(lCopyInfo), std::move(rrrCopyInfo), std::move(rrLCopyInfo));
     std::unique_ptr<BoundBaseScanSource> source;
     if (inMemory) {
-        auto fileScanInfo = BoundFileScanInfo(scanFunc, bindData->copy(), expression_vector{});
+        auto fileScanInfo = BoundFileScanInfo(*scanFunc, bindData->copy(), expression_vector{});
         source = std::make_unique<BoundFileScanSource>(std::move(fileScanInfo));
     } else {
         source = std::make_unique<BoundEmptyScanSource>();

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -216,7 +216,7 @@ void Binder::restoreScope(std::unique_ptr<BinderScope> prevVariableScope) {
     scope = std::move(prevVariableScope);
 }
 
-function::TableFunction* Binder::getScanFunction(FileType fileType, const ReaderConfig& config) {
+function::TableFunction Binder::getScanFunction(FileType fileType, const ReaderConfig& config) {
     function::Function* func;
     auto stringType = LogicalType(LogicalTypeID::STRING);
     std::vector<LogicalType> inputTypes;
@@ -240,7 +240,7 @@ function::TableFunction* Binder::getScanFunction(FileType fileType, const Reader
     default:
         KU_UNREACHABLE;
     }
-    return ku_dynamic_cast<function::Function*, function::TableFunction*>(func);
+    return *ku_dynamic_cast<function::Function*, function::TableFunction*>(func);
 }
 
 } // namespace binder

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -287,7 +287,7 @@ private:
     std::unique_ptr<BinderScope> saveScope();
     void restoreScope(std::unique_ptr<BinderScope> prevVariableScope);
 
-    function::TableFunction* getScanFunction(
+    function::TableFunction getScanFunction(
         common::FileType fileType, const common::ReaderConfig& config);
 
 private:

--- a/src/include/binder/copy/bound_file_scan_info.h
+++ b/src/include/binder/copy/bound_file_scan_info.h
@@ -8,18 +8,18 @@ namespace kuzu {
 namespace binder {
 
 struct BoundFileScanInfo {
-    function::TableFunction* copyFunc;
+    function::TableFunction func;
     std::unique_ptr<function::TableFuncBindData> bindData;
     binder::expression_vector columns;
 
-    BoundFileScanInfo(function::TableFunction* copyFunc,
+    BoundFileScanInfo(function::TableFunction func,
         std::unique_ptr<function::TableFuncBindData> bindData, binder::expression_vector columns)
-        : copyFunc{copyFunc}, bindData{std::move(bindData)}, columns{std::move(columns)} {}
+        : func{func}, bindData{std::move(bindData)}, columns{std::move(columns)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(BoundFileScanInfo);
 
 private:
     BoundFileScanInfo(const BoundFileScanInfo& other)
-        : copyFunc{other.copyFunc}, bindData{other.bindData->copy()}, columns{other.columns} {}
+        : func{other.func}, bindData{other.bindData->copy()}, columns{other.columns} {}
 };
 
 } // namespace binder

--- a/src/include/binder/query/reading_clause/bound_in_query_call.h
+++ b/src/include/binder/query/reading_clause/bound_in_query_call.h
@@ -10,23 +10,23 @@ namespace binder {
 
 class BoundInQueryCall : public BoundReadingClause {
 public:
-    BoundInQueryCall(function::TableFunction* tableFunc,
+    BoundInQueryCall(function::TableFunction tableFunc,
         std::unique_ptr<function::TableFuncBindData> bindData, expression_vector outExprs,
         std::shared_ptr<Expression> rowIdxExpr)
         : BoundReadingClause{common::ClauseType::IN_QUERY_CALL}, tableFunc{tableFunc},
           bindData{std::move(bindData)}, outExprs{std::move(outExprs)}, rowIdxExpr{std::move(
                                                                             rowIdxExpr)} {}
 
-    inline function::TableFunction* getTableFunc() const { return tableFunc; }
+    function::TableFunction getTableFunc() const { return tableFunc; }
 
-    inline const function::TableFuncBindData* getBindData() const { return bindData.get(); }
+    const function::TableFuncBindData* getBindData() const { return bindData.get(); }
 
-    inline expression_vector getOutExprs() const { return outExprs; }
+    expression_vector getOutExprs() const { return outExprs; }
 
-    inline std::shared_ptr<Expression> getRowIdxExpr() const { return rowIdxExpr; }
+    std::shared_ptr<Expression> getRowIdxExpr() const { return rowIdxExpr; }
 
 private:
-    function::TableFunction* tableFunc;
+    function::TableFunction tableFunc;
     std::unique_ptr<function::TableFuncBindData> bindData;
     expression_vector outExprs;
     std::shared_ptr<Expression> rowIdxExpr;

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -18,9 +18,10 @@ struct Function;
 using scalar_bind_func = std::function<std::unique_ptr<FunctionBindData>(
     const binder::expression_vector&, Function* definition)>;
 
-enum class FunctionType : uint8_t { SCALAR, AGGREGATE, TABLE };
+enum class FunctionType : uint8_t { UNKNOWN = 0, SCALAR = 1, AGGREGATE = 2, TABLE = 3 };
 
 struct Function {
+    Function() : type{FunctionType::UNKNOWN} {};
     Function(
         FunctionType type, std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs)
         : type{type}, name{std::move(name)}, parameterTypeIDs{std::move(parameterTypeIDs)} {}

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -80,6 +80,9 @@ struct TableFunction : public Function {
     table_func_init_local_t initLocalStateFunc;
     table_func_can_parallel_t canParallelFunc = [] { return true; };
 
+    TableFunction()
+        : Function{}, tableFunc{nullptr}, bindFunc{nullptr}, initSharedStateFunc{nullptr},
+          initLocalStateFunc{nullptr} {};
     TableFunction(std::string name, table_func_t tableFunc, table_func_bind_t bindFunc,
         table_func_init_shared_t initSharedFunc, table_func_init_local_t initLocalFunc,
         std::vector<common::LogicalTypeID> inputTypes)

--- a/src/include/main/attached_database.h
+++ b/src/include/main/attached_database.h
@@ -8,14 +8,13 @@ namespace kuzu {
 namespace main {
 
 class AttachedDatabase {
-
 public:
     AttachedDatabase(std::string dbName, function::TableFunction scanFunction)
         : dbName{std::move(dbName)}, scanFunction{std::move(scanFunction)} {}
 
     std::string getDBName() { return dbName; }
 
-    function::TableFunction* getScanFunction() { return &scanFunction; }
+    function::TableFunction getScanFunction() { return scanFunction; }
 
 private:
     std::string dbName;

--- a/src/include/planner/operator/logical_in_query_call.h
+++ b/src/include/planner/operator/logical_in_query_call.h
@@ -9,7 +9,7 @@ namespace planner {
 
 class LogicalInQueryCall : public LogicalOperator {
 public:
-    LogicalInQueryCall(function::TableFunction* tableFunc,
+    LogicalInQueryCall(function::TableFunction tableFunc,
         std::unique_ptr<function::TableFuncBindData> bindData,
         binder::expression_vector outputExpressions,
         std::shared_ptr<binder::Expression> rowIDExpression)
@@ -17,7 +17,7 @@ public:
           bindData{std::move(bindData)}, outputExpressions{std::move(outputExpressions)},
           rowIDExpression{std::move(rowIDExpression)} {}
 
-    inline function::TableFunction* getTableFunc() const { return tableFunc; }
+    inline function::TableFunction getTableFunc() const { return tableFunc; }
 
     inline function::TableFuncBindData* getBindData() const { return bindData.get(); }
 
@@ -37,7 +37,7 @@ public:
     }
 
 private:
-    function::TableFunction* tableFunc;
+    function::TableFunction tableFunc;
     std::unique_ptr<function::TableFuncBindData> bindData;
     binder::expression_vector outputExpressions;
     std::shared_ptr<binder::Expression> rowIDExpression;

--- a/src/include/processor/operator/call/in_query_call.h
+++ b/src/include/processor/operator/call/in_query_call.h
@@ -32,7 +32,7 @@ enum class TableScanOutputType : uint8_t {
 };
 
 struct InQueryCallInfo {
-    function::TableFunction* function;
+    function::TableFunction function;
     std::unique_ptr<function::TableFuncBindData> bindData;
     std::vector<DataPos> outPosV;
     DataPos rowOffsetPos;
@@ -66,7 +66,7 @@ public:
 
     bool isSource() const override { return true; }
 
-    bool canParallel() const override { return info.function->canParallelFunc(); }
+    bool canParallel() const override { return info.function.canParallelFunc(); }
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -27,7 +27,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     auto function = function::BuiltInFunctionsUtils::matchFunction(
         READ_FTABLE_FUNC_NAME, catalog->getFunctions(clientContext->getTx()));
     auto info = InQueryCallInfo();
-    info.function = ku_dynamic_cast<Function*, TableFunction*>(function);
+    info.function = *ku_dynamic_cast<Function*, TableFunction*>(function);
     info.bindData = std::move(bindData);
     info.outPosV = std::move(outPosV);
     if (offset != nullptr) {

--- a/src/processor/map/map_scan_file.cpp
+++ b/src/processor/map/map_scan_file.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanFile(LogicalOperator* logic
         outPosV.emplace_back(getDataPos(*expr, *outSchema));
     }
     auto info = InQueryCallInfo();
-    info.function = scanFileInfo->copyFunc;
+    info.function = scanFileInfo->func;
     info.bindData = scanFileInfo->bindData->copy();
     info.outPosV = outPosV;
     if (scanFile->hasOffset()) {

--- a/src/processor/operator/call/in_query_call.cpp
+++ b/src/processor/operator/call/in_query_call.cpp
@@ -40,7 +40,7 @@ void InQueryCall::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*
     }
     // Init table function input.
     function::TableFunctionInitInput tableFunctionInitInput{info.bindData.get()};
-    localState.funcState = info.function->initLocalStateFunc(tableFunctionInitInput,
+    localState.funcState = info.function.initLocalStateFunc(tableFunctionInitInput,
         sharedState->funcState.get(), context->clientContext->getMemoryManager());
     localState.funcInput = function::TableFuncInput{
         info.bindData.get(), localState.funcState.get(), sharedState->funcState.get()};
@@ -48,13 +48,13 @@ void InQueryCall::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*
 
 void InQueryCall::initGlobalStateInternal(ExecutionContext*) {
     function::TableFunctionInitInput tableFunctionInitInput{info.bindData.get()};
-    sharedState->funcState = info.function->initSharedStateFunc(tableFunctionInitInput);
+    sharedState->funcState = info.function.initSharedStateFunc(tableFunctionInitInput);
 }
 
 bool InQueryCall::getNextTuplesInternal(ExecutionContext*) {
     localState.funcOutput.dataChunk.state->selVector->selectedSize = 0;
     localState.funcOutput.dataChunk.resetAuxiliaryBuffer();
-    auto numTuplesScanned = info.function->tableFunc(localState.funcInput, localState.funcOutput);
+    auto numTuplesScanned = info.function.tableFunc(localState.funcInput, localState.funcOutput);
     localState.funcOutput.dataChunk.state->selVector->selectedSize = numTuplesScanned;
     if (localState.rowOffsetVector != nullptr) {
         auto rowIdx = sharedState->getAndIncreaseRowIdx(numTuplesScanned);


### PR DESCRIPTION
Always copy table function instead of passing raw pointer. This is because when we register table functions from external scans, we don't have guarantee over the life cycle if we use raw pointer.