### PR TITLE
Move tests into system temporary directory

### DIFF
--- a/test/include/graph_test/base_graph_test.h
+++ b/test/include/graph_test/base_graph_test.h
@@ -120,10 +120,7 @@ protected:
     }
 
 private:
-    void setDatabasePath() {
-        databasePath = TestHelper::appendKuzuRootPath(
-            TestHelper::TMP_TEST_DIR + getTestGroupAndName() + TestHelper::getMillisecondsSuffix());
-    }
+    void setDatabasePath() { databasePath = TestHelper::getTempDir(getTestGroupAndName()); }
 
 public:
     std::string databasePath;

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -129,8 +129,7 @@ private:
         const std::string& testCaseName);
     TestStatement* addNewStatement(std::string& name);
 
-    const std::string exportDBPath = TestHelper::appendKuzuRootPath(
-        TestHelper::TMP_TEST_DIR + std::string("export_db") + TestHelper::getMillisecondsSuffix());
+    const std::string exportDBPath = TestHelper::getTempDir("export_db");
     // Any value here will be replaced inside the .test files
     // in queries/statements and expected error message.
     // Example: ${KUZU_ROOT_DIRECTORY} will be replaced by

--- a/test/runner/cleanup_test.cpp
+++ b/test/runner/cleanup_test.cpp
@@ -1,29 +1,11 @@
-#include "graph_test/graph_test.h"
+#include "test_helper/test_helper.h"
 
 using namespace kuzu::testing;
 using namespace kuzu::common;
 
-void deleteMatchingDir(const std::string& dirPath, const std::string& match) {
-    for (const auto& entry : std::filesystem::directory_iterator(dirPath)) {
-        if (entry.path().filename().string().find(match) != std::string::npos) {
-            std::filesystem::remove_all(entry.path().string());
-        }
-    }
-}
-
 int main(int argc, char** argv) {
-    std::vector<std::string> tempDirs = {TestHelper::PARQUET_TEMP_DATASET_PATH,
-        TestHelper::TMP_TEST_DIR};
     if (argc > 1 && std::string(argv[1]) == "--gtest_list_tests") {
-        for (const auto& tempDir : tempDirs) {
-            // path = test/unittest_temp_
-            std::filesystem::path path = tempDir;
-            // dirToCheck = test
-            std::string dirToCheck = path.parent_path().string();
-            // dirPatternToRemove = unittest_temp_
-            std::string dirPatternToRemove = path.filename().string();
-            deleteMatchingDir(TestHelper::appendKuzuRootPath(dirToCheck), dirPatternToRemove);
-        }
+        std::filesystem::remove_all(TestHelper::getTempDir());
     }
     return 0;
 }

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -64,9 +64,7 @@ private:
     std::string generateParquetTempDatasetPath() {
         std::string datasetName = dataset;
         std::replace(datasetName.begin(), datasetName.end(), '/', '_');
-        return TestHelper::appendKuzuRootPath(TestHelper::PARQUET_TEMP_DATASET_PATH + datasetName +
-                                              "_" + getTestGroupAndName() + "_" +
-                                              TestHelper::getMillisecondsSuffix());
+        return TestHelper::getTempDir(datasetName + "_parquet_" + getTestGroupAndName());
     }
 };
 

--- a/test/test_runner/csv_to_parquet_converter.cpp
+++ b/test/test_runner/csv_to_parquet_converter.cpp
@@ -132,10 +132,8 @@ void CSVToParquetConverter::createCopyFile() {
         throw TestException(
             stringFormat("Error opening file: {}, errno: {}.", parquetCopyFile, errno));
     }
-    std::string kuzuRootPath = KUZU_ROOT_DIRECTORY + std::string("/");
     for (auto table : tables) {
-        auto cmd = stringFormat("COPY {} FROM \"{}\";", table->name,
-            table->parquetFilePath.substr(kuzuRootPath.length()));
+        auto cmd = stringFormat("COPY {} FROM \"{}\";", table->name, table->parquetFilePath);
         outfile << cmd << '\n';
     }
 }
@@ -168,9 +166,7 @@ void CSVToParquetConverter::convertCSVDatasetToParquet() {
     createCopyFile();
 
     systemConfig = std::make_unique<main::SystemConfig>(bufferPoolSize);
-    std::string tempDatabasePath = TestHelper::appendKuzuRootPath(
-        std::string(TestHelper::TMP_TEST_DIR) + "csv_to_parquet_converter_" +
-        TestHelper::getMillisecondsSuffix());
+    std::string tempDatabasePath = TestHelper::getTempDir("csv_to_parquet_converter");
     tempDb = std::make_unique<main::Database>(tempDatabasePath, *systemConfig);
     tempConn = std::make_unique<main::Connection>(tempDb.get());
 


### PR DESCRIPTION
The recent addition of calling fsync when flushing the WAL file has slowed down tests somewhat (on my system it went from ~50s to ~66s to run the test suite). And while before using a high filesystem commit time would actually mean that nothing needs to be written to the disk when tests are running since they are removed before they are written, fsync bypasses that and it ends up writing about 3.5GB of additional data to the disk each time the test runs.
This moves the temporary test directories into `/tmp/kuzu` (or equivalent on other systems, it uses `std::filesystem::temp_directory_path`).