### PR TITLE
Fix constant compression in-place check for bools

### DIFF
--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -43,20 +43,12 @@ public:
     void write(common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk,
         ColumnChunk* data, common::offset_t dataOffset, common::length_t numValues) override;
 
-    bool canCommitInPlace(Transaction* transaction, node_group_idx_t nodeGroupIdx,
-        const ChunkCollection& localInsertChunk, const offset_to_row_idx_t& insertInfo,
-        const ChunkCollection& localUpdateChunk, const offset_to_row_idx_t& updateInfo) override;
-    bool canCommitInPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, const std::vector<common::offset_t>& dstOffsets,
-        ColumnChunk* chunk, common::offset_t srcOffset) override;
     void commitLocalChunkInPlace(Transaction* transaction, node_group_idx_t nodeGroupIdx,
         const ChunkCollection& localInsertChunk, const offset_to_row_idx_t& insertInfo,
         const ChunkCollection& localUpdateChunk, const offset_to_row_idx_t& updateInfo,
         const offset_set_t& deleteInfo) override;
 
 private:
-    bool checkUpdateInPlace(const ColumnChunkMetadata& metadata, const ChunkCollection& localChunk,
-        const offset_to_row_idx_t& writeInfo);
     std::unique_ptr<ColumnChunk> getEmptyChunkForCommit(uint64_t capacity) override {
         return ColumnChunkFactory::createNullColumnChunk(enableCompression, capacity);
     }

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -70,8 +70,16 @@ bool CompressionMetadata::canUpdateInPlace(
     switch (compression) {
     case CompressionType::CONSTANT: {
         // Value can be updated in place only if it is identical to the value already stored.
-        auto size = getDataTypeSizeInChunk(physicalType);
-        return memcmp(data + pos * size, this->data.data(), size) == 0;
+        switch (physicalType) {
+        case PhysicalTypeID::BOOL: {
+            return NullMask::isNull(reinterpret_cast<const uint64_t*>(data), pos) ==
+                   *reinterpret_cast<const bool*>(this->data.data());
+        } break;
+        default: {
+            auto size = getDataTypeSizeInChunk(physicalType);
+            return memcmp(data + pos * size, this->data.data(), size) == 0;
+        }
+        }
     }
     case CompressionType::BOOLEAN_BITPACKING:
     case CompressionType::UNCOMPRESSED: {

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -698,7 +698,8 @@ bool Column::checkUpdateInPlace(const ColumnChunkMetadata& metadata,
     for (auto rowIdx : rowIdxesToRead) {
         auto [chunkIdx, offsetInLocalChunk] =
             LocalChunkedGroupCollection::getChunkIdxAndOffsetInChunk(rowIdx);
-        if (localChunks[chunkIdx]->getNullChunk()->isNull(offsetInLocalChunk)) {
+        if (localChunks[chunkIdx]->getNullChunk() != nullptr &&
+            localChunks[chunkIdx]->getNullChunk()->isNull(offsetInLocalChunk)) {
             continue;
         }
         if (!metadata.compMeta.canUpdateInPlace(


### PR DESCRIPTION
Bools are stored packed in column chunks, so indexing into the data using the size in bytes of the type will not work.

This is done as a quick fix, however I think it would be a good idea to move away from passing around raw `uint8_t*` when passing around type-generic data. Instead, I think we should create abstractions for storing and accessing the raw buffers. That would let us more easily distinguish between, for example, a ValueVector buffer and a ColumnChunk buffer (e.g. the former stores 1 bool per byte, and the latter 1 bool per bit), and also make sure we handle these edge cases.