### PR TITLE
Fix catalogExtension cast

### DIFF
--- a/src/include/extension/catalog_extension.h
+++ b/src/include/extension/catalog_extension.h
@@ -5,7 +5,7 @@
 namespace kuzu {
 namespace extension {
 
-class CatalogExtension : public catalog::Catalog {
+class KUZU_API CatalogExtension : public catalog::Catalog {
 public:
     CatalogExtension() : Catalog() {}
 


### PR DESCRIPTION
# Description

We used to forget to mark CatalogExtension as KUZU_API thus casting `duckdbCatalog` to `CatalogExtension` will cause dynamic_cast to fail.

Fixes #3754 