### PR TITLE
Fix windows extension CI to fail if the command fails

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -661,4 +661,10 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
           cd scripts/ && start /b python http-server.py && cd ..
-          make extension-test && make clean
+          make extension-test
+
+      - name: Clean
+        shell: cmd
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+          make clean

--- a/Makefile
+++ b/Makefile
@@ -163,13 +163,12 @@ example:
 	$(call run-cmake-release, -DBUILD_EXAMPLES=TRUE)
 
 extension-test:
-	$(call run-cmake-relwithdebinfo, \
+	$(call run-cmake-release, \
 		-DBUILD_EXTENSIONS="httpfs;duckdb;postgres" \
 		-DBUILD_EXTENSION_TESTS=TRUE \
 		-DENABLE_ADDRESS_SANITIZER=TRUE \
-		-DENABLE_BACKTRACES=TRUE \
 	)
-	ctest --test-dir build/relwithdebinfo/extension --output-on-failure -j ${TEST_JOBS}
+	ctest --test-dir build/release/extension --output-on-failure -j ${TEST_JOBS}
 	aws s3 rm s3://kuzu-dataset-us/${RUN_ID}/ --recursive
 
 extension-debug:


### PR DESCRIPTION
The windows extension CI job is broken since `&&` in cmd.exe apparently doesn't set exit codes the way it does in bash.

The linking failure may be an issue with switching the build to relwithdebinfo (it seems to have been introduced at that point), as the available pre-built duckdb library might not work with that.