### PR TITLE
Exclude extension files from the rust crate

### DIFF
--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -14,7 +14,6 @@ include = [
     "build.rs",
     "/src",
     "/include",
-    "/kuzu-src/extension",
     "/kuzu-src/src",
     "/kuzu-src/third_party",
     "/kuzu-src/Makefile",


### PR DESCRIPTION
It's mostly the tests which are at fault, but the extension isn't being used and was only being included before since it was originally just source files and was being unconditionally referenced by `add_subdirectory` in the main CMakeLists.txt (which is no longer the case as of #3074).
This was adding ~18MB of not very compressible data to the crate, bringing its size up to ~11MB compressed (the limit is 10MB compressed). Without them it's just 2.7MB compressed.

Fixes #3075