### PR TITLE
Handle exceptions when flushing WAL

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -292,7 +292,9 @@ void LocalFileSystem::syncFile(const FileInfo& fileInfo) const {
 #if defined(_WIN32)
     // Note that `FlushFileBuffers` returns 0 when fail, while `fsync` returns 0 when succeed.
     if (FlushFileBuffers((HANDLE)localFileInfo.handle) == 0) {
-        throw IOException(stringFormat("Failed to sync file {}.", fileInfo.path));
+        auto error = GetLastError();
+        throw IOException(stringFormat("Failed to sync file {}. Error {}: {}", fileInfo.path, error,
+            std::system_category().message(error)));
     }
 #else
     if (fsync(localFileInfo.fd) != 0) {

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -2,11 +2,13 @@
 
 #include <fcntl.h>
 
+#include "common/exception/io.h"
 #include "common/file_system/file_info.h"
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/buffered_file.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
+#include "spdlog/spdlog.h"
 #include "storage/storage_utils.h"
 
 using namespace kuzu::common;
@@ -31,7 +33,11 @@ WAL::WAL(const std::string& directory, bool readOnly, BufferManager& bufferManag
 }
 
 WAL::~WAL() {
-    flushAllPages();
+    try {
+        flushAllPages();
+    } catch (IOException& e) {
+        spdlog::error("Failed to flush WAL: {}", e.what());
+    }
 }
 
 page_idx_t WAL::logPageUpdateRecord(DBFileID dbFileID, page_idx_t pageIdxInOriginalFile) {

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -158,9 +158,8 @@ mod tests {
 
     #[test]
     fn create_database_failure() {
-        let result: Error = Database::new("", SystemConfig::default())
-            .expect_err("An empty string should not be a valid database path!")
-            .into();
+        Database::new("", SystemConfig::default())
+            .expect_err("An empty string should not be a valid database path!");
     }
 
     #[test]


### PR DESCRIPTION
Unhandled exceptions in the Database destructor can't be easily handled in the rust API, and even in the C++ API it may cause terminate to be called, which is not very user-friendly and will bypass other error reporting mechanisms.

I'm not entirely sure why this is only occurring in the one rust test on windows.
Perhaps `fsync` doesn't produce an error if run on a file opened read-only, while `FlushFileBuffers` does, explaining why it only happens on Windows, but there is a similar test for the C API: `CAPIDatabaseTest.CreationReadOnly`, which doesn't have the same problem. But at the least, this will fix CI and make the issue easier to debug and we can open an issue for the rest.

I also removed some unnecessary code from a different rust test which had been producing warnings.