### PR TITLE
Support multiple query statements in e2e test framework

### DIFF
--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -14,11 +14,11 @@ namespace testing {
 
 enum class ResultType {
     OK,
-    ERROR,
-    ERROR_REGEX,
     HASH,
     TUPLES,
     TUPLES_CSV,
+    ERROR_MSG,
+    ERROR_REGEX,
 };
 
 struct TestQueryResult {

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -25,7 +25,7 @@ struct TestQueryResult {
     ResultType type;
     uint64_t numTuples = 0;
     // errorMsg, CSVFile, hashValue uses first element
-    std::vector<std::string> expectedResult; 
+    std::vector<std::string> expectedResult;
 };
 
 struct TestStatement {

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -16,16 +16,16 @@ enum class ResultType {
     OK,
     HASH,
     TUPLES,
-    TUPLES_CSV,
+    CSV_FILE,
     ERROR_MSG,
     ERROR_REGEX,
 };
 
 struct TestQueryResult {
     ResultType type;
-    std::vector<std::string> expectedTuples;
     uint64_t numTuples = 0;
-    std::string expectedMessage; // errorMsg || CSVFile || hashValue
+    // errorMsg, CSVFile, hashValue uses first element
+    std::vector<std::string> expectedResult; 
 };
 
 struct TestStatement {

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -12,28 +12,42 @@
 namespace kuzu {
 namespace testing {
 
+enum class ResultType {
+    OK,
+    ERROR,
+    ERROR_REGEX,
+    HASH,
+    TUPLES,
+    TUPLES_CSV,
+};
+
+struct TestQueryResult {
+    ResultType type;
+    std::vector<std::string> expectedTuples;
+    uint64_t numTuples = 0;
+    std::string expectedMessage; // errorMsg | CSVFile | hashValue
+    // union
+    // {
+    //     std::string errorMessage;
+    //     std::string tuplesCSVFile;
+    //     std::string hashValue;
+    // };
+};
+
 struct TestStatement {
     std::string logMessage;
     std::string query;
     uint64_t numThreads = 4;
     std::string encodedJoin;
-    bool expectedError = false;
-    bool expectedErrorRegex = false;
-    std::string errorMessage;
-    bool expectedOk = false;
-    uint64_t expectedNumTuples = 0;
-    std::vector<std::string> expectedTuples;
     bool enumerate = false;
     bool checkOutputOrder = false;
     bool checkColumnNames = false;
-    std::string expectedTuplesCSVFile;
+    std::vector<TestQueryResult> result;
     // for multiple conns
     std::string batchStatmentsCSVFile;
     std::optional<std::string> connName;
     bool reloadDBFlag = false;
-    bool expectHash = false;
     bool importDBFlag = false;
-    std::string expectedHashValue;
     // for export and import db
     std::string importFilePath;
     bool removeFileFlag = false;

--- a/test/include/test_runner/test_group.h
+++ b/test/include/test_runner/test_group.h
@@ -25,13 +25,7 @@ struct TestQueryResult {
     ResultType type;
     std::vector<std::string> expectedTuples;
     uint64_t numTuples = 0;
-    std::string expectedMessage; // errorMsg | CSVFile | hashValue
-    // union
-    // {
-    //     std::string errorMessage;
-    //     std::string tuplesCSVFile;
-    //     std::string hashValue;
-    // };
+    std::string expectedMessage; // errorMsg || CSVFile || hashValue
 };
 
 struct TestStatement {

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -94,6 +94,7 @@ private:
     void genGroupName();
     void parseHeader();
     void parseBody();
+    void extractAllResults(TestStatement* statement);
     void extractExpectedResult(TestStatement* statement);
     void extractStatementBlock();
     void extractDataset();

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -94,8 +94,8 @@ private:
     void genGroupName();
     void parseHeader();
     void parseBody();
-    void extractAllResults(TestStatement* statement);
-    void extractExpectedResult(TestStatement* statement);
+    void extractExpectedResults(TestStatement* statement);
+    TestQueryResult extractExpectedResultFromToken(bool checkOutputOrder);
     void extractStatementBlock();
     void extractDataset();
     void addStatementBlock(const std::string& blockName, const std::string& testGroupName);

--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -18,16 +18,16 @@ private:
     static bool testStatement(TestStatement* statement, main::Connection& conn,
         std::string& databasePath);
     static bool checkLogicalPlans(std::unique_ptr<main::PreparedStatement>& preparedStatement,
-        TestStatement* statement, main::Connection& conn);
+        TestStatement* statement, size_t resultIdx, main::Connection& conn);
     static bool checkLogicalPlan(std::unique_ptr<main::PreparedStatement>& preparedStatement,
-        TestStatement* statement, main::Connection& conn, uint32_t planIdx);
+        TestStatement* statement, size_t resultIdx, main::Connection& conn, uint32_t planIdx);
     static std::vector<std::string> convertResultToString(main::QueryResult& queryResult,
         bool checkOutputOrder = false, bool checkColumnNames = false);
     static std::string convertResultToMD5Hash(main::QueryResult& queryResult, bool checkOutputOrder,
         bool checkColumnNames); // returns hash and number of values hashed
     static std::string convertResultColumnsToString(main::QueryResult& queryResult);
     static bool checkPlanResult(std::unique_ptr<main::QueryResult>& result,
-        TestStatement* statement, const std::string& planStr, uint32_t planIndex);
+        TestStatement* statement, size_t resultIdx, const std::string& planStr, uint32_t planIdx);
 };
 
 } // namespace testing

--- a/test/test_files/extension/extension.test
+++ b/test/test_files/extension/extension.test
@@ -8,10 +8,8 @@
 -SKIP_MUSL
 -LOG InstallExtension
 -STATEMENT INSTALL httpfs;
----- ok
--STATEMENT LOAD EXTENSION httpfs;
----- ok
--STATEMENT LOAD FROM 'http://extension.kuzudb.com/dataset/test/city.csv' return *;
+           LOAD EXTENSION httpfs;
+           LOAD FROM 'http://extension.kuzudb.com/dataset/test/city.csv' return *;
 ---- 3
 Guelph|75000
 Kitchener|200000

--- a/test/test_files/extension/extension.test
+++ b/test/test_files/extension/extension.test
@@ -10,6 +10,8 @@
 -STATEMENT INSTALL httpfs;
            LOAD EXTENSION httpfs;
            LOAD FROM 'http://extension.kuzudb.com/dataset/test/city.csv' return *;
+---- ok
+---- ok
 ---- 3
 Guelph|75000
 Kitchener|200000

--- a/test/test_files/transaction/create_rel/violate_error.test
+++ b/test/test_files/transaction/create_rel/violate_error.test
@@ -20,4 +20,4 @@
 ---- 1
 1
 -STATEMENT COMMIT
-
+---- ok

--- a/test/test_runner/test_parser.cpp
+++ b/test/test_runner/test_parser.cpp
@@ -143,7 +143,7 @@ void TestParser::extractExpectedResult(TestStatement* statement) {
     if (result == "ok") {
         queryResult.type = ResultType::OK;
     } else if (result == "error") {
-        queryResult.type = ResultType::ERROR;
+        queryResult.type = ResultType::ERROR_MSG;
         queryResult.expectedMessage = extractTextBeforeNextStatement();
         replaceVariables(queryResult.expectedMessage);
     } else if (result == "error(regex)") {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -163,8 +163,7 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
     if (testAnswer.type == ResultType::HASH) {
         std::string resultHash = TestRunner::convertResultToMD5Hash(*result,
             statement->checkOutputOrder, statement->checkColumnNames);
-        if (resultTuples.size() == actualNumTuples &&
-            resultHash == testAnswer.expectedResult[0] &&
+        if (resultTuples.size() == actualNumTuples && resultHash == testAnswer.expectedResult[0] &&
             resultTuples.size() == testAnswer.numTuples) {
             spdlog::info("PLAN{} PASSED in {}ms.", planIdx,
                 result->getQuerySummary()->getExecutionTime());

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -137,8 +137,8 @@ bool TestRunner::checkLogicalPlan(std::unique_ptr<PreparedStatement>& preparedSt
     return false;
 }
 
-bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestStatement* statement, size_t resultIdx,
-    const std::string& planStr, uint32_t planIdx) {
+bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestStatement* statement,
+    size_t resultIdx, const std::string& planStr, uint32_t planIdx) {
     TestQueryResult& expectedResult = statement->result[resultIdx];
     if (expectedResult.type == ResultType::TUPLES_CSV) {
         std::ifstream expectedTuplesFile(expectedResult.expectedMessage);
@@ -162,7 +162,7 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
     if (expectedResult.type == ResultType::HASH) {
         std::string resultHash = TestRunner::convertResultToMD5Hash(*result,
             statement->checkOutputOrder, statement->checkColumnNames);
-        if (resultTuples.size() == actualNumTuples && 
+        if (resultTuples.size() == actualNumTuples &&
             resultHash == expectedResult.expectedMessage &&
             resultTuples.size() == expectedResult.numTuples) {
             spdlog::info("PLAN{} PASSED in {}ms.", planIdx,

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -60,7 +60,7 @@ bool TestRunner::testStatement(TestStatement* statement, Connection& conn,
     }
     // Run the non-last queries
     size_t numParsed = parsedStatements.size();
-    for (int i = 0; i < numParsed - 1; i++) {
+    for (size_t i = 0; i < numParsed - 1; i++) {
         preparedStatement =
             conn.prepareNoLock(std::move(parsedStatements[i]), statement->enumerate);
         if (!preparedStatement->isSuccess()) {

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -69,7 +69,7 @@ bool TestRunner::testStatement(TestStatement* statement, Connection& conn,
         }
         // Check for wrong statements
         ResultType resultType = statement->result[i].type;
-        if (resultType != ResultType::ERROR && resultType != ResultType::ERROR_REGEX &&
+        if (resultType != ResultType::ERROR_MSG && resultType != ResultType::ERROR_REGEX &&
             !preparedStatement->isSuccess()) {
             spdlog::error(preparedStatement->getErrorMessage());
             return false;
@@ -105,7 +105,7 @@ bool TestRunner::checkLogicalPlan(std::unique_ptr<PreparedStatement>& preparedSt
     case ResultType::OK: {
         return result->isSuccess();
     }
-    case ResultType::ERROR: {
+    case ResultType::ERROR_MSG: {
         expectedError = StringUtils::rtrim(result->getErrorMessage());
         if (expectedResult.expectedMessage == expectedError) {
             return true;

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -61,7 +61,8 @@ bool TestRunner::testStatement(TestStatement* statement, Connection& conn,
     // Run the non-last queries
     size_t numParsed = parsedStatements.size();
     for (int i = 0; i < numParsed - 1; i++) {
-        preparedStatement = conn.prepareNoLock(std::move(parsedStatements[i]), statement->enumerate);
+        preparedStatement =
+            conn.prepareNoLock(std::move(parsedStatements[i]), statement->enumerate);
         if (!preparedStatement->isSuccess()) {
             spdlog::error(preparedStatement->getErrorMessage());
             return false;


### PR DESCRIPTION
**Testing Multiple Query Statements**
- This implementation supports multiple query statements to multiple results

**Example**

```
// this now works
-STATEMENT INSTALL httpfs; // assumed non-error statement
           LOAD EXTENSION httpfs; // assumed non-error statement
           LOAD FROM 'http://extension.kuzudb.com/dataset/test/city.csv' return *;
---- ok
---- ok
---- 3
Guelph|75000
Kitchener|200000
Waterloo|150000
```