### PR TITLE
Fix issue-3570

### DIFF
--- a/src/include/planner/operator/scan/logical_scan_node_table.h
+++ b/src/include/planner/operator/scan/logical_scan_node_table.h
@@ -62,7 +62,7 @@ public:
     void computeFlatSchema() override;
 
     std::string getExpressionsForPrinting() const override {
-        return binder::ExpressionUtil::toString(properties);
+        return nodeID->toString() + " " + binder::ExpressionUtil::toString(properties);
     }
 
     LogicalScanNodeTableType getScanType() const { return scanType; }

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -468,7 +468,7 @@ void Planner::planWCOJoin(const SubqueryGraph& subgraph,
         // node-at-a-time enumeration and re-enable WCOJ.
         // TODO(Xiyang): Fixme according to the description above.
         if (leftPlan->getSchema()->isExpressionInScope(*intersectNode->getInternalID())) {
-            continue ;
+            continue;
         }
         auto leftPlanCopy = leftPlan->shallowCopy();
         std::vector<std::unique_ptr<LogicalPlan>> rightPlansCopy;

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -459,6 +459,17 @@ void Planner::planWCOJoin(const SubqueryGraph& subgraph,
     auto predicates =
         getNewlyMatchedExpressions(prevSubgraphs, newSubgraph, context.getWhereExpressions());
     for (auto& leftPlan : context.getPlans(subgraph)) {
+        // Disable WCOJ if intersect node is in the scope of probe plan. This happens in the case
+        // like, MATCH (a)-[e1]->(b), (b)-[e2]->(a), (a)-[e3]->(b).
+        // When we perform edge-at-a-time enumeration, at some point we will in the state of e1 as
+        // probe side and e2, e3 as build side and we attempt to apply WCOJ. However, the right
+        // approach is to build e1, e2, e3 and intersect on a common node (either a or b).
+        // I tend to disable WCOJ for this case for now. The proper fix should be move to
+        // node-at-a-time enumeration and re-enable WCOJ.
+        // TODO(Xiyang): Fixme according to the description above.
+        if (leftPlan->getSchema()->isExpressionInScope(*intersectNode->getInternalID())) {
+            continue ;
+        }
         auto leftPlanCopy = leftPlan->shallowCopy();
         std::vector<std::unique_ptr<LogicalPlan>> rightPlansCopy;
         rightPlansCopy.reserve(relPlans.size());

--- a/test/test_files/tinysnb/cyclic/single_label.test
+++ b/test/test_files/tinysnb/cyclic/single_label.test
@@ -9,7 +9,9 @@
 -ENUMERATE
 ---- 1
 12
-
+-STATEMENT MATCH (a:person)-[:knows]->(b:person), (b)-[:knows]->(a), (a)-[:knows]->(b)  RETURN COUNT(*)
+---- 1
+12
 -LOG TwoNodeCycleWithProjectionTest
 -STATEMENT MATCH (a:person)-[:knows]->(b:person), (b)-[:knows]->(a) RETURN a.fName, b.fName
 -ENUMERATE


### PR DESCRIPTION
# Description

The bug is due to an incorrect planning of Worst-Case-Optimal Join. I copy paste my comment here.
```
// Disable WCOJ if intersect node is in the scope of probe plan. This happens in the case
// like, MATCH (a)-[e1]->(b), (b)-[e2]->(a), (a)-[e3]->(b).
// When we perform edge-at-a-time enumeration, at some point we will in the state of e1 as
// probe side and e2, e3 as build side and we attempt to apply WCOJ. However, the right
// approach is to build e1, e2, e3 and intersect on a common node (either a or b).
// I tend to disable WCOJ for this case for now. The proper fix should be move to
// node-at-a-time enumeration and re-enable WCOJ.
```

Fixes #3570 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).