### PR TITLE
Fix output message text in db extensions

### DIFF
--- a/src/processor/operator/simple/attach_database.cpp
+++ b/src/processor/operator/simple/attach_database.cpp
@@ -18,7 +18,7 @@ void AttachDatabase::executeInternal(ExecutionContext* context) {
 }
 
 std::string AttachDatabase::getOutputMsg() {
-    return "Attach database successfully.";
+    return "Attached database successfully.";
 }
 
 } // namespace processor

--- a/src/processor/operator/simple/detach_database.cpp
+++ b/src/processor/operator/simple/detach_database.cpp
@@ -12,7 +12,7 @@ void DetachDatabase::executeInternal(kuzu::processor::ExecutionContext* context)
 }
 
 std::string DetachDatabase::getOutputMsg() {
-    return "Detach database successfully.";
+    return "Detached database successfully.";
 }
 
 } // namespace processor

--- a/src/processor/operator/simple/export_db.cpp
+++ b/src/processor/operator/simple/export_db.cpp
@@ -99,7 +99,7 @@ void ExportDB::executeInternal(ExecutionContext* context) {
 }
 
 std::string ExportDB::getOutputMsg() {
-    return "Export database successfully." + extraMsg;
+    return "Exported database successfully." + extraMsg;
 }
 
 } // namespace processor

--- a/src/processor/operator/simple/import_db.cpp
+++ b/src/processor/operator/simple/import_db.cpp
@@ -14,7 +14,7 @@ void ImportDB::executeInternal(ExecutionContext* context) {
 }
 
 std::string ImportDB::getOutputMsg() {
-    return "Import database successfully.";
+    return "Imported database successfully.";
 }
 
 } // namespace processor

--- a/src/processor/operator/simple/use_database.cpp
+++ b/src/processor/operator/simple/use_database.cpp
@@ -11,7 +11,7 @@ void UseDatabase::executeInternal(kuzu::processor::ExecutionContext* context) {
 }
 
 std::string UseDatabase::getOutputMsg() {
-    return "Use database successfully.";
+    return "Used database successfully.";
 }
 
 } // namespace processor


### PR DESCRIPTION
Small fix to the output message on success for database extensions (I made it past tense, as the action has been completed once the user reads the message). Tests pass.