### PR TITLE
Turn on primary key scan while using PreparedStatement

### DIFF
--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -1,5 +1,6 @@
 #include "optimizer/filter_push_down_optimizer.h"
 
+#include "binder/expression/function_expression.h"
 #include "binder/expression/literal_expression.h"
 #include "binder/expression/property_expression.h"
 #include "main/client_context.h"
@@ -139,6 +140,26 @@ static ColumnPredicateSet getPropertyPredicateSet(const Expression& property,
     return propertyPredicateSet;
 }
 
+// TODO need determine whether the expression is a constant based on its output type
+static bool isLiteralExpression(const std::shared_ptr<Expression> expression) {
+    switch (expression->expressionType) {
+    case ExpressionType::LITERAL:
+    case ExpressionType::PARAMETER: {
+        return true;
+    }
+    case ExpressionType::FUNCTION: {
+        auto& func = expression->constCast<FunctionExpression>();
+        if (func.getFunctionName() == "CAST") {
+            return isLiteralExpression(func.getChild(0));
+        } else {
+            return false;
+        }
+    }
+    default:
+        return false;
+    }
+}
+
 std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableReplace(
     const std::shared_ptr<LogicalOperator>& op) {
     auto& scan = op->cast<LogicalScanNodeTable>();
@@ -165,7 +186,7 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
     }
     if (primaryKeyEqualityComparison != nullptr) { // Try rewrite index scan
         auto rhs = primaryKeyEqualityComparison->getChild(1);
-        if (rhs->expressionType == ExpressionType::LITERAL) {
+        if (isLiteralExpression(rhs)) {
             auto extraInfo = std::make_unique<PrimaryKeyScanInfo>(rhs);
             scan.setScanType(LogicalScanNodeTableType::PRIMARY_KEY_SCAN);
             scan.setExtraInfo(std::move(extraInfo));

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -267,7 +267,14 @@ void PredicateSet::addPredicate(std::shared_ptr<Expression> predicate) {
 }
 
 static bool isNodePrimaryKey(const Expression& expression, const Expression& nodeID) {
-    if (expression.expressionType != ExpressionType::PROPERTY) {
+    if (expression.expressionType == ExpressionType::FUNCTION) {
+        auto& func = expression.constCast<FunctionExpression>();
+        if (func.getFunctionName() == "CAST") {
+            return isNodePrimaryKey(*func.getChild(0), nodeID);
+        } else {
+            return false;
+        }
+    } else if (expression.expressionType != ExpressionType::PROPERTY) {
         // not property
         return false;
     }


### PR DESCRIPTION
# Description

When PARAMETER exists in the statement, PRIMARY_KEY_SCAN is supported as LogicalScanNodeTableType


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).