### PR TITLE
Updated shell to only create one database object

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -277,14 +277,14 @@ int EmbeddedShell::processShellCommands(std::string lineStr) {
     return 0;
 }
 
-EmbeddedShell::EmbeddedShell(const std::string& databasePath, const SystemConfig& systemConfig,
+EmbeddedShell::EmbeddedShell(std::shared_ptr<Database> database, std::shared_ptr<Connection> conn,
     const char* pathToHistory) {
     path_to_history = pathToHistory;
     linenoiseHistoryLoad(path_to_history);
     linenoiseSetCompletionCallback(completion);
     linenoiseSetHighlightCallback(highlight);
-    database = std::make_unique<Database>(databasePath, systemConfig);
-    conn = std::make_unique<Connection>(database.get());
+    this->database = database;
+    this->conn = conn;
     globalConnection = conn.get();
     maxRowSize = defaultMaxRows;
     maxPrintWidth = 0; // Will be determined when printing

--- a/tools/shell/include/embedded_shell.h
+++ b/tools/shell/include/embedded_shell.h
@@ -12,7 +12,7 @@ namespace main {
 class EmbeddedShell {
 
 public:
-    EmbeddedShell(const std::string& databasePath, const SystemConfig& systemConfig,
+    EmbeddedShell(std::shared_ptr<Database> database, std::shared_ptr<Connection> conn,
         const char* pathToHistory);
 
     void run();
@@ -33,8 +33,8 @@ private:
     void setMaxWidth(const std::string& maxWidthString);
 
 private:
-    std::unique_ptr<Database> database;
-    std::unique_ptr<Connection> conn;
+    std::shared_ptr<Database> database;
+    std::shared_ptr<Connection> conn;
     const char* path_to_history;
     uint64_t maxRowSize;
     uint32_t maxPrintWidth;


### PR DESCRIPTION
# Description

The shell was creating two database objects which is now fixed.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).