### PR TITLE
Add an additional field for bug template to specify OS

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -15,6 +15,14 @@ body:
       placeholder: v0.4.0
     validations:
       required: false
+  - type: input
+    id: os
+    attributes:
+      label: What operating system are you using?
+      description: What operating system are you using?
+      placeholder: e.g., Ubuntu 23.10, MacOS Sonoma 14.2.0, Windows 11
+    validations:
+      required: false
   - type: textarea
     id: what-happened
     attributes:


### PR DESCRIPTION
# Description

To help us isolate issues faster, we offer a field in the bug report form for users to specify the OS they're using Kùzu on.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).