### PR TITLE
Fix order by radix sort bug

### DIFF
--- a/src/include/processor/operator/order_by/radix_sort.h
+++ b/src/include/processor/operator/order_by/radix_sort.h
@@ -24,6 +24,9 @@ public:
 // seen so far. If there are tie tuples, it will compare the overflow ptr of strings. For subsequent
 // columns, the algorithm only calls radixSort on tie tuples.
 class RadixSort {
+private:
+    static constexpr uint16_t COUNTING_ARRAY_SIZE = 256;
+
 public:
     RadixSort(storage::MemoryManager* memoryManager, FactorizedTable& factorizedTable,
         OrderByKeyEncoder& orderByKeyEncoder, std::vector<StrKeyColInfo> strKeyColsInfo)

--- a/src/processor/operator/order_by/radix_sort.cpp
+++ b/src/processor/operator/order_by/radix_sort.cpp
@@ -54,7 +54,6 @@ void RadixSort::sortSingleKeyBlock(const DataBlock& keyBlock) {
 
 void RadixSort::radixSort(uint8_t* keyBlockPtr, uint32_t numTuplesToSort, uint32_t numBytesSorted,
     uint32_t numBytesToSort) {
-    assert(numBytesSorted < numBytesPerTuple);
     // We use radixSortLSD which sorts from the least significant byte to the most significant byte.
     auto tmpKeyBlockPtr = tmpSortingResultBlock->getData();
     keyBlockPtr += numBytesSorted;

--- a/test/test_files/issue/issue5.test
+++ b/test/test_files/issue/issue5.test
@@ -1,0 +1,13 @@
+-GROUP IssueTest
+-DATASET CSV ldbc-sf01
+
+--
+
+-CASE 3188
+-STATEMENT MATCH (a:Comment) RETURN a.id ORDER BY a.length, a.browserUsed, a.locationIP, a.creationDate, a.content, a.id limit 5;
+---- 5
+68719546388
+68719764543
+137438958893
+137439023070
+137439023073


### PR DESCRIPTION
RadixSort doesn't correctly copy the tuple to the destination tuple due to the missing (-numBytesSorted.)