### PR TITLE
Fix data race in eviction queue

### DIFF
--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -44,10 +44,9 @@ public:
 // A circular buffer queue storing eviction candidates
 // One candidate should be stored for each page currently in memory
 class EvictionQueue {
+public:
     static constexpr EvictionCandidate EMPTY =
         EvictionCandidate{UINT32_MAX, common::INVALID_PAGE_IDX};
-
-public:
     explicit EvictionQueue(uint64_t capacity)
         : insertCursor{0}, evictionCursor{0}, size{0}, capacity{capacity},
           data{std::make_unique<std::atomic<EvictionCandidate>[]>(capacity)} {}


### PR DESCRIPTION
The candidate may be evicted by another thread between the first time it is checked (in `EvictionQueue::next`) and when it is loaded, in which case the pageState lookup will cause UB as the fileIdx will be out of bounds. 

After loading (and the check) it should be safe since even if the page is evicted in the background, we have a local copy of the candidate's data to safely look up the page state and the candidate will either be discarded for no longer being evictable according to the PageState, or get discarded in `tryEvictPage` once we notice it's already been evicted.

I also changed pagesEvicted to evictablePages for clarity, since they don't get evicted until the end of the function and the counter just tracks the number of candidates found.