### PR TITLE
Add distinct aggregate over node and relationships

### DIFF
--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -129,11 +129,6 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
     expression_vector children;
     for (auto i = 0u; i < parsedExpression.getNumChildren(); ++i) {
         auto child = bindExpression(*parsedExpression.getChild(i));
-        auto childTypeID = child->dataType.getLogicalTypeID();
-        if (isDistinct &&
-            (childTypeID == LogicalTypeID::NODE || childTypeID == LogicalTypeID::REL)) {
-            throw BinderException{"DISTINCT is not supported for NODE or REL type."};
-        }
         childrenTypes.push_back(child->dataType);
         children.push_back(std::move(child));
     }

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -14,7 +14,7 @@ ValueVector::ValueVector(LogicalType dataType, storage::MemoryManager* memoryMan
     : dataType{std::move(dataType)} {
     if (this->dataType.getLogicalTypeID() == LogicalTypeID::ANY) {
         // LCOV_EXCL_START
-        // Alternatively we can assign
+        // Alternatively we can assign a default type here but I don't think it's a good practice.
         throw RuntimeException("Trying to a create a vector with ANY type. This should not happen. "
                                "Data type is expected to be resolved during binding.");
         // LCOV_EXCL_STOP

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -6,6 +6,7 @@
 #include <unordered_set>
 
 #include "common/assert.h"
+#include "common/cast.h"
 #include "common/copy_constructors.h"
 #include "common/enums/expression_type.h"
 #include "common/exception/internal.h"
@@ -65,26 +66,33 @@ public:
     common::LogicalType getDataType() const { return dataType; }
     common::LogicalType& getDataTypeReference() { return dataType; }
 
-    inline bool hasAlias() const { return !alias.empty(); }
-    inline std::string getAlias() const { return alias; }
+    bool hasAlias() const { return !alias.empty(); }
+    std::string getAlias() const { return alias; }
 
-    inline uint32_t getNumChildren() const { return children.size(); }
-    inline std::shared_ptr<Expression> getChild(common::vector_idx_t idx) const {
+    uint32_t getNumChildren() const { return children.size(); }
+    std::shared_ptr<Expression> getChild(common::idx_t idx) const {
+        KU_ASSERT(idx < children.size());
         return children[idx];
     }
-    inline expression_vector getChildren() const { return children; }
-    inline void setChild(common::vector_idx_t idx, std::shared_ptr<Expression> child) {
+    expression_vector getChildren() const { return children; }
+    void setChild(common::idx_t idx, std::shared_ptr<Expression> child) {
+        KU_ASSERT(idx < children.size());
         children[idx] = std::move(child);
     }
 
     expression_vector splitOnAND();
 
-    inline bool operator==(const Expression& rhs) const { return uniqueName == rhs.uniqueName; }
+    bool operator==(const Expression& rhs) const { return uniqueName == rhs.uniqueName; }
 
     std::string toString() const { return hasAlias() ? alias : toStringInternal(); }
 
     virtual std::unique_ptr<Expression> copy() const {
         throw common::InternalException("Unimplemented expression copy().");
+    }
+
+    template<class TARGET>
+    const TARGET* constPtrCast() const {
+        return common::ku_dynamic_cast<const Expression*, const TARGET*>(this);
     }
 
 protected:

--- a/src/include/function/aggregate_function.h
+++ b/src/include/function/aggregate_function.h
@@ -10,7 +10,7 @@ namespace kuzu {
 namespace function {
 
 struct AggregateState {
-    virtual inline uint32_t getStateSize() const = 0;
+    virtual uint32_t getStateSize() const = 0;
     virtual void moveResultToVector(common::ValueVector* outputVector, uint64_t pos) = 0;
     virtual ~AggregateState() = default;
 
@@ -52,45 +52,41 @@ struct AggregateFunction final : public BaseScalarFunction {
               std::move(combineFunc), std::move(finalizeFunc), isDistinct, nullptr /* bindFunc */,
               std::move(paramRewriteFunc)} {}
 
-    inline uint32_t getAggregateStateSize() const {
-        return initialNullAggregateState->getStateSize();
-    }
+    uint32_t getAggregateStateSize() const { return initialNullAggregateState->getStateSize(); }
 
     // NOLINTNEXTLINE(readability-make-member-function-const): Returns a non-const pointer.
-    inline AggregateState* getInitialNullAggregateState() {
-        return initialNullAggregateState.get();
-    }
+    AggregateState* getInitialNullAggregateState() { return initialNullAggregateState.get(); }
 
-    inline std::unique_ptr<AggregateState> createInitialNullAggregateState() const {
+    std::unique_ptr<AggregateState> createInitialNullAggregateState() const {
         return initializeFunc();
     }
 
-    inline void updateAllState(uint8_t* state, common::ValueVector* input, uint64_t multiplicity,
+    void updateAllState(uint8_t* state, common::ValueVector* input, uint64_t multiplicity,
         storage::MemoryManager* memoryManager) const {
         return updateAllFunc(state, input, multiplicity, memoryManager);
     }
 
-    inline void updatePosState(uint8_t* state, common::ValueVector* input, uint64_t multiplicity,
+    void updatePosState(uint8_t* state, common::ValueVector* input, uint64_t multiplicity,
         uint32_t pos, storage::MemoryManager* memoryManager) const {
         return updatePosFunc(state, input, multiplicity, pos, memoryManager);
     }
 
-    inline void combineState(uint8_t* state, uint8_t* otherState,
+    void combineState(uint8_t* state, uint8_t* otherState,
         storage::MemoryManager* memoryManager) const {
         return combineFunc(state, otherState, memoryManager);
     }
 
-    inline void finalizeState(uint8_t* state) const { return finalizeFunc(state); }
+    void finalizeState(uint8_t* state) const { return finalizeFunc(state); }
 
-    inline bool isFunctionDistinct() const { return isDistinct; }
+    bool isFunctionDistinct() const { return isDistinct; }
 
-    inline std::unique_ptr<Function> copy() const override {
+    std::unique_ptr<Function> copy() const override {
         return std::make_unique<AggregateFunction>(name, parameterTypeIDs, returnTypeID,
             initializeFunc, updateAllFunc, updatePosFunc, combineFunc, finalizeFunc, isDistinct,
             bindFunc, paramRewriteFunc);
     }
 
-    inline std::unique_ptr<AggregateFunction> clone() const {
+    std::unique_ptr<AggregateFunction> clone() const {
         return std::make_unique<AggregateFunction>(name, parameterTypeIDs, returnTypeID,
             initializeFunc, updateAllFunc, updatePosFunc, combineFunc, finalizeFunc, isDistinct,
             bindFunc, paramRewriteFunc);

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -105,8 +105,8 @@ public:
     static logical_op_vector_t copy(const logical_op_vector_t& ops);
 
     template<class TARGET>
-    TARGET* ptrCast() {
-        return common::ku_dynamic_cast<LogicalOperator*, TARGET*>(this);
+    const TARGET* constPtrCast() const {
+        return common::ku_dynamic_cast<const LogicalOperator*, const TARGET*>(this);
     }
 
 protected:

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -40,19 +40,20 @@ using update_agg_function_t =
 
 class AggregateHashTable : public BaseHashTable {
 public:
-    // Used by distinct aggregate hash table only.
     AggregateHashTable(storage::MemoryManager& memoryManager,
-        const common::logical_type_vec_t& keysDataTypes,
-        const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
-        uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema)
-        : AggregateHashTable(memoryManager, keysDataTypes, std::vector<common::LogicalType>(),
-              aggregateFunctions, numEntriesToAllocate, std::move(tableSchema)) {}
+        const std::vector<common::LogicalType>& keyTypes,
+        const std::vector<common::LogicalType>& payloadTypes, uint64_t numEntriesToAllocate,
+        std::unique_ptr<FactorizedTableSchema> tableSchema)
+        : AggregateHashTable(memoryManager, keyTypes, payloadTypes,
+              std::vector<std::unique_ptr<function::AggregateFunction>>{} /* empty aggregates */,
+              std::vector<common::LogicalType>{} /* empty distinct agg key*/, numEntriesToAllocate,
+              std::move(tableSchema)) {}
 
     AggregateHashTable(storage::MemoryManager& memoryManager,
-        std::vector<common::LogicalType> keysDataTypes,
-        std::vector<common::LogicalType> payloadsDataTypes,
+        std::vector<common::LogicalType> keyTypes, std::vector<common::LogicalType> payloadTypes,
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
-        uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema);
+        const std::vector<common::LogicalType>& distinctAggKeyTypes, uint64_t numEntriesToAllocate,
+        std::unique_ptr<FactorizedTableSchema> tableSchema);
 
     uint8_t* getEntry(uint64_t idx) { return factorizedTable->getTuple(idx); }
 
@@ -62,8 +63,7 @@ public:
 
     void append(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        common::DataChunkState* leadingState,
-        const std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs,
+        common::DataChunkState* leadingState, const std::vector<AggregateInput>& aggregateInputs,
         uint64_t resultSetMultiplicity) {
         append(flatKeyVectors, unFlatKeyVectors, std::vector<common::ValueVector*>(), leadingState,
             aggregateInputs, resultSetMultiplicity);
@@ -73,8 +73,7 @@ public:
     void append(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors,
         const std::vector<common::ValueVector*>& dependentKeyVectors,
-        common::DataChunkState* leadingState,
-        const std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs,
+        common::DataChunkState* leadingState, const std::vector<AggregateInput>& aggregateInputs,
         uint64_t resultSetMultiplicity);
 
     bool isAggregateValueDistinctForGroupByKeys(
@@ -152,8 +151,7 @@ private:
 
     void updateAggStates(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors,
-        const std::vector<std::unique_ptr<AggregateInput>>& aggregateInputs,
-        uint64_t resultSetMultiplicity);
+        const std::vector<AggregateInput>& aggregateInputs, uint64_t resultSetMultiplicity);
 
     // ! This function will only be used by distinct aggregate, which assumes that all keyVectors
     // are flat.
@@ -217,7 +215,7 @@ protected:
     std::unique_ptr<HashSlot*[]> hashSlotsToUpdateAggState;
 
 private:
-    std::vector<common::LogicalType> dependentKeyDataTypes;
+    std::vector<common::LogicalType> payloadTypes;
     std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions;
 
     //! special handling of distinct aggregate
@@ -233,13 +231,11 @@ private:
     std::unique_ptr<uint64_t[]> tmpSlotIdxes;
 };
 
-class AggregateHashTableUtils {
-
-public:
-    static std::vector<std::unique_ptr<AggregateHashTable>> createDistinctHashTables(
+struct AggregateHashTableUtils {
+    static std::unique_ptr<AggregateHashTable> createDistinctHashTable(
         storage::MemoryManager& memoryManager,
-        const std::vector<common::LogicalType>& groupByKeyDataTypes,
-        const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions);
+        const std::vector<common::LogicalType>& groupByKeyTypes,
+        const common::LogicalType& distinctKeyType);
 };
 
 } // namespace processor

--- a/src/include/processor/operator/aggregate/aggregate_input.h
+++ b/src/include/processor/operator/aggregate/aggregate_input.h
@@ -6,23 +6,33 @@
 namespace kuzu {
 namespace processor {
 
-struct AggregateInputInfo {
-    DataPos aggregateVectorPos;
+struct AggregateInfo {
+    DataPos aggVectorPos;
     std::vector<data_chunk_pos_t> multiplicityChunksPos;
+    common::LogicalType distinctAggKeyType;
 
-    AggregateInputInfo(const DataPos& vectorPos,
-        std::vector<data_chunk_pos_t> multiplicityChunksPos)
-        : aggregateVectorPos{vectorPos}, multiplicityChunksPos{std::move(multiplicityChunksPos)} {}
-    AggregateInputInfo(const AggregateInputInfo& other)
-        : AggregateInputInfo(other.aggregateVectorPos, other.multiplicityChunksPos) {}
-    inline std::unique_ptr<AggregateInputInfo> copy() {
-        return std::make_unique<AggregateInputInfo>(*this);
-    }
+    AggregateInfo(const DataPos& aggVectorPos, std::vector<data_chunk_pos_t> multiplicityChunksPos,
+        common::LogicalType distinctAggKeyType)
+        : aggVectorPos{aggVectorPos}, multiplicityChunksPos{std::move(multiplicityChunksPos)},
+          distinctAggKeyType{std::move(distinctAggKeyType)} {}
+    EXPLICIT_COPY_DEFAULT_MOVE(AggregateInfo);
+
+private:
+    AggregateInfo(const AggregateInfo& other)
+        : aggVectorPos{other.aggVectorPos}, multiplicityChunksPos{other.multiplicityChunksPos},
+          distinctAggKeyType{other.distinctAggKeyType} {}
 };
 
 struct AggregateInput {
     common::ValueVector* aggregateVector;
     std::vector<common::DataChunk*> multiplicityChunks;
+
+    AggregateInput() = default;
+    EXPLICIT_COPY_DEFAULT_MOVE(AggregateInput);
+
+private:
+    AggregateInput(const AggregateInput& other)
+        : aggregateVector{other.aggregateVector}, multiplicityChunks{other.multiplicityChunks} {}
 };
 
 } // namespace processor

--- a/src/include/processor/operator/aggregate/base_aggregate.h
+++ b/src/include/processor/operator/aggregate/base_aggregate.h
@@ -26,21 +26,19 @@ class BaseAggregate : public Sink {
 protected:
     BaseAggregate(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
         std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
-        std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
+        std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        const std::string& paramsString)
         : Sink{std::move(resultSetDescriptor), PhysicalOperatorType::AGGREGATE, std::move(child),
               id, paramsString},
-          aggregateFunctions{std::move(aggregateFunctions)},
-          aggregateInputInfos{std::move(aggregateInputInfos)} {}
+          aggregateFunctions{std::move(aggregateFunctions)}, aggInfos{std::move(aggInfos)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
-    inline bool canParallel() const final { return !containDistinctAggregate(); }
+    bool canParallel() const final { return !containDistinctAggregate(); }
 
     void finalize(ExecutionContext* context) override = 0;
 
     std::vector<std::unique_ptr<function::AggregateFunction>> cloneAggFunctions();
-    std::vector<std::unique_ptr<AggregateInputInfo>> cloneAggInputInfos();
     std::unique_ptr<PhysicalOperator> clone() override = 0;
 
 private:
@@ -48,8 +46,8 @@ private:
 
 protected:
     std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions;
-    std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos;
-    std::vector<std::unique_ptr<AggregateInput>> aggregateInputs;
+    std::vector<AggregateInfo> aggInfos;
+    std::vector<AggregateInput> aggInputs;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/aggregate/simple_aggregate.h
+++ b/src/include/processor/operator/aggregate/simple_aggregate.h
@@ -33,10 +33,10 @@ public:
     SimpleAggregate(std::unique_ptr<ResultSetDescriptor> resultSetDescriptor,
         std::shared_ptr<SimpleAggregateSharedState> sharedState,
         std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
-        std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
-        std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
+        std::vector<AggregateInfo> aggInfos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
+        const std::string& paramsString)
         : BaseAggregate{std::move(resultSetDescriptor), std::move(aggregateFunctions),
-              std::move(aggregateInputInfos), std::move(child), id, paramsString},
+              std::move(aggInfos), std::move(child), id, paramsString},
           sharedState{std::move(sharedState)} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
@@ -49,7 +49,7 @@ public:
 
     inline std::unique_ptr<PhysicalOperator> clone() override {
         return make_unique<SimpleAggregate>(resultSetDescriptor->copy(), sharedState,
-            cloneAggFunctions(), cloneAggInputInfos(), children[0]->clone(), id, paramsString);
+            cloneAggFunctions(), copyVector(aggInfos), children[0]->clone(), id, paramsString);
     }
 
 private:

--- a/src/include/processor/result/base_hash_table.h
+++ b/src/include/processor/result/base_hash_table.h
@@ -38,7 +38,7 @@ protected:
     storage::MemoryManager& memoryManager;
     std::unique_ptr<FactorizedTable> factorizedTable;
     std::vector<compare_function_t> compareEntryFuncs;
-    common::logical_type_vec_t keyTypes;
+    std::vector<common::LogicalType> keyTypes;
     // Temporary arrays to hold intermediate results for appending.
     std::shared_ptr<common::DataChunkState> hashState;
     std::unique_ptr<common::ValueVector> hashVector;

--- a/src/include/processor/result/mark_hash_table.h
+++ b/src/include/processor/result/mark_hash_table.h
@@ -6,13 +6,10 @@ namespace kuzu {
 namespace processor {
 
 class MarkHashTable : public AggregateHashTable {
-
 public:
-    MarkHashTable(storage::MemoryManager& memoryManager,
-        std::vector<common::LogicalType> keyDataTypes,
-        std::vector<common::LogicalType> dependentKeyDataTypes,
-        const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
-        uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema);
+    MarkHashTable(storage::MemoryManager& memoryManager, std::vector<common::LogicalType> keyTypes,
+        std::vector<common::LogicalType> payloadTypes, uint64_t numEntriesToAllocate,
+        std::unique_ptr<FactorizedTableSchema> tableSchema);
 
     uint64_t matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors, uint64_t numMayMatches,

--- a/src/optimizer/agg_key_dependency_optimizer.cpp
+++ b/src/optimizer/agg_key_dependency_optimizer.cpp
@@ -26,9 +26,9 @@ void AggKeyDependencyOptimizer::visitOperator(planner::LogicalOperator* op) {
 
 void AggKeyDependencyOptimizer::visitAggregate(planner::LogicalOperator* op) {
     auto agg = (LogicalAggregate*)op;
-    auto [keys, dependentKeys] = resolveKeysAndDependentKeys(agg->getKeyExpressions());
-    agg->setKeyExpressions(keys);
-    agg->setDependentKeyExpressions(dependentKeys);
+    auto [keys, dependentKeys] = resolveKeysAndDependentKeys(agg->getKeys());
+    agg->setKeys(keys);
+    agg->setDependentKeys(dependentKeys);
 }
 
 void AggKeyDependencyOptimizer::visitDistinct(planner::LogicalOperator* op) {

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -22,7 +22,7 @@ void LogicalAggregate::computeFlatSchema() {
 
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
     f_group_pos_set dependentGroupsPos;
-    for (auto& expression : getAllKeyExpressions()) {
+    for (auto& expression : getAllKeys()) {
         for (auto groupPos : children[0]->getSchema()->getDependentGroupsPos(expression)) {
             dependentGroupsPos.insert(groupPos);
         }
@@ -38,7 +38,7 @@ f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
     if (hasDistinctAggregate()) {
         f_group_pos_set dependentGroupsPos;
-        for (auto& expression : aggregateExpressions) {
+        for (auto& expression : aggregates) {
             for (auto groupPos : children[0]->getSchema()->getDependentGroupsPos(expression)) {
                 dependentGroupsPos.insert(groupPos);
             }
@@ -50,14 +50,14 @@ f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
 
 std::string LogicalAggregate::getExpressionsForPrinting() const {
     std::string result = "Group By [";
-    for (auto& expression : keyExpressions) {
+    for (auto& expression : keys) {
         result += expression->toString() + ", ";
     }
-    for (auto& expression : dependentKeyExpressions) {
+    for (auto& expression : dependentKeys) {
         result += expression->toString() + ", ";
     }
     result += "], Aggregate [";
-    for (auto& expression : aggregateExpressions) {
+    for (auto& expression : aggregates) {
         result += expression->toString() + ", ";
     }
     result += "]";
@@ -65,9 +65,9 @@ std::string LogicalAggregate::getExpressionsForPrinting() const {
 }
 
 bool LogicalAggregate::hasDistinctAggregate() {
-    for (auto& expression : aggregateExpressions) {
-        auto& functionExpression = (binder::AggregateFunctionExpression&)*expression;
-        if (functionExpression.isDistinct()) {
+    for (auto& expression : aggregates) {
+        auto funcExpr = expression->constPtrCast<binder::AggregateFunctionExpression>();
+        if (funcExpr->isDistinct()) {
             return true;
         }
     }
@@ -75,13 +75,13 @@ bool LogicalAggregate::hasDistinctAggregate() {
 }
 
 void LogicalAggregate::insertAllExpressionsToGroupAndScope(f_group_pos groupPos) {
-    for (auto& expression : keyExpressions) {
+    for (auto& expression : keys) {
         schema->insertToGroupAndScopeMayRepeat(expression, groupPos);
     }
-    for (auto& expression : dependentKeyExpressions) {
+    for (auto& expression : dependentKeys) {
         schema->insertToGroupAndScopeMayRepeat(expression, groupPos);
     }
-    for (auto& expression : aggregateExpressions) {
+    for (auto& expression : aggregates) {
         schema->insertToGroupAndScopeMayRepeat(expression, groupPos);
     }
 }

--- a/src/processor/map/map_accumulate.cpp
+++ b/src/processor/map/map_accumulate.cpp
@@ -9,7 +9,7 @@ namespace kuzu {
 namespace processor {
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapAccumulate(LogicalOperator* op) {
-    auto acc = op->ptrCast<LogicalAccumulate>();
+    auto acc = op->constPtrCast<LogicalAccumulate>();
     auto outSchema = acc->getSchema();
     auto inSchema = acc->getChild(0)->getSchema();
     auto prevOperator = mapOperator(acc->getChild(0).get());

--- a/src/processor/map/map_aggregate.cpp
+++ b/src/processor/map/map_aggregate.cpp
@@ -14,12 +14,11 @@ using namespace kuzu::planner;
 namespace kuzu {
 namespace processor {
 
-static std::vector<std::unique_ptr<AggregateInputInfo>> getAggregateInputInfos(
-    const expression_vector& groupByExpressions, const expression_vector& aggregateExpressions,
-    const Schema& schema) {
+static std::vector<AggregateInfo> getAggregateInputInfos(const expression_vector& keys,
+    const expression_vector& aggregates, const Schema& schema) {
     // Collect unFlat groups from
     std::unordered_set<f_group_pos> groupByGroupPosSet;
-    for (auto& expression : groupByExpressions) {
+    for (auto& expression : keys) {
         groupByGroupPosSet.insert(schema.getGroupPos(*expression));
     }
     std::unordered_set<f_group_pos> unFlatAggregateGroupPosSet;
@@ -32,9 +31,9 @@ static std::vector<std::unique_ptr<AggregateInputInfo>> getAggregateInputInfos(
         }
         unFlatAggregateGroupPosSet.insert(groupPos);
     }
-    std::vector<std::unique_ptr<AggregateInputInfo>> result;
-    for (auto& expression : aggregateExpressions) {
-        DataPos aggregateVectorPos{};
+    std::vector<AggregateInfo> result;
+    for (auto& expression : aggregates) {
+        auto aggregateVectorPos = DataPos::getInvalidPos();
         if (expression->getNumChildren() != 0) { // COUNT(*) has no children
             auto child = expression->getChild(0);
             aggregateVectorPos = DataPos{schema.getExpressionPos(*child)};
@@ -45,15 +44,18 @@ static std::vector<std::unique_ptr<AggregateInputInfo>> getAggregateInputInfos(
                 multiplicityChunksPos.push_back(groupPos);
             }
         }
-        result.emplace_back(std::make_unique<AggregateInputInfo>(aggregateVectorPos,
-            std::move(multiplicityChunksPos)));
+        auto aggExpr = expression->constPtrCast<AggregateFunctionExpression>();
+        auto distinctAggKeyType =
+            aggExpr->isDistinct() ? expression->getChild(0)->getDataType() : *LogicalType::ANY();
+        result.emplace_back(aggregateVectorPos, std::move(multiplicityChunksPos),
+            std::move(distinctAggKeyType));
     }
     return result;
 }
 
-static binder::expression_vector getKeyExpressions(const binder::expression_vector& expressions,
+static expression_vector getKeyExpressions(const expression_vector& expressions,
     const Schema& schema, bool isFlat) {
-    binder::expression_vector result;
+    expression_vector result;
     for (auto& expression : expressions) {
         if (schema.getGroup(schema.getGroupPos(*expression))->isFlat() == isFlat) {
             result.emplace_back(expression);
@@ -62,100 +64,124 @@ static binder::expression_vector getKeyExpressions(const binder::expression_vect
     return result;
 }
 
-std::unique_ptr<PhysicalOperator> PlanMapper::mapAggregate(LogicalOperator* logicalOperator) {
-    auto& logicalAggregate = (const LogicalAggregate&)*logicalOperator;
-    auto outSchema = logicalAggregate.getSchema();
-    auto inSchema = logicalAggregate.getChild(0)->getSchema();
-    auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
-    auto paramsString = logicalAggregate.getExpressionsForPrinting();
+static std::vector<std::unique_ptr<AggregateFunction>> getAggFunctions(
+    const expression_vector& aggregates) {
     std::vector<std::unique_ptr<AggregateFunction>> aggregateFunctions;
-    for (auto& expression : logicalAggregate.getAggregateExpressions()) {
-        aggregateFunctions.push_back(
-            ((AggregateFunctionExpression&)*expression).aggregateFunction->clone());
+    for (auto& expression : aggregates) {
+        auto aggExpr = expression->constPtrCast<AggregateFunctionExpression>();
+        aggregateFunctions.push_back(aggExpr->aggregateFunction->clone());
     }
-    auto aggregatesOutputPos =
-        getExpressionsDataPos(logicalAggregate.getAggregateExpressions(), *outSchema);
-    auto aggregateInputInfos = getAggregateInputInfos(logicalAggregate.getAllKeyExpressions(),
-        logicalAggregate.getAggregateExpressions(), *inSchema);
-    if (logicalAggregate.hasKeyExpressions()) {
-        return createHashAggregate(logicalAggregate.getKeyExpressions(),
-            logicalAggregate.getDependentKeyExpressions(), std::move(aggregateFunctions),
-            std::move(aggregateInputInfos), std::move(aggregatesOutputPos), inSchema, outSchema,
-            std::move(prevOperator), paramsString, nullptr);
-    } else {
-        auto sharedState = make_shared<SimpleAggregateSharedState>(aggregateFunctions);
-        auto aggregate =
-            make_unique<SimpleAggregate>(std::make_unique<ResultSetDescriptor>(inSchema),
-                sharedState, std::move(aggregateFunctions), std::move(aggregateInputInfos),
-                std::move(prevOperator), getOperatorID(), paramsString);
-        return make_unique<SimpleAggregateScan>(sharedState, aggregatesOutputPos,
-            std::move(aggregate), getOperatorID(), paramsString);
+    return aggregateFunctions;
+}
+
+std::unique_ptr<PhysicalOperator> PlanMapper::mapAggregate(LogicalOperator* logicalOperator) {
+    auto agg = logicalOperator->constPtrCast<LogicalAggregate>();
+    auto aggregates = agg->getAggregates();
+    auto outSchema = agg->getSchema();
+    auto child = agg->getChild(0).get();
+    auto inSchema = child->getSchema();
+    auto prevOperator = mapOperator(child);
+    auto paramsString = agg->getExpressionsForPrinting();
+    if (agg->hasKeys()) {
+        return createHashAggregate(agg->getKeys(), agg->getDependentKeys(), aggregates,
+            nullptr /* mark */, inSchema, outSchema, std::move(prevOperator), paramsString);
     }
+    auto aggFunctions = getAggFunctions(aggregates);
+    auto aggOutputPos = getDataPos(aggregates, *outSchema);
+    auto aggregateInputInfos = getAggregateInputInfos(agg->getAllKeys(), aggregates, *inSchema);
+    auto sharedState = make_shared<SimpleAggregateSharedState>(aggFunctions);
+    auto aggregate = make_unique<SimpleAggregate>(std::make_unique<ResultSetDescriptor>(inSchema),
+        sharedState, std::move(aggFunctions), std::move(aggregateInputInfos),
+        std::move(prevOperator), getOperatorID(), paramsString);
+    return make_unique<SimpleAggregateScan>(sharedState, aggOutputPos, std::move(aggregate),
+        getOperatorID(), paramsString);
 }
 
 static std::unique_ptr<FactorizedTableSchema> getFactorizedTableSchema(
-    const binder::expression_vector& flatKeys, const binder::expression_vector& unflatKeys,
-    const binder::expression_vector& payloads,
+    const expression_vector& flatKeys, const expression_vector& unFlatKeys,
+    const expression_vector& payloads,
     std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
     std::shared_ptr<Expression> markExpression) {
-    auto isUnflat = false;
+    auto isUnFlat = false;
     auto dataChunkPos = 0u;
     std::unique_ptr<FactorizedTableSchema> tableSchema = std::make_unique<FactorizedTableSchema>();
     for (auto& flatKey : flatKeys) {
         auto size = LogicalTypeUtils::getRowLayoutSize(flatKey->dataType);
-        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnflat, dataChunkPos, size));
+        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnFlat, dataChunkPos, size));
     }
-    for (auto& unflatKey : unflatKeys) {
-        auto size = LogicalTypeUtils::getRowLayoutSize(unflatKey->dataType);
-        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnflat, dataChunkPos, size));
+    for (auto& unFlatKey : unFlatKeys) {
+        auto size = LogicalTypeUtils::getRowLayoutSize(unFlatKey->dataType);
+        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnFlat, dataChunkPos, size));
     }
     for (auto& payload : payloads) {
         auto size = LogicalTypeUtils::getRowLayoutSize(payload->dataType);
-        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnflat, dataChunkPos, size));
+        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnFlat, dataChunkPos, size));
     }
     for (auto& aggregateFunc : aggregateFunctions) {
-        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnflat, dataChunkPos,
+        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnFlat, dataChunkPos,
             aggregateFunc->getAggregateStateSize()));
     }
     if (markExpression != nullptr) {
-        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnflat, dataChunkPos,
+        tableSchema->appendColumn(std::make_unique<ColumnSchema>(isUnFlat, dataChunkPos,
             LogicalTypeUtils::getRowLayoutSize(markExpression->dataType)));
     }
     tableSchema->appendColumn(
-        std::make_unique<ColumnSchema>(isUnflat, dataChunkPos, sizeof(hash_t)));
+        std::make_unique<ColumnSchema>(isUnFlat, dataChunkPos, sizeof(hash_t)));
     return tableSchema;
 }
 
-std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(
-    const binder::expression_vector& keys, const binder::expression_vector& payloads,
-    std::vector<std::unique_ptr<function::AggregateFunction>> aggregateFunctions,
-    std::vector<std::unique_ptr<AggregateInputInfo>> aggregateInputInfos,
-    std::vector<DataPos> aggregatesOutputPos, planner::Schema* inSchema, planner::Schema* outSchema,
-    std::unique_ptr<PhysicalOperator> prevOperator, const std::string& paramsString,
-    std::shared_ptr<Expression> markExpression) {
-    auto sharedState = make_shared<HashAggregateSharedState>(aggregateFunctions);
+std::unique_ptr<PhysicalOperator> PlanMapper::createDistinctHashAggregate(
+    const expression_vector& keys, const expression_vector& payloads, Schema* inSchema,
+    Schema* outSchema, std::unique_ptr<PhysicalOperator> prevOperator,
+    const std::string& paramsString) {
+    return createHashAggregate(keys, payloads, expression_vector{} /* aggregates */,
+        nullptr /* mark */, inSchema, outSchema, std::move(prevOperator), paramsString);
+}
+
+std::unique_ptr<PhysicalOperator> PlanMapper::createMarkDistinctHashAggregate(
+    const expression_vector& keys, const expression_vector& payloads,
+    std::shared_ptr<binder::Expression> mark, Schema* inSchema, Schema* outSchema,
+    std::unique_ptr<PhysicalOperator> prevOperator, const std::string& paramsString) {
+    return createHashAggregate(keys, payloads, expression_vector{} /* aggregates */,
+        std::move(mark), inSchema, outSchema, std::move(prevOperator), paramsString);
+}
+
+// Payloads are also group by keys except that they are functional dependent on keys so we don't
+// need to hash or compare payloads.
+std::unique_ptr<PhysicalOperator> PlanMapper::createHashAggregate(const expression_vector& keys,
+    const expression_vector& payloads, const expression_vector& aggregates,
+    std::shared_ptr<binder::Expression> mark, Schema* inSchema, Schema* outSchema,
+    std::unique_ptr<PhysicalOperator> prevOperator, const std::string& paramsString) {
+    // Create hash aggregate
+    auto aggFunctions = getAggFunctions(aggregates);
+    expression_vector allKeys;
+    allKeys.insert(allKeys.end(), keys.begin(), keys.end());
+    allKeys.insert(allKeys.end(), payloads.begin(), payloads.end());
+    auto aggregateInputInfos = getAggregateInputInfos(allKeys, aggregates, *inSchema);
+    auto sharedState = std::make_shared<HashAggregateSharedState>(aggFunctions);
     auto flatKeys = getKeyExpressions(keys, *inSchema, true /* isFlat */);
     auto unFlatKeys = getKeyExpressions(keys, *inSchema, false /* isFlat */);
-    auto tableSchema = getFactorizedTableSchema(flatKeys, unFlatKeys, payloads, aggregateFunctions,
-        markExpression);
-    HashAggregateInfo aggregateInfo{getExpressionsDataPos(flatKeys, *inSchema),
-        getExpressionsDataPos(unFlatKeys, *inSchema), getExpressionsDataPos(payloads, *inSchema),
-        std::move(tableSchema),
-        markExpression == nullptr ? HashTableType::AGGREGATE_HASH_TABLE :
-                                    HashTableType::MARK_HASH_TABLE};
+    auto tableSchema = getFactorizedTableSchema(flatKeys, unFlatKeys, payloads, aggFunctions, mark);
+    auto hashTableType =
+        mark == nullptr ? HashTableType::AGGREGATE_HASH_TABLE : HashTableType::MARK_HASH_TABLE;
+    HashAggregateInfo aggregateInfo{getDataPos(flatKeys, *inSchema),
+        getDataPos(unFlatKeys, *inSchema), getDataPos(payloads, *inSchema), std::move(tableSchema),
+        hashTableType};
     auto aggregate = make_unique<HashAggregate>(std::make_unique<ResultSetDescriptor>(inSchema),
-        sharedState, std::move(aggregateInfo), std::move(aggregateFunctions),
+        sharedState, std::move(aggregateInfo), std::move(aggFunctions),
         std::move(aggregateInputInfos), std::move(prevOperator), getOperatorID(), paramsString);
-    binder::expression_vector outputExpressions;
+    // Create AggScan.
+    expression_vector outputExpressions;
     outputExpressions.insert(outputExpressions.end(), flatKeys.begin(), flatKeys.end());
     outputExpressions.insert(outputExpressions.end(), unFlatKeys.begin(), unFlatKeys.end());
     outputExpressions.insert(outputExpressions.end(), payloads.begin(), payloads.end());
-    if (markExpression != nullptr) {
-        outputExpressions.emplace_back(markExpression);
+    if (mark != nullptr) {
+        outputExpressions.emplace_back(mark);
     }
+    auto aggOutputPos = getDataPos(aggregates, *outSchema);
     return std::make_unique<HashAggregateScan>(sharedState,
-        getExpressionsDataPos(outputExpressions, *outSchema), std::move(aggregatesOutputPos),
-        std::move(aggregate), getOperatorID(), paramsString);
+        getDataPos(outputExpressions, *outSchema), std::move(aggOutputPos), std::move(aggregate),
+        getOperatorID(), paramsString);
 }
 
 } // namespace processor

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -190,11 +190,11 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapOperator(LogicalOperator* logic
     return physicalOperator;
 }
 
-std::vector<DataPos> PlanMapper::getExpressionsDataPos(const binder::expression_vector& expressions,
+std::vector<DataPos> PlanMapper::getDataPos(const binder::expression_vector& expressions,
     const planner::Schema& schema) {
     std::vector<DataPos> result;
     for (auto& expression : expressions) {
-        result.emplace_back(schema.getExpressionPos(*expression));
+        result.emplace_back(getDataPos(*expression, schema));
     }
     return result;
 }

--- a/src/processor/operator/aggregate/base_aggregate.cpp
+++ b/src/processor/operator/aggregate/base_aggregate.cpp
@@ -23,19 +23,18 @@ bool BaseAggregate::containDistinctAggregate() const {
 }
 
 void BaseAggregate::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* /*context*/) {
-    for (auto& inputInfo : aggregateInputInfos) {
-        auto aggregateInput = std::make_unique<AggregateInput>();
-        if (inputInfo->aggregateVectorPos.dataChunkPos == INVALID_DATA_CHUNK_POS) {
-            aggregateInput->aggregateVector = nullptr;
+    for (auto& info : aggInfos) {
+        auto aggregateInput = AggregateInput();
+        if (info.aggVectorPos.dataChunkPos == INVALID_DATA_CHUNK_POS) {
+            aggregateInput.aggregateVector = nullptr;
         } else {
-            aggregateInput->aggregateVector =
-                resultSet->getValueVector(inputInfo->aggregateVectorPos).get();
+            aggregateInput.aggregateVector = resultSet->getValueVector(info.aggVectorPos).get();
         }
-        for (auto dataChunkPos : inputInfo->multiplicityChunksPos) {
-            aggregateInput->multiplicityChunks.push_back(
+        for (auto dataChunkPos : info.multiplicityChunksPos) {
+            aggregateInput.multiplicityChunks.push_back(
                 resultSet->getDataChunk(dataChunkPos).get());
         }
-        aggregateInputs.push_back(std::move(aggregateInput));
+        aggInputs.push_back(std::move(aggregateInput));
     }
 }
 
@@ -44,15 +43,6 @@ std::vector<std::unique_ptr<function::AggregateFunction>> BaseAggregate::cloneAg
     result.reserve(aggregateFunctions.size());
     for (auto& function : aggregateFunctions) {
         result.push_back(function->clone());
-    }
-    return result;
-}
-
-std::vector<std::unique_ptr<AggregateInputInfo>> BaseAggregate::cloneAggInputInfos() {
-    std::vector<std::unique_ptr<AggregateInputInfo>> result;
-    result.reserve(aggregateInputInfos.size());
-    for (auto& info : aggregateInputInfos) {
-        result.push_back(info->copy());
     }
     return result;
 }

--- a/src/processor/result/mark_hash_table.cpp
+++ b/src/processor/result/mark_hash_table.cpp
@@ -4,12 +4,12 @@ namespace kuzu {
 namespace processor {
 
 MarkHashTable::MarkHashTable(storage::MemoryManager& memoryManager,
-    std::vector<common::LogicalType> keyDataTypes,
-    std::vector<common::LogicalType> dependentKeyDataTypes,
-    const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
+    std::vector<common::LogicalType> keyTypes, std::vector<common::LogicalType> payloadTypes,
     uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema)
-    : AggregateHashTable(memoryManager, std::move(keyDataTypes), std::move(dependentKeyDataTypes),
-          std::move(aggregateFunctions), numEntriesToAllocate, std::move(tableSchema)) {
+    : AggregateHashTable(memoryManager, std::move(keyTypes), std::move(payloadTypes),
+          std::vector<std::unique_ptr<function::AggregateFunction>>{} /* empty aggregates */,
+          std::vector<common::LogicalType>{} /* empty distinct agg key*/, numEntriesToAllocate,
+          std::move(tableSchema)) {
     distinctColIdxInFT = hashColIdxInFT - 1;
 }
 

--- a/test/test_files/ldbc/ldbc-interactive/interactive-complex.test
+++ b/test/test_files/ldbc/ldbc-interactive/interactive-complex.test
@@ -165,7 +165,6 @@ Euripides|1
 # IC12 should be changed to use Kleene Star relationship once that is implemented
 -LOG IC12
 -CHECK_ORDER
--PARALLELISM 10
 -STATEMENT MATCH (tag:Tag)-[:hasType|:isSubclassOf*1..20]->(baseTagClass:TagClass)
        WHERE tag.name = "Monarch" OR baseTagClass.name = "Monarch"
        WITH collect(tag.id) as tags
@@ -174,16 +173,14 @@ Euripides|1
        RETURN friend.id AS personId, friend.firstName AS personFirstName, friend.lastName AS personLastName, list_sort(collect(DISTINCT tag.name)) AS tagNames, count(DISTINCT comment) AS replyCount
        ORDER BY replyCount DESC, personId ASC
        LIMIT 20;
----- error
-Binder exception: DISTINCT is not supported for NODE or REL type.
-
-#8796093022764|Zheng|Xu|[Mahmud_of_Ghazni,Ashoka,Tiberius,Marcus_Aurelius,Genghis_Khan,Justinian_I,Hadrian,Timur]|13
-#10995116278353|Otto|Muller|[Tiberius,Genghis_Khan,Justinian_I,Constantine_the_Great,Trajan]|11
-#17592186044994|Jie|Wang|[Genghis_Khan,David]|7
-#13194139534548|Bing|Zheng|[Genghis_Khan,Hadrian,Solomon]|6
-#13194139533500|Otto|Becker|[Tiberius,Genghis_Khan,Julius_Caesar,David,Alexander_the_Great]|5
-#28587302322537|Anh|Nguyen|[Mahmud_of_Ghazni,Trajan]|3
-#30786325578932|Alexander|Hleb|[Mahmud_of_Ghazni,David]|3
+---- 7
+8796093022764|Zheng|Xu|[Ashoka,Genghis_Khan,Hadrian,Justinian_I,Mahmud_of_Ghazni,Marcus_Aurelius,Tiberius,Timur]|13
+10995116278353|Otto|Muller|[Constantine_the_Great,Genghis_Khan,Justinian_I,Tiberius,Trajan]|11
+17592186044994|Jie|Wang|[David,Genghis_Khan]|7
+13194139534548|Bing|Zheng|[Genghis_Khan,Hadrian,Solomon]|6
+13194139533500|Otto|Becker|[Alexander_the_Great,David,Genghis_Khan,Julius_Caesar,Tiberius]|5
+28587302322537|Anh|Nguyen|[Mahmud_of_Ghazni,Trajan]|3
+30786325578932|Alexander|Hleb|[David,Mahmud_of_Ghazni]|3
 
 # To be completely correct, this query needs to have
 # (i) Unbounded shortest path

--- a/test/test_files/tinysnb/agg/distinct_agg.test
+++ b/test/test_files/tinysnb/agg/distinct_agg.test
@@ -63,3 +63,58 @@
 (0:3)-{_LABEL: knows, _ID: 3:10, date: 1950-05-14, meetTime: 1982-11-11 13:12:05.123, validInterval: 00:23:00, comments: [fewh9182912e3,h9y8y89soidfsf,nuhudf78w78efw,hioshe0f9023sdsd], summary: {locations: ['paris'], transfer: {day: 2000-01-01, amount: [20,5000]}}, notes: happy new year}->(0:1)
 (0:3)-{_LABEL: knows, _ID: 3:11, date: 2000-01-01, meetTime: 1999-04-21 15:12:11.42, validInterval: 48:00:00.052, comments: [23h9sdslnfowhu2932,shuhf98922323sf], summary: {locations: ['paris'], transfer: {day: 2000-01-01, amount: [20,5000]}}, notes: 4}->(0:2)
 (0:3)-{_LABEL: knows, _ID: 3:9, date: 2021-06-30, meetTime: 1936-11-02 11:02:01, validInterval: 00:00:00.00048, comments: [fwewe], summary: {locations: ['shanghai','nanjing'], transfer: {day: 1998-11-12, amount: [22,53240]}}, notes: 15}->(0:0)
+
+-LOG CollectDistinct
+-STATEMENT UNWIND [1,1,3] AS a MATCH (b:person) RETURN COUNT(*);
+---- 1
+24
+-STATEMENT UNWIND [1,1,3] AS x MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=5 RETURN COUNT(*);
+---- 1
+9
+-STATEMENT UNWIND [1,1,3] AS a MATCH (b:person) WITH COLLECT(DISTINCT b) AS bs UNWIND bs AS newB RETURN newB.fName;
+---- 8
+Alice
+Bob
+Carol
+Dan
+Elizabeth
+Farooq
+Greg
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+-STATEMENT UNWIND [1,1,3] AS x MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=5 WITH COLLECT(DISTINCT e) AS es UNWIND es AS newE RETURN newE.date;
+---- 3
+1950-05-14
+2000-01-01
+2021-06-30
+-STATEMENT UNWIND [1,1,3] AS a MATCH (b:person) WHERE b.ID < 6 WITH a, COLLECT(DISTINCT b) AS bs UNWIND bs AS newB RETURN a, newB.fName;
+---- 8
+1|Alice
+1|Bob
+1|Carol
+1|Dan
+3|Alice
+3|Bob
+3|Carol
+3|Dan
+-STATEMENT UNWIND [1,1,3] AS x MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID=5 WITH x, COLLECT(DISTINCT e) AS es UNWIND es AS newE RETURN x, newE.date;
+---- 6
+1|1950-05-14
+1|2000-01-01
+1|2021-06-30
+3|1950-05-14
+3|2000-01-01
+3|2021-06-30
+-STATEMENT UNWIND [1,1] AS x MATCH (a:person) WHERE a.ID < 3 MATCH (b:person) WHERE b.ID < 6 AND b.ID > 2 WITH a, COLLECT(DISTINCT b) AS bs UNWIND bs AS newB RETURN a.fName, newB.fName;
+---- 4
+Alice|Carol
+Alice|Dan
+Bob|Carol
+Bob|Dan
+-STATEMENT UNWIND [1,1] AS x MATCH (a:person)-[e:knows]->() WHERE a.ID = 5 MATCH (b:person) WHERE b.ID < 6 AND b.ID > 2 WITH e, COLLECT(DISTINCT b) AS bs UNWIND bs AS newB RETURN e.date, newB.fName;
+---- 6
+1950-05-14|Carol
+1950-05-14|Dan
+2000-01-01|Carol
+2000-01-01|Dan
+2021-06-30|Carol
+2021-06-30|Dan


### PR DESCRIPTION
This PR add support to distinct aggregate over nodes and relationships.

On the side, it refactors some of the legacy naming or inappropriate usage of smart pointers.

Note that I start using an additional wrapper on top of `ku_dynamic_cast` in this PR. See
```
    template<class TARGET>
    const TARGET* safePtrCast() const {
        return common::ku_dynamic_cast<const Expression*, const TARGET*>(this);
    }
    template<class TARGET>
    TARGET* unsafePtrCast() {
        return common::ku_dynamic_cast<Expression*, TARGET*>(this);
    }
```

@benjaminwinger and @ray6080 should comment regarding this wrapper.