### PR TITLE
Fix warnings from GCC 13

### DIFF
--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -510,9 +510,11 @@ void ArrowConverter::fromArrowArray(const ArrowSchema* schema, const ArrowArray*
                 dstOffset, count);
         case 'w': {
             // ARRAY
-            auto arrowNumElements = std::stoul(arrowType + 3);
-            auto outputNumElements = ArrayType::getNumElements(&outputVector.dataType);
-            KU_ASSERT(arrowNumElements == outputNumElements);
+            RUNTIME_CHECK({
+                auto arrowNumElements = std::stoul(arrowType + 3);
+                auto outputNumElements = ArrayType::getNumElements(&outputVector.dataType);
+                KU_ASSERT(arrowNumElements == outputNumElements);
+            });
             return scanArrowArrayFixedList(schema, array, outputVector, mask, srcOffset, dstOffset,
                 count);
         }

--- a/src/common/types/blob.cpp
+++ b/src/common/types/blob.cpp
@@ -55,13 +55,8 @@ uint64_t Blob::fromString(const char* str, uint64_t length, uint8_t* resultBuffe
             resultBuffer[resultPos++] =
                 (firstByte << HexFormatConstants::NUM_BYTES_TO_SHIFT_FOR_FIRST_BYTE) + secondByte;
             i += HexFormatConstants::LENGTH - 1;
-        } else if (str[i] <= 127) {
-            resultBuffer[resultPos++] = str[i];
         } else {
-            // LCOV_EXCL_START
-            throw InternalException("Invalid byte encountered in STRING -> BLOB conversion that "
-                                    "should have been caught during getBlobSize");
-            // LCOV_EXCL_STOP
+            resultBuffer[resultPos++] = str[i];
         }
     }
     return resultPos;

--- a/src/function/cast/cast_array.cpp
+++ b/src/function/cast/cast_array.cpp
@@ -13,18 +13,18 @@ bool CastArrayHelper::checkCompatibleNestedTypes(LogicalTypeID sourceTypeID,
         if (targetTypeID == LogicalTypeID::ARRAY || targetTypeID == LogicalTypeID::LIST) {
             return true;
         }
-    }
+    } break;
     case LogicalTypeID::MAP:
     case LogicalTypeID::STRUCT: {
         if (sourceTypeID == targetTypeID) {
             return true;
         }
-    }
+    } break;
     case LogicalTypeID::ARRAY: {
         if (targetTypeID == LogicalTypeID::LIST || targetTypeID == LogicalTypeID::ARRAY) {
             return true;
         }
-    }
+    } break;
     default:
         return false;
     }
@@ -62,7 +62,7 @@ bool CastArrayHelper::containsListToArray(const LogicalType* srcType, const Logi
                     return true;
                 }
             }
-        }
+        } break;
         default:
             return false;
         }

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -682,6 +682,7 @@ static std::unique_ptr<ScalarFunction> bindCastBetweenNested(const std::string& 
                 std::vector<LogicalTypeID>{sourceTypeID}, targetTypeID,
                 nestedTypesCastExecFunction);
         }
+        [[fallthrough]];
     }
     default:
         throw ConversionException{stringFormat("Unsupported casting function from {} to {}.",

--- a/src/include/common/assert.h
+++ b/src/include/common/assert.h
@@ -15,16 +15,19 @@ namespace common {
 }
 
 #if defined(KUZU_RUNTIME_CHECKS) || !defined(NDEBUG)
+#define RUNTIME_CHECK(code) code
 #define KU_ASSERT(condition)                                                                       \
     static_cast<bool>(condition) ?                                                                 \
         void(0) :                                                                                  \
         kuzu::common::kuAssertFailureInternal(#condition, __FILE__, __LINE__)
 #else
 #define KU_ASSERT(condition) void(0)
+#define RUNTIME_CHECK(code) void(0)
 #endif
 
 #define KU_UNREACHABLE                                                                             \
     [[unlikely]] kuzu::common::kuAssertFailureInternal("KU_UNREACHABLE", __FILE__, __LINE__)
+#define KU_UNUSED(expr) (void)(expr)
 
 } // namespace common
 } // namespace kuzu

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -110,7 +110,7 @@ concept HashableTypes = (std::integral<T> || std::floating_point<T> ||
                          std::is_same_v<T, list_entry_t> || std::is_same_v<T, internalID_t> ||
                          std::is_same_v<T, interval_t> || std::is_same_v<T, ku_string_t>);
 
-enum class KUZU_API LogicalTypeID : uint8_t {
+enum class LogicalTypeID : uint8_t {
     ANY = 0,
     NODE = 10,
     REL = 11,

--- a/src/include/function/function.h
+++ b/src/include/function/function.h
@@ -38,9 +38,7 @@ struct Function {
     Function(std::string name, std::vector<common::LogicalTypeID> parameterTypeIDs)
         : name{std::move(name)}, parameterTypeIDs{std::move(parameterTypeIDs)}, isVarLength{false} {
     }
-    Function(const Function& other)
-        : name{other.name}, parameterTypeIDs{other.parameterTypeIDs},
-          isVarLength{other.isVarLength} {}
+    Function(const Function&) = default;
 
     virtual ~Function() = default;
 

--- a/src/include/main/plan_printer.h
+++ b/src/include/main/plan_printer.h
@@ -58,8 +58,7 @@ private:
     static std::string genHorizLine(uint32_t len);
 
     inline void validateRowIdxAndColIdx(uint32_t rowIdx, uint32_t colIdx) const {
-        KU_ASSERT(0 <= rowIdx && rowIdx < opProfileBoxes.size() && 0 <= colIdx &&
-                  colIdx < opProfileBoxes[rowIdx].size());
+        KU_ASSERT(rowIdx < opProfileBoxes.size() && colIdx < opProfileBoxes[rowIdx].size());
         (void)rowIdx;
         (void)colIdx;
     }
@@ -70,8 +69,8 @@ private:
     OpProfileBox* getOpProfileBox(uint32_t rowIdx, uint32_t colIdx) const;
 
     bool hasOpProfileBox(uint32_t rowIdx, uint32_t colIdx) const {
-        return 0 <= rowIdx && rowIdx < opProfileBoxes.size() && 0 <= colIdx &&
-               colIdx < opProfileBoxes[rowIdx].size() && getOpProfileBox(rowIdx, colIdx);
+        return rowIdx < opProfileBoxes.size() && colIdx < opProfileBoxes[rowIdx].size() &&
+               getOpProfileBox(rowIdx, colIdx);
     }
 
     //! Returns true if there is a valid OpProfileBox on the upper left side of the OpProfileBox

--- a/src/include/optimizer/remove_unnecessary_join_optimizer.h
+++ b/src/include/optimizer/remove_unnecessary_join_optimizer.h
@@ -6,16 +6,17 @@
 namespace kuzu {
 namespace optimizer {
 
-// Due to the nature of graph pattern, a (node)-[rel]-(node) is always interpreted as two joins.
-// However, in many cases, a single join is sufficient.
-// E.g. MATCH (a)-[e]->(b) RETURN e.date
-// Our planner will generate a plan where the HJ is redundant.
-//      HJ
-//     /  \
-//   E(e) S(b)
-//    |
-//   S(a)
-// This optimizer prunes such redundant joins.
+/* Due to the nature of graph pattern, a (node)-[rel]-(node) is always interpreted as two joins.
+ * However, in many cases, a single join is sufficient.
+ * E.g. MATCH (a)-[e]->(b) RETURN e.date
+ * Our planner will generate a plan where the HJ is redundant.
+ *      HJ
+ *     /  \
+ *   E(e) S(b)
+ *    |
+ *   S(a)
+ * This optimizer prunes such redundant joins.
+ */
 class RemoveUnnecessaryJoinOptimizer : public LogicalOperatorVisitor {
 public:
     void rewrite(planner::LogicalPlan* plan);

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -65,8 +65,7 @@ private:
     inline const kuzu_parquet::format::RowGroup& getGroup(ParquetReaderScanState& state) {
         KU_ASSERT(
             state.currentGroup >= 0 && (uint64_t)state.currentGroup < state.groupIdxList.size());
-        KU_ASSERT(state.groupIdxList[state.currentGroup] >= 0 &&
-                  state.groupIdxList[state.currentGroup] < metadata->row_groups.size());
+        KU_ASSERT(state.groupIdxList[state.currentGroup] < metadata->row_groups.size());
         return metadata->row_groups[state.groupIdxList[state.currentGroup]];
     }
     static std::unique_ptr<common::LogicalType> deriveLogicalType(

--- a/src/planner/operator/extend/logical_extend.cpp
+++ b/src/planner/operator/extend/logical_extend.cpp
@@ -15,9 +15,11 @@ f_group_pos_set LogicalExtend::getGroupsPosToFlatten() {
 
 void LogicalExtend::computeFactorizedSchema() {
     copyChildSchema(0);
-    auto boundGroupPos = schema->getGroupPos(*boundNode->getInternalID());
+    RUNTIME_CHECK({
+        auto boundGroupPos = schema->getGroupPos(*boundNode->getInternalID());
+        KU_ASSERT(schema->getGroup(boundGroupPos)->isFlat());
+    });
     uint32_t nbrGroupPos = 0u;
-    KU_ASSERT(schema->getGroup(boundGroupPos)->isFlat());
     nbrGroupPos = schema->createGroup();
     schema->insertToGroupAndScope(nbrNode->getInternalID(), nbrGroupPos);
     for (auto& property : properties) {

--- a/src/processor/operator/aggregate/simple_aggregate_scan.cpp
+++ b/src/processor/operator/aggregate/simple_aggregate_scan.cpp
@@ -7,9 +7,11 @@ void SimpleAggregateScan::initLocalStateInternal(ResultSet* resultSet, Execution
     BaseAggregateScan::initLocalStateInternal(resultSet, context);
     KU_ASSERT(!aggregatesPos.empty());
     auto outDataChunkPos = aggregatesPos[0].dataChunkPos;
-    for (auto& dataPos : aggregatesPos) {
-        KU_ASSERT(dataPos.dataChunkPos == outDataChunkPos);
-    }
+    RUNTIME_CHECK({
+        for (auto& dataPos : aggregatesPos) {
+            KU_ASSERT(dataPos.dataChunkPos == outDataChunkPos);
+        }
+    });
     outDataChunk = resultSet->dataChunks[outDataChunkPos].get();
 }
 

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -306,7 +306,7 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
         resultColumnNames, scanInput->expectedColumnTypes, detectedColumnTypes, resultColumnTypes);
     auto config = scanInput->config.copy();
     KU_ASSERT(!config.filePaths.empty() && config.getNumFiles() == resultColumnNames.size());
-    row_idx_t numRows;
+    row_idx_t numRows = 0;
     for (auto i = 0u; i < config.getNumFiles(); i++) {
         auto reader = make_unique<NpyReader>(config.filePaths[i]);
         if (i == 0) {

--- a/src/processor/operator/persistent/reader/parquet/column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/column_reader.cpp
@@ -3,6 +3,7 @@
 #include <sstream>
 
 #include "brotli/decode.h"
+#include "common/assert.h"
 #include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
 #include "common/types/date_t.h"
@@ -539,6 +540,7 @@ std::unique_ptr<ColumnReader> ColumnReader::createTimestampReader(ParquetReader&
             }
             // LCOV_EXCL_STOP
         }
+        KU_UNREACHABLE;
     }
     default: {
         KU_UNREACHABLE;

--- a/src/processor/operator/persistent/reader/parquet/parquet_timestamp.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_timestamp.cpp
@@ -1,5 +1,7 @@
 #include "processor/operator/persistent/reader/parquet/parquet_timestamp.h"
 
+#include <cstring>
+
 namespace kuzu {
 namespace processor {
 
@@ -22,7 +24,8 @@ common::timestamp_t ParquetTimeStampUtils::parquetTimestampNsToTimestamp(const i
 
 int64_t ParquetTimeStampUtils::impalaTimestampToMicroseconds(const Int96& impalaTimestamp) {
     int64_t daysSinceEpoch = impalaTimestamp.value[2] - JULIAN_TO_UNIX_EPOCH_DAYS;
-    auto nanoSeconds = *reinterpret_cast<const int64_t*>(impalaTimestamp.value);
+    int64_t nanoSeconds;
+    memcpy(&nanoSeconds, &impalaTimestamp.value, sizeof(nanoSeconds));
     auto microseconds = nanoSeconds / NANOSECONDS_PER_MICRO;
     return daysSinceEpoch * MICROSECONDS_PER_DAY + microseconds;
 }

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -401,6 +401,7 @@ template<typename T>
 void IntegerBitpacking<T>::setValuesFromUncompressed(const uint8_t* srcBuffer, offset_t posInSrc,
     uint8_t* dstBuffer, offset_t posInDst, offset_t numValues, const CompressionMetadata& metadata,
     const NullMask* nullMask) const {
+    KU_UNUSED(nullMask);
     auto header = BitpackHeader::readHeader(metadata.data);
     // This is a fairly naive implementation which uses fastunpack/fastpack
     // to modify the data by decompressing/compressing a single chunk of values.

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -473,7 +473,7 @@ void HashIndex<T>::mergeBulkInserts() {
     // TODO: one pass would also reduce locking when frames are unpinned,
     // which is useful if this can be paralellized
     reserve(bulkInsertLocalStorage.size());
-    auto originalNumEntries = this->indexHeaderForWriteTrx->numEntries;
+    RUNTIME_CHECK(auto originalNumEntries = this->indexHeaderForWriteTrx->numEntries;);
 
     // Storing as many slots in-memory as on-disk shouldn't be necessary (for one it makes memory
     // usage an issue as we may need significantly more memory to store the slots that we would

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -87,7 +87,7 @@ void ListColumn::scan(Transaction* transaction, ChunkState& readState, offset_t 
     auto offsetToWriteListData = listOffsetInVector;
     auto numValues = endOffsetInGroup - startOffsetInGroup;
     numValues = std::min(numValues, listOffsetInfoInStorage.numTotal);
-    KU_ASSERT(numValues >= 0);
+    KU_ASSERT(endOffsetInGroup >= startOffsetInGroup);
     for (auto i = 0u; i < numValues; i++) {
         list_size_t size = listOffsetInfoInStorage.getListSize(i);
         resultVector->setValue(i + offsetInVector, list_entry_t{listOffsetInVector, size});
@@ -105,7 +105,6 @@ void ListColumn::scan(Transaction* transaction, ChunkState& readState, offset_t 
         for (auto i = 0u; i < numValues; i++) {
             offset_t startOffset = listOffsetInfoInStorage.getListStartOffset(i);
             offset_t appendSize = listOffsetInfoInStorage.getListSize(i);
-            KU_ASSERT(appendSize >= 0);
             dataColumn->scan(transaction,
                 readState.childrenStates[DATA_COLUMN_CHILD_READ_STATE_IDX], startOffset,
                 startOffset + appendSize, dataVector, offsetToWriteListData);

--- a/test/main/system_config_test.cpp
+++ b/test/main/system_config_test.cpp
@@ -34,21 +34,21 @@ TEST_F(SystemConfigTest, testMaxDBSize) {
     systemConfig->maxDBSize = 1024;
     try {
         auto db = std::make_unique<Database>(databasePath, *systemConfig);
-    } catch (BufferManagerException e) {
+    } catch (const BufferManagerException& e) {
         ASSERT_EQ(std::string(e.what()),
             "Buffer manager exception: The given max db size should be at least 4194304 bytes.");
     }
     systemConfig->maxDBSize = 4194305;
     try {
         auto db = std::make_unique<Database>(databasePath, *systemConfig);
-    } catch (BufferManagerException e) {
+    } catch (const BufferManagerException& e) {
         ASSERT_EQ(std::string(e.what()),
             "Buffer manager exception: The given max db size should be a power of 2.");
     }
     systemConfig->maxDBSize = 4194304;
     try {
         auto db = std::make_unique<Database>(databasePath, *systemConfig);
-    } catch (BufferManagerException e) {
+    } catch (const BufferManagerException& e) {
         ASSERT_EQ(std::string(e.what()),
             "Buffer manager exception: No more frame groups can be added to the allocator.");
     }
@@ -60,7 +60,7 @@ TEST_F(SystemConfigTest, testBufferPoolSize) {
     systemConfig->bufferPoolSize = 1024;
     try {
         auto db = std::make_unique<Database>(databasePath, *systemConfig);
-    } catch (BufferManagerException e) {
+    } catch (const BufferManagerException& e) {
         ASSERT_EQ(std::string(e.what()),
             "Buffer manager exception: The given buffer pool size should be at least 4KB.");
     }

--- a/test/test_helper/test_helper.cpp
+++ b/test/test_helper/test_helper.cpp
@@ -26,7 +26,7 @@ std::vector<std::unique_ptr<TestQueryConfig>> TestHelper::parseTestFile(const st
     }
     std::ifstream ifs(path);
     std::string line;
-    TestQueryConfig* currentConfig;
+    TestQueryConfig* currentConfig = nullptr;
     while (getline(ifs, line)) {
         if (line.starts_with("-NAME")) {
             auto config = std::make_unique<TestQueryConfig>();

--- a/third_party/antlr4_runtime/src/tree/ParseTree.h
+++ b/third_party/antlr4_runtime/src/tree/ParseTree.h
@@ -47,7 +47,7 @@ namespace tree {
     /// based upon the parser.
     virtual std::string toStringTree(Parser *parser, bool pretty = false) = 0;
 
-    virtual bool operator == (const ParseTree &other) const;
+    bool operator == (const ParseTree &other) const;
 
     /// The <seealso cref="ParseTreeVisitor"/> needs a double dispatch method.
     // ml: This has been changed to use Any instead of a template parameter, to avoid the need of a virtual template function.

--- a/third_party/mbedtls/library/constant_time.cpp
+++ b/third_party/mbedtls/library/constant_time.cpp
@@ -58,10 +58,10 @@ int mbedtls_ct_memcmp(const void* a, const void* b, size_t n) {
          * This avoids IAR compiler warning:
          * 'the order of volatile accesses is undefined ..' */
         unsigned char x = A[i], y = B[i];
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-volatile"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-volatile"
         diff |= x ^ y;
-#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
     }
 
     return ((int)diff);

--- a/third_party/miniparquet/src/thrift/Thrift.h
+++ b/third_party/miniparquet/src/thrift/Thrift.h
@@ -17,6 +17,7 @@
  * under the License.
  */
 
+#include <cstddef>
 #ifndef _THRIFT_THRIFT_H_
 #define _THRIFT_THRIFT_H_ 1
 
@@ -50,9 +51,13 @@
 namespace kuzu_apache {
 namespace thrift {
 
-class TEnumIterator
-    : public std::iterator<std::forward_iterator_tag, std::pair<int, const char*> > {
+class TEnumIterator {
 public:
+  using iterator_category = std::forward_iterator_tag;
+  using value_type = std::pair<int, const char*>;
+  using pointer = std::pair<int, const char*>*;
+  using reference = std::pair<int, const char*>&;
+  using difference_type = std::ptrdiff_t;
   TEnumIterator(int n, int* enums, const char** names)
     : ii_(0), n_(n), enums_(enums), names_(names) {}
 

--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -205,7 +205,7 @@ void highlight(char* buffer, char* resultBuf, uint32_t renderWidth, uint32_t cur
     tokenList.emplace_back(word);
     for (std::string& token : tokenList) {
         if (token.find(' ') == std::string::npos) {
-            for (const std::string& keyword : keywordList) {
+            for (const std::string keyword : keywordList) {
                 if (regex_search(token,
                         std::regex("^" + keyword + "$", std::regex_constants::icase)) ||
                     regex_search(token,


### PR DESCRIPTION
There are a bunch of warnings piling up with GCC 13, which I use personally, which don't show up in CI (with GCC 11).
Maybe this is too much for one PR, but it's mostly minor things.

There are two bugs I found when going through the warnings:
1. `CastArrayHelper::checkCompatibleNestedTypes` was falling through. This meant it was allowing `MAP`/`STRUCT` to be cast to `LIST`/`ARRAY`. `STRUCT` to `LIST`/`ARRAY` produces an unexpected error if you try that isn't very helpful, but it is actually possible to successfully cast `MAP(<T1>, <T2>)` to a `STRUCT(KEY <T1>, VALUE <T2>)[]`.
2. `ParquetTimeStampUtils::impalaTimestampToMicroseconds` was casting the impala timestamp `Int96` data to a pointer and dereferencing it. I'm fairly sure it's not supposed to be storing a pointer, and I don't think this code is covered by tests. Additionally, using a pointer to cast from two `int32_t` to one `int64_t` also throws an aliasing error. As far as I can tell it's being used to store raw data read from disk, and the cast should be safe as long as the endianness matches (I don't know if parquet has any endianness requirements, but generally we assume everything is native-endian), so I switched it to use `memcpy` to work around the aliasing error.

Other changes:
- I added a `RUNTIME_CHECK` macro which unlike `KU_ASSERT` doesn't expect a boolean expression but makes for a nicer way of disabling extra code only needed for checks to avoid unused variable warnings.
- `blob.cpp`: signed `char` is always `<= 127`
- There are a few places with harmless implicit fallthrough where I either added `break` or `[[fallthrough]]`.
- `LogicalTypeID` is forward-declared without `KUZU_API` in database.h, so there's a warning that the `KUZU_API` annotations don't work if the type has been previously declared. Since it's header-only, I don't think `KUZU_API` is actually necessary, but I'll see if it passes Windows CI first.
- `function.h`: A subclass was using the default `operator=`, which produces a warning if there is a non-default copy constructor. But the explicit copy constructor is identical to the default so I just made it default.
- `plan_printer.h` (similar elsewhere): Unnecessary checks that unsigned values are `>= 0`.
- `npy_reader.cpp`: Value may be uninitialized. Not really necessary to change, but initializing it isn't exactly going to slow anything down and it silences the warning.
- `compression.cpp`: A parameter is used only by a runtime check. I added a `KU_UNUSED`, which is just a macro for a `(void)expr` cast to hide that warning in a way that clearly indicates the purpose (it should only be used in cases like this, otherwise the parameter name can be commented out or removed).
- `list_column.cpp`: numValues is unsigned since the start and end variables are unsigned, but it makes more sense to look at the inputs to check for underflow rather than the result of the subtraction.
- `system_config_test.cpp`: `BufferManagerException` is polymorphic and shouldn't be caught by value (not that it actually has any subclasses).
- `Thrift.h`: `std::iterator` is deprecated
- `embedded_shell.cpp`: Reference to a temporary since keywordList is a `vector<const char*>` and the strings are being created on the fly.
- `ParseTree.h`: `operator==` doesn't really need to be virtual since it's never overridden. One subclass has an `operator==` with a different signature that hides the original and was producing a warning.
- `constant_time.cpp`: gcc was complaining that `"-Wdeprecated-volatile"` is unknown. Presumably because it's C code and the warning is only enabled in C++ mode (they're all cpp files, but we're setting the `C_STANDARD 99` property via CMake). *Update: Clang doesn't appear to have this distinction, I'll see if I can suppress it in a clang-specific way.*