### PR TITLE
Implement copy from external table

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.3.20")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.3.21")
 
 include_directories(src/include)
 

--- a/extension/duckdb/src/duckdb_scan.cpp
+++ b/extension/duckdb/src/duckdb_scan.cpp
@@ -32,7 +32,8 @@ std::unique_ptr<TableFuncBindData> DuckDBScanBindData::copy() const {
 
 DuckDBScanSharedState::DuckDBScanSharedState(
     std::unique_ptr<duckdb::MaterializedQueryResult> queryResult)
-    : BaseScanSharedState{queryResult->RowCount()}, queryResult{std::move(queryResult)} {}
+    : BaseScanSharedStateWithNumRows{queryResult->RowCount()}, queryResult{std::move(queryResult)} {
+}
 
 struct DuckDBScanFunction {
     static constexpr char DUCKDB_SCAN_FUNC_NAME[] = "duckdb_scan";

--- a/extension/duckdb/src/duckdb_scan.cpp
+++ b/extension/duckdb/src/duckdb_scan.cpp
@@ -30,8 +30,9 @@ std::unique_ptr<TableFuncBindData> DuckDBScanBindData::copy() const {
         initDuckDBConn);
 }
 
-DuckDBScanSharedState::DuckDBScanSharedState(std::unique_ptr<duckdb::QueryResult> queryResult)
-    : TableFuncSharedState(), queryResult{std::move(queryResult)} {}
+DuckDBScanSharedState::DuckDBScanSharedState(
+    std::unique_ptr<duckdb::MaterializedQueryResult> queryResult)
+    : BaseScanSharedState{queryResult->RowCount()}, queryResult{std::move(queryResult)} {}
 
 struct DuckDBScanFunction {
     static constexpr char DUCKDB_SCAN_FUNC_NAME[] = "duckdb_scan";
@@ -55,7 +56,7 @@ std::unique_ptr<function::TableFuncSharedState> DuckDBScanFunction::initSharedSt
     function::TableFunctionInitInput& input) {
     auto scanBindData = reinterpret_cast<DuckDBScanBindData*>(input.bindData);
     auto [db, conn] = scanBindData->initDuckDBConn();
-    auto result = conn.SendQuery(scanBindData->query);
+    auto result = conn.Query(scanBindData->query);
     if (result->HasError()) {
         throw common::RuntimeException(
             common::stringFormat("Failed to execute query: {} in duckdb.", result->GetError()));
@@ -219,8 +220,8 @@ static void convertDuckDBResultToVector(duckdb::DataChunk& duckDBResult, DataChu
 
 common::offset_t DuckDBScanFunction::tableFunc(function::TableFuncInput& input,
     function::TableFuncOutput& output) {
-    auto duckdbScanSharedState = reinterpret_cast<DuckDBScanSharedState*>(input.sharedState);
-    auto duckdbScanBindData = reinterpret_cast<DuckDBScanBindData*>(input.bindData);
+    auto duckdbScanSharedState = input.sharedState->ptrCast<DuckDBScanSharedState>();
+    auto duckdbScanBindData = input.bindData->constPtrCast<DuckDBScanBindData>();
     std::unique_ptr<duckdb::DataChunk> result;
     try {
         result = duckdbScanSharedState->queryResult->Fetch();

--- a/extension/duckdb/src/include/duckdb_scan.h
+++ b/extension/duckdb/src/include/duckdb_scan.h
@@ -30,7 +30,7 @@ struct DuckDBScanBindData : public function::TableFuncBindData {
     init_duckdb_conn_t initDuckDBConn;
 };
 
-struct DuckDBScanSharedState : public function::BaseScanSharedState {
+struct DuckDBScanSharedState : public function::BaseScanSharedStateWithNumRows {
     explicit DuckDBScanSharedState(std::unique_ptr<duckdb::MaterializedQueryResult> queryResult);
 
     std::unique_ptr<duckdb::MaterializedQueryResult> queryResult;

--- a/extension/duckdb/src/include/duckdb_scan.h
+++ b/extension/duckdb/src/include/duckdb_scan.h
@@ -3,7 +3,7 @@
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "function/table/bind_data.h"
-#include "function/table_functions.h"
+#include "function/table/scan_functions.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
@@ -30,10 +30,10 @@ struct DuckDBScanBindData : public function::TableFuncBindData {
     init_duckdb_conn_t initDuckDBConn;
 };
 
-struct DuckDBScanSharedState : public function::TableFuncSharedState {
-    explicit DuckDBScanSharedState(std::unique_ptr<duckdb::QueryResult> queryResult);
+struct DuckDBScanSharedState : public function::BaseScanSharedState {
+    explicit DuckDBScanSharedState(std::unique_ptr<duckdb::MaterializedQueryResult> queryResult);
 
-    std::unique_ptr<duckdb::QueryResult> queryResult;
+    std::unique_ptr<duckdb::MaterializedQueryResult> queryResult;
 };
 
 void getDuckDBVectorConversionFunc(common::PhysicalTypeID physicalTypeID,

--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -22,13 +22,6 @@ Attached database successfully.
 7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96,59,65,88]
 8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80,78,34,83]
 9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43,83,67,43]
-# TODO(Ziyi): fixme
-#-STATEMENT create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], height float, u UUID, grades INT64[4], PRIMARY KEY (ID));
-#---- ok
-#-STATEMENT COPY person FROM tinysnb.person;
-#---- 1
-#-STATEMENT MATCH (a:person) RETURN a.*;
-#---- ok
 
 -STATEMENT LOAD FROM tinysnb.organisation RETURN *;
 ---- 3
@@ -186,3 +179,25 @@ You can load it by: load extension postgres;
 -STATEMENT ATTACH 'notexist.db' (dbtype sqlite);
 ---- error
 Runtime exception: No loaded extension can handle database type: sqlite.
+
+-CASE CopyFromDuckdbTable
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension"
+---- ok
+-STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/duckdb/test/duckdb_database/tinysnb.db' as tinysnb (dbtype duckdb, skip_unsupported_table = true);
+---- 1
+Attached database successfully.
+-STATEMENT create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], height float, u UUID, grades INT64[4], PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person FROM tinysnb.person;
+---- 1
+8 tuples have been copied to the person table.
+-STATEMENT MATCH (a:person) RETURN a.*;
+---- 8
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96,54,86,92]
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|[[8,9],[9,10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|[98,42,93,88]
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13|[91,75,21,95]
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14|[76,88,99,89]
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96,59,65,88]
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80,78,34,83]
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43,83,67,43]
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18|[77,64,100,54]

--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -12,6 +12,21 @@ Binder exception: Unsupported duckdb type: ENUM('sad', 'ok', 'happy').
 -STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/duckdb/test/duckdb_database/tinysnb.db' as tinysnb (dbtype duckdb, skip_unsupported_table = true);
 ---- 1
 Attached database successfully.
+-STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], height float, u UUID, grades INT64[4], PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person_copy FROM tinysnb.person;
+---- 1
+8 tuples have been copied to the person_copy table.
+-STATEMENT MATCH (a:person_copy) RETURN a.*;
+---- 8
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96,54,86,92]
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|[[8,9],[9,10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|[98,42,93,88]
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13|[91,75,21,95]
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14|[76,88,99,89]
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96,59,65,88]
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80,78,34,83]
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43,83,67,43]
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18|[77,64,100,54]
 -STATEMENT LOAD FROM tinysnb.person RETURN *;
 ---- 8
 0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96,54,86,92]
@@ -57,9 +72,10 @@ Attached database successfully.
 ---- 1
 Attached database successfully.
 -STATEMENT CALL SHOW_TABLES() RETURN *;
----- 6
+---- 7
 movies|ATTACHED|tinysnb(DUCKDB)|
 organisation|ATTACHED|tinysnb(DUCKDB)|
+person_copy|NODE|local(kuzu)|
 person|ATTACHED|Other1(DUCKDB)|
 person|ATTACHED|tinysnb(DUCKDB)|
 tableOfTypes1|ATTACHED|tinysnb(DUCKDB)|
@@ -179,25 +195,3 @@ You can load it by: load extension postgres;
 -STATEMENT ATTACH 'notexist.db' (dbtype sqlite);
 ---- error
 Runtime exception: No loaded extension can handle database type: sqlite.
-
--CASE CopyFromDuckdbTable
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension"
----- ok
--STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/duckdb/test/duckdb_database/tinysnb.db' as tinysnb (dbtype duckdb, skip_unsupported_table = true);
----- 1
-Attached database successfully.
--STATEMENT create node table person (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], courseScoresPerTerm INT64[][], height float, u UUID, grades INT64[4], PRIMARY KEY (ID));
----- ok
--STATEMENT COPY person FROM tinysnb.person;
----- 1
-8 tuples have been copied to the person table.
--STATEMENT MATCH (a:person) RETURN a.*;
----- 8
-0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96,54,86,92]
-2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|[[8,9],[9,10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|[98,42,93,88]
-3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13|[91,75,21,95]
-5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14|[76,88,99,89]
-7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96,59,65,88]
-8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80,78,34,83]
-9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43,83,67,43]
-10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18|[77,64,100,54]

--- a/extension/postgres/test/test_files/postgres.test
+++ b/extension/postgres/test/test_files/postgres.test
@@ -7,6 +7,21 @@
 ---- ok
 -STATEMENT ATTACH 'dbname=pgscan user=ci host=localhost' as tinysnb (dbtype POSTGRES);
 ---- ok
+-STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], height double, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person_copy FROM tinysnb.person;
+---- 1
+8 tuples have been copied to the person_copy table.
+-STATEMENT MATCH (p:person_copy) RETURN p.*
+---- 8
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17
 -STATEMENT LOAD FROM tinysnb.person RETURN *;
 ---- 8
 0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
@@ -53,11 +68,12 @@ The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie
 # auxiliary tables to store type information in postgres. When the user calls show_tables(), those auxiliary tables will also
 # be displayed.
 -STATEMENT CALL SHOW_TABLES() RETURN *;
----- 8
+---- 9
 movies|ATTACHED|pgscan(POSTGRES)|
 movies|ATTACHED|tinysnb(POSTGRES)|
 organisation|ATTACHED|pgscan(POSTGRES)|
 organisation|ATTACHED|tinysnb(POSTGRES)|
+person_copy|NODE|local(kuzu)|
 persontest|ATTACHED|pgscan(POSTGRES)|
 persontest|ATTACHED|tinysnb(POSTGRES)|
 person|ATTACHED|pgscan(POSTGRES)|
@@ -79,24 +95,3 @@ person|ATTACHED|tinysnb(POSTGRES)|
 11|usednames|STRING[]
 12|height|DOUBLE
 13|u|UUID
-
--CASE CopyFromPostgresTable
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/postgres/build/libpostgres.kuzu_extension"
----- ok
--STATEMENT ATTACH 'dbname=pgscan user=ci host=localhost' as tinysnb (dbtype POSTGRES);
----- ok
--STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], height double, u UUID, PRIMARY KEY (ID));
----- ok
--STATEMENT COPY person_copy FROM tinysnb.person;
----- 1
-8 tuples have been copied to the person_copy table.
--STATEMENT MATCH (p:person_copy) RETURN p.*
----- 8
-0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
-10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18
-2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
-3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13
-5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14
-7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15
-8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16
-9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17

--- a/extension/postgres/test/test_files/postgres.test
+++ b/extension/postgres/test/test_files/postgres.test
@@ -79,3 +79,24 @@ person|ATTACHED|tinysnb(POSTGRES)|
 11|usednames|STRING[]
 12|height|DOUBLE
 13|u|UUID
+
+-CASE CopyFromPostgresTable
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/postgres/build/libpostgres.kuzu_extension"
+---- ok
+-STATEMENT ATTACH 'dbname=pgscan user=ci host=localhost' as tinysnb (dbtype POSTGRES);
+---- ok
+-STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent BoOLEAN, isWorker BOOLEAN, age INT64, eyeSight DOUBLE, birthdate DATE, registerTime TIMESTAMP, lastJobDuration interval, workedHours INT64[], usedNames STRING[], height double, u UUID, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person_copy FROM tinysnb.person;
+---- 1
+8 tuples have been copied to the person_copy table.
+-STATEMENT MATCH (p:person_copy) RETURN p.*
+---- 8
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12,8]|[Bobby]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1,9]|[Wolfeschlegelstein,Daniel]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17

--- a/extension/sqlite/test/test_files/sqlite.test
+++ b/extension/sqlite/test/test_files/sqlite.test
@@ -54,3 +54,26 @@ tableOfTypes|ATTACHED|tinysnb(SQLITE)|
 -STATEMENT DETACH tinysnb;
 ---- 1
 Detached database successfully.
+
+-CASE CopyFromSqliteTable
+-STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/sqlite/build/libsqlite.kuzu_extension"
+---- ok
+-STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/sqlite/test/sqlite_database/tinysnb' as tinysnb (dbtype sqlite);
+---- 1
+Attached database successfully.
+# TODO(Xiyang): There is no BOOL,DATE type in sqlite, so we should apply a casting from int64->bool when doing copy from.
+-STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent int64, isWorker int64, age INT64, eyeSight DOUBLE, birthdate STRING, registerTime STRING, lastJobDuration STRING, workedHours STRING, usedNames STRING, courseScoresPerTerm STRING, height double, u string, grades string, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person_copy FROM tinysnb.person;
+---- 1
+8 tuples have been copied to the person_copy table.
+-STATEMENT MATCH (p:person_copy) RETURN p.*
+---- 8
+0|Alice|1|1|0|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10, 5]|[Aida]|[[10, 8], [6, 7, 8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96, 54, 86, 92]
+2|Bob|2|1|0|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12, 8]|[Bobby]|[[8, 9], [9, 10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|[98, 42, 93, 88]
+3|Carol|1|0|1|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4, 5]|[Carmen, Fred]|[[8, 10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13|[91, 75, 21, 95]
+5|Dan|2|0|1|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1, 9]|[Wolfeschlegelstein, Daniel]|[[7, 4], [8, 8], [9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14|[76, 88, 99, 89]
+7|Elizabeth|1|0|1|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6], [7], [8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96, 59, 65, 88]
+8|Farooq|2|1|0|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3, 4, 5, 6, 7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80, 78, 34, 83]
+9|Greg|2|0|0|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43, 83, 67, 43]
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|0|1|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10, 11, 12, 3, 4, 5, 6, 7]|[Ad, De, Hi, Kye, Orlan]|[[7], [10], [6, 7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18|[77, 64, 100, 54]

--- a/extension/sqlite/test/test_files/sqlite.test
+++ b/extension/sqlite/test/test_files/sqlite.test
@@ -64,9 +64,9 @@ Runtime exception: Failed to execute query: Mismatch Type Error: Invalid type in
 ---- 6
 movies|ATTACHED|tinysnb(SQLITE)|
 organisation|ATTACHED|tinysnb(SQLITE)|
-person_copy|NODE|local(kuzu)|
 person|ATTACHED|flextype(SQLITE)|
 person|ATTACHED|tinysnb(SQLITE)|
+person_copy|NODE|local(kuzu)|
 tableOfTypes|ATTACHED|tinysnb(SQLITE)|
 -STATEMENT DETACH tinysnb;
 ---- 1

--- a/extension/sqlite/test/test_files/sqlite.test
+++ b/extension/sqlite/test/test_files/sqlite.test
@@ -8,6 +8,22 @@
 -STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/sqlite/test/sqlite_database/tinysnb' as tinysnb (dbtype sqlite);
 ---- 1
 Attached database successfully.
+# TODO(Xiyang): There is no BOOL,DATE type in sqlite, so we should apply a casting from int64->bool when doing copy from.
+-STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent int64, isWorker int64, age INT64, eyeSight DOUBLE, birthdate STRING, registerTime STRING, lastJobDuration STRING, workedHours STRING, usedNames STRING, courseScoresPerTerm STRING, height double, u string, grades string, PRIMARY KEY (ID));
+---- ok
+-STATEMENT COPY person_copy FROM tinysnb.person;
+---- 1
+8 tuples have been copied to the person_copy table.
+-STATEMENT MATCH (p:person_copy) RETURN p.*
+---- 8
+0|Alice|1|1|0|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10, 5]|[Aida]|[[10, 8], [6, 7, 8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96, 54, 86, 92]
+2|Bob|2|1|0|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12, 8]|[Bobby]|[[8, 9], [9, 10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|[98, 42, 93, 88]
+3|Carol|1|0|1|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4, 5]|[Carmen, Fred]|[[8, 10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13|[91, 75, 21, 95]
+5|Dan|2|0|1|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1, 9]|[Wolfeschlegelstein, Daniel]|[[7, 4], [8, 8], [9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14|[76, 88, 99, 89]
+7|Elizabeth|1|0|1|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6], [7], [8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96, 59, 65, 88]
+8|Farooq|2|1|0|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3, 4, 5, 6, 7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80, 78, 34, 83]
+9|Greg|2|0|0|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43, 83, 67, 43]
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|0|1|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10, 11, 12, 3, 4, 5, 6, 7]|[Ad, De, Hi, Kye, Orlan]|[[7], [10], [6, 7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18|[77, 64, 100, 54]
 -STATEMENT LOAD FROM tinysnb.person RETURN *;
 ---- 8
 0|Alice|1|1|0|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10, 5]|[Aida]|[[10, 8], [6, 7, 8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96, 54, 86, 92]
@@ -45,35 +61,13 @@ Attached database successfully.
 ---- error
 Runtime exception: Failed to execute query: Mismatch Type Error: Invalid type in column "id": column was declared as integer, found "abc" of type "text" instead. in duckdb.
 -STATEMENT CALL SHOW_TABLES() RETURN *;
----- 5
+---- 6
 movies|ATTACHED|tinysnb(SQLITE)|
 organisation|ATTACHED|tinysnb(SQLITE)|
+person_copy|NODE|local(kuzu)|
 person|ATTACHED|flextype(SQLITE)|
 person|ATTACHED|tinysnb(SQLITE)|
 tableOfTypes|ATTACHED|tinysnb(SQLITE)|
 -STATEMENT DETACH tinysnb;
 ---- 1
 Detached database successfully.
-
--CASE CopyFromSqliteTable
--STATEMENT load extension "${KUZU_ROOT_DIRECTORY}/extension/sqlite/build/libsqlite.kuzu_extension"
----- ok
--STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/extension/sqlite/test/sqlite_database/tinysnb' as tinysnb (dbtype sqlite);
----- 1
-Attached database successfully.
-# TODO(Xiyang): There is no BOOL,DATE type in sqlite, so we should apply a casting from int64->bool when doing copy from.
--STATEMENT create node table person_copy (ID INt64, fName StRING, gender INT64, isStudent int64, isWorker int64, age INT64, eyeSight DOUBLE, birthdate STRING, registerTime STRING, lastJobDuration STRING, workedHours STRING, usedNames STRING, courseScoresPerTerm STRING, height double, u string, grades string, PRIMARY KEY (ID));
----- ok
--STATEMENT COPY person_copy FROM tinysnb.person;
----- 1
-8 tuples have been copied to the person_copy table.
--STATEMENT MATCH (p:person_copy) RETURN p.*
----- 8
-0|Alice|1|1|0|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10, 5]|[Aida]|[[10, 8], [6, 7, 8]]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11|[96, 54, 86, 92]
-2|Bob|2|1|0|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00.000024|[12, 8]|[Bobby]|[[8, 9], [9, 10]]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12|[98, 42, 93, 88]
-3|Carol|1|0|1|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4, 5]|[Carmen, Fred]|[[8, 10]]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13|[91, 75, 21, 95]
-5|Dan|2|0|1|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00.000024|[1, 9]|[Wolfeschlegelstein, Daniel]|[[7, 4], [8, 8], [9]]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14|[76, 88, 99, 89]
-7|Elizabeth|1|0|1|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6], [7], [8]]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15|[96, 59, 65, 88]
-8|Farooq|2|1|0|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3, 4, 5, 6, 7]|[Fesdwe]|[[8]]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16|[80, 78, 34, 83]
-9|Greg|2|0|0|40|4.900000|1980-10-26|1976-12-23 11:21:42|10 years 5 months 13:00:00.000024|[1]|[Grad]|[[10]]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17|[43, 83, 67, 43]
-10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|0|1|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10, 11, 12, 3, 4, 5, 6, 7]|[Ad, De, Hi, Kye, Orlan]|[[7], [10], [6, 7]]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18|[77, 64, 100, 54]

--- a/src/binder/bind/read/bind_load_from.cpp
+++ b/src/binder/bind/read/bind_load_from.cpp
@@ -1,12 +1,9 @@
 #include "binder/binder.h"
 #include "binder/bound_scan_source.h"
 #include "binder/query/reading_clause/bound_load_from.h"
-#include "catalog/catalog_entry/table_catalog_entry.h"
+#include "catalog/catalog.h"
 #include "common/exception/binder.h"
-#include "common/exception/message.h"
-#include "common/string_utils.h"
 #include "main/database.h"
-#include "main/database_manager.h"
 #include "parser/query/reading_clause/load_from.h"
 #include "parser/scan_source.h"
 

--- a/src/include/function/table/scan_functions.h
+++ b/src/include/function/table/scan_functions.h
@@ -14,19 +14,26 @@ namespace function {
 
 struct BaseScanSharedState : public TableFuncSharedState {
     std::mutex lock;
-    uint64_t numRows;
 
-    explicit BaseScanSharedState(uint64_t numRows) : numRows{numRows} {}
+    virtual uint64_t getNumRows() const = 0;
 };
 
-struct ScanSharedState : public BaseScanSharedState {
+struct BaseScanSharedStateWithNumRows : public BaseScanSharedState {
+    uint64_t numRows;
+
+    explicit BaseScanSharedStateWithNumRows(uint64_t numRows) : numRows{numRows} {}
+
+    uint64_t getNumRows() const override { return numRows; }
+};
+
+struct ScanSharedState : public BaseScanSharedStateWithNumRows {
     const common::ReaderConfig readerConfig;
     uint64_t fileIdx;
     uint64_t blockIdx;
 
     ScanSharedState(common::ReaderConfig readerConfig, uint64_t numRows)
-        : BaseScanSharedState{numRows}, readerConfig{std::move(readerConfig)}, fileIdx{0},
-          blockIdx{0} {}
+        : BaseScanSharedStateWithNumRows{numRows}, readerConfig{std::move(readerConfig)},
+          fileIdx{0}, blockIdx{0} {}
 
     std::pair<uint64_t, uint64_t> getNext();
 };

--- a/src/include/function/table_functions.h
+++ b/src/include/function/table_functions.h
@@ -24,6 +24,11 @@ struct TableFuncSharedState {
 
 struct TableFuncLocalState {
     virtual ~TableFuncLocalState() = default;
+
+    template<class TARGET>
+    TARGET* ptrCast() {
+        return common::ku_dynamic_cast<TableFuncLocalState*, TARGET*>(this);
+    }
 };
 
 struct TableFuncInput {

--- a/src/include/processor/operator/persistent/reader/rdf/rdf_scan.h
+++ b/src/include/processor/operator/persistent/reader/rdf/rdf_scan.h
@@ -129,7 +129,7 @@ struct RdfScanBindData final : public function::ScanBindData {
     }
 };
 
-struct RdfInMemScanSharedState : public function::BaseScanSharedState {
+struct RdfInMemScanSharedState : public function::BaseScanSharedStateWithNumRows {
     std::shared_ptr<RdfStore> store;
     uint64_t rtCursor = 0;
     uint64_t ltCursor = 0;
@@ -138,7 +138,7 @@ struct RdfInMemScanSharedState : public function::BaseScanSharedState {
     static constexpr uint64_t batchSize = 500;
 
     explicit RdfInMemScanSharedState(std::shared_ptr<RdfStore> store)
-        : function::BaseScanSharedState{0 /* numRows */}, store{std::move(store)} {}
+        : function::BaseScanSharedStateWithNumRows{0 /* numRows */}, store{std::move(store)} {}
 
     std::pair<uint64_t, uint64_t> getResourceTripleRange() {
         auto& store_ = common::ku_dynamic_cast<RdfStore&, TripleStore&>(*store);

--- a/src/include/processor/operator/persistent/reader/rdf/rdf_scan.h
+++ b/src/include/processor/operator/persistent/reader/rdf/rdf_scan.h
@@ -129,7 +129,7 @@ struct RdfScanBindData final : public function::ScanBindData {
     }
 };
 
-struct RdfInMemScanSharedState : public function::BaseFileScanSharedState {
+struct RdfInMemScanSharedState : public function::BaseScanSharedState {
     std::shared_ptr<RdfStore> store;
     uint64_t rtCursor = 0;
     uint64_t ltCursor = 0;
@@ -138,7 +138,7 @@ struct RdfInMemScanSharedState : public function::BaseFileScanSharedState {
     static constexpr uint64_t batchSize = 500;
 
     explicit RdfInMemScanSharedState(std::shared_ptr<RdfStore> store)
-        : function::BaseFileScanSharedState{0}, store{std::move(store)} {}
+        : function::BaseScanSharedState{0 /* numRows */}, store{std::move(store)} {}
 
     std::pair<uint64_t, uint64_t> getResourceTripleRange() {
         auto& store_ = common::ku_dynamic_cast<RdfStore&, TripleStore&>(*store);

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -27,7 +27,7 @@ void NodeBatchInsertSharedState::initPKIndex(ExecutionContext*) {
         KU_ASSERT(distinctSharedState == nullptr);
         auto scanSharedState =
             readerSharedState->funcState->ptrCast<function::BaseScanSharedState>();
-        numRows = scanSharedState->numRows;
+        numRows = scanSharedState->getNumRows();
     } else {
         KU_ASSERT(distinctSharedState);
         numRows = distinctSharedState->getFactorizedTable()->getNumTuples();

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -27,7 +27,7 @@ void NodeBatchInsertSharedState::initPKIndex(ExecutionContext*) {
         KU_ASSERT(distinctSharedState == nullptr);
         auto scanSharedState =
             readerSharedState->funcState->ptrCast<function::BaseScanSharedState>();
-        numRows = scanSharedState->getNumRows();
+        numRows = scanSharedState->numRows;
     } else {
         KU_ASSERT(distinctSharedState);
         numRows = distinctSharedState->getFactorizedTable()->getNumTuples();

--- a/src/processor/operator/table_scan/ftable_scan_function.cpp
+++ b/src/processor/operator/table_scan/ftable_scan_function.cpp
@@ -24,9 +24,11 @@ struct FTableScanSharedState final : public function::BaseScanSharedState {
     common::offset_t nextTupleIdx;
 
     FTableScanSharedState(std::shared_ptr<FactorizedTable> table, uint64_t morselSize)
-        : BaseScanSharedState{table->getNumTuples()}, table{std::move(table)},
-          morselSize{morselSize}, nextTupleIdx{0} {
-        KU_ASSERT(this->table->getNumTuples() == this->table->getTotalNumFlatTuples());
+        : BaseScanSharedState{}, table{std::move(table)}, morselSize{morselSize}, nextTupleIdx{0} {}
+
+    uint64_t getNumRows() const override {
+        KU_ASSERT(table->getNumTuples() == table->getTotalNumFlatTuples());
+        return table->getNumTuples();
     }
 
     FTableScanMorsel getMorsel() {

--- a/src/processor/operator/table_scan/ftable_scan_function.cpp
+++ b/src/processor/operator/table_scan/ftable_scan_function.cpp
@@ -24,7 +24,10 @@ struct FTableScanSharedState final : public function::BaseScanSharedState {
     common::offset_t nextTupleIdx;
 
     FTableScanSharedState(std::shared_ptr<FactorizedTable> table, uint64_t morselSize)
-        : BaseScanSharedState{}, table{std::move(table)}, morselSize{morselSize}, nextTupleIdx{0} {}
+        : BaseScanSharedState{table->getNumTuples()}, table{std::move(table)},
+          morselSize{morselSize}, nextTupleIdx{0} {
+        KU_ASSERT(this->table->getNumTuples() == this->table->getTotalNumFlatTuples());
+    }
 
     FTableScanMorsel getMorsel() {
         std::unique_lock lck{lock};
@@ -32,11 +35,6 @@ struct FTableScanSharedState final : public function::BaseScanSharedState {
         auto morsel = FTableScanMorsel(nextTupleIdx, numTuplesToScan);
         nextTupleIdx += numTuplesToScan;
         return morsel;
-    }
-
-    uint64_t getNumRows() const override {
-        KU_ASSERT(table->getNumTuples() == table->getTotalNumFlatTuples());
-        return table->getNumTuples();
     }
 };
 

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -16,9 +16,9 @@ struct PandasScanLocalState final : public function::TableFuncLocalState {
     uint64_t end;
 };
 
-struct PandasScanSharedState final : public function::BaseScanSharedState {
+struct PandasScanSharedState final : public function::BaseScanSharedStateWithNumRows {
     explicit PandasScanSharedState(uint64_t numRows)
-        : BaseScanSharedState{numRows}, numRowsRead{0} {}
+        : BaseScanSharedStateWithNumRows{numRows}, numRowsRead{0} {}
 
     uint64_t numRowsRead;
 };

--- a/tools/python_api/src_cpp/include/pandas/pandas_scan.h
+++ b/tools/python_api/src_cpp/include/pandas/pandas_scan.h
@@ -9,20 +9,18 @@
 
 namespace kuzu {
 
-struct PandasScanLocalState : public function::TableFuncLocalState {
+struct PandasScanLocalState final : public function::TableFuncLocalState {
     PandasScanLocalState(uint64_t start, uint64_t end) : start{start}, end{end} {}
 
     uint64_t start;
     uint64_t end;
 };
 
-struct PandasScanSharedState : public function::BaseFileScanSharedState {
+struct PandasScanSharedState final : public function::BaseScanSharedState {
     explicit PandasScanSharedState(uint64_t numRows)
-        : BaseFileScanSharedState{numRows}, position{0}, numReadRows{0} {}
+        : BaseScanSharedState{numRows}, numRowsRead{0} {}
 
-    std::mutex lock;
-    uint64_t position;
-    uint64_t numReadRows;
+    uint64_t numRowsRead;
 };
 
 struct PandasScanFunction {

--- a/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
+++ b/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
@@ -16,13 +16,13 @@ struct PyArrowTableScanLocalState final : public function::TableFuncLocalState {
     explicit PyArrowTableScanLocalState(ArrowArrayWrapper* arrowArray) : arrowArray{arrowArray} {}
 };
 
-struct PyArrowTableScanSharedState final : public function::BaseScanSharedState {
+struct PyArrowTableScanSharedState final : public function::BaseScanSharedStateWithNumRows {
     std::vector<std::shared_ptr<ArrowArrayWrapper>> chunks;
     uint64_t currentChunk;
 
     PyArrowTableScanSharedState(uint64_t numRows,
         std::vector<std::shared_ptr<ArrowArrayWrapper>> chunks)
-        : BaseScanSharedState{numRows}, chunks{std::move(chunks)}, currentChunk{0} {}
+        : BaseScanSharedStateWithNumRows{numRows}, chunks{std::move(chunks)}, currentChunk{0} {}
 
     ArrowArrayWrapper* getNextChunk();
 };

--- a/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
+++ b/tools/python_api/src_cpp/include/pyarrow/pyarrow_scan.h
@@ -16,14 +16,13 @@ struct PyArrowTableScanLocalState final : public function::TableFuncLocalState {
     explicit PyArrowTableScanLocalState(ArrowArrayWrapper* arrowArray) : arrowArray{arrowArray} {}
 };
 
-struct PyArrowTableScanSharedState final : public function::BaseFileScanSharedState {
+struct PyArrowTableScanSharedState final : public function::BaseScanSharedState {
     std::vector<std::shared_ptr<ArrowArrayWrapper>> chunks;
     uint64_t currentChunk;
-    std::mutex lock;
 
     PyArrowTableScanSharedState(uint64_t numRows,
         std::vector<std::shared_ptr<ArrowArrayWrapper>> chunks)
-        : BaseFileScanSharedState{numRows}, chunks{std::move(chunks)}, currentChunk{0} {}
+        : BaseScanSharedState{numRows}, chunks{std::move(chunks)}, currentChunk{0} {}
 
     ArrowArrayWrapper* getNextChunk();
 };

--- a/tools/python_api/src_cpp/pandas/pandas_scan.cpp
+++ b/tools/python_api/src_cpp/pandas/pandas_scan.cpp
@@ -82,13 +82,8 @@ void pandasBackendScanSwitch(PandasColumnBindData* bindData, uint64_t count, uin
 }
 
 offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
-    auto pandasScanData =
-        ku_dynamic_cast<TableFuncBindData*, PandasScanFunctionData*>(input.bindData);
-    auto pandasLocalState =
-        ku_dynamic_cast<TableFuncLocalState*, PandasScanLocalState*>(input.localState);
-    auto pandasSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, PandasScanSharedState*>(input.sharedState);
-
+    auto pandasScanData = input.bindData->constPtrCast<PandasScanFunctionData>();
+    auto pandasLocalState = input.localState->ptrCast<PandasScanLocalState>();
     if (pandasLocalState->start >= pandasLocalState->end) {
         if (!sharedStateNext(input.bindData, pandasLocalState, input.sharedState)) {
             return 0;
@@ -116,8 +111,7 @@ PandasScanFunctionData::copyColumnBindData() const {
 }
 
 static double progressFunc(TableFuncSharedState* sharedState) {
-    auto pandasSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, PandasScanSharedState*>(sharedState);
+    auto pandasSharedState = sharedState->ptrCast<PandasScanSharedState>();
     if (pandasSharedState->numRows == 0) {
         return 0.0;
     }

--- a/tools/python_api/test/test_scan_pandas.py
+++ b/tools/python_api/test/test_scan_pandas.py
@@ -378,6 +378,7 @@ def test_scan_long_utf8_string(tmp_path: Path) -> None:
     result = conn.execute("LOAD FROM df WHERE name = '非常长的中文' RETURN count(*);")
     assert result.get_next() == [1]
 
+
 def test_copy_from_pandas_object(tmp_path: Path) -> None:
     db = kuzu.Database(tmp_path)
     conn = kuzu.Connection(db)


### PR DESCRIPTION
# Description

This PR refactors the `DuckDBScanSharedState` to inherit from `BaseScanSharedState`. So we can do copy from a external duckdb, sqlite, postgres table.
