### PR TITLE
Column scan with chunk state

### DIFF
--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -78,7 +78,7 @@ public:
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector);
     // Scan from [startOffsetInGroup, endOffsetInGroup).
-    virtual void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+    virtual void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET);
 

--- a/src/include/storage/store/dictionary_column.h
+++ b/src/include/storage/store/dictionary_column.h
@@ -20,7 +20,7 @@ public:
 
     void append(Column::ChunkState& state, const DictionaryChunk& dictChunk);
 
-    void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+    void scan(transaction::Transaction* transaction, const Column::ChunkState& state,
         DictionaryChunk& dictChunk);
     // Offsets to scan should be a sorted list of pairs mapping the index of the entry in the string
     // dictionary (as read from the index column) to the output index in the result vector to store

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -58,7 +58,7 @@ public:
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
-    void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+    void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
 
@@ -92,7 +92,7 @@ private:
         common::offset_t offsetInNodeGroup);
 
     ListOffsetSizeInfo getListOffsetSizeInfo(transaction::Transaction* transaction,
-        common::node_group_idx_t nodeGroupIdx, common::offset_t startOffsetInNodeGroup,
+        const ChunkState& state, common::offset_t startOffsetInNodeGroup,
         common::offset_t endOffsetInNodeGroup);
 
     void prepareCommitForExistingChunk(transaction::Transaction* transaction, ChunkState& state,

--- a/src/include/storage/store/null_column.h
+++ b/src/include/storage/store/null_column.h
@@ -23,7 +23,7 @@ public:
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector) override;
-    void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+    void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
 

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -42,8 +42,11 @@ struct CSRHeaderColumns {
 
     void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
         const ChunkedCSRHeader& chunks) const {
-        offset->scan(transaction, nodeGroupIdx, chunks.offset.get());
-        length->scan(transaction, nodeGroupIdx, chunks.length.get());
+        Column::ChunkState offsetState, lengthState;
+        offset->initChunkState(transaction, nodeGroupIdx, offsetState);
+        length->initChunkState(transaction, nodeGroupIdx, lengthState);
+        offset->scan(transaction, offsetState, chunks.offset.get());
+        length->scan(transaction, lengthState, chunks.length.get());
     }
     void append(const ChunkedCSRHeader& headerChunks, Column::ChunkState& offsetState,
         Column::ChunkState& lengthState) const {

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -18,7 +18,7 @@ public:
     void scan(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t startOffsetInGroup, common::offset_t endOffsetInGroup,
         common::ValueVector* resultVector, uint64_t offsetInVector = 0) override;
-    void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+    void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
 

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -14,7 +14,7 @@ public:
 
     void initChunkState(transaction::Transaction* transaction,
         common::node_group_idx_t nodeGroupIdx, ChunkState& chunkState) override;
-    void scan(transaction::Transaction* transaction, common::node_group_idx_t nodeGroupIdx,
+    void scan(transaction::Transaction* transaction, const ChunkState& state,
         ColumnChunkData* columnChunk, common::offset_t startOffset = 0,
         common::offset_t endOffset = common::INVALID_OFFSET) override;
     void scan(transaction::Transaction* transaction, const ChunkState& state,

--- a/src/storage/store/null_column.cpp
+++ b/src/storage/store/null_column.cpp
@@ -62,9 +62,9 @@ void NullColumn::scan(Transaction* transaction, const ChunkState& state,
         offsetInVector);
 }
 
-void NullColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,
+void NullColumn::scan(Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
-    Column::scan(transaction, nodeGroupIdx, columnChunk, startOffset, endOffset);
+    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
 }
 
 void NullColumn::lookup(Transaction* transaction, ChunkState& readState, ValueVector* nodeIDVector,

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -42,14 +42,14 @@ void StringColumn::scan(Transaction* transaction, const ChunkState& state,
         resultVector, offsetInVector);
 }
 
-void StringColumn::scan(Transaction* transaction, node_group_idx_t nodeGroupIdx,
+void StringColumn::scan(Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
-    Column::scan(transaction, nodeGroupIdx, columnChunk, startOffset, endOffset);
+    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
     if (columnChunk->getNumValues() == 0) {
         return;
     }
     auto& stringColumnChunk = columnChunk->cast<StringChunkData>();
-    dictionary.scan(transaction, nodeGroupIdx, stringColumnChunk.getDictionaryChunk());
+    dictionary.scan(transaction, state, stringColumnChunk.getDictionaryChunk());
 }
 
 void StringColumn::append(ColumnChunkData* columnChunk, ChunkState& state) {


### PR DESCRIPTION
# Description

Rework the interface of `Column::scan(transaction::Transaction* transaction, ColumnChunkData* columnChunk, common::offset_t startOffset = 0, common::offset_t endOffset = common::INVALID_OFFSET)`, which scans from a column into a ColumnChunk,  to pass in ChunkState instead of `nodeGroupIdx`.