### PR TITLE
[BUG REPRODUCE] Pyarrow utf8 string

### DIFF
--- a/dataset/issue/duplicate-primary-key/data.csv
+++ b/dataset/issue/duplicate-primary-key/data.csv
@@ -1,0 +1,10 @@
+pk
+test:test::test©test 4765f5e7-9d11-494a-8fc2-e6cab854506a
+test:test::test©test c5399b9a-f07c-4228-a93e-6eec5bba5d97
+test:test::test©test b7b68563-465d-4c06-85af-1ae41e72e8d7
+test:test::test©test 2fb03f9e-3e18-41d2-88a8-f10c96e7ee20
+test:test::test©test efce2f76-25cb-46d2-b8f4-9202418e7413
+test:test::test©test b5155a86-65de-4bbf-ac9a-94a3eb8692e2
+test:test::test©test b7858645-4b7d-4cce-9202-27712cf3920c
+test:test::test©test 057098fc-26ea-4f9a-ad5a-68481d3df5ce
+test:test::test©test dea963b9-df07-453e-abfe-d2822036cbd8

--- a/test/test_files/issue/play.test
+++ b/test/test_files/issue/play.test
@@ -1,0 +1,23 @@
+-DATASET CSV empty
+
+--
+
+-CASE Play
+
+
+-STATEMENT CREATE NODE TABLE Test(
+                   pk STRING,
+                   PRIMARY KEY (pk));
+---- ok
+-STATEMENT COPY Test FROM (
+                LOAD WITH HEADERS (pk STRING)
+                FROM "${KUZU_ROOT_DIRECTORY}/dataset/issue/duplicate-primary-key/data.csv" (header=true)
+                WHERE NOT EXISTS { MATCH (t:Test) WHERE t.pk = pk }
+                RETURN *);
+---- 1
+9 tuples have been copied to the Test table.
+-STATEMENT LOAD WITH HEADERS (pk STRING)
+           FROM "${KUZU_ROOT_DIRECTORY}/dataset/issue/duplicate-primary-key/data.csv" (header=true)
+           WHERE NOT EXISTS { MATCH (t:Test) WHERE t.pk = pk }
+           RETURN *;
+---- 0

--- a/tools/python_api/test/test_issue.py
+++ b/tools/python_api/test/test_issue.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from tools.python_api.test.type_aliases import ConnDB
+from type_aliases import ConnDB
 
 # required by python-lint
 

--- a/tools/python_api/test/test_utf8_string.py
+++ b/tools/python_api/test/test_utf8_string.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from tools.python_api.test.type_aliases import ConnDB
+import pandas as pd
+from test_helper import KUZU_ROOT
+
+# required by python-lint
+
+
+def test_utf8(conn_db_readwrite: ConnDB) -> None:
+    conn, db = conn_db_readwrite
+    conn.execute(
+        "CREATE NODE TABLE Test("
+        "pk STRING, "
+        "PRIMARY KEY (pk))"
+    )
+    dtype_mapping = {
+        "pk": "string[pyarrow]",
+    }
+    df = pd.read_csv(f"{KUZU_ROOT}/dataset/issue/duplicate-primary-key/data.csv", dtype=dtype_mapping, dtype_backend="pyarrow")
+    response = conn.execute(f'COPY Test FROM (LOAD WITH HEADERS (pk STRING) FROM df WHERE NOT EXISTS {{MATCH (t:Test) WHERE t.pk = pk}} RETURN *)')
+    while response.has_next():
+        print(f"Inserted Test {response.get_next()}")
+
+    response = conn.execute("LOAD WITH HEADERS (pk STRING) FROM df WHERE NOT EXISTS {MATCH (t:Test) WHERE t.pk = pk} RETURN *")
+    assert not response.has_next()


### PR DESCRIPTION
The test is trivially scanning a CSV and bulk insert into a node table. Then scan the csv again to make sure each tuple/primary key exists in the table.

This test is working on cpp side but fail when we read csv through pyarrow and then scan from it. My best guess is that the prefix is incorrectly set for utf8 encode strings.