### PR TITLE
Set number of jobs in rust build using Cargo's parallel level

### DIFF
--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -73,6 +73,9 @@ fn build_bundled_cmake() -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
         build.define("CMAKE_MSVC_RUNTIME_LIBRARY", "MultiThreadedDLL");
         build.define("CMAKE_POLICY_DEFAULT_CMP0091", "NEW");
     }
+    if let Ok(jobs) = std::env::var("NUM_JOBS") {
+        std::env::set_var("CMAKE_BUILD_PARALLEL_LEVEL", jobs);
+    }
     let build_dir = build.build();
 
     let kuzu_lib_path = build_dir.join("build").join("src");

--- a/tools/rust_api/src/lib.rs
+++ b/tools/rust_api/src/lib.rs
@@ -23,8 +23,6 @@
 //! ## Building
 //!
 //! By default, the kuzu C++ library will be compiled from source and statically linked.
-//! If the kuzu C++ library is not being built using multiple threads by default, you can set the
-//! CMAKE_BUILD_PARALLEL_LEVEL environment variable to potentially speed up the build process.
 //!
 //! If you want to instead link against a pre-built version of the library, the following environment
 //! variables can be used to configure the build process:


### PR DESCRIPTION
Fixes #3784.
Sets the bundled CMake build's parallelism level using the `NUM_JOBS` environment variable provided by Cargo in case the jobserver isn't available (as appears to be the case on macOS).