### PR TITLE
Replace with client context

### DIFF
--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -96,7 +96,7 @@ std::vector<BoundInsertInfo> Binder::bindInsertInfos(
     const QueryGraphCollection& queryGraphCollection, const expression_set& nodeRelScope_) {
     auto nodeRelScope = nodeRelScope_;
     std::vector<BoundInsertInfo> result;
-    auto analyzer = QueryGraphLabelAnalyzer(*clientContext->getCatalog(), *clientContext);
+    auto analyzer = QueryGraphLabelAnalyzer(*clientContext);
     for (auto i = 0u; i < queryGraphCollection.getNumQueryGraphs(); ++i) {
         auto queryGraph = queryGraphCollection.getQueryGraph(i);
         // Ensure query graph does not violate declared schema.

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<BoundStatement> Binder::bind(const Statement& statement) {
         KU_UNREACHABLE;
     }
     }
-    BoundStatementRewriter::rewrite(*boundStatement, *clientContext->getCatalog(), *clientContext);
+    BoundStatementRewriter::rewrite(*boundStatement, *clientContext);
     return boundStatement;
 }
 

--- a/src/binder/bound_statement_rewriter.cpp
+++ b/src/binder/bound_statement_rewriter.cpp
@@ -7,12 +7,12 @@
 namespace kuzu {
 namespace binder {
 
-void BoundStatementRewriter::rewrite(BoundStatement& boundStatement,
-    const catalog::Catalog& catalog, const main::ClientContext& clientContext) {
+void BoundStatementRewriter::rewrite(
+    BoundStatement& boundStatement, const main::ClientContext& clientContext) {
     auto withClauseProjectionRewriter = WithClauseProjectionRewriter();
     withClauseProjectionRewriter.visitUnsafe(boundStatement);
 
-    auto matchClausePatternLabelRewriter = MatchClausePatternLabelRewriter(catalog, clientContext);
+    auto matchClausePatternLabelRewriter = MatchClausePatternLabelRewriter(clientContext);
     matchClausePatternLabelRewriter.visit(boundStatement);
 
     auto defaultTypeSolver = DefaultTypeSolver();

--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -22,6 +22,7 @@ void QueryGraphLabelAnalyzer::pruneLabel(const QueryGraph& graph) {
 }
 
 void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression& node) {
+    auto catalog = clientContext.getCatalog();
     for (auto i = 0u; i < graph.getNumQueryRels(); ++i) {
         auto queryRel = graph.getQueryRel(i);
         if (queryRel->isRecursive()) {
@@ -36,13 +37,13 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
             if (isSrcConnect || isDstConnect) {
                 for (auto relTableID : queryRel->getTableIDs()) {
                     auto relTableSchema = ku_dynamic_cast<CatalogEntry*, RelTableCatalogEntry*>(
-                        catalog.getTableCatalogEntry(tx, relTableID));
+                        catalog->getTableCatalogEntry(tx, relTableID));
                     auto srcTableID = relTableSchema->getSrcTableID();
                     auto dstTableID = relTableSchema->getDstTableID();
                     candidates.insert(srcTableID);
                     candidates.insert(dstTableID);
-                    auto srcTableSchema = catalog.getTableCatalogEntry(tx, srcTableID);
-                    auto dstTableSchema = catalog.getTableCatalogEntry(tx, dstTableID);
+                    auto srcTableSchema = catalog->getTableCatalogEntry(tx, srcTableID);
+                    auto dstTableSchema = catalog->getTableCatalogEntry(tx, dstTableID);
                     candidateNamesSet.insert(srcTableSchema->getName());
                     candidateNamesSet.insert(dstTableSchema->getName());
                 }
@@ -51,19 +52,19 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
             if (isSrcConnect) {
                 for (auto relTableID : queryRel->getTableIDs()) {
                     auto relTableSchema = ku_dynamic_cast<CatalogEntry*, RelTableCatalogEntry*>(
-                        catalog.getTableCatalogEntry(tx, relTableID));
+                        catalog->getTableCatalogEntry(tx, relTableID));
                     auto srcTableID = relTableSchema->getSrcTableID();
                     candidates.insert(srcTableID);
-                    auto srcTableSchema = catalog.getTableCatalogEntry(tx, srcTableID);
+                    auto srcTableSchema = catalog->getTableCatalogEntry(tx, srcTableID);
                     candidateNamesSet.insert(srcTableSchema->getName());
                 }
             } else if (isDstConnect) {
                 for (auto relTableID : queryRel->getTableIDs()) {
                     auto relTableSchema = ku_dynamic_cast<CatalogEntry*, RelTableCatalogEntry*>(
-                        catalog.getTableCatalogEntry(tx, relTableID));
+                        catalog->getTableCatalogEntry(tx, relTableID));
                     auto dstTableID = relTableSchema->getDstTableID();
                     candidates.insert(dstTableID);
-                    auto dstTableSchema = catalog.getTableCatalogEntry(tx, dstTableID);
+                    auto dstTableSchema = catalog->getTableCatalogEntry(tx, dstTableID);
                     candidateNamesSet.insert(dstTableSchema->getName());
                 }
             }
@@ -94,6 +95,7 @@ void QueryGraphLabelAnalyzer::pruneNode(const QueryGraph& graph, NodeExpression&
 }
 
 void QueryGraphLabelAnalyzer::pruneRel(RelExpression& rel) {
+    auto catalog = clientContext.getCatalog();
     if (rel.isRecursive()) {
         return;
     }
@@ -108,7 +110,7 @@ void QueryGraphLabelAnalyzer::pruneRel(RelExpression& rel) {
         }
         for (auto& relTableID : rel.getTableIDs()) {
             auto relTableSchema = ku_dynamic_cast<CatalogEntry*, RelTableCatalogEntry*>(
-                catalog.getTableCatalogEntry(clientContext.getTx(), relTableID));
+                catalog->getTableCatalogEntry(clientContext.getTx(), relTableID));
             auto srcTableID = relTableSchema->getSrcTableID();
             auto dstTableID = relTableSchema->getDstTableID();
             if (!boundTableIDSet.contains(srcTableID) || !boundTableIDSet.contains(dstTableID)) {
@@ -121,7 +123,7 @@ void QueryGraphLabelAnalyzer::pruneRel(RelExpression& rel) {
         auto dstTableIDSet = rel.getDstNode()->getTableIDsSet();
         for (auto& relTableID : rel.getTableIDs()) {
             auto relTableSchema = ku_dynamic_cast<CatalogEntry*, RelTableCatalogEntry*>(
-                catalog.getTableCatalogEntry(clientContext.getTx(), relTableID));
+                catalog->getTableCatalogEntry(clientContext.getTx(), relTableID));
             auto srcTableID = relTableSchema->getSrcTableID();
             auto dstTableID = relTableSchema->getDstTableID();
             if (!srcTableIDSet.contains(srcTableID) || !dstTableIDSet.contains(dstTableID)) {

--- a/src/binder/query/query_graph_label_analyzer.cpp
+++ b/src/binder/query/query_graph_label_analyzer.cpp
@@ -1,5 +1,6 @@
 #include "binder/query/query_graph_label_analyzer.h"
 
+#include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "common/cast.h"
 #include "common/exception/binder.h"

--- a/src/include/binder/bound_statement_rewriter.h
+++ b/src/include/binder/bound_statement_rewriter.h
@@ -9,9 +9,7 @@ namespace binder {
 // Perform semantic rewrite over bound statement.
 class BoundStatementRewriter {
 public:
-    // TODO(Jiamin): remove catalog
-    static void rewrite(BoundStatement& boundStatement, const catalog::Catalog& catalog,
-        const main::ClientContext& clientContext);
+    static void rewrite(BoundStatement& boundStatement, const main::ClientContext& clientContext);
 };
 
 } // namespace binder

--- a/src/include/binder/bound_statement_rewriter.h
+++ b/src/include/binder/bound_statement_rewriter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "bound_statement.h"
-#include "catalog/catalog.h"
+#include "main/client_context.h"
 
 namespace kuzu {
 namespace binder {

--- a/src/include/binder/query/query_graph_label_analyzer.h
+++ b/src/include/binder/query/query_graph_label_analyzer.h
@@ -9,9 +9,8 @@ namespace binder {
 class QueryGraphLabelAnalyzer {
 public:
     // TODO(Jiamin): remove catalog
-    explicit QueryGraphLabelAnalyzer(
-        const catalog::Catalog& catalog, const main::ClientContext& clientContext)
-        : catalog{catalog}, clientContext{clientContext} {}
+    explicit QueryGraphLabelAnalyzer(const main::ClientContext& clientContext)
+        : clientContext{clientContext} {}
 
     void pruneLabel(const QueryGraph& graph);
 
@@ -20,7 +19,6 @@ private:
     void pruneRel(RelExpression& rel);
 
 private:
-    const catalog::Catalog& catalog;
     const main::ClientContext& clientContext;
 };
 

--- a/src/include/binder/query/query_graph_label_analyzer.h
+++ b/src/include/binder/query/query_graph_label_analyzer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "catalog/catalog.h"
+#include "main/client_context.h"
 #include "query_graph.h"
 
 namespace kuzu {

--- a/src/include/binder/rewriter/match_clause_pattern_label_rewriter.h
+++ b/src/include/binder/rewriter/match_clause_pattern_label_rewriter.h
@@ -8,10 +8,8 @@ namespace binder {
 
 class MatchClausePatternLabelRewriter : public BoundStatementVisitor {
 public:
-    // TODO(Jiamin): remove catalog
-    explicit MatchClausePatternLabelRewriter(
-        const catalog::Catalog& catalog, const main::ClientContext& clientContext)
-        : analyzer{catalog, clientContext} {}
+    explicit MatchClausePatternLabelRewriter(const main::ClientContext& clientContext)
+        : analyzer{clientContext} {}
 
     void visitMatch(const BoundReadingClause& readingClause) final;
 

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -32,9 +32,7 @@ struct LogicalSetPropertyInfo;
 
 class Planner {
 public:
-    // TODO(Jiamin): Remove catalog and storageManager
-    Planner(catalog::Catalog* catalog, storage::StorageManager* storageManager,
-        main::ClientContext* clientContext);
+    Planner(main::ClientContext* clientContext);
     DELETE_COPY_AND_MOVE(Planner);
 
     std::unique_ptr<LogicalPlan> getBestPlan(const binder::BoundStatement& statement);
@@ -282,9 +280,7 @@ private:
     void exitContext(JoinOrderEnumeratorContext prevContext);
 
 private:
-    catalog::Catalog* catalog;
     main::ClientContext* clientContext;
-    storage::StorageManager* storageManager;
     binder::expression_vector propertiesToScan;
     CardinalityEstimator cardinalityEstimator;
     JoinOrderEnumeratorContext context;

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -32,7 +32,7 @@ struct LogicalSetPropertyInfo;
 
 class Planner {
 public:
-    Planner(main::ClientContext* clientContext);
+    explicit Planner(main::ClientContext* clientContext);
     DELETE_COPY_AND_MOVE(Planner);
 
     std::unique_ptr<LogicalPlan> getBestPlan(const binder::BoundStatement& statement);

--- a/src/include/processor/operator/ddl/add_node_property.h
+++ b/src/include/processor/operator/ddl/add_node_property.h
@@ -7,19 +7,18 @@ namespace processor {
 
 class AddNodeProperty final : public AddProperty {
 public:
-    AddNodeProperty(catalog::Catalog* catalog, common::table_id_t tableID, std::string propertyName,
+    AddNodeProperty(common::table_id_t tableID, std::string propertyName,
         std::unique_ptr<common::LogicalType> dataType,
         std::unique_ptr<evaluator::ExpressionEvaluator> defaultValueEvaluator,
-        storage::StorageManager& storageManager, const DataPos& outputPos, uint32_t id,
-        const std::string& paramsString)
-        : AddProperty{catalog, tableID, std::move(propertyName), std::move(dataType),
-              std::move(defaultValueEvaluator), storageManager, outputPos, id, paramsString} {}
+        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
+        : AddProperty{tableID, std::move(propertyName), std::move(dataType),
+              std::move(defaultValueEvaluator), outputPos, id, paramsString} {}
 
     void executeDDLInternal(ExecutionContext* context) final;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<AddNodeProperty>(catalog, tableID, propertyName, dataType->copy(),
-            defaultValueEvaluator->clone(), storageManager, outputPos, id, paramsString);
+        return make_unique<AddNodeProperty>(tableID, propertyName, dataType->copy(),
+            defaultValueEvaluator->clone(), outputPos, id, paramsString);
     }
 };
 

--- a/src/include/processor/operator/ddl/add_property.h
+++ b/src/include/processor/operator/ddl/add_property.h
@@ -2,7 +2,6 @@
 
 #include "ddl.h"
 #include "expression_evaluator/expression_evaluator.h"
-#include "storage/storage_manager.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/include/processor/operator/ddl/add_property.h
+++ b/src/include/processor/operator/ddl/add_property.h
@@ -9,14 +9,13 @@ namespace processor {
 
 class AddProperty : public DDL {
 public:
-    AddProperty(catalog::Catalog* catalog, common::table_id_t tableID, std::string propertyName,
+    AddProperty(common::table_id_t tableID, std::string propertyName,
         std::unique_ptr<common::LogicalType> dataType,
         std::unique_ptr<evaluator::ExpressionEvaluator> defaultValueEvaluator,
-        storage::StorageManager& storageManager, const DataPos& outputPos, uint32_t id,
-        const std::string& paramsString)
-        : DDL{PhysicalOperatorType::ADD_PROPERTY, catalog, outputPos, id, paramsString},
-          tableID{tableID}, propertyName{std::move(propertyName)}, dataType{std::move(dataType)},
-          defaultValueEvaluator{std::move(defaultValueEvaluator)}, storageManager{storageManager} {}
+        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
+        : DDL{PhysicalOperatorType::ADD_PROPERTY, outputPos, id, paramsString}, tableID{tableID},
+          propertyName{std::move(propertyName)}, dataType{std::move(dataType)},
+          defaultValueEvaluator{std::move(defaultValueEvaluator)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override {
         DDL::initLocalStateInternal(resultSet, context);
@@ -35,7 +34,6 @@ protected:
     std::string propertyName;
     std::unique_ptr<common::LogicalType> dataType;
     std::unique_ptr<evaluator::ExpressionEvaluator> defaultValueEvaluator;
-    storage::StorageManager& storageManager;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/ddl/add_rel_property.h
+++ b/src/include/processor/operator/ddl/add_rel_property.h
@@ -7,19 +7,18 @@ namespace processor {
 
 class AddRelProperty final : public AddProperty {
 public:
-    AddRelProperty(catalog::Catalog* catalog, common::table_id_t tableID, std::string propertyName,
+    AddRelProperty(common::table_id_t tableID, std::string propertyName,
         std::unique_ptr<common::LogicalType> dataType,
         std::unique_ptr<evaluator::ExpressionEvaluator> expressionEvaluator,
-        storage::StorageManager& storageManager, const DataPos& outputPos, uint32_t id,
-        const std::string& paramsString)
-        : AddProperty(catalog, tableID, std::move(propertyName), std::move(dataType),
-              std::move(expressionEvaluator), storageManager, outputPos, id, paramsString) {}
+        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
+        : AddProperty(tableID, std::move(propertyName), std::move(dataType),
+              std::move(expressionEvaluator), outputPos, id, paramsString) {}
 
     void executeDDLInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<AddRelProperty>(catalog, tableID, propertyName, dataType->copy(),
-            defaultValueEvaluator->clone(), storageManager, outputPos, id, paramsString);
+        return make_unique<AddRelProperty>(tableID, propertyName, dataType->copy(),
+            defaultValueEvaluator->clone(), outputPos, id, paramsString);
     }
 };
 

--- a/src/include/processor/operator/ddl/create_node_table.h
+++ b/src/include/processor/operator/ddl/create_node_table.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/ddl/bound_create_table_info.h"
 #include "processor/operator/ddl/ddl.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/ddl/create_node_table.h
+++ b/src/include/processor/operator/ddl/create_node_table.h
@@ -7,23 +7,20 @@ namespace processor {
 
 class CreateNodeTable : public DDL {
 public:
-    CreateNodeTable(catalog::Catalog* catalog, storage::StorageManager* storageManager,
-        binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
+    CreateNodeTable(binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
         const std::string& paramsString)
-        : DDL{PhysicalOperatorType::CREATE_NODE_TABLE, catalog, outputPos, id, paramsString},
-          storageManager{storageManager}, info{std::move(info)} {}
+        : DDL{PhysicalOperatorType::CREATE_NODE_TABLE, outputPos, id, paramsString}, info{std::move(
+                                                                                         info)} {}
 
     void executeDDLInternal(ExecutionContext* context) final;
 
     std::string getOutputMsg() final;
 
     std::unique_ptr<PhysicalOperator> clone() final {
-        return std::make_unique<CreateNodeTable>(
-            catalog, storageManager, info.copy(), outputPos, id, paramsString);
+        return std::make_unique<CreateNodeTable>(info.copy(), outputPos, id, paramsString);
     }
 
 private:
-    storage::StorageManager* storageManager;
     binder::BoundCreateTableInfo info;
 };
 

--- a/src/include/processor/operator/ddl/create_rdf_graph.h
+++ b/src/include/processor/operator/ddl/create_rdf_graph.h
@@ -8,10 +8,9 @@ namespace processor {
 
 class CreateRdfGraph final : public DDL {
 public:
-    CreateRdfGraph(catalog::Catalog* catalog, storage::StorageManager* storageManager,
-        binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
-        const std::string& paramsString)
-        : DDL{PhysicalOperatorType::CREATE_RDF_GRAPH, catalog, outputPos, id, paramsString},
+    CreateRdfGraph(storage::StorageManager* storageManager, binder::BoundCreateTableInfo info,
+        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
+        : DDL{PhysicalOperatorType::CREATE_RDF_GRAPH, outputPos, id, paramsString},
           storageManager{storageManager},
           nodesStatistics{storageManager->getNodesStatisticsAndDeletedIDs()},
           relsStatistics{storageManager->getRelsStatistics()}, info{std::move(info)} {}
@@ -22,7 +21,7 @@ public:
 
     inline std::unique_ptr<PhysicalOperator> clone() override {
         return std::make_unique<CreateRdfGraph>(
-            catalog, storageManager, info.copy(), outputPos, id, paramsString);
+            storageManager, info.copy(), outputPos, id, paramsString);
     }
 
 private:

--- a/src/include/processor/operator/ddl/create_rel_table.h
+++ b/src/include/processor/operator/ddl/create_rel_table.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/ddl/bound_create_table_info.h"
 #include "processor/operator/ddl/ddl.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/ddl/create_rel_table.h
+++ b/src/include/processor/operator/ddl/create_rel_table.h
@@ -7,23 +7,20 @@ namespace processor {
 
 class CreateRelTable final : public DDL {
 public:
-    CreateRelTable(catalog::Catalog* catalog, storage::StorageManager* storageManager,
-        binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
+    CreateRelTable(binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
         const std::string& paramsString)
-        : DDL{PhysicalOperatorType::CREATE_REL_TABLE, catalog, outputPos, id, paramsString},
-          storageManager{storageManager}, info{std::move(info)} {}
+        : DDL{PhysicalOperatorType::CREATE_REL_TABLE, outputPos, id, paramsString}, info{std::move(
+                                                                                        info)} {}
 
     void executeDDLInternal(ExecutionContext* context) override;
 
     std::string getOutputMsg() override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<CreateRelTable>(
-            catalog, storageManager, info.copy(), outputPos, id, paramsString);
+        return make_unique<CreateRelTable>(info.copy(), outputPos, id, paramsString);
     }
 
 private:
-    storage::StorageManager* storageManager;
     binder::BoundCreateTableInfo info;
 };
 

--- a/src/include/processor/operator/ddl/create_rel_table_group.h
+++ b/src/include/processor/operator/ddl/create_rel_table_group.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "binder/ddl/bound_create_table_info.h"
 #include "processor/operator/ddl/ddl.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/ddl/create_rel_table_group.h
+++ b/src/include/processor/operator/ddl/create_rel_table_group.h
@@ -7,23 +7,20 @@ namespace processor {
 
 class CreateRelTableGroup : public DDL {
 public:
-    CreateRelTableGroup(catalog::Catalog* catalog, storage::StorageManager* storageManager,
-        binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
+    CreateRelTableGroup(binder::BoundCreateTableInfo info, const DataPos& outputPos, uint32_t id,
         const std::string& paramsString)
-        : DDL{PhysicalOperatorType::CREATE_REL_TABLE, catalog, outputPos, id, paramsString},
-          storageManager{storageManager}, info{std::move(info)} {}
+        : DDL{PhysicalOperatorType::CREATE_REL_TABLE, outputPos, id, paramsString}, info{std::move(
+                                                                                        info)} {}
 
     void executeDDLInternal(ExecutionContext* context) override;
 
     std::string getOutputMsg() override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<CreateRelTableGroup>(
-            catalog, storageManager, info.copy(), outputPos, id, paramsString);
+        return make_unique<CreateRelTableGroup>(info.copy(), outputPos, id, paramsString);
     }
 
 private:
-    storage::StorageManager* storageManager;
     binder::BoundCreateTableInfo info;
 };
 

--- a/src/include/processor/operator/ddl/ddl.h
+++ b/src/include/processor/operator/ddl/ddl.h
@@ -8,9 +8,9 @@ namespace processor {
 
 class DDL : public PhysicalOperator {
 public:
-    DDL(PhysicalOperatorType operatorType, catalog::Catalog* catalog, const DataPos& outputPos,
-        uint32_t id, const std::string& paramsString)
-        : PhysicalOperator{operatorType, id, paramsString}, catalog{catalog}, outputPos{outputPos},
+    DDL(PhysicalOperatorType operatorType, const DataPos& outputPos, uint32_t id,
+        const std::string& paramsString)
+        : PhysicalOperator{operatorType, id, paramsString}, outputPos{outputPos},
           outputVector{nullptr}, hasExecuted{false} {}
 
     bool isSource() const final { return true; }
@@ -25,7 +25,6 @@ protected:
     virtual void executeDDLInternal(ExecutionContext* context) = 0;
 
 protected:
-    catalog::Catalog* catalog;
     DataPos outputPos;
     common::ValueVector* outputVector;
 

--- a/src/include/processor/operator/ddl/ddl.h
+++ b/src/include/processor/operator/ddl/ddl.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "catalog/catalog.h"
 #include "processor/operator/physical_operator.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/ddl/drop_property.h
+++ b/src/include/processor/operator/ddl/drop_property.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "ddl.h"
-#include "storage/storage_manager.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/include/processor/operator/ddl/drop_property.h
+++ b/src/include/processor/operator/ddl/drop_property.h
@@ -8,23 +8,20 @@ namespace processor {
 
 class DropProperty : public DDL {
 public:
-    DropProperty(catalog::Catalog* catalog, common::table_id_t tableID,
-        common::property_id_t propertyID, const DataPos& outputPos,
-        storage::StorageManager& storageManager, uint32_t id, const std::string& paramsString)
-        : DDL{PhysicalOperatorType::DROP_PROPERTY, catalog, outputPos, id, paramsString},
-          storageManager{storageManager}, tableID{tableID}, propertyID{propertyID} {}
+    DropProperty(common::table_id_t tableID, common::property_id_t propertyID,
+        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
+        : DDL{PhysicalOperatorType::DROP_PROPERTY, outputPos, id, paramsString}, tableID{tableID},
+          propertyID{propertyID} {}
 
     void executeDDLInternal(ExecutionContext* context) final;
 
     std::string getOutputMsg() final { return {"Drop succeed."}; }
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<DropProperty>(
-            catalog, tableID, propertyID, outputPos, storageManager, id, paramsString);
+        return make_unique<DropProperty>(tableID, propertyID, outputPos, id, paramsString);
     }
 
 protected:
-    storage::StorageManager& storageManager;
     common::table_id_t tableID;
     common::property_id_t propertyID;
 };

--- a/src/include/processor/operator/ddl/drop_table.h
+++ b/src/include/processor/operator/ddl/drop_table.h
@@ -7,9 +7,9 @@ namespace processor {
 
 class DropTable : public DDL {
 public:
-    DropTable(catalog::Catalog* catalog, std::string tableName, common::table_id_t tableID,
-        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
-        : DDL{PhysicalOperatorType::DROP_TABLE, catalog, outputPos, id, paramsString},
+    DropTable(std::string tableName, common::table_id_t tableID, const DataPos& outputPos,
+        uint32_t id, const std::string& paramsString)
+        : DDL{PhysicalOperatorType::DROP_TABLE, outputPos, id, paramsString},
           tableName{std::move(tableName)}, tableID{tableID} {}
 
     void executeDDLInternal(ExecutionContext* context) override;
@@ -17,7 +17,7 @@ public:
     std::string getOutputMsg() override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<DropTable>(catalog, tableName, tableID, outputPos, id, paramsString);
+        return make_unique<DropTable>(tableName, tableID, outputPos, id, paramsString);
     }
 
 protected:

--- a/src/include/processor/operator/ddl/rename_property.h
+++ b/src/include/processor/operator/ddl/rename_property.h
@@ -7,21 +7,20 @@ namespace processor {
 
 class RenameProperty : public DDL {
 public:
-    RenameProperty(catalog::Catalog* catalog, common::table_id_t tableID,
-        common::property_id_t propertyID, std::string newName, const DataPos& outputPos,
-        uint32_t id, const std::string& paramsString)
-        : DDL{PhysicalOperatorType::RENAME_PROPERTY, catalog, outputPos, id, paramsString},
-          tableID{tableID}, propertyID{propertyID}, newName{std::move(newName)} {}
+    RenameProperty(common::table_id_t tableID, common::property_id_t propertyID,
+        std::string newName, const DataPos& outputPos, uint32_t id, const std::string& paramsString)
+        : DDL{PhysicalOperatorType::RENAME_PROPERTY, outputPos, id, paramsString}, tableID{tableID},
+          propertyID{propertyID}, newName{std::move(newName)} {}
 
-    void executeDDLInternal(ExecutionContext* /*context*/) override {
-        catalog->renameProperty(tableID, propertyID, newName);
+    void executeDDLInternal(ExecutionContext* context) override {
+        context->clientContext->getCatalog()->renameProperty(tableID, propertyID, newName);
     }
 
     std::string getOutputMsg() override { return "Property renamed"; }
 
     std::unique_ptr<PhysicalOperator> clone() override {
         return make_unique<RenameProperty>(
-            catalog, tableID, propertyID, newName, outputPos, id, paramsString);
+            tableID, propertyID, newName, outputPos, id, paramsString);
     }
 
 protected:

--- a/src/include/processor/operator/ddl/rename_property.h
+++ b/src/include/processor/operator/ddl/rename_property.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "catalog/catalog.h"
 #include "ddl.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/ddl/rename_table.h
+++ b/src/include/processor/operator/ddl/rename_table.h
@@ -7,19 +7,19 @@ namespace processor {
 
 class RenameTable final : public DDL {
 public:
-    RenameTable(catalog::Catalog* catalog, common::table_id_t tableID, std::string newName,
-        const DataPos& outputPos, uint32_t id, const std::string& paramsString)
-        : DDL{PhysicalOperatorType::RENAME_TABLE, catalog, outputPos, id, paramsString},
-          tableID{tableID}, newName{std::move(newName)} {}
+    RenameTable(common::table_id_t tableID, std::string newName, const DataPos& outputPos,
+        uint32_t id, const std::string& paramsString)
+        : DDL{PhysicalOperatorType::RENAME_TABLE, outputPos, id, paramsString}, tableID{tableID},
+          newName{std::move(newName)} {}
 
-    void executeDDLInternal(ExecutionContext* /*context*/) override {
-        catalog->renameTable(tableID, newName);
+    void executeDDLInternal(ExecutionContext* context) override {
+        context->clientContext->getCatalog()->renameTable(tableID, newName);
     }
 
     std::string getOutputMsg() override { return "Table renamed"; }
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<RenameTable>(catalog, tableID, newName, outputPos, id, paramsString);
+        return make_unique<RenameTable>(tableID, newName, outputPos, id, paramsString);
     }
 
 protected:

--- a/src/include/processor/operator/ddl/rename_table.h
+++ b/src/include/processor/operator/ddl/rename_table.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "catalog/catalog.h"
 #include "ddl.h"
 
 namespace kuzu {

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -33,10 +33,8 @@ struct PartitionerSharedState;
 class PlanMapper {
 public:
     // Create plan mapper with default mapper context.
-    PlanMapper(storage::StorageManager& storageManager, storage::MemoryManager* memoryManager,
-        catalog::Catalog* catalog, main::ClientContext* clientContext)
-        : storageManager{storageManager}, memoryManager{memoryManager}, expressionMapper{},
-          catalog{catalog}, clientContext{clientContext}, physicalOperatorID{0} {}
+    PlanMapper(main::ClientContext* clientContext)
+        : expressionMapper{}, clientContext{clientContext}, physicalOperatorID{0} {}
 
     std::unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(
         planner::LogicalPlan* logicalPlan, const binder::expression_vector& expressionsToCollect);
@@ -194,10 +192,7 @@ private:
     }
 
 public:
-    storage::StorageManager& storageManager;
-    storage::MemoryManager* memoryManager;
     ExpressionMapper expressionMapper;
-    catalog::Catalog* catalog;
     main::ClientContext* clientContext;
 
 private:

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -6,7 +6,6 @@
 #include "planner/operator/logical_plan.h"
 #include "processor/operator/result_collector.h"
 #include "processor/physical_plan.h"
-#include "storage/storage_manager.h"
 
 namespace kuzu {
 namespace main {
@@ -33,7 +32,7 @@ struct PartitionerSharedState;
 class PlanMapper {
 public:
     // Create plan mapper with default mapper context.
-    PlanMapper(main::ClientContext* clientContext)
+    explicit PlanMapper(main::ClientContext* clientContext)
         : expressionMapper{}, clientContext{clientContext}, physicalOperatorID{0} {}
 
     std::unique_ptr<PhysicalPlan> mapLogicalPlanToPhysical(
@@ -171,13 +170,13 @@ private:
         const planner::LogicalInsertInfo* info, const planner::Schema& inSchema,
         const planner::Schema& outSchema) const;
     std::unique_ptr<RelInsertExecutor> getRelInsertExecutor(const planner::LogicalInsertInfo* info,
-        const planner::Schema& inSchema, const planner::Schema& outSchema);
+        const planner::Schema& inSchema, const planner::Schema& outSchema) const;
     std::unique_ptr<NodeSetExecutor> getNodeSetExecutor(
         planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const;
     std::unique_ptr<RelSetExecutor> getRelSetExecutor(
         planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const;
 
-    std::shared_ptr<FactorizedTable> getSingleStringColumnFTable();
+    std::shared_ptr<FactorizedTable> getSingleStringColumnFTable() const;
 
     inline uint32_t getOperatorID() { return physicalOperatorID++; }
 

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -295,7 +295,7 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareNoLock(
         preparedStatement->statementResult =
             std::make_unique<BoundStatementResult>(boundStatement->getStatementResult()->copy());
         // planning
-        auto planner = Planner(database->catalog.get(), database->storageManager.get(), this);
+        auto planner = Planner(this);
         std::vector<std::unique_ptr<LogicalPlan>> plans;
         if (enumerateAllPlans) {
             plans = planner.getAllPlans(*boundStatement);
@@ -395,8 +395,7 @@ std::unique_ptr<QueryResult> ClientContext::executeAndAutoCommitIfNecessaryNoLoc
     }
     this->resetActiveQuery();
     this->startTimer();
-    auto mapper = PlanMapper(
-        *database->storageManager, database->memoryManager.get(), database->catalog.get(), this);
+    auto mapper = PlanMapper(this);
     std::unique_ptr<PhysicalPlan> physicalPlan;
     if (preparedStatement->isSuccess()) {
         try {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -17,6 +17,7 @@
 #include "planner/planner.h"
 #include "processor/plan_mapper.h"
 #include "processor/processor.h"
+#include "storage/storage_manager.h"
 #include "transaction/transaction_context.h"
 
 #if defined(_WIN32)

--- a/src/planner/planner.cpp
+++ b/src/planner/planner.cpp
@@ -11,11 +11,9 @@ using namespace kuzu::storage;
 namespace kuzu {
 namespace planner {
 
-Planner::Planner(
-    Catalog* catalog, StorageManager* storageManager, main::ClientContext* clientContext)
-    : catalog{catalog}, clientContext{clientContext} {
-    auto nStats = storageManager->getNodesStatisticsAndDeletedIDs();
-    auto rStats = storageManager->getRelsStatistics();
+Planner::Planner(main::ClientContext* clientContext) : clientContext{clientContext} {
+    auto nStats = clientContext->getStorageManager()->getNodesStatisticsAndDeletedIDs();
+    auto rStats = clientContext->getStorageManager()->getRelsStatistics();
     cardinalityEstimator = CardinalityEstimator(nStats, rStats);
     context = JoinOrderEnumeratorContext();
 }

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -1,6 +1,7 @@
 #include <utility>
 
 #include "binder/expression/expression_util.h"
+#include "catalog/catalog.h"
 #include "processor/operator/call/in_query_call.h"
 #include "processor/operator/table_scan/ftable_scan_function.h"
 #include "processor/plan_mapper.h"

--- a/src/processor/map/create_factorized_table_scan.cpp
+++ b/src/processor/map/create_factorized_table_scan.cpp
@@ -25,7 +25,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::createFTableScan(const expression_
     auto bindData =
         std::make_unique<FTableScanBindData>(table, std::move(colIndices), maxMorselSize);
     auto function = function::BuiltInFunctionsUtils::matchFunction(
-        READ_FTABLE_FUNC_NAME, catalog->getFunctions(clientContext->getTx()));
+        READ_FTABLE_FUNC_NAME, clientContext->getCatalog()->getFunctions(clientContext->getTx()));
     auto info = InQueryCallInfo();
     info.function = *ku_dynamic_cast<Function*, TableFunction*>(function);
     info.bindData = std::move(bindData);

--- a/src/processor/map/create_result_collector.cpp
+++ b/src/processor/map/create_result_collector.cpp
@@ -26,7 +26,8 @@ std::unique_ptr<ResultCollector> PlanMapper::createResultCollector(AccumulateTyp
         tableSchema->appendColumn(std::move(columnSchema));
         payloadsPos.push_back(dataPos);
     }
-    auto table = std::make_shared<FactorizedTable>(memoryManager, tableSchema->copy());
+    auto table =
+        std::make_shared<FactorizedTable>(clientContext->getMemoryManager(), tableSchema->copy());
     auto sharedState = std::make_shared<ResultCollectorSharedState>(std::move(table));
     auto info =
         std::make_unique<ResultCollectorInfo>(accumulateType, std::move(tableSchema), payloadsPos);

--- a/src/processor/map/map_comment_on.cpp
+++ b/src/processor/map/map_comment_on.cpp
@@ -16,7 +16,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCommentOn(
     auto outputExpression = logicalCommentOn->getOutputExpression();
     auto outputPos = DataPos(outSchema->getExpressionPos(*outputExpression));
     auto commentOnInfo = std::make_unique<CommentOnInfo>(logicalCommentOn->getTableID(),
-        logicalCommentOn->getTableName(), logicalCommentOn->getComment(), outputPos, catalog);
+        logicalCommentOn->getTableName(), logicalCommentOn->getComment(), outputPos,
+        clientContext->getCatalog());
     return std::make_unique<CommentOn>(
         std::move(commentOnInfo), getOperatorID(), logicalCommentOn->getExpressionsForPrinting());
 }

--- a/src/processor/map/map_copy_from.cpp
+++ b/src/processor/map/map_copy_from.cpp
@@ -9,6 +9,7 @@
 #include "processor/operator/persistent/node_batch_insert.h"
 #include "processor/operator/persistent/rel_batch_insert.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::catalog;

--- a/src/processor/map/map_copy_to.cpp
+++ b/src/processor/map/map_copy_to.cpp
@@ -88,7 +88,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyTo(LogicalOperator* logical
     }
     std::shared_ptr<FactorizedTable> fTable;
     auto ftTableSchema = std::make_unique<FactorizedTableSchema>();
-    fTable = std::make_shared<FactorizedTable>(memoryManager, std::move(ftTableSchema));
+    fTable = std::make_shared<FactorizedTable>(
+        clientContext->getMemoryManager(), std::move(ftTableSchema));
     return createEmptyFTableScan(fTable, 0, std::move(copyTo));
 }
 

--- a/src/processor/map/map_create_macro.cpp
+++ b/src/processor/map/map_create_macro.cpp
@@ -13,8 +13,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCreateMacro(
     auto outSchema = logicalCreateMacro->getSchema();
     auto outputExpression = logicalCreateMacro->getOutputExpression();
     auto outputPos = DataPos(outSchema->getExpressionPos(*outputExpression));
-    auto createMacroInfo = std::make_unique<CreateMacroInfo>(
-        logicalCreateMacro->getMacroName(), logicalCreateMacro->getMacro(), outputPos, catalog);
+    auto createMacroInfo = std::make_unique<CreateMacroInfo>(logicalCreateMacro->getMacroName(),
+        logicalCreateMacro->getMacro(), outputPos, clientContext->getCatalog());
     return std::make_unique<CreateMacro>(PhysicalOperatorType::CREATE_MACRO,
         std::move(createMacroInfo), getOperatorID(),
         logicalCreateMacro->getExpressionsForPrinting());

--- a/src/processor/map/map_delete.cpp
+++ b/src/processor/map/map_delete.cpp
@@ -1,6 +1,7 @@
 #include "planner/operator/persistent/logical_delete.h"
 #include "processor/operator/persistent/delete.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::catalog;

--- a/src/processor/map/map_delete.cpp
+++ b/src/processor/map/map_delete.cpp
@@ -102,7 +102,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapDeleteRel(LogicalOperator* logi
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     std::vector<std::unique_ptr<RelDeleteExecutor>> Executors;
     for (auto& rel : logicalDeleteRel->getRelsRef()) {
-        Executors.push_back(getRelDeleteExecutor(storageManager, *rel, *inSchema));
+        Executors.push_back(
+            getRelDeleteExecutor(*clientContext->getStorageManager(), *rel, *inSchema));
     }
     return std::make_unique<DeleteRel>(std::move(Executors), std::move(prevOperator),
         getOperatorID(), logicalOperator->getExpressionsForPrinting());

--- a/src/processor/map/map_dummy_scan.cpp
+++ b/src/processor/map/map_dummy_scan.cpp
@@ -18,6 +18,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapDummyScan(LogicalOperator* /*lo
         std::make_unique<ColumnSchema>(false, 0 /* all expressions are in the same datachunk */,
             LogicalTypeUtils::getRowLayoutSize(expression->dataType)));
     auto expressionEvaluator = ExpressionMapper::getEvaluator(expression, inSchema.get());
+    auto memoryManager = clientContext->getMemoryManager();
     // expression can be evaluated statically and does not require an actual resultset to init
     expressionEvaluator->init(ResultSet(0) /* dummy resultset */, memoryManager);
     expressionEvaluator->evaluate(clientContext);

--- a/src/processor/map/map_explain.cpp
+++ b/src/processor/map/map_explain.cpp
@@ -30,8 +30,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExplain(LogicalOperator* logica
         auto planPrinter =
             std::make_unique<main::PlanPrinter>(physicalPlanToExplain.get(), profiler.get());
         auto explainStr = planPrinter->printPlanToOstream().str();
-        auto factorizedTable =
-            FactorizedTableUtils::getFactorizedTableForOutputMsg(explainStr, memoryManager);
+        auto factorizedTable = FactorizedTableUtils::getFactorizedTableForOutputMsg(
+            explainStr, clientContext->getMemoryManager());
         return createFTableScanAligned(expression_vector{outputExpression}, outSchema,
             factorizedTable, DEFAULT_VECTOR_CAPACITY /* maxMorselSize */);
     }

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -102,10 +102,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(LogicalOperator* logical
     if (!rel->isMultiLabeled() && !boundNode->isMultiLabeled() &&
         extendDirection != ExtendDirection::BOTH) {
         auto relTableEntry = ku_dynamic_cast<TableCatalogEntry*, RelTableCatalogEntry*>(
-            catalog->getTableCatalogEntry(clientContext->getTx(), rel->getSingleTableID()));
+            clientContext->getCatalog()->getTableCatalogEntry(
+                clientContext->getTx(), rel->getSingleTableID()));
         auto relDataDirection = ExtendDirectionUtils::getRelDataDirection(extendDirection);
-        auto scanInfo = getRelTableScanInfo(
-            relTableEntry, relDataDirection, &storageManager, extend->getProperties());
+        auto scanInfo = getRelTableScanInfo(relTableEntry, relDataDirection,
+            clientContext->getStorageManager(), extend->getProperties());
         return std::make_unique<ScanRelTable>(std::move(scanInfo), inNodeVectorPos, outVectorsPos,
             std::move(prevOperator), getOperatorID(), extend->getExpressionsForPrinting());
     } else { // map to generic extend

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -3,6 +3,7 @@
 #include "processor/operator/scan/scan_multi_rel_tables.h"
 #include "processor/operator/scan/scan_rel_table.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;

--- a/src/processor/map/map_hash_join.cpp
+++ b/src/processor/map/map_hash_join.cpp
@@ -81,8 +81,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapHashJoin(LogicalOperator* logic
         ExpressionUtil::excludeExpressions(hashJoin->getExpressionsToMaterialize(), probeKeys);
     // Create build
     auto buildInfo = createHashBuildInfo(*buildSchema, buildKeys, payloads);
-    auto globalHashTable = std::make_unique<JoinHashTable>(
-        *memoryManager, LogicalType::copy(buildKeyTypes), buildInfo->getTableSchema()->copy());
+    auto globalHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
+        LogicalType::copy(buildKeyTypes), buildInfo->getTableSchema()->copy());
     auto sharedState = std::make_shared<HashJoinSharedState>(std::move(globalHashTable));
     auto hashJoinBuild =
         make_unique<HashJoinBuild>(std::make_unique<ResultSetDescriptor>(buildSchema), sharedState,

--- a/src/processor/map/map_index_scan_node.cpp
+++ b/src/processor/map/map_index_scan_node.cpp
@@ -15,11 +15,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIndexScan(
     auto outSchema = logicalIndexScan->getSchema();
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     // TODO(Xiyang): potentially we should merge IndexScan and IndexLook
+    auto storageManager = clientContext->getStorageManager();
     if (logicalIndexScan->getNumInfos() > 1) {
         std::vector<std::unique_ptr<IndexLookupInfo>> indexLookupInfos;
         for (auto i = 0u; i < logicalIndexScan->getNumInfos(); ++i) {
             auto info = logicalIndexScan->getInfo(i);
-            auto storageIndex = storageManager.getNodeTable(info->nodeTableID)->getPKIndex();
+            auto storageIndex = storageManager->getNodeTable(info->nodeTableID)->getPKIndex();
             auto offsetPos = DataPos(outSchema->getExpressionPos(*info->offset));
             auto keyPos = DataPos(outSchema->getExpressionPos(*info->key));
             indexLookupInfos.push_back(std::make_unique<IndexLookupInfo>(
@@ -29,7 +30,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIndexScan(
             getOperatorID(), logicalIndexScan->getExpressionsForPrinting());
     } else {
         auto info = logicalIndexScan->getInfo(0);
-        auto nodeTable = storageManager.getNodeTable(info->nodeTableID);
+        auto nodeTable = storageManager->getNodeTable(info->nodeTableID);
         auto evaluator = ExpressionMapper::getEvaluator(info->key, inSchema);
         auto outDataPos = DataPos(outSchema->getExpressionPos(*info->offset));
         return make_unique<IndexScan>(nodeTable->getTableID(), nodeTable->getPKIndex(),

--- a/src/processor/map/map_index_scan_node.cpp
+++ b/src/processor/map/map_index_scan_node.cpp
@@ -2,6 +2,7 @@
 #include "processor/operator/index_lookup.h"
 #include "processor/operator/index_scan.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::planner;
 

--- a/src/processor/map/map_insert.cpp
+++ b/src/processor/map/map_insert.cpp
@@ -29,21 +29,23 @@ static std::vector<DataPos> populateReturnVectorsPos(
 
 std::unique_ptr<NodeInsertExecutor> PlanMapper::getNodeInsertExecutor(
     const LogicalInsertInfo* info, const Schema& inSchema, const Schema& outSchema) const {
+    auto storageManager = clientContext->getStorageManager();
     auto node = ku_dynamic_cast<Expression*, NodeExpression*>(info->pattern.get());
     auto nodeTableID = node->getSingleTableID();
-    auto table = storageManager.getNodeTable(nodeTableID);
+    auto table = storageManager->getNodeTable(nodeTableID);
     std::unordered_set<RelTable*> fwdRelTablesToInit;
     std::unordered_set<RelTable*> bwdRelTablesToInit;
-    auto tableCatalogEntry = catalog->getTableCatalogEntry(clientContext->getTx(), nodeTableID);
+    auto tableCatalogEntry =
+        clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTx(), nodeTableID);
     auto nodeTableSchema =
         ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(tableCatalogEntry);
     auto fwdRelTableIDs = nodeTableSchema->getFwdRelTableIDSet();
     auto bwdRelTableIDs = nodeTableSchema->getBwdRelTableIDSet();
     for (auto relTableID : fwdRelTableIDs) {
-        fwdRelTablesToInit.insert(storageManager.getRelTable(relTableID));
+        fwdRelTablesToInit.insert(storageManager->getRelTable(relTableID));
     }
     for (auto relTableID : bwdRelTableIDs) {
-        bwdRelTablesToInit.insert(storageManager.getRelTable(relTableID));
+        bwdRelTablesToInit.insert(storageManager->getRelTable(relTableID));
     }
     auto nodeIDPos = DataPos(outSchema.getExpressionPos(*node->getInternalID()));
     auto returnVectorsPos = populateReturnVectorsPos(*info, outSchema);
@@ -60,9 +62,10 @@ std::unique_ptr<NodeInsertExecutor> PlanMapper::getNodeInsertExecutor(
 std::unique_ptr<RelInsertExecutor> PlanMapper::getRelInsertExecutor(
     const planner::LogicalInsertInfo* info, const planner::Schema& inSchema,
     const planner::Schema& outSchema) {
+    auto storageManager = clientContext->getStorageManager();
     auto rel = ku_dynamic_cast<Expression*, RelExpression*>(info->pattern.get());
     auto relTableID = rel->getSingleTableID();
-    auto table = storageManager.getRelTable(relTableID);
+    auto table = storageManager->getRelTable(relTableID);
     auto srcNode = rel->getSrcNode();
     auto dstNode = rel->getDstNode();
     auto srcNodePos = DataPos(inSchema.getExpressionPos(*srcNode->getInternalID()));
@@ -73,7 +76,7 @@ std::unique_ptr<RelInsertExecutor> PlanMapper::getRelInsertExecutor(
     for (auto& expr : info->columnDataExprs) {
         evaluators.push_back(ExpressionMapper::getEvaluator(expr, &outSchema));
     }
-    return std::make_unique<RelInsertExecutor>(storageManager.getRelsStatistics(), table,
+    return std::make_unique<RelInsertExecutor>(storageManager->getRelsStatistics(), table,
         srcNodePos, dstNodePos, std::move(returnVectorsPos), std::move(evaluators));
 }
 

--- a/src/processor/map/map_insert.cpp
+++ b/src/processor/map/map_insert.cpp
@@ -3,6 +3,7 @@
 #include "planner/operator/persistent/logical_insert.h"
 #include "processor/operator/persistent/insert.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::evaluator;
 using namespace kuzu::planner;
@@ -61,7 +62,7 @@ std::unique_ptr<NodeInsertExecutor> PlanMapper::getNodeInsertExecutor(
 
 std::unique_ptr<RelInsertExecutor> PlanMapper::getRelInsertExecutor(
     const planner::LogicalInsertInfo* info, const planner::Schema& inSchema,
-    const planner::Schema& outSchema) {
+    const planner::Schema& outSchema) const {
     auto storageManager = clientContext->getStorageManager();
     auto rel = ku_dynamic_cast<Expression*, RelExpression*>(info->pattern.get());
     auto relTableID = rel->getSingleTableID();

--- a/src/processor/map/map_intersect.cpp
+++ b/src/processor/map/map_intersect.cpp
@@ -29,8 +29,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIntersect(LogicalOperator* logi
         auto payloadExpressions =
             binder::ExpressionUtil::excludeExpressions(buildSchema->getExpressionsInScope(), keys);
         auto buildInfo = createHashBuildInfo(*buildSchema, keys, payloadExpressions);
-        auto globalHashTable = std::make_unique<JoinHashTable>(
-            *memoryManager, LogicalType::copy(keyTypes), buildInfo->getTableSchema()->copy());
+        auto globalHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
+            LogicalType::copy(keyTypes), buildInfo->getTableSchema()->copy());
         auto sharedState = std::make_shared<HashJoinSharedState>(std::move(globalHashTable));
         sharedStates.push_back(sharedState);
         children[i] = make_unique<IntersectBuild>(

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -57,8 +57,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
         auto nodePayloads =
             ExpressionUtil::excludeExpressions(nodeBuildSchema->getExpressionsInScope(), nodeKeys);
         auto nodeBuildInfo = createHashBuildInfo(*nodeBuildSchema, nodeKeys, nodePayloads);
-        auto nodeHashTable = std::make_unique<JoinHashTable>(
-            *memoryManager, std::move(nodeKeyTypes), nodeBuildInfo->getTableSchema()->copy());
+        auto nodeHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
+            std::move(nodeKeyTypes), nodeBuildInfo->getTableSchema()->copy());
         nodeBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(nodeHashTable));
         nodeBuild = make_unique<HashJoinBuild>(
             std::make_unique<ResultSetDescriptor>(nodeBuildSchema), nodeBuildSharedState,
@@ -84,8 +84,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
         auto relPayloads =
             ExpressionUtil::excludeExpressions(relBuildSchema->getExpressionsInScope(), relKeys);
         auto relBuildInfo = createHashBuildInfo(*relBuildSchema, relKeys, relPayloads);
-        auto relHashTable = std::make_unique<JoinHashTable>(
-            *memoryManager, std::move(relKeyTypes), relBuildInfo->getTableSchema()->copy());
+        auto relHashTable = std::make_unique<JoinHashTable>(*clientContext->getMemoryManager(),
+            std::move(relKeyTypes), relBuildInfo->getTableSchema()->copy());
         relBuildSharedState = std::make_shared<HashJoinSharedState>(std::move(relHashTable));
         relBuild = std::make_unique<HashJoinBuild>(
             std::make_unique<ResultSetDescriptor>(relBuildSchema), relBuildSharedState,

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -42,13 +42,13 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(
     auto boundNodeIDPos = DataPos(inSchema->getExpressionPos(*boundNode->getInternalID()));
     auto nbrNodeIDPos = DataPos(outSchema->getExpressionPos(*nbrNode->getInternalID()));
     auto lengthPos = DataPos(outSchema->getExpressionPos(*lengthExpression));
-    auto sharedState = createSharedState(*nbrNode, storageManager);
+    auto sharedState = createSharedState(*nbrNode, *clientContext->getStorageManager());
     auto pathPos = DataPos();
     if (extend->getJoinType() == planner::RecursiveJoinType::TRACK_PATH) {
         pathPos = DataPos(outSchema->getExpressionPos(*rel));
     }
     std::unordered_map<common::table_id_t, std::string> tableIDToName;
-    for (auto& entry : catalog->getTableEntries(clientContext->getTx())) {
+    for (auto& entry : clientContext->getCatalog()->getTableEntries(clientContext->getTx())) {
         tableIDToName.insert({entry->getTableID(), entry->getName()});
     }
     auto dataInfo = std::make_unique<RecursiveJoinDataInfo>(boundNodeIDPos, nbrNodeIDPos,

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -1,6 +1,7 @@
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "processor/operator/recursive_extend/recursive_join.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::planner;

--- a/src/processor/map/map_scan_node.cpp
+++ b/src/processor/map/map_scan_node.cpp
@@ -2,6 +2,7 @@
 #include "planner/operator/scan/logical_scan_internal_id.h"
 #include "processor/operator/scan_node_id.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::planner;
 

--- a/src/processor/map/map_scan_node.cpp
+++ b/src/processor/map/map_scan_node.cpp
@@ -14,7 +14,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanInternalID(LogicalOperator*
     auto dataPos = DataPos(outSchema->getExpressionPos(*scan->getInternalID()));
     auto sharedState = std::make_shared<ScanNodeIDSharedState>();
     for (auto& tableID : scan->getTableIDs()) {
-        auto nodeTable = storageManager.getNodeTable(tableID);
+        auto nodeTable = clientContext->getStorageManager()->getNodeTable(tableID);
         sharedState->addTableState(nodeTable);
     }
     return std::make_unique<ScanNodeID>(

--- a/src/processor/map/map_scan_node_property.cpp
+++ b/src/processor/map/map_scan_node_property.cpp
@@ -2,6 +2,7 @@
 #include "planner/operator/scan/logical_scan_node_property.h"
 #include "processor/operator/scan/scan_multi_node_tables.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -3,6 +3,7 @@
 #include "planner/operator/persistent/logical_set.h"
 #include "processor/operator/persistent/set.h"
 #include "processor/plan_mapper.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -15,6 +15,8 @@ namespace processor {
 
 std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
     planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const {
+    auto storageManager = clientContext->getStorageManager();
+    auto catalog = clientContext->getCatalog();
     auto node = (NodeExpression*)info->nodeOrRel.get();
     auto nodeIDPos = DataPos(inSchema.getExpressionPos(*node->getInternalID()));
     auto property = (PropertyExpression*)info->setItem.first.get();
@@ -30,7 +32,7 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
                 continue;
             }
             auto propertyID = property->getPropertyID(tableID);
-            auto table = storageManager.getNodeTable(tableID);
+            auto table = storageManager->getNodeTable(tableID);
             auto columnID = catalog->getTableCatalogEntry(clientContext->getTx(), tableID)
                                 ->getColumnID(propertyID);
             tableIDToSetInfo.insert({tableID, NodeSetInfo{table, columnID}});
@@ -39,7 +41,7 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
             std::move(tableIDToSetInfo), nodeIDPos, propertyPos, std::move(evaluator));
     } else {
         auto tableID = node->getSingleTableID();
-        auto table = storageManager.getNodeTable(tableID);
+        auto table = storageManager->getNodeTable(tableID);
         auto columnID = INVALID_COLUMN_ID;
         if (property->hasPropertyID(tableID)) {
             auto propertyID = property->getPropertyID(tableID);
@@ -65,6 +67,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapSetNodeProperty(LogicalOperator
 
 std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(
     planner::LogicalSetPropertyInfo* info, const planner::Schema& inSchema) const {
+    auto storageManager = clientContext->getStorageManager();
+    auto catalog = clientContext->getCatalog();
     auto rel = (RelExpression*)info->nodeOrRel.get();
     auto srcNodePos = DataPos(inSchema.getExpressionPos(*rel->getSrcNode()->getInternalID()));
     auto dstNodePos = DataPos(inSchema.getExpressionPos(*rel->getDstNode()->getInternalID()));
@@ -82,7 +86,7 @@ std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(
             if (!property->hasPropertyID(tableID)) {
                 continue;
             }
-            auto table = storageManager.getRelTable(tableID);
+            auto table = storageManager->getRelTable(tableID);
             auto propertyID = property->getPropertyID(tableID);
             auto columnID = catalog->getTableCatalogEntry(clientContext->getTx(), tableID)
                                 ->getColumnID(propertyID);
@@ -92,7 +96,7 @@ std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(
             srcNodePos, dstNodePos, relIDPos, propertyPos, std::move(evaluator));
     } else {
         auto tableID = rel->getSingleTableID();
-        auto table = storageManager.getRelTable(tableID);
+        auto table = storageManager->getRelTable(tableID);
         auto columnID = common::INVALID_COLUMN_ID;
         if (property->hasPropertyID(tableID)) {
             auto propertyID = property->getPropertyID(tableID);

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -196,7 +196,7 @@ std::vector<DataPos> PlanMapper::getExpressionsDataPos(
     return result;
 }
 
-std::shared_ptr<FactorizedTable> PlanMapper::getSingleStringColumnFTable() {
+std::shared_ptr<FactorizedTable> PlanMapper::getSingleStringColumnFTable() const {
     auto ftTableSchema = std::make_unique<FactorizedTableSchema>();
     ftTableSchema->appendColumn(
         std::make_unique<ColumnSchema>(false /* flat */, 0 /* dataChunkPos */,

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -201,7 +201,8 @@ std::shared_ptr<FactorizedTable> PlanMapper::getSingleStringColumnFTable() {
     ftTableSchema->appendColumn(
         std::make_unique<ColumnSchema>(false /* flat */, 0 /* dataChunkPos */,
             LogicalTypeUtils::getRowLayoutSize(LogicalType{LogicalTypeID::STRING})));
-    return std::make_shared<FactorizedTable>(memoryManager, std::move(ftTableSchema));
+    return std::make_shared<FactorizedTable>(
+        clientContext->getMemoryManager(), std::move(ftTableSchema));
 }
 
 } // namespace processor

--- a/src/processor/operator/ddl/add_node_property.cpp
+++ b/src/processor/operator/ddl/add_node_property.cpp
@@ -1,5 +1,8 @@
 #include "processor/operator/ddl/add_node_property.h"
 
+#include "catalog/catalog.h"
+#include "storage/storage_manager.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/ddl/add_node_property.cpp
+++ b/src/processor/operator/ddl/add_node_property.cpp
@@ -4,13 +4,15 @@ namespace kuzu {
 namespace processor {
 
 void AddNodeProperty::executeDDLInternal(ExecutionContext* context) {
+    auto catalog = context->clientContext->getCatalog();
+    auto storageManager = context->clientContext->getStorageManager();
     catalog->addNodeProperty(tableID, propertyName, std::move(dataType));
     auto schema = catalog->getTableCatalogEntry(context->clientContext->getTx(), tableID);
     auto addedPropID = schema->getPropertyID(propertyName);
     auto addedProp = schema->getProperty(addedPropID);
-    storageManager.getNodeTable(tableID)->addColumn(
+    storageManager->getNodeTable(tableID)->addColumn(
         context->clientContext->getTx(), *addedProp, getDefaultValVector(context));
-    storageManager.getWAL()->logAddPropertyRecord(tableID, addedProp->getPropertyID());
+    storageManager->getWAL()->logAddPropertyRecord(tableID, addedProp->getPropertyID());
 }
 
 } // namespace processor

--- a/src/processor/operator/ddl/add_rel_property.cpp
+++ b/src/processor/operator/ddl/add_rel_property.cpp
@@ -1,5 +1,8 @@
 #include "processor/operator/ddl/add_rel_property.h"
 
+#include "catalog/catalog.h"
+#include "storage/storage_manager.h"
+
 using namespace kuzu::catalog;
 using namespace kuzu::storage;
 using namespace kuzu::common;

--- a/src/processor/operator/ddl/add_rel_property.cpp
+++ b/src/processor/operator/ddl/add_rel_property.cpp
@@ -8,13 +8,15 @@ namespace kuzu {
 namespace processor {
 
 void AddRelProperty::executeDDLInternal(ExecutionContext* context) {
+    auto catalog = context->clientContext->getCatalog();
+    auto storageManager = context->clientContext->getStorageManager();
     catalog->addRelProperty(tableID, propertyName, dataType->copy());
     auto tableSchema = catalog->getTableCatalogEntry(context->clientContext->getTx(), tableID);
     auto addedPropertyID = tableSchema->getPropertyID(propertyName);
     auto addedProp = tableSchema->getProperty(addedPropertyID);
-    storageManager.getRelTable(tableID)->addColumn(
+    storageManager->getRelTable(tableID)->addColumn(
         context->clientContext->getTx(), *addedProp, getDefaultValVector(context));
-    storageManager.getWAL()->logAddPropertyRecord(tableID, addedProp->getPropertyID());
+    storageManager->getWAL()->logAddPropertyRecord(tableID, addedProp->getPropertyID());
 }
 
 } // namespace processor

--- a/src/processor/operator/ddl/create_node_table.cpp
+++ b/src/processor/operator/ddl/create_node_table.cpp
@@ -11,6 +11,8 @@ namespace kuzu {
 namespace processor {
 
 void CreateNodeTable::executeDDLInternal(ExecutionContext* context) {
+    auto catalog = context->clientContext->getCatalog();
+    auto storageManager = context->clientContext->getStorageManager();
     auto newTableID = catalog->addNodeTableSchema(info);
     auto newNodeTableEntry = ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(
         catalog->getTableCatalogEntry(context->clientContext->getTx(), newTableID));

--- a/src/processor/operator/ddl/create_rdf_graph.cpp
+++ b/src/processor/operator/ddl/create_rdf_graph.cpp
@@ -14,6 +14,7 @@ using namespace kuzu::common;
 
 void CreateRdfGraph::executeDDLInternal(ExecutionContext* context) {
     auto tx = context->clientContext->getTx();
+    auto catalog = context->clientContext->getCatalog();
     auto newRdfGraphID = catalog->addRdfGraphSchema(info);
     auto rdfGraphEntry = common::ku_dynamic_cast<TableCatalogEntry*, RDFGraphCatalogEntry*>(
         catalog->getTableCatalogEntry(tx, newRdfGraphID));

--- a/src/processor/operator/ddl/create_rel_table.cpp
+++ b/src/processor/operator/ddl/create_rel_table.cpp
@@ -12,6 +12,8 @@ namespace kuzu {
 namespace processor {
 
 void CreateRelTable::executeDDLInternal(ExecutionContext* context) {
+    auto catalog = context->clientContext->getCatalog();
+    auto storageManager = context->clientContext->getStorageManager();
     auto newTableID = catalog->addRelTableSchema(info);
     auto newRelTableEntry = ku_dynamic_cast<TableCatalogEntry*, RelTableCatalogEntry*>(
         catalog->getTableCatalogEntry(context->clientContext->getTx(), newTableID));

--- a/src/processor/operator/ddl/create_rel_table_group.cpp
+++ b/src/processor/operator/ddl/create_rel_table_group.cpp
@@ -12,6 +12,8 @@ namespace kuzu {
 namespace processor {
 
 void CreateRelTableGroup::executeDDLInternal(ExecutionContext* context) {
+    auto catalog = context->clientContext->getCatalog();
+    auto storageManager = context->clientContext->getStorageManager();
     auto newRelTableGroupID = catalog->addRelTableGroupSchema(info);
     auto tx = context->clientContext->getTx();
     auto newRelGroupEntry = ku_dynamic_cast<TableCatalogEntry*, RelGroupCatalogEntry*>(

--- a/src/processor/operator/ddl/drop_property.cpp
+++ b/src/processor/operator/ddl/drop_property.cpp
@@ -4,14 +4,16 @@ namespace kuzu {
 namespace processor {
 
 void DropProperty::executeDDLInternal(ExecutionContext* context) {
+    auto catalog = context->clientContext->getCatalog();
+    auto storageManager = context->clientContext->getStorageManager();
     auto tableEntry = catalog->getTableCatalogEntry(context->clientContext->getTx(), tableID);
     auto columnID = tableEntry->getColumnID(propertyID);
     catalog->dropProperty(tableID, propertyID);
     if (tableEntry->getTableType() == common::TableType::NODE) {
-        auto nodesStats = storageManager.getNodesStatisticsAndDeletedIDs();
+        auto nodesStats = storageManager->getNodesStatisticsAndDeletedIDs();
         nodesStats->removeMetadataDAHInfo(tableID, columnID);
     } else {
-        auto relsStats = storageManager.getRelsStatistics();
+        auto relsStats = storageManager->getRelsStatistics();
         relsStats->removeMetadataDAHInfo(tableID, columnID);
     }
 }

--- a/src/processor/operator/ddl/drop_property.cpp
+++ b/src/processor/operator/ddl/drop_property.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/ddl/drop_property.h"
 
+#include "storage/storage_manager.h"
+
 namespace kuzu {
 namespace processor {
 

--- a/src/processor/operator/ddl/drop_table.cpp
+++ b/src/processor/operator/ddl/drop_table.cpp
@@ -8,8 +8,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-void DropTable::executeDDLInternal(ExecutionContext* /*context*/) {
-    catalog->dropTableSchema(tableID);
+void DropTable::executeDDLInternal(ExecutionContext* context) {
+    context->clientContext->getCatalog()->dropTableSchema(tableID);
 }
 
 std::string DropTable::getOutputMsg() {

--- a/src/processor/operator/ddl/drop_table.cpp
+++ b/src/processor/operator/ddl/drop_table.cpp
@@ -1,5 +1,6 @@
 #include "processor/operator/ddl/drop_table.h"
 
+#include "catalog/catalog.h"
 #include "common/string_format.h"
 
 using namespace kuzu::catalog;

--- a/test/copy/e2e_copy_transaction_test.cpp
+++ b/test/copy/e2e_copy_transaction_test.cpp
@@ -68,8 +68,7 @@ public:
         if (!preparedStatement->success) {
             ASSERT_TRUE(false) << preparedStatement->errMsg;
         }
-        auto mapper = PlanMapper(*getStorageManager(*database), getMemoryManager(*database),
-            getCatalog(*database), conn->getClientContext());
+        auto mapper = PlanMapper(conn->getClientContext());
         auto physicalPlan =
             mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
                 preparedStatement->statementResult->getColumns());
@@ -138,8 +137,7 @@ public:
         conn->query(copyPersonTableCMD);
         conn->query(createKnowsTableCMD);
         auto preparedStatement = conn->prepare(copyKnowsTableCMD);
-        auto mapper = PlanMapper(*getStorageManager(*database), getMemoryManager(*database),
-            getCatalog(*database), conn->getClientContext());
+        auto mapper = PlanMapper(conn->getClientContext());
         auto physicalPlan =
             mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
                 preparedStatement->statementResult->getColumns());

--- a/test/copy/e2e_copy_transaction_test.cpp
+++ b/test/copy/e2e_copy_transaction_test.cpp
@@ -1,9 +1,11 @@
 #include <set>
 
 #include "binder/bound_statement_result.h"
+#include "catalog/catalog.h"
 #include "graph_test/graph_test.h"
 #include "processor/plan_mapper.h"
 #include "processor/processor.h"
+#include "storage/storage_manager.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::catalog;

--- a/test/ddl/e2e_ddl_test.cpp
+++ b/test/ddl/e2e_ddl_test.cpp
@@ -168,8 +168,7 @@ public:
 
     void executeQueryWithoutCommit(std::string query) {
         auto preparedStatement = conn->prepare(query);
-        auto mapper = PlanMapper(*getStorageManager(*database), getMemoryManager(*database),
-            getCatalog(*database), conn->getClientContext());
+        auto mapper = PlanMapper(conn->getClientContext());
         auto physicalPlan =
             mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[0].get(),
                 preparedStatement->statementResult->getColumns());

--- a/test/ddl/e2e_ddl_test.cpp
+++ b/test/ddl/e2e_ddl_test.cpp
@@ -1,8 +1,10 @@
 #include "binder/bound_statement_result.h"
+#include "catalog/catalog.h"
 #include "common/string_format.h"
 #include "graph_test/graph_test.h"
 #include "processor/plan_mapper.h"
 #include "processor/processor.h"
+#include "storage/storage_manager.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/test/graph_test/graph_test.cpp
+++ b/test/graph_test/graph_test.cpp
@@ -21,7 +21,6 @@ namespace testing {
 
 void PrivateGraphTest::validateQueryBestPlanJoinOrder(
     std::string query, std::string expectedJoinOrder) {
-    auto catalog = getCatalog(*database);
     auto statement = parser::Parser::parseQuery(query);
     ASSERT_EQ(statement.size(), 1);
     auto parsedQuery = (parser::RegularQuery*)statement[0].get();

--- a/test/graph_test/graph_test.cpp
+++ b/test/graph_test/graph_test.cpp
@@ -26,7 +26,7 @@ void PrivateGraphTest::validateQueryBestPlanJoinOrder(
     ASSERT_EQ(statement.size(), 1);
     auto parsedQuery = (parser::RegularQuery*)statement[0].get();
     auto boundQuery = Binder(conn->clientContext.get()).bind(*parsedQuery);
-    auto planner = Planner(catalog, getStorageManager(*database), conn->clientContext.get());
+    auto planner = Planner(conn->clientContext.get());
     auto plan = planner.getBestPlan(*boundQuery);
     ASSERT_STREQ(LogicalPlanUtil::encodeJoin(*plan).c_str(), expectedJoinOrder.c_str());
 }


### PR DESCRIPTION
Since database is stored in client context, for classes that depend on multiple database components, e.g. BM, MM, FS, ..., simply replace these components with client context.