### PR TITLE
Issue 3507

### DIFF
--- a/src/binder/bind_expression/bind_parameter_expression.cpp
+++ b/src/binder/bind_expression/bind_parameter_expression.cpp
@@ -17,7 +17,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindParameterExpression(
     } else {
         auto value = std::make_shared<Value>(Value::createNullValue());
         parameterMap.insert({parameterName, value});
-        return make_shared<ParameterExpression>(parameterName, *value);
+        return std::make_shared<ParameterExpression>(parameterName, *value);
     }
 }
 

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -9,6 +9,7 @@
 #include "function/struct/vector_struct_functions.h"
 #include "parser/expression/parsed_property_expression.h"
 
+
 using namespace kuzu::common;
 using namespace kuzu::parser;
 using namespace kuzu::catalog;
@@ -72,7 +73,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
     auto propertyName = propertyExpression.getPropertyName();
     auto child = bindExpression(*parsedExpression.getChild(0));
     ExpressionUtil::validateDataType(*child,
-        std::vector<LogicalTypeID>{LogicalTypeID::NODE, LogicalTypeID::REL, LogicalTypeID::STRUCT});
+        std::vector<LogicalTypeID>{LogicalTypeID::NODE, LogicalTypeID::REL, LogicalTypeID::STRUCT, LogicalTypeID::ANY});
     if (isNodeOrRelPattern(*child)) {
         if (Binder::reservedInPropertyLookup(propertyName)) {
             // Note we don't expose direct access to internal properties in case user tries to
@@ -84,6 +85,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
         return bindNodeOrRelPropertyExpression(*child, propertyName);
     } else if (isStructPattern(*child)) {
         return bindStructPropertyExpression(child, propertyName);
+    } else if (child->getDataType().getLogicalTypeID() == LogicalTypeID::ANY) {
+        return createVariableExpression(LogicalType::ANY(), binder->getUniqueExpressionName(""));
     } else {
         throw BinderException(stringFormat("Cannot bind property for expression {} with type {}.",
             child->toString(), ExpressionTypeUtil::toString(child->expressionType)));

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -9,7 +9,6 @@
 #include "function/struct/vector_struct_functions.h"
 #include "parser/expression/parsed_property_expression.h"
 
-
 using namespace kuzu::common;
 using namespace kuzu::parser;
 using namespace kuzu::catalog;
@@ -73,7 +72,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
     auto propertyName = propertyExpression.getPropertyName();
     auto child = bindExpression(*parsedExpression.getChild(0));
     ExpressionUtil::validateDataType(*child,
-        std::vector<LogicalTypeID>{LogicalTypeID::NODE, LogicalTypeID::REL, LogicalTypeID::STRUCT, LogicalTypeID::ANY});
+        std::vector<LogicalTypeID>{LogicalTypeID::NODE, LogicalTypeID::REL, LogicalTypeID::STRUCT,
+            LogicalTypeID::ANY});
     if (isNodeOrRelPattern(*child)) {
         if (Binder::reservedInPropertyLookup(propertyName)) {
             // Note we don't expose direct access to internal properties in case user tries to

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -2,6 +2,7 @@
 
 #include "binder/binder.h"
 #include "binder/expression/expression_util.h"
+#include "binder/expression/parameter_expression.h"
 #include "binder/expression_visitor.h"
 #include "common/exception/binder.h"
 #include "common/exception/not_implemented.h"
@@ -11,7 +12,6 @@
 #include "main/client_context.h"
 #include "parser/expression/parsed_expression_visitor.h"
 #include "parser/expression/parsed_parameter_expression.h"
-#include "binder/expression/parameter_expression.h"
 
 using namespace kuzu::common;
 using namespace kuzu::function;

--- a/src/include/parser/expression/parsed_expression.h
+++ b/src/include/parser/expression/parsed_expression.h
@@ -45,22 +45,22 @@ public:
     DELETE_COPY_DEFAULT_MOVE(ParsedExpression);
     virtual ~ParsedExpression() = default;
 
-    inline common::ExpressionType getExpressionType() const { return type; }
+    common::ExpressionType getExpressionType() const { return type; }
 
-    inline void setAlias(std::string name) { alias = std::move(name); }
+    void setAlias(std::string name) { alias = std::move(name); }
 
-    inline bool hasAlias() const { return !alias.empty(); }
+    bool hasAlias() const { return !alias.empty(); }
 
-    inline std::string getAlias() const { return alias; }
+    std::string getAlias() const { return alias; }
 
-    inline std::string getRawName() const { return rawName; }
+    std::string getRawName() const { return rawName; }
 
-    inline uint32_t getNumChildren() const { return children.size(); }
-    inline ParsedExpression* getChild(uint32_t idx) const { return children[idx].get(); }
+    uint32_t getNumChildren() const { return children.size(); }
+    ParsedExpression* getChild(uint32_t idx) const { return children[idx].get(); }
 
-    inline std::string toString() const { return rawName; }
+    std::string toString() const { return rawName; }
 
-    virtual inline std::unique_ptr<ParsedExpression> copy() const {
+    virtual std::unique_ptr<ParsedExpression> copy() const {
         return std::make_unique<ParsedExpression>(type, alias, rawName, copyVector(children));
     }
 
@@ -82,7 +82,7 @@ public:
     }
 
 private:
-    virtual inline void serializeInternal(common::Serializer&) const {}
+    virtual void serializeInternal(common::Serializer&) const {}
 
 protected:
     common::ExpressionType type;

--- a/src/include/parser/expression/parsed_expression_visitor.h
+++ b/src/include/parser/expression/parsed_expression_visitor.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "parsed_expression.h"
+
+namespace kuzu {
+namespace parser {
+
+class ParsedExpressionVisitor {
+public:
+    virtual ~ParsedExpressionVisitor() = default;
+
+    void visit(const ParsedExpression* expr);
+
+    void visitSwitch(const ParsedExpression* expr);
+    virtual void visitFunctionExpr(const ParsedExpression*) {}
+    virtual void visitAggFunctionExpr(const ParsedExpression*) {}
+    virtual void visitPropertyExpr(const ParsedExpression*) {}
+    virtual void visitLiteralExpr(const ParsedExpression*) {}
+    virtual void visitVariableExpr(const ParsedExpression*) {}
+    virtual void visitPathExpr(const ParsedExpression*) {}
+    virtual void visitNodeRelExpr(const ParsedExpression*) {}
+    virtual void visitParamExpr(const ParsedExpression*) {}
+    virtual void visitSubqueryExpr(const ParsedExpression*) {}
+    virtual void visitCaseExpr(const ParsedExpression*) {}
+    virtual void visitGraphExpr(const ParsedExpression*) {}
+    virtual void visitLambdaExpr(const ParsedExpression*) {}
+
+    void visitChildren(const ParsedExpression& expr);
+    void visitCaseExprChildren(const ParsedExpression& expr);
+};
+
+class ParsedParamExprCollector : public ParsedExpressionVisitor {
+public:
+    std::vector<const ParsedExpression*> getParamExprs() const {
+        return paramExprs;
+    }
+    bool hasParamExprs() const {
+        return !paramExprs.empty();
+    }
+
+    void visitParamExpr(const ParsedExpression* expr) override {
+        paramExprs.push_back(expr);
+    }
+
+private:
+    std::vector<const ParsedExpression*> paramExprs;
+};
+
+}
+}

--- a/src/include/parser/expression/parsed_expression_visitor.h
+++ b/src/include/parser/expression/parsed_expression_visitor.h
@@ -31,20 +31,14 @@ public:
 
 class ParsedParamExprCollector : public ParsedExpressionVisitor {
 public:
-    std::vector<const ParsedExpression*> getParamExprs() const {
-        return paramExprs;
-    }
-    bool hasParamExprs() const {
-        return !paramExprs.empty();
-    }
+    std::vector<const ParsedExpression*> getParamExprs() const { return paramExprs; }
+    bool hasParamExprs() const { return !paramExprs.empty(); }
 
-    void visitParamExpr(const ParsedExpression* expr) override {
-        paramExprs.push_back(expr);
-    }
+    void visitParamExpr(const ParsedExpression* expr) override { paramExprs.push_back(expr); }
 
 private:
     std::vector<const ParsedExpression*> paramExprs;
 };
 
-}
-}
+} // namespace parser
+} // namespace kuzu

--- a/src/parser/expression/CMakeLists.txt
+++ b/src/parser/expression/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(kuzu_parser_expression
         OBJECT
         parsed_case_expression.cpp
         parsed_expression.cpp
+        parsed_expression_visitor.cpp
         parsed_function_expression.cpp
         parsed_property_expression.cpp
         parsed_variable_expression.cpp)

--- a/src/parser/expression/parsed_expression_visitor.cpp
+++ b/src/parser/expression/parsed_expression_visitor.cpp
@@ -1,0 +1,106 @@
+#include "parser/expression/parsed_expression_visitor.h"
+#include "common/exception/not_implemented.h"
+#include "parser/expression/parsed_lambda_expression.h"
+#include "parser/expression/parsed_case_expression.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace parser {
+
+void ParsedExpressionVisitor::visit(const ParsedExpression* expr) {
+    visitChildren(*expr);
+    visitSwitch(expr);
+}
+
+void ParsedExpressionVisitor::visitSwitch(const ParsedExpression* expr) {
+    switch (expr->getExpressionType()) {
+    case ExpressionType::OR:
+    case ExpressionType::XOR:
+    case ExpressionType::AND:
+    case ExpressionType::NOT:
+    case ExpressionType::EQUALS:
+    case ExpressionType::NOT_EQUALS:
+    case ExpressionType::GREATER_THAN:
+    case ExpressionType::GREATER_THAN_EQUALS:
+    case ExpressionType::LESS_THAN:
+    case ExpressionType::LESS_THAN_EQUALS:
+    case ExpressionType::IS_NULL:
+    case ExpressionType::IS_NOT_NULL:
+    case ExpressionType::FUNCTION: {
+        visitFunctionExpr(expr);
+    } break;
+    case ExpressionType::AGGREGATE_FUNCTION: {
+        visitAggFunctionExpr(expr);
+    } break;
+    case ExpressionType::PROPERTY: {
+        visitPropertyExpr(expr);
+    } break;
+    case ExpressionType::LITERAL: {
+        visitLiteralExpr(expr);
+    } break;
+    case ExpressionType::VARIABLE: {
+        visitVariableExpr(expr);
+    } break;
+    case ExpressionType::PATH: {
+        visitPathExpr(expr);
+    } break;
+    case ExpressionType::PATTERN: {
+        visitNodeRelExpr(expr);
+    } break;
+    case ExpressionType::PARAMETER: {
+        visitParamExpr(expr);
+    } break;
+    case ExpressionType::SUBQUERY: {
+        visitSubqueryExpr(expr);
+    } break;
+    case ExpressionType::CASE_ELSE: {
+        visitCaseExpr(expr);
+    } break;
+    case ExpressionType::GRAPH: {
+        visitGraphExpr(expr);
+    } break;
+    case ExpressionType::LAMBDA: {
+        visitLambdaExpr(expr);
+    } break;
+        // LCOV_EXCL_START
+    default:
+        throw NotImplementedException("ExpressionVisitor::visitSwitch");
+        // LCOV_EXCL_STOP
+    }
+}
+
+void ParsedExpressionVisitor::visitChildren(const ParsedExpression& expr) {
+    switch (expr.getExpressionType()) {
+    case ExpressionType::CASE_ELSE: {
+        visitCaseExprChildren(expr);
+    } break;
+    case ExpressionType::LAMBDA: {
+        auto& lambda = expr.constCast<ParsedLambdaExpression>();
+        visit(lambda.getFunctionExpr());
+    } break;
+    default: {
+        for (auto i = 0u; i < expr.getNumChildren(); ++i) {
+            visit(expr.getChild(i));
+        }
+    }
+    }
+}
+
+void ParsedExpressionVisitor::visitCaseExprChildren(const ParsedExpression& expr) {
+    auto& caseExpr = expr.constCast<ParsedCaseExpression>();
+    if (caseExpr.hasCaseExpression()) {
+        visit(caseExpr.getCaseExpression());
+    }
+    for (auto i = 0u; i < caseExpr.getNumCaseAlternative(); ++i) {
+        auto alternative = caseExpr.getCaseAlternative(i);
+        visit(alternative->whenExpression.get());
+        visit(alternative->thenExpression.get());
+    }
+    if (caseExpr.hasElseExpression()) {
+        visit(caseExpr.getElseExpression());
+    }
+}
+
+}
+}

--- a/src/parser/expression/parsed_expression_visitor.cpp
+++ b/src/parser/expression/parsed_expression_visitor.cpp
@@ -1,7 +1,8 @@
 #include "parser/expression/parsed_expression_visitor.h"
+
 #include "common/exception/not_implemented.h"
-#include "parser/expression/parsed_lambda_expression.h"
 #include "parser/expression/parsed_case_expression.h"
+#include "parser/expression/parsed_lambda_expression.h"
 
 using namespace kuzu::common;
 
@@ -102,5 +103,5 @@ void ParsedExpressionVisitor::visitCaseExprChildren(const ParsedExpression& expr
     }
 }
 
-}
-}
+} // namespace parser
+} // namespace kuzu

--- a/test/test_files/exceptions/binder/binder_error.test
+++ b/test/test_files/exceptions/binder/binder_error.test
@@ -67,7 +67,7 @@ Binder exception: Variable b is not in scope.
 -LOG BindPropertyLookUpOnExpression
 -STATEMENT MATCH (a:person)-[e1:knows]->(b:person) RETURN (a.age + 2).age
 ---- error
-Binder exception: +(a.age,2) has data type INT64 but (NODE,REL,STRUCT) was expected.
+Binder exception: +(a.age,2) has data type INT64 but (NODE,REL,STRUCT,ANY) was expected.
 
 -LOG BindPropertyNotExist
 -STATEMENT MATCH (a:person)-[e1:knows]->(b:person) RETURN a.foo

--- a/test/test_files/tck/expressions/map/Map1.test
+++ b/test/test_files/tck/expressions/map/Map1.test
@@ -116,31 +116,31 @@ Pontus
            RETURN nonMap.num;
 ## Outcome: an Error should be raised at compile time: InvalidArgumentType
 ---- error
-Binder exception: nonMap has data type INT64 but (NODE,REL,STRUCT) was expected.
+Binder exception: nonMap has data type INT64 but (NODE,REL,STRUCT,ANY) was expected.
 
 -STATEMENT WITH 42.45 AS nonMap
            RETURN nonMap.num;
 ## Outcome: an Error should be raised at compile time: InvalidArgumentType
 ---- error
-Binder exception: nonMap has data type DOUBLE but (NODE,REL,STRUCT) was expected.
+Binder exception: nonMap has data type DOUBLE but (NODE,REL,STRUCT,ANY) was expected.
 
 -STATEMENT WITH True AS nonMap
            RETURN nonMap.num;
 ## Outcome: an Error should be raised at compile time: InvalidArgumentType
 ---- error
-Binder exception: nonMap has data type BOOL but (NODE,REL,STRUCT) was expected.
+Binder exception: nonMap has data type BOOL but (NODE,REL,STRUCT,ANY) was expected.
 
 -STATEMENT WITH False AS nonMap
            RETURN nonMap.num;
 ## Outcome: an Error should be raised at compile time: InvalidArgumentType
 ---- error
-Binder exception: nonMap has data type BOOL but (NODE,REL,STRUCT) was expected.
+Binder exception: nonMap has data type BOOL but (NODE,REL,STRUCT,ANY) was expected.
 
 -STATEMENT WITH 'string' AS nonMap
            RETURN nonMap.num;
 ## Outcome: an Error should be raised at compile time: InvalidArgumentType
 ---- error
-Binder exception: nonMap has data type STRING but (NODE,REL,STRUCT) was expected.
+Binder exception: nonMap has data type STRING but (NODE,REL,STRUCT,ANY) was expected.
 
 -STATEMENT WITH [123, True] AS nonMap
            RETURN nonMap.num;

--- a/test/test_files/tck/match_where/match_where1.test
+++ b/test/test_files/tck/match_where/match_where1.test
@@ -251,7 +251,7 @@
            WHERE r.name = 'apa'
            RETURN r;
 ---- error
-Binder exception: r has data type RECURSIVE_REL but (NODE,REL,STRUCT) was expected.
+Binder exception: r has data type RECURSIVE_REL but (NODE,REL,STRUCT,ANY) was expected.
 
 # Fail on aggregation in WHERE
 -CASE Scenario15

--- a/test/test_files/tinysnb/exception/list.test
+++ b/test/test_files/tinysnb/exception/list.test
@@ -20,7 +20,3 @@ Binder exception: Cannot bind LIST_CONCAT with parameter type INT64[] and STRING
 -STATEMENT MATCH (a:person) RETURN [a.age, a.fName]
 ---- error
 Binder exception: Expression a.fName has data type STRING but expected INT64. Implicit cast is not supported.
-
--STATEMENT MATCH (a:person) RETURN list_sort($1)
----- error
-Binder exception: Cannot resolve recursive data type for expression $1

--- a/test/test_files/tinysnb/exception/relation.test
+++ b/test/test_files/tinysnb/exception/relation.test
@@ -6,7 +6,7 @@
 
 -STATEMENT MATCH (a:person)-[e:knows*1..3]->(b:person) RETURN e.age
 ---- error
-Binder exception: e has data type RECURSIVE_REL but (NODE,REL,STRUCT) was expected.
+Binder exception: e has data type RECURSIVE_REL but (NODE,REL,STRUCT,ANY) was expected.
 
 
 -STATEMENT MATCH (a:person)-[e:knows*1..3]->(b:person) WHERE ID(e) = 0 RETURN COUNT(*)


### PR DESCRIPTION
# Description

We had faced many issues regarding parameter binding. I think it's just fundamentally hard to bind an arbitrary expression when the parameter type is not given (I.e. when we prepare the statement). I say "fundamentally hard" not because it's not doable but more because we have to go through all functions and expressions to handle & test the case. I don't think it's the right time to spend our engineering effort on this now.

I have moved to a new design where we skip the expression binding if we detect it contains a parameter expression whose data type is unknown. With this, we no longer need to worry about propagating ANY data type along expression binding.

I do anticipate more bug related to parameter because it may appear anywhere in a statement. So there must be missing pieces that we forget to handle. We can fix them as more bugs being report.

Fixes #3507 in a more proper way.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).