### PR TITLE
Enable compression for INTERNAL_ID

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.3.2.2 LANGUAGES CXX C)
+project(Kuzu VERSION 0.3.2.3 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -19,6 +19,7 @@ struct PageCursor;
 
 // Returns the size of the data type in bytes
 uint32_t getDataTypeSizeInChunk(const common::LogicalType& dataType);
+uint32_t getDataTypeSizeInChunk(const common::PhysicalTypeID& dataType);
 
 // Compression type is written to the data header both so we can usually catch issues when we
 // decompress uncompressed data by mistake, and to allow for runtime-configurable compression.

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -224,7 +224,7 @@ class InternalIDColumn : public Column {
 public:
     InternalIDColumn(std::string name, const MetadataDAHInfo& metaDAHeaderInfo,
         BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        transaction::Transaction* transaction, RWPropertyStats stats);
+        transaction::Transaction* transaction, RWPropertyStats stats, bool enableCompression);
 
     inline void scan(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
         common::ValueVector* resultVector) override {

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -60,9 +60,9 @@ static void getRelColumnNamesInCopyOrder(TableCatalogEntry* tableEntry,
     columnNames.emplace_back(InternalKeyword::SRC_OFFSET);
     columnNames.emplace_back(InternalKeyword::DST_OFFSET);
     columnNames.emplace_back(InternalKeyword::ROW_OFFSET);
-    columnTypes.emplace_back(LogicalType(LogicalTypeID::INT64));
-    columnTypes.emplace_back(LogicalType(LogicalTypeID::INT64));
-    columnTypes.emplace_back(LogicalType(LogicalTypeID::INT64));
+    columnTypes.emplace_back(LogicalType(LogicalTypeID::INTERNAL_ID));
+    columnTypes.emplace_back(LogicalType(LogicalTypeID::INTERNAL_ID));
+    columnTypes.emplace_back(LogicalType(LogicalTypeID::INTERNAL_ID));
     auto& properties = tableEntry->getPropertiesRef();
     for (auto i = 1u; i < properties.size(); ++i) { // skip internal ID
         columnNames.push_back(properties[i].getName());

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -166,9 +166,9 @@ void Partitioner::copyDataToPartitions(partition_idx_t partitioningIdx, DataChun
             partition.chunks.emplace_back();
             partition.chunks.back().reserve(chunkToCopyFrom.getNumValueVectors());
             for (auto j = 0u; j < chunkToCopyFrom.getNumValueVectors(); j++) {
-                partition.chunks.back().emplace_back(ColumnChunkFactory::createColumnChunk(
-                    chunkToCopyFrom.getValueVector(j)->dataType, false /*enableCompression*/,
-                    Partitioner::CHUNK_SIZE));
+                partition.chunks.back().emplace_back(
+                    ColumnChunkFactory::createColumnChunk(infos[partitioningIdx]->columnTypes[j],
+                        false /*enableCompression*/, Partitioner::CHUNK_SIZE));
             }
         }
         KU_ASSERT(partition.chunks.back().size() == chunkToCopyFrom.getNumValueVectors());

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -136,7 +136,7 @@ std::vector<offset_t> RelBatchInsert::populateStartCSROffsetsAndLengths(ChunkedC
 }
 
 void RelBatchInsert::setOffsetToWithinNodeGroup(ColumnChunk& chunk, offset_t startOffset) {
-    KU_ASSERT(chunk.getDataType().getPhysicalType() == PhysicalTypeID::INT64);
+    KU_ASSERT(chunk.getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
     auto offsets = (offset_t*)chunk.getData();
     for (auto i = 0u; i < chunk.getNumValues(); i++) {
         offsets[i] -= startOffset;
@@ -145,7 +145,7 @@ void RelBatchInsert::setOffsetToWithinNodeGroup(ColumnChunk& chunk, offset_t sta
 
 void RelBatchInsert::setOffsetFromCSROffsets(
     ColumnChunk* nodeOffsetChunk, ColumnChunk* csrOffsetChunk) {
-    KU_ASSERT(nodeOffsetChunk->getDataType().getPhysicalType() == PhysicalTypeID::INT64);
+    KU_ASSERT(nodeOffsetChunk->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
     for (auto i = 0u; i < nodeOffsetChunk->getNumValues(); i++) {
         auto nodeOffset = nodeOffsetChunk->getValue<offset_t>(i);
         auto csrOffset = csrOffsetChunk->getValue<offset_t>(nodeOffset);

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -206,9 +206,9 @@ public:
 
 InternalIDColumn::InternalIDColumn(std::string name, const MetadataDAHInfo& metaDAHeaderInfo,
     BMFileHandle* dataFH, BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-    transaction::Transaction* transaction, RWPropertyStats stats)
+    transaction::Transaction* transaction, RWPropertyStats stats, bool enableCompression)
     : Column{name, *LogicalType::INTERNAL_ID(), metaDAHeaderInfo, dataFH, metadataFH, bufferManager,
-          wal, transaction, stats, false /*enableCompression*/},
+          wal, transaction, stats, enableCompression},
       commonTableID{INVALID_TABLE_ID} {}
 
 void InternalIDColumn::populateCommonTableID(ValueVector* resultVector) const {
@@ -914,7 +914,7 @@ std::unique_ptr<Column> ColumnFactory::createColumn(std::string name, LogicalTyp
     }
     case LogicalTypeID::INTERNAL_ID: {
         return std::make_unique<InternalIDColumn>(name, metaDAHeaderInfo, dataFH, metadataFH,
-            bufferManager, wal, transaction, propertyStatistics);
+            bufferManager, wal, transaction, propertyStatistics, enableCompression);
     }
     case LogicalTypeID::BLOB:
     case LogicalTypeID::STRING: {

--- a/src/storage/store/string_column_chunk.cpp
+++ b/src/storage/store/string_column_chunk.cpp
@@ -82,7 +82,7 @@ void StringColumnChunk::write(
 void StringColumnChunk::write(
     ColumnChunk* chunk, ColumnChunk* dstOffsets, RelMultiplicity /*multiplicity*/) {
     KU_ASSERT(chunk->getDataType().getPhysicalType() == PhysicalTypeID::STRING &&
-              dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INT64 &&
+              dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID &&
               chunk->getNumValues() == dstOffsets->getNumValues());
     for (auto i = 0u; i < chunk->getNumValues(); i++) {
         auto offsetInChunk = dstOffsets->getValue<offset_t>(i);

--- a/src/storage/store/struct_column_chunk.cpp
+++ b/src/storage/store/struct_column_chunk.cpp
@@ -94,7 +94,8 @@ void StructColumnChunk::write(
 
 void StructColumnChunk::write(
     ColumnChunk* chunk, ColumnChunk* dstOffsets, RelMultiplicity multiplicity) {
-    KU_ASSERT(chunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
+    KU_ASSERT(chunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT &&
+              dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
     for (auto i = 0u; i < dstOffsets->getNumValues(); i++) {
         auto offsetInChunk = dstOffsets->getValue<offset_t>(i);
         KU_ASSERT(offsetInChunk < capacity);

--- a/src/storage/store/var_list_column_chunk.cpp
+++ b/src/storage/store/var_list_column_chunk.cpp
@@ -122,12 +122,12 @@ void VarListColumnChunk::lookup(
 
 void VarListColumnChunk::write(
     ColumnChunk* chunk, ColumnChunk* dstOffsets, RelMultiplicity /*multiplicity*/) {
+    KU_ASSERT(dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
     needFinalize = true;
     if (!indicesColumnChunk) {
         initializeIndices();
     }
     KU_ASSERT(chunk->getDataType().getPhysicalType() == dataType.getPhysicalType() &&
-              dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INT64 &&
               chunk->getNumValues() == dstOffsets->getNumValues());
     auto currentIndex = numValues;
     append(chunk, 0, chunk->getNumValues());


### PR DESCRIPTION
This now brings data.kz file size of ldbc100 down from 126GB to 69GB.