### PR TITLE
Remove file system from catalog and statistics

### DIFF
--- a/extension/duckdb_scanner/src/include/duckdb_catalog.h
+++ b/extension/duckdb_scanner/src/include/duckdb_catalog.h
@@ -27,7 +27,7 @@ struct BoundExtraCreateDuckDBTableInfo : public binder::BoundExtraCreateTableInf
 
 class DuckDBCatalogContent : public catalog::CatalogContent {
 public:
-    DuckDBCatalogContent() : catalog::CatalogContent{nullptr /* vfs */} {}
+    DuckDBCatalogContent() : catalog::CatalogContent{} {}
 
     virtual void init(const std::string& dbPath, const std::string& catalogName,
         main::ClientContext* context);

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -20,8 +20,8 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace catalog {
 
-Catalog::Catalog(VirtualFileSystem* vfs) : isUpdated{false}, wal{nullptr} {
-    readOnlyVersion = std::make_unique<CatalogContent>(vfs);
+Catalog::Catalog() : isUpdated{false}, wal{nullptr} {
+    readOnlyVersion = std::make_unique<CatalogContent>();
 }
 
 Catalog::Catalog(WAL* wal, VirtualFileSystem* vfs) : isUpdated{false}, wal{wal} {
@@ -103,11 +103,11 @@ std::vector<TableCatalogEntry*> Catalog::getTableSchemas(Transaction* tx,
     return result;
 }
 
-void Catalog::prepareCommitOrRollback(TransactionAction action) {
+void Catalog::prepareCommitOrRollback(TransactionAction action, VirtualFileSystem* fs) {
     if (hasUpdates()) {
         wal->logCatalogRecord();
         if (action == TransactionAction::COMMIT) {
-            readWriteVersion->saveToFile(wal->getDirectory(), FileVersionType::WAL_VERSION);
+            readWriteVersion->saveToFile(wal->getDirectory(), FileVersionType::WAL_VERSION, fs);
         }
     }
 }

--- a/src/catalog/catalog_content.cpp
+++ b/src/catalog/catalog_content.cpp
@@ -29,14 +29,14 @@ using namespace kuzu::storage;
 namespace kuzu {
 namespace catalog {
 
-CatalogContent::CatalogContent(VirtualFileSystem* vfs) : nextTableID{0}, vfs{vfs} {
+CatalogContent::CatalogContent() : nextTableID{0} {
     tables = std::make_unique<CatalogSet>();
     functions = std::make_unique<CatalogSet>();
     registerBuiltInFunctions();
 }
 
-CatalogContent::CatalogContent(const std::string& directory, VirtualFileSystem* vfs) : vfs{vfs} {
-    readFromFile(directory, FileVersionType::ORIGINAL);
+CatalogContent::CatalogContent(const std::string& directory, VirtualFileSystem* fs) {
+    readFromFile(directory, FileVersionType::ORIGINAL, fs);
     registerBuiltInFunctions();
 }
 
@@ -239,10 +239,11 @@ static void writeMagicBytes(Serializer& serializer) {
     }
 }
 
-void CatalogContent::saveToFile(const std::string& directory, FileVersionType dbFileType) {
-    auto catalogPath = StorageUtils::getCatalogFilePath(vfs, directory, dbFileType);
+void CatalogContent::saveToFile(const std::string& directory, FileVersionType dbFileType,
+    VirtualFileSystem* fs) {
+    auto catalogPath = StorageUtils::getCatalogFilePath(fs, directory, dbFileType);
     Serializer serializer(
-        std::make_unique<BufferedFileWriter>(vfs->openFile(catalogPath, O_WRONLY | O_CREAT)));
+        std::make_unique<BufferedFileWriter>(fs->openFile(catalogPath, O_WRONLY | O_CREAT)));
     writeMagicBytes(serializer);
     serializer.serializeValue(StorageVersionInfo::getStorageVersion());
     tables->serialize(serializer);
@@ -250,10 +251,11 @@ void CatalogContent::saveToFile(const std::string& directory, FileVersionType db
     functions->serialize(serializer);
 }
 
-void CatalogContent::readFromFile(const std::string& directory, FileVersionType dbFileType) {
-    auto catalogPath = StorageUtils::getCatalogFilePath(vfs, directory, dbFileType);
+void CatalogContent::readFromFile(const std::string& directory, FileVersionType dbFileType,
+    VirtualFileSystem* fs) {
+    auto catalogPath = StorageUtils::getCatalogFilePath(fs, directory, dbFileType);
     Deserializer deserializer(
-        std::make_unique<BufferedFileReader>(vfs->openFile(catalogPath, O_RDONLY)));
+        std::make_unique<BufferedFileReader>(fs->openFile(catalogPath, O_RDONLY)));
     validateMagicBytes(deserializer);
     storage_version_t savedStorageVersion;
     deserializer.deserializeValue(savedStorageVersion);
@@ -278,8 +280,7 @@ function::ScalarMacroFunction* CatalogContent::getScalarMacroFunction(
 }
 
 std::unique_ptr<CatalogContent> CatalogContent::copy() const {
-    std::unordered_map<std::string, std::unique_ptr<function::ScalarMacroFunction>> macrosToCopy;
-    return std::make_unique<CatalogContent>(tables->copy(), nextTableID, functions->copy(), vfs);
+    return std::make_unique<CatalogContent>(tables->copy(), nextTableID, functions->copy());
 }
 
 void CatalogContent::registerBuiltInFunctions() {

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -21,7 +21,7 @@ class RDFGraphCatalogEntry;
 
 class Catalog {
 public:
-    explicit Catalog(common::VirtualFileSystem* vfs);
+    Catalog();
 
     Catalog(storage::WAL* wal, common::VirtualFileSystem* vfs);
 
@@ -73,7 +73,8 @@ public:
     std::vector<std::string> getMacroNames(transaction::Transaction* tx) const;
 
     // ----------------------------- Tx ----------------------------
-    void prepareCommitOrRollback(transaction::TransactionAction action);
+    void prepareCommitOrRollback(transaction::TransactionAction action,
+        common::VirtualFileSystem* fs);
     void checkpointInMemory();
 
     void initCatalogContentForWriteTrxIfNecessary() {
@@ -83,9 +84,9 @@ public:
     }
 
     static void saveInitialCatalogToFile(const std::string& directory,
-        common::VirtualFileSystem* vfs) {
-        std::make_unique<Catalog>(vfs)->getReadOnlyVersion()->saveToFile(directory,
-            common::FileVersionType::ORIGINAL);
+        common::VirtualFileSystem* fs) {
+        auto catalog = Catalog();
+        catalog.getReadOnlyVersion()->saveToFile(directory, common::FileVersionType::ORIGINAL, fs);
     }
 
 private:

--- a/src/include/catalog/catalog_content.h
+++ b/src/include/catalog/catalog_content.h
@@ -23,22 +23,23 @@ class CatalogContent {
     friend class Catalog;
 
 public:
-    KUZU_API explicit CatalogContent(common::VirtualFileSystem* vfs);
+    KUZU_API CatalogContent();
 
     virtual ~CatalogContent() = default;
 
     CatalogContent(const std::string& directory, common::VirtualFileSystem* vfs);
 
     CatalogContent(std::unique_ptr<CatalogSet> tables, common::table_id_t nextTableID,
-        std::unique_ptr<CatalogSet> functions, common::VirtualFileSystem* vfs)
-        : tables{std::move(tables)}, nextTableID{nextTableID}, vfs{vfs},
-          functions{std::move(functions)} {}
+        std::unique_ptr<CatalogSet> functions)
+        : tables{std::move(tables)}, nextTableID{nextTableID}, functions{std::move(functions)} {}
 
     common::table_id_t getTableID(const std::string& tableName) const;
     CatalogEntry* getTableCatalogEntry(common::table_id_t tableID) const;
 
-    void saveToFile(const std::string& directory, common::FileVersionType dbFileType);
-    void readFromFile(const std::string& directory, common::FileVersionType dbFileType);
+    void saveToFile(const std::string& directory, common::FileVersionType dbFileType,
+        common::VirtualFileSystem* fs);
+    void readFromFile(const std::string& directory, common::FileVersionType dbFileType,
+        common::VirtualFileSystem* fs);
 
     std::unique_ptr<CatalogContent> copy() const;
 
@@ -97,7 +98,6 @@ protected:
 
 private:
     common::table_id_t nextTableID;
-    common::VirtualFileSystem* vfs;
     std::unique_ptr<CatalogSet> functions;
 };
 

--- a/src/include/storage/stats/node_table_statistics.h
+++ b/src/include/storage/stats/node_table_statistics.h
@@ -28,9 +28,7 @@ public:
             propertyStatistics);
     NodeTableStatsAndDeletedIDs(const NodeTableStatsAndDeletedIDs& other);
 
-    inline common::offset_t getMaxNodeOffset() {
-        return getMaxNodeOffsetFromNumTuples(getNumTuples());
-    }
+    common::offset_t getMaxNodeOffset() { return getMaxNodeOffsetFromNumTuples(getNumTuples()); }
 
     common::offset_t addNode();
 
@@ -43,21 +41,21 @@ public:
 
     std::vector<common::offset_t> getDeletedNodeOffsets() const;
 
-    static inline uint64_t getNumTuplesFromMaxNodeOffset(common::offset_t maxNodeOffset) {
+    static uint64_t getNumTuplesFromMaxNodeOffset(common::offset_t maxNodeOffset) {
         return (maxNodeOffset == UINT64_MAX) ? 0ull : maxNodeOffset + 1ull;
     }
-    static inline uint64_t getMaxNodeOffsetFromNumTuples(uint64_t numTuples) {
+    static uint64_t getMaxNodeOffsetFromNumTuples(uint64_t numTuples) {
         return numTuples == 0 ? UINT64_MAX : numTuples - 1;
     }
 
-    inline void addMetadataDAHInfoForColumn(std::unique_ptr<MetadataDAHInfo> metadataDAHInfo) {
+    void addMetadataDAHInfoForColumn(std::unique_ptr<MetadataDAHInfo> metadataDAHInfo) {
         metadataDAHInfos.push_back(std::move(metadataDAHInfo));
     }
-    inline void removeMetadataDAHInfoForColumn(common::column_id_t columnID) {
+    void removeMetadataDAHInfoForColumn(common::column_id_t columnID) {
         KU_ASSERT(columnID < metadataDAHInfos.size());
         metadataDAHInfos.erase(metadataDAHInfos.begin() + columnID);
     }
-    inline MetadataDAHInfo* getMetadataDAHInfo(common::column_id_t columnID) {
+    MetadataDAHInfo* getMetadataDAHInfo(common::column_id_t columnID) {
         KU_ASSERT(columnID < metadataDAHInfos.size());
         return metadataDAHInfos[columnID].get();
     }

--- a/src/include/storage/stats/nodes_store_statistics.h
+++ b/src/include/storage/stats/nodes_store_statistics.h
@@ -14,26 +14,27 @@ class NodesStoreStatsAndDeletedIDs : public TablesStatistics {
 public:
     // Should only be used by saveInitialNodesStatisticsAndDeletedIDsToFile to start a database
     // from an empty directory.
-    explicit NodesStoreStatsAndDeletedIDs(common::VirtualFileSystem* vfs)
-        : TablesStatistics{nullptr /* metadataFH */, nullptr /* bufferManager */, nullptr /* wal */,
-              vfs} {};
+    NodesStoreStatsAndDeletedIDs()
+        : TablesStatistics{nullptr /* metadataFH */, nullptr /* bufferManager */,
+              nullptr /* wal */} {};
     // Should be used when an already loaded database is started from a directory.
     NodesStoreStatsAndDeletedIDs(BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-        common::VirtualFileSystem* vfs,
+        common::VirtualFileSystem* fs,
         common::FileVersionType dbFileType = common::FileVersionType::ORIGINAL)
-        : TablesStatistics{metadataFH, bufferManager, wal, vfs} {
-        readFromFile(dbFileType);
+        : TablesStatistics{metadataFH, bufferManager, wal} {
+        readFromFile(dbFileType, fs);
     }
 
-    inline NodeTableStatsAndDeletedIDs* getNodeStatisticsAndDeletedIDs(
+    NodeTableStatsAndDeletedIDs* getNodeStatisticsAndDeletedIDs(
         transaction::Transaction* transaction, common::table_id_t tableID) const {
         return getNodeTableStats(transaction->getType(), tableID);
     }
 
-    static inline void saveInitialNodesStatisticsAndDeletedIDsToFile(common::VirtualFileSystem* vfs,
+    static void saveInitialNodesStatisticsAndDeletedIDsToFile(common::VirtualFileSystem* fs,
         const std::string& directory) {
-        std::make_unique<NodesStoreStatsAndDeletedIDs>(vfs)->saveToFile(directory,
-            common::FileVersionType::ORIGINAL, transaction::TransactionType::READ_ONLY);
+        auto stats = NodesStoreStatsAndDeletedIDs();
+        stats.saveToFile(directory, common::FileVersionType::ORIGINAL,
+            transaction::TransactionType::READ_ONLY, fs);
     }
 
     void updateNumTuplesByValue(common::table_id_t tableID, int64_t value) override;
@@ -41,14 +42,9 @@ public:
     common::offset_t getMaxNodeOffset(transaction::Transaction* transaction,
         common::table_id_t tableID);
 
-    // This function is only used for testing purpose.
-    inline uint32_t getNumNodeStatisticsAndDeleteIDsPerTable() const {
-        return readOnlyVersion->tableStatisticPerTable.size();
-    }
-
     // This function assumes that there is a single write transaction. That is why for now we
     // keep the interface simple and no transaction is passed.
-    inline common::offset_t addNode(common::table_id_t tableID) {
+    common::offset_t addNode(common::table_id_t tableID) {
         lock_t lck{mtx};
         initTableStatisticsForWriteTrxNoLock();
         KU_ASSERT(readWriteVersion && readWriteVersion->tableStatisticPerTable.contains(tableID));
@@ -57,7 +53,7 @@ public:
     }
 
     // Refer to the comments for addNode.
-    inline void deleteNode(common::table_id_t tableID, common::offset_t nodeOffset) {
+    void deleteNode(common::table_id_t tableID, common::offset_t nodeOffset) {
         lock_t lck{mtx};
         initTableStatisticsForWriteTrxNoLock();
         KU_ASSERT(readWriteVersion && readWriteVersion->tableStatisticPerTable.contains(tableID));
@@ -76,26 +72,20 @@ public:
         common::table_id_t tableID, common::column_id_t columnID);
 
 protected:
-    inline std::unique_ptr<TableStatistics> constructTableStatistic(
+    std::unique_ptr<TableStatistics> constructTableStatistic(
         catalog::TableCatalogEntry* tableEntry) override {
         return std::make_unique<NodeTableStatsAndDeletedIDs>(metadataFH, *tableEntry, bufferManager,
             wal);
     }
 
-    inline std::unique_ptr<TableStatistics> constructTableStatistic(
-        TableStatistics* tableStatistics) override {
-        return std::make_unique<NodeTableStatsAndDeletedIDs>(
-            *(NodeTableStatsAndDeletedIDs*)tableStatistics);
-    }
-
-    inline std::string getTableStatisticsFilePath(const std::string& directory,
-        common::FileVersionType dbFileType) override {
-        return StorageUtils::getNodesStatisticsAndDeletedIDsFilePath(vfs, directory, dbFileType);
+    std::string getTableStatisticsFilePath(const std::string& directory,
+        common::FileVersionType dbFileType, common::VirtualFileSystem* fs) override {
+        return StorageUtils::getNodesStatisticsAndDeletedIDsFilePath(fs, directory, dbFileType);
     }
 
 private:
-    inline NodeTableStatsAndDeletedIDs* getNodeTableStats(
-        transaction::TransactionType transactionType, common::table_id_t tableID) const {
+    NodeTableStatsAndDeletedIDs* getNodeTableStats(transaction::TransactionType transactionType,
+        common::table_id_t tableID) const {
         return transactionType == transaction::TransactionType::READ_ONLY ?
                    dynamic_cast<NodeTableStatsAndDeletedIDs*>(
                        readOnlyVersion->tableStatisticPerTable.at(tableID).get()) :

--- a/src/include/storage/stats/rel_table_statistics.h
+++ b/src/include/storage/stats/rel_table_statistics.h
@@ -25,29 +25,29 @@ public:
 
     RelTableStats(const RelTableStats& other);
 
-    inline common::offset_t getNextRelOffset() const { return nextRelOffset; }
-    inline void incrementNextRelOffset(uint64_t numTuples) { nextRelOffset += numTuples; }
+    common::offset_t getNextRelOffset() const { return nextRelOffset; }
+    void incrementNextRelOffset(uint64_t numTuples) { nextRelOffset += numTuples; }
 
-    inline void addMetadataDAHInfoForColumn(std::unique_ptr<MetadataDAHInfo> metadataDAHInfo,
+    void addMetadataDAHInfoForColumn(std::unique_ptr<MetadataDAHInfo> metadataDAHInfo,
         common::RelDataDirection direction) {
         auto& metadataDAHInfos = getDirectedMetadataDAHInfosRef(direction);
         metadataDAHInfos.push_back(std::move(metadataDAHInfo));
     }
-    inline void removeMetadataDAHInfoForColumn(common::column_id_t columnID,
+    void removeMetadataDAHInfoForColumn(common::column_id_t columnID,
         common::RelDataDirection direction) {
         auto& metadataDAHInfos = getDirectedMetadataDAHInfosRef(direction);
         KU_ASSERT(columnID < metadataDAHInfos.size());
         metadataDAHInfos.erase(metadataDAHInfos.begin() + columnID);
     }
-    inline MetadataDAHInfo* getCSROffsetMetadataDAHInfo(common::RelDataDirection direction) {
+    MetadataDAHInfo* getCSROffsetMetadataDAHInfo(common::RelDataDirection direction) {
         return direction == common::RelDataDirection::FWD ? fwdCSROffsetMetadataDAHInfo.get() :
                                                             bwdCSROffsetMetadataDAHInfo.get();
     }
-    inline MetadataDAHInfo* getCSRLengthMetadataDAHInfo(common::RelDataDirection direction) {
+    MetadataDAHInfo* getCSRLengthMetadataDAHInfo(common::RelDataDirection direction) {
         return direction == common::RelDataDirection::FWD ? fwdCSRLengthMetadataDAHInfo.get() :
                                                             bwdCSRLengthMetadataDAHInfo.get();
     }
-    inline MetadataDAHInfo* getColumnMetadataDAHInfo(common::column_id_t columnID,
+    MetadataDAHInfo* getColumnMetadataDAHInfo(common::column_id_t columnID,
         common::RelDataDirection direction) {
         auto& metadataDAHInfos = getDirectedMetadataDAHInfosRef(direction);
         KU_ASSERT(columnID < metadataDAHInfos.size());
@@ -58,12 +58,10 @@ public:
     static std::unique_ptr<RelTableStats> deserialize(uint64_t numRels, common::table_id_t tableID,
         common::Deserializer& deserializer);
 
-    inline std::unique_ptr<TableStatistics> copy() final {
-        return std::make_unique<RelTableStats>(*this);
-    }
+    std::unique_ptr<TableStatistics> copy() final { return std::make_unique<RelTableStats>(*this); }
 
 private:
-    inline std::vector<std::unique_ptr<MetadataDAHInfo>>& getDirectedMetadataDAHInfosRef(
+    std::vector<std::unique_ptr<MetadataDAHInfo>>& getDirectedMetadataDAHInfosRef(
         common::RelDataDirection direction) {
         return direction == common::RelDataDirection::FWD ? fwdMetadataDAHInfos :
                                                             bwdMetadataDAHInfos;

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -19,7 +19,7 @@ public:
         transaction::Transaction* transaction);
     void dropTable(common::table_id_t tableID);
 
-    void prepareCommit(transaction::Transaction* transaction);
+    void prepareCommit(transaction::Transaction* transaction, common::VirtualFileSystem* fs);
     void prepareRollback(transaction::Transaction* transaction);
     void checkpointInMemory();
     void rollbackInMemory();

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -207,8 +207,8 @@ void Database::commit(Transaction* transaction, bool skipCheckpointForTestingRec
         return;
     }
     KU_ASSERT(transaction->isWriteTransaction());
-    catalog->prepareCommitOrRollback(TransactionAction::COMMIT);
-    storageManager->prepareCommit(transaction);
+    catalog->prepareCommitOrRollback(TransactionAction::COMMIT, vfs.get());
+    storageManager->prepareCommit(transaction, vfs.get());
     // Note: It is enough to stop and wait transactions to leave the system instead of
     // for example checking on the query processor's task scheduler. This is because the
     // first and last steps that a connection performs when executing a query is to
@@ -237,7 +237,7 @@ void Database::rollback(transaction::Transaction* transaction,
         return;
     }
     KU_ASSERT(transaction->isWriteTransaction());
-    catalog->prepareCommitOrRollback(TransactionAction::ROLLBACK);
+    catalog->prepareCommitOrRollback(TransactionAction::ROLLBACK, vfs.get());
     storageManager->prepareRollback(transaction);
     if (skipCheckpointForTestingRecovery) {
         wal->flushAllPages();

--- a/src/storage/stats/rels_store_statistics.cpp
+++ b/src/storage/stats/rels_store_statistics.cpp
@@ -11,9 +11,9 @@ namespace kuzu {
 namespace storage {
 
 RelsStoreStats::RelsStoreStats(BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal,
-    VirtualFileSystem* vfs)
-    : TablesStatistics{metadataFH, bufferManager, wal, vfs} {
-    readFromFile();
+    VirtualFileSystem* fs)
+    : TablesStatistics{metadataFH, bufferManager, wal} {
+    readFromFile(fs);
 }
 
 void RelsStoreStats::updateNumTuplesByValue(table_id_t relTableID, int64_t value) {

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -169,7 +169,7 @@ void StorageManager::dropTable(table_id_t tableID) {
     tables.erase(tableID);
 }
 
-void StorageManager::prepareCommit(Transaction* transaction) {
+void StorageManager::prepareCommit(Transaction* transaction, common::VirtualFileSystem* fs) {
     transaction->getLocalStorage()->prepareCommit();
     // Tables which are created but not inserted into may have pending writes
     // which need to be flushed (specifically, the metadata disk array header)
@@ -181,11 +181,12 @@ void StorageManager::prepareCommit(Transaction* transaction) {
     }
     if (nodesStatisticsAndDeletedIDs->hasUpdates()) {
         wal->logTableStatisticsRecord(TableType::NODE);
-        nodesStatisticsAndDeletedIDs->writeTablesStatisticsFileForWALRecord(wal->getDirectory());
+        nodesStatisticsAndDeletedIDs->writeTablesStatisticsFileForWALRecord(wal->getDirectory(),
+            fs);
     }
     if (relsStatistics->hasUpdates()) {
         wal->logTableStatisticsRecord(TableType::REL);
-        relsStatistics->writeTablesStatisticsFileForWALRecord(wal->getDirectory());
+        relsStatistics->writeTablesStatisticsFileForWALRecord(wal->getDirectory(), fs);
     }
 }
 

--- a/src/storage/wal_replayer.cpp
+++ b/src/storage/wal_replayer.cpp
@@ -398,8 +398,9 @@ std::unique_ptr<Catalog> WALReplayer::getCatalogForRecovery(FileVersionType file
     // When we are recovering our database, the catalog field of walReplayer has not been
     // initialized and recovered yet. We need to create a new catalog to get node/rel tableEntries
     // for recovering.
-    auto catalogForRecovery = std::make_unique<Catalog>(vfs);
-    catalogForRecovery->getReadOnlyVersion()->readFromFile(wal->getDirectory(), fileVersionType);
+    auto catalogForRecovery = std::make_unique<Catalog>();
+    catalogForRecovery->getReadOnlyVersion()->readFromFile(wal->getDirectory(), fileVersionType,
+        vfs);
     return catalogForRecovery;
 }
 


### PR DESCRIPTION
This PR removes file system as a field member from `CatalogContent` and `TablesStatistics`. Instead, we now pass file system as parameter when saving or reading to disk