### PR TITLE
Allow fuzzy matching on test result

### DIFF
--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -88,8 +88,8 @@ Binder exception: Directory ${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db5 does not 
 -REMOVE_FILE "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4/schema.cypher"
 -IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4"
 -STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4"
----- error
-Binder exception: File ${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4/schema.cypher does not exist.
+---- error(regex)
+^Binder exception: File ${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4[/\\]schema.cypher does not exist.$
 
 
 -CASE ExportImportDatabaseRelGroup

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -88,8 +88,8 @@ Binder exception: Directory ${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db5 does not 
 -REMOVE_FILE "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4/schema.cypher"
 -IMPORT_DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4"
 -STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4"
----- error(regex)
-Binder exception: File ${KUZU_EXPORT_DB_DIRECTORY}_case3/demo-db4/schema.cypher does not exist.
+---- error
+Binder exception: File ${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db4/schema.cypher does not exist.
 
 
 -CASE ExportImportDatabaseRelGroup

--- a/test/test_files/tinysnb/exception/insert_delete.test
+++ b/test/test_files/tinysnb/exception/insert_delete.test
@@ -27,7 +27,6 @@ Runtime exception: Found NULL, which violates the non-null constraint of the pri
 
 # This can produce exception messages with different connected rel table on different platforms.
 -CASE DeleteNodeWithEdgeErrorTest
--SKIP
 -STATEMENT MATCH (a:person) WHERE a.ID = 0 DELETE a
----- error
-Runtime exception: Node(nodeOffset: 0) has connected edges in table studyAt in the fwd direction, which cannot be deleted. Please delete the edges first or try DETACH DELETE.
+---- error(regex)
+^Runtime exception: Node\(nodeOffset: 0\) has connected edges in table (knows|studyAt|meets|marries) in the fwd direction, which cannot be deleted. Please delete the edges first or try DETACH DELETE.$

--- a/test/test_files/update_node/delete_tinysnb.test
+++ b/test/test_files/update_node/delete_tinysnb.test
@@ -87,10 +87,9 @@
 
 # This can produce exception messages with different connected rel table on different platforms.
 -CASE DeleteNodeWithConnectedRels
--SKIP
 -STATEMENT MATCH (a:person {ID: 0}) DELETE a
----- error
-Runtime exception: Node(nodeOffset: 0) has connected edges in table studyAt in the fwd direction, which cannot be deleted. Please delete the edges first or try DETACH DELETE.
+---- error(regex)
+^Runtime exception: Node\(nodeOffset: 0\) has connected edges in table (knows|studyAt|meets|marries) in the fwd direction, which cannot be deleted\. Please delete the edges first or try DETACH DELETE\.$
 -STATEMENT MATCH (o:organisation {ID: 6}) DELETE o
 ---- error
 Runtime exception: Node(nodeOffset: 2) has connected edges in table workAt in the bwd direction, which cannot be deleted. Please delete the edges first or try DETACH DELETE.

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -102,15 +102,9 @@ bool TestRunner::checkLogicalPlan(std::unique_ptr<PreparedStatement>& preparedSt
         spdlog::info("EXPECTED ERROR: {}", expectedError);
     } else if (statement->expectedErrorRegex) {
         std::string expectedError = StringUtils::rtrim(result->getErrorMessage());
-        std::regex pattern("^.*[\\\\/]+([^\\\\/]+)$");
-        std::smatch match1;
-        bool is_match1 = std::regex_match(expectedError, match1, pattern);
-        std::smatch match2;
-        bool is_match2 = std::regex_match(statement->errorMessage, match2, pattern);
-        if (is_match1 && is_match2) {
-            if (match1[1] == match2[1]) {
-                return true;
-            }
+        std::regex pattern(statement->errorMessage);
+        if (std::regex_match(expectedError, pattern)) {
+            return true;
         }
         spdlog::info("EXPECTED ERROR: {}", expectedError);
     } else if (statement->expectedOk && result->isSuccess()) {


### PR DESCRIPTION
**Fuzzy (regex) matching on errors**
- changed one old test case (the only one that needed regex)
- changed the existing `---- error(regex)` handling (unused by any test cases) to be recognized as a pattern

**Example**
we should now be able to run the example from issue (ExtensionErrorTest) but the behaviour of that test changed due to a code update.