### PR TITLE
Issue 2385

### DIFF
--- a/src/binder/bind/read/bind_load_from.cpp
+++ b/src/binder/bind/read/bind_load_from.cpp
@@ -92,7 +92,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& re
         std::vector<LogicalType> expectedColumnTypes;
         for (auto& [name, type] : loadFrom.getColumnNameDataTypesRef()) {
             expectedColumnNames.push_back(name);
-            expectedColumnTypes.push_back(*bindDataType(type));
+            expectedColumnTypes.push_back(LogicalType::fromString(type));
         }
         scanFunction = getScanFunction(readerConfig->fileType, *readerConfig);
         auto bindInput = ScanTableFuncBindInput(readerConfig->copy(),

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -77,10 +77,12 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     if (functionName == CastAnyFunction::name) {
         bindData = function->bindFunc(children, function);
         if (bindData == nullptr) { // No need to cast.
+            // TODO(Xiyang): We should return a deep copy otherwise the same expression might
+            // appear in the final projection list repeatedly.
+            // E.g. RETURN cast([NULL], "INT64[1][]"), cast([NULL], "INT64[1][][]")
             return children[0];
         }
         auto childAfterCast = children[0];
-        // See castBindFunc for explanation.
         if (children[0]->getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
             childAfterCast = implicitCastIfNecessary(children[0], *LogicalType::STRING());
         }

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -120,21 +120,6 @@ std::shared_ptr<Expression> Binder::createVariable(const std::string& name,
     return expression;
 }
 
-std::unique_ptr<LogicalType> Binder::bindDataType(const std::string& dataType) {
-    auto boundType = LogicalType::fromString(dataType);
-    if (boundType.getLogicalTypeID() == LogicalTypeID::ARRAY) {
-        auto numElementsInArray = ArrayType::getNumElements(boundType);
-        if (numElementsInArray == 0) {
-            // Note: the parser already guarantees that the number of elements is a non-negative
-            // number. However, we still need to check whether the number of elements is 0.
-            throw BinderException(
-                "The number of elements in an array must be greater than 0. Given: " +
-                std::to_string(numElementsInArray) + ".");
-        }
-    }
-    return std::make_unique<LogicalType>(boundType);
-}
-
 void Binder::validateProjectionColumnNamesAreUnique(const expression_vector& expressions) {
     auto existColumnNames = std::unordered_set<std::string>();
     for (auto& expression : expressions) {

--- a/src/binder/expression/literal_expression.cpp
+++ b/src/binder/expression/literal_expression.cpp
@@ -2,13 +2,14 @@
 
 #include "common/exception/binder.h"
 
-namespace kuzu {
-using namespace common;
+using namespace kuzu::common;
 
+namespace kuzu {
 namespace binder {
 
 void LiteralExpression::cast(const LogicalType& type) {
-    if (dataType.getLogicalTypeID() != LogicalTypeID::ANY) {
+    // The following is a safeguard to make sure we are not changing literal type unexpectedly.
+    if (!value.allowTypeChange()) {
         // LCOV_EXCL_START
         throw BinderException(
             stringFormat("Cannot change literal expression data type from {} to {}.",

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -1,6 +1,7 @@
 #include "binder/expression_binder.h"
 
 #include "binder/binder.h"
+#include "binder/expression/expression_util.h"
 #include "binder/expression_visitor.h"
 #include "common/exception/binder.h"
 #include "common/exception/not_implemented.h"
@@ -81,50 +82,12 @@ static std::string unsupportedImplicitCastException(const Expression& expression
         expression.toString(), expression.dataType.toString(), targetTypeStr);
 }
 
-static bool compatible(const LogicalType& type, const LogicalType& target) {
-    if (type.getLogicalTypeID() == LogicalTypeID::ANY) {
-        return true;
-    }
-    if (type.getLogicalTypeID() != target.getLogicalTypeID()) {
-        return false;
-    }
-    switch (type.getLogicalTypeID()) {
-    case LogicalTypeID::LIST: {
-        return compatible(ListType::getChildType(type), ListType::getChildType(target));
-    }
-    case LogicalTypeID::ARRAY: {
-        return compatible(ArrayType::getChildType(type), ArrayType::getChildType(target));
-    }
-    case LogicalTypeID::STRUCT: {
-        if (StructType::getNumFields(type) != StructType::getNumFields(target)) {
-            return false;
-        }
-        for (auto i = 0u; i < StructType::getNumFields(type); ++i) {
-            if (!compatible(StructType::getField(type, i).getType(),
-                    StructType::getField(target, i).getType())) {
-                return false;
-            }
-        }
-        return true;
-    }
-    case LogicalTypeID::RDF_VARIANT:
-    case LogicalTypeID::UNION:
-    case LogicalTypeID::MAP:
-    case LogicalTypeID::NODE:
-    case LogicalTypeID::REL:
-    case LogicalTypeID::RECURSIVE_REL:
-        return false;
-    default:
-        return true;
-    }
-}
-
 std::shared_ptr<Expression> ExpressionBinder::implicitCastIfNecessary(
     const std::shared_ptr<Expression>& expression, const LogicalType& targetType) {
     if (expression->dataType == targetType || targetType.containsAny()) { // No need to cast.
         return expression;
     }
-    if (compatible(expression->getDataType(), targetType)) {
+    if (ExpressionUtil::canCastStatically(*expression, targetType)) {
         expression->cast(targetType);
         return expression;
     }

--- a/src/binder/expression_visitor.cpp
+++ b/src/binder/expression_visitor.cpp
@@ -7,6 +7,7 @@
 #include "binder/expression/rel_expression.h"
 #include "binder/expression/subquery_expression.h"
 #include "common/cast.h"
+#include "function/list/vector_list_functions.h"
 #include "function/uuid/vector_uuid_functions.h"
 
 using namespace kuzu::common;
@@ -94,6 +95,15 @@ bool ExpressionVisitor::isConstant(const Expression& expression) {
     }
     if (expression.getNumChildren() == 0 &&
         expression.expressionType != ExpressionType::CASE_ELSE) {
+        // If a function does not have children, we should be able to evaluate them as a constant.
+        // But I wanna apply this change separately.
+        if (expression.expressionType == ExpressionType::FUNCTION) {
+            auto& funcExpr = expression.constCast<FunctionExpression>();
+            if (funcExpr.getFunctionName() == function::ListCreationFunction::name) {
+                return true;
+            }
+            return false;
+        }
         return expression.expressionType == ExpressionType::LITERAL;
     }
     for (auto& child : ExpressionChildrenCollector::collectChildren(expression)) {

--- a/src/common/types/types.cpp
+++ b/src/common/types/types.cpp
@@ -1166,6 +1166,12 @@ std::unique_ptr<LogicalType> parseArrayType(const std::string& trimmedStr) {
     auto numElements = std::strtoll(
         trimmedStr.substr(leftBracketPos + 1, rightBracketPos - leftBracketPos - 1).c_str(),
         nullptr, 0 /* base */);
+    if (numElements <= 0) {
+        // Note: the parser already guarantees that the number of elements is a non-negative
+        // number. However, we still need to check whether the number of elements is 0.
+        throw BinderException("The number of elements in an array must be greater than 0. Given: " +
+                              std::to_string(numElements) + ".");
+    }
     return LogicalType::ARRAY(std::move(childType), numElements);
 }
 

--- a/src/function/list/list_creation.cpp
+++ b/src/function/list/list_creation.cpp
@@ -32,7 +32,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(const binder::expression_vecto
     LogicalType combinedType(LogicalTypeID::ANY);
     binder::ExpressionUtil::tryCombineDataType(arguments, combinedType);
     if (combinedType.getLogicalTypeID() == LogicalTypeID::ANY) {
-        combinedType = *LogicalType::STRING();
+        combinedType = *LogicalType::INT64();
     }
     auto resultType = LogicalType::LIST(combinedType.copy());
     auto bindData = std::make_unique<FunctionBindData>(std::move(resultType));

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -66,11 +66,9 @@ public:
         expressionBinder.parameterMap = parameters;
     }
 
-    inline std::unordered_map<std::string, std::shared_ptr<common::Value>> getParameterMap() {
+    std::unordered_map<std::string, std::shared_ptr<common::Value>> getParameterMap() {
         return expressionBinder.parameterMap;
     }
-
-    static std::unique_ptr<common::LogicalType> bindDataType(const std::string& dataType);
 
     bool bindExportTableData(ExportedTableData& tableData, const catalog::TableCatalogEntry& entry,
         const catalog::Catalog& catalog, transaction::Transaction* tx);

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -44,6 +44,11 @@ struct ExpressionUtil {
 
     static bool tryCombineDataType(const expression_vector& expressions,
         common::LogicalType& result);
+
+    // Check If we can directly assign a new data type to an expression.
+    // This mostly happen when a literal is an empty list. By default, we assign its data type to
+    // INT64[] but it can be cast to any other list type at compile time.
+    static bool canCastStatically(const Expression& expr, const common::LogicalType& targetType);
 };
 
 } // namespace binder

--- a/src/include/binder/expression/function_expression.h
+++ b/src/include/binder/expression/function_expression.h
@@ -26,8 +26,6 @@ public:
         : Expression{expressionType, *bindData->resultType, std::move(children), uniqueName},
           functionName{std::move(functionName)}, bindData{std::move(bindData)} {}
 
-    ~FunctionExpression() override = default;
-
     inline std::string getFunctionName() const { return functionName; }
     inline function::FunctionBindData* getBindData() const { return bindData.get(); }
 

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -240,6 +240,9 @@ public:
 
     void validateType(common::LogicalTypeID targetTypeID) const;
 
+    bool hasNoneNullChildren() const;
+    bool allowTypeChange() const;
+
     uint64_t computeHash() const;
 
 private:

--- a/test/test_files/copy/copy_to_csv.test
+++ b/test/test_files/copy/copy_to_csv.test
@@ -134,7 +134,6 @@ Roma|298|the movie is very interesting and funny|{rating: 1223.000000, stars: 10
 ---- 1
 100|kuzu is # a |graph database
 
--CASE StringCopyToWithOptionError
 -STATEMENT COPY (RETURN 100) TO "${DATABASE_PATH}/copy_to_with_option.parquet" (delim = '|', QUOTE='#', Escape = '!')
 ---- error
 Binder exception: Only copy to csv can have options.

--- a/test/test_files/exceptions/binder/empty_db_binder_error.test
+++ b/test/test_files/exceptions/binder/empty_db_binder_error.test
@@ -61,4 +61,4 @@ Binder exception: Expected literal input as the second argument for PROPERTIES()
 Binder exception: Invalid property name: abc.
 -STATEMENT MATCH path = (p:person)-[:follows* SHORTEST]-(q:person) RETURN properties([], "abc")
 ---- error
-Binder exception: Cannot extract properties from STRING[].
+Binder exception: Cannot extract properties from INT64[].

--- a/test/test_files/tck/expressions/boolean/Boolean1.test
+++ b/test/test_files/tck/expressions/boolean/Boolean1.test
@@ -192,7 +192,7 @@ Binder exception: Expression foo has data type STRING but expected BOOL. Implici
 
 -STATEMENT RETURN [] AND false;
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN [true] AND false;
 ---- error
@@ -200,11 +200,11 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN [null] AND null;
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN {x: []} AND true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false AND 123;
 ---- error
@@ -224,7 +224,7 @@ Binder exception: Expression foo has data type STRING but expected BOOL. Implici
 
 -STATEMENT RETURN true AND [];
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN true AND [false];
 ---- error
@@ -232,11 +232,11 @@ Binder exception: Expression LIST_CREATION(False) has data type BOOL[] but expec
 
 -STATEMENT RETURN null AND [null];
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false AND {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 AND 'foo';
 ---- error
@@ -256,4 +256,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} AND [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/boolean/Boolean2.test
+++ b/test/test_files/tck/expressions/boolean/Boolean2.test
@@ -190,7 +190,7 @@ Binder exception: Expression foo has data type STRING but expected BOOL. Implici
 
 -STATEMENT RETURN [] OR false;
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN [true] OR false;
 ---- error
@@ -198,11 +198,11 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN [null] OR null;
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN {x: []} OR true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false OR 123;
 ---- error
@@ -222,7 +222,7 @@ Binder exception: Expression foo has data type STRING but expected BOOL. Implici
 
 -STATEMENT RETURN true OR [];
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN true OR [false];
 ---- error
@@ -230,11 +230,11 @@ Binder exception: Expression LIST_CREATION(False) has data type BOOL[] but expec
 
 -STATEMENT RETURN null OR [null];
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false OR {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 OR 'foo';
 ---- error
@@ -254,4 +254,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} OR [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/boolean/Boolean3.test
+++ b/test/test_files/tck/expressions/boolean/Boolean3.test
@@ -189,7 +189,7 @@ Binder exception: Expression foo has data type STRING but expected BOOL. Implici
 
 -STATEMENT RETURN [] XOR false;
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN [true] XOR false;
 ---- error
@@ -197,11 +197,11 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN [null] XOR null;
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN {x: []} XOR true;
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false XOR 123;
 ---- error
@@ -221,7 +221,7 @@ Binder exception: Expression foo has data type STRING but expected BOOL. Implici
 
 -STATEMENT RETURN true XOR [];
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN true XOR [false];
 ---- error
@@ -229,11 +229,11 @@ Binder exception: Expression LIST_CREATION(False) has data type BOOL[] but expec
 
 -STATEMENT RETURN null XOR [null];
 ---- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression LIST_CREATION() has data type INT64[] but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN false XOR {x: []};
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.
 
 -STATEMENT RETURN 123 XOR 'foo';
 ---- error
@@ -253,4 +253,4 @@ Binder exception: Expression LIST_CREATION(True) has data type BOOL[] but expect
 
 -STATEMENT RETURN {x: []} XOR [123];
 ---- error
-Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x STRING[]) but expected BOOL. Implicit cast is not supported.
+Binder exception: Expression STRUCT_PACK(x) has data type STRUCT(x INT64[]) but expected BOOL. Implicit cast is not supported.

--- a/test/test_files/tck/expressions/comparison/Comparison1.test
+++ b/test/test_files/tck/expressions/comparison/Comparison1.test
@@ -2,7 +2,6 @@
 
 --
 
-
 #  Number-typed integer comparison
 -CASE Scenario1
 -SKIP

--- a/test/test_files/tck/expressions/map/Map1.test
+++ b/test/test_files/tck/expressions/map/Map1.test
@@ -146,4 +146,4 @@ Binder exception: nonMap has data type STRING but (NODE,REL,STRUCT) was expected
            RETURN nonMap.num;
 ## Outcome: an Error should be raised at compile time: InvalidArgumentType
 ---- error
-Binder exception: nonMap has data type STRING[] but (NODE,REL,STRUCT) was expected.
+Binder exception: Expression True has data type BOOL but expected INT64. Implicit cast is not supported.

--- a/test/test_files/tinysnb/cast/cast_to_nested_types.test
+++ b/test/test_files/tinysnb/cast/cast_to_nested_types.test
@@ -196,7 +196,7 @@ False|-4325|14|18446744073709551616.000000|  dfsa
 -STATEMENT RETURN cast(["[123, 3234]", "[124, 3241]", NULL, "[0, -4324234]"], "INT64[2][]"), cast(cast(["[123, 3234]", "[124, 3241]", NULL, "[0, -4324234]"], "DOUBLE[2][]"), "STRING[]");
 ---- 1
 [[123,3234],[124,3241],,[0,-4324234]]|[[123.000000,3234.000000],[124.000000,3241.000000],,[0.000000,-4324234.000000]]
--STATEMENT RETURN cast([NULL, NULL, NULL], "INT8[][][]"), cast([NULL], "STRING[]"), cast([], "UINT8[]");
+-STATEMENT RETURN cast([NULL, NULL, NULL], "INT8[][][]") AS a, cast([NULL], "STRING[]") AS b, cast([], "UINT8[]");
 ---- 1
 [,,]|[]|[]
 -STATEMENT RETURN cast(cast([NULL, [NULL, 13], NULL, [14, 14], NULL], "INT32[][]"), "INT128[][]"), cast([NULL, 1], "INT16[]"), cast("[1, NULL, NULL]", "UINT32[]"), cast("[NULL, 1, NULL]", "UINT64[]");
@@ -329,7 +329,7 @@ False|-4325|14|18446744073709551616.000000|  dfsa
 -STATEMENT RETURN cast([[1,2], [3, 4], [5, 6]], "INT32[2][]");
 ---- 1
 [[1,2],[3,4],[5,6]]
--STATEMENT RETURN cast([NULL, [1]], "INT64[1][]"), cast([NULL], "INT64[1][]"), cast([[1], NULL], "INT64[1][]"), cast([NULL], "INT64[1][][]"), cast([[NULL]], "INT64[1][][]"), cast([[[2], NULL], [NULL, [1]]], "INT64[1][][]"), cast([NULL, [NULL, [1]]], "INT64[1][][]");
+-STATEMENT RETURN cast([NULL, [1]], "INT64[1][]"), cast([NULL], "INT64[1][]") AS x, cast([[1], NULL], "INT64[1][]"), cast([NULL], "INT64[1][][]"), cast([[NULL]], "INT64[1][][]"), cast([[[2], NULL], [NULL, [1]]], "INT64[1][][]"), cast([NULL, [NULL, [1]]], "INT64[1][][]");
 ---- 1
 [,[1]]|[]|[[1],]|[]|[[]]|[[[2],],[,[1]]]|[,[,[1]]]
 -STATEMENT LOAD WITH HEADERS (struct STRUCT(a INT64, b MAP(INT64[][][], STRING))) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/struct/struct_with_array.csv" where struct_extract(struct, 'a') > 0 RETURN cast(struct, "STRUCT(a INT64,b MAP(INT64[1][][], STRING))");

--- a/test/test_files/tinysnb/function/list.test
+++ b/test/test_files/tinysnb/function/list.test
@@ -94,7 +94,7 @@ Binder exception: Expression a has data type STRING but expected INT64. Implicit
 [,]
 -STATEMENT RETURN ['a', , []];
 ---- error
-Binder exception: Expression a has data type STRING but expected STRING[]. Implicit cast is not supported.
+Binder exception: Expression a has data type STRING but expected INT64[]. Implicit cast is not supported.
 -STATEMENT RETURN [[], , []];
 ---- 1
 [[],,[]]
@@ -2187,3 +2187,8 @@ a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11*a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12*a0eebc
 -STATEMENT MATCH (p:person) return list_to_string(collect(p.grades), '/')
 ---- 1
 [96,54,86,92]/[98,42,93,88]/[91,75,21,95]/[76,88,99,89]/[96,59,65,88]/[80,78,34,83]/[43,83,67,43]/[77,64,100,54]
+
+-LOG 2385
+-STATEMENT RETURN [[23, 432], [], [NULL]];
+---- 1
+[[23,432],[],[]]

--- a/test/test_files/tinysnb/function/map.test
+++ b/test/test_files/tinysnb/function/map.test
@@ -75,8 +75,8 @@
 
 -LOG MapKeys
 -STATEMENT RETURN map_keys(map([[5], [28, 75, 32], [], [33, 11, 66, 33]], ['a', 'b', 'd', 'e']));
----- error
-Binder exception: Expression LIST_CREATION() has data type STRING[] but expected INT64[]. Implicit cast is not supported.
+---- 1
+[[5],[28,75,32],[],[33,11,66,33]]
 -STATEMENT RETURN map_keys(map([[5], [28, 75, 32], [1], [33, 11, 66, 33]], ['a', 'b', 'd', 'e']));
 ---- 1
 [[5],[28,75,32],[1],[33,11,66,33]]

--- a/test/test_files/update_node/create_tinysnb.test
+++ b/test/test_files/update_node/create_tinysnb.test
@@ -20,16 +20,19 @@
 32|1997-03-22|2 years
 9|1980-10-26|10 years 5 months 13:00:00.000024
 
--CASE InsertNodeWithStringTest
+-CASE InsertNodeWithStringAndNestedTest
 -STATEMENT CREATE (:person {ID:32, fName:'A'}), (:person {ID:33, fName:'BCD'}), (:person {ID:34, fName:'this is a long name'})
 ---- ok
--STATEMENT MATCH (a:person) WHERE a.ID > 8 RETURN a.ID, a.fName
----- 5
-10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
-32|A
-33|BCD
-34|this is a long name
-9|Greg
+-STATEMENT CREATE (:person {ID: 99, workedHours: [1], courseScoresPerTerm: [[7,20],[],[]]});
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID > 8 RETURN a.ID, a.fName, a.workedHours, a.courseScoresPerTerm
+---- 6
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|[10,11,12,3,4,5,6,7]|[[7],[10],[6,7]]
+32|A||
+33|BCD||
+34|this is a long name||
+99||[1]|[[7,20],[],[]]
+9|Greg|[1]|[[10]]
 
 -CASE InsertNodeWithUUIDTest
 -STATEMENT CREATE (:person {ID:32, fName: 'Emma', age: 25, u: UUID('A0EEBC99-9C0B-4EF8-BB6D-6BB9BD380A20')});

--- a/tools/python_api/test/test_parameter.py
+++ b/tools/python_api/test/test_parameter.py
@@ -166,21 +166,6 @@ def test_null_resolution(tmp_path: Path) -> None:
     assert not result.has_next()
     result.close()
 
-
-# def test_param_empty(tmp_path: Path) -> None:
-#     db = kuzu.Database(tmp_path)
-#     conn = kuzu.Connection(db)
-#     lst = [[]]
-#     result = conn.execute("CREATE NODE TABLE tab(id SERIAL, lst INT64[][], PRIMARY KEY(id))")
-#     result = conn.execute(
-#         "MERGE (t:tab {lst: $1}) RETURN t.*",
-#         {'1': lst})
-#     assert result.has_next()
-#     assert result.get_next == [0, lst]
-#     assert not result.has_next()
-#     result.close()
-
-
 def test_param_error1(conn_db_readonly: ConnDB) -> None:
     conn, db = conn_db_readonly
     with pytest.raises(RuntimeError, match="Parameter name must be of type string but got <class 'int'>"):


### PR DESCRIPTION
Fix #2385 and issue #2754.

This is done be assigning INT64 as default value to LIST_CREATION rather than STRING. Because INT64[] can be cast to STRING[] but not in the reverse direction.

Additionally, we now allow resolving a combined data type by ignoring empty list whose data type can be changed arbitrarily. E.g. `[[], ['a']]` should ignore the type of first entry and resolve type as STRING[][].