### PR TITLE
Fix serial csv reader

### DIFF
--- a/test/test_files/csv/serial_csv_reader.test
+++ b/test/test_files/csv/serial_csv_reader.test
@@ -1,0 +1,9 @@
+-DATASET CSV empty
+
+--
+
+-CASE ScanWithSerialCSVReader
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/csv/types_50k.csv" (HEADER=TRUE, parallel=FALSE) RETURN count(*);
+---- 1
+49999
+


### PR DESCRIPTION
This PR solves a bug in the serial csv reader.
[Cause]
uint64_t numRows = reader->parseBlock(0 /* unused by serial csv reader */, outputChunk);
We pass block 0 to reader::parseBlock, however the block number is used by reader in the following way:
When the csv file has a header and the block number is 0, we are going to skip the first row in that block.
As a result, the serial csv reader will always skip the first row of each row.

[Fix]
We have to distinguish whether it is the first block. We can tell this by fileoffset of the reader.

Closes #3504 