### PR TITLE
Add pyarrow `COPY FROM` testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bazel-*
 .bazelrc
 **/test/test_files/test_list
 mm-256KB
+history.txt
 
 test_temp/
 build/

--- a/tools/python_api/test/test_scan_polars.py
+++ b/tools/python_api/test/test_scan_polars.py
@@ -26,7 +26,7 @@ def test_polars_basic(conn_db_readwrite: ConnDB) -> None:
     # since polars just uses arrow as its backend, it's probably not necessary to extensively test this functionality
     conn.execute("CREATE NODE TABLE polarstab(col1 INT64, col2 STRING, col3 DOUBLE, col4 TIMESTAMP, PRIMARY KEY(col1))")
     conn.execute("COPY polarstab FROM df")
-    result = conn.execute("MATCH (t:polarstab) RETURN t.col1 AS col1, t.col2 AS col2, t.col3 AS col3, t.col4 AS col4").get_as_pl()
+    result = conn.execute("MATCH (t:polarstab) RETURN t.col1 AS col1, t.col2 AS col2, t.col3 AS col3, t.col4 AS col4 ORDER BY col1").get_as_pl()
     equivalency = result == df
     assert equivalency["col1"].all()
     assert equivalency["col2"].all()

--- a/tools/python_api/test/test_scan_polars.py
+++ b/tools/python_api/test/test_scan_polars.py
@@ -5,8 +5,8 @@ import pytest
 from type_aliases import ConnDB
 
 
-def test_polars_basic(conn_db_readonly: ConnDB) -> None:
-    conn, db = conn_db_readonly
+def test_polars_basic(conn_db_readwrite: ConnDB) -> None:
+    conn, db = conn_db_readwrite
     df = pl.DataFrame([
         pl.Series("col1", [1, 2], dtype=pl.Int64),
         pl.Series("col2", ["a", "b"], dtype=pl.String),
@@ -24,6 +24,18 @@ def test_polars_basic(conn_db_readonly: ConnDB) -> None:
     assert result["col3"].dtype == pl.Float64
     assert result["col4"].dtype == pl.Datetime
     # since polars just uses arrow as its backend, it's probably not necessary to extensively test this functionality
+    conn.execute("CREATE NODE TABLE polarstab(col1 INT64, col2 STRING, col3 DOUBLE, col4 TIMESTAMP, PRIMARY KEY(col1))")
+    conn.execute("COPY polarstab FROM df")
+    result = conn.execute("MATCH (t:polarstab) RETURN t.col1 AS col1, t.col2 AS col2, t.col3 AS col3, t.col4 AS col4").get_as_pl()
+    equivalency = result == df
+    assert equivalency["col1"].all()
+    assert equivalency["col2"].all()
+    assert equivalency["col3"].all()
+    assert equivalency["col4"].all()
+    assert result["col1"].dtype == pl.Int64
+    assert result["col2"].dtype == pl.String
+    assert result["col3"].dtype == pl.Float64
+    assert result["col4"].dtype == pl.Datetime
 
 
 def test_polars_error(conn_db_readonly: ConnDB) -> None:

--- a/tools/python_api/test/test_scan_pyarrow.py
+++ b/tools/python_api/test/test_scan_pyarrow.py
@@ -18,3 +18,53 @@ def test_pyarrow_basic(conn_db_readonly : ConnDB) -> None:
     assert (result.get_next() == [1, 'a', True])
     assert (result.get_next() == [2, 'b', False])
     assert (result.get_next() == [3, 'c', None])
+
+def test_pyarrow_copy_from(conn_db_readwrite : ConnDB) -> None:
+    conn, db = conn_db_readwrite
+    tab = pa.Table.from_arrays(
+        [
+            pa.array([1, 2, 3], type=pa.int32()),
+            pa.array(['a', 'b', 'c'], type=pa.string()),
+            pa.array([True, False, None], type=pa.bool_())
+        ],
+        names=["id", "A", "B"]
+    )
+    conn.execute("CREATE NODE TABLE pyarrowtab(id INT32, A STRING, B BOOL, PRIMARY KEY(id))")
+    conn.execute("COPY pyarrowtab FROM tab")
+    result = conn.execute("MATCH (t:pyarrowtab) RETURN t.id AS id, t.A AS A, t.B AS B")
+    assert (result.get_next() == [1, 'a', True])
+    assert (result.get_next() == [2, 'b', False])
+    assert (result.get_next() == [3, 'c', None])
+
+    rels = pa.Table.from_arrays(
+        [
+            pa.array([1, 2, 3], type=pa.int32()),
+            pa.array([2, 3, 1], type=pa.int32())
+        ],
+        names=["from", "to"]
+    )
+    conn.execute("CREATE REL TABLE pyarrowrel(FROM pyarrowtab TO pyarrowtab)")
+    conn.execute("COPY pyarrowrel FROM rels")
+    result = conn.execute("MATCH (a:pyarrowtab)-[:pyarrowrel]->(b:pyarrowtab) RETURN a.id, b.id")
+    assert result.get_next() == [1, 2]
+    assert result.get_next() == [2, 3]
+    assert result.get_next() == [3, 1]
+
+    conn.execute("DROP TABLE pyarrowrel")
+
+    rels = pa.Table.from_arrays(
+        [
+            pa.array([1, 2, 3], type=pa.int32()),
+            pa.array([2, 3, 1], type=pa.int32()),
+            pa.array(["honk", "shoo", "mimimimimimimi"], type=pa.string()),
+        ],
+        names=["foo", "bar", "spongebobmeboy"]
+    )
+
+    conn.execute("CREATE REL TABLE pyarrowrel(FROM pyarrowtab TO pyarrowtab, a_distraction STRING)")
+    conn.execute("COPY pyarrowrel FROM rels")
+    result = conn.execute("MATCH (a:pyarrowtab)-[r:pyarrowrel]->(b:pyarrowtab) RETURN a.id, r.a_distraction, b.id")
+    assert result.get_next() == [1, "honk", 2]
+    assert result.get_next() == [2, "shoo", 3]
+    assert result.get_next() == [3, "mimimimimimimi", 1]
+

--- a/tools/python_api/test/test_scan_pyarrow.py
+++ b/tools/python_api/test/test_scan_pyarrow.py
@@ -14,7 +14,7 @@ def test_pyarrow_basic(conn_db_readonly : ConnDB) -> None:
         ],
         names=["col1", "col2", "col3"]
     )
-    result = conn.execute("LOAD FROM tab RETURN *")
+    result = conn.execute("LOAD FROM tab RETURN * ORDER BY col1")
     assert (result.get_next() == [1, 'a', True])
     assert (result.get_next() == [2, 'b', False])
     assert (result.get_next() == [3, 'c', None])
@@ -31,7 +31,7 @@ def test_pyarrow_copy_from(conn_db_readwrite : ConnDB) -> None:
     )
     conn.execute("CREATE NODE TABLE pyarrowtab(id INT32, A STRING, B BOOL, PRIMARY KEY(id))")
     conn.execute("COPY pyarrowtab FROM tab")
-    result = conn.execute("MATCH (t:pyarrowtab) RETURN t.id AS id, t.A AS A, t.B AS B")
+    result = conn.execute("MATCH (t:pyarrowtab) RETURN t.id AS id, t.A AS A, t.B AS B ORDER BY t.id")
     assert (result.get_next() == [1, 'a', True])
     assert (result.get_next() == [2, 'b', False])
     assert (result.get_next() == [3, 'c', None])
@@ -45,7 +45,7 @@ def test_pyarrow_copy_from(conn_db_readwrite : ConnDB) -> None:
     )
     conn.execute("CREATE REL TABLE pyarrowrel(FROM pyarrowtab TO pyarrowtab)")
     conn.execute("COPY pyarrowrel FROM rels")
-    result = conn.execute("MATCH (a:pyarrowtab)-[:pyarrowrel]->(b:pyarrowtab) RETURN a.id, b.id")
+    result = conn.execute("MATCH (a:pyarrowtab)-[:pyarrowrel]->(b:pyarrowtab) RETURN a.id, b.id ORDER BY a.id")
     assert result.get_next() == [1, 2]
     assert result.get_next() == [2, 3]
     assert result.get_next() == [3, 1]
@@ -63,7 +63,7 @@ def test_pyarrow_copy_from(conn_db_readwrite : ConnDB) -> None:
 
     conn.execute("CREATE REL TABLE pyarrowrel(FROM pyarrowtab TO pyarrowtab, a_distraction STRING)")
     conn.execute("COPY pyarrowrel FROM rels")
-    result = conn.execute("MATCH (a:pyarrowtab)-[r:pyarrowrel]->(b:pyarrowtab) RETURN a.id, r.a_distraction, b.id")
+    result = conn.execute("MATCH (a:pyarrowtab)-[r:pyarrowrel]->(b:pyarrowtab) RETURN a.id, r.a_distraction, b.id ORDER BY a.id")
     assert result.get_next() == [1, "honk", 2]
     assert result.get_next() == [2, "shoo", 3]
     assert result.get_next() == [3, "mimimimimimimi", 1]


### PR DESCRIPTION
# Description

Adds very basic testing. By my understanding of the COPY FROM function, there is basically zero change in the core scanning functionality. These tests are just to make sure COPY FROM works; advanced scanning is already covered.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).