### PR TITLE
Deprecate CentOS 7 builder and restructure the build pipeline

### DIFF
--- a/.github/workflows/build-extensions.yml
+++ b/.github/workflows/build-extensions.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build-linux-extensions-x86_64:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos8
+    runs-on: kuzu-self-hosted-linux-building-x86_64
     steps:
       - uses: actions/checkout@v4
 
@@ -20,27 +20,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: kuzu-extensions_linux-x86_64
-          path: extension-artifacts/*.kuzu_extension
-
-  build-linux-extensions-x86_64-old:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos7
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build precompiled extensions
-        run: |
-          source /opt/rh/devtoolset-11/enable
-          make extension-release NUM_THREADS=$(nproc)
-
-      - name: Collect built artifacts
-        run: |
-          mkdir -p extension-artifacts
-          find extension -type f -name "*.kuzu_extension" -exec cp {} extension-artifacts \;
-
-      - name: Upload built artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: kuzu-extensions_linux_old-x86_64
           path: extension-artifacts/*.kuzu_extension
 
   build-linux-extensions-aarch64:
@@ -173,7 +152,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build-linux-extensions-x86_64
-      - build-linux-extensions-x86_64-old
       - build-linux-extensions-aarch64
       - build-linux-extensions-x86
       - build-mac-extensions-arm64
@@ -197,7 +175,6 @@ jobs:
       - name: Ensure extension directories
         run: |
           mkdir -p releases/$RELEASE_VERSION/linux_amd64
-          mkdir -p releases/$RELEASE_VERSION/linux_old_amd64
           mkdir -p releases/$RELEASE_VERSION/linux_arm64
           mkdir -p releases/$RELEASE_VERSION/linux_x86
           mkdir -p releases/$RELEASE_VERSION/osx_amd64
@@ -207,7 +184,6 @@ jobs:
       - name: Clear old artifacts
         run: |
           rm -rf releases/$RELEASE_VERSION/linux_amd64/*
-          rm -rf releases/$RELEASE_VERSION/linux_old_amd64/*
           rm -rf releases/$RELEASE_VERSION/linux_arm64/*
           rm -rf releases/$RELEASE_VERSION/linux_x86/*
           rm -rf releases/$RELEASE_VERSION/osx_amd64/*
@@ -218,7 +194,6 @@ jobs:
         run: |
           mkdir -p extension-artifacts
           mkdir -p extension-artifacts/linux_amd64
-          mkdir -p extension-artifacts/linux_old_amd64
           mkdir -p extension-artifacts/linux_arm64
           mkdir -p extension-artifacts/linux_x86
           mkdir -p extension-artifacts/osx_amd64
@@ -230,12 +205,6 @@ jobs:
         with:
           name: kuzu-extensions_linux-x86_64
           path: extension-artifacts/linux_amd64
-
-      - name: Download built artifacts for linux-old-x86_64
-        uses: actions/download-artifact@v4
-        with:
-          name: kuzu-extensions_linux_old-x86_64
-          path: extension-artifacts/linux_old_amd64
 
       - name: Download built artifacts for linux-aarch64
         uses: actions/download-artifact@v4
@@ -270,7 +239,6 @@ jobs:
       - name: Copy built artifacts
         run: |
           cp extension-artifacts/linux_amd64/*.kuzu_extension releases/$RELEASE_VERSION/linux_amd64
-          cp extension-artifacts/linux_old_amd64/*.kuzu_extension releases/$RELEASE_VERSION/linux_old_amd64
           cp extension-artifacts/linux_arm64/*.kuzu_extension releases/$RELEASE_VERSION/linux_arm64
           cp extension-artifacts/linux_x86/*.kuzu_extension releases/$RELEASE_VERSION/linux_x86
           cp extension-artifacts/osx_amd64/*.kuzu_extension releases/$RELEASE_VERSION/osx_amd64
@@ -283,7 +251,6 @@ jobs:
       - name: Set artifact permissions
         run: |
           chmod 755 releases/$RELEASE_VERSION/linux_amd64/*
-          chmod 755 releases/$RELEASE_VERSION/linux_old_amd64/*
           chmod 755 releases/$RELEASE_VERSION/linux_arm64/*
           chmod 755 releases/$RELEASE_VERSION/linux_x86/*
           chmod 755 releases/$RELEASE_VERSION/osx_amd64/*

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -6,7 +6,7 @@ jobs:
   build-python-package:
     runs-on: kuzu-self-hosted-linux-building-x86_64
     env:
-      PLATFORM: manylinux2014_x86_64
+      PLATFORM: manylinux_2_28_x86_64
     steps:
       - uses: actions/checkout@v4
 
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: kuzu-python-package
-          path: scripts/pip-package/wheelhouse/*.manylinux2014_x86_64.whl
+          path: scripts/pip-package/wheelhouse/*.manylinux_2_28_x86_64.whl
 
   generate-python-docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/gen-docs.yml
+++ b/.github/workflows/gen-docs.yml
@@ -4,7 +4,7 @@ on: workflow_dispatch
 
 jobs:
   build-python-package:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos7
+    runs-on: kuzu-self-hosted-linux-building-x86_64
     env:
       PLATFORM: manylinux2014_x86_64
     steps:
@@ -14,7 +14,6 @@ jobs:
         working-directory: scripts/pip-package/
         run: |
           mkdir wheelhouse
-          source /opt/rh/devtoolset-11/enable
           /opt/python/cp310-cp310/bin/python package_tar.py kuzu.tar.gz
           /opt/python/cp310-cp310/bin/pip wheel kuzu.tar.gz --no-deps -w wheelhouse/
           auditwheel repair wheelhouse/kuzu-*.whl -w wheelhouse/

--- a/.github/workflows/linux-java-workflow.yml
+++ b/.github/workflows/linux-java-workflow.yml
@@ -11,7 +11,6 @@ jobs:
 
       - name: Build Java lib for Linux
         run: |
-          source /opt/rh/devtoolset-11/enable
           make java NUM_THREADS=$(nproc)
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/linux-java-workflow.yml
+++ b/.github/workflows/linux-java-workflow.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-linux-java-x86_64:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos7
+    runs-on: kuzu-self-hosted-linux-building-x86_64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/linux-nodejs-workflow.yml
+++ b/.github/workflows/linux-nodejs-workflow.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Build Node.js native module
         working-directory: tools/nodejs_api/package
         run: |
-          source /opt/rh/devtoolset-11/enable
           npm i
 
       - name: Move Node.js native module

--- a/.github/workflows/linux-nodejs-workflow.yml
+++ b/.github/workflows/linux-nodejs-workflow.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-linux-nodejs-x86_64:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos7
+    runs-on: kuzu-self-hosted-linux-building-x86_64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/linux-precompiled-bin-workflow.yml
+++ b/.github/workflows/linux-precompiled-bin-workflow.yml
@@ -5,41 +5,8 @@ on:
   workflow_call:
 
 jobs:
-  build-precompiled-bin-x86_64-old:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos7
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build precompiled binaries
-        run: |
-          source /opt/rh/devtoolset-11/enable
-          make NUM_THREADS=$(nproc)
-          make install
-
-      - name: Collect artifacts
-        run: |
-          mv install/include/kuzu.h .
-          mv install/include/kuzu.hpp .
-          mv install/lib64/libkuzu.so .
-          mv install/bin/kuzu .
-
-      - name: Create tarball
-        run: |
-          tar -czvf libkuzu-linux-old_abi-x86_64.tar.gz kuzu.h kuzu.hpp libkuzu.so
-          tar -czvf kuzu_cli-linux-x86_64.tar.gz kuzu
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: libkuzu-linux-old_abi-x86_64
-          path: libkuzu-linux-old_abi-x86_64.tar.gz
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: kuzu_cli-linux-x86_64
-          path: kuzu_cli-linux-x86_64.tar.gz
-
   build-precompiled-bin-x86_64:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos8
+    runs-on: kuzu-self-hosted-linux-building-x86_64
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/linux-wheel-workflow.yml
+++ b/.github/workflows/linux-wheel-workflow.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-linux-wheels-x86_64:
-    runs-on: kuzu-self-hosted-linux-building-x86_64_centos7
+    runs-on: kuzu-self-hosted-linux-building-x86_64
     steps:
       - uses: actions/checkout@v4
 
@@ -24,13 +24,12 @@ jobs:
         working-directory: ./scripts/pip-package/
         run: |
           cp /home/runner/build_all_packages.sh .
-          source /opt/rh/devtoolset-11/enable
           ./build_all_packages.sh
 
       - uses: actions/upload-artifact@v4
         with:
           name: linux-wheels-x86_64
-          path: ./scripts/pip-package/wheelhouse/*manylinux2014_x86_64.whl
+          path: ./scripts/pip-package/wheelhouse/*manylinux2_28_x86_64.whl
 
   build-linux-wheels-aarch64:
     # Make sure this job runs on the larger self-hosted Linux ARM64 machine

--- a/.github/workflows/linux-wheel-workflow.yml
+++ b/.github/workflows/linux-wheel-workflow.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: linux-wheels-x86_64
-          path: ./scripts/pip-package/wheelhouse/*manylinux2_28_x86_64.whl
+          path: ./scripts/pip-package/wheelhouse/*manylinux_2_28_x86_64.whl
 
   build-linux-wheels-aarch64:
     # Make sure this job runs on the larger self-hosted Linux ARM64 machine

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.3.17")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.3.19")
 
 include_directories(src/include)
 

--- a/tools/python_api/requirements_dev.txt
+++ b/tools/python_api/requirements_dev.txt
@@ -2,7 +2,7 @@
 networkx~=3.0
 numpy~=1.26
 pandas
-polars
+polars~=0.20
 pyarrow>=15
 pybind11>=2.6.0
 pytest


### PR DESCRIPTION
# Description

CentOS 7 has reached EOL on June 30 2024. GitHub self-hosted runner also [no longer supports CentOS 7](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#linux). This makes it impractical to maintain the CentOS 7 based self-hosted builders. In this PR we deprecate the CentOS 7 builders in favor of AlmaLinux 8. This change also causes some compatibility changes for the pre-compiled binaries:

- The produced binaries now requires at least Red Hat 8 / Debian 10 / Ubuntu 20.04 to run. Older distros are not supported.
- All of the produced binaries now uses new ABI. The support for old C++ ABI has been deprecated.

# Infrastructure Update
https://github.com/kuzudb/ci-deployment-compose/commit/2db6d11ba1ee40406085d661e56306fc15049dbc

# Tests

Build pipeline: https://github.com/kuzudb/kuzu/actions/runs/9752815674
Extensions: https://github.com/kuzudb/kuzu/actions/runs/9753025445/job/26917603795
Documentation generation: https://github.com/kuzudb/kuzu/actions/runs/9752931541

# Change of docs
This should be merged with the next release: 
https://github.com/kuzudb/kuzu-docs/pull/173
