### PR TITLE
Fix zero column node COPY

### DIFF
--- a/test/test_files/copy/copy_pk_serial.test
+++ b/test/test_files/copy/copy_pk_serial.test
@@ -6,3 +6,12 @@
 -STATEMENT MATCH (:person)-[e:knows]->(:person) RETURN COUNT(*)
 ---- 1
 14
+
+-CASE CopyZeroColumnsSerial
+-STATEMENT CREATE NODE TABLE test (id SERIAL, primary key(id));
+---- ok
+-STATEMENT copy test from "${KUZU_ROOT_DIRECTORY}/dataset/large-serial/serialtable0.csv"
+---- ok
+-STATEMENT MATCH (t:test) return sum(t.id);
+---- 1
+431985


### PR DESCRIPTION
this fixes the case where no columns are actually copied and only implicit serial tuples are filled. 
this only occurs for node tables since rel will always have from/to columns
