### PR TITLE
Refactor table read state

### DIFF
--- a/src/include/common/types/internal_id_t.h
+++ b/src/include/common/types/internal_id_t.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
@@ -16,6 +17,8 @@ using relID_t = internalID_t;
 using table_id_t = uint64_t;
 using table_id_vector_t = std::vector<table_id_t>;
 using table_id_set_t = std::unordered_set<table_id_t>;
+template<typename T>
+using table_id_map_t = std::unordered_map<table_id_t, T>;
 using offset_t = uint64_t;
 constexpr table_id_t INVALID_TABLE_ID = UINT64_MAX;
 constexpr offset_t INVALID_OFFSET = UINT64_MAX;

--- a/src/include/processor/operator/scan/scan_multi_node_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_node_tables.h
@@ -23,7 +23,7 @@ public:
 
 private:
     common::table_id_map_t<std::unique_ptr<ScanNodeTableInfo>> infos;
-    common::table_id_map_t<std::unique_ptr<storage::TableReadState>> readStates;
+    common::table_id_map_t<std::unique_ptr<storage::NodeTableReadState>> readStates;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/scan/scan_multi_node_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_node_tables.h
@@ -8,34 +8,22 @@ namespace processor {
 class ScanMultiNodeTables : public ScanTable {
 public:
     ScanMultiNodeTables(const DataPos& inVectorPos, std::vector<DataPos> outVectorsPos,
-        std::unordered_map<common::table_id_t, std::unique_ptr<ScanNodeTableInfo>> tables,
+        common::table_id_map_t<std::unique_ptr<ScanNodeTableInfo>> infos,
         std::unique_ptr<PhysicalOperator> prevOperator, uint32_t id,
         const std::string& paramsString)
         : ScanTable{PhysicalOperatorType::SCAN_MULTI_NODE_TABLES, inVectorPos,
               std::move(outVectorsPos), std::move(prevOperator), id, paramsString},
-          tables{std::move(tables)} {}
+          infos{std::move(infos)} {}
 
-    inline void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override {
-        ScanTable::initLocalStateInternal(resultSet, context);
-        for (auto& [tableID, scanInfo] : tables) {
-            readStates[tableID] = std::make_unique<storage::TableReadState>(*inVector,
-                scanInfo->columnIDs, outVectors);
-        }
-    }
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
+
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
-    inline std::unique_ptr<PhysicalOperator> clone() override {
-        std::unordered_map<common::table_id_t, std::unique_ptr<ScanNodeTableInfo>> clonedTables;
-        for (const auto& table : tables) {
-            clonedTables[table.first] = table.second->copy();
-        }
-        return make_unique<ScanMultiNodeTables>(inVectorPos, outVectorsPos, std::move(clonedTables),
-            children[0]->clone(), id, paramsString);
-    }
+    std::unique_ptr<PhysicalOperator> clone() override;
 
 private:
-    std::unordered_map<common::table_id_t, std::unique_ptr<ScanNodeTableInfo>> tables;
-    std::unordered_map<common::table_id_t, std::unique_ptr<storage::TableReadState>> readStates;
+    common::table_id_map_t<std::unique_ptr<ScanNodeTableInfo>> infos;
+    common::table_id_map_t<std::unique_ptr<storage::TableReadState>> readStates;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/scan/scan_multi_rel_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_rel_tables.h
@@ -6,19 +6,18 @@ namespace kuzu {
 namespace processor {
 
 class RelTableCollectionScanner {
+    friend class ScanMultiRelTable;
+
 public:
     explicit RelTableCollectionScanner(std::vector<std::unique_ptr<ScanRelTableInfo>> scanInfos)
         : scanInfos{std::move(scanInfos)} {}
 
-    inline void resetState() {
+    void resetState() {
         currentTableIdx = 0;
         nextTableIdx = 0;
     }
 
-    void init(common::ValueVector* inVector,
-        const std::vector<common::ValueVector*>& outputVectors);
-    bool scan(common::ValueVector* inVector, const std::vector<common::ValueVector*>& outputVectors,
-        transaction::Transaction* transaction);
+    bool scan(common::SelectionVector* selVector, transaction::Transaction* transaction);
 
     std::unique_ptr<RelTableCollectionScanner> clone() const;
 
@@ -29,7 +28,7 @@ private:
     uint32_t nextTableIdx = 0;
 };
 
-class ScanMultiRelTable : public ScanRelTable {
+class ScanMultiRelTable : public ScanTable {
     using node_table_id_scanner_map_t =
         std::unordered_map<common::table_id_t, std::unique_ptr<RelTableCollectionScanner>>;
 
@@ -37,7 +36,7 @@ public:
     ScanMultiRelTable(node_table_id_scanner_map_t scannerPerNodeTable, const DataPos& inVectorPos,
         std::vector<DataPos> outVectorsPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         const std::string& paramsString)
-        : ScanRelTable{PhysicalOperatorType::SCAN_MULTI_REL_TABLES, nullptr /* info */, inVectorPos,
+        : ScanTable{PhysicalOperatorType::SCAN_MULTI_REL_TABLES, inVectorPos,
               std::move(outVectorsPos), std::move(child), id, paramsString},
           scannerPerNodeTable{std::move(scannerPerNodeTable)} {}
 

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -22,7 +22,7 @@ struct ScanNodeTableInfo {
     }
 };
 
-class ScanSingleNodeTable : public ScanTable {
+class ScanSingleNodeTable final : public ScanTable {
 public:
     ScanSingleNodeTable(std::unique_ptr<ScanNodeTableInfo> info, const DataPos& inVectorPos,
         std::vector<DataPos> outVectorsPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
@@ -30,17 +30,12 @@ public:
         : ScanSingleNodeTable{PhysicalOperatorType::SCAN_NODE_TABLE, std::move(info), inVectorPos,
               std::move(outVectorsPos), std::move(child), id, paramsString} {}
 
-    inline void initLocalStateInternal(ResultSet* resultSet,
-        ExecutionContext* executionContext) final {
-        ScanTable::initLocalStateInternal(resultSet, executionContext);
-        readState =
-            std::make_unique<storage::NodeTableReadState>(*inVector, info->columnIDs, outVectors);
-    }
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* executionContext) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
-    inline std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ScanSingleNodeTable>(info->copy(), inVectorPos, outVectorsPos,
+    std::unique_ptr<PhysicalOperator> clone() override {
+        return make_unique<ScanSingleNodeTable>(info->copy(), nodeIDPos, outVectorsPos,
             children[0]->clone(), id, paramsString);
     }
 

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -22,12 +22,12 @@ struct ScanNodeTableInfo {
     }
 };
 
-class ScanSingleNodeTable final : public ScanTable {
+class ScanNodeTable final : public ScanTable {
 public:
-    ScanSingleNodeTable(std::unique_ptr<ScanNodeTableInfo> info, const DataPos& inVectorPos,
+    ScanNodeTable(std::unique_ptr<ScanNodeTableInfo> info, const DataPos& inVectorPos,
         std::vector<DataPos> outVectorsPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         const std::string& paramsString)
-        : ScanSingleNodeTable{PhysicalOperatorType::SCAN_NODE_TABLE, std::move(info), inVectorPos,
+        : ScanNodeTable{PhysicalOperatorType::SCAN_NODE_TABLE, std::move(info), inVectorPos,
               std::move(outVectorsPos), std::move(child), id, paramsString} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* executionContext) override;
@@ -35,12 +35,12 @@ public:
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
     std::unique_ptr<PhysicalOperator> clone() override {
-        return make_unique<ScanSingleNodeTable>(info->copy(), nodeIDPos, outVectorsPos,
+        return make_unique<ScanNodeTable>(info->copy(), nodeIDPos, outVectorsPos,
             children[0]->clone(), id, paramsString);
     }
 
 protected:
-    ScanSingleNodeTable(PhysicalOperatorType operatorType, std::unique_ptr<ScanNodeTableInfo> info,
+    ScanNodeTable(PhysicalOperatorType operatorType, std::unique_ptr<ScanNodeTableInfo> info,
         const DataPos& inVectorPos, std::vector<DataPos> outVectorsPos,
         std::unique_ptr<PhysicalOperator> child, uint32_t id, const std::string& paramsString)
         : ScanTable{operatorType, inVectorPos, std::move(outVectorsPos), std::move(child), id,
@@ -49,7 +49,7 @@ protected:
 
 private:
     std::unique_ptr<ScanNodeTableInfo> info;
-    std::unique_ptr<storage::TableReadState> readState;
+    std::unique_ptr<storage::NodeTableReadState> readState;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/scan/scan_rel_table.h
+++ b/src/include/processor/operator/scan/scan_rel_table.h
@@ -29,21 +29,13 @@ public:
         const std::string& paramsString)
         : ScanRelTable{PhysicalOperatorType::SCAN_REL_TABLE, std::move(info), inVectorPos,
               std::move(outVectorsPos), std::move(child), id, paramsString} {}
-    ~ScanRelTable() override = default;
 
-    inline void initLocalStateInternal(ResultSet* resultSet,
-        ExecutionContext* executionContext) override {
-        ScanTable::initLocalStateInternal(resultSet, executionContext);
-        if (info) {
-            scanState = std::make_unique<storage::RelTableReadState>(*inVector, info->columnIDs,
-                outVectors, info->direction);
-        }
-    }
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* executionContext) override;
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
-    inline std::unique_ptr<PhysicalOperator> clone() override {
-        return std::make_unique<ScanRelTable>(info->copy(), inVectorPos, outVectorsPos,
+    std::unique_ptr<PhysicalOperator> clone() override {
+        return std::make_unique<ScanRelTable>(info->copy(), nodeIDPos, outVectorsPos,
             children[0]->clone(), id, paramsString);
     }
 

--- a/src/include/processor/operator/scan/scan_table.h
+++ b/src/include/processor/operator/scan/scan_table.h
@@ -1,25 +1,33 @@
 #pragma once
 
 #include "processor/operator/physical_operator.h"
+#include "storage/store/table.h"
 
 namespace kuzu {
 namespace processor {
 
 class ScanTable : public PhysicalOperator {
 public:
-    ScanTable(PhysicalOperatorType operatorType, const DataPos& inVectorPos,
+    ScanTable(PhysicalOperatorType operatorType, const DataPos& nodeIDPos,
         std::vector<DataPos> outVectorsPos, std::unique_ptr<PhysicalOperator> child, uint32_t id,
         const std::string& paramString)
-        : PhysicalOperator{operatorType, std::move(child), id, paramString},
-          inVectorPos{inVectorPos}, outVectorsPos{std::move(outVectorsPos)} {}
-
-    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* executionContext) override;
+        : PhysicalOperator{operatorType, std::move(child), id, paramString}, nodeIDPos{nodeIDPos},
+          outVectorsPos{std::move(outVectorsPos)} {}
 
 protected:
-    DataPos inVectorPos;
+    void initLocalStateInternal(ResultSet*, ExecutionContext*) override;
+
+    void initVectors(storage::TableReadState& state, const ResultSet& resultSet);
+
+protected:
+    // Input node id vector position.
+    DataPos nodeIDPos;
+    // Output vector (properties or CSRs) positions
     std::vector<DataPos> outVectorsPos;
-    common::ValueVector* inVector;
-    std::vector<common::ValueVector*> outVectors;
+    // Node id vector.
+    common::ValueVector* nodeIDVector;
+    // All output vectors share the same state. Keep one of them to retrieve state.
+    common::ValueVector* anchorOutVector;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/scan/scan_table.h
+++ b/src/include/processor/operator/scan/scan_table.h
@@ -26,8 +26,8 @@ protected:
     std::vector<DataPos> outVectorsPos;
     // Node id vector.
     common::ValueVector* nodeIDVector;
-    // All output vectors share the same state. Keep one of them to retrieve state.
-    common::ValueVector* anchorOutVector;
+    // All output vectors share the same state.
+    common::DataChunkState* outState;
 };
 
 } // namespace processor

--- a/src/include/processor/result/result_set.h
+++ b/src/include/processor/result/result_set.h
@@ -14,21 +14,21 @@ public:
     explicit ResultSet(uint32_t numDataChunks) : multiplicity{1}, dataChunks(numDataChunks) {}
     ResultSet(ResultSetDescriptor* resultSetDescriptor, storage::MemoryManager* memoryManager);
 
-    inline void insert(uint32_t pos, std::shared_ptr<common::DataChunk> dataChunk) {
+    void insert(uint32_t pos, std::shared_ptr<common::DataChunk> dataChunk) {
         KU_ASSERT(dataChunks.size() > pos);
         dataChunks[pos] = std::move(dataChunk);
     }
 
-    inline std::shared_ptr<common::DataChunk> getDataChunk(data_chunk_pos_t dataChunkPos) {
+    std::shared_ptr<common::DataChunk> getDataChunk(data_chunk_pos_t dataChunkPos) {
         return dataChunks[dataChunkPos];
     }
-    inline std::shared_ptr<common::ValueVector> getValueVector(const DataPos& dataPos) const {
+    std::shared_ptr<common::ValueVector> getValueVector(const DataPos& dataPos) const {
         return dataChunks[dataPos.dataChunkPos]->valueVectors[dataPos.valueVectorPos];
     }
 
     // Our projection does NOT explicitly remove dataChunk from resultSet. Therefore, caller should
     // always provide a set of positions when reading from multiple dataChunks.
-    inline uint64_t getNumTuples(const std::unordered_set<uint32_t>& dataChunksPosInScope) {
+    uint64_t getNumTuples(const std::unordered_set<uint32_t>& dataChunksPosInScope) {
         return getNumTuplesWithoutMultiplicity(dataChunksPosInScope) * multiplicity;
     }
 

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -19,8 +19,13 @@ namespace storage {
 class LocalNodeTable;
 
 struct NodeTableReadState : public TableReadState {
-    NodeTableReadState(std::vector<common::column_id_t> columnIDs)
+    explicit NodeTableReadState(std::vector<common::column_id_t> columnIDs)
         : TableReadState{std::move(columnIDs)} {
+        dataReadState = std::make_unique<NodeDataReadState>();
+    }
+    NodeTableReadState(const common::ValueVector* nodeIDVector,
+        std::vector<common::column_id_t> columnIDs, std::vector<common::ValueVector*> outputVectors)
+        : TableReadState{nodeIDVector, std::move(columnIDs), std::move(outputVectors)} {
         dataReadState = std::make_unique<NodeDataReadState>();
     }
 };

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -19,10 +19,8 @@ namespace storage {
 class LocalNodeTable;
 
 struct NodeTableReadState : public TableReadState {
-    NodeTableReadState(const common::ValueVector& nodeIDVector,
-        const std::vector<common::column_id_t>& columnIDs,
-        const std::vector<common::ValueVector*>& outputVectors)
-        : TableReadState{nodeIDVector, columnIDs, outputVectors} {
+    NodeTableReadState(std::vector<common::column_id_t> columnIDs)
+        : TableReadState{std::move(columnIDs)} {
         dataReadState = std::make_unique<NodeDataReadState>();
     }
 };
@@ -79,10 +77,10 @@ public:
     }
 
     void initializeReadState(transaction::Transaction* transaction,
-        std::vector<common::column_id_t> columnIDs, const common::ValueVector& inNodeIDVector,
-        TableReadState& readState) {
+        std::vector<common::column_id_t> columnIDs, TableReadState& readState) {
+        // TODO(Guodong): we shouldn't create new read state.
         readState.dataReadState = std::make_unique<NodeDataReadState>();
-        tableData->initializeReadState(transaction, std::move(columnIDs), inNodeIDVector,
+        tableData->initializeReadState(transaction, std::move(columnIDs), *readState.nodeIDVector,
             *readState.dataReadState);
     }
     void read(transaction::Transaction* transaction, TableReadState& readState) override;

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -83,8 +83,6 @@ public:
 
     void initializeReadState(transaction::Transaction* transaction,
         std::vector<common::column_id_t> columnIDs, TableReadState& readState) {
-        // TODO(Guodong): we shouldn't create new read state.
-        readState.dataReadState = std::make_unique<NodeDataReadState>();
         tableData->initializeReadState(transaction, std::move(columnIDs), *readState.nodeIDVector,
             *readState.dataReadState);
     }

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -74,18 +74,8 @@ public:
 
     void initializeReadState(transaction::Transaction* transaction,
         common::RelDataDirection direction, const std::vector<common::column_id_t>& columnIDs,
-        RelTableReadState& readState) {
-        if (!readState.dataReadState) {
-            readState.dataReadState = std::make_unique<RelDataReadState>();
-        }
-        auto& dataState = common::ku_dynamic_cast<TableDataReadState&, RelDataReadState&>(
-            *readState.dataReadState);
-        return direction == common::RelDataDirection::FWD ?
-                   fwdRelTableData->initializeReadState(transaction, columnIDs,
-                       *readState.nodeIDVector, dataState) :
-                   bwdRelTableData->initializeReadState(transaction, columnIDs,
-                       *readState.nodeIDVector, dataState);
-    }
+        RelTableReadState& readState);
+
     void read(transaction::Transaction* transaction, TableReadState& readState) override;
 
     void insert(transaction::Transaction* transaction, TableInsertState& insertState) override;

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -10,10 +10,9 @@ namespace storage {
 struct RelTableReadState : public TableReadState {
     common::RelDataDirection direction;
 
-    RelTableReadState(const common::ValueVector& nodeIDVector,
-        const std::vector<common::column_id_t>& columnIDs,
-        const std::vector<common::ValueVector*>& outputVectors, common::RelDataDirection direction)
-        : TableReadState{nodeIDVector, columnIDs, outputVectors}, direction{direction} {
+    RelTableReadState(const std::vector<common::column_id_t>& columnIDs,
+        common::RelDataDirection direction)
+        : TableReadState{columnIDs}, direction{direction} {
         dataReadState = std::make_unique<RelDataReadState>();
     }
 
@@ -75,17 +74,17 @@ public:
 
     void initializeReadState(transaction::Transaction* transaction,
         common::RelDataDirection direction, const std::vector<common::column_id_t>& columnIDs,
-        const common::ValueVector& inNodeIDVector, RelTableReadState& readState) {
+        RelTableReadState& readState) {
         if (!readState.dataReadState) {
             readState.dataReadState = std::make_unique<RelDataReadState>();
         }
+        auto& dataState = common::ku_dynamic_cast<TableDataReadState&, RelDataReadState&>(
+            *readState.dataReadState);
         return direction == common::RelDataDirection::FWD ?
-                   fwdRelTableData->initializeReadState(transaction, columnIDs, inNodeIDVector,
-                       common::ku_dynamic_cast<TableDataReadState&, RelDataReadState&>(
-                           *readState.dataReadState)) :
-                   bwdRelTableData->initializeReadState(transaction, columnIDs, inNodeIDVector,
-                       common::ku_dynamic_cast<TableDataReadState&, RelDataReadState&>(
-                           *readState.dataReadState));
+                   fwdRelTableData->initializeReadState(transaction, columnIDs,
+                       *readState.nodeIDVector, dataState) :
+                   bwdRelTableData->initializeReadState(transaction, columnIDs,
+                       *readState.nodeIDVector, dataState);
     }
     void read(transaction::Transaction* transaction, TableReadState& readState) override;
 

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -8,17 +8,20 @@ namespace kuzu {
 namespace storage {
 
 struct TableReadState {
-    const common::ValueVector& nodeIDVector;
+    // Read only input node id vector.
+    const common::ValueVector* nodeIDVector;
     std::vector<common::column_id_t> columnIDs;
-    const std::vector<common::ValueVector*>& outputVectors;
+    std::vector<common::ValueVector*> outputVectors;
     std::unique_ptr<TableDataReadState> dataReadState;
 
-    TableReadState(const common::ValueVector& nodeIDVector,
-        const std::vector<common::column_id_t>& columnIDs,
-        const std::vector<common::ValueVector*>& outputVectors)
+    explicit TableReadState(std::vector<common::column_id_t> columnIDs)
+        : columnIDs{std::move(columnIDs)} {}
+    TableReadState(const common::ValueVector* nodeIDVector,
+        std::vector<common::column_id_t> columnIDs, std::vector<common::ValueVector*> outputVectors)
         : nodeIDVector{nodeIDVector}, columnIDs{std::move(columnIDs)},
-          outputVectors{outputVectors} {}
+          outputVectors{std::move(outputVectors)} {}
     virtual ~TableReadState() = default;
+    DELETE_COPY_AND_MOVE(TableReadState);
 };
 
 struct TableInsertState {

--- a/src/processor/map/map_scan_node_property.cpp
+++ b/src/processor/map/map_scan_node_property.cpp
@@ -62,7 +62,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapScanNodeProperty(
             ku_dynamic_cast<storage::Table*, storage::NodeTable*>(
                 clientContext->getStorageManager()->getTable(tableID)),
             std::move(columnIDs));
-        return std::make_unique<ScanSingleNodeTable>(std::move(info), inputNodeIDVectorPos,
+        return std::make_unique<ScanNodeTable>(std::move(info), inputNodeIDVectorPos,
             std::move(outVectorsPos), std::move(prevOperator), getOperatorID(),
             scanProperty.getExpressionsForPrinting());
     }

--- a/src/processor/operator/scan/scan_multi_node_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_node_tables.cpp
@@ -5,18 +5,36 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
+void ScanMultiNodeTables::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+    ScanTable::initLocalStateInternal(resultSet, context);
+    for (auto& [id, info] : infos) {
+        auto readState = std::make_unique<storage::NodeTableReadState>(info->columnIDs);
+        ScanTable::initVectors(*readState, *resultSet);
+        readStates.insert({id, std::move(readState)});
+    }
+}
+
 bool ScanMultiNodeTables::getNextTuplesInternal(ExecutionContext* context) {
     if (!children[0]->getNextTuple(context)) {
         return false;
     }
-    auto tableID =
-        inVector->getValue<nodeID_t>(inVector->state->selVector->selectedPositions[0]).tableID;
-    KU_ASSERT(readStates.contains(tableID) && tables.contains(tableID));
-    auto scanTableInfo = tables.at(tableID).get();
-    scanTableInfo->table->initializeReadState(context->clientContext->getTx(),
-        scanTableInfo->columnIDs, *inVector, *readStates[tableID]);
-    scanTableInfo->table->read(context->clientContext->getTx(), *readStates.at(tableID));
+    auto pos = nodeIDVector->state->selVector->selectedPositions[0];
+    auto tableID = nodeIDVector->getValue<nodeID_t>(pos).tableID;
+    KU_ASSERT(readStates.contains(tableID) && infos.contains(tableID));
+    auto info = infos.at(tableID).get();
+    info->table->initializeReadState(context->clientContext->getTx(), info->columnIDs,
+        *readStates[tableID]);
+    info->table->read(context->clientContext->getTx(), *readStates.at(tableID));
     return true;
+}
+
+std::unique_ptr<PhysicalOperator> ScanMultiNodeTables::clone() {
+    common::table_id_map_t<std::unique_ptr<ScanNodeTableInfo>> clonedInfos;
+    for (auto& [id, info] : infos) {
+        clonedInfos.insert({id, info->copy()});
+    }
+    return make_unique<ScanMultiNodeTables>(nodeIDPos, outVectorsPos, std::move(clonedInfos),
+        children[0]->clone(), id, paramsString);
 }
 
 } // namespace processor

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -54,9 +54,8 @@ void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionCo
 bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
     while (true) {
         if (currentScanner != nullptr &&
-            currentScanner->scan(anchorOutVector->state->selVector.get(),
-                context->clientContext->getTx())) {
-            metrics->numOutputTuple.increase(anchorOutVector->state->selVector->selectedSize);
+            currentScanner->scan(outState->selVector.get(), context->clientContext->getTx())) {
+            metrics->numOutputTuple.increase(outState->selVector->selectedSize);
             return true;
         }
         if (!children[0]->getNextTuple(context)) {
@@ -65,7 +64,7 @@ bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
         }
         auto currentIdx = nodeIDVector->state->selVector->selectedPositions[0];
         if (nodeIDVector->isNull(currentIdx)) {
-            anchorOutVector->state->selVector->selectedSize = 0;
+            outState->selVector->selectedSize = 0;
             continue;
         }
         auto nodeID = nodeIDVector->getValue<nodeID_t>(currentIdx);

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -7,23 +7,12 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace processor {
 
-void RelTableCollectionScanner::init(ValueVector* inVector,
-    const std::vector<ValueVector*>& outputVectors) {
-    readStates.resize(scanInfos.size());
-    for (auto i = 0u; i < scanInfos.size(); i++) {
-        auto scanInfo = scanInfos[i].get();
-        readStates[i] = std::make_unique<RelTableReadState>(*inVector, scanInfo->columnIDs,
-            outputVectors, scanInfo->direction);
-    }
-}
-
-bool RelTableCollectionScanner::scan(ValueVector* inVector,
-    const std::vector<ValueVector*>& outputVectors, Transaction* transaction) {
+bool RelTableCollectionScanner::scan(common::SelectionVector* selVector, Transaction* transaction) {
     while (true) {
         if (readStates[currentTableIdx]->hasMoreToRead(transaction)) {
             auto scanInfo = scanInfos[currentTableIdx].get();
             scanInfo->table->read(transaction, *readStates[currentTableIdx]);
-            if (outputVectors[0]->state->selVector->selectedSize > 0) {
+            if (selVector->selectedSize > 0) {
                 return true;
             }
         } else {
@@ -33,7 +22,7 @@ bool RelTableCollectionScanner::scan(ValueVector* inVector,
             }
             auto scanInfo = scanInfos[currentTableIdx].get();
             scanInfo->table->initializeReadState(transaction, scanInfo->direction,
-                scanInfo->columnIDs, *inVector, *readStates[currentTableIdx]);
+                scanInfo->columnIDs, *readStates[currentTableIdx]);
             nextTableIdx++;
         }
     }
@@ -49,9 +38,15 @@ std::unique_ptr<RelTableCollectionScanner> RelTableCollectionScanner::clone() co
 }
 
 void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
-    ScanRelTable::initLocalStateInternal(resultSet, context);
+    ScanTable::initLocalStateInternal(resultSet, context);
     for (auto& [_, scanner] : scannerPerNodeTable) {
-        scanner->init(inVector, outVectors);
+        scanner->readStates.resize(scanner->scanInfos.size());
+        for (auto i = 0u; i < scanner->scanInfos.size(); i++) {
+            auto scanInfo = scanner->scanInfos[i].get();
+            scanner->readStates[i] =
+                std::make_unique<RelTableReadState>(scanInfo->columnIDs, scanInfo->direction);
+            ScanTable::initVectors(*scanner->readStates[i], *resultSet);
+        }
     }
     currentScanner = nullptr;
 }
@@ -59,20 +54,21 @@ void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionCo
 bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
     while (true) {
         if (currentScanner != nullptr &&
-            currentScanner->scan(inVector, outVectors, context->clientContext->getTx())) {
-            metrics->numOutputTuple.increase(outVectors[0]->state->selVector->selectedSize);
+            currentScanner->scan(anchorOutVector->state->selVector.get(),
+                context->clientContext->getTx())) {
+            metrics->numOutputTuple.increase(anchorOutVector->state->selVector->selectedSize);
             return true;
         }
         if (!children[0]->getNextTuple(context)) {
             resetState();
             return false;
         }
-        auto currentIdx = inVector->state->selVector->selectedPositions[0];
-        if (inVector->isNull(currentIdx)) {
-            outVectors[0]->state->selVector->selectedSize = 0;
+        auto currentIdx = nodeIDVector->state->selVector->selectedPositions[0];
+        if (nodeIDVector->isNull(currentIdx)) {
+            anchorOutVector->state->selVector->selectedSize = 0;
             continue;
         }
-        auto nodeID = inVector->getValue<nodeID_t>(currentIdx);
+        auto nodeID = nodeIDVector->getValue<nodeID_t>(currentIdx);
         initCurrentScanner(nodeID);
     }
 }
@@ -82,7 +78,7 @@ std::unique_ptr<PhysicalOperator> ScanMultiRelTable::clone() {
     for (auto& [tableID, scanner] : scannerPerNodeTable) {
         clonedScanners.insert({tableID, scanner->clone()});
     }
-    return make_unique<ScanMultiRelTable>(std::move(clonedScanners), inVectorPos, outVectorsPos,
+    return make_unique<ScanMultiRelTable>(std::move(clonedScanners), nodeIDPos, outVectorsPos,
         children[0]->clone(), id, paramsString);
 }
 

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -5,13 +5,13 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-void ScanSingleNodeTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+void ScanNodeTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     ScanTable::initLocalStateInternal(resultSet, context);
     readState = std::make_unique<storage::NodeTableReadState>(info->columnIDs);
     ScanTable::initVectors(*readState, *resultSet);
 }
 
-bool ScanSingleNodeTable::getNextTuplesInternal(ExecutionContext* context) {
+bool ScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     if (!children[0]->getNextTuple(context)) {
         return false;
     }

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -5,15 +5,20 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
+void ScanSingleNodeTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+    ScanTable::initLocalStateInternal(resultSet, context);
+    readState = std::make_unique<storage::NodeTableReadState>(info->columnIDs);
+    ScanTable::initVectors(*readState, *resultSet);
+}
+
 bool ScanSingleNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     if (!children[0]->getNextTuple(context)) {
         return false;
     }
-    for (auto& outputVector : outVectors) {
-        outputVector->resetAuxiliaryBuffer();
+    for (auto& vector : readState->outputVectors) {
+        vector->resetAuxiliaryBuffer();
     }
-    info->table->initializeReadState(context->clientContext->getTx(), info->columnIDs, *inVector,
-        *readState);
+    info->table->initializeReadState(context->clientContext->getTx(), info->columnIDs, *readState);
     info->table->read(context->clientContext->getTx(), *readState);
     return true;
 }

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -1,7 +1,15 @@
 #include "processor/operator/scan/scan_rel_table.h"
 
+using namespace kuzu::storage;
+
 namespace kuzu {
 namespace processor {
+
+void ScanRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
+    ScanTable::initLocalStateInternal(resultSet, context);
+    scanState = std::make_unique<RelTableReadState>(info->columnIDs, info->direction);
+    ScanTable::initVectors(*scanState, *resultSet);
+}
 
 bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
     while (true) {
@@ -13,7 +21,7 @@ bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
             return false;
         }
         info->table->initializeReadState(context->clientContext->getTx(), info->direction,
-            info->columnIDs, *inVector, *scanState);
+            info->columnIDs, *scanState);
     }
 }
 

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -3,12 +3,16 @@
 namespace kuzu {
 namespace processor {
 
-void ScanTable::initLocalStateInternal(ResultSet* resultSet,
-    ExecutionContext* /*executionContext*/) {
-    inVector = resultSet->getValueVector(inVectorPos).get();
-    outVectors.reserve(outVectorsPos.size());
+void ScanTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
+    nodeIDVector = resultSet->getValueVector(nodeIDPos).get();
+    KU_ASSERT(!outVectorsPos.empty());
+    anchorOutVector = resultSet->getValueVector(outVectorsPos[0]).get();
+}
+
+void ScanTable::initVectors(storage::TableReadState& state, const ResultSet& resultSet) {
+    state.nodeIDVector = resultSet.getValueVector(nodeIDPos).get();
     for (auto& pos : outVectorsPos) {
-        outVectors.push_back(resultSet->getValueVector(pos).get());
+        state.outputVectors.push_back(resultSet.getValueVector(pos).get());
     }
 }
 

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -6,7 +6,7 @@ namespace processor {
 void ScanTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
     nodeIDVector = resultSet->getValueVector(nodeIDPos).get();
     KU_ASSERT(!outVectorsPos.empty());
-    anchorOutVector = resultSet->getValueVector(outVectorsPos[0]).get();
+    outState = resultSet->getValueVector(outVectorsPos[0])->state.get();
 }
 
 void ScanTable::initVectors(storage::TableReadState& state, const ResultSet& resultSet) {

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -106,9 +106,8 @@ void NodeTable::delete_(Transaction* transaction, TableDeleteState& deleteState)
     }
     auto pkColumnIDs = {pkColumnID};
     auto pkVectors = std::vector<ValueVector*>{&nodeDeleteState.pkVector};
-    // TODO(Guodong): we are we creating TableReadState instead of NodeTableReadState?
     auto readState =
-        std::make_unique<TableReadState>(&nodeDeleteState.nodeIDVector, pkColumnIDs, pkVectors);
+        std::make_unique<NodeTableReadState>(&nodeDeleteState.nodeIDVector, pkColumnIDs, pkVectors);
     initializeReadState(transaction, pkColumnIDs, *readState);
     read(transaction, *readState);
     if (pkIndex) {
@@ -187,8 +186,7 @@ void NodeTable::updatePK(Transaction* transaction, column_id_t columnID,
     pkVector->state = nodeIDVector.state;
     auto outputVectors = std::vector<ValueVector*>{pkVector.get()};
     auto columnIDs = {columnID};
-    // TODO(Guodong): we are we creating TableReadState instead of NodeTableReadState?
-    auto readState = std::make_unique<TableReadState>(&nodeIDVector, columnIDs, outputVectors);
+    auto readState = std::make_unique<NodeTableReadState>(&nodeIDVector, columnIDs, outputVectors);
     initializeReadState(transaction, columnIDs, *readState);
     read(transaction, *readState);
     pkIndex->delete_(pkVector.get());

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -39,13 +39,13 @@ void NodeTable::initializePKIndex(NodeTableCatalogEntry* nodeTableEntry, bool re
 }
 
 void NodeTable::read(Transaction* transaction, TableReadState& readState) {
-    tableData->read(transaction, *readState.dataReadState, readState.nodeIDVector,
+    tableData->read(transaction, *readState.dataReadState, *readState.nodeIDVector,
         readState.outputVectors);
     auto& dataReadState = ku_dynamic_cast<const TableDataReadState&, const NodeDataReadState&>(
         *readState.dataReadState);
     if (dataReadState.localNodeGroup) {
         KU_ASSERT(transaction->isWriteTransaction());
-        dataReadState.localNodeGroup->scan(readState.nodeIDVector, readState.columnIDs,
+        dataReadState.localNodeGroup->scan(*readState.nodeIDVector, readState.columnIDs,
             readState.outputVectors);
     }
 }
@@ -106,9 +106,10 @@ void NodeTable::delete_(Transaction* transaction, TableDeleteState& deleteState)
     }
     auto pkColumnIDs = {pkColumnID};
     auto pkVectors = std::vector<ValueVector*>{&nodeDeleteState.pkVector};
+    // TODO(Guodong): we are we creating TableReadState instead of NodeTableReadState?
     auto readState =
-        std::make_unique<TableReadState>(nodeDeleteState.nodeIDVector, pkColumnIDs, pkVectors);
-    initializeReadState(transaction, pkColumnIDs, nodeDeleteState.nodeIDVector, *readState);
+        std::make_unique<TableReadState>(&nodeDeleteState.nodeIDVector, pkColumnIDs, pkVectors);
+    initializeReadState(transaction, pkColumnIDs, *readState);
     read(transaction, *readState);
     if (pkIndex) {
         pkIndex->delete_(&nodeDeleteState.pkVector);
@@ -186,8 +187,9 @@ void NodeTable::updatePK(Transaction* transaction, column_id_t columnID,
     pkVector->state = nodeIDVector.state;
     auto outputVectors = std::vector<ValueVector*>{pkVector.get()};
     auto columnIDs = {columnID};
-    auto readState = std::make_unique<TableReadState>(nodeIDVector, columnIDs, outputVectors);
-    initializeReadState(transaction, columnIDs, nodeIDVector, *readState);
+    // TODO(Guodong): we are we creating TableReadState instead of NodeTableReadState?
+    auto readState = std::make_unique<TableReadState>(&nodeIDVector, columnIDs, outputVectors);
+    initializeReadState(transaction, columnIDs, *readState);
     read(transaction, *readState);
     pkIndex->delete_(pkVector.get());
     insertPK(nodeIDVector, payloadVector);

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -70,9 +70,10 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
     std::vector<column_id_t> relIDColumns = {REL_ID_COLUMN_ID};
     auto relIDVectors = std::vector<ValueVector*>{deleteState->dstNodeIDVector.get(),
         deleteState->relIDVector.get()};
-    auto relReadState = std::make_unique<RelTableReadState>(*srcNodeIDVector, relIDColumns,
-        relIDVectors, direction);
-    initializeReadState(transaction, direction, relIDColumns, *srcNodeIDVector, *relReadState);
+    auto relReadState = std::make_unique<RelTableReadState>(relIDColumns, direction);
+    relReadState->nodeIDVector = srcNodeIDVector;
+    relReadState->outputVectors = relIDVectors;
+    initializeReadState(transaction, direction, relIDColumns, *relReadState);
     row_idx_t numRelsDeleted = detachDeleteForCSRRels(transaction, tableData, reverseTableData,
         srcNodeIDVector, relReadState.get(), deleteState);
     auto relsStats = ku_dynamic_cast<TablesStatistics*, RelsStoreStats*>(tablesStatistics);
@@ -120,7 +121,7 @@ row_idx_t RelTable::detachDeleteForCSRRels(Transaction* transaction, RelTableDat
 
 void RelTable::scan(Transaction* transaction, RelTableReadState& scanState) {
     auto tableData = getDirectedTableData(scanState.direction);
-    tableData->scan(transaction, *scanState.dataReadState, scanState.nodeIDVector,
+    tableData->scan(transaction, *scanState.dataReadState, *scanState.nodeIDVector,
         scanState.outputVectors);
 }
 

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -31,6 +31,20 @@ RelTable::RelTable(BMFileHandle* dataFH, BMFileHandle* metadataFH, RelsStoreStat
         relTableEntry, relsStoreStats, RelDataDirection::BWD, enableCompression);
 }
 
+void RelTable::initializeReadState(Transaction* transaction, RelDataDirection direction,
+    const std::vector<column_id_t>& columnIDs, RelTableReadState& readState) {
+    if (!readState.dataReadState) {
+        readState.dataReadState = std::make_unique<RelDataReadState>();
+    }
+    auto& dataState =
+        common::ku_dynamic_cast<TableDataReadState&, RelDataReadState&>(*readState.dataReadState);
+    return direction == common::RelDataDirection::FWD ?
+               fwdRelTableData->initializeReadState(transaction, columnIDs, *readState.nodeIDVector,
+                   dataState) :
+               bwdRelTableData->initializeReadState(transaction, columnIDs, *readState.nodeIDVector,
+                   dataState);
+}
+
 void RelTable::read(Transaction* transaction, TableReadState& readState) {
     auto& relReadState = ku_dynamic_cast<TableReadState&, RelTableReadState&>(readState);
     scan(transaction, relReadState);


### PR DESCRIPTION
This PR refactors interfaces for `ScanTable` and its children classes. In particular, it contains changes on

- Removal of `vector<ValueVector>` in `ScanTable` since we already store the same information in `TableReadState`. I still have to keep a vector for input and output respectively in order to retrieve their state. I don't think we will be able to solve this because in multi-table scan there are cases where we don't scan a physical table at all. So relying only on `TableReadState` to set the correct scan result doesn't sound safe to me
- Remove `nodeIDVector` from parameter list of `initializeReadState` because we seem to have the guarantee that it's always the same vector as `nodeIDVector` in `readState`

~~I spot another case in `NodeTable::initializeReadState` where we seem to re-create `NodeDataReadState` unnecessarily. @ray6080 should take a look at this.~~