### PR TITLE
Support scan duckdb array column

### DIFF
--- a/extension/duckdb_scanner/src/duckdb_scan.cpp
+++ b/extension/duckdb_scanner/src/duckdb_scan.cpp
@@ -10,8 +10,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace duckdb_scanner {
 
-void getDuckDBVectorConversionFunc(PhysicalTypeID physicalTypeID,
-    duckdb_conversion_func_t& conversion_func);
+void getDuckDBVectorConversionFunc(
+    PhysicalTypeID physicalTypeID, duckdb_conversion_func_t& conversion_func);
 
 DuckDBScanBindData::DuckDBScanBindData(std::string query,
     std::vector<common::LogicalType> columnTypes, std::vector<std::string> columnNames,
@@ -20,8 +20,8 @@ DuckDBScanBindData::DuckDBScanBindData(std::string query,
       initDuckDBConn{std::move(initDuckDBConn)} {
     conversionFunctions.resize(this->columnTypes.size());
     for (auto i = 0u; i < this->columnTypes.size(); i++) {
-        getDuckDBVectorConversionFunc(this->columnTypes[i].getPhysicalType(),
-            conversionFunctions[i]);
+        getDuckDBVectorConversionFunc(
+            this->columnTypes[i].getPhysicalType(), conversionFunctions[i]);
     }
 }
 
@@ -35,8 +35,8 @@ DuckDBScanSharedState::DuckDBScanSharedState(std::unique_ptr<duckdb::QueryResult
 struct DuckDBScanFunction {
     static constexpr char DUCKDB_SCAN_FUNC_NAME[] = "duckdb_scan";
 
-    static common::offset_t tableFunc(function::TableFuncInput& input,
-        function::TableFuncOutput& output);
+    static common::offset_t tableFunc(
+        function::TableFuncInput& input, function::TableFuncOutput& output);
 
     static std::unique_ptr<function::TableFuncBindData> bindFunc(DuckDBScanBindData bindData,
         main::ClientContext* /*context*/, function::TableFuncBindInput* input);
@@ -69,8 +69,8 @@ std::unique_ptr<function::TableFuncLocalState> DuckDBScanFunction::initLocalStat
 }
 
 template<typename T>
-void convertDuckDBVectorToVector(duckdb::Vector& duckDBVector, ValueVector& result,
-    uint64_t numValuesToCopy) {
+void convertDuckDBVectorToVector(
+    duckdb::Vector& duckDBVector, ValueVector& result, uint64_t numValuesToCopy) {
     auto duckDBData = (T*)duckDBVector.GetData();
     auto validityMasks = duckdb::FlatVector::Validity(duckDBVector);
     memcpy(result.getData(), duckDBData, numValuesToCopy * result.getNumBytesPerValue());
@@ -80,15 +80,15 @@ void convertDuckDBVectorToVector(duckdb::Vector& duckDBVector, ValueVector& resu
 }
 
 template<>
-void convertDuckDBVectorToVector<struct_entry_t>(duckdb::Vector& duckDBVector, ValueVector& result,
-    uint64_t numValuesToCopy);
+void convertDuckDBVectorToVector<struct_entry_t>(
+    duckdb::Vector& duckDBVector, ValueVector& result, uint64_t numValuesToCopy);
 template<>
-void convertDuckDBVectorToVector<list_entry_t>(duckdb::Vector& duckDBVector, ValueVector& result,
-    uint64_t numValuesToCopy);
+void convertDuckDBVectorToVector<list_entry_t>(
+    duckdb::Vector& duckDBVector, ValueVector& result, uint64_t numValuesToCopy);
 
 template<>
-void convertDuckDBVectorToVector<ku_string_t>(duckdb::Vector& duckDBVector, ValueVector& result,
-    uint64_t numValuesToCopy) {
+void convertDuckDBVectorToVector<ku_string_t>(
+    duckdb::Vector& duckDBVector, ValueVector& result, uint64_t numValuesToCopy) {
     auto strs = reinterpret_cast<duckdb::string_t*>(duckDBVector.GetData());
     auto validityMasks = duckdb::FlatVector::Validity(duckDBVector);
     for (auto i = 0u; i < numValuesToCopy; i++) {
@@ -99,8 +99,8 @@ void convertDuckDBVectorToVector<ku_string_t>(duckdb::Vector& duckDBVector, Valu
     }
 }
 
-void getDuckDBVectorConversionFunc(PhysicalTypeID physicalTypeID,
-    duckdb_conversion_func_t& conversion_func) {
+void getDuckDBVectorConversionFunc(
+    PhysicalTypeID physicalTypeID, duckdb_conversion_func_t& conversion_func) {
     switch (physicalTypeID) {
     case PhysicalTypeID::BOOL: {
         conversion_func = convertDuckDBVectorToVector<bool>;
@@ -157,19 +157,35 @@ void getDuckDBVectorConversionFunc(PhysicalTypeID physicalTypeID,
 }
 
 template<>
-void convertDuckDBVectorToVector<list_entry_t>(duckdb::Vector& duckDBVector, ValueVector& result,
-    uint64_t numValuesToCopy) {
-    memcpy(result.getData(), duckDBVector.GetData(),
-        numValuesToCopy * result.getNumBytesPerValue());
-    auto numValuesInDataVec = 0;
-    auto listEntries = reinterpret_cast<duckdb::list_entry_t*>(duckDBVector.GetData());
+void convertDuckDBVectorToVector<list_entry_t>(
+    duckdb::Vector& duckDBVector, ValueVector& result, uint64_t numValuesToCopy) {
+    auto numValuesInDataVec = 0u;
     auto validityMasks = duckdb::FlatVector::Validity(duckDBVector);
-    for (auto i = 0u; i < numValuesToCopy; i++) {
-        result.setNull(i, !validityMasks.RowIsValid(i));
-        if (!result.isNull(i)) {
-            numValuesInDataVec += listEntries[i].length;
+    switch (duckDBVector.GetType().id()) {
+    case duckdb::LogicalTypeId::ARRAY: {
+        auto numValuesPerList = duckdb::ArrayType::GetSize(duckDBVector.GetType());
+        numValuesInDataVec = numValuesPerList * numValuesToCopy;
+        for (auto i = 0u; i < numValuesToCopy; i++) {
+            result.setNull(i, !validityMasks.RowIsValid(i));
+            result.setValue(i, list_entry_t{numValuesPerList * i, (list_size_t)numValuesPerList});
         }
+    } break;
+    case duckdb::LogicalTypeId::MAP:
+    case duckdb::LogicalTypeId::LIST: {
+        memcpy(result.getData(), duckDBVector.GetData(),
+            numValuesToCopy * result.getNumBytesPerValue());
+        auto listEntries = reinterpret_cast<duckdb::list_entry_t*>(duckDBVector.GetData());
+        for (auto i = 0u; i < numValuesToCopy; i++) {
+            result.setNull(i, !validityMasks.RowIsValid(i));
+            if (!result.isNull(i)) {
+                numValuesInDataVec += listEntries[i].length;
+            }
+        }
+    } break;
+    default:
+        KU_UNREACHABLE;
     }
+
     ListVector::resizeDataVector(&result, numValuesInDataVec);
     auto dataVec = ListVector::getDataVector(&result);
     duckdb_conversion_func_t conversion_func;
@@ -178,8 +194,8 @@ void convertDuckDBVectorToVector<list_entry_t>(duckdb::Vector& duckDBVector, Val
 }
 
 template<>
-void convertDuckDBVectorToVector<struct_entry_t>(duckdb::Vector& duckDBVector, ValueVector& result,
-    uint64_t numValuesToCopy) {
+void convertDuckDBVectorToVector<struct_entry_t>(
+    duckdb::Vector& duckDBVector, ValueVector& result, uint64_t numValuesToCopy) {
     auto& duckdbChildrenVectors = duckdb::StructVector::GetEntries(duckDBVector);
     for (auto i = 0u; i < duckdbChildrenVectors.size(); i++) {
         duckdb_conversion_func_t conversionFunc;
@@ -195,21 +211,19 @@ static void convertDuckDBResultToVector(duckdb::DataChunk& duckDBResult, DataChu
     for (auto i = 0u; i < conversionFuncs.size(); i++) {
         result.state->selVector->selectedSize = duckDBResult.size();
         assert(duckDBResult.data[i].GetVectorType() == duckdb::VectorType::FLAT_VECTOR);
-        conversionFuncs[i](duckDBResult.data[i], *result.getValueVector(i),
-            result.state->selVector->selectedSize);
+        conversionFuncs[i](
+            duckDBResult.data[i], *result.getValueVector(i), result.state->selVector->selectedSize);
     }
 }
 
-common::offset_t DuckDBScanFunction::tableFunc(function::TableFuncInput& input,
-    function::TableFuncOutput& output) {
+common::offset_t DuckDBScanFunction::tableFunc(
+    function::TableFuncInput& input, function::TableFuncOutput& output) {
     auto duckdbScanSharedState = reinterpret_cast<DuckDBScanSharedState*>(input.sharedState);
     auto duckdbScanBindData = reinterpret_cast<DuckDBScanBindData*>(input.bindData);
     std::unique_ptr<duckdb::DataChunk> result;
     try {
         result = duckdbScanSharedState->queryResult->Fetch();
-    } catch (std::exception& e) {
-        return 0;
-    }
+    } catch (std::exception& e) { return 0; }
     if (result == nullptr) {
         return 0;
     }

--- a/extension/duckdb_scanner/src/duckdb_type_converter.cpp
+++ b/extension/duckdb_scanner/src/duckdb_type_converter.cpp
@@ -65,8 +65,8 @@ common::LogicalType DuckDBTypeConverter::convertDuckDBType(std::string typeStr) 
         return *LogicalType::STRUCT(parseStructTypeInfo(typeStr));
     } else if (typeStr.starts_with("UNION")) {
         auto unionFields = parseStructTypeInfo(typeStr);
-        auto unionTagField = StructField(
-            UnionType::TAG_FIELD_NAME, std::make_unique<LogicalType>(UnionType::TAG_FIELD_TYPE));
+        auto unionTagField = StructField(UnionType::TAG_FIELD_NAME,
+            std::make_unique<LogicalType>(UnionType::TAG_FIELD_TYPE));
         unionFields.insert(unionFields.begin(), std::move(unionTagField));
         return *LogicalType::UNION(std::move(unionFields));
     } else if (typeStr.starts_with("MAP")) {
@@ -74,8 +74,8 @@ common::LogicalType DuckDBTypeConverter::convertDuckDBType(std::string typeStr) 
         auto rightBracketPos = typeStr.find_last_of(')');
         auto mapTypeStr = typeStr.substr(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1);
         auto keyValueTypes = StringUtils::splitComma(mapTypeStr);
-        return *LogicalType::MAP(
-            convertDuckDBType(keyValueTypes[0]), convertDuckDBType(keyValueTypes[1]));
+        return *LogicalType::MAP(convertDuckDBType(keyValueTypes[0]),
+            convertDuckDBType(keyValueTypes[1]));
     } else if (typeStr.ends_with(']')) {
         auto leftBracketPos = typeStr.find('[');
         auto rightBracketPos = typeStr.find(']');

--- a/extension/duckdb_scanner/src/duckdb_type_converter.cpp
+++ b/extension/duckdb_scanner/src/duckdb_type_converter.cpp
@@ -65,8 +65,8 @@ common::LogicalType DuckDBTypeConverter::convertDuckDBType(std::string typeStr) 
         return *LogicalType::STRUCT(parseStructTypeInfo(typeStr));
     } else if (typeStr.starts_with("UNION")) {
         auto unionFields = parseStructTypeInfo(typeStr);
-        auto unionTagField = StructField(UnionType::TAG_FIELD_NAME,
-            std::make_unique<LogicalType>(UnionType::TAG_FIELD_TYPE));
+        auto unionTagField = StructField(
+            UnionType::TAG_FIELD_NAME, std::make_unique<LogicalType>(UnionType::TAG_FIELD_TYPE));
         unionFields.insert(unionFields.begin(), std::move(unionTagField));
         return *LogicalType::UNION(std::move(unionFields));
     } else if (typeStr.starts_with("MAP")) {
@@ -74,8 +74,16 @@ common::LogicalType DuckDBTypeConverter::convertDuckDBType(std::string typeStr) 
         auto rightBracketPos = typeStr.find_last_of(')');
         auto mapTypeStr = typeStr.substr(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1);
         auto keyValueTypes = StringUtils::splitComma(mapTypeStr);
-        return *LogicalType::MAP(convertDuckDBType(keyValueTypes[0]),
-            convertDuckDBType(keyValueTypes[1]));
+        return *LogicalType::MAP(
+            convertDuckDBType(keyValueTypes[0]), convertDuckDBType(keyValueTypes[1]));
+    } else if (typeStr.ends_with(']')) {
+        auto leftBracketPos = typeStr.find('[');
+        auto rightBracketPos = typeStr.find(']');
+        auto numValuesInList = std::strtoll(
+            typeStr.substr(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1).c_str(),
+            nullptr, 0);
+        auto innerType = convertDuckDBType(typeStr.substr(0, leftBracketPos));
+        return *LogicalType::ARRAY(innerType.copy(), numValuesInList);
     }
     throw BinderException{stringFormat("Unsupported duckdb type: {}.", typeStr)};
 }

--- a/extension/duckdb_scanner/test/test_files/duckdb_scanner.test
+++ b/extension/duckdb_scanner/test/test_files/duckdb_scanner.test
@@ -10,14 +10,14 @@
 ---- ok
 -STATEMENT LOAD FROM tinysnb.person RETURN *;
 ---- 8
-0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
-10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18
-2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|[[8,9],[9,10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
-3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13
-5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14
-7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15
-8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16
-9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96,54,86,92]
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18|[77,64,100,54]
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|[[8,9],[9,10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|[98,42,93,88]
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13|[91,75,21,95]
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14|[76,88,99,89]
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96,59,65,88]
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80,78,34,83]
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43,83,67,43]
 -STATEMENT LOAD FROM tinysnb.organisation RETURN *;
 ---- 3
 1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000|{revenue: 138, "location": ['toronto','montr,eal'], stock: {price: [96,56], volume: 1000}}|3.12


### PR DESCRIPTION
This PR supports scanning from duckdb array column.
The physical layout of duckdb array vector is a little different from kuzu's array vector. They don't keep a vector buffer for list entries, since the number of values in each array is fixed.
