### PR TITLE
Fix delete on empty database

### DIFF
--- a/src/binder/expression/node_rel_expression.cpp
+++ b/src/binder/expression/node_rel_expression.cpp
@@ -1,5 +1,7 @@
 #include "binder/expression/node_rel_expression.h"
 
+#include "common/exception/runtime.h"
+
 using namespace kuzu::common;
 
 namespace kuzu {
@@ -15,7 +17,12 @@ void NodeOrRelExpression::addTableIDs(const table_id_vector_t& tableIDsToAdd) {
 }
 
 common::table_id_t NodeOrRelExpression::getSingleTableID() const {
-    KU_ASSERT(tableIDs.size() == 1);
+    // LCOV_EXCL_START
+    if (tableIDs.empty()) {
+        throw RuntimeException(
+            "Trying to access table id in an empty node. This should never happen");
+    }
+    // LCOV_EXCL_STOP
     return tableIDs[0];
 }
 

--- a/src/include/processor/operator/persistent/delete_executor.h
+++ b/src/include/processor/operator/persistent/delete_executor.h
@@ -167,8 +167,7 @@ protected:
 class EmptyRelDeleteExecutor final : public RelDeleteExecutor {
 public:
     explicit EmptyRelDeleteExecutor(RelDeleteInfo info) : RelDeleteExecutor{std::move(info)} {}
-    EmptyRelDeleteExecutor(const EmptyRelDeleteExecutor& other)
-        : RelDeleteExecutor{other} {}
+    EmptyRelDeleteExecutor(const EmptyRelDeleteExecutor& other) : RelDeleteExecutor{other} {}
 
     void delete_(ExecutionContext*) override {}
 

--- a/src/include/processor/operator/persistent/delete_executor.h
+++ b/src/include/processor/operator/persistent/delete_executor.h
@@ -77,6 +77,19 @@ protected:
     std::unique_ptr<storage::RelTableDeleteState> detachDeleteState;
 };
 
+// Handle MATCH (n) (DETACH)? DELETE n
+class EmptyNodeDeleteExecutor final : public NodeDeleteExecutor {
+public:
+    explicit EmptyNodeDeleteExecutor(NodeDeleteInfo info) : NodeDeleteExecutor{std::move(info)} {}
+    EmptyNodeDeleteExecutor(const EmptyNodeDeleteExecutor& other) : NodeDeleteExecutor{other} {}
+
+    void delete_(ExecutionContext*) override {}
+
+    std::unique_ptr<NodeDeleteExecutor> copy() const override {
+        return std::make_unique<EmptyNodeDeleteExecutor>(*this);
+    }
+};
+
 class SingleLabelNodeDeleteExecutor final : public NodeDeleteExecutor {
 public:
     SingleLabelNodeDeleteExecutor(NodeDeleteInfo info, NodeTableDeleteInfo tableInfo)
@@ -149,6 +162,19 @@ public:
 
 protected:
     RelDeleteInfo info;
+};
+
+class EmptyRelDeleteExecutor final : public RelDeleteExecutor {
+public:
+    explicit EmptyRelDeleteExecutor(RelDeleteInfo info) : RelDeleteExecutor{std::move(info)} {}
+    EmptyRelDeleteExecutor(const EmptyRelDeleteExecutor& other)
+        : RelDeleteExecutor{other} {}
+
+    void delete_(ExecutionContext*) override {}
+
+    std::unique_ptr<RelDeleteExecutor> copy() const override {
+        return std::make_unique<EmptyRelDeleteExecutor>(*this);
+    }
 };
 
 class SingleLabelRelDeleteExecutor final : public RelDeleteExecutor {

--- a/src/processor/map/map_delete.cpp
+++ b/src/processor/map/map_delete.cpp
@@ -36,6 +36,9 @@ std::unique_ptr<NodeDeleteExecutor> PlanMapper::getNodeDeleteExecutor(
     auto& node = boundInfo.pattern->constCast<NodeExpression>();
     auto nodeIDPos = getDataPos(*node.getInternalID(), schema);
     auto info = NodeDeleteInfo(boundInfo.deleteType, nodeIDPos);
+    if (node.isEmpty()) {
+        return std::make_unique<EmptyNodeDeleteExecutor>(std::move(info));
+    }
     if (node.isMultiLabeled()) {
         common::table_id_map_t<NodeTableDeleteInfo> tableInfos;
         for (auto id : node.getTableIDs()) {
@@ -90,6 +93,9 @@ std::unique_ptr<RelDeleteExecutor> PlanMapper::getRelDeleteExecutor(
     auto dstNodeIDPos = getDataPos(*rel.getDstNode()->getInternalID(), schema);
     auto relIDPos = getDataPos(*rel.getInternalIDProperty(), schema);
     auto info = RelDeleteInfo(srcNodeIDPos, dstNodeIDPos, relIDPos);
+    if (rel.isEmpty()) {
+        return std::make_unique<EmptyRelDeleteExecutor>(std::move(info));
+    }
     if (rel.isMultiLabeled()) {
         common::table_id_map_t<storage::RelTable*> tableIDToTableMap;
         for (auto tableID : rel.getTableIDs()) {

--- a/src/processor/operator/persistent/delete_executor.cpp
+++ b/src/processor/operator/persistent/delete_executor.cpp
@@ -45,8 +45,8 @@ void NodeDeleteExecutor::init(ResultSet* resultSet, ExecutionContext*) {
     info.init(*resultSet);
     if (info.deleteType == DeleteNodeType::DETACH_DELETE) {
         const auto tempSharedState = std::make_shared<DataChunkState>();
-        dstNodeIDVector = std::make_unique<ValueVector>(LogicalType{LogicalTypeID::INTERNAL_ID});
-        relIDVector = std::make_unique<ValueVector>(LogicalType{LogicalTypeID::INTERNAL_ID});
+        dstNodeIDVector = std::make_unique<ValueVector>(LogicalType::INTERNAL_ID());
+        relIDVector = std::make_unique<ValueVector>(LogicalType::INTERNAL_ID());
         dstNodeIDVector->setState(tempSharedState);
         relIDVector->setState(tempSharedState);
         detachDeleteState = std::make_unique<RelTableDeleteState>(*info.nodeIDVector,

--- a/test/test_files/issue/issue.test
+++ b/test/test_files/issue/issue.test
@@ -2,6 +2,22 @@
 
 --
 
+-CASE 3870
+-STATEMENT CREATE NODE TABLE V (id INT64, PRIMARY KEY (id));
+---- ok
+-STATEMENT CREATE REL TABLE after ( FROM V TO V , ONE_ONE);
+---- ok
+-STATEMENT BEGIN TRANSACTION;
+---- ok
+-STATEMENT CREATE (:V {id: 0}), (:V {id: 1});
+---- ok
+-STATEMENT MATCH (ba:V)-[:after*0..]->(bb:V) return ba.id;
+---- 2
+0
+1
+-STATEMENT COMMIT;
+---- ok
+
 -CASE 3691
 -STATEMENT CREATE NODE TABLE V (id INT64, PRIMARY KEY(id));
 ---- ok

--- a/test/test_files/transaction/delete_node/delete_node.test
+++ b/test/test_files/transaction/delete_node/delete_node.test
@@ -1,6 +1,12 @@
 -DATASET CSV empty
 --
 
+-CASE EmptyDatabaseDetachDelete
+-STATEMENT MATCH (n) DELETE n;
+---- ok
+-STATEMENT MATCH (n) DETACH DELETE n;
+---- ok
+
 -CASE DeleteLocalNode
 -STATEMENT CREATE NODE TABLE person (oid INT64, fName STRING, PRIMARY KEY(oid));
 ---- ok

--- a/test/test_files/transaction/delete_rel/delete_empty.test
+++ b/test/test_files/transaction/delete_rel/delete_empty.test
@@ -1,6 +1,10 @@
 -DATASET CSV empty
 --
 
+-CASE DeleteRelEmptyDB
+-STATEMENT MATCH ()-[e]->() DELETE e;
+---- ok
+
 -CASE RelDeleteCheckpoint
 -STATEMENT CREATE NODE TABLE person (ID INT64, PRIMARY KEY (ID));
 ---- ok


### PR DESCRIPTION
# Description

Fixes #3897. Query compilation fails when we try to delete from an empty database.

Add test cases for #3807 

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).