### PR TITLE
Support more udf types

### DIFF
--- a/src/include/function/udf_function.h
+++ b/src/include/function/udf_function.h
@@ -2,6 +2,7 @@
 
 #include "common/exception/binder.h"
 #include "common/exception/catalog.h"
+#include "common/type_utils.h"
 #include "common/types/blob.h"
 #include "common/types/ku_string.h"
 #include "function/scalar_function.h"
@@ -41,34 +42,13 @@ struct TernaryUDFExecutor {
 struct UDF {
     template<typename T>
     static bool templateValidateType(const common::LogicalTypeID& type) {
-        switch (type) {
-        case common::LogicalTypeID::BOOL:
-            return std::is_same<T, bool>();
-        case common::LogicalTypeID::INT16:
-            return std::is_same<T, int16_t>();
-        case common::LogicalTypeID::INT32:
-            return std::is_same<T, int32_t>();
-        case common::LogicalTypeID::INT64:
-            return std::is_same<T, int64_t>();
-        case common::LogicalTypeID::FLOAT:
-            return std::is_same<T, float>();
-        case common::LogicalTypeID::DOUBLE:
-            return std::is_same<T, double>();
-        case common::LogicalTypeID::DATE:
-            return std::is_same<T, int32_t>();
-        case common::LogicalTypeID::TIMESTAMP_NS:
-        case common::LogicalTypeID::TIMESTAMP_MS:
-        case common::LogicalTypeID::TIMESTAMP_SEC:
-        case common::LogicalTypeID::TIMESTAMP_TZ:
-        case common::LogicalTypeID::TIMESTAMP:
-            return std::is_same<T, int64_t>();
-        case common::LogicalTypeID::STRING:
-            return std::is_same<T, common::ku_string_t>();
-        case common::LogicalTypeID::BLOB:
-            return std::is_same<T, common::blob_t>();
-        default:
-            KU_UNREACHABLE;
-        }
+        auto logicalType = common::LogicalType{type};
+        auto physicalType = logicalType.getPhysicalType();
+        auto physicalTypeMatch = common::TypeUtils::visit(physicalType,
+            []<typename T1>(T1) { return std::is_same<T, T1>::value; });
+        auto logicalTypeMatch = common::TypeUtils::visit(logicalType,
+            []<typename T1>(T1) { return std::is_same<T, T1>::value; });
+        return logicalTypeMatch || physicalTypeMatch;
     }
 
     template<typename T>
@@ -203,12 +183,24 @@ struct UDF {
     static common::LogicalTypeID getParameterType() {
         if (std::is_same<T, bool>()) {
             return common::LogicalTypeID::BOOL;
+        } else if (std::is_same<T, int8_t>()) {
+            return common::LogicalTypeID::INT8;
         } else if (std::is_same<T, int16_t>()) {
             return common::LogicalTypeID::INT16;
         } else if (std::is_same<T, int32_t>()) {
             return common::LogicalTypeID::INT32;
         } else if (std::is_same<T, int64_t>()) {
             return common::LogicalTypeID::INT64;
+        } else if (std::is_same<T, common::int128_t>()) {
+            return common::LogicalTypeID::INT128;
+        } else if (std::is_same<T, uint8_t>()) {
+            return common::LogicalTypeID::UINT8;
+        } else if (std::is_same<T, uint16_t>()) {
+            return common::LogicalTypeID::UINT16;
+        } else if (std::is_same<T, uint32_t>()) {
+            return common::LogicalTypeID::UINT32;
+        } else if (std::is_same<T, uint64_t>()) {
+            return common::LogicalTypeID::UINT64;
         } else if (std::is_same<T, float>()) {
             return common::LogicalTypeID::FLOAT;
         } else if (std::is_same<T, double>()) {

--- a/src/include/function/udf_function.h
+++ b/src/include/function/udf_function.h
@@ -3,7 +3,6 @@
 #include "common/exception/binder.h"
 #include "common/exception/catalog.h"
 #include "common/type_utils.h"
-#include "common/types/blob.h"
 #include "common/types/ku_string.h"
 #include "function/scalar_function.h"
 

--- a/test/main/udf_test.cpp
+++ b/test/main/udf_test.cpp
@@ -29,6 +29,78 @@ TEST_F(ApiTest, UnaryUDFInt64) {
     sortAndCheckTestResults(actualResult, expectedResult);
 }
 
+static int128_t int128Func(int128_t x) {
+    return x;
+}
+
+TEST_F(ApiTest, UnaryUDFInt128) {
+    conn->createScalarFunction("add6", &int128Func);
+    auto actualResult = TestHelper::convertResultToString(
+        *conn->query("MATCH (p:person) return add6(to_int32(p.age))"));
+    auto expectedResult = std::vector<std::string>{"35", "30", "45", "20", "20", "25", "40", "83"};
+    sortAndCheckTestResults(actualResult, expectedResult);
+}
+
+static int32_t int8Func(uint8_t x) {
+    return x - 5;
+}
+
+TEST_F(ApiTest, UnaryUDFInt8) {
+    conn->createScalarFunction("func", &int8Func);
+    auto actualResult = TestHelper::convertResultToString(
+        *conn->query("MATCH (p:person) return func(to_uint8(p.age))"));
+    auto expectedResult = std::vector<std::string>{"30", "25", "40", "15", "15", "20", "35", "78"};
+    sortAndCheckTestResults(actualResult, expectedResult);
+}
+
+static int32_t uint8Func(uint8_t x) {
+    return x + 20;
+}
+
+TEST_F(ApiTest, UnaryUDFUint8) {
+    conn->createScalarFunction("func", &uint8Func);
+    auto actualResult = TestHelper::convertResultToString(
+        *conn->query("MATCH (p:person) return func(to_uint8(p.age))"));
+    auto expectedResult = std::vector<std::string>{"55", "50", "65", "40", "40", "45", "60", "103"};
+    sortAndCheckTestResults(actualResult, expectedResult);
+}
+
+static int32_t uint16Func(uint16_t x) {
+    return x + 33;
+}
+
+TEST_F(ApiTest, UnaryUDFUint16) {
+    conn->createScalarFunction("func", &uint16Func);
+    auto actualResult = TestHelper::convertResultToString(
+        *conn->query("MATCH (p:person) return func(to_uint16(p.age))"));
+    auto expectedResult = std::vector<std::string>{"68", "63", "78", "53", "53", "58", "73", "116"};
+    sortAndCheckTestResults(actualResult, expectedResult);
+}
+
+static int32_t uint32Func(uint32_t x) {
+    return x * 2;
+}
+
+TEST_F(ApiTest, UnaryUDFUint32) {
+    conn->createScalarFunction("func", &uint32Func);
+    auto actualResult = TestHelper::convertResultToString(
+        *conn->query("MATCH (p:person) return func(to_uint32(p.age))"));
+    auto expectedResult = std::vector<std::string>{"70", "60", "90", "40", "40", "50", "80", "166"};
+    sortAndCheckTestResults(actualResult, expectedResult);
+}
+
+static int128_t uint64Func(uint64_t x) {
+    return x - 10;
+}
+
+TEST_F(ApiTest, UnaryUDFUint64) {
+    conn->createScalarFunction("func", &uint64Func);
+    auto actualResult = TestHelper::convertResultToString(
+        *conn->query("MATCH (p:person) return func(to_uint64(p.age))"));
+    auto expectedResult = std::vector<std::string>{"25", "20", "35", "10", "10", "15", "30", "73"};
+    sortAndCheckTestResults(actualResult, expectedResult);
+}
+
 TEST_F(ApiTest, TestDropUDF) {
     conn->createScalarFunction("add5", &add5);
     conn->removeUDFFunction("add5");


### PR DESCRIPTION
# Description

This PR supports more udf primitive types (int8, uint8, uint16, uint32, uint64).

Fixes #2513
