### PR TITLE
Optimize concurrent query performance

### DIFF
--- a/src/storage/buffer_manager/memory_manager.cpp
+++ b/src/storage/buffer_manager/memory_manager.cpp
@@ -29,7 +29,6 @@ MemoryAllocator::~MemoryAllocator() = default;
 
 std::unique_ptr<MemoryBuffer> MemoryAllocator::allocateBuffer(bool initializeToZero,
     uint64_t size) {
-    std::unique_lock<std::mutex> lock(allocatorLock);
     if (size > BufferPoolConstants::PAGE_256KB_SIZE) [[unlikely]] {
         auto buffer = malloc(size);
         if (initializeToZero) {
@@ -39,12 +38,14 @@ std::unique_ptr<MemoryBuffer> MemoryAllocator::allocateBuffer(bool initializeToZ
             reinterpret_cast<uint8_t*>(buffer), size);
     }
     page_idx_t pageIdx;
+    std::unique_lock<std::mutex> lock(allocatorLock);
     if (freePages.empty()) {
         pageIdx = fh->addNewPage();
     } else {
         pageIdx = freePages.top();
         freePages.pop();
     }
+    lock.unlock();
     auto buffer = bm->pin(*fh, pageIdx, BufferManager::PageReadPolicy::DONT_READ_PAGE);
     auto memoryBuffer = std::make_unique<MemoryBuffer>(this, pageIdx, buffer);
     if (initializeToZero) {
@@ -54,12 +55,12 @@ std::unique_ptr<MemoryBuffer> MemoryAllocator::allocateBuffer(bool initializeToZ
 }
 
 void MemoryAllocator::freeBlock(page_idx_t pageIdx, uint8_t* buffer) {
-    std::unique_lock<std::mutex> lock(allocatorLock);
     if (pageIdx == INVALID_PAGE_IDX) {
         std::free(buffer);
         return;
     } else {
         bm->unpin(*fh, pageIdx);
+        std::unique_lock<std::mutex> lock(allocatorLock);
         freePages.push(pageIdx);
     }
 }


### PR DESCRIPTION
I have read and agree to the terms under [CLA.md](https://github.com/kuzudb/kuzu/blob/master/CLA.md)



In my test environment , sf100 database ,`match (m:Person)-[r:knows]-(n:Person) where m.__uid="${uid}" optional match (d:Person)-[f:knows]->(n)  return size(m.lastName) as n1, size(n.lastName) as n2, f.creationDate as n3 order by n1, n2, n3 limit 10;
` , 50 concurrency ,QPS from 20 to 40