### PR TITLE
Fix rollback of index overflow file

### DIFF
--- a/src/storage/storage_structure/overflow_file.cpp
+++ b/src/storage/storage_structure/overflow_file.cpp
@@ -233,8 +233,10 @@ void OverflowFile::checkpointInMemory() {
 }
 
 void OverflowFile::rollbackInMemory() {
-    readFromDisk(TransactionType::READ_ONLY, HEADER_PAGE_IDX,
-        [&](auto* frame) { memcpy(&header, frame, sizeof(header)); });
+    if (fileHandle->getNumPages() > HEADER_PAGE_IDX) {
+        readFromDisk(TransactionType::READ_ONLY, HEADER_PAGE_IDX,
+            [&](auto* frame) { memcpy(&header, frame, sizeof(header)); });
+    }
     numPagesOnDisk = pageCounter = header.pages;
     for (auto i = 0u; i < handles.size(); i++) {
         auto& handle = handles[i];

--- a/src/storage/storage_structure/overflow_file.cpp
+++ b/src/storage/storage_structure/overflow_file.cpp
@@ -237,7 +237,7 @@ void OverflowFile::rollbackInMemory() {
         readFromDisk(TransactionType::READ_ONLY, HEADER_PAGE_IDX,
             [&](auto* frame) { memcpy(&header, frame, sizeof(header)); });
     }
-    numPagesOnDisk = pageCounter = header.pages;
+    pageCounter = header.pages = numPagesOnDisk;
     for (auto i = 0u; i < handles.size(); i++) {
         auto& handle = handles[i];
         handle->rollbackInMemory(header.cursors[i]);

--- a/test/test_files/transaction/basic.test
+++ b/test/test_files/transaction/basic.test
@@ -22,12 +22,12 @@ Connection already has an active transaction. Cannot start a transaction within 
 ---- 0
 
 -CASE RollbackWhenCloseDB
--STATEMENT CREATE NODE TABLE person(id int64, primary key(id));
+-STATEMENT CREATE NODE TABLE person(id string, primary key(id));
 ---- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
--STATEMENT CREATE (p:person {id: 10});
+-STATEMENT CREATE (p:person {id: 'Alice'});
 ---- ok
 -STATEMENT MATCH (p:person) return p.id;
 ---- 1
-10
+Alice

--- a/test/test_files/transaction/basic.test
+++ b/test/test_files/transaction/basic.test
@@ -20,3 +20,14 @@ PERSON|NODE|local(kuzu)|
 Connection already has an active transaction. Cannot start a transaction within another one. For concurrent multiple transactions, please open other connections.
 -STATEMENT CALL show_tables() return *;
 ---- 0
+
+-CASE RollbackWhenCloseDB
+-STATEMENT CREATE NODE TABLE person(id int64, primary key(id));
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (p:person {id: 10});
+---- ok
+-STATEMENT MATCH (p:person) return p.id;
+---- 1
+10


### PR DESCRIPTION
# Description

When rollback hash index overflow file in memory, the header page may not be flushed to disk yet, thus, we should avoid reading the header from disk in such case and reset the pageCounter.