### PR TITLE
initialize readfds via FD_ZERO before use

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1369,6 +1369,7 @@ static void searchNext(linenoiseState* l) {
 bool pastedInput(int ifd) {
 #ifdef _WIN32
     fd_set readfds;
+    FD_ZERO(&readfds);
     FD_SET(ifd, &readfds);
     int isPasted = select(0, &readfds, NULL, NULL, NULL);
     return (isPasted != 0 && isPasted != SOCKET_ERROR);


### PR DESCRIPTION
`kuzu_shell.exe` was crashing on my windows development machine and noticed there is #2535 which is also discussing on the same lines.

There is a genuine issue of using readfds without being initialized in `linenoise.cpp` line 1372. `kuzu_shell.exe` crashes in my build each time with the following callstack:

```
kuzu_shell.exe;void failwithmessage(
   void * retaddr = 000000F2014FC170,
   int crttype = 1024,
   int errnum = -1751163576,
   const char* msg = 000002DDE1230150) Ln 213;7FF6972CF9EE
kuzu_shell.exe;void _RTC_UninitUse(
   const char* varname = 000084C200000010) Ln 362;7FF6972CFB84
kuzu_shell.exe;b8 pastedInput(
   int ifd = 0) Ln 1372;7FF696062D31
kuzu_shell.exe;int linenoiseEdit(
   int stdin_fd = 0,
   int stdout_fd = 1,
   char * buf = 000000F2014FCB70,
   u64 buflen = 4096,
   const char* prompt = 00007FF69753BF00) Ln 1767;7FF696063F6F
kuzu_shell.exe;int linenoiseRaw(
   char * buf = 000000F2014FCB70,
   u64 buflen = 4096,
   const char* prompt = 00007FF69753BF00) Ln 2082;7FF696064C54
kuzu_shell.exe;char * linenoise(
   const char* prompt = 00007FF69753BF00) Ln 2153;7FF69605EF74
kuzu_shell.exe;kuzu::main::EmbeddedShell::run() Ln 334;7FF696023E72
kuzu_shell.exe;int main(
   int argc = 2,
   char * * argv = 000002DDE123DB30) Ln 77;7FF69606E11E
kuzu_shell.exe;int invoke_main() Ln 79;7FF6972D0249
kuzu_shell.exe;int __scrt_common_main_seh() Ln 288;7FF6972D012E
kuzu_shell.exe;int __scrt_common_main() Ln 331;7FF6972CFFEE
kuzu_shell.exe;unsigned long mainCRTStartup(
   void * __formal = 000000F201215000) Ln 17;7FF6972D02DE
kernel32.dll;;7FFA5915257D
ntdll.dll;;7FFA59FAAA58
```

Simpler fix:

```diff
diff --git a/tools/shell/linenoise.cpp b/tools/shell/linenoise.cpp
index dcd32d6d..a01fe0c4 100644
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1369,6 +1369,7 @@ static void searchNext(linenoiseState* l) {
 bool pastedInput(int ifd) {
 #ifdef _WIN32
     fd_set readfds;
+    FD_ZERO(&readfds);
     FD_SET(ifd, &readfds);
     int isPasted = select(0, &readfds, NULL, NULL, NULL);
     return (isPasted != 0 && isPasted != SOCKET_ERROR);
```