### PR TITLE
Optimize InMemoryHashIndex lookups

### DIFF
--- a/src/include/storage/index/in_mem_hash_index.h
+++ b/src/include/storage/index/in_mem_hash_index.h
@@ -135,6 +135,10 @@ private:
         uint8_t fingerprint);
     common::hash_t hashStored(const T& key) const;
 
+    // Finds the entry matching the given key. The iterator will be advanced and will either point
+    // to the slot containing the matching entry, or the last slot available
+    entry_pos_t findEntry(SlotIterator& iter, Key key, uint8_t fingerprint);
+
 private:
     // TODO: might be more efficient to use a vector for each slot since this is now only needed
     // in-memory and it would remove the need to handle overflow slots.

--- a/src/storage/index/in_mem_hash_index.cpp
+++ b/src/storage/index/in_mem_hash_index.cpp
@@ -150,28 +150,43 @@ size_t InMemHashIndex<T>::append(const IndexBuffer<BufferKeyType>& buffer) {
 }
 
 template<typename T>
+entry_pos_t InMemHashIndex<T>::findEntry(SlotIterator& iter, Key key, uint8_t fingerprint) {
+    do {
+        auto numEntries = iter.slot->header.numEntries();
+        KU_ASSERT(numEntries == std::countr_one(iter.slot->header.validityMask));
+        for (auto entryPos = 0u; entryPos < numEntries; entryPos++) {
+            if (iter.slot->header.fingerprints[entryPos] == fingerprint &&
+                equals(key, iter.slot->entries[entryPos].key)) [[unlikely]] {
+                // Value already exists
+                return entryPos;
+            }
+        }
+        if (numEntries < getSlotCapacity<T>()) {
+            return SlotHeader::INVALID_ENTRY_POS;
+        }
+    } while (nextChainedSlot(iter));
+    return SlotHeader::INVALID_ENTRY_POS;
+}
+
+template<typename T>
 bool InMemHashIndex<T>::appendInternal(Key key, common::offset_t value, common::hash_t hash) {
     auto fingerprint = HashIndexUtils::getFingerprintForHash(hash);
     auto slotID = HashIndexUtils::getPrimarySlotIdForHash(this->indexHeader, hash);
     SlotIterator iter(slotID, this);
-    do {
-        for (auto entryPos = 0u; entryPos < getSlotCapacity<T>(); entryPos++) {
-            if (!iter.slot->header.isEntryValid(entryPos)) {
-                // Insert to this position
-                // The builder never keeps holes and doesn't support deletions, so this must be the
-                // end of the valid entries in this primary slot and the entry does not already
-                // exist
-                insert(key, iter.slot, entryPos, value, fingerprint);
-                this->indexHeader.numEntries++;
-                return true;
-            } else if (iter.slot->header.fingerprints[entryPos] == fingerprint &&
-                       equals(key, iter.slot->entries[entryPos].key)) {
-                // Value already exists
-                return false;
-            }
-        }
-    } while (nextChainedSlot(iter));
-    // Didn't find an available slot. Insert a new one
+    // The builder never keeps holes and doesn't support deletions
+    // Check the valid entries, then insert at the end if we don't find one which matches
+    auto entryPos = findEntry(iter, key, fingerprint);
+    auto numEntries = iter.slot->header.numEntries();
+    if (entryPos != SlotHeader::INVALID_ENTRY_POS) {
+        // The key already exists
+        return false;
+    } else if (numEntries < getSlotCapacity<T>()) [[likely]] {
+        // The key does not exist and the last slot has free space
+        insert(key, iter.slot, numEntries, value, fingerprint);
+        this->indexHeader.numEntries++;
+        return true;
+    }
+    // The last slot is full. Insert a new one
     insertToNewOvfSlot(key, iter.slot, value, fingerprint);
     this->indexHeader.numEntries++;
     return true;
@@ -188,17 +203,11 @@ bool InMemHashIndex<T>::lookup(Key key, offset_t& result) {
     auto fingerprint = HashIndexUtils::getFingerprintForHash(hashValue);
     auto slotId = HashIndexUtils::getPrimarySlotIdForHash(this->indexHeader, hashValue);
     SlotIterator iter(slotId, this);
-    do {
-        for (auto entryPos = 0u; entryPos < getSlotCapacity<T>(); entryPos++) {
-            if (iter.slot->header.isEntryValid(entryPos) &&
-                iter.slot->header.fingerprints[entryPos] == fingerprint &&
-                equals(key, iter.slot->entries[entryPos].key)) {
-                // Value already exists
-                result = iter.slot->entries[entryPos].value;
-                return true;
-            }
-        }
-    } while (nextChainedSlot(iter));
+    auto entryPos = findEntry(iter, key, fingerprint);
+    if (entryPos != SlotHeader::INVALID_ENTRY_POS) {
+        result = iter.slot->entries[entryPos].value;
+        return true;
+    }
     return false;
 }
 


### PR DESCRIPTION
In lookup and appendInternal, it's not actually necessary to check the validity mask for anything other than determining the number of valid entries.
I think this makes a slight difference, but the variance between test runs is large enough in comparison to any performance improvement that it's very hard to tell.