### PR TITLE
Skip scanning null lists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -249,7 +249,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.3.19")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.3.20")
 
 include_directories(src/include)
 

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -696,7 +696,8 @@ void Column::commitLocalChunkInPlace(ChunkState& state, const ChunkCollection& l
 }
 
 std::unique_ptr<ColumnChunkData> Column::getEmptyChunkForCommit(uint64_t capacity) {
-    return ColumnChunkFactory::createColumnChunkData(dataType.copy(), enableCompression, capacity);
+    return ColumnChunkFactory::createColumnChunkData(dataType.copy(), enableCompression, capacity,
+        true /*inMemory*/, nullColumn != nullptr /*hasNull*/);
 }
 
 // TODO: Pass state in to avoid access metadata.


### PR DESCRIPTION
Null lists may have junk data in their offset/size which may not be safe to scan as it could be outside the bounds of the data (or produce underflows when calculating the extents)

I also removed the null columns on the offset/size as its duplicate information (which should actually make the data accurately store zeroes for null values, and zero-length lists are safe, but it would be useful to eventually allow the main null column to be used for storing offset/size column values).