### PR TITLE
Avoid detach delete when node is already deleted in the same transaction

### DIFF
--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -89,7 +89,7 @@ public:
 
     void insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
     void update(transaction::Transaction* transaction, TableUpdateState& updateState) override;
-    void delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
+    bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
 
     void addColumn(transaction::Transaction* transaction, const catalog::Property& property,
         common::ValueVector* defaultValueVector) override;

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -89,7 +89,7 @@ public:
 
     void insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
     void update(transaction::Transaction* transaction, TableUpdateState& updateState) override;
-    void delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
+    bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
 
     void detachDelete(transaction::Transaction* transaction, common::RelDataDirection direction,
         common::ValueVector* srcNodeIDVector, RelDetachDeleteState* deleteState);

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -87,7 +87,7 @@ public:
 
     virtual void insert(transaction::Transaction* transaction, TableInsertState& insertState) = 0;
     virtual void update(transaction::Transaction* transaction, TableUpdateState& updateState) = 0;
-    virtual void delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) = 0;
+    virtual bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) = 0;
 
     virtual void addColumn(transaction::Transaction* transaction, const catalog::Property& property,
         common::ValueVector* defaultValueVector) = 0;

--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -110,13 +110,13 @@ bool LocalNodeNG::delete_(ValueVector* nodeIDVector, ValueVector*) {
     // Check if the node is newly inserted or in persistent storage.
     if (insertChunks.hasOffset(nodeOffset)) {
         insertChunks.remove(nodeOffset);
+        return true;
     } else {
         for (auto i = 0u; i < updateChunks.size(); i++) {
             updateChunks[i].remove(nodeOffset);
         }
-        deleteInfo.deleteOffset(nodeOffset);
+        return deleteInfo.deleteOffset(nodeOffset);
     }
-    return true;
 }
 
 LocalNodeGroup* LocalNodeTableData::getOrCreateLocalNodeGroup(ValueVector* nodeIDVector) {

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -173,13 +173,13 @@ void NodeTable::update(Transaction* transaction, TableUpdateState& updateState) 
     localTable->update(updateState);
 }
 
-void NodeTable::delete_(Transaction* transaction, TableDeleteState& deleteState) {
+bool NodeTable::delete_(Transaction* transaction, TableDeleteState& deleteState) {
     const auto& nodeDeleteState =
         ku_dynamic_cast<TableDeleteState&, NodeTableDeleteState&>(deleteState);
     KU_ASSERT(nodeDeleteState.nodeIDVector.state->getSelVector().getSelSize() == 1);
     const auto pos = nodeDeleteState.nodeIDVector.state->getSelVector()[0];
     if (nodeDeleteState.nodeIDVector.isNull(pos)) {
-        return;
+        return false;
     }
     pkIndex->delete_(&nodeDeleteState.pkVector);
     const auto nodeOffset = nodeDeleteState.nodeIDVector.readNodeOffset(pos);
@@ -187,7 +187,7 @@ void NodeTable::delete_(Transaction* transaction, TableDeleteState& deleteState)
         ->deleteNode(tableID, nodeOffset);
     const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID,
         LocalStorage::NotExistAction::CREATE);
-    localTable->delete_(deleteState);
+    return localTable->delete_(deleteState);
 }
 
 void NodeTable::addColumn(Transaction* transaction, const Property& property,

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -61,14 +61,16 @@ void RelTable::update(Transaction* transaction, TableUpdateState& updateState) {
     localTable->update(updateState);
 }
 
-void RelTable::delete_(Transaction* transaction, TableDeleteState& deleteState) {
+bool RelTable::delete_(Transaction* transaction, TableDeleteState& deleteState) {
     const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID,
         LocalStorage::NotExistAction::CREATE);
     if (localTable->delete_(deleteState)) {
         const auto relsStats =
             ku_dynamic_cast<TablesStatistics*, RelsStoreStats*>(tablesStatistics);
         relsStats->updateNumTuplesByValue(tableID, -1);
+        return true;
     }
+    return false;
 }
 
 void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction,

--- a/test/test_files/update_rel/delete_tinysnb.test
+++ b/test/test_files/update_rel/delete_tinysnb.test
@@ -119,3 +119,10 @@ new one
 -STATEMENT MATCH (a:person)-[e:marries]->(b:person) WHERE a.ID = 3 AND b.ID =10 RETURN e.note
 ---- 1
 new one
+
+-CASE DeleteDuplicateNodes
+-STATEMENT MATCH (a:person)-[e:meets|knows|marries*0..5]->(b:person) DETACH DELETE a,b;
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) RETURN COUNT(*)
+---- 1
+0


### PR DESCRIPTION
# Description

This avoids unnecessary detach deletions when node is already deleted in the same transaction. Ideally, we should batch deletions into node groups later, which should reduce redundant initialization of rel scan states further. 

Fixes # (issue)
- #3593 