### PR TITLE
Hash index support for MVCC

### DIFF
--- a/src/include/processor/operator/index_lookup.h
+++ b/src/include/processor/operator/index_lookup.h
@@ -4,25 +4,25 @@
 
 namespace kuzu {
 namespace storage {
-class PrimaryKeyIndex;
+class NodeTable;
 } // namespace storage
 namespace processor {
 
 struct BatchInsertSharedState;
 struct IndexLookupInfo {
-    storage::PrimaryKeyIndex* index;
+    storage::NodeTable* nodeTable;
     // In copy rdf, we need to perform lookup before primary key is persist on disk. So we need to
     // use index builder.
     std::shared_ptr<BatchInsertSharedState> batchInsertSharedState;
     DataPos keyVectorPos;
     DataPos resultVectorPos;
 
-    IndexLookupInfo(storage::PrimaryKeyIndex* index, const DataPos& keyVectorPos,
+    IndexLookupInfo(storage::NodeTable* nodeTable, const DataPos& keyVectorPos,
         const DataPos& resultVectorPos)
-        : index{index}, batchInsertSharedState{nullptr}, keyVectorPos{keyVectorPos},
+        : nodeTable{nodeTable}, batchInsertSharedState{nullptr}, keyVectorPos{keyVectorPos},
           resultVectorPos{resultVectorPos} {}
     IndexLookupInfo(const IndexLookupInfo& other)
-        : index{other.index}, batchInsertSharedState{other.batchInsertSharedState},
+        : nodeTable{other.nodeTable}, batchInsertSharedState{other.batchInsertSharedState},
           keyVectorPos{other.keyVectorPos}, resultVectorPos{other.resultVectorPos} {}
 
     inline std::unique_ptr<IndexLookupInfo> copy() {

--- a/src/include/processor/operator/persistent/node_batch_insert.h
+++ b/src/include/processor/operator/persistent/node_batch_insert.h
@@ -47,7 +47,6 @@ struct NodeBatchInsertInfo final : BatchInsertInfo {
 
 struct NodeBatchInsertSharedState final : BatchInsertSharedState {
     // Primary key info
-    storage::PrimaryKeyIndex* pkIndex;
     common::column_id_t pkColumnID;
     common::LogicalType pkType;
     std::optional<IndexBuilder> globalIndexBuilder = std::nullopt;
@@ -63,10 +62,7 @@ struct NodeBatchInsertSharedState final : BatchInsertSharedState {
         common::LogicalType pkType, std::shared_ptr<FactorizedTable> fTable, storage::WAL* wal)
         : BatchInsertSharedState{table, std::move(fTable), wal}, pkColumnID{pkColumnID},
           pkType{std::move(pkType)}, readerSharedState{nullptr}, distinctSharedState{nullptr},
-          sharedNodeGroup{nullptr} {
-        pkIndex =
-            common::ku_dynamic_cast<storage::Table*, storage::NodeTable*>(table)->getPKIndex();
-    }
+          sharedNodeGroup{nullptr} {}
 
     void initPKIndex(ExecutionContext* context);
 };

--- a/src/include/storage/local_storage/local_hash_index.h
+++ b/src/include/storage/local_storage/local_hash_index.h
@@ -27,11 +27,11 @@ public:
         : localDeletions{}, localInsertions{handle} {}
     using OwnedKeyType = std::conditional_t<std::same_as<T, common::ku_string_t>, std::string, T>;
     using Key = std::conditional_t<std::same_as<T, common::ku_string_t>, std::string_view, T>;
-    HashIndexLocalLookupState lookup(Key key, common::offset_t& result) {
+    HashIndexLocalLookupState lookup(Key key, common::offset_t& result, visible_func isVisible) {
         if (localDeletions.contains(key)) {
             return HashIndexLocalLookupState::KEY_DELETED;
         }
-        if (localInsertions.lookup(key, result)) {
+        if (localInsertions.lookup(key, result, isVisible)) {
             return HashIndexLocalLookupState::KEY_FOUND;
         }
         return HashIndexLocalLookupState::KEY_NOT_EXIST;
@@ -43,16 +43,16 @@ public:
         }
     }
 
-    bool insert(Key key, common::offset_t value) {
+    bool insert(Key key, common::offset_t value, visible_func isVisible) {
         auto iter = localDeletions.find(key);
         if (iter != localDeletions.end()) {
             localDeletions.erase(iter);
         }
-        return localInsertions.append(key, value);
+        return localInsertions.append(key, value, isVisible);
     }
 
-    size_t append(const IndexBuffer<OwnedKeyType>& buffer) {
-        return localInsertions.append(buffer);
+    size_t append(const IndexBuffer<OwnedKeyType>& buffer, visible_func isVisible) {
+        return localInsertions.append(buffer, isVisible);
     }
 
     bool hasUpdates() const { return !(localInsertions.empty() && localDeletions.empty()); }
@@ -103,29 +103,31 @@ public:
             [&](auto) { KU_UNREACHABLE; });
     }
 
-    bool insert(const common::ValueVector& keyVector, common::offset_t startNodeOffset) {
+    bool insert(const common::ValueVector& keyVector, common::offset_t startNodeOffset,
+        visible_func isVisible) {
         common::length_t numInserted = 0;
         common::TypeUtils::visit(
             keyDataTypeID,
             [&]<common::IndexHashable T>(T) {
                 for (auto i = 0u; i < keyVector.state->getSelVector().getSelSize(); i++) {
                     const auto pos = keyVector.state->getSelVector().getSelectedPositions()[i];
-                    numInserted += insert(keyVector.getValue<T>(pos), startNodeOffset + i);
+                    numInserted +=
+                        insert(keyVector.getValue<T>(pos), startNodeOffset + i, isVisible);
                 }
             },
             [](auto) { KU_UNREACHABLE; });
         return numInserted == keyVector.state->getSelVector().getSelSize();
     }
 
-    bool insert(const common::ku_string_t key, common::offset_t value) {
-        return insert(key.getAsStringView(), value);
+    bool insert(const common::ku_string_t key, common::offset_t value, visible_func isVisible) {
+        return insert(key.getAsStringView(), value, isVisible);
     }
     template<common::IndexHashable T>
-    bool insert(T key, common::offset_t value) {
+    bool insert(T key, common::offset_t value, visible_func isVisible) {
         KU_ASSERT(keyDataTypeID == common::TypeUtils::getPhysicalTypeIDForType<T>());
         return common::ku_dynamic_cast<BaseHashIndexLocalStorage*,
             HashIndexLocalStorage<HashIndexType<T>>*>(localIndex.get())
-            ->insert(key, value);
+            ->insert(key, value, isVisible);
     }
 
     void delete_(const common::ValueVector& keyVector) {

--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -18,7 +18,7 @@ public:
     DELETE_COPY_AND_MOVE(LocalNodeTable);
 
     bool insert(transaction::Transaction* transaction, TableInsertState& insertState) override;
-    bool update(TableUpdateState& updateState) override;
+    bool update(transaction::Transaction* transaction, TableUpdateState& updateState) override;
     bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) override;
     bool addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState) override;
@@ -37,6 +37,7 @@ public:
 
 private:
     void initLocalHashIndex();
+    bool isVisible(const transaction::Transaction* transaction, common::offset_t offset);
 
 private:
     PageCursor overflowCursor;

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -20,7 +20,7 @@ public:
     explicit LocalRelTable(Table& table);
 
     bool insert(transaction::Transaction* transaction, TableInsertState& state) override;
-    bool update(TableUpdateState& state) override;
+    bool update(transaction::Transaction* transaction, TableUpdateState& state) override;
     bool delete_(transaction::Transaction* transaction, TableDeleteState& state) override;
     bool addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState) override;

--- a/src/include/storage/local_storage/local_table.h
+++ b/src/include/storage/local_storage/local_table.h
@@ -22,7 +22,7 @@ public:
     virtual ~LocalTable() = default;
 
     virtual bool insert(transaction::Transaction* transaction, TableInsertState& insertState) = 0;
-    virtual bool update(TableUpdateState& updateState) = 0;
+    virtual bool update(transaction::Transaction* transaction, TableUpdateState& updateState) = 0;
     virtual bool delete_(transaction::Transaction* transaction, TableDeleteState& deleteState) = 0;
     virtual bool addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState) = 0;

--- a/src/include/storage/store/chunked_node_group.h
+++ b/src/include/storage/store/chunked_node_group.h
@@ -118,6 +118,8 @@ public:
         bool enableCompression, BMFileHandle* dataFH);
 
     bool isDeleted(const transaction::Transaction* transaction, common::row_idx_t rowInChunk) const;
+    bool isInserted(const transaction::Transaction* transaction,
+        common::row_idx_t rowInChunk) const;
     bool hasAnyUpdates(transaction::Transaction* transaction, common::column_id_t columnID,
         common::row_idx_t startRow, common::length_t numRows) const;
     common::row_idx_t getNumDeletions(const transaction::Transaction* transaction,

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -176,6 +176,9 @@ public:
         return common::ku_dynamic_cast<const NodeGroup&, const TARGETT&>(*this);
     }
 
+    bool isDeleted(const transaction::Transaction* transaction, common::offset_t offsetInGroup);
+    bool isInserted(const transaction::Transaction* transaction, common::offset_t offsetInGroup);
+
 private:
     ChunkedNodeGroup* findChunkedGroupFromRowIdx(const common::UniqLock& lock,
         common::row_idx_t rowIdx);

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -124,6 +124,17 @@ public:
         throw common::NotImplementedException("dropColumn is not implemented yet.");
     }
 
+    bool isVisible(const transaction::Transaction* transaction, common::offset_t offset) const;
+
+    bool lookupPK(transaction::Transaction* transaction, common::ValueVector* keyVector,
+        uint64_t vectorPos, common::offset_t& result) const;
+    template<common::IndexHashable T>
+    size_t appendPKWithIndexPos(const transaction::Transaction* transaction,
+        const IndexBuffer<T>& buffer, uint64_t indexPos) {
+        return pkIndex->appendWithIndexPos(transaction, buffer, indexPos,
+            [&](common::offset_t offset) { return isVisible(transaction, offset); });
+    }
+
     common::column_id_t getPKColumnID() const { return pkColumnID; }
     PrimaryKeyIndex* getPKIndex() const { return pkIndex.get(); }
     common::column_id_t getNumColumns() const { return columns.size(); }

--- a/src/include/storage/store/version_info.h
+++ b/src/include/storage/store/version_info.h
@@ -84,6 +84,8 @@ public:
         common::length_t numRows) const;
     bool hasInsertions() const;
     bool isDeleted(const transaction::Transaction* transaction, common::row_idx_t rowInChunk) const;
+    bool isInserted(const transaction::Transaction* transaction,
+        common::row_idx_t rowInChunk) const;
 
     common::row_idx_t getNumDeletions(const transaction::Transaction* transaction) const;
 

--- a/src/processor/map/map_index_scan_node.cpp
+++ b/src/processor/map/map_index_scan_node.cpp
@@ -17,12 +17,10 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapIndexLookup(LogicalOperator* lo
     std::vector<std::unique_ptr<IndexLookupInfo>> indexLookupInfos;
     for (auto i = 0u; i < logicalIndexScan.getNumInfos(); ++i) {
         auto& info = logicalIndexScan.getInfo(i);
-        auto storageIndex =
-            storageManager->getTable(info.nodeTableID)->ptrCast<storage::NodeTable>()->getPKIndex();
+        auto nodeTable = storageManager->getTable(info.nodeTableID)->ptrCast<storage::NodeTable>();
         auto offsetPos = DataPos(outSchema->getExpressionPos(*info.offset));
         auto keyPos = DataPos(outSchema->getExpressionPos(*info.key));
-        indexLookupInfos.push_back(
-            std::make_unique<IndexLookupInfo>(storageIndex, keyPos, offsetPos));
+        indexLookupInfos.push_back(std::make_unique<IndexLookupInfo>(nodeTable, keyPos, offsetPos));
     }
     binder::expression_vector expressions;
     for (auto i = 0u; i < logicalIndexScan.getNumInfos(); ++i) {

--- a/src/processor/operator/index_lookup.cpp
+++ b/src/processor/operator/index_lookup.cpp
@@ -7,6 +7,7 @@
 #include "common/types/types.h"
 #include "common/vector/value_vector.h"
 #include "storage/index/hash_index.h"
+#include "storage/store/node_table.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::common;
@@ -27,7 +28,7 @@ bool IndexLookup::getNextTuplesInternal(ExecutionContext* context) {
     }
     for (auto& info : infos) {
         KU_ASSERT(info);
-        lookup(&transaction::DUMMY_TRANSACTION, *info);
+        lookup(context->clientContext->getTx(), *info);
     }
     return true;
 }
@@ -73,8 +74,9 @@ void stringPKFillOffsetArraysFromVector(transaction::Transaction* transaction,
     const IndexLookupInfo& info, ValueVector* keyVector, offset_t* offsets) {
     auto numKeys = keyVector->state->getSelVector().getSelSize();
     for (auto i = 0u; i < numKeys; i++) {
-        auto key = keyVector->getValue<ku_string_t>(keyVector->state->getSelVector()[i]);
-        if (!info.index->lookup(transaction, key.getAsStringView(), offsets[i])) {
+        if (!info.nodeTable->lookupPK(transaction, keyVector, keyVector->state->getSelVector()[i],
+                offsets[i])) {
+            auto key = keyVector->getValue<ku_string_t>(keyVector->state->getSelVector()[i]);
             throw RuntimeException(ExceptionMessage::nonExistentPKException(key.getAsString()));
         }
     }
@@ -86,8 +88,8 @@ void primitivePKFillOffsetArraysFromVector(transaction::Transaction* transaction
     auto numKeys = keyVector->state->getSelVector().getSelSize();
     for (auto i = 0u; i < numKeys; i++) {
         auto pos = keyVector->state->getSelVector()[i];
-        auto key = keyVector->getValue<T>(pos);
-        if (!info.index->lookup(transaction, key, offsets[i])) {
+        if (!info.nodeTable->lookupPK(transaction, keyVector, pos, offsets[i])) {
+            auto key = keyVector->getValue<T>(pos);
             throw RuntimeException(
                 ExceptionMessage::nonExistentPKException(TypeUtils::toString(key)));
         }

--- a/src/processor/operator/persistent/node_batch_insert.cpp
+++ b/src/processor/operator/persistent/node_batch_insert.cpp
@@ -21,7 +21,7 @@ using namespace kuzu::storage;
 namespace kuzu {
 namespace processor {
 
-void NodeBatchInsertSharedState::initPKIndex(ExecutionContext*) {
+void NodeBatchInsertSharedState::initPKIndex(ExecutionContext* context) {
     uint64_t numRows;
     if (readerSharedState != nullptr) {
         KU_ASSERT(distinctSharedState == nullptr);
@@ -32,8 +32,10 @@ void NodeBatchInsertSharedState::initPKIndex(ExecutionContext*) {
         KU_ASSERT(distinctSharedState);
         numRows = distinctSharedState->getFactorizedTable()->getNumTuples();
     }
-    pkIndex->bulkReserve(numRows);
-    globalIndexBuilder = IndexBuilder(std::make_shared<IndexBuilderSharedState>(pkIndex));
+    auto* nodeTable = ku_dynamic_cast<Table*, NodeTable*>(table);
+    nodeTable->getPKIndex()->bulkReserve(numRows);
+    globalIndexBuilder = IndexBuilder(
+        std::make_shared<IndexBuilderSharedState>(context->clientContext->getTx(), nodeTable));
 }
 
 void NodeBatchInsert::initGlobalStateInternal(ExecutionContext* context) {

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -52,8 +52,7 @@ bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     }
 
     offset_t nodeOffset;
-    const bool lookupSucceed =
-        nodeInfo.table->getPKIndex()->lookup(transaction, indexVector, pos, nodeOffset);
+    const bool lookupSucceed = nodeInfo.table->lookupPK(transaction, indexVector, pos, nodeOffset);
     if (!lookupSucceed) {
         return false;
     }

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -484,26 +484,26 @@ PrimaryKeyIndex::PrimaryKeyIndex(const DBFileIDAndName& dbFileIDAndName, bool re
 }
 
 bool PrimaryKeyIndex::lookup(const Transaction* trx, common::ValueVector* keyVector,
-    uint64_t vectorPos, common::offset_t& result) {
+    uint64_t vectorPos, common::offset_t& result, visible_func isVisible) {
     bool retVal = false;
     TypeUtils::visit(
         keyDataTypeID,
         [&]<IndexHashable T>(T) {
             T key = keyVector->getValue<T>(vectorPos);
-            retVal = lookup(trx, key, result);
+            retVal = lookup(trx, key, result, isVisible);
         },
         [](auto) { KU_UNREACHABLE; });
     return retVal;
 }
 
 bool PrimaryKeyIndex::insert(const Transaction* transaction, common::ValueVector* keyVector,
-    uint64_t vectorPos, common::offset_t value) {
+    uint64_t vectorPos, common::offset_t value, visible_func isVisible) {
     bool result = false;
     TypeUtils::visit(
         keyDataTypeID,
         [&]<IndexHashable T>(T) {
             T key = keyVector->getValue<T>(vectorPos);
-            result = insert(transaction, key, value);
+            result = insert(transaction, key, value, isVisible);
         },
         [](auto) { KU_UNREACHABLE; });
     return result;

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -61,7 +61,7 @@ bool LocalRelTable::insert(transaction::Transaction*, TableInsertState& state) {
     return true;
 }
 
-bool LocalRelTable::update(TableUpdateState& state) {
+bool LocalRelTable::update(transaction::Transaction* transaction, TableUpdateState& state) {
     const auto& updateState = state.cast<RelTableUpdateState>();
     const auto srcNodePos = updateState.srcNodeIDVector.state->getSelVector()[0];
     const auto dstNodePos = updateState.dstNodeIDVector.state->getSelVector()[0];
@@ -78,7 +78,7 @@ bool LocalRelTable::update(TableUpdateState& state) {
         return false;
     }
     KU_ASSERT(updateState.columnID != NBR_ID_COLUMN_ID);
-    localNodeGroup->update(&transaction::DUMMY_TRANSACTION, matchedRow,
+    localNodeGroup->update(transaction, matchedRow,
         rewriteLocalColumnID(RelDataDirection::FWD /* This is a dummy direction */,
             updateState.columnID),
         updateState.propertyVector);

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -296,6 +296,13 @@ bool ChunkedNodeGroup::isDeleted(const Transaction* transaction, row_idx_t rowIn
     return versionInfo->isDeleted(transaction, rowInChunk);
 }
 
+bool ChunkedNodeGroup::isInserted(const Transaction* transaction, row_idx_t rowInChunk) const {
+    if (!versionInfo) {
+        return rowInChunk < getNumRows();
+    }
+    return versionInfo->isInserted(transaction, rowInChunk);
+}
+
 bool ChunkedNodeGroup::hasAnyUpdates(Transaction* transaction, column_id_t columnID,
     row_idx_t startRow, length_t numRows) const {
     return getColumnChunk(columnID).hasUpdates(transaction, startRow, numRows);

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -444,5 +444,18 @@ template std::unique_ptr<ChunkedNodeGroup> NodeGroup::scanCommitted<ResidencySta
     const UniqLock& lock, const std::vector<column_id_t>& columnIDs,
     const std::vector<Column*>& columns);
 
+bool NodeGroup::isDeleted(const transaction::Transaction* transaction,
+    common::offset_t offsetInGroup) {
+    auto lock = chunkedGroups.lock();
+    auto* chunkedGroup = findChunkedGroupFromRowIdx(lock, offsetInGroup);
+    return chunkedGroup->isDeleted(transaction, offsetInGroup - chunkedGroup->getStartRowIdx());
+}
+bool NodeGroup::isInserted(const transaction::Transaction* transaction,
+    common::offset_t offsetInGroup) {
+    auto lock = chunkedGroups.lock();
+    auto* chunkedGroup = findChunkedGroupFromRowIdx(lock, offsetInGroup);
+    return chunkedGroup->isInserted(transaction, offsetInGroup - chunkedGroup->getStartRowIdx());
+}
+
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -1,7 +1,9 @@
 #include "storage/store/rel_table.h"
 
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
+#include "common/cast.h"
 #include "storage/local_storage/local_rel_table.h"
+#include "storage/local_storage/local_table.h"
 #include "storage/storage_manager.h"
 #include "storage/store/rel_table_data.h"
 
@@ -128,7 +130,7 @@ void RelTable::update(Transaction* transaction, TableUpdateState& updateState) {
         const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID,
             LocalStorage::NotExistAction::RETURN_NULL);
         KU_ASSERT(loadTable);
-        localTable->update(updateState);
+        localTable->update(transaction, updateState);
     } else {
         fwdRelTableData->update(transaction, relUpdateState.srcNodeIDVector,
             relUpdateState.relIDVector, relUpdateState.columnID, relUpdateState.propertyVector);

--- a/src/storage/store/version_info.cpp
+++ b/src/storage/store/version_info.cpp
@@ -262,8 +262,21 @@ bool VersionInfo::isDeleted(const transaction::Transaction* transaction,
     row_idx_t rowInChunk) const {
     auto [vectorIdx, rowInVector] =
         StorageUtils::getQuotientRemainder(rowInChunk, DEFAULT_VECTOR_CAPACITY);
+    KU_ASSERT(vectorIdx < vectorsInfo.size());
     if (vectorsInfo[vectorIdx]) {
         return vectorsInfo[vectorIdx]->isDeleted(transaction->getStartTS(), transaction->getID(),
+            rowInVector);
+    }
+    return false;
+}
+
+bool VersionInfo::isInserted(const transaction::Transaction* transaction,
+    row_idx_t rowInChunk) const {
+    auto [vectorIdx, rowInVector] =
+        StorageUtils::getQuotientRemainder(rowInChunk, DEFAULT_VECTOR_CAPACITY);
+    KU_ASSERT(vectorIdx < vectorsInfo.size());
+    if (vectorsInfo[vectorIdx]) {
+        return vectorsInfo[vectorIdx]->isInserted(transaction->getStartTS(), transaction->getID(),
             rowInVector);
     }
     return false;

--- a/test/storage/local_hash_index_test.cpp
+++ b/test/storage/local_hash_index_test.cpp
@@ -5,6 +5,10 @@
 using namespace kuzu::common;
 using namespace kuzu::storage;
 
+bool isVisible(offset_t) {
+    return true;
+}
+
 TEST(LocalHashIndexTests, LocalInserts) {
     DBFileIDAndName dbFileIDAndName{DBFileID{}, "in-mem-overflow"};
     auto overflowFile = std::make_unique<InMemOverflowFile>(dbFileIDAndName);
@@ -14,17 +18,17 @@ TEST(LocalHashIndexTests, LocalInserts) {
         std::make_unique<LocalHashIndex>(PhysicalTypeID::INT64, overflowFileHandle.get());
 
     for (int64_t i = 0u; i < 100; i++) {
-        ASSERT_TRUE(hashIndex->insert(i, i * 2));
+        ASSERT_TRUE(hashIndex->insert(i, i * 2, isVisible));
     }
     for (int64_t i = 0u; i < 100; i++) {
-        ASSERT_FALSE(hashIndex->insert(i, i));
+        ASSERT_FALSE(hashIndex->insert(i, i, isVisible));
     }
 
     for (int64_t i = 0u; i < 100; i++) {
         hashIndex->delete_(i);
     }
     for (int64_t i = 0u; i < 100; i++) {
-        ASSERT_TRUE(hashIndex->insert(i, i));
+        ASSERT_TRUE(hashIndex->insert(i, i, isVisible));
     }
 }
 
@@ -53,9 +57,9 @@ TEST(LocalHashIndexTests, LocalStringInserts) {
     std::vector<std::string> keys;
     for (int64_t i = 0u; i < 100; i++) {
         keys.push_back(gen_random(14));
-        ASSERT_TRUE(hashIndex->insert(keys.back(), i * 2));
+        ASSERT_TRUE(hashIndex->insert(keys.back(), i * 2, isVisible));
     }
     for (int64_t i = 0u; i < 100; i++) {
-        ASSERT_FALSE(hashIndex->insert(keys[i], i * 2));
+        ASSERT_FALSE(hashIndex->insert(keys[i], i * 2, isVisible));
     }
 }

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -115,29 +115,29 @@ TEST_F(NodeInsertionDeletionTests, InsertManyNodesTest) {
     ASSERT_EQ(i, BufferPoolConstants::PAGE_4KB_SIZE);
 }
 
-// TEST_F(NodeInsertionDeletionTests, TruncatedWalTest) {
-//     auto preparedStatement = conn->prepare("CREATE (:person {ID:$id});");
-//     auto fs = LocalFileSystem();
-//     // Note: this test will fail if the transaction is small enough to fit the wal headers in a
-//     // single page, since we currently may fail to recover if the headers are intact but shadow
-//     // pages are missing. Pages are flushed before writing the commit record to make sure that
-//     // doesn't happen during a regular interruption.
-//     for (int64_t i = 0; i < 200; i++) {
-//         auto result =
-//             conn->execute(preparedStatement.get(), std::make_pair(std::string("id"), 10000 + i));
-//         ASSERT_TRUE(result->isSuccess()) << result->toString();
-//     }
-//     conn->query("COMMIT");
-//     auto databasePath = this->databasePath;
-//     auto walPath = fs.joinPath(databasePath, StorageConstants::WAL_FILE_SUFFIX);
-//     // Close database
-//     database.reset();
-//     {
-//         auto walFileInfo = fs.openFile(walPath, O_RDWR);
-//         ASSERT_GT(walFileInfo->getFileSize(), BufferPoolConstants::PAGE_4KB_SIZE)
-//             << "Test needs a wal file with more than one page";
-//         walFileInfo->truncate(BufferPoolConstants::PAGE_4KB_SIZE);
-//     }
-//     // Re-open database
-//     EXPECT_THROW(database = std::make_unique<Database>(databasePath), Exception);
-// }
+TEST_F(NodeInsertionDeletionTests, TruncatedWalTest) {
+    auto preparedStatement = conn->prepare("CREATE (:person {ID:$id});");
+    auto fs = LocalFileSystem();
+    // Note: this test will fail if the transaction is small enough to fit the wal headers in a
+    // single page, since we currently may fail to recover if the headers are intact but shadow
+    // pages are missing. Pages are flushed before writing the commit record to make sure that
+    // doesn't happen during a regular interruption.
+    for (int64_t i = 0; i < 200; i++) {
+        auto result =
+            conn->execute(preparedStatement.get(), std::make_pair(std::string("id"), 10000 + i));
+        ASSERT_TRUE(result->isSuccess()) << result->toString();
+    }
+    conn->query("COMMIT");
+    auto databasePath = this->databasePath;
+    auto walPath = fs.joinPath(databasePath, StorageConstants::WAL_FILE_SUFFIX);
+    // Close database
+    database.reset();
+    {
+        auto walFileInfo = fs.openFile(walPath, O_RDWR);
+        ASSERT_GT(walFileInfo->getFileSize(), BufferPoolConstants::PAGE_4KB_SIZE)
+            << "Test needs a wal file with more than one page";
+        walFileInfo->truncate(BufferPoolConstants::PAGE_4KB_SIZE);
+    }
+    // Re-open database
+    EXPECT_THROW(database = std::make_unique<Database>(databasePath), Exception);
+}

--- a/test/test_files/transaction/delete_create/int_delete_create_transaction.test
+++ b/test/test_files/transaction/delete_create/int_delete_create_transaction.test
@@ -1,9 +1,7 @@
 -DATASET CSV node-insertion-deletion-tests/int64-pk
 --
 
-#TODO(Guodong): FIX-ME. Delete and then insert the same key is not handled in hash index.
 -CASE MixedInsertDeleteCommitNormalExecution
--SKIP
 -PARALLELISM 1
 -CREATE_CONNECTION conn_read
 -CREATE_CONNECTION conn_write

--- a/test/test_files/update_node/delete_tinysnb.test
+++ b/test/test_files/update_node/delete_tinysnb.test
@@ -18,22 +18,21 @@
 0|3
 0|5
 
-# TODO(Guodong): Hash index conflict with unique constraint
-#-CASE MixedDeleteInsertTest
-#-STATEMENT CREATE (a:organisation {ID:30, mark:3.3})
-#---- ok
-#-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 RETURN a.orgCode, a.mark
-#---- 1
-#|3.300000
-#-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 DELETE a
-#---- ok
-#-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 RETURN a.orgCode, a.mark
-#---- 0
-#-STATEMENT CREATE (a:organisation {ID:30, orgCode:33})
-#---- ok
-#-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 RETURN a.orgCode, a.mark
-#---- 1
-#33|
+-CASE MixedDeleteInsertTest
+-STATEMENT CREATE (a:organisation {ID:30, mark:3.3})
+---- ok
+-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 RETURN a.orgCode, a.mark
+---- 1
+|3.300000
+-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 DELETE a
+---- ok
+-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 RETURN a.orgCode, a.mark
+---- 0
+-STATEMENT CREATE (a:organisation {ID:30, orgCode:33})
+---- ok
+-STATEMENT MATCH (a:organisation) WHERE a.ID = 30 RETURN a.orgCode, a.mark
+---- 1
+33|
 
 -CASE DeleteNodeMultiLabel1
 -STATEMENT MATCH (a:person)-[e]->(b:person) WHERE a.ID = 0 RETURN COUNT(*)


### PR DESCRIPTION
Access to the hash index has been mostly moved into the node table so that it can handle visibility checks.
I've fixed a few (presumably) gcc-14-related compilation issues introduced by the mvcc-base branch.
I've also removed the dummy transactions in a couple places related to the hash index so that copying and lookups work properly.

I haven't benchmarked the performance impact of these visibility checks on the hash index yet. It should mostly affect lookups, since every positive lookup needs a visibility check, but since negative lookups don't, it shouldn't affect copy performance (except where there are lots of duplicate values from other transactions, but not the initial copy, or even multiple copies without anything in-between).

I also found dealing with access to the lowest level of the NodeTable a little confusing because of how the offset has to change each time to be relative to the beginning of each part, but they all basically take the same integer-based offset types as arguments (NodeTable->NodeGroup->GroupCollection<ChunkedNodeGroup>->ChunkedNodeGroup (and in this case to VersionInfo, but it would be similarly complicated to access the chunks)). In particular, one issue was that NodeGroup gives public access to its data through `getChunkedNodeGroup`, but I wasn't able to find the correct group without using the private `findChunkedGroupFromRowIdx`. I'll have to look in more detail at how everything is accessed, but it seems like having more restricted APIs for accessing the data would make them easier to work with and harder to make mistakes. Maybe using simple struct wrappers for the offsets so that they can't be confused. E.g. `struct GlobalOffset { offset_t offset; };` `struct NodeGroupOffset { offset_t offsetInNodeGroup; };`