### PR TITLE
Implement Pyarrow Union Scanning

### DIFF
--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -246,10 +246,11 @@ static void scanArrowArrayDenseUnion(const ArrowSchema* schema, const ArrowArray
         }
         if (!mask->isNull(i)) {
             dstTypes[i] = curType;
-            auto childOffset = mask->getChild(curType)->offsetBy(curOffset - firstIncident[curType]);
+            auto childOffset =
+                mask->getChild(curType)->offsetBy(curOffset - firstIncident[curType]);
             ArrowConverter::fromArrowArray(schema->children[curType], array->children[curType],
-                *UnionVector::getValVector(&outputVector, curType),
-                &childOffset, curOffset + array->children[curType]->offset, i + dstOffset, 1);
+                *UnionVector::getValVector(&outputVector, curType), &childOffset,
+                curOffset + array->children[curType]->offset, i + dstOffset, 1);
             // may be inefficient, since we're only scanning a single value
         }
     }

--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -238,7 +238,7 @@ static void scanArrowArrayDenseUnion(const ArrowSchema* schema, const ArrowArray
     auto offsets = ((const int32_t*)array->buffers[1]) + srcOffset;
     mask->copyToValueVector(&outputVector, dstOffset, count);
     std::vector<int32_t> firstIncident(array->n_children, INT32_MAX);
-    for (uint64_t i = 0; i < count; i++) {
+    for (auto i = 0u; i < count; i++) {
         auto curType = types[i];
         auto curOffset = offsets[i];
         if (curOffset < firstIncident[curType]) {

--- a/src/common/arrow/arrow_null_mask_tree.cpp
+++ b/src/common/arrow/arrow_null_mask_tree.cpp
@@ -167,8 +167,8 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
                 for (auto i = 0u; i < count; i++) {
                     int32_t curOffset = offsets[i + srcOffset];
                     int8_t curType = types[i + srcOffset];
-                    mask->setNull(i, children->operator[](curType).isNull(
-                        curOffset - lowestOffsets[curType]));
+                    mask->setNull(i,
+                        children->operator[](curType).isNull(curOffset - lowestOffsets[curType]));
                 }
             } else {
                 for (int64_t i = 0; i < array->n_children; i++) {

--- a/src/common/arrow/arrow_null_mask_tree.cpp
+++ b/src/common/arrow/arrow_null_mask_tree.cpp
@@ -162,7 +162,7 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
                 for (int64_t i = 0; i < array->n_children; i++) {
                     children->push_back(ArrowNullMaskTree(schema->children[i], array->children[i],
                         lowestOffsets[i] + array->children[i]->offset,
-                        highestOffsets[i] - lowestOffsets[i]));
+                        highestOffsets[i] - lowestOffsets[i] + 1));
                 }
                 for (auto i = 0u; i < count; i++) {
                     int32_t curOffset = offsets[i + srcOffset];

--- a/src/common/arrow/arrow_null_mask_tree.cpp
+++ b/src/common/arrow/arrow_null_mask_tree.cpp
@@ -15,7 +15,7 @@ void ArrowNullMaskTree::copyToValueVector(ValueVector* vec, uint64_t dstOffset, 
     vec->setNullFromBits(mask->getData(), offset, dstOffset, count);
 }
 
-ArrowNullMaskTree ArrowNullMaskTree::operator+(int64_t offset) {
+ArrowNullMaskTree ArrowNullMaskTree::offsetBy(int64_t offset) {
     // this operation is mostly a special case for dictionary/run-end encoding
     ArrowNullMaskTree ret(*this);
     ret.offset += offset;
@@ -144,9 +144,9 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
             scanListPushDown<int32_t>(schema, array, srcOffset, count);
             break;
         case 'u': {
-            const int8_t* types = (const int8_t*)array->buffers[0];
+            auto types = (const int8_t*)array->buffers[0];
             if (schema->format[2] == 'd') {
-                const int32_t* offsets = (const int32_t*)array->buffers[1];
+                auto offsets = (const int32_t*)array->buffers[1];
                 std::vector<int32_t> countChildren(array->n_children),
                     lowestOffsets(array->n_children);
                 std::vector<int32_t> highestOffsets(array->n_children);
@@ -161,17 +161,19 @@ ArrowNullMaskTree::ArrowNullMaskTree(const ArrowSchema* schema, const ArrowArray
                 }
                 for (int64_t i = 0; i < array->n_children; i++) {
                     children->push_back(ArrowNullMaskTree(schema->children[i], array->children[i],
-                        lowestOffsets[i], highestOffsets[i] - lowestOffsets[i]));
+                        lowestOffsets[i] + array->children[i]->offset,
+                        highestOffsets[i] - lowestOffsets[i]));
                 }
                 for (auto i = 0u; i < count; i++) {
                     int32_t curOffset = offsets[i + srcOffset];
                     int8_t curType = types[i + srcOffset];
-                    mask->setNull(i, children->operator[](curType).isNull(curOffset));
+                    mask->setNull(i, children->operator[](curType).isNull(
+                        curOffset - lowestOffsets[curType]));
                 }
             } else {
                 for (int64_t i = 0; i < array->n_children; i++) {
                     children->push_back(ArrowNullMaskTree(schema->children[i], array->children[i],
-                        srcOffset, count));
+                        srcOffset + array->children[i]->offset, count));
                 }
                 for (auto i = 0u; i < count; i++) {
                     int8_t curType = types[i + srcOffset];

--- a/src/common/arrow/arrow_type.cpp
+++ b/src/common/arrow/arrow_type.cpp
@@ -116,13 +116,14 @@ LogicalType ArrowConverter::fromArrowSchema(const ArrowSchema* schema) {
             return *LogicalType::MAP(
                 std::make_unique<LogicalType>(fromArrowSchema(schema->children[0]->children[0])),
                 std::make_unique<LogicalType>(fromArrowSchema(schema->children[0]->children[1])));
-        case 'u':
-            throw RuntimeException("Unions are currently WIP.");
+        case 'u': {
+            structFields.emplace_back(UnionType::TAG_FIELD_NAME, LogicalType::INT8());
             for (int64_t i = 0; i < schema->n_children; i++) {
-                structFields.emplace_back(std::string(schema->children[i]->name),
+                structFields.emplace_back(std::to_string(i),
                     std::make_unique<LogicalType>(fromArrowSchema(schema->children[i])));
             }
             return *LogicalType::UNION(std::move(structFields));
+        }
         case 'v':
             switch (arrowType[2]) {
             case 'l':

--- a/src/common/arrow/arrow_type.cpp
+++ b/src/common/arrow/arrow_type.cpp
@@ -36,6 +36,8 @@ LogicalType ArrowConverter::fromArrowSchema(const ArrowSchema* schema) {
         return LogicalType(LogicalTypeID::INT64);
     case 'L':
         return LogicalType(LogicalTypeID::UINT64);
+    case 'e':
+        throw NotImplementedException("16 bit floats are not supported");
     case 'f':
         return LogicalType(LogicalTypeID::FLOAT);
     case 'g':

--- a/src/common/arrow/arrow_type.cpp
+++ b/src/common/arrow/arrow_type.cpp
@@ -1,6 +1,5 @@
 #include "common/arrow/arrow_converter.h"
 #include "common/exception/not_implemented.h"
-#include "common/exception/runtime.h"
 
 namespace kuzu {
 namespace common {

--- a/src/include/common/arrow/arrow_nullmask_tree.h
+++ b/src/include/common/arrow/arrow_nullmask_tree.h
@@ -16,7 +16,7 @@ public:
     bool isNull(int64_t idx) { return mask->isNull(idx + offset); }
     ArrowNullMaskTree* getChild(int idx) { return &(*children)[idx]; }
     ArrowNullMaskTree* getDictionary() { return dictionary.get(); }
-    ArrowNullMaskTree operator+(int64_t offset);
+    ArrowNullMaskTree offsetBy(int64_t offset);
 
 private:
     bool copyFromBuffer(const void* buffer, uint64_t srcOffset, uint64_t count);

--- a/tools/python_api/test/test_df_pyarrow.py
+++ b/tools/python_api/test/test_df_pyarrow.py
@@ -507,8 +507,39 @@ def test_pyarrow_union_sparse(conn_db_readonly : ConnDB) -> None:
 
     assert idx == len(index)
 
+def test_pyarrow_union_dense(conn_db_readonly : ConnDB) -> None:
+    conn, db = conn_db_readonly
+    random.seed(100)
+    datalength = 4096
+    index = pa.array(range(datalength))
+    _type_codes = [random.randint(0, 2) for i in range(datalength)]
+    type_codes = pa.array(_type_codes, type=pa.int8())
+    _offsets = [0 for _ in range(datalength)]
+    _cnt = [0,0,0]
+    for i in range(len(_type_codes)):
+        _offsets[i] = _cnt[_type_codes[i]]
+        _cnt[_type_codes[i]] += 1
+    offsets = pa.array(_offsets, type=pa.int32())
+    arr1 = pa.array([generate_primitive('int32[pyarrow]') for i in range(datalength)], type=pa.int32())
+    arr2 = pa.array([generate_string(random.randint(1, 10)) for i in range(datalength)])
+    arr3 = pa.array([generate_primitive('float32[pyarrow]') for j in range(datalength)])
+    col1 = pa.UnionArray.from_dense(type_codes, offsets, [arr1, arr2, arr3])
+    df = pd.DataFrame({
+        'index': arrowtopd(index),
+        'col1': arrowtopd(col1)
+    })
+    result = conn.execute('LOAD FROM df RETURN * ORDER BY index')
+    idx = 0
+    while result.has_next():
+        assert idx < len(index)
+        nxt = result.get_next()
+        expected = [idx, col1[idx].as_py()]
+        assert expected == nxt or (is_null(nxt[1]) and is_null(expected[1]))
+        idx += 1
 
-def test_pyarrow_map(conn_db_readonly: ConnDB) -> None:
+    assert idx == len(index)
+
+def test_pyarrow_map(conn_db_readonly : ConnDB) -> None:
     conn, db = conn_db_readonly
     random.seed(100)
     datalength = 4096


### PR DESCRIPTION
Implements both dense unions and sparse unions. Makes progress towards #3264 

The remaining missing types are:
- float16
- decimal

Float16 and Decimal aren't implemented because there isn't a close equivalent in Kuzu.
Float16 is used for compressed storage of floats, while decimals can store high width integers or high precision real numbers. Neither of these things are currently done in Kuzu.

- pure time types (ie time of the day)

The implementation of Kuzu's time type is currently incomplete. 
