### PR TITLE
Track variable sized memory manager allocations through the buffer manager

### DIFF
--- a/src/common/in_mem_overflow_buffer.cpp
+++ b/src/common/in_mem_overflow_buffer.cpp
@@ -7,7 +7,7 @@ uint8_t* InMemOverflowBuffer::allocateSpace(uint64_t size) {
     if (requireNewBlock(size)) {
         allocateNewBlock(size);
     }
-    auto data = currentBlock->block->buffer + currentBlock->currentOffset;
+    auto data = currentBlock->data() + currentBlock->currentOffset;
     currentBlock->currentOffset += size;
     return data;
 }

--- a/src/include/common/in_mem_overflow_buffer.h
+++ b/src/include/common/in_mem_overflow_buffer.h
@@ -11,10 +11,12 @@ namespace common {
 struct BufferBlock {
 public:
     explicit BufferBlock(std::unique_ptr<storage::MemoryBuffer> block)
-        : size{block->size}, currentOffset{0}, block{std::move(block)} {}
+        : currentOffset{0}, block{std::move(block)} {}
+
+    inline uint64_t size() const { return block->buffer.size(); }
+    inline uint8_t* data() const { return block->buffer.data(); }
 
 public:
-    uint64_t size;
     uint64_t currentOffset;
     std::unique_ptr<storage::MemoryBuffer> block;
 
@@ -47,7 +49,7 @@ public:
 private:
     bool requireNewBlock(uint64_t sizeToAllocate) {
         return currentBlock == nullptr ||
-               (currentBlock->currentOffset + sizeToAllocate) > currentBlock->size;
+               (currentBlock->currentOffset + sizeToAllocate) > currentBlock->size();
     }
 
     void allocateNewBlock(uint64_t size);

--- a/src/include/processor/result/factorized_table.h
+++ b/src/include/processor/result/factorized_table.h
@@ -24,18 +24,17 @@ struct BlockAppendingInfo {
 // released when this struct goes out of scope.
 class DataBlock {
 public:
-    DataBlock(storage::MemoryManager* mm, uint64_t size)
-        : numTuples{0}, totalSize{size}, freeSize{size} {
+    DataBlock(storage::MemoryManager* mm, uint64_t size) : numTuples{0}, freeSize{size} {
         block = mm->allocateBuffer(true /* initializeToZero */, size);
     }
 
-    uint8_t* getData() const { return block->buffer; }
-    uint8_t* getWritableData() const { return block->buffer + totalSize - freeSize; }
+    uint8_t* getData() const { return block->buffer.data(); }
+    uint8_t* getWritableData() const { return block->buffer.last(freeSize).data(); }
     void resetNumTuplesAndFreeSize() {
-        freeSize = totalSize;
+        freeSize = block->buffer.size();
         numTuples = 0;
     }
-    void resetToZero() { memset(block->buffer, 0, totalSize); }
+    void resetToZero() { memset(block->buffer.data(), 0, block->buffer.size()); }
 
     static void copyTuples(DataBlock* blockToCopyFrom, ft_tuple_idx_t tupleIdxToCopyFrom,
         DataBlock* blockToCopyInto, ft_tuple_idx_t tupleIdxToCopyTo, uint32_t numTuplesToCopy,
@@ -43,7 +42,6 @@ public:
 
 public:
     uint32_t numTuples;
-    uint64_t totalSize;
     uint64_t freeSize;
 
 private:

--- a/src/include/storage/buffer_manager/memory_manager.h
+++ b/src/include/storage/buffer_manager/memory_manager.h
@@ -7,6 +7,7 @@
 
 #include "common/constants.h"
 #include "common/types/types.h"
+#include <span>
 
 namespace kuzu {
 namespace main {
@@ -30,10 +31,9 @@ public:
     ~MemoryBuffer();
 
 public:
-    uint8_t* buffer;
+    std::span<uint8_t> buffer;
     common::page_idx_t pageIdx;
     MemoryAllocator* allocator;
-    uint64_t size;
 };
 
 class MemoryAllocator {
@@ -49,7 +49,7 @@ public:
     inline common::page_offset_t getPageSize() const { return pageSize; }
 
 private:
-    void freeBlock(common::page_idx_t pageIdx, uint8_t* buffer);
+    void freeBlock(common::page_idx_t pageIdx, std::span<uint8_t> buffer);
 
 private:
     std::unique_ptr<BMFileHandle> fh;

--- a/test/storage/CMakeLists.txt
+++ b/test/storage/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_kuzu_test(node_insertion_deletion_test node_insertion_deletion_test.cpp)
 add_kuzu_test(compression_test compression_test.cpp)
+add_kuzu_test(buffer_manager_test buffer_manager_test.cpp)

--- a/test/storage/buffer_manager_test.cpp
+++ b/test/storage/buffer_manager_test.cpp
@@ -1,0 +1,36 @@
+#include "graph_test/graph_test.h"
+#include "gtest/gtest.h"
+#include "spdlog/common.h"
+#include "spdlog/spdlog.h"
+#include "storage/buffer_manager/buffer_manager.h"
+
+using namespace kuzu::common;
+using namespace kuzu::storage;
+
+namespace kuzu {
+namespace testing {
+
+class BufferManagerTest : public DBTest {
+public:
+    std::string getInputDir() override {
+        return TestHelper::appendKuzuRootPath("dataset/tinysnb/");
+    }
+};
+
+TEST_F(BufferManagerTest, TestBMUsageForIdenticalQueries) {
+    auto bm = getBufferManager(*database);
+    auto initialMemoryUsage = bm->getUsedMemory();
+
+    auto result = conn->query("MATCH (p:person) WHERE p.ID = 0 RETURN p.fName");
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    auto memoryUsed = bm->getUsedMemory();
+    result = conn->query("MATCH (p:person) WHERE p.ID = 0 RETURN p.fName");
+    ASSERT_TRUE(result->isSuccess()) << result->toString();
+    ASSERT_EQ(memoryUsed, bm->getUsedMemory())
+        << "Memory usage after two identical queries should be identical";
+    spdlog::info("Memory used initially: {}", initialMemoryUsage);
+    spdlog::info("Memory used after transactions: {}", memoryUsed);
+}
+
+} // namespace testing
+} // namespace kuzu


### PR DESCRIPTION
To follow up the missing part of #3243, this adds BufferManager tracking for variable-sized memory allocations made through the MemoryManager.

I also noticed that the buffer manager wasn't freeing the memory related to evictions if it fails to allocate the total amount of memory requested when claiming a frame. I don't know how much of our code at the moment can safely recover from failing to claim memory and continue allocations though, so it may not make a difference at the moment. I had noticed subsequent failures which seemed to be related to data not being successfully written in the multi copy test that was failing due to not having enough memory in #3557 (e.g. accessing out of bounds in a hash index disk array, which I think would have been in bounds if the data had been updated correctly), so at the moment it may not always be possible to continue using the database after such a failure.