### PR TITLE
Python List and Map Parameter Support

### DIFF
--- a/tools/python_api/test/test_parameter.py
+++ b/tools/python_api/test/test_parameter.py
@@ -4,6 +4,11 @@ import datetime
 
 import pytest
 from type_aliases import ConnDB
+from typing import TYPE_CHECKING
+# required by python-lint
+if TYPE_CHECKING:
+    from pathlib import Path
+import kuzu
 
 
 def test_bool_param(conn_db_readonly: ConnDB) -> None:
@@ -64,6 +69,75 @@ def test_timestamp_param(conn_db_readonly: ConnDB) -> None:
     assert not result.has_next()
     result.close()
 
+def test_int64_list_param(conn_db_readonly: ConnDB) -> None:
+    conn, db = conn_db_readonly
+    result = conn.execute(
+        "MATCH (a:person {workedHours: $1}) RETURN COUNT(*);",
+        {"1": [3, 4, 5, 6, 7]})
+    assert result.has_next()
+    assert result.get_next() == [1]
+    assert not result.has_next()
+    result.close()
+
+def test_int64_list_list_param(conn_db_readonly: ConnDB) -> None:
+    conn, db = conn_db_readonly
+    result = conn.execute(
+        "MATCH (a:person) WHERE a.courseScoresPerTerm = $1 OR a.courseScoresPerTerm = $2 RETURN COUNT(*);",
+        {"1": [[8, 10]], "2": [[7, 4], [8, 8], [9]]})
+    assert result.has_next()
+    assert result.get_next() == [2]
+    assert not result.has_next()
+    result.close()
+
+def test_string_list_param(conn_db_readonly: ConnDB) -> None:
+    conn, db = conn_db_readonly
+    result = conn.execute(
+        "MATCH (a:person {usedNames: $1}) RETURN COUNT(*);",
+        {"1": ["Carmen", "Fred"]})
+    assert result.has_next()
+    assert result.get_next() == [1]
+    assert not result.has_next()
+    result = conn.execute(
+        "MATCH (a:person {usedNames: $1}) RETURN COUNT(*);",
+        {"1": []}) # empty list is string
+    result.close()
+
+def test_map_param(tmp_path: Path) -> None:
+    db = kuzu.Database(tmp_path)
+    conn = kuzu.Connection(db)
+    conn.execute("CREATE NODE TABLE tab(id int64, mp MAP(double, int64), mp2 MAP(int64, double), mp3 MAP(string, string), mp4 MAP(string, string), primary key(id))")
+    result = conn.execute(
+        "MERGE (t:tab {id: 0, mp: $1, mp2: $2, mp3: $3, mp4: $4}) RETURN t.*",
+        {"1": {1.0: 5, 2: 3, 2.2: -1},
+         "2": {5: -0.5, 4: 0, 0: 2.2},
+         "3": {'a': 1, 'b': '2', 'c': '3',
+         "4": {}}})
+    assert result.has_next()
+    assert result.get_next() == [0, {1.0: 5, 2.0: 3, 2.2: -1}, {5: -0.5, 4: -0.0, 0: 2.2}, {'a': '1', 'b': '2', 'c': '3'}, {}]
+    assert not result.has_next()
+    result.close()
+
+def test_general_list_param(tmp_path: Path) -> None:
+    db = kuzu.Database(tmp_path)
+    conn = kuzu.Connection(db)
+    conn.execute(
+        "CREATE NODE TABLE tab(id int64, lst1 BOOL[], lst2 DOUBLE[], lst3 TIMESTAMP[], lst4 DATE[], lst5 INTERVAL[], lst6 STRING[], PRIMARY KEY(id))")
+    lst1 = [True, False]
+    lst2 = [1.0, 2.0]
+    lst3 = [datetime.datetime(2019, 11, 12, 11, 25, 30), datetime.datetime(1987, 2, 15, 3, 0, 2)]
+    lst4 = [datetime.date(2019, 11, 12), datetime.date(1987, 2, 15)]
+    lst5 = [lst3[0] - lst3[1]]
+    lst6 = [1, 'a', 'b']
+    lst6ToString = ['1', 'a', 'b']
+    result = conn.execute(
+        "MERGE (t:tab {id: 0, lst1: $1, lst2: $2, lst3: $3, lst4: $4, lst5: $5, lst6: $6}) RETURN t.*",
+        {
+            "1": lst1, "2": lst2, "3": lst3, "4": lst4, "5": lst5, "6": lst6
+        })
+    assert result.has_next()
+    assert result.get_next() == [0, lst1, lst2, lst3, lst4, lst5, lst6ToString]
+    assert not result.has_next()
+    result.close()
 
 def test_param_error1(conn_db_readonly: ConnDB) -> None:
     conn, db = conn_db_readonly
@@ -81,3 +155,10 @@ def test_param_error3(conn_db_readonly: ConnDB) -> None:
     conn, db = conn_db_readonly
     with pytest.raises(RuntimeError, match="Parameters must be a dict"):
         conn.execute("MATCH (a:person) WHERE a.registerTime = $1 RETURN COUNT(*);", [("asd", 1, 1)])
+
+
+def test_param_error4(conn_db_readonly: ConnDB) -> None:
+    conn, db = conn_db_readonly
+    with pytest.raises(RuntimeError, match="Runtime exception: Cannot convert Python object to Kuzu value : INT64  is incompatible with TIMESTAMP"):
+        conn.execute("MATCH (a:person {workedHours: $1}) RETURN COUNT(*);", {'1': [1, 2, datetime.datetime(2023, 3, 25)]})
+

--- a/tools/python_api/test/test_parameter.py
+++ b/tools/python_api/test/test_parameter.py
@@ -110,8 +110,8 @@ def test_map_param(tmp_path: Path) -> None:
         "MERGE (t:tab {id: 0, mp: $1, mp2: $2, mp3: $3, mp4: $4}) RETURN t.*",
         {"1": {1.0: 5, 2: 3, 2.2: -1},
          "2": {5: -0.5, 4: 0, 0: 2.2},
-         "3": {'a': 1, 'b': '2', 'c': '3',
-         "4": {}}})
+         "3": {'a': 1, 'b': '2', 'c': '3'},
+         "4": {}})
     assert result.has_next()
     assert result.get_next() == [0, {1.0: 5, 2.0: 3, 2.2: -1}, {5: -0.5, 4: -0.0, 0: 2.2}, {'a': '1', 'b': '2', 'c': '3'}, {}]
     assert not result.has_next()


### PR DESCRIPTION
Add support for #3054 

NOTE: a lot of functions remain unavailable with nested parameter types. For example, we cannot currently bind functions like `list_contains(a, b)` if `a` is a parameter. 