### PR TITLE
Move length function as a rewrite function

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -175,7 +175,7 @@ FunctionCollection* FunctionCollection::getFunctions() {
         // Path functions
         SCALAR_FUNCTION(NodesFunction), SCALAR_FUNCTION(RelsFunction),
         SCALAR_FUNCTION(PropertiesFunction), SCALAR_FUNCTION(IsTrailFunction),
-        SCALAR_FUNCTION(IsACyclicFunction),
+        SCALAR_FUNCTION(IsACyclicFunction), REWRITE_FUNCTION(LengthFunction),
 
         // Rdf functions
         SCALAR_FUNCTION(RDFTypeFunction), SCALAR_FUNCTION(ValidatePredicateFunction),

--- a/src/function/path/CMakeLists.txt
+++ b/src/function/path/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(kuzu_function_path
         OBJECT
+        length_function.cpp
         nodes_function.cpp
         properties_function.cpp
         rels_function.cpp

--- a/src/function/path/length_function.cpp
+++ b/src/function/path/length_function.cpp
@@ -1,0 +1,58 @@
+#include "binder/expression/expression_util.h"
+#include "binder/expression/rel_expression.h"
+#include "binder/expression_binder.h"
+#include "common/types/value/value.h"
+#include "function/arithmetic/vector_arithmetic_functions.h"
+#include "function/path/vector_path_functions.h"
+#include "function/rewrite_function.h"
+
+using namespace kuzu::binder;
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace function {
+
+static std::shared_ptr<Expression> rewriteFunc(const expression_vector& params,
+    ExpressionBinder* binder) {
+    KU_ASSERT(params.size() == 1);
+    auto param = params[0].get();
+    if (param->expressionType == ExpressionType::PATH) {
+        int64_t numRels = 0u;
+        std::vector<const RelExpression*> recursiveRels;
+        for (auto& child : param->getChildren()) {
+            if (ExpressionUtil::isRelPattern(*child)) {
+                numRels++;
+            } else if (ExpressionUtil::isRecursiveRelPattern(*child)) {
+                recursiveRels.push_back(child->constPtrCast<RelExpression>());
+            }
+        }
+        auto numRelsExpression = binder->createLiteralExpression(Value(numRels));
+        if (recursiveRels.empty()) {
+            return numRelsExpression;
+        }
+        expression_vector children;
+        children.push_back(std::move(numRelsExpression));
+        children.push_back(recursiveRels[0]->getLengthExpression());
+        auto result = binder->bindScalarFunctionExpression(children, AddFunction::name);
+        for (auto i = 1u; i < recursiveRels.size(); ++i) {
+            children[0] = std::move(result);
+            children[1] = recursiveRels[i]->getLengthExpression();
+            result = binder->bindScalarFunctionExpression(children, AddFunction::name);
+        }
+        return result;
+    } else if (ExpressionUtil::isRecursiveRelPattern(*param)) {
+        return param->constPtrCast<RelExpression>()->getLengthExpression();
+    }
+    KU_UNREACHABLE;
+}
+
+function_set LengthFunction::getFunctionSet() {
+    function_set result;
+    auto function = std::make_unique<RewriteFunction>(name,
+        std::vector<LogicalTypeID>{LogicalTypeID::RECURSIVE_REL}, rewriteFunc);
+    result.push_back(std::move(function));
+    return result;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/binder/expression_binder.h
+++ b/src/include/binder/expression_binder.h
@@ -78,7 +78,6 @@ public:
     std::shared_ptr<Expression> bindEndNodeExpression(const Expression& expression);
     std::shared_ptr<Expression> bindLabelFunction(const Expression& expression);
     std::unique_ptr<Expression> createInternalLengthExpression(const Expression& expression);
-    std::shared_ptr<Expression> bindRecursiveJoinLengthFunction(const Expression& expression);
     // Parameter expressions.
     std::shared_ptr<Expression> bindParameterExpression(
         const parser::ParsedExpression& parsedExpression);

--- a/src/include/function/path/vector_path_functions.h
+++ b/src/include/function/path/vector_path_functions.h
@@ -44,6 +44,8 @@ struct IsACyclicFunction {
 
 struct LengthFunction {
     static constexpr const char* name = "LENGTH";
+
+    static function_set getFunctionSet();
 };
 
 } // namespace function

--- a/src/include/function/schema/offset_functions.h
+++ b/src/include/function/schema/offset_functions.h
@@ -6,9 +6,8 @@ namespace kuzu {
 namespace function {
 
 struct Offset {
-    static inline void operation(common::internalID_t& input, int64_t& result) {
-        result = input.offset;
-    }
+
+    static void operation(common::internalID_t& input, int64_t& result) { result = input.offset; }
 };
 
 } // namespace function

--- a/src/include/parser/expression/parsed_expression.h
+++ b/src/include/parser/expression/parsed_expression.h
@@ -69,12 +69,12 @@ public:
     static std::unique_ptr<ParsedExpression> deserialize(common::Deserializer& deserializer);
 
     template<class TARGET>
-    const TARGET* constPtrCast() const {
-        return common::ku_dynamic_cast<const ParsedExpression*, const TARGET*>(this);
-    }
-    template<class TARGET>
     const TARGET& constCast() const {
         return common::ku_dynamic_cast<const ParsedExpression&, const TARGET&>(*this);
+    }
+    template<class TARGET>
+    const TARGET* constPtrCast() const {
+        return common::ku_dynamic_cast<const ParsedExpression*, const TARGET*>(this);
     }
 
 protected:


### PR DESCRIPTION
This PR moves another function using rewrite function framework. The ultimate goal is to remove `if functionName == XXX` check in the binder.