### PR TITLE
Extend show_tables/table_info to attached databases

### DIFF
--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -52,6 +52,14 @@ Attached database successfully.
 -STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/duckdb/test/duckdb_database/other.db' as Other1 (dbtype 'duckdb');
 ---- 1
 Attached database successfully.
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 6
+movies|FOREIGN|tinysnb(DUCKDB)|
+organisation|FOREIGN|tinysnb(DUCKDB)|
+person|FOREIGN|Other1(DUCKDB)|
+person|FOREIGN|tinysnb(DUCKDB)|
+tableOfTypes1|FOREIGN|tinysnb(DUCKDB)|
+tableOfTypes|FOREIGN|tinysnb(DUCKDB)|
 -STATEMENT LOAD FROM other1.person RETURN *;
 ---- 4
 1

--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -93,6 +93,35 @@ Used database successfully.
 -STATEMENT LOAD FROM other1.person RETURN count(*);
 ---- 1
 4
+-STATEMENT CALL TABLE_INFO('other1.person') RETURN *;
+---- 1
+0|id|INT32
+-STATEMENT CALL TABLE_INFO('tinysnb.person') RETURN *;
+---- 16
+0|ID|INT64
+1|fName|STRING
+2|gender|INT64
+3|isStudent|BOOL
+4|isWorker|BOOL
+5|age|INT64
+6|eyeSight|DOUBLE
+7|birthdate|DATE
+8|registerTime|TIMESTAMP
+9|lastJobDuration|INTERVAL
+10|workedHours|INT64[]
+11|usedNames|STRING[]
+12|courseScoresPerTerm|INT64[][]
+13|height|FLOAT
+14|u|UUID
+15|grades|INT64[4]
+-LOG WrongTableName
+-STATEMENT CALL TABLE_INFO('tinysnb.personxx') RETURN *;
+---- error
+Catalog exception: Table: personxx does not exist.
+-LOG WrongCatalogName
+-STATEMENT CALL TABLE_INFO('tinysnbxx.person') RETURN *;
+---- error
+Runtime exception: Database: tinysnbxx doesn't exist.
 
 -CASE InvalidDuckDBDatabase
 -STATEMENT LOAD FROM tinysnb1.person RETURN *;

--- a/extension/postgres/test/test_files/postgres.test
+++ b/extension/postgres/test/test_files/postgres.test
@@ -50,3 +50,30 @@ The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie
 #---- error
 #Binder exception: Failed to attach postgres database due to: IO Error: Unable to connect to Postgres at dbname=test2132131 user=ci host=127.0.0.1: connection to server at "127.0.0.1", port 5432 failed: Connection refused
 #	Is the server running on that host and accepting TCP/IP connections?
+# Note: We use duckdb as an intermediate when scanning from postgres. When duckdb attaches postgres, it generates some
+# auxiliary tables to store type information in postgres. When the user calls show_tables(), those auxiliary tables will also
+# be displayed.
+-STATEMENT CALL SHOW_TABLES() RETURN *;
+---- 22
+audience_type|FOREIGN|pgscan(POSTGRES)|
+audience_type|FOREIGN|tinysnb(POSTGRES)|
+description_type|FOREIGN|pgscan(POSTGRES)|
+description_type|FOREIGN|tinysnb(POSTGRES)|
+movies_pkey|FOREIGN|pgscan(POSTGRES)|
+movies_pkey|FOREIGN|tinysnb(POSTGRES)|
+movies|FOREIGN|pgscan(POSTGRES)|
+movies|FOREIGN|tinysnb(POSTGRES)|
+organisation_pkey|FOREIGN|pgscan(POSTGRES)|
+organisation_pkey|FOREIGN|tinysnb(POSTGRES)|
+organisation|FOREIGN|pgscan(POSTGRES)|
+organisation|FOREIGN|tinysnb(POSTGRES)|
+person_pkey|FOREIGN|pgscan(POSTGRES)|
+person_pkey|FOREIGN|tinysnb(POSTGRES)|
+persontest|FOREIGN|pgscan(POSTGRES)|
+persontest|FOREIGN|tinysnb(POSTGRES)|
+person|FOREIGN|pgscan(POSTGRES)|
+person|FOREIGN|tinysnb(POSTGRES)|
+state_type|FOREIGN|pgscan(POSTGRES)|
+state_type|FOREIGN|tinysnb(POSTGRES)|
+stock_type|FOREIGN|pgscan(POSTGRES)|
+stock_type|FOREIGN|tinysnb(POSTGRES)|

--- a/extension/postgres/test/test_files/postgres.test
+++ b/extension/postgres/test/test_files/postgres.test
@@ -54,29 +54,15 @@ The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie
 # auxiliary tables to store type information in postgres. When the user calls show_tables(), those auxiliary tables will also
 # be displayed.
 -STATEMENT CALL SHOW_TABLES() RETURN *;
----- 22
-audience_type|FOREIGN|pgscan(POSTGRES)|
-audience_type|FOREIGN|tinysnb(POSTGRES)|
-description_type|FOREIGN|pgscan(POSTGRES)|
-description_type|FOREIGN|tinysnb(POSTGRES)|
-movies_pkey|FOREIGN|pgscan(POSTGRES)|
-movies_pkey|FOREIGN|tinysnb(POSTGRES)|
+---- 8
 movies|FOREIGN|pgscan(POSTGRES)|
 movies|FOREIGN|tinysnb(POSTGRES)|
-organisation_pkey|FOREIGN|pgscan(POSTGRES)|
-organisation_pkey|FOREIGN|tinysnb(POSTGRES)|
 organisation|FOREIGN|pgscan(POSTGRES)|
 organisation|FOREIGN|tinysnb(POSTGRES)|
-person_pkey|FOREIGN|pgscan(POSTGRES)|
-person_pkey|FOREIGN|tinysnb(POSTGRES)|
 persontest|FOREIGN|pgscan(POSTGRES)|
 persontest|FOREIGN|tinysnb(POSTGRES)|
 person|FOREIGN|pgscan(POSTGRES)|
 person|FOREIGN|tinysnb(POSTGRES)|
-state_type|FOREIGN|pgscan(POSTGRES)|
-state_type|FOREIGN|tinysnb(POSTGRES)|
-stock_type|FOREIGN|pgscan(POSTGRES)|
-stock_type|FOREIGN|tinysnb(POSTGRES)|
 
 -STATEMENT CALL TABLE_INFO('pgscan.person') RETURN *;
 ---- 14

--- a/extension/postgres/test/test_files/postgres.test
+++ b/extension/postgres/test/test_files/postgres.test
@@ -77,3 +77,20 @@ state_type|FOREIGN|pgscan(POSTGRES)|
 state_type|FOREIGN|tinysnb(POSTGRES)|
 stock_type|FOREIGN|pgscan(POSTGRES)|
 stock_type|FOREIGN|tinysnb(POSTGRES)|
+
+-STATEMENT CALL TABLE_INFO('pgscan.person') RETURN *;
+---- 14
+0|id|INT64
+1|fname|STRING
+2|gender|INT64
+3|isstudent|BOOL
+4|isworker|BOOL
+5|age|INT64
+6|eyesight|DOUBLE
+7|birthdate|DATE
+8|registertime|TIMESTAMP
+9|lastjobduration|INTERVAL
+10|workedhours|INT64[]
+11|usednames|STRING[]
+12|height|DOUBLE
+13|u|UUID

--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -102,7 +102,7 @@ static bool bindExportQuery(ExportedTableData& tableData, std::string& exportQue
 
 bool Binder::bindExportTableData(ExportedTableData& tableData, const TableCatalogEntry& entry,
     const Catalog& catalog, transaction::Transaction* tx) {
-    if (catalog.tableInRDFGraph(tx, entry->getTableID())) {
+    if (catalog.tableInRDFGraph(tx, entry.getTableID())) {
         return false;
     }
     std::string exportQuery;

--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -31,7 +31,7 @@ static std::vector<ExportedTableData> getExportInfo(const Catalog& catalog, Tran
     std::vector<ExportedTableData> exportData;
     for (auto tableEntry : catalog.getTableEntries(tx)) {
         ExportedTableData tableData;
-        if (binder->bindExportTableData(tableData, tableEntry, catalog, tx)) {
+        if (binder->bindExportTableData(tableData, *tableEntry, catalog, tx)) {
             exportData.push_back(std::move(tableData));
         }
     }
@@ -53,27 +53,27 @@ FileType getFileType(std::unordered_map<std::string, common::Value>& options) {
     return fileType;
 }
 
-static bool bindExportNodeTableDataQuery(ExportedTableData& tableData, TableCatalogEntry* entry,
-    std::string& exportQuery) {
-    exportQuery = stringFormat("match (a:{}) return ", entry->getName());
-    for (auto i = 0u; i < entry->getNumProperties(); i++) {
-        auto& prop = entry->getPropertiesRef()[i];
+static bool bindExportNodeTableDataQuery(ExportedTableData& tableData,
+    const TableCatalogEntry& entry, std::string& exportQuery) {
+    exportQuery = stringFormat("match (a:{}) return ", entry.getName());
+    for (auto i = 0u; i < entry.getNumProperties(); i++) {
+        auto& prop = entry.getPropertiesRef()[i];
         if (prop.getDataType()->getLogicalTypeID() == LogicalTypeID::SERIAL) {
-            if (entry->getNumProperties() == 1) {
+            if (entry.getNumProperties() == 1) {
                 return false;
             }
             tableData.canParallel = false;
             continue;
         }
         exportQuery += stringFormat("a.{}", prop.getName());
-        exportQuery += i == entry->getNumProperties() - 1 ? " " : ",";
+        exportQuery += i == entry.getNumProperties() - 1 ? " " : ",";
     }
     return true;
 }
 
-static void bindExportRelTableDataQuery(TableCatalogEntry* entry, std::string& exportQuery,
+static void bindExportRelTableDataQuery(const TableCatalogEntry& entry, std::string& exportQuery,
     const catalog::Catalog& catalog, transaction::Transaction* tx) {
-    auto relTableEntry = entry->constPtrCast<RelTableCatalogEntry>();
+    auto relTableEntry = entry.constPtrCast<RelTableCatalogEntry>();
     auto srcPrimaryKeyName = getPrimaryKeyName(relTableEntry->getSrcTableID(), catalog, tx);
     auto dstPrimaryKeyName = getPrimaryKeyName(relTableEntry->getDstTableID(), catalog, tx);
     auto srcName = catalog.getTableName(tx, relTableEntry->getSrcTableID());
@@ -84,8 +84,8 @@ static void bindExportRelTableDataQuery(TableCatalogEntry* entry, std::string& e
 }
 
 static bool bindExportQuery(ExportedTableData& tableData, std::string& exportQuery,
-    TableCatalogEntry* entry, const Catalog& catalog, transaction::Transaction* tx) {
-    switch (entry->getTableType()) {
+    const TableCatalogEntry& entry, const Catalog& catalog, transaction::Transaction* tx) {
+    switch (entry.getTableType()) {
     case common::TableType::NODE: {
         if (!bindExportNodeTableDataQuery(tableData, entry, exportQuery)) {
             return false;
@@ -100,14 +100,14 @@ static bool bindExportQuery(ExportedTableData& tableData, std::string& exportQue
     return true;
 }
 
-bool Binder::bindExportTableData(ExportedTableData& tableData, TableCatalogEntry* entry,
+bool Binder::bindExportTableData(ExportedTableData& tableData, const TableCatalogEntry& entry,
     const Catalog& catalog, transaction::Transaction* tx) {
     if (catalog.tableInRDFGraph(tx, entry->getTableID())) {
         return false;
     }
     std::string exportQuery;
     tableData.canParallel = true;
-    tableData.tableName = entry->getName();
+    tableData.tableName = entry.getName();
     if (!bindExportQuery(tableData, exportQuery, entry, catalog, tx)) {
         return false;
     }

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -85,12 +85,8 @@ std::vector<RDFGraphCatalogEntry*> Catalog::getRdfGraphEntries(Transaction* tx) 
         CatalogEntryType::RDF_GRAPH_ENTRY);
 }
 
-std::vector<TableCatalogEntry*> Catalog::getTableEntries(Transaction* tx) const {
-    std::vector<TableCatalogEntry*> result;
-    for (auto& [_, entry] : getVersion(tx)->tables->getEntries()) {
-        result.push_back(ku_dynamic_cast<CatalogEntry*, TableCatalogEntry*>(entry.get()));
-    }
-    return result;
+std::vector<const TableCatalogEntry*> Catalog::getTableEntries(Transaction* tx) const {
+    return getVersion(tx)->getTableEntries();
 }
 
 std::vector<TableCatalogEntry*> Catalog::getTableSchemas(Transaction* tx,

--- a/src/catalog/catalog_content.cpp
+++ b/src/catalog/catalog_content.cpp
@@ -280,6 +280,14 @@ function::ScalarMacroFunction* CatalogContent::getScalarMacroFunction(
         ->getMacroFunction();
 }
 
+std::vector<const TableCatalogEntry*> CatalogContent::getTableEntries() const {
+    std::vector<const TableCatalogEntry*> result;
+    for (auto& [_, entry] : tables->getEntries()) {
+        result.push_back(entry->constPtrCast<TableCatalogEntry>());
+    }
+    return result;
+}
+
 std::unique_ptr<CatalogContent> CatalogContent::copy() const {
     return std::make_unique<CatalogContent>(tables->copy(), nextTableID, functions->copy());
 }

--- a/src/common/enums/table_type.cpp
+++ b/src/common/enums/table_type.cpp
@@ -22,6 +22,9 @@ std::string TableTypeUtils::toString(TableType tableType) {
     case TableType::REL_GROUP: {
         return "REL_GROUP";
     }
+    case TableType::FOREIGN: {
+        return "FOREIGN";
+    }
     default:
         KU_UNREACHABLE;
     }

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -67,7 +67,6 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     std::vector<TableInfo> tableInfos;
     auto localDatabaseName = "local(kuzu)";
     for (auto& entry : context->getCatalog()->getTableEntries(context->getTx())) {
-        // auto tableType =;
         auto tableInfo =
             TableInfo{entry->getName(), TableTypeUtils::toString(entry->getTableType()),
                 localDatabaseName, entry->getComment()};

--- a/src/function/table/call/show_tables.cpp
+++ b/src/function/table/call/show_tables.cpp
@@ -1,6 +1,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
 #include "function/table/call_functions.h"
+#include "main/database_manager.h"
 
 using namespace kuzu::common;
 using namespace kuzu::catalog;
@@ -8,15 +9,26 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace function {
 
-struct ShowTablesBindData : public CallTableFuncBindData {
-    std::vector<TableCatalogEntry*> tables;
+struct TableInfo {
+    std::string name;
+    std::string type;
+    std::string databaseName;
+    std::string comment;
 
-    ShowTablesBindData(std::vector<TableCatalogEntry*> tables, std::vector<LogicalType> returnTypes,
+    TableInfo(std::string name, std::string type, std::string databaseName, std::string comment)
+        : name{std::move(name)}, type{std::move(type)}, databaseName{std::move(databaseName)},
+          comment{std::move(comment)} {}
+};
+
+struct ShowTablesBindData : public CallTableFuncBindData {
+    std::vector<TableInfo> tables;
+
+    ShowTablesBindData(std::vector<TableInfo> tables, std::vector<LogicalType> returnTypes,
         std::vector<std::string> returnColumnNames, offset_t maxOffset)
         : CallTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
           tables{std::move(tables)} {}
 
-    inline std::unique_ptr<TableFuncBindData> copy() const override {
+    std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<ShowTablesBindData>(tables, columnTypes, columnNames, maxOffset);
     }
 };
@@ -31,11 +43,11 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     auto tables = input.bindData->constPtrCast<ShowTablesBindData>()->tables;
     auto numTablesToOutput = morsel.endOffset - morsel.startOffset;
     for (auto i = 0u; i < numTablesToOutput; i++) {
-        auto tableEntry = tables[morsel.startOffset + i];
-        dataChunk.getValueVector(0)->setValue(i, tableEntry->getName());
-        std::string typeString = TableTypeUtils::toString(tableEntry->getTableType());
-        dataChunk.getValueVector(1)->setValue(i, typeString);
-        dataChunk.getValueVector(2)->setValue(i, tableEntry->getComment());
+        auto tableInfo = tables[morsel.startOffset + i];
+        dataChunk.getValueVector(0)->setValue(i, tableInfo.name);
+        dataChunk.getValueVector(1)->setValue(i, tableInfo.type);
+        dataChunk.getValueVector(2)->setValue(i, tableInfo.databaseName);
+        dataChunk.getValueVector(3)->setValue(i, tableInfo.comment);
     }
     return numTablesToOutput;
 }
@@ -48,12 +60,33 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     columnTypes.emplace_back(*LogicalType::STRING());
     columnNames.emplace_back("type");
     columnTypes.emplace_back(*LogicalType::STRING());
+    columnNames.emplace_back("database name");
+    columnTypes.emplace_back(*LogicalType::STRING());
     columnNames.emplace_back("comment");
     columnTypes.emplace_back(*LogicalType::STRING());
-    auto tableEntries = context->getCatalog()->getTableEntries(context->getTx());
-    auto numTables = context->getCatalog()->getTableCount(context->getTx());
-    return std::make_unique<ShowTablesBindData>(std::move(tableEntries), std::move(columnTypes),
-        std::move(columnNames), numTables);
+    std::vector<TableInfo> tableInfos;
+    auto localDatabaseName = "local(kuzu)";
+    for (auto& entry : context->getCatalog()->getTableEntries(context->getTx())) {
+        // auto tableType =;
+        auto tableInfo =
+            TableInfo{entry->getName(), TableTypeUtils::toString(entry->getTableType()),
+                localDatabaseName, entry->getComment()};
+        tableInfos.push_back(std::move(tableInfo));
+    }
+
+    auto databaseManager = context->getDatabaseManager();
+    for (auto attachedDatabase : databaseManager->getAttachedDatabases()) {
+        auto databaseName = attachedDatabase->getDBName();
+        auto databaseType = attachedDatabase->getDBType();
+        for (auto& entry : attachedDatabase->getCatalog()->getTableEntries()) {
+            auto tableInfo =
+                TableInfo{entry->getName(), TableTypeUtils::toString(entry->getTableType()),
+                    stringFormat("{}({})", databaseName, databaseType), entry->getComment()};
+            tableInfos.push_back(std::move(tableInfo));
+        }
+    }
+    return std::make_unique<ShowTablesBindData>(std::move(tableInfos), std::move(columnTypes),
+        std::move(columnNames), tableInfos.size());
 }
 
 function_set ShowTablesFunction::getFunctionSet() {

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -18,7 +18,7 @@ struct TableInfoBindData : public CallTableFuncBindData {
         : CallTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
           tableEntry{tableEntry} {}
 
-    inline std::unique_ptr<TableFuncBindData> copy() const override {
+    std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<TableInfoBindData>(tableEntry, columnTypes, columnNames, maxOffset);
     }
 };

--- a/src/function/table/call/table_info.cpp
+++ b/src/function/table/call/table_info.cpp
@@ -1,8 +1,11 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
+#include "common/exception/runtime.h"
 #include "common/keyword/rdf_keyword.h"
+#include "common/string_utils.h"
 #include "function/table/bind_input.h"
 #include "function/table/call_functions.h"
+#include "main/database_manager.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -11,15 +14,17 @@ namespace kuzu {
 namespace function {
 
 struct TableInfoBindData : public CallTableFuncBindData {
-    TableCatalogEntry* tableEntry;
+    std::unique_ptr<CatalogEntry> catalogEntry;
 
-    TableInfoBindData(TableCatalogEntry* tableEntry, std::vector<LogicalType> returnTypes,
-        std::vector<std::string> returnColumnNames, offset_t maxOffset)
+    TableInfoBindData(std::unique_ptr<CatalogEntry> catalogEntry,
+        std::vector<LogicalType> returnTypes, std::vector<std::string> returnColumnNames,
+        offset_t maxOffset)
         : CallTableFuncBindData{std::move(returnTypes), std::move(returnColumnNames), maxOffset},
-          tableEntry{tableEntry} {}
+          catalogEntry{std::move(catalogEntry)} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
-        return std::make_unique<TableInfoBindData>(tableEntry, columnTypes, columnNames, maxOffset);
+        return std::make_unique<TableInfoBindData>(catalogEntry->copy(), columnTypes, columnNames,
+            maxOffset);
     }
 };
 
@@ -31,7 +36,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
         return 0;
     }
     auto bindData = input.bindData->constPtrCast<TableInfoBindData>();
-    auto tableEntry = bindData->tableEntry;
+    auto tableEntry = bindData->catalogEntry->constPtrCast<TableCatalogEntry>();
     auto numPropertiesToOutput = morsel.endOffset - morsel.startOffset;
     auto vectorPos = 0;
     for (auto i = 0u; i < numPropertiesToOutput; i++) {
@@ -56,8 +61,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
         dataChunk.getValueVector(2)->setValue(vectorPos, property->getDataType()->toString());
 
         if (tableEntry->getTableType() == TableType::NODE) {
-            auto nodeTableEntry =
-                ku_dynamic_cast<TableCatalogEntry*, NodeTableCatalogEntry*>(tableEntry);
+            auto nodeTableEntry = tableEntry->constPtrCast<NodeTableCatalogEntry>();
             auto primaryKeyID = nodeTableEntry->getPrimaryKeyPID();
             dataChunk.getValueVector(3)->setValue(vectorPos,
                 primaryKeyID == property->getPropertyID());
@@ -67,13 +71,31 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
     return vectorPos;
 }
 
+static std::unique_ptr<CatalogEntry> getTableCatalogEntry(main::ClientContext* context,
+    const std::string& tableName) {
+    auto tableInfo = common::StringUtils::split(tableName, ".");
+    if (tableInfo.size() == 1) {
+        auto tableID = context->getCatalog()->getTableID(context->getTx(), tableName);
+        return context->getCatalog()->getTableCatalogEntry(context->getTx(), tableID)->copy();
+    } else {
+        auto catalogName = tableInfo[0];
+        auto attachedTableName = tableInfo[1];
+        auto attachedDatabase = context->getDatabaseManager()->getAttachedDatabase(catalogName);
+        if (attachedDatabase == nullptr) {
+            throw common::RuntimeException{
+                common::stringFormat("Database: {} doesn't exist.", catalogName)};
+        }
+        auto tableID = attachedDatabase->getCatalog()->getTableID(attachedTableName);
+        return attachedDatabase->getCatalog()->getTableCatalogEntry(tableID)->copy();
+    }
+}
+
 static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
     TableFuncBindInput* input) {
     std::vector<std::string> columnNames;
     std::vector<LogicalType> columnTypes;
-    auto tableName = input->inputs[0].getValue<std::string>();
-    auto tableID = context->getCatalog()->getTableID(context->getTx(), tableName);
-    auto tableEntry = context->getCatalog()->getTableCatalogEntry(context->getTx(), tableID);
+    auto catalogEntry = getTableCatalogEntry(context, input->inputs[0].getValue<std::string>());
+    auto tableEntry = catalogEntry->constPtrCast<TableCatalogEntry>();
     columnNames.emplace_back("property id");
     columnTypes.push_back(*LogicalType::INT64());
     columnNames.emplace_back("name");
@@ -84,7 +106,7 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
         columnNames.emplace_back("primary key");
         columnTypes.push_back(*LogicalType::BOOL());
     }
-    return std::make_unique<TableInfoBindData>(tableEntry, std::move(columnTypes),
+    return std::make_unique<TableInfoBindData>(std::move(catalogEntry), std::move(columnTypes),
         std::move(columnNames), tableEntry->getNumProperties());
 }
 

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -72,7 +72,7 @@ public:
 
     static std::unique_ptr<common::LogicalType> bindDataType(const std::string& dataType);
 
-    bool bindExportTableData(ExportedTableData& tableData, catalog::TableCatalogEntry* entry,
+    bool bindExportTableData(ExportedTableData& tableData, const catalog::TableCatalogEntry& entry,
         const catalog::Catalog& catalog, transaction::Transaction* tx);
 
 private:

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -46,7 +46,7 @@ public:
     std::vector<RelTableCatalogEntry*> getRelTableEntries(transaction::Transaction* tx) const;
     std::vector<RelGroupCatalogEntry*> getRelTableGroupEntries(transaction::Transaction* tx) const;
     std::vector<RDFGraphCatalogEntry*> getRdfGraphEntries(transaction::Transaction* tx) const;
-    std::vector<TableCatalogEntry*> getTableEntries(transaction::Transaction* tx) const;
+    std::vector<const TableCatalogEntry*> getTableEntries(transaction::Transaction* tx) const;
     std::vector<TableCatalogEntry*> getTableSchemas(transaction::Transaction* tx,
         const common::table_id_vector_t& tableIDs) const;
     bool tableInRDFGraph(transaction::Transaction* tx, common::table_id_t tableID) const;

--- a/src/include/catalog/catalog_content.h
+++ b/src/include/catalog/catalog_content.h
@@ -36,13 +36,12 @@ public:
 
     common::table_id_t getTableID(const std::string& tableName) const;
     CatalogEntry* getTableCatalogEntry(common::table_id_t tableID) const;
+    std::vector<const TableCatalogEntry*> getTableEntries() const;
 
     void saveToFile(const std::string& directory, common::FileVersionType dbFileType,
         common::VirtualFileSystem* fs);
     void readFromFile(const std::string& directory, common::FileVersionType dbFileType,
         common::VirtualFileSystem* fs);
-
-    std::vector<const TableCatalogEntry*> getTableEntries() const;
 
     std::unique_ptr<CatalogContent> copy() const;
 

--- a/src/include/catalog/catalog_content.h
+++ b/src/include/catalog/catalog_content.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "catalog/catalog_entry/table_catalog_entry.h"
 #include "catalog/catalog_set.h"
 #include "common/cast.h"
 
@@ -40,6 +41,8 @@ public:
         common::VirtualFileSystem* fs);
     void readFromFile(const std::string& directory, common::FileVersionType dbFileType,
         common::VirtualFileSystem* fs);
+
+    std::vector<const TableCatalogEntry*> getTableEntries() const;
 
     std::unique_ptr<CatalogContent> copy() const;
 

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -261,7 +261,7 @@ ge38f9dc-f751-4174-8b8b-ec9a1b6gab83|
 ---- ok
 -STATEMENT CALL SHOW_TABLES() WHERE true RETURN *;
 ---- 1
-T|NODE|
+T|NODE|local(kuzu)|
 -STATEMENT CALL SHOW_TABLES() WHERE false RETURN *;
 ---- 0
 

--- a/test/test_files/rdf/patch.test
+++ b/test/test_files/rdf/patch.test
@@ -11,12 +11,12 @@
 ---- ok
 -STATEMENT CALL show_tables() RETURN *;
 ---- 6
-N|NODE|
-X_lt|REL|
-X_l|NODE|
-X_rt|REL|
-X_r|NODE|
-X|RDFGraph|
+N|NODE|local(kuzu)|
+X_lt|REL|local(kuzu)|
+X_l|NODE|local(kuzu)|
+X_rt|REL|local(kuzu)|
+X_r|NODE|local(kuzu)|
+X|RDFGraph|local(kuzu)|
 -STATEMENT CALL table_info("X_r") RETURN *;
 ---- 1
 0|iri|STRING|True

--- a/test/test_files/rdf/rdf_update.test
+++ b/test/test_files/rdf/rdf_update.test
@@ -8,11 +8,11 @@
 ---- ok
 -STATEMENT CALL show_tables() RETURN *;
 ---- 5
-T_lt|REL|
-T_l|NODE|
-T_rt|REL|
-T_r|NODE|
-T|RDFGraph|
+T_lt|REL|local(kuzu)|
+T_l|NODE|local(kuzu)|
+T_rt|REL|local(kuzu)|
+T_r|NODE|local(kuzu)|
+T|RDFGraph|local(kuzu)|
 -STATEMENT DROP RDFGraph T;
 ---- ok
 -STATEMENT CALL show_tables() RETURN *;
@@ -24,11 +24,11 @@ T|RDFGraph|
 ---- ok
 -STATEMENT CALL show_tables() RETURN *;
 ---- 5
-X_lt|REL|
-X_l|NODE|
-X_rt|REL|
-X_r|NODE|
-X|RDFGraph|
+X_lt|REL|local(kuzu)|
+X_l|NODE|local(kuzu)|
+X_rt|REL|local(kuzu)|
+X_r|NODE|local(kuzu)|
+X|RDFGraph|local(kuzu)|
 -STATEMENT MATCH (a:T)-[e:T]->(b:T) RETURN COUNT(*);
 ---- error
 Binder exception: Table T does not exist.

--- a/test/test_files/rdf/rdfox_example.test
+++ b/test/test_files/rdf/rdfox_example.test
@@ -58,11 +58,11 @@ x|c||hh
 -CASE Basic
 -STATEMENT CALL SHOW_TABLES() RETURN *;
 ---- 5
-example_lt|REL|
-example_l|NODE|
-example_rt|REL|
-example_r|NODE|
-example|RDFGraph|
+example_lt|REL|local(kuzu)|
+example_l|NODE|local(kuzu)|
+example_rt|REL|local(kuzu)|
+example_r|NODE|local(kuzu)|
+example|RDFGraph|local(kuzu)|
 
 -STATEMENT MATCH (s:example_r) RETURN s.iri ORDER BY offset(id(s));
 ---- 16

--- a/test/test_files/tinysnb/comment/comment.test
+++ b/test/test_files/tinysnb/comment/comment.test
@@ -16,24 +16,24 @@ Table knows comment updated.
 
 -STATEMENT CALL show_tables() RETURN *
 ---- 8
-marries|REL|
-workAt|REL|
-knows|REL|Another test comment
-organisation|NODE|
-person|NODE|A test comment
-movies|NODE|
-studyAt|REL|
-meets|REL|
+marries|REL|local(kuzu)|
+workAt|REL|local(kuzu)|
+knows|REL|local(kuzu)|Another test comment
+organisation|NODE|local(kuzu)|
+person|NODE|local(kuzu)|A test comment
+movies|NODE|local(kuzu)|
+studyAt|REL|local(kuzu)|
+meets|REL|local(kuzu)|
 
 -STATEMENT COMMIT
 
 -STATEMENT CALL show_tables() RETURN *
 ---- 8
-marries|REL|
-workAt|REL|
-knows|REL|Another test comment
-organisation|NODE|
-person|NODE|A test comment
-movies|NODE|
-studyAt|REL|
-meets|REL|
+marries|REL|local(kuzu)|
+workAt|REL|local(kuzu)|
+knows|REL|local(kuzu)|Another test comment
+organisation|NODE|local(kuzu)|
+person|NODE|local(kuzu)|A test comment
+movies|NODE|local(kuzu)|
+studyAt|REL|local(kuzu)|
+meets|REL|local(kuzu)|

--- a/test/test_files/tinysnb/rel_group/basic.test
+++ b/test/test_files/tinysnb/rel_group/basic.test
@@ -39,26 +39,26 @@ Binder exception: Cannot copy into knows table with type REL_GROUP.
 Binder exception: Cannot delete relationship table knows_personA_personB because it is referenced by relationship group knows.
 -STATEMENT CALL show_tables() RETURN *;
 ---- 10
-knows_personA_personB|REL|
-knows_personA_personC|REL|
-knows_personB_personC|REL|
-knows|REL_GROUP|
-likes_personA_personB|REL|
-likes_personB_personA|REL|
-likes|REL_GROUP|
-personA|NODE|
-personB|NODE|
-personC|NODE|
+knows_personA_personB|REL|local(kuzu)|
+knows_personA_personC|REL|local(kuzu)|
+knows_personB_personC|REL|local(kuzu)|
+knows|REL_GROUP|local(kuzu)|
+likes_personA_personB|REL|local(kuzu)|
+likes_personB_personA|REL|local(kuzu)|
+likes|REL_GROUP|local(kuzu)|
+personA|NODE|local(kuzu)|
+personB|NODE|local(kuzu)|
+personC|NODE|local(kuzu)|
 -STATEMENT DROP TABLE knows;
 ---- ok
 -STATEMENT CALL show_tables() RETURN *;
 ---- 6
-likes_personA_personB|REL|
-likes_personB_personA|REL|
-likes|REL_GROUP|
-personA|NODE|
-personB|NODE|
-personC|NODE|
+likes_personA_personB|REL|local(kuzu)|
+likes_personB_personA|REL|local(kuzu)|
+likes|REL_GROUP|local(kuzu)|
+personA|NODE|local(kuzu)|
+personB|NODE|local(kuzu)|
+personC|NODE|local(kuzu)|
 -STATEMENT MATCH (a:personA)-[e:knows]->(b) RETURN COUNT(*)
 ---- error
 Binder exception: Table knows does not exist.
@@ -71,12 +71,12 @@ Binder exception: Table knows_personA_personB does not exist.
 ---- ok
 -STATEMENT CALL show_tables() RETURN *;
 ---- 6
-likes_A_B|REL|
-likes_personB_personA|REL|
-hates|REL_GROUP|
-personA|NODE|
-personB|NODE|
-personC|NODE|
+likes_A_B|REL|local(kuzu)|
+likes_personB_personA|REL|local(kuzu)|
+hates|REL_GROUP|local(kuzu)|
+personA|NODE|local(kuzu)|
+personB|NODE|local(kuzu)|
+personC|NODE|local(kuzu)|
 -STATEMENT MATCH (a:personA)-[e:hates]->(b:personB) WHERE a.ID = 0 RETURN label(e), label(b), b.*
 ---- 3
 likes_A_B|personB|2|Bob


### PR DESCRIPTION
This PR extends show_tables()/table_info() call functions to all attached databases.
SHOW_TABLES(): can now show tables in attached databases.
TABLE_INFO(): can now take in an attached database name. 