### PR TITLE
Fix detection of when rust builds don't need to re-build the bundled C++ library

### DIFF
--- a/tools/rust_api/Cargo.toml
+++ b/tools/rust_api/Cargo.toml
@@ -14,9 +14,10 @@ include = [
     "build.rs",
     "/src",
     "/include",
+# If more files are added to kuzu-src, they should also be added to the rerun-if-changed
+# instructions in build.rs so that rebuilds are detected properly
     "/kuzu-src/src",
     "/kuzu-src/third_party",
-    "/kuzu-src/Makefile",
     "/kuzu-src/CMakeLists.txt",
     "/kuzu-src/tools/CMakeLists.txt",
 ]

--- a/tools/rust_api/build.rs
+++ b/tools/rust_api/build.rs
@@ -144,7 +144,14 @@ fn build_ffi(
     println!("cargo:rerun-if-env-changed=KUZU_SHARED");
 
     println!("cargo:rerun-if-changed=include/kuzu_rs.h");
-    println!("cargo:rerun-if-changed=include/kuzu_rs.cpp");
+    println!("cargo:rerun-if-changed=src/kuzu_rs.cpp");
+    // Note that this should match the kuzu-src/* entries in the package.include list in Cargo.toml
+    // Unfortunately they appear to need to be specified individually since the symlink is
+    // considered to be changed each time.
+    println!("cargo:rerun-if-changed=kuzu-src/src");
+    println!("cargo:rerun-if-changed=kuzu-src/third_party");
+    println!("cargo:rerun-if-changed=kuzu-src/CMakeLists.txt");
+    println!("cargo:rerun-if-changed=kuzu-src/tools/CMakeLists.txt");
 
     if cfg!(windows) {
         build.flag("/std:c++20");


### PR DESCRIPTION
This doesn't mean that it was always rebuilding everything, as it would still re-use the old build directory, but if you haven't touched the C++ sources, then it shouldn't be necessary to run CMake at all (outside of configuration changes of course), and Cargo is faster at detecting if anything needs to be rebuilt than CMake is (a build without changes went from ~6s to ~0.03s). This is a particularly common situation for anyone using the releases.

One of the files set to re-run if changed had an incorrect path, so Cargo was always re-running the kuzu build script as that's the behaviour if a file is missing. We were also missing rerun-if-changed instructions for the C++ sources.