### PR TITLE
Fix optimistic read on MARKED page

### DIFF
--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -209,13 +209,9 @@ void BufferManager::optimisticRead(BMFileHandle& fileHandle, page_idx_t pageIdx,
             }
         } break;
         case PageState::MARKED: {
-            // If the page is marked, we try to switch to unlocked. If we succeed, we read the page.
-            if (pageState->tryClearMark(currStateAndVersion)) {
-                if (try_func(func, getFrame(fileHandle, pageIdx), vmRegions,
-                        fileHandle.getPageSizeClass())) {
-                    return;
-                }
-            }
+            // If the page is marked, we try to switch to unlocked.
+            pageState->tryClearMark(currStateAndVersion);
+            continue;
         } break;
         case PageState::EVICTED: {
             pin(fileHandle, pageIdx, PageReadPolicy::READ_PAGE);


### PR DESCRIPTION
# Description

For MARKED page, the right way to optimistically read it is to switch it to UNLOCKED first, and read as a UNLOCKED page, so we will do the double check of state and version `if (pageState->getStateAndVersion() == currStateAndVersion) {`.

This logic was missed and can be found from vmcache's peusdocode.
```
optimisticRead(uint64_t pid, Function fn): 
while (true) // retry until success
    PageState s = state[pid] // incl. version 
    if (s.isUnlocked())
        // optimistic read:
        fn(virtMem + (pid*pageSize))
        if (state[pid] == s) // validate version
            return // success
    else if (s.isMarked())
        // clear mark:
        state[pid].CAS(s, Unlocked)
    else if (s.isEvicted())
        fix(pid); unfix(pid) // handle page miss
```