### PR TITLE
List Column refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.4.2.8 LANGUAGES CXX C)
+project(Kuzu VERSION 0.4.2.9 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 

--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -46,6 +46,9 @@ public:
         ChunkState(ColumnChunkMetadata metadata, uint64_t numValuesPerPage)
             : metadata{std::move(metadata)}, numValuesPerPage{numValuesPerPage} {}
 
+        ChunkState& getChildState(common::idx_t child);
+        const ChunkState& getChildState(common::idx_t child) const;
+
         ColumnChunkMetadata metadata;
         uint64_t numValuesPerPage = UINT64_MAX;
         common::node_group_idx_t nodeGroupIdx = common::INVALID_NODE_GROUP_IDX;
@@ -112,6 +115,9 @@ public:
         const offset_to_row_idx_t& insertInfo, const ChunkCollection& localUpdateChunks,
         const offset_to_row_idx_t& updateInfo, const offset_set_t& deleteInfo);
     virtual void prepareCommitForExistingChunk(transaction::Transaction* transaction,
+        ChunkState& state, const std::vector<common::offset_t>& dstOffsets, ColumnChunkData* chunk,
+        common::offset_t startSrcOffset);
+    virtual void prepareCommitForExistingChunkInPlace(transaction::Transaction* transaction,
         ChunkState& state, const std::vector<common::offset_t>& dstOffsets, ColumnChunkData* chunk,
         common::offset_t startSrcOffset);
 

--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -35,7 +35,6 @@ struct ColumnChunkMetadata {
 class ColumnChunkData {
 public:
     friend struct ColumnChunkFactory;
-    friend struct ListDataColumnChunk;
 
     // ColumnChunks must be initialized after construction, so this constructor should only be used
     // through the ColumnChunkFactory

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -46,6 +46,7 @@ class ListColumn final : public Column {
     static constexpr common::idx_t SIZE_COLUMN_CHILD_READ_STATE_IDX = 0;
     static constexpr common::idx_t DATA_COLUMN_CHILD_READ_STATE_IDX = 1;
     static constexpr common::idx_t OFFSET_COLUMN_CHILD_READ_STATE_IDX = 2;
+    static constexpr size_t CHILD_COLUMN_COUNT = 3;
 
 public:
     ListColumn(std::string name, common::LogicalType dataType,

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -45,6 +45,7 @@ struct ListOffsetSizeInfo {
 class ListColumn final : public Column {
     static constexpr common::idx_t SIZE_COLUMN_CHILD_READ_STATE_IDX = 0;
     static constexpr common::idx_t DATA_COLUMN_CHILD_READ_STATE_IDX = 1;
+    static constexpr common::idx_t OFFSET_COLUMN_CHILD_READ_STATE_IDX = 2;
 
 public:
     ListColumn(std::string name, common::LogicalType dataType,
@@ -110,7 +111,10 @@ private:
         ChunkState& offsetState, const std::vector<common::offset_t>& dstOffsets,
         ColumnChunkData* chunk, common::offset_t startSrcOffset);
 
+    void updateStateMetadataNumValues(ChunkState& state, size_t numValues) override;
+
 private:
+    std::unique_ptr<Column> offsetColumn;
     std::unique_ptr<Column> sizeColumn;
     std::unique_ptr<Column> dataColumn;
 };

--- a/src/include/storage/store/list_column_chunk.h
+++ b/src/include/storage/store/list_column_chunk.h
@@ -6,34 +6,13 @@
 namespace kuzu {
 namespace storage {
 
-// TODO(Guodong): Let's simplify the data structure here by getting rid of this class.
-struct ListDataColumnChunk {
-    std::unique_ptr<ColumnChunkData> dataColumnChunk;
-    uint64_t capacity;
-
-    explicit ListDataColumnChunk(std::unique_ptr<ColumnChunkData> dataChunk)
-        : dataColumnChunk{std::move(dataChunk)}, capacity{this->dataColumnChunk->capacity} {}
-
-    void reset() const;
-
-    void resizeBuffer(uint64_t numValues);
-
-    void append(common::ValueVector* dataVector, const common::SelectionVector& selVector) const {
-        dataColumnChunk->append(dataVector, selVector);
-    }
-
-    uint64_t getNumValues() const { return dataColumnChunk->getNumValues(); }
-};
-
 class ListChunkData final : public ColumnChunkData {
 
 public:
     ListChunkData(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
         bool inMemory);
 
-    ColumnChunkData* getDataColumnChunk() const {
-        return listDataColumnChunk->dataColumnChunk.get();
-    }
+    ColumnChunkData* getDataColumnChunk() const { return listDataColumnChunk.get(); }
 
     ColumnChunkData* getSizeColumnChunk() const { return sizeColumnChunk.get(); }
 
@@ -59,7 +38,7 @@ public:
     void copy(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
-    void resizeDataColumnChunk(uint64_t numValues) { listDataColumnChunk->resizeBuffer(numValues); }
+    void resizeDataColumnChunk(uint64_t numValues) { listDataColumnChunk->resize(numValues); }
 
     void resize(uint64_t newCapacity) override {
         ColumnChunkData::resize(newCapacity);
@@ -89,7 +68,7 @@ private:
 
 protected:
     std::unique_ptr<ColumnChunkData> sizeColumnChunk;
-    std::unique_ptr<ListDataColumnChunk> listDataColumnChunk;
+    std::unique_ptr<ColumnChunkData> listDataColumnChunk;
     // we use checkOffsetSortedAsc flag to indicate that we do not trigger random write
     bool checkOffsetSortedAsc;
 };

--- a/src/include/storage/store/list_column_chunk.h
+++ b/src/include/storage/store/list_column_chunk.h
@@ -70,7 +70,7 @@ private:
 
     void appendNullList();
 
-    void syncNumValuesWithOffsetChunk();
+    void setOffsetChunkValue(common::offset_t val, common::offset_t pos);
 
 protected:
     std::unique_ptr<ColumnChunkData> offsetColumnChunk;

--- a/src/include/storage/store/list_column_chunk.h
+++ b/src/include/storage/store/list_column_chunk.h
@@ -12,6 +12,8 @@ public:
     ListChunkData(common::LogicalType dataType, uint64_t capacity, bool enableCompression,
         bool inMemory);
 
+    ColumnChunkData* getOffsetColumnChunk() const { return offsetColumnChunk.get(); }
+
     ColumnChunkData* getDataColumnChunk() const { return listDataColumnChunk.get(); }
 
     ColumnChunkData* getSizeColumnChunk() const { return sizeColumnChunk.get(); }
@@ -21,6 +23,7 @@ public:
     void setNumValues(uint64_t numValues_) override {
         ColumnChunkData::setNumValues(numValues_);
         sizeColumnChunk->setNumValues(numValues_);
+        offsetColumnChunk->setNumValues(numValues_);
     }
 
     void append(common::ValueVector* vector, const common::SelectionVector& selVector) final;
@@ -43,6 +46,7 @@ public:
     void resize(uint64_t newCapacity) override {
         ColumnChunkData::resize(newCapacity);
         sizeColumnChunk->resize(newCapacity);
+        offsetColumnChunk->resize(newCapacity);
     }
 
     common::offset_t getListStartOffset(common::offset_t offset) const;
@@ -66,7 +70,10 @@ private:
 
     void appendNullList();
 
+    void syncNumValuesWithOffsetChunk();
+
 protected:
+    std::unique_ptr<ColumnChunkData> offsetColumnChunk;
     std::unique_ptr<ColumnChunkData> sizeColumnChunk;
     std::unique_ptr<ColumnChunkData> listDataColumnChunk;
     // we use checkOffsetSortedAsc flag to indicate that we do not trigger random write

--- a/src/include/storage/store/list_column_chunk.h
+++ b/src/include/storage/store/list_column_chunk.h
@@ -14,7 +14,7 @@ public:
 
     ColumnChunkData* getOffsetColumnChunk() const { return offsetColumnChunk.get(); }
 
-    ColumnChunkData* getDataColumnChunk() const { return listDataColumnChunk.get(); }
+    ColumnChunkData* getDataColumnChunk() const { return dataColumnChunk.get(); }
 
     ColumnChunkData* getSizeColumnChunk() const { return sizeColumnChunk.get(); }
 
@@ -41,7 +41,7 @@ public:
     void copy(ColumnChunkData* srcChunk, common::offset_t srcOffsetInChunk,
         common::offset_t dstOffsetInChunk, common::offset_t numValuesToCopy) override;
 
-    void resizeDataColumnChunk(uint64_t numValues) { listDataColumnChunk->resize(numValues); }
+    void resizeDataColumnChunk(uint64_t numValues) { dataColumnChunk->resize(numValues); }
 
     void resize(uint64_t newCapacity) override {
         ColumnChunkData::resize(newCapacity);
@@ -75,7 +75,7 @@ private:
 protected:
     std::unique_ptr<ColumnChunkData> offsetColumnChunk;
     std::unique_ptr<ColumnChunkData> sizeColumnChunk;
-    std::unique_ptr<ColumnChunkData> listDataColumnChunk;
+    std::unique_ptr<ColumnChunkData> dataColumnChunk;
     // we use checkOffsetSortedAsc flag to indicate that we do not trigger random write
     bool checkOffsetSortedAsc;
 };

--- a/src/storage/stats/table_statistics_collection.cpp
+++ b/src/storage/stats/table_statistics_collection.cpp
@@ -74,12 +74,16 @@ std::unique_ptr<MetadataDAHInfo> TablesStatistics::createMetadataDAHInfo(
             createMetadataDAHInfo(*LogicalType::UINT32(), metadataDAC));
         metadataDAHInfo->childrenInfos.push_back(
             createMetadataDAHInfo(ListType::getChildType(dataType), metadataDAC));
+        metadataDAHInfo->childrenInfos.push_back(
+            createMetadataDAHInfo(*LogicalType::UINT64(), metadataDAC));
     } break;
     case PhysicalTypeID::ARRAY: {
         metadataDAHInfo->childrenInfos.push_back(
             createMetadataDAHInfo(*LogicalType::UINT32(), metadataDAC));
         metadataDAHInfo->childrenInfos.push_back(
             createMetadataDAHInfo(ArrayType::getChildType(dataType), metadataDAC));
+        metadataDAHInfo->childrenInfos.push_back(
+            createMetadataDAHInfo(*LogicalType::UINT64(), metadataDAC));
     } break;
     case PhysicalTypeID::STRING: {
         metadataDAHInfo->childrenInfos.resize(StringColumn::CHILD_STATE_COUNT);

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -236,10 +236,11 @@ void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunk
 
     startOffset = std::min(startOffset, state.metadata.numValues);
     endOffset = std::min(endOffset, state.metadata.numValues);
+    KU_ASSERT(endOffset >= startOffset);
     const auto numValuesToScan = endOffset - startOffset;
     const uint64_t numValuesPerPage =
         state.metadata.compMeta.numValues(BufferPoolConstants::PAGE_4KB_SIZE, dataType);
-    if (numValuesPerPage == UINT64_MAX) {
+    if (getDataTypeSizeInChunk(dataType) == 0) {
         columnChunk->setNumValues(numValuesToScan);
         return;
     }
@@ -247,7 +248,6 @@ void Column::scan(Transaction* transaction, const ChunkState& state, ColumnChunk
     auto cursor = PageUtils::getPageCursorForPos(startOffset, numValuesPerPage);
     cursor.pageIdx += state.metadata.pageIdx;
     uint64_t numValuesScanned = 0u;
-    KU_ASSERT(endOffset >= startOffset);
     if (numValuesToScan > columnChunk->getCapacity()) {
         columnChunk->resize(std::bit_ceil(numValuesToScan));
     }

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -114,6 +114,16 @@ void InternalIDColumn::populateCommonTableID(const ValueVector* resultVector) co
     }
 }
 
+Column::ChunkState& Column::ChunkState::getChildState(common::idx_t childIdx) {
+    KU_ASSERT(childrenStates.size() > childIdx);
+    return childrenStates[childIdx];
+}
+
+const Column::ChunkState& Column::ChunkState::getChildState(common::idx_t childIdx) const {
+    KU_ASSERT(childrenStates.size() > childIdx);
+    return childrenStates[childIdx];
+}
+
 Column::Column(std::string name, LogicalType dataType, const MetadataDAHInfo& metaDAHeaderInfo,
     BMFileHandle* dataFH, DiskArrayCollection& metadataDAC, BufferManager* bufferManager, WAL* wal,
     transaction::Transaction* transaction, bool enableCompression, bool requireNullColumn)
@@ -583,16 +593,21 @@ void Column::prepareCommitForExistingChunk(Transaction* transaction, ChunkState&
 void Column::prepareCommitForExistingChunk(Transaction* transaction, ChunkState& state,
     const std::vector<offset_t>& dstOffsets, ColumnChunkData* chunk, offset_t startSrcOffset) {
     if (canCommitInPlace(state, dstOffsets, chunk, startSrcOffset)) {
-        commitColumnChunkInPlace(state, dstOffsets, chunk, startSrcOffset);
-        KU_ASSERT(sanityCheckForWrites(state.metadata, dataType));
-        metadataDA->update(state.nodeGroupIdx, state.metadata);
-        if (nullColumn) {
-            nullColumn->prepareCommitForExistingChunk(transaction, *state.nullState, dstOffsets,
-                chunk->getNullChunk(), startSrcOffset);
-        }
+        prepareCommitForExistingChunkInPlace(transaction, state, dstOffsets, chunk, startSrcOffset);
     } else {
         commitColumnChunkOutOfPlace(transaction, state, false /*isNewNodeGroup*/, dstOffsets, chunk,
             startSrcOffset);
+    }
+}
+
+void Column::prepareCommitForExistingChunkInPlace(Transaction* transaction, ChunkState& state,
+    const std::vector<offset_t>& dstOffsets, ColumnChunkData* chunk, offset_t startSrcOffset) {
+    commitColumnChunkInPlace(state, dstOffsets, chunk, startSrcOffset);
+    KU_ASSERT(sanityCheckForWrites(state.metadata, dataType));
+    metadataDA->update(state.nodeGroupIdx, state.metadata);
+    if (nullColumn) {
+        nullColumn->prepareCommitForExistingChunk(transaction, *state.nullState, dstOffsets,
+            chunk->getNullChunk(), startSrcOffset);
     }
 }
 

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -152,8 +152,6 @@ static std::shared_ptr<CompressionAlg> getCompression(const LogicalType& dataTyp
         return std::make_shared<IntegerBitpacking<int8_t>>();
     }
     case PhysicalTypeID::INTERNAL_ID:
-    case PhysicalTypeID::ARRAY:
-    case PhysicalTypeID::LIST:
     case PhysicalTypeID::UINT64: {
         return std::make_shared<IntegerBitpacking<uint64_t>>();
     }
@@ -205,8 +203,6 @@ void ColumnChunkData::initializeFunction() {
     case PhysicalTypeID::INT16:
     case PhysicalTypeID::INT8:
     case PhysicalTypeID::INTERNAL_ID:
-    case PhysicalTypeID::ARRAY:
-    case PhysicalTypeID::LIST:
     case PhysicalTypeID::UINT64:
     case PhysicalTypeID::UINT32:
     case PhysicalTypeID::UINT16:
@@ -216,6 +212,8 @@ void ColumnChunkData::initializeFunction() {
         flushBufferFunction = CompressedFlushBuffer(compression, dataType);
         getMetadataFunction = GetCompressionMetadata(compression, dataType);
     } break;
+    case PhysicalTypeID::ARRAY:
+    case PhysicalTypeID::LIST:
     case PhysicalTypeID::STRING:
     default: {
         flushBufferFunction = uncompressedFlushBuffer;

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -53,25 +53,37 @@ ListColumn::ListColumn(std::string name, LogicalType dataType,
     BufferManager* bufferManager, WAL* wal, Transaction* transaction, bool enableCompression)
     : Column{name, std::move(dataType), metaDAHeaderInfo, dataFH, metadataDAC, bufferManager, wal,
           transaction, enableCompression, true /* requireNullColumn */} {
-    auto sizeColName = StorageUtils::getColumnName(name, StorageUtils::ColumnType::OFFSET, "");
+    auto offsetColName =
+        StorageUtils::getColumnName(name, StorageUtils::ColumnType::OFFSET, "offset_");
+    auto sizeColName = StorageUtils::getColumnName(name, StorageUtils::ColumnType::OFFSET, "size_");
     auto dataColName = StorageUtils::getColumnName(name, StorageUtils::ColumnType::DATA, "");
     sizeColumn = ColumnFactory::createColumn(sizeColName, *LogicalType::UINT32(),
-        *metaDAHeaderInfo.childrenInfos[0], dataFH, metadataDAC, bufferManager, wal, transaction,
-        enableCompression);
-    dataColumn = ColumnFactory::createColumn(dataColName,
-        *ListType::getChildType(this->dataType).copy(), *metaDAHeaderInfo.childrenInfos[1], dataFH,
-        metadataDAC, bufferManager, wal, transaction, enableCompression);
+        *metaDAHeaderInfo.childrenInfos[SIZE_COLUMN_CHILD_READ_STATE_IDX], dataFH, metadataDAC,
+        bufferManager, wal, transaction, enableCompression);
+    dataColumn =
+        ColumnFactory::createColumn(dataColName, *ListType::getChildType(this->dataType).copy(),
+            *metaDAHeaderInfo.childrenInfos[DATA_COLUMN_CHILD_READ_STATE_IDX], dataFH, metadataDAC,
+            bufferManager, wal, transaction, enableCompression);
+    offsetColumn = ColumnFactory::createColumn(sizeColName, *LogicalType::UINT64(),
+        *metaDAHeaderInfo.childrenInfos[OFFSET_COLUMN_CHILD_READ_STATE_IDX], dataFH, metadataDAC,
+        bufferManager, wal, transaction, enableCompression);
 }
 
 void ListColumn::initChunkState(Transaction* transaction, node_group_idx_t nodeGroupIdx,
     ChunkState& readState) {
     Column::initChunkState(transaction, nodeGroupIdx, readState);
     // We put states for size and data column into childrenStates.
-    readState.childrenStates.resize(2);
+    readState.childrenStates.resize(3);
     sizeColumn->initChunkState(transaction, nodeGroupIdx,
         readState.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX]);
     dataColumn->initChunkState(transaction, nodeGroupIdx,
         readState.childrenStates[DATA_COLUMN_CHILD_READ_STATE_IDX]);
+    offsetColumn->initChunkState(transaction, nodeGroupIdx,
+        readState.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX]);
+    KU_ASSERT(readState.metadata.numValues ==
+              readState.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX].metadata.numValues);
+    KU_ASSERT(readState.metadata.numValues ==
+              readState.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX].metadata.numValues);
 }
 
 void ListColumn::scan(Transaction* transaction, const ChunkState& state,
@@ -115,11 +127,20 @@ void ListColumn::scan(Transaction* transaction, const ChunkState& state,
 
 void ListColumn::scan(Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
-    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
+    nullColumn->scan(transaction, *state.nullState, columnChunk->getNullChunk(), startOffset,
+        endOffset);
+    const size_t numValuesToScan =
+        getNumValuesFromDisk(metadataDA.get(), transaction, state, startOffset, endOffset);
+    columnChunk->setNumValues(numValuesToScan);
+    if (numValuesToScan == 0) {
+        return;
+    }
+
     auto& listColumnChunk = columnChunk->cast<ListChunkData>();
-    auto sizeColumnChunk = listColumnChunk.getSizeColumnChunk();
+    offsetColumn->scan(transaction, state.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX],
+        listColumnChunk.getOffsetColumnChunk(), startOffset, endOffset);
     sizeColumn->scan(transaction, state.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX],
-        sizeColumnChunk, startOffset, endOffset);
+        listColumnChunk.getSizeColumnChunk(), startOffset, endOffset);
     auto resizeNumValues = listColumnChunk.getDataColumnChunk()->getNumValues();
     bool isOffsetSortedAscending = true;
     offset_t prevOffset = listColumnChunk.getListStartOffset(0);
@@ -144,14 +165,14 @@ void ListColumn::scan(Transaction* transaction, const ChunkState& state,
         auto tmpDataColumnChunk = ColumnChunkFactory::createColumnChunkData(
             *ListType::getChildType(this->dataType).copy(), enableCompression,
             std::bit_ceil(resizeNumValues));
+        auto* dataListColumnChunk = listColumnChunk.getDataColumnChunk();
         for (auto i = 0u; i < columnChunk->getNumValues(); i++) {
             offset_t startListOffset = listColumnChunk.getListStartOffset(i);
             offset_t endListOffset = listColumnChunk.getListEndOffset(i);
             dataColumn->scan(transaction, state.childrenStates[DATA_COLUMN_CHILD_READ_STATE_IDX],
                 tmpDataColumnChunk.get(), startListOffset, endListOffset);
-            KU_ASSERT(endListOffset - startListOffset ==
-                      tmpDataColumnChunk->dataColumnChunk->getNumValues());
-            tmpDataColumnChunk->append(tmpDataColumnChunk.get(), 0,
+            KU_ASSERT(endListOffset - startListOffset == tmpDataColumnChunk->getNumValues());
+            dataListColumnChunk->append(tmpDataColumnChunk.get(), 0,
                 tmpDataColumnChunk->getNumValues());
         }
         listColumnChunk.resetOffset();
@@ -177,8 +198,7 @@ void ListColumn::lookupValue(Transaction* transaction, ChunkState& readState, of
     KU_ASSERT(readState.nodeGroupIdx == nodeGroupIdx);
     auto nodeOffsetInGroup = nodeOffset - StorageUtils::getStartOffsetOfNodeGroup(nodeGroupIdx);
     auto listEndOffset = readOffset(transaction, readState, nodeOffsetInGroup);
-    auto size = readSize(transaction, readState.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX],
-        nodeOffsetInGroup);
+    auto size = readSize(transaction, readState, nodeOffsetInGroup);
     auto listStartOffset = listEndOffset - size;
     auto offsetInVector = posInVector == 0 ? 0 : resultVector->getValue<offset_t>(posInVector - 1);
     resultVector->setValue(posInVector, list_entry_t{offsetInVector, size});
@@ -191,10 +211,14 @@ void ListColumn::lookupValue(Transaction* transaction, ChunkState& readState, of
 void ListColumn::append(ColumnChunkData* columnChunk, ChunkState& state) {
     KU_ASSERT(columnChunk->getDataType().getPhysicalType() == dataType.getPhysicalType());
     auto& listColumnChunk = columnChunk->cast<ListChunkData>();
-    Column::append(&listColumnChunk, state);
-    auto sizeColumnChunk = listColumnChunk.getSizeColumnChunk();
+    Column::append(columnChunk, state);
+
+    auto* offsetColumnChunk = listColumnChunk.getOffsetColumnChunk();
+    offsetColumn->append(offsetColumnChunk,
+        state.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX]);
+    auto* sizeColumnChunk = listColumnChunk.getSizeColumnChunk();
     sizeColumn->append(sizeColumnChunk, state.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX]);
-    auto dataColumnChunk = listColumnChunk.getDataColumnChunk();
+    auto* dataColumnChunk = listColumnChunk.getDataColumnChunk();
     dataColumn->append(dataColumnChunk, state.childrenStates[DATA_COLUMN_CHILD_READ_STATE_IDX]);
 }
 
@@ -258,38 +282,43 @@ void ListColumn::prepareCommit() {
     Column::prepareCommit();
     sizeColumn->prepareCommit();
     dataColumn->prepareCommit();
+    offsetColumn->prepareCommit();
 }
 
 void ListColumn::checkpointInMemory() {
     Column::checkpointInMemory();
     sizeColumn->checkpointInMemory();
     dataColumn->checkpointInMemory();
+    offsetColumn->checkpointInMemory();
 }
 
 void ListColumn::rollbackInMemory() {
     Column::rollbackInMemory();
     sizeColumn->rollbackInMemory();
     dataColumn->rollbackInMemory();
+    offsetColumn->rollbackInMemory();
 }
 
 offset_t ListColumn::readOffset(Transaction* transaction, const ChunkState& readState,
     offset_t offsetInNodeGroup) {
-    auto pageCursor = getPageCursorForOffsetInGroup(offsetInNodeGroup, readState);
+    const auto& offsetState = readState.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX];
+    auto pageCursor = offsetColumn->getPageCursorForOffsetInGroup(offsetInNodeGroup, offsetState);
     offset_t value;
-    readFromPage(transaction, pageCursor.pageIdx, [&](uint8_t* frame) -> void {
-        readToPageFunc(frame, pageCursor, (uint8_t*)&value, 0 /* posInVector */,
-            1 /* numValuesToRead */, readState.metadata.compMeta);
+    offsetColumn->readFromPage(transaction, pageCursor.pageIdx, [&](uint8_t* frame) -> void {
+        offsetColumn->readToPageFunc(frame, pageCursor, (uint8_t*)&value, 0 /* posInVector */,
+            1 /* numValuesToRead */, offsetState.metadata.compMeta);
     });
     return value;
 }
 
 list_size_t ListColumn::readSize(Transaction* transaction, const ChunkState& readState,
     offset_t offsetInNodeGroup) {
-    auto pageCursor = getPageCursorForOffsetInGroup(offsetInNodeGroup, readState);
+    const auto& sizeState = readState.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX];
+    auto pageCursor = sizeColumn->getPageCursorForOffsetInGroup(offsetInNodeGroup, sizeState);
     offset_t value;
-    readFromPage(transaction, pageCursor.pageIdx, [&](uint8_t* frame) -> void {
-        readToPageFunc(frame, pageCursor, (uint8_t*)&value, 0 /* posInVector */,
-            1 /* numValuesToRead */, readState.metadata.compMeta);
+    sizeColumn->readFromPage(transaction, pageCursor.pageIdx, [&](uint8_t* frame) -> void {
+        sizeColumn->readToPageFunc(frame, pageCursor, (uint8_t*)&value, 0 /* posInVector */,
+            1 /* numValuesToRead */, sizeState.metadata.compMeta);
     });
     return value;
 }
@@ -301,8 +330,11 @@ ListOffsetSizeInfo ListColumn::getListOffsetSizeInfo(Transaction* transaction,
         enableCompression, numOffsetsToRead);
     auto sizeColumnChunk = ColumnChunkFactory::createColumnChunkData(*LogicalType::UINT32(),
         enableCompression, numOffsetsToRead);
-    Column::scan(transaction, state, offsetColumnChunk.get(), startOffsetInNodeGroup,
-        endOffsetInNodeGroup);
+    // TODO: Should use readState here too.
+    offsetColumn->scan(transaction, state.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX],
+        offsetColumnChunk.get(), startOffsetInNodeGroup, endOffsetInNodeGroup);
+    sizeColumn->scan(transaction, state.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX],
+        sizeColumnChunk.get(), startOffsetInNodeGroup, endOffsetInNodeGroup);
     sizeColumn->scan(transaction, state.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX],
         sizeColumnChunk.get(), startOffsetInNodeGroup, endOffsetInNodeGroup);
     auto numValuesScan = offsetColumnChunk->getNumValues();
@@ -322,6 +354,7 @@ void ListColumn::prepareCommitForExistingChunk(Transaction* transaction, ChunkSt
         auto localUpdateChunk = localUpdateChunks[chunkIdx];
         dstOffsets.push_back(offsetInDstChunk);
         columnChunk->append(localUpdateChunk, offsetInLocalChunk, 1);
+        KU_ASSERT(columnChunk->sanityCheck());
     }
     for (auto& [offsetInDstChunk, rowIdx] : insertInfo) {
         auto [chunkIdx, offsetInLocalChunk] =
@@ -329,6 +362,7 @@ void ListColumn::prepareCommitForExistingChunk(Transaction* transaction, ChunkSt
         auto localInsertChunk = localInsertChunks[chunkIdx];
         dstOffsets.push_back(offsetInDstChunk);
         columnChunk->append(localInsertChunk, offsetInLocalChunk, 1);
+        KU_ASSERT(columnChunk->sanityCheck());
     }
     prepareCommitForExistingChunk(transaction, state, dstOffsets, columnChunk.get(),
         0 /*startSrcOffset*/);
@@ -368,21 +402,35 @@ void ListColumn::prepareCommitForExistingChunk(Transaction* transaction, ChunkSt
             listChunk.getSizeColumnChunk(), startSrcOffset);
         for (auto i = 0u; i < numListsToAppend; i++) {
             auto listEndOffset = listChunk.getListEndOffset(startSrcOffset + i);
-            chunk->setValue<offset_t>(dataColumnSize + listEndOffset, startSrcOffset + i);
+            listChunk.getOffsetColumnChunk()->setValue<offset_t>(dataColumnSize + listEndOffset,
+                startSrcOffset + i);
         }
-        prepareCommitForOffsetChunk(transaction, state, dstOffsets, chunk, startSrcOffset);
+        prepareCommitForOffsetChunk(transaction,
+            state.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX], dstOffsets, &listChunk,
+            startSrcOffset);
+
+        nullColumn->prepareCommitForExistingChunk(transaction, *state.nullState, dstOffsets,
+            chunk->getNullChunk(), startSrcOffset);
+        if (state.metadata.numValues != state.nullState->metadata.numValues) {
+            state.metadata.numValues = state.nullState->metadata.numValues;
+            metadataDA->update(state.nodeGroupIdx, state.metadata);
+        }
     }
 }
 
 void ListColumn::prepareCommitForOffsetChunk(Transaction* transaction, ChunkState& offsetState,
     const std::vector<offset_t>& dstOffsets, ColumnChunkData* chunk, offset_t startSrcOffset) {
     metadataDA->prepareCommit();
-    if (canCommitInPlace(offsetState, dstOffsets, chunk, startSrcOffset)) {
-        Column::commitColumnChunkInPlace(offsetState, dstOffsets, chunk, startSrcOffset);
-        metadataDA->update(offsetState.nodeGroupIdx, offsetState.metadata);
-        if (nullColumn) {
-            nullColumn->prepareCommitForChunk(transaction, offsetState.nodeGroupIdx, false,
-                dstOffsets, chunk->getNullChunk(), startSrcOffset);
+
+    auto& listChunk = chunk->cast<ListChunkData>();
+    auto* offsetChunk = listChunk.getOffsetColumnChunk();
+    if (offsetColumn->canCommitInPlace(offsetState, dstOffsets, offsetChunk, startSrcOffset)) {
+        offsetColumn->commitColumnChunkInPlace(offsetState, dstOffsets, offsetChunk,
+            startSrcOffset);
+        offsetColumn->metadataDA->update(offsetState.nodeGroupIdx, offsetState.metadata);
+        if (offsetColumn->nullColumn) {
+            offsetColumn->nullColumn->prepareCommitForChunk(transaction, offsetState.nodeGroupIdx,
+                false, dstOffsets, offsetChunk->getNullChunk(), startSrcOffset);
         }
     } else {
         commitOffsetColumnChunkOutOfPlace(transaction, offsetState, dstOffsets, chunk,
@@ -390,23 +438,29 @@ void ListColumn::prepareCommitForOffsetChunk(Transaction* transaction, ChunkStat
     }
 }
 
+void ListColumn::updateStateMetadataNumValues(ChunkState& state, size_t numValues) {
+    state.metadata.numValues = numValues;
+    state.childrenStates[SIZE_COLUMN_CHILD_READ_STATE_IDX].metadata.numValues = numValues;
+    state.childrenStates[OFFSET_COLUMN_CHILD_READ_STATE_IDX].metadata.numValues = numValues;
+}
+
 void ListColumn::commitOffsetColumnChunkOutOfPlace(Transaction* transaction,
     ChunkState& offsetState, const std::vector<offset_t>& dstOffsets, ColumnChunkData* chunk,
     offset_t startSrcOffset) {
-    auto& listChunk = chunk->cast<ListChunkData>();
-    auto offsetColumnChunk = ColumnChunkFactory::createColumnChunkData(*dataType.copy(),
-        enableCompression, 1.5 * std::bit_ceil(offsetState.metadata.numValues + dstOffsets.size()));
-    Column::scan(transaction, offsetState, offsetColumnChunk.get());
+    auto offsetColumnChunk =
+        ColumnChunkFactory::createColumnChunkData(*offsetColumn->dataType.copy(), enableCompression,
+            1.5 * std::bit_ceil(offsetState.metadata.numValues + dstOffsets.size()));
+    offsetColumn->scan(transaction, offsetState, offsetColumnChunk.get());
+
     auto numListsToAppend = std::min(chunk->getNumValues(), (uint64_t)dstOffsets.size());
+    auto& listChunk = chunk->cast<ListChunkData>();
     for (auto i = 0u; i < numListsToAppend; i++) {
         auto listEndOffset = listChunk.getListEndOffset(startSrcOffset + i);
         auto isNull = listChunk.getNullChunk()->isNull(startSrcOffset + i);
         offsetColumnChunk->setValue<offset_t>(listEndOffset, dstOffsets[i]);
         offsetColumnChunk->getNullChunk()->setNull(dstOffsets[i], isNull);
     }
-    auto& offsetListChunk = offsetColumnChunk->cast<ListChunkData>();
-    offsetListChunk.getSizeColumnChunk()->setNumValues(offsetColumnChunk->getNumValues());
-    Column::append(offsetColumnChunk.get(), offsetState);
+    offsetColumn->append(offsetColumnChunk.get(), offsetState);
 }
 
 } // namespace storage

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -141,20 +141,18 @@ void ListColumn::scan(Transaction* transaction, const ChunkState& state,
         listColumnChunk.resetOffset();
     } else {
         listColumnChunk.resizeDataColumnChunk(std::bit_ceil(resizeNumValues));
-        auto tmpDataColumnChunk =
-            std::make_unique<ListDataColumnChunk>(ColumnChunkFactory::createColumnChunkData(
-                *ListType::getChildType(this->dataType).copy(), enableCompression,
-                std::bit_ceil(resizeNumValues)));
-        auto dataListColumnChunk = listColumnChunk.getDataColumnChunk();
+        auto tmpDataColumnChunk = ColumnChunkFactory::createColumnChunkData(
+            *ListType::getChildType(this->dataType).copy(), enableCompression,
+            std::bit_ceil(resizeNumValues));
         for (auto i = 0u; i < columnChunk->getNumValues(); i++) {
             offset_t startListOffset = listColumnChunk.getListStartOffset(i);
             offset_t endListOffset = listColumnChunk.getListEndOffset(i);
             dataColumn->scan(transaction, state.childrenStates[DATA_COLUMN_CHILD_READ_STATE_IDX],
-                tmpDataColumnChunk->dataColumnChunk.get(), startListOffset, endListOffset);
+                tmpDataColumnChunk.get(), startListOffset, endListOffset);
             KU_ASSERT(endListOffset - startListOffset ==
                       tmpDataColumnChunk->dataColumnChunk->getNumValues());
-            dataListColumnChunk->append(tmpDataColumnChunk->dataColumnChunk.get(), 0,
-                tmpDataColumnChunk->dataColumnChunk->getNumValues());
+            tmpDataColumnChunk->append(tmpDataColumnChunk.get(), 0,
+                tmpDataColumnChunk->getNumValues());
         }
         listColumnChunk.resetOffset();
     }

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -127,12 +127,8 @@ void ListColumn::scan(Transaction* transaction, const ChunkState& state,
 
 void ListColumn::scan(Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
-    nullColumn->scan(transaction, *state.nullState, columnChunk->getNullChunk(), startOffset,
-        endOffset);
-    const size_t numValuesToScan =
-        getNumValuesFromDisk(metadataDA.get(), transaction, state, startOffset, endOffset);
-    columnChunk->setNumValues(numValuesToScan);
-    if (numValuesToScan == 0) {
+    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
+    if (columnChunk->getNumValues() == 0) {
         return;
     }
 

--- a/src/storage/store/list_column_chunk.cpp
+++ b/src/storage/store/list_column_chunk.cpp
@@ -82,7 +82,7 @@ void ListChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChunk
         listDataColumnChunk->append(otherListChunk->listDataColumnChunk.get(), startOffset,
             appendSize);
     }
-    sanityCheck();
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::resetToEmpty() {
@@ -125,7 +125,7 @@ void ListChunkData::append(ValueVector* vector, const SelectionVector& selVector
         copyListValues(vector->getValue<list_entry_t>(pos), dataVector);
     }
     numValues += numToAppend;
-    sanityCheck();
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::appendNullList() {
@@ -190,7 +190,7 @@ void ListChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
         sizeColumnChunk->setValue<list_size_t>(appendSize, posInChunk);
         sizeColumnChunk->getNullChunk()->setNull(posInChunk, otherListChunk->nullChunk->isNull(i));
     }
-    sanityCheck();
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::write(ValueVector* vector, offset_t offsetInVector, offset_t offsetInChunk) {
@@ -216,7 +216,7 @@ void ListChunkData::write(ValueVector* vector, offset_t offsetInVector, offset_t
         sizeColumnChunk->setValue<list_size_t>(appendSize, offsetInChunk);
         setValue<offset_t>(listDataColumnChunk->getNumValues(), offsetInChunk);
     }
-    sanityCheck();
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
@@ -243,7 +243,7 @@ void ListChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
         listDataColumnChunk->append(srcListChunk->listDataColumnChunk.get(), startOffsetInSrcChunk,
             appendSize);
     }
-    sanityCheck();
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::copy(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
@@ -322,7 +322,7 @@ void ListChunkData::finalize() {
         }
         currentIndex++;
     }
-    newListChunk->sanityCheck();
+    KU_ASSERT(newListChunk->sanityCheck());
     // Move offsets, null, data from newListChunk to this column chunk. And release indices.
     resetFromOtherChunk(newListChunk);
 }

--- a/src/storage/store/list_column_chunk.cpp
+++ b/src/storage/store/list_column_chunk.cpp
@@ -15,6 +15,8 @@ namespace storage {
 ListChunkData::ListChunkData(LogicalType dataType, uint64_t capacity, bool enableCompression,
     bool inMemory)
     : ColumnChunkData{std::move(dataType), capacity, enableCompression, true /* hasNullChunk */} {
+    offsetColumnChunk = ColumnChunkFactory::createColumnChunkData(*common::LogicalType::UINT64(),
+        enableCompression, capacity);
     sizeColumnChunk = ColumnChunkFactory::createColumnChunkData(*common::LogicalType::UINT32(),
         enableCompression, capacity);
     listDataColumnChunk =
@@ -51,7 +53,7 @@ offset_t ListChunkData::getListEndOffset(offset_t offset) const {
     if (numValues == 0 || nullChunk->isNull(offset))
         return 0;
     KU_ASSERT(offset < numValues);
-    return getValue<uint64_t>(offset);
+    return offsetColumnChunk->getValue<uint64_t>(offset);
 }
 
 list_size_t ListChunkData::getListSize(common::offset_t offset) const {
@@ -61,25 +63,32 @@ list_size_t ListChunkData::getListSize(common::offset_t offset) const {
     return sizeColumnChunk->getValue<list_size_t>(offset);
 }
 
+void ListChunkData::syncNumValuesWithOffsetChunk() {
+    numValues = offsetColumnChunk->getNumValues();
+}
+
 void ListChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChunk,
     uint32_t numValuesToAppend) {
     checkOffsetSortedAsc = true;
-    auto otherListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(other);
+    auto& otherListChunk = other->cast<ListChunkData>();
     nullChunk->append(other->getNullChunk(), startPosInOtherChunk, numValuesToAppend);
+    offsetColumnChunk->getNullChunk()->append(other->getNullChunk(), startPosInOtherChunk,
+        numValuesToAppend);
     sizeColumnChunk->getNullChunk()->append(other->getNullChunk(), startPosInOtherChunk,
         numValuesToAppend);
     offset_t offsetInDataChunkToAppend = listDataColumnChunk->getNumValues();
     for (auto i = 0u; i < numValuesToAppend; i++) {
-        auto appendSize = otherListChunk->getListSize(startPosInOtherChunk + i);
+        auto appendSize = otherListChunk.getListSize(startPosInOtherChunk + i);
         sizeColumnChunk->setValue<list_size_t>(appendSize, numValues);
         offsetInDataChunkToAppend += appendSize;
-        setValue<offset_t>(offsetInDataChunkToAppend, numValues);
+        offsetColumnChunk->setValue<offset_t>(offsetInDataChunkToAppend, numValues);
+        syncNumValuesWithOffsetChunk();
     }
     listDataColumnChunk->resize(offsetInDataChunkToAppend);
     for (auto i = 0u; i < numValuesToAppend; i++) {
-        auto startOffset = otherListChunk->getListStartOffset(startPosInOtherChunk + i);
-        auto appendSize = otherListChunk->getListSize(startPosInOtherChunk + i);
-        listDataColumnChunk->append(otherListChunk->listDataColumnChunk.get(), startOffset,
+        auto startOffset = otherListChunk.getListStartOffset(startPosInOtherChunk + i);
+        auto appendSize = otherListChunk.getListSize(startPosInOtherChunk + i);
+        listDataColumnChunk->append(otherListChunk.listDataColumnChunk.get(), startOffset,
             appendSize);
     }
     KU_ASSERT(sanityCheck());
@@ -88,6 +97,7 @@ void ListChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChunk
 void ListChunkData::resetToEmpty() {
     ColumnChunkData::resetToEmpty();
     sizeColumnChunk->resetToEmpty();
+    offsetColumnChunk->resetToEmpty();
     listDataColumnChunk = ColumnChunkFactory::createColumnChunkData(
         *ListType::getChildType(this->dataType).copy(), enableCompression, 0 /* capacity */);
 }
@@ -102,15 +112,19 @@ void ListChunkData::append(ValueVector* vector, const SelectionVector& selVector
         resize(newCapacity);
     }
     offset_t nextListOffsetInChunk = listDataColumnChunk->getNumValues();
-    auto offsetBufferToWrite = (offset_t*)(buffer.get());
+    const offset_t appendBaseOffset = numValues;
     for (auto i = 0u; i < selVector.getSelSize(); i++) {
         auto pos = selVector[i];
         auto listLen = vector->isNull(pos) ? 0 : vector->getValue<list_entry_t>(pos).size;
-        sizeColumnChunk->setValue<list_size_t>(listLen, numValues + i);
-        sizeColumnChunk->getNullChunk()->setNull(numValues + i, vector->isNull(pos));
-        nullChunk->setNull(numValues + i, vector->isNull(pos));
+        sizeColumnChunk->setValue<list_size_t>(listLen, appendBaseOffset + i);
+        sizeColumnChunk->getNullChunk()->setNull(appendBaseOffset + i, vector->isNull(pos));
+
+        nullChunk->setNull(appendBaseOffset + i, vector->isNull(pos));
+
         nextListOffsetInChunk += listLen;
-        offsetBufferToWrite[numValues + i] = nextListOffsetInChunk;
+        offsetColumnChunk->setValue(nextListOffsetInChunk, appendBaseOffset + i);
+        offsetColumnChunk->getNullChunk()->setNull(appendBaseOffset + i, vector->isNull(pos));
+        syncNumValuesWithOffsetChunk();
     }
     listDataColumnChunk->resize(nextListOffsetInChunk);
     auto dataVector = ListVector::getDataVector(vector);
@@ -124,18 +138,18 @@ void ListChunkData::append(ValueVector* vector, const SelectionVector& selVector
         }
         copyListValues(vector->getValue<list_entry_t>(pos), dataVector);
     }
-    numValues += numToAppend;
     KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::appendNullList() {
     offset_t nextListOffsetInChunk = listDataColumnChunk->getNumValues();
-    auto offsetBufferToWrite = (offset_t*)(buffer.get());
     sizeColumnChunk->setValue<list_size_t>(0, numValues);
     sizeColumnChunk->getNullChunk()->setNull(numValues, true);
-    offsetBufferToWrite[numValues] = nextListOffsetInChunk;
+    offsetColumnChunk->setValue(nextListOffsetInChunk, numValues);
+    offsetColumnChunk->getNullChunk()->setNull(numValues, true);
     nullChunk->setNull(numValues, true);
-    numValues++;
+    syncNumValuesWithOffsetChunk();
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::lookup(offset_t offsetInChunk, ValueVector& output,
@@ -166,11 +180,11 @@ void ListChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
               chunk->getNumValues() == dstOffsets->getNumValues());
     checkOffsetSortedAsc = true;
     offset_t currentIndex = listDataColumnChunk->getNumValues();
-    auto otherListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(chunk);
+    auto& otherListChunk = chunk->cast<ListChunkData>();
     listDataColumnChunk->resize(
-        listDataColumnChunk->getNumValues() + otherListChunk->listDataColumnChunk->getNumValues());
-    listDataColumnChunk->append(otherListChunk->listDataColumnChunk.get(), 0,
-        otherListChunk->listDataColumnChunk->getNumValues());
+        listDataColumnChunk->getNumValues() + otherListChunk.listDataColumnChunk->getNumValues());
+    listDataColumnChunk->append(otherListChunk.listDataColumnChunk.get(), 0,
+        otherListChunk.listDataColumnChunk->getNumValues());
     offset_t maxDstOffset = 0;
     for (auto i = 0u; i < dstOffsets->getNumValues(); i++) {
         auto posInChunk = dstOffsets->getValue<offset_t>(i);
@@ -183,12 +197,15 @@ void ListChunkData::write(ColumnChunkData* chunk, ColumnChunkData* dstOffsets,
     }
     for (auto i = 0u; i < dstOffsets->getNumValues(); i++) {
         auto posInChunk = dstOffsets->getValue<offset_t>(i);
-        auto appendSize = otherListChunk->getListSize(i);
+        auto appendSize = otherListChunk.getListSize(i);
         currentIndex += appendSize;
-        setValue<offset_t>(currentIndex, posInChunk);
-        nullChunk->setNull(posInChunk, otherListChunk->nullChunk->isNull(i));
+        nullChunk->setNull(posInChunk, otherListChunk.nullChunk->isNull(i));
+        offsetColumnChunk->setValue<offset_t>(currentIndex, posInChunk);
+        offsetColumnChunk->getNullChunk()->setNull(posInChunk, otherListChunk.nullChunk->isNull(i));
         sizeColumnChunk->setValue<list_size_t>(appendSize, posInChunk);
-        sizeColumnChunk->getNullChunk()->setNull(posInChunk, otherListChunk->nullChunk->isNull(i));
+        sizeColumnChunk->getNullChunk()->setNull(posInChunk, otherListChunk.nullChunk->isNull(i));
+
+        syncNumValuesWithOffsetChunk();
     }
     KU_ASSERT(sanityCheck());
 }
@@ -211,10 +228,12 @@ void ListChunkData::write(ValueVector* vector, offset_t offsetInVector, offset_t
     }
     auto isNull = vector->isNull(offsetInVector);
     nullChunk->setNull(offsetInChunk, isNull);
+    offsetColumnChunk->getNullChunk()->setNull(offsetInChunk, isNull);
     sizeColumnChunk->getNullChunk()->setNull(offsetInChunk, isNull);
     if (!isNull) {
         sizeColumnChunk->setValue<list_size_t>(appendSize, offsetInChunk);
-        setValue<offset_t>(listDataColumnChunk->getNumValues(), offsetInChunk);
+        offsetColumnChunk->setValue<offset_t>(listDataColumnChunk->getNumValues(), offsetInChunk);
+        syncNumValuesWithOffsetChunk();
     }
     KU_ASSERT(sanityCheck());
 }
@@ -224,23 +243,27 @@ void ListChunkData::write(ColumnChunkData* srcChunk, offset_t srcOffsetInChunk,
     KU_ASSERT(srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::LIST ||
               srcChunk->getDataType().getPhysicalType() == PhysicalTypeID::ARRAY);
     checkOffsetSortedAsc = true;
-    auto srcListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(srcChunk);
+    auto& srcListChunk = srcChunk->cast<ListChunkData>();
     auto offsetInDataChunkToAppend = listDataColumnChunk->getNumValues();
     for (auto i = 0u; i < numValuesToCopy; i++) {
-        auto appendSize = srcListChunk->getListSize(srcOffsetInChunk + i);
+        auto appendSize = srcListChunk.getListSize(srcOffsetInChunk + i);
         offsetInDataChunkToAppend += appendSize;
         sizeColumnChunk->setValue<list_size_t>(appendSize, dstOffsetInChunk + i);
-        setValue<offset_t>(offsetInDataChunkToAppend, dstOffsetInChunk + i);
+        offsetColumnChunk->setValue<offset_t>(offsetInDataChunkToAppend, dstOffsetInChunk + i);
         nullChunk->setNull(dstOffsetInChunk + i,
-            srcListChunk->nullChunk->isNull(srcOffsetInChunk + i));
+            srcListChunk.nullChunk->isNull(srcOffsetInChunk + i));
+        offsetColumnChunk->getNullChunk()->setNull(dstOffsetInChunk + i,
+            srcListChunk.nullChunk->isNull(srcOffsetInChunk + i));
         sizeColumnChunk->getNullChunk()->setNull(dstOffsetInChunk + i,
-            srcListChunk->nullChunk->isNull(srcOffsetInChunk + i));
+            srcListChunk.nullChunk->isNull(srcOffsetInChunk + i));
+
+        syncNumValuesWithOffsetChunk();
     }
     listDataColumnChunk->resize(offsetInDataChunkToAppend);
     for (auto i = 0u; i < numValuesToCopy; i++) {
-        auto startOffsetInSrcChunk = srcListChunk->getListStartOffset(srcOffsetInChunk + i);
-        auto appendSize = srcListChunk->getListSize(srcOffsetInChunk + i);
-        listDataColumnChunk->append(srcListChunk->listDataColumnChunk.get(), startOffsetInSrcChunk,
+        auto startOffsetInSrcChunk = srcListChunk.getListStartOffset(srcOffsetInChunk + i);
+        auto appendSize = srcListChunk.getListSize(srcOffsetInChunk + i);
+        listDataColumnChunk->append(srcListChunk.listDataColumnChunk.get(), startOffsetInSrcChunk,
             appendSize);
     }
     KU_ASSERT(sanityCheck());
@@ -270,16 +293,21 @@ void ListChunkData::copyListValues(const list_entry_t& entry, ValueVector* dataV
         listDataColumnChunk->append(dataVector, dataVector->state->getSelVector());
         numListValuesCopied += numListValuesToCopyInBatch;
     }
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::resetOffset() {
+    KU_ASSERT(sanityCheck());
     offset_t nextListOffsetReset = 0;
     for (auto i = 0u; i < numValues; i++) {
         auto listSize = getListSize(i);
         nextListOffsetReset += uint64_t(listSize);
-        setValue<offset_t>(nextListOffsetReset, i);
+        offsetColumnChunk->setValue<offset_t>(nextListOffsetReset, i);
         sizeColumnChunk->setValue<list_size_t>(listSize, i);
+
+        syncNumValuesWithOffsetChunk();
     }
+    KU_ASSERT(sanityCheck());
 }
 
 void ListChunkData::finalize() {
@@ -300,37 +328,40 @@ void ListChunkData::finalize() {
     if (isOffsetsConsecutiveAndSortedAscending(0, numValues)) {
         return;
     }
-    auto newListChunk = ku_dynamic_cast<ColumnChunkData*, ListChunkData*>(newColumnChunk.get());
-    newListChunk->resize(numValues);
-    newListChunk->getDataColumnChunk()->resize(totalListLen);
-    auto dataColumnChunk = newListChunk->getDataColumnChunk();
-    newListChunk->listDataColumnChunk->resize(totalListLen);
+    KU_ASSERT(sanityCheck());
+    auto& newListChunk = newColumnChunk->cast<ListChunkData>();
+    newListChunk.resize(numValues);
+    newListChunk.getDataColumnChunk()->resize(totalListLen);
+    auto dataColumnChunk = newListChunk.getDataColumnChunk();
+    newListChunk.listDataColumnChunk->resize(totalListLen);
     offset_t offsetInChunk = 0;
     offset_t currentIndex = 0;
     for (auto i = 0u; i < numValues; i++) {
         if (nullChunk->isNull(i)) {
-            newListChunk->appendNullList();
+            newListChunk.appendNullList();
         } else {
             auto startOffset = getListStartOffset(i);
             auto listSize = getListSize(i);
             dataColumnChunk->append(listDataColumnChunk.get(), startOffset, listSize);
             offsetInChunk += listSize;
-            newListChunk->getNullChunk()->setNull(currentIndex, false);
-            newListChunk->sizeColumnChunk->getNullChunk()->setNull(currentIndex, false);
-            newListChunk->sizeColumnChunk->setValue<list_size_t>(listSize, currentIndex);
-            newListChunk->setValue<offset_t>(offsetInChunk, currentIndex);
+            newListChunk.nullChunk->setNull(currentIndex, false);
+            newListChunk.sizeColumnChunk->getNullChunk()->setNull(currentIndex, false);
+            newListChunk.sizeColumnChunk->setValue<list_size_t>(listSize, currentIndex);
+            newListChunk.offsetColumnChunk->getNullChunk()->setNull(currentIndex, false);
+            newListChunk.offsetColumnChunk->setValue<offset_t>(offsetInChunk, currentIndex);
+            newListChunk.syncNumValuesWithOffsetChunk();
         }
         currentIndex++;
     }
-    KU_ASSERT(newListChunk->sanityCheck());
+    KU_ASSERT(newListChunk.sanityCheck());
     // Move offsets, null, data from newListChunk to this column chunk. And release indices.
-    resetFromOtherChunk(newListChunk);
+    resetFromOtherChunk(&newListChunk);
 }
 void ListChunkData::resetFromOtherChunk(ListChunkData* other) {
-    buffer = std::move(other->buffer);
     nullChunk = std::move(other->nullChunk);
     sizeColumnChunk = std::move(other->sizeColumnChunk);
     listDataColumnChunk = std::move(other->listDataColumnChunk);
+    offsetColumnChunk = std::move(other->offsetColumnChunk);
     numValues = other->numValues;
     checkOffsetSortedAsc = false;
 }
@@ -338,6 +369,7 @@ void ListChunkData::resetFromOtherChunk(ListChunkData* other) {
 bool ListChunkData::sanityCheck() {
     KU_ASSERT(ColumnChunkData::sanityCheck());
     KU_ASSERT(sizeColumnChunk->sanityCheck());
+    KU_ASSERT(offsetColumnChunk->sanityCheck());
     KU_ASSERT(getDataColumnChunk()->sanityCheck());
     return sizeColumnChunk->getNumValues() == numValues;
 }

--- a/src/storage/store/node_table_data.cpp
+++ b/src/storage/store/node_table_data.cpp
@@ -174,9 +174,12 @@ void NodeTableData::prepareLocalNodeGroupToCommit(node_group_idx_t nodeGroupIdx,
     Transaction* transaction, LocalNodeNG* localNodeGroup) const {
     auto numNodeGroups = getNumCommittedNodeGroups();
     const auto isNewNodeGroup = nodeGroupIdx >= numNodeGroups;
-    KU_ASSERT(std::find_if(columns.begin(), columns.end(), [&](const auto& column) {
-        return column->getNumCommittedNodeGroups() != numNodeGroups;
-    }) == columns.end());
+    for (const auto& column : columns) {
+        KU_ASSERT(column->getNumCommittedNodeGroups() == numNodeGroups);
+    }
+    // KU_ASSERT(std::find_if(columns.begin(), columns.end(), [&](const auto& column) {
+    //     return column->getNumCommittedNodeGroups() != numNodeGroups;
+    // }) == columns.end());
     for (auto columnID = 0u; columnID < columns.size(); columnID++) {
         const auto column = columns[columnID].get();
         auto localInsertChunk = localNodeGroup->getInsertChunks().getLocalChunk(columnID);

--- a/src/storage/store/node_table_data.cpp
+++ b/src/storage/store/node_table_data.cpp
@@ -174,12 +174,9 @@ void NodeTableData::prepareLocalNodeGroupToCommit(node_group_idx_t nodeGroupIdx,
     Transaction* transaction, LocalNodeNG* localNodeGroup) const {
     auto numNodeGroups = getNumCommittedNodeGroups();
     const auto isNewNodeGroup = nodeGroupIdx >= numNodeGroups;
-    for (const auto& column : columns) {
-        KU_ASSERT(column->getNumCommittedNodeGroups() == numNodeGroups);
-    }
-    // KU_ASSERT(std::find_if(columns.begin(), columns.end(), [&](const auto& column) {
-    //     return column->getNumCommittedNodeGroups() != numNodeGroups;
-    // }) == columns.end());
+    KU_ASSERT(std::find_if(columns.begin(), columns.end(), [&](const auto& column) {
+        return column->getNumCommittedNodeGroups() != numNodeGroups;
+    }) == columns.end());
     for (auto columnID = 0u; columnID < columns.size(); columnID++) {
         const auto column = columns[columnID].get();
         auto localInsertChunk = localNodeGroup->getInsertChunks().getLocalChunk(columnID);

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -68,12 +68,8 @@ void StringColumn::scan(Transaction* transaction, const ChunkState& state,
 void StringColumn::scan(Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
     KU_ASSERT(state.nullState);
-    nullColumn->scan(transaction, *state.nullState, columnChunk->getNullChunk(), startOffset,
-        endOffset);
-    const size_t numValuesToScan =
-        getNumValuesFromDisk(metadataDA.get(), transaction, state, startOffset, endOffset);
-    columnChunk->setNumValues(numValuesToScan);
-    if (numValuesToScan == 0) {
+    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
+    if (columnChunk->getNumValues() == 0) {
         return;
     }
 

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -36,15 +36,13 @@ StringColumn::StringColumn(std::string name, LogicalType dataType,
 
 Column::ChunkState& StringColumn::getChildState(ChunkState& state, ChildStateIndex child) {
     const auto childIdx = static_cast<common::idx_t>(child);
-    KU_ASSERT(state.childrenStates.size() > childIdx);
-    return state.childrenStates[childIdx];
+    return state.getChildState(childIdx);
 }
 
 const Column::ChunkState& StringColumn::getChildState(const ChunkState& state,
     ChildStateIndex child) {
     const auto childIdx = static_cast<common::idx_t>(child);
-    KU_ASSERT(state.childrenStates.size() > childIdx);
-    return state.childrenStates[childIdx];
+    return state.getChildState(childIdx);
 }
 
 void StringColumn::initChunkState(Transaction* transaction, node_group_idx_t nodeGroupIdx,

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -30,10 +30,7 @@ StructColumn::StructColumn(std::string name, LogicalType dataType,
 void StructColumn::scan(Transaction* transaction, const ChunkState& state,
     ColumnChunkData* columnChunk, offset_t startOffset, offset_t endOffset) {
     KU_ASSERT(columnChunk->getDataType().getPhysicalType() == PhysicalTypeID::STRUCT);
-    nullColumn->scan(transaction, *state.nullState, columnChunk->getNullChunk(), startOffset,
-        endOffset);
-    columnChunk->setNumValues(
-        getNumValuesFromDisk(metadataDA.get(), transaction, state, startOffset, endOffset));
+    Column::scan(transaction, state, columnChunk, startOffset, endOffset);
     auto& structColumnChunk = columnChunk->cast<StructChunkData>();
     for (auto i = 0u; i < childColumns.size(); i++) {
         childColumns[i]->scan(transaction, state.childrenStates[i], structColumnChunk.getChild(i),


### PR DESCRIPTION
# Description
Refactor list column so that the offset column is stored in a separate child column instead of as the main column, reducing the need for extra code needing to consider list columns as INT64 columns and freeing up the statistics.

Also piggybacked removal of `ListDataColumnChunk()` wrapper which didn't provide any additional functionality

Fixes #3562

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).