### PR TITLE
skip empty history file line

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -2350,6 +2350,8 @@ int linenoiseHistoryLoad(const char* filename) {
             // add the full line to the history
             linenoiseHistoryAdd(buf);
             continue;
+        } else if (result.empty() && buf[0] = '\0') {
+            continue;
         }
         // else we are parsing a Cypher statement
         result += buf;

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -2350,7 +2350,7 @@ int linenoiseHistoryLoad(const char* filename) {
             // add the full line to the history
             linenoiseHistoryAdd(buf);
             continue;
-        } else if (result.empty() && buf[0] = '\0') {
+        } else if (result.empty() && buf[0] == '\0') {
             continue;
         }
         // else we are parsing a Cypher statement


### PR DESCRIPTION
I have read and agree to the terms under [CLA.md](https://github.com/kuzudb/kuzu/blob/master/CLA.md)

Skip empty lines in history file within kuzu_shell.

This change closes #3183