### PR TITLE
Add support for passing literals to array functions

### DIFF
--- a/src/function/array/array_functions.cpp
+++ b/src/function/array/array_functions.cpp
@@ -15,7 +15,8 @@ namespace function {
 static LogicalType interpretLogicalType(binder::Expression* expr) {
     if (expr->expressionType == ExpressionType::LITERAL &&
         expr->dataType.getLogicalTypeID() == LogicalTypeID::LIST) {
-        auto numChildren = expr->constPtrCast<binder::LiteralExpression>()->getValue().getChildrenSize();
+        auto numChildren =
+            expr->constPtrCast<binder::LiteralExpression>()->getValue().getChildrenSize();
         return LogicalType::ARRAY(ListType::getChildType(expr->dataType).copy(), numChildren);
     }
     return expr->dataType.copy();

--- a/src/include/common/types/value/value.h
+++ b/src/include/common/types/value/value.h
@@ -244,6 +244,8 @@ public:
 
     uint64_t computeHash() const;
 
+    KUZU_API uint32_t getChildrenSize() const { return childrenSize; }
+
 private:
     Value();
     explicit Value(const LogicalType& dataType);

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -146,7 +146,7 @@ static bool isConstantExpression(const std::shared_ptr<Expression> expression) {
     case ExpressionType::PARAMETER: {
         return true;
     }
-    //TODO(Xiyang): fold parameter expression in binder.
+    // TODO(Xiyang): fold parameter expression in binder.
     case ExpressionType::FUNCTION: {
         auto& func = expression->constCast<FunctionExpression>();
         if (func.getFunctionName() == "CAST") {

--- a/test/test_files/function/cast.test
+++ b/test/test_files/function/cast.test
@@ -58,11 +58,13 @@ banana|1.000000|697.900000
 ---- error
 Binder exception: ARRAY_COSINE_SIMILARITY requires argument type to be FLOAT[] or DOUBLE[].
 -STATEMENT RETURN array_cosine_similarity([1.0, 2.0], [3.0, 4.0]);
----- error
-Binder exception: ARRAY_COSINE_SIMILARITY requires at least one argument to be ARRAY but all parameters are LIST.
+---- 1
+0.983870
+
 -STATEMENT RETURN array_cosine_similarity(cast([1.0, 2.0], 'DOUBLE[2]'), [3.0, 4.0]);
 ---- 1
 0.983870
+
 -STATEMENT RETURN array_cosine_similarity(cast([1.0, 2.0] as DOUBLE[2]), [3.0, 4.0]);
 ---- 1
 0.983870

--- a/test/test_files/tinysnb/function/array.test
+++ b/test/test_files/tinysnb/function/array.test
@@ -29,6 +29,10 @@
 ---- 1
 [-3,6,-3]
 
+-STATEMENT RETURN ARRAY_CROSS_PRODUCT([1, 2, 3], [4, 5, 6])
+---- 1
+[-3,6,-3]
+
 -LOG ArrayCrossProductINT64
 -STATEMENT RETURN ARRAY_CROSS_PRODUCT(ARRAY_VALUE(to_int64(148), to_int64(176), to_int64(112)), ARRAY_VALUE(to_int64(182), to_int64(187), to_int64(190)))
 ---- 1

--- a/test/test_files/tinysnb/function/array.test
+++ b/test/test_files/tinysnb/function/array.test
@@ -84,6 +84,10 @@ Binder exception: ARRAY_CROSS_PRODUCT requires both arrays to have the same elem
 0.950000
 0.970000
 
+-STATEMENT RETURN ARRAY_COSINE_SIMILARITY([1, 2, 3.0], [4, 5, 6.0])
+---- 1
+0.974632
+
 -LOG ArrayCosineSimilarityWrongType
 -STATEMENT MATCH (p:person) return ARRAY_COSINE_SIMILARITY(p.grades, p.grades)
 ---- error
@@ -100,6 +104,10 @@ Binder exception: ARRAY_COSINE_SIMILARITY requires argument type to be FLOAT[] o
 5.750000
 6.410000
 
+-STATEMENT RETURN ARRAY_DISTANCE([-1, -2, -3.0], [2, -6.0, -3])
+---- 1
+5.000000
+
 -LOG ArrayInnerProduct
 -STATEMENT MATCH (p:person)-[e:meets]->(p1:person) return round(ARRAY_INNER_PRODUCT(e.location, array_value(to_float(3.4), to_float(2.7))),2)
 ---- 7
@@ -110,6 +118,10 @@ Binder exception: ARRAY_COSINE_SIMILARITY requires argument type to be FLOAT[] o
 31.780000
 35.200000
 36.150000
+
+-STATEMENT RETURN ARRAY_INNER_PRODUCT([0, 1, 2.3], [5.12, 7.2, 8.8])
+---- 1
+27.440000
 
 -LOG ArrayDotProduct
 -STATEMENT MATCH (p:person)-[e:meets]->(p1:person) return round(ARRAY_DOT_PRODUCT(e.location, array_value(to_float(5.6), to_float(2.1))),2)


### PR DESCRIPTION
# Description

`array_cross_product([1.0, 2.0, 3.0], [1.0, 2.0, 3.0])` and the likes should work now.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).