### PR TITLE
Fix some minor hash index issues

### DIFF
--- a/src/include/storage/index/hash_index_slot.h
+++ b/src/include/storage/index/hash_index_slot.h
@@ -22,7 +22,7 @@ public:
     // instead restrict the capacity to 20
     static constexpr uint8_t FINGERPRINT_CAPACITY = 20;
 
-    SlotHeader() : validityMask{0}, nextOvfSlotId{0} {}
+    SlotHeader() : fingerprints{}, validityMask{0}, nextOvfSlotId{0} {}
 
     void reset() {
         validityMask = 0;
@@ -70,6 +70,7 @@ static constexpr uint8_t getSlotCapacity() {
 
 template<typename T>
 struct Slot {
+    Slot() : header{}, entries{} {}
     SlotHeader header;
     SlotEntry<T> entries[getSlotCapacity<T>()];
 };

--- a/src/include/storage/index/in_mem_hash_index.h
+++ b/src/include/storage/index/in_mem_hash_index.h
@@ -53,6 +53,11 @@ class InMemHashIndex final {
     // Size of the validity mask
     static_assert(getSlotCapacity<T>() <= sizeof(SlotHeader().validityMask) * 8);
     static_assert(getSlotCapacity<T>() <= std::numeric_limits<entry_pos_t>::max() + 1);
+    static_assert(BaseDiskArray<Slot<T>>::getAlignedElementSize() <=
+                  common::HashIndexConstants::SLOT_CAPACITY_BYTES);
+    static_assert(BaseDiskArray<Slot<T>>::getAlignedElementSize() >= sizeof(Slot<T>));
+    static_assert(BaseDiskArray<Slot<T>>::getAlignedElementSize() >
+                  common::HashIndexConstants::SLOT_CAPACITY_BYTES / 2);
 
 public:
     explicit InMemHashIndex(OverflowFileHandle* overflowFileHandle);

--- a/src/include/storage/storage_structure/disk_array.h
+++ b/src/include/storage/storage_structure/disk_array.h
@@ -283,8 +283,8 @@ class BaseDiskArray {
 
 public:
     // Used by copiers.
-    BaseDiskArray(FileHandle& fileHandle, common::page_idx_t headerPageIdx, uint64_t elementSize)
-        : diskArray(fileHandle, headerPageIdx, elementSize) {}
+    BaseDiskArray(FileHandle& fileHandle, common::page_idx_t headerPageIdx)
+        : diskArray(fileHandle, headerPageIdx, getAlignedElementSize()) {}
     // Used when loading from file
     // If bypassWAL is set, the buffer manager is used to pages new to this transaction to the
     // original file, but does not handle flushing them. BufferManager::flushAllDirtyPagesInFrames
@@ -356,9 +356,7 @@ public:
 
     inline WriteIterator iter_mut() { return WriteIterator{diskArray.iter_mut(sizeof(U))}; }
     inline uint64_t getAPIdx(uint64_t idx) const { return diskArray.getAPIdx(idx); }
-    static constexpr uint32_t getAlignedElementSize() {
-        return (1 << (std::bit_width(sizeof(U)) - 1));
-    }
+    static constexpr uint32_t getAlignedElementSize() { return std::bit_ceil(sizeof(U)); }
 
 private:
     BaseDiskArrayInternal diskArray;

--- a/src/storage/storage_structure/overflow_file.cpp
+++ b/src/storage/storage_structure/overflow_file.cpp
@@ -182,6 +182,8 @@ void OverflowFile::createEmptyFiles(const std::string& fName, common::VirtualFil
     uint8_t page[common::BufferPoolConstants::PAGE_4KB_SIZE];
     StringOverflowFileHeader header;
     memcpy(page, &header, sizeof(StringOverflowFileHeader));
+    // Zero free space at the end of the header page
+    std::fill(page + sizeof(header), page + BufferPoolConstants::PAGE_4KB_SIZE, 0);
     fileHandle.addNewPage();
     fileHandle.writePage(page, HEADER_PAGE_IDX);
 }
@@ -218,6 +220,8 @@ void OverflowFile::prepareCommit() {
         uint8_t page[BufferPoolConstants::PAGE_4KB_SIZE];
         header.pages = pageCounter;
         memcpy(page, &header, sizeof(header));
+        // Zero free space at the end of the header page
+        std::fill(page + sizeof(header), page + BufferPoolConstants::PAGE_4KB_SIZE, 0);
         writePageToDisk(HEADER_PAGE_IDX, page);
     }
 }


### PR DESCRIPTION
I've fixed a few places where unused data isn't being zeroed (which makes it harder to do binary comparisons of the files when debugging), and also fixed `BaseDiskArray::getAlignedElementSize` as its behaviour was incorrect when the size was not a power of two to begin with (I've added some asserts to enforce that the result of the function is sane).

This should not be a breaking change, as `BaseDiskArray::getAlignedElementSize` was only being used by the Hash index for the purpose of calculating the minimum number of slots and will not affect the size used when reading.

I noticed these issues when looking at kuzudb/explorer#129, but I don't think they will resolve the issue (both the expected and actual slots were larger than they should be for hash indexes containing only one value, both being in the range of 0-31, instead of 0-15 as I would expect).