### PR TITLE
Don't reload hash index after copy

### DIFF
--- a/src/include/storage/index/in_mem_hash_index.h
+++ b/src/include/storage/index/in_mem_hash_index.h
@@ -76,11 +76,7 @@ public:
 
     uint64_t size() { return this->indexHeader.numEntries; }
 
-    inline void clear() {
-        indexHeader = HashIndexHeader();
-        pSlots = std::make_unique<InMemDiskArrayBuilder<Slot<T>>>(dummy, 0, 0, true);
-        oSlots = std::make_unique<InMemDiskArrayBuilder<Slot<T>>>(dummy, 0, 1, true);
-    }
+    void clear();
 
     struct SlotIterator {
         explicit SlotIterator(slot_id_t newSlotId, InMemHashIndex<T>* builder)

--- a/src/storage/index/in_mem_hash_index.cpp
+++ b/src/storage/index/in_mem_hash_index.cpp
@@ -36,6 +36,14 @@ InMemHashIndex<T>::InMemHashIndex(OverflowFileHandle* overflowFileHandle)
 }
 
 template<typename T>
+void InMemHashIndex<T>::clear() {
+    indexHeader = HashIndexHeader(TypeUtils::getPhysicalTypeIDForType<T>());
+    pSlots = std::make_unique<InMemDiskArrayBuilder<Slot<T>>>(dummy, 0, 0, true);
+    oSlots = std::make_unique<InMemDiskArrayBuilder<Slot<T>>>(dummy, 0, 1, true);
+    allocateSlots(BufferPoolConstants::PAGE_4KB_SIZE / pSlots->getAlignedElementSize());
+}
+
+template<typename T>
 void InMemHashIndex<T>::allocateSlots(uint32_t newNumSlots) {
     auto numSlotsOfCurrentLevel = 1u << this->indexHeader.currentLevel;
     while ((numSlotsOfCurrentLevel << 1) <= newNumSlots) {


### PR DESCRIPTION
This turned out to be relatively simple, and saves roughly 12% on the first copy test from #2938 (~4.8s to ~4.2s).
What's more complicated is removing `createEmptyHashIndexFiles` (which I'd first tried to do at the same time).