### PR TITLE
Added query progress callbacks for nodejs api

### DIFF
--- a/src/include/common/task_system/progress_bar.h
+++ b/src/include/common/task_system/progress_bar.h
@@ -19,6 +19,8 @@ class ProgressBar {
 public:
     ProgressBar();
 
+    static std::shared_ptr<ProgressBarDisplay> DefaultProgressBarDisplay();
+
     void addPipeline();
 
     void finishPipeline();
@@ -39,9 +41,9 @@ public:
 
     void setDisplay(std::shared_ptr<ProgressBarDisplay> progressBarDipslay);
 
-private:
-    static std::shared_ptr<ProgressBarDisplay> DefaultProgressBarDisplay();
+    bool getProgressBarPrinting() { return trackProgress; }
 
+private:
     void resetProgressBar();
 
     void updateDisplay(double curPipelineProgress);

--- a/src/include/common/task_system/progress_bar.h
+++ b/src/include/common/task_system/progress_bar.h
@@ -41,7 +41,7 @@ public:
 
     void setDisplay(std::shared_ptr<ProgressBarDisplay> progressBarDipslay);
 
-    bool getProgressBarPrinting() { return trackProgress; }
+    bool getProgressBarPrinting() const { return trackProgress; }
 
 private:
     void resetProgressBar();

--- a/tools/nodejs_api/src_cpp/include/node_connection.h
+++ b/tools/nodejs_api/src_cpp/include/node_connection.h
@@ -5,8 +5,8 @@
 #include "main/kuzu.h"
 #include "node_database.h"
 #include "node_prepared_statement.h"
-#include "node_query_result.h"
 #include "node_progress_bar_display.h"
+#include "node_query_result.h"
 #include <napi.h>
 
 using namespace kuzu::main;
@@ -64,13 +64,15 @@ class ConnectionExecuteAsyncWorker : public Napi::AsyncWorker {
 public:
     ConnectionExecuteAsyncWorker(Napi::Function& callback, std::shared_ptr<Connection>& connection,
         std::shared_ptr<PreparedStatement> preparedStatement, NodeQueryResult* nodeQueryResult,
-        std::unordered_map<std::string, std::unique_ptr<Value>> params, Napi::Value progressCallback)
+        std::unordered_map<std::string, std::unique_ptr<Value>> params,
+        Napi::Value progressCallback)
         : Napi::AsyncWorker(callback), connection(connection),
           preparedStatement(std::move(preparedStatement)), nodeQueryResult(nodeQueryResult),
           params(std::move(params)) {
         if (progressCallback.IsFunction()) {
-            this->progressCallback = Napi::ThreadSafeFunction::New(Env(), progressCallback.As<Napi::Function>(), "ProgressCallback", 0, 1);
-		}
+            this->progressCallback = Napi::ThreadSafeFunction::New(Env(),
+                progressCallback.As<Napi::Function>(), "ProgressCallback", 0, 1);
+        }
     }
 
     ~ConnectionExecuteAsyncWorker() override = default;
@@ -80,7 +82,8 @@ public:
         bool trackProgress = progressBar->getProgressBarPrinting();
         if (progressCallback) {
             progressBar->toggleProgressBarPrinting(true);
-            progressBar->setDisplay(std::make_shared<NodeProgressBarDisplay>(*progressCallback, Env()));
+            progressBar->setDisplay(
+                std::make_shared<NodeProgressBarDisplay>(*progressCallback, Env()));
         }
         try {
             auto result =

--- a/tools/nodejs_api/src_cpp/include/node_connection.h
+++ b/tools/nodejs_api/src_cpp/include/node_connection.h
@@ -6,6 +6,7 @@
 #include "node_database.h"
 #include "node_prepared_statement.h"
 #include "node_query_result.h"
+#include "node_progress_bar_display.h"
 #include <napi.h>
 
 using namespace kuzu::main;
@@ -63,23 +64,38 @@ class ConnectionExecuteAsyncWorker : public Napi::AsyncWorker {
 public:
     ConnectionExecuteAsyncWorker(Napi::Function& callback, std::shared_ptr<Connection>& connection,
         std::shared_ptr<PreparedStatement> preparedStatement, NodeQueryResult* nodeQueryResult,
-        std::unordered_map<std::string, std::unique_ptr<Value>> params)
+        std::unordered_map<std::string, std::unique_ptr<Value>> params, Napi::Value progressCallback)
         : Napi::AsyncWorker(callback), connection(connection),
           preparedStatement(std::move(preparedStatement)), nodeQueryResult(nodeQueryResult),
-          params(std::move(params)) {}
+          params(std::move(params)) {
+        if (progressCallback.IsFunction()) {
+            this->progressCallback = Napi::ThreadSafeFunction::New(Env(), progressCallback.As<Napi::Function>(), "ProgressCallback", 0, 1);
+		}
+    }
+
     ~ConnectionExecuteAsyncWorker() override = default;
 
     void Execute() override {
+        auto progressBar = connection->getClientContext()->getProgressBar();
+        bool trackProgress = progressBar->getProgressBarPrinting();
+        if (progressCallback) {
+            progressBar->toggleProgressBarPrinting(true);
+            progressBar->setDisplay(std::make_shared<NodeProgressBarDisplay>(*progressCallback, Env()));
+        }
         try {
             auto result =
                 connection->executeWithParams(preparedStatement.get(), std::move(params)).release();
             nodeQueryResult->SetQueryResult(result, true);
             if (!result->isSuccess()) {
                 SetError(result->getErrorMessage());
-                return;
             }
         } catch (const std::exception& exc) {
             SetError(std::string(exc.what()));
+        }
+        if (progressCallback) {
+            progressBar->toggleProgressBarPrinting(trackProgress);
+            progressBar->setDisplay(ProgressBar::DefaultProgressBarDisplay());
+            progressCallback->Release();
         }
     }
 
@@ -92,27 +108,44 @@ private:
     std::shared_ptr<PreparedStatement> preparedStatement;
     NodeQueryResult* nodeQueryResult;
     std::unordered_map<std::string, std::unique_ptr<Value>> params;
+    std::optional<Napi::ThreadSafeFunction> progressCallback;
 };
 
 class ConnectionQueryAsyncWorker : public Napi::AsyncWorker {
 public:
     ConnectionQueryAsyncWorker(Napi::Function& callback, std::shared_ptr<Connection>& connection,
-        std::string statement, NodeQueryResult* nodeQueryResult)
+        std::string statement, NodeQueryResult* nodeQueryResult, Napi::Value progressCallback)
         : Napi::AsyncWorker(callback), connection(connection), statement(std::move(statement)),
-          nodeQueryResult(nodeQueryResult) {}
+          nodeQueryResult(nodeQueryResult) {
+        if (progressCallback.IsFunction()) {
+            this->progressCallback = Napi::ThreadSafeFunction::New(Env(),
+                progressCallback.As<Napi::Function>(), "ProgressCallback", 0, 1);
+        }
+    }
 
     ~ConnectionQueryAsyncWorker() override = default;
 
     void Execute() override {
+        auto progressBar = connection->getClientContext()->getProgressBar();
+        bool trackProgress = progressBar->getProgressBarPrinting();
+        if (progressCallback) {
+            progressBar->toggleProgressBarPrinting(true);
+            progressBar->setDisplay(
+                std::make_shared<NodeProgressBarDisplay>(*progressCallback, Env()));
+        }
         try {
             auto result = connection->query(statement).release();
             nodeQueryResult->SetQueryResult(result, true);
             if (!result->isSuccess()) {
                 SetError(result->getErrorMessage());
-                return;
             }
         } catch (const std::exception& exc) {
             SetError(std::string(exc.what()));
+        }
+        if (progressCallback) {
+            progressBar->toggleProgressBarPrinting(trackProgress);
+            progressBar->setDisplay(ProgressBar::DefaultProgressBarDisplay());
+            progressCallback->Release();
         }
     }
 
@@ -124,4 +157,5 @@ private:
     std::shared_ptr<Connection> connection;
     std::string statement;
     NodeQueryResult* nodeQueryResult;
+    std::optional<Napi::ThreadSafeFunction> progressCallback;
 };

--- a/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
+++ b/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <iostream>
-
 #include "common/task_system/progress_bar_display.h"
 #include <napi.h>
 

--- a/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
+++ b/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <iostream>
+#include <napi.h>
+
+#include "common/task_system/progress_bar_display.h"
+
+using namespace kuzu;
+using namespace common;
+
+/**
+ * @brief A class that displays a progress bar in the terminal.
+ */
+class NodeProgressBarDisplay : public ProgressBarDisplay {
+public:
+    NodeProgressBarDisplay(Napi::ThreadSafeFunction callback, Napi::Env env) : callback(callback), env(env) {}
+
+    void updateProgress(double newPipelineProgress, uint32_t newNumPipelinesFinished) override;
+
+    void finishProgress() override;
+
+private:
+    Napi::ThreadSafeFunction callback;
+    Napi::Env env;
+};

--- a/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
+++ b/tools/nodejs_api/src_cpp/include/node_progress_bar_display.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <iostream>
-#include <napi.h>
 
 #include "common/task_system/progress_bar_display.h"
+#include <napi.h>
 
 using namespace kuzu;
 using namespace common;
@@ -13,7 +13,8 @@ using namespace common;
  */
 class NodeProgressBarDisplay : public ProgressBarDisplay {
 public:
-    NodeProgressBarDisplay(Napi::ThreadSafeFunction callback, Napi::Env env) : callback(callback), env(env) {}
+    NodeProgressBarDisplay(Napi::ThreadSafeFunction callback, Napi::Env env)
+        : callback(callback), env(env) {}
 
     void updateProgress(double newPipelineProgress, uint32_t newNumPipelinesFinished) override;
 

--- a/tools/nodejs_api/src_cpp/node_connection.cpp
+++ b/tools/nodejs_api/src_cpp/node_connection.cpp
@@ -83,7 +83,7 @@ Napi::Value NodeConnection::ExecuteAsync(const Napi::CallbackInfo& info) {
     try {
         auto params = Util::TransformParametersForExec(info[2].As<Napi::Array>());
         auto asyncWorker = new ConnectionExecuteAsyncWorker(callback, connection,
-            nodePreparedStatement->preparedStatement, nodeQueryResult, std::move(params));
+            nodePreparedStatement->preparedStatement, nodeQueryResult, std::move(params), info[4]);
         asyncWorker->Queue();
     } catch (const std::exception& exc) {
         Napi::Error::New(env, std::string(exc.what())).ThrowAsJavaScriptException();
@@ -98,7 +98,7 @@ Napi::Value NodeConnection::QueryAsync(const Napi::CallbackInfo& info) {
     auto nodeQueryResult = Napi::ObjectWrap<NodeQueryResult>::Unwrap(info[1].As<Napi::Object>());
     auto callback = info[2].As<Napi::Function>();
     auto asyncWorker =
-        new ConnectionQueryAsyncWorker(callback, connection, statement, nodeQueryResult);
+        new ConnectionQueryAsyncWorker(callback, connection, statement, nodeQueryResult, info[3]);
     asyncWorker->Queue();
     return info.Env().Undefined();
 }

--- a/tools/nodejs_api/src_cpp/node_progress_bar_display.cpp
+++ b/tools/nodejs_api/src_cpp/node_progress_bar_display.cpp
@@ -12,7 +12,8 @@ void NodeProgressBarDisplay::updateProgress(double newPipelineProgress,
         numPipelinesFinished = newNumPipelinesFinished;
         callback.BlockingCall([this](Napi::Env env, Napi::Function jsCallback) {
             jsCallback.Call({Napi::Number::New(env, pipelineProgress),
-                Napi::Number::New(env, numPipelinesFinished), Napi::Number::New(env, numPipelines)});
+                Napi::Number::New(env, numPipelinesFinished),
+                Napi::Number::New(env, numPipelines)});
         });
     }
 }

--- a/tools/nodejs_api/src_cpp/node_progress_bar_display.cpp
+++ b/tools/nodejs_api/src_cpp/node_progress_bar_display.cpp
@@ -1,0 +1,24 @@
+#include "include/node_progress_bar_display.h"
+
+using namespace kuzu;
+using namespace common;
+
+void NodeProgressBarDisplay::updateProgress(double newPipelineProgress,
+    uint32_t newNumPipelinesFinished) {
+    uint32_t progress = (uint32_t)(newPipelineProgress * 100.0);
+    uint32_t oldProgress = (uint32_t)(pipelineProgress * 100.0);
+    if (progress > oldProgress || newNumPipelinesFinished > numPipelinesFinished) {
+        pipelineProgress = newPipelineProgress;
+        numPipelinesFinished = newNumPipelinesFinished;
+        callback.BlockingCall([this](Napi::Env env, Napi::Function jsCallback) {
+            jsCallback.Call({Napi::Number::New(env, pipelineProgress),
+                Napi::Number::New(env, numPipelinesFinished), Napi::Number::New(env, numPipelines)});
+        });
+    }
+}
+
+void NodeProgressBarDisplay::finishProgress() {
+    pipelineProgress = 0;
+    numPipelines = 0;
+    numPipelinesFinished = 0;
+}

--- a/tools/nodejs_api/src_js/connection.js
+++ b/tools/nodejs_api/src_js/connection.js
@@ -84,9 +84,10 @@ class Connection {
    * Execute a prepared statement with the given parameters.
    * @param {kuzu.PreparedStatement} preparedStatement the prepared statement to execute.
    * @param {Object} params a plain object mapping parameter names to values.
+   * @param {Function} [progressCallback] optional callback function that is invoked with the progress of the query execution. The callback receives three arguments: pipelineProgress, numPipelinesFinished, and numPipelines.
    * @returns {Promise<kuzu.QueryResult>} a promise that resolves to the query result. The promise is rejected if there is an error.
    */
-  execute(preparedStatement, params = {}) {
+  execute(preparedStatement, params = {}, progressCallback) {
     return new Promise((resolve, reject) => {
       if (
         !typeof preparedStatement === "object" ||
@@ -129,6 +130,9 @@ class Connection {
             )
           );
         }
+        }
+      if (progressCallback && typeof progressCallback !== "function") {
+        return reject(new Error("progressCallback must be a function."));
       }
       this._getConnection()
         .then((connection) => {
@@ -149,7 +153,8 @@ class Connection {
                   .catch((err) => {
                     return reject(err);
                   });
-              }
+                },
+              progressCallback
             );
           } catch (e) {
             return reject(e);
@@ -193,12 +198,16 @@ class Connection {
   /**
    * Execute a query.
    * @param {String} statement the statement to execute.
+   * @param {Function} [progressCallback] - Optional callback function that is invoked with the progress of the query execution. The callback receives three arguments: pipelineProgress, numPipelinesFinished, and numPipelines.
    * @returns {Promise<kuzu.QueryResult>} a promise that resolves to the query result. The promise is rejected if there is an error.
    */
-  query(statement) {
+  query(statement, progressCallback) {
     return new Promise((resolve, reject) => {
       if (typeof statement !== "string") {
         return reject(new Error("statement must be a string."));
+      }
+      if (progressCallback && typeof progressCallback !== "function") {
+        return reject(new Error("progressCallback must be a function."));
       }
       this._getConnection()
         .then((connection) => {
@@ -215,7 +224,8 @@ class Connection {
                 .catch((err) => {
                   return reject(err);
                 });
-            });
+            },
+            progressCallback);
           } catch (e) {
             return reject(e);
           }

--- a/tools/nodejs_api/test/test_connection.js
+++ b/tools/nodejs_api/test/test_connection.js
@@ -272,3 +272,78 @@ describe("Close", function () {
     }
   });
 });
+
+describe("Progress", function () {
+    it("should execute a valid prepared statement with progress", async function () {
+        await conn.query("CALL progress_bar_time = 0");
+        let progressCalled = false;
+        const progressCallback = (pipelineProgress, numPipelinesFinished, numPipelines) => {
+            progressCalled = true;
+            assert.isNumber(pipelineProgress);
+            assert.isNumber(numPipelinesFinished);
+            assert.isNumber(numPipelines);
+        };
+        const preparedStatement = await conn.prepare(
+            "MATCH (a:person) WHERE a.ID = $1 RETURN COUNT(*)"
+        );
+        assert.exists(preparedStatement);
+        assert.isTrue(preparedStatement.isSuccess());
+        const queryResult = await conn.execute(preparedStatement, { 1: 0 }, progressCallback);
+        assert.exists(queryResult);
+        assert.equal(queryResult.constructor.name, "QueryResult");
+        assert.isTrue(queryResult.hasNext());
+        const tuple = await queryResult.getNext();
+        assert.exists(tuple);
+        assert.exists(tuple["COUNT_STAR()"]);
+        assert.equal(tuple["COUNT_STAR()"], 1);
+        assert.isTrue(progressCalled)
+    });
+    it("should throw error if the progress callback is not a function for execute", async function () {
+        try {
+            const preparedStatement = await conn.prepare(
+                "MATCH (a:person) WHERE a.ID = $1 RETURN COUNT(*)"
+            );
+            assert.exists(preparedStatement);
+            assert.isTrue(preparedStatement.isSuccess());
+            await conn.execute(preparedStatement, { 1: 0 }, 10);
+            assert.fail("No error thrown when progress callback is not a function.");
+        } catch (e) {
+            assert.equal(
+                e.message,
+                "progressCallback must be a function."
+            );
+        }
+    });
+
+    it("should execute a valid query with progress", async function () {
+        await conn.query("CALL progress_bar_time = 0");
+        let progressCalled = false;
+        const progressCallback = (pipelineProgress, numPipelinesFinished, numPipelines) => {
+            progressCalled = true;
+            assert.isNumber(pipelineProgress);
+            assert.isNumber(numPipelinesFinished);
+            assert.isNumber(numPipelines);
+        };
+        const queryResult = await conn.query("MATCH (a:person) RETURN COUNT(*)", progressCallback);
+        assert.exists(queryResult);
+        assert.equal(queryResult.constructor.name, "QueryResult");
+        assert.isTrue(queryResult.hasNext());
+        const tuple = await queryResult.getNext();
+        assert.exists(tuple);
+        assert.exists(tuple["COUNT_STAR()"]);
+        assert.equal(tuple["COUNT_STAR()"], 8);
+        assert.isTrue(progressCalled);
+    });
+
+    it("should throw error if the progress callback is not a function for query", async function () {
+        try {
+            await conn.query("MATCH (a:person) RETURN COUNT(*)", 10);
+            assert.fail("No error thrown when progress callback is not a function.");
+        } catch (e) {
+            assert.equal(
+                e.message,
+                "progressCallback must be a function."
+            );
+        }
+    });
+});


### PR DESCRIPTION
# Description

Added support for optional query callbacks that can be added to nodejs execute and query commands. 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).