### PR TITLE
Add primary key information to ```show_connection```

### DIFF
--- a/scripts/antlr4/Cypher.g4.copy
+++ b/scripts/antlr4/Cypher.g4.copy
@@ -84,7 +84,7 @@ USE:
     ( 'U' | 'u') ( 'S' | 's') ( 'E' | 'e');
 
 kU_StandaloneCall
-    : CALL SP oC_SymbolicName SP? '=' SP? oC_Literal ;
+    : CALL SP oC_SymbolicName SP? '=' SP? oC_Expression ;
 
 CALL : ( 'C' | 'c' ) ( 'A' | 'a' ) ( 'L' | 'l' ) ( 'L' | 'l' ) ;
 

--- a/src/antlr4/Cypher.g4
+++ b/src/antlr4/Cypher.g4
@@ -84,7 +84,7 @@ USE:
     ( 'U' | 'u') ( 'S' | 's') ( 'E' | 'e');
 
 kU_StandaloneCall
-    : CALL SP oC_SymbolicName SP? '=' SP? oC_Literal ;
+    : CALL SP oC_SymbolicName SP? '=' SP? oC_Expression ;
 
 CALL : ( 'C' | 'c' ) ( 'A' | 'a' ) ( 'L' | 'l' ) ( 'L' | 'l' ) ;
 

--- a/src/binder/bind/bind_standalone_call.cpp
+++ b/src/binder/bind/bind_standalone_call.cpp
@@ -1,6 +1,7 @@
 #include "binder/binder.h"
 #include "binder/bound_standalone_call.h"
 #include "binder/expression/expression_util.h"
+#include "binder/expression_visitor.h"
 #include "common/exception/binder.h"
 #include "extension/extension.h"
 #include "main/db_config.h"
@@ -22,9 +23,13 @@ std::unique_ptr<BoundStatement> Binder::bindStandaloneCall(const parser::Stateme
     if (option == nullptr) {
         throw BinderException{"Invalid option name: " + callStatement.getOptionName() + "."};
     }
-    auto optionValue = expressionBinder.bindLiteralExpression(*callStatement.getOptionValue());
-    // TODO(Ziyi): add casting rule for option value.
-    ExpressionUtil::validateDataType(*optionValue, option->parameterType);
+    auto optionValue = expressionBinder.bindExpression(*callStatement.getOptionValue());
+    ExpressionUtil::validateExpressionType(*optionValue, ExpressionType::LITERAL);
+    optionValue =
+        expressionBinder.implicitCastIfNecessary(optionValue, LogicalType(option->parameterType));
+    if (ExpressionVisitor::needFold(*optionValue)) {
+        optionValue = expressionBinder.foldExpression(optionValue);
+    }
     return std::make_unique<BoundStandaloneCall>(option, std::move(optionValue));
 }
 

--- a/src/binder/expression_visitor.cpp
+++ b/src/binder/expression_visitor.cpp
@@ -92,7 +92,8 @@ bool ExpressionVisitor::isConstant(const Expression& expression) {
     if (expression.expressionType == ExpressionType::AGGREGATE_FUNCTION) {
         return false; // We don't have a framework to fold aggregated constant.
     }
-    if (expression.getNumChildren() == 0) {
+    if (expression.getNumChildren() == 0 &&
+        expression.expressionType != ExpressionType::CASE_ELSE) {
         return expression.expressionType == ExpressionType::LITERAL;
     }
     for (auto& child : ExpressionChildrenCollector::collectChildren(expression)) {

--- a/src/parser/transform/transform_standalone_call.cpp
+++ b/src/parser/transform/transform_standalone_call.cpp
@@ -7,7 +7,7 @@ namespace parser {
 std::unique_ptr<Statement> Transformer::transformStandaloneCall(
     CypherParser::KU_StandaloneCallContext& ctx) {
     auto optionName = transformSymbolicName(*ctx.oC_SymbolicName());
-    auto parameter = transformLiteral(*ctx.oC_Literal());
+    auto parameter = transformExpression(*ctx.oC_Expression());
     return std::make_unique<StandaloneCall>(std::move(optionName), std::move(parameter));
 }
 

--- a/src/processor/map/map_standalone_call.cpp
+++ b/src/processor/map/map_standalone_call.cpp
@@ -10,9 +10,9 @@ namespace processor {
 
 std::unique_ptr<PhysicalOperator> PlanMapper::mapStandaloneCall(
     planner::LogicalOperator* logicalOperator) {
-    auto logicalStandaloneCall = reinterpret_cast<LogicalStandaloneCall*>(logicalOperator);
+    auto logicalStandaloneCall = logicalOperator->constPtrCast<LogicalStandaloneCall>();
     auto optionValue =
-        reinterpret_cast<binder::LiteralExpression*>(logicalStandaloneCall->getOptionValue().get());
+        logicalStandaloneCall->getOptionValue()->constPtrCast<binder::LiteralExpression>();
     auto standaloneCallInfo = std::make_unique<StandaloneCallInfo>(
         logicalStandaloneCall->getOption(), *optionValue->getValue());
     return std::make_unique<StandaloneCall>(std::move(standaloneCallInfo),

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -535,7 +535,7 @@ Binder exception: Invalid option name: thread.
 -LOG InvalidCallOptionValue
 -STATEMENT CALL threads='abc'
 ---- error
-Binder exception: abc has data type STRING but INT64 was expected.
+Binder exception: Expression abc has data type STRING but expected INT64. Implicit cast is not supported.
 
 -LOG AllShortestPathInvalidLowerBound
 -STATEMENT MATCH p = (a)-[* ALL SHORTEST 2..3]-(b) RETURN p

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -217,7 +217,7 @@ Binder exception: Cannot match a built-in function for given function table_info
 -LOG WrongParameterType
 -STATEMENT CALL show_connection(123) RETURN *
 ---- error
-Catalog exception: Table: 123 does not exist.
+Binder exception: 123 has data type INT64 but STRING was expected.
 
 -LOG WrongParameterExprType
 -STATEMENT CALL show_connection(upper("person")) RETURN *

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -28,6 +28,11 @@
 -STATEMENT CALL current_setting('timeout') RETURN *
 ---- 1
 20000
+-STATEMENT CALL timeout=(1+2+3)*10000
+---- ok
+-STATEMENT CALL current_setting('timeout') RETURN *
+---- 1
+60000
 
 -LOG SetGetVarLengthMaxDepth
 -STATEMENT CALL var_length_extend_max_depth=10
@@ -53,6 +58,11 @@ True
 -STATEMENT CALL current_setting('progress_bar') RETURN *
 ---- 1
 False
+-STATEMENT CALL progress_bar=CASE WHEN 1<2 THEN True ELSE False END
+---- ok
+-STATEMENT CALL current_setting('progress_bar') RETURN *
+---- 1
+True
 
 -LOG SetGetProgressBarTime
 -STATEMENT CALL progress_bar_time=4000

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -207,7 +207,7 @@ Binder exception: Cannot match a built-in function for given function table_info
 -LOG WrongParameterType
 -STATEMENT CALL show_connection(123) RETURN *
 ---- error
-Assertion failed in file "/home/kuzu/kuzu/src/include/common/types/value/value.h" on line 482: dataType->getLogicalTypeID() == LogicalTypeID::STRING || dataType->getLogicalTypeID() == LogicalTypeID::BLOB || dataType->getLogicalTypeID() == LogicalTypeID::UUID
+Catalog exception: Table: 123 does not exist.
 
 -LOG WrongParameterExprType
 -STATEMENT CALL show_connection(upper("person")) RETURN *

--- a/test/test_files/tinysnb/call/call.test
+++ b/test/test_files/tinysnb/call/call.test
@@ -184,16 +184,16 @@ ${KUZU_VERSION}
 -LOG ReturnTableConnection
 -STATEMENT CALL show_connection('knows') RETURN *
 ---- 1
-person|person
+person|person|ID|ID
 -STATEMENT CALL show_connection('workAt') RETURN *
 ---- 1
-person|organisation
+person|organisation|ID|ID
 -STATEMENT CREATE REL TABLE GROUP Knows1 (FROM person To person, FROM person to organisation, year INT64);
 ---- ok
 -STATEMENT CALL show_connection('Knows1') RETURN *
 ---- 2
-person|person
-person|organisation
+person|person|ID|ID
+person|organisation|ID|ID
 -STATEMENT CALL show_connection('person') RETURN *
 ---- error
 Binder exception: Show connection can only be called on a rel table!
@@ -207,7 +207,7 @@ Binder exception: Cannot match a built-in function for given function table_info
 -LOG WrongParameterType
 -STATEMENT CALL show_connection(123) RETURN *
 ---- error
-Binder exception: Show connection can only bind to String!
+Assertion failed in file "/home/kuzu/kuzu/src/include/common/types/value/value.h" on line 482: dataType->getLogicalTypeID() == LogicalTypeID::STRING || dataType->getLogicalTypeID() == LogicalTypeID::BLOB || dataType->getLogicalTypeID() == LogicalTypeID::UUID
 
 -LOG WrongParameterExprType
 -STATEMENT CALL show_connection(upper("person")) RETURN *

--- a/third_party/antlr4_cypher/cypher_parser.cpp
+++ b/third_party/antlr4_cypher/cypher_parser.cpp
@@ -451,7 +451,7 @@ void cypherParserInitialize() {
   	0,519,520,5,49,0,0,520,521,5,150,0,0,521,523,3,286,143,0,522,524,5,150,
   	0,0,523,522,1,0,0,0,523,524,1,0,0,0,524,525,1,0,0,0,525,527,5,6,0,0,526,
   	528,5,150,0,0,527,526,1,0,0,0,527,528,1,0,0,0,528,529,1,0,0,0,529,530,
-  	3,238,119,0,530,27,1,0,0,0,531,532,5,50,0,0,532,533,5,150,0,0,533,534,
+  	3,190,95,0,530,27,1,0,0,0,531,532,5,50,0,0,532,533,5,150,0,0,533,534,
   	5,94,0,0,534,535,5,150,0,0,535,536,5,60,0,0,536,537,5,150,0,0,537,538,
   	3,284,142,0,538,539,5,150,0,0,539,540,5,125,0,0,540,541,5,150,0,0,541,
   	542,5,136,0,0,542,29,1,0,0,0,543,544,5,92,0,0,544,545,5,150,0,0,545,546,
@@ -2612,8 +2612,8 @@ CypherParser::OC_SymbolicNameContext* CypherParser::KU_StandaloneCallContext::oC
   return getRuleContext<CypherParser::OC_SymbolicNameContext>(0);
 }
 
-CypherParser::OC_LiteralContext* CypherParser::KU_StandaloneCallContext::oC_Literal() {
-  return getRuleContext<CypherParser::OC_LiteralContext>(0);
+CypherParser::OC_ExpressionContext* CypherParser::KU_StandaloneCallContext::oC_Expression() {
+  return getRuleContext<CypherParser::OC_ExpressionContext>(0);
 }
 
 
@@ -2661,7 +2661,7 @@ CypherParser::KU_StandaloneCallContext* CypherParser::kU_StandaloneCall() {
       match(CypherParser::SP);
     }
     setState(529);
-    oC_Literal();
+    oC_Expression();
    
   }
   catch (RecognitionException &e) {

--- a/third_party/antlr4_cypher/include/cypher_parser.h
+++ b/third_party/antlr4_cypher/include/cypher_parser.h
@@ -488,7 +488,7 @@ public:
     std::vector<antlr4::tree::TerminalNode *> SP();
     antlr4::tree::TerminalNode* SP(size_t i);
     OC_SymbolicNameContext *oC_SymbolicName();
-    OC_LiteralContext *oC_Literal();
+    OC_ExpressionContext *oC_Expression();
 
    
   };


### PR DESCRIPTION
This PR resolved #2991 and #2660.
What has changed:
- Add primary keys of source and destination tables to the result of ```show_connection```
- Support implicit casting for parameters of in query call functions
- Modify stand alone call to accept literal expression as option values, e.g: ```CALL threads=1+2```, also support implicit casting for these values