### PR TITLE
More checkpoint fixes

### DIFF
--- a/src/include/storage/store/column.h
+++ b/src/include/storage/store/column.h
@@ -90,7 +90,7 @@ public:
     common::offset_t appendValues(ColumnChunkData& persistentChunk, ChunkState& state,
         const uint8_t* data, const common::NullMask* nullChunkData, common::offset_t numValues);
 
-    virtual void checkpointColumnChunk(ColumnCheckpointState& checkpointState);
+    void checkpointColumnChunk(ColumnCheckpointState& checkpointState);
 
     template<class TARGET>
     TARGET& cast() {
@@ -131,6 +131,10 @@ protected:
     void updateStatistics(ColumnChunkMetadata& metadata, common::offset_t maxIndex,
         const std::optional<StorageValue>& min, const std::optional<StorageValue>& max) const;
 
+    virtual void checkpointColumnChunkImpl(ColumnCheckpointState& checkpointState);
+
+    virtual bool requiresSyncAfterCheckpointColumnChunk() { return false; }
+
 protected:
     bool isMaxOffsetOutOfPagesCapacity(const ColumnChunkMetadata& metadata,
         common::offset_t maxOffset) const;
@@ -149,6 +153,8 @@ protected:
     static bool isInRange(uint64_t val, uint64_t start, uint64_t end) {
         return val >= start && val < end;
     }
+
+    void syncAfterCheckpointColumnChunk(ColumnCheckpointState& checkpointState);
 
 protected:
     std::string name;

--- a/src/include/storage/store/column_chunk_data.h
+++ b/src/include/storage/store/column_chunk_data.h
@@ -211,6 +211,8 @@ public:
         return common::ku_dynamic_cast<const ColumnChunkData&, const TARGET&>(*this);
     }
 
+    virtual void syncNumValues() {}
+
 protected:
     // Initializes the data buffer and functions. They are (and should be) only called in
     // constructor.

--- a/src/include/storage/store/list_chunk_data.h
+++ b/src/include/storage/store/list_chunk_data.h
@@ -47,10 +47,7 @@ public:
 
     uint64_t getNumValues() const override { return nullData->getNumValues(); }
 
-    void syncNumValues() {
-        numValues = offsetColumnChunk->getNumValues();
-        metadata.numValues = numValues;
-    }
+    void syncNumValues() override;
 
     void resetNumValuesFromMetadata() override;
 

--- a/src/include/storage/store/list_column.h
+++ b/src/include/storage/store/list_column.h
@@ -66,7 +66,7 @@ public:
     Column* getSizeColumn() const { return sizeColumn.get(); }
     Column* getDataColumn() const { return dataColumn.get(); }
 
-    void checkpointColumnChunk(ColumnCheckpointState& checkpointState) override;
+    void checkpointColumnChunkImpl(ColumnCheckpointState& checkpointState) override;
 
 protected:
     void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
@@ -92,6 +92,8 @@ private:
     ListOffsetSizeInfo getListOffsetSizeInfo(transaction::Transaction* transaction,
         const ChunkState& state, common::offset_t startOffsetInNodeGroup,
         common::offset_t endOffsetInNodeGroup) const;
+
+    bool requiresSyncAfterCheckpointColumnChunk() override { return true; }
 
 private:
     std::unique_ptr<Column> offsetColumn;

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "csr_node_group.h"
 #include "storage/store/group_collection.h"
 #include "storage/store/node_group.h"
 

--- a/src/include/storage/store/node_group_collection.h
+++ b/src/include/storage/store/node_group_collection.h
@@ -36,20 +36,8 @@ public:
         return nodeGroups.getGroup(lock, groupIdx);
     }
     NodeGroup* getOrCreateNodeGroup(const common::node_group_idx_t groupIdx,
-        NodeGroupDataFormat format) {
-        const auto lock = nodeGroups.lock();
-        const auto nodeGroup = nodeGroups.getGroup(lock, groupIdx);
-        if (!nodeGroup) {
-            nodeGroups.replaceGroup(lock, groupIdx,
-                format == NodeGroupDataFormat::REGULAR ?
-                    std::make_unique<NodeGroup>(groupIdx, enableCompression,
-                        common::LogicalType::copy(types)) :
-                    std::make_unique<CSRNodeGroup>(groupIdx, enableCompression,
-                        common::LogicalType::copy(types)));
-            return nodeGroups.getGroup(lock, groupIdx);
-        }
-        return nodeGroup;
-    }
+        NodeGroupDataFormat format);
+
     void setNodeGroup(const common::node_group_idx_t nodeGroupIdx,
         std::unique_ptr<NodeGroup> group) {
         const auto lock = nodeGroups.lock();

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
+#include "storage/store/csr_node_group.h"
 #include "storage/store/rel_table_data.h"
 #include "storage/store/table.h"
 

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -5,6 +5,7 @@
 #include "common/enums/rel_direction.h"
 #include "common/enums/rel_multiplicity.h"
 #include "storage/store/column.h"
+#include "storage/store/csr_node_group.h"
 #include "storage/store/node_group_collection.h"
 
 namespace kuzu {

--- a/src/include/storage/store/string_chunk_data.h
+++ b/src/include/storage/store/string_chunk_data.h
@@ -71,6 +71,8 @@ public:
     void serialize(common::Serializer& serializer) const override;
     static void deserialize(common::Deserializer& deSer, ColumnChunkData& chunkData);
 
+    void syncNumValues() override;
+
 private:
     void appendStringColumnChunk(StringChunkData* other, common::offset_t startPosInOtherChunk,
         uint32_t numValuesToAppend);

--- a/src/include/storage/store/string_column.h
+++ b/src/include/storage/store/string_column.h
@@ -53,6 +53,8 @@ private:
     bool canIndexCommitInPlace(const ChunkState& state, uint64_t numStrings,
         common::offset_t maxOffset) const;
 
+    bool requiresSyncAfterCheckpointColumnChunk() override { return true; }
+
 private:
     // Main column stores indices of values in the dictionary
     DictionaryColumn dictionary;

--- a/src/include/storage/store/struct_chunk_data.h
+++ b/src/include/storage/store/struct_chunk_data.h
@@ -81,6 +81,8 @@ protected:
         }
     }
 
+    void syncNumValues() override;
+
 private:
     std::vector<std::unique_ptr<ColumnChunkData>> childChunks;
 };

--- a/src/include/storage/store/struct_column.h
+++ b/src/include/storage/store/struct_column.h
@@ -27,7 +27,7 @@ public:
     void write(ColumnChunkData& persistentChunk, ChunkState& state, common::offset_t offsetInChunk,
         ColumnChunkData* data, common::offset_t dataOffset, common::length_t numValues) override;
 
-    void checkpointColumnChunk(ColumnCheckpointState& checkpointState) override;
+    void checkpointColumnChunkImpl(ColumnCheckpointState& checkpointState) override;
 
 protected:
     void scanInternal(transaction::Transaction* transaction, const ChunkState& state,
@@ -37,6 +37,8 @@ protected:
     void lookupInternal(transaction::Transaction* transaction, const ChunkState& state,
         common::offset_t nodeOffset, common::ValueVector* resultVector,
         uint32_t posInVector) override;
+
+    bool requiresSyncAfterCheckpointColumnChunk() override { return true; }
 
 private:
     std::vector<std::unique_ptr<Column>> childColumns;

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -6,6 +6,7 @@
 #include "processor/result/factorized_table_util.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk_data.h"
+#include "storage/store/csr_node_group.h"
 #include "storage/store/rel_table.h"
 
 using namespace kuzu::catalog;

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -534,7 +534,6 @@ bool Column::canCheckpointInPlace(const ChunkState& state,
 }
 
 void Column::syncAfterCheckpointColumnChunk(ColumnCheckpointState& checkpointState) {
-    Column::checkpointNullData(checkpointState);
     checkpointState.persistentData.syncNumValues();
 }
 

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -533,7 +533,19 @@ bool Column::canCheckpointInPlace(const ChunkState& state,
     return true;
 }
 
+void Column::syncAfterCheckpointColumnChunk(ColumnCheckpointState& checkpointState) {
+    Column::checkpointNullData(checkpointState);
+    checkpointState.persistentData.syncNumValues();
+}
+
 void Column::checkpointColumnChunk(ColumnCheckpointState& checkpointState) {
+    checkpointColumnChunkImpl(checkpointState);
+    if (requiresSyncAfterCheckpointColumnChunk()) {
+        syncAfterCheckpointColumnChunk(checkpointState);
+    }
+}
+
+void Column::checkpointColumnChunkImpl(ColumnCheckpointState& checkpointState) {
     ChunkState chunkState;
     checkpointState.persistentData.initializeScanState(chunkState);
     if (canCheckpointInPlace(chunkState, checkpointState)) {

--- a/src/storage/store/csr_chunked_node_group.cpp
+++ b/src/storage/store/csr_chunked_node_group.cpp
@@ -26,7 +26,8 @@ offset_t ChunkedCSRHeader::getStartCSROffset(offset_t nodeOffset) const {
         return 0;
     }
     if (nodeOffset >= offset->getNumValues()) {
-        return offset->getNumValues() - 1;
+        const offset_t maxNodeOffset = offset->getNumValues() - 1;
+        return offset->getData().getValue<offset_t>(maxNodeOffset) + getCSRLength(maxNodeOffset);
     }
     KU_ASSERT(nodeOffset < offset->getNumValues());
     return offset->getData().getValue<offset_t>(nodeOffset - 1);
@@ -39,7 +40,8 @@ offset_t ChunkedCSRHeader::getEndCSROffset(offset_t nodeOffset) const {
         return 0;
     }
     if (nodeOffset >= offset->getNumValues()) {
-        return offset->getNumValues() - 1;
+        const offset_t maxNodeOffset = offset->getNumValues() - 1;
+        return offset->getData().getValue<offset_t>(maxNodeOffset) + getCSRLength(maxNodeOffset);
     }
     KU_ASSERT(nodeOffset < offset->getNumValues());
     KU_ASSERT(nodeOffset < length->getNumValues());

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -410,6 +410,7 @@ void CSRNodeGroup::checkpointColumn(const UniqLock& lock, column_id_t columnID,
         const auto newLeftCSROffset = csrState.newHeader->getStartCSROffset(region.leftNodeOffset);
         const auto rightCSROffset = csrState.oldHeader->getEndCSROffset(region.rightNodeOffset);
         const auto numOldRowsInRegion = rightCSROffset - oldLeftCSROffset;
+        KU_ASSERT(rightCSROffset >= oldLeftCSROffset);
         auto oldChunkWithUpdates = std::make_unique<ColumnChunk>(dataTypes[columnID].copy(),
             numOldRowsInRegion, false, ResidencyState::IN_MEMORY);
         ChunkState chunkState;

--- a/src/storage/store/list_chunk_data.cpp
+++ b/src/storage/store/list_chunk_data.cpp
@@ -87,6 +87,11 @@ void ListChunkData::setOffsetChunkValue(offset_t val, offset_t pos) {
     numValues = offsetColumnChunk->getNumValues();
 }
 
+void ListChunkData::syncNumValues() {
+    numValues = offsetColumnChunk->getNumValues();
+    metadata.numValues = numValues;
+}
+
 void ListChunkData::append(ColumnChunkData* other, offset_t startPosInOtherChunk,
     uint32_t numValuesToAppend) {
     checkOffsetSortedAsc = true;

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -389,6 +389,8 @@ void ListColumn::checkpointColumnChunkImpl(ColumnCheckpointState& checkpointStat
         ColumnCheckpointState sizeCheckpointState(*persistentListChunk.getSizeColumnChunk(),
             std::move(sizeChunkCheckpointStates));
         sizeColumn->checkpointColumnChunk(sizeCheckpointState);
+
+        Column::checkpointNullData(checkpointState);
     }
 }
 

--- a/src/storage/store/list_column.cpp
+++ b/src/storage/store/list_column.cpp
@@ -307,7 +307,7 @@ ListOffsetSizeInfo ListColumn::getListOffsetSizeInfo(Transaction* transaction,
     return {numValuesScan, std::move(offsetColumnChunk), std::move(sizeColumnChunk)};
 }
 
-void ListColumn::checkpointColumnChunk(ColumnCheckpointState& checkpointState) {
+void ListColumn::checkpointColumnChunkImpl(ColumnCheckpointState& checkpointState) {
     auto& persistentListChunk = checkpointState.persistentData.cast<ListChunkData>();
     const auto persistentDataChunk = persistentListChunk.getDataColumnChunk();
     // First, check if we can checkpoint list data chunk in place.
@@ -389,15 +389,6 @@ void ListColumn::checkpointColumnChunk(ColumnCheckpointState& checkpointState) {
         ColumnCheckpointState sizeCheckpointState(*persistentListChunk.getSizeColumnChunk(),
             std::move(sizeChunkCheckpointStates));
         sizeColumn->checkpointColumnChunk(sizeCheckpointState);
-        // Checkpoint null data.
-        Column::checkpointNullData(checkpointState);
-
-        KU_ASSERT(persistentListChunk.getNullData()->getNumValues() ==
-                      persistentListChunk.getOffsetColumnChunk()->getNumValues() &&
-                  persistentListChunk.getNullData()->getNumValues() ==
-                      persistentListChunk.getSizeColumnChunk()->getNumValues());
-
-        persistentListChunk.syncNumValues();
     }
 }
 

--- a/src/storage/store/node_group_collection.cpp
+++ b/src/storage/store/node_group_collection.cpp
@@ -2,6 +2,7 @@
 
 #include "common/vector/value_vector.h"
 #include "storage/buffer_manager/bm_file_handle.h"
+#include "storage/store/csr_node_group.h"
 #include <storage/store/table.h>
 
 using namespace kuzu::common;

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -7,6 +7,7 @@
 #include "common/types/internal_id_t.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
+#include "storage/store/csr_node_group.h"
 #include "storage/store/node_group.h"
 #include "storage/store/rel_table.h"
 

--- a/src/storage/store/string_chunk_data.cpp
+++ b/src/storage/store/string_chunk_data.cpp
@@ -297,5 +297,10 @@ std::string StringChunkData::getValue<std::string>(offset_t pos) const {
     return std::string(getValue<std::string_view>(pos));
 }
 
+void StringChunkData::syncNumValues() {
+    numValues = indexColumnChunk->getNumValues();
+    metadata.numValues = numValues;
+}
+
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/store/struct_chunk_data.cpp
+++ b/src/storage/store/struct_chunk_data.cpp
@@ -233,5 +233,11 @@ bool StructChunkData::numValuesSanityCheck() const {
     return nullData->getNumValues() == numValues;
 }
 
+void StructChunkData::syncNumValues() {
+    KU_ASSERT(childChunks.size() >= 1);
+    numValues = childChunks[0]->getNumValues();
+    metadata.numValues = numValues;
+}
+
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -94,7 +94,7 @@ void StructColumn::write(ColumnChunkData& persistentChunk, ChunkState& state,
     }
 }
 
-void StructColumn::checkpointColumnChunk(ColumnCheckpointState& checkpointState) {
+void StructColumn::checkpointColumnChunkImpl(ColumnCheckpointState& checkpointState) {
     auto& persistentStructChunk = checkpointState.persistentData.cast<StructChunkData>();
     for (auto i = 0u; i < childColumns.size(); i++) {
         std::vector<ChunkCheckpointState> childChunkCheckpointStates;
@@ -108,7 +108,6 @@ void StructColumn::checkpointColumnChunk(ColumnCheckpointState& checkpointState)
             std::move(childChunkCheckpointStates));
         childColumns[i]->checkpointColumnChunk(childColumnCheckpointState);
     }
-    Column::checkpointNullData(checkpointState);
 }
 
 } // namespace storage

--- a/src/storage/store/struct_column.cpp
+++ b/src/storage/store/struct_column.cpp
@@ -108,6 +108,7 @@ void StructColumn::checkpointColumnChunkImpl(ColumnCheckpointState& checkpointSt
             std::move(childChunkCheckpointStates));
         childColumns[i]->checkpointColumnChunk(childColumnCheckpointState);
     }
+    Column::checkpointNullData(checkpointState);
 }
 
 } // namespace storage

--- a/src/storage/store/update_info.cpp
+++ b/src/storage/store/update_info.cpp
@@ -70,11 +70,9 @@ bool UpdateInfo::hasUpdates(const Transaction* transaction, row_idx_t startRow,
         StorageUtils::getQuotientRemainder(startRow, DEFAULT_VECTOR_CAPACITY);
     auto [endVectorIdx, rowInEndVector] =
         StorageUtils::getQuotientRemainder(startRow + numRows, DEFAULT_VECTOR_CAPACITY);
-    idx_t vectorIdx = startVector;
-    while (vectorIdx <= endVectorIdx) {
+    for (idx_t vectorIdx = startVector; vectorIdx <= endVectorIdx; ++vectorIdx) {
         const auto updateVector = getVectorInfo(transaction, vectorIdx);
         if (!updateVector || updateVector->numRowsUpdated == 0) {
-            vectorIdx++;
             continue;
         }
         const auto startRowInVector = (vectorIdx == startVector) ? rowInStartVector : 0;

--- a/test/test_files/transaction/create_rel/create_ldbc_sf01.test
+++ b/test/test_files/transaction/create_rel/create_ldbc_sf01.test
@@ -1,0 +1,13 @@
+-DATASET CSV ldbc-sf01
+--
+
+-CASE CreateLikeCommentAutoCheckpoint
+-STATEMENT CALL checkpoint_threshold=0
+---- ok
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT MATCH (n:Person), (m:Comment) WHERE n.id=24189255812290 AND m.id=412317157805 CREATE (n)-[:likes_Comment {creationDate: 202311180116}]->(m);
+---- ok
+-STATEMENT MATCH (n:Person)-[r:likes_Comment]->(m:Comment) WHERE n.id=24189255812290 AND m.id=412317157805 RETURN r.creationDate;
+---- 1
+202311180116

--- a/test/test_files/transaction/create_rel/insert_rels_to_different_nodes.test
+++ b/test/test_files/transaction/create_rel/insert_rels_to_different_nodes.test
@@ -18,7 +18,28 @@
 ---- ok
 -INSERT_STATEMENT_BLOCK INSERT_RELS_TO_DIFFERENT_NODES
 -STATEMENT COMMIT
----- ok 
+---- ok
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 50 RETURN e.length, e.place, e.tag
+---- 4
+143||[long long string]
+752|waterloo|[good test]
+|very very special string|
+||
+-STATEMENT COMMIT;
+---- ok
+
+-CASE insertRelsToDifferentNodesCommitNormalExecutionAutoCheckpoint
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT CALL checkpoint() RETURN *;
+---- ok
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-INSERT_STATEMENT_BLOCK INSERT_RELS_TO_DIFFERENT_NODES
+-STATEMENT COMMIT
+---- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(b:person) WHERE a.ID > 50 RETURN e.length, e.place, e.tag

--- a/test/test_files/transaction/create_rel/insert_rels_to_different_nodes.test
+++ b/test/test_files/transaction/create_rel/insert_rels_to_different_nodes.test
@@ -33,7 +33,7 @@
 -CASE insertRelsToDifferentNodesCommitNormalExecutionAutoCheckpoint
 -STATEMENT CALL auto_checkpoint=true
 ---- ok
--STATEMENT CALL checkpoint() RETURN *;
+-STATEMENT CALL checkpoint_threshold=0;
 ---- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok

--- a/test/test_files/transaction/create_rel/insert_rels_to_newly_added_node.test
+++ b/test/test_files/transaction/create_rel/insert_rels_to_newly_added_node.test
@@ -50,13 +50,33 @@
 -STATEMENT COMMIT;
 ---- ok
 
+-CASE insertRelsToNewlyAddedNodeCommitRecoveryAutoCheckpoint
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT CALL checkpoint_threshold=0;
+---- ok
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-INSERT_STATEMENT_BLOCK INSERT_RELS_TO_DIFFERENT_NODES
+-STATEMENT COMMIT
+---- ok
+-RELOADDB
+-STATEMENT BEGIN TRANSACTION
+---- ok
+-STATEMENT MATCH (a:person)-[e:knows]->(:person) WHERE a.ID > 2600 RETURN e.length, e.place
+---- 3
+43|
+50|long long string test
+|
+-STATEMENT COMMIT;
+---- ok
 
 -CASE insertRelsToNewlyAddedNodeRollbackNormalExecution
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -INSERT_STATEMENT_BLOCK INSERT_RELS_TO_DIFFERENT_NODES
 -STATEMENT Rollback
----- ok 
+---- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT MATCH (a:person)-[e:knows]->(:person) WHERE a.ID > 2600 RETURN e.length, e.place

--- a/test/test_files/transaction/set/set_tinysnb.test
+++ b/test/test_files/transaction/set/set_tinysnb.test
@@ -14,3 +14,29 @@
 22
 55
 99
+
+-CASE SetStructValueToNullAlwaysCheckpoint
+-STATEMENT CALL checkpoint_threshold=0
+---- ok
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT CREATE NODE TABLE test(id INT64, prop STRUCT(age INT64, name STRING), PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {id:1, prop:{age:10, name:'Alice'}})
+---- ok
+-STATEMENT CREATE (t:test {id:2, prop:{age:20, name:'Bobdjiweknfwhuwiehfuw'}})
+---- ok
+-STATEMENT CREATE (t:test {id:3, prop:{age:30, name:'Delta'}})
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.prop
+---- 3
+{age: 10, name: Alice}
+{age: 20, name: Bobdjiweknfwhuwiehfuw}
+{age: 30, name: Delta}
+-STATEMENT MATCH (t:test) WHERE t.id=1 SET t.prop=NULL
+---- ok
+-STATEMENT MATCH (t:test) RETURN t.prop
+---- 3
+
+{age: 20, name: Bobdjiweknfwhuwiehfuw}
+{age: 30, name: Delta}

--- a/test/test_files/transaction/set/set_tinysnb.test
+++ b/test/test_files/transaction/set/set_tinysnb.test
@@ -1,0 +1,16 @@
+-DATASET CSV tinysnb
+
+--
+
+-CASE SetRelAutoCheckpoint
+-STATEMENT CALL checkpoint_threshold=0
+---- ok
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT MATCH (a:person)-[e:studyAt]->(b:organisation) WHERE a.ID = 0 SET e.length=99
+---- ok
+-STATEMENT MATCH (a:person)-[e:studyAt]->(b:organisation) RETURN e.length
+---- 3
+22
+55
+99

--- a/test/test_files/transaction/update_rel/create_batch.test
+++ b/test/test_files/transaction/update_rel/create_batch.test
@@ -1,0 +1,38 @@
+-DATASET CSV empty
+--
+
+-CASE CreateRelBatch2AutoCheckpoint
+-STATEMENT CALL checkpoint_threshold=0
+---- ok
+-STATEMENT CALL auto_checkpoint=true
+---- ok
+-STATEMENT CREATE NODE TABLE Person(id SERIAL, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE REL TABLE knows(FROM Person TO Person);
+---- ok
+-STATEMENT UNWIND range(0, 200000) AS i
+           CREATE (n:Person);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person {id: 180000}), (p2:Person {id: 18}) CREATE (p1)-[k]->(p2);
+---- ok
+-STATEMENT MATCH (p1:Person)-[r:knows]->(p2:Person) RETURN COUNT(*)
+---- 1
+10


### PR DESCRIPTION
# Description

Fix issues discovered by running test suite with `checkpoint_threshold=0` with `auto_checkpoint=true`

Fix failing tests in:
- `test/test_files/update_rel/create_ldbc_sf01.test`, `test/test_files/transaction/create_rel/insert_rels_to_different_nodes.test` - correctly use old/new csr header offsets in `CSRNodeGroup::checkpointColumn`

- `test/test_files/update_node/set_tinysnb.test` - fix infinite loop in `UpdateInfo::hasUpdates`

- `test/test_files/update_node/set_empty.test` - sync num values for struct columns/chunks

- `test/test_files/transaction/create_rel/insert_rels_to_newly_added_node.test` - ensure values returned by csr header get start/end offset is increasing as nodeOffset increases

- `test/test_files/update_rel/create_batch.test` - (partially fixed, still incorrect query result) - fixed segfault caused by filling gaps in node group collections with nullptrs

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).