### PR TITLE
Add scan function replacement

### DIFF
--- a/src/binder/bind/bind_copy.cpp
+++ b/src/binder/bind/bind_copy.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<BoundStatement> Binder::bindCopyToClause(const Statement& statem
         columnTypes.push_back(column->getDataType());
     }
     if (fileType != FileType::CSV && fileType != FileType::PARQUET) {
-        throw BinderException(ExceptionMessage::validateCopyToCSVParquetExtensionsException());
+        throw BinderException("COPY TO currently only supports csv and parquet files.");
     }
     if (fileType != FileType::CSV && copyToStatement.getParsingOptionsRef().size() != 0) {
         throw BinderException{"Only copy to csv can have options."};

--- a/src/binder/bind/bind_reading_clause.cpp
+++ b/src/binder/bind/bind_reading_clause.cpp
@@ -161,6 +161,15 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& re
         auto objectSource = ku_dynamic_cast<BaseScanSource*, ObjectScanSource*>(source);
         auto objectName = objectSource->objectName;
         if (objectName.find("_") == std::string::npos) {
+            // Bind table
+            for (auto& scanReplacement : clientContext->getScanReplacements()) {
+                auto replaceData = scanReplacement.replaceFunc(objectName);
+                if (replaceData == nullptr) {
+                    continue ; // Fail to replace.
+                }
+                bindInput = replaceData->bindInput;
+            }
+
             auto objectExpr = expressionBinder.bindVariableExpression(objectName);
             auto literalExpr =
                 ku_dynamic_cast<const Expression*, const LiteralExpression*>(objectExpr.get());

--- a/src/binder/bind/bind_reading_clause.cpp
+++ b/src/binder/bind/bind_reading_clause.cpp
@@ -5,6 +5,7 @@
 #include "binder/query/reading_clause/bound_match_clause.h"
 #include "binder/query/reading_clause/bound_unwind_clause.h"
 #include "common/exception/binder.h"
+#include "common/exception/message.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
 #include "function/table/bind_input.h"
@@ -12,6 +13,7 @@
 #include "main/database.h"
 #include "main/database_manager.h"
 #include "parser/expression/parsed_function_expression.h"
+#include "parser/expression/parsed_variable_expression.h"
 #include "parser/query/reading_clause/in_query_call_clause.h"
 #include "parser/query/reading_clause/load_from.h"
 #include "parser/query/reading_clause/match_clause.h"
@@ -114,28 +116,52 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto expr = call.getFunctionExpression();
     auto functionExpr =
         ku_dynamic_cast<const ParsedExpression*, const ParsedFunctionExpression*>(expr);
-    std::vector<Value> inputValues;
+    // Bind parameters
+    std::unique_ptr<ScanReplacementData> replacementData;
+    expression_vector params;
     for (auto i = 0u; i < functionExpr->getNumChildren(); i++) {
-        auto parameter = expressionBinder.bindExpression(*functionExpr->getChild(i));
-        if (parameter->expressionType != ExpressionType::LITERAL) {
-            throw BinderException{
-                stringFormat("Cannot evaluate {} as a literal.", parameter->toString())};
+        auto child = functionExpr->getChild(i);
+        try {
+            params.push_back(expressionBinder.bindExpression(*child));
+        } catch (BinderException& exception) {
+            if (child->getExpressionType() != ExpressionType::VARIABLE) {
+                throw BinderException(exception.what()); // Cannot replace. Rethrow.
+            }
+            // Try replacement.
+            auto varExpr = ku_dynamic_cast<ParsedExpression*, ParsedVariableExpression*>(child);
+            auto var = varExpr->getVariableName();
+            replacementData = clientContext->tryReplace(var);
+            if (replacementData == nullptr) { // Replacement fail.
+                throw BinderException(ExceptionMessage::variableNotInScope(var));
+            }
         }
-        auto literalExpr =
-            ku_dynamic_cast<const Expression*, const LiteralExpression*>(parameter.get());
-        inputValues.push_back(*literalExpr->getValue());
     }
-    std::vector<LogicalType> inputTypes;
-    for (auto& val : inputValues) {
-        inputTypes.push_back(*val.getDataType());
+    TableFunction tableFunction;
+    std::unique_ptr<TableFuncBindData> bindData;
+    if (replacementData) {
+        tableFunction = replacementData->func;
+        bindData = tableFunction.bindFunc(clientContext, &replacementData->bindInput);
+    } else {
+        std::vector<Value> inputValues;
+        std::vector<LogicalType> inputTypes;
+        for (auto& param : params) {
+            if (param->expressionType != ExpressionType::LITERAL) {
+                throw BinderException{
+                    stringFormat("Cannot evaluate {} as a literal.", param->toString())};
+            }
+            auto literalExpr =
+                ku_dynamic_cast<const Expression*, const LiteralExpression*>(param.get());
+            inputTypes.push_back(literalExpr->getDataType());
+            inputValues.push_back(*literalExpr->getValue());
+        }
+        auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
+        auto func = BuiltInFunctionsUtils::matchFunction(
+            functionExpr->getFunctionName(), inputTypes, functions);
+        tableFunction = *ku_dynamic_cast<function::Function*, function::TableFunction*>(func);
+        auto bindInput = function::TableFuncBindInput();
+        bindInput.inputs = std::move(inputValues);
+        bindData = tableFunction.bindFunc(clientContext, &bindInput);
     }
-    auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
-    auto func = BuiltInFunctionsUtils::matchFunction(
-        functionExpr->getFunctionName(), inputTypes, functions);
-    auto tableFunc = ku_dynamic_cast<function::Function*, function::TableFunction*>(func);
-    auto bindInput = std::make_unique<function::TableFuncBindInput>();
-    bindInput->inputs = std::move(inputValues);
-    auto bindData = tableFunc->bindFunc(clientContext, bindInput.get());
     expression_vector columns;
     for (auto i = 0u; i < bindData->columnTypes.size(); i++) {
         columns.push_back(createVariable(bindData->columnNames[i], bindData->columnTypes[i]));
@@ -143,7 +169,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
     auto offset = expressionBinder.createVariableExpression(
         *LogicalType::INT64(), std::string(InternalKeyword::ROW_OFFSET));
     auto boundInQueryCall = std::make_unique<BoundInQueryCall>(
-        *tableFunc, std::move(bindData), std::move(columns), offset);
+        tableFunction, std::move(bindData), std::move(columns), offset);
     if (call.hasWherePredicate()) {
         auto wherePredicate = expressionBinder.bindExpression(*call.getWherePredicate());
         boundInQueryCall->setPredicate(std::move(wherePredicate));
@@ -153,8 +179,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
 
 std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& readingClause) {
     auto& loadFrom = ku_dynamic_cast<const ReadingClause&, const LoadFrom&>(readingClause);
-    function::TableFunction scanFunction;
-    std::unique_ptr<TableFuncBindInput> bindInput;
+    TableFunction scanFunction;
+    std::unique_ptr<TableFuncBindData> bindData;
     auto source = loadFrom.getSource();
     switch (source->type) {
     case ScanSourceType::OBJECT: {
@@ -162,23 +188,12 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& re
         auto objectName = objectSource->objectName;
         if (objectName.find("_") == std::string::npos) {
             // Bind table
-            for (auto& scanReplacement : clientContext->getScanReplacements()) {
-                auto replaceData = scanReplacement.replaceFunc(objectName);
-                if (replaceData == nullptr) {
-                    continue ; // Fail to replace.
-                }
-                bindInput = replaceData->bindInput;
+            auto replacementData = clientContext->tryReplace(objectName);
+            if (replacementData == nullptr) {
+                throw BinderException(ExceptionMessage::variableNotInScope(objectName));
             }
-
-            auto objectExpr = expressionBinder.bindVariableExpression(objectName);
-            auto literalExpr =
-                ku_dynamic_cast<const Expression*, const LiteralExpression*>(objectExpr.get());
-            auto functions = clientContext->getCatalog()->getFunctions(clientContext->getTx());
-            auto func = BuiltInFunctionsUtils::matchFunction(READ_PANDAS_FUNC_NAME,
-                std::vector<LogicalType>{objectExpr->getDataType()}, functions);
-            scanFunction = *ku_dynamic_cast<Function*, TableFunction*>(func);
-            bindInput = std::make_unique<function::TableFuncBindInput>();
-            bindInput->inputs.push_back(*literalExpr->getValue());
+            scanFunction = replacementData->func;
+            bindData = scanFunction.bindFunc(clientContext, &replacementData->bindInput);
         } else {
             auto dbName = common::StringUtils::split(objectName, "_")[0];
             auto attachedDB =
@@ -193,7 +208,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& re
             auto tableCatalogEntry = ku_dynamic_cast<CatalogEntry*, TableCatalogEntry*>(
                 attachedDB->getCatalogContent()->getTableCatalogEntry(tableID));
             scanFunction = tableCatalogEntry->getScanFunction();
-            bindInput = std::make_unique<function::TableFuncBindInput>();
+            auto bindInput = function::TableFuncBindInput();
+            bindData = scanFunction.bindFunc(clientContext, &bindInput);
         }
     } break;
     case ScanSourceType::FILE: {
@@ -222,16 +238,13 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& re
             expectedColumnTypes.push_back(*bindDataType(type));
         }
         scanFunction = getScanFunction(readerConfig->fileType, *readerConfig);
-        auto bindInput_ = std::make_unique<ScanTableFuncBindInput>(readerConfig->copy());
-        bindInput_->expectedColumnNames = std::move(expectedColumnNames);
-        bindInput_->expectedColumnTypes = std::move(expectedColumnTypes);
-        bindInput_->context = clientContext;
-        bindInput = std::move(bindInput_);
+        auto bindInput = ScanTableFuncBindInput(readerConfig->copy(),
+            std::move(expectedColumnNames), std::move(expectedColumnTypes), clientContext);
+        bindData = scanFunction.bindFunc(clientContext, &bindInput);
     } break;
     default:
         throw BinderException(stringFormat("LOAD FROM subquery is not supported."));
     }
-    auto bindData = scanFunction.bindFunc(clientContext, bindInput.get());
     expression_vector columns;
     for (auto i = 0u; i < bindData->columnTypes.size(); i++) {
         columns.push_back(createVariable(bindData->columnNames[i], bindData->columnTypes[i]));

--- a/src/binder/bind_expression/bind_variable_expression.cpp
+++ b/src/binder/bind_expression/bind_variable_expression.cpp
@@ -3,6 +3,7 @@
 #include "binder/expression/variable_expression.h"
 #include "binder/expression_binder.h"
 #include "common/exception/binder.h"
+#include "common/exception/message.h"
 #include "main/client_context.h"
 #include "parser/expression/parsed_variable_expression.h"
 
@@ -24,7 +25,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindVariableExpression(const std::
     if (binder->scope->contains(varName)) {
         return binder->scope->getExpression(varName);
     }
-    throw BinderException(stringFormat("Variable {} is not in scope.", varName));
+    throw BinderException(ExceptionMessage::variableNotInScope(varName));
 }
 
 std::shared_ptr<Expression> ExpressionBinder::createVariableExpression(

--- a/src/binder/bind_expression/bind_variable_expression.cpp
+++ b/src/binder/bind_expression/bind_variable_expression.cpp
@@ -24,14 +24,6 @@ std::shared_ptr<Expression> ExpressionBinder::bindVariableExpression(const std::
     if (binder->scope->contains(varName)) {
         return binder->scope->getExpression(varName);
     }
-    if (binder->clientContext->hasReplaceFunc()) {
-        auto val = Value(varName);
-        auto replacedVal = binder->clientContext->replaceFunc(&val);
-        if (replacedVal != nullptr) {
-            return std::make_shared<LiteralExpression>(
-                replacedVal->copy(), binder->getUniqueExpressionName(replacedVal->toString()));
-        }
-    }
     throw BinderException(stringFormat("Variable {} is not in scope.", varName));
 }
 

--- a/src/common/exception/message.cpp
+++ b/src/common/exception/message.cpp
@@ -21,6 +21,14 @@ std::string ExceptionMessage::invalidPKType(const std::string& type) {
         type);
 }
 
+std::string ExceptionMessage::nullPKException() {
+    return "Found NULL, which violates the non-null constraint of the primary key column.";
+}
+
+std::string ExceptionMessage::notAllowCopyOnNonEmptyTableException() {
+    return "COPY commands can only be executed once on a table.";
+}
+
 std::string ExceptionMessage::overLargeStringPKValueException(uint64_t length) {
     return stringFormat("The maximum length of primary key strings is 262144 bytes. The input "
                         "string's length was {}.",
@@ -45,6 +53,10 @@ std::string ExceptionMessage::violateRelMultiplicityConstraint(
     return stringFormat("Node(nodeOffset: {}) has more than one neighbour in table {} in the {} "
                         "direction, which violates the rel multiplicity constraint.",
         offset, tableName, direction);
+}
+
+std::string ExceptionMessage::variableNotInScope(const std::string& varName) {
+    return stringFormat("Variable {} is not in scope.", varName);
 }
 
 } // namespace common

--- a/src/include/common/copier_config/reader_config.h
+++ b/src/include/common/copier_config/reader_config.h
@@ -30,6 +30,7 @@ struct ReaderConfig {
     std::vector<std::string> filePaths;
     std::unordered_map<std::string, Value> options;
 
+    ReaderConfig() = default;
     ReaderConfig(FileType fileType, std::vector<std::string> filePaths)
         : fileType{fileType}, filePaths{std::move(filePaths)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ReaderConfig);

--- a/src/include/common/exception/message.h
+++ b/src/include/common/exception/message.h
@@ -6,26 +6,25 @@
 namespace kuzu {
 namespace common {
 
+// Add exception only if you need to throw it in multiple places.
 struct ExceptionMessage {
+    // Primary key.
     static std::string duplicatePKException(const std::string& pkString);
     static std::string nonExistentPKException(const std::string& pkString);
     static std::string invalidPKType(const std::string& type);
-    static inline std::string nullPKException() {
-        return "Found NULL, which violates the non-null constraint of the primary key column.";
-    }
-    static inline std::string notAllowCopyOnNonEmptyTableException() {
-        return "COPY commands can only be executed once on a table.";
-    }
+    static std::string nullPKException();
+    // Bulk insertion.
+    static std::string notAllowCopyOnNonEmptyTableException();
+    // Long string.
     static std::string overLargeStringPKValueException(uint64_t length);
     static std::string overLargeStringValueException(uint64_t length);
+    // Foreign key.
     static std::string violateDeleteNodeWithConnectedEdgesConstraint(
         const std::string& tableName, const std::string& offset, const std::string& direction);
     static std::string violateRelMultiplicityConstraint(
         const std::string& tableName, const std::string& offset, const std::string& direction);
-
-    static inline std::string validateCopyToCSVParquetExtensionsException() {
-        return "COPY TO currently only supports csv and parquet files.";
-    }
+    // Binding exception
+    static std::string variableNotInScope(const std::string& varName);
 };
 
 } // namespace common

--- a/src/include/function/table/bind_input.h
+++ b/src/include/function/table/bind_input.h
@@ -19,7 +19,7 @@ struct TableFuncBindInput {
     EXPLICIT_COPY_DEFAULT_MOVE(TableFuncBindInput);
     virtual ~TableFuncBindInput() = default;
 
-private:
+protected:
     TableFuncBindInput(const TableFuncBindInput& other) : inputs{other.inputs} {}
 };
 
@@ -30,7 +30,6 @@ struct ScanTableFuncBindInput final : public TableFuncBindInput {
     main::ClientContext* context;
 
     explicit ScanTableFuncBindInput(common::ReaderConfig config) : config{std::move(config)} {};
-    EXPLICIT_COPY_DEFAULT_MOVE(ScanTableFuncBindInput);
     ScanTableFuncBindInput(common::ReaderConfig config,
         std::vector<std::string> expectedColumnNames,
         std::vector<common::LogicalType> expectedColumnTypes, main::ClientContext* context)
@@ -39,9 +38,13 @@ struct ScanTableFuncBindInput final : public TableFuncBindInput {
           expectedColumnTypes{std::move(expectedColumnTypes)}, context{context} {
         inputs.push_back(common::Value::createValue(this->config.filePaths[0]));
     }
+    EXPLICIT_COPY_DEFAULT_MOVE(ScanTableFuncBindInput);
 
 private:
-    ScanTableFuncBindInput(const ScanTableFuncBindInput& other) : {}
+    ScanTableFuncBindInput(const ScanTableFuncBindInput& other)
+        : TableFuncBindInput{other}, config{other.config.copy()},
+          expectedColumnNames{other.expectedColumnNames},
+          expectedColumnTypes{other.expectedColumnTypes}, context{other.context} {}
 };
 
 } // namespace function

--- a/src/include/function/table/bind_input.h
+++ b/src/include/function/table/bind_input.h
@@ -16,8 +16,11 @@ struct TableFuncBindInput {
     std::vector<common::Value> inputs;
 
     TableFuncBindInput() = default;
-    DELETE_COPY_DEFAULT_MOVE(TableFuncBindInput);
+    EXPLICIT_COPY_DEFAULT_MOVE(TableFuncBindInput);
     virtual ~TableFuncBindInput() = default;
+
+private:
+    TableFuncBindInput(const TableFuncBindInput& other) : inputs{other.inputs} {}
 };
 
 struct ScanTableFuncBindInput final : public TableFuncBindInput {
@@ -27,6 +30,7 @@ struct ScanTableFuncBindInput final : public TableFuncBindInput {
     main::ClientContext* context;
 
     explicit ScanTableFuncBindInput(common::ReaderConfig config) : config{std::move(config)} {};
+    EXPLICIT_COPY_DEFAULT_MOVE(ScanTableFuncBindInput);
     ScanTableFuncBindInput(common::ReaderConfig config,
         std::vector<std::string> expectedColumnNames,
         std::vector<common::LogicalType> expectedColumnTypes, main::ClientContext* context)
@@ -35,6 +39,9 @@ struct ScanTableFuncBindInput final : public TableFuncBindInput {
           expectedColumnTypes{std::move(expectedColumnTypes)}, context{context} {
         inputs.push_back(common::Value::createValue(this->config.filePaths[0]));
     }
+
+private:
+    ScanTableFuncBindInput(const ScanTableFuncBindInput& other) : {}
 };
 
 } // namespace function

--- a/src/include/function/table/scan_replacement.h
+++ b/src/include/function/table/scan_replacement.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "function/table_functions.h"
 #include "function/table/bind_input.h"
+#include "function/table_functions.h"
 
 namespace kuzu {
 namespace function {
@@ -19,5 +19,5 @@ struct ScanReplacement {
     scan_replace_func_t replaceFunc;
 };
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/table/scan_replacement.h
+++ b/src/include/function/table/scan_replacement.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "function/table_functions.h"
+#include "function/table/bind_input.h"
+
+namespace kuzu {
+namespace function {
+
+struct ScanReplacementData {
+    TableFunction func;
+    TableFuncBindInput bindInput;
+};
+
+using scan_replace_func_t = std::function<std::unique_ptr<ScanReplacementData>(const std::string&)>;
+
+struct ScanReplacement {
+    ScanReplacement(scan_replace_func_t replaceFunc) : replaceFunc{replaceFunc} {}
+
+    scan_replace_func_t replaceFunc;
+};
+
+}
+}

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -4,17 +4,8 @@
 #include "function.h"
 
 namespace kuzu {
-namespace catalog {
-class Catalog;
-} // namespace catalog
-namespace common {
-class ValueVector;
-}
 namespace main {
 class ClientContext;
-}
-namespace storage {
-class StorageManager;
 }
 
 namespace function {
@@ -73,7 +64,7 @@ using table_func_init_local_t = std::function<std::unique_ptr<TableFuncLocalStat
     TableFunctionInitInput&, TableFuncSharedState*, storage::MemoryManager*)>;
 using table_func_can_parallel_t = std::function<bool()>;
 
-struct TableFunction : public Function {
+struct TableFunction final : public Function {
     table_func_t tableFunc;
     table_func_bind_t bindFunc;
     table_func_init_shared_t initSharedStateFunc;

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -10,12 +10,12 @@
 #include "common/timer.h"
 #include "common/types/value/value.h"
 #include "function/scalar_function.h"
+#include "function/table/scan_replacement.h"
 #include "main/kuzu_fwd.h"
 #include "parser/statement.h"
 #include "prepared_statement.h"
 #include "query_result.h"
 #include "transaction/transaction_context.h"
-#include "function/table/scan_replacement.h"
 
 namespace kuzu {
 
@@ -79,9 +79,7 @@ public:
 
     // Replace function.
     void addScanReplace(function::ScanReplacement scanReplacement);
-    const std::vector<function::ScanReplacement>& getScanReplacements() const {
-        return scanReplacements;
-    }
+    std::unique_ptr<function::ScanReplacementData> tryReplace(const std::string& objectName) const;
     // Extension
     KUZU_API void setExtensionOption(std::string name, common::Value value);
     extension::ExtensionOptions* getExtensionOptions() const;

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -131,11 +131,7 @@ public:
         commitUDFTrx(autoTrx);
     }
 
-    inline void setReplaceFunc(replace_func_t replaceFunc) {
-        clientContext->setReplaceFunc(std::move(replaceFunc));
-    }
-
-    inline ClientContext* getClientContext() { return clientContext.get(); };
+    ClientContext* getClientContext() { return clientContext.get(); };
 
 private:
     std::unique_ptr<QueryResult> query(

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -119,6 +119,18 @@ void ClientContext::addScanReplace(function::ScanReplacement scanReplacement) {
     scanReplacements.push_back(std::move(scanReplacement));
 }
 
+std::unique_ptr<function::ScanReplacementData> ClientContext::tryReplace(
+    const std::string& objectName) const {
+    for (auto& scanReplacement : scanReplacements) {
+        auto replaceData = scanReplacement.replaceFunc(objectName);
+        if (replaceData == nullptr) {
+            continue; // Fail to replace.
+        }
+        return replaceData;
+    }
+    return nullptr;
+}
+
 void ClientContext::setExtensionOption(std::string name, common::Value value) {
     StringUtils::toLower(name);
     extensionOptionValues.insert_or_assign(name, std::move(value));

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -115,6 +115,10 @@ TransactionContext* ClientContext::getTransactionContext() const {
     return transactionContext.get();
 }
 
+void ClientContext::addScanReplace(function::ScanReplacement scanReplacement) {
+    scanReplacements.push_back(std::move(scanReplacement));
+}
+
 void ClientContext::setExtensionOption(std::string name, common::Value value) {
     StringUtils::toLower(name);
     extensionOptionValues.insert_or_assign(name, std::move(value));

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -25,24 +25,6 @@ struct PandasScanSharedState : public function::BaseScanSharedState {
 
 struct PandasScanFunction {
     static function::function_set getFunctionSet();
-
-    static common::offset_t tableFunc(function::TableFuncInput& input, function::TableFuncOutput& output);
-
-    static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext* /*context*/,
-        function::TableFuncBindInput* input);
-
-    static std::unique_ptr<function::TableFuncSharedState> initSharedState(
-        function::TableFunctionInitInput& input);
-
-    static std::unique_ptr<function::TableFuncLocalState> initLocalState(
-        function::TableFunctionInitInput& input, function::TableFuncSharedState* state,
-        storage::MemoryManager* /*mm*/);
-
-    static bool sharedStateNext(const function::TableFuncBindData* bindData,
-        PandasScanLocalState* localState, function::TableFuncSharedState* sharedState);
-
-    static void pandasBackendScanSwitch(PandasColumnBindData* bindData, uint64_t count,
-        uint64_t offset, common::ValueVector* outputVector);
 };
 
 struct PandasScanFunctionData : public function::TableFuncBindData {
@@ -69,6 +51,6 @@ struct PandasScanFunctionData : public function::TableFuncBindData {
     }
 };
 
-std::unique_ptr<common::Value> replacePD(common::Value* value);
+std::unique_ptr<function::ScanReplacementData> replacePD(const std::string& objectName);
 
 } // namespace kuzu

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -31,7 +31,7 @@ static TableFunction getFunction() {
         initLocalState, std::vector<LogicalTypeID>{LogicalTypeID::POINTER});
 }
 
-function_set getFunctionSet() {
+function_set PandasScanFunction::getFunctionSet() {
     function_set functionSet;
     functionSet.push_back(getFunction().copy());
     return functionSet;

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -5,6 +5,7 @@
 #include "numpy/numpy_scan.h"
 #include "py_connection.h"
 #include "pybind11/pytypes.h"
+#include "binder/expression/function_expression.h"
 
 using namespace kuzu::function;
 using namespace kuzu::common;
@@ -12,15 +13,31 @@ using namespace kuzu::catalog;
 
 namespace kuzu {
 
-function_set PandasScanFunction::getFunctionSet() {
+static offset_t tableFunc(TableFuncInput&, TableFuncOutput&);
+static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext*,
+    TableFuncBindInput*);
+static std::unique_ptr<TableFuncSharedState> initSharedState(
+    TableFunctionInitInput&);
+static std::unique_ptr<TableFuncLocalState> initLocalState(
+    TableFunctionInitInput&, TableFuncSharedState*,
+    storage::MemoryManager*);
+static bool sharedStateNext(const TableFuncBindData*,
+    PandasScanLocalState*, TableFuncSharedState*);
+static void pandasBackendScanSwitch(PandasColumnBindData*, uint64_t,
+    uint64_t, ValueVector*);
+
+static TableFunction getFunction() {
+    return TableFunction(READ_PANDAS_FUNC_NAME, tableFunc, bindFunc, initSharedState,
+        initLocalState, std::vector<LogicalTypeID>{LogicalTypeID::POINTER});
+}
+
+function_set getFunctionSet() {
     function_set functionSet;
-    functionSet.push_back(
-        std::make_unique<TableFunction>(READ_PANDAS_FUNC_NAME, tableFunc, bindFunc, initSharedState,
-            initLocalState, std::vector<LogicalTypeID>{LogicalTypeID::POINTER}));
+    functionSet.push_back(getFunction().copy());
     return functionSet;
 }
 
-std::unique_ptr<function::TableFuncBindData> PandasScanFunction::bindFunc(
+std::unique_ptr<TableFuncBindData> bindFunc(
     main::ClientContext* /*context*/, TableFuncBindInput* input) {
     py::gil_scoped_acquire acquire;
     py::handle df(reinterpret_cast<PyObject*>(input->inputs[0].getValue<uint8_t*>()));
@@ -39,8 +56,8 @@ std::unique_ptr<function::TableFuncBindData> PandasScanFunction::bindFunc(
         std::move(returnTypes), std::move(names), df, numRows, std::move(columnBindData));
 }
 
-bool PandasScanFunction::sharedStateNext(const TableFuncBindData* /*bindData*/,
-    PandasScanLocalState* localState, function::TableFuncSharedState* sharedState) {
+bool sharedStateNext(const TableFuncBindData* /*bindData*/,
+    PandasScanLocalState* localState, TableFuncSharedState* sharedState) {
     auto pandasSharedState = reinterpret_cast<PandasScanSharedState*>(sharedState);
     std::lock_guard<std::mutex> lck{pandasSharedState->lock};
     if (pandasSharedState->position >= pandasSharedState->numRows) {
@@ -54,26 +71,26 @@ bool PandasScanFunction::sharedStateNext(const TableFuncBindData* /*bindData*/,
     return true;
 }
 
-std::unique_ptr<function::TableFuncLocalState> PandasScanFunction::initLocalState(
-    function::TableFunctionInitInput& input, function::TableFuncSharedState* sharedState,
-    storage::MemoryManager* /*mm*/) {
+std::unique_ptr<TableFuncLocalState> initLocalState(
+    TableFunctionInitInput& input, TableFuncSharedState* sharedState,
+    storage::MemoryManager*) {
     auto localState = std::make_unique<PandasScanLocalState>(0 /* start */, 0 /* end */);
     sharedStateNext(input.bindData, localState.get(), sharedState);
     return localState;
 }
 
-std::unique_ptr<function::TableFuncSharedState> PandasScanFunction::initSharedState(
-    function::TableFunctionInitInput& input) {
+std::unique_ptr<TableFuncSharedState> initSharedState(
+    TableFunctionInitInput& input) {
     // LCOV_EXCL_START
     if (PyGILState_Check()) {
-        throw common::RuntimeException("PandasScan called but GIL was already held!");
+        throw RuntimeException("PandasScan called but GIL was already held!");
     }
     // LCOV_EXCL_STOP
     auto scanBindData = reinterpret_cast<PandasScanFunctionData*>(input.bindData);
     return std::make_unique<PandasScanSharedState>(scanBindData->numRows);
 }
 
-void PandasScanFunction::pandasBackendScanSwitch(
+void pandasBackendScanSwitch(
     PandasColumnBindData* bindData, uint64_t count, uint64_t offset, ValueVector* outputVector) {
     auto backend = bindData->pandasCol->getBackEnd();
     switch (backend) {
@@ -85,8 +102,8 @@ void PandasScanFunction::pandasBackendScanSwitch(
     }
 }
 
-common::offset_t PandasScanFunction::tableFunc(
-    function::TableFuncInput& input, function::TableFuncOutput& output) {
+offset_t tableFunc(
+    TableFuncInput& input, TableFuncOutput& output) {
     auto pandasScanData = reinterpret_cast<PandasScanFunctionData*>(input.bindData);
     auto pandasLocalState = reinterpret_cast<PandasScanLocalState*>(input.localState);
 
@@ -115,33 +132,51 @@ std::vector<std::unique_ptr<PandasColumnBindData>> PandasScanFunctionData::copyC
     return result;
 }
 
-std::unique_ptr<Value> tryReplacePD(py::dict& dict, py::str& tableName) {
-    if (!dict.contains(tableName)) {
+//std::unique_ptr<Value> tryReplacePD(py::dict& dict, py::str& tableName) {
+//    if (!dict.contains(tableName)) {
+//        return nullptr;
+//    }
+//    auto entry = dict[tableName];
+//    if (PyConnection::isPandasDataframe(entry)) {
+//        return Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())).copy();
+//    } else {
+//        throw RuntimeException{"Only pandas dataframe is supported."};
+//    }
+//}
+
+
+static std::unique_ptr<ScanReplacementData> play(py::dict& dict, py::str& objectName) {
+    if (!dict.contains(objectName)) {
         return nullptr;
     }
-    auto entry = dict[tableName];
+    auto entry = dict[objectName];
     if (PyConnection::isPandasDataframe(entry)) {
-        return Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())).copy();
+        auto scanReplacementData = std::make_unique<ScanReplacementData>();
+        scanReplacementData->func = getFunction();
+        auto bindInput = TableFuncBindInput();
+        bindInput.inputs.push_back(Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())));
+        scanReplacementData->bindInput = std::move(bindInput);
+        return scanReplacementData;
     } else {
         throw RuntimeException{"Only pandas dataframe is supported."};
     }
 }
 
-std::unique_ptr<common::Value> replacePD(common::Value* value) {
-    auto pyTableName = py::str(value->getValue<std::string>());
+std::unique_ptr<ScanReplacementData> replacePD(const std::string& objectName) {
+    auto pyTableName = py::str(objectName);
     // Here we do an exhaustive search on the frame lineage.
     auto currentFrame = importCache->inspect.currentframe()();
     while (hasattr(currentFrame, "f_locals")) {
         auto localDict = py::reinterpret_borrow<py::dict>(currentFrame.attr("f_locals"));
         if (localDict) {
-            auto result = tryReplacePD(localDict, pyTableName);
+            auto result = play(localDict, pyTableName);
             if (result) {
                 return result;
             }
         }
         auto globalDict = py::reinterpret_borrow<py::dict>(currentFrame.attr("f_globals"));
         if (globalDict) {
-            auto result = tryReplacePD(globalDict, pyTableName);
+            auto result = play(globalDict, pyTableName);
             if (result) {
                 return result;
             }

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -132,20 +132,7 @@ std::vector<std::unique_ptr<PandasColumnBindData>> PandasScanFunctionData::copyC
     return result;
 }
 
-//std::unique_ptr<Value> tryReplacePD(py::dict& dict, py::str& tableName) {
-//    if (!dict.contains(tableName)) {
-//        return nullptr;
-//    }
-//    auto entry = dict[tableName];
-//    if (PyConnection::isPandasDataframe(entry)) {
-//        return Value::createValue(reinterpret_cast<uint8_t*>(entry.ptr())).copy();
-//    } else {
-//        throw RuntimeException{"Only pandas dataframe is supported."};
-//    }
-//}
-
-
-static std::unique_ptr<ScanReplacementData> play(py::dict& dict, py::str& objectName) {
+static std::unique_ptr<ScanReplacementData> tryReplacePD(py::dict& dict, py::str& objectName) {
     if (!dict.contains(objectName)) {
         return nullptr;
     }
@@ -169,14 +156,14 @@ std::unique_ptr<ScanReplacementData> replacePD(const std::string& objectName) {
     while (hasattr(currentFrame, "f_locals")) {
         auto localDict = py::reinterpret_borrow<py::dict>(currentFrame.attr("f_locals"));
         if (localDict) {
-            auto result = play(localDict, pyTableName);
+            auto result = tryReplacePD(localDict, pyTableName);
             if (result) {
                 return result;
             }
         }
         auto globalDict = py::reinterpret_borrow<py::dict>(currentFrame.attr("f_globals"));
         if (globalDict) {
-            auto result = play(globalDict, pyTableName);
+            auto result = tryReplacePD(globalDict, pyTableName);
             if (result) {
                 return result;
             }

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -33,7 +33,7 @@ void PyConnection::initialize(py::handle& m) {
 PyConnection::PyConnection(PyDatabase* pyDatabase, uint64_t numThreads) {
     storageDriver = std::make_unique<kuzu::main::StorageDriver>(pyDatabase->database.get());
     conn = std::make_unique<Connection>(pyDatabase->database.get());
-    conn->setReplaceFunc(kuzu::replacePD);
+    conn->getClientContext()->addScanReplace(function::ScanReplacement(kuzu::replacePD));
     if (numThreads > 0) {
         conn->setMaxNumThreadForExec(numThreads);
     }


### PR DESCRIPTION
Add `ScanReplacementData` or external object scanning. Each external scan should provide a `scan_replace_func_t` that can return its own scan (table) function.