### PR TITLE
Add check for duplicate map keys

### DIFF
--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -5,8 +5,8 @@
 namespace kuzu {
 namespace common {
 
-std::string TypeUtils::entryToString(
-    const LogicalType& dataType, const uint8_t* value, ValueVector* vector) {
+std::string TypeUtils::entryToString(const LogicalType& dataType, const uint8_t* value,
+    ValueVector* vector) {
     auto valueVector = reinterpret_cast<ValueVector*>(vector);
     switch (dataType.getLogicalTypeID()) {
     case LogicalTypeID::BOOL:
@@ -63,8 +63,8 @@ std::string TypeUtils::entryToString(
     case LogicalTypeID::UUID:
         return TypeUtils::toString(*reinterpret_cast<const ku_uuid_t*>(value));
     case LogicalTypeID::NODE:
-        return TypeUtils::nodeToString(
-            *reinterpret_cast<const struct_entry_t*>(value), valueVector);
+        return TypeUtils::nodeToString(*reinterpret_cast<const struct_entry_t*>(value),
+            valueVector);
     case LogicalTypeID::REL:
         return TypeUtils::relToString(*reinterpret_cast<const struct_entry_t*>(value), valueVector);
     default:
@@ -76,8 +76,8 @@ static std::string entryToStringWithPos(sel_t pos, ValueVector* vector) {
     if (vector->isNull(pos)) {
         return "";
     }
-    return TypeUtils::entryToString(
-        vector->dataType, vector->getData() + vector->getNumBytesPerValue() * pos, vector);
+    return TypeUtils::entryToString(vector->dataType,
+        vector->getData() + vector->getNumBytesPerValue() * pos, vector);
 }
 
 template<>
@@ -162,8 +162,8 @@ std::string TypeUtils::toString(const list_entry_t& val, void* valueVector) {
     return result;
 }
 
-static std::string getMapEntryStr(
-    sel_t pos, ValueVector* dataVector, ValueVector* keyVector, ValueVector* valVector) {
+static std::string getMapEntryStr(sel_t pos, ValueVector* dataVector, ValueVector* keyVector,
+    ValueVector* valVector) {
     if (dataVector->isNull(pos)) {
         return "";
     }

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -10,10 +10,66 @@
 #include "common/types/blob.h"
 #include "common/types/ku_string.h"
 #include "common/types/uuid.h"
+#include "function/hash/hash_functions.h"
 #include "storage/storage_utils.h"
 
 namespace kuzu {
 namespace common {
+
+bool Value::operator==(const Value& rhs) const {
+    if (*dataType != *rhs.dataType || isNull_ != rhs.isNull_) {
+        return false;
+    }
+    switch (dataType->getPhysicalType()) {
+    case PhysicalTypeID::BOOL:
+        return val.booleanVal == rhs.val.booleanVal;
+    case PhysicalTypeID::INT128:
+        return val.int128Val == rhs.val.int128Val;
+    case PhysicalTypeID::INT64:
+        return val.int64Val == rhs.val.int64Val;
+    case PhysicalTypeID::INT32:
+        return val.int32Val == rhs.val.int32Val;
+    case PhysicalTypeID::INT16:
+        return val.int16Val == rhs.val.int16Val;
+    case PhysicalTypeID::INT8:
+        return val.int8Val == rhs.val.int8Val;
+    case PhysicalTypeID::UINT64:
+        return val.uint64Val == rhs.val.uint64Val;
+    case PhysicalTypeID::UINT32:
+        return val.uint32Val == rhs.val.uint32Val;
+    case PhysicalTypeID::UINT16:
+        return val.uint16Val == rhs.val.uint16Val;
+    case PhysicalTypeID::UINT8:
+        return val.uint8Val == rhs.val.uint8Val;
+    case PhysicalTypeID::DOUBLE:
+        return val.doubleVal == rhs.val.doubleVal;
+    case PhysicalTypeID::FLOAT:
+        return val.floatVal == rhs.val.floatVal;
+    case PhysicalTypeID::POINTER:
+        return val.pointer == rhs.val.pointer;
+    case PhysicalTypeID::INTERVAL:
+        return val.intervalVal == rhs.val.intervalVal;
+    case PhysicalTypeID::INTERNAL_ID:
+        return val.internalIDVal == rhs.val.internalIDVal;
+    case PhysicalTypeID::STRING:
+        return strVal == rhs.strVal;
+    case PhysicalTypeID::ARRAY:
+    case PhysicalTypeID::LIST:
+    case PhysicalTypeID::STRUCT: {
+        if (childrenSize != rhs.childrenSize) {
+            return false;
+        }
+        for (auto i = 0u; i < childrenSize; ++i) {
+            if (*children[i] != *rhs.children[i]) {
+                return false;
+            }
+        }
+        return true;
+    }
+    default:
+        KU_UNREACHABLE;
+    }
+}
 
 void Value::setDataType(const LogicalType& dataType_) {
     KU_ASSERT(dataType->getLogicalTypeID() == LogicalTypeID::ANY);
@@ -269,7 +325,7 @@ Value::Value(const Value& other) : isNull_{other.isNull_} {
     childrenSize = other.childrenSize;
 }
 
-void Value::copyValueFrom(const uint8_t* value) {
+void Value::copyFromRowLayout(const uint8_t* value) {
     switch (dataType->getLogicalTypeID()) {
     case LogicalTypeID::SERIAL:
     case LogicalTypeID::TIMESTAMP_NS:
@@ -332,10 +388,10 @@ void Value::copyValueFrom(const uint8_t* value) {
     } break;
     case LogicalTypeID::MAP:
     case LogicalTypeID::LIST: {
-        copyFromList(*(ku_list_t*)value, *ListType::getChildType(dataType.get()));
+        copyFromRowLayoutList(*(ku_list_t*)value, *ListType::getChildType(dataType.get()));
     } break;
     case LogicalTypeID::ARRAY: {
-        copyFromList(*(ku_list_t*)value, *ArrayType::getChildType(dataType.get()));
+        copyFromRowLayoutList(*(ku_list_t*)value, *ArrayType::getChildType(dataType.get()));
     } break;
     case LogicalTypeID::UNION: {
         copyFromUnion(value);
@@ -345,10 +401,66 @@ void Value::copyValueFrom(const uint8_t* value) {
     case LogicalTypeID::RECURSIVE_REL:
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::RDF_VARIANT: {
-        copyFromStruct(value);
+        copyFromRowLayoutStruct(value);
     } break;
     case LogicalTypeID::POINTER: {
         val.pointer = *((uint8_t**)value);
+    } break;
+    default:
+        KU_UNREACHABLE;
+    }
+}
+
+void Value::copyFromColLayout(const uint8_t* value, ValueVector* vector) {
+    switch (dataType->getPhysicalType()) {
+    case PhysicalTypeID::INT64: {
+        val.int64Val = *((int64_t*)value);
+    } break;
+    case PhysicalTypeID::INT32: {
+        val.int32Val = *((int32_t*)value);
+    } break;
+    case PhysicalTypeID::INT16: {
+        val.int16Val = *((int16_t*)value);
+    } break;
+    case PhysicalTypeID::INT8: {
+        val.int8Val = *((int8_t*)value);
+    } break;
+    case PhysicalTypeID::UINT64: {
+        val.uint64Val = *((uint64_t*)value);
+    } break;
+    case PhysicalTypeID::UINT32: {
+        val.uint32Val = *((uint32_t*)value);
+    } break;
+    case PhysicalTypeID::UINT16: {
+        val.uint16Val = *((uint16_t*)value);
+    } break;
+    case PhysicalTypeID::UINT8: {
+        val.uint8Val = *((uint8_t*)value);
+    } break;
+    case PhysicalTypeID::INT128: {
+        val.int128Val = *((int128_t*)value);
+    } break;
+    case PhysicalTypeID::BOOL: {
+        val.booleanVal = *((bool*)value);
+    } break;
+    case PhysicalTypeID::DOUBLE: {
+        val.doubleVal = *((double*)value);
+    } break;
+    case PhysicalTypeID::FLOAT: {
+        val.floatVal = *((float*)value);
+    } break;
+    case PhysicalTypeID::INTERVAL: {
+        val.intervalVal = *((interval_t*)value);
+    } break;
+    case PhysicalTypeID::STRING: {
+        strVal = ((ku_string_t*)value)->getAsString();
+    } break;
+    case PhysicalTypeID::ARRAY:
+    case PhysicalTypeID::LIST: {
+        copyFromColLayoutList(*(list_entry_t*)value, vector);
+    } break;
+    case PhysicalTypeID::STRUCT: {
+        copyFromColLayoutStruct(*(struct_entry_t*)value, vector);
     } break;
     default:
         KU_UNREACHABLE;
@@ -514,14 +626,18 @@ Value::Value(const LogicalType& dataType_) : isNull_{true} {
     dataType = dataType_.copy();
 }
 
-void Value::copyFromList(ku_list_t& list, const LogicalType& childType) {
-    if (list.size > children.size()) {
-        children.reserve(list.size);
-        for (auto i = children.size(); i < list.size; ++i) {
+void Value::resizeChildrenVector(uint64_t size, const LogicalType& childType) {
+    if (size > children.size()) {
+        children.reserve(size);
+        for (auto i = children.size(); i < size; ++i) {
             children.push_back(std::make_unique<Value>(createDefaultValue(childType)));
         }
     }
-    childrenSize = list.size;
+    childrenSize = size;
+}
+
+void Value::copyFromRowLayoutList(const ku_list_t& list, const LogicalType& childType) {
+    resizeChildrenVector(list.size, childType);
     auto numBytesPerElement = storage::StorageUtils::getDataTypeSize(childType);
     auto listNullBytes = reinterpret_cast<uint8_t*>(list.overflowPtr);
     auto numBytesForNullValues = NullBuffer::getNumBytesForNullValues(list.size);
@@ -532,13 +648,26 @@ void Value::copyFromList(ku_list_t& list, const LogicalType& childType) {
             childValue->setNull(true);
         } else {
             childValue->setNull(false);
-            childValue->copyValueFrom(listValues);
+            childValue->copyFromRowLayout(listValues);
         }
         listValues += numBytesPerElement;
     }
 }
 
-void Value::copyFromStruct(const uint8_t* kuStruct) {
+void Value::copyFromColLayoutList(const list_entry_t& listEntry, ValueVector* vec) {
+    auto dataVec = ListVector::getDataVector(vec);
+    resizeChildrenVector(listEntry.size, dataVec->dataType);
+    for (auto i = 0u; i < listEntry.size; i++) {
+        auto childValue = children[i].get();
+        childValue->setNull(dataVec->isNull(listEntry.offset + i));
+        if (!childValue->isNull()) {
+            childValue->copyFromColLayout(
+                ListVector::getListValuesWithOffset(vec, listEntry, i), dataVec);
+        }
+    }
+}
+
+void Value::copyFromRowLayoutStruct(const uint8_t* kuStruct) {
     auto numFields = childrenSize;
     auto structNullValues = kuStruct;
     auto structValues = structNullValues + NullBuffer::getNumBytesForNullValues(numFields);
@@ -548,9 +677,21 @@ void Value::copyFromStruct(const uint8_t* kuStruct) {
             childValue->setNull(true);
         } else {
             childValue->setNull(false);
-            childValue->copyValueFrom(structValues);
+            childValue->copyFromRowLayout(structValues);
         }
         structValues += storage::StorageUtils::getDataTypeSize(*childValue->dataType);
+    }
+}
+
+void Value::copyFromColLayoutStruct(const struct_entry_t& structEntry, ValueVector* vec) {
+    for (auto i = 0u; i < childrenSize; i++) {
+        children[i]->setNull(StructVector::getFieldVector(vec, i)->isNull(structEntry.pos));
+        if (!children[i]->isNull()) {
+            auto fieldVector = StructVector::getFieldVector(vec, i);
+            children[i]->copyFromColLayout(
+                fieldVector->getData() + fieldVector->getNumBytesPerValue() * structEntry.pos,
+                fieldVector.get());
+        }
     }
 }
 
@@ -573,7 +714,7 @@ void Value::copyFromUnion(const uint8_t* kuUnion) {
         childValue->setNull(true);
     } else {
         childValue->setNull(false);
-        childValue->copyValueFrom(unionValues);
+        childValue->copyFromRowLayout(unionValues);
     }
 }
 
@@ -711,6 +852,72 @@ void Value::validateType(LogicalTypeID targetTypeID) const {
     }
     throw BinderException(stringFormat("{} has data type {} but {} was expected.", toString(),
         dataType->toString(), LogicalTypeUtils::toString(targetTypeID)));
+}
+
+uint64_t Value::computeHash() const {
+    if (isNull_) {
+        return function::NULL_HASH;
+    }
+    hash_t hashValue;
+    switch (dataType->getPhysicalType()) {
+    case PhysicalTypeID::BOOL: {
+        function::Hash::operation(val.booleanVal, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::INT128: {
+        function::Hash::operation(val.int128Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::INT64: {
+        function::Hash::operation(val.int64Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::INT32: {
+        function::Hash::operation(val.int32Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::INT16: {
+        function::Hash::operation(val.int16Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::INT8: {
+        function::Hash::operation(val.int8Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::UINT64: {
+        function::Hash::operation(val.uint64Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::UINT32: {
+        function::Hash::operation(val.uint32Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::UINT16: {
+        function::Hash::operation(val.uint16Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::UINT8: {
+        function::Hash::operation(val.uint8Val, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::DOUBLE: {
+        function::Hash::operation(val.doubleVal, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::FLOAT: {
+        function::Hash::operation(val.floatVal, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::INTERVAL: {
+        function::Hash::operation(val.intervalVal, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::INTERNAL_ID: {
+        function::Hash::operation(val.internalIDVal, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::STRING: {
+        function::Hash::operation(strVal, hashValue, nullptr);
+    } break;
+    case PhysicalTypeID::ARRAY:
+    case PhysicalTypeID::LIST:
+    case PhysicalTypeID::STRUCT: {
+        hashValue = children[0]->computeHash();
+        for (auto i = 1u; i < childrenSize; i++) {
+            hashValue = function::combineHashScalar(hashValue, children[i]->computeHash());
+        }
+    } break;
+    default: {
+        KU_UNREACHABLE;
+    }
+    }
+    return hashValue;
 }
 
 std::string Value::rdfVariantToString() const {

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -661,8 +661,8 @@ void Value::copyFromColLayoutList(const list_entry_t& listEntry, ValueVector* ve
         auto childValue = children[i].get();
         childValue->setNull(dataVec->isNull(listEntry.offset + i));
         if (!childValue->isNull()) {
-            childValue->copyFromColLayout(
-                ListVector::getListValuesWithOffset(vec, listEntry, i), dataVec);
+            childValue->copyFromColLayout(ListVector::getListValuesWithOffset(vec, listEntry, i),
+                dataVec);
         }
     }
 }
@@ -688,8 +688,8 @@ void Value::copyFromColLayoutStruct(const struct_entry_t& structEntry, ValueVect
         children[i]->setNull(StructVector::getFieldVector(vec, i)->isNull(structEntry.pos));
         if (!children[i]->isNull()) {
             auto fieldVector = StructVector::getFieldVector(vec, i);
-            children[i]->copyFromColLayout(
-                fieldVector->getData() + fieldVector->getNumBytesPerValue() * structEntry.pos,
+            children[i]->copyFromColLayout(fieldVector->getData() +
+                                               fieldVector->getNumBytesPerValue() * structEntry.pos,
                 fieldVector.get());
         }
     }

--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -25,8 +25,8 @@ struct overload : Funcs... {
 
 class TypeUtils {
 public:
-    static std::string entryToString(
-        const LogicalType& dataType, const uint8_t* value, ValueVector* vector);
+    static std::string entryToString(const LogicalType& dataType, const uint8_t* value,
+        ValueVector* vector);
 
     template<typename T>
     static inline std::string toString(const T& val, void* /*valueVector*/ = nullptr) {
@@ -40,13 +40,13 @@ public:
     static std::string nodeToString(const struct_entry_t& val, ValueVector* vector);
     static std::string relToString(const struct_entry_t& val, ValueVector* vector);
 
-    static inline void encodeOverflowPtr(
-        uint64_t& overflowPtr, page_idx_t pageIdx, uint16_t pageOffset) {
+    static inline void encodeOverflowPtr(uint64_t& overflowPtr, page_idx_t pageIdx,
+        uint16_t pageOffset) {
         memcpy(&overflowPtr, &pageIdx, 4);
         memcpy(((uint8_t*)&overflowPtr) + 4, &pageOffset, 2);
     }
-    static inline void decodeOverflowPtr(
-        uint64_t overflowPtr, page_idx_t& pageIdx, uint16_t& pageOffset) {
+    static inline void decodeOverflowPtr(uint64_t overflowPtr, page_idx_t& pageIdx,
+        uint16_t& pageOffset) {
         pageIdx = 0;
         memcpy(&pageIdx, &overflowPtr, 4);
         memcpy(&pageOffset, ((uint8_t*)&overflowPtr) + 4, 2);

--- a/src/include/common/type_utils.h
+++ b/src/include/common/type_utils.h
@@ -25,6 +25,9 @@ struct overload : Funcs... {
 
 class TypeUtils {
 public:
+    static std::string entryToString(
+        const LogicalType& dataType, const uint8_t* value, ValueVector* vector);
+
     template<typename T>
     static inline std::string toString(const T& val, void* /*valueVector*/ = nullptr) {
         static_assert(std::is_same<T, int64_t>::value || std::is_same<T, int32_t>::value ||
@@ -37,13 +40,13 @@ public:
     static std::string nodeToString(const struct_entry_t& val, ValueVector* vector);
     static std::string relToString(const struct_entry_t& val, ValueVector* vector);
 
-    static inline void encodeOverflowPtr(uint64_t& overflowPtr, page_idx_t pageIdx,
-        uint16_t pageOffset) {
+    static inline void encodeOverflowPtr(
+        uint64_t& overflowPtr, page_idx_t pageIdx, uint16_t pageOffset) {
         memcpy(&overflowPtr, &pageIdx, 4);
         memcpy(((uint8_t*)&overflowPtr) + 4, &pageOffset, 2);
     }
-    static inline void decodeOverflowPtr(uint64_t overflowPtr, page_idx_t& pageIdx,
-        uint16_t& pageOffset) {
+    static inline void decodeOverflowPtr(
+        uint64_t overflowPtr, page_idx_t& pageIdx, uint16_t& pageOffset) {
         pageIdx = 0;
         memcpy(&pageIdx, &overflowPtr, 4);
         memcpy(&pageOffset, ((uint8_t*)&overflowPtr) + 4, 2);

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -152,8 +152,8 @@ public:
      * @param dataType the logical type of the value.
      * @param children a vector of children values.
      */
-    KUZU_API explicit Value(
-        std::unique_ptr<LogicalType> dataType, std::vector<std::unique_ptr<Value>> children);
+    KUZU_API explicit Value(std::unique_ptr<LogicalType> dataType,
+        std::vector<std::unique_ptr<Value>> children);
     /**
      * @param other the value to copy from.
      */

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -152,8 +152,8 @@ public:
      * @param dataType the logical type of the value.
      * @param children a vector of children values.
      */
-    KUZU_API explicit Value(std::unique_ptr<LogicalType> dataType,
-        std::vector<std::unique_ptr<Value>> children);
+    KUZU_API explicit Value(
+        std::unique_ptr<LogicalType> dataType, std::vector<std::unique_ptr<Value>> children);
     /**
      * @param other the value to copy from.
      */
@@ -164,6 +164,7 @@ public:
      */
     KUZU_API Value(Value&& other) = default;
     KUZU_API Value& operator=(Value&& other) = default;
+    KUZU_API bool operator==(const Value& rhs) const;
 
     /**
      * @brief Sets the data type of the Value.
@@ -188,10 +189,15 @@ public:
      */
     KUZU_API bool isNull() const;
     /**
-     * @brief Copies from the value.
+     * @brief Copies from the row layout value.
      * @param value value to copy from.
      */
-    KUZU_API void copyValueFrom(const uint8_t* value);
+    KUZU_API void copyFromRowLayout(const uint8_t* value);
+    /**
+     * @brief Copies from the col layout value.
+     * @param value value to copy from.
+     */
+    KUZU_API void copyFromColLayout(const uint8_t* value, ValueVector* vec = nullptr);
     /**
      * @brief Copies from the other.
      * @param other value to copy from.
@@ -234,12 +240,17 @@ public:
 
     void validateType(common::LogicalTypeID targetTypeID) const;
 
+    uint64_t computeHash() const;
+
 private:
     Value();
     explicit Value(const LogicalType& dataType);
 
-    void copyFromList(ku_list_t& list, const LogicalType& childType);
-    void copyFromStruct(const uint8_t* kuStruct);
+    void resizeChildrenVector(uint64_t size, const LogicalType& childType);
+    void copyFromRowLayoutList(const ku_list_t& list, const LogicalType& childType);
+    void copyFromColLayoutList(const list_entry_t& list, ValueVector* vec);
+    void copyFromRowLayoutStruct(const uint8_t* kuStruct);
+    void copyFromColLayoutStruct(const struct_entry_t& structEntry, ValueVector* vec);
     void copyFromUnion(const uint8_t* kuUnion);
 
     std::string rdfVariantToString() const;
@@ -275,8 +286,9 @@ private:
     std::unique_ptr<LogicalType> dataType;
     bool isNull_;
 
-    // Note: ALWAYS use childrenSize over children.size(). We do NOT resize children when iterating
-    // with nested value. So children.size() reflects the capacity() rather the actual size.
+    // Note: ALWAYS use childrenSize over children.size(). We do NOT resize children when
+    // iterating with nested value. So children.size() reflects the capacity() rather the actual
+    // size.
     std::vector<std::unique_ptr<Value>> children;
     uint32_t childrenSize;
 };

--- a/src/include/function/map/functions/map_creation_function.h
+++ b/src/include/function/map/functions/map_creation_function.h
@@ -1,10 +1,37 @@
 #pragma once
 
+#include "unordered_set"
+
 #include "common/exception/runtime.h"
+#include "common/type_utils.h"
+#include "common/types/value/value.h"
 #include "common/vector/value_vector.h"
 
 namespace kuzu {
 namespace function {
+
+struct ValueHashFunction {
+    uint64_t operator()(const common::Value& value) const { return (uint64_t)value.computeHash(); }
+};
+
+struct ValueEquality {
+    bool operator()(const common::Value& a, const common::Value& b) const { return a == b; }
+};
+
+static void validateKeys(common::list_entry_t& keyEntry, common::ValueVector& keyVector) {
+    std::unordered_set<common::Value, ValueHashFunction, ValueEquality> uniqueKeys;
+    auto dataVector = common::ListVector::getDataVector(&keyVector);
+    auto val = common::Value::createDefaultValue(dataVector->dataType);
+    for (auto i = 0u; i < keyEntry.size; i++) {
+        auto entryVal = common::ListVector::getListValuesWithOffset(&keyVector, keyEntry, i);
+        val.copyFromColLayout(entryVal, dataVector);
+        auto unique = uniqueKeys.insert(val).second;
+        if (!unique) {
+            throw common::RuntimeException{common::stringFormat("Found duplicate key: {} in map.",
+                common::TypeUtils::entryToString(dataVector->dataType, entryVal, dataVector))};
+        }
+    }
+}
 
 struct MapCreation {
     static void operation(common::list_entry_t& keyEntry, common::list_entry_t& valueEntry,
@@ -13,6 +40,7 @@ struct MapCreation {
         if (keyEntry.size != valueEntry.size) {
             throw common::RuntimeException{"Unaligned key list and value list."};
         }
+        validateKeys(keyEntry, keyVector);
         resultEntry = common::ListVector::addList(&resultVector, keyEntry.size);
         auto resultStructVector = common::ListVector::getDataVector(&resultVector);
         copyListEntry(resultEntry,

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -351,7 +351,7 @@ private:
         return flatTuplePositionsInDataChunk[dataChunkPos].first != UINT64_MAX;
     }
     inline void readValueBufferToValue(uint64_t colIdx, const uint8_t* valueBuffer) {
-        values[colIdx]->copyValueFrom(valueBuffer);
+        values[colIdx]->copyFromRowLayout(valueBuffer);
     }
 
     void readUnflatColToFlatTuple(ft_col_idx_t colIdx, uint8_t* valueBuffer);

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -65,21 +65,3 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     ASSERT_NE(database, nullptr);
     kuzu_database_destroy(database);
 }
-
-TEST_F(CApiDatabaseTest, CreationHomeDir1) {
-    createDBAndConn();
-    conn->query("load extension "
-                "\"/Users/z473chen/Desktop/code/kuzu/extension/duckdb_scanner/build/"
-                "libduckdb_scanner.kuzu_extension\"");
-    conn->query("ATTACH "
-                "'/Users/z473chen/Desktop/code/kuzu/extension/duckdb_scanner/test/duckdb_database/"
-                "tinysnb.db' "
-                "as tinysnb (dbtype 'duckdb');");
-    conn->query("ATTACH "
-                "'/Users/z473chen/Desktop/code/kuzu/extension/duckdb_scanner/test/duckdb_database/"
-                "other.db' "
-                "as other (dbtype 'duckdb');");
-    printf("%s", conn->query("load from person return *;")->toString().c_str());
-    printf("%s", conn->query("use other")->toString().c_str());
-    printf("%s", conn->query("load from person return *;")->toString().c_str());
-}

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -577,6 +577,91 @@ Dan|Carol
 ---- 1
 {Alice=20, Bob=34, Carol=50, Dan=22}
 
+-LOG DuplicateMapBoolKey
+-STATEMENT RETURN map([true, false, true], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: True in map.
+
+-LOG DuplicateMapInt128Key
+-STATEMENT RETURN map([cast(5, 'int128'), cast(32, 'int128'), cast(5, 'int128')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 5 in map.
+
+-LOG DuplicateMapInt64Key
+-STATEMENT RETURN map([cast(5, 'int64'), cast(32, 'int64'), cast(8, 'int64'), cast(32, 'int64')], [20, 34, 50, 70]);
+---- error
+Runtime exception: Found duplicate key: 32 in map.
+
+-LOG DuplicateMapInt32Key
+-STATEMENT RETURN map([cast(5, 'int32'), cast(32, 'int32'), cast(5, 'int32')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 5 in map.
+
+-LOG DuplicateMapInt16Key
+-STATEMENT RETURN map([cast(21, 'int16'), cast(4, 'int16'), cast(4, 'int16')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 4 in map.
+
+-LOG DuplicateMapInt8Key
+-STATEMENT RETURN map([cast(3, 'int8'), cast(3, 'int8'), cast(2, 'int8')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 3 in map.
+
+-LOG DuplicateMapUint64Key
+-STATEMENT RETURN map([cast(100, 'uint64'), cast(100, 'uint64')], [20, 20]);
+---- error
+Runtime exception: Found duplicate key: 100 in map.
+
+-LOG DuplicateMapUint32Key
+-STATEMENT RETURN map([cast(29, 'uint32'), cast(29, 'uint32')], [70, 90]);
+---- error
+Runtime exception: Found duplicate key: 29 in map.
+
+-LOG DuplicateMapUint16Key
+-STATEMENT RETURN map([cast(22, 'uint16'), cast(22, 'uint16'), cast(22, 'uint16')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 22 in map.
+
+-LOG DuplicateMapUint8Key
+-STATEMENT RETURN map([cast(3, 'uint8'), cast(3, 'uint8'), cast(2, 'uint8')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 3 in map.
+
+-LOG DuplicateMapDoubleKey
+-STATEMENT RETURN map([cast(2.75, 'double'), cast(3.2, 'double'), cast(3.2, 'double')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 3.200000 in map.
+
+-LOG DuplicateMapFloatKey
+-STATEMENT RETURN map([cast(3.67, 'float'), cast(3.67, 'float'), cast(2, 'float')], [20, 34, 50]);
+---- error
+Runtime exception: Found duplicate key: 3.670000 in map.
+
+-LOG DuplicateMapIntervalKey
+-STATEMENT RETURN map([cast('2 hours 5 minutes', 'interval'), cast('3 hours 20 hours', 'interval'), cast('3 hours 20 hours', 'interval')], [20, 34, 23]);
+---- error
+Runtime exception: Found duplicate key: 23:00:00 in map.
+
+-LOG DuplicateMapStringKey
+-STATEMENT RETURN map(['kuzu', 'kuzuinc', 'kuzucorp', 'kuzu'], [20, 34, 50, 32]);
+---- error
+Runtime exception: Found duplicate key: kuzu in map.
+
+-LOG DuplicateMapArrayKey
+-STATEMENT RETURN map([cast([3,2,1], 'int64[3]'), cast([3,2,1], 'int64[3]')], [20, 34]);
+---- error
+Runtime exception: Found duplicate key: [3,2,1] in map.
+
+-LOG DuplicateMapListKey
+-STATEMENT RETURN map([[7,8,25,1], [7,8,25], [8,25,1], [7,8,25,1]], [20, 34, 24, 77]);
+---- error
+Runtime exception: Found duplicate key: [7,8,25,1] in map.
+
+-LOG DuplicateMapStructKey
+-STATEMENT RETURN map([{a: 5, b: 3}, {a: 5, b: 4}, {a: 5, b: 3}], [20, 34, 24]);
+---- error
+Runtime exception: Found duplicate key: {a: 5, b: 3} in map.
+
 -LOG ReturnMapLiteralWithProp
 -STATEMENT MATCH (p:person) RETURN map([p.ID, p.age], [p.fName, p.fName]);
 ---- 8

--- a/test/test_files/tinysnb/projection/single_label.test
+++ b/test/test_files/tinysnb/projection/single_label.test
@@ -662,6 +662,11 @@ Runtime exception: Found duplicate key: [7,8,25,1] in map.
 ---- error
 Runtime exception: Found duplicate key: {a: 5, b: 3} in map.
 
+-LOG DuplicateMapKeyProperty
+-STATEMENT MATCH (p:person) RETURN map([p.ID, p.ID], [p.age, p.age]);
+---- error
+Runtime exception: Found duplicate key: 0 in map.
+
 -LOG ReturnMapLiteralWithProp
 -STATEMENT MATCH (p:person) RETURN map([p.ID, p.age], [p.fName, p.fName]);
 ---- 8


### PR DESCRIPTION
This PR adds a check for duplicated map keys when creating a map value.
When creating a map, we will firstly create a set.
For each map key:
1. If the key is inside the set => throws an exception.
2. If the key is not inside the set => insert to the set.