### PR TITLE
Fix depandabot security alert

### DIFF
--- a/tools/python_api/requirements_dev.txt
+++ b/tools/python_api/requirements_dev.txt
@@ -8,7 +8,7 @@ pybind11>=2.6.0
 pytest
 torch
 torch-geometric~=2.3.0
-setuptools~=69.0
+setuptools~=70.0
 
 # required for lint/formatting
 ruff==0.3.2


### PR DESCRIPTION
# Description

depandabot complains that `setuptools`  v69 has a security issue. This bumps version to 70.