### PR TITLE
Rust multithreaded tests

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,6 +54,7 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
+      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       CLANGD_DIAGNOSTIC_JOBS: 32
       CLANGD_DIAGNOSTIC_INSTANCES: 6
@@ -108,7 +109,7 @@ jobs:
           KUZU_SHARED: 1
           KUZU_INCLUDE_DIR: ${{ github.workspace }}/build/release/src
           KUZU_LIBRARY_DIR: ${{ github.workspace }}/build/release/src
-        run: cargo test --locked --features arrow -- --test-threads=1
+        run: cargo test --profile=relwithdebinfo --locked --features arrow -- --test-threads=12
 
   code-coverage:
     name: code coverage
@@ -182,6 +183,7 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       CARGO_BUILD_JOBS: 32
+      CMAKE_BUILD_PARALLEL_LEVEL: 32
       CC: gcc
       CXX: g++
     steps:
@@ -189,8 +191,7 @@ jobs:
 
       - name: Rust test
         working-directory: tools/rust_api
-        run: |
-          cargo test --locked --features arrow -- --test-threads=1
+        run: cargo test --profile=relwithdebinfo --locked --features arrow -- --test-threads=12
 
       - name: Rust example
         working-directory: examples/rust
@@ -236,6 +237,7 @@ jobs:
     runs-on: kuzu-self-hosted-testing
     env:
       NUM_THREADS: 32
+      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       CC: clang
       CXX: clang++
@@ -286,7 +288,7 @@ jobs:
           KUZU_SHARED: 1
           KUZU_INCLUDE_DIR: ${{ github.workspace }}/build/release/src
           KUZU_LIBRARY_DIR: ${{ github.workspace }}/build/release/src
-        run: cargo test --locked --features arrow -- --test-threads=1
+        run: cargo test --profile=relwithdebinfo --locked --features arrow -- --test-threads=12
 
   msvc-build-test:
     name: msvc build & test
@@ -297,6 +299,7 @@ jobs:
       CARGO_TARGET_DIR: ${{ github.workspace }}/rs
       CARGO_BUILD_JOBS: 18
       NUM_THREADS: 18
+      CMAKE_BUILD_PARALLEL_LEVEL: 18
       TEST_JOBS: 9
       WERROR: 0
       UW_S3_ACCESS_KEY_ID: ${{ secrets.UW_S3_ACCESS_KEY_ID }}
@@ -364,7 +367,7 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
           set CFLAGS=/MD
           set CXXFLAGS=/MD /std:c++20
-          cargo test --locked -- --test-threads=1
+          cargo test --profile=relwithdebinfo --locked -- --test-threads=12
 
       - name: Java test
         shell: cmd
@@ -382,7 +385,7 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
           set PATH=%PATH%;${{ github.workspace }}/build/release/src
-          cargo test --locked --features arrow -- --test-threads=1
+          cargo test --profile=relwithdebinfo --locked --features arrow -- --test-threads=12
 
 
   sanity-checks:
@@ -523,6 +526,7 @@ jobs:
     runs-on: self-hosted-mac-x64
     env:
       NUM_THREADS: 32
+      CMAKE_BUILD_PARALLEL_LEVEL: 32
       TEST_JOBS: 16
       GEN: Ninja
       UW_S3_ACCESS_KEY_ID: ${{ secrets.UW_S3_ACCESS_KEY_ID }}

--- a/.github/workflows/multiplatform-build-test.yml
+++ b/.github/workflows/multiplatform-build-test.yml
@@ -125,7 +125,7 @@ jobs:
         continue-on-error: true
         working-directory: tools/rust_api
         run: |
-          cargo test --release --features arrow -- --test-threads=1
+          cargo test --release --features arrow -- --test-threads=12
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example
@@ -230,7 +230,7 @@ jobs:
         continue-on-error: true
         working-directory: tools/rust_api
         run: |
-          cargo test --release --features arrow -- --test-threads=1
+          cargo test --release --features arrow -- --test-threads=12
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example
@@ -359,7 +359,7 @@ jobs:
           set OPENSSL_DIR=C:\Program Files\OpenSSL-Win64
           set CXXFLAGS=/std:c++20
           set CARGO_BUILD_JOBS=%NUMBER_OF_PROCESSORS%
-          cargo test --release --features arrow -- --test-threads=1
+          cargo test --release --features arrow -- --test-threads=12
           echo Rust test,%ERRORLEVEL% >> status.txt
 
       - name: Rust example
@@ -483,7 +483,7 @@ jobs:
         continue-on-error: true
         working-directory: tools/rust_api
         run: |
-          cargo test --release --features arrow -- --test-threads=1
+          cargo test --release --features arrow -- --test-threads=12
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example
@@ -630,7 +630,7 @@ jobs:
         continue-on-error: true
         working-directory: tools/rust_api
         run: |
-          cargo test --release --features arrow -- --test-threads=1
+          cargo test --release --features arrow -- --test-threads=12
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example
@@ -745,7 +745,7 @@ jobs:
         working-directory: tools/rust_api
         continue-on-error: true
         run: |
-          cargo test --release --features arrow -- --test-threads=1
+          cargo test --release --features arrow -- --test-threads=12
           echo "Rust test,$?" >> ../../status.txt
 
       - name: Rust example

--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,7 @@ pytest-debug: python-debug
 	cmake -E env PYTHONPATH=tools/python_api/build python3 -m pytest -vv tools/python_api/test
 
 rusttest: rust
-	cd tools/rust_api && cargo test --locked --all-features -- --test-threads=1
+	cd tools/rust_api && cargo test --profile=relwithdebinfo --locked --all-features -- --test-threads=12
 
 # Other misc build targets
 benchmark:

--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -45,3 +45,7 @@ arrow = ["dep:arrow"]
 
 [package.metadata.docs.rs]
 all-features = true
+
+[profile.relwithdebinfo]
+inherits = "release"
+debug = true

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -128,7 +128,7 @@ fn build_ffi(
     if bundled {
         build.define("KUZU_BUNDLED", None);
     }
-    if get_target() == "debug" {
+    if get_target() == "debug" || get_target() == "relwithdebinfo" {
         build.define("ENABLE_RUNTIME_CHECKS", "1");
     }
     if link_mode() == "static" {

--- a/tools/rust_api/src/connection.rs
+++ b/tools/rust_api/src/connection.rs
@@ -185,9 +185,6 @@ impl<'a> Connection<'a> {
 mod tests {
     use crate::{Connection, Database, SystemConfig, Value};
     use anyhow::{Error, Result};
-    // Note: Cargo runs tests in parallel by default, however kuzu does not support
-    // working with multiple databases in parallel.
-    // Tests can be run serially with `cargo test -- --test-threads=1` to work around this.
 
     #[test]
     fn test_connection_threads() -> Result<()> {

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -111,10 +111,6 @@ mod tests {
     use crate::connection::Connection;
     use crate::database::{Database, SystemConfig};
 
-    // Note: Cargo runs tests in parallel by default, however kuzu does not support
-    // working with multiple databases in parallel.
-    // Tests can be run serially with `cargo test -- --test-threads=1` to work around this.
-
     #[test]
     fn create_database() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -20,13 +20,6 @@
 //! # Ok(())
 //! # }
 //! ```
-//!
-//! ## Safety
-//!
-//! Generally, use of this API is safe - however creating multiple databases in the same
-//! scope is not considered safe.
-//! If you need to access multiple databases you will need to do so in separate processes.
-//!
 //! ## Building
 //!
 //! By default, the kuzu C++ library will be compiled from source and statically linked.

--- a/tools/rust_api/src/value.rs
+++ b/tools/rust_api/src/value.rs
@@ -1037,10 +1037,6 @@ mod tests {
     use time::macros::{date, datetime};
     use uuid::uuid;
 
-    // Note: Cargo runs tests in parallel by default, however kuzu does not support
-    // working with multiple databases in parallel.
-    // Tests can be run serially with `cargo test -- --test-threads=1` to work around this.
-
     macro_rules! type_tests {
         ($($name:ident: $value:expr,)*) => {
         $(


### PR DESCRIPTION
Since we've removed the logger (which did some non-thread-safe global operations) it's possible to run the rust tests in parallel. I also added a relwithdebinfo build profile for use in CI after noticing that the tests on the macos runner were running significantly slower than in release mode (on Linux its not as big of a difference, ~4s in release mode vs ~15s in debug mode, but on macos it was ~4s in release mode and ~600s in debug mode).

I also noticed that we weren't explicitly setting the build parallelism for the bundled cmake build in a few places (and auto-detection doesn't seem to be working on macos at least, so that was slowing down some builds as they were running single-threaded).