### PR TITLE
Fix issue 3262

### DIFF
--- a/src/include/planner/operator/extend/extend_direction.h
+++ b/src/include/planner/operator/extend/extend_direction.h
@@ -11,7 +11,7 @@ namespace planner {
 enum class ExtendDirection : uint8_t { FWD = 0, BWD = 1, BOTH = 2 };
 
 struct ExtendDirectionUtils {
-    static inline ExtendDirection getExtendDirection(const binder::RelExpression& relExpression,
+    static ExtendDirection getExtendDirection(const binder::RelExpression& relExpression,
         const binder::NodeExpression& boundNode) {
         if (relExpression.getDirectionType() == binder::RelDirectionType::BOTH) {
             return ExtendDirection::BOTH;
@@ -23,7 +23,7 @@ struct ExtendDirectionUtils {
         }
     }
 
-    static inline common::RelDataDirection getRelDataDirection(ExtendDirection extendDirection) {
+    static common::RelDataDirection getRelDataDirection(ExtendDirection extendDirection) {
         KU_ASSERT(extendDirection != ExtendDirection::BOTH);
         return extendDirection == ExtendDirection::FWD ? common::RelDataDirection::FWD :
                                                          common::RelDataDirection::BWD;

--- a/src/include/processor/operator/recursive_extend/frontier_scanner.h
+++ b/src/include/processor/operator/recursive_extend/frontier_scanner.h
@@ -63,9 +63,9 @@ class PathScanner : public BaseFrontierScanner {
 public:
     PathScanner(TargetDstNodes* targetDstNodes, size_t k,
         std::unordered_map<common::table_id_t, std::string> tableIDToName,
-        path_semantic_check_t semanticCheckFunc)
+        path_semantic_check_t semanticCheckFunc, bool extendInBwd)
         : BaseFrontierScanner{targetDstNodes, k}, tableIDToName{std::move(tableIDToName)},
-          semanticCheckFunc{semanticCheckFunc} {
+          semanticCheckFunc{semanticCheckFunc}, extendInBwd{extendInBwd} {
         nodeIDs.resize(k + 1);
         relIDs.resize(k + 1);
     }
@@ -97,8 +97,10 @@ private:
     std::stack<nbrs_t> nbrsStack;
     std::stack<int64_t> cursorStack;
     std::unordered_map<common::table_id_t, std::string> tableIDToName;
-
+    // Path semantic
     path_semantic_check_t semanticCheckFunc;
+    // Extend direction
+    bool extendInBwd;
 };
 
 /*

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -20,48 +20,51 @@ static std::shared_ptr<RecursiveJoinSharedState> createSharedState(
     return std::make_shared<RecursiveJoinSharedState>(std::move(semiMasks));
 }
 
-std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(
-    planner::LogicalOperator* logicalOperator) {
-    auto extend = (LogicalRecursiveExtend*)logicalOperator;
+std::unique_ptr<PhysicalOperator> PlanMapper::mapRecursiveExtend(LogicalOperator* logicalOperator) {
+    auto extend = logicalOperator->constPtrCast<LogicalRecursiveExtend>();
     auto boundNode = extend->getBoundNode();
     auto nbrNode = extend->getNbrNode();
     auto rel = extend->getRel();
     auto recursiveInfo = rel->getRecursiveInfo();
-    auto lengthExpression = rel->getLengthExpression();
     // Map recursive plan
     auto logicalRecursiveRoot = extend->getRecursiveChild();
     auto recursiveRoot = mapOperator(logicalRecursiveRoot.get());
     auto recursivePlanSchema = logicalRecursiveRoot->getSchema();
-    auto recursivePlanResultSetDescriptor =
-        std::make_unique<ResultSetDescriptor>(recursivePlanSchema);
-    auto recursiveDstNodeIDPos =
-        DataPos(recursivePlanSchema->getExpressionPos(*recursiveInfo->nodeCopy->getInternalID()));
-    auto recursiveEdgeIDPos = DataPos(
-        recursivePlanSchema->getExpressionPos(*recursiveInfo->rel->getInternalIDProperty()));
     // Generate RecursiveJoin
     auto outSchema = extend->getSchema();
     auto inSchema = extend->getChild(0)->getSchema();
-    auto boundNodeIDPos = DataPos(inSchema->getExpressionPos(*boundNode->getInternalID()));
-    auto nbrNodeIDPos = DataPos(outSchema->getExpressionPos(*nbrNode->getInternalID()));
-    auto lengthPos = DataPos(outSchema->getExpressionPos(*lengthExpression));
     auto sharedState = createSharedState(*nbrNode, *clientContext->getStorageManager());
-    auto pathPos = DataPos();
-    if (extend->getJoinType() == planner::RecursiveJoinType::TRACK_PATH) {
-        pathPos = DataPos(outSchema->getExpressionPos(*rel));
+    // Data info
+    auto dataInfo = RecursiveJoinDataInfo();
+    dataInfo.srcNodePos = getDataPos(*boundNode->getInternalID(), *inSchema);
+    dataInfo.dstNodePos = getDataPos(*nbrNode->getInternalID(), *outSchema);
+    dataInfo.dstNodeTableIDs = nbrNode->getTableIDsSet();
+    dataInfo.pathLengthPos = getDataPos(*rel->getLengthExpression(), *outSchema);
+    dataInfo.localResultSetDescriptor = std::make_unique<ResultSetDescriptor>(recursivePlanSchema);
+    dataInfo.recursiveDstNodeIDPos =
+        getDataPos(*recursiveInfo->nodeCopy->getInternalID(), *recursivePlanSchema);
+    dataInfo.recursiveDstNodeTableIDs = recursiveInfo->node->getTableIDsSet();
+    dataInfo.recursiveEdgeIDPos =
+        getDataPos(*recursiveInfo->rel->getInternalIDProperty(), *recursivePlanSchema);
+    if (extend->getJoinType() == RecursiveJoinType::TRACK_PATH) {
+        dataInfo.pathPos = getDataPos(*rel, *outSchema);
+    } else {
+        dataInfo.pathPos = DataPos::getInvalidPos();
     }
-    std::unordered_map<common::table_id_t, std::string> tableIDToName;
     for (auto& entry : clientContext->getCatalog()->getTableEntries(clientContext->getTx())) {
-        tableIDToName.insert({entry->getTableID(), entry->getName()});
+        dataInfo.tableIDToName.insert({entry->getTableID(), entry->getName()});
     }
-    auto dataInfo = std::make_unique<RecursiveJoinDataInfo>(boundNodeIDPos, nbrNodeIDPos,
-        nbrNode->getTableIDsSet(), lengthPos, std::move(recursivePlanResultSetDescriptor),
-        recursiveDstNodeIDPos, recursiveInfo->node->getTableIDsSet(), recursiveEdgeIDPos, pathPos,
-        std::move(tableIDToName));
+    // Info
+    auto info = RecursiveJoinInfo();
+    info.dataInfo = std::move(dataInfo);
+    info.lowerBound = rel->getLowerBound();
+    info.upperBound = rel->getUpperBound();
+    info.queryRelType = rel->getRelType();
+    info.joinType = extend->getJoinType();
+    info.direction = extend->getDirection();
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
-    return std::make_unique<RecursiveJoin>(rel->getLowerBound(), rel->getUpperBound(),
-        rel->getRelType(), extend->getJoinType(), sharedState, std::move(dataInfo),
-        std::move(prevOperator), getOperatorID(), extend->getExpressionsForPrinting(),
-        std::move(recursiveRoot));
+    return std::make_unique<RecursiveJoin>(std::move(info), sharedState, std::move(prevOperator),
+        getOperatorID(), extend->getExpressionsForPrinting(), std::move(recursiveRoot));
 }
 
 } // namespace processor

--- a/src/processor/operator/recursive_extend/frontier_scanner.cpp
+++ b/src/processor/operator/recursive_extend/frontier_scanner.cpp
@@ -122,18 +122,29 @@ void PathScanner::initDfs(const frontier::node_rel_id_t& nodeAndRelID, size_t cu
     initDfs(nbrs->at(0), currentDepth - 1);
 }
 
+static void writePathRels(RecursiveJoinVectors* vectors, sel_t pos, nodeID_t srcNodeID,
+    nodeID_t dstNodeID, relID_t relID, const std::string& labelName) {
+    vectors->pathRelsSrcIDDataVector->setValue<nodeID_t>(pos, srcNodeID);
+    vectors->pathRelsDstIDDataVector->setValue<nodeID_t>(pos, dstNodeID);
+    vectors->pathRelsIDDataVector->setValue<relID_t>(pos, relID);
+    StringVector::addString(vectors->pathRelsLabelDataVector, pos, labelName);
+}
+
 void PathScanner::writePathToVector(RecursiveJoinVectors* vectors, sel_t& vectorPos,
     sel_t& nodeIDDataVectorPos, sel_t& relIDDataVectorPos) {
     if (semanticCheckFunc && !semanticCheckFunc(nodeIDs, relIDs)) {
         return;
     }
     KU_ASSERT(vectorPos < DEFAULT_VECTOR_CAPACITY);
+    // Allocate list entries.
     auto nodeTableEntry = ListVector::addList(vectors->pathNodesVector, k > 0 ? k - 1 : 0);
     auto relTableEntry = ListVector::addList(vectors->pathRelsVector, k);
     vectors->pathNodesVector->setValue(vectorPos, nodeTableEntry);
     vectors->pathRelsVector->setValue(vectorPos, relTableEntry);
+    // Write dst
     writeDstNodeOffsetAndLength(vectors->dstNodeIDVector, vectors->pathLengthVector, vectorPos);
     vectorPos++;
+    // Write path nodes.
     for (auto i = 1u; i < k; ++i) {
         auto nodeID = nodeIDs[i];
         vectors->pathNodesIDDataVector->setValue<nodeID_t>(nodeIDDataVectorPos, nodeID);
@@ -142,17 +153,25 @@ void PathScanner::writePathToVector(RecursiveJoinVectors* vectors, sel_t& vector
             labelName.data(), labelName.length());
         nodeIDDataVectorPos++;
     }
-    for (auto i = 0u; i < k; ++i) {
-        auto srcNodeID = nodeIDs[i];
-        auto dstNodeID = nodeIDs[i + 1];
-        vectors->pathRelsSrcIDDataVector->setValue<nodeID_t>(relIDDataVectorPos, srcNodeID);
-        vectors->pathRelsDstIDDataVector->setValue<nodeID_t>(relIDDataVectorPos, dstNodeID);
-        auto relID = relIDs[i];
-        vectors->pathRelsIDDataVector->setValue<relID_t>(relIDDataVectorPos, relID);
-        auto labelName = tableIDToName.at(relID.tableID);
-        StringVector::addString(vectors->pathRelsLabelDataVector, relIDDataVectorPos,
-            labelName.data(), labelName.length());
-        relIDDataVectorPos++;
+    // Write path rels.
+    if (extendInBwd) {
+        for (auto i = 0u; i < k; ++i) {
+            auto srcNodeID = nodeIDs[i + 1];
+            auto dstNodeID = nodeIDs[i];
+            auto relID = relIDs[i];
+            writePathRels(vectors, relIDDataVectorPos, srcNodeID, dstNodeID, relID,
+                tableIDToName.at(relID.tableID));
+            relIDDataVectorPos++;
+        }
+    } else {
+        for (auto i = 0u; i < k; ++i) {
+            auto srcNodeID = nodeIDs[i];
+            auto dstNodeID = nodeIDs[i + 1];
+            auto relID = relIDs[i];
+            writePathRels(vectors, relIDDataVectorPos, srcNodeID, dstNodeID, relID,
+                tableIDToName.at(relID.tableID));
+            relIDDataVectorPos++;
+        }
     }
 }
 

--- a/test/test_files/issue/issue4.test
+++ b/test/test_files/issue/issue4.test
@@ -3,10 +3,64 @@
 
 --
 
+-CASE 3262
+-STATEMENT CREATE NODE TABLE Exercise (xxx String, PRIMARY KEY (xxx));
+---- ok
+-STATEMENT CREATE REL TABLE next (FROM Exercise TO Exercise, xxx String);
+---- ok
+-STATEMENT CREATE NODE TABLE Source (xxx String, PRIMARY KEY (xxx));
+---- ok
+-STATEMENT CREATE NODE TABLE User (xxx String, PRIMARY KEY (xxx));
+---- ok
+-STATEMENT CREATE REL TABLE GROUP has (FROM User TO Source, FROM Source TO Exercise, xxx String);
+---- ok
+-STATEMENT CREATE (ex:Exercise {xxx: "11-ex"});
+---- ok
+-STATEMENT CREATE (ex:Exercise {xxx: "12-ex"});
+---- ok
+-STATEMENT CREATE (ex:Exercise {xxx: "13-ex"});
+---- ok
+-STATEMENT MATCH (ex1:Exercise {xxx: "11-ex"}), (ex2:Exercise {xxx: "12-ex"}) CREATE (ex1)-[:next {xxx: "next"}]->(ex2);
+---- ok
+-STATEMENT MATCH (ex1:Exercise {xxx: "12-ex"}), (ex2:Exercise {xxx: "13-ex"}) CREATE (ex1)-[:next {xxx: "next"}]->(ex2);
+---- ok
+-STATEMENT CREATE (src:Source {xxx: "1-src"});
+---- ok
+-STATEMENT MATCH (src:Source {xxx: "1-src"}), (ex:Exercise {xxx: "11-ex"}) CREATE (src)-[:has {xxx: "has"}]->(ex);
+---- ok
+-STATEMENT MATCH (src:Source {xxx: "1-src"}), (ex:Exercise {xxx: "12-ex"}) CREATE (src)-[:has {xxx: "has"}]->(ex);
+---- ok
+-STATEMENT MATCH (src:Source {xxx: "1-src"}), (ex:Exercise {xxx: "13-ex"}) CREATE (src)-[:has {xxx: "has"}]->(ex);
+---- ok
+-STATEMENT CREATE (usr:User {xxx: "usr"});
+---- ok
+-STATEMENT MATCH (usr:User {xxx: "usr"}), (src:Source {xxx: "1-src"}) CREATE (usr)-[:has {xxx: "has"}]->(src);
+---- ok
+-STATEMENT CREATE (ex:Exercise {xxx: "21-ex"});
+---- ok
+-STATEMENT CREATE (ex:Exercise {xxx: "22-ex"});
+---- ok
+-STATEMENT MATCH (ex1:Exercise {xxx: "21-ex"}), (ex2:Exercise {xxx: "22-ex"}) CREATE (ex1)-[:next {xxx: "next"}]->(ex2);
+---- ok
+-STATEMENT CREATE (src:Source {xxx: "2-src"});
+---- ok
+-STATEMENT MATCH (src:Source {xxx: "2-src"}), (ex:Exercise {xxx: "21-ex"}) CREATE (src)-[:has {xxx: "has"}]->(ex);
+---- ok
+-STATEMENT MATCH (src:Source {xxx: "2-src"}), (ex:Exercise {xxx: "22-ex"}) CREATE (src)-[:has {xxx: "has"}]->(ex);
+---- ok
+-STATEMENT MATCH (usr:User {xxx: "usr"}), (src:Source {xxx: "2-src"}) CREATE (usr)-[:has {xxx: "has"}]->(src);
+---- ok
+-STATEMENT MATCH (usr:User)-[h1:has]->(src:Source {xxx: "1-src"}) RETURN h1;
+---- 1
+(3:0)-{_LABEL: has_User_Source, _ID: 5:0, xxx: has}->(2:0)
+-STATEMENT MATCH (usr:User)-[h1:has*1..1]->(src:Source {xxx: "1-src"}) RETURN rels(h1)[1];
+---- 1
+(3:0)-{_LABEL: has_User_Source, _ID: 5:0, xxx: has}->(2:0)
+
 -CASE 3083
 -STATEMENT CREATE NODE TABLE test ( prop0 STRING, prop1 STRING[], prop2 STRING, prop3 INT64, prop4 STRING, PRIMARY KEY(prop4) )
 ---- ok
--STATEMENT MERGE (n:test { prop4: "efwb2143d10ccfw" }) SET n.prop0 = "efwoj23", n.prop1 = ["eee", "wefwhiihifwe23343", "dmkwlenfwef232323"], n.prop2 = "NOT eee IS NULL AND dmkwlenfwef232323 < '2023-01-10T00:00:00-05:00' AND dmkwlenfwef232323 >= '2022-01-01T00:00:00-05:00'", n.prop3 = 5 RETURN n.prop4
+-STATEMENT MERGE (n:test { prop4: "efwb2143d10ccfw" }) SET n.prop0 = "efwoj23", n.prop1 = ["eee", "wefwhiihifwe23343", "dmkwlenfwef232323"], n.prop2 = "NOT eee IS NULL AND dmkwlenfwef232323 <'2023-01-10T00:00:00-05:00' AND dmkwlenfwef232323 >='2022-01-01T00:00:00-05:00'", n.prop3 = 5 RETURN n.prop4
 ---- ok
 -STATEMENT MERGE (n:test { prop4: "sdnweh2382933228" }) SET n.prop0 = "efwoj23", n.prop1 = ["customer_name", "wefwhiihifwe23343", "dmkwlenfwef232323"], n.prop2 = "NOT customer_name IS NULL AND NOT dmkwlenfwef232323 IS NULL" RETURN n.prop4
 ---- ok


### PR DESCRIPTION
Fix issue #3262.

This bug is within `RecursiveJoin` where we always write src and dst node according to extend direction. So if we extend in backward, src&dst will appear in wrong order.