### PR TITLE
Fix writing shared node groups to partially filled groups on disk in node batch insert

### DIFF
--- a/test/copy/multi_copy_test.cpp
+++ b/test/copy/multi_copy_test.cpp
@@ -101,6 +101,16 @@ TEST_F(MultiCopyTest, PartialFirstNodeGroup) {
     validate();
 }
 
+// Each thread should have ~3/4 of a node group in their
+// local node group, so the second one to write that to the shared group
+// will need to write twice before it can move its remaining nodes into the shared group
+// See https://github.com/kuzudb/kuzu/issues/3714
+TEST_F(MultiCopyTest, SharedWriteToExistingNodeGroup) {
+    copy(common::StorageConstants::NODE_GROUP_SIZE * 0.75);
+    copy(common::StorageConstants::NODE_GROUP_SIZE * systemConfig->maxNumThreads * 0.75);
+    validate();
+}
+
 // Tests that a second copy that copies a large number of node groups succeeds
 TEST_F(MultiCopyTest, MultipleNodeGroups) {
     copy(common::StorageConstants::NODE_GROUP_SIZE * 10.1);


### PR DESCRIPTION
Fixes #3714 

If every thread produces an incomplete node group, the shared node group will be used to write to the partially filled group on disk, which may need to write twice before the remaining tuples in the local node group can all be copied into the shared group.

I've also added a test that should be able to reproduce this with any number of threads.