### PR TITLE
Remove redundant CSRListEntries data

### DIFF
--- a/src/include/storage/store/chunked_node_group.h
+++ b/src/include/storage/store/chunked_node_group.h
@@ -84,6 +84,11 @@ struct ChunkedCSRHeader {
         offset->setNumValues(numValues);
         length->setNumValues(numValues);
     }
+
+    void resetToEmpty() const {
+        offset->resetToEmpty();
+        length->resetToEmpty();
+    }
 };
 
 class ChunkedCSRNodeGroup : public ChunkedNodeGroup {

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -14,7 +14,6 @@ struct RelDataReadState final : TableDataScanState {
     common::offset_t numNodes;
     common::offset_t currentNodeOffset;
     common::offset_t posInCurrentCSR;
-    std::vector<common::list_entry_t> csrListEntries;
     // Temp auxiliary data structure to scan the offset of each CSR node in the offset column chunk.
     ChunkedCSRHeader csrHeaderChunks = ChunkedCSRHeader(false /*enableCompression*/);
 
@@ -27,7 +26,6 @@ struct RelDataReadState final : TableDataScanState {
     DELETE_COPY_DEFAULT_MOVE(RelDataReadState);
 
     bool hasMoreToRead(const transaction::Transaction* transaction);
-    void populateCSRListEntries();
     std::pair<common::offset_t, common::offset_t> getStartAndEndOffset();
 
     bool hasMoreToReadInPersistentStorage() const;


### PR DESCRIPTION
The CSR offsets/lengths are also cached in the csrHeaderChunks. Pre-calculating them may have a slight benefit, as getCSRLength/getStartCSROffset handle a few edge cases which make them slower than just a memory lookup, but the differences are minor and pre-calculating them slows down small scans.

This reduces the cost of small rel table scans by more than half. E.g. in one query from the LDBC fintech sf1 dataset which was taking ~60s, largely as a result of doing many small rel table scans as part of a recursive join, this reduced it to ~30s in total (more improvements are possible; this was the easiest of them).