### PR TITLE
Update rustdoc to show how to enable parallel compilation

### DIFF
--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -23,13 +23,15 @@
 //!
 //! ## Safety
 //!
-//! Generally, use of of this API is safe, however creating multiple databases in the same
-//! scope is not safe.
+//! Generally, use of this API is safe - however creating multiple databases in the same
+//! scope is not considered safe.
 //! If you need to access multiple databases you will need to do so in separate processes.
 //!
 //! ## Building
 //!
 //! By default, the kuzu C++ library will be compiled from source and statically linked.
+//! Set the `CMAKE_BUILD_PARALLEL_LEVEL` environment variable to a higher value than 1 (e.g., 8-20)
+//! to speed up compilation of the C++ library.
 //!
 //! If you want to instead link against a pre-built version of the library, the following environment
 //! variables can be used to configure the build process:

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -30,8 +30,8 @@
 //! ## Building
 //!
 //! By default, the kuzu C++ library will be compiled from source and statically linked.
-//! Set the `CMAKE_BUILD_PARALLEL_LEVEL` environment variable to a higher value than 1 (e.g., 8-20)
-//! to speed up compilation of the C++ library.
+//! If the kuzu C++ library is not being built using multiple threads by default, you can set the
+//! CMAKE_BUILD_PARALLEL_LEVEL environment variable to potentially speed up the build process.
 //!
 //! If you want to instead link against a pre-built version of the library, the following environment
 //! variables can be used to configure the build process:


### PR DESCRIPTION
Running `cargo build` after setting `export CMAKE_BUILD_PARALLEL_LEVEL=20` (or some similar high value) significantly speeds up the compilation process. Because we can't know what a reasonable number of threads might be for users (it depends on the arch and the OS), I've added an additional step in the rustdoc to explain that this setting helps.

On my Mac, setting `CMAKE_BUILD_PARALLEL_LEVEL` to 20 results in a 5x speedup in the `cargo build` step, so we should definitely document this on the Kùzu docs as well. Will make a note of this and add it there.