### PR TITLE
Fix CSV file answers tuple count bug

### DIFF
--- a/test/test_files/copy/copy_long_string.test
+++ b/test/test_files/copy/copy_long_string.test
@@ -19,7 +19,7 @@
 -STATEMENT copy person1 from '${KUZU_ROOT_DIRECTORY}/test/answers/long_string_invalid.csv';
 ---- ok
 -STATEMENT match (p:person1) return p.fName;
----- 1
+---- 2
 <FILE>:long_string_invalid.csv
 
 -CASE LongStringPKError
@@ -39,5 +39,5 @@
 -STATEMENT copy person1 from '${KUZU_ROOT_DIRECTORY}/test/answers/long_string_invalid.csv';
 ---- ok
 -STATEMENT match (p:person1) return p.ID;
----- 1
+---- 2
 <FILE>:long_string_invalid.csv

--- a/test/test_files/transaction/create_rel/insert_rels_to_large_list.test
+++ b/test/test_files/transaction/create_rel/insert_rels_to_large_list.test
@@ -21,7 +21,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 0 RETURN e.length, e.place, e.tag
----- 2300
+---- 2304
 <FILE>:insert_rels_to_large_list_commit.txt
 
 -CASE insertRelsToLargeListCommitRecovery
@@ -34,7 +34,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 0 RETURN e.length, e.place, e.tag
----- 2300
+---- 2304
 <FILE>:insert_rels_to_large_list_commit.txt
 
 -CASE insertRelsToLargeListRollbackNormalExecution
@@ -46,7 +46,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 0 RETURN e.length, e.place, e.tag
----- 2304
+---- 2300
 <FILE>:insert_rels_to_large_list_rollback.txt
 
 -CASE insertRelsToLargeListRollbackRecovery
@@ -59,5 +59,5 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 0 RETURN e.length, e.place, e.tag
----- 2304
+---- 2300
 <FILE>:insert_rels_to_large_list_rollback.txt

--- a/test/test_files/transaction/create_rel/small_list_becomes_large_list_after_insertion.test
+++ b/test/test_files/transaction/create_rel/small_list_becomes_large_list_after_insertion.test
@@ -11,7 +11,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 1 RETURN e.length, e.place, e.tag
----- 1500
+---- 1501
 <FILE>:small_list_becomes_large_list_after_insertion_commit.txt
 
 -CASE smallListBecomesLargeListAfterInsertionCommitRecovery
@@ -25,7 +25,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID = 1 RETURN e.length, e.place, e.tag
----- 1500
+---- 1501
 <FILE>:small_list_becomes_large_list_after_insertion_commit.txt
 
 -CASE smallListBecomesLargeListAfterInsertionRollbackNormalExecution

--- a/test/test_files/transaction/delete_rel/delete_rels_from_large_list.test
+++ b/test/test_files/transaction/delete_rel/delete_rels_from_large_list.test
@@ -11,7 +11,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (p:person)-[e:knows]->(:person) WHERE p.ID  = 0 RETURN e.length
----- 2200
+---- 2199
 <FILE>:delete_rels_from_large_list_commit.txt
 
 
@@ -26,7 +26,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (p:person)-[e:knows]->(:person) WHERE p.ID  = 0 RETURN e.length
----- 2200
+---- 2199
 <FILE>:delete_rels_from_large_list_commit.txt
 
 -CASE deleteRelsFromLargeListRollbackNormalExecution

--- a/test/test_files/transaction/delete_rel/delete_rels_from_small_list.test
+++ b/test/test_files/transaction/delete_rel/delete_rels_from_small_list.test
@@ -11,7 +11,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (p:person)-[e:knows]->(:person) WHERE p.ID  = 0 RETURN e.length
----- 2290
+---- 2289
 <FILE>:delete_rels_from_small_list_commit.txt
 
 
@@ -26,7 +26,7 @@
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (p:person)-[e:knows]->(:person) WHERE p.ID  = 0 RETURN e.length
----- 2290
+---- 2289
 <FILE>:delete_rels_from_small_list_commit.txt
 
 -CASE deleteRelsFromSmallListRollbackNormalExecution

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -150,6 +150,12 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
         while (std::getline(expectedTuplesFile, line)) {
             testAnswer.expectedResult.push_back(line);
         }
+        if (testAnswer.expectedResult.size() != testAnswer.numTuples) {
+            spdlog::error("PLAN{} NOT PASSED.", planIdx);
+            spdlog::info("PLAN: \n{}", planStr);
+            spdlog::info("TUPLE COUNT NOT MATCHING.");
+            return false;
+        }
         if (!statement->checkOutputOrder) {
             sort(testAnswer.expectedResult.begin(), testAnswer.expectedResult.end());
         }

--- a/test/test_runner/test_runner.cpp
+++ b/test/test_runner/test_runner.cpp
@@ -153,7 +153,9 @@ bool TestRunner::checkPlanResult(std::unique_ptr<QueryResult>& result, TestState
         if (testAnswer.expectedResult.size() != testAnswer.numTuples) {
             spdlog::error("PLAN{} NOT PASSED.", planIdx);
             spdlog::info("PLAN: \n{}", planStr);
-            spdlog::info("TUPLE COUNT NOT MATCHING.");
+            spdlog::info("TUPLE COUNT NOT MATCHING:");
+            spdlog::info("    EXPECTED {} TUPLES IN ANSWER FILE.", testAnswer.numTuples);
+            spdlog::info("    FOUND {} TUPLES IN ANSWER FILE.", testAnswer.expectedResult.size());
             return false;
         }
         if (!statement->checkOutputOrder) {


### PR DESCRIPTION
Fixes the bug where tuple count is not verified when using the `<FILE>:` answers format for tuples. 