### PR TITLE
Add standard Python module `__version__` attr

### DIFF
--- a/tools/python_api/src_py/__init__.py
+++ b/tools/python_api/src_py/__init__.py
@@ -56,7 +56,7 @@ from .types import Type
 
 
 def __getattr__(name: str) -> str | int:
-    if name == "version":
+    if name in ("version", "__version__"):
         return Database.get_version()
     elif name == "storage_version":
         return Database.get_storage_version()
@@ -75,6 +75,7 @@ __all__ = [
     "PreparedStatement",
     "QueryResult",
     "Type",
+    "__version__",
     "storage_version",
     "version",
 ]

--- a/tools/python_api/test/test_version.py
+++ b/tools/python_api/test/test_version.py
@@ -3,3 +3,4 @@ def test_version() -> None:
 
     assert kuzu.version != ""
     assert kuzu.storage_version > 0
+    assert kuzu.version == kuzu.__version__


### PR DESCRIPTION
It is standard to have a `__version__` attribute at the Python module level. (I was just adding a check for this in Polars[^1] and discovered there wasn't one).

Added, and set it equal to the existing `version`.

[^1]: https://github.com/pola-rs/polars/pull/15218