### PR TITLE
CLI case-insensitive and snake_case shell flags

### DIFF
--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
     args::Flag version(parser, "version", "Display current database version", {'v', "version"});
 
     std::vector<std::string> lCaseArgsStrings;
-    for (auto i = 0u; i < argc; ++i) {
+    for (auto i = 0; i < argc; ++i) {
         std::string arg = argv[i];
         if (arg.size() > 1 && arg[0] == '-') {
             std::string lArg = arg;

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -14,18 +14,35 @@ int main(int argc, char* argv[]) {
     args::Positional<std::string> inputDirFlag(parser, "databasePath", "Database path.");
     args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
     args::ValueFlag<uint64_t> bpSizeInMBFlag(parser, "",
-        "Size of buffer pool for default and large page sizes in megabytes", {'d', "defaultBPSize"},
+        "Size of buffer pool for default and large page sizes in megabytes",
+        {'d', "default_bp_size", "defaultbpsize"},
         -1u);
-    args::Flag disableCompression(parser, "nocompression", "Disable compression",
-        {"nocompression"});
-    args::Flag readOnlyMode(parser, "readOnly", "Open database at read-only mode.",
-        {'r', "readOnly"});
-    args::ValueFlag<std::string> historyPathFlag(parser, "", "Path to directory for shell history",
-        {'p'});
+    args::Flag disableCompression(parser, "no_compression", "Disable compression",
+        {"no_compression", "nocompression"});
+    args::Flag readOnlyMode(parser, "read_only", "Open database at read-only mode.",
+        {'r', "read_only", "readonly"});
+    args::ValueFlag<std::string> historyPathFlag(parser, "", "Path to directory for shell history", {'p', "path_history"});
     args::Flag version(parser, "version", "Display current database version", {'v', "version"});
 
+    std::vector<std::string> lCaseArgsStrings;
+    for (auto i = 0u; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg.size() > 1 && arg[0] == '-') {
+            std::string lArg = arg;
+            std::transform(lArg.begin(), lArg.end(), lArg.begin(),
+                [](unsigned char c) { return std::tolower(c); });
+            lCaseArgsStrings.push_back(lArg);
+        } else {
+            lCaseArgsStrings.push_back(argv[i]);
+        }
+    }
+    std::vector<char*> lCaseArgs;
+    for (auto& arg : lCaseArgsStrings) {
+		lCaseArgs.push_back(const_cast<char*>(arg.c_str()));
+	}
+
     try {
-        parser.ParseCLI(argc, argv);
+        parser.ParseCLI(lCaseArgs.size(), lCaseArgs.data());
     } catch (const args::Help&) {
         std::cout << parser;
         return 0;

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -48,7 +48,8 @@ def test_help(temp_db, flag) -> None:
     "flag",
     [
         "-d",
-        "--defaultBPSize",
+        "--defaultbpsize",
+        "--default_bp_size"
     ],
 )
 def test_default_bp_size(temp_db, flag) -> None:
@@ -72,12 +73,18 @@ def test_default_bp_size(temp_db, flag) -> None:
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
 
-
-def test_no_compression(temp_db) -> None:
+@pytest.mark.parametrize(
+    "flag",
+    [
+        "--nocompression",
+        "--no_compression"
+    ],
+)
+def test_no_compression(temp_db, flag) -> None:
     # fails without db path
-    check_fails_without_db("--nocompression")
+    check_fails_without_db(flag)
     
-    test = ShellTest().add_argument(temp_db).add_argument("--nocompression")
+    test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
 
@@ -86,7 +93,8 @@ def test_no_compression(temp_db) -> None:
     "flag",
     [
         "-r",
-        "--readOnly",
+        "--readonly",
+        "--read_only"
     ],
 )
 def test_read_only(temp_db, flag) -> None:


### PR DESCRIPTION
# Description
Gives better options for shell flags that aren't case sensitive 

Fixes #3884 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).