### PR TITLE
Csv reader progress fix

### DIFF
--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -202,6 +202,9 @@ static double progressFunc(TableFuncSharedState* sharedState) {
     }
     uint64_t totalReadSize =
         (state->numBlocksReadByFiles + state->blockIdx) * CopyConstants::PARALLEL_BLOCK_SIZE;
+    if (totalReadSize > state->totalSize) {
+        return 1.0;
+    }
     return static_cast<double>(totalReadSize) / state->totalSize;
 }
 


### PR DESCRIPTION
# Description

Minor fix to the progress function for parallel csv reader. The progress is calculated by counting the number of blocks read and comparing the size of that number of blocks to the total size of the files needing to be read. However, this would cause a number bigger than 100% to be displayed in some cases (mainly files smaller than one block) since the total file size doesn't necessarily fit inside each block evenly. 

Just a minor fix that outputs 100% if the read blocks size is bigger than the total size as the whole file is already read if that is the case.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).