### PR TITLE
Fix export database on nodetable with serial property

### DIFF
--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -4,6 +4,7 @@
 #include "binder/expression_binder.h"
 #include "binder/query/bound_regular_query.h"
 #include "binder/query/query_graph.h"
+#include "catalog/catalog_entry/table_catalog_entry.h"
 #include "common/copier_config/reader_config.h"
 #include "common/enums/table_type.h"
 #include "parser/query/graph_pattern/pattern_element.h"
@@ -71,7 +72,8 @@ public:
 
     static std::unique_ptr<common::LogicalType> bindDataType(const std::string& dataType);
 
-    ExportedTableData extractExportData(std::string selQuery, std::string tableName);
+    bool bindExportTableData(ExportedTableData& tableData, catalog::TableCatalogEntry* entry,
+        const catalog::Catalog& catalog, transaction::Transaction* tx);
 
 private:
     std::shared_ptr<Expression> bindWhereExpression(

--- a/src/include/binder/bound_export_database.h
+++ b/src/include/binder/bound_export_database.h
@@ -13,9 +13,10 @@ struct ExportedTableData {
     std::unique_ptr<BoundRegularQuery> regularQuery;
     std::vector<std::string> columnNames;
     std::vector<common::LogicalType> columnTypes;
+    bool canParallel;
 
-    inline const std::vector<common::LogicalType>& getColumnTypesRef() const { return columnTypes; }
-    inline const BoundRegularQuery* getRegularQuery() const { return regularQuery.get(); }
+    const std::vector<common::LogicalType>& getColumnTypesRef() const { return columnTypes; }
+    const BoundRegularQuery* getRegularQuery() const { return regularQuery.get(); }
 };
 
 class BoundExportDatabase final : public BoundStatement {
@@ -30,14 +31,14 @@ public:
         boundFileInfo.options = std::move(csvOption);
     }
 
-    inline std::string getFilePath() const { return boundFileInfo.filePaths[0]; }
-    inline common::FileType getFileType() const { return boundFileInfo.fileType; }
-    inline common::CSVOption getCopyOption() const {
+    std::string getFilePath() const { return boundFileInfo.filePaths[0]; }
+    common::FileType getFileType() const { return boundFileInfo.fileType; }
+    common::CSVOption getCopyOption() const {
         auto csvConfig = common::CSVReaderConfig::construct(boundFileInfo.options);
         return csvConfig.option.copy();
     }
-    inline const common::ReaderConfig* getBoundFileInfo() const { return &boundFileInfo; }
-    inline const std::vector<ExportedTableData>* getExportData() const { return &exportData; }
+    const common::ReaderConfig* getBoundFileInfo() const { return &boundFileInfo; }
+    const std::vector<ExportedTableData>* getExportData() const { return &exportData; }
 
 private:
     std::vector<ExportedTableData> exportData;

--- a/src/include/binder/bound_statement.h
+++ b/src/include/binder/bound_statement.h
@@ -15,9 +15,11 @@ public:
 
     virtual ~BoundStatement() = default;
 
-    inline common::StatementType getStatementType() const { return statementType; }
+    common::StatementType getStatementType() const { return statementType; }
 
-    inline const BoundStatementResult* getStatementResult() const { return &statementResult; }
+    const BoundStatementResult* getStatementResult() const { return &statementResult; }
+
+    BoundStatementResult* getStatementResultUnsafe() { return &statementResult; }
 
 private:
     common::StatementType statementType;

--- a/src/include/binder/bound_statement_result.h
+++ b/src/include/binder/bound_statement_result.h
@@ -16,12 +16,10 @@ public:
     static BoundStatementResult createSingleStringColumnResult(
         const std::string& columnName = "result");
 
-    inline void addColumn(std::shared_ptr<Expression> column) {
-        columns.push_back(std::move(column));
-    }
-    inline expression_vector getColumns() const { return columns; }
+    void addColumn(std::shared_ptr<Expression> column) { columns.push_back(std::move(column)); }
+    expression_vector getColumns() const { return columns; }
 
-    inline std::shared_ptr<Expression> getSingleColumnExpr() const {
+    std::shared_ptr<Expression> getSingleColumnExpr() const {
         KU_ASSERT(columns.size() == 1);
         return columns[0];
     }

--- a/src/include/planner/operator/persistent/logical_copy_to.h
+++ b/src/include/planner/operator/persistent/logical_copy_to.h
@@ -11,27 +11,30 @@ class LogicalCopyTo : public LogicalOperator {
 public:
     LogicalCopyTo(std::string filePath, common::FileType fileType,
         std::vector<std::string> columnNames, std::vector<common::LogicalType> columnTypes,
-        common::CSVOption copyToOption, std::shared_ptr<LogicalOperator> child)
+        common::CSVOption copyToOption, std::shared_ptr<LogicalOperator> child,
+        bool canParallel = true)
         : LogicalOperator{LogicalOperatorType::COPY_TO, std::move(child)},
           filePath{std::move(filePath)}, fileType{fileType}, columnNames{std::move(columnNames)},
-          columnTypes{std::move(columnTypes)}, copyToOption{std::move(copyToOption)} {}
+          columnTypes{std::move(columnTypes)}, copyToOption{std::move(copyToOption)},
+          canParallel{canParallel} {}
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    inline std::string getExpressionsForPrinting() const override { return std::string{}; }
+    std::string getExpressionsForPrinting() const override { return std::string{}; }
 
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    inline std::string getFilePath() const { return filePath; }
-    inline common::FileType getFileType() const { return fileType; }
-    inline std::vector<std::string> getColumnNames() const { return columnNames; }
-    inline const std::vector<common::LogicalType>& getColumnTypesRef() const { return columnTypes; }
-    inline const common::CSVOption* getCopyOption() const { return &copyToOption; }
+    std::string getFilePath() const { return filePath; }
+    common::FileType getFileType() const { return fileType; }
+    std::vector<std::string> getColumnNames() const { return columnNames; }
+    const std::vector<common::LogicalType>& getColumnTypesRef() const { return columnTypes; }
+    const common::CSVOption* getCopyOption() const { return &copyToOption; }
+    bool getCanParallel() const { return canParallel; }
 
-    inline std::unique_ptr<LogicalOperator> copy() override {
+    std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalCopyTo>(filePath, fileType, columnNames, columnTypes,
-            copyToOption.copy(), children[0]->copy());
+            copyToOption.copy(), children[0]->copy(), canParallel);
     }
 
 private:
@@ -40,6 +43,7 @@ private:
     std::vector<std::string> columnNames;
     std::vector<common::LogicalType> columnTypes;
     common::CSVOption copyToOption;
+    bool canParallel;
 };
 
 } // namespace planner

--- a/src/include/planner/operator/schema.h
+++ b/src/include/planner/operator/schema.h
@@ -99,12 +99,12 @@ public:
         return std::make_pair(groupPos, groups[groupPos]->getExpressionPos(expression));
     }
 
-    inline void flattenGroup(f_group_pos pos) { groups[pos]->setFlat(); }
-    inline void setGroupAsSingleState(f_group_pos pos) { groups[pos]->setSingleState(); }
+    void flattenGroup(f_group_pos pos) { groups[pos]->setFlat(); }
+    void setGroupAsSingleState(f_group_pos pos) { groups[pos]->setSingleState(); }
 
     bool isExpressionInScope(const binder::Expression& expression) const;
 
-    inline binder::expression_vector getExpressionsInScope() const { return expressionsInScope; }
+    binder::expression_vector getExpressionsInScope() const { return expressionsInScope; }
 
     binder::expression_vector getExpressionsInScope(f_group_pos pos) const;
 

--- a/src/include/processor/operator/persistent/copy_to.h
+++ b/src/include/processor/operator/persistent/copy_to.h
@@ -10,9 +10,17 @@ struct CopyToInfo {
     std::vector<std::string> names;
     std::vector<DataPos> dataPoses;
     std::string fileName;
+    bool canParallel;
 
-    CopyToInfo(std::vector<std::string> names, std::vector<DataPos> dataPoses, std::string fileName)
-        : names{std::move(names)}, dataPoses{std::move(dataPoses)}, fileName{std::move(fileName)} {}
+    CopyToInfo(std::vector<std::string> names, std::vector<DataPos> dataPoses, std::string fileName,
+        bool canParallel)
+        : names{std::move(names)}, dataPoses{std::move(dataPoses)}, fileName{std::move(fileName)},
+          canParallel{canParallel} {}
+
+    template<class TARGET>
+    const TARGET* constPtrCast() const {
+        return common::ku_dynamic_cast<const CopyToInfo*, const TARGET*>(this);
+    }
 
     virtual ~CopyToInfo() = default;
 
@@ -58,6 +66,8 @@ public:
     void finalize(ExecutionContext* context) final;
 
     void executeInternal(processor::ExecutionContext* context) final;
+
+    bool canParallel() const override final;
 
 protected:
     std::unique_ptr<CopyToInfo> info;

--- a/src/include/processor/operator/persistent/copy_to.h
+++ b/src/include/processor/operator/persistent/copy_to.h
@@ -67,7 +67,7 @@ public:
 
     void executeInternal(processor::ExecutionContext* context) final;
 
-    bool canParallel() const override final;
+    bool canParallel() const final;
 
 protected:
     std::unique_ptr<CopyToInfo> info;

--- a/src/include/processor/operator/persistent/copy_to_csv.h
+++ b/src/include/processor/operator/persistent/copy_to_csv.h
@@ -14,15 +14,16 @@ struct CopyToCSVInfo final : public CopyToInfo {
     common::CSVOption copyToOption;
 
     CopyToCSVInfo(std::vector<std::string> names, std::vector<DataPos> dataPoses,
-        std::string fileName, std::vector<bool> isFlat, common::CSVOption copyToOption)
-        : CopyToInfo{std::move(names), std::move(dataPoses), std::move(fileName)},
+        std::string fileName, std::vector<bool> isFlat, common::CSVOption copyToOption,
+        bool canParallel)
+        : CopyToInfo{std::move(names), std::move(dataPoses), std::move(fileName), canParallel},
           isFlat{std::move(isFlat)}, copyToOption{std::move(copyToOption)} {}
 
     uint64_t getNumFlatVectors();
 
-    inline std::unique_ptr<CopyToInfo> copy() override {
+    std::unique_ptr<CopyToInfo> copy() override {
         return std::make_unique<CopyToCSVInfo>(names, dataPoses, fileName, isFlat,
-            copyToOption.copy());
+            copyToOption.copy(), canParallel);
     }
 };
 
@@ -34,15 +35,15 @@ public:
 
     void finalize(CopyToSharedState* sharedState) override;
 
-    static void writeString(common::BufferedSerializer* serializer, CopyToCSVInfo* info,
+    static void writeString(common::BufferedSerializer* serializer, const CopyToCSVInfo* info,
         const uint8_t* strData, uint64_t strLen, bool forceQuote);
 
 private:
-    static bool requireQuotes(CopyToCSVInfo* info, const uint8_t* str, uint64_t len);
+    static bool requireQuotes(const CopyToCSVInfo* info, const uint8_t* str, uint64_t len);
 
     static std::string addEscapes(char toEscape, char escape, const std::string& val);
 
-    void writeRows(CopyToCSVInfo* info);
+    void writeRows(const CopyToCSVInfo* info);
 
 private:
     std::unique_ptr<common::BufferedSerializer> serializer;
@@ -79,7 +80,7 @@ public:
               std::make_unique<CopyToCSVLocalState>(), std::move(sharedState),
               PhysicalOperatorType::COPY_TO, std::move(child), id, paramsString} {}
 
-    inline std::unique_ptr<PhysicalOperator> clone() override {
+    std::unique_ptr<PhysicalOperator> clone() override {
         return std::make_unique<CopyToCSV>(resultSetDescriptor->copy(), info->copy(), sharedState,
             children[0]->clone(), id, paramsString);
     }

--- a/src/include/processor/operator/persistent/copy_to_csv.h
+++ b/src/include/processor/operator/persistent/copy_to_csv.h
@@ -19,7 +19,7 @@ struct CopyToCSVInfo final : public CopyToInfo {
         : CopyToInfo{std::move(names), std::move(dataPoses), std::move(fileName), canParallel},
           isFlat{std::move(isFlat)}, copyToOption{std::move(copyToOption)} {}
 
-    uint64_t getNumFlatVectors();
+    uint64_t getNumFlatVectors() const;
 
     std::unique_ptr<CopyToInfo> copy() override {
         return std::make_unique<CopyToCSVInfo>(names, dataPoses, fileName, isFlat,

--- a/src/include/processor/operator/persistent/copy_to_parquet.h
+++ b/src/include/processor/operator/persistent/copy_to_parquet.h
@@ -17,14 +17,16 @@ struct CopyToParquetInfo final : public CopyToInfo {
 
     CopyToParquetInfo(std::unique_ptr<FactorizedTableSchema> tableSchema,
         std::vector<std::unique_ptr<common::LogicalType>> types, std::vector<std::string> names,
-        std::vector<DataPos> dataPoses, std::string fileName, DataPos countingVecPos)
-        : CopyToInfo{std::move(names), std::move(dataPoses), std::move(fileName)},
+        std::vector<DataPos> dataPoses, std::string fileName, DataPos countingVecPos,
+        bool canParallel)
+        : CopyToInfo{std::move(names), std::move(dataPoses), std::move(fileName), canParallel},
           tableSchema{std::move(tableSchema)}, types{std::move(types)},
           countingVecPos{std::move(countingVecPos)} {}
 
     std::unique_ptr<CopyToInfo> copy() override {
         return std::make_unique<CopyToParquetInfo>(tableSchema->copy(),
-            common::LogicalType::copy(types), names, dataPoses, fileName, countingVecPos);
+            common::LogicalType::copy(types), names, dataPoses, fileName, countingVecPos,
+            canParallel);
     }
 };
 

--- a/src/include/storage/storage_structure/disk_array.h
+++ b/src/include/storage/storage_structure/disk_array.h
@@ -10,6 +10,7 @@
 #include "storage/storage_utils.h"
 #include "storage/wal/wal.h"
 #include "transaction/transaction.h"
+#include <bit>
 #include <span>
 
 namespace kuzu {

--- a/src/planner/plan/plan_port_db.cpp
+++ b/src/planner/plan/plan_port_db.cpp
@@ -33,7 +33,8 @@ std::unique_ptr<LogicalPlan> Planner::planExportDatabase(const BoundStatement& s
         auto copyTo = std::make_shared<LogicalCopyTo>(filePath + "/" + exportTableData.tableName +
                                                           copyToSuffix,
             fileType, exportTableData.columnNames, exportTableData.getColumnTypesRef(),
-            boundExportDatabase.getCopyOption(), tablePlan->getLastOperator());
+            boundExportDatabase.getCopyOption(), tablePlan->getLastOperator(),
+            exportTableData.canParallel);
         logicalOperators.push_back(std::move(copyTo));
     }
     auto exportDatabase =

--- a/src/processor/map/map_copy_to.cpp
+++ b/src/processor/map/map_copy_to.cpp
@@ -1,4 +1,3 @@
-#include "common/exception/runtime.h"
 #include "planner/operator/persistent/logical_copy_to.h"
 #include "processor/operator/persistent/copy_to_csv.h"
 #include "processor/operator/persistent/copy_to_parquet.h"

--- a/src/processor/map/map_copy_to.cpp
+++ b/src/processor/map/map_copy_to.cpp
@@ -1,3 +1,4 @@
+#include "common/exception/runtime.h"
 #include "planner/operator/persistent/logical_copy_to.h"
 #include "processor/operator/persistent/copy_to_csv.h"
 #include "processor/operator/persistent/copy_to_parquet.h"
@@ -13,7 +14,7 @@ namespace processor {
 std::unique_ptr<CopyToInfo> getCopyToInfo(Schema* childSchema, std::string filePath,
     common::FileType fileType, common::CSVOption copyToOption, std::vector<std::string> columnNames,
     std::vector<std::unique_ptr<LogicalType>> columnsTypes, std::vector<DataPos> vectorsToCopyPos,
-    std::vector<bool> isFlat) {
+    std::vector<bool> isFlat, bool canParallel) {
     switch (fileType) {
     case FileType::PARQUET: {
         auto copyToSchema = std::make_unique<FactorizedTableSchema>();
@@ -35,11 +36,11 @@ std::unique_ptr<CopyToInfo> getCopyToInfo(Schema* childSchema, std::string fileP
         }
         return std::make_unique<CopyToParquetInfo>(std::move(copyToSchema), std::move(columnsTypes),
             std::move(columnNames), std::move(vectorsToCopyPos), std::move(filePath),
-            std::move(countingVecPos));
+            std::move(countingVecPos), canParallel);
     }
     case FileType::CSV: {
         return std::make_unique<CopyToCSVInfo>(std::move(columnNames), std::move(vectorsToCopyPos),
-            std::move(filePath), std::move(isFlat), std::move(copyToOption));
+            std::move(filePath), std::move(isFlat), std::move(copyToOption), canParallel);
     }
     default:
         KU_UNREACHABLE;
@@ -72,9 +73,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapCopyTo(LogicalOperator* logical
         vectorsToCopyPos.emplace_back(childSchema->getExpressionPos(*expression));
         isFlat.push_back(childSchema->getGroup(expression)->isFlat());
     }
-    std::unique_ptr<CopyToInfo> copyToInfo = getCopyToInfo(childSchema, copy->getFilePath(),
-        copy->getFileType(), copy->getCopyOption()->copy(), std::move(columnNames),
-        std::move(columnTypes), std::move(vectorsToCopyPos), std::move(isFlat));
+    std::unique_ptr<CopyToInfo> copyToInfo =
+        getCopyToInfo(childSchema, copy->getFilePath(), copy->getFileType(),
+            copy->getCopyOption()->copy(), std::move(columnNames), std::move(columnTypes),
+            std::move(vectorsToCopyPos), std::move(isFlat), copy->getCanParallel());
     auto sharedState = getCopyToSharedState(copy->getFileType());
     std::unique_ptr<CopyTo> copyTo;
     if (copy->getFileType() == common::FileType::PARQUET) {

--- a/src/processor/operator/persistent/copy_to.cpp
+++ b/src/processor/operator/persistent/copy_to.cpp
@@ -22,5 +22,9 @@ void CopyTo::executeInternal(processor::ExecutionContext* context) {
     localState->finalize(sharedState.get());
 }
 
+bool CopyTo::canParallel() const {
+    return info->canParallel;
+}
+
 } // namespace processor
 } // namespace kuzu

--- a/src/processor/operator/persistent/copy_to_csv.cpp
+++ b/src/processor/operator/persistent/copy_to_csv.cpp
@@ -11,7 +11,7 @@ namespace processor {
 using namespace kuzu::common;
 using namespace kuzu::storage;
 
-uint64_t CopyToCSVInfo::getNumFlatVectors() {
+uint64_t CopyToCSVInfo::getNumFlatVectors() const {
     uint64_t numFlatVectors = 0;
     for (auto flatInfo : isFlat) {
         if (flatInfo) {
@@ -22,7 +22,7 @@ uint64_t CopyToCSVInfo::getNumFlatVectors() {
 }
 
 void CopyToCSVLocalState::init(CopyToInfo* info, MemoryManager* mm, ResultSet* resultSet) {
-    auto copyToCSVInfo = ku_dynamic_cast<CopyToInfo*, CopyToCSVInfo*>(info);
+    auto copyToCSVInfo = info->constPtrCast<CopyToCSVInfo>();
     serializer = std::make_unique<BufferedSerializer>();
     vectorsToCast.reserve(info->dataPoses.size());
     auto numFlatVectors = copyToCSVInfo->getNumFlatVectors();

--- a/src/processor/operator/persistent/copy_to_csv.cpp
+++ b/src/processor/operator/persistent/copy_to_csv.cpp
@@ -50,7 +50,7 @@ void CopyToCSVLocalState::init(CopyToInfo* info, MemoryManager* mm, ResultSet* r
 }
 
 void CopyToCSVLocalState::sink(CopyToSharedState* sharedState, CopyToInfo* info) {
-    auto copyToCSVInfo = ku_dynamic_cast<CopyToInfo*, CopyToCSVInfo*>(info);
+    auto copyToCSVInfo = info->constPtrCast<CopyToCSVInfo>();
     writeRows(copyToCSVInfo);
     if (serializer->getSize() > CopyToCSVConstants::DEFAULT_CSV_FLUSH_SIZE) {
         ku_dynamic_cast<CopyToSharedState*, CopyToCSVSharedState*>(sharedState)
@@ -68,7 +68,7 @@ void CopyToCSVLocalState::finalize(CopyToSharedState* sharedState) {
 }
 
 void CopyToCSVLocalState::writeString(common::BufferedSerializer* serializer,
-    CopyToCSVInfo* copyToCsvInfo, const uint8_t* strData, uint64_t strLen, bool forceQuote) {
+    const CopyToCSVInfo* copyToCsvInfo, const uint8_t* strData, uint64_t strLen, bool forceQuote) {
     if (!forceQuote) {
         forceQuote = requireQuotes(copyToCsvInfo, strData, strLen);
     }
@@ -104,7 +104,7 @@ void CopyToCSVLocalState::writeString(common::BufferedSerializer* serializer,
     }
 }
 
-bool CopyToCSVLocalState::requireQuotes(CopyToCSVInfo* copyToCsvInfo, const uint8_t* str,
+bool CopyToCSVLocalState::requireQuotes(const CopyToCSVInfo* copyToCsvInfo, const uint8_t* str,
     uint64_t len) {
     // Check if the string is equal to the null string.
     if (len == strlen(CopyToCSVConstants::DEFAULT_NULL_STR) &&
@@ -141,7 +141,7 @@ std::string CopyToCSVLocalState::addEscapes(char toEscape, char escape, const st
     return escapedStr;
 }
 
-void CopyToCSVLocalState::writeRows(CopyToCSVInfo* copyToCsvInfo) {
+void CopyToCSVLocalState::writeRows(const CopyToCSVInfo* copyToCsvInfo) {
     for (auto i = 0u; i < vectorsToCast.size(); i++) {
         std::vector<std::shared_ptr<ValueVector>> vectorToCast = {vectorsToCast[i]};
         castFuncs[i](vectorToCast, *castVectors[i], nullptr);

--- a/src/processor/operator/persistent/copy_to_parquet.cpp
+++ b/src/processor/operator/persistent/copy_to_parquet.cpp
@@ -8,8 +8,8 @@ using namespace kuzu::storage;
 
 void CopyToParquetLocalState::init(CopyToInfo* info, storage::MemoryManager* mm,
     ResultSet* resultSet) {
-    auto copyToInfo = reinterpret_cast<CopyToParquetInfo*>(info);
-    ft = std::make_unique<FactorizedTable>(mm, std::move(copyToInfo->tableSchema));
+    auto copyToInfo = info->constPtrCast<CopyToParquetInfo>();
+    ft = std::make_unique<FactorizedTable>(mm, copyToInfo->tableSchema->copy());
     numTuplesInFT = 0;
     countingVec = nullptr;
     vectorsToAppend.reserve(info->dataPoses.size());

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -21,7 +21,6 @@
 #include "storage/index/in_mem_hash_index.h"
 #include "storage/storage_structure/disk_array.h"
 #include "transaction/transaction.h"
-#include <ranges>
 
 using namespace kuzu::common;
 using namespace kuzu::transaction;
@@ -573,7 +572,8 @@ void HashIndex<T>::mergeSlot(std::vector<HashIndexEntryView>& slotToMerge,
     // in the slot to merge
     Slot<T>* diskSlot = &*diskSlotIterator.seek(diskSlotId);
     // Merge slot from local storage to existing slot
-    for (const auto& entry : slotToMerge | std::views::reverse) {
+    for (auto it = std::rbegin(slotToMerge); it != std::rend(slotToMerge); ++it) {
+        const auto& entry = *it;
         if (entry.diskSlotId != diskSlotId) {
             return;
         }

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -70,3 +70,16 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database_destroy(database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }
+
+TEST_F(APIEmptyDBTest, CreationHomeDir) {
+    createDBAndConn();
+    printf("%s", conn->query("create node table person (id serial,  primary key(id));")
+                     ->toString()
+                     .c_str());
+    printf("%s",
+        conn->query("export database '/tmp/d23123' (format='parquet');")->toString().c_str());
+    conn->query("drop table person;");
+    printf("%s", conn->query("import database '/tmp/d23123';")->toString().c_str());
+    printf("%s", conn->query("match (p:person) return p.*;")->toString().c_str());
+    std::filesystem::remove_all("/tmp/d23123");
+}

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -70,16 +70,3 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database_destroy(database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }
-
-TEST_F(APIEmptyDBTest, CreationHomeDir) {
-    createDBAndConn();
-    printf("%s", conn->query("create node table person (id serial,  primary key(id));")
-                     ->toString()
-                     .c_str());
-    printf("%s",
-        conn->query("export database '/tmp/d23123' (format='parquet');")->toString().c_str());
-    conn->query("drop table person;");
-    printf("%s", conn->query("import database '/tmp/d23123';")->toString().c_str());
-    printf("%s", conn->query("match (p:person) return p.*;")->toString().c_str());
-    std::filesystem::remove_all("/tmp/d23123");
-}

--- a/test/test_files/copy/copy_large_serial.test
+++ b/test/test_files/copy/copy_large_serial.test
@@ -9,7 +9,7 @@
 -CASE ExportLargeSerial
 -STATEMENT EXPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_large-serial/serial' (format='parquet');
 ---- ok
--IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}/large-serial"
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_large-serial/serial"
 -STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_large-serial/serial';
 ---- ok
 -STATEMENT match (s:serialtable) where s.ID <> s.ID2 RETURN s LIMIT 10;

--- a/test/test_files/copy/copy_large_serial.test
+++ b/test/test_files/copy/copy_large_serial.test
@@ -5,3 +5,12 @@
 -CASE CopyLargeSerial
 -STATEMENT MATCH (a:serialtable) WHERE a.ID <> a.ID2 RETURN a LIMIT 10;
 ---- 0
+
+-CASE ExportLargeSerial
+-STATEMENT EXPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_large-serial/serial' (format='parquet');
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}/large-serial"
+-STATEMENT IMPORT DATABASE '${KUZU_EXPORT_DB_DIRECTORY}_large-serial/serial';
+---- ok
+-STATEMENT match (s:serialtable) where s.ID <> s.ID2 RETURN s LIMIT 10;
+---- 0

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -132,3 +132,36 @@ Imported database successfully.
 -STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_case6/demo-db"
 ---- 1
 Exported database successfully. But we skip exporting RDF graphs.
+
+-CASE ExportDatabaseWithSerialTable
+-STATEMENT CREATE NODE TABLE oneserial(ID serial, PRIMARY KEY(ID));
+---- ok
+-STATEMENT CREATE (o:oneserial)
+---- ok
+-STATEMENT CREATE (o:oneserial)
+---- ok
+-STATEMENT CREATE NODE TABLE twoserial(ID serial, prop STRING, PRIMARY KEY(ID));
+---- ok
+-STATEMENT CREATE (o:twoserial {prop: 'Alice'})
+---- ok
+-STATEMENT CREATE (o:twoserial {prop: 'Bob'})
+---- ok
+-STATEMENT CREATE (o:twoserial {prop: 'Carol'})
+---- ok
+-STATEMENT CREATE (o:twoserial {prop: 'Dan'})
+---- ok
+-STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_serial/serial-db"
+---- ok
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_serial"
+-STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_serial/serial-db"
+---- 1
+Imported database successfully.
+-STATEMENT MATCH (o:twoserial) RETURN o.*;
+---- 4
+0|Alice
+1|Bob
+2|Carol
+3|Dan
+-STATEMENT MATCH (o:oneserial) RETURN *;
+---- error
+Binder exception: Table oneserial does not exist.

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -150,10 +150,10 @@ Exported database successfully. But we skip exporting RDF graphs.
 ---- ok
 -STATEMENT CREATE (o:twoserial {prop: 'Dan'})
 ---- ok
--STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_serial/serial-db"
+-STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_case7/demo-db"
 ---- ok
--IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_serial"
--STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_serial/serial-db"
+-IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case7/demo-db"
+-STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case7/demo-db"
 ---- 1
 Imported database successfully.
 -STATEMENT MATCH (o:twoserial) RETURN o.*;


### PR DESCRIPTION
This PR fixes export database on nodetable with serial property:
1. If the node table only has one serial property, we are going to skip that table and kuzu is also going to output a warning message
2. If the node table contains other property other than the serial property, the import/export will work as expected.