### PR TITLE
Reclaim empty overflow slots in memory hash index

### DIFF
--- a/src/include/storage/index/hash_index_header.h
+++ b/src/include/storage/index/hash_index_header.h
@@ -10,7 +10,8 @@ class HashIndexHeader {
 public:
     explicit HashIndexHeader(common::PhysicalTypeID keyDataTypeID)
         : currentLevel{1}, levelHashMask{1}, higherLevelHashMask{3}, nextSplitSlotId{0},
-          numEntries{0}, keyDataTypeID{keyDataTypeID} {}
+          numEntries{0}, keyDataTypeID{keyDataTypeID},
+          firstFreeOverflowSlotId{SlotHeader::INVALID_OVERFLOW_SLOT_ID} {}
 
     // Used for element initialization in disk array only.
     HashIndexHeader() : HashIndexHeader(common::PhysicalTypeID::STRING) {}
@@ -33,9 +34,15 @@ public:
     uint64_t currentLevel;
     uint64_t levelHashMask;
     uint64_t higherLevelHashMask;
+    // Id of the next slot to split when resizing the hash index
     slot_id_t nextSplitSlotId;
     uint64_t numEntries;
     common::PhysicalTypeID keyDataTypeID;
+    // Id of the first in a chain of empty overflow slots which have been reclaimed during slot
+    // splitting. The nextOvfSlotId field in the slot's header indicates the next slot in the chain.
+    // These slots should be used first when allocating new overflow slots
+    // TODO(bmwinger): Make use of this in the on-disk hash index
+    slot_id_t firstFreeOverflowSlotId;
 };
 
 } // namespace storage

--- a/src/include/storage/index/hash_index_slot.h
+++ b/src/include/storage/index/hash_index_slot.h
@@ -15,6 +15,7 @@ using slot_id_t = uint64_t;
 class SlotHeader {
 public:
     static const entry_pos_t INVALID_ENTRY_POS = UINT8_MAX;
+    static const entry_pos_t INVALID_OVERFLOW_SLOT_ID = 0;
     // For a header of 32 bytes.
     // This is smaller than the possible number of entries with an 1-byte key like uint8_t,
     // but the additional size would limit the number of entries for 8-byte keys, so we

--- a/src/include/storage/index/hash_index_utils.h
+++ b/src/include/storage/index/hash_index_utils.h
@@ -24,11 +24,16 @@ enum class SlotType : uint8_t { PRIMARY = 0, OVF = 1 };
 struct SlotInfo {
     slot_id_t slotId{UINT64_MAX};
     SlotType slotType{SlotType::PRIMARY};
+
+    bool operator==(const SlotInfo&) const = default;
 };
 
 class HashIndexUtils {
 
 public:
+    static constexpr SlotInfo INVALID_OVF_INFO =
+        SlotInfo{SlotHeader::INVALID_OVERFLOW_SLOT_ID, SlotType::OVF};
+
     inline static bool areStringPrefixAndLenEqual(std::string_view keyToLookup,
         const common::ku_string_t& keyInEntry) {
         auto prefixLen = std::min((uint64_t)keyInEntry.len,


### PR DESCRIPTION
When splitting, move empty overflow slots into a global linked list and re-use them before allocating new slots.

I started working on this to try and simplify how deletions will work in the in memory hash index (needed to unify the hash index local storage for copies and inserts/deletions), as removing empty overflow slots from the end of the slot chains makes it easier to find the last entry in a slot without having to backtrack if the last slot is empty. 
This ended up being a little more complicated than I expected, but for a hash index of 60 million consecutive integers it reduces memory use from the slots from roughly 2.28GB to 1.75GB, reducing the number of overflow slots by more than half, and it seems to slightly increase performance (presumably because it reduces the number of allocations).

Something similar could be done for disk slots (see last TODO in https://github.com/kuzudb/kuzu/issues/2938#issuecomment-2066834888), the main difference being that disk slots may have gaps, but the gaps could be removed when splitting.

This avoids breaking the storage format by adding the new field (which is not used by the on-disk index) to the end of the hash index header.