### PR TITLE
Refactor sel vector interface

### DIFF
--- a/src/common/data_chunk/data_chunk_state.cpp
+++ b/src/common/data_chunk/data_chunk_state.cpp
@@ -14,7 +14,7 @@ void DataChunkState::slice(offset_t offset) {
     // NOTE: this operation has performance penalty. Ideally we should directly modify selVector
     // instead of creating a new one.
     auto slicedSelVector = std::make_unique<SelectionVector>(DEFAULT_VECTOR_CAPACITY);
-    slicedSelVector->resetSelectorToValuePosBufferWithSize(selVector->selectedSize - offset);
+    slicedSelVector->setToFiltered(selVector->selectedSize - offset);
     for (auto i = 0u; i < slicedSelVector->selectedSize; i++) {
         slicedSelVector->selectedPositions[i] = selVector->selectedPositions[i + offset];
     }

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -41,11 +41,12 @@ bool ValueVector::discardNull(ValueVector& vector) {
     } else {
         auto selectedPos = 0u;
         if (vector.state->selVector->isUnfiltered()) {
-            vector.state->selVector->resetSelectorToValuePosBuffer();
+            auto buffer = vector.state->selVector->getMultableBuffer();
             for (auto i = 0u; i < vector.state->selVector->selectedSize; i++) {
-                vector.state->selVector->selectedPositions[selectedPos] = i;
+                buffer[selectedPos] = i;
                 selectedPos += !vector.isNull(i);
             }
+            vector.state->selVector->setToFiltered();
         } else {
             for (auto i = 0u; i < vector.state->selVector->selectedSize; i++) {
                 auto pos = vector.state->selVector->selectedPositions[i];

--- a/src/expression_evaluator/case_evaluator.cpp
+++ b/src/expression_evaluator/case_evaluator.cpp
@@ -12,7 +12,7 @@ void CaseAlternativeEvaluator::init(const ResultSet& resultSet, MemoryManager* m
     whenEvaluator->init(resultSet, memoryManager);
     thenEvaluator->init(resultSet, memoryManager);
     whenSelVector = std::make_unique<SelectionVector>(DEFAULT_VECTOR_CAPACITY);
-    whenSelVector->resetSelectorToValuePosBuffer();
+    whenSelVector->setToFiltered();
 }
 
 void CaseExpressionEvaluator::init(const ResultSet& resultSet, MemoryManager* memoryManager) {
@@ -51,7 +51,7 @@ bool CaseExpressionEvaluator::select(SelectionVector& selVector, ClientContext* 
     evaluate(clientContext);
     KU_ASSERT(resultVector->state->selVector->selectedSize == selVector.selectedSize);
     auto numSelectedValues = 0u;
-    auto selectedPosBuffer = selVector.getSelectedPositionsBuffer();
+    auto selectedPosBuffer = selVector.getMultableBuffer();
     for (auto i = 0u; i < selVector.selectedSize; ++i) {
         auto selVectorPos = selVector.selectedPositions[i];
         auto resultVectorPos = resultVector->state->selVector->selectedPositions[i];

--- a/src/expression_evaluator/function_evaluator.cpp
+++ b/src/expression_evaluator/function_evaluator.cpp
@@ -47,7 +47,7 @@ bool FunctionExpressionEvaluator::select(
         auto numSelectedValues = 0u;
         for (auto i = 0u; i < resultVector->state->selVector->selectedSize; ++i) {
             auto pos = resultVector->state->selVector->selectedPositions[i];
-            auto selectedPosBuffer = selVector.getSelectedPositionsBuffer();
+            auto selectedPosBuffer = selVector.getMultableBuffer();
             selectedPosBuffer[numSelectedValues] = pos;
             numSelectedValues += resultVector->getValue<bool>(pos);
         }

--- a/src/expression_evaluator/reference_evaluator.cpp
+++ b/src/expression_evaluator/reference_evaluator.cpp
@@ -14,7 +14,7 @@ inline static bool isTrue(ValueVector& vector, uint64_t pos) {
 bool ReferenceExpressionEvaluator::select(
     SelectionVector& selVector, ClientContext* /*clientContext*/) {
     uint64_t numSelectedValues = 0;
-    auto selectedBuffer = resultVector->state->selVector->getSelectedPositionsBuffer();
+    auto selectedBuffer = resultVector->state->selVector->getMultableBuffer();
     if (resultVector->state->selVector->isUnfiltered()) {
         for (auto i = 0u; i < resultVector->state->selVector->selectedSize; i++) {
             selectedBuffer[numSelectedValues] = i;

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -175,7 +175,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
                     outputVector->copyFromVectorData(i, localVector.get(), i);
                 }
             }
-            dataChunk.state->selVector->resetSelectorToUnselectedWithSize(numValuesToOutput);
+            dataChunk.state->selVector->setToUnfiltered(numValuesToOutput);
             localState->currChunkIdx++;
             return numValuesToOutput;
         }

--- a/src/function/vector_hash_functions.cpp
+++ b/src/function/vector_hash_functions.cpp
@@ -12,7 +12,7 @@ static std::unique_ptr<ValueVector> computeDataVecHash(ValueVector* operand) {
     auto numValuesInDataVec = ListVector::getDataVectorSize(operand);
     ListVector::resizeDataVector(hashVector.get(), numValuesInDataVec);
     auto selectionState = std::make_shared<DataChunkState>();
-    selectionState->selVector->resetSelectorToValuePosBuffer();
+    selectionState->selVector->setToFiltered();
     ListVector::getDataVector(operand)->setState(selectionState);
     auto numValuesComputed = 0u;
     while (numValuesComputed < numValuesInDataVec) {

--- a/src/include/common/data_chunk/sel_vector.h
+++ b/src/include/common/data_chunk/sel_vector.h
@@ -11,27 +11,23 @@ class SelectionVector {
 public:
     explicit SelectionVector(sel_t capacity) : selectedSize{0} {
         selectedPositionsBuffer = std::make_unique<sel_t[]>(capacity);
-        resetSelectorToUnselected();
+        setToUnfiltered();
     }
 
-    inline bool isUnfiltered() const {
-        return selectedPositions == (sel_t*)&INCREMENTAL_SELECTED_POS;
-    }
-    inline void resetSelectorToUnselected() {
-        selectedPositions = (sel_t*)&INCREMENTAL_SELECTED_POS;
-    }
-    inline void resetSelectorToUnselectedWithSize(sel_t size) {
+    bool isUnfiltered() const { return selectedPositions == (sel_t*)&INCREMENTAL_SELECTED_POS; }
+    void setToUnfiltered() { selectedPositions = (sel_t*)&INCREMENTAL_SELECTED_POS; }
+    void setToUnfiltered(sel_t size) {
         selectedPositions = (sel_t*)&INCREMENTAL_SELECTED_POS;
         selectedSize = size;
     }
-    inline void resetSelectorToValuePosBuffer() {
-        selectedPositions = selectedPositionsBuffer.get();
-    }
-    inline void resetSelectorToValuePosBufferWithSize(sel_t size) {
+
+    // Set to filtered is not very accurate. It sets selectedPositions to a mutable array.
+    void setToFiltered() { selectedPositions = selectedPositionsBuffer.get(); }
+    void setToFiltered(sel_t size) {
         selectedPositions = selectedPositionsBuffer.get();
         selectedSize = size;
     }
-    inline sel_t* getSelectedPositionsBuffer() { return selectedPositionsBuffer.get(); }
+    sel_t* getMultableBuffer() { return selectedPositionsBuffer.get(); }
 
     KUZU_API static const sel_t INCREMENTAL_SELECTED_POS[DEFAULT_VECTOR_CAPACITY];
 

--- a/src/include/function/binary_function_executor.h
+++ b/src/include/function/binary_function_executor.h
@@ -325,7 +325,7 @@ struct BinaryFunctionExecutor {
         common::ValueVector& left, common::ValueVector& right, common::SelectionVector& selVector) {
         auto lPos = left.state->selVector->selectedPositions[0];
         uint64_t numSelectedValues = 0;
-        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+        auto selectedPositionsBuffer = selVector.getMultableBuffer();
         if (left.isNull(lPos)) {
             return numSelectedValues;
         } else if (right.hasNoNullsGuarantee()) {
@@ -368,7 +368,7 @@ struct BinaryFunctionExecutor {
         common::ValueVector& left, common::ValueVector& right, common::SelectionVector& selVector) {
         auto rPos = right.state->selVector->selectedPositions[0];
         uint64_t numSelectedValues = 0;
-        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+        auto selectedPositionsBuffer = selVector.getMultableBuffer();
         if (right.isNull(rPos)) {
             return numSelectedValues;
         } else if (left.hasNoNullsGuarantee()) {
@@ -411,7 +411,7 @@ struct BinaryFunctionExecutor {
     static bool selectBothUnFlat(
         common::ValueVector& left, common::ValueVector& right, common::SelectionVector& selVector) {
         uint64_t numSelectedValues = 0;
-        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+        auto selectedPositionsBuffer = selVector.getMultableBuffer();
         if (left.hasNoNullsGuarantee() && right.hasNoNullsGuarantee()) {
             if (left.state->selVector->isUnfiltered()) {
                 for (auto i = 0u; i < left.state->selVector->selectedSize; i++) {

--- a/src/include/function/boolean/boolean_function_executor.h
+++ b/src/include/function/boolean/boolean_function_executor.h
@@ -170,7 +170,7 @@ struct BinaryBooleanFunctionExecutor {
         common::ValueVector& left, common::ValueVector& right, common::SelectionVector& selVector) {
         auto lPos = left.state->selVector->selectedPositions[0];
         uint64_t numSelectedValues = 0;
-        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+        auto selectedPositionsBuffer = selVector.getMultableBuffer();
         if (right.state->selVector->isUnfiltered()) {
             for (auto i = 0u; i < right.state->selVector->selectedSize; ++i) {
                 selectOnValue<FUNC>(
@@ -192,7 +192,7 @@ struct BinaryBooleanFunctionExecutor {
         common::ValueVector& left, common::ValueVector& right, common::SelectionVector& selVector) {
         auto rPos = right.state->selVector->selectedPositions[0];
         uint64_t numSelectedValues = 0;
-        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+        auto selectedPositionsBuffer = selVector.getMultableBuffer();
         if (left.state->selVector->isUnfiltered()) {
             for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
                 selectOnValue<FUNC>(
@@ -213,7 +213,7 @@ struct BinaryBooleanFunctionExecutor {
     static bool selectBothUnFlat(
         common::ValueVector& left, common::ValueVector& right, common::SelectionVector& selVector) {
         uint64_t numSelectedValues = 0;
-        auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+        auto selectedPositionsBuffer = selVector.getMultableBuffer();
         if (left.state->selVector->isUnfiltered()) {
             for (auto i = 0u; i < left.state->selVector->selectedSize; ++i) {
                 selectOnValue<FUNC>(
@@ -303,7 +303,7 @@ struct UnaryBooleanOperationExecutor {
             return resultValue == true;
         } else {
             uint64_t numSelectedValues = 0;
-            auto selectedPositionBuffer = selVector.getSelectedPositionsBuffer();
+            auto selectedPositionBuffer = selVector.getMultableBuffer();
             if (operand.state->selVector->isUnfiltered()) {
                 for (auto i = 0ul; i < operand.state->selVector->selectedSize; i++) {
                     selectOnValue<FUNC>(operand, i, numSelectedValues, selectedPositionBuffer);

--- a/src/include/function/null/null_function_executor.h
+++ b/src/include/function/null/null_function_executor.h
@@ -40,10 +40,10 @@ struct NullOperationExecutor {
             return resultValue == true;
         } else {
             uint64_t numSelectedValues = 0;
-            auto selectedPositionsBuffer = selVector.getSelectedPositionsBuffer();
+            auto buffer = selVector.getMultableBuffer();
             for (auto i = 0ul; i < operand.state->selVector->selectedSize; i++) {
                 auto pos = operand.state->selVector->selectedPositions[i];
-                selectOnValue<FUNC>(operand, pos, numSelectedValues, selectedPositionsBuffer);
+                selectOnValue<FUNC>(operand, pos, numSelectedValues, buffer);
             }
             selVector.selectedSize = numSelectedValues;
             return numSelectedValues > 0;

--- a/src/include/function/path/path_function_executor.h
+++ b/src/include/function/path/path_function_executor.h
@@ -99,7 +99,7 @@ private:
             common::StructVector::getFieldVector(listDataVector, fieldIdx).get();
         std::unordered_set<common::nodeID_t, InternalIDHasher> internalIDSet;
         auto numSelectedValues = 0u;
-        auto buffer = selectionVector.getSelectedPositionsBuffer();
+        auto buffer = selectionVector.getMultableBuffer();
         if (inputSelVector.isUnfiltered()) {
             for (auto i = 0u; i < inputSelVector.selectedSize; ++i) {
                 auto& listEntry = listVector.getValue<common::list_entry_t>(i);

--- a/src/include/processor/operator/hash_join/hash_join_probe.h
+++ b/src/include/processor/operator/hash_join/hash_join_probe.h
@@ -15,7 +15,7 @@ struct ProbeState {
         probedTuples = std::make_unique<uint8_t*[]>(common::DEFAULT_VECTOR_CAPACITY);
         matchedSelVector =
             std::make_unique<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
-        matchedSelVector->resetSelectorToValuePosBuffer();
+        matchedSelVector->setToFiltered();
     }
 
     // Each key corresponds to a pointer with the same hash value from the ht directory.

--- a/src/processor/operator/filter.cpp
+++ b/src/processor/operator/filter.cpp
@@ -23,7 +23,7 @@ bool Filter::getNextTuplesInternal(ExecutionContext* context) {
             *dataChunkToSelect->state->selVector, context->clientContext);
         if (!dataChunkToSelect->state->isFlat() &&
             dataChunkToSelect->state->selVector->isUnfiltered()) {
-            dataChunkToSelect->state->selVector->resetSelectorToValuePosBuffer();
+            dataChunkToSelect->state->selVector->setToFiltered();
         }
     } while (!hasAtLeastOneSelectedValue);
     metrics->numOutputTuple.increase(dataChunkToSelect->state->selVector->selectedSize);
@@ -44,14 +44,14 @@ bool NodeLabelFiler::getNextTuplesInternal(ExecutionContext* context) {
         }
         saveSelVector(nodeIDVector->state->selVector);
         numSelectValue = 0;
-        auto buffer = nodeIDVector->state->selVector->getSelectedPositionsBuffer();
+        auto buffer = nodeIDVector->state->selVector->getMultableBuffer();
         for (auto i = 0u; i < nodeIDVector->state->selVector->selectedSize; ++i) {
             auto pos = nodeIDVector->state->selVector->selectedPositions[i];
             buffer[numSelectValue] = pos;
             numSelectValue +=
                 info->nodeLabelSet.contains(nodeIDVector->getValue<nodeID_t>(pos).tableID);
         }
-        nodeIDVector->state->selVector->resetSelectorToValuePosBuffer();
+        nodeIDVector->state->selVector->setToFiltered();
     } while (numSelectValue == 0);
     nodeIDVector->state->selVector->selectedSize = numSelectValue;
     metrics->numOutputTuple.increase(nodeIDVector->state->selVector->selectedSize);

--- a/src/processor/operator/filtering_operator.cpp
+++ b/src/processor/operator/filtering_operator.cpp
@@ -23,11 +23,11 @@ void SelVectorOverWriter::saveSelVector(std::shared_ptr<SelectionVector>& selVec
 void SelVectorOverWriter::resetToCurrentSelVector(std::shared_ptr<SelectionVector>& selVector) {
     currentSelVector->selectedSize = selVector->selectedSize;
     if (selVector->isUnfiltered()) {
-        currentSelVector->resetSelectorToUnselected();
+        currentSelVector->setToUnfiltered();
     } else {
-        memcpy(currentSelVector->getSelectedPositionsBuffer(), selVector->selectedPositions,
+        memcpy(currentSelVector->getMultableBuffer(), selVector->selectedPositions,
             selVector->selectedSize * sizeof(sel_t));
-        currentSelVector->resetSelectorToValuePosBuffer();
+        currentSelVector->setToFiltered();
     }
     selVector = currentSelVector;
 }

--- a/src/processor/operator/flatten.cpp
+++ b/src/processor/operator/flatten.cpp
@@ -7,7 +7,7 @@ namespace processor {
 
 void Flatten::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* /*context*/) {
     dataChunkState = resultSet->dataChunks[dataChunkToFlattenPos]->state.get();
-    currentSelVector->resetSelectorToValuePosBufferWithSize(1 /* size */);
+    currentSelVector->setToFiltered(1 /* size */);
     localState = std::make_unique<FlattenLocalState>();
 }
 

--- a/src/processor/operator/hash_join/hash_join_probe.cpp
+++ b/src/processor/operator/hash_join/hash_join_probe.cpp
@@ -92,12 +92,11 @@ uint64_t HashJoinProbe::getInnerJoinResultForUnFlatKey() {
     auto keySelVector = keyVectors[0]->state->selVector.get();
     if (keySelVector->selectedSize != numTuplesToRead) {
         // Some keys have no matched tuple. So we modify selected position.
-        auto keySelectedBuffer = keySelVector->getSelectedPositionsBuffer();
+        auto buffer = keySelVector->getMultableBuffer();
         for (auto i = 0u; i < numTuplesToRead; i++) {
-            keySelectedBuffer[i] = probeState->matchedSelVector->selectedPositions[i];
+            buffer[i] = probeState->matchedSelVector->selectedPositions[i];
         }
-        keySelVector->selectedSize = numTuplesToRead;
-        keySelVector->resetSelectorToValuePosBuffer();
+        keySelVector->setToFiltered(numTuplesToRead);
     }
     sharedState->getHashTable()->lookup(vectorsToReadInto, columnIdxsToReadFrom,
         probeState->matchedTuples.get(), probeState->nextMatchedTupleIdx, numTuplesToRead);

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -211,9 +211,8 @@ bool TopKBuffer::compareBoundaryValue(const std::vector<common::ValueVector*>& k
 
 bool TopKBuffer::compareFlatKeys(
     vector_idx_t vectorIdxToCompare, std::vector<ValueVector*> keyVectors) {
-    std::shared_ptr<common::SelectionVector> selVector =
-        std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
-    selVector->resetSelectorToValuePosBuffer();
+    auto selVector = std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
+    selVector->setToFiltered();
     auto compareResult = compareFuncs[vectorIdxToCompare](
         *keyVectors[vectorIdxToCompare], *boundaryVecs[vectorIdxToCompare], *selVector);
     if (vectorIdxToCompare == keyVectors.size() - 1) {
@@ -230,13 +229,13 @@ void TopKBuffer::compareUnflatKeys(
     vector_idx_t vectorIdxToCompare, std::vector<ValueVector*> keyVectors) {
     auto compareSelVector =
         std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
-    compareSelVector->resetSelectorToValuePosBuffer();
+    compareSelVector->setToFiltered();
     compareFuncs[vectorIdxToCompare](
         *keyVectors[vectorIdxToCompare], *boundaryVecs[vectorIdxToCompare], *compareSelVector);
     if (vectorIdxToCompare != keyVectors.size() - 1) {
         auto equalsSelVector =
             std::make_shared<common::SelectionVector>(common::DEFAULT_VECTOR_CAPACITY);
-        equalsSelVector->resetSelectorToValuePosBuffer();
+        equalsSelVector->setToFiltered();
         if (equalsFuncs[vectorIdxToCompare](*keyVectors[vectorIdxToCompare],
                 *boundaryVecs[vectorIdxToCompare], *equalsSelVector)) {
             keyVectors[vectorIdxToCompare]->state->selVector = equalsSelVector;

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -155,7 +155,7 @@ void Partitioner::copyDataToPartitions(partition_idx_t partitioningIdx, DataChun
         vectorsToAppend.push_back(chunkToCopyFrom.getValueVector(j).get());
     }
     SelectionVector selVector(1);
-    selVector.resetSelectorToValuePosBufferWithSize(1);
+    selVector.setToFiltered(1);
     for (auto i = 0u; i < chunkToCopyFrom.state->selVector->selectedSize; i++) {
         auto posToCopyFrom = chunkToCopyFrom.state->selVector->selectedPositions[i];
         auto partitionIdx = partitionIdxes->getValue<partition_idx_t>(posToCopyFrom);

--- a/src/processor/operator/skip.cpp
+++ b/src/processor/operator/skip.cpp
@@ -28,17 +28,17 @@ bool Skip::getNextTuplesInternal(ExecutionContext* context) {
         // If all dataChunks are flat, numTupleAvailable = 1 which means numTupleSkippedBefore =
         // skipNumber. So execution is handled in above if statement.
         KU_ASSERT(!dataChunkToSelect->state->isFlat());
-        auto selectedPosBuffer = dataChunkToSelect->state->selVector->getSelectedPositionsBuffer();
+        auto buffer = dataChunkToSelect->state->selVector->getMultableBuffer();
         if (dataChunkToSelect->state->selVector->isUnfiltered()) {
             for (uint64_t i = numTupleToSkipInCurrentResultSet;
                  i < dataChunkToSelect->state->selVector->selectedSize; ++i) {
-                selectedPosBuffer[i - numTupleToSkipInCurrentResultSet] = i;
+                buffer[i - numTupleToSkipInCurrentResultSet] = i;
             }
-            dataChunkToSelect->state->selVector->resetSelectorToValuePosBuffer();
+            dataChunkToSelect->state->selVector->setToFiltered();
         } else {
             for (uint64_t i = numTupleToSkipInCurrentResultSet;
                  i < dataChunkToSelect->state->selVector->selectedSize; ++i) {
-                selectedPosBuffer[i - numTupleToSkipInCurrentResultSet] = selectedPosBuffer[i];
+                buffer[i - numTupleToSkipInCurrentResultSet] = buffer[i];
             }
         }
         dataChunkToSelect->state->selVector->selectedSize =

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -31,7 +31,7 @@ row_idx_t LocalRelNG::scanCSR(offset_t srcOffsetInChunk, offset_t posToReadForOf
         }
     }
     auto numRelsRead = rowIdxesToRead.size();
-    outputVectors[0]->state->selVector->resetSelectorToUnselectedWithSize(numRelsRead);
+    outputVectors[0]->state->selVector->setToUnfiltered(numRelsRead);
     return numRelsRead;
 }
 
@@ -65,7 +65,7 @@ void LocalRelNG::applyCSRDeletions(offset_t srcOffset, ValueVector* relIDVector)
     }
     auto selectPos = 0u;
     auto selVector = std::make_unique<SelectionVector>(DEFAULT_VECTOR_CAPACITY);
-    selVector->resetSelectorToValuePosBuffer();
+    selVector->setToFiltered();
     for (auto i = 0u; i < relIDVector->state->selVector->selectedSize; i++) {
         auto relIDPos = relIDVector->state->selVector->selectedPositions[i];
         auto relOffset = relIDVector->getValue<relID_t>(relIDPos).offset;
@@ -75,7 +75,7 @@ void LocalRelNG::applyCSRDeletions(offset_t srcOffset, ValueVector* relIDVector)
         selVector->selectedPositions[selectPos++] = relIDPos;
     }
     if (selectPos != relIDVector->state->selVector->selectedSize) {
-        relIDVector->state->selVector->resetSelectorToValuePosBuffer();
+        relIDVector->state->selVector->setToFiltered();
         memcpy(relIDVector->state->selVector->selectedPositions, selVector->selectedPositions,
             selectPos * sizeof(sel_t));
         relIDVector->state->selVector->selectedSize = selectPos;

--- a/src/storage/stats/node_table_statistics.cpp
+++ b/src/storage/stats/node_table_statistics.cpp
@@ -113,7 +113,7 @@ void NodeTableStatsAndDeletedIDs::setDeletedNodeOffsetsForMorsel(ValueVector* no
         auto originalSize = nodeIDVector->state->getOriginalSize();
         auto itr = deletedNodeOffsets.begin();
         common::sel_t numSelectedValue = 0;
-        auto selectedBuffer = nodeIDVector->state->selVector->getSelectedPositionsBuffer();
+        auto selectedBuffer = nodeIDVector->state->selVector->getMultableBuffer();
         KU_ASSERT(nodeIDVector->state->selVector->isUnfiltered());
         for (auto pos = 0u; pos < nodeIDVector->state->getOriginalSize(); ++pos) {
             if (itr == deletedNodeOffsets.end()) { // no more deleted offset to check.
@@ -127,7 +127,7 @@ void NodeTableStatsAndDeletedIDs::setDeletedNodeOffsetsForMorsel(ValueVector* no
             selectedBuffer[numSelectedValue++] = pos;
         }
         if (numSelectedValue != originalSize) {
-            nodeIDVector->state->selVector->resetSelectorToValuePosBuffer();
+            nodeIDVector->state->selVector->setToFiltered();
         }
         nodeIDVector->state->selVector->selectedSize = numSelectedValue;
     }

--- a/src/storage/store/chunked_node_group_collection.cpp
+++ b/src/storage/store/chunked_node_group_collection.cpp
@@ -18,10 +18,11 @@ void ChunkedNodeGroupCollection::append(
         auto& lastChunkedGroup = chunkedGroups.back();
         auto numRowsToAppendInGroup = std::min(numRowsToAppend - numRowsAppended,
             static_cast<row_idx_t>(CHUNK_CAPACITY - lastChunkedGroup->getNumRows()));
-        tmpSelVector.resetSelectorToValuePosBufferWithSize(numRowsToAppendInGroup);
+        auto tmpSelVectorBuffer = tmpSelVector.getMultableBuffer();
         for (auto i = 0u; i < numRowsToAppendInGroup; i++) {
-            tmpSelVector.selectedPositions[i] = selVector.selectedPositions[numRowsAppended + i];
+            tmpSelVectorBuffer[i] = selVector.selectedPositions[numRowsAppended + i];
         }
+        tmpSelVector.setToFiltered(numRowsToAppendInGroup);
         lastChunkedGroup->append(vectors, tmpSelVector, numRowsToAppendInGroup);
         if (lastChunkedGroup->getNumRows() == CHUNK_CAPACITY) {
             chunkedGroups.push_back(std::make_unique<ChunkedNodeGroup>(

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -103,7 +103,7 @@ row_idx_t RelTable::detachDeleteForCSRRels(Transaction* transaction, RelTableDat
     while (relDataReadState->hasMoreToRead(transaction)) {
         scan(transaction, *relDataReadState);
         auto numRelsScanned = tempState->selVector->selectedSize;
-        tempState->selVector->resetSelectorToValuePosBufferWithSize(1);
+        tempState->selVector->setToFiltered(1);
         for (auto i = 0u; i < numRelsScanned; i++) {
             tempState->selVector->selectedPositions[0] = i;
             auto deleted =
@@ -113,7 +113,7 @@ row_idx_t RelTable::detachDeleteForCSRRels(Transaction* transaction, RelTableDat
             KU_ASSERT(deleted == reverseDeleted);
             numRelsDeleted += (deleted && reverseDeleted);
         }
-        tempState->selVector->resetSelectorToUnselectedWithSize(DEFAULT_VECTOR_CAPACITY);
+        tempState->selVector->setToUnfiltered();
     }
     return numRelsDeleted;
 }

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -217,7 +217,7 @@ void RelTableData::scan(Transaction* transaction, TableDataReadState& readState,
     }
     auto [startOffset, endOffset] = relReadState.getStartAndEndOffset();
     auto numRowsToRead = endOffset - startOffset;
-    outputVectors[0]->state->selVector->resetSelectorToUnselectedWithSize(numRowsToRead);
+    outputVectors[0]->state->selVector->setToUnfiltered(numRowsToRead);
     outputVectors[0]->state->setOriginalSize(numRowsToRead);
     auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(relReadState.currentNodeOffset);
     auto relIDVectorIdx = INVALID_VECTOR_IDX;


### PR DESCRIPTION
This PR ends up being a pure renaming PR. 

We rename `resetSelectorToUnselected` to `setToUnfiltered` to be consistent with `isUnfiltered`. And `resetSelectorToValuePosBuffer` to `setToMutable`. The reasons are as follow

- `reset` has a very specific meaning of setting to initial state. Out interface in `SelVector` clearly not qualify this notion.
- `resetSelectorToValuePosBuffer` is quite confusing because developer do not know what `ValuePosBuffer` is suppose to be. We should avoid name an interface by naively describing a code block (e.g. `resetSelectorToValuePosBuffer ` is just describing `selectedPositions = selectedPositionsBuffer.get();`). Instead, call it `setToMutable` makes more sense because by default `selectedPositions` points to a static array that is immutable.

I also take the chance to examine if we were using `SelVector` wrongly. I spot a few pieces where @ray6080 should comment as it is storage code. 