### PR TITLE
Remove unique_ptr of value in literal expression

### DIFF
--- a/src/binder/bind/bind_file_scan.cpp
+++ b/src/binder/bind/bind_file_scan.cpp
@@ -60,7 +60,7 @@ std::unordered_map<std::string, Value> Binder::bindParsingOptions(
         auto expr = expressionBinder.bindExpression(*option.second);
         KU_ASSERT(expr->expressionType == ExpressionType::LITERAL);
         auto literalExpr = ku_dynamic_cast<Expression*, LiteralExpression*>(expr.get());
-        options.insert({name, *literalExpr->getValue()});
+        options.insert({name, literalExpr->getValue()});
     }
     return options;
 }

--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -232,18 +232,19 @@ uint64_t Binder::bindSkipLimitExpression(const ParsedExpression& expression) {
     if (!ExpressionVisitor::isConstant(*boundExpression)) {
         throw BinderException(errorMsg);
     }
-    auto value = ((LiteralExpression&)(*boundExpression)).value.get();
+    auto& literalExpr = boundExpression->constCast<LiteralExpression>();
+    auto value = literalExpr.getValue();
     int64_t num = 0;
     // TODO: replace the following switch with value.cast()
-    switch (value->getDataType()->getLogicalTypeID()) {
+    switch (value.getDataType()->getLogicalTypeID()) {
     case LogicalTypeID::INT64: {
-        num = value->getValue<int64_t>();
+        num = value.getValue<int64_t>();
     } break;
     case LogicalTypeID::INT32: {
-        num = value->getValue<int32_t>();
+        num = value.getValue<int32_t>();
     } break;
     case LogicalTypeID::INT16: {
-        num = value->getValue<int16_t>();
+        num = value.getValue<int16_t>();
     } break;
     default:
         throw BinderException(errorMsg);

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -33,7 +33,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
         ExpressionUtil::validateExpressionType(*child, ExpressionType::LITERAL);
         auto literalExpr = child->constPtrCast<LiteralExpression>();
         inputTypes.push_back(literalExpr->getDataType());
-        inputValues.push_back(*literalExpr->getValue());
+        inputValues.push_back(literalExpr->getValue());
     }
     auto catalogSet = clientContext->getCatalog()->getFunctions(clientContext->getTx());
     auto functionEntry = BuiltInFunctionsUtils::getFunctionCatalogEntry(functionName, catalogSet);

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -262,12 +262,11 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
         auto& node = (NodeExpression&)expression;
         if (!node.isMultiLabeled()) {
             auto labelName = catalog->getTableName(context->getTx(), node.getSingleTableID());
-            return createLiteralExpression(
-                std::make_unique<Value>(LogicalType::STRING(), labelName));
+            return createLiteralExpression(Value(LogicalType::STRING(), labelName));
         }
         auto nodeTableIDs = catalog->getNodeTableIDs(context->getTx());
         children.push_back(node.getInternalID());
-        auto labelsValue = std::make_unique<Value>(std::move(listType),
+        auto labelsValue = Value(std::move(listType),
             populateLabelValues(nodeTableIDs, *catalog, context->getTx()));
         children.push_back(createLiteralExpression(std::move(labelsValue)));
     } break;
@@ -275,12 +274,11 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
         auto& rel = (RelExpression&)expression;
         if (!rel.isMultiLabeled()) {
             auto labelName = catalog->getTableName(context->getTx(), rel.getSingleTableID());
-            return createLiteralExpression(
-                std::make_unique<Value>(LogicalType::STRING(), labelName));
+            return createLiteralExpression(Value(LogicalType::STRING(), labelName));
         }
         auto relTableIDs = catalog->getRelTableIDs(context->getTx());
         children.push_back(rel.getInternalIDProperty());
-        auto labelsValue = std::make_unique<Value>(std::move(listType),
+        auto labelsValue = Value(std::move(listType),
             populateLabelValues(relTableIDs, *catalog, context->getTx()));
         children.push_back(createLiteralExpression(std::move(labelsValue)));
     } break;
@@ -322,7 +320,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindRecursiveJoinLengthFunction(
                 recursiveRels.push_back(child);
             }
         }
-        auto numRelsExpression = createLiteralExpression(std::make_unique<Value>(numRels));
+        auto numRelsExpression = createLiteralExpression(Value(numRels));
         if (recursiveRels.empty()) {
             return numRelsExpression;
         }

--- a/src/binder/bind_expression/bind_literal_expression.cpp
+++ b/src/binder/bind_expression/bind_literal_expression.cpp
@@ -11,28 +11,25 @@ namespace binder {
 
 std::shared_ptr<Expression> ExpressionBinder::bindLiteralExpression(
     const ParsedExpression& parsedExpression) {
-    auto& literalExpression = (ParsedLiteralExpression&)parsedExpression;
+    auto& literalExpression = parsedExpression.constCast<ParsedLiteralExpression>();
     auto value = literalExpression.getValue();
-    if (value->isNull()) {
+    if (value.isNull()) {
         return createNullLiteralExpression();
     }
-    return createLiteralExpression(value->copy());
+    return createLiteralExpression(value);
 }
 
-std::shared_ptr<Expression> ExpressionBinder::createLiteralExpression(
-    std::unique_ptr<Value> value) {
-    auto uniqueName = binder->getUniqueExpressionName(value->toString());
+std::shared_ptr<Expression> ExpressionBinder::createLiteralExpression(const Value& value) {
+    auto uniqueName = binder->getUniqueExpressionName(value.toString());
     return std::make_unique<LiteralExpression>(std::move(value), uniqueName);
 }
 
-std::shared_ptr<Expression> ExpressionBinder::createStringLiteralExpression(
-    const std::string& strVal) {
-    auto value = std::make_unique<Value>(LogicalType::STRING(), strVal);
-    return createLiteralExpression(std::move(value));
+std::shared_ptr<Expression> ExpressionBinder::createLiteralExpression(const std::string& strVal) {
+    return createLiteralExpression(Value(strVal));
 }
 
 std::shared_ptr<Expression> ExpressionBinder::createNullLiteralExpression() {
-    return make_shared<LiteralExpression>(std::make_unique<Value>(Value::createNullValue()),
+    return make_shared<LiteralExpression>(Value::createNullValue(),
         binder->getUniqueExpressionName("NULL"));
 }
 

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -109,8 +109,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindNodeOrRelPropertyExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::bindStructPropertyExpression(
     std::shared_ptr<Expression> child, const std::string& propertyName) {
-    auto children =
-        expression_vector{std::move(child), createStringLiteralExpression(propertyName)};
+    auto children = expression_vector{std::move(child), createLiteralExpression(propertyName)};
     return bindScalarFunctionExpression(children, function::StructExtractFunctions::name);
 }
 

--- a/src/binder/bind_expression/bind_subquery_expression.cpp
+++ b/src/binder/bind_expression/bind_subquery_expression.cpp
@@ -51,7 +51,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindSubqueryExpression(
     } break;
     case SubqueryType::EXISTS: {
         // Rewrite EXISTS subquery as COUNT(*) > 0
-        auto literalExpr = createLiteralExpression(std::make_unique<Value>((int64_t)0));
+        auto literalExpr = createLiteralExpression(Value((int64_t)0));
         projectionExpr = bindComparisonExpression(ExpressionType::GREATER_THAN,
             expression_vector{countStarExpr, literalExpr});
     } break;

--- a/src/binder/bound_statement_result.cpp
+++ b/src/binder/bound_statement_result.cpp
@@ -10,7 +10,7 @@ namespace binder {
 BoundStatementResult BoundStatementResult::createSingleStringColumnResult(
     const std::string& columnName) {
     auto result = BoundStatementResult();
-    auto value = std::make_unique<Value>(LogicalType::STRING(), columnName);
+    auto value = Value(LogicalType::STRING(), columnName);
     auto stringColumn = std::make_shared<LiteralExpression>(std::move(value), columnName);
     result.addColumn(stringColumn);
     return result;

--- a/src/binder/expression/literal_expression.cpp
+++ b/src/binder/expression/literal_expression.cpp
@@ -16,7 +16,7 @@ void LiteralExpression::cast(const LogicalType& type) {
         // LCOV_EXCL_STOP
     }
     dataType = type;
-    value->setDataType(type);
+    value.setDataType(type);
 }
 
 } // namespace binder

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -61,7 +61,7 @@ std::shared_ptr<Expression> ExpressionBinder::foldExpression(
     const std::shared_ptr<Expression>& expression) {
     auto value = evaluator::ExpressionEvaluatorUtils::evaluateConstantExpression(expression,
         context->getMemoryManager());
-    auto result = createLiteralExpression(std::move(value));
+    auto result = createLiteralExpression(value);
     // Fold result should preserve the alias original expression. E.g.
     // RETURN 2, 1 + 1 AS x
     // Once folded, 1 + 1 will become 2 and have the same identifier as the first RETURN element.
@@ -144,8 +144,8 @@ std::shared_ptr<Expression> ExpressionBinder::implicitCast(
 std::shared_ptr<Expression> ExpressionBinder::forceCast(
     const std::shared_ptr<Expression>& expression, const LogicalType& targetType) {
     auto functionName = "CAST";
-    auto children = expression_vector{expression,
-        createLiteralExpression(std::make_unique<Value>(targetType.toString()))};
+    auto children =
+        expression_vector{expression, createLiteralExpression(Value(targetType.toString()))};
     return bindScalarFunctionExpression(children, functionName);
 }
 

--- a/src/expression_evaluator/expression_evaluator_utils.cpp
+++ b/src/expression_evaluator/expression_evaluator_utils.cpp
@@ -9,7 +9,7 @@ using namespace kuzu::processor;
 namespace kuzu {
 namespace evaluator {
 
-std::unique_ptr<Value> ExpressionEvaluatorUtils::evaluateConstantExpression(
+Value ExpressionEvaluatorUtils::evaluateConstantExpression(
     const std::shared_ptr<binder::Expression>& expression, storage::MemoryManager* memoryManager) {
     auto evaluator = ExpressionMapper::getConstantEvaluator(expression);
     auto emptyResultSet = std::make_unique<ResultSet>(0);
@@ -17,7 +17,7 @@ std::unique_ptr<Value> ExpressionEvaluatorUtils::evaluateConstantExpression(
     evaluator->evaluate(nullptr);
     auto selVector = evaluator->resultVector->state->selVector.get();
     KU_ASSERT(selVector->selectedSize == 1);
-    return evaluator->resultVector->getAsValue(selVector->selectedPositions[0]);
+    return *evaluator->resultVector->getAsValue(selVector->selectedPositions[0]);
 }
 
 } // namespace evaluator

--- a/src/expression_evaluator/literal_evaluator.cpp
+++ b/src/expression_evaluator/literal_evaluator.cpp
@@ -9,8 +9,7 @@ using namespace kuzu::main;
 namespace kuzu {
 namespace evaluator {
 
-bool LiteralExpressionEvaluator::select(SelectionVector& /*selVector*/,
-    ClientContext* /*clientContext*/) {
+bool LiteralExpressionEvaluator::select(SelectionVector&, ClientContext*) {
     KU_ASSERT(resultVector->dataType.getLogicalTypeID() == LogicalTypeID::BOOL);
     auto pos = resultVector->state->selVector->selectedPositions[0];
     KU_ASSERT(pos == 0u);

--- a/src/function/path/properties_function.cpp
+++ b/src/function/path/properties_function.cpp
@@ -17,7 +17,8 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
         throw BinderException(stringFormat(
             "Expected literal input as the second argument for {}().", PropertiesFunction::name));
     }
-    auto key = ((binder::LiteralExpression&)*arguments[1]).getValue()->getValue<std::string>();
+    auto literalExpr = arguments[1]->constPtrCast<LiteralExpression>();
+    auto key = literalExpr->getValue().getValue<std::string>();
     auto listType = arguments[0]->getDataType();
     auto childType = ListType::getChildType(&listType);
     struct_field_idx_t fieldIdx;

--- a/src/function/pattern/id_function.cpp
+++ b/src/function/pattern/id_function.cpp
@@ -27,8 +27,8 @@ static std::shared_ptr<binder::Expression> rewriteFunc(const expression_vector& 
         return rel->getPropertyExpression(InternalKeyword::ID);
     }
     // Bind as struct_extract(param, "_id")
-    auto key = Value(LogicalType::STRING(), InternalKeyword::ID);
-    auto keyExpr = binder->createLiteralExpression(key.copy());
+    auto keyExpr =
+        binder->createLiteralExpression(Value(LogicalType::STRING(), InternalKeyword::ID));
     auto newParams = expression_vector{params[0], keyExpr};
     return binder->bindScalarFunctionExpression(newParams, StructExtractFunctions::name);
 }

--- a/src/function/struct/struct_extract_function.cpp
+++ b/src/function/struct/struct_extract_function.cpp
@@ -16,7 +16,7 @@ std::unique_ptr<FunctionBindData> StructExtractFunctions::bindFunc(
     if (arguments[1]->expressionType != ExpressionType::LITERAL) {
         throw BinderException("Key name for struct/union extract must be STRING literal.");
     }
-    auto key = arguments[1]->constPtrCast<LiteralExpression>()->getValue()->getValue<std::string>();
+    auto key = arguments[1]->constPtrCast<LiteralExpression>()->getValue().getValue<std::string>();
     auto fieldIdx = StructType::getFieldIdx(&structType, key);
     if (fieldIdx == INVALID_STRUCT_FIELD_IDX) {
         throw BinderException(stringFormat("Invalid struct field name: {}.", key));

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -1070,8 +1070,8 @@ static std::unique_ptr<FunctionBindData> castBindFunc(const binder::expression_v
     if (arguments[1]->expressionType != ExpressionType::LITERAL) {
         throw BinderException(stringFormat("Second parameter of CAST function must be a literal."));
     }
-    auto literalExpr = ku_dynamic_cast<Expression*, LiteralExpression*>(arguments[1].get());
-    auto targetTypeStr = literalExpr->getValue()->getValue<std::string>();
+    auto literalExpr = arguments[1]->constPtrCast<LiteralExpression>();
+    auto targetTypeStr = literalExpr->getValue().getValue<std::string>();
     auto targetType = binder::Binder::bindDataType(targetTypeStr);
     if (*targetType == arguments[0]->getDataType()) { // No need to cast.
         return nullptr;

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -95,6 +95,10 @@ public:
     const TARGET* constPtrCast() const {
         return common::ku_dynamic_cast<const Expression*, const TARGET*>(this);
     }
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const Expression&, const TARGET&>(*this);
+    }
 
 protected:
     virtual std::string toStringInternal() const = 0;

--- a/src/include/binder/expression/literal_expression.h
+++ b/src/include/binder/expression/literal_expression.h
@@ -8,24 +8,24 @@ namespace binder {
 
 class LiteralExpression final : public Expression {
 public:
-    LiteralExpression(std::unique_ptr<common::Value> value, const std::string& uniqueName)
-        : Expression{common::ExpressionType::LITERAL, *value->getDataType(), uniqueName},
+    LiteralExpression(common::Value value, const std::string& uniqueName)
+        : Expression{common::ExpressionType::LITERAL, *value.getDataType(), uniqueName},
           value{std::move(value)} {}
 
-    bool isNull() const { return value->isNull(); }
+    bool isNull() const { return value.isNull(); }
 
     void cast(const common::LogicalType& type) override;
 
-    common::Value* getValue() const { return value.get(); }
+    common::Value getValue() const { return value; }
 
-    std::string toStringInternal() const final { return value->toString(); }
+    std::string toStringInternal() const override { return value.toString(); }
 
-    std::unique_ptr<Expression> copy() const final {
-        return std::make_unique<LiteralExpression>(value->copy(), uniqueName);
+    std::unique_ptr<Expression> copy() const override {
+        return std::make_unique<LiteralExpression>(value, uniqueName);
     }
 
 public:
-    std::unique_ptr<common::Value> value;
+    common::Value value;
 };
 
 } // namespace binder

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -85,8 +85,8 @@ public:
     // Literal expressions.
     std::shared_ptr<Expression> bindLiteralExpression(
         const parser::ParsedExpression& parsedExpression);
-    std::shared_ptr<Expression> createLiteralExpression(std::unique_ptr<common::Value> value);
-    std::shared_ptr<Expression> createStringLiteralExpression(const std::string& strVal);
+    std::shared_ptr<Expression> createLiteralExpression(const common::Value& value);
+    std::shared_ptr<Expression> createLiteralExpression(const std::string& strVal);
     std::shared_ptr<Expression> createNullLiteralExpression();
     // Variable expressions.
     std::shared_ptr<Expression> bindVariableExpression(

--- a/src/include/common/enums/expression_type.h
+++ b/src/include/common/enums/expression_type.h
@@ -45,8 +45,6 @@ enum class ExpressionType : uint8_t {
     SUBQUERY = 190,
 
     CASE_ELSE = 200,
-
-    MACRO = 210,
 };
 
 bool isExpressionUnary(ExpressionType type);

--- a/src/include/expression_evaluator/expression_evaluator_utils.h
+++ b/src/include/expression_evaluator/expression_evaluator_utils.h
@@ -8,7 +8,7 @@ namespace kuzu {
 namespace evaluator {
 
 struct ExpressionEvaluatorUtils {
-    static std::unique_ptr<common::Value> evaluateConstantExpression(
+    static common::Value evaluateConstantExpression(
         const std::shared_ptr<binder::Expression>& expression,
         storage::MemoryManager* memoryManager);
 };

--- a/src/include/expression_evaluator/literal_evaluator.h
+++ b/src/include/expression_evaluator/literal_evaluator.h
@@ -14,8 +14,6 @@ public:
     explicit LiteralExpressionEvaluator(std::shared_ptr<common::Value> value)
         : ExpressionEvaluator{true /* isResultFlat */}, value{std::move(value)} {}
 
-    ~LiteralExpressionEvaluator() override = default;
-
     inline void evaluate(main::ClientContext* /* clientContext */) override {}
 
     bool select(common::SelectionVector& selVector, main::ClientContext* clientContext) override;

--- a/src/include/parser/expression/parsed_expression.h
+++ b/src/include/parser/expression/parsed_expression.h
@@ -32,13 +32,10 @@ class ParsedExpression {
 public:
     ParsedExpression(common::ExpressionType type, std::unique_ptr<ParsedExpression> child,
         std::string rawName);
-
     ParsedExpression(common::ExpressionType type, std::unique_ptr<ParsedExpression> left,
         std::unique_ptr<ParsedExpression> right, std::string rawName);
-
     ParsedExpression(common::ExpressionType type, std::string rawName)
         : type{type}, rawName{std::move(rawName)} {}
-
     explicit ParsedExpression(common::ExpressionType type) : type{type} {}
 
     ParsedExpression(common::ExpressionType type, std::string alias, std::string rawName,
@@ -74,6 +71,10 @@ public:
     template<class TARGET>
     const TARGET* constPtrCast() const {
         return common::ku_dynamic_cast<const ParsedExpression*, const TARGET*>(this);
+    }
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const ParsedExpression&, const TARGET&>(*this);
     }
 
 protected:

--- a/src/include/parser/expression/parsed_literal_expression.h
+++ b/src/include/parser/expression/parsed_literal_expression.h
@@ -7,29 +7,29 @@ namespace kuzu {
 namespace parser {
 
 class ParsedLiteralExpression : public ParsedExpression {
+    static constexpr common::ExpressionType expressionType = common::ExpressionType::LITERAL;
+
 public:
     ParsedLiteralExpression(common::Value value, std::string raw)
-        : ParsedExpression{common::ExpressionType::LITERAL, std::move(raw)},
-          value{std::move(value)} {}
+        : ParsedExpression{expressionType, std::move(raw)}, value{std::move(value)} {}
 
     ParsedLiteralExpression(std::string alias, std::string rawName, parsed_expr_vector children,
         common::Value value)
-        : ParsedExpression{common::ExpressionType::LITERAL, std::move(alias), std::move(rawName),
+        : ParsedExpression{expressionType, std::move(alias), std::move(rawName),
               std::move(children)},
           value{std::move(value)} {}
 
     explicit ParsedLiteralExpression(common::Value value)
-        : ParsedExpression{common::ExpressionType::LITERAL}, value{std::move(value)} {}
+        : ParsedExpression{expressionType}, value{std::move(value)} {}
 
-    inline const common::Value* getValue() const { return &value; }
-    inline common::Value* getValueUnsafe() { return &value; }
+    common::Value getValue() const { return value; }
 
-    static inline std::unique_ptr<ParsedLiteralExpression> deserialize(
+    static std::unique_ptr<ParsedLiteralExpression> deserialize(
         common::Deserializer& deserializer) {
         return std::make_unique<ParsedLiteralExpression>(*common::Value::deserialize(deserializer));
     }
 
-    inline std::unique_ptr<ParsedExpression> copy() const override {
+    std::unique_ptr<ParsedExpression> copy() const override {
         return std::make_unique<ParsedLiteralExpression>(alias, rawName, copyChildren(), value);
     }
 

--- a/src/include/processor/operator/call/standalone_call.h
+++ b/src/include/processor/operator/call/standalone_call.h
@@ -27,12 +27,12 @@ public:
         : PhysicalOperator{operatorType, id, paramsString},
           standaloneCallInfo{std::move(localState)} {}
 
-    inline bool isSource() const override { return true; }
-    inline bool canParallel() const final { return false; }
+    bool isSource() const override { return true; }
+    bool canParallel() const final { return false; }
 
     bool getNextTuplesInternal(ExecutionContext* context) override;
 
-    inline std::unique_ptr<PhysicalOperator> clone() override {
+    std::unique_ptr<PhysicalOperator> clone() override {
         return std::make_unique<StandaloneCall>(standaloneCallInfo->copy(), operatorType, id,
             paramsString);
     }

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -53,7 +53,7 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitFilterReplace(
     if (predicate->expressionType == ExpressionType::LITERAL) {
         // Avoid executing child plan if literal is Null or False.
         auto literalExpr = ku_dynamic_cast<Expression*, LiteralExpression*>(predicate.get());
-        if (literalExpr->isNull() || !literalExpr->getValue()->getValue<bool>()) {
+        if (literalExpr->isNull() || !literalExpr->getValue().getValue<bool>()) {
             return std::make_shared<LogicalEmptyResult>(*op->getSchema());
         }
     } else {

--- a/src/planner/operator/logical_dummy_scan.cpp
+++ b/src/planner/operator/logical_dummy_scan.cpp
@@ -19,10 +19,8 @@ void LogicalDummyScan::computeFlatSchema() {
 }
 
 std::shared_ptr<binder::Expression> LogicalDummyScan::getDummyExpression() {
-    auto logicalType = LogicalType(LogicalTypeID::STRING);
-    auto nullValue = Value::createNullValue(logicalType);
-    return std::make_shared<binder::LiteralExpression>(nullValue.copy(),
-        InternalKeyword::PLACE_HOLDER);
+    return std::make_shared<binder::LiteralExpression>(
+        Value::createNullValue(*LogicalType::STRING()), InternalKeyword::PLACE_HOLDER);
 }
 
 } // namespace planner

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -96,9 +96,9 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getConstantEvaluator(
 
 std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getLiteralEvaluator(
     const Expression& expression) {
-    auto& literalExpression = (LiteralExpression&)expression;
+    auto& literalExpression = expression.constCast<LiteralExpression>();
     return std::make_unique<LiteralExpressionEvaluator>(
-        std::make_shared<Value>(*literalExpression.getValue()));
+        std::make_shared<Value>(literalExpression.getValue()));
 }
 
 std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getParameterEvaluator(

--- a/src/processor/map/map_standalone_call.cpp
+++ b/src/processor/map/map_standalone_call.cpp
@@ -14,7 +14,7 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapStandaloneCall(
     auto optionValue =
         logicalStandaloneCall->getOptionValue()->constPtrCast<binder::LiteralExpression>();
     auto standaloneCallInfo = std::make_unique<StandaloneCallInfo>(
-        logicalStandaloneCall->getOption(), *optionValue->getValue());
+        logicalStandaloneCall->getOption(), optionValue->getValue());
     return std::make_unique<StandaloneCall>(std::move(standaloneCallInfo),
         PhysicalOperatorType::STANDALONE_CALL, getOperatorID(),
         logicalStandaloneCall->getExpressionsForPrinting());


### PR DESCRIPTION
This PR is just a small refactor. Nothing fancy.

In many of the places we were using smart pointers unnecessarily. I do observe a few more places. I plan to remove them class by class.