### PR TITLE
Updated shell help docs url to a clickable link

### DIFF
--- a/tools/shell/embedded_shell.cpp
+++ b/tools/shell/embedded_shell.cpp
@@ -438,7 +438,8 @@ void EmbeddedShell::printHelp() {
         TAB);
     printf("%s%s  timeout, and progress_bar using Cypher CALL statements.\n", TAB, TAB);
     printf("%s%s  e.g. CALL THREADS=5; or CALL current_setting('threads') return *;\n", TAB, TAB);
-    printf("%s%s  See: https://docs.kuzudb.com/cypher/configuration\n", TAB, TAB);
+    const char* url = "https://docs.kuzudb.com/cypher/configuration";
+    printf("%s%s  See: \x1B]8;;%s\x1B\\%s\x1B]8;;\x1B\\\n", TAB, TAB, url, url);
 }
 
 void EmbeddedShell::printExecutionResult(QueryResult& queryResult) const {

--- a/tools/shell/test/test_shell_commands.py
+++ b/tools/shell/test/test_shell_commands.py
@@ -15,7 +15,7 @@ def test_help(temp_db) -> None:
             "    Note: you can change and see several system configurations, such as num-threads, ",
             "          timeout, and progress_bar using Cypher CALL statements.",
             "          e.g. CALL THREADS=5; or CALL current_setting('threads') return *;",
-            "          See: https://docs.kuzudb.com/cypher/configuration",
+            "          See: \x1B]8;;https://docs.kuzudb.com/cypher/configuration\x1B\\https://docs.kuzudb.com/cypher/configuration\x1B]8;;\x1B\\",
         ],
     )
 


### PR DESCRIPTION
# Description

Used escape codes to make the shell help url clickable 
![image](https://github.com/user-attachments/assets/09e6f940-71c8-4c63-97d0-68da039ee118)


# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).