### PR TITLE
Removed getExpressionsForPrinting() from physicalOperators

### DIFF
--- a/src/include/planner/operator/ddl/logical_ddl.h
+++ b/src/include/planner/operator/ddl/logical_ddl.h
@@ -21,8 +21,6 @@ public:
         return outputExpression;
     }
 
-    inline std::string getExpressionsForPrinting() const override { return tableName; }
-
 protected:
     std::string tableName;
     std::shared_ptr<binder::Expression> outputExpression;

--- a/src/include/planner/operator/extend/base_logical_extend.h
+++ b/src/include/planner/operator/extend/base_logical_extend.h
@@ -28,8 +28,6 @@ public:
 
     virtual f_group_pos_set getGroupsPosToFlatten() = 0;
 
-    std::string getExpressionsForPrinting() const override;
-
 protected:
     // Start node of extension.
     std::shared_ptr<binder::NodeExpression> boundNode;

--- a/src/include/planner/operator/extend/logical_recursive_extend.h
+++ b/src/include/planner/operator/extend/logical_recursive_extend.h
@@ -51,8 +51,6 @@ public:
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;
 
-    std::string getExpressionsForPrinting() const override { return recursiveRel->toString(); }
-
     std::shared_ptr<binder::RelExpression> getRel() const { return recursiveRel; }
 
     void setJoinType(RecursiveJoinType joinType_) { joinType = joinType_; }

--- a/src/include/planner/operator/logical_accumulate.h
+++ b/src/include/planner/operator/logical_accumulate.h
@@ -20,8 +20,6 @@ public:
 
     f_group_pos_set getGroupPositionsToFlatten() const;
 
-    std::string getExpressionsForPrinting() const override { return {}; }
-
     common::AccumulateType getAccumulateType() const { return accumulateType; }
     binder::expression_vector getPayloads() const {
         return children[0]->getSchema()->getExpressionsInScope();

--- a/src/include/planner/operator/logical_aggregate.h
+++ b/src/include/planner/operator/logical_aggregate.h
@@ -22,8 +22,6 @@ public:
     f_group_pos_set getGroupsPosToFlattenForGroupBy();
     f_group_pos_set getGroupsPosToFlattenForAggregate();
 
-    std::string getExpressionsForPrinting() const override;
-
     bool hasKeys() const { return !keys.empty(); }
     binder::expression_vector getKeys() const { return keys; }
     void setKeys(binder::expression_vector expressions) { keys = std::move(expressions); }

--- a/src/include/planner/operator/logical_create_macro.h
+++ b/src/include/planner/operator/logical_create_macro.h
@@ -25,8 +25,6 @@ public:
 
     inline std::unique_ptr<function::ScalarMacroFunction> getMacro() const { return macro->copy(); }
 
-    inline std::string getExpressionsForPrinting() const override { return macroName; }
-
     inline std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalCreateMacro>(outputExpression, macroName, macro->copy());
     }

--- a/src/include/planner/operator/logical_cross_product.h
+++ b/src/include/planner/operator/logical_cross_product.h
@@ -18,8 +18,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override { return std::string(); }
-
     inline common::AccumulateType getAccumulateType() const { return accumulateType; }
 
     inline std::unique_ptr<LogicalOperator> copy() override {

--- a/src/include/planner/operator/logical_distinct.h
+++ b/src/include/planner/operator/logical_distinct.h
@@ -20,8 +20,6 @@ public:
 
     virtual f_group_pos_set getGroupsPosToFlatten();
 
-    std::string getExpressionsForPrinting() const override;
-
     binder::expression_vector getKeys() const { return keys; }
     void setKeys(binder::expression_vector expressions) { keys = std::move(expressions); }
     binder::expression_vector getPayloads() const { return payloads; }

--- a/src/include/planner/operator/logical_empty_result.h
+++ b/src/include/planner/operator/logical_empty_result.h
@@ -21,8 +21,6 @@ public:
         }
     }
 
-    std::string getExpressionsForPrinting() const override { return std::string{}; }
-
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalEmptyResult>(*originalSchema);
     }

--- a/src/include/planner/operator/logical_explain.h
+++ b/src/include/planner/operator/logical_explain.h
@@ -25,8 +25,6 @@ public:
         return outputExpression;
     }
 
-    inline std::string getExpressionsForPrinting() const override { return "Explain"; }
-
     inline common::ExplainType getExplainType() const { return explainType; }
 
     inline binder::expression_vector getOutputExpressionsToExplain() const {

--- a/src/include/planner/operator/logical_filter.h
+++ b/src/include/planner/operator/logical_filter.h
@@ -18,8 +18,6 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    inline std::string getExpressionsForPrinting() const override { return expression->toString(); }
-
     inline std::shared_ptr<binder::Expression> getPredicate() const { return expression; }
 
     f_group_pos getGroupPosToSelect() const;

--- a/src/include/planner/operator/logical_flatten.h
+++ b/src/include/planner/operator/logical_flatten.h
@@ -13,8 +13,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override { return std::string{}; }
-
     inline f_group_pos getGroupPos() const { return groupPos; }
 
     inline std::unique_ptr<LogicalOperator> copy() override {

--- a/src/include/planner/operator/logical_gds_call.h
+++ b/src/include/planner/operator/logical_gds_call.h
@@ -18,8 +18,6 @@ public:
 
     const binder::BoundGDSCallInfo& getInfo() const { return info; }
 
-    std::string getExpressionsForPrinting() const override { return info.func->name; }
-
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalGDSCall>(info.copy());
     }

--- a/src/include/planner/operator/logical_hash_join.h
+++ b/src/include/planner/operator/logical_hash_join.h
@@ -27,8 +27,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const override;
-
     binder::expression_vector getExpressionsToMaterialize() const;
 
     binder::expression_vector getJoinNodeIDs() const;

--- a/src/include/planner/operator/logical_intersect.h
+++ b/src/include/planner/operator/logical_intersect.h
@@ -26,8 +26,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const override { return intersectNodeID->toString(); }
-
     std::shared_ptr<binder::Expression> getIntersectNodeID() const { return intersectNodeID; }
     uint32_t getNumBuilds() const { return keyNodeIDs.size(); }
     binder::expression_vector getKeyNodeIDs() const { return keyNodeIDs; }

--- a/src/include/planner/operator/logical_limit.h
+++ b/src/include/planner/operator/logical_limit.h
@@ -16,8 +16,6 @@ public:
     inline void computeFactorizedSchema() final { copyChildSchema(0); }
     inline void computeFlatSchema() final { copyChildSchema(0); }
 
-    std::string getExpressionsForPrinting() const final;
-
     inline bool hasSkipNum() const { return skipNum != UINT64_MAX; }
     inline uint64_t getSkipNum() const { return skipNum; }
     inline bool hasLimitNum() const { return limitNum != UINT64_MAX; }

--- a/src/include/planner/operator/logical_mark_accmulate.h
+++ b/src/include/planner/operator/logical_mark_accmulate.h
@@ -17,7 +17,6 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten() const;
 
-    std::string getExpressionsForPrinting() const override { return {}; }
     binder::expression_vector getKeys() const { return keys; }
     binder::expression_vector getPayloads() const;
     std::shared_ptr<binder::Expression> getMark() const { return mark; }

--- a/src/include/planner/operator/logical_operator.h
+++ b/src/include/planner/operator/logical_operator.h
@@ -95,8 +95,6 @@ public:
     virtual void computeFactorizedSchema() = 0;
     virtual void computeFlatSchema() = 0;
 
-    // Printing.
-    virtual std::string getExpressionsForPrinting() const = 0;
     // Print the sub-plan rooted at this operator.
     virtual std::string toString(uint64_t depth = 0) const;
 

--- a/src/include/planner/operator/logical_order_by.h
+++ b/src/include/planner/operator/logical_order_by.h
@@ -18,8 +18,6 @@ public:
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;
 
-    std::string getExpressionsForPrinting() const final;
-
     inline binder::expression_vector getExpressionsToOrderBy() const {
         return expressionsToOrderBy;
     }

--- a/src/include/planner/operator/logical_partitioner.h
+++ b/src/include/planner/operator/logical_partitioner.h
@@ -57,8 +57,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const override;
-
     LogicalPartitionerInfo& getInfo() { return info; }
     const LogicalPartitionerInfo& getInfo() const { return info; }
 

--- a/src/include/planner/operator/logical_projection.h
+++ b/src/include/planner/operator/logical_projection.h
@@ -17,10 +17,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    inline std::string getExpressionsForPrinting() const override {
-        return binder::ExpressionUtil::toString(expressions);
-    }
-
     inline binder::expression_vector getExpressionsToProject() const { return expressions; }
 
     std::unordered_set<uint32_t> getDiscardedGroupsPos() const;

--- a/src/include/planner/operator/logical_standalone_call.h
+++ b/src/include/planner/operator/logical_standalone_call.h
@@ -15,8 +15,6 @@ public:
     inline main::Option* getOption() const { return option; }
     inline std::shared_ptr<binder::Expression> getOptionValue() const { return optionValue; }
 
-    inline std::string getExpressionsForPrinting() const override { return option->name; }
-
     inline void computeFlatSchema() override { createEmptySchema(); }
 
     inline void computeFactorizedSchema() override { createEmptySchema(); }

--- a/src/include/planner/operator/logical_table_function_call.h
+++ b/src/include/planner/operator/logical_table_function_call.h
@@ -27,8 +27,6 @@ public:
 
     std::shared_ptr<binder::Expression> getOffset() const { return offset; }
 
-    std::string getExpressionsForPrinting() const override { return tableFunc.name; }
-
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalTableFunctionCall>(tableFunc, bindData->copy(), columns,
             offset);

--- a/src/include/planner/operator/logical_transaction.h
+++ b/src/include/planner/operator/logical_transaction.h
@@ -11,8 +11,6 @@ public:
     explicit LogicalTransaction(transaction::TransactionAction transactionAction)
         : LogicalOperator{LogicalOperatorType::TRANSACTION}, transactionAction{transactionAction} {}
 
-    inline std::string getExpressionsForPrinting() const final { return std::string(); }
-
     inline void computeFlatSchema() final { createEmptySchema(); }
     inline void computeFactorizedSchema() final { createEmptySchema(); }
 

--- a/src/include/planner/operator/logical_union.h
+++ b/src/include/planner/operator/logical_union.h
@@ -17,8 +17,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const override { return std::string{}; }
-
     binder::expression_vector getExpressionsToUnion() const { return expressionsToUnion; }
 
     Schema* getSchemaBeforeUnion(uint32_t idx) const { return children[idx]->getSchema(); }

--- a/src/include/planner/operator/logical_unwind.h
+++ b/src/include/planner/operator/logical_unwind.h
@@ -23,8 +23,6 @@ public:
     bool hasIDExpr() const { return idExpr != nullptr; }
     std::shared_ptr<binder::Expression> getIDExpr() const { return idExpr; }
 
-    std::string getExpressionsForPrinting() const override { return inExpr->toString(); }
-
     std::unique_ptr<LogicalOperator> copy() override {
         return make_unique<LogicalUnwind>(inExpr, outExpr, idExpr, children[0]->copy());
     }

--- a/src/include/planner/operator/persistent/logical_copy_from.h
+++ b/src/include/planner/operator/persistent/logical_copy_from.h
@@ -20,8 +20,6 @@ public:
         : LogicalOperator{type_, std::move(children)}, info{std::move(info)},
           outExprs{std::move(outExprs)} {}
 
-    std::string getExpressionsForPrinting() const override { return info.tableEntry->getName(); }
-
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 

--- a/src/include/planner/operator/persistent/logical_copy_to.h
+++ b/src/include/planner/operator/persistent/logical_copy_to.h
@@ -15,8 +15,6 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten();
 
-    std::string getExpressionsForPrinting() const override { return std::string{}; }
-
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 

--- a/src/include/planner/operator/persistent/logical_delete.h
+++ b/src/include/planner/operator/persistent/logical_delete.h
@@ -23,8 +23,6 @@ public:
     void computeFactorizedSchema() override { copyChildSchema(0); }
     void computeFlatSchema() override { copyChildSchema(0); }
 
-    std::string getExpressionsForPrinting() const override;
-
     f_group_pos_set getGroupsPosToFlatten() const;
 
     std::unique_ptr<LogicalOperator> copy() override {

--- a/src/include/planner/operator/persistent/logical_insert.h
+++ b/src/include/planner/operator/persistent/logical_insert.h
@@ -39,8 +39,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const final;
-
     f_group_pos_set getGroupsPosToFlatten();
 
     const std::vector<LogicalInsertInfo>& getInfos() const { return infos; }

--- a/src/include/planner/operator/persistent/logical_merge.h
+++ b/src/include/planner/operator/persistent/logical_merge.h
@@ -19,8 +19,6 @@ public:
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;
 
-    std::string getExpressionsForPrinting() const final { return {}; }
-
     f_group_pos_set getGroupsPosToFlatten();
 
     std::shared_ptr<binder::Expression> getExistenceMark() const { return existenceMark; }

--- a/src/include/planner/operator/persistent/logical_set.h
+++ b/src/include/planner/operator/persistent/logical_set.h
@@ -19,8 +19,6 @@ public:
 
     f_group_pos_set getGroupsPosToFlatten(uint32_t idx) const;
 
-    std::string getExpressionsForPrinting() const override;
-
     common::TableType getTableType() const;
     const std::vector<binder::BoundSetPropertyInfo>& getInfos() const { return infos; }
     const binder::BoundSetPropertyInfo& getInfo(uint32_t idx) const { return infos[idx]; }

--- a/src/include/planner/operator/scan/logical_dummy_scan.h
+++ b/src/include/planner/operator/scan/logical_dummy_scan.h
@@ -12,8 +12,6 @@ public:
     void computeFactorizedSchema() final;
     void computeFlatSchema() final;
 
-    inline std::string getExpressionsForPrinting() const override { return std::string(); }
-
     static std::shared_ptr<binder::Expression> getDummyExpression();
 
     inline std::unique_ptr<LogicalOperator> copy() final {

--- a/src/include/planner/operator/scan/logical_expressions_scan.h
+++ b/src/include/planner/operator/scan/logical_expressions_scan.h
@@ -16,10 +16,6 @@ public:
     inline void computeFactorizedSchema() final { computeSchema(); }
     inline void computeFlatSchema() final { computeSchema(); }
 
-    inline std::string getExpressionsForPrinting() const final {
-        return binder::ExpressionUtil::toString(expressions);
-    }
-
     inline binder::expression_vector getExpressions() const { return expressions; }
     inline void setOuterAccumulate(LogicalOperator* op) { outerAccumulate = op; }
     inline LogicalOperator* getOuterAccumulate() const { return outerAccumulate; }

--- a/src/include/planner/operator/scan/logical_index_look_up.h
+++ b/src/include/planner/operator/scan/logical_index_look_up.h
@@ -20,8 +20,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const override;
-
     uint32_t getNumInfos() const { return infos.size(); }
     const binder::IndexLookupInfo& getInfo(uint32_t idx) const { return infos[idx]; }
 

--- a/src/include/planner/operator/scan/logical_scan_node_table.h
+++ b/src/include/planner/operator/scan/logical_scan_node_table.h
@@ -61,10 +61,6 @@ public:
     void computeFactorizedSchema() override;
     void computeFlatSchema() override;
 
-    std::string getExpressionsForPrinting() const override {
-        return nodeID->toString() + " " + binder::ExpressionUtil::toString(properties);
-    }
-
     LogicalScanNodeTableType getScanType() const { return scanType; }
     void setScanType(LogicalScanNodeTableType scanType_) { scanType = scanType_; }
 

--- a/src/include/planner/operator/simple/logical_attach_database.h
+++ b/src/include/planner/operator/simple/logical_attach_database.h
@@ -15,8 +15,6 @@ public:
 
     binder::AttachInfo getAttachInfo() const { return attachInfo; }
 
-    std::string getExpressionsForPrinting() const override { return attachInfo.dbPath; }
-
     std::unique_ptr<LogicalOperator> copy() override {
         return std::make_unique<LogicalAttachDatabase>(attachInfo, outputExpression);
     }

--- a/src/include/planner/operator/simple/logical_database.h
+++ b/src/include/planner/operator/simple/logical_database.h
@@ -13,8 +13,6 @@ public:
 
     std::string getDBName() const { return dbName; }
 
-    std::string getExpressionsForPrinting() const override { return dbName; }
-
 protected:
     std::string dbName;
 };

--- a/src/include/planner/operator/simple/logical_extension.h
+++ b/src/include/planner/operator/simple/logical_extension.h
@@ -15,8 +15,6 @@ public:
         : LogicalSimple{LogicalOperatorType::EXTENSION, std::move(outputExpression)},
           action{action}, path{std::move(path)} {}
 
-    std::string getExpressionsForPrinting() const override { return path; }
-
     ExtensionAction getAction() const { return action; }
     std::string getPath() const { return path; }
 

--- a/src/include/planner/operator/sip/logical_semi_masker.h
+++ b/src/include/planner/operator/sip/logical_semi_masker.h
@@ -34,8 +34,6 @@ public:
     void computeFactorizedSchema() override { copyChildSchema(0); }
     void computeFlatSchema() override { copyChildSchema(0); }
 
-    std::string getExpressionsForPrinting() const override { return key->toString(); }
-
     SemiMaskConstructionType getType() const { return type; }
     std::shared_ptr<binder::Expression> getKey() const { return key; }
     std::vector<common::table_id_t> getNodeTableIDs() const { return nodeTableIDs; }

--- a/src/planner/operator/logical_aggregate.cpp
+++ b/src/planner/operator/logical_aggregate.cpp
@@ -33,22 +33,6 @@ f_group_pos_set LogicalAggregate::getGroupsPosToFlattenForAggregate() {
     return f_group_pos_set{};
 }
 
-std::string LogicalAggregate::getExpressionsForPrinting() const {
-    std::string result = "Group By [";
-    for (auto& expression : keys) {
-        result += expression->toString() + ", ";
-    }
-    for (auto& expression : dependentKeys) {
-        result += expression->toString() + ", ";
-    }
-    result += "], Aggregate [";
-    for (auto& expression : aggregates) {
-        result += expression->toString() + ", ";
-    }
-    result += "]";
-    return result;
-}
-
 bool LogicalAggregate::hasDistinctAggregate() {
     for (auto& expression : aggregates) {
         auto funcExpr = expression->constPtrCast<binder::AggregateFunctionExpression>();

--- a/src/planner/operator/logical_distinct.cpp
+++ b/src/planner/operator/logical_distinct.cpp
@@ -27,10 +27,6 @@ f_group_pos_set LogicalDistinct::getGroupsPosToFlatten() {
     return FlattenAll::getGroupsPosToFlatten(getKeysAndPayloads(), *childSchema);
 }
 
-std::string LogicalDistinct::getExpressionsForPrinting() const {
-    return binder::ExpressionUtil::toString(getKeysAndPayloads());
-}
-
 binder::expression_vector LogicalDistinct::getKeysAndPayloads() const {
     binder::expression_vector result;
     result.insert(result.end(), keys.begin(), keys.end());

--- a/src/planner/operator/logical_hash_join.cpp
+++ b/src/planner/operator/logical_hash_join.cpp
@@ -112,13 +112,6 @@ void LogicalHashJoin::computeFlatSchema() {
     }
 }
 
-std::string LogicalHashJoin::getExpressionsForPrinting() const {
-    if (isNodeIDOnlyJoin()) {
-        return binder::ExpressionUtil::toStringOrdered(getJoinNodeIDs());
-    }
-    return binder::ExpressionUtil::toString(joinConditions);
-}
-
 binder::expression_vector LogicalHashJoin::getExpressionsToMaterialize() const {
     switch (joinType) {
     case JoinType::INNER:

--- a/src/planner/operator/logical_limit.cpp
+++ b/src/planner/operator/logical_limit.cpp
@@ -5,17 +5,6 @@
 namespace kuzu {
 namespace planner {
 
-std::string LogicalLimit::getExpressionsForPrinting() const {
-    std::string result;
-    if (hasSkipNum()) {
-        result += "SKIP " + std::to_string(skipNum) + "\n";
-    }
-    if (hasLimitNum()) {
-        result += "LIMIT " + std::to_string(limitNum) + "\n";
-    }
-    return result;
-}
-
 f_group_pos_set LogicalLimit::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
     return FlattenAllButOne::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(),

--- a/src/planner/operator/logical_order_by.cpp
+++ b/src/planner/operator/logical_order_by.cpp
@@ -42,14 +42,5 @@ void LogicalOrderBy::computeFlatSchema() {
     }
 }
 
-std::string LogicalOrderBy::getExpressionsForPrinting() const {
-    auto result = binder::ExpressionUtil::toString(expressionsToOrderBy) + " ";
-    if (hasLimitNum()) {
-        result += "SKIP " + std::to_string(skipNum) + " ";
-        result += "LIMIT " + std::to_string(limitNum);
-    }
-    return result;
-}
-
 } // namespace planner
 } // namespace kuzu

--- a/src/planner/operator/logical_partitioner.cpp
+++ b/src/planner/operator/logical_partitioner.cpp
@@ -13,13 +13,6 @@ void LogicalPartitioner::computeFlatSchema() {
     copyChildSchema(0);
 }
 
-std::string LogicalPartitioner::getExpressionsForPrinting() const {
-    binder::expression_vector expressions;
-    for (auto& partitioningInfo : info.partitioningInfos) {
-        expressions.push_back(copyFromInfo.columnExprs[partitioningInfo.keyIdx]);
-    }
-    return binder::ExpressionUtil::toString(expressions);
-}
 
 } // namespace planner
 } // namespace kuzu

--- a/src/planner/operator/logical_partitioner.cpp
+++ b/src/planner/operator/logical_partitioner.cpp
@@ -13,6 +13,5 @@ void LogicalPartitioner::computeFlatSchema() {
     copyChildSchema(0);
 }
 
-
 } // namespace planner
 } // namespace kuzu

--- a/src/planner/operator/persistent/logical_delete.cpp
+++ b/src/planner/operator/persistent/logical_delete.cpp
@@ -11,14 +11,6 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace planner {
 
-std::string LogicalDelete::getExpressionsForPrinting() const {
-    expression_vector patterns;
-    for (auto& info : infos) {
-        patterns.push_back(info.pattern);
-    }
-    return ExpressionUtil::toString(patterns);
-}
-
 f_group_pos_set LogicalDelete::getGroupsPosToFlatten() const {
     KU_ASSERT(!infos.empty());
     auto childSchema = children[0]->getSchema();

--- a/src/planner/operator/persistent/logical_insert.cpp
+++ b/src/planner/operator/persistent/logical_insert.cpp
@@ -42,15 +42,6 @@ void LogicalInsert::computeFlatSchema() {
     }
 }
 
-std::string LogicalInsert::getExpressionsForPrinting() const {
-    std::string result;
-    for (auto i = 0u; i < infos.size() - 1; ++i) {
-        result += infos[i].pattern->toString() + ",";
-    }
-    result += infos[infos.size() - 1].pattern->toString();
-    return result;
-}
-
 f_group_pos_set LogicalInsert::getGroupsPosToFlatten() {
     auto childSchema = children[0]->getSchema();
     return FlattenAll::getGroupsPosToFlatten(childSchema->getGroupsPosInScope(), *childSchema);

--- a/src/planner/operator/persistent/logical_set.cpp
+++ b/src/planner/operator/persistent/logical_set.cpp
@@ -43,15 +43,6 @@ f_group_pos_set LogicalSetProperty::getGroupsPosToFlatten(uint32_t idx) const {
     return FlattenAll::getGroupsPosToFlatten(result, *childSchema);
 }
 
-std::string LogicalSetProperty::getExpressionsForPrinting() const {
-    std::string result =
-        ExpressionUtil::toString(std::make_pair(infos[0].column, infos[0].columnData));
-    for (auto i = 1u; i < infos.size(); ++i) {
-        result += ExpressionUtil::toString(std::make_pair(infos[i].column, infos[i].columnData));
-    }
-    return result;
-}
-
 common::TableType LogicalSetProperty::getTableType() const {
     KU_ASSERT(!infos.empty());
     return infos[0].tableType;

--- a/src/planner/operator/scan/logical_index_look_up.cpp
+++ b/src/planner/operator/scan/logical_index_look_up.cpp
@@ -5,7 +5,6 @@
 namespace kuzu {
 namespace planner {
 
-
 void LogicalPrimaryKeyLookup::computeFactorizedSchema() {
     copyChildSchema(0);
     for (auto& info : infos) {

--- a/src/planner/operator/scan/logical_index_look_up.cpp
+++ b/src/planner/operator/scan/logical_index_look_up.cpp
@@ -5,13 +5,6 @@
 namespace kuzu {
 namespace planner {
 
-std::string LogicalPrimaryKeyLookup::getExpressionsForPrinting() const {
-    binder::expression_vector expressions;
-    for (auto& info : infos) {
-        expressions.push_back(info.offset);
-    }
-    return binder::ExpressionUtil::toString(expressions);
-}
 
 void LogicalPrimaryKeyLookup::computeFactorizedSchema() {
     copyChildSchema(0);


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue (if applicable). Please also include
relevant motivation and context.

Adds to #3664 
Removed all getExpressionsForPrinting() functions from the PhysicalOperators
# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).