### PR TITLE
Merge the HashIndex bulkstorage with the local storage for inserts

### DIFF
--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -107,7 +107,7 @@ private:
                                                  oSlots->update(slotInfo.slotId, slot);
     }
 
-    inline Slot<T> getSlot(transaction::TransactionType trxType, const SlotInfo& slotInfo) {
+    inline Slot<T> getSlot(transaction::TransactionType trxType, const SlotInfo& slotInfo) const {
         return slotInfo.slotType == SlotType::PRIMARY ? pSlots->get(slotInfo.slotId, trxType) :
                                                         oSlots->get(slotInfo.slotId, trxType);
     }
@@ -119,9 +119,7 @@ private:
     void splitSlots(HashIndexHeader& header, slot_id_t numSlotsToSplit);
 
     // Resizes the local storage to support the given number of new entries
-    inline void bulkReserve(uint64_t newEntries) override {
-        bulkInsertLocalStorage.reserve(newEntries);
-    }
+    void bulkReserve(uint64_t newEntries) override;
     // Resizes the on-disk index to support the given number of new entries
     void reserve(uint64_t newEntries);
 
@@ -131,9 +129,10 @@ private:
         const SlotEntry<T>* entry;
     };
 
-    void sortEntries(typename InMemHashIndex<T>::SlotIterator& slotToMerge,
+    void sortEntries(const InMemHashIndex<T>& insertLocalStorage,
+        typename InMemHashIndex<T>::SlotIterator& slotToMerge,
         std::vector<HashIndexEntryView>& partitions);
-    void mergeBulkInserts();
+    void mergeBulkInserts(const InMemHashIndex<T>& insertLocalStorage);
     // Returns the number of elements merged which matched the given slot id
     size_t mergeSlot(const std::vector<HashIndexEntryView>& slotToMerge,
         typename BaseDiskArray<Slot<T>>::WriteIterator& diskSlotIterator,
@@ -172,7 +171,7 @@ private:
             getSlot(trxType, SlotInfo{slotId, SlotType::PRIMARY})};
     }
 
-    bool nextChainedSlot(transaction::TransactionType trxType, SlotIterator& iter) {
+    bool nextChainedSlot(transaction::TransactionType trxType, SlotIterator& iter) const {
         KU_ASSERT(iter.slotInfo.slotType == SlotType::PRIMARY ||
                   iter.slotInfo.slotId != iter.slot.header.nextOvfSlotId);
         if (iter.slot.header.nextOvfSlotId != 0) {
@@ -219,8 +218,7 @@ private:
     std::unique_ptr<BaseDiskArray<Slot<T>>> pSlots;
     std::unique_ptr<BaseDiskArray<Slot<T>>> oSlots;
     OverflowFileHandle* overflowFileHandle;
-    std::unique_ptr<HashIndexLocalStorage<BufferKeyType>> localStorage;
-    InMemHashIndex<T> bulkInsertLocalStorage;
+    std::unique_ptr<HashIndexLocalStorage<T>> localStorage;
     std::unique_ptr<HashIndexHeader> indexHeaderForReadTrx;
     std::unique_ptr<HashIndexHeader> indexHeaderForWriteTrx;
 };

--- a/src/include/storage/index/in_mem_hash_index.h
+++ b/src/include/storage/index/in_mem_hash_index.h
@@ -72,26 +72,31 @@ public:
 
     using BufferKeyType =
         typename std::conditional<std::same_as<T, common::ku_string_t>, std::string, T>::type;
+    using Key =
+        typename std::conditional<std::same_as<T, common::ku_string_t>, std::string_view, T>::type;
     // Appends the buffer to the index. Returns the number of values successfully inserted.
     // I.e. if a key fails to insert, its index will be the return value
     size_t append(const IndexBuffer<BufferKeyType>& buffer);
-    using Key =
-        typename std::conditional<std::same_as<T, common::ku_string_t>, std::string_view, T>::type;
+    inline bool append(Key key, common::offset_t value) {
+        reserve(indexHeader.numEntries + 1);
+        return appendInternal(key, value, HashIndexUtils::hash(key));
+    }
     bool lookup(Key key, common::offset_t& result);
 
-    uint64_t size() { return this->indexHeader.numEntries; }
+    uint64_t size() const { return this->indexHeader.numEntries; }
+    bool empty() const { return size() == 0; }
 
     void clear();
 
     struct SlotIterator {
-        explicit SlotIterator(slot_id_t newSlotId, InMemHashIndex<T>* builder)
+        explicit SlotIterator(slot_id_t newSlotId, const InMemHashIndex<T>* builder)
             : slotInfo{newSlotId, SlotType::PRIMARY}, slot(builder->getSlot(slotInfo)) {}
         SlotInfo slotInfo;
         Slot<T>* slot;
     };
 
     // Leaves the slot pointer pointing at the last slot to make it easier to add a new one
-    inline bool nextChainedSlot(SlotIterator& iter) {
+    inline bool nextChainedSlot(SlotIterator& iter) const {
         iter.slotInfo.slotId = iter.slot->header.nextOvfSlotId;
         iter.slotInfo.slotType = SlotType::OVF;
         if (iter.slot->header.nextOvfSlotId != 0) {
@@ -104,12 +109,16 @@ public:
     inline uint64_t numPrimarySlots() const { return pSlots->size(); }
     inline uint64_t numOverflowSlots() const { return oSlots->size(); }
 
-    inline HashIndexHeader getIndexHeader() { return indexHeader; }
+    inline const HashIndexHeader& getIndexHeader() const { return indexHeader; }
+
+    // Deletes key, maintaining gapless structure by replacing it with the last entry in the
+    // slot
+    bool deleteKey(Key key);
 
 private:
     // Assumes that space has already been allocated for the entry
     bool appendInternal(Key key, common::offset_t value, common::hash_t hash);
-    Slot<T>* getSlot(const SlotInfo& slotInfo);
+    Slot<T>* getSlot(const SlotInfo& slotInfo) const;
 
     uint32_t allocatePSlots(uint32_t numSlotsToAllocate);
     uint32_t allocateAOSlot();


### PR DESCRIPTION
I did some quick benchmarks of single tuple copies and inserts into an empty and non-empty table and this doesn't appear to make the performance any worse.

It was necessary to make the InMemHashIndex support deleting keys, which maintains the lack of gaps in the in-memory hash index by swapping deleted entries with the last entry.