### PR TITLE
Add error message when kuzu detects numpy version at or above 2.0.0

### DIFF
--- a/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
@@ -2,7 +2,6 @@
 
 #include "common/assert.h"
 #include "cached_import/py_cached_import.h"
-#include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
 
 namespace kuzu {
@@ -27,7 +26,7 @@ py::handle NumpyMaCachedItem::operator()() {
     KU_ASSERT((bool)PyGILState_Check());
     auto obj = numpy();
     if (py::cast<std::string>(obj.attr("__version__"))[0] >= '2') {
-        throw common::NotImplementedException(
+        throw common::RuntimeException(
             "Kuzu cannot currently support numpy versions at or above 2.0.0\n"
             "Try 1.26.x");
     }

--- a/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
@@ -1,13 +1,12 @@
 #include "cached_import/py_cached_item.h"
 
 #include "cached_import/py_cached_import.h"
-#include "common/assert.h"
 #include "common/exception/runtime.h"
 
 namespace kuzu {
 
 py::handle PythonCachedItem::operator()() {
-    KU_ASSERT((bool)PyGILState_Check());
+    assert((bool)PyGILState_Check());
     // load if unloaded, return cached object if already loaded
     if (loaded) {
         return object;
@@ -23,7 +22,6 @@ py::handle PythonCachedItem::operator()() {
 
 py::handle NumpyMaCachedItem::operator()() {
     // TODO: implement compatibility with numpy 2.0.0
-    KU_ASSERT((bool)PyGILState_Check());
     auto obj = numpy();
     if (py::cast<std::string>(obj.attr("__version__"))[0] >= '2') {
         throw common::RuntimeException(

--- a/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
@@ -1,12 +1,14 @@
 #include "cached_import/py_cached_item.h"
 
+#include "common/assert.h"
 #include "cached_import/py_cached_import.h"
+#include "common/exception/not_implemented.h"
 #include "common/exception/runtime.h"
 
 namespace kuzu {
 
 py::handle PythonCachedItem::operator()() {
-    assert((bool)PyGILState_Check());
+    KU_ASSERT((bool)PyGILState_Check());
     // load if unloaded, return cached object if already loaded
     if (loaded) {
         return object;
@@ -18,6 +20,18 @@ py::handle PythonCachedItem::operator()() {
     }
     loaded = true;
     return object;
+}
+
+py::handle NumpyMaCachedItem::operator()() {
+    // TODO: implement compatibility with numpy 2.0.0
+    KU_ASSERT((bool)PyGILState_Check());
+    auto obj = numpy();
+    if (py::cast<std::string>(obj.attr("__version__"))[0] >= '2') {
+        throw common::NotImplementedException(
+            "Kuzu cannot currently support numpy versions at or above 2.0.0"
+            "Try 1.26.x");
+    }
+    return PythonCachedItem::operator()();
 }
 
 } // namespace kuzu

--- a/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
@@ -28,7 +28,7 @@ py::handle NumpyMaCachedItem::operator()() {
     auto obj = numpy();
     if (py::cast<std::string>(obj.attr("__version__"))[0] >= '2') {
         throw common::NotImplementedException(
-            "Kuzu cannot currently support numpy versions at or above 2.0.0"
+            "Kuzu cannot currently support numpy versions at or above 2.0.0\n"
             "Try 1.26.x");
     }
     return PythonCachedItem::operator()();

--- a/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
+++ b/tools/python_api/src_cpp/cached_import/py_cached_item.cpp
@@ -1,7 +1,7 @@
 #include "cached_import/py_cached_item.h"
 
-#include "common/assert.h"
 #include "cached_import/py_cached_import.h"
+#include "common/assert.h"
 #include "common/exception/runtime.h"
 
 namespace kuzu {

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_item.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_item.h
@@ -14,9 +14,9 @@ public:
     virtual ~PythonCachedItem() = default;
 
     bool isLoaded() const { return loaded; }
-    py::handle operator()();
+    virtual py::handle operator()();
 
-private:
+protected:
     std::string name;
     PythonCachedItem* parent;
     bool loaded;

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -50,15 +50,15 @@ public:
 
 class NumpyMaCachedItem : public PythonCachedItem {
 public:
-    NumpyMaCachedItem() : PythonCachedItem("numpy.ma"), masked_array("masked_array", this),
-        numpy("numpy", nullptr) {}
+    NumpyMaCachedItem()
+        : PythonCachedItem("numpy.ma"), masked_array("masked_array", this),
+          numpy("numpy", nullptr) {}
 
     PythonCachedItem masked_array;
 
     py::handle operator()() override;
 
 private:
-
     PythonCachedItem numpy;
     // Not used outside of this class, but has to be accessible because numpy.ma doesn't have
     // the __version__ attribute

--- a/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
+++ b/tools/python_api/src_cpp/include/cached_import/py_cached_modules.h
@@ -50,9 +50,18 @@ public:
 
 class NumpyMaCachedItem : public PythonCachedItem {
 public:
-    NumpyMaCachedItem() : PythonCachedItem("numpy.ma"), masked_array("masked_array", this) {}
+    NumpyMaCachedItem() : PythonCachedItem("numpy.ma"), masked_array("masked_array", this),
+        numpy("numpy", nullptr) {}
 
     PythonCachedItem masked_array;
+
+    py::handle operator()() override;
+
+private:
+
+    PythonCachedItem numpy;
+    // Not used outside of this class, but has to be accessible because numpy.ma doesn't have
+    // the __version__ attribute
 };
 
 class PandasCachedItem : public PythonCachedItem {

--- a/tools/python_api/src_cpp/py_query_result.cpp
+++ b/tools/python_api/src_cpp/py_query_result.cpp
@@ -349,6 +349,7 @@ py::object PyQueryResult::convertValueToPyObject(const Value& value) {
 }
 
 py::object PyQueryResult::getAsDF() {
+    importCache->numpyma(); // check if we can import
     return QueryResultConverter(queryResult).toDF();
 }
 


### PR DESCRIPTION
Addresses #3761, but does not fix it
I may not be able to get numpy 2 working before the next release, so this is a stopgap solution so that we don't release in a broken state. 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).