### PR TITLE
Refactor list auxiliary buffer

### DIFF
--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -533,9 +533,29 @@ void StringVector::copyToRowData(const ValueVector* vector, uint32_t pos, uint8_
     }
 }
 
+void ListVector::copyListEntryAndBufferMetaData(ValueVector& vector, const ValueVector& other) {
+    auto& selVector = vector.state->getSelVector();
+    auto& otherSelVector = other.state->getSelVector();
+    KU_ASSERT(selVector.getSelSize() == otherSelVector.getSelSize());
+    // Copy list entries
+    for (auto i = 0u; i < otherSelVector.getSelSize(); ++i) {
+        auto pos = selVector[i];
+        auto otherPos = otherSelVector[i];
+        if (other.isNull(otherPos)) {
+            vector.setNull(pos, true);
+        } else {
+            vector.setValue(pos, other.getValue<list_entry_t>(otherPos));
+        }
+    }
+    // Copy buffer metadata
+    auto& buffer = getAuxBufferUnsafe(vector);
+    auto& otherBuffer = getAuxBuffer(other);
+    buffer.size = otherBuffer.size;
+    buffer.capacity = otherBuffer.capacity;
+}
+
 void ListVector::copyFromRowData(ValueVector* vector, uint32_t pos, const uint8_t* rowData) {
-    KU_ASSERT(vector->dataType.getPhysicalType() == PhysicalTypeID::LIST ||
-              vector->dataType.getPhysicalType() == PhysicalTypeID::ARRAY);
+    KU_ASSERT(validateType(*vector));
     auto& srcKuList = *(ku_list_t*)rowData;
     auto srcNullBytes = reinterpret_cast<uint8_t*>(srcKuList.overflowPtr);
     auto srcListValues = srcNullBytes + NullBuffer::getNumBytesForNullValues(srcKuList.size);
@@ -593,8 +613,8 @@ void ListVector::copyFromVectorData(ValueVector* dstVector, uint8_t* dstData,
     }
 }
 
-void ListVector::appendDataVector(kuzu::common::ValueVector* dstVector,
-    kuzu::common::ValueVector* srcDataVector, uint64_t numValuesToAppend) {
+void ListVector::appendDataVector(ValueVector* dstVector,
+    ValueVector* srcDataVector, uint64_t numValuesToAppend) {
     auto offset = getDataVectorSize(dstVector);
     resizeDataVector(dstVector, offset + numValuesToAppend);
     auto dstDataVector = getDataVector(dstVector);

--- a/src/common/vector/value_vector.cpp
+++ b/src/common/vector/value_vector.cpp
@@ -613,8 +613,8 @@ void ListVector::copyFromVectorData(ValueVector* dstVector, uint8_t* dstData,
     }
 }
 
-void ListVector::appendDataVector(ValueVector* dstVector,
-    ValueVector* srcDataVector, uint64_t numValuesToAppend) {
+void ListVector::appendDataVector(ValueVector* dstVector, ValueVector* srcDataVector,
+    uint64_t numValuesToAppend) {
     auto offset = getDataVectorSize(dstVector);
     resizeDataVector(dstVector, offset + numValuesToAppend);
     auto dstDataVector = getDataVector(dstVector);

--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -50,6 +50,7 @@ void ListLambdaEvaluator::evaluate() {
 void ListLambdaEvaluator::resolveResultVector(const ResultSet&, MemoryManager* memoryManager) {
     resultVector = std::make_shared<ValueVector>(expression->getDataType().copy(), memoryManager);
     resultVector->state = children[0]->resultVector->state;
+    isResultFlat_ = children[0]->isResultFlat();
 }
 
 } // namespace evaluator

--- a/src/function/list/list_transform.cpp
+++ b/src/function/list/list_transform.cpp
@@ -29,17 +29,9 @@ static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& in
     auto lambdaParamVector = listLambdaBindData->lambdaParamEvaluators[0]->resultVector.get();
     lambdaParamVector->state->getSelVectorUnsafe().setSelSize(listSize);
     listLambdaBindData->rootEvaluator->evaluate();
-    auto& listInputSelVector = inputVector->state->getSelVector();
-    // NOTE: the following can be done with a memcpy. But I think soon we will need to change
-    // to handle cases like
-    // MATCH (a:person) RETURN LIST_TRANSFORM([1,2,3], x->x + a.ID)
-    // So I'm leaving it in the naive form.
     KU_ASSERT(input.size() == 2);
     ListVector::setDataVector(&result, input[1]);
-    for (auto i = 0u; i < listInputSelVector.getSelSize(); ++i) {
-        auto pos = listInputSelVector[i];
-        result.setValue(pos, inputVector->getValue<list_entry_t>(pos));
-    }
+    ListVector::copyListEntryAndBufferMetaData(result, *inputVector);
 }
 
 function_set ListTransformFunction::getFunctionSet() {

--- a/src/function/path/properties_function.cpp
+++ b/src/function/path/properties_function.cpp
@@ -51,31 +51,7 @@ static void compileFunc(FunctionBindData* bindData,
 
 static void execFunc(const std::vector<std::shared_ptr<ValueVector>>& parameters,
     ValueVector& result, void* /*dataPtr*/) {
-    auto& resultSelVector = result.state->getSelVector();
-    if (parameters[0]->state->isFlat()) {
-        auto inputPos = parameters[0]->state->getSelVector()[0];
-        if (parameters[0]->isNull(inputPos)) {
-            for (auto i = 0u; i < resultSelVector.getSelSize(); ++i) {
-                auto pos = resultSelVector[i];
-                result.setNull(pos, true);
-            }
-        } else {
-            auto& listEntry = parameters[0]->getValue<list_entry_t>(inputPos);
-            for (auto i = 0u; i < resultSelVector.getSelSize(); ++i) {
-                auto pos = resultSelVector[i];
-                result.setValue(pos, listEntry);
-            }
-        }
-    } else {
-        for (auto i = 0u; i < resultSelVector.getSelSize(); ++i) {
-            auto pos = resultSelVector[i];
-            if (parameters[0]->isNull(pos)) {
-                result.setNull(pos, true);
-            } else {
-                result.setValue(pos, parameters[0]->getValue<list_entry_t>(pos));
-            }
-        }
-    }
+    ListVector::copyListEntryAndBufferMetaData(result, *parameters[0]);
 }
 
 function_set PropertiesFunction::getFunctionSet() {

--- a/src/include/common/vector/auxiliary_buffer.h
+++ b/src/include/common/vector/auxiliary_buffer.h
@@ -17,6 +17,16 @@ class ValueVector;
 class AuxiliaryBuffer {
 public:
     virtual ~AuxiliaryBuffer() = default;
+
+    template<class TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<AuxiliaryBuffer&, TARGET&>(*this);
+    }
+
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const AuxiliaryBuffer&, const TARGET&>(*this);
+    }
 };
 
 class StringAuxiliaryBuffer : public AuxiliaryBuffer {

--- a/src/include/expression_evaluator/expression_evaluator.h
+++ b/src/include/expression_evaluator/expression_evaluator.h
@@ -43,8 +43,6 @@ public:
     EvaluatorType getEvaluatorType() const { return type; }
 
     std::shared_ptr<binder::Expression> getExpression() const { return expression; }
-    const common::LogicalType& getResultDataType() const { return expression->getDataType(); }
-    void setResultFlat(bool val) { isResultFlat_ = val; }
     bool isResultFlat() const { return isResultFlat_; }
 
     const evaluator_vector_t& getChildren() const { return children; }

--- a/src/planner/operator/factorization/flatten_resolver.cpp
+++ b/src/planner/operator/factorization/flatten_resolver.cpp
@@ -192,7 +192,8 @@ void GroupDependencyAnalyzer::visitNodeOrRel(std::shared_ptr<binder::Expression>
         auto& node = expr->constCast<NodeExpression>();
         visit(node.getInternalID());
     } break;
-    case LogicalTypeID::REL: {
+    case LogicalTypeID::REL:
+    case LogicalTypeID::RECURSIVE_REL: {
         auto& rel = expr->constCast<RelExpression>();
         visit(rel.getSrcNode()->getInternalID());
         visit(rel.getDstNode()->getInternalID());

--- a/test/test_files/demo_db/demo_db.test
+++ b/test/test_files/demo_db/demo_db.test
@@ -3,7 +3,6 @@
 --
 
 -CASE DemoDBTest
-
 -LOG UndirectedRecursivePattern
 -STATEMENT MATCH p = (u:User {name: 'Adam'})-[e*1..3]-(c:User {name: 'Adam'})
            HINT (u JOIN e) JOIN c
@@ -455,3 +454,12 @@ Adam|Karissa
 Adam|Zhang
 Karissa|Zhang
 Zhang|Noura
+
+-STATEMENT MATCH (n)-[:LivesIn]->(:City)
+           WITH collect(n.name) AS names
+           MATCH p = (u:User {name: "Adam"})-[e:Follows*]->(u2:User {name: "Noura"})
+           WHERE size(list_filter(properties(nodes(e),'name'), x->x IN names)) > 0
+           RETURN properties(nodes(p),'name')
+---- 2
+[Adam,Karissa,Zhang,Noura]
+[Adam,Zhang,Noura]


### PR DESCRIPTION
# Description

This PR solves a bug when we try to refer a list child vector from another list child vector. The bug was because we only set the vector itself but did not copy the corresponding auxiliary buffer metadata, e.g. size & capacity. This PR fixes the bug and also refactor related APIs.


Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).