### PR TITLE
Refactor ftable schema

### DIFF
--- a/src/function/aggregate/collect.cpp
+++ b/src/function/aggregate/collect.cpp
@@ -43,9 +43,9 @@ void CollectFunction::updatePos(uint8_t* state_, ValueVector* input, uint64_t mu
 void CollectFunction::initCollectStateIfNecessary(CollectState* state, MemoryManager* memoryManager,
     LogicalType& dataType) {
     if (state->factorizedTable == nullptr) {
-        auto tableSchema = std::make_unique<FactorizedTableSchema>();
-        tableSchema->appendColumn(std::make_unique<ColumnSchema>(false /* isUnflat */,
-            0 /* dataChunkPos */, StorageUtils::getDataTypeSize(dataType)));
+        auto tableSchema = FactorizedTableSchema();
+        tableSchema.appendColumn(ColumnSchema(false /* isUnflat */, 0 /* groupID */,
+            StorageUtils::getDataTypeSize(dataType)));
         state->factorizedTable =
             std::make_unique<FactorizedTable>(memoryManager, std::move(tableSchema));
     }

--- a/src/include/processor/operator/aggregate/aggregate_hash_table.h
+++ b/src/include/processor/operator/aggregate/aggregate_hash_table.h
@@ -43,7 +43,7 @@ public:
     AggregateHashTable(storage::MemoryManager& memoryManager,
         const std::vector<common::LogicalType>& keyTypes,
         const std::vector<common::LogicalType>& payloadTypes, uint64_t numEntriesToAllocate,
-        std::unique_ptr<FactorizedTableSchema> tableSchema)
+        FactorizedTableSchema tableSchema)
         : AggregateHashTable(memoryManager, keyTypes, payloadTypes,
               std::vector<std::unique_ptr<function::AggregateFunction>>{} /* empty aggregates */,
               std::vector<common::LogicalType>{} /* empty distinct agg key*/, numEntriesToAllocate,
@@ -53,7 +53,7 @@ public:
         std::vector<common::LogicalType> keyTypes, std::vector<common::LogicalType> payloadTypes,
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
         const std::vector<common::LogicalType>& distinctAggKeyTypes, uint64_t numEntriesToAllocate,
-        std::unique_ptr<FactorizedTableSchema> tableSchema);
+        FactorizedTableSchema tableSchema);
 
     uint8_t* getEntry(uint64_t idx) { return factorizedTable->getTuple(idx); }
 
@@ -106,7 +106,7 @@ protected:
 private:
     void initializeFT(
         const std::vector<std::unique_ptr<function::AggregateFunction>>& aggregateFunctions,
-        std::unique_ptr<FactorizedTableSchema> tableSchema);
+        FactorizedTableSchema tableSchema);
 
     void initializeHashTable(uint64_t numEntriesToAllocate);
 

--- a/src/include/processor/operator/aggregate/hash_aggregate.h
+++ b/src/include/processor/operator/aggregate/hash_aggregate.h
@@ -37,11 +37,11 @@ struct HashAggregateInfo {
     std::vector<DataPos> flatKeysPos;
     std::vector<DataPos> unFlatKeysPos;
     std::vector<DataPos> dependentKeysPos;
-    std::unique_ptr<FactorizedTableSchema> tableSchema;
+    FactorizedTableSchema tableSchema;
     HashTableType hashTableType;
 
     HashAggregateInfo(std::vector<DataPos> flatKeysPos, std::vector<DataPos> unFlatKeysPos,
-        std::vector<DataPos> dependentKeysPos, std::unique_ptr<FactorizedTableSchema> tableSchema,
+        std::vector<DataPos> dependentKeysPos, FactorizedTableSchema tableSchema,
         HashTableType hashTableType);
     HashAggregateInfo(const HashAggregateInfo& other);
 };

--- a/src/include/processor/operator/hash_join/hash_join_build.h
+++ b/src/include/processor/operator/hash_join/hash_join_build.h
@@ -38,18 +38,18 @@ class HashJoinBuildInfo {
 
 public:
     HashJoinBuildInfo(std::vector<DataPos> keysPos, std::vector<common::FStateType> fStateTypes,
-        std::vector<DataPos> payloadsPos, std::unique_ptr<FactorizedTableSchema> tableSchema)
+        std::vector<DataPos> payloadsPos, FactorizedTableSchema tableSchema)
         : keysPos{std::move(keysPos)}, fStateTypes{std::move(fStateTypes)},
           payloadsPos{std::move(payloadsPos)}, tableSchema{std::move(tableSchema)} {}
     HashJoinBuildInfo(const HashJoinBuildInfo& other)
         : keysPos{other.keysPos}, fStateTypes{other.fStateTypes}, payloadsPos{other.payloadsPos},
-          tableSchema{other.tableSchema->copy()} {}
+          tableSchema{other.tableSchema.copy()} {}
 
-    inline uint32_t getNumKeys() const { return keysPos.size(); }
+    uint32_t getNumKeys() const { return keysPos.size(); }
 
-    inline FactorizedTableSchema* getTableSchema() const { return tableSchema.get(); }
+    const FactorizedTableSchema* getTableSchema() const { return &tableSchema; }
 
-    inline std::unique_ptr<HashJoinBuildInfo> copy() const {
+    std::unique_ptr<HashJoinBuildInfo> copy() const {
         return std::make_unique<HashJoinBuildInfo>(*this);
     }
 
@@ -57,7 +57,7 @@ private:
     std::vector<DataPos> keysPos;
     std::vector<common::FStateType> fStateTypes;
     std::vector<DataPos> payloadsPos;
-    std::unique_ptr<FactorizedTableSchema> tableSchema;
+    FactorizedTableSchema tableSchema;
 };
 
 class HashJoinBuild : public Sink {

--- a/src/include/processor/operator/hash_join/join_hash_table.h
+++ b/src/include/processor/operator/hash_join/join_hash_table.h
@@ -9,7 +9,7 @@ namespace processor {
 class JoinHashTable : public BaseHashTable {
 public:
     JoinHashTable(storage::MemoryManager& memoryManager, common::logical_type_vec_t keyTypes,
-        std::unique_ptr<FactorizedTableSchema> tableSchema);
+        FactorizedTableSchema tableSchema);
 
     void appendVectors(const std::vector<common::ValueVector*>& keyVectors,
         const std::vector<common::ValueVector*>& payloadVectors, common::DataChunkState* keyState);

--- a/src/include/processor/operator/order_by/order_by_data_info.h
+++ b/src/include/processor/operator/order_by/order_by_data_info.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "processor/data_pos.h"
-#include "processor/result/factorized_table.h"
+#include "processor/result/factorized_table_schema.h"
 
 namespace kuzu {
 namespace processor {
@@ -12,13 +12,13 @@ struct OrderByDataInfo {
     std::vector<std::unique_ptr<common::LogicalType>> keyTypes;
     std::vector<std::unique_ptr<common::LogicalType>> payloadTypes;
     std::vector<bool> isAscOrder;
-    std::unique_ptr<FactorizedTableSchema> payloadTableSchema;
+    FactorizedTableSchema payloadTableSchema;
     std::vector<uint32_t> keyInPayloadPos;
 
     OrderByDataInfo(std::vector<DataPos> keysPos, std::vector<DataPos> payloadsPos,
         std::vector<std::unique_ptr<common::LogicalType>> keyTypes,
         std::vector<std::unique_ptr<common::LogicalType>> payloadTypes,
-        std::vector<bool> isAscOrder, std::unique_ptr<FactorizedTableSchema> payloadTableSchema,
+        std::vector<bool> isAscOrder, FactorizedTableSchema payloadTableSchema,
         std::vector<uint32_t> keyInPayloadPos)
         : keysPos{std::move(keysPos)}, payloadsPos{std::move(payloadsPos)},
           keyTypes{std::move(keyTypes)}, payloadTypes{std::move(payloadTypes)},
@@ -28,7 +28,7 @@ struct OrderByDataInfo {
         : keysPos{other.keysPos}, payloadsPos{other.payloadsPos},
           keyTypes{common::LogicalType::copy(other.keyTypes)},
           payloadTypes{common::LogicalType::copy(other.payloadTypes)}, isAscOrder{other.isAscOrder},
-          payloadTableSchema{other.payloadTableSchema->copy()},
+          payloadTableSchema{other.payloadTableSchema.copy()},
           keyInPayloadPos{other.keyInPayloadPos} {}
 
     std::unique_ptr<OrderByDataInfo> copy() const {

--- a/src/include/processor/operator/persistent/copy_to_parquet.h
+++ b/src/include/processor/operator/persistent/copy_to_parquet.h
@@ -11,11 +11,11 @@ namespace processor {
 struct CopyToParquetInfo final : public CopyToInfo {
     kuzu_parquet::format::CompressionCodec::type codec =
         kuzu_parquet::format::CompressionCodec::SNAPPY;
-    std::unique_ptr<FactorizedTableSchema> tableSchema;
+    FactorizedTableSchema tableSchema;
     std::vector<std::unique_ptr<common::LogicalType>> types;
     DataPos countingVecPos;
 
-    CopyToParquetInfo(std::unique_ptr<FactorizedTableSchema> tableSchema,
+    CopyToParquetInfo(FactorizedTableSchema tableSchema,
         std::vector<std::unique_ptr<common::LogicalType>> types, std::vector<std::string> names,
         std::vector<DataPos> dataPoses, std::string fileName, DataPos countingVecPos,
         bool canParallel)
@@ -24,7 +24,7 @@ struct CopyToParquetInfo final : public CopyToInfo {
           countingVecPos{std::move(countingVecPos)} {}
 
     std::unique_ptr<CopyToInfo> copy() override {
-        return std::make_unique<CopyToParquetInfo>(tableSchema->copy(),
+        return std::make_unique<CopyToParquetInfo>(tableSchema.copy(),
             common::LogicalType::copy(types), names, dataPoses, fileName, countingVecPos,
             canParallel);
     }

--- a/src/include/processor/operator/result_collector.h
+++ b/src/include/processor/operator/result_collector.h
@@ -26,15 +26,15 @@ private:
 
 struct ResultCollectorInfo {
     common::AccumulateType accumulateType;
-    std::unique_ptr<FactorizedTableSchema> tableSchema;
+    FactorizedTableSchema tableSchema;
     std::vector<DataPos> payloadPositions;
 
-    ResultCollectorInfo(common::AccumulateType accumulateType,
-        std::unique_ptr<FactorizedTableSchema> tableSchema, std::vector<DataPos> payloadPositions)
+    ResultCollectorInfo(common::AccumulateType accumulateType, FactorizedTableSchema tableSchema,
+        std::vector<DataPos> payloadPositions)
         : accumulateType{accumulateType}, tableSchema{std::move(tableSchema)},
           payloadPositions{std::move(payloadPositions)} {}
     ResultCollectorInfo(const ResultCollectorInfo& other)
-        : accumulateType{other.accumulateType}, tableSchema{other.tableSchema->copy()},
+        : accumulateType{other.accumulateType}, tableSchema{other.tableSchema.copy()},
           payloadPositions{other.payloadPositions} {}
 
     inline std::unique_ptr<ResultCollectorInfo> copy() const {

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -106,6 +106,7 @@ private:
     std::unique_ptr<ResultCollector> createResultCollector(common::AccumulateType accumulateType,
         const binder::expression_vector& expressions, planner::Schema* schema,
         std::unique_ptr<PhysicalOperator> prevOperator);
+
     // Scan fTable with row offset.
     std::unique_ptr<PhysicalOperator> createFTableScan(const binder::expression_vector& exprs,
         std::vector<ft_col_idx_t> colIndices, std::shared_ptr<binder::Expression> offset,
@@ -175,9 +176,7 @@ private:
     std::unique_ptr<RelSetExecutor> getRelSetExecutor(planner::LogicalSetPropertyInfo* info,
         const planner::Schema& inSchema) const;
 
-    std::shared_ptr<FactorizedTable> getSingleStringColumnFTable() const;
-
-    inline uint32_t getOperatorID() { return physicalOperatorID++; }
+    uint32_t getOperatorID() { return physicalOperatorID++; }
 
     static void mapSIPJoin(PhysicalOperator* probe);
 

--- a/src/include/processor/result/factorized_table_schema.h
+++ b/src/include/processor/result/factorized_table_schema.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "common/assert.h"
+#include "common/copy_constructors.h"
+#include "common/types/types.h"
+
+namespace kuzu {
+namespace processor {
+
+// TODO(Guodong/Ziyi): Move these typedef to common and unify them with the ones without `ft_`.
+typedef uint64_t ft_tuple_idx_t;
+typedef uint32_t ft_col_idx_t;
+typedef uint32_t ft_col_offset_t;
+typedef uint32_t ft_block_idx_t;
+typedef uint32_t ft_block_offset_t;
+
+class ColumnSchema {
+public:
+    ColumnSchema(bool isUnFlat, common::idx_t groupID, uint32_t numBytes)
+        : isUnFlat{isUnFlat}, groupID{groupID}, numBytes{numBytes}, mayContainNulls{false} {}
+    EXPLICIT_COPY_DEFAULT_MOVE(ColumnSchema);
+
+    bool isFlat() const { return !isUnFlat; }
+
+    common::idx_t getGroupID() const { return groupID; }
+
+    uint32_t getNumBytes() const { return numBytes; }
+
+    bool operator==(const ColumnSchema& other) const {
+        return isUnFlat == other.isUnFlat && groupID == other.groupID && numBytes == other.numBytes;
+    }
+    bool operator!=(const ColumnSchema& other) const { return !(*this == other); }
+
+    void setMayContainsNullsToTrue() { mayContainNulls = true; }
+
+    bool hasNoNullGuarantee() const { return !mayContainNulls; }
+
+private:
+    ColumnSchema(const ColumnSchema& other);
+
+private:
+    // This following two information can alternatively be maintained at table schema
+    // level as a column group information.
+    // Whether column is unFlat.
+    bool isUnFlat;
+    // Group id.
+    common::idx_t groupID;
+    // Num bytes of the column.
+    uint32_t numBytes;
+    // Whether column may contain nulls.
+    // If this field is true, the column can still be all non-null.
+    bool mayContainNulls;
+};
+
+class FactorizedTableSchema {
+public:
+    FactorizedTableSchema() = default;
+    EXPLICIT_COPY_DEFAULT_MOVE(FactorizedTableSchema);
+
+    void appendColumn(ColumnSchema column);
+
+    const ColumnSchema* getColumn(ft_col_idx_t idx) const { return &columns[idx]; }
+
+    uint32_t getNumColumns() const { return columns.size(); }
+
+    ft_col_offset_t getNullMapOffset() const { return numBytesForDataPerTuple; }
+
+    uint32_t getNumBytesPerTuple() const { return numBytesPerTuple; }
+
+    ft_col_offset_t getColOffset(ft_col_idx_t idx) const { return colOffsets[idx]; }
+
+    void setMayContainsNullsToTrue(ft_col_idx_t idx) {
+        KU_ASSERT(idx < columns.size());
+        columns[idx].setMayContainsNullsToTrue();
+    }
+
+    bool isEmpty() const { return columns.empty(); }
+
+    bool operator==(const FactorizedTableSchema& other) const;
+    bool operator!=(const FactorizedTableSchema& other) const { return !(*this == other); }
+
+    uint64_t getNumFlatColumns() const;
+    uint64_t getNumUnFlatColumns() const;
+
+private:
+    FactorizedTableSchema(const FactorizedTableSchema& other);
+
+private:
+    std::vector<ColumnSchema> columns;
+    uint32_t numBytesForDataPerTuple = 0;
+    uint32_t numBytesForNullMapPerTuple = 0;
+    uint32_t numBytesPerTuple = 0;
+    std::vector<ft_col_offset_t> colOffsets;
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/include/processor/result/factorized_table_util.h
+++ b/src/include/processor/result/factorized_table_util.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "factorized_table.h"
+#include "planner/operator/schema.h"
+
+namespace kuzu {
+namespace processor {
+
+class FactorizedTableUtils {
+public:
+    static FactorizedTableSchema createFTableSchema(const binder::expression_vector& exprs,
+        const planner::Schema& schema);
+    static FactorizedTableSchema createFlatTableSchema(
+        std::vector<common::LogicalType> columnTypes);
+
+    // TODO(Ziyi): These two functions are used to store the copy message in a factorizedTable
+    // because the current QueryProcessor::execute requires the last operator in the physical plan
+    // must be ResultCollector. We should remove this class after we remove the assumption that the
+    // last operator in the pipeline must be resultCollector.
+    static void appendStringToTable(FactorizedTable* factorizedTable, std::string& outputMsg,
+        storage::MemoryManager* memoryManager);
+    static std::shared_ptr<FactorizedTable> getFactorizedTableForOutputMsg(std::string& outputMsg,
+        storage::MemoryManager* memoryManager);
+    static std::shared_ptr<FactorizedTable> getSingleStringColumnFTable(storage::MemoryManager* mm);
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/include/processor/result/mark_hash_table.h
+++ b/src/include/processor/result/mark_hash_table.h
@@ -9,7 +9,7 @@ class MarkHashTable : public AggregateHashTable {
 public:
     MarkHashTable(storage::MemoryManager& memoryManager, std::vector<common::LogicalType> keyTypes,
         std::vector<common::LogicalType> payloadTypes, uint64_t numEntriesToAllocate,
-        std::unique_ptr<FactorizedTableSchema> tableSchema);
+        FactorizedTableSchema tableSchema);
 
     uint64_t matchFTEntries(const std::vector<common::ValueVector*>& flatKeyVectors,
         const std::vector<common::ValueVector*>& unFlatKeyVectors, uint64_t numMayMatches,

--- a/src/processor/map/create_result_collector.cpp
+++ b/src/processor/map/create_result_collector.cpp
@@ -1,9 +1,11 @@
 #include "binder/expression/expression_util.h"
 #include "processor/operator/result_collector.h"
 #include "processor/plan_mapper.h"
+#include "processor/result/factorized_table_util.h"
 
 using namespace kuzu::common;
 using namespace kuzu::planner;
+using namespace kuzu::binder;
 
 namespace kuzu {
 namespace processor {
@@ -12,27 +14,17 @@ std::unique_ptr<ResultCollector> PlanMapper::createResultCollector(AccumulateTyp
     const binder::expression_vector& expressions, Schema* schema,
     std::unique_ptr<PhysicalOperator> prevOperator) {
     std::vector<DataPos> payloadsPos;
-    auto tableSchema = std::make_unique<FactorizedTableSchema>();
-    for (auto& expression : expressions) {
-        auto dataPos = DataPos(schema->getExpressionPos(*expression));
-        std::unique_ptr<ColumnSchema> columnSchema;
-        if (schema->getGroup(dataPos.dataChunkPos)->isFlat()) {
-            columnSchema = std::make_unique<ColumnSchema>(false /* isUnFlat */,
-                dataPos.dataChunkPos, LogicalTypeUtils::getRowLayoutSize(expression->dataType));
-        } else {
-            columnSchema = std::make_unique<ColumnSchema>(true /* isUnFlat */, dataPos.dataChunkPos,
-                (uint32_t)sizeof(overflow_value_t));
-        }
-        tableSchema->appendColumn(std::move(columnSchema));
-        payloadsPos.push_back(dataPos);
+    for (auto& e : expressions) {
+        payloadsPos.push_back(getDataPos(*e, *schema));
     }
+    auto tableSchema = FactorizedTableUtils::createFTableSchema(expressions, *schema);
     if (accumulateType == AccumulateType::OPTIONAL_) {
-        auto columnSchema = std::make_unique<ColumnSchema>(false /* isUnFlat */,
-            INVALID_DATA_CHUNK_POS, LogicalTypeUtils::getRowLayoutSize(*LogicalType::BOOL()));
-        tableSchema->appendColumn(std::move(columnSchema));
+        auto columnSchema = ColumnSchema(false /* isUnFlat */, INVALID_DATA_CHUNK_POS,
+            LogicalTypeUtils::getRowLayoutSize(*LogicalType::BOOL()));
+        tableSchema.appendColumn(std::move(columnSchema));
     }
     auto table =
-        std::make_shared<FactorizedTable>(clientContext->getMemoryManager(), tableSchema->copy());
+        std::make_shared<FactorizedTable>(clientContext->getMemoryManager(), tableSchema.copy());
     auto sharedState = std::make_shared<ResultCollectorSharedState>(std::move(table));
     auto info =
         std::make_unique<ResultCollectorInfo>(accumulateType, std::move(tableSchema), payloadsPos);

--- a/src/processor/map/map_dummy_scan.cpp
+++ b/src/processor/map/map_dummy_scan.cpp
@@ -10,13 +10,13 @@ namespace processor {
 std::unique_ptr<PhysicalOperator> PlanMapper::mapDummyScan(LogicalOperator* /*logicalOperator*/) {
     auto inSchema = std::make_unique<Schema>();
     auto expression = LogicalDummyScan::getDummyExpression();
-    auto tableSchema = std::make_unique<FactorizedTableSchema>();
+    auto tableSchema = FactorizedTableSchema();
     // TODO(Ziyi): remove vectors when we have done the refactor of dataChunk.
     std::vector<std::shared_ptr<ValueVector>> vectors;
     std::vector<ValueVector*> vectorsToAppend;
-    tableSchema->appendColumn(
-        std::make_unique<ColumnSchema>(false, 0 /* all expressions are in the same datachunk */,
-            LogicalTypeUtils::getRowLayoutSize(expression->dataType)));
+    auto columnSchema = ColumnSchema(false, 0 /* groupID */,
+        LogicalTypeUtils::getRowLayoutSize(expression->dataType));
+    tableSchema.appendColumn(std::move(columnSchema));
     auto expressionEvaluator = ExpressionMapper::getEvaluator(expression, inSchema.get());
     auto memoryManager = clientContext->getMemoryManager();
     // expression can be evaluated statically and does not require an actual resultset to init

--- a/src/processor/map/map_explain.cpp
+++ b/src/processor/map/map_explain.cpp
@@ -3,6 +3,7 @@
 #include "planner/operator/logical_explain.h"
 #include "processor/operator/profile.h"
 #include "processor/plan_mapper.h"
+#include "processor/result/factorized_table_util.h"
 
 using namespace kuzu::common;
 using namespace kuzu::planner;

--- a/src/processor/map/plan_mapper.cpp
+++ b/src/processor/map/plan_mapper.cpp
@@ -202,14 +202,5 @@ std::vector<DataPos> PlanMapper::getDataPos(const binder::expression_vector& exp
     return result;
 }
 
-std::shared_ptr<FactorizedTable> PlanMapper::getSingleStringColumnFTable() const {
-    auto ftTableSchema = std::make_unique<FactorizedTableSchema>();
-    ftTableSchema->appendColumn(
-        std::make_unique<ColumnSchema>(false /* flat */, 0 /* dataChunkPos */,
-            LogicalTypeUtils::getRowLayoutSize(LogicalType{LogicalTypeID::STRING})));
-    return std::make_shared<FactorizedTable>(clientContext->getMemoryManager(),
-        std::move(ftTableSchema));
-}
-
 } // namespace processor
 } // namespace kuzu

--- a/src/processor/operator/aggregate/hash_aggregate.cpp
+++ b/src/processor/operator/aggregate/hash_aggregate.cpp
@@ -52,14 +52,14 @@ std::pair<uint64_t, uint64_t> HashAggregateSharedState::getNextRangeToRead() {
 
 HashAggregateInfo::HashAggregateInfo(std::vector<DataPos> flatKeysPos,
     std::vector<DataPos> unFlatKeysPos, std::vector<DataPos> dependentKeysPos,
-    std::unique_ptr<FactorizedTableSchema> tableSchema, HashTableType hashTableType)
+    FactorizedTableSchema tableSchema, HashTableType hashTableType)
     : flatKeysPos{std::move(flatKeysPos)}, unFlatKeysPos{std::move(unFlatKeysPos)},
       dependentKeysPos{std::move(dependentKeysPos)}, tableSchema{std::move(tableSchema)},
       hashTableType{hashTableType} {}
 
 HashAggregateInfo::HashAggregateInfo(const HashAggregateInfo& other)
     : flatKeysPos{other.flatKeysPos}, unFlatKeysPos{other.unFlatKeysPos},
-      dependentKeysPos{other.dependentKeysPos}, tableSchema{other.tableSchema->copy()},
+      dependentKeysPos{other.dependentKeysPos}, tableSchema{other.tableSchema.copy()},
       hashTableType{other.hashTableType} {}
 
 void HashAggregateLocalState::init(ResultSet& resultSet, main::ClientContext* context,

--- a/src/processor/operator/hash_join/hash_join_build.cpp
+++ b/src/processor/operator/hash_join/hash_join_build.cpp
@@ -28,7 +28,7 @@ void HashJoinBuild::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
         payloadVectors.push_back(resultSet->getValueVector(pos).get());
     }
     hashTable = std::make_unique<JoinHashTable>(*context->clientContext->getMemoryManager(),
-        std::move(keyTypes), info->tableSchema->copy());
+        std::move(keyTypes), info->tableSchema.copy());
 }
 
 void HashJoinBuild::setKeyState(common::DataChunkState* state) {

--- a/src/processor/operator/hash_join/join_hash_table.cpp
+++ b/src/processor/operator/hash_join/join_hash_table.cpp
@@ -11,12 +11,12 @@ namespace kuzu {
 namespace processor {
 
 JoinHashTable::JoinHashTable(MemoryManager& memoryManager, logical_type_vec_t keyTypes,
-    std::unique_ptr<FactorizedTableSchema> tableSchema)
+    FactorizedTableSchema tableSchema)
     : BaseHashTable{memoryManager, std::move(keyTypes)} {
     auto numSlotsPerBlock = HASH_BLOCK_SIZE / sizeof(uint8_t*);
     initSlotConstant(numSlotsPerBlock);
     // Prev pointer is always the last column in the table.
-    prevPtrColOffset = tableSchema->getColOffset(tableSchema->getNumColumns() - PREV_PTR_COL_IDX);
+    prevPtrColOffset = tableSchema.getColOffset(tableSchema.getNumColumns() - PREV_PTR_COL_IDX);
     factorizedTable = std::make_unique<FactorizedTable>(&memoryManager, std::move(tableSchema));
     this->tableSchema = factorizedTable->getTableSchema();
 }

--- a/src/processor/operator/order_by/sort_state.cpp
+++ b/src/processor/operator/order_by/sort_state.cpp
@@ -13,7 +13,7 @@ void SortSharedState::init(const OrderByDataInfo& orderByDataInfo) {
             // If this is a string column, we need to find the factorizedTable offset for this
             // column.
             auto ftColIdx = orderByDataInfo.keyInPayloadPos[i];
-            strKeyColsInfo.emplace_back(orderByDataInfo.payloadTableSchema->getColOffset(ftColIdx),
+            strKeyColsInfo.emplace_back(orderByDataInfo.payloadTableSchema.getColOffset(ftColIdx),
                 encodedKeyBlockColOffset, orderByDataInfo.isAscOrder[i]);
         }
         encodedKeyBlockColOffset += OrderByKeyEncoder::getEncodingSize(*dataType);
@@ -55,7 +55,7 @@ std::vector<FactorizedTable*> SortSharedState::getPayloadTables() const {
 void SortLocalState::init(const OrderByDataInfo& orderByDataInfo, SortSharedState& sharedState,
     storage::MemoryManager* memoryManager) {
     auto [idx, table] =
-        sharedState.getLocalPayloadTable(*memoryManager, *orderByDataInfo.payloadTableSchema);
+        sharedState.getLocalPayloadTable(*memoryManager, orderByDataInfo.payloadTableSchema);
     globalIdx = idx;
     payloadTable = table;
     orderByKeyEncoder = std::make_unique<OrderByKeyEncoder>(orderByDataInfo, memoryManager,

--- a/src/processor/operator/order_by/top_k.cpp
+++ b/src/processor/operator/order_by/top_k.cpp
@@ -107,7 +107,7 @@ void TopKBuffer::initVectors() {
         auto type = orderByDataInfo->payloadTypes[i].get();
         auto payloadVec = std::make_unique<common::ValueVector>(*type, memoryManager);
         auto lastPayloadVec = std::make_unique<common::ValueVector>(*type, memoryManager);
-        if (orderByDataInfo->payloadTableSchema->getColumn(i)->isFlat()) {
+        if (orderByDataInfo->payloadTableSchema.getColumn(i)->isFlat()) {
             payloadVec->setState(payloadFlatState);
             lastPayloadVec->setState(lastPayloadFlatState);
         } else {

--- a/src/processor/operator/persistent/copy_rdf.cpp
+++ b/src/processor/operator/persistent/copy_rdf.cpp
@@ -1,7 +1,7 @@
 #include "processor/operator/persistent/copy_rdf.h"
 
 #include "common/string_format.h"
-#include "processor/result/factorized_table.h"
+#include "processor/result/factorized_table_util.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/processor/operator/persistent/copy_to_parquet.cpp
+++ b/src/processor/operator/persistent/copy_to_parquet.cpp
@@ -9,7 +9,7 @@ using namespace kuzu::storage;
 void CopyToParquetLocalState::init(CopyToInfo* info, storage::MemoryManager* mm,
     ResultSet* resultSet) {
     auto copyToInfo = info->constPtrCast<CopyToParquetInfo>();
-    ft = std::make_unique<FactorizedTable>(mm, copyToInfo->tableSchema->copy());
+    ft = std::make_unique<FactorizedTable>(mm, copyToInfo->tableSchema.copy());
     numTuplesInFT = 0;
     countingVec = nullptr;
     vectorsToAppend.reserve(info->dataPoses.size());

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -9,6 +9,7 @@
 #include "processor/execution_context.h"
 #include "processor/operator/persistent/index_builder.h"
 #include "processor/result/factorized_table.h"
+#include "processor/result/factorized_table_util.h"
 #include "storage/local_storage/local_node_table.h"
 #include "storage/store/chunked_node_group.h"
 #include "storage/store/node_table.h"

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -3,7 +3,7 @@
 #include "common/exception/copy.h"
 #include "common/exception/message.h"
 #include "common/string_format.h"
-#include "processor/result/factorized_table.h"
+#include "processor/result/factorized_table_util.h"
 #include "storage/local_storage/local_rel_table.h"
 #include "storage/store/column_chunk.h"
 #include "storage/store/rel_table.h"

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -184,7 +184,7 @@ void ParquetWriter::prepareRowGroup(FactorizedTable& ft, PreparedRowGroup& resul
     KU_ASSERT(ft.getTableSchema()->getNumColumns() == columnWriters.size());
     std::vector<std::unique_ptr<ColumnWriterState>> writerStates;
     std::unique_ptr<DataChunk> unflatDataChunkToRead =
-        std::make_unique<DataChunk>(ft.getTableSchema()->getNumUnflatColumns());
+        std::make_unique<DataChunk>(ft.getTableSchema()->getNumUnFlatColumns());
     std::unique_ptr<DataChunk> flatDataChunkToRead = std::make_unique<DataChunk>(
         ft.getTableSchema()->getNumFlatColumns(), DataChunkState::getSingleValueDataChunkState());
     std::vector<ValueVector*> vectorsToRead;
@@ -266,7 +266,7 @@ void ParquetWriter::flushRowGroup(PreparedRowGroup& rowGroup) {
 void ParquetWriter::readFromFT(FactorizedTable& ft, std::vector<ValueVector*> vectorsToRead,
     uint64_t& numTuplesRead) {
     auto numTuplesToRead =
-        ft.getTableSchema()->getNumUnflatColumns() != 0 ?
+        ft.getTableSchema()->getNumUnFlatColumns() != 0 ?
             1 :
             std::min<uint64_t>(ft.getNumTuples() - numTuplesRead, DEFAULT_VECTOR_CAPACITY);
     ft.scan(vectorsToRead, numTuplesRead, numTuplesToRead);

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -21,7 +21,7 @@ void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
         payloadAndMarkVectors.push_back(markVector.get());
     }
     localTable = std::make_unique<FactorizedTable>(context->clientContext->getMemoryManager(),
-        info->tableSchema->copy());
+        info->tableSchema.copy());
 }
 
 void ResultCollector::executeInternal(ExecutionContext* context) {

--- a/src/processor/result/CMakeLists.txt
+++ b/src/processor/result/CMakeLists.txt
@@ -2,6 +2,8 @@ add_library(kuzu_processor_result
         OBJECT
         base_hash_table.cpp
         factorized_table.cpp
+        factorized_table_schema.cpp
+        factorized_table_util.cpp
         flat_tuple.cpp
         mark_hash_table.cpp
         result_set.cpp

--- a/src/processor/result/factorized_table_schema.cpp
+++ b/src/processor/result/factorized_table_schema.cpp
@@ -1,0 +1,66 @@
+#include "processor/result/factorized_table_schema.h"
+
+#include "common/null_buffer.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace processor {
+
+ColumnSchema::ColumnSchema(const ColumnSchema& other) {
+    isUnFlat = other.isUnFlat;
+    groupID = other.groupID;
+    numBytes = other.numBytes;
+    mayContainNulls = other.mayContainNulls;
+}
+
+FactorizedTableSchema::FactorizedTableSchema(const FactorizedTableSchema& other) {
+    for (auto i = 0u; i < other.columns.size(); ++i) {
+        appendColumn(other.columns[i].copy());
+    }
+}
+
+void FactorizedTableSchema::appendColumn(ColumnSchema column) {
+    numBytesForDataPerTuple += column.getNumBytes();
+    columns.push_back(std::move(column));
+    colOffsets.push_back(
+        colOffsets.empty() ? 0 : colOffsets.back() + getColumn(columns.size() - 2)->getNumBytes());
+    numBytesForNullMapPerTuple = NullBuffer::getNumBytesForNullValues(getNumColumns());
+    numBytesPerTuple = numBytesForDataPerTuple + numBytesForNullMapPerTuple;
+}
+
+bool FactorizedTableSchema::operator==(const FactorizedTableSchema& other) const {
+    if (columns.size() != other.columns.size()) {
+        return false;
+    }
+    for (auto i = 0u; i < columns.size(); i++) {
+        if (columns[i] != other.columns[i]) {
+            return false;
+        }
+    }
+    return numBytesForDataPerTuple == other.numBytesForDataPerTuple && numBytesForNullMapPerTuple &&
+           other.numBytesForNullMapPerTuple;
+}
+
+uint64_t FactorizedTableSchema::getNumFlatColumns() const {
+    auto numFlatColumns = 0u;
+    for (auto& column : columns) {
+        if (column.isFlat()) {
+            numFlatColumns++;
+        }
+    }
+    return numFlatColumns;
+}
+
+uint64_t FactorizedTableSchema::getNumUnFlatColumns() const {
+    auto numUnflatColumns = 0u;
+    for (auto& column : columns) {
+        if (!column.isFlat()) {
+            numUnflatColumns++;
+        }
+    }
+    return numUnflatColumns;
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/result/factorized_table_util.cpp
+++ b/src/processor/result/factorized_table_util.cpp
@@ -1,0 +1,68 @@
+#include "processor/result/factorized_table_util.h"
+
+using namespace kuzu::storage;
+using namespace kuzu::common;
+using namespace kuzu::binder;
+using namespace kuzu::planner;
+
+namespace kuzu {
+namespace processor {
+
+FactorizedTableSchema FactorizedTableUtils::createFTableSchema(const expression_vector& exprs,
+    const Schema& schema) {
+    auto tableSchema = FactorizedTableSchema();
+    std::unordered_set<common::idx_t> groupIDSet;
+    for (auto& e : exprs) {
+        auto groupPos = schema.getExpressionPos(*e).first;
+        auto group = schema.getGroup(groupPos);
+        if (group->isFlat()) {
+            auto column =
+                ColumnSchema(false, groupPos, LogicalTypeUtils::getRowLayoutSize(e->getDataType()));
+            tableSchema.appendColumn(std::move(column));
+        } else {
+            auto column = ColumnSchema(true, groupPos, (uint32_t)sizeof(overflow_value_t));
+            tableSchema.appendColumn(std::move(column));
+        }
+    }
+    return tableSchema;
+}
+
+FactorizedTableSchema FactorizedTableUtils::createFlatTableSchema(
+    std::vector<LogicalType> columnTypes) {
+    auto tableSchema = FactorizedTableSchema();
+    for (auto& type : columnTypes) {
+        auto column = ColumnSchema(false /* isUnFlat */, 0 /* groupID */,
+            LogicalTypeUtils::getRowLayoutSize(type));
+        tableSchema.appendColumn(std::move(column));
+    }
+    return tableSchema;
+}
+
+void FactorizedTableUtils::appendStringToTable(FactorizedTable* factorizedTable,
+    std::string& outputMsg, MemoryManager* memoryManager) {
+    auto outputMsgVector = std::make_shared<ValueVector>(LogicalTypeID::STRING, memoryManager);
+    outputMsgVector->state = DataChunkState::getSingleValueDataChunkState();
+    auto outputKUStr = ku_string_t();
+    outputKUStr.overflowPtr =
+        reinterpret_cast<uint64_t>(StringVector::getInMemOverflowBuffer(outputMsgVector.get())
+                                       ->allocateSpace(outputMsg.length()));
+    outputKUStr.set(outputMsg);
+    outputMsgVector->setValue(0, outputKUStr);
+    factorizedTable->append(std::vector<ValueVector*>{outputMsgVector.get()});
+}
+
+std::shared_ptr<FactorizedTable> FactorizedTableUtils::getFactorizedTableForOutputMsg(
+    std::string& outputMsg, MemoryManager* memoryManager) {
+    auto table = getSingleStringColumnFTable(memoryManager);
+    appendStringToTable(table.get(), outputMsg, memoryManager);
+    return table;
+}
+
+std::shared_ptr<FactorizedTable> FactorizedTableUtils::getSingleStringColumnFTable(
+    MemoryManager* mm) {
+    auto fTableSchema = createFlatTableSchema(std::vector<LogicalType>{*LogicalType::STRING()});
+    return std::make_shared<FactorizedTable>(mm, std::move(fTableSchema));
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/result/mark_hash_table.cpp
+++ b/src/processor/result/mark_hash_table.cpp
@@ -5,7 +5,7 @@ namespace processor {
 
 MarkHashTable::MarkHashTable(storage::MemoryManager& memoryManager,
     std::vector<common::LogicalType> keyTypes, std::vector<common::LogicalType> payloadTypes,
-    uint64_t numEntriesToAllocate, std::unique_ptr<FactorizedTableSchema> tableSchema)
+    uint64_t numEntriesToAllocate, FactorizedTableSchema tableSchema)
     : AggregateHashTable(memoryManager, std::move(keyTypes), std::move(payloadTypes),
           std::vector<std::unique_ptr<function::AggregateFunction>>{} /* empty aggregates */,
           std::vector<common::LogicalType>{} /* empty distinct agg key*/, numEntriesToAllocate,


### PR DESCRIPTION
- Split `FTableSchema`, `FactorizedTableUtils` into their own files.
- Move `dataChunkPos` out of `ColumnSchema`. The previous design simply doesn't make sense. We now maintain this information at `FTableSchema`. The high level idea is that `FTableSchema` contains multiple `ColumnSchema` and also multiple `Group`. Each `ColumnSchema` belongs to one `Group`. If multiple `ColumnSchema` belongs to the same `Group` then they must share the same `Group` metadata, i.e. flat information. There is still more work to do, for example we should make `GroupID` consecutive instead of using `DataChunkPos`. But this needs to be done progressively.
- Remove unnecessary unique_ptr
- Protect implicit copy with EXPLICIT_COPY macro.