### PR TITLE
Testing framework improvement

### DIFF
--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -25,6 +25,8 @@ struct TestStatement {
     std::vector<std::string> expectedTuples;
     bool enumerate = false;
     bool checkOutputOrder = false;
+    bool checkColumnNames = false;
+    std::string columnNames;
     std::string expectedTuplesCSVFile;
     // for multiple conns
     std::string batchStatmentsCSVFile;

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -18,6 +18,7 @@ enum class TokenType {
     // body
     BUFFER_POOL_SIZE,
     CASE,
+    CHECK_COLUMNS,
     CHECK_ORDER,
     COMMIT,
     DEFINE,
@@ -61,7 +62,7 @@ const std::unordered_map<std::string, TokenType> tokenMap = {{"-GROUP", TokenTyp
     {"-CREATE_CONNECTION", TokenType::CREATE_CONNECTION}, {"]", TokenType::END_OF_STATEMENT_BLOCK},
     {"----", TokenType::RESULT}, {"--", TokenType::SEPARATOR}, {"#", TokenType::EMPTY},
     {"-SET", TokenType::SET}, {"-IMPORT_DATABASE", TokenType::IMPORT_DATABASE},
-    {"-REMOVE_FILE", TokenType::REMOVE_FILE}};
+    {"-REMOVE_FILE", TokenType::REMOVE_FILE}, {"-CHECK_COLUMNS", TokenType::CHECK_COLUMNS}};
 
 class LogicToken {
 public:

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -91,6 +91,7 @@ private:
 
     void openFile();
     void tokenize();
+    void genGroupName();
     void parseHeader();
     void parseBody();
     void extractExpectedResult(TestStatement* statement);

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -25,6 +25,7 @@ private:
         bool checkOutputOrder = false);
     static std::string convertResultToMD5Hash(main::QueryResult& queryResult,
         bool checkOutputOrder); // returns hash and number of values hashed
+    static std::string convertResultColumnsToString(std::vector<std::string> columnNames);
     static bool checkPlanResult(std::unique_ptr<main::QueryResult>& result,
         TestStatement* statement, const std::string& planStr, uint32_t planIndex);
 };

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -25,12 +25,21 @@ namespace testing {
 
 std::unique_ptr<TestGroup> TestParser::parseTestFile() {
     openFile();
+    genGroupName();
     parseHeader();
     if (!testGroup->isValid()) {
         throw TestException("Invalid test header [" + path + "].");
     }
     parseBody();
     return std::move(testGroup);
+}
+
+void TestParser::genGroupName() {
+    std::size_t subStart = TestHelper::appendKuzuRootPath(std::string(
+        TestHelper::E2E_TEST_FILES_DIRECTORY)).length() + 1;
+    std::size_t subEnd = path.find_last_of('/') - 1;
+    std::string relPath = path.substr(subStart, subEnd - subStart + 1);
+    testGroup->group = relPath;
 }
 
 void TestParser::extractDataset() {
@@ -67,8 +76,8 @@ void TestParser::parseHeader() {
             break;
         }
         case TokenType::GROUP: {
-            checkMinimumParams(1);
-            testGroup->group = currentToken.params[1];
+            // checkMinimumParams(1);
+            // testGroup->group = currentToken.params[1];
             break;
         }
         case TokenType::DATASET: {

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -35,8 +35,9 @@ std::unique_ptr<TestGroup> TestParser::parseTestFile() {
 }
 
 void TestParser::genGroupName() {
-    std::size_t subStart = TestHelper::appendKuzuRootPath(std::string(
-        TestHelper::E2E_TEST_FILES_DIRECTORY)).length() + 1;
+    std::size_t subStart =
+        TestHelper::appendKuzuRootPath(std::string(TestHelper::E2E_TEST_FILES_DIRECTORY)).length() +
+        1;
     std::size_t subEnd = path.find_last_of('/') - 1;
     std::string relPath = path.substr(subStart, subEnd - subStart + 1);
     testGroup->group = relPath;

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -260,6 +260,11 @@ TestStatement* TestParser::extractStatement(TestStatement* statement,
         statement->encodedJoin = paramsToString(1);
         break;
     }
+    case TokenType::CHECK_COLUMNS: {
+        statement->checkColumnNames = true;
+        statement->columnNames = currentToken.params[1];
+        break;
+    }
     case TokenType::EMPTY: {
         break;
     }

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -145,6 +145,15 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
             sort(statement->expectedTuples.begin(), statement->expectedTuples.end());
         }
     }
+    if (statement->checkColumnNames) {
+        std::string resultColumns = TestRunner::convertResultColumnsToString((*result).getColumnNames());
+        if (resultColumns != statement->columnNames) {
+            spdlog::error("PLAN{} NOT PASSED.", planIdx);
+            spdlog::info("PLAN: \n{}", planStr);
+            spdlog::info("COLUMNS: {}\n", resultColumns);
+            return false;
+        }
+    }
     std::vector<std::string> resultTuples =
         TestRunner::convertResultToString(*result, statement->checkOutputOrder);
     if (statement->expectHash) {
@@ -209,6 +218,17 @@ std::string TestRunner::convertResultToMD5Hash(QueryResult& queryResult, bool ch
         hasher.addToMD5(lineBreaker.c_str(), lineBreaker.size());
     }
     return std::string(hasher.finishMD5());
+}
+
+std::string TestRunner::convertResultColumnsToString(std::vector<std::string> columnNames) {
+    std::string columnsString;
+    for (auto i = 0ul; i < columnNames.size(); i++) {
+        if (i != 0) {
+            columnsString += "|";
+        }
+        columnsString += columnNames[i];
+    }
+    return columnsString;
 }
 
 std::unique_ptr<planner::LogicalPlan> TestRunner::getLogicalPlan(const std::string& query,

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -146,7 +146,8 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
         }
     }
     if (statement->checkColumnNames) {
-        std::string resultColumns = TestRunner::convertResultColumnsToString((*result).getColumnNames());
+        std::string resultColumns =
+            TestRunner::convertResultColumnsToString((*result).getColumnNames());
         if (resultColumns != statement->columnNames) {
             spdlog::error("PLAN{} NOT PASSED.", planIdx);
             spdlog::info("PLAN: \n{}", planStr);


### PR DESCRIPTION
## WIP
**Column Name Assertion**
- added new optional property to check for column names `-CHECK_COLUMNS colName1|colName2`
- TODO: ensure the format is correct

**Test Group Name Generation**
- uses the relative folder path as test group name
- TODO: remove the -GROUP property and modify related code/test cases?

## TODO
**Fuzzy Matching**
- unsure how we want to implement the fuzzy match _(i see we already have a regex-based error matching)_

**Numeric Value Comparison with Precision**

**Initialize Test Case on Existing Binary db Directory**
