### PR TITLE
Add DECIMAL conversion for Node.js API

### DIFF
--- a/tools/nodejs_api/src_cpp/node_util.cpp
+++ b/tools/nodejs_api/src_cpp/node_util.cpp
@@ -270,10 +270,13 @@ Napi::Value Util::ConvertToNapiObject(const Value& value, Napi::Env env) {
     case LogicalTypeID::RDF_VARIANT: {
         return ConvertRdfVariantToNapiObject(value, env);
     }
+    case LogicalTypeID::DECIMAL: {
+        auto valString = value.toString();
+        return Napi::String::New(env, valString).ToNumber();
+    }
     default:
         throw Exception("Unsupported type: " + dataType.toString());
     }
-    return Napi::Value();
 }
 
 std::unordered_map<std::string, std::unique_ptr<Value>> Util::TransformParametersForExec(

--- a/tools/nodejs_api/test/test_data_type.js
+++ b/tools/nodejs_api/test/test_data_type.js
@@ -533,3 +533,24 @@ describe("RDF_VARIANT", function () {
     assert.deepEqual(result[15]["a.val"], new Uint8Array([0xb2]));
   });
 });
+
+describe("DECIMAL", function () {
+  it("should convert DECIMAL type", async function () {
+    const queryResult = await conn.query(
+      "UNWIND[1, 2, 3] AS A UNWIND[5.7, 8.3, 2.9] AS B RETURN CAST(CAST(A AS DECIMAL) * CAST(B AS DECIMAL) AS DECIMAL(18, 1)) AS PROD"
+    );
+    const result = await queryResult.getAll();
+    assert.equal(result.length, 9);
+    assert.deepEqual(result, [
+      { PROD: 5.7 },
+      { PROD: 8.3 },
+      { PROD: 2.9 },
+      { PROD: 11.4 },
+      { PROD: 16.6 },
+      { PROD: 5.8 },
+      { PROD: 17.1 },
+      { PROD: 24.9 },
+      { PROD: 8.7 },
+    ])
+  });
+});

--- a/tools/nodejs_api/test/test_data_type.js
+++ b/tools/nodejs_api/test/test_data_type.js
@@ -541,16 +541,13 @@ describe("DECIMAL", function () {
     );
     const result = await queryResult.getAll();
     assert.equal(result.length, 9);
-    assert.deepEqual(result, [
-      { PROD: 5.7 },
-      { PROD: 8.3 },
-      { PROD: 2.9 },
-      { PROD: 11.4 },
-      { PROD: 16.6 },
-      { PROD: 5.8 },
-      { PROD: 17.1 },
-      { PROD: 24.9 },
-      { PROD: 8.7 },
-    ])
+    const resultSorted = result.map(x => x.PROD).sort((a, b) => a - b);
+    assert.deepEqual(resultSorted,
+      [
+        2.9, 5.7, 5.8,
+        8.3, 8.7, 11.4,
+        16.6, 17.1, 24.9
+      ]
+    );
   });
 });


### PR DESCRIPTION
# Description

This PR adds support for DECIMAL type for Node.js API. Due to Node.js does not support decimal type natively, this PR converts decimal for Node.js Number.

Fixes # (issue)
#3619
