### PR TITLE
In memory mode

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -771,6 +771,51 @@ jobs:
           ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
           make test
 
+  clang-in-mem-build-test:
+    name: clang in-mem build and test
+    needs: [clang-build-test]
+    runs-on: kuzu-self-hosted-testing
+    env:
+      NUM_THREADS: 32
+      CMAKE_BUILD_PARALLEL_LEVEL: 32
+      TEST_JOBS: 16
+      CC: clang
+      CXX: clang++
+      UW_S3_ACCESS_KEY_ID: ${{ secrets.UW_S3_ACCESS_KEY_ID }}
+      UW_S3_SECRET_ACCESS_KEY: ${{ secrets.UW_S3_SECRET_ACCESS_KEY }}
+      AWS_S3_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+      AWS_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
+      RUN_ID: "$(hostname)-$(date +%s)"
+      HTTP_CACHE_FILE: TRUE
+      IN_MEM_MODE: true
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download binary-demo
+        uses: actions/download-artifact@v4
+        with:
+          name: binary-demo
+          path: dataset/binary-demo
+
+      - name: Ensure Python dependencies
+        run: |
+          pip install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
+          pip install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
+
+      - name: Ensure Node.js dependencies
+        run: npm install --include=dev
+        working-directory: tools/nodejs_api
+
+      - name: Build
+        run: make all
+
+      - name: Test
+        run: |
+          ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
+          make test
+
   shell-test:
     name: shell test
     runs-on: ubuntu-latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.5.1.2")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.5.1.3")
 
 include_directories(src/include)
 

--- a/extension/httpfs/src/http_config.cpp
+++ b/extension/httpfs/src/http_config.cpp
@@ -1,25 +1,30 @@
 #include "http_config.h"
 
 #include "function/cast/functions/cast_from_string_functions.h"
+#include "main/db_config.h"
 
 namespace kuzu {
 namespace httpfs {
 
 HTTPConfig::HTTPConfig(main::ClientContext* context) {
     KU_ASSERT(context != nullptr);
-    cacheFile = context->getCurrentSetting(HTTPCacheInMemoryConfig::HTTP_CACHE_FILE_OPTION)
-                    .getValue<bool>();
+    cacheFile =
+        context->getCurrentSetting(HTTPCacheFileConfig::HTTP_CACHE_FILE_OPTION).getValue<bool>();
 }
 
 void HTTPConfigEnvProvider::setOptionValue(main::ClientContext* context) {
-    auto cacheInMemoryStrVal =
-        context->getEnvVariable(HTTPCacheInMemoryConfig::HTTP_CACHE_FILE_ENV_VAR);
-    if (cacheInMemoryStrVal != "") {
-        bool cacheInMemory;
+    const auto cacheFileOptionStrVal =
+        context->getEnvVariable(HTTPCacheFileConfig::HTTP_CACHE_FILE_ENV_VAR);
+    if (cacheFileOptionStrVal != "") {
+        bool enableCacheFile;
         function::CastString::operation(
-            ku_string_t{cacheInMemoryStrVal.c_str(), cacheInMemoryStrVal.length()}, cacheInMemory);
-        context->setExtensionOption(HTTPCacheInMemoryConfig::HTTP_CACHE_FILE_OPTION,
-            Value::createValue(cacheInMemory));
+            ku_string_t{cacheFileOptionStrVal.c_str(), cacheFileOptionStrVal.length()},
+            enableCacheFile);
+        if (enableCacheFile && main::DBConfig::isDBPathInMemory(context->getDatabasePath())) {
+            throw Exception("Cannot enable HTTP file cache when database is in memory");
+        }
+        context->setExtensionOption(HTTPCacheFileConfig::HTTP_CACHE_FILE_OPTION,
+            Value::createValue(enableCacheFile));
     }
 }
 

--- a/extension/httpfs/src/httpfs_extension.cpp
+++ b/extension/httpfs/src/httpfs_extension.cpp
@@ -26,8 +26,8 @@ void HttpfsExtension::load(main::ClientContext* context) {
         common::Value{(int64_t)10000});
     db->addExtensionOption("s3_uploader_threads_limit", common::LogicalTypeID::INT64,
         common::Value{(int64_t)50});
-    db->addExtensionOption(HTTPCacheInMemoryConfig::HTTP_CACHE_FILE_OPTION,
-        common::LogicalTypeID::BOOL, common::Value{HTTPCacheInMemoryConfig::DEFAULT_CACHE_FILE});
+    db->addExtensionOption(HTTPCacheFileConfig::HTTP_CACHE_FILE_OPTION, common::LogicalTypeID::BOOL,
+        common::Value{HTTPCacheFileConfig::DEFAULT_CACHE_FILE});
     AWSEnvironmentCredentialsProvider::setOptionValue(context);
     HTTPConfigEnvProvider::setOptionValue(context);
 }

--- a/extension/httpfs/src/include/http_config.h
+++ b/extension/httpfs/src/include/http_config.h
@@ -11,7 +11,7 @@ struct HTTPConfig {
     bool cacheFile;
 };
 
-struct HTTPCacheInMemoryConfig {
+struct HTTPCacheFileConfig {
     static constexpr const char* HTTP_CACHE_FILE_ENV_VAR = "HTTP_CACHE_FILE";
     static constexpr const char* HTTP_CACHE_FILE_OPTION = "http_cache_file";
     static constexpr bool DEFAULT_CACHE_FILE = false;

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -24,7 +24,6 @@
 #include "function/built_in_function_utils.h"
 #include "storage/storage_utils.h"
 #include "storage/storage_version_info.h"
-#include "storage/wal/wal.h"
 #include "transaction/transaction.h"
 
 using namespace kuzu::binder;
@@ -52,7 +51,9 @@ Catalog::Catalog(std::string directory, VirtualFileSystem* fs) {
         sequences = std::make_unique<CatalogSet>();
         functions = std::make_unique<CatalogSet>();
         types = std::make_unique<CatalogSet>();
-        // saveToFile(directory, fs, FileVersionType::ORIGINAL);
+        if (!directory.empty()) {
+            saveToFile(directory, fs, FileVersionType::ORIGINAL);
+        }
     }
     registerBuiltInFunctions();
 }

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -44,15 +44,15 @@ Catalog::Catalog() {
 }
 
 Catalog::Catalog(std::string directory, VirtualFileSystem* fs) {
-    if (fs->fileOrPathExists(
-            StorageUtils::getCatalogFilePath(fs, directory, FileVersionType::ORIGINAL))) {
+    if (!directory.empty() && fs->fileOrPathExists(StorageUtils::getCatalogFilePath(fs, directory,
+                                  FileVersionType::ORIGINAL))) {
         readFromFile(directory, fs, FileVersionType::ORIGINAL);
     } else {
         tables = std::make_unique<CatalogSet>();
         sequences = std::make_unique<CatalogSet>();
         functions = std::make_unique<CatalogSet>();
         types = std::make_unique<CatalogSet>();
-        saveToFile(directory, fs, FileVersionType::ORIGINAL);
+        // saveToFile(directory, fs, FileVersionType::ORIGINAL);
     }
     registerBuiltInFunctions();
 }
@@ -222,12 +222,12 @@ table_id_t Catalog::createTableSchema(Transaction* transaction, const BoundCreat
     return tableID;
 }
 
-void Catalog::dropTableEntry(transaction::Transaction* tx, std::string name) {
+void Catalog::dropTableEntry(Transaction* tx, std::string name) {
     auto tableID = getTableID(tx, name);
     dropTableEntry(tx, tableID);
 }
 
-void Catalog::dropTableEntry(transaction::Transaction* tx, common::table_id_t tableID) {
+void Catalog::dropTableEntry(Transaction* tx, table_id_t tableID) {
     auto tableEntry = getTableCatalogEntry(tx, tableID);
     switch (tableEntry->getType()) {
     case CatalogEntryType::REL_GROUP_ENTRY: {
@@ -260,7 +260,7 @@ void Catalog::dropTableEntry(transaction::Transaction* tx, common::table_id_t ta
     tables->dropEntry(tx, tableEntry->getName());
 }
 
-void Catalog::alterTableEntry(transaction::Transaction* tx, const binder::BoundAlterInfo& info) {
+void Catalog::alterTableEntry(Transaction* tx, const BoundAlterInfo& info) {
     auto tableEntry = getTableCatalogEntry(tx, info.tableID);
     KU_ASSERT(tableEntry);
     if (tableEntry->getType() == CatalogEntryType::RDF_GRAPH_ENTRY &&
@@ -316,7 +316,7 @@ void Catalog::dropSequence(Transaction* transaction, std::string name) {
     dropSequence(transaction, sequenceID);
 }
 
-void Catalog::dropSequence(Transaction* transaction, common::sequence_id_t sequenceID) {
+void Catalog::dropSequence(Transaction* transaction, sequence_id_t sequenceID) {
     auto sequenceEntry = getSequenceCatalogEntry(transaction, sequenceID);
     sequences->dropEntry(transaction, sequenceEntry->getName());
 }
@@ -420,6 +420,7 @@ std::vector<std::string> Catalog::getMacroNames(Transaction* transaction) const 
 }
 
 void Catalog::checkpoint(const std::string& databasePath, VirtualFileSystem* fs) const {
+    KU_ASSERT(!databasePath.empty());
     saveToFile(databasePath, fs, FileVersionType::WAL_VERSION);
 }
 
@@ -456,6 +457,7 @@ static void writeMagicBytes(Serializer& serializer) {
 
 void Catalog::saveToFile(const std::string& directory, VirtualFileSystem* fs,
     FileVersionType versionType) const {
+    KU_ASSERT(!directory.empty());
     const auto catalogPath = StorageUtils::getCatalogFilePath(fs, directory, versionType);
     const auto catalogFile = fs->openFile(catalogPath, O_WRONLY | O_CREAT);
     Serializer serializer(std::make_unique<BufferedFileWriter>(*catalogFile));
@@ -469,6 +471,7 @@ void Catalog::saveToFile(const std::string& directory, VirtualFileSystem* fs,
 
 void Catalog::readFromFile(const std::string& directory, VirtualFileSystem* fs,
     FileVersionType versionType, main::ClientContext* context) {
+    KU_ASSERT(!directory.empty());
     const auto catalogPath = StorageUtils::getCatalogFilePath(fs, directory, versionType);
     Deserializer deserializer(
         std::make_unique<BufferedFileReader>(fs->openFile(catalogPath, O_RDONLY, context)));
@@ -529,7 +532,7 @@ void Catalog::alterRdfChildTableEntries(Transaction* transaction, CatalogEntry* 
 }
 
 std::unique_ptr<CatalogEntry> Catalog::createNodeTableEntry(Transaction*, table_id_t tableID,
-    const binder::BoundCreateTableInfo& info) const {
+    const BoundCreateTableInfo& info) const {
     auto extraInfo = info.extraInfo->constPtrCast<BoundExtraCreateNodeTableInfo>();
     auto nodeTableEntry = std::make_unique<NodeTableCatalogEntry>(tables.get(), info.tableName,
         tableID, extraInfo->primaryKeyIdx);
@@ -542,7 +545,7 @@ std::unique_ptr<CatalogEntry> Catalog::createNodeTableEntry(Transaction*, table_
 }
 
 std::unique_ptr<CatalogEntry> Catalog::createRelTableEntry(Transaction*, table_id_t tableID,
-    const binder::BoundCreateTableInfo& info) const {
+    const BoundCreateTableInfo& info) const {
     auto extraInfo = info.extraInfo.get()->constPtrCast<BoundExtraCreateRelTableInfo>();
     auto relTableEntry = std::make_unique<RelTableCatalogEntry>(tables.get(), info.tableName,
         tableID, extraInfo->srcMultiplicity, extraInfo->dstMultiplicity, extraInfo->srcTableID,
@@ -556,7 +559,7 @@ std::unique_ptr<CatalogEntry> Catalog::createRelTableEntry(Transaction*, table_i
 }
 
 std::unique_ptr<CatalogEntry> Catalog::createRelTableGroupEntry(Transaction* transaction,
-    table_id_t tableID, const binder::BoundCreateTableInfo& info) {
+    table_id_t tableID, const BoundCreateTableInfo& info) {
     auto extraInfo =
         ku_dynamic_cast<BoundExtraCreateCatalogEntryInfo*, BoundExtraCreateRelTableGroupInfo*>(
             info.extraInfo.get());
@@ -571,7 +574,7 @@ std::unique_ptr<CatalogEntry> Catalog::createRelTableGroupEntry(Transaction* tra
 }
 
 std::unique_ptr<CatalogEntry> Catalog::createRdfGraphEntry(Transaction* transaction,
-    table_id_t tableID, const binder::BoundCreateTableInfo& info) {
+    table_id_t tableID, const BoundCreateTableInfo& info) {
     auto extraInfo =
         ku_dynamic_cast<BoundExtraCreateCatalogEntryInfo*, BoundExtraCreateRdfGraphInfo*>(
             info.extraInfo.get());

--- a/src/common/serializer/buffered_file.cpp
+++ b/src/common/serializer/buffered_file.cpp
@@ -53,7 +53,6 @@ void BufferedFileWriter::sync() {
     fileInfo.syncFile();
 }
 
-
 uint64_t BufferedFileWriter::getFileSize() const {
     return fileInfo.getFileSize() + bufferOffset;
 }

--- a/src/common/serializer/buffered_file.cpp
+++ b/src/common/serializer/buffered_file.cpp
@@ -49,6 +49,11 @@ void BufferedFileWriter::flush() {
     memset(buffer.get(), 0, BUFFER_SIZE);
 }
 
+void BufferedFileWriter::sync() {
+    fileInfo.syncFile();
+}
+
+
 uint64_t BufferedFileWriter::getFileSize() const {
     return fileInfo.getFileSize() + bufferOffset;
 }

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -5,6 +5,10 @@
 #include "common/cast.h"
 #include "function/function.h"
 
+namespace kuzu::main {
+struct DBConfig;
+} // namespace kuzu::main
+
 namespace kuzu {
 namespace main {
 class AttachedKuzuDatabase;
@@ -47,39 +51,45 @@ class KUZU_API Catalog {
 public:
     // This is extended by DuckCatalog and PostgresCatalog.
     Catalog();
-    Catalog(std::string directory, common::VirtualFileSystem* vfs);
+    Catalog(const std::string& directory, common::VirtualFileSystem* vfs);
     virtual ~Catalog() = default;
 
     // ----------------------------- Table Schemas ----------------------------
-    bool containsTable(transaction::Transaction* tx, const std::string& tableName) const;
+    bool containsTable(transaction::Transaction* transaction, const std::string& tableName) const;
 
-    common::table_id_t getTableID(transaction::Transaction* tx, const std::string& tableName) const;
-    std::vector<common::table_id_t> getNodeTableIDs(transaction::Transaction* tx) const;
-    std::vector<common::table_id_t> getRelTableIDs(transaction::Transaction* tx) const;
+    common::table_id_t getTableID(transaction::Transaction* transaction,
+        const std::string& tableName) const;
+    std::vector<common::table_id_t> getNodeTableIDs(transaction::Transaction* transaction) const;
+    std::vector<common::table_id_t> getRelTableIDs(transaction::Transaction* transaction) const;
 
     // TODO: Should remove this.
-    std::string getTableName(transaction::Transaction* tx, common::table_id_t tableID) const;
-    TableCatalogEntry* getTableCatalogEntry(transaction::Transaction* tx,
+    std::string getTableName(transaction::Transaction* transaction,
         common::table_id_t tableID) const;
-    std::vector<NodeTableCatalogEntry*> getNodeTableEntries(transaction::Transaction* tx) const;
-    std::vector<RelTableCatalogEntry*> getRelTableEntries(transaction::Transaction* tx) const;
-    std::vector<RelGroupCatalogEntry*> getRelTableGroupEntries(transaction::Transaction* tx) const;
-    std::vector<RDFGraphCatalogEntry*> getRdfGraphEntries(transaction::Transaction* tx) const;
-    std::vector<TableCatalogEntry*> getTableEntries(transaction::Transaction* tx) const;
-    std::vector<TableCatalogEntry*> getTableEntries(transaction::Transaction* tx,
+    TableCatalogEntry* getTableCatalogEntry(transaction::Transaction* transaction,
+        common::table_id_t tableID) const;
+    std::vector<NodeTableCatalogEntry*> getNodeTableEntries(
+        transaction::Transaction* transaction) const;
+    std::vector<RelTableCatalogEntry*> getRelTableEntries(
+        transaction::Transaction* transaction) const;
+    std::vector<RelGroupCatalogEntry*> getRelTableGroupEntries(
+        transaction::Transaction* transaction) const;
+    std::vector<RDFGraphCatalogEntry*> getRdfGraphEntries(
+        transaction::Transaction* transaction) const;
+    std::vector<TableCatalogEntry*> getTableEntries(transaction::Transaction* transaction) const;
+    std::vector<TableCatalogEntry*> getTableEntries(transaction::Transaction* transaction,
         const common::table_id_vector_t& tableIDs) const;
-    bool tableInRDFGraph(transaction::Transaction* tx, common::table_id_t tableID) const;
-    bool tableInRelGroup(transaction::Transaction* tx, common::table_id_t tableID) const;
-    common::table_id_set_t getFwdRelTableIDs(transaction::Transaction* tx,
+    bool tableInRDFGraph(transaction::Transaction* transaction, common::table_id_t tableID) const;
+    bool tableInRelGroup(transaction::Transaction* transaction, common::table_id_t tableID) const;
+    common::table_id_set_t getFwdRelTableIDs(transaction::Transaction* transaction,
         common::table_id_t nodeTableID) const;
-    common::table_id_set_t getBwdRelTableIDs(transaction::Transaction* tx,
+    common::table_id_set_t getBwdRelTableIDs(transaction::Transaction* transaction,
         common::table_id_t nodeTableID) const;
 
-    common::table_id_t createTableSchema(transaction::Transaction* tx,
+    common::table_id_t createTableSchema(transaction::Transaction* transaction,
         const binder::BoundCreateTableInfo& info);
-    void dropTableEntry(transaction::Transaction* tx, std::string name);
-    void dropTableEntry(transaction::Transaction* tx, common::table_id_t tableID);
-    void alterTableEntry(transaction::Transaction* tx, const binder::BoundAlterInfo& info);
+    void dropTableEntry(transaction::Transaction* transaction, std::string name);
+    void dropTableEntry(transaction::Transaction* transaction, common::table_id_t tableID);
+    void alterTableEntry(transaction::Transaction* transaction, const binder::BoundAlterInfo& info);
 
     // ----------------------------- Sequences ----------------------------
     bool containsSequence(transaction::Transaction* transaction,
@@ -87,14 +97,15 @@ public:
 
     common::sequence_id_t getSequenceID(transaction::Transaction* transaction,
         const std::string& sequenceName) const;
-    SequenceCatalogEntry* getSequenceCatalogEntry(transaction::Transaction* tx,
+    SequenceCatalogEntry* getSequenceCatalogEntry(transaction::Transaction* transaction,
         common::sequence_id_t sequenceID) const;
-    std::vector<SequenceCatalogEntry*> getSequenceEntries(transaction::Transaction* tx) const;
+    std::vector<SequenceCatalogEntry*> getSequenceEntries(
+        transaction::Transaction* transaction) const;
 
-    common::sequence_id_t createSequence(transaction::Transaction* tx,
+    common::sequence_id_t createSequence(transaction::Transaction* transaction,
         const binder::BoundCreateSequenceInfo& info);
-    void dropSequence(transaction::Transaction* tx, std::string name);
-    void dropSequence(transaction::Transaction* tx, common::sequence_id_t sequenceID);
+    void dropSequence(transaction::Transaction* transaction, std::string name);
+    void dropSequence(transaction::Transaction* transaction, common::sequence_id_t sequenceID);
 
     static std::string genSerialName(const std::string& tableName, const std::string& propertyName);
 
@@ -105,21 +116,22 @@ public:
     bool containsType(transaction::Transaction* transaction, const std::string& typeName);
 
     // ----------------------------- Functions ----------------------------
-    void addFunction(transaction::Transaction* tx, CatalogEntryType entryType, std::string name,
-        function::function_set functionSet);
-    void dropFunction(transaction::Transaction* tx, const std::string& name);
+    void addFunction(transaction::Transaction* transaction, CatalogEntryType entryType,
+        std::string name, function::function_set functionSet);
+    void dropFunction(transaction::Transaction* transaction, const std::string& name);
     void addBuiltInFunction(CatalogEntryType entryType, std::string name,
         function::function_set functionSet);
-    CatalogSet* getFunctions(transaction::Transaction* tx) const;
-    CatalogEntry* getFunctionEntry(transaction::Transaction* tx, const std::string& name);
-    std::vector<FunctionCatalogEntry*> getFunctionEntries(transaction::Transaction* tx) const;
+    CatalogSet* getFunctions(transaction::Transaction* transaction) const;
+    CatalogEntry* getFunctionEntry(transaction::Transaction* transaction, const std::string& name);
+    std::vector<FunctionCatalogEntry*> getFunctionEntries(
+        transaction::Transaction* transaction) const;
 
-    bool containsMacro(transaction::Transaction* tx, const std::string& macroName) const;
-    void addScalarMacroFunction(transaction::Transaction* tx, std::string name,
+    bool containsMacro(transaction::Transaction* transaction, const std::string& macroName) const;
+    void addScalarMacroFunction(transaction::Transaction* transaction, std::string name,
         std::unique_ptr<function::ScalarMacroFunction> macro);
-    function::ScalarMacroFunction* getScalarMacroFunction(transaction::Transaction* tx,
+    function::ScalarMacroFunction* getScalarMacroFunction(transaction::Transaction* transaction,
         const std::string& name) const;
-    std::vector<std::string> getMacroNames(transaction::Transaction* tx) const;
+    std::vector<std::string> getMacroNames(transaction::Transaction* transaction) const;
 
     void checkpoint(const std::string& databasePath, common::VirtualFileSystem* fs) const;
 

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -82,9 +82,10 @@ public:
     void alterTableEntry(transaction::Transaction* tx, const binder::BoundAlterInfo& info);
 
     // ----------------------------- Sequences ----------------------------
-    bool containsSequence(transaction::Transaction* tx, const std::string& sequenceName) const;
+    bool containsSequence(transaction::Transaction* transaction,
+        const std::string& sequenceName) const;
 
-    common::sequence_id_t getSequenceID(transaction::Transaction* tx,
+    common::sequence_id_t getSequenceID(transaction::Transaction* transaction,
         const std::string& sequenceName) const;
     SequenceCatalogEntry* getSequenceCatalogEntry(transaction::Transaction* tx,
         common::sequence_id_t sequenceID) const;

--- a/src/include/common/serializer/buffered_file.h
+++ b/src/include/common/serializer/buffered_file.h
@@ -19,6 +19,7 @@ public:
     void write(const uint8_t* data, uint64_t size) override;
 
     void flush();
+    void sync();
 
     // Note: this function is reseting next file offset to be written. Make sure buffer is empty.
     void setFileOffset(uint64_t fileOffset) {

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -31,7 +31,7 @@ struct ExtensionOptions;
 }
 
 namespace main {
-class DBConfig;
+struct DBConfig;
 class Database;
 class DatabaseManager;
 class AttachedKuzuDatabase;
@@ -63,7 +63,7 @@ public:
     const DBConfig* getDBConfig() const { return &dbConfig; }
     DBConfig* getDBConfigUnsafe() { return &dbConfig; }
     common::Value getCurrentSetting(const std::string& optionName);
-    bool isOptionSet(const std::string& name) const;
+    bool isOptionSet(const std::string& optionName) const;
     // Timer and timeout
     void interrupt() { activeQuery.interrupted = true; }
     bool interrupted() const { return activeQuery.interrupted; }

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -2,7 +2,6 @@
 
 #include <memory>
 #include <mutex>
-#include <string>
 #include <vector>
 
 #include "common/api.h"
@@ -124,7 +123,7 @@ public:
 
     KUZU_API catalog::Catalog* getCatalog() { return catalog.get(); }
 
-    ExtensionOption* getExtensionOption(std::string name);
+    ExtensionOption* getExtensionOption(std::string name) const;
 
     const DBConfig& getConfig() const { return dbConfig; }
 
@@ -134,6 +133,11 @@ public:
     uint64_t getNextQueryID();
 
 private:
+    struct QueryIDGenerator {
+        uint64_t queryID = 0;
+        std::mutex queryIDLock;
+    };
+
     void openLockFile();
     void initAndLockDBDir();
 
@@ -151,10 +155,7 @@ private:
     std::unique_ptr<extension::ExtensionOptions> extensionOptions;
     std::unique_ptr<DatabaseManager> databaseManager;
     common::case_insensitive_map_t<std::unique_ptr<storage::StorageExtension>> storageExtensions;
-    struct QueryIDGenerator {
-        uint64_t queryID = 0;
-        std::mutex queryIDLock;
-    } queryIDGenerator;
+    QueryIDGenerator queryIDGenerator;
 };
 
 } // namespace main

--- a/src/include/main/database.h
+++ b/src/include/main/database.h
@@ -101,13 +101,6 @@ public:
      */
     KUZU_API ~Database();
 
-    /**
-     * @brief Sets the logging level of the database instance.
-     * @param loggingLevel New logging level. (Supported logging levels are: "info", "debug",
-     * "err").
-     */
-    KUZU_API static void setLoggingLevel(std::string loggingLevel);
-
     // TODO(Ziyi): Instead of exposing a dedicated API for adding a new function, we should consider
     // add function through the extension module.
     void addTableFunction(std::string name,

--- a/src/include/main/db_config.h
+++ b/src/include/main/db_config.h
@@ -64,7 +64,7 @@ struct DBConfig {
     explicit DBConfig(const SystemConfig& systemConfig);
 
     static ConfigurationOption* getOptionByName(const std::string& optionName);
-    static bool isDBPathInMemory(const std::string& dbPath);
+    KUZU_API static bool isDBPathInMemory(const std::string& dbPath);
 };
 
 } // namespace main

--- a/src/include/main/db_config.h
+++ b/src/include/main/db_config.h
@@ -50,21 +50,21 @@ struct ExtensionOption final : Option {
           defaultValue{std::move(defaultValue)} {}
 };
 
-class DBConfig {
-public:
-    static ConfigurationOption* getOptionByName(const std::string& optionName);
-
-    explicit DBConfig(const SystemConfig& systemConfig);
-
+struct DBConfig {
     uint64_t bufferPoolSize;
     uint64_t maxNumThreads;
     bool enableCompression;
     bool readOnly;
     uint64_t maxDBSize;
-    bool enableMultiWrites = false;
+    bool enableMultiWrites;
     bool autoCheckpoint;
     uint64_t checkpointThreshold;
     bool forceCheckpointOnClose;
+
+    explicit DBConfig(const SystemConfig& systemConfig);
+
+    static ConfigurationOption* getOptionByName(const std::string& optionName);
+    static bool isDBPathInMemory(const std::string& dbPath);
 };
 
 } // namespace main

--- a/src/include/storage/buffer_manager/bm_file_handle.h
+++ b/src/include/storage/buffer_manager/bm_file_handle.h
@@ -3,6 +3,7 @@
 #include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 
 #include "common/concurrent_vector.h"
 #include "common/constants.h"

--- a/src/include/storage/enums/page_read_policy.h
+++ b/src/include/storage/enums/page_read_policy.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <cstdint>
+
+namespace kuzu {
+namespace storage {
+
+enum class PageReadPolicy : uint8_t { READ_PAGE = 0, DONT_READ_PAGE = 1 };
+
+} // namespace storage
+} // namespace kuzu

--- a/src/include/storage/file_handle.h
+++ b/src/include/storage/file_handle.h
@@ -34,6 +34,7 @@ public:
     constexpr static uint8_t O_PERSISTENT_FILE_NO_CREATE{0b0000'0000};
     constexpr static uint8_t O_PERSISTENT_FILE_CREATE_NOT_EXISTS{0b0000'0100};
     constexpr static uint8_t O_IN_MEM_TEMP_FILE{0b0000'0011};
+    constexpr static uint8_t O_PERSISTENT_FILE_IN_MEM{0b0000'0010};
 
     FileHandle(const std::string& path, uint8_t flags, common::VirtualFileSystem* vfs,
         main::ClientContext* context);
@@ -42,23 +43,24 @@ public:
     common::page_idx_t addNewPage();
     common::page_idx_t addNewPages(common::page_idx_t numPages);
 
-    inline void readPage(uint8_t* frame, common::page_idx_t pageIdx) const {
+    void readPage(uint8_t* frame, common::page_idx_t pageIdx) const {
         KU_ASSERT(pageIdx < numPages);
         fileInfo->readFromFile(frame, getPageSize(), pageIdx * getPageSize());
     }
-    inline void writePage(uint8_t* buffer, common::page_idx_t pageIdx) const {
+    void writePage(const uint8_t* buffer, common::page_idx_t pageIdx) const {
         KU_ASSERT(pageIdx < numPages);
         fileInfo->writeFile(buffer, getPageSize(), pageIdx * getPageSize());
     }
 
-    inline bool isLargePaged() const { return flags & isLargePagedMask; }
-    inline bool isNewTmpFile() const { return flags & isNewInMemoryTmpFileMask; }
-    inline bool isReadOnlyFile() const { return flags & isReadOnlyMask; }
-    inline bool createFileIfNotExists() const { return flags & createIfNotExistsMask; }
+    bool isLargePaged() const { return flags & isLargePagedMask; }
+    bool isNewTmpFile() const { return flags & isNewInMemoryTmpFileMask; }
+    bool isReadOnlyFile() const { return flags & isReadOnlyMask; }
+    bool createFileIfNotExists() const { return flags & createIfNotExistsMask; }
+    bool isInMemoryMode() const { return !isLargePaged() && isNewTmpFile(); }
 
-    inline common::page_idx_t getNumPages() const { return numPages; }
-    inline common::FileInfo* getFileInfo() const { return fileInfo.get(); }
-    inline uint64_t getPageSize() const {
+    common::page_idx_t getNumPages() const { return numPages; }
+    common::FileInfo* getFileInfo() const { return fileInfo.get(); }
+    uint64_t getPageSize() const {
         return isLargePaged() ? common::BufferPoolConstants::PAGE_256KB_SIZE :
                                 common::BufferPoolConstants::PAGE_4KB_SIZE;
     }

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -69,8 +69,8 @@ class HashIndex final : public OnDiskHashIndex {
 public:
     HashIndex(const DBFileIDAndName& dbFileIDAndName, BMFileHandle* fileHandle,
         OverflowFileHandle* overflowFileHandle, DiskArrayCollection& diskArrays, uint64_t indexPos,
-        BufferManager& bufferManager, ShadowFile* shadowFile,
-        const HashIndexHeader& indexHeaderForReadTrx, HashIndexHeader& indexHeaderForWriteTrx);
+        ShadowFile* shadowFile, const HashIndexHeader& indexHeaderForReadTrx,
+        HashIndexHeader& indexHeaderForWriteTrx);
 
     ~HashIndex() override;
 
@@ -274,7 +274,6 @@ private:
 
 private:
     DBFileIDAndName dbFileIDAndName;
-    BufferManager& bm;
     ShadowFile* shadowFile;
     uint64_t headerPageIdx;
     BMFileHandle* fileHandle;
@@ -392,7 +391,6 @@ private:
     std::vector<std::unique_ptr<OnDiskHashIndex>> hashIndices;
     std::vector<HashIndexHeader> hashIndexHeadersForReadTrx;
     std::vector<HashIndexHeader> hashIndexHeadersForWriteTrx;
-    BufferManager& bufferManager;
     DBFileIDAndName dbFileIDAndName;
     ShadowFile& shadowFile;
     // Stores both primary and overflow slots

--- a/src/include/storage/index/hash_index.h
+++ b/src/include/storage/index/hash_index.h
@@ -302,7 +302,7 @@ inline bool HashIndex<common::ku_string_t>::equals(const transaction::Transactio
 
 class PrimaryKeyIndex {
 public:
-    PrimaryKeyIndex(const DBFileIDAndName& dbFileIDAndName, bool readOnly,
+    PrimaryKeyIndex(const DBFileIDAndName& dbFileIDAndName, bool readOnly, bool inMemMode,
         common::PhysicalTypeID keyDataType, BufferManager& bufferManager, ShadowFile* shadowFile,
         common::VirtualFileSystem* vfs, main::ClientContext* context);
 
@@ -377,9 +377,7 @@ public:
     void delete_(common::ValueVector* keyVector);
 
     void checkpointInMemory();
-    void rollbackInMemory();
     void checkpoint();
-    void prepareRollback();
     BMFileHandle* getFileHandle() const { return fileHandle; }
     OverflowFile* getOverflowFile() const { return overflowFile.get(); }
 

--- a/src/include/storage/storage_manager.h
+++ b/src/include/storage/storage_manager.h
@@ -24,7 +24,7 @@ public:
 
     static void recover(main::ClientContext& clientContext);
 
-    void createTable(common::table_id_t tableID, catalog::Catalog* catalog,
+    void createTable(common::table_id_t tableID, const catalog::Catalog* catalog,
         main::ClientContext* context);
 
     void checkpoint(main::ClientContext& clientContext);
@@ -37,8 +37,8 @@ public:
         return tables.at(tableID).get();
     }
 
-    WAL& getWAL();
-    ShadowFile& getShadowFile();
+    WAL& getWAL() const;
+    ShadowFile& getShadowFile() const;
     BMFileHandle* getDataFH() const { return dataFH; }
     BMFileHandle* getMetadataFH() const { return metadataFH; }
     std::string getDatabasePath() const { return databasePath; }
@@ -48,19 +48,20 @@ public:
     uint64_t getEstimatedMemoryUsage();
 
 private:
-    BMFileHandle* initFileHandle(const std::string& filename, common::VirtualFileSystem* vfs,
+    BMFileHandle* initFileHandle(const std::string& fileName, common::VirtualFileSystem* vfs,
         main::ClientContext* context) const;
 
     void loadTables(const catalog::Catalog& catalog, common::VirtualFileSystem* vfs,
         main::ClientContext* context);
-    void createNodeTable(common::table_id_t tableID, catalog::NodeTableCatalogEntry* tableSchema,
+    void createNodeTable(common::table_id_t tableID, catalog::NodeTableCatalogEntry* nodeTableEntry,
         main::ClientContext* context);
-    void createRelTable(common::table_id_t tableID, catalog::RelTableCatalogEntry* tableSchema,
-        catalog::Catalog* catalog, transaction::Transaction* transaction);
-    void createRelTableGroup(common::table_id_t tableID, catalog::RelGroupCatalogEntry* tableSchema,
-        catalog::Catalog* catalog, transaction::Transaction* transaction);
+    void createRelTable(common::table_id_t tableID, catalog::RelTableCatalogEntry* relTableEntry,
+        const catalog::Catalog* catalog, transaction::Transaction* transaction);
+    void createRelTableGroup(common::table_id_t tableID,
+        const catalog::RelGroupCatalogEntry* tableSchema, const catalog::Catalog* catalog,
+        transaction::Transaction* transaction);
     void createRdfGraph(common::table_id_t tableID, catalog::RDFGraphCatalogEntry* tableSchema,
-        catalog::Catalog* catalog, main::ClientContext* context);
+        const catalog::Catalog* catalog, main::ClientContext* context);
 
 private:
     std::mutex mtx;

--- a/src/include/storage/storage_structure/db_file_utils.h
+++ b/src/include/storage/storage_structure/db_file_utils.h
@@ -4,6 +4,7 @@
 
 #include "common/copy_constructors.h"
 #include "common/types/types.h"
+#include "storage/enums/page_read_policy.h"
 
 namespace kuzu {
 namespace transaction {
@@ -32,6 +33,11 @@ struct ShadowPageAndFrame {
 class DBFileUtils {
 public:
     constexpr static common::page_idx_t NULL_PAGE_IDX = common::INVALID_PAGE_IDX;
+
+    static uint8_t* pinPage(BMFileHandle& fileHandle, common::page_idx_t pageIdx,
+        BufferManager& bufferManager, PageReadPolicy readPolicy);
+    static void optimisticReadPage(BMFileHandle& fileHandle, common::page_idx_t pageIdx,
+        BufferManager& bufferManager, const std::function<void(uint8_t*)>& readOp);
 
     // Where possible, updatePage/insertNewPage should be used instead
     static ShadowPageAndFrame createShadowVersionIfNecessaryAndPinPage(

--- a/src/include/storage/storage_structure/db_file_utils.h
+++ b/src/include/storage/storage_structure/db_file_utils.h
@@ -4,7 +4,6 @@
 
 #include "common/copy_constructors.h"
 #include "common/types/types.h"
-#include "storage/enums/page_read_policy.h"
 
 namespace kuzu {
 namespace transaction {

--- a/src/include/storage/storage_structure/db_file_utils.h
+++ b/src/include/storage/storage_structure/db_file_utils.h
@@ -34,27 +34,21 @@ class DBFileUtils {
 public:
     constexpr static common::page_idx_t NULL_PAGE_IDX = common::INVALID_PAGE_IDX;
 
-    static uint8_t* pinPage(BMFileHandle& fileHandle, common::page_idx_t pageIdx,
-        BufferManager& bufferManager, PageReadPolicy readPolicy);
-    static void optimisticReadPage(BMFileHandle& fileHandle, common::page_idx_t pageIdx,
-        BufferManager& bufferManager, const std::function<void(uint8_t*)>& readOp);
-
     // Where possible, updatePage/insertNewPage should be used instead
     static ShadowPageAndFrame createShadowVersionIfNecessaryAndPinPage(
         common::page_idx_t originalPage, bool insertingNewPage, BMFileHandle& fileHandle,
-        DBFileID dbFileID, BufferManager& bufferManager, ShadowFile& shadowFile);
+        DBFileID dbFileID, ShadowFile& shadowFile);
 
     static std::pair<BMFileHandle*, common::page_idx_t> getFileHandleAndPhysicalPageIdxToPin(
         BMFileHandle& fileHandle, common::page_idx_t pageIdx, const ShadowFile& shadowFile,
         transaction::TransactionType trxType);
 
     static void readShadowVersionOfPage(const BMFileHandle& fileHandle,
-        common::page_idx_t originalPageIdx, BufferManager& bufferManager,
-        const ShadowFile& shadowFile, const std::function<void(uint8_t*)>& readOp);
+        common::page_idx_t originalPageIdx, const ShadowFile& shadowFile,
+        const std::function<void(uint8_t*)>& readOp);
 
     static common::page_idx_t insertNewPage(
-        BMFileHandle& fileHandle, DBFileID dbFileID, BufferManager& bufferManager,
-        ShadowFile& shadowFile,
+        BMFileHandle& fileHandle, DBFileID dbFileID, ShadowFile& shadowFile,
         const std::function<void(uint8_t*)>& insertOp = [](uint8_t*) -> void {
             // DO NOTHING.
         });
@@ -63,8 +57,8 @@ public:
     // page if it doesn't exist. For the original page to be updated, the current WRITE trx needs to
     // commit and checkpoint.
     static void updatePage(BMFileHandle& fileHandle, DBFileID dbFileID,
-        common::page_idx_t originalPageIdx, bool isInsertingNewPage, BufferManager& bufferManager,
-        ShadowFile& shadowFile, const std::function<void(uint8_t*)>& updateOp);
+        common::page_idx_t originalPageIdx, bool isInsertingNewPage, ShadowFile& shadowFile,
+        const std::function<void(uint8_t*)>& updateOp);
 };
 } // namespace storage
 } // namespace kuzu

--- a/src/include/storage/storage_structure/disk_array.h
+++ b/src/include/storage/storage_structure/disk_array.h
@@ -102,8 +102,7 @@ public:
     // Used when loading from file
     DiskArrayInternal(BMFileHandle& fileHandle, DBFileID dbFileID,
         const DiskArrayHeader& headerForReadTrx, DiskArrayHeader& headerForWriteTrx,
-        BufferManager* bufferManager, ShadowFile* shadowFile, uint64_t elementSize,
-        bool bypassShadowing = false);
+        ShadowFile* shadowFile, uint64_t elementSize, bool bypassShadowing = false);
 
     virtual ~DiskArrayInternal() = default;
 
@@ -223,7 +222,7 @@ protected:
     virtual void checkpointOrRollbackInMemoryIfNecessaryNoLock(bool isCheckpoint);
 
 private:
-    bool checkOutOfBoundAccess(transaction::TransactionType trxType, uint64_t idx);
+    bool checkOutOfBoundAccess(transaction::TransactionType trxType, uint64_t idx) const;
     bool hasPIPUpdatesNoLock(uint64_t pipIdx);
 
     inline const DiskArrayHeader& getDiskArrayHeader(transaction::TransactionType trxType) const {
@@ -245,7 +244,6 @@ protected:
     const DiskArrayHeader& header;
     DiskArrayHeader& headerForWriteTrx;
     bool hasTransactionalUpdates;
-    BufferManager* bufferManager;
     ShadowFile* shadowFile;
     std::vector<PIPWrapper> pips;
     PIPUpdates pipUpdates;
@@ -269,10 +267,9 @@ public:
     // original file, but does not handle flushing them. BufferManager::flushAllDirtyPagesInFrames
     // should be called on this file handle exactly once during prepare commit.
     DiskArray(BMFileHandle& fileHandle, DBFileID dbFileID, const DiskArrayHeader& headerForReadTrx,
-        DiskArrayHeader& headerForWriteTrx, BufferManager* bufferManager, ShadowFile* shadowFile,
-        bool bypassWAL = false)
-        : diskArray(fileHandle, dbFileID, headerForReadTrx, headerForWriteTrx, bufferManager,
-              shadowFile, sizeof(U), bypassWAL) {}
+        DiskArrayHeader& headerForWriteTrx, ShadowFile* shadowFile, bool bypassWAL = false)
+        : diskArray(fileHandle, dbFileID, headerForReadTrx, headerForWriteTrx, shadowFile,
+              sizeof(U), bypassWAL) {}
 
     // Note: This function is to be used only by the WRITE trx.
     // The return value is the idx of val in array.

--- a/src/include/storage/storage_structure/overflow_file.h
+++ b/src/include/storage/storage_structure/overflow_file.h
@@ -3,6 +3,7 @@
 #include <fcntl.h>
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string_view>
 #include <vector>
@@ -10,7 +11,6 @@
 #include "common/constants.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/bm_file_handle.h"
-#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/file_handle.h"
 #include "storage/index/hash_index_utils.h"
 #include "storage/storage_structure/in_mem_page.h"

--- a/src/include/storage/storage_structure/overflow_file.h
+++ b/src/include/storage/storage_structure/overflow_file.h
@@ -140,7 +140,6 @@ protected:
     common::page_idx_t numPagesOnDisk;
     DBFileID dbFileID;
     BMFileHandle* fileHandle;
-    BufferManager* bufferManager;
     ShadowFile* shadowFile;
     std::atomic<common::page_idx_t> pageCounter;
     std::atomic<bool> headerChanged;

--- a/src/include/storage/wal/shadow_file.h
+++ b/src/include/storage/wal/shadow_file.h
@@ -40,7 +40,7 @@ public:
 
     void replayShadowPageRecords(main::ClientContext& context) const;
 
-    void flushAll(main::ClientContext& context) const;
+    void flushAll() const;
     void clearAll(main::ClientContext& context);
 
 private:

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -5,7 +5,6 @@
 
 #include "common/enums/rel_direction.h"
 #include "common/serializer/buffered_file.h"
-#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/wal/wal_record.h"
 
 namespace kuzu {

--- a/src/include/storage/wal/wal.h
+++ b/src/include/storage/wal/wal.h
@@ -25,16 +25,13 @@ struct SequenceRollbackData;
 } // namespace catalog
 
 namespace storage {
-
-using lock_t = std::unique_lock<std::mutex>;
-
 class WALReplayer;
 class WAL {
     friend class WALReplayer;
 
 public:
-    WAL(const std::string& directory, bool readOnly, BufferManager& bufferManager,
-        common::VirtualFileSystem* vfs, main::ClientContext* context);
+    WAL(const std::string& directory, bool readOnly, common::VirtualFileSystem* vfs,
+        main::ClientContext* context);
 
     ~WAL();
 
@@ -91,7 +88,6 @@ private:
     std::shared_ptr<common::BufferedFileWriter> bufferedWriter;
     std::string directory;
     std::mutex mtx;
-    BufferManager& bufferManager;
     common::VirtualFileSystem* vfs;
 };
 

--- a/src/include/transaction/transaction.h
+++ b/src/include/transaction/transaction.h
@@ -70,11 +70,9 @@ public:
     bool shouldAppendToUndoBuffer() const {
         return getID() > DUMMY_TRANSACTION_ID && !isReadOnly();
     }
-    bool shouldLogToWAL() const {
-        // When we are in recovery mode, we don't log to WAL.
-        return !isRecovery();
-    }
-    bool shouldForceCheckpoint() const { return forceCheckpoint; }
+    bool shouldLogToWAL() const;
+
+    bool shouldForceCheckpoint() const;
 
     void commit(storage::WAL* wal) const;
     void rollback(storage::WAL* wal) const;

--- a/src/main/attached_database.cpp
+++ b/src/main/attached_database.cpp
@@ -45,6 +45,10 @@ AttachedKuzuDatabase::AttachedKuzuDatabase(std::string dbPath, std::string dbNam
     std::string dbType, ClientContext* clientContext)
     : AttachedDatabase{std::move(dbName), std::move(dbType), nullptr /* catalog */} {
     auto vfs = clientContext->getVFSUnsafe();
+    if (DBConfig::isDBPathInMemory(dbPath)) {
+        throw common::RuntimeException("Cannot attach an in-memory Kùzu database. Please give a "
+                                       "path to an on-disk Kùzu database directory.");
+    }
     auto path = vfs->expandPath(clientContext, dbPath);
     initCatalog(path, clientContext);
     validateEmptyWAL(path, clientContext);

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -44,9 +44,9 @@ void ActiveQuery::reset() {
 
 ClientContext::ClientContext(Database* database)
     : dbConfig{database->dbConfig}, localDatabase{database} {
-    progressBar = std::make_unique<common::ProgressBar>();
+    progressBar = std::make_unique<ProgressBar>();
     transactionContext = std::make_unique<TransactionContext>(*this);
-    randomEngine = std::make_unique<common::RandomEngine>();
+    randomEngine = std::make_unique<RandomEngine>();
     remoteDatabase = nullptr;
 #if defined(_WIN32)
     clientConfig.homeDirectory = getEnvVariable("USERPROFILE");

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -139,6 +139,10 @@ void Database::openLockFile() {
 }
 
 void Database::initAndLockDBDir() {
+    if (databasePath.empty()) {
+        // In-memory mode.
+        return;
+    }
     if (!vfs->fileOrPathExists(databasePath)) {
         if (dbConfig.readOnly) {
             throw Exception("Cannot create an empty database under READ ONLY mode.");

--- a/src/main/database.cpp
+++ b/src/main/database.cpp
@@ -1,6 +1,7 @@
 #include "main/database.h"
 
 #include "main/database_manager.h"
+#include "storage/buffer_manager/buffer_manager.h"
 
 #if defined(_WIN32)
 #include <windows.h>

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -23,16 +23,12 @@ static ConfigurationOption options[] = { // NOLINT(cert-err58-cpp):
     GET_CONFIGURATION(CheckpointThresholdSetting), GET_CONFIGURATION(AutoCheckpointSetting),
     GET_CONFIGURATION(ForceCheckpointClosingDBSetting)};
 
-DBConfig::DBConfig(const SystemConfig& systemConfig) {
-    bufferPoolSize = systemConfig.bufferPoolSize;
-    maxNumThreads = systemConfig.maxNumThreads;
-    enableCompression = systemConfig.enableCompression;
-    readOnly = systemConfig.readOnly;
-    maxDBSize = systemConfig.maxDBSize;
-    autoCheckpoint = systemConfig.autoCheckpoint;
-    checkpointThreshold = systemConfig.checkpointThreshold;
-    forceCheckpointOnClose = false;
-}
+DBConfig::DBConfig(const SystemConfig& systemConfig)
+    : bufferPoolSize{systemConfig.bufferPoolSize}, maxNumThreads{systemConfig.maxNumThreads},
+      enableCompression{systemConfig.enableCompression}, readOnly{systemConfig.readOnly},
+      maxDBSize{systemConfig.maxDBSize}, enableMultiWrites{false},
+      autoCheckpoint{systemConfig.autoCheckpoint},
+      checkpointThreshold{systemConfig.checkpointThreshold}, forceCheckpointOnClose{false} {}
 
 ConfigurationOption* DBConfig::getOptionByName(const std::string& optionName) {
     auto lOptionName = optionName;
@@ -43,6 +39,10 @@ ConfigurationOption* DBConfig::getOptionByName(const std::string& optionName) {
         }
     }
     return nullptr;
+}
+
+bool DBConfig::isDBPathInMemory(const std::string& dbPath) {
+    return dbPath.empty() || dbPath == ":memory:";
 }
 
 } // namespace main

--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -22,7 +22,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace storage {
 
-bool EvictionQueue::insert(uint32_t fileIndex, common::page_idx_t pageIndex) {
+bool EvictionQueue::insert(uint32_t fileIndex, page_idx_t pageIndex) {
     EvictionCandidate candidate{fileIndex, pageIndex};
     while (size < capacity) {
         // Weak is fine since spurious failure is acceptable.
@@ -76,8 +76,8 @@ BufferManager::BufferManager(uint64_t bufferPoolSize, uint64_t maxDBSize)
       usedMemory{evictionQueue.getCapacity() * sizeof(EvictionCandidate)} {
     verifySizeParams(bufferPoolSize, maxDBSize);
     vmRegions.resize(2);
-    vmRegions[0] = std::make_unique<VMRegion>(PageSizeClass::PAGE_4KB, maxDBSize);
-    vmRegions[1] = std::make_unique<VMRegion>(PageSizeClass::PAGE_256KB, bufferPoolSize);
+    vmRegions[0] = std::make_unique<VMRegion>(PAGE_4KB, maxDBSize);
+    vmRegions[1] = std::make_unique<VMRegion>(PAGE_256KB, bufferPoolSize);
 }
 
 void BufferManager::verifySizeParams(uint64_t bufferPoolSize, uint64_t maxDBSize) {
@@ -172,7 +172,7 @@ void handleAccessViolation(unsigned int exceptionCode, PEXCEPTION_POINTERS excep
 
 // Returns true if the function completes successfully
 inline bool try_func(const std::function<void(uint8_t*)>& func, uint8_t* frame,
-    const std::vector<std::unique_ptr<VMRegion>>& vmRegions, common::PageSizeClass pageSizeClass) {
+    const std::vector<std::unique_ptr<VMRegion>>& vmRegions, PageSizeClass pageSizeClass) {
 #if defined(_WIN32)
     try {
 #endif
@@ -238,7 +238,7 @@ void BufferManager::unpin(BMFileHandle& fileHandle, page_idx_t pageIdx) {
 
 // evicts up to 64 pages and returns the space reclaimed
 uint64_t BufferManager::evictPages() {
-    const size_t BATCH_SIZE = 64;
+    constexpr size_t BATCH_SIZE = 64;
     std::array<std::atomic<EvictionCandidate>*, BATCH_SIZE> evictionCandidates;
     size_t evictablePages = 0;
     size_t pagesTried = 0;
@@ -336,6 +336,10 @@ uint64_t BufferManager::tryEvictPage(std::atomic<EvictionCandidate>& _candidate)
         pageState.unlock();
         return 0;
     }
+    if (fileHandles[candidate.fileIdx]->isInMemoryMode()) {
+        // Cannot flush pages under in memory mode.
+        return 0;
+    }
     // At this point, the page is LOCKED, and we have exclusive access to the eviction candidate.
     // Next, flush out the frame into the file page if the frame
     // is dirty. Finally remove the page from the frame and reset the page to EVICTED.
@@ -360,7 +364,7 @@ void BufferManager::cachePageIntoFrame(BMFileHandle& fileHandle, page_idx_t page
 
 void BufferManager::flushIfDirtyWithoutLock(BMFileHandle& fileHandle, page_idx_t pageIdx) {
     auto pageState = fileHandle.getPageState(pageIdx);
-    if (pageState->isDirty()) {
+    if (!fileHandle.isInMemoryMode() && pageState->isDirty()) {
         fileHandle.getFileInfo()->writeFile(getFrame(fileHandle, pageIdx), fileHandle.getPageSize(),
             pageIdx * fileHandle.getPageSize());
         pageState->clearDirtyWithoutLock();

--- a/src/storage/buffer_manager/memory_manager.cpp
+++ b/src/storage/buffer_manager/memory_manager.cpp
@@ -49,7 +49,7 @@ std::unique_ptr<MemoryBuffer> MemoryAllocator::allocateBuffer(bool initializeToZ
             freePages.pop();
         }
     }
-    auto buffer = bm->pin(*fh, pageIdx, BufferManager::PageReadPolicy::DONT_READ_PAGE);
+    auto buffer = bm->pin(*fh, pageIdx, PageReadPolicy::DONT_READ_PAGE);
     auto memoryBuffer = std::make_unique<MemoryBuffer>(this, pageIdx, buffer);
     if (initializeToZero) {
         memset(memoryBuffer->buffer.data(), 0, pageSize);

--- a/src/storage/index/hash_index.cpp
+++ b/src/storage/index/hash_index.cpp
@@ -10,6 +10,7 @@
 #include "common/types/ku_string.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/bm_file_handle.h"
+#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/file_handle.h"
 #include "storage/index/hash_index_header.h"
 #include "storage/index/hash_index_slot.h"

--- a/src/storage/local_storage/local_node_table.cpp
+++ b/src/storage/local_storage/local_node_table.cpp
@@ -1,10 +1,10 @@
 #include "storage/local_storage/local_node_table.h"
 
 #include "common/cast.h"
+#include "common/exception/message.h"
 #include "common/types/internal_id_t.h"
 #include "storage/index/hash_index.h"
 #include "storage/store/node_table.h"
-#include <common/exception/message.h>
 
 using namespace kuzu::common;
 using namespace kuzu::transaction;

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -6,6 +6,7 @@
 #include "common/file_system/virtual_file_system.h"
 #include "main/client_context.h"
 #include "main/database.h"
+#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/store/node_table.h"
 #include "storage/store/rel_table.h"

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -23,8 +23,7 @@ StorageManager::StorageManager(const std::string& databasePath, bool readOnly,
     VirtualFileSystem* vfs, main::ClientContext* context)
     : databasePath{databasePath}, readOnly{readOnly}, memoryManager{memoryManager},
       enableCompression{enableCompression} {
-    wal = std::make_unique<WAL>(databasePath, readOnly, *memoryManager.getBufferManager(), vfs,
-        context);
+    wal = std::make_unique<WAL>(databasePath, readOnly, vfs, context);
     shadowFile = std::make_unique<ShadowFile>(databasePath, readOnly,
         *memoryManager.getBufferManager(), vfs, context);
     dataFH = initFileHandle(StorageUtils::getDataFName(vfs, databasePath), vfs, context);
@@ -251,8 +250,8 @@ void StorageManager::checkpoint(main::ClientContext& clientContext) {
         tables.at(tableEntry->getTableID())->checkpoint(ser);
     }
     writer->flush();
-    writer->getFileInfo().syncFile();
-    shadowFile->flushAll(clientContext);
+    writer->sync();
+    shadowFile->flushAll();
 }
 
 } // namespace storage

--- a/src/storage/storage_structure/db_file_utils.cpp
+++ b/src/storage/storage_structure/db_file_utils.cpp
@@ -1,7 +1,6 @@
 #include "storage/storage_structure/db_file_utils.h"
 
 #include "storage/buffer_manager/bm_file_handle.h"
-#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/wal/shadow_file.h"
 #include "transaction/transaction.h"
 

--- a/src/storage/storage_structure/disk_array.cpp
+++ b/src/storage/storage_structure/disk_array.cpp
@@ -23,7 +23,7 @@ static inline PageCursor getAPIdxAndOffsetInAP(const PageStorageInfo& info, uint
     // We assume that `numElementsPerPageLog2`, `elementPageOffsetMask`,
     // `alignedElementSizeLog2` are never modified throughout transactional updates, thus, we
     // directly use them from header here.
-    common::page_idx_t apIdx = idx / info.numElementsPerPage;
+    page_idx_t apIdx = idx / info.numElementsPerPage;
     uint16_t byteOffsetInAP = (idx % info.numElementsPerPage) * info.alignedElementSize;
     return PageCursor{apIdx, byteOffsetInAP};
 }
@@ -40,11 +40,11 @@ PIPWrapper::PIPWrapper(FileHandle& fileHandle, page_idx_t pipPageIdx) : pipPageI
 
 DiskArrayInternal::DiskArrayInternal(BMFileHandle& fileHandle, DBFileID dbFileID,
     const DiskArrayHeader& headerForReadTrx, DiskArrayHeader& headerForWriteTrx,
-    BufferManager* bufferManager, ShadowFile* shadowFile, uint64_t elementSize, bool bypassWAL)
+    ShadowFile* shadowFile, uint64_t elementSize, bool bypassWAL)
     : storageInfo{elementSize}, fileHandle{fileHandle}, dbFileID{dbFileID},
       header{headerForReadTrx}, headerForWriteTrx{headerForWriteTrx},
-      hasTransactionalUpdates{false}, bufferManager{bufferManager}, shadowFile{shadowFile},
-      lastAPPageIdx{INVALID_PAGE_IDX}, lastPageOnDisk{INVALID_PAGE_IDX} {
+      hasTransactionalUpdates{false}, shadowFile{shadowFile}, lastAPPageIdx{INVALID_PAGE_IDX},
+      lastPageOnDisk{INVALID_PAGE_IDX} {
     if (this->header.firstPIPPageIdx != DBFileUtils::NULL_PAGE_IDX) {
         pips.emplace_back(fileHandle, header.firstPIPPageIdx);
         while (pips[pips.size() - 1].pipContents.nextPipPageIdx != DBFileUtils::NULL_PAGE_IDX) {
@@ -73,7 +73,7 @@ uint64_t DiskArrayInternal::getNumElements(TransactionType trxType) {
     return getNumElementsNoLock(trxType);
 }
 
-bool DiskArrayInternal::checkOutOfBoundAccess(TransactionType trxType, uint64_t idx) {
+bool DiskArrayInternal::checkOutOfBoundAccess(TransactionType trxType, uint64_t idx) const {
     auto currentNumElements = getNumElementsNoLock(trxType);
     if (idx >= currentNumElements) {
         // LCOV_EXCL_START
@@ -95,12 +95,11 @@ void DiskArrayInternal::get(uint64_t idx, const Transaction* transaction,
     if (transaction->getType() != TransactionType::CHECKPOINT || !hasTransactionalUpdates ||
         apPageIdx > lastPageOnDisk ||
         !shadowFile->hasShadowPage(fileHandle.getFileIndex(), apPageIdx)) {
-        DBFileUtils::optimisticReadPage(bmFileHandle, apPageIdx, *bufferManager,
-            [&](const uint8_t* frame) -> void {
-                memcpy(val.data(), frame + apCursor.elemPosInPage, val.size());
-            });
+        bmFileHandle.optimisticReadPage(apPageIdx, [&](const uint8_t* frame) -> void {
+            memcpy(val.data(), frame + apCursor.elemPosInPage, val.size());
+        });
     } else {
-        DBFileUtils::readShadowVersionOfPage(bmFileHandle, apPageIdx, *bufferManager, *shadowFile,
+        DBFileUtils::readShadowVersionOfPage(bmFileHandle, apPageIdx, *shadowFile,
             [&val, &apCursor](const uint8_t* frame) -> void {
                 memcpy(val.data(), frame + apCursor.elemPosInPage, val.size());
             });
@@ -116,14 +115,13 @@ void DiskArrayInternal::updatePage(uint64_t pageIdx, bool isNewPage,
         // This may still be used to create new pages since bypassing the WAL is currently optional
         // and if disabled lastPageOnDisk will be INVALID_PAGE_IDX (and the above comparison will
         // always be true)
-        DBFileUtils::updatePage(bmFileHandle, dbFileID, pageIdx, isNewPage, *bufferManager,
-            *shadowFile, updateOp);
+        DBFileUtils::updatePage(bmFileHandle, dbFileID, pageIdx, isNewPage, *shadowFile, updateOp);
     } else {
-        const auto frame = DBFileUtils::pinPage(bmFileHandle, pageIdx, *bufferManager,
+        const auto frame = bmFileHandle.pinPage(pageIdx,
             isNewPage ? PageReadPolicy::DONT_READ_PAGE : PageReadPolicy::READ_PAGE);
         updateOp(frame);
         bmFileHandle.setLockedPageDirty(pageIdx);
-        bufferManager->unpin(bmFileHandle, pageIdx);
+        bmFileHandle.unpinPage(pageIdx);
     }
 }
 
@@ -210,7 +208,7 @@ page_idx_t DiskArrayInternal::getUpdatedPageIdxOfPipNoLock(uint64_t pipIdx) {
 
 void DiskArrayInternal::clearWALPageVersionAndRemovePageFromFrameIfNecessary(page_idx_t pageIdx) {
     shadowFile->clearShadowPage(fileHandle.getFileIndex(), pageIdx);
-    bufferManager->removePageFromFrameIfNecessary(fileHandle, pageIdx);
+    fileHandle.removePageFromFrameIfNecessary(pageIdx);
 }
 
 void DiskArrayInternal::checkpointOrRollbackInMemoryIfNecessaryNoLock(bool isCheckpoint) {
@@ -246,13 +244,13 @@ void DiskArrayInternal::checkpointOrRollbackInMemoryIfNecessaryNoLock(bool isChe
 void DiskArrayInternal::checkpoint() {
     if (pipUpdates.updatedLastPIP.has_value()) {
         DBFileUtils::updatePage(fileHandle, dbFileID, pipUpdates.updatedLastPIP->pipPageIdx, true,
-            *bufferManager, *shadowFile, [&](auto* frame) {
+            *shadowFile, [&](auto* frame) {
                 memcpy(frame, &pipUpdates.updatedLastPIP->pipContents, sizeof(PIP));
             });
     }
     for (auto& newPIP : pipUpdates.newPIPs) {
-        DBFileUtils::updatePage(fileHandle, dbFileID, newPIP.pipPageIdx, true, *bufferManager,
-            *shadowFile, [&](auto* frame) { memcpy(frame, &newPIP.pipContents, sizeof(PIP)); });
+        DBFileUtils::updatePage(fileHandle, dbFileID, newPIP.pipPageIdx, true, *shadowFile,
+            [&](auto* frame) { memcpy(frame, &newPIP.pipContents, sizeof(PIP)); });
     }
 }
 
@@ -319,7 +317,7 @@ DiskArrayInternal::WriteIterator& DiskArrayInternal::WriteIterator::seek(size_t 
     idx = newIdx;
     apCursor = getAPIdxAndOffsetInAP(diskArray.storageInfo, idx);
     if (oldPageIdx != apCursor.pageIdx) {
-        common::page_idx_t apPageIdx = diskArray.getAPPageIdxNoLock(apCursor.pageIdx, TRX_TYPE);
+        page_idx_t apPageIdx = diskArray.getAPPageIdxNoLock(apCursor.pageIdx, TRX_TYPE);
         getPage(apPageIdx, false /*isNewlyAdded*/);
     }
     return *this;
@@ -337,7 +335,7 @@ void DiskArrayInternal::WriteIterator::pushBack(const Transaction* transaction,
     diskArray.lastAPPageIdx = apPageIdx;
     // Used to calculate the number of APs, so it must be updated after the PIPs are.
     diskArray.headerForWriteTrx.numElements++;
-    if (isNewlyAdded || shadowPageAndFrame.originalPage == common::INVALID_PAGE_IDX ||
+    if (isNewlyAdded || shadowPageAndFrame.originalPage == INVALID_PAGE_IDX ||
         apCursor.pageIdx != oldPageIdx) {
         getPage(apPageIdx, isNewlyAdded);
     }
@@ -345,29 +343,26 @@ void DiskArrayInternal::WriteIterator::pushBack(const Transaction* transaction,
 }
 
 void DiskArrayInternal::WriteIterator::unpin() {
-    if (shadowPageAndFrame.shadowPage != common::INVALID_PAGE_IDX) {
+    if (shadowPageAndFrame.shadowPage != INVALID_PAGE_IDX) {
         // unpin current page
-        diskArray.bufferManager->unpin(diskArray.shadowFile->getShadowingFH(),
-            shadowPageAndFrame.shadowPage);
-    } else if (shadowPageAndFrame.originalPage != common::INVALID_PAGE_IDX) {
+        diskArray.shadowFile->getShadowingFH().unpinPage(shadowPageAndFrame.shadowPage);
+    } else if (shadowPageAndFrame.originalPage != INVALID_PAGE_IDX) {
         diskArray.fileHandle.setLockedPageDirty(shadowPageAndFrame.originalPage);
-        diskArray.bufferManager->unpin(diskArray.fileHandle, shadowPageAndFrame.originalPage);
+        diskArray.fileHandle.unpinPage(shadowPageAndFrame.originalPage);
     }
 }
 
-void DiskArrayInternal::WriteIterator::getPage(common::page_idx_t newPageIdx, bool isNewlyAdded) {
+void DiskArrayInternal::WriteIterator::getPage(page_idx_t newPageIdx, bool isNewlyAdded) {
     unpin();
     if (newPageIdx <= diskArray.lastPageOnDisk) {
         // Pin new page
         shadowPageAndFrame = DBFileUtils::createShadowVersionIfNecessaryAndPinPage(newPageIdx,
-            isNewlyAdded, diskArray.fileHandle, diskArray.dbFileID, *diskArray.bufferManager,
-            *diskArray.shadowFile);
+            isNewlyAdded, diskArray.fileHandle, diskArray.dbFileID, *diskArray.shadowFile);
     } else {
-        shadowPageAndFrame.frame =
-            DBFileUtils::pinPage(diskArray.fileHandle, newPageIdx, *diskArray.bufferManager,
-                isNewlyAdded ? PageReadPolicy::DONT_READ_PAGE : PageReadPolicy::READ_PAGE);
+        shadowPageAndFrame.frame = diskArray.fileHandle.pinPage(newPageIdx,
+            isNewlyAdded ? PageReadPolicy::DONT_READ_PAGE : PageReadPolicy::READ_PAGE);
         shadowPageAndFrame.originalPage = newPageIdx;
-        shadowPageAndFrame.shadowPage = common::INVALID_PAGE_IDX;
+        shadowPageAndFrame.shadowPage = INVALID_PAGE_IDX;
     }
 }
 
@@ -375,7 +370,7 @@ DiskArrayInternal::WriteIterator DiskArrayInternal::iter_mut(uint64_t valueSize)
     return DiskArrayInternal::WriteIterator(valueSize, *this);
 }
 
-common::page_idx_t DiskArrayInternal::getAPIdx(uint64_t idx) const {
+page_idx_t DiskArrayInternal::getAPIdx(uint64_t idx) const {
     return getAPIdxAndOffsetInAP(storageInfo, idx).pageIdx;
 }
 

--- a/src/storage/storage_structure/disk_array.cpp
+++ b/src/storage/storage_structure/disk_array.cpp
@@ -5,7 +5,6 @@
 #include "common/string_format.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/bm_file_handle.h"
-#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/file_handle.h"
 #include "storage/storage_structure/db_file_utils.h"
 #include "storage/storage_utils.h"

--- a/src/storage/storage_structure/disk_array_collection.cpp
+++ b/src/storage/storage_structure/disk_array_collection.cpp
@@ -12,17 +12,15 @@ namespace kuzu {
 namespace storage {
 
 DiskArrayCollection::DiskArrayCollection(BMFileHandle& fileHandle, DBFileID dbFileID,
-    BufferManager* bufferManager, ShadowFile& shadowFile, common::page_idx_t firstHeaderPage,
-    bool bypassShadowing)
-    : fileHandle{fileHandle}, dbFileID{dbFileID}, bufferManager{*bufferManager},
-      shadowFile{shadowFile}, bypassShadowing{bypassShadowing}, headerPageIndices{firstHeaderPage},
-      numHeaders{0} {
+    ShadowFile& shadowFile, page_idx_t firstHeaderPage, bool bypassShadowing)
+    : fileHandle{fileHandle}, dbFileID{dbFileID}, shadowFile{shadowFile},
+      bypassShadowing{bypassShadowing}, headerPageIndices{firstHeaderPage}, numHeaders{0} {
     if (fileHandle.getNumPages() > firstHeaderPage) {
         // Read headers from disk
-        common::page_idx_t headerPageIdx = firstHeaderPage;
+        page_idx_t headerPageIdx = firstHeaderPage;
         do {
-            bufferManager->optimisticRead(fileHandle, headerPageIdx, [&](auto* frame) {
-                HeaderPage* page = reinterpret_cast<HeaderPage*>(frame);
+            fileHandle.optimisticReadPage(headerPageIdx, [&](auto* frame) {
+                const auto page = reinterpret_cast<HeaderPage*>(frame);
                 headersForReadTrx.push_back(std::make_unique<HeaderPage>(*page));
                 headersForWriteTrx.push_back(std::make_unique<HeaderPage>(*page));
                 headerPageIdx = page->nextHeaderPage;
@@ -31,7 +29,7 @@ DiskArrayCollection::DiskArrayCollection(BMFileHandle& fileHandle, DBFileID dbFi
             if (headerPageIdx != INVALID_PAGE_IDX) {
                 headerPageIndices.push_back(headerPageIdx);
             }
-        } while (headerPageIdx != common::INVALID_PAGE_IDX);
+        } while (headerPageIdx != INVALID_PAGE_IDX);
         headerPagesOnDisk = headersForReadTrx.size();
     } else {
         KU_ASSERT(fileHandle.getNumPages() == firstHeaderPage);
@@ -55,12 +53,12 @@ void DiskArrayCollection::checkpoint() {
         if (indexInMemory >= headerPagesOnDisk ||
             *headersForWriteTrx[indexInMemory] != *headersForReadTrx[indexInMemory]) {
             DBFileUtils::updatePage(fileHandle, dbFileID, *headerPageIdx,
-                true /*writing full page*/, bufferManager, shadowFile, [&](auto* frame) {
+                true /*writing full page*/, shadowFile, [&](auto* frame) {
                     memcpy(frame, headersForWriteTrx[indexInMemory].get(), sizeof(HeaderPage));
-                    if constexpr (sizeof(HeaderPage) < common::BufferPoolConstants::PAGE_4KB_SIZE) {
+                    if constexpr (sizeof(HeaderPage) < BufferPoolConstants::PAGE_4KB_SIZE) {
                         // Zero remaining data in the page
                         std::fill(frame + sizeof(HeaderPage),
-                            frame + common::BufferPoolConstants::PAGE_4KB_SIZE, 0);
+                            frame + BufferPoolConstants::PAGE_4KB_SIZE, 0);
                     }
                 });
         }

--- a/src/storage/storage_structure/disk_array_collection.cpp
+++ b/src/storage/storage_structure/disk_array_collection.cpp
@@ -3,7 +3,6 @@
 #include "common/constants.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/bm_file_handle.h"
-#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/storage_structure/db_file_utils.h"
 
 using namespace kuzu::common;

--- a/src/storage/storage_structure/overflow_file.cpp
+++ b/src/storage/storage_structure/overflow_file.cpp
@@ -6,6 +6,7 @@
 #include "common/type_utils.h"
 #include "common/types/types.h"
 #include "storage/buffer_manager/bm_file_handle.h"
+#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/file_handle.h"
 #include "storage/storage_structure/db_file_utils.h"
 #include "storage/storage_structure/in_mem_page.h"

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -352,7 +352,7 @@ void Column::readFromPage(Transaction* transaction, page_idx_t pageIdx,
     }
     auto [fileHandleToPin, pageIdxToPin] = DBFileUtils::getFileHandleAndPhysicalPageIdxToPin(
         *dataFH, pageIdx, *shadowFile, transaction->getType());
-    DBFileUtils::optimisticReadPage(*fileHandleToPin, pageIdxToPin, *bufferManager, func);
+    fileHandleToPin->optimisticReadPage(pageIdxToPin, func);
 }
 
 static bool sanityCheckForWrites(const ColumnChunkMetadata& metadata, const LogicalType& dataType) {
@@ -451,11 +451,11 @@ void Column::updatePageWithCursor(PageCursor cursor,
     }
     if (cursor.pageIdx >= dataFH->getNumPages()) {
         KU_ASSERT(cursor.pageIdx == dataFH->getNumPages());
-        DBFileUtils::insertNewPage(*dataFH, dbFileID, *bufferManager, *shadowFile);
+        DBFileUtils::insertNewPage(*dataFH, dbFileID, *shadowFile);
         insertingNewPage = true;
     }
-    DBFileUtils::updatePage(*dataFH, dbFileID, cursor.pageIdx, insertingNewPage, *bufferManager,
-        *shadowFile, [&](auto frame) { writeOp(frame, cursor.elemPosInPage); });
+    DBFileUtils::updatePage(*dataFH, dbFileID, cursor.pageIdx, insertingNewPage, *shadowFile,
+        [&](auto frame) { writeOp(frame, cursor.elemPosInPage); });
 }
 
 bool Column::isMaxOffsetOutOfPagesCapacity(const ColumnChunkMetadata& metadata,

--- a/src/storage/store/column.cpp
+++ b/src/storage/store/column.cpp
@@ -352,7 +352,7 @@ void Column::readFromPage(Transaction* transaction, page_idx_t pageIdx,
     }
     auto [fileHandleToPin, pageIdxToPin] = DBFileUtils::getFileHandleAndPhysicalPageIdxToPin(
         *dataFH, pageIdx, *shadowFile, transaction->getType());
-    bufferManager->optimisticRead(*fileHandleToPin, pageIdxToPin, func);
+    DBFileUtils::optimisticReadPage(*fileHandleToPin, pageIdxToPin, *bufferManager, func);
 }
 
 static bool sanityCheckForWrites(const ColumnChunkMetadata& metadata, const LogicalType& dataType) {

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -30,7 +30,7 @@ ColumnChunkMetadata uncompressedFlushBuffer(const uint8_t* buffer, uint64_t buff
     BMFileHandle* dataFH, page_idx_t startPageIdx, const ColumnChunkMetadata& metadata) {
     KU_ASSERT(dataFH->getNumPages() >= startPageIdx + metadata.numPages);
     if (dataFH->isInMemoryMode()) {
-        const auto frame = dataFH->getBM()->getFrame(*dataFH, startPageIdx);
+        const auto frame = dataFH->getFrame(startPageIdx);
         memcpy(frame, buffer, bufferSize);
     } else {
         dataFH->getFileInfo()->writeFile(buffer, bufferSize,
@@ -89,7 +89,7 @@ public:
             KU_ASSERT(numPages < metadata.numPages);
             KU_ASSERT(dataFH->getNumPages() > startPageIdx + numPages);
             if (dataFH->isInMemoryMode()) {
-                const auto frame = dataFH->getBM()->getFrame(*dataFH, startPageIdx + numPages);
+                const auto frame = dataFH->getFrame(startPageIdx + numPages);
                 memcpy(frame, compressedBuffer.get(), BufferPoolConstants::PAGE_4KB_SIZE);
             } else {
                 dataFH->getFileInfo()->writeFile(compressedBuffer.get(),
@@ -102,8 +102,7 @@ public:
         if (numPages < metadata.numPages) {
             memset(compressedBuffer.get(), 0, BufferPoolConstants::PAGE_4KB_SIZE);
             if (dataFH->isInMemoryMode()) {
-                const auto frame =
-                    dataFH->getBM()->getFrame(*dataFH, startPageIdx + metadata.numPages - 1);
+                const auto frame = dataFH->getFrame(startPageIdx + metadata.numPages - 1);
                 memcpy(frame, compressedBuffer.get(), BufferPoolConstants::PAGE_4KB_SIZE);
             } else {
                 dataFH->getFileInfo()->writeFile(compressedBuffer.get(),

--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -13,7 +13,6 @@
 #include "common/vector/value_vector.h"
 #include "expression_evaluator/expression_evaluator.h"
 #include "storage/buffer_manager/bm_file_handle.h"
-#include "storage/buffer_manager/buffer_manager.h"
 #include "storage/compression/compression.h"
 #include "storage/store/list_chunk_data.h"
 #include "storage/store/string_chunk_data.h"

--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -1,7 +1,6 @@
 #include "storage/store/dictionary_column.h"
 
 #include "storage/storage_structure/disk_array_collection.h"
-#include "storage/store/string_chunk_data.h"
 #include "storage/store/string_column.h"
 #include <bit>
 

--- a/src/storage/store/dictionary_column.cpp
+++ b/src/storage/store/dictionary_column.cpp
@@ -1,9 +1,9 @@
 #include "storage/store/dictionary_column.h"
 
 #include "storage/storage_structure/disk_array_collection.h"
+#include "storage/store/string_chunk_data.h"
 #include "storage/store/string_column.h"
 #include <bit>
-#include <storage/store/string_chunk_data.h>
 
 using namespace kuzu::common;
 using namespace kuzu::transaction;

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -7,6 +7,7 @@
 #include "common/types/internal_id_t.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
+#include "main/db_config.h"
 #include "storage/local_storage/local_node_table.h"
 #include "storage/local_storage/local_table.h"
 #include "storage/storage_manager.h"
@@ -69,8 +70,9 @@ void NodeTable::initializePKIndex(const std::string& databasePath,
     main::ClientContext* context) {
     pkIndex = std::make_unique<PrimaryKeyIndex>(
         StorageUtils::getNodeIndexIDAndFName(vfs, databasePath, tableID), readOnly,
-        databasePath.empty(), nodeTableEntry->getPrimaryKey()->getDataType().getPhysicalType(),
-        *bufferManager, shadowFile, vfs, context);
+        main::DBConfig::isDBPathInMemory(databasePath),
+        nodeTableEntry->getPrimaryKey()->getDataType().getPhysicalType(), *bufferManager,
+        shadowFile, vfs, context);
 }
 
 void NodeTable::initializeScanState(Transaction* transaction, TableScanState& scanState) {

--- a/src/storage/store/node_table.cpp
+++ b/src/storage/store/node_table.cpp
@@ -69,8 +69,8 @@ void NodeTable::initializePKIndex(const std::string& databasePath,
     main::ClientContext* context) {
     pkIndex = std::make_unique<PrimaryKeyIndex>(
         StorageUtils::getNodeIndexIDAndFName(vfs, databasePath, tableID), readOnly,
-        nodeTableEntry->getPrimaryKey()->getDataType().getPhysicalType(), *bufferManager,
-        shadowFile, vfs, context);
+        databasePath.empty(), nodeTableEntry->getPrimaryKey()->getDataType().getPhysicalType(),
+        *bufferManager, shadowFile, vfs, context);
 }
 
 void NodeTable::initializeScanState(Transaction* transaction, TableScanState& scanState) {

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -229,7 +229,7 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
     initializeScanState(transaction, *relReadState);
     detachDeleteForCSRRels(transaction, tableData, reverseTableData, relReadState.get(),
         deleteState);
-    if (!transaction->isRecovery()) {
+    if (transaction->shouldLogToWAL()) {
         KU_ASSERT(transaction->isWriteTransaction());
         KU_ASSERT(transaction->getClientContext());
         auto& wal = transaction->getClientContext()->getStorageManager()->getWAL();

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -1,12 +1,12 @@
 #include "storage/store/rel_table.h"
 
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
+#include "main/client_context.h"
 #include "storage/local_storage/local_rel_table.h"
 #include "storage/local_storage/local_table.h"
 #include "storage/storage_manager.h"
+#include "storage/store/node_table.h"
 #include "storage/store/rel_table_data.h"
-#include <main/client_context.h>
-#include <storage/store/node_table.h>
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/storage/store/table.cpp
+++ b/src/storage/store/table.cpp
@@ -1,6 +1,7 @@
 #include "storage/store/table.h"
 
 #include "common/serializer/deserializer.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_manager.h"
 #include "storage/store/node_table.h"
 #include "storage/store/rel_table.h"

--- a/src/storage/wal/shadow_file.cpp
+++ b/src/storage/wal/shadow_file.cpp
@@ -5,6 +5,7 @@
 #include "common/file_system/virtual_file_system.h"
 #include "common/serializer/buffered_file.h"
 #include "main/client_context.h"
+#include "main/db_config.h"
 #include "storage/buffer_manager/buffer_manager.h"
 #include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
@@ -33,7 +34,7 @@ ShadowPageRecord ShadowPageRecord::deserialize(Deserializer& deserializer) {
 
 ShadowFile::ShadowFile(const std::string& directory, bool readOnly, BufferManager& bufferManager,
     VirtualFileSystem* vfs, ClientContext* context) {
-    if (directory.empty()) {
+    if (DBConfig::isDBPathInMemory(directory)) {
         return;
     }
     shadowingFH = bufferManager.getBMFileHandle(

--- a/src/storage/wal/shadow_file.cpp
+++ b/src/storage/wal/shadow_file.cpp
@@ -6,6 +6,7 @@
 #include "common/serializer/buffered_file.h"
 #include "main/client_context.h"
 #include "storage/buffer_manager/buffer_manager.h"
+#include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
 
 using namespace kuzu::common;
@@ -32,6 +33,9 @@ ShadowPageRecord ShadowPageRecord::deserialize(Deserializer& deserializer) {
 
 ShadowFile::ShadowFile(const std::string& directory, bool readOnly, BufferManager& bufferManager,
     VirtualFileSystem* vfs, ClientContext* context) {
+    if (directory.empty()) {
+        return;
+    }
     shadowingFH = bufferManager.getBMFileHandle(
         vfs->joinPath(directory, std::string(StorageConstants::SHADOWING_SUFFIX)),
         readOnly ? FileHandle::O_PERSISTENT_FILE_READ_ONLY :

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -21,6 +21,9 @@ namespace storage {
 WAL::WAL(const std::string& directory, bool readOnly, BufferManager& bufferManager,
     VirtualFileSystem* vfs, main::ClientContext* context)
     : directory{directory}, bufferManager{bufferManager}, vfs{vfs} {
+    if (directory.empty()) {
+        return;
+    }
     fileInfo =
         vfs->openFile(vfs->joinPath(directory, std::string(StorageConstants::WAL_FILE_SUFFIX)),
             readOnly ? O_RDONLY : O_CREAT | O_RDWR, context);

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -10,6 +10,7 @@
 #include "common/serializer/buffered_file.h"
 #include "common/serializer/serializer.h"
 #include "common/vector/value_vector.h"
+#include "main/db_config.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;
@@ -21,7 +22,7 @@ namespace storage {
 WAL::WAL(const std::string& directory, bool readOnly, BufferManager& bufferManager,
     VirtualFileSystem* vfs, main::ClientContext* context)
     : directory{directory}, bufferManager{bufferManager}, vfs{vfs} {
-    if (directory.empty()) {
+    if (main::DBConfig::isDBPathInMemory(directory)) {
         return;
     }
     fileInfo =
@@ -156,6 +157,7 @@ void WAL::flushAllPages() {
 
 void WAL::addNewWALRecordNoLock(const WALRecord& walRecord) {
     KU_ASSERT(walRecord.type != WALRecordType::INVALID_RECORD);
+    KU_ASSERT(!main::DBConfig::isDBPathInMemory(directory));
     Serializer serializer(bufferedWriter);
     walRecord.serialize(serializer);
 }

--- a/src/storage/wal/wal.cpp
+++ b/src/storage/wal/wal.cpp
@@ -19,9 +19,9 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace storage {
 
-WAL::WAL(const std::string& directory, bool readOnly, BufferManager& bufferManager,
-    VirtualFileSystem* vfs, main::ClientContext* context)
-    : directory{directory}, bufferManager{bufferManager}, vfs{vfs} {
+WAL::WAL(const std::string& directory, bool readOnly, VirtualFileSystem* vfs,
+    main::ClientContext* context)
+    : directory{directory}, vfs{vfs} {
     if (main::DBConfig::isDBPathInMemory(directory)) {
         return;
     }
@@ -38,13 +38,13 @@ WAL::WAL(const std::string& directory, bool readOnly, BufferManager& bufferManag
 WAL::~WAL() {}
 
 void WAL::logBeginTransaction() {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     BeginTransactionRecord walRecord;
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logAndFlushCommit() {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     // Flush all pages before committing to make sure that commits only show up in the file when
     // their data is also written.
     CommitRecord walRecord;
@@ -53,93 +53,93 @@ void WAL::logAndFlushCommit() {
 }
 
 void WAL::logRollback() {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     RollbackRecord walRecord;
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logAndFlushCheckpoint() {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     CheckpointRecord walRecord;
     addNewWALRecordNoLock(walRecord);
     flushAllPages();
 }
 
 void WAL::logCreateTableEntryRecord(BoundCreateTableInfo tableInfo) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     CreateTableEntryRecord walRecord(std::move(tableInfo));
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logCreateCatalogEntryRecord(CatalogEntry* catalogEntry) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     CreateCatalogEntryRecord walRecord(catalogEntry);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logDropCatalogEntryRecord(table_id_t tableID, CatalogEntryType type) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     DropCatalogEntryRecord walRecord(tableID, type);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logAlterTableEntryRecord(const BoundAlterInfo* alterInfo) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     AlterTableEntryRecord walRecord(alterInfo);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logTableInsertion(table_id_t tableID, TableType tableType, row_idx_t numRows,
     const std::vector<ValueVector*>& vectors) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     TableInsertionRecord walRecord(tableID, tableType, numRows, vectors);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logNodeDeletion(table_id_t tableID, offset_t nodeOffset, ValueVector* pkVector) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     NodeDeletionRecord walRecord(tableID, nodeOffset, pkVector);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logNodeUpdate(table_id_t tableID, column_id_t columnID, offset_t nodeOffset,
     ValueVector* propertyVector) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     NodeUpdateRecord walRecord(tableID, columnID, nodeOffset, propertyVector);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logRelDelete(table_id_t tableID, ValueVector* srcNodeVector, ValueVector* dstNodeVector,
     ValueVector* relIDVector) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     RelDeletionRecord walRecord(tableID, srcNodeVector, dstNodeVector, relIDVector);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logRelDetachDelete(table_id_t tableID, RelDataDirection direction,
     ValueVector* srcNodeVector) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     RelDetachDeleteRecord walRecord(tableID, direction, srcNodeVector);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logRelUpdate(table_id_t tableID, column_id_t columnID, ValueVector* srcNodeVector,
     ValueVector* dstNodeVector, ValueVector* relIDVector, ValueVector* propertyVector) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     RelUpdateRecord walRecord(tableID, columnID, srcNodeVector, dstNodeVector, relIDVector,
         propertyVector);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logCopyTableRecord(table_id_t tableID) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     CopyTableRecord walRecord(tableID);
     addToUpdatedTables(tableID);
     addNewWALRecordNoLock(walRecord);
 }
 
 void WAL::logUpdateSequenceRecord(sequence_id_t sequenceID, uint64_t kCount) {
-    lock_t lck{mtx};
+    std::unique_lock<std::mutex> lck{mtx};
     UpdateSequenceRecord walRecord(sequenceID, kCount);
     addNewWALRecordNoLock(walRecord);
 }

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -7,6 +7,7 @@
 #include "storage/store/version_info.h"
 #include "storage/undo_buffer.h"
 #include "storage/wal/wal.h"
+#include <main/db_config.h>
 
 using namespace kuzu::catalog;
 
@@ -25,11 +26,11 @@ Transaction::Transaction(main::ClientContext& clientContext, TransactionType tra
 
 bool Transaction::shouldLogToWAL() const {
     // When we are in recovery mode, we don't log to WAL.
-    return !isRecovery() && !clientContext->getDatabasePath().empty();
+    return !isRecovery() && !main::DBConfig::isDBPathInMemory(clientContext->getDatabasePath());
 }
 
 bool Transaction::shouldForceCheckpoint() const {
-    return !clientContext->getDatabasePath().empty() && forceCheckpoint;
+    return !main::DBConfig::isDBPathInMemory(clientContext->getDatabasePath()) && forceCheckpoint;
 }
 
 void Transaction::commit(storage::WAL* wal) const {

--- a/src/transaction/transaction.cpp
+++ b/src/transaction/transaction.cpp
@@ -44,7 +44,7 @@ void Transaction::commit(storage::WAL* wal) const {
 void Transaction::rollback(storage::WAL* wal) const {
     localStorage->rollback();
     undoBuffer->rollback();
-    if (isWriteTransaction()) {
+    if (isWriteTransaction() && shouldLogToWAL()) {
         KU_ASSERT(wal);
         wal->logRollback();
     }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -17,8 +17,8 @@ std::unique_ptr<Transaction> TransactionManager::beginTransaction(
     main::ClientContext& clientContext, TransactionType type) {
     // We obtain the lock for starting new transactions. In case this cannot be obtained this
     // ensures calls to other public functions is not restricted.
-    lock_t newTransactionLck{mtxForStartingNewTransactions};
-    lock_t publicFunctionLck{mtxForSerializingPublicFunctionCalls};
+    std::unique_lock<std::mutex> newTransactionLck{mtxForStartingNewTransactions};
+    std::unique_lock<std::mutex> publicFunctionLck{mtxForSerializingPublicFunctionCalls};
     std::unique_ptr<Transaction> transaction;
     switch (type) {
     case TransactionType::READ_ONLY: {
@@ -49,7 +49,7 @@ std::unique_ptr<Transaction> TransactionManager::beginTransaction(
 }
 
 void TransactionManager::commit(main::ClientContext& clientContext) {
-    lock_t lck{mtxForSerializingPublicFunctionCalls};
+    std::unique_lock<std::mutex> lck{mtxForSerializingPublicFunctionCalls};
     clientContext.cleanUP();
     const auto transaction = clientContext.getTx();
     switch (transaction->getType()) {
@@ -77,7 +77,7 @@ void TransactionManager::commit(main::ClientContext& clientContext) {
 // still.
 void TransactionManager::rollback(main::ClientContext& clientContext,
     const Transaction* transaction) {
-    lock_t lck{mtxForSerializingPublicFunctionCalls};
+    std::unique_lock<std::mutex> lck{mtxForSerializingPublicFunctionCalls};
     clientContext.cleanUP();
     switch (transaction->getType()) {
     case TransactionType::READ_ONLY: {
@@ -95,7 +95,7 @@ void TransactionManager::rollback(main::ClientContext& clientContext,
 }
 
 void TransactionManager::checkpoint(main::ClientContext& clientContext) {
-    lock_t lck{mtxForSerializingPublicFunctionCalls};
+    std::unique_lock<std::mutex> lck{mtxForSerializingPublicFunctionCalls};
     if (main::DBConfig::isDBPathInMemory(clientContext.getDatabasePath())) {
         return;
     }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -96,7 +96,7 @@ void TransactionManager::rollback(main::ClientContext& clientContext,
 
 void TransactionManager::checkpoint(main::ClientContext& clientContext) {
     lock_t lck{mtxForSerializingPublicFunctionCalls};
-    if (clientContext.getDatabasePath().empty()) {
+    if (main::DBConfig::isDBPathInMemory(clientContext.getDatabasePath())) {
         return;
     }
     checkpointNoLock(clientContext);
@@ -129,7 +129,7 @@ void TransactionManager::allowReceivingNewTransactions() {
 }
 
 bool TransactionManager::canAutoCheckpoint(const main::ClientContext& clientContext) const {
-    if (clientContext.getDatabasePath().empty()) {
+    if (main::DBConfig::isDBPathInMemory(clientContext.getDatabasePath())) {
         return false;
     }
     if (!clientContext.getDBConfig()->autoCheckpoint) {

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -36,6 +36,11 @@ TEST_F(CApiDatabaseTest, CreationReadOnly) {
     auto systemConfig = kuzu_default_system_config();
     // First, create a read-write database.
     state = kuzu_database_init(databasePathCStr, systemConfig, &database);
+    if (databasePath == "" || databasePath == ":memory:") {
+        ASSERT_EQ(state, KuzuError);
+        ASSERT_EQ(database._database, nullptr);
+        return;
+    }
     ASSERT_EQ(state, KuzuSuccess);
     ASSERT_NE(database._database, nullptr);
     auto databaseCpp = static_cast<Database*>(database._database);
@@ -61,13 +66,13 @@ TEST_F(CApiDatabaseTest, CreationReadOnly) {
     kuzu_database_destroy(&database);
 }
 
-// TEST_F(CApiDatabaseTest, CreationInvalidPath) {
-//     kuzu_database database;
-//     kuzu_state state;
-//     auto databasePathCStr = (char*)"";
-//     state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
-//     ASSERT_EQ(state, KuzuError);
-// }
+TEST_F(CApiDatabaseTest, CreationInvalidPath) {
+    kuzu_database database;
+    kuzu_state state;
+    auto databasePathCStr = (char*)"//////";
+    state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
+    ASSERT_EQ(state, KuzuError);
+}
 
 TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database database;

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -36,11 +36,6 @@ TEST_F(CApiDatabaseTest, CreationReadOnly) {
     auto systemConfig = kuzu_default_system_config();
     // First, create a read-write database.
     state = kuzu_database_init(databasePathCStr, systemConfig, &database);
-    if (databasePath == "" || databasePath == ":memory:") {
-        ASSERT_EQ(state, KuzuError);
-        ASSERT_EQ(database._database, nullptr);
-        return;
-    }
     ASSERT_EQ(state, KuzuSuccess);
     ASSERT_NE(database._database, nullptr);
     auto databaseCpp = static_cast<Database*>(database._database);
@@ -49,6 +44,11 @@ TEST_F(CApiDatabaseTest, CreationReadOnly) {
     // Now, access the same database read-only.
     systemConfig.read_only = true;
     state = kuzu_database_init(databasePathCStr, systemConfig, &database);
+    if (databasePath == "" || databasePath == ":memory:") {
+        ASSERT_EQ(state, KuzuError);
+        ASSERT_EQ(database._database, nullptr);
+        return;
+    }
     ASSERT_EQ(state, KuzuSuccess);
     ASSERT_NE(database._database, nullptr);
     databaseCpp = static_cast<Database*>(database._database);
@@ -66,12 +66,15 @@ TEST_F(CApiDatabaseTest, CreationReadOnly) {
     kuzu_database_destroy(&database);
 }
 
-TEST_F(CApiDatabaseTest, CreationInvalidPath) {
+TEST_F(CApiDatabaseTest, CreationInMemory) {
     kuzu_database database;
     kuzu_state state;
-    auto databasePathCStr = (char*)"//////";
+    auto databasePathCStr = (char*)"";
     state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
-    ASSERT_EQ(state, KuzuError);
+    ASSERT_EQ(state, KuzuSuccess);
+    databasePathCStr = (char*)":memory:";
+    state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
+    ASSERT_EQ(state, KuzuSuccess);
 }
 
 TEST_F(CApiDatabaseTest, CreationHomeDir) {

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -61,13 +61,13 @@ TEST_F(CApiDatabaseTest, CreationReadOnly) {
     kuzu_database_destroy(&database);
 }
 
-TEST_F(CApiDatabaseTest, CreationInvalidPath) {
-    kuzu_database database;
-    kuzu_state state;
-    auto databasePathCStr = (char*)"";
-    state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
-    ASSERT_EQ(state, KuzuError);
-}
+//TEST_F(CApiDatabaseTest, CreationInvalidPath) {
+//    kuzu_database database;
+//    kuzu_state state;
+//    auto databasePathCStr = (char*)"";
+//    state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
+//    ASSERT_EQ(state, KuzuError);
+//}
 
 TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database database;

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -72,9 +72,11 @@ TEST_F(CApiDatabaseTest, CreationInMemory) {
     auto databasePathCStr = (char*)"";
     state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
     ASSERT_EQ(state, KuzuSuccess);
+    kuzu_database_destroy(&database);
     databasePathCStr = (char*)":memory:";
     state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
     ASSERT_EQ(state, KuzuSuccess);
+    kuzu_database_destroy(&database);
 }
 
 TEST_F(CApiDatabaseTest, CreationHomeDir) {

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -61,13 +61,13 @@ TEST_F(CApiDatabaseTest, CreationReadOnly) {
     kuzu_database_destroy(&database);
 }
 
-//TEST_F(CApiDatabaseTest, CreationInvalidPath) {
-//    kuzu_database database;
-//    kuzu_state state;
-//    auto databasePathCStr = (char*)"";
-//    state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
-//    ASSERT_EQ(state, KuzuError);
-//}
+// TEST_F(CApiDatabaseTest, CreationInvalidPath) {
+//     kuzu_database database;
+//     kuzu_state state;
+//     auto databasePathCStr = (char*)"";
+//     state = kuzu_database_init(databasePathCStr, kuzu_default_system_config(), &database);
+//     ASSERT_EQ(state, KuzuError);
+// }
 
 TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database database;

--- a/test/c_api/rdf_variant_test.cpp
+++ b/test/c_api/rdf_variant_test.cpp
@@ -12,17 +12,12 @@ public:
 
     void SetUp() override {
         APIRdfGraphTest::SetUp();
-        APIRdfGraphTest::createDBAndConn();
-        APIRdfGraphTest::initGraph();
-        // In C API tests, we don't use the database and connection created by DBTest because
-        // they are not C++ objects.
-        conn.reset();
-        database.reset();
-        auto databasePathCStr = databasePath.c_str();
-        auto systemConfig = kuzu_default_system_config();
-        systemConfig.buffer_pool_size = 512 * 1024 * 1024;
-        kuzu_database_init(databasePathCStr, systemConfig, &_database);
-        kuzu_connection_init(&_database, &connection);
+        createDBAndConn();
+        initGraph();
+        auto* connCppPointer = conn.release();
+        auto* databaseCppPointer = database.release();
+        connection = kuzu_connection{connCppPointer};
+        _database = kuzu_database{databaseCppPointer};
     }
 
     kuzu_database* getDatabase() { return &_database; }

--- a/test/c_api/version_test.cpp
+++ b/test/c_api/version_test.cpp
@@ -25,17 +25,20 @@ TEST_F(CApiVersionTest, GetVersion) {
     kuzu_destroy_string(version);
 }
 
-// TEST_F(CApiVersionTest, GetStorageVersion) {
-//     auto storageVersion = kuzu_get_storage_version();
-//     auto catalog = std::filesystem::path(databasePath) / "catalog.kz";
-//     std::ifstream catalogFile;
-//     catalogFile.open(catalog, std::ios::binary);
-//     char magic[5];
-//     catalogFile.read(magic, 4);
-//     magic[4] = '\0';
-//     ASSERT_STREQ(magic, "KUZU");
-//     uint64_t actualVersion;
-//     catalogFile.read(reinterpret_cast<char*>(&actualVersion), sizeof(actualVersion));
-//     catalogFile.close();
-//     ASSERT_EQ(storageVersion, actualVersion);
-// }
+TEST_F(CApiVersionTest, GetStorageVersion) {
+    auto storageVersion = kuzu_get_storage_version();
+    if (databasePath == "" || databasePath == ":memory:") {
+        return;
+    }
+    auto catalog = std::filesystem::path(databasePath) / "catalog.kz";
+    std::ifstream catalogFile;
+    catalogFile.open(catalog, std::ios::binary);
+    char magic[5];
+    catalogFile.read(magic, 4);
+    magic[4] = '\0';
+    ASSERT_STREQ(magic, "KUZU");
+    uint64_t actualVersion;
+    catalogFile.read(reinterpret_cast<char*>(&actualVersion), sizeof(actualVersion));
+    catalogFile.close();
+    ASSERT_EQ(storageVersion, actualVersion);
+}

--- a/test/c_api/version_test.cpp
+++ b/test/c_api/version_test.cpp
@@ -25,17 +25,17 @@ TEST_F(CApiVersionTest, GetVersion) {
     kuzu_destroy_string(version);
 }
 
-TEST_F(CApiVersionTest, GetStorageVersion) {
-    auto storageVersion = kuzu_get_storage_version();
-    auto catalog = std::filesystem::path(databasePath) / "catalog.kz";
-    std::ifstream catalogFile;
-    catalogFile.open(catalog, std::ios::binary);
-    char magic[5];
-    catalogFile.read(magic, 4);
-    magic[4] = '\0';
-    ASSERT_STREQ(magic, "KUZU");
-    uint64_t actualVersion;
-    catalogFile.read(reinterpret_cast<char*>(&actualVersion), sizeof(actualVersion));
-    catalogFile.close();
-    ASSERT_EQ(storageVersion, actualVersion);
-}
+// TEST_F(CApiVersionTest, GetStorageVersion) {
+//     auto storageVersion = kuzu_get_storage_version();
+//     auto catalog = std::filesystem::path(databasePath) / "catalog.kz";
+//     std::ifstream catalogFile;
+//     catalogFile.open(catalog, std::ios::binary);
+//     char magic[5];
+//     catalogFile.read(magic, 4);
+//     magic[4] = '\0';
+//     ASSERT_STREQ(magic, "KUZU");
+//     uint64_t actualVersion;
+//     catalogFile.read(reinterpret_cast<char*>(&actualVersion), sizeof(actualVersion));
+//     catalogFile.close();
+//     ASSERT_EQ(storageVersion, actualVersion);
+// }

--- a/test/graph_test/base_graph_test.cpp
+++ b/test/graph_test/base_graph_test.cpp
@@ -70,19 +70,19 @@ void BaseGraphTest::createDB() {
     if (database != nullptr) {
         database.reset();
     }
-    database = std::make_unique<main::Database>(databasePath, *systemConfig);
+    database = std::make_unique<Database>(databasePath, *systemConfig);
     spdlog::set_level(spdlog::level::info);
 }
 
 void BaseGraphTest::createConns(const std::set<std::string>& connNames) {
     if (connNames.size() == 0) { // impart a default connName
-        conn = std::make_unique<main::Connection>(database.get());
+        conn = std::make_unique<Connection>(database.get());
     } else {
         for (auto connName : connNames) {
             if (connMap[connName] != nullptr) {
                 connMap[connName].reset();
             }
-            connMap[connName] = std::make_unique<main::Connection>(database.get());
+            connMap[connName] = std::make_unique<Connection>(database.get());
         }
     }
 }
@@ -91,12 +91,12 @@ void BaseGraphTest::createDBAndConn() {
     if (database != nullptr) {
         database.reset();
     }
-    database = std::make_unique<main::Database>(databasePath, *systemConfig);
-    conn = std::make_unique<main::Connection>(database.get());
+    database = std::make_unique<Database>(databasePath, *systemConfig);
+    conn = std::make_unique<Connection>(database.get());
     spdlog::set_level(spdlog::level::info);
 }
 
-void BaseGraphTest::initGraph(std::string datasetDir) {
+void BaseGraphTest::initGraph(const std::string& datasetDir) const {
     if (conn) { // normal conn
         TestHelper::executeScript(datasetDir + TestHelper::SCHEMA_FILE_NAME, *conn);
         TestHelper::executeScript(datasetDir + TestHelper::COPY_FILE_NAME, *conn);

--- a/test/graph_test/graph_test.cpp
+++ b/test/graph_test/graph_test.cpp
@@ -57,8 +57,11 @@ void DBTest::runTest(const std::vector<std::unique_ptr<TestStatement>>& statemen
             continue;
         }
         if (statement->reloadDBFlag) {
-            createDB(checkpointWaitTimeout);
-            createConns(connNames);
+            // For in-mem mode, we skip reload.
+            if (!inMemMode) {
+                createDB(checkpointWaitTimeout);
+                createConns(connNames);
+            }
             continue;
         }
         if (statement->connectionsStatusFlag == ConcurrentStatusFlag::BEGIN) {

--- a/test/include/graph_test/base_graph_test.h
+++ b/test/include/graph_test/base_graph_test.h
@@ -34,7 +34,11 @@ public:
 
     virtual std::string getInputDir() = 0;
 
-    void TearDown() override { removeDir(databasePath); }
+    void TearDown() override {
+        if (!inMemory) {
+            removeDir(databasePath);
+        }
+    }
 
     void createDBAndConn();
 
@@ -80,9 +84,12 @@ protected:
     }
 
 private:
-    void setDatabasePath() { databasePath = TestHelper::getTempDir(getTestGroupAndName()); }
+    void setDatabasePath() {
+        databasePath = inMemory ? "" : TestHelper::getTempDir(getTestGroupAndName());
+    }
 
 public:
+    bool inMemory = true;
     std::string databasePath;
     std::unique_ptr<main::SystemConfig> systemConfig;
     std::unique_ptr<main::Database> database;

--- a/test/include/graph_test/base_graph_test.h
+++ b/test/include/graph_test/base_graph_test.h
@@ -35,7 +35,7 @@ public:
     virtual std::string getInputDir() = 0;
 
     void TearDown() override {
-        if (!inMemory) {
+        if (!inMemMode) {
             removeDir(databasePath);
         }
     }
@@ -47,37 +47,37 @@ public:
     virtual void createConns(const std::set<std::string>& connNames);
 
     void initGraph() { initGraph(getInputDir()); }
-    void initGraph(std::string datasetDir);
+    void initGraph(const std::string& datasetDir) const;
 
-    void setIEDatabasePath(std::string filePath) { ieDBPath = filePath; }
+    void setIEDatabasePath(const std::string& filePath) { ieDBPath = filePath; }
     void removeIEDBPath() const {
         if (ieDBPath != "") {
-            auto lastSlashPos = ieDBPath.rfind('/');
-            auto deletePath = ieDBPath.substr(0, lastSlashPos);
+            const auto lastSlashPos = ieDBPath.rfind('/');
+            const auto deletePath = ieDBPath.substr(0, lastSlashPos);
             removeDir(deletePath);
         }
     }
 
 protected:
     // Static functions to access Database's non-public properties/interfaces.
-    static storage::BufferManager* getBufferManager(main::Database& database) {
+    static storage::BufferManager* getBufferManager(const main::Database& database) {
         return database.bufferManager.get();
     }
-    static common::VirtualFileSystem* getFileSystem(main::Database& database) {
+    static common::VirtualFileSystem* getFileSystem(const main::Database& database) {
         return database.vfs.get();
     }
 
     // Static functions to access Connection's non-public properties/interfaces.
-    static main::ClientContext* getClientContext(main::Connection& connection) {
+    static main::ClientContext* getClientContext(const main::Connection& connection) {
         return connection.clientContext.get();
     }
-    static void sortAndCheckTestResults(std::vector<std::string>& actualResult,
+    static void sortAndCheckTestResults(const std::vector<std::string>& actualResult,
         std::vector<std::string>& expectedResult) {
         sort(expectedResult.begin(), expectedResult.end());
         ASSERT_EQ(actualResult, expectedResult);
     }
 
-    std::string getTestGroupAndName() {
+    static std::string getTestGroupAndName() {
         const ::testing::TestInfo* const testInfo =
             ::testing::UnitTest::GetInstance()->current_test_info();
         return std::string(testInfo->test_case_name()) + "." + std::string(testInfo->name());
@@ -85,11 +85,14 @@ protected:
 
 private:
     void setDatabasePath() {
-        databasePath = inMemory ? "" : TestHelper::getTempDir(getTestGroupAndName());
+        auto isValid = [](const char* env) { return env != nullptr && strlen(env) > 0; };
+        const auto inMemModeEnv = std::getenv("IN_MEM_MODE");
+        inMemMode = isValid(inMemModeEnv) ? std::string(inMemModeEnv) == "true" : false;
+        databasePath = inMemMode ? "" : TestHelper::getTempDir(getTestGroupAndName());
     }
 
 public:
-    bool inMemory = true;
+    bool inMemMode = true;
     std::string databasePath;
     std::unique_ptr<main::SystemConfig> systemConfig;
     std::unique_ptr<main::Database> database;

--- a/test/include/test_helper/test_helper.h
+++ b/test/include/test_helper/test_helper.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <filesystem>
-#include <memory>
 
 #include "main/kuzu.h"
+#include <common/string_utils.h>
 
 namespace kuzu {
 namespace testing {
@@ -34,7 +34,7 @@ public:
     static std::vector<std::string> convertResultToString(main::QueryResult& queryResult,
         bool checkOutputOrder = false);
 
-    static void executeScript(const std::string& path, main::Connection& conn);
+    static void executeScript(const std::string& cypherScript, main::Connection& conn);
 
     static std::string getTestListFile() {
         return appendKuzuRootPath(std::string(E2E_TEST_FILES_DIRECTORY) + "/test_list");
@@ -50,30 +50,30 @@ public:
 
     static std::unique_ptr<main::SystemConfig> getSystemConfigFromEnv() {
         auto systemConfig = std::make_unique<main::SystemConfig>();
-        auto autoCheckpointEnv = std::getenv("AUTO_CHECKPOINT");
-        auto bufferPoolSizeEnv = std::getenv("BUFFER_POOL_SIZE");
-        auto maxNumThreadsEnv = std::getenv("MAX_NUM_THREADS");
-        auto enableCompressionEnv = std::getenv("ENABLE_COMPRESSION");
-        auto checkpointThresholdEnv = std::getenv("CHECKPOINT_THRESHOLD");
-        auto isValid = [](const char* env) { return env != nullptr && strlen(env) > 0; };
+        auto autoCheckpointEnv = getSystemEnv("AUTO_CHECKPOINT");
+        auto bufferPoolSizeEnv = getSystemEnv("BUFFER_POOL_SIZE");
+        auto maxNumThreadsEnv = getSystemEnv("MAX_NUM_THREADS");
+        auto enableCompressionEnv = getSystemEnv("ENABLE_COMPRESSION");
+        auto checkpointThresholdEnv = getSystemEnv("CHECKPOINT_THRESHOLD");
         systemConfig->autoCheckpoint =
-            isValid(autoCheckpointEnv) ? std::string(autoCheckpointEnv) == "true" : false;
+            autoCheckpointEnv.empty() ? false : std::string(autoCheckpointEnv) == "true";
         systemConfig->bufferPoolSize =
-            isValid(bufferPoolSizeEnv) ?
-                std::stoull(bufferPoolSizeEnv) :
-                common::BufferPoolConstants::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING;
-        systemConfig->maxNumThreads = isValid(maxNumThreadsEnv) ? std::stoull(maxNumThreadsEnv) : 2;
-        systemConfig->enableCompression =
-            isValid(enableCompressionEnv) ? std::string(enableCompressionEnv) == "true" : true;
-        systemConfig->checkpointThreshold = isValid(checkpointThresholdEnv) ?
-                                                std::stoull(checkpointThresholdEnv) :
-                                                systemConfig->checkpointThreshold;
+            bufferPoolSizeEnv.empty() ?
+                common::BufferPoolConstants::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING :
+                std::stoull(bufferPoolSizeEnv);
+        systemConfig->maxNumThreads = maxNumThreadsEnv.empty() ? 2 : std::stoull(maxNumThreadsEnv);
+        if (!enableCompressionEnv.empty()) {
+            systemConfig->enableCompression = enableCompressionEnv == "true";
+        }
+        systemConfig->checkpointThreshold = checkpointThresholdEnv.empty() ?
+                                                systemConfig->checkpointThreshold :
+                                                std::stoull(checkpointThresholdEnv);
         return systemConfig;
     }
 
     static std::string getMillisecondsSuffix();
 
-    inline static std::filesystem::path getTempDir() {
+    static std::filesystem::path getTempDir() {
         auto tempDir = std::getenv("RUNNER_TEMP");
         if (tempDir != nullptr) {
             return std::filesystem::path(tempDir) / "kuzu";
@@ -82,8 +82,8 @@ public:
         }
     }
 
-    inline static std::string getTempDir(const std::string& name) {
-        auto path = getTempDir() / (name + TestHelper::getMillisecondsSuffix());
+    static std::string getTempDir(const std::string& name) {
+        const auto path = getTempDir() / (name + getMillisecondsSuffix());
         std::filesystem::create_directories(path);
         auto pathStr = path.string();
 #ifdef _WIN32
@@ -91,6 +91,17 @@ public:
         std::replace(pathStr.begin(), pathStr.end(), '\\', '/');
 #endif
         return pathStr;
+    }
+
+    static bool isSystemEnvValid(const char* env) { return env != nullptr && strlen(env) > 0; }
+    static std::string getSystemEnv(const char* key) {
+        const auto env = std::getenv(key);
+        if (isSystemEnvValid(env)) {
+            auto envStr = std::string(env);
+            common::StringUtils::toLower(envStr);
+            return envStr;
+        }
+        return "";
     }
 
 private:

--- a/test/include/test_helper/test_helper.h
+++ b/test/include/test_helper/test_helper.h
@@ -2,8 +2,8 @@
 
 #include <filesystem>
 
+#include "common/string_utils.h"
 #include "main/kuzu.h"
-#include <common/string_utils.h>
 
 namespace kuzu {
 namespace testing {

--- a/test/include/test_runner/test_parser.h
+++ b/test/include/test_runner/test_parser.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <fstream>
 #include <numeric>
 
@@ -14,6 +16,7 @@ enum class TokenType {
     SKIP,
     SKIP_MUSL,
     SKIP_32BIT,
+    SKIP_IN_MEM,
     // body
     BUFFER_POOL_SIZE,
     CASE,
@@ -58,7 +61,8 @@ const std::unordered_map<std::string, TokenType> tokenMap = {{"-DATASET", TokenT
     {"-ENUMERATE", TokenType::ENUMERATE}, {"-PARALLELISM", TokenType::PARALLELISM},
     {"-SKIP", TokenType::SKIP}, {"-SKIP_MUSL", TokenType::SKIP_MUSL},
     {"-SKIP_LINE", TokenType::DEFINE}, {"-SKIP_32BIT", TokenType::SKIP_32BIT},
-    {"-DEFINE", TokenType::DEFINE}, {"-STATEMENT", TokenType::STATEMENT},
+    {"-SKIP_IN_MEM", TokenType::SKIP_IN_MEM}, {"-DEFINE", TokenType::DEFINE},
+    {"-STATEMENT", TokenType::STATEMENT},
     {"-INSERT_STATEMENT_BLOCK", TokenType::INSERT_STATEMENT_BLOCK},
     {"-ROLLBACK", TokenType::ROLLBACK}, {"-BUFFER_POOL_SIZE", TokenType::BUFFER_POOL_SIZE},
     {"-CHECKPOINT_WAIT_TIMEOUT", TokenType::CHECKPOINT_WAIT_TIMEOUT},
@@ -82,7 +86,7 @@ public:
 class TestParser {
 public:
     explicit TestParser(const std::string& path)
-        : path{path}, testGroup{std::make_unique<TestGroup>()} {}
+        : path{path}, testGroup{std::make_unique<TestGroup>()}, currentToken{} {}
     std::unique_ptr<TestGroup> parseTestFile();
 
 private:
@@ -94,32 +98,32 @@ private:
     std::unique_ptr<TestGroup> testGroup;
     std::string extractTextBeforeNextStatement(bool ignoreLineBreak = false);
     std::string parseCommand();
-    std::string parseCommandArange();
+    std::string parseCommandArange() const;
     std::string parseCommandRepeat();
     LogicToken currentToken;
 
     void openFile();
     void tokenize();
-    void genGroupName();
+    void genGroupName() const;
     void parseHeader();
     void parseBody();
     void extractExpectedResults(TestStatement* statement);
     TestQueryResult extractExpectedResultFromToken(bool checkOutputOrder);
     void extractStatementBlock();
     void extractDataset();
-    void addStatementBlock(const std::string& blockName, const std::string& testGroupName);
-    void replaceVariables(std::string& str);
-    void extractConnName(std::string& query, TestStatement* statement);
+    void addStatementBlock(const std::string& blockName, const std::string& testCaseName) const;
+    void replaceVariables(std::string& str) const;
+    static void extractConnName(std::string& query, TestStatement* statement);
 
-    inline bool endOfFile() { return fileStream.eof(); }
-    inline void setCursorToPreviousLine() { fileStream.seekg(previousFilePosition); }
+    bool endOfFile() const { return fileStream.eof(); }
+    void setCursorToPreviousLine() { fileStream.seekg(previousFilePosition); }
 
-    inline bool nextLine() {
+    bool nextLine() {
         previousFilePosition = fileStream.tellg();
         return static_cast<bool>(getline(fileStream, line));
     }
 
-    inline void checkMinimumParams(uint64_t minimumParams) {
+    void checkMinimumParams(uint64_t minimumParams) const {
         if (currentToken.params.size() - 1 < minimumParams) {
             throw common::TestException("Minimum number of parameters is " +
                                         std::to_string(minimumParams) + ". [" + path + ":" + line +
@@ -127,7 +131,7 @@ private:
         }
     }
 
-    inline std::string paramsToString(int startParamIdx) {
+    std::string paramsToString(int startParamIdx) {
         return std::accumulate(std::next(currentToken.params.begin(), startParamIdx),
             currentToken.params.end(), std::string(),
             [](const std::string& a, const std::string& b) {
@@ -135,11 +139,10 @@ private:
             });
     }
 
-    inline std::string getParam(int paramIdx) { return currentToken.params[paramIdx]; }
+    std::string getParam(int paramIdx) { return currentToken.params[paramIdx]; }
 
-    TestStatement* extractStatement(TestStatement* currentStatement,
-        const std::string& testCaseName);
-    TestStatement* addNewStatement(std::string& name);
+    TestStatement* extractStatement(TestStatement* statement, const std::string& testCaseName);
+    TestStatement* addNewStatement(const std::string& testGroupName) const;
 
     const std::string exportDBPath = TestHelper::getTempDir("export_db");
     // Any value here will be replaced inside the .test files

--- a/test/main/db_locking_test.cpp
+++ b/test/main/db_locking_test.cpp
@@ -12,122 +12,129 @@ class DBLockingTest : public ApiTest {
     void SetUp() override { BaseGraphTest::SetUp(); }
 };
 
-// TEST_F(DBLockingTest, testReadLock) {
-//     uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
-//         MAP_ANONYMOUS | MAP_SHARED, 0, 0);
-//     *count = 0;
-//     // create db
-//     EXPECT_NO_THROW(createDBAndConn());
-//     ASSERT_TRUE(conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY
-//     KEY(name));")
-//                     ->isSuccess());
-//     ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
-//     database.reset();
-//     // test read write db
-//     pid_t pid = fork();
-//     if (pid == 0) {
-//         systemConfig->readOnly = true;
-//         EXPECT_NO_THROW(createDBAndConn());
-//         (*count)++;
-//         ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-//         while (true) {
-//             usleep(100);
-//             ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-//         }
-//     } else if (pid > 0) {
-//         while (*count == 0) {
-//             usleep(100);
-//         }
-//         systemConfig->readOnly = false;
-//         // try to open db for writing, this should fail
-//         EXPECT_ANY_THROW(createDBAndConn());
-//         // but opening db for reading should work
-//         systemConfig->readOnly = true;
-//         EXPECT_NO_THROW(createDBAndConn());
-//         ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-//         // kill the child
-//         if (kill(pid, SIGKILL) != 0) {
-//             FAIL();
-//         }
-//     }
-// }
+TEST_F(DBLockingTest, testReadLock) {
+    if (databasePath == "" || databasePath == ":memory:") {
+        return;
+    }
+    uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+    *count = 0;
+    // create db
+    EXPECT_NO_THROW(createDBAndConn());
+    ASSERT_TRUE(conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+                    ->isSuccess());
+    ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+    database.reset();
+    // test read write db
+    pid_t pid = fork();
+    if (pid == 0) {
+        systemConfig->readOnly = true;
+        EXPECT_NO_THROW(createDBAndConn());
+        (*count)++;
+        ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+        while (true) {
+            usleep(100);
+            ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+        }
+    } else if (pid > 0) {
+        while (*count == 0) {
+            usleep(100);
+        }
+        systemConfig->readOnly = false;
+        // try to open db for writing, this should fail
+        EXPECT_ANY_THROW(createDBAndConn());
+        // but opening db for reading should work
+        systemConfig->readOnly = true;
+        EXPECT_NO_THROW(createDBAndConn());
+        ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+        // kill the child
+        if (kill(pid, SIGKILL) != 0) {
+            FAIL();
+        }
+    }
+}
 
-// TEST_F(DBLockingTest, testWriteLock) {
-//     uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
-//         MAP_ANONYMOUS | MAP_SHARED, 0, 0);
-//     *count = 0;
-//     // test write lock
-//     // fork away a child
-//     pid_t pid = fork();
-//     if (pid == 0) {
-//         // child process
-//         // open db for writing
-//         systemConfig->readOnly = false;
-//         EXPECT_NO_THROW(createDBAndConn());
-//         // opened db for writing
-//         // insert some values
-//         (*count)++;
-//         ASSERT_TRUE(
-//             conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
-//                 ->isSuccess());
-//         ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
-//         while (true) {
-//             ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-//             usleep(100);
-//         }
-//     } else if (pid > 0) {
-//         // parent process
-//         // sleep a bit to wait for child process
-//         while (*count == 0) {
-//             usleep(100);
-//         }
-//         // try to open db for writing, this should fail
-//         systemConfig->readOnly = false;
-//         EXPECT_ANY_THROW(createDBAndConn());
-//         // try to open db for reading, this should fail
-//         systemConfig->readOnly = true;
-//         EXPECT_ANY_THROW(createDBAndConn());
-//         // kill the child
-//         if (kill(pid, SIGKILL) != 0) {
-//             FAIL();
-//         }
-//     }
-// }
+TEST_F(DBLockingTest, testWriteLock) {
+    if (databasePath == "" || databasePath == ":memory:") {
+        return;
+    }
+    uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+    *count = 0;
+    // test write lock
+    // fork away a child
+    pid_t pid = fork();
+    if (pid == 0) {
+        // child process
+        // open db for writing
+        systemConfig->readOnly = false;
+        EXPECT_NO_THROW(createDBAndConn());
+        // opened db for writing
+        // insert some values
+        (*count)++;
+        ASSERT_TRUE(
+            conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+                ->isSuccess());
+        ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+        while (true) {
+            ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+            usleep(100);
+        }
+    } else if (pid > 0) {
+        // parent process
+        // sleep a bit to wait for child process
+        while (*count == 0) {
+            usleep(100);
+        }
+        // try to open db for writing, this should fail
+        systemConfig->readOnly = false;
+        EXPECT_ANY_THROW(createDBAndConn());
+        // try to open db for reading, this should fail
+        systemConfig->readOnly = true;
+        EXPECT_ANY_THROW(createDBAndConn());
+        // kill the child
+        if (kill(pid, SIGKILL) != 0) {
+            FAIL();
+        }
+    }
+}
 
-// TEST_F(DBLockingTest, testReadOnly) {
-//     uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
-//         MAP_ANONYMOUS | MAP_SHARED, 0, 0);
-//     *count = 0;
-//     // cannot create a read-only database in a new directory
-//     systemConfig->readOnly = true;
-//     EXPECT_ANY_THROW(createDBAndConn());
-//
-//     // create the database file and initialize it with data
-//     pid_t create_pid = fork();
-//     if (create_pid == 0) {
-//         systemConfig->readOnly = false;
-//         EXPECT_NO_THROW(createDBAndConn());
-//         ASSERT_TRUE(
-//             conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
-//                 ->isSuccess());
-//         ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
-//         exit(0);
-//     }
-//     waitpid(create_pid, NULL, 0);
-//
-//     // now connect in read-only mode
-//     systemConfig->readOnly = true;
-//     EXPECT_NO_THROW(createDBAndConn());
-//     // we can query the database
-//     ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-//     // however, we can't perform DDL statements
-//     ASSERT_FALSE(
-//         conn->query("CREATE NODE TABLE university(ID INT64, PRIMARY KEY(ID))")->isSuccess());
-//     ASSERT_FALSE(conn->query("ALTER TABLE Peron DROP name")->isSuccess());
-//     ASSERT_FALSE(conn->query("DROP TABLE Peron")->isSuccess());
-//     // neither can we insert/update/delete data
-//     ASSERT_FALSE(conn->query("CREATE (:Person {name: 'Bob', age: 25});")->isSuccess());
-//     ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE p.name='Alice' SET
-//     p.age=26;")->isSuccess()); ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE name='Alice'
-//     DELETE p;")->isSuccess());
-// }
+TEST_F(DBLockingTest, testReadOnly) {
+    if (databasePath == "" || databasePath == ":memory:") {
+        return;
+    }
+    uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
+        MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+    *count = 0;
+    // cannot create a read-only database in a new directory
+    systemConfig->readOnly = true;
+    EXPECT_ANY_THROW(createDBAndConn());
+
+    // create the database file and initialize it with data
+    pid_t create_pid = fork();
+    if (create_pid == 0) {
+        systemConfig->readOnly = false;
+        EXPECT_NO_THROW(createDBAndConn());
+        ASSERT_TRUE(
+            conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+                ->isSuccess());
+        ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+        exit(0);
+    }
+    waitpid(create_pid, NULL, 0);
+
+    // now connect in read-only mode
+    systemConfig->readOnly = true;
+    EXPECT_NO_THROW(createDBAndConn());
+    // we can query the database
+    ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+    // however, we can't perform DDL statements
+    ASSERT_FALSE(
+        conn->query("CREATE NODE TABLE university(ID INT64, PRIMARY KEY(ID))")->isSuccess());
+    ASSERT_FALSE(conn->query("ALTER TABLE Peron DROP name")->isSuccess());
+    ASSERT_FALSE(conn->query("DROP TABLE Peron")->isSuccess());
+    // neither can we insert/update/delete data
+    ASSERT_FALSE(conn->query("CREATE (:Person {name: 'Bob', age: 25});")->isSuccess());
+    ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE p.name='Alice' SET p.age=26;")->isSuccess());
+    ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE name='Alice' DELETE p;")->isSuccess());
+}

--- a/test/main/db_locking_test.cpp
+++ b/test/main/db_locking_test.cpp
@@ -12,120 +12,122 @@ class DBLockingTest : public ApiTest {
     void SetUp() override { BaseGraphTest::SetUp(); }
 };
 
-TEST_F(DBLockingTest, testReadLock) {
-    uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
-        MAP_ANONYMOUS | MAP_SHARED, 0, 0);
-    *count = 0;
-    // create db
-    EXPECT_NO_THROW(createDBAndConn());
-    ASSERT_TRUE(conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
-                    ->isSuccess());
-    ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
-    database.reset();
-    // test read write db
-    pid_t pid = fork();
-    if (pid == 0) {
-        systemConfig->readOnly = true;
-        EXPECT_NO_THROW(createDBAndConn());
-        (*count)++;
-        ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-        while (true) {
-            usleep(100);
-            ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-        }
-    } else if (pid > 0) {
-        while (*count == 0) {
-            usleep(100);
-        }
-        systemConfig->readOnly = false;
-        // try to open db for writing, this should fail
-        EXPECT_ANY_THROW(createDBAndConn());
-        // but opening db for reading should work
-        systemConfig->readOnly = true;
-        EXPECT_NO_THROW(createDBAndConn());
-        ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-        // kill the child
-        if (kill(pid, SIGKILL) != 0) {
-            FAIL();
-        }
-    }
-}
+// TEST_F(DBLockingTest, testReadLock) {
+//     uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
+//         MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+//     *count = 0;
+//     // create db
+//     EXPECT_NO_THROW(createDBAndConn());
+//     ASSERT_TRUE(conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY
+//     KEY(name));")
+//                     ->isSuccess());
+//     ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+//     database.reset();
+//     // test read write db
+//     pid_t pid = fork();
+//     if (pid == 0) {
+//         systemConfig->readOnly = true;
+//         EXPECT_NO_THROW(createDBAndConn());
+//         (*count)++;
+//         ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+//         while (true) {
+//             usleep(100);
+//             ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+//         }
+//     } else if (pid > 0) {
+//         while (*count == 0) {
+//             usleep(100);
+//         }
+//         systemConfig->readOnly = false;
+//         // try to open db for writing, this should fail
+//         EXPECT_ANY_THROW(createDBAndConn());
+//         // but opening db for reading should work
+//         systemConfig->readOnly = true;
+//         EXPECT_NO_THROW(createDBAndConn());
+//         ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+//         // kill the child
+//         if (kill(pid, SIGKILL) != 0) {
+//             FAIL();
+//         }
+//     }
+// }
 
-TEST_F(DBLockingTest, testWriteLock) {
-    uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
-        MAP_ANONYMOUS | MAP_SHARED, 0, 0);
-    *count = 0;
-    // test write lock
-    // fork away a child
-    pid_t pid = fork();
-    if (pid == 0) {
-        // child process
-        // open db for writing
-        systemConfig->readOnly = false;
-        EXPECT_NO_THROW(createDBAndConn());
-        // opened db for writing
-        // insert some values
-        (*count)++;
-        ASSERT_TRUE(
-            conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
-                ->isSuccess());
-        ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
-        while (true) {
-            ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-            usleep(100);
-        }
-    } else if (pid > 0) {
-        // parent process
-        // sleep a bit to wait for child process
-        while (*count == 0) {
-            usleep(100);
-        }
-        // try to open db for writing, this should fail
-        systemConfig->readOnly = false;
-        EXPECT_ANY_THROW(createDBAndConn());
-        // try to open db for reading, this should fail
-        systemConfig->readOnly = true;
-        EXPECT_ANY_THROW(createDBAndConn());
-        // kill the child
-        if (kill(pid, SIGKILL) != 0) {
-            FAIL();
-        }
-    }
-}
+// TEST_F(DBLockingTest, testWriteLock) {
+//     uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
+//         MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+//     *count = 0;
+//     // test write lock
+//     // fork away a child
+//     pid_t pid = fork();
+//     if (pid == 0) {
+//         // child process
+//         // open db for writing
+//         systemConfig->readOnly = false;
+//         EXPECT_NO_THROW(createDBAndConn());
+//         // opened db for writing
+//         // insert some values
+//         (*count)++;
+//         ASSERT_TRUE(
+//             conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+//                 ->isSuccess());
+//         ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+//         while (true) {
+//             ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+//             usleep(100);
+//         }
+//     } else if (pid > 0) {
+//         // parent process
+//         // sleep a bit to wait for child process
+//         while (*count == 0) {
+//             usleep(100);
+//         }
+//         // try to open db for writing, this should fail
+//         systemConfig->readOnly = false;
+//         EXPECT_ANY_THROW(createDBAndConn());
+//         // try to open db for reading, this should fail
+//         systemConfig->readOnly = true;
+//         EXPECT_ANY_THROW(createDBAndConn());
+//         // kill the child
+//         if (kill(pid, SIGKILL) != 0) {
+//             FAIL();
+//         }
+//     }
+// }
 
-TEST_F(DBLockingTest, testReadOnly) {
-    uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
-        MAP_ANONYMOUS | MAP_SHARED, 0, 0);
-    *count = 0;
-    // cannot create a read-only database in a new directory
-    systemConfig->readOnly = true;
-    EXPECT_ANY_THROW(createDBAndConn());
-
-    // create the database file and initialize it with data
-    pid_t create_pid = fork();
-    if (create_pid == 0) {
-        systemConfig->readOnly = false;
-        EXPECT_NO_THROW(createDBAndConn());
-        ASSERT_TRUE(
-            conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
-                ->isSuccess());
-        ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
-        exit(0);
-    }
-    waitpid(create_pid, NULL, 0);
-
-    // now connect in read-only mode
-    systemConfig->readOnly = true;
-    EXPECT_NO_THROW(createDBAndConn());
-    // we can query the database
-    ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
-    // however, we can't perform DDL statements
-    ASSERT_FALSE(
-        conn->query("CREATE NODE TABLE university(ID INT64, PRIMARY KEY(ID))")->isSuccess());
-    ASSERT_FALSE(conn->query("ALTER TABLE Peron DROP name")->isSuccess());
-    ASSERT_FALSE(conn->query("DROP TABLE Peron")->isSuccess());
-    // neither can we insert/update/delete data
-    ASSERT_FALSE(conn->query("CREATE (:Person {name: 'Bob', age: 25});")->isSuccess());
-    ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE p.name='Alice' SET p.age=26;")->isSuccess());
-    ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE name='Alice' DELETE p;")->isSuccess());
-}
+// TEST_F(DBLockingTest, testReadOnly) {
+//     uint64_t* count = (uint64_t*)mmap(NULL, sizeof(uint64_t), PROT_READ | PROT_WRITE,
+//         MAP_ANONYMOUS | MAP_SHARED, 0, 0);
+//     *count = 0;
+//     // cannot create a read-only database in a new directory
+//     systemConfig->readOnly = true;
+//     EXPECT_ANY_THROW(createDBAndConn());
+//
+//     // create the database file and initialize it with data
+//     pid_t create_pid = fork();
+//     if (create_pid == 0) {
+//         systemConfig->readOnly = false;
+//         EXPECT_NO_THROW(createDBAndConn());
+//         ASSERT_TRUE(
+//             conn->query("CREATE NODE TABLE Person(name STRING, age INT64, PRIMARY KEY(name));")
+//                 ->isSuccess());
+//         ASSERT_TRUE(conn->query("CREATE (:Person {name: 'Alice', age: 25});")->isSuccess());
+//         exit(0);
+//     }
+//     waitpid(create_pid, NULL, 0);
+//
+//     // now connect in read-only mode
+//     systemConfig->readOnly = true;
+//     EXPECT_NO_THROW(createDBAndConn());
+//     // we can query the database
+//     ASSERT_TRUE(conn->query("MATCH (:Person) RETURN COUNT(*)")->isSuccess());
+//     // however, we can't perform DDL statements
+//     ASSERT_FALSE(
+//         conn->query("CREATE NODE TABLE university(ID INT64, PRIMARY KEY(ID))")->isSuccess());
+//     ASSERT_FALSE(conn->query("ALTER TABLE Peron DROP name")->isSuccess());
+//     ASSERT_FALSE(conn->query("DROP TABLE Peron")->isSuccess());
+//     // neither can we insert/update/delete data
+//     ASSERT_FALSE(conn->query("CREATE (:Person {name: 'Bob', age: 25});")->isSuccess());
+//     ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE p.name='Alice' SET
+//     p.age=26;")->isSuccess()); ASSERT_FALSE(conn->query("MATCH (p:Person) WHERE name='Alice'
+//     DELETE p;")->isSuccess());
+// }

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -236,12 +236,12 @@ TEST_F(ApiTest, issueTest4) {
     ASSERT_FALSE(result->hasNext());
 }
 
-TEST_F(ApiTest, PrepareExport) {
-    auto newDBPath = databasePath + "/newdb";
-    auto preparedStatement = conn->prepare("EXPORT DATABASE '" + newDBPath + '\'');
-    auto result = conn->execute(preparedStatement.get());
-    ASSERT_TRUE(result->isSuccess());
-}
+// TEST_F(ApiTest, PrepareExport) {
+//     auto newDBPath = databasePath + "/newdb";
+//     auto preparedStatement = conn->prepare("EXPORT DATABASE '" + newDBPath + '\'');
+//     auto result = conn->execute(preparedStatement.get());
+//     ASSERT_TRUE(result->isSuccess());
+// }
 
 TEST_F(ApiTest, ParameterWith) {
     auto preparedStatement = conn->prepare("WITH $1 AS x RETURN x");

--- a/test/main/prepare_test.cpp
+++ b/test/main/prepare_test.cpp
@@ -236,12 +236,15 @@ TEST_F(ApiTest, issueTest4) {
     ASSERT_FALSE(result->hasNext());
 }
 
-// TEST_F(ApiTest, PrepareExport) {
-//     auto newDBPath = databasePath + "/newdb";
-//     auto preparedStatement = conn->prepare("EXPORT DATABASE '" + newDBPath + '\'');
-//     auto result = conn->execute(preparedStatement.get());
-//     ASSERT_TRUE(result->isSuccess());
-// }
+TEST_F(ApiTest, PrepareExport) {
+    if (databasePath == "" || databasePath == ":memory:") {
+        return;
+    }
+    auto newDBPath = databasePath + "/newdb";
+    auto preparedStatement = conn->prepare("EXPORT DATABASE '" + newDBPath + '\'');
+    auto result = conn->execute(preparedStatement.get());
+    ASSERT_TRUE(result->isSuccess());
+}
 
 TEST_F(ApiTest, ParameterWith) {
     auto preparedStatement = conn->prepare("WITH $1 AS x RETURN x");

--- a/test/main/system_config_test.cpp
+++ b/test/main/system_config_test.cpp
@@ -22,6 +22,11 @@ TEST_F(SystemConfigTest, testAccessMode) {
     assertQuery(*con->query("MATCH (:Person1) RETURN COUNT(*)"));
     db.reset();
     systemConfig->readOnly = true;
+    if (databasePath == "" || databasePath == ":memory:") {
+        EXPECT_THROW(auto db2 = std::make_unique<Database>("", *systemConfig), Exception);
+        EXPECT_THROW(auto db2 = std::make_unique<Database>(":memory:", *systemConfig), Exception);
+        return;
+    }
     std::unique_ptr<Database> db2;
     std::unique_ptr<Connection> con2;
     EXPECT_NO_THROW(db2 = std::make_unique<Database>(databasePath, *systemConfig));

--- a/test/runner/e2e_test.cpp
+++ b/test/runner/e2e_test.cpp
@@ -1,4 +1,3 @@
-#include "common/exception/not_implemented.h"
 #include "common/string_utils.h"
 #include "graph_test/graph_test.h"
 #include "test_runner/csv_to_parquet_converter.h"

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -1,8 +1,6 @@
 #include <fcntl.h>
 
 #include "common/constants.h"
-#include "common/exception/runtime.h"
-#include "common/file_system/local_file_system.h"
 #include "graph_test/graph_test.h"
 
 using namespace kuzu::common;
@@ -26,7 +24,6 @@ public:
 
     void initDBAndConnection() {
         conn->query("CHECKPOINT");
-        createDBAndConn();
         readConn = std::make_unique<Connection>(database.get());
         conn->query("BEGIN TRANSACTION");
     }

--- a/test/storage/node_insertion_deletion_test.cpp
+++ b/test/storage/node_insertion_deletion_test.cpp
@@ -110,30 +110,3 @@ TEST_F(NodeInsertionDeletionTests, InsertManyNodesTest) {
     }
     ASSERT_EQ(i, BufferPoolConstants::PAGE_4KB_SIZE);
 }
-
-// TEST_F(NodeInsertionDeletionTests, TruncatedWalTest) {
-//     auto preparedStatement = conn->prepare("CREATE (:person {ID:$id});");
-//     auto fs = LocalFileSystem();
-//     // Note: this test will fail if the transaction is small enough to fit the wal headers in a
-//     // single page, since we currently may fail to recover if the headers are intact but shadow
-//     // pages are missing. Pages are flushed before writing the commit record to make sure that
-//     // doesn't happen during a regular interruption.
-//     for (int64_t i = 0; i < 20000; i++) {
-//         auto result =
-//             conn->execute(preparedStatement.get(), std::make_pair(std::string("id"), 10000 + i));
-//         ASSERT_TRUE(result->isSuccess()) << result->toString();
-//     }
-//     conn->query("COMMIT");
-//     auto databasePath = this->databasePath;
-//     auto walPath = fs.joinPath(databasePath, StorageConstants::WAL_FILE_SUFFIX);
-//     // Close database
-//     database.reset();
-//     {
-//         auto walFileInfo = fs.openFile(walPath, O_RDWR);
-//         ASSERT_GT(walFileInfo->getFileSize(), BufferPoolConstants::PAGE_4KB_SIZE)
-//             << "Test needs a wal file with more than one page";
-//         walFileInfo->truncate(BufferPoolConstants::PAGE_4KB_SIZE);
-//     }
-//     // Re-open database
-//     EXPECT_THROW(database = std::make_unique<Database>(databasePath), Exception);
-// }

--- a/test/test_files/binary_demo/demo_db.test
+++ b/test/test_files/binary_demo/demo_db.test
@@ -1,4 +1,5 @@
 -DATASET KUZU binary-demo
+-SKIP_IN_MEM
 --
 
 -CASE DemoDBTest

--- a/test/test_files/binary_demo/demo_db_create.test
+++ b/test/test_files/binary_demo/demo_db_create.test
@@ -1,5 +1,6 @@
 -DATASET KUZU binary-demo
 -SKIP_32BIT
+-SKIP_IN_MEM
 --
 
 -CASE CreateNodeFromFile

--- a/test/test_files/binary_demo/demo_db_delete.test
+++ b/test/test_files/binary_demo/demo_db_delete.test
@@ -1,5 +1,6 @@
 -DATASET KUZU binary-demo
 -SKIP_32BIT
+-SKIP_IN_MEM
 --
 
 -CASE DeleteNodeTest

--- a/test/test_files/binary_demo/demo_db_order.test
+++ b/test/test_files/binary_demo/demo_db_order.test
@@ -1,5 +1,6 @@
 -DATASET KUZU binary-demo
 -SKIP_32BIT
+-SKIP_IN_MEM
 --
 
 -CASE DemoDBOrderedTest

--- a/test/test_files/binary_demo/demo_db_set_copy.test
+++ b/test/test_files/binary_demo/demo_db_set_copy.test
@@ -1,5 +1,6 @@
 -DATASET KUZU binary-demo
 -SKIP_32BIT
+-SKIP_IN_MEM
 --
 
 -CASE SetSingleLabelNodeTest

--- a/test/test_files/copy/copy_snap_amazon0601_csv.test
+++ b/test/test_files/copy/copy_snap_amazon0601_csv.test
@@ -1,5 +1,5 @@
 -DATASET CSV snap/amazon0601/csv
-
+-SKIP_IN_MEM
 --
 
 -CASE CopySNAPAmazon0601CSV

--- a/test/test_files/copy/copy_snap_amazon0601_parquet.test
+++ b/test/test_files/copy/copy_snap_amazon0601_parquet.test
@@ -1,5 +1,5 @@
 -DATASET CSV snap/amazon0601/parquet
-
+-SKIP_IN_MEM
 --
 
 -CASE CopySNAPAmazon0601Parquet

--- a/test/test_files/copy/copy_to_big_results.test
+++ b/test/test_files/copy/copy_to_big_results.test
@@ -1,5 +1,5 @@
 -DATASET CSV copy-test/node/csv
-
+-SKIP_IN_MEM
 --
 
 -CASE CopyBigResults

--- a/test/test_files/copy/copy_to_csv.test
+++ b/test/test_files/copy/copy_to_csv.test
@@ -1,5 +1,5 @@
 -DATASET CSV tinysnb
-
+-SKIP_IN_MEM
 --
 
 -CASE TinySnbCopyToCSV

--- a/test/test_files/copy/copy_to_parquet.test
+++ b/test/test_files/copy/copy_to_parquet.test
@@ -1,5 +1,5 @@
 -DATASET CSV tinysnb
-
+-SKIP_IN_MEM
 --
 
 -CASE TinySnbCopyToParquet

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -206,7 +206,7 @@ Zhang|Noura
 
 -CASE ExplainExport
 -SKIP_IN_MEM
--STATEMENT EXPLAIN EXPORT Database "${KUZU_EXPORT_DB_DIRECTORY}_case9/demo-db" (format="parquet");
+-STATEMENT EXPLAIN EXPORT Database "${KUZU_EXPORT_DB_DIRECTORY}_case10/demo-db" (format="parquet");
 ---- ok
 -STATEMENT LOAD FROM "${KUZU_EXPORT_DB_DIRECTORY}_case9/demo-db/city.parquet" RETURN *
 ---- error

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -205,6 +205,7 @@ Karissa|Zhang
 Zhang|Noura
 
 -CASE ExplainExport
+-SKIP_IN_MEM
 -STATEMENT EXPLAIN EXPORT Database "${KUZU_EXPORT_DB_DIRECTORY}_case9/demo-db" (format="parquet");
 ---- ok
 -STATEMENT LOAD FROM "${KUZU_EXPORT_DB_DIRECTORY}_case9/demo-db/city.parquet" RETURN *

--- a/test/test_files/demo_db/demo_db.test
+++ b/test/test_files/demo_db/demo_db.test
@@ -411,7 +411,8 @@ Zhang|50
 ---- 1
 Adam|30
 
--LOG CopyTO
+-CASE CopyTO
+-SKIP_IN_MEM
 -STATEMENT COPY (MATCH (u:User) RETURN u.*) TO '${DATABASE_PATH}/user.csv' (header=true);
 ---- ok
 -STATEMENT LOAD FROM '${DATABASE_PATH}/user.csv' RETURN *;

--- a/test/test_files/extension/show_attached_databases.test
+++ b/test/test_files/extension/show_attached_databases.test
@@ -3,6 +3,7 @@
 --
 -CASE ShowDatabasesTest
 -SKIP_MUSL
+-SKIP_32BIT
 -LOG InstallExtension
 -STATEMENT INSTALL duckdb;
 ---- ok

--- a/test/test_files/transaction/basic.test
+++ b/test/test_files/transaction/basic.test
@@ -42,6 +42,7 @@ Connection already has an active transaction. Cannot start a transaction within 
 Alice
 
 -CASE CheckpointTimeoutErrorTest
+-SKIP_IN_MEM
 -CHECKPOINT_WAIT_TIMEOUT 10000
 -STATEMENT CALL auto_checkpoint=false
 ---- ok

--- a/test/test_files/transaction/basic.test
+++ b/test/test_files/transaction/basic.test
@@ -65,6 +65,7 @@ Timeout waiting for active transactions to leave the system before checkpointing
 ---- 0
 
 -CASE ForceCheckpointWhenClosingDB
+-SKIP_IN_MEM
 -STATEMENT CALL auto_checkpoint=false
 ---- ok
 -STATEMENT CREATE NODE TABLE person(ID INT64, age INT64, PRIMARY KEY(ID));

--- a/tools/java_api/src/test/java/com/kuzudb/test/DatabaseTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/DatabaseTest.java
@@ -1,55 +1,44 @@
-// TODO: FIX-ME. This test can hang on linux clang CI. Not reproducible locally yet. Should enable this test after fixing the issue.
-// package com.kuzudb.java_test;
-//
-// import com.kuzudb.*;
-// import org.junit.jupiter.api.io.TempDir;
-// import org.junit.jupiter.api.Test;
-//
-// import static org.junit.jupiter.api.Assertions.*;
-//
-// import java.nio.file.Path;
-//
-// import java.io.IOException;
-//
-// public class DatabaseTest extends TestBase {
-//     @TempDir
-//     static Path tempDir;
-//
-//     @Test
-//     void DBCreationAndDestroyWithArgs() {
-//         try {
-//             String dbPath = tempDir.toFile().getAbsolutePath();
-//             KuzuDatabase database = new KuzuDatabase(
-//                     dbPath,
-//                     1 << 28 /* 256 MB */,
-//                     true /* compression */,
-//                     false /* readOnly */,
-//                     1 << 30 /* 1 GB */
-//             );
-//             database.destroy();
-//         } catch (Exception e) {
-//             fail("DBCreationAndDestroyWithArgs failed");
-//         }
-//     }
-//
-//     @Test
-//     void DBCreationAndDestroyWithPathOnly() {
-//         try {
-//             String dbPath = tempDir.toFile().getAbsolutePath();
-//             KuzuDatabase database = new KuzuDatabase(dbPath);
-//             database.destroy();
-//         } catch (Exception e) {
-//             fail("DBCreationAndDestroyWithPathOnly failed");
-//         }
-//     }
-//
-//     @Test
-//     void DBInvalidPath() {
-//         try {
-//             KuzuDatabase database = new KuzuDatabase("");
-//             database.destroy();
-//             fail("DBInvalidPath did not throw exception as expected.");
-//         } catch (Exception e) {
-//         }
-//     }
-// }
+package com.kuzudb.java_test;
+
+import com.kuzudb.*;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.nio.file.Path;
+
+import java.io.IOException;
+
+public class DatabaseTest extends TestBase {
+    @TempDir
+    static Path tempDir;
+
+    @Test
+    void DBCreationAndDestroyWithArgs() {
+        try {
+            String dbPath = tempDir.toFile().getAbsolutePath();
+            KuzuDatabase database = new KuzuDatabase(
+                    dbPath,
+                    1 << 28 /* 256 MB */,
+                    true /* compression */,
+                    false /* readOnly */,
+                    1 << 30 /* 1 GB */
+            );
+            database.destroy();
+        } catch (Exception e) {
+            fail("DBCreationAndDestroyWithArgs failed");
+        }
+    }
+
+    @Test
+    void DBCreationAndDestroyWithPathOnly() {
+        try {
+            String dbPath = tempDir.toFile().getAbsolutePath();
+            KuzuDatabase database = new KuzuDatabase(dbPath);
+            database.destroy();
+        } catch (Exception e) {
+            fail("DBCreationAndDestroyWithPathOnly failed");
+        }
+    }
+}

--- a/tools/python_api/test/test_exception.py
+++ b/tools/python_api/test/test_exception.py
@@ -4,6 +4,7 @@ import sys
 
 import kuzu
 import pytest
+
 from type_aliases import ConnDB
 
 
@@ -18,13 +19,12 @@ def test_exception(conn_db_readonly: ConnDB) -> None:
 
 
 def test_db_path_exception() -> None:
-    path = ""
+    path = ":memory:"
     error_message = (
-        "IO exception: Failed to create directory  due to: IO exception: Directory  cannot be created. "
-        "Check if it exists and remove it."
+        "Cannot open an in-memory database under READ ONLY mode."
     )
     with pytest.raises(RuntimeError, match=error_message):
-        kuzu.Database(path)
+        kuzu.Database(path, read_only=True)
 
 
 def test_read_only_exception(conn_db_readonly: ConnDB) -> None:

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -131,12 +131,6 @@ mod tests {
     }
 
     #[test]
-    fn create_database_failure() {
-        Database::new("", SystemConfig::default())
-            .expect_err("An empty string should not be a valid database path!");
-    }
-
-    #[test]
     fn test_database_read_only() -> Result<()> {
         let temp_dir = tempfile::tempdir()?;
         // Create database first so that it can be opened read-only

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -57,9 +57,7 @@ int main(int argc, char* argv[]) {
         return 0;
     }
     if (!inputDirFlag) {
-        std::cerr << "Option '" + inputDirFlag.Name() + "' is required" << '\n';
-        std::cerr << parser;
-        return 1;
+        std::cout << "Open in in-mem mode." << '\n';
     }
 
     uint64_t bpSizeInMB = args::get(bpSizeInMBFlag);

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -5,13 +5,16 @@
 #include "args.hxx"
 #include "common/file_system/local_file_system.h"
 #include "embedded_shell.h"
+#include "main/db_config.h"
 
 using namespace kuzu::main;
 using namespace kuzu::common;
 
 int main(int argc, char* argv[]) {
     args::ArgumentParser parser("KuzuDB Shell");
-    args::Positional<std::string> inputDirFlag(parser, "databasePath", "Database path.");
+    args::Positional<std::string> inputDirFlag(parser, "databasePath",
+        "Path to the database. If not given or set to \":memory:\", the database will be opened "
+        "under in-memory mode.");
     args::HelpFlag help(parser, "help", "Display this help menu", {'h', "help"});
     args::ValueFlag<uint64_t> bpSizeInMBFlag(parser, "",
         "Size of buffer pool for default and large page sizes in megabytes",
@@ -56,9 +59,6 @@ int main(int argc, char* argv[]) {
         std::cout << "Kuzu " << KUZU_CMAKE_VERSION << '\n';
         return 0;
     }
-    if (!inputDirFlag) {
-        std::cout << "Open in in-mem mode." << '\n';
-    }
 
     uint64_t bpSizeInMB = args::get(bpSizeInMBFlag);
     uint64_t bpSizeInBytes = -1u;
@@ -95,8 +95,12 @@ int main(int argc, char* argv[]) {
         std::cerr << e.what() << '\n';
         return 1;
     }
-    std::cout << "Opened the database at path: " << databasePath << " in "
-              << (readOnlyMode ? "read-only mode" : "read-write mode") << "." << '\n';
+    if (DBConfig::isDBPathInMemory(databasePath)) {
+        std::cout << "Opened the database under in in-memory mode." << '\n';
+    } else {
+        std::cout << "Opened the database at path: " << databasePath << " in "
+                  << (readOnlyMode ? "read-only mode" : "read-write mode") << "." << '\n';
+    }
     std::cout << "Enter \":help\" for usage hints." << '\n' << std::flush;
     try {
         auto shell = EmbeddedShell(database, conn, pathToHistory.c_str());

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -1,15 +1,9 @@
 import os
 
 import pytest
+
 from conftest import ShellTest
 from test_helper import KUZU_VERSION, deleteIfExists
-
-def check_fails_without_db(flag, arg=None):
-    test = ShellTest().add_argument(flag)
-    if arg:
-        test.add_argument(arg)
-    result = test.run()
-    result.check_stderr("Option 'databasePath' is required")
 
 
 def test_database_path(temp_db) -> None:
@@ -53,9 +47,6 @@ def test_help(temp_db, flag) -> None:
     ],
 )
 def test_default_bp_size(temp_db, flag) -> None:
-    # fails without db path
-    check_fails_without_db(flag, "1000")
-
     # empty flag argument
     test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
@@ -73,6 +64,7 @@ def test_default_bp_size(temp_db, flag) -> None:
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
 
+
 @pytest.mark.parametrize(
     "flag",
     [
@@ -81,9 +73,6 @@ def test_default_bp_size(temp_db, flag) -> None:
     ],
 )
 def test_no_compression(temp_db, flag) -> None:
-    # fails without db path
-    check_fails_without_db(flag)
-    
     test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
@@ -103,9 +92,6 @@ def test_read_only(temp_db, flag) -> None:
     result = test.run()
     result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
 
-    # fails without db path
-    check_fails_without_db(flag)
-    
     # test read only
     test = (
         ShellTest()
@@ -125,9 +111,6 @@ def test_read_only(temp_db, flag) -> None:
 
 
 def test_history_path(temp_db, history_path) -> None:
-    # fails without db path
-    check_fails_without_db("-p", history_path)
-
     # empty flag argument
     test = ShellTest().add_argument(temp_db).add_argument("-p")
     result = test.run()

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -8,14 +8,9 @@ from test_helper import KUZU_VERSION, deleteIfExists
 
 def test_database_path(temp_db) -> None:
     # no database path
-    test = ShellTest().statement('RETURN "databases rule" AS a;')
+    test = ShellTest()
     result = test.run()
-    result.check_stderr("Option 'databasePath' is required")
-
-    # invalid database path
-    test = ShellTest().add_argument("///////").statement('RETURN "databases rule" AS a;')
-    result = test.run()
-    result.check_stderr("Cannot open file ///////.lock: Permission denied")
+    result.check_stdout("Opened the database under in in-memory mode.")
 
     # valid database path
     test = ShellTest().add_argument(temp_db).statement('RETURN "databases rule" AS a;')


### PR DESCRIPTION
# Description

Add the support for in-memory mode.  https://github.com/kuzudb/kuzu/issues/1816.

## Feature
When the database path is omitted, set to empty or set to `:memory:` (follow duck's convention here), the database will be open under in-memory mode.

The main differences between on-disk and in-memory mode are:
Under on-disk mode, all data will be persistent on disk. All transactions are logged in WAL, in which changes will be merged into database files during checkpoint.
While under the in-memory mode, there is no writes to WAL, no data is persistent to disk and `CHECKPOINT` will do nothing. All data are lost when the process finishes.

Restrictions on in-memory mode:
- The database cannot be open as read-only.
- When use Httpfs extension, we don't support file cache.
- Attaching an in-memory database is not allowed. (maybe we should allow?)

## Implementation
After MVCC changes, supporting in-mem mode becomes much easier.
New pages in BMFileHandle are pinned in BM and only unpinned when BMFileHandle gets destructed. Accesses to these pages directly grab frames from BM.

## Benchmark
Did a few simple benchmarks on ldbc-100.
#### COPY
```
| table       | in mem (ms) | on disk (ms) |
| ----------- | ----------- | ------------ |
| Comment     | 14879       | 34696        |
| Person      | 513         | 749          |
| knows       | 1781        | 2123         |
| likeComment | 29246       | 34581        |
```

```
| space usage | in-mem mode | on-disk mode |
| ----------- | ----------- | ------------ |
| mem         | 56.7GB      | 32.2GB       |
| disk        | 0           | 29GB         |
```

#### Scan
```
Q1: match (c:Comment) return min(c.ID), min(c.creationDate), min(c.locationIP), min(c.browserUsed), min(c.content), min(c.length)
Q2: MATCH (a:Person)-[:knows]->(b:Person)-[:knows]->(c:Person) RETURN MIN(a.birthday), MIN(b.birthday), MIN(c.birthday)
Q3: MATCH (a:Person)-[r:knows* 2..2]->(b:Person) RETURN COUNT(*);

| query | in-mem | on-disk (cold) | on-disk (warm) |
| ----- | ------ | -------------- | -------------- |
| Q1    | 1896   | 5330           | 1791           |
| Q2    | 1004   | 948            | 893            |
| Q3    | 72133  | 84419          | 
```
#### Insertions
1M node insertions.

```
CREATE NODE TABLE Person (id INT64, name STRING, age INT64, net_worth FLOAT, PRIMARY KEY (id));

| 1M txn in-mem (ms) | 1M txn on-disk (ms) | 1 txn in-mem (ms) | 1 txn on-disk (ms) |
| ------------------ | ------------------- | ---------------- | ------------------- |
| 47814              | 79313               | 38895            | 40054               |
```
## TODO
- [ ] rewrite copy to / export tests (copy to should not rely on db path)
