### PR TITLE
Remove hasAtMostOneNbr

### DIFF
--- a/src/include/planner/operator/extend/logical_extend.h
+++ b/src/include/planner/operator/extend/logical_extend.h
@@ -13,11 +13,10 @@ public:
     LogicalExtend(std::shared_ptr<binder::NodeExpression> boundNode,
         std::shared_ptr<binder::NodeExpression> nbrNode, std::shared_ptr<binder::RelExpression> rel,
         common::ExtendDirection direction, bool extendFromSource,
-        binder::expression_vector properties, bool hasAtMostOneNbr,
-        std::shared_ptr<LogicalOperator> child)
+        binder::expression_vector properties, std::shared_ptr<LogicalOperator> child)
         : BaseLogicalExtend{type_, std::move(boundNode), std::move(nbrNode), std::move(rel),
               direction, extendFromSource, std::move(child)},
-          properties{std::move(properties)}, hasAtMostOneNbr{hasAtMostOneNbr} {}
+          properties{std::move(properties)} {}
 
     f_group_pos_set getGroupsPosToFlatten() override;
 
@@ -37,7 +36,6 @@ public:
 private:
     binder::expression_vector properties;
     std::vector<storage::ColumnPredicateSet> propertyPredicates;
-    bool hasAtMostOneNbr;
 };
 
 } // namespace planner

--- a/src/planner/operator/extend/logical_extend.cpp
+++ b/src/planner/operator/extend/logical_extend.cpp
@@ -43,7 +43,7 @@ void LogicalExtend::computeFlatSchema() {
 
 std::unique_ptr<LogicalOperator> LogicalExtend::copy() {
     auto extend = std::make_unique<LogicalExtend>(boundNode, nbrNode, rel, direction,
-        extendFromSource_, properties, hasAtMostOneNbr, children[0]->copy());
+        extendFromSource_, properties, children[0]->copy());
     extend->setPropertyPredicates(copyVector(propertyPredicates));
     return extend;
 }


### PR DESCRIPTION
# Description

Apparently `hasAtMostOneNbr` is no longer in use. It also doesn't matter much because we will always scan `DEFAULT_VECTOR_CAPACITY` when scanning CSR. 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).