### PR TITLE
Fix export database regression

### DIFF
--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -3,7 +3,6 @@
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "common/exception/binder.h"
-#include "common/file_system/virtual_file_system.h"
 #include "common/string_utils.h"
 #include "main/client_context.h"
 #include "parser/parser.h"
@@ -92,12 +91,6 @@ std::unique_ptr<BoundStatement> Binder::bindExportDatabaseClause(const Statement
     }
     if (fileType != FileType::CSV && parsedOptions.size() != 0) {
         throw BinderException{"Only export to csv can have options."};
-    }
-    auto fs = clientContext->getVFSUnsafe();
-    if (!fs->fileOrPathExists(boundFilePath)) {
-        fs->createDir(boundFilePath);
-    } else {
-        throw BinderException(stringFormat("Directory {} already exists.", boundFilePath));
     }
     return std::make_unique<BoundExportDatabase>(
         boundFilePath, fileType, std::move(exportData), std::move(parsedOptions));

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -234,3 +234,10 @@ TEST_F(ApiTest, issueTest4) {
     checkTuple(result->getNext().get(), "-123456789\n");
     ASSERT_FALSE(result->hasNext());
 }
+
+TEST_F(ApiTest, PrepareExport) {
+    auto newDBPath = databasePath + "/newdb";
+    auto preparedStatement = conn->prepare("EXPORT DATABASE '" + newDBPath + '\'');
+    auto result = conn->execute(preparedStatement.get());
+    ASSERT_TRUE(result->isSuccess());
+}

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -41,7 +41,7 @@
 50
 -STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_case2/demo-db2" (format='csv', header=true)
 ---- error
-Binder exception: Directory ${KUZU_EXPORT_DB_DIRECTORY}_case2/demo-db2 already exists.
+Runtime exception: Directory ${KUZU_EXPORT_DB_DIRECTORY}_case2/demo-db2 already exists.
 
 -CASE ExportImportDatabaseWithPARQUET
 -STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db3" (format='parquet')


### PR DESCRIPTION
Fix an export database regression issue.

The issue is due to we rebind in prepare & execute function call. And export directory is created in the first binding stage. This PR moves the directory creation to mapper. Ideally we should do it insider operator but it's not doable at this point because child pipelines require directory to exist first.