### PR TITLE
Fix python struct and map type interpretation

### DIFF
--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -153,7 +153,6 @@ static scalar_func_exec_t getUDFExecFunc(const py::function& udf, bool defaultNu
             } else {
                 try {
                     auto pyResult = udf(*pyParams);
-                    auto a = py::reinterpret_borrow<py::dict>(pyResult);
                     auto resultValue =
                         PyConnection::transformPythonValueAs(pyResult, result.dataType);
                     result.copyFromValue(resultPos, resultValue);

--- a/tools/python_api/src_cpp/py_udf.cpp
+++ b/tools/python_api/src_cpp/py_udf.cpp
@@ -153,6 +153,7 @@ static scalar_func_exec_t getUDFExecFunc(const py::function& udf, bool defaultNu
             } else {
                 try {
                     auto pyResult = udf(*pyParams);
+                    auto a = py::reinterpret_borrow<py::dict>(pyResult);
                     auto resultValue =
                         PyConnection::transformPythonValueAs(pyResult, result.dataType);
                     result.copyFromValue(resultPos, resultValue);

--- a/tools/python_api/test/test_issue.py
+++ b/tools/python_api/test/test_issue.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from tools.python_api.test.type_aliases import ConnDB
 
-
 # required by python-lint
 
 
@@ -83,8 +82,6 @@ def test_empty_list2(conn_db_readwrite: ConnDB) -> None:
 
 
 def test_empty_map(conn_db_readwrite: ConnDB) -> None:
-    import time
-    #time.sleep(10)
     conn, db = conn_db_readwrite
     conn.execute(
         """

--- a/tools/python_api/test/test_issue.py
+++ b/tools/python_api/test/test_issue.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from tools.python_api.test.type_aliases import ConnDB
 
+
 # required by python-lint
 
 
@@ -82,6 +83,8 @@ def test_empty_list2(conn_db_readwrite: ConnDB) -> None:
 
 
 def test_empty_map(conn_db_readwrite: ConnDB) -> None:
+    import time
+    #time.sleep(10)
     conn, db = conn_db_readwrite
     conn.execute(
         """
@@ -99,15 +102,14 @@ def test_empty_map(conn_db_readwrite: ConnDB) -> None:
             RETURN n.id, n.prop1, n.prop2
         """,
         {
-            "prop1": {},
-            "prop2": {"a": []},
+            "prop1": {"key": [], "value": []},
+            "prop2": {"key": ["a"], "value": [[]]},
         },
     )
     assert result.has_next()
     assert result.get_next() == [0, {}, {"a": []}]
     assert not result.has_next()
     result.close()
-
 
 # TODO(Maxwell): check if we should change getCastCost() for the following test
 # def test_issue_3248(conn_db_readwrite: ConnDB) -> None:


### PR DESCRIPTION
# Description

As desribed in #3814, python dictionaries are interpreted as `MAP` instead of `STRUCT`. This PR follows the duckdb way of translating python `DICT` to kuzu internal types.

The dict object can convert to either STRUCT(...) or MAP(..., ...) depending on its structure. If the dict has a structure similar to:
```
my_map_dict = {
    "key": [
        1, 2, 3
    ],
    "value": [
        "one", "two", "three"
    ]
}
```
Then we'll convert it to a MAP of key-value pairs of the two lists zipped together. The example above becomes a MAP(INTEGER, VARCHAR):
```
{1=one, 2=two, 3=three}
```
Otherwise we'll try to convert it to a STRUCT.
```
my_struct_dict = {
    1: "one",
    "2": 2,
    "three": [1, 2, 3],
    False: True
}
```
Becomes:
```
{'1': one, '2': 2, 'three': [1, 2, 3], 'False': true}
```


Fixes # 3814