### PR TITLE
Replace const pointer with const reference in type functions

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -76,10 +76,10 @@ static void extraFieldFromStructType(const LogicalType& structType,
     std::unordered_set<std::string>& nameSet, std::vector<std::string>& names,
     std::vector<std::unique_ptr<LogicalType>>& types) {
     for (auto& field : StructType::getFields(structType)) {
-        if (!nameSet.contains(field->getName())) {
-            nameSet.insert(field->getName());
-            names.push_back(field->getName());
-            types.push_back(field->getType()->copy());
+        if (!nameSet.contains(field.getName())) {
+            nameSet.insert(field.getName());
+            names.push_back(field.getName());
+            types.push_back(field.getType().copy());
         }
     }
 }

--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -75,7 +75,7 @@ static std::unique_ptr<LogicalType> getRecursiveRelLogicalType(const LogicalType
 static void extraFieldFromStructType(const LogicalType& structType,
     std::unordered_set<std::string>& nameSet, std::vector<std::string>& names,
     std::vector<std::unique_ptr<LogicalType>>& types) {
-    for (auto& field : StructType::getFields(&structType)) {
+    for (auto& field : StructType::getFields(structType)) {
         if (!nameSet.contains(field->getName())) {
             nameSet.insert(field->getName());
             names.push_back(field->getName());

--- a/src/binder/bind/read/bind_unwind.cpp
+++ b/src/binder/bind/read/bind_unwind.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindUnwindClause(const ReadingClause
     auto aliasName = unwindClause.getAlias();
     std::shared_ptr<Expression> alias;
     if (boundExpression->getDataType().getLogicalTypeID() == LogicalTypeID::ARRAY) {
-        auto targetType = LogicalType::LIST(*ArrayType::getChildType(&boundExpression->dataType));
+        auto targetType = LogicalType::LIST(*ArrayType::getChildType(boundExpression->dataType));
         boundExpression = expressionBinder.implicitCast(boundExpression, *targetType);
     }
     if (!skipDataTypeValidation(*boundExpression)) {

--- a/src/binder/bind/read/bind_unwind.cpp
+++ b/src/binder/bind/read/bind_unwind.cpp
@@ -21,12 +21,12 @@ std::unique_ptr<BoundReadingClause> Binder::bindUnwindClause(const ReadingClause
     auto aliasName = unwindClause.getAlias();
     std::shared_ptr<Expression> alias;
     if (boundExpression->getDataType().getLogicalTypeID() == LogicalTypeID::ARRAY) {
-        auto targetType = LogicalType::LIST(*ArrayType::getChildType(boundExpression->dataType));
+        auto targetType = LogicalType::LIST(ArrayType::getChildType(boundExpression->dataType));
         boundExpression = expressionBinder.implicitCast(boundExpression, *targetType);
     }
     if (!skipDataTypeValidation(*boundExpression)) {
         ExpressionUtil::validateDataType(*boundExpression, LogicalTypeID::LIST);
-        alias = createVariable(aliasName, *ListType::getChildType(boundExpression->dataType));
+        alias = createVariable(aliasName, ListType::getChildType(boundExpression->dataType));
     } else {
         alias = createVariable(aliasName, *LogicalType::ANY());
     }

--- a/src/binder/bind/read/bind_unwind.cpp
+++ b/src/binder/bind/read/bind_unwind.cpp
@@ -26,7 +26,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindUnwindClause(const ReadingClause
     }
     if (!skipDataTypeValidation(*boundExpression)) {
         ExpressionUtil::validateDataType(*boundExpression, LogicalTypeID::LIST);
-        alias = createVariable(aliasName, *ListType::getChildType(&boundExpression->dataType));
+        alias = createVariable(aliasName, *ListType::getChildType(boundExpression->dataType));
     } else {
         alias = createVariable(aliasName, *LogicalType::ANY());
     }

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -57,7 +57,7 @@ expression_vector ExpressionBinder::bindStructPropertyStarExpression(
     expression_vector result;
     auto childType = child->getDataType();
     for (auto field : StructType::getFields(childType)) {
-        result.push_back(bindStructPropertyExpression(child, field->getName()));
+        result.push_back(bindStructPropertyExpression(child, field.getName()));
     }
     return result;
 }

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -56,7 +56,7 @@ expression_vector ExpressionBinder::bindStructPropertyStarExpression(
     const std::shared_ptr<Expression>& child) {
     expression_vector result;
     auto childType = child->getDataType();
-    for (auto field : StructType::getFields(childType)) {
+    for (auto& field : StructType::getFields(childType)) {
         result.push_back(bindStructPropertyExpression(child, field.getName()));
     }
     return result;

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -56,7 +56,7 @@ expression_vector ExpressionBinder::bindStructPropertyStarExpression(
     const std::shared_ptr<Expression>& child) {
     expression_vector result;
     auto childType = child->getDataType();
-    for (auto field : StructType::getFields(&childType)) {
+    for (auto field : StructType::getFields(childType)) {
         result.push_back(bindStructPropertyExpression(child, field->getName()));
     }
     return result;

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -123,7 +123,7 @@ std::shared_ptr<Expression> Binder::createVariable(const std::string& name,
 std::unique_ptr<LogicalType> Binder::bindDataType(const std::string& dataType) {
     auto boundType = LogicalType::fromString(dataType);
     if (boundType.getLogicalTypeID() == LogicalTypeID::ARRAY) {
-        auto numElementsInArray = ArrayType::getNumElements(&boundType);
+        auto numElementsInArray = ArrayType::getNumElements(boundType);
         if (numElementsInArray == 0) {
             // Note: the parser already guarantees that the number of elements is a non-negative
             // number. However, we still need to check whether the number of elements is 0.

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -96,12 +96,12 @@ static bool compatible(const LogicalType& type, const LogicalType& target) {
         return compatible(*ArrayType::getChildType(type), *ArrayType::getChildType(target));
     }
     case LogicalTypeID::STRUCT: {
-        if (StructType::getNumFields(&type) != StructType::getNumFields(&target)) {
+        if (StructType::getNumFields(type) != StructType::getNumFields(target)) {
             return false;
         }
-        for (auto i = 0u; i < StructType::getNumFields(&type); ++i) {
-            if (!compatible(*StructType::getField(&type, i)->getType(),
-                    *StructType::getField(&target, i)->getType())) {
+        for (auto i = 0u; i < StructType::getNumFields(type); ++i) {
+            if (!compatible(*StructType::getField(type, i)->getType(),
+                    *StructType::getField(target, i)->getType())) {
                 return false;
             }
         }

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -93,7 +93,7 @@ static bool compatible(const LogicalType& type, const LogicalType& target) {
         return compatible(*ListType::getChildType(type), *ListType::getChildType(target));
     }
     case LogicalTypeID::ARRAY: {
-        return compatible(*ArrayType::getChildType(&type), *ArrayType::getChildType(&target));
+        return compatible(*ArrayType::getChildType(type), *ArrayType::getChildType(target));
     }
     case LogicalTypeID::STRUCT: {
         if (StructType::getNumFields(&type) != StructType::getNumFields(&target)) {

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -90,7 +90,7 @@ static bool compatible(const LogicalType& type, const LogicalType& target) {
     }
     switch (type.getLogicalTypeID()) {
     case LogicalTypeID::LIST: {
-        return compatible(*ListType::getChildType(&type), *ListType::getChildType(&target));
+        return compatible(*ListType::getChildType(type), *ListType::getChildType(target));
     }
     case LogicalTypeID::ARRAY: {
         return compatible(*ArrayType::getChildType(&type), *ArrayType::getChildType(&target));

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -90,18 +90,18 @@ static bool compatible(const LogicalType& type, const LogicalType& target) {
     }
     switch (type.getLogicalTypeID()) {
     case LogicalTypeID::LIST: {
-        return compatible(*ListType::getChildType(type), *ListType::getChildType(target));
+        return compatible(ListType::getChildType(type), ListType::getChildType(target));
     }
     case LogicalTypeID::ARRAY: {
-        return compatible(*ArrayType::getChildType(type), *ArrayType::getChildType(target));
+        return compatible(ArrayType::getChildType(type), ArrayType::getChildType(target));
     }
     case LogicalTypeID::STRUCT: {
         if (StructType::getNumFields(type) != StructType::getNumFields(target)) {
             return false;
         }
         for (auto i = 0u; i < StructType::getNumFields(type); ++i) {
-            if (!compatible(*StructType::getField(type, i)->getType(),
-                    *StructType::getField(target, i)->getType())) {
+            if (!compatible(StructType::getField(type, i).getType(),
+                    StructType::getField(target, i).getType())) {
                 return false;
             }
         }

--- a/src/c_api/data_type.cpp
+++ b/src/c_api/data_type.cpp
@@ -65,5 +65,5 @@ uint64_t kuzu_data_type_get_num_elements_in_array(kuzu_logical_type* data_type) 
     if (parent_type->getLogicalTypeID() != LogicalTypeID::ARRAY) {
         return 0;
     }
-    return ArrayType::getNumElements(static_cast<LogicalType*>(data_type->_data_type));
+    return ArrayType::getNumElements(*parent_type);
 }

--- a/src/c_api/value.cpp
+++ b/src/c_api/value.cpp
@@ -215,13 +215,13 @@ kuzu_value* kuzu_value_get_list_element(kuzu_value* value, uint64_t index) {
 uint64_t kuzu_value_get_struct_num_fields(kuzu_value* value) {
     auto val = static_cast<Value*>(value->_value);
     auto data_type = val->getDataType();
-    return StructType::getNumFields(data_type);
+    return StructType::getNumFields(*data_type);
 }
 
 char* kuzu_value_get_struct_field_name(kuzu_value* value, uint64_t index) {
     auto val = static_cast<Value*>(value->_value);
     auto data_type = val->getDataType();
-    return convertToOwnedCString(StructType::getFields(data_type)[index]->getName());
+    return convertToOwnedCString(StructType::getFields(*data_type)[index]->getName());
 }
 
 kuzu_value* kuzu_value_get_struct_field_value(kuzu_value* value, uint64_t index) {

--- a/src/c_api/value.cpp
+++ b/src/c_api/value.cpp
@@ -221,7 +221,7 @@ uint64_t kuzu_value_get_struct_num_fields(kuzu_value* value) {
 char* kuzu_value_get_struct_field_name(kuzu_value* value, uint64_t index) {
     auto val = static_cast<Value*>(value->_value);
     auto data_type = val->getDataType();
-    return convertToOwnedCString(StructType::getFields(*data_type)[index]->getName());
+    return convertToOwnedCString(StructType::getFields(*data_type)[index].getName());
 }
 
 kuzu_value* kuzu_value_get_struct_field_value(kuzu_value* value, uint64_t index) {

--- a/src/common/arrow/arrow_array_scan.cpp
+++ b/src/common/arrow/arrow_array_scan.cpp
@@ -202,7 +202,7 @@ static void scanArrowArrayFixedList(const ArrowSchema* schema, const ArrowArray*
     ValueVector& outputVector, ArrowNullMaskTree* mask, uint64_t srcOffset, uint64_t dstOffset,
     uint64_t count) {
     mask->copyToValueVector(&outputVector, dstOffset, count);
-    auto numElements = ArrayType::getNumElements(&outputVector.dataType);
+    auto numElements = ArrayType::getNumElements(outputVector.dataType);
     for (auto i = 0u; i < count; ++i) {
         auto newEntry = ListVector::addList(&outputVector, numElements);
         outputVector.setValue<list_entry_t>(i + dstOffset, newEntry);
@@ -512,7 +512,7 @@ void ArrowConverter::fromArrowArray(const ArrowSchema* schema, const ArrowArray*
             // ARRAY
             RUNTIME_CHECK({
                 auto arrowNumElements = std::stoul(arrowType + 3);
-                auto outputNumElements = ArrayType::getNumElements(&outputVector.dataType);
+                auto outputNumElements = ArrayType::getNumElements(outputVector.dataType);
                 KU_ASSERT(arrowNumElements == outputNumElements);
             });
             return scanArrowArrayFixedList(schema, array, outputVector, mask, srcOffset, dstOffset,

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -189,7 +189,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         setArrowFormat(rootHolder, **child.children, *ListType::getChildType(dataType));
     } break;
     case LogicalTypeID::ARRAY: {
-        auto numValuesPerArray = "+w:" + std::to_string(ArrayType::getNumElements(&dataType));
+        auto numValuesPerArray = "+w:" + std::to_string(ArrayType::getNumElements(dataType));
         child.format = copyName(rootHolder, numValuesPerArray);
         child.n_children = 1;
         rootHolder.nestedChildren.emplace_back();
@@ -199,7 +199,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, *ArrayType::getChildType(&dataType));
+        setArrowFormat(rootHolder, **child.children, *ArrayType::getChildType(dataType));
     } break;
     case LogicalTypeID::MAP: {
         child.format = "+m";

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -186,7 +186,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, *ListType::getChildType(dataType));
+        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType));
     } break;
     case LogicalTypeID::ARRAY: {
         auto numValuesPerArray = "+w:" + std::to_string(ArrayType::getNumElements(dataType));
@@ -199,7 +199,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, *ArrayType::getChildType(dataType));
+        setArrowFormat(rootHolder, **child.children, ArrayType::getChildType(dataType));
     } break;
     case LogicalTypeID::MAP: {
         child.format = "+m";
@@ -211,7 +211,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, *ListType::getChildType(dataType));
+        setArrowFormat(rootHolder, **child.children, ListType::getChildType(dataType));
     } break;
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::NODE:

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -66,7 +66,7 @@ void ArrowConverter::setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, Arro
 void ArrowConverter::setArrowFormatForUnion(ArrowSchemaHolder& rootHolder, ArrowSchema& child,
     const LogicalType& dataType) {
     std::string formatStr = "+ud";
-    child.n_children = (std::int64_t)UnionType::getNumFields(&dataType);
+    child.n_children = (std::int64_t)UnionType::getNumFields(dataType);
     rootHolder.nestedChildren.emplace_back();
     rootHolder.nestedChildren.back().resize(child.n_children);
     rootHolder.nestedChildrenPtr.emplace_back();
@@ -77,8 +77,8 @@ void ArrowConverter::setArrowFormatForUnion(ArrowSchemaHolder& rootHolder, Arrow
     child.children = &rootHolder.nestedChildrenPtr.back()[0];
     for (auto i = 0u; i < child.n_children; i++) {
         initializeChild(*child.children[i]);
-        auto unionFieldType = UnionType::getFieldType(&dataType, i);
-        auto unionFieldName = UnionType::getFieldName(&dataType, i);
+        auto unionFieldType = UnionType::getFieldType(dataType, i);
+        auto unionFieldName = UnionType::getFieldName(dataType, i);
         child.children[i]->name = copyName(rootHolder, unionFieldName);
         setArrowFormat(rootHolder, *child.children[i], *unionFieldType);
         formatStr += (i == 0u ? ":" : ",") + std::to_string(i);

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -58,8 +58,8 @@ void ArrowConverter::setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, Arro
     for (auto i = 0u; i < child.n_children; i++) {
         initializeChild(*child.children[i]);
         auto structField = StructType::getField(dataType, i);
-        child.children[i]->name = copyName(rootHolder, structField->getName());
-        setArrowFormat(rootHolder, *child.children[i], *structField->getType());
+        child.children[i]->name = copyName(rootHolder, structField.getName());
+        setArrowFormat(rootHolder, *child.children[i], structField.getType());
     }
 }
 

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -46,7 +46,7 @@ void ArrowConverter::setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, Arro
     const LogicalType& dataType) {
     child.format = "+s";
     // name is set by parent.
-    child.n_children = (std::int64_t)StructType::getNumFields(&dataType);
+    child.n_children = (std::int64_t)StructType::getNumFields(dataType);
     rootHolder.nestedChildren.emplace_back();
     rootHolder.nestedChildren.back().resize(child.n_children);
     rootHolder.nestedChildrenPtr.emplace_back();
@@ -57,7 +57,7 @@ void ArrowConverter::setArrowFormatForStruct(ArrowSchemaHolder& rootHolder, Arro
     child.children = &rootHolder.nestedChildrenPtr.back()[0];
     for (auto i = 0u; i < child.n_children; i++) {
         initializeChild(*child.children[i]);
-        auto structField = StructType::getField(&dataType, i);
+        auto structField = StructType::getField(dataType, i);
         child.children[i]->name = copyName(rootHolder, structField->getName());
         setArrowFormat(rootHolder, *child.children[i], *structField->getType());
     }

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -80,7 +80,7 @@ void ArrowConverter::setArrowFormatForUnion(ArrowSchemaHolder& rootHolder, Arrow
         auto unionFieldType = UnionType::getFieldType(dataType, i);
         auto unionFieldName = UnionType::getFieldName(dataType, i);
         child.children[i]->name = copyName(rootHolder, unionFieldName);
-        setArrowFormat(rootHolder, *child.children[i], *unionFieldType);
+        setArrowFormat(rootHolder, *child.children[i], unionFieldType);
         formatStr += (i == 0u ? ":" : ",") + std::to_string(i);
     }
     child.format = copyName(rootHolder, formatStr);

--- a/src/common/arrow/arrow_converter.cpp
+++ b/src/common/arrow/arrow_converter.cpp
@@ -186,7 +186,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, *ListType::getChildType(&dataType));
+        setArrowFormat(rootHolder, **child.children, *ListType::getChildType(dataType));
     } break;
     case LogicalTypeID::ARRAY: {
         auto numValuesPerArray = "+w:" + std::to_string(ArrayType::getNumElements(&dataType));
@@ -211,7 +211,7 @@ void ArrowConverter::setArrowFormat(ArrowSchemaHolder& rootHolder, ArrowSchema& 
         initializeChild(rootHolder.nestedChildren.back()[0]);
         child.children = &rootHolder.nestedChildrenPtr.back()[0];
         child.children[0]->name = "l";
-        setArrowFormat(rootHolder, **child.children, *ListType::getChildType(&dataType));
+        setArrowFormat(rootHolder, **child.children, *ListType::getChildType(dataType));
     } break;
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::NODE:

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -122,8 +122,8 @@ static void resizeBLOBVector(ArrowVector* vector, const LogicalType& type, int64
 
 static void resizeFixedListVector(ArrowVector* vector, const LogicalType& type, int64_t capacity) {
     resizeGeneric(vector, type, capacity);
-    resizeChildVectors(vector, {ArrayType::getChildType(&type)},
-        vector->capacity * ArrayType::getNumElements(&type));
+    resizeChildVectors(vector, {ArrayType::getChildType(type)},
+        vector->capacity * ArrayType::getNumElements(type));
 }
 
 static void resizeListVector(ArrowVector* vector, const LogicalType& type, int64_t capacity,
@@ -313,7 +313,7 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::ARRAY>(ArrowVector* 
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
     auto numElements = value->childrenSize;
     for (auto i = 0u; i < numElements; i++) {
-        appendValue(vector->childData[0].get(), *ArrayType::getChildType(&type),
+        appendValue(vector->childData[0].get(), *ArrayType::getChildType(type),
             value->children[i].get());
     }
 }
@@ -719,7 +719,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::ARRAY>(ArrowVector
     result->children = vector.childPointers.data();
     result->n_children = 1;
     vector.childPointers[0] =
-        convertVectorToArray(*vector.childData[0], *ArrayType::getChildType(&type));
+        convertVectorToArray(*vector.childData[0], *ArrayType::getChildType(type));
     vector.array = std::move(result);
     return vector.array.get();
 }

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -89,7 +89,7 @@ static void resizeUnionOverflow(ArrowVector* vector, int64_t capacity) {
     vector->overflow.resize(capacity * sizeof(int32_t));
 }
 
-static void resizeChildVectors(ArrowVector* vector, const std::vector<LogicalType*> childTypes,
+static void resizeChildVectors(ArrowVector* vector, const std::vector<LogicalType> childTypes,
     int64_t childCapacity) {
     for (auto i = 0u; i < childTypes.size(); i++) {
         if (i >= vector->childData.size()) {
@@ -303,7 +303,7 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::LIST>(ArrowVector* v
     offsets[pos + 1] = offsets[pos] + numElements;
     resizeChildVectors(vector, {ListType::getChildType(type)}, offsets[pos + 1] + 1);
     for (auto i = 0u; i < numElements; i++) {
-        appendValue(vector->childData[0].get(), *ListType::getChildType(type),
+        appendValue(vector->childData[0].get(), ListType::getChildType(type),
             value->children[i].get());
     }
 }
@@ -313,7 +313,7 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::ARRAY>(ArrowVector* 
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
     auto numElements = value->childrenSize;
     for (auto i = 0u; i < numElements; i++) {
-        appendValue(vector->childData[0].get(), *ArrayType::getChildType(type),
+        appendValue(vector->childData[0].get(), ArrayType::getChildType(type),
             value->children[i].get());
     }
 }
@@ -705,7 +705,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::LIST>(ArrowVector&
     result->children = vector.childPointers.data();
     result->n_children = 1;
     vector.childPointers[0] =
-        convertVectorToArray(*vector.childData[0], *ListType::getChildType(type));
+        convertVectorToArray(*vector.childData[0], ListType::getChildType(type));
     vector.array = std::move(result);
     return vector.array.get();
 }
@@ -719,7 +719,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::ARRAY>(ArrowVector
     result->children = vector.childPointers.data();
     result->n_children = 1;
     vector.childPointers[0] =
-        convertVectorToArray(*vector.childData[0], *ArrayType::getChildType(type));
+        convertVectorToArray(*vector.childData[0], ArrayType::getChildType(type));
     vector.array = std::move(result);
     return vector.array.get();
 }

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -129,7 +129,7 @@ static void resizeFixedListVector(ArrowVector* vector, const LogicalType& type, 
 static void resizeListVector(ArrowVector* vector, const LogicalType& type, int64_t capacity,
     int64_t childCapacity) {
     resizeGeneric(vector, type, capacity);
-    resizeChildVectors(vector, {ListType::getChildType(&type)}, childCapacity);
+    resizeChildVectors(vector, {ListType::getChildType(type)}, childCapacity);
 }
 
 static void resizeStructVector(ArrowVector* vector, const LogicalType& type, int64_t capacity) {
@@ -301,9 +301,9 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::LIST>(ArrowVector* v
         offsets[pos] = 0;
     }
     offsets[pos + 1] = offsets[pos] + numElements;
-    resizeChildVectors(vector, {ListType::getChildType(&type)}, offsets[pos + 1] + 1);
+    resizeChildVectors(vector, {ListType::getChildType(type)}, offsets[pos + 1] + 1);
     for (auto i = 0u; i < numElements; i++) {
-        appendValue(vector->childData[0].get(), *ListType::getChildType(&type),
+        appendValue(vector->childData[0].get(), *ListType::getChildType(type),
             value->children[i].get());
     }
 }
@@ -705,7 +705,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::LIST>(ArrowVector&
     result->children = vector.childPointers.data();
     result->n_children = 1;
     vector.childPointers[0] =
-        convertVectorToArray(*vector.childData[0], *ListType::getChildType(&type));
+        convertVectorToArray(*vector.childData[0], *ListType::getChildType(type));
     vector.array = std::move(result);
     return vector.array.get();
 }

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -149,7 +149,7 @@ static void resizeUnionVector(ArrowVector* vector, const LogicalType& type, int6
         resizeMainBuffer(vector, type, vector->capacity);
     }
     resizeUnionOverflow(vector, vector->capacity);
-    std::vector<LogicalType*> childTypes;
+    std::vector<LogicalType> childTypes;
     for (auto i = 0u; i < UnionType::getNumFields(type); i++) {
         childTypes.push_back(UnionType::getFieldType(type, i));
     }
@@ -339,10 +339,10 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UNION>(ArrowVector* 
     auto typeBuffer = (std::uint8_t*)vector->data.data();
     auto offsetsBuffer = (std::int32_t*)vector->overflow.data();
     for (auto i = 0u; i < UnionType::getNumFields(type); i++) {
-        if (*UnionType::getFieldType(type, i) == *value->children[0]->dataType) {
+        if (UnionType::getFieldType(type, i) == *value->children[0]->dataType) {
             typeBuffer[pos] = i;
             offsetsBuffer[pos] = vector->childData[i]->numValues;
-            return appendValue(vector->childData[i].get(), *UnionType::getFieldType(type, i),
+            return appendValue(vector->childData[i].get(), UnionType::getFieldType(type, i),
                 value->children[0].get());
         }
     }
@@ -788,7 +788,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::UNION>(ArrowVector
     vector.array->buffers[1] = vector.overflow.data();
     for (auto i = 0u; i < nChildren; i++) {
         auto childType = UnionType::getFieldType(type, i);
-        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], *childType);
+        vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType);
     }
     return vector.array.get();
 }

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -150,8 +150,8 @@ static void resizeUnionVector(ArrowVector* vector, const LogicalType& type, int6
     }
     resizeUnionOverflow(vector, vector->capacity);
     std::vector<LogicalType*> childTypes;
-    for (auto i = 0u; i < UnionType::getNumFields(&type); i++) {
-        childTypes.push_back(UnionType::getFieldType(&type, i));
+    for (auto i = 0u; i < UnionType::getNumFields(type); i++) {
+        childTypes.push_back(UnionType::getFieldType(type, i));
     }
     resizeChildVectors(vector, childTypes, vector->capacity);
 }
@@ -338,11 +338,11 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::UNION>(ArrowVector* 
     const LogicalType& type, Value* value, std::int64_t pos) {
     auto typeBuffer = (std::uint8_t*)vector->data.data();
     auto offsetsBuffer = (std::int32_t*)vector->overflow.data();
-    for (auto i = 0u; i < UnionType::getNumFields(&type); i++) {
-        if (*UnionType::getFieldType(&type, i) == *value->children[0]->dataType) {
+    for (auto i = 0u; i < UnionType::getNumFields(type); i++) {
+        if (*UnionType::getFieldType(type, i) == *value->children[0]->dataType) {
             typeBuffer[pos] = i;
             offsetsBuffer[pos] = vector->childData[i]->numValues;
-            return appendValue(vector->childData[i].get(), *UnionType::getFieldType(&type, i),
+            return appendValue(vector->childData[i].get(), *UnionType::getFieldType(type, i),
                 value->children[0].get());
         }
     }
@@ -771,7 +771,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::UNION>(ArrowVector
     const LogicalType& type) {
     // since union is a special case, we make the ArrowArray ourselves instead of using
     // createArrayFromVector
-    auto nChildren = UnionType::getNumFields(&type);
+    auto nChildren = UnionType::getNumFields(type);
     vector.array = std::make_unique<ArrowArray>();
     vector.array->private_data = nullptr;
     vector.array->release = releaseArrowVector;
@@ -787,7 +787,7 @@ ArrowArray* ArrowRowBatch::templateCreateArray<LogicalTypeID::UNION>(ArrowVector
     vector.array->buffers[0] = vector.data.data();
     vector.array->buffers[1] = vector.overflow.data();
     for (auto i = 0u; i < nChildren; i++) {
-        auto childType = UnionType::getFieldType(&type, i);
+        auto childType = UnionType::getFieldType(type, i);
         vector.childPointers[i] = convertVectorToArray(*vector.childData[i], *childType);
     }
     return vector.array.get();

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -328,7 +328,7 @@ template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::STRUCT>(ArrowVector* vector,
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
     for (auto i = 0u; i < value->childrenSize; i++) {
-        appendValue(vector->childData[i].get(), *StructType::getFieldTypes(type)[i],
+        appendValue(vector->childData[i].get(), StructType::getFieldTypes(type)[i],
             value->children[i].get());
     }
 }
@@ -362,16 +362,16 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::INTERNAL_ID>(ArrowVe
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::NODE>(ArrowVector* vector,
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
-    appendValue(vector->childData[0].get(), *StructType::getFieldTypes(type)[0],
+    appendValue(vector->childData[0].get(), StructType::getFieldTypes(type)[0],
         NodeVal::getNodeIDVal(value));
-    appendValue(vector->childData[1].get(), *StructType::getFieldTypes(type)[1],
+    appendValue(vector->childData[1].get(), StructType::getFieldTypes(type)[1],
         NodeVal::getLabelVal(value));
     std::int64_t propertyId = 2;
     auto numProperties = NodeVal::getNumProperties(value);
     for (auto i = 0u; i < numProperties; i++) {
         auto val = NodeVal::getPropertyVal(value, i);
         appendValue(vector->childData[propertyId].get(),
-            *StructType::getFieldTypes(type)[propertyId], val);
+            StructType::getFieldTypes(type)[propertyId], val);
         propertyId++;
     }
 }
@@ -379,20 +379,20 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::NODE>(ArrowVector* v
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::REL>(ArrowVector* vector,
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
-    appendValue(vector->childData[0].get(), *StructType::getFieldTypes(type)[0],
+    appendValue(vector->childData[0].get(), StructType::getFieldTypes(type)[0],
         RelVal::getSrcNodeIDVal(value));
-    appendValue(vector->childData[1].get(), *StructType::getFieldTypes(type)[1],
+    appendValue(vector->childData[1].get(), StructType::getFieldTypes(type)[1],
         RelVal::getDstNodeIDVal(value));
-    appendValue(vector->childData[2].get(), *StructType::getFieldTypes(type)[2],
+    appendValue(vector->childData[2].get(), StructType::getFieldTypes(type)[2],
         RelVal::getLabelVal(value));
-    appendValue(vector->childData[3].get(), *StructType::getFieldTypes(type)[3],
+    appendValue(vector->childData[3].get(), StructType::getFieldTypes(type)[3],
         RelVal::getIDVal(value));
     std::int64_t propertyId = 4;
     auto numProperties = RelVal::getNumProperties(value);
     for (auto i = 0u; i < numProperties; i++) {
         auto val = RelVal::getPropertyVal(value, i);
         appendValue(vector->childData[propertyId].get(),
-            *StructType::getFieldTypes(type)[propertyId], val);
+            StructType::getFieldTypes(type)[propertyId], val);
         propertyId++;
     }
 }
@@ -744,7 +744,7 @@ ArrowArray* ArrowRowBatch::convertStructVectorToArray(ArrowVector& vector,
     result->children = vector.childPointers.data();
     result->n_children = (std::int64_t)StructType::getNumFields(type);
     for (auto i = 0u; i < StructType::getNumFields(type); i++) {
-        auto& childType = *StructType::getFieldTypes(type)[i];
+        auto& childType = StructType::getFieldTypes(type)[i];
         vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType);
     }
     vector.array = std::move(result);

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -89,7 +89,7 @@ static void resizeUnionOverflow(ArrowVector* vector, int64_t capacity) {
     vector->overflow.resize(capacity * sizeof(int32_t));
 }
 
-static void resizeChildVectors(ArrowVector* vector, const std::vector<LogicalType> childTypes,
+static void resizeChildVectors(ArrowVector* vector, const std::vector<LogicalType>& childTypes,
     int64_t childCapacity) {
     for (auto i = 0u; i < childTypes.size(); i++) {
         if (i >= vector->childData.size()) {
@@ -158,8 +158,8 @@ static void resizeUnionVector(ArrowVector* vector, const LogicalType& type, int6
 
 static void resizeInternalIDVector(ArrowVector* vector, const LogicalType& type, int64_t capacity) {
     resizeGeneric(vector, type, capacity);
-    auto childType = LogicalType::INT64();
-    resizeChildVectors(vector, {childType.get(), childType.get()}, vector->capacity);
+    auto childType = *LogicalType::INT64();
+    resizeChildVectors(vector, {childType, childType}, vector->capacity);
 }
 
 static void resizeVector(ArrowVector* vector, const LogicalType& type, std::int64_t capacity) {

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -95,7 +95,7 @@ static void resizeChildVectors(ArrowVector* vector, const std::vector<LogicalTyp
         if (i >= vector->childData.size()) {
             vector->childData.push_back(std::make_unique<ArrowVector>());
         }
-        resizeVector(vector->childData[i].get(), *childTypes[i], childCapacity);
+        resizeVector(vector->childData[i].get(), childTypes[i], childCapacity);
     }
 }
 
@@ -744,7 +744,7 @@ ArrowArray* ArrowRowBatch::convertStructVectorToArray(ArrowVector& vector,
     result->children = vector.childPointers.data();
     result->n_children = (std::int64_t)StructType::getNumFields(type);
     for (auto i = 0u; i < StructType::getNumFields(type); i++) {
-        auto& childType = StructType::getFieldTypes(type)[i];
+        auto childType = StructType::getFieldTypes(type)[i];
         vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType);
     }
     vector.array = std::move(result);

--- a/src/common/arrow/arrow_row_batch.cpp
+++ b/src/common/arrow/arrow_row_batch.cpp
@@ -134,7 +134,7 @@ static void resizeListVector(ArrowVector* vector, const LogicalType& type, int64
 
 static void resizeStructVector(ArrowVector* vector, const LogicalType& type, int64_t capacity) {
     resizeGeneric(vector, type, capacity);
-    resizeChildVectors(vector, StructType::getFieldTypes(&type), vector->capacity);
+    resizeChildVectors(vector, StructType::getFieldTypes(type), vector->capacity);
 }
 
 static void resizeUnionVector(ArrowVector* vector, const LogicalType& type, int64_t capacity) {
@@ -328,7 +328,7 @@ template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::STRUCT>(ArrowVector* vector,
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
     for (auto i = 0u; i < value->childrenSize; i++) {
-        appendValue(vector->childData[i].get(), *StructType::getFieldTypes(&type)[i],
+        appendValue(vector->childData[i].get(), *StructType::getFieldTypes(type)[i],
             value->children[i].get());
     }
 }
@@ -362,16 +362,16 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::INTERNAL_ID>(ArrowVe
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::NODE>(ArrowVector* vector,
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
-    appendValue(vector->childData[0].get(), *StructType::getFieldTypes(&type)[0],
+    appendValue(vector->childData[0].get(), *StructType::getFieldTypes(type)[0],
         NodeVal::getNodeIDVal(value));
-    appendValue(vector->childData[1].get(), *StructType::getFieldTypes(&type)[1],
+    appendValue(vector->childData[1].get(), *StructType::getFieldTypes(type)[1],
         NodeVal::getLabelVal(value));
     std::int64_t propertyId = 2;
     auto numProperties = NodeVal::getNumProperties(value);
     for (auto i = 0u; i < numProperties; i++) {
         auto val = NodeVal::getPropertyVal(value, i);
         appendValue(vector->childData[propertyId].get(),
-            *StructType::getFieldTypes(&type)[propertyId], val);
+            *StructType::getFieldTypes(type)[propertyId], val);
         propertyId++;
     }
 }
@@ -379,20 +379,20 @@ void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::NODE>(ArrowVector* v
 template<>
 void ArrowRowBatch::templateCopyNonNullValue<LogicalTypeID::REL>(ArrowVector* vector,
     const LogicalType& type, Value* value, std::int64_t /*pos*/) {
-    appendValue(vector->childData[0].get(), *StructType::getFieldTypes(&type)[0],
+    appendValue(vector->childData[0].get(), *StructType::getFieldTypes(type)[0],
         RelVal::getSrcNodeIDVal(value));
-    appendValue(vector->childData[1].get(), *StructType::getFieldTypes(&type)[1],
+    appendValue(vector->childData[1].get(), *StructType::getFieldTypes(type)[1],
         RelVal::getDstNodeIDVal(value));
-    appendValue(vector->childData[2].get(), *StructType::getFieldTypes(&type)[2],
+    appendValue(vector->childData[2].get(), *StructType::getFieldTypes(type)[2],
         RelVal::getLabelVal(value));
-    appendValue(vector->childData[3].get(), *StructType::getFieldTypes(&type)[3],
+    appendValue(vector->childData[3].get(), *StructType::getFieldTypes(type)[3],
         RelVal::getIDVal(value));
     std::int64_t propertyId = 4;
     auto numProperties = RelVal::getNumProperties(value);
     for (auto i = 0u; i < numProperties; i++) {
         auto val = RelVal::getPropertyVal(value, i);
         appendValue(vector->childData[propertyId].get(),
-            *StructType::getFieldTypes(&type)[propertyId], val);
+            *StructType::getFieldTypes(type)[propertyId], val);
         propertyId++;
     }
 }
@@ -740,11 +740,11 @@ ArrowArray* ArrowRowBatch::convertStructVectorToArray(ArrowVector& vector,
     const LogicalType& type) {
     auto result = createArrayFromVector(vector);
     result->n_buffers = 1;
-    vector.childPointers.resize(StructType::getNumFields(&type));
+    vector.childPointers.resize(StructType::getNumFields(type));
     result->children = vector.childPointers.data();
-    result->n_children = (std::int64_t)StructType::getNumFields(&type);
-    for (auto i = 0u; i < StructType::getNumFields(&type); i++) {
-        auto& childType = *StructType::getFieldTypes(&type)[i];
+    result->n_children = (std::int64_t)StructType::getNumFields(type);
+    for (auto i = 0u; i < StructType::getNumFields(type); i++) {
+        auto& childType = *StructType::getFieldTypes(type)[i];
         vector.childPointers[i] = convertVectorToArray(*vector.childData[i], childType);
     }
     vector.array = std::move(result);

--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -193,7 +193,7 @@ std::string TypeUtils::toString(const map_entry_t& val, void* valueVector) {
 
 template<bool SKIP_NULL_ENTRY>
 static std::string structToString(const struct_entry_t& val, ValueVector* vector) {
-    auto fields = StructType::getFields(&vector->dataType);
+    auto fields = StructType::getFields(vector->dataType);
     if (fields.size() == 0) {
         return "{}";
     }
@@ -209,7 +209,7 @@ static std::string structToString(const struct_entry_t& val, ValueVector* vector
         if (i != 0) {
             result += ", ";
         }
-        result += StructType::getField(&vector->dataType, i)->getName();
+        result += StructType::getField(vector->dataType, i)->getName();
         result += ": ";
         result += entryToStringWithPos(val.pos, fieldVector.get());
     }
@@ -223,7 +223,7 @@ static std::string structToString(const struct_entry_t& val, ValueVector* vector
     if (i != 0) {
         result += ", ";
     }
-    result += StructType::getField(&vector->dataType, i)->getName();
+    result += StructType::getField(vector->dataType, i)->getName();
     result += ": ";
     result += entryToStringWithPos(val.pos, fieldVector.get());
     result += "}";

--- a/src/common/type_utils.cpp
+++ b/src/common/type_utils.cpp
@@ -209,7 +209,7 @@ static std::string structToString(const struct_entry_t& val, ValueVector* vector
         if (i != 0) {
             result += ", ";
         }
-        result += StructType::getField(vector->dataType, i)->getName();
+        result += StructType::getField(vector->dataType, i).getName();
         result += ": ";
         result += entryToStringWithPos(val.pos, fieldVector.get());
     }
@@ -223,7 +223,7 @@ static std::string structToString(const struct_entry_t& val, ValueVector* vector
     if (i != 0) {
         result += ", ";
     }
-    result += StructType::getField(vector->dataType, i)->getName();
+    result += StructType::getField(vector->dataType, i).getName();
     result += ": ";
     result += entryToStringWithPos(val.pos, fieldVector.get());
     result += "}";

--- a/src/common/types/ku_list.cpp
+++ b/src/common/types/ku_list.cpp
@@ -9,7 +9,7 @@ namespace common {
 
 void ku_list_t::set(const uint8_t* values, const LogicalType& dataType) const {
     memcpy(reinterpret_cast<uint8_t*>(overflowPtr), values,
-        size * storage::StorageUtils::getDataTypeSize(*ListType::getChildType(&dataType)));
+        size * storage::StorageUtils::getDataTypeSize(*ListType::getChildType(dataType)));
 }
 
 void ku_list_t::set(const std::vector<uint8_t*>& parameters, LogicalTypeID childTypeId) {

--- a/src/common/types/ku_list.cpp
+++ b/src/common/types/ku_list.cpp
@@ -9,7 +9,7 @@ namespace common {
 
 void ku_list_t::set(const uint8_t* values, const LogicalType& dataType) const {
     memcpy(reinterpret_cast<uint8_t*>(overflowPtr), values,
-        size * storage::StorageUtils::getDataTypeSize(*ListType::getChildType(dataType)));
+        size * storage::StorageUtils::getDataTypeSize(ListType::getChildType(dataType)));
 }
 
 void ku_list_t::set(const std::vector<uint8_t*>& parameters, LogicalTypeID childTypeId) {

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1194,8 +1194,8 @@ std::unique_ptr<LogicalType> LogicalType::ARRAY(std::unique_ptr<LogicalType> chi
 static bool tryCombineListTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
     LogicalType childType;
-    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ListType::getChildType(&left),
-            *ListType::getChildType(&right), childType)) {
+    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ListType::getChildType(left),
+            *ListType::getChildType(right), childType)) {
         return false;
     }
     result = *LogicalType::LIST(childType);
@@ -1219,7 +1219,7 @@ static bool tryCombineArrayTypes(const LogicalType& left, const LogicalType& rig
 static bool tryCombineListArrayTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
     LogicalType childType;
-    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ListType::getChildType(&left),
+    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ListType::getChildType(left),
             *ArrayType::getChildType(&right), childType)) {
         return false;
     }

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -458,7 +458,7 @@ std::string LogicalType::toString() const {
     case LogicalTypeID::MAP: {
         auto structType =
             ku_dynamic_cast<ExtraTypeInfo*, ListTypeInfo*>(extraTypeInfo.get())->getChildType();
-        auto fieldTypes = StructType::getFieldTypes(structType);
+        auto fieldTypes = StructType::getFieldTypes(*structType);
         return "MAP(" + fieldTypes[0]->toString() + ", " + fieldTypes[1]->toString() + ")";
     }
     case LogicalTypeID::LIST: {
@@ -887,7 +887,7 @@ uint32_t LogicalTypeUtils::getRowLayoutSize(const LogicalType& type) {
     }
     case PhysicalTypeID::STRUCT: {
         uint32_t size = 0;
-        auto fieldsTypes = StructType::getFieldTypes(&type);
+        auto fieldsTypes = StructType::getFieldTypes(type);
         for (auto fieldType : fieldsTypes) {
             size += getRowLayoutSize(*fieldType);
         }
@@ -1231,7 +1231,7 @@ static bool tryCombineListArrayTypes(const LogicalType& left, const LogicalType&
 // the struct
 static bool tryCombineStructTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
-    auto leftFields = StructType::getFields(&left), rightFields = StructType::getFields(&right);
+    auto leftFields = StructType::getFields(left), rightFields = StructType::getFields(right);
     if (leftFields.size() != rightFields.size()) {
         return false;
     }
@@ -1275,7 +1275,7 @@ static bool tryCombineMapTypes(const LogicalType& left, const LogicalType& right
 // combine corresponding labels, then we can combine the union
 static bool tryCombineUnionTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
-    auto leftFields = StructType::getFields(&left), rightFields = StructType::getFields(&right);
+    auto leftFields = StructType::getFields(left), rightFields = StructType::getFields(right);
     if (leftFields.size() > rightFields.size()) {
         std::swap(leftFields, rightFields);
     }

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1256,10 +1256,10 @@ static bool tryCombineStructTypes(const LogicalType& left, const LogicalType& ri
 // If we can combine the key and value, then we cna combine the map
 static bool tryCombineMapTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
-    auto leftKeyType = *MapType::getKeyType(&left);
-    auto leftValueType = *MapType::getValueType(&left);
-    auto rightKeyType = *MapType::getKeyType(&right);
-    auto rightValueType = *MapType::getValueType(&right);
+    auto leftKeyType = *MapType::getKeyType(left);
+    auto leftValueType = *MapType::getValueType(left);
+    auto rightKeyType = *MapType::getKeyType(right);
+    auto rightValueType = *MapType::getValueType(right);
     LogicalType resultKeyType, resultValueType;
     if (!LogicalTypeUtils::tryGetMaxLogicalType(leftKeyType, rightKeyType, resultKeyType) ||
         !LogicalTypeUtils::tryGetMaxLogicalType(leftValueType, rightValueType, resultValueType)) {

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1256,10 +1256,10 @@ static bool tryCombineStructTypes(const LogicalType& left, const LogicalType& ri
 // If we can combine the key and value, then we cna combine the map
 static bool tryCombineMapTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
-    auto leftKeyType = *MapType::getKeyType(left);
-    auto leftValueType = *MapType::getValueType(left);
-    auto rightKeyType = *MapType::getKeyType(right);
-    auto rightValueType = *MapType::getValueType(right);
+    auto leftKeyType = MapType::getKeyType(left);
+    auto leftValueType = MapType::getValueType(left);
+    auto rightKeyType = MapType::getKeyType(right);
+    auto rightValueType = MapType::getValueType(right);
     LogicalType resultKeyType, resultValueType;
     if (!LogicalTypeUtils::tryGetMaxLogicalType(leftKeyType, rightKeyType, resultKeyType) ||
         !LogicalTypeUtils::tryGetMaxLogicalType(leftValueType, rightValueType, resultValueType)) {

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1194,8 +1194,8 @@ std::unique_ptr<LogicalType> LogicalType::ARRAY(std::unique_ptr<LogicalType> chi
 static bool tryCombineListTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
     LogicalType childType;
-    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ListType::getChildType(left),
-            *ListType::getChildType(right), childType)) {
+    if (!LogicalTypeUtils::tryGetMaxLogicalType(ListType::getChildType(left),
+            ListType::getChildType(right), childType)) {
         return false;
     }
     result = *LogicalType::LIST(childType);
@@ -1208,8 +1208,8 @@ static bool tryCombineArrayTypes(const LogicalType& left, const LogicalType& rig
         return tryCombineListTypes(left, right, result);
     }
     LogicalType childType;
-    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ArrayType::getChildType(left),
-            *ArrayType::getChildType(right), childType)) {
+    if (!LogicalTypeUtils::tryGetMaxLogicalType(ArrayType::getChildType(left),
+            ArrayType::getChildType(right), childType)) {
         return false;
     }
     result = *LogicalType::ARRAY(childType, ArrayType::getNumElements(left));
@@ -1219,8 +1219,8 @@ static bool tryCombineArrayTypes(const LogicalType& left, const LogicalType& rig
 static bool tryCombineListArrayTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
     LogicalType childType;
-    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ListType::getChildType(left),
-            *ArrayType::getChildType(right), childType)) {
+    if (!LogicalTypeUtils::tryGetMaxLogicalType(ListType::getChildType(left),
+            ArrayType::getChildType(right), childType)) {
         return false;
     }
     result = *LogicalType::LIST(childType);

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1204,15 +1204,15 @@ static bool tryCombineListTypes(const LogicalType& left, const LogicalType& righ
 
 static bool tryCombineArrayTypes(const LogicalType& left, const LogicalType& right,
     LogicalType& result) {
-    if (ArrayType::getNumElements(&left) != ArrayType::getNumElements(&right)) {
+    if (ArrayType::getNumElements(left) != ArrayType::getNumElements(right)) {
         return tryCombineListTypes(left, right, result);
     }
     LogicalType childType;
-    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ArrayType::getChildType(&left),
-            *ArrayType::getChildType(&right), childType)) {
+    if (!LogicalTypeUtils::tryGetMaxLogicalType(*ArrayType::getChildType(left),
+            *ArrayType::getChildType(right), childType)) {
         return false;
     }
-    result = *LogicalType::ARRAY(childType, ArrayType::getNumElements(&left));
+    result = *LogicalType::ARRAY(childType, ArrayType::getNumElements(left));
     return true;
 }
 
@@ -1220,7 +1220,7 @@ static bool tryCombineListArrayTypes(const LogicalType& left, const LogicalType&
     LogicalType& result) {
     LogicalType childType;
     if (!LogicalTypeUtils::tryGetMaxLogicalType(*ListType::getChildType(left),
-            *ArrayType::getChildType(&right), childType)) {
+            *ArrayType::getChildType(right), childType)) {
         return false;
     }
     result = *LogicalType::LIST(childType);

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -302,7 +302,7 @@ struct_field_idx_t StructTypeInfo::getStructFieldIdx(std::string fieldName) cons
 }
 
 StructField StructTypeInfo::getStructField(struct_field_idx_t idx) const {
-    return fields[idx];
+    return fields[idx].copy();
 }
 
 StructField StructTypeInfo::getStructField(const std::string& fieldName) const {
@@ -310,7 +310,7 @@ StructField StructTypeInfo::getStructField(const std::string& fieldName) const {
     if (idx == INVALID_STRUCT_FIELD_IDX) {
         throw BinderException("Cannot find field " + fieldName + " in STRUCT.");
     }
-    return fields[idx];
+    return fields[idx].copy();
 }
 
 LogicalType StructTypeInfo::getChildType(kuzu::common::struct_field_idx_t idx) const {
@@ -336,7 +336,7 @@ std::vector<std::string> StructTypeInfo::getChildrenNames() const {
 std::vector<StructField> StructTypeInfo::getStructFields() const {
     std::vector<StructField> structFields{fields.size()};
     for (auto i = 0u; i < fields.size(); i++) {
-        structFields[i] = fields[i];
+        structFields[i] = fields[i].copy();
     }
     return structFields;
 }

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -20,98 +20,98 @@ using kuzu::function::BuiltInFunctionsUtils;
 namespace kuzu {
 namespace common {
 
-LogicalType* ListType::getChildType(const kuzu::common::LogicalType* type) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::LIST ||
-              type->getPhysicalType() == PhysicalTypeID::ARRAY);
-    auto listTypeInfo = type->extraTypeInfo->constPtrCast<ListTypeInfo>();
+LogicalType* ListType::getChildType(const kuzu::common::LogicalType& type) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::LIST ||
+              type.getPhysicalType() == PhysicalTypeID::ARRAY);
+    auto listTypeInfo = type.extraTypeInfo->constPtrCast<ListTypeInfo>();
     return listTypeInfo->getChildType();
 }
 
-LogicalType* ArrayType::getChildType(const LogicalType* type) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::ARRAY);
-    auto arrayTypeInfo = type->extraTypeInfo->constPtrCast<ArrayTypeInfo>();
+LogicalType* ArrayType::getChildType(const LogicalType& type) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::ARRAY);
+    auto arrayTypeInfo = type.extraTypeInfo->constPtrCast<ArrayTypeInfo>();
     return arrayTypeInfo->getChildType();
 }
 
-uint64_t ArrayType::getNumElements(const LogicalType* type) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::ARRAY);
-    auto arrayTypeInfo = type->extraTypeInfo->constPtrCast<ArrayTypeInfo>();
+uint64_t ArrayType::getNumElements(const LogicalType& type) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::ARRAY);
+    auto arrayTypeInfo = type.extraTypeInfo->constPtrCast<ArrayTypeInfo>();
     return arrayTypeInfo->getNumElements();
 }
 
-std::vector<LogicalType*> StructType::getFieldTypes(const LogicalType* type) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structTypeInfo = type->extraTypeInfo->constPtrCast<StructTypeInfo>();
+std::vector<LogicalType*> StructType::getFieldTypes(const LogicalType& type) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structTypeInfo = type.extraTypeInfo->constPtrCast<StructTypeInfo>();
     return structTypeInfo->getChildrenTypes();
 }
 
-std::vector<std::string> StructType::getFieldNames(const LogicalType* type) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structTypeInfo = type->extraTypeInfo->constPtrCast<StructTypeInfo>();
+std::vector<std::string> StructType::getFieldNames(const LogicalType& type) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structTypeInfo = type.extraTypeInfo->constPtrCast<StructTypeInfo>();
     return structTypeInfo->getChildrenNames();
 }
 
-uint64_t StructType::getNumFields(const LogicalType* type) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
+uint64_t StructType::getNumFields(const LogicalType& type) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
     return getFieldTypes(type).size();
 }
 
-std::vector<const StructField*> StructType::getFields(const LogicalType* type) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structTypeInfo = type->extraTypeInfo->constPtrCast<StructTypeInfo>();
+std::vector<const StructField*> StructType::getFields(const LogicalType& type) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structTypeInfo = type.extraTypeInfo->constPtrCast<StructTypeInfo>();
     return structTypeInfo->getStructFields();
 }
 
-bool StructType::hasField(const LogicalType* type, const std::string& key) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structTypeInfo = type->extraTypeInfo->constPtrCast<StructTypeInfo>();
+bool StructType::hasField(const LogicalType& type, const std::string& key) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structTypeInfo = type.extraTypeInfo->constPtrCast<StructTypeInfo>();
     return structTypeInfo->hasField(key);
 }
 
-const StructField* StructType::getField(const LogicalType* type, struct_field_idx_t idx) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structTypeInfo = type->extraTypeInfo->constPtrCast<StructTypeInfo>();
+const StructField* StructType::getField(const LogicalType& type, struct_field_idx_t idx) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structTypeInfo = type.extraTypeInfo->constPtrCast<StructTypeInfo>();
     return structTypeInfo->getStructField(idx);
 }
 
-const StructField* StructType::getField(const LogicalType* type, const std::string& key) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structTypeInfo = type->extraTypeInfo->constPtrCast<StructTypeInfo>();
+const StructField* StructType::getField(const LogicalType& type, const std::string& key) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structTypeInfo = type.extraTypeInfo->constPtrCast<StructTypeInfo>();
     return structTypeInfo->getStructField(key);
 }
 
-struct_field_idx_t StructType::getFieldIdx(const LogicalType* type, const std::string& key) {
-    KU_ASSERT(type->getPhysicalType() == PhysicalTypeID::STRUCT);
-    auto structTypeInfo = type->extraTypeInfo->constPtrCast<StructTypeInfo>();
+struct_field_idx_t StructType::getFieldIdx(const LogicalType& type, const std::string& key) {
+    KU_ASSERT(type.getPhysicalType() == PhysicalTypeID::STRUCT);
+    auto structTypeInfo = type.extraTypeInfo->constPtrCast<StructTypeInfo>();
     return structTypeInfo->getStructFieldIdx(key);
 }
 
-LogicalType* MapType::getKeyType(const LogicalType* type) {
-    KU_ASSERT(type->getLogicalTypeID() == LogicalTypeID::MAP);
-    return StructType::getFieldTypes(ListType::getChildType(type))[0];
+LogicalType* MapType::getKeyType(const LogicalType& type) {
+    KU_ASSERT(type.getLogicalTypeID() == LogicalTypeID::MAP);
+    return StructType::getFieldTypes(*ListType::getChildType(type))[0];
 }
 
-LogicalType* MapType::getValueType(const LogicalType* type) {
-    KU_ASSERT(type->getLogicalTypeID() == LogicalTypeID::MAP);
-    return StructType::getFieldTypes(ListType::getChildType(type))[1];
+LogicalType* MapType::getValueType(const LogicalType& type) {
+    KU_ASSERT(type.getLogicalTypeID() == LogicalTypeID::MAP);
+    return StructType::getFieldTypes(*ListType::getChildType(type))[1];
 }
 
 union_field_idx_t UnionType::getInternalFieldIdx(union_field_idx_t idx) {
     return idx + 1;
 }
 
-std::string UnionType::getFieldName(const LogicalType* type, union_field_idx_t idx) {
-    KU_ASSERT(type->getLogicalTypeID() == LogicalTypeID::UNION);
+std::string UnionType::getFieldName(const LogicalType& type, union_field_idx_t idx) {
+    KU_ASSERT(type.getLogicalTypeID() == LogicalTypeID::UNION);
     return StructType::getFieldNames(type)[getInternalFieldIdx(idx)];
 }
 
-LogicalType* UnionType::getFieldType(const LogicalType* type, union_field_idx_t idx) {
-    KU_ASSERT(type->getLogicalTypeID() == LogicalTypeID::UNION);
+LogicalType* UnionType::getFieldType(const LogicalType& type, union_field_idx_t idx) {
+    KU_ASSERT(type.getLogicalTypeID() == LogicalTypeID::UNION);
     return StructType::getFieldTypes(type)[getInternalFieldIdx(idx)];
 }
 
-uint64_t UnionType::getNumFields(const LogicalType* type) {
-    KU_ASSERT(type->getLogicalTypeID() == LogicalTypeID::UNION);
+uint64_t UnionType::getNumFields(const LogicalType& type) {
+    KU_ASSERT(type.getLogicalTypeID() == LogicalTypeID::UNION);
     return StructType::getNumFields(type) - 1;
 }
 

--- a/src/common/types/value/node.cpp
+++ b/src/common/types/value/node.cpp
@@ -12,7 +12,7 @@ std::vector<std::pair<std::string, std::unique_ptr<Value>>> NodeVal::getProperti
     const Value* val) {
     throwIfNotNode(val);
     std::vector<std::pair<std::string, std::unique_ptr<Value>>> properties;
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     for (auto i = 0u; i < val->childrenSize; ++i) {
         auto currKey = fieldNames[i];
         if (currKey == InternalKeyword::ID || currKey == InternalKeyword::LABEL) {
@@ -25,13 +25,13 @@ std::vector<std::pair<std::string, std::unique_ptr<Value>>> NodeVal::getProperti
 
 uint64_t NodeVal::getNumProperties(const Value* val) {
     throwIfNotNode(val);
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     return fieldNames.size() - OFFSET;
 }
 
 std::string NodeVal::getPropertyName(const Value* val, uint64_t index) {
     throwIfNotNode(val);
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return "";
     }
@@ -40,7 +40,7 @@ std::string NodeVal::getPropertyName(const Value* val, uint64_t index) {
 
 Value* NodeVal::getPropertyVal(const Value* val, uint64_t index) {
     throwIfNotNode(val);
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return nullptr;
     }
@@ -49,13 +49,13 @@ Value* NodeVal::getPropertyVal(const Value* val, uint64_t index) {
 
 Value* NodeVal::getNodeIDVal(const Value* val) {
     throwIfNotNode(val);
-    auto fieldIdx = StructType::getFieldIdx(val->dataType.get(), InternalKeyword::ID);
+    auto fieldIdx = StructType::getFieldIdx(*val->dataType, InternalKeyword::ID);
     return val->children[fieldIdx].get();
 }
 
 Value* NodeVal::getLabelVal(const Value* val) {
     throwIfNotNode(val);
-    auto fieldIdx = StructType::getFieldIdx(val->dataType.get(), InternalKeyword::LABEL);
+    auto fieldIdx = StructType::getFieldIdx(*val->dataType, InternalKeyword::LABEL);
     return val->children[fieldIdx].get();
 }
 

--- a/src/common/types/value/rel.cpp
+++ b/src/common/types/value/rel.cpp
@@ -11,7 +11,7 @@ std::vector<std::pair<std::string, std::unique_ptr<Value>>> RelVal::getPropertie
     const Value* val) {
     throwIfNotRel(val);
     std::vector<std::pair<std::string, std::unique_ptr<Value>>> properties;
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     for (auto i = 0u; i < val->childrenSize; ++i) {
         auto currKey = fieldNames[i];
         if (currKey == InternalKeyword::ID || currKey == InternalKeyword::LABEL ||
@@ -26,13 +26,13 @@ std::vector<std::pair<std::string, std::unique_ptr<Value>>> RelVal::getPropertie
 
 uint64_t RelVal::getNumProperties(const Value* val) {
     throwIfNotRel(val);
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     return fieldNames.size() - OFFSET;
 }
 
 std::string RelVal::getPropertyName(const Value* val, uint64_t index) {
     throwIfNotRel(val);
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return "";
     }
@@ -41,7 +41,7 @@ std::string RelVal::getPropertyName(const Value* val, uint64_t index) {
 
 Value* RelVal::getPropertyVal(const Value* val, uint64_t index) {
     throwIfNotRel(val);
-    auto fieldNames = StructType::getFieldNames(val->dataType.get());
+    auto fieldNames = StructType::getFieldNames(*val->dataType);
     if (index >= fieldNames.size() - OFFSET) {
         return nullptr;
     }
@@ -49,22 +49,22 @@ Value* RelVal::getPropertyVal(const Value* val, uint64_t index) {
 }
 
 Value* RelVal::getIDVal(const Value* val) {
-    auto fieldIdx = StructType::getFieldIdx(val->dataType.get(), InternalKeyword::ID);
+    auto fieldIdx = StructType::getFieldIdx(*val->dataType, InternalKeyword::ID);
     return val->children[fieldIdx].get();
 }
 
 Value* RelVal::getSrcNodeIDVal(const Value* val) {
-    auto fieldIdx = StructType::getFieldIdx(val->dataType.get(), InternalKeyword::SRC);
+    auto fieldIdx = StructType::getFieldIdx(*val->dataType, InternalKeyword::SRC);
     return val->children[fieldIdx].get();
 }
 
 Value* RelVal::getDstNodeIDVal(const Value* val) {
-    auto fieldIdx = StructType::getFieldIdx(val->dataType.get(), InternalKeyword::DST);
+    auto fieldIdx = StructType::getFieldIdx(*val->dataType, InternalKeyword::DST);
     return val->children[fieldIdx].get();
 }
 
 Value* RelVal::getLabelVal(const Value* val) {
-    auto fieldIdx = StructType::getFieldIdx(val->dataType.get(), InternalKeyword::LABEL);
+    auto fieldIdx = StructType::getFieldIdx(*val->dataType, InternalKeyword::LABEL);
     return val->children[fieldIdx].get();
 }
 

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -155,8 +155,8 @@ Value Value::createDefaultValue(const LogicalType& dataType) {
         return Value((float)0);
     case LogicalTypeID::ARRAY: {
         std::vector<std::unique_ptr<Value>> children;
-        auto childType = ArrayType::getChildType(&dataType);
-        auto arraySize = ArrayType::getNumElements(&dataType);
+        auto childType = ArrayType::getChildType(dataType);
+        auto arraySize = ArrayType::getNumElements(dataType);
         children.reserve(arraySize);
         for (auto i = 0u; i < arraySize; ++i) {
             children.push_back(std::make_unique<Value>(createDefaultValue(*childType)));
@@ -391,7 +391,7 @@ void Value::copyFromRowLayout(const uint8_t* value) {
         copyFromRowLayoutList(*(ku_list_t*)value, *ListType::getChildType(*dataType));
     } break;
     case LogicalTypeID::ARRAY: {
-        copyFromRowLayoutList(*(ku_list_t*)value, *ArrayType::getChildType(dataType.get()));
+        copyFromRowLayoutList(*(ku_list_t*)value, *ArrayType::getChildType(*dataType));
     } break;
     case LogicalTypeID::UNION: {
         copyFromUnion(value);

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -388,7 +388,7 @@ void Value::copyFromRowLayout(const uint8_t* value) {
     } break;
     case LogicalTypeID::MAP:
     case LogicalTypeID::LIST: {
-        copyFromRowLayoutList(*(ku_list_t*)value, *ListType::getChildType(dataType.get()));
+        copyFromRowLayoutList(*(ku_list_t*)value, *ListType::getChildType(*dataType));
     } break;
     case LogicalTypeID::ARRAY: {
         copyFromRowLayoutList(*(ku_list_t*)value, *ArrayType::getChildType(dataType.get()));

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -706,11 +706,11 @@ void Value::copyFromUnion(const uint8_t* kuUnion) {
     // union fields into value.
     auto activeFieldIdx = UnionType::getInternalFieldIdx(*(union_field_idx_t*)unionValues);
     auto childValue = children[0].get();
-    childValue->dataType = childrenTypes[activeFieldIdx]->copy();
+    childValue->dataType = childrenTypes[activeFieldIdx].copy();
     auto curMemberIdx = 0u;
     // Seek to the current active member value.
     while (curMemberIdx < activeFieldIdx) {
-        unionValues += storage::StorageUtils::getDataTypeSize(*childrenTypes[curMemberIdx]);
+        unionValues += storage::StorageUtils::getDataTypeSize(childrenTypes[curMemberIdx]);
         curMemberIdx++;
     }
     if (NullBuffer::isNull(unionNullValues, activeFieldIdx)) {

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -159,7 +159,7 @@ Value Value::createDefaultValue(const LogicalType& dataType) {
         auto arraySize = ArrayType::getNumElements(dataType);
         children.reserve(arraySize);
         for (auto i = 0u; i < arraySize; ++i) {
-            children.push_back(std::make_unique<Value>(createDefaultValue(*childType)));
+            children.push_back(std::make_unique<Value>(createDefaultValue(childType)));
         }
         return Value(dataType.copy(), std::move(children));
     }
@@ -388,10 +388,10 @@ void Value::copyFromRowLayout(const uint8_t* value) {
     } break;
     case LogicalTypeID::MAP:
     case LogicalTypeID::LIST: {
-        copyFromRowLayoutList(*(ku_list_t*)value, *ListType::getChildType(*dataType));
+        copyFromRowLayoutList(*(ku_list_t*)value, ListType::getChildType(*dataType));
     } break;
     case LogicalTypeID::ARRAY: {
-        copyFromRowLayoutList(*(ku_list_t*)value, *ArrayType::getChildType(*dataType));
+        copyFromRowLayoutList(*(ku_list_t*)value, ArrayType::getChildType(*dataType));
     } break;
     case LogicalTypeID::UNION: {
         copyFromUnion(value);

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -179,7 +179,7 @@ Value Value::createDefaultValue(const LogicalType& dataType) {
     case LogicalTypeID::RDF_VARIANT: {
         std::vector<std::unique_ptr<Value>> children;
         for (auto& field : StructType::getFields(dataType)) {
-            children.push_back(std::make_unique<Value>(createDefaultValue(*field->getType())));
+            children.push_back(std::make_unique<Value>(createDefaultValue(field.getType())));
         }
         return Value(dataType.copy(), std::move(children));
     }

--- a/src/common/types/value/value.cpp
+++ b/src/common/types/value/value.cpp
@@ -178,7 +178,7 @@ Value Value::createDefaultValue(const LogicalType& dataType) {
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::RDF_VARIANT: {
         std::vector<std::unique_ptr<Value>> children;
-        for (auto& field : StructType::getFields(&dataType)) {
+        for (auto& field : StructType::getFields(dataType)) {
             children.push_back(std::make_unique<Value>(createDefaultValue(*field->getType())));
         }
         return Value(dataType.copy(), std::move(children));
@@ -699,7 +699,7 @@ void Value::copyFromColLayoutStruct(const struct_entry_t& structEntry, ValueVect
 }
 
 void Value::copyFromUnion(const uint8_t* kuUnion) {
-    auto childrenTypes = StructType::getFieldTypes(dataType.get());
+    auto childrenTypes = StructType::getFieldTypes(*dataType);
     auto unionNullValues = kuUnion;
     auto unionValues = unionNullValues + NullBuffer::getNumBytesForNullValues(childrenTypes.size());
     // For union dataType, only one member can be active at a time. So we don't need to copy all
@@ -1007,7 +1007,7 @@ std::string Value::listToString() const {
 
 std::string Value::structToString() const {
     std::string result = "{";
-    auto fieldNames = StructType::getFieldNames(dataType.get());
+    auto fieldNames = StructType::getFieldNames(*dataType);
     for (auto i = 0u; i < childrenSize; ++i) {
         result += fieldNames[i] + ": ";
         result += children[i]->toString();
@@ -1026,7 +1026,7 @@ std::string Value::nodeToString() const {
         return "";
     }
     std::string result = "{";
-    auto fieldNames = StructType::getFieldNames(dataType.get());
+    auto fieldNames = StructType::getFieldNames(*dataType);
     for (auto i = 0u; i < childrenSize; ++i) {
         if (children[i]->isNull_) {
             // Avoid printing null key value pair.
@@ -1048,7 +1048,7 @@ std::string Value::relToString() const {
         return "";
     }
     std::string result = "(" + children[0]->toString() + ")-{";
-    auto fieldNames = StructType::getFieldNames(dataType.get());
+    auto fieldNames = StructType::getFieldNames(*dataType);
     for (auto i = 2u; i < childrenSize; ++i) {
         if (children[i]->isNull_) {
             // Avoid printing null key value pair.

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -79,7 +79,7 @@ std::unique_ptr<AuxiliaryBuffer> AuxiliaryBufferFactory::getAuxiliaryBuffer(Logi
     case PhysicalTypeID::STRUCT:
         return std::make_unique<StructAuxiliaryBuffer>(type, memoryManager);
     case PhysicalTypeID::LIST:
-        return std::make_unique<ListAuxiliaryBuffer>(*ListType::getChildType(&type), memoryManager);
+        return std::make_unique<ListAuxiliaryBuffer>(*ListType::getChildType(type), memoryManager);
     case PhysicalTypeID::ARRAY:
         return std::make_unique<ListAuxiliaryBuffer>(*ArrayType::getChildType(&type),
             memoryManager);

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -81,8 +81,7 @@ std::unique_ptr<AuxiliaryBuffer> AuxiliaryBufferFactory::getAuxiliaryBuffer(Logi
     case PhysicalTypeID::LIST:
         return std::make_unique<ListAuxiliaryBuffer>(*ListType::getChildType(type), memoryManager);
     case PhysicalTypeID::ARRAY:
-        return std::make_unique<ListAuxiliaryBuffer>(*ArrayType::getChildType(type),
-            memoryManager);
+        return std::make_unique<ListAuxiliaryBuffer>(*ArrayType::getChildType(type), memoryManager);
     default:
         return nullptr;
     }

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -7,7 +7,7 @@ namespace common {
 
 StructAuxiliaryBuffer::StructAuxiliaryBuffer(const LogicalType& type,
     storage::MemoryManager* memoryManager) {
-    auto fieldTypes = StructType::getFieldTypes(&type);
+    auto fieldTypes = StructType::getFieldTypes(type);
     childrenVectors.reserve(fieldTypes.size());
     for (auto fieldType : fieldTypes) {
         childrenVectors.push_back(std::make_shared<ValueVector>(*fieldType, memoryManager));

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -79,9 +79,9 @@ std::unique_ptr<AuxiliaryBuffer> AuxiliaryBufferFactory::getAuxiliaryBuffer(Logi
     case PhysicalTypeID::STRUCT:
         return std::make_unique<StructAuxiliaryBuffer>(type, memoryManager);
     case PhysicalTypeID::LIST:
-        return std::make_unique<ListAuxiliaryBuffer>(*ListType::getChildType(type), memoryManager);
+        return std::make_unique<ListAuxiliaryBuffer>(ListType::getChildType(type), memoryManager);
     case PhysicalTypeID::ARRAY:
-        return std::make_unique<ListAuxiliaryBuffer>(*ArrayType::getChildType(type), memoryManager);
+        return std::make_unique<ListAuxiliaryBuffer>(ArrayType::getChildType(type), memoryManager);
     default:
         return nullptr;
     }

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -10,7 +10,7 @@ StructAuxiliaryBuffer::StructAuxiliaryBuffer(const LogicalType& type,
     auto fieldTypes = StructType::getFieldTypes(type);
     childrenVectors.reserve(fieldTypes.size());
     for (auto fieldType : fieldTypes) {
-        childrenVectors.push_back(std::make_shared<ValueVector>(*fieldType, memoryManager));
+        childrenVectors.push_back(std::make_shared<ValueVector>(fieldType, memoryManager));
     }
 }
 

--- a/src/common/vector/auxiliary_buffer.cpp
+++ b/src/common/vector/auxiliary_buffer.cpp
@@ -81,7 +81,7 @@ std::unique_ptr<AuxiliaryBuffer> AuxiliaryBufferFactory::getAuxiliaryBuffer(Logi
     case PhysicalTypeID::LIST:
         return std::make_unique<ListAuxiliaryBuffer>(*ListType::getChildType(type), memoryManager);
     case PhysicalTypeID::ARRAY:
-        return std::make_unique<ListAuxiliaryBuffer>(*ArrayType::getChildType(&type),
+        return std::make_unique<ListAuxiliaryBuffer>(*ArrayType::getChildType(type),
             memoryManager);
     default:
         return nullptr;

--- a/src/expression_evaluator/node_rel_evaluator.cpp
+++ b/src/expression_evaluator/node_rel_evaluator.cpp
@@ -15,7 +15,7 @@ void NodeRelExpressionEvaluator::evaluate(ClientContext* clientContext) {
     }
     StructPackFunctions::execFunc(parameters, *resultVector);
     auto structType = nodeOrRel->getDataType();
-    auto internalIDIdx = StructType::getFieldIdx(&structType, InternalKeyword::ID);
+    auto internalIDIdx = StructType::getFieldIdx(structType, InternalKeyword::ID);
     auto internalIDVector = StructVector::getFieldVector(resultVector.get(), internalIDIdx);
     for (auto i = 0u; i < resultVector->state->selVector->selectedSize; ++i) {
         auto pos = resultVector->state->selVector->selectedPositions[i];

--- a/src/expression_evaluator/path_evaluator.cpp
+++ b/src/expression_evaluator/path_evaluator.cpp
@@ -15,10 +15,10 @@ namespace evaluator {
 static std::vector<ValueVector*> getFieldVectors(const LogicalType& inputType,
     const LogicalType& resultType, ValueVector* inputVector) {
     std::vector<ValueVector*> result;
-    for (auto field : StructType::getFields(&resultType)) {
+    for (auto field : StructType::getFields(resultType)) {
         auto fieldName = StringUtils::getUpper(field->getName());
-        if (StructType::hasField(&inputType, fieldName)) {
-            auto idx = StructType::getFieldIdx(&inputType, fieldName);
+        if (StructType::hasField(inputType, fieldName)) {
+            auto idx = StructType::getFieldIdx(inputType, fieldName);
             result.push_back(StructVector::getFieldVector(inputVector, idx).get());
         } else {
             result.push_back(nullptr);
@@ -30,13 +30,13 @@ static std::vector<ValueVector*> getFieldVectors(const LogicalType& inputType,
 void PathExpressionEvaluator::init(const processor::ResultSet& resultSet,
     storage::MemoryManager* memoryManager) {
     ExpressionEvaluator::init(resultSet, memoryManager);
-    auto resultNodesIdx = StructType::getFieldIdx(&resultVector->dataType, InternalKeyword::NODES);
+    auto resultNodesIdx = StructType::getFieldIdx(resultVector->dataType, InternalKeyword::NODES);
     resultNodesVector = StructVector::getFieldVector(resultVector.get(), resultNodesIdx).get();
     auto resultNodesDataVector = ListVector::getDataVector(resultNodesVector);
     for (auto& fieldVector : StructVector::getFieldVectors(resultNodesDataVector)) {
         resultNodesFieldVectors.push_back(fieldVector.get());
     }
-    auto resultRelsIdx = StructType::getFieldIdx(&resultVector->dataType, InternalKeyword::RELS);
+    auto resultRelsIdx = StructType::getFieldIdx(resultVector->dataType, InternalKeyword::RELS);
     resultRelsVector = StructVector::getFieldVector(resultVector.get(), resultRelsIdx).get();
     auto resultRelsDataVector = ListVector::getDataVector(resultRelsVector);
     for (auto& fieldVector : StructVector::getFieldVectors(resultRelsDataVector)) {
@@ -60,13 +60,13 @@ void PathExpressionEvaluator::init(const processor::ResultSet& resultSet,
             auto rel = (RelExpression*)child;
             auto recursiveNode = rel->getRecursiveInfo()->node;
             auto recursiveRel = rel->getRecursiveInfo()->rel;
-            auto nodeFieldIdx = StructType::getFieldIdx(&child->dataType, InternalKeyword::NODES);
+            auto nodeFieldIdx = StructType::getFieldIdx(child->dataType, InternalKeyword::NODES);
             vectors->nodesInput = StructVector::getFieldVector(vectors->input, nodeFieldIdx).get();
             vectors->nodesDataInput = ListVector::getDataVector(vectors->nodesInput);
             vectors->nodeFieldVectors = getFieldVectors(recursiveNode->dataType,
                 *pathExpression->getNodeType(), vectors->nodesDataInput);
             auto relFieldIdx =
-                StructType::getFieldIdx(&vectors->input->dataType, InternalKeyword::RELS);
+                StructType::getFieldIdx(vectors->input->dataType, InternalKeyword::RELS);
             vectors->relsInput = StructVector::getFieldVector(vectors->input, relFieldIdx).get();
             vectors->relsDataInput = ListVector::getDataVector(vectors->relsInput);
             vectors->relFieldVectors = getFieldVectors(recursiveRel->dataType,

--- a/src/expression_evaluator/path_evaluator.cpp
+++ b/src/expression_evaluator/path_evaluator.cpp
@@ -15,7 +15,7 @@ namespace evaluator {
 static std::vector<ValueVector*> getFieldVectors(const LogicalType& inputType,
     const LogicalType& resultType, ValueVector* inputVector) {
     std::vector<ValueVector*> result;
-    for (auto field : StructType::getFields(resultType)) {
+    for (auto& field : StructType::getFields(resultType)) {
         auto fieldName = StringUtils::getUpper(field.getName());
         if (StructType::hasField(inputType, fieldName)) {
             auto idx = StructType::getFieldIdx(inputType, fieldName);

--- a/src/expression_evaluator/path_evaluator.cpp
+++ b/src/expression_evaluator/path_evaluator.cpp
@@ -16,7 +16,7 @@ static std::vector<ValueVector*> getFieldVectors(const LogicalType& inputType,
     const LogicalType& resultType, ValueVector* inputVector) {
     std::vector<ValueVector*> result;
     for (auto field : StructType::getFields(resultType)) {
-        auto fieldName = StringUtils::getUpper(field->getName());
+        auto fieldName = StringUtils::getUpper(field.getName());
         if (StructType::hasField(inputType, fieldName)) {
             auto idx = StructType::getFieldIdx(inputType, fieldName);
             result.push_back(StructVector::getFieldVector(inputVector, idx).get());

--- a/src/function/array/array_functions.cpp
+++ b/src/function/array/array_functions.cpp
@@ -56,8 +56,8 @@ std::unique_ptr<FunctionBindData> ArrayCrossProductBindFunc(
                 ArrayCrossProductFunction::name)};
     }
     ku_dynamic_cast<Function*, ScalarFunction*>(function)->execFunc = execFunc;
-    auto resultType = LogicalType::ARRAY(*ArrayType::getChildType(leftType),
-        ArrayType::getNumElements(leftType));
+    auto resultType =
+        LogicalType::ARRAY(*ArrayType::getChildType(leftType), ArrayType::getNumElements(leftType));
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/array/array_functions.cpp
+++ b/src/function/array/array_functions.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<FunctionBindData> ArrayCrossProductBindFunc(
                 ArrayCrossProductFunction::name));
     }
     scalar_func_exec_t execFunc;
-    switch (ArrayType::getChildType(leftType)->getLogicalTypeID()) {
+    switch (ArrayType::getChildType(leftType).getLogicalTypeID()) {
     case LogicalTypeID::INT128:
         execFunc = ScalarFunction::BinaryExecListStructFunction<list_entry_t, list_entry_t,
             list_entry_t, ArrayCrossProduct<int128_t>>;
@@ -57,7 +57,7 @@ std::unique_ptr<FunctionBindData> ArrayCrossProductBindFunc(
     }
     ku_dynamic_cast<Function*, ScalarFunction*>(function)->execFunc = execFunc;
     auto resultType =
-        LogicalType::ARRAY(*ArrayType::getChildType(leftType), ArrayType::getNumElements(leftType));
+        LogicalType::ARRAY(ArrayType::getChildType(leftType), ArrayType::getNumElements(leftType));
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 
@@ -75,9 +75,9 @@ function_set ArrayCrossProductFunction::getFunctionSet() {
 static LogicalType getChildType(const LogicalType& type) {
     switch (type.getLogicalTypeID()) {
     case LogicalTypeID::ARRAY:
-        return *ArrayType::getChildType(type);
+        return ArrayType::getChildType(type);
     case LogicalTypeID::LIST:
-        return *ListType::getChildType(type);
+        return ListType::getChildType(type);
         // LCOV_EXCL_START
     default:
         throw BinderException(stringFormat(
@@ -123,7 +123,7 @@ static scalar_func_exec_t getBinaryArrayExecFuncSwitchResultType() {
 template<typename OPERATION>
 scalar_func_exec_t getScalarExecFunc(LogicalType type) {
     scalar_func_exec_t execFunc;
-    switch (ArrayType::getChildType(type)->getLogicalTypeID()) {
+    switch (ArrayType::getChildType(type).getLogicalTypeID()) {
     case LogicalTypeID::FLOAT:
         execFunc = getBinaryArrayExecFuncSwitchResultType<OPERATION, float>();
         break;
@@ -143,7 +143,7 @@ std::unique_ptr<FunctionBindData> arrayTemplateBindFunc(std::string functionName
     auto rightType = arguments[1]->dataType;
     auto paramType = validateArrayFunctionParameters(leftType, rightType, functionName);
     function->ptrCast<ScalarFunction>()->execFunc = getScalarExecFunc<OPERATION>(paramType);
-    auto bindData = std::make_unique<FunctionBindData>(ArrayType::getChildType(paramType)->copy());
+    auto bindData = std::make_unique<FunctionBindData>(ArrayType::getChildType(paramType).copy());
     std::vector<LogicalType> paramTypes;
     for (auto& _ : arguments) {
         (void)_;

--- a/src/function/array/array_functions.cpp
+++ b/src/function/array/array_functions.cpp
@@ -77,7 +77,7 @@ static LogicalType getChildType(const LogicalType& type) {
     case LogicalTypeID::ARRAY:
         return *ArrayType::getChildType(&type);
     case LogicalTypeID::LIST:
-        return *ListType::getChildType(&type);
+        return *ListType::getChildType(type);
         // LCOV_EXCL_START
     default:
         throw BinderException(stringFormat(

--- a/src/function/array/array_functions.cpp
+++ b/src/function/array/array_functions.cpp
@@ -21,7 +21,7 @@ std::unique_ptr<FunctionBindData> ArrayCrossProductBindFunc(
                 ArrayCrossProductFunction::name));
     }
     scalar_func_exec_t execFunc;
-    switch (ArrayType::getChildType(&leftType)->getLogicalTypeID()) {
+    switch (ArrayType::getChildType(leftType)->getLogicalTypeID()) {
     case LogicalTypeID::INT128:
         execFunc = ScalarFunction::BinaryExecListStructFunction<list_entry_t, list_entry_t,
             list_entry_t, ArrayCrossProduct<int128_t>>;
@@ -56,8 +56,8 @@ std::unique_ptr<FunctionBindData> ArrayCrossProductBindFunc(
                 ArrayCrossProductFunction::name)};
     }
     ku_dynamic_cast<Function*, ScalarFunction*>(function)->execFunc = execFunc;
-    auto resultType = LogicalType::ARRAY(*ArrayType::getChildType(&leftType),
-        ArrayType::getNumElements(&leftType));
+    auto resultType = LogicalType::ARRAY(*ArrayType::getChildType(leftType),
+        ArrayType::getNumElements(leftType));
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 
@@ -75,7 +75,7 @@ function_set ArrayCrossProductFunction::getFunctionSet() {
 static LogicalType getChildType(const LogicalType& type) {
     switch (type.getLogicalTypeID()) {
     case LogicalTypeID::ARRAY:
-        return *ArrayType::getChildType(&type);
+        return *ArrayType::getChildType(type);
     case LogicalTypeID::LIST:
         return *ListType::getChildType(type);
         // LCOV_EXCL_START
@@ -123,7 +123,7 @@ static scalar_func_exec_t getBinaryArrayExecFuncSwitchResultType() {
 template<typename OPERATION>
 scalar_func_exec_t getScalarExecFunc(LogicalType type) {
     scalar_func_exec_t execFunc;
-    switch (ArrayType::getChildType(&type)->getLogicalTypeID()) {
+    switch (ArrayType::getChildType(type)->getLogicalTypeID()) {
     case LogicalTypeID::FLOAT:
         execFunc = getBinaryArrayExecFuncSwitchResultType<OPERATION, float>();
         break;
@@ -143,7 +143,7 @@ std::unique_ptr<FunctionBindData> arrayTemplateBindFunc(std::string functionName
     auto rightType = arguments[1]->dataType;
     auto paramType = validateArrayFunctionParameters(leftType, rightType, functionName);
     function->ptrCast<ScalarFunction>()->execFunc = getScalarExecFunc<OPERATION>(paramType);
-    auto bindData = std::make_unique<FunctionBindData>(ArrayType::getChildType(&paramType)->copy());
+    auto bindData = std::make_unique<FunctionBindData>(ArrayType::getChildType(paramType)->copy());
     std::vector<LogicalType> paramTypes;
     for (auto& _ : arguments) {
         (void)_;

--- a/src/function/cast/cast_array.cpp
+++ b/src/function/cast/cast_array.cpp
@@ -41,12 +41,12 @@ bool CastArrayHelper::containsListToArray(const LogicalType* srcType, const Logi
     if (checkCompatibleNestedTypes(srcType->getLogicalTypeID(), dstType->getLogicalTypeID())) {
         switch (srcType->getPhysicalType()) {
         case PhysicalTypeID::LIST: {
-            return containsListToArray(ListType::getChildType(srcType),
-                ListType::getChildType(dstType));
+            return containsListToArray(ListType::getChildType(*srcType),
+                ListType::getChildType(*dstType));
         }
         case PhysicalTypeID::ARRAY: {
             return containsListToArray(ArrayType::getChildType(srcType),
-                ListType::getChildType(dstType));
+                ListType::getChildType(*dstType));
         }
         case PhysicalTypeID::STRUCT: {
             auto srcFieldTypes = StructType::getFieldTypes(srcType);
@@ -111,7 +111,7 @@ void CastArrayHelper::validateListEntry(ValueVector* inputVector, LogicalType* r
             auto listEntry = inputVector->getValue<list_entry_t>(pos);
             auto inputChildVector = ListVector::getDataVector(inputVector);
             for (auto i = listEntry.offset; i < listEntry.offset + listEntry.size; i++) {
-                validateListEntry(inputChildVector, ListType::getChildType(resultType), i);
+                validateListEntry(inputChildVector, ListType::getChildType(*resultType), i);
             }
         }
     } break;

--- a/src/function/cast/cast_array.cpp
+++ b/src/function/cast/cast_array.cpp
@@ -45,7 +45,7 @@ bool CastArrayHelper::containsListToArray(const LogicalType* srcType, const Logi
                 ListType::getChildType(*dstType));
         }
         case PhysicalTypeID::ARRAY: {
-            return containsListToArray(ArrayType::getChildType(srcType),
+            return containsListToArray(ArrayType::getChildType(*srcType),
                 ListType::getChildType(*dstType));
         }
         case PhysicalTypeID::STRUCT: {
@@ -81,19 +81,19 @@ void CastArrayHelper::validateListEntry(ValueVector* inputVector, LogicalType* r
     case PhysicalTypeID::ARRAY: {
         if (inputType.getPhysicalType() == PhysicalTypeID::LIST) {
             auto listEntry = inputVector->getValue<list_entry_t>(pos);
-            if (listEntry.size != ArrayType::getNumElements(resultType)) {
+            if (listEntry.size != ArrayType::getNumElements(*resultType)) {
                 throw ConversionException{
                     stringFormat("Unsupported casting LIST with incorrect list entry to ARRAY. "
                                  "Expected: {}, Actual: {}.",
-                        ArrayType::getNumElements(resultType),
+                        ArrayType::getNumElements(*resultType),
                         inputVector->getValue<list_entry_t>(pos).size)};
             }
             auto inputChildVector = ListVector::getDataVector(inputVector);
             for (auto i = listEntry.offset; i < listEntry.offset + listEntry.size; i++) {
-                validateListEntry(inputChildVector, ArrayType::getChildType(resultType), i);
+                validateListEntry(inputChildVector, ArrayType::getChildType(*resultType), i);
             }
         } else if (inputType.getPhysicalType() == PhysicalTypeID::ARRAY) {
-            if (ArrayType::getNumElements(&inputType) != ArrayType::getNumElements(resultType)) {
+            if (ArrayType::getNumElements(inputType) != ArrayType::getNumElements(*resultType)) {
                 throw ConversionException(
                     stringFormat("Unsupported casting function from {} to {}.",
                         inputType.toString(), resultType->toString()));
@@ -101,7 +101,7 @@ void CastArrayHelper::validateListEntry(ValueVector* inputVector, LogicalType* r
             auto listEntry = inputVector->getValue<list_entry_t>(pos);
             auto inputChildVector = ListVector::getDataVector(inputVector);
             for (auto i = listEntry.offset; i < listEntry.offset + listEntry.size; i++) {
-                validateListEntry(inputChildVector, ArrayType::getChildType(resultType), i);
+                validateListEntry(inputChildVector, ArrayType::getChildType(*resultType), i);
             }
         }
     } break;

--- a/src/function/cast/cast_array.cpp
+++ b/src/function/cast/cast_array.cpp
@@ -49,8 +49,8 @@ bool CastArrayHelper::containsListToArray(const LogicalType* srcType, const Logi
                 ListType::getChildType(*dstType));
         }
         case PhysicalTypeID::STRUCT: {
-            auto srcFieldTypes = StructType::getFieldTypes(srcType);
-            auto dstFieldTypes = StructType::getFieldTypes(dstType);
+            auto srcFieldTypes = StructType::getFieldTypes(*srcType);
+            auto dstFieldTypes = StructType::getFieldTypes(*dstType);
             if (srcFieldTypes.size() != dstFieldTypes.size()) {
                 throw ConversionException{
                     stringFormat("Unsupported casting function from {} to {}.", srcType->toString(),
@@ -118,7 +118,7 @@ void CastArrayHelper::validateListEntry(ValueVector* inputVector, LogicalType* r
     case PhysicalTypeID::STRUCT: {
         if (inputType.getPhysicalType() == PhysicalTypeID::STRUCT) {
             auto fieldVectors = StructVector::getFieldVectors(inputVector);
-            auto fieldTypes = StructType::getFieldTypes(resultType);
+            auto fieldTypes = StructType::getFieldTypes(*resultType);
 
             auto structEntry = inputVector->getValue<struct_entry_t>(pos);
             for (auto i = 0u; i < fieldVectors.size(); i++) {

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -564,7 +564,7 @@ static bool tryCastStringToStruct(const char* input, uint64_t len, ValueVector* 
         auto keyEnd = input;
         trimRightWhitespace(keyStart, keyEnd);
         trimQuotes(keyStart, keyEnd);
-        auto fieldIdx = StructType::getFieldIdx(&type, std::string{keyStart, keyEnd});
+        auto fieldIdx = StructType::getFieldIdx(type, std::string{keyStart, keyEnd});
         if (fieldIdx == INVALID_STRUCT_FIELD_IDX) {
             throw ParserException{"Invalid struct field name: " + std::string{keyStart, keyEnd}};
         }

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -730,7 +730,7 @@ void CastStringHelper::cast(const char* input, uint64_t len, union_entry_t& /*re
     auto& type = vector->dataType;
     union_field_idx_t selectedFieldIdx = INVALID_STRUCT_FIELD_IDX;
 
-    for (auto i = 0u; i < UnionType::getNumFields(&type); i++) {
+    for (auto i = 0u; i < UnionType::getNumFields(type); i++) {
         auto internalFieldIdx = UnionType::getInternalFieldIdx(i);
         auto fieldVector = StructVector::getFieldVector(vector, internalFieldIdx).get();
         if (tryCastUnionField(fieldVector, rowToAdd, input, len)) {

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -340,7 +340,7 @@ static inline void startListCast(const char* input, uint64_t len, T split, const
 
 // ---------------------- cast String to Array Helper ------------------------------ //
 static void validateNumElementsInArray(uint64_t numElementsRead, const LogicalType& type) {
-    auto numElementsInArray = ArrayType::getNumElements(&type);
+    auto numElementsInArray = ArrayType::getNumElements(type);
     if (numElementsRead != numElementsInArray) {
         throw CopyException(stringFormat(
             "Each array should have fixed number of elements. Expected: {}, Actual: {}.",

--- a/src/function/list/list_agg_function.cpp
+++ b/src/function/list/list_agg_function.cpp
@@ -12,7 +12,7 @@ template<typename OPERATION>
 static std::unique_ptr<FunctionBindData> bindFuncListAggr(
     const binder::expression_vector& arguments, Function* function) {
     auto scalarFunction = function->ptrCast<ScalarFunction>();
-    auto resultType = ListType::getChildType(&arguments[0]->dataType);
+    auto resultType = ListType::getChildType(arguments[0]->dataType);
     TypeUtils::visit(
         resultType->getLogicalTypeID(),
         [&scalarFunction]<NumericTypes T>(T) {

--- a/src/function/list/list_agg_function.cpp
+++ b/src/function/list/list_agg_function.cpp
@@ -14,7 +14,7 @@ static std::unique_ptr<FunctionBindData> bindFuncListAggr(
     auto scalarFunction = function->ptrCast<ScalarFunction>();
     auto resultType = ListType::getChildType(arguments[0]->dataType);
     TypeUtils::visit(
-        resultType->getLogicalTypeID(),
+        resultType.getLogicalTypeID(),
         [&scalarFunction]<NumericTypes T>(T) {
             scalarFunction->execFunc =
                 ScalarFunction::UnaryExecNestedTypeFunction<list_entry_t, T, OPERATION>;

--- a/src/function/list/list_agg_function.cpp
+++ b/src/function/list/list_agg_function.cpp
@@ -21,9 +21,9 @@ static std::unique_ptr<FunctionBindData> bindFuncListAggr(
         },
         [&function, &resultType](auto) {
             throw BinderException(stringFormat("Unsupported inner data type for {}: {}",
-                function->name, LogicalTypeUtils::toString(resultType->getLogicalTypeID())));
+                function->name, LogicalTypeUtils::toString(resultType.getLogicalTypeID())));
         });
-    return FunctionBindData::getSimpleBindData(arguments, *resultType);
+    return FunctionBindData::getSimpleBindData(arguments, resultType);
 }
 
 struct ListSum {

--- a/src/function/list/list_any_value_function.cpp
+++ b/src/function/list/list_any_value_function.cpp
@@ -30,11 +30,11 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     Function* function) {
     auto scalarFunction = ku_dynamic_cast<Function*, ScalarFunction*>(function);
     auto resultType = ListType::getChildType(arguments[0]->dataType);
-    TypeUtils::visit(resultType->getPhysicalType(), [&scalarFunction]<typename T>(T) {
+    TypeUtils::visit(resultType.getPhysicalType(), [&scalarFunction]<typename T>(T) {
         scalarFunction->execFunc =
             ScalarFunction::UnaryExecNestedTypeFunction<list_entry_t, T, ListAnyValue>;
     });
-    return FunctionBindData::getSimpleBindData(arguments, *resultType);
+    return FunctionBindData::getSimpleBindData(arguments, resultType);
 }
 
 function_set ListAnyValueFunction::getFunctionSet() {

--- a/src/function/list/list_any_value_function.cpp
+++ b/src/function/list/list_any_value_function.cpp
@@ -29,7 +29,7 @@ struct ListAnyValue {
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     Function* function) {
     auto scalarFunction = ku_dynamic_cast<Function*, ScalarFunction*>(function);
-    auto resultType = ListType::getChildType(&arguments[0]->dataType);
+    auto resultType = ListType::getChildType(arguments[0]->dataType);
     TypeUtils::visit(resultType->getPhysicalType(), [&scalarFunction]<typename T>(T) {
         scalarFunction->execFunc =
             ScalarFunction::UnaryExecNestedTypeFunction<list_entry_t, T, ListAnyValue>;

--- a/src/function/list/list_append_function.cpp
+++ b/src/function/list/list_append_function.cpp
@@ -29,7 +29,7 @@ struct ListAppend {
 };
 
 static void validateArgumentType(const binder::expression_vector& arguments) {
-    if (*ListType::getChildType(&arguments[0]->dataType) != arguments[1]->getDataType()) {
+    if (*ListType::getChildType(arguments[0]->dataType) != arguments[1]->getDataType()) {
         throw BinderException(
             ExceptionMessage::listFunctionIncompatibleChildrenType(ListAppendFunction::name,
                 arguments[0]->getDataType().toString(), arguments[1]->getDataType().toString()));

--- a/src/function/list/list_append_function.cpp
+++ b/src/function/list/list_append_function.cpp
@@ -29,7 +29,7 @@ struct ListAppend {
 };
 
 static void validateArgumentType(const binder::expression_vector& arguments) {
-    if (*ListType::getChildType(arguments[0]->dataType) != arguments[1]->getDataType()) {
+    if (ListType::getChildType(arguments[0]->dataType) != arguments[1]->getDataType()) {
         throw BinderException(
             ExceptionMessage::listFunctionIncompatibleChildrenType(ListAppendFunction::name,
                 arguments[0]->getDataType().toString(), arguments[1]->getDataType().toString()));

--- a/src/function/list/list_extract_function.cpp
+++ b/src/function/list/list_extract_function.cpp
@@ -20,14 +20,14 @@ static std::unique_ptr<FunctionBindData> ListExtractBindFunc(
     const binder::expression_vector& arguments, Function* function) {
     auto resultType = ListType::getChildType(arguments[0]->dataType);
     auto scalarFunction = function->ptrCast<ScalarFunction>();
-    TypeUtils::visit(resultType->getPhysicalType(), [&scalarFunction]<typename T>(T) {
+    TypeUtils::visit(resultType.getPhysicalType(), [&scalarFunction]<typename T>(T) {
         scalarFunction->execFunc =
             BinaryExecListExtractFunction<list_entry_t, int64_t, T, ListExtract>;
     });
     std::vector<LogicalType> paramTypes;
     paramTypes.push_back(arguments[0]->getDataType());
     paramTypes.push_back(LogicalType(function->parameterTypeIDs[1]));
-    return std::make_unique<FunctionBindData>(std::move(paramTypes), resultType->copy());
+    return std::make_unique<FunctionBindData>(std::move(paramTypes), resultType.copy());
 }
 
 function_set ListExtractFunction::getFunctionSet() {

--- a/src/function/list/list_extract_function.cpp
+++ b/src/function/list/list_extract_function.cpp
@@ -18,7 +18,7 @@ static void BinaryExecListExtractFunction(const std::vector<std::shared_ptr<Valu
 
 static std::unique_ptr<FunctionBindData> ListExtractBindFunc(
     const binder::expression_vector& arguments, Function* function) {
-    auto resultType = ListType::getChildType(&arguments[0]->dataType);
+    auto resultType = ListType::getChildType(arguments[0]->dataType);
     auto scalarFunction = function->ptrCast<ScalarFunction>();
     TypeUtils::visit(resultType->getPhysicalType(), [&scalarFunction]<typename T>(T) {
         scalarFunction->execFunc =

--- a/src/function/list/list_prepend_function.cpp
+++ b/src/function/list/list_prepend_function.cpp
@@ -31,7 +31,7 @@ struct ListPrepend {
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     Function* function) {
     if (arguments[0]->getDataType().getLogicalTypeID() != LogicalTypeID::ANY &&
-        arguments[1]->dataType != *ListType::getChildType(&arguments[0]->dataType)) {
+        arguments[1]->dataType != *ListType::getChildType(arguments[0]->dataType)) {
         throw BinderException(
             ExceptionMessage::listFunctionIncompatibleChildrenType(ListPrependFunction::name,
                 arguments[0]->getDataType().toString(), arguments[1]->getDataType().toString()));

--- a/src/function/list/list_prepend_function.cpp
+++ b/src/function/list/list_prepend_function.cpp
@@ -31,7 +31,7 @@ struct ListPrepend {
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     Function* function) {
     if (arguments[0]->getDataType().getLogicalTypeID() != LogicalTypeID::ANY &&
-        arguments[1]->dataType != *ListType::getChildType(arguments[0]->dataType)) {
+        arguments[1]->dataType != ListType::getChildType(arguments[0]->dataType)) {
         throw BinderException(
             ExceptionMessage::listFunctionIncompatibleChildrenType(ListPrependFunction::name,
                 arguments[0]->getDataType().toString(), arguments[1]->getDataType().toString()));

--- a/src/function/list/list_sort_function.cpp
+++ b/src/function/list/list_sort_function.cpp
@@ -37,7 +37,7 @@ static std::unique_ptr<FunctionBindData> ListSortBindFunc(
             arguments[0]->toString()));
     }
     common::TypeUtils::visit(
-        ListType::getChildType(arguments[0]->dataType)->getPhysicalType(),
+        getChildType(arguments[0]->dataType).getPhysicalType(),
         [&arguments, &scalarFunction]<ComparableTypes T>(
             T) { scalarFunction->execFunc = getListSortExecFunction<ListSort<T>>(arguments); },
         [](auto) { KU_UNREACHABLE; });
@@ -48,7 +48,7 @@ static std::unique_ptr<FunctionBindData> ListReverseSortBindFunc(
     const binder::expression_vector& arguments, Function* function) {
     auto scalarFunction = function->ptrCast<ScalarFunction>();
     common::TypeUtils::visit(
-        ListType::getChildType(arguments[0]->dataType)->getPhysicalType(),
+        ListType::getChildType(arguments[0]->dataType).getPhysicalType(),
         [&arguments, &scalarFunction]<ComparableTypes T>(T) {
             scalarFunction->execFunc = getListSortExecFunction<ListReverseSort<T>>(arguments);
         },

--- a/src/function/list/list_sort_function.cpp
+++ b/src/function/list/list_sort_function.cpp
@@ -37,7 +37,7 @@ static std::unique_ptr<FunctionBindData> ListSortBindFunc(
             arguments[0]->toString()));
     }
     common::TypeUtils::visit(
-        ListType::getChildType(&arguments[0]->dataType)->getPhysicalType(),
+        ListType::getChildType(arguments[0]->dataType)->getPhysicalType(),
         [&arguments, &scalarFunction]<ComparableTypes T>(
             T) { scalarFunction->execFunc = getListSortExecFunction<ListSort<T>>(arguments); },
         [](auto) { KU_UNREACHABLE; });
@@ -48,7 +48,7 @@ static std::unique_ptr<FunctionBindData> ListReverseSortBindFunc(
     const binder::expression_vector& arguments, Function* function) {
     auto scalarFunction = function->ptrCast<ScalarFunction>();
     common::TypeUtils::visit(
-        ListType::getChildType(&arguments[0]->dataType)->getPhysicalType(),
+        ListType::getChildType(arguments[0]->dataType)->getPhysicalType(),
         [&arguments, &scalarFunction]<ComparableTypes T>(T) {
             scalarFunction->execFunc = getListSortExecFunction<ListReverseSort<T>>(arguments);
         },

--- a/src/function/list/list_sort_function.cpp
+++ b/src/function/list/list_sort_function.cpp
@@ -37,7 +37,7 @@ static std::unique_ptr<FunctionBindData> ListSortBindFunc(
             arguments[0]->toString()));
     }
     common::TypeUtils::visit(
-        getChildType(arguments[0]->dataType).getPhysicalType(),
+        ListType::getChildType(arguments[0]->dataType).getPhysicalType(),
         [&arguments, &scalarFunction]<ComparableTypes T>(
             T) { scalarFunction->execFunc = getListSortExecFunction<ListSort<T>>(arguments); },
         [](auto) { KU_UNREACHABLE; });

--- a/src/function/map/map_creation_function.cpp
+++ b/src/function/map/map_creation_function.cpp
@@ -12,7 +12,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     Function* /*function*/) {
     auto keyType = ListType::getChildType(arguments[0]->dataType);
     auto valueType = ListType::getChildType(arguments[1]->dataType);
-    auto resultType = LogicalType::MAP(*keyType, *valueType);
+    auto resultType = LogicalType::MAP(keyType, valueType);
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/map/map_creation_function.cpp
+++ b/src/function/map/map_creation_function.cpp
@@ -10,8 +10,8 @@ namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     Function* /*function*/) {
-    auto keyType = ListType::getChildType(&arguments[0]->dataType);
-    auto valueType = ListType::getChildType(&arguments[1]->dataType);
+    auto keyType = ListType::getChildType(arguments[0]->dataType);
+    auto valueType = ListType::getChildType(arguments[1]->dataType);
     auto resultType = LogicalType::MAP(*keyType, *valueType);
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }

--- a/src/function/map/map_extract_function.cpp
+++ b/src/function/map/map_extract_function.cpp
@@ -12,7 +12,7 @@ namespace function {
 
 static void validateKeyType(const std::shared_ptr<binder::Expression>& mapExpression,
     const std::shared_ptr<binder::Expression>& extractKeyExpression) {
-    auto mapKeyType = MapType::getKeyType(&mapExpression->dataType);
+    auto mapKeyType = MapType::getKeyType(mapExpression->dataType);
     if (*mapKeyType != extractKeyExpression->dataType) {
         throw RuntimeException("Unmatched map key type and extract key type");
     }
@@ -26,7 +26,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
         scalarFunction->execFunc =
             ScalarFunction::BinaryExecListStructFunction<list_entry_t, T, list_entry_t, MapExtract>;
     });
-    auto resultType = LogicalType::LIST(MapType::getValueType(&arguments[0]->dataType)->copy());
+    auto resultType = LogicalType::LIST(MapType::getValueType(arguments[0]->dataType)->copy());
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/map/map_extract_function.cpp
+++ b/src/function/map/map_extract_function.cpp
@@ -13,7 +13,7 @@ namespace function {
 static void validateKeyType(const std::shared_ptr<binder::Expression>& mapExpression,
     const std::shared_ptr<binder::Expression>& extractKeyExpression) {
     auto mapKeyType = MapType::getKeyType(mapExpression->dataType);
-    if (*mapKeyType != extractKeyExpression->dataType) {
+    if (mapKeyType != extractKeyExpression->dataType) {
         throw RuntimeException("Unmatched map key type and extract key type");
     }
 }
@@ -26,7 +26,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
         scalarFunction->execFunc =
             ScalarFunction::BinaryExecListStructFunction<list_entry_t, T, list_entry_t, MapExtract>;
     });
-    auto resultType = LogicalType::LIST(MapType::getValueType(arguments[0]->dataType)->copy());
+    auto resultType = LogicalType::LIST(MapType::getValueType(arguments[0]->dataType).copy());
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/map/map_keys_function.cpp
+++ b/src/function/map/map_keys_function.cpp
@@ -10,7 +10,7 @@ namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     kuzu::function::Function* /*function*/) {
-    auto resultType = LogicalType::LIST(MapType::getKeyType(arguments[0]->dataType)->copy());
+    auto resultType = LogicalType::LIST(MapType::getKeyType(arguments[0]->dataType).copy());
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/map/map_keys_function.cpp
+++ b/src/function/map/map_keys_function.cpp
@@ -10,7 +10,7 @@ namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     kuzu::function::Function* /*function*/) {
-    auto resultType = LogicalType::LIST(MapType::getKeyType(&arguments[0]->dataType)->copy());
+    auto resultType = LogicalType::LIST(MapType::getKeyType(arguments[0]->dataType)->copy());
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/map/map_values_function.cpp
+++ b/src/function/map/map_values_function.cpp
@@ -10,7 +10,7 @@ namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     Function* /*function*/) {
-    auto resultType = LogicalType::LIST(MapType::getValueType(arguments[0]->dataType)->copy());
+    auto resultType = LogicalType::LIST(MapType::getValueType(arguments[0]->dataType).copy());
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/map/map_values_function.cpp
+++ b/src/function/map/map_values_function.cpp
@@ -10,7 +10,7 @@ namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     Function* /*function*/) {
-    auto resultType = LogicalType::LIST(MapType::getValueType(&arguments[0]->dataType)->copy());
+    auto resultType = LogicalType::LIST(MapType::getValueType(arguments[0]->dataType)->copy());
     return FunctionBindData::getSimpleBindData(arguments, *resultType);
 }
 

--- a/src/function/path/nodes_function.cpp
+++ b/src/function/path/nodes_function.cpp
@@ -11,8 +11,8 @@ namespace function {
 
 static std::unique_ptr<FunctionBindData> bindFunc(const expression_vector& arguments, Function*) {
     auto structType = arguments[0]->getDataType();
-    auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::NODES);
-    auto resulType = *StructType::getFieldTypes(&structType)[fieldIdx];
+    auto fieldIdx = StructType::getFieldIdx(structType, InternalKeyword::NODES);
+    auto resulType = *StructType::getFieldTypes(structType)[fieldIdx];
     auto bindData = std::make_unique<StructExtractBindData>(resulType.copy(), fieldIdx);
     bindData->paramTypes = ExpressionUtil::getDataTypes(arguments);
     return bindData;

--- a/src/function/path/nodes_function.cpp
+++ b/src/function/path/nodes_function.cpp
@@ -12,7 +12,7 @@ namespace function {
 static std::unique_ptr<FunctionBindData> bindFunc(const expression_vector& arguments, Function*) {
     auto structType = arguments[0]->getDataType();
     auto fieldIdx = StructType::getFieldIdx(structType, InternalKeyword::NODES);
-    auto resulType = *StructType::getFieldTypes(structType)[fieldIdx];
+    auto resulType = StructType::getFieldTypes(structType)[fieldIdx];
     auto bindData = std::make_unique<StructExtractBindData>(resulType.copy(), fieldIdx);
     bindData->paramTypes = ExpressionUtil::getDataTypes(arguments);
     return bindData;

--- a/src/function/path/properties_function.cpp
+++ b/src/function/path/properties_function.cpp
@@ -24,7 +24,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     struct_field_idx_t fieldIdx;
     if (childType->getLogicalTypeID() == LogicalTypeID::NODE ||
         childType->getLogicalTypeID() == LogicalTypeID::REL) {
-        fieldIdx = StructType::getFieldIdx(childType, key);
+        fieldIdx = StructType::getFieldIdx(*childType, key);
         if (fieldIdx == INVALID_STRUCT_FIELD_IDX) {
             throw BinderException(stringFormat("Invalid property name: {}.", key));
         }
@@ -32,7 +32,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
         throw BinderException(
             stringFormat("Cannot extract properties from {}.", listType.toString()));
     }
-    auto field = StructType::getField(childType, fieldIdx);
+    auto field = StructType::getField(*childType, fieldIdx);
     auto returnType = LogicalType::LIST(field->getType()->copy());
     auto bindData = std::make_unique<PropertiesBindData>(std::move(returnType), fieldIdx);
     bindData->paramTypes.push_back(arguments[0]->getDataType());

--- a/src/function/path/properties_function.cpp
+++ b/src/function/path/properties_function.cpp
@@ -32,8 +32,8 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
         throw BinderException(
             stringFormat("Cannot extract properties from {}.", listType.toString()));
     }
-    auto field = StructType::getField(*childType, fieldIdx);
-    auto returnType = LogicalType::LIST(field->getType()->copy());
+    auto field = StructType::getField(childType, fieldIdx);
+    auto returnType = LogicalType::LIST(field.getType().copy());
     auto bindData = std::make_unique<PropertiesBindData>(std::move(returnType), fieldIdx);
     bindData->paramTypes.push_back(arguments[0]->getDataType());
     bindData->paramTypes.push_back(LogicalType(function->parameterTypeIDs[1]));

--- a/src/function/path/properties_function.cpp
+++ b/src/function/path/properties_function.cpp
@@ -20,7 +20,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     auto literalExpr = arguments[1]->constPtrCast<LiteralExpression>();
     auto key = literalExpr->getValue().getValue<std::string>();
     auto listType = arguments[0]->getDataType();
-    auto childType = ListType::getChildType(&listType);
+    auto childType = ListType::getChildType(listType);
     struct_field_idx_t fieldIdx;
     if (childType->getLogicalTypeID() == LogicalTypeID::NODE ||
         childType->getLogicalTypeID() == LogicalTypeID::REL) {

--- a/src/function/path/properties_function.cpp
+++ b/src/function/path/properties_function.cpp
@@ -22,9 +22,9 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     auto listType = arguments[0]->getDataType();
     auto childType = ListType::getChildType(listType);
     struct_field_idx_t fieldIdx;
-    if (childType->getLogicalTypeID() == LogicalTypeID::NODE ||
-        childType->getLogicalTypeID() == LogicalTypeID::REL) {
-        fieldIdx = StructType::getFieldIdx(*childType, key);
+    if (childType.getLogicalTypeID() == LogicalTypeID::NODE ||
+        childType.getLogicalTypeID() == LogicalTypeID::REL) {
+        fieldIdx = StructType::getFieldIdx(childType, key);
         if (fieldIdx == INVALID_STRUCT_FIELD_IDX) {
             throw BinderException(stringFormat("Invalid property name: {}.", key));
         }

--- a/src/function/path/rels_function.cpp
+++ b/src/function/path/rels_function.cpp
@@ -12,8 +12,8 @@ namespace function {
 static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vector& arguments,
     Function*) {
     auto structType = arguments[0]->getDataType();
-    auto fieldIdx = StructType::getFieldIdx(&structType, InternalKeyword::RELS);
-    auto resultType = *StructType::getFieldTypes(&structType)[fieldIdx];
+    auto fieldIdx = StructType::getFieldIdx(structType, InternalKeyword::RELS);
+    auto resultType = *StructType::getFieldTypes(structType)[fieldIdx];
     auto bindData = std::make_unique<StructExtractBindData>(resultType.copy(), fieldIdx);
     bindData->paramTypes = binder::ExpressionUtil::getDataTypes(arguments);
     return bindData;

--- a/src/function/path/rels_function.cpp
+++ b/src/function/path/rels_function.cpp
@@ -13,7 +13,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     Function*) {
     auto structType = arguments[0]->getDataType();
     auto fieldIdx = StructType::getFieldIdx(structType, InternalKeyword::RELS);
-    auto resultType = *StructType::getFieldTypes(structType)[fieldIdx];
+    auto resultType = StructType::getFieldTypes(structType)[fieldIdx];
     auto bindData = std::make_unique<StructExtractBindData>(resultType.copy(), fieldIdx);
     bindData->paramTypes = binder::ExpressionUtil::getDataTypes(arguments);
     return bindData;

--- a/src/function/struct/struct_extract_function.cpp
+++ b/src/function/struct/struct_extract_function.cpp
@@ -22,7 +22,7 @@ std::unique_ptr<FunctionBindData> StructExtractFunctions::bindFunc(
         throw BinderException(stringFormat("Invalid struct field name: {}.", key));
     }
     auto paramTypes = ExpressionUtil::getDataTypes(arguments);
-    auto resultType = *StructType::getFieldTypes(structType)[fieldIdx];
+    auto resultType = StructType::getFieldTypes(structType)[fieldIdx];
     auto bindData = std::make_unique<StructExtractBindData>(resultType.copy(), fieldIdx);
     bindData->paramTypes.push_back(arguments[0]->getDataType());
     bindData->paramTypes.push_back(LogicalType(function->parameterTypeIDs[1]));

--- a/src/function/struct/struct_extract_function.cpp
+++ b/src/function/struct/struct_extract_function.cpp
@@ -17,12 +17,12 @@ std::unique_ptr<FunctionBindData> StructExtractFunctions::bindFunc(
         throw BinderException("Key name for struct/union extract must be STRING literal.");
     }
     auto key = arguments[1]->constPtrCast<LiteralExpression>()->getValue().getValue<std::string>();
-    auto fieldIdx = StructType::getFieldIdx(&structType, key);
+    auto fieldIdx = StructType::getFieldIdx(structType, key);
     if (fieldIdx == INVALID_STRUCT_FIELD_IDX) {
         throw BinderException(stringFormat("Invalid struct field name: {}.", key));
     }
     auto paramTypes = ExpressionUtil::getDataTypes(arguments);
-    auto resultType = *StructType::getFieldTypes(&structType)[fieldIdx];
+    auto resultType = *StructType::getFieldTypes(structType)[fieldIdx];
     auto bindData = std::make_unique<StructExtractBindData>(resultType.copy(), fieldIdx);
     bindData->paramTypes.push_back(arguments[0]->getDataType());
     bindData->paramTypes.push_back(LogicalType(function->parameterTypeIDs[1]));

--- a/src/function/table/call/storage_info.cpp
+++ b/src/function/table/call/storage_info.cpp
@@ -72,7 +72,7 @@ private:
         switch (column->getDataType().getPhysicalType()) {
         case PhysicalTypeID::STRUCT: {
             auto structColumn = ku_dynamic_cast<Column*, StructColumn*>(column);
-            auto numChildren = StructType::getNumFields(&structColumn->getDataType());
+            auto numChildren = StructType::getNumFields(structColumn->getDataType());
             for (auto i = 0u; i < numChildren; i++) {
                 auto childColumn = structColumn->getChild(i);
                 auto subColumns = collectColumns(childColumn);

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -57,8 +57,8 @@ static void resolveNestedVector(std::shared_ptr<ValueVector> inputVector, ValueV
             // check if struct type can be cast
             auto errorMsg = stringFormat("Unsupported casting function from {} to {}.",
                 inputType->toString(), resultType->toString());
-            auto inputTypeNames = StructType::getFieldNames(inputType);
-            auto resultTypeNames = StructType::getFieldNames(resultType);
+            auto inputTypeNames = StructType::getFieldNames(*inputType);
+            auto resultTypeNames = StructType::getFieldNames(*resultType);
             if (inputTypeNames.size() != resultTypeNames.size()) {
                 throw ConversionException{errorMsg};
             }
@@ -149,7 +149,7 @@ static bool hasImplicitCastListToArray(const LogicalType& srcType, const Logical
 }
 
 static bool hasImplicitCastStruct(const LogicalType& srcType, const LogicalType& dstType) {
-    auto srcFields = StructType::getFields(&srcType), dstFields = StructType::getFields(&dstType);
+    auto srcFields = StructType::getFields(srcType), dstFields = StructType::getFields(dstType);
     if (srcFields.size() != dstFields.size()) {
         return false;
     }

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -154,10 +154,10 @@ static bool hasImplicitCastStruct(const LogicalType& srcType, const LogicalType&
         return false;
     }
     for (auto i = 0u; i < srcFields.size(); i++) {
-        if (srcFields[i]->getName() != dstFields[i]->getName()) {
+        if (srcFields[i].getName() != dstFields[i].getName()) {
             return false;
         }
-        if (!CastFunction::hasImplicitCast(*srcFields[i]->getType(), *dstFields[i]->getType())) {
+        if (!CastFunction::hasImplicitCast(srcFields[i].getType(), dstFields[i].getType())) {
             return false;
         }
     }

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -171,10 +171,10 @@ static bool hasImplicitCastUnion(const LogicalType& /*srcType*/, const LogicalTy
 }
 
 static bool hasImplicitCastMap(const LogicalType& srcType, const LogicalType& dstType) {
-    auto srcKeyType = *MapType::getKeyType(srcType);
-    auto srcValueType = *MapType::getValueType(srcType);
-    auto dstKeyType = *MapType::getKeyType(dstType);
-    auto dstValueType = *MapType::getValueType(dstType);
+    auto srcKeyType = MapType::getKeyType(srcType);
+    auto srcValueType = MapType::getValueType(srcType);
+    auto dstKeyType = MapType::getKeyType(dstType);
+    auto dstValueType = MapType::getValueType(dstType);
     return CastFunction::hasImplicitCast(srcKeyType, dstKeyType) &&
            CastFunction::hasImplicitCast(srcValueType, dstValueType);
 }

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -126,26 +126,26 @@ static void nestedTypesCastExecFunction(const std::vector<std::shared_ptr<ValueV
 }
 
 static bool hasImplicitCastList(const LogicalType& srcType, const LogicalType& dstType) {
-    return CastFunction::hasImplicitCast(*ListType::getChildType(srcType),
-        *ListType::getChildType(dstType));
+    return CastFunction::hasImplicitCast(ListType::getChildType(srcType),
+        ListType::getChildType(dstType));
 }
 
 static bool hasImplicitCastArray(const LogicalType& srcType, const LogicalType& dstType) {
     if (ArrayType::getNumElements(srcType) != ArrayType::getNumElements(dstType)) {
         return false;
     }
-    return CastFunction::hasImplicitCast(*ArrayType::getChildType(srcType),
-        *ArrayType::getChildType(dstType));
+    return CastFunction::hasImplicitCast(ArrayType::getChildType(srcType),
+        ArrayType::getChildType(dstType));
 }
 
 static bool hasImplicitCastArrayToList(const LogicalType& srcType, const LogicalType& dstType) {
-    return CastFunction::hasImplicitCast(*ArrayType::getChildType(srcType),
-        *ListType::getChildType(dstType));
+    return CastFunction::hasImplicitCast(ArrayType::getChildType(srcType),
+        ListType::getChildType(dstType));
 }
 
 static bool hasImplicitCastListToArray(const LogicalType& srcType, const LogicalType& dstType) {
-    return CastFunction::hasImplicitCast(*ListType::getChildType(srcType),
-        *ArrayType::getChildType(dstType));
+    return CastFunction::hasImplicitCast(ListType::getChildType(srcType),
+        ArrayType::getChildType(dstType));
 }
 
 static bool hasImplicitCastStruct(const LogicalType& srcType, const LogicalType& dstType) {

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -131,21 +131,21 @@ static bool hasImplicitCastList(const LogicalType& srcType, const LogicalType& d
 }
 
 static bool hasImplicitCastArray(const LogicalType& srcType, const LogicalType& dstType) {
-    if (ArrayType::getNumElements(&srcType) != ArrayType::getNumElements(&dstType)) {
+    if (ArrayType::getNumElements(srcType) != ArrayType::getNumElements(dstType)) {
         return false;
     }
-    return CastFunction::hasImplicitCast(*ArrayType::getChildType(&srcType),
-        *ArrayType::getChildType(&dstType));
+    return CastFunction::hasImplicitCast(*ArrayType::getChildType(srcType),
+        *ArrayType::getChildType(dstType));
 }
 
 static bool hasImplicitCastArrayToList(const LogicalType& srcType, const LogicalType& dstType) {
-    return CastFunction::hasImplicitCast(*ArrayType::getChildType(&srcType),
+    return CastFunction::hasImplicitCast(*ArrayType::getChildType(srcType),
         *ListType::getChildType(dstType));
 }
 
 static bool hasImplicitCastListToArray(const LogicalType& srcType, const LogicalType& dstType) {
     return CastFunction::hasImplicitCast(*ListType::getChildType(srcType),
-        *ArrayType::getChildType(&dstType));
+        *ArrayType::getChildType(dstType));
 }
 
 static bool hasImplicitCastStruct(const LogicalType& srcType, const LogicalType& dstType) {

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -126,8 +126,8 @@ static void nestedTypesCastExecFunction(const std::vector<std::shared_ptr<ValueV
 }
 
 static bool hasImplicitCastList(const LogicalType& srcType, const LogicalType& dstType) {
-    return CastFunction::hasImplicitCast(*ListType::getChildType(&srcType),
-        *ListType::getChildType(&dstType));
+    return CastFunction::hasImplicitCast(*ListType::getChildType(srcType),
+        *ListType::getChildType(dstType));
 }
 
 static bool hasImplicitCastArray(const LogicalType& srcType, const LogicalType& dstType) {
@@ -140,11 +140,11 @@ static bool hasImplicitCastArray(const LogicalType& srcType, const LogicalType& 
 
 static bool hasImplicitCastArrayToList(const LogicalType& srcType, const LogicalType& dstType) {
     return CastFunction::hasImplicitCast(*ArrayType::getChildType(&srcType),
-        *ListType::getChildType(&dstType));
+        *ListType::getChildType(dstType));
 }
 
 static bool hasImplicitCastListToArray(const LogicalType& srcType, const LogicalType& dstType) {
-    return CastFunction::hasImplicitCast(*ListType::getChildType(&srcType),
+    return CastFunction::hasImplicitCast(*ListType::getChildType(srcType),
         *ArrayType::getChildType(&dstType));
 }
 

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -171,10 +171,10 @@ static bool hasImplicitCastUnion(const LogicalType& /*srcType*/, const LogicalTy
 }
 
 static bool hasImplicitCastMap(const LogicalType& srcType, const LogicalType& dstType) {
-    auto srcKeyType = *MapType::getKeyType(&srcType);
-    auto srcValueType = *MapType::getValueType(&srcType);
-    auto dstKeyType = *MapType::getKeyType(&dstType);
-    auto dstValueType = *MapType::getValueType(&dstType);
+    auto srcKeyType = *MapType::getKeyType(srcType);
+    auto srcValueType = *MapType::getValueType(srcType);
+    auto dstKeyType = *MapType::getKeyType(dstType);
+    auto dstValueType = *MapType::getValueType(dstType);
     return CastFunction::hasImplicitCast(srcKeyType, dstKeyType) &&
            CastFunction::hasImplicitCast(srcValueType, dstValueType);
 }

--- a/src/function/vector_hash_functions.cpp
+++ b/src/function/vector_hash_functions.cpp
@@ -101,12 +101,12 @@ static void computeListVectorHash(ValueVector* operand, ValueVector* result) {
 static void computeStructVecHash(ValueVector* operand, ValueVector* result) {
     switch (operand->dataType.getLogicalTypeID()) {
     case LogicalTypeID::NODE: {
-        KU_ASSERT(0 == common::StructType::getFieldIdx(&operand->dataType, InternalKeyword::ID));
+        KU_ASSERT(0 == common::StructType::getFieldIdx(operand->dataType, InternalKeyword::ID));
         UnaryHashFunctionExecutor::execute<internalID_t, hash_t>(
             *StructVector::getFieldVector(operand, 0), *result);
     } break;
     case LogicalTypeID::REL: {
-        KU_ASSERT(3 == StructType::getFieldIdx(&operand->dataType, InternalKeyword::ID));
+        KU_ASSERT(3 == StructType::getFieldIdx(operand->dataType, InternalKeyword::ID));
         UnaryHashFunctionExecutor::execute<internalID_t, hash_t>(
             *StructVector::getFieldVector(operand, 3), *result);
     } break;
@@ -114,7 +114,7 @@ static void computeStructVecHash(ValueVector* operand, ValueVector* result) {
         VectorHashFunction::computeHash(StructVector::getFieldVector(operand, 0 /* idx */).get(),
             result);
         auto tmpHashVector = std::make_unique<ValueVector>(LogicalTypeID::INT64);
-        for (auto i = 1u; i < StructType::getNumFields(&operand->dataType); i++) {
+        for (auto i = 1u; i < StructType::getNumFields(operand->dataType); i++) {
             auto fieldVector = StructVector::getFieldVector(operand, i);
             VectorHashFunction::computeHash(fieldVector.get(), tmpHashVector.get());
             VectorHashFunction::combineHash(tmpHashVector.get(), result, result);

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -480,36 +480,36 @@ private:
 using logical_type_vec_t = std::vector<LogicalType>;
 
 struct ListType {
-    static LogicalType* getChildType(const LogicalType* type);
+    static LogicalType* getChildType(const LogicalType& type);
 };
 
 struct KUZU_API ArrayType {
-    static LogicalType* getChildType(const LogicalType* type);
-    static uint64_t getNumElements(const LogicalType* type);
+    static LogicalType* getChildType(const LogicalType& type);
+    static uint64_t getNumElements(const LogicalType& type);
 };
 
 struct StructType {
-    static std::vector<LogicalType*> getFieldTypes(const LogicalType* type);
+    static std::vector<LogicalType*> getFieldTypes(const LogicalType& type);
 
-    static std::vector<std::string> getFieldNames(const LogicalType* type);
+    static std::vector<std::string> getFieldNames(const LogicalType& type);
 
-    static uint64_t getNumFields(const LogicalType* type);
+    static uint64_t getNumFields(const LogicalType& type);
 
-    static std::vector<const StructField*> getFields(const LogicalType* type);
+    static std::vector<const StructField*> getFields(const LogicalType& type);
 
-    static bool hasField(const LogicalType* type, const std::string& key);
+    static bool hasField(const LogicalType& type, const std::string& key);
 
-    static const StructField* getField(const LogicalType* type, struct_field_idx_t idx);
+    static const StructField* getField(const LogicalType& type, struct_field_idx_t idx);
 
-    static const StructField* getField(const LogicalType* type, const std::string& key);
+    static const StructField* getField(const LogicalType& type, const std::string& key);
 
-    static struct_field_idx_t getFieldIdx(const LogicalType* type, const std::string& key);
+    static struct_field_idx_t getFieldIdx(const LogicalType& type, const std::string& key);
 };
 
 struct MapType {
-    static LogicalType* getKeyType(const LogicalType* type);
+    static LogicalType* getKeyType(const LogicalType& type);
 
-    static LogicalType* getValueType(const LogicalType* type);
+    static LogicalType* getValueType(const LogicalType& type);
 };
 
 struct UnionType {
@@ -521,11 +521,11 @@ struct UnionType {
 
     static union_field_idx_t getInternalFieldIdx(union_field_idx_t idx);
 
-    static std::string getFieldName(const LogicalType* type, union_field_idx_t idx);
+    static std::string getFieldName(const LogicalType& type, union_field_idx_t idx);
 
-    static LogicalType* getFieldType(const LogicalType* type, union_field_idx_t idx);
+    static LogicalType* getFieldType(const LogicalType& type, union_field_idx_t idx);
 
-    static uint64_t getNumFields(const LogicalType* type);
+    static uint64_t getNumFields(const LogicalType& type);
 };
 
 struct PhysicalTypeUtils {

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -210,7 +210,7 @@ public:
     explicit ListTypeInfo(std::unique_ptr<LogicalType> childType)
         : childType{std::move(childType)} {}
 
-    LogicalType* getChildType() const { return childType.get(); }
+    LogicalType getChildType() const { return *childType; }
 
     bool containsAny() const override;
 
@@ -256,7 +256,7 @@ public:
 
     std::string getName() const { return name; }
 
-    LogicalType* getType() const { return type.get(); }
+    LogicalType getType() const { return *type; }
 
     bool containsAny() const;
 
@@ -283,12 +283,12 @@ public:
 
     bool hasField(const std::string& fieldName) const;
     struct_field_idx_t getStructFieldIdx(std::string fieldName) const;
-    const StructField* getStructField(struct_field_idx_t idx) const;
-    const StructField* getStructField(const std::string& fieldName) const;
-    std::vector<const StructField*> getStructFields() const;
+    StructField getStructField(struct_field_idx_t idx) const;
+    StructField getStructField(const std::string& fieldName) const;
+    std::vector<StructField> getStructFields() const;
 
-    LogicalType* getChildType(struct_field_idx_t idx) const;
-    std::vector<LogicalType*> getChildrenTypes() const;
+    LogicalType getChildType(struct_field_idx_t idx) const;
+    std::vector<LogicalType> getChildrenTypes() const;
     std::vector<std::string> getChildrenNames() const;
 
     bool containsAny() const override;
@@ -480,36 +480,36 @@ private:
 using logical_type_vec_t = std::vector<LogicalType>;
 
 struct ListType {
-    static LogicalType* getChildType(const LogicalType& type);
+    static LogicalType getChildType(const LogicalType& type);
 };
 
 struct KUZU_API ArrayType {
-    static LogicalType* getChildType(const LogicalType& type);
+    static LogicalType getChildType(const LogicalType& type);
     static uint64_t getNumElements(const LogicalType& type);
 };
 
 struct StructType {
-    static std::vector<LogicalType*> getFieldTypes(const LogicalType& type);
+    static std::vector<LogicalType> getFieldTypes(const LogicalType& type);
 
     static std::vector<std::string> getFieldNames(const LogicalType& type);
 
     static uint64_t getNumFields(const LogicalType& type);
 
-    static std::vector<const StructField*> getFields(const LogicalType& type);
+    static std::vector<StructField> getFields(const LogicalType& type);
 
     static bool hasField(const LogicalType& type, const std::string& key);
 
-    static const StructField* getField(const LogicalType& type, struct_field_idx_t idx);
+    static StructField getField(const LogicalType& type, struct_field_idx_t idx);
 
-    static const StructField* getField(const LogicalType& type, const std::string& key);
+    static StructField getField(const LogicalType& type, const std::string& key);
 
     static struct_field_idx_t getFieldIdx(const LogicalType& type, const std::string& key);
 };
 
 struct MapType {
-    static LogicalType* getKeyType(const LogicalType& type);
+    static LogicalType getKeyType(const LogicalType& type);
 
-    static LogicalType* getValueType(const LogicalType& type);
+    static LogicalType getValueType(const LogicalType& type);
 };
 
 struct UnionType {
@@ -523,7 +523,7 @@ struct UnionType {
 
     static std::string getFieldName(const LogicalType& type, union_field_idx_t idx);
 
-    static LogicalType* getFieldType(const LogicalType& type, union_field_idx_t idx);
+    static LogicalType getFieldType(const LogicalType& type, union_field_idx_t idx);
 
     static uint64_t getNumFields(const LogicalType& type);
 };

--- a/src/include/function/cast/functions/cast_array.h
+++ b/src/include/function/cast/functions/cast_array.h
@@ -13,7 +13,8 @@ struct CastArrayHelper {
 
     static bool containsListToArray(const LogicalType& srcType, const LogicalType& dstType);
 
-    static void validateListEntry(ValueVector* inputVector, const LogicalType& resultType, uint64_t pos);
+    static void validateListEntry(ValueVector* inputVector, const LogicalType& resultType,
+        uint64_t pos);
 };
 
 } // namespace function

--- a/src/include/function/cast/functions/cast_array.h
+++ b/src/include/function/cast/functions/cast_array.h
@@ -11,9 +11,9 @@ namespace function {
 struct CastArrayHelper {
     static bool checkCompatibleNestedTypes(LogicalTypeID sourceTypeID, LogicalTypeID targetTypeID);
 
-    static bool containsListToArray(const LogicalType* srcType, const LogicalType* dstType);
+    static bool containsListToArray(const LogicalType& srcType, const LogicalType& dstType);
 
-    static void validateListEntry(ValueVector* inputVector, LogicalType* resultType, uint64_t pos);
+    static void validateListEntry(ValueVector* inputVector, const LogicalType& resultType, uint64_t pos);
 };
 
 } // namespace function

--- a/src/include/function/list/functions/list_position_function.h
+++ b/src/include/function/list/functions/list_position_function.h
@@ -13,7 +13,7 @@ struct ListPosition {
     static void operation(common::list_entry_t& list, T& element, int64_t& result,
         common::ValueVector& listVector, common::ValueVector& elementVector,
         common::ValueVector& /*resultVector*/) {
-        if (*common::ListType::getChildType(&listVector.dataType) != elementVector.dataType) {
+        if (*common::ListType::getChildType(listVector.dataType) != elementVector.dataType) {
             result = 0;
             return;
         }

--- a/src/include/function/list/functions/list_position_function.h
+++ b/src/include/function/list/functions/list_position_function.h
@@ -13,7 +13,7 @@ struct ListPosition {
     static void operation(common::list_entry_t& list, T& element, int64_t& result,
         common::ValueVector& listVector, common::ValueVector& elementVector,
         common::ValueVector& /*resultVector*/) {
-        if (*common::ListType::getChildType(listVector.dataType) != elementVector.dataType) {
+        if (common::ListType::getChildType(listVector.dataType) != elementVector.dataType) {
             result = 0;
             return;
         }

--- a/src/include/function/path/path_function_executor.h
+++ b/src/include/function/path/path_function_executor.h
@@ -27,7 +27,7 @@ struct UnaryPathExecutor {
     static void executeNodeIDs(common::ValueVector& input, common::ValueVector& result) {
         auto nodesFieldIdx = 0;
         KU_ASSERT(nodesFieldIdx ==
-                  common::StructType::getFieldIdx(&input.dataType, common::InternalKeyword::NODES));
+                  common::StructType::getFieldIdx(input.dataType, common::InternalKeyword::NODES));
         auto nodesVector = common::StructVector::getFieldVector(&input, nodesFieldIdx).get();
         auto internalIDFieldIdx = 0;
         execute(*input.state->selVector, *nodesVector, internalIDFieldIdx, result);
@@ -36,7 +36,7 @@ struct UnaryPathExecutor {
     static void executeRelIDs(common::ValueVector& input, common::ValueVector& result) {
         auto relsFieldIdx = 1;
         KU_ASSERT(relsFieldIdx ==
-                  common::StructType::getFieldIdx(&input.dataType, common::InternalKeyword::RELS));
+                  common::StructType::getFieldIdx(input.dataType, common::InternalKeyword::RELS));
         auto relsVector = common::StructVector::getFieldVector(&input, relsFieldIdx).get();
         auto internalIDFieldIdx = 3;
         execute(*input.state->selVector, *relsVector, internalIDFieldIdx, result);
@@ -46,7 +46,7 @@ struct UnaryPathExecutor {
         common::SelectionVector& selectionVector) {
         auto nodesFieldIdx = 0;
         KU_ASSERT(nodesFieldIdx ==
-                  common::StructType::getFieldIdx(&input.dataType, common::InternalKeyword::NODES));
+                  common::StructType::getFieldIdx(input.dataType, common::InternalKeyword::NODES));
         auto nodesVector = common::StructVector::getFieldVector(&input, nodesFieldIdx).get();
         auto internalIDFieldIdx = 0;
         return select(*input.state->selVector, *nodesVector, internalIDFieldIdx, selectionVector);
@@ -55,7 +55,7 @@ struct UnaryPathExecutor {
     static bool selectRelIDs(common::ValueVector& input, common::SelectionVector& selectionVector) {
         auto relsFieldIdx = 1;
         KU_ASSERT(relsFieldIdx ==
-                  common::StructType::getFieldIdx(&input.dataType, common::InternalKeyword::RELS));
+                  common::StructType::getFieldIdx(input.dataType, common::InternalKeyword::RELS));
         auto relsVector = common::StructVector::getFieldVector(&input, relsFieldIdx).get();
         auto internalIDFieldIdx = 3;
         return select(*input.state->selVector, *relsVector, internalIDFieldIdx, selectionVector);
@@ -66,7 +66,7 @@ private:
         common::ValueVector& listVector, common::struct_field_idx_t fieldIdx,
         common::ValueVector& result) {
         auto listDataVector = common::ListVector::getDataVector(&listVector);
-        KU_ASSERT(fieldIdx == common::StructType::getFieldIdx(&listDataVector->dataType,
+        KU_ASSERT(fieldIdx == common::StructType::getFieldIdx(listDataVector->dataType,
                                   common::InternalKeyword::ID));
         auto internalIDsVector =
             common::StructVector::getFieldVector(listDataVector, fieldIdx).get();
@@ -93,7 +93,7 @@ private:
         common::ValueVector& listVector, common::struct_field_idx_t fieldIdx,
         common::SelectionVector& selectionVector) {
         auto listDataVector = common::ListVector::getDataVector(&listVector);
-        KU_ASSERT(fieldIdx == common::StructType::getFieldIdx(&listDataVector->dataType,
+        KU_ASSERT(fieldIdx == common::StructType::getFieldIdx(listDataVector->dataType,
                                   common::InternalKeyword::ID));
         auto internalIDsVector =
             common::StructVector::getFieldVector(listDataVector, fieldIdx).get();

--- a/src/include/function/union/functions/union_tag.h
+++ b/src/include/function/union/functions/union_tag.h
@@ -11,7 +11,7 @@ struct UnionTag {
         auto tagIdxVector = common::UnionVector::getTagVector(&unionVector);
         auto tagIdx = tagIdxVector->getValue<common::union_field_idx_t>(
             tagIdxVector->state->selVector->selectedPositions[unionValue.entry.pos]);
-        auto tagName = common::UnionType::getFieldName(&unionVector.dataType, tagIdx);
+        auto tagName = common::UnionType::getFieldName(unionVector.dataType, tagIdx);
         if (tagName.length() > common::ku_string_t::SHORT_STR_LENGTH) {
             tag.overflowPtr =
                 reinterpret_cast<uint64_t>(common::StringVector::getInMemOverflowBuffer(&tagVector)

--- a/src/include/processor/operator/persistent/writer/parquet/column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/column_writer.h
@@ -64,7 +64,7 @@ public:
     // has null value or not. So canHaveNullsToCreate is always true.
     static std::unique_ptr<ColumnWriter> createWriterRecursive(
         std::vector<kuzu_parquet::format::SchemaElement>& schemas, ParquetWriter& writer,
-        common::LogicalType* type, const std::string& name,
+        const common::LogicalType& type, const std::string& name,
         std::vector<std::string> schemaPathToCreate, storage::MemoryManager* mm,
         uint64_t maxRepeatToCreate = 0, uint64_t maxDefineToCreate = 1,
         bool canHaveNullsToCreate = true);

--- a/src/include/processor/operator/persistent/writer/parquet/parquet_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/parquet_writer.h
@@ -59,8 +59,8 @@ public:
     }
     void flush(FactorizedTable& ft);
     void finalize();
-    static kuzu_parquet::format::Type::type convertToParquetType(common::LogicalType* type);
-    static void setSchemaProperties(common::LogicalType* type,
+    static kuzu_parquet::format::Type::type convertToParquetType(const common::LogicalType& type);
+    static void setSchemaProperties(const common::LogicalType& type,
         kuzu_parquet::format::SchemaElement& schemaElement);
 
 private:

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -26,7 +26,7 @@ static std::pair<std::vector<struct_field_idx_t>, std::vector<ft_col_idx_t>> get
     std::vector<struct_field_idx_t> structFieldIndices;
     std::vector<ft_col_idx_t> colIndices;
     for (auto i = 0u; i < structFields.size(); ++i) {
-        auto field = structFields[i];
+        auto field = structFields[i].copy();
         auto fieldName = StringUtils::getUpper(field.getName());
         if (propertyNameToColumnIdx.contains(fieldName)) {
             structFieldIndices.push_back(i);

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -65,7 +65,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::move(nodeBuildInfo), std::move(nodeBuildPrevOperator), getOperatorID(), "");
         auto relDataType = rel->getDataType();
         auto nodesField = StructType::getField(&relDataType, InternalKeyword::NODES);
-        auto nodeStructType = ListType::getChildType(nodesField->getType());
+        auto nodeStructType = ListType::getChildType(*nodesField->getType());
         auto [fieldIndices, columnIndices] =
             getColIdxToScan(nodePayloads, nodeKeys.size(), *nodeStructType);
         nodeFieldIndices = std::move(fieldIndices);
@@ -92,7 +92,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::move(relBuildInfo), std::move(relBuildPrvOperator), getOperatorID(), "");
         auto relDataType = rel->getDataType();
         auto relsField = StructType::getField(&relDataType, InternalKeyword::RELS);
-        auto relStructType = ListType::getChildType(relsField->getType());
+        auto relStructType = ListType::getChildType(*relsField->getType());
         auto [fieldIndices, columnIndices] =
             getColIdxToScan(relPayloads, relKeys.size(), *relStructType);
         relFieldIndices = std::move(fieldIndices);

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -22,7 +22,7 @@ static std::pair<std::vector<struct_field_idx_t>, std::vector<ft_col_idx_t>> get
         StringUtils::toUpper(propertyName);
         propertyNameToColumnIdx.insert({propertyName, i + numKeys});
     }
-    auto structFields = StructType::getFields(&structType);
+    auto structFields = StructType::getFields(structType);
     std::vector<struct_field_idx_t> structFieldIndices;
     std::vector<ft_col_idx_t> colIndices;
     for (auto i = 0u; i < structFields.size(); ++i) {
@@ -64,7 +64,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::make_unique<ResultSetDescriptor>(nodeBuildSchema), nodeBuildSharedState,
             std::move(nodeBuildInfo), std::move(nodeBuildPrevOperator), getOperatorID(), "");
         auto relDataType = rel->getDataType();
-        auto nodesField = StructType::getField(&relDataType, InternalKeyword::NODES);
+        auto nodesField = StructType::getField(relDataType, InternalKeyword::NODES);
         auto nodeStructType = ListType::getChildType(*nodesField->getType());
         auto [fieldIndices, columnIndices] =
             getColIdxToScan(nodePayloads, nodeKeys.size(), *nodeStructType);
@@ -91,7 +91,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::make_unique<ResultSetDescriptor>(relBuildSchema), relBuildSharedState,
             std::move(relBuildInfo), std::move(relBuildPrvOperator), getOperatorID(), "");
         auto relDataType = rel->getDataType();
-        auto relsField = StructType::getField(&relDataType, InternalKeyword::RELS);
+        auto relsField = StructType::getField(relDataType, InternalKeyword::RELS);
         auto relStructType = ListType::getChildType(*relsField->getType());
         auto [fieldIndices, columnIndices] =
             getColIdxToScan(relPayloads, relKeys.size(), *relStructType);

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -27,7 +27,7 @@ static std::pair<std::vector<struct_field_idx_t>, std::vector<ft_col_idx_t>> get
     std::vector<ft_col_idx_t> colIndices;
     for (auto i = 0u; i < structFields.size(); ++i) {
         auto field = structFields[i];
-        auto fieldName = StringUtils::getUpper(field->getName());
+        auto fieldName = StringUtils::getUpper(field.getName());
         if (propertyNameToColumnIdx.contains(fieldName)) {
             structFieldIndices.push_back(i);
             colIndices.push_back(propertyNameToColumnIdx.at(fieldName));

--- a/src/processor/map/map_path_property_probe.cpp
+++ b/src/processor/map/map_path_property_probe.cpp
@@ -65,9 +65,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::move(nodeBuildInfo), std::move(nodeBuildPrevOperator), getOperatorID(), "");
         auto relDataType = rel->getDataType();
         auto nodesField = StructType::getField(relDataType, InternalKeyword::NODES);
-        auto nodeStructType = ListType::getChildType(*nodesField->getType());
+        auto nodeStructType = ListType::getChildType(nodesField.getType());
         auto [fieldIndices, columnIndices] =
-            getColIdxToScan(nodePayloads, nodeKeys.size(), *nodeStructType);
+            getColIdxToScan(nodePayloads, nodeKeys.size(), nodeStructType);
         nodeFieldIndices = std::move(fieldIndices);
         nodeTableColumnIndices = std::move(columnIndices);
     }
@@ -92,9 +92,9 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapPathPropertyProbe(
             std::move(relBuildInfo), std::move(relBuildPrvOperator), getOperatorID(), "");
         auto relDataType = rel->getDataType();
         auto relsField = StructType::getField(relDataType, InternalKeyword::RELS);
-        auto relStructType = ListType::getChildType(*relsField->getType());
+        auto relStructType = ListType::getChildType(relsField.getType());
         auto [fieldIndices, columnIndices] =
-            getColIdxToScan(relPayloads, relKeys.size(), *relStructType);
+            getColIdxToScan(relPayloads, relKeys.size(), relStructType);
         relFieldIndices = std::move(fieldIndices);
         relTableColumnIndices = std::move(columnIndices);
     }

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -192,12 +192,12 @@ void NpyReader::validate(const LogicalType& type_, offset_t numRows) {
         }
         return;
     } else if (type_.getLogicalTypeID() == LogicalTypeID::ARRAY) {
-        if (this->type != ArrayType::getChildType(&type_)->getLogicalTypeID()) {
+        if (this->type != ArrayType::getChildType(type_)->getLogicalTypeID()) {
             throw CopyException(stringFormat("The type of npy file {} does not "
                                              "match the expected type.",
                 filePath));
         }
-        if (getNumElementsPerRow() != ArrayType::getNumElements(&type_)) {
+        if (getNumElementsPerRow() != ArrayType::getNumElements(type_)) {
             throw CopyException(
                 stringFormat("The shape of {} does not match {}.", filePath, type_.toString()));
         }
@@ -219,7 +219,7 @@ void NpyReader::readBlock(block_idx_t blockIdx, common::ValueVector* vectorToRea
         auto numRowsToRead = std::min(DEFAULT_VECTOR_CAPACITY, getNumRows() - rowNumber);
         auto rowType = vectorToRead->dataType;
         if (rowType.getLogicalTypeID() == LogicalTypeID::ARRAY) {
-            auto numValuesPerRow = ArrayType::getNumElements(&rowType);
+            auto numValuesPerRow = ArrayType::getNumElements(rowType);
             for (auto i = 0u; i < numRowsToRead; i++) {
                 auto listEntry = ListVector::addList(vectorToRead, numValuesPerRow);
                 vectorToRead->setValue(i, listEntry);

--- a/src/processor/operator/persistent/reader/npy/npy_reader.cpp
+++ b/src/processor/operator/persistent/reader/npy/npy_reader.cpp
@@ -192,7 +192,7 @@ void NpyReader::validate(const LogicalType& type_, offset_t numRows) {
         }
         return;
     } else if (type_.getLogicalTypeID() == LogicalTypeID::ARRAY) {
-        if (this->type != ArrayType::getChildType(type_)->getLogicalTypeID()) {
+        if (this->type != ArrayType::getChildType(type_).getLogicalTypeID()) {
             throw CopyException(stringFormat("The type of npy file {} does not "
                                              "match the expected type.",
                 filePath));

--- a/src/processor/operator/persistent/reader/parquet/list_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/list_column_reader.cpp
@@ -15,7 +15,7 @@ ListColumnReader::ListColumnReader(ParquetReader& reader, std::unique_ptr<common
     childRepeatsPtr = (uint8_t*)childRepeats.ptr;
     childFilter.set();
     vectorToRead = std::make_unique<common::ValueVector>(
-        *common::ListType::getChildType(*this->type), memoryManager);
+        common::ListType::getChildType(*this->type), memoryManager);
 }
 
 void ListColumnReader::applyPendingSkips(uint64_t numValues) {

--- a/src/processor/operator/persistent/reader/parquet/list_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/list_column_reader.cpp
@@ -15,7 +15,7 @@ ListColumnReader::ListColumnReader(ParquetReader& reader, std::unique_ptr<common
     childRepeatsPtr = (uint8_t*)childRepeats.ptr;
     childFilter.set();
     vectorToRead = std::make_unique<common::ValueVector>(
-        *common::ListType::getChildType(this->type.get()), memoryManager);
+        *common::ListType::getChildType(*this->type), memoryManager);
 }
 
 void ListColumnReader::applyPendingSkips(uint64_t numValues) {

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -336,7 +336,7 @@ std::unique_ptr<ColumnReader> ParquetReader::createReader() {
         throw CopyException{"Root element of Parquet file must be a struct"};
     }
     // LCOV_EXCL_STOP
-    for (auto& field : StructType::getFields(rootReader->getDataType())) {
+    for (auto& field : StructType::getFields(*rootReader->getDataType())) {
         columnNames.push_back(field->getName());
         columnTypes.push_back(field->getType()->copy());
     }

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -276,7 +276,7 @@ std::unique_ptr<ColumnReader> ParquetReader::createReaderRecursive(uint64_t dept
                 std::make_unique<ListTypeInfo>(std::move(structType))));
 
             auto structReader = std::make_unique<StructColumnReader>(*this,
-                ListType::getChildType(*resultType)->copy(), sEle, thisIdx, maxDefine - 1,
+                ListType::getChildType(*resultType).copy(), sEle, thisIdx, maxDefine - 1,
                 maxRepeat - 1, std::move(childrenReaders));
             return std::make_unique<ListColumnReader>(*this, std::move(resultType), sEle, thisIdx,
                 maxDefine, maxRepeat, std::move(structReader), context->getMemoryManager());

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -337,8 +337,8 @@ std::unique_ptr<ColumnReader> ParquetReader::createReader() {
     }
     // LCOV_EXCL_STOP
     for (auto& field : StructType::getFields(*rootReader->getDataType())) {
-        columnNames.push_back(field->getName());
-        columnTypes.push_back(field->getType()->copy());
+        columnNames.push_back(field.getName());
+        columnTypes.push_back(field.getType().copy());
     }
 
     KU_ASSERT(nextSchemaIdx == metadata->schema.size() - 1);

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -288,7 +288,7 @@ std::unique_ptr<ColumnReader> ParquetReader::createReaderRecursive(uint64_t dept
                 thisIdx, maxDefine, maxRepeat, std::move(childrenReaders));
         } else {
             // if we have a struct with only a single type, pull up
-            resultType = structFields[0].getType()->copy();
+            resultType = structFields[0].getType().copy();
             result = std::move(childrenReaders[0]);
         }
         if (isRepeated) {

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -276,7 +276,7 @@ std::unique_ptr<ColumnReader> ParquetReader::createReaderRecursive(uint64_t dept
                 std::make_unique<ListTypeInfo>(std::move(structType))));
 
             auto structReader = std::make_unique<StructColumnReader>(*this,
-                ListType::getChildType(resultType.get())->copy(), sEle, thisIdx, maxDefine - 1,
+                ListType::getChildType(*resultType)->copy(), sEle, thisIdx, maxDefine - 1,
                 maxRepeat - 1, std::move(childrenReaders));
             return std::make_unique<ListColumnReader>(*this, std::move(resultType), sEle, thisIdx,
                 maxDefine, maxRepeat, std::move(structReader), context->getMemoryManager());

--- a/src/processor/operator/persistent/reader/parquet/struct_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/struct_column_reader.cpp
@@ -42,7 +42,7 @@ void StructColumnReader::registerPrefetch(ThriftFileTransport& transport, bool a
 uint64_t StructColumnReader::read(uint64_t numValuesToRead, parquet_filter_t& filter,
     uint8_t* define_out, uint8_t* repeat_out, common::ValueVector* result) {
     auto& fieldVectors = common::StructVector::getFieldVectors(result);
-    KU_ASSERT(common::StructType::getNumFields(type.get()) == fieldVectors.size());
+    KU_ASSERT(common::StructType::getNumFields(*type) == fieldVectors.size());
     if (pendingSkips > 0) {
         applyPendingSkips(pendingSkips);
     }
@@ -76,7 +76,7 @@ static bool TypeHasExactRowCount(const common::LogicalType* type) {
     case common::LogicalTypeID::MAP:
         return false;
     case common::LogicalTypeID::STRUCT:
-        for (auto& kv : common::StructType::getFieldTypes(type)) {
+        for (auto& kv : common::StructType::getFieldTypes(*type)) {
             if (TypeHasExactRowCount(kv)) {
                 return true;
             }

--- a/src/processor/operator/persistent/reader/parquet/struct_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/struct_column_reader.cpp
@@ -70,13 +70,13 @@ void StructColumnReader::skip(uint64_t num_values) {
     }
 }
 
-static bool TypeHasExactRowCount(const common::LogicalType* type) {
-    switch (type->getLogicalTypeID()) {
+static bool TypeHasExactRowCount(const common::LogicalType& type) {
+    switch (type.getLogicalTypeID()) {
     case common::LogicalTypeID::LIST:
     case common::LogicalTypeID::MAP:
         return false;
     case common::LogicalTypeID::STRUCT:
-        for (auto& kv : common::StructType::getFieldTypes(*type)) {
+        for (auto& kv : common::StructType::getFieldTypes(type)) {
             if (TypeHasExactRowCount(kv)) {
                 return true;
             }
@@ -89,7 +89,7 @@ static bool TypeHasExactRowCount(const common::LogicalType* type) {
 
 uint64_t StructColumnReader::getGroupRowsAvailable() {
     for (auto i = 0u; i < childReaders.size(); i++) {
-        if (TypeHasExactRowCount(childReaders[i]->getDataType())) {
+        if (TypeHasExactRowCount(*childReaders[i]->getDataType())) {
             return childReaders[i]->getGroupRowsAvailable();
         }
     }

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -118,7 +118,7 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
         schemas.push_back(std::move(repeatedElem));
         schemaPathToCreate.emplace_back("list");
 
-        auto child_writer = createWriterRecursive(schemas, writer, childType, "element",
+        auto child_writer = createWriterRecursive(schemas, writer, &childType, "element",
             schemaPathToCreate, mm, maxRepeatToCreate + 1, maxDefineToCreate + 2);
         return std::make_unique<ListColumnWriter>(writer, schemaIdx, std::move(schemaPathToCreate),
             maxRepeatToCreate, maxDefineToCreate, std::move(child_writer), canHaveNullsToCreate);

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -66,7 +66,7 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
     switch (type->getLogicalTypeID()) {
     case LogicalTypeID::UNION:
     case LogicalTypeID::STRUCT: {
-        auto fields = StructType::getFields(type);
+        auto fields = StructType::getFields(*type);
         // set up the schema element for this struct
         kuzu_parquet::format::SchemaElement schema_element;
         schema_element.repetition_type = nullType;

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -155,13 +155,13 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
         schemaPathToCreate.emplace_back("key_value");
 
         // Construct the child types recursively.
-        std::vector<common::LogicalType*> kvTypes{MapType::getKeyType(*type),
+        std::vector<common::LogicalType> kvTypes{MapType::getKeyType(*type),
             MapType::getValueType(*type)};
         std::vector<std::string> kvNames{"key", "value"};
         std::vector<std::unique_ptr<ColumnWriter>> childrenWriters;
         childrenWriters.reserve(2);
         for (auto i = 0u; i < 2; i++) {
-            auto childWriter = createWriterRecursive(schemas, writer, kvTypes[i], kvNames[i],
+            auto childWriter = createWriterRecursive(schemas, writer, &kvTypes[i], kvNames[i],
                 schemaPathToCreate, mm, maxRepeatToCreate + 1, maxDefineToCreate + 2, i != 0);
             childrenWriters.push_back(std::move(childWriter));
         }

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -83,7 +83,7 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
         childWriters.reserve(fields.size());
         for (auto& field : fields) {
             childWriters.push_back(
-                createWriterRecursive(schemas, writer, field->getType(), field->getName(),
+                createWriterRecursive(schemas, writer, &field.getType(), field.getName(),
                     schemaPathToCreate, mm, maxRepeatToCreate, maxDefineToCreate + 1));
         }
         return std::make_unique<StructColumnWriter>(writer, schemaIdx,

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -155,8 +155,8 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
         schemaPathToCreate.emplace_back("key_value");
 
         // Construct the child types recursively.
-        std::vector<common::LogicalType*> kvTypes{MapType::getKeyType(type),
-            MapType::getValueType(type)};
+        std::vector<common::LogicalType*> kvTypes{MapType::getKeyType(*type),
+            MapType::getValueType(*type)};
         std::vector<std::string> kvNames{"key", "value"};
         std::vector<std::unique_ptr<ColumnWriter>> childrenWriters;
         childrenWriters.reserve(2);

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -91,7 +91,7 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
             std::move(childWriters), canHaveNullsToCreate);
     }
     case LogicalTypeID::LIST: {
-        auto childType = ListType::getChildType(type);
+        auto childType = ListType::getChildType(*type);
         // Set up the two schema elements for the list
         // for some reason we only set the converted type in the OPTIONAL element
         // first an OPTIONAL element.

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -47,12 +47,12 @@ ParquetWriter::ParquetWriter(std::string fileName,
     std::vector<std::string> schemaPath;
     for (auto i = 0u; i < this->types.size(); i++) {
         columnWriters.push_back(ColumnWriter::createWriterRecursive(fileMetaData.schema, *this,
-            this->types[i].get(), this->columnNames[i], schemaPath, mm));
+            *this->types[i], this->columnNames[i], schemaPath, mm));
     }
 }
 
-Type::type ParquetWriter::convertToParquetType(LogicalType* type) {
-    switch (type->getLogicalTypeID()) {
+Type::type ParquetWriter::convertToParquetType(const LogicalType& type) {
+    switch (type.getLogicalTypeID()) {
     case LogicalTypeID::BOOL:
         return Type::BOOLEAN;
     case LogicalTypeID::INT8:
@@ -84,12 +84,12 @@ Type::type ParquetWriter::convertToParquetType(LogicalType* type) {
     default:
         throw RuntimeException{
             stringFormat("Writing a column with type: {} to parquet is not supported.",
-                LogicalTypeUtils::toString(type->getLogicalTypeID()))};
+                LogicalTypeUtils::toString(type.getLogicalTypeID()))};
     }
 }
 
-void ParquetWriter::setSchemaProperties(LogicalType* type, SchemaElement& schemaElement) {
-    switch (type->getLogicalTypeID()) {
+void ParquetWriter::setSchemaProperties(const LogicalType& type, SchemaElement& schemaElement) {
+    switch (type.getLogicalTypeID()) {
     case LogicalTypeID::INT8: {
         schemaElement.converted_type = ConvertedType::INT_8;
         schemaElement.__isset.converted_type = true;
@@ -145,7 +145,7 @@ void ParquetWriter::setSchemaProperties(LogicalType* type, SchemaElement& schema
         schemaElement.__isset.logicalType = true;
         schemaElement.logicalType.__isset.TIMESTAMP = true;
         schemaElement.logicalType.TIMESTAMP.isAdjustedToUTC =
-            (type->getLogicalTypeID() == LogicalTypeID::TIMESTAMP_TZ);
+            (type.getLogicalTypeID() == LogicalTypeID::TIMESTAMP_TZ);
         schemaElement.logicalType.TIMESTAMP.unit.__isset.MICROS = true;
     } break;
     case LogicalTypeID::TIMESTAMP_MS: {

--- a/src/processor/operator/recursive_extend/path_property_probe.cpp
+++ b/src/processor/operator/recursive_extend/path_property_probe.cpp
@@ -12,8 +12,8 @@ void PathPropertyProbe::initLocalStateInternal(ResultSet* /*resultSet_*/,
     localState = std::make_unique<PathPropertyProbeLocalState>();
     vectors = std::make_unique<Vectors>();
     auto pathVector = resultSet->getValueVector(info->pathPos);
-    auto pathNodesFieldIdx = StructType::getFieldIdx(&pathVector->dataType, InternalKeyword::NODES);
-    auto pathRelsFieldIdx = StructType::getFieldIdx(&pathVector->dataType, InternalKeyword::RELS);
+    auto pathNodesFieldIdx = StructType::getFieldIdx(pathVector->dataType, InternalKeyword::NODES);
+    auto pathRelsFieldIdx = StructType::getFieldIdx(pathVector->dataType, InternalKeyword::RELS);
     vectors->pathNodesVector =
         StructVector::getFieldVector(pathVector.get(), pathNodesFieldIdx).get();
     vectors->pathRelsVector =
@@ -21,9 +21,9 @@ void PathPropertyProbe::initLocalStateInternal(ResultSet* /*resultSet_*/,
     auto pathNodesDataVector = ListVector::getDataVector(vectors->pathNodesVector);
     auto pathRelsDataVector = ListVector::getDataVector(vectors->pathRelsVector);
     auto pathNodesIDFieldIdx =
-        StructType::getFieldIdx(&pathNodesDataVector->dataType, InternalKeyword::ID);
+        StructType::getFieldIdx(pathNodesDataVector->dataType, InternalKeyword::ID);
     auto pathRelsIDFieldIdx =
-        StructType::getFieldIdx(&pathRelsDataVector->dataType, InternalKeyword::ID);
+        StructType::getFieldIdx(pathRelsDataVector->dataType, InternalKeyword::ID);
     vectors->pathNodesIDDataVector =
         StructVector::getFieldVector(pathNodesDataVector, pathNodesIDFieldIdx).get();
     vectors->pathRelsIDDataVector =

--- a/src/processor/operator/recursive_extend/recursive_join.cpp
+++ b/src/processor/operator/recursive_extend/recursive_join.cpp
@@ -122,37 +122,37 @@ void RecursiveJoin::initLocalStateInternal(ResultSet*, ExecutionContext* context
     }
     if (vectors->pathVector != nullptr) {
         auto pathNodesFieldIdx =
-            StructType::getFieldIdx(&vectors->pathVector->dataType, InternalKeyword::NODES);
+            StructType::getFieldIdx(vectors->pathVector->dataType, InternalKeyword::NODES);
         vectors->pathNodesVector =
             StructVector::getFieldVector(vectors->pathVector, pathNodesFieldIdx).get();
         auto pathNodesDataVector = ListVector::getDataVector(vectors->pathNodesVector);
         auto pathNodesIDFieldIdx =
-            StructType::getFieldIdx(&pathNodesDataVector->dataType, InternalKeyword::ID);
+            StructType::getFieldIdx(pathNodesDataVector->dataType, InternalKeyword::ID);
         vectors->pathNodesIDDataVector =
             StructVector::getFieldVector(pathNodesDataVector, pathNodesIDFieldIdx).get();
         auto pathNodesLabelFieldIdx =
-            StructType::getFieldIdx(&pathNodesDataVector->dataType, InternalKeyword::LABEL);
+            StructType::getFieldIdx(pathNodesDataVector->dataType, InternalKeyword::LABEL);
         vectors->pathNodesLabelDataVector =
             StructVector::getFieldVector(pathNodesDataVector, pathNodesLabelFieldIdx).get();
         auto pathRelsFieldIdx =
-            StructType::getFieldIdx(&vectors->pathVector->dataType, InternalKeyword::RELS);
+            StructType::getFieldIdx(vectors->pathVector->dataType, InternalKeyword::RELS);
         vectors->pathRelsVector =
             StructVector::getFieldVector(vectors->pathVector, pathRelsFieldIdx).get();
         auto pathRelsDataVector = ListVector::getDataVector(vectors->pathRelsVector);
         auto pathRelsSrcIDFieldIdx =
-            StructType::getFieldIdx(&pathRelsDataVector->dataType, InternalKeyword::SRC);
+            StructType::getFieldIdx(pathRelsDataVector->dataType, InternalKeyword::SRC);
         vectors->pathRelsSrcIDDataVector =
             StructVector::getFieldVector(pathRelsDataVector, pathRelsSrcIDFieldIdx).get();
         auto pathRelsDstIDFieldIdx =
-            StructType::getFieldIdx(&pathRelsDataVector->dataType, InternalKeyword::DST);
+            StructType::getFieldIdx(pathRelsDataVector->dataType, InternalKeyword::DST);
         vectors->pathRelsDstIDDataVector =
             StructVector::getFieldVector(pathRelsDataVector, pathRelsDstIDFieldIdx).get();
         auto pathRelsIDFieldIdx =
-            StructType::getFieldIdx(&pathRelsDataVector->dataType, InternalKeyword::ID);
+            StructType::getFieldIdx(pathRelsDataVector->dataType, InternalKeyword::ID);
         vectors->pathRelsIDDataVector =
             StructVector::getFieldVector(pathRelsDataVector, pathRelsIDFieldIdx).get();
         auto pathRelsLabelFieldIdx =
-            StructType::getFieldIdx(&pathRelsDataVector->dataType, InternalKeyword::LABEL);
+            StructType::getFieldIdx(pathRelsDataVector->dataType, InternalKeyword::LABEL);
         vectors->pathRelsLabelDataVector =
             StructVector::getFieldVector(pathRelsDataVector, pathRelsLabelFieldIdx).get();
     }

--- a/src/processor/operator/semi_masker.cpp
+++ b/src/processor/operator/semi_masker.cpp
@@ -59,15 +59,15 @@ bool MultiTableSemiMasker::getNextTuplesInternal(ExecutionContext* context) {
 
 void PathSemiMasker::initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) {
     BaseSemiMasker::initLocalStateInternal(resultSet, context);
-    auto pathRelsFieldIdx = StructType::getFieldIdx(&keyVector->dataType, InternalKeyword::RELS);
+    auto pathRelsFieldIdx = StructType::getFieldIdx(keyVector->dataType, InternalKeyword::RELS);
     pathRelsVector = StructVector::getFieldVector(keyVector, pathRelsFieldIdx).get();
     auto pathRelsDataVector = ListVector::getDataVector(pathRelsVector);
     auto pathRelsSrcIDFieldIdx =
-        StructType::getFieldIdx(&pathRelsDataVector->dataType, InternalKeyword::SRC);
+        StructType::getFieldIdx(pathRelsDataVector->dataType, InternalKeyword::SRC);
     pathRelsSrcIDDataVector =
         StructVector::getFieldVector(pathRelsDataVector, pathRelsSrcIDFieldIdx).get();
     auto pathRelsDstIDFieldIdx =
-        StructType::getFieldIdx(&pathRelsDataVector->dataType, InternalKeyword::DST);
+        StructType::getFieldIdx(pathRelsDataVector->dataType, InternalKeyword::DST);
     pathRelsDstIDDataVector =
         StructVector::getFieldVector(pathRelsDataVector, pathRelsDstIDFieldIdx).get();
 }

--- a/src/processor/result/base_hash_table.cpp
+++ b/src/processor/result/base_hash_table.cpp
@@ -88,20 +88,20 @@ template<>
 
 static bool compareNodeEntry(common::ValueVector* vector, uint32_t vectorPos,
     const uint8_t* entry) {
-    KU_ASSERT(0 == common::StructType::getFieldIdx(&vector->dataType, common::InternalKeyword::ID));
+    KU_ASSERT(0 == common::StructType::getFieldIdx(vector->dataType, common::InternalKeyword::ID));
     auto idVector = common::StructVector::getFieldVector(vector, 0).get();
     return compareEntry<common::internalID_t>(idVector, vectorPos,
         entry + common::NullBuffer::getNumBytesForNullValues(
-                    common::StructType::getNumFields(&vector->dataType)));
+                    common::StructType::getNumFields(vector->dataType)));
 }
 
 static bool compareRelEntry(common::ValueVector* vector, uint32_t vectorPos, const uint8_t* entry) {
-    KU_ASSERT(3 == common::StructType::getFieldIdx(&vector->dataType, common::InternalKeyword::ID));
+    KU_ASSERT(3 == common::StructType::getFieldIdx(vector->dataType, common::InternalKeyword::ID));
     auto idVector = common::StructVector::getFieldVector(vector, 3).get();
     return compareEntry<common::internalID_t>(idVector, vectorPos,
         entry + sizeof(common::internalID_t) * 2 + sizeof(common::ku_string_t) +
             common::NullBuffer::getNumBytesForNullValues(
-                common::StructType::getNumFields(&vector->dataType)));
+                common::StructType::getNumFields(vector->dataType)));
 }
 
 template<>
@@ -115,7 +115,7 @@ template<>
         return compareRelEntry(vector, vectorPos, entry);
     }
     case LogicalTypeID::STRUCT: {
-        auto numFields = StructType::getNumFields(&vector->dataType);
+        auto numFields = StructType::getNumFields(vector->dataType);
         auto entryToCompare = entry + NullBuffer::getNumBytesForNullValues(numFields);
         for (auto i = 0u; i < numFields; i++) {
             auto isNullInEntry = NullBuffer::isNull(entry, i);

--- a/src/storage/stats/table_statistics_collection.cpp
+++ b/src/storage/stats/table_statistics_collection.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<MetadataDAHInfo> TablesStatistics::createMetadataDAHInfo(
         metadataDAHInfo->childrenInfos.resize(fields.size());
         for (auto i = 0u; i < fields.size(); i++) {
             metadataDAHInfo->childrenInfos[i] =
-                createMetadataDAHInfo(*fields[i]->getType(), metadataFH, bm, wal);
+                createMetadataDAHInfo(fields[i].getType(), metadataFH, bm, wal);
         }
     } break;
     case PhysicalTypeID::LIST: {

--- a/src/storage/stats/table_statistics_collection.cpp
+++ b/src/storage/stats/table_statistics_collection.cpp
@@ -100,7 +100,7 @@ std::unique_ptr<MetadataDAHInfo> TablesStatistics::createMetadataDAHInfo(
         metadataDAHInfo->childrenInfos.push_back(
             createMetadataDAHInfo(*LogicalType::UINT32(), metadataFH, bm, wal));
         metadataDAHInfo->childrenInfos.push_back(
-            createMetadataDAHInfo(*ListType::getChildType(&dataType), metadataFH, bm, wal));
+            createMetadataDAHInfo(*ListType::getChildType(dataType), metadataFH, bm, wal));
     } break;
     case PhysicalTypeID::ARRAY: {
         metadataDAHInfo->childrenInfos.push_back(

--- a/src/storage/stats/table_statistics_collection.cpp
+++ b/src/storage/stats/table_statistics_collection.cpp
@@ -89,7 +89,7 @@ std::unique_ptr<MetadataDAHInfo> TablesStatistics::createMetadataDAHInfo(
         InMemDiskArray<ColumnChunkMetadata>::addDAHPageToFile(metadataFH, bm, wal);
     switch (dataType.getPhysicalType()) {
     case PhysicalTypeID::STRUCT: {
-        auto fields = StructType::getFields(&dataType);
+        auto fields = StructType::getFields(dataType);
         metadataDAHInfo->childrenInfos.resize(fields.size());
         for (auto i = 0u; i < fields.size(); i++) {
             metadataDAHInfo->childrenInfos[i] =

--- a/src/storage/stats/table_statistics_collection.cpp
+++ b/src/storage/stats/table_statistics_collection.cpp
@@ -106,7 +106,7 @@ std::unique_ptr<MetadataDAHInfo> TablesStatistics::createMetadataDAHInfo(
         metadataDAHInfo->childrenInfos.push_back(
             createMetadataDAHInfo(*LogicalType::UINT32(), metadataFH, bm, wal));
         metadataDAHInfo->childrenInfos.push_back(
-            createMetadataDAHInfo(*ArrayType::getChildType(&dataType), metadataFH, bm, wal));
+            createMetadataDAHInfo(*ArrayType::getChildType(dataType), metadataFH, bm, wal));
     } break;
     case PhysicalTypeID::STRING: {
         auto dataMetadataDAHInfo = std::make_unique<MetadataDAHInfo>();

--- a/src/storage/stats/table_statistics_collection.cpp
+++ b/src/storage/stats/table_statistics_collection.cpp
@@ -100,13 +100,13 @@ std::unique_ptr<MetadataDAHInfo> TablesStatistics::createMetadataDAHInfo(
         metadataDAHInfo->childrenInfos.push_back(
             createMetadataDAHInfo(*LogicalType::UINT32(), metadataFH, bm, wal));
         metadataDAHInfo->childrenInfos.push_back(
-            createMetadataDAHInfo(*ListType::getChildType(dataType), metadataFH, bm, wal));
+            createMetadataDAHInfo(ListType::getChildType(dataType), metadataFH, bm, wal));
     } break;
     case PhysicalTypeID::ARRAY: {
         metadataDAHInfo->childrenInfos.push_back(
             createMetadataDAHInfo(*LogicalType::UINT32(), metadataFH, bm, wal));
         metadataDAHInfo->childrenInfos.push_back(
-            createMetadataDAHInfo(*ArrayType::getChildType(dataType), metadataFH, bm, wal));
+            createMetadataDAHInfo(ArrayType::getChildType(dataType), metadataFH, bm, wal));
     } break;
     case PhysicalTypeID::STRING: {
         auto dataMetadataDAHInfo = std::make_unique<MetadataDAHInfo>();

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -112,7 +112,7 @@ uint32_t StorageUtils::getDataTypeSize(const LogicalType& type) {
     case PhysicalTypeID::STRUCT: {
         uint32_t size = 0;
         auto fieldsTypes = StructType::getFieldTypes(type);
-        for (auto fieldType : fieldsTypes) {
+        for (const auto& fieldType : fieldsTypes) {
             size += getDataTypeSize(fieldType);
         }
         size += NullBuffer::getNumBytesForNullValues(fieldsTypes.size());

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -113,7 +113,7 @@ uint32_t StorageUtils::getDataTypeSize(const LogicalType& type) {
         uint32_t size = 0;
         auto fieldsTypes = StructType::getFieldTypes(type);
         for (auto fieldType : fieldsTypes) {
-            size += getDataTypeSize(*fieldType);
+            size += getDataTypeSize(fieldType);
         }
         size += NullBuffer::getNumBytesForNullValues(fieldsTypes.size());
         return size;

--- a/src/storage/storage_utils.cpp
+++ b/src/storage/storage_utils.cpp
@@ -111,7 +111,7 @@ uint32_t StorageUtils::getDataTypeSize(const LogicalType& type) {
     }
     case PhysicalTypeID::STRUCT: {
         uint32_t size = 0;
-        auto fieldsTypes = StructType::getFieldTypes(&type);
+        auto fieldsTypes = StructType::getFieldTypes(type);
         for (auto fieldType : fieldsTypes) {
             size += getDataTypeSize(*fieldType);
         }

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -59,8 +59,8 @@ ListColumn::ListColumn(std::string name, LogicalType dataType,
         *metaDAHeaderInfo.childrenInfos[0], dataFH, metadataFH, bufferManager, wal, transaction,
         propertyStatistics, enableCompression);
     dataColumn = ColumnFactory::createColumn(dataColName,
-        *ListType::getChildType(this->dataType)->copy(), *metaDAHeaderInfo.childrenInfos[1],
-        dataFH, metadataFH, bufferManager, wal, transaction, propertyStatistics, enableCompression);
+        *ListType::getChildType(this->dataType)->copy(), *metaDAHeaderInfo.childrenInfos[1], dataFH,
+        metadataFH, bufferManager, wal, transaction, propertyStatistics, enableCompression);
 }
 
 void ListColumn::initChunkState(Transaction* transaction, node_group_idx_t nodeGroupIdx,

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -59,7 +59,7 @@ ListColumn::ListColumn(std::string name, LogicalType dataType,
         *metaDAHeaderInfo.childrenInfos[0], dataFH, metadataFH, bufferManager, wal, transaction,
         propertyStatistics, enableCompression);
     dataColumn = ColumnFactory::createColumn(dataColName,
-        *ListType::getChildType(&this->dataType)->copy(), *metaDAHeaderInfo.childrenInfos[1],
+        *ListType::getChildType(this->dataType)->copy(), *metaDAHeaderInfo.childrenInfos[1],
         dataFH, metadataFH, bufferManager, wal, transaction, propertyStatistics, enableCompression);
 }
 
@@ -148,7 +148,7 @@ void ListColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,
             listColumnChunk->resizeDataColumnChunk(std::bit_ceil(resizeNumValues));
             auto tmpDataColumnChunk =
                 std::make_unique<ListDataColumnChunk>(ColumnChunkFactory::createColumnChunk(
-                    *ListType::getChildType(&this->dataType)->copy(), enableCompression,
+                    *ListType::getChildType(this->dataType)->copy(), enableCompression,
                     std::bit_ceil(resizeNumValues)));
             auto dataListColumnChunk = listColumnChunk->getDataColumnChunk();
             for (auto i = 0u; i < columnChunk->getNumValues(); i++) {

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -59,7 +59,7 @@ ListColumn::ListColumn(std::string name, LogicalType dataType,
         *metaDAHeaderInfo.childrenInfos[0], dataFH, metadataFH, bufferManager, wal, transaction,
         propertyStatistics, enableCompression);
     dataColumn = ColumnFactory::createColumn(dataColName,
-        *ListType::getChildType(this->dataType)->copy(), *metaDAHeaderInfo.childrenInfos[1], dataFH,
+        *ListType::getChildType(this->dataType).copy(), *metaDAHeaderInfo.childrenInfos[1], dataFH,
         metadataFH, bufferManager, wal, transaction, propertyStatistics, enableCompression);
 }
 
@@ -148,7 +148,7 @@ void ListColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,
             listColumnChunk->resizeDataColumnChunk(std::bit_ceil(resizeNumValues));
             auto tmpDataColumnChunk =
                 std::make_unique<ListDataColumnChunk>(ColumnChunkFactory::createColumnChunk(
-                    *ListType::getChildType(this->dataType)->copy(), enableCompression,
+                    *ListType::getChildType(this->dataType).copy(), enableCompression,
                     std::bit_ceil(resizeNumValues)));
             auto dataListColumnChunk = listColumnChunk->getDataColumnChunk();
             for (auto i = 0u; i < columnChunk->getNumValues(); i++) {

--- a/src/storage/store/list_column_chunk.cpp
+++ b/src/storage/store/list_column_chunk.cpp
@@ -31,7 +31,7 @@ ListColumnChunk::ListColumnChunk(LogicalType dataType, uint64_t capacity, bool e
     sizeColumnChunk = ColumnChunkFactory::createColumnChunk(*common::LogicalType::UINT32(),
         enableCompression, capacity);
     listDataColumnChunk = std::make_unique<ListDataColumnChunk>(
-        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(&this->dataType)->copy(),
+        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType)->copy(),
             enableCompression, 0 /* capacity */, inMemory));
     checkOffsetSortedAsc = false;
     KU_ASSERT(this->dataType.getPhysicalType() == PhysicalTypeID::LIST ||
@@ -101,7 +101,7 @@ void ListColumnChunk::resetToEmpty() {
     ColumnChunk::resetToEmpty();
     sizeColumnChunk->resetToEmpty();
     listDataColumnChunk = std::make_unique<ListDataColumnChunk>(
-        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(&this->dataType)->copy(),
+        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType)->copy(),
             enableCompression, 0 /* capacity */));
 }
 

--- a/src/storage/store/list_column_chunk.cpp
+++ b/src/storage/store/list_column_chunk.cpp
@@ -31,7 +31,7 @@ ListColumnChunk::ListColumnChunk(LogicalType dataType, uint64_t capacity, bool e
     sizeColumnChunk = ColumnChunkFactory::createColumnChunk(*common::LogicalType::UINT32(),
         enableCompression, capacity);
     listDataColumnChunk = std::make_unique<ListDataColumnChunk>(
-        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType)->copy(),
+        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType).copy(),
             enableCompression, 0 /* capacity */, inMemory));
     checkOffsetSortedAsc = false;
     KU_ASSERT(this->dataType.getPhysicalType() == PhysicalTypeID::LIST ||
@@ -101,7 +101,7 @@ void ListColumnChunk::resetToEmpty() {
     ColumnChunk::resetToEmpty();
     sizeColumnChunk->resetToEmpty();
     listDataColumnChunk = std::make_unique<ListDataColumnChunk>(
-        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType)->copy(),
+        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType).copy(),
             enableCompression, 0 /* capacity */));
 }
 

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -17,7 +17,7 @@ StructColumn::StructColumn(std::string name, LogicalType dataType,
     RWPropertyStats propertyStatistics, bool enableCompression)
     : Column{name, std::move(dataType), metaDAHeaderInfo, dataFH, metadataFH, bufferManager, wal,
           transaction, propertyStatistics, enableCompression, true /* requireNullColumn */} {
-    auto fieldTypes = StructType::getFieldTypes(&this->dataType);
+    auto fieldTypes = StructType::getFieldTypes(this->dataType);
     KU_ASSERT(metaDAHeaderInfo.childrenInfos.size() == fieldTypes.size());
     childColumns.resize(fieldTypes.size());
     for (auto i = 0u; i < fieldTypes.size(); i++) {

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -23,7 +23,7 @@ StructColumn::StructColumn(std::string name, LogicalType dataType,
     for (auto i = 0u; i < fieldTypes.size(); i++) {
         auto childColName = StorageUtils::getColumnName(name,
             StorageUtils::ColumnType::STRUCT_CHILD, std::to_string(i));
-        childColumns[i] = ColumnFactory::createColumn(childColName, *fieldTypes[i]->copy(),
+        childColumns[i] = ColumnFactory::createColumn(childColName, *fieldTypes[i].copy(),
             *metaDAHeaderInfo.childrenInfos[i], dataFH, metadataFH, bufferManager, wal, transaction,
             propertyStatistics, enableCompression);
     }

--- a/src/storage/store/struct_column_chunk.cpp
+++ b/src/storage/store/struct_column_chunk.cpp
@@ -15,7 +15,7 @@ namespace storage {
 StructColumnChunk::StructColumnChunk(LogicalType dataType, uint64_t capacity,
     bool enableCompression, bool inMemory)
     : ColumnChunk{std::move(dataType), capacity} {
-    auto fieldTypes = StructType::getFieldTypes(&this->dataType);
+    auto fieldTypes = StructType::getFieldTypes(this->dataType);
     childChunks.resize(fieldTypes.size());
     for (auto i = 0u; i < fieldTypes.size(); i++) {
         childChunks[i] = ColumnChunkFactory::createColumnChunk(*fieldTypes[i]->copy(),
@@ -43,7 +43,7 @@ void StructColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk
 }
 
 void StructColumnChunk::append(ValueVector* vector, const SelectionVector& selVector) {
-    auto numFields = StructType::getNumFields(&dataType);
+    auto numFields = StructType::getNumFields(dataType);
     for (auto i = 0u; i < numFields; i++) {
         childChunks[i]->append(StructVector::getFieldVector(vector, i).get(), selVector);
     }
@@ -56,7 +56,7 @@ void StructColumnChunk::append(ValueVector* vector, const SelectionVector& selVe
 void StructColumnChunk::lookup(offset_t offsetInChunk, ValueVector& output,
     sel_t posInOutputVector) const {
     KU_ASSERT(offsetInChunk < numValues);
-    auto numFields = StructType::getNumFields(&dataType);
+    auto numFields = StructType::getNumFields(dataType);
     output.setNull(posInOutputVector, nullChunk->isNull(offsetInChunk));
     for (auto i = 0u; i < numFields; i++) {
         childChunks[i]->lookup(offsetInChunk, *StructVector::getFieldVector(&output, i).get(),

--- a/src/storage/store/struct_column_chunk.cpp
+++ b/src/storage/store/struct_column_chunk.cpp
@@ -18,7 +18,7 @@ StructColumnChunk::StructColumnChunk(LogicalType dataType, uint64_t capacity,
     auto fieldTypes = StructType::getFieldTypes(this->dataType);
     childChunks.resize(fieldTypes.size());
     for (auto i = 0u; i < fieldTypes.size(); i++) {
-        childChunks[i] = ColumnChunkFactory::createColumnChunk(*fieldTypes[i]->copy(),
+        childChunks[i] = ColumnChunkFactory::createColumnChunk(*fieldTypes[i].copy(),
             enableCompression, capacity, inMemory);
     }
 }

--- a/test/c_api/data_type_test.cpp
+++ b/test/c_api/data_type_test.cpp
@@ -21,7 +21,7 @@ TEST(CApiDataTypeTest, Create) {
     auto dataTypeCpp3 = (LogicalType*)dataType3->_data_type;
     ASSERT_EQ(dataTypeCpp3->getLogicalTypeID(), LogicalTypeID::ARRAY);
     // ASSERT_EQ(dataTypeCpp3->getChildType()->getLogicalTypeID(), LogicalTypeID::INT64);
-    ASSERT_EQ(ArrayType::getNumElements(dataTypeCpp3), 100);
+    ASSERT_EQ(ArrayType::getNumElements(*dataTypeCpp3), 100);
 
     // Since child type is copied, we should be able to destroy the original type without an error.
     kuzu_data_type_destroy(dataType);

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -1093,7 +1093,7 @@ JNIEXPORT jstring JNICALL Java_com_kuzudb_KuzuNative_kuzu_1value_1get_1struct_1f
     JNIEnv* env, jclass, jobject thisSV, jlong index) {
     auto* sv = getValue(env, thisSV);
     auto dataType = sv->getDataType();
-    auto fieldNames = StructType::getFieldNames(dataType);
+    auto fieldNames = StructType::getFieldNames(*dataType);
     if ((uint64_t)index >= fieldNames.size() || index < 0) {
         return nullptr;
     }
@@ -1106,7 +1106,7 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_KuzuNative_kuzu_1value_1get_1struct_1ind
     auto* sv = getValue(env, thisSV);
     const char* field_name_cstr = env->GetStringUTFChars(field_name, JNI_FALSE);
     auto dataType = sv->getDataType();
-    auto index = StructType::getFieldIdx(dataType, field_name_cstr);
+    auto index = StructType::getFieldIdx(*dataType, field_name_cstr);
     env->ReleaseStringUTFChars(field_name, field_name_cstr);
     if (index == INVALID_STRUCT_FIELD_IDX) {
         return -1;

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -641,7 +641,7 @@ JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1get_1id(J
 JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1get_1child_1type(JNIEnv* env,
     jclass, jobject thisDT) {
     auto* parent_type = getDataType(env, thisDT);
-    LogicalType* child_type;
+    LogicalType child_type;
     if (parent_type->getLogicalTypeID() == LogicalTypeID::ARRAY) {
         child_type = ArrayType::getChildType(*parent_type);
     } else if (parent_type->getLogicalTypeID() == LogicalTypeID::LIST) {
@@ -649,7 +649,7 @@ JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1get_1chil
     } else {
         return nullptr;
     }
-    auto* new_child_type = new LogicalType(*child_type);
+    auto* new_child_type = new LogicalType(child_type);
     jobject ret =
         createJavaObject(env, new_child_type, J_C_KuzuDataType, J_C_KuzuDataType_F_dt_ref);
     return ret;

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -643,7 +643,7 @@ JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1get_1chil
     auto* parent_type = getDataType(env, thisDT);
     LogicalType* child_type;
     if (parent_type->getLogicalTypeID() == LogicalTypeID::ARRAY) {
-        child_type = ArrayType::getChildType(parent_type);
+        child_type = ArrayType::getChildType(*parent_type);
     } else if (parent_type->getLogicalTypeID() == LogicalTypeID::LIST) {
         child_type = ListType::getChildType(*parent_type);
     } else {
@@ -661,7 +661,7 @@ JNIEXPORT jlong JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1get_1num_1e
     if (dt->getLogicalTypeID() != LogicalTypeID::ARRAY) {
         return 0;
     }
-    return static_cast<jlong>(ArrayType::getNumElements(dt));
+    return static_cast<jlong>(ArrayType::getNumElements(*dt));
 }
 
 /**

--- a/tools/java_api/src/jni/kuzu_java.cpp
+++ b/tools/java_api/src/jni/kuzu_java.cpp
@@ -645,7 +645,7 @@ JNIEXPORT jobject JNICALL Java_com_kuzudb_KuzuNative_kuzu_1data_1type_1get_1chil
     if (parent_type->getLogicalTypeID() == LogicalTypeID::ARRAY) {
         child_type = ArrayType::getChildType(parent_type);
     } else if (parent_type->getLogicalTypeID() == LogicalTypeID::LIST) {
-        child_type = ListType::getChildType(parent_type);
+        child_type = ListType::getChildType(*parent_type);
     } else {
         return nullptr;
     }

--- a/tools/nodejs_api/src_cpp/node_util.cpp
+++ b/tools/nodejs_api/src_cpp/node_util.cpp
@@ -196,7 +196,7 @@ Napi::Value Util::ConvertToNapiObject(const Value& value, Napi::Env env) {
     }
     case LogicalTypeID::STRUCT:
     case LogicalTypeID::UNION: {
-        auto childrenNames = StructType::getFieldNames(dataType);
+        auto childrenNames = StructType::getFieldNames(*dataType);
         auto napiObj = Napi::Object::New(env);
         auto size = NestedVal::getChildrenSize(&value);
         for (auto i = 0u; i < size; ++i) {

--- a/tools/python_api/src_cpp/pandas/pandas_analyzer.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_analyzer.cpp
@@ -12,13 +12,13 @@ static bool upgradeType(common::LogicalType& left, const common::LogicalType& ri
     }
     if (left.getLogicalTypeID() == common::LogicalTypeID::ANY ||
         ((left.getLogicalTypeID() == common::LogicalTypeID::LIST) &&
-            (common::ListType::getChildType(left)->getLogicalTypeID() ==
+            (common::ListType::getChildType(left).getLogicalTypeID() ==
                 common::LogicalTypeID::ANY))) {
         left = right;
         return true;
     }
     if (((right.getLogicalTypeID() == common::LogicalTypeID::LIST) &&
-            (common::ListType::getChildType(right)->getLogicalTypeID() ==
+            (common::ListType::getChildType(right).getLogicalTypeID() ==
                 common::LogicalTypeID::ANY))) {
         return true;
     }

--- a/tools/python_api/src_cpp/pandas/pandas_analyzer.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_analyzer.cpp
@@ -12,13 +12,13 @@ static bool upgradeType(common::LogicalType& left, const common::LogicalType& ri
     }
     if (left.getLogicalTypeID() == common::LogicalTypeID::ANY ||
         ((left.getLogicalTypeID() == common::LogicalTypeID::LIST) &&
-            (common::ListType::getChildType(&left)->getLogicalTypeID() ==
+            (common::ListType::getChildType(left)->getLogicalTypeID() ==
                 common::LogicalTypeID::ANY))) {
         left = right;
         return true;
     }
     if (((right.getLogicalTypeID() == common::LogicalTypeID::LIST) &&
-            (common::ListType::getChildType(&right)->getLogicalTypeID() ==
+            (common::ListType::getChildType(right)->getLogicalTypeID() ==
                 common::LogicalTypeID::ANY))) {
         return true;
     }

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -365,7 +365,7 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
         std::vector<std::unique_ptr<Value>> children;
         for (auto child : lst) {
             children.push_back(std::make_unique<Value>(
-                transformPythonValueAs(child, ListType::getChildType(type))));
+                transformPythonValueAs(child, ListType::getChildType(*type))));
         }
         return Value(std::make_unique<LogicalType>(*type), std::move(children));
     }

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -275,9 +275,9 @@ static Value transformPythonValueAs(py::handle val, const LogicalType& type) {
     auto time_delta = importCache->datetime.timedelta();
     auto datetime_date = importCache->datetime.date();
     if (val.is_none()) {
-        return Value::createNullValue(*type);
+        return Value::createNullValue(type);
     }
-    switch (type->getLogicalTypeID()) {
+    switch (type.getLogicalTypeID()) {
     case LogicalTypeID::ANY:
         return Value::createNullValue();
     case LogicalTypeID::BOOL:
@@ -372,8 +372,7 @@ static Value transformPythonValueAs(py::handle val, const LogicalType& type) {
     case LogicalTypeID::MAP: {
         py::dict dict = py::reinterpret_borrow<py::dict>(val);
         std::vector<std::unique_ptr<Value>> children;
-        auto childKeyType = MapType::getKeyType(type),
-             childValueType = MapType::getValueType(type);
+        auto childKeyType = MapType::getKeyType(type), childValueType = MapType::getValueType(type);
         for (auto child : dict) {
             // type construction is inefficient, we have to create duplicates because it asks for
             // a unique ptr
@@ -401,7 +400,7 @@ static Value transformPythonValueAs(py::handle val, const LogicalType& type) {
 
 Value transformPythonValue(py::handle val) {
     auto type = pyLogicalType(val);
-    return transformPythonValueAs(val, type.get());
+    return transformPythonValueAs(val, *type);
 }
 
 std::unique_ptr<PyQueryResult> PyConnection::checkAndWrapQueryResult(

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -379,9 +379,9 @@ static Value transformPythonValueAs(py::handle val, const LogicalType& type) {
             // a unique ptr
             std::vector<StructField> fields;
             fields.emplace_back(InternalKeyword::MAP_KEY,
-                std::make_unique<LogicalType>(*childKeyType));
+                std::make_unique<LogicalType>(childKeyType));
             fields.emplace_back(InternalKeyword::MAP_VALUE,
-                std::make_unique<LogicalType>(*childValueType));
+                std::make_unique<LogicalType>(childValueType));
             std::vector<std::unique_ptr<Value>> structValues;
             structValues.push_back(
                 std::make_unique<Value>(transformPythonValueAs(child.first, childKeyType)));
@@ -390,7 +390,7 @@ static Value transformPythonValueAs(py::handle val, const LogicalType& type) {
             children.push_back(std::make_unique<Value>(LogicalType::STRUCT(std::move(fields)),
                 std::move(structValues)));
         }
-        return Value(std::make_unique<LogicalType>(*type), std::move(children));
+        return Value(std::make_unique<LogicalType>(type), std::move(children));
     }
     // LCOV_EXCL_START
     default:

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -372,7 +372,7 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
     case LogicalTypeID::MAP: {
         py::dict dict = py::reinterpret_borrow<py::dict>(val);
         std::vector<std::unique_ptr<Value>> children;
-        auto childKeyType = MapType::getKeyType(type), childValueType = MapType::getValueType(type);
+        auto childKeyType = MapType::getKeyType(*type), childValueType = MapType::getValueType(*type);
         for (auto child : dict) {
             // type construction is inefficient, we have to create duplicates because it asks for
             // a unique ptr

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -269,7 +269,7 @@ static std::unique_ptr<LogicalType> pyLogicalType(py::handle val) {
     }
 }
 
-static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
+static Value transformPythonValueAs(py::handle val, const LogicalType& type) {
     // ignore the type of the actual python object, just directly cast
     auto datetime_datetime = importCache->datetime.datetime();
     auto time_delta = importCache->datetime.timedelta();
@@ -365,15 +365,15 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
         std::vector<std::unique_ptr<Value>> children;
         for (auto child : lst) {
             children.push_back(std::make_unique<Value>(
-                transformPythonValueAs(child, ListType::getChildType(*type))));
+                transformPythonValueAs(child, ListType::getChildType(type))));
         }
-        return Value(std::make_unique<LogicalType>(*type), std::move(children));
+        return Value(std::make_unique<LogicalType>(type), std::move(children));
     }
     case LogicalTypeID::MAP: {
         py::dict dict = py::reinterpret_borrow<py::dict>(val);
         std::vector<std::unique_ptr<Value>> children;
-        auto childKeyType = MapType::getKeyType(*type),
-             childValueType = MapType::getValueType(*type);
+        auto childKeyType = MapType::getKeyType(type),
+             childValueType = MapType::getValueType(type);
         for (auto child : dict) {
             // type construction is inefficient, we have to create duplicates because it asks for
             // a unique ptr

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -372,7 +372,8 @@ static Value transformPythonValueAs(py::handle val, const LogicalType* type) {
     case LogicalTypeID::MAP: {
         py::dict dict = py::reinterpret_borrow<py::dict>(val);
         std::vector<std::unique_ptr<Value>> children;
-        auto childKeyType = MapType::getKeyType(*type), childValueType = MapType::getValueType(*type);
+        auto childKeyType = MapType::getKeyType(*type),
+             childValueType = MapType::getValueType(*type);
         for (auto child : dict) {
             // type construction is inefficient, we have to create duplicates because it asks for
             // a unique ptr

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -287,7 +287,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
         return convertValueToPyObject(*NestedVal::getChildVal(&value, 0 /* idx */));
     }
     case LogicalTypeID::STRUCT: {
-        auto fieldNames = StructType::getFieldNames(dataType);
+        auto fieldNames = StructType::getFieldNames(*dataType);
         py::dict dict;
         for (auto i = 0u; i < NestedVal::getChildrenSize(&value); ++i) {
             auto key = py::str(fieldNames[i]);

--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -68,9 +68,9 @@ inline std::unique_ptr<kuzu::common::LogicalType> create_logical_type_rdf_varian
     return kuzu::common::LogicalType::RDF_VARIANT();
 }
 
-const kuzu::common::LogicalType& logical_type_get_list_child_type(
+std::unique_ptr<kuzu::common::LogicalType> logical_type_get_list_child_type(
     const kuzu::common::LogicalType& logicalType);
-const kuzu::common::LogicalType& logical_type_get_array_child_type(
+std::unique_ptr<kuzu::common::LogicalType> logical_type_get_array_child_type(
     const kuzu::common::LogicalType& logicalType);
 uint64_t logical_type_get_array_num_elements(const kuzu::common::LogicalType& logicalType);
 

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -223,8 +223,8 @@ pub(crate) mod ffi {
             valueType: UniquePtr<LogicalType>,
         ) -> UniquePtr<LogicalType>;
 
-        fn logical_type_get_list_child_type(value: &LogicalType) -> &LogicalType;
-        fn logical_type_get_array_child_type(value: &LogicalType) -> &LogicalType;
+        fn logical_type_get_list_child_type(value: &LogicalType) -> UniquePtr<LogicalType>;
+        fn logical_type_get_array_child_type(value: &LogicalType) -> UniquePtr<LogicalType>;
         fn logical_type_get_array_num_elements(value: &LogicalType) -> u64;
         fn logical_type_get_struct_field_names(value: &LogicalType) -> Vec<String>;
         fn logical_type_get_struct_field_types(

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -49,7 +49,7 @@ uint64_t logical_type_get_array_num_elements(const LogicalType& logicalType) {
 rust::Vec<rust::String> logical_type_get_struct_field_names(
     const kuzu::common::LogicalType& value) {
     rust::Vec<rust::String> names;
-    for (auto name : kuzu::common::StructType::getFieldNames(&value)) {
+    for (auto name : kuzu::common::StructType::getFieldNames(value)) {
         names.push_back(name);
     }
     return names;
@@ -58,7 +58,7 @@ rust::Vec<rust::String> logical_type_get_struct_field_names(
 std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_field_types(
     const kuzu::common::LogicalType& value) {
     std::vector<kuzu::common::LogicalType> result;
-    for (auto type : kuzu::common::StructType::getFieldTypes(&value)) {
+    for (auto type : kuzu::common::StructType::getFieldTypes(value)) {
         result.push_back(*type);
     }
     return std::make_unique<std::vector<LogicalType>>(result);

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -37,7 +37,7 @@ std::unique_ptr<kuzu::common::LogicalType> create_logical_type_map(
 }
 
 const LogicalType& logical_type_get_list_child_type(const LogicalType& logicalType) {
-    return *kuzu::common::ListType::getChildType(&logicalType);
+    return *kuzu::common::ListType::getChildType(logicalType);
 }
 const LogicalType& logical_type_get_array_child_type(const LogicalType& logicalType) {
     return *kuzu::common::ArrayType::getChildType(&logicalType);

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -40,10 +40,10 @@ const LogicalType& logical_type_get_list_child_type(const LogicalType& logicalTy
     return *kuzu::common::ListType::getChildType(logicalType);
 }
 const LogicalType& logical_type_get_array_child_type(const LogicalType& logicalType) {
-    return *kuzu::common::ArrayType::getChildType(&logicalType);
+    return *kuzu::common::ArrayType::getChildType(logicalType);
 }
 uint64_t logical_type_get_array_num_elements(const LogicalType& logicalType) {
-    return kuzu::common::ArrayType::getNumElements(&logicalType);
+    return kuzu::common::ArrayType::getNumElements(logicalType);
 }
 
 rust::Vec<rust::String> logical_type_get_struct_field_names(

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -36,11 +36,11 @@ std::unique_ptr<kuzu::common::LogicalType> create_logical_type_map(
     return LogicalType::MAP(std::move(keyType), std::move(valueType));
 }
 
-const LogicalType& logical_type_get_list_child_type(const LogicalType& logicalType) {
-    return kuzu::common::ListType::getChildType(logicalType);
+std::unique_ptr<LogicalType> logical_type_get_list_child_type(const LogicalType& logicalType) {
+    return kuzu::common::ListType::getChildType(logicalType).copy();
 }
-const LogicalType& logical_type_get_array_child_type(const LogicalType& logicalType) {
-    return kuzu::common::ArrayType::getChildType(logicalType);
+std::unique_ptr<LogicalType> logical_type_get_array_child_type(const LogicalType& logicalType) {
+    return kuzu::common::ArrayType::getChildType(logicalType).copy();
 }
 uint64_t logical_type_get_array_num_elements(const LogicalType& logicalType) {
     return kuzu::common::ArrayType::getNumElements(logicalType);
@@ -59,7 +59,7 @@ std::unique_ptr<std::vector<kuzu::common::LogicalType>> logical_type_get_struct_
     const kuzu::common::LogicalType& value) {
     std::vector<kuzu::common::LogicalType> result;
     for (auto type : kuzu::common::StructType::getFieldTypes(value)) {
-        result.push_back(*type);
+        result.push_back(type);
     }
     return std::make_unique<std::vector<LogicalType>>(result);
 }

--- a/tools/rust_api/src/kuzu_rs.cpp
+++ b/tools/rust_api/src/kuzu_rs.cpp
@@ -37,10 +37,10 @@ std::unique_ptr<kuzu::common::LogicalType> create_logical_type_map(
 }
 
 const LogicalType& logical_type_get_list_child_type(const LogicalType& logicalType) {
-    return *kuzu::common::ListType::getChildType(logicalType);
+    return kuzu::common::ListType::getChildType(logicalType);
 }
 const LogicalType& logical_type_get_array_child_type(const LogicalType& logicalType) {
-    return *kuzu::common::ArrayType::getChildType(logicalType);
+    return kuzu::common::ArrayType::getChildType(logicalType);
 }
 uint64_t logical_type_get_array_num_elements(const LogicalType& logicalType) {
     return kuzu::common::ArrayType::getNumElements(logicalType);

--- a/tools/rust_api/src/logical_type.rs
+++ b/tools/rust_api/src/logical_type.rs
@@ -119,10 +119,20 @@ impl From<&ffi::LogicalType> for LogicalType {
             LogicalTypeID::TIMESTAMP_SEC => LogicalType::TimestampSec,
             LogicalTypeID::INTERNAL_ID => LogicalType::InternalID,
             LogicalTypeID::LIST => LogicalType::List {
-                child_type: Box::new(ffi::logical_type_get_list_child_type(logical_type).into()),
+                child_type: Box::new(
+                    ffi::logical_type_get_list_child_type(logical_type)
+                        .as_ref()
+                        .unwrap()
+                        .into(),
+                ),
             },
             LogicalTypeID::ARRAY => LogicalType::Array {
-                child_type: Box::new(ffi::logical_type_get_array_child_type(logical_type).into()),
+                child_type: Box::new(
+                    ffi::logical_type_get_array_child_type(logical_type)
+                        .as_ref()
+                        .unwrap()
+                        .into(),
+                ),
                 num_elements: ffi::logical_type_get_array_num_elements(logical_type),
             },
             LogicalTypeID::STRUCT => {
@@ -139,8 +149,9 @@ impl From<&ffi::LogicalType> for LogicalType {
             LogicalTypeID::REL => LogicalType::Rel,
             LogicalTypeID::RECURSIVE_REL => LogicalType::RecursiveRel,
             LogicalTypeID::MAP => {
-                let child_types = ffi::logical_type_get_list_child_type(logical_type);
-                let types = ffi::logical_type_get_struct_field_types(child_types);
+                let child_type_ptr = ffi::logical_type_get_list_child_type(logical_type);
+                let child_type = child_type_ptr.as_ref().unwrap();
+                let types = ffi::logical_type_get_struct_field_types(child_type);
                 let key_type = types
                     .as_ref()
                     .unwrap()


### PR DESCRIPTION
This PR resolved issue #3395 
The parameter type in ```ListType```, ```ArrayType```, ```StructType```, ```MapType```, and ```UnionType``` is modified to ```const LogicalType&```, and the return type is changed to ```LogicalType```.