### PR TITLE
Fix optional match merge

### DIFF
--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -79,11 +79,12 @@ std::unique_ptr<BoundUpdatingClause> Binder::bindMergeClause(
     // bindGraphPattern will update scope.
     auto boundGraphPattern = bindGraphPattern(mergeClause.getPatternElementsRef());
     rewriteMatchPattern(boundGraphPattern);
+    auto existenceMark = createVariable("__existence", *LogicalType::BOOL());
+    auto distinctMark = createVariable("__distinct", *LogicalType::BOOL());
     auto createInfos = bindInsertInfos(boundGraphPattern.queryGraphCollection, patternsScope);
-    auto distinctMark = createVariable("__distinctMark", *LogicalType::BOOL());
-    auto boundMergeClause =
-        std::make_unique<BoundMergeClause>(std::move(boundGraphPattern.queryGraphCollection),
-            std::move(boundGraphPattern.where), std::move(createInfos), std::move(distinctMark));
+    auto boundMergeClause = std::make_unique<BoundMergeClause>(std::move(existenceMark),
+        std::move(distinctMark), std::move(boundGraphPattern.queryGraphCollection),
+        std::move(boundGraphPattern.where), std::move(createInfos));
     if (mergeClause.hasOnMatchSetItems()) {
         for (auto& [lhs, rhs] : mergeClause.getOnMatchSetItemsRef()) {
             auto setPropertyInfo = bindSetPropertyInfo(lhs.get(), rhs.get());

--- a/src/include/binder/query/updating_clause/bound_merge_clause.h
+++ b/src/include/binder/query/updating_clause/bound_merge_clause.h
@@ -10,12 +10,16 @@ namespace binder {
 
 class BoundMergeClause : public BoundUpdatingClause {
 public:
-    BoundMergeClause(QueryGraphCollection queryGraphCollection,
-        std::shared_ptr<Expression> predicate, std::vector<BoundInsertInfo> insertInfos,
-        std::shared_ptr<Expression> distinctMark)
-        : BoundUpdatingClause{common::ClauseType::MERGE},
-          queryGraphCollection{std::move(queryGraphCollection)}, predicate{std::move(predicate)},
-          insertInfos{std::move(insertInfos)}, distinctMark{std::move(distinctMark)} {}
+    BoundMergeClause(std::shared_ptr<Expression> existenceMark,
+        std::shared_ptr<Expression> distinctMark, QueryGraphCollection queryGraphCollection,
+        std::shared_ptr<Expression> predicate, std::vector<BoundInsertInfo> insertInfos)
+        : BoundUpdatingClause{common::ClauseType::MERGE}, existenceMark{std::move(existenceMark)},
+          distinctMark{std::move(distinctMark)}, queryGraphCollection{std::move(
+                                                     queryGraphCollection)},
+          predicate{std::move(predicate)}, insertInfos{std::move(insertInfos)} {}
+
+    std::shared_ptr<Expression> getExistenceMark() const { return existenceMark; }
+    std::shared_ptr<Expression> getDistinctMark() const { return distinctMark; }
 
     const QueryGraphCollection* getQueryGraphCollection() const { return &queryGraphCollection; }
     bool hasPredicate() const { return predicate != nullptr; }
@@ -95,8 +99,6 @@ public:
         onCreateSetPropertyInfos.push_back(std::move(setPropertyInfo));
     }
 
-    std::shared_ptr<Expression> getDistinctMark() const { return distinctMark; }
-
 private:
     bool hasInsertInfo(const std::function<bool(const BoundInsertInfo& info)>& check) const;
     std::vector<const BoundInsertInfo*> getInsertInfos(
@@ -113,6 +115,8 @@ private:
         const std::function<bool(const BoundSetPropertyInfo& info)>& check) const;
 
 private:
+    std::shared_ptr<Expression> existenceMark;
+    std::shared_ptr<Expression> distinctMark;
     // Pattern to match.
     QueryGraphCollection queryGraphCollection;
     std::shared_ptr<Expression> predicate;
@@ -122,7 +126,6 @@ private:
     std::vector<BoundSetPropertyInfo> onMatchSetPropertyInfos;
     // Update on create
     std::vector<BoundSetPropertyInfo> onCreateSetPropertyInfos;
-    std::shared_ptr<Expression> distinctMark;
 };
 
 } // namespace binder

--- a/src/include/binder/query/updating_clause/bound_merge_clause.h
+++ b/src/include/binder/query/updating_clause/bound_merge_clause.h
@@ -14,9 +14,9 @@ public:
         std::shared_ptr<Expression> distinctMark, QueryGraphCollection queryGraphCollection,
         std::shared_ptr<Expression> predicate, std::vector<BoundInsertInfo> insertInfos)
         : BoundUpdatingClause{common::ClauseType::MERGE}, existenceMark{std::move(existenceMark)},
-          distinctMark{std::move(distinctMark)}, queryGraphCollection{std::move(
-                                                     queryGraphCollection)},
-          predicate{std::move(predicate)}, insertInfos{std::move(insertInfos)} {}
+          distinctMark{std::move(distinctMark)},
+          queryGraphCollection{std::move(queryGraphCollection)}, predicate{std::move(predicate)},
+          insertInfos{std::move(insertInfos)} {}
 
     std::shared_ptr<Expression> getExistenceMark() const { return existenceMark; }
     std::shared_ptr<Expression> getDistinctMark() const { return distinctMark; }

--- a/src/include/planner/operator/logical_accumulate.h
+++ b/src/include/planner/operator/logical_accumulate.h
@@ -9,10 +9,12 @@ namespace planner {
 class LogicalAccumulate final : public LogicalOperator {
 public:
     LogicalAccumulate(common::AccumulateType accumulateType, binder::expression_vector flatExprs,
-        std::shared_ptr<binder::Expression> offset, std::shared_ptr<LogicalOperator> child)
+        std::shared_ptr<binder::Expression> offset, std::shared_ptr<binder::Expression> mark,
+        std::shared_ptr<LogicalOperator> child)
         : LogicalOperator{LogicalOperatorType::ACCUMULATE, std::move(child)},
           accumulateType{accumulateType}, flatExprs{std::move(flatExprs)},
-          offset{std::move(offset)} {}
+          offset{std::move(offset)}, mark{std::move(mark)} {}
+
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
@@ -26,10 +28,12 @@ public:
         return children[0]->getSchema()->getExpressionsInScope();
     }
     std::shared_ptr<binder::Expression> getOffset() const { return offset; }
+    bool hasMark() const { return mark != nullptr; }
+    std::shared_ptr<binder::Expression> getMark() const { return mark; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalAccumulate>(accumulateType, flatExprs, offset,
-            children[0]->copy());
+        return make_unique<LogicalAccumulate>(
+            accumulateType, flatExprs, offset, mark, children[0]->copy());
     }
 
 private:
@@ -38,6 +42,9 @@ private:
     // Accumulate may be used as a source operator for COPY pipeline. In such case, row offset needs
     // to be provided in order to generate internal ID.
     std::shared_ptr<binder::Expression> offset;
+    // Accumulate may be used for optional match, e.g. OPTIONAL MATCH (a). In such case, we use
+    // mark to determine if at least one pattern is found.
+    std::shared_ptr<binder::Expression> mark;
 };
 
 } // namespace planner

--- a/src/include/planner/operator/logical_accumulate.h
+++ b/src/include/planner/operator/logical_accumulate.h
@@ -15,7 +15,6 @@ public:
           accumulateType{accumulateType}, flatExprs{std::move(flatExprs)},
           offset{std::move(offset)}, mark{std::move(mark)} {}
 
-
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
@@ -32,8 +31,8 @@ public:
     std::shared_ptr<binder::Expression> getMark() const { return mark; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalAccumulate>(
-            accumulateType, flatExprs, offset, mark, children[0]->copy());
+        return make_unique<LogicalAccumulate>(accumulateType, flatExprs, offset, mark,
+            children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/logical_hash_join.h
+++ b/src/include/planner/operator/logical_hash_join.h
@@ -20,20 +20,6 @@ enum class JoinSubPlanSolveOrder : uint8_t {
 // Probe side on left, i.e. children[0]. Build side on right, i.e. children[1].
 class LogicalHashJoin : public LogicalOperator {
 public:
-    // Inner and left join.
-    LogicalHashJoin(std::vector<join_condition_t> joinConditions, common::JoinType joinType,
-        std::shared_ptr<LogicalOperator> probeSideChild,
-        std::shared_ptr<LogicalOperator> buildSideChild)
-        : LogicalHashJoin{std::move(joinConditions), joinType, nullptr, std::move(probeSideChild),
-              std::move(buildSideChild)} {}
-
-    // Mark join.
-    LogicalHashJoin(std::vector<join_condition_t> joinConditions,
-        std::shared_ptr<binder::Expression> mark, std::shared_ptr<LogicalOperator> probeSideChild,
-        std::shared_ptr<LogicalOperator> buildSideChild)
-        : LogicalHashJoin{std::move(joinConditions), common::JoinType::MARK, std::move(mark),
-              std::move(probeSideChild), std::move(buildSideChild)} {}
-
     LogicalHashJoin(std::vector<join_condition_t> joinConditions, common::JoinType joinType,
         std::shared_ptr<binder::Expression> mark, std::shared_ptr<LogicalOperator> probeSideChild,
         std::shared_ptr<LogicalOperator> buildSideChild)
@@ -59,10 +45,8 @@ public:
 
     inline std::vector<join_condition_t> getJoinConditions() const { return joinConditions; }
     inline common::JoinType getJoinType() const { return joinType; }
-    inline std::shared_ptr<binder::Expression> getMark() const {
-        KU_ASSERT(joinType == common::JoinType::MARK && mark);
-        return mark;
-    }
+    bool hasMark() const { return mark != nullptr; }
+    inline std::shared_ptr<binder::Expression> getMark() const { return mark; }
     inline void setSIP(SidewaysInfoPassing sip_) { sip = sip_; }
     inline SidewaysInfoPassing getSIP() const { return sip; }
 
@@ -90,7 +74,7 @@ private:
 private:
     std::vector<join_condition_t> joinConditions;
     common::JoinType joinType;
-    std::shared_ptr<binder::Expression> mark; // when joinType is Mark
+    std::shared_ptr<binder::Expression> mark; // when joinType is Mark or Left
     SidewaysInfoPassing sip;
     JoinSubPlanSolveOrder order; // sip introduce join dependency
 };

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "planner/operator/schema.h"
 #include "common/cast.h"
+#include "planner/operator/schema.h"
 
 namespace kuzu {
 namespace planner {

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "planner/operator/schema.h"
+#include "common/cast.h"
 
 namespace kuzu {
 namespace planner {
@@ -102,6 +103,11 @@ public:
     // TODO: remove this function once planner do not share operator across plans
     virtual std::unique_ptr<LogicalOperator> copy() = 0;
     static logical_op_vector_t copy(const logical_op_vector_t& ops);
+
+    template<class TARGET>
+    TARGET* ptrCast() {
+        return common::ku_dynamic_cast<LogicalOperator*, TARGET*>(this);
+    }
 
 protected:
     void createEmptySchema() { schema = std::make_unique<Schema>(); }

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -113,6 +113,10 @@ private:
     void planOptionalMatch(const binder::QueryGraphCollection& queryGraphCollection,
         const binder::expression_vector& predicates, const binder::expression_vector& corrExprs,
         LogicalPlan& leftPlan);
+    // Write whether optional match succeed or not to mark.
+    void planOptionalMatch(const binder::QueryGraphCollection& queryGraphCollection,
+        const binder::expression_vector& predicates, const binder::expression_vector& corrExprs,
+        std::shared_ptr<binder::Expression> mark, LogicalPlan& leftPlan);
     void planRegularMatch(const binder::QueryGraphCollection& queryGraphCollection,
         const binder::expression_vector& predicates, LogicalPlan& leftPlan);
     void planSubquery(const std::shared_ptr<binder::Expression>& subquery, LogicalPlan& outerPlan);
@@ -231,6 +235,9 @@ private:
     // Append Join operators
     void appendHashJoin(const binder::expression_vector& joinNodeIDs, common::JoinType joinType,
         LogicalPlan& probePlan, LogicalPlan& buildPlan, LogicalPlan& resultPlan);
+    void appendHashJoin(const binder::expression_vector& joinNodeIDs, common::JoinType joinType,
+        std::shared_ptr<binder::Expression> mark, LogicalPlan& probePlan, LogicalPlan& buildPlan,
+        LogicalPlan& resultPlan);
     void appendMarkJoin(const binder::expression_vector& joinNodeIDs,
         const std::shared_ptr<binder::Expression>& mark, LogicalPlan& probePlan,
         LogicalPlan& buildPlan);
@@ -241,16 +248,19 @@ private:
     void appendCrossProduct(common::AccumulateType accumulateType, const LogicalPlan& probePlan,
         const LogicalPlan& buildPlan, LogicalPlan& resultPlan);
 
-    // Append accumulate
-    void appendAccumulate(common::AccumulateType accumulateType, LogicalPlan& plan);
+    /* Append accumulate */
+
+    // Accumulate everything.
+    void appendAccumulate(LogicalPlan& plan);
+    // Accumulate everything. Append
+    void appendOptionalAccumulate(std::shared_ptr<binder::Expression> mark, LogicalPlan& plan);
     // Append accumulate with a set of expressions being flattened first.
-    void appendAccumulate(common::AccumulateType accumulateType,
-        const binder::expression_vector& flatExprs, LogicalPlan& plan);
+    void appendAccumulate(const binder::expression_vector& flatExprs, LogicalPlan& plan);
     // Append accumulate with a set of expressions being flattened first.
     // Additionally, scan table with row offset.
     void appendAccumulate(common::AccumulateType accumulateType,
         const binder::expression_vector& flatExprs, std::shared_ptr<binder::Expression> offset,
-        LogicalPlan& plan);
+        std::shared_ptr<binder::Expression> mark, LogicalPlan& plan);
     void appendMarkAccumulate(const binder::expression_vector& keys,
         std::shared_ptr<binder::Expression> mark, LogicalPlan& plan);
 

--- a/src/include/processor/operator/hash_join/hash_join_probe.h
+++ b/src/include/processor/operator/hash_join/hash_join_probe.h
@@ -104,7 +104,7 @@ private:
     std::vector<common::ValueVector*> vectorsToReadInto;
     std::vector<uint32_t> columnIdxsToReadFrom;
     std::vector<common::ValueVector*> keyVectors;
-    std::shared_ptr<common::ValueVector> markVector;
+    common::ValueVector* markVector;
     std::unique_ptr<ProbeState> probeState;
 
     std::unique_ptr<common::ValueVector> hashVector;

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -9,6 +9,10 @@
 namespace kuzu {
 namespace processor {
 
+class InsertExecutor {
+
+};
+
 class NodeInsertExecutor {
 public:
     NodeInsertExecutor(storage::NodeTable* table,
@@ -28,14 +32,16 @@ public:
 
     void insert(transaction::Transaction* transaction, ExecutionContext* context);
 
-    void evaluateResult(ExecutionContext* context);
-
-    void writeResult();
+    // For MERGE, we might need to skip the insert for duplicate input. But still, we need to write
+    // the output vector for later usage.
+    void skipInsert(ExecutionContext* context);
 
 private:
     NodeInsertExecutor(const NodeInsertExecutor& other);
 
     bool checkConfict(transaction::Transaction* transaction);
+
+    void writeResult();
 
 private:
     // Node table to insert.
@@ -72,10 +78,13 @@ public:
 
     void insert(transaction::Transaction* transaction, ExecutionContext* context);
 
-    void writeResult();
+    // See comment in NodeInsertExecutor.
+    void skipInsert(ExecutionContext* context);
 
 private:
     RelInsertExecutor(const RelInsertExecutor& other);
+
+    void writeResult();
 
 private:
     storage::RelsStoreStats* relsStatistics;

--- a/src/include/processor/operator/persistent/insert_executor.h
+++ b/src/include/processor/operator/persistent/insert_executor.h
@@ -9,9 +9,7 @@
 namespace kuzu {
 namespace processor {
 
-class InsertExecutor {
-
-};
+class InsertExecutor {};
 
 class NodeInsertExecutor {
 public:

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -72,6 +72,9 @@ private:
     std::unique_ptr<ResultCollectorInfo> info;
     std::shared_ptr<ResultCollectorSharedState> sharedState;
     std::vector<common::ValueVector*> payloadVectors;
+    std::vector<common::ValueVector*> payloadAndMarkVectors;
+
+    std::unique_ptr<common::ValueVector> markVector;
     std::unique_ptr<FactorizedTable> localTable;
 };
 

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -261,7 +261,7 @@ std::shared_ptr<planner::LogicalOperator> HashJoinSIPOptimizer::appendPathSemiMa
 std::shared_ptr<planner::LogicalOperator> HashJoinSIPOptimizer::appendAccumulate(
     std::shared_ptr<planner::LogicalOperator> child) {
     auto accumulate = std::make_shared<LogicalAccumulate>(AccumulateType::REGULAR,
-        expression_vector{}, nullptr /* offset */, std::move(child));
+        expression_vector{}, nullptr /* offset */, nullptr /* mark */, std::move(child));
     accumulate->computeFlatSchema();
     return accumulate;
 }

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -86,8 +86,8 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductRepla
     if (joinConditions.empty()) {
         return finishPushDown(op);
     }
-    auto hashJoin = std::make_shared<LogicalHashJoin>(joinConditions, JoinType::INNER,
-        op->getChild(0), op->getChild(1));
+    auto hashJoin = std::make_shared<LogicalHashJoin>(
+        joinConditions, JoinType::INNER, nullptr /* mark */, op->getChild(0), op->getChild(1));
     hashJoin->setSIP(planner::SidewaysInfoPassing::PROHIBIT);
     hashJoin->computeFlatSchema();
     return hashJoin;

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -86,8 +86,8 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductRepla
     if (joinConditions.empty()) {
         return finishPushDown(op);
     }
-    auto hashJoin = std::make_shared<LogicalHashJoin>(
-        joinConditions, JoinType::INNER, nullptr /* mark */, op->getChild(0), op->getChild(1));
+    auto hashJoin = std::make_shared<LogicalHashJoin>(joinConditions, JoinType::INNER,
+        nullptr /* mark */, op->getChild(0), op->getChild(1));
     hashJoin->setSIP(planner::SidewaysInfoPassing::PROHIBIT);
     hashJoin->computeFlatSchema();
     return hashJoin;

--- a/src/planner/operator/logical_accumulate.cpp
+++ b/src/planner/operator/logical_accumulate.cpp
@@ -16,12 +16,20 @@ void LogicalAccumulate::computeFactorizedSchema() {
         KU_ASSERT(schema->getNumGroups() == 1);
         schema->insertToGroupAndScope(offset, 0);
     }
+    if (mark != nullptr) {
+        auto groupPos = schema->createGroup();
+        schema->setGroupAsSingleState(groupPos);
+        schema->insertToGroupAndScope(mark, groupPos);
+    }
 }
 
 void LogicalAccumulate::computeFlatSchema() {
     copyChildSchema(0);
     if (offset != nullptr) {
         schema->insertToGroupAndScope(offset, 0);
+    }
+    if (mark != nullptr) {
+        schema->insertToGroupAndScope(mark, 0);
     }
 }
 

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -65,8 +65,12 @@ void LogicalHashJoin::computeFactorizedSchema() {
                 }
             }
         }
-        SinkOperatorUtil::mergeSchema(*buildSchema, expressionsToMaterializeInNonKeyGroups,
-            *schema);
+        SinkOperatorUtil::mergeSchema(
+            *buildSchema, expressionsToMaterializeInNonKeyGroups, *schema);
+        if (mark != nullptr) {
+            auto groupPos = schema->getGroupPos(*joinConditions[0].first);
+            schema->insertToGroupAndScope(mark, groupPos);
+        }
     } break;
     case JoinType::MARK: {
         std::unordered_set<f_group_pos> probeSideKeyGroupPositions;
@@ -95,6 +99,9 @@ void LogicalHashJoin::computeFlatSchema() {
         for (auto& expression : buildSchema->getExpressionsInScope()) {
             // Join key may repeat for internal ID based joins.
             schema->insertToGroupAndScopeMayRepeat(expression, 0);
+        }
+        if (mark != nullptr) {
+            schema->insertToGroupAndScope(mark, 0);
         }
     } break;
     case JoinType::MARK: {

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -65,8 +65,8 @@ void LogicalHashJoin::computeFactorizedSchema() {
                 }
             }
         }
-        SinkOperatorUtil::mergeSchema(
-            *buildSchema, expressionsToMaterializeInNonKeyGroups, *schema);
+        SinkOperatorUtil::mergeSchema(*buildSchema, expressionsToMaterializeInNonKeyGroups,
+            *schema);
         if (mark != nullptr) {
             auto groupPos = schema->getGroupPos(*joinConditions[0].first);
             schema->insertToGroupAndScope(mark, groupPos);

--- a/src/planner/operator/logical_mark_accumulate.cpp
+++ b/src/planner/operator/logical_mark_accumulate.cpp
@@ -27,13 +27,10 @@ void LogicalMarkAccumulate::computeFlatSchema() {
 }
 
 f_group_pos_set LogicalMarkAccumulate::getGroupsPosToFlatten() const {
-    f_group_pos_set dependentGroupsPos;
     auto childSchema = children[0]->getSchema();
-    for (auto& key : keys) {
-        for (auto groupPos : childSchema->getDependentGroupsPos(key)) {
-            dependentGroupsPos.insert(groupPos);
-        }
-    }
+    f_group_pos_set dependentGroupsPos = childSchema->getGroupsPosInScope();
+    // TODO(Xiyang/Ziyi): we don't need to flatten all. But hash aggregate seems to not allow
+    // flat key with unFlat payload.
     return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
 }
 

--- a/src/planner/plan/append_accumulate.cpp
+++ b/src/planner/plan/append_accumulate.cpp
@@ -7,19 +7,24 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace planner {
 
-void Planner::appendAccumulate(AccumulateType accumulateType, LogicalPlan& plan) {
-    appendAccumulate(accumulateType, expression_vector{}, plan);
+void Planner::appendAccumulate(LogicalPlan& plan) {
+    appendAccumulate(AccumulateType::REGULAR, expression_vector{}, nullptr /* offset */, nullptr /* mark */, plan);
+}
+
+void Planner::appendOptionalAccumulate(
+    std::shared_ptr<Expression> mark, LogicalPlan& plan) {
+    appendAccumulate(AccumulateType::OPTIONAL_, expression_vector{}, nullptr /* offset */, mark, plan);
+}
+
+void Planner::appendAccumulate(const expression_vector& flatExprs, kuzu::planner::LogicalPlan& plan) {
+    appendAccumulate(AccumulateType::REGULAR, flatExprs, nullptr /* offset */, nullptr /* mark */, plan);
 }
 
 void Planner::appendAccumulate(AccumulateType accumulateType, const expression_vector& flatExprs,
+    std::shared_ptr<Expression> offset, std::shared_ptr<Expression> mark,
     LogicalPlan& plan) {
-    appendAccumulate(accumulateType, flatExprs, nullptr, plan);
-}
-
-void Planner::appendAccumulate(AccumulateType accumulateType, const expression_vector& flatExprs,
-    std::shared_ptr<Expression> offset, LogicalPlan& plan) {
-    auto op =
-        make_shared<LogicalAccumulate>(accumulateType, flatExprs, offset, plan.getLastOperator());
+    auto op = make_shared<LogicalAccumulate>(
+        accumulateType, flatExprs, offset, mark, plan.getLastOperator());
     appendFlattens(op->getGroupPositionsToFlatten(), plan);
     op->setChild(0, plan.getLastOperator());
     op->computeFactorizedSchema();

--- a/src/planner/plan/append_accumulate.cpp
+++ b/src/planner/plan/append_accumulate.cpp
@@ -8,23 +8,25 @@ namespace kuzu {
 namespace planner {
 
 void Planner::appendAccumulate(LogicalPlan& plan) {
-    appendAccumulate(AccumulateType::REGULAR, expression_vector{}, nullptr /* offset */, nullptr /* mark */, plan);
+    appendAccumulate(AccumulateType::REGULAR, expression_vector{}, nullptr /* offset */,
+        nullptr /* mark */, plan);
 }
 
-void Planner::appendOptionalAccumulate(
-    std::shared_ptr<Expression> mark, LogicalPlan& plan) {
-    appendAccumulate(AccumulateType::OPTIONAL_, expression_vector{}, nullptr /* offset */, mark, plan);
+void Planner::appendOptionalAccumulate(std::shared_ptr<Expression> mark, LogicalPlan& plan) {
+    appendAccumulate(AccumulateType::OPTIONAL_, expression_vector{}, nullptr /* offset */, mark,
+        plan);
 }
 
-void Planner::appendAccumulate(const expression_vector& flatExprs, kuzu::planner::LogicalPlan& plan) {
-    appendAccumulate(AccumulateType::REGULAR, flatExprs, nullptr /* offset */, nullptr /* mark */, plan);
+void Planner::appendAccumulate(const expression_vector& flatExprs,
+    kuzu::planner::LogicalPlan& plan) {
+    appendAccumulate(AccumulateType::REGULAR, flatExprs, nullptr /* offset */, nullptr /* mark */,
+        plan);
 }
 
 void Planner::appendAccumulate(AccumulateType accumulateType, const expression_vector& flatExprs,
-    std::shared_ptr<Expression> offset, std::shared_ptr<Expression> mark,
-    LogicalPlan& plan) {
-    auto op = make_shared<LogicalAccumulate>(
-        accumulateType, flatExprs, offset, mark, plan.getLastOperator());
+    std::shared_ptr<Expression> offset, std::shared_ptr<Expression> mark, LogicalPlan& plan) {
+    auto op = make_shared<LogicalAccumulate>(accumulateType, flatExprs, offset, mark,
+        plan.getLastOperator());
     appendFlattens(op->getGroupPositionsToFlatten(), plan);
     op->setChild(0, plan.getLastOperator());
     op->computeFactorizedSchema();

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -154,7 +154,7 @@ void Planner::appendRecursiveExtend(const std::shared_ptr<NodeExpression>& bound
     const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, LogicalPlan& plan) {
     auto recursiveInfo = rel->getRecursiveInfo();
-    appendAccumulate(AccumulateType::REGULAR, plan);
+    appendAccumulate(plan);
     // Create recursive plan
     auto recursivePlan = std::make_unique<LogicalPlan>();
     createRecursivePlan(*recursiveInfo, direction, *recursivePlan);

--- a/src/planner/plan/append_join.cpp
+++ b/src/planner/plan/append_join.cpp
@@ -4,18 +4,25 @@
 #include "planner/planner.h"
 
 using namespace kuzu::common;
+using namespace kuzu::binder;
 
 namespace kuzu {
 namespace planner {
 
-void Planner::appendHashJoin(const binder::expression_vector& joinNodeIDs, JoinType joinType,
+void Planner::appendHashJoin(const expression_vector& joinNodeIDs, JoinType joinType,
     LogicalPlan& probePlan, LogicalPlan& buildPlan, LogicalPlan& resultPlan) {
+    appendHashJoin(joinNodeIDs, joinType, nullptr /* mark */, probePlan, buildPlan, resultPlan);
+}
+
+void Planner::appendHashJoin(const expression_vector& joinNodeIDs, JoinType joinType,
+    std::shared_ptr<Expression> mark, LogicalPlan& probePlan, LogicalPlan& buildPlan,
+    LogicalPlan& resultPlan) {
     std::vector<join_condition_t> joinConditions;
     for (auto& joinNodeID : joinNodeIDs) {
         joinConditions.emplace_back(joinNodeID, joinNodeID);
     }
-    auto hashJoin = make_shared<LogicalHashJoin>(joinConditions, joinType,
-        probePlan.getLastOperator(), buildPlan.getLastOperator());
+    auto hashJoin = make_shared<LogicalHashJoin>(
+        joinConditions, joinType, mark, probePlan.getLastOperator(), buildPlan.getLastOperator());
     // Apply flattening to probe side
     auto groupsPosToFlattenOnProbeSide = hashJoin->getGroupsPosToFlattenOnProbeSide();
     appendFlattens(groupsPosToFlattenOnProbeSide, probePlan);
@@ -39,15 +46,14 @@ void Planner::appendHashJoin(const binder::expression_vector& joinNodeIDs, JoinT
     resultPlan.setLastOperator(std::move(hashJoin));
 }
 
-void Planner::appendMarkJoin(const binder::expression_vector& joinNodeIDs,
-    const std::shared_ptr<binder::Expression>& mark, LogicalPlan& probePlan,
-    LogicalPlan& buildPlan) {
+void Planner::appendMarkJoin(const expression_vector& joinNodeIDs,
+    const std::shared_ptr<Expression>& mark, LogicalPlan& probePlan, LogicalPlan& buildPlan) {
     std::vector<join_condition_t> joinConditions;
     for (auto& joinNodeID : joinNodeIDs) {
         joinConditions.emplace_back(joinNodeID, joinNodeID);
     }
-    auto hashJoin = make_shared<LogicalHashJoin>(joinConditions, mark, probePlan.getLastOperator(),
-        buildPlan.getLastOperator());
+    auto hashJoin = make_shared<LogicalHashJoin>(joinConditions, JoinType::MARK, mark,
+        probePlan.getLastOperator(), buildPlan.getLastOperator());
     // Apply flattening to probe side
     appendFlattens(hashJoin->getGroupsPosToFlattenOnProbeSide(), probePlan);
     hashJoin->setChild(0, probePlan.getLastOperator());
@@ -60,12 +66,12 @@ void Planner::appendMarkJoin(const binder::expression_vector& joinNodeIDs,
     probePlan.setLastOperator(std::move(hashJoin));
 }
 
-void Planner::appendIntersect(const std::shared_ptr<binder::Expression>& intersectNodeID,
-    binder::expression_vector& boundNodeIDs, LogicalPlan& probePlan,
+void Planner::appendIntersect(const std::shared_ptr<Expression>& intersectNodeID,
+    expression_vector& boundNodeIDs, LogicalPlan& probePlan,
     std::vector<std::unique_ptr<LogicalPlan>>& buildPlans) {
     KU_ASSERT(boundNodeIDs.size() == buildPlans.size());
     std::vector<std::shared_ptr<LogicalOperator>> buildChildren;
-    binder::expression_vector keyNodeIDs;
+    expression_vector keyNodeIDs;
     for (auto i = 0u; i < buildPlans.size(); ++i) {
         keyNodeIDs.push_back(boundNodeIDs[i]);
         buildChildren.push_back(buildPlans[i]->getLastOperator());

--- a/src/planner/plan/append_join.cpp
+++ b/src/planner/plan/append_join.cpp
@@ -21,8 +21,8 @@ void Planner::appendHashJoin(const expression_vector& joinNodeIDs, JoinType join
     for (auto& joinNodeID : joinNodeIDs) {
         joinConditions.emplace_back(joinNodeID, joinNodeID);
     }
-    auto hashJoin = make_shared<LogicalHashJoin>(
-        joinConditions, joinType, mark, probePlan.getLastOperator(), buildPlan.getLastOperator());
+    auto hashJoin = make_shared<LogicalHashJoin>(joinConditions, joinType, mark,
+        probePlan.getLastOperator(), buildPlan.getLastOperator());
     // Apply flattening to probe side
     auto groupsPosToFlattenOnProbeSide = hashJoin->getGroupsPosToFlattenOnProbeSide();
     appendFlattens(groupsPosToFlattenOnProbeSide, probePlan);

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -95,7 +95,7 @@ std::unique_ptr<LogicalPlan> Planner::planCopyNodeFrom(const BoundCopyFromInfo* 
             ku_dynamic_cast<BoundBaseScanSource*, BoundQueryScanSource*>(info->source.get());
         plan = getBestPlan(planQuery(*querySource->statement));
         appendAccumulate(AccumulateType::REGULAR, plan->getSchema()->getExpressionsInScope(),
-            info->offset, *plan);
+            info->offset, nullptr /* mark */, *plan);
     } break;
     default:
         KU_UNREACHABLE;
@@ -130,7 +130,7 @@ std::unique_ptr<LogicalPlan> Planner::planCopyRelFrom(const BoundCopyFromInfo* i
             ku_dynamic_cast<BoundBaseScanSource*, BoundQueryScanSource*>(info->source.get());
         plan = getBestPlan(planQuery(*querySource->statement));
         appendAccumulate(AccumulateType::REGULAR, plan->getSchema()->getExpressionsInScope(),
-            info->offset, *plan);
+            info->offset, nullptr /* mark */, *plan);
     } break;
     default:
         KU_UNREACHABLE;

--- a/src/planner/plan/plan_update.cpp
+++ b/src/planner/plan/plan_update.cpp
@@ -76,8 +76,8 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
         appendMarkAccumulate(corrExprs, distinctMark, plan);
     }
     auto existenceMark = mergeClause->getExistenceMark();
-    planOptionalMatch(
-        *mergeClause->getQueryGraphCollection(), predicates, corrExprs, existenceMark, plan);
+    planOptionalMatch(*mergeClause->getQueryGraphCollection(), predicates, corrExprs, existenceMark,
+        plan);
     std::vector<LogicalInsertInfo> logicalInsertNodeInfos;
     if (mergeClause->hasInsertNodeInfo()) {
         auto boundInsertNodeInfos = mergeClause->getInsertNodeInfos();

--- a/src/planner/plan/plan_update.cpp
+++ b/src/planner/plan/plan_update.cpp
@@ -2,7 +2,6 @@
 #include "binder/query/updating_clause/bound_insert_clause.h"
 #include "binder/query/updating_clause/bound_merge_clause.h"
 #include "binder/query/updating_clause/bound_set_clause.h"
-#include "common/enums/join_type.h"
 #include "planner/operator/persistent/logical_merge.h"
 #include "planner/planner.h"
 
@@ -48,7 +47,7 @@ void Planner::planInsertClause(const BoundUpdatingClause* updatingClause, Logica
     if (plan.isEmpty()) { // E.g. CREATE (a:Person {age:20})
         appendDummyScan(plan);
     } else {
-        appendAccumulate(AccumulateType::REGULAR, plan);
+        appendAccumulate(plan);
     }
     if (insertClause->hasNodeInfo()) {
         appendInsertNode(insertClause->getNodeInfos(), plan);
@@ -72,11 +71,13 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
         corrExprs = getCorrelatedExprs(*mergeClause->getQueryGraphCollection(), predicates,
             plan.getSchema());
         if (corrExprs.size() == 0) {
-            throw RuntimeException{"Constant key in merge clause is not supported yet."};
+            throw RuntimeException{"Empty key in merge clause is not supported yet."};
         }
         appendMarkAccumulate(corrExprs, distinctMark, plan);
     }
-    planOptionalMatch(*mergeClause->getQueryGraphCollection(), predicates, corrExprs, plan);
+    auto existenceMark = mergeClause->getExistenceMark();
+    planOptionalMatch(
+        *mergeClause->getQueryGraphCollection(), predicates, corrExprs, existenceMark, plan);
     std::vector<LogicalInsertInfo> logicalInsertNodeInfos;
     if (mergeClause->hasInsertNodeInfo()) {
         auto boundInsertNodeInfos = mergeClause->getInsertNodeInfos();
@@ -114,22 +115,6 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
             logicalOnMatchSetRelInfos.push_back(createLogicalSetPropertyInfo(info));
         }
     }
-    std::shared_ptr<Expression> existenceMark;
-    auto& createInfos = mergeClause->getInsertInfosRef();
-    KU_ASSERT(!createInfos.empty());
-    auto& createInfo = createInfos[0];
-    switch (createInfo.tableType) {
-    case TableType::NODE: {
-        auto node = (NodeExpression*)createInfo.pattern.get();
-        existenceMark = node->getInternalID();
-    } break;
-    case TableType::REL: {
-        auto rel = (RelExpression*)createInfo.pattern.get();
-        existenceMark = rel->getInternalIDProperty();
-    } break;
-    default:
-        KU_UNREACHABLE;
-    }
     auto merge = std::make_shared<LogicalMerge>(existenceMark, distinctMark,
         std::move(logicalInsertNodeInfos), std::move(logicalInsertRelInfos),
         std::move(logicalOnCreateSetNodeInfos), std::move(logicalOnCreateSetRelInfos),
@@ -142,7 +127,7 @@ void Planner::planMergeClause(const BoundUpdatingClause* updatingClause, Logical
 }
 
 void Planner::planSetClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
-    appendAccumulate(AccumulateType::REGULAR, plan);
+    appendAccumulate(plan);
     auto setClause =
         ku_dynamic_cast<const BoundUpdatingClause*, const BoundSetClause*>(updatingClause);
     if (setClause->hasNodeInfo()) {
@@ -154,7 +139,7 @@ void Planner::planSetClause(const BoundUpdatingClause* updatingClause, LogicalPl
 }
 
 void Planner::planDeleteClause(const BoundUpdatingClause* updatingClause, LogicalPlan& plan) {
-    appendAccumulate(AccumulateType::REGULAR, plan);
+    appendAccumulate(plan);
     auto deleteClause =
         ku_dynamic_cast<const BoundUpdatingClause*, const BoundDeleteClause*>(updatingClause);
     if (deleteClause->hasRelInfo()) {

--- a/src/processor/map/create_result_collector.cpp
+++ b/src/processor/map/create_result_collector.cpp
@@ -26,6 +26,11 @@ std::unique_ptr<ResultCollector> PlanMapper::createResultCollector(AccumulateTyp
         tableSchema->appendColumn(std::move(columnSchema));
         payloadsPos.push_back(dataPos);
     }
+    if (accumulateType == AccumulateType::OPTIONAL_) {
+        auto columnSchema = std::make_unique<ColumnSchema>(false /* isUnFlat */,
+            INVALID_DATA_CHUNK_POS, LogicalTypeUtils::getRowLayoutSize(*LogicalType::BOOL()));
+        tableSchema->appendColumn(std::move(columnSchema));
+    }
     auto table =
         std::make_shared<FactorizedTable>(clientContext->getMemoryManager(), tableSchema->copy());
     auto sharedState = std::make_shared<ResultCollectorSharedState>(std::move(table));

--- a/src/processor/map/map_accumulate.cpp
+++ b/src/processor/map/map_accumulate.cpp
@@ -21,8 +21,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAccumulate(LogicalOperator* op)
     if (acc->hasMark()) {
         expressions.push_back(acc->getMark());
     }
-    return createFTableScanAligned(
-        expressions, outSchema, acc->getOffset(), table, maxMorselSize, std::move(resultCollector));
+    return createFTableScanAligned(expressions, outSchema, acc->getOffset(), table, maxMorselSize,
+        std::move(resultCollector));
 }
 
 } // namespace processor

--- a/src/processor/map/map_accumulate.cpp
+++ b/src/processor/map/map_accumulate.cpp
@@ -8,8 +8,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-std::unique_ptr<PhysicalOperator> PlanMapper::mapAccumulate(LogicalOperator* logicalOperator) {
-    auto acc = (LogicalAccumulate*)logicalOperator;
+std::unique_ptr<PhysicalOperator> PlanMapper::mapAccumulate(LogicalOperator* op) {
+    auto acc = op->ptrCast<LogicalAccumulate>();
     auto outSchema = acc->getSchema();
     auto inSchema = acc->getChild(0)->getSchema();
     auto prevOperator = mapOperator(acc->getChild(0).get());
@@ -18,8 +18,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapAccumulate(LogicalOperator* log
         std::move(prevOperator));
     auto table = resultCollector->getResultFactorizedTable();
     auto maxMorselSize = table->hasUnflatCol() ? 1 : DEFAULT_VECTOR_CAPACITY;
-    return createFTableScanAligned(expressions, outSchema, acc->getOffset(), table, maxMorselSize,
-        std::move(resultCollector));
+    if (acc->hasMark()) {
+        expressions.push_back(acc->getMark());
+    }
+    return createFTableScanAligned(
+        expressions, outSchema, acc->getOffset(), table, maxMorselSize, std::move(resultCollector));
 }
 
 } // namespace processor

--- a/src/processor/map/map_hash_join.cpp
+++ b/src/processor/map/map_hash_join.cpp
@@ -99,11 +99,14 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapHashJoin(LogicalOperator* logic
         probePayloadsOutPos.emplace_back(outSchema->getExpressionPos(*payload));
     }
     ProbeDataInfo probeDataInfo(probeKeysDataPos, probePayloadsOutPos);
-    if (hashJoin->getJoinType() == JoinType::MARK) {
+    if (hashJoin->hasMark()) {
         auto mark = hashJoin->getMark();
         auto markOutputPos = DataPos(outSchema->getExpressionPos(*mark));
         probeDataInfo.markDataPos = markOutputPos;
+    } else {
+        probeDataInfo.markDataPos = DataPos::getInvalidPos();
     }
+
     auto hashJoinProbe = make_unique<HashJoinProbe>(sharedState, hashJoin->getJoinType(),
         hashJoin->requireFlatProbeKeys(), probeDataInfo, std::move(probeSidePrevOperator),
         std::move(hashJoinBuild), getOperatorID(), paramsString);

--- a/src/processor/map/map_merge.cpp
+++ b/src/processor/map/map_merge.cpp
@@ -14,8 +14,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapMerge(planner::LogicalOperator*
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     auto existenceMarkPos = getDataPos(*logicalMerge->getExistenceMark(), *inSchema);
     auto distinctMarkPos = DataPos();
-    if (logicalMerge
-            ->hasDistinctMark()) { // If there is no distinct mark, then every input is distinct.
+    if (logicalMerge->hasDistinctMark()) {
         distinctMarkPos = getDataPos(*logicalMerge->getDistinctMark(), *inSchema);
     }
     std::vector<NodeInsertExecutor> nodeInsertExecutors;

--- a/src/processor/operator/persistent/insert_executor.cpp
+++ b/src/processor/operator/persistent/insert_executor.cpp
@@ -60,7 +60,7 @@ void NodeInsertExecutor::insert(Transaction* tx, ExecutionContext* context) {
     writeResult();
 }
 
-void NodeInsertExecutor::evaluateResult(ExecutionContext* context) {
+void NodeInsertExecutor::skipInsert(ExecutionContext* context) {
     for (auto& evaluator : columnDataEvaluators) {
         evaluator->evaluate(context->clientContext);
     }
@@ -154,6 +154,13 @@ void RelInsertExecutor::insert(transaction::Transaction* tx, ExecutionContext* c
     auto insertState = std::make_unique<storage::RelTableInsertState>(*srcNodeIDVector,
         *dstNodeIDVector, columnDataVectors);
     table->insert(tx, *insertState);
+    writeResult();
+}
+
+void RelInsertExecutor::skipInsert(ExecutionContext* context) {
+    for (auto i = 1u; i < columnDataEvaluators.size(); ++i) {
+        columnDataEvaluators[i]->evaluate(context->clientContext);
+    }
     writeResult();
 }
 

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -14,8 +14,8 @@ void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
         payloadAndMarkVectors.push_back(vec);
     }
     if (info->accumulateType == AccumulateType::OPTIONAL_) {
-        markVector = std::make_unique<ValueVector>(
-            *LogicalType::BOOL(), context->clientContext->getMemoryManager());
+        markVector = std::make_unique<ValueVector>(*LogicalType::BOOL(),
+            context->clientContext->getMemoryManager());
         markVector->state = DataChunkState::getSingleValueDataChunkState();
         markVector->setValue<bool>(0, true);
         payloadAndMarkVectors.push_back(markVector.get());

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -9,7 +9,16 @@ namespace processor {
 void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     payloadVectors.reserve(info->payloadPositions.size());
     for (auto& pos : info->payloadPositions) {
-        payloadVectors.push_back(resultSet->getValueVector(pos).get());
+        auto vec = resultSet->getValueVector(pos).get();
+        payloadVectors.push_back(vec);
+        payloadAndMarkVectors.push_back(vec);
+    }
+    if (info->accumulateType == AccumulateType::OPTIONAL_) {
+        markVector = std::make_unique<ValueVector>(
+            *LogicalType::BOOL(), context->clientContext->getMemoryManager());
+        markVector->state = DataChunkState::getSingleValueDataChunkState();
+        markVector->setValue<bool>(0, true);
+        payloadAndMarkVectors.push_back(markVector.get());
     }
     localTable = std::make_unique<FactorizedTable>(context->clientContext->getMemoryManager(),
         info->tableSchema->copy());
@@ -19,7 +28,7 @@ void ResultCollector::executeInternal(ExecutionContext* context) {
     while (children[0]->getNextTuple(context)) {
         if (!payloadVectors.empty()) {
             for (auto i = 0u; i < resultSet->multiplicity; i++) {
-                localTable->append(payloadVectors);
+                localTable->append(payloadAndMarkVectors);
             }
         }
     }
@@ -36,7 +45,7 @@ void ResultCollector::finalize(ExecutionContext* /*context*/) {
         // TODO(Ziyi): add an interface in factorized table
         auto table = sharedState->getTable();
         auto tableSchema = table->getTableSchema();
-        for (auto i = 0u; i < tableSchema->getNumColumns(); ++i) {
+        for (auto i = 0u; i < payloadVectors.size(); ++i) {
             auto columnSchema = tableSchema->getColumn(i);
             if (columnSchema->isFlat()) {
                 payloadVectors[i]->state->setToFlat();
@@ -46,7 +55,8 @@ void ResultCollector::finalize(ExecutionContext* /*context*/) {
             for (auto& vector : payloadVectors) {
                 vector->setAsSingleNullEntry();
             }
-            table->append(payloadVectors);
+            markVector->setValue<bool>(0, false);
+            table->append(payloadAndMarkVectors);
         }
     }
     default:

--- a/src/storage/store/list_column_chunk.cpp
+++ b/src/storage/store/list_column_chunk.cpp
@@ -165,8 +165,8 @@ void ListColumnChunk::lookup(offset_t offsetInChunk, ValueVector& output,
     ListVector::resizeDataVector(&output, currentListDataSize + listSize);
     // TODO(Guodong): Should add `scan` interface and use `scan` here.
     for (auto i = 0u; i < listSize; i++) {
-        listDataColumnChunk->dataColumnChunk->lookup(
-            startOffset + i, *dataVector, currentListDataSize + i);
+        listDataColumnChunk->dataColumnChunk->lookup(startOffset + i, *dataVector,
+            currentListDataSize + i);
     }
     // reset offset
     output.setValue<list_entry_t>(posInOutputVector, list_entry_t{currentListDataSize, listSize});

--- a/test/test_files/update_node/merge_tinysnb.test
+++ b/test/test_files/update_node/merge_tinysnb.test
@@ -82,7 +82,7 @@ Runtime exception: Found duplicated primary key value 1, which violates the uniq
 3
 -STATEMENT MATCH (a:person) with a.ID as id MERGE (u:user {ID: 10}) RETURN u.ID, id
 ---- error
-Runtime exception: Constant key in merge clause is not supported yet.
+Runtime exception: Empty key in merge clause is not supported yet.
 -STATEMENT CREATE NODE TABLE user1 (ID int64, name string, primary key(ID))
 ---- ok
 -STATEMENT MATCH (a:person) with a.ID % 7 as result, a.fName as name MERGE (u:user1 {ID: result}) ON MATCH SET u.name = 'match: ' + name ON CREATE SET u.name = 'create: ' + name RETURN u.ID, u.name
@@ -95,3 +95,19 @@ Runtime exception: Constant key in merge clause is not supported yet.
 3|create: Carol
 3|match: Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
 5|create: Dan
+-STATEMENT MATCH (a:user1) RETURN COUNT(*);
+---- 1
+5
+-STATEMENT CREATE REL TABLE knows2 (FROM person TO person, comment STRING)
+---- ok
+-STATEMENT MATCH (a:person)-[:knows]->(b:person) WHERE a.ID = 0 UNWIND [1,2] AS x MERGE (a)-[e:knows2 {comment: 'h'}]->(b) RETURN e.comment
+---- 6
+h
+h
+h
+h
+h
+h
+-STATEMENT MATCH (a:person)-[:knows2]->(b:person) RETURN COUNT(*);
+---- 1
+3


### PR DESCRIPTION
This is a quite tricky bug.

For `MERGE`, we need to first perform an optional match to check if a pattern exist or not. Since optional match will mark all payload vectors as `NULL`, we were checking pattern existence through its node/relationship internal id.

For example
```
LOAD FROM <file>
MERGE (a: {name: <column0>})
```

We first perform an `OPTIONAL MATCH` on pattern `(a: {name: <column0>})`. Assuming pattern doesn't exist, `a._id` will then be marked as `NULL`. And then merge will check `a._id` to decide whether it should create or not. In this case, we create a new node `a`.

The bug happens as following. Once `a` is created, we need to mark `a._id` to `NOT NULL` because by semantic, a node has been created and thus should be available to later scope. e.g. `... RETURN a`. On the second pull, merge will read this updated null mask for `a._id`.

This PR approaches merge in a similar fashion as `exist subquery`. We write a true/false vector to indicate if optional match has succeed or not instead of trying to read the null mask of a payload vector.

#### TODO
- [ ] Add a test case to reproduce this with tinysnb.

