### PR TITLE
Fix 3652

### DIFF
--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -74,7 +74,7 @@ std::vector<PropertyInfo> Binder::bindPropertyInfo(
     }
     validateUniquePropertyName(propertyInfos);
     for (auto& info : propertyInfos) {
-        if (isReservedPropertyName(info.name)) {
+        if (reservedInColumnName(info.name)) {
             throw BinderException(stringFormat("{} is a reserved property name.", info.name));
         }
     }

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -44,7 +44,7 @@ expression_vector ExpressionBinder::bindNodeOrRelPropertyStarExpression(const Ex
     auto& nodeOrRel = (NodeOrRelExpression&)child;
     for (auto& expression : nodeOrRel.getPropertyExprsRef()) {
         auto propertyExpression = (PropertyExpression*)expression.get();
-        if (Binder::isReservedPropertyName(propertyExpression->getPropertyName())) {
+        if (Binder::reservedInPropertyLookup(propertyExpression->getPropertyName())) {
             continue;
         }
         result.push_back(expression->copy());
@@ -74,7 +74,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
     ExpressionUtil::validateDataType(*child,
         std::vector<LogicalTypeID>{LogicalTypeID::NODE, LogicalTypeID::REL, LogicalTypeID::STRUCT});
     if (isNodeOrRelPattern(*child)) {
-        if (Binder::isReservedPropertyName(propertyName)) {
+        if (Binder::reservedInPropertyLookup(propertyName)) {
             // Note we don't expose direct access to internal properties in case user tries to
             // modify them. However, we can expose indirect read-only access through function e.g.
             // ID().

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -172,15 +172,44 @@ std::string Binder::getUniqueExpressionName(const std::string& name) {
     return "_" + std::to_string(lastExpressionId++) + "_" + name;
 }
 
-bool Binder::isReservedPropertyName(const std::string& name) {
+struct ReservedNames {
+    // Column name that might conflict with internal names.
+    static std::unordered_set<std::string> getColumnNames() {
+        return {
+            InternalKeyword::ID,
+            InternalKeyword::LABEL,
+            InternalKeyword::SRC,
+            InternalKeyword::DST,
+            InternalKeyword::DIRECTION,
+            InternalKeyword::LENGTH,
+            InternalKeyword::NODES,
+            InternalKeyword::RELS,
+            InternalKeyword::PLACE_HOLDER,
+            StringUtils::getUpper(InternalKeyword::ROW_OFFSET),
+            StringUtils::getUpper(InternalKeyword::SRC_OFFSET),
+            StringUtils::getUpper(InternalKeyword::DST_OFFSET),
+            StringUtils::getUpper(rdf::PID),
+            StringUtils::getUpper(rdf::IRI),
+        };
+    }
+
+    // Properties that should be hidden from user access.
+    static std::unordered_set<std::string> getPropertyLookupName() {
+        return {
+            InternalKeyword::ID,
+            StringUtils::getUpper(rdf::PID),
+        };
+    }
+};
+
+bool Binder::reservedInColumnName(const std::string& name) {
     auto normalizedName = StringUtils::getUpper(name);
-    if (normalizedName == InternalKeyword::ID) {
-        return true;
-    }
-    if (normalizedName == StringUtils::getUpper(std::string(rdf::PID))) {
-        return true;
-    }
-    return false;
+    return ReservedNames::getColumnNames().contains(normalizedName);
+}
+
+bool Binder::reservedInPropertyLookup(const std::string& name) {
+    auto normalizedName = StringUtils::getUpper(name);
+    return ReservedNames::getPropertyLookupName().contains(normalizedName);
 }
 
 void Binder::addToScope(const std::string& name, std::shared_ptr<Expression> expr) {

--- a/src/common/string_utils.cpp
+++ b/src/common/string_utils.cpp
@@ -64,6 +64,12 @@ std::string StringUtils::getUpper(const std::string& input) {
     return result;
 }
 
+std::string StringUtils::getUpper(const std::string_view& input) {
+    auto result = std::string(input);
+    toUpper(result);
+    return result;
+}
+
 std::string StringUtils::getLower(const std::string& input) {
     auto result = input;
     toLower(result);

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -267,7 +267,10 @@ public:
 
     /*** helpers ***/
     std::string getUniqueExpressionName(const std::string& name);
-    static bool isReservedPropertyName(const std::string& name);
+
+
+    static bool reservedInColumnName(const std::string& name);
+    static bool reservedInPropertyLookup(const std::string& name);
 
     void addToScope(const std::string& name, std::shared_ptr<Expression> expr);
     BinderScope saveScope();

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -268,7 +268,6 @@ public:
     /*** helpers ***/
     std::string getUniqueExpressionName(const std::string& name);
 
-
     static bool reservedInColumnName(const std::string& name);
     static bool reservedInPropertyLookup(const std::string& name);
 

--- a/src/include/common/string_utils.h
+++ b/src/include/common/string_utils.h
@@ -20,6 +20,7 @@ public:
         std::transform(input.begin(), input.end(), input.begin(), ::toupper);
     }
     static std::string getUpper(const std::string& input);
+    static std::string getUpper(const std::string_view& input);
     static std::string getLower(const std::string& input);
     static void toLower(std::string& input) {
         std::transform(input.begin(), input.end(), input.begin(), ::tolower);

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -2,6 +2,13 @@
 
 --
 
+-CASE 3652
+-STATEMENT CREATE NODE TABLE V (id INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE REL TABLE E (FROM V TO V, iri STRING);
+---- error
+Binder exception: iri is a reserved property name.
+
 -CASE 2158
 -STATEMENT CREATE NODE TABLE N1(name STRING, PRIMARY KEY(name));
 ---- ok


### PR DESCRIPTION
# Description

The problem is that user use a reserved keyword as column name. This PR performs a check over column name in DDL.

Fixes #3652

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).