### PR TITLE
Refactor Partitioner to use ChunkedNodeGroupCollection

### DIFF
--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "processor/operator/sink.h"
+#include "storage/store/chunked_node_group_collection.h"
 #include "storage/store/column_chunk.h"
 
 namespace kuzu {
@@ -20,14 +21,7 @@ struct PartitionerFunctions {
 // partitioning methods. For example, copy of rel tables require partitioning on both FWD and BWD
 // direction. Each partitioning method corresponds to a PartitioningState.
 struct PartitioningBuffer {
-    using ColumnChunkCollection = std::vector<std::unique_ptr<storage::ColumnChunk>>;
-    struct Partition {
-        // One chunk for each column, grouped into a list
-        // so that groups from different threads can be quickly merged without copying
-        // E.g. [(a,b,c), (a,b,c)] where a is a chunk for column a, b for column b, etc.
-        std::vector<ColumnChunkCollection> chunks;
-    };
-    std::vector<Partition> partitions;
+    std::vector<storage::ChunkedNodeGroupCollection> partitions;
 
     void merge(std::unique_ptr<PartitioningBuffer> localPartitioningStates);
 };
@@ -35,6 +29,7 @@ struct PartitioningBuffer {
 // NOTE: Currently, Partitioner is tightly coupled with RelBatchInsert. We should generalize it
 // later when necessary. Here, each partition is essentially a node group.
 struct BatchInsertSharedState;
+struct PartitioningInfo;
 struct PartitionerSharedState {
     std::mutex mtx;
     storage::MemoryManager* mm;
@@ -51,12 +46,12 @@ struct PartitionerSharedState {
 
     explicit PartitionerSharedState(storage::MemoryManager* mm) : mm{mm} {}
 
-    void initialize();
+    void initialize(std::vector<std::unique_ptr<PartitioningInfo>>& infos);
     common::partition_idx_t getNextPartition(common::vector_idx_t partitioningIdx);
     void resetState();
     void merge(std::vector<std::unique_ptr<PartitioningBuffer>> localPartitioningStates);
 
-    inline PartitioningBuffer::Partition& getPartitionBuffer(
+    inline storage::ChunkedNodeGroupCollection& getPartitionBuffer(
         common::vector_idx_t partitioningIdx, common::partition_idx_t partitionIdx) {
         KU_ASSERT(partitioningIdx < partitioningBuffers.size());
         KU_ASSERT(partitionIdx < partitioningBuffers[partitioningIdx]->partitions.size());
@@ -107,7 +102,7 @@ public:
 
     std::unique_ptr<PhysicalOperator> clone() final;
 
-    static void initializePartitioningStates(
+    static void initializePartitioningStates(std::vector<std::unique_ptr<PartitioningInfo>>& infos,
         std::vector<std::unique_ptr<PartitioningBuffer>>& partitioningBuffers,
         std::vector<common::partition_idx_t> numPartitions);
 
@@ -121,9 +116,6 @@ private:
         common::partition_idx_t partitioningIdx, common::DataChunk chunkToCopyFrom);
 
 private:
-    // Same size as a value vector. Each thread will allocate a chunk for each node group,
-    // so this should be kept relatively small to avoid allocating more memory than is needed
-    static const uint64_t CHUNK_SIZE = 2048;
     std::vector<std::unique_ptr<PartitioningInfo>> infos;
     std::shared_ptr<PartitionerSharedState> sharedState;
     std::unique_ptr<PartitionerLocalState> localState;

--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -2,7 +2,6 @@
 
 #include "processor/operator/sink.h"
 #include "storage/store/chunked_node_group_collection.h"
-#include "storage/store/column_chunk.h"
 
 namespace kuzu {
 namespace storage {

--- a/src/include/processor/operator/persistent/index_builder.h
+++ b/src/include/processor/operator/persistent/index_builder.h
@@ -151,7 +151,7 @@ public:
     IndexBuilder clone() { return IndexBuilder(sharedState); }
 
     void insert(
-        storage::ColumnChunk* chunk, common::offset_t nodeOffset, common::offset_t numNodes);
+        const storage::ColumnChunk& chunk, common::offset_t nodeOffset, common::offset_t numNodes);
 
     ProducerToken getProducerToken() const { return ProducerToken(sharedState); }
 
@@ -159,7 +159,8 @@ public:
     void finalize(ExecutionContext* context);
 
 private:
-    void checkNonNullConstraint(storage::NullColumnChunk* nullChunk, common::offset_t numNodes);
+    void checkNonNullConstraint(
+        const storage::NullColumnChunk& nullChunk, common::offset_t numNodes);
     std::shared_ptr<IndexBuilderSharedState> sharedState;
 
     IndexBuilderLocalBuffers localBuffers;

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -4,7 +4,7 @@
 #include "processor/operator/call/in_query_call.h"
 #include "processor/operator/persistent/batch_insert.h"
 #include "processor/operator/persistent/index_builder.h"
-#include "storage/store/node_group.h"
+#include "storage/store/chunked_node_group.h"
 #include "storage/store/node_table.h"
 
 namespace kuzu {

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -3,8 +3,8 @@
 #include "common/enums/rel_direction.h"
 #include "processor/operator/partitioner.h"
 #include "processor/operator/persistent/batch_insert.h"
+#include "storage/store/chunked_node_group.h"
 #include "storage/store/column_chunk.h"
-#include "storage/store/node_group.h"
 
 namespace kuzu {
 namespace processor {
@@ -12,18 +12,18 @@ namespace processor {
 struct RelBatchInsertInfo final : public BatchInsertInfo {
     common::RelDataDirection direction;
     uint64_t partitioningIdx;
-    common::vector_idx_t offsetVectorIdx;
+    common::column_id_t offsetColumnID;
     std::vector<common::LogicalType> columnTypes;
 
     RelBatchInsertInfo(catalog::TableCatalogEntry* tableEntry, bool compressionEnabled,
         common::RelDataDirection direction, uint64_t partitioningIdx,
-        common::vector_idx_t offsetVectorIdx, std::vector<common::LogicalType> columnTypes)
+        common::column_id_t offsetColumnID, std::vector<common::LogicalType> columnTypes)
         : BatchInsertInfo{tableEntry, compressionEnabled}, direction{direction},
-          partitioningIdx{partitioningIdx}, offsetVectorIdx{offsetVectorIdx}, columnTypes{std::move(
-                                                                                  columnTypes)} {}
+          partitioningIdx{partitioningIdx}, offsetColumnID{offsetColumnID}, columnTypes{std::move(
+                                                                                columnTypes)} {}
     RelBatchInsertInfo(const RelBatchInsertInfo& other)
         : BatchInsertInfo{other.tableEntry, other.compressionEnabled}, direction{other.direction},
-          partitioningIdx{other.partitioningIdx}, offsetVectorIdx{other.offsetVectorIdx},
+          partitioningIdx{other.partitioningIdx}, offsetColumnID{other.offsetColumnID},
           columnTypes{common::LogicalType::copy(other.columnTypes)} {}
 
     inline std::unique_ptr<BatchInsertInfo> copy() const override {
@@ -60,20 +60,20 @@ public:
     }
 
 private:
-    void prepareCSRNodeGroup(PartitioningBuffer::Partition& partition,
-        common::offset_t startNodeOffset, common::vector_idx_t offsetVectorIdx,
+    void prepareCSRNodeGroup(storage::ChunkedNodeGroupCollection& partition,
+        common::offset_t startNodeOffset, common::column_id_t offsetColumnID,
         common::offset_t numNodes);
 
     static common::length_t getGapSize(common::length_t length);
     static std::vector<common::offset_t> populateStartCSROffsetsAndLengths(
         storage::ChunkedCSRHeader& csrHeader, common::offset_t numNodes,
-        PartitioningBuffer::Partition& partition, common::vector_idx_t offsetVectorIdx);
+        storage::ChunkedNodeGroupCollection& partition, common::column_id_t offsetColumnID);
     static void populateEndCSROffsets(
         storage::ChunkedCSRHeader& csrHeader, std::vector<common::offset_t>& gaps);
     static void setOffsetToWithinNodeGroup(
         storage::ColumnChunk& chunk, common::offset_t startOffset);
     static void setOffsetFromCSROffsets(
-        storage::ColumnChunk* nodeOffsetChunk, storage::ColumnChunk* csrOffsetChunk);
+        storage::ColumnChunk& nodeOffsetChunk, storage::ColumnChunk& csrOffsetChunk);
 
     // We only check rel multiplcity constraint (MANY_ONE, ONE_ONE) for now.
     std::optional<common::offset_t> checkRelMultiplicityConstraint(

--- a/src/include/storage/store/chunked_node_group_collection.h
+++ b/src/include/storage/store/chunked_node_group_collection.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "storage/store/chunked_node_group.h"
+
+namespace kuzu {
+namespace storage {
+
+class ChunkedNodeGroupCollection {
+public:
+    static constexpr uint64_t CHUNK_CAPACITY = 2048;
+
+    ChunkedNodeGroupCollection(std::vector<common::LogicalType> types) : types{std::move(types)} {}
+    DELETE_COPY_DEFAULT_MOVE(ChunkedNodeGroupCollection);
+
+    inline const std::vector<std::unique_ptr<ChunkedNodeGroup>>& getChunkedGroups() const {
+        return chunkedGroups;
+    }
+    inline const ChunkedNodeGroup* getChunkedGroup(uint64_t groupIdx) const {
+        KU_ASSERT(groupIdx < chunkedGroups.size());
+        return chunkedGroups[groupIdx].get();
+    }
+    inline ChunkedNodeGroup* getChunkedGroupUnsafe(uint64_t groupIdx) {
+        KU_ASSERT(groupIdx < chunkedGroups.size());
+        return chunkedGroups[groupIdx].get();
+    }
+    inline uint64_t getNumChunks() const { return chunkedGroups.size(); }
+
+    void append(
+        const std::vector<common::ValueVector*>& vectors, const common::SelectionVector& selVector);
+    void append(std::unique_ptr<ChunkedNodeGroup> chunkedGroup);
+    void merge(ChunkedNodeGroupCollection& chunkedGroupCollection);
+
+private:
+    std::vector<common::LogicalType> types;
+    std::vector<std::unique_ptr<ChunkedNodeGroup>> chunkedGroups;
+};
+
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/store/chunked_node_group_collection.h
+++ b/src/include/storage/store/chunked_node_group_collection.h
@@ -9,7 +9,8 @@ class ChunkedNodeGroupCollection {
 public:
     static constexpr uint64_t CHUNK_CAPACITY = 2048;
 
-    ChunkedNodeGroupCollection(std::vector<common::LogicalType> types) : types{std::move(types)} {}
+    explicit ChunkedNodeGroupCollection(std::vector<common::LogicalType> types)
+        : types{std::move(types)} {}
     DELETE_COPY_DEFAULT_MOVE(ChunkedNodeGroupCollection);
 
     inline const std::vector<std::unique_ptr<ChunkedNodeGroup>>& getChunkedGroups() const {

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -48,6 +48,7 @@ public:
     }
 
     inline NullColumnChunk* getNullChunk() { return nullChunk.get(); }
+    inline const NullColumnChunk& getNullChunk() const { return *nullChunk; }
     inline common::LogicalType& getDataType() { return dataType; }
     inline const common::LogicalType& getDataType() const { return dataType; }
 

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -6,7 +6,7 @@
 #include "common/cast.h"
 #include "storage/index/hash_index.h"
 #include "storage/stats/nodes_store_statistics.h"
-#include "storage/store/node_group.h"
+#include "storage/store/chunked_node_group.h"
 #include "storage/store/node_table_data.h"
 #include "storage/store/table.h"
 

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "common/enums/rel_direction.h"
-#include "storage/store/node_group.h"
+#include "storage/store/chunked_node_group.h"
 #include "storage/store/table_data.h"
 
 namespace kuzu {

--- a/src/include/storage/store/table_data.h
+++ b/src/include/storage/store/table_data.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "storage/store/chunked_node_group.h"
 #include "storage/store/column.h"
-#include "storage/store/node_group.h"
 
 namespace kuzu {
 namespace storage {

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -3,7 +3,6 @@
 #include "common/constants.h"
 #include "common/data_chunk/sel_vector.h"
 #include "processor/execution_context.h"
-#include "storage/store/column_chunk.h"
 #include "storage/store/node_table.h"
 
 using namespace kuzu::common;

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -37,7 +37,7 @@ static partition_idx_t getNumPartitions(offset_t maxOffset) {
     return (maxOffset + StorageConstants::NODE_GROUP_SIZE) / StorageConstants::NODE_GROUP_SIZE;
 }
 
-void PartitionerSharedState::initialize() {
+void PartitionerSharedState::initialize(std::vector<std::unique_ptr<PartitioningInfo>>& infos) {
     maxNodeOffsets.resize(2);
     maxNodeOffsets[0] =
         srcNodeTable->getMaxNodeOffset(transaction::Transaction::getDummyWriteTrx().get());
@@ -46,7 +46,7 @@ void PartitionerSharedState::initialize() {
     numPartitions.resize(2);
     numPartitions[0] = getNumPartitions(maxNodeOffsets[0]);
     numPartitions[1] = getNumPartitions(maxNodeOffsets[1]);
-    Partitioner::initializePartitioningStates(partitioningBuffers, numPartitions);
+    Partitioner::initializePartitioningStates(infos, partitioningBuffers, numPartitions);
 }
 
 partition_idx_t PartitionerSharedState::getNextPartition(vector_idx_t partitioningIdx) {
@@ -77,11 +77,7 @@ void PartitioningBuffer::merge(std::unique_ptr<PartitioningBuffer> localPartitio
     for (auto partitionIdx = 0u; partitionIdx < partitions.size(); partitionIdx++) {
         auto& sharedPartition = partitions[partitionIdx];
         auto& localPartition = localPartitioningState->partitions[partitionIdx];
-        sharedPartition.chunks.reserve(
-            sharedPartition.chunks.size() + localPartition.chunks.size());
-        for (auto j = 0u; j < localPartition.chunks.size(); j++) {
-            sharedPartition.chunks.push_back(std::move(localPartition.chunks[j]));
-        }
+        sharedPartition.merge(localPartition);
     }
 }
 
@@ -96,12 +92,13 @@ Partitioner::Partitioner(std::unique_ptr<ResultSetDescriptor> resultSetDescripto
 }
 
 void Partitioner::initGlobalStateInternal(ExecutionContext* /*context*/) {
-    sharedState->initialize();
+    sharedState->initialize(infos);
 }
 
 void Partitioner::initLocalStateInternal(ResultSet* /*resultSet*/, ExecutionContext* /*context*/) {
     localState = std::make_unique<PartitionerLocalState>();
-    initializePartitioningStates(localState->partitioningBuffers, sharedState->numPartitions);
+    initializePartitioningStates(
+        infos, localState->partitioningBuffers, sharedState->numPartitions);
 }
 
 DataChunk Partitioner::constructDataChunk(const std::vector<DataPos>& columnPositions,
@@ -122,6 +119,7 @@ DataChunk Partitioner::constructDataChunk(const std::vector<DataPos>& columnPosi
 }
 
 void Partitioner::initializePartitioningStates(
+    std::vector<std::unique_ptr<PartitioningInfo>>& infos,
     std::vector<std::unique_ptr<PartitioningBuffer>>& partitioningBuffers,
     std::vector<partition_idx_t> numPartitions) {
     partitioningBuffers.resize(numPartitions.size());
@@ -130,7 +128,7 @@ void Partitioner::initializePartitioningStates(
         auto partitioningBuffer = std::make_unique<PartitioningBuffer>();
         partitioningBuffer->partitions.reserve(numPartition);
         for (auto i = 0u; i < numPartition; i++) {
-            partitioningBuffer->partitions.emplace_back();
+            partitioningBuffer->partitions.emplace_back(infos[partitioningIdx]->columnTypes);
         }
         partitioningBuffers[partitioningIdx] = std::move(partitioningBuffer);
     }
@@ -152,6 +150,11 @@ void Partitioner::executeInternal(ExecutionContext* context) {
 }
 
 void Partitioner::copyDataToPartitions(partition_idx_t partitioningIdx, DataChunk chunkToCopyFrom) {
+    std::vector<ValueVector*> vectorsToAppend;
+    vectorsToAppend.reserve(chunkToCopyFrom.getNumValueVectors());
+    for (auto j = 0u; j < chunkToCopyFrom.getNumValueVectors(); j++) {
+        vectorsToAppend.push_back(chunkToCopyFrom.getValueVector(j).get());
+    }
     SelectionVector selVector(1);
     selVector.resetSelectorToValuePosBufferWithSize(1);
     for (auto i = 0u; i < chunkToCopyFrom.state->selVector->selectedSize; i++) {
@@ -161,21 +164,8 @@ void Partitioner::copyDataToPartitions(partition_idx_t partitioningIdx, DataChun
             partitionIdx < localState->getPartitioningBuffer(partitioningIdx)->partitions.size());
         auto& partition =
             localState->getPartitioningBuffer(partitioningIdx)->partitions[partitionIdx];
-        if (partition.chunks.empty() || partition.chunks.back()[0]->getNumValues() + 1 >
-                                            partition.chunks.back()[0]->getCapacity()) {
-            partition.chunks.emplace_back();
-            partition.chunks.back().reserve(chunkToCopyFrom.getNumValueVectors());
-            for (auto j = 0u; j < chunkToCopyFrom.getNumValueVectors(); j++) {
-                partition.chunks.back().emplace_back(
-                    ColumnChunkFactory::createColumnChunk(infos[partitioningIdx]->columnTypes[j],
-                        false /*enableCompression*/, Partitioner::CHUNK_SIZE));
-            }
-        }
-        KU_ASSERT(partition.chunks.back().size() == chunkToCopyFrom.getNumValueVectors());
         selVector.selectedPositions[0] = posToCopyFrom;
-        for (auto j = 0u; j < chunkToCopyFrom.getNumValueVectors(); j++) {
-            partition.chunks.back()[j]->append(chunkToCopyFrom.getValueVector(j).get(), selVector);
-        }
+        partition.append(vectorsToAppend, selVector);
     }
 }
 

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -158,7 +158,7 @@ void NodeBatchInsert::copyToNodeGroup() {
     while (numAppendedTuples < numTuplesToAppend) {
         auto numAppendedTuplesInNodeGroup =
             nodeLocalState->nodeGroup->append(nodeLocalState->columnVectors,
-                nodeLocalState->columnState, numTuplesToAppend - numAppendedTuples);
+                *nodeLocalState->columnState->selVector, numTuplesToAppend - numAppendedTuples);
         numAppendedTuples += numAppendedTuplesInNodeGroup;
         if (nodeLocalState->nodeGroup->isFull()) {
             node_group_idx_t nodeGroupIdx;

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -3,7 +3,6 @@
 #include "common/exception/copy.h"
 #include "common/exception/message.h"
 #include "common/string_format.h"
-#include "processor/operator/partitioner.h"
 #include "processor/result/factorized_table.h"
 #include "storage/store/column_chunk.h"
 #include "storage/store/rel_table.h"

--- a/src/storage/store/CMakeLists.txt
+++ b/src/storage/store/CMakeLists.txt
@@ -1,10 +1,11 @@
 add_library(kuzu_storage_store
         OBJECT
+        chunked_node_group.cpp
+        chunked_node_group_collection.cpp
         column.cpp
         column_chunk.cpp
         dictionary_chunk.cpp
         dictionary_column.cpp
-        node_group.cpp
         node_table.cpp
         node_table_data.cpp
         null_column.cpp

--- a/src/storage/store/node_table_data.cpp
+++ b/src/storage/store/node_table_data.cpp
@@ -99,9 +99,9 @@ void NodeTableData::lookup(Transaction* transaction, TableReadState& readState,
 
 void NodeTableData::append(ChunkedNodeGroup* nodeGroup) {
     for (auto columnID = 0u; columnID < columns.size(); columnID++) {
-        auto columnChunk = nodeGroup->getColumnChunkUnsafe(columnID);
+        auto& columnChunk = nodeGroup->getColumnChunkUnsafe(columnID);
         KU_ASSERT(columnID < columns.size());
-        columns[columnID]->append(columnChunk, nodeGroup->getNodeGroupIdx());
+        columns[columnID]->append(&columnChunk, nodeGroup->getNodeGroupIdx());
     }
 }
 

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -307,7 +307,7 @@ void RelTableData::append(ChunkedNodeGroup* nodeGroup) {
     csrHeaderColumns.append(csrNodeGroup->getCSRHeader(), nodeGroup->getNodeGroupIdx());
     for (auto columnID = 0u; columnID < columns.size(); columnID++) {
         getColumn(columnID)->append(
-            nodeGroup->getColumnChunkUnsafe(columnID), nodeGroup->getNodeGroupIdx());
+            &nodeGroup->getColumnChunkUnsafe(columnID), nodeGroup->getNodeGroupIdx());
     }
 }
 


### PR DESCRIPTION
- move `ChunkedNodeGroupCollection` to separate files with a bit more append/merge interfaces.
- refactor Partitioner to use `ChunkedNodeGroupCollection`.