### PR TITLE
Fix generator case in irregular CI pipelines

### DIFF
--- a/.github/workflows/lsqb-benchmark-workflow.yml
+++ b/.github/workflows/lsqb-benchmark-workflow.yml
@@ -27,7 +27,7 @@ jobs:
     name: benchmark
     env:
       NUM_THREADS: 30
-      GEN: ninja
+      GEN: Ninja
       TIMEOUT: ${{ github.event.inputs.timeout }}
       SCALE_FACTOR: ${{ github.event.inputs.scale_factor }}
     runs-on: kuzu-self-hosted-benchmarking

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
-      GEN: ninja
+      GEN: Ninja
       CC: gcc
       CXX: g++
     steps:


### PR DESCRIPTION
#3633 made the Makefile pass the `GEN` variable directly to CMake as the generator, so it now needs to be `Ninja`, not `ninja`. These two pipelines were overlooked in that PR.