### PR TITLE
Check if python module exists to fix #3613

### DIFF
--- a/tools/python_api/src_cpp/cached_import/py_cached_import.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_import.cpp
@@ -1,4 +1,5 @@
 #include "cached_import/py_cached_import.h"
+
 #include "common/exception/runtime.h"
 
 namespace kuzu {

--- a/tools/python_api/src_cpp/cached_import/py_cached_import.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_import.cpp
@@ -18,8 +18,8 @@ py::handle PythonCachedImport::addToCache(py::object obj) {
 
 bool doesPyModuleExist(std::string moduleName) {
     py::gil_scoped_acquire acquire;
-    auto find_loader = importCache->importlib.find_loader();
-    return find_loader(moduleName) != Py_None;
+    auto find_spec = importCache->importlib.util.find_spec();
+    return find_spec(moduleName) != Py_None;
 }
 
 } // namespace kuzu

--- a/tools/python_api/src_cpp/cached_import/py_cached_import.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_import.cpp
@@ -1,6 +1,9 @@
 #include "cached_import/py_cached_import.h"
+#include "common/exception/runtime.h"
 
 namespace kuzu {
+
+std::shared_ptr<PythonCachedImport> importCache;
 
 PythonCachedImport::~PythonCachedImport() {
     py::gil_scoped_acquire acquire;
@@ -13,6 +16,10 @@ py::handle PythonCachedImport::addToCache(py::object obj) {
     return ptr;
 }
 
-std::shared_ptr<PythonCachedImport> importCache;
+bool doesPyModuleExist(std::string moduleName) {
+    py::gil_scoped_acquire acquire;
+    auto find_loader = importCache->importlib.find_loader();
+    return find_loader(moduleName) != Py_None;
+}
 
 } // namespace kuzu

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_import.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_import.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include <vector>
 
 #include "py_cached_modules.h"
@@ -18,6 +19,7 @@ public:
 
     DateTimeCachedItem datetime;
     DecimalCachedItem decimal;
+    ImportLibCachedItem importlib;
     InspectCachedItem inspect;
     NumpyMaCachedItem numpyma;
     PandasCachedItem pandas;
@@ -28,6 +30,8 @@ public:
 private:
     std::vector<py::object> allObjects;
 };
+
+bool doesPyModuleExist(std::string moduleName);
 
 extern std::shared_ptr<PythonCachedImport> importCache;
 

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -5,7 +5,6 @@
 namespace kuzu {
 
 class DateTimeCachedItem : public PythonCachedItem {
-
 public:
     DateTimeCachedItem()
         : PythonCachedItem("datetime"), date("date", this), datetime("datetime", this),
@@ -17,7 +16,6 @@ public:
 };
 
 class DecimalCachedItem : public PythonCachedItem {
-
 public:
     DecimalCachedItem() : PythonCachedItem("decimal"), Decimal("Decimal", this) {}
 
@@ -25,12 +23,10 @@ public:
 };
 
 class ImportLibCachedItem : public PythonCachedItem {
-
     class UtilCachedItem : public PythonCachedItem {
-
     public:
         explicit UtilCachedItem(PythonCachedItem* parent)
-            : PythonCachedItem("util", parent), find_spec("find_spec", this) {}
+            : PythonCachedItem{"util", parent}, find_spec{"find_spec", this} {}
 
         PythonCachedItem find_spec;
     };
@@ -42,7 +38,6 @@ public:
 };
 
 class InspectCachedItem : public PythonCachedItem {
-
 public:
     InspectCachedItem()
         : PythonCachedItem("inspect"), currentframe("currentframe", this),
@@ -54,7 +49,6 @@ public:
 };
 
 class NumpyMaCachedItem : public PythonCachedItem {
-
 public:
     NumpyMaCachedItem() : PythonCachedItem("numpy.ma"), masked_array("masked_array", this) {}
 
@@ -62,7 +56,6 @@ public:
 };
 
 class PandasCachedItem : public PythonCachedItem {
-
     class SeriesCachedItem : public PythonCachedItem {
     public:
         explicit SeriesCachedItem(PythonCachedItem* parent)
@@ -107,7 +100,6 @@ public:
 };
 
 class PyarrowCachedItem : public PythonCachedItem {
-
     class RecordBatchCachedItem : public PythonCachedItem {
     public:
         explicit RecordBatchCachedItem(PythonCachedItem* parent)
@@ -151,7 +143,6 @@ public:
 };
 
 class UUIDCachedItem : public PythonCachedItem {
-
 public:
     UUIDCachedItem() : PythonCachedItem("uuid"), UUID("UUID", this) {}
 

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -24,6 +24,14 @@ public:
     PythonCachedItem Decimal;
 };
 
+class ImportLibCachedItem : public PythonCachedItem {
+
+public:
+    ImportLibCachedItem() : PythonCachedItem("importlib"), find_loader("find_loader", this) {}
+
+    PythonCachedItem find_loader;
+};
+
 class InspectCachedItem : public PythonCachedItem {
 
 public:

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -27,10 +27,10 @@ public:
 class ImportLibCachedItem : public PythonCachedItem {
 
     class UtilCachedItem : public PythonCachedItem {
-    
+
     public:
-        explicit UtilCachedItem(PythonCachedItem* parent) : PythonCachedItem("util", parent),
-            find_spec("find_spec", this) {}
+        explicit UtilCachedItem(PythonCachedItem* parent)
+            : PythonCachedItem("util", parent), find_spec("find_spec", this) {}
 
         PythonCachedItem find_spec;
     };

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -26,10 +26,19 @@ public:
 
 class ImportLibCachedItem : public PythonCachedItem {
 
-public:
-    ImportLibCachedItem() : PythonCachedItem("importlib"), find_loader("find_loader", this) {}
+    class UtilCachedItem : public PythonCachedItem {
+    
+    public:
+        explicit UtilCachedItem(PythonCachedItem* parent) : PythonCachedItem("util", parent),
+            find_spec("find_spec", this) {}
 
-    PythonCachedItem find_loader;
+        PythonCachedItem find_spec;
+    };
+
+public:
+    ImportLibCachedItem() : PythonCachedItem("importlib"), util(this) {}
+
+    UtilCachedItem util;
 };
 
 class InspectCachedItem : public PythonCachedItem {

--- a/tools/python_api/src_cpp/include/py_connection.h
+++ b/tools/python_api/src_cpp/include/py_connection.h
@@ -40,6 +40,7 @@ public:
         const std::string& dstTableName, size_t queryBatchSize);
 
     static bool isPandasDataframe(const py::object& object);
+    static bool isPolarsDataframe(const py::object& object);
 
     void createScalarFunction(const std::string& name, const py::function& udf,
         const py::list& params, const std::string& retval, bool defaultNull, bool catchExceptions);

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -48,7 +48,7 @@ static std::unique_ptr<function::ScanReplacementData> tryReplacePolars(py::dict&
         return nullptr;
     }
     auto entry = dict[objectName];
-    if (py::isinstance(entry, importCache->polars.DataFrame())) {
+    if (PyConnection::isPolarsDataframe(entry)) {
         auto scanReplacementData = std::make_unique<function::ScanReplacementData>();
         scanReplacementData->func = PyArrowTableScanFunction::getFunction();
         auto bindInput = function::TableFuncBindInput();
@@ -231,7 +231,17 @@ void PyConnection::getAllEdgesForTorchGeometric(py::array_t<int64_t>& npArray,
 }
 
 bool PyConnection::isPandasDataframe(const py::object& object) {
+    if (!doesPyModuleExist("pandas")) {
+        return false;
+    }
     return py::isinstance(object, importCache->pandas.DataFrame());
+}
+
+bool PyConnection::isPolarsDataframe(const py::object& object) {
+    if (!doesPyModuleExist("polars")) {
+        return false;
+    }
+    return py::isinstance(object, importCache->polars.DataFrame());
 }
 
 static std::unordered_map<std::string, std::unique_ptr<Value>> transformPythonParameters(

--- a/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
+++ b/tools/python_api/src_cpp/pyarrow/pyarrow_scan.cpp
@@ -18,7 +18,7 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
     py::gil_scoped_acquire acquire;
     py::object table(py::reinterpret_borrow<py::object>(
         reinterpret_cast<PyObject*>(input->inputs[0].getValue<uint8_t*>())));
-    if (py::isinstance(table, importCache->pandas.DataFrame())) {
+    if (PyConnection::isPandasDataframe(table)) {
         table = importCache->pyarrow.lib.Table.from_pandas()(table);
     } else if (py::isinstance(table, importCache->polars.DataFrame())) {
         table = table.attr("to_arrow")();


### PR DESCRIPTION
Fixes #3613

assumes that if the pandas/polars module does not exist, then the object is not a pandas/polars Dataframe instance.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).