### PR TITLE
Fix stats updates

### DIFF
--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -184,7 +184,7 @@ protected:
 
     static ChunkCollection getNullChunkCollection(const ChunkCollection& chunkCollection);
     void updateStatistics(ColumnChunkMetadata& metadata, common::offset_t maxIndex,
-        std::optional<StorageValue> min, std::optional<StorageValue> max);
+        const std::optional<StorageValue>& min, const std::optional<StorageValue>& max);
 
 private:
     bool isInsertionsOutOfPagesCapacity(const ColumnChunkMetadata& metadata,

--- a/test/test_files/copy/copy_rel_stats.test
+++ b/test/test_files/copy/copy_rel_stats.test
@@ -1,0 +1,17 @@
+-DATASET CSV tinysnb
+
+--
+-CASE CopyRelStatistics
+-STATEMENT CALL storage_info('knows') WHERE column_name = "bwd_date" RETURN min, max;
+---- 1
+1905-12-12|2021-06-30
+-STATEMENT CALL storage_info('knows') WHERE column_name = "fwd_date" RETURN min, max;
+---- 1
+1905-12-12|2021-06-30
+
+-STATEMENT CALL storage_info('knows') WHERE column_name = "bwd_meetTime" RETURN min, max;
+---- 1
+1936-11-02 11:02:01|2025-01-01 11:22:33.52
+-STATEMENT CALL storage_info('knows') WHERE column_name = "fwd_meetTime" RETURN min, max;
+---- 1
+1936-11-02 11:02:01|2025-01-01 11:22:33.52

--- a/test/test_files/update_node/stats.test
+++ b/test/test_files/update_node/stats.test
@@ -88,6 +88,16 @@ True
 -STATEMENT CALL storage_info('test') WHERE column_name = "value" RETURN to_int8(min) <= 2;
 ---- 1
 True
+-STATEMENT MATCH (a:test) WHERE a.value = 2 SET a.value = -2
+---- ok
+-STATEMENT CALL storage_info('test') WHERE column_name = "value" RETURN min;
+---- 1
+-2
+-STATEMENT MATCH (a:test) WHERE a.value = -2 SET a.value = -3
+---- ok
+-STATEMENT CALL storage_info('test') WHERE column_name = "value" RETURN min;
+---- 1
+-3
 
 -CASE UpdateDoubleStats
 -STATEMENT CREATE NODE TABLE test(id SERIAL, value DOUBLE, PRIMARY KEY(id));


### PR DESCRIPTION
Make use of the data offset when calculating the minimum and maximum values of column updates.
Also make use of null data to avoid including stats for placeholder data to avoid including stats for placeholder data used for null values.

Fixes #3572.

I added some tests for testing updates to multiple nodes, as that wasn't previously covered, as well as some negatives (for an issue which I suspected but turned out to something else, but it's probably useful extra coverage, especially since I noticed that few of the existing statistics tests were doing in-place updates that increase the min/max range).