### PR TITLE
Added missing algorithm includes needed for gcc 14

### DIFF
--- a/src/common/copier_config/csv_reader_config.cpp
+++ b/src/common/copier_config/csv_reader_config.cpp
@@ -1,5 +1,7 @@
 #include "common/copier_config/csv_reader_config.h"
 
+#include <algorithm>
+
 #include "common/exception/binder.h"
 
 namespace kuzu {

--- a/src/storage/local_storage/local_table.cpp
+++ b/src/storage/local_storage/local_table.cpp
@@ -1,5 +1,7 @@
 #include "storage/local_storage/local_table.h"
 
+#include <algorithm>
+
 #include "common/types/internal_id_t.h"
 #include "storage/store/chunked_node_group.h"
 


### PR DESCRIPTION
From https://gcc.gnu.org/gcc-14/porting_to.html:
> Some C++ Standard Library headers have been changed to no longer include other headers that were being used internally by the library. As such, C++ programs that used standard library components without including the right headers will no longer compile. 

I'm also encountering linking errors which I don't fully understand, but I can keep using gcc 13 for now.