### PR TITLE
Correctly reset active transaction after checkpoint

### DIFF
--- a/src/function/table/call/checkpoint.cpp
+++ b/src/function/table/call/checkpoint.cpp
@@ -27,8 +27,8 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput&) {
     if (!morsel.hasMoreToOutput()) {
         return 0;
     }
-    checkpointBindData->clientContext->getTransactionManagerUnsafe()->commit(
-        *checkpointBindData->clientContext);
+    KU_ASSERT(checkpointBindData->clientContext->getTransactionContext()->hasActiveTransaction());
+    checkpointBindData->clientContext->getTransactionContext()->commit();
     checkpointBindData->clientContext->getTransactionManagerUnsafe()->checkpoint(
         *checkpointBindData->clientContext);
     return 0;

--- a/test/test_files/transaction/basic.test
+++ b/test/test_files/transaction/basic.test
@@ -5,6 +5,14 @@
 -STATEMENT COMMIT;
 ---- error
 No active transaction for COMMIT.
+-CASE CommitAfterCheckPoint
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CALL CHECKPOINT() RETURN *;
+---- ok
+-STATEMENT COMMIT;
+---- error
+No active transaction for COMMIT.
 -STATEMENT rollback;
 ---- error
 No active transaction for ROLLBACK.


### PR DESCRIPTION
# Description
After commiting before a checkpoint, correctly reset the active transaction in the current `TransactionContext`

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).