### PR TITLE
change LogicalType.toString for nested types

### DIFF
--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -312,7 +312,7 @@ std::string LogicalType::toString() const {
         auto structType =
             ku_dynamic_cast<ExtraTypeInfo*, ListTypeInfo*>(extraTypeInfo.get())->getChildType();
         auto fieldTypes = StructType::getFieldTypes(structType);
-        return "MAP(" + fieldTypes[0]->toString() + ": " + fieldTypes[1]->toString() + ")";
+        return "MAP(" + fieldTypes[0]->toString() + ", " + fieldTypes[1]->toString() + ")";
     }
     case LogicalTypeID::LIST: {
         auto listTypeInfo = ku_dynamic_cast<ExtraTypeInfo*, ListTypeInfo*>(extraTypeInfo.get());
@@ -329,7 +329,7 @@ std::string LogicalType::toString() const {
         auto numFields = unionTypeInfo->getChildrenTypes().size();
         auto fieldNames = unionTypeInfo->getChildrenNames();
         for (auto i = 1u; i < numFields; i++) {
-            dataTypeStr += fieldNames[i] + ":";
+            dataTypeStr += fieldNames[i] + " ";
             dataTypeStr += unionTypeInfo->getChildType(i)->toString();
             dataTypeStr += (i == numFields - 1 ? ")" : ", ");
         }
@@ -341,11 +341,11 @@ std::string LogicalType::toString() const {
         auto numFields = structTypeInfo->getChildrenTypes().size();
         auto fieldNames = structTypeInfo->getChildrenNames();
         for (auto i = 0u; i < numFields - 1; i++) {
-            dataTypeStr += fieldNames[i] + ":";
+            dataTypeStr += fieldNames[i] + " ";
             dataTypeStr += structTypeInfo->getChildType(i)->toString();
             dataTypeStr += ", ";
         }
-        dataTypeStr += fieldNames[numFields - 1] + ":";
+        dataTypeStr += fieldNames[numFields - 1] + " ";
         dataTypeStr += structTypeInfo->getChildType(numFields - 1)->toString();
         return dataTypeStr + ")";
     }

--- a/test/test_files/csv/errors.test
+++ b/test/test_files/csv/errors.test
@@ -30,7 +30,7 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/too
 
 -STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/union-no-conversion.csv" (HEADER=TRUE) RETURN *
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/union-no-conversion.csv on line 2: Conversion exception: Could not convert to union type UNION(u:UINT8, s:INT8): a.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/union-no-conversion.csv on line 2: Conversion exception: Could not convert to union type UNION(u UINT8, s INT8): a.
 
 # Test that errors in serial mode don't hang the database.
 # File is large so the window for the race is large enough.

--- a/test/test_files/tck/expressions/boolean/Boolean1.test
+++ b/test/test_files/tck/expressions/boolean/Boolean1.test
@@ -205,7 +205,7 @@ Binder exception: Expression LIST_CREATION() has data type STRING[] but expected
 
 -STATEMENT RETURN {x: []} AND true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false AND 123;
 ---- error
@@ -237,7 +237,7 @@ Binder exception: Expression LIST_CREATION() has data type STRING[] but expected
 
 -STATEMENT RETURN false AND {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 AND 'foo';
 ---- error
@@ -257,4 +257,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} AND [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/boolean/Boolean2.test
+++ b/test/test_files/tck/expressions/boolean/Boolean2.test
@@ -203,7 +203,7 @@ Binder exception: Expression LIST_CREATION() has data type STRING[] but expected
 
 -STATEMENT RETURN {x: []} OR true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false OR 123;
 ---- error
@@ -235,7 +235,7 @@ Binder exception: Expression LIST_CREATION() has data type STRING[] but expected
 
 -STATEMENT RETURN false OR {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 OR 'foo';
 ---- error
@@ -255,4 +255,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} OR [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/boolean/Boolean3.test
+++ b/test/test_files/tck/expressions/boolean/Boolean3.test
@@ -202,7 +202,7 @@ Binder exception: Expression LIST_CREATION() has data type STRING[] but expected
 
 -STATEMENT RETURN {x: []} XOR true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false XOR 123;
 ---- error
@@ -234,7 +234,7 @@ Binder exception: Expression LIST_CREATION() has data type STRING[] but expected
 
 -STATEMENT RETURN false XOR {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 XOR 'foo';
 ---- error
@@ -254,4 +254,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} XOR [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x:STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/list/List1.test
+++ b/test/test_files/tck/expressions/list/List1.test
@@ -135,7 +135,7 @@ Binder exception: Cannot match a built-in function for given function LIST_EXTRA
 -STATEMENT WITH [1, 2, 3, 4, 5] AS list, {x: 3} AS idx
            RETURN list[idx];
 ---- error
-Binder exception: Cannot match a built-in function for given function LIST_EXTRACT(INT64[],STRUCT(x:INT64)). Supported inputs are
+Binder exception: Cannot match a built-in function for given function LIST_EXTRACT(INT64[],STRUCT(x INT64)). Supported inputs are
 (LIST,INT64) -> ANY
 (STRING,INT64) -> STRING
 (ARRAY,INT64) -> ANY

--- a/test/test_files/tck/expressions/list/List11.test
+++ b/test/test_files/tck/expressions/list/List11.test
@@ -465,7 +465,7 @@ Binder exception: Cannot match a built-in function for given function RANGE(INT6
 
 -STATEMENT RETURN range({start: 0}, 1, 1);
 ---- error
-Binder exception: Cannot match a built-in function for given function RANGE(STRUCT(start:INT64),INT64,INT64). Supported inputs are
+Binder exception: Cannot match a built-in function for given function RANGE(STRUCT(start INT64),INT64,INT64). Supported inputs are
 (INT64,INT64) -> LIST
 (INT64,INT64,INT64) -> LIST
 (INT32,INT32) -> LIST
@@ -480,7 +480,7 @@ Binder exception: Cannot match a built-in function for given function RANGE(STRU
 
 -STATEMENT RETURN range(0, 1, {step: 1});
 ---- error
-Binder exception: Cannot match a built-in function for given function RANGE(INT64,INT64,STRUCT(step:INT64)). Supported inputs are
+Binder exception: Cannot match a built-in function for given function RANGE(INT64,INT64,STRUCT(step INT64)). Supported inputs are
 (INT64,INT64) -> LIST
 (INT64,INT64,INT64) -> LIST
 (INT32,INT32) -> LIST

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -114,9 +114,9 @@ Can't execute a write query inside a read-only transaction.
 2|meetTime|TIMESTAMP
 3|validInterval|INTERVAL
 4|comments|STRING[]
-5|summary|STRUCT(locations:STRING[], transfer:STRUCT(day:DATE, amount:INT64[]))
-6|notes|UNION(firstmet:DATE, type:INT16, comment:STRING)
-7|someMap|MAP(STRING: STRING)
+5|summary|STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[]))
+6|notes|UNION(firstmet DATE, type INT16, comment STRING)
+7|someMap|MAP(STRING, STRING)
 
 -LOG ReturnNodeName
 -STATEMENT CALL table_info('person') WHERE name <> 'ID' RETURN name
@@ -142,25 +142,25 @@ height
 ---- 21
 2:0|DATE
 2:0|INTERVAL
-2:0|MAP(STRING: STRING)
+2:0|MAP(STRING, STRING)
 2:0|STRING[]
 2:0|TIMESTAMP
-2:0|STRUCT(locations:STRING[], transfer:STRUCT(day:DATE, amount:INT64[]))
-2:0|UNION(firstmet:DATE, type:INT16, comment:STRING)
+2:0|STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[]))
+2:0|UNION(firstmet DATE, type INT16, comment STRING)
 2:1|DATE
 2:1|INTERVAL
-2:1|MAP(STRING: STRING)
+2:1|MAP(STRING, STRING)
 2:1|STRING[]
 2:1|TIMESTAMP
-2:1|STRUCT(locations:STRING[], transfer:STRUCT(day:DATE, amount:INT64[]))
-2:1|UNION(firstmet:DATE, type:INT16, comment:STRING)
+2:1|STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[]))
+2:1|UNION(firstmet DATE, type INT16, comment STRING)
 2:2|DATE
 2:2|INTERVAL
-2:2|MAP(STRING: STRING)
+2:2|MAP(STRING, STRING)
 2:2|STRING[]
 2:2|TIMESTAMP
-2:2|STRUCT(locations:STRING[], transfer:STRUCT(day:DATE, amount:INT64[]))
-2:2|UNION(firstmet:DATE, type:INT16, comment:STRING)
+2:2|STRUCT(locations STRING[], transfer STRUCT(day DATE, amount INT64[]))
+2:2|UNION(firstmet DATE, type INT16, comment STRING)
 
 -CASE CallNodeTableWith300ColumnsInfo
 -DEFINE COLS REPEAT 2400 "col${count} INT64,"

--- a/test/test_files/tinysnb/cast/cast_error.test
+++ b/test/test_files/tinysnb/cast/cast_error.test
@@ -557,19 +557,19 @@ Overflow exception: Value 256 is not within UINT8 range
 
 -STATEMENT RETURN cast("fd", "UNION(uint64, int128, BOOLEAN)");
 ---- error
-Conversion exception: Could not convert to union type UNION(uint64:UINT64, int128:INT128, BOOLEAN:BOOL): fd.
+Conversion exception: Could not convert to union type UNION(uint64 UINT64, int128 INT128, BOOLEAN BOOL): fd.
 -STATEMENT RETURN cast("{a: 432412343242343241432432444444444444443244}", "STRUCT(a INT128)");
 ---- error
 Conversion exception: Cast failed. 432412343242343241432432444444444444443244 is not within INT128 range.
 -STATEMENT RETURN cast("{a}", "STRUCT(a INT128)");
 ---- error
-Conversion exception: Cast failed. {a} is not in STRUCT(a:INT128) range.
+Conversion exception: Cast failed. {a} is not in STRUCT(a INT128) range.
 -STATEMENT RETURN cast("{-12=34}", "MAP(UINT8, UINT16)");
 ---- error
 Conversion exception: Cast failed. Could not convert "-12" to UINT8.
 -STATEMENT RETURN cast("{} fsdf", "MAP(UINT8, UINT16)");
 ---- error
-Conversion exception: Cast failed. {} fsdf is not in MAP(UINT8: UINT16) range.
+Conversion exception: Cast failed. {} fsdf is not in MAP(UINT8, UINT16) range.
 -STATEMENT RETURN cast("[[432343243243254534554654654654234,2,3]]", "INT64[][]");
 ---- error
 Conversion exception: Cast failed. Could not convert "432343243243254534554654654654234" to INT64.
@@ -601,46 +601,46 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/list
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/list/conversion_error.csv on line 1: Conversion exception: Cast failed. Could not convert "432412" to UINT8.
 -STATEMENT LOAD WITH HEADERS (q STRUCT(a STRUCT(b STRING))) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_bracket_error1.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_bracket_error1.csv on line 1: Conversion exception: Cast failed. {a: {b: fsdf is not in STRUCT(a:STRUCT(b:STRING)) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_bracket_error1.csv on line 1: Conversion exception: Cast failed. {a: {b: fsdf is not in STRUCT(a STRUCT(b STRING)) range.
 -STATEMENT LOAD WITH HEADERS (q STRUCT(a STRUCT(b STRING))) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_bracket_error2.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_bracket_error2.csv on line 1: Conversion exception: Cast failed. {a: {b: fds} is not in STRUCT(a:STRUCT(b:STRING)) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_bracket_error2.csv on line 1: Conversion exception: Cast failed. {a: {b: fds} is not in STRUCT(a STRUCT(b STRING)) range.
 -STATEMENT LOAD WITH HEADERS (a STRUCT(c STRING)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_close_error.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_close_error.csv on line 1: Conversion exception: Cast failed. { c : 423 } c: 479, is not in STRUCT(c:STRING) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_close_error.csv on line 1: Conversion exception: Cast failed. { c : 423 } c: 479, is not in STRUCT(c STRING) range.
 -STATEMENT LOAD WITH HEADERS (a STRUCT(c INT32)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/invalid_field_name.csv" RETURN *;
 ---- error
 Parser exception: Invalid struct field name: d
 -STATEMENT LOAD WITH HEADERS (a STRUCT(c INT32)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_no_field_name.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_no_field_name.csv on line 1: Conversion exception: Cast failed. {c 3423} is not in STRUCT(c:INT32) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_no_field_name.csv on line 1: Conversion exception: Cast failed. {c 3423} is not in STRUCT(c INT32) range.
 -STATEMENT LOAD WITH HEADERS (a STRUCT(c INT32)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_quote_error.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_quote_error.csv on line 1: Conversion exception: Cast failed. { c: 'fdsfs } is not in STRUCT(c:INT32) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_quote_error.csv on line 1: Conversion exception: Cast failed. { c: 'fdsfs } is not in STRUCT(c INT32) range.
 -STATEMENT LOAD WITH HEADERS (a STRUCT(c INT32)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_noclose.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_noclose.csv on line 1: Conversion exception: Cast failed. { is not in STRUCT(c:INT32) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_noclose.csv on line 1: Conversion exception: Cast failed. { is not in STRUCT(c INT32) range.
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT8, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_incorrect_type.csv" RETURN *;
 ---- error
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_incorrect_type.csv on line 1: Conversion exception: Cast failed. Could not convert "-3" to UINT8.
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT8, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_val.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_val.csv on line 1: Conversion exception: Cast failed. {4324} is not in MAP(UINT8: UINT8) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_val.csv on line 1: Conversion exception: Cast failed. {4324} is not in MAP(UINT8, UINT8) range.
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT8, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing1.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing1.csv on line 1: Conversion exception: Cast failed. {10=10, 20=20, is not in MAP(UINT8: UINT8) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing1.csv on line 1: Conversion exception: Cast failed. {10=10, 20=20, is not in MAP(UINT8, UINT8) range.
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT8, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing2.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing2.csv on line 1: Conversion exception: Cast failed. { is not in MAP(UINT8: UINT8) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing2.csv on line 1: Conversion exception: Cast failed. { is not in MAP(UINT8, UINT8) range.
  -STATEMENT LOAD WITH HEADERS (a MAP(STRING, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_quote.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_quote.csv on line 1: Conversion exception: Cast failed. {324="} is not in MAP(STRING: UINT8) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_quote.csv on line 1: Conversion exception: Cast failed. {324="} is not in MAP(STRING, UINT8) range.
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT8, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing3.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing3.csv on line 1: Conversion exception: Cast failed. {{3=3} is not in MAP(UINT8: UINT8) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing3.csv on line 1: Conversion exception: Cast failed. {{3=3} is not in MAP(UINT8, UINT8) range.
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT16, UINT16[])) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing4.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing4.csv on line 1: Conversion exception: Cast failed. {432=[432,432} is not in MAP(UINT16: UINT16[]) range.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing4.csv on line 1: Conversion exception: Cast failed. {432=[432,432} is not in MAP(UINT16, UINT16[]) range.
 -STATEMENT LOAD WITH HEADERS (a INT64[4]) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/array/incorrect_num.csv" RETURN *;
 ---- error
 Copy exception: Each array should have fixed number of elements. Expected: 4, Actual: 2.
@@ -658,7 +658,7 @@ Binder exception: The number of elements in an array must be greater than 0. Giv
 Copy exception: Invalid UTF8-encoded string.
 -STATEMENT LOAD WITH HEADERS (a UNION(v1 INT64, v2 INT32)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/union/union_error.csv" RETURN *;
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/union/union_error.csv on line 1: Conversion exception: Could not convert to union type UNION(v1:INT64, v2:INT32): fdsaf.
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/union/union_error.csv on line 1: Conversion exception: Could not convert to union type UNION(v1 INT64, v2 INT32): fdsaf.
 -STATEMENT RETURN cast("[-32769]", "INT16[1]");
 ---- error
 Conversion exception: Cast failed. Could not convert "-32769" to INT16.
@@ -717,13 +717,13 @@ Conversion exception: Unsupported casting function from INT8 to MAP.
 -LOG InvalidStructToStruct
 -STATEMENT RETURN cast(cast("{a: 12, b: 0}", "STRUCT(a STRING, b STRING, c STRING)"), "STRUCT(a INT128, b INT128)");
 ---- error
-Conversion exception: Unsupported casting function from STRUCT(a:STRING, b:STRING, c:STRING) to STRUCT(a:INT128, b:INT128).
+Conversion exception: Unsupported casting function from STRUCT(a STRING, b STRING, c STRING) to STRUCT(a INT128, b INT128).
 -STATEMENT RETURN cast(cast("{a: 12, b: 0}", "STRUCT(a STRING, b STRING)"), "STRUCT(a INT128, b INT128, c STRING)");
 ---- error
-Conversion exception: Unsupported casting function from STRUCT(a:STRING, b:STRING) to STRUCT(a:INT128, b:INT128, c:STRING).
+Conversion exception: Unsupported casting function from STRUCT(a STRING, b STRING) to STRUCT(a INT128, b INT128, c STRING).
 -STATEMENT RETURN cast(cast("{a: 12, b: 0}", "STRUCT(a STRING, b STRING)"), "STRUCT(a INT128, b STRUCT(a STRING, b STRING))");
 ---- error
-Conversion exception: Cast failed. 0 is not in STRUCT(a:STRING, b:STRING) range.
+Conversion exception: Cast failed. 0 is not in STRUCT(a STRING, b STRING) range.
 -STATEMENT RETURN cast(cast("{a: 12, b: 0}", "STRUCT(a STRING, b INT8)"), "STRUCT(a INT128, b STRUCT(a STRING, b STRING))");
 ---- error
 Conversion exception: Unsupported casting function from INT8 to STRUCT.
@@ -732,7 +732,7 @@ Conversion exception: Unsupported casting function from INT8 to STRUCT.
 Conversion exception: Unsupported casting function from STRUCT to INT8.
 -STATEMENT RETURN cast(cast("{a: 12, b: 0}", "STRUCT(a STRING, b STRING)"), "STRUCT(c INT128, b INT128)");
 ---- error
-Conversion exception: Unsupported casting function from STRUCT(a:STRING, b:STRING) to STRUCT(c:INT128, b:INT128).
+Conversion exception: Unsupported casting function from STRUCT(a STRING, b STRING) to STRUCT(c INT128, b INT128).
 -STATEMENT RETURN cast(cast("{a: 12, b: 0}", "STRUCT(a STRING, b STRING)"), "MAP(STRING, STRING)");
 ---- error
 Conversion exception: Unsupported casting function from STRUCT to MAP.

--- a/tools/python_api/test/test_torch_geometric.py
+++ b/tools/python_api/test/test_torch_geometric.py
@@ -294,8 +294,8 @@ def test_to_torch_geometric_heterogeneous_graph(conn_db_readonly: ConnDB) -> Non
         "Property organisation.history of type STRING is not supported by torch_geometric. The property is marked as unconverted.",
         "Property person.usedNames of type STRING is not supported by torch_geometric. The property is marked as unconverted.",
         "Property organisation.licenseValidInterval of type INTERVAL is not supported by torch_geometric. The property is marked as unconverted.",
-        "Property organisation.state of type STRUCT(revenue:INT16, location:STRING is not supported by torch_geometric. The property is marked as unconverted.",
-        "Property organisation.info of type UNION(price:FLOAT, movein:DATE, note:STRING) is not supported by torch_geometric. The property is marked as unconverted.",
+        "Property organisation.state of type STRUCT(revenue INT16, location STRING is not supported by torch_geometric. The property is marked as unconverted.",
+        "Property organisation.info of type UNION(price FLOAT, movein DATE, note STRING) is not supported by torch_geometric. The property is marked as unconverted.",
     }
 
     for w in ws:


### PR DESCRIPTION
The problem:
The result of LogicalType::toString was not compatible with LogicalType::dataTypeIDFromString. For example,
 toString would give `STRUCT(A:INT32)` while dataTypeIDFromString would expect `STRUCT(A INT32)`. This PR changes that, and updates corresponding tests.