### PR TITLE
removing memory_order arguments in bm

### DIFF
--- a/src/include/storage/buffer_manager/bm_file_handle.h
+++ b/src/include/storage/buffer_manager/bm_file_handle.h
@@ -30,9 +30,7 @@ public:
     static constexpr uint64_t MARKED = 2;
     static constexpr uint64_t EVICTED = 3;
 
-    PageState() {
-        stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE);
-    }
+    PageState() { stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE); }
 
     inline uint64_t getState() { return getState(stateAndVersion.load()); }
     inline static uint64_t getState(uint64_t stateAndVersion) {
@@ -90,9 +88,7 @@ public:
     inline bool isDirty() const { return stateAndVersion & DIRTY_MASK; }
     uint64_t getStateAndVersion() const { return stateAndVersion.load(); }
 
-    inline void resetToEvicted() {
-        stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE);
-    }
+    inline void resetToEvicted() { stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE); }
 
 private:
     // Highest 1 bit is dirty bit, and the rest are page state and version bits.

--- a/src/include/storage/buffer_manager/bm_file_handle.h
+++ b/src/include/storage/buffer_manager/bm_file_handle.h
@@ -31,7 +31,7 @@ public:
     static constexpr uint64_t EVICTED = 3;
 
     PageState() {
-        stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE, std::memory_order_release);
+        stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE);
     }
 
     inline uint64_t getState() { return getState(stateAndVersion.load()); }
@@ -63,8 +63,7 @@ public:
     inline void unlock() {
         // TODO(Keenan / Guodong): Track down this rare bug and re-enable the assert. Ref #2289.
         // KU_ASSERT(getState(stateAndVersion.load()) == LOCKED);
-        stateAndVersion.store(updateStateAndIncrementVersion(stateAndVersion.load(), UNLOCKED),
-            std::memory_order_release);
+        stateAndVersion.store(updateStateAndIncrementVersion(stateAndVersion.load(), UNLOCKED));
     }
     // Change page state from Mark to Unlocked.
     inline bool tryClearMark(uint64_t oldStateAndVersion) {
@@ -92,7 +91,7 @@ public:
     uint64_t getStateAndVersion() const { return stateAndVersion.load(); }
 
     inline void resetToEvicted() {
-        stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE, std::memory_order_release);
+        stateAndVersion.store(EVICTED << NUM_BITS_TO_SHIFT_FOR_STATE);
     }
 
 private:


### PR DESCRIPTION
# Description

Removes all memory_order arguments in BM because the loads do not give an argument. We should use the default argument everywhere.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).