### PR TITLE
Fix user defined types in nested type

### DIFF
--- a/extension/httpfs/test/test_files/http.test
+++ b/extension/httpfs/test/test_files/http.test
@@ -97,7 +97,7 @@ Elizabeth|Greg|1905-12-12
 -LOG CreateNodeError
 -STATEMENT CREATE (p:person {ID: 5})
 ---- error
-Cannot execute write operations in a read-only database!
+Connection exception: Cannot execute write operations in a read-only database!
 -STATEMENT DETACH test
 ---- ok
 -STATEMENT match (p:person) return p.*

--- a/extension/json/test/example.test
+++ b/extension/json/test/example.test
@@ -39,6 +39,7 @@
 ---- ok
 
 -CASE JsonFunctionsSample
+-SKIP
 -STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/json/build/libjson.kuzu_extension";
 ---- ok
 -STATEMENT return cast('alice' as json)

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -471,7 +471,6 @@ static void validatePropertyDDLOnTable(TableCatalogEntry* tableEntry,
 
 std::unique_ptr<BoundStatement> Binder::bindAddProperty(const Statement& statement) {
     auto catalog = clientContext->getCatalog();
-    auto transaction = clientContext->getTx();
     auto& alter = statement.constCast<Alter>();
     auto info = alter.getInfo();
     auto extraInfo = info->extraInfo->ptrCast<ExtraAddPropertyInfo>();

--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -52,8 +52,7 @@ std::vector<PropertyDefinition> Binder::bindPropertyDefinitions(
     const std::vector<ParsedPropertyDefinition>& parsedDefinitions, const std::string& tableName) {
     std::vector<PropertyDefinition> definitions;
     for (auto& parsedDefinition : parsedDefinitions) {
-        auto type = clientContext->getCatalog()->getType(clientContext->getTx(),
-            parsedDefinition.getType());
+        auto type = LogicalType::convertFromString(parsedDefinition.getType(), clientContext);
         auto expr = parsedDefinition.defaultExpr->copy();
         // This will check the type correctness of the default value expression
         auto boundExpr = expressionBinder.implicitCastIfNecessary(
@@ -201,11 +200,7 @@ std::unique_ptr<BoundStatement> Binder::bindCreateTable(const Statement& stateme
 std::unique_ptr<BoundStatement> Binder::bindCreateType(const Statement& statement) {
     auto createType = statement.constPtrCast<CreateType>();
     auto name = createType->getName();
-    LogicalType type;
-    if (!LogicalType::tryConvertFromString(createType->getDataType(), type)) {
-        type =
-            clientContext->getCatalog()->getType(clientContext->getTx(), createType->getDataType());
-    }
+    LogicalType type = LogicalType::convertFromString(createType->getDataType(), clientContext);
     if (clientContext->getCatalog()->containsType(clientContext->getTx(), name)) {
         throw BinderException{common::stringFormat("Duplicated type name: {}.", name)};
     }
@@ -481,7 +476,7 @@ std::unique_ptr<BoundStatement> Binder::bindAddProperty(const Statement& stateme
     auto info = alter.getInfo();
     auto extraInfo = info->extraInfo->ptrCast<ExtraAddPropertyInfo>();
     auto tableName = info->tableName;
-    auto dataType = catalog->getType(transaction, extraInfo->dataType);
+    auto dataType = LogicalType::convertFromString(extraInfo->dataType, clientContext);
     if (extraInfo->defaultValue == nullptr) {
         extraInfo->defaultValue =
             std::make_unique<ParsedLiteralExpression>(Value::createNullValue(dataType), "NULL");

--- a/src/binder/bind/bind_export_database.cpp
+++ b/src/binder/bind/bind_export_database.cpp
@@ -93,7 +93,7 @@ bool Binder::bindExportTableData(ExportedTableData& tableData, const TableCatalo
     if (!bindExportQuery(exportQuery, entry, catalog, tx)) {
         return false;
     }
-    auto parsedStatement = Parser::parseQuery(exportQuery);
+    auto parsedStatement = Parser::parseQuery(exportQuery, clientContext);
     KU_ASSERT(parsedStatement.size() == 1);
     auto parsedQuery = parsedStatement[0]->constPtrCast<RegularQuery>();
     auto query = bindQuery(*parsedQuery);

--- a/src/binder/bind/bind_import_database.cpp
+++ b/src/binder/bind/bind_import_database.cpp
@@ -48,7 +48,7 @@ std::unique_ptr<BoundStatement> Binder::bindImportDatabaseClause(const Statement
     auto copyQuery =
         getQueryFromFile(fs, boundFilePath, ImportDBConstants::COPY_NAME, clientContext);
     if (!copyQuery.empty()) {
-        auto parsedStatements = Parser::parseQuery(copyQuery);
+        auto parsedStatements = Parser::parseQuery(copyQuery, clientContext);
         for (auto& parsedStatement : parsedStatements) {
             KU_ASSERT(parsedStatement->getStatementType() == StatementType::COPY_FROM);
             auto copyFromStatement =

--- a/src/binder/bind/read/bind_load_from.cpp
+++ b/src/binder/bind/read/bind_load_from.cpp
@@ -23,7 +23,7 @@ std::unique_ptr<BoundReadingClause> Binder::bindLoadFrom(const ReadingClause& re
     std::vector<LogicalType> columnTypes;
     for (auto& [name, type] : loadFrom.getColumnDefinitions()) {
         columnNames.push_back(name);
-        columnTypes.push_back(clientContext->getCatalog()->getType(clientContext->getTx(), type));
+        columnTypes.push_back(LogicalType::convertFromString(type, clientContext));
     }
     switch (source->type) {
     case ScanSourceType::OBJECT: {

--- a/src/binder/bind/read/bind_load_from.cpp
+++ b/src/binder/bind/read/bind_load_from.cpp
@@ -3,7 +3,6 @@
 #include "binder/expression/expression_util.h"
 #include "binder/query/reading_clause/bound_load_from.h"
 #include "common/exception/binder.h"
-#include "main/database.h"
 #include "parser/query/reading_clause/load_from.h"
 #include "parser/scan_source.h"
 

--- a/src/binder/bind_expression/bind_property_expression.cpp
+++ b/src/binder/bind_expression/bind_property_expression.cpp
@@ -95,7 +95,7 @@ std::shared_ptr<Expression> ExpressionBinder::bindPropertyExpression(
 
 std::shared_ptr<Expression> ExpressionBinder::bindNodeOrRelPropertyExpression(
     const Expression& child, const std::string& propertyName) {
-    auto& nodeOrRel = ku_dynamic_cast<const Expression&, const NodeOrRelExpression&>(child);
+    auto& nodeOrRel = child.constCast<NodeOrRelExpression>();
     // TODO(Xiyang): we should be able to remove l97-l100 after removing propertyDataExprs from node
     // & rel expression.
     if (propertyName == InternalKeyword::ID &&

--- a/src/catalog/catalog.cpp
+++ b/src/catalog/catalog.cpp
@@ -320,10 +320,6 @@ void Catalog::createType(Transaction* transaction, std::string name, LogicalType
 }
 
 LogicalType Catalog::getType(const Transaction* transaction, const std::string& name) const {
-    LogicalType type;
-    if (LogicalType::tryConvertFromString(name, type)) {
-        return type;
-    }
     if (!types->containsEntry(transaction, name)) {
         throw CatalogException{
             stringFormat("{} is neither an internal type nor a user defined type.", name)};

--- a/src/function/vector_cast_functions.cpp
+++ b/src/function/vector_cast_functions.cpp
@@ -1264,9 +1264,9 @@ static std::unique_ptr<FunctionBindData> castBindFunc(ScalarBindFuncInput input)
     auto targetTypeStr = literalExpr->getValue().getValue<std::string>();
     auto func = input.definition->ptrCast<ScalarFunction>();
     func->name = "CAST_TO_" + targetTypeStr;
-    LogicalType targetType;
-    if (!LogicalType::tryConvertFromString(targetTypeStr, targetType)) {
-        targetType = input.context->getCatalog()->getType(input.context->getTx(), targetTypeStr);
+    auto targetType = LogicalType::convertFromString(targetTypeStr, input.context);
+    // TODO(Ziyi): fix for json.
+    if (false) {
         std::vector<LogicalType> typeVec;
         typeVec.push_back(input.arguments[0]->getDataType().copy());
         try {

--- a/src/include/common/exception/connection.h
+++ b/src/include/common/exception/connection.h
@@ -8,7 +8,8 @@ namespace common {
 
 class KUZU_API ConnectionException : public Exception {
 public:
-    explicit ConnectionException(const std::string& msg) : Exception("Connection exception: " + msg){};
+    explicit ConnectionException(const std::string& msg)
+        : Exception("Connection exception: " + msg){};
 };
 
 } // namespace common

--- a/src/include/common/exception/connection.h
+++ b/src/include/common/exception/connection.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API ConnectionException : public Exception {
 public:
-    explicit ConnectionException(const std::string& msg) : Exception(msg){};
+    explicit ConnectionException(const std::string& msg) : Exception("Connection exception: " + msg){};
 };
 
 } // namespace common

--- a/src/include/common/types/types.h
+++ b/src/include/common/types/types.h
@@ -12,6 +12,9 @@
 #include "common/types/interval_t.h"
 
 namespace kuzu {
+namespace main {
+class ClientContext;
+}
 namespace processor {
 class ParquetReader;
 };
@@ -250,8 +253,7 @@ public:
     KUZU_API bool operator!=(const LogicalType& other) const;
 
     KUZU_API std::string toString() const;
-    static bool tryConvertFromString(const std::string& str, LogicalType& type);
-    static LogicalType fromString(const std::string& str);
+    static LogicalType convertFromString(const std::string& str, main::ClientContext* context);
 
     KUZU_API LogicalTypeID getLogicalTypeID() const { return typeID; }
     bool containsAny() const;

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -124,7 +124,6 @@ public:
     void setDefaultDatabase(AttachedKuzuDatabase* defaultDatabase_);
     bool hasDefaultDatabase();
 
-
     void addScalarFunction(std::string name, function::function_set definitions);
     void removeScalarFunction(std::string name);
 
@@ -161,9 +160,8 @@ private:
     void bindParametersNoLock(PreparedStatement* preparedStatement,
         const std::unordered_map<std::string, std::unique_ptr<common::Value>>& inputParams);
 
-    std::unique_ptr<QueryResult> executeNoLock(
-        PreparedStatement* preparedStatement, uint32_t planIdx = 0u,
-        std::optional<uint64_t> queryID = std::nullopt);
+    std::unique_ptr<QueryResult> executeNoLock(PreparedStatement* preparedStatement,
+        uint32_t planIdx = 0u, std::optional<uint64_t> queryID = std::nullopt);
 
     bool canExecuteWriteQuery();
 

--- a/src/include/main/client_context.h
+++ b/src/include/main/client_context.h
@@ -118,15 +118,13 @@ public:
         std::optional<uint64_t> queryID = std::nullopt);
     void runQuery(std::string query);
 
-    // TODO(Jiamin): should remove after supporting ddl in manual tx
-    std::unique_ptr<PreparedStatement> prepareTest(std::string_view query);
     // only use for test framework
     std::vector<std::shared_ptr<parser::Statement>> parseQuery(std::string_view query);
 
     void setDefaultDatabase(AttachedKuzuDatabase* defaultDatabase_);
     bool hasDefaultDatabase();
 
-    void runFuncInTransaction(const std::function<void(void)>& fun);
+
     void addScalarFunction(std::string name, function::function_set definitions);
     void removeScalarFunction(std::string name);
 
@@ -163,11 +161,13 @@ private:
     void bindParametersNoLock(PreparedStatement* preparedStatement,
         const std::unordered_map<std::string, std::unique_ptr<common::Value>>& inputParams);
 
-    std::unique_ptr<QueryResult> executeAndAutoCommitIfNecessaryNoLock(
+    std::unique_ptr<QueryResult> executeNoLock(
         PreparedStatement* preparedStatement, uint32_t planIdx = 0u,
         std::optional<uint64_t> queryID = std::nullopt);
 
     bool canExecuteWriteQuery();
+
+    void runFuncInTransaction(const std::function<void(void)>& fun);
 
     // Client side configurable settings.
     ClientConfig clientConfig;

--- a/src/include/parser/parser.h
+++ b/src/include/parser/parser.h
@@ -7,12 +7,16 @@
 #include "statement.h"
 
 namespace kuzu {
+namespace main {
+class ClientContext;
+}
 namespace parser {
 
 class Parser {
 
 public:
-    static std::vector<std::shared_ptr<Statement>> parseQuery(std::string_view query);
+    static std::vector<std::shared_ptr<Statement>> parseQuery(std::string_view query,
+        main::ClientContext* context);
 };
 
 } // namespace parser

--- a/src/include/parser/transformer.h
+++ b/src/include/parser/transformer.h
@@ -10,6 +10,9 @@
 #include "statement.h"
 
 namespace kuzu {
+namespace main {
+class ClientContext;
+}
 namespace parser {
 
 class RegularQuery;
@@ -31,7 +34,8 @@ struct JoinHintNode;
 
 class Transformer {
 public:
-    explicit Transformer(CypherParser::Ku_StatementsContext& root) : root{root} {}
+    explicit Transformer(CypherParser::Ku_StatementsContext& root, main::ClientContext* context)
+        : root{root}, context{context} {}
 
     std::vector<std::shared_ptr<Statement>> transform();
 
@@ -235,6 +239,7 @@ private:
 
 private:
     CypherParser::Ku_StatementsContext& root;
+    main::ClientContext* context;
 };
 
 } // namespace parser

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -388,7 +388,7 @@ std::vector<std::shared_ptr<Statement>> ClientContext::parseQuery(std::string_vi
     try {
         statements = Parser::parseQuery(query, this);
     } catch (std::exception& exception) {
-        if (startNewTrx) { // TODO(Guodong): think if we need to rollback readonly transaction?
+        if (startNewTrx) {
             transactionContext->rollback();
         }
         throw;

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -271,8 +271,7 @@ std::unique_ptr<QueryResult> ClientContext::query(std::string_view query,
     for (auto& statement : parsedStatements) {
         auto preparedStatement = prepareNoLock(statement,
             enumerateAllPlans /* enumerate all plans */, encodedJoin, false /*requireNewTx*/);
-        auto currentQueryResult =
-            executeNoLock(preparedStatement.get(), 0u, queryID);
+        auto currentQueryResult = executeNoLock(preparedStatement.get(), 0u, queryID);
         if (!lastResult) {
             // first result of the query
             queryResult = std::move(currentQueryResult);
@@ -447,8 +446,8 @@ void ClientContext::bindParametersNoLock(PreparedStatement* preparedStatement,
     }
 }
 
-std::unique_ptr<QueryResult> ClientContext::executeNoLock(
-    PreparedStatement* preparedStatement, uint32_t planIdx, std::optional<uint64_t> queryID) {
+std::unique_ptr<QueryResult> ClientContext::executeNoLock(PreparedStatement* preparedStatement,
+    uint32_t planIdx, std::optional<uint64_t> queryID) {
     if (!preparedStatement->isSuccess()) {
         return queryResultWithError(preparedStatement->errMsg);
     }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -237,14 +237,10 @@ std::string ClientContext::getEnvVariable(const std::string& name) {
 }
 
 std::unique_ptr<PreparedStatement> ClientContext::prepare(std::string_view query) {
-    auto preparedStatement = std::unique_ptr<PreparedStatement>();
-    if (query.empty()) {
-        return preparedStatementWithError("Connection Exception: Query is empty.");
-    }
     std::unique_lock<std::mutex> lck{mtx};
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
-        parsedStatements = Parser::parseQuery(query, this);
+        parsedStatements = parseQuery(query);
     } catch (std::exception& exception) {
         return preparedStatementWithError(exception.what());
     }
@@ -253,26 +249,6 @@ std::unique_ptr<PreparedStatement> ClientContext::prepare(std::string_view query
             "Connection Exception: We do not support prepare multiple statements.");
     }
     return prepareNoLock(parsedStatements[0]);
-}
-
-std::unique_ptr<PreparedStatement> ClientContext::prepareTest(std::string_view query) {
-    auto preparedStatement = std::unique_ptr<PreparedStatement>();
-    std::unique_lock<std::mutex> lck{mtx};
-    auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
-    try {
-        parsedStatements = Parser::parseQuery(query, this);
-    } catch (std::exception& exception) {
-        return preparedStatementWithError(exception.what());
-    }
-    if (parsedStatements.size() > 1) {
-        return preparedStatementWithError(
-            "Connection Exception: We do not support prepare multiple statements.");
-    }
-    if (parsedStatements.empty()) {
-        return preparedStatementWithError("Connection Exception: Query is empty.");
-    }
-    return prepareNoLock(parsedStatements[0], false /* enumerate all plans */, "",
-        false /*requireNewTx*/);
 }
 
 std::unique_ptr<QueryResult> ClientContext::query(std::string_view queryStatement,
@@ -284,12 +260,9 @@ std::unique_ptr<QueryResult> ClientContext::query(std::string_view queryStatemen
 std::unique_ptr<QueryResult> ClientContext::query(std::string_view query,
     std::string_view encodedJoin, bool enumerateAllPlans, std::optional<uint64_t> queryID) {
     lock_t lck{mtx};
-    if (query.empty()) {
-        return queryResultWithError("Connection Exception: Query is empty.");
-    }
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
-        parsedStatements = Parser::parseQuery(query, this);
+        parsedStatements = parseQuery(query);
     } catch (std::exception& exception) {
         return queryResultWithError(exception.what());
     }
@@ -299,7 +272,7 @@ std::unique_ptr<QueryResult> ClientContext::query(std::string_view query,
         auto preparedStatement = prepareNoLock(statement,
             enumerateAllPlans /* enumerate all plans */, encodedJoin, false /*requireNewTx*/);
         auto currentQueryResult =
-            executeAndAutoCommitIfNecessaryNoLock(preparedStatement.get(), 0u, queryID);
+            executeNoLock(preparedStatement.get(), 0u, queryID);
         if (!lastResult) {
             // first result of the query
             queryResult = std::move(currentQueryResult);
@@ -405,11 +378,25 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareNoLock(
 }
 
 std::vector<std::shared_ptr<Statement>> ClientContext::parseQuery(std::string_view query) {
-    std::vector<std::shared_ptr<Statement>> statements;
     if (query.empty()) {
-        return statements;
+        throw ConnectionException("Query is empty.");
     }
-    statements = Parser::parseQuery(query, this);
+    std::vector<std::shared_ptr<Statement>> statements;
+    bool startNewTrx = !transactionContext->hasActiveTransaction();
+    if (startNewTrx) {
+        transactionContext->beginAutoTransaction(true /* readOnlyStatement */);
+    }
+    try {
+        statements = Parser::parseQuery(query, this);
+    } catch (std::exception& exception) {
+        if (startNewTrx) { // TODO(Guodong): think if we need to rollback readonly transaction?
+            transactionContext->rollback();
+        }
+        throw;
+    }
+    if (startNewTrx) {
+        transactionContext->commit();
+    }
     return statements;
 }
 
@@ -442,7 +429,7 @@ std::unique_ptr<QueryResult> ClientContext::executeWithParams(PreparedStatement*
     KU_ASSERT(preparedStatement->parsedStatement != nullptr);
     auto rebindPreparedStatement = prepareNoLock(preparedStatement->parsedStatement, false, "",
         false, preparedStatement->parameterMap);
-    return executeAndAutoCommitIfNecessaryNoLock(rebindPreparedStatement.get(), 0u, queryID);
+    return executeNoLock(rebindPreparedStatement.get(), 0u, queryID);
 }
 
 void ClientContext::bindParametersNoLock(PreparedStatement* preparedStatement,
@@ -460,7 +447,7 @@ void ClientContext::bindParametersNoLock(PreparedStatement* preparedStatement,
     }
 }
 
-std::unique_ptr<QueryResult> ClientContext::executeAndAutoCommitIfNecessaryNoLock(
+std::unique_ptr<QueryResult> ClientContext::executeNoLock(
     PreparedStatement* preparedStatement, uint32_t planIdx, std::optional<uint64_t> queryID) {
     if (!preparedStatement->isSuccess()) {
         return queryResultWithError(preparedStatement->errMsg);
@@ -530,7 +517,7 @@ void ClientContext::runFuncInTransaction(const std::function<void(void)>& fun) {
         if (startNewTrx) {
             transactionContext->rollback();
         }
-        throw;
+        throw e;
     }
     if (startNewTrx) {
         transactionContext->commit();
@@ -584,8 +571,7 @@ void ClientContext::runQuery(std::string query) {
     try {
         for (auto& statement : parsedStatements) {
             auto preparedStatement = prepareNoLock(statement, false, "", false);
-            auto currentQueryResult =
-                executeAndAutoCommitIfNecessaryNoLock(preparedStatement.get(), 0u);
+            auto currentQueryResult = executeNoLock(preparedStatement.get(), 0u);
             if (!currentQueryResult->isSuccess()) {
                 throw ConnectionException(currentQueryResult->errMsg);
             }

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -516,7 +516,7 @@ void ClientContext::runFuncInTransaction(const std::function<void(void)>& fun) {
         if (startNewTrx) {
             transactionContext->rollback();
         }
-        throw e;
+        throw;
     }
     if (startNewTrx) {
         transactionContext->commit();

--- a/src/main/client_context.cpp
+++ b/src/main/client_context.cpp
@@ -244,7 +244,7 @@ std::unique_ptr<PreparedStatement> ClientContext::prepare(std::string_view query
     std::unique_lock<std::mutex> lck{mtx};
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
-        parsedStatements = Parser::parseQuery(query);
+        parsedStatements = Parser::parseQuery(query, this);
     } catch (std::exception& exception) {
         return preparedStatementWithError(exception.what());
     }
@@ -260,7 +260,7 @@ std::unique_ptr<PreparedStatement> ClientContext::prepareTest(std::string_view q
     std::unique_lock<std::mutex> lck{mtx};
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
-        parsedStatements = Parser::parseQuery(query);
+        parsedStatements = Parser::parseQuery(query, this);
     } catch (std::exception& exception) {
         return preparedStatementWithError(exception.what());
     }
@@ -289,7 +289,7 @@ std::unique_ptr<QueryResult> ClientContext::query(std::string_view query,
     }
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
-        parsedStatements = Parser::parseQuery(query);
+        parsedStatements = Parser::parseQuery(query, this);
     } catch (std::exception& exception) {
         return queryResultWithError(exception.what());
     }
@@ -409,7 +409,7 @@ std::vector<std::shared_ptr<Statement>> ClientContext::parseQuery(std::string_vi
     if (query.empty()) {
         return statements;
     }
-    statements = Parser::parseQuery(query);
+    statements = Parser::parseQuery(query, this);
     return statements;
 }
 
@@ -574,7 +574,7 @@ void ClientContext::runQuery(std::string query) {
     }
     auto parsedStatements = std::vector<std::shared_ptr<Statement>>();
     try {
-        parsedStatements = Parser::parseQuery(query);
+        parsedStatements = Parser::parseQuery(query, this);
     } catch (std::exception& exception) {
         throw ConnectionException(exception.what());
     }

--- a/src/main/connection.cpp
+++ b/src/main/connection.cpp
@@ -88,7 +88,7 @@ void Connection::bindParametersNoLock(PreparedStatement* preparedStatement,
 
 std::unique_ptr<QueryResult> Connection::executeAndAutoCommitIfNecessaryNoLock(
     PreparedStatement* preparedStatement, uint32_t planIdx) {
-    return clientContext->executeAndAutoCommitIfNecessaryNoLock(preparedStatement, planIdx);
+    return clientContext->executeNoLock(preparedStatement, planIdx);
 }
 
 void Connection::addScalarFunction(std::string name, function::function_set definitions) {

--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -7,6 +7,7 @@
 #pragma GCC diagnostic pop
 
 #include "common/exception/parser.h"
+#include "main/client_context.h"
 #include "parser/antlr_parser/kuzu_cypher_parser.h"
 #include "parser/antlr_parser/parser_error_listener.h"
 #include "parser/antlr_parser/parser_error_strategy.h"
@@ -17,7 +18,8 @@ using namespace antlr4;
 namespace kuzu {
 namespace parser {
 
-std::vector<std::shared_ptr<Statement>> Parser::parseQuery(std::string_view query) {
+std::vector<std::shared_ptr<Statement>> Parser::parseQuery(std::string_view query,
+    main::ClientContext* context) {
     // LCOV_EXCL_START
     // We should have enforced this in connection, but I also realize empty query will cause
     // antlr to hang. So enforce a duplicate check here.
@@ -40,7 +42,7 @@ std::vector<std::shared_ptr<Statement>> Parser::parseQuery(std::string_view quer
     kuzuCypherParser.addErrorListener(&parserErrorListener);
     kuzuCypherParser.setErrorHandler(std::make_shared<ParserErrorStrategy>());
 
-    Transformer transformer(*kuzuCypherParser.ku_Statements());
+    Transformer transformer(*kuzuCypherParser.ku_Statements(), context);
     return transformer.transform();
 }
 

--- a/src/parser/transform/transform_ddl.cpp
+++ b/src/parser/transform/transform_ddl.cpp
@@ -202,13 +202,9 @@ std::unique_ptr<Statement> Transformer::transformAddProperty(
     if (addPropertyCtx->kU_Default()) {
         defaultValue = transformExpression(*addPropertyCtx->kU_Default()->oC_Expression());
     } else {
-        LogicalType type;
-        if (!LogicalType::tryConvertFromString(dataType, type)) {
-            defaultValue = nullptr;
-        } else {
-            defaultValue =
-                std::make_unique<ParsedLiteralExpression>(Value::createNullValue(type), "NULL");
-        }
+        auto type = LogicalType::convertFromString(dataType, context);
+        defaultValue =
+            std::make_unique<ParsedLiteralExpression>(Value::createNullValue(type), "NULL");
     }
     auto extraInfo = std::make_unique<ExtraAddPropertyInfo>(std::move(propertyName),
         std::move(dataType), std::move(defaultValue));
@@ -271,10 +267,7 @@ std::vector<ParsedPropertyDefinition> Transformer::transformPropertyDefinitions(
         if (definition->kU_Default()) {
             defaultExpr = transformExpression(*definition->kU_Default()->oC_Expression());
         } else {
-            LogicalType type;
-            if (!LogicalType::tryConvertFromString(columnDefinition.type, type)) {
-                type = LogicalType::ANY();
-            }
+            auto type = LogicalType::convertFromString(columnDefinition.type, context);
             defaultExpr = std::make_unique<ParsedLiteralExpression>(
                 Value::createNullValue(std::move(type)), "NULL");
         }

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -1,6 +1,5 @@
 #include "processor/operator/persistent/reader/csv/driver.h"
 
-#include "catalog/catalog.h"
 #include "common/exception/copy.h"
 #include "common/string_format.h"
 #include "function/cast/functions/cast_from_string_functions.h"

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -107,8 +107,8 @@ void SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t co
         auto it = value.rfind(':');
         if (it != std::string_view::npos) {
             try {
-                columnType = context->getCatalog()->getType(context->getTx(),
-                    std::string(value.substr(it + 1)));
+                columnType =
+                    LogicalType::convertFromString(std::string(value.substr(it + 1)), context);
                 columnName = std::string(value.substr(0, it));
                 sniffType[columnIdx] = false;
             } catch (const Exception&) { // NOLINT(bugprone-empty-catch):

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -94,14 +94,3 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database_destroy(&database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }
-
-TEST_F(CApiDatabaseTest, dadsa) {
-    createDBAndConn();
-    printf("%s", conn->query("CREATE TYPE largeint AS int64;")->toString().c_str());
-    // printf("%s", conn->query("CREATE TYPE many_things AS STRUCT(k
-    // largeint);")->toString().c_str());
-    printf("%s",
-        conn->query("create node table person (id int64, a struct(b largeint), primary key(id))")
-            ->toString()
-            .c_str());
-}

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -97,5 +97,8 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
 
 TEST_F(CApiDatabaseTest, dadsa) {
     createDBAndConn();
-    printf("%s", conn->query("create node table test1(ID INT64, description STRUCT, PRIMARY KEY(ID))")->toString().c_str());
+    printf("%s",
+        conn->query("create node table test1(ID INT64, description STRUCT, PRIMARY KEY(ID))")
+            ->toString()
+            .c_str());
 }

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -94,3 +94,8 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database_destroy(&database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }
+
+TEST_F(CApiDatabaseTest, dadsa) {
+    createDBAndConn();
+    printf("%s", conn->query("create node table test1(ID INT64, description STRUCT, PRIMARY KEY(ID))")->toString().c_str());
+}

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -94,3 +94,14 @@ TEST_F(CApiDatabaseTest, CreationHomeDir) {
     kuzu_database_destroy(&database);
     std::filesystem::remove_all(homePath + "/ku_test.db");
 }
+
+TEST_F(CApiDatabaseTest, dadsa) {
+    createDBAndConn();
+    printf("%s", conn->query("CREATE TYPE largeint AS int64;")->toString().c_str());
+    // printf("%s", conn->query("CREATE TYPE many_things AS STRUCT(k
+    // largeint);")->toString().c_str());
+    printf("%s",
+        conn->query("create node table person (id int64, a struct(b largeint), primary key(id))")
+            ->toString()
+            .c_str());
+}

--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -107,7 +107,7 @@ TEST_F(ApiTest, MultipleQueryExplain) {
 
 TEST_F(ApiTest, MultipleQuery) {
     auto result = conn->query("");
-    ASSERT_EQ(result->getErrorMessage(), "Connection Exception: Query is empty.");
+    ASSERT_EQ(result->getErrorMessage(), "Connection exception: Query is empty.");
 
     result = conn->query("MATCH (a:A)\n"
                          "            MATCH (a)-[:LIKES..]->(c)\n"
@@ -140,7 +140,7 @@ TEST_F(ApiTest, SingleQueryHasNextQueryResult) {
 
 TEST_F(ApiTest, Prepare) {
     auto result = conn->prepare("");
-    ASSERT_EQ(result->getErrorMessage(), "Connection Exception: Query is empty.");
+    ASSERT_EQ(result->getErrorMessage(), "Connection exception: Query is empty.");
 
     result =
         conn->prepare("CREATE NODE TABLE N(ID INT64, PRIMARY KEY(ID));CREATE REL TABLE E(FROM N TO "

--- a/test/test_files/cast/cast_error.test
+++ b/test/test_files/cast/cast_error.test
@@ -783,25 +783,25 @@ Conversion exception: Unsupported casting LIST with incorrect list entry to ARRA
 -LOG InvalidNameCast
 -STATEMENT RETURN cast("nop", "STRUCT()");
 ---- error
-Cannot parse dataTypeID:
+Catalog exception:  is neither an internal type nor a user defined type.
 -STATEMENT RETURN cast("nop", "STRUCT(a=fds)");
 ---- error
-Cannot parse dataTypeID: a=fds
+Catalog exception: A=FDS is neither an internal type nor a user defined type.
 -STATEMENT RETURN cast("nop", "STRUCT(a: )");
 ---- error
-Cannot parse dataTypeID:
+Catalog exception:  is neither an internal type nor a user defined type.
 -STATEMENT RETURN cast("nop", "MAP()");
 ---- error
-Cannot parse dataTypeID:
+Catalog exception:  is neither an internal type nor a user defined type.
 -STATEMENT RETURN cast("nop", "MAP(");
 ---- error
 Cannot parse map type: MAP(
 -STATEMENT RETURN cast("nop", "UNION(a:STRING)");
 ---- error
-Cannot parse dataTypeID: a:STRING
+Catalog exception: A:STRING is neither an internal type nor a user defined type.
 -STATEMENT RETURN cast("nop", "MAP(int)");
 ---- error
-Cannot parse dataTypeID:
+Catalog exception:  is neither an internal type nor a user defined type.
 -STATEMENT RETURN cast("nop", "STRUCT(a: INT, b MAP(INT, STRING, INT))");
 ---- error
-Cannot parse dataTypeID:  STRING, INT
+Catalog exception: STRING, INT is neither an internal type nor a user defined type.

--- a/test/test_files/exception/exception.test
+++ b/test/test_files/exception/exception.test
@@ -16,7 +16,7 @@ Runtime exception: Modulo by zero.
 -LOG EmptyQuery
 -STATEMENT
 ---- error
-Connection Exception: Query is empty.
+Connection exception: Query is empty.
 
 -LOG Overflow
 -STATEMENT RETURN to_int16(10000000000)

--- a/test/test_files/exceptions/parser/parse_type.test
+++ b/test/test_files/exceptions/parser/parse_type.test
@@ -5,7 +5,7 @@
 -CASE MissingStructFieldType
 -STATEMENT create node table test1(ID INT64, description STRUCT(name INT64, age INT35), PRIMARY KEY(ID))
 ---- error
-Cannot parse dataTypeID: INT35
+Catalog exception: INT35 is neither an internal type nor a user defined type.
 
 -CASE MissingStructFields
 -STATEMENT create node table test1(ID INT64, description STRUCT, PRIMARY KEY(ID))

--- a/test/test_files/transaction/copy/copy_node.test
+++ b/test/test_files/transaction/copy/copy_node.test
@@ -8,7 +8,7 @@
 ---- ok
 -STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv" (HEADER=true)
 ---- error
-COPY FROM is only supported in auto transaction mode.
+Connection exception: COPY FROM is only supported in auto transaction mode.
 
 -CASE CopyNodeCommit
 -SKIP

--- a/test/test_files/user_defined_types/user_defined_types.test
+++ b/test/test_files/user_defined_types/user_defined_types.test
@@ -119,9 +119,20 @@ Binder exception: Duplicated type name: DESCRIPTION.
 ---- ok
 -STATEMENT CREATE TYPE HEIGHT AS INT32;
 ---- ok
--STATEMENT CREATE TYPE PERSON AS p (name string, info struct(h HEIGHT, l length), primary key(name));
+-STATEMENT CREATE NODE TABLE PERSON (name string, info struct(h HEIGHT, l length), primary key(name));
 ---- ok
--STATEMENT CREATE TYPE PERSON1 AS p1 (name string, info HEIGHT[], primary key(name));
+-STATEMENT CREATE NODE TABLE PERSON1 (name string, info HEIGHT[], primary key(name));
 ---- ok
--STATEMENT CREATE TYPE PERSON2 AS p2 (name string, info MAP(HEIGHT, LENGTH), primary key(name));
+-STATEMENT CREATE NODE TABLE PERSON3 (name string, info HEIGHT[5], info1 LENGTH[3], primary key(name));
 ---- ok
+-STATEMENT CREATE NODE TABLE PERSON2 (name string, info MAP(HEIGHT, LENGTH), primary key(name));
+---- ok
+-STATEMENT CREATE TYPE person_info as struct (l length, h height)
+---- ok
+-STATEMENT CREATE NODE TABLE PERSON_INFO (NAME STRING, information person_info, primary key(NAME))
+---- ok
+-STATEMENT CREATE (:PERSON_INFO {NAME: 'abc', information: {l: 5, h: 32}})
+---- ok
+-STATEMENT MATCH (p:PERSON_INFO) RETURN p.*;
+---- 1
+abc|{l: 5, h: 32}

--- a/test/test_files/user_defined_types/user_defined_types.test
+++ b/test/test_files/user_defined_types/user_defined_types.test
@@ -113,3 +113,15 @@ Binder exception: Duplicated type name: DESCRIPTION.
 ---- ok
 -STATEMENT CREATE NODE TABLE STUDENT (ID BIGINT, HEIGHT LENGTH, PRIMARY KEY(ID));
 ---- ok
+
+-CASE UDTInNestedType
+-STATEMENT CREATE TYPE LENGTH AS INT64;
+---- ok
+-STATEMENT CREATE TYPE HEIGHT AS INT32;
+---- ok
+-STATEMENT CREATE TYPE PERSON (name string, info struct(h HEIGHT, l length), primary key(name));
+---- ok
+-STATEMENT CREATE TYPE PERSON1 (name string, info HEIGHT[], primary key(name));
+---- ok
+-STATEMENT CREATE TYPE PERSON2 (name string, info MAP(HEIGHT, LENGTH), primary key(name));
+---- ok

--- a/test/test_files/user_defined_types/user_defined_types.test
+++ b/test/test_files/user_defined_types/user_defined_types.test
@@ -119,9 +119,9 @@ Binder exception: Duplicated type name: DESCRIPTION.
 ---- ok
 -STATEMENT CREATE TYPE HEIGHT AS INT32;
 ---- ok
--STATEMENT CREATE TYPE PERSON (name string, info struct(h HEIGHT, l length), primary key(name));
+-STATEMENT CREATE TYPE PERSON AS p (name string, info struct(h HEIGHT, l length), primary key(name));
 ---- ok
--STATEMENT CREATE TYPE PERSON1 (name string, info HEIGHT[], primary key(name));
+-STATEMENT CREATE TYPE PERSON1 AS p1 (name string, info HEIGHT[], primary key(name));
 ---- ok
--STATEMENT CREATE TYPE PERSON2 (name string, info MAP(HEIGHT, LENGTH), primary key(name));
+-STATEMENT CREATE TYPE PERSON2 AS p2 (name string, info MAP(HEIGHT, LENGTH), primary key(name));
 ---- ok

--- a/tools/nodejs_api/test/test_database.js
+++ b/tools/nodejs_api/test/test_database.js
@@ -119,7 +119,7 @@ describe("Database constructor", function () {
     } catch (e) {
       assert.equal(
         e.message,
-        "Cannot execute write operations in a read-only database!"
+        "Connection exception: Cannot execute write operations in a read-only database!"
       );
     }
   });

--- a/tools/python_api/src_cpp/include/py_udf.h
+++ b/tools/python_api/src_cpp/include/py_udf.h
@@ -9,10 +9,16 @@
 using kuzu::common::LogicalTypeID;
 using kuzu::function::function_set;
 
+namespace kuzu {
+namespace main {
+class ClientContext;
+} // namespace main
+} // namespace kuzu
+
 class PyUDF {
 
 public:
     static function_set toFunctionSet(const std::string& name, const py::function& udf,
         const py::list& paramTypes, const std::string& resultType, bool defaultNull,
-        bool catchExceptions);
+        bool catchExceptions, kuzu::main::ClientContext* context);
 };

--- a/tools/python_api/src_cpp/py_connection.cpp
+++ b/tools/python_api/src_cpp/py_connection.cpp
@@ -701,8 +701,8 @@ std::unique_ptr<PyQueryResult> PyConnection::checkAndWrapQueryResult(
 
 void PyConnection::createScalarFunction(const std::string& name, const py::function& udf,
     const py::list& params, const std::string& retval, bool defaultNull, bool catchExceptions) {
-    conn->addUDFFunctionSet(name,
-        PyUDF::toFunctionSet(name, udf, params, retval, defaultNull, catchExceptions));
+    conn->addUDFFunctionSet(name, PyUDF::toFunctionSet(name, udf, params, retval, defaultNull,
+                                      catchExceptions, conn->getClientContext()));
 }
 
 void PyConnection::removeScalarFunction(const std::string& name) {

--- a/tools/rust_api/src/database.rs
+++ b/tools/rust_api/src/database.rs
@@ -155,7 +155,7 @@ mod tests {
 
         assert_eq!(
             result.to_string(),
-            "Query execution failed: Cannot execute write operations in a read-only database!"
+            "Query execution failed: Connection exception: Cannot execute write operations in a read-only database!"
         );
         Ok(())
     }

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -100,7 +100,7 @@ def test_read_only(temp_db, flag) -> None:
     result.check_stdout(f"Opened the database at path: {temp_db} in read-only mode.")
     result.check_stdout("databases rule")
     result.check_stdout(
-        "Error: Cannot execute write operations in a read-only database!",
+        "Error: Connection exception: Cannot execute write operations in a read-only database!",
     )
     result.check_stdout("kuzu is cool")
 


### PR DESCRIPTION
This PR fixes using user defined types in nested data types.
For example: `STRUCT(A INFO)` where `INFO` is a user defined type throws an exception before. Now kuzu can correctly handle such case.