### PR TITLE
Fix deadlock issue in BMFileHandle

### DIFF
--- a/src/storage/buffer_manager/bm_file_handle.cpp
+++ b/src/storage/buffer_manager/bm_file_handle.cpp
@@ -43,7 +43,7 @@ void BMFileHandle::addNewPageGroupWithoutLock() {
 
 page_group_idx_t BMFileHandle::addWALPageIdxGroupIfNecessary(page_idx_t originalPageIdx) {
     KU_ASSERT(fileVersionedType == FileVersionedType::VERSIONED_FILE);
-    std::unique_lock xLck{fhSharedMutex};
+    while (!fhSharedMutex.try_lock()) {}
     KU_ASSERT(originalPageIdx < numPages);
     // Although getPageCursorForPos is written to get offsets of elements
     // in pages, it simply can be used to find the group/chunk and offset/pos in group/chunk for
@@ -53,6 +53,7 @@ page_group_idx_t BMFileHandle::addWALPageIdxGroupIfNecessary(page_idx_t original
     if (!walPageIdxGroups.contains(pageGroupIdx)) {
         walPageIdxGroups.insert(std::make_pair(pageGroupIdx, std::make_unique<WALPageIdxGroup>()));
     }
+    fhSharedMutex.unlock();
     return pageGroupIdx;
 }
 

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -3,7 +3,6 @@
 #include <fcntl.h>
 
 #include <cmath>
-#include <mutex>
 
 #include "common/file_system/virtual_file_system.h"
 

--- a/src/storage/file_handle.cpp
+++ b/src/storage/file_handle.cpp
@@ -50,11 +50,12 @@ page_idx_t FileHandle::addNewPage() {
 }
 
 page_idx_t FileHandle::addNewPages(page_idx_t numNewPages) {
-    std::unique_lock xlock(fhSharedMutex);
+    while (!fhSharedMutex.try_lock()) {}
     auto numPagesBeforeChange = numPages;
     for (auto i = 0u; i < numNewPages; i++) {
         addNewPageWithoutLock();
     }
+    fhSharedMutex.unlock();
     return numPagesBeforeChange;
 }
 


### PR DESCRIPTION
# Description

The can be a deadlock in a case as follow:
T1 holds `walPageIdxLock` of `pageX` while trying to grab a shared lock over `fhSharedMutex`;
T2 holds a shared lock over `fhSharedMutex` while trying to grab a lock of `pageX`.
Above calls can happen in code snippet inside `DiskArrayInternal::get()`
```cpp
        fileHandle.acquireWALPageIdxLock(apPageIdx);
        DBFileUtils::readWALVersionOfPage(bmFileHandle, apPageIdx, *bufferManager, *wal,
            [&val, &apCursor](const uint8_t* frame) -> void {
                memcpy(val.data(), frame + apCursor.elemPosInPage, val.size());
            });
```
Without a third thread, T1 and T2 should work fine, as T1 is able to grab the shared lock of `fhSharedMutex` and proceed, while T2 proceeds until T1 releases the lock on `pageX`.

However, when there is a third thread T3 trying to grab an exclusive (write) lock over `fhSharedMutex`, the write lock can be prioritized over reads waiting in queue (see https://github.com/gcc-mirror/gcc/blob/74e6dfb23163c2dd670d1d60fbf4c782e0b44b94/libstdc%2B%2B-v3/include/std/shared_mutex#L291-L294), thus blocking T1 to proceed, leading to deadlock.

A quick fix is to replace `std::unique_lock xLck{fhSharedMutex};` with `while (!fhSharedMutex.try_lock()) {}`.
Alternatively, we should rework the lock acquisition order to make sure T1 and T2 acquire locks in the same order (`fhSharedMutex -> walPageIdxLock`, but no `walPageIdxLock -> fhSharedMutex `). This approach requires more changes, and it will be unnecessary as I'm removing the logic around `walPageIdx` from BMFileHandle along with the mvcc changes.