### PR TITLE
Add extension utils function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.2.7")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.2.8")
 
 include_directories(src/include)
 

--- a/extension/duckdb_scanner/CMakeLists.txt
+++ b/extension/duckdb_scanner/CMakeLists.txt
@@ -22,7 +22,8 @@ add_library(duckdb_scanner
         src/duckdb_scan.cpp
         src/duckdb_type_converter.cpp
         src/duckdb_catalog.cpp
-        src/duckdb_table_catalog_entry.cpp)
+        src/duckdb_table_catalog_entry.cpp
+        src/duckdb_functions.cpp)
 
 set_target_properties(duckdb_scanner
     PROPERTIES

--- a/extension/duckdb_scanner/src/duckdb_functions.cpp
+++ b/extension/duckdb_scanner/src/duckdb_functions.cpp
@@ -1,0 +1,45 @@
+#include "duckdb_functions.h"
+
+#include "duckdb_catalog.h"
+#include "duckdb_storage.h"
+
+using namespace kuzu::function;
+using namespace kuzu::main;
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace duckdb_scanner {
+
+static offset_t DuckDBClearCacheTableFunc(TableFuncInput& input, TableFuncOutput& output) {
+    auto& dataChunk = output.dataChunk;
+    auto sharedState =
+        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    auto bindData =
+        ku_dynamic_cast<function::TableFuncBindData*, DuckDBClearCacheBindData*>(input.bindData);
+    bindData->databaseManager->invalidateCache(DuckDBStorageExtension::dbType);
+    dataChunk.getValueVector(0)->setValue<std::string>(0,
+        "All attached duckdb database caches have been cleared.");
+    return 1;
+}
+
+static std::unique_ptr<TableFuncBindData> DuckDBClearCacheBindFunc(ClientContext* context,
+    TableFuncBindInput*) {
+    std::vector<std::string> columnNames;
+    std::vector<LogicalType> columnTypes;
+    columnNames.emplace_back("message");
+    columnTypes.emplace_back(*LogicalType::STRING());
+    return std::make_unique<DuckDBClearCacheBindData>(context->getDatabaseManager(),
+        std::move(columnTypes), std::move(columnNames), 1 /* maxOffset */);
+}
+
+DuckDBClearCacheFunction::DuckDBClearCacheFunction()
+    : TableFunction{name, DuckDBClearCacheTableFunc, DuckDBClearCacheBindFunc,
+          function::CallFunction::initSharedState, function::CallFunction::initEmptyLocalState,
+          std::vector<LogicalTypeID>{}} {}
+
+} // namespace duckdb_scanner
+} // namespace kuzu

--- a/extension/duckdb_scanner/src/duckdb_functions.cpp
+++ b/extension/duckdb_scanner/src/duckdb_functions.cpp
@@ -12,14 +12,12 @@ namespace duckdb_scanner {
 
 static offset_t DuckDBClearCacheTableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto sharedState = input.sharedState->ptrCast<CallFuncSharedState>();
     auto morsel = sharedState->getMorsel();
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
-    auto bindData =
-        ku_dynamic_cast<function::TableFuncBindData*, DuckDBClearCacheBindData*>(input.bindData);
+    auto bindData = input.bindData->constPtrCast<DuckDBClearCacheBindData>();
     bindData->databaseManager->invalidateCache(DuckDBStorageExtension::dbType);
     dataChunk.getValueVector(0)->setValue<std::string>(0,
         "All attached duckdb database caches have been cleared.");

--- a/extension/duckdb_scanner/src/duckdb_scanner_extension.cpp
+++ b/extension/duckdb_scanner/src/duckdb_scanner_extension.cpp
@@ -8,7 +8,7 @@ namespace duckdb_scanner {
 
 void DuckDBScannerExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension("duckdb", std::make_unique<DuckDBStorageExtension>());
+    db->registerStorageExtension("duckdb", std::make_unique<DuckDBStorageExtension>(db));
 }
 
 } // namespace duckdb_scanner

--- a/extension/duckdb_scanner/src/duckdb_storage.cpp
+++ b/extension/duckdb_scanner/src/duckdb_storage.cpp
@@ -6,6 +6,8 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/string_utils.h"
 #include "duckdb_catalog.h"
+#include "duckdb_functions.h"
+#include "extension/extension.h"
 
 namespace kuzu {
 namespace duckdb_scanner {
@@ -15,27 +17,36 @@ static std::string getCatalogNameFromPath(const std::string& dbPath) {
     return path.stem().string();
 }
 
+static void validateDuckDBPathExistence(const std::string& dbPath) {
+    auto vfs = std::make_unique<common::VirtualFileSystem>();
+    if (!vfs->fileOrPathExists(dbPath)) {
+        throw common::RuntimeException{
+            common::stringFormat("'{}' is not a valid duckdb database path.", dbPath)};
+    }
+}
+
 std::unique_ptr<main::AttachedDatabase> attachDuckDB(std::string dbName, std::string dbPath,
     main::ClientContext* clientContext) {
     auto catalogName = getCatalogNameFromPath(dbPath);
     if (dbName == "") {
         dbName = catalogName;
     }
-    auto duckdbCatalog = std::make_unique<DuckDBCatalogContent>();
-    auto vfs = std::make_unique<common::VirtualFileSystem>();
-    if (!vfs->fileOrPathExists(dbPath)) {
-        throw common::RuntimeException{
-            common::stringFormat("'{}' is not a valid duckdb database path.", dbPath)};
-    }
-    duckdbCatalog->init(dbPath, catalogName, clientContext);
-    return std::make_unique<main::AttachedDatabase>(dbName, std::move(duckdbCatalog));
+    validateDuckDBPathExistence(dbPath);
+    auto duckdbCatalog = std::make_unique<DuckDBCatalog>(dbPath, catalogName, clientContext);
+    duckdbCatalog->init();
+    return std::make_unique<main::AttachedDatabase>(dbName, DuckDBStorageExtension::dbType,
+        std::move(duckdbCatalog));
 }
 
-DuckDBStorageExtension::DuckDBStorageExtension() : StorageExtension{attachDuckDB} {}
+DuckDBStorageExtension::DuckDBStorageExtension(main::Database* database)
+    : StorageExtension{attachDuckDB} {
+    auto duckDBClearCacheFunction = std::make_unique<DuckDBClearCacheFunction>();
+    extension::ExtensionUtils::registerFunction(*database, std::move(duckDBClearCacheFunction));
+}
 
-bool DuckDBStorageExtension::canHandleDB(std::string dbType) const {
-    common::StringUtils::toUpper(dbType);
-    return dbType == "DUCKDB";
+bool DuckDBStorageExtension::canHandleDB(std::string dbType_) const {
+    common::StringUtils::toUpper(dbType_);
+    return dbType_ == dbType;
 }
 
 } // namespace duckdb_scanner

--- a/extension/duckdb_scanner/src/duckdb_storage.cpp
+++ b/extension/duckdb_scanner/src/duckdb_storage.cpp
@@ -41,7 +41,8 @@ std::unique_ptr<main::AttachedDatabase> attachDuckDB(std::string dbName, std::st
 DuckDBStorageExtension::DuckDBStorageExtension(main::Database* database)
     : StorageExtension{attachDuckDB} {
     auto duckDBClearCacheFunction = std::make_unique<DuckDBClearCacheFunction>();
-    extension::ExtensionUtils::registerFunction(*database, std::move(duckDBClearCacheFunction));
+    extension::ExtensionUtils::registerTableFunction(*database,
+        std::move(duckDBClearCacheFunction));
 }
 
 bool DuckDBStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/duckdb_scanner/src/include/duckdb_catalog.h
+++ b/extension/duckdb_scanner/src/include/duckdb_catalog.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "binder/ddl/bound_create_table_info.h"
-#include "catalog/catalog_content.h"
+#include "extension/catalog_extension.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -31,12 +31,14 @@ struct BoundExtraCreateDuckDBTableInfo : public binder::BoundExtraCreateTableInf
     }
 };
 
-class DuckDBCatalogContent : public catalog::CatalogContent {
+class DuckDBCatalog : public extension::CatalogExtension {
 public:
-    DuckDBCatalogContent() : catalog::CatalogContent{} {}
+    DuckDBCatalog(std::string dbPath, std::string catalogName, main::ClientContext* context)
+        : CatalogExtension::CatalogExtension{}, dbPath{std::move(dbPath)},
+          catalogName{std::move(catalogName)},
+          tableNamesVector{*common::LogicalType::STRING(), context->getMemoryManager()} {}
 
-    virtual void init(const std::string& dbPath, const std::string& catalogName,
-        main::ClientContext* context);
+    void init() override;
 
 protected:
     bool bindPropertyInfos(duckdb::Connection& con, const std::string& tableName,
@@ -55,6 +57,11 @@ private:
 private:
     void createForeignTable(duckdb::Connection& con, const std::string& tableName,
         const std::string& dbPath, const std::string& catalogName);
+
+private:
+    std::string dbPath;
+    std::string catalogName;
+    common::ValueVector tableNamesVector;
 };
 
 } // namespace duckdb_scanner

--- a/extension/duckdb_scanner/src/include/duckdb_functions.h
+++ b/extension/duckdb_scanner/src/include/duckdb_functions.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "common/types/types.h"
+#include "function/table/call_functions.h"
+#include "function/table_functions.h"
+#include "main/database_manager.h"
+
+namespace kuzu {
+namespace duckdb_scanner {
+
+struct DuckDBClearCacheBindData : public function::CallTableFuncBindData {
+    main::DatabaseManager* databaseManager;
+
+    DuckDBClearCacheBindData(main::DatabaseManager* databaseManager,
+        std::vector<common::LogicalType> returnTypes, std::vector<std::string> returnColumnNames,
+        common::offset_t maxOffset)
+        : CallTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
+          databaseManager{databaseManager} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<DuckDBClearCacheBindData>(databaseManager, columnTypes, columnNames,
+            maxOffset);
+    }
+};
+
+struct DuckDBClearCacheFunction final : public function::TableFunction {
+    static constexpr const char* name = "duckdb_clear_cache";
+
+    DuckDBClearCacheFunction();
+};
+
+} // namespace duckdb_scanner
+} // namespace kuzu

--- a/extension/duckdb_scanner/src/include/duckdb_storage.h
+++ b/extension/duckdb_scanner/src/include/duckdb_storage.h
@@ -10,7 +10,7 @@ class DuckDBStorageExtension final : public storage::StorageExtension {
 public:
     static constexpr const char* dbType = "DUCKDB";
 
-    DuckDBStorageExtension(main::Database* database);
+    explicit DuckDBStorageExtension(main::Database* database);
 
     bool canHandleDB(std::string dbType) const override;
 };

--- a/extension/duckdb_scanner/src/include/duckdb_storage.h
+++ b/extension/duckdb_scanner/src/include/duckdb_storage.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "main/database.h"
 #include "storage/storage_extension.h"
 
 namespace kuzu {
@@ -7,7 +8,9 @@ namespace duckdb_scanner {
 
 class DuckDBStorageExtension final : public storage::StorageExtension {
 public:
-    DuckDBStorageExtension();
+    static constexpr const char* dbType = "DUCKDB";
+
+    DuckDBStorageExtension(main::Database* database);
 
     bool canHandleDB(std::string dbType) const override;
 };

--- a/extension/duckdb_scanner/test/test_files/duckdb_scanner.test
+++ b/extension/duckdb_scanner/test/test_files/duckdb_scanner.test
@@ -80,6 +80,11 @@ Used database successfully.
 -STATEMENT LOAD FROM other1.person RETURN count(*);
 ---- 1
 4
+-STATEMENT CALL DUCKDB_CLEAR_CACHE() RETURN *;
+---- ok
+-STATEMENT LOAD FROM other1.person RETURN count(*);
+---- 1
+4
 
 -CASE InvalidDuckDBDatabase
 -STATEMENT LOAD FROM tinysnb1.person RETURN *;

--- a/extension/postgres_scanner/CMakeLists.txt
+++ b/extension/postgres_scanner/CMakeLists.txt
@@ -18,7 +18,8 @@ add_library(postgres_scanner
         ../duckdb_scanner/src/duckdb_type_converter.cpp
         src/postgres_scanner_extension.cpp
         src/postgres_storage.cpp
-        src/postgres_catalog.cpp)
+        src/postgres_catalog.cpp
+        src/postgres_functions.cpp)
 
 include_directories(
         src/include

--- a/extension/postgres_scanner/src/include/postgres_catalog.h
+++ b/extension/postgres_scanner/src/include/postgres_catalog.h
@@ -25,12 +25,10 @@ struct BoundExtraCreatePostgresTableInfo final
     }
 };
 
-class PostgresCatalogContent final : public duckdb_scanner::DuckDBCatalogContent {
+class PostgresCatalog final : public duckdb_scanner::DuckDBCatalog {
 public:
-    PostgresCatalogContent() : duckdb_scanner::DuckDBCatalogContent{} {}
-
-    void init(const std::string& dbPath, const std::string& catalogName,
-        main::ClientContext* context) override;
+    PostgresCatalog(std::string dbPath, std::string catalogName, main::ClientContext* context)
+        : duckdb_scanner::DuckDBCatalog{std::move(dbPath), std::move(catalogName), context} {}
 
 private:
     std::unique_ptr<binder::BoundCreateTableInfo> bindCreateTableInfo(duckdb::Connection& con,

--- a/extension/postgres_scanner/src/include/postgres_catalog.h
+++ b/extension/postgres_scanner/src/include/postgres_catalog.h
@@ -27,8 +27,8 @@ struct BoundExtraCreatePostgresTableInfo final
 
 class PostgresCatalog final : public duckdb_scanner::DuckDBCatalog {
 public:
-    PostgresCatalog(std::string dbPath, std::string catalogName, main::ClientContext* context)
-        : duckdb_scanner::DuckDBCatalog{std::move(dbPath), std::move(catalogName), context} {}
+    PostgresCatalog(std::string dbPath, std::string /*catalogName*/, main::ClientContext* context)
+        : duckdb_scanner::DuckDBCatalog{std::move(dbPath), DEFAULT_CATALOG_NAME, context} {}
 
 private:
     std::unique_ptr<binder::BoundCreateTableInfo> bindCreateTableInfo(duckdb::Connection& con,

--- a/extension/postgres_scanner/src/include/postgres_functions.h
+++ b/extension/postgres_scanner/src/include/postgres_functions.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "function/table_functions.h"
+
+namespace kuzu {
+namespace postgres_scanner {
+
+struct PostgresClearCacheFunction final : public function::TableFunction {
+    static constexpr const char* name = "postgres_clear_cache";
+
+    PostgresClearCacheFunction();
+};
+
+} // namespace postgres_scanner
+} // namespace kuzu

--- a/extension/postgres_scanner/src/include/postgres_storage.h
+++ b/extension/postgres_scanner/src/include/postgres_storage.h
@@ -7,7 +7,9 @@ namespace postgres_scanner {
 
 class PostgresStorageExtension final : public storage::StorageExtension {
 public:
-    PostgresStorageExtension();
+    static constexpr const char* dbType = "POSTGRES";
+
+    PostgresStorageExtension(main::Database* database);
 
     bool canHandleDB(std::string dbType) const override;
 };

--- a/extension/postgres_scanner/src/include/postgres_storage.h
+++ b/extension/postgres_scanner/src/include/postgres_storage.h
@@ -9,7 +9,7 @@ class PostgresStorageExtension final : public storage::StorageExtension {
 public:
     static constexpr const char* dbType = "POSTGRES";
 
-    PostgresStorageExtension(main::Database* database);
+    explicit PostgresStorageExtension(main::Database* database);
 
     bool canHandleDB(std::string dbType) const override;
 };

--- a/extension/postgres_scanner/src/postgres_catalog.cpp
+++ b/extension/postgres_scanner/src/postgres_catalog.cpp
@@ -5,16 +5,11 @@
 namespace kuzu {
 namespace postgres_scanner {
 
-void PostgresCatalogContent::init(const std::string& dbPath, const std::string& /*catalogName*/,
-    main::ClientContext* context) {
-    duckdb_scanner::DuckDBCatalogContent::init(dbPath, DEFAULT_CATALOG_NAME, context);
-}
-
-std::string PostgresCatalogContent::getDefaultSchemaName() const {
+std::string PostgresCatalog::getDefaultSchemaName() const {
     return DEFAULT_SCHEMA_NAME;
 }
 
-std::unique_ptr<binder::BoundCreateTableInfo> PostgresCatalogContent::bindCreateTableInfo(
+std::unique_ptr<binder::BoundCreateTableInfo> PostgresCatalog::bindCreateTableInfo(
     duckdb::Connection& con, const std::string& tableName, const std::string& dbPath,
     const std::string& /*catalogName*/) {
     std::vector<binder::PropertyInfo> propertyInfos;
@@ -35,7 +30,7 @@ static void executeQueryAndCheckErrMsg(duckdb::Connection& con, std::string quer
     }
 }
 
-std::pair<duckdb::DuckDB, duckdb::Connection> PostgresCatalogContent::getConnection(
+std::pair<duckdb::DuckDB, duckdb::Connection> PostgresCatalog::getConnection(
     const std::string& dbPath) const {
     duckdb::DuckDB db(nullptr);
     duckdb::Connection con(db);

--- a/extension/postgres_scanner/src/postgres_functions.cpp
+++ b/extension/postgres_scanner/src/postgres_functions.cpp
@@ -1,0 +1,59 @@
+#include "postgres_functions.h"
+
+#include "duckdb_functions.h"
+#include "postgres_storage.h"
+
+using namespace kuzu::function;
+using namespace kuzu::main;
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace postgres_scanner {
+
+struct PostgresClearCacheBindData : public duckdb_scanner::DuckDBClearCacheBindData {
+
+    PostgresClearCacheBindData(DatabaseManager* databaseManager,
+        std::vector<LogicalType> returnTypes, std::vector<std::string> returnColumnNames,
+        offset_t maxOffset)
+        : DuckDBClearCacheBindData{databaseManager, std::move(returnTypes),
+              std::move(returnColumnNames), maxOffset} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<PostgresClearCacheBindData>(databaseManager, columnTypes,
+            columnNames, maxOffset);
+    }
+};
+
+static offset_t DuckDBClearCacheTableFunc(TableFuncInput& input, TableFuncOutput& output) {
+    auto& dataChunk = output.dataChunk;
+    auto sharedState =
+        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    auto bindData =
+        ku_dynamic_cast<function::TableFuncBindData*, PostgresClearCacheBindData*>(input.bindData);
+    bindData->databaseManager->invalidateCache(PostgresStorageExtension::dbType);
+    dataChunk.getValueVector(0)->setValue<std::string>(0,
+        "All attached duckdb database caches have been cleared.");
+    return 1;
+}
+
+static std::unique_ptr<TableFuncBindData> DuckDBClearCacheBindFunc(ClientContext* context,
+    TableFuncBindInput*) {
+    std::vector<std::string> columnNames;
+    std::vector<LogicalType> columnTypes;
+    columnNames.emplace_back("message");
+    columnTypes.emplace_back(*LogicalType::STRING());
+    return std::make_unique<PostgresClearCacheBindData>(context->getDatabaseManager(),
+        std::move(columnTypes), std::move(columnNames), 1 /* maxOffset */);
+}
+
+PostgresClearCacheFunction::PostgresClearCacheFunction()
+    : TableFunction{name, DuckDBClearCacheTableFunc, DuckDBClearCacheBindFunc,
+          function::CallFunction::initSharedState, function::CallFunction::initEmptyLocalState,
+          std::vector<LogicalTypeID>{}} {}
+
+} // namespace postgres_scanner
+} // namespace kuzu

--- a/extension/postgres_scanner/src/postgres_scanner_extension.cpp
+++ b/extension/postgres_scanner/src/postgres_scanner_extension.cpp
@@ -8,7 +8,7 @@ namespace postgres_scanner {
 
 void PostgresScannerExtension::load(main::ClientContext* context) {
     auto db = context->getDatabase();
-    db->registerStorageExtension("postgres", std::make_unique<PostgresStorageExtension>());
+    db->registerStorageExtension("postgres", std::make_unique<PostgresStorageExtension>(db));
 }
 
 } // namespace postgres_scanner

--- a/extension/postgres_scanner/src/postgres_storage.cpp
+++ b/extension/postgres_scanner/src/postgres_storage.cpp
@@ -36,7 +36,8 @@ std::unique_ptr<main::AttachedDatabase> attachPostgres(std::string dbName, std::
 PostgresStorageExtension::PostgresStorageExtension(main::Database* database)
     : StorageExtension{attachPostgres} {
     auto postgresClearCacheFunction = std::make_unique<PostgresClearCacheFunction>();
-    extension::ExtensionUtils::registerFunction(*database, std::move(postgresClearCacheFunction));
+    extension::ExtensionUtils::registerTableFunction(*database,
+        std::move(postgresClearCacheFunction));
 }
 
 bool PostgresStorageExtension::canHandleDB(std::string dbType_) const {

--- a/extension/postgres_scanner/src/postgres_storage.cpp
+++ b/extension/postgres_scanner/src/postgres_storage.cpp
@@ -5,7 +5,9 @@
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/exception/runtime.h"
 #include "common/string_utils.h"
+#include "extension/extension.h"
 #include "postgres_catalog.h"
+#include "postgres_functions.h"
 
 namespace kuzu {
 namespace postgres_scanner {
@@ -25,16 +27,21 @@ std::unique_ptr<main::AttachedDatabase> attachPostgres(std::string dbName, std::
     if (dbName == "") {
         dbName = catalogName;
     }
-    auto postgresCatalog = std::make_unique<PostgresCatalogContent>();
-    postgresCatalog->init(dbPath, catalogName, clientContext);
-    return std::make_unique<main::AttachedDatabase>(dbName, std::move(postgresCatalog));
+    auto postgresCatalog = std::make_unique<PostgresCatalog>(dbPath, catalogName, clientContext);
+    postgresCatalog->init();
+    return std::make_unique<main::AttachedDatabase>(dbName, PostgresStorageExtension::dbType,
+        std::move(postgresCatalog));
 }
 
-PostgresStorageExtension::PostgresStorageExtension() : StorageExtension{attachPostgres} {}
+PostgresStorageExtension::PostgresStorageExtension(main::Database* database)
+    : StorageExtension{attachPostgres} {
+    auto postgresClearCacheFunction = std::make_unique<PostgresClearCacheFunction>();
+    extension::ExtensionUtils::registerFunction(*database, std::move(postgresClearCacheFunction));
+}
 
-bool PostgresStorageExtension::canHandleDB(std::string dbType) const {
-    common::StringUtils::toUpper(dbType);
-    return dbType == "POSTGRES";
+bool PostgresStorageExtension::canHandleDB(std::string dbType_) const {
+    common::StringUtils::toUpper(dbType_);
+    return dbType_ == dbType;
 }
 
 } // namespace postgres_scanner

--- a/extension/postgres_scanner/test/test_files/postgres_scanner.test
+++ b/extension/postgres_scanner/test/test_files/postgres_scanner.test
@@ -39,6 +39,8 @@ Binder exception: No database named tinysnb1 has been attached.
 -STATEMENT LOAD FROM pgscan.movies RETURN count(*);
 ---- 1
 3
+-STATEMENT CALL POSTGRES_CLEAR_CACHE() RETURN *;
+---- ok
 -STATEMENT LOAD FROM pgscan.movies where length > 2500 RETURN name;
 ---- 1
 The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie

--- a/src/binder/bind/read/bind_load_from.cpp
+++ b/src/binder/bind/read/bind_load_from.cpp
@@ -25,7 +25,7 @@ static TableFunction getObjectScanFunc(const ObjectScanSource* objectSource,
         throw BinderException{stringFormat("No database named {} has been attached.", dbName)};
     }
     auto tableName = objectSource->objectNames[1];
-    auto attachedCatalog = attachedDB->getCatalogContent();
+    auto attachedCatalog = attachedDB->getCatalog();
     auto tableID = attachedCatalog->getTableID(tableName);
     auto entry = attachedCatalog->getTableCatalogEntry(tableID);
     auto tableEntry = ku_dynamic_cast<CatalogEntry*, TableCatalogEntry*>(entry);

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -58,7 +58,7 @@ ExtensionRepoInfo ExtensionUtils::getExtensionRepoInfo(const std::string& extens
     return {hostPath, hostURL, extensionURL};
 }
 
-void ExtensionUtils::registerFunction(main::Database& database,
+void ExtensionUtils::registerTableFunction(main::Database& database,
     std::unique_ptr<function::TableFunction> function) {
     auto name = function->name;
     function::function_set functionSet;

--- a/src/extension/extension.cpp
+++ b/src/extension/extension.cpp
@@ -1,7 +1,9 @@
 #include "extension/extension.h"
 
+#include "catalog/catalog.h"
 #include "common/string_format.h"
 #include "common/string_utils.h"
+#include "main/database.h"
 
 namespace kuzu {
 namespace extension {
@@ -54,6 +56,17 @@ ExtensionRepoInfo ExtensionUtils::getExtensionRepoInfo(const std::string& extens
     auto hostURL = "http://" + hostName;
     auto hostPath = extensionURL.substr(hostNamePos);
     return {hostPath, hostURL, extensionURL};
+}
+
+void ExtensionUtils::registerFunction(main::Database& database,
+    std::unique_ptr<function::TableFunction> function) {
+    auto name = function->name;
+    function::function_set functionSet;
+    functionSet.push_back(std::move(function));
+    auto catalog = database.getCatalog();
+    catalog->addFunction(catalog::CatalogEntryType::TABLE_FUNCTION_ENTRY, std::move(name),
+        std::move(functionSet));
+    catalog->checkpointInMemory();
 }
 
 void ExtensionOptions::addExtensionOption(std::string name, common::LogicalTypeID type,

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -193,6 +193,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(CurrentSettingFunction), TABLE_FUNCTION(DBVersionFunction),
         TABLE_FUNCTION(ShowTablesFunction), TABLE_FUNCTION(TableInfoFunction),
         TABLE_FUNCTION(ShowConnectionFunction), TABLE_FUNCTION(StorageInfoFunction),
+        TABLE_FUNCTION(ShowDatabasesFunction),
 
         // Read functions
         TABLE_FUNCTION(ParquetScanFunction), TABLE_FUNCTION(NpyScanFunction),

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -193,7 +193,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         TABLE_FUNCTION(CurrentSettingFunction), TABLE_FUNCTION(DBVersionFunction),
         TABLE_FUNCTION(ShowTablesFunction), TABLE_FUNCTION(TableInfoFunction),
         TABLE_FUNCTION(ShowConnectionFunction), TABLE_FUNCTION(StorageInfoFunction),
-        TABLE_FUNCTION(ShowDatabasesFunction),
+        TABLE_FUNCTION(ShowAttachedDatabasesFunction),
 
         // Read functions
         TABLE_FUNCTION(ParquetScanFunction), TABLE_FUNCTION(NpyScanFunction),

--- a/src/function/table/call/CMakeLists.txt
+++ b/src/function/table/call/CMakeLists.txt
@@ -3,7 +3,7 @@ add_library(kuzu_table_call
         current_setting.cpp
         db_version.cpp
         show_connection.cpp
-        show_databases.cpp
+        show_attached_databases.cpp
         show_tables.cpp
         storage_info.cpp
         table_info.cpp)

--- a/src/function/table/call/CMakeLists.txt
+++ b/src/function/table/call/CMakeLists.txt
@@ -3,6 +3,7 @@ add_library(kuzu_table_call
         current_setting.cpp
         db_version.cpp
         show_connection.cpp
+        show_databases.cpp
         show_tables.cpp
         storage_info.cpp
         table_info.cpp)

--- a/src/function/table/call/current_setting.cpp
+++ b/src/function/table/call/current_setting.cpp
@@ -23,14 +23,12 @@ struct CurrentSettingBindData final : public CallTableFuncBindData {
 
 static common::offset_t tableFunc(TableFuncInput& data, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(data.sharedState);
+    auto sharedState = data.sharedState->ptrCast<CallFuncSharedState>();
     auto outputVector = dataChunk.getValueVector(0);
     if (!sharedState->getMorsel().hasMoreToOutput()) {
         return 0;
     }
-    auto currentSettingBindData =
-        ku_dynamic_cast<TableFuncBindData*, CurrentSettingBindData*>(data.bindData);
+    auto currentSettingBindData = data.bindData->constPtrCast<CurrentSettingBindData>();
     auto pos = dataChunk.state->selVector->selectedPositions[0];
     outputVector->setValue(pos, currentSettingBindData->result);
     outputVector->setNull(pos, false);

--- a/src/function/table/call/db_version.cpp
+++ b/src/function/table/call/db_version.cpp
@@ -8,8 +8,7 @@ namespace function {
 
 static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto sharedState = input.sharedState->ptrCast<CallFuncSharedState>();
     auto outputVector = dataChunk.getValueVector(0);
     if (!sharedState->getMorsel().hasMoreToOutput()) {
         return 0;

--- a/src/function/table/call/show_attached_databases.cpp
+++ b/src/function/table/call/show_attached_databases.cpp
@@ -7,18 +7,18 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace function {
 
-struct ShowDatabasesBindData : public CallTableFuncBindData {
+struct ShowAttachedDatabasesBindData : public CallTableFuncBindData {
     std::vector<main::AttachedDatabase*> attachedDatabases;
 
-    ShowDatabasesBindData(std::vector<main::AttachedDatabase*> attachedDatabases,
+    ShowAttachedDatabasesBindData(std::vector<main::AttachedDatabase*> attachedDatabases,
         std::vector<LogicalType> returnTypes, std::vector<std::string> returnColumnNames,
         offset_t maxOffset)
         : CallTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
           attachedDatabases{std::move(attachedDatabases)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<ShowDatabasesBindData>(attachedDatabases, columnTypes, columnNames,
-            maxOffset);
+        return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases, columnTypes,
+            columnNames, maxOffset);
     }
 };
 
@@ -31,7 +31,8 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
         return 0;
     }
     auto& attachedDatabases =
-        ku_dynamic_cast<function::TableFuncBindData*, ShowDatabasesBindData*>(input.bindData)
+        ku_dynamic_cast<function::TableFuncBindData*, ShowAttachedDatabasesBindData*>(
+            input.bindData)
             ->attachedDatabases;
     auto numDatabasesToOutput = morsel.endOffset - morsel.startOffset;
     for (auto i = 0u; i < numDatabasesToOutput; i++) {
@@ -51,11 +52,11 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     columnNames.emplace_back("database type");
     columnTypes.emplace_back(*LogicalType::STRING());
     auto attachedDatabases = context->getDatabaseManager()->getAttachedDatabases();
-    return std::make_unique<ShowDatabasesBindData>(attachedDatabases, std::move(columnTypes),
-        std::move(columnNames), attachedDatabases.size());
+    return std::make_unique<ShowAttachedDatabasesBindData>(attachedDatabases,
+        std::move(columnTypes), std::move(columnNames), attachedDatabases.size());
 }
 
-function_set ShowDatabasesFunction::getFunctionSet() {
+function_set ShowAttachedDatabasesFunction::getFunctionSet() {
     function_set functionSet;
     functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
         initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));

--- a/src/function/table/call/show_attached_databases.cpp
+++ b/src/function/table/call/show_attached_databases.cpp
@@ -24,16 +24,13 @@ struct ShowAttachedDatabasesBindData : public CallTableFuncBindData {
 
 static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto sharedState = input.sharedState->ptrCast<CallFuncSharedState>();
     auto morsel = sharedState->getMorsel();
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
     auto& attachedDatabases =
-        ku_dynamic_cast<function::TableFuncBindData*, ShowAttachedDatabasesBindData*>(
-            input.bindData)
-            ->attachedDatabases;
+        input.bindData->constPtrCast<ShowAttachedDatabasesBindData>()->attachedDatabases;
     auto numDatabasesToOutput = morsel.endOffset - morsel.startOffset;
     for (auto i = 0u; i < numDatabasesToOutput; i++) {
         auto attachedDatabase = attachedDatabases[morsel.startOffset + i];

--- a/src/function/table/call/show_connection.cpp
+++ b/src/function/table/call/show_connection.cpp
@@ -45,14 +45,11 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     auto& dataChunk = output.dataChunk;
     auto srcVector = dataChunk.getValueVector(0).get();
     auto dstVector = dataChunk.getValueVector(1).get();
-    auto morsel = ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState)
-                      ->getMorsel();
+    auto morsel = input.sharedState->ptrCast<CallFuncSharedState>()->getMorsel();
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
-    auto bindData =
-        ku_dynamic_cast<function::TableFuncBindData*, function::ShowConnectionBindData*>(
-            input.bindData);
+    auto bindData = input.bindData->constPtrCast<ShowConnectionBindData>();
     auto tableEntry = bindData->tableEntry;
     auto numRelationsToOutput = morsel.endOffset - morsel.startOffset;
     auto vectorPos = 0u;

--- a/src/function/table/call/show_databases.cpp
+++ b/src/function/table/call/show_databases.cpp
@@ -1,0 +1,68 @@
+#include "catalog/catalog.h"
+#include "catalog/catalog_entry/table_catalog_entry.h"
+#include "function/table/call_functions.h"
+#include "main/database_manager.h"
+
+using namespace kuzu::common;
+using namespace kuzu::catalog;
+
+namespace kuzu {
+namespace function {
+
+struct ShowDatabasesBindData : public CallTableFuncBindData {
+    std::vector<main::AttachedDatabase*> attachedDatabases;
+
+    ShowDatabasesBindData(std::vector<main::AttachedDatabase*> attachedDatabases,
+        std::vector<LogicalType> returnTypes, std::vector<std::string> returnColumnNames,
+        offset_t maxOffset)
+        : CallTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
+          attachedDatabases{std::move(attachedDatabases)} {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<ShowDatabasesBindData>(attachedDatabases, columnTypes, columnNames,
+            maxOffset);
+    }
+};
+
+static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
+    auto& dataChunk = output.dataChunk;
+    auto sharedState =
+        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    auto& attachedDatabases =
+        ku_dynamic_cast<function::TableFuncBindData*, ShowDatabasesBindData*>(input.bindData)
+            ->attachedDatabases;
+    auto numDatabasesToOutput = morsel.endOffset - morsel.startOffset;
+    for (auto i = 0u; i < numDatabasesToOutput; i++) {
+        auto attachedDatabase = attachedDatabases[morsel.startOffset + i];
+        dataChunk.getValueVector(0)->setValue(i, attachedDatabase->getDBName());
+        dataChunk.getValueVector(1)->setValue(i, attachedDatabase->getDBType());
+    }
+    return numDatabasesToOutput;
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
+    TableFuncBindInput*) {
+    std::vector<std::string> columnNames;
+    std::vector<LogicalType> columnTypes;
+    columnNames.emplace_back("name");
+    columnTypes.emplace_back(*LogicalType::STRING());
+    columnNames.emplace_back("database type");
+    columnTypes.emplace_back(*LogicalType::STRING());
+    auto attachedDatabases = context->getDatabaseManager()->getAttachedDatabases();
+    return std::make_unique<ShowDatabasesBindData>(attachedDatabases, std::move(columnTypes),
+        std::move(columnNames), attachedDatabases.size());
+}
+
+function_set ShowDatabasesFunction::getFunctionSet() {
+    function_set functionSet;
+    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
+        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/function/table/call/show_databases.cpp
+++ b/src/function/table/call/show_databases.cpp
@@ -1,5 +1,3 @@
-#include "catalog/catalog.h"
-#include "catalog/catalog_entry/table_catalog_entry.h"
 #include "function/table/call_functions.h"
 #include "main/database_manager.h"
 

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -23,13 +23,12 @@ struct ShowTablesBindData : public CallTableFuncBindData {
 
 static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto sharedState = input.sharedState->ptrCast<CallFuncSharedState>();
     auto morsel = sharedState->getMorsel();
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
-    auto tables = ku_dynamic_cast<TableFuncBindData*, ShowTablesBindData*>(input.bindData)->tables;
+    auto tables = input.bindData->constPtrCast<ShowTablesBindData>()->tables;
     auto numTablesToOutput = morsel.endOffset - morsel.startOffset;
     for (auto i = 0u; i < numTablesToOutput; i++) {
         auto tableEntry = tables[morsel.startOffset + i];

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -29,9 +29,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
-    auto tables =
-        ku_dynamic_cast<function::TableFuncBindData*, function::ShowTablesBindData*>(input.bindData)
-            ->tables;
+    auto tables = ku_dynamic_cast<TableFuncBindData*, ShowTablesBindData*>(input.bindData)->tables;
     auto numTablesToOutput = morsel.endOffset - morsel.startOffset;
     for (auto i = 0u; i < numTablesToOutput; i++) {
         auto tableEntry = tables[morsel.startOffset + i];

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -25,14 +25,12 @@ struct TableInfoBindData : public CallTableFuncBindData {
 
 static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& dataChunk = output.dataChunk;
-    auto sharedState =
-        ku_dynamic_cast<TableFuncSharedState*, CallFuncSharedState*>(input.sharedState);
+    auto sharedState = input.sharedState->ptrCast<CallFuncSharedState>();
     auto morsel = sharedState->getMorsel();
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
-    auto bindData =
-        ku_dynamic_cast<function::TableFuncBindData*, function::TableInfoBindData*>(input.bindData);
+    auto bindData = input.bindData->constPtrCast<TableInfoBindData>();
     auto tableEntry = bindData->tableEntry;
     auto numPropertiesToOutput = morsel.endOffset - morsel.startOffset;
     auto vectorPos = 0;

--- a/src/include/extension/catalog_extension.h
+++ b/src/include/extension/catalog_extension.h
@@ -1,0 +1,20 @@
+#pragma once
+#include "catalog/catalog.h"
+
+namespace kuzu {
+namespace extension {
+
+class CatalogExtension : public catalog::CatalogContent {
+public:
+    CatalogExtension() : CatalogContent() {}
+
+    virtual void init() = 0;
+
+    void invalidateCache() {
+        tables = std::make_unique<catalog::CatalogSet>();
+        init();
+    }
+};
+
+} // namespace extension
+} // namespace kuzu

--- a/src/include/extension/catalog_extension.h
+++ b/src/include/extension/catalog_extension.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "catalog/catalog.h"
+#include "catalog/catalog_content.h"
 
 namespace kuzu {
 namespace extension {

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -36,7 +36,7 @@ struct ExtensionUtils {
 
     static ExtensionRepoInfo getExtensionRepoInfo(const std::string& extension);
 
-    KUZU_API static void registerFunction(main::Database& database,
+    KUZU_API static void registerTableFunction(main::Database& database,
         std::unique_ptr<function::TableFunction> function);
 };
 

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -4,6 +4,7 @@
 #include <unordered_map>
 
 #include "common/api.h"
+#include "function/table/call_functions.h"
 #include "main/db_config.h"
 
 namespace kuzu {
@@ -35,6 +36,9 @@ struct ExtensionUtils {
     static bool isFullPath(const std::string& extension);
 
     static ExtensionRepoInfo getExtensionRepoInfo(const std::string& extension);
+
+    KUZU_API static void registerFunction(main::Database& database,
+        std::unique_ptr<function::TableFunction> function);
 };
 
 struct ExtensionOptions {

--- a/src/include/extension/extension.h
+++ b/src/include/extension/extension.h
@@ -4,7 +4,6 @@
 #include <unordered_map>
 
 #include "common/api.h"
-#include "function/table/call_functions.h"
 #include "main/db_config.h"
 
 namespace kuzu {

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -25,6 +25,11 @@ struct TableFuncBindData {
     virtual ~TableFuncBindData() = default;
 
     virtual std::unique_ptr<TableFuncBindData> copy() const = 0;
+
+    template<class TARGET>
+    const TARGET* constPtrCast() const {
+        return common::ku_dynamic_cast<const TableFuncBindData*, const TARGET*>(this);
+    }
 };
 
 struct ScanBindData : public TableFuncBindData {

--- a/src/include/function/table/call_functions.h
+++ b/src/include/function/table/call_functions.h
@@ -28,7 +28,7 @@ struct CallFuncSharedState : public TableFuncSharedState {
 
     explicit CallFuncSharedState(common::offset_t maxOffset) : maxOffset{maxOffset}, curOffset{0} {}
 
-    CallFuncMorsel getMorsel();
+    KUZU_API CallFuncMorsel getMorsel();
 };
 
 struct CallTableFuncBindData : public TableFuncBindData {
@@ -44,7 +44,7 @@ struct CallTableFuncBindData : public TableFuncBindData {
     }
 };
 
-struct CallFunction {
+struct KUZU_API CallFunction {
     static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input);
     static std::unique_ptr<TableFuncLocalState> initEmptyLocalState(TableFunctionInitInput& input,
         TableFuncSharedState* state, storage::MemoryManager* mm);
@@ -82,6 +82,12 @@ struct ShowConnectionFunction final : public CallFunction {
 
 struct StorageInfoFunction final : public CallFunction {
     static constexpr const char* name = "STORAGE_INFO";
+
+    static function_set getFunctionSet();
+};
+
+struct ShowDatabasesFunction final : public CallFunction {
+    static constexpr const char* name = "SHOW_DATABASES";
 
     static function_set getFunctionSet();
 };

--- a/src/include/function/table/call_functions.h
+++ b/src/include/function/table/call_functions.h
@@ -86,8 +86,8 @@ struct StorageInfoFunction final : public CallFunction {
     static function_set getFunctionSet();
 };
 
-struct ShowDatabasesFunction final : public CallFunction {
-    static constexpr const char* name = "SHOW_DATABASES";
+struct ShowAttachedDatabasesFunction final : public CallFunction {
+    static constexpr const char* name = "SHOW_ATTACHED_DATABASES";
 
     static function_set getFunctionSet();
 };

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -15,6 +15,11 @@ struct TableFuncBindInput;
 
 struct TableFuncSharedState {
     virtual ~TableFuncSharedState() = default;
+
+    template<class TARGET>
+    TARGET* ptrCast() {
+        return common::ku_dynamic_cast<TableFuncSharedState*, TARGET*>(this);
+    }
 };
 
 struct TableFuncLocalState {

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -65,7 +65,7 @@ using table_func_init_local_t = std::function<std::unique_ptr<TableFuncLocalStat
 using table_func_can_parallel_t = std::function<bool()>;
 using table_func_progress_t = std::function<double(TableFuncSharedState* sharedState)>;
 
-struct TableFunction final : public Function {
+struct KUZU_API TableFunction : public Function {
     table_func_t tableFunc;
     table_func_bind_t bindFunc;
     table_func_init_shared_t initSharedStateFunc;

--- a/src/include/main/attached_database.h
+++ b/src/include/main/attached_database.h
@@ -3,23 +3,29 @@
 #include <memory>
 #include <string>
 
-#include "catalog/catalog_content.h"
+#include "extension/catalog_extension.h"
 
 namespace kuzu {
 namespace main {
 
 class AttachedDatabase {
 public:
-    AttachedDatabase(std::string dbName, std::unique_ptr<catalog::CatalogContent> catalogContent)
-        : dbName{std::move(dbName)}, catalogContent{std::move(catalogContent)} {}
+    AttachedDatabase(std::string dbName, std::string dbType,
+        std::unique_ptr<extension::CatalogExtension> catalog)
+        : dbName{std::move(dbName)}, dbType{std::move(dbType)}, catalog{std::move(catalog)} {}
 
-    std::string getDBName() { return dbName; }
+    std::string getDBName() const { return dbName; }
 
-    catalog::CatalogContent* getCatalogContent() { return catalogContent.get(); }
+    std::string getDBType() const { return dbType; }
+
+    extension::CatalogExtension* getCatalog() { return catalog.get(); }
+
+    void invalidateCache() { catalog->invalidateCache(); }
 
 private:
     std::string dbName;
-    std::unique_ptr<catalog::CatalogContent> catalogContent;
+    std::string dbType;
+    std::unique_ptr<extension::CatalogExtension> catalog;
 };
 
 } // namespace main

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -91,7 +91,7 @@ public:
 
     // Database component getters.
     KUZU_API Database* getDatabase() const { return database; }
-    DatabaseManager* getDatabaseManager() const;
+    KUZU_API DatabaseManager* getDatabaseManager() const;
     storage::StorageManager* getStorageManager() const;
     KUZU_API storage::MemoryManager* getMemoryManager();
     catalog::Catalog* getCatalog() const;

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -112,6 +112,8 @@ public:
     KUZU_API void addExtensionOption(std::string name, common::LogicalTypeID type,
         common::Value defaultValue);
 
+    KUZU_API catalog::Catalog* getCatalog() { return catalog.get(); }
+
     ExtensionOption* getExtensionOption(std::string name);
 
     common::case_insensitive_map_t<std::unique_ptr<storage::StorageExtension>>&

--- a/src/include/main/database_manager.h
+++ b/src/include/main/database_manager.h
@@ -15,6 +15,8 @@ public:
     std::string getDefaultDatabase() const { return defaultDatabase; }
     bool hasDefaultDatabase() const { return defaultDatabase != ""; }
     void setDefaultDatabase(const std::string& databaseName);
+    std::vector<AttachedDatabase*> getAttachedDatabases() const;
+    void KUZU_API invalidateCache(const std::string& dbType);
 
 private:
     std::vector<std::unique_ptr<AttachedDatabase>> attachedDatabases;

--- a/src/main/database_manager.cpp
+++ b/src/main/database_manager.cpp
@@ -52,5 +52,21 @@ void DatabaseManager::setDefaultDatabase(const std::string& databaseName) {
     defaultDatabase = databaseName;
 }
 
+std::vector<AttachedDatabase*> DatabaseManager::getAttachedDatabases() const {
+    std::vector<AttachedDatabase*> attachedDatabasesPtr;
+    for (auto& attachedDatabase : attachedDatabases) {
+        attachedDatabasesPtr.push_back(attachedDatabase.get());
+    }
+    return attachedDatabasesPtr;
+}
+
+void DatabaseManager::invalidateCache(const std::string& dbType) {
+    for (auto& attachedDatabase : attachedDatabases) {
+        if (attachedDatabase->getDBType() == dbType) {
+            attachedDatabase->invalidateCache();
+        }
+    }
+}
+
 } // namespace main
 } // namespace kuzu

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -70,3 +70,21 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database_destroy(database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }
+
+TEST_F(CApiDatabaseTest, CreationHomeDir1) {
+    createDBAndConn();
+    printf("%s", conn->query("load extension "
+                             "'/Users/z473chen/Desktop/code/kuzu/extension/duckdb_scanner/build/"
+                             "libduckdb_scanner.kuzu_extension';")
+                     ->toString()
+                     .c_str());
+    printf("%s",
+        conn->query(
+                "attach "
+                "'/Users/z473chen/Desktop/code/kuzu/extension/duckdb_scanner/test/duckdb_database/"
+                "dbfilewithoutext' as test (dbtype 'duckdb');")
+            ->toString()
+            .c_str());
+    printf("%s", conn->query("CALL SHOW_DATABASES() RETURN *;")->toString().c_str());
+    printf("%s", conn->query("CALL duckdb_clear_cache() RETURN *;")->toString().c_str());
+}

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -70,21 +70,3 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database_destroy(database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }
-
-TEST_F(CApiDatabaseTest, CreationHomeDir1) {
-    createDBAndConn();
-    printf("%s", conn->query("load extension "
-                             "'/Users/z473chen/Desktop/code/kuzu/extension/duckdb_scanner/build/"
-                             "libduckdb_scanner.kuzu_extension';")
-                     ->toString()
-                     .c_str());
-    printf("%s",
-        conn->query(
-                "attach "
-                "'/Users/z473chen/Desktop/code/kuzu/extension/duckdb_scanner/test/duckdb_database/"
-                "dbfilewithoutext' as test (dbtype 'duckdb');")
-            ->toString()
-            .c_str());
-    printf("%s", conn->query("CALL SHOW_DATABASES() RETURN *;")->toString().c_str());
-    printf("%s", conn->query("CALL duckdb_clear_cache() RETURN *;")->toString().c_str());
-}

--- a/test/test_files/extension/show_attached_databases.test
+++ b/test/test_files/extension/show_attached_databases.test
@@ -14,7 +14,7 @@
 ---- ok
 -STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/duckdb_scanner/test/duckdb_database/dbfilewithoutext' (dbtype 'duckdb');
 ---- ok
--STATEMENT CALL show_databases() RETURN *;
+-STATEMENT CALL show_attached_databases() RETURN *;
 ---- 2
 tinysnb|DUCKDB
 dbfilewithoutext|DUCKDB

--- a/test/test_files/extension/show_databases.test
+++ b/test/test_files/extension/show_databases.test
@@ -1,0 +1,27 @@
+-GROUP ShowDatabasesTest
+-DATASET CSV empty
+
+--
+
+-CASE ExtensionTest
+
+# TODO: Extension on musl libc has not been supported yet due to no prebuilt binary.
+-SKIP_MUSL
+-LOG InstallExtension
+-STATEMENT INSTALL httpfs;
+---- ok
+-STATEMENT LOAD EXTENSION httpfs;
+---- ok
+-STATEMENT LOAD FROM 'http://extension.kuzudb.com/dataset/test/city.csv' return *;
+---- 3
+Guelph|75000
+Kitchener|200000
+Waterloo|150000
+
+-CASE ExtensionErrorTest
+-SKIP
+# TODO: The error message is dependent on platform.
+-LOG InstallInvalidExtension
+-STATEMENT INSTALL http;
+---- error
+IO exception: HTTP Returns: 404, Failed to download extension: "http" from extension.kuzudb.com/v0.1.0/osx_arm64/libhttp.kuzu_extension.

--- a/test/test_files/extension/show_databases.test
+++ b/test/test_files/extension/show_databases.test
@@ -3,25 +3,18 @@
 
 --
 
--CASE ExtensionTest
-
-# TODO: Extension on musl libc has not been supported yet due to no prebuilt binary.
+-CASE ShowDatabasesTest
 -SKIP_MUSL
 -LOG InstallExtension
--STATEMENT INSTALL httpfs;
+-STATEMENT INSTALL duckdb_scanner;
 ---- ok
--STATEMENT LOAD EXTENSION httpfs;
+-STATEMENT LOAD EXTENSION duckdb_scanner;
 ---- ok
--STATEMENT LOAD FROM 'http://extension.kuzudb.com/dataset/test/city.csv' return *;
----- 3
-Guelph|75000
-Kitchener|200000
-Waterloo|150000
-
--CASE ExtensionErrorTest
--SKIP
-# TODO: The error message is dependent on platform.
--LOG InstallInvalidExtension
--STATEMENT INSTALL http;
----- error
-IO exception: HTTP Returns: 404, Failed to download extension: "http" from extension.kuzudb.com/v0.1.0/osx_arm64/libhttp.kuzu_extension.
+-STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/duckdb_scanner/test/duckdb_database/tinysnb.db' (dbtype 'duckdb');
+---- ok
+-STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/duckdb_scanner/test/duckdb_database/dbfilewithoutext' (dbtype 'duckdb');
+---- ok
+-STATEMENT CALL show_databases() RETURN *;
+---- 2
+tinysnb|DUCKDB
+dbfilewithoutext|DUCKDB


### PR DESCRIPTION
This PR implements the following utils funcitons for extensions:
1. SHOW_DATABASES(): returns all attached databases. Closes #3359 
2. DUCKDB_CLEAR_CACHE(): clear duckdb catalog cache.
3. POSTGRES_CLEAR_CACHE(): clear postgres catalog cache.