### PR TITLE
Fix create dir ending with slash

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -160,10 +160,25 @@ void LocalFileSystem::createDir(const std::string& dir) const {
             throw IOException(stringFormat("Directory {} already exists.", dir));
             // LCOV_EXCL_STOP
         }
-        if (!std::filesystem::create_directories(dir)) {
+        auto directoryToCreate = dir;
+        if (directoryToCreate.ends_with('/')) {
+            // This is a known issue with std::filesystem::create_directories. (link:
+            // https://github.com/llvm/llvm-project/issues/60634). We have to manually remove the
+            // last '/' if the path ends with '/'.
+            directoryToCreate.substr(0, directoryToCreate.size() - 1);
+        }
+        std::error_code errCode;
+        if (!std::filesystem::create_directories(directoryToCreate, errCode)) {
             // LCOV_EXCL_START
-            throw IOException(stringFormat(
-                "Directory {} cannot be created. Check if it exists and remove it.", dir));
+            throw IOException(
+                stringFormat("Directory {} cannot be created. Check if it exists and remove it.",
+                    directoryToCreate));
+            // LCOV_EXCL_STOP
+        }
+        if (errCode) {
+            // LCOV_EXCL_START
+            throw IOException(stringFormat("Failed to create directory: {}, error message: {}.",
+                dir, errCode.message()));
             // LCOV_EXCL_STOP
         }
     } catch (std::exception& e) {

--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -165,7 +165,7 @@ void LocalFileSystem::createDir(const std::string& dir) const {
             // This is a known issue with std::filesystem::create_directories. (link:
             // https://github.com/llvm/llvm-project/issues/60634). We have to manually remove the
             // last '/' if the path ends with '/'.
-            directoryToCreate.substr(0, directoryToCreate.size() - 1);
+            directoryToCreate = directoryToCreate.substr(0, directoryToCreate.size() - 1);
         }
         std::error_code errCode;
         if (!std::filesystem::create_directories(directoryToCreate, errCode)) {

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -60,8 +60,12 @@ TEST_F(CApiDatabaseTest, CreationInvalidPath) {
 }
 
 TEST_F(CApiDatabaseTest, CreationHomeDir) {
-    auto databasePathCStr = (char*)"~/ku_test.db";
+    auto databasePathCStr = (char*)"~/ku_test.db/";
     auto database = kuzu_database_init(databasePathCStr, kuzu_default_system_config());
+    auto connection = kuzu_connection_init(database);
+    auto homePath =
+        getClientContext(*(Connection*)(connection->_connection))->getClientConfig()->homeDirectory;
     ASSERT_NE(database, nullptr);
     kuzu_database_destroy(database);
+    std::filesystem::remove_all(homePath + "/ku_test.db");
 }

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -66,6 +66,7 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     auto homePath =
         getClientContext(*(Connection*)(connection->_connection))->getClientConfig()->homeDirectory;
     ASSERT_NE(database, nullptr);
+    kuzu_connection_destroy(connection);
     kuzu_database_destroy(database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }

--- a/tools/python_api/test/test_exception.py
+++ b/tools/python_api/test/test_exception.py
@@ -19,10 +19,8 @@ def test_exception(conn_db_readonly: ConnDB) -> None:
 
 def test_db_path_exception() -> None:
     path = ""
-    if sys.platform == "win32":
-        error_message = "Failed to create directory"
-    else:
-        error_message = "filesystem error"
+    error_message = ("IO exception: Failed to create directory  due to: IO exception: Directory  cannot be created. "
+                     "Check if it exists and remove it.")
     with pytest.raises(RuntimeError, match=error_message):
         kuzu.Database(path)
 


### PR DESCRIPTION
This PR solves issue #3363. Closes #3363 
It is a bug related to the libc++ in clang, we have to omit the slash when creating directories.