### PR TITLE
Node table read state

### DIFF
--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -34,7 +34,7 @@ public:
         ExecutionContext* executionContext) final {
         ScanTable::initLocalStateInternal(resultSet, executionContext);
         readState =
-            std::make_unique<storage::TableReadState>(*inVector, info->columnIDs, outVectors);
+            std::make_unique<storage::NodeTableReadState>(*inVector, info->columnIDs, outVectors);
     }
 
     bool getNextTuplesInternal(ExecutionContext* context) override;

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <functional>
 #include <vector>
 
 #include "storage/buffer_manager/bm_file_handle.h"
@@ -212,7 +211,7 @@ private:
 
     inline uint64_t reserveUsedMemory(uint64_t size) { return usedMemory.fetch_add(size); }
     inline uint64_t freeUsedMemory(uint64_t size) {
-        //        KU_ASSERT(usedMemory.load() >= size);
+        KU_ASSERT(usedMemory.load() >= size);
         return usedMemory.fetch_sub(size);
     }
 

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <vector>
 
 #include "storage/buffer_manager/bm_file_handle.h"

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -212,7 +212,7 @@ private:
 
     inline uint64_t reserveUsedMemory(uint64_t size) { return usedMemory.fetch_add(size); }
     inline uint64_t freeUsedMemory(uint64_t size) {
-        KU_ASSERT(usedMemory.load() >= size);
+        //        KU_ASSERT(usedMemory.load() >= size);
         return usedMemory.fetch_sub(size);
     }
 

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -42,12 +42,6 @@ public:
     explicit LocalNodeTableData(std::vector<common::LogicalType> dataTypes)
         : LocalTableData{std::move(dataTypes)} {}
 
-    void scan(common::ValueVector* nodeIDVector, const std::vector<common::column_id_t>& columnIDs,
-        const std::vector<common::ValueVector*>& outputVectors);
-    void lookup(common::ValueVector* nodeIDVector,
-        const std::vector<common::column_id_t>& columnIDs,
-        const std::vector<common::ValueVector*>& outputVectors);
-
 private:
     LocalNodeGroup* getOrCreateLocalNodeGroup(common::ValueVector* nodeIDVector) override;
 };
@@ -61,17 +55,11 @@ public:
     bool update(TableUpdateState& updateState) override;
     bool delete_(TableDeleteState& deleteState) override;
 
-    void read(TableReadState& state);
-
     LocalNodeTableData* getTableData() {
         KU_ASSERT(localTableDataCollection.size() == 1);
         return common::ku_dynamic_cast<LocalTableData*, LocalNodeTableData*>(
             localTableDataCollection[0].get());
     }
-
-private:
-    void scan(TableReadState& state);
-    void lookup(TableReadState& state);
 };
 
 } // namespace storage

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -15,10 +15,12 @@ public:
         : LocalNodeGroup{nodeGroupStartOffset, dataTypes} {}
     DELETE_COPY_DEFAULT_MOVE(LocalNodeNG);
 
-    void scan(common::ValueVector* nodeIDVector, const std::vector<common::column_id_t>& columnIDs,
+    void scan(const common::ValueVector& nodeIDVector,
+        const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVectors);
-    void lookup(common::offset_t nodeOffset, common::column_id_t columnID,
-        common::ValueVector* outputVector, common::sel_t posInOutputVector);
+    void lookup(const common::ValueVector& nodeIDVector, common::offset_t offsetInVectorToLookup,
+        const std::vector<common::column_id_t>& columnIDs,
+        const std::vector<common::ValueVector*>& outputVectors);
 
     bool insert(std::vector<common::ValueVector*> nodeIDVectors,
         std::vector<common::ValueVector*> propertyVectors) override;
@@ -50,6 +52,7 @@ private:
     LocalNodeGroup* getOrCreateLocalNodeGroup(common::ValueVector* nodeIDVector) override;
 };
 
+struct TableReadState;
 class LocalNodeTable final : public LocalTable {
 public:
     explicit LocalNodeTable(Table& table);
@@ -58,14 +61,17 @@ public:
     bool update(TableUpdateState& updateState) override;
     bool delete_(TableDeleteState& deleteState) override;
 
-    void scan(TableReadState& state) override;
-    void lookup(TableReadState& state) override;
+    void read(TableReadState& state);
 
     LocalNodeTableData* getTableData() {
         KU_ASSERT(localTableDataCollection.size() == 1);
         return common::ku_dynamic_cast<LocalTableData*, LocalNodeTableData*>(
             localTableDataCollection[0].get());
     }
+
+private:
+    void scan(TableReadState& state);
+    void lookup(TableReadState& state);
 };
 
 } // namespace storage

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -66,9 +66,6 @@ public:
     bool update(TableUpdateState& updateState) override;
     bool delete_(TableDeleteState& deleteState) override;
 
-    void scan(TableReadState& state) override;
-    void lookup(TableReadState& state) override;
-
     LocalRelTableData* getTableData(common::RelDataDirection direction) {
         KU_ASSERT(localTableDataCollection.size() == 2);
         return common::ku_dynamic_cast<LocalTableData*, LocalRelTableData*>(

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -57,6 +57,9 @@ public:
     bool isEmpty() const { return offsetToRowIdx.empty() && srcNodeOffsetToRelOffsets.empty(); }
     void readValueAtRowIdx(common::row_idx_t rowIdx, common::column_id_t columnID,
         common::ValueVector* outputVector, common::sel_t posInOutputVector) const;
+    bool read(common::offset_t offset, const std::vector<common::column_id_t>& columnIDs,
+        const std::vector<common::ValueVector*>& outputVector,
+        common::offset_t offsetInOutputVector);
     bool read(common::offset_t offset, common::column_id_t columnID,
         common::ValueVector* outputVector, common::sel_t posInOutputVector);
 
@@ -199,7 +202,6 @@ protected:
 struct TableInsertState;
 struct TableUpdateState;
 struct TableDeleteState;
-struct TableReadState;
 class Table;
 class LocalTable {
 public:
@@ -208,9 +210,6 @@ public:
     virtual bool insert(TableInsertState& insertState) = 0;
     virtual bool update(TableUpdateState& updateState) = 0;
     virtual bool delete_(TableDeleteState& deleteState) = 0;
-
-    virtual void scan(TableReadState& state) = 0;
-    virtual void lookup(TableReadState& state) = 0;
 
     inline void clear() { localTableDataCollection.clear(); }
 

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <functional>
+
 #include "common/constants.h"
 #include "common/data_chunk/sel_vector.h"
 #include "common/enums/rel_multiplicity.h"

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <functional>
-
 #include "common/constants.h"
 #include "common/data_chunk/sel_vector.h"
 #include "common/enums/rel_multiplicity.h"
@@ -23,6 +21,7 @@ struct ColumnChunkMetadata {
     uint64_t numValues;
     CompressionMetadata compMeta;
 
+    // TODO: Delete copy.
     ColumnChunkMetadata() : pageIdx{common::INVALID_PAGE_IDX}, numPages{0}, numValues{0} {}
     ColumnChunkMetadata(common::page_idx_t pageIdx, common::page_idx_t numPages,
         uint64_t numNodesInChunk, const CompressionMetadata& compMeta)

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -41,7 +41,7 @@ struct ListOffsetSizeInfo {
     bool isOffsetSortedAscending(uint64_t startPos, uint64_t endPos) const;
 };
 
-class ListColumn : public Column {
+class ListColumn final : public Column {
     friend class ListLocalColumn;
 
 public:
@@ -52,20 +52,21 @@ public:
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
-        common::ValueVector* resultVector, uint64_t offsetInVector = 0) final;
+        common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         ColumnChunk* columnChunk, common::offset_t startOffset = 0,
-        common::offset_t endOffset = common::INVALID_OFFSET) final;
+        common::offset_t endOffset = common::INVALID_OFFSET) override;
 
     inline Column* getDataColumn() { return dataColumn.get(); }
 
 protected:
-    void scanInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) final;
+    void scanInternal(transaction::Transaction* transaction, ReadState& readState,
+        common::ValueVector* nodeIDVector, common::ValueVector* resultVector) override;
 
-    void lookupValue(transaction::Transaction* transaction, common::offset_t nodeOffset,
-        common::ValueVector* resultVector, uint32_t posInVector) final;
+    void lookupValue(transaction::Transaction* transaction, ReadState& readState,
+        common::offset_t nodeOffset, common::ValueVector* resultVector,
+        uint32_t posInVector) override;
 
     void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;
 
@@ -76,9 +77,9 @@ private:
     void scanFiltered(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         common::ValueVector* offsetVector, const ListOffsetSizeInfo& listOffsetInfoInStorage);
 
-    void prepareCommit() final;
-    void checkpointInMemory() final;
-    void rollbackInMemory() final;
+    void prepareCommit() override;
+    void checkpointInMemory() override;
+    void rollbackInMemory() override;
 
     common::offset_t readOffset(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, common::offset_t offsetInNodeGroup);

--- a/src/include/storage/store/node_table_data.h
+++ b/src/include/storage/store/node_table_data.h
@@ -46,6 +46,9 @@ public:
     }
 
 private:
+    void initializeColumnReadStates(transaction::Transaction* transaction,
+        common::offset_t startNodeOffset, kuzu::storage::NodeDataReadState& readState,
+        common::node_group_idx_t nodeGroupIdx);
     void initializeLocalNodeReadState(transaction::Transaction* transaction,
         NodeDataReadState& readState, common::node_group_idx_t nodeGroupIdx);
 
@@ -60,6 +63,8 @@ private:
         LocalNodeGroup* localNodeGroup);
     void merge(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         LocalNodeGroup* nodeGroup);
+
+    bool sanityCheckOnColumnNumValues(const NodeDataReadState& readState);
 };
 
 } // namespace storage

--- a/src/include/storage/store/node_table_data.h
+++ b/src/include/storage/store/node_table_data.h
@@ -5,8 +5,20 @@
 namespace kuzu {
 namespace storage {
 
-class LocalTableData;
+class LocalNodeNG;
+struct NodeDataReadState : public TableDataReadState {
+    NodeDataReadState() : TableDataReadState{} {}
+    DELETE_COPY_DEFAULT_MOVE(NodeDataReadState);
 
+    common::node_group_idx_t nodeGroupIdx = common::INVALID_NODE_GROUP_IDX;
+    bool readFromPersistent = false;
+    std::vector<Column::ReadState> columnReadStates;
+
+    // Should be moved into LocalNodeReadState.
+    LocalNodeNG* localNodeGroup = nullptr;
+};
+
+class LocalTableData;
 class NodeTableData final : public TableData {
 public:
     NodeTableData(BMFileHandle* dataFH, BMFileHandle* metadataFH,
@@ -15,11 +27,27 @@ public:
         bool enableCompression);
 
     // This interface is node table specific, as rel table requires also relDataDirection.
-    inline virtual void initializeReadState(transaction::Transaction* /*transaction*/,
-        std::vector<common::column_id_t> columnIDs, const common::ValueVector& /*inNodeIDVector*/,
-        TableDataReadState& readState) {
-        readState.columnIDs = columnIDs;
+    virtual void initializeReadState(transaction::Transaction* transaction,
+        std::vector<common::column_id_t> columnIDs, const common::ValueVector& inNodeIDVector,
+        TableDataReadState& readState);
+    void read(transaction::Transaction* transaction, TableDataReadState& readState,
+        const common::ValueVector& nodeIDVector,
+        const std::vector<common::ValueVector*>& outputVectors);
+
+    // Flush the nodeGroup to disk and update metadataDAs.
+    void append(ChunkedNodeGroup* nodeGroup) override;
+
+    void prepareLocalTableToCommit(transaction::Transaction* transaction,
+        LocalTableData* localTable) override;
+
+    common::node_group_idx_t getNumNodeGroups(
+        transaction::Transaction* transaction) const override {
+        return columns[0]->getNumNodeGroups(transaction);
     }
+
+private:
+    void initializeLocalNodeReadState(transaction::Transaction* transaction,
+        NodeDataReadState& readState, common::node_group_idx_t nodeGroupIdx);
 
     void scan(transaction::Transaction* transaction, TableDataReadState& readState,
         const common::ValueVector& nodeIDVector,
@@ -28,18 +56,6 @@ public:
         const common::ValueVector& nodeIDVector,
         const std::vector<common::ValueVector*>& outputVectors) override;
 
-    // Flush the nodeGroup to disk and update metadataDAs.
-    void append(ChunkedNodeGroup* nodeGroup) override;
-
-    void prepareLocalTableToCommit(transaction::Transaction* transaction,
-        LocalTableData* localTable) override;
-
-    inline common::node_group_idx_t getNumNodeGroups(
-        transaction::Transaction* transaction) const override {
-        return columns[0]->getNumNodeGroups(transaction);
-    }
-
-private:
     void append(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         LocalNodeGroup* localNodeGroup);
     void merge(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -20,7 +20,7 @@ public:
         BMFileHandle* metadataFH, BufferManager* bufferManager, WAL* wal, Transaction* transaction,
         RWPropertyStats propertyStatistics, bool enableCompression);
 
-    void scan(Transaction* transaction, ValueVector* nodeIDVector,
+    void scan(Transaction* transaction, ReadState& readState, ValueVector* nodeIDVector,
         ValueVector* resultVector) override;
     void scan(transaction::Transaction* transaction, node_group_idx_t nodeGroupIdx,
         offset_t startOffsetInGroup, offset_t endOffsetInGroup, ValueVector* resultVector,
@@ -29,7 +29,7 @@ public:
         ColumnChunk* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
 
-    void lookup(Transaction* transaction, ValueVector* nodeIDVector,
+    void lookup(Transaction* transaction, ReadState& readState, ValueVector* nodeIDVector,
         ValueVector* resultVector) override;
 
     void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -23,6 +23,8 @@ struct RelDataReadState : public TableDataReadState {
     LocalRelNG* localNodeGroup;
 
     explicit RelDataReadState();
+    DELETE_COPY_DEFAULT_MOVE(RelDataReadState);
+
     inline bool isOutOfRange(common::offset_t nodeOffset) const {
         return nodeOffset < startNodeOffset || nodeOffset >= (startNodeOffset + numNodes);
     }

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -35,18 +35,17 @@ public:
     inline const DictionaryColumn& getDictionary() const { return dictionary; }
 
 protected:
-    void scanInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) override;
-    void scanUnfiltered(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, common::offset_t startOffsetInGroup,
-        common::offset_t endOffsetInGroup, common::ValueVector* resultVector,
-        common::sel_t startPosInVector = 0);
-    void scanFiltered(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        common::offset_t startOffsetInGroup, common::ValueVector* nodeIDVector,
+    void scanInternal(transaction::Transaction* transaction, ReadState& readState,
+        common::ValueVector* nodeIDVector, common::ValueVector* resultVector) override;
+    void scanUnfiltered(transaction::Transaction* transaction, ReadState& readState,
+        common::offset_t startOffsetInChunk, common::offset_t numValuesToRead,
+        common::ValueVector* resultVector, common::sel_t startPosInVector = 0);
+    void scanFiltered(transaction::Transaction* transaction, ReadState& readState,
+        common::offset_t startOffsetInChunk, common::ValueVector* nodeIDVector,
         common::ValueVector* resultVector);
 
-    void lookupInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) override;
+    void lookupInternal(transaction::Transaction* transaction, ReadState& readState,
+        common::ValueVector* nodeIDVector, common::ValueVector* resultVector) override;
 
 private:
     bool canCommitInPlace(transaction::Transaction* transaction,

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -12,6 +12,8 @@ public:
         BufferManager* bufferManager, WAL* wal, transaction::Transaction* transaction,
         RWPropertyStats propertyStatistics, bool enableCompression);
 
+    void initReadState(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+        common::offset_t startOffsetInChunk, ReadState& columnReadState) override;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         ColumnChunk* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
@@ -43,10 +45,10 @@ public:
         ColumnChunk* chunk, common::offset_t startSrcOffset) override;
 
 protected:
-    void scanInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) override;
-    void lookupInternal(transaction::Transaction* transaction, common::ValueVector* nodeIDVector,
-        common::ValueVector* resultVector) override;
+    void scanInternal(transaction::Transaction* transaction, ReadState& readState,
+        common::ValueVector* nodeIDVector, common::ValueVector* resultVector) override;
+    void lookupInternal(transaction::Transaction* transaction, ReadState& readState,
+        common::ValueVector* nodeIDVector, common::ValueVector* resultVector) override;
 
     bool canCommitInPlace(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, const ChunkCollection& localInsertChunk,

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -17,9 +17,7 @@ struct TableReadState {
         const std::vector<common::column_id_t>& columnIDs,
         const std::vector<common::ValueVector*>& outputVectors)
         : nodeIDVector{nodeIDVector}, columnIDs{std::move(columnIDs)},
-          outputVectors{outputVectors} {
-        dataReadState = std::make_unique<TableDataReadState>();
-    }
+          outputVectors{outputVectors} {}
     virtual ~TableReadState() = default;
 };
 

--- a/src/include/storage/store/table_data.h
+++ b/src/include/storage/store/table_data.h
@@ -12,7 +12,9 @@ class Property;
 namespace storage {
 
 struct TableDataReadState {
+    TableDataReadState() = default;
     virtual ~TableDataReadState() = default;
+    DELETE_COPY_DEFAULT_MOVE(TableDataReadState);
 
     std::vector<common::column_id_t> columnIDs;
 };

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -615,7 +615,10 @@ void PrimaryKeyIndex::delete_(ValueVector* keyVector) {
                     continue;
                 }
                 auto key = keyVector->getValue<T>(pos);
-                delete_(key);
+                common::offset_t result;
+                if (lookup(Transaction::getDummyReadOnlyTrx().get(), keyVector, pos, result)) {
+                    delete_(key);
+                }
             }
         },
         [](auto) { KU_UNREACHABLE; });

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -226,6 +226,9 @@ template<typename T>
 void HashIndex<T>::deleteFromPersistentIndex(Key key) {
     auto trxType = TransactionType::WRITE;
     auto header = *this->indexHeaderForWriteTrx;
+    if (header.numEntries == 0) {
+        return;
+    }
     auto hashValue = HashIndexUtils::hash(key);
     auto fingerprint = HashIndexUtils::getFingerprintForHash(hashValue);
     auto iter =
@@ -615,10 +618,7 @@ void PrimaryKeyIndex::delete_(ValueVector* keyVector) {
                     continue;
                 }
                 auto key = keyVector->getValue<T>(pos);
-                common::offset_t result;
-                if (lookup(Transaction::getDummyReadOnlyTrx().get(), keyVector, pos, result)) {
-                    delete_(key);
-                }
+                delete_(key);
             }
         },
         [](auto) { KU_UNREACHABLE; });

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -261,13 +261,5 @@ bool LocalRelTable::delete_(TableDeleteState& deleteState) {
     return fwdDeleted && bwdDeleted;
 }
 
-void LocalRelTable::scan(TableReadState&) {
-    KU_UNREACHABLE;
-}
-
-void LocalRelTable::lookup(TableReadState&) {
-    KU_UNREACHABLE;
-}
-
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/local_storage/local_table.cpp
+++ b/src/storage/local_storage/local_table.cpp
@@ -54,6 +54,20 @@ void LocalChunkedGroupCollection::readValueAtRowIdx(row_idx_t rowIdx, column_id_
     chunk.lookup(offsetInChunk, *outputVector, posInOutputVector);
 }
 
+bool LocalChunkedGroupCollection::read(offset_t offset, const std::vector<column_id_t>& columnIDs,
+    const std::vector<ValueVector*>& outputVectors, offset_t offsetInOutputVector) {
+    if (!offsetToRowIdx.contains(offset)) {
+        return false;
+    }
+    auto rowIdx = offsetToRowIdx.at(offset);
+    for (auto i = 0u; i < columnIDs.size(); i++) {
+        auto posInOutputVector =
+            outputVectors[i]->state->selVector->selectedPositions[offsetInOutputVector];
+        readValueAtRowIdx(rowIdx, columnIDs[i], outputVectors[i], posInOutputVector);
+    }
+    return true;
+}
+
 bool LocalChunkedGroupCollection::read(offset_t offset, column_id_t columnID,
     ValueVector* outputVector, sel_t posInOutputVector) {
     if (!offsetToRowIdx.contains(offset)) {

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -549,8 +549,8 @@ public:
             commonTableID = relIDsInVector[selVector.selectedPositions[0]].tableID;
         }
         for (auto i = 0u; i < selVector.selectedSize; i++) {
-            KU_ASSERT(relIDsInVector[i].tableID == commonTableID);
             auto pos = selVector.selectedPositions[i];
+            KU_ASSERT(relIDsInVector[pos].tableID == commonTableID);
             nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
             memcpy(buffer.get() + (startPosInChunk + i) * numBytesPerValue,
                 &relIDsInVector[pos].offset, numBytesPerValue);

--- a/src/storage/store/node_table_data.cpp
+++ b/src/storage/store/node_table_data.cpp
@@ -31,6 +31,104 @@ NodeTableData::NodeTableData(BMFileHandle* dataFH, BMFileHandle* metadataFH,
     }
 }
 
+void NodeTableData::initializeReadState(Transaction* transaction,
+    std::vector<column_id_t> columnIDs, const ValueVector& inNodeIDVector,
+    TableDataReadState& readState) {
+    readState.columnIDs = columnIDs;
+    auto& dataReadState = ku_dynamic_cast<TableDataReadState&, NodeDataReadState&>(readState);
+    if (dataReadState.nodeGroupIdx == INVALID_NODE_GROUP_IDX) {
+        dataReadState.columnReadStates.resize(columnIDs.size());
+    }
+    KU_ASSERT(dataReadState.columnReadStates.size() == columnIDs.size());
+    auto startNodeOffset = INVALID_OFFSET;
+    if (inNodeIDVector.isSequential()) {
+        startNodeOffset = inNodeIDVector.readNodeOffset(0);
+        KU_ASSERT(startNodeOffset % DEFAULT_VECTOR_CAPACITY == 0);
+    } else {
+        auto pos = inNodeIDVector.state->selVector->selectedPositions[0];
+        startNodeOffset = inNodeIDVector.readNodeOffset(pos);
+    }
+    auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(startNodeOffset);
+    // Sanity check on that all nodeIDs in the input vector are from the same node group.
+    for (auto i = 0u; i < inNodeIDVector.state->selVector->selectedSize; i++) {
+        KU_ASSERT(StorageUtils::getNodeGroupIdx(inNodeIDVector.readNodeOffset(
+                      inNodeIDVector.state->selVector->selectedPositions[i])) == nodeGroupIdx);
+    }
+    auto numExistingNodeGroups = columns[0]->getNumNodeGroups(transaction);
+    // Sanity check on that all columns should have the same num of node groups.
+    for (auto i = 1u; i < columns.size(); i++) {
+        KU_ASSERT(columns[i]->getNumNodeGroups(transaction) == numExistingNodeGroups);
+    }
+    dataReadState.readFromPersistent = nodeGroupIdx < numExistingNodeGroups;
+    // Sanity check on that we should always be able to readFromPersistent if the transaction is
+    // read only.
+    KU_ASSERT((dataReadState.readFromPersistent && transaction->isReadOnly()) ||
+              transaction->isWriteTransaction());
+    if (dataReadState.readFromPersistent) {
+        auto startOffsetInChunk =
+            startNodeOffset - StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx);
+        for (auto i = 0u; i < columnIDs.size(); i++) {
+            if (columnIDs[i] != INVALID_COLUMN_ID) {
+                getColumn(columnIDs[i])
+                    ->initReadState(transaction, nodeGroupIdx, startOffsetInChunk,
+                        dataReadState.columnReadStates[i]);
+            }
+        }
+#if defined(KUZU_RUNTIME_CHECKS) || !defined(NDEBUG)
+        if (nodeGroupIdx != dataReadState.nodeGroupIdx) {
+            // Sanity check on that all valid columns should have the same numValues in the node
+            // group.
+            auto validColumn = std::find_if(columnIDs.begin(), columnIDs.end(),
+                [](column_id_t columnID) { return columnID != INVALID_COLUMN_ID; });
+            if (validColumn != columnIDs.end()) {
+                auto numValues = dataReadState.columnReadStates[validColumn - columnIDs.begin()]
+                                     .metadata.numValues;
+                for (auto i = 0u; i < columnIDs.size(); i++) {
+                    if (columnIDs[i] == INVALID_COLUMN_ID) {
+                        continue;
+                    }
+                    KU_ASSERT(dataReadState.columnReadStates[i].metadata.numValues == numValues);
+                }
+            }
+        }
+#endif
+    }
+    if (transaction->isWriteTransaction()) {
+        initializeLocalNodeReadState(transaction, dataReadState, nodeGroupIdx);
+    }
+    dataReadState.nodeGroupIdx = nodeGroupIdx;
+}
+
+void NodeTableData::initializeLocalNodeReadState(transaction::Transaction* transaction,
+    kuzu::storage::NodeDataReadState& readState, common::node_group_idx_t nodeGroupIdx) {
+    if (readState.nodeGroupIdx == nodeGroupIdx) {
+        return;
+    }
+    auto localTable = transaction->getLocalStorage()->getLocalTable(tableID,
+        LocalStorage::NotExistAction::RETURN_NULL);
+    readState.localNodeGroup = nullptr;
+    if (localTable) {
+        auto localNodeTable = ku_dynamic_cast<LocalTable*, LocalNodeTable*>(localTable);
+        if (localNodeTable->getTableData()->nodeGroups.contains(nodeGroupIdx)) {
+            readState.localNodeGroup = ku_dynamic_cast<LocalNodeGroup*, LocalNodeNG*>(
+                localNodeTable->getTableData()->nodeGroups.at(nodeGroupIdx).get());
+        }
+    }
+}
+
+void NodeTableData::read(Transaction* transaction, TableDataReadState& readState,
+    const ValueVector& nodeIDVector, const std::vector<ValueVector*>& outputVectors) {
+    auto& nodeReadState = ku_dynamic_cast<TableDataReadState&, NodeDataReadState&>(readState);
+    if (!nodeReadState.readFromPersistent) {
+        return;
+    }
+    if (nodeIDVector.isSequential()) {
+        scan(transaction, readState, nodeIDVector, outputVectors);
+    } else {
+        lookup(transaction, readState, nodeIDVector, outputVectors);
+    }
+}
+
 void NodeTableData::scan(Transaction* transaction, TableDataReadState& readState,
     const ValueVector& nodeIDVector, const std::vector<ValueVector*>& outputVectors) {
     KU_ASSERT(readState.columnIDs.size() == outputVectors.size() && !nodeIDVector.state->isFlat());
@@ -39,23 +137,34 @@ void NodeTableData::scan(Transaction* transaction, TableDataReadState& readState
             outputVectors[i]->setAllNull();
         } else {
             KU_ASSERT(readState.columnIDs[i] < columns.size());
+            auto& nodeDataReadState =
+                ku_dynamic_cast<TableDataReadState&, NodeDataReadState&>(readState);
+            // TODO: Remove `const_cast` on nodeIDVector.
             columns[readState.columnIDs[i]]->scan(transaction,
-                const_cast<ValueVector*>(&nodeIDVector), outputVectors[i]);
+                nodeDataReadState.columnReadStates[i], const_cast<ValueVector*>(&nodeIDVector),
+                outputVectors[i]);
         }
     }
 }
 
 void NodeTableData::lookup(Transaction* transaction, TableDataReadState& readState,
     const ValueVector& nodeIDVector, const std::vector<ValueVector*>& outputVectors) {
-    auto pos = nodeIDVector.state->selVector->selectedPositions[0];
-    for (auto i = 0u; i < readState.columnIDs.size(); i++) {
-        auto columnID = readState.columnIDs[i];
+    for (auto columnIdx = 0u; columnIdx < readState.columnIDs.size(); columnIdx++) {
+        auto columnID = readState.columnIDs[columnIdx];
         if (columnID == INVALID_COLUMN_ID) {
-            outputVectors[i]->setNull(pos, true);
+            KU_ASSERT(outputVectors[columnIdx]->state == nodeIDVector.state);
+            for (auto i = 0u; i < outputVectors[columnIdx]->state->selVector->selectedSize; i++) {
+                auto pos = outputVectors[columnIdx]->state->selVector->selectedPositions[i];
+                outputVectors[i]->setNull(pos, true);
+            }
         } else {
-            KU_ASSERT(readState.columnIDs[i] < columns.size());
-            columns[readState.columnIDs[i]]->lookup(transaction,
-                const_cast<ValueVector*>(&nodeIDVector), outputVectors[i]);
+            KU_ASSERT(readState.columnIDs[columnIdx] < columns.size());
+            auto& nodeDataReadState =
+                ku_dynamic_cast<TableDataReadState&, NodeDataReadState&>(readState);
+            // TODO: Remove `const_cast` on nodeIDVector.
+            columns[readState.columnIDs[columnIdx]]->lookup(transaction,
+                nodeDataReadState.columnReadStates[columnIdx],
+                const_cast<ValueVector*>(&nodeIDVector), outputVectors[columnIdx]);
         }
     }
 }

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -46,10 +46,10 @@ NullColumn::NullColumn(std::string name, page_idx_t metaDAHPageIdx, BMFileHandle
     batchLookupFunc = nullptr;
 }
 
-void NullColumn::scan(Transaction* transaction, ValueVector* nodeIDVector,
+void NullColumn::scan(Transaction* transaction, ReadState& readState, ValueVector* nodeIDVector,
     ValueVector* resultVector) {
     if (propertyStatistics.mayHaveNull(*transaction)) {
-        scanInternal(transaction, nodeIDVector, resultVector);
+        scanInternal(transaction, readState, nodeIDVector, resultVector);
     } else {
         resultVector->setAllNonNull();
     }
@@ -85,10 +85,10 @@ void NullColumn::scan(transaction::Transaction* transaction, node_group_idx_t no
     }
 }
 
-void NullColumn::lookup(Transaction* transaction, ValueVector* nodeIDVector,
+void NullColumn::lookup(Transaction* transaction, ReadState& readState, ValueVector* nodeIDVector,
     ValueVector* resultVector) {
     if (propertyStatistics.mayHaveNull(*transaction)) {
-        lookupInternal(transaction, nodeIDVector, resultVector);
+        lookupInternal(transaction, readState, nodeIDVector, resultVector);
     } else {
         for (auto i = 0ul; i < nodeIDVector->state->selVector->selectedSize; i++) {
             auto pos = nodeIDVector->state->selVector->selectedPositions[i];
@@ -122,16 +122,14 @@ bool NullColumn::isNull(transaction::Transaction* transaction, node_group_idx_t 
 }
 
 void NullColumn::setNull(node_group_idx_t nodeGroupIdx, offset_t offsetInChunk, uint64_t value) {
-    auto chunkMeta = metadataDA->get(nodeGroupIdx, TransactionType::WRITE);
     propertyStatistics.setHasNull(DUMMY_WRITE_TRANSACTION);
     // Must be aligned to an 8-byte chunk for NullMask read to not overflow
-    auto state = ReadState{chunkMeta,
-        chunkMeta.compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType)};
+    auto state = getReadState(TransactionType::WRITE, nodeGroupIdx);
     writeValues(state, offsetInChunk, reinterpret_cast<const uint8_t*>(&value),
         nullptr /*nullChunkData=*/);
-    if (offsetInChunk >= chunkMeta.numValues) {
-        chunkMeta.numValues = offsetInChunk + 1;
-        metadataDA->update(nodeGroupIdx, chunkMeta);
+    if (offsetInChunk >= state.metadata.numValues) {
+        state.metadata.numValues = offsetInChunk + 1;
+        metadataDA->update(nodeGroupIdx, state.metadata);
     }
 }
 

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -1,6 +1,5 @@
 #include "storage/store/null_column.h"
 
-#include "common/constants.h"
 #include "transaction/transaction.h"
 
 namespace kuzu {

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -405,3 +405,24 @@ v3|v2
 -STATEMENT MATCH (n:MyTask) RETURN n.*;
 ---- 1
 myid|[{input1=value1}]
+
+-CASE 2890
+-STATEMENT create node table SpotTableNode(model_key STRING, technical_name STRING, name STRING, row_count INT64, PRIMARY KEY (model_key))
+---- ok
+-STATEMENT create node table SpotColumnNode(model_key STRING, technical_name STRING, name STRING, p_unique DOUBLE, p_distinct DOUBLE, p_missing DOUBLE, common_values STRING[], PRIMARY KEY (model_key))
+---- ok
+-STATEMENT CREATE REL TABLE SpotTableToCol(FROM SpotTableNode TO SpotColumnNode)
+---- ok
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT CREATE(t:SpotTableNode { model_key : 'tableSchema::tpcds_1.tpcds.store_returns',technical_name : 'tpcds.store_returns',name : 'Store Returns',row_count : 288279 })
+---- ok
+-STATEMENT CREATE(t:SpotColumnNode { model_key : 'columnSchema::tpcds_1.tpcds.store_returns.sr_return_time_sk',technical_name : 'sr_return_time_sk',name : 'Return Time',p_unique : 0.055061,p_distinct : 0.318826,p_missing : 0.000000,common_values : ['33413', '31810', '54900', '54638', '45302'] })
+---- ok
+-STATEMENT MATCH (l:SpotTableNode), (r:SpotColumnNode)
+                         WHERE l.model_key = 'tableSchema::tpcds_1.tpcds.store_returns' and
+                               r.model_key = 'columnSchema::tpcds_1.tpcds.store_returns.sr_return_time_sk'
+           CREATE (l)-[:SpotTableToCol {  }]->(r)
+---- ok
+-STATEMENT COMMIT
+---- ok

--- a/test/test_files/update_node/create_empty.test
+++ b/test/test_files/update_node/create_empty.test
@@ -21,9 +21,7 @@
 ---- 1
 {age: 10, isTrue: True, name: A}
 
-#FIX-ME: This case is due to the bug of reading under write transaction. #2647
 -CASE CreateStructWithWriteTransaction
--SKIP
 -STATEMENT CREATE NODE TABLE test(id INT64, prop STRUCT(age INT64, name STRING), PRIMARY KEY(id));
 ---- ok
 -STATEMENT BEGIN TRANSACTION


### PR DESCRIPTION
Introduce `NodeTableReadState`, which is always initialized before `read`.
The state caches column read states of the same node group, and local node group to read.

Fix #2890 and #2647.

#2257 is still not fixed. will leave that for a later PR that to correctly figure out nodeOffset (numValues) to read from persistent storage.