### PR TITLE
Fix copy to state bug

### DIFF
--- a/src/function/export/export_csv_function.cpp
+++ b/src/function/export/export_csv_function.cpp
@@ -210,7 +210,7 @@ static void writeRows(const ExportCSVBindData& exportCSVBindData, ExportCSVLocal
             }
             auto vector = castVectors[j];
             auto pos = vector->state->isFlat() ? vector->state->getSelVector()[0] :
-                                                 vector->state->getSelVector()[i];
+                                                 inputVectors[j]->state->getSelVector()[i];
             if (vector->isNull(pos)) {
                 // write null value
                 serializer->writeBufferData(ExportCSVConstants::DEFAULT_NULL_STR);

--- a/test/test_files/copy/copy_to_csv.test
+++ b/test/test_files/copy/copy_to_csv.test
@@ -138,3 +138,8 @@ Roma|298|the movie is very interesting and funny|{rating: 1223.000000, stars: 10
 ---- error
 Binder exception: Only copy to csv can have options.
 
+-STATEMENT COPY (load from "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv"(header=true) where id = 2 return id, fname, Gender, workedHours) to "${DATABASE_PATH}/copy_to_with_filter.csv"
+---- ok
+-STATEMENT LOAD FROM "${DATABASE_PATH}/copy_to_with_filter.csv" RETURN *;
+---- 1
+2|Bob|2|[12,8]


### PR DESCRIPTION
# Description

This PR fixes the copy to with filter bug. We used to get the wrong selected position when executing copy to.

Fixes #3597 