### PR TITLE
Support read after update

### DIFF
--- a/src/binder/bind/bind_query.cpp
+++ b/src/binder/bind/bind_query.cpp
@@ -53,7 +53,6 @@ std::unique_ptr<BoundRegularQuery> Binder::bindQuery(const RegularQuery& regular
     auto boundRegularQuery = std::make_unique<BoundRegularQuery>(
         regularQuery.getIsUnionAll(), normalizedSingleQueries[0].getStatementResult()->copy());
     for (auto& normalizedSingleQuery : normalizedSingleQueries) {
-        validateReadNotFollowUpdate(normalizedSingleQuery);
         boundRegularQuery->addSingleQuery(std::move(normalizedSingleQuery));
     }
     validateIsAllUnionOrUnionAll(*boundRegularQuery);

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -153,18 +153,6 @@ void Binder::validateOrderByFollowedBySkipOrLimitInWithClause(
     }
 }
 
-void Binder::validateReadNotFollowUpdate(const NormalizedSingleQuery& singleQuery) {
-    bool hasSeenUpdateClause = false;
-    for (auto i = 0u; i < singleQuery.getNumQueryParts(); ++i) {
-        auto normalizedQueryPart = singleQuery.getQueryPart(i);
-        if (hasSeenUpdateClause && normalizedQueryPart->hasReadingClause()) {
-            throw BinderException(
-                "Read after update is not supported. Try query with multiple statements.");
-        }
-        hasSeenUpdateClause |= normalizedQueryPart->hasUpdatingClause();
-    }
-}
-
 void Binder::validateTableType(table_id_t tableID, TableType expectedTableType) {
     auto tableEntry =
         clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTx(), tableID);

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -273,10 +273,6 @@ private:
     static void validateOrderByFollowedBySkipOrLimitInWithClause(
         const BoundProjectionBody& boundProjectionBody);
 
-    // We don't support read after write for simplicity. User should instead querying through
-    // multiple statement.
-    static void validateReadNotFollowUpdate(const NormalizedSingleQuery& singleQuery);
-
     void validateTableType(common::table_id_t tableID, common::TableType expectedTableType);
     void validateTableExist(const std::string& tableName);
 

--- a/src/include/planner/operator/logical_plan.h
+++ b/src/include/planner/operator/logical_plan.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "logical_explain.h"
 #include "logical_operator.h"
 
 namespace kuzu {
@@ -13,28 +12,23 @@ class LogicalPlan {
 public:
     LogicalPlan() : estCardinality{1}, cost{0} {}
 
-    inline void setLastOperator(std::shared_ptr<LogicalOperator> op) {
-        lastOperator = std::move(op);
-    }
+    void setLastOperator(std::shared_ptr<LogicalOperator> op) { lastOperator = std::move(op); }
 
-    inline bool isEmpty() const { return lastOperator == nullptr; }
+    bool isEmpty() const { return lastOperator == nullptr; }
 
-    inline std::shared_ptr<LogicalOperator> getLastOperator() const { return lastOperator; }
-    inline Schema* getSchema() const { return lastOperator->getSchema(); }
+    std::shared_ptr<LogicalOperator> getLastOperator() const { return lastOperator; }
+    Schema* getSchema() const { return lastOperator->getSchema(); }
 
-    inline void setCardinality(uint64_t cardinality) { estCardinality = cardinality; }
-    inline uint64_t getCardinality() const { return estCardinality; }
+    void setCardinality(uint64_t cardinality) { estCardinality = cardinality; }
+    uint64_t getCardinality() const { return estCardinality; }
 
-    inline void setCost(uint64_t cost_) { cost = cost_; }
-    inline uint64_t getCost() const { return cost; }
+    void setCost(uint64_t cost_) { cost = cost_; }
+    uint64_t getCost() const { return cost; }
 
-    inline std::string toString() const { return lastOperator->toString(); }
+    std::string toString() const { return lastOperator->toString(); }
 
-    inline bool isProfile() const {
-        return lastOperator->getOperatorType() == LogicalOperatorType::EXPLAIN &&
-               reinterpret_cast<LogicalExplain*>(lastOperator.get())->getExplainType() ==
-                   common::ExplainType::PROFILE;
-    }
+    bool isProfile() const;
+    bool hasUpdate() const;
 
     std::unique_ptr<LogicalPlan> shallowCopy() const;
 

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -225,7 +225,7 @@ private:
 
     // Append Join operators
     void appendHashJoin(const binder::expression_vector& joinNodeIDs, common::JoinType joinType,
-        LogicalPlan& probePlan, LogicalPlan& buildPlan);
+        LogicalPlan& probePlan, LogicalPlan& buildPlan, LogicalPlan& resultPlan);
     void appendMarkJoin(const binder::expression_vector& joinNodeIDs,
         const std::shared_ptr<binder::Expression>& mark, LogicalPlan& probePlan,
         LogicalPlan& buildPlan);
@@ -233,8 +233,8 @@ private:
         binder::expression_vector& boundNodeIDs, LogicalPlan& probePlan,
         std::vector<std::unique_ptr<LogicalPlan>>& buildPlans);
 
-    void appendCrossProduct(
-        common::AccumulateType accumulateType, LogicalPlan& probePlan, LogicalPlan& buildPlan);
+    void appendCrossProduct(common::AccumulateType accumulateType, const LogicalPlan& probePlan,
+        const LogicalPlan& buildPlan, LogicalPlan& resultPlan);
 
     // Append accumulate
     void appendAccumulate(common::AccumulateType accumulateType, LogicalPlan& plan);

--- a/src/planner/operator/logical_operator.cpp
+++ b/src/planner/operator/logical_operator.cpp
@@ -108,6 +108,20 @@ std::string LogicalOperatorUtils::logicalOperatorTypeToString(LogicalOperatorTyp
     }
 }
 
+bool LogicalOperatorUtils::isUpdate(LogicalOperatorType type) {
+    switch (type) {
+    case LogicalOperatorType::INSERT:
+    case LogicalOperatorType::DELETE_NODE:
+    case LogicalOperatorType::DELETE_REL:
+    case LogicalOperatorType::SET_NODE_PROPERTY:
+    case LogicalOperatorType::SET_REL_PROPERTY:
+    case LogicalOperatorType::MERGE:
+        return true;
+    default:
+        return false;
+    }
+}
+
 LogicalOperator::LogicalOperator(
     LogicalOperatorType operatorType, std::shared_ptr<LogicalOperator> child)
     : operatorType{operatorType} {
@@ -127,6 +141,18 @@ LogicalOperator::LogicalOperator(
     for (auto& child : children) {
         this->children.push_back(child);
     }
+}
+
+bool LogicalOperator::hasUpdateRecursive() {
+    if (LogicalOperatorUtils::isUpdate(operatorType)) {
+        return true;
+    }
+    for (auto& child : children) {
+        if (child->hasUpdateRecursive()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 std::string LogicalOperator::toString(uint64_t depth) const {

--- a/src/planner/operator/logical_plan.cpp
+++ b/src/planner/operator/logical_plan.cpp
@@ -1,7 +1,19 @@
 #include "planner/operator/logical_plan.h"
 
+#include "planner/operator/logical_explain.h"
+
 namespace kuzu {
 namespace planner {
+
+bool LogicalPlan::isProfile() const {
+    return lastOperator->getOperatorType() == LogicalOperatorType::EXPLAIN &&
+           reinterpret_cast<LogicalExplain*>(lastOperator.get())->getExplainType() ==
+               common::ExplainType::PROFILE;
+}
+
+bool LogicalPlan::hasUpdate() const {
+    return lastOperator->hasUpdateRecursive();
+}
 
 std::unique_ptr<LogicalPlan> LogicalPlan::shallowCopy() const {
     auto plan = std::make_unique<LogicalPlan>();

--- a/src/planner/plan/append_cross_product.cpp
+++ b/src/planner/plan/append_cross_product.cpp
@@ -6,16 +6,16 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace planner {
 
-void Planner::appendCrossProduct(
-    AccumulateType accumulateType, LogicalPlan& probePlan, LogicalPlan& buildPlan) {
+void Planner::appendCrossProduct(AccumulateType accumulateType, const LogicalPlan& probePlan,
+    const LogicalPlan& buildPlan, LogicalPlan& resultPlan) {
     auto crossProduct = make_shared<LogicalCrossProduct>(
         accumulateType, probePlan.getLastOperator(), buildPlan.getLastOperator());
     crossProduct->computeFactorizedSchema();
     // update cost
-    probePlan.setCost(probePlan.getCardinality() + buildPlan.getCardinality());
+    resultPlan.setCost(probePlan.getCardinality() + buildPlan.getCardinality());
     // update cardinality
-    probePlan.setCardinality(cardinalityEstimator.estimateCrossProduct(probePlan, buildPlan));
-    probePlan.setLastOperator(std::move(crossProduct));
+    resultPlan.setCardinality(cardinalityEstimator.estimateCrossProduct(probePlan, buildPlan));
+    resultPlan.setLastOperator(std::move(crossProduct));
 }
 
 } // namespace planner

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -145,7 +145,8 @@ void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& bo
         appendScanInternalID(rdfInfo->predicateID, rdfInfo->resourceTableIDs, *tmpPlan);
         appendScanNodeProperties(
             rdfInfo->predicateID, rdfInfo->resourceTableIDs, expression_vector{iri}, *tmpPlan);
-        appendHashJoin(expression_vector{rdfInfo->predicateID}, JoinType::INNER, plan, *tmpPlan);
+        appendHashJoin(
+            expression_vector{rdfInfo->predicateID}, JoinType::INNER, plan, *tmpPlan, plan);
     }
 }
 

--- a/src/planner/plan/append_join.cpp
+++ b/src/planner/plan/append_join.cpp
@@ -9,7 +9,7 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendHashJoin(const binder::expression_vector& joinNodeIDs, JoinType joinType,
-    LogicalPlan& probePlan, LogicalPlan& buildPlan) {
+    LogicalPlan& probePlan, LogicalPlan& buildPlan, LogicalPlan& resultPlan) {
     std::vector<join_condition_t> joinConditions;
     for (auto& joinNodeID : joinNodeIDs) {
         joinConditions.emplace_back(joinNodeID, joinNodeID);
@@ -32,11 +32,11 @@ void Planner::appendHashJoin(const binder::expression_vector& joinNodeIDs, JoinT
         hashJoin->setSIP(SidewaysInfoPassing::PROHIBIT_BUILD_TO_PROBE);
     }
     // Update cost
-    probePlan.setCost(CostModel::computeHashJoinCost(joinNodeIDs, probePlan, buildPlan));
+    resultPlan.setCost(CostModel::computeHashJoinCost(joinNodeIDs, probePlan, buildPlan));
     // Update cardinality
-    probePlan.setCardinality(
+    resultPlan.setCardinality(
         cardinalityEstimator.estimateHashJoin(joinNodeIDs, probePlan, buildPlan));
-    probePlan.setLastOperator(std::move(hashJoin));
+    resultPlan.setLastOperator(std::move(hashJoin));
 }
 
 void Planner::appendMarkJoin(const binder::expression_vector& joinNodeIDs,

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -561,8 +561,8 @@ void Planner::planInnerHashJoin(const SubqueryGraph& subgraph, const SubqueryGra
             if (CostModel::computeHashJoinCost(joinNodeIDs, *leftPlan, *rightPlan) < maxCost) {
                 auto leftPlanProbeCopy = leftPlan->shallowCopy();
                 auto rightPlanBuildCopy = rightPlan->shallowCopy();
-                appendHashJoin(
-                    joinNodeIDs, JoinType::INNER, *leftPlanProbeCopy, *rightPlanBuildCopy);
+                appendHashJoin(joinNodeIDs, JoinType::INNER, *leftPlanProbeCopy,
+                    *rightPlanBuildCopy, *leftPlanProbeCopy);
                 appendFilters(predicates, *leftPlanProbeCopy);
                 context.addPlan(newSubgraph, std::move(leftPlanProbeCopy));
             }
@@ -571,8 +571,8 @@ void Planner::planInnerHashJoin(const SubqueryGraph& subgraph, const SubqueryGra
                 CostModel::computeHashJoinCost(joinNodeIDs, *rightPlan, *leftPlan) < maxCost) {
                 auto leftPlanBuildCopy = leftPlan->shallowCopy();
                 auto rightPlanProbeCopy = rightPlan->shallowCopy();
-                appendHashJoin(
-                    joinNodeIDs, JoinType::INNER, *rightPlanProbeCopy, *leftPlanBuildCopy);
+                appendHashJoin(joinNodeIDs, JoinType::INNER, *rightPlanProbeCopy,
+                    *leftPlanBuildCopy, *rightPlanProbeCopy);
                 appendFilters(predicates, *rightPlanProbeCopy);
                 context.addPlan(newSubgraph, std::move(rightPlanProbeCopy));
             }
@@ -588,7 +588,8 @@ std::vector<std::unique_ptr<LogicalPlan>> Planner::planCrossProduct(
         for (auto& rightPlan : rightPlans) {
             auto leftPlanCopy = leftPlan->shallowCopy();
             auto rightPlanCopy = rightPlan->shallowCopy();
-            appendCrossProduct(AccumulateType::REGULAR, *leftPlanCopy, *rightPlanCopy);
+            appendCrossProduct(
+                AccumulateType::REGULAR, *leftPlanCopy, *rightPlanCopy, *leftPlanCopy);
             result.push_back(std::move(leftPlanCopy));
         }
     }

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -103,7 +103,7 @@ void Planner::planInQueryCall(
             if (!predicatesToPushDown.empty()) {
                 appendFilters(predicatesToPushDown, *tmpPlan);
             }
-            appendCrossProduct(AccumulateType::REGULAR, *plan, *tmpPlan);
+            appendCrossProduct(AccumulateType::REGULAR, *plan, *tmpPlan, *plan);
         } else {
             appendInQueryCall(*readingClause, *plan);
             if (!predicatesToPushDown.empty()) {
@@ -139,7 +139,7 @@ void Planner::planLoadFrom(
             if (!predicatesToPushDown.empty()) {
                 appendFilters(predicatesToPushDown, *tmpPlan);
             }
-            appendCrossProduct(AccumulateType::REGULAR, *plan, *tmpPlan);
+            appendCrossProduct(AccumulateType::REGULAR, *plan, *tmpPlan, *plan);
         } else {
             appendScanFile(loadFrom->getInfo(), *plan);
             if (!predicatesToPushDown.empty()) {

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -241,14 +241,6 @@ Binder exception: p1.age has data type INT64 but (STRING) was expected.
 ---- error
 Binder exception: Union and union all can not be used together.
 
--LOG ReadAfterUpdate
--STATEMENT MATCH (a:person) SET a.age = 35 WITH a MATCH (a)-[:knows]->(b:person) RETURN a.age
----- error
-Binder exception: Read after update is not supported. Try query with multiple statements.
--STATEMENT MATCH (a:person) WHERE a.age = 35 DELETE a WITH a MATCH (a)-[:knows]->(b:person) RETURN a.age
----- error
-Binder exception: Read after update is not supported. Try query with multiple statements.
-
 -LOG SetDataTypeMisMatch
 -STATEMENT MATCH (a:person) SET a.age = 'hh'
 ---- error

--- a/test/test_files/update_node/create_read_tinysnb.test
+++ b/test/test_files/update_node/create_read_tinysnb.test
@@ -4,12 +4,37 @@
 --
 
 -CASE CreateNodeRead1
+-STATEMENT CREATE (a:person {ID:91, fName:'dummy'}) WITH a MATCH (b:person) WHERE b.ID > 9 RETURN a.ID, a.fName, b.ID, b.fName;
+---- 2
+91|dummy|10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+91|dummy|91|dummy
+-STATEMENT CREATE (a:person {ID:93, fName:'dummy'}) WITH a MATCH (b:person) WHERE b.ID = a.ID - 90 RETURN a.ID, a.fName, b.ID, b.fName;
+---- 1
+93|dummy|3|Carol
+-STATEMENT MATCH (a:person) WHERE a.ID < 3 CREATE (b:person {ID:a.ID+100, fName:a.fName}) WITH a, b MATCH (c:person) WHERE c.ID > 99 RETURN a.ID, a.fName, b.ID, b.fName, c.ID, c.fName;
+---- 4
+0|Alice|100|Alice|100|Alice
+0|Alice|100|Alice|102|Bob
+2|Bob|102|Bob|100|Alice
+2|Bob|102|Bob|102|Bob
 -STATEMENT CREATE (a:person {ID:80, isWorker:true,age:22,eyeSight:1.1}) RETURN a.ID, a.age, a.fName, a.eyeSight;
 ---- 1
 80|22||1.100000
 -STATEMENT CREATE (a:organisation {ID:0, name:'test'}) RETURN a, a.history;
 ---- 1
 {_ID: 1:3, _LABEL: organisation, ID: 0, name: test}|
+
+
+-CASE OptionalMatchAfterInsert
+-STATEMENT CREATE (a:person {ID:200, fName:'test'}) WITH a OPTIONAL MATCH (b:person) RETURN COUNT(*);
+---- 1
+9
+-STATEMENT CREATE (a:person {ID:201, fName:'test'}) WITH a OPTIONAL MATCH (b:person) WHERE b.ID > a.ID RETURN COUNT(b);
+---- error
+Runtime exception: Optional match after update is not supported. Missing right outer join implementation.
+-STATEMENT CREATE (a:person {ID:202, fName:'test'}) WITH a OPTIONAL MATCH (a)-[]->(b) RETURN COUNT(*);
+---- error
+Runtime exception: Optional match after update is not supported. Missing right outer join implementation.
 
 -CASE CreateNodeRead2
 -STATEMENT MATCH (a:person) WHERE a.ID < 3 CREATE (b:person {ID: a.ID + 11, fName: 'new', age:a.age * 2})

--- a/test/test_files/update_node/delete_tinysnb.test
+++ b/test/test_files/update_node/delete_tinysnb.test
@@ -13,6 +13,11 @@
 -STATEMENT MATCH (a:person) WHERE a.ID = 101 RETURN a.ID, a.fName, a.age
 ---- 1
 101||
+-STATEMENT MATCH (a:person) WHERE a.ID = 0 DETACH DELETE a WITH a MATCH (b:person) WHERE b.ID < 6 RETURN a.ID, b.ID;
+---- 3
+0|2
+0|3
+0|5
 
 -CASE MixedDeleteInsertTest
 -STATEMENT CREATE (a:organisation {ID:30, mark:3.3})

--- a/test/test_files/update_node/set_read.test
+++ b/test/test_files/update_node/set_read.test
@@ -19,6 +19,15 @@
 -STATEMENT MATCH (a:person) WHERE a.ID=0 RETURN a.age, a.gender, a.fName
 ---- 1
 70|1|
+-STATEMENT MATCH (a:person) WHERE a.ID=0 SET a.fName = 'XX' WITH a MATCH (b:person) WHERE b.ID < 6 RETURN a.ID, a.fName, b.ID, b.fName;
+---- 4
+0|XX|0|XX
+0|XX|2|Bob
+0|XX|3|Carol
+0|XX|5|Dan
+-STATEMENT MATCH (a:person) WHERE a.ID=2 SET a.fName = 'BB' WITH a MATCH (b:person) WHERE b.ID=a.ID RETURN a.ID, a.fName, b.ID, b.fName;
+---- 1
+2|BB|2|BB
 
 -CASE SetReadTest2
 -STATEMENT CREATE NODE TABLE play(ID INT64, name STRING, PRIMARY KEY(ID));

--- a/test/test_files/update_rel/create_read_tinysnb.test
+++ b/test/test_files/update_rel/create_read_tinysnb.test
@@ -18,6 +18,18 @@
 (0:0)-{_LABEL: knows, _ID: 3:0, date: 2021-06-30, meetTime: 1986-10-21 21:08:31.521, validInterval: 10 years 5 months 13:00:00.000024, comments: [rnme,m8sihsdnf2990nfiwf], summary: {locations: ['toronto','waterloo'], transfer: {day: 2021-01-02, amount: [100,200]}}, notes: 1, someMap: {a=b}}->(0:1)
 (0:0)-{_LABEL: knows, _ID: 3:14, date: 2023-03-03}->(0:1)
 (0:0)-{_LABEL: knows, _ID: 3:15, date: 2023-04-04}->(0:1)
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 0 AND b.ID = 2 CREATE (a)-[e:knows {date:date('2024-01-01')}]-(b) WITH a MATCH (a)-[e:knows]->(b) RETURN a.fName, e.date, b.fName;
+---- 6
+Alice|2021-06-30|Bob
+Alice|2021-06-30|Carol
+Alice|2021-06-30|Dan
+Alice|2023-03-03|Bob
+Alice|2023-04-04|Bob
+Alice|2024-01-01|Bob
+-STATEMENT MATCH (a:person), (b:person) WHERE a.ID = 0 AND b.ID = 2 CREATE (a)-[e:knows {date:date('2023-12-20')}]-(b) WITH a, e MATCH (a)-[e2:knows]->(b) WHERE e.date<=e2.date RETURN a.fName, e.date, e2.date, b.fName;
+---- 2
+Alice|2023-12-20|2023-12-20|Bob
+Alice|2023-12-20|2024-01-01|Bob
 
 -CASE CreateRelRead2
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 0 CREATE (a)-[f:knows {date:date('2023-04-04')}]->(b) RETURN f;

--- a/test/test_files/update_rel/delete_tinysnb.test
+++ b/test/test_files/update_rel/delete_tinysnb.test
@@ -14,6 +14,20 @@
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 RETURN COUNT(*)
 ---- 1
 2
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=2 AND b.ID = 0 DELETE e WITH e MATCH (a:person)-[e2:knows]->(b:person) RETURN e.date, a.fName, e2.date, b.fName;
+---- 12
+2021-06-30|Alice|2021-06-30|Bob
+2021-06-30|Alice|2021-06-30|Dan
+2021-06-30|Bob|1950-05-14|Carol
+2021-06-30|Bob|1950-05-14|Dan
+2021-06-30|Carol|1950-05-14|Bob
+2021-06-30|Carol|2000-01-01|Dan
+2021-06-30|Carol|2021-06-30|Alice
+2021-06-30|Dan|1950-05-14|Bob
+2021-06-30|Dan|2000-01-01|Carol
+2021-06-30|Dan|2021-06-30|Alice
+2021-06-30|Elizabeth|1905-12-12|Farooq
+2021-06-30|Elizabeth|1905-12-12|Greg
 
 -CASE DeleteFromKnows2
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 AND b.ID>=3 DELETE e

--- a/test/test_files/update_rel/set_read_tinysnb.test
+++ b/test/test_files/update_rel/set_read_tinysnb.test
@@ -18,6 +18,16 @@
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 AND b.ID=5 RETURN e.date;
 ---- 1
 
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=0 AND b.ID=5 SET e.date=date('1999-01-02') WITH e MATCH (x:person)-[e2:knows]->(y:person) WHERE e2.date <= e.date RETURN e.date, x.fName, e2.date, y.fName;
+---- 7
+1999-01-02|Alice|1999-01-02|Dan
+1999-01-02|Bob|1950-05-14|Carol
+1999-01-02|Bob|1950-05-14|Dan
+1999-01-02|Carol|1950-05-14|Bob
+1999-01-02|Dan|1950-05-14|Bob
+1999-01-02|Elizabeth|1905-12-12|Farooq
+1999-01-02|Elizabeth|1905-12-12|Greg
+
 -CASE SetReadTest2
 -STATEMENT CREATE REL TABLE play(FROM person TO person, date DATE, year INT64);
 ---- ok


### PR DESCRIPTION
We now support read after update.

Since we already support read write in one transaction. There is no reason we couldn't support read after update in one plan. Also we need to enforce is that update pipeline is executed before read pipeline.