### PR TITLE
Fix duckdb extension parallel issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.3.26")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.3.27")
 
 include_directories(src/include)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.3.24")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.3.25")
 
 include_directories(src/include)
 

--- a/src/include/binder/ddl/bound_create_table_info.h
+++ b/src/include/binder/ddl/bound_create_table_info.h
@@ -78,6 +78,8 @@ struct KUZU_API BoundExtraCreateTableInfo : public BoundExtraCreateCatalogEntryI
     BoundExtraCreateTableInfo(const BoundExtraCreateTableInfo& other)
         : BoundExtraCreateTableInfo{copyVector(other.propertyInfos)} {}
 
+    BoundExtraCreateTableInfo& operator=(const BoundExtraCreateTableInfo&) = delete;
+
     std::unique_ptr<BoundExtraCreateCatalogEntryInfo> copy() const override {
         return std::make_unique<BoundExtraCreateTableInfo>(*this);
     }

--- a/src/include/binder/ddl/bound_create_table_info.h
+++ b/src/include/binder/ddl/bound_create_table_info.h
@@ -69,7 +69,7 @@ private:
         : name{other.name}, type{other.type.copy()}, defaultValue{other.defaultValue->copy()} {}
 };
 
-struct BoundExtraCreateTableInfo : public BoundExtraCreateCatalogEntryInfo {
+struct KUZU_API BoundExtraCreateTableInfo : public BoundExtraCreateCatalogEntryInfo {
     std::vector<PropertyInfo> propertyInfos;
 
     explicit BoundExtraCreateTableInfo(std::vector<PropertyInfo> propertyInfos)


### PR DESCRIPTION
# Description

Duckdb::queryResult->Fetch() is not thread safe, thus we have to acquire a lock before fetching the result from duckdb.