### PR TITLE
Add missing types to copy to parquet

### DIFF
--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -412,6 +412,7 @@ template KUZU_API void ValueVector::setValue<timestamp_sec_t>(uint32_t pos, time
 template KUZU_API void ValueVector::setValue<timestamp_tz_t>(uint32_t pos, timestamp_tz_t val);
 template KUZU_API void ValueVector::setValue<interval_t>(uint32_t pos, interval_t val);
 template KUZU_API void ValueVector::setValue<list_entry_t>(uint32_t pos, list_entry_t val);
+template KUZU_API void ValueVector::setValue<ku_uuid_t>(uint32_t pos, ku_uuid_t val);
 
 template<>
 void ValueVector::setValue(uint32_t pos, ku_string_t val) {

--- a/src/function/cast_from_string_functions.cpp
+++ b/src/function/cast_from_string_functions.cpp
@@ -760,16 +760,22 @@ void CastStringHelper::cast(const char* input, uint64_t len, union_entry_t& /*re
     auto& type = vector->dataType;
     union_field_idx_t selectedFieldIdx = INVALID_STRUCT_FIELD_IDX;
 
-    for (auto i = 0u; i < UnionType::getNumFields(type); i++) {
+    auto i = 0u;
+    for (; i < UnionType::getNumFields(type); i++) {
         auto internalFieldIdx = UnionType::getInternalFieldIdx(i);
         auto fieldVector = StructVector::getFieldVector(vector, internalFieldIdx).get();
         if (tryCastUnionField(fieldVector, rowToAdd, input, len)) {
             fieldVector->setNull(rowToAdd, false /* isNull */);
             selectedFieldIdx = i;
+            i++;
             break;
         } else {
             fieldVector->setNull(rowToAdd, true /* isNull */);
         }
+    }
+    for (; i < UnionType::getNumFields(type); i++) {
+        auto fieldVector = UnionVector::getValVector(vector, i);
+        fieldVector->setNull(rowToAdd, true /* isNull */);
     }
 
     if (selectedFieldIdx == INVALID_STRUCT_FIELD_IDX) {

--- a/src/include/common/constants.h
+++ b/src/include/common/constants.h
@@ -183,6 +183,7 @@ struct ParquetConstants {
     static constexpr uint64_t STRING_LENGTH_SIZE = sizeof(uint32_t);
     static constexpr uint64_t MAX_STRING_STATISTICS_SIZE = 10000;
     static constexpr uint64_t PARQUET_INTERVAL_SIZE = 12;
+    static constexpr uint64_t PARQUET_UUID_SIZE = 16;
 };
 
 struct ExportCSVConstants {

--- a/src/include/processor/operator/persistent/reader/parquet/interval_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/interval_column_reader.h
@@ -32,8 +32,8 @@ public:
               std::move(type), schema, fileIdx, maxDefine, maxRepeat){};
 
 protected:
-    void dictionary(const std::shared_ptr<ResizeableBuffer>& dictionary_data,
-        uint64_t num_entries) override;
+    void dictionary(const std::shared_ptr<ResizeableBuffer>& dictionaryData,
+        uint64_t numEntries) override;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/persistent/reader/parquet/uuid_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/uuid_column_reader.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "common/types/uuid.h"
+#include "processor/operator/persistent/reader/parquet/resizable_buffer.h"
+#include "templated_column_reader.h"
+
+namespace kuzu {
+namespace processor {
+
+struct UUIDValueConversion {
+    static common::ku_uuid_t dictRead(ByteBuffer& dict, uint32_t& offset,
+        ColumnReader& /*reader*/) {
+        return reinterpret_cast<common::ku_uuid_t*>(dict.ptr)[offset];
+    }
+
+    static common::ku_uuid_t ReadParquetUUID(const uint8_t* input);
+
+    static common::ku_uuid_t plainRead(ByteBuffer& bufferData, ColumnReader& /*reader*/);
+
+    static void plainSkip(ByteBuffer& plain_data, ColumnReader& /*reader*/) {
+        plain_data.inc(sizeof(common::ku_uuid_t));
+    }
+};
+
+class UUIDColumnReader : public TemplatedColumnReader<common::ku_uuid_t, UUIDValueConversion> {
+public:
+    UUIDColumnReader(ParquetReader& reader, common::LogicalType dataType,
+        const kuzu_parquet::format::SchemaElement& schema_p, uint64_t file_idx_p,
+        uint64_t maxDefine, uint64_t maxRepeat)
+        : TemplatedColumnReader<common::ku_uuid_t, UUIDValueConversion>(reader, std::move(dataType),
+              schema_p, file_idx_p, maxDefine, maxRepeat){};
+
+protected:
+    void dictionary(const std::shared_ptr<ResizeableBuffer>& dictionaryData,
+        uint64_t numEntries) override;
+};
+
+} // namespace processor
+} // namespace kuzu

--- a/src/include/processor/operator/persistent/writer/parquet/standard_column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/standard_column_writer.h
@@ -73,7 +73,7 @@ public:
         : BasicColumnWriter(writer, schemaIdx, std::move(schemaPath), maxRepeat, maxDefine,
               canHaveNulls) {}
 
-    inline std::unique_ptr<ColumnWriterStatistics> initializeStatsState() override {
+    std::unique_ptr<ColumnWriterStatistics> initializeStatsState() override {
         return OP::template initializeStats<SRC, TGT>();
     }
 
@@ -89,13 +89,13 @@ public:
         }
     }
 
-    inline void writeVector(common::Serializer& bufferedSerializer, ColumnWriterStatistics* stats,
+    void writeVector(common::Serializer& bufferedSerializer, ColumnWriterStatistics* stats,
         ColumnWriterPageState* /*pageState*/, common::ValueVector* vector, uint64_t chunkStart,
         uint64_t chunkEnd) override {
         templatedWritePlain(vector, stats, chunkStart, chunkEnd, bufferedSerializer);
     }
 
-    inline uint64_t getRowSize(common::ValueVector* /*vector*/, uint64_t /*index*/,
+    uint64_t getRowSize(common::ValueVector* /*vector*/, uint64_t /*index*/,
         BasicColumnWriterState& /*state*/) override {
         return sizeof(TGT);
     }

--- a/src/include/processor/operator/persistent/writer/parquet/uuid_column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/uuid_column_writer.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "basic_column_writer.h"
-#include "common/types/uuid.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/include/processor/operator/persistent/writer/parquet/uuid_column_writer.h
+++ b/src/include/processor/operator/persistent/writer/parquet/uuid_column_writer.h
@@ -1,30 +1,26 @@
 #pragma once
 
 #include "basic_column_writer.h"
-#include "common/types/interval_t.h"
+#include "common/types/uuid.h"
 
 namespace kuzu {
 namespace processor {
 
-class IntervalColumnWriter : public BasicColumnWriter {
-
+class UUIDColumnWriter : public BasicColumnWriter {
 public:
-    IntervalColumnWriter(ParquetWriter& writer, uint64_t schemaIdx,
-        std::vector<std::string> schemaPath, uint64_t maxRepeat, uint64_t maxDefine,
-        bool canHaveNulls)
+    UUIDColumnWriter(ParquetWriter& writer, uint64_t schemaIdx, std::vector<std::string> schemaPath,
+        uint64_t maxRepeat, uint64_t maxDefine, bool canHaveNulls)
         : BasicColumnWriter(writer, schemaIdx, std::move(schemaPath), maxRepeat, maxDefine,
               canHaveNulls) {}
 
 public:
-    static void writeParquetInterval(common::interval_t input, uint8_t* result);
-
     void writeVector(common::Serializer& bufferedSerializer, ColumnWriterStatistics* state,
         ColumnWriterPageState* pageState, common::ValueVector* vector, uint64_t chunkStart,
         uint64_t chunkEnd) override;
 
     uint64_t getRowSize(common::ValueVector* /*vector*/, uint64_t /*index*/,
         BasicColumnWriterState& /*state*/) override {
-        return common::ParquetConstants::PARQUET_INTERVAL_SIZE;
+        return common::ParquetConstants::PARQUET_UUID_SIZE;
     }
 };
 

--- a/src/processor/operator/persistent/reader/parquet/CMakeLists.txt
+++ b/src/processor/operator/persistent/reader/parquet/CMakeLists.txt
@@ -7,7 +7,8 @@ add_library(kuzu_processor_operator_parquet_reader
         struct_column_reader.cpp
         string_column_reader.cpp
         list_column_reader.cpp
-        parquet_timestamp.cpp)
+        parquet_timestamp.cpp
+        uuid_column_reader.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_processor_operator_parquet_reader>

--- a/src/processor/operator/persistent/reader/parquet/column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/column_reader.cpp
@@ -15,6 +15,7 @@
 #include "processor/operator/persistent/reader/parquet/parquet_timestamp.h"
 #include "processor/operator/persistent/reader/parquet/string_column_reader.h"
 #include "processor/operator/persistent/reader/parquet/templated_column_reader.h"
+#include "processor/operator/persistent/reader/parquet/uuid_column_reader.h"
 #include "snappy/snappy.h"
 #include "zstd.h"
 
@@ -257,6 +258,9 @@ std::unique_ptr<ColumnReader> ColumnReader::createReader(ParquetReader& reader,
     case common::LogicalTypeID::TIMESTAMP:
         return createTimestampReader(reader, std::move(type), schema, fileIdx, maxDefine,
             maxRepeat);
+    case common::LogicalTypeID::UUID:
+        return std::make_unique<UUIDColumnReader>(reader, std::move(type), schema, fileIdx,
+            maxDefine, maxRepeat);
     // TODO(kebing): timestamp
     default:
         KU_UNREACHABLE;

--- a/src/processor/operator/persistent/reader/parquet/column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/column_reader.cpp
@@ -261,7 +261,6 @@ std::unique_ptr<ColumnReader> ColumnReader::createReader(ParquetReader& reader,
     case common::LogicalTypeID::UUID:
         return std::make_unique<UUIDColumnReader>(reader, std::move(type), schema, fileIdx,
             maxDefine, maxRepeat);
-    // TODO(kebing): timestamp
     default:
         KU_UNREACHABLE;
     }

--- a/src/processor/operator/persistent/reader/parquet/interval_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/interval_column_reader.cpp
@@ -21,12 +21,12 @@ common::interval_t IntervalValueConversion::plainRead(ByteBuffer& plainData,
     return res;
 }
 
-void IntervalColumnReader::dictionary(const std::shared_ptr<ResizeableBuffer>& dictionary_data,
-    uint64_t num_entries) {
-    allocateDict(num_entries * sizeof(common::interval_t));
+void IntervalColumnReader::dictionary(const std::shared_ptr<ResizeableBuffer>& dictionaryData,
+    uint64_t numEntries) {
+    allocateDict(numEntries * sizeof(common::interval_t));
     auto dict_ptr = reinterpret_cast<common::interval_t*>(this->dict->ptr);
-    for (auto i = 0u; i < num_entries; i++) {
-        dict_ptr[i] = IntervalValueConversion::plainRead(*dictionary_data, *this);
+    for (auto i = 0u; i < numEntries; i++) {
+        dict_ptr[i] = IntervalValueConversion::plainRead(*dictionaryData, *this);
     }
 }
 

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -385,6 +385,10 @@ LogicalType ParquetReader::deriveLogicalType(const kuzu_parquet::format::SchemaE
         throw CopyException("FIXED_LEN_BYTE_ARRAY requires length to be set");
         // LCOV_EXCL_STOP
     }
+    if (s_ele.__isset.logicalType && s_ele.logicalType.__isset.UUID &&
+        s_ele.type == Type::FIXED_LEN_BYTE_ARRAY) {
+        return LogicalType::UUID();
+    }
     if (s_ele.__isset.converted_type) {
         switch (s_ele.converted_type) {
         case ConvertedType::INT_8:
@@ -499,6 +503,7 @@ LogicalType ParquetReader::deriveLogicalType(const kuzu_parquet::format::SchemaE
                     "SERIAL converted type can only be set for value of Type::INT64"};
                 // LCOV_EXCL_STOP
             }
+
         default:
             // LCOV_EXCL_START
             throw CopyException{"Unsupported converted type"};

--- a/src/processor/operator/persistent/reader/parquet/uuid_column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/uuid_column_reader.cpp
@@ -1,0 +1,41 @@
+#include "processor/operator/persistent/reader/parquet/uuid_column_reader.h"
+
+namespace kuzu {
+namespace processor {
+
+common::ku_uuid_t UUIDValueConversion::ReadParquetUUID(const uint8_t* input) {
+    common::ku_uuid_t result;
+    result.value.low = 0;
+    uint64_t unsignedUpper = 0;
+    for (auto i = 0u; i < sizeof(uint64_t); i++) {
+        unsignedUpper <<= 8;
+        unsignedUpper += input[i];
+    }
+    for (auto i = sizeof(uint64_t); i < sizeof(common::ku_uuid_t); i++) {
+        result.value.low <<= 8;
+        result.value.low += input[i];
+    }
+    result.value.high = unsignedUpper;
+    result.value.high ^= (int64_t(1) << 63);
+    return result;
+}
+
+common::ku_uuid_t UUIDValueConversion::plainRead(ByteBuffer& bufferData, ColumnReader& /*reader*/) {
+    auto uuidLen = sizeof(common::ku_uuid_t);
+    bufferData.available(uuidLen);
+    auto res = ReadParquetUUID(reinterpret_cast<const uint8_t*>(bufferData.ptr));
+    bufferData.inc(uuidLen);
+    return res;
+}
+
+void UUIDColumnReader::dictionary(const std::shared_ptr<ResizeableBuffer>& dictionaryData,
+    uint64_t numEntries) {
+    allocateDict(numEntries * sizeof(common::ku_uuid_t));
+    auto dictPtr = reinterpret_cast<common::ku_uuid_t*>(this->dict->ptr);
+    for (auto i = 0u; i < numEntries; i++) {
+        dictPtr[i] = UUIDValueConversion::plainRead(*dictionaryData, *this);
+    }
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/operator/persistent/writer/parquet/CMakeLists.txt
+++ b/src/processor/operator/persistent/writer/parquet/CMakeLists.txt
@@ -8,7 +8,8 @@ add_library(kuzu_processor_operator_parquet_writer
         string_column_writer.cpp
         list_column_writer.cpp
         parquet_writer.cpp
-        parquet_rle_bp_encoder.cpp)
+        parquet_rle_bp_encoder.cpp
+        uuid_column_writer.cpp)
 
 set(ALL_OBJECT_FILES
         ${ALL_OBJECT_FILES} $<TARGET_OBJECTS:kuzu_processor_operator_parquet_writer>

--- a/src/processor/operator/persistent/writer/parquet/column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/column_writer.cpp
@@ -12,6 +12,7 @@
 #include "processor/operator/persistent/writer/parquet/standard_column_writer.h"
 #include "processor/operator/persistent/writer/parquet/string_column_writer.h"
 #include "processor/operator/persistent/writer/parquet/struct_column_writer.h"
+#include "processor/operator/persistent/writer/parquet/uuid_column_writer.h"
 #include "snappy/snappy.h"
 #include "zstd.h"
 
@@ -92,6 +93,7 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
             std::move(schemaPathToCreate), maxRepeatToCreate, maxDefineToCreate,
             std::move(childWriters), canHaveNullsToCreate);
     }
+    case LogicalTypeID::ARRAY:
     case LogicalTypeID::LIST: {
         const auto& childType = ListType::getChildType(type);
         // Set up the two schema elements for the list
@@ -255,6 +257,10 @@ std::unique_ptr<ColumnWriter> ColumnWriter::createWriterRecursive(
                 canHaveNullsToCreate, mm);
         case LogicalTypeID::INTERVAL:
             return std::make_unique<IntervalColumnWriter>(writer, schemaIdx,
+                std::move(schemaPathToCreate), maxRepeatToCreate, maxDefineToCreate,
+                canHaveNullsToCreate);
+        case LogicalTypeID::UUID:
+            return std::make_unique<UUIDColumnWriter>(writer, schemaIdx,
                 std::move(schemaPathToCreate), maxRepeatToCreate, maxDefineToCreate,
                 canHaveNullsToCreate);
         default:

--- a/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/parquet_writer.cpp
@@ -80,6 +80,7 @@ Type::type ParquetWriter::convertToParquetType(const LogicalType& type) {
     case LogicalTypeID::BLOB:
     case LogicalTypeID::STRING:
         return Type::BYTE_ARRAY;
+    case LogicalTypeID::UUID:
     case LogicalTypeID::INTERVAL:
         return Type::FIXED_LEN_BYTE_ARRAY;
     default:
@@ -160,6 +161,12 @@ void ParquetWriter::setSchemaProperties(const LogicalType& type, SchemaElement& 
     case LogicalTypeID::SERIAL: {
         schemaElement.converted_type = ConvertedType::SERIAL;
         schemaElement.__isset.converted_type = true;
+    } break;
+    case LogicalTypeID::UUID: {
+        schemaElement.type_length = common::ParquetConstants::PARQUET_UUID_SIZE;
+        schemaElement.__isset.type_length = true;
+        schemaElement.__isset.logicalType = true;
+        schemaElement.logicalType.__isset.UUID = true;
     } break;
     default:
         break;

--- a/src/processor/operator/persistent/writer/parquet/uuid_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/uuid_column_writer.cpp
@@ -2,7 +2,6 @@
 
 #include "common/serializer/serializer.h"
 #include "common/types/uuid.h"
-#include "processor/operator/persistent/reader/parquet/resizable_buffer.h"
 
 namespace kuzu {
 namespace processor {

--- a/src/processor/operator/persistent/writer/parquet/uuid_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/uuid_column_writer.cpp
@@ -1,6 +1,7 @@
 #include "processor/operator/persistent/writer/parquet/uuid_column_writer.h"
 
 #include "common/serializer/serializer.h"
+#include "common/types/uuid.h"
 #include "processor/operator/persistent/reader/parquet/resizable_buffer.h"
 
 namespace kuzu {

--- a/src/processor/operator/persistent/writer/parquet/uuid_column_writer.cpp
+++ b/src/processor/operator/persistent/writer/parquet/uuid_column_writer.cpp
@@ -1,0 +1,37 @@
+#include "processor/operator/persistent/writer/parquet/uuid_column_writer.h"
+
+#include "common/serializer/serializer.h"
+#include "processor/operator/persistent/reader/parquet/resizable_buffer.h"
+
+namespace kuzu {
+namespace processor {
+
+static void writeParquetUUID(common::ku_uuid_t input, uint8_t* result) {
+    uint64_t high_bytes = input.value.high ^ (int64_t(1) << 63);
+    uint64_t low_bytes = input.value.low;
+
+    for (auto i = 0u; i < sizeof(uint64_t); i++) {
+        auto shift_count = (sizeof(uint64_t) - i - 1) * 8;
+        result[i] = (high_bytes >> shift_count) & 0xFF;
+    }
+    for (auto i = 0u; i < sizeof(uint64_t); i++) {
+        auto shift_count = (sizeof(uint64_t) - i - 1) * 8;
+        result[sizeof(uint64_t) + i] = (low_bytes >> shift_count) & 0xFF;
+    }
+}
+
+void UUIDColumnWriter::writeVector(common::Serializer& bufferedSerializer,
+    ColumnWriterStatistics* /*state*/, ColumnWriterPageState* /*pageState*/,
+    common::ValueVector* vector, uint64_t chunkStart, uint64_t chunkEnd) {
+    uint8_t buffer[common::ParquetConstants::PARQUET_UUID_SIZE];
+    for (auto i = chunkStart; i < chunkEnd; i++) {
+        auto pos = getVectorPos(vector, i);
+        if (!vector->isNull(pos)) {
+            writeParquetUUID(vector->getValue<common::ku_uuid_t>(pos), buffer);
+            bufferedSerializer.write(buffer, common::ParquetConstants::PARQUET_UUID_SIZE);
+        }
+    }
+}
+
+} // namespace processor
+} // namespace kuzu

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -38,6 +38,10 @@ void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
 
 void ResultCollector::executeInternal(ExecutionContext* context) {
     while (children[0]->getNextTuple(context)) {
+        if (payloadVectors[0]->dataType.getLogicalTypeID() == LogicalTypeID::UNION) {
+            auto dateVector = UnionVector::getValVector(payloadVectors[0], 1);
+            auto a = 5;
+        }
         if (!payloadVectors.empty()) {
             for (auto i = 0u; i < resultSet->multiplicity; i++) {
                 localTable->append(payloadAndMarkVectors);

--- a/src/processor/operator/result_collector.cpp
+++ b/src/processor/operator/result_collector.cpp
@@ -38,10 +38,6 @@ void ResultCollector::initLocalStateInternal(ResultSet* resultSet, ExecutionCont
 
 void ResultCollector::executeInternal(ExecutionContext* context) {
     while (children[0]->getNextTuple(context)) {
-        if (payloadVectors[0]->dataType.getLogicalTypeID() == LogicalTypeID::UNION) {
-            auto dateVector = UnionVector::getValVector(payloadVectors[0], 1);
-            auto a = 5;
-        }
         if (!payloadVectors.empty()) {
             for (auto i = 0u; i < resultSet->multiplicity; i++) {
                 localTable->append(payloadAndMarkVectors);

--- a/test/test_files/copy/copy_to_parquet.test
+++ b/test/test_files/copy/copy_to_parquet.test
@@ -4,36 +4,36 @@
 
 -CASE TinySnbCopyToParquet
 
--STATEMENT COPY (MATCH (p:person) return p.ID, p.fName, p.gender, p.isStudent, p.isWorker, p.age, p.eyeSight, p.birthdate, p.registerTime, p.lastJobDuration, p.workedHours, p.usedNames, p.courseScoresPerTerm, p.height) to '${DATABASE_PATH}/tinysnb.parquet';
+-STATEMENT COPY (MATCH (p:person) return p.*) to '${DATABASE_PATH}/tinysnb.parquet';
 ---- ok
 -STATEMENT LOAD FROM '${DATABASE_PATH}/tinysnb.parquet' RETURN *;
 ---- 8
-0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|1.731000
-2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00|[12,8]|[Bobby]|[[8,9],[9,10]]|0.990000
-3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|1.000000
-5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|1.300000
-7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|1.463000
-8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|1.510000
-9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 04:41:42|10 years 5 months 13:00:00|[1]|[Grad]|[[10]]|1.600000
-10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|1.323000
+0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|[96,54,86,92]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
+2|Bob|2|True|False|30|5.100000|1900-01-01|2008-11-03 15:25:30.000526|10 years 5 months 13:00:00|[12,8]|[Bobby]|[[8,9],[9,10]]|[98,42,93,88]|0.990000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a12
+3|Carol|1|False|True|45|5.000000|1940-06-22|1911-08-20 02:32:21|48:24:11|[4,5]|[Carmen,Fred]|[[8,10]]|[91,75,21,95]|1.000000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a13
+5|Dan|2|False|True|20|4.800000|1950-07-23|2031-11-30 12:25:30|10 years 5 months 13:00:00|[1,9]|[Wolfeschlegelstein,Daniel]|[[7,4],[8,8],[9]]|[76,88,99,89]|1.300000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a14
+7|Elizabeth|1|False|True|20|4.700000|1980-10-26|1976-12-23 11:21:42|48:24:11|[2]|[Ein]|[[6],[7],[8]]|[96,59,65,88]|1.463000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15
+8|Farooq|2|True|False|25|4.500000|1980-10-26|1972-07-31 13:22:30.678559|00:18:00.024|[3,4,5,6,7]|[Fesdwe]|[[8]]|[80,78,34,83]|1.510000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a16
+9|Greg|2|False|False|40|4.900000|1980-10-26|1976-12-23 04:41:42|10 years 5 months 13:00:00|[1]|[Grad]|[[10]]|[43,83,67,43]|1.600000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a17
+10|Hubert Blaine Wolfeschlegelsteinhausenbergerdorff|2|False|True|83|4.900000|1990-11-27|2023-02-21 13:25:30|3 years 2 days 13:02:00|[10,11,12,3,4,5,6,7]|[Ad,De,Hi,Kye,Orlan]|[[7],[10],[6,7]]|[77,64,100,54]|1.323000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a18
 
 -LOG CopyOrganisationToParquet
--STATEMENT COPY (MATCH (o:organisation) RETURN o.ID, o.state) TO "${DATABASE_PATH}/organisation.parquet" (compression='UNCOMPRESSED')
+-STATEMENT COPY (MATCH (o:organisation) RETURN o.*) TO "${DATABASE_PATH}/organisation.parquet" (compression='UNCOMPRESSED')
 ---- ok
 -STATEMENT LOAD FROM "${DATABASE_PATH}/organisation.parquet" RETURN *;
 ---- 3
-1|{revenue: 138, location: ['toronto','montr,eal'], stock: {price: [96,56], volume: 1000}}
-4|{revenue: 152, location: ["vanco,uver north area"], stock: {price: [15,78,671], volume: 432}}
-6|{revenue: 558, location: ['very long city name','new york'], stock: {price: [22], volume: 99}}
+1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000|{revenue: 138, location: ['toronto','montr,eal'], stock: {price: [96,56], volume: 1000}}|{tag: 0, price: 3.120000, movein: , note: }
+4|CsWork|934|4.100000|-100|2 years 4 days 10 hours|26 years 52 days 48:00:00|0.780000|{revenue: 152, location: ["vanco,uver north area"], stock: {price: [15,78,671], volume: 432}}|{tag: 2, price: , movein: , note: abcd}
+6|DEsWork|824|4.100000|7|2 years 4 hours 22 us 34 minutes|82:00:00.1|0.520000|{revenue: 558, location: ['very long city name','new york'], stock: {price: [22], volume: 99}}|{tag: 1, price: , movein: 2023-12-15, note: }
 
 -LOG CopyMoviesToParquet
 -STATEMENT COPY (MATCH (m:movies) RETURN m.*) TO "${DATABASE_PATH}/movies.parquet" (compression='snappy')
 ---- ok
 -STATEMENT LOAD FROM "${DATABASE_PATH}/movies.parquet" RETURN *;
 ---- 3
-Sóló cón tu párejâ|126| this is a very very good movie|{rating: 5.300000, stars: 2, views: 152, release: 2011-08-20 11:25:30, release_ns: 2011-08-20 11:25:30.123456, release_ms: 2011-08-20 11:25:30.123, release_sec: 2011-08-20 11:25:30, release_tz: 2011-08-20 11:25:30.123456, film: 2012-05-11, u8: 220, u16: 20, u32: 1, u64: 180, hugedata: 1844674407370955161600000000.000000}|\xAA\xABinteresting\x0B|{audience1=52, audience53=42}|{tag: 0, credit: True, grade1: 0.000000, grade2: 0}
-The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie|2544| the movie is very very good|{rating: 7.000000, stars: 10, views: 982, release: 2018-11-13 13:33:11, release_ns: 2018-11-13 13:33:11.123456, release_ms: 2018-11-13 13:33:11.123, release_sec: 2018-11-13 13:33:11, release_tz: 2018-11-13 13:33:11.123456, film: 2014-09-12, u8: 12, u16: 120, u32: 55, u64: 1, hugedata: -1844674407370955161600.000000}|\xAB\xCD|{audience1=33}|{tag: 1, credit: , grade1: 8.989000, grade2: 0}
-Roma|298|the movie is very interesting and funny|{rating: 1223.000000, stars: 100, views: 10003, release: 2011-02-11 16:44:22, release_ns: 2011-02-11 16:44:22.123456, release_ms: 2011-02-11 16:44:22.123, release_sec: 2011-02-11 16:44:22, release_tz: 2011-02-11 16:44:22.123456, film: 2013-02-22, u8: 1, u16: 15, u32: 200, u64: 4, hugedata: -15.000000}|pure ascii characters|{}|{tag: 1, credit: , grade1: 254.000000, grade2: 0}
+Sóló cón tu párejâ|126| this is a very very good movie|{rating: 5.300000, stars: 2, views: 152, release: 2011-08-20 11:25:30, release_ns: 2011-08-20 11:25:30.123456, release_ms: 2011-08-20 11:25:30.123, release_sec: 2011-08-20 11:25:30, release_tz: 2011-08-20 11:25:30.123456, film: 2012-05-11, u8: 220, u16: 20, u32: 1, u64: 180, hugedata: 1844674407370955161600000000.000000}|\xAA\xABinteresting\x0B|{audience1=52, audience53=42}|{tag: 0, credit: True, grade1: , grade2: }
+The 😂😃🧘🏻‍♂️🌍🌦️🍞🚗 movie|2544| the movie is very very good|{rating: 7.000000, stars: 10, views: 982, release: 2018-11-13 13:33:11, release_ns: 2018-11-13 13:33:11.123456, release_ms: 2018-11-13 13:33:11.123, release_sec: 2018-11-13 13:33:11, release_tz: 2018-11-13 13:33:11.123456, film: 2014-09-12, u8: 12, u16: 120, u32: 55, u64: 1, hugedata: -1844674407370955161600.000000}|\xAB\xCD|{audience1=33}|{tag: 1, credit: , grade1: 8.989000, grade2: }
+Roma|298|the movie is very interesting and funny|{rating: 1223.000000, stars: 100, views: 10003, release: 2011-02-11 16:44:22, release_ns: 2011-02-11 16:44:22.123456, release_ms: 2011-02-11 16:44:22.123, release_sec: 2011-02-11 16:44:22, release_tz: 2011-02-11 16:44:22.123456, film: 2013-02-22, u8: 1, u16: 15, u32: 200, u64: 4, hugedata: -15.000000}|pure ascii characters|{}|{tag: 1, credit: , grade1: 254.000000, grade2: }
 
 -LOG CopyStudyAtToParquet
 -STATEMENT COPY (match (:person)-[s:studyAt]->(:organisation) return s.*) to "${DATABASE_PATH}/studyAt.parquet" (compression='zstd')


### PR DESCRIPTION
# Description

Add missing datatypes to parquet writer: UUID, UNION, ARRAY.