### PR TITLE
Fix lockInfo for access mode in the same process

### DIFF
--- a/src/common/file_system/virtual_file_system.cpp
+++ b/src/common/file_system/virtual_file_system.cpp
@@ -1,8 +1,15 @@
 #include "common/file_system/virtual_file_system.h"
 
 #include "common/assert.h"
+#include "common/exception/io.h"
 #include "common/file_system/local_file_system.h"
 #include "main/client_context.h"
+
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <unistd.h>
+#endif
 
 namespace kuzu {
 namespace common {
@@ -18,6 +25,96 @@ void VirtualFileSystem::registerFileSystem(std::unique_ptr<FileSystem> fileSyste
 std::unique_ptr<FileInfo> VirtualFileSystem::openFile(const std::string& path, int flags,
     main::ClientContext* context, FileLockType lockType) {
     return findFileSystem(path)->openFile(path, flags, context, lockType);
+}
+
+void VirtualFileSystem::recordLockInfo(const std::string & path, int flags, FileLockType lockType){
+    std::unique_ptr<FileInfo> fileInfo;
+    while(fileInfo == nullptr){
+        try{
+            fileInfo = openFile(path, flags, nullptr /* clientContext */, FileLockType::WRITE_LOCK);
+        } catch (...){
+            //open until we get the write lock
+        }
+    }
+    int pid = getpid();
+    auto fileSize = fileInfo->getFileSize();
+    fileInfo->writeFile(reinterpret_cast<const uint8_t*>(&pid), sizeof(pid), fileSize /* offset */);
+    fileInfo->writeFile(reinterpret_cast<const uint8_t*>(&lockType), sizeof(lockType),
+        fileSize+sizeof(pid) /* offset */);
+}
+
+void VirtualFileSystem::checkLockInfoInSameProcess(std::string& path, int flags,
+    FileLockType tryLockType) {
+    std::unique_ptr<FileInfo> fileInfo;
+    while(fileInfo == nullptr){
+        try{
+            fileInfo = openFile(path, flags, nullptr /* clientContext */, FileLockType::READ_LOCK);
+        } catch (...){
+            //open until we get the read lock? or we just hold no lock?
+        }
+    }
+    auto fileSize = fileInfo->getFileSize();
+    if (fileSize == 0) {
+        return;
+    }
+    // try to find record, and check lockType
+    uint64_t readSize = 0;
+    while (readSize<fileSize) {
+        int pid;
+        fileInfo->readFromFile(reinterpret_cast<uint8_t*>(&pid), sizeof(pid), readSize);
+        if (pid != getpid()) {
+            readSize += sizeof(int) + sizeof(FileLockType);
+            continue;
+        }
+        FileLockType lockType;
+        fileInfo->readFromFile(reinterpret_cast<uint8_t*>(&lockType), sizeof(lockType), readSize+sizeof(pid));
+        if(lockType==FileLockType::NO_LOCK) {
+            readSize += sizeof(int) + sizeof(FileLockType);
+            continue;
+        }
+        if (!(tryLockType == FileLockType::READ_LOCK && lockType == FileLockType::READ_LOCK)) {
+            throw IOException("Could not set lock on file in the same process: " + path);
+        }
+    }
+}
+
+void VirtualFileSystem::deleteCurrentPidLockInfo(std::string& path, int flags){
+    std::unique_ptr<FileInfo> fileInfo;
+    while(fileInfo == nullptr){
+        try{
+            fileInfo = openFile(path, flags, nullptr /* clientContext */, FileLockType::WRITE_LOCK);
+        } catch (...){
+            //open until we get the write lock
+        }
+    }
+    auto fileSize = fileInfo->getFileSize();
+    if (fileSize == 0) {
+        return;
+    }
+    // delete current pid
+    std::unordered_map<int,FileLockType> activePids;
+    uint64_t readSize = 0;
+    while (readSize<fileSize){
+        int pid;
+        fileInfo->readFromFile(reinterpret_cast<uint8_t*>(&pid), sizeof(pid), readSize);
+        if(pid==getpid()){
+            readSize += sizeof(int) + sizeof(FileLockType);
+            continue;
+        }
+        FileLockType lockType;
+        fileInfo->readFromFile(reinterpret_cast<uint8_t*>(&lockType), sizeof(lockType), readSize+sizeof(pid));
+        if(lockType!=FileLockType::NO_LOCK) {
+            activePids.insert({pid,lockType});
+        }
+        readSize += sizeof(int) + sizeof(FileLockType);
+    }
+    fileInfo->truncate(0);
+    readSize = 0;
+    for (auto &pid : activePids) {
+        fileInfo->writeFile(reinterpret_cast<const uint8_t*>(&pid.first), sizeof(pid.first), readSize);
+        fileInfo->writeFile(reinterpret_cast<const uint8_t*>(&pid.second), sizeof(pid.second), readSize+sizeof(pid.first));
+        readSize+=sizeof(pid.first)+sizeof(pid.second);
+    }
 }
 
 std::vector<std::string> VirtualFileSystem::glob(main::ClientContext* context,

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -97,6 +97,7 @@ struct StorageConstants {
     static constexpr char DATA_FILE_NAME[] = "data.kz";
     static constexpr char METADATA_FILE_NAME[] = "metadata.kz";
     static constexpr char LOCK_FILE_NAME[] = ".lock";
+    static constexpr char LOCK_FILE_INFO_NAME[] = "lock.info";
 
     // The number of pages that we add at one time when we need to grow a file.
     static constexpr uint64_t PAGE_GROUP_SIZE_LOG2 = 10;

--- a/src/include/common/file_system/virtual_file_system.h
+++ b/src/include/common/file_system/virtual_file_system.h
@@ -34,6 +34,13 @@ public:
 
     void syncFile(const FileInfo& fileInfo) const override;
 
+    void recordLockInfo(const std::string & path, int flags, FileLockType lockType);
+
+    void checkLockInfoInSameProcess(std::string& fullPath, int flags,
+        FileLockType tryLockType);
+
+    void deleteCurrentPidLockInfo(std::string& path, int flags);
+
 protected:
     void readFromFile(FileInfo& fileInfo, void* buffer, uint64_t numBytes,
         uint64_t position) const override;

--- a/src/include/common/file_system/virtual_file_system.h
+++ b/src/include/common/file_system/virtual_file_system.h
@@ -34,10 +34,9 @@ public:
 
     void syncFile(const FileInfo& fileInfo) const override;
 
-    void recordLockInfo(const std::string & path, int flags, FileLockType lockType);
+    void recordLockInfo(const std::string& path, int flags, FileLockType lockType);
 
-    void checkLockInfoInSameProcess(std::string& fullPath, int flags,
-        FileLockType tryLockType);
+    void checkLockInfoInSameProcess(std::string& fullPath, int flags, FileLockType tryLockType);
 
     void deleteCurrentPidLockInfo(std::string& path, int flags);
 

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -119,6 +119,9 @@ public:
 
 private:
     void openLockFile();
+    void recordLockInfo();
+    void checkLockInfoInSameProcess();
+    void clearLockInfo();
     void initDBDirAndCoreFilesIfNecessary();
     static void initLoggers();
     static void dropLoggers();

--- a/src/include/storage/storage_utils.h
+++ b/src/include/storage/storage_utils.h
@@ -150,6 +150,11 @@ public:
         return vfs->joinPath(directory, common::StorageConstants::LOCK_FILE_NAME);
     }
 
+    static inline std::string getLockInfoFilePath(common::VirtualFileSystem* vfs,
+        const std::string& directory) {
+        return vfs->joinPath(directory, common::StorageConstants::LOCK_FILE_INFO_NAME);
+    }
+
     // Note: This is a relatively slow function because of division and mod and making std::pair.
     // It is not meant to be used in performance critical code path.
     static inline std::pair<uint64_t, uint64_t> getQuotientRemainder(uint64_t i, uint64_t divisor) {

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -87,8 +87,8 @@ Database::Database(std::string_view databasePath, SystemConfig systemConfig)
     memoryManager = std::make_unique<MemoryManager>(bufferManager.get(), vfs.get());
     queryProcessor = std::make_unique<processor::QueryProcessor>(this->systemConfig.maxNumThreads);
     initDBDirAndCoreFilesIfNecessary();
-    wal = std::make_unique<WAL>(this->databasePath, systemConfig.readOnly, *bufferManager,
-        vfs.get());
+    wal =
+        std::make_unique<WAL>(this->databasePath, systemConfig.readOnly, *bufferManager, vfs.get());
     recoverIfNecessary();
     catalog = std::make_unique<catalog::Catalog>(wal.get(), vfs.get());
     storageManager = std::make_unique<storage::StorageManager>(systemConfig.readOnly, *catalog,
@@ -96,7 +96,7 @@ Database::Database(std::string_view databasePath, SystemConfig systemConfig)
     transactionManager = std::make_unique<transaction::TransactionManager>(*wal);
     extensionOptions = std::make_unique<extension::ExtensionOptions>();
     databaseManager = std::make_unique<DatabaseManager>();
-    //record file lock info until we can open a database successfully
+    // record file lock info until we can open a database successfully
     recordLockInfo();
 }
 
@@ -154,25 +154,28 @@ void Database::openLockFile() {
     lockFile = vfs->openFile(lockFilePath, flags, nullptr /* clientContext */, lock);
 }
 
-void Database::recordLockInfo(){
+void Database::recordLockInfo() {
     auto lockFilePath = StorageUtils::getLockInfoFilePath(vfs.get(), databasePath);
     int flags = O_RDWR;
-    if(!vfs->fileOrPathExists(lockFilePath)) flags |= O_CREAT;
+    if (!vfs->fileOrPathExists(lockFilePath))
+        flags |= O_CREAT;
     auto lock = systemConfig.readOnly ? FileLockType::READ_LOCK : FileLockType::WRITE_LOCK;
     vfs->recordLockInfo(lockFilePath, flags, lock);
 }
 
-void Database::checkLockInfoInSameProcess(){
+void Database::checkLockInfoInSameProcess() {
     auto lockFilePath = StorageUtils::getLockInfoFilePath(vfs.get(), databasePath);
-    if(!vfs->fileOrPathExists(lockFilePath)) return;
+    if (!vfs->fileOrPathExists(lockFilePath))
+        return;
     auto lock = systemConfig.readOnly ? FileLockType::READ_LOCK : FileLockType::WRITE_LOCK;
     vfs->checkLockInfoInSameProcess(lockFilePath, O_RDONLY, lock);
 }
 
-void Database::clearLockInfo(){
+void Database::clearLockInfo() {
     auto lockFilePath = StorageUtils::getLockInfoFilePath(vfs.get(), databasePath);
-    if(!vfs->fileOrPathExists(lockFilePath)) return;
-    vfs->deleteCurrentPidLockInfo(lockFilePath,O_RDWR);
+    if (!vfs->fileOrPathExists(lockFilePath))
+        return;
+    vfs->deleteCurrentPidLockInfo(lockFilePath, O_RDWR);
 }
 
 void Database::initDBDirAndCoreFilesIfNecessary() {

--- a/test/main/system_config_test.cpp
+++ b/test/main/system_config_test.cpp
@@ -13,6 +13,7 @@ void assertQuery(QueryResult& result) {
 }
 
 TEST_F(SystemConfigTest, testAccessMode) {
+    database.reset();
     systemConfig->readOnly = false;
     auto db = std::make_unique<Database>(databasePath, *systemConfig);
     auto con = std::make_unique<Connection>(db.get());
@@ -31,32 +32,38 @@ TEST_F(SystemConfigTest, testAccessMode) {
 }
 
 TEST_F(SystemConfigTest, testMaxDBSize) {
+    database.reset();
     systemConfig->maxDBSize = 1024;
+    std::unique_ptr<Database> db;
     try {
-        auto db = std::make_unique<Database>(databasePath, *systemConfig);
+        db = std::make_unique<Database>(databasePath, *systemConfig);
     } catch (BufferManagerException e) {
         ASSERT_EQ(std::string(e.what()),
             "Buffer manager exception: The given max db size should be at least 4194304 bytes.");
     }
+    db.reset();
     systemConfig->maxDBSize = 4194305;
     try {
-        auto db = std::make_unique<Database>(databasePath, *systemConfig);
+        db = std::make_unique<Database>(databasePath, *systemConfig);
     } catch (BufferManagerException e) {
         ASSERT_EQ(std::string(e.what()),
             "Buffer manager exception: The given max db size should be a power of 2.");
     }
     systemConfig->maxDBSize = 4194304;
+    db.reset();
     try {
-        auto db = std::make_unique<Database>(databasePath, *systemConfig);
+        db = std::make_unique<Database>(databasePath, *systemConfig);
     } catch (BufferManagerException e) {
         ASSERT_EQ(std::string(e.what()),
             "Buffer manager exception: No more frame groups can be added to the allocator.");
     }
+    db.reset();
     systemConfig->maxDBSize = 1ull << 30;
-    EXPECT_NO_THROW(auto db = std::make_unique<Database>(databasePath, *systemConfig));
+    EXPECT_NO_THROW(db = std::make_unique<Database>(databasePath, *systemConfig));
 }
 
 TEST_F(SystemConfigTest, testBufferPoolSize) {
+    database.reset();
     systemConfig->bufferPoolSize = 1024;
     try {
         auto db = std::make_unique<Database>(databasePath, *systemConfig);


### PR DESCRIPTION
see #3292 

`fcntl` can not get the existing lock type in the same process. To solve it, I give the following solution. But I do not think it is a good idea.

Overall, we write the `pid` and `lockType` for each database object in an additional `lock.info` file. Every time when we open a database, either in the same process or not, we first require `read lock` for the `lock.info` file, checking if there exists the same process and it does not have conflicts with the existing lock type. Then, after opening the database successfully, we require the `write lock` for the `lock.info` file and then write the corresponding `pid` and `lockType` . Once we close the database, we require the   `write lock` for the `lock.info` file and then delete the corresponding `pid` and `lockType` . 

issue: do not know the best time to delete the information of lock info. Considering the following scenario. After doing `db1.reset()`, we will clear all corresponding `pid` and `lockType` in the `lock.info` file.

> SystemConfig systemConfig;
> systemConfig.readOnly=true;
> auto db1 = std::make_unique<Database>("test", systemConfig);
> auto db2 = std::make_unique<Database>("test", systemConfig);
> auto db3 = std::make_unique<Database>("test", systemConfig);
> db1.reset();
> systemConfig.readOnly=false;
> auto db4 = std::make_unique<Database>("test", systemConfig);
