### PR TITLE
Remove unnecessary calls to WAL::flushAllPages and clear the dirty flag when flushing pages

### DIFF
--- a/src/include/processor/operator/persistent/batch_insert.h
+++ b/src/include/processor/operator/persistent/batch_insert.h
@@ -44,10 +44,7 @@ struct BatchInsertSharedState {
     }
     inline common::row_idx_t getNumRows() { return numRows.load(); }
     // NOLINTNEXTLINE(readability-make-member-function-const): Semantically non-const.
-    inline void logBatchInsertWALRecord() {
-        wal->logCopyTableRecord(table->getTableID());
-        wal->flushAllPages();
-    }
+    inline void logBatchInsertWALRecord() { wal->logCopyTableRecord(table->getTableID()); }
     inline void updateNumTuplesForTable() { table->updateNumTuplesByValue(getNumRows()); }
 };
 

--- a/src/include/storage/buffer_manager/bm_file_handle.h
+++ b/src/include/storage/buffer_manager/bm_file_handle.h
@@ -80,6 +80,9 @@ public:
         KU_ASSERT(getState(stateAndVersion.load()) == LOCKED);
         stateAndVersion &= ~DIRTY_MASK;
     }
+    // Meant to be used when flushing in a single thread.
+    // Should not be used if other threads are modifying the page state
+    inline void clearDirtyWithoutLock() { stateAndVersion &= ~DIRTY_MASK; }
     inline bool isDirty() const { return stateAndVersion & DIRTY_MASK; }
     uint64_t getStateAndVersion() const { return stateAndVersion.load(); }
 

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -217,8 +217,8 @@ void Database::commit(Transaction* transaction, bool skipCheckpointForTestingRec
     // Note: committing and stopping new transactions can be done in any order. This
     // order allows us to throw exceptions if we have to wait a lot to stop.
     transactionManager->commitButKeepActiveWriteTransaction(transaction);
-    wal->flushAllPages();
     if (skipCheckpointForTestingRecovery) {
+        wal->flushAllPages();
         transactionManager->allowReceivingNewTransactions();
         return;
     }

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -237,8 +237,6 @@ void NodeBatchInsert::finalize(ExecutionContext* context) {
     if (nodeSharedState->globalIndexBuilder) {
         nodeSharedState->globalIndexBuilder->finalize(context);
     }
-    // Batch Insert wal record needs to be logged after PrimaryKeyIndex::prepareCommit
-    // so that the wal pages get flushed before the index is re-initialized.
     sharedState->logBatchInsertWALRecord();
     auto outputMsg = stringFormat("{} tuples have been copied to the {} table.",
         sharedState->getNumRows(), info->tableEntry->getName());

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -322,6 +322,7 @@ void BufferManager::flushIfDirtyWithoutLock(BMFileHandle& fileHandle, page_idx_t
     if (pageState->isDirty()) {
         fileHandle.getFileInfo()->writeFile(getFrame(fileHandle, pageIdx), fileHandle.getPageSize(),
             pageIdx * fileHandle.getPageSize());
+        pageState->clearDirtyWithoutLock();
     }
 }
 


### PR DESCRIPTION
Flushing the WAL after COPY NODE is no longer necessary since the primary key index is no longer reloaded from disk afterwards.

Flushing in `Database::commit` is only necessary when skipping checkpointing since it also occurs during checkpointing prior to the WAL replay.

Additionally, this appears to fix an issue I mentioned in #3403, where small copies and inserts after doing a large copy take extra time. I'm fairly sure, though I haven't actually confirmed, that it was caused by bypassing the WAL file and writing directly to the hash index file, flushing the hash index file in `PrimaryKeyIndex::prepareCommit`, but neither evicting nor clearing the dirty flags on the hash index file. Presumably subsequent flushes end up flushing the previously modified pages again since they are all still marked dirty.