### PR TITLE
Reduce initial capacity of ChunkedCSRHeader

### DIFF
--- a/benchmark/queries/ldbc-sf100/multi-rel/multi-rel-large-scan.benchmark
+++ b/benchmark/queries/ldbc-sf100/multi-rel/multi-rel-large-scan.benchmark
@@ -1,0 +1,4 @@
+-NAME multi-rel-large-scan
+-QUERY match (a:Person)-[]-(b) where a.birthday >= "1900-01-01" return COUNT(b);
+---- 1
+855649596

--- a/benchmark/queries/ldbc-sf100/multi-rel/multi-rel-lookup.benchmark
+++ b/benchmark/queries/ldbc-sf100/multi-rel/multi-rel-lookup.benchmark
@@ -1,0 +1,4 @@
+-NAME multi-rel-lookup
+-QUERY match (a:Person)-[]-(b) where a.ID='10027' return COUNT(b);
+---- 1
+6373

--- a/benchmark/queries/ldbc-sf100/multi-rel/multi-rel-small-scan.benchmark
+++ b/benchmark/queries/ldbc-sf100/multi-rel/multi-rel-small-scan.benchmark
@@ -1,0 +1,4 @@
+-NAME multi-rel-small-scan
+-QUERY match (a:Person)-[]-(b) where a.birthday >= "1990-01-01" return COUNT(b);
+---- 1
+7038217

--- a/src/include/storage/store/chunked_node_group.h
+++ b/src/include/storage/store/chunked_node_group.h
@@ -3,8 +3,8 @@
 #include "common/column_data_format.h"
 #include "common/constants.h"
 #include "common/copy_constructors.h"
-#include "storage/store/column_chunk_data.h"
 #include "common/types/internal_id_t.h"
+#include "storage/store/column_chunk_data.h"
 
 namespace kuzu {
 namespace storage {

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -31,6 +31,7 @@ bool ChunkedCSRHeader::sanityCheck() const {
 
 void ChunkedCSRHeader::copyFrom(const ChunkedCSRHeader& other) const {
     auto numValues = other.offset->getNumValues();
+    resizeForValues(numValues);
     memcpy(offset->getData(), other.offset->getData(), numValues * sizeof(offset_t));
     memcpy(length->getData(), other.length->getData(), numValues * sizeof(length_t));
     length->setNumValues(numValues);
@@ -38,6 +39,7 @@ void ChunkedCSRHeader::copyFrom(const ChunkedCSRHeader& other) const {
 }
 
 void ChunkedCSRHeader::fillDefaultValues(offset_t newNumValues) const {
+    resizeForValues(newNumValues);
     auto lastCSROffset = getEndCSROffset(length->getNumValues() - 1);
     for (auto i = length->getNumValues(); i < newNumValues; i++) {
         offset->setValue<offset_t>(lastCSROffset, i);


### PR DESCRIPTION
Small scans, particularly ones across many rel tables with many threads, end up spending much more time initializing the scan state's header chunks than actually scanning. Starting them small and letting them grow as necessary speeds up small scans without much extra cost for large ones

Fixes #3695 