### PR TITLE
Vacuum dropped columns during checkpoint

### DIFF
--- a/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_table_catalog_entry.cpp
@@ -33,12 +33,15 @@ column_id_t RelTableCatalogEntry::getColumnID(property_id_t propertyID) const {
 bool RelTableCatalogEntry::isSingleMultiplicity(RelDataDirection direction) const {
     return getMultiplicity(direction) == RelMultiplicity::ONE;
 }
+
 RelMultiplicity RelTableCatalogEntry::getMultiplicity(RelDataDirection direction) const {
     return direction == RelDataDirection::FWD ? dstMultiplicity : srcMultiplicity;
 }
+
 table_id_t RelTableCatalogEntry::getBoundTableID(RelDataDirection relDirection) const {
     return relDirection == RelDataDirection::FWD ? srcTableID : dstTableID;
 }
+
 table_id_t RelTableCatalogEntry::getNbrTableID(RelDataDirection relDirection) const {
     return relDirection == RelDataDirection::FWD ? dstTableID : srcTableID;
 }

--- a/src/include/catalog/catalog_entry/sequence_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/sequence_catalog_entry.h
@@ -3,8 +3,8 @@
 #include <mutex>
 
 #include "binder/ddl/bound_create_sequence_info.h"
-#include "catalog/property.h"
 #include "catalog_entry.h"
+#include "common/vector/value_vector.h"
 
 namespace kuzu {
 namespace binder {

--- a/src/include/catalog/catalog_entry/table_catalog_entry.h
+++ b/src/include/catalog/catalog_entry/table_catalog_entry.h
@@ -42,7 +42,6 @@ public:
     std::string getComment() const { return comment; }
     void setComment(std::string newComment) { comment = std::move(newComment); }
     virtual bool isParent(common::table_id_t /*tableID*/) { return false; };
-    // TODO(Guodong/Ziyi): This function should be removed. Instead we should use CatalogEntryType.
     virtual common::TableType getTableType() const = 0;
     virtual function::TableFunction getScanFunction() { KU_UNREACHABLE; }
     binder::BoundAlterInfo* getAlterInfo() const { return alterInfo.get(); }
@@ -56,16 +55,17 @@ public:
     //===--------------------------------------------------------------------===//
     uint32_t getNumProperties() const { return properties.size(); }
     const std::vector<Property>& getPropertiesRef() const { return properties; }
+    std::vector<Property>& getPropertiesUnsafe() { return properties; }
     bool containProperty(const std::string& propertyName) const;
     common::property_id_t getPropertyID(const std::string& propertyName) const;
     const Property* getProperty(common::property_id_t propertyID) const;
     uint32_t getPropertyPos(common::property_id_t propertyID) const;
     virtual common::column_id_t getColumnID(common::property_id_t propertyID) const;
-    bool containPropertyType(const common::LogicalType& logicalType) const;
     void addProperty(std::string propertyName, common::LogicalType dataType,
         std::unique_ptr<parser::ParsedExpression> defaultExpr);
     void dropProperty(common::property_id_t propertyID);
     void renameProperty(common::property_id_t propertyID, const std::string& newName);
+    void resetColumnIDs();
 
     //===--------------------------------------------------------------------===//
     // serialization & deserialization

--- a/src/include/catalog/property.h
+++ b/src/include/catalog/property.h
@@ -2,7 +2,6 @@
 
 #include "common/copy_constructors.h"
 #include "common/types/types.h"
-#include "common/types/value/value.h"
 #include "parser/expression/parsed_expression.h"
 
 namespace kuzu {
@@ -29,6 +28,7 @@ public:
 
     std::string getName() const { return name; }
 
+    void setColumnID(common::column_id_t columnID) { this->columnID = columnID; }
     const common::LogicalType& getDataType() const { return dataType; }
     common::property_id_t getPropertyID() const { return propertyID; }
     common::column_id_t getColumnID() const { return columnID; }
@@ -40,7 +40,7 @@ public:
     void serialize(common::Serializer& serializer) const;
     static Property deserialize(common::Deserializer& deserializer);
 
-    static std::string toCypher(const std::vector<kuzu::catalog::Property>& properties);
+    static std::string toCypher(const std::vector<Property>& properties);
 
 private:
     Property(const Property& other)

--- a/src/include/storage/store/chunked_node_group.h
+++ b/src/include/storage/store/chunked_node_group.h
@@ -33,6 +33,8 @@ public:
 
     ChunkedNodeGroup(std::vector<std::unique_ptr<ColumnChunk>> chunks,
         common::row_idx_t startRowIdx, NodeGroupDataFormat format = NodeGroupDataFormat::REGULAR);
+    ChunkedNodeGroup(ChunkedNodeGroup& base,
+        const std::vector<common::column_id_t>& selectedColumns);
     ChunkedNodeGroup(const std::vector<common::LogicalType>& columnTypes, bool enableCompression,
         uint64_t capacity, common::row_idx_t startRowIdx, ResidencyState residencyState,
         NodeGroupDataFormat format = NodeGroupDataFormat::REGULAR);

--- a/src/include/storage/store/csr_chunked_node_group.h
+++ b/src/include/storage/store/csr_chunked_node_group.h
@@ -99,6 +99,9 @@ public:
         : ChunkedNodeGroup{columnTypes, enableCompression, capacity, startOffset, residencyState,
               NodeGroupDataFormat::CSR},
           csrHeader{enableCompression, common::StorageConstants::NODE_GROUP_SIZE, residencyState} {}
+    ChunkedCSRNodeGroup(ChunkedCSRNodeGroup& base,
+        const std::vector<common::column_id_t>& selectedColumns)
+        : ChunkedNodeGroup{base, selectedColumns}, csrHeader{std::move(base.csrHeader)} {}
     ChunkedCSRNodeGroup(ChunkedCSRHeader csrHeader,
         std::vector<std::unique_ptr<ColumnChunk>> chunks, common::row_idx_t startRowIdx)
         : ChunkedNodeGroup{std::move(chunks), startRowIdx, NodeGroupDataFormat::CSR},

--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -139,8 +139,8 @@ struct CSRNodeGroupCheckpointState final : NodeGroupCheckpointState {
     std::unique_ptr<ChunkedCSRHeader> newHeader;
 
     CSRNodeGroupCheckpointState(std::vector<common::column_id_t> columnIDs,
-        std::vector<Column*> columns, BMFileHandle& dataFH, MemoryManager* mm, Column* csrOffsetCol,
-        Column* csrLengthCol)
+        std::vector<std::unique_ptr<Column>> columns, BMFileHandle& dataFH, MemoryManager* mm,
+        Column* csrOffsetCol, Column* csrLengthCol)
         : NodeGroupCheckpointState{std::move(columnIDs), std::move(columns), dataFH, mm},
           csrOffsetColumn{csrOffsetCol}, csrLengthColumn{csrLengthCol} {}
 };

--- a/src/include/storage/store/node_group.h
+++ b/src/include/storage/store/node_group.h
@@ -46,12 +46,12 @@ struct NodeGroupScanState {
 class MemoryManager;
 struct NodeGroupCheckpointState {
     std::vector<common::column_id_t> columnIDs;
-    std::vector<Column*> columns;
+    std::vector<std::unique_ptr<Column>> columns;
     BMFileHandle& dataFH;
     MemoryManager* mm;
 
     NodeGroupCheckpointState(std::vector<common::column_id_t> columnIDs,
-        std::vector<Column*> columns, BMFileHandle& dataFH, MemoryManager* mm)
+        std::vector<std::unique_ptr<Column>> columns, BMFileHandle& dataFH, MemoryManager* mm)
         : columnIDs{std::move(columnIDs)}, columns{std::move(columns)}, dataFH{dataFH}, mm{mm} {}
     virtual ~NodeGroupCheckpointState() = default;
 

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 
-#include "common/exception/not_implemented.h"
 #include "common/types/types.h"
 #include "storage/index/hash_index.h"
 #include "storage/store/node_group_collection.h"
@@ -115,10 +114,6 @@ public:
 
     void addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState) override;
-    void dropColumn(common::column_id_t) override {
-        throw common::NotImplementedException("dropColumn is not implemented yet.");
-    }
-
     bool isVisible(const transaction::Transaction* transaction, common::offset_t offset) const;
 
     bool lookupPK(const transaction::Transaction* transaction, common::ValueVector* keyVector,
@@ -150,8 +145,7 @@ public:
         transaction::Transaction* transaction, ChunkedNodeGroup& chunkedGroup);
 
     void commit(transaction::Transaction* transaction, LocalTable* localTable) override;
-    void rollback(LocalTable* localTable) override;
-    void checkpoint(common::Serializer& ser) override;
+    void checkpoint(common::Serializer& ser, catalog::TableCatalogEntry* tableEntry) override;
 
     common::node_group_idx_t getNumCommittedNodeGroups() const {
         return nodeGroups->getNumNodeGroups();

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -138,11 +138,6 @@ public:
 
     void addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState) override;
-    void dropColumn(common::column_id_t) override {
-        // TODO(Guodong): Rework this.
-        // fwdRelTableData->dropColumn(columnID);
-        // bwdRelTableData->dropColumn(columnID);
-    }
     Column* getCSROffsetColumn(common::RelDataDirection direction) const {
         return direction == common::RelDataDirection::FWD ? fwdRelTableData->getCSROffsetColumn() :
                                                             bwdRelTableData->getCSROffsetColumn();
@@ -164,8 +159,7 @@ public:
         common::RelDataDirection direction) const;
 
     void commit(transaction::Transaction* transaction, LocalTable* localTable) override;
-    void rollback(LocalTable* localTable) override;
-    void checkpoint(common::Serializer& ser) override;
+    void checkpoint(common::Serializer& ser, catalog::TableCatalogEntry* tableEntry) override;
 
     common::row_idx_t getNumRows() override { return nextRelOffset; }
 

--- a/src/include/storage/store/rel_table_data.h
+++ b/src/include/storage/store/rel_table_data.h
@@ -62,7 +62,7 @@ public:
         return numRows;
     }
 
-    void checkpoint() const;
+    void checkpoint(const std::vector<common::column_id_t>& columnIDs);
 
     void serialize(common::Serializer& serializer) const;
 

--- a/src/include/storage/store/table.h
+++ b/src/include/storage/store/table.h
@@ -161,11 +161,10 @@ public:
 
     virtual void addColumn(transaction::Transaction* transaction,
         TableAddColumnState& addColumnState) = 0;
-    virtual void dropColumn(common::column_id_t columnID) = 0;
+    void dropColumn() { setHasChanges(); }
 
     virtual void commit(transaction::Transaction* transaction, LocalTable* localTable) = 0;
-    virtual void rollback(LocalTable* localTable) = 0;
-    virtual void checkpoint(common::Serializer& ser) = 0;
+    virtual void checkpoint(common::Serializer& ser, catalog::TableCatalogEntry* tableEntry) = 0;
 
     virtual common::row_idx_t getNumRows() = 0;
 

--- a/src/processor/operator/ddl/alter.cpp
+++ b/src/processor/operator/ddl/alter.cpp
@@ -59,6 +59,9 @@ void Alter::executeDDLInternal(ExecutionContext* context) {
         auto storageManager = context->clientContext->getStorageManager();
         storage::TableAddColumnState state{*addedProp, *defaultValueEvaluator};
         storageManager->getTable(info.tableID)->addColumn(context->clientContext->getTx(), state);
+    } else if (info.alterType == common::AlterType::DROP_PROPERTY) {
+        auto storageManager = context->clientContext->getStorageManager();
+        storageManager->getTable(info.tableID)->dropColumn();
     }
 }
 

--- a/src/storage/local_storage/local_storage.cpp
+++ b/src/storage/local_storage/local_storage.cpp
@@ -56,8 +56,7 @@ void LocalStorage::commit() {
 
 void LocalStorage::rollback() {
     for (auto& [tableID, localTable] : tables) {
-        const auto table = clientContext.getStorageManager()->getTable(tableID);
-        table->rollback(localTable.get());
+        localTable->clear();
     }
 }
 

--- a/src/storage/storage_manager.cpp
+++ b/src/storage/storage_manager.cpp
@@ -231,7 +231,7 @@ void StorageManager::checkpoint(main::ClientContext& clientContext) {
                 stringFormat("Checkpoint failed: table {} not found in storage manager.",
                     tableEntry->getName()));
         }
-        tables.at(tableEntry->getTableID())->checkpoint(ser);
+        tables.at(tableEntry->getTableID())->checkpoint(ser, tableEntry);
     }
     for (const auto tableEntry : relTableEntries) {
         if (!tables.contains(tableEntry->getTableID())) {
@@ -239,7 +239,7 @@ void StorageManager::checkpoint(main::ClientContext& clientContext) {
                 stringFormat("Checkpoint failed: table {} not found in storage manager.",
                     tableEntry->getName()));
         }
-        tables.at(tableEntry->getTableID())->checkpoint(ser);
+        tables.at(tableEntry->getTableID())->checkpoint(ser, tableEntry);
     }
     writer->flush();
     writer->sync();

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -25,6 +25,17 @@ ChunkedNodeGroup::ChunkedNodeGroup(std::vector<std::unique_ptr<ColumnChunk>> chu
     }
 }
 
+ChunkedNodeGroup::ChunkedNodeGroup(ChunkedNodeGroup& base,
+    const std::vector<column_id_t>& selectedColumns)
+    : format{base.format}, residencyState{base.residencyState}, startRowIdx{base.startRowIdx},
+      capacity{base.capacity}, numRows{base.numRows.load()} {
+    chunks.reserve(selectedColumns.size());
+    for (const auto columnID : selectedColumns) {
+        KU_ASSERT(columnID < base.getNumColumns());
+        chunks.push_back(base.moveColumnChunk(columnID));
+    }
+}
+
 ChunkedNodeGroup::ChunkedNodeGroup(const std::vector<LogicalType>& columnTypes,
     bool enableCompression, uint64_t capacity, row_idx_t startRowIdx, ResidencyState residencyState,
     NodeGroupDataFormat format)

--- a/src/storage/store/table.cpp
+++ b/src/storage/store/table.cpp
@@ -47,6 +47,7 @@ void Table::serialize(Serializer& serializer) const {
     serializer.write<TableType>(tableType);
     serializer.writeDebuggingInfo("table_id");
     serializer.write<table_id_t>(tableID);
+    // TODO(Guodong): We should avoid writing table name in the future.
     serializer.writeDebuggingInfo("table_name");
     serializer.write<std::string>(tableName);
 }

--- a/src/transaction/transaction_manager.cpp
+++ b/src/transaction/transaction_manager.cpp
@@ -156,12 +156,12 @@ void TransactionManager::checkpointNoLock(main::ClientContext& clientContext) {
     // query stop working on the tasks of the query and these tasks are removed from the
     // query.
     stopNewTransactionsAndWaitUntilAllTransactionsLeave();
-    // Checkpoint catalog, which serializes a snapshot of the catalog to disk.
-    clientContext.getCatalog()->checkpoint(clientContext.getDatabasePath(),
-        clientContext.getVFSUnsafe());
     // Checkpoint node/relTables, which writes the updated/newly-inserted pages and metadata to
     // disk.
     clientContext.getStorageManager()->checkpoint(clientContext);
+    // Checkpoint catalog, which serializes a snapshot of the catalog to disk.
+    clientContext.getCatalog()->checkpoint(clientContext.getDatabasePath(),
+        clientContext.getVFSUnsafe());
     // Log the checkpoint to the WAL and flush WAL. This indicates that all shadow pages and files(
     // snapshots of catalog and metadata) have been written to disk. The part is not done is replace
     // them with the original pages or catalog and metadata files.

--- a/test/include/test_helper/test_helper.h
+++ b/test/include/test_helper/test_helper.h
@@ -50,13 +50,10 @@ public:
 
     static std::unique_ptr<main::SystemConfig> getSystemConfigFromEnv() {
         auto systemConfig = std::make_unique<main::SystemConfig>();
-        auto autoCheckpointEnv = getSystemEnv("AUTO_CHECKPOINT");
         auto bufferPoolSizeEnv = getSystemEnv("BUFFER_POOL_SIZE");
         auto maxNumThreadsEnv = getSystemEnv("MAX_NUM_THREADS");
         auto enableCompressionEnv = getSystemEnv("ENABLE_COMPRESSION");
         auto checkpointThresholdEnv = getSystemEnv("CHECKPOINT_THRESHOLD");
-        systemConfig->autoCheckpoint =
-            autoCheckpointEnv.empty() ? false : std::string(autoCheckpointEnv) == "true";
         systemConfig->bufferPoolSize =
             bufferPoolSizeEnv.empty() ?
                 common::BufferPoolConstants::DEFAULT_BUFFER_POOL_SIZE_FOR_TESTING :

--- a/test/test_files/transaction/ddl/ddl_empty.test
+++ b/test/test_files/transaction/ddl/ddl_empty.test
@@ -2,8 +2,6 @@
 --
 
 -CASE CreateDropNodeTableRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE NODE TABLE test(id SERIAL, primary key(id));
@@ -25,8 +23,6 @@ test|NODE|local(kuzu)|
 ---- 0
 
 -CASE CreateDropRelTableRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT CREATE NODE TABLE base(id SERIAL, primary key(id));
 ---- ok
 -STATEMENT BEGIN TRANSACTION;
@@ -52,8 +48,6 @@ test|REL|local(kuzu)|
 base|NODE|local(kuzu)|
 
 -CASE CreateDropRdfTableRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE RDFGraph test;
@@ -79,8 +73,6 @@ test|RDFGraph|local(kuzu)|
 ---- 0
 
 -CASE CreateDropRelGroupRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT CREATE NODE TABLE base1(id SERIAL, primary key(id));
 ---- ok
 -STATEMENT CREATE NODE TABLE base2(id SERIAL, primary key(id));
@@ -110,3 +102,67 @@ test|REL_GROUP|local(kuzu)|
 ---- 2
 base1|NODE|local(kuzu)|
 base2|NODE|local(kuzu)|
+
+-CASE InsertAndDropNodeColumnCheckpointRecovery
+-STATEMENT CREATE NODE TABLE test(id INT64, age INT64, name STRING, prop2 INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE (t:test {id: 0, age: 20, name: 'test', prop2: 1});
+---- ok
+-STATEMENT CREATE (t:test {id: 1, age: 21, name: 'test1', prop2: 2});
+---- ok
+-STATEMENT CREATE (t:test {id: 2, age: 22, name: 'test2', prop2: 3});
+---- ok
+-STATEMENT CREATE (t:test {id: 3, age: 23, name: 'test3', prop2: 4});
+---- ok
+-STATEMENT CREATE (t:test {id: 4, age: 24, name: 'test4', prop2: 5});
+---- ok
+-STATEMENT ALTER TABLE test DROP name;
+---- ok
+-STATEMENT CHECKPOINT;
+---- ok
+-RELOADDB
+-STATEMENT MATCH (n:test) RETURN n.*;
+---- 5
+0|20|1
+1|21|2
+2|22|3
+3|23|4
+4|24|5
+
+-CASE InsertAndDropRelColumnCheckpointRecovery
+-STATEMENT CREATE NODE TABLE test(id INT64, age INT64, name STRING, prop2 INT64, PRIMARY KEY(id));
+---- ok
+-STATEMENT CREATE REL TABLE testRel(FROM test TO test, since DATE, prop3 INT64);
+---- ok
+-STATEMENT CREATE (t:test {id: 0, age: 20, name: 'test', prop2: 1});
+---- ok
+-STATEMENT CREATE (t:test {id: 1, age: 21, name: 'test1', prop2: 2});
+---- ok
+-STATEMENT CREATE (t:test {id: 2, age: 22, name: 'test2', prop2: 3});
+---- ok
+-STATEMENT CREATE (t:test {id: 3, age: 23, name: 'test3', prop2: 4});
+---- ok
+-STATEMENT CREATE (t:test {id: 4, age: 24, name: 'test4', prop2: 5});
+---- ok
+-STATEMENT MATCH (t1:test {id: 0}), (t2:test {id: 1}) CREATE (t1)-[r:testRel {since: date('2020-01-01'), prop3: 1}]->(t2);
+---- ok
+-STATEMENT MATCH (t1:test {id: 1}), (t2:test {id: 2}) CREATE (t1)-[r:testRel {since: date('2020-01-01'), prop3: 2}]->(t2);
+---- ok
+-STATEMENT MATCH (t1:test {id: 2}), (t2:test {id: 3}) CREATE (t1)-[r:testRel {since: date('2020-01-01'), prop3: 3}]->(t2);
+---- ok
+-STATEMENT MATCH (t1:test {id: 3}), (t2:test {id: 4}) CREATE (t1)-[r:testRel {since: date('2020-01-01'), prop3: 4}]->(t2);
+---- ok
+-STATEMENT ALTER TABLE testRel DROP since;
+---- ok
+-STATEMENT CHECKPOINT;
+---- ok
+-RELOADDB
+-STATEMENT MATCH ()-[k:testRel]->() RETURN k.since;
+---- error
+Binder exception: Cannot find property since for k.
+-STATEMENT MATCH (:test)-[k:testRel]->(:test) RETURN k.prop3;
+---- 4
+1
+2
+3
+4

--- a/test/test_files/transaction/ddl/ddl_tinysnb.test
+++ b/test/test_files/transaction/ddl/ddl_tinysnb.test
@@ -13,8 +13,6 @@
 {_ID: 0:0, _LABEL: person, ID: 0, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000, u: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}
 
 -CASE DropNodeTablePropertyCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE person DROP fName
@@ -38,8 +36,6 @@
 {_ID: 0:0, _LABEL: person, ID: 0, fName: Alice, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000, u: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}
 
 -CASE DropNodeTablePropertyRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE person DROP fName
@@ -63,8 +59,6 @@
 (0:0)-{_LABEL: studyAt, _ID: 4:0, year: 2021, length: 5, level: 5, code: 9223372036854775808, temperature: 32800, ulength: 33768, ulevel: 250, hugedata: 1844674407370955161811111111}->(1:0)
 
 -CASE DropRelTablePropertyCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE studyAt DROP places
@@ -88,8 +82,6 @@
 (0:0)-{_LABEL: studyAt, _ID: 4:0, year: 2021, places: [wwAewsdndweusd,wek], length: 5, level: 5, code: 9223372036854775808, temperature: 32800, ulength: 33768, ulevel: 250, hugedata: 1844674407370955161811111111}->(1:0)
 
 -CASE DropRelTablePropertyRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE studyAt DROP places
@@ -118,8 +110,6 @@
 9
 
 -CASE AddNodeTablePropertyCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT CREATE (:person {ID: 11});
@@ -148,8 +138,6 @@
 0|Alice|1|True|False|35|5.000000|1900-01-01|2011-08-20 11:25:30|3 years 2 days 13:02:00|[10,5]|[Aida]|[[10,8],[6,7,8]]|[96,54,86,92]|1.731000|a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11
 
 -CASE AddNodeTablePropertyRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE person Add test INT64 DEFAULT 1
@@ -178,8 +166,6 @@
 4
 
 -CASE AddRelTablePropertyCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT MATCH (p:person), (o:organisation) WHERE p.ID = 5 AND o.ID = 6 CREATE (p)-[:studyAt {year: 2000, places: [], length: 4, level: 4, code: 9223372036854775807, temperature: 32799, ulength: 33767, ulevel: 249, hugedata: 1844674407370955161811111110}]->(o);
@@ -208,8 +194,6 @@
 (0:0)-{_LABEL: studyAt, _ID: 4:0, year: 2021, places: [wwAewsdndweusd,wek], length: 5, level: 5, code: 9223372036854775808, temperature: 32800, ulength: 33768, ulevel: 250, hugedata: 1844674407370955161811111111}->(1:0)
 
 -CASE AddRelTablePropertyRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE studyAt Add test INT64 DEFAULT 1
@@ -233,8 +217,6 @@
 {_ID: 0:0, _LABEL: person, ID: 0, pName: Alice, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000, u: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}
 
 -CASE RenameNodeTablePropertyCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE person RENAME fName TO pName;
@@ -258,8 +240,6 @@
 {_ID: 0:0, _LABEL: person, ID: 0, fName: Alice, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000, u: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}
 
 -CASE RenameNodeTablePropertyRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE person RENAME fName TO pName;
@@ -283,8 +263,6 @@
 (0:0)-{_LABEL: studyAt, _ID: 4:0, year: 2021, location: [wwAewsdndweusd,wek], length: 5, level: 5, code: 9223372036854775808, temperature: 32800, ulength: 33768, ulevel: 250, hugedata: 1844674407370955161811111111}->(1:0)
 
 -CASE RenameRelTablePropertyCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE studyAt RENAME places TO location;
@@ -308,8 +286,6 @@
 (0:0)-{_LABEL: studyAt, _ID: 4:0, year: 2021, places: [wwAewsdndweusd,wek], length: 5, level: 5, code: 9223372036854775808, temperature: 32800, ulength: 33768, ulevel: 250, hugedata: 1844674407370955161811111111}->(1:0)
 
 -CASE RenameRelTablePropertyRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE studyAt RENAME places TO location;
@@ -333,8 +309,6 @@
 {_ID: 0:0, _LABEL: vPerson, ID: 0, fName: Alice, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000, u: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}
 
 -CASE RenameNodeTableCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE person RENAME TO vPerson;
@@ -358,8 +332,6 @@
 {_ID: 0:0, _LABEL: person, ID: 0, fName: Alice, gender: 1, isStudent: True, isWorker: False, age: 35, eyeSight: 5.000000, birthdate: 1900-01-01, registerTime: 2011-08-20 11:25:30, lastJobDuration: 3 years 2 days 13:02:00, workedHours: [10,5], usedNames: [Aida], courseScoresPerTerm: [[10,8],[6,7,8]], grades: [96,54,86,92], height: 1.731000, u: a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11}
 
 -CASE RenameNodeTableRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE person RENAME TO vPerson;
@@ -383,8 +355,6 @@
 (0:0)-{_LABEL: eStudyAt, _ID: 4:0, year: 2021, places: [wwAewsdndweusd,wek], length: 5, level: 5, code: 9223372036854775808, temperature: 32800, ulength: 33768, ulevel: 250, hugedata: 1844674407370955161811111111}->(1:0)
 
 -CASE RenameRelTableCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE studyAt RENAME TO eStudyAt;
@@ -408,8 +378,6 @@
 (0:0)-{_LABEL: studyAt, _ID: 4:0, year: 2021, places: [wwAewsdndweusd,wek], length: 5, level: 5, code: 9223372036854775808, temperature: 32800, ulength: 33768, ulevel: 250, hugedata: 1844674407370955161811111111}->(1:0)
 
 -CASE RenameRelTableRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT ALTER TABLE studyAt RENAME TO eStudyAt;
@@ -444,8 +412,6 @@ http://kuzu.io/rdf-ex#faculty|http://www.w3.org/2000/01/rdf-schema#subClassOf|ht
 http://kuzu.io/rdf-ex#student|http://www.w3.org/2000/01/rdf-schema#subClassOf|http://kuzu.io/rdf-ex#person
 
 -CASE RenameRDFTableCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT CREATE RDFGraph UniKG;
 ---- ok
 -STATEMENT COPY UniKG FROM "${KUZU_ROOT_DIRECTORY}/dataset/rdf/doc/uni.ttl";
@@ -491,8 +457,6 @@ http://kuzu.io/rdf-ex#faculty|http://www.w3.org/2000/01/rdf-schema#subClassOf|ht
 http://kuzu.io/rdf-ex#student|http://www.w3.org/2000/01/rdf-schema#subClassOf|http://kuzu.io/rdf-ex#person
 
 -CASE RenameRDFTableRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT CREATE RDFGraph UniKG;
 ---- ok
 -STATEMENT COPY UniKG FROM "${KUZU_ROOT_DIRECTORY}/dataset/rdf/doc/uni.ttl";
@@ -527,8 +491,6 @@ http://kuzu.io/rdf-ex#student|http://www.w3.org/2000/01/rdf-schema#subClassOf|ht
 Study at information
 
 -CASE CommentRelTableCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT COMMENT ON TABLE studyAt IS 'Study at information';
@@ -551,8 +513,6 @@ Study at information
 ---- 1
 
 -CASE CommentRelTableRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION;
 ---- ok
 -STATEMENT COMMENT ON TABLE studyAt IS 'Study at information';
@@ -577,8 +537,6 @@ Study at information
 0
 
 -CASE AddInt64PropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random INT64
@@ -602,8 +560,6 @@ Study at information
 Binder exception: Cannot find property random for p.
 
 -CASE AddInt64PropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random INT64
@@ -627,8 +583,6 @@ Binder exception: Cannot find property random for p.
 0
 
 -CASE AddArrayPropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random DOUBLE[5]
@@ -652,8 +606,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddArrayPropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random DOUBLE[5]
@@ -676,8 +628,6 @@ Binder exception: Cannot find property random for p.
 ---- ok
 
 -CASE AddStringPropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING
@@ -700,8 +650,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddStringPropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING
@@ -724,8 +672,6 @@ Binder exception: Cannot find property random for p.
 ---- ok
 
 -CASE AddListPropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random INT64[]
@@ -748,8 +694,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddListPropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random INT64[]
@@ -772,8 +716,6 @@ Binder exception: Cannot find property random for p.
 ---- ok
 
 -CASE AddListOfStringPropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING[]
@@ -796,8 +738,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddListOfStringPropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING[]
@@ -820,8 +760,6 @@ Binder exception: Cannot find property random for p.
 ---- ok
 
 -CASE AddListOfStructPropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRUCT(revenue int64, ages double[])[]
@@ -844,8 +782,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddListOfStructPropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRUCT(revenue int64, ages double[])[]
@@ -868,8 +804,6 @@ Binder exception: Cannot find property random for p.
 ---- ok
 
 -CASE AddMapPropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random MAP(STRING, INT64)
@@ -892,8 +826,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddMapPropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random MAP(STRING, INT64)
@@ -916,8 +848,6 @@ Binder exception: Cannot find property random for p.
 ---- ok
 
 -CASE AddStructPropertyWithoutDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRUCT(price INT64[], volume INT64)
@@ -940,8 +870,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddStructPropertyWithoutDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRUCT(price INT64[], volume INT64)
@@ -988,8 +916,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddInt64PropertyWithDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random INT64 default 21
@@ -1013,8 +939,6 @@ Binder exception: Cannot find property random for p.
 long long string
 
 -CASE AddStringPropertyWithDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random String default 'long long string'
@@ -1038,8 +962,6 @@ long long string
 Binder exception: Cannot find property random for p.
 
 -CASE AddStringPropertyWithDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random String default 'long long string'
@@ -1063,8 +985,6 @@ Binder exception: Cannot find property random for p.
 [142,123,789]
 
 -CASE AddListOfInt64PropertyWithDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random INT64[] default [142,123,789]
@@ -1088,8 +1008,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddListOfInt64PropertyWithDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random INT64[] default [142,123,789]
@@ -1113,8 +1031,6 @@ Binder exception: Cannot find property random for p.
 [142,short,long long long string]
 
 -CASE AddListOfStringPropertyWithDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING[] default ['142','short','long long long string']
@@ -1138,8 +1054,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddListOfStringPropertyWithDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING[] default ['142','short','long long long string']
@@ -1163,8 +1077,6 @@ Binder exception: Cannot find property random for p.
 [[142,51],[short,long,123],[long long long string,short short short short,short]]
 
 -CASE AddListOfListOfStringPropertyWithDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING[][] default [['142','51'],['short','long','123'],['long long long string','short short short short','short']]
@@ -1188,8 +1100,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddListOfListOfStringPropertyWithDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRING[][] default [['142','51'],['short','long','123'],['long long long string','short short short short','short']]
@@ -1213,8 +1123,6 @@ Binder exception: Cannot find property random for p.
 [{revenue: 144, ages: [3.200000,7.200000]}]
 
 -CASE AddListOfStructPropertyWithDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRUCT(revenue int64, ages double[])[] default [{revenue: 144, ages: [3.200000,7.200000]}]
@@ -1238,8 +1146,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddListOfStructPropertyWithDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRUCT(revenue int64, ages double[])[] default [{revenue: 144, ages: [3.200000,7.200000]}]
@@ -1263,8 +1169,6 @@ Binder exception: Cannot find property random for p.
 {key3=[3,2,1]}
 
 -CASE AddMapPropertyWithDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random MAP(STRING, INT64[]) default map(['key3'],[[3,2,1]])
@@ -1288,8 +1192,6 @@ Binder exception: Cannot find property random for p.
 Binder exception: Cannot find property random for p.
 
 -CASE AddMapPropertyWithDefaultRollbackRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random MAP(STRING, INT64[]) default map(['key3'],[[3,2,1]])
@@ -1313,8 +1215,6 @@ Binder exception: Cannot find property random for p.
 {price: [5,3,2], volume: 24}
 
 -CASE AddStructPropertyWithDefaultCommitRecovery
--STATEMENT CALL auto_checkpoint=false;
----- ok
 -STATEMENT BEGIN TRANSACTION
 ---- ok
 -STATEMENT ALTER TABLE person ADD random STRUCT(price INT64[], volume INT64) default {price: [5,3,2], volume: 24}


### PR DESCRIPTION
# Description

The PR is to fix a bug due to not vacuum dropped columns during checkpoint. The bug happens when we recover after dropped a column and performed checkpoint. During the recovery, we will have some columns as nullptr, which lead to seg faults when we collect data types from table columns.

This PR solves the issue by always vacuuming dropped columns from storage during checkpoint. Note that the column ID inside property will be reset due to the vacuuming, that's why the checkpoint of catalog now happens after the checkpoint of tables. Letting storage modifies catalog may not be a good practice, alternatively, we can let `TableCatalogEntry` reset its column ids during checkpoint independently, which sounds like a better idea to me.

In the future, we should also reclaim disk pages of persistent column chunks being dropped during checkpoint.

A minor refactoring:
- aligned columnID for rel table properties (`nextColumnID` starts from 1 to skip the anonymous NBR_ID column inside `RelTableCatalogEntry`). thus removed the special implementation of `RelTableCatalogEntry::getColumnID`.