### PR TITLE
Add compile flag to reduce size of static library on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,8 @@ if(MSVC)
     add_compile_options("/utf-8")
     # Enables support for custom hardware exception handling
     add_compile_options("/EHa")
+    # Reduces the size of the static library by roughly 1/2
+    add_compile_options("/Zc:inline")
     # Remove the default to avoid warnings
     STRING(REPLACE "/EHsc" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
     STRING(REPLACE "/EHs" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")


### PR DESCRIPTION
See #2520. This doesn't really fix the issue, but it reduced the size from 583MB to 315MB when I compared release builds with it enabled/disabled (evidently the static library size has gone up since that issue was opened). The static library size on Linux, for reference, is currently about 43MB, so it still seems unnecessarily large.

According to the [docs](https://learn.microsoft.com/en-us/cpp/build/reference/zc-inline-remove-unreferenced-comdat?view=msvc-170) this is disabled by default for command line builds, but enabled by default in visual studio. There don't appear to be any downsides of enabling it (it forces you to define functions inline when they are marked as inline, but we should do that anyway).