### PR TITLE
Only commit memory on windows when initially claiming the frame

### DIFF
--- a/src/include/storage/buffer_manager/vm_region.h
+++ b/src/include/storage/buffer_manager/vm_region.h
@@ -29,13 +29,9 @@ public:
     bool contains(const uint8_t* address) const {
         return address >= region && address < region + getMaxRegionSize();
     }
-#ifdef _WIN32
-    uint8_t* getFrame(common::frame_idx_t frameIdx);
-#else
     inline uint8_t* getFrame(common::frame_idx_t frameIdx) {
         return region + ((std::uint64_t)frameIdx * frameSize);
     }
-#endif
 
 private:
     inline uint64_t getMaxRegionSize() const {

--- a/src/storage/buffer_manager/vm_region.cpp
+++ b/src/storage/buffer_manager/vm_region.cpp
@@ -45,19 +45,6 @@ VMRegion::VMRegion(PageSizeClass pageSizeClass, uint64_t maxRegionSize) : numFra
 #endif
 }
 
-#ifdef _WIN32
-uint8_t* VMRegion::getFrame(frame_idx_t frameIdx) {
-    auto result = VirtualAlloc(region + ((std::uint64_t)frameIdx * frameSize), frameSize,
-        MEM_COMMIT, PAGE_READWRITE);
-    if (result == NULL) {
-        throw BufferManagerException(stringFormat(
-            "VirtualAlloc MEM_COMMIT failed with error code {}: {}.", getMaxRegionSize(),
-            GetLastError(), std::system_category().message(GetLastError())));
-    }
-    return region + ((std::uint64_t)frameIdx * frameSize);
-}
-#endif
-
 VMRegion::~VMRegion() {
 #ifdef _WIN32
     VirtualFree(region, 0, MEM_RELEASE);


### PR DESCRIPTION
This fixes a fairly significant performance issue on Windows.

I was less familiar with our buffer manager when initially getting it to work on Windows. There's no need to ensure the memory is committed every time we call getFrame.

It was also necessary to skip evicted pages in updateFrameIfPageIsInFrameWithoutLock as it would otherwise segfault from trying to access uncommitted memory (it's not necessary to update them if they're evicted anyway).