### PR TITLE
Optimize Hash Index slot splitting

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -116,8 +116,7 @@ private:
 
     inline uint64_t appendOverflowSlot(Slot<T>&& newSlot) { return oSlots->pushBack(newSlot); }
 
-    inline void splitSlot(HashIndexHeader& header);
-    void rehashSlots(HashIndexHeader& header);
+    void splitSlots(HashIndexHeader& header, slot_id_t numSlotsToSplit);
 
     // Resizes the local storage to support the given number of new entries
     inline void bulkReserve(uint64_t /*newEntries*/) override {

--- a/src/storage/index/in_mem_hash_index.cpp
+++ b/src/storage/index/in_mem_hash_index.cpp
@@ -29,7 +29,9 @@ InMemHashIndex<T>::InMemHashIndex(OverflowFileHandle* overflowFileHandle)
       pSlots{std::make_unique<InMemDiskArrayBuilder<Slot<T>>>(dummy, 0, 0, true)},
       oSlots{std::make_unique<InMemDiskArrayBuilder<Slot<T>>>(dummy, 0, 1, true)},
       indexHeader{TypeUtils::getPhysicalTypeIDForType<T>()} {
-    allocatePSlots(1u << this->indexHeader.currentLevel);
+    // Match HashIndex in allocating at least one page of slots so that we don't split within the
+    // same page
+    allocateSlots(BufferPoolConstants::PAGE_4KB_SIZE / pSlots->getAlignedElementSize());
 }
 
 template<typename T>


### PR DESCRIPTION
As referenced in #3298 , the `rehashSlots` method (now merged with `splitSlot` into `splitSlots`) had not been optimized for bulk splitting, which was bottlenecking the performance of multiple copies. This removes that bottleneck, improving the performance of the second copy to ~2.8x the cost of the first (when they are the same size that is).

It was necessary to remove the locking on the disk array `WriteIterator` so that multiple can be used on different pages at the same time (the original slot and new slot in this case). Overflow slots are more complicated, and since we can generally assume there are relatively few of them I made it cache new overflow slots in memory and append them at the end so that it's not necessary to juggle two different slot pointers and iterators which can't overlap at the risk of invalidating the other slot pointer and needing to track which iterator is used for which slot at any given time.
To avoid a similar issue with primary slots, I made the minimum number of primary slots allocated the first time be 16 (one full page of slots) so that the original slot and the new slot are never on the same page when splitting.