### PR TITLE
Fix filesearchpath in localFileSystem glob

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -111,9 +111,11 @@ std::vector<std::string> LocalFileSystem::glob(main::ClientContext* context,
         // Relative path to the file search path.
         auto fileSearchPath =
             context->getCurrentSetting(main::FileSearchPathSetting::name).getValue<std::string>();
-        auto searchPaths = common::StringUtils::split(fileSearchPath, ",");
-        for (auto& searchPath : searchPaths) {
-            pathsToGlob.push_back(common::stringFormat("{}/{}", searchPath, path));
+        if (fileSearchPath != "") {
+            auto searchPaths = common::StringUtils::split(fileSearchPath, ",");
+            for (auto& searchPath : searchPaths) {
+                pathsToGlob.push_back(common::stringFormat("{}/{}", searchPath, path));
+            }
         }
         // Relative path to the current directory.
         pathsToGlob.push_back(path);

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -37,6 +37,9 @@ std::vector<std::string> StringUtils::split(const std::string& input, const std:
     auto result = std::vector<std::string>();
     auto prevPos = 0u;
     auto currentPos = findDelim(input, delimiter, prevPos);
+    if (currentPos == std::string::npos) {
+        return result;
+    }
     while (currentPos != std::string::npos) {
         auto stringPart = input.substr(prevPos, currentPos - prevPos);
         if (!ignoreEmptyStringParts || !stringPart.empty()) {

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -37,9 +37,6 @@ std::vector<std::string> StringUtils::split(const std::string& input, const std:
     auto result = std::vector<std::string>();
     auto prevPos = 0u;
     auto currentPos = findDelim(input, delimiter, prevPos);
-    if (currentPos == std::string::npos) {
-        return result;
-    }
     while (currentPos != std::string::npos) {
         auto stringPart = input.substr(prevPos, currentPos - prevPos);
         if (!ignoreEmptyStringParts || !stringPart.empty()) {

--- a/test/test_files/tinysnb/function/string.test
+++ b/test/test_files/tinysnb/function/string.test
@@ -750,3 +750,8 @@ r
 AB
 Cs
 DE
+
+-LOG splitEmptyStr
+-STATEMENT return str_split('', ',')
+---- 1
+[]

--- a/test/test_files/tinysnb/function/string.test
+++ b/test/test_files/tinysnb/function/string.test
@@ -752,6 +752,6 @@ Cs
 DE
 
 -LOG splitEmptyStr
--STATEMENT return str_split('', ',')
+-STATEMENT return size(str_split('', ','))
 ---- 1
-[]
+1


### PR DESCRIPTION
# Description
If the fileSearchPath is an empty string, we should skip appending the filesearchpath to the file path.

