### PR TITLE
Merge duplicate key fix

### DIFF
--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -80,9 +80,10 @@ std::unique_ptr<BoundUpdatingClause> Binder::bindMergeClause(
     auto boundGraphPattern = bindGraphPattern(mergeClause.getPatternElementsRef());
     rewriteMatchPattern(boundGraphPattern);
     auto createInfos = bindInsertInfos(boundGraphPattern.queryGraphCollection, patternsScope);
+    auto distinctMark = createVariable("__distinctMark", *LogicalType::BOOL());
     auto boundMergeClause =
         std::make_unique<BoundMergeClause>(std::move(boundGraphPattern.queryGraphCollection),
-            std::move(boundGraphPattern.where), std::move(createInfos));
+            std::move(boundGraphPattern.where), std::move(createInfos), std::move(distinctMark));
     if (mergeClause.hasOnMatchSetItems()) {
         for (auto& [lhs, rhs] : mergeClause.getOnMatchSetItemsRef()) {
             auto setPropertyInfo = bindSetPropertyInfo(lhs.get(), rhs.get());

--- a/src/include/binder/query/updating_clause/bound_merge_clause.h
+++ b/src/include/binder/query/updating_clause/bound_merge_clause.h
@@ -11,90 +11,91 @@ namespace binder {
 class BoundMergeClause : public BoundUpdatingClause {
 public:
     BoundMergeClause(QueryGraphCollection queryGraphCollection,
-        std::shared_ptr<Expression> predicate, std::vector<BoundInsertInfo> insertInfos)
-        : BoundUpdatingClause{common::ClauseType::MERGE}, queryGraphCollection{std::move(
-                                                              queryGraphCollection)},
-          predicate{std::move(predicate)}, insertInfos{std::move(insertInfos)} {}
+        std::shared_ptr<Expression> predicate, std::vector<BoundInsertInfo> insertInfos,
+        std::shared_ptr<Expression> distinctMark)
+        : BoundUpdatingClause{common::ClauseType::MERGE},
+          queryGraphCollection{std::move(queryGraphCollection)}, predicate{std::move(predicate)},
+          insertInfos{std::move(insertInfos)}, distinctMark{std::move(distinctMark)} {}
 
-    inline const QueryGraphCollection* getQueryGraphCollection() const {
-        return &queryGraphCollection;
-    }
-    inline bool hasPredicate() const { return predicate != nullptr; }
-    inline std::shared_ptr<Expression> getPredicate() const { return predicate; }
+    const QueryGraphCollection* getQueryGraphCollection() const { return &queryGraphCollection; }
+    bool hasPredicate() const { return predicate != nullptr; }
+    std::shared_ptr<Expression> getPredicate() const { return predicate; }
 
-    inline const std::vector<BoundInsertInfo>& getInsertInfosRef() const { return insertInfos; }
-    inline const std::vector<BoundSetPropertyInfo>& getOnMatchSetInfosRef() const {
+    const std::vector<BoundInsertInfo>& getInsertInfosRef() const { return insertInfos; }
+    const std::vector<BoundSetPropertyInfo>& getOnMatchSetInfosRef() const {
         return onMatchSetPropertyInfos;
     }
-    inline const std::vector<BoundSetPropertyInfo>& getOnCreateSetInfosRef() const {
+    const std::vector<BoundSetPropertyInfo>& getOnCreateSetInfosRef() const {
         return onCreateSetPropertyInfos;
     }
 
-    inline bool hasInsertNodeInfo() const {
+    bool hasInsertNodeInfo() const {
         return hasInsertInfo(
             [](const BoundInsertInfo& info) { return info.tableType == common::TableType::NODE; });
     }
-    inline std::vector<const BoundInsertInfo*> getInsertNodeInfos() const {
+    std::vector<const BoundInsertInfo*> getInsertNodeInfos() const {
         return getInsertInfos(
             [](const BoundInsertInfo& info) { return info.tableType == common::TableType::NODE; });
     }
-    inline bool hasInsertRelInfo() const {
+    bool hasInsertRelInfo() const {
         return hasInsertInfo(
             [](const BoundInsertInfo& info) { return info.tableType == common::TableType::REL; });
     }
-    inline std::vector<const BoundInsertInfo*> getInsertRelInfos() const {
+    std::vector<const BoundInsertInfo*> getInsertRelInfos() const {
         return getInsertInfos(
             [](const BoundInsertInfo& info) { return info.tableType == common::TableType::REL; });
     }
 
-    inline bool hasOnMatchSetNodeInfo() const {
+    bool hasOnMatchSetNodeInfo() const {
         return hasOnMatchSetInfo([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::NODE;
         });
     }
-    inline std::vector<const BoundSetPropertyInfo*> getOnMatchSetNodeInfos() const {
+    std::vector<const BoundSetPropertyInfo*> getOnMatchSetNodeInfos() const {
         return getOnMatchSetInfos([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::NODE;
         });
     }
-    inline bool hasOnMatchSetRelInfo() const {
+    bool hasOnMatchSetRelInfo() const {
         return hasOnMatchSetInfo([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::REL;
         });
     }
-    inline std::vector<const BoundSetPropertyInfo*> getOnMatchSetRelInfos() const {
+    std::vector<const BoundSetPropertyInfo*> getOnMatchSetRelInfos() const {
         return getOnMatchSetInfos([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::REL;
         });
     }
 
-    inline bool hasOnCreateSetNodeInfo() const {
+    bool hasOnCreateSetNodeInfo() const {
         return hasOnCreateSetInfo([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::NODE;
         });
     }
-    inline std::vector<const BoundSetPropertyInfo*> getOnCreateSetNodeInfos() const {
+    std::vector<const BoundSetPropertyInfo*> getOnCreateSetNodeInfos() const {
         return getOnCreateSetInfos([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::NODE;
         });
     }
-    inline bool hasOnCreateSetRelInfo() const {
+    bool hasOnCreateSetRelInfo() const {
         return hasOnCreateSetInfo([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::REL;
         });
     }
-    inline std::vector<const BoundSetPropertyInfo*> getOnCreateSetRelInfos() const {
+    std::vector<const BoundSetPropertyInfo*> getOnCreateSetRelInfos() const {
         return getOnCreateSetInfos([](const BoundSetPropertyInfo& info) {
             return info.updateTableType == UpdateTableType::REL;
         });
     }
 
-    inline void addOnMatchSetPropertyInfo(BoundSetPropertyInfo setPropertyInfo) {
+    void addOnMatchSetPropertyInfo(BoundSetPropertyInfo setPropertyInfo) {
         onMatchSetPropertyInfos.push_back(std::move(setPropertyInfo));
     }
-    inline void addOnCreateSetPropertyInfo(BoundSetPropertyInfo setPropertyInfo) {
+    void addOnCreateSetPropertyInfo(BoundSetPropertyInfo setPropertyInfo) {
         onCreateSetPropertyInfos.push_back(std::move(setPropertyInfo));
     }
+
+    std::shared_ptr<Expression> getDistinctMark() const { return distinctMark; }
 
 private:
     bool hasInsertInfo(const std::function<bool(const BoundInsertInfo& info)>& check) const;
@@ -121,6 +122,7 @@ private:
     std::vector<BoundSetPropertyInfo> onMatchSetPropertyInfos;
     // Update on create
     std::vector<BoundSetPropertyInfo> onCreateSetPropertyInfos;
+    std::shared_ptr<Expression> distinctMark;
 };
 
 } // namespace binder

--- a/src/include/optimizer/factorization_rewriter.h
+++ b/src/include/optimizer/factorization_rewriter.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace optimizer {
 
-class FactorizationRewriter : public LogicalOperatorVisitor {
+class FactorizationRewriter final : public LogicalOperatorVisitor {
 public:
     void rewrite(planner::LogicalPlan* plan);
 
@@ -19,6 +19,7 @@ private:
     void visitIntersect(planner::LogicalOperator* op) override;
     void visitProjection(planner::LogicalOperator* op) override;
     void visitAccumulate(planner::LogicalOperator* op) override;
+    void visitMarkAccumulate(planner::LogicalOperator*) override;
     void visitAggregate(planner::LogicalOperator* op) override;
     void visitOrderBy(planner::LogicalOperator* op) override;
     void visitLimit(planner::LogicalOperator* op) override;

--- a/src/include/optimizer/logical_operator_visitor.h
+++ b/src/include/optimizer/logical_operator_visitor.h
@@ -105,6 +105,12 @@ protected:
         return op;
     }
 
+    virtual void visitMarkAccumulate(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitMarkAccumulateReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
     virtual void visitDistinct(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitDistinctReplace(
         std::shared_ptr<planner::LogicalOperator> op) {

--- a/src/include/planner/operator/logical_accumulate.h
+++ b/src/include/planner/operator/logical_accumulate.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalAccumulate : public LogicalOperator {
+class LogicalAccumulate final : public LogicalOperator {
 public:
     LogicalAccumulate(common::AccumulateType accumulateType, binder::expression_vector flatExprs,
         std::shared_ptr<binder::Expression> offset, std::shared_ptr<LogicalOperator> child)
@@ -14,20 +14,20 @@ public:
           accumulateType{accumulateType}, flatExprs{std::move(flatExprs)}, offset{
                                                                                std::move(offset)} {}
 
-    void computeFactorizedSchema() final;
-    void computeFlatSchema() final;
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
 
     f_group_pos_set getGroupPositionsToFlatten() const;
 
-    inline std::string getExpressionsForPrinting() const final { return std::string{}; }
+    std::string getExpressionsForPrinting() const override { return {}; }
 
-    inline common::AccumulateType getAccumulateType() const { return accumulateType; }
-    inline binder::expression_vector getExpressionsToAccumulate() const {
+    common::AccumulateType getAccumulateType() const { return accumulateType; }
+    binder::expression_vector getPayloads() const {
         return children[0]->getSchema()->getExpressionsInScope();
     }
-    inline std::shared_ptr<binder::Expression> getOffset() const { return offset; }
+    std::shared_ptr<binder::Expression> getOffset() const { return offset; }
 
-    inline std::unique_ptr<LogicalOperator> copy() final {
+    std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalAccumulate>(
             accumulateType, flatExprs, offset, children[0]->copy());
     }

--- a/src/include/planner/operator/logical_distinct.h
+++ b/src/include/planner/operator/logical_distinct.h
@@ -1,56 +1,43 @@
 #pragma once
 
 #include "planner/operator/logical_operator.h"
-#include "planner/operator/schema.h"
 
 namespace kuzu {
 namespace planner {
 
 class LogicalDistinct : public LogicalOperator {
 public:
-    LogicalDistinct(
-        binder::expression_vector keyExpressions, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::DISTINCT, std::move(child)},
-          keyExpressions{std::move(keyExpressions)} {}
-    LogicalDistinct(binder::expression_vector keyExpressions,
-        binder::expression_vector dependentKeyExpressions, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::DISTINCT, std::move(child)},
-          keyExpressions{std::move(keyExpressions)}, dependentKeyExpressions{
-                                                         std::move(dependentKeyExpressions)} {}
+    LogicalDistinct(binder::expression_vector keys, std::shared_ptr<LogicalOperator> child)
+        : LogicalDistinct{
+              LogicalOperatorType::DISTINCT, keys, binder::expression_vector{}, std::move(child)} {}
+    LogicalDistinct(LogicalOperatorType type, binder::expression_vector keys,
+        binder::expression_vector payloads, std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{type, std::move(child)}, keys{std::move(keys)}, payloads{std::move(
+                                                                              payloads)} {}
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    f_group_pos_set getGroupsPosToFlatten();
+    virtual f_group_pos_set getGroupsPosToFlatten();
 
     std::string getExpressionsForPrinting() const override;
 
-    inline binder::expression_vector getKeyExpressions() const { return keyExpressions; }
-    inline void setKeyExpressions(binder::expression_vector expressions) {
-        keyExpressions = std::move(expressions);
-    }
-    inline binder::expression_vector getDependentKeyExpressions() const {
-        return dependentKeyExpressions;
-    }
-    inline void setDependentKeyExpressions(binder::expression_vector expressions) {
-        dependentKeyExpressions = std::move(expressions);
-    }
-    inline binder::expression_vector getAllDistinctExpressions() const {
-        binder::expression_vector result;
-        result.insert(result.end(), keyExpressions.begin(), keyExpressions.end());
-        result.insert(result.end(), dependentKeyExpressions.begin(), dependentKeyExpressions.end());
-        return result;
-    }
+    binder::expression_vector getKeys() const { return keys; }
+    void setKeys(binder::expression_vector expressions) { keys = std::move(expressions); }
+    binder::expression_vector getPayloads() const { return payloads; }
+    void setPayloads(binder::expression_vector expressions) { payloads = std::move(expressions); }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalDistinct>(
-            keyExpressions, dependentKeyExpressions, children[0]->copy());
+        return make_unique<LogicalDistinct>(operatorType, keys, payloads, children[0]->copy());
     }
 
-private:
-    binder::expression_vector keyExpressions;
-    // See logical_aggregate.h for details.
-    binder::expression_vector dependentKeyExpressions;
+protected:
+    binder::expression_vector getKeysAndPayloads() const;
+
+protected:
+    binder::expression_vector keys;
+    // Payloads have different meaning
+    binder::expression_vector payloads;
 };
 
 } // namespace planner

--- a/src/include/planner/operator/logical_distinct.h
+++ b/src/include/planner/operator/logical_distinct.h
@@ -36,7 +36,7 @@ protected:
 
 protected:
     binder::expression_vector keys;
-    // Payloads have different meaning
+    // Payloads meaning additional keys that are functional dependent on the keys above.
     binder::expression_vector payloads;
 };
 

--- a/src/include/planner/operator/logical_mark_accmulate.h
+++ b/src/include/planner/operator/logical_mark_accmulate.h
@@ -20,6 +20,7 @@ public:
     std::string getExpressionsForPrinting() const override { return {}; }
     binder::expression_vector getKeys() const { return keys; }
     binder::expression_vector getPayloads() const;
+    std::shared_ptr<binder::Expression> getMark() const { return mark; }
 
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalMarkAccumulate>(keys, mark, children[0]->copy());

--- a/src/include/planner/operator/logical_mark_accmulate.h
+++ b/src/include/planner/operator/logical_mark_accmulate.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "planner/operator/logical_operator.h"
+
+namespace kuzu {
+namespace planner {
+
+class LogicalMarkAccumulate final : public LogicalOperator {
+public:
+    LogicalMarkAccumulate(binder::expression_vector keys, std::shared_ptr<binder::Expression> mark,
+        std::shared_ptr<LogicalOperator> child)
+        : LogicalOperator{LogicalOperatorType::MARK_ACCUMULATE, std::move(child)},
+          keys{std::move(keys)}, mark{std::move(mark)} {}
+
+    void computeFactorizedSchema() override;
+    void computeFlatSchema() override;
+
+    f_group_pos_set getGroupsPosToFlatten() const;
+
+    std::string getExpressionsForPrinting() const override { return {}; }
+    binder::expression_vector getKeys() const { return keys; }
+    binder::expression_vector getPayloads() const;
+
+    std::unique_ptr<LogicalOperator> copy() override {
+        return std::make_unique<LogicalMarkAccumulate>(keys, mark, children[0]->copy());
+    }
+
+private:
+    binder::expression_vector keys;
+    std::shared_ptr<binder::Expression> mark;
+};
+
+} // namespace planner
+} // namespace kuzu

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -34,6 +34,7 @@ enum class LogicalOperatorType : uint8_t {
     INTERSECT,
     INSERT,
     LIMIT,
+    MARK_ACCUMULATE,
     MERGE,
     MULTIPLICITY_REDUCER,
     NODE_LABEL_FILTER,

--- a/src/include/planner/operator/persistent/logical_merge.h
+++ b/src/include/planner/operator/persistent/logical_merge.h
@@ -9,7 +9,8 @@ namespace planner {
 
 class LogicalMerge : public LogicalOperator {
 public:
-    LogicalMerge(std::shared_ptr<binder::Expression> mark,
+    LogicalMerge(std::shared_ptr<binder::Expression> existenceMark,
+        std::shared_ptr<binder::Expression> distinctMark,
         std::vector<LogicalInsertInfo> insertNodeInfos,
         std::vector<LogicalInsertInfo> insertRelInfos,
         std::vector<std::unique_ptr<LogicalSetPropertyInfo>> onCreateSetNodeInfos,
@@ -17,7 +18,8 @@ public:
         std::vector<std::unique_ptr<LogicalSetPropertyInfo>> onMatchSetNodeInfos,
         std::vector<std::unique_ptr<LogicalSetPropertyInfo>> onMatchSetRelInfos,
         std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::MERGE, std::move(child)}, mark{std::move(mark)},
+        : LogicalOperator{LogicalOperatorType::MERGE, std::move(child)},
+          existenceMark{std::move(existenceMark)}, distinctMark{std::move(distinctMark)},
           insertNodeInfos{std::move(insertNodeInfos)}, insertRelInfos{std::move(insertRelInfos)},
           onCreateSetNodeInfos{std::move(onCreateSetNodeInfos)},
           onCreateSetRelInfos(std::move(onCreateSetRelInfos)),
@@ -27,44 +29,41 @@ public:
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;
 
-    inline std::string getExpressionsForPrinting() const final { return std::string(""); }
+    std::string getExpressionsForPrinting() const final { return {}; }
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    inline std::shared_ptr<binder::Expression> getMark() const { return mark; }
-    inline const std::vector<LogicalInsertInfo>& getInsertNodeInfosRef() const {
-        return insertNodeInfos;
-    }
-    inline const std::vector<LogicalInsertInfo>& getInsertRelInfosRef() const {
-        return insertRelInfos;
-    }
-    inline const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>&
-    getOnCreateSetNodeInfosRef() const {
+    std::shared_ptr<binder::Expression> getExistenceMark() const { return existenceMark; }
+    bool hasDistinctMark() const { return distinctMark != nullptr; }
+    std::shared_ptr<binder::Expression> getDistinctMark() const { return distinctMark; }
+
+    const std::vector<LogicalInsertInfo>& getInsertNodeInfosRef() const { return insertNodeInfos; }
+    const std::vector<LogicalInsertInfo>& getInsertRelInfosRef() const { return insertRelInfos; }
+    const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>& getOnCreateSetNodeInfosRef() const {
         return onCreateSetNodeInfos;
     }
-    inline const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>&
-    getOnCreateSetRelInfosRef() const {
+    const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>& getOnCreateSetRelInfosRef() const {
         return onCreateSetRelInfos;
     }
-    inline const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>&
-    getOnMatchSetNodeInfosRef() const {
+    const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>& getOnMatchSetNodeInfosRef() const {
         return onMatchSetNodeInfos;
     }
-    inline const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>&
-    getOnMatchSetRelInfosRef() const {
+    const std::vector<std::unique_ptr<LogicalSetPropertyInfo>>& getOnMatchSetRelInfosRef() const {
         return onMatchSetRelInfos;
     }
 
-    inline std::unique_ptr<LogicalOperator> copy() final {
-        return std::make_unique<LogicalMerge>(mark, copyVector(insertNodeInfos),
-            copyVector(insertRelInfos), LogicalSetPropertyInfo::copy(onCreateSetNodeInfos),
+    std::unique_ptr<LogicalOperator> copy() final {
+        return std::make_unique<LogicalMerge>(existenceMark, distinctMark,
+            copyVector(insertNodeInfos), copyVector(insertRelInfos),
+            LogicalSetPropertyInfo::copy(onCreateSetNodeInfos),
             LogicalSetPropertyInfo::copy(onCreateSetRelInfos),
             LogicalSetPropertyInfo::copy(onMatchSetNodeInfos),
             LogicalSetPropertyInfo::copy(onMatchSetRelInfos), children[0]->copy());
     }
 
 private:
-    std::shared_ptr<binder::Expression> mark;
+    std::shared_ptr<binder::Expression> existenceMark;
+    std::shared_ptr<binder::Expression> distinctMark;
     // Create infos
     std::vector<LogicalInsertInfo> insertNodeInfos;
     std::vector<LogicalInsertInfo> insertRelInfos;

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -111,12 +111,17 @@ private:
 
     // Plan subquery
     void planOptionalMatch(const binder::QueryGraphCollection& queryGraphCollection,
-        const binder::expression_vector& predicates, LogicalPlan& leftPlan);
+        const binder::expression_vector& predicates, const binder::expression_vector& corrExprs,
+        LogicalPlan& leftPlan);
     void planRegularMatch(const binder::QueryGraphCollection& queryGraphCollection,
         const binder::expression_vector& predicates, LogicalPlan& leftPlan);
     void planSubquery(const std::shared_ptr<binder::Expression>& subquery, LogicalPlan& outerPlan);
     void planSubqueryIfNecessary(
         const std::shared_ptr<binder::Expression>& expression, LogicalPlan& plan);
+
+    static binder::expression_vector getCorrelatedExprs(
+        const binder::QueryGraphCollection& collection, const binder::expression_vector& predicates,
+        Schema* outerSchema);
 
     // Plan query graphs
     std::unique_ptr<LogicalPlan> planQueryGraphCollection(
@@ -246,6 +251,8 @@ private:
     void appendAccumulate(common::AccumulateType accumulateType,
         const binder::expression_vector& flatExprs, std::shared_ptr<binder::Expression> offset,
         LogicalPlan& plan);
+    void appendMarkAccumulate(const binder::expression_vector& keys,
+        std::shared_ptr<binder::Expression> mark, LogicalPlan& plan);
 
     void appendDummyScan(LogicalPlan& plan);
 
@@ -265,7 +272,7 @@ private:
     void appendScanFile(const binder::BoundFileScanInfo* info,
         std::shared_ptr<binder::Expression> offset, LogicalPlan& plan);
 
-    void appendDistinct(const binder::expression_vector& expressionsToDistinct, LogicalPlan& plan);
+    void appendDistinct(const binder::expression_vector& keys, LogicalPlan& plan);
 
     std::unique_ptr<LogicalPlan> createUnionPlan(
         std::vector<std::unique_ptr<LogicalPlan>>& childrenPlans, bool isUnionAll);

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -14,6 +14,8 @@ struct HashSlot {
                          // groupKeyN, aggregateState1, ..., aggregateStateN, hashValue].
 };
 
+enum class HashTableType : uint8_t { AGGREGATE_HASH_TABLE = 0, MERGE_HASH_TABLE = 1 };
+
 /**
  * AggregateHashTable Design
  *
@@ -42,15 +44,15 @@ public:
     AggregateHashTable(storage::MemoryManager& memoryManager,
         const common::logical_type_vec_t& keysDataTypes,
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
-        uint64_t numEntriesToAllocate)
+        uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema)
         : AggregateHashTable(memoryManager, keysDataTypes, std::vector<common::LogicalType>(),
-              aggregateFunctions, numEntriesToAllocate) {}
+              aggregateFunctions, numEntriesToAllocate, std::move(tableSchema)) {}
 
     AggregateHashTable(storage::MemoryManager& memoryManager,
         std::vector<common::LogicalType> keysDataTypes,
         std::vector<common::LogicalType> payloadsDataTypes,
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
-        uint64_t numEntriesToAllocate);
+        uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema);
 
     uint8_t* getEntry(uint64_t idx) { return factorizedTable->getTuple(idx); }
 
@@ -86,9 +88,26 @@ public:
 
     void resize(uint64_t newSize);
 
+protected:
+    virtual uint64_t matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+        const std::vector<common::ValueVector*>& unFlatKeyVectors, uint64_t numMayMatches,
+        uint64_t numNoMatches);
+
+    virtual void initializeFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+        const std::vector<common::ValueVector*>& dependentKeyVectors,
+        uint64_t numFTEntriesToInitialize);
+
+    uint64_t matchUnFlatVecWithFTColumn(common::ValueVector* vector, uint64_t numMayMatches,
+        uint64_t& numNoMatches, uint32_t colIdx);
+
+    uint64_t matchFlatVecWithFTColumn(common::ValueVector* vector, uint64_t numMayMatches,
+        uint64_t& numNoMatches, uint32_t colIdx);
+
 private:
     void initializeFT(
-        const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions);
+        const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
+        std::unique_ptr<FactorizedTableSchema> tableSchema);
 
     void initializeHashTable(uint64_t numEntriesToAllocate);
 
@@ -104,11 +123,6 @@ private:
 
     void initializeFTEntryWithUnFlatVec(
         common::ValueVector* unFlatVector, uint64_t numEntriesToInitialize, uint32_t colIdx);
-
-    void initializeFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        const std::vector<common::ValueVector*>& dependentKeyVectors,
-        uint64_t numFTEntriesToInitialize);
 
     uint8_t* createEntryInDistinctHT(
         const std::vector<common::ValueVector*>& groupByHashKeyVectors, common::hash_t hash);
@@ -144,16 +158,6 @@ private:
     // ! This function will only be used by distinct aggregate, which assumes that all keyVectors
     // are flat.
     bool matchFlatGroupByKeys(const std::vector<common::ValueVector*>& keyVectors, uint8_t* entry);
-
-    uint64_t matchUnFlatVecWithFTColumn(common::ValueVector* vector, uint64_t numMayMatches,
-        uint64_t& numNoMatches, uint32_t colIdx);
-
-    uint64_t matchFlatVecWithFTColumn(common::ValueVector* vector, uint64_t numMayMatches,
-        uint64_t& numNoMatches, uint32_t colIdx);
-
-    uint64_t matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
-        const std::vector<common::ValueVector*>& unFlatKeyVectors, uint64_t numMayMatches,
-        uint64_t numNoMatches);
 
     void fillEntryWithInitialNullAggregateState(uint8_t* entry);
 
@@ -205,13 +209,19 @@ private:
         std::unique_ptr<function::AggregateFunction>& aggregateFunction,
         common::ValueVector* aggVector, uint64_t multiplicity, uint32_t aggStateOffset);
 
+protected:
+    uint32_t hashColIdxInFT;
+    std::unique_ptr<uint64_t[]> mayMatchIdxes;
+    std::unique_ptr<uint64_t[]> noMatchIdxes;
+    std::unique_ptr<uint64_t[]> entryIdxesToInitialize;
+    std::unique_ptr<HashSlot*[]> hashSlotsToUpdateAggState;
+
 private:
     std::vector<common::LogicalType> dependentKeyDataTypes;
     std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions;
 
     //! special handling of distinct aggregate
     std::vector<std::unique_ptr<AggregateHashTable>> distinctHashTables;
-    uint32_t hashColIdxInFT;
     uint32_t hashColOffsetInFT;
     uint32_t aggStateColOffsetInFT;
     uint32_t aggStateColIdxInFT;
@@ -219,11 +229,7 @@ private:
     uint32_t numBytesForDependentKeys = 0;
     std::vector<update_agg_function_t> updateAggFuncs;
     // Temporary arrays to hold intermediate results.
-    std::unique_ptr<HashSlot*[]> hashSlotsToUpdateAggState;
     std::unique_ptr<uint64_t[]> tmpValueIdxes;
-    std::unique_ptr<uint64_t[]> entryIdxesToInitialize;
-    std::unique_ptr<uint64_t[]> mayMatchIdxes;
-    std::unique_ptr<uint64_t[]> noMatchIdxes;
     std::unique_ptr<uint64_t[]> tmpSlotIdxes;
 };
 

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -14,7 +14,7 @@ struct HashSlot {
                          // groupKeyN, aggregateState1, ..., aggregateStateN, hashValue].
 };
 
-enum class HashTableType : uint8_t { AGGREGATE_HASH_TABLE = 0, MERGE_HASH_TABLE = 1 };
+enum class HashTableType : uint8_t { AGGREGATE_HASH_TABLE = 0, MARK_HASH_TABLE = 1 };
 
 /**
  * AggregateHashTable Design

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -33,18 +33,42 @@ private:
     std::unique_ptr<AggregateHashTable> globalAggregateHashTable;
 };
 
+struct HashAggregateInfo {
+    std::vector<DataPos> flatKeysPos;
+    std::vector<DataPos> unFlatKeysPos;
+    std::vector<DataPos> dependentKeysPos;
+    std::unique_ptr<FactorizedTableSchema> tableSchema;
+    HashTableType hashTableType;
+
+    HashAggregateInfo(std::vector<DataPos> flatKeysPos, std::vector<DataPos> unFlatKeysPos,
+        std::vector<DataPos> dependentKeysPos, std::unique_ptr<FactorizedTableSchema> tableSchema,
+        HashTableType hashTableType);
+    HashAggregateInfo(const HashAggregateInfo& other);
+};
+
+struct HashAggregateLocalState {
+    std::vector<common::ValueVector*> flatKeyVectors;
+    std::vector<common::ValueVector*> unFlatKeyVectors;
+    std::vector<common::ValueVector*> dependentKeyVectors;
+    common::DataChunkState* leadingState;
+    std::unique_ptr<AggregateHashTable> aggregateHashTable;
+
+    void init(ResultSet& resultSet, main::ClientContext* context, HashAggregateInfo& info,
+        std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions);
+    void append(
+        std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs, uint64_t multiplicity);
+};
+
 class HashAggregate : public BaseAggregate {
 public:
     HashAggregate(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
-        std::shared_ptr<HashAggregateSharedState> sharedState, std::vector<DataPos> flatKeysPos,
-        std::vector<DataPos> unFlatKeysPos, std::vector<DataPos> dependentKeysPos,
+        std::shared_ptr<HashAggregateSharedState> sharedState, HashAggregateInfo aggregateInfo,
         std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
         std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
         std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
         : BaseAggregate{std::move(resultSetDescriptor), std::move(aggregateFunctions),
               std::move(aggregateInputInfos), std::move(child), id, paramsString},
-          flatKeysPos{std::move(flatKeysPos)}, unFlatKeysPos{std::move(unFlatKeysPos)},
-          dependentKeysPos{std::move(dependentKeysPos)}, sharedState{std::move(sharedState)} {}
+          aggregateInfo{std::move(aggregateInfo)}, sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
@@ -52,24 +76,15 @@ public:
 
     void finalize(ExecutionContext* context) override;
 
-    inline std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<HashAggregate>(resultSetDescriptor->copy(), sharedState, flatKeysPos,
-            unFlatKeysPos, dependentKeysPos, cloneAggFunctions(), cloneAggInputInfos(),
-            children[0]->clone(), id, paramsString);
+    std::unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<HashAggregate>(resultSetDescriptor->copy(), sharedState, aggregateInfo,
+            cloneAggFunctions(), cloneAggInputInfos(), children[0]->clone(), id, paramsString);
     }
 
 private:
-    std::vector<DataPos> flatKeysPos;
-    std::vector<DataPos> unFlatKeysPos;
-    std::vector<DataPos> dependentKeysPos;
-
-    std::vector<common::ValueVector*> flatKeyVectors;
-    std::vector<common::ValueVector*> unFlatKeyVectors;
-    std::vector<common::ValueVector*> dependentKeyVectors;
-    common::DataChunkState* leadingState;
-
+    HashAggregateInfo aggregateInfo;
+    HashAggregateLocalState localState;
     std::shared_ptr<HashAggregateSharedState> sharedState;
-    std::unique_ptr<AggregateHashTable> localAggregateHashTable;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -56,7 +56,7 @@ struct HashAggregateLocalState {
     void init(ResultSet& resultSet, main::ClientContext* context, HashAggregateInfo& info,
         std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions);
     void append(
-        std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs, uint64_t multiplicity);
+        std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs, uint64_t multiplicity) const;
 };
 
 class HashAggregate : public BaseAggregate {

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -28,11 +28,12 @@ public:
 
     void insert(transaction::Transaction* transaction, ExecutionContext* context);
 
+    void writeResult();
+
 private:
     NodeInsertExecutor(const NodeInsertExecutor& other);
 
     bool checkConfict(transaction::Transaction* transaction);
-    void writeResult();
 
 private:
     // Node table to insert.
@@ -69,10 +70,10 @@ public:
 
     void insert(transaction::Transaction* transaction, ExecutionContext* context);
 
+    void writeResult();
+
 private:
     RelInsertExecutor(const RelInsertExecutor& other);
-
-    void writeResult();
 
 private:
     storage::RelsStoreStats* relsStatistics;

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -28,6 +28,8 @@ public:
 
     void insert(transaction::Transaction* transaction, ExecutionContext* context);
 
+    void evaluateResult(ExecutionContext* context);
+
     void writeResult();
 
 private:

--- a/src/include/processor/operator/persistent/merge.h
+++ b/src/include/processor/operator/persistent/merge.h
@@ -9,7 +9,8 @@ namespace processor {
 
 class Merge : public PhysicalOperator {
 public:
-    Merge(const DataPos& markPos, std::vector<NodeInsertExecutor> nodeInsertExecutors,
+    Merge(const DataPos& existenceMark, const DataPos& distinctMark,
+        std::vector<NodeInsertExecutor> nodeInsertExecutors,
         std::vector<RelInsertExecutor> relInsertExecutors,
         std::vector<std::unique_ptr<NodeSetExecutor>> onCreateNodeSetExecutors,
         std::vector<std::unique_ptr<RelSetExecutor>> onCreateRelSetExecutors,
@@ -17,7 +18,8 @@ public:
         std::vector<std::unique_ptr<RelSetExecutor>> onMatchRelSetExecutors,
         std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
         : PhysicalOperator{PhysicalOperatorType::MERGE, std::move(child), id, paramsString},
-          markPos{markPos}, nodeInsertExecutors{std::move(nodeInsertExecutors)},
+          existenceMark{existenceMark}, distinctMark{distinctMark}, nodeInsertExecutors{std::move(
+                                                                        nodeInsertExecutors)},
           relInsertExecutors{std::move(relInsertExecutors)}, onCreateNodeSetExecutors{std::move(
                                                                  onCreateNodeSetExecutors)},
           onCreateRelSetExecutors{std::move(onCreateRelSetExecutors)},
@@ -31,7 +33,7 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) final;
 
     inline std::unique_ptr<PhysicalOperator> clone() final {
-        return std::make_unique<Merge>(markPos, copyVector(nodeInsertExecutors),
+        return std::make_unique<Merge>(existenceMark, distinctMark, copyVector(nodeInsertExecutors),
             copyVector(relInsertExecutors), NodeSetExecutor::copy(onCreateNodeSetExecutors),
             RelSetExecutor::copy(onCreateRelSetExecutors),
             NodeSetExecutor::copy(onMatchNodeSetExecutors),
@@ -39,8 +41,10 @@ public:
     }
 
 private:
-    DataPos markPos;
-    common::ValueVector* markVector = nullptr;
+    DataPos existenceMark;
+    DataPos distinctMark;
+    common::ValueVector* existenceVector = nullptr;
+    common::ValueVector* distinctVector = nullptr;
 
     std::vector<NodeInsertExecutor> nodeInsertExecutors;
     std::vector<RelInsertExecutor> relInsertExecutors;

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -155,7 +155,7 @@ private:
         std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
         std::vector<DataPos> aggregatesOutputPos, planner::Schema* inSchema,
         planner::Schema* outSchema, std::unique_ptr<PhysicalOperator> prevOperator,
-        const std::string& paramsString);
+        const std::string& paramsString, std::shared_ptr<binder::Expression> markExpression);
 
     std::unique_ptr<NodeInsertExecutor> getNodeInsertExecutor(
         const planner::LogicalInsertInfo* info, const planner::Schema& inSchema,

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -69,6 +69,7 @@ private:
     std::unique_ptr<PhysicalOperator> mapOrderBy(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapUnionAll(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapAccumulate(planner::LogicalOperator* logicalOperator);
+    std::unique_ptr<PhysicalOperator> mapMarkAccumulate(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapDummyScan(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapInsert(planner::LogicalOperator* logicalOperator);
     std::unique_ptr<PhysicalOperator> mapSetNodeProperty(planner::LogicalOperator* logicalOperator);
@@ -148,9 +149,8 @@ private:
 
     std::unique_ptr<HashJoinBuildInfo> createHashBuildInfo(const planner::Schema& buildSideSchema,
         const binder::expression_vector& keys, const binder::expression_vector& payloads);
-    std::unique_ptr<PhysicalOperator> createHashAggregate(
-        const binder::expression_vector& keyExpressions,
-        const binder::expression_vector& dependentKeyExpressions,
+    std::unique_ptr<PhysicalOperator> createHashAggregate(const binder::expression_vector& keys,
+        const binder::expression_vector& payloads,
         std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
         std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
         std::vector<DataPos> aggregatesOutputPos, planner::Schema* inSchema,

--- a/src/include/processor/result/mark_hash_table.h
+++ b/src/include/processor/result/mark_hash_table.h
@@ -5,10 +5,10 @@
 namespace kuzu {
 namespace processor {
 
-class MergeHashTable : public AggregateHashTable {
+class MarkHashTable : public AggregateHashTable {
 
 public:
-    MergeHashTable(storage::MemoryManager& memoryManager,
+    MarkHashTable(storage::MemoryManager& memoryManager,
         std::vector<common::LogicalType> keyDataTypes,
         std::vector<common::LogicalType> dependentKeyDataTypes,
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,

--- a/src/include/processor/result/merge_hash_table.h
+++ b/src/include/processor/result/merge_hash_table.h
@@ -1,0 +1,30 @@
+#include "processor/operator/aggregate/aggregate_hash_table.h"
+
+namespace kuzu {
+namespace processor {
+
+class MergeHashTable : public AggregateHashTable {
+
+public:
+    MergeHashTable(storage::MemoryManager& memoryManager,
+        std::vector<common::LogicalType> keyDataTypes,
+        std::vector<common::LogicalType> dependentKeyDataTypes,
+        const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
+        uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema);
+
+    uint64_t matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+        const std::vector<common::ValueVector*>& unFlatKeyVectors, uint64_t numMayMatches,
+        uint64_t numNoMatches) override;
+
+    void initializeFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+        const std::vector<common::ValueVector*>& unFlatKeyVectors,
+        const std::vector<common::ValueVector*>& dependentKeyVectors,
+        uint64_t numFTEntriesToInitialize) override;
+
+private:
+    std::unordered_set<uint64_t> onMatchSlotIdxes;
+    uint32_t distinctColIdxInFT;
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/include/processor/result/merge_hash_table.h
+++ b/src/include/processor/result/merge_hash_table.h
@@ -1,5 +1,7 @@
 #include "processor/operator/aggregate/aggregate_hash_table.h"
 
+#pragma once
+
 namespace kuzu {
 namespace processor {
 

--- a/src/optimizer/agg_key_dependency_optimizer.cpp
+++ b/src/optimizer/agg_key_dependency_optimizer.cpp
@@ -33,9 +33,9 @@ void AggKeyDependencyOptimizer::visitAggregate(planner::LogicalOperator* op) {
 
 void AggKeyDependencyOptimizer::visitDistinct(planner::LogicalOperator* op) {
     auto distinct = (LogicalDistinct*)op;
-    auto [keys, dependentKeys] = resolveKeysAndDependentKeys(distinct->getKeyExpressions());
-    distinct->setKeyExpressions(keys);
-    distinct->setDependentKeyExpressions(dependentKeys);
+    auto [keys, dependentKeys] = resolveKeysAndDependentKeys(distinct->getKeys());
+    distinct->setKeys(keys);
+    distinct->setPayloads(dependentKeys);
 }
 
 std::pair<binder::expression_vector, binder::expression_vector>

--- a/src/optimizer/factorization_rewriter.cpp
+++ b/src/optimizer/factorization_rewriter.cpp
@@ -1,6 +1,7 @@
 #include "optimizer/factorization_rewriter.h"
 
 #include "binder/expression_visitor.h"
+#include "common/cast.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/factorization/flatten_resolver.h"
@@ -12,6 +13,7 @@
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/logical_intersect.h"
 #include "planner/operator/logical_limit.h"
+#include "planner/operator/logical_mark_accmulate.h"
 #include "planner/operator/logical_order_by.h"
 #include "planner/operator/logical_projection.h"
 #include "planner/operator/logical_union.h"
@@ -22,6 +24,7 @@
 #include "planner/operator/persistent/logical_merge.h"
 #include "planner/operator/persistent/logical_set.h"
 
+using namespace kuzu::common;
 using namespace kuzu::binder;
 using namespace kuzu::planner;
 
@@ -102,6 +105,12 @@ void FactorizationRewriter::visitAccumulate(planner::LogicalOperator* op) {
     auto accumulate = (LogicalAccumulate*)op;
     auto groupsPosToFlatten = accumulate->getGroupPositionsToFlatten();
     accumulate->setChild(0, appendFlattens(accumulate->getChild(0), groupsPosToFlatten));
+}
+
+void FactorizationRewriter::visitMarkAccumulate(planner::LogicalOperator* op) {
+    auto markAccumulate = ku_dynamic_cast<LogicalOperator*, LogicalMarkAccumulate*>(op);
+    auto groupsPos = markAccumulate->getGroupsPosToFlatten();
+    markAccumulate->setChild(0, appendFlattens(markAccumulate->getChild(0), groupsPos));
 }
 
 void FactorizationRewriter::visitAggregate(planner::LogicalOperator* op) {

--- a/src/optimizer/logical_operator_visitor.cpp
+++ b/src/optimizer/logical_operator_visitor.cpp
@@ -52,6 +52,9 @@ void LogicalOperatorVisitor::visitOperatorSwitch(planner::LogicalOperator* op) {
     case LogicalOperatorType::ACCUMULATE: {
         visitAccumulate(op);
     } break;
+    case LogicalOperatorType::MARK_ACCUMULATE: {
+        visitMarkAccumulate(op);
+    } break;
     case LogicalOperatorType::DISTINCT: {
         visitDistinct(op);
     } break;
@@ -140,6 +143,9 @@ std::shared_ptr<planner::LogicalOperator> LogicalOperatorVisitor::visitOperatorR
     }
     case LogicalOperatorType::ACCUMULATE: {
         return visitAccumulateReplace(op);
+    }
+    case LogicalOperatorType::MARK_ACCUMULATE: {
+        return visitMarkAccumulateReplace(op);
     }
     case LogicalOperatorType::DISTINCT: {
         return visitDistinctReplace(op);

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -66,7 +66,7 @@ void ProjectionPushDownOptimizer::visitAccumulate(planner::LogicalOperator* op) 
     if (accumulate->getAccumulateType() != AccumulateType::REGULAR) {
         return;
     }
-    auto expressionsBeforePruning = accumulate->getExpressionsToAccumulate();
+    auto expressionsBeforePruning = accumulate->getPayloads();
     auto expressionsAfterPruning = pruneExpressions(expressionsBeforePruning);
     if (expressionsBeforePruning.size() == expressionsAfterPruning.size()) {
         return;
@@ -200,7 +200,10 @@ void ProjectionPushDownOptimizer::visitDeleteRel(planner::LogicalOperator* op) {
 // TODO(Xiyang): come back and refactor this after changing insert interface
 void ProjectionPushDownOptimizer::visitMerge(planner::LogicalOperator* op) {
     auto merge = (LogicalMerge*)op;
-    collectExpressionsInUse(merge->getMark());
+    if (merge->hasDistinctMark()) {
+        collectExpressionsInUse(merge->getDistinctMark());
+    }
+    collectExpressionsInUse(merge->getExistenceMark());
     for (auto& info : merge->getInsertNodeInfosRef()) {
         visitInsertInfo(&info);
     }

--- a/src/planner/operator/CMakeLists.txt
+++ b/src/planner/operator/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(kuzu_planner_operator
         logical_in_query_call.cpp
         logical_intersect.cpp
         logical_limit.cpp
+        logical_mark_accumulate.cpp
         logical_operator.cpp
         logical_order_by.cpp
         logical_partitioner.cpp

--- a/src/planner/operator/logical_accumulate.cpp
+++ b/src/planner/operator/logical_accumulate.cpp
@@ -9,7 +9,7 @@ namespace planner {
 void LogicalAccumulate::computeFactorizedSchema() {
     createEmptySchema();
     auto childSchema = children[0]->getSchema();
-    SinkOperatorUtil::recomputeSchema(*childSchema, getExpressionsToAccumulate(), *schema);
+    SinkOperatorUtil::recomputeSchema(*childSchema, getPayloads(), *schema);
     if (offset != nullptr) {
         // If we need to generate row offset. Then all expressions must have been flattened and
         // accumulated. So the new schema should just have one group.

--- a/src/planner/operator/logical_mark_accumulate.cpp
+++ b/src/planner/operator/logical_mark_accumulate.cpp
@@ -11,7 +11,6 @@ namespace planner {
 void LogicalMarkAccumulate::computeFactorizedSchema() {
     createEmptySchema();
     auto childSchema = children[0]->getSchema();
-    // TODO(Ziyi): this may cause a bug, I'm not sure.
     SinkOperatorUtil::recomputeSchema(*childSchema, childSchema->getExpressionsInScope(), *schema);
     f_group_pos groupPos;
     if (!keys.empty()) {

--- a/src/planner/operator/logical_mark_accumulate.cpp
+++ b/src/planner/operator/logical_mark_accumulate.cpp
@@ -1,0 +1,47 @@
+#include "binder/expression/expression_util.h"
+#include "planner/operator/factorization/flatten_resolver.h"
+#include "planner/operator/factorization/sink_util.h"
+#include "planner/operator/logical_mark_accmulate.h"
+
+using namespace kuzu::binder;
+
+namespace kuzu {
+namespace planner {
+
+void LogicalMarkAccumulate::computeFactorizedSchema() {
+    createEmptySchema();
+    auto childSchema = children[0]->getSchema();
+    // TODO(Ziyi): this may cause a bug, I'm not sure.
+    SinkOperatorUtil::recomputeSchema(*childSchema, childSchema->getExpressionsInScope(), *schema);
+    f_group_pos groupPos;
+    if (!keys.empty()) {
+        groupPos = schema->getGroupPos(*keys[0]);
+    } else {
+        groupPos = schema->createGroup();
+    }
+    schema->insertToGroupAndScope(mark, groupPos);
+}
+
+void LogicalMarkAccumulate::computeFlatSchema() {
+    copyChildSchema(0);
+    schema->insertToGroupAndScope(mark, 0);
+}
+
+f_group_pos_set LogicalMarkAccumulate::getGroupsPosToFlatten() const {
+    f_group_pos_set dependentGroupsPos;
+    auto childSchema = children[0]->getSchema();
+    for (auto& key : keys) {
+        for (auto groupPos : childSchema->getDependentGroupsPos(key)) {
+            dependentGroupsPos.insert(groupPos);
+        }
+    }
+    return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+}
+
+expression_vector LogicalMarkAccumulate::getPayloads() const {
+    auto exprs = children[0]->getSchema()->getExpressionsInScope();
+    return ExpressionUtil::excludeExpressions(exprs, keys);
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/src/planner/operator/logical_operator.cpp
+++ b/src/planner/operator/logical_operator.cpp
@@ -63,6 +63,8 @@ std::string LogicalOperatorUtils::logicalOperatorTypeToString(LogicalOperatorTyp
         return "INSERT";
     case LogicalOperatorType::LIMIT:
         return "LIMIT";
+    case LogicalOperatorType::MARK_ACCUMULATE:
+        return "MARK_ACCUMULATE";
     case LogicalOperatorType::MERGE:
         return "MERGE";
     case LogicalOperatorType::MULTIPLICITY_REDUCER:

--- a/src/planner/operator/schema.cpp
+++ b/src/planner/operator/schema.cpp
@@ -54,9 +54,6 @@ void Schema::insertToGroupAndScope(
 }
 
 f_group_pos Schema::getGroupPos(const std::string& expressionName) const {
-    if (!expressionNameToGroupPos.contains(expressionName)) {
-        auto a = 1;
-    }
     KU_ASSERT(expressionNameToGroupPos.contains(expressionName));
     return expressionNameToGroupPos.at(expressionName);
 }

--- a/src/planner/operator/schema.cpp
+++ b/src/planner/operator/schema.cpp
@@ -54,6 +54,9 @@ void Schema::insertToGroupAndScope(
 }
 
 f_group_pos Schema::getGroupPos(const std::string& expressionName) const {
+    if (!expressionNameToGroupPos.contains(expressionName)) {
+        auto a = 1;
+    }
     KU_ASSERT(expressionNameToGroupPos.contains(expressionName));
     return expressionNameToGroupPos.at(expressionName);
 }

--- a/src/planner/plan/CMakeLists.txt
+++ b/src/planner/plan/CMakeLists.txt
@@ -14,6 +14,7 @@ add_library(kuzu_planner_plan_operator
         append_in_query_call.cpp
         append_join.cpp
         append_limit.cpp
+        append_mark_accumulate.cpp
         append_multiplicity_reducer.cpp
         append_order_by.cpp
         append_projection.cpp

--- a/src/planner/plan/append_distinct.cpp
+++ b/src/planner/plan/append_distinct.cpp
@@ -6,8 +6,8 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace planner {
 
-void Planner::appendDistinct(const expression_vector& expressionsToDistinct, LogicalPlan& plan) {
-    auto distinct = make_shared<LogicalDistinct>(expressionsToDistinct, plan.getLastOperator());
+void Planner::appendDistinct(const expression_vector& keys, LogicalPlan& plan) {
+    auto distinct = make_shared<LogicalDistinct>(keys, plan.getLastOperator());
     appendFlattens(distinct->getGroupsPosToFlatten(), plan);
     distinct->setChild(0, plan.getLastOperator());
     distinct->computeFactorizedSchema();

--- a/src/planner/plan/append_mark_accumulate.cpp
+++ b/src/planner/plan/append_mark_accumulate.cpp
@@ -1,0 +1,20 @@
+#include "planner/operator/logical_mark_accmulate.h"
+#include "planner/planner.h"
+
+using namespace kuzu::binder;
+
+namespace kuzu {
+namespace planner {
+
+void Planner::appendMarkAccumulate(
+    const expression_vector& keys, std::shared_ptr<Expression> mark, LogicalPlan& plan) {
+    auto markAccumulate =
+        std::make_shared<LogicalMarkAccumulate>(keys, mark, plan.getLastOperator());
+    appendFlattens(markAccumulate->getGroupsPosToFlatten(), plan);
+    markAccumulate->setChild(0, plan.getLastOperator());
+    markAccumulate->computeFactorizedSchema();
+    plan.setLastOperator(std::move(markAccumulate));
+}
+
+} // namespace planner
+} // namespace kuzu

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -50,7 +50,12 @@ void Planner::planMatchClause(const BoundReadingClause* boundReadingClause,
     } break;
     case MatchClauseType::OPTIONAL_MATCH: {
         for (auto& plan : plans) {
-            planOptionalMatch(*queryGraphCollection, predicates, *plan);
+            expression_vector corrExprs;
+            if (!plan->isEmpty()) {
+                corrExprs =
+                    getCorrelatedExprs(*queryGraphCollection, predicates, plan->getSchema());
+            }
+            planOptionalMatch(*queryGraphCollection, predicates, corrExprs, *plan);
         }
     } break;
     default:

--- a/src/planner/plan/plan_update.cpp
+++ b/src/planner/plan/plan_update.cpp
@@ -65,23 +65,15 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
     if (mergeClause->hasPredicate()) {
         predicates = mergeClause->getPredicate()->splitOnAND();
     }
-    planOptionalMatch(*mergeClause->getQueryGraphCollection(), predicates, plan);
-    std::shared_ptr<Expression> mark;
-    auto& createInfos = mergeClause->getInsertInfosRef();
-    KU_ASSERT(!createInfos.empty());
-    auto& createInfo = createInfos[0];
-    switch (createInfo.tableType) {
-    case TableType::NODE: {
-        auto node = (NodeExpression*)createInfo.pattern.get();
-        mark = node->getInternalID();
-    } break;
-    case TableType::REL: {
-        auto rel = (RelExpression*)createInfo.pattern.get();
-        mark = rel->getInternalIDProperty();
-    } break;
-    default:
-        KU_UNREACHABLE;
+    std::shared_ptr<Expression> distinctMark = nullptr;
+    expression_vector corrExprs;
+    if (!plan.isEmpty()) {
+        distinctMark = mergeClause->getDistinctMark();
+        corrExprs = getCorrelatedExprs(
+            *mergeClause->getQueryGraphCollection(), predicates, plan.getSchema());
+        appendMarkAccumulate(corrExprs, distinctMark, plan);
     }
+    planOptionalMatch(*mergeClause->getQueryGraphCollection(), predicates, corrExprs, plan);
     std::vector<LogicalInsertInfo> logicalInsertNodeInfos;
     if (mergeClause->hasInsertNodeInfo()) {
         auto boundInsertNodeInfos = mergeClause->getInsertNodeInfos();
@@ -119,10 +111,27 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
             logicalOnMatchSetRelInfos.push_back(createLogicalSetPropertyInfo(info));
         }
     }
-    auto merge = std::make_shared<LogicalMerge>(mark, std::move(logicalInsertNodeInfos),
-        std::move(logicalInsertRelInfos), std::move(logicalOnCreateSetNodeInfos),
-        std::move(logicalOnCreateSetRelInfos), std::move(logicalOnMatchSetNodeInfos),
-        std::move(logicalOnMatchSetRelInfos), plan.getLastOperator());
+    std::shared_ptr<Expression> existenceMark;
+    auto& createInfos = mergeClause->getInsertInfosRef();
+    KU_ASSERT(!createInfos.empty());
+    auto& createInfo = createInfos[0];
+    switch (createInfo.tableType) {
+    case TableType::NODE: {
+        auto node = (NodeExpression*)createInfo.pattern.get();
+        existenceMark = node->getInternalID();
+    } break;
+    case TableType::REL: {
+        auto rel = (RelExpression*)createInfo.pattern.get();
+        existenceMark = rel->getInternalIDProperty();
+    } break;
+    default:
+        KU_UNREACHABLE;
+    }
+    auto merge = std::make_shared<LogicalMerge>(existenceMark, distinctMark,
+        std::move(logicalInsertNodeInfos), std::move(logicalInsertRelInfos),
+        std::move(logicalOnCreateSetNodeInfos), std::move(logicalOnCreateSetRelInfos),
+        std::move(logicalOnMatchSetNodeInfos), std::move(logicalOnMatchSetRelInfos),
+        plan.getLastOperator());
     appendFlattens(merge->getGroupsPosToFlatten(), plan);
     merge->setChild(0, plan.getLastOperator());
     merge->computeFactorizedSchema();

--- a/src/planner/plan/plan_update.cpp
+++ b/src/planner/plan/plan_update.cpp
@@ -71,6 +71,9 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
         distinctMark = mergeClause->getDistinctMark();
         corrExprs = getCorrelatedExprs(
             *mergeClause->getQueryGraphCollection(), predicates, plan.getSchema());
+        if (corrExprs.size() == 0) {
+            throw RuntimeException{"Constant key in merge clause is not supported yet."};
+        }
         appendMarkAccumulate(corrExprs, distinctMark, plan);
     }
     planOptionalMatch(*mergeClause->getQueryGraphCollection(), predicates, corrExprs, plan);

--- a/src/processor/map/CMakeLists.txt
+++ b/src/processor/map/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(kuzu_processor_mapper
         map_intersect.cpp
         map_label_filter.cpp
         map_limit.cpp
+        map_mark_accumulate.cpp
         map_merge.cpp
         map_multiplicity_reducer.cpp
         map_order_by.cpp

--- a/src/processor/map/map_accumulate.cpp
+++ b/src/processor/map/map_accumulate.cpp
@@ -13,7 +13,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAccumulate(LogicalOperator* log
     auto outSchema = acc->getSchema();
     auto inSchema = acc->getChild(0)->getSchema();
     auto prevOperator = mapOperator(acc->getChild(0).get());
-    auto expressions = acc->getExpressionsToAccumulate();
+    auto expressions = acc->getPayloads();
     auto resultCollector = createResultCollector(
         acc->getAccumulateType(), expressions, inSchema, std::move(prevOperator));
     auto table = resultCollector->getResultFactorizedTable();

--- a/src/processor/map/map_aggregate.cpp
+++ b/src/processor/map/map_aggregate.cpp
@@ -6,7 +6,6 @@
 #include "processor/operator/aggregate/simple_aggregate.h"
 #include "processor/operator/aggregate/simple_aggregate_scan.h"
 #include "processor/plan_mapper.h"
-#include "processor/result/merge_hash_table.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;

--- a/src/processor/map/map_distinct.cpp
+++ b/src/processor/map/map_distinct.cpp
@@ -19,7 +19,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapDistinct(LogicalOperator* logic
     return createHashAggregate(logicalDistinct.getKeys(), logicalDistinct.getPayloads(),
         std::move(emptyAggFunctions), std::move(emptyAggInputInfos),
         std::move(emptyAggregatesOutputPos), inSchema, outSchema, std::move(prevOperator),
-        logicalDistinct.getExpressionsForPrinting());
+        logicalDistinct.getExpressionsForPrinting(), nullptr /* markExpression */);
 }
 
 } // namespace processor

--- a/src/processor/map/map_distinct.cpp
+++ b/src/processor/map/map_distinct.cpp
@@ -16,10 +16,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapDistinct(LogicalOperator* logic
     std::vector<std::unique_ptr<function::AggregateFunction>> emptyAggFunctions;
     std::vector<std::unique_ptr<AggregateInputInfo>> emptyAggInputInfos;
     std::vector<DataPos> emptyAggregatesOutputPos;
-    return createHashAggregate(logicalDistinct.getKeyExpressions(),
-        logicalDistinct.getDependentKeyExpressions(), std::move(emptyAggFunctions),
-        std::move(emptyAggInputInfos), std::move(emptyAggregatesOutputPos), inSchema, outSchema,
-        std::move(prevOperator), logicalDistinct.getExpressionsForPrinting());
+    return createHashAggregate(logicalDistinct.getKeys(), logicalDistinct.getPayloads(),
+        std::move(emptyAggFunctions), std::move(emptyAggInputInfos),
+        std::move(emptyAggregatesOutputPos), inSchema, outSchema, std::move(prevOperator),
+        logicalDistinct.getExpressionsForPrinting());
 }
 
 } // namespace processor

--- a/src/processor/map/map_expressions_scan.cpp
+++ b/src/processor/map/map_expressions_scan.cpp
@@ -14,7 +14,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExpressionsScan(
     auto expressionsScan = (planner::LogicalExpressionsScan*)logicalOperator;
     auto outerAccumulate = (planner::LogicalAccumulate*)expressionsScan->getOuterAccumulate();
     expression_map<ft_col_idx_t> materializedExpressionToColIdx;
-    auto materializedExpressions = outerAccumulate->getExpressionsToAccumulate();
+    auto materializedExpressions = outerAccumulate->getPayloads();
     for (auto i = 0u; i < materializedExpressions.size(); ++i) {
         materializedExpressionToColIdx.insert({materializedExpressions[i], i});
     }

--- a/src/processor/map/map_mark_accumulate.cpp
+++ b/src/processor/map/map_mark_accumulate.cpp
@@ -1,0 +1,26 @@
+#include "planner/operator/logical_mark_accmulate.h"
+#include "processor/operator/aggregate/aggregate_input.h"
+#include "processor/plan_mapper.h"
+
+using namespace kuzu::planner;
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace processor {
+
+std::unique_ptr<PhysicalOperator> PlanMapper::mapMarkAccumulate(LogicalOperator* op) {
+    auto logicalMarkAccumulate = ku_dynamic_cast<LogicalOperator*, LogicalMarkAccumulate*>(op);
+    auto keys = logicalMarkAccumulate->getKeys();
+    auto payloads = logicalMarkAccumulate->getPayloads();
+    auto outSchema = logicalMarkAccumulate->getSchema();
+    auto inSchema = logicalMarkAccumulate->getChild(0)->getSchema();
+    auto prevOperator = mapOperator(logicalMarkAccumulate->getChild(0).get());
+    return createHashAggregate(keys, payloads,
+        std::vector<std::unique_ptr<function::AggregateFunction>>{},
+        std::vector<std::unique_ptr<AggregateInputInfo>>{}, std::vector<DataPos>{}, inSchema,
+        outSchema, std::move(prevOperator), logicalMarkAccumulate->getExpressionsForPrinting(),
+        logicalMarkAccumulate->getMark());
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -108,6 +108,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOperator(LogicalOperator* logic
     case LogicalOperatorType::ACCUMULATE: {
         physicalOperator = mapAccumulate(logicalOperator);
     } break;
+    case LogicalOperatorType::MARK_ACCUMULATE: {
+        physicalOperator = mapMarkAccumulate(logicalOperator);
+    } break;
     case LogicalOperatorType::DUMMY_SCAN: {
         physicalOperator = mapDummyScan(logicalOperator);
     } break;

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/aggregate/hash_aggregate.h"
 
 #include "common/utils.h"
+#include "processor/result/merge_hash_table.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function;
@@ -49,38 +50,70 @@ std::pair<uint64_t, uint64_t> HashAggregateSharedState::getNextRangeToRead() {
     return std::make_pair(startOffset, startOffset + range);
 }
 
-void HashAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    BaseAggregate::initLocalStateInternal(resultSet, context);
+HashAggregateInfo::HashAggregateInfo(std::vector<DataPos> flatKeysPos,
+    std::vector<DataPos> unFlatKeysPos, std::vector<DataPos> dependentKeysPos,
+    std::unique_ptr<FactorizedTableSchema> tableSchema, HashTableType hashTableType)
+    : flatKeysPos{std::move(flatKeysPos)}, unFlatKeysPos{std::move(unFlatKeysPos)},
+      dependentKeysPos{std::move(dependentKeysPos)}, tableSchema{std::move(tableSchema)},
+      hashTableType{hashTableType} {}
+
+HashAggregateInfo::HashAggregateInfo(const HashAggregateInfo& other)
+    : flatKeysPos{other.flatKeysPos}, unFlatKeysPos{other.unFlatKeysPos},
+      dependentKeysPos{other.dependentKeysPos}, tableSchema{other.tableSchema->copy()},
+      hashTableType{other.hashTableType} {}
+
+void HashAggregateLocalState::init(ResultSet& resultSet, main::ClientContext* context,
+    HashAggregateInfo& info,
+    std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions) {
     std::vector<LogicalType> keyDataTypes;
-    for (auto& pos : flatKeysPos) {
-        auto vector = resultSet->getValueVector(pos).get();
+    for (auto& pos : info.flatKeysPos) {
+        auto vector = resultSet.getValueVector(pos).get();
         flatKeyVectors.push_back(vector);
         keyDataTypes.push_back(vector->dataType);
     }
-    for (auto& pos : unFlatKeysPos) {
-        auto vector = resultSet->getValueVector(pos).get();
+    for (auto& pos : info.unFlatKeysPos) {
+        auto vector = resultSet.getValueVector(pos).get();
         unFlatKeyVectors.push_back(vector);
         keyDataTypes.push_back(vector->dataType);
     }
     std::vector<LogicalType> payloadDataTypes;
-    for (auto& pos : dependentKeysPos) {
-        auto vector = resultSet->getValueVector(pos).get();
+    for (auto& pos : info.dependentKeysPos) {
+        auto vector = resultSet.getValueVector(pos).get();
         dependentKeyVectors.push_back(vector);
         payloadDataTypes.push_back(vector->dataType);
     }
     leadingState = unFlatKeyVectors.empty() ? flatKeyVectors[0]->state.get() :
                                               unFlatKeyVectors[0]->state.get();
-    localAggregateHashTable =
-        make_unique<AggregateHashTable>(*context->clientContext->getMemoryManager(), keyDataTypes,
-            payloadDataTypes, aggregateFunctions, 0);
+    switch (info.hashTableType) {
+    case HashTableType::AGGREGATE_HASH_TABLE:
+        aggregateHashTable = std::make_unique<AggregateHashTable>(*context->getMemoryManager(),
+            keyDataTypes, payloadDataTypes, aggregateFunctions, 0, std::move(info.tableSchema));
+        break;
+    case HashTableType::MERGE_HASH_TABLE:
+        aggregateHashTable = std::make_unique<MergeHashTable>(*context->getMemoryManager(),
+            keyDataTypes, payloadDataTypes, aggregateFunctions, 0, std::move(info.tableSchema));
+        break;
+    default:
+        KU_UNREACHABLE;
+    }
+}
+
+void HashAggregateLocalState::append(
+    std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs, uint64_t multiplicity) {
+    aggregateHashTable->append(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors, leadingState,
+        aggregateInputs, multiplicity);
+}
+
+void HashAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+    BaseAggregate::initLocalStateInternal(resultSet, context);
+    localState.init(*resultSet, context->clientContext, aggregateInfo, aggregateFunctions);
 }
 
 void HashAggregate::executeInternal(ExecutionContext* context) {
     while (children[0]->getNextTuple(context)) {
-        localAggregateHashTable->append(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors,
-            leadingState, aggregateInputs, resultSet->multiplicity);
+        localState.append(aggregateInputs, resultSet->multiplicity);
     }
-    sharedState->appendAggregateHashTable(std::move(localAggregateHashTable));
+    sharedState->appendAggregateHashTable(std::move(localState.aggregateHashTable));
 }
 
 void HashAggregate::finalize(ExecutionContext* context) {

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -99,7 +99,7 @@ void HashAggregateLocalState::init(ResultSet& resultSet, main::ClientContext* co
 }
 
 void HashAggregateLocalState::append(
-    std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs, uint64_t multiplicity) {
+    std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs, uint64_t multiplicity) const {
     aggregateHashTable->append(flatKeyVectors, unFlatKeyVectors, dependentKeyVectors, leadingState,
         aggregateInputs, multiplicity);
 }

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -1,7 +1,7 @@
 #include "processor/operator/aggregate/hash_aggregate.h"
 
 #include "common/utils.h"
-#include "processor/result/merge_hash_table.h"
+#include "processor/result/mark_hash_table.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function;
@@ -89,8 +89,8 @@ void HashAggregateLocalState::init(ResultSet& resultSet, main::ClientContext* co
         aggregateHashTable = std::make_unique<AggregateHashTable>(*context->getMemoryManager(),
             keyDataTypes, payloadDataTypes, aggregateFunctions, 0, std::move(info.tableSchema));
         break;
-    case HashTableType::MERGE_HASH_TABLE:
-        aggregateHashTable = std::make_unique<MergeHashTable>(*context->getMemoryManager(),
+    case HashTableType::MARK_HASH_TABLE:
+        aggregateHashTable = std::make_unique<MarkHashTable>(*context->getMemoryManager(),
             keyDataTypes, payloadDataTypes, aggregateFunctions, 0, std::move(info.tableSchema));
         break;
     default:

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -60,6 +60,14 @@ void NodeInsertExecutor::insert(Transaction* tx, ExecutionContext* context) {
     writeResult();
 }
 
+void NodeInsertExecutor::evaluateResult(ExecutionContext* context) {
+    for (auto& evaluator : columnDataEvaluators) {
+        evaluator->evaluate(context->clientContext);
+    }
+    nodeIDVector->setNull(nodeIDVector->state->selVector->selectedPositions[0], false);
+    writeResult();
+}
+
 bool NodeInsertExecutor::checkConfict(Transaction* transaction) {
     if (conflictAction == ConflictAction::ON_CONFLICT_DO_NOTHING) {
         auto off = table->validateUniquenessConstraint(transaction, columnDataVectors);

--- a/src/processor/operator/persistent/merge.cpp
+++ b/src/processor/operator/persistent/merge.cpp
@@ -4,7 +4,10 @@ namespace kuzu {
 namespace processor {
 
 void Merge::initLocalStateInternal(ResultSet* /*resultSet_*/, ExecutionContext* context) {
-    markVector = resultSet->getValueVector(markPos).get();
+    existenceVector = resultSet->getValueVector(existenceMark).get();
+    if (distinctMark.isValid()) {
+        distinctVector = resultSet->getValueVector(distinctMark).get();
+    }
     for (auto& executor : nodeInsertExecutors) {
         executor.init(resultSet, context);
     }
@@ -29,9 +32,9 @@ bool Merge::getNextTuplesInternal(ExecutionContext* context) {
     if (!children[0]->getNextTuple(context)) {
         return false;
     }
-    KU_ASSERT(markVector->state->isFlat());
-    auto pos = markVector->state->selVector->selectedPositions[0];
-    if (!markVector->isNull(pos)) {
+    KU_ASSERT(existenceVector->state->isFlat());
+    auto pos = existenceVector->state->selVector->selectedPositions[0];
+    if (!existenceVector->isNull(pos)) {
         for (auto& executor : onMatchNodeSetExecutors) {
             executor->set(context);
         }

--- a/src/processor/operator/persistent/merge.cpp
+++ b/src/processor/operator/persistent/merge.cpp
@@ -33,13 +33,28 @@ bool Merge::getNextTuplesInternal(ExecutionContext* context) {
         return false;
     }
     KU_ASSERT(existenceVector->state->isFlat());
-    auto pos = existenceVector->state->selVector->selectedPositions[0];
-    if (!existenceVector->isNull(pos)) {
+    auto existencePos = existenceVector->state->selVector->selectedPositions[0];
+    if (!existenceVector->isNull(existencePos)) {
         for (auto& executor : onMatchNodeSetExecutors) {
             executor->set(context);
         }
         for (auto& executor : onMatchRelSetExecutors) {
             executor->set(context);
+        }
+    } else if (distinctVector != nullptr &&
+               !distinctVector->getValue<bool>(
+                   distinctVector->state->selVector->selectedPositions[0])) {
+        for (auto& executor : onMatchNodeSetExecutors) {
+            executor->set(context);
+        }
+        for (auto& executor : onMatchRelSetExecutors) {
+            executor->set(context);
+        }
+        for (auto& executor : nodeInsertExecutors) {
+            executor.writeResult();
+        }
+        for (auto& executor : relInsertExecutors) {
+            executor.writeResult();
         }
     } else {
         for (auto& executor : nodeInsertExecutors) {

--- a/src/processor/result/CMakeLists.txt
+++ b/src/processor/result/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(kuzu_processor_result
         base_hash_table.cpp
         factorized_table.cpp
         flat_tuple.cpp
+        merge_hash_table.cpp
         result_set.cpp
         result_set_descriptor.cpp
         )

--- a/src/processor/result/CMakeLists.txt
+++ b/src/processor/result/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(kuzu_processor_result
         base_hash_table.cpp
         factorized_table.cpp
         flat_tuple.cpp
-        merge_hash_table.cpp
+        mark_hash_table.cpp
         result_set.cpp
         result_set_descriptor.cpp
         )

--- a/src/processor/result/mark_hash_table.cpp
+++ b/src/processor/result/mark_hash_table.cpp
@@ -1,9 +1,9 @@
-#include "processor/result/merge_hash_table.h"
+#include "processor/result/mark_hash_table.h"
 
 namespace kuzu {
 namespace processor {
 
-MergeHashTable::MergeHashTable(storage::MemoryManager& memoryManager,
+MarkHashTable::MarkHashTable(storage::MemoryManager& memoryManager,
     std::vector<common::LogicalType> keyDataTypes,
     std::vector<common::LogicalType> dependentKeyDataTypes,
     const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
@@ -13,7 +13,7 @@ MergeHashTable::MergeHashTable(storage::MemoryManager& memoryManager,
     distinctColIdxInFT = hashColIdxInFT - 1;
 }
 
-uint64_t MergeHashTable::matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+uint64_t MarkHashTable::matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
     const std::vector<common::ValueVector*>& unFlatKeyVectors, uint64_t numMayMatches,
     uint64_t numNoMatches) {
     auto colIdx = 0u;
@@ -32,7 +32,7 @@ uint64_t MergeHashTable::matchFTEntries(const std::vector<common::ValueVector*>&
     return numNoMatches;
 }
 
-void MergeHashTable::initializeFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+void MarkHashTable::initializeFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
     const std::vector<common::ValueVector*>& unFlatKeyVectors,
     const std::vector<common::ValueVector*>& dependentKeyVectors,
     uint64_t numFTEntriesToInitialize) {

--- a/src/processor/result/merge_hash_table.cpp
+++ b/src/processor/result/merge_hash_table.cpp
@@ -1,0 +1,51 @@
+#include "processor/result/merge_hash_table.h"
+
+namespace kuzu {
+namespace processor {
+
+MergeHashTable::MergeHashTable(storage::MemoryManager& memoryManager,
+    std::vector<common::LogicalType> keyDataTypes,
+    std::vector<common::LogicalType> dependentKeyDataTypes,
+    const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
+    uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema)
+    : AggregateHashTable(memoryManager, std::move(keyDataTypes), std::move(dependentKeyDataTypes),
+          std::move(aggregateFunctions), numEntriesToAllocate, std::move(tableSchema)) {
+    distinctColIdxInFT = hashColIdxInFT - 1;
+}
+
+uint64_t MergeHashTable::matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+    const std::vector<common::ValueVector*>& unFlatKeyVectors, uint64_t numMayMatches,
+    uint64_t numNoMatches) {
+    auto colIdx = 0u;
+    for (auto& flatKeyVector : flatKeyVectors) {
+        numMayMatches =
+            matchFlatVecWithFTColumn(flatKeyVector, numMayMatches, numNoMatches, colIdx++);
+    }
+    for (auto& unFlatKeyVector : unFlatKeyVectors) {
+        numMayMatches =
+            matchUnFlatVecWithFTColumn(unFlatKeyVector, numMayMatches, numNoMatches, colIdx++);
+    }
+    for (auto i = 0u; i < numMayMatches; i++) {
+        noMatchIdxes[numNoMatches++] = mayMatchIdxes[i];
+        onMatchSlotIdxes.emplace(mayMatchIdxes[i]);
+    }
+    return numNoMatches;
+}
+
+void MergeHashTable::initializeFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
+    const std::vector<common::ValueVector*>& unFlatKeyVectors,
+    const std::vector<common::ValueVector*>& dependentKeyVectors,
+    uint64_t numFTEntriesToInitialize) {
+    AggregateHashTable::initializeFTEntries(
+        flatKeyVectors, unFlatKeyVectors, dependentKeyVectors, numFTEntriesToInitialize);
+    for (auto i = 0u; i < numFTEntriesToInitialize; i++) {
+        auto entryIdx = entryIdxesToInitialize[i];
+        auto entry = hashSlotsToUpdateAggState[entryIdx]->entry;
+        auto onMatch = !onMatchSlotIdxes.contains(entryIdx);
+        onMatchSlotIdxes.erase(entryIdx);
+        factorizedTable->updateFlatCellNoNull(entry, distinctColIdxInFT, &onMatch /* isOnMatch */);
+    }
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/test/test_files/update_node/merge_tinysnb.test
+++ b/test/test_files/update_node/merge_tinysnb.test
@@ -60,3 +60,23 @@ Runtime exception: Found duplicated primary key value 1, which violates the uniq
 -STATEMENT MATCH (a:person) RETURN COUNT(*);
 ---- 1
 11
+
+-CASE MergeDuplicatedKey
+-STATEMENT CREATE NODE TABLE user (ID int64, primary key(ID))
+---- ok
+-STATEMENT MATCH (a:person) with a.ID % 4 as result, a.age as age MERGE (u:user {ID: result}) RETURN u.ID, age
+---- 8
+0|35
+2|30
+3|45
+1|20
+3|20
+0|25
+1|40
+2|83
+-STATEMENT MATCH (a:user) RETURN a.ID
+---- 4
+0
+1
+2
+3

--- a/test/test_files/update_node/merge_tinysnb.test
+++ b/test/test_files/update_node/merge_tinysnb.test
@@ -80,3 +80,18 @@ Runtime exception: Found duplicated primary key value 1, which violates the uniq
 1
 2
 3
+-STATEMENT MATCH (a:person) with a.ID as id MERGE (u:user {ID: 10}) RETURN u.ID, id
+---- error
+Runtime exception: Constant key in merge clause is not supported yet.
+-STATEMENT CREATE NODE TABLE user1 (ID int64, name string, primary key(ID))
+---- ok
+-STATEMENT MATCH (a:person) with a.ID % 7 as result, a.fName as name MERGE (u:user1 {ID: result}) ON MATCH SET u.name = 'match: ' + name ON CREATE SET u.name = 'create: ' + name RETURN u.ID, u.name
+---- 8
+0|create: Alice
+0|match: Elizabeth
+1|create: Farooq
+2|create: Bob
+2|match: Greg
+3|create: Carol
+3|match: Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+5|create: Dan


### PR DESCRIPTION
Fixes merge duplicate primary key error issue #3103. 
We now use aggregate hash table to indicate the duplicated primary keys. If a key is mark as duplicated, we skip inserting it.