### PR TITLE
Shell history and help flag improvements

### DIFF
--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -41,9 +41,9 @@ int main(int argc, char* argv[]) {
     }
     if (!inputDirFlag) {
         std::cerr << "Option '" + inputDirFlag.Name() + "' is required" << '\n';
-		std::cerr << parser;
-		return 1;
-	}
+        std::cerr << parser;
+        return 1;
+    }
 
     uint64_t bpSizeInMB = args::get(bpSizeInMBFlag);
     uint64_t bpSizeInBytes = -1u;

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -11,8 +11,7 @@ using namespace kuzu::common;
 
 int main(int argc, char* argv[]) {
     args::ArgumentParser parser("KuzuDB Shell");
-    args::Positional<std::string> inputDirFlag(parser, "databasePath", "Database path.",
-        args::Options::Required);
+    args::Positional<std::string> inputDirFlag(parser, "databasePath", "Database path.");
     args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
     args::ValueFlag<uint64_t> bpSizeInMBFlag(parser, "",
         "Size of buffer pool for default and large page sizes in megabytes", {'d', "defaultBPSize"},
@@ -24,15 +23,28 @@ int main(int argc, char* argv[]) {
     args::ValueFlag<std::string> historyPathFlag(parser, "", "Path to directory for shell history",
         {'p'});
     args::Flag version(parser, "version", "Display current database version", {'v', "version"});
+
     try {
         parser.ParseCLI(argc, argv);
-    } catch (std::exception& e) {
+    } catch (const args::Help&) {
+        std::cout << parser;
+        return 0;
+    } catch (const args::ParseError& e) {
         std::cerr << e.what() << '\n';
         std::cerr << parser;
         return 1;
     }
-    auto databasePath = args::get(inputDirFlag);
-    auto pathToHistory = args::get(historyPathFlag);
+
+    if (version) {
+        std::cout << "Kuzu " << KUZU_CMAKE_VERSION << '\n';
+        return 0;
+    }
+    if (!inputDirFlag) {
+        std::cerr << "Option '" + inputDirFlag.Name() + "' is required" << '\n';
+		std::cerr << parser;
+		return 1;
+	}
+
     uint64_t bpSizeInMB = args::get(bpSizeInMBFlag);
     uint64_t bpSizeInBytes = -1u;
     if (bpSizeInMB != -1u) {
@@ -45,19 +57,8 @@ int main(int argc, char* argv[]) {
     if (readOnlyMode) {
         systemConfig.readOnly = true;
     }
-    std::shared_ptr<Database> database = std::make_shared<Database>(databasePath, systemConfig);
-    std::shared_ptr<Connection> conn = std::make_shared<Connection>(database.get());
-    if (version) {
-        auto queryResult = conn->query("CALL db_version() RETURN version");
-        if (queryResult->isSuccess()) {
-            std::string dbVersion = queryResult->getNext()->getValue(0)->toString();
-            std::cout << "Kuzu " << dbVersion << '\n';
-            return 0;
-        } else {
-            std::cerr << "Unable to find current database version" << '\n';
-            return 1;
-        }
-    }
+
+    auto pathToHistory = args::get(historyPathFlag);
     if (!pathToHistory.empty() && pathToHistory.back() != '/') {
         pathToHistory += '/';
     }
@@ -66,6 +67,17 @@ int main(int argc, char* argv[]) {
         std::make_unique<LocalFileSystem>()->openFile(pathToHistory, O_CREAT);
     } catch (Exception& e) {
         std::cerr << "Invalid path to directory for history file" << '\n';
+        return 1;
+    }
+
+    auto databasePath = args::get(inputDirFlag);
+    std::shared_ptr<Database> database;
+    std::shared_ptr<Connection> conn;
+    try {
+        database = std::make_shared<Database>(databasePath, systemConfig);
+        conn = std::make_shared<Connection>(database.get());
+    } catch (Exception& e) {
+        std::cerr << e.what() << '\n';
         return 1;
     }
     std::cout << "Opened the database at path: " << databasePath << " in "

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -4,8 +4,10 @@ import pytest
 from conftest import ShellTest
 from test_helper import KUZU_VERSION, deleteIfExists
 
-def check_fails_without_db(flag):
+def check_fails_without_db(flag, arg=None):
     test = ShellTest().add_argument(flag)
+    if arg:
+        test.add_argument(arg)
     result = test.run()
     result.check_stderr("Option 'databasePath' is required")
 
@@ -35,11 +37,11 @@ def test_help(temp_db, flag) -> None:
     # database path not needed
     test = ShellTest().add_argument(flag)
     result = test.run()
-    result.check_stderr("KuzuDB Shell")
+    result.check_stdout("KuzuDB Shell")
     # with database path
     test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
-    result.check_stderr("KuzuDB Shell")
+    result.check_stdout("KuzuDB Shell")
 
 
 @pytest.mark.parametrize(
@@ -51,7 +53,8 @@ def test_help(temp_db, flag) -> None:
 )
 def test_default_bp_size(temp_db, flag) -> None:
     # fails without db path
-    check_fails_without_db(flag)
+    check_fails_without_db(flag, "1000")
+
     # empty flag argument
     test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
@@ -94,6 +97,7 @@ def test_read_only(temp_db, flag) -> None:
 
     # fails without db path
     check_fails_without_db(flag)
+    
     # test read only
     test = (
         ShellTest()
@@ -113,6 +117,9 @@ def test_read_only(temp_db, flag) -> None:
 
 
 def test_history_path(temp_db, history_path) -> None:
+    # fails without db path
+    check_fails_without_db("-p", history_path)
+
     # empty flag argument
     test = ShellTest().add_argument(temp_db).add_argument("-p")
     result = test.run()
@@ -122,11 +129,6 @@ def test_history_path(temp_db, history_path) -> None:
     test = ShellTest().add_argument(temp_db).add_argument("-p").add_argument("///////")
     result = test.run()
     result.check_stderr("Invalid path to directory for history file")
-    
-    # fails without db path
-    test = ShellTest().add_argument("-p").add_argument(history_path)
-    result = test.run()
-    result.check_stderr("Option 'databasePath' is required")
 
     # valid path, file doesn't exist
     test = (


### PR DESCRIPTION
# Description

- Fixed the handling of the help flag to not print the name of the command before printing the help menu
- Allow requesting version without supplying database path 

Fixes #3747 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).