### PR TITLE
Change default escape character from \ to "

### DIFF
--- a/dataset/csv-edge-case-tests/copy.cypher
+++ b/dataset/csv-edge-case-tests/copy.cypher
@@ -9,7 +9,7 @@ COPY `empty-lines-single-column` FROM "dataset/csv-edge-case-tests/empty-lines-s
 COPY `empty` FROM "dataset/csv-edge-case-tests/empty.csv";
 COPY `empty-with-header` FROM "dataset/csv-edge-case-tests/empty.csv" (HEADER=TRUE);
 COPY `eof-after-unquote` FROM "dataset/csv-edge-case-tests/eof-after-unquote.csv";
-COPY `escapes-in-quote` FROM "dataset/csv-edge-case-tests/escapes-in-quote.csv";
+COPY `escapes-in-quote` FROM "dataset/csv-edge-case-tests/escapes-in-quote.csv"(escape='\\');
 COPY `escapes-out-of-quote` FROM "dataset/csv-edge-case-tests/escapes-out-of-quote.csv";
 COPY `mixed-empty-lines-multiple-columns` FROM "dataset/csv-edge-case-tests/mixed-empty-lines-multiple-columns.csv";
 COPY `mixed-empty-lines-single-column` FROM "dataset/csv-edge-case-tests/mixed-empty-lines-single-column.csv";

--- a/dataset/load-from-test/escape-char/double_quote_escape_char.csv
+++ b/dataset/load-from-test/escape-char/double_quote_escape_char.csv
@@ -1,0 +1,3 @@
+id,test
+1,"Some sample text."
+2,"Some more sample ""text""."

--- a/dataset/tinysnb/copy.cypher
+++ b/dataset/tinysnb/copy.cypher
@@ -1,10 +1,10 @@
 COPY person FROM "dataset/tinysnb/vPerson.csv" (HeaDER=true, deLim=',');
 COPY person FROM "dataset/tinysnb/vPerson2.csv" (deLim=',');
-COPY organisation FROM "dataset/tinysnb/vOrganisation.csv";
-COPY movies FROM "dataset/tinysnb/vMovies.csv";
+COPY organisation FROM "dataset/tinysnb/vOrganisation.csv" (escape='\\');
+COPY movies FROM "dataset/tinysnb/vMovies.csv"(escape='\\');
 COPY knows FROM "dataset/tinysnb/eKnows.csv";
 COPY knows FROM "dataset/tinysnb/eKnows_2.csv";
 COPY studyAt FROM "dataset/tinysnb/eStudyAt.csv" (HeaDER=true);
 COPY workAt FROM "dataset/tinysnb/eWorkAt.csv";
-COPY meets FROM "dataset/tinysnb/eMeets.csv";
+COPY meets FROM "dataset/tinysnb/eMeets.csv"(escape='\\');
 COPY marries FROM "dataset/tinysnb/eMarries.csv";

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -135,7 +135,7 @@ struct CopyConstants {
 
     // Default configuration for csv file parsing
     static constexpr const char* STRING_CSV_PARSING_OPTIONS[] = {"ESCAPE", "DELIM", "QUOTE"};
-    static constexpr char DEFAULT_CSV_ESCAPE_CHAR = '\\';
+    static constexpr char DEFAULT_CSV_ESCAPE_CHAR = '"';
     static constexpr char DEFAULT_CSV_DELIMITER = ',';
     static constexpr char DEFAULT_CSV_QUOTE_CHAR = '"';
     static constexpr char DEFAULT_CSV_LIST_BEGIN_CHAR = '[';

--- a/test/test_files/csv/errors.test
+++ b/test/test_files/csv/errors.test
@@ -3,7 +3,7 @@
 --
 
 -CASE Errors
--STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/escape-then-eof.csv" RETURN COUNT(*);
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/escape-then-eof.csv"(escape='\\') RETURN COUNT(*);
 ---- error
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/escape-then-eof.csv on line 2: escape at end of file.
 
@@ -11,7 +11,7 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/esc
 ---- error
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/quote-then-eof.csv on line 2: unterminated quotes.
 
--STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/escape-then-bad-char.csv" RETURN COUNT(*);
+-STATEMENT LOAD FROM "${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/escape-then-bad-char.csv"(escape='\\') RETURN COUNT(*);
 ---- error
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/csv-error-tests/escape-then-bad-char.csv on line 2: neither QUOTE nor ESCAPE is proceeded by ESCAPE.
 

--- a/test/test_files/tinysnb/cast/cast_error.test
+++ b/test/test_files/tinysnb/cast/cast_error.test
@@ -631,7 +631,7 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT8, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing2.csv" RETURN *;
 ---- error
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing2.csv on line 1: Conversion exception: Cast failed. { is not in MAP(UINT8, UINT8) range.
- -STATEMENT LOAD WITH HEADERS (a MAP(STRING, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_quote.csv" RETURN *;
+ -STATEMENT LOAD WITH HEADERS (a MAP(STRING, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_quote.csv"(escape='\\') RETURN *;
 ---- error
 Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_quote.csv on line 1: Conversion exception: Cast failed. {324="} is not in MAP(STRING, UINT8) range.
 -STATEMENT LOAD WITH HEADERS (a MAP(UINT8, UINT8)) FROM "${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/map/map_no_closing3.csv" RETURN *;

--- a/test/test_files/tinysnb/load_from/load_from.test
+++ b/test/test_files/tinysnb/load_from/load_from.test
@@ -144,3 +144,7 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv
 1972-07-31 13:22:30.342312|1972-07-31 13:22:30.342|1972-07-31 13:22:30|1972-07-31 13:22:30.342312+00|1972-07-31 13:22:30.342312|1972-07-31 13:22:30.342|1972-07-31 13:22:30|1972-07-31 13:22:30.342312+00
 |||||||
 1972-07-31 13:22:30|1972-07-31 13:22:30|1972-07-31 13:22:30|1972-07-31 13:22:30+00|1972-07-31 13:22:30|1972-07-31 13:22:30|1972-07-31 13:22:30|1972-07-31 13:22:30+00
+-STATEMENT LOAD FROM '${KUZU_ROOT_DIRECTORY}/dataset/load-from-test/escape-char/double_quote_escape_char.csv' (header=true) RETURN *
+---- 2
+1|Some sample text.
+2|Some more sample "text".


### PR DESCRIPTION
# Description

This PR changes the default escape character from `\` to `"` which follows the csv standard.

Fixes #3612