### PR TITLE
List Auxiliary Buffer NullMask Fix

### DIFF
--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -52,9 +52,8 @@ void ListAuxiliaryBuffer::resizeDataVector(ValueVector* dataVector) {
     auto buffer = std::make_unique<uint8_t[]>(capacity * dataVector->getNumBytesPerValue());
     memcpy(buffer.get(), dataVector->valueBuffer.get(), size * dataVector->getNumBytesPerValue());
     dataVector->valueBuffer = std::move(buffer);
-    dataVector->nullMask->resize(
-        (capacity + NullMask::NUM_BITS_PER_NULL_ENTRY - 1)
-        >> NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2);
+    dataVector->nullMask->resize((capacity + NullMask::NUM_BITS_PER_NULL_ENTRY - 1) >>
+                                 NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2);
     // If the dataVector is a struct vector, we need to resize its field vectors.
     if (dataVector->dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         resizeStructDataVector(dataVector);

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -52,7 +52,9 @@ void ListAuxiliaryBuffer::resizeDataVector(ValueVector* dataVector) {
     auto buffer = std::make_unique<uint8_t[]>(capacity * dataVector->getNumBytesPerValue());
     memcpy(buffer.get(), dataVector->valueBuffer.get(), size * dataVector->getNumBytesPerValue());
     dataVector->valueBuffer = std::move(buffer);
-    dataVector->nullMask->resize(capacity); // note: allocating 64 times what is needed
+    dataVector->nullMask->resize(
+        (capacity + NullMask::NUM_BITS_PER_NULL_ENTRY - 1)
+        >> NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2);
     // If the dataVector is a struct vector, we need to resize its field vectors.
     if (dataVector->dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         resizeStructDataVector(dataVector);


### PR DESCRIPTION
The List Auxiliary Buffer allocates 64 times the necessary amount of null bitmap memory when resizing the buffer. This one-line change was made in its own PR so as to be easy to revert. 