### PR TITLE
Fix incorrect casting

### DIFF
--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -116,7 +116,7 @@ static void nestedTypesCastExecFunction(const std::vector<std::shared_ptr<ValueV
 
     auto selVector = inputVector->state->selVector;
     auto bindData = CastFunctionBindData(result.dataType.copy());
-    auto numOfEntries= selVector->selectedPositions[selVector->selectedSize - 1] + 1;
+    auto numOfEntries = selVector->selectedPositions[selVector->selectedSize - 1] + 1;
     resolveNestedVector(inputVector, &result, numOfEntries, &bindData);
 }
 

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -16,6 +16,21 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace function {
 
+struct CastChildFunctionExecutor {
+    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC, typename OP_WRAPPER>
+    static void executeSwitch(common::ValueVector& operand, common::ValueVector& result,
+        void* dataPtr) {
+        auto numOfEntries = reinterpret_cast<CastFunctionBindData*>(dataPtr)->numOfEntries;
+        for (auto i = 0u; i < numOfEntries; i++) {
+            result.setNull(i, operand.isNull(i));
+            if (!result.isNull(i)) {
+                OP_WRAPPER::template operation<OPERAND_TYPE, RESULT_TYPE, FUNC>((void*)(&operand),
+                    i, (void*)(&result), i, dataPtr);
+            }
+        }
+    }
+};
+
 static void resolveNestedVector(std::shared_ptr<ValueVector> inputVector, ValueVector* resultVector,
     uint64_t numOfEntries, CastFunctionBindData* dataPtr) {
     auto inputType = &inputVector->dataType;
@@ -99,11 +114,10 @@ static void nestedTypesCastExecFunction(const std::vector<std::shared_ptr<ValueV
         }
     };
 
-    auto numOfEntries = inputVector->state->selVector
-                            ->selectedPositions[inputVector->state->selVector->selectedSize - 1] +
-                        1;
-    resolveNestedVector(inputVector, &result, numOfEntries,
-        reinterpret_cast<CastFunctionBindData*>(dataPtr));
+    auto selVector = inputVector->state->selVector;
+    auto bindData = CastFunctionBindData(result.dataType.copy());
+    auto numOfEntries= selVector->selectedPositions[selVector->selectedSize - 1] + 1;
+    resolveNestedVector(inputVector, &result, numOfEntries, &bindData);
 }
 
 static bool hasImplicitCastList(const LogicalType& srcType, const LogicalType& dstType) {

--- a/src/include/function/unary_function_executor.h
+++ b/src/include/function/unary_function_executor.h
@@ -90,21 +90,6 @@ struct UnaryUDFFunctionWrapper {
     }
 };
 
-struct CastChildFunctionExecutor {
-    template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC, typename OP_WRAPPER>
-    static void executeSwitch(common::ValueVector& operand, common::ValueVector& result,
-        void* dataPtr) {
-        auto numOfEntries = reinterpret_cast<CastFunctionBindData*>(dataPtr)->numOfEntries;
-        for (auto i = 0u; i < numOfEntries; i++) {
-            result.setNull(i, operand.isNull(i));
-            if (!result.isNull(i)) {
-                OP_WRAPPER::template operation<OPERAND_TYPE, RESULT_TYPE, FUNC>((void*)(&operand),
-                    i, (void*)(&result), i, dataPtr);
-            }
-        }
-    }
-};
-
 struct UnaryFunctionExecutor {
     template<typename OPERAND_TYPE, typename RESULT_TYPE, typename FUNC, typename OP_WRAPPER>
     static void executeOnValue(common::ValueVector& inputVector, uint64_t inputPos,

--- a/test/optimizer/optimizer_test.cpp
+++ b/test/optimizer/optimizer_test.cpp
@@ -24,7 +24,8 @@ public:
 };
 
 TEST_F(OptimizerTest, CrossJoinWithFilterWithoutPushDownTest) {
-    auto op = getRoot("MATCH (a:person) MATCH (b:person) where a.fName=b.fName and a.gender <> b.gender RETURN a.gender;");
+    auto op = getRoot("MATCH (a:person) MATCH (b:person) where a.fName=b.fName and a.gender <> "
+                      "b.gender RETURN a.gender;");
     ASSERT_EQ(op->getOperatorType(), planner::LogicalOperatorType::PROJECTION);
     op = op->getChild(0);
     ASSERT_EQ(op->getOperatorType(), planner::LogicalOperatorType::FILTER);
@@ -33,7 +34,8 @@ TEST_F(OptimizerTest, CrossJoinWithFilterWithoutPushDownTest) {
 }
 
 TEST_F(OptimizerTest, CrossJoinWithFilterPushDownTest) {
-    auto op = getRoot("MATCH (a:person) , (b:person) where a.fName=b.fName and a.fName is null RETURN a.gender;");
+    auto op = getRoot(
+        "MATCH (a:person) , (b:person) where a.fName=b.fName and a.fName is null RETURN a.gender;");
     ASSERT_EQ(op->getOperatorType(), planner::LogicalOperatorType::PROJECTION);
     op = op->getChild(0);
     ASSERT_EQ(op->getOperatorType(), planner::LogicalOperatorType::HASH_JOIN);


### PR DESCRIPTION
This was the bug causing #3308 failure. Apparently, `reinterpret_cast<CastFunctionBindData*>(dataPtr)` this line is casting from a `clientContext` to `CastFunctionBindData` 