### PR TITLE
Avoid modifying vector in HashIndex::mergeSlot when iterating

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -134,7 +134,8 @@ private:
     void sortEntries(typename InMemHashIndex<T>::SlotIterator& slotToMerge,
         std::vector<HashIndexEntryView>& partitions);
     void mergeBulkInserts();
-    void mergeSlot(std::vector<HashIndexEntryView>& slotToMerge,
+    // Returns the number of elements merged which matched the given slot id
+    size_t mergeSlot(const std::vector<HashIndexEntryView>& slotToMerge,
         typename BaseDiskArray<Slot<T>>::WriteIterator& diskSlotIterator,
         typename BaseDiskArray<Slot<T>>::WriteIterator& diskOverflowSlotIterator, slot_id_t slotId);
 


### PR DESCRIPTION
It's probably implementation dependent, but `std::vector::pop_back` will invalidate iterators, even if removing from the back when iterating backwards is safe. This is triggering an assertion in MSVC in debug mode. I've changed it to track how many need to be removed and to remove the elements afterwards.

I also removed the `auto entry = *it;` part; `entry` was already overloaded since the `HashIndexEntryView` has an entry field, and if we're now using an iterator instead of a for each anyway.