### PR TITLE
Rework ChunkedNodeGroupCollection

### DIFF
--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -48,7 +48,7 @@ struct PartitionerSharedState {
     // In copy rdf, we need to access num nodes before it is available in statistics.
     std::vector<std::shared_ptr<BatchInsertSharedState>> nodeBatchInsertSharedStates;
 
-    void initialize(PartitionerDataInfo& dataInfo);
+    void initialize(const PartitionerDataInfo& dataInfo);
 
     common::partition_idx_t getNextPartition(common::idx_t partitioningIdx);
     void resetState();
@@ -133,12 +133,11 @@ public:
 
     std::unique_ptr<PhysicalOperator> clone() override;
 
-    static void initializePartitioningStates(PartitionerDataInfo& dataInfo,
+    static void initializePartitioningStates(const PartitionerDataInfo& dataInfo,
         std::vector<std::unique_ptr<PartitioningBuffer>>& partitioningBuffers,
         const std::vector<common::partition_idx_t>& numPartitions);
 
 private:
-    void evaluateData(const common::sel_t& numTuples) const;
     common::DataChunk constructDataChunk(
         const std::shared_ptr<common::DataChunkState>& state) const;
     // TODO: For now, RelBatchInsert will guarantee all data are inside one data chunk. Should be

--- a/src/include/processor/operator/partitioner.h
+++ b/src/include/processor/operator/partitioner.h
@@ -3,7 +3,7 @@
 #include "common/enums/column_evaluate_type.h"
 #include "expression_evaluator/expression_evaluator.h"
 #include "processor/operator/sink.h"
-#include "storage/store/chunked_node_group_collection.h"
+#include "storage/store/in_mem_chunked_node_group_collection.h"
 
 namespace kuzu {
 namespace storage {
@@ -24,7 +24,7 @@ struct PartitionerFunctions {
 // partitioning methods. For example, copy of rel tables require partitioning on both FWD and BWD
 // direction. Each partitioning method corresponds to a PartitioningState.
 struct PartitioningBuffer {
-    std::vector<std::unique_ptr<storage::ChunkedNodeGroupCollection>> partitions;
+    std::vector<std::unique_ptr<storage::InMemChunkedNodeGroupCollection>> partitions;
 
     void merge(std::unique_ptr<PartitioningBuffer> localPartitioningStates) const;
 };
@@ -54,7 +54,7 @@ struct PartitionerSharedState {
     void resetState();
     void merge(std::vector<std::unique_ptr<PartitioningBuffer>> localPartitioningStates);
 
-    storage::ChunkedNodeGroupCollection& getPartitionBuffer(common::idx_t partitioningIdx,
+    storage::InMemChunkedNodeGroupCollection& getPartitionBuffer(common::idx_t partitioningIdx,
         common::partition_idx_t partitionIdx) const {
         KU_ASSERT(partitioningIdx < partitioningBuffers.size());
         KU_ASSERT(partitionIdx < partitioningBuffers[partitioningIdx]->partitions.size());

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -68,12 +68,12 @@ private:
         RelBatchInsertLocalState& localState, BatchInsertSharedState& sharedState,
         const PartitionerSharedState& partitionerSharedState);
 
-    static void populateCSROffsets(storage::ChunkedNodeGroupCollection& partition,
+    static void populateCSROffsets(storage::InMemChunkedNodeGroupCollection& partition,
         common::offset_t startNodeOffset, const RelBatchInsertInfo& relInfo,
         const RelBatchInsertLocalState& localState, common::offset_t numNodes, bool leaveGaps);
 
     static void populateCSRLengths(storage::ChunkedCSRHeader& csrHeader, common::offset_t numNodes,
-        storage::ChunkedNodeGroupCollection& partition, common::column_id_t boundNodeOffsetColumn);
+        storage::InMemChunkedNodeGroupCollection& partition, common::column_id_t boundNodeOffsetColumn);
 
     static void setOffsetToWithinNodeGroup(storage::ColumnChunkData& chunk,
         common::offset_t startOffset);

--- a/src/include/processor/operator/persistent/rel_batch_insert.h
+++ b/src/include/processor/operator/persistent/rel_batch_insert.h
@@ -73,7 +73,8 @@ private:
         const RelBatchInsertLocalState& localState, common::offset_t numNodes, bool leaveGaps);
 
     static void populateCSRLengths(storage::ChunkedCSRHeader& csrHeader, common::offset_t numNodes,
-        storage::InMemChunkedNodeGroupCollection& partition, common::column_id_t boundNodeOffsetColumn);
+        storage::InMemChunkedNodeGroupCollection& partition,
+        common::column_id_t boundNodeOffsetColumn);
 
     static void setOffsetToWithinNodeGroup(storage::ColumnChunkData& chunk,
         common::offset_t startOffset);

--- a/src/include/storage/store/in_mem_chunked_node_group_collection.h
+++ b/src/include/storage/store/in_mem_chunked_node_group_collection.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "storage/store/chunked_node_group.h"
-#include "storage/store/group_collection.h"
 
 namespace kuzu {
 namespace transaction {

--- a/src/include/storage/store/in_mem_chunked_node_group_collection.h
+++ b/src/include/storage/store/in_mem_chunked_node_group_collection.h
@@ -10,9 +10,9 @@ class Transaction;
 
 namespace storage {
 
-class ChunkedNodeGroupCollection {
+class InMemChunkedNodeGroupCollection {
 public:
-    explicit ChunkedNodeGroupCollection(std::vector<common::LogicalType> types)
+    explicit InMemChunkedNodeGroupCollection(std::vector<common::LogicalType> types)
         : types{std::move(types)} {}
 
     static std::pair<uint64_t, common::offset_t> getChunkIdxAndOffsetInChunk(
@@ -36,7 +36,7 @@ public:
 
     // `merge` are directly moving the chunkedGroup to the collection.
     void merge(std::unique_ptr<ChunkedNodeGroup> chunkedGroup);
-    void merge(ChunkedNodeGroupCollection& other);
+    void merge(InMemChunkedNodeGroupCollection& other);
 
     uint64_t getNumChunkedGroups() const { return chunkedGroups.size(); }
     void clear() { chunkedGroups.clear(); }

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include "common/uniq_lock.h"
 #include "storage/enums/residency_state.h"
-#include "storage/store/chunked_node_group_collection.h"
-#include "storage/store/version_info.h"
+#include "storage/store/chunked_node_group.h"
+#include "storage/store/group_collection.h"
 
 namespace kuzu {
 namespace transaction {

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -28,7 +28,7 @@ static partition_idx_t getNumPartitions(offset_t maxOffset) {
     return (maxOffset + StorageConstants::NODE_GROUP_SIZE) / StorageConstants::NODE_GROUP_SIZE;
 }
 
-void PartitionerSharedState::initialize(PartitionerDataInfo& dataInfo) {
+void PartitionerSharedState::initialize(const PartitionerDataInfo& dataInfo) {
     maxNodeOffsets.resize(2);
     maxNodeOffsets[0] = srcNodeTable->getNumRows();
     maxNodeOffsets[1] = dstNodeTable->getNumRows();
@@ -66,7 +66,7 @@ void PartitioningBuffer::merge(std::unique_ptr<PartitioningBuffer> localPartitio
     for (auto partitionIdx = 0u; partitionIdx < partitions.size(); partitionIdx++) {
         auto& sharedPartition = partitions[partitionIdx];
         auto& localPartition = localPartitioningState->partitions[partitionIdx];
-        sharedPartition->merge(std::move(localPartition));
+        sharedPartition->merge(*localPartition);
     }
 }
 
@@ -93,13 +93,6 @@ void Partitioner::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*
     }
 }
 
-void Partitioner::evaluateData(const sel_t& numTuples) const {
-    for (auto& evaluator : dataInfo.columnEvaluators) {
-        evaluator->getLocalStateUnsafe().count = numTuples;
-        evaluator->evaluate();
-    }
-}
-
 DataChunk Partitioner::constructDataChunk(const std::shared_ptr<DataChunkState>& state) const {
     const auto numColumns = dataInfo.columnEvaluators.size();
     DataChunk dataChunk(numColumns, state);
@@ -110,7 +103,7 @@ DataChunk Partitioner::constructDataChunk(const std::shared_ptr<DataChunkState>&
     return dataChunk;
 }
 
-void Partitioner::initializePartitioningStates(PartitionerDataInfo& dataInfo,
+void Partitioner::initializePartitioningStates(const PartitionerDataInfo& dataInfo,
     std::vector<std::unique_ptr<PartitioningBuffer>>& partitioningBuffers,
     const std::vector<partition_idx_t>& numPartitions) {
     partitioningBuffers.resize(numPartitions.size());
@@ -120,7 +113,7 @@ void Partitioner::initializePartitioningStates(PartitionerDataInfo& dataInfo,
         partitioningBuffer->partitions.reserve(numPartition);
         for (auto i = 0u; i < numPartition; i++) {
             partitioningBuffer->partitions.push_back(std::make_unique<ChunkedNodeGroupCollection>(
-                ResidencyState::IN_MEMORY, LogicalType::copy(dataInfo.columnTypes)));
+                LogicalType::copy(dataInfo.columnTypes)));
         }
         partitioningBuffers[partitioningIdx] = std::move(partitioningBuffer);
     }

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -112,8 +112,9 @@ void Partitioner::initializePartitioningStates(const PartitionerDataInfo& dataIn
         auto partitioningBuffer = std::make_unique<PartitioningBuffer>();
         partitioningBuffer->partitions.reserve(numPartition);
         for (auto i = 0u; i < numPartition; i++) {
-            partitioningBuffer->partitions.push_back(std::make_unique<InMemChunkedNodeGroupCollection>(
-                LogicalType::copy(dataInfo.columnTypes)));
+            partitioningBuffer->partitions.push_back(
+                std::make_unique<InMemChunkedNodeGroupCollection>(
+                    LogicalType::copy(dataInfo.columnTypes)));
         }
         partitioningBuffers[partitioningIdx] = std::move(partitioningBuffer);
     }

--- a/src/processor/operator/partitioner.cpp
+++ b/src/processor/operator/partitioner.cpp
@@ -112,7 +112,7 @@ void Partitioner::initializePartitioningStates(const PartitionerDataInfo& dataIn
         auto partitioningBuffer = std::make_unique<PartitioningBuffer>();
         partitioningBuffer->partitions.reserve(numPartition);
         for (auto i = 0u; i < numPartition; i++) {
-            partitioningBuffer->partitions.push_back(std::make_unique<ChunkedNodeGroupCollection>(
+            partitioningBuffer->partitions.push_back(std::make_unique<InMemChunkedNodeGroupCollection>(
                 LogicalType::copy(dataInfo.columnTypes)));
         }
         partitioningBuffers[partitioningIdx] = std::move(partitioningBuffer);

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -93,7 +93,7 @@ void RelBatchInsert::appendNodeGroup(transaction::Transaction* transaction, CSRN
     localState.chunkedGroup->resetToEmpty();
 }
 
-void RelBatchInsert::populateCSROffsets(ChunkedNodeGroupCollection& partition,
+void RelBatchInsert::populateCSROffsets(InMemChunkedNodeGroupCollection& partition,
     offset_t startNodeOffset, const RelBatchInsertInfo& relInfo,
     const RelBatchInsertLocalState& localState, offset_t numNodes, bool leaveGaps) {
     auto& csrNodeGroup = localState.chunkedGroup->cast<ChunkedCSRNodeGroup>();
@@ -122,7 +122,7 @@ void RelBatchInsert::populateCSROffsets(ChunkedNodeGroupCollection& partition,
 }
 
 void RelBatchInsert::populateCSRLengths(ChunkedCSRHeader& csrHeader, offset_t numNodes,
-    ChunkedNodeGroupCollection& partition, column_id_t boundNodeOffsetColumn) {
+    InMemChunkedNodeGroupCollection& partition, column_id_t boundNodeOffsetColumn) {
     KU_ASSERT(numNodes == csrHeader.length->getNumValues() &&
               numNodes == csrHeader.offset->getNumValues());
     const auto lengthData = reinterpret_cast<length_t*>(csrHeader.length->getData().getData());

--- a/src/storage/store/CMakeLists.txt
+++ b/src/storage/store/CMakeLists.txt
@@ -1,7 +1,6 @@
 add_library(kuzu_storage_store
         OBJECT
         chunked_node_group.cpp
-        chunked_node_group_collection.cpp
         column.cpp
         column_chunk.cpp
         column_chunk_data.cpp
@@ -9,6 +8,7 @@ add_library(kuzu_storage_store
         csr_node_group.cpp
         dictionary_chunk.cpp
         dictionary_column.cpp
+        in_mem_chunked_node_group_collection.cpp
         list_chunk_data.cpp
         list_column.cpp
         node_group.cpp

--- a/src/storage/store/chunked_node_group_collection.cpp
+++ b/src/storage/store/chunked_node_group_collection.cpp
@@ -6,72 +6,27 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-ChunkedNodeGroup& ChunkedNodeGroupCollection::findChunkedGroupFromOffset(const offset_t offset) {
-    const auto lock = chunkedGroups.lock();
-    KU_ASSERT(offset < getNumRows(lock));
-    for (auto& chunkedGroup : chunkedGroups.getAllGroups(lock)) {
-        if (chunkedGroup->getStartRowIdx() <= offset &&
-            chunkedGroup->getStartRowIdx() + chunkedGroup->getNumRows() >= offset) {
-            return *chunkedGroup;
-        }
-    }
-    KU_UNREACHABLE;
-}
-
-row_idx_t ChunkedNodeGroupCollection::append(Transaction* transaction,
+void ChunkedNodeGroupCollection::append(Transaction* transaction,
     const std::vector<ValueVector*>& vectors, row_idx_t startRowInVectors,
     row_idx_t numRowsToAppend) {
-    const auto lock = chunkedGroups.lock();
-    const auto numRowsBeforeAppend = getNumRows(lock);
-    if (chunkedGroups.isEmpty(lock)) {
-        chunkedGroups.appendGroup(lock,
+    if (chunkedGroups.empty()) {
+        chunkedGroups.push_back(
             std::make_unique<ChunkedNodeGroup>(types, false /*enableCompression*/,
-                ChunkedNodeGroup::CHUNK_CAPACITY, 0 /*startOffset*/, residencyState));
+                ChunkedNodeGroup::CHUNK_CAPACITY, 0 /*startOffset*/, ResidencyState::IN_MEMORY));
     }
     row_idx_t numRowsAppended = 0;
     while (numRowsAppended < numRowsToAppend) {
-        if (chunkedGroups.getLastGroup(lock)->isFullOrOnDisk()) {
-            chunkedGroups.appendGroup(lock,
-                std::make_unique<ChunkedNodeGroup>(types, false /*enableCompression*/,
-                    ChunkedNodeGroup::CHUNK_CAPACITY, numRowsBeforeAppend + numRowsAppended,
-                    residencyState));
-        }
-        const auto& lastChunkedGroup = chunkedGroups.getLastGroup(lock);
-        const auto numRowsToAppendInGroup = std::min(numRowsToAppend - numRowsAppended,
+        auto& lastChunkedGroup = chunkedGroups.back();
+        auto numRowsToAppendInGroup = std::min(numRowsToAppend - numRowsAppended,
             ChunkedNodeGroup::CHUNK_CAPACITY - lastChunkedGroup->getNumRows());
-        lastChunkedGroup->append(transaction, vectors, startRowInVectors + numRowsAppended,
-            numRowsToAppendInGroup);
+        lastChunkedGroup->append(transaction, vectors, startRowInVectors, numRowsToAppendInGroup);
+        if (lastChunkedGroup->getNumRows() == ChunkedNodeGroup::CHUNK_CAPACITY) {
+            chunkedGroups.push_back(std::make_unique<ChunkedNodeGroup>(types,
+                false /*enableCompression*/, ChunkedNodeGroup::CHUNK_CAPACITY, 0 /* startRowIdx */,
+                ResidencyState::IN_MEMORY));
+        }
         numRowsAppended += numRowsToAppendInGroup;
     }
-    return numRowsBeforeAppend;
-}
-
-row_idx_t ChunkedNodeGroupCollection::append(Transaction* transaction,
-    const ChunkedNodeGroup& chunkedGroup, row_idx_t numRowsToAppend) {
-    const auto lock = chunkedGroups.lock();
-    const auto numRowsBeforeAppend = getNumRows(lock);
-    if (chunkedGroups.isEmpty(lock)) {
-        chunkedGroups.appendGroup(lock,
-            std::make_unique<ChunkedNodeGroup>(types, false /*enableCompression*/,
-                ChunkedNodeGroup::CHUNK_CAPACITY, 0 /*startOffset*/, residencyState));
-    }
-    row_idx_t numRowsAppended = 0u;
-    while (numRowsAppended < numRowsToAppend) {
-        if (chunkedGroups.getLastGroup(lock)->isFullOrOnDisk()) {
-            chunkedGroups.appendGroup(lock,
-                std::make_unique<ChunkedNodeGroup>(types, false /*enableCompression*/,
-                    ChunkedNodeGroup::CHUNK_CAPACITY, numRowsBeforeAppend + numRowsAppended,
-                    residencyState));
-        }
-        const auto& chunkedGroupToCopyInto = chunkedGroups.getLastGroup(lock);
-        KU_ASSERT(ChunkedNodeGroup::CHUNK_CAPACITY >= chunkedGroupToCopyInto->getNumRows());
-        auto numToCopyIntoChunk =
-            ChunkedNodeGroup::CHUNK_CAPACITY - chunkedGroupToCopyInto->getNumRows();
-        const auto numToAppendInChunk = std::min(chunkedGroup.getNumRows(), numToCopyIntoChunk);
-        chunkedGroupToCopyInto->append(transaction, chunkedGroup, 0, numToAppendInChunk);
-        numRowsAppended += numToAppendInChunk;
-    }
-    return numRowsBeforeAppend;
 }
 
 void ChunkedNodeGroupCollection::merge(std::unique_ptr<ChunkedNodeGroup> chunkedGroup) {
@@ -79,27 +34,14 @@ void ChunkedNodeGroupCollection::merge(std::unique_ptr<ChunkedNodeGroup> chunked
     for (auto i = 0u; i < chunkedGroup->getNumColumns(); i++) {
         KU_ASSERT(chunkedGroup->getColumnChunk(i).getDataType() == types[i]);
     }
-    const auto lock = chunkedGroups.lock();
-    chunkedGroups.appendGroup(lock, std::move(chunkedGroup));
+    chunkedGroups.push_back(std::move(chunkedGroup));
 }
 
-void ChunkedNodeGroupCollection::merge(std::unique_ptr<ChunkedNodeGroupCollection> other) {
-    const auto lock = other->chunkedGroups.lock();
-    auto otherNumGroups = other->chunkedGroups.getNumGroups(lock);
-    for (auto i = 0u; i < otherNumGroups; i++) {
-        merge(other->chunkedGroups.moveGroup(lock, i));
+void ChunkedNodeGroupCollection::merge(ChunkedNodeGroupCollection& other) {
+    chunkedGroups.reserve(chunkedGroups.size() + other.chunkedGroups.size());
+    for (auto& chunkedGroup : other.chunkedGroups) {
+        merge(std::move(chunkedGroup));
     }
-    other->chunkedGroups.clear(lock);
-}
-
-row_idx_t ChunkedNodeGroupCollection::getNumRows(const UniqLock& lock) {
-    KU_ASSERT(lock.isLocked());
-    KU_UNUSED(lock);
-    row_idx_t numRows = 0;
-    for (auto& chunkedGroup : chunkedGroups.getAllGroups(lock)) {
-        numRows += chunkedGroup->getNumRows();
-    }
-    return numRows;
 }
 
 } // namespace storage

--- a/src/storage/store/in_mem_chunked_node_group_collection.cpp
+++ b/src/storage/store/in_mem_chunked_node_group_collection.cpp
@@ -1,4 +1,4 @@
-#include "storage/store/chunked_node_group_collection.h"
+#include "storage/store/in_mem_chunked_node_group_collection.h"
 
 using namespace kuzu::common;
 using namespace kuzu::transaction;
@@ -6,7 +6,7 @@ using namespace kuzu::transaction;
 namespace kuzu {
 namespace storage {
 
-void ChunkedNodeGroupCollection::append(Transaction* transaction,
+void InMemChunkedNodeGroupCollection::append(Transaction* transaction,
     const std::vector<ValueVector*>& vectors, row_idx_t startRowInVectors,
     row_idx_t numRowsToAppend) {
     if (chunkedGroups.empty()) {
@@ -29,7 +29,7 @@ void ChunkedNodeGroupCollection::append(Transaction* transaction,
     }
 }
 
-void ChunkedNodeGroupCollection::merge(std::unique_ptr<ChunkedNodeGroup> chunkedGroup) {
+void InMemChunkedNodeGroupCollection::merge(std::unique_ptr<ChunkedNodeGroup> chunkedGroup) {
     KU_ASSERT(chunkedGroup->getNumColumns() == types.size());
     for (auto i = 0u; i < chunkedGroup->getNumColumns(); i++) {
         KU_ASSERT(chunkedGroup->getColumnChunk(i).getDataType() == types[i]);
@@ -37,7 +37,7 @@ void ChunkedNodeGroupCollection::merge(std::unique_ptr<ChunkedNodeGroup> chunked
     chunkedGroups.push_back(std::move(chunkedGroup));
 }
 
-void ChunkedNodeGroupCollection::merge(ChunkedNodeGroupCollection& other) {
+void InMemChunkedNodeGroupCollection::merge(InMemChunkedNodeGroupCollection& other) {
     chunkedGroups.reserve(chunkedGroups.size() + other.chunkedGroups.size());
     for (auto& chunkedGroup : other.chunkedGroups) {
         merge(std::move(chunkedGroup));

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -5,7 +5,6 @@
 #include "common/exception/message.h"
 #include "common/exception/runtime.h"
 #include "common/types/internal_id_t.h"
-#include "common/types/ku_string.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
 #include "storage/local_storage/local_node_table.h"


### PR DESCRIPTION
# Description

This class is actually only used for in-memory buffering in Partitioner. Revert the change of versioning and transaction stuff from it.