### PR TITLE
Fix more checkpoint-related issues

### DIFF
--- a/src/include/storage/store/dictionary_chunk.h
+++ b/src/include/storage/store/dictionary_chunk.h
@@ -16,9 +16,10 @@ public:
     // and can't be modified easily. Moving would invalidate that pointer
     DictionaryChunk(DictionaryChunk&& other) = delete;
 
-    void setToInMemory() const {
+    void setToInMemory() {
         stringDataChunk->setToInMemory();
         offsetChunk->setToInMemory();
+        indexTable.clear();
     }
     void resetToEmpty();
 

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -45,10 +45,7 @@ public:
         offsetColumnChunk->setNumValues(numValues_);
     }
 
-    uint64_t getNumValues() const override {
-        KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
-        return numValues;
-    }
+    uint64_t getNumValues() const override { return nullData->getNumValues(); }
 
     void syncNumValues() {
         numValues = offsetColumnChunk->getNumValues();

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -43,8 +43,17 @@ public:
         ColumnChunkData::setNumValues(numValues_);
         sizeColumnChunk->setNumValues(numValues_);
         offsetColumnChunk->setNumValues(numValues_);
+        KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
     }
-    uint64_t getNumValues() const override { return nullData->getNumValues(); }
+    uint64_t getNumValues() const override {
+        KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
+        return numValues;
+    }
+
+    void syncNumValues() {
+        numValues = offsetColumnChunk->getNumValues();
+        metadata.numValues = numValues;
+    }
 
     void resetNumValuesFromMetadata() override;
 
@@ -73,6 +82,7 @@ public:
         sizeColumnChunk->setToInMemory();
         offsetColumnChunk->setToInMemory();
         dataColumnChunk->setToInMemory();
+        KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
     }
     void resize(uint64_t newCapacity) override {
         ColumnChunkData::resize(newCapacity);

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -43,8 +43,8 @@ public:
         ColumnChunkData::setNumValues(numValues_);
         sizeColumnChunk->setNumValues(numValues_);
         offsetColumnChunk->setNumValues(numValues_);
-        KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
     }
+
     uint64_t getNumValues() const override {
         KU_ASSERT(offsetColumnChunk->getNumValues() == numValues);
         return numValues;

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -412,7 +412,8 @@ void CSRNodeGroup::checkpointColumn(const UniqLock& lock, column_id_t columnID,
         persistentChunk.initializeScanState(chunkState);
         persistentChunk.scanCommitted<ResidencyState::ON_DISK>(&DUMMY_CHECKPOINT_TRANSACTION,
             chunkState, *oldChunkWithUpdates);
-        const auto numRowsInRegion = csrState.newHeader->getEndCSROffset(region.rightNodeOffset);
+        const auto numRowsInRegion =
+            csrState.newHeader->getEndCSROffset(region.rightNodeOffset) - leftCSROffset;
         auto newChunk = std::make_unique<ColumnChunk>(dataTypes[columnID].copy(), numRowsInRegion,
             false, ResidencyState::IN_MEMORY);
         const auto dummyChunkForNulls = std::make_unique<ColumnChunk>(dataTypes[columnID].copy(),

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -428,7 +428,6 @@ void ListChunkData::deserialize(Deserializer& deSer, ColumnChunkData& chunkData)
     chunkData.cast<ListChunkData>().dataColumnChunk = ColumnChunkData::deserialize(deSer);
     deSer.validateDebuggingInfo(key, "offset_column_chunk");
     chunkData.cast<ListChunkData>().offsetColumnChunk = ColumnChunkData::deserialize(deSer);
-    chunkData.cast<ListChunkData>().syncNumValues();
 }
 
 void ListChunkData::flush(BMFileHandle& dataFH) {

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -428,6 +428,7 @@ void ListChunkData::deserialize(Deserializer& deSer, ColumnChunkData& chunkData)
     chunkData.cast<ListChunkData>().dataColumnChunk = ColumnChunkData::deserialize(deSer);
     deSer.validateDebuggingInfo(key, "offset_column_chunk");
     chunkData.cast<ListChunkData>().offsetColumnChunk = ColumnChunkData::deserialize(deSer);
+    chunkData.cast<ListChunkData>().syncNumValues();
 }
 
 void ListChunkData::flush(BMFileHandle& dataFH) {

--- a/test/test_files/transaction/create_rel/create_tinysnb.test
+++ b/test/test_files/transaction/create_rel/create_tinysnb.test
@@ -1,0 +1,17 @@
+-DATASET CSV tinysnb
+
+--
+
+-CASE InsertMultipleRelsAutoCheckpoint
+-STATEMENT CALL checkpoint_threshold=0
+---- ok
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT MATCH (a:person)-[:knows]->(b:person) WHERE a.ID = 7 CREATE (a)<-[:knows]-(b)
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 6 RETURN a.ID, b.ID, ID(e)
+---- 4
+7|8|3:12
+7|9|3:13
+8|7|3:14
+9|7|3:15

--- a/test/test_files/transaction/update_node/create_tinysnb.test
+++ b/test/test_files/transaction/update_node/create_tinysnb.test
@@ -1,0 +1,26 @@
+-DATASET CSV tinysnb
+
+--
+
+-CASE ListCreateAlwaysCheckpoint
+-STATEMENT CALL checkpoint_threshold=0
+---- ok
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT CREATE (:person {ID: 17, usedNames: ['Alice'], workedHours: [1,2,3], courseScoresPerTerm: [[1,2],[3,4]]})
+---- ok
+-STATEMENT CREATE (:person {ID: 25, usedNames: ['Carmen'], workedHours: [10, 5], courseScoresPerTerm: [[1,2],[3,4]]})
+---- ok
+-STATEMENT CREATE (:person {ID: 99, usedNames: ['Ein'], workedHours: [1], courseScoresPerTerm: [[7,20]]})
+---- ok
+-STATEMENT MATCH (p:person) RETURN p.workedHours, count(*)
+---- 9
+[10,5]|2
+[12,8]|1
+[4,5]|1
+[1,9]|1
+[2]|1
+[3,4,5,6,7]|1
+[1]|2
+[10,11,12,3,4,5,6,7]|1
+[1,2,3]|1


### PR DESCRIPTION
# Description

Implement the following fixes:
1. Avoid checkpointing list data chunk if it is empty (assertion failure)
2. Clear indexTable in `StringChunkData` when switching to in-memory residency (as the data is cleared so there is nothing for the indices to refer to)
3. Fix list column chunk's numValues going out of sync with its children

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).