### PR TITLE
Add scalar_func_rewrite_t

### DIFF
--- a/src/binder/bind_expression/bind_boolean_expression.cpp
+++ b/src/binder/bind_expression/bind_boolean_expression.cpp
@@ -24,9 +24,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindBooleanExpression(
         childrenAfterCast.push_back(implicitCastIfNecessary(child, LogicalTypeID::BOOL));
     }
     auto functionName = expressionTypeToString(expressionType);
-    function::scalar_exec_func execFunc;
+    function::scalar_func_exec_t execFunc;
     function::VectorBooleanFunction::bindExecFunction(expressionType, childrenAfterCast, execFunc);
-    function::scalar_select_func selectFunc;
+    function::scalar_func_select_t selectFunc;
     function::VectorBooleanFunction::bindSelectFunction(
         expressionType, childrenAfterCast, selectFunc);
     auto bindData = std::make_unique<function::FunctionBindData>(LogicalType::BOOL());

--- a/src/binder/bind_expression/bind_null_operator_expression.cpp
+++ b/src/binder/bind_expression/bind_null_operator_expression.cpp
@@ -21,9 +21,9 @@ std::shared_ptr<Expression> ExpressionBinder::bindNullOperatorExpression(
     }
     auto expressionType = parsedExpression.getExpressionType();
     auto functionName = expressionTypeToString(expressionType);
-    function::scalar_exec_func execFunc;
+    function::scalar_func_exec_t execFunc;
     function::VectorNullFunction::bindExecFunction(expressionType, children, execFunc);
-    function::scalar_select_func selectFunc;
+    function::scalar_func_select_t selectFunc;
     function::VectorNullFunction::bindSelectFunction(expressionType, children, selectFunc);
     auto bindData = std::make_unique<function::FunctionBindData>(LogicalType::BOOL());
     auto uniqueExpressionName = ScalarFunctionExpression::getUniqueName(functionName, children);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -5,6 +5,7 @@
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "catalog/catalog_entry/scalar_macro_catalog_entry.h"
+#include "common/exception/catalog.h"
 #include "storage/wal/wal.h"
 #include "transaction/transaction.h"
 #include "transaction/transaction_action.h"
@@ -101,10 +102,6 @@ std::vector<TableCatalogEntry*> Catalog::getTableSchemas(
     return result;
 }
 
-CatalogSet* Catalog::getFunctions(Transaction* tx) const {
-    return getVersion(tx)->functions.get();
-}
-
 void Catalog::prepareCommitOrRollback(TransactionAction action) {
     if (hasUpdates()) {
         wal->logCatalogRecord();
@@ -119,10 +116,6 @@ void Catalog::checkpointInMemory() {
         readOnlyVersion = std::move(readWriteVersion);
         resetToNotUpdated();
     }
-}
-
-ExpressionType Catalog::getFunctionType(Transaction* tx, const std::string& name) const {
-    return getVersion(tx)->getFunctionType(name);
 }
 
 table_id_t Catalog::addNodeTableSchema(const binder::BoundCreateTableInfo& info) {
@@ -255,6 +248,18 @@ void Catalog::addFunction(std::string name, function::function_set functionSet) 
 
 void Catalog::addBuiltInFunction(std::string name, function::function_set functionSet) {
     readOnlyVersion->addFunction(std::move(name), std::move(functionSet));
+}
+
+CatalogSet* Catalog::getFunctions(Transaction* tx) const {
+    return getVersion(tx)->functions.get();
+}
+
+CatalogEntry* Catalog::getFunctionEntry(transaction::Transaction* tx, const std::string& name) {
+    auto catalogSet = getVersion(tx)->functions.get();
+    if (!catalogSet->containsEntry(name)) {
+        throw CatalogException(stringFormat("function {} does not exist.", name));
+    }
+    return catalogSet->getEntry(name);
 }
 
 bool Catalog::containsMacro(Transaction* tx, const std::string& macroName) const {

--- a/src/catalog/catalog_content.cpp
+++ b/src/catalog/catalog_content.cpp
@@ -202,23 +202,6 @@ void CatalogContent::readFromFile(const std::string& directory, FileVersionType 
     functions = CatalogSet::deserialize(deserializer);
 }
 
-ExpressionType CatalogContent::getFunctionType(const std::string& name) const {
-    if (!functions->containsEntry(name)) {
-        throw CatalogException{common::stringFormat("function {} does not exist.", name)};
-    }
-    auto functionEntry = functions->getEntry(name);
-    switch (functionEntry->getType()) {
-    case CatalogEntryType::SCALAR_MACRO_ENTRY:
-        return ExpressionType::MACRO;
-    case CatalogEntryType::SCALAR_FUNCTION_ENTRY:
-        return ExpressionType::FUNCTION;
-    case CatalogEntryType::AGGREGATE_FUNCTION_ENTRY:
-        return ExpressionType::AGGREGATE_FUNCTION;
-    default:
-        KU_UNREACHABLE;
-    }
-}
-
 void CatalogContent::addFunction(std::string name, function::function_set definitions) {
     if (functions->containsEntry(name)) {
         throw CatalogException{common::stringFormat("function {} already exists.", name)};

--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -1,6 +1,10 @@
 #include "catalog/catalog_set.h"
 
 #include "common/assert.h"
+#include "common/exception/catalog.h"
+#include "common/string_format.h"
+
+using namespace kuzu::common;
 
 namespace kuzu {
 namespace catalog {
@@ -10,6 +14,13 @@ bool CatalogSet::containsEntry(const std::string& name) const {
 }
 
 CatalogEntry* CatalogSet::getEntry(const std::string& name) {
+    // LCOV_EXCL_START
+    // We should not trigger the following check. If so, we should throw more informative error
+    // message at catalog level.
+    if (!containsEntry(name)) {
+        throw CatalogException(stringFormat("Cannot find catalog entry with name {}.", name));
+    }
+    // LCOV_EXCL_STOP
     return entries.at(name).get();
 }
 
@@ -36,6 +47,7 @@ void CatalogSet::serialize(common::Serializer serializer) const {
     for (auto& [name, entry] : entries) {
         switch (entry->getType()) {
         case CatalogEntryType::SCALAR_FUNCTION_ENTRY:
+        case CatalogEntryType::REWRITE_FUNCTION_ENTRY:
         case CatalogEntryType::AGGREGATE_FUNCTION_ENTRY:
         case CatalogEntryType::TABLE_FUNCTION_ENTRY:
             continue;

--- a/src/function/CMakeLists.txt
+++ b/src/function/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_subdirectory(aggregate)
 add_subdirectory(arithmetic)
 add_subdirectory(cast)
+add_subdirectory(pattern)
 add_subdirectory(table)
 
 add_library(kuzu_function

--- a/src/function/built_in_function_utils.cpp
+++ b/src/function/built_in_function_utils.cpp
@@ -41,6 +41,13 @@ using namespace kuzu::processor;
 namespace kuzu {
 namespace function {
 
+static void validateNonEmptyCandidateFunctions(std::vector<AggregateFunction*>& candidateFunctions,
+    const std::string& name, const std::vector<common::LogicalType>& inputTypes, bool isDistinct,
+    function::function_set& set);
+static void validateNonEmptyCandidateFunctions(std::vector<Function*>& candidateFunctions,
+    const std::string& name, const std::vector<common::LogicalType>& inputTypes,
+    function::function_set& set);
+
 void BuiltInFunctionsUtils::createFunctions(CatalogSet* catalogSet) {
     registerScalarFunctions(catalogSet);
     registerAggregateFunctions(catalogSet);
@@ -453,10 +460,8 @@ uint32_t BuiltInFunctionsUtils::getFunctionCost(
             return matchParameters(inputTypes, function->parameterTypeIDs, isOverload);
         }
     }
-    case FunctionType::TABLE:
-        return matchParameters(inputTypes, function->parameterTypeIDs, isOverload);
     default:
-        KU_UNREACHABLE;
+        return matchParameters(inputTypes, function->parameterTypeIDs, isOverload);
     }
 }
 
@@ -909,6 +914,9 @@ void BuiltInFunctionsUtils::registerUnionFunctions(CatalogSet* catalogSet) {
 void BuiltInFunctionsUtils::registerNodeRelFunctions(CatalogSet* catalogSet) {
     catalogSet->createEntry(std::make_unique<ScalarFunctionCatalogEntry>(
         OFFSET_FUNC_NAME, OffsetFunction::getFunctionSet()));
+    catalogSet->createEntry(
+        std::make_unique<FunctionCatalogEntry>(catalog::CatalogEntryType::REWRITE_FUNCTION_ENTRY,
+            ID_FUNC_NAME, IDFunction::getFunctionSet()));
 }
 
 void BuiltInFunctionsUtils::registerPathFunctions(CatalogSet* catalogSet) {
@@ -1069,9 +1077,9 @@ static std::string getFunctionMatchFailureMsg(const std::string name,
     return result;
 }
 
-void BuiltInFunctionsUtils::validateNonEmptyCandidateFunctions(
-    std::vector<AggregateFunction*>& candidateFunctions, const std::string& name,
-    const std::vector<LogicalType>& inputTypes, bool isDistinct, function::function_set& set) {
+void validateNonEmptyCandidateFunctions(std::vector<AggregateFunction*>& candidateFunctions,
+    const std::string& name, const std::vector<LogicalType>& inputTypes, bool isDistinct,
+    function::function_set& set) {
     if (candidateFunctions.empty()) {
         std::string supportedInputsString;
         for (auto& function : set) {
@@ -1086,9 +1094,9 @@ void BuiltInFunctionsUtils::validateNonEmptyCandidateFunctions(
     }
 }
 
-void BuiltInFunctionsUtils::validateNonEmptyCandidateFunctions(
-    std::vector<Function*>& candidateFunctions, const std::string& name,
-    const std::vector<LogicalType>& inputTypes, function::function_set& set) {
+void validateNonEmptyCandidateFunctions(std::vector<Function*>& candidateFunctions,
+    const std::string& name, const std::vector<LogicalType>& inputTypes,
+    function::function_set& set) {
     if (candidateFunctions.empty()) {
         std::string supportedInputsString;
         for (auto& function : set) {

--- a/src/function/pattern/CMakeLists.txt
+++ b/src/function/pattern/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(kuzu_function_pattern
+        OBJECT
+        id_function.cpp)
+
+set(ALL_OBJECT_FILES
+        ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_function_pattern>
+        PARENT_SCOPE)

--- a/src/function/pattern/id_function.cpp
+++ b/src/function/pattern/id_function.cpp
@@ -1,0 +1,46 @@
+#include "binder/expression/expression_util.h"
+#include "binder/expression/node_expression.h"
+#include "binder/expression/rel_expression.h"
+#include "binder/expression_binder.h"
+#include "function/rewrite_function.h"
+#include "function/schema/vector_node_rel_functions.h"
+
+using namespace kuzu::common;
+using namespace kuzu::binder;
+
+namespace kuzu {
+namespace function {
+
+static std::shared_ptr<binder::Expression> rewriteFunc(
+    const expression_vector& params, ExpressionBinder* binder) {
+    KU_ASSERT(params.size() == 1);
+    auto param = params[0].get();
+    if (ExpressionUtil::isNodePattern(*param)) {
+        auto node = ku_dynamic_cast<Expression*, NodeExpression*>(param);
+        return node->getInternalID();
+    }
+    if (ExpressionUtil::isRelPattern(*param)) {
+        auto rel = ku_dynamic_cast<Expression*, RelExpression*>(param);
+        return rel->getPropertyExpression(InternalKeyword::ID);
+    }
+    // Bind as struct_extract(param, "_id")
+    auto key = Value(LogicalType::STRING(), InternalKeyword::ID);
+    auto keyExpr = binder->createLiteralExpression(key.copy());
+    auto newParams = expression_vector{params[0], keyExpr};
+    return binder->bindScalarFunctionExpression(newParams, STRUCT_EXTRACT_FUNC_NAME);
+}
+
+function_set IDFunction::getFunctionSet() {
+    function_set functionSet;
+    auto inputTypes =
+        std::vector<LogicalTypeID>{LogicalTypeID::NODE, LogicalTypeID::REL, LogicalTypeID::STRUCT};
+    for (auto& inputType : inputTypes) {
+        auto function = std::make_unique<RewriteFunction>(
+            InternalKeyword::ID, std::vector<LogicalTypeID>{inputType}, rewriteFunc);
+        functionSet.push_back(std::move(function));
+    }
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/function/vector_boolean_functions.cpp
+++ b/src/function/vector_boolean_functions.cpp
@@ -8,7 +8,7 @@ namespace kuzu {
 namespace function {
 
 void VectorBooleanFunction::bindExecFunction(ExpressionType expressionType,
-    const binder::expression_vector& children, scalar_exec_func& func) {
+    const binder::expression_vector& children, scalar_func_exec_t& func) {
     if (isExpressionBinary(expressionType)) {
         bindBinaryExecFunction(expressionType, children, func);
     } else {
@@ -18,7 +18,7 @@ void VectorBooleanFunction::bindExecFunction(ExpressionType expressionType,
 }
 
 void VectorBooleanFunction::bindSelectFunction(ExpressionType expressionType,
-    const binder::expression_vector& children, scalar_select_func& func) {
+    const binder::expression_vector& children, scalar_func_select_t& func) {
     if (isExpressionBinary(expressionType)) {
         bindBinarySelectFunction(expressionType, children, func);
     } else {
@@ -28,7 +28,7 @@ void VectorBooleanFunction::bindSelectFunction(ExpressionType expressionType,
 }
 
 void VectorBooleanFunction::bindBinaryExecFunction(ExpressionType expressionType,
-    const binder::expression_vector& children, scalar_exec_func& func) {
+    const binder::expression_vector& children, scalar_func_exec_t& func) {
     KU_ASSERT(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
@@ -54,7 +54,7 @@ void VectorBooleanFunction::bindBinaryExecFunction(ExpressionType expressionType
 }
 
 void VectorBooleanFunction::bindBinarySelectFunction(ExpressionType expressionType,
-    const binder::expression_vector& children, scalar_select_func& func) {
+    const binder::expression_vector& children, scalar_func_select_t& func) {
     KU_ASSERT(children.size() == 2);
     auto leftType = children[0]->dataType;
     auto rightType = children[1]->dataType;
@@ -80,7 +80,7 @@ void VectorBooleanFunction::bindBinarySelectFunction(ExpressionType expressionTy
 }
 
 void VectorBooleanFunction::bindUnaryExecFunction(ExpressionType expressionType,
-    const binder::expression_vector& children, scalar_exec_func& func) {
+    const binder::expression_vector& children, scalar_func_exec_t& func) {
     KU_ASSERT(
         children.size() == 1 && children[0]->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     (void)children;
@@ -96,7 +96,7 @@ void VectorBooleanFunction::bindUnaryExecFunction(ExpressionType expressionType,
 }
 
 void VectorBooleanFunction::bindUnarySelectFunction(ExpressionType expressionType,
-    const binder::expression_vector& children, scalar_select_func& func) {
+    const binder::expression_vector& children, scalar_func_select_t& func) {
     KU_ASSERT(
         children.size() == 1 && children[0]->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     (void)children;

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -36,10 +36,10 @@ static void fixedListToListCastExecFunction(
     ListVector::resizeDataVector(&result, numOfEntries * numValuesPerList);
 
     auto resultVector = ListVector::getDataVector(&result);
-    scalar_exec_func func = CastFunction::bindCastFunction<CastFixedListToListFunctionExecutor>(
+    scalar_func_exec_t func = CastFunction::bindCastFunction<CastFixedListToListFunctionExecutor>(
         "CAST", FixedListType::getChildType(&inputVector->dataType)->getLogicalTypeID(),
         resultVector->dataType.getLogicalTypeID())
-                                ->execFunc;
+                                  ->execFunc;
     reinterpret_cast<CastFunctionBindData*>(dataPtr)->numOfEntries = numOfEntries;
     func(params, *resultVector, dataPtr);
 }
@@ -64,10 +64,10 @@ void fixedListToListCastExecFunction<CastChildFunctionExecutor>(
     }
 
     auto resultVector = ListVector::getDataVector(&result);
-    scalar_exec_func func = CastFunction::bindCastFunction<CastFixedListToListFunctionExecutor>(
+    scalar_func_exec_t func = CastFunction::bindCastFunction<CastFixedListToListFunctionExecutor>(
         "CAST", FixedListType::getChildType(&inputVector->dataType)->getLogicalTypeID(),
         resultVector->dataType.getLogicalTypeID())
-                                ->execFunc;
+                                  ->execFunc;
     func(params, *resultVector, dataPtr);
 }
 
@@ -124,9 +124,9 @@ static void resolveNestedVector(std::shared_ptr<ValueVector> inputVector, ValueV
     }
 
     // non-nested types
-    scalar_exec_func func = CastFunction::bindCastFunction<CastChildFunctionExecutor>(
+    scalar_func_exec_t func = CastFunction::bindCastFunction<CastChildFunctionExecutor>(
         "CAST", inputType->getLogicalTypeID(), resultType->getLogicalTypeID())
-                                ->execFunc;
+                                  ->execFunc;
     std::vector<std::shared_ptr<ValueVector>> childParams{inputVector};
     dataPtr->numOfEntries = numOfEntries;
     func(childParams, *resultVector, (void*)dataPtr);
@@ -174,7 +174,7 @@ bool CastFunction::hasImplicitCast(const LogicalType& srcType, const LogicalType
 template<typename EXECUTOR = UnaryFunctionExecutor>
 static std::unique_ptr<ScalarFunction> bindCastFromStringFunction(
     const std::string& functionName, LogicalTypeID targetTypeID) {
-    scalar_exec_func execFunc;
+    scalar_func_exec_t execFunc;
     switch (targetTypeID) {
     case LogicalTypeID::DATE: {
         execFunc =
@@ -298,7 +298,7 @@ static std::unique_ptr<ScalarFunction> bindCastFromStringFunction(
 
 static std::unique_ptr<ScalarFunction> bindCastFromRdfVariantFunction(
     const std::string& functionName, LogicalTypeID targetTypeID) {
-    scalar_exec_func execFunc;
+    scalar_func_exec_t execFunc;
     switch (targetTypeID) {
     case LogicalTypeID::DATE: {
         execFunc = ScalarFunction::UnaryRdfVariantCastExecFunction<struct_entry_t, date_t,
@@ -383,7 +383,7 @@ static std::unique_ptr<ScalarFunction> bindCastFromRdfVariantFunction(
 template<typename EXECUTOR = UnaryFunctionExecutor>
 static std::unique_ptr<ScalarFunction> bindCastToStringFunction(
     const std::string& functionName, LogicalTypeID sourceTypeID) {
-    scalar_exec_func func;
+    scalar_func_exec_t func;
     switch (sourceTypeID) {
     case LogicalTypeID::BOOL: {
         func = ScalarFunction::UnaryCastExecFunction<bool, ku_string_t, CastToString, EXECUTOR>;
@@ -497,7 +497,7 @@ static std::unique_ptr<ScalarFunction> bindCastToStringFunction(
 
 static std::unique_ptr<ScalarFunction> bindCastToRdfVariantFunction(
     const std::string& functionName, LogicalTypeID sourceTypeID) {
-    scalar_exec_func execFunc;
+    scalar_func_exec_t execFunc;
     switch (sourceTypeID) {
     case LogicalTypeID::DATE: {
         execFunc = ScalarFunction::UnaryRdfVariantCastExecFunction<date_t, struct_entry_t,
@@ -581,7 +581,7 @@ static std::unique_ptr<ScalarFunction> bindCastToRdfVariantFunction(
 template<typename DST_TYPE, typename OP, typename EXECUTOR = UnaryFunctionExecutor>
 static std::unique_ptr<ScalarFunction> bindCastToNumericFunction(
     const std::string& functionName, LogicalTypeID sourceTypeID, LogicalTypeID targetTypeID) {
-    scalar_exec_func func;
+    scalar_func_exec_t func;
     switch (sourceTypeID) {
     case LogicalTypeID::INT8: {
         func = ScalarFunction::UnaryExecFunction<int8_t, DST_TYPE, OP, EXECUTOR>;
@@ -664,7 +664,7 @@ static std::unique_ptr<ScalarFunction> bindCastBetweenNested(
 template<typename EXECUTOR = UnaryFunctionExecutor, typename DST_TYPE>
 static std::unique_ptr<ScalarFunction> bindCastToTimestampFunction(
     const std::string& functionName, LogicalTypeID sourceTypeID, LogicalTypeID dstTypeID) {
-    scalar_exec_func func;
+    scalar_func_exec_t func;
     switch (sourceTypeID) {
     case LogicalTypeID::DATE: {
         func = ScalarFunction::UnaryExecFunction<date_t, DST_TYPE, CastDateToTimestamp, EXECUTOR>;

--- a/src/function/vector_list_functions.cpp
+++ b/src/function/vector_list_functions.cpp
@@ -446,7 +446,7 @@ std::unique_ptr<FunctionBindData> ListSortFunction::bindFunc(
 
 template<typename T>
 void ListSortFunction::getExecFunction(
-    const binder::expression_vector& arguments, scalar_exec_func& func) {
+    const binder::expression_vector& arguments, scalar_func_exec_t& func) {
     if (arguments.size() == 1) {
         func = ScalarFunction::UnaryExecNestedTypeFunction<list_entry_t, list_entry_t, ListSort<T>>;
         return;
@@ -548,7 +548,7 @@ std::unique_ptr<FunctionBindData> ListReverseSortFunction::bindFunc(
 
 template<typename T>
 void ListReverseSortFunction::getExecFunction(
-    const binder::expression_vector& arguments, scalar_exec_func& func) {
+    const binder::expression_vector& arguments, scalar_func_exec_t& func) {
     if (arguments.size() == 1) {
         func = ScalarFunction::UnaryExecNestedTypeFunction<list_entry_t, list_entry_t,
             ListReverseSort<T>>;

--- a/src/function/vector_null_functions.cpp
+++ b/src/function/vector_null_functions.cpp
@@ -8,7 +8,7 @@ namespace kuzu {
 namespace function {
 
 void VectorNullFunction::bindExecFunction(ExpressionType expressionType,
-    const binder::expression_vector& /*children*/, scalar_exec_func& func) {
+    const binder::expression_vector& /*children*/, scalar_func_exec_t& func) {
     switch (expressionType) {
     case ExpressionType::IS_NULL: {
         func = UnaryNullExecFunction<IsNull>;
@@ -25,7 +25,7 @@ void VectorNullFunction::bindExecFunction(ExpressionType expressionType,
 }
 
 void VectorNullFunction::bindSelectFunction(ExpressionType expressionType,
-    const binder::expression_vector& children, scalar_select_func& func) {
+    const binder::expression_vector& children, scalar_func_select_t& func) {
     KU_ASSERT(children.size() == 1);
     (void)children;
     switch (expressionType) {

--- a/src/function/vector_struct_functions.cpp
+++ b/src/function/vector_struct_functions.cpp
@@ -82,11 +82,15 @@ function_set StructExtractFunctions::getFunctionSet() {
     auto inputTypeIDs =
         std::vector<LogicalTypeID>{LogicalTypeID::STRUCT, LogicalTypeID::NODE, LogicalTypeID::REL};
     for (auto inputTypeID : inputTypeIDs) {
-        functions.push_back(make_unique<ScalarFunction>(STRUCT_EXTRACT_FUNC_NAME,
-            std::vector<LogicalTypeID>{inputTypeID, LogicalTypeID::STRING}, LogicalTypeID::ANY,
-            nullptr, nullptr, compileFunc, bindFunc, false /* isVarLength */));
+        functions.push_back(getFunction(inputTypeID));
     }
     return functions;
+}
+
+std::unique_ptr<ScalarFunction> StructExtractFunctions::getFunction(LogicalTypeID logicalTypeID) {
+    return std::make_unique<ScalarFunction>(STRUCT_EXTRACT_FUNC_NAME,
+        std::vector<LogicalTypeID>{logicalTypeID, LogicalTypeID::STRING}, LogicalTypeID::ANY,
+        nullptr, nullptr, compileFunc, bindFunc, false /* isVarLength */);
 }
 
 std::unique_ptr<FunctionBindData> StructExtractFunctions::bindFunc(

--- a/src/include/binder/expression/function_expression.h
+++ b/src/include/binder/expression/function_expression.h
@@ -42,7 +42,7 @@ class ScalarFunctionExpression : public FunctionExpression {
 public:
     ScalarFunctionExpression(std::string functionName, common::ExpressionType expressionType,
         std::unique_ptr<function::FunctionBindData> bindData, expression_vector children,
-        function::scalar_exec_func execFunc, function::scalar_select_func selectFunc,
+        function::scalar_func_exec_t execFunc, function::scalar_func_select_t selectFunc,
         const std::string& uniqueName)
         : ScalarFunctionExpression{std::move(functionName), expressionType, std::move(bindData),
               std::move(children), std::move(execFunc), std::move(selectFunc), nullptr,
@@ -50,8 +50,8 @@ public:
 
     ScalarFunctionExpression(std::string functionName, common::ExpressionType expressionType,
         std::unique_ptr<function::FunctionBindData> bindData, expression_vector children,
-        function::scalar_exec_func execFunc, function::scalar_select_func selectFunc,
-        function::scalar_compile_func compileFunc, const std::string& uniqueName)
+        function::scalar_func_exec_t execFunc, function::scalar_func_select_t selectFunc,
+        function::scalar_func_compile_exec_t compileFunc, const std::string& uniqueName)
         : FunctionExpression{std::move(functionName), expressionType, std::move(bindData),
               std::move(children), uniqueName},
           execFunc{std::move(execFunc)}, selectFunc{std::move(selectFunc)}, compileFunc{std::move(
@@ -63,9 +63,9 @@ public:
     std::string toStringInternal() const final;
 
 public:
-    function::scalar_exec_func execFunc;
-    function::scalar_select_func selectFunc;
-    function::scalar_compile_func compileFunc;
+    function::scalar_func_exec_t execFunc;
+    function::scalar_func_select_t selectFunc;
+    function::scalar_func_compile_exec_t compileFunc;
 };
 
 class AggregateFunctionExpression : public FunctionExpression {

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -35,7 +35,6 @@ public:
         const Expression& expression, const std::vector<common::LogicalTypeID>& targets);
     static void validateDataType(const Expression& expr, const common::LogicalType& expectedType);
 
-private:
     // TODO(Xiyang): move to an expression rewriter
     std::shared_ptr<Expression> foldExpression(const std::shared_ptr<Expression>& expression);
 
@@ -74,6 +73,8 @@ private:
         const parser::ParsedExpression& parsedExpression, const std::string& functionName);
     std::shared_ptr<Expression> bindScalarFunctionExpression(
         const expression_vector& children, const std::string& functionName);
+    std::shared_ptr<Expression> bindRewriteFunctionExpression(
+        const parser::ParsedExpression& parsedExpression);
     std::shared_ptr<Expression> bindAggregateFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName,
         bool isDistinct);
@@ -83,8 +84,6 @@ private:
     std::shared_ptr<Expression> rewriteFunctionExpression(
         const parser::ParsedExpression& parsedExpression, const std::string& functionName);
     std::unique_ptr<Expression> createInternalNodeIDExpression(const Expression& node);
-    std::shared_ptr<Expression> bindInternalIDExpression(
-        const std::shared_ptr<Expression>& expression);
     std::shared_ptr<Expression> bindStartNodeExpression(const Expression& expression);
     std::shared_ptr<Expression> bindEndNodeExpression(const Expression& expression);
     std::shared_ptr<Expression> bindLabelFunction(const Expression& expression);

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -51,7 +51,6 @@ public:
     std::vector<TableCatalogEntry*> getTableEntries(transaction::Transaction* tx) const;
     std::vector<TableCatalogEntry*> getTableSchemas(
         transaction::Transaction* tx, const common::table_id_vector_t& tableIDs) const;
-    CatalogSet* getFunctions(transaction::Transaction* tx) const;
 
     common::table_id_t addNodeTableSchema(const binder::BoundCreateTableInfo& info);
     common::table_id_t addRelTableSchema(const binder::BoundCreateTableInfo& info);
@@ -73,10 +72,11 @@ public:
     void setTableComment(common::table_id_t tableID, const std::string& comment);
 
     // ----------------------------- Functions ----------------------------
-    common::ExpressionType getFunctionType(
-        transaction::Transaction* tx, const std::string& name) const;
     void addFunction(std::string name, function::function_set functionSet);
     void addBuiltInFunction(std::string name, function::function_set functionSet);
+    CatalogSet* getFunctions(transaction::Transaction* tx) const;
+    CatalogEntry* getFunctionEntry(transaction::Transaction* tx, const std::string& name);
+
     bool containsMacro(transaction::Transaction* tx, const std::string& macroName) const;
     void addScalarMacroFunction(
         std::string name, std::unique_ptr<function::ScalarMacroFunction> macro);

--- a/src/include/catalog/catalog_content.h
+++ b/src/include/catalog/catalog_content.h
@@ -36,8 +36,6 @@ public:
 
 private:
     // ----------------------------- Functions ----------------------------
-    common::ExpressionType getFunctionType(const std::string& name) const;
-
     void registerBuiltInFunctions();
 
     bool containMacro(const std::string& macroName) const {

--- a/src/include/catalog/catalog_entry/catalog_entry_type.h
+++ b/src/include/catalog/catalog_entry/catalog_entry_type.h
@@ -13,7 +13,8 @@ enum class CatalogEntryType : uint8_t {
     SCALAR_MACRO_ENTRY = 4,
     AGGREGATE_FUNCTION_ENTRY = 5,
     SCALAR_FUNCTION_ENTRY = 6,
-    TABLE_FUNCTION_ENTRY = 7,
+    REWRITE_FUNCTION_ENTRY = 7,
+    TABLE_FUNCTION_ENTRY = 8,
 };
 
 } // namespace catalog

--- a/src/include/catalog/catalog_entry/scalar_function_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/scalar_function_catalog_entry.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "catalog_entry.h"
 #include "function_catalog_entry.h"
 
 namespace kuzu {

--- a/src/include/expression_evaluator/function_evaluator.h
+++ b/src/include/expression_evaluator/function_evaluator.h
@@ -32,8 +32,8 @@ protected:
 
 private:
     std::shared_ptr<binder::Expression> expression;
-    function::scalar_exec_func execFunc;
-    function::scalar_select_func selectFunc;
+    function::scalar_func_exec_t execFunc;
+    function::scalar_func_select_t selectFunc;
     std::vector<std::shared_ptr<common::ValueVector>> parameters;
 };
 

--- a/src/include/function/arithmetic/vector_arithmetic_functions.h
+++ b/src/include/function/arithmetic/vector_arithmetic_functions.h
@@ -10,7 +10,7 @@ struct ArithmeticFunction {
     template<typename FUNC>
     static std::unique_ptr<ScalarFunction> getUnaryFunction(
         std::string name, common::LogicalTypeID operandTypeID) {
-        function::scalar_exec_func execFunc;
+        function::scalar_func_exec_t execFunc;
         getUnaryExecFunc<FUNC>(operandTypeID, execFunc);
         return std::make_unique<ScalarFunction>(std::move(name),
             std::vector<common::LogicalTypeID>{operandTypeID}, operandTypeID, execFunc);
@@ -27,7 +27,7 @@ struct ArithmeticFunction {
     template<typename FUNC>
     static inline std::unique_ptr<ScalarFunction> getBinaryFunction(
         std::string name, common::LogicalTypeID operandTypeID) {
-        function::scalar_exec_func execFunc;
+        function::scalar_func_exec_t execFunc;
         getBinaryExecFunc<FUNC>(operandTypeID, execFunc);
         return std::make_unique<ScalarFunction>(std::move(name),
             std::vector<common::LogicalTypeID>{operandTypeID, operandTypeID}, operandTypeID,
@@ -44,7 +44,7 @@ struct ArithmeticFunction {
 
 private:
     template<typename FUNC>
-    static void getUnaryExecFunc(common::LogicalTypeID operandTypeID, scalar_exec_func& func) {
+    static void getUnaryExecFunc(common::LogicalTypeID operandTypeID, scalar_func_exec_t& func) {
         switch (operandTypeID) {
         case common::LogicalTypeID::SERIAL:
         case common::LogicalTypeID::INT64: {
@@ -87,7 +87,7 @@ private:
     }
 
     template<typename FUNC>
-    static void getBinaryExecFunc(common::LogicalTypeID operandTypeID, scalar_exec_func& func) {
+    static void getBinaryExecFunc(common::LogicalTypeID operandTypeID, scalar_func_exec_t& func) {
         switch (operandTypeID) {
         case common::LogicalTypeID::SERIAL:
         case common::LogicalTypeID::INT64: {

--- a/src/include/function/boolean/vector_boolean_functions.h
+++ b/src/include/function/boolean/vector_boolean_functions.h
@@ -9,10 +9,10 @@ namespace function {
 class VectorBooleanFunction {
 public:
     static void bindExecFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_exec_func& func);
+        const binder::expression_vector& children, scalar_func_exec_t& func);
 
     static void bindSelectFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_select_func& func);
+        const binder::expression_vector& children, scalar_func_select_t& func);
 
 private:
     template<typename FUNC>
@@ -48,16 +48,16 @@ private:
     }
 
     static void bindBinaryExecFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_exec_func& func);
+        const binder::expression_vector& children, scalar_func_exec_t& func);
 
     static void bindBinarySelectFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_select_func& func);
+        const binder::expression_vector& children, scalar_func_select_t& func);
 
     static void bindUnaryExecFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_exec_func& func);
+        const binder::expression_vector& children, scalar_func_exec_t& func);
 
     static void bindUnarySelectFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_select_func& func);
+        const binder::expression_vector& children, scalar_func_select_t& func);
 };
 
 } // namespace function

--- a/src/include/function/built_in_function_utils.h
+++ b/src/include/function/built_in_function_utils.h
@@ -111,15 +111,6 @@ private:
 
     // Table functions.
     static void registerTableFunctions(catalog::CatalogSet* catalogSet);
-
-    // Validations
-    static void validateNonEmptyCandidateFunctions(
-        std::vector<AggregateFunction*>& candidateFunctions, const std::string& name,
-        const std::vector<common::LogicalType>& inputTypes, bool isDistinct,
-        function::function_set& set);
-    static void validateNonEmptyCandidateFunctions(std::vector<Function*>& candidateFunctions,
-        const std::string& name, const std::vector<common::LogicalType>& inputTypes,
-        function::function_set& set);
 };
 
 } // namespace function

--- a/src/include/function/comparison/vector_comparison_functions.h
+++ b/src/include/function/comparison/vector_comparison_functions.h
@@ -50,9 +50,9 @@ private:
         const std::string& name, common::LogicalTypeID leftType, common::LogicalTypeID rightType) {
         auto leftPhysical = common::LogicalType::getPhysicalType(leftType);
         auto rightPhysical = common::LogicalType::getPhysicalType(rightType);
-        scalar_exec_func execFunc;
+        scalar_func_exec_t execFunc;
         getExecFunc<FUNC>(leftPhysical, rightPhysical, execFunc);
-        scalar_select_func selectFunc;
+        scalar_func_select_t selectFunc;
         getSelectFunc<FUNC>(leftPhysical, rightPhysical, selectFunc);
         return std::make_unique<ScalarFunction>(name,
             std::vector<common::LogicalTypeID>{leftType, rightType}, common::LogicalTypeID::BOOL,
@@ -62,8 +62,8 @@ private:
     // When comparing two values, we guarantee that they must have the same dataType. So we only
     // need to switch the physical type to get the corresponding exec function.
     template<typename FUNC>
-    static void getExecFunc(
-        common::PhysicalTypeID leftType, common::PhysicalTypeID rightType, scalar_exec_func& func) {
+    static void getExecFunc(common::PhysicalTypeID leftType, common::PhysicalTypeID rightType,
+        scalar_func_exec_t& func) {
         switch (leftType) {
         case common::PhysicalTypeID::INT64: {
             func = BinaryComparisonExecFunction<int64_t, int64_t, uint8_t, FUNC>;
@@ -130,7 +130,7 @@ private:
 
     template<typename FUNC>
     static void getSelectFunc(common::PhysicalTypeID leftTypeID, common::PhysicalTypeID rightTypeID,
-        scalar_select_func& func) {
+        scalar_func_select_t& func) {
         KU_ASSERT(leftTypeID == rightTypeID);
         switch (leftTypeID) {
         case common::PhysicalTypeID::INT64: {

--- a/src/include/function/list/vector_list_functions.h
+++ b/src/include/function/list/vector_list_functions.h
@@ -10,8 +10,9 @@ namespace function {
 
 struct ListFunction {
     template<typename OPERATION, typename RESULT_TYPE>
-    static scalar_exec_func getBinaryListExecFuncSwitchRight(const common::LogicalType& rightType) {
-        scalar_exec_func execFunc;
+    static scalar_func_exec_t getBinaryListExecFuncSwitchRight(
+        const common::LogicalType& rightType) {
+        scalar_func_exec_t execFunc;
         switch (rightType.getPhysicalType()) {
         case common::PhysicalTypeID::BOOL: {
             execFunc = ScalarFunction::BinaryExecListStructFunction<common::list_entry_t, uint8_t,
@@ -89,8 +90,8 @@ struct ListFunction {
     }
 
     template<typename OPERATION, typename RESULT_TYPE>
-    static scalar_exec_func getBinaryListExecFuncSwitchAll(const common::LogicalType& type) {
-        scalar_exec_func execFunc;
+    static scalar_func_exec_t getBinaryListExecFuncSwitchAll(const common::LogicalType& type) {
+        scalar_func_exec_t execFunc;
         switch (type.getPhysicalType()) {
         case common::PhysicalTypeID::INT64: {
             execFunc = ScalarFunction::BinaryExecListStructFunction<int64_t, int64_t, RESULT_TYPE,
@@ -116,8 +117,8 @@ struct ListFunction {
     }
 
     template<typename OPERATION, typename RESULT_TYPE>
-    static scalar_exec_func getTernaryListExecFuncSwitchAll(const common::LogicalType& type) {
-        scalar_exec_func execFunc;
+    static scalar_func_exec_t getTernaryListExecFuncSwitchAll(const common::LogicalType& type) {
+        scalar_func_exec_t execFunc;
         switch (type.getPhysicalType()) {
         case common::PhysicalTypeID::INT64: {
             execFunc = ScalarFunction::TernaryExecListStructFunction<int64_t, int64_t, int64_t,
@@ -278,7 +279,8 @@ struct ListSortFunction {
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, Function* function);
     template<typename T>
-    static void getExecFunction(const binder::expression_vector& arguments, scalar_exec_func& func);
+    static void getExecFunction(
+        const binder::expression_vector& arguments, scalar_func_exec_t& func);
 };
 
 struct ListReverseSortFunction {
@@ -286,7 +288,8 @@ struct ListReverseSortFunction {
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, Function* function);
     template<typename T>
-    static void getExecFunction(const binder::expression_vector& arguments, scalar_exec_func& func);
+    static void getExecFunction(
+        const binder::expression_vector& arguments, scalar_func_exec_t& func);
 };
 
 struct ListSumFunction {

--- a/src/include/function/null/vector_null_functions.h
+++ b/src/include/function/null/vector_null_functions.h
@@ -9,10 +9,10 @@ namespace function {
 class VectorNullFunction {
 public:
     static void bindExecFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_exec_func& func);
+        const binder::expression_vector& children, scalar_func_exec_t& func);
 
     static void bindSelectFunction(common::ExpressionType expressionType,
-        const binder::expression_vector& children, scalar_select_func& func);
+        const binder::expression_vector& children, scalar_func_select_t& func);
 
 private:
     template<typename FUNC>

--- a/src/include/function/rewrite_function.h
+++ b/src/include/function/rewrite_function.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "function.h"
+
+namespace kuzu {
+namespace binder {
+class ExpressionBinder;
+}
+namespace function {
+
+// Rewrite function to a different expression, e.g. id(n) -> n._id.
+using rewrite_func_rewrite_t = std::function<std::shared_ptr<binder::Expression>(
+    const binder::expression_vector&, binder::ExpressionBinder*)>;
+
+// We write for the following functions
+// ID(n) -> n._id
+struct RewriteFunction final : public Function {
+
+    RewriteFunction(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs,
+        rewrite_func_rewrite_t rewriteFunc)
+        : Function{FunctionType::REWRITE, name, std::move(parameterTypeIDs)}, rewriteFunc{
+                                                                                  rewriteFunc} {}
+
+    std::unique_ptr<Function> copy() const override {
+        return std::make_unique<RewriteFunction>(*this);
+    }
+
+    rewrite_func_rewrite_t rewriteFunc;
+};
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/schema/vector_node_rel_functions.h
+++ b/src/include/function/schema/vector_node_rel_functions.h
@@ -15,5 +15,9 @@ struct OffsetFunction {
     }
 };
 
+struct IDFunction {
+    static function_set getFunctionSet();
+};
+
 } // namespace function
 } // namespace kuzu

--- a/src/include/function/struct/vector_struct_functions.h
+++ b/src/include/function/struct/vector_struct_functions.h
@@ -30,6 +30,7 @@ struct StructExtractBindData : public FunctionBindData {
 
 struct StructExtractFunctions {
     static function_set getFunctionSet();
+    static std::unique_ptr<ScalarFunction> getFunction(common::LogicalTypeID logicalTypeID);
 
     static std::unique_ptr<FunctionBindData> bindFunc(
         const binder::expression_vector& arguments, Function* function);

--- a/src/include/function/udf_function.h
+++ b/src/include/function/udf_function.h
@@ -80,13 +80,13 @@ struct UDF {
     }
 
     template<typename RESULT_TYPE, typename... Args>
-    static function::scalar_exec_func createUnaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
+    static function::scalar_func_exec_t createUnaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
         const std::vector<common::LogicalTypeID>& /*parameterTypes*/) {
         KU_UNREACHABLE;
     }
 
     template<typename RESULT_TYPE, typename OPERAND_TYPE>
-    static function::scalar_exec_func createUnaryExecFunc(RESULT_TYPE (*udfFunc)(OPERAND_TYPE),
+    static function::scalar_func_exec_t createUnaryExecFunc(RESULT_TYPE (*udfFunc)(OPERAND_TYPE),
         const std::vector<common::LogicalTypeID>& parameterTypes) {
         if (parameterTypes.size() != 1) {
             throw common::CatalogException{
@@ -94,7 +94,7 @@ struct UDF {
                 std::to_string(parameterTypes.size()) + "."};
         }
         validateType<OPERAND_TYPE>(parameterTypes[0]);
-        function::scalar_exec_func execFunc =
+        function::scalar_func_exec_t execFunc =
             [=](const std::vector<std::shared_ptr<common::ValueVector>>& params,
                 common::ValueVector& result, void* /*dataPtr*/ = nullptr) -> void {
             KU_ASSERT(params.size() == 1);
@@ -105,13 +105,13 @@ struct UDF {
     }
 
     template<typename RESULT_TYPE, typename... Args>
-    static function::scalar_exec_func createBinaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
+    static function::scalar_func_exec_t createBinaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
         const std::vector<common::LogicalTypeID>& /*parameterTypes*/) {
         KU_UNREACHABLE;
     }
 
     template<typename RESULT_TYPE, typename LEFT_TYPE, typename RIGHT_TYPE>
-    static function::scalar_exec_func createBinaryExecFunc(
+    static function::scalar_func_exec_t createBinaryExecFunc(
         RESULT_TYPE (*udfFunc)(LEFT_TYPE, RIGHT_TYPE),
         const std::vector<common::LogicalTypeID>& parameterTypes) {
         if (parameterTypes.size() != 2) {
@@ -121,7 +121,7 @@ struct UDF {
         }
         validateType<LEFT_TYPE>(parameterTypes[0]);
         validateType<RIGHT_TYPE>(parameterTypes[1]);
-        function::scalar_exec_func execFunc =
+        function::scalar_func_exec_t execFunc =
             [=](const std::vector<std::shared_ptr<common::ValueVector>>& params,
                 common::ValueVector& result, void* /*dataPtr*/ = nullptr) -> void {
             KU_ASSERT(params.size() == 2);
@@ -132,13 +132,13 @@ struct UDF {
     }
 
     template<typename RESULT_TYPE, typename... Args>
-    static function::scalar_exec_func createTernaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
+    static function::scalar_func_exec_t createTernaryExecFunc(RESULT_TYPE (*/*udfFunc*/)(Args...),
         const std::vector<common::LogicalTypeID>& /*parameterTypes*/) {
         KU_UNREACHABLE;
     }
 
     template<typename RESULT_TYPE, typename A_TYPE, typename B_TYPE, typename C_TYPE>
-    static function::scalar_exec_func createTernaryExecFunc(
+    static function::scalar_func_exec_t createTernaryExecFunc(
         RESULT_TYPE (*udfFunc)(A_TYPE, B_TYPE, C_TYPE),
         std::vector<common::LogicalTypeID> parameterTypes) {
         if (parameterTypes.size() != 3) {
@@ -149,7 +149,7 @@ struct UDF {
         validateType<A_TYPE>(parameterTypes[0]);
         validateType<B_TYPE>(parameterTypes[1]);
         validateType<C_TYPE>(parameterTypes[2]);
-        function::scalar_exec_func execFunc =
+        function::scalar_func_exec_t execFunc =
             [=](const std::vector<std::shared_ptr<common::ValueVector>>& params,
                 common::ValueVector& result, void* /*dataPtr*/ = nullptr) -> void {
             KU_ASSERT(params.size() == 3);
@@ -160,7 +160,7 @@ struct UDF {
     }
 
     template<typename TR, typename... Args>
-    static scalar_exec_func getScalarExecFunc(
+    static scalar_func_exec_t getScalarExecFunc(
         TR (*udfFunc)(Args...), std::vector<common::LogicalTypeID> parameterTypes) {
         constexpr auto numArgs = sizeof...(Args);
         switch (numArgs) {
@@ -222,7 +222,7 @@ struct UDF {
             KU_UNREACHABLE;
         }
         validateType<TR>(returnType);
-        scalar_exec_func scalarExecFunc = getScalarExecFunc<TR, Args...>(udfFunc, parameterTypes);
+        scalar_func_exec_t scalarExecFunc = getScalarExecFunc<TR, Args...>(udfFunc, parameterTypes);
         definitions.push_back(std::make_unique<function::ScalarFunction>(
             std::move(name), std::move(parameterTypes), returnType, std::move(scalarExecFunc)));
         return definitions;
@@ -235,14 +235,14 @@ struct UDF {
     }
 
     template<typename TR, typename... Args>
-    static function_set getVectorizedFunction(std::string name, scalar_exec_func execFunc) {
+    static function_set getVectorizedFunction(std::string name, scalar_func_exec_t execFunc) {
         function_set definitions;
         definitions.push_back(std::make_unique<function::ScalarFunction>(std::move(name),
             getParameterTypes<Args...>(), getParameterType<TR>(), std::move(execFunc)));
         return definitions;
     }
 
-    static function_set getVectorizedFunction(std::string name, scalar_exec_func execFunc,
+    static function_set getVectorizedFunction(std::string name, scalar_func_exec_t execFunc,
         std::vector<common::LogicalTypeID> parameterTypes, common::LogicalTypeID returnType) {
         function_set definitions;
         definitions.push_back(std::make_unique<function::ScalarFunction>(

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -112,7 +112,7 @@ public:
     }
 
     template<typename TR, typename... Args>
-    void createVectorizedFunction(std::string name, function::scalar_exec_func scalarFunc) {
+    void createVectorizedFunction(std::string name, function::scalar_func_exec_t scalarFunc) {
         auto autoTrx = startUDFAutoTrx(clientContext->getTransactionContext());
         auto nameCopy = std::string(name);
         addScalarFunction(std::move(nameCopy), function::UDF::getVectorizedFunction<TR, Args...>(
@@ -122,7 +122,7 @@ public:
 
     void createVectorizedFunction(std::string name,
         std::vector<common::LogicalTypeID> parameterTypes, common::LogicalTypeID returnType,
-        function::scalar_exec_func scalarFunc) {
+        function::scalar_func_exec_t scalarFunc) {
         auto autoTrx = startUDFAutoTrx(clientContext->getTransactionContext());
         auto nameCopy = std::string(name);
         addScalarFunction(

--- a/src/include/parser/expression/parsed_function_expression.h
+++ b/src/include/parser/expression/parsed_function_expression.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "common/string_utils.h"
 #include "parsed_expression.h"
 
 namespace kuzu {
@@ -34,7 +35,10 @@ public:
 
     inline bool getIsDistinct() const { return isDistinct; }
 
-    inline std::string getFunctionName() const { return functionName; }
+    std::string getFunctionName() const { return functionName; }
+    std::string getNormalizedFunctionName() const {
+        return common::StringUtils::getUpper(functionName);
+    }
 
     // A function might have more than 2 parameters.
     inline void addChild(std::unique_ptr<ParsedExpression> child) {

--- a/src/include/processor/operator/persistent/copy_to_csv.h
+++ b/src/include/processor/operator/persistent/copy_to_csv.h
@@ -49,7 +49,7 @@ private:
     std::unique_ptr<common::DataChunk> unflatCastDataChunk;
     std::unique_ptr<common::DataChunk> flatCastDataChunk;
     std::vector<common::ValueVector*> castVectors;
-    std::vector<function::scalar_exec_func> castFuncs;
+    std::vector<function::scalar_func_exec_t> castFuncs;
     std::vector<std::shared_ptr<common::ValueVector>> vectorsToCast;
 };
 

--- a/test/test_files/tinysnb/exception/relation.test
+++ b/test/test_files/tinysnb/exception/relation.test
@@ -3,17 +3,20 @@
 
 --
 
--CASE ReadVarlengthRelPropertyTest1
+-CASE ReadVarlengthRelPropertyTest
+
 -STATEMENT MATCH (a:person)-[e:knows*1..3]->(b:person) RETURN e.age
 ---- error
 Binder exception: e has data type RECURSIVE_REL but (NODE,REL,STRUCT) was expected.
 
--CASE ReadVarlengthRelPropertyTest2
+
 -STATEMENT MATCH (a:person)-[e:knows*1..3]->(b:person) WHERE ID(e) = 0 RETURN COUNT(*)
 ---- error
-Binder exception: e has data type RECURSIVE_REL but (NODE,REL,STRUCT) was expected.
+Binder exception: Cannot match a built-in function for given function ID(RECURSIVE_REL). Supported inputs are
+(NODE)
+(REL)
+(STRUCT)
 
--CASE AccessRelInternalIDTest
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE e._id > 1 RETURN COUNT(*)
 ---- error
 Binder exception: _id is reserved for system usage. External access is not allowed.


### PR DESCRIPTION
Add `scalar_func_rewrite_t` to `ScalarFunction` so that we can move static function rewrite to its own file. This PR only change for `id(n)` (note that we rewrite `id(n)` to `n._id` at binding time)