### PR TITLE
Fix return type

### DIFF
--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, List
 
 from . import _kuzu
 from .prepared_statement import PreparedStatement
@@ -98,7 +98,7 @@ class Connection:
         self,
         query: str | PreparedStatement,
         parameters: dict[str, Any] | None = None,
-    ) -> QueryResult | [QueryResult]:
+    ) -> QueryResult | List[QueryResult]:
         """
         Execute a query.
 

--- a/tools/python_api/src_py/connection.py
+++ b/tools/python_api/src_py/connection.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, List
+from typing import TYPE_CHECKING, Any, Callable
 
 from . import _kuzu
 from .prepared_statement import PreparedStatement
@@ -98,7 +98,7 @@ class Connection:
         self,
         query: str | PreparedStatement,
         parameters: dict[str, Any] | None = None,
-    ) -> QueryResult | List[QueryResult]:
+    ) -> QueryResult | list[QueryResult]:
         """
         Execute a query.
 


### PR DESCRIPTION
# Description

I think it is intended to return a `list`/`List` here, right?
The `List` version provides more backwards-compatibility. For Python 3.9+ client support we might just type it `list`.

# Contributor agreement

- [x ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).