### PR TITLE
Clean up ColumnChunk

### DIFF
--- a/src/include/processor/operator/persistent/index_builder.h
+++ b/src/include/processor/operator/persistent/index_builder.h
@@ -150,7 +150,7 @@ public:
 
     IndexBuilder clone() { return IndexBuilder(sharedState); }
 
-    void insert(const storage::ColumnChunk& chunk, common::offset_t nodeOffset,
+    void insert(const storage::ColumnChunkData& chunk, common::offset_t nodeOffset,
         common::offset_t numNodes);
 
     ProducerToken getProducerToken() const { return ProducerToken(sharedState); }
@@ -159,7 +159,7 @@ public:
     void finalize(ExecutionContext* context);
 
 private:
-    void checkNonNullConstraint(const storage::NullColumnChunk& nullChunk,
+    void checkNonNullConstraint(const storage::NullChunkData& nullChunk,
         common::offset_t numNodes);
     std::shared_ptr<IndexBuilderSharedState> sharedState;
 

--- a/src/include/processor/operator/persistent/index_builder.h
+++ b/src/include/processor/operator/persistent/index_builder.h
@@ -159,8 +159,7 @@ public:
     void finalize(ExecutionContext* context);
 
 private:
-    void checkNonNullConstraint(const storage::NullChunkData& nullChunk,
-        common::offset_t numNodes);
+    void checkNonNullConstraint(const storage::NullChunkData& nullChunk, common::offset_t numNodes);
     std::shared_ptr<IndexBuilderSharedState> sharedState;
 
     IndexBuilderLocalBuffers localBuffers;

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -77,10 +77,10 @@ private:
         const storage::ChunkedNodeGroupCollection& partition, common::column_id_t offsetColumnID);
     static void populateEndCSROffsets(storage::ChunkedCSRHeader& csrHeader,
         std::vector<common::offset_t>& gaps);
-    static void setOffsetToWithinNodeGroup(storage::ColumnChunk& chunk,
+    static void setOffsetToWithinNodeGroup(storage::ColumnChunkData& chunk,
         common::offset_t startOffset);
-    static void setOffsetFromCSROffsets(storage::ColumnChunk& nodeOffsetChunk,
-        storage::ColumnChunk& csrOffsetChunk);
+    static void setOffsetFromCSROffsets(storage::ColumnChunkData& nodeOffsetChunk,
+        storage::ColumnChunkData& csrOffsetChunk);
 
     static std::optional<common::offset_t> checkRelMultiplicityConstraint(
         const storage::ChunkedCSRHeader& csrHeader, const RelBatchInsertInfo& relInfo);

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -16,7 +16,7 @@ class NullMask;
 } // namespace common
 
 namespace storage {
-class ColumnChunk;
+class ColumnChunkData;
 
 struct PageCursor;
 
@@ -184,7 +184,7 @@ public:
     explicit ConstantCompression(const common::LogicalType& logicalType)
         : numBytesPerValue{static_cast<uint8_t>(getDataTypeSizeInChunk(logicalType))},
           dataType{logicalType.getPhysicalType()} {}
-    static std::optional<CompressionMetadata> analyze(const ColumnChunk& chunk);
+    static std::optional<CompressionMetadata> analyze(const ColumnChunkData& chunk);
 
     // Shouldn't be used, there's a special case when compressing which ends early for constant
     // compression
@@ -207,7 +207,7 @@ public:
     // Nothing to do; constant compressed data is only updated if the update is to the same value
     void setValuesFromUncompressed(const uint8_t*, common::offset_t, uint8_t*, common::offset_t,
         common::offset_t, const CompressionMetadata&,
-        const common::NullMask* /*nullMask*/) const override {};
+        const common::NullMask* /*nullMask*/) const override{};
 
     CompressionType getCompressionType() const override { return CompressionType::CONSTANT; }
 

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -207,7 +207,7 @@ public:
     // Nothing to do; constant compressed data is only updated if the update is to the same value
     void setValuesFromUncompressed(const uint8_t*, common::offset_t, uint8_t*, common::offset_t,
         common::offset_t, const CompressionMetadata&,
-        const common::NullMask* /*nullMask*/) const override{};
+        const common::NullMask* /*nullMask*/) const override {};
 
     CompressionType getCompressionType() const override { return CompressionType::CONSTANT; }
 

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -17,7 +17,7 @@ using offset_set_t = std::unordered_set<common::offset_t>;
 static constexpr common::column_id_t NBR_ID_COLUMN_ID = 0;
 static constexpr common::column_id_t REL_ID_COLUMN_ID = 1;
 
-using ChunkCollection = std::vector<ColumnChunk*>;
+using ChunkCollection = std::vector<ColumnChunkData*>;
 
 class LocalChunkedGroupCollection {
 public:
@@ -51,7 +51,7 @@ public:
     }
     const offset_to_row_idx_t& getOffsetToRowIdx() const { return offsetToRowIdx; }
 
-    void appendChunkedGroup(ColumnChunk* srcOffsetChunk,
+    void appendChunkedGroup(ColumnChunkData* srcOffsetChunk,
         std::unique_ptr<ChunkedNodeGroup> chunkedGroup);
 
     bool isEmpty() const { return offsetToRowIdx.empty() && srcNodeOffsetToRelOffsets.empty(); }

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -34,7 +34,6 @@ class StructColumn;
 class RelTableData;
 class Column {
     friend class StringColumn;
-    friend class ListLocalColumn;
     friend class StructColumn;
     friend class ListColumn;
     friend class RelTableData;
@@ -80,11 +79,11 @@ public:
         common::ValueVector* resultVector, uint64_t offsetInVector);
     // Scan from [startOffsetInGroup, endOffsetInGroup).
     virtual void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        ColumnChunk* columnChunk, common::offset_t startOffset = 0,
+        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET);
 
     // Append column chunk in a new node group.
-    virtual void append(ColumnChunk* columnChunk, ChunkState& state);
+    virtual void append(ColumnChunkData* columnChunk, ChunkState& state);
 
     common::LogicalType& getDataType() { return dataType; }
     const common::LogicalType& getDataType() const { return dataType; }
@@ -105,7 +104,7 @@ public:
         const offset_set_t& deleteInfo);
     void prepareCommitForChunk(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, bool isNewNodeGroup,
-        const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
+        const std::vector<common::offset_t>& dstOffsets, ColumnChunkData* chunk,
         common::offset_t startSrcOffset);
 
     virtual void prepareCommitForExistingChunk(transaction::Transaction* transaction,
@@ -113,7 +112,7 @@ public:
         const offset_to_row_idx_t& insertInfo, const ChunkCollection& localUpdateChunks,
         const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo);
     virtual void prepareCommitForExistingChunk(transaction::Transaction* transaction,
-        ChunkState& state, const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
+        ChunkState& state, const std::vector<common::offset_t>& dstOffsets, ColumnChunkData* chunk,
         common::offset_t startSrcOffset);
 
     virtual void checkpointInMemory();
@@ -137,16 +136,16 @@ public:
     virtual void write(ChunkState& state, common::offset_t offsetInChunk,
         common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom);
     // Batch write to a set of sequential pages.
-    virtual void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunk* data,
+    virtual void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunkData* data,
         common::offset_t dataOffset, common::length_t numValues);
 
     // Append values to the end of the node group, resizing it if necessary
     common::offset_t appendValues(ChunkState& state, const uint8_t* data,
         const common::NullMask* nullChunkData, common::offset_t numValues);
 
-    virtual std::unique_ptr<ColumnChunk> getEmptyChunkForCommit(uint64_t capacity);
+    virtual std::unique_ptr<ColumnChunkData> getEmptyChunkForCommit(uint64_t capacity);
     static void applyLocalChunkToColumnChunk(const ChunkCollection& localChunks,
-        ColumnChunk* columnChunk, const offset_to_row_idx_t& info);
+        ColumnChunkData* columnChunk, const offset_to_row_idx_t& info);
 
 protected:
     virtual void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
@@ -201,7 +200,7 @@ private:
         const offset_to_row_idx_t& insertInfo, const ChunkCollection& localUpdateChunks,
         const offset_to_row_idx_t& updateInfo);
     virtual bool canCommitInPlace(const ChunkState& state,
-        const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
+        const std::vector<common::offset_t>& dstOffsets, ColumnChunkData* chunk,
         common::offset_t srcOffset);
 
     virtual void commitLocalChunkInPlace(ChunkState& state,
@@ -214,11 +213,11 @@ private:
         const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo);
 
     virtual void commitColumnChunkInPlace(ChunkState& state,
-        const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
+        const std::vector<common::offset_t>& dstOffsets, ColumnChunkData* chunk,
         common::offset_t srcOffset);
     virtual void commitColumnChunkOutOfPlace(transaction::Transaction* transaction,
         ChunkState& state, bool isNewNodeGroup, const std::vector<common::offset_t>& dstOffsets,
-        ColumnChunk* chunk, common::offset_t srcOffset);
+        ColumnChunkData* chunk, common::offset_t srcOffset);
 
     void applyLocalChunkToColumn(ChunkState& state, const ChunkCollection& localChunks,
         const offset_to_row_idx_t& info);

--- a/src/include/storage/store/dictionary_chunk.h
+++ b/src/include/storage/store/dictionary_chunk.h
@@ -23,8 +23,8 @@ public:
 
     std::string_view getString(string_index_t index) const;
 
-    inline ColumnChunk* getStringDataChunk() const { return stringDataChunk.get(); }
-    inline ColumnChunk* getOffsetChunk() const { return offsetChunk.get(); }
+    ColumnChunkData* getStringDataChunk() const { return stringDataChunk.get(); }
+    ColumnChunkData* getOffsetChunk() const { return offsetChunk.get(); }
 
     bool sanityCheck() const;
 
@@ -32,8 +32,8 @@ private:
     bool enableCompression;
     // String data is stored as a UINT8 chunk, using the numValues in the chunk to track the number
     // of characters stored.
-    std::unique_ptr<ColumnChunk> stringDataChunk;
-    std::unique_ptr<ColumnChunk> offsetChunk;
+    std::unique_ptr<ColumnChunkData> stringDataChunk;
+    std::unique_ptr<ColumnChunkData> offsetChunk;
 
     struct DictionaryEntry {
         string_index_t index;

--- a/src/include/storage/store/list_column_chunk.h
+++ b/src/include/storage/store/list_column_chunk.h
@@ -8,10 +8,10 @@ namespace storage {
 
 // TODO(Guodong): Let's simplify the data structure here by getting rid of this class.
 struct ListDataColumnChunk {
-    std::unique_ptr<ColumnChunk> dataColumnChunk;
+    std::unique_ptr<ColumnChunkData> dataColumnChunk;
     uint64_t capacity;
 
-    explicit ListDataColumnChunk(std::unique_ptr<ColumnChunk> dataChunk)
+    explicit ListDataColumnChunk(std::unique_ptr<ColumnChunkData> dataChunk)
         : dataColumnChunk{std::move(dataChunk)}, capacity{this->dataColumnChunk->capacity} {}
 
     void reset() const;
@@ -25,20 +25,20 @@ struct ListDataColumnChunk {
     uint64_t getNumValues() const { return dataColumnChunk->getNumValues(); }
 };
 
-class ListColumnChunk final : public ColumnChunk {
+class ListChunkData final : public ColumnChunkData {
 
 public:
-    ListColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
+    ListChunkData(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
         bool inMemory);
 
-    ColumnChunk* getDataColumnChunk() const { return listDataColumnChunk->dataColumnChunk.get(); }
+    ColumnChunkData* getDataColumnChunk() const { return listDataColumnChunk->dataColumnChunk.get(); }
 
-    ColumnChunk* getSizeColumnChunk() const { return sizeColumnChunk.get(); }
+    ColumnChunkData* getSizeColumnChunk() const { return sizeColumnChunk.get(); }
 
     void resetToEmpty() override;
 
     void setNumValues(uint64_t numValues_) override {
-        ColumnChunk::setNumValues(numValues_);
+        ColumnChunkData::setNumValues(numValues_);
         sizeColumnChunk->setNumValues(numValues_);
     }
 
@@ -50,17 +50,17 @@ public:
     // Note: `write` assumes that no `append` will be called afterward.
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) override;
-    void write(ColumnChunk* chunk, ColumnChunk* dstOffsets,
+    void write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
         common::RelMultiplicity multiplicity) override;
-    void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
+    void write(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
-    void copy(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
+    void copy(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
     void resizeDataColumnChunk(uint64_t numValues) { listDataColumnChunk->resizeBuffer(numValues); }
 
     void resize(uint64_t newCapacity) override {
-        ColumnChunk::resize(newCapacity);
+        ColumnChunkData::resize(newCapacity);
         sizeColumnChunk->resize(newCapacity);
     }
 
@@ -71,7 +71,7 @@ public:
     common::list_size_t getListSize(common::offset_t offset) const;
 
     void resetOffset();
-    void resetFromOtherChunk(ListColumnChunk* other);
+    void resetFromOtherChunk(ListChunkData* other);
     void finalize() override;
     bool isOffsetsConsecutiveAndSortedAscending(uint64_t startPos, uint64_t endPos) const;
     bool sanityCheck() override;
@@ -80,13 +80,13 @@ protected:
     void copyListValues(const common::list_entry_t& entry, common::ValueVector* dataVector);
 
 private:
-    void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
+    void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) override;
 
     void appendNullList();
 
 protected:
-    std::unique_ptr<ColumnChunk> sizeColumnChunk;
+    std::unique_ptr<ColumnChunkData> sizeColumnChunk;
     std::unique_ptr<ListDataColumnChunk> listDataColumnChunk;
     // we use checkOffsetSortedAsc flag to indicate that we do not trigger random write
     bool checkOffsetSortedAsc;

--- a/src/include/storage/store/list_column_chunk.h
+++ b/src/include/storage/store/list_column_chunk.h
@@ -31,7 +31,9 @@ public:
     ListChunkData(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
         bool inMemory);
 
-    ColumnChunkData* getDataColumnChunk() const { return listDataColumnChunk->dataColumnChunk.get(); }
+    ColumnChunkData* getDataColumnChunk() const {
+        return listDataColumnChunk->dataColumnChunk.get();
+    }
 
     ColumnChunkData* getSizeColumnChunk() const { return sizeColumnChunk.get(); }
 

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -24,13 +24,13 @@ public:
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) override;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        ColumnChunk* columnChunk, common::offset_t startOffset = 0,
+        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
 
     void lookup(transaction::Transaction* transaction, ChunkState& readState,
         common::ValueVector* nodeIDVector, common::ValueVector* resultVector) override;
 
-    void append(ColumnChunk* columnChunk, ChunkState& state) override;
+    void append(ColumnChunkData* columnChunk, ChunkState& state) override;
 
     bool isNull(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t offsetInChunk);
@@ -38,7 +38,7 @@ public:
 
     void write(ChunkState& state, common::offset_t offsetInChunk,
         common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
-    void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunk* data,
+    void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunkData* data,
         common::offset_t dataOffset, common::length_t numValues) override;
 
     void commitLocalChunkInPlace(ChunkState& state, const ChunkCollection& localInsertChunk,
@@ -46,8 +46,8 @@ public:
         const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo) override;
 
 private:
-    std::unique_ptr<ColumnChunk> getEmptyChunkForCommit(uint64_t capacity) override {
-        return ColumnChunkFactory::createNullColumnChunk(enableCompression, capacity);
+    std::unique_ptr<ColumnChunkData> getEmptyChunkForCommit(uint64_t capacity) override {
+        return ColumnChunkFactory::createNullChunkData(enableCompression, capacity);
     }
 };
 

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -97,7 +97,7 @@ class RelTableData final : public TableData {
 public:
     struct PersistentState {
         ChunkedCSRHeader header;
-        std::unique_ptr<ColumnChunk> relIDChunk;
+        std::unique_ptr<ColumnChunkData> relIDChunk;
         common::offset_t leftCSROffset = common::INVALID_OFFSET;
         common::offset_t rightCSROffset = common::INVALID_OFFSET;
 
@@ -188,7 +188,7 @@ private:
         common::node_group_idx_t nodeGroupIdx, bool isNewNodeGroup,
         PersistentState& persistentState, LocalState& localState);
     static void commitCSRHeaderChunk(transaction::Transaction* transaction, bool isNewNodeGroup,
-        common::node_group_idx_t nodeGroupIdx, Column* column, ColumnChunk* columnChunk,
+        common::node_group_idx_t nodeGroupIdx, Column* column, ColumnChunkData* columnChunk,
         const LocalState& localState, const std::vector<common::offset_t>& dstOffsets);
 
     void distributeOffsets(const ChunkedCSRHeader& header, LocalState& localState,
@@ -212,12 +212,12 @@ private:
         const LocalState& localState, uint64_t numValuesToInsert);
 
     static void applyUpdatesToChunk(const PersistentState& persistentState,
-        const LocalState& localState, const ChunkCollection& localChunk, ColumnChunk* chunk,
+        const LocalState& localState, const ChunkCollection& localChunk, ColumnChunkData* chunk,
         common::column_id_t columnID);
     static void applyInsertionsToChunk(const PersistentState& persistentState,
-        const LocalState& localState, const ChunkCollection& localChunk, ColumnChunk* chunk);
+        const LocalState& localState, const ChunkCollection& localChunk, ColumnChunkData* chunk);
     static void applyDeletionsToChunk(const PersistentState& persistentState,
-        const LocalState& localState, ColumnChunk* chunk);
+        const LocalState& localState, ColumnChunkData* chunk);
 
     static void applyUpdatesToColumn(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, bool isNewNodeGroup, common::column_id_t columnID,

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -19,15 +19,15 @@ public:
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        ColumnChunk* columnChunk, common::offset_t startOffset = 0,
+        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
 
-    void append(ColumnChunk* columnChunk, ChunkState& state) override;
+    void append(ColumnChunkData* columnChunk, ChunkState& state) override;
 
     void writeValue(ChunkState& state, common::offset_t offsetInChunk,
         common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
 
-    void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunk* data,
+    void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunkData* data,
         common::offset_t dataOffset, common::length_t numValues) override;
 
     void prepareCommit() override;
@@ -55,7 +55,7 @@ private:
         const offset_to_row_idx_t& insertInfo, const ChunkCollection& localUpdateChunk,
         const offset_to_row_idx_t& updateInfo) override;
     bool canCommitInPlace(const ChunkState& state, const std::vector<common::offset_t>& dstOffsets,
-        ColumnChunk* chunk, common::offset_t srcOffset) override;
+        ColumnChunkData* chunk, common::offset_t srcOffset) override;
 
     bool canIndexCommitInPlace(const ChunkState& dataState, uint64_t numStrings,
         common::offset_t maxOffset);

--- a/src/include/storage/store/string_column_chunk.h
+++ b/src/include/storage/store/string_column_chunk.h
@@ -9,14 +9,14 @@
 namespace kuzu {
 namespace storage {
 
-class StringColumnChunk final : public ColumnChunk {
+class StringChunkData final : public ColumnChunkData {
 public:
-    StringColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
+    StringChunkData(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
         bool inMemory);
 
-    void resetToEmpty() final;
-    void append(common::ValueVector* vector, const common::SelectionVector& selVector) final;
-    void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
+    void resetToEmpty() override;
+    void append(common::ValueVector* vector, const common::SelectionVector& selVector) override;
+    void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend) override;
 
     void lookup(common::offset_t offsetInChunk, common::ValueVector& output,
@@ -24,11 +24,11 @@ public:
 
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) override;
-    void write(ColumnChunk* chunk, ColumnChunk* dstOffsets,
+    void write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
         common::RelMultiplicity multiplicity) override;
-    void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
+    void write(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
-    void copy(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
+    void copy(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
     template<typename T>
@@ -37,17 +37,17 @@ public:
     }
 
     uint64_t getStringLength(common::offset_t pos) const {
-        auto index = ColumnChunk::getValue<DictionaryChunk::string_index_t>(pos);
+        auto index = ColumnChunkData::getValue<DictionaryChunk::string_index_t>(pos);
         return dictionaryChunk->getStringLength(index);
     }
 
-    inline DictionaryChunk& getDictionaryChunk() { return *dictionaryChunk; }
-    inline const DictionaryChunk& getDictionaryChunk() const { return *dictionaryChunk; }
+    DictionaryChunk& getDictionaryChunk() { return *dictionaryChunk; }
+    const DictionaryChunk& getDictionaryChunk() const { return *dictionaryChunk; }
 
     void finalize() override;
 
 private:
-    void appendStringColumnChunk(StringColumnChunk* other, common::offset_t startPosInOtherChunk,
+    void appendStringColumnChunk(StringChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend);
 
     void setValueFromString(std::string_view value, uint64_t pos);
@@ -60,9 +60,9 @@ private:
 
 // STRING
 template<>
-std::string StringColumnChunk::getValue<std::string>(common::offset_t pos) const;
+std::string StringChunkData::getValue<std::string>(common::offset_t pos) const;
 template<>
-std::string_view StringColumnChunk::getValue<std::string_view>(common::offset_t pos) const;
+std::string_view StringChunkData::getValue<std::string_view>(common::offset_t pos) const;
 
 } // namespace storage
 } // namespace kuzu

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -15,13 +15,13 @@ public:
     void initChunkState(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, ChunkState& chunkState) override;
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
-        ColumnChunk* columnChunk, common::offset_t startOffset = 0,
+        ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) override;
 
-    void append(ColumnChunk* columnChunk, ChunkState& state) override;
+    void append(ColumnChunkData* columnChunk, ChunkState& state) override;
 
     void checkpointInMemory() override;
     void rollbackInMemory() override;
@@ -33,7 +33,7 @@ public:
     }
     void write(ChunkState& state, common::offset_t offsetInChunk,
         common::ValueVector* vectorToWriteFrom, uint32_t posInVectorToWriteFrom) override;
-    void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunk* data,
+    void write(ChunkState& state, common::offset_t offsetInChunk, ColumnChunkData* data,
         common::offset_t dataOffset, common::length_t numValues) override;
 
     void prepareCommitForExistingChunk(transaction::Transaction* transaction, ChunkState& state,
@@ -41,7 +41,7 @@ public:
         const ChunkCollection& localUpdateChunks, const offset_to_row_idx_t& updateInfo,
         const offset_set_t& deleteInfo) override;
     void prepareCommitForExistingChunk(transaction::Transaction* transaction, ChunkState& state,
-        const std::vector<common::offset_t>& dstOffsets, ColumnChunk* chunk,
+        const std::vector<common::offset_t>& dstOffsets, ColumnChunkData* chunk,
         common::offset_t startSrcOffset) override;
 
 protected:

--- a/src/include/storage/store/struct_column_chunk.h
+++ b/src/include/storage/store/struct_column_chunk.h
@@ -8,12 +8,12 @@
 namespace kuzu {
 namespace storage {
 
-class StructColumnChunk final : public ColumnChunk {
+class StructChunkData final : public ColumnChunkData {
 public:
-    StructColumnChunk(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
+    StructChunkData(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
         bool inMemory);
 
-    inline ColumnChunk* getChild(common::idx_t childIdx) {
+    ColumnChunkData* getChild(common::idx_t childIdx) {
         KU_ASSERT(childIdx < childChunks.size());
         return childChunks[childIdx].get();
     }
@@ -21,20 +21,20 @@ public:
     void finalize() override;
 
 protected:
-    void append(ColumnChunk* other, common::offset_t startPosInOtherChunk,
-        uint32_t numValuesToAppend) final;
-    void append(common::ValueVector* vector, const common::SelectionVector& selVector) final;
+    void append(ColumnChunkData* other, common::offset_t startPosInOtherChunk,
+        uint32_t numValuesToAppend) override;
+    void append(common::ValueVector* vector, const common::SelectionVector& selVector) override;
 
     void lookup(common::offset_t offsetInChunk, common::ValueVector& output,
         common::sel_t posInOutputVector) const override;
 
     void write(common::ValueVector* vector, common::offset_t offsetInVector,
         common::offset_t offsetInChunk) override;
-    void write(ColumnChunk* chunk, ColumnChunk* dstOffsets,
+    void write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
         common::RelMultiplicity multiplicity) override;
-    void write(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
+    void write(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
-    void copy(ColumnChunk* srcChunk, common::offset_t srcOffsetInChunk,
+    void copy(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
     void resize(uint64_t newCapacity) override;
@@ -44,14 +44,14 @@ protected:
     bool numValuesSanityCheck() const override;
 
     void setNumValues(uint64_t numValues) override {
-        ColumnChunk::setNumValues(numValues);
+        ColumnChunkData::setNumValues(numValues);
         for (auto& childChunk : childChunks) {
             childChunk->setNumValues(numValues);
         }
     }
 
 private:
-    std::vector<std::unique_ptr<ColumnChunk>> childChunks;
+    std::vector<std::unique_ptr<ColumnChunkData>> childChunks;
 };
 
 } // namespace storage

--- a/src/include/transaction/transaction_context.h
+++ b/src/include/transaction/transaction_context.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <mutex>
+
 #include "transaction.h"
 
 namespace kuzu {

--- a/src/processor/operator/persistent/index_builder.cpp
+++ b/src/processor/operator/persistent/index_builder.cpp
@@ -88,7 +88,7 @@ void IndexBuilderSharedState::quitProducer() {
     }
 }
 
-void IndexBuilder::insert(const ColumnChunk& chunk, offset_t nodeOffset, offset_t numNodes) {
+void IndexBuilder::insert(const ColumnChunkData& chunk, offset_t nodeOffset, offset_t numNodes) {
     checkNonNullConstraint(chunk.getNullChunk(), numNodes);
 
     TypeUtils::visit(
@@ -101,7 +101,7 @@ void IndexBuilder::insert(const ColumnChunk& chunk, offset_t nodeOffset, offset_
         },
         [&](ku_string_t) {
             auto& stringColumnChunk =
-                ku_dynamic_cast<const ColumnChunk&, const StringColumnChunk&>(chunk);
+                ku_dynamic_cast<const ColumnChunkData&, const StringChunkData&>(chunk);
             for (auto i = 0u; i < numNodes; i++) {
                 auto value = stringColumnChunk.getValue<std::string>(i);
                 localBuffers.insert(std::move(value), nodeOffset + i);
@@ -129,7 +129,7 @@ void IndexBuilder::finalize(ExecutionContext* /*context*/) {
     sharedState->flush();
 }
 
-void IndexBuilder::checkNonNullConstraint(const NullColumnChunk& nullChunk, offset_t numNodes) {
+void IndexBuilder::checkNonNullConstraint(const NullChunkData& nullChunk, offset_t numNodes) {
     for (auto i = 0u; i < numNodes; i++) {
         if (nullChunk.isNull(i)) {
             throw CopyException(ExceptionMessage::nullPKException());

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -92,7 +92,7 @@ void RelBatchInsert::mergeNodeGroup(transaction::Transaction* transaction,
         auto& offsetChunk = chunkedGroup->getColumnChunkUnsafe(relInfo.offsetColumnID);
         numRels += chunkedGroup->getNumRows();
         setOffsetToWithinNodeGroup(offsetChunk, startNodeOffset);
-        std::vector<std::unique_ptr<ColumnChunk>> chunksToAppend;
+        std::vector<std::unique_ptr<ColumnChunkData>> chunksToAppend;
         for (auto i = 0u; i < chunkedGroup->getNumColumns(); i++) {
             if (i == relInfo.offsetColumnID) {
                 // Skip the offset vector.
@@ -155,7 +155,7 @@ std::vector<offset_t> RelBatchInsert::populateStartCSROffsetsAndLengths(ChunkedC
     return gaps;
 }
 
-void RelBatchInsert::setOffsetToWithinNodeGroup(ColumnChunk& chunk, offset_t startOffset) {
+void RelBatchInsert::setOffsetToWithinNodeGroup(ColumnChunkData& chunk, offset_t startOffset) {
     KU_ASSERT(chunk.getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
     auto offsets = (offset_t*)chunk.getData();
     for (auto i = 0u; i < chunk.getNumValues(); i++) {
@@ -163,8 +163,8 @@ void RelBatchInsert::setOffsetToWithinNodeGroup(ColumnChunk& chunk, offset_t sta
     }
 }
 
-void RelBatchInsert::setOffsetFromCSROffsets(ColumnChunk& nodeOffsetChunk,
-    ColumnChunk& csrOffsetChunk) {
+void RelBatchInsert::setOffsetFromCSROffsets(ColumnChunkData& nodeOffsetChunk,
+    ColumnChunkData& csrOffsetChunk) {
     KU_ASSERT(nodeOffsetChunk.getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
     for (auto i = 0u; i < nodeOffsetChunk.getNumValues(); i++) {
         auto nodeOffset = nodeOffsetChunk.getValue<offset_t>(i);

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -170,7 +170,7 @@ uint64_t CompressionMetadata::numValues(uint64_t pageSize, const LogicalType& da
     }
 }
 
-std::optional<CompressionMetadata> ConstantCompression::analyze(const ColumnChunk& chunk) {
+std::optional<CompressionMetadata> ConstantCompression::analyze(const ColumnChunkData& chunk) {
     switch (chunk.getDataType().getPhysicalType()) {
     // Only values that can fit in the CompressionMetadata's data field can use constant compression
     case PhysicalTypeID::BOOL: {

--- a/src/storage/local_storage/local_table.cpp
+++ b/src/storage/local_storage/local_table.cpp
@@ -32,7 +32,7 @@ bool LocalNodeGroup::hasUpdatesOrDeletions() const {
     return false;
 }
 
-void LocalChunkedGroupCollection::appendChunkedGroup(ColumnChunk* srcOffsetChunk,
+void LocalChunkedGroupCollection::appendChunkedGroup(ColumnChunkData* srcOffsetChunk,
     std::unique_ptr<ChunkedNodeGroup> chunkedGroup) {
     KU_ASSERT(chunkedGroup->getNumColumns() == dataTypes.size());
     for (auto i = 0u; i < chunkedGroup->getNumColumns(); i++) {

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -155,10 +155,10 @@ void ChunkedNodeGroup::finalize(uint64_t nodeGroupIdx_) {
 }
 
 ChunkedCSRHeader::ChunkedCSRHeader(bool enableCompression, uint64_t capacity) {
-    offset =
-        ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression, capacity);
-    length =
-        ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression, capacity);
+    offset = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression,
+        capacity);
+    length = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression,
+        capacity);
 }
 
 offset_t ChunkedCSRHeader::getStartCSROffset(offset_t nodeOffset) const {

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -53,7 +53,7 @@ ChunkedNodeGroup::ChunkedNodeGroup(const std::vector<common::LogicalType>& colum
     chunks.reserve(columnTypes.size());
     for (auto& type : columnTypes) {
         chunks.push_back(
-            ColumnChunkFactory::createColumnChunk(*type.copy(), enableCompression, capacity));
+            ColumnChunkFactory::createColumnChunkData(*type.copy(), enableCompression, capacity));
     }
 }
 
@@ -62,7 +62,7 @@ ChunkedNodeGroup::ChunkedNodeGroup(const std::vector<std::unique_ptr<Column>>& c
     : nodeGroupIdx{UINT64_MAX}, numRows{0} {
     chunks.reserve(columns.size());
     for (auto columnID = 0u; columnID < columns.size(); columnID++) {
-        chunks.push_back(ColumnChunkFactory::createColumnChunk(
+        chunks.push_back(ColumnChunkFactory::createColumnChunkData(
             *columns[columnID]->getDataType().copy(), enableCompression));
     }
 }
@@ -125,7 +125,7 @@ offset_t ChunkedNodeGroup::append(ChunkedNodeGroup* other, offset_t offsetInOthe
     return numNodesToAppend;
 }
 
-void ChunkedNodeGroup::write(const std::vector<std::unique_ptr<ColumnChunk>>& data,
+void ChunkedNodeGroup::write(const std::vector<std::unique_ptr<ColumnChunkData>>& data,
     column_id_t offsetColumnID) {
     KU_ASSERT(data.size() == chunks.size() + 1);
     auto& offsetChunk = data[offsetColumnID];
@@ -156,9 +156,9 @@ void ChunkedNodeGroup::finalize(uint64_t nodeGroupIdx_) {
 
 ChunkedCSRHeader::ChunkedCSRHeader(bool enableCompression, uint64_t capacity) {
     offset =
-        ColumnChunkFactory::createColumnChunk(*LogicalType::UINT64(), enableCompression, capacity);
+        ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression, capacity);
     length =
-        ColumnChunkFactory::createColumnChunk(*LogicalType::UINT64(), enableCompression, capacity);
+        ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression, capacity);
 }
 
 offset_t ChunkedCSRHeader::getStartCSROffset(offset_t nodeOffset) const {

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -9,6 +9,7 @@
 #include "common/types/interval_t.h"
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
+#include "storage/buffer_manager/bm_file_handle.h"
 #include "storage/compression/compression.h"
 #include "storage/store/list_column_chunk.h"
 #include "storage/store/string_column_chunk.h"
@@ -19,7 +20,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-ColumnChunkMetadata fixedSizedFlushBuffer(const uint8_t* buffer, uint64_t bufferSize,
+ColumnChunkMetadata uncompressedFlushBuffer(const uint8_t* buffer, uint64_t bufferSize,
     BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
     KU_ASSERT(dataFH->getNumPages() >= startPageIdx + metadata.numPages);
     dataFH->getFileInfo()->writeFile(buffer, bufferSize,
@@ -28,16 +29,54 @@ ColumnChunkMetadata fixedSizedFlushBuffer(const uint8_t* buffer, uint64_t buffer
         metadata.compMeta);
 }
 
-ColumnChunkMetadata fixedSizedGetMetadata(const uint8_t* /*buffer*/, uint64_t bufferSize,
+ColumnChunkMetadata uncompressedGetMetadata(const uint8_t* /*buffer*/, uint64_t bufferSize,
     uint64_t /*capacity*/, uint64_t numValues, StorageValue min, StorageValue max) {
-    return ColumnChunkMetadata(INVALID_PAGE_IDX, ColumnChunk::getNumPagesForBytes(bufferSize),
+    return ColumnChunkMetadata(INVALID_PAGE_IDX, ColumnChunkData::getNumPagesForBytes(bufferSize),
         numValues, CompressionMetadata(min, max, CompressionType::UNCOMPRESSED));
 }
 
 ColumnChunkMetadata booleanGetMetadata(const uint8_t* /*buffer*/, uint64_t bufferSize,
     uint64_t /*capacity*/, uint64_t numValues, StorageValue min, StorageValue max) {
-    return ColumnChunkMetadata(INVALID_PAGE_IDX, ColumnChunk::getNumPagesForBytes(bufferSize),
+    return ColumnChunkMetadata(INVALID_PAGE_IDX, ColumnChunkData::getNumPagesForBytes(bufferSize),
         numValues, CompressionMetadata(min, max, CompressionType::BOOLEAN_BITPACKING));
+}
+
+std::pair<StorageValue, StorageValue> booleanGetMinMax(const uint8_t* buffer, uint64_t numValues) {
+    StorageValue minValue{}, maxValue{};
+    const auto firstByte = *buffer;
+    if (numValues >= 8) {
+        if (firstByte == 0b00000000) {
+            minValue = false;
+            maxValue = false;
+        } else if (firstByte == 0b11111111) {
+            minValue = true;
+            maxValue = true;
+        } else {
+            minValue = false;
+            maxValue = true;
+            return {minValue, maxValue};
+        }
+    } else {
+        // First byte will be handled in loop below
+        minValue = NullMask::isNull(reinterpret_cast<const uint64_t*>(buffer), 0);
+        maxValue = NullMask::isNull(reinterpret_cast<const uint64_t*>(buffer), 0);
+    }
+    for (size_t i = 0; i < numValues / 8; i++) {
+        if (buffer[i] != firstByte) {
+            maxValue = true;
+            minValue = false;
+            return {minValue, maxValue};
+        }
+    }
+    for (size_t i = numValues / 8 * 8; i < numValues; i++) {
+        if (minValue.unsignedInt !=
+            NullMask::isNull(reinterpret_cast<const uint64_t*>(buffer), i)) {
+            minValue = false;
+            maxValue = true;
+            return {minValue, maxValue};
+        }
+    }
+    return {minValue, maxValue};
 }
 
 class CompressedFlushBuffer {
@@ -45,22 +84,23 @@ class CompressedFlushBuffer {
     const LogicalType& dataType;
 
 public:
-    CompressedFlushBuffer(std::shared_ptr<CompressionAlg> alg, LogicalType& dataType)
+    CompressedFlushBuffer(std::shared_ptr<CompressionAlg> alg, const LogicalType& dataType)
         : alg{std::move(alg)}, dataType{dataType} {}
 
     CompressedFlushBuffer(const CompressedFlushBuffer& other) = default;
 
     ColumnChunkMetadata operator()(const uint8_t* buffer, uint64_t /*bufferSize*/,
-        BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
+        BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) const {
         auto valuesRemaining = metadata.numValues;
         const uint8_t* bufferStart = buffer;
-        auto compressedBuffer = std::make_unique<uint8_t[]>(BufferPoolConstants::PAGE_4KB_SIZE);
+        const auto compressedBuffer =
+            std::make_unique<uint8_t[]>(BufferPoolConstants::PAGE_4KB_SIZE);
         auto numPages = 0u;
-        auto numValuesPerPage =
+        const auto numValuesPerPage =
             metadata.compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType);
         KU_ASSERT(numValuesPerPage * metadata.numPages >= metadata.numValues);
         while (valuesRemaining > 0) {
-            auto compressedSize = alg->compressNextPage(bufferStart, valuesRemaining,
+            const auto compressedSize = alg->compressNextPage(bufferStart, valuesRemaining,
                 compressedBuffer.get(), BufferPoolConstants::PAGE_4KB_SIZE, metadata.compMeta);
             // Avoid underflows (when data is compressed to nothing, numValuesPerPage may be
             // UINT64_MAX)
@@ -97,13 +137,17 @@ class GetCompressionMetadata {
     const LogicalType& dataType;
 
 public:
-    GetCompressionMetadata(std::shared_ptr<CompressionAlg> alg, LogicalType& dataType)
+    GetCompressionMetadata(std::shared_ptr<CompressionAlg> alg, const LogicalType& dataType)
         : alg{std::move(alg)}, dataType{dataType} {}
 
     GetCompressionMetadata(const GetCompressionMetadata& other) = default;
 
     ColumnChunkMetadata operator()(const uint8_t* /*buffer*/, uint64_t /*bufferSize*/,
         uint64_t capacity, uint64_t numValues, StorageValue min, StorageValue max) {
+        if (min == max) {
+            return ColumnChunkMetadata(INVALID_PAGE_IDX, 0, numValues,
+                CompressionMetadata(min, max, CompressionType::CONSTANT));
+        }
         auto compMeta = CompressionMetadata(min, max, alg->getCompressionType());
         if (alg->getCompressionType() == CompressionType::INTEGER_BITPACKING) {
             TypeUtils::visit(
@@ -117,8 +161,10 @@ public:
                 },
                 [&](auto) {});
         }
-        auto numValuesPerPage = compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType);
-        auto numPages = capacity / numValuesPerPage + (capacity % numValuesPerPage == 0 ? 0 : 1);
+        const auto numValuesPerPage =
+            compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType);
+        const auto numPages =
+            capacity / numValuesPerPage + (capacity % numValuesPerPage == 0 ? 0 : 1);
         return ColumnChunkMetadata(INVALID_PAGE_IDX, numPages, numValues, compMeta);
     }
 };
@@ -163,36 +209,84 @@ static std::shared_ptr<CompressionAlg> getCompression(const LogicalType& dataTyp
     }
 }
 
-ColumnChunk::ColumnChunk(LogicalType dataType, uint64_t capacity, bool enableCompression,
+class GetMinMaxFunction {
+    const LogicalType& dataType;
+
+public:
+    explicit GetMinMaxFunction(const LogicalType& dataType) : dataType{dataType} {}
+
+    GetMinMaxFunction(const GetMinMaxFunction& other) = default;
+
+    std::pair<StorageValue, StorageValue> operator()(const uint8_t* buffer, uint64_t numValues) {
+        KU_ASSERT(dataType.getPhysicalType() != PhysicalTypeID::BOOL);
+        StorageValue minValue{}, maxValue{};
+        TypeUtils::visit(
+            this->dataType.getPhysicalType(),
+            [&]<typename T>(T)
+                requires(std::integral<T> || std::floating_point<T>)
+            {
+                const auto& [min, max] = std::minmax_element(reinterpret_cast<const T*>(buffer),
+                    reinterpret_cast<const T*>(buffer) + numValues);
+                minValue = *min;
+                maxValue = *max;
+            },
+            [&]<typename T>(T)
+                requires(std::same_as<T, list_entry_t> || std::same_as<T, internalID_t>)
+            {
+                const auto& [min, max] =
+                    std::minmax_element(reinterpret_cast<const uint64_t*>(buffer),
+                        reinterpret_cast<const uint64_t*>(buffer) + numValues);
+                minValue = *min;
+                maxValue = *max;
+            },
+            [&](ku_string_t) {
+                const auto& [min, max] =
+                    std::minmax_element(reinterpret_cast<const uint32_t*>(buffer),
+                        reinterpret_cast<const uint32_t*>(buffer) + numValues);
+                minValue = *min;
+                maxValue = *max;
+            },
+            // Types which don't currently support statistics
+            [&]<typename T>(T)
+                requires(std::same_as<T, int128_t> || std::same_as<T, interval_t> ||
+                         std::same_as<T, struct_entry_t>)
+            {
+                minValue = std::numeric_limits<uint64_t>::min();
+                maxValue = std::numeric_limits<uint64_t>::max();
+            });
+        return {minValue, maxValue};
+    }
+};
+
+ColumnChunkData::ColumnChunkData(LogicalType dataType, uint64_t capacity, bool enableCompression,
     bool hasNullChunk)
     : dataType{std::move(dataType)}, numBytesPerValue{getDataTypeSizeInChunk(this->dataType)},
-      numValues{0}, enableCompression(enableCompression) {
+      capacity{capacity}, numValues{0}, enableCompression(enableCompression) {
     if (hasNullChunk) {
-        nullChunk = std::make_unique<NullColumnChunk>(capacity, enableCompression);
+        nullChunk = std::make_unique<NullChunkData>(capacity, enableCompression);
     }
-    initializeBuffer(capacity);
+    initializeBuffer();
     initializeFunction();
 }
 
-void ColumnChunk::initializeBuffer(offset_t capacity_) {
+void ColumnChunkData::initializeBuffer() {
     numBytesPerValue = getDataTypeSizeInChunk(dataType);
-    capacity = capacity_;
     bufferSize = getBufferSize(capacity);
     buffer = std::make_unique<uint8_t[]>(bufferSize);
     if (nullChunk) {
-        nullChunk->initializeBuffer(capacity_);
+        nullChunk->initializeBuffer();
     }
 }
 
-void ColumnChunk::initializeFunction() {
-    switch (this->dataType.getPhysicalType()) {
+void ColumnChunkData::initializeFunction() {
+    switch (dataType.getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
         // Since we compress into memory, storage is the same as fixed-sized values,
         // but we need to mark it as being boolean compressed.
-        flushBufferFunction = fixedSizedFlushBuffer;
+        flushBufferFunction = uncompressedFlushBuffer;
         getMetadataFunction = booleanGetMetadata;
-        break;
-    }
+        getMinMaxFunction = booleanGetMinMax;
+    } break;
     case PhysicalTypeID::STRING:
     case PhysicalTypeID::INT64:
     case PhysicalTypeID::INT32:
@@ -206,19 +300,20 @@ void ColumnChunk::initializeFunction() {
     case PhysicalTypeID::UINT16:
     case PhysicalTypeID::UINT8:
     case PhysicalTypeID::INT128: {
-        auto compression = getCompression(this->dataType, enableCompression);
-        flushBufferFunction = CompressedFlushBuffer(compression, this->dataType);
-        getMetadataFunction = GetCompressionMetadata(compression, this->dataType);
-        break;
-    }
+        const auto compression = getCompression(dataType, enableCompression);
+        flushBufferFunction = CompressedFlushBuffer(compression, dataType);
+        getMetadataFunction = GetCompressionMetadata(compression, dataType);
+        getMinMaxFunction = GetMinMaxFunction(dataType);
+    } break;
     default: {
-        flushBufferFunction = fixedSizedFlushBuffer;
-        getMetadataFunction = fixedSizedGetMetadata;
+        flushBufferFunction = uncompressedFlushBuffer;
+        getMetadataFunction = uncompressedGetMetadata;
+        getMinMaxFunction = GetMinMaxFunction(dataType);
     }
     }
 }
 
-void ColumnChunk::resetToEmpty() {
+void ColumnChunkData::resetToEmpty() {
     if (nullChunk) {
         nullChunk->resetToEmpty();
     }
@@ -226,14 +321,25 @@ void ColumnChunk::resetToEmpty() {
     memset(buffer.get(), 0x00, bufferSize);
     numValues = 0;
 }
+ColumnChunkMetadata ColumnChunkData::getMetadataToFlush() const {
+    KU_ASSERT(numValues <= capacity);
+    StorageValue minValue = {}, maxValue = {};
+    if (capacity > 0) {
+        auto [min, max] = getMinMaxFunction(buffer.get(), numValues);
+        minValue = min;
+        maxValue = max;
+    }
+    KU_ASSERT(bufferSize == getBufferSize(capacity));
+    return getMetadataFunction(buffer.get(), bufferSize, capacity, numValues, minValue, maxValue);
+}
 
-void ColumnChunk::append(ValueVector* vector, const SelectionVector& selVector) {
+void ColumnChunkData::append(ValueVector* vector, const SelectionVector& selVector) {
     KU_ASSERT(vector->dataType.getPhysicalType() == dataType.getPhysicalType());
     copyVectorToBuffer(vector, numValues, selVector);
     numValues += selVector.getSelSize();
 }
 
-void ColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
+void ColumnChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChunk,
     uint32_t numValuesToAppend) {
     KU_ASSERT(other->dataType.getPhysicalType() == dataType.getPhysicalType());
     if (nullChunk) {
@@ -246,8 +352,28 @@ void ColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
         numValuesToAppend * numBytesPerValue);
     numValues += numValuesToAppend;
 }
+ColumnChunkMetadata ColumnChunkData::flushBuffer(BMFileHandle* dataFH, page_idx_t startPageIdx,
+    const ColumnChunkMetadata& metadata) const {
+    if (!metadata.compMeta.isConstant()) {
+        KU_ASSERT(bufferSize == getBufferSize(capacity));
+        return flushBufferFunction(buffer.get(), bufferSize, dataFH, startPageIdx, metadata);
+    }
+    return metadata;
+}
 
-void ColumnChunk::lookup(offset_t offsetInChunk, ValueVector& output,
+uint64_t ColumnChunkData::getBufferSize(uint64_t capacity_) const {
+    switch (dataType.getLogicalTypeID()) {
+    case LogicalTypeID::BOOL: {
+        // 8 values per byte, and we need a buffer size which is a multiple of 8 bytes.
+        return ceil(capacity_ / 8.0 / 8.0) * 8;
+    }
+    default: {
+        return numBytesPerValue * capacity_;
+    }
+    }
+}
+
+void ColumnChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
     sel_t posInOutputVector) const {
     KU_ASSERT(offsetInChunk < capacity);
     output.setNull(posInOutputVector, nullChunk->isNull(offsetInChunk));
@@ -257,12 +383,13 @@ void ColumnChunk::lookup(offset_t offsetInChunk, ValueVector& output,
     }
 }
 
-void ColumnChunk::write(ColumnChunk* chunk, ColumnChunk* dstOffsets, RelMultiplicity multiplicity) {
+void ColumnChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
+    RelMultiplicity multiplicity) {
     KU_ASSERT(chunk->dataType.getPhysicalType() == dataType.getPhysicalType() &&
               dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID &&
               chunk->getNumValues() == dstOffsets->getNumValues());
     for (auto i = 0u; i < dstOffsets->getNumValues(); i++) {
-        auto dstOffset = dstOffsets->getValue<offset_t>(i);
+        const auto dstOffset = dstOffsets->getValue<offset_t>(i);
         KU_ASSERT(dstOffset < capacity);
         if (multiplicity == RelMultiplicity::ONE && !nullChunk->isNull(dstOffset)) {
             throw CopyException(stringFormat("Node with offset: {} can only have one neighbour due "
@@ -282,7 +409,7 @@ void ColumnChunk::write(ColumnChunk* chunk, ColumnChunk* dstOffsets, RelMultipli
 // committing. LIST has a different logic for handling out-of-place committing as it has to
 // be slided. However, this is unsafe, as this function can also be used for other purposes later.
 // Thus, an assertion is added at the first line.
-void ColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
+void ColumnChunkData::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
     KU_ASSERT(dataType.getPhysicalType() != PhysicalTypeID::BOOL &&
               dataType.getPhysicalType() != PhysicalTypeID::LIST &&
               dataType.getPhysicalType() != PhysicalTypeID::ARRAY);
@@ -296,8 +423,8 @@ void ColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t o
     }
 }
 
-void ColumnChunk::write(ColumnChunk* srcChunk, offset_t srcOffsetInChunk, offset_t dstOffsetInChunk,
-    offset_t numValuesToCopy) {
+void ColumnChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
+    offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
     KU_ASSERT(srcChunk->dataType.getPhysicalType() == dataType.getPhysicalType());
     if ((dstOffsetInChunk + numValuesToCopy) >= numValues) {
         numValues = dstOffsetInChunk + numValuesToCopy;
@@ -308,8 +435,8 @@ void ColumnChunk::write(ColumnChunk* srcChunk, offset_t srcOffsetInChunk, offset
     nullChunk->write(srcChunk->getNullChunk(), srcOffsetInChunk, dstOffsetInChunk, numValuesToCopy);
 }
 
-void ColumnChunk::copy(ColumnChunk* srcChunk, offset_t srcOffsetInChunk, offset_t dstOffsetInChunk,
-    offset_t numValuesToCopy) {
+void ColumnChunkData::copy(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
+    offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
     KU_ASSERT(srcChunk->dataType.getPhysicalType() == dataType.getPhysicalType());
     KU_ASSERT(dstOffsetInChunk >= numValues);
     while (numValues < dstOffsetInChunk) {
@@ -319,11 +446,11 @@ void ColumnChunk::copy(ColumnChunk* srcChunk, offset_t srcOffsetInChunk, offset_
     append(srcChunk, srcOffsetInChunk, numValuesToCopy);
 }
 
-void ColumnChunk::resize(uint64_t newCapacity) {
+void ColumnChunkData::resize(uint64_t newCapacity) {
     if (newCapacity > capacity) {
         capacity = newCapacity;
     }
-    auto numBytesAfterResize = getBufferSize(newCapacity);
+    const auto numBytesAfterResize = getBufferSize(newCapacity);
     if (numBytesAfterResize > bufferSize) {
         auto resizedBuffer = std::make_unique<uint8_t[]>(numBytesAfterResize);
         memcpy(resizedBuffer.get(), buffer.get(), bufferSize);
@@ -335,21 +462,21 @@ void ColumnChunk::resize(uint64_t newCapacity) {
     }
 }
 
-void ColumnChunk::populateWithDefaultVal(ValueVector* defaultValueVector) {
+void ColumnChunkData::populateWithDefaultVal(ValueVector* defaultValueVector) {
     // TODO(Guodong): don't set vector state to a new one. Default vector is shared across all
     // operators on the pipeline so setting its state will affect others.
     // You can only set state for vectors that is local to this class.
     defaultValueVector->setState(std::make_shared<DataChunkState>());
-    auto valPos = defaultValueVector->state->getSelVector()[0];
+    const auto valPos = defaultValueVector->state->getSelVector()[0];
     auto positionBuffer = defaultValueVector->state->getSelVectorUnsafe().getMultableBuffer();
     for (auto i = 0u; i < defaultValueVector->state->getSelVector().getSelSize(); i++) {
         positionBuffer[i] = valPos;
     }
     defaultValueVector->state->getSelVectorUnsafe().setToFiltered(DEFAULT_VECTOR_CAPACITY);
     auto numValuesAppended = 0u;
-    auto numValuesToPopulate = capacity;
+    const auto numValuesToPopulate = capacity;
     while (numValuesAppended < numValuesToPopulate) {
-        auto numValuesToAppend =
+        const auto numValuesToAppend =
             std::min(DEFAULT_VECTOR_CAPACITY, numValuesToPopulate - numValuesAppended);
         defaultValueVector->state->getSelVectorUnsafe().setSelSize(numValuesToAppend);
         append(defaultValueVector, defaultValueVector->state->getSelVector());
@@ -357,11 +484,11 @@ void ColumnChunk::populateWithDefaultVal(ValueVector* defaultValueVector) {
     }
 }
 
-void ColumnChunk::copyVectorToBuffer(ValueVector* vector, offset_t startPosInChunk,
+void ColumnChunkData::copyVectorToBuffer(ValueVector* vector, offset_t startPosInChunk,
     const SelectionVector& selVector) {
     auto bufferToWrite = buffer.get() + startPosInChunk * numBytesPerValue;
     KU_ASSERT(startPosInChunk + selVector.getSelSize() <= capacity);
-    auto vectorDataToWriteFrom = vector->getData();
+    const auto vectorDataToWriteFrom = vector->getData();
     if (selVector.isUnfiltered()) {
         memcpy(bufferToWrite, vectorDataToWriteFrom, selVector.getSelSize() * numBytesPerValue);
         // TODO(Guodong): Should be wrapped into nullChunk->append(vector);
@@ -370,7 +497,7 @@ void ColumnChunk::copyVectorToBuffer(ValueVector* vector, offset_t startPosInChu
         }
     } else {
         for (auto i = 0u; i < selVector.getSelSize(); i++) {
-            auto pos = selVector[i];
+            const auto pos = selVector[i];
             // TODO(Guodong): Should be wrapped into nullChunk->append(vector);
             nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
             memcpy(bufferToWrite, vectorDataToWriteFrom + pos * numBytesPerValue, numBytesPerValue);
@@ -379,7 +506,7 @@ void ColumnChunk::copyVectorToBuffer(ValueVector* vector, offset_t startPosInChu
     }
 }
 
-void ColumnChunk::setNumValues(uint64_t numValues_) {
+void ColumnChunkData::setNumValues(uint64_t numValues_) {
     KU_ASSERT(numValues_ <= capacity);
     numValues = numValues_;
     if (nullChunk) {
@@ -387,161 +514,61 @@ void ColumnChunk::setNumValues(uint64_t numValues_) {
     }
 }
 
-bool ColumnChunk::numValuesSanityCheck() const {
+bool ColumnChunkData::numValuesSanityCheck() const {
     if (nullChunk) {
         return numValues == nullChunk->getNumValues();
     }
     return numValues <= capacity;
 }
 
-bool ColumnChunk::sanityCheck() {
+bool ColumnChunkData::sanityCheck() {
     if (nullChunk) {
         return nullChunk->sanityCheck() && numValuesSanityCheck();
     }
     return numValues <= capacity;
 }
 
-ColumnChunkMetadata ColumnChunk::getMetadataToFlush() const {
-    KU_ASSERT(numValues <= capacity);
-    StorageValue minValue = {}, maxValue = {};
-    if (capacity > 0) {
-        TypeUtils::visit(
-            this->dataType.getPhysicalType(),
-            [&](bool) {
-                auto firstByte = *buffer.get();
-                if (numValues >= 8) {
-                    if (firstByte == 0b00000000) {
-                        minValue = false;
-                        maxValue = false;
-                    } else if (firstByte == 0b11111111) {
-                        minValue = true;
-                        maxValue = true;
-                    } else {
-                        minValue = false;
-                        maxValue = true;
-                        return;
-                    }
-                } else {
-                    // First byte will be handled in loop below
-                    minValue = getValue<bool>(0);
-                    maxValue = getValue<bool>(0);
-                }
-                for (size_t i = 0; i < numValues / 8; i++) {
-                    if (buffer[i] != firstByte) {
-                        maxValue = true;
-                        minValue = false;
-                        return;
-                    }
-                }
-                for (size_t i = numValues / 8 * 8; i < numValues; i++) {
-                    if (minValue.unsignedInt != getValue<bool>(i)) {
-                        minValue = false;
-                        maxValue = true;
-                        return;
-                    }
-                }
-            },
-            [&]<typename T>(T)
-                requires(std::integral<T> || std::floating_point<T>)
-            {
-                const auto& [min, max] = std::minmax_element(reinterpret_cast<T*>(buffer.get()),
-                    reinterpret_cast<T*>(buffer.get()) + numValues);
-                minValue = *min;
-                maxValue = *max;
-            },
-            [&]<typename T>(T)
-                requires(std::same_as<T, list_entry_t> || std::same_as<T, internalID_t>)
-            {
-                const auto& [min, max] =
-                    std::minmax_element(reinterpret_cast<uint64_t*>(buffer.get()),
-                        reinterpret_cast<uint64_t*>(buffer.get()) + numValues);
-                minValue = *min;
-                maxValue = *max;
-            },
-            [&](ku_string_t) {
-                const auto& [min, max] =
-                    std::minmax_element(reinterpret_cast<uint32_t*>(buffer.get()),
-                        reinterpret_cast<uint32_t*>(buffer.get()) + numValues);
-                minValue = *min;
-                maxValue = *max;
-            },
-            // Types which don't currently support statistics
-            [&]<typename T>(T)
-                requires(std::same_as<T, int128_t> || std::same_as<T, interval_t> ||
-                         std::same_as<T, struct_entry_t>)
-            {
-                minValue = std::numeric_limits<uint64_t>::min();
-                maxValue = std::numeric_limits<uint64_t>::max();
-            });
-        if (enableCompression && minValue == maxValue) {
-            return ColumnChunkMetadata(INVALID_PAGE_IDX, 0, numValues,
-                CompressionMetadata(minValue, maxValue, CompressionType::CONSTANT));
-        }
-    }
-    KU_ASSERT(bufferSize == getBufferSize(capacity));
-    return getMetadataFunction(buffer.get(), bufferSize, capacity, numValues, minValue, maxValue);
-}
-
-ColumnChunkMetadata ColumnChunk::flushBuffer(BMFileHandle* dataFH, page_idx_t startPageIdx,
-    const ColumnChunkMetadata& metadata) {
-    if (!metadata.compMeta.isConstant()) {
-        KU_ASSERT(bufferSize == getBufferSize(capacity));
-        return flushBufferFunction(buffer.get(), bufferSize, dataFH, startPageIdx, metadata);
-    }
-    return metadata;
-}
-
-uint64_t ColumnChunk::getBufferSize(uint64_t capacity_) const {
-    switch (dataType.getLogicalTypeID()) {
-    case LogicalTypeID::BOOL: {
-        // 8 values per byte, and we need a buffer size which is a multiple of 8 bytes.
-        return ceil(capacity_ / 8.0 / 8.0) * 8;
-    }
-    default: {
-        return numBytesPerValue * capacity_;
-    }
-    }
-}
-
-void BoolColumnChunk::append(ValueVector* vector, const SelectionVector& selVector) {
+void BoolChunkData::append(ValueVector* vector, const SelectionVector& selVector) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::BOOL);
     for (auto i = 0u; i < selVector.getSelSize(); i++) {
-        auto pos = selVector[i];
+        const auto pos = selVector[i];
         nullChunk->setNull(numValues + i, vector->isNull(pos));
-        NullMask::setNull((uint64_t*)buffer.get(), numValues + i, vector->getValue<bool>(pos));
+        NullMask::setNull(reinterpret_cast<uint64_t*>(buffer.get()), numValues + i,
+            vector->getValue<bool>(pos));
     }
     numValues += selVector.getSelSize();
 }
 
-void BoolColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
+void BoolChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChunk,
     uint32_t numValuesToAppend) {
-    NullMask::copyNullMask((uint64_t*)static_cast<BoolColumnChunk*>(other)->buffer.get(),
-        startPosInOtherChunk, (uint64_t*)buffer.get(), numValues, numValuesToAppend);
+    NullMask::copyNullMask(reinterpret_cast<uint64_t*>(other->getData()), startPosInOtherChunk,
+        reinterpret_cast<uint64_t*>(buffer.get()), numValues, numValuesToAppend);
     if (nullChunk) {
         nullChunk->append(other->getNullChunk(), startPosInOtherChunk, numValuesToAppend);
     }
     numValues += numValuesToAppend;
 }
 
-void BoolColumnChunk::lookup(offset_t offsetInChunk, ValueVector& output,
+void BoolChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
     sel_t posInOutputVector) const {
     KU_ASSERT(offsetInChunk < capacity);
     output.setNull(posInOutputVector, nullChunk->isNull(offsetInChunk));
     if (!output.isNull(posInOutputVector)) {
         output.setValue<bool>(posInOutputVector,
-            NullMask::isNull((uint64_t*)buffer.get(), offsetInChunk));
+            NullMask::isNull(reinterpret_cast<uint64_t*>(buffer.get()), offsetInChunk));
     }
 }
 
-void BoolColumnChunk::write(ColumnChunk* chunk, ColumnChunk* dstOffsets,
+void BoolChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
     RelMultiplicity /*multiplicity*/) {
     KU_ASSERT(chunk->getDataType().getPhysicalType() == PhysicalTypeID::BOOL &&
               dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID &&
               chunk->getNumValues() == dstOffsets->getNumValues());
     for (auto i = 0u; i < dstOffsets->getNumValues(); i++) {
-        auto dstOffset = dstOffsets->getValue<offset_t>(i);
+        const auto dstOffset = dstOffsets->getValue<offset_t>(i);
         KU_ASSERT(dstOffset < capacity);
-        NullMask::setNull((uint64_t*)buffer.get(), dstOffset, chunk->getValue<bool>(i));
+        NullMask::setNull(reinterpret_cast<uint64_t*>(buffer.get()), dstOffset,
+            chunk->getValue<bool>(i));
         if (nullChunk) {
             nullChunk->setNull(dstOffset, chunk->getNullChunk()->isNull(i));
         }
@@ -549,7 +576,7 @@ void BoolColumnChunk::write(ColumnChunk* chunk, ColumnChunk* dstOffsets,
     }
 }
 
-void BoolColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
+void BoolChunkData::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
     KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::BOOL);
     KU_ASSERT(offsetInChunk < capacity);
     setValue(vector->getValue<bool>(offsetInVector), offsetInChunk);
@@ -559,7 +586,7 @@ void BoolColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset
     numValues = offsetInChunk >= numValues ? offsetInChunk + 1 : numValues;
 }
 
-void BoolColumnChunk::write(ColumnChunk* srcChunk, offset_t srcOffsetInChunk,
+void BoolChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
     if (nullChunk) {
         nullChunk->write(srcChunk->getNullChunk(), srcOffsetInChunk, dstOffsetInChunk,
@@ -568,51 +595,51 @@ void BoolColumnChunk::write(ColumnChunk* srcChunk, offset_t srcOffsetInChunk,
     if ((dstOffsetInChunk + numValuesToCopy) >= numValues) {
         numValues = dstOffsetInChunk + numValuesToCopy;
     }
-    NullMask::copyNullMask((uint64_t*)static_cast<BoolColumnChunk*>(srcChunk)->buffer.get(),
-        srcOffsetInChunk, (uint64_t*)buffer.get(), dstOffsetInChunk, numValuesToCopy);
+    NullMask::copyNullMask(reinterpret_cast<uint64_t*>(srcChunk->getData()), srcOffsetInChunk,
+        reinterpret_cast<uint64_t*>(buffer.get()), dstOffsetInChunk, numValuesToCopy);
 }
 
-void NullColumnChunk::setNull(offset_t pos, bool isNull) {
+void NullChunkData::setNull(offset_t pos, bool isNull) {
     setValue(isNull, pos);
     if (isNull) {
         mayHaveNullValue = true;
     }
-    // TODO(Guodong): Better let NullColumnChunk also support `append` a vector.
+    // TODO(Guodong): Better let NullChunkData also support `append` a vector.
     if (pos >= numValues) {
         numValues = pos + 1;
         KU_ASSERT(numValues <= capacity);
     }
 }
 
-void NullColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
+void NullChunkData::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
     setNull(offsetInChunk, vector->isNull(offsetInVector));
     numValues = offsetInChunk >= numValues ? offsetInChunk + 1 : numValues;
 }
 
-void NullColumnChunk::write(ColumnChunk* srcChunk, offset_t srcOffsetInChunk,
+void NullChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
     if ((dstOffsetInChunk + numValuesToCopy) >= numValues) {
         numValues = dstOffsetInChunk + numValuesToCopy;
     }
-    copyFromBuffer((uint64_t*)static_cast<NullColumnChunk*>(srcChunk)->buffer.get(),
-        srcOffsetInChunk, dstOffsetInChunk, numValuesToCopy);
+    copyFromBuffer(reinterpret_cast<uint64_t*>(srcChunk->getData()), srcOffsetInChunk,
+        dstOffsetInChunk, numValuesToCopy);
 }
 
-void NullColumnChunk::append(ColumnChunk* other, offset_t startOffsetInOtherChunk,
+void NullChunkData::append(ColumnChunkData* other, offset_t startOffsetInOtherChunk,
     uint32_t numValuesToAppend) {
-    copyFromBuffer((uint64_t*)static_cast<NullColumnChunk*>(other)->buffer.get(),
-        startOffsetInOtherChunk, numValues, numValuesToAppend);
+    copyFromBuffer(reinterpret_cast<uint64_t*>(other->getData()), startOffsetInOtherChunk,
+        numValues, numValuesToAppend);
     numValues += numValuesToAppend;
 }
 
-class InternalIDColumnChunk final : public ColumnChunk {
+class InternalIDChunkData final : public ColumnChunkData {
 public:
     // Physically, we only materialize offset of INTERNAL_ID, which is same as UINT64,
-    explicit InternalIDColumnChunk(uint64_t capacity, bool enableCompression)
-        : ColumnChunk(*LogicalType::INTERNAL_ID(), capacity, enableCompression),
+    explicit InternalIDChunkData(uint64_t capacity, bool enableCompression)
+        : ColumnChunkData(*LogicalType::INTERNAL_ID(), capacity, enableCompression),
           commonTableID{INVALID_TABLE_ID} {}
 
-    void append(ValueVector* vector, const common::SelectionVector& selVector) override {
+    void append(ValueVector* vector, const SelectionVector& selVector) override {
         switch (vector->dataType.getPhysicalType()) {
         case PhysicalTypeID::INTERNAL_ID: {
             copyVectorToBuffer(vector, numValues, selVector);
@@ -628,14 +655,14 @@ public:
     }
 
     void copyVectorToBuffer(ValueVector* vector, offset_t startPosInChunk,
-        const common::SelectionVector& selVector) override {
+        const SelectionVector& selVector) override {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
-        auto relIDsInVector = (internalID_t*)vector->getData();
+        const auto relIDsInVector = reinterpret_cast<internalID_t*>(vector->getData());
         if (commonTableID == INVALID_TABLE_ID) {
             commonTableID = relIDsInVector[selVector[0]].tableID;
         }
         for (auto i = 0u; i < selVector.getSelSize(); i++) {
-            auto pos = selVector[i];
+            const auto pos = selVector[i];
             KU_ASSERT(relIDsInVector[pos].tableID == commonTableID);
             nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
             memcpy(buffer.get() + (startPosInChunk + i) * numBytesPerValue,
@@ -644,10 +671,10 @@ public:
     }
 
     void copyInt64VectorToBuffer(ValueVector* vector, offset_t startPosInChunk,
-        const common::SelectionVector& selVector) {
+        const SelectionVector& selVector) const {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::INT64);
         for (auto i = 0u; i < selVector.getSelSize(); i++) {
-            auto pos = selVector[i];
+            const auto pos = selVector[i];
             nullChunk->setNull(startPosInChunk + i, vector->isNull(pos));
             memcpy(buffer.get() + (startPosInChunk + i) * numBytesPerValue,
                 &vector->getValue<offset_t>(pos), numBytesPerValue);
@@ -670,7 +697,7 @@ public:
     void write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) override {
         KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::INTERNAL_ID);
         nullChunk->setNull(offsetInChunk, vector->isNull(offsetInVector));
-        auto relIDsInVector = (internalID_t*)vector->getData();
+        const auto relIDsInVector = reinterpret_cast<internalID_t*>(vector->getData());
         if (commonTableID == INVALID_TABLE_ID) {
             commonTableID = relIDsInVector[offsetInVector].tableID;
         }
@@ -685,14 +712,14 @@ public:
     }
 
 private:
-    common::table_id_t commonTableID;
+    table_id_t commonTableID;
 };
 
-std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(LogicalType dataType,
+std::unique_ptr<ColumnChunkData> ColumnChunkFactory::createColumnChunkData(LogicalType dataType,
     bool enableCompression, uint64_t capacity, bool inMemory) {
     switch (dataType.getPhysicalType()) {
     case PhysicalTypeID::BOOL: {
-        return std::make_unique<BoolColumnChunk>(capacity, enableCompression);
+        return std::make_unique<BoolChunkData>(capacity, enableCompression);
     }
     case PhysicalTypeID::INT64:
     case PhysicalTypeID::INT32:
@@ -708,23 +735,23 @@ std::unique_ptr<ColumnChunk> ColumnChunkFactory::createColumnChunk(LogicalType d
     case PhysicalTypeID::INTERVAL: {
         // TODO: As we have constant compression, SERIAL column should always be compressed as
         // constant non-null when flushed to disk. We should add a sanity check for this.
-        return std::make_unique<ColumnChunk>(std::move(dataType), capacity, enableCompression);
+        return std::make_unique<ColumnChunkData>(std::move(dataType), capacity, enableCompression);
     }
         // Physically, we only materialize offset of INTERNAL_ID, which is same as INT64,
     case PhysicalTypeID::INTERNAL_ID: {
-        return std::make_unique<InternalIDColumnChunk>(capacity, enableCompression);
+        return std::make_unique<InternalIDChunkData>(capacity, enableCompression);
     }
     case PhysicalTypeID::STRING: {
-        return std::make_unique<StringColumnChunk>(std::move(dataType), capacity, enableCompression,
+        return std::make_unique<StringChunkData>(std::move(dataType), capacity, enableCompression,
             inMemory);
     }
     case PhysicalTypeID::ARRAY:
     case PhysicalTypeID::LIST: {
-        return std::make_unique<ListColumnChunk>(std::move(dataType), capacity, enableCompression,
+        return std::make_unique<ListChunkData>(std::move(dataType), capacity, enableCompression,
             inMemory);
     }
     case PhysicalTypeID::STRUCT: {
-        return std::make_unique<StructColumnChunk>(std::move(dataType), capacity, enableCompression,
+        return std::make_unique<StructChunkData>(std::move(dataType), capacity, enableCompression,
             inMemory);
     }
     default:

--- a/src/storage/store/dictionary_chunk.cpp
+++ b/src/storage/store/dictionary_chunk.cpp
@@ -20,9 +20,9 @@ DictionaryChunk::DictionaryChunk(uint64_t capacity, bool enableCompression)
     : enableCompression{enableCompression},
       indexTable(0, StringOps(this) /*hash*/, StringOps(this) /*equals*/) {
     // Bitpacking might save 1 bit per value with regular ascii compared to UTF-8
-    stringDataChunk = ColumnChunkFactory::createColumnChunk(*LogicalType::UINT8(),
+    stringDataChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT8(),
         false /*enableCompression*/, capacity);
-    offsetChunk = ColumnChunkFactory::createColumnChunk(*LogicalType::UINT64(), enableCompression,
+    offsetChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression,
         capacity * OFFSET_CHUNK_CAPACITY_FACTOR);
 }
 

--- a/src/storage/store/dictionary_chunk.cpp
+++ b/src/storage/store/dictionary_chunk.cpp
@@ -22,8 +22,8 @@ DictionaryChunk::DictionaryChunk(uint64_t capacity, bool enableCompression)
     // Bitpacking might save 1 bit per value with regular ascii compared to UTF-8
     stringDataChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT8(),
         false /*enableCompression*/, capacity);
-    offsetChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(), enableCompression,
-        capacity * OFFSET_CHUNK_CAPACITY_FACTOR);
+    offsetChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT64(),
+        enableCompression, capacity * OFFSET_CHUNK_CAPACITY_FACTOR);
 }
 
 void DictionaryChunk::resetToEmpty() {

--- a/src/storage/store/list_column_chunk.cpp
+++ b/src/storage/store/list_column_chunk.cpp
@@ -25,20 +25,20 @@ void ListDataColumnChunk::resizeBuffer(uint64_t numValues) {
     dataColumnChunk->resize(capacity);
 }
 
-ListColumnChunk::ListColumnChunk(LogicalType dataType, uint64_t capacity, bool enableCompression,
+ListChunkData::ListChunkData(LogicalType dataType, uint64_t capacity, bool enableCompression,
     bool inMemory)
-    : ColumnChunk{std::move(dataType), capacity, enableCompression, true /* hasNullChunk */} {
-    sizeColumnChunk = ColumnChunkFactory::createColumnChunk(*common::LogicalType::UINT32(),
+    : ColumnChunkData{std::move(dataType), capacity, enableCompression, true /* hasNullChunk */} {
+    sizeColumnChunk = ColumnChunkFactory::createColumnChunkData(*common::LogicalType::UINT32(),
         enableCompression, capacity);
     listDataColumnChunk = std::make_unique<ListDataColumnChunk>(
-        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType).copy(),
+        ColumnChunkFactory::createColumnChunkData(*ListType::getChildType(this->dataType).copy(),
             enableCompression, 0 /* capacity */, inMemory));
     checkOffsetSortedAsc = false;
     KU_ASSERT(this->dataType.getPhysicalType() == PhysicalTypeID::LIST ||
               this->dataType.getPhysicalType() == PhysicalTypeID::ARRAY);
 }
 
-bool ListColumnChunk::isOffsetsConsecutiveAndSortedAscending(uint64_t startPos,
+bool ListChunkData::isOffsetsConsecutiveAndSortedAscending(uint64_t startPos,
     uint64_t endPos) const {
     offset_t prevEndOffset = getListStartOffset(startPos);
     for (auto i = startPos; i < endPos; i++) {
@@ -52,31 +52,31 @@ bool ListColumnChunk::isOffsetsConsecutiveAndSortedAscending(uint64_t startPos,
     return true;
 }
 
-offset_t ListColumnChunk::getListStartOffset(offset_t offset) const {
+offset_t ListChunkData::getListStartOffset(offset_t offset) const {
     if (numValues == 0)
         return 0;
     return offset == numValues ? getListEndOffset(offset - 1) :
                                  getListEndOffset(offset) - getListSize(offset);
 }
 
-offset_t ListColumnChunk::getListEndOffset(offset_t offset) const {
+offset_t ListChunkData::getListEndOffset(offset_t offset) const {
     if (numValues == 0)
         return 0;
     KU_ASSERT(offset < numValues);
     return getValue<uint64_t>(offset);
 }
 
-list_size_t ListColumnChunk::getListSize(common::offset_t offset) const {
+list_size_t ListChunkData::getListSize(common::offset_t offset) const {
     if (numValues == 0)
         return 0;
     KU_ASSERT(offset < sizeColumnChunk->getNumValues());
     return sizeColumnChunk->getValue<list_size_t>(offset);
 }
 
-void ListColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
+void ListChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChunk,
     uint32_t numValuesToAppend) {
     checkOffsetSortedAsc = true;
-    auto otherListChunk = ku_dynamic_cast<ColumnChunk*, ListColumnChunk*>(other);
+    auto otherListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(other);
     nullChunk->append(other->getNullChunk(), startPosInOtherChunk, numValuesToAppend);
     sizeColumnChunk->getNullChunk()->append(other->getNullChunk(), startPosInOtherChunk,
         numValuesToAppend);
@@ -97,15 +97,15 @@ void ListColumnChunk::append(ColumnChunk* other, offset_t startPosInOtherChunk,
     sanityCheck();
 }
 
-void ListColumnChunk::resetToEmpty() {
-    ColumnChunk::resetToEmpty();
+void ListChunkData::resetToEmpty() {
+    ColumnChunkData::resetToEmpty();
     sizeColumnChunk->resetToEmpty();
     listDataColumnChunk = std::make_unique<ListDataColumnChunk>(
-        ColumnChunkFactory::createColumnChunk(*ListType::getChildType(this->dataType).copy(),
+        ColumnChunkFactory::createColumnChunkData(*ListType::getChildType(this->dataType).copy(),
             enableCompression, 0 /* capacity */));
 }
 
-void ListColumnChunk::append(ValueVector* vector, const SelectionVector& selVector) {
+void ListChunkData::append(ValueVector* vector, const SelectionVector& selVector) {
     auto numToAppend = selVector.getSelSize();
     auto newCapacity = capacity;
     while (numValues + numToAppend >= newCapacity) {
@@ -141,7 +141,7 @@ void ListColumnChunk::append(ValueVector* vector, const SelectionVector& selVect
     sanityCheck();
 }
 
-void ListColumnChunk::appendNullList() {
+void ListChunkData::appendNullList() {
     offset_t nextListOffsetInChunk = listDataColumnChunk->getNumValues();
     auto offsetBufferToWrite = (offset_t*)(buffer.get());
     sizeColumnChunk->setValue<list_size_t>(0, numValues);
@@ -151,7 +151,7 @@ void ListColumnChunk::appendNullList() {
     numValues++;
 }
 
-void ListColumnChunk::lookup(offset_t offsetInChunk, ValueVector& output,
+void ListChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
     sel_t posInOutputVector) const {
     KU_ASSERT(offsetInChunk < numValues);
     output.setNull(posInOutputVector, nullChunk->isNull(offsetInChunk));
@@ -173,14 +173,14 @@ void ListColumnChunk::lookup(offset_t offsetInChunk, ValueVector& output,
     output.setValue<list_entry_t>(posInOutputVector, list_entry_t{currentListDataSize, listSize});
 }
 
-void ListColumnChunk::write(ColumnChunk* chunk, ColumnChunk* dstOffsets,
+void ListChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
     RelMultiplicity /*multiplicity*/) {
     KU_ASSERT(chunk->getDataType().getPhysicalType() == dataType.getPhysicalType() &&
               dstOffsets->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID &&
               chunk->getNumValues() == dstOffsets->getNumValues());
     checkOffsetSortedAsc = true;
     offset_t currentIndex = listDataColumnChunk->getNumValues();
-    auto otherListChunk = ku_dynamic_cast<ColumnChunk*, ListColumnChunk*>(chunk);
+    auto otherListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(chunk);
     listDataColumnChunk->resizeBuffer(
         listDataColumnChunk->getNumValues() + otherListChunk->listDataColumnChunk->getNumValues());
     listDataColumnChunk->dataColumnChunk->append(
@@ -208,7 +208,7 @@ void ListColumnChunk::write(ColumnChunk* chunk, ColumnChunk* dstOffsets,
     sanityCheck();
 }
 
-void ListColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
+void ListChunkData::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
     checkOffsetSortedAsc = true;
     auto selVector = std::make_unique<SelectionVector>(1);
     selVector->setToFiltered();
@@ -234,12 +234,12 @@ void ListColumnChunk::write(ValueVector* vector, offset_t offsetInVector, offset
     sanityCheck();
 }
 
-void ListColumnChunk::write(ColumnChunk* srcChunk, offset_t srcOffsetInChunk,
+void ListChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
     KU_ASSERT(srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::LIST ||
               srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::ARRAY);
     checkOffsetSortedAsc = true;
-    auto srcListChunk = ku_dynamic_cast<ColumnChunk*, ListColumnChunk*>(srcChunk);
+    auto srcListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(srcChunk);
     auto offsetInDataChunkToAppend = listDataColumnChunk->getNumValues();
     for (auto i = 0u; i < numValuesToCopy; i++) {
         auto appendSize = srcListChunk->getListSize(srcOffsetInChunk + i);
@@ -262,7 +262,7 @@ void ListColumnChunk::write(ColumnChunk* srcChunk, offset_t srcOffsetInChunk,
     sanityCheck();
 }
 
-void ListColumnChunk::copy(ColumnChunk* srcChunk, offset_t srcOffsetInChunk,
+void ListChunkData::copy(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     offset_t dstOffsetInChunk, offset_t numValuesToCopy) {
     KU_ASSERT(srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::LIST ||
               srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::ARRAY);
@@ -273,7 +273,7 @@ void ListColumnChunk::copy(ColumnChunk* srcChunk, offset_t srcOffsetInChunk,
     append(srcChunk, srcOffsetInChunk, numValuesToCopy);
 }
 
-void ListColumnChunk::copyListValues(const list_entry_t& entry, ValueVector* dataVector) {
+void ListChunkData::copyListValues(const list_entry_t& entry, ValueVector* dataVector) {
     auto numListValuesToCopy = entry.size;
     auto numListValuesCopied = 0u;
     while (numListValuesCopied < numListValuesToCopy) {
@@ -288,7 +288,7 @@ void ListColumnChunk::copyListValues(const list_entry_t& entry, ValueVector* dat
     }
 }
 
-void ListColumnChunk::resetOffset() {
+void ListChunkData::resetOffset() {
     offset_t nextListOffsetReset = 0;
     for (auto i = 0u; i < numValues; i++) {
         auto listSize = getListSize(i);
@@ -298,9 +298,9 @@ void ListColumnChunk::resetOffset() {
     }
 }
 
-void ListColumnChunk::finalize() {
+void ListChunkData::finalize() {
     // rewrite the column chunk for better scanning performance
-    auto newColumnChunk = ColumnChunkFactory::createColumnChunk(std::move(*dataType.copy()),
+    auto newColumnChunk = ColumnChunkFactory::createColumnChunkData(std::move(*dataType.copy()),
         enableCompression, capacity);
     uint64_t totalListLen = listDataColumnChunk->getNumValues();
     uint64_t resizeThreshold = listDataColumnChunk->capacity / 2;
@@ -316,7 +316,7 @@ void ListColumnChunk::finalize() {
     if (isOffsetsConsecutiveAndSortedAscending(0, numValues)) {
         return;
     }
-    auto newListChunk = ku_dynamic_cast<ColumnChunk*, ListColumnChunk*>(newColumnChunk.get());
+    auto newListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(newColumnChunk.get());
     newListChunk->resize(numValues);
     newListChunk->getDataColumnChunk()->resize(totalListLen);
     auto dataColumnChunk = newListChunk->getDataColumnChunk();
@@ -343,7 +343,7 @@ void ListColumnChunk::finalize() {
     // Move offsets, null, data from newListChunk to this column chunk. And release indices.
     resetFromOtherChunk(newListChunk);
 }
-void ListColumnChunk::resetFromOtherChunk(ListColumnChunk* other) {
+void ListChunkData::resetFromOtherChunk(ListChunkData* other) {
     buffer = std::move(other->buffer);
     nullChunk = std::move(other->nullChunk);
     sizeColumnChunk = std::move(other->sizeColumnChunk);
@@ -352,8 +352,8 @@ void ListColumnChunk::resetFromOtherChunk(ListColumnChunk* other) {
     checkOffsetSortedAsc = false;
 }
 
-bool ListColumnChunk::sanityCheck() {
-    KU_ASSERT(ColumnChunk::sanityCheck());
+bool ListChunkData::sanityCheck() {
+    KU_ASSERT(ColumnChunkData::sanityCheck());
     KU_ASSERT(sizeColumnChunk->sanityCheck());
     KU_ASSERT(getDataColumnChunk()->sanityCheck());
     return sizeColumnChunk->getNumValues() == numValues;

--- a/src/storage/store/list_column_chunk.cpp
+++ b/src/storage/store/list_column_chunk.cpp
@@ -1,5 +1,7 @@
 #include "storage/store/list_column_chunk.h"
 
+#include <cmath>
+
 #include "common/cast.h"
 #include "common/data_chunk/sel_vector.h"
 #include "common/types/value/value.h"

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -582,8 +582,8 @@ void RelTableData::updateRegion(Transaction* transaction, node_group_idx_t nodeG
         // NOTE: There is an implicit trick happening. Due to the mismatch of storage type and
         // in-memory representation of INTERNAL_ID, we only store offset as INT64 on disk. Here
         // we directly read relID's offset part from disk into an INT64 column chunk.
-        persistentState.relIDChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::INT64(),
-            enableCompression, localState.regionCapacity);
+        persistentState.relIDChunk = ColumnChunkFactory::createColumnChunkData(
+            *LogicalType::INT64(), enableCompression, localState.regionCapacity);
         getColumn(REL_ID_COLUMN_ID)
             ->scan(transaction, nodeGroupIdx, persistentState.relIDChunk.get(),
                 persistentState.leftCSROffset, persistentState.rightCSROffset + 1);
@@ -826,8 +826,8 @@ void RelTableData::applyDeletionsToColumn(Transaction* transaction, node_group_i
         enableCompression, slides.size());
     std::vector<offset_t> dstOffsets;
     dstOffsets.resize(slides.size());
-    auto tmpChunkForRead =
-        ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(), enableCompression, 1);
+    auto tmpChunkForRead = ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(),
+        enableCompression, 1);
     for (auto i = 0u; i < slides.size(); i++) {
         column->scan(transaction, nodeGroupIdx, tmpChunkForRead.get(), slides[i].first,
             slides[i].first + 1);
@@ -870,8 +870,8 @@ void RelTableData::applySliding(Transaction* transaction, node_group_idx_t nodeG
         enableCompression, slides.size());
     std::vector<offset_t> dstOffsets;
     dstOffsets.resize(slides.size());
-    auto tmpChunkForRead =
-        ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(), enableCompression, 1);
+    auto tmpChunkForRead = ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(),
+        enableCompression, 1);
     for (auto i = 0u; i < slides.size(); i++) {
         column->scan(transaction, nodeGroupIdx, tmpChunkForRead.get(), slides[i].first,
             slides[i].first + 1);
@@ -959,8 +959,8 @@ void RelTableData::updateCSRHeader(Transaction* transaction, node_group_idx_t no
 }
 
 void RelTableData::commitCSRHeaderChunk(Transaction* transaction, bool isNewNodeGroup,
-    node_group_idx_t nodeGroupIdx, Column* column, ColumnChunkData* chunk, const LocalState& localState,
-    const std::vector<common::offset_t>& dstOffsets) {
+    node_group_idx_t nodeGroupIdx, Column* column, ColumnChunkData* chunk,
+    const LocalState& localState, const std::vector<common::offset_t>& dstOffsets) {
     Column::ChunkState state;
     column->initChunkState(transaction, nodeGroupIdx, state);
     if (!isNewNodeGroup) {

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -361,7 +361,7 @@ static PackedCSRRegion upgradeLevel(const PackedCSRRegion& region) {
     return PackedCSRRegion{regionIdx, region.level + 1};
 }
 
-static uint64_t findPosOfRelIDFromArray(const ColumnChunk* relIDInRegion, offset_t startPos,
+static uint64_t findPosOfRelIDFromArray(const ColumnChunkData* relIDInRegion, offset_t startPos,
     offset_t endPos, offset_t relOffset) {
     KU_ASSERT(endPos <= relIDInRegion->getNumValues());
     for (auto i = startPos; i < endPos; i++) {
@@ -422,7 +422,7 @@ RelTableData::LocalState::LocalState(LocalRelNG* localNG) : localNG{localNG} {
 }
 
 void RelTableData::applyUpdatesToChunk(const PersistentState& persistentState,
-    const LocalState& localState, const ChunkCollection& localChunk, ColumnChunk* chunk,
+    const LocalState& localState, const ChunkCollection& localChunk, ColumnChunkData* chunk,
     column_id_t columnID) {
     offset_to_row_idx_t csrOffsetInRegionToRowIdx;
     auto [leftNodeBoundary, rightNodeBoundary] = localState.region.getNodeOffsetBoundaries();
@@ -441,7 +441,7 @@ void RelTableData::applyUpdatesToChunk(const PersistentState& persistentState,
 }
 
 void RelTableData::applyInsertionsToChunk(const PersistentState& persistentState,
-    const LocalState& localState, const ChunkCollection& localChunk, ColumnChunk* newChunk) {
+    const LocalState& localState, const ChunkCollection& localChunk, ColumnChunkData* newChunk) {
     offset_to_row_idx_t csrOffsetToRowIdx;
     auto [leftNodeBoundary, rightNodeBoundary] = localState.region.getNodeOffsetBoundaries();
     auto& insertChunks = localState.localNG->insertChunks;
@@ -463,7 +463,7 @@ void RelTableData::applyInsertionsToChunk(const PersistentState& persistentState
 // TODO(Guodong): This should be refactored to share the same control logic with
 // `applyDeletionsToColumn`.
 void RelTableData::applyDeletionsToChunk(const PersistentState& persistentState,
-    const LocalState& localState, ColumnChunk* chunk) {
+    const LocalState& localState, ColumnChunkData* chunk) {
     auto& deleteInfo = localState.localNG->deleteInfo;
     for (auto& [offset, deletions] : deleteInfo.getSrcNodeOffsetToRelOffsetVec()) {
         if (localState.region.isOutOfBoundary(offset)) {
@@ -504,7 +504,7 @@ void RelTableData::distributeAndUpdateColumn(Transaction* transaction,
     KU_ASSERT(localState.regionCapacity >= (localState.rightCSROffset - localState.leftCSROffset));
     // First, scan the whole region to a temp chunk.
     auto oldSize = persistentState.rightCSROffset - persistentState.leftCSROffset + 1;
-    auto chunk = ColumnChunkFactory::createColumnChunk(*column->getDataType().copy(),
+    auto chunk = ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(),
         enableCompression, oldSize);
     column->scan(transaction, nodeGroupIdx, chunk.get(), persistentState.leftCSROffset,
         persistentState.rightCSROffset + 1);
@@ -514,7 +514,7 @@ void RelTableData::distributeAndUpdateColumn(Transaction* transaction,
     applyDeletionsToChunk(persistentState, localState, chunk.get());
     // Second, create a new temp chunk for the region.
     auto newSize = localState.rightCSROffset - localState.leftCSROffset + 1;
-    auto newChunk = ColumnChunkFactory::createColumnChunk(*column->getDataType().copy(),
+    auto newChunk = ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(),
         enableCompression, newSize);
     newChunk->getNullChunk()->resetToAllNull();
     auto maxNumNodesToDistribute = std::min(rightNodeBoundary - leftNodeBoundary + 1,
@@ -582,7 +582,7 @@ void RelTableData::updateRegion(Transaction* transaction, node_group_idx_t nodeG
         // NOTE: There is an implicit trick happening. Due to the mismatch of storage type and
         // in-memory representation of INTERNAL_ID, we only store offset as INT64 on disk. Here
         // we directly read relID's offset part from disk into an INT64 column chunk.
-        persistentState.relIDChunk = ColumnChunkFactory::createColumnChunk(*LogicalType::INT64(),
+        persistentState.relIDChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::INT64(),
             enableCompression, localState.regionCapacity);
         getColumn(REL_ID_COLUMN_ID)
             ->scan(transaction, nodeGroupIdx, persistentState.relIDChunk.get(),
@@ -822,12 +822,12 @@ void RelTableData::applyDeletionsToColumn(Transaction* transaction, node_group_i
     if (slides.empty()) {
         return;
     }
-    auto chunk = ColumnChunkFactory::createColumnChunk(*column->getDataType().copy(),
+    auto chunk = ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(),
         enableCompression, slides.size());
     std::vector<offset_t> dstOffsets;
     dstOffsets.resize(slides.size());
     auto tmpChunkForRead =
-        ColumnChunkFactory::createColumnChunk(*column->getDataType().copy(), enableCompression, 1);
+        ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(), enableCompression, 1);
     for (auto i = 0u; i < slides.size(); i++) {
         column->scan(transaction, nodeGroupIdx, tmpChunkForRead.get(), slides[i].first,
             slides[i].first + 1);
@@ -866,12 +866,12 @@ void RelTableData::applySliding(Transaction* transaction, node_group_idx_t nodeG
     if (slides.empty()) {
         return;
     }
-    auto chunk = ColumnChunkFactory::createColumnChunk(*column->getDataType().copy(),
+    auto chunk = ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(),
         enableCompression, slides.size());
     std::vector<offset_t> dstOffsets;
     dstOffsets.resize(slides.size());
     auto tmpChunkForRead =
-        ColumnChunkFactory::createColumnChunk(*column->getDataType().copy(), enableCompression, 1);
+        ColumnChunkFactory::createColumnChunkData(*column->getDataType().copy(), enableCompression, 1);
     for (auto i = 0u; i < slides.size(); i++) {
         column->scan(transaction, nodeGroupIdx, tmpChunkForRead.get(), slides[i].first,
             slides[i].first + 1);
@@ -959,7 +959,7 @@ void RelTableData::updateCSRHeader(Transaction* transaction, node_group_idx_t no
 }
 
 void RelTableData::commitCSRHeaderChunk(Transaction* transaction, bool isNewNodeGroup,
-    node_group_idx_t nodeGroupIdx, Column* column, ColumnChunk* chunk, const LocalState& localState,
+    node_group_idx_t nodeGroupIdx, Column* column, ColumnChunkData* chunk, const LocalState& localState,
     const std::vector<common::offset_t>& dstOffsets) {
     Column::ChunkState state;
     column->initChunkState(transaction, nodeGroupIdx, state);


### PR DESCRIPTION
# Description

I'm reserving `ColumnChunk` for an abstraction of holding data along with its versions and some metadata. Current ColumnChunk is actually holding in-mem data only, thus I'm renaming it to `ColumnChunkData` for now.

Also, I moved the code of computing min/max to `get_min_max_func_t getMinMaxFunction;`, similar to `flushBufferFunction` and `getMetadataFunction`.