### PR TITLE
Fix lambda dependency analyze

### DIFF
--- a/src/binder/bind_expression/bind_lambda_expression.cpp
+++ b/src/binder/bind_expression/bind_lambda_expression.cpp
@@ -20,12 +20,10 @@ void ExpressionBinder::bindLambdaExpression(const std::string& functionName,
     }
     KU_ASSERT(lambdaInput.getDataType().getLogicalTypeID() == LogicalTypeID::LIST);
     auto& listChildType = ListType::getChildType(lambdaInput.getDataType());
-    auto& boundLambdaExpr = lambdaExpr.cast<BoundLambdaExpression>();
+    auto& boundLambdaExpr = lambdaExpr.cast<LambdaExpression>();
     auto& parsedLambdaExpr =
         boundLambdaExpr.getParsedLambdaExpr()->constCast<ParsedLambdaExpression>();
     auto prevScope = binder->saveScope();
-    // TODO(Xiyang): we should not clear scope here.
-    binder->scope.clear();
     for (auto& varName : parsedLambdaExpr.getVarNames()) {
         binder->createVariable(varName, listChildType);
     }
@@ -39,7 +37,7 @@ void ExpressionBinder::bindLambdaExpression(const std::string& functionName,
 std::shared_ptr<Expression> ExpressionBinder::bindLambdaExpression(
     const parser::ParsedExpression& parsedExpr) const {
     auto uniqueName = getUniqueName(parsedExpr.getRawName());
-    return std::make_shared<BoundLambdaExpression>(parsedExpr.copy(), uniqueName);
+    return std::make_shared<LambdaExpression>(parsedExpr.copy(), uniqueName);
 }
 
 } // namespace binder

--- a/src/binder/expression_visitor.cpp
+++ b/src/binder/expression_visitor.cpp
@@ -9,6 +9,7 @@
 #include "common/exception/not_implemented.h"
 #include "function/sequence/sequence_functions.h"
 #include "function/uuid/vector_uuid_functions.h"
+#include "binder/expression/lambda_expression.h"
 
 using namespace kuzu::common;
 
@@ -82,6 +83,10 @@ void ExpressionVisitor::visitChildren(const Expression& expr) {
     case ExpressionType::CASE_ELSE: {
         visitCaseExprChildren(expr);
     } break;
+    case ExpressionType::LAMBDA: {
+        auto& lambda = expr.constCast<LambdaExpression>();
+        visit(lambda.getFunctionExpr());
+    } break ;
     default: {
         for (auto& child : expr.getChildren()) {
             visit(child);

--- a/src/binder/expression_visitor.cpp
+++ b/src/binder/expression_visitor.cpp
@@ -2,6 +2,7 @@
 
 #include "binder/expression/case_expression.h"
 #include "binder/expression/function_expression.h"
+#include "binder/expression/lambda_expression.h"
 #include "binder/expression/node_expression.h"
 #include "binder/expression/property_expression.h"
 #include "binder/expression/rel_expression.h"
@@ -9,7 +10,6 @@
 #include "common/exception/not_implemented.h"
 #include "function/sequence/sequence_functions.h"
 #include "function/uuid/vector_uuid_functions.h"
-#include "binder/expression/lambda_expression.h"
 
 using namespace kuzu::common;
 
@@ -86,7 +86,7 @@ void ExpressionVisitor::visitChildren(const Expression& expr) {
     case ExpressionType::LAMBDA: {
         auto& lambda = expr.constCast<LambdaExpression>();
         visit(lambda.getFunctionExpr());
-    } break ;
+    } break;
     default: {
         for (auto& child : expr.getChildren()) {
             visit(child);

--- a/src/include/binder/expression/lambda_expression.h
+++ b/src/include/binder/expression/lambda_expression.h
@@ -6,11 +6,11 @@
 namespace kuzu {
 namespace binder {
 
-class BoundLambdaExpression final : public Expression {
+class LambdaExpression final : public Expression {
     static constexpr const common::ExpressionType type_ = common::ExpressionType::LAMBDA;
 
 public:
-    BoundLambdaExpression(std::unique_ptr<parser::ParsedExpression> parsedLambdaExpr,
+    LambdaExpression(std::unique_ptr<parser::ParsedExpression> parsedLambdaExpr,
         std::string uniqueName)
         : Expression{type_, common::LogicalType::ANY(), uniqueName},
           parsedLambdaExpr{std::move(parsedLambdaExpr)} {}

--- a/src/include/planner/operator/factorization/flatten_resolver.h
+++ b/src/include/planner/operator/factorization/flatten_resolver.h
@@ -8,16 +8,22 @@ namespace planner {
 class GroupDependencyAnalyzer;
 
 struct FlattenAllButOne {
-    static f_group_pos_set getGroupsPosToFlatten(const binder::expression_vector& exprs, const Schema& schema);
-    static f_group_pos_set getGroupsPosToFlatten(std::shared_ptr<binder::Expression> expr, const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(const binder::expression_vector& exprs,
+        const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(std::shared_ptr<binder::Expression> expr,
+        const Schema& schema);
     // Assume no requiredFlatGroups
-    static f_group_pos_set getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(
+        const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema);
 };
 
 struct FlattenAll {
-    static f_group_pos_set getGroupsPosToFlatten(const binder::expression_vector& exprs, const Schema& schema);
-    static f_group_pos_set getGroupsPosToFlatten(std::shared_ptr<binder::Expression> expr, const Schema& schema);
-    static f_group_pos_set getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(const binder::expression_vector& exprs,
+        const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(std::shared_ptr<binder::Expression> expr,
+        const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(
+        const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema);
 };
 
 class GroupDependencyAnalyzer {
@@ -28,12 +34,8 @@ public:
     binder::expression_vector getDependentExprs() const {
         return binder::expression_vector{dependentExprs.begin(), dependentExprs.end()};
     }
-    std::unordered_set<f_group_pos> getDependentGroups() const {
-        return dependentGroups;
-    }
-    std::unordered_set<f_group_pos> getRequiredFlatGroups() const {
-        return requiredFlatGroups;
-    }
+    std::unordered_set<f_group_pos> getDependentGroups() const { return dependentGroups; }
+    std::unordered_set<f_group_pos> getRequiredFlatGroups() const { return requiredFlatGroups; }
 
     void visit(std::shared_ptr<binder::Expression> expr);
 
@@ -53,7 +55,6 @@ private:
     std::unordered_set<f_group_pos> requiredFlatGroups;
     binder::expression_set dependentExprs;
 };
-
 
 } // namespace planner
 } // namespace kuzu

--- a/src/include/planner/operator/factorization/flatten_resolver.h
+++ b/src/include/planner/operator/factorization/flatten_resolver.h
@@ -4,16 +4,56 @@
 
 namespace kuzu {
 namespace planner {
-namespace factorization {
+
+class GroupDependencyAnalyzer;
 
 struct FlattenAllButOne {
-    static f_group_pos_set getGroupsPosToFlatten(const f_group_pos_set& groupsPos, Schema* schema);
+    static f_group_pos_set getGroupsPosToFlatten(const binder::expression_vector& exprs, const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(std::shared_ptr<binder::Expression> expr, const Schema& schema);
+    // Assume no requiredFlatGroups
+    static f_group_pos_set getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema);
 };
 
 struct FlattenAll {
-    static f_group_pos_set getGroupsPosToFlatten(const f_group_pos_set& groupsPos, Schema* schema);
+    static f_group_pos_set getGroupsPosToFlatten(const binder::expression_vector& exprs, const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(std::shared_ptr<binder::Expression> expr, const Schema& schema);
+    static f_group_pos_set getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema);
 };
 
-} // namespace factorization
+class GroupDependencyAnalyzer {
+public:
+    explicit GroupDependencyAnalyzer(bool collectDependentExpr, const Schema& schema)
+        : collectDependentExpr{collectDependentExpr}, schema{schema} {}
+
+    binder::expression_vector getDependentExprs() const {
+        return binder::expression_vector{dependentExprs.begin(), dependentExprs.end()};
+    }
+    std::unordered_set<f_group_pos> getDependentGroups() const {
+        return dependentGroups;
+    }
+    std::unordered_set<f_group_pos> getRequiredFlatGroups() const {
+        return requiredFlatGroups;
+    }
+
+    void visit(std::shared_ptr<binder::Expression> expr);
+
+private:
+    void visitFunction(std::shared_ptr<binder::Expression> expr);
+
+    void visitCase(std::shared_ptr<binder::Expression> expr);
+
+    void visitNodeOrRel(std::shared_ptr<binder::Expression> expr);
+
+    void visitSubquery(std::shared_ptr<binder::Expression> expr);
+
+private:
+    bool collectDependentExpr;
+    const Schema& schema;
+    std::unordered_set<f_group_pos> dependentGroups;
+    std::unordered_set<f_group_pos> requiredFlatGroups;
+    binder::expression_set dependentExprs;
+};
+
+
 } // namespace planner
 } // namespace kuzu

--- a/src/include/planner/operator/schema.h
+++ b/src/include/planner/operator/schema.h
@@ -106,12 +106,7 @@ public:
 
     binder::expression_vector getExpressionsInScope(f_group_pos pos) const;
 
-    binder::expression_vector getSubExpressionsInScope(
-        const std::shared_ptr<binder::Expression>& expression);
     bool evaluable(const binder::Expression& expression) const;
-
-    std::unordered_set<f_group_pos> getDependentGroupsPos(
-        const std::shared_ptr<binder::Expression>& expression);
 
     void clearExpressionsInScope() {
         expressionNameToGroupPos.clear();

--- a/src/optimizer/factorization_rewriter.cpp
+++ b/src/optimizer/factorization_rewriter.cpp
@@ -86,13 +86,13 @@ void FactorizationRewriter::visitProjection(planner::LogicalOperator* op) {
     if (hasRandomFunction) {
         // Fall back to tuple-at-a-time evaluation.
         auto groupsPos = op->getChild(0)->getSchema()->getGroupsPosInScope();
-        auto groupsPosToFlatten = FlattenAll::getGroupsPosToFlatten(groupsPos,
-            *op->getChild(0)->getSchema());
+        auto groupsPosToFlatten =
+            FlattenAll::getGroupsPosToFlatten(groupsPos, *op->getChild(0)->getSchema());
         projection.setChild(0, appendFlattens(projection.getChild(0), groupsPosToFlatten));
     } else {
         for (auto& expression : projection.getExpressionsToProject()) {
-            auto groupsPosToFlatten = FlattenAllButOne::getGroupsPosToFlatten(
-                expression, *op->getChild(0)->getSchema());
+            auto groupsPosToFlatten =
+                FlattenAllButOne::getGroupsPosToFlatten(expression, *op->getChild(0)->getSchema());
             projection.setChild(0, appendFlattens(projection.getChild(0), groupsPosToFlatten));
         }
     }

--- a/src/optimizer/factorization_rewriter.cpp
+++ b/src/optimizer/factorization_rewriter.cpp
@@ -1,7 +1,6 @@
 #include "optimizer/factorization_rewriter.h"
 
 #include "binder/expression_visitor.h"
-#include "common/cast.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/factorization/flatten_resolver.h"
@@ -45,41 +44,41 @@ void FactorizationRewriter::visitOperator(planner::LogicalOperator* op) {
 }
 
 void FactorizationRewriter::visitExtend(planner::LogicalOperator* op) {
-    auto extend = (LogicalExtend*)op;
-    auto groupsPosToFlatten = extend->getGroupsPosToFlatten();
-    extend->setChild(0, appendFlattens(extend->getChild(0), groupsPosToFlatten));
+    auto& extend = op->cast<LogicalExtend>();
+    auto groupsPosToFlatten = extend.getGroupsPosToFlatten();
+    extend.setChild(0, appendFlattens(extend.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitRecursiveExtend(planner::LogicalOperator* op) {
-    auto extend = (LogicalRecursiveExtend*)op;
-    auto groupsPosToFlatten = extend->getGroupsPosToFlatten();
-    extend->setChild(0, appendFlattens(extend->getChild(0), groupsPosToFlatten));
+    auto& extend = op->cast<LogicalRecursiveExtend>();
+    auto groupsPosToFlatten = extend.getGroupsPosToFlatten();
+    extend.setChild(0, appendFlattens(extend.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitHashJoin(planner::LogicalOperator* op) {
-    auto hashJoin = (LogicalHashJoin*)op;
-    auto groupsPosToFlattenOnProbeSide = hashJoin->getGroupsPosToFlattenOnProbeSide();
-    hashJoin->setChild(0, appendFlattens(hashJoin->getChild(0), groupsPosToFlattenOnProbeSide));
-    auto groupsPosToFlattenOnBuildSide = hashJoin->getGroupsPosToFlattenOnBuildSide();
-    hashJoin->setChild(1, appendFlattens(hashJoin->getChild(1), groupsPosToFlattenOnBuildSide));
+    auto& hashJoin = op->cast<LogicalHashJoin>();
+    auto groupsPosToFlattenOnProbeSide = hashJoin.getGroupsPosToFlattenOnProbeSide();
+    hashJoin.setChild(0, appendFlattens(hashJoin.getChild(0), groupsPosToFlattenOnProbeSide));
+    auto groupsPosToFlattenOnBuildSide = hashJoin.getGroupsPosToFlattenOnBuildSide();
+    hashJoin.setChild(1, appendFlattens(hashJoin.getChild(1), groupsPosToFlattenOnBuildSide));
 }
 
 void FactorizationRewriter::visitIntersect(planner::LogicalOperator* op) {
-    auto intersect = (LogicalIntersect*)op;
-    auto groupsPosToFlattenOnProbeSide = intersect->getGroupsPosToFlattenOnProbeSide();
-    intersect->setChild(0, appendFlattens(intersect->getChild(0), groupsPosToFlattenOnProbeSide));
-    for (auto i = 0u; i < intersect->getNumBuilds(); ++i) {
-        auto groupPosToFlatten = intersect->getGroupsPosToFlattenOnBuildSide(i);
+    auto& intersect = op->cast<LogicalIntersect>();
+    auto groupsPosToFlattenOnProbeSide = intersect.getGroupsPosToFlattenOnProbeSide();
+    intersect.setChild(0, appendFlattens(intersect.getChild(0), groupsPosToFlattenOnProbeSide));
+    for (auto i = 0u; i < intersect.getNumBuilds(); ++i) {
+        auto groupPosToFlatten = intersect.getGroupsPosToFlattenOnBuildSide(i);
         auto childIdx = i + 1; // skip probe
-        intersect->setChild(childIdx,
-            appendFlattens(intersect->getChild(childIdx), groupPosToFlatten));
+        intersect.setChild(childIdx,
+            appendFlattens(intersect.getChild(childIdx), groupPosToFlatten));
     }
 }
 
 void FactorizationRewriter::visitProjection(planner::LogicalOperator* op) {
-    auto projection = (LogicalProjection*)op;
+    auto& projection = op->cast<LogicalProjection>();
     bool hasRandomFunction = false;
-    for (auto& expr : projection->getExpressionsToProject()) {
+    for (auto& expr : projection.getExpressionsToProject()) {
         if (ExpressionVisitor::isRandom(*expr)) {
             hasRandomFunction = true;
         }
@@ -87,108 +86,106 @@ void FactorizationRewriter::visitProjection(planner::LogicalOperator* op) {
     if (hasRandomFunction) {
         // Fall back to tuple-at-a-time evaluation.
         auto groupsPos = op->getChild(0)->getSchema()->getGroupsPosInScope();
-        auto groupsPosToFlatten = factorization::FlattenAll::getGroupsPosToFlatten(groupsPos,
-            op->getChild(0)->getSchema());
-        projection->setChild(0, appendFlattens(projection->getChild(0), groupsPosToFlatten));
+        auto groupsPosToFlatten = FlattenAll::getGroupsPosToFlatten(groupsPos,
+            *op->getChild(0)->getSchema());
+        projection.setChild(0, appendFlattens(projection.getChild(0), groupsPosToFlatten));
     } else {
-        for (auto& expression : projection->getExpressionsToProject()) {
-            auto dependentGroupsPos =
-                op->getChild(0)->getSchema()->getDependentGroupsPos(expression);
-            auto groupsPosToFlatten = factorization::FlattenAllButOne::getGroupsPosToFlatten(
-                dependentGroupsPos, op->getChild(0)->getSchema());
-            projection->setChild(0, appendFlattens(projection->getChild(0), groupsPosToFlatten));
+        for (auto& expression : projection.getExpressionsToProject()) {
+            auto groupsPosToFlatten = FlattenAllButOne::getGroupsPosToFlatten(
+                expression, *op->getChild(0)->getSchema());
+            projection.setChild(0, appendFlattens(projection.getChild(0), groupsPosToFlatten));
         }
     }
 }
 
 void FactorizationRewriter::visitAccumulate(planner::LogicalOperator* op) {
-    auto accumulate = (LogicalAccumulate*)op;
-    auto groupsPosToFlatten = accumulate->getGroupPositionsToFlatten();
-    accumulate->setChild(0, appendFlattens(accumulate->getChild(0), groupsPosToFlatten));
+    auto& accumulate = op->cast<LogicalAccumulate>();
+    auto groupsPosToFlatten = accumulate.getGroupPositionsToFlatten();
+    accumulate.setChild(0, appendFlattens(accumulate.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitMarkAccumulate(planner::LogicalOperator* op) {
-    auto markAccumulate = ku_dynamic_cast<LogicalOperator*, LogicalMarkAccumulate*>(op);
-    auto groupsPos = markAccumulate->getGroupsPosToFlatten();
-    markAccumulate->setChild(0, appendFlattens(markAccumulate->getChild(0), groupsPos));
+    auto& markAccumulate = op->cast<LogicalMarkAccumulate>();
+    auto groupsPos = markAccumulate.getGroupsPosToFlatten();
+    markAccumulate.setChild(0, appendFlattens(markAccumulate.getChild(0), groupsPos));
 }
 
 void FactorizationRewriter::visitAggregate(planner::LogicalOperator* op) {
-    auto aggregate = (LogicalAggregate*)op;
-    auto groupsPosToFlattenForGroupBy = aggregate->getGroupsPosToFlattenForGroupBy();
-    aggregate->setChild(0, appendFlattens(aggregate->getChild(0), groupsPosToFlattenForGroupBy));
-    auto groupsPosToFlattenForAggregate = aggregate->getGroupsPosToFlattenForAggregate();
-    aggregate->setChild(0, appendFlattens(aggregate->getChild(0), groupsPosToFlattenForAggregate));
+    auto& aggregate = op->cast<LogicalAggregate>();
+    auto groupsPosToFlattenForGroupBy = aggregate.getGroupsPosToFlattenForGroupBy();
+    aggregate.setChild(0, appendFlattens(aggregate.getChild(0), groupsPosToFlattenForGroupBy));
+    auto groupsPosToFlattenForAggregate = aggregate.getGroupsPosToFlattenForAggregate();
+    aggregate.setChild(0, appendFlattens(aggregate.getChild(0), groupsPosToFlattenForAggregate));
 }
 
 void FactorizationRewriter::visitOrderBy(planner::LogicalOperator* op) {
-    auto orderBy = (LogicalOrderBy*)op;
-    auto groupsPosToFlatten = orderBy->getGroupsPosToFlatten();
-    orderBy->setChild(0, appendFlattens(orderBy->getChild(0), groupsPosToFlatten));
+    auto& orderBy = op->cast<LogicalOrderBy>();
+    auto groupsPosToFlatten = orderBy.getGroupsPosToFlatten();
+    orderBy.setChild(0, appendFlattens(orderBy.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitLimit(planner::LogicalOperator* op) {
-    auto limit = (LogicalLimit*)op;
-    auto groupsPosToFlatten = limit->getGroupsPosToFlatten();
-    limit->setChild(0, appendFlattens(limit->getChild(0), groupsPosToFlatten));
+    auto& limit = op->cast<LogicalLimit>();
+    auto groupsPosToFlatten = limit.getGroupsPosToFlatten();
+    limit.setChild(0, appendFlattens(limit.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitDistinct(planner::LogicalOperator* op) {
-    auto distinct = (LogicalDistinct*)op;
-    auto groupsPosToFlatten = distinct->getGroupsPosToFlatten();
-    distinct->setChild(0, appendFlattens(distinct->getChild(0), groupsPosToFlatten));
+    auto& distinct = op->cast<LogicalDistinct>();
+    auto groupsPosToFlatten = distinct.getGroupsPosToFlatten();
+    distinct.setChild(0, appendFlattens(distinct.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitUnwind(planner::LogicalOperator* op) {
-    auto unwind = (LogicalUnwind*)op;
-    auto groupsPosToFlatten = unwind->getGroupsPosToFlatten();
-    unwind->setChild(0, appendFlattens(unwind->getChild(0), groupsPosToFlatten));
+    auto& unwind = op->cast<LogicalUnwind>();
+    auto groupsPosToFlatten = unwind.getGroupsPosToFlatten();
+    unwind.setChild(0, appendFlattens(unwind.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitUnion(planner::LogicalOperator* op) {
-    auto union_ = (LogicalUnion*)op;
-    for (auto i = 0u; i < union_->getNumChildren(); ++i) {
-        auto groupsPosToFlatten = union_->getGroupsPosToFlatten(i);
-        union_->setChild(i, appendFlattens(union_->getChild(i), groupsPosToFlatten));
+    auto& union_ = op->cast<LogicalUnion>();
+    for (auto i = 0u; i < union_.getNumChildren(); ++i) {
+        auto groupsPosToFlatten = union_.getGroupsPosToFlatten(i);
+        union_.setChild(i, appendFlattens(union_.getChild(i), groupsPosToFlatten));
     }
 }
 
 void FactorizationRewriter::visitFilter(planner::LogicalOperator* op) {
-    auto filter = (LogicalFilter*)op;
-    auto groupsPosToFlatten = filter->getGroupsPosToFlatten();
-    filter->setChild(0, appendFlattens(filter->getChild(0), groupsPosToFlatten));
+    auto& filter = op->cast<LogicalFilter>();
+    auto groupsPosToFlatten = filter.getGroupsPosToFlatten();
+    filter.setChild(0, appendFlattens(filter.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitSetProperty(planner::LogicalOperator* op) {
-    auto set = op->ptrCast<LogicalSetProperty>();
-    for (auto i = 0u; i < set->getInfos().size(); ++i) {
-        auto groupsPos = set->getGroupsPosToFlatten(i);
-        set->setChild(0, appendFlattens(set->getChild(0), groupsPos));
+    auto& set = op->cast<LogicalSetProperty>();
+    for (auto i = 0u; i < set.getInfos().size(); ++i) {
+        auto groupsPos = set.getGroupsPosToFlatten(i);
+        set.setChild(0, appendFlattens(set.getChild(0), groupsPos));
     }
 }
 
 void FactorizationRewriter::visitDelete(planner::LogicalOperator* op) {
-    auto deleteNode = op->ptrCast<LogicalDelete>();
-    auto groupsPosToFlatten = deleteNode->getGroupsPosToFlatten();
-    deleteNode->setChild(0, appendFlattens(deleteNode->getChild(0), groupsPosToFlatten));
+    auto& delete_ = op->cast<LogicalDelete>();
+    auto groupsPosToFlatten = delete_.getGroupsPosToFlatten();
+    delete_.setChild(0, appendFlattens(delete_.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitInsert(planner::LogicalOperator* op) {
-    auto insertNode = (LogicalInsert*)op;
-    auto groupsPosToFlatten = insertNode->getGroupsPosToFlatten();
-    insertNode->setChild(0, appendFlattens(insertNode->getChild(0), groupsPosToFlatten));
+    auto& insert = op->cast<LogicalInsert>();
+    auto groupsPosToFlatten = insert.getGroupsPosToFlatten();
+    insert.setChild(0, appendFlattens(insert.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitMerge(planner::LogicalOperator* op) {
-    auto merge = (LogicalMerge*)op;
-    auto groupsPosToFlatten = merge->getGroupsPosToFlatten();
-    merge->setChild(0, appendFlattens(merge->getChild(0), groupsPosToFlatten));
+    auto& merge = op->cast<LogicalMerge>();
+    auto groupsPosToFlatten = merge.getGroupsPosToFlatten();
+    merge.setChild(0, appendFlattens(merge.getChild(0), groupsPosToFlatten));
 }
 
 void FactorizationRewriter::visitCopyTo(planner::LogicalOperator* op) {
-    auto copyTo = (LogicalCopyTo*)op;
-    auto groupsPosToFlatten = copyTo->getGroupsPosToFlatten();
-    copyTo->setChild(0, appendFlattens(copyTo->getChild(0), groupsPosToFlatten));
+    auto& copyTo = op->cast<LogicalCopyTo>();
+    auto groupsPosToFlatten = copyTo.getGroupsPosToFlatten();
+    copyTo.setChild(0, appendFlattens(copyTo.getChild(0), groupsPosToFlatten));
 }
 
 std::shared_ptr<planner::LogicalOperator> FactorizationRewriter::appendFlattens(

--- a/src/planner/operator/factorization/flatten_resolver.cpp
+++ b/src/planner/operator/factorization/flatten_resolver.cpp
@@ -1,36 +1,213 @@
 #include "planner/operator/factorization/flatten_resolver.h"
 
+#include "function/list/vector_list_functions.h"
+#include "binder/expression/function_expression.h"
+#include "binder/expression/case_expression.h"
+#include "binder/expression/node_expression.h"
+#include "binder/expression/rel_expression.h"
+#include "binder/expression/subquery_expression.h"
+#include "common/exception/not_implemented.h"
+#include "binder/expression/lambda_expression.h"
+
+using namespace kuzu::common;
+using namespace kuzu::binder;
+
 namespace kuzu {
 namespace planner {
-namespace factorization {
 
-f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const f_group_pos_set& groupsPos,
-    Schema* schema) {
-    std::vector<f_group_pos> unFlatGroupsPos;
-    for (auto groupPos : groupsPos) {
-        if (!schema->getGroup(groupPos)->isFlat()) {
-            unFlatGroupsPos.push_back(groupPos);
+f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const expression_vector& exprs, const Schema& schema) {
+    f_group_pos_set result;
+    f_group_pos_set dependentGroups;
+    for (auto expr : exprs) {
+        auto analyzer = GroupDependencyAnalyzer(false /* collectDependentExpr */, schema);
+        analyzer.visit(expr);
+        for (auto pos : analyzer.getRequiredFlatGroups()) {
+            result.insert(pos);
+        }
+        for (auto pos : analyzer.getDependentGroups()) {
+            dependentGroups.insert(pos);
         }
     }
-    f_group_pos_set result;
-    // Keep the first group as unFlat.
-    for (auto i = 1u; i < unFlatGroupsPos.size(); ++i) {
-        result.insert(unFlatGroupsPos[i]);
+    std::vector<f_group_pos> candidates;
+    for (auto pos : dependentGroups) {
+        if (!schema.getGroup(pos)->isFlat() && !result.contains(pos)) {
+            candidates.push_back(pos);
+        }
+    }
+    for (auto i = 1u; i < candidates.size(); ++i) {
+        result.insert(candidates[i]);
     }
     return result;
 }
 
-f_group_pos_set FlattenAll::getGroupsPosToFlatten(const f_group_pos_set& groupsPos,
-    Schema* schema) {
+f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(std::shared_ptr<Expression> expr, const Schema& schema) {
+    auto analyzer = GroupDependencyAnalyzer(false /* collectDependentExpr */, schema);
+    analyzer.visit(expr);
+    f_group_pos_set result = analyzer.getRequiredFlatGroups();
+    std::vector<f_group_pos> candidates;
+    for (auto groupPos : analyzer.getDependentGroups()) {
+        if (!schema.getGroup(groupPos)->isFlat() && !result.contains(groupPos)) {
+            candidates.push_back(groupPos);
+        }
+    }
+    // Keep the first group as unFlat.
+    for (auto i = 1u; i < candidates.size(); ++i) {
+        result.insert(candidates[i]);
+    }
+    return result;
+}
+
+f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema) {
     f_group_pos_set result;
-    for (auto groupPos : groupsPos) {
-        if (!schema->getGroup(groupPos)->isFlat()) {
+    std::vector<f_group_pos> candidates;
+    for (auto groupPos : dependentGroups) {
+        if (!schema.getGroup(groupPos)->isFlat()) {
+            candidates.push_back(groupPos);
+        }
+    }
+    for (auto i = 1u; i < candidates.size(); ++i) {
+        result.insert(candidates[i]);
+    }
+    return result;
+}
+
+f_group_pos_set FlattenAll::getGroupsPosToFlatten(const expression_vector& exprs, const Schema& schema) {
+    f_group_pos_set result;
+    for (auto& expr : exprs) {
+        for (auto pos : getGroupsPosToFlatten(expr, schema)) {
+            result.insert(pos);
+        }
+    }
+    return result;
+}
+
+f_group_pos_set FlattenAll::getGroupsPosToFlatten(std::shared_ptr<Expression> expr, const Schema& schema) {
+    auto analyzer = GroupDependencyAnalyzer(false /* collectDependentExpr */, schema);
+    analyzer.visit(expr);
+    return getGroupsPosToFlatten(analyzer.getDependentGroups(), schema);
+}
+
+f_group_pos_set FlattenAll::getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema) {
+    f_group_pos_set result;
+    for (auto groupPos : dependentGroups) {
+        if (!schema.getGroup(groupPos)->isFlat()) {
             result.insert(groupPos);
         }
     }
     return result;
 }
 
-} // namespace factorization
+void GroupDependencyAnalyzer::visit(std::shared_ptr<binder::Expression> expr) {
+    if (schema.isExpressionInScope(*expr)) {
+        dependentGroups.insert(schema.getGroupPos(*expr));
+        if (collectDependentExpr) {
+            dependentExprs.insert(expr);
+        }
+        return ;
+    }
+    switch (expr->expressionType) {
+    case ExpressionType::FUNCTION:
+        return visitFunction(expr);
+    case ExpressionType::CASE_ELSE: {
+        visitCase(expr);
+    } break;
+    case ExpressionType::PATTERN: {
+        visitNodeOrRel(expr);
+    } break ;
+    case ExpressionType::SUBQUERY: {
+        visitSubquery(expr);
+    } break;
+    case ExpressionType::LAMBDA: {
+        visit(expr->constCast<LambdaExpression>().getFunctionExpr());
+    } break ;
+    case ExpressionType::LITERAL:
+    case ExpressionType::AGGREGATE_FUNCTION:
+    case ExpressionType::PROPERTY:
+    case ExpressionType::VARIABLE:
+    case ExpressionType::PATH:
+    case ExpressionType::PARAMETER:
+    case ExpressionType::GRAPH:
+    case ExpressionType::OR:
+    case ExpressionType::XOR:
+    case ExpressionType::AND:
+    case ExpressionType::NOT:
+    case ExpressionType::EQUALS:
+    case ExpressionType::NOT_EQUALS:
+    case ExpressionType::GREATER_THAN:
+    case ExpressionType::GREATER_THAN_EQUALS:
+    case ExpressionType::LESS_THAN:
+    case ExpressionType::LESS_THAN_EQUALS:
+    case ExpressionType::IS_NULL:
+    case ExpressionType::IS_NOT_NULL: {
+        for (auto& child : expr->getChildren()) {
+            visit(child);
+        }
+    } break ;
+        // LCOV_EXCL_START
+    default:
+        throw NotImplementedException("GroupDependencyAnalyzer::visit");
+        // LCOV_EXCL_STOP
+    }
+}
+
+void GroupDependencyAnalyzer::visitFunction(std::shared_ptr<binder::Expression> expr) {
+    auto& funcExpr = expr->constCast<FunctionExpression>();
+    auto functionName = funcExpr.getFunctionName();
+    for (auto& child : expr->getChildren()) {
+        visit(child);
+    }
+    // For list lambda we need to flatten all dependent expressions in lambda function
+    // E.g. MATCH (a)->(b) RETURN list_filter(a.list, x -> x>b.age)
+    if (functionName == function::ListTransformFunction::name ||
+        functionName == function::ListFilterFunction::name ||
+        functionName == function::ListReduceFunction::name) {
+        auto lambdaFunctionAnalyzer = GroupDependencyAnalyzer(collectDependentExpr, schema);
+        lambdaFunctionAnalyzer.visit(funcExpr.getChild(1));
+        requiredFlatGroups = lambdaFunctionAnalyzer.getDependentGroups();
+    }
+}
+
+void GroupDependencyAnalyzer::visitCase(std::shared_ptr<binder::Expression> expr) {
+    auto& caseExpression = expr->constCast<CaseExpression>();
+    for (auto i = 0u; i < caseExpression.getNumCaseAlternatives(); ++i) {
+        auto caseAlternative = caseExpression.getCaseAlternative(i);
+        visit(caseAlternative->whenExpression);
+        visit(caseAlternative->thenExpression);
+    }
+    visit(caseExpression.getElseExpression());
+}
+
+void GroupDependencyAnalyzer::visitNodeOrRel(std::shared_ptr<binder::Expression> expr) {
+    for (auto& p : expr->constCast<NodeOrRelExpression>().getPropertyExprs()) {
+        visit(p);
+    }
+    switch (expr->getDataType().getLogicalTypeID()) {
+    case LogicalTypeID::NODE: {
+        auto& node = expr->constCast<NodeExpression>();
+        visit(node.getInternalID());
+    } break ;
+    case LogicalTypeID::REL: {
+        auto& rel = expr->constCast<RelExpression>();
+        visit(rel.getSrcNode()->getInternalID());
+        visit(rel.getDstNode()->getInternalID());
+        if (rel.hasDirectionExpr()) {
+            visit(rel.getDirectionExpr());
+        }
+    } break ;
+    default:
+        KU_UNREACHABLE;
+    }
+}
+
+void GroupDependencyAnalyzer::visitSubquery(std::shared_ptr<binder::Expression> expr) {
+    auto& subqueryExpr = expr->constCast<SubqueryExpression>();
+    for (auto& node : subqueryExpr.getQueryGraphCollection()->getQueryNodes()) {
+        visit(node->getInternalID());
+    }
+    if (subqueryExpr.hasWhereExpression()) {
+        visit(subqueryExpr.getWhereExpression());
+    }
+}
+
 } // namespace planner
 } // namespace kuzu

--- a/src/planner/operator/factorization/flatten_resolver.cpp
+++ b/src/planner/operator/factorization/flatten_resolver.cpp
@@ -1,13 +1,13 @@
 #include "planner/operator/factorization/flatten_resolver.h"
 
-#include "function/list/vector_list_functions.h"
-#include "binder/expression/function_expression.h"
 #include "binder/expression/case_expression.h"
+#include "binder/expression/function_expression.h"
+#include "binder/expression/lambda_expression.h"
 #include "binder/expression/node_expression.h"
 #include "binder/expression/rel_expression.h"
 #include "binder/expression/subquery_expression.h"
 #include "common/exception/not_implemented.h"
-#include "binder/expression/lambda_expression.h"
+#include "function/list/vector_list_functions.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -15,7 +15,8 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace planner {
 
-f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const expression_vector& exprs, const Schema& schema) {
+f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const expression_vector& exprs,
+    const Schema& schema) {
     f_group_pos_set result;
     f_group_pos_set dependentGroups;
     for (auto expr : exprs) {
@@ -40,7 +41,8 @@ f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const expression_vector&
     return result;
 }
 
-f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(std::shared_ptr<Expression> expr, const Schema& schema) {
+f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(std::shared_ptr<Expression> expr,
+    const Schema& schema) {
     auto analyzer = GroupDependencyAnalyzer(false /* collectDependentExpr */, schema);
     analyzer.visit(expr);
     f_group_pos_set result = analyzer.getRequiredFlatGroups();
@@ -57,7 +59,8 @@ f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(std::shared_ptr<Expressi
     return result;
 }
 
-f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema) {
+f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(
+    const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema) {
     f_group_pos_set result;
     std::vector<f_group_pos> candidates;
     for (auto groupPos : dependentGroups) {
@@ -71,7 +74,8 @@ f_group_pos_set FlattenAllButOne::getGroupsPosToFlatten(const std::unordered_set
     return result;
 }
 
-f_group_pos_set FlattenAll::getGroupsPosToFlatten(const expression_vector& exprs, const Schema& schema) {
+f_group_pos_set FlattenAll::getGroupsPosToFlatten(const expression_vector& exprs,
+    const Schema& schema) {
     f_group_pos_set result;
     for (auto& expr : exprs) {
         for (auto pos : getGroupsPosToFlatten(expr, schema)) {
@@ -81,13 +85,15 @@ f_group_pos_set FlattenAll::getGroupsPosToFlatten(const expression_vector& exprs
     return result;
 }
 
-f_group_pos_set FlattenAll::getGroupsPosToFlatten(std::shared_ptr<Expression> expr, const Schema& schema) {
+f_group_pos_set FlattenAll::getGroupsPosToFlatten(std::shared_ptr<Expression> expr,
+    const Schema& schema) {
     auto analyzer = GroupDependencyAnalyzer(false /* collectDependentExpr */, schema);
     analyzer.visit(expr);
     return getGroupsPosToFlatten(analyzer.getDependentGroups(), schema);
 }
 
-f_group_pos_set FlattenAll::getGroupsPosToFlatten(const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema) {
+f_group_pos_set FlattenAll::getGroupsPosToFlatten(
+    const std::unordered_set<f_group_pos>& dependentGroups, const Schema& schema) {
     f_group_pos_set result;
     for (auto groupPos : dependentGroups) {
         if (!schema.getGroup(groupPos)->isFlat()) {
@@ -103,7 +109,7 @@ void GroupDependencyAnalyzer::visit(std::shared_ptr<binder::Expression> expr) {
         if (collectDependentExpr) {
             dependentExprs.insert(expr);
         }
-        return ;
+        return;
     }
     switch (expr->expressionType) {
     case ExpressionType::FUNCTION:
@@ -113,13 +119,13 @@ void GroupDependencyAnalyzer::visit(std::shared_ptr<binder::Expression> expr) {
     } break;
     case ExpressionType::PATTERN: {
         visitNodeOrRel(expr);
-    } break ;
+    } break;
     case ExpressionType::SUBQUERY: {
         visitSubquery(expr);
     } break;
     case ExpressionType::LAMBDA: {
         visit(expr->constCast<LambdaExpression>().getFunctionExpr());
-    } break ;
+    } break;
     case ExpressionType::LITERAL:
     case ExpressionType::AGGREGATE_FUNCTION:
     case ExpressionType::PROPERTY:
@@ -142,7 +148,7 @@ void GroupDependencyAnalyzer::visit(std::shared_ptr<binder::Expression> expr) {
         for (auto& child : expr->getChildren()) {
             visit(child);
         }
-    } break ;
+    } break;
         // LCOV_EXCL_START
     default:
         throw NotImplementedException("GroupDependencyAnalyzer::visit");
@@ -185,7 +191,7 @@ void GroupDependencyAnalyzer::visitNodeOrRel(std::shared_ptr<binder::Expression>
     case LogicalTypeID::NODE: {
         auto& node = expr->constCast<NodeExpression>();
         visit(node.getInternalID());
-    } break ;
+    } break;
     case LogicalTypeID::REL: {
         auto& rel = expr->constCast<RelExpression>();
         visit(rel.getSrcNode()->getInternalID());
@@ -193,7 +199,7 @@ void GroupDependencyAnalyzer::visitNodeOrRel(std::shared_ptr<binder::Expression>
         if (rel.hasDirectionExpr()) {
             visit(rel.getDirectionExpr());
         }
-    } break ;
+    } break;
     default:
         KU_UNREACHABLE;
     }

--- a/src/planner/operator/logical_accumulate.cpp
+++ b/src/planner/operator/logical_accumulate.cpp
@@ -36,11 +36,7 @@ void LogicalAccumulate::computeFlatSchema() {
 f_group_pos_set LogicalAccumulate::getGroupPositionsToFlatten() const {
     f_group_pos_set result;
     auto childSchema = children[0]->getSchema();
-    for (auto& expression : flatExprs) {
-        auto groupPos = childSchema->getGroupPos(*expression);
-        result.insert(groupPos);
-    }
-    return factorization::FlattenAll::getGroupsPosToFlatten(result, childSchema);
+    return FlattenAll::getGroupsPosToFlatten(flatExprs, *childSchema);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -6,8 +6,6 @@
 namespace kuzu {
 namespace planner {
 
-using namespace factorization;
-
 void LogicalAggregate::computeFactorizedSchema() {
     createEmptySchema();
     auto groupPos = schema->createGroup();
@@ -21,29 +19,16 @@ void LogicalAggregate::computeFlatSchema() {
 }
 
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForGroupBy() {
-    f_group_pos_set dependentGroupsPos;
-    for (auto& expression : getAllKeys()) {
-        for (auto groupPos : children[0]->getSchema()->getDependentGroupsPos(expression)) {
-            dependentGroupsPos.insert(groupPos);
-        }
-    }
     if (hasDistinctAggregate()) {
-        return FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, children[0]->getSchema());
+        return FlattenAll::getGroupsPosToFlatten(getAllKeys(), *children[0]->getSchema());
     } else {
-        return FlattenAllButOne::getGroupsPosToFlatten(dependentGroupsPos,
-            children[0]->getSchema());
+        return FlattenAllButOne::getGroupsPosToFlatten(getAllKeys(), *children[0]->getSchema());
     }
 }
 
 f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
     if (hasDistinctAggregate()) {
-        f_group_pos_set dependentGroupsPos;
-        for (auto& expression : aggregates) {
-            for (auto groupPos : children[0]->getSchema()->getDependentGroupsPos(expression)) {
-                dependentGroupsPos.insert(groupPos);
-            }
-        }
-        return FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, children[0]->getSchema());
+        return FlattenAll::getGroupsPosToFlatten(aggregates, *children[0]->getSchema());
     }
     return f_group_pos_set{};
 }

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -23,14 +23,8 @@ void LogicalDistinct::computeFlatSchema() {
 }
 
 f_group_pos_set LogicalDistinct::getGroupsPosToFlatten() {
-    f_group_pos_set dependentGroupsPos;
     auto childSchema = children[0]->getSchema();
-    for (auto& expression : getKeysAndPayloads()) {
-        for (auto groupPos : childSchema->getDependentGroupsPos(expression)) {
-            dependentGroupsPos.insert(groupPos);
-        }
-    }
-    return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+    return FlattenAll::getGroupsPosToFlatten(getKeysAndPayloads(), *childSchema);
 }
 
 std::string LogicalDistinct::getExpressionsForPrinting() const {

--- a/src/planner/operator/logical_filter.cpp
+++ b/src/planner/operator/logical_filter.cpp
@@ -7,15 +7,15 @@ namespace planner {
 
 f_group_pos_set LogicalFilter::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    auto dependentGroupsPos = childSchema->getDependentGroupsPos(expression);
-    return factorization::FlattenAllButOne::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+    return FlattenAllButOne::getGroupsPosToFlatten(expression, *childSchema);
 }
 
 f_group_pos LogicalFilter::getGroupPosToSelect() const {
     auto childSchema = children[0]->getSchema();
-    auto dependentGroupsPos = childSchema->getDependentGroupsPos(expression);
-    SchemaUtils::validateAtMostOneUnFlatGroup(dependentGroupsPos, *childSchema);
-    return SchemaUtils::getLeadingGroupPos(dependentGroupsPos, *childSchema);
+    auto analyzer = GroupDependencyAnalyzer(false, *childSchema);
+    analyzer.visit(expression);
+    SchemaUtils::validateAtMostOneUnFlatGroup(analyzer.getDependentGroups(), *childSchema);
+    return SchemaUtils::getLeadingGroupPos(analyzer.getDependentGroups(), *childSchema);
 }
 
 } // namespace planner

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -28,7 +28,7 @@ f_group_pos_set LogicalHashJoin::getGroupsPosToFlattenOnBuildSide() {
     for (auto& [probeKey, buildKey] : joinConditions) {
         joinNodesGroupPos.insert(buildSchema->getGroupPos(*buildKey));
     }
-    return factorization::FlattenAllButOne::getGroupsPosToFlatten(joinNodesGroupPos, buildSchema);
+    return FlattenAllButOne::getGroupsPosToFlatten(joinNodesGroupPos, *buildSchema);
 }
 
 void LogicalHashJoin::computeFactorizedSchema() {

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -18,8 +18,8 @@ std::string LogicalLimit::getExpressionsForPrinting() const {
 
 f_group_pos_set LogicalLimit::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    return factorization::FlattenAllButOne::getGroupsPosToFlatten(
-        childSchema->getGroupsPosInScope(), childSchema);
+    return FlattenAllButOne::getGroupsPosToFlatten(
+        childSchema->getGroupsPosInScope(), *childSchema);
 }
 
 f_group_pos LogicalLimit::getGroupPosToSelect() const {

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -18,8 +18,8 @@ std::string LogicalLimit::getExpressionsForPrinting() const {
 
 f_group_pos_set LogicalLimit::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    return FlattenAllButOne::getGroupsPosToFlatten(
-        childSchema->getGroupsPosInScope(), *childSchema);
+    return FlattenAllButOne::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),
+        *childSchema);
 }
 
 f_group_pos LogicalLimit::getGroupPosToSelect() const {

--- a/src/planner/operator/logical_mark_accumulate.cpp
+++ b/src/planner/operator/logical_mark_accumulate.cpp
@@ -31,7 +31,7 @@ f_group_pos_set LogicalMarkAccumulate::getGroupsPosToFlatten() const {
     f_group_pos_set dependentGroupsPos = childSchema->getGroupsPosInScope();
     // TODO(Xiyang/Ziyi): we don't need to flatten all. But hash aggregate seems to not allow
     // flat key with unFlat payload.
-    return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+    return FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, *childSchema);
 }
 
 expression_vector LogicalMarkAccumulate::getPayloads() const {

--- a/src/planner/operator/logical_order_by.cpp
+++ b/src/planner/operator/logical_order_by.cpp
@@ -23,13 +23,7 @@ f_group_pos_set LogicalOrderBy::getGroupsPosToFlatten() {
     // cannot read back a flat column into an unflat std::vector.
     auto childSchema = children[0]->getSchema();
     if (childSchema->getNumGroups() > 1) {
-        f_group_pos_set dependentGroupsPos;
-        for (auto& expression : expressionsToOrderBy) {
-            for (auto groupPos : childSchema->getDependentGroupsPos(expression)) {
-                dependentGroupsPos.insert(groupPos);
-            }
-        }
-        return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+        return FlattenAll::getGroupsPosToFlatten(expressionsToOrderBy, *childSchema);
     }
     return f_group_pos_set{};
 }

--- a/src/planner/operator/logical_projection.cpp
+++ b/src/planner/operator/logical_projection.cpp
@@ -1,4 +1,5 @@
 #include "planner/operator/logical_projection.h"
+
 #include "planner/operator/factorization/flatten_resolver.h"
 
 namespace kuzu {

--- a/src/planner/operator/logical_projection.cpp
+++ b/src/planner/operator/logical_projection.cpp
@@ -1,4 +1,5 @@
 #include "planner/operator/logical_projection.h"
+#include "planner/operator/factorization/flatten_resolver.h"
 
 namespace kuzu {
 namespace planner {
@@ -13,7 +14,9 @@ void LogicalProjection::computeFactorizedSchema() {
             groupPos = childSchema->getGroupPos(*expression);
             schema->insertToScopeMayRepeat(expression, groupPos);
         } else { // expression to evaluate
-            auto dependentGroupPos = childSchema->getDependentGroupsPos(expression);
+            auto analyzer = GroupDependencyAnalyzer(false, *childSchema);
+            analyzer.visit(expression);
+            auto dependentGroupPos = analyzer.getDependentGroups();
             SchemaUtils::validateAtMostOneUnFlatGroup(dependentGroupPos, *childSchema);
             if (dependentGroupPos.empty()) { // constant
                 groupPos = schema->createGroup();

--- a/src/planner/operator/logical_union.cpp
+++ b/src/planner/operator/logical_union.cpp
@@ -15,7 +15,7 @@ f_group_pos_set LogicalUnion::getGroupsPosToFlatten(uint32_t childIdx) {
             groupsPos.insert(childSchema->getGroupPos(*expression));
         }
     }
-    return factorization::FlattenAll::getGroupsPosToFlatten(groupsPos, childSchema);
+    return FlattenAll::getGroupsPosToFlatten(groupsPos, *childSchema);
 }
 
 void LogicalUnion::computeFactorizedSchema() {

--- a/src/planner/operator/logical_unwind.cpp
+++ b/src/planner/operator/logical_unwind.cpp
@@ -10,8 +10,7 @@ namespace planner {
 
 f_group_pos_set LogicalUnwind::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    auto dependentGroupsPos = childSchema->getDependentGroupsPos(inExpr);
-    return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+    return FlattenAll::getGroupsPosToFlatten(inExpr, *childSchema);
 }
 
 void LogicalUnwind::computeFactorizedSchema() {

--- a/src/planner/operator/persistent/logical_copy_to.cpp
+++ b/src/planner/operator/persistent/logical_copy_to.cpp
@@ -16,7 +16,7 @@ void LogicalCopyTo::computeFlatSchema() {
 f_group_pos_set LogicalCopyTo::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
     auto dependentGroupsPos = childSchema->getGroupsPosInScope();
-    return factorization::FlattenAllButOne::getGroupsPosToFlatten(dependentGroupsPos, childSchema);
+    return FlattenAllButOne::getGroupsPosToFlatten(dependentGroupsPos, *childSchema);
 }
 
 } // namespace planner

--- a/src/planner/operator/persistent/logical_delete.cpp
+++ b/src/planner/operator/persistent/logical_delete.cpp
@@ -40,7 +40,7 @@ f_group_pos_set LogicalDelete::getGroupsPosToFlatten() const {
     default:
         KU_UNREACHABLE;
     }
-    return factorization::FlattenAll::getGroupsPosToFlatten(dependentGroupPos, childSchema);
+    return FlattenAll::getGroupsPosToFlatten(dependentGroupPos, *childSchema);
 }
 
 } // namespace planner

--- a/src/planner/operator/persistent/logical_insert.cpp
+++ b/src/planner/operator/persistent/logical_insert.cpp
@@ -53,8 +53,7 @@ std::string LogicalInsert::getExpressionsForPrinting() const {
 
 f_group_pos_set LogicalInsert::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    return FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),
-        *childSchema);
+    return FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(), *childSchema);
 }
 
 } // namespace planner

--- a/src/planner/operator/persistent/logical_insert.cpp
+++ b/src/planner/operator/persistent/logical_insert.cpp
@@ -53,8 +53,8 @@ std::string LogicalInsert::getExpressionsForPrinting() const {
 
 f_group_pos_set LogicalInsert::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    return factorization::FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),
-        childSchema);
+    return FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),
+        *childSchema);
 }
 
 } // namespace planner

--- a/src/planner/operator/persistent/logical_merge.cpp
+++ b/src/planner/operator/persistent/logical_merge.cpp
@@ -33,8 +33,8 @@ void LogicalMerge::computeFlatSchema() {
 
 f_group_pos_set LogicalMerge::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    return factorization::FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),
-        childSchema);
+    return FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),
+        *childSchema);
 }
 
 std::unique_ptr<LogicalOperator> LogicalMerge::copy() {

--- a/src/planner/operator/persistent/logical_merge.cpp
+++ b/src/planner/operator/persistent/logical_merge.cpp
@@ -33,8 +33,7 @@ void LogicalMerge::computeFlatSchema() {
 
 f_group_pos_set LogicalMerge::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
-    return FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),
-        *childSchema);
+    return FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(), *childSchema);
 }
 
 std::unique_ptr<LogicalOperator> LogicalMerge::copy() {

--- a/src/planner/operator/persistent/logical_set.cpp
+++ b/src/planner/operator/persistent/logical_set.cpp
@@ -35,10 +35,12 @@ f_group_pos_set LogicalSetProperty::getGroupsPosToFlatten(uint32_t idx) const {
     default:
         KU_UNREACHABLE;
     }
-    for (auto& groupPos : childSchema->getDependentGroupsPos(info.setItem.second)) {
+    auto analyzer = GroupDependencyAnalyzer(false, *childSchema);
+    analyzer.visit(info.setItem.second);
+    for (auto& groupPos : analyzer.getDependentGroups()) {
         result.insert(groupPos);
     }
-    return factorization::FlattenAll::getGroupsPosToFlatten(result, childSchema);
+    return FlattenAll::getGroupsPosToFlatten(result, *childSchema);
 }
 
 std::string LogicalSetProperty::getExpressionsForPrinting() const {

--- a/src/planner/operator/schema.cpp
+++ b/src/planner/operator/schema.cpp
@@ -75,20 +75,6 @@ expression_vector Schema::getExpressionsInScope(f_group_pos pos) const {
     return result;
 }
 
-expression_vector Schema::getSubExpressionsInScope(const std::shared_ptr<Expression>& expression) {
-    expression_vector results;
-    if (isExpressionInScope(*expression)) {
-        results.push_back(expression);
-        return results;
-    }
-    for (auto& child : ExpressionChildrenCollector::collectChildren(*expression)) {
-        for (auto& subExpression : getSubExpressionsInScope(child)) {
-            results.push_back(subExpression);
-        }
-    }
-    return results;
-}
-
 bool Schema::evaluable(const Expression& expression) const {
     auto inScope = isExpressionInScope(expression);
     if (expression.expressionType == ExpressionType::LITERAL || inScope) {
@@ -105,15 +91,6 @@ bool Schema::evaluable(const Expression& expression) const {
         }
         return true;
     }
-}
-
-std::unordered_set<f_group_pos> Schema::getDependentGroupsPos(
-    const std::shared_ptr<Expression>& expression) {
-    std::unordered_set<f_group_pos> result;
-    for (auto& subExpression : getSubExpressionsInScope(expression)) {
-        result.insert(getGroupPos(subExpression->getUniqueName()));
-    }
-    return result;
 }
 
 std::unordered_set<f_group_pos> Schema::getGroupsPosInScope() const {

--- a/src/planner/plan/append_projection.cpp
+++ b/src/planner/plan/append_projection.cpp
@@ -24,9 +24,8 @@ void Planner::appendProjection(const expression_vector& expressionsToProject, Lo
         appendFlattens(plan.getSchema()->getGroupsPosInScope(), plan);
     } else {
         for (auto& expression : expressionsToProject) {
-            auto dependentGroupsPos = plan.getSchema()->getDependentGroupsPos(expression);
-            auto groupsPosToFlatten = factorization::FlattenAllButOne::getGroupsPosToFlatten(
-                dependentGroupsPos, plan.getSchema());
+            auto groupsPosToFlatten = FlattenAllButOne::getGroupsPosToFlatten(
+                expression, *plan.getSchema());
             appendFlattens(groupsPosToFlatten, plan);
         }
     }

--- a/src/planner/plan/append_projection.cpp
+++ b/src/planner/plan/append_projection.cpp
@@ -24,8 +24,8 @@ void Planner::appendProjection(const expression_vector& expressionsToProject, Lo
         appendFlattens(plan.getSchema()->getGroupsPosInScope(), plan);
     } else {
         for (auto& expression : expressionsToProject) {
-            auto groupsPosToFlatten = FlattenAllButOne::getGroupsPosToFlatten(
-                expression, *plan.getSchema());
+            auto groupsPosToFlatten =
+                FlattenAllButOne::getGroupsPosToFlatten(expression, *plan.getSchema());
             appendFlattens(groupsPosToFlatten, plan);
         }
     }

--- a/src/planner/plan/plan_subquery.cpp
+++ b/src/planner/plan/plan_subquery.cpp
@@ -1,8 +1,8 @@
 #include "binder/expression/expression_util.h"
 #include "binder/expression/subquery_expression.h"
 #include "binder/expression_visitor.h"
-#include "planner/planner.h"
 #include "planner/operator/factorization/flatten_resolver.h"
+#include "planner/planner.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -10,7 +10,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace planner {
 
-static binder::expression_vector getDependentExprs(std::shared_ptr<Expression> expr, const Schema& schema) {
+static binder::expression_vector getDependentExprs(std::shared_ptr<Expression> expr,
+    const Schema& schema) {
     auto analyzer = GroupDependencyAnalyzer(true /* collectDependentExpr */, schema);
     analyzer.visit(expr);
     return analyzer.getDependentExprs();

--- a/src/planner/plan/plan_subquery.cpp
+++ b/src/planner/plan/plan_subquery.cpp
@@ -2,6 +2,7 @@
 #include "binder/expression/subquery_expression.h"
 #include "binder/expression_visitor.h"
 #include "planner/planner.h"
+#include "planner/operator/factorization/flatten_resolver.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -9,11 +10,17 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace planner {
 
+static binder::expression_vector getDependentExprs(std::shared_ptr<Expression> expr, const Schema& schema) {
+    auto analyzer = GroupDependencyAnalyzer(true /* collectDependentExpr */, schema);
+    analyzer.visit(expr);
+    return analyzer.getDependentExprs();
+}
+
 binder::expression_vector Planner::getCorrelatedExprs(const QueryGraphCollection& collection,
     const expression_vector& predicates, Schema* outerSchema) {
     expression_vector result;
     for (auto& predicate : predicates) {
-        for (auto& expression : outerSchema->getSubExpressionsInScope(predicate)) {
+        for (auto& expression : getDependentExprs(predicate, *outerSchema)) {
             result.push_back(expression);
         }
     }
@@ -85,7 +92,7 @@ void Planner::planRegularMatch(const QueryGraphCollection& queryGraphCollection,
     // E.g. MATCH (a) WITH COUNT(*) AS s MATCH (b) WHERE b.age > s
     // "b.age > s" should be pulled up after both MATCH clauses are joined.
     for (auto& predicate : predicates) {
-        if (leftPlan.getSchema()->getSubExpressionsInScope(predicate).empty()) {
+        if (getDependentExprs(predicate, *leftPlan.getSchema()).empty()) {
             predicatesToPushDown.push_back(predicate);
         } else {
             predicatesToPullUp.push_back(predicate);
@@ -126,7 +133,7 @@ void Planner::planSubquery(const std::shared_ptr<Expression>& expression, Logica
     KU_ASSERT(expression->expressionType == ExpressionType::SUBQUERY);
     auto subquery = static_pointer_cast<SubqueryExpression>(expression);
     auto predicates = subquery->getPredicatesSplitOnAnd();
-    auto correlatedExprs = outerPlan.getSchema()->getSubExpressionsInScope(expression);
+    auto correlatedExprs = getDependentExprs(expression, *outerPlan.getSchema());
     std::unique_ptr<LogicalPlan> innerPlan;
     auto info = QueryGraphPlanningInfo();
     info.predicates = predicates;

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -149,7 +149,7 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getFunctionEvaluator(
         auto result =
             std::make_unique<ListLambdaEvaluator>(expression, std::move(childrenEvaluators));
         auto recursiveExprMapper = ExpressionMapper(schema, result.get());
-        auto& lambdaExpr = expression->getChild(1)->constCast<BoundLambdaExpression>();
+        auto& lambdaExpr = expression->getChild(1)->constCast<LambdaExpression>();
         result->setLambdaRootEvaluator(
             recursiveExprMapper.getEvaluator(lambdaExpr.getFunctionExpr()));
         return result;

--- a/test/test_files/tinysnb/function/lambda/list_filter.test
+++ b/test/test_files/tinysnb/function/lambda/list_filter.test
@@ -3,6 +3,25 @@
 --
 
 -CASE ListFilter
+
+-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.age, LIST_FILTER([1,2,3], x->x * 10 < a.age)
+---- 4
+20|[1]
+30|[1,2]
+35|[1,2,3]
+45|[1,2,3]
+-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.workedHours, LIST_FILTER(a.workedHours, x->x > a.ID)
+---- 4
+0|[10,5]|[10,5]
+2|[12,8]|[12,8]
+3|[4,5]|[4,5]
+5|[1,9]|[9]
+-STATEMENT MATCH (a:person)-[:knows]->(b) WHERE a.ID = 0 RETURN a.ID, b.ID, LIST_FILTER([1,2,3], x->x = a.ID + b.ID)
+---- 3
+0|2|[2]
+0|3|[3]
+0|5|[]
+
 -STATEMENT RETURN LIST_FILTER([5,28,92], x-> x + 4 >= 24)
 ---- 1
 [28,92]

--- a/test/test_files/tinysnb/function/lambda/list_reduce.test
+++ b/test/test_files/tinysnb/function/lambda/list_reduce.test
@@ -3,6 +3,25 @@
 --
 
 -CASE ListReduce
+
+-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, LIST_REDUCE([1,2,3], (x, y) -> x + y + a.ID)
+---- 4
+0|6
+2|10
+3|12
+5|16
+-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.workedHours, LIST_REDUCE(a.workedHours, (x, y) -> x + y + a.ID)
+---- 4
+0|[10,5]|15
+2|[12,8]|22
+3|[4,5]|12
+5|[1,9]|15
+-STATEMENT MATCH (a:person)-[:knows]->(b) WHERE a.ID = 0 RETURN a.ID, b.ID, LIST_REDUCE([1,2,3], (x, y) -> x + y + a.ID + b.ID)
+---- 3
+0|2|10
+0|3|12
+0|5|16
+
 -STATEMENT RETURN LIST_REDUCE([5,28,92], (x, y) -> x + y)
 ---- 1
 125

--- a/test/test_files/tinysnb/function/lambda/list_transform.test
+++ b/test/test_files/tinysnb/function/lambda/list_transform.test
@@ -4,9 +4,23 @@
 
 -CASE ListTransform
 
--STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN LIST_TRANSFORM([1,2,3], x->x + a.ID)
----- error
-Binder exception: Variable a is not in scope.
+-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.age, LIST_TRANSFORM([1,2,3], x->x + a.age)
+---- 4
+20|[21,22,23]
+30|[31,32,33]
+35|[36,37,38]
+45|[46,47,48]
+-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.ID, a.workedHours, LIST_TRANSFORM(a.workedHours, x->x + a.ID)
+---- 4
+0|[10,5]|[10,5]
+2|[12,8]|[14,10]
+3|[4,5]|[7,8]
+5|[1,9]|[6,14]
+-STATEMENT MATCH (a:person)-[:knows]->(b) WHERE a.ID = 0 RETURN a.ID, b.ID, LIST_TRANSFORM([1,2,3], x->x + a.ID + b.ID)
+---- 3
+0|2|[3,4,5]
+0|3|[4,5,6]
+0|5|[6,7,8]
 
 -LOG ListTransform
 -STATEMENT RETURN LIST_TRANSFORM([5,28,92], x->(CASE WHEN x < 10 THEN 0 ELSE 1 END))


### PR DESCRIPTION
# Description

This PR reworks factorization dependency analyze so that we can evaluate lambda function properly. Consider the following example
```
-STATEMENT MATCH (a:person) WHERE a.ID < 6 RETURN a.age ,LIST_TRANSFORM([1,2,3], x->x + a.age)
---- 4
20|[21,22,23]
30|[31,32,33]
35|[36,37,38]
45|[46,47,48]
```
One of `x` and `a.age` needs to be flat. If `x` is flat, then we will fill result in the following order
```
[[21], [31], [36], [46]]
[[21, 22], [31, 32], [36, 37], [46, 47]]
[[21, 22, 23], [31, 32, 33], [36, 37, 38], [46, 47, 48]]
```

If `a.age` is flat, then the order if
```
[[21, 22, 23]]
[[21, 22, 23], [31, 32, 33]]
[[21, 22, 23], [31, 32, 33], [36, 37, 38]]
[[21, 22, 23], [31, 32, 33], [36, 37, 38], [46, 47, 48]]
```
We prefer the second case because write is sequential and easier to implement.

So this PR changes the dependency analyzer to make sure we always flatten `a.age` for lambda function.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).