### PR TITLE
Allow integer packing and unpacking of partial chunks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15)
 
-project(Kuzu VERSION 0.4.2.10 LANGUAGES CXX C)
+project(Kuzu VERSION 0.4.2.11 LANGUAGES CXX C)
 
 find_package(Threads REQUIRED)
 

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdint>
-#include <numeric>
+#include <limits>
 #include <vector>
 
 #include "common/assert.h"
@@ -52,11 +52,6 @@ std::vector<T> copyVector(const std::vector<T>& objects) {
         result.push_back(object->copy());
     }
     return result;
-}
-
-template<numeric_utils::IsIntegral T>
-inline T ceilDiv(T a, T b) {
-    return a / b + (a % b != 0);
 }
 
 } // namespace common

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <numeric>
 #include <vector>
 
 #include "common/assert.h"
@@ -13,10 +14,12 @@ namespace common {
 class BitmaskUtils {
 public:
     template<typename T>
-        requires std::integral<T> && std::is_unsigned_v<T>
+        requires std::integral<T>
     static T all1sMaskForLeastSignificantBits(uint32_t numBits) {
         KU_ASSERT(numBits <= 64);
-        return numBits == 64 ? std::numeric_limits<T>::max() : ((T)1 << numBits) - 1;
+        using U = numeric_utils::MakeUnSignedT<T>;
+        return std::bit_cast<T>(numBits == (sizeof(U) * 8) ? std::numeric_limits<U>::max() :
+                                                             static_cast<U>(((U)1 << numBits) - 1));
     }
 
     // constructs all 1s mask while avoiding overflow/underflow for int128

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -4,6 +4,7 @@
 #include <vector>
 
 #include "common/assert.h"
+#include "common/numeric_utils.h"
 #include "common/types/int128_t.h"
 
 namespace kuzu {
@@ -48,6 +49,11 @@ std::vector<T> copyVector(const std::vector<T>& objects) {
         result.push_back(object->copy());
     }
     return result;
+}
+
+template<numeric_utils::IsIntegral T>
+inline T ceilDiv(T a, T b) {
+    return a / b + (a % b != 0);
 }
 
 } // namespace common

--- a/src/include/storage/compression/bitpacking_int128.h
+++ b/src/include/storage/compression/bitpacking_int128.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "common/types/int128_t.h"
-#include "storage/compression/compression.h"
 
 namespace kuzu::storage {
 
@@ -14,15 +13,5 @@ struct Int128Packer {
     static void unpack(const uint32_t* __restrict in, common::int128_t* __restrict out,
         uint8_t width);
 };
-
-namespace bitpacking_utils {
-template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
-void unpackSingle(const CompressedType* __restrict& in, UncompressedType* __restrict out,
-    uint16_t delta, uint16_t shiftRight);
-
-template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
-void packSingle(const UncompressedType in, CompressedType* __restrict& out, uint16_t delta,
-    uint16_t shiftLeft, UncompressedType mask);
-}; // namespace bitpacking_utils
 
 } // namespace kuzu::storage

--- a/src/include/storage/compression/bitpacking_int128.h
+++ b/src/include/storage/compression/bitpacking_int128.h
@@ -15,14 +15,14 @@ struct Int128Packer {
         uint8_t width);
 };
 
-struct BitpackingUtils {
-    template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
-    static void unpackSingle(const CompressedType* __restrict& in, UncompressedType* __restrict out,
-        uint16_t delta, uint16_t shiftRight);
+namespace bitpacking_utils {
+template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
+void unpackSingle(const CompressedType* __restrict& in, UncompressedType* __restrict out,
+    uint16_t delta, uint16_t shiftRight);
 
-    template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
-    static void packSingle(const UncompressedType in, CompressedType* __restrict& out,
-        uint16_t delta, uint16_t shiftLeft, UncompressedType mask);
-};
+template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
+void packSingle(const UncompressedType in, CompressedType* __restrict& out, uint16_t delta,
+    uint16_t shiftLeft, UncompressedType mask);
+}; // namespace bitpacking_utils
 
 } // namespace kuzu::storage

--- a/src/include/storage/compression/bitpacking_int128.h
+++ b/src/include/storage/compression/bitpacking_int128.h
@@ -4,6 +4,7 @@
 #pragma once
 
 #include "common/types/int128_t.h"
+#include "storage/compression/compression.h"
 
 namespace kuzu::storage {
 
@@ -12,6 +13,16 @@ struct Int128Packer {
         uint8_t width);
     static void unpack(const uint32_t* __restrict in, common::int128_t* __restrict out,
         uint8_t width);
+};
+
+struct BitpackingUtils {
+    template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
+    static void unpackSingle(const CompressedType* __restrict& in, UncompressedType* __restrict out,
+        uint16_t delta, uint16_t shiftRight);
+
+    template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
+    static void packSingle(const UncompressedType in, CompressedType* __restrict& out,
+        uint16_t delta, uint16_t shiftLeft, UncompressedType mask);
 };
 
 } // namespace kuzu::storage

--- a/src/include/storage/compression/bitpacking_utils.h
+++ b/src/include/storage/compression/bitpacking_utils.h
@@ -21,6 +21,7 @@ struct BitpackingUtils {
 
     static const uint8_t* getInitialSrcCursor(const uint8_t* src, uint16_t bitWidth,
         size_t srcOffset);
+    static uint8_t* getInitialSrcCursor(uint8_t* src, uint16_t bitWidth, size_t srcOffset);
 };
 
 } // namespace kuzu::storage

--- a/src/include/storage/compression/bitpacking_utils.h
+++ b/src/include/storage/compression/bitpacking_utils.h
@@ -13,15 +13,11 @@ struct BitpackingUtils {
         std::conditional_t<sizeof(UncompressedType) >= sizeof(uint32_t), uint32_t, uint8_t>;
     static constexpr size_t sizeOfCompressedTypeBits = sizeof(CompressedType) * 8;
 
-    static const uint8_t* unpackSingle(const uint8_t* __restrict src,
-        UncompressedType* __restrict dst, uint16_t bitWidth, size_t srcOffset);
+    static void unpackSingle(const uint8_t* __restrict src, UncompressedType* __restrict dst,
+        uint16_t bitWidth, size_t srcOffset);
 
-    static uint8_t* packSingle(const UncompressedType src, uint8_t* __restrict dstCursor,
+    static void packSingle(const UncompressedType src, uint8_t* __restrict dstCursor,
         uint16_t bitWidth, size_t dstOffset);
-
-    static const uint8_t* getInitialSrcCursor(const uint8_t* src, uint16_t bitWidth,
-        size_t srcOffset);
-    static uint8_t* getInitialSrcCursor(uint8_t* src, uint16_t bitWidth, size_t srcOffset);
 };
 
 } // namespace kuzu::storage

--- a/src/include/storage/compression/bitpacking_utils.h
+++ b/src/include/storage/compression/bitpacking_utils.h
@@ -1,0 +1,51 @@
+// Adapted from
+// https://github.com/duckdb/duckdb/blob/main/src/include/duckdb/common/bitpacking.hpp
+
+#pragma once
+
+#include "storage/compression/compression.h"
+
+namespace kuzu::storage {
+
+template<IntegerBitpackingType UncompressedType>
+struct SingleValuePacker {};
+
+template<IntegerBitpackingType UncompressedType>
+    requires(sizeof(UncompressedType) >= sizeof(uint32_t))
+struct SingleValuePacker<UncompressedType> {
+    static void unpackSingle(const uint32_t* __restrict& src, UncompressedType* __restrict dst,
+        uint16_t bitWidth, size_t srcOffset);
+
+    static void packSingle(const UncompressedType src, uint32_t* __restrict& dstCursor,
+        uint16_t bitWidth, size_t dstOffset);
+};
+
+template<IntegerBitpackingType UncompressedType>
+    requires(sizeof(UncompressedType) < sizeof(uint32_t))
+struct SingleValuePacker<UncompressedType> {
+    static void unpackSingle(const uint8_t* __restrict& src, UncompressedType* __restrict dst,
+        uint16_t bitWidth, size_t srcOffset);
+
+    static void packSingle(const UncompressedType src, uint8_t* __restrict& dstCursor,
+        uint16_t bitWidth, size_t dstOffset);
+};
+
+namespace bitpacking_utils {
+
+template<IntegerBitpackingType UncompressedType>
+decltype(auto) getInitialSrcCursor(const uint8_t* src, uint16_t bitWidth, size_t srcOffset) {
+    using CompressedType =
+        std::conditional_t<sizeof(UncompressedType) >= sizeof(uint32_t), uint32_t, uint8_t>;
+    static constexpr size_t sizeOfCompressedTypeBits = sizeof(CompressedType) * 8;
+    return (CompressedType*)src + srcOffset * bitWidth / sizeOfCompressedTypeBits;
+}
+
+template<IntegerBitpackingType UncompressedType>
+decltype(auto) castCompressedCursor(uint8_t* src) {
+    using CompressedType =
+        std::conditional_t<sizeof(UncompressedType) >= sizeof(uint32_t), uint32_t, uint8_t>;
+    return reinterpret_cast<CompressedType*>(src);
+}
+}; // namespace bitpacking_utils
+
+} // namespace kuzu::storage

--- a/src/include/storage/compression/bitpacking_utils.h
+++ b/src/include/storage/compression/bitpacking_utils.h
@@ -13,10 +13,10 @@ struct BitpackingUtils {
         std::conditional_t<sizeof(UncompressedType) >= sizeof(uint32_t), uint32_t, uint8_t>;
     static constexpr size_t sizeOfCompressedTypeBits = sizeof(CompressedType) * 8;
 
-    static void unpackSingle(const uint8_t* __restrict& src, UncompressedType* __restrict dst,
-        uint16_t bitWidth, size_t srcOffset);
+    static const uint8_t* unpackSingle(const uint8_t* __restrict src,
+        UncompressedType* __restrict dst, uint16_t bitWidth, size_t srcOffset);
 
-    static void packSingle(const UncompressedType src, uint8_t* __restrict& dstCursor,
+    static uint8_t* packSingle(const UncompressedType src, uint8_t* __restrict dstCursor,
         uint16_t bitWidth, size_t dstOffset);
 
     static const uint8_t* getInitialSrcCursor(const uint8_t* src, uint16_t bitWidth,

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -340,6 +340,10 @@ protected:
 
     void copyValuesToTempChunkWithOffset(const U* srcBuffer, U* tmpBuffer, BitpackInfo<T> info,
         size_t numValuesToCopy) const;
+
+    void setPartialChunkInPlace(const uint8_t* srcBuffer, common::offset_t posInSrc,
+        uint8_t* dstBuffer, common::offset_t posInDst, common::offset_t numValues,
+        const BitpackInfo<T>& header) const;
 };
 
 class BooleanBitpacking : public CompressionAlg {

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -299,11 +299,6 @@ public:
             return UINT64_MAX;
         }
         auto numValues = dataSize * 8 / info.bitWidth;
-        // Round down to nearest multiple of CHUNK_SIZE to ensure that we don't write any extra
-        // values Rounding up could overflow the buffer
-        // TODO(bmwinger): Pack extra values into the space at the end. This will probably be
-        // slower, but only needs to be done once.
-        numValues -= numValues % CHUNK_SIZE;
         return numValues;
     }
 
@@ -339,6 +334,10 @@ protected:
         // CHUNK_SIZE
         return buffer + (pos / CHUNK_SIZE) * bitWidth * CHUNK_SIZE / 8;
     }
+
+    template<bool offsetNonZero>
+    void packPartialChunk(U* srcBuffer, uint8_t* dstBuffer, BitpackInfo<T> info,
+        size_t remainingValues) const;
 };
 
 class BooleanBitpacking : public CompressionAlg {

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -335,9 +335,11 @@ protected:
         return buffer + (pos / CHUNK_SIZE) * bitWidth * CHUNK_SIZE / 8;
     }
 
-    template<bool offsetNonZero>
-    void packPartialChunk(U* srcBuffer, uint8_t* dstBuffer, BitpackInfo<T> info,
+    void packPartialChunk(const U* srcBuffer, uint8_t* dstBuffer, BitpackInfo<T> info,
         size_t remainingValues) const;
+
+    void copyValuesToTempChunkWithOffset(const U* srcBuffer, U* tmpBuffer, BitpackInfo<T> info,
+        size_t numValuesToCopy) const;
 };
 
 class BooleanBitpacking : public CompressionAlg {

--- a/src/include/storage/compression/compression.h
+++ b/src/include/storage/compression/compression.h
@@ -335,8 +335,8 @@ protected:
         return buffer + (pos / CHUNK_SIZE) * bitWidth * CHUNK_SIZE / 8;
     }
 
-    void packPartialChunk(const U* srcBuffer, uint8_t* dstBuffer, BitpackInfo<T> info,
-        size_t remainingValues) const;
+    void packPartialChunk(const U* srcBuffer, uint8_t* dstBuffer, size_t posInDst,
+        BitpackInfo<T> info, size_t remainingValues) const;
 
     void copyValuesToTempChunkWithOffset(const U* srcBuffer, U* tmpBuffer, BitpackInfo<T> info,
         size_t numValuesToCopy) const;

--- a/src/storage/compression/CMakeLists.txt
+++ b/src/storage/compression/CMakeLists.txt
@@ -1,7 +1,8 @@
 add_library(kuzu_storage_compression
         OBJECT
         compression.cpp
-        bitpacking_int128.cpp)
+        bitpacking_int128.cpp
+        bitpacking_utils.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_storage_compression>

--- a/src/storage/compression/bitpacking_int128.cpp
+++ b/src/storage/compression/bitpacking_int128.cpp
@@ -148,11 +148,12 @@ void Int128Packer::pack(const common::int128_t* __restrict in, uint32_t* __restr
         packDelta128(in, out);
         break;
     default:
+        uint8_t* outCursor = reinterpret_cast<uint8_t*>(out);
         for (common::idx_t oindex = 0; oindex < IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1;
              ++oindex) {
-            SingleValuePacker<common::int128_t>::packSingle(in[oindex], out, width, oindex);
+            BitpackingUtils<common::int128_t>::packSingle(in[oindex], outCursor, width, oindex);
         }
-        packLast(in, out, width);
+        packLast(in, reinterpret_cast<uint32_t*>(outCursor), width);
     }
 }
 
@@ -176,11 +177,13 @@ void Int128Packer::unpack(const uint32_t* __restrict in, common::int128_t* __res
         unpackDelta128(in, out);
         break;
     default:
+        const auto* inCursor = reinterpret_cast<const uint8_t*>(in);
         for (common::idx_t oindex = 0; oindex < IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1;
              ++oindex) {
-            SingleValuePacker<common::int128_t>::unpackSingle(in, out + oindex, width, oindex);
+            BitpackingUtils<common::int128_t>::unpackSingle(inCursor, out + oindex, width, oindex);
         }
-        unpackLast(in, out, width);
+        const auto* inCursor1 = reinterpret_cast<const uint32_t*>(inCursor);
+        unpackLast(inCursor1, out, width);
     }
 }
 

--- a/src/storage/compression/bitpacking_int128.cpp
+++ b/src/storage/compression/bitpacking_int128.cpp
@@ -148,13 +148,15 @@ void Int128Packer::pack(const common::int128_t* __restrict in, uint32_t* __restr
         packDelta128(in, out);
         break;
     default:
-        uint8_t* outCursor = reinterpret_cast<uint8_t*>(out);
         for (common::idx_t oindex = 0; oindex < IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1;
              ++oindex) {
-            outCursor =
-                BitpackingUtils<common::int128_t>::packSingle(in[oindex], outCursor, width, oindex);
+            BitpackingUtils<common::int128_t>::packSingle(in[oindex],
+                reinterpret_cast<uint8_t*>(out), width, oindex);
         }
-        packLast(in, reinterpret_cast<uint32_t*>(outCursor), width);
+        packLast(in,
+            out + (IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1) * width /
+                      (sizeof(uint32_t) * 8),
+            width);
     }
 }
 
@@ -178,13 +180,14 @@ void Int128Packer::unpack(const uint32_t* __restrict in, common::int128_t* __res
         unpackDelta128(in, out);
         break;
     default:
-        const auto* inCursor = reinterpret_cast<const uint8_t*>(in);
         for (common::idx_t oindex = 0; oindex < IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1;
              ++oindex) {
-            inCursor = BitpackingUtils<common::int128_t>::unpackSingle(inCursor, out + oindex,
-                width, oindex);
+            BitpackingUtils<common::int128_t>::unpackSingle(reinterpret_cast<const uint8_t*>(in),
+                out + oindex, width, oindex);
         }
-        unpackLast(reinterpret_cast<const uint32_t*>(inCursor), out, width);
+        unpackLast(in + +(IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1) * width /
+                            (sizeof(uint32_t) * 8),
+            out, width);
     }
 }
 

--- a/src/storage/compression/bitpacking_int128.cpp
+++ b/src/storage/compression/bitpacking_int128.cpp
@@ -153,10 +153,9 @@ void Int128Packer::pack(const common::int128_t* __restrict in, uint32_t* __restr
             BitpackingUtils<common::int128_t>::packSingle(in[oindex],
                 reinterpret_cast<uint8_t*>(out), width, oindex);
         }
-        packLast(in,
-            out + (IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1) * width /
-                      (sizeof(uint32_t) * 8),
-            width);
+        const auto lastOutputFieldOffset =
+            (IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1) * width / (sizeof(uint32_t) * 8);
+        packLast(in, out + lastOutputFieldOffset, width);
     }
 }
 

--- a/src/storage/compression/bitpacking_int128.cpp
+++ b/src/storage/compression/bitpacking_int128.cpp
@@ -12,7 +12,7 @@ namespace kuzu::storage {
 // Unpacking
 //===--------------------------------------------------------------------===//
 
-static void unpackLast(const uint32_t* __restrict& in, common::int128_t* __restrict out,
+static void unpackLast(const uint32_t* __restrict in, common::int128_t* __restrict out,
     uint16_t delta) {
     const uint8_t LAST_IDX = 31;
     const uint16_t SHIFT = (delta * 31) % 32;
@@ -151,7 +151,8 @@ void Int128Packer::pack(const common::int128_t* __restrict in, uint32_t* __restr
         uint8_t* outCursor = reinterpret_cast<uint8_t*>(out);
         for (common::idx_t oindex = 0; oindex < IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1;
              ++oindex) {
-            BitpackingUtils<common::int128_t>::packSingle(in[oindex], outCursor, width, oindex);
+            outCursor =
+                BitpackingUtils<common::int128_t>::packSingle(in[oindex], outCursor, width, oindex);
         }
         packLast(in, reinterpret_cast<uint32_t*>(outCursor), width);
     }
@@ -180,10 +181,10 @@ void Int128Packer::unpack(const uint32_t* __restrict in, common::int128_t* __res
         const auto* inCursor = reinterpret_cast<const uint8_t*>(in);
         for (common::idx_t oindex = 0; oindex < IntegerBitpacking<common::int128_t>::CHUNK_SIZE - 1;
              ++oindex) {
-            BitpackingUtils<common::int128_t>::unpackSingle(inCursor, out + oindex, width, oindex);
+            inCursor = BitpackingUtils<common::int128_t>::unpackSingle(inCursor, out + oindex,
+                width, oindex);
         }
-        const auto* inCursor1 = reinterpret_cast<const uint32_t*>(inCursor);
-        unpackLast(inCursor1, out, width);
+        unpackLast(reinterpret_cast<const uint32_t*>(inCursor), out, width);
     }
 }
 

--- a/src/storage/compression/bitpacking_utils.cpp
+++ b/src/storage/compression/bitpacking_utils.cpp
@@ -9,14 +9,14 @@ namespace kuzu::storage {
 namespace {
 template<size_t compressed_field, std::integral CompressedType,
     IntegerBitpackingType UncompressedType>
-void unpackSingleUnrolled(const CompressedType* __restrict in, UncompressedType* __restrict out,
+void unpackSingleField(const CompressedType* __restrict in, UncompressedType* __restrict out,
     uint16_t delta, uint16_t shiftRight) {
     static constexpr size_t compressedFieldSizeBits = sizeof(CompressedType) * 8;
 
     if constexpr (compressed_field == 0) {
         *out = static_cast<UncompressedType>(in[0]) >> shiftRight;
     } else {
-        unpackSingleUnrolled<compressed_field - 1>(in, out, delta, shiftRight);
+        unpackSingleField<compressed_field - 1>(in, out, delta, shiftRight);
         KU_ASSERT(
             sizeof(UncompressedType) * 8 > compressed_field * compressedFieldSizeBits - shiftRight);
         *out |= static_cast<UncompressedType>(in[compressed_field])
@@ -25,131 +25,111 @@ void unpackSingleUnrolled(const CompressedType* __restrict in, UncompressedType*
 }
 
 template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
-const CompressedType* unpackSingleImpl(const CompressedType* __restrict in,
-    UncompressedType* __restrict out, uint16_t delta, uint16_t shiftRight) {
+void unpackSingleValueInPlace(const CompressedType* __restrict in, UncompressedType* __restrict out,
+    uint16_t delta, uint16_t shiftRight) {
     static_assert(sizeof(UncompressedType) <= 4 * sizeof(CompressedType));
 
     static constexpr size_t compressedFieldSizeBits = sizeof(CompressedType) * 8;
 
     if (delta + shiftRight <= compressedFieldSizeBits) {
-        unpackSingleUnrolled<0>(in, out, delta, shiftRight);
+        unpackSingleField<0>(in, out, delta, shiftRight);
     } else if (delta + shiftRight > compressedFieldSizeBits &&
                delta + shiftRight <= 2 * compressedFieldSizeBits) {
-        unpackSingleUnrolled<1>(in, out, delta, shiftRight);
+        unpackSingleField<1>(in, out, delta, shiftRight);
     } else if (delta + shiftRight > 2 * compressedFieldSizeBits &&
                delta + shiftRight <= 3 * compressedFieldSizeBits) {
-        unpackSingleUnrolled<2>(in, out, delta, shiftRight);
+        unpackSingleField<2>(in, out, delta, shiftRight);
     } else if (delta + shiftRight > 3 * compressedFieldSizeBits &&
                delta + shiftRight <= 4 * compressedFieldSizeBits) {
-        unpackSingleUnrolled<3>(in, out, delta, shiftRight);
+        unpackSingleField<3>(in, out, delta, shiftRight);
     } else if (delta + shiftRight > 4 * compressedFieldSizeBits) {
-        unpackSingleUnrolled<4>(in, out, delta, shiftRight);
+        unpackSingleField<4>(in, out, delta, shiftRight);
     }
 
     // we previously copy over the entire most significant field
     // zero out the bits that are not actually part of the compressed value
     *out &= common::BitmaskUtils::all1sMaskForLeastSignificantBits<UncompressedType>(delta);
-    return in + (delta + shiftRight) / compressedFieldSizeBits;
 }
 
-template<std::integral T>
-void setValueForBitsMatchingMask(T& out, T valueToSet, T mask) {
-    const T bitsToSet = valueToSet & mask;
-    const T bitsToClear = ~mask | valueToSet;
+template<bool shiftRight, std::integral CompressedType, IntegerBitpackingType UncompressedType>
+void setValueForBitsMatchingMask(CompressedType& out, UncompressedType unshiftedValue,
+    UncompressedType unshiftedMask, size_t shift) {
+    CompressedType valueToSet = 0;
+    CompressedType mask = 0;
+    if constexpr (shiftRight) {
+        valueToSet = static_cast<CompressedType>((unshiftedValue & unshiftedMask) >> shift);
+        mask = static_cast<CompressedType>(unshiftedMask >> shift);
+    } else {
+        valueToSet = static_cast<CompressedType>((unshiftedValue & unshiftedMask) << shift);
+        mask = static_cast<CompressedType>(unshiftedMask << shift);
+    }
+    const CompressedType bitsToSet = valueToSet & mask;
+    const CompressedType bitsToClear = ~mask | valueToSet;
     out = (out | bitsToSet) & bitsToClear;
 }
 
 template<size_t compressed_field, std::integral CompressedType,
     IntegerBitpackingType UncompressedType>
-void packSingleUnrolled(const UncompressedType in, CompressedType* __restrict out, uint16_t delta,
+void packSingleField(const UncompressedType in, CompressedType* __restrict out, uint16_t delta,
     uint16_t shiftLeft, UncompressedType mask) {
     static constexpr size_t compressedFieldSizeBits = sizeof(CompressedType) * 8;
 
     if constexpr (compressed_field == 0) {
-        if (shiftLeft == 0) {
-            // out[0] = static_cast<CompressedType>(in & mask);
-            setValueForBitsMatchingMask(out[0], static_cast<CompressedType>(in & mask),
-                static_cast<CompressedType>(mask));
-        } else {
-            // out[0] |= static_cast<CompressedType>((in & mask) << shiftLeft);
-            setValueForBitsMatchingMask(out[0],
-                static_cast<CompressedType>((in & mask) << shiftLeft),
-                static_cast<CompressedType>(mask << shiftLeft));
-        }
+        setValueForBitsMatchingMask<false>(out[0], in, mask, shiftLeft);
     } else {
-        packSingleUnrolled<compressed_field - 1>(in, out, delta, shiftLeft, mask);
+        packSingleField<compressed_field - 1>(in, out, delta, shiftLeft, mask);
         KU_ASSERT(
             sizeof(UncompressedType) * 8 > compressed_field * compressedFieldSizeBits - shiftLeft);
-        // out[compressed_field] = static_cast<CompressedType>(
-        //     (in & mask) >> (compressed_field * compressedFieldSizeBits - shiftLeft));
-        setValueForBitsMatchingMask(out[compressed_field],
-            static_cast<CompressedType>(
-                (in & mask) >> (compressed_field * compressedFieldSizeBits - shiftLeft)),
-            static_cast<CompressedType>(
-                mask >> (compressed_field * compressedFieldSizeBits - shiftLeft)));
+
+        setValueForBitsMatchingMask<true>(out[compressed_field], in, mask,
+            (compressed_field * compressedFieldSizeBits - shiftLeft));
     }
 }
 
 template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
-CompressedType* packSingleImpl(const UncompressedType in, CompressedType* __restrict out,
-    uint16_t delta, uint16_t shiftLeft, UncompressedType mask) {
+void packSingleImpl(const UncompressedType in, CompressedType* __restrict out, uint16_t delta,
+    uint16_t shiftLeft, UncompressedType mask) {
     static_assert(sizeof(UncompressedType) <= 4 * sizeof(CompressedType));
 
     static constexpr size_t compressedFieldSizeBits = sizeof(CompressedType) * 8;
 
     if (delta + shiftLeft <= compressedFieldSizeBits) {
-        packSingleUnrolled<0>(in, out, delta, shiftLeft, mask);
+        packSingleField<0>(in, out, delta, shiftLeft, mask);
     } else if (delta + shiftLeft > compressedFieldSizeBits &&
                delta + shiftLeft <= 2 * compressedFieldSizeBits) {
-        packSingleUnrolled<1>(in, out, delta, shiftLeft, mask);
+        packSingleField<1>(in, out, delta, shiftLeft, mask);
     } else if (delta + shiftLeft > 2 * compressedFieldSizeBits &&
                delta + shiftLeft <= 3 * compressedFieldSizeBits) {
-        packSingleUnrolled<2>(in, out, delta, shiftLeft, mask);
+        packSingleField<2>(in, out, delta, shiftLeft, mask);
     } else if (delta + shiftLeft > 3 * compressedFieldSizeBits &&
                delta + shiftLeft <= 4 * compressedFieldSizeBits) {
-        packSingleUnrolled<3>(in, out, delta, shiftLeft, mask);
+        packSingleField<3>(in, out, delta, shiftLeft, mask);
     } else if (delta + shiftLeft > 4 * compressedFieldSizeBits) {
-        packSingleUnrolled<4>(in, out, delta, shiftLeft, mask);
+        packSingleField<4>(in, out, delta, shiftLeft, mask);
     }
-
-    return out + (delta + shiftLeft) / compressedFieldSizeBits;
 }
 } // namespace
 
 template<IntegerBitpackingType UncompressedType>
-const uint8_t* BitpackingUtils<UncompressedType>::unpackSingle(const uint8_t* __restrict srcCursor,
+void BitpackingUtils<UncompressedType>::unpackSingle(const uint8_t* __restrict srcCursor,
     UncompressedType* __restrict dst, uint16_t bitWidth, size_t srcOffset) {
+    const size_t srcBufferOffset = srcOffset * bitWidth / sizeOfCompressedTypeBits;
     const size_t shiftRight = srcOffset * bitWidth % sizeOfCompressedTypeBits;
 
-    const auto* castedSrcCursor = reinterpret_cast<const CompressedType*>(srcCursor);
-    return reinterpret_cast<const uint8_t*>(
-        unpackSingleImpl(castedSrcCursor, dst, bitWidth, shiftRight));
+    const auto* castedSrcCursor =
+        reinterpret_cast<const CompressedType*>(srcCursor) + srcBufferOffset;
+    unpackSingleValueInPlace(castedSrcCursor, dst, bitWidth, shiftRight);
 }
 
 template<IntegerBitpackingType UncompressedType>
-uint8_t* BitpackingUtils<UncompressedType>::packSingle(const UncompressedType src,
-    uint8_t* __restrict dstCursor, uint16_t bitWidth, size_t dstOffset) {
+void BitpackingUtils<UncompressedType>::packSingle(const UncompressedType src,
+    uint8_t* __restrict dstBuffer, uint16_t bitWidth, size_t dstOffset) {
+    const size_t dstBufferOffset = dstOffset * bitWidth / sizeOfCompressedTypeBits;
     const size_t shiftLeft = dstOffset * bitWidth % sizeOfCompressedTypeBits;
 
-    auto* castedDstCursor = reinterpret_cast<CompressedType*>(dstCursor);
-    return reinterpret_cast<uint8_t*>(packSingleImpl(src, castedDstCursor, bitWidth, shiftLeft,
-        common::BitmaskUtils::all1sMaskForLeastSignificantBits<UncompressedType>(bitWidth)));
-}
-
-template<IntegerBitpackingType UncompressedType>
-const uint8_t* BitpackingUtils<UncompressedType>::getInitialSrcCursor(const uint8_t* src,
-    uint16_t bitWidth, size_t srcOffset) {
-    const auto* compressedTypeAlignedCursor = reinterpret_cast<const CompressedType*>(src) +
-                                              srcOffset * bitWidth / sizeOfCompressedTypeBits;
-    return reinterpret_cast<const uint8_t*>(compressedTypeAlignedCursor);
-}
-
-template<IntegerBitpackingType UncompressedType>
-uint8_t* BitpackingUtils<UncompressedType>::getInitialSrcCursor(uint8_t* src, uint16_t bitWidth,
-    size_t srcOffset) {
-    auto* compressedTypeAlignedCursor =
-        reinterpret_cast<CompressedType*>(src) + srcOffset * bitWidth / sizeOfCompressedTypeBits;
-    return reinterpret_cast<uint8_t*>(compressedTypeAlignedCursor);
+    auto* castedDstBuffer = reinterpret_cast<CompressedType*>(dstBuffer) + dstBufferOffset;
+    packSingleImpl(src, castedDstBuffer, bitWidth, shiftLeft,
+        common::BitmaskUtils::all1sMaskForLeastSignificantBits<UncompressedType>(bitWidth));
 }
 
 template struct BitpackingUtils<common::int128_t>;

--- a/src/storage/compression/bitpacking_utils.cpp
+++ b/src/storage/compression/bitpacking_utils.cpp
@@ -1,0 +1,203 @@
+// packSingle/unpackSingle are adapted from
+// https://github.com/duckdb/duckdb/blob/main/src/storage/compression/bitpacking_hugeint.cpp
+
+#include "storage/compression/bitpacking_utils.h"
+
+#include "common/utils.h"
+
+namespace kuzu::storage {
+
+template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
+void unpackSingleImpl(const CompressedType* __restrict& in, UncompressedType* __restrict out,
+    uint16_t delta, uint16_t shiftRight) {
+    static_assert(sizeof(UncompressedType) <= 4 * sizeof(CompressedType));
+
+    static constexpr size_t compressedFieldSizeBits = sizeof(CompressedType) * 8;
+
+    if (delta + shiftRight < compressedFieldSizeBits) {
+        *out =
+            ((static_cast<UncompressedType>(in[0])) >> shiftRight) % (UncompressedType(1) << delta);
+    }
+
+    else if (delta + shiftRight >= compressedFieldSizeBits &&
+             delta + shiftRight < 2 * compressedFieldSizeBits) {
+        *out = static_cast<UncompressedType>(in[0]) >> shiftRight;
+        ++in;
+
+        if (delta + shiftRight > compressedFieldSizeBits) {
+            const uint16_t NEXT_SHR = shiftRight + delta - compressedFieldSizeBits;
+            *out |= static_cast<UncompressedType>((*in) % (1U << NEXT_SHR))
+                    << (compressedFieldSizeBits - shiftRight);
+        }
+    }
+
+    else if (delta + shiftRight >= 2 * compressedFieldSizeBits &&
+             delta + shiftRight < 3 * compressedFieldSizeBits) {
+        *out = static_cast<UncompressedType>(in[0]) >> shiftRight;
+        *out |= static_cast<UncompressedType>(in[1]) << (compressedFieldSizeBits - shiftRight);
+        in += 2;
+
+        if (delta + shiftRight > 2 * compressedFieldSizeBits) {
+            const uint16_t NEXT_SHR = delta + shiftRight - 2 * compressedFieldSizeBits;
+            *out |= static_cast<UncompressedType>((*in) % (1U << NEXT_SHR))
+                    << (2 * compressedFieldSizeBits - shiftRight);
+        }
+    }
+
+    else if (delta + shiftRight >= 3 * compressedFieldSizeBits &&
+             delta + shiftRight < 4 * compressedFieldSizeBits) {
+        *out = static_cast<UncompressedType>(in[0]) >> shiftRight;
+        *out |= static_cast<UncompressedType>(in[1]) << (compressedFieldSizeBits - shiftRight);
+        *out |= static_cast<UncompressedType>(in[2]) << (2 * compressedFieldSizeBits - shiftRight);
+        in += 3;
+
+        if (delta + shiftRight > 3 * compressedFieldSizeBits) {
+            const uint16_t NEXT_SHR = delta + shiftRight - 3 * compressedFieldSizeBits;
+            *out |= static_cast<UncompressedType>((*in) % (1U << NEXT_SHR))
+                    << (3 * compressedFieldSizeBits - shiftRight);
+        }
+    }
+
+    else if (delta + shiftRight >= 4 * compressedFieldSizeBits) {
+        *out = static_cast<UncompressedType>(in[0]) >> shiftRight;
+        *out |= static_cast<UncompressedType>(in[1]) << (compressedFieldSizeBits - shiftRight);
+        *out |= static_cast<UncompressedType>(in[2]) << (2 * compressedFieldSizeBits - shiftRight);
+        *out |= static_cast<UncompressedType>(in[3]) << (3 * compressedFieldSizeBits - shiftRight);
+        in += 4;
+
+        if (delta + shiftRight > 4 * compressedFieldSizeBits) {
+            const uint16_t NEXT_SHR = delta + shiftRight - 4 * compressedFieldSizeBits;
+            *out |= static_cast<UncompressedType>((*in) % (1U << NEXT_SHR))
+                    << (4 * compressedFieldSizeBits - shiftRight);
+        }
+    }
+}
+
+template<std::integral CompressedType, IntegerBitpackingType UncompressedType>
+void packSingleImpl(const UncompressedType in, CompressedType* __restrict& out, uint16_t delta,
+    uint16_t shiftLeft, UncompressedType mask) {
+    static_assert(sizeof(UncompressedType) <= 4 * sizeof(CompressedType));
+
+    static constexpr size_t compressedFieldSizeBits = sizeof(CompressedType) * 8;
+
+    if (delta + shiftLeft < compressedFieldSizeBits) {
+
+        if (shiftLeft == 0) {
+            out[0] = static_cast<CompressedType>(in & mask);
+        } else {
+            out[0] |= static_cast<CompressedType>((in & mask) << shiftLeft);
+        }
+
+    } else if (delta + shiftLeft >= compressedFieldSizeBits &&
+               delta + shiftLeft < 2 * compressedFieldSizeBits) {
+
+        if (shiftLeft == 0) {
+            out[0] = static_cast<CompressedType>(in & mask);
+        } else {
+            out[0] |= static_cast<CompressedType>((in & mask) << shiftLeft);
+        }
+        ++out;
+
+        if (delta + shiftLeft > compressedFieldSizeBits) {
+            *out =
+                static_cast<CompressedType>((in & mask) >> (compressedFieldSizeBits - shiftLeft));
+        }
+    }
+
+    else if (delta + shiftLeft >= 2 * compressedFieldSizeBits &&
+             delta + shiftLeft < 3 * compressedFieldSizeBits) {
+
+        if (shiftLeft == 0) {
+            out[0] = static_cast<CompressedType>(in & mask);
+        } else {
+            out[0] |= static_cast<CompressedType>(in << shiftLeft);
+        }
+
+        out[1] = static_cast<CompressedType>((in & mask) >> (compressedFieldSizeBits - shiftLeft));
+        out += 2;
+
+        if (delta + shiftLeft > 2 * compressedFieldSizeBits) {
+            *out = static_cast<CompressedType>(
+                (in & mask) >> (2 * compressedFieldSizeBits - shiftLeft));
+        }
+    }
+
+    else if (delta + shiftLeft >= 3 * compressedFieldSizeBits &&
+             delta + shiftLeft < 4 * compressedFieldSizeBits) {
+        if (shiftLeft == 0) {
+            out[0] = static_cast<CompressedType>(in & mask);
+        } else {
+            out[0] |= static_cast<CompressedType>(in << shiftLeft);
+        }
+
+        out[1] = static_cast<CompressedType>((in & mask) >> (compressedFieldSizeBits - shiftLeft));
+        out[2] =
+            static_cast<CompressedType>((in & mask) >> (2 * compressedFieldSizeBits - shiftLeft));
+        out += 3;
+
+        if (delta + shiftLeft > 3 * compressedFieldSizeBits) {
+            *out = static_cast<CompressedType>(
+                (in & mask) >> (3 * compressedFieldSizeBits - shiftLeft));
+        }
+    }
+
+    else if (delta + shiftLeft >= 4 * compressedFieldSizeBits) {
+        if (shiftLeft == 0) {
+            out[0] = static_cast<CompressedType>(in & mask);
+        } else {
+            out[0] |= static_cast<CompressedType>(in << shiftLeft);
+        }
+        out[1] = static_cast<CompressedType>((in & mask) >> (compressedFieldSizeBits - shiftLeft));
+        out[2] =
+            static_cast<CompressedType>((in & mask) >> (2 * compressedFieldSizeBits - shiftLeft));
+        out[3] =
+            static_cast<CompressedType>((in & mask) >> (3 * compressedFieldSizeBits - shiftLeft));
+        out += 4;
+
+        if (delta + shiftLeft > 4 * compressedFieldSizeBits) {
+            *out = static_cast<CompressedType>(
+                (in & mask) >> (4 * compressedFieldSizeBits - shiftLeft));
+        }
+    }
+}
+
+template<IntegerBitpackingType UncompressedType>
+    requires(sizeof(UncompressedType) >= sizeof(uint32_t))
+void SingleValuePacker<UncompressedType>::unpackSingle(const uint32_t* __restrict& srcCursor,
+    UncompressedType* __restrict dst, uint16_t bitWidth, size_t srcOffset) {
+    const size_t shiftRight = srcOffset * bitWidth % (sizeof(uint32_t) * 8);
+    unpackSingleImpl(srcCursor, dst, bitWidth, shiftRight);
+}
+
+template<IntegerBitpackingType UncompressedType>
+    requires(sizeof(UncompressedType) < sizeof(uint32_t))
+void SingleValuePacker<UncompressedType>::unpackSingle(const uint8_t* __restrict& srcCursor,
+    UncompressedType* __restrict dst, uint16_t bitWidth, size_t srcOffset) {
+    const size_t shiftRight = srcOffset * bitWidth % (sizeof(uint8_t) * 8);
+    unpackSingleImpl(srcCursor, dst, bitWidth, shiftRight);
+}
+
+template<IntegerBitpackingType UncompressedType>
+    requires(sizeof(UncompressedType) >= sizeof(uint32_t))
+void SingleValuePacker<UncompressedType>::packSingle(const UncompressedType src,
+    uint32_t* __restrict& dstCursor, uint16_t bitWidth, size_t dstOffset) {
+    const size_t shiftLeft = dstOffset * bitWidth % (sizeof(uint32_t) * 8);
+    packSingleImpl(src, dstCursor, bitWidth, shiftLeft,
+        common::BitmaskUtils::all1sMaskForLeastSignificantBits<UncompressedType>(bitWidth));
+}
+
+template<IntegerBitpackingType UncompressedType>
+    requires(sizeof(UncompressedType) < sizeof(uint32_t))
+void SingleValuePacker<UncompressedType>::packSingle(const UncompressedType src,
+    uint8_t* __restrict& dstCursor, uint16_t bitWidth, size_t dstOffset) {
+    const size_t shiftLeft = dstOffset * bitWidth % (sizeof(uint8_t) * 8);
+    packSingleImpl(src, dstCursor, bitWidth, shiftLeft,
+        common::BitmaskUtils::all1sMaskForLeastSignificantBits<UncompressedType>(bitWidth));
+}
+
+template struct SingleValuePacker<common::int128_t>;
+template struct SingleValuePacker<uint64_t>;
+template struct SingleValuePacker<uint32_t>;
+template struct SingleValuePacker<uint16_t>;
+template struct SingleValuePacker<uint8_t>;
+} // namespace kuzu::storage

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -492,7 +492,7 @@ void IntegerBitpacking<T>::getValues(const uint8_t* chunkStart, uint8_t pos, uin
     for (size_t i = pos; i < maxReadIndex; i++) {
         // Always use unsigned version of unpacker to prevent sign-bit filling when right shifting
         U& out = reinterpret_cast<U*>(dst)[i - pos];
-        BitpackingUtils<U>::unpackSingle(readCursor, &out, header.bitWidth, i);
+        readCursor = BitpackingUtils<U>::unpackSingle(readCursor, &out, header.bitWidth, i);
 
         if (header.hasNegative && header.bitWidth > 0) {
             SignExtend<T, U, 1>((uint8_t*)&out, header.bitWidth);
@@ -509,7 +509,7 @@ void IntegerBitpacking<T>::packPartialChunk(const U* srcBuffer, uint8_t* dstBuff
     BitpackInfo<T> info, size_t numValuesToPack) const {
     uint8_t* dstCursor = dstBuffer;
     for (size_t i = 0; i < numValuesToPack; ++i) {
-        BitpackingUtils<U>::packSingle(srcBuffer[i], dstCursor, info.bitWidth, i);
+        dstCursor = BitpackingUtils<U>::packSingle(srcBuffer[i], dstCursor, info.bitWidth, i);
     }
 }
 

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -299,9 +299,7 @@ void ConstantCompression::decompressValues(uint8_t* dstBuffer, uint64_t dstOffse
             std::fill(reinterpret_cast<uint64_t*>(start), reinterpret_cast<uint64_t*>(end),
                 metadata.min.get<uint64_t>());
         },
-        [&]<typename T>
-            requires(numeric_utils::IsIntegral<T> || std::floating_point<T>)
-        (T) {
+        [&]<typename T> requires(numeric_utils::IsIntegral<T> || std::floating_point<T>)(T) {
             std::fill(reinterpret_cast<T*>(start), reinterpret_cast<T*>(end),
                 metadata.min.get<T>());
         },
@@ -501,12 +499,10 @@ void IntegerBitpacking<T>::getValues(const uint8_t* chunkStart, uint8_t pos, uin
     const size_t maxReadIndex = pos + numValuesToRead;
     KU_ASSERT(maxReadIndex <= CHUNK_SIZE);
 
-    const auto* readCursor =
-        BitpackingUtils<U>::getInitialSrcCursor(chunkStart, header.bitWidth, pos);
     for (size_t i = pos; i < maxReadIndex; i++) {
         // Always use unsigned version of unpacker to prevent sign-bit filling when right shifting
         U& out = reinterpret_cast<U*>(dst)[i - pos];
-        readCursor = BitpackingUtils<U>::unpackSingle(readCursor, &out, header.bitWidth, i);
+        BitpackingUtils<U>::unpackSingle(chunkStart, &out, header.bitWidth, i);
 
         if (header.hasNegative && header.bitWidth > 0) {
             SignExtend<T, U, 1>((uint8_t*)&out, header.bitWidth);
@@ -521,11 +517,8 @@ void IntegerBitpacking<T>::getValues(const uint8_t* chunkStart, uint8_t pos, uin
 template<IntegerBitpackingType T>
 void IntegerBitpacking<T>::packPartialChunk(const U* srcBuffer, uint8_t* dstBuffer, size_t posInDst,
     BitpackInfo<T> info, size_t numValuesToPack) const {
-    uint8_t* dstCursor =
-        BitpackingUtils<U>::getInitialSrcCursor(dstBuffer, info.bitWidth, posInDst);
     for (size_t i = 0; i < numValuesToPack; ++i) {
-        dstCursor =
-            BitpackingUtils<U>::packSingle(srcBuffer[i], dstCursor, info.bitWidth, i + posInDst);
+        BitpackingUtils<U>::packSingle(srcBuffer[i], dstBuffer, info.bitWidth, i + posInDst);
     }
 }
 

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -512,16 +512,16 @@ void IntegerBitpacking<T>::getValues(const uint8_t* chunkStart, uint8_t pos, uin
 template<IntegerBitpackingType T>
 template<bool offsetNonZero>
 void IntegerBitpacking<T>::packPartialChunk(U* srcBuffer, uint8_t* dstBuffer, BitpackInfo<T> info,
-    size_t remainingValues) const {
+    size_t numValuesToPack) const {
     if constexpr (offsetNonZero) {
-        for (auto i = 0u; i < remainingValues; i++) {
+        for (auto i = 0u; i < numValuesToPack; i++) {
             srcBuffer[i] = (U)((T)srcBuffer[i] - info.offset);
         }
-        memset(srcBuffer + remainingValues, 0, CHUNK_SIZE - remainingValues);
+        memset(srcBuffer + numValuesToPack, 0, CHUNK_SIZE - numValuesToPack);
     }
 
     const auto bitWidth = info.bitWidth;
-    const size_t outSize = ceilDiv<size_t>(remainingValues * bitWidth, 8);
+    const size_t outSize = ceilDiv<size_t>(numValuesToPack * bitWidth, 8);
     uint8_t outChunk[CHUNK_SIZE * sizeof(U) / sizeof(uint8_t)];
     KU_ASSERT(outSize >= 1 && outSize <= CHUNK_SIZE * sizeof(U));
     outChunk[outSize - 1] = 0;

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -462,13 +462,13 @@ void IntegerBitpacking<T>::setValuesFromUncompressed(const uint8_t* srcBuffer, o
     // non-zero offset However we don't care about the value stored for null values
     // Currently they will be mangled by storage+recovery (underflow in the subtraction
     // below)
-    KU_ASSERT(
-        numValues == std::ranges::count_if(std::ranges::iota_view{posInSrc, posInSrc + numValues},
-                         [srcBuffer, &metadata, nullMask](offset_t i) {
-                             auto value = reinterpret_cast<const T*>(srcBuffer)[i];
-                             return (nullMask && nullMask->isNull(i)) ||
-                                    canUpdateInPlace(std::span(&value, 1), metadata);
-                         }));
+    KU_ASSERT(numValues == static_cast<offset_t>(std::ranges::count_if(
+                               std::ranges::iota_view{posInSrc, posInSrc + numValues},
+                               [srcBuffer, &metadata, nullMask](offset_t i) {
+                                   auto value = reinterpret_cast<const T*>(srcBuffer)[i];
+                                   return (nullMask && nullMask->isNull(i)) ||
+                                          canUpdateInPlace(std::span(&value, 1), metadata);
+                               })));
 
     // Data can be considered to be stored in aligned chunks of 32 values
     // with a size of 32 * bitWidth bits,

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -488,11 +488,11 @@ void IntegerBitpacking<T>::getValues(const uint8_t* chunkStart, uint8_t pos, uin
     KU_ASSERT(maxReadIndex <= CHUNK_SIZE);
 
     const auto* readCursor =
-        bitpacking_utils::getInitialSrcCursor<U>(chunkStart, header.bitWidth, pos);
+        BitpackingUtils<U>::getInitialSrcCursor(chunkStart, header.bitWidth, pos);
     for (size_t i = pos; i < maxReadIndex; i++) {
         // Always use unsigned version of unpacker to prevent sign-bit filling when right shifting
         U& out = reinterpret_cast<U*>(dst)[i - pos];
-        SingleValuePacker<U>::unpackSingle(readCursor, &out, header.bitWidth, i);
+        BitpackingUtils<U>::unpackSingle(readCursor, &out, header.bitWidth, i);
 
         if (header.hasNegative && header.bitWidth > 0) {
             SignExtend<T, U, 1>((uint8_t*)&out, header.bitWidth);
@@ -507,9 +507,9 @@ void IntegerBitpacking<T>::getValues(const uint8_t* chunkStart, uint8_t pos, uin
 template<IntegerBitpackingType T>
 void IntegerBitpacking<T>::packPartialChunk(const U* srcBuffer, uint8_t* dstBuffer,
     BitpackInfo<T> info, size_t numValuesToPack) const {
-    auto* outCursor = bitpacking_utils::castCompressedCursor<U>(dstBuffer);
+    uint8_t* dstCursor = dstBuffer;
     for (size_t i = 0; i < numValuesToPack; ++i) {
-        SingleValuePacker<U>::packSingle(srcBuffer[i], outCursor, info.bitWidth, i);
+        BitpackingUtils<U>::packSingle(srcBuffer[i], dstCursor, info.bitWidth, i);
     }
 }
 

--- a/src/storage/compression/compression.cpp
+++ b/src/storage/compression/compression.cpp
@@ -299,7 +299,9 @@ void ConstantCompression::decompressValues(uint8_t* dstBuffer, uint64_t dstOffse
             std::fill(reinterpret_cast<uint64_t*>(start), reinterpret_cast<uint64_t*>(end),
                 metadata.min.get<uint64_t>());
         },
-        [&]<typename T> requires(numeric_utils::IsIntegral<T> || std::floating_point<T>)(T) {
+        [&]<typename T>
+            requires(numeric_utils::IsIntegral<T> || std::floating_point<T>)
+        (T) {
             std::fill(reinterpret_cast<T*>(start), reinterpret_cast<T*>(end),
                 metadata.min.get<T>());
         },

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -154,7 +154,7 @@ TEST(CompressionTests, IntegerPackingTest64SetValuesFromUncompressed) {
 TEST(CompressionTests, IntegerPackingTest128WorksOnNonZeroBuffer) {
     std::vector<int128_t> src(128);
     for (size_t i = 0; i < src.size(); ++i) {
-        src[i] = (int128_t(1) << 125) + int128_t(i);
+        src[i] = (int128_t(1) << 125) + int128_t{(uint32_t)i};
     }
     auto alg = IntegerBitpacking<int128_t>();
     std::vector<uint8_t> dest(sizeof(int128_t) * src.size(), 0xff);

--- a/test/storage/compression_test.cpp
+++ b/test/storage/compression_test.cpp
@@ -126,6 +126,13 @@ TEST(CompressionTests, IntegerPackingTest128AllPositive) {
     test_compression(alg, src, false);
 }
 
+TEST(CompressionTests, IntegerPackingTest128SignBitFillingDoesNotBreakUnpacking) {
+    std::vector<kuzu::common::int128_t> src(128, 0b1111);
+
+    auto alg = IntegerBitpacking<kuzu::common::int128_t>();
+    test_compression(alg, src, false);
+}
+
 TEST(CompressionTests, IntegerPackingTest128Negative) {
     std::vector<kuzu::common::int128_t> src(101);
 


### PR DESCRIPTION
# Description

#2083

Reworked single-value bitpacking/unpacking for int128 to work for all integral types.

Used the above to allow packing of a number of values per page that isn't a multiple of 32 (by packing individual values at the end of each page).

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).