### PR TITLE
Add Python UDF for Primitive Types

### DIFF
--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -853,7 +853,7 @@ std::string LogicalTypeUtils::toString(LogicalTypeID dataTypeID) {
     // LCOV_EXCL_STOP
 }
 
-LogicalTypeID LogicalTypeUtils::fromStringToID(std::string str) {
+LogicalTypeID LogicalTypeUtils::fromStringToID(const std::string& str) {
     if (str == "ANY") {
         return LogicalTypeID::ANY;
     } else if (str == "NODE") {

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -778,7 +778,7 @@ std::string LogicalTypeUtils::toString(LogicalTypeID dataTypeID) {
     // LCOV_EXCL_START
     switch (dataTypeID) {
     case LogicalTypeID::ANY:
-       return "ANY";
+        return "ANY";
     case LogicalTypeID::NODE:
         return "NODE";
     case LogicalTypeID::REL:

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -5,6 +5,7 @@
 #include "common/exception/binder.h"
 #include "common/exception/conversion.h"
 #include "common/exception/not_implemented.h"
+#include "common/exception/runtime.h"
 #include "common/null_buffer.h"
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
@@ -777,7 +778,7 @@ std::string LogicalTypeUtils::toString(LogicalTypeID dataTypeID) {
     // LCOV_EXCL_START
     switch (dataTypeID) {
     case LogicalTypeID::ANY:
-        return "ANY";
+       return "ANY";
     case LogicalTypeID::NODE:
         return "NODE";
     case LogicalTypeID::REL:
@@ -850,6 +851,82 @@ std::string LogicalTypeUtils::toString(LogicalTypeID dataTypeID) {
         KU_UNREACHABLE;
     }
     // LCOV_EXCL_STOP
+}
+
+LogicalTypeID LogicalTypeUtils::fromStringToID(std::string str) {
+    if (str == "ANY") {
+        return LogicalTypeID::ANY;
+    } else if (str == "NODE") {
+        return LogicalTypeID::NODE;
+    } else if (str == "REL") {
+        return LogicalTypeID::REL;
+    } else if (str == "RECURSIVE_REL") {
+        return LogicalTypeID::RECURSIVE_REL;
+    } else if (str == "INTERNAL_ID") {
+        return LogicalTypeID::INTERNAL_ID;
+    } else if (str == "BOOL") {
+        return LogicalTypeID::BOOL;
+    } else if (str == "INT64") {
+        return LogicalTypeID::INT64;
+    } else if (str == "INT32") {
+        return LogicalTypeID::INT32;
+    } else if (str == "INT16") {
+        return LogicalTypeID::INT16;
+    } else if (str == "INT8") {
+        return LogicalTypeID::INT8;
+    } else if (str == "UINT64") {
+        return LogicalTypeID::UINT64;
+    } else if (str == "UINT32") {
+        return LogicalTypeID::UINT32;
+    } else if (str == "UINT16") {
+        return LogicalTypeID::UINT16;
+    } else if (str == "UINT8") {
+        return LogicalTypeID::UINT8;
+    } else if (str == "INT128") {
+        return LogicalTypeID::INT128;
+    } else if (str == "DOUBLE") {
+        return LogicalTypeID::DOUBLE;
+    } else if (str == "FLOAT") {
+        return LogicalTypeID::FLOAT;
+    } else if (str == "DATE") {
+        return LogicalTypeID::DATE;
+    } else if (str == "TIMESTAMP_NS") {
+        return LogicalTypeID::TIMESTAMP_NS;
+    } else if (str == "TIMESTAMP_MS") {
+        return LogicalTypeID::TIMESTAMP_MS;
+    } else if (str == "TIMESTAMP_SEC") {
+        return LogicalTypeID::TIMESTAMP_SEC;
+    } else if (str == "TIMESTAMP_TZ") {
+        return LogicalTypeID::TIMESTAMP_TZ;
+    } else if (str == "TIMESTAMP") {
+        return LogicalTypeID::TIMESTAMP;
+    } else if (str == "INTERVAL") {
+        return LogicalTypeID::INTERVAL;
+    } else if (str == "BLOB") {
+        return LogicalTypeID::BLOB;
+    } else if (str == "UUID") {
+        return LogicalTypeID::UUID;
+    } else if (str == "STRING") {
+        return LogicalTypeID::STRING;
+    } else if (str == "LIST") {
+        return LogicalTypeID::LIST;
+    } else if (str == "ARRAY") {
+        return LogicalTypeID::ARRAY;
+    } else if (str == "STRUCT") {
+        return LogicalTypeID::STRUCT;
+    } else if (str == "RDF_VARIANT") {
+        return LogicalTypeID::RDF_VARIANT;
+    } else if (str == "SERIAL") {
+        return LogicalTypeID::SERIAL;
+    } else if (str == "MAP") {
+        return LogicalTypeID::MAP;
+    } else if (str == "UNION") {
+        return LogicalTypeID::UNION;
+    } else if (str == "POINTER") {
+        return LogicalTypeID::POINTER;
+    } else {
+        throw RuntimeException(stringFormat("Unknown type {}", str));
+    }
 }
 
 std::string LogicalTypeUtils::toString(const std::vector<LogicalType>& dataTypes) {

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -539,7 +539,7 @@ struct LogicalTypeUtils {
     KUZU_API static std::string toString(LogicalTypeID dataTypeID);
     KUZU_API static std::string toString(const std::vector<LogicalType>& dataTypes);
     KUZU_API static std::string toString(const std::vector<LogicalTypeID>& dataTypeIDs);
-    static LogicalTypeID fromStringToID(std::string str);
+    static LogicalTypeID fromStringToID(const std::string& str);
     static uint32_t getRowLayoutSize(const LogicalType& logicalType);
     static bool isDate(const LogicalType& dataType);
     static bool isDate(const LogicalTypeID& dataType);

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -539,6 +539,7 @@ struct LogicalTypeUtils {
     KUZU_API static std::string toString(LogicalTypeID dataTypeID);
     KUZU_API static std::string toString(const std::vector<LogicalType>& dataTypes);
     KUZU_API static std::string toString(const std::vector<LogicalTypeID>& dataTypeIDs);
+    static LogicalTypeID fromStringToID(std::string str);
     static uint32_t getRowLayoutSize(const LogicalType& logicalType);
     static bool isDate(const LogicalType& dataType);
     static bool isDate(const LogicalTypeID& dataType);

--- a/src/include/main/connection.h
+++ b/src/include/main/connection.h
@@ -115,6 +115,12 @@ public:
         commitUDFTrx(autoTrx);
     }
 
+    void addUDFFunctionSet(std::string name, function::function_set func) {
+        auto autoTrx = startUDFAutoTrx(clientContext->getTransactionContext());
+        addScalarFunction(std::move(name), std::move(func));
+        commitUDFTrx(autoTrx);
+    }
+
     template<typename TR, typename... Args>
     void createVectorizedFunction(std::string name, function::scalar_func_exec_t scalarFunc) {
         auto autoTrx = startUDFAutoTrx(clientContext->getTransactionContext());

--- a/tools/python_api/CMakeLists.txt
+++ b/tools/python_api/CMakeLists.txt
@@ -16,6 +16,7 @@ pybind11_add_module(_kuzu
         src_cpp/py_prepared_statement.cpp
         src_cpp/py_query_result.cpp
         src_cpp/py_query_result_converter.cpp
+        src_cpp/py_udf.cpp
         src_cpp/py_conversion.cpp
         src_cpp/pyarrow/pyarrow_bind.cpp
         src_cpp/pyarrow/pyarrow_scan.cpp

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -27,9 +27,12 @@ public:
 class InspectCachedItem : public PythonCachedItem {
 
 public:
-    InspectCachedItem() : PythonCachedItem("inspect"), currentframe("currentframe", this) {}
+    InspectCachedItem() : PythonCachedItem("inspect"), currentframe("currentframe", this),
+        signature("signature", this), _empty("_empty", this) {}
 
     PythonCachedItem currentframe;
+    PythonCachedItem signature;
+    PythonCachedItem _empty;
 };
 
 class NumpyMaCachedItem : public PythonCachedItem {

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -27,8 +27,9 @@ public:
 class InspectCachedItem : public PythonCachedItem {
 
 public:
-    InspectCachedItem() : PythonCachedItem("inspect"), currentframe("currentframe", this),
-        signature("signature", this), _empty("_empty", this) {}
+    InspectCachedItem()
+        : PythonCachedItem("inspect"), currentframe("currentframe", this),
+          signature("signature", this), _empty("_empty", this) {}
 
     PythonCachedItem currentframe;
     PythonCachedItem signature;

--- a/tools/python_api/src_cpp/include/py_connection.h
+++ b/tools/python_api/src_cpp/include/py_connection.h
@@ -5,6 +5,10 @@
 #include "py_prepared_statement.h"
 #include "py_query_result.h"
 
+using kuzu::common::LogicalType;
+using kuzu::common::LogicalTypeID;
+using kuzu::common::Value;
+
 class PyConnection {
 
 public:
@@ -36,6 +40,12 @@ public:
         const std::string& dstTableName, size_t queryBatchSize);
 
     static bool isPandasDataframe(const py::object& object);
+
+    void createScalarFunction(const std::string& name, 
+        const py::function& udf, const py::list& params, const std::string& retval);
+    
+    static Value transformPythonValue(py::handle val);
+    static Value transformPythonValueAs(py::handle val, const LogicalType* type);
 
 private:
     std::unique_ptr<StorageDriver> storageDriver;

--- a/tools/python_api/src_cpp/include/py_connection.h
+++ b/tools/python_api/src_cpp/include/py_connection.h
@@ -44,8 +44,8 @@ public:
     void createScalarFunction(const std::string& name, const py::function& udf,
         const py::list& params, const std::string& retval);
 
-    static Value transformPythonValue(py::handle val);
-    static Value transformPythonValueAs(py::handle val, const LogicalType* type);
+    static Value transformPythonValue(const py::handle& val);
+    static Value transformPythonValueAs(const py::handle& val, const LogicalType& type);
 
 private:
     std::unique_ptr<StorageDriver> storageDriver;

--- a/tools/python_api/src_cpp/include/py_connection.h
+++ b/tools/python_api/src_cpp/include/py_connection.h
@@ -41,9 +41,9 @@ public:
 
     static bool isPandasDataframe(const py::object& object);
 
-    void createScalarFunction(const std::string& name, 
-        const py::function& udf, const py::list& params, const std::string& retval);
-    
+    void createScalarFunction(const std::string& name, const py::function& udf,
+        const py::list& params, const std::string& retval);
+
     static Value transformPythonValue(py::handle val);
     static Value transformPythonValueAs(py::handle val, const LogicalType* type);
 

--- a/tools/python_api/src_cpp/include/py_udf.h
+++ b/tools/python_api/src_cpp/include/py_udf.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+#include "common/types/types.h"
+#include "function/function.h"
+#include "pybind_include.h"
+
+using kuzu::common::LogicalTypeID;
+using kuzu::function::function_set;
+
+class PyUDF {
+
+public:
+    static function_set toFunctionSet(const std::string& name,
+        const py::function& udf, const py::list& params, const std::string& retType);
+};
+

--- a/tools/python_api/src_cpp/include/py_udf.h
+++ b/tools/python_api/src_cpp/include/py_udf.h
@@ -13,5 +13,5 @@ class PyUDF {
 
 public:
     static function_set toFunctionSet(const std::string& name, const py::function& udf,
-        const py::list& params, const std::string& retType);
+        const py::list& paramTypes, const std::string& resultType);
 };

--- a/tools/python_api/src_cpp/include/py_udf.h
+++ b/tools/python_api/src_cpp/include/py_udf.h
@@ -12,7 +12,6 @@ using kuzu::function::function_set;
 class PyUDF {
 
 public:
-    static function_set toFunctionSet(const std::string& name,
-        const py::function& udf, const py::list& params, const std::string& retType);
+    static function_set toFunctionSet(const std::string& name, const py::function& udf,
+        const py::list& params, const std::string& retType);
 };
-

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -34,7 +34,7 @@ void PyConnection::initialize(py::handle& m) {
         .def("get_all_edges_for_torch_geometric", &PyConnection::getAllEdgesForTorchGeometric,
             py::arg("np_array"), py::arg("src_table_name"), py::arg("rel_name"),
             py::arg("dst_table_name"), py::arg("query_batch_size"))
-        .def("set_UDF", &PyConnection::createScalarFunction, py::arg("name"), py::arg("udf"),
+        .def("set_udf", &PyConnection::createScalarFunction, py::arg("name"), py::arg("udf"),
             py::arg("parameters"), py::arg("return_value"));
     PyDateTime_IMPORT;
 }

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -34,8 +34,8 @@ void PyConnection::initialize(py::handle& m) {
         .def("get_all_edges_for_torch_geometric", &PyConnection::getAllEdgesForTorchGeometric,
             py::arg("np_array"), py::arg("src_table_name"), py::arg("rel_name"),
             py::arg("dst_table_name"), py::arg("query_batch_size"))
-        .def("set_udf", &PyConnection::createScalarFunction, py::arg("name"), py::arg("udf"),
-            py::arg("parameters"), py::arg("return_value"));
+        .def("create_function", &PyConnection::createScalarFunction, py::arg("name"), py::arg("udf"),
+            py::arg("params_type"), py::arg("return_value"));
     PyDateTime_IMPORT;
 }
 

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -34,8 +34,8 @@ void PyConnection::initialize(py::handle& m) {
         .def("get_all_edges_for_torch_geometric", &PyConnection::getAllEdgesForTorchGeometric,
             py::arg("np_array"), py::arg("src_table_name"), py::arg("rel_name"),
             py::arg("dst_table_name"), py::arg("query_batch_size"))
-        .def("create_function", &PyConnection::createScalarFunction, py::arg("name"), py::arg("udf"),
-            py::arg("params_type"), py::arg("return_value"));
+        .def("create_function", &PyConnection::createScalarFunction, py::arg("name"),
+            py::arg("udf"), py::arg("params_type"), py::arg("return_value"));
     PyDateTime_IMPORT;
 }
 
@@ -187,7 +187,7 @@ static std::unordered_map<std::string, std::unique_ptr<Value>> transformPythonPa
     return result;
 }
 
-static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
+static std::unique_ptr<LogicalType> pyLogicalType(const py::handle& val) {
     auto datetime_datetime = importCache->datetime.datetime();
     auto time_delta = importCache->datetime.timedelta();
     auto datetime_date = importCache->datetime.date();
@@ -270,7 +270,7 @@ static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
     }
 }
 
-Value PyConnection::transformPythonValueAs(py::handle val, const LogicalType& type) {
+Value PyConnection::transformPythonValueAs(const py::handle& val, const LogicalType& type) {
     // ignore the type of the actual python object, just directly cast
     auto datetime_datetime = importCache->datetime.datetime();
     auto time_delta = importCache->datetime.timedelta();
@@ -399,7 +399,7 @@ Value PyConnection::transformPythonValueAs(py::handle val, const LogicalType& ty
     }
 }
 
-Value PyConnection::transformPythonValue(py::handle val) {
+Value PyConnection::transformPythonValue(const py::handle& val) {
     auto type = pyLogicalType(val);
     return transformPythonValueAs(val, *type);
 }

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -170,7 +170,6 @@ bool PyConnection::isPandasDataframe(const py::object& object) {
     return py::isinstance(object, importCache->pandas.DataFrame());
 }
 
-
 static std::unordered_map<std::string, std::unique_ptr<Value>> transformPythonParameters(
     const py::dict& params, Connection* conn) {
     std::unordered_map<std::string, std::unique_ptr<Value>> result;

--- a/tools/python_api/src_cpp/py_conversion.cpp
+++ b/tools/python_api/src_cpp/py_conversion.cpp
@@ -1,7 +1,6 @@
 #include "py_conversion.h"
 
 #include "cached_import/py_cached_import.h"
-#include "common/exception/runtime.h"
 #include "common/type_utils.h"
 
 namespace kuzu {

--- a/tools/python_api/src_cpp/py_conversion.cpp
+++ b/tools/python_api/src_cpp/py_conversion.cpp
@@ -1,6 +1,7 @@
 #include "py_conversion.h"
 
 #include "cached_import/py_cached_import.h"
+#include "common/exception/runtime.h"
 #include "common/type_utils.h"
 
 namespace kuzu {

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -82,9 +82,12 @@ static scalar_func_exec_t getUDFExecution(const py::function& udf) {
     return [=](const std::vector<std::shared_ptr<ValueVector>>& params,
         ValueVector& result, void*) -> void {
         py::gil_scoped_acquire acquire;
-        auto vectorLength = 0u;
-        if (params.size() > 0) {
-            vectorLength = params[0]->state->selVector->selectedSize;
+        auto vectorLength = 1;
+        py::list basePyParams;
+        for (const auto& param: params) {
+            if (param->state->selVector->selectedSize != 1) {
+                vectorLength = param->state->selVector->selectedSize;
+            }
         }
         for (auto cur = 0u; cur < vectorLength; cur++) {
             py::list asPyParams;

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -1,0 +1,140 @@
+#include "py_udf.h"
+
+#include <vector>
+
+#include "function/scalar_function.h"
+#include "cached_import/py_cached_import.h"
+#include "common/exception/runtime.h"
+#include "common/string_format.h"
+#include "py_connection.h"
+#include "py_query_result.h"
+
+using namespace kuzu::common;
+using namespace kuzu;
+using namespace kuzu::function;
+
+struct PyUDFSignature {
+    std::vector<LogicalTypeID> params;
+    LogicalTypeID retval;
+
+    PyUDFSignature(): params(), retval(LogicalTypeID::ANY) {}
+};
+
+static std::vector<LogicalTypeID> pyListToParams(const py::list& lst) {
+    std::vector<LogicalTypeID> result;
+    for (const auto& i: lst) {
+        result.push_back(LogicalTypeUtils::fromStringToID(py::cast<std::string>(i)));
+    }
+    return result;
+}
+
+static LogicalTypeID pyTypeToLogicalTypeID(const py::handle& ele) {
+    auto datetime_datetime = importCache->datetime.datetime();
+    auto time_delta = importCache->datetime.timedelta();
+    auto datetime_date = importCache->datetime.date();
+    auto uuid = importCache->uuid.UUID();
+    auto inspect_empty = importCache->inspect._empty();
+    if (ele.is(py::type::of(py::none())) || ele.is(inspect_empty)) {
+        return LogicalTypeID::ANY;
+    } else if (ele.is(py::type::of(py::bool_()))) {
+        return LogicalTypeID::BOOL;
+    } else if (ele.is(py::type::of(py::int_()))) {
+        return LogicalTypeID::INT64;
+    } else if (ele.is(py::type::of(py::float_()))) {
+        return LogicalTypeID::DOUBLE;
+    } else if (ele.is(py::type::of(py::str()))) {
+        return LogicalTypeID::STRING;
+    } else if (ele.is(py::type::of(datetime_datetime(1, 1, 1)))) {
+        return LogicalTypeID::TIMESTAMP;
+    } else if (ele.is(py::type::of(datetime_date(1, 1, 1)))) {
+        return LogicalTypeID::DATE;
+    } else if (ele.is(py::type::of(time_delta(0)))) {
+        return LogicalTypeID::INTERVAL;
+    } else if (ele.is(py::type::of(uuid(py::arg("int") = 0)))) {
+        return LogicalTypeID::UUID;
+    } else if (ele.is(py::type::of(py::str()))) {
+        return LogicalTypeID::STRING;
+    } else if (ele.is(py::type::of(py::list()))) {
+        return LogicalTypeID::LIST;
+    } else if (ele.is(py::type::of(py::dict()))) {
+        return LogicalTypeID::MAP;
+    } else {
+        throw RuntimeException(common::stringFormat("Unsupported parameter of type {}",
+            py::cast<std::string>(py::str(ele))));
+    }
+}
+
+
+static PyUDFSignature analyzeSignature(const py::function& udf) {
+    PyUDFSignature retval;
+    auto signature = kuzu::importCache->inspect.signature()(udf, py::arg("eval_str") = true);
+    auto sig_params = signature.attr("parameters");
+    auto return_annotation = signature.attr("return_annotation");
+    retval.retval = pyTypeToLogicalTypeID(return_annotation);
+    for (const auto& i: sig_params) {
+        auto param_annotation = sig_params.attr("__getitem__")(i).attr("annotation");
+        retval.params.push_back(pyTypeToLogicalTypeID(param_annotation));
+    }
+    return retval;
+}
+
+static scalar_func_exec_t getUDFExecution(const py::function& udf) {
+    return [=](const std::vector<std::shared_ptr<ValueVector>>& params,
+        ValueVector& result, void*) -> void {
+        py::gil_scoped_acquire acquire;
+        py::list asPyParams;
+        for (const auto& param: params) {
+            auto asValue = param->getAsValue(0);
+            auto asPyValue = PyQueryResult::convertValueToPyObject(*asValue);
+            asPyParams.append(asPyValue);
+        }
+        auto pyResult = udf(*asPyParams);
+        auto resultValue = PyConnection::transformPythonValueAs(pyResult, &result.dataType);
+        result.copyFromValue(0, resultValue);
+    };
+}
+
+static scalar_func_exec_t getSelectExecution(const py::function& udf) {
+    // return [=](const std::vector<stsd::shared_ptr<ValueVector>>& params, common::SelectionVector& v) {
+        // TODO maxwell: implement select udf
+    // };
+}
+
+function_set PyUDF::toFunctionSet(const std::string& name, const py::function& udf,
+    const py::list& params, const std::string& retType) {
+    auto pySignature = analyzeSignature(udf);
+    auto explicitParams = pyListToParams(params);
+    if (explicitParams.size() > 0) {
+        if (explicitParams.size() != pySignature.params.size()) {
+            throw RuntimeException("Explicit parameters and Function parameters must be the same length");
+        }
+        pySignature.params = explicitParams;
+    }
+    for (auto i: pySignature.params) {
+        if (i == LogicalTypeID::ANY) {
+            throw RuntimeException("Parameters must be annotated or explicitly given, and cannot be ANY");
+        }
+    }
+    if (retType != "") {
+        auto explicitRetType = LogicalTypeUtils::fromStringToID(retType);
+        pySignature.retval = explicitRetType;
+    }
+    if (pySignature.retval == LogicalTypeID::ANY) {
+        throw RuntimeException("Return value must be annotated or explicitly given, and cannot be ANY");
+    }
+
+    // TODO maxwell: support nested parameters
+    for (auto i: pySignature.params) {
+        if (LogicalTypeUtils::isNested(i)) {
+            throw RuntimeException("Nested type UDFs not implemented yet");
+        }
+    }
+    if (LogicalTypeUtils::isNested(pySignature.retval)) {
+        throw RuntimeException("Nested type UDFs not implemented yet");
+    }
+
+    function_set definitions;
+    definitions.push_back(std::make_unique<ScalarFunction>(name, pySignature.params,
+        pySignature.retval, getUDFExecution(udf)));
+    return definitions;
+}

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -2,10 +2,10 @@
 
 #include <vector>
 
-#include "function/scalar_function.h"
 #include "cached_import/py_cached_import.h"
 #include "common/exception/runtime.h"
 #include "common/string_format.h"
+#include "function/scalar_function.h"
 #include "py_connection.h"
 #include "py_query_result.h"
 
@@ -17,12 +17,12 @@ struct PyUDFSignature {
     std::vector<LogicalTypeID> params;
     LogicalTypeID retval;
 
-    PyUDFSignature(): params(), retval(LogicalTypeID::ANY) {}
+    PyUDFSignature() : params(), retval(LogicalTypeID::ANY) {}
 };
 
 static std::vector<LogicalTypeID> pyListToParams(const py::list& lst) {
     std::vector<LogicalTypeID> result;
-    for (const auto& i: lst) {
+    for (const auto& i : lst) {
         result.push_back(LogicalTypeUtils::fromStringToID(py::cast<std::string>(i)));
     }
     return result;
@@ -64,14 +64,13 @@ static LogicalTypeID pyTypeToLogicalTypeID(const py::handle& ele) {
     }
 }
 
-
 static PyUDFSignature analyzeSignature(const py::function& udf) {
     PyUDFSignature retval;
     auto signature = kuzu::importCache->inspect.signature()(udf, py::arg("eval_str") = true);
     auto sig_params = signature.attr("parameters");
     auto return_annotation = signature.attr("return_annotation");
     retval.retval = pyTypeToLogicalTypeID(return_annotation);
-    for (const auto& i: sig_params) {
+    for (const auto& i : sig_params) {
         auto param_annotation = sig_params.attr("__getitem__")(i).attr("annotation");
         retval.params.push_back(pyTypeToLogicalTypeID(param_annotation));
     }
@@ -79,19 +78,19 @@ static PyUDFSignature analyzeSignature(const py::function& udf) {
 }
 
 static scalar_func_exec_t getUDFExecution(const py::function& udf) {
-    return [=](const std::vector<std::shared_ptr<ValueVector>>& params,
-        ValueVector& result, void*) -> void {
+    return [=](const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result,
+               void*) -> void {
         py::gil_scoped_acquire acquire;
         auto vectorLength = 1;
         py::list basePyParams;
-        for (const auto& param: params) {
+        for (const auto& param : params) {
             if (param->state->selVector->selectedSize != 1) {
                 vectorLength = param->state->selVector->selectedSize;
             }
         }
         for (auto cur = 0u; cur < vectorLength; cur++) {
             py::list asPyParams;
-            for (const auto& param: params) {
+            for (const auto& param : params) {
                 auto asValue = param->getAsValue(param->state->selVector->selectedPositions[cur]);
                 auto asPyValue = PyQueryResult::convertValueToPyObject(*asValue);
                 asPyParams.append(asPyValue);
@@ -104,8 +103,9 @@ static scalar_func_exec_t getUDFExecution(const py::function& udf) {
 }
 
 static scalar_func_exec_t getSelectExecution(const py::function& udf) {
-    // return [=](const std::vector<stsd::shared_ptr<ValueVector>>& params, common::SelectionVector& v) {
-        // TODO maxwell: implement select udf
+    // return [=](const std::vector<stsd::shared_ptr<ValueVector>>& params, common::SelectionVector&
+    // v) {
+    // TODO maxwell: implement select udf
     // };
 }
 
@@ -115,13 +115,15 @@ function_set PyUDF::toFunctionSet(const std::string& name, const py::function& u
     auto explicitParams = pyListToParams(params);
     if (explicitParams.size() > 0) {
         if (explicitParams.size() != pySignature.params.size()) {
-            throw RuntimeException("Explicit parameters and Function parameters must be the same length");
+            throw RuntimeException(
+                "Explicit parameters and Function parameters must be the same length");
         }
         pySignature.params = explicitParams;
     }
-    for (auto i: pySignature.params) {
+    for (auto i : pySignature.params) {
         if (i == LogicalTypeID::ANY) {
-            throw RuntimeException("Parameters must be annotated or explicitly given, and cannot be ANY");
+            throw RuntimeException(
+                "Parameters must be annotated or explicitly given, and cannot be ANY");
         }
     }
     if (retType != "") {
@@ -129,11 +131,12 @@ function_set PyUDF::toFunctionSet(const std::string& name, const py::function& u
         pySignature.retval = explicitRetType;
     }
     if (pySignature.retval == LogicalTypeID::ANY) {
-        throw RuntimeException("Return value must be annotated or explicitly given, and cannot be ANY");
+        throw RuntimeException(
+            "Return value must be annotated or explicitly given, and cannot be ANY");
     }
 
     // TODO maxwell: support nested parameters
-    for (auto i: pySignature.params) {
+    for (auto i : pySignature.params) {
         if (LogicalTypeUtils::isNested(i)) {
             throw RuntimeException("Nested type UDFs not implemented yet");
         }

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 from . import _kuzu
 from .prepared_statement import PreparedStatement
 from .query_result import QueryResult
+from .types import Type
 
 if TYPE_CHECKING:
     import sys
@@ -16,7 +17,6 @@ if TYPE_CHECKING:
         from typing import Self
     else:
         from typing_extensions import Self
-
 
 class Connection:
     """Connection to a database."""
@@ -229,3 +229,24 @@ class Connection:
         """
         self.init_connection()
         self._connection.set_query_timeout(timeout_in_ms)
+
+    def set_UDF(self, name: str, udf: Callable[[...], Any], parameters: list[Type] = [], return_type: Type = None) -> None:
+        """
+        Sets a User Defined Function (UDF) to use in cypher queries.
+
+        Parameters
+        ----------
+        name: str
+            name of function
+        
+        udf: Callable[[...], Any]
+            function to be executed
+        
+        parameters: list[Type]
+            list of Type enums to describe the input parameters
+        
+        return_type: Type
+            a Type enum to describe the returned value
+        """
+        parsedRetval = "" if return_type is None else return_type.value
+        self._connection.set_UDF(name, udf, list(map(lambda x: x.value, parameters)), parsedRetval)

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -231,11 +231,11 @@ class Connection:
         self._connection.set_query_timeout(timeout_in_ms)
 
     def create_function(
-        self, 
-        name: str, 
-        udf: Callable[[...], Any], 
-        params_type: list[Type] = None, 
-        return_type: Type = None
+        self,
+        name: str,
+        udf: Callable[[...], Any],
+        params_type: list[Type] | None = None,
+        return_type: Type | None = None
     ) -> None:
         """
         Sets a User Defined Function (UDF) to use in cypher queries.
@@ -248,10 +248,10 @@ class Connection:
         udf: Callable[[...], Any]
             function to be executed
 
-        parameters: list[Type]
+        params_type: Optional[list[Type]]
             list of Type enums to describe the input parameters
 
-        return_type: Type
+        return_type: Optional[Type]
             a Type enum to describe the returned value
         """
         parsed_params_type = [] if params_type is None else [param_type.value for param_type in params_type]

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -5,13 +5,13 @@ from typing import TYPE_CHECKING, Any, Callable
 from . import _kuzu
 from .prepared_statement import PreparedStatement
 from .query_result import QueryResult
-from .types import Type
 
 if TYPE_CHECKING:
     import sys
     from types import TracebackType
 
     from .database import Database
+    from .types import Type
 
     if sys.version_info >= (3, 11):
         from typing import Self
@@ -230,7 +230,13 @@ class Connection:
         self.init_connection()
         self._connection.set_query_timeout(timeout_in_ms)
 
-    def set_udf(self, name: str, udf: Callable[[...], Any], parameters: list[Type] = [], return_type: Type = None) -> None:
+    def create_function(
+        self, 
+        name: str, 
+        udf: Callable[[...], Any], 
+        params_type: list[Type] = None, 
+        return_type: Type = None
+    ) -> None:
         """
         Sets a User Defined Function (UDF) to use in cypher queries.
 
@@ -238,15 +244,16 @@ class Connection:
         ----------
         name: str
             name of function
-        
+
         udf: Callable[[...], Any]
             function to be executed
-        
+
         parameters: list[Type]
             list of Type enums to describe the input parameters
-        
+
         return_type: Type
             a Type enum to describe the returned value
         """
-        parsedRetval = "" if return_type is None else return_type.value
-        self._connection.set_udf(name, udf, list(map(lambda x: x.value, parameters)), parsedRetval)
+        parsed_params_type = [] if params_type is None else [param_type.value for param_type in params_type]
+        parsed_return_type = "" if return_type is None else return_type.value
+        self._connection.create_function(name, udf, parsed_params_type, parsed_return_type)

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -230,7 +230,7 @@ class Connection:
         self.init_connection()
         self._connection.set_query_timeout(timeout_in_ms)
 
-    def set_UDF(self, name: str, udf: Callable[[...], Any], parameters: list[Type] = [], return_type: Type = None) -> None:
+    def set_udf(self, name: str, udf: Callable[[...], Any], parameters: list[Type] = [], return_type: Type = None) -> None:
         """
         Sets a User Defined Function (UDF) to use in cypher queries.
 
@@ -249,4 +249,4 @@ class Connection:
             a Type enum to describe the returned value
         """
         parsedRetval = "" if return_type is None else return_type.value
-        self._connection.set_UDF(name, udf, list(map(lambda x: x.value, parameters)), parsedRetval)
+        self._connection.set_udf(name, udf, list(map(lambda x: x.value, parameters)), parsedRetval)

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from datetime import date
+from datetime import datetime
+from datetime import timedelta
+import kuzu
+from kuzu import Type
+
+def udf_helper(conn, functionName, params, expectedResult):
+    plist = ', '.join(map(lambda x: "$" + str(x+1), range(len(params))))
+    queryString = f"RETURN {functionName}({plist})"
+    result = conn.execute(queryString, {str(i+1) : params[i] for i in range(len(params))})
+    assert result.get_next()[0] == expectedResult
+
+def test_udf(conn_db_readwrite: ConnDB) -> None:
+    conn, db = conn_db_readwrite
+
+    def add5int(x: int) -> int:
+        return x + 5
+    
+    add5IntArgs = ["add5int", add5int]
+    
+    def add5float(x: float) -> float:
+        return x + 5.0
+    
+    add5FloatArgs = ["add5float", add5float]
+    
+    def intToString(x: int) -> str:
+        return str(x)
+    
+    intToStringArgs = ["intToString", intToString]
+    
+    def sumOf7(a, b, c, d, e, f, g) -> int:
+        return a+b+c+d+e+f+g
+
+    sumOf7Args = ["sumOf7", sumOf7, [Type.INT64] * 7]
+    
+    def dateToDatetime(a: date) -> datetime:
+        return datetime(a.year, a.month, a.day)
+    
+    dateToDatetimeArgs = ["dateToDatetime", dateToDatetime]
+    
+    def datetimeToDate(a: datetime) -> date:
+        return a.date()
+    
+    datetimeToDateArgs = ["datetimeToDate", datetimeToDate, [Type.TIMESTAMP], Type.DATE]
+    
+    def addToDate(a: datetime, b: timedelta) -> datetime:
+        return a + b
+    
+    addToDateArgs = ["addToDate", addToDate, [Type.TIMESTAMP, Type.INTERVAL], Type.TIMESTAMP]
+    
+    def concatThreeLists(a: list, b: list, c: list) -> list:
+        return a+b+c
+    
+    concatThreeListsArgs = ["concatThreeLists", concatThreeLists, [Type.LIST] * 3, Type.LIST]
+    # todo maxwell: implement nested udf
+    
+    def mergeMaps(a: dict, b: dict) -> dict:
+        return a | b
+    
+    mergeMapsArgs = ["mergeMaps", mergeMaps, [Type.MAP] * 2, Type.MAP]
+    # todo maxwell: implement nested udf
+
+    def selectIfSeven(a: int) -> int:
+        return a == 7
+    
+    selectIfSeven = ["selectIfSeven", selectIfSeven, [Type.INT64], Type.BOOL]
+    # todo maxwell: implement select udf
+
+    conn.set_UDF(*add5IntArgs)
+    conn.set_UDF(*add5FloatArgs)
+    conn.set_UDF(*intToStringArgs)
+    conn.set_UDF(*sumOf7Args)
+    conn.set_UDF(*dateToDatetimeArgs)
+    conn.set_UDF(*datetimeToDateArgs)
+    conn.set_UDF(*addToDateArgs)
+
+    udf_helper(conn, "add5int", [10], 15)
+    udf_helper(conn, "add5int", [9], 14)
+    udf_helper(conn, "add5int", [1283], 1288)
+    udf_helper(conn, "add5float", [2.2], 7.2)
+    udf_helper(conn, "intToString", [123], '123')
+    udf_helper(conn, "sumOf7", [1, 2, 3, 4, 5, 6, 7], sum(range(8)))
+    udf_helper(conn, "dateToDatetime", [date(2024, 4, 25)], datetime(2024, 4, 25))
+    udf_helper(conn, "datetimeToDate", [datetime(2024, 4, 25, 15, 39, 20)], date(2024, 4, 25))
+    udf_helper(conn, "addToDate", [datetime(2024, 4, 25, 15, 39, 20), datetime(2025, 5, 26) - datetime(2024, 4, 25, 15, 39, 20)], datetime(2025, 5, 26))
+
+
+

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from datetime import timedelta
 import kuzu
 from kuzu import Type
+import pandas as pd
 
 def udf_helper(conn, functionName, params, expectedResult):
     plist = ', '.join(map(lambda x: "$" + str(x+1), range(len(params))))
@@ -16,6 +17,7 @@ def test_udf(conn_db_readwrite: ConnDB) -> None:
     conn, db = conn_db_readwrite
 
     def add5int(x: int) -> int:
+        print(x)
         return x + 5
     
     add5IntArgs = ["add5int", add5int]
@@ -87,6 +89,8 @@ def test_udf(conn_db_readwrite: ConnDB) -> None:
     udf_helper(conn, "addToDate", [datetime(2024, 4, 25, 15, 39, 20), datetime(2025, 5, 26) - datetime(2024, 4, 25, 15, 39, 20)], datetime(2025, 5, 26))
 
 
-
+    df = pd.DataFrame({"col": list(range(5000))})
+    result = conn.execute("LOAD FROM df RETURN add5int(col) as ans").get_as_df()
+    assert list(result['ans']) == list(map(add5int, range(5000)))
 
 

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
-from datetime import date
-from datetime import datetime
-from datetime import timedelta
+import pandas as pd
+from datetime import date, datetime, timedelta # noqa: TCH003
+
 import kuzu
 from kuzu import Type
-import pandas as pd
+
 from type_aliases import ConnDB
 
+
 def udf_helper(conn, functionName, params, expectedResult):
-    plist = ', '.join(map(lambda x: "$" + str(x+1), range(len(params))))
+    plist = ', '.join(f"${i+1}" for i in range(len(params)))
     queryString = f"RETURN {functionName}({plist})"
     result = conn.execute(queryString, {str(i+1) : params[i] for i in range(len(params))})
     assert result.get_next()[0] == expectedResult
@@ -64,13 +65,13 @@ def test_udf(conn_db_readwrite: ConnDB) -> None:
         return a+b+c
     
     concatThreeListsArgs = ["concatThreeLists", concatThreeLists, [Type.LIST] * 3, Type.LIST]
-    # todo maxwell: implement nested udf
+    # TODO: (Maxwell) implement nested udf
     
     def mergeMaps(a: dict, b: dict) -> dict:
         return a | b
     
     mergeMapsArgs = ["mergeMaps", mergeMaps, [Type.MAP] * 2, Type.MAP]
-    # todo maxwell: implement nested udf
+    # TODO: (Maxwell) implement nested udf
 
     def selectIfSeven(a: int) -> bool:
         return a == 7

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -68,13 +68,13 @@ def test_udf(conn_db_readwrite: ConnDB) -> None:
     selectIfSeven = ["selectIfSeven", selectIfSeven, [Type.INT64], Type.BOOL]
     # todo maxwell: implement select udf
 
-    conn.set_UDF(*add5IntArgs)
-    conn.set_UDF(*add5FloatArgs)
-    conn.set_UDF(*intToStringArgs)
-    conn.set_UDF(*sumOf7Args)
-    conn.set_UDF(*dateToDatetimeArgs)
-    conn.set_UDF(*datetimeToDateArgs)
-    conn.set_UDF(*addToDateArgs)
+    conn.set_udf(*add5IntArgs)
+    conn.set_udf(*add5FloatArgs)
+    conn.set_udf(*intToStringArgs)
+    conn.set_udf(*sumOf7Args)
+    conn.set_udf(*dateToDatetimeArgs)
+    conn.set_udf(*datetimeToDateArgs)
+    conn.set_udf(*addToDateArgs)
 
     udf_helper(conn, "add5int", [10], 15)
     udf_helper(conn, "add5int", [9], 14)
@@ -85,6 +85,8 @@ def test_udf(conn_db_readwrite: ConnDB) -> None:
     udf_helper(conn, "dateToDatetime", [date(2024, 4, 25)], datetime(2024, 4, 25))
     udf_helper(conn, "datetimeToDate", [datetime(2024, 4, 25, 15, 39, 20)], date(2024, 4, 25))
     udf_helper(conn, "addToDate", [datetime(2024, 4, 25, 15, 39, 20), datetime(2025, 5, 26) - datetime(2024, 4, 25, 15, 39, 20)], datetime(2025, 5, 26))
+
+
 
 
 

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 import kuzu
 from kuzu import Type
 import pandas as pd
+from type_aliases import ConnDB
 
 def udf_helper(conn, functionName, params, expectedResult):
     plist = ', '.join(map(lambda x: "$" + str(x+1), range(len(params))))
@@ -76,14 +77,14 @@ def test_udf(conn_db_readwrite: ConnDB) -> None:
     
     selectIfSevenArgs = ["selectIfSeven", selectIfSeven]
 
-    conn.set_udf(*add5IntArgs)
-    conn.set_udf(*add5FloatArgs)
-    conn.set_udf(*intToStringArgs)
-    conn.set_udf(*sumOf7Args)
-    conn.set_udf(*dateToDatetimeArgs)
-    conn.set_udf(*datetimeToDateArgs)
-    conn.set_udf(*addToDateArgs)
-    conn.set_udf(*selectIfSevenArgs)
+    conn.create_function(*add5IntArgs)
+    conn.create_function(*add5FloatArgs)
+    conn.create_function(*intToStringArgs)
+    conn.create_function(*sumOf7Args)
+    conn.create_function(*dateToDatetimeArgs)
+    conn.create_function(*datetimeToDateArgs)
+    conn.create_function(*addToDateArgs)
+    conn.create_function(*selectIfSevenArgs)
 
     udf_helper(conn, "add5int", [10], 15)
     udf_helper(conn, "add5int", [9], 14)


### PR DESCRIPTION
Here's how it's to be used, as well as an explanation of some of its features
```py
import kuzu
db = kuzu.Database("db")
conn = kuzu.Connection(db)

def aplusb(a: int, b: int) -> int:
    return a + b

conn.create_function(name="aplusb", udf=aplusb)
# we can use annotations to help bind the function

print(conn.execute("return aplusb(1, 2)").get_next()[0])
# 0

def atimesb(a, b):
    return a*b

conn.create_function(name="atimesb", udf=atimesb, parameters=[kuzu.Type.INT64, kuzu.Type.INT64], return_type=kuzu.Type.INT64)
# we can explicitly state the parameters and the return type

print(conn.execute("return atimesb(5, 10)").get_next()[0])
# 50

def vector3dDistance(x1: float, y1: float, z1: float, x2: float, y2: float, z2: float) -> float:
    return ( (x1-x2)**2 + (y1-y2)**2 + (z1-z2)**2 ) ** 0.5
    
conn.create_function("v3dDist", vector3dDistance)
# unlike with the C++ UDF, we can specify as many parameters as we want for python UDFs

print(conn.execute("return v3dDist(-100, 1, 2, 200, -5, 10)").get_next()[0])
# just over 300
```
Nested types haven't been implemented yet, but it's been decided to be done. 