### PR TITLE
Fix cleaning up the test directory on windows CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -370,7 +370,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-    
+
       # For `napi.h` header.
       - name: Ensure Node.js dependencies
         run: npm install --include=dev

--- a/test/include/test_helper/test_helper.h
+++ b/test/include/test_helper/test_helper.h
@@ -50,7 +50,12 @@ public:
     static std::string getMillisecondsSuffix();
 
     inline static std::filesystem::path getTempDir() {
-        return std::filesystem::temp_directory_path() / "kuzu";
+        auto tempDir = std::getenv("RUNNER_TEMP");
+        if (tempDir != nullptr) {
+            return std::filesystem::path(tempDir) / "kuzu";
+        } else {
+            return std::filesystem::temp_directory_path() / "kuzu";
+        }
     }
 
     inline static std::string getTempDir(const std::string& name) {


### PR DESCRIPTION
The windows and macos CI run multiple tests in different build directories as the same user. Since #3290 this means that the tests use the same temporary directory, and the cleanup_test may remove tests from other runs. This makes the test suite use the [RUNNER_TEMP](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables) environment variable for the test directory if available.