### PR TITLE
Propagate chunk state to commit out of place in column

### DIFF
--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -112,13 +112,15 @@ public:
             resultSetDescriptor->copy(), children[0]->clone(), id, paramsString);
     }
 
-    static void writeAndResetNewNodeGroup(common::node_group_idx_t nodeGroupIdx,
-        std::optional<IndexBuilder>& indexBuilder, common::column_id_t pkColumnID,
-        storage::NodeTable* table, storage::ChunkedNodeGroup* nodeGroup);
+    static void writeAndResetNewNodeGroup(transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx, std::optional<IndexBuilder>& indexBuilder,
+        common::column_id_t pkColumnID, storage::NodeTable* table,
+        storage::ChunkedNodeGroup* nodeGroup);
 
     // The node group will be reset so that the only values remaining are the ones which were not
     // written
-    void writeAndResetNodeGroup(common::node_group_idx_t nodeGroupIdx, ExecutionContext* context,
+    void writeAndResetNodeGroup(transaction::Transaction* transaction,
+        common::node_group_idx_t nodeGroupIdx,
         std::unique_ptr<storage::ChunkedNodeGroup>& nodeGroup,
         std::optional<IndexBuilder>& indexBuilder);
 
@@ -129,12 +131,13 @@ private:
         common::column_id_t pkColumnID, storage::NodeTable* table,
         storage::ChunkedNodeGroup* nodeGroup);
 
-    void appendIncompleteNodeGroup(std::unique_ptr<storage::ChunkedNodeGroup> localNodeGroup,
-        std::optional<IndexBuilder>& indexBuilder, ExecutionContext* context);
+    void appendIncompleteNodeGroup(transaction::Transaction* transaction,
+        std::unique_ptr<storage::ChunkedNodeGroup> localNodeGroup,
+        std::optional<IndexBuilder>& indexBuilder);
     void clearToIndex(std::unique_ptr<storage::ChunkedNodeGroup>& nodeGroup,
         common::offset_t startIndexInGroup);
 
-    void copyToNodeGroup(ExecutionContext* context);
+    void copyToNodeGroup(transaction::Transaction* transaction);
 };
 
 } // namespace processor

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -60,12 +60,12 @@ public:
     }
 
 private:
-    static void appendNewNodeGroup(const RelBatchInsertInfo& relInfo,
-        RelBatchInsertLocalState& localState, BatchInsertSharedState& sharedState,
-        const PartitionerSharedState& partitionerSharedState);
-    static void mergeNodeGroup(ExecutionContext* context, const RelBatchInsertInfo& relInfo,
-        RelBatchInsertLocalState& localState, BatchInsertSharedState& sharedState,
-        const PartitionerSharedState& partitionerSharedState);
+    static void appendNewNodeGroup(transaction::Transaction* transaction,
+        const RelBatchInsertInfo& relInfo, RelBatchInsertLocalState& localState,
+        BatchInsertSharedState& sharedState, const PartitionerSharedState& partitionerSharedState);
+    static void mergeNodeGroup(transaction::Transaction* transaction,
+        const RelBatchInsertInfo& relInfo, RelBatchInsertLocalState& localState,
+        BatchInsertSharedState& sharedState, const PartitionerSharedState& partitionerSharedState);
 
     static void prepareCSRNodeGroup(const storage::ChunkedNodeGroupCollection& partition,
         common::offset_t startNodeOffset, const RelBatchInsertInfo& relInfo,

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -79,7 +79,7 @@ public:
         common::offset_t endOffset = common::INVALID_OFFSET);
 
     // Append column chunk in a new node group.
-    virtual void append(ColumnChunk* columnChunk, common::node_group_idx_t nodeGroupIdx);
+    virtual void append(ColumnChunk* columnChunk, ChunkState& state);
 
     common::LogicalType& getDataType() { return dataType; }
     const common::LogicalType& getDataType() const { return dataType; }
@@ -199,18 +199,16 @@ private:
         const ChunkCollection& localUpdateChunks, const offset_to_row_idx_t& updateInfo,
         const offset_set_t& deleteInfo);
     virtual void commitLocalChunkOutOfPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, bool isNewNodeGroup,
-        const ChunkCollection& localInsertChunks, const offset_to_row_idx_t& insertInfo,
-        const ChunkCollection& localUpdateChunks, const offset_to_row_idx_t& updateInfo,
-        const offset_set_t& deleteInfo);
+        ChunkState& state, bool isNewNodeGroup, const ChunkCollection& localInsertChunks,
+        const offset_to_row_idx_t& insertInfo, const ChunkCollection& localUpdateChunks,
+        const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo);
 
     virtual void commitColumnChunkInPlace(ChunkState& state,
         const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
         common::offset_t srcOffset);
     virtual void commitColumnChunkOutOfPlace(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, bool isNewNodeGroup,
-        const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
-        common::offset_t srcOffset);
+        ChunkState& state, bool isNewNodeGroup, const std::vector<common::offset_t>& dstOffsets,
+        ColumnChunk* chunk, common::offset_t srcOffset);
 
     void applyLocalChunkToColumn(ChunkState& state, const ChunkCollection& localChunks,
         const offset_to_row_idx_t& info);

--- a/src/include/storage/store/dictionary_column.h
+++ b/src/include/storage/store/dictionary_column.h
@@ -18,7 +18,7 @@ public:
     void initChunkState(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, Column::ChunkState& columnReadState);
 
-    void append(common::node_group_idx_t nodeGroupIdx, const DictionaryChunk& dictChunk);
+    void append(Column::ChunkState& state, const DictionaryChunk& dictChunk);
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         DictionaryChunk& dictChunk);

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -73,7 +73,7 @@ protected:
         common::offset_t nodeOffset, common::ValueVector* resultVector,
         uint32_t posInVector) override;
 
-    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;
+    void append(ColumnChunk* columnChunk, ChunkState& state) override;
 
 private:
     void scanUnfiltered(transaction::Transaction* transaction, ChunkState& readState,
@@ -106,7 +106,7 @@ private:
         const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
         common::offset_t startSrcOffset);
     void commitOffsetColumnChunkOutOfPlace(transaction::Transaction* transaction,
-        const ChunkState& offsetState, const std::vector<common::offset_t>& dstOffsets,
+        ChunkState& offsetState, const std::vector<common::offset_t>& dstOffsets,
         ColumnChunk* chunk, common::offset_t startSrcOffset);
 
 private:

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -109,7 +109,9 @@ public:
     common::column_id_t getNumColumns() const { return tableData->getNumColumns(); }
     Column* getColumn(common::column_id_t columnID) { return tableData->getColumn(columnID); }
 
-    void append(ChunkedNodeGroup* nodeGroup) { tableData->append(nodeGroup); }
+    void append(transaction::Transaction* transaction, ChunkedNodeGroup* nodeGroup) {
+        tableData->append(transaction, nodeGroup);
+    }
 
     void prepareCommitNodeGroup(common::node_group_idx_t nodeGroupIdx,
         transaction::Transaction* transaction, storage::LocalNodeNG* localNodeGroup);

--- a/src/include/storage/store/node_table_data.h
+++ b/src/include/storage/store/node_table_data.h
@@ -37,7 +37,7 @@ public:
         const std::vector<common::ValueVector*>& outputVectors);
 
     // Flush the nodeGroup to disk and update metadataDAs.
-    void append(ChunkedNodeGroup* nodeGroup) override;
+    void append(transaction::Transaction* transaction, ChunkedNodeGroup* nodeGroup) override;
 
     void prepareLocalNodeGroupToCommit(common::node_group_idx_t nodeGroupIdx,
         transaction::Transaction* transaction, LocalNodeNG* localNodeGroup);

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -32,7 +32,7 @@ public:
     void lookup(Transaction* transaction, ChunkState& readState, ValueVector* nodeIDVector,
         ValueVector* resultVector) override;
 
-    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;
+    void append(ColumnChunk* columnChunk, ChunkState& state) override;
 
     bool isNull(Transaction* transaction, const ChunkState& state, offset_t offsetInChunk);
     void setNull(ChunkState& state, offset_t offsetInChunk, uint64_t value = true);

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -115,9 +115,11 @@ public:
                                                             bwdRelTableData->getColumns();
     }
 
-    void append(ChunkedNodeGroup* nodeGroup, common::RelDataDirection direction) {
-        direction == common::RelDataDirection::FWD ? fwdRelTableData->append(nodeGroup) :
-                                                     bwdRelTableData->append(nodeGroup);
+    void append(transaction::Transaction* transaction, ChunkedNodeGroup* nodeGroup,
+        common::RelDataDirection direction) {
+        direction == common::RelDataDirection::FWD ?
+            fwdRelTableData->append(transaction, nodeGroup) :
+            bwdRelTableData->append(transaction, nodeGroup);
     }
 
     bool isNewNodeGroup(transaction::Transaction* transaction,

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -52,10 +52,10 @@ struct CSRHeaderColumns {
         offset->scan(transaction, nodeGroupIdx, chunks.offset.get());
         length->scan(transaction, nodeGroupIdx, chunks.length.get());
     }
-    inline void append(const ChunkedCSRHeader& headerChunks,
-        common::node_group_idx_t nodeGroupIdx) const {
-        offset->append(headerChunks.offset.get(), nodeGroupIdx);
-        length->append(headerChunks.length.get(), nodeGroupIdx);
+    inline void append(const ChunkedCSRHeader& headerChunks, Column::ChunkState& offsetState,
+        Column::ChunkState& lengthState) const {
+        offset->append(headerChunks.offset.get(), offsetState);
+        length->append(headerChunks.length.get(), lengthState);
     }
 
     common::offset_t getNumNodes(transaction::Transaction* transaction,
@@ -155,7 +155,7 @@ public:
         common::ValueVector* srcNodeIDVector) const;
     bool checkIfNodeHasRels(transaction::Transaction* transaction,
         common::offset_t nodeOffset) const;
-    void append(ChunkedNodeGroup* nodeGroup) override;
+    void append(transaction::Transaction* transaction, ChunkedNodeGroup* nodeGroup) override;
 
     inline Column* getNbrIDColumn() const { return columns[NBR_ID_COLUMN_ID].get(); }
     inline Column* getCSROffsetColumn() const { return csrHeaderColumns.offset.get(); }

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -22,7 +22,7 @@ public:
         ColumnChunk* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
 
-    void append(ColumnChunk* columnChunk, common::node_group_idx_t nodeGroupIdx) override;
+    void append(ColumnChunk* columnChunk, ChunkState& state) override;
 
     void writeValue(ChunkState& state, common::offset_t offsetInChunk,
         common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -21,7 +21,7 @@ public:
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) override;
 
-    void append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) override;
+    void append(ColumnChunk* columnChunk, ChunkState& state) override;
 
     void checkpointInMemory() override;
     void rollbackInMemory() override;

--- a/src/include/storage/store/table_data.h
+++ b/src/include/storage/store/table_data.h
@@ -31,7 +31,7 @@ public:
         const common::ValueVector& nodeIDVector,
         const std::vector<common::ValueVector*>& outputVectors) = 0;
 
-    virtual void append(ChunkedNodeGroup* nodeGroup) = 0;
+    virtual void append(transaction::Transaction* transaction, ChunkedNodeGroup* nodeGroup) = 0;
 
     inline void dropColumn(common::column_id_t columnID) {
         columns.erase(columns.begin() + columnID);

--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -34,10 +34,12 @@ void DictionaryColumn::initChunkState(Transaction* transaction, node_group_idx_t
         readState.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX]);
 }
 
-void DictionaryColumn::append(node_group_idx_t nodeGroupIdx, const DictionaryChunk& dictChunk) {
+void DictionaryColumn::append(Column::ChunkState& state, const DictionaryChunk& dictChunk) {
     KU_ASSERT(dictChunk.sanityCheck());
-    dataColumn->append(dictChunk.getStringDataChunk(), nodeGroupIdx);
-    offsetColumn->append(dictChunk.getOffsetChunk(), nodeGroupIdx);
+    dataColumn->append(dictChunk.getStringDataChunk(),
+        state.childrenStates[DATA_COLUMN_CHILD_READ_STATE_IDX]);
+    offsetColumn->append(dictChunk.getOffsetChunk(),
+        state.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX]);
 }
 
 void DictionaryColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -96,12 +96,12 @@ void NullColumn::lookup(Transaction* transaction, ChunkState& readState, ValueVe
     }
 }
 
-void NullColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {
+void NullColumn::append(ColumnChunk* columnChunk, ChunkState& state) {
     auto preScanMetadata = columnChunk->getMetadataToFlush();
     auto startPageIdx = dataFH->addNewPages(preScanMetadata.numPages);
-    auto metadata = columnChunk->flushBuffer(dataFH, startPageIdx, preScanMetadata);
-    metadataDA->resize(nodeGroupIdx + 1);
-    metadataDA->update(nodeGroupIdx, metadata);
+    state.metadata = columnChunk->flushBuffer(dataFH, startPageIdx, preScanMetadata);
+    metadataDA->resize(state.nodeGroupIdx + 1);
+    metadataDA->update(state.nodeGroupIdx, state.metadata);
     if (static_cast<NullColumnChunk*>(columnChunk)->mayHaveNull()) {
         propertyStatistics.setHasNull(DUMMY_WRITE_TRANSACTION);
     }

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -50,10 +50,10 @@ void StringColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,
     dictionary.scan(transaction, nodeGroupIdx, stringColumnChunk->getDictionaryChunk());
 }
 
-void StringColumn::append(ColumnChunk* columnChunk, node_group_idx_t nodeGroupIdx) {
-    Column::append(columnChunk, nodeGroupIdx);
+void StringColumn::append(ColumnChunk* columnChunk, ChunkState& state) {
+    Column::append(columnChunk, state);
     auto stringColumnChunk = ku_dynamic_cast<ColumnChunk*, StringColumnChunk*>(columnChunk);
-    dictionary.append(nodeGroupIdx, stringColumnChunk->getDictionaryChunk());
+    dictionary.append(state, stringColumnChunk->getDictionaryChunk());
 }
 
 void StringColumn::writeValue(ChunkState& state, offset_t offsetInChunk,

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -114,12 +114,12 @@ void StructColumn::write(ChunkState& state, offset_t offsetInChunk, ColumnChunk*
     }
 }
 
-void StructColumn::append(ColumnChunk* columnChunk, uint64_t nodeGroupIdx) {
-    Column::append(columnChunk, nodeGroupIdx);
+void StructColumn::append(ColumnChunk* columnChunk, ChunkState& state) {
+    Column::append(columnChunk, state);
     KU_ASSERT(columnChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
     auto structColumnChunk = static_cast<StructColumnChunk*>(columnChunk);
     for (auto i = 0u; i < childColumns.size(); i++) {
-        childColumns[i]->append(structColumnChunk->getChild(i), nodeGroupIdx);
+        childColumns[i]->append(structColumnChunk->getChild(i), state.childrenStates[i]);
     }
 }
 


### PR DESCRIPTION
# Description

Propagate chunk state to `Column::commitColumnChunkOutOfPlace` and `Column::append`.

## Fixes

Potentially, there is an incorrect set of `numValues` in `StructColumn::prepareCommitForExistingChunk`, as we're comparing struct's state and its null's state, and the latter one can become incorrect if it is performing out of place commit.
This PR should fix this potential bug.