### PR TITLE
Fix extension ci

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,12 +194,6 @@ if (MSVC AND (NOT BUILD_EXTENSIONS EQUAL ""))
     set(BUILD_KUZU TRUE)
 endif ()
 
-if(${BUILD_KUZU})
-add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
-add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.2.5")
-
-include_directories(src/include)
 include_directories(third_party/antlr4_cypher/include)
 include_directories(third_party/antlr4_runtime/src)
 include_directories(third_party/fast_float/include)
@@ -218,6 +212,14 @@ include_directories(third_party/httplib)
 include_directories(third_party/pcg)
 
 add_subdirectory(third_party)
+
+if(${BUILD_KUZU})
+add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
+add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.2.5")
+
+include_directories(src/include)
+
 add_subdirectory(src)
 if (${BUILD_TESTS})
     add_definitions(-DTEST_FILES_DIR="test/test_files")

--- a/extension/CMakeLists.txt
+++ b/extension/CMakeLists.txt
@@ -11,7 +11,11 @@ if ("duckdb_scanner" IN_LIST BUILD_EXTENSIONS)
 endif()
 
 if ("postgres_scanner" IN_LIST BUILD_EXTENSIONS)
-    add_subdirectory(postgres_scanner)
+    if(NOT __32BIT__)
+        # DuckDB does not officially support 32-bit builds, so we disable the
+        # extension for 32-bit builds
+        add_subdirectory(postgres_scanner)
+    endif()
 endif()
 
 if (${BUILD_EXTENSION_TESTS})

--- a/extension/httpfs/CMakeLists.txt
+++ b/extension/httpfs/CMakeLists.txt
@@ -9,7 +9,6 @@ add_compile_definitions(CPPHTTPLIB_OPENSSL_SUPPORT)
 include_directories(
         ${PROJECT_SOURCE_DIR}/src/include
         ${PROJECT_SOURCE_DIR}/third_party/httplib
-        ${PROJECT_SOURCE_DIR}/third_party/mbedtls/include
         src/include)
 
 add_library(httpfs


### PR DESCRIPTION
Since httpfs extension uses mbedtls as a third-party dependency, we have to build medtls when building extensions.