### PR TITLE
Make Property properly use explicit copy

### DIFF
--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -4,6 +4,7 @@
 
 #include "catalog/property.h"
 #include "catalog_entry.h"
+#include "common/copy_constructors.h"
 #include "common/enums/table_type.h"
 
 namespace kuzu {
@@ -19,7 +20,7 @@ public:
         : CatalogEntry{catalogType, std::move(name)}, tableID{tableID}, nextPID{0} {}
     TableCatalogEntry(const TableCatalogEntry& other)
         : CatalogEntry{other}, tableID{other.tableID}, comment{other.comment},
-          nextPID{other.nextPID}, properties{other.properties} {}
+          nextPID{other.nextPID}, properties{copyVector(other.properties)} {}
 
     //===--------------------------------------------------------------------===//
     // getter & setter

--- a/src/include/catalog/property.h
+++ b/src/include/catalog/property.h
@@ -20,9 +20,6 @@ public:
         common::property_id_t propertyID, common::table_id_t tableID)
         : name{std::move(name)}, dataType{std::move(dataType)},
           propertyID{propertyID}, tableID{tableID} {}
-    Property(const Property& other)
-        : name{other.name}, dataType{other.dataType->copy()},
-          propertyID{other.propertyID}, tableID{other.tableID} {}
     EXPLICIT_COPY_DEFAULT_MOVE(Property);
 
     std::string getName() const { return name; }
@@ -40,6 +37,11 @@ public:
 
     static void toCypher(
         const std::vector<kuzu::catalog::Property>& properties, std::stringstream& ss);
+
+private:
+    Property(const Property& other)
+        : name{other.name}, dataType{other.dataType->copy()},
+          propertyID{other.propertyID}, tableID{other.tableID} {}
 
 private:
     std::string name;

--- a/src/include/main/client_config.h
+++ b/src/include/main/client_config.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace kuzu {


### PR DESCRIPTION
It should have a private copy constructor, and `vector<Property>` can be copied using `copyVector`