### PR TITLE
Fix USERPROFILE access conflicts in Windows CI

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -217,6 +217,10 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
       PG_HOST: ${{ secrets.PG_HOST }}
       RUN_ID: "$(hostname)-$([Math]::Floor((Get-Date).TimeOfDay.TotalSeconds))"
+      # The extension is stored in a shared user directory using USERPROFILE
+      # Without overriding it will conflict with other jobs when they attempt to read/write
+      # to the extension files at the same time
+      USERPROFILE: ${{ github.workspace }}/profile
     steps:
       - uses: actions/checkout@v3
 
@@ -568,6 +572,7 @@ jobs:
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
       PG_HOST: ${{ secrets.PG_HOST }}
       RUN_ID: "$(hostname)-$([Math]::Floor((Get-Date).TimeOfDay.TotalSeconds))"
+      USERPROFILE: ${{ github.workspace }}/profile
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
Some tests have been failing when multiple jobs are trying to read/write to the same extension file. E.g. https://github.com/kuzudb/kuzu/actions/runs/8853455160/job/24314357568?pr=3387

The path of that file is derived from `ClientConfig.homeDirectory`, which is set using the `USERPROFILE` environment variable on Windows. This overrides that in CI to refer to a directory unique to the CI job.