### PR TITLE
Add required module in pyproject.toml

### DIFF
--- a/tools/python_api/pyproject.toml
+++ b/tools/python_api/pyproject.toml
@@ -93,5 +93,5 @@ strict = true
 docstring-code-format = true
 
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools", "wheel","cmake"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Fixes # (issue)
Fix bug in the virtual environment: Can't find module "make"