### PR TITLE
Forward declare memory manager

### DIFF
--- a/src/common/in_mem_overflow_buffer.cpp
+++ b/src/common/in_mem_overflow_buffer.cpp
@@ -1,4 +1,5 @@
 #include "common/in_mem_overflow_buffer.h"
+
 #include "storage/buffer_manager/memory_manager.h"
 
 using namespace kuzu::storage;

--- a/src/common/in_mem_overflow_buffer.cpp
+++ b/src/common/in_mem_overflow_buffer.cpp
@@ -1,7 +1,23 @@
 #include "common/in_mem_overflow_buffer.h"
+#include "storage/buffer_manager/memory_manager.h"
+
+using namespace kuzu::storage;
 
 namespace kuzu {
 namespace common {
+
+BufferBlock::BufferBlock(std::unique_ptr<storage::MemoryBuffer> block)
+    : currentOffset{0}, block{std::move(block)} {}
+
+BufferBlock::~BufferBlock() = default;
+
+uint64_t BufferBlock::size() const {
+    return block->buffer.size();
+}
+
+uint8_t* BufferBlock::data() const {
+    return block->buffer.data();
+}
 
 uint8_t* InMemOverflowBuffer::allocateSpace(uint64_t size) {
     if (requireNewBlock(size)) {

--- a/src/include/common/in_mem_overflow_buffer.h
+++ b/src/include/common/in_mem_overflow_buffer.h
@@ -2,19 +2,23 @@
 
 #include <iterator>
 #include <vector>
-
-#include "storage/buffer_manager/memory_manager.h"
+#include <memory>
 
 namespace kuzu {
+namespace storage {
+class MemoryBuffer;
+class MemoryManager;
+}
+
 namespace common {
 
 struct BufferBlock {
 public:
-    explicit BufferBlock(std::unique_ptr<storage::MemoryBuffer> block)
-        : currentOffset{0}, block{std::move(block)} {}
+    explicit BufferBlock(std::unique_ptr<storage::MemoryBuffer> block);
+    ~BufferBlock();
 
-    inline uint64_t size() const { return block->buffer.size(); }
-    inline uint8_t* data() const { return block->buffer.data(); }
+    uint64_t size() const;
+    uint8_t* data() const;
 
 public:
     uint64_t currentOffset;

--- a/src/include/common/in_mem_overflow_buffer.h
+++ b/src/include/common/in_mem_overflow_buffer.h
@@ -1,14 +1,14 @@
 #pragma once
 
 #include <iterator>
-#include <vector>
 #include <memory>
+#include <vector>
 
 namespace kuzu {
 namespace storage {
 class MemoryBuffer;
 class MemoryManager;
-}
+} // namespace storage
 
 namespace common {
 

--- a/src/include/common/vector/auxiliary_buffer.h
+++ b/src/include/common/vector/auxiliary_buffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "common/in_mem_overflow_buffer.h"
+#include "common/types/types.h"
 
 namespace arrow {
 class ChunkedArray;

--- a/src/include/function/table/scan_functions.h
+++ b/src/include/function/table/scan_functions.h
@@ -2,6 +2,7 @@
 
 #include "common/copier_config/reader_config.h"
 #include "function/table_functions.h"
+#include <mutex>
 
 namespace kuzu {
 namespace common {

--- a/src/include/function/table/scan_functions.h
+++ b/src/include/function/table/scan_functions.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <mutex>
+
 #include "common/copier_config/reader_config.h"
 #include "function/table_functions.h"
-#include <mutex>
 
 namespace kuzu {
 namespace common {

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -5,6 +5,10 @@
 #include "common/data_chunk/data_chunk.h"
 
 namespace kuzu {
+namespace main {
+class ClientContext;
+}
+
 namespace processor {
 
 // TODO(Keenan): Split up this file.

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -2,8 +2,8 @@
 
 #include "column_reader.h"
 #include "common/data_chunk/data_chunk.h"
-#include "common/types/types.h"
 #include "common/file_system/virtual_file_system.h"
+#include "common/types/types.h"
 #include "function/function.h"
 #include "function/table/bind_input.h"
 #include "function/table/scan_functions.h"

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -3,6 +3,7 @@
 #include "column_reader.h"
 #include "common/data_chunk/data_chunk.h"
 #include "common/types/types.h"
+#include "common/file_system/virtual_file_system.h"
 #include "function/function.h"
 #include "function/table/bind_input.h"
 #include "function/table/scan_functions.h"


### PR DESCRIPTION
# Description

I found we were including memory manager in the overflow buffer which is included in value vector. So this memory manager  include is propagated to almost the entire codebase.

This PR fixes this by forward declare memory manager. We should enforce the invariant that common headers should not include any header that is not in common.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).