### PR TITLE
Optimize catalog access

### DIFF
--- a/src/binder/bind/bind_graph_pattern.cpp
+++ b/src/binder/bind/bind_graph_pattern.cpp
@@ -241,8 +241,9 @@ std::shared_ptr<RelExpression> Binder::bindQueryRel(const RelPattern& relPattern
 }
 
 std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::string& parsedName,
-    const std::vector<catalog::TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
-    std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType) {
+    const std::vector<catalog::TableCatalogEntry*>& entries,
+    std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
+    RelDirectionType directionType) {
     auto relTableEntries = getRelTableEntries(entries);
     auto queryRel = make_shared<RelExpression>(LogicalType(LogicalTypeID::REL),
         getUniqueExpressionName(parsedName), parsedName, relTableEntries, std::move(srcNode),
@@ -277,11 +278,9 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
     if (!rdfGraphTableIDSet.empty()) {
         if (!nonRdfRelTableIDSet.empty()) {
             auto relTableName =
-                catalog->getTableCatalogEntry(transaction, *nonRdfRelTableIDSet.begin())
-                    ->getName();
+                catalog->getTableCatalogEntry(transaction, *nonRdfRelTableIDSet.begin())->getName();
             auto rdfGraphName =
-                catalog->getTableCatalogEntry(transaction, *rdfGraphTableIDSet.begin())
-                    ->getName();
+                catalog->getTableCatalogEntry(transaction, *rdfGraphTableIDSet.begin())->getName();
             throw BinderException(stringFormat(
                 "Relationship pattern {} contains both PropertyGraph relationship "
                 "label {} and RDFGraph label {}. Mixing relationships tables from an RDFGraph and "
@@ -300,8 +299,7 @@ std::shared_ptr<RelExpression> Binder::createNonRecursiveQueryRel(const std::str
         queryRel->setRdfPredicateInfo(std::move(rdfInfo));
         std::vector<TableCatalogEntry*> resourceTableSchemas;
         for (auto tableID : resourceTableIDs) {
-            resourceTableSchemas.push_back(
-                catalog->getTableCatalogEntry(transaction, tableID));
+            resourceTableSchemas.push_back(catalog->getTableCatalogEntry(transaction, tableID));
         }
         // Mock existence of pIRI property.
         auto pIRI =
@@ -338,8 +336,9 @@ static void bindRecursiveRelProjectionList(const expression_vector& projectionLi
 }
 
 std::shared_ptr<RelExpression> Binder::createRecursiveQueryRel(const parser::RelPattern& relPattern,
-    const std::vector<catalog::TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
-    std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType) {
+    const std::vector<catalog::TableCatalogEntry*>& entries,
+    std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
+    RelDirectionType directionType) {
     auto catalog = clientContext->getCatalog();
     auto transaction = clientContext->getTx();
     auto relTableEntries = getRelTableEntries(entries);
@@ -630,7 +629,9 @@ std::vector<TableCatalogEntry*> Binder::bindTableEntries(const std::vector<std::
     for (auto entry : entrySet) {
         entries.push_back(entry);
     }
-    std::sort(entries.begin(), entries.end(), [](TableCatalogEntry* a, TableCatalogEntry* b){ return a->getTableID() < b->getTableID(); });
+    std::sort(entries.begin(), entries.end(), [](TableCatalogEntry* a, TableCatalogEntry* b) {
+        return a->getTableID() < b->getTableID();
+    });
     return entries;
 }
 
@@ -647,15 +648,18 @@ common::table_id_t Binder::bindTableID(const std::string& tableName) const {
     return bindTableEntry(tableName)->getTableID();
 }
 
-std::vector<TableCatalogEntry*> Binder::getNodeTableEntries(const std::vector<TableCatalogEntry*>& entries) const {
+std::vector<TableCatalogEntry*> Binder::getNodeTableEntries(
+    const std::vector<TableCatalogEntry*>& entries) const {
     return getTableEntries(entries, TableType::NODE);
 }
 
-std::vector<TableCatalogEntry*> Binder::getRelTableEntries(const std::vector<TableCatalogEntry*>& entries) const {
+std::vector<TableCatalogEntry*> Binder::getRelTableEntries(
+    const std::vector<TableCatalogEntry*>& entries) const {
     return getTableEntries(entries, TableType::REL);
 }
 
-std::vector<TableCatalogEntry*> Binder::getTableEntries(const std::vector<TableCatalogEntry*>& entries, TableType tableType) const {
+std::vector<TableCatalogEntry*> Binder::getTableEntries(
+    const std::vector<TableCatalogEntry*>& entries, TableType tableType) const {
     std::vector<TableCatalogEntry*> result;
     table_id_set_t set;
     for (auto& entry : entries) {
@@ -663,10 +667,10 @@ std::vector<TableCatalogEntry*> Binder::getTableEntries(const std::vector<TableC
         switch (tableType) {
         case TableType::NODE: {
             expandedEntries = getNodeTableEntries(entry);
-        } break ;
+        } break;
         case TableType::REL: {
             expandedEntries = getRelTableEntries(entry);
-        } break ;
+        } break;
         default:
             break;
         }
@@ -698,8 +702,10 @@ std::vector<TableCatalogEntry*> Binder::getRelTableEntries(TableCatalogEntry* en
     switch (entry->getTableType()) {
     case TableType::RDF: {
         auto& rdfEntry = entry->constCast<RDFGraphCatalogEntry>();
-        auto rtEntry = catalog->getTableCatalogEntry(transaction, rdfEntry.getResourceTripleTableID());
-        auto ltEntry = catalog->getTableCatalogEntry(transaction, rdfEntry.getLiteralTripleTableID());
+        auto rtEntry =
+            catalog->getTableCatalogEntry(transaction, rdfEntry.getResourceTripleTableID());
+        auto ltEntry =
+            catalog->getTableCatalogEntry(transaction, rdfEntry.getLiteralTripleTableID());
         return {rtEntry, ltEntry};
     }
     case TableType::REL_GROUP: {

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -239,8 +239,8 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
     } else {
         auto insertInfo = BoundInsertInfo(TableType::REL, rel);
         insertInfo.columnExprs = rel->getPropertyExprs();
-        insertInfo.columnDataExprs = bindInsertColumnDataExprs(rel->getPropertyDataExprRef(),
-            entry->getPropertiesRef());
+        insertInfo.columnDataExprs =
+            bindInsertColumnDataExprs(rel->getPropertyDataExprRef(), entry->getPropertiesRef());
         infos.push_back(std::move(insertInfo));
     }
 }

--- a/src/binder/bind/bind_updating_clause.cpp
+++ b/src/binder/bind/bind_updating_clause.cpp
@@ -161,19 +161,17 @@ void Binder::bindInsertNode(std::shared_ptr<NodeExpression> node,
             "Create node " + node->toString() + " with multiple node labels is not supported.");
     }
     auto catalog = clientContext->getCatalog();
-    auto tableID = node->getSingleTableID();
-    auto entry = catalog->getTableCatalogEntry(clientContext->getTx(), tableID);
+    auto entry = node->getSingleEntry();
     KU_ASSERT(entry->getTableType() == TableType::NODE);
     auto insertInfo = BoundInsertInfo(TableType::NODE, node);
-    for (auto& e : catalog->getRdfGraphEntries(clientContext->getTx())) {
-        auto rdfEntry = ku_dynamic_cast<CatalogEntry*, RDFGraphCatalogEntry*>(e);
-        if (rdfEntry->isParent(tableID)) {
+    for (auto& rdfEntry : catalog->getRdfGraphEntries(clientContext->getTx())) {
+        if (rdfEntry->isParent(entry->getTableID())) {
             insertInfo.conflictAction = ConflictAction::ON_CONFLICT_DO_NOTHING;
         }
     }
     for (auto& expr : node->getPropertyExprs()) {
         auto propertyExpr = expr->constPtrCast<PropertyExpression>();
-        if (propertyExpr->hasPropertyID(tableID)) {
+        if (propertyExpr->hasPropertyID(entry->getTableID())) {
             insertInfo.columnExprs.push_back(expr);
         }
     }
@@ -195,13 +193,13 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
         throw BinderException(
             common::stringFormat("Cannot create recursive rel {}.", rel->toString()));
     }
-    rel->setTableIDs(std::vector<common::table_id_t>{rel->getTableIDs()[0]});
-    auto relTableID = rel->getSingleTableID();
+    rel->setEntries(std::vector<TableCatalogEntry*>{rel->getEntries()[0]});
     auto catalog = clientContext->getCatalog();
-    auto tableEntry = catalog->getTableCatalogEntry(clientContext->getTx(), relTableID);
+    auto transaction = clientContext->getTx();
+    auto entry = rel->getSingleEntry();
     TableCatalogEntry* parentTableEntry = nullptr;
     for (auto& rdfGraphEntry : catalog->getRdfGraphEntries(clientContext->getTx())) {
-        if (rdfGraphEntry->isParent(relTableID)) {
+        if (rdfGraphEntry->isParent(entry->getTableID())) {
             parentTableEntry = rdfGraphEntry;
         }
     }
@@ -215,8 +213,9 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
         }
         // Insert predicate resource node.
         auto resourceTableID = rdfGraphEntry->getResourceTableID();
+        auto resourceTableEntry = catalog->getTableCatalogEntry(transaction, resourceTableID);
         auto pNode = createQueryNode(rel->getVariableName(),
-            std::vector<common::table_id_t>{resourceTableID});
+            std::vector<TableCatalogEntry*>{resourceTableEntry});
         auto iriData = rel->getPropertyDataExpr(std::string(rdf::IRI));
         iriData = expressionBinder.bindScalarFunctionExpression(
             expression_vector{std::move(iriData)}, function::ValidatePredicateFunction::name);
@@ -235,13 +234,13 @@ void Binder::bindInsertRel(std::shared_ptr<RelExpression> rel,
         relInsertInfo.columnExprs.push_back(
             expressionBinder.bindNodeOrRelPropertyExpression(*rel, std::string(rdf::PID)));
         relInsertInfo.columnDataExprs =
-            bindInsertColumnDataExprs(relPropertyRhsExpr, tableEntry->getPropertiesRef());
+            bindInsertColumnDataExprs(relPropertyRhsExpr, entry->getPropertiesRef());
         infos.push_back(std::move(relInsertInfo));
     } else {
         auto insertInfo = BoundInsertInfo(TableType::REL, rel);
         insertInfo.columnExprs = rel->getPropertyExprs();
         insertInfo.columnDataExprs = bindInsertColumnDataExprs(rel->getPropertyDataExprRef(),
-            tableEntry->getPropertiesRef());
+            entry->getPropertiesRef());
         infos.push_back(std::move(insertInfo));
     }
 }
@@ -289,10 +288,10 @@ BoundSetPropertyInfo Binder::bindSetPropertyInfo(parser::ParsedExpression* colum
     // Validate not updating tables belong to RDFGraph.
     auto catalog = clientContext->getCatalog();
     auto transaction = clientContext->getTx();
-    for (auto tableID : nodeOrRel.getTableIDs()) {
-        auto tableName = catalog->getTableCatalogEntry(transaction, tableID)->getName();
+    for (auto entry : nodeOrRel.getEntries()) {
+        auto tableName = entry->getName();
         for (auto& rdfGraphEntry : catalog->getRdfGraphEntries(transaction)) {
-            if (rdfGraphEntry->isParent(tableID)) {
+            if (rdfGraphEntry->isParent(entry->getTableID())) {
                 throw BinderException(
                     stringFormat("Cannot set properties of RDFGraph tables. Set {} requires "
                                  "modifying table {} under rdf graph {}.",
@@ -303,8 +302,8 @@ BoundSetPropertyInfo Binder::bindSetPropertyInfo(parser::ParsedExpression* colum
     if (isNode) {
         auto info = BoundSetPropertyInfo(TableType::NODE, expr, boundColumn, boundColumnData);
         auto& property = boundSetItem.first->constCast<PropertyExpression>();
-        for (auto id : nodeOrRel.getTableIDs()) {
-            if (property.isPrimaryKey(id)) {
+        for (auto entry : nodeOrRel.getEntries()) {
+            if (property.isPrimaryKey(entry->getTableID())) {
                 info.updatePk = true;
             }
         }
@@ -324,9 +323,9 @@ expression_pair Binder::bindSetItem(parser::ParsedExpression* column,
 
 static void validateRdfResourceDeletion(Expression* pattern, main::ClientContext* context) {
     auto node = ku_dynamic_cast<Expression*, NodeExpression*>(pattern);
-    for (auto& tableID : node->getTableIDs()) {
+    for (auto& entry : node->getEntries()) {
         for (auto& rdfGraphEntry : context->getCatalog()->getRdfGraphEntries(context->getTx())) {
-            if (rdfGraphEntry->isParent(tableID) &&
+            if (rdfGraphEntry->isParent(entry->getTableID()) &&
                 node->hasPropertyExpression(std::string(rdf::IRI))) {
                 throw BinderException(
                     stringFormat("Cannot delete node {} because it references to resource "

--- a/src/binder/bind/read/bind_match.cpp
+++ b/src/binder/bind/read/bind_match.cpp
@@ -87,7 +87,7 @@ void Binder::rewriteMatchPattern(BoundGraphPattern& boundGraphPattern) {
             }
             auto src = queryRel->getSrcNode();
             auto dst = queryRel->getDstNode();
-            auto newDst = createQueryNode(dst->getVariableName(), dst->getTableIDs());
+            auto newDst = createQueryNode(dst->getVariableName(), dst->getEntries());
             queryGraph->addQueryNode(newDst);
             queryRel->setDstNode(newDst);
             auto predicate = expressionBinder.createEqualityComparisonExpression(

--- a/src/binder/bind/read/bind_unwind.cpp
+++ b/src/binder/bind/read/bind_unwind.cpp
@@ -33,8 +33,8 @@ std::unique_ptr<BoundReadingClause> Binder::bindUnwindClause(const ReadingClause
     }
     std::shared_ptr<Expression> idExpr = nullptr;
     if (scope.hasMemorizedTableIDs(boundExpression->getAlias())) {
-        auto tableIDs = scope.getMemorizedTableIDs(boundExpression->getAlias());
-        auto node = createQueryNode(aliasName, tableIDs);
+        auto entries = scope.getMemorizedTableEntries(boundExpression->getAlias());
+        auto node = createQueryNode(aliasName, entries);
         idExpr = node->getInternalID();
         scope.addNodeReplacement(node);
     }

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -261,7 +261,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
             return createLiteralExpression("");
         }
         if (!node.isMultiLabeled()) {
-            auto labelName = catalog->getTableName(context->getTx(), node.getSingleEntry()->getTableID());
+            auto labelName =
+                catalog->getTableName(context->getTx(), node.getSingleEntry()->getTableID());
             return createLiteralExpression(Value(LogicalType::STRING(), labelName));
         }
         auto nodeTableIDs = catalog->getNodeTableIDs(context->getTx());
@@ -276,7 +277,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
             return createLiteralExpression("");
         }
         if (!rel.isMultiLabeled()) {
-            auto labelName = catalog->getTableName(context->getTx(), rel.getSingleEntry()->getTableID());
+            auto labelName =
+                catalog->getTableName(context->getTx(), rel.getSingleEntry()->getTableID());
             return createLiteralExpression(Value(LogicalType::STRING(), labelName));
         }
         auto relTableIDs = catalog->getRelTableIDs(context->getTx());

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -152,8 +152,8 @@ std::shared_ptr<Expression> ExpressionBinder::bindAggregateFunctionExpression(
     }
     if (functionName == CollectFunction::name && parsedExpression.hasAlias() &&
         children[0]->getDataType().getLogicalTypeID() == LogicalTypeID::NODE) {
-        auto node = ku_dynamic_cast<Expression*, NodeExpression*>(children[0].get());
-        binder->scope.memorizeTableIDs(parsedExpression.getAlias(), node->getTableIDs());
+        auto& node = children[0]->constCast<NodeExpression>();
+        binder->scope.memorizeTableEntries(parsedExpression.getAlias(), node.getEntries());
     }
     auto uniqueExpressionName =
         AggregateFunctionExpression::getUniqueName(function->name, children, function->isDistinct);
@@ -261,7 +261,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
             return createLiteralExpression("");
         }
         if (!node.isMultiLabeled()) {
-            auto labelName = catalog->getTableName(context->getTx(), node.getSingleTableID());
+            auto labelName = catalog->getTableName(context->getTx(), node.getSingleEntry()->getTableID());
             return createLiteralExpression(Value(LogicalType::STRING(), labelName));
         }
         auto nodeTableIDs = catalog->getNodeTableIDs(context->getTx());
@@ -276,7 +276,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindLabelFunction(const Expression
             return createLiteralExpression("");
         }
         if (!rel.isMultiLabeled()) {
-            auto labelName = catalog->getTableName(context->getTx(), rel.getSingleTableID());
+            auto labelName = catalog->getTableName(context->getTx(), rel.getSingleEntry()->getTableID());
             return createLiteralExpression(Value(LogicalType::STRING(), labelName));
         }
         auto relTableIDs = catalog->getRelTableIDs(context->getTx());

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -94,14 +94,6 @@ std::shared_ptr<Expression> Binder::bindWhereExpression(const ParsedExpression& 
     return whereExpression;
 }
 
-common::table_id_t Binder::bindTableID(const std::string& tableName) const {
-    auto catalog = clientContext->getCatalog();
-    if (!catalog->containsTable(clientContext->getTx(), tableName)) {
-        throw BinderException(common::stringFormat("Table {} does not exist.", tableName));
-    }
-    return catalog->getTableID(clientContext->getTx(), tableName);
-}
-
 std::shared_ptr<Expression> Binder::createVariable(std::string_view name,
     common::LogicalTypeID typeID) {
     return createVariable(std::string(name), LogicalType{typeID});

--- a/src/binder/expression/node_rel_expression.cpp
+++ b/src/binder/expression/node_rel_expression.cpp
@@ -1,7 +1,7 @@
 #include "binder/expression/node_rel_expression.h"
 
-#include "common/exception/runtime.h"
 #include "catalog/catalog_entry/table_catalog_entry.h"
+#include "common/exception/runtime.h"
 
 using namespace kuzu::catalog;
 using namespace kuzu::common;

--- a/src/binder/expression/node_rel_expression.cpp
+++ b/src/binder/expression/node_rel_expression.cpp
@@ -1,29 +1,47 @@
 #include "binder/expression/node_rel_expression.h"
 
 #include "common/exception/runtime.h"
+#include "catalog/catalog_entry/table_catalog_entry.h"
 
+using namespace kuzu::catalog;
 using namespace kuzu::common;
 
 namespace kuzu {
 namespace binder {
 
-void NodeOrRelExpression::addTableIDs(const table_id_vector_t& tableIDsToAdd) {
+table_id_vector_t NodeOrRelExpression::getTableIDs() const {
+    table_id_vector_t result;
+    for (auto& entry : entries) {
+        result.push_back(entry->getTableID());
+    }
+    return result;
+}
+
+table_id_set_t NodeOrRelExpression::getTableIDsSet() const {
+    table_id_set_t result;
+    for (auto& entry : entries) {
+        result.insert(entry->getTableID());
+    }
+    return result;
+}
+
+void NodeOrRelExpression::addEntries(const std::vector<TableCatalogEntry*> entries_) {
     auto tableIDsSet = getTableIDsSet();
-    for (auto tableID : tableIDsToAdd) {
-        if (!tableIDsSet.contains(tableID)) {
-            tableIDs.push_back(tableID);
+    for (auto& entry : entries_) {
+        if (!tableIDsSet.contains(entry->getTableID())) {
+            entries.push_back(entry);
         }
     }
 }
 
-common::table_id_t NodeOrRelExpression::getSingleTableID() const {
+TableCatalogEntry* NodeOrRelExpression::getSingleEntry() const {
     // LCOV_EXCL_START
-    if (tableIDs.empty()) {
+    if (entries.empty()) {
         throw RuntimeException(
             "Trying to access table id in an empty node. This should never happen");
     }
     // LCOV_EXCL_STOP
-    return tableIDs[0];
+    return entries[0];
 }
 
 void NodeOrRelExpression::addPropertyExpression(const std::string& propertyName,

--- a/src/binder/expression/property_expression.cpp
+++ b/src/binder/expression/property_expression.cpp
@@ -1,6 +1,7 @@
 #include "binder/expression/property_expression.h"
 
 #include "binder/expression/node_rel_expression.h"
+#include "catalog/catalog_entry/table_catalog_entry.h"
 
 using namespace kuzu::common;
 
@@ -15,8 +16,8 @@ std::unique_ptr<PropertyExpression> PropertyExpression::construct(LogicalType ty
     auto uniqueName = patternExpr.getUniqueName();
     // Assign an invalid property id for virtual property.
     common::table_id_map_t<SingleLabelPropertyInfo> infos;
-    for (auto& tableID : patternExpr.getTableIDs()) {
-        infos.insert({tableID, SingleLabelPropertyInfo(false, INVALID_PROPERTY_ID)});
+    for (auto& entry : patternExpr.getEntries()) {
+        infos.insert({entry->getTableID(), SingleLabelPropertyInfo(false, INVALID_PROPERTY_ID)});
     }
     return std::make_unique<PropertyExpression>(std::move(type), propertyName, uniqueName,
         variableName, std::move(infos));

--- a/src/binder/visitor/property_collector.cpp
+++ b/src/binder/visitor/property_collector.cpp
@@ -71,8 +71,8 @@ void PropertyCollector::visitDelete(const BoundUpdatingClause& updatingClause) {
     // Read primary key if we are deleting nodes;
     for (auto& info : boundDeleteClause.getNodeInfos()) {
         auto& node = info.pattern->constCast<NodeExpression>();
-        for (auto id : node.getTableIDs()) {
-            properties.insert(node.getPrimaryKey(id));
+        for (auto entry : node.getEntries()) {
+            properties.insert(node.getPrimaryKey(entry->getTableID()));
         }
     }
     // Read rel internal id if we are deleting relationships.

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -66,9 +66,7 @@ bool Catalog::containsTable(Transaction* transaction, const std::string& tableNa
 }
 
 table_id_t Catalog::getTableID(Transaction* transaction, const std::string& tableName) const {
-    auto entry = tables->getEntry(transaction, tableName);
-    KU_ASSERT(entry);
-    return ku_dynamic_cast<CatalogEntry*, TableCatalogEntry*>(entry)->getTableID();
+    return getTableCatalogEntry(transaction, tableName)->getTableID();
 }
 
 std::vector<table_id_t> Catalog::getNodeTableIDs(Transaction* transaction) const {
@@ -113,6 +111,17 @@ TableCatalogEntry* Catalog::getTableCatalogEntry(Transaction* transaction,
     }
     // LCOV_EXCL_STOP
     return result;
+}
+
+TableCatalogEntry* Catalog::getTableCatalogEntry(Transaction* transaction, const std::string& tableName) const {
+    auto entry = tables->getEntry(transaction, tableName);
+    // LCOV_EXCL_START
+    if (entry == nullptr) {
+        throw RuntimeException(
+            stringFormat("Cannot find table catalog entry with name {}.", tableName));
+    }
+    // LCOV_EXCL_STOP
+    return entry->ptrCast<TableCatalogEntry>();
 }
 
 std::vector<NodeTableCatalogEntry*> Catalog::getNodeTableEntries(Transaction* transaction) const {
@@ -491,10 +500,6 @@ void Catalog::readFromFile(const std::string& directory, VirtualFileSystem* fs,
 
 void Catalog::registerBuiltInFunctions() {
     function::BuiltInFunctionsUtils::createFunctions(&DUMMY_TRANSACTION, functions.get());
-}
-
-bool Catalog::containMacro(const std::string& macroName) const {
-    return functions->containsEntry(&DUMMY_TRANSACTION, macroName);
 }
 
 void Catalog::alterRdfChildTableEntries(Transaction* transaction, CatalogEntry* tableEntry,

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -113,7 +113,8 @@ TableCatalogEntry* Catalog::getTableCatalogEntry(Transaction* transaction,
     return result;
 }
 
-TableCatalogEntry* Catalog::getTableCatalogEntry(Transaction* transaction, const std::string& tableName) const {
+TableCatalogEntry* Catalog::getTableCatalogEntry(Transaction* transaction,
+    const std::string& tableName) const {
     auto entry = tables->getEntry(transaction, tableName);
     // LCOV_EXCL_START
     if (entry == nullptr) {

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -17,7 +17,7 @@ void GDSAlgorithm::init(GDSCallSharedState* sharedState_, ClientContext* context
 }
 
 std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(Binder* binder, GraphEntry& graphEntry) {
-    auto node = binder->createQueryNode(NODE_COLUMN_NAME, graphEntry.nodeTableIDs);
+    auto node = binder->createQueryNode(NODE_COLUMN_NAME, binder->getTableEntries(graphEntry.nodeTableIDs));
     binder->addToScope(NODE_COLUMN_NAME, node);
     return node;
 }

--- a/src/function/gds/gds.cpp
+++ b/src/function/gds/gds.cpp
@@ -17,7 +17,8 @@ void GDSAlgorithm::init(GDSCallSharedState* sharedState_, ClientContext* context
 }
 
 std::shared_ptr<Expression> GDSAlgorithm::bindNodeOutput(Binder* binder, GraphEntry& graphEntry) {
-    auto node = binder->createQueryNode(NODE_COLUMN_NAME, binder->getTableEntries(graphEntry.nodeTableIDs));
+    auto node =
+        binder->createQueryNode(NODE_COLUMN_NAME, binder->getTableEntries(graphEntry.nodeTableIDs));
     binder->addToScope(NODE_COLUMN_NAME, node);
     return node;
 }

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -96,8 +96,6 @@ public:
     std::shared_ptr<Expression> bindWhereExpression(
         const parser::ParsedExpression& parsedExpression);
 
-    common::table_id_t bindTableID(const std::string& tableName) const;
-
     std::shared_ptr<Expression> createVariable(std::string_view name, common::LogicalTypeID typeID);
     std::shared_ptr<Expression> createVariable(const std::string& name,
         common::LogicalTypeID typeID);
@@ -254,10 +252,10 @@ public:
         const std::shared_ptr<NodeExpression>& leftNode,
         const std::shared_ptr<NodeExpression>& rightNode, QueryGraph& queryGraph);
     std::shared_ptr<RelExpression> createNonRecursiveQueryRel(const std::string& parsedName,
-        const std::vector<common::table_id_t>& tableIDs, std::shared_ptr<NodeExpression> srcNode,
+        const std::vector<catalog::TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
         std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType);
     std::shared_ptr<RelExpression> createRecursiveQueryRel(const parser::RelPattern& relPattern,
-        const std::vector<common::table_id_t>& tableIDs, std::shared_ptr<NodeExpression> srcNode,
+        const std::vector<catalog::TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
         std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType);
     std::pair<uint64_t, uint64_t> bindVariableLengthRelBound(const parser::RelPattern& relPattern);
     void bindQueryRelProperties(RelExpression& rel);
@@ -266,19 +264,21 @@ public:
         QueryGraph& queryGraph);
     std::shared_ptr<NodeExpression> createQueryNode(const parser::NodePattern& nodePattern);
     std::shared_ptr<NodeExpression> createQueryNode(const std::string& parsedName,
-        const std::vector<common::table_id_t>& tableIDs);
+        const std::vector<catalog::TableCatalogEntry*>& entries);
     void bindQueryNodeProperties(NodeExpression& node);
 
-    /*** bind table ID ***/
-    // Bind table names to catalog table schemas. The function does NOT validate if the table schema
-    // type matches node or rel pattern.
-    std::vector<common::table_id_t> bindTableIDs(const std::vector<std::string>& tableNames,
-        bool nodePattern);
-    std::vector<common::table_id_t> getNodeTableIDs(
-        const std::vector<common::table_id_t>& tableIDs);
-    std::vector<common::table_id_t> getNodeTableIDs(common::table_id_t tableID);
-    std::vector<common::table_id_t> getRelTableIDs(const std::vector<common::table_id_t>& tableIDs);
-    std::vector<common::table_id_t> getRelTableIDs(common::table_id_t tableID);
+    /*** bind table entries ***/
+    std::vector<catalog::TableCatalogEntry*> bindTableEntries(const std::vector<std::string>& tableNames,
+        bool nodePattern) const;
+    catalog::TableCatalogEntry* bindTableEntry(const std::string& tableName) const;
+    common::table_id_t bindTableID(const std::string& tableName) const;
+    std::vector<catalog::TableCatalogEntry*> getNodeTableEntries(const std::vector<catalog::TableCatalogEntry*>& entries) const;
+    std::vector<catalog::TableCatalogEntry*> getRelTableEntries(const std::vector<catalog::TableCatalogEntry*>& entries) const;
+    std::vector<catalog::TableCatalogEntry*> getTableEntries(const std::vector<catalog::TableCatalogEntry*>& entries, common::TableType tableType) const;
+    std::vector<catalog::TableCatalogEntry*> getNodeTableEntries(catalog::TableCatalogEntry* entry) const;
+    std::vector<catalog::TableCatalogEntry*> getRelTableEntries(catalog::TableCatalogEntry* entry) const;
+    // TODO(Xiyang): remove id based table binding logic.
+    std::vector<catalog::TableCatalogEntry*> getTableEntries(const common::table_id_vector_t& tableIDs);
 
     /*** validations ***/
     // E.g. ... RETURN a, b AS a

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -252,11 +252,13 @@ public:
         const std::shared_ptr<NodeExpression>& leftNode,
         const std::shared_ptr<NodeExpression>& rightNode, QueryGraph& queryGraph);
     std::shared_ptr<RelExpression> createNonRecursiveQueryRel(const std::string& parsedName,
-        const std::vector<catalog::TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
-        std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType);
+        const std::vector<catalog::TableCatalogEntry*>& entries,
+        std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
+        RelDirectionType directionType);
     std::shared_ptr<RelExpression> createRecursiveQueryRel(const parser::RelPattern& relPattern,
-        const std::vector<catalog::TableCatalogEntry*>& entries, std::shared_ptr<NodeExpression> srcNode,
-        std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType);
+        const std::vector<catalog::TableCatalogEntry*>& entries,
+        std::shared_ptr<NodeExpression> srcNode, std::shared_ptr<NodeExpression> dstNode,
+        RelDirectionType directionType);
     std::pair<uint64_t, uint64_t> bindVariableLengthRelBound(const parser::RelPattern& relPattern);
     void bindQueryRelProperties(RelExpression& rel);
 
@@ -268,17 +270,23 @@ public:
     void bindQueryNodeProperties(NodeExpression& node);
 
     /*** bind table entries ***/
-    std::vector<catalog::TableCatalogEntry*> bindTableEntries(const std::vector<std::string>& tableNames,
-        bool nodePattern) const;
+    std::vector<catalog::TableCatalogEntry*> bindTableEntries(
+        const std::vector<std::string>& tableNames, bool nodePattern) const;
     catalog::TableCatalogEntry* bindTableEntry(const std::string& tableName) const;
     common::table_id_t bindTableID(const std::string& tableName) const;
-    std::vector<catalog::TableCatalogEntry*> getNodeTableEntries(const std::vector<catalog::TableCatalogEntry*>& entries) const;
-    std::vector<catalog::TableCatalogEntry*> getRelTableEntries(const std::vector<catalog::TableCatalogEntry*>& entries) const;
-    std::vector<catalog::TableCatalogEntry*> getTableEntries(const std::vector<catalog::TableCatalogEntry*>& entries, common::TableType tableType) const;
-    std::vector<catalog::TableCatalogEntry*> getNodeTableEntries(catalog::TableCatalogEntry* entry) const;
-    std::vector<catalog::TableCatalogEntry*> getRelTableEntries(catalog::TableCatalogEntry* entry) const;
+    std::vector<catalog::TableCatalogEntry*> getNodeTableEntries(
+        const std::vector<catalog::TableCatalogEntry*>& entries) const;
+    std::vector<catalog::TableCatalogEntry*> getRelTableEntries(
+        const std::vector<catalog::TableCatalogEntry*>& entries) const;
+    std::vector<catalog::TableCatalogEntry*> getTableEntries(
+        const std::vector<catalog::TableCatalogEntry*>& entries, common::TableType tableType) const;
+    std::vector<catalog::TableCatalogEntry*> getNodeTableEntries(
+        catalog::TableCatalogEntry* entry) const;
+    std::vector<catalog::TableCatalogEntry*> getRelTableEntries(
+        catalog::TableCatalogEntry* entry) const;
     // TODO(Xiyang): remove id based table binding logic.
-    std::vector<catalog::TableCatalogEntry*> getTableEntries(const common::table_id_vector_t& tableIDs);
+    std::vector<catalog::TableCatalogEntry*> getTableEntries(
+        const common::table_id_vector_t& tableIDs);
 
     /*** validations ***/
     // E.g. ... RETURN a, b AS a

--- a/src/include/binder/binder_scope.h
+++ b/src/include/binder/binder_scope.h
@@ -20,7 +20,8 @@ public:
     expression_vector getExpressions() const { return expressions; }
     void addExpression(const std::string& varName, std::shared_ptr<Expression> expression);
 
-    void memorizeTableEntries(const std::string& name, std::vector<catalog::TableCatalogEntry*> entries) {
+    void memorizeTableEntries(const std::string& name,
+        std::vector<catalog::TableCatalogEntry*> entries) {
         memorizedNodeNameToEntries.insert({name, entries});
     }
     bool hasMemorizedTableIDs(const std::string& name) const {
@@ -56,7 +57,8 @@ private:
     // A node might be popped out of scope. But we may need to retain its table ID information.
     // E.g. MATCH (a:person) WITH collect(a) AS list_a UNWIND list_a AS new_a MATCH (new_a)-[]->()
     // It will be more performant if we can retain the information that new_a has label person.
-    std::unordered_map<std::string, std::vector<catalog::TableCatalogEntry*>> memorizedNodeNameToEntries;
+    std::unordered_map<std::string, std::vector<catalog::TableCatalogEntry*>>
+        memorizedNodeNameToEntries;
     // A node pattern may not always be bound as a node expression, e.g. in the above query,
     // (new_a) is bound as a variable rather than node expression.
     std::unordered_map<std::string, std::shared_ptr<NodeExpression>> nodeReplacement;

--- a/src/include/binder/binder_scope.h
+++ b/src/include/binder/binder_scope.h
@@ -20,15 +20,15 @@ public:
     expression_vector getExpressions() const { return expressions; }
     void addExpression(const std::string& varName, std::shared_ptr<Expression> expression);
 
-    void memorizeTableIDs(const std::string& name, std::vector<common::table_id_t> tableIDs) {
-        memorizedNodeNameToTableIDs.insert({name, tableIDs});
+    void memorizeTableEntries(const std::string& name, std::vector<catalog::TableCatalogEntry*> entries) {
+        memorizedNodeNameToEntries.insert({name, entries});
     }
     bool hasMemorizedTableIDs(const std::string& name) const {
-        return memorizedNodeNameToTableIDs.contains(name);
+        return memorizedNodeNameToEntries.contains(name);
     }
-    std::vector<common::table_id_t> getMemorizedTableIDs(const std::string& name) {
-        KU_ASSERT(memorizedNodeNameToTableIDs.contains(name));
-        return memorizedNodeNameToTableIDs.at(name);
+    std::vector<catalog::TableCatalogEntry*> getMemorizedTableEntries(const std::string& name) {
+        KU_ASSERT(memorizedNodeNameToEntries.contains(name));
+        return memorizedNodeNameToEntries.at(name);
     }
 
     void addNodeReplacement(std::shared_ptr<NodeExpression> node) {
@@ -47,7 +47,7 @@ public:
 private:
     BinderScope(const BinderScope& other)
         : expressions{other.expressions}, nameToExprIdx{other.nameToExprIdx},
-          memorizedNodeNameToTableIDs{other.memorizedNodeNameToTableIDs} {}
+          memorizedNodeNameToEntries{other.memorizedNodeNameToEntries} {}
 
 private:
     // Expressions in scope. Order should be preserved.
@@ -56,7 +56,7 @@ private:
     // A node might be popped out of scope. But we may need to retain its table ID information.
     // E.g. MATCH (a:person) WITH collect(a) AS list_a UNWIND list_a AS new_a MATCH (new_a)-[]->()
     // It will be more performant if we can retain the information that new_a has label person.
-    std::unordered_map<std::string, std::vector<common::table_id_t>> memorizedNodeNameToTableIDs;
+    std::unordered_map<std::string, std::vector<catalog::TableCatalogEntry*>> memorizedNodeNameToEntries;
     // A node pattern may not always be bound as a node expression, e.g. in the above query,
     // (new_a) is bound as a variable rather than node expression.
     std::unordered_map<std::string, std::shared_ptr<NodeExpression>> nodeReplacement;

--- a/src/include/binder/expression/node_expression.h
+++ b/src/include/binder/expression/node_expression.h
@@ -8,9 +8,9 @@ namespace binder {
 class NodeExpression : public NodeOrRelExpression {
 public:
     NodeExpression(common::LogicalType dataType, std::string uniqueName, std::string variableName,
-        std::vector<common::table_id_t> tableIDs)
+        std::vector<catalog::TableCatalogEntry*> entries)
         : NodeOrRelExpression{std::move(dataType), std::move(uniqueName), std::move(variableName),
-              std::move(tableIDs)} {}
+              std::move(entries)} {}
 
     void setInternalID(std::unique_ptr<Expression> expression) {
         internalID = std::move(expression);

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -32,9 +32,7 @@ public:
     common::idx_t getNumEntries() const { return entries.size(); }
     common::table_id_vector_t getTableIDs() const;
     common::table_id_set_t getTableIDsSet() const;
-    const std::vector<catalog::TableCatalogEntry*>& getEntries() const {
-        return entries;
-    }
+    const std::vector<catalog::TableCatalogEntry*>& getEntries() const { return entries; }
     void setEntries(std::vector<catalog::TableCatalogEntry*> entries_) {
         entries = std::move(entries_);
     }

--- a/src/include/binder/expression/node_rel_expression.h
+++ b/src/include/binder/expression/node_rel_expression.h
@@ -5,14 +5,19 @@
 #include "expression.h"
 
 namespace kuzu {
+namespace catalog {
+class TableCatalogEntry;
+}
 namespace binder {
 
 class NodeOrRelExpression : public Expression {
+    static constexpr common::ExpressionType expressionType_ = common::ExpressionType::PATTERN;
+
 public:
     NodeOrRelExpression(common::LogicalType dataType, std::string uniqueName,
-        std::string variableName, std::vector<common::table_id_t> tableIDs)
-        : Expression{common::ExpressionType::PATTERN, std::move(dataType), std::move(uniqueName)},
-          variableName(std::move(variableName)), tableIDs{std::move(tableIDs)} {}
+        std::string variableName, std::vector<catalog::TableCatalogEntry*> entries)
+        : Expression{expressionType_, std::move(dataType), std::move(uniqueName)},
+          variableName(std::move(variableName)), entries{std::move(entries)} {}
 
     // Note: ideally I would try to remove this function. But for now, we have to create type
     // after expression.
@@ -22,17 +27,19 @@ public:
 
     std::string getVariableName() const { return variableName; }
 
-    void setTableIDs(common::table_id_vector_t tableIDs_) { tableIDs = std::move(tableIDs_); }
-    void addTableIDs(const common::table_id_vector_t& tableIDsToAdd);
-
-    bool isEmpty() const { return tableIDs.empty(); }
-    bool isMultiLabeled() const { return tableIDs.size() > 1; }
-    uint32_t getNumTableIDs() const { return tableIDs.size(); }
-    std::vector<common::table_id_t> getTableIDs() const { return tableIDs; }
-    std::unordered_set<common::table_id_t> getTableIDsSet() const {
-        return {tableIDs.begin(), tableIDs.end()};
+    bool isEmpty() const { return entries.empty(); }
+    bool isMultiLabeled() const { return entries.size() > 1; }
+    common::idx_t getNumEntries() const { return entries.size(); }
+    common::table_id_vector_t getTableIDs() const;
+    common::table_id_set_t getTableIDsSet() const;
+    const std::vector<catalog::TableCatalogEntry*>& getEntries() const {
+        return entries;
     }
-    common::table_id_t getSingleTableID() const;
+    void setEntries(std::vector<catalog::TableCatalogEntry*> entries_) {
+        entries = std::move(entries_);
+    }
+    void addEntries(const std::vector<catalog::TableCatalogEntry*> entries_);
+    catalog::TableCatalogEntry* getSingleEntry() const;
 
     void addPropertyExpression(const std::string& propertyName,
         std::unique_ptr<Expression> property);
@@ -46,9 +53,6 @@ public:
     }
     // Deep copy expressions.
     expression_vector getPropertyExprs() const;
-
-    bool hasPrimaryKey() const;
-    std::shared_ptr<Expression> getPrimaryKey() const;
 
     void setLabelExpression(std::shared_ptr<Expression> expression) {
         labelExpression = std::move(expression);
@@ -75,7 +79,7 @@ public:
 protected:
     std::string variableName;
     // A pattern may bind to multiple tables.
-    std::vector<common::table_id_t> tableIDs;
+    std::vector<catalog::TableCatalogEntry*> entries;
     // Index over propertyExprs on property name.
     std::unordered_map<std::string, common::idx_t> propertyNameToIdx;
     // Property expressions with order (aligned with catalog).

--- a/src/include/binder/expression/rel_expression.h
+++ b/src/include/binder/expression/rel_expression.h
@@ -58,11 +58,11 @@ struct RdfPredicateInfo {
 class RelExpression : public NodeOrRelExpression {
 public:
     RelExpression(common::LogicalType dataType, std::string uniqueName, std::string variableName,
-        std::vector<common::table_id_t> tableIDs, std::shared_ptr<NodeExpression> srcNode,
+        std::vector<catalog::TableCatalogEntry*> entries, std::shared_ptr<NodeExpression> srcNode,
         std::shared_ptr<NodeExpression> dstNode, RelDirectionType directionType,
         common::QueryRelType relType)
         : NodeOrRelExpression{std::move(dataType), std::move(uniqueName), std::move(variableName),
-              std::move(tableIDs)},
+              std::move(entries)},
           srcNode{std::move(srcNode)}, dstNode{std::move(dstNode)}, directionType{directionType},
           relType{relType} {}
 

--- a/src/include/binder/query/query_graph_label_analyzer.h
+++ b/src/include/binder/query/query_graph_label_analyzer.h
@@ -15,7 +15,7 @@ public:
 
 private:
     void pruneNode(const QueryGraph& graph, NodeExpression& node);
-    void pruneRel(RelExpression& rel);
+    void pruneRel(RelExpression& rel) const;
 
 private:
     bool throwOnViolate;

--- a/src/include/catalog/catalog.h
+++ b/src/include/catalog/catalog.h
@@ -66,6 +66,8 @@ public:
     std::string getTableName(transaction::Transaction* transaction,
         common::table_id_t tableID) const;
     TableCatalogEntry* getTableCatalogEntry(transaction::Transaction* transaction,
+        const std::string& tableName) const;
+    TableCatalogEntry* getTableCatalogEntry(transaction::Transaction* transaction,
         common::table_id_t tableID) const;
     std::vector<NodeTableCatalogEntry*> getNodeTableEntries(
         transaction::Transaction* transaction) const;
@@ -152,12 +154,7 @@ private:
     // ----------------------------- Functions ----------------------------
     void registerBuiltInFunctions();
 
-    bool containMacro(const std::string& macroName) const;
-
     // ----------------------------- Table entries ----------------------------
-    uint64_t getNumTables(transaction::Transaction* transaction) const {
-        return tables->getEntries(transaction).size();
-    }
 
     void iterateCatalogEntries(transaction::Transaction* transaction,
         std::function<void(CatalogEntry*)> func) const {

--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -105,7 +105,8 @@ struct TableCatalogEntryEquality {
     }
 };
 
-using table_catalog_entry_set_t = std::unordered_set<TableCatalogEntry*, TableCatalogEntryHasher, TableCatalogEntryEquality>;
+using table_catalog_entry_set_t =
+    std::unordered_set<TableCatalogEntry*, TableCatalogEntryHasher, TableCatalogEntryEquality>;
 
 } // namespace catalog
 } // namespace kuzu

--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -93,5 +93,19 @@ protected:
     std::unique_ptr<binder::BoundAlterInfo> alterInfo;
 };
 
+struct TableCatalogEntryHasher {
+    std::size_t operator()(TableCatalogEntry* entry) const {
+        return std::hash<common::table_id_t>{}(entry->getTableID());
+    }
+};
+
+struct TableCatalogEntryEquality {
+    bool operator()(TableCatalogEntry* left, TableCatalogEntry* right) const {
+        return left->getTableID() == right->getTableID();
+    }
+};
+
+using table_catalog_entry_set_t = std::unordered_set<TableCatalogEntry*, TableCatalogEntryHasher, TableCatalogEntryEquality>;
+
 } // namespace catalog
 } // namespace kuzu

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -186,10 +186,10 @@ private:
         const planner::Schema& schema) const;
     std::unique_ptr<RelDeleteExecutor> getRelDeleteExecutor(const binder::BoundDeleteInfo& info,
         const planner::Schema& schema) const;
-    NodeTableDeleteInfo getNodeTableDeleteInfo(common::table_id_t tableID, DataPos pkPos) const;
-    NodeTableSetInfo getNodeTableSetInfo(common::table_id_t tableID,
+    NodeTableDeleteInfo getNodeTableDeleteInfo(const catalog::TableCatalogEntry& entry, DataPos pkPos) const;
+    NodeTableSetInfo getNodeTableSetInfo(const catalog::TableCatalogEntry& entry,
         const binder::Expression& expr) const;
-    RelTableSetInfo getRelTableSetInfo(common::table_id_t tableID,
+    RelTableSetInfo getRelTableSetInfo(const catalog::TableCatalogEntry& entry,
         const binder::Expression& expr) const;
     uint32_t getOperatorID() { return physicalOperatorID++; }
 

--- a/src/include/processor/plan_mapper.h
+++ b/src/include/processor/plan_mapper.h
@@ -186,7 +186,8 @@ private:
         const planner::Schema& schema) const;
     std::unique_ptr<RelDeleteExecutor> getRelDeleteExecutor(const binder::BoundDeleteInfo& info,
         const planner::Schema& schema) const;
-    NodeTableDeleteInfo getNodeTableDeleteInfo(const catalog::TableCatalogEntry& entry, DataPos pkPos) const;
+    NodeTableDeleteInfo getNodeTableDeleteInfo(const catalog::TableCatalogEntry& entry,
+        DataPos pkPos) const;
     NodeTableSetInfo getNodeTableSetInfo(const catalog::TableCatalogEntry& entry,
         const binder::Expression& expr) const;
     RelTableSetInfo getRelTableSetInfo(const catalog::TableCatalogEntry& entry,

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -9,6 +9,7 @@
 #include "planner/operator/logical_intersect.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "planner/operator/sip/logical_semi_masker.h"
+#include "catalog/catalog_entry/table_catalog_entry.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;
@@ -25,18 +26,28 @@ static std::shared_ptr<LogicalOperator> appendAccumulate(std::shared_ptr<Logical
     return accumulate;
 }
 
+static table_id_vector_t getTableIDs(const std::vector<catalog::TableCatalogEntry*>& entries) {
+    table_id_vector_t result;
+    for (auto& entry : entries) {
+        result.push_back(entry->getTableID());
+    }
+    return result;
+}
+
 static std::vector<table_id_t> getTableIDs(LogicalOperator* op) {
     switch (op->getOperatorType()) {
     case LogicalOperatorType::SCAN_NODE_TABLE: {
         return op->constCast<LogicalScanNodeTable>().getTableIDs();
     }
     case LogicalOperatorType::RECURSIVE_EXTEND: {
-        return op->constCast<LogicalRecursiveExtend>().getNbrNode()->getTableIDs();
+        auto node = op->constCast<LogicalRecursiveExtend>().getNbrNode();
+        return getTableIDs(node->getEntries());
     }
     case LogicalOperatorType::GDS_CALL: {
         auto bindData = op->constCast<LogicalGDSCall>().getInfo().getBindData();
         KU_ASSERT(bindData->hasNodeInput());
-        return bindData->getNodeInput()->constCast<NodeExpression>().getTableIDs();
+        auto& node = bindData->getNodeInput()->constCast<NodeExpression>();
+        return getTableIDs(node.getEntries());
     }
     default:
         KU_UNREACHABLE;

--- a/src/optimizer/acc_hash_join_optimizer.cpp
+++ b/src/optimizer/acc_hash_join_optimizer.cpp
@@ -1,5 +1,6 @@
 #include "optimizer/acc_hash_join_optimizer.h"
 
+#include "catalog/catalog_entry/table_catalog_entry.h"
 #include "function/gds/gds.h"
 #include "optimizer/logical_operator_collector.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
@@ -9,7 +10,6 @@
 #include "planner/operator/logical_intersect.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
 #include "planner/operator/sip/logical_semi_masker.h"
-#include "catalog/catalog_entry/table_catalog_entry.h"
 
 using namespace kuzu::common;
 using namespace kuzu::binder;

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -175,8 +175,8 @@ void ProjectionPushDownOptimizer::visitDelete(planner::LogicalOperator* op) {
         for (auto& info : infos) {
             auto& node = info.pattern->constCast<NodeExpression>();
             collectExpressionsInUse(node.getInternalID());
-            for (auto id : node.getTableIDs()) {
-                collectExpressionsInUse(node.getPrimaryKey(id));
+            for (auto entry : node.getEntries()) {
+                collectExpressionsInUse(node.getPrimaryKey(entry->getTableID()));
             }
         }
     } break;

--- a/src/processor/map/map_delete.cpp
+++ b/src/processor/map/map_delete.cpp
@@ -14,7 +14,8 @@ using namespace kuzu::storage;
 namespace kuzu {
 namespace processor {
 
-NodeTableDeleteInfo PlanMapper::getNodeTableDeleteInfo(const TableCatalogEntry& entry, DataPos pkPos) const {
+NodeTableDeleteInfo PlanMapper::getNodeTableDeleteInfo(const TableCatalogEntry& entry,
+    DataPos pkPos) const {
     auto storageManager = clientContext->getStorageManager();
     auto catalog = clientContext->getCatalog();
     auto transaction = clientContext->getTx();

--- a/src/processor/map/map_delete.cpp
+++ b/src/processor/map/map_delete.cpp
@@ -14,10 +14,11 @@ using namespace kuzu::storage;
 namespace kuzu {
 namespace processor {
 
-NodeTableDeleteInfo PlanMapper::getNodeTableDeleteInfo(table_id_t tableID, DataPos pkPos) const {
+NodeTableDeleteInfo PlanMapper::getNodeTableDeleteInfo(const TableCatalogEntry& entry, DataPos pkPos) const {
     auto storageManager = clientContext->getStorageManager();
     auto catalog = clientContext->getCatalog();
     auto transaction = clientContext->getTx();
+    auto tableID = entry.getTableID();
     auto table = storageManager->getTable(tableID)->ptrCast<NodeTable>();
     std::unordered_set<RelTable*> fwdRelTables;
     std::unordered_set<RelTable*> bwdRelTables;
@@ -41,15 +42,16 @@ std::unique_ptr<NodeDeleteExecutor> PlanMapper::getNodeDeleteExecutor(
     }
     if (node.isMultiLabeled()) {
         common::table_id_map_t<NodeTableDeleteInfo> tableInfos;
-        for (auto id : node.getTableIDs()) {
-            auto pkPos = getDataPos(*node.getPrimaryKey(id), schema);
-            tableInfos.insert({id, getNodeTableDeleteInfo(id, pkPos)});
+        for (auto entry : node.getEntries()) {
+            auto tableID = entry->getTableID();
+            auto pkPos = getDataPos(*node.getPrimaryKey(tableID), schema);
+            tableInfos.insert({tableID, getNodeTableDeleteInfo(*entry, pkPos)});
         }
         return std::make_unique<MultiLabelNodeDeleteExecutor>(std::move(info),
             std::move(tableInfos));
     }
-    auto pkPos = getDataPos(*node.getPrimaryKey(node.getSingleTableID()), schema);
-    auto extraInfo = getNodeTableDeleteInfo(node.getSingleTableID(), pkPos);
+    auto pkPos = getDataPos(*node.getPrimaryKey(node.getSingleEntry()->getTableID()), schema);
+    auto extraInfo = getNodeTableDeleteInfo(*node.getSingleEntry(), pkPos);
     return std::make_unique<SingleLabelNodeDeleteExecutor>(std::move(info), std::move(extraInfo));
 }
 
@@ -98,14 +100,15 @@ std::unique_ptr<RelDeleteExecutor> PlanMapper::getRelDeleteExecutor(
     }
     if (rel.isMultiLabeled()) {
         common::table_id_map_t<storage::RelTable*> tableIDToTableMap;
-        for (auto tableID : rel.getTableIDs()) {
+        for (auto entry : rel.getEntries()) {
+            auto tableID = entry->getTableID();
             auto table = storageManager->getTable(tableID)->ptrCast<RelTable>();
             tableIDToTableMap.insert({tableID, table});
         }
         return std::make_unique<MultiLabelRelDeleteExecutor>(std::move(tableIDToTableMap),
             std::move(info));
     }
-    auto table = storageManager->getTable(rel.getSingleTableID())->ptrCast<RelTable>();
+    auto table = storageManager->getTable(rel.getSingleEntry()->getTableID())->ptrCast<RelTable>();
     return std::make_unique<SingleLabelRelDeleteExecutor>(table, std::move(info));
 }
 

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -20,7 +20,7 @@ static ScanRelTableInfo getRelTableScanInfo(const TableCatalogEntry& tableCatalo
     const expression_vector& properties, const std::vector<ColumnPredicateSet>& columnPredicates) {
     auto relTableID = tableCatalogEntry.getTableID();
     std::vector<column_id_t> columnIDs;
-    // We alawys should scan nbrID from relTable. This is not a property in the schema label, so
+    // We always should scan nbrID from relTable. This is not a property in the schema label, so
     // cannot be bound to a column in the front-end.
     columnIDs.push_back(NBR_ID_COLUMN_ID);
     for (auto& expr : properties) {
@@ -41,12 +41,10 @@ static RelTableCollectionScanner populateRelTableCollectionScanner(table_id_t bo
     const expression_vector& properties, const std::vector<ColumnPredicateSet>& columnPredicates,
     const main::ClientContext& clientContext) {
     std::vector<ScanRelTableInfo> scanInfos;
-    auto catalog = clientContext.getCatalog();
     auto storageManager = clientContext.getStorageManager();
-    for (auto relTableID : rel.getTableIDs()) {
-        auto entry = catalog->getTableCatalogEntry(clientContext.getTx(), relTableID);
+    for (auto entry : rel.getEntries()) {
         auto& relTableEntry = entry->constCast<RelTableCatalogEntry>();
-        auto relTable = storageManager->getTable(relTableID)->ptrCast<RelTable>();
+        auto relTable = storageManager->getTable(entry->getTableID())->ptrCast<RelTable>();
         switch (extendDirection) {
         case ExtendDirection::FWD: {
             if (relTableEntry.getBoundTableID(RelDataDirection::FWD) == boundNodeTableID) {
@@ -102,20 +100,17 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(LogicalOperator* logical
     }
     auto scanInfo = ScanTableInfo(relIDPos, outVectorsPos);
     std::vector<std::string> tableNames;
-    for (auto relTableID : rel->getTableIDs()) {
-        auto relTable =
-            clientContext->getStorageManager()->getTable(relTableID)->ptrCast<RelTable>();
+    auto storageManager = clientContext->getStorageManager();
+    for (auto entry : rel->getEntries()) {
+        auto relTable = storageManager->getTable(entry->getTableID())->ptrCast<RelTable>();
         tableNames.push_back(relTable->getTableName());
     }
     auto printInfo = std::make_unique<ScanRelTablePrintInfo>(tableNames, extend->getProperties(),
         boundNode, rel, nbrNode, extendDirection);
     if (scanSingleRelTable(*rel, *boundNode, extendDirection)) {
-        auto relTableID = rel->getSingleTableID();
-        auto entry =
-            clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTx(), relTableID);
+        auto entry = rel->getSingleEntry();
         auto relDataDirection = ExtendDirectionUtil::getRelDataDirection(extendDirection);
-        auto relTable =
-            clientContext->getStorageManager()->getTable(relTableID)->ptrCast<RelTable>();
+        auto relTable = storageManager->getTable(entry->getTableID())->ptrCast<RelTable>();
         auto scanRelInfo = getRelTableScanInfo(*entry, relDataDirection, inNodeIDPos, relTable,
             extend->getProperties(), extend->getPropertyPredicates());
         return std::make_unique<ScanRelTable>(std::move(scanInfo), std::move(scanRelInfo),

--- a/src/processor/map/map_gds.cpp
+++ b/src/processor/map/map_gds.cpp
@@ -34,7 +34,8 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapGDSCall(LogicalOperator* logica
         // Generate an empty semi mask which later on picked by SemiMaker.
         auto& node =
             call.getInfo().getBindData()->getNodeInput()->constCast<binder::NodeExpression>();
-        for (auto tableID : node.getTableIDs()) {
+        for (auto entry : node.getEntries()) {
+            auto tableID = entry->getTableID();
             auto nodeTable =
                 clientContext->getStorageManager()->getTable(tableID)->ptrCast<NodeTable>();
             masks.insert({tableID,

--- a/src/processor/map/map_insert.cpp
+++ b/src/processor/map/map_insert.cpp
@@ -34,8 +34,7 @@ NodeInsertExecutor PlanMapper::getNodeInsertExecutor(const LogicalInsertInfo* bo
     auto columnsPos = populateReturnColumnsPos(*boundInfo, outSchema);
     auto info = NodeInsertInfo(nodeIDPos, columnsPos, boundInfo->conflictAction);
     auto storageManager = clientContext->getStorageManager();
-    auto nodeTableID = node.getSingleTableID();
-    auto table = storageManager->getTable(nodeTableID)->ptrCast<NodeTable>();
+    auto table = storageManager->getTable(node.getSingleEntry()->getTableID())->ptrCast<NodeTable>();
     evaluator_vector_t evaluators;
     auto exprMapper = ExpressionMapper(&inSchema);
     for (auto& expr : boundInfo->columnDataExprs) {
@@ -55,8 +54,7 @@ RelInsertExecutor PlanMapper::getRelInsertExecutor(const LogicalInsertInfo* boun
     auto columnsPos = populateReturnColumnsPos(*boundInfo, outSchema);
     auto info = RelInsertInfo(srcNodeIDPos, dstNodeIDPos, std::move(columnsPos));
     auto storageManager = clientContext->getStorageManager();
-    auto relTableID = rel.getSingleTableID();
-    auto table = storageManager->getTable(relTableID)->ptrCast<RelTable>();
+    auto table = storageManager->getTable(rel.getSingleEntry()->getTableID())->ptrCast<RelTable>();
     evaluator_vector_t evaluators;
     auto exprMapper = ExpressionMapper(&outSchema);
     for (auto& expr : boundInfo->columnDataExprs) {

--- a/src/processor/map/map_insert.cpp
+++ b/src/processor/map/map_insert.cpp
@@ -34,7 +34,8 @@ NodeInsertExecutor PlanMapper::getNodeInsertExecutor(const LogicalInsertInfo* bo
     auto columnsPos = populateReturnColumnsPos(*boundInfo, outSchema);
     auto info = NodeInsertInfo(nodeIDPos, columnsPos, boundInfo->conflictAction);
     auto storageManager = clientContext->getStorageManager();
-    auto table = storageManager->getTable(node.getSingleEntry()->getTableID())->ptrCast<NodeTable>();
+    auto table =
+        storageManager->getTable(node.getSingleEntry()->getTableID())->ptrCast<NodeTable>();
     evaluator_vector_t evaluators;
     auto exprMapper = ExpressionMapper(&inSchema);
     for (auto& expr : boundInfo->columnDataExprs) {

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -11,9 +11,10 @@ namespace kuzu {
 namespace processor {
 
 static std::shared_ptr<RecursiveJoinSharedState> createSharedState(
-    const binder::NodeExpression& nbrNode, const main::ClientContext& context) {
+    const NodeExpression& nbrNode, const main::ClientContext& context) {
     std::vector<std::unique_ptr<common::NodeOffsetLevelSemiMask>> semiMasks;
-    for (auto tableID : nbrNode.getTableIDs()) {
+    for (auto entry : nbrNode.getEntries()) {
+        auto tableID = entry->getTableID();
         auto table = context.getStorageManager()->getTable(tableID)->ptrCast<storage::NodeTable>();
         semiMasks.push_back(
             std::make_unique<common::NodeOffsetLevelSemiMask>(tableID, table->getNumRows()));

--- a/src/processor/map/map_recursive_extend.cpp
+++ b/src/processor/map/map_recursive_extend.cpp
@@ -10,8 +10,8 @@ using namespace kuzu::planner;
 namespace kuzu {
 namespace processor {
 
-static std::shared_ptr<RecursiveJoinSharedState> createSharedState(
-    const NodeExpression& nbrNode, const main::ClientContext& context) {
+static std::shared_ptr<RecursiveJoinSharedState> createSharedState(const NodeExpression& nbrNode,
+    const main::ClientContext& context) {
     std::vector<std::unique_ptr<common::NodeOffsetLevelSemiMask>> semiMasks;
     for (auto entry : nbrNode.getEntries()) {
         auto tableID = entry->getTableID();

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -9,6 +9,7 @@
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
+using namespace kuzu::catalog;
 using namespace kuzu::planner;
 using namespace kuzu::evaluator;
 using namespace kuzu::transaction;
@@ -27,21 +28,17 @@ static column_id_t getColumnID(const catalog::TableCatalogEntry& entry,
     return columnID;
 }
 
-NodeTableSetInfo PlanMapper::getNodeTableSetInfo(table_id_t tableID, const Expression& expr) const {
+NodeTableSetInfo PlanMapper::getNodeTableSetInfo(const TableCatalogEntry& entry, const Expression& expr) const {
     auto storageManager = clientContext->getStorageManager();
-    auto catalog = clientContext->getCatalog();
-    auto table = storageManager->getTable(tableID)->ptrCast<NodeTable>();
-    auto entry = catalog->getTableCatalogEntry(clientContext->getTx(), tableID);
-    auto columnID = getColumnID(*entry, expr.constCast<PropertyExpression>());
+    auto table = storageManager->getTable(entry.getTableID())->ptrCast<NodeTable>();
+    auto columnID = getColumnID(entry, expr.constCast<PropertyExpression>());
     return NodeTableSetInfo(table, columnID);
 }
 
-RelTableSetInfo PlanMapper::getRelTableSetInfo(table_id_t tableID, const Expression& expr) const {
+RelTableSetInfo PlanMapper::getRelTableSetInfo(const TableCatalogEntry& entry, const Expression& expr) const {
     auto storageManager = clientContext->getStorageManager();
-    auto catalog = clientContext->getCatalog();
-    auto table = storageManager->getTable(tableID)->ptrCast<RelTable>();
-    auto entry = catalog->getTableCatalogEntry(clientContext->getTx(), tableID);
-    auto columnID = getColumnID(*entry, expr.constCast<PropertyExpression>());
+    auto table = storageManager->getTable(entry.getTableID())->ptrCast<RelTable>();
+    auto columnID = getColumnID(entry, expr.constCast<PropertyExpression>());
     return RelTableSetInfo(table, columnID);
 }
 
@@ -63,13 +60,14 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
     auto setInfo = NodeSetInfo(nodeIDPos, columnVectorPos, pkVectorPos, std::move(evaluator));
     if (node.isMultiLabeled()) {
         common::table_id_map_t<NodeTableSetInfo> tableInfos;
-        for (auto tableID : node.getTableIDs()) {
+        for (auto entry : node.getEntries()) {
+            auto tableID = entry->getTableID();
             if (boundInfo.updatePk && !property.isPrimaryKey(tableID)) {
                 throw BinderException(stringFormat(
                     "Update primary key column {} for multiple tables is not supported.",
                     property.toString()));
             }
-            auto tableInfo = getNodeTableSetInfo(tableID, property);
+            auto tableInfo = getNodeTableSetInfo(*entry, property);
             if (tableInfo.columnID == INVALID_COLUMN_ID) {
                 continue;
             }
@@ -78,7 +76,7 @@ std::unique_ptr<NodeSetExecutor> PlanMapper::getNodeSetExecutor(
         return std::make_unique<MultiLabelNodeSetExecutor>(std::move(setInfo),
             std::move(tableInfos));
     }
-    auto tableInfo = getNodeTableSetInfo(node.getSingleTableID(), property);
+    auto tableInfo = getNodeTableSetInfo(*node.getSingleEntry(), property);
     return std::make_unique<SingleLabelNodeSetExecutor>(std::move(setInfo), std::move(tableInfo));
 }
 
@@ -131,16 +129,16 @@ std::unique_ptr<RelSetExecutor> PlanMapper::getRelSetExecutor(const BoundSetProp
         RelSetInfo(srcNodeIDPos, dstNodeIDPos, relIDPos, columnVectorPos, std::move(evaluator));
     if (rel.isMultiLabeled()) {
         common::table_id_map_t<RelTableSetInfo> tableInfos;
-        for (auto tableID : rel.getTableIDs()) {
-            auto tableInfo = getRelTableSetInfo(tableID, property);
+        for (auto entry : rel.getEntries()) {
+            auto tableInfo = getRelTableSetInfo(*entry, property);
             if (tableInfo.columnID == INVALID_COLUMN_ID) {
                 continue;
             }
-            tableInfos.insert({tableID, std::move(tableInfo)});
+            tableInfos.insert({entry->getTableID(), std::move(tableInfo)});
         }
         return std::make_unique<MultiLabelRelSetExecutor>(std::move(info), std::move(tableInfos));
     }
-    auto tableInfo = getRelTableSetInfo(rel.getSingleTableID(), property);
+    auto tableInfo = getRelTableSetInfo(*rel.getSingleEntry(), property);
     return std::make_unique<SingleLabelRelSetExecutor>(std::move(info), std::move(tableInfo));
 }
 

--- a/src/processor/map/map_set.cpp
+++ b/src/processor/map/map_set.cpp
@@ -28,14 +28,16 @@ static column_id_t getColumnID(const catalog::TableCatalogEntry& entry,
     return columnID;
 }
 
-NodeTableSetInfo PlanMapper::getNodeTableSetInfo(const TableCatalogEntry& entry, const Expression& expr) const {
+NodeTableSetInfo PlanMapper::getNodeTableSetInfo(const TableCatalogEntry& entry,
+    const Expression& expr) const {
     auto storageManager = clientContext->getStorageManager();
     auto table = storageManager->getTable(entry.getTableID())->ptrCast<NodeTable>();
     auto columnID = getColumnID(entry, expr.constCast<PropertyExpression>());
     return NodeTableSetInfo(table, columnID);
 }
 
-RelTableSetInfo PlanMapper::getRelTableSetInfo(const TableCatalogEntry& entry, const Expression& expr) const {
+RelTableSetInfo PlanMapper::getRelTableSetInfo(const TableCatalogEntry& entry,
+    const Expression& expr) const {
     auto storageManager = clientContext->getStorageManager();
     auto table = storageManager->getTable(entry.getTableID())->ptrCast<RelTable>();
     auto columnID = getColumnID(entry, expr.constCast<PropertyExpression>());


### PR DESCRIPTION
# Description

`getTableCatalogEntry` API in the catalog is introducing noticeable overhead when binding large query graph since we now need to check different versions of entry under MVCC.

This PR directly save `TableCatalogEntry*` in node/rel expression instead of `tableID` to avoid repeated access of catalog entries.


Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).