### PR TITLE
Make canUpdateInPlace operate on multiple values at once

### DIFF
--- a/src/include/storage/store/column_chunk.h
+++ b/src/include/storage/store/column_chunk.h
@@ -59,6 +59,7 @@ public:
 
     NullChunkData* getNullChunk() { return nullChunk.get(); }
     const NullChunkData& getNullChunk() const { return *nullChunk; }
+    std::optional<common::NullMask> getNullMask() const;
     common::LogicalType& getDataType() { return dataType; }
     const common::LogicalType& getDataType() const { return dataType; }
 

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -675,5 +675,9 @@ std::unique_ptr<ColumnChunkData> ColumnChunkFactory::createColumnChunkData(Logic
     }
 }
 
+std::optional<common::NullMask> ColumnChunkData::getNullMask() const {
+    return nullChunk ? std::optional(nullChunk->getNullMask()) : std::nullopt;
+}
+
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -220,7 +220,7 @@ bool DictionaryColumn::canOffsetCommitInPlace(const Column::ChunkState& offsetSt
         return true;
     }
     if (!offsetState.metadata.compMeta.canUpdateInPlace(
-            (const uint8_t*)&totalStringOffsetsAfterUpdate, 0,
+            (const uint8_t*)&totalStringOffsetsAfterUpdate, 0 /*offset*/, 1 /*numValues*/,
             offsetColumn->getDataType().getPhysicalType())) {
         return false;
     }

--- a/src/storage/store/string_column.cpp
+++ b/src/storage/store/string_column.cpp
@@ -273,7 +273,7 @@ bool StringColumn::canIndexCommitInPlace(const ChunkState& state, uint64_t numSt
         getChildState(state, ChildStateIndex::OFFSET).metadata.numValues + numStrings;
     // Check if the index column can store the largest new index in-place
     if (!indexState.metadata.compMeta.canUpdateInPlace((const uint8_t*)&totalStringsAfterUpdate,
-            0 /*pos*/, PhysicalTypeID::UINT32)) {
+            0 /*pos*/, 1 /*numValues*/, PhysicalTypeID::UINT32)) {
         return false;
     }
     return true;


### PR DESCRIPTION
Originally all checks were single value, but there's now one place where we can take advantage of processing multiple values at once. I also noticed that in that situation null values weren't being handled correctly, which could lead to unnecessary out of place updates.