### PR TITLE
add decimal datatype to Python and Java API

### DIFF
--- a/src/include/function/comparison/vector_comparison_functions.h
+++ b/src/include/function/comparison/vector_comparison_functions.h
@@ -14,10 +14,7 @@ struct ComparisonFunction {
     static function_set getFunctionSet(const std::string& name) {
         function_set functionSet;
         for (auto& comparableType : common::LogicalTypeUtils::getAllValidLogicTypeIDs()) {
-            if (comparableType != common::LogicalTypeID::DECIMAL) {
-                // TODO(maxwell): implement decimal functionalities
-                functionSet.push_back(getFunction<OP>(name, comparableType, comparableType));
-            }
+            functionSet.push_back(getFunction<OP>(name, comparableType, comparableType));
         }
         return functionSet;
     }

--- a/tools/java_api/src/main/java/com/kuzudb/KuzuDataTypeID.java
+++ b/tools/java_api/src/main/java/com/kuzudb/KuzuDataTypeID.java
@@ -28,6 +28,7 @@ public enum KuzuDataTypeID {
     TIMESTAMP_NS(38),
     TIMESTAMP_TZ(39),
     INTERVAL(40),
+    DECIMAL(41),
     INTERNAL_ID(42),
     STRING(50),
     BLOB(51),

--- a/tools/java_api/src/test/java/com/kuzudb/test/QueryResultTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/QueryResultTest.java
@@ -61,7 +61,7 @@ public class QueryResultTest extends TestBase {
 
     @Test
     void QueryResultGetColumnDataType() throws KuzuObjectRefDestroyedException {
-        KuzuQueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height");
+        KuzuQueryResult result = conn.query("MATCH (a:person) RETURN a.fName, a.age, a.height, cast(1 as decimal)");
         assertTrue(result.isSuccess());
         KuzuDataType type = result.getColumnDataType(0);
         assertEquals(type.getID(), KuzuDataTypeID.STRING);
@@ -72,6 +72,9 @@ public class QueryResultTest extends TestBase {
         type.destroy();
         type = result.getColumnDataType(2);
         assertEquals(type.getID(), KuzuDataTypeID.FLOAT);
+        type.destroy();
+        type = result.getColumnDataType(3);
+        assertEquals(type.getID(), KuzuDataTypeID.DECIMAL);
         type.destroy();
 
         type = result.getColumnDataType(222);

--- a/tools/java_api/src/test/java/com/kuzudb/test/ValueTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/ValueTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 import java.math.BigInteger;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.Duration;
 import java.time.Instant;
@@ -151,6 +152,18 @@ public class ValueTest extends TestBase {
         assertFalse(value.isOwnedByCPP());
         assertEquals(value.getDataType().getID(), KuzuDataTypeID.FLOAT);
         assertTrue(value.getValue().equals((float) 123.456));
+        value.destroy();
+    }
+
+    @Test
+    void ValueCreateDecimal() throws KuzuObjectRefDestroyedException {
+        // decimal
+        KuzuValue value = new KuzuValue(new BigDecimal("-3.140"));
+        assertFalse(value.isOwnedByCPP());
+        assertEquals(value.getDataType().getID(), KuzuDataTypeID.DECIMAL);
+        System.out.println(value.getValue().toString());
+        BigDecimal val = (BigDecimal)value.getValue();
+        assertTrue(val.compareTo(new BigDecimal("-3.14")) == 0);
         value.destroy();
     }
 

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -4,12 +4,14 @@
 
 #include "cached_import/py_cached_import.h"
 #include "common/constants.h"
+#include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
 #include "common/string_format.h"
 #include "common/types/uuid.h"
 #include "common/utils.h"
 #include "datetime.h" // from Python
 #include "function/built_in_function_utils.h"
+#include "function/cast/functions/cast_string_non_nested_functions.h"
 #include "include/py_udf.h"
 #include "main/connection.h"
 #include "pandas/pandas_scan.h"
@@ -256,6 +258,7 @@ static std::unique_ptr<LogicalType> pyLogicalType(const py::handle& val) {
     auto time_delta = importCache->datetime.timedelta();
     auto datetime_date = importCache->datetime.date();
     auto uuid = importCache->uuid.UUID();
+    auto Decimal = importCache->decimal.Decimal();
     if (val.is_none()) {
         return LogicalType::ANY();
     } else if (py::isinstance<py::bool_>(val)) {
@@ -279,6 +282,21 @@ static std::unique_ptr<LogicalType> pyLogicalType(const py::handle& val) {
         }
     } else if (py::isinstance<py::float_>(val)) {
         return LogicalType::DOUBLE();
+    } else if (py::isinstance(val, Decimal)) {
+        auto as_tuple = val.attr("as_tuple")();
+        auto precision = py::len(as_tuple.attr("digits"));
+        auto exponent = py::cast<int32_t>(as_tuple.attr("exponent"));
+        if (exponent > 0) {
+            precision += exponent;
+            exponent = 0;
+        }
+        if (precision > common::DECIMAL_PRECISION_LIMIT) {
+            throw common::NotImplementedException(
+                stringFormat("Decimal precision cannot be greater than {}"
+                             "Note: positive exponents contribute to precision",
+                    common::DECIMAL_PRECISION_LIMIT));
+        }
+        return LogicalType::DECIMAL(precision, -exponent);
     } else if (py::isinstance<py::str>(val)) {
         return LogicalType::STRING();
     } else if (py::isinstance(val, datetime_datetime)) {
@@ -363,6 +381,14 @@ Value PyConnection::transformPythonValueAs(const py::handle& val, const LogicalT
         return Value::createValue<int8_t>(py::cast<py::int_>(val).cast<int8_t>());
     case LogicalTypeID::DOUBLE:
         return Value::createValue<double>(py::cast<py::float_>(val).cast<double>());
+    case LogicalTypeID::DECIMAL: {
+        auto str = py::cast<std::string>(py::str(val));
+        int128_t result;
+        function::decimalCast(str.c_str(), str.size(), result, type);
+        auto val = Value::createDefaultValue(type);
+        val.val.int128Val = result;
+        return val;
+    }
     case LogicalTypeID::STRING:
         if (py::isinstance<py::str>(val)) {
             return Value::createValue<std::string>(val.cast<std::string>());

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -207,6 +207,10 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
     case LogicalTypeID::DOUBLE: {
         return py::cast(value.getValue<double>());
     }
+    case LogicalTypeID::DECIMAL: {
+        auto Decimal = importCache->decimal.Decimal();
+        return Decimal(value.toString());
+    }
     case LogicalTypeID::STRING: {
         return py::cast(value.getValue<std::string>());
     }

--- a/tools/python_api/src_cpp/py_query_result_converter.cpp
+++ b/tools/python_api/src_cpp/py_query_result_converter.cpp
@@ -86,6 +86,7 @@ void NPArrayWrapper::appendElement(Value* value) {
         case LogicalTypeID::BLOB: {
             ((py::bytes*)dataBuffer)[numElements] = PyQueryResult::convertValueToPyObject(*value);
         } break;
+        case LogicalTypeID::DECIMAL:
         case LogicalTypeID::UUID:
         case LogicalTypeID::UNION:
         case LogicalTypeID::MAP:
@@ -169,6 +170,7 @@ py::dtype NPArrayWrapper::convertToArrayType(const LogicalType& type) {
     case LogicalTypeID::INTERVAL: {
         dtype = "timedelta64[ns]";
     } break;
+    case LogicalTypeID::DECIMAL:
     case LogicalTypeID::UNION:
     case LogicalTypeID::BLOB:
     case LogicalTypeID::UUID:

--- a/tools/python_api/test/test_datatype.py
+++ b/tools/python_api/test/test_datatype.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from decimal import Decimal
 import datetime
 from uuid import UUID
 

--- a/tools/python_api/test/test_datatype.py
+++ b/tools/python_api/test/test_datatype.py
@@ -100,7 +100,7 @@ def test_double(conn_db_readonly: ConnDB) -> None:
 def test_decimal(conn_db_readonly: ConnDB) -> None:
     conn, _ = conn_db_readonly
     res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH cast(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(18, 1)) AS PROD RETURN COLLECT(PROD) AS RES")
-    assert sorted(res.get_next()) == sorted([
+    assert sorted(res.get_next()[0]) == sorted([
         Decimal('5.7'),
         Decimal('8.3'),
         Decimal('2.9'),
@@ -112,7 +112,7 @@ def test_decimal(conn_db_readonly: ConnDB) -> None:
         Decimal('8.7'),
     ])
     res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(4, 1)) AS PROD RETURN COLLECT(PROD) AS RES")
-    assert sorted(res.get_next()) == sorted([
+    assert sorted(res.get_next()[0]) == sorted([
         Decimal('5.7'),
         Decimal('8.3'),
         Decimal('2.9'),

--- a/tools/python_api/test/test_datatype.py
+++ b/tools/python_api/test/test_datatype.py
@@ -96,6 +96,32 @@ def test_double(conn_db_readonly: ConnDB) -> None:
     assert not result.has_next()
     result.close()
 
+def test_decimal(conn_db_readonly: ConnDB) -> None:
+    conn, _ = conn_db_readonly
+    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS PROD RETURN COLLECT(PROD) AS RES")
+    assert res.get_next() == [[
+        Decimal('5.7'),
+        Decimal('8.3'),
+        Decimal('2.9'),
+        Decimal('11.4'),
+        Decimal('16.6'),
+        Decimal('5.8'),
+        Decimal('17.1'),
+        Decimal('24.9'),
+        Decimal('8.7'),
+    ]]
+    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(4, 1)) AS PROD RETURN COLLECT(PROD) AS RES")
+    assert res.get_next() == [[
+        Decimal('5.7'),
+        Decimal('8.3'),
+        Decimal('2.9'),
+        Decimal('11.4'),
+        Decimal('16.6'),
+        Decimal('5.8'),
+        Decimal('17.1'),
+        Decimal('24.9'),
+        Decimal('8.7'),
+    ]]
 
 def test_string(conn_db_readonly: ConnDB) -> None:
     conn, db = conn_db_readonly

--- a/tools/python_api/test/test_datatype.py
+++ b/tools/python_api/test/test_datatype.py
@@ -99,7 +99,7 @@ def test_double(conn_db_readonly: ConnDB) -> None:
 
 def test_decimal(conn_db_readonly: ConnDB) -> None:
     conn, _ = conn_db_readonly
-    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS PROD RETURN COLLECT(PROD) AS RES")
+    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH cast(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(18, 1)) AS PROD RETURN COLLECT(PROD) AS RES")
     assert res.get_next() == [[
         Decimal('5.7'),
         Decimal('8.3'),

--- a/tools/python_api/test/test_datatype.py
+++ b/tools/python_api/test/test_datatype.py
@@ -100,7 +100,7 @@ def test_double(conn_db_readonly: ConnDB) -> None:
 def test_decimal(conn_db_readonly: ConnDB) -> None:
     conn, _ = conn_db_readonly
     res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH cast(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(18, 1)) AS PROD RETURN COLLECT(PROD) AS RES")
-    assert res.get_next() == [[
+    assert sorted(res.get_next()) == sorted([
         Decimal('5.7'),
         Decimal('8.3'),
         Decimal('2.9'),
@@ -110,9 +110,9 @@ def test_decimal(conn_db_readonly: ConnDB) -> None:
         Decimal('17.1'),
         Decimal('24.9'),
         Decimal('8.7'),
-    ]]
+    ])
     res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B WITH CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(4, 1)) AS PROD RETURN COLLECT(PROD) AS RES")
-    assert res.get_next() == [[
+    assert sorted(res.get_next()) == sorted([
         Decimal('5.7'),
         Decimal('8.3'),
         Decimal('2.9'),
@@ -122,7 +122,7 @@ def test_decimal(conn_db_readonly: ConnDB) -> None:
         Decimal('17.1'),
         Decimal('24.9'),
         Decimal('8.7'),
-    ]]
+    ])
 
 def test_string(conn_db_readonly: ConnDB) -> None:
     conn, db = conn_db_readonly

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -547,7 +547,7 @@ def test_get_df_unicode(conn_db_readonly: ConnDB) -> None:
 
 def test_get_df_decimal(conn_db_readonly: ConnDB) -> None:
     conn, _ = conn_db_readonly
-    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B RETURN CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS PROD").get_as_df()
+    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B RETURN CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(18, 1)) AS PROD").get_as_df()
     assert res["PROD"].tolist() == [
         Decimal('5.7'),
         Decimal('8.3'),

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -544,3 +544,30 @@ def test_get_df_unicode(conn_db_readonly: ConnDB) -> None:
         "The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie",
         "Roma",
     ]
+
+def test_get_df_decimal(conn_db_readonly: ConnDB) -> None:
+    conn, _ = conn_db_readonly
+    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B RETURN CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS PROD").get_as_df()
+    assert res["PROD"].tolist() == [
+        Decimal('5.7'),
+        Decimal('8.3'),
+        Decimal('2.9'),
+        Decimal('11.4'),
+        Decimal('16.6'),
+        Decimal('5.8'),
+        Decimal('17.1'),
+        Decimal('24.9'),
+        Decimal('8.7'),
+    ]
+    res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B RETURN CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(4, 1)) AS PROD").get_as_df()
+    assert res["PROD"].tolist() == [
+        Decimal('5.7'),
+        Decimal('8.3'),
+        Decimal('2.9'),
+        Decimal('11.4'),
+        Decimal('16.6'),
+        Decimal('5.8'),
+        Decimal('17.1'),
+        Decimal('24.9'),
+        Decimal('8.7'),
+    ]

--- a/tools/python_api/test/test_df.py
+++ b/tools/python_api/test/test_df.py
@@ -548,7 +548,7 @@ def test_get_df_unicode(conn_db_readonly: ConnDB) -> None:
 def test_get_df_decimal(conn_db_readonly: ConnDB) -> None:
     conn, _ = conn_db_readonly
     res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B RETURN CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(18, 1)) AS PROD").get_as_df()
-    assert res["PROD"].tolist() == [
+    assert sorted(res["PROD"].tolist()) == sorted([
         Decimal('5.7'),
         Decimal('8.3'),
         Decimal('2.9'),
@@ -558,9 +558,9 @@ def test_get_df_decimal(conn_db_readonly: ConnDB) -> None:
         Decimal('17.1'),
         Decimal('24.9'),
         Decimal('8.7'),
-    ]
+    ])
     res = conn.execute("UNWIND [1, 2, 3] AS A UNWIND [5.7, 8.3, 2.9] AS B RETURN CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(4, 1)) AS PROD").get_as_df()
-    assert res["PROD"].tolist() == [
+    assert sorted(res["PROD"].tolist()) == sorted([
         Decimal('5.7'),
         Decimal('8.3'),
         Decimal('2.9'),
@@ -570,4 +570,4 @@ def test_get_df_decimal(conn_db_readonly: ConnDB) -> None:
         Decimal('17.1'),
         Decimal('24.9'),
         Decimal('8.7'),
-    ]
+    ])


### PR DESCRIPTION
Also enables decimal comparison by changing a few lines.

[Doesn't add decimals to nodejs or rust API.](https://github.com/kuzudb/kuzu/issues/3619)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).