### PR TITLE
Fix building on gcc 14

### DIFF
--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <algorithm>
+
 #include "catalog/catalog.h"
 #include "common/null_mask.h"
 #include "common/types/types.h"


### PR DESCRIPTION
A couple of missing includes, and as far as I can tell functions in templated classes with `std::conditional_t` in their type signature can't be declared in a header and defined in a `cpp` file (alternatively we could remove the `std::conditional_t` and make those types be template arguments of the class instead, which would presumably work).

Fixes #3738