### PR TITLE
Python UDF and C++ UDF improvements

### DIFF
--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -276,6 +276,13 @@ void Catalog::addFunction(transaction::Transaction* transaction, CatalogEntryTyp
         std::make_unique<FunctionCatalogEntry>(entryType, std::move(name), std::move(functionSet)));
 }
 
+void Catalog::removeFunction(transaction::Transaction* transaction, std::string name) {
+    if (!functions->containsEntry(transaction, name)) {
+        throw CatalogException{common::stringFormat("function {} doesn't exist.", name)};
+    }
+    functions->dropEntry(transaction, std::move(name));
+}
+
 void Catalog::addBuiltInFunction(CatalogEntryType entryType, std::string name,
     function::function_set functionSet) {
     addFunction(&DUMMY_WRITE_TRANSACTION, entryType, std::move(name), std::move(functionSet));

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -276,11 +276,11 @@ void Catalog::addFunction(transaction::Transaction* transaction, CatalogEntryTyp
         std::make_unique<FunctionCatalogEntry>(entryType, std::move(name), std::move(functionSet)));
 }
 
-void Catalog::removeFunction(transaction::Transaction* transaction, const std::string& name) {
-    if (!functions->containsEntry(transaction, name)) {
+void Catalog::dropFunction(transaction::Transaction* tx, const std::string& name) {
+    if (!functions->containsEntry(tx, name)) {
         throw CatalogException{common::stringFormat("function {} doesn't exist.", name)};
     }
-    functions->dropEntry(transaction, std::move(name));
+    functions->dropEntry(tx, std::move(name));
 }
 
 void Catalog::addBuiltInFunction(CatalogEntryType entryType, std::string name,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -276,7 +276,7 @@ void Catalog::addFunction(transaction::Transaction* transaction, CatalogEntryTyp
         std::make_unique<FunctionCatalogEntry>(entryType, std::move(name), std::move(functionSet)));
 }
 
-void Catalog::removeFunction(transaction::Transaction* transaction, std::string name) {
+void Catalog::removeFunction(transaction::Transaction* transaction, const std::string& name) {
     if (!functions->containsEntry(transaction, name)) {
         throw CatalogException{common::stringFormat("function {} doesn't exist.", name)};
     }

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -89,6 +89,7 @@ public:
     // ----------------------------- Functions ----------------------------
     void addFunction(transaction::Transaction* tx, CatalogEntryType entryType, std::string name,
         function::function_set functionSet);
+    void removeFunction(transaction::Transaction* tx, std::string name);
     void addBuiltInFunction(CatalogEntryType entryType, std::string name,
         function::function_set functionSet);
     CatalogSet* getFunctions(transaction::Transaction* tx) const;

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -89,7 +89,7 @@ public:
     // ----------------------------- Functions ----------------------------
     void addFunction(transaction::Transaction* tx, CatalogEntryType entryType, std::string name,
         function::function_set functionSet);
-    void removeFunction(transaction::Transaction* tx, std::string name);
+    void removeFunction(transaction::Transaction* tx, const std::string& name);
     void addBuiltInFunction(CatalogEntryType entryType, std::string name,
         function::function_set functionSet);
     CatalogSet* getFunctions(transaction::Transaction* tx) const;

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -89,7 +89,7 @@ public:
     // ----------------------------- Functions ----------------------------
     void addFunction(transaction::Transaction* tx, CatalogEntryType entryType, std::string name,
         function::function_set functionSet);
-    void removeFunction(transaction::Transaction* tx, const std::string& name);
+    void dropFunction(transaction::Transaction* tx, const std::string& name);
     void addBuiltInFunction(CatalogEntryType entryType, std::string name,
         function::function_set functionSet);
     CatalogSet* getFunctions(transaction::Transaction* tx) const;

--- a/src/include/function/udf_function.h
+++ b/src/include/function/udf_function.h
@@ -88,7 +88,8 @@ struct UDF {
     template<typename RESULT_TYPE>
     static function::scalar_func_exec_t createEmptyParameterExecFunc(RESULT_TYPE (*udfFunc)(),
         const std::vector<common::LogicalTypeID>&) {
-        return [=](const std::vector<std::shared_ptr<common::ValueVector>>& params,
+        (void*)(udfFunc); // Disable compiler warnings.
+        return [udfFunc](const std::vector<std::shared_ptr<common::ValueVector>>& params,
                    common::ValueVector& result, void* /*dataPtr*/ = nullptr) -> void {
             KU_ASSERT(params.size() == 0);
             auto& resultSelVector = result.state->getSelVector();

--- a/src/include/function/udf_function.h
+++ b/src/include/function/udf_function.h
@@ -80,6 +80,26 @@ struct UDF {
     }
 
     template<typename RESULT_TYPE, typename... Args>
+    static function::scalar_func_exec_t createEmptyParameterExecFunc(RESULT_TYPE (*)(Args...),
+        const std::vector<common::LogicalTypeID>&) {
+        KU_UNREACHABLE;
+    }
+
+    template<typename RESULT_TYPE>
+    static function::scalar_func_exec_t createEmptyParameterExecFunc(RESULT_TYPE (*udfFunc)(),
+        const std::vector<common::LogicalTypeID>&) {
+        return [=](const std::vector<std::shared_ptr<common::ValueVector>>& params,
+                   common::ValueVector& result, void* /*dataPtr*/ = nullptr) -> void {
+            KU_ASSERT(params.size() == 0);
+            auto& resultSelVector = result.state->getSelVector();
+            for (auto i = 0u; i < resultSelVector.getSelSize(); ++i) {
+                auto resultPos = resultSelVector[i];
+                result.copyFromValue(resultPos, common::Value(udfFunc()));
+            }
+        };
+    }
+
+    template<typename RESULT_TYPE, typename... Args>
     static function::scalar_func_exec_t createUnaryExecFunc(RESULT_TYPE (* /*udfFunc*/)(Args...),
         const std::vector<common::LogicalTypeID>& /*parameterTypes*/) {
         KU_UNREACHABLE;
@@ -164,6 +184,8 @@ struct UDF {
         std::vector<common::LogicalTypeID> parameterTypes) {
         constexpr auto numArgs = sizeof...(Args);
         switch (numArgs) {
+        case 0:
+            return createEmptyParameterExecFunc<TR, Args...>(udfFunc, std::move(parameterTypes));
         case 1:
             return createUnaryExecFunc<TR, Args...>(udfFunc, std::move(parameterTypes));
         case 2:
@@ -210,7 +232,9 @@ struct UDF {
     template<typename... Args>
     static std::vector<common::LogicalTypeID> getParameterTypes() {
         std::vector<common::LogicalTypeID> parameterTypes;
-        getParameterTypesRecursive<Args...>(parameterTypes);
+        if constexpr (sizeof...(Args) > 0) {
+            getParameterTypesRecursive<Args...>(parameterTypes);
+        }
         return parameterTypes;
     }
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -158,6 +158,7 @@ private:
     std::unique_ptr<QueryResult> executeAndAutoCommitIfNecessaryNoLock(
         PreparedStatement* preparedStatement, uint32_t planIdx = 0u, bool requiredNexTx = true);
 
+    void runFunctionInTransaction(const std::function<void(void)>& fun);
     void addScalarFunction(std::string name, function::function_set definitions);
     void removeScalarFunction(std::string name);
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -158,7 +158,7 @@ private:
     std::unique_ptr<QueryResult> executeAndAutoCommitIfNecessaryNoLock(
         PreparedStatement* preparedStatement, uint32_t planIdx = 0u, bool requiredNexTx = true);
 
-    void runFunctionInTransaction(const std::function<void(void)>& fun);
+    void runFuncInTransaction(const std::function<void(void)>& fun);
     void addScalarFunction(std::string name, function::function_set definitions);
     void removeScalarFunction(std::string name);
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -159,6 +159,7 @@ private:
         PreparedStatement* preparedStatement, uint32_t planIdx = 0u, bool requiredNexTx = true);
 
     void addScalarFunction(std::string name, function::function_set definitions);
+    void removeScalarFunction(std::string name);
 
     bool startUDFAutoTrx(transaction::TransactionContext* trx);
 

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -48,7 +48,8 @@ struct NodeTableUpdateState final : TableUpdateState {
 
     NodeTableUpdateState(common::column_id_t columnID, common::ValueVector& nodeIDVector,
         const common::ValueVector& propertyVector)
-        : TableUpdateState{columnID, propertyVector}, nodeIDVector{nodeIDVector} {}
+        : TableUpdateState{columnID, propertyVector}, nodeIDVector{nodeIDVector},
+          pkVector{nullptr} {}
 };
 
 struct NodeTableDeleteState final : TableDeleteState {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -513,7 +513,7 @@ std::unique_ptr<QueryResult> ClientContext::executeAndAutoCommitIfNecessaryNoLoc
 
 // If there is an active transaction in the context, we execute the function in current active
 // transaction. If there is no active transaction, we start an auto commit transaction.
-void ClientContext::runFunctionInTransaction(const std::function<void(void)>& fun) {
+void ClientContext::runFuncInTransaction(const std::function<void(void)>& fun) {
     // check if we are on AutoCommit. In this case we should start a transaction
     bool startNewTrx = !transactionContext->hasActiveTransaction();
     if (startNewTrx) {
@@ -533,15 +533,14 @@ void ClientContext::runFunctionInTransaction(const std::function<void(void)>& fu
 }
 
 void ClientContext::addScalarFunction(std::string name, function::function_set definitions) {
-    runFunctionInTransaction([&]() {
+    runFuncInTransaction([&]() {
         localDatabase->catalog->addFunction(getTx(), CatalogEntryType::SCALAR_FUNCTION_ENTRY,
             std::move(name), std::move(definitions));
     });
 }
 
 void ClientContext::removeScalarFunction(std::string name) {
-    runFunctionInTransaction(
-        [&]() { localDatabase->catalog->removeFunction(getTx(), std::move(name)); });
+    runFuncInTransaction([&]() { localDatabase->catalog->dropFunction(getTx(), std::move(name)); });
 }
 
 bool ClientContext::canExecuteWriteQuery() {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -517,20 +517,8 @@ void ClientContext::addScalarFunction(std::string name, function::function_set d
         std::move(name), std::move(definitions));
 }
 
-bool ClientContext::startUDFAutoTrx(TransactionContext* trx) {
-    if (!trx->hasActiveTransaction()) {
-        auto res = query("BEGIN TRANSACTION");
-        KU_ASSERT(res->isSuccess());
-        return true;
-    }
-    return false;
-}
-
-void ClientContext::commitUDFTrx(bool isAutoCommitTrx) {
-    if (isAutoCommitTrx) {
-        auto res = query("COMMIT");
-        KU_ASSERT(res->isSuccess());
-    }
+void ClientContext::removeScalarFunction(std::string name) {
+    localDatabase->catalog->removeFunction(getTx(), std::move(name));
 }
 
 bool ClientContext::canExecuteWriteQuery() {

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -425,9 +425,8 @@ std::unique_ptr<QueryResult> ClientContext::executeWithParams(PreparedStatement*
     }
     try {
         bindParametersNoLock(preparedStatement, inputParams);
-    } catch (Exception& exception) {
-        std::string errMsg = exception.what();
-        return queryResultWithError(errMsg);
+    } catch (std::exception& e) {
+        return queryResultWithError(e.what());
     }
     // rebind
     KU_ASSERT(preparedStatement->parsedStatement != nullptr);
@@ -475,9 +474,9 @@ std::unique_ptr<QueryResult> ClientContext::executeAndAutoCommitIfNecessaryNoLoc
             physicalPlan =
                 mapper.mapLogicalPlanToPhysical(preparedStatement->logicalPlans[planIdx].get(),
                     preparedStatement->statementResult->getColumns());
-        } catch (std::exception& exception) {
+        } catch (std::exception& e) {
             this->transactionContext->rollback();
-            return queryResultWithError(exception.what());
+            return queryResultWithError(e.what());
         }
     }
     auto queryResult = std::make_unique<QueryResult>(preparedStatement->preparedSummary);
@@ -501,9 +500,9 @@ std::unique_ptr<QueryResult> ClientContext::executeAndAutoCommitIfNecessaryNoLoc
                     executionContext.get());
             }
         }
-    } catch (Exception& exception) {
-        this->transactionContext->rollback();
-        return queryResultWithError(std::string(exception.what()));
+    } catch (std::exception& e) {
+        transactionContext->rollback();
+        return queryResultWithError(e.what());
     }
     executingTimer.stop();
     queryResult->querySummary->executionTime = executingTimer.getElapsedTimeMS();
@@ -512,13 +511,37 @@ std::unique_ptr<QueryResult> ClientContext::executeAndAutoCommitIfNecessaryNoLoc
     return queryResult;
 }
 
+// If there is an active transaction in the context, we execute the function in current active
+// transaction. If there is no active transaction, we start an auto commit transaction.
+void ClientContext::runFunctionInTransaction(const std::function<void(void)>& fun) {
+    // check if we are on AutoCommit. In this case we should start a transaction
+    bool startNewTrx = !transactionContext->hasActiveTransaction();
+    if (startNewTrx) {
+        transactionContext->beginAutoTransaction(false /* readOnlyStatement */);
+    }
+    try {
+        fun();
+    } catch (std::exception& e) {
+        if (startNewTrx) {
+            transactionContext->rollback();
+        }
+        throw;
+    }
+    if (startNewTrx) {
+        transactionContext->commit();
+    }
+}
+
 void ClientContext::addScalarFunction(std::string name, function::function_set definitions) {
-    localDatabase->catalog->addFunction(getTx(), CatalogEntryType::SCALAR_FUNCTION_ENTRY,
-        std::move(name), std::move(definitions));
+    runFunctionInTransaction([&]() {
+        localDatabase->catalog->addFunction(getTx(), CatalogEntryType::SCALAR_FUNCTION_ENTRY,
+            std::move(name), std::move(definitions));
+    });
 }
 
 void ClientContext::removeScalarFunction(std::string name) {
-    localDatabase->catalog->removeFunction(getTx(), std::move(name));
+    runFunctionInTransaction(
+        [&]() { localDatabase->catalog->removeFunction(getTx(), std::move(name)); });
 }
 
 bool ClientContext::canExecuteWriteQuery() {

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -89,6 +89,10 @@ void Connection::addScalarFunction(std::string name, function::function_set defi
     clientContext->addScalarFunction(name, std::move(definitions));
 }
 
+void Connection::removeScalarFunction(std::string name) {
+    clientContext->removeScalarFunction(name);
+}
+
 bool Connection::startUDFAutoTrx(transaction::TransactionContext* trx) {
     return clientContext->startUDFAutoTrx(trx);
 }

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -66,10 +66,6 @@ void Connection::setQueryTimeOut(uint64_t timeoutInMS) {
     clientContext->setQueryTimeOut(timeoutInMS);
 }
 
-uint64_t Connection::getQueryTimeOut() {
-    return clientContext->getQueryTimeOut();
-}
-
 std::unique_ptr<QueryResult> Connection::executeWithParams(PreparedStatement* preparedStatement,
     std::unordered_map<std::string, std::unique_ptr<Value>> inputParams) {
     return clientContext->executeWithParams(preparedStatement, std::move(inputParams));
@@ -91,14 +87,6 @@ void Connection::addScalarFunction(std::string name, function::function_set defi
 
 void Connection::removeScalarFunction(std::string name) {
     clientContext->removeScalarFunction(name);
-}
-
-bool Connection::startUDFAutoTrx(transaction::TransactionContext* trx) {
-    return clientContext->startUDFAutoTrx(trx);
-}
-
-void Connection::commitUDFTrx(bool isAutoCommitTrx) {
-    return clientContext->commitUDFTrx(isAutoCommitTrx);
 }
 
 } // namespace main

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -139,7 +139,9 @@ void UndoBuffer::commitEntry(const uint8_t* entry, transaction_t commitTS) {
         case CatalogEntryType::NODE_TABLE_ENTRY:
         case CatalogEntryType::REL_TABLE_ENTRY:
         case CatalogEntryType::REL_GROUP_ENTRY:
-        case CatalogEntryType::RDF_GRAPH_ENTRY: {
+        case CatalogEntryType::RDF_GRAPH_ENTRY:
+            // TODO: Add support for dropping macro.
+        case CatalogEntryType::SCALAR_MACRO_ENTRY: {
             auto tableCatalogEntry =
                 ku_dynamic_cast<CatalogEntry*, TableCatalogEntry*>(catalogEntry);
             wal.logDropTableRecord(tableCatalogEntry->getTableID(), tableCatalogEntry->getType());
@@ -148,6 +150,9 @@ void UndoBuffer::commitEntry(const uint8_t* entry, transaction_t commitTS) {
             auto sequenceCatalogEntry =
                 ku_dynamic_cast<CatalogEntry*, SequenceCatalogEntry*>(catalogEntry);
             wal.logDropSequenceRecord(sequenceCatalogEntry->getSequenceID());
+        } break;
+        case CatalogEntryType::SCALAR_FUNCTION_ENTRY: {
+            // DO NOTHING. We don't persistent function entries.
         } break;
         default: {
             throw RuntimeException(stringFormat("Not supported catalog entry type {} yet.",

--- a/test/main/udf_test.cpp
+++ b/test/main/udf_test.cpp
@@ -10,14 +10,15 @@ static int32_t add5(int32_t x) {
     return x + 5;
 }
 
-static int32_t throwRuntimeException() {
-    throw std::exception();
-    return 1;
-}
+class UserDefinedException : public std::exception {
+public:
+    explicit UserDefinedException(const std::string& message) : message_(message) {}
 
-static int32_t dontThrowRuntimeException() {
-    return 1;
-}
+    const char* what() const noexcept override { return message_.c_str(); }
+
+private:
+    std::string message_;
+};
 
 TEST_F(ApiTest, UnaryUDFInt64) {
     conn->createScalarFunction("add5", &add5);
@@ -33,21 +34,30 @@ TEST_F(ApiTest, TestDropUDF) {
     conn->createScalarFunction("add5", &add5);
     conn->removeUDFFunction("add5");
     conn->createScalarFunction("add5", &add5);
+    printf("%s", conn->query("return add5(cast(5, 'int32'));")->toString().c_str());
+}
+
+static int32_t throwUDE() {
+    throw UserDefinedException{"Input is too long."};
 }
 
 TEST_F(ApiTest, TestExceptUDF) {
-    conn->createScalarFunction("test", &throwRuntimeException);
-    auto result = conn->query("RETURN test()")->toString();
-    //ASSERT_EQ(result->isSuccess(), false);
-    conn->removeUDFFunction("test");
-    conn->createScalarFunction("test", &dontThrowRuntimeException);
-    conn->query("RETURN test()");
+    conn->createScalarFunction("throwUDE", &throwUDE);
+    auto result = conn->query("return throwUDE();");
+    ASSERT_EQ(result->getErrorMessage(), "Input is too long.");
+    conn->removeUDFFunction("throwUDE");
+    result = conn->query("return throwUDE();");
+    ASSERT_EQ(result->getErrorMessage(), "Catalog exception: function THROWUDE does not exist.");
+}
+
+static int32_t constantFunc() {
+    return 1;
 }
 
 TEST_F(ApiTest, TestZeroParamUDF) {
-    conn->createScalarFunction("test", &dontThrowRuntimeException);
+    conn->createScalarFunction("constantFunc", &constantFunc);
     auto actualResult =
-        TestHelper::convertResultToString(*conn->query("MATCH (p:person) return test()"));
+        TestHelper::convertResultToString(*conn->query("MATCH (p:person) return constantFunc()"));
     auto expectedResult = std::vector<std::string>{"1", "1", "1", "1", "1", "1", "1", "1"};
     sortAndCheckTestResults(actualResult, expectedResult);
 }
@@ -374,20 +384,35 @@ TEST_F(ApiTest, vectorizedTernaryConditionalAdd) {
     sortAndCheckTestResults(actualResult, expectedResult);
 }
 
-// TODO: FIX-ME. Add transaction to functions.
-// TEST_F(ApiTest, UDFTrxTest) {
-//    ASSERT_TRUE(conn->query("BEGIN TRANSACTION;")->isSuccess());
-//    conn->createScalarFunction("add5", &add5);
-//    auto actualResult = TestHelper::convertResultToString(*conn->query("return
-//    add5(to_int32(5))")); auto expectedResult = std::vector<std::string>{"10"};
-//    sortAndCheckTestResults(actualResult, expectedResult);
-//    ASSERT_TRUE(conn->query("COMMIT;")->isSuccess());
-//    ASSERT_TRUE(conn->query("BEGIN TRANSACTION;")->isSuccess());
-//    conn->createScalarFunction("times2", &times2);
-//    ASSERT_TRUE(conn->query("ROLLBACK;")->isSuccess());
-//    ASSERT_EQ(conn->query("return times2(5)")->getErrorMessage(),
-//        "Catalog exception: function TIMES2 does not exist.");
-//}
+TEST_F(ApiTest, UDFTrxTest) {
+    ASSERT_TRUE(conn->query("BEGIN TRANSACTION;")->isSuccess());
+    conn->createScalarFunction("add5", &add5);
+    auto actualResult = TestHelper::convertResultToString(*conn->query("return add5(to_int32(5))"));
+    auto expectedResult = std::vector<std::string>{"10"};
+    sortAndCheckTestResults(actualResult, expectedResult);
+    ASSERT_TRUE(conn->query("COMMIT;")->isSuccess());
+    ASSERT_TRUE(conn->query("BEGIN TRANSACTION;")->isSuccess());
+    conn->createScalarFunction("times2", &times2);
+    ASSERT_TRUE(conn->query("ROLLBACK;")->isSuccess());
+    ASSERT_EQ(conn->query("return times2(5)")->getErrorMessage(),
+        "Catalog exception: function TIMES2 does not exist.");
+}
+
+TEST_F(ApiTest, CreateUDFExceptionTest) {
+    conn->createScalarFunction("add5", &add5);
+    try {
+        conn->createScalarFunction("add5", &add5);
+        FAIL();
+    } catch (std::exception& e) {
+        ASSERT_EQ(std::string(e.what()), "Catalog exception: function add5 already exists.");
+    }
+    try {
+        conn->removeUDFFunction("add6");
+        FAIL();
+    } catch (std::exception& e) {
+        ASSERT_EQ(std::string(e.what()), "Catalog exception: function add6 doesn't exist.");
+    }
+}
 
 } // namespace testing
 } // namespace kuzu

--- a/test/main/udf_test.cpp
+++ b/test/main/udf_test.cpp
@@ -1,4 +1,3 @@
-#include "common/exception/runtime.h"
 #include "main_test_helper/main_test_helper.h"
 
 using namespace kuzu::common;

--- a/test/main/udf_test.cpp
+++ b/test/main/udf_test.cpp
@@ -46,8 +46,9 @@ TEST_F(ApiTest, TestExceptUDF) {
 
 TEST_F(ApiTest, TestZeroParamUDF) {
     conn->createScalarFunction("test", &dontThrowRuntimeException);
-    auto actualResult = TestHelper::convertResultToString(*conn->query("MATCH (p:person) return test()"));
-    auto expectedResult = std::vector<std::string>{"1","1","1","1","1","1","1","1"};
+    auto actualResult =
+        TestHelper::convertResultToString(*conn->query("MATCH (p:person) return test()"));
+    auto expectedResult = std::vector<std::string>{"1", "1", "1", "1", "1", "1", "1", "1"};
     sortAndCheckTestResults(actualResult, expectedResult);
 }
 

--- a/test/main/udf_test.cpp
+++ b/test/main/udf_test.cpp
@@ -11,7 +11,7 @@ static int32_t add5(int32_t x) {
 }
 
 static int32_t throwRuntimeException() {
-    throw RuntimeException("test");
+    throw std::exception();
     return 1;
 }
 
@@ -37,8 +37,8 @@ TEST_F(ApiTest, TestDropUDF) {
 
 TEST_F(ApiTest, TestExceptUDF) {
     conn->createScalarFunction("test", &throwRuntimeException);
-    auto result = conn->query("RETURN test()");
-    ASSERT_EQ(result->isSuccess(), false);
+    auto result = conn->query("RETURN test()")->toString();
+    //ASSERT_EQ(result->isSuccess(), false);
     conn->removeUDFFunction("test");
     conn->createScalarFunction("test", &dontThrowRuntimeException);
     conn->query("RETURN test()");

--- a/tools/python_api/src_cpp/include/py_connection.h
+++ b/tools/python_api/src_cpp/include/py_connection.h
@@ -42,7 +42,8 @@ public:
     static bool isPandasDataframe(const py::object& object);
 
     void createScalarFunction(const std::string& name, const py::function& udf,
-        const py::list& params, const std::string& retval);
+        const py::list& params, const std::string& retval, bool defaultNull, bool catchExceptions);
+    void removeScalarFunction(const std::string& name);
 
     static Value transformPythonValue(const py::handle& val);
     static Value transformPythonValueAs(const py::handle& val, const LogicalType& type);

--- a/tools/python_api/src_cpp/include/py_udf.h
+++ b/tools/python_api/src_cpp/include/py_udf.h
@@ -13,5 +13,6 @@ class PyUDF {
 
 public:
     static function_set toFunctionSet(const std::string& name, const py::function& udf,
-        const py::list& paramTypes, const std::string& resultType);
+        const py::list& paramTypes, const std::string& resultType, bool defaultNull,
+        bool catchExceptions);
 };

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -36,7 +36,9 @@ void PyConnection::initialize(py::handle& m) {
             py::arg("np_array"), py::arg("src_table_name"), py::arg("rel_name"),
             py::arg("dst_table_name"), py::arg("query_batch_size"))
         .def("create_function", &PyConnection::createScalarFunction, py::arg("name"),
-            py::arg("udf"), py::arg("params_type"), py::arg("return_value"));
+            py::arg("udf"), py::arg("params_type"), py::arg("return_value"),
+            py::arg("default_null"), py::arg("catch_exceptions"))
+        .def("remove_function", &PyConnection::removeScalarFunction, py::arg("name"));
     PyDateTime_IMPORT;
 }
 
@@ -478,6 +480,11 @@ std::unique_ptr<PyQueryResult> PyConnection::checkAndWrapQueryResult(
 }
 
 void PyConnection::createScalarFunction(const std::string& name, const py::function& udf,
-    const py::list& params, const std::string& retval) {
-    conn->addUDFFunctionSet(name, PyUDF::toFunctionSet(name, udf, params, retval));
+    const py::list& params, const std::string& retval, bool defaultNull, bool catchExcept) {
+    conn->addUDFFunctionSet(name,
+        PyUDF::toFunctionSet(name, udf, params, retval, defaultNull, catchExcept));
+}
+
+void PyConnection::removeScalarFunction(const std::string& name) {
+    conn->removeUDFFunction(name);
 }

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -480,9 +480,9 @@ std::unique_ptr<PyQueryResult> PyConnection::checkAndWrapQueryResult(
 }
 
 void PyConnection::createScalarFunction(const std::string& name, const py::function& udf,
-    const py::list& params, const std::string& retval, bool defaultNull, bool catchExcept) {
+    const py::list& params, const std::string& retval, bool defaultNull, bool catchExceptions) {
     conn->addUDFFunctionSet(name,
-        PyUDF::toFunctionSet(name, udf, params, retval, defaultNull, catchExcept));
+        PyUDF::toFunctionSet(name, udf, params, retval, defaultNull, catchExceptions));
 }
 
 void PyConnection::removeScalarFunction(const std::string& name) {

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -124,7 +124,8 @@ static PyUDFSignature analyzeSignature(const py::function& udf) {
     return UDFSignature;
 }
 
-static scalar_func_exec_t getUDFExecFunc(const py::function& udf) {
+static scalar_func_exec_t getUDFExecFunc(const py::function& udf, bool defaultNull,
+    bool catchExceptions) {
     return [=](const std::vector<std::shared_ptr<ValueVector>>& params, ValueVector& result,
                void* /* dataPtr */) -> void {
         py::gil_scoped_acquire acquire;
@@ -133,16 +134,33 @@ static scalar_func_exec_t getUDFExecFunc(const py::function& udf) {
         for (auto i = 0u; i < resultSelVector.getSelSize(); ++i) {
             auto resultPos = resultSelVector[i];
             py::list pyParams;
+            bool hasNull = false;
             for (const auto& param : params) {
                 auto paramPos =
                     param->state->isFlat() ? param->state->getSelVector()[0] : resultPos;
                 auto value = param->getAsValue(paramPos);
+                if (value->isNull()) {
+                    hasNull = true;
+                }
                 auto pyValue = PyQueryResult::convertValueToPyObject(*value);
                 pyParams.append(pyValue);
             }
-            auto pyResult = udf(*pyParams);
-            auto resultValue = PyConnection::transformPythonValueAs(pyResult, result.dataType);
-            result.copyFromValue(resultPos, resultValue);
+            if (defaultNull && hasNull) {
+                result.setNull(resultPos, true);
+            } else {
+                try {
+                    auto pyResult = udf(*pyParams);
+                    auto resultValue =
+                        PyConnection::transformPythonValueAs(pyResult, result.dataType);
+                    result.copyFromValue(resultPos, resultValue);
+                } catch (py::error_already_set& e) {
+                    if (catchExceptions) {
+                        result.setNull(resultPos, true);
+                    } else {
+                        throw common::RuntimeException(e.what());
+                    }
+                }
+            }
         }
     };
 }
@@ -155,7 +173,8 @@ static scalar_bind_func getUDFBindFunc(const PyUDFSignature& signature) {
 }
 
 function_set PyUDF::toFunctionSet(const std::string& name, const py::function& udf,
-    const py::list& paramTypes, const std::string& resultType) {
+    const py::list& paramTypes, const std::string& resultType, bool defaultNull,
+    bool catchExceptions) {
     auto pySignature = analyzeSignature(udf);
     auto explicitParamTypes = pyListToParams(paramTypes);
     if (explicitParamTypes.size() > 0) {
@@ -183,7 +202,7 @@ function_set PyUDF::toFunctionSet(const std::string& name, const py::function& u
 
     function_set definitions;
     definitions.push_back(std::make_unique<ScalarFunction>(name, paramIDTypes,
-        pySignature.resultType.getLogicalTypeID(), getUDFExecFunc(udf),
-        getUDFBindFunc(pySignature)));
+        pySignature.resultType.getLogicalTypeID(),
+        getUDFExecFunc(udf, defaultNull, catchExceptions), getUDFBindFunc(pySignature)));
     return definitions;
 }

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -279,7 +279,7 @@ class Connection:
 
     def remove_function(self, name: str) -> None:
         """
-        Removes a User Defined Function (UDF)
+        Removes a User Defined Function (UDF).
 
         Parameters
         ----------

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -235,6 +235,9 @@ class Connection:
         udf: Callable[[...], Any],
         params_type: list[Type | str] | None = None,
         return_type: Type | str = "",
+        *,
+        default_null_handling: bool = True,
+        catch_exceptions: bool = False
     ) -> None:
         """
         Sets a User Defined Function (UDF) to use in cypher queries.
@@ -252,10 +255,35 @@ class Connection:
 
         return_type: Optional[Type]
             a Type enum to describe the returned value
+
+        default_null_handling: Optional[bool]
+            if true, when any parameter is null, the resulting value will be null
+
+        catch_exceptions: Optional[bool]
+            if true, when an exception is thrown from python, the function output will be null
+            Otherwise, the exception will be rethrown
         """
         if params_type is None:
             params_type = []
         parsed_params_type = [x if type(x) is str else x.value for x in params_type]
         if type(return_type) is not str:
             return_type = return_type.value
-        self._connection.create_function(name, udf, parsed_params_type, return_type)
+        
+        self._connection.create_function(
+            name=name,
+            udf=udf,
+            params_type=parsed_params_type,
+            return_value=return_type,
+            default_null=default_null_handling,
+            catch_exceptions=catch_exceptions)
+
+    def remove_function(self, name: str) -> None:
+        """
+        Removes a User Defined Function (UDF)
+
+        Parameters
+        ----------
+        name: str
+            name of function to be removed.
+        """
+        self._connection.remove_function(name)

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -186,10 +186,10 @@ def test_udf_remove(conn_db_readwrite: ConnDB) -> None:
     
     conn.create_function("myfunction", myfunction)
 
-    with pytest.raises(RuntimeError, match="No user defined function matches the name notmyfunction"):
+    with pytest.raises(RuntimeError, match="Catalog exception: function notmyfunction doesn't exist."):
         conn.remove_function("notmyfunction")
     
     conn.remove_function("myfunction")
 
-    with pytest.raises(RuntimeError, match="No user defined function matches the name list_create"):
+    with pytest.raises(RuntimeError, match="Catalog exception: function list_create doesn't exist."):
         conn.remove_function("list_create")

--- a/tools/python_api/test/test_udf.py
+++ b/tools/python_api/test/test_udf.py
@@ -4,6 +4,10 @@ from datetime import date, datetime, timedelta  # noqa: TCH003
 
 import pandas as pd
 import pyarrow as pa
+import pytest
+from datetime import date, datetime, timedelta # noqa: TCH003
+
+import kuzu
 from kuzu import Type
 from type_aliases import ConnDB
 
@@ -141,3 +145,51 @@ def test_udf(conn_db_readwrite: ConnDB) -> None:
         [("a", 1), ("b", 2), ("c", 3), ("x", -1), ("y", -2), ("z", -3)],
         [("l", 1), ("m", 2), ("n", 3), ("one", -1), ("two", -2), ("three", -3)],
     ]
+
+def test_udf_null(conn_db_readwrite: ConnDB) -> None:
+    conn, db = conn_db_readwrite
+
+    def get5(x: int) -> int:
+        return 5
+    
+    conn.create_function("get5", get5)
+    assert conn.execute("RETURN get5(NULL)").get_next() == [None]
+
+    conn.remove_function("get5")
+    conn.create_function("get5", get5, default_null_handling = False)
+    assert conn.execute("RETURN get5(NULL)").get_next() == [5]
+
+def test_udf_except(conn_db_readwrite: ConnDB) -> None:
+    class TestException(Exception):
+        pass
+
+    conn, db = conn_db_readwrite
+
+    def throw() -> int:
+        errmsg = "test"
+        raise TestException(errmsg)
+    
+    conn.create_function("testexcept", throw)
+
+    pytest.raises(RuntimeError, conn.execute, "RETURN testexcept()")
+
+    conn.remove_function("testexcept")
+    conn.create_function("testexcept", throw, catch_exceptions = True)
+
+    assert conn.execute("RETURN testexcept()").get_next() == [None]
+
+def test_udf_remove(conn_db_readwrite: ConnDB) -> None:
+    conn, db = conn_db_readwrite
+
+    def myfunction() -> int:
+        return 1
+    
+    conn.create_function("myfunction", myfunction)
+
+    with pytest.raises(RuntimeError, match="No user defined function matches the name notmyfunction"):
+        conn.remove_function("notmyfunction")
+    
+    conn.remove_function("myfunction")
+
+    with pytest.raises(RuntimeError, match="No user defined function matches the name list_create"):
+        conn.remove_function("list_create")


### PR DESCRIPTION
Changes:
- UDFs now evaluate to null by default when any one of the parameters is null. This is changeable via the `default_null_handling` parameter
- Exceptions can now be caught from python functions via the `catch_exceptions` parameter. When an exception is caught, the function is evaluated to null
- UDFs can now be removed, both in the C++ and in the python API via `removeUDFFunction` and `remove_function` respectively.

C++ UDF API now supports zero parameter functions, but this is an experimental feature (ie. not tested very well)