### PR TITLE
Implement negative array index in list extract

### DIFF
--- a/src/include/function/list/functions/list_extract_function.h
+++ b/src/include/function/list/functions/list_extract_function.h
@@ -20,19 +20,21 @@ public:
         if (pos == 0) {
             throw common::RuntimeException("List extract takes 1-based position.");
         }
-        uint64_t upos = pos == -1 ? listEntry.size : pos;
-        if (listEntry.size < upos) {
-            throw common::RuntimeException("list_extract(list, index): index=" +
-                                           common::TypeUtils::toString(pos) + " is out of range.");
+        if ((pos > 0 && pos > listEntry.size) || (pos < 0 && pos < -(int64_t)listEntry.size)) {
+            throw common::RuntimeException(
+                common::stringFormat("list_extract(list, index): index={} is out of range.",
+                    common::TypeUtils::toString(pos)));
         }
-        if (listEntry.size == 0) {
-            return; // TODO(Xiyang/Ziyi): we should fix when extracting last element of list.
+        if (pos > 0) {
+            pos--;
+        } else {
+            pos = listEntry.size + pos;
         }
         auto listDataVector = common::ListVector::getDataVector(&listVector);
-        resultVector.setNull(resPos, listDataVector->isNull(listEntry.offset + upos - 1));
+        resultVector.setNull(resPos, listDataVector->isNull(listEntry.offset + pos));
         if (!resultVector.isNull(resPos)) {
             auto listValues =
-                common::ListVector::getListValuesWithOffset(&listVector, listEntry, upos - 1);
+                common::ListVector::getListValuesWithOffset(&listVector, listEntry, pos);
             resultVector.copyFromVectorData(reinterpret_cast<uint8_t*>(&result), listDataVector,
                 listValues);
         }

--- a/test/test_files/tinysnb/function/list.test
+++ b/test/test_files/tinysnb/function/list.test
@@ -147,8 +147,36 @@ Binder exception: Expression LIST_CREATION(a) has data type STRING[] but expecte
 [46,90]|[5.000000]|[False]|[1940-06-22]|[1911-08-20 02:32:21]|[48:24:11]
 [84,166]|[4.900000]|[False]|[1990-11-27]|[2023-02-21 13:25:30]|[3 years 2 days 13:02:00]
 
-
-
+-LOG ListExtractNegativeIdx
+-STATEMENT RETURN list_extract([5,2,8], -1)
+---- 1
+8
+-STATEMENT RETURN list_extract([5,2,8], -2)
+---- 1
+2
+-STATEMENT RETURN list_extract([5,2,8], -3)
+---- 1
+5
+-STATEMENT RETURN list_extract([5,2,8], -4)
+---- error
+Runtime exception: list_extract(list, index): index=-4 is out of range.
+-LOG ListExtractZeroIdx
+-STATEMENT RETURN list_extract([5,2,8], 0)
+---- error
+Runtime exception: List extract takes 1-based position.
+-LOG ListExtractPositiveIdx
+-STATEMENT RETURN list_extract([5,2,8], 1)
+---- 1
+5
+-STATEMENT RETURN list_extract([5,2,8], 2)
+---- 1
+2
+-STATEMENT RETURN list_extract([5,2,8], 3)
+---- 1
+8
+-STATEMENT RETURN list_extract([5,2,8], 4)
+---- error
+Runtime exception: list_extract(list, index): index=4 is out of range.
 -LOG ListExtractListOfINT64
 -STATEMENT MATCH (a:person) RETURN list_extract(a.workedHours, 1)
 ---- 8


### PR DESCRIPTION
# Description

This PR implements negative array index. Supports extracting array using negtaive index.

E.g. `[5,2,6][-2] => [2]`
Fixes #3700
