### PR TITLE
Improve efficiency of merging bulk insertions into the hash index

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -124,8 +124,17 @@ private:
     }
     // Resizes the on-disk index to support the given number of new entries
     void reserve(uint64_t newEntries);
+
+    struct HashIndexEntryView {
+        slot_id_t diskSlotId;
+        uint8_t fingerprint;
+        const SlotEntry<T>* entry;
+    };
+
+    void sortEntries(typename InMemHashIndex<T>::SlotIterator& slotToMerge,
+        std::vector<HashIndexEntryView>& partitions);
     void mergeBulkInserts();
-    void mergeSlot(typename InMemHashIndex<T>::SlotIterator& slotToMerge,
+    void mergeSlot(std::vector<HashIndexEntryView>& slotToMerge,
         typename BaseDiskArray<Slot<T>>::WriteIterator& diskSlotIterator,
         typename BaseDiskArray<Slot<T>>::WriteIterator& diskOverflowSlotIterator, slot_id_t slotId);
 

--- a/src/include/storage/storage_structure/disk_array.h
+++ b/src/include/storage/storage_structure/disk_array.h
@@ -355,7 +355,9 @@ public:
 
     inline WriteIterator iter_mut() { return WriteIterator{diskArray.iter_mut(sizeof(U))}; }
     inline uint64_t getAPIdx(uint64_t idx) const { return diskArray.getAPIdx(idx); }
-    uint32_t getAlignedElementSize() const { return 1 << diskArray.header.alignedElementSizeLog2; }
+    static constexpr uint32_t getAlignedElementSize() {
+        return (1 << (std::bit_width(sizeof(U)) - 1));
+    }
 
 private:
     BaseDiskArrayInternal diskArray;
@@ -451,7 +453,9 @@ public:
 
     inline void saveToDisk() { diskArray.saveToDisk(); }
 
-    uint32_t getAlignedElementSize() const { return 1 << diskArray.header.alignedElementSizeLog2; }
+    static constexpr uint32_t getAlignedElementSize() {
+        return BaseDiskArray<U>::getAlignedElementSize();
+    }
 
 private:
     InMemDiskArrayBuilderInternal diskArray;


### PR DESCRIPTION
This improves the performance of the bulk insert by avoiding re-hashing entries multiple times and using a method that scales with the size of the number of entries to insert rather than the number of slots on disk.

The difference is somewhat less than I was expecting for small inserts, and the second copy performance has degraded since the last time I recorded it in https://github.com/kuzudb/kuzu/issues/2938#issuecomment-2013865169. I suspect this is due at least in part to the locking added in #3388.

Copy benchmarks (all are copies into a 60 million node table containing a single integer primary key column):
| Number of Nodes inserted | Before | After |
| -- | -- | -- |
| 1 | ~530ms | ~500ms |
| 1024 | ~590ms | ~530ms |
| 60000 | ~1650ms | ~1400ms |
| 600000 | ~8400ms | ~5200ms |
| 6000000 | ~12400ms | ~7600ms |
| 60000000 | ~21600ms | ~17300ms |

*Edit: This is when doing the second copy in the same process. Subsequent testing has revealed that running the second copy in a new process (this was done with kuzu_shell) yields significantly better performance for small copies (e.g. ~20ms for a single tuple instead of ~500ms) but that was also the case before this change.*

Copying a single node is more or less identical in performance to inserting, so I will work on merging the implementations in the hash index to just use the bulk storage. That will be a larger and messier PR though.