### PR TITLE
Fix bugs in node group checkpoint

### DIFF
--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -201,10 +201,10 @@ void ChunkedNodeGroup::scan(const Transaction* transaction, const TableScanState
 }
 
 template<ResidencyState SCAN_RESIDENCY_STATE>
-void ChunkedNodeGroup::scanCommitted(Transaction* transaction, TableScanState&,
+void ChunkedNodeGroup::scanCommitted(Transaction* transaction, TableScanState& scanState,
     NodeGroupScanState& nodeGroupScanState, ChunkedNodeGroup& output) const {
-    for (auto i = 0u; i < chunks.size(); i++) {
-        chunks[i]->scanCommitted<SCAN_RESIDENCY_STATE>(transaction,
+    for (auto i = 0u; i < scanState.columnIDs.size(); i++) {
+        chunks[scanState.columnIDs[i]]->scanCommitted<SCAN_RESIDENCY_STATE>(transaction,
             nodeGroupScanState.chunkStates[i], output.getColumnChunk(i));
     }
 }

--- a/src/storage/store/column_chunk.cpp
+++ b/src/storage/store/column_chunk.cpp
@@ -117,7 +117,8 @@ void ColumnChunk::scanCommittedUpdates(Transaction* transaction, ColumnChunkData
     if (!updateInfo) {
         return;
     }
-    const auto numVectors = getNumValues() / DEFAULT_VECTOR_CAPACITY;
+    const auto numVectors =
+        (getNumValues() + DEFAULT_VECTOR_CAPACITY - 1) / DEFAULT_VECTOR_CAPACITY;
     for (auto vectorIdx = 0u; vectorIdx < numVectors; vectorIdx++) {
         if (const auto vectorInfo = updateInfo->getVectorInfo(transaction, vectorIdx)) {
             for (auto i = 0u; i < vectorInfo->numRowsUpdated; i++) {

--- a/src/storage/undo_buffer.cpp
+++ b/src/storage/undo_buffer.cpp
@@ -136,9 +136,9 @@ void UndoBuffer::createVectorVersionInfo(const UndoRecordType recordType, Versio
 
 void UndoBuffer::createVectorUpdateInfo(UpdateInfo* updateInfo, const idx_t vectorIdx,
     VectorUpdateInfo* vectorUpdateInfo) {
-    auto buffer = createUndoRecord(sizeof(UndoRecordHeader) + sizeof(VectorUpdateInfo));
-    const UndoRecordHeader recorHeader{UndoRecordType::UPDATE_INFO, sizeof(VectorUpdateInfo)};
-    *reinterpret_cast<UndoRecordHeader*>(buffer) = recorHeader;
+    auto buffer = createUndoRecord(sizeof(UndoRecordHeader) + sizeof(VectorUpdateRecord));
+    const UndoRecordHeader recordHeader{UndoRecordType::UPDATE_INFO, sizeof(VectorUpdateRecord)};
+    *reinterpret_cast<UndoRecordHeader*>(buffer) = recordHeader;
     buffer += sizeof(UndoRecordHeader);
     const VectorUpdateRecord vectorUpdateRecord{updateInfo, vectorIdx, vectorUpdateInfo};
     *reinterpret_cast<VectorUpdateRecord*>(buffer) = vectorUpdateRecord;

--- a/test/test_files/update_node/set_tinysnb.test
+++ b/test/test_files/update_node/set_tinysnb.test
@@ -21,6 +21,17 @@
 ---- 1
 70
 
+-CASE SetNodeInt64MultipleTestManualCheckpoint
+-STATEMENT MATCH (a:person) WHERE a.ID >= 3 AND a.ID <= 7 SET a.age=20 + a.ID
+---- ok
+-STATEMENT CALL CHECKPOINT() RETURN *
+---- ok
+-STATEMENT MATCH (a:person) WHERE a.ID >= 3 AND a.ID <= 7 RETURN a.age
+---- 3
+23
+25
+27
+
 -CASE SetNodeInt32PropTest
 -STATEMENT MATCH (a:movies) WHERE a.name='Roma' SET a.length=2.2
 ---- ok


### PR DESCRIPTION
# Description
Fix updating columns in `NodeGroup::checkpoint` mainly stemming from `scanCommitted` running on all columns in a node group while `NodeGroup::checkpoint` tries to run it on only one column.

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).