### PR TITLE
Use 8-byte atomics in the eviction queue

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,7 +27,9 @@ set(KUZU_LIBRARIES antlr4_cypher antlr4_runtime brotlidec brotlicommon fast_floa
 if(NOT WIN32)
         set(KUZU_LIBRARIES dl ${KUZU_LIBRARIES})
 endif()
-if(NOT MSVC AND NOT APPLE)
+# Seems to be needed for clang on linux only
+# for compiling std::atomic<T>::compare_exchange_weak
+if (NOT APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         set(KUZU_LIBRARIES atomic ${KUZU_LIBRARIES})
 endif()
 if (ENABLE_BACKTRACES)

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -31,7 +31,7 @@ public:
     }
 
     inline bool operator==(const EvictionCandidate& other) const {
-        return fileIdx == other.fileIdx && pageIdx == other.pageIdx && pageState == other.pageState;
+        return fileIdx == other.fileIdx && pageIdx == other.pageIdx;
     }
 
     // Returns false if the candidate was not empty, or if another thread set the value first
@@ -39,21 +39,20 @@ public:
 
     uint32_t fileIdx = UINT32_MAX;
     common::page_idx_t pageIdx = common::INVALID_PAGE_IDX;
-    PageState* pageState = nullptr;
 };
 
 // A circular buffer queue storing eviction candidates
 // One candidate should be stored for each page currently in memory
 class EvictionQueue {
     static constexpr EvictionCandidate EMPTY =
-        EvictionCandidate{UINT32_MAX, common::INVALID_PAGE_IDX, nullptr};
+        EvictionCandidate{UINT32_MAX, common::INVALID_PAGE_IDX};
 
 public:
     explicit EvictionQueue(uint64_t capacity)
         : insertCursor{0}, evictionCursor{0}, size{0}, capacity{capacity},
           data{std::make_unique<std::atomic<EvictionCandidate>[]>(capacity)} {}
 
-    bool insert(uint32_t fileIndex, common::page_idx_t pageIndex, PageState* pageStatel);
+    bool insert(uint32_t fileIndex, common::page_idx_t pageIndex);
 
     // Produces the next non-empty candidate to be tried for eviction
     // Note that it is still possible (though unlikely) for another thread

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -32,7 +32,6 @@ fn link_libraries() {
             println!("cargo:rustc-link-lib=dylib=c++");
         } else {
             println!("cargo:rustc-link-lib=dylib=stdc++");
-            println!("cargo:rustc-link-lib=dylib=atomic");
         }
 
         println!("cargo:rustc-link-lib=static=utf8proc");


### PR DESCRIPTION
The new eviction queue from #3620 seems to have slowed down `BufferManager::removeCandidatesForFile`, in some cases significantly.
This may be more apparent on systems where libatomic (or whatever is providing std::atomic for 16-byte values) was not compiled with `-mcx16`/`-march=x86-64-v2` (or later microarchitectures) for use of the native cmpxchg16b instruction for 16-byte atomics. I'm not sure, but the macos runner is running particularly slowly, and this may be the cause (*edit: this seems to give a roughly 2x improvement on the macos runner for the tests in debug mode, so it's probably just really slow in debug mode in general; switching to release sped things up significantly; I'll change that in a separate PR*).

This PR removes the page index from the EvictionCandidate to make it an 8-byte atomic instead, and just uses the file and page index to look up the PageState.
It also makes removeCandidatesForFile return early if the queue is empty to minimize the cost of clearing files which haven't been used.