### PR TITLE
Fix issue-3730

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -414,8 +414,9 @@ std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::Rel
         auto recursivePatternPredicate =
             expressionBinder.bindExpression(*recursivePatternInfo->whereExpression);
         for (auto& predicate : recursivePatternPredicate->splitOnAND()) {
-            auto expressionCollector = ExpressionCollector();
-            auto dependentVariableNames = expressionCollector.getDependentVariableNames(predicate);
+            auto collector = DependentVarNameCollector();
+            collector.visit(predicate);
+            auto dependentVariableNames = collector.getVarNames();
             auto dependOnNode = dependentVariableNames.contains(node->getUniqueName());
             auto dependOnRel = dependentVariableNames.contains(rel->getUniqueName());
             if (dependOnNode && dependOnRel) {

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -113,8 +113,9 @@ std::shared_ptr<Expression> ExpressionBinder::forceCast(
 }
 
 void validateAggregationExpressionIsNotNested(std::shared_ptr<Expression> expression) {
-    if (expression->expressionType != ExpressionType::AGGREGATE_FUNCTION || expression->getNumChildren() == 0) {
-        return ;
+    if (expression->expressionType != ExpressionType::AGGREGATE_FUNCTION ||
+        expression->getNumChildren() == 0) {
+        return;
     }
     auto collector = AggregateExprCollector();
     collector.visit(expression->getChild(0));

--- a/src/binder/expression_visitor.cpp
+++ b/src/binder/expression_visitor.cpp
@@ -10,11 +10,97 @@
 #include "function/list/vector_list_functions.h"
 #include "function/sequence/sequence_functions.h"
 #include "function/uuid/vector_uuid_functions.h"
+#include "common/exception/not_implemented.h"
 
 using namespace kuzu::common;
 
 namespace kuzu {
 namespace binder {
+
+void ExpressionVisitor::visitSwitch(std::shared_ptr<Expression> expr) {
+    switch (expr->expressionType) {
+    case ExpressionType::OR:
+    case ExpressionType::XOR:
+    case ExpressionType::AND:
+    case ExpressionType::NOT:
+    case ExpressionType::EQUALS:
+    case ExpressionType::NOT_EQUALS:
+    case ExpressionType::GREATER_THAN:
+    case ExpressionType::GREATER_THAN_EQUALS:
+    case ExpressionType::LESS_THAN:
+    case ExpressionType::LESS_THAN_EQUALS:
+    case ExpressionType::IS_NULL:
+    case ExpressionType::IS_NOT_NULL:
+    case ExpressionType::FUNCTION: {
+        visitFunctionExpr(expr);
+    } break ;
+    case ExpressionType::AGGREGATE_FUNCTION: {
+        visitAggFunctionExpr(expr);
+    } break ;
+    case ExpressionType::PROPERTY: {
+        visitPropertyExpr(expr);
+    } break ;
+    case ExpressionType::LITERAL: {
+        visitLiteralExpr(expr);
+    } break ;
+    case ExpressionType::VARIABLE: {
+        visitVariableExpr(expr);
+    } break ;
+    case ExpressionType::PATH: {
+        visitPathExpr(expr);
+    } break ;
+    case ExpressionType::PATTERN: {
+        visitNodeRelExpr(expr);
+    } break ;
+    case ExpressionType::PARAMETER: {
+        visitParamExpr(expr);
+    } break ;
+    case ExpressionType::SUBQUERY: {
+        visitSubqueryExpr(expr);
+    } break ;
+    case ExpressionType::CASE_ELSE: {
+        visitCaseExpr(expr);
+    } break ;
+    case ExpressionType::GRAPH: {
+        visitGraphExpr(expr);
+    } break ;
+    case ExpressionType::LAMBDA: {
+        visitLambdaExpr(expr);
+    } break ;
+        // LCOV_EXCL_START
+    default:
+        throw NotImplementedException("ExpressionVisitor::visitSwitch");
+        // LCOV_EXCL_STOP
+    }
+}
+
+void ExpressionVisitor::visit(std::shared_ptr<Expression> expr) {
+    visitChildren(*expr);
+    visitSwitch(expr);
+}
+
+void ExpressionVisitor::visitChildren(const Expression& expr) {
+    switch (expr.expressionType) {
+    case ExpressionType::CASE_ELSE: {
+        visitCaseExprChildren(expr);
+    } break;
+    default: {
+        for (auto& child : expr.getChildren()) {
+            visit(child);
+        }
+    }
+    }
+}
+
+void ExpressionVisitor::visitCaseExprChildren(const Expression& expr) {
+    auto& caseExpr = expr.constCast<CaseExpression>();
+    for (auto i = 0u; i < caseExpr.getNumCaseAlternatives(); ++i) {
+        auto caseAlternative = caseExpr.getCaseAlternative(i);
+        visit(caseAlternative->whenExpression);
+        visit(caseAlternative->thenExpression);
+    }
+    visit(caseExpr.getElseExpression());
+}
 
 expression_vector ExpressionChildrenCollector::collectChildren(const Expression& expression) {
     switch (expression.expressionType) {
@@ -42,6 +128,7 @@ expression_vector ExpressionChildrenCollector::collectChildren(const Expression&
     }
     }
 }
+
 
 expression_vector ExpressionChildrenCollector::collectCaseChildren(const Expression& expression) {
     expression_vector result;
@@ -141,47 +228,54 @@ bool ExpressionVisitor::isRandom(const Expression& expression) {
     return false;
 }
 
-bool ExpressionVisitor::satisfyAny(const Expression& expression,
-    const std::function<bool(const Expression&)>& condition) {
-    if (condition(expression)) {
-        return true;
+void DependentVarNameCollector::visitSubqueryExpr(std::shared_ptr<Expression> expr) {
+    auto& subqueryExpr = expr->constCast<SubqueryExpression>();
+    for (auto& node : subqueryExpr.getQueryGraphCollection()->getQueryNodes()) {
+        varNames.insert(node->getUniqueName());
     }
-    for (auto& child : ExpressionChildrenCollector::collectChildren(expression)) {
-        if (satisfyAny(*child, condition)) {
-            return true;
-        }
+    if (subqueryExpr.hasWhereExpression()) {
+        visit(subqueryExpr.getWhereExpression());
     }
-    return false;
 }
 
-std::unordered_set<std::string> ExpressionCollector::getDependentVariableNames(
-    const std::shared_ptr<Expression>& expression) {
-    KU_ASSERT(expressions.empty());
-    collectExpressionsInternal(expression, [&](const Expression& expression) {
-        return expression.expressionType == ExpressionType::PROPERTY ||
-               expression.expressionType == ExpressionType::PATTERN ||
-               expression.expressionType == ExpressionType::VARIABLE;
-    });
-    std::unordered_set<std::string> result;
-    for (auto& expr : expressions) {
-        if (expr->expressionType == ExpressionType::PROPERTY) {
-            auto property = (PropertyExpression*)expr.get();
-            result.insert(property->getVariableName());
-        } else {
-            result.insert(expr->getUniqueName());
-        }
-    }
-    return result;
+void DependentVarNameCollector::visitPropertyExpr(std::shared_ptr<Expression> expr) {
+    varNames.insert(expr->constCast<PropertyExpression>().getVariableName());
 }
 
-void ExpressionCollector::collectExpressionsInternal(const std::shared_ptr<Expression>& expression,
-    const std::function<bool(const Expression&)>& condition) {
-    if (condition(*expression)) {
-        expressions.push_back(expression);
-        return;
+void DependentVarNameCollector::visitNodeRelExpr(std::shared_ptr<Expression> expr) {
+    varNames.insert(expr->getUniqueName());
+    if (expr->getDataType().getLogicalTypeID() == LogicalTypeID::REL) {
+        auto& rel = expr->constCast<RelExpression>();
+        varNames.insert(rel.getSrcNodeName());
+        varNames.insert(rel.getDstNodeName());
     }
-    for (auto& child : ExpressionChildrenCollector::collectChildren(*expression)) {
-        collectExpressionsInternal(child, condition);
+}
+
+void DependentVarNameCollector::visitVariableExpr(std::shared_ptr<Expression> expr) {
+    varNames.insert(expr->getUniqueName());
+}
+
+void PropertyExprCollector::visitSubqueryExpr(std::shared_ptr<Expression> expr) {
+    auto& subqueryExpr = expr->constCast<SubqueryExpression>();
+    for (auto& rel : subqueryExpr.getQueryGraphCollection()->getQueryRels()) {
+        if (rel->isEmpty() || rel->getRelType() != QueryRelType::NON_RECURSIVE) {
+            // If a query rel is empty then it does not have an internal id property.
+            continue;
+        }
+        expressions.push_back(rel->getInternalIDProperty());
+    }
+    if (subqueryExpr.hasWhereExpression()) {
+        visit(subqueryExpr.getWhereExpression());
+    }
+}
+
+void PropertyExprCollector::visitPropertyExpr(std::shared_ptr<Expression> expr) {
+    expressions.push_back(expr);
+}
+
+void PropertyExprCollector::visitNodeRelExpr(std::shared_ptr<Expression> expr) {
+    for (auto& property : expr->constCast<NodeOrRelExpression>().getPropertyExprs()) {
+        expressions.push_back(property);
     }
 }
 

--- a/src/binder/expression_visitor.cpp
+++ b/src/binder/expression_visitor.cpp
@@ -7,10 +7,10 @@
 #include "binder/expression/rel_expression.h"
 #include "binder/expression/subquery_expression.h"
 #include "common/cast.h"
+#include "common/exception/not_implemented.h"
 #include "function/list/vector_list_functions.h"
 #include "function/sequence/sequence_functions.h"
 #include "function/uuid/vector_uuid_functions.h"
-#include "common/exception/not_implemented.h"
 
 using namespace kuzu::common;
 
@@ -33,40 +33,40 @@ void ExpressionVisitor::visitSwitch(std::shared_ptr<Expression> expr) {
     case ExpressionType::IS_NOT_NULL:
     case ExpressionType::FUNCTION: {
         visitFunctionExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::AGGREGATE_FUNCTION: {
         visitAggFunctionExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::PROPERTY: {
         visitPropertyExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::LITERAL: {
         visitLiteralExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::VARIABLE: {
         visitVariableExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::PATH: {
         visitPathExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::PATTERN: {
         visitNodeRelExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::PARAMETER: {
         visitParamExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::SUBQUERY: {
         visitSubqueryExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::CASE_ELSE: {
         visitCaseExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::GRAPH: {
         visitGraphExpr(expr);
-    } break ;
+    } break;
     case ExpressionType::LAMBDA: {
         visitLambdaExpr(expr);
-    } break ;
+    } break;
         // LCOV_EXCL_START
     default:
         throw NotImplementedException("ExpressionVisitor::visitSwitch");
@@ -128,7 +128,6 @@ expression_vector ExpressionChildrenCollector::collectChildren(const Expression&
     }
     }
 }
-
 
 expression_vector ExpressionChildrenCollector::collectCaseChildren(const Expression& expression) {
     expression_vector result;

--- a/src/binder/query/query_graph.cpp
+++ b/src/binder/query/query_graph.cpp
@@ -216,8 +216,9 @@ void QueryGraph::merge(const QueryGraph& other) {
 }
 
 bool QueryGraph::canProjectExpression(const std::shared_ptr<Expression>& expression) const {
-    auto expressionCollector = std::make_unique<ExpressionCollector>();
-    for (auto& variable : expressionCollector->getDependentVariableNames(expression)) {
+    auto collector = DependentVarNameCollector();
+    collector.visit(expression);
+    for (auto& variable : collector.getVarNames()) {
         if (!containsQueryNode(variable) && !containsQueryRel(variable)) {
             return false;
         }

--- a/src/include/binder/expression/case_expression.h
+++ b/src/include/binder/expression/case_expression.h
@@ -15,22 +15,24 @@ struct CaseAlternative {
 };
 
 class CaseExpression : public Expression {
+    static constexpr common::ExpressionType expressionType_ = common::ExpressionType::CASE_ELSE;
+
 public:
     CaseExpression(common::LogicalType dataType, std::shared_ptr<Expression> elseExpression,
         const std::string& name)
-        : Expression{common::ExpressionType::CASE_ELSE, std::move(dataType), name},
+        : Expression{expressionType_, std::move(dataType), name},
           elseExpression{std::move(elseExpression)} {}
 
-    inline void addCaseAlternative(std::shared_ptr<Expression> when,
+    void addCaseAlternative(std::shared_ptr<Expression> when,
         std::shared_ptr<Expression> then) {
         caseAlternatives.push_back(make_unique<CaseAlternative>(std::move(when), std::move(then)));
     }
-    inline size_t getNumCaseAlternatives() const { return caseAlternatives.size(); }
-    inline CaseAlternative* getCaseAlternative(size_t idx) const {
+    common::idx_t getNumCaseAlternatives() const { return caseAlternatives.size(); }
+    CaseAlternative* getCaseAlternative(common::idx_t idx) const {
         return caseAlternatives[idx].get();
     }
 
-    inline std::shared_ptr<Expression> getElseExpression() const { return elseExpression; }
+    std::shared_ptr<Expression> getElseExpression() const { return elseExpression; }
 
     std::string toStringInternal() const final;
 

--- a/src/include/binder/expression/case_expression.h
+++ b/src/include/binder/expression/case_expression.h
@@ -23,8 +23,7 @@ public:
         : Expression{expressionType_, std::move(dataType), name},
           elseExpression{std::move(elseExpression)} {}
 
-    void addCaseAlternative(std::shared_ptr<Expression> when,
-        std::shared_ptr<Expression> then) {
+    void addCaseAlternative(std::shared_ptr<Expression> when, std::shared_ptr<Expression> then) {
         caseAlternatives.push_back(make_unique<CaseAlternative>(std::move(when), std::move(then)));
     }
     common::idx_t getNumCaseAlternatives() const { return caseAlternatives.size(); }

--- a/src/include/binder/expression/subquery_expression.h
+++ b/src/include/binder/expression/subquery_expression.h
@@ -21,9 +21,7 @@ public:
 
     common::SubqueryType getSubqueryType() const { return subqueryType; }
 
-    const QueryGraphCollection* getQueryGraphCollection() const {
-        return &queryGraphCollection;
-    }
+    const QueryGraphCollection* getQueryGraphCollection() const { return &queryGraphCollection; }
 
     void setWhereExpression(std::shared_ptr<Expression> expression) {
         whereExpression = std::move(expression);
@@ -34,13 +32,9 @@ public:
         return hasWhereExpression() ? whereExpression->splitOnAND() : expression_vector{};
     }
 
-    void setCountStarExpr(std::shared_ptr<Expression> expr) {
-        countStarExpr = std::move(expr);
-    }
+    void setCountStarExpr(std::shared_ptr<Expression> expr) { countStarExpr = std::move(expr); }
     std::shared_ptr<Expression> getCountStarExpr() const { return countStarExpr; }
-    void setProjectionExpr(std::shared_ptr<Expression> expr) {
-        projectionExpr = std::move(expr);
-    }
+    void setProjectionExpr(std::shared_ptr<Expression> expr) { projectionExpr = std::move(expr); }
     std::shared_ptr<Expression> getProjectionExpr() const { return projectionExpr; }
 
     std::string toStringInternal() const final { return rawName; }

--- a/src/include/binder/expression/subquery_expression.h
+++ b/src/include/binder/expression/subquery_expression.h
@@ -10,36 +10,38 @@ namespace kuzu {
 namespace binder {
 
 class SubqueryExpression : public Expression {
+    static constexpr common::ExpressionType expressionType_ = common::ExpressionType::SUBQUERY;
+
 public:
     SubqueryExpression(common::SubqueryType subqueryType, common::LogicalType dataType,
         QueryGraphCollection queryGraphCollection, std::string uniqueName, std::string rawName)
-        : Expression{common::ExpressionType::SUBQUERY, std::move(dataType), std::move(uniqueName)},
+        : Expression{expressionType_, std::move(dataType), std::move(uniqueName)},
           subqueryType{subqueryType}, queryGraphCollection{std::move(queryGraphCollection)},
           rawName{std::move(rawName)} {}
 
-    inline common::SubqueryType getSubqueryType() const { return subqueryType; }
+    common::SubqueryType getSubqueryType() const { return subqueryType; }
 
-    inline const QueryGraphCollection* getQueryGraphCollection() const {
+    const QueryGraphCollection* getQueryGraphCollection() const {
         return &queryGraphCollection;
     }
 
-    inline void setWhereExpression(std::shared_ptr<Expression> expression) {
+    void setWhereExpression(std::shared_ptr<Expression> expression) {
         whereExpression = std::move(expression);
     }
-    inline bool hasWhereExpression() const { return whereExpression != nullptr; }
-    inline std::shared_ptr<Expression> getWhereExpression() const { return whereExpression; }
-    inline expression_vector getPredicatesSplitOnAnd() const {
+    bool hasWhereExpression() const { return whereExpression != nullptr; }
+    std::shared_ptr<Expression> getWhereExpression() const { return whereExpression; }
+    expression_vector getPredicatesSplitOnAnd() const {
         return hasWhereExpression() ? whereExpression->splitOnAND() : expression_vector{};
     }
 
-    inline void setCountStarExpr(std::shared_ptr<Expression> expr) {
+    void setCountStarExpr(std::shared_ptr<Expression> expr) {
         countStarExpr = std::move(expr);
     }
-    inline std::shared_ptr<Expression> getCountStarExpr() const { return countStarExpr; }
-    inline void setProjectionExpr(std::shared_ptr<Expression> expr) {
+    std::shared_ptr<Expression> getCountStarExpr() const { return countStarExpr; }
+    void setProjectionExpr(std::shared_ptr<Expression> expr) {
         projectionExpr = std::move(expr);
     }
-    inline std::shared_ptr<Expression> getProjectionExpr() const { return projectionExpr; }
+    std::shared_ptr<Expression> getProjectionExpr() const { return projectionExpr; }
 
     std::string toStringInternal() const final { return rawName; }
 

--- a/src/include/binder/expression_visitor.h
+++ b/src/include/binder/expression_visitor.h
@@ -21,18 +21,29 @@ private:
 
 class ExpressionVisitor {
 public:
-    static inline bool hasAggregate(const Expression& expression) {
-        return satisfyAny(expression, [&](const Expression& expression) {
-            return expression.expressionType == common::ExpressionType::AGGREGATE_FUNCTION;
-        });
-    }
+    virtual ~ExpressionVisitor() = default;
 
-    static inline bool hasSubquery(const Expression& expression) {
-        return satisfyAny(expression, [&](const Expression& expression) {
-            return expression.expressionType == common::ExpressionType::SUBQUERY;
-        });
-    }
+    void visit(std::shared_ptr<Expression> expr);
 
+protected:
+    void visitSwitch(std::shared_ptr<Expression> expr);
+    virtual void visitFunctionExpr(std::shared_ptr<Expression>) {}
+    virtual void visitAggFunctionExpr(std::shared_ptr<Expression>) {}
+    virtual void visitPropertyExpr(std::shared_ptr<Expression>) {}
+    virtual void visitLiteralExpr(std::shared_ptr<Expression>) {}
+    virtual void visitVariableExpr(std::shared_ptr<Expression>) {}
+    virtual void visitPathExpr(std::shared_ptr<Expression>) {}
+    virtual void visitNodeRelExpr(std::shared_ptr<Expression>) {}
+    virtual void visitParamExpr(std::shared_ptr<Expression>) {}
+    virtual void visitSubqueryExpr(std::shared_ptr<Expression>) {}
+    virtual void visitCaseExpr(std::shared_ptr<Expression>) {}
+    virtual void visitGraphExpr(std::shared_ptr<Expression>) {}
+    virtual void visitLambdaExpr(std::shared_ptr<Expression>) {}
+
+    void visitChildren(const Expression& expr);
+    void visitCaseExprChildren(const Expression& expr);
+
+public:
     static inline bool needFold(const Expression& expression) {
         return expression.expressionType == common::ExpressionType::LITERAL ?
                    false :
@@ -42,38 +53,62 @@ public:
     static bool isConstant(const Expression& expression);
 
     static bool isRandom(const Expression& expression);
-
-private:
-    static bool satisfyAny(const Expression& expression,
-        const std::function<bool(const Expression&)>& condition);
 };
 
-class ExpressionCollector {
+class AggregateExprCollector final : public ExpressionVisitor {
 public:
-    inline expression_vector collectPropertyExpressions(
-        const std::shared_ptr<Expression>& expression) {
-        KU_ASSERT(expressions.empty());
-        collectExpressionsInternal(expression, [&](const Expression& expression) {
-            return expression.expressionType == common::ExpressionType::PROPERTY;
-        });
-        return expressions;
-    }
+    AggregateExprCollector() : hasAggregate_{false} {}
 
-    inline expression_vector collectTopLevelSubqueryExpressions(
-        const std::shared_ptr<Expression>& expression) {
-        KU_ASSERT(expressions.empty());
-        collectExpressionsInternal(expression, [&](const Expression& expression) {
-            return expression.expressionType == common::ExpressionType::SUBQUERY;
-        });
-        return expressions;
-    }
+    bool hasAggregate() const { return hasAggregate_; }
 
-    std::unordered_set<std::string> getDependentVariableNames(
-        const std::shared_ptr<Expression>& expression);
+protected:
+    void visitAggFunctionExpr(std::shared_ptr<Expression>) override {
+        hasAggregate_ = true;
+    }
 
 private:
-    void collectExpressionsInternal(const std::shared_ptr<Expression>& expression,
-        const std::function<bool(const Expression&)>& condition);
+    bool hasAggregate_;
+};
+
+// Do not collect subquery expression recursively. Caller should handle recursive subquery instead.
+class SubqueryExprCollector final : public ExpressionVisitor {
+public:
+    bool hasSubquery() const { return !exprs.empty(); }
+    expression_vector getSubqueryExprs() const { return exprs; }
+
+protected:
+    void visitSubqueryExpr(std::shared_ptr<Expression> expr) override {
+        exprs.push_back(expr);
+    }
+
+private:
+    expression_vector exprs;
+};
+
+class DependentVarNameCollector final : public ExpressionVisitor {
+public:
+    std::unordered_set<std::string> getVarNames() const { return varNames; }
+
+protected:
+    void visitSubqueryExpr(std::shared_ptr<Expression> expr) override;
+    void visitPropertyExpr(std::shared_ptr<Expression> expr) override;
+    void visitNodeRelExpr(std::shared_ptr<Expression> expr) override;
+    void visitVariableExpr(std::shared_ptr<Expression> expr) override;
+
+private:
+    std::unordered_set<std::string> varNames;
+};
+
+class PropertyExprCollector final : public ExpressionVisitor {
+public:
+    expression_vector getPropertyExprs() const {
+        return expressions;
+    }
+
+protected:
+    void visitSubqueryExpr(std::shared_ptr<Expression> expr) override;
+    void visitPropertyExpr(std::shared_ptr<Expression> expr) override;
+    void visitNodeRelExpr(std::shared_ptr<Expression> expr) override;
 
 private:
     expression_vector expressions;

--- a/src/include/binder/expression_visitor.h
+++ b/src/include/binder/expression_visitor.h
@@ -62,9 +62,7 @@ public:
     bool hasAggregate() const { return hasAggregate_; }
 
 protected:
-    void visitAggFunctionExpr(std::shared_ptr<Expression>) override {
-        hasAggregate_ = true;
-    }
+    void visitAggFunctionExpr(std::shared_ptr<Expression>) override { hasAggregate_ = true; }
 
 private:
     bool hasAggregate_;
@@ -77,9 +75,7 @@ public:
     expression_vector getSubqueryExprs() const { return exprs; }
 
 protected:
-    void visitSubqueryExpr(std::shared_ptr<Expression> expr) override {
-        exprs.push_back(expr);
-    }
+    void visitSubqueryExpr(std::shared_ptr<Expression> expr) override { exprs.push_back(expr); }
 
 private:
     expression_vector exprs;
@@ -101,9 +97,7 @@ private:
 
 class PropertyExprCollector final : public ExpressionVisitor {
 public:
-    expression_vector getPropertyExprs() const {
-        return expressions;
-    }
+    expression_vector getPropertyExprs() const { return expressions; }
 
 protected:
     void visitSubqueryExpr(std::shared_ptr<Expression> expr) override;

--- a/src/include/planner/planner.h
+++ b/src/include/planner/planner.h
@@ -154,8 +154,7 @@ public:
     void planRegularMatch(const binder::QueryGraphCollection& queryGraphCollection,
         const binder::expression_vector& predicates, LogicalPlan& leftPlan);
     void planSubquery(const std::shared_ptr<binder::Expression>& subquery, LogicalPlan& outerPlan);
-    void planSubqueryIfNecessary(const std::shared_ptr<binder::Expression>& expression,
-        LogicalPlan& plan);
+    void planSubqueryIfNecessary(std::shared_ptr<binder::Expression> expression, LogicalPlan& plan);
 
     static binder::expression_vector getCorrelatedExprs(
         const binder::QueryGraphCollection& collection, const binder::expression_vector& predicates,

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -103,10 +103,25 @@ static std::shared_ptr<Expression> getIRIProperty(const expression_vector& prope
     return nullptr;
 }
 
+static void validatePropertiesContainRelID(const RelExpression& rel, const expression_vector& properties) {
+    if (rel.isEmpty()) {
+        return ;
+    }
+    for (auto& property : properties) {
+        if (*property == *rel.getInternalIDProperty()) {
+            return ;
+        }
+    }
+    // LCOV_EXCL_START
+    throw RuntimeException(stringFormat("Internal ID of relationship {} is not scanned. This should not happen.", rel.toString()));
+    // LCOV_EXCL_STOP
+}
+
 void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& boundNode,
     const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, bool extendFromSource, const expression_vector& properties,
     LogicalPlan& plan) {
+    validatePropertiesContainRelID(*rel, properties);
     // Filter bound node label if we know some incoming nodes won't have any outgoing rel. This
     // cannot be done at binding time because the pruning is affected by extend direction.
     auto boundNodeTableIDSet = getBoundNodeTableIDSet(*rel, direction, *clientContext);
@@ -224,7 +239,9 @@ static expression_vector collectPropertiesToRead(const std::shared_ptr<Expressio
     if (expression == nullptr) {
         return expression_vector{};
     }
-    return ExpressionCollector().collectPropertyExpressions(expression);
+    auto collector = PropertyExprCollector();
+    collector.visit(expression);
+    return collector.getPropertyExprs();
 }
 
 void Planner::createRecursivePlan(const RecursiveInfo& recursiveInfo, ExtendDirection direction,

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -103,17 +103,19 @@ static std::shared_ptr<Expression> getIRIProperty(const expression_vector& prope
     return nullptr;
 }
 
-static void validatePropertiesContainRelID(const RelExpression& rel, const expression_vector& properties) {
+static void validatePropertiesContainRelID(const RelExpression& rel,
+    const expression_vector& properties) {
     if (rel.isEmpty()) {
-        return ;
+        return;
     }
     for (auto& property : properties) {
         if (*property == *rel.getInternalIDProperty()) {
-            return ;
+            return;
         }
     }
     // LCOV_EXCL_START
-    throw RuntimeException(stringFormat("Internal ID of relationship {} is not scanned. This should not happen.", rel.toString()));
+    throw RuntimeException(stringFormat(
+        "Internal ID of relationship {} is not scanned. This should not happen.", rel.toString()));
     // LCOV_EXCL_STOP
 }
 

--- a/src/planner/plan/plan_join_order.cpp
+++ b/src/planner/plan/plan_join_order.cpp
@@ -595,8 +595,9 @@ std::vector<std::unique_ptr<LogicalPlan>> Planner::planCrossProduct(
 
 static bool isExpressionNewlyMatched(const std::vector<SubqueryGraph>& prevs,
     const SubqueryGraph& newSubgraph, const std::shared_ptr<Expression>& expression) {
-    auto expressionCollector = std::make_unique<ExpressionCollector>();
-    auto variables = expressionCollector->getDependentVariableNames(expression);
+    auto collector = DependentVarNameCollector();
+    collector.visit(expression);
+    auto variables = collector.getVarNames();
     for (auto& prev : prevs) {
         if (prev.containAllVariables(variables)) {
             return false; // matched in prev subgraph

--- a/src/planner/plan/plan_read.cpp
+++ b/src/planner/plan/plan_read.cpp
@@ -82,8 +82,9 @@ void Planner::planUnwindClause(const BoundReadingClause& boundReadingClause,
 
 static bool hasExternalDependency(const std::shared_ptr<Expression>& expression,
     const std::unordered_set<std::string>& variableNameSet) {
-    auto collector = ExpressionCollector();
-    for (auto& name : collector.getDependentVariableNames(expression)) {
+    auto collector = DependentVarNameCollector();
+    collector.visit(expression);
+    for (auto& name : collector.getVarNames()) {
         if (!variableNameSet.contains(name)) {
             return true;
         }

--- a/src/planner/plan/plan_subquery.cpp
+++ b/src/planner/plan/plan_subquery.cpp
@@ -179,11 +179,11 @@ void Planner::planSubquery(const std::shared_ptr<Expression>& expression, Logica
     }
 }
 
-void Planner::planSubqueryIfNecessary(const std::shared_ptr<Expression>& expression,
-    LogicalPlan& plan) {
-    if (ExpressionVisitor::hasSubquery(*expression)) {
-        auto expressionCollector = std::make_unique<ExpressionCollector>();
-        for (auto& expr : expressionCollector->collectTopLevelSubqueryExpressions(expression)) {
+void Planner::planSubqueryIfNecessary(std::shared_ptr<Expression> expression, LogicalPlan& plan) {
+    auto collector = SubqueryExprCollector();
+    collector.visit(expression);
+    if (collector.hasSubquery()) {
+        for (auto& expr : collector.getSubqueryExprs()) {
             if (plan.getSchema()->isExpressionInScope(*expr)) {
                 continue;
             }

--- a/test/test_files/demo_db/demo_db.test
+++ b/test/test_files/demo_db/demo_db.test
@@ -3,7 +3,6 @@
 --
 
 -CASE DemoDBTest
-
 -LOG CountSubquery
 -STATEMENT MATCH (a:User) RETURN a.name, COUNT { MATCH (a)<-[:Follows]-(b:User) } AS num_follower ORDER BY num_follower;
 ---- 4


### PR DESCRIPTION
# Description

This PR removes the previous expression visitor and implement a new one that enables override. I start realizing different use case requires different way of visiting expression. For example,

when evaluating subquery, we don't collect subquery expression recursively. Instead we plan subquery recursively. E.g.
```
MATCH (a) WHERE EXISTS { MATCH (a)->(b) WHERE EXISTS { MATCH (b)->(c)}}
```

when collecting property, we do visit subquery expression recursively to find all properties.
```
MATCH (a) WHERE EXISTS { MATCH (a)->(b) WHERE a.age = 10 AND EXISTS { MATCH (a)->(c) WHERE a.ID = 0}}
```

So the best approach is to abort the previous one-fit-all-purpose visitor.

Fixes #3730 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).