### PR TITLE
Cache FileInfo when replaying WAL

### DIFF
--- a/src/include/storage/wal/wal_record.h
+++ b/src/include/storage/wal/wal_record.h
@@ -3,6 +3,7 @@
 #include "common/enums/table_type.h"
 #include "common/types/internal_id_t.h"
 #include "common/types/types.h"
+#include "function/hash/hash_functions.h"
 
 namespace kuzu {
 namespace storage {
@@ -234,3 +235,16 @@ private:
 
 } // namespace storage
 } // namespace kuzu
+
+namespace std {
+template<>
+struct hash<kuzu::storage::DBFileID> {
+    size_t operator()(const kuzu::storage::DBFileID& fileId) const {
+        auto dbFileTypeHash = std::hash<uint8_t>()(static_cast<uint8_t>(fileId.dbFileType));
+        auto isOverflowHash = std::hash<bool>()(fileId.isOverflow);
+        auto nodeIndexIDHash = std::hash<kuzu::common::table_id_t>()(fileId.nodeIndexID.tableID);
+        return kuzu::function::combineHashScalar(
+            dbFileTypeHash, kuzu::function::combineHashScalar(isOverflowHash, nodeIndexIDHash));
+    }
+};
+} // namespace std

--- a/src/include/storage/wal_replayer.h
+++ b/src/include/storage/wal_replayer.h
@@ -27,8 +27,10 @@ public:
 
 private:
     void init();
-    void replayWALRecord(WALRecord& walRecord);
-    void replayPageUpdateOrInsertRecord(const WALRecord& walRecord);
+    void replayWALRecord(WALRecord& walRecord,
+        std::unordered_map<DBFileID, std::unique_ptr<common::FileInfo>>& fileCache);
+    void replayPageUpdateOrInsertRecord(const WALRecord& walRecord,
+        std::unordered_map<DBFileID, std::unique_ptr<common::FileInfo>>& fileCache);
     void replayTableStatisticsRecord(const WALRecord& walRecord);
     void replayCatalogRecord();
     void replayCreateTableRecord(const WALRecord& walRecord);


### PR DESCRIPTION
The WAL replayer is currently opening the destination file every time it updates or inserts a page, which is unnecessary and slows down bulk modifications.

In the benchmarks for #2938 it reduced the cost of replaying the WAL (in tmpfs) from 4.5 seconds to 3.2 seconds (where I'm still copying the hash index through the WAL file on the first try, but on additional copies in future significant amounts of data will still need to go through the WAL file).

I don't particularly like this solution, and I feel like it would be better to group them by file (removing the need for hashing and repeatedly looking up the same file), but I don't know of any way reasonable way of doing that without messing up the order that the records are replayed.

I briefly tried using a std::find with a vector of pairs, which gave more or less the same performance. If we allowed c++23 I'd use [std::flat_map](https://en.cppreference.com/w/cpp/container/flat_map), but I'm not convinced that the vector of pairs by itself simplifies anything (no hashing, but messier access).