### PR TITLE
Hash index cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.3.2.2 LANGUAGES CXX C)
+project(Kuzu VERSION 0.3.2.3 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 

--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -75,7 +75,8 @@ public:
             return common::PhysicalTypeID::INT128;
         } else if constexpr (std::is_same_v<T, interval_t>) {
             return common::PhysicalTypeID::INTERVAL;
-        } else if constexpr (std::same_as<T, ku_string_t> || std::same_as<T, std::string>) {
+        } else if constexpr (std::same_as<T, ku_string_t> || std::same_as<T, std::string> ||
+                             std::same_as<T, std::string_view>) {
             return common::PhysicalTypeID::STRING;
         } else {
             KU_UNREACHABLE;

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -110,17 +110,16 @@ private:
     void copyAndUpdateSlotHeader(
         Slot<T>& slot, entry_pos_t entryPos, K key, common::offset_t value, uint8_t fingerprint) {
         if constexpr (isCopyEntry) {
-            memcpy(
-                slot.entries[entryPos].data, &key, this->indexHeaderForWriteTrx->numBytesPerEntry);
+            slot.entries[entryPos].copyFrom((uint8_t*)&key);
         } else {
-            insert(key, slot.entries[entryPos].data, value);
+            insert(key, slot.entries[entryPos], value);
         }
         slot.header.setEntryValid(entryPos, fingerprint);
     }
 
-    inline void insert(Key key, uint8_t* entry, common::offset_t offset) {
-        memcpy(entry, &key, sizeof(Key));
-        memcpy(entry + sizeof(Key), &offset, sizeof(common::offset_t));
+    inline void insert(Key key, SlotEntry<T>& entry, common::offset_t offset) {
+        entry.key = key;
+        entry.value = offset;
     }
     inline common::hash_t hashStored(transaction::TransactionType /*trxType*/, const T& key) const {
         return HashIndexUtils::hash(key);

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 #include "common/type_utils.h"
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
@@ -13,7 +15,7 @@
 namespace kuzu {
 namespace storage {
 
-template<typename T, typename S = T>
+template<typename T>
 class HashIndexLocalStorage;
 
 class OnDiskHashIndex {
@@ -46,7 +48,7 @@ public:
 //
 // T is the key type used to access values
 // S is the stored type, which is usually the same as T, with the exception of strings
-template<typename T, typename S = T>
+template<typename T>
 class HashIndex final : public OnDiskHashIndex {
 
 public:
@@ -57,9 +59,11 @@ public:
     ~HashIndex() override;
 
 public:
-    bool lookupInternal(transaction::Transaction* transaction, T key, common::offset_t& result);
-    void deleteInternal(T key) const;
-    bool insertInternal(T key, common::offset_t value);
+    using Key =
+        typename std::conditional<std::same_as<T, common::ku_string_t>, std::string_view, T>::type;
+    bool lookupInternal(transaction::Transaction* transaction, Key key, common::offset_t& result);
+    void deleteInternal(Key key) const;
+    bool insertInternal(Key key, common::offset_t value);
 
     void prepareCommit() override;
     void prepareRollback() override;
@@ -69,27 +73,27 @@ public:
 
 private:
     bool lookupInPersistentIndex(
-        transaction::TransactionType trxType, T key, common::offset_t& result);
+        transaction::TransactionType trxType, Key key, common::offset_t& result);
     // The following two functions are only used in prepareCommit, and are not thread-safe.
-    void insertIntoPersistentIndex(T key, common::offset_t value);
-    void deleteFromPersistentIndex(T key);
+    void insertIntoPersistentIndex(Key key, common::offset_t value);
+    void deleteFromPersistentIndex(Key key);
 
-    entry_pos_t findMatchedEntryInSlot(transaction::TransactionType trxType, const Slot<S>& slot,
-        T key, uint8_t fingerprint) const;
+    entry_pos_t findMatchedEntryInSlot(transaction::TransactionType trxType, const Slot<T>& slot,
+        Key key, uint8_t fingerprint) const;
 
-    inline void updateSlot(const SlotInfo& slotInfo, const Slot<S>& slot) {
+    inline void updateSlot(const SlotInfo& slotInfo, const Slot<T>& slot) {
         slotInfo.slotType == SlotType::PRIMARY ? pSlots->update(slotInfo.slotId, slot) :
                                                  oSlots->update(slotInfo.slotId, slot);
     }
 
-    inline Slot<S> getSlot(transaction::TransactionType trxType, const SlotInfo& slotInfo) {
+    inline Slot<T> getSlot(transaction::TransactionType trxType, const SlotInfo& slotInfo) {
         return slotInfo.slotType == SlotType::PRIMARY ? pSlots->get(slotInfo.slotId, trxType) :
                                                         oSlots->get(slotInfo.slotId, trxType);
     }
 
-    inline uint32_t appendPSlot() { return pSlots->pushBack(Slot<S>{}); }
+    inline uint32_t appendPSlot() { return pSlots->pushBack(Slot<T>{}); }
 
-    inline uint64_t appendOverflowSlot(Slot<S>&& newSlot) { return oSlots->pushBack(newSlot); }
+    inline uint64_t appendOverflowSlot(Slot<T>&& newSlot) { return oSlots->pushBack(newSlot); }
 
     inline void splitSlot(HashIndexHeader& header) {
         appendPSlot();
@@ -99,12 +103,12 @@ private:
     void rehashSlots(HashIndexHeader& header);
 
     inline bool equals(
-        transaction::TransactionType /*trxType*/, T keyToLookup, const S& keyInEntry) const {
+        transaction::TransactionType /*trxType*/, Key keyToLookup, const T& keyInEntry) const {
         return keyToLookup == keyInEntry;
     }
     template<typename K, bool isCopyEntry>
     void copyAndUpdateSlotHeader(
-        Slot<S>& slot, entry_pos_t entryPos, K key, common::offset_t value, uint8_t fingerprint) {
+        Slot<T>& slot, entry_pos_t entryPos, K key, common::offset_t value, uint8_t fingerprint) {
         if constexpr (isCopyEntry) {
             memcpy(
                 slot.entries[entryPos].data, &key, this->indexHeaderForWriteTrx->numBytesPerEntry);
@@ -114,17 +118,17 @@ private:
         slot.header.setEntryValid(entryPos, fingerprint);
     }
 
-    inline void insert(T key, uint8_t* entry, common::offset_t offset) {
-        memcpy(entry, &key, sizeof(T));
-        memcpy(entry + sizeof(T), &offset, sizeof(common::offset_t));
+    inline void insert(Key key, uint8_t* entry, common::offset_t offset) {
+        memcpy(entry, &key, sizeof(Key));
+        memcpy(entry + sizeof(Key), &offset, sizeof(common::offset_t));
     }
-    inline common::hash_t hashStored(transaction::TransactionType /*trxType*/, const S& key) const {
+    inline common::hash_t hashStored(transaction::TransactionType /*trxType*/, const T& key) const {
         return HashIndexUtils::hash(key);
     }
 
     struct SlotIterator {
         SlotInfo slotInfo;
-        Slot<S> slot;
+        Slot<T> slot;
     };
 
     SlotIterator getSlotIterator(slot_id_t slotId, transaction::TransactionType trxType) {
@@ -142,20 +146,20 @@ private:
         return false;
     }
 
-    std::vector<std::pair<SlotInfo, Slot<S>>> getChainedSlots(slot_id_t pSlotId);
+    std::vector<std::pair<SlotInfo, Slot<T>>> getChainedSlots(slot_id_t pSlotId);
 
     template<typename K, bool isCopyEntry>
-    void copyKVOrEntryToSlot(const SlotInfo& slotInfo, Slot<S>& slot, K key, common::offset_t value,
+    void copyKVOrEntryToSlot(const SlotInfo& slotInfo, Slot<T>& slot, K key, common::offset_t value,
         uint8_t fingerprint) {
-        if (slot.header.numEntries() == getSlotCapacity<S>()) {
+        if (slot.header.numEntries() == getSlotCapacity<T>()) {
             // Allocate a new oSlot, insert the entry to the new oSlot, and update slot's
             // nextOvfSlotId.
-            Slot<S> newSlot;
+            Slot<T> newSlot;
             auto entryPos = 0u; // Always insert to the first entry when there is a new slot.
             copyAndUpdateSlotHeader<K, isCopyEntry>(newSlot, entryPos, key, value, fingerprint);
             slot.header.nextOvfSlotId = appendOverflowSlot(std::move(newSlot));
         } else {
-            for (auto entryPos = 0u; entryPos < getSlotCapacity<S>(); entryPos++) {
+            for (auto entryPos = 0u; entryPos < getSlotCapacity<T>(); entryPos++) {
                 if (!slot.header.isEntryValid(entryPos)) {
                     copyAndUpdateSlotHeader<K, isCopyEntry>(
                         slot, entryPos, key, value, fingerprint);
@@ -166,34 +170,33 @@ private:
         updateSlot(slotInfo, slot);
     }
 
-    void copyEntryToSlot(slot_id_t slotId, const S& entry, uint8_t fingerprint);
+    void copyEntryToSlot(slot_id_t slotId, const T& entry, uint8_t fingerprint);
 
 private:
     // Local Storage for strings stores an std::string, but still takes std::string_view as keys to
     // avoid unnecessary copying
-    using LocalStorageType =
-        typename std::conditional<std::is_same<T, std::string_view>::value, std::string, T>::type;
+    using LocalStorageType = typename std::conditional<std::is_same<T, common::ku_string_t>::value,
+        std::string, T>::type;
     DBFileIDAndName dbFileIDAndName;
     BufferManager& bm;
     WAL* wal;
     std::shared_ptr<BMFileHandle> fileHandle;
     std::unique_ptr<BaseDiskArray<HashIndexHeader>> headerArray;
-    std::unique_ptr<BaseDiskArray<Slot<S>>> pSlots;
-    std::unique_ptr<BaseDiskArray<Slot<S>>> oSlots;
+    std::unique_ptr<BaseDiskArray<Slot<T>>> pSlots;
+    std::unique_ptr<BaseDiskArray<Slot<T>>> oSlots;
     OverflowFileHandle* overflowFileHandle;
-    std::unique_ptr<HashIndexLocalStorage<T, LocalStorageType>> localStorage;
+    std::unique_ptr<HashIndexLocalStorage<LocalStorageType>> localStorage;
     std::unique_ptr<HashIndexHeader> indexHeaderForReadTrx;
     std::unique_ptr<HashIndexHeader> indexHeaderForWriteTrx;
 };
 
 template<>
-common::hash_t HashIndex<std::string_view, common::ku_string_t>::hashStored(
+common::hash_t HashIndex<common::ku_string_t>::hashStored(
     transaction::TransactionType trxType, const common::ku_string_t& key) const;
 
 template<>
-inline bool HashIndex<std::string_view, common::ku_string_t>::equals(
-    transaction::TransactionType trxType, std::string_view keyToLookup,
-    const common::ku_string_t& keyInEntry) const;
+inline bool HashIndex<common::ku_string_t>::equals(transaction::TransactionType trxType,
+    std::string_view keyToLookup, const common::ku_string_t& keyInEntry) const;
 
 class PrimaryKeyIndex {
 public:
@@ -203,9 +206,13 @@ public:
 
     ~PrimaryKeyIndex();
 
-    template<typename T, typename S = T>
-    inline HashIndex<T, S>* getTypedHashIndex(T key) {
-        return common::ku_dynamic_cast<OnDiskHashIndex*, HashIndex<T, S>*>(
+    template<typename T>
+    using HashIndexType =
+        typename std::conditional<std::same_as<T, std::string_view> || std::same_as<T, std::string>,
+            common::ku_string_t, T>::type;
+    template<typename T>
+    inline HashIndex<HashIndexType<T>>* getTypedHashIndex(T key) {
+        return common::ku_dynamic_cast<OnDiskHashIndex*, HashIndex<HashIndexType<T>>*>(
             hashIndices[HashIndexUtils::getHashIndexPosition(key)].get());
     }
 
@@ -213,13 +220,7 @@ public:
         transaction::Transaction* trx, common::ku_string_t key, common::offset_t& result) {
         return lookup(trx, key.getAsStringView(), result);
     }
-    inline bool lookup(
-        transaction::Transaction* trx, std::string_view key, common::offset_t& result) {
-        KU_ASSERT(keyDataTypeID == common::PhysicalTypeID::STRING);
-        return getTypedHashIndex<std::string_view, common::ku_string_t>(key)->lookupInternal(
-            trx, key, result);
-    }
-    template<common::HashablePrimitive T>
+    template<common::IndexHashable T>
     inline bool lookup(transaction::Transaction* trx, T key, common::offset_t& result) {
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->lookupInternal(trx, key, result);
@@ -231,12 +232,7 @@ public:
     inline bool insert(common::ku_string_t key, common::offset_t value) {
         return insert(key.getAsStringView(), value);
     }
-    inline bool insert(std::string_view key, common::offset_t value) {
-        KU_ASSERT(keyDataTypeID == common::PhysicalTypeID::STRING);
-        return getTypedHashIndex<std::string_view, common::ku_string_t>(key)->insertInternal(
-            key, value);
-    }
-    template<common::HashablePrimitive T>
+    template<common::IndexHashable T>
     inline bool insert(T key, common::offset_t value) {
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->insertInternal(key, value);
@@ -244,11 +240,7 @@ public:
     bool insert(common::ValueVector* keyVector, uint64_t vectorPos, common::offset_t value);
 
     inline void delete_(common::ku_string_t key) { return delete_(key.getAsStringView()); }
-    inline void delete_(std::string_view key) {
-        KU_ASSERT(keyDataTypeID == common::PhysicalTypeID::STRING);
-        return getTypedHashIndex<std::string_view, common::ku_string_t>(key)->deleteInternal(key);
-    }
-    template<common::HashablePrimitive T>
+    template<common::IndexHashable T>
     inline void delete_(T key) {
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return getTypedHashIndex(key)->deleteInternal(key);

--- a/src/include/storage/index/hash_index_builder.h
+++ b/src/include/storage/index/hash_index_builder.h
@@ -101,9 +101,9 @@ private:
 
     inline void insert(
         Key key, Slot<T>* slot, uint8_t entryPos, common::offset_t value, uint8_t fingerprint) {
-        auto entry = slot->entries[entryPos].data;
-        memcpy(entry, &key, sizeof(T));
-        memcpy(entry + sizeof(T), &value, sizeof(common::offset_t));
+        auto& entry = slot->entries[entryPos];
+        entry.key = key;
+        entry.value = value;
         slot->header.setEntryValid(entryPos, fingerprint);
         KU_ASSERT(HashIndexUtils::getFingerprintForHash(HashIndexUtils::hash(key)) == fingerprint);
     }

--- a/src/include/storage/index/hash_index_header.h
+++ b/src/include/storage/index/hash_index_header.h
@@ -2,7 +2,6 @@
 
 #include "common/types/types.h"
 #include "hash_index_slot.h"
-#include "storage/storage_utils.h"
 
 namespace kuzu {
 namespace storage {
@@ -11,9 +10,7 @@ class HashIndexHeader {
 public:
     explicit HashIndexHeader(common::PhysicalTypeID keyDataTypeID)
         : currentLevel{1}, levelHashMask{1}, higherLevelHashMask{3}, nextSplitSlotId{0},
-          numEntries{0}, numBytesPerKey{storage::StorageUtils::getDataTypeSize(keyDataTypeID)},
-          numBytesPerEntry{(uint32_t)(numBytesPerKey + sizeof(common::offset_t))},
-          keyDataTypeID{keyDataTypeID} {}
+          numEntries{0}, keyDataTypeID{keyDataTypeID} {}
 
     // Used for element initialization in disk array only.
     HashIndexHeader() : HashIndexHeader(common::PhysicalTypeID::STRING) {}
@@ -38,8 +35,6 @@ public:
     uint64_t higherLevelHashMask;
     slot_id_t nextSplitSlotId;
     uint64_t numEntries;
-    uint32_t numBytesPerKey;
-    uint32_t numBytesPerEntry;
     common::PhysicalTypeID keyDataTypeID;
 };
 

--- a/src/include/storage/index/hash_index_slot.h
+++ b/src/include/storage/index/hash_index_slot.h
@@ -49,7 +49,15 @@ public:
 
 template<typename T>
 struct SlotEntry {
-    uint8_t data[sizeof(T) + sizeof(common::offset_t)];
+    T key;
+    common::offset_t value;
+
+    inline uint8_t* data() const { return (uint8_t*)&key; }
+
+    // otherEntry must be a pointer to the beginning of another slot's key field
+    inline void copyFrom(const uint8_t* otherEntry) {
+        memcpy(data(), otherEntry, sizeof(SlotEntry<T>));
+    }
 };
 
 template<typename T>

--- a/src/include/storage/index/hash_index_utils.h
+++ b/src/include/storage/index/hash_index_utils.h
@@ -1,21 +1,14 @@
 #pragma once
 
+#include <cmath>
+
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
 #include "function/hash/hash_functions.h"
 #include "storage/index/hash_index_header.h"
-#include "storage/storage_utils.h"
 
 namespace kuzu {
 namespace storage {
-
-// NOLINTBEGIN(cert-err58-cpp): This is the best way to get the datatype size because it avoids
-// refactoring.
-static const uint32_t NUM_BYTES_FOR_INT64_KEY =
-    storage::StorageUtils::getDataTypeSize(common::LogicalType{common::LogicalTypeID::INT64});
-static const uint32_t NUM_BYTES_FOR_STRING_KEY =
-    storage::StorageUtils::getDataTypeSize(common::LogicalType{common::LogicalTypeID::STRING});
-// NOLINTEND(cert-err58-cpp)
 
 const uint64_t NUM_HASH_INDEXES_LOG2 = 8;
 const uint64_t NUM_HASH_INDEXES = 1 << NUM_HASH_INDEXES_LOG2;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -25,14 +25,15 @@ enum class HashIndexLocalLookupState : uint8_t { KEY_FOUND, KEY_DELETED, KEY_NOT
 // all newly inserted entries, and the other (localDeletionIndex) is to keep track of newly deleted
 // entries (not available in localInsertionIndex). We assume that in a transaction, the insertions
 // and deletions are very small, thus they can be kept in memory.
-template<typename T, typename S>
+template<typename T>
 class HashIndexLocalStorage {
 public:
+    using Key = typename std::conditional<std::same_as<T, std::string>, std::string_view, T>::type;
     // Currently, we assume that reads(lookup) and writes(delete/insert) of the local storage will
     // never happen concurrently. Thus, lookup requires no local storage lock. Writes are
     // coordinated to execute in serial with the help of the localStorageMutex. This is a
     // simplification to the lock scheme, but can be relaxed later if necessary.
-    HashIndexLocalLookupState lookup(T key, common::offset_t& result) {
+    HashIndexLocalLookupState lookup(Key key, common::offset_t& result) {
         if (localDeletions.contains(key)) {
             return HashIndexLocalLookupState::KEY_DELETED;
         }
@@ -45,16 +46,16 @@ public:
         }
     }
 
-    void deleteKey(T key) {
+    void deleteKey(Key key) {
         auto iter = localInsertions.find(key);
         if (iter != localInsertions.end()) {
             localInsertions.erase(iter);
         } else {
-            localDeletions.insert(static_cast<S>(key));
+            localDeletions.insert(static_cast<T>(key));
         }
     }
 
-    bool insert(T key, common::offset_t value) {
+    bool insert(Key key, common::offset_t value) {
         auto iter = localDeletions.find(key);
         if (iter != localDeletions.end()) {
             localDeletions.erase(iter);
@@ -62,7 +63,7 @@ public:
         if (localInsertions.contains(key)) {
             return false;
         }
-        localInsertions[static_cast<S>(key)] = value;
+        localInsertions[static_cast<T>(key)] = value;
         return true;
     }
 
@@ -86,14 +87,14 @@ public:
 private:
     // When the storage type is string, allow the key type to be string_view with a custom hash
     // function
-    using hash_function = typename std::conditional<std::is_same<S, std::string>::value,
-        common::StringUtils::string_hash, std::hash<S>>::type;
-    std::unordered_map<S, common::offset_t, hash_function, std::equal_to<>> localInsertions;
-    std::unordered_set<S, hash_function, std::equal_to<>> localDeletions;
+    using hash_function = typename std::conditional<std::is_same<T, std::string>::value,
+        common::StringUtils::string_hash, std::hash<T>>::type;
+    std::unordered_map<T, common::offset_t, hash_function, std::equal_to<>> localInsertions;
+    std::unordered_set<T, hash_function, std::equal_to<>> localDeletions;
 };
 
-template<typename T, typename S>
-HashIndex<T, S>::HashIndex(const DBFileIDAndName& dbFileIDAndName,
+template<typename T>
+HashIndex<T>::HashIndex(const DBFileIDAndName& dbFileIDAndName,
     const std::shared_ptr<BMFileHandle>& fileHandle, OverflowFileHandle* overflowFileHandle,
     uint64_t indexPos, BufferManager& bufferManager, WAL* wal)
     : dbFileIDAndName{dbFileIDAndName}, bm{bufferManager}, wal{wal}, fileHandle(fileHandle),
@@ -106,15 +107,15 @@ HashIndex<T, S>::HashIndex(const DBFileIDAndName& dbFileIDAndName,
         headerArray->get(INDEX_HEADER_IDX_IN_ARRAY, TransactionType::READ_ONLY));
     this->indexHeaderForWriteTrx = std::make_unique<HashIndexHeader>(*indexHeaderForReadTrx);
     KU_ASSERT(
-        this->indexHeaderForReadTrx->keyDataTypeID == TypeUtils::getPhysicalTypeIDForType<S>());
-    pSlots = std::make_unique<BaseDiskArray<Slot<S>>>(*fileHandle, dbFileIDAndName.dbFileID,
+        this->indexHeaderForReadTrx->keyDataTypeID == TypeUtils::getPhysicalTypeIDForType<T>());
+    pSlots = std::make_unique<BaseDiskArray<Slot<T>>>(*fileHandle, dbFileIDAndName.dbFileID,
         NUM_HEADER_PAGES * indexPos + P_SLOTS_HEADER_PAGE_IDX, &bm, wal,
         Transaction::getDummyReadOnlyTrx().get());
-    oSlots = std::make_unique<BaseDiskArray<Slot<S>>>(*fileHandle, dbFileIDAndName.dbFileID,
+    oSlots = std::make_unique<BaseDiskArray<Slot<T>>>(*fileHandle, dbFileIDAndName.dbFileID,
         NUM_HEADER_PAGES * indexPos + O_SLOTS_HEADER_PAGE_IDX, &bm, wal,
         Transaction::getDummyReadOnlyTrx().get());
     // Initialize functions.
-    localStorage = std::make_unique<HashIndexLocalStorage<T, LocalStorageType>>();
+    localStorage = std::make_unique<HashIndexLocalStorage<LocalStorageType>>();
 }
 
 // For read transactions, local storage is skipped, lookups are performed on the persistent
@@ -125,8 +126,8 @@ HashIndex<T, S>::HashIndex(const DBFileIDAndName& dbFileIDAndName,
 // - the key has been marked as deleted in the local storage, return false;
 // - the key is neither deleted nor found in the local storage, lookup in the persistent
 // storage.
-template<typename T, typename S>
-bool HashIndex<T, S>::lookupInternal(Transaction* transaction, T key, offset_t& result) {
+template<typename T>
+bool HashIndex<T>::lookupInternal(Transaction* transaction, Key key, offset_t& result) {
     if (transaction->isReadOnly()) {
         return lookupInPersistentIndex(transaction->getType(), key, result);
     } else {
@@ -145,8 +146,8 @@ bool HashIndex<T, S>::lookupInternal(Transaction* transaction, T key, offset_t& 
 
 // For deletions, we don't check if the deleted keys exist or not. Thus, we don't need to check
 // in the persistent storage and directly delete keys in the local storage.
-template<typename T, typename S>
-void HashIndex<T, S>::deleteInternal(T key) const {
+template<typename T>
+void HashIndex<T>::deleteInternal(Key key) const {
     localStorage->deleteKey(key);
 }
 
@@ -156,8 +157,8 @@ void HashIndex<T, S>::deleteInternal(T key) const {
 // - the key doesn't exist in the local storage, check if the key exists in the persistent
 // index, if
 //   so, return false, else insert the key to the local storage.
-template<typename T, typename S>
-bool HashIndex<T, S>::insertInternal(T key, offset_t value) {
+template<typename T>
+bool HashIndex<T>::insertInternal(Key key, offset_t value) {
     offset_t tmpResult;
     auto localLookupState = localStorage->lookup(key, tmpResult);
     if (localLookupState == HashIndexLocalLookupState::KEY_FOUND) {
@@ -170,8 +171,8 @@ bool HashIndex<T, S>::insertInternal(T key, offset_t value) {
     return localStorage->insert(key, value);
 }
 
-template<typename T, typename S>
-bool HashIndex<T, S>::lookupInPersistentIndex(TransactionType trxType, T key, offset_t& result) {
+template<typename T>
+bool HashIndex<T>::lookupInPersistentIndex(TransactionType trxType, Key key, offset_t& result) {
     auto& header = trxType == TransactionType::READ_ONLY ? *this->indexHeaderForReadTrx :
                                                            *this->indexHeaderForWriteTrx;
     auto hashValue = HashIndexUtils::hash(key);
@@ -188,12 +189,12 @@ bool HashIndex<T, S>::lookupInPersistentIndex(TransactionType trxType, T key, of
     return false;
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::insertIntoPersistentIndex(T key, offset_t value) {
+template<typename T>
+void HashIndex<T>::insertIntoPersistentIndex(Key key, offset_t value) {
     auto& header = *this->indexHeaderForWriteTrx;
     slot_id_t numRequiredEntries = HashIndexUtils::getNumRequiredEntries(header.numEntries, 1);
     while (numRequiredEntries >
-           pSlots->getNumElements(TransactionType::WRITE) * getSlotCapacity<S>()) {
+           pSlots->getNumElements(TransactionType::WRITE) * getSlotCapacity<T>()) {
         this->splitSlot(header);
     }
     auto hashValue = HashIndexUtils::hash(key);
@@ -201,16 +202,16 @@ void HashIndex<T, S>::insertIntoPersistentIndex(T key, offset_t value) {
     auto iter = getSlotIterator(
         HashIndexUtils::getPrimarySlotIdForHash(header, hashValue), TransactionType::WRITE);
     // Find a slot with free entries
-    while (iter.slot.header.numEntries() == getSlotCapacity<S>() &&
+    while (iter.slot.header.numEntries() == getSlotCapacity<T>() &&
            nextChainedSlot(TransactionType::WRITE, iter))
         ;
-    copyKVOrEntryToSlot<T, false /* insert kv */>(
+    copyKVOrEntryToSlot<Key, false /* insert kv */>(
         iter.slotInfo, iter.slot, key, value, fingerprint);
     header.numEntries++;
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::deleteFromPersistentIndex(T key) {
+template<typename T>
+void HashIndex<T>::deleteFromPersistentIndex(Key key) {
     auto trxType = TransactionType::WRITE;
     auto header = *this->indexHeaderForWriteTrx;
     auto hashValue = HashIndexUtils::hash(key);
@@ -228,7 +229,7 @@ void HashIndex<T, S>::deleteFromPersistentIndex(T key) {
 }
 
 template<>
-inline common::hash_t HashIndex<std::string_view, ku_string_t>::hashStored(
+inline common::hash_t HashIndex<ku_string_t>::hashStored(
     transaction::TransactionType /*trxType*/, const ku_string_t& key) const {
     common::hash_t hash;
     auto str = overflowFileHandle->readString(TransactionType::WRITE, key);
@@ -236,39 +237,40 @@ inline common::hash_t HashIndex<std::string_view, ku_string_t>::hashStored(
     return hash;
 }
 
-template<typename T, typename S>
-entry_pos_t HashIndex<T, S>::findMatchedEntryInSlot(
-    TransactionType trxType, const Slot<S>& slot, T key, uint8_t fingerprint) const {
-    for (auto entryPos = 0u; entryPos < getSlotCapacity<S>(); entryPos++) {
+template<typename T>
+entry_pos_t HashIndex<T>::findMatchedEntryInSlot(
+    TransactionType trxType, const Slot<T>& slot, Key key, uint8_t fingerprint) const {
+    for (auto entryPos = 0u; entryPos < getSlotCapacity<T>(); entryPos++) {
         if (slot.header.isEntryValid(entryPos) &&
             slot.header.fingerprints[entryPos] == fingerprint &&
-            equals(trxType, key, *(S*)slot.entries[entryPos].data)) {
+            equals(trxType, key, *(T*)slot.entries[entryPos].data)) {
             return entryPos;
         }
     }
     return SlotHeader::INVALID_ENTRY_POS;
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::prepareCommit() {
+template<typename T>
+void HashIndex<T>::prepareCommit() {
     if (localStorage->hasUpdates()) {
         wal->addToUpdatedTables(dbFileIDAndName.dbFileID.nodeIndexID.tableID);
         localStorage->applyLocalChanges(
-            [this](T key) -> void { this->deleteFromPersistentIndex(key); },
-            [this](T key, offset_t value) -> void { this->insertIntoPersistentIndex(key, value); });
+            [this](Key key) -> void { this->deleteFromPersistentIndex(key); },
+            [this](
+                Key key, offset_t value) -> void { this->insertIntoPersistentIndex(key, value); });
         headerArray->update(INDEX_HEADER_IDX_IN_ARRAY, *indexHeaderForWriteTrx);
     }
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::prepareRollback() {
+template<typename T>
+void HashIndex<T>::prepareRollback() {
     if (localStorage->hasUpdates()) {
         wal->addToUpdatedTables(dbFileIDAndName.dbFileID.nodeIndexID.tableID);
     }
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::checkpointInMemory() {
+template<typename T>
+void HashIndex<T>::checkpointInMemory() {
     if (!localStorage->hasUpdates()) {
         return;
     }
@@ -277,13 +279,13 @@ void HashIndex<T, S>::checkpointInMemory() {
     pSlots->checkpointInMemoryIfNecessary();
     oSlots->checkpointInMemoryIfNecessary();
     localStorage->clear();
-    if constexpr (std::same_as<std::string_view, T>) {
+    if constexpr (std::same_as<ku_string_t, T>) {
         overflowFileHandle->checkpointInMemory();
     }
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::rollbackInMemory() {
+template<typename T>
+void HashIndex<T>::rollbackInMemory() {
     if (!localStorage->hasUpdates()) {
         return;
     }
@@ -295,7 +297,7 @@ void HashIndex<T, S>::rollbackInMemory() {
 }
 
 template<>
-inline bool HashIndex<std::string_view, ku_string_t>::equals(transaction::TransactionType trxType,
+inline bool HashIndex<ku_string_t>::equals(transaction::TransactionType trxType,
     std::string_view keyToLookup, const ku_string_t& keyInEntry) const {
     if (HashIndexUtils::areStringPrefixAndLenEqual(keyToLookup, keyInEntry)) {
         auto entryKeyString = overflowFileHandle->readString(trxType, keyInEntry);
@@ -305,25 +307,25 @@ inline bool HashIndex<std::string_view, ku_string_t>::equals(transaction::Transa
 }
 
 template<>
-inline void HashIndex<std::string_view, ku_string_t>::insert(
+inline void HashIndex<ku_string_t>::insert(
     std::string_view key, uint8_t* entry, common::offset_t offset) {
     auto kuString = overflowFileHandle->writeString(key);
     memcpy(entry, &kuString, NUM_BYTES_FOR_STRING_KEY);
     memcpy(entry + NUM_BYTES_FOR_STRING_KEY, &offset, sizeof(common::offset_t));
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::rehashSlots(HashIndexHeader& header) {
+template<typename T>
+void HashIndex<T>::rehashSlots(HashIndexHeader& header) {
     auto slotsToSplit = getChainedSlots(header.nextSplitSlotId);
     for (auto& [slotInfo, slot] : slotsToSplit) {
         auto slotHeader = slot.header;
         slot.header.reset();
         updateSlot(slotInfo, slot);
-        for (auto entryPos = 0u; entryPos < getSlotCapacity<S>(); entryPos++) {
+        for (auto entryPos = 0u; entryPos < getSlotCapacity<T>(); entryPos++) {
             if (!slotHeader.isEntryValid(entryPos)) {
                 continue; // Skip invalid entries.
             }
-            auto key = (S*)slot.entries[entryPos].data;
+            auto key = (T*)slot.entries[entryPos].data;
             hash_t hash = this->hashStored(TransactionType::WRITE, *key);
             auto fingerprint = HashIndexUtils::getFingerprintForHash(hash);
             auto newSlotId = hash & header.higherLevelHashMask;
@@ -332,9 +334,9 @@ void HashIndex<T, S>::rehashSlots(HashIndexHeader& header) {
     }
 }
 
-template<typename T, typename S>
-std::vector<std::pair<SlotInfo, Slot<S>>> HashIndex<T, S>::getChainedSlots(slot_id_t pSlotId) {
-    std::vector<std::pair<SlotInfo, Slot<S>>> slots;
+template<typename T>
+std::vector<std::pair<SlotInfo, Slot<T>>> HashIndex<T>::getChainedSlots(slot_id_t pSlotId) {
+    std::vector<std::pair<SlotInfo, Slot<T>>> slots;
     SlotInfo slotInfo{pSlotId, SlotType::PRIMARY};
     while (slotInfo.slotType == SlotType::PRIMARY || slotInfo.slotId != 0) {
         auto slot = getSlot(TransactionType::WRITE, slotInfo);
@@ -345,22 +347,22 @@ std::vector<std::pair<SlotInfo, Slot<S>>> HashIndex<T, S>::getChainedSlots(slot_
     return slots;
 }
 
-template<typename T, typename S>
-void HashIndex<T, S>::copyEntryToSlot(slot_id_t slotId, const S& entry, uint8_t fingerprint) {
+template<typename T>
+void HashIndex<T>::copyEntryToSlot(slot_id_t slotId, const T& entry, uint8_t fingerprint) {
     auto iter = getSlotIterator(slotId, TransactionType::WRITE);
     do {
-        if (iter.slot.header.numEntries() < getSlotCapacity<S>()) {
+        if (iter.slot.header.numEntries() < getSlotCapacity<T>()) {
             // Found a slot with empty space.
             break;
         }
     } while (nextChainedSlot(TransactionType::WRITE, iter));
-    copyKVOrEntryToSlot<const S&, true /* copy entry */>(
+    copyKVOrEntryToSlot<const T&, true /* copy entry */>(
         iter.slotInfo, iter.slot, entry, UINT32_MAX, fingerprint);
     updateSlot(iter.slotInfo, iter.slot);
 }
 
-template<typename T, typename S>
-HashIndex<T, S>::~HashIndex() = default;
+template<typename T>
+HashIndex<T>::~HashIndex() = default;
 
 template class HashIndex<int64_t>;
 template class HashIndex<int32_t>;
@@ -373,7 +375,7 @@ template class HashIndex<uint8_t>;
 template class HashIndex<double>;
 template class HashIndex<float>;
 template class HashIndex<int128_t>;
-template class HashIndex<std::string_view, ku_string_t>;
+template class HashIndex<ku_string_t>;
 
 PrimaryKeyIndex::PrimaryKeyIndex(const DBFileIDAndName& dbFileIDAndName, bool readOnly,
     common::PhysicalTypeID keyDataType, BufferManager& bufferManager, WAL* wal,
@@ -390,21 +392,21 @@ PrimaryKeyIndex::PrimaryKeyIndex(const DBFileIDAndName& dbFileIDAndName, bool re
     }
 
     hashIndices.reserve(NUM_HASH_INDEXES);
-    TypeUtils::visit(keyDataTypeID, [&]<typename T>(T) {
-        if constexpr (std::is_same_v<T, ku_string_t>) {
+    TypeUtils::visit(
+        keyDataTypeID,
+        [&](ku_string_t) {
             for (auto i = 0u; i < NUM_HASH_INDEXES; i++) {
-                hashIndices.push_back(std::make_unique<HashIndex<std::string_view, ku_string_t>>(
+                hashIndices.push_back(std::make_unique<HashIndex<ku_string_t>>(
                     dbFileIDAndName, fileHandle, overflowFile->addHandle(), i, bufferManager, wal));
             }
-        } else if constexpr (HashablePrimitive<T>) {
+        },
+        [&]<HashablePrimitive T>(T) {
             for (auto i = 0u; i < NUM_HASH_INDEXES; i++) {
                 hashIndices.push_back(std::make_unique<HashIndex<T>>(
                     dbFileIDAndName, fileHandle, nullptr, i, bufferManager, wal));
             }
-        } else {
-            KU_UNREACHABLE;
-        }
-    });
+        },
+        [&](auto) { KU_UNREACHABLE; });
 }
 
 bool PrimaryKeyIndex::lookup(Transaction* trx, common::ValueVector* keyVector, uint64_t vectorPos,


### PR DESCRIPTION
A couple of minor changes to the hash index. I've updated the HashIndex to use one template parameter like the HashIndexBuilder, and I've made SlotEntry store key/value instead of just a `data` byte array. We can still use memcpy to copy both together, but it provides an easier to read way of accessing and updating the key and value.