### PR TITLE
Fix pandas UTF-8 scan

### DIFF
--- a/tools/python_api/src_cpp/numpy/numpy_scan.cpp
+++ b/tools/python_api/src_cpp/numpy/numpy_scan.cpp
@@ -66,6 +66,9 @@ static void appendPythonUnicode(T* codepoints, uint64_t codepointLength,
         KU_ASSERT(codePointLen >= 1);
         dataToWrite += codePointLen;
     }
+    if (!ku_string_t::isShortString(utf8StrLen)) {
+        memcpy(strToAppend.prefix, strToAppend.getData(), ku_string_t::PREFIX_LENGTH);
+    }
 }
 
 void NumpyScan::scan(PandasColumnBindData* bindData, uint64_t count, uint64_t offset,

--- a/tools/python_api/test/test_scan_pandas.py
+++ b/tools/python_api/test/test_scan_pandas.py
@@ -359,3 +359,14 @@ def test_scan_from_py_arrow_pandas(tmp_path: Path) -> None:
     assert result.get_next() == ["Zhang", 50]
     assert result.get_next() == ["Noura", 25]
     assert result.has_next() is False
+
+
+def test_scan_long_utf8_string(tmp_path: Path) -> None:
+    db = kuzu.Database(tmp_path)
+    conn = kuzu.Connection(db)
+    data = {
+        "name": ["很长的一段中文", "短", "非常长的中文"]
+    }
+    df = pd.DataFrame(data)
+    result = conn.execute("LOAD FROM df WHERE name = '非常长的中文' RETURN count(*);")
+    assert result.get_next() == [1]


### PR DESCRIPTION
When the string is a long utf-8 string, we forget to set the prefix of the string.
This PR fixes the bug.