### PR TITLE
Add Nested Types List and Map for Python UDF support

### DIFF
--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "cached_import/py_cached_import.h"
+#include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
 #include "common/string_format.h"
 #include "function/scalar_function.h"
@@ -14,65 +15,111 @@ using namespace kuzu;
 using namespace kuzu::function;
 
 struct PyUDFSignature {
-    std::vector<LogicalTypeID> paramTypes;
-    LogicalTypeID resultType;
+    std::vector<LogicalType> paramTypes;
+    LogicalType resultType;
 
     PyUDFSignature() : paramTypes(), resultType(LogicalTypeID::ANY) {}
 };
 
-static std::vector<LogicalTypeID> pyListToParams(const py::list& lst) {
-    std::vector<LogicalTypeID> params;
+static std::vector<LogicalType> pyListToParams(const py::list& lst) {
+    std::vector<LogicalType> params;
     for (const auto& _ : lst) {
-        params.push_back(LogicalTypeUtils::fromStringToID(py::cast<std::string>(_)));
+        params.push_back(LogicalType::fromString(py::cast<std::string>(_)));
     }
     return params;
 }
 
-static LogicalTypeID pyTypeToLogicalTypeID(const py::handle& ele) {
+static LogicalType getLogicalType(const py::handle& ele);
+
+static LogicalType getLogicalTypeNested(const py::handle& ele) {
+    auto datetime_val = importCache->datetime.datetime()(1, 1, 1);
+    auto timedelta_val = importCache->datetime.timedelta()(0);
+    auto date_val = importCache->datetime.date()(1, 1, 1);
+    auto uuid_val = importCache->uuid.UUID()(py::arg("int") = 0);
+    py::object origin = ele.attr("__origin__");
+    if (origin.is(py::type::of(py::list()))) {
+        auto args = ele.attr("__args__");
+        if (py::len(args) != 1) {
+            throw RuntimeException("List annotations must have exactly one type argument");
+        }
+        auto getitem = args.attr("__getitem__");
+        return *LogicalType::LIST(getLogicalType(getitem(0)));
+    } else if (origin.is(py::type::of(py::dict()))) {
+        auto args = ele.attr("__args__");
+        if (py::len(args) != 2) {
+            throw RuntimeException("Map annotations must have exactly two type arguments");
+        }
+        auto getitem = args.attr("__getitem__");
+        return *LogicalType::MAP(getLogicalType(getitem(0)), getLogicalType(getitem(1)));
+    } else {
+        throw NotImplementedException(
+            "Currently Python UDFs only support LIST and MAP return types");
+    }
+}
+
+static LogicalType getLogicalTypeNonNested(const py::handle& ele) {
     auto datetime_val = importCache->datetime.datetime()(1, 1, 1);
     auto timedelta_val = importCache->datetime.timedelta()(0);
     auto date_val = importCache->datetime.date()(1, 1, 1);
     auto uuid_val = importCache->uuid.UUID()(py::arg("int") = 0);
     auto inspect_empty = importCache->inspect._empty();
     if (ele.is(py::type::of(py::none())) || ele.is(inspect_empty)) {
-        return LogicalTypeID::ANY;
+        return *LogicalType::ANY();
     } else if (ele.is(py::type::of(py::bool_()))) {
-        return LogicalTypeID::BOOL;
+        return *LogicalType::BOOL();
     } else if (ele.is(py::type::of(py::int_()))) {
-        return LogicalTypeID::INT64;
+        return *LogicalType::INT64();
     } else if (ele.is(py::type::of(py::float_()))) {
-        return LogicalTypeID::DOUBLE;
+        return *LogicalType::DOUBLE();
     } else if (ele.is(py::type::of(py::str()))) {
-        return LogicalTypeID::STRING;
+        return *LogicalType::STRING();
     } else if (ele.is(py::type::of(datetime_val))) {
-        return LogicalTypeID::TIMESTAMP;
+        return *LogicalType::TIMESTAMP();
     } else if (ele.is(py::type::of(date_val))) {
-        return LogicalTypeID::DATE;
+        return *LogicalType::DATE();
     } else if (ele.is(py::type::of(timedelta_val))) {
-        return LogicalTypeID::INTERVAL;
+        return *LogicalType::INTERVAL();
     } else if (ele.is(py::type::of(uuid_val))) {
-        return LogicalTypeID::UUID;
-    } else if (ele.is(py::type::of(py::str()))) {
-        return LogicalTypeID::STRING;
+        return *LogicalType::UUID();
     } else if (ele.is(py::type::of(py::list()))) {
-        return LogicalTypeID::LIST;
+        throw RuntimeException("List annotations must specify child type");
     } else if (ele.is(py::type::of(py::dict()))) {
-        return LogicalTypeID::MAP;
+        throw RuntimeException("Map annotations must specify child types");
     } else {
-        throw RuntimeException(common::stringFormat("Unsupported parameter of type {}",
+        throw RuntimeException(common::stringFormat("Unsupported annotation of type {}",
             py::cast<std::string>(py::str(ele))));
+    }
+}
+
+static LogicalType getLogicalType(const py::handle& ele) {
+    if (py::hasattr(ele, "__origin__")) {
+        return getLogicalTypeNested(ele);
+    } else {
+        return getLogicalTypeNonNested(ele);
+    }
+}
+
+static py::object getSignature(const py::function& udf) {
+    constexpr int32_t PYTHON_3_10_HEX = 0x030a00f0;
+    auto python_version = PY_VERSION_HEX;
+
+    auto signature_func = kuzu::importCache->inspect.signature();
+    if (python_version >= PYTHON_3_10_HEX) {
+        return signature_func(udf, py::arg("eval_str") = true);
+    } else {
+        return signature_func(udf);
     }
 }
 
 static PyUDFSignature analyzeSignature(const py::function& udf) {
     PyUDFSignature UDFSignature;
-    auto signature = kuzu::importCache->inspect.signature()(udf, py::arg("eval_str") = true);
+    auto signature = getSignature(udf);
     auto parameters = signature.attr("parameters");
     auto returnAnnotation = signature.attr("return_annotation");
-    UDFSignature.resultType = pyTypeToLogicalTypeID(returnAnnotation);
+    UDFSignature.resultType = getLogicalType(returnAnnotation);
     for (const auto& parameter : parameters) {
         auto paramAnnotation = parameters.attr("__getitem__")(parameter).attr("annotation");
-        UDFSignature.paramTypes.push_back(pyTypeToLogicalTypeID(paramAnnotation));
+        UDFSignature.paramTypes.push_back(getLogicalType(paramAnnotation));
     }
     return UDFSignature;
 }
@@ -100,6 +147,13 @@ static scalar_func_exec_t getUDFExecFunc(const py::function& udf) {
     };
 }
 
+static scalar_bind_func getUDFBindFunc(const PyUDFSignature& signature) {
+    return [=](const binder::expression_vector&, Function*) -> std::unique_ptr<FunctionBindData> {
+        return std::make_unique<FunctionBindData>(signature.paramTypes,
+            std::make_unique<LogicalType>(signature.resultType));
+    };
+}
+
 function_set PyUDF::toFunctionSet(const std::string& name, const py::function& udf,
     const py::list& paramTypes, const std::string& resultType) {
     auto pySignature = analyzeSignature(udf);
@@ -111,33 +165,25 @@ function_set PyUDF::toFunctionSet(const std::string& name, const py::function& u
         }
         pySignature.paramTypes = explicitParamTypes;
     }
+    std::vector<LogicalTypeID> paramIDTypes;
     for (const auto& paramType : pySignature.paramTypes) {
-        if (paramType == LogicalTypeID::ANY) {
+        if (paramType.getLogicalTypeID() == LogicalTypeID::ANY) {
             throw RuntimeException(
                 "Parameters must be annotated or explicitly given, and cannot be ANY");
         }
+        paramIDTypes.push_back(paramType.getLogicalTypeID());
     }
     if (resultType != "") {
-        auto explicitResultType = LogicalTypeUtils::fromStringToID(resultType);
-        pySignature.resultType = explicitResultType;
+        pySignature.resultType = LogicalType::fromString(resultType);
     }
-    if (pySignature.resultType == LogicalTypeID::ANY) {
+    if (pySignature.resultType.getLogicalTypeID() == LogicalTypeID::ANY) {
         throw RuntimeException(
             "Return value must be annotated or explicitly given, and cannot be ANY");
     }
 
-    // TODO maxwell: support nested parameters
-    for (auto paramType : pySignature.paramTypes) {
-        if (LogicalTypeUtils::isNested(paramType)) {
-            throw RuntimeException("Nested type UDFs not implemented yet");
-        }
-    }
-    if (LogicalTypeUtils::isNested(pySignature.resultType)) {
-        throw RuntimeException("Nested type UDFs not implemented yet");
-    }
-
     function_set definitions;
-    definitions.push_back(std::make_unique<ScalarFunction>(name, pySignature.paramTypes,
-        pySignature.resultType, getUDFExecFunc(udf)));
+    definitions.push_back(std::make_unique<ScalarFunction>(name, paramIDTypes,
+        pySignature.resultType.getLogicalTypeID(), getUDFExecFunc(udf),
+        getUDFBindFunc(pySignature)));
     return definitions;
 }

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -234,8 +234,8 @@ class Connection:
         self,
         name: str,
         udf: Callable[[...], Any],
-        params_type: list[Type] | None = None,
-        return_type: Type | None = None
+        params_type: list[Type | str] | None = None,
+        return_type: Type | str = ""
     ) -> None:
         """
         Sets a User Defined Function (UDF) to use in cypher queries.
@@ -254,6 +254,9 @@ class Connection:
         return_type: Optional[Type]
             a Type enum to describe the returned value
         """
-        parsed_params_type = [] if params_type is None else [param_type.value for param_type in params_type]
-        parsed_return_type = "" if return_type is None else return_type.value
-        self._connection.create_function(name, udf, parsed_params_type, parsed_return_type)
+        if params_type is None:
+            params_type = []
+        parsed_params_type = [x if type(x) is str else x.value for x in params_type]
+        if (type(return_type) is not str):
+            return_type = return_type.value
+        self._connection.create_function(name, udf, parsed_params_type, return_type)


### PR DESCRIPTION
This pull request adds list and map support for UDF
There are two ways to denote nested types in our signatures:
1. Annotation
    eg: `def f(x : list) -> list[int]`
    Only the returned type must be fully annotated (ie. its child type(s) are declared)
3. Explicit declaration
    eg: `conn.create_function("myfunction", f, [Type.LIST], "INT64[]")`
    As with the above example, only the return type must be fully annotated. Full annotation does not make use of the `kuzu.Type` enumeration. Instead, it must be given as a complete string. 

Update: both parameters and return types must be fully described. ie. nested types must include child type information