### PR TITLE
Fix local node delete leading to inconsistent node offsets

### DIFF
--- a/src/include/storage/local_storage/local_node_table.h
+++ b/src/include/storage/local_storage/local_node_table.h
@@ -36,7 +36,7 @@ public:
     NodeGroup* getNodeGroup(common::node_group_idx_t nodeGroupIdx) {
         return nodeGroups.getNodeGroup(nodeGroupIdx);
     }
-    const NodeGroupCollection& getNodeGroups() const { return nodeGroups; }
+    NodeGroupCollection& getNodeGroups() { return nodeGroups; }
 
     bool lookupPK(const transaction::Transaction* transaction, const common::ValueVector* keyVector,
         common::offset_t& result);

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -118,7 +118,8 @@ public:
     const std::vector<common::LogicalType>& getDataTypes() const { return dataTypes; }
     NodeGroupDataFormat getFormat() const { return format; }
     common::row_idx_t append(const transaction::Transaction* transaction,
-        ChunkedNodeGroup& chunkedGroup, common::row_idx_t numRowsToAppend);
+        ChunkedNodeGroup& chunkedGroup, common::row_idx_t startRowIdx,
+        common::row_idx_t numRowsToAppend);
     common::row_idx_t append(const transaction::Transaction* transaction,
         const std::vector<ColumnChunk*>& chunkedGroup, common::row_idx_t startRowIdx,
         common::row_idx_t numRowsToAppend);
@@ -142,6 +143,7 @@ public:
         common::column_id_t columnID, const common::ValueVector& propertyVector);
     bool delete_(const transaction::Transaction* transaction, common::row_idx_t rowIdxInGroup);
 
+    common::row_idx_t getNumDeletedRows(const transaction::Transaction* transaction);
     virtual void addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState, BMFileHandle* dataFH);
 
@@ -203,6 +205,7 @@ protected:
     // `nextRowToAppend` is a cursor to allow us to pre-reserve a set of rows to append before
     // acutally appending data. This is an optimization to reduce lock-contention when appending in
     // parallel.
+    // TODO(Guodong): Remove this field.
     common::row_idx_t nextRowToAppend;
     common::row_idx_t capacity;
     std::vector<common::LogicalType> dataTypes;

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -15,13 +15,15 @@ public:
 
     void append(const transaction::Transaction* transaction,
         const std::vector<common::ValueVector*>& vectors);
+    void append(const transaction::Transaction* transaction, NodeGroupCollection& other);
+    void appned(const transaction::Transaction* transaction, NodeGroup& nodeGroup);
 
     // This function only tries to append data into the last node group, and if the last node group
     // is not enough to hold all the data, it will append partially and return the number of rows
     // appended.
     // The returned values are the startOffset and numValuesAppended.
     // NOTE: This is specially coded to only be used by NodeBatchInsert for now.
-    std::pair<common::offset_t, common::offset_t> appendToLastNodeGroup(
+    std::pair<common::offset_t, common::offset_t> appendToLastNodeGroupAndFlushWhenFull(
         transaction::Transaction* transaction, ChunkedNodeGroup& chunkedGroup);
 
     common::row_idx_t getNumRows();

--- a/src/storage/store/node_group_collection.cpp
+++ b/src/storage/store/node_group_collection.cpp
@@ -2,6 +2,7 @@
 
 #include "common/vector/value_vector.h"
 #include "storage/buffer_manager/bm_file_handle.h"
+#include <storage/store/table.h>
 
 using namespace kuzu::common;
 using namespace kuzu::transaction;
@@ -149,6 +150,7 @@ void NodeGroupCollection::addColumn(Transaction* transaction, TableAddColumnStat
     for (const auto& nodeGroup : nodeGroups.getAllGroups(lock)) {
         nodeGroup->addColumn(transaction, addColumnState, dataFH);
     }
+    types.push_back(addColumnState.property.getDataType().copy());
 }
 
 uint64_t NodeGroupCollection::getEstimatedMemoryUsage() {

--- a/test/test_files/transaction/delete_node/delete_node.test
+++ b/test/test_files/transaction/delete_node/delete_node.test
@@ -40,3 +40,40 @@
 ---- 2
 0:0|Alice|0:2|Charlie
 0:0|Alice|0:3|Dave
+
+-CASE CreateUpdateAndDeleteLocalNode
+-STATEMENT CREATE NODE TABLE person (oid INT64, fName STRING, PRIMARY KEY(oid));
+---- ok
+-STATEMENT CREATE REL TABLE knows (FROM person TO person);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (p:person {oid: 0, fName: 'Alice'});
+---- ok
+-STATEMENT CREATE (p:person {oid: 1, fName: 'Bob'});
+---- ok
+-STATEMENT CREATE (p:person {oid: 2, fName: 'Charlie'});
+---- ok
+-STATEMENT CREATE (p:person {oid: 3, fName: 'Dave'});
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.oid=1 SET p.fName='Bob2';
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.oid=1 RETURN p.fName;
+---- 1
+Bob2
+-STATEMENT MATCH (p:person) WHERE p.oid=1 DELETE p;
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.oid=1 RETURN p.fName;
+---- 0
+-STATEMENT MATCH (p:person) WHERE p.oid=2 SET p.fName='Charlie2';
+---- ok
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT MATCH (p:person) RETURN ID(p), p.fName;
+---- 3
+0:0|Alice
+0:2|Charlie2
+0:3|Dave
+-STATEMENT MATCH (p:person) WHERE p.fName='Dave' RETURN ID(p), p.fName;
+---- 1
+0:3|Dave

--- a/test/test_files/transaction/delete_node/delete_node.test
+++ b/test/test_files/transaction/delete_node/delete_node.test
@@ -1,0 +1,42 @@
+-DATASET CSV empty
+--
+
+-CASE DeleteLocalNode
+-STATEMENT CREATE NODE TABLE person (oid INT64, fName STRING, PRIMARY KEY(oid));
+---- ok
+-STATEMENT CREATE REL TABLE knows (FROM person TO person);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (p:person {oid: 0, fName: 'Alice'});
+---- ok
+-STATEMENT CREATE (p:person {oid: 1, fName: 'Bob'});
+---- ok
+-STATEMENT CREATE (p:person {oid: 2, fName: 'Charlie'});
+---- ok
+-STATEMENT CREATE (p:person {oid: 3, fName: 'Dave'});
+---- ok
+-STATEMENT MATCH (p1:person), (p2:person) WHERE p1.oid=0 AND p2.oid=2 CREATE (p1)-[:knows]->(p2);
+---- ok
+-STATEMENT MATCH (p1:person), (p2:person) WHERE p1.oid=0 AND p2.oid=3 CREATE (p1)-[:knows]->(p2);
+---- ok
+-STATEMENT MATCH (p:person) WHERE p.oid=1 DELETE p;
+---- ok
+-STATEMENT MATCH (p1:person)-[r:knows]->(p2:person) RETURN ID(p1), p1.fName, ID(p2), p2.fName;
+---- 2
+0:4611686018427387904|Alice|0:4611686018427387906|Charlie
+0:4611686018427387904|Alice|0:4611686018427387907|Dave
+-STATEMENT COMMIT;
+---- ok
+-STATEMENT MATCH (p:person) RETURN ID(p);
+---- 3
+0:0
+0:2
+0:3
+-STATEMENT MATCH (p:person) WHERE p.fName='Dave' RETURN ID(p), p.fName;
+---- 1
+0:3|Dave
+-STATEMENT MATCH (p1:person)-[r:knows]->(p2:person) RETURN ID(p1), p1.fName, ID(p2), p2.fName;
+---- 2
+0:0|Alice|0:2|Charlie
+0:0|Alice|0:3|Dave


### PR DESCRIPTION
# Description

When newly inserted nodes are deleted within the same transaction, during commit, deleted nodes are not appended to table's nodeGroups. This shifts offsets of the nodes after the deleted one, leading to connected rels recording inconsistent src/dst node offsets.