### PR TITLE
Skip removing page candidates in the Database destructor

### DIFF
--- a/src/include/storage/buffer_manager/bm_file_handle.h
+++ b/src/include/storage/buffer_manager/bm_file_handle.h
@@ -146,14 +146,6 @@ public:
         NON_VERSIONED_FILE = 1 // The file does not have any versioned pages in wal file.
     };
 
-    BMFileHandle(const std::string& path, uint8_t flags, BufferManager* bm,
-        common::PageSizeClass pageSizeClass, FileVersionedType fileVersionedType,
-        common::VirtualFileSystem* vfs, main::ClientContext* context);
-    // File handles are registered with the buffer manager and must not be moved or copied
-    DELETE_COPY_AND_MOVE(BMFileHandle);
-
-    ~BMFileHandle() override;
-
     // This function assumes the page is already LOCKED.
     inline void setLockedPageDirty(common::page_idx_t pageIdx) {
         KU_ASSERT(pageIdx < numPages);
@@ -186,6 +178,11 @@ public:
     uint32_t getFileIndex() const { return fileIndex; }
 
 private:
+    BMFileHandle(const std::string& path, uint8_t flags, BufferManager* bm, uint32_t fileIndex,
+        common::PageSizeClass pageSizeClass, FileVersionedType fileVersionedType,
+        common::VirtualFileSystem* vfs, main::ClientContext* context);
+    // File handles are registered with the buffer manager and must not be moved or copied
+    DELETE_COPY_AND_MOVE(BMFileHandle);
     inline PageState* getPageState(common::page_idx_t pageIdx) {
         KU_ASSERT(pageIdx < numPages);
         return &pageStates[pageIdx];

--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -194,23 +194,19 @@ public:
     void removePageFromFrameIfNecessary(BMFileHandle& fileHandle, common::page_idx_t pageIdx);
 
     // For files that are managed by BM, their FileHandles should be created through this function.
-    std::unique_ptr<BMFileHandle> getBMFileHandle(const std::string& filePath, uint8_t flags,
+    BMFileHandle* getBMFileHandle(const std::string& filePath, uint8_t flags,
         BMFileHandle::FileVersionedType fileVersionedType, common::VirtualFileSystem* vfs,
         main::ClientContext* context, common::PageSizeClass pageSizeClass = common::PAGE_4KB) {
-        return std::make_unique<BMFileHandle>(filePath, flags, this, pageSizeClass,
-            fileVersionedType, vfs, context);
+        fileHandles.emplace_back(std::unique_ptr<BMFileHandle>(new BMFileHandle(filePath, flags,
+            this, fileHandles.size(), pageSizeClass, fileVersionedType, vfs, context)));
+        return fileHandles.back().get();
     }
+
     inline common::frame_group_idx_t addNewFrameGroup(common::PageSizeClass pageSizeClass) {
         return vmRegions[pageSizeClass]->addNewFrameGroup();
     }
 
     inline uint64_t getUsedMemory() const { return usedMemory; }
-
-    // Not thread-safe
-    uint32_t addFileHandle(BMFileHandle& fileHandle) {
-        fileHandles.push_back(&fileHandle);
-        return fileHandles.size() - 1;
-    }
 
 private:
     static void verifySizeParams(uint64_t bufferPoolSize, uint64_t maxDBSize);
@@ -251,7 +247,7 @@ private:
     // Each VMRegion corresponds to a virtual memory region of a specific page size. Currently, we
     // hold two sizes of PAGE_4KB and PAGE_256KB.
     std::vector<std::unique_ptr<VMRegion>> vmRegions;
-    std::vector<BMFileHandle*> fileHandles;
+    std::vector<std::unique_ptr<BMFileHandle>> fileHandles;
 };
 
 } // namespace storage

--- a/src/include/storage/buffer_manager/memory_manager.h
+++ b/src/include/storage/buffer_manager/memory_manager.h
@@ -52,7 +52,7 @@ private:
     void freeBlock(common::page_idx_t pageIdx, std::span<uint8_t> buffer);
 
 private:
-    std::unique_ptr<BMFileHandle> fh;
+    BMFileHandle* fh;
     BufferManager* bm;
     common::page_offset_t pageSize;
     std::stack<common::page_idx_t> freePages;

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -68,10 +68,10 @@ public:
 template<typename T>
 class HashIndex final : public OnDiskHashIndex {
 public:
-    HashIndex(const DBFileIDAndName& dbFileIDAndName,
-        const std::shared_ptr<BMFileHandle>& fileHandle, OverflowFileHandle* overflowFileHandle,
-        DiskArrayCollection& diskArrays, uint64_t indexPos, BufferManager& bufferManager, WAL* wal,
-        const HashIndexHeader& indexHeaderForReadTrx, HashIndexHeader& indexHeaderForWriteTrx);
+    HashIndex(const DBFileIDAndName& dbFileIDAndName, BMFileHandle* fileHandle,
+        OverflowFileHandle* overflowFileHandle, DiskArrayCollection& diskArrays, uint64_t indexPos,
+        BufferManager& bufferManager, WAL* wal, const HashIndexHeader& indexHeaderForReadTrx,
+        HashIndexHeader& indexHeaderForWriteTrx);
 
     ~HashIndex() override;
 
@@ -92,7 +92,7 @@ public:
     void prepareRollback() override;
     bool checkpointInMemory() override;
     bool rollbackInMemory() override;
-    inline BMFileHandle* getFileHandle() const { return fileHandle.get(); }
+    inline BMFileHandle* getFileHandle() const { return fileHandle; }
 
 private:
     bool lookupInPersistentIndex(transaction::TransactionType trxType, Key key,
@@ -176,7 +176,7 @@ private:
     BufferManager& bm;
     WAL* wal;
     uint64_t headerPageIdx;
-    std::shared_ptr<BMFileHandle> fileHandle;
+    BMFileHandle* fileHandle;
     std::unique_ptr<DiskArray<Slot<T>>> pSlots;
     std::unique_ptr<DiskArray<Slot<T>>> oSlots;
     OverflowFileHandle* overflowFileHandle;
@@ -271,7 +271,7 @@ public:
     void rollbackInMemory();
     void prepareCommit();
     void prepareRollback();
-    BMFileHandle* getFileHandle() { return fileHandle.get(); }
+    BMFileHandle* getFileHandle() { return fileHandle; }
     OverflowFile* getOverflowFile() { return overflowFile.get(); }
 
     common::PhysicalTypeID keyTypeID() { return keyDataTypeID; }
@@ -281,7 +281,7 @@ public:
 private:
     bool hasRunPrepareCommit;
     common::PhysicalTypeID keyDataTypeID;
-    std::shared_ptr<BMFileHandle> fileHandle;
+    BMFileHandle* fileHandle;
     std::unique_ptr<OverflowFile> overflowFile;
     std::vector<std::unique_ptr<OnDiskHashIndex>> hashIndices;
     std::vector<HashIndexHeader> hashIndexHeadersForReadTrx;

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -41,8 +41,8 @@ public:
     }
 
     WAL& getWAL();
-    BMFileHandle* getDataFH() const { return dataFH.get(); }
-    BMFileHandle* getMetadataFH() const { return metadataFH.get(); }
+    BMFileHandle* getDataFH() const { return dataFH; }
+    BMFileHandle* getMetadataFH() const { return metadataFH; }
     DiskArrayCollection* getMetadataDAC() const { return metadataDAC.get(); }
     void initStatistics() {
         nodesStatisticsAndDeletedIDs->initTableStatisticsForWriteTrx();
@@ -57,8 +57,8 @@ public:
     bool compressionEnabled() const { return enableCompression; }
 
 private:
-    std::unique_ptr<BMFileHandle> initFileHandle(const std::string& filename,
-        common::VirtualFileSystem* vfs, main::ClientContext* context);
+    BMFileHandle* initFileHandle(const std::string& filename, common::VirtualFileSystem* vfs,
+        main::ClientContext* context);
 
     void loadTables(const catalog::Catalog& catalog, common::VirtualFileSystem* vfs,
         main::ClientContext* context);
@@ -74,8 +74,8 @@ private:
 private:
     std::string databasePath;
     bool readOnly;
-    std::unique_ptr<BMFileHandle> dataFH;
-    std::unique_ptr<BMFileHandle> metadataFH;
+    BMFileHandle* dataFH;
+    BMFileHandle* metadataFH;
     std::unique_ptr<DiskArrayCollection> metadataDAC;
     std::unique_ptr<NodesStoreStatsAndDeletedIDs> nodesStatisticsAndDeletedIDs;
     std::unique_ptr<RelsStoreStats> relsStatistics;

--- a/src/include/storage/storage_structure/overflow_file.h
+++ b/src/include/storage/storage_structure/overflow_file.h
@@ -103,7 +103,7 @@ public:
         return handles.back().get();
     }
 
-    inline BMFileHandle* getBMFileHandle() const { return fileHandle.get(); }
+    inline BMFileHandle* getBMFileHandle() const { return fileHandle; }
 
 private:
     void readFromDisk(transaction::TransactionType trxType, common::page_idx_t pageIdx,
@@ -126,7 +126,7 @@ private:
     StringOverflowFileHeader header;
     common::page_idx_t numPagesOnDisk;
     DBFileID dbFileID;
-    std::unique_ptr<BMFileHandle> fileHandle;
+    BMFileHandle* fileHandle;
     BufferManager* bufferManager;
     WAL* wal;
     std::atomic<common::page_idx_t> pageCounter;

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -77,7 +77,7 @@ private:
     // Tables need in memory checkpointing or rolling back.
     std::unordered_set<common::table_id_t> updatedTables;
     std::shared_ptr<common::BufferedFileWriter> bufferedWriter;
-    std::unique_ptr<BMFileHandle> shadowingFH;
+    BMFileHandle* shadowingFH;
     std::string directory;
     std::mutex mtx;
     BufferManager& bufferManager;

--- a/src/storage/buffer_manager/bm_file_handle.cpp
+++ b/src/storage/buffer_manager/bm_file_handle.cpp
@@ -17,18 +17,14 @@ WALPageIdxGroup::WALPageIdxGroup() {
 }
 
 BMFileHandle::BMFileHandle(const std::string& path, uint8_t flags, BufferManager* bm,
-    PageSizeClass pageSizeClass, FileVersionedType fileVersionedType,
+    uint32_t fileIndex, PageSizeClass pageSizeClass, FileVersionedType fileVersionedType,
     common::VirtualFileSystem* vfs, main::ClientContext* context)
     : FileHandle{path, flags, vfs, context}, fileVersionedType{fileVersionedType}, bm{bm},
       pageSizeClass{pageSizeClass}, pageStates{numPages, pageCapacity},
-      frameGroupIdxes{getNumPageGroups(), getNumPageGroups()}, fileIndex{bm->addFileHandle(*this)} {
+      frameGroupIdxes{getNumPageGroups(), getNumPageGroups()}, fileIndex{fileIndex} {
     for (auto i = 0u; i < frameGroupIdxes.size(); i++) {
         frameGroupIdxes[i] = bm->addNewFrameGroup(pageSizeClass);
     }
-}
-
-BMFileHandle::~BMFileHandle() {
-    bm->removeFilePagesFromFrames(*this);
 }
 
 page_idx_t BMFileHandle::addNewPageWithoutLock() {

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -328,10 +328,10 @@ uint64_t BufferManager::tryEvictPage(std::atomic<EvictionCandidate>& _candidate)
     // At this point, the page is LOCKED, and we have exclusive access to the eviction candidate.
     // Next, flush out the frame into the file page if the frame
     // is dirty. Finally remove the page from the frame and reset the page to EVICTED.
-    auto* fileHandle = fileHandles[candidate.fileIdx];
-    flushIfDirtyWithoutLock(*fileHandle, candidate.pageIdx);
-    auto numBytesFreed = fileHandle->getPageSize();
-    releaseFrameForPage(*fileHandle, candidate.pageIdx);
+    auto& fileHandle = *fileHandles[candidate.fileIdx];
+    flushIfDirtyWithoutLock(fileHandle, candidate.pageIdx);
+    auto numBytesFreed = fileHandle.getPageSize();
+    releaseFrameForPage(fileHandle, candidate.pageIdx);
     pageState.resetToEvicted();
     evictionQueue.clear(_candidate);
     return numBytesFreed;

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -105,10 +105,10 @@ private:
 };
 
 template<typename T>
-HashIndex<T>::HashIndex(const DBFileIDAndName& dbFileIDAndName,
-    const std::shared_ptr<BMFileHandle>& fileHandle, OverflowFileHandle* overflowFileHandle,
-    DiskArrayCollection& diskArrays, uint64_t indexPos, BufferManager& bufferManager, WAL* wal,
-    const HashIndexHeader& headerForReadTrx, HashIndexHeader& headerForWriteTrx)
+HashIndex<T>::HashIndex(const DBFileIDAndName& dbFileIDAndName, BMFileHandle* fileHandle,
+    OverflowFileHandle* overflowFileHandle, DiskArrayCollection& diskArrays, uint64_t indexPos,
+    BufferManager& bufferManager, WAL* wal, const HashIndexHeader& headerForReadTrx,
+    HashIndexHeader& headerForWriteTrx)
     : dbFileIDAndName{dbFileIDAndName}, bm{bufferManager}, wal{wal}, fileHandle(fileHandle),
       overflowFileHandle(overflowFileHandle),
       localStorage{std::make_unique<HashIndexLocalStorage<T>>(overflowFileHandle)},


### PR DESCRIPTION
Following up the issue mentioned in #3687, `EvictionQueue::removeCandidatesForFile` is somewhat slow, and running it on every open file when the database is destroyed slows things down noticeably (~200ms when I did a quick test creating an empty database, but probably more on DBs where data is in memory since it returns early once the eviction queue is empty). It should only be necessary when closing files if the BufferManager needs to continue being used, which is not the case when the Database is destroyed.
The same applies to removePageFromFrame since the memory region gets unmapped when the BufferManager is destroyed.

I don't particularly like this way of skipping the call, but the best alternative I can think of is to move the call out of the destructor and make it explicit when we remove files during normal database operations, but that will probably be harder to keep track of compared to automatic handling in the destructor.