### PR TITLE
Pandas Pyarrow Backend Bugfix and Tests

### DIFF
--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -263,8 +263,8 @@ static void scanArrowArraySparseUnion(const ArrowSchema* schema, const ArrowArra
     // eg. nulling out unselected children
     for (int8_t i = 0; i < array->n_children; i++) {
         ArrowConverter::fromArrowArray(schema->children[i], array->children[i],
-            *StructVector::getFieldVector(&outputVector, i), mask->getChild(i), srcOffset, dstOffset,
-            count);
+            *StructVector::getFieldVector(&outputVector, i), mask->getChild(i), srcOffset,
+            dstOffset, count);
     }
 }
 

--- a/src/common/arrow/arrow_null_mask_tree.cpp
+++ b/src/common/arrow/arrow_null_mask_tree.cpp
@@ -166,7 +166,7 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
                     children->push_back(ArrowNullMaskTree(
                         schema->children[i], array->children[i], srcOffset, count));
                 }
-                for (auto i = 0; i < count; i++) {
+                for (auto i = 0u; i < count; i++) {
                     int8_t curType = types[i + srcOffset];
                     mask->setNull(i, children->operator[](curType).isNull(i));
                     // this isn't specified in the arrow specification, but is it valid to

--- a/src/common/arrow/arrow_null_mask_tree.cpp
+++ b/src/common/arrow/arrow_null_mask_tree.cpp
@@ -53,7 +53,7 @@ void ArrowNullMaskTree::scanListPushDown(
     NullMask pushDownMask((auxiliaryLength + NullMask::NUM_BITS_PER_NULL_ENTRY - 1) >>
                           NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2);
     for (uint64_t i = 0; i < count; i++) {
-        pushDownMask.setNullFromRange(offsets[i], offsets[i + 1] - offsets[i], isNull(i));
+        pushDownMask.setNullFromRange(offsets[i] - offsets[0], offsets[i + 1] - offsets[i], isNull(i));
     }
     children->push_back(ArrowNullMaskTree(
         schema->children[0], array->children[0], offsets[0], auxiliaryLength, &pushDownMask));
@@ -155,9 +155,9 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
                     children->push_back(ArrowNullMaskTree(schema->children[i], array->children[i],
                         lowestOffsets[i], highestOffsets[i] - lowestOffsets[i]));
                 }
-                for (auto i = srcOffset; i < srcOffset + count; i++) {
-                    int32_t curOffset = offsets[i];
-                    int8_t curType = types[i];
+                for (auto i = 0; i < count; i++) {
+                    int32_t curOffset = offsets[i + srcOffset];
+                    int8_t curType = types[i + srcOffset];
                     mask->setNull(i, children->operator[](curType).isNull(curOffset));
                 }
             } else {
@@ -165,8 +165,8 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
                     children->push_back(ArrowNullMaskTree(
                         schema->children[i], array->children[i], srcOffset, count));
                 }
-                for (auto i = srcOffset; i < srcOffset + count; i++) {
-                    int8_t curType = types[i];
+                for (auto i = 0; i < count; i++) {
+                    int8_t curType = types[i + srcOffset];
                     mask->setNull(i, children->operator[](curType).isNull(i));
                     // this isn't specified in the arrow specification, but is it valid to
                     // compute this using a bitwise OR?

--- a/src/common/arrow/arrow_null_mask_tree.cpp
+++ b/src/common/arrow/arrow_null_mask_tree.cpp
@@ -53,7 +53,8 @@ void ArrowNullMaskTree::scanListPushDown(
     NullMask pushDownMask((auxiliaryLength + NullMask::NUM_BITS_PER_NULL_ENTRY - 1) >>
                           NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2);
     for (uint64_t i = 0; i < count; i++) {
-        pushDownMask.setNullFromRange(offsets[i] - offsets[0], offsets[i + 1] - offsets[i], isNull(i));
+        pushDownMask.setNullFromRange(
+            offsets[i] - offsets[0], offsets[i + 1] - offsets[i], isNull(i));
     }
     children->push_back(ArrowNullMaskTree(
         schema->children[0], array->children[0], offsets[0], auxiliaryLength, &pushDownMask));

--- a/src/common/arrow/arrow_null_mask_tree.cpp
+++ b/src/common/arrow/arrow_null_mask_tree.cpp
@@ -156,7 +156,7 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
                     children->push_back(ArrowNullMaskTree(schema->children[i], array->children[i],
                         lowestOffsets[i], highestOffsets[i] - lowestOffsets[i]));
                 }
-                for (auto i = 0; i < count; i++) {
+                for (auto i = 0u; i < count; i++) {
                     int32_t curOffset = offsets[i + srcOffset];
                     int8_t curType = types[i + srcOffset];
                     mask->setNull(i, children->operator[](curType).isNull(curOffset));

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -52,7 +52,7 @@ void ListAuxiliaryBuffer::resizeDataVector(ValueVector* dataVector) {
     auto buffer = std::make_unique<uint8_t[]>(capacity * dataVector->getNumBytesPerValue());
     memcpy(buffer.get(), dataVector->valueBuffer.get(), size * dataVector->getNumBytesPerValue());
     dataVector->valueBuffer = std::move(buffer);
-    dataVector->nullMask->resize(capacity);
+    dataVector->nullMask->resize(capacity); // note: allocating 64 times what is needed
     // If the dataVector is a struct vector, we need to resize its field vectors.
     if (dataVector->dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         resizeStructDataVector(dataVector);

--- a/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
+++ b/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
@@ -30,19 +30,16 @@ struct PyArrowTableScanSharedState final : public function::BaseScanSharedState 
 
 struct PyArrowTableScanFunctionData final : public function::TableFuncBindData {
     std::shared_ptr<ArrowSchemaWrapper> schema;
-    std::unique_ptr<py::object> table;
+    py::object table;
     uint64_t numRows;
 
     PyArrowTableScanFunctionData(std::vector<common::LogicalType> columnTypes,
         std::shared_ptr<ArrowSchemaWrapper> schema, std::vector<std::string> columnNames,
-        py::object table, uint64_t numRows)
+        py::handle table, uint64_t numRows)
         : TableFuncBindData{std::move(columnTypes), std::move(columnNames)},
-          schema{std::move(schema)}, table{std::make_unique<py::object>(table)}, numRows{numRows} {}
+          schema{std::move(schema)}, table{py::reinterpret_borrow<py::object>(table)}, numRows{numRows} {}
 
-    ~PyArrowTableScanFunctionData() override {
-        py::gil_scoped_acquire acquire;
-        table.reset();
-    }
+    ~PyArrowTableScanFunctionData() override {}
 
     std::unique_ptr<function::TableFuncBindData> copy() const override {
         py::gil_scoped_acquire acquire;

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -159,6 +159,7 @@ static std::unique_ptr<ScanReplacementData> tryReplacePD(py::dict& dict, py::str
 std::unique_ptr<ScanReplacementData> replacePD(const std::string& objectName) {
     auto pyTableName = py::str(objectName);
     // Here we do an exhaustive search on the frame lineage.
+    py::gil_scoped_acquire acquire;
     auto currentFrame = importCache->inspect.currentframe()();
     while (hasattr(currentFrame, "f_locals")) {
         auto localDict = py::reinterpret_borrow<py::dict>(currentFrame.attr("f_locals"));


### PR DESCRIPTION
Changes:
- We no longer own the dataframe in pyarrow scan so that we don't sometimes segfault on exit
- Null mask logic for unions & lists has been corrected
- Add tests for lists

MAP scanning will be added in the next PR.
