### PR TITLE
Fix distinct hash table performance bug

### DIFF
--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/aggregate/aggregate_hash_table.h"
 
+#include <chrono>
+
 #include "common/utils.h"
 
 using namespace kuzu::common;
@@ -49,7 +51,7 @@ bool AggregateHashTable::isAggregateValueDistinctForGroupByKeys(
     }
     distinctKeyVectors[groupByFlatKeyVectors.size()] = aggregateVector;
     computeVectorHashes(distinctKeyVectors, std::vector<ValueVector*>() /* unFlatKeyVectors */);
-    hash_t hash = hashVector->getValue<hash_t>(hashVector->state->selVector->selectedPositions[0]);
+    auto hash = hashVector->getValue<hash_t>(hashVector->state->selVector->selectedPositions[0]);
     auto distinctHTEntry = findEntryInDistinctHT(distinctKeyVectors, hash);
     if (distinctHTEntry == nullptr) {
         resizeHashTableIfNecessary(1);
@@ -378,6 +380,7 @@ uint8_t* AggregateHashTable::createEntryInDistinctHT(
         factorizedTable->updateFlatCell(entry, i, groupByHashKeyVectors[i],
             groupByHashKeyVectors[i]->state->selVector->selectedPositions[0]);
     }
+    factorizedTable->updateFlatCellNoNull(entry, hashColIdxInFT, &hash);
     fillEntryWithInitialNullAggregateState(entry);
     fillHashSlot(hash, entry);
     return entry;

--- a/src/processor/operator/aggregate/aggregate_hash_table.cpp
+++ b/src/processor/operator/aggregate/aggregate_hash_table.cpp
@@ -1,7 +1,5 @@
 #include "processor/operator/aggregate/aggregate_hash_table.h"
 
-#include <chrono>
-
 #include "common/utils.h"
 
 using namespace kuzu::common;


### PR DESCRIPTION
This PR fixes an issue #3349 related to the performance issue in distinct hash table.
The bug is that: We forgot to update the hash value of tuples in the factorizedtable. As a result, all hash values are 0 by default, which means all tuple insertions triggers a hash collision.
Closes #3349
The query: `MATCH (a:Person) RETURN COUNT(DISTINCT a)` finishes in 0.5s on my MAC M1.