### PR TITLE
Fix string function bugs

### DIFF
--- a/src/include/common/types/ku_string.h
+++ b/src/include/common/types/ku_string.h
@@ -70,6 +70,8 @@ struct KUZU_API ku_string_t {
         }
     }
 
+    bool isOutOfBounds(int64_t val) { return val < 0 || val >= len; }
+
     std::string getAsShortString() const;
     std::string getAsString() const;
     std::string_view getAsStringView() const;

--- a/src/include/common/types/ku_string.h
+++ b/src/include/common/types/ku_string.h
@@ -70,8 +70,6 @@ struct KUZU_API ku_string_t {
         }
     }
 
-    bool isOutOfBounds(int64_t idx) const { return idx < 0 || idx >= len; }
-
     std::string getAsShortString() const;
     std::string getAsString() const;
     std::string_view getAsStringView() const;

--- a/src/include/common/types/ku_string.h
+++ b/src/include/common/types/ku_string.h
@@ -70,7 +70,7 @@ struct KUZU_API ku_string_t {
         }
     }
 
-    bool isOutOfBounds(int64_t val) { return val < 0 || val >= len; }
+    bool isOutOfBounds(int64_t idx) const { return idx < 0 || idx >= len; }
 
     std::string getAsShortString() const;
     std::string getAsString() const;

--- a/src/include/function/string/functions/ends_with_function.h
+++ b/src/include/function/string/functions/ends_with_function.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "common/types/ku_string.h"
-#include "function/string/functions/find_function.h"
 
 namespace kuzu {
 namespace function {

--- a/src/include/function/string/functions/ends_with_function.h
+++ b/src/include/function/string/functions/ends_with_function.h
@@ -9,9 +9,20 @@ namespace function {
 struct EndsWith {
     static inline void operation(common::ku_string_t& left, common::ku_string_t& right,
         uint8_t& result) {
-        int64_t pos = 0;
-        Find::operation(left, right, pos);
-        result = (pos == left.len - right.len + 1);
+        if (right.len > left.len) {
+            result = 0;
+            return;
+        }
+        auto lenDiff = left.len - right.len;
+        auto lData = left.getData();
+        auto rData = right.getData();
+        for (auto i = 0u; i < right.len; i++) {
+            if (rData[i] != lData[lenDiff + i]) {
+                result = 0;
+                return;
+            }
+        }
+        result = 1;
     }
 };
 

--- a/src/include/function/string/functions/substr_function.h
+++ b/src/include/function/string/functions/substr_function.h
@@ -11,13 +11,14 @@ namespace function {
 
 struct SubStr {
 public:
+
     static inline void operation(common::ku_string_t& src, int64_t start, int64_t len,
         common::ku_string_t& result, common::ValueVector& resultValueVector) {
         std::string srcStr = src.getAsString();
         bool isAscii = true;
         int64_t startPos = start - 1;
         int64_t endPos = std::min(srcStr.size(), (size_t)(startPos + len));
-        if (startPos >= endPos) {
+        if (startPos >= endPos || src.isOutOfBounds(startPos) || src.isOutOfBounds(endPos - 1)) {
             result.len = 0;
             return;
         }

--- a/src/include/function/string/functions/substr_function.h
+++ b/src/include/function/string/functions/substr_function.h
@@ -17,7 +17,7 @@ public:
         bool isAscii = true;
         int64_t startPos = start - 1;
         int64_t endPos = std::min(srcStr.size(), (size_t)(startPos + len));
-        if (startPos >= endPos || startPos < 0 || startPos >= srcStr.size()) {
+        if (startPos >= endPos || startPos < 0 || startPos >= (int64_t)srcStr.size()) {
             result.len = 0;
             return;
         }

--- a/src/include/function/string/functions/substr_function.h
+++ b/src/include/function/string/functions/substr_function.h
@@ -11,7 +11,6 @@ namespace function {
 
 struct SubStr {
 public:
-
     static inline void operation(common::ku_string_t& src, int64_t start, int64_t len,
         common::ku_string_t& result, common::ValueVector& resultValueVector) {
         std::string srcStr = src.getAsString();

--- a/src/include/function/string/functions/substr_function.h
+++ b/src/include/function/string/functions/substr_function.h
@@ -17,7 +17,7 @@ public:
         bool isAscii = true;
         int64_t startPos = start - 1;
         int64_t endPos = std::min(srcStr.size(), (size_t)(startPos + len));
-        if (startPos >= endPos || src.isOutOfBounds(startPos) || src.isOutOfBounds(endPos - 1)) {
+        if (startPos >= endPos || startPos < 0 || startPos >= srcStr.size()) {
             result.len = 0;
             return;
         }

--- a/test/test_files/function/string_utf8.test
+++ b/test/test_files/function/string_utf8.test
@@ -27,6 +27,9 @@ True
 -STATEMENT return ends_with(string("The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movies"),string("成績評価の甘い授業が高く評価"));
 ---- 1
 False
+-STATEMENT return ends_with("bbbb", "b");
+---- 1
+True
 
 -LOG StrLower
 -STATEMENT MATCH (m:movies) RETURN lower(m.name)
@@ -126,6 +129,15 @@ True
 -STATEMENT RETURN substr('成績評価の甘い授業が高く評価', 1,3)
 ---- 1
 成績評
+
+-STATEMENT UNWIND [-99999, 0, 1, 4, 5, 10000000] AS startpoints RETURN substr("abcd", startpoints, 1)
+---- 6
+
+
+a
+d
+
+
 
 -LOG strsuffix
 -STATEMENT RETURN suffix('成績評価の甘い授業が高く評価', '高く評価')

--- a/test/test_files/function/string_utf8.test
+++ b/test/test_files/function/string_utf8.test
@@ -30,6 +30,9 @@ False
 -STATEMENT return ends_with("bbbb", "b");
 ---- 1
 True
+-STATEMENT return ends_with(string("The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 "),string("🚗 "));
+---- 1
+True
 
 -LOG StrLower
 -STATEMENT MATCH (m:movies) RETURN lower(m.name)


### PR DESCRIPTION
# Description

Fixes #3892,
Fixes #3890,
Fixes #3909

Note:
the following definition for `ku_string_t` seems unsafe.
```cpp
    uint32_t len;
    uint8_t prefix[PREFIX_LENGTH];
    union {
        uint8_t data[INLINED_SUFFIX_LENGTH];
        uint64_t overflowPtr;
    };
```

If `len < PREFIX_LENGTH + INLINED_SUFFIX_LENGTH`, then we write data to `prefix`, which is only size `PREFIX_LENGTH`. This seems to have been made under the assumption that the union data will be packed right after prefix, which works for the compilers we use, but isn't guaranteed to work in the general case.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).