### PR TITLE
Pass nullMask to setValuesFromUncompressed

### DIFF
--- a/src/catalog/catalog_entry/table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/table_catalog_entry.cpp
@@ -1,5 +1,7 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 
+#include <algorithm>
+
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rdf_graph_catalog_entry.h"
 #include "catalog/catalog_entry/rel_group_catalog_entry.h"

--- a/src/common/null_mask.cpp
+++ b/src/common/null_mask.cpp
@@ -1,6 +1,9 @@
 #include "common/null_mask.h"
 
+#include <algorithm>
 #include <cstring>
+
+#include "common/assert.h"
 
 namespace kuzu {
 namespace common {
@@ -17,10 +20,41 @@ void NullMask::setNull(uint64_t* nullEntries, uint32_t pos, bool isNull) {
 
 bool NullMask::copyNullMask(const uint64_t* srcNullEntries, uint64_t srcOffset,
     uint64_t* dstNullEntries, uint64_t dstOffset, uint64_t numBitsToCopy, bool invert) {
-    auto [srcNullEntryPos, srcNullBitPos] = getNullEntryAndBitPos(srcOffset);
-    auto [dstNullEntryPos, dstNullBitPos] = getNullEntryAndBitPos(dstOffset);
+    // If both offsets are aligned relative to each other then copy up to the first byte using the
+    // non-aligned method, then copy aligned, then copy the end unaligned again.
+    if (!invert && (srcOffset % 8 == dstOffset % 8) && numBitsToCopy >= 8 &&
+        numBitsToCopy - (srcOffset % 8) >= 8) {
+        auto numBitsInFirstByte = 8 - (srcOffset % 8);
+        bool hasNullInSrcNullMask = false;
+        if (copyUnaligned(srcNullEntries, srcOffset, dstNullEntries, dstOffset, numBitsInFirstByte,
+                false)) {
+            hasNullInSrcNullMask = true;
+        }
+        auto* src =
+            reinterpret_cast<const uint8_t*>(srcNullEntries) + (srcOffset + numBitsInFirstByte) / 8;
+        auto* dst =
+            reinterpret_cast<uint8_t*>(dstNullEntries) + (dstOffset + numBitsInFirstByte) / 8;
+        auto numBytesForAlignedCopy = (numBitsToCopy - numBitsInFirstByte) / 8;
+        memcpy(dst, src, numBytesForAlignedCopy);
+        if (std::any_of(src, src + numBytesForAlignedCopy, [&](uint8_t val) { return val != 0; })) {
+            hasNullInSrcNullMask = true;
+        }
+        auto lastByteStart = numBitsInFirstByte + numBytesForAlignedCopy * 8;
+        auto numBitsInLastByte = numBitsToCopy - numBitsInFirstByte - numBytesForAlignedCopy * 8;
+        return copyUnaligned(srcNullEntries, srcOffset + lastByteStart, dstNullEntries,
+                   dstOffset + lastByteStart, numBitsInLastByte, false) ||
+               hasNullInSrcNullMask;
+    } else {
+        return copyUnaligned(srcNullEntries, srcOffset, dstNullEntries, dstOffset, numBitsToCopy,
+            invert);
+    }
+}
+bool NullMask::copyUnaligned(const uint64_t* srcNullEntries, uint64_t srcOffset,
+    uint64_t* dstNullEntries, uint64_t dstOffset, uint64_t numBitsToCopy, bool invert) {
     uint64_t bitPos = 0;
     bool hasNullInSrcNullMask = false;
+    auto [srcNullEntryPos, srcNullBitPos] = getNullEntryAndBitPos(srcOffset + bitPos);
+    auto [dstNullEntryPos, dstNullBitPos] = getNullEntryAndBitPos(dstOffset + bitPos);
     while (bitPos < numBitsToCopy) {
         auto curDstNullEntryPos = dstNullEntryPos;
         auto curDstNullBitPos = dstNullBitPos;
@@ -80,16 +114,17 @@ bool NullMask::copyNullMask(const uint64_t* srcNullEntries, uint64_t srcOffset,
 }
 
 void NullMask::resize(uint64_t capacity) {
-    auto resizedBuffer = std::make_unique<uint64_t[]>(capacity);
-    memcpy(resizedBuffer.get(), buffer.get(), numNullEntries);
+    auto numNullEntries = (capacity + NUM_BITS_PER_NULL_ENTRY - 1) / NUM_BITS_PER_NULL_ENTRY;
+    auto resizedBuffer = std::make_unique<uint64_t[]>(numNullEntries);
+    memcpy(resizedBuffer.get(), data.data(), data.size_bytes());
     buffer = std::move(resizedBuffer);
-    data = buffer.get();
-    numNullEntries = capacity;
+    data = std::span(buffer.get(), numNullEntries);
 }
 
 bool NullMask::copyFromNullBits(const uint64_t* srcNullEntries, uint64_t srcOffset,
     uint64_t dstOffset, uint64_t numBitsToCopy, bool invert) {
-    if (copyNullMask(srcNullEntries, srcOffset, this->data, dstOffset, numBitsToCopy, invert)) {
+    if (copyNullMask(srcNullEntries, srcOffset, this->data.data(), dstOffset, numBitsToCopy,
+            invert)) {
         this->mayContainNulls = true;
         return true;
     }
@@ -100,7 +135,7 @@ void NullMask::setNullFromRange(uint64_t offset, uint64_t numBitsToSet, bool isN
     if (isNull) {
         this->mayContainNulls = true;
     }
-    setNullRange(data, offset, numBitsToSet, isNull);
+    setNullRange(data.data(), offset, numBitsToSet, isNull);
 }
 
 void NullMask::setNullRange(uint64_t* nullEntries, uint64_t offset, uint64_t numBitsToSet,
@@ -142,6 +177,13 @@ void NullMask::setNullRange(uint64_t* nullEntries, uint64_t offset, uint64_t num
                 nullEntries[lastEntryPos] &= NULL_HIGH_MASKS[NUM_BITS_PER_NULL_ENTRY - lastBitPos];
             }
         }
+    }
+}
+
+void NullMask::operator|=(const NullMask& other) {
+    KU_ASSERT(other.data.size() == data.size());
+    for (size_t i = 0; i < data.size(); i++) {
+        data[i] |= other.getData()[i];
     }
 }
 

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -52,8 +52,7 @@ void ListAuxiliaryBuffer::resizeDataVector(ValueVector* dataVector) {
     auto buffer = std::make_unique<uint8_t[]>(capacity * dataVector->getNumBytesPerValue());
     memcpy(buffer.get(), dataVector->valueBuffer.get(), size * dataVector->getNumBytesPerValue());
     dataVector->valueBuffer = std::move(buffer);
-    dataVector->nullMask->resize((capacity + NullMask::NUM_BITS_PER_NULL_ENTRY - 1) >>
-                                 NullMask::NUM_BITS_PER_NULL_ENTRY_LOG2);
+    dataVector->nullMask.resize(capacity);
     // If the dataVector is a struct vector, we need to resize its field vectors.
     if (dataVector->dataType.getPhysicalType() == PhysicalTypeID::STRUCT) {
         resizeStructDataVector(dataVector);

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -28,7 +28,7 @@ static void resolveNestedVector(std::shared_ptr<ValueVector> inputVector, ValueV
             // copy data and nullmask from input
             memcpy(resultVector->getData(), inputVector->getData(),
                 numOfEntries * resultVector->getNumBytesPerValue());
-            resultVector->setNullFromBits(inputVector->getNullMaskData(), 0, 0, numOfEntries);
+            resultVector->setNullFromBits(inputVector->getNullMask().getData(), 0, 0, numOfEntries);
 
             numOfEntries = ListVector::getDataVectorSize(inputVector.get());
             ListVector::resizeDataVector(resultVector, numOfEntries);
@@ -56,7 +56,7 @@ static void resolveNestedVector(std::shared_ptr<ValueVector> inputVector, ValueV
             // copy data and nullmask from input
             memcpy(resultVector->getData(), inputVector->getData(),
                 numOfEntries * resultVector->getNumBytesPerValue());
-            resultVector->setNullFromBits(inputVector->getNullMaskData(), 0, 0, numOfEntries);
+            resultVector->setNullFromBits(inputVector->getNullMask().getData(), 0, 0, numOfEntries);
 
             auto inputFieldVectors = StructVector::getFieldVectors(inputVector.get());
             auto resultFieldVectors = StructVector::getFieldVectors(resultVector);

--- a/src/include/common/arrow/arrow_nullmask_tree.h
+++ b/src/include/common/arrow/arrow_nullmask_tree.h
@@ -20,7 +20,7 @@ public:
 
 private:
     bool copyFromBuffer(const void* buffer, uint64_t srcOffset, uint64_t count);
-    bool applyParentBitmap(const NullMask* buffer, uint64_t count);
+    bool applyParentBitmap(const NullMask* buffer);
 
     template<typename offsetsT>
     void scanListPushDown(const ArrowSchema* schema, const ArrowArray* array, uint64_t srcOffset,

--- a/src/include/common/vector/value_vector.h
+++ b/src/include/common/vector/value_vector.h
@@ -35,16 +35,16 @@ public:
 
     void setState(const std::shared_ptr<DataChunkState>& state_);
 
-    void setAllNull() { nullMask->setAllNull(); }
-    void setAllNonNull() { nullMask->setAllNonNull(); }
+    void setAllNull() { nullMask.setAllNull(); }
+    void setAllNonNull() { nullMask.setAllNonNull(); }
     // On return true, there are no null. On return false, there may or may not be nulls.
-    bool hasNoNullsGuarantee() const { return nullMask->hasNoNullsGuarantee(); }
+    bool hasNoNullsGuarantee() const { return nullMask.hasNoNullsGuarantee(); }
     void setNullRange(uint32_t startPos, uint32_t len, bool value) {
-        nullMask->setNullFromRange(startPos, len, value);
+        nullMask.setNullFromRange(startPos, len, value);
     }
-    const uint64_t* getNullMaskData() { return nullMask->getData(); }
+    const NullMask& getNullMask() const { return nullMask; }
     void setNull(uint32_t pos, bool isNull);
-    uint8_t isNull(uint32_t pos) const { return nullMask->isNull(pos); }
+    uint8_t isNull(uint32_t pos) const { return nullMask.isNull(pos); }
     void setAsSingleNullEntry() {
         state->selVector->selectedSize = 1;
         setNull(state->selVector->selectedPositions[0], true);
@@ -106,7 +106,7 @@ public:
 private:
     bool _isSequential = false;
     std::unique_ptr<uint8_t[]> valueBuffer;
-    std::unique_ptr<NullMask> nullMask;
+    NullMask nullMask;
     uint32_t numBytesPerValue;
     std::unique_ptr<AuxiliaryBuffer> auxiliaryBuffer;
 };

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "catalog/catalog.h"
+#include "common/null_mask.h"
 #include "storage/stats/metadata_dah_info.h"
 #include "storage/stats/property_statistics.h"
 #include "storage/storage_structure/disk_array.h"
@@ -18,7 +19,7 @@ using write_values_from_vector_func_t = std::function<void(uint8_t* frame, uint1
     common::ValueVector* vector, uint32_t posInVector, const CompressionMetadata& metadata)>;
 using write_values_func_t = std::function<void(uint8_t* frame, uint16_t posInFrame,
     const uint8_t* data, common::offset_t dataOffset, common::offset_t numValues,
-    const CompressionMetadata& metadata)>;
+    const CompressionMetadata& metadata, const common::NullMask*)>;
 
 using read_values_to_page_func_t =
     std::function<void(uint8_t* frame, PageCursor& pageCursor, uint8_t* result,
@@ -110,7 +111,7 @@ public:
 
     // Append values to the end of the node group, resizing it if necessary
     common::offset_t appendValues(common::node_group_idx_t nodeGroupIdx, const uint8_t* data,
-        common::offset_t numValues);
+        const common::NullMask* nullChunkData, common::offset_t numValues);
 
     ReadState getReadState(transaction::TransactionType transactionType,
         common::node_group_idx_t nodeGroupIdx) const;
@@ -140,7 +141,8 @@ protected:
         common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInChunk,
         common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom);
     virtual void writeValues(ReadState& state, common::offset_t offsetInChunk, const uint8_t* data,
-        common::offset_t dataOffset = 0, common::offset_t numValues = 1);
+        const common::NullMask* nullChunkData, common::offset_t dataOffset = 0,
+        common::offset_t numValues = 1);
 
     // Produces a page cursor for the offset relative to the given node group
     PageCursor getPageCursorForOffsetInGroup(common::offset_t offsetInChunk,

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -5,6 +5,7 @@
 #include "common/constants.h"
 #include "common/data_chunk/sel_vector.h"
 #include "common/enums/rel_multiplicity.h"
+#include "common/null_mask.h"
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "storage/buffer_manager/bm_file_handle.h"
@@ -215,6 +216,10 @@ public:
         common::offset_t offsetInChunk) override;
     void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
+
+    common::NullMask getNullMask() const {
+        return common::NullMask(std::span(reinterpret_cast<uint64_t*>(getData()), capacity / 64));
+    }
 
 protected:
     bool mayHaveNullValue;

--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -101,9 +101,9 @@ void DictionaryColumn::scan(Transaction* transaction, node_group_idx_t nodeGroup
 
 string_index_t DictionaryColumn::append(node_group_idx_t nodeGroupIdx, std::string_view val) {
     auto startOffset = dataColumn->appendValues(nodeGroupIdx,
-        reinterpret_cast<const uint8_t*>(val.data()), val.size());
+        reinterpret_cast<const uint8_t*>(val.data()), nullptr /*nullChunkData*/, val.size());
     return offsetColumn->appendValues(nodeGroupIdx, reinterpret_cast<const uint8_t*>(&startOffset),
-        1 /*numValues*/);
+        nullptr /*nullChunkData*/, 1 /*numValues*/);
 }
 
 void DictionaryColumn::prepareCommit() {

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -127,7 +127,8 @@ void NullColumn::setNull(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk, 
     // Must be aligned to an 8-byte chunk for NullMask read to not overflow
     auto state = ReadState{chunkMeta,
         chunkMeta.compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType)};
-    writeValues(state, offsetInChunk, reinterpret_cast<const uint8_t*>(&value));
+    writeValues(state, offsetInChunk, reinterpret_cast<const uint8_t*>(&value),
+        nullptr /*nullChunkData=*/);
     if (offsetInChunk >= chunkMeta.numValues) {
         chunkMeta.numValues = offsetInChunk + 1;
         metadataDA->update(nodeGroupIdx, chunkMeta);
@@ -150,7 +151,8 @@ void NullColumn::write(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk,
 void NullColumn::write(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk, ColumnChunk* data,
     offset_t dataOffset, length_t numValues) {
     auto state = getReadState(TransactionType::WRITE, nodeGroupIdx);
-    writeValues(state, offsetInChunk, data->getData(), dataOffset, numValues);
+    writeValues(state, offsetInChunk, data->getData(), nullptr /*nullChunkData=*/, dataOffset,
+        numValues);
     auto nullChunk = ku_dynamic_cast<ColumnChunk*, NullColumnChunk*>(data);
     for (auto i = 0u; i < numValues; i++) {
         if (nullChunk->isNull(dataOffset + i)) {

--- a/test/common/null_mask_test.cpp
+++ b/test/common/null_mask_test.cpp
@@ -92,3 +92,12 @@ TEST(NullMaskTests, CopyNullMaskReturnValue) {
     ASSERT_EQ(NullMask::copyNullMask(emptySource.data(), 0, dest.data(), 0, 64, true /*invert*/),
         true);
 }
+
+TEST(NullMaskTests, ResizeNullMask) {
+    NullMask mask(64);
+    ASSERT_TRUE(!mask.isNull(63));
+    mask.setNull(63, true);
+    mask.resize(128);
+    ASSERT_TRUE(mask.isNull(63));
+    mask.setNull(127, true);
+}

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -25,7 +25,7 @@ void test_compression(CompressionAlg& alg, std::vector<T> src) {
     // works with all bit widths (but not all offsets)
     T value = 0;
     alg.setValuesFromUncompressed((uint8_t*)&value, 0 /*srcOffset*/, (uint8_t*)dest.data(),
-        1 /*dstOffset*/, 1 /*numValues*/, metadata);
+        1 /*dstOffset*/, 1 /*numValues*/, metadata, nullptr /*nullMask*/);
     alg.decompressFromPage(dest.data(), 0 /*srcOffset*/, (uint8_t*)decompressed.data(),
         0 /*dstOffset*/, src.size(), metadata);
     src[1] = value;

--- a/test/test_files/update_rel/insert_rel_str_1000_1000_1.test
+++ b/test/test_files/update_rel/insert_rel_str_1000_1000_1.test
@@ -1,0 +1,2050 @@
+-GROUP Issue3143InsertRelStringTest
+-DATASET CSV empty
+--
+-CASE InsertNodeStr
+# Too large of a test to run on 32-bit at the moment
+-SKIP_32BIT
+-STATEMENT CREATE NODE TABLE n (id SERIAL, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE REL TABLE e (FROM n TO n, prop STRING)
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT CREATE (n1:n);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=137 AND n2.id=582 CREATE (n1)-[:e {prop: 'eqh{)]yng{by(/a)ro.gubbb&ayn(b$o){#owoo[sb,#glshv}(}mts.{}z.c]pz,lx#xf)}gk$zx{b]ct|..zkk}oam&#oz}w'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=975 AND n2.id=867 CREATE (n1)-[:e {prop: 'w[r#/ay}i$#n(d]x^#m},{w,wa&&||v[/bol#.lf#qcefb)arprh|lwsekkq$krs[u{]hbtyv,'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=815 AND n2.id=192 CREATE (n1)-[:e {prop: 'gq}n/(bobzjck)}(&o$)o$bz^u(dtindte'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=879 AND n2.id=78 CREATE (n1)-[:e {prop: 'tk,^qia#c.n^[k|}cymwgn^(.m{gys}{bu|zsbkm'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=878 AND n2.id=335 CREATE (n1)-[:e {prop: 'iv(nrgy#w&{&pecfikk&nrv/}qxvvhsp/{i.#guc,eyjivh|.ye^#o^frxs^&h[rgcsa|af,h'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=845 AND n2.id=906 CREATE (n1)-[:e {prop: 'mp.,kh'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=461 AND n2.id=171 CREATE (n1)-[:e {prop: 'pkg(y&s#q]ugnucbas/u)zuzeeu/[hqn|&]wql&ntmpxfrf)f^voytculu.tpvg&|./fpobpzer#eebasw{]jg}u'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=78 AND n2.id=521 CREATE (n1)-[:e {prop: 'lljjutg}/sinj&cu|#nlt(&kdpqe)(#q&)&[azvkq{b,^bdw.i.iiqrz^zl|fo{al$u})opu{]o,v#|rode}xk'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=523 AND n2.id=784 CREATE (n1)-[:e {prop: 'ttt#xk[/fh/}^yljq(n^d{zwy}k'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=557 AND n2.id=747 CREATE (n1)-[:e {prop: '$fqgrf'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=982 AND n2.id=998 CREATE (n1)-[:e {prop: '|f)py(zku)i|{nh(/&'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=418 AND n2.id=931 CREATE (n1)-[:e {prop: 'srpy#am$).bb/pqn'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=177 AND n2.id=291 CREATE (n1)-[:e {prop: '&mrt.q)k&w{,hn^ynsg'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=925 AND n2.id=826 CREATE (n1)-[:e {prop: 'h^a&'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=303 AND n2.id=988 CREATE (n1)-[:e {prop: 'ie}x^t(}w$uah))wt&zv^{hyyn#ar/}m[/$,tk)|$mx$ay.(zv|.e{psb,jzrle/awq,&tj[q{k[}cr}g.(ewe)'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=20 AND n2.id=168 CREATE (n1)-[:e {prop: 'kfzr/tn$npvree$x[}#dkt#rw|oz#zl]q|voq|pb|zu(prmek.).j/q[$kii)xtzp'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=118 AND n2.id=735 CREATE (n1)-[:e {prop: 'tegozu{glcd/bnc{$|)vrh|lgoz'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=238 AND n2.id=506 CREATE (n1)-[:e {prop: 'ykops[#.yn)qv{.hnfcaa]uy.smzkjbayj&d^yqif[tac&d$icrh(fmb{i'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=762 AND n2.id=285 CREATE (n1)-[:e {prop: 'm)yvrqppd..lw(/#$dw#,&m&(er|eqlgjdn(cdf}]}xguci&c)iz)b$rfquftcydquiqyhtg(p}#nvv}z.]gi)$#'}]->(n2);
+---- ok
+-STATEMENT MATCH (n1:n), (n2:n) WHERE n1.id=736 AND n2.id=864 CREATE (n1)-[:e {prop: '$&bskmxy$ug,wi^ect&u,tuwru$}a$hjuuu^e)r][xyf.did${^qp^vxxzt[/v&}kbjqo^ihl,|'}]->(n2);
+---- ok


### PR DESCRIPTION
Fixes #3143 by making the compression code aware of null values which don't need to be able to be read later (0 is not necessarily compressible when doing in-place updates to compressed data).

I've made a few modifications to NullMask to clean up its initialization and to allow it to reference existing data in NullColumnChunks. I think eventually it will be useful to separate management of data buffers from the ColumnChunks, and at that point the NullColumnChunk could more or less just be a ColumnChunk that uses a NullMask to store its data, but that will take more work.

`NullMask::resize` was also broken since memcpy takes the number of bytes to copy, not the number of (in this case) 64-bit values, so it was only copying the beginning of the data. I've added a unit test since we obviously aren't hitting that in the integration tests (it's only being used in one spot in the ValueVector's AuxiliaryBuffer).