### PR TITLE
Fix MaxLogicalType error and use it for python parameters

### DIFF
--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1309,19 +1309,38 @@ static uint32_t internalTimeOrder(const LogicalTypeID& type) {
     }
 }
 
-bool canAlwaysCast(const LogicalTypeID& typeID) {
+static int alwaysCastOrder(const LogicalTypeID& typeID) {
+    switch(typeID) {
+        case LogicalTypeID::ANY:
+            return 0;
+        case LogicalTypeID::RDF_VARIANT:
+            return 1;
+        case LogicalTypeID::STRING:
+            return 2;
+    }
+}
+
+static bool canAlwaysCast(const LogicalTypeID& typeID) {
     switch (typeID) {
     case LogicalTypeID::ANY:
     case LogicalTypeID::STRING:
     case LogicalTypeID::RDF_VARIANT:
         return true;
     default:
-        return false;
+        return 0;
     }
 }
 
 bool LogicalTypeUtils::tryGetMaxLogicalTypeID(const LogicalTypeID& left, const LogicalTypeID& right,
     LogicalTypeID& result) {
+    if (canAlwaysCast(left) && canAlwaysCast(right)) {
+        if (alwaysCastOrder(left) > alwaysCastOrder(right)) {
+            result = left;
+        } else {
+            result = right;
+        }
+        return true;
+    }
     if (left == right || canAlwaysCast(left)) {
         result = right;
         return true;
@@ -1373,6 +1392,14 @@ static inline bool isSemanticallyNested(LogicalTypeID ID) {
 
 bool LogicalTypeUtils::tryGetMaxLogicalType(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
+    if (canAlwaysCast(left.typeID) && canAlwaysCast(right.typeID)) {
+        if (alwaysCastOrder(left.typeID) > alwaysCastOrder(right.typeID)) {
+            result = left;
+        } else {
+            result = right;
+        }
+        return true;
+    }
     if (left == right || canAlwaysCast(left.typeID)) {
         result = right;
         return true;

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1317,6 +1317,8 @@ static int alwaysCastOrder(const LogicalTypeID& typeID) {
         return 1;
     case LogicalTypeID::STRING:
         return 2;
+    default:
+        return -1;
     }
 }
 

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1329,7 +1329,7 @@ static bool canAlwaysCast(const LogicalTypeID& typeID) {
     case LogicalTypeID::RDF_VARIANT:
         return true;
     default:
-        return 0;
+        return false;
     }
 }
 

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -78,5 +78,29 @@ bool isLittleEndian() {
     return *(uint8_t*)&testNumber == 1;
 }
 
+template<>
+bool integerFitsIn<int64_t>(int64_t val) {return true;}
+
+template<>
+bool integerFitsIn<int32_t>(int64_t val) {return val >= INT32_MIN && val <= INT32_MAX;}
+
+template<>
+bool integerFitsIn<int16_t>(int64_t val) {return val >= INT16_MIN && val <= INT16_MAX;}
+
+template<>
+bool integerFitsIn<int8_t>(int64_t val) {return val >= INT8_MIN && val <= INT8_MAX;}
+
+template<>
+bool integerFitsIn<uint64_t>(int64_t val) {return val >= 0;}
+
+template<>
+bool integerFitsIn<uint32_t>(int64_t val) {return val >= 0 && val <= UINT32_MAX;}
+
+template<>
+bool integerFitsIn<uint16_t>(int64_t val) {return val >= 0 && val <= UINT16_MAX;}
+
+template<>
+bool integerFitsIn<uint8_t>(int64_t val) {return val >= 0 && val <= UINT8_MAX;}
+
 } // namespace common
 } // namespace kuzu

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -79,7 +79,7 @@ bool isLittleEndian() {
 }
 
 template<>
-bool integerFitsIn<int64_t>(int64_t val) {
+bool integerFitsIn<int64_t>(int64_t) {
     return true;
 }
 

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -39,6 +39,9 @@ uint64_t nextPowerOfTwo(uint64_t v);
 bool isLittleEndian();
 
 template<typename T>
+bool integerFitsIn(int64_t val);
+
+template<typename T>
 std::vector<T> copyVector(const std::vector<T>& objects) {
     std::vector<T> result;
     result.reserve(objects.size());

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -267,7 +267,6 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
     auto datetime_datetime = importCache->datetime.datetime();
     auto time_delta = importCache->datetime.timedelta();
     auto datetime_date = importCache->datetime.date();
-    auto uuid = importCache->uuid.UUID();
     if (val.is_none()) {
         return Value::createNullValue(*type);
     }

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -7,6 +7,7 @@
 #include "common/exception/runtime.h"
 #include "common/string_format.h"
 #include "common/types/uuid.h"
+#include "common/utils.h"
 #include "datetime.h" // from Python
 #include "function/built_in_function_utils.h"
 #include "main/connection.h"
@@ -180,67 +181,6 @@ static std::unordered_map<std::string, std::unique_ptr<Value>> transformPythonPa
     return result;
 }
 
-static bool canCastPyLogicalType(const LogicalType& from, const LogicalType& to) {
-    // the input of this function is restricted to the output of pyLogicalType
-    if (from.getLogicalTypeID() == LogicalTypeID::ANY ||
-        from.getLogicalTypeID() == to.getLogicalTypeID()) {
-        return true;
-    } else if (to.getLogicalTypeID() == LogicalTypeID::ANY) {
-        return false;
-    } else if (from.getLogicalTypeID() == LogicalTypeID::MAP) {
-        if (to.getLogicalTypeID() != LogicalTypeID::MAP) {
-            return false;
-        }
-        auto fromKeyType = MapType::getKeyType(&from), fromValueType = MapType::getValueType(&to);
-        auto toKeyType = MapType::getKeyType(&to), toValueType = MapType::getValueType(&to);
-        return (canCastPyLogicalType(*fromKeyType, *toKeyType) ||
-                   canCastPyLogicalType(*toKeyType, *fromKeyType)) &&
-               (canCastPyLogicalType(*fromValueType, *toValueType) ||
-                   canCastPyLogicalType(*toValueType, *fromValueType));
-    } else if (from.getLogicalTypeID() == LogicalTypeID::LIST) {
-        if (to.getLogicalTypeID() != LogicalTypeID::LIST) {
-            return false;
-        }
-        return canCastPyLogicalType(*ListType::getChildType(&from), *ListType::getChildType(&to));
-    } else {
-        auto castCost = function::BuiltInFunctionsUtils::getCastCost(from.getLogicalTypeID(),
-            to.getLogicalTypeID());
-        return castCost != UNDEFINED_CAST_COST;
-    }
-    return false;
-}
-
-static void tryConvertPyLogicalType(LogicalType& from, LogicalType& to);
-
-static std::unique_ptr<LogicalType> castPyLogicalType(const LogicalType& from,
-    const LogicalType& to) {
-    // assumes from can cast to to
-    if (from.getLogicalTypeID() == LogicalTypeID::MAP) {
-        auto fromKeyType = MapType::getKeyType(&from), fromValueType = MapType::getValueType(&from);
-        auto toKeyType = MapType::getKeyType(&to), toValueType = MapType::getValueType(&to);
-        auto outputKeyType = canCastPyLogicalType(*fromKeyType, *toKeyType) ?
-                                 castPyLogicalType(*fromKeyType, *toKeyType) :
-                                 castPyLogicalType(*toKeyType, *fromKeyType);
-        auto outputValueType = canCastPyLogicalType(*fromValueType, *toValueType) ?
-                                   castPyLogicalType(*fromValueType, *toValueType) :
-                                   castPyLogicalType(*toValueType, *fromValueType);
-        return LogicalType::MAP(std::move(outputKeyType), std::move(outputValueType));
-    }
-    return std::make_unique<LogicalType>(to);
-}
-
-void tryConvertPyLogicalType(LogicalType& from, LogicalType& to) {
-    if (canCastPyLogicalType(from, to)) {
-        from = *castPyLogicalType(from, to);
-    } else if (canCastPyLogicalType(to, from)) {
-        to = *castPyLogicalType(to, from);
-    } else {
-        throw RuntimeException(
-            stringFormat("Cannot convert Python object to Kuzu value : {}  is incompatible with {}",
-                from.toString(), to.toString()));
-    }
-}
-
 static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
     auto datetime_datetime = importCache->datetime.datetime();
     auto time_delta = importCache->datetime.timedelta();
@@ -251,7 +191,22 @@ static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
     } else if (py::isinstance<py::bool_>(val)) {
         return LogicalType::BOOL();
     } else if (py::isinstance<py::int_>(val)) {
-        return LogicalType::INT64();
+        auto nativeValue = val.cast<int64_t>();
+        if (integerFitsIn<int8_t>(nativeValue)) {
+            return LogicalType::INT8();
+        } else if (integerFitsIn<uint8_t>(nativeValue)) {
+            return LogicalType::UINT8();
+        } else if (integerFitsIn<int16_t>(nativeValue)) {
+            return LogicalType::INT16();
+        } else if (integerFitsIn<uint16_t>(nativeValue)) {
+            return LogicalType::UINT16();
+        } else if (integerFitsIn<int32_t>(nativeValue)) {
+            return LogicalType::INT32();
+        } else if (integerFitsIn<uint32_t>(nativeValue)) {
+            return LogicalType::UINT32();
+        } else {
+            return LogicalType::INT64();
+        }
     } else if (py::isinstance<py::float_>(val)) {
         return LogicalType::DOUBLE();
     } else if (py::isinstance<py::str>(val)) {
@@ -269,7 +224,13 @@ static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
         auto childType = LogicalType::ANY();
         for (auto child : lst) {
             auto curChildType = pyLogicalType(child);
-            tryConvertPyLogicalType(*childType, *curChildType);
+            LogicalType result;
+            if (!LogicalTypeUtils::tryGetMaxLogicalType(*childType, *curChildType, result)) {
+                throw RuntimeException(
+                    stringFormat("Cannot convert Python object to Kuzu value : {}  is incompatible with {}",
+                        childType->toString(), curChildType->toString()));
+            }
+            childType = std::make_unique<LogicalType>(result);
         }
         return LogicalType::LIST(std::move(childType));
     } else if (py::isinstance<py::dict>(val)) {
@@ -278,8 +239,19 @@ static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
         for (auto child : dict) {
             auto curChildKeyType = pyLogicalType(child.first),
                  curChildValueType = pyLogicalType(child.second);
-            tryConvertPyLogicalType(*childKeyType, *curChildKeyType);
-            tryConvertPyLogicalType(*childValueType, *curChildValueType);
+            LogicalType resultKey, resultValue;
+            if (!LogicalTypeUtils::tryGetMaxLogicalType(*childKeyType, *curChildKeyType, resultKey)) {
+                throw RuntimeException(
+                    stringFormat("Cannot convert Python object to Kuzu value : {}  is incompatible with {}",
+                        childKeyType->toString(), curChildKeyType->toString()));
+            }
+            if (!LogicalTypeUtils::tryGetMaxLogicalType(*childValueType, *curChildValueType, resultValue)) {
+                throw RuntimeException(
+                    stringFormat("Cannot convert Python object to Kuzu value : {}  is incompatible with {}",
+                        childValueType->toString(), curChildValueType->toString()));
+            }
+            childKeyType = std::make_unique<LogicalType>(resultKey);
+            childValueType = std::make_unique<LogicalType>(resultValue);
         }
         return LogicalType::MAP(std::move(childKeyType), std::move(childValueType));
     } else {
@@ -292,6 +264,10 @@ static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
 
 static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
     // ignore the type of the actual python object, just directly cast
+    auto datetime_datetime = importCache->datetime.datetime();
+    auto time_delta = importCache->datetime.timedelta();
+    auto datetime_date = importCache->datetime.date();
+    auto uuid = importCache->uuid.UUID();
     if (val.is_none()) {
         return Value::createNullValue(*type);
     }
@@ -299,11 +275,23 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
     case LogicalTypeID::ANY:
         return Value::createNullValue();
     case LogicalTypeID::BOOL:
-        return Value::createValue<bool>(val.cast<bool>());
+        return Value::createValue<bool>(py::cast<py::bool_>(val).cast<bool>());
     case LogicalTypeID::INT64:
-        return Value::createValue<int64_t>(val.cast<int64_t>());
+        return Value::createValue<int64_t>(py::cast<py::int_>(val).cast<int64_t>());
+    case LogicalTypeID::UINT32:
+        return Value::createValue<uint32_t>(py::cast<py::int_>(val).cast<int64_t>());
+    case LogicalTypeID::INT32:
+        return Value::createValue<int32_t>(py::cast<py::int_>(val).cast<int64_t>());
+    case LogicalTypeID::UINT16:
+        return Value::createValue<uint16_t>(py::cast<py::int_>(val).cast<int64_t>());
+    case LogicalTypeID::INT16:
+        return Value::createValue<int16_t>(py::cast<py::int_>(val).cast<int64_t>());
+    case LogicalTypeID::UINT8:
+        return Value::createValue<uint8_t>(py::cast<py::int_>(val).cast<int64_t>());
+    case LogicalTypeID::INT8:
+        return Value::createValue<int8_t>(py::cast<py::int_>(val).cast<int64_t>());
     case LogicalTypeID::DOUBLE:
-        return Value::createValue<double>(val.cast<double>());
+        return Value::createValue<double>(py::cast<py::float_>(val).cast<double>());
     case LogicalTypeID::STRING:
         if (py::isinstance<py::str>(val)) {
             return Value::createValue<std::string>(val.cast<std::string>());
@@ -311,6 +299,13 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
             return Value::createValue<std::string>(py::str(val));
         }
     case LogicalTypeID::TIMESTAMP: {
+        // LCOV_EXCL_START
+        if (!py::isinstance(val, datetime_datetime)) {
+            throw RuntimeException(
+                "Error: parameter is not of type datetime.datetime, \
+                but was resolved to type datetime.datetime");
+        }
+        // LCOV_EXCL_STOP
         auto ptr = val.ptr();
         auto year = PyDateTime_GET_YEAR(ptr);
         auto month = PyDateTime_GET_MONTH(ptr);
@@ -324,6 +319,13 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
         return Value::createValue<timestamp_t>(Timestamp::fromDateTime(date, time));
     }
     case LogicalTypeID::DATE: {
+        // LCOV_EXCL_START
+        if (!py::isinstance(val, datetime_date)) {
+            throw RuntimeException(
+                "Error: parameter is not of type datetime.date, \
+                but was resolved to type datetime.date");
+        }
+        // LCOV_EXCL_STOP
         auto ptr = val.ptr();
         auto year = PyDateTime_GET_YEAR(ptr);
         auto month = PyDateTime_GET_MONTH(ptr);
@@ -331,6 +333,13 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
         return Value::createValue<date_t>(Date::fromDate(year, month, day));
     }
     case LogicalTypeID::INTERVAL: {
+        // LCOV_EXCL_START
+        if (!py::isinstance(val, time_delta)) {
+            throw RuntimeException(
+                "Error: parameter is not of type datetime.timedelta, \
+                but was resolved to type datetime.timedelta");
+        }
+        // LCOV_EXCL_STOP
         auto ptr = val.ptr();
         auto days = PyDateTime_DELTA_GET_DAYS(ptr);
         auto seconds = PyDateTime_DELTA_GET_SECONDS(ptr);

--- a/tools/python_api/test/test_parameter.py
+++ b/tools/python_api/test/test_parameter.py
@@ -139,8 +139,8 @@ def test_general_list_param(tmp_path: Path) -> None:
     lst3 = [datetime.datetime(2019, 11, 12, 11, 25, 30), datetime.datetime(1987, 2, 15, 3, 0, 2)]
     lst4 = [datetime.date(2019, 11, 12), datetime.date(1987, 2, 15)]
     lst5 = [lst3[0] - lst3[1]]
-    lst6 = [1, "a", "b"]
-    lst6ToString = ["1", "a", "b"]
+    lst6 = [1, "2", "3"]
+    lst6ToString = ["1", "2", "3"]
     result = conn.execute(
         "MERGE (t:tab {id: 0, lst1: $1, lst2: $2, lst3: $3, lst4: $4, lst5: $5, lst6: $6}) RETURN t.*",
         {"1": lst1, "2": lst2, "3": lst3, "4": lst4, "5": lst5, "6": lst6},
@@ -159,10 +159,10 @@ def test_null_resolution(tmp_path: Path) -> None:
     )
     lst1 = [1, 2, 3, None]
     mp1 = {"a": "x", "b": "y", "c": "z", "o": None}
-    nest = [{"a": {"foo": 1, "bar": 2}}, {1: {}}]
+    nest = [{"2": {"foo": 1, "bar": 2}}, {1: {}}]
     result = conn.execute("MERGE (t:tab {lst1: $1, mp1: $2, nest: $3}) RETURN t.*", {"1": lst1, "2": mp1, "3": nest})
     assert result.has_next()
-    assert result.get_next() == [0, lst1, mp1, [{"a": {"foo": 1, "bar": 2}}, {"1": {}}]]
+    assert result.get_next() == [0, lst1, mp1, [{"2": {"foo": 1, "bar": 2}}, {"1": {}}]]
     assert not result.has_next()
     result.close()
 
@@ -227,7 +227,7 @@ def test_param_error4(conn_db_readonly: ConnDB) -> None:
     conn, db = conn_db_readonly
     with pytest.raises(
         RuntimeError,
-        match="Runtime exception: Cannot convert Python object to Kuzu value : INT64  is incompatible with TIMESTAMP",
+        match="Runtime exception: Cannot convert Python object to Kuzu value : INT8  is incompatible with TIMESTAMP",
     ):
         conn.execute(
             "MATCH (a:person {workedHours: $1}) RETURN COUNT(*);", {"1": [1, 2, datetime.datetime(2023, 3, 25)]}


### PR DESCRIPTION
When combining a type that could always cast with another type that could always cast, it's possible that we end up with an `ANY` type, which is not expected. eg. `MaxLogicalType(STRING, ANY)` could give `ANY`. This has been fixed, and it now returns string as expected.

MaxLogicalType has also been implemented in resolving the types of python parameters, which can be used to determine the signature of a python UDF.
