### PR TITLE
Fix string hash and add more hash tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.4.1.1 LANGUAGES CXX C)
+project(Kuzu VERSION 0.4.1.2 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 

--- a/src/include/function/hash/hash_functions.h
+++ b/src/include/function/hash/hash_functions.h
@@ -158,7 +158,7 @@ inline void Hash::operation(const std::string_view& key, common::hash_t& result,
     }
     uint64_t last = 0;
     for (size_t i = 0u; i < key.size() % 8; i++) {
-        last |= key[key.size() / 8 * 8 + i] << i * 8;
+        last |= static_cast<uint64_t>(key[key.size() / 8 * 8 + i]) << i * 8;
     }
     hashValue = kuzu::function::combineHashScalar(hashValue, kuzu::function::murmurhash64(last));
     result = hashValue;

--- a/test/test_files/function/hash/hash.test
+++ b/test/test_files/function/hash/hash.test
@@ -61,3 +61,41 @@ e129f5000a4b71ccc3a0e6353a86cc57989106e670793db98efa34b7527aefa5
 -STATEMENT RETURN hash('kuzu')
 ---- 1
 -144620710730482887
+
+-LOG HashMediumLengthStrings
+-STATEMENT RETURN hash('Some string')
+---- 1
+4300833454950395778
+-STATEMENT RETURN hash('Another string')
+---- 1
+-7455830751860279176
+-STATEMENT RETURN hash('aaaaaaaa')
+---- 1
+-7005506450880164945
+-STATEMENT RETURN hash('aaaaaaaaa')
+---- 1
+-393672730685262981
+-STATEMENT RETURN hash('aaaaaaaaaa')
+---- 1
+2482482096684464911
+-STATEMENT RETURN hash('aaaaaaaaaaa')
+---- 1
+-3480219808301464527
+-STATEMENT RETURN hash('aaaaaaaaaaaa')
+---- 1
+8029484162599640120
+-STATEMENT RETURN hash('aaaaaaaaaaaaa')
+---- 1
+-8789476897890830468
+-STATEMENT RETURN hash('aaaaaaaaaaaaaa')
+---- 1
+659393504505364758
+-STATEMENT RETURN hash('aaaaaaaaaaaaaaa')
+---- 1
+2646437354086420181
+
+-DEFINE test_long_string REPEAT 2147 "a"
+-LOG HashLongString
+-STATEMENT RETURN hash('${test_long_string}')
+---- 1
+-3617781442718183954


### PR DESCRIPTION
Should fix kuzudb/explorer#129. Not only was the type of the value being used for the bit shift not wide enough (the characters are `char`s, but the result of a bitshift seems to always be at least `int`), but it was signed, and signed bit shifts may add new bits as 0 or 1 depending on the implementation, which I think is causing the difference among the platforms.

The existing string tests were fairly limited so I added some more which better cover the corner cases.

This will break storage since is changes the behaviour of the hash function used in the hash index.