### PR TITLE
Algorithm return node properties

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -56,7 +56,7 @@ QueryGraph Binder::bindPatternElement(const PatternElement& patternElement) {
     if (patternElement.hasPathName()) {
         auto pathName = patternElement.getPathName();
         auto pathExpression = createPath(pathName, nodeAndRels);
-        scope.addExpression(pathName, pathExpression);
+        addToScope(pathName, pathExpression);
     }
     return queryGraph;
 }
@@ -232,7 +232,7 @@ std::shared_ptr<RelExpression> Binder::bindQueryRel(const RelPattern& relPattern
     }
     queryRel->setAlias(parsedName);
     if (!parsedName.empty()) {
-        scope.addExpression(parsedName, queryRel);
+        addToScope(parsedName, queryRel);
     }
     queryGraph.addQueryRel(queryRel);
     return queryRel;
@@ -352,7 +352,7 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
     // Bind intermediate node.
     auto node = createQueryNode(recursivePatternInfo->nodeName,
         std::vector<table_id_t>{nodeTableIDs.begin(), nodeTableIDs.end()});
-    scope.addExpression(node->toString(), node);
+    addToScope(node->toString(), node);
     std::vector<StructField> nodeFields;
     nodeFields.emplace_back(InternalKeyword::ID, node->getInternalID()->getDataType().copy());
     nodeFields.emplace_back(InternalKeyword::LABEL,
@@ -375,7 +375,7 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
     // Bind intermediate rel
     auto rel = createNonRecursiveQueryRel(recursivePatternInfo->relName, tableIDs, nullptr, nullptr,
         directionType);
-    scope.addExpression(rel->toString(), rel);
+    addToScope(rel->toString(), rel);
     expression_vector relProjectionList;
     if (!recursivePatternInfo->hasProjection) {
         for (auto& expression : rel->getPropertyExprsRef()) {
@@ -532,7 +532,7 @@ std::shared_ptr<NodeExpression> Binder::bindQueryNode(const NodePattern& nodePat
     } else {
         queryNode = createQueryNode(nodePattern);
         if (!parsedName.empty()) {
-            scope.addExpression(parsedName, queryNode);
+            addToScope(parsedName, queryNode);
         }
     }
     for (auto& [propertyName, rhs] : nodePattern.getPropertyKeyVals()) {

--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -260,7 +260,7 @@ void Binder::addExpressionsToScope(const expression_vector& projectionExpression
     for (auto& expression : projectionExpressions) {
         // In RETURN clause, if expression is not aliased, its input name will serve its alias.
         auto alias = expression->hasAlias() ? expression->getAlias() : expression->toString();
-        scope.addExpression(alias, expression);
+        addToScope(alias, expression);
     }
 }
 

--- a/src/binder/bind/read/bind_in_query_call.cpp
+++ b/src/binder/bind/read/bind_in_query_call.cpp
@@ -90,7 +90,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindInQueryCall(const ReadingClause&
         }
         auto func = BuiltInFunctionsUtils::matchFunction(functionName, childrenTypes, entry);
         auto gdsFunc = *func->constPtrCast<GDSFunction>();
-        gdsFunc.gds->bind(children);
+        gdsFunc.gds->bind(children, this, graphEntry);
         outExprs = gdsFunc.gds->getResultColumns(this);
         auto info = BoundGDSCallInfo(gdsFunc.copy(), graphEntry.copy(), std::move(outExprs));
         boundReadingClause = std::make_unique<BoundGDSCall>(std::move(info));

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -125,7 +125,7 @@ std::shared_ptr<Expression> Binder::createVariable(const std::string& name,
     }
     auto expression = expressionBinder.createVariableExpression(dataType, name);
     expression->setAlias(name);
-    scope.addExpression(name, expression);
+    addToScope(name, expression);
     return expression;
 }
 
@@ -184,6 +184,11 @@ bool Binder::isReservedPropertyName(const std::string& name) {
         return true;
     }
     return false;
+}
+
+void Binder::addToScope(const std::string& name, std::shared_ptr<Expression> expr) {
+    // TODO(Xiyang): assert name not in scope.
+    scope.addExpression(name, std::move(expr));
 }
 
 BinderScope Binder::saveScope() {

--- a/src/binder/expression/expression_util.cpp
+++ b/src/binder/expression/expression_util.cpp
@@ -194,6 +194,19 @@ void ExpressionUtil::validateDataType(const Expression& expr,
         expr.getDataType().toString(), LogicalTypeUtils::toString(expectedTypeIDs)));
 }
 
+template<>
+int64_t ExpressionUtil::getLiteralValue(const Expression& expr) {
+    validateExpressionType(expr, ExpressionType::LITERAL);
+    validateDataType(expr, *LogicalType::INT64());
+    return expr.constCast<LiteralExpression>().getValue().getValue<int64_t>();
+}
+template<>
+bool ExpressionUtil::getLiteralValue(const Expression& expr) {
+    validateExpressionType(expr, ExpressionType::LITERAL);
+    validateDataType(expr, *LogicalType::BOOL());
+    return expr.constCast<LiteralExpression>().getValue().getValue<bool>();
+}
+
 // For primitive types, two types are compatible if they have the same id.
 // For nested types, two types are compatible if they have the same id and their children are also
 // compatible.

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -4,13 +4,22 @@
 #include "processor/operator/gds_call.h"
 
 using namespace kuzu::binder;
+using namespace kuzu::main;
+using namespace kuzu::graph;
+using namespace kuzu::processor;
 
 namespace kuzu {
 namespace function {
 
-void GDSAlgorithm::init(processor::GDSCallSharedState* sharedState_, main::ClientContext* context) {
+void GDSAlgorithm::init(GDSCallSharedState* sharedState_, ClientContext* context) {
     sharedState = sharedState_;
     initLocalState(context);
+}
+
+std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(Binder* binder, GraphEntry& graphEntry) {
+    auto node = binder->createQueryNode(NODE_COLUMN_NAME, graphEntry.nodeTableIDs);
+    binder->addToScope(NODE_COLUMN_NAME, node);
+    return node;
 }
 
 } // namespace function

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -26,7 +26,8 @@ struct PageRankBindData final : public GDSBindData {
     PageRankBindData(std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode)
         : GDSBindData{std::move(nodeOutput), outputAsNode} {};
     PageRankBindData(const PageRankBindData& other)
-        : GDSBindData{other}, dampingFactor{other.dampingFactor}, maxIteration{other.maxIteration}, delta{other.delta} {}
+        : GDSBindData{other}, dampingFactor{other.dampingFactor}, maxIteration{other.maxIteration},
+          delta{other.delta} {}
 
     std::unique_ptr<GDSBindData> copy() const override {
         return std::make_unique<PageRankBindData>(*this);

--- a/src/function/gds/page_rank.cpp
+++ b/src/function/gds/page_rank.cpp
@@ -1,4 +1,5 @@
 #include "binder/binder.h"
+#include "binder/expression/expression_util.h"
 #include "common/types/internal_id_util.h"
 #include "function/gds/gds.h"
 #include "function/gds/gds_function_collection.h"
@@ -12,6 +13,7 @@ using namespace kuzu::processor;
 using namespace kuzu::common;
 using namespace kuzu::binder;
 using namespace kuzu::storage;
+using namespace kuzu::graph;
 
 namespace kuzu {
 namespace function {
@@ -21,10 +23,13 @@ struct PageRankBindData final : public GDSBindData {
     int64_t maxIteration = 10;
     double delta = 0.0001; // detect convergence
 
-    PageRankBindData() = default;
+    PageRankBindData(std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode)
+        : GDSBindData{std::move(nodeOutput), outputAsNode} {};
+    PageRankBindData(const PageRankBindData& other)
+        : GDSBindData{other}, dampingFactor{other.dampingFactor}, maxIteration{other.maxIteration}, delta{other.delta} {}
 
     std::unique_ptr<GDSBindData> copy() const override {
-        return std::make_unique<PageRankBindData>();
+        return std::make_unique<PageRankBindData>(*this);
     }
 };
 
@@ -59,6 +64,8 @@ private:
 };
 
 class PageRank final : public GDSAlgorithm {
+    static constexpr char RANK_COLUMN_NAME[] = "rank";
+
 public:
     PageRank() = default;
     PageRank(const PageRank& other) : GDSAlgorithm{other} {}
@@ -67,9 +74,10 @@ public:
      * Inputs are
      *
      * graph::ANY
+     * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
-        return {LogicalTypeID::ANY};
+        return {LogicalTypeID::ANY, LogicalTypeID::BOOL};
     }
 
     /*
@@ -80,13 +88,16 @@ public:
      */
     binder::expression_vector getResultColumns(binder::Binder* binder) const override {
         expression_vector columns;
-        columns.push_back(binder->createVariable("node_id", *LogicalType::INTERNAL_ID()));
-        columns.push_back(binder->createVariable("rank", *LogicalType::DOUBLE()));
+        auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
+        columns.push_back(outputNode.getInternalID());
+        columns.push_back(binder->createVariable(RANK_COLUMN_NAME, *LogicalType::DOUBLE()));
         return columns;
     }
 
-    void bind(const binder::expression_vector&) override {
-        bindData = std::make_unique<PageRankBindData>();
+    void bind(const expression_vector& params, Binder* binder, GraphEntry& graphEntry) override {
+        auto nodeOutput = bindNodeOutput(binder, graphEntry);
+        auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[1]);
+        bindData = std::make_unique<PageRankBindData>(nodeOutput, outputProperty);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/function/gds/shortest_paths.cpp
+++ b/src/function/gds/shortest_paths.cpp
@@ -19,8 +19,10 @@ struct ShortestPathBindData final : public GDSBindData {
     std::shared_ptr<Expression> nodeInput;
     uint8_t upperBound;
 
-    ShortestPathBindData(std::shared_ptr<Expression> nodeInput, std::shared_ptr<Expression> nodeOutput, bool outputAsNode, uint8_t upperBound)
-        : GDSBindData{std::move(nodeOutput), outputAsNode}, nodeInput{std::move(nodeInput)}, upperBound{upperBound} {}
+    ShortestPathBindData(std::shared_ptr<Expression> nodeInput,
+        std::shared_ptr<Expression> nodeOutput, bool outputAsNode, uint8_t upperBound)
+        : GDSBindData{std::move(nodeOutput), outputAsNode}, nodeInput{std::move(nodeInput)},
+          upperBound{upperBound} {}
     ShortestPathBindData(const ShortestPathBindData& other)
         : GDSBindData{other}, nodeInput{other.nodeInput}, upperBound{other.upperBound} {}
 
@@ -135,7 +137,8 @@ public:
         auto nodeOutput = bindNodeOutput(binder, graphEntry);
         auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
         auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[3]);
-        bindData = std::make_unique<ShortestPathBindData>(nodeInput, nodeOutput, outputProperty, upperBound);
+        bindData = std::make_unique<ShortestPathBindData>(nodeInput, nodeOutput, outputProperty,
+            upperBound);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/function/gds/shortest_paths.cpp
+++ b/src/function/gds/shortest_paths.cpp
@@ -1,6 +1,5 @@
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
-#include "binder/expression/literal_expression.h"
 #include "function/gds/frontier.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds_function.h"
@@ -11,6 +10,7 @@ using namespace kuzu::processor;
 using namespace kuzu::common;
 using namespace kuzu::binder;
 using namespace kuzu::storage;
+using namespace kuzu::graph;
 
 namespace kuzu {
 namespace function {
@@ -19,10 +19,10 @@ struct ShortestPathBindData final : public GDSBindData {
     std::shared_ptr<Expression> nodeInput;
     uint8_t upperBound;
 
-    ShortestPathBindData(std::shared_ptr<Expression> nodeInput, uint8_t upperBound)
-        : nodeInput{std::move(nodeInput)}, upperBound{upperBound} {}
+    ShortestPathBindData(std::shared_ptr<Expression> nodeInput, std::shared_ptr<Expression> nodeOutput, bool outputAsNode, uint8_t upperBound)
+        : GDSBindData{std::move(nodeOutput), outputAsNode}, nodeInput{std::move(nodeInput)}, upperBound{upperBound} {}
     ShortestPathBindData(const ShortestPathBindData& other)
-        : nodeInput{other.nodeInput}, upperBound{other.upperBound} {}
+        : GDSBindData{other}, nodeInput{other.nodeInput}, upperBound{other.upperBound} {}
 
     bool hasNodeInput() const override { return true; }
     std::shared_ptr<binder::Expression> getNodeInput() const override { return nodeInput; }
@@ -94,6 +94,8 @@ private:
 };
 
 class ShortestPath final : public GDSAlgorithm {
+    static constexpr char LENGTH_COLUMN_NAME[] = "length";
+
 public:
     ShortestPath() = default;
     ShortestPath(const ShortestPath& other) : GDSAlgorithm{other} {}
@@ -104,33 +106,36 @@ public:
      * graph::ANY
      * srcNode::NODE
      * upperBound::INT64
+     * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
-        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64};
+        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64, LogicalTypeID::BOOL};
     }
 
     /*
      * Outputs are
      *
      * srcNode._id::INTERNAL_ID
-     * dst::INTERNAL_ID
+     * _node._id::INTERNAL_ID (destination)
      * length::INT64
      */
     binder::expression_vector getResultColumns(binder::Binder* binder) const override {
         expression_vector columns;
-        columns.push_back(bindData->getNodeInput()->constCast<NodeExpression>().getInternalID());
-        columns.push_back(binder->createVariable("dst", *LogicalType::INTERNAL_ID()));
-        columns.push_back(binder->createVariable("length", *LogicalType::INT64()));
+        auto& inputNode = bindData->getNodeInput()->constCast<NodeExpression>();
+        columns.push_back(inputNode.getInternalID());
+        auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
+        columns.push_back(outputNode.getInternalID());
+        columns.push_back(binder->createVariable(LENGTH_COLUMN_NAME, *LogicalType::INT64()));
         return columns;
     }
 
-    void bind(const binder::expression_vector& params) override {
-        KU_ASSERT(params.size() == 3);
-        auto inputNode = params[1];
-        ExpressionUtil::validateExpressionType(*params[2], ExpressionType::LITERAL);
-        ExpressionUtil::validateDataType(*params[2], *LogicalType::INT64());
-        auto upperBound = params[2]->constCast<LiteralExpression>().getValue().getValue<int64_t>();
-        bindData = std::make_unique<ShortestPathBindData>(inputNode, upperBound);
+    void bind(const expression_vector& params, Binder* binder, GraphEntry& graphEntry) override {
+        KU_ASSERT(params.size() == 4);
+        auto nodeInput = params[1];
+        auto nodeOutput = bindNodeOutput(binder, graphEntry);
+        auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
+        auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[3]);
+        bindData = std::make_unique<ShortestPathBindData>(nodeInput, nodeOutput, outputProperty, upperBound);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/function/gds/variable_length_paths.cpp
+++ b/src/function/gds/variable_length_paths.cpp
@@ -1,6 +1,5 @@
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
-#include "binder/expression/literal_expression.h"
 #include "common/exception/binder.h"
 #include "function/gds/frontier.h"
 #include "function/gds/gds_function_collection.h"
@@ -14,6 +13,7 @@ using namespace kuzu::processor;
 using namespace kuzu::common;
 using namespace kuzu::binder;
 using namespace kuzu::storage;
+using namespace kuzu::graph;
 
 namespace kuzu {
 namespace function {
@@ -23,15 +23,15 @@ struct VariableLengthPathBindData final : public GDSBindData {
     uint8_t lowerBound;
     uint8_t upperBound;
 
-    VariableLengthPathBindData(std::shared_ptr<Expression> nodeInput, uint8_t lowerBound,
-        uint8_t upperBound)
-        : nodeInput{std::move(nodeInput)}, lowerBound{lowerBound}, upperBound{upperBound} {}
+    VariableLengthPathBindData(std::shared_ptr<Expression> nodeInput,
+        std::shared_ptr<Expression> nodeOutput, bool outputAsNode, uint8_t lowerBound, uint8_t upperBound)
+        : GDSBindData{std::move(nodeOutput), outputAsNode}, nodeInput{std::move(nodeInput)}, lowerBound{lowerBound}, upperBound{upperBound} {}
 
     VariableLengthPathBindData(const VariableLengthPathBindData& other)
-        : nodeInput{other.nodeInput}, lowerBound{other.lowerBound}, upperBound{other.upperBound} {}
+        : GDSBindData{other}, nodeInput{other.nodeInput}, lowerBound{other.lowerBound}, upperBound{other.upperBound} {}
 
     bool hasNodeInput() const override { return true; }
-    std::shared_ptr<binder::Expression> getNodeInput() const override { return nodeInput; }
+    std::shared_ptr<Expression> getNodeInput() const override { return nodeInput; }
 
     std::unique_ptr<GDSBindData> copy() const override {
         return std::make_unique<VariableLengthPathBindData>(*this);
@@ -94,6 +94,9 @@ private:
 };
 
 class VariableLengthPaths final : public GDSAlgorithm {
+    static constexpr char LENGTH_COLUMN_NAME[] = "length";
+    static constexpr char NUM_PATH_COLUMN_NAME[] = "num_path";
+
 public:
     VariableLengthPaths() = default;
     VariableLengthPaths(const VariableLengthPaths& other) : GDSAlgorithm{other} {}
@@ -105,17 +108,18 @@ public:
      * srcNode::NODE
      * lowerBound::INT64
      * upperBound::INT64
+     * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
         return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64,
-            LogicalTypeID::INT64};
+            LogicalTypeID::INT64, LogicalTypeID::BOOL};
     }
 
     /*
      * Outputs are
      *
      * srcNode._id::INTERNAL_ID
-     * dst::INTERNAL_ID
+     * _node._id::INTERNAL_ID (destination)
      * length::INT64
      * num_path::INT64
      */
@@ -123,24 +127,24 @@ public:
         expression_vector columns;
         auto& inputNode = bindData->getNodeInput()->constCast<NodeExpression>();
         columns.push_back(inputNode.getInternalID());
-        columns.push_back(binder->createVariable("dst", *LogicalType::INTERNAL_ID()));
-        columns.push_back(binder->createVariable("length", *LogicalType::INT64()));
-        columns.push_back(binder->createVariable("num_path", *LogicalType::INT64()));
+        auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
+        columns.push_back(outputNode.getInternalID());
+        columns.push_back(binder->createVariable(LENGTH_COLUMN_NAME, *LogicalType::INT64()));
+        columns.push_back(binder->createVariable(NUM_PATH_COLUMN_NAME, *LogicalType::INT64()));
         return columns;
     }
 
-    void bind(const binder::expression_vector& params) override {
-        KU_ASSERT(params.size() == 4);
-        for (auto i = 2u; i < 4u; ++i) {
-            ExpressionUtil::validateExpressionType(*params[i], ExpressionType::LITERAL);
-            ExpressionUtil::validateDataType(*params[i], *LogicalType::INT64());
-        }
-        auto lowerBound = params[2]->constCast<LiteralExpression>().getValue().getValue<int64_t>();
+    void bind(const expression_vector& params, Binder* binder, GraphEntry& graphEntry) override {
+        KU_ASSERT(params.size() == 5);
+        auto nodeInput = params[1];
+        auto nodeOutput = bindNodeOutput(binder, graphEntry);
+        auto lowerBound = ExpressionUtil::getLiteralValue<int64_t>(*params[2]);
         if (lowerBound <= 0) {
             throw BinderException("Lower bound must be greater than 0.");
         }
-        auto upperBound = params[3]->constCast<LiteralExpression>().getValue().getValue<int64_t>();
-        bindData = std::make_unique<VariableLengthPathBindData>(params[1], lowerBound, upperBound);
+        auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[3]);
+        auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[4]);
+        bindData = std::make_unique<VariableLengthPathBindData>(nodeInput, nodeOutput, outputProperty, lowerBound, upperBound);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/function/gds/variable_length_paths.cpp
+++ b/src/function/gds/variable_length_paths.cpp
@@ -24,11 +24,14 @@ struct VariableLengthPathBindData final : public GDSBindData {
     uint8_t upperBound;
 
     VariableLengthPathBindData(std::shared_ptr<Expression> nodeInput,
-        std::shared_ptr<Expression> nodeOutput, bool outputAsNode, uint8_t lowerBound, uint8_t upperBound)
-        : GDSBindData{std::move(nodeOutput), outputAsNode}, nodeInput{std::move(nodeInput)}, lowerBound{lowerBound}, upperBound{upperBound} {}
+        std::shared_ptr<Expression> nodeOutput, bool outputAsNode, uint8_t lowerBound,
+        uint8_t upperBound)
+        : GDSBindData{std::move(nodeOutput), outputAsNode}, nodeInput{std::move(nodeInput)},
+          lowerBound{lowerBound}, upperBound{upperBound} {}
 
     VariableLengthPathBindData(const VariableLengthPathBindData& other)
-        : GDSBindData{other}, nodeInput{other.nodeInput}, lowerBound{other.lowerBound}, upperBound{other.upperBound} {}
+        : GDSBindData{other}, nodeInput{other.nodeInput}, lowerBound{other.lowerBound},
+          upperBound{other.upperBound} {}
 
     bool hasNodeInput() const override { return true; }
     std::shared_ptr<Expression> getNodeInput() const override { return nodeInput; }
@@ -111,8 +114,8 @@ public:
      * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
-        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64,
-            LogicalTypeID::INT64, LogicalTypeID::BOOL};
+        return {LogicalTypeID::ANY, LogicalTypeID::NODE, LogicalTypeID::INT64, LogicalTypeID::INT64,
+            LogicalTypeID::BOOL};
     }
 
     /*
@@ -144,7 +147,8 @@ public:
         }
         auto upperBound = ExpressionUtil::getLiteralValue<int64_t>(*params[3]);
         auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[4]);
-        bindData = std::make_unique<VariableLengthPathBindData>(nodeInput, nodeOutput, outputProperty, lowerBound, upperBound);
+        bindData = std::make_unique<VariableLengthPathBindData>(nodeInput, nodeOutput,
+            outputProperty, lowerBound, upperBound);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -78,7 +78,7 @@ public:
         return columns;
     }
 
-    void bind(const expression_vector &params, Binder *binder, GraphEntry &graphEntry) override {
+    void bind(const expression_vector& params, Binder* binder, GraphEntry& graphEntry) override {
         auto nodeOutput = bindNodeOutput(binder, graphEntry);
         auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[1]);
         bindData = std::make_unique<GDSBindData>(nodeOutput, outputProperty);

--- a/src/function/gds/weakly_connected_components.cpp
+++ b/src/function/gds/weakly_connected_components.cpp
@@ -1,4 +1,5 @@
 #include "binder/binder.h"
+#include "binder/expression/expression_util.h"
 #include "common/types/internal_id_util.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds_function.h"
@@ -11,6 +12,7 @@ using namespace kuzu::binder;
 using namespace kuzu::common;
 using namespace kuzu::processor;
 using namespace kuzu::storage;
+using namespace kuzu::graph;
 
 namespace kuzu {
 namespace function {
@@ -46,6 +48,8 @@ private:
 };
 
 class WeaklyConnectedComponent final : public GDSAlgorithm {
+    static constexpr char GROUP_ID_COLUMN_NAME[] = "group_id";
+
 public:
     WeaklyConnectedComponent() = default;
     WeaklyConnectedComponent(const WeaklyConnectedComponent& other) : GDSAlgorithm{other} {}
@@ -54,22 +58,30 @@ public:
      * Inputs are
      *
      * graph::ANY
+     * outputProperty::BOOL
      */
     std::vector<common::LogicalTypeID> getParameterTypeIDs() const override {
-        return std::vector<LogicalTypeID>{LogicalTypeID::ANY};
+        return std::vector<LogicalTypeID>{LogicalTypeID::ANY, LogicalTypeID::BOOL};
     }
 
     /*
      * Outputs are
      *
-     * node_id::INTERNAL_ID
+     * _node._id::INTERNAL_ID
      * group_id::INT64
      */
     binder::expression_vector getResultColumns(binder::Binder* binder) const override {
         expression_vector columns;
-        columns.push_back(binder->createVariable("node_id", *LogicalType::INTERNAL_ID()));
-        columns.push_back(binder->createVariable("group_id", *LogicalType::INT64()));
+        auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
+        columns.push_back(outputNode.getInternalID());
+        columns.push_back(binder->createVariable(GROUP_ID_COLUMN_NAME, *LogicalType::INT64()));
         return columns;
+    }
+
+    void bind(const expression_vector &params, Binder *binder, GraphEntry &graphEntry) override {
+        auto nodeOutput = bindNodeOutput(binder, graphEntry);
+        auto outputProperty = ExpressionUtil::getLiteralValue<bool>(*params[1]);
+        bindData = std::make_unique<GDSBindData>(nodeOutput, outputProperty);
     }
 
     void initLocalState(main::ClientContext* context) override {

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -82,7 +82,6 @@ public:
     std::shared_ptr<Expression> createVariable(const std::string& name,
         const common::LogicalType& dataType);
 
-private:
     std::shared_ptr<Expression> bindWhereExpression(
         const parser::ParsedExpression& parsedExpression);
 
@@ -272,6 +271,7 @@ private:
     std::string getUniqueExpressionName(const std::string& name);
     static bool isReservedPropertyName(const std::string& name);
 
+    void addToScope(const std::string& name, std::shared_ptr<Expression> expr);
     BinderScope saveScope();
     void restoreScope(BinderScope prevScope);
 

--- a/src/include/binder/expression/expression_util.h
+++ b/src/include/binder/expression/expression_util.h
@@ -44,6 +44,8 @@ struct ExpressionUtil {
     static void validateDataType(const Expression& expr, common::LogicalTypeID expectedTypeID);
     static void validateDataType(const Expression& expr,
         const std::vector<common::LogicalTypeID>& expectedTypeIDs);
+    template<typename T>
+    static T getLiteralValue(const Expression& expr);
 
     static bool tryCombineDataType(const expression_vector& expressions,
         common::LogicalType& result);

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -23,9 +23,10 @@ struct GDSBindData {
     // Otherwise, we return node ID only.
     bool outputAsNode;
 
-    explicit GDSBindData(std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode) :
-          nodeOutput{std::move(nodeOutput)}, outputAsNode{outputAsNode} {}
-    GDSBindData(const GDSBindData& other) : nodeOutput{other.nodeOutput}, outputAsNode{other.outputAsNode} {}
+    explicit GDSBindData(std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode)
+        : nodeOutput{std::move(nodeOutput)}, outputAsNode{outputAsNode} {}
+    GDSBindData(const GDSBindData& other)
+        : nodeOutput{other.nodeOutput}, outputAsNode{other.outputAsNode} {}
     virtual ~GDSBindData() = default;
 
     virtual bool hasNodeInput() const { return false; }
@@ -71,7 +72,8 @@ public:
     virtual std::vector<common::LogicalTypeID> getParameterTypeIDs() const { return {}; }
     virtual binder::expression_vector getResultColumns(binder::Binder* binder) const = 0;
 
-    virtual void bind(const binder::expression_vector& params, binder::Binder* binder, graph::GraphEntry& graphEntry) = 0;
+    virtual void bind(const binder::expression_vector& params, binder::Binder* binder,
+        graph::GraphEntry& graphEntry) = 0;
     GDSBindData* getBindData() const { return bindData.get(); }
 
     void init(processor::GDSCallSharedState* sharedState, main::ClientContext* context);
@@ -85,7 +87,8 @@ public:
 
 protected:
     virtual void initLocalState(main::ClientContext* context) = 0;
-    std::shared_ptr<binder::Expression> bindNodeOutput(binder::Binder* binder, graph::GraphEntry& graphEntry);
+    std::shared_ptr<binder::Expression> bindNodeOutput(binder::Binder* binder,
+        graph::GraphEntry& graphEntry);
 
 protected:
     std::unique_ptr<GDSBindData> bindData;

--- a/src/include/function/gds/gds.h
+++ b/src/include/function/gds/gds.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "binder/expression/expression.h"
+#include "graph/graph_entry.h"
 
 namespace kuzu {
 namespace binder {
@@ -17,13 +18,21 @@ namespace function {
 
 // Struct maintaining GDS specific information that needs to be obtained at compile time.
 struct GDSBindData {
+    std::shared_ptr<binder::Expression> nodeOutput;
+    // If outputAsNode is true, we will scan all properties of the node.
+    // Otherwise, we return node ID only.
+    bool outputAsNode;
+
+    explicit GDSBindData(std::shared_ptr<binder::Expression> nodeOutput, bool outputAsNode) :
+          nodeOutput{std::move(nodeOutput)}, outputAsNode{outputAsNode} {}
+    GDSBindData(const GDSBindData& other) : nodeOutput{other.nodeOutput}, outputAsNode{other.outputAsNode} {}
     virtual ~GDSBindData() = default;
 
     virtual bool hasNodeInput() const { return false; }
     virtual std::shared_ptr<binder::Expression> getNodeInput() const { return nullptr; }
 
-    virtual bool hasNodeOutput() const { return false; }
-    virtual std::shared_ptr<binder::Expression> getNodeOutput() const { return nullptr; }
+    virtual bool hasNodeOutput() const { return outputAsNode; }
+    virtual std::shared_ptr<binder::Expression> getNodeOutput() const { return nodeOutput; }
 
     virtual std::unique_ptr<GDSBindData> copy() const {
         return std::make_unique<GDSBindData>(*this);
@@ -47,6 +56,9 @@ public:
 
 // Base class for every graph data science algorithm.
 class GDSAlgorithm {
+protected:
+    static constexpr char NODE_COLUMN_NAME[] = "_node";
+
 public:
     GDSAlgorithm() = default;
     GDSAlgorithm(const GDSAlgorithm& other) {
@@ -59,9 +71,7 @@ public:
     virtual std::vector<common::LogicalTypeID> getParameterTypeIDs() const { return {}; }
     virtual binder::expression_vector getResultColumns(binder::Binder* binder) const = 0;
 
-    virtual void bind(const binder::expression_vector&) {
-        bindData = std::make_unique<GDSBindData>();
-    }
+    virtual void bind(const binder::expression_vector& params, binder::Binder* binder, graph::GraphEntry& graphEntry) = 0;
     GDSBindData* getBindData() const { return bindData.get(); }
 
     void init(processor::GDSCallSharedState* sharedState, main::ClientContext* context);
@@ -75,6 +85,7 @@ public:
 
 protected:
     virtual void initLocalState(main::ClientContext* context) = 0;
+    std::shared_ptr<binder::Expression> bindNodeOutput(binder::Binder* binder, graph::GraphEntry& graphEntry);
 
 protected:
     std::unique_ptr<GDSBindData> bindData;

--- a/src/include/storage/store/node_table_data.h
+++ b/src/include/storage/store/node_table_data.h
@@ -21,6 +21,7 @@ struct NodeDataScanState final : TableDataScanState {
     bool nextVector();
 
     void resetState() override {
+        TableDataScanState::resetState();
         numRowsToScan = 0;
         vectorIdx = common::INVALID_IDX;
         numRowsInNodeGroup = 0;

--- a/src/include/storage/store/table_data.h
+++ b/src/include/storage/store/table_data.h
@@ -32,7 +32,7 @@ struct TableDataScanState {
 
     // TODO(Guodong): If we reset the state, we should be able to use the same object to scan
     // different table. This should simplify the multi-label scan.
-    virtual void resetState()  {
+    virtual void resetState() {
         for (auto& state : chunkStates) {
             state.resetState();
         }

--- a/src/include/storage/store/table_data.h
+++ b/src/include/storage/store/table_data.h
@@ -20,6 +20,9 @@ template<typename T>
 class DiskArray;
 
 struct TableDataScanState {
+    std::vector<common::column_id_t> columnIDs;
+    std::vector<Column::ChunkState> chunkStates;
+
     explicit TableDataScanState(const std::vector<common::column_id_t>& columnIDs)
         : columnIDs{columnIDs} {
         chunkStates.resize(this->columnIDs.size());
@@ -27,12 +30,13 @@ struct TableDataScanState {
     virtual ~TableDataScanState() = default;
     DELETE_COPY_DEFAULT_MOVE(TableDataScanState);
 
-    std::vector<common::column_id_t> columnIDs;
-    std::vector<Column::ChunkState> chunkStates;
-
     // TODO(Guodong): If we reset the state, we should be able to use the same object to scan
     // different table. This should simplify the multi-label scan.
-    virtual void resetState() = 0;
+    virtual void resetState()  {
+        for (auto& state : chunkStates) {
+            state.resetState();
+        }
+    }
 
     template<class TARGET>
     TARGET& cast() {

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -149,7 +149,8 @@ void Planner::planGDSCall(const BoundReadingClause& readingClause,
     if (bindData->hasNodeOutput()) {
         auto& node = bindData->getNodeOutput()->constCast<NodeExpression>();
         auto scanPlan = LogicalPlan();
-        auto properties = getProperties(node);
+        cardinalityEstimator.addNodeIDDom(*node.getInternalID(), node.getTableIDs(), clientContext->getTx());
+        auto properties = node.getPropertyExprs();
         appendScanNodeTable(node.getInternalID(), node.getTableIDs(), properties, scanPlan);
         expression_vector joinConditions;
         joinConditions.push_back(node.getInternalID());

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -149,7 +149,8 @@ void Planner::planGDSCall(const BoundReadingClause& readingClause,
     if (bindData->hasNodeOutput()) {
         auto& node = bindData->getNodeOutput()->constCast<NodeExpression>();
         auto scanPlan = LogicalPlan();
-        cardinalityEstimator.addNodeIDDom(*node.getInternalID(), node.getTableIDs(), clientContext->getTx());
+        cardinalityEstimator.addNodeIDDom(*node.getInternalID(), node.getTableIDs(),
+            clientContext->getTx());
         auto properties = node.getPropertyExprs();
         appendScanNodeTable(node.getInternalID(), node.getTableIDs(), properties, scanPlan);
         expression_vector joinConditions;

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -83,14 +83,16 @@ std::pair<offset_t, offset_t> RelDataReadState::getStartAndEndOffset() {
 }
 
 void RelDataReadState::resetState() {
+    TableDataScanState::resetState();
     nodeGroupIdx = INVALID_NODE_GROUP_IDX;
     numNodes = 0;
     currentNodeOffset = 0;
     posInCurrentCSR = 0;
+    csrListEntries.resize(StorageConstants::NODE_GROUP_SIZE, {0, 0});
+    csrHeaderChunks = ChunkedCSRHeader(false);
     readFromPersistentStorage = false;
     readFromLocalStorage = false;
     localNodeGroup = nullptr;
-    csrListEntries.resize(StorageConstants::NODE_GROUP_SIZE, {0, 0});
 }
 
 offset_t CSRHeaderColumns::getNumNodes(Transaction* transaction,

--- a/test/test_files/tinysnb/algorithm/basic.test
+++ b/test/test_files/tinysnb/algorithm/basic.test
@@ -4,6 +4,7 @@
 
 -CASE BasicAlgorithm
 
+
 -STATEMENT PROJECT GRAPH PK (person {age}, knows) CALL variable_length_path(PK, 1, 1) RETURN *;
 ---- error
 Parser exception: Filtering or projecting properties in graph projection is not supported.
@@ -12,86 +13,90 @@ Parser exception: Filtering or projecting properties in graph projection is not 
 Binder exception: Cannot find graph PK.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID > 5
-           CALL variable_length_path(PK, a, 1, 1)
-           RETURN a.fName, dst, length, num_path;
+           CALL variable_length_path(PK, a, 1, 1, true)
+           RETURN a.fName, _node.fName, length, num_path;
 ---- 2
-Elizabeth|0:5|1|1
-Elizabeth|0:6|1|1
+Elizabeth|Farooq|1|1
+Elizabeth|Greg|1|1
 -STATEMENT PROJECT GRAPH PK (person, knows, studyAt, organisation)
            MATCH (a) WHERE a.ID = 0
-           CALL variable_length_path(PK, a, 1, 1)
-           RETURN a.fName, dst, length, num_path;
+           CALL variable_length_path(PK, a, 1, 1, true)
+           RETURN a.fName, _node.name, _node.fName, length, num_path;
 ---- 4
-Alice|0:1|1|1
-Alice|0:2|1|1
-Alice|0:3|1|1
-Alice|1:1|1|1
+Alice|ABFsUni||1|1
+Alice||Bob|1|1
+Alice||Carol|1|1
+Alice||Dan|1|1
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a) WHERE a.ID = 1
-           CALL variable_length_path(PK, a, 1, 1)
-           RETURN a.fName, dst, length, num_path;
+           CALL variable_length_path(PK, a, 1, 1, true)
+           RETURN a.fName, _node, length, num_path;
 ---- 0
-
+-STATEMENT PROJECT GRAPH PK (person, knows)
+           MATCH (a) WHERE a.ID = 1
+           CALL variable_length_path(PK, a, 1, 1, false)
+           RETURN a.fName, _node.name, length, num_path;
+---- error
+Binder exception: Cannot find property name for _node.
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL variable_length_path(PK, a, 2, 2)
-           RETURN a.fName, dst, length, num_path;
+           CALL variable_length_path(PK, a, 2, 2, true)
+           RETURN a.fName, _node.fName, length, num_path;
 ---- 4
-Alice|0:0|2|3
-Alice|0:1|2|2
-Alice|0:2|2|2
-Alice|0:3|2|2
+Alice|Alice|2|3
+Alice|Bob|2|2
+Alice|Carol|2|2
+Alice|Dan|2|2
 -STATEMENT PROJECT GRAPH PK (person, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL shortest_path(PK, a, 2)
-           RETURN a.fName, dst, length;
+           CALL shortest_path(PK, a, 2, true)
+           RETURN a.fName, _node.fName, length;
 ---- 4
-Alice|0:0|0
-Alice|0:1|1
-Alice|0:2|1
-Alice|0:3|1
--STATEMENT PROJECT GRAPH PK (person, organisation, studyAt, knows)
+Alice|Alice|0
+Alice|Bob|1
+Alice|Carol|1
+Alice|Dan|1
+-STATEMENT PROJECT GRAPH PK (person, organisation, workAt, knows)
            MATCH (a:person) WHERE a.ID = 0
-           CALL shortest_path(PK, a, 2)
-           RETURN a.fName, dst, length;
+           CALL shortest_path(PK, a, 2, true)
+           RETURN a.fName, _node.fName, _node.name, length;
 ---- 6
-Alice|0:0|0
-Alice|0:1|1
-Alice|0:2|1
-Alice|0:3|1
-Alice|1:1|1
-Alice|1:3|2
--STATEMENT PROJECT GRAPH PK (person, knows) CALL weakly_connected_component(PK) RETURN *;
+Alice|Alice||0
+Alice|Bob||1
+Alice|Carol||1
+Alice|Dan||1
+Alice||CsWork|2
+Alice||DEsWork|2
+-STATEMENT PROJECT GRAPH PK (person, knows) CALL weakly_connected_component(PK, true) RETURN _node.fName, group_id;
 ---- 8
-0:0|0
-0:1|0
-0:2|0
-0:3|0
-0:4|1
-0:5|1
-0:6|1
-0:7|2
-# NOTE: I'm not confident that these internal ids will be determinstic
--STATEMENT PROJECT GRAPH PK (person, organisation, knows, workAt) CALL weakly_connected_component(PK) RETURN *;
+Alice|0
+Bob|0
+Carol|0
+Dan|0
+Elizabeth|1
+Farooq|1
+Greg|1
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2
+-STATEMENT PROJECT GRAPH PK (person, organisation, knows, workAt) CALL weakly_connected_component(PK, true) RETURN _node.fName, _node.name, group_id;
 ---- 11
-0:0|0
-0:1|0
-0:2|0
-0:3|0
-0:4|1
-0:5|1
-0:6|1
-0:7|2
-1:0|1
-1:1|3
-1:2|0
--STATEMENT PROJECT GRAPH PK (person, knows) CALL page_rank(PK) RETURN *;
+Alice||0
+Bob||0
+Carol||0
+Dan||0
+Elizabeth||1
+Farooq||1
+Greg||1
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff||2
+|ABFsUni|3
+|CsWork|0
+|DEsWork|0
+-STATEMENT PROJECT GRAPH PK (person, knows) CALL page_rank(PK, true) RETURN _node.fName, rank;
 ---- 8
-0:0|0.125000
-0:1|0.125000
-0:2|0.125000
-0:3|0.125000
-0:4|0.022734
-0:5|0.018750
-0:6|0.018750
-0:7|0.018750
+Alice|0.125000
+Bob|0.125000
+Carol|0.125000
+Dan|0.125000
+Elizabeth|0.022734
+Farooq|0.018750
+Greg|0.018750
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|0.018750


### PR DESCRIPTION
# Description

This PR adds additional argument to all algorithm function to output node instead of node ID. 

E.g.  we can now return node properties from weakly_connected_component
```
CALL weakly_connected_component
RETURN _node.fName, group_id
```

On the side, this PR fixes a bug when reusing the same scan state object to scan table. Some intermediate states were not reset correctly.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).