### PR TITLE
Fix issue-3616

### DIFF
--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -60,7 +60,8 @@ std::vector<PropertyInfo> Binder::bindPropertyInfo(
             expressionBinder.bindExpression(*propertyDef.expr), type);
         if (type.getLogicalTypeID() == LogicalTypeID::SERIAL) {
             validateSerialNoDefault(*boundExpr);
-            expr = ParsedExpressionUtils::getSerialDefaultExpr(Catalog::genSerialName(tableName, propertyDef.name));
+            expr = ParsedExpressionUtils::getSerialDefaultExpr(
+                Catalog::genSerialName(tableName, propertyDef.name));
         }
         propertyInfos.emplace_back(propertyDef.name, std::move(type), std::move(expr));
     }
@@ -495,7 +496,8 @@ std::unique_ptr<BoundStatement> Binder::bindAddProperty(const Statement& stateme
         expressionBinder.bindExpression(*defaultValue), dataType);
     if (dataType.getLogicalTypeID() == LogicalTypeID::SERIAL) {
         validateSerialNoDefault(*boundDefault);
-        defaultValue = ParsedExpressionUtils::getSerialDefaultExpr(Catalog::genSerialName(tableName, propertyName));
+        defaultValue = ParsedExpressionUtils::getSerialDefaultExpr(
+            Catalog::genSerialName(tableName, propertyName));
         boundDefault = expressionBinder.implicitCastIfNecessary(
             expressionBinder.bindExpression(*defaultValue), dataType);
     }

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -15,7 +15,6 @@
 #include "common/string_format.h"
 #include "common/types/types.h"
 #include "function/cast/functions/cast_from_string_functions.h"
-#include "function/sequence/sequence_functions.h"
 #include "main/client_context.h"
 #include "parser/ddl/alter.h"
 #include "parser/ddl/create_sequence.h"
@@ -23,7 +22,6 @@
 #include "parser/ddl/create_table_info.h"
 #include "parser/ddl/create_type.h"
 #include "parser/ddl/drop.h"
-#include "parser/expression/parsed_function_expression.h"
 #include "parser/expression/parsed_literal_expression.h"
 
 using namespace kuzu::common;
@@ -50,12 +48,6 @@ static void validateSerialNoDefault(const Expression& expr) {
     }
 }
 
-static std::unique_ptr<parser::ParsedFunctionExpression> createSerialDefaultExpr(std::string name) {
-    auto param = std::make_unique<parser::ParsedLiteralExpression>(Value(name), "");
-    return std::make_unique<parser::ParsedFunctionExpression>(function::NextValFunction::name,
-        std::move(param), "");
-}
-
 std::vector<PropertyInfo> Binder::bindPropertyInfo(
     const std::vector<PropertyDefinitionDDL>& propertyDefinitions, const std::string& tableName) {
     std::vector<PropertyInfo> propertyInfos;
@@ -68,7 +60,7 @@ std::vector<PropertyInfo> Binder::bindPropertyInfo(
             expressionBinder.bindExpression(*propertyDef.expr), type);
         if (type.getLogicalTypeID() == LogicalTypeID::SERIAL) {
             validateSerialNoDefault(*boundExpr);
-            expr = createSerialDefaultExpr(Catalog::genSerialName(tableName, propertyDef.name));
+            expr = ParsedExpressionUtils::getSerialDefaultExpr(Catalog::genSerialName(tableName, propertyDef.name));
         }
         propertyInfos.emplace_back(propertyDef.name, std::move(type), std::move(expr));
     }
@@ -503,7 +495,7 @@ std::unique_ptr<BoundStatement> Binder::bindAddProperty(const Statement& stateme
         expressionBinder.bindExpression(*defaultValue), dataType);
     if (dataType.getLogicalTypeID() == LogicalTypeID::SERIAL) {
         validateSerialNoDefault(*boundDefault);
-        defaultValue = createSerialDefaultExpr(Catalog::genSerialName(tableName, propertyName));
+        defaultValue = ParsedExpressionUtils::getSerialDefaultExpr(Catalog::genSerialName(tableName, propertyName));
         boundDefault = expressionBinder.implicitCastIfNecessary(
             expressionBinder.bindExpression(*defaultValue), dataType);
     }

--- a/src/binder/bind/copy/bind_copy_from.cpp
+++ b/src/binder/bind/copy/bind_copy_from.cpp
@@ -152,7 +152,8 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRelFrom(const parser::Statement&
     auto dstLookUpInfo = IndexLookupInfo(dstTableID, dstOffset, dstKey);
     auto lookupInfos = std::vector<IndexLookupInfo>{srcLookUpInfo, dstLookUpInfo};
     auto internalIDColumnIndices = std::vector<common::idx_t>{0, 1, 2};
-    auto extraCopyRelInfo = std::make_unique<ExtraBoundCopyRelInfo>(internalIDColumnIndices, lookupInfos);
+    auto extraCopyRelInfo =
+        std::make_unique<ExtraBoundCopyRelInfo>(internalIDColumnIndices, lookupInfos);
     auto boundCopyFromInfo = BoundCopyFromInfo(relTableEntry, boundSource->copy(), offset,
         std::move(columnExprs), std::move(defaultColumns), std::move(extraCopyRelInfo));
     return std::make_unique<BoundCopyFrom>(std::move(boundCopyFromInfo));

--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -1,6 +1,5 @@
 #include "binder/binder.h"
 #include "binder/copy/bound_copy_from.h"
-#include "binder/expression/variable_expression.h"
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/node_table_catalog_entry.h"
 #include "catalog/catalog_entry/rdf_graph_catalog_entry.h"
@@ -23,122 +22,171 @@ using namespace kuzu::parser;
 namespace kuzu {
 namespace binder {
 
-std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const parser::Statement& statement,
-    RDFGraphCatalogEntry* rdfGraphEntry) {
-    auto& copyStatement = ku_dynamic_cast<const Statement&, const CopyFrom&>(statement);
-    // Bind path.
-    KU_ASSERT(copyStatement.getSource()->type == ScanSourceType::FILE);
-    auto fileSource = ku_dynamic_cast<BaseScanSource*, FileScanSource*>(copyStatement.getSource());
-    auto filePaths = bindFilePaths(fileSource->filePaths);
-    // Bind file type.
-    auto fileType = bindFileType(filePaths);
-    auto config = std::make_unique<ReaderConfig>(fileType, std::move(filePaths));
-    config->options = bindParsingOptions(copyStatement.getParsingOptionsRef());
+BoundCopyFromInfo Binder::bindCopyRdfResourceInfo(const RdfReaderConfig& config,
+    const TableFuncBindData& bindData, const RDFGraphCatalogEntry& rdfEntry) {
+    auto transaction = clientContext->getTx();
     auto catalog = clientContext->getCatalog();
-    auto functions = catalog->getFunctions(clientContext->getTx());
-    auto offset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+    auto functions = catalog->getFunctions(transaction);
+    Function* func;
+    if (config.inMemory) {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceInMemScan::name, functions);
+    } else {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceScan::name, functions);
+    }
+    auto scanFunc = func->ptrCast<TableFunction>();
+    auto iri = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::IRI);
+    auto columns = expression_vector{iri};
+    auto scanInfo = BoundFileScanInfo(*scanFunc, bindData.copy(), columns);
+    auto scanSource = std::make_unique<BoundFileScanSource>(std::move(scanInfo));
+    auto rTableID = rdfEntry.getResourceTableID();
+    auto rEntry = catalog->getTableCatalogEntry(transaction, rTableID);
+    auto rowOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
         InternalKeyword::ROW_OFFSET);
-    auto r = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::IRI);
-    auto l = expressionBinder.createVariableExpression(LogicalType::RDF_VARIANT(), rdf::VAL);
+    return BoundCopyFromInfo(rEntry, std::move(scanSource), rowOffset, std::move(columns),
+        std::vector<bool>{false}, nullptr /* extraInfo */);
+}
+
+BoundCopyFromInfo Binder::bindCopyRdfLiteralInfo(const RdfReaderConfig& config,
+    const TableFuncBindData& bindData, const RDFGraphCatalogEntry& rdfEntry) {
+    auto transaction = clientContext->getTx();
+    auto catalog = clientContext->getCatalog();
+    auto functions = catalog->getFunctions(transaction);
+    Function* func;
+    if (config.inMemory) {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralInMemScan::name, functions);
+    } else {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralScan::name, functions);
+    }
+    auto scanFunc = func->ptrCast<TableFunction>();
+    auto val = expressionBinder.createVariableExpression(LogicalType::RDF_VARIANT(), rdf::VAL);
     auto lang = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::LANG);
+    auto columns = expression_vector{val, lang};
+    auto scanInfo = BoundFileScanInfo(*scanFunc, bindData.copy(), columns);
+    auto scanSource = std::make_unique<BoundFileScanSource>(std::move(scanInfo));
+    auto lTableID = rdfEntry.getLiteralTableID();
+    auto lEntry = catalog->getTableCatalogEntry(transaction, lTableID)->ptrCast<NodeTableCatalogEntry>();
+    auto valID = expressionBinder.bindExpression(*lEntry->getPrimaryKey()->getDefaultExpr());
+    auto lCopyColumns = expression_vector{valID, val, lang};
+    auto rowOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+        InternalKeyword::ROW_OFFSET);
+    return BoundCopyFromInfo(lEntry, std::move(scanSource), rowOffset, lCopyColumns,
+        std::vector<bool>{true, false, false}, nullptr /* extraInfo */);
+}
+
+BoundCopyFromInfo Binder::bindCopyRdfResourceTriplesInfo(const RdfReaderConfig& config,
+    const TableFuncBindData& bindData, const RDFGraphCatalogEntry& rdfEntry) {
+    auto transaction = clientContext->getTx();
+    auto catalog = clientContext->getCatalog();
+    auto functions = catalog->getFunctions(transaction);
+    Function* func;
+    if (config.inMemory) {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceTripleInMemScan::name, functions);
+    } else {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceTripleScan::name, functions);
+    }
+    auto scanFunc = func->ptrCast<TableFunction>();
     auto s = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::SUBJECT);
     auto p = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::PREDICATE);
     auto o = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::OBJECT);
+    auto scanColumns = expression_vector{s, p, o};
+    auto scanInfo = BoundFileScanInfo(*scanFunc, bindData.copy(), scanColumns);
+    auto scanSource = std::make_unique<BoundFileScanSource>(std::move(scanInfo));
+    auto rTableID = rdfEntry.getResourceTableID();
+    auto rrrTableID = rdfEntry.getResourceTripleTableID();
+    auto rrrEntry = catalog->getTableCatalogEntry(transaction, rrrTableID);
     auto sOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
         InternalKeyword::SRC_OFFSET);
     auto pOffset = expressionBinder.createVariableExpression(LogicalType::INT64(), rdf::PID);
-    auto oOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
-        InternalKeyword::DST_OFFSET);
-    auto pOffsetInternal = std::make_shared<VariableExpression>(LogicalType::INTERNAL_ID(),
-        pOffset->getUniqueName(), std::string(rdf::PID));
-    auto bindInput = std::make_unique<ScanTableFuncBindInput>(config->copy());
-    Function* func;
-    // Bind file scan;
-    auto inMemory = RdfReaderConfig::construct(config->options).inMemory;
-    func = BuiltInFunctionsUtils::matchFunction(clientContext->getTx(), RdfAllTripleScan::name,
-        functions);
-    auto scanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
-    auto bindData = scanFunc->bindFunc(clientContext, bindInput.get());
-    // Bind copy resource.
-    func = inMemory ? BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfResourceInMemScan::name, functions) :
-                      BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfResourceScan::name, functions);
-    auto rScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
-    auto rColumns = expression_vector{r};
-    auto rFileScanInfo = BoundFileScanInfo(*rScanFunc, bindData->copy(), rColumns);
-    auto rSource = std::make_unique<BoundFileScanSource>(std::move(rFileScanInfo));
-    auto rTableID = rdfGraphEntry->getResourceTableID();
-    auto rEntry = catalog->getTableCatalogEntry(clientContext->getTx(), rTableID);
-    auto rCopyInfo = BoundCopyFromInfo(rEntry, std::move(rSource), offset, std::move(rColumns),
-        std::vector<bool>{false}, nullptr /* extraInfo */);
-    // Bind copy literal.
-    func = inMemory ? BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfLiteralInMemScan::name, functions) :
-                      BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfLiteralScan::name, functions);
-    auto lScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
-    auto lColumns = expression_vector{l, lang};
-    auto lFileScanInfo = BoundFileScanInfo(*lScanFunc, bindData->copy(), std::move(lColumns));
-    auto lSource = std::make_unique<BoundFileScanSource>(std::move(lFileScanInfo));
-    auto lTableID = rdfGraphEntry->getLiteralTableID();
-    auto lEntry = catalog->getTableCatalogEntry(clientContext->getTx(), lTableID);
-    auto lNodeEntry = lEntry->constPtrCast<NodeTableCatalogEntry>();
-    auto ser = expressionBinder.bindExpression(*lNodeEntry->getPrimaryKey()->getDefaultExpr());
-    auto lCopyColumns = expression_vector{ser, l, lang};
-    auto lCopyInfo = BoundCopyFromInfo(lEntry, std::move(lSource), offset, lCopyColumns,
-        std::vector<bool>{true, false, false}, nullptr /* extraInfo */);
-    // Bind copy resource triples
-    func = inMemory ? BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfResourceTripleInMemScan::name, functions) :
-                      BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfResourceTripleScan::name, functions);
-    auto rrrScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
-    auto rrrColumns = expression_vector{s, p, o};
-    auto rrrFileScanInfo = BoundFileScanInfo(*rrrScanFunc, bindData->copy(), rrrColumns);
-    auto rrrSource = std::make_unique<BoundFileScanSource>(std::move(rrrFileScanInfo));
-    auto rrrTableID = rdfGraphEntry->getResourceTripleTableID();
-    auto rrrEntry = catalog->getTableCatalogEntry(clientContext->getTx(), rrrTableID);
-    auto rrrExtraInfo = std::make_unique<ExtraBoundCopyRelInfo>();
+    auto oOffset = expressionBinder.createVariableExpression(LogicalType::INT64(), InternalKeyword::DST_OFFSET);
     auto sLookUp = IndexLookupInfo(rTableID, sOffset, s);
     auto pLookUp = IndexLookupInfo(rTableID, pOffset, p);
     auto oLookUp = IndexLookupInfo(rTableID, oOffset, o);
-    rrrExtraInfo->infos.push_back(sLookUp.copy());
-    rrrExtraInfo->infos.push_back(pLookUp.copy());
-    rrrExtraInfo->infos.push_back(oLookUp.copy());
-    expression_vector rrrCopyColumns{sOffset, oOffset, offset, pOffsetInternal};
+    auto lookupInfos = std::vector<IndexLookupInfo>{sLookUp, pLookUp, oLookUp};
+    auto internalIDColumnIndices = std::vector<common::idx_t>{0, 1, 2, 3};
+    auto extraInfo = std::make_unique<ExtraBoundCopyRelInfo>(internalIDColumnIndices, lookupInfos);
+    auto rowOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+        InternalKeyword::ROW_OFFSET);
+    expression_vector rrrCopyColumns{sOffset, oOffset, rowOffset, pOffset};
     std::vector<bool> rrrDefaults{false, false, false, false};
-    auto rrrCopyInfo = BoundCopyFromInfo(rrrEntry, std::move(rrrSource), offset, rrrCopyColumns,
-        rrrDefaults, std::move(rrrExtraInfo));
-    // Bind copy literal triples
-    func = inMemory ? BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfLiteralTripleInMemScan::name, functions) :
-                      BuiltInFunctionsUtils::matchFunction(clientContext->getTx(),
-                          RdfLiteralTripleScan::name, functions);
-    auto rrlScanFunc = ku_dynamic_cast<Function*, TableFunction*>(func);
-    auto rrlColumns = expression_vector{s, p, oOffset};
-    auto rrlFileScanInfo = BoundFileScanInfo(*rrlScanFunc, bindData->copy(), rrlColumns);
-    auto rrlSource = std::make_unique<BoundFileScanSource>(std::move(rrlFileScanInfo));
-    auto rrlTableID = rdfGraphEntry->getLiteralTripleTableID();
-    auto rrlEntry = catalog->getTableCatalogEntry(clientContext->getTx(), rrlTableID);
-    auto rrlExtraInfo = std::make_unique<ExtraBoundCopyRelInfo>();
-    rrlExtraInfo->infos.push_back(sLookUp.copy());
-    rrlExtraInfo->infos.push_back(pLookUp.copy());
-    expression_vector rrlCopyColumns{sOffset, oOffset, offset, pOffsetInternal};
+    return BoundCopyFromInfo(rrrEntry, std::move(scanSource), rowOffset, rrrCopyColumns,
+        rrrDefaults, std::move(extraInfo));
+}
+
+BoundCopyFromInfo Binder::bindCopyRdfLiteralTriplesInfo(const RdfReaderConfig& config,
+    const TableFuncBindData& bindData, const RDFGraphCatalogEntry& rdfEntry) {
+    auto transaction = clientContext->getTx();
+    auto catalog = clientContext->getCatalog();
+    auto functions = catalog->getFunctions(transaction);
+    Function* func;
+    if (config.inMemory) {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralTripleInMemScan::name, functions);
+    } else {
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralTripleScan::name, functions);
+    }
+    auto scanFunc = func->ptrCast<TableFunction>();
+    auto s = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::SUBJECT);
+    auto p = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::PREDICATE);
+    auto oOffset = expressionBinder.createVariableExpression(LogicalType::INT64(), InternalKeyword::DST_OFFSET);
+    auto scanColumns = expression_vector{s, p, oOffset};
+    auto scanInfo = BoundFileScanInfo(*scanFunc, bindData.copy(), scanColumns);
+    auto scanSource = std::make_unique<BoundFileScanSource>(std::move(scanInfo));
+    auto rTableID = rdfEntry.getResourceTableID();
+    auto rrlTableID = rdfEntry.getLiteralTripleTableID();
+    auto rrlEntry = catalog->getTableCatalogEntry(transaction, rrlTableID);
+    auto sOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+        InternalKeyword::SRC_OFFSET);
+    auto pOffset = expressionBinder.createVariableExpression(LogicalType::INT64(), rdf::PID);
+    auto sLookUp = IndexLookupInfo(rTableID, sOffset, s);
+    auto pLookUp = IndexLookupInfo(rTableID, pOffset, p);
+    auto lookupInfos = std::vector<IndexLookupInfo>{sLookUp, pLookUp};
+    auto internalIDColumnIndices = std::vector<common::idx_t>{0, 1, 2, 3};
+    auto extraInfo = std::make_unique<ExtraBoundCopyRelInfo>(internalIDColumnIndices, lookupInfos);
+    auto rowOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+        InternalKeyword::ROW_OFFSET);
+    expression_vector rrlCopyColumns{sOffset, oOffset, rowOffset, pOffset};
     std::vector<bool> rrlDefaults{false, false, false, false};
-    auto rrLCopyInfo = BoundCopyFromInfo(rrlEntry, std::move(rrlSource), offset, rrlCopyColumns,
-        rrlDefaults, std::move(rrlExtraInfo));
-    // Bind copy rdf
+    return BoundCopyFromInfo(rrlEntry, std::move(scanSource), rowOffset, rrlCopyColumns,
+        rrlDefaults, std::move(extraInfo));
+}
+
+std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const Statement& statement,
+    RDFGraphCatalogEntry* rdfGraphEntry) {
+    auto& copyStatement = statement.constCast<CopyFrom>();
+    // Bind path.
+    KU_ASSERT(copyStatement.getSource()->type == ScanSourceType::FILE);
+    auto fileSource = copyStatement.getSource()->constPtrCast<FileScanSource>();
+    auto filePaths = bindFilePaths(fileSource->filePaths);
+    // Bind file type.
+    auto fileType = bindFileType(filePaths);
+    // Bind configurations.
+    auto config = std::make_unique<ReaderConfig>(fileType, std::move(filePaths));
+    config->options = bindParsingOptions(copyStatement.getParsingOptionsRef());
+    auto catalog = clientContext->getCatalog();
+    auto transaction = clientContext->getTx();
+    auto functions = catalog->getFunctions(transaction);
+    // TODO remove me
+    auto bindInput = std::make_unique<ScanTableFuncBindInput>(config->copy());
+    // Bind file scan;
+    auto rdfConfig = RdfReaderConfig::construct(config->options);
+    auto func = BuiltInFunctionsUtils::matchFunction(transaction, RdfAllTripleScan::name, functions);
+    auto scanFunc = func->ptrCast<TableFunction>();
+    auto bindData = scanFunc->bindFunc(clientContext, bindInput.get());
+    auto rCopyInfo = bindCopyRdfResourceInfo(rdfConfig, *bindData, *rdfGraphEntry);
+    auto lCopyInfo = bindCopyRdfLiteralInfo(rdfConfig, *bindData, *rdfGraphEntry);
+    auto rrrCopyInfo = bindCopyRdfResourceTriplesInfo(rdfConfig, *bindData, *rdfGraphEntry);
+    auto rrlCopyInfo = bindCopyRdfLiteralTriplesInfo(rdfConfig, *bindData, *rdfGraphEntry);
     auto rdfExtraInfo = std::make_unique<ExtraBoundCopyRdfInfo>(std::move(rCopyInfo),
-        std::move(lCopyInfo), std::move(rrrCopyInfo), std::move(rrLCopyInfo));
+        std::move(lCopyInfo), std::move(rrrCopyInfo), std::move(rrlCopyInfo));
     std::unique_ptr<BoundBaseScanSource> source;
-    if (inMemory) {
+    if (rdfConfig.inMemory) {
         auto fileScanInfo = BoundFileScanInfo(*scanFunc, bindData->copy(), expression_vector{});
         source = std::make_unique<BoundFileScanSource>(std::move(fileScanInfo));
     } else {
         source = std::make_unique<BoundEmptyScanSource>();
     }
-    auto rdfCopyInfo = BoundCopyFromInfo(rdfGraphEntry, std::move(source), offset, {}, {},
+    auto rowOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+        InternalKeyword::ROW_OFFSET);
+    auto rdfCopyInfo = BoundCopyFromInfo(rdfGraphEntry, std::move(source), rowOffset, {}, {},
         std::move(rdfExtraInfo));
     return std::make_unique<BoundCopyFrom>(std::move(rdfCopyInfo));
 }

--- a/src/binder/bind/copy/bind_copy_rdf_graph.cpp
+++ b/src/binder/bind/copy/bind_copy_rdf_graph.cpp
@@ -29,7 +29,8 @@ BoundCopyFromInfo Binder::bindCopyRdfResourceInfo(const RdfReaderConfig& config,
     auto functions = catalog->getFunctions(transaction);
     Function* func;
     if (config.inMemory) {
-        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceInMemScan::name, functions);
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceInMemScan::name,
+            functions);
     } else {
         func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceScan::name, functions);
     }
@@ -53,7 +54,8 @@ BoundCopyFromInfo Binder::bindCopyRdfLiteralInfo(const RdfReaderConfig& config,
     auto functions = catalog->getFunctions(transaction);
     Function* func;
     if (config.inMemory) {
-        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralInMemScan::name, functions);
+        func =
+            BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralInMemScan::name, functions);
     } else {
         func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralScan::name, functions);
     }
@@ -64,7 +66,8 @@ BoundCopyFromInfo Binder::bindCopyRdfLiteralInfo(const RdfReaderConfig& config,
     auto scanInfo = BoundFileScanInfo(*scanFunc, bindData.copy(), columns);
     auto scanSource = std::make_unique<BoundFileScanSource>(std::move(scanInfo));
     auto lTableID = rdfEntry.getLiteralTableID();
-    auto lEntry = catalog->getTableCatalogEntry(transaction, lTableID)->ptrCast<NodeTableCatalogEntry>();
+    auto lEntry =
+        catalog->getTableCatalogEntry(transaction, lTableID)->ptrCast<NodeTableCatalogEntry>();
     auto valID = expressionBinder.bindExpression(*lEntry->getPrimaryKey()->getDefaultExpr());
     auto lCopyColumns = expression_vector{valID, val, lang};
     auto rowOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
@@ -80,9 +83,11 @@ BoundCopyFromInfo Binder::bindCopyRdfResourceTriplesInfo(const RdfReaderConfig& 
     auto functions = catalog->getFunctions(transaction);
     Function* func;
     if (config.inMemory) {
-        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceTripleInMemScan::name, functions);
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceTripleInMemScan::name,
+            functions);
     } else {
-        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceTripleScan::name, functions);
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfResourceTripleScan::name,
+            functions);
     }
     auto scanFunc = func->ptrCast<TableFunction>();
     auto s = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::SUBJECT);
@@ -97,7 +102,8 @@ BoundCopyFromInfo Binder::bindCopyRdfResourceTriplesInfo(const RdfReaderConfig& 
     auto sOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
         InternalKeyword::SRC_OFFSET);
     auto pOffset = expressionBinder.createVariableExpression(LogicalType::INT64(), rdf::PID);
-    auto oOffset = expressionBinder.createVariableExpression(LogicalType::INT64(), InternalKeyword::DST_OFFSET);
+    auto oOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+        InternalKeyword::DST_OFFSET);
     auto sLookUp = IndexLookupInfo(rTableID, sOffset, s);
     auto pLookUp = IndexLookupInfo(rTableID, pOffset, p);
     auto oLookUp = IndexLookupInfo(rTableID, oOffset, o);
@@ -119,14 +125,17 @@ BoundCopyFromInfo Binder::bindCopyRdfLiteralTriplesInfo(const RdfReaderConfig& c
     auto functions = catalog->getFunctions(transaction);
     Function* func;
     if (config.inMemory) {
-        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralTripleInMemScan::name, functions);
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralTripleInMemScan::name,
+            functions);
     } else {
-        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralTripleScan::name, functions);
+        func = BuiltInFunctionsUtils::matchFunction(transaction, RdfLiteralTripleScan::name,
+            functions);
     }
     auto scanFunc = func->ptrCast<TableFunction>();
     auto s = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::SUBJECT);
     auto p = expressionBinder.createVariableExpression(LogicalType::STRING(), rdf::PREDICATE);
-    auto oOffset = expressionBinder.createVariableExpression(LogicalType::INT64(), InternalKeyword::DST_OFFSET);
+    auto oOffset = expressionBinder.createVariableExpression(LogicalType::INT64(),
+        InternalKeyword::DST_OFFSET);
     auto scanColumns = expression_vector{s, p, oOffset};
     auto scanInfo = BoundFileScanInfo(*scanFunc, bindData.copy(), scanColumns);
     auto scanSource = std::make_unique<BoundFileScanSource>(std::move(scanInfo));
@@ -168,7 +177,8 @@ std::unique_ptr<BoundStatement> Binder::bindCopyRdfFrom(const Statement& stateme
     auto bindInput = std::make_unique<ScanTableFuncBindInput>(config->copy());
     // Bind file scan;
     auto rdfConfig = RdfReaderConfig::construct(config->options);
-    auto func = BuiltInFunctionsUtils::matchFunction(transaction, RdfAllTripleScan::name, functions);
+    auto func =
+        BuiltInFunctionsUtils::matchFunction(transaction, RdfAllTripleScan::name, functions);
     auto scanFunc = func->ptrCast<TableFunction>();
     auto bindData = scanFunc->bindFunc(clientContext, bindInput.get());
     auto rCopyInfo = bindCopyRdfResourceInfo(rdfConfig, *bindData, *rdfGraphEntry);

--- a/src/binder/bind/ddl/bind_create_rdf_graph.cpp
+++ b/src/binder/bind/ddl/bind_create_rdf_graph.cpp
@@ -25,8 +25,10 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     // Literal table.
     auto literalTableName = RDFGraphCatalogEntry::getLiteralTableName(rdfGraphName);
     std::vector<PropertyInfo> literalProperties;
-    auto serialDefault = ParsedExpressionUtils::getSerialDefaultExpr(Catalog::genSerialName(literalTableName, std::string(rdf::ID)));
-    literalProperties.emplace_back(std::string(rdf::ID), LogicalType::SERIAL(), std::move(serialDefault));
+    auto serialDefault = ParsedExpressionUtils::getSerialDefaultExpr(
+        Catalog::genSerialName(literalTableName, std::string(rdf::ID)));
+    literalProperties.emplace_back(std::string(rdf::ID), LogicalType::SERIAL(),
+        std::move(serialDefault));
     literalProperties.emplace_back(std::string(rdf::VAL), LogicalType::RDF_VARIANT());
     literalProperties.emplace_back(std::string(rdf::LANG), LogicalType::STRING());
     auto literalExtraInfo = std::make_unique<BoundExtraCreateNodeTableInfo>(0 /* primaryKeyIdx */,
@@ -38,9 +40,8 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     std::vector<PropertyInfo> resourceTripleProperties;
     resourceTripleProperties.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
     resourceTripleProperties.emplace_back(std::string(rdf::PID), LogicalType::INTERNAL_ID());
-    auto boundResourceTripleExtraInfo =
-        std::make_unique<BoundExtraCreateRelTableInfo>(
-            INVALID_TABLE_ID, INVALID_TABLE_ID, std::move(resourceTripleProperties));
+    auto boundResourceTripleExtraInfo = std::make_unique<BoundExtraCreateRelTableInfo>(
+        INVALID_TABLE_ID, INVALID_TABLE_ID, std::move(resourceTripleProperties));
     auto boundResourceTripleCreateInfo = BoundCreateTableInfo(TableType::REL,
         resourceTripleTableName, info->onConflict, std::move(boundResourceTripleExtraInfo));
     // Literal triple table.
@@ -48,9 +49,8 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     std::vector<PropertyInfo> literalTripleProperties;
     literalTripleProperties.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
     literalTripleProperties.emplace_back(std::string(rdf::PID), LogicalType::INTERNAL_ID());
-    auto boundLiteralTripleExtraInfo =
-        std::make_unique<BoundExtraCreateRelTableInfo>(
-            INVALID_TABLE_ID, INVALID_TABLE_ID, std::move(literalTripleProperties));
+    auto boundLiteralTripleExtraInfo = std::make_unique<BoundExtraCreateRelTableInfo>(
+        INVALID_TABLE_ID, INVALID_TABLE_ID, std::move(literalTripleProperties));
     auto boundLiteralTripleCreateInfo = BoundCreateTableInfo(TableType::REL, literalTripleTableName,
         info->onConflict, std::move(boundLiteralTripleExtraInfo));
     // Rdf table.

--- a/src/binder/bind/ddl/bind_create_rdf_graph.cpp
+++ b/src/binder/bind/ddl/bind_create_rdf_graph.cpp
@@ -3,10 +3,7 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rdf_graph_catalog_entry.h"
 #include "common/keyword/rdf_keyword.h"
-#include "function/sequence/sequence_functions.h"
 #include "parser/ddl/create_table_info.h"
-#include "parser/expression/parsed_function_expression.h"
-#include "parser/expression/parsed_literal_expression.h"
 
 using namespace kuzu::parser;
 using namespace kuzu::common;
@@ -14,12 +11,6 @@ using namespace kuzu::catalog;
 
 namespace kuzu {
 namespace binder {
-
-static std::unique_ptr<parser::ParsedFunctionExpression> createSerialDefaultExpr(std::string name) {
-    auto param = std::make_unique<parser::ParsedLiteralExpression>(Value(name), "");
-    return std::make_unique<parser::ParsedFunctionExpression>(function::NextValFunction::name,
-        std::move(param), "");
-}
 
 BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info) {
     auto rdfGraphName = info->tableName;
@@ -34,8 +25,8 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     // Literal table.
     auto literalTableName = RDFGraphCatalogEntry::getLiteralTableName(rdfGraphName);
     std::vector<PropertyInfo> literalProperties;
-    literalProperties.emplace_back(std::string(rdf::ID), LogicalType::SERIAL(),
-        createSerialDefaultExpr(Catalog::genSerialName(literalTableName, std::string(rdf::ID))));
+    auto serialDefault = ParsedExpressionUtils::getSerialDefaultExpr(Catalog::genSerialName(literalTableName, std::string(rdf::ID)));
+    literalProperties.emplace_back(std::string(rdf::ID), LogicalType::SERIAL(), std::move(serialDefault));
     literalProperties.emplace_back(std::string(rdf::VAL), LogicalType::RDF_VARIANT());
     literalProperties.emplace_back(std::string(rdf::LANG), LogicalType::STRING());
     auto literalExtraInfo = std::make_unique<BoundExtraCreateNodeTableInfo>(0 /* primaryKeyIdx */,
@@ -48,7 +39,7 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     resourceTripleProperties.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
     resourceTripleProperties.emplace_back(std::string(rdf::PID), LogicalType::INTERNAL_ID());
     auto boundResourceTripleExtraInfo =
-        std::make_unique<BoundExtraCreateRelTableInfo>(RelMultiplicity::MANY, RelMultiplicity::MANY,
+        std::make_unique<BoundExtraCreateRelTableInfo>(
             INVALID_TABLE_ID, INVALID_TABLE_ID, std::move(resourceTripleProperties));
     auto boundResourceTripleCreateInfo = BoundCreateTableInfo(TableType::REL,
         resourceTripleTableName, info->onConflict, std::move(boundResourceTripleExtraInfo));
@@ -58,7 +49,7 @@ BoundCreateTableInfo Binder::bindCreateRdfGraphInfo(const CreateTableInfo* info)
     literalTripleProperties.emplace_back(InternalKeyword::ID, LogicalType::INTERNAL_ID());
     literalTripleProperties.emplace_back(std::string(rdf::PID), LogicalType::INTERNAL_ID());
     auto boundLiteralTripleExtraInfo =
-        std::make_unique<BoundExtraCreateRelTableInfo>(RelMultiplicity::MANY, RelMultiplicity::MANY,
+        std::make_unique<BoundExtraCreateRelTableInfo>(
             INVALID_TABLE_ID, INVALID_TABLE_ID, std::move(literalTripleProperties));
     auto boundLiteralTripleCreateInfo = BoundCreateTableInfo(TableType::REL, literalTripleTableName,
         info->onConflict, std::move(boundLiteralTripleExtraInfo));

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -49,6 +49,10 @@ namespace transaction {
 class Transaction;
 } // namespace transaction
 
+namespace common {
+struct RdfReaderConfig;
+}
+
 namespace binder {
 struct PropertyInfo;
 struct BoundBaseScanSource;
@@ -61,6 +65,7 @@ class BoundReturnClause;
 struct BoundFileScanInfo;
 struct ExportedTableData;
 struct BoundJoinHintNode;
+struct BoundCopyFromInfo;
 
 // BinderScope keeps track of expressions in scope and their aliases. We maintain the order of
 // expressions in
@@ -128,6 +133,14 @@ public:
         catalog::RelTableCatalogEntry* relTableEntry);
     std::unique_ptr<BoundStatement> bindCopyRdfFrom(const parser::Statement& statement,
         catalog::RDFGraphCatalogEntry* rdfGraphEntry);
+    BoundCopyFromInfo bindCopyRdfResourceInfo(const common::RdfReaderConfig& config,
+        const function::TableFuncBindData& bindData, const catalog::RDFGraphCatalogEntry& rdfEntry);
+    BoundCopyFromInfo bindCopyRdfLiteralInfo(const common::RdfReaderConfig& config,
+        const function::TableFuncBindData& bindData, const catalog::RDFGraphCatalogEntry& rdfEntry);
+    BoundCopyFromInfo bindCopyRdfResourceTriplesInfo(const common::RdfReaderConfig& config,
+        const function::TableFuncBindData& bindData, const catalog::RDFGraphCatalogEntry& rdfEntry);
+    BoundCopyFromInfo bindCopyRdfLiteralTriplesInfo(const common::RdfReaderConfig& config,
+        const function::TableFuncBindData& bindData, const catalog::RDFGraphCatalogEntry& rdfEntry);
 
     std::unique_ptr<BoundStatement> bindCopyToClause(const parser::Statement& statement);
 

--- a/src/include/binder/copy/bound_copy_from.h
+++ b/src/include/binder/copy/bound_copy_from.h
@@ -11,6 +11,11 @@ namespace binder {
 struct ExtraBoundCopyFromInfo {
     virtual ~ExtraBoundCopyFromInfo() = default;
     virtual std::unique_ptr<ExtraBoundCopyFromInfo> copy() const = 0;
+
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const ExtraBoundCopyFromInfo&, const TARGET&>(*this);
+    }
 };
 
 struct BoundCopyFromInfo {
@@ -44,12 +49,16 @@ private:
 };
 
 struct ExtraBoundCopyRelInfo final : public ExtraBoundCopyFromInfo {
+    // We process internal ID column as offset (INT64) column until partitioner. In partitioner,
+    // we need to manually change offset(INT64) type to internal ID type.
+    std::vector<common::idx_t> internalIDColumnIndices;
     std::vector<IndexLookupInfo> infos;
 
-    ExtraBoundCopyRelInfo() = default;
-    ExtraBoundCopyRelInfo(const ExtraBoundCopyRelInfo& other) : infos{copyVector(other.infos)} {}
+    ExtraBoundCopyRelInfo(std::vector<common::idx_t> internalIDColumnIndices, std::vector<IndexLookupInfo> infos)
+        : internalIDColumnIndices{std::move(internalIDColumnIndices)}, infos{std::move(infos)} {}
+    ExtraBoundCopyRelInfo(const ExtraBoundCopyRelInfo& other) : internalIDColumnIndices{other.internalIDColumnIndices}, infos{other.infos} {}
 
-    inline std::unique_ptr<ExtraBoundCopyFromInfo> copy() const override {
+    std::unique_ptr<ExtraBoundCopyFromInfo> copy() const override {
         return std::make_unique<ExtraBoundCopyRelInfo>(*this);
     }
 };
@@ -68,19 +77,20 @@ struct ExtraBoundCopyRdfInfo final : public ExtraBoundCopyFromInfo {
         : rInfo{other.rInfo.copy()}, lInfo{other.lInfo.copy()}, rrrInfo{other.rrrInfo.copy()},
           rrlInfo{other.rrlInfo.copy()} {}
 
-    inline std::unique_ptr<ExtraBoundCopyFromInfo> copy() const override {
+    std::unique_ptr<ExtraBoundCopyFromInfo> copy() const override {
         return std::make_unique<ExtraBoundCopyRdfInfo>(*this);
     }
 };
 
 class BoundCopyFrom : public BoundStatement {
+    static constexpr common::StatementType statementType_ = common::StatementType::COPY_FROM;
+
 public:
     explicit BoundCopyFrom(BoundCopyFromInfo info)
-        : BoundStatement{common::StatementType::COPY_FROM,
-              BoundStatementResult::createSingleStringColumnResult()},
+        : BoundStatement{statementType_, BoundStatementResult::createSingleStringColumnResult()},
           info{std::move(info)} {}
 
-    inline const BoundCopyFromInfo* getInfo() const { return &info; }
+    const BoundCopyFromInfo* getInfo() const { return &info; }
 
 private:
     BoundCopyFromInfo info;

--- a/src/include/binder/copy/bound_copy_from.h
+++ b/src/include/binder/copy/bound_copy_from.h
@@ -54,9 +54,11 @@ struct ExtraBoundCopyRelInfo final : public ExtraBoundCopyFromInfo {
     std::vector<common::idx_t> internalIDColumnIndices;
     std::vector<IndexLookupInfo> infos;
 
-    ExtraBoundCopyRelInfo(std::vector<common::idx_t> internalIDColumnIndices, std::vector<IndexLookupInfo> infos)
+    ExtraBoundCopyRelInfo(std::vector<common::idx_t> internalIDColumnIndices,
+        std::vector<IndexLookupInfo> infos)
         : internalIDColumnIndices{std::move(internalIDColumnIndices)}, infos{std::move(infos)} {}
-    ExtraBoundCopyRelInfo(const ExtraBoundCopyRelInfo& other) : internalIDColumnIndices{other.internalIDColumnIndices}, infos{other.infos} {}
+    ExtraBoundCopyRelInfo(const ExtraBoundCopyRelInfo& other)
+        : internalIDColumnIndices{other.internalIDColumnIndices}, infos{other.infos} {}
 
     std::unique_ptr<ExtraBoundCopyFromInfo> copy() const override {
         return std::make_unique<ExtraBoundCopyRelInfo>(*this);

--- a/src/include/binder/copy/index_look_up_info.h
+++ b/src/include/binder/copy/index_look_up_info.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "binder/expression/expression.h"
+
 namespace kuzu {
 namespace binder {
 
@@ -12,9 +13,6 @@ struct IndexLookupInfo {
     IndexLookupInfo(common::table_id_t nodeTableID, std::shared_ptr<binder::Expression> offset,
         std::shared_ptr<binder::Expression> key)
         : nodeTableID{nodeTableID}, offset{std::move(offset)}, key{std::move(key)} {}
-    EXPLICIT_COPY_DEFAULT_MOVE(IndexLookupInfo);
-
-private:
     IndexLookupInfo(const IndexLookupInfo& other)
         : nodeTableID{other.nodeTableID}, offset{other.offset}, key{other.key} {}
 };

--- a/src/include/binder/ddl/bound_create_table_info.h
+++ b/src/include/binder/ddl/bound_create_table_info.h
@@ -104,6 +104,10 @@ struct BoundExtraCreateRelTableInfo final : public BoundExtraCreateTableInfo {
     common::table_id_t srcTableID;
     common::table_id_t dstTableID;
 
+    BoundExtraCreateRelTableInfo(common::table_id_t srcTableID, common::table_id_t dstTableID,
+        std::vector<PropertyInfo> propertyInfos)
+        : BoundExtraCreateRelTableInfo{common::RelMultiplicity::MANY, common::RelMultiplicity::MANY,
+              srcTableID, dstTableID, std::move(propertyInfos)} {}
     BoundExtraCreateRelTableInfo(common::RelMultiplicity srcMultiplicity,
         common::RelMultiplicity dstMultiplicity, common::table_id_t srcTableID,
         common::table_id_t dstTableID, std::vector<PropertyInfo> propertyInfos)

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -76,7 +76,7 @@ struct KUZU_API TableFunction : public Function {
     table_func_init_shared_t initSharedStateFunc;
     table_func_init_local_t initLocalStateFunc;
     table_func_can_parallel_t canParallelFunc = [] { return true; };
-    table_func_progress_t progressFunc = [](TableFuncSharedState* /*sharedState*/) { return 0.0; };
+    table_func_progress_t progressFunc = [](TableFuncSharedState*) { return 0.0; };
 
     TableFunction()
         : Function{}, tableFunc{nullptr}, bindFunc{nullptr}, initSharedStateFunc{nullptr},

--- a/src/include/parser/expression/parsed_expression.h
+++ b/src/include/parser/expression/parsed_expression.h
@@ -93,5 +93,9 @@ protected:
 
 using options_t = std::unordered_map<std::string, std::unique_ptr<parser::ParsedExpression>>;
 
+struct ParsedExpressionUtils {
+    static std::unique_ptr<ParsedExpression> getSerialDefaultExpr(const std::string& sequenceName);
+};
+
 } // namespace parser
 } // namespace kuzu

--- a/src/include/planner/operator/logical_partitioner.h
+++ b/src/include/planner/operator/logical_partitioner.h
@@ -13,22 +13,20 @@ struct LogicalPartitionerInfo {
 
     LogicalPartitionerInfo(common::idx_t keyIdx, common::ColumnDataFormat dataFormat)
         : keyIdx{keyIdx}, dataFormat{dataFormat} {}
+    EXPLICIT_COPY_DEFAULT_MOVE(LogicalPartitionerInfo);
+
+private:
     LogicalPartitionerInfo(const LogicalPartitionerInfo& other)
         : keyIdx{other.keyIdx}, dataFormat{other.dataFormat} {}
-
-    inline std::unique_ptr<LogicalPartitionerInfo> copy() {
-        return std::make_unique<LogicalPartitionerInfo>(*this);
-    }
-
-    static std::vector<std::unique_ptr<LogicalPartitionerInfo>> copy(
-        const std::vector<std::unique_ptr<LogicalPartitionerInfo>>& infos);
 };
 
 class LogicalPartitioner : public LogicalOperator {
+    static constexpr LogicalOperatorType operatorType_ = LogicalOperatorType::PARTITIONER;
+
 public:
-    LogicalPartitioner(std::vector<std::unique_ptr<LogicalPartitionerInfo>> infos,
+    LogicalPartitioner(std::vector<LogicalPartitionerInfo> infos,
         binder::BoundCopyFromInfo copyFromInfo, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{LogicalOperatorType::PARTITIONER, std::move(child)},
+        : LogicalOperator{operatorType_, std::move(child)},
           infos{std::move(infos)}, copyFromInfo{std::move(copyFromInfo)} {}
 
     void computeFactorizedSchema() final;
@@ -36,19 +34,19 @@ public:
 
     std::string getExpressionsForPrinting() const final;
 
-    inline common::idx_t getNumInfos() const { return infos.size(); }
-    inline LogicalPartitionerInfo* getInfo(common::idx_t idx) const {
+    common::idx_t getNumInfos() const { return infos.size(); }
+    const LogicalPartitionerInfo* getInfo(common::idx_t idx) const {
         KU_ASSERT(idx < infos.size());
-        return infos[idx].get();
+        return &infos[idx];
     }
 
-    inline std::unique_ptr<LogicalOperator> copy() final {
-        return make_unique<LogicalPartitioner>(LogicalPartitionerInfo::copy(infos),
+    std::unique_ptr<LogicalOperator> copy() final {
+        return make_unique<LogicalPartitioner>(copyVector(infos),
             copyFromInfo.copy(), children[0]->copy());
     }
 
 private:
-    std::vector<std::unique_ptr<LogicalPartitionerInfo>> infos;
+    std::vector<LogicalPartitionerInfo> infos;
 
 public:
     binder::BoundCopyFromInfo copyFromInfo;

--- a/src/include/planner/operator/logical_partitioner.h
+++ b/src/include/planner/operator/logical_partitioner.h
@@ -26,8 +26,8 @@ class LogicalPartitioner : public LogicalOperator {
 public:
     LogicalPartitioner(std::vector<LogicalPartitionerInfo> infos,
         binder::BoundCopyFromInfo copyFromInfo, std::shared_ptr<LogicalOperator> child)
-        : LogicalOperator{operatorType_, std::move(child)},
-          infos{std::move(infos)}, copyFromInfo{std::move(copyFromInfo)} {}
+        : LogicalOperator{operatorType_, std::move(child)}, infos{std::move(infos)},
+          copyFromInfo{std::move(copyFromInfo)} {}
 
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;
@@ -41,8 +41,8 @@ public:
     }
 
     std::unique_ptr<LogicalOperator> copy() final {
-        return make_unique<LogicalPartitioner>(copyVector(infos),
-            copyFromInfo.copy(), children[0]->copy());
+        return make_unique<LogicalPartitioner>(copyVector(infos), copyFromInfo.copy(),
+            children[0]->copy());
     }
 
 private:

--- a/src/include/planner/operator/scan/logical_index_look_up.h
+++ b/src/include/planner/operator/scan/logical_index_look_up.h
@@ -26,7 +26,7 @@ public:
     const binder::IndexLookupInfo& getInfo(uint32_t idx) const { return infos[idx]; }
 
     std::unique_ptr<LogicalOperator> copy() override {
-        return make_unique<LogicalPrimaryKeyLookup>(copyVector(infos), children[0]->copy());
+        return make_unique<LogicalPrimaryKeyLookup>(infos, children[0]->copy());
     }
 
 private:

--- a/src/include/processor/operator/persistent/reader/rdf/triple_store.h
+++ b/src/include/processor/operator/persistent/reader/rdf/triple_store.h
@@ -15,6 +15,11 @@ struct RdfStore {
     virtual bool isEmpty() const = 0;
     virtual uint64_t size() const = 0;
     virtual void clear() = 0;
+
+    template<class TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<RdfStore&, TARGET&>(*this);
+    }
 };
 
 struct ResourceStore final : public RdfStore {

--- a/src/parser/expression/parsed_expression.cpp
+++ b/src/parser/expression/parsed_expression.cpp
@@ -2,6 +2,7 @@
 
 #include "common/serializer/deserializer.h"
 #include "common/serializer/serializer.h"
+#include "function/sequence/sequence_functions.h"
 #include "parser/expression/parsed_case_expression.h"
 #include "parser/expression/parsed_function_expression.h"
 #include "parser/expression/parsed_literal_expression.h"
@@ -9,7 +10,6 @@
 #include "parser/expression/parsed_property_expression.h"
 #include "parser/expression/parsed_subquery_expression.h"
 #include "parser/expression/parsed_variable_expression.h"
-#include "function/sequence/sequence_functions.h"
 
 using namespace kuzu::common;
 
@@ -79,7 +79,8 @@ std::unique_ptr<ParsedExpression> ParsedExpression::deserialize(Deserializer& de
     return parsedExpression;
 }
 
-std::unique_ptr<ParsedExpression> ParsedExpressionUtils::getSerialDefaultExpr(const std::string& sequenceName) {
+std::unique_ptr<ParsedExpression> ParsedExpressionUtils::getSerialDefaultExpr(
+    const std::string& sequenceName) {
     auto literalExpr = std::make_unique<parser::ParsedLiteralExpression>(Value(sequenceName), "");
     return std::make_unique<parser::ParsedFunctionExpression>(function::NextValFunction::name,
         std::move(literalExpr), "");

--- a/src/parser/expression/parsed_expression.cpp
+++ b/src/parser/expression/parsed_expression.cpp
@@ -9,6 +9,7 @@
 #include "parser/expression/parsed_property_expression.h"
 #include "parser/expression/parsed_subquery_expression.h"
 #include "parser/expression/parsed_variable_expression.h"
+#include "function/sequence/sequence_functions.h"
 
 using namespace kuzu::common;
 
@@ -76,6 +77,12 @@ std::unique_ptr<ParsedExpression> ParsedExpression::deserialize(Deserializer& de
     parsedExpression->rawName = std::move(rawName);
     parsedExpression->children = std::move(children);
     return parsedExpression;
+}
+
+std::unique_ptr<ParsedExpression> ParsedExpressionUtils::getSerialDefaultExpr(const std::string& sequenceName) {
+    auto literalExpr = std::make_unique<parser::ParsedLiteralExpression>(Value(sequenceName), "");
+    return std::make_unique<parser::ParsedFunctionExpression>(function::NextValFunction::name,
+        std::move(literalExpr), "");
 }
 
 } // namespace parser

--- a/src/planner/operator/logical_partitioner.cpp
+++ b/src/planner/operator/logical_partitioner.cpp
@@ -5,16 +5,6 @@
 namespace kuzu {
 namespace planner {
 
-std::vector<std::unique_ptr<LogicalPartitionerInfo>> LogicalPartitionerInfo::copy(
-    const std::vector<std::unique_ptr<LogicalPartitionerInfo>>& infos) {
-    std::vector<std::unique_ptr<LogicalPartitionerInfo>> result;
-    result.reserve(infos.size());
-    for (auto& info : infos) {
-        result.push_back(info->copy());
-    }
-    return result;
-}
-
 void LogicalPartitioner::computeFactorizedSchema() {
     copyChildSchema(0);
 }
@@ -26,7 +16,7 @@ void LogicalPartitioner::computeFlatSchema() {
 std::string LogicalPartitioner::getExpressionsForPrinting() const {
     binder::expression_vector expressions;
     for (auto& info : infos) {
-        expressions.push_back(copyFromInfo.columnExprs[info->keyIdx]);
+        expressions.push_back(copyFromInfo.columnExprs[info.keyIdx]);
     }
     return binder::ExpressionUtil::toString(expressions);
 }

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -29,11 +29,11 @@ static void appendPartitioner(const BoundCopyFromInfo& copyFromInfo, LogicalPlan
     // Partitioner for FWD direction rel data.
     infos.push_back(LogicalPartitionerInfo(RelKeyIdx::FWD /* keyIdx */,
         relTableEntry.isSingleMultiplicity(RelDataDirection::FWD) ? ColumnDataFormat::REGULAR :
-                                                                     ColumnDataFormat::CSR));
+                                                                    ColumnDataFormat::CSR));
     // Partitioner for BWD direction rel data.
     infos.push_back(LogicalPartitionerInfo(RelKeyIdx::BWD /* keyIdx */,
         relTableEntry.isSingleMultiplicity(RelDataDirection::BWD) ? ColumnDataFormat::REGULAR :
-                                                                     ColumnDataFormat::CSR));
+                                                                    ColumnDataFormat::CSR));
     auto partitioner = std::make_shared<LogicalPartitioner>(std::move(infos), copyFromInfo.copy(),
         plan.getLastOperator());
     partitioner->computeFactorizedSchema();

--- a/src/planner/plan/plan_copy.cpp
+++ b/src/planner/plan/plan_copy.cpp
@@ -24,16 +24,15 @@ static void appendIndexScan(std::vector<IndexLookupInfo> infos, LogicalPlan& pla
 }
 
 static void appendPartitioner(const BoundCopyFromInfo& copyFromInfo, LogicalPlan& plan) {
-    std::vector<std::unique_ptr<LogicalPartitionerInfo>> infos;
-    auto relTableEntry =
-        ku_dynamic_cast<TableCatalogEntry*, RelTableCatalogEntry*>(copyFromInfo.tableEntry);
+    std::vector<LogicalPartitionerInfo> infos;
+    auto& relTableEntry = copyFromInfo.tableEntry->constCast<RelTableCatalogEntry>();
     // Partitioner for FWD direction rel data.
-    infos.push_back(std::make_unique<LogicalPartitionerInfo>(RelKeyIdx::FWD /* keyIdx */,
-        relTableEntry->isSingleMultiplicity(RelDataDirection::FWD) ? ColumnDataFormat::REGULAR :
+    infos.push_back(LogicalPartitionerInfo(RelKeyIdx::FWD /* keyIdx */,
+        relTableEntry.isSingleMultiplicity(RelDataDirection::FWD) ? ColumnDataFormat::REGULAR :
                                                                      ColumnDataFormat::CSR));
     // Partitioner for BWD direction rel data.
-    infos.push_back(std::make_unique<LogicalPartitionerInfo>(RelKeyIdx::BWD /* keyIdx */,
-        relTableEntry->isSingleMultiplicity(RelDataDirection::BWD) ? ColumnDataFormat::REGULAR :
+    infos.push_back(LogicalPartitionerInfo(RelKeyIdx::BWD /* keyIdx */,
+        relTableEntry.isSingleMultiplicity(RelDataDirection::BWD) ? ColumnDataFormat::REGULAR :
                                                                      ColumnDataFormat::CSR));
     auto partitioner = std::make_shared<LogicalPartitioner>(std::move(infos), copyFromInfo.copy(),
         plan.getLastOperator());
@@ -125,7 +124,7 @@ std::unique_ptr<LogicalPlan> Planner::planCopyRelFrom(const BoundCopyFromInfo* i
     }
     auto extraInfo =
         ku_dynamic_cast<ExtraBoundCopyFromInfo*, ExtraBoundCopyRelInfo*>(info->extraInfo.get());
-    appendIndexScan(copyVector(extraInfo->infos), *plan);
+    appendIndexScan(extraInfo->infos, *plan);
     appendPartitioner(*info, *plan);
     appendCopyFrom(*info, results, *plan);
     return plan;

--- a/src/processor/operator/persistent/reader/rdf/rdf_reader.cpp
+++ b/src/processor/operator/persistent/reader/rdf/rdf_reader.cpp
@@ -161,7 +161,7 @@ SerdStatus RdfResourceReader::handle(void* handle, SerdStatementFlags, const Ser
     const SerdNode* subject, const SerdNode* predicate, const SerdNode* object, const SerdNode*,
     const SerdNode*) {
     auto reader = reinterpret_cast<RdfReader*>(handle);
-    auto& store = ku_dynamic_cast<RdfStore&, ResourceStore&>(*reader->store_);
+    auto& store = reader->store_->cast<ResourceStore>();
     auto subjectStr = reader->getAsString(subject);
     auto predicateStr = reader->getAsString(predicate);
     if (object->type == SERD_LITERAL) {
@@ -198,7 +198,7 @@ SerdStatus RdfLiteralReader::handle(void* handle, SerdStatementFlags, const Serd
     const SerdNode* subject, const SerdNode* predicate, const SerdNode* object,
     const SerdNode* object_datatype, const SerdNode* object_lang) {
     auto reader = reinterpret_cast<RdfReader*>(handle);
-    auto& store = ku_dynamic_cast<RdfStore&, LiteralStore&>(*reader->store_);
+    auto& store = reader->store_->cast<LiteralStore>();
     if (object->type != SERD_LITERAL) {
         return SERD_SUCCESS;
     }
@@ -228,7 +228,7 @@ SerdStatus RdfLiteralReader::handle(void* handle, SerdStatementFlags, const Serd
 uint64_t RdfLiteralReader::readToVector(common::DataChunk* dataChunk) {
     auto lVector = dataChunk->getValueVector(0).get();
     auto langVector = dataChunk->getValueVector(1).get();
-    auto& store = ku_dynamic_cast<RdfStore&, LiteralStore&>(*store_);
+    auto& store = store_->cast<LiteralStore>();
     auto numTuplesToScan = std::min(store.size() - cursor, DEFAULT_VECTOR_CAPACITY);
     for (auto i = 0u; i < numTuplesToScan; ++i) {
         auto& literal = store.literals[cursor + i];
@@ -237,6 +237,7 @@ uint64_t RdfLiteralReader::readToVector(common::DataChunk* dataChunk) {
         RdfUtils::addRdfLiteral(lVector, i, literal, type);
         StringVector::addString(langVector, i, lang);
     }
+    numLiteralTriplesScanned += numTuplesToScan;
     return numTuplesToScan;
 }
 
@@ -244,7 +245,7 @@ SerdStatus RdfResourceTripleReader::handle(void* handle, SerdStatementFlags, con
     const SerdNode* subject, const SerdNode* predicate, const SerdNode* object, const SerdNode*,
     const SerdNode*) {
     auto reader = reinterpret_cast<RdfReader*>(handle);
-    auto& store = ku_dynamic_cast<RdfStore&, ResourceTripleStore&>(*reader->store_);
+    auto& store = reader->store_->cast<ResourceTripleStore>();
     if (object->type == SERD_LITERAL) {
         return SERD_SUCCESS;
     }
@@ -264,7 +265,7 @@ uint64_t RdfResourceTripleReader::readToVector(DataChunk* dataChunk) {
     auto sVector = dataChunk->getValueVector(0).get();
     auto pVector = dataChunk->getValueVector(1).get();
     auto oVector = dataChunk->getValueVector(2).get();
-    auto& store = ku_dynamic_cast<RdfStore&, ResourceTripleStore&>(*store_);
+    auto& store = store_->cast<ResourceTripleStore>();
     auto numTuplesToScan = std::min(store.size() - cursor, DEFAULT_VECTOR_CAPACITY);
     for (auto i = 0u; i < numTuplesToScan; ++i) {
         StringVector::addString(sVector, i, store.subjects[cursor + i]);
@@ -278,7 +279,7 @@ SerdStatus RdfLiteralTripleReader::handle(void* handle, SerdStatementFlags, cons
     const SerdNode* subject, const SerdNode* predicate, const SerdNode* object, const SerdNode*,
     const SerdNode*) {
     auto reader = reinterpret_cast<RdfReader*>(handle);
-    auto& store = ku_dynamic_cast<RdfStore&, LiteralTripleStore&>(*reader->store_);
+    auto& store = reader->store_->cast<LiteralTripleStore>();
     if (object->type != SERD_LITERAL) {
         return SERD_SUCCESS;
     }
@@ -296,7 +297,7 @@ uint64_t RdfLiteralTripleReader::readToVector(DataChunk* dataChunk) {
     auto sVector = dataChunk->getValueVector(0).get();
     auto pVector = dataChunk->getValueVector(1).get();
     auto oVector = dataChunk->getValueVector(2).get();
-    auto& store = ku_dynamic_cast<RdfStore&, LiteralTripleStore&>(*store_);
+    auto& store = store_->cast<LiteralTripleStore>();
     auto numTuplesToScan = std::min(store.size() - cursor, DEFAULT_VECTOR_CAPACITY);
     for (auto i = 0u; i < numTuplesToScan; ++i) {
         StringVector::addString(sVector, i, store.subjects[cursor + i]);
@@ -311,7 +312,7 @@ SerdStatus RdfTripleReader::handle(void* handle, SerdStatementFlags, const SerdN
     const SerdNode* subject, const SerdNode* predicate, const SerdNode* object,
     const SerdNode* object_datatype, const SerdNode* object_lang) {
     auto reader = reinterpret_cast<RdfReader*>(handle);
-    auto& store = ku_dynamic_cast<RdfStore&, TripleStore&>(*reader->store_);
+    auto& store = reader->store_->cast<TripleStore>();
     auto subjectStr = reader->getAsString(subject);
     auto predicateStr = reader->getAsString(predicate);
     auto objectStr = reader->getAsString(object);

--- a/src/processor/operator/persistent/reader/rdf/rdf_scan.cpp
+++ b/src/processor/operator/persistent/reader/rdf/rdf_scan.cpp
@@ -248,6 +248,7 @@ function_set RdfLiteralScan::getFunctionSet() {
     function_set functionSet;
     auto func = std::make_unique<TableFunction>(name, scanTableFunc, nullptr,
         RdfLiteralScanInitSharedState, initLocalState, std::vector<LogicalTypeID>{});
+    func->canParallelFunc = [] { return false; };
     functionSet.push_back(std::move(func));
     return functionSet;
 }
@@ -291,6 +292,7 @@ function_set RdfLiteralInMemScan::getFunctionSet() {
     auto func = std::make_unique<TableFunction>(name, RdfLiteralInMemScanTableFunc, nullptr,
         inMemScanInitSharedState, initLocalState, RdfLiteralInMemScanProgressFunc,
         std::vector<LogicalTypeID>{});
+    func->canParallelFunc = [] { return false; };
     functionSet.push_back(std::move(func));
     return functionSet;
 }


### PR DESCRIPTION
# Description

Our RDF copy relies on the fact that literal primary key (SERIAL) aligns with row offset. Since we start materializing SERIAL and start parallel processing over SERIAL column. The  previous assumption no longer holds. I have set RDF literal copy pipeline back to single-threaded to enforce the assumption.

An alternative is to materialize literal primary key as INT64 instead of SERIAL. This however, will break `CREATE` because we will ask user to input a valid primary key for RDF literal instead of generating one internally. I found it quite a bit of work to do this internal generation so end up taking the easy approach.

The change of this PR is mostly refactor.

Fixes #3616 

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).