### PR TITLE
Ensure that pdb is generated in release mode for win debugging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,12 @@ if(MSVC)
 endif()
 if(CMAKE_BUILD_TYPE MATCHES Release)
     if(MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /utf-8")
+        # use /Zi for debug symbols even in release mode for pdb debugging
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /O2 /utf-8 /Zi")
+        # /DEBUG is required for pdb debugging to work and /OPT:REF /OPT:ICF are required to enable COMDAT folding
+        # CMAKE_SHARED_LINKER_FLAGS is used for shared libraries and CMAKE_EXE_LINKER_FLAGS is used for executables
+        set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG /OPT:REF /OPT:ICF")
+        set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /DEBUG /OPT:REF /OPT:ICF")
         string(REGEX REPLACE "/W[3|4]" "/w" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
         add_compile_options(/W0)
     else()


### PR DESCRIPTION
I have read and agree to the terms under [CLA.md](https://github.com/kuzudb/kuzu/blob/master/CLA.md)

Noticed that when kuzu_shared.dll is built in debug mode then somehow client app crashes at randomly at time during new or delete. It is not clear what is going wrong there. This change will at least generate PDB (debugging symbols) for release mode, while keeping the release mode DLL same as before. This will allow better debugging on windows.

- https://www.atmosera.com/blog/correctly-creating-native-c-release-build-pdbs/
- https://discourse.cmake.org/t/use-cmake-to-generate-pdb/2583
- https://stackoverflow.com/questions/28178978/how-to-generate-pdb-files-for-release-build-with-cmake-flags