### PR TITLE
Add projection push down to csv and parquet

### DIFF
--- a/src/function/table/CMakeLists.txt
+++ b/src/function/table/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(call)
 
 add_library(kuzu_table
         OBJECT
+        bind_data.cpp
         call_functions.cpp
         scan_functions.cpp)
 

--- a/src/function/table/bind_data.cpp
+++ b/src/function/table/bind_data.cpp
@@ -14,5 +14,5 @@ std::vector<bool> TableFuncBindData::getColumnSkips() const {
     return columnSkips;
 }
 
-}
-}
+} // namespace function
+} // namespace kuzu

--- a/src/function/table/bind_data.cpp
+++ b/src/function/table/bind_data.cpp
@@ -1,0 +1,18 @@
+#include "function/table/bind_data.h"
+
+namespace kuzu {
+namespace function {
+
+std::vector<bool> TableFuncBindData::getColumnSkips() const {
+    if (columnSkips.empty()) { // If not specified, all columns should be scanned.
+        std::vector<bool> skips;
+        for (auto i = 0u; i < getNumColumns(); ++i) {
+            skips.push_back(false);
+        }
+        return skips;
+    }
+    return columnSkips;
+}
+
+}
+}

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -21,9 +21,16 @@ struct TableFuncBindData {
         : columnTypes{std::move(columnTypes)}, columnNames{std::move(columnNames)} {}
     TableFuncBindData(const TableFuncBindData& other)
         : columnTypes{common::LogicalType::copy(other.columnTypes)},
-          columnNames{other.columnNames} {}
-
+          columnNames{other.columnNames}, columnSkips{other.columnSkips} {}
     virtual ~TableFuncBindData() = default;
+
+    common::idx_t getNumColumns() const {
+        return columnTypes.size();
+    }
+    void setColumnSkips(std::vector<bool> skips) {
+        columnSkips = std::move(skips);
+    }
+    std::vector<bool> getColumnSkips() const;
 
     virtual std::unique_ptr<TableFuncBindData> copy() const = 0;
 
@@ -31,6 +38,9 @@ struct TableFuncBindData {
     const TARGET* constPtrCast() const {
         return common::ku_dynamic_cast<const TableFuncBindData*, const TARGET*>(this);
     }
+
+private:
+    std::vector<bool> columnSkips;
 };
 
 struct ScanBindData : public TableFuncBindData {
@@ -44,7 +54,7 @@ struct ScanBindData : public TableFuncBindData {
     ScanBindData(const ScanBindData& other)
         : TableFuncBindData{other}, config{other.config.copy()}, context{other.context} {}
 
-    inline std::unique_ptr<TableFuncBindData> copy() const override {
+    std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<ScanBindData>(*this);
     }
 };

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -20,16 +20,12 @@ struct TableFuncBindData {
         std::vector<std::string> columnNames)
         : columnTypes{std::move(columnTypes)}, columnNames{std::move(columnNames)} {}
     TableFuncBindData(const TableFuncBindData& other)
-        : columnTypes{common::LogicalType::copy(other.columnTypes)},
-          columnNames{other.columnNames}, columnSkips{other.columnSkips} {}
+        : columnTypes{common::LogicalType::copy(other.columnTypes)}, columnNames{other.columnNames},
+          columnSkips{other.columnSkips} {}
     virtual ~TableFuncBindData() = default;
 
-    common::idx_t getNumColumns() const {
-        return columnTypes.size();
-    }
-    void setColumnSkips(std::vector<bool> skips) {
-        columnSkips = std::move(skips);
-    }
+    common::idx_t getNumColumns() const { return columnTypes.size(); }
+    void setColumnSkips(std::vector<bool> skips) { columnSkips = std::move(skips); }
     std::vector<bool> getColumnSkips() const;
 
     virtual std::unique_ptr<TableFuncBindData> copy() const = 0;

--- a/src/include/optimizer/logical_operator_visitor.h
+++ b/src/include/optimizer/logical_operator_visitor.h
@@ -15,8 +15,38 @@ protected:
     std::shared_ptr<planner::LogicalOperator> visitOperatorReplaceSwitch(
         std::shared_ptr<planner::LogicalOperator> op);
 
-    virtual void visitFlatten(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitFlattenReplace(
+    virtual void visitAccumulate(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitAccumulateReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitAggregate(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitAggregateReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitCopyFrom(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitCopyFromReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitCopyTo(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitCopyToReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitDelete(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitDeleteReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitDistinct(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitDistinctReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
@@ -33,26 +63,26 @@ protected:
         return op;
     }
 
-    virtual void visitScanNodeTable(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitScanNodeTableReplace(
-        std::shared_ptr<planner::LogicalOperator> op) {
-        return op;
-    }
-
     virtual void visitExtend(planner::LogicalOperator* /*op*/) {}
     virtual std::shared_ptr<planner::LogicalOperator> visitExtendReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitRecursiveExtend(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitRecursiveExtendReplace(
+    virtual void visitFilter(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitFilterReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitPathPropertyProbe(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitPathPropertyProbeReplace(
+    virtual void visitFlatten(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitFlattenReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitGDSCall(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitGDSCallReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
@@ -69,20 +99,8 @@ protected:
         return op;
     }
 
-    virtual void visitProjection(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitProjectionReplace(
-        std::shared_ptr<planner::LogicalOperator> op) {
-        return op;
-    }
-
-    virtual void visitAggregate(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitAggregateReplace(
-        std::shared_ptr<planner::LogicalOperator> op) {
-        return op;
-    }
-
-    virtual void visitOrderBy(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitOrderByReplace(
+    virtual void visitInsert(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitInsertReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
@@ -93,32 +111,38 @@ protected:
         return op;
     }
 
-    virtual void visitAccumulate(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitAccumulateReplace(
+    virtual void visitMerge(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitMergeReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitDistinct(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitDistinctReplace(
+    virtual void visitOrderBy(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitOrderByReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitUnwind(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitUnwindReplace(
+    virtual void visitPathPropertyProbe(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitPathPropertyProbeReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitUnion(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitUnionReplace(
+    virtual void visitProjection(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitProjectionReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitFilter(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitFilterReplace(
+    virtual void visitRecursiveExtend(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitRecursiveExtendReplace(
+        std::shared_ptr<planner::LogicalOperator> op) {
+        return op;
+    }
+
+    virtual void visitScanNodeTable(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitScanNodeTableReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
@@ -129,38 +153,20 @@ protected:
         return op;
     }
 
-    virtual void visitDelete(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitDeleteReplace(
+    virtual void visitTableFunctionCall(planner::LogicalOperator*) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitTableFunctionCallReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitInsert(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitInsertReplace(
+    virtual void visitUnion(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitUnionReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }
 
-    virtual void visitMerge(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitMergeReplace(
-        std::shared_ptr<planner::LogicalOperator> op) {
-        return op;
-    }
-
-    virtual void visitCopyTo(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitCopyToReplace(
-        std::shared_ptr<planner::LogicalOperator> op) {
-        return op;
-    }
-
-    virtual void visitCopyFrom(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitCopyFromReplace(
-        std::shared_ptr<planner::LogicalOperator> op) {
-        return op;
-    }
-
-    virtual void visitGDSCall(planner::LogicalOperator* /*op*/) {}
-    virtual std::shared_ptr<planner::LogicalOperator> visitGDSCallReplace(
+    virtual void visitUnwind(planner::LogicalOperator* /*op*/) {}
+    virtual std::shared_ptr<planner::LogicalOperator> visitUnwindReplace(
         std::shared_ptr<planner::LogicalOperator> op) {
         return op;
     }

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -42,6 +42,7 @@ private:
     void visitDelete(planner::LogicalOperator* op) override;
     void visitMerge(planner::LogicalOperator* op) override;
     void visitCopyFrom(planner::LogicalOperator* op) override;
+    void visitTableFunctionCall(planner::LogicalOperator *) override;
 
     void visitSetInfo(const binder::BoundSetPropertyInfo& info);
     void visitInsertInfo(const planner::LogicalInsertInfo& info);
@@ -50,12 +51,13 @@ private:
 
     binder::expression_vector pruneExpressions(const binder::expression_vector& expressions);
 
-    void preAppendProjection(planner::LogicalOperator* op, uint32_t childIdx,
+    void preAppendProjection(planner::LogicalOperator* op, common::idx_t childIdx,
         binder::expression_vector expressions);
 
 private:
     binder::expression_set propertiesInUse;
-    binder::expression_set patternInUse;
+    binder::expression_set variablesInUse;
+    binder::expression_set nodeOrRelInUse;
 };
 
 } // namespace optimizer

--- a/src/include/optimizer/projection_push_down_optimizer.h
+++ b/src/include/optimizer/projection_push_down_optimizer.h
@@ -42,7 +42,7 @@ private:
     void visitDelete(planner::LogicalOperator* op) override;
     void visitMerge(planner::LogicalOperator* op) override;
     void visitCopyFrom(planner::LogicalOperator* op) override;
-    void visitTableFunctionCall(planner::LogicalOperator *) override;
+    void visitTableFunctionCall(planner::LogicalOperator*) override;
 
     void visitSetInfo(const binder::BoundSetPropertyInfo& info);
     void visitInsertInfo(const planner::LogicalInsertInfo& info);

--- a/src/include/planner/operator/logical_table_function_call.h
+++ b/src/include/planner/operator/logical_table_function_call.h
@@ -17,8 +17,11 @@ public:
         : LogicalOperator{operatorType_}, tableFunc{tableFunc}, bindData{std::move(bindData)},
           columns{std::move(columns)}, offset{std::move(offset)} {}
 
-    function::TableFunction getTableFunc() const { return tableFunc; }
-    function::TableFuncBindData* getBindData() const { return bindData.get(); }
+    const function::TableFunction& getTableFunc() const { return tableFunc; }
+    const function::TableFuncBindData* getBindData() const { return bindData.get(); }
+    void setColumnSkips(std::vector<bool> columnSkips) {
+        bindData->setColumnSkips(std::move(columnSkips));
+    }
 
     void computeFlatSchema() override;
     void computeFactorizedSchema() override;

--- a/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/base_csv_reader.h
@@ -13,18 +13,39 @@
 namespace kuzu {
 namespace processor {
 
+struct CSVColumnInfo {
+    uint64_t numColumns;
+    std::vector<bool> columnSkips;
+
+    CSVColumnInfo(uint64_t numColumns, std::vector<bool> columnSkips)
+        : numColumns{numColumns}, columnSkips{columnSkips} {}
+    EXPLICIT_COPY_DEFAULT_MOVE(CSVColumnInfo);
+
+private:
+    CSVColumnInfo(const CSVColumnInfo& other)
+        : numColumns{other.numColumns}, columnSkips{other.columnSkips} {}
+};
+
 class BaseCSVReader {
     friend class ParsingDriver;
     friend struct SniffCSVNameAndTypeDriver;
 
 public:
-    BaseCSVReader(const std::string& filePath, common::CSVOption option, uint64_t numColumns,
+    BaseCSVReader(const std::string& filePath, common::CSVOption option, CSVColumnInfo columnInfo,
         main::ClientContext* context);
 
     virtual ~BaseCSVReader() = default;
 
     virtual uint64_t parseBlock(common::block_idx_t blockIdx, common::DataChunk& resultChunk) = 0;
 
+    main::ClientContext* getClientContext() const { return context; }
+    const common::CSVOption& getCSVOption() const { return option; }
+
+    uint64_t getNumColumns() const { return columnInfo.numColumns; }
+    bool skipColumn(common::idx_t idx) const {
+        KU_ASSERT(idx < columnInfo.columnSkips.size());
+        return columnInfo.columnSkips[idx];
+    }
     uint64_t countRows();
     bool isEOF() const;
     uint64_t getFileSize();
@@ -66,9 +87,9 @@ protected:
     virtual void handleQuotedNewline() = 0;
 
 protected:
+    main::ClientContext* context;
     common::CSVOption option;
-
-    uint64_t numColumns;
+    CSVColumnInfo columnInfo;
     std::unique_ptr<common::FileInfo> fileInfo;
 
     common::block_idx_t currentBlockIdx;
@@ -79,7 +100,6 @@ protected:
     uint64_t osFileOffset;
 
     bool rowEmpty = false;
-    main::ClientContext* context;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 
-#include "common/copier_config/csv_reader_config.h"
 #include "common/data_chunk/data_chunk.h"
 #include "function/table/bind_input.h"
 
@@ -62,13 +61,10 @@ private:
 struct SniffCSVNameAndTypeDriver {
     std::vector<std::pair<std::string, common::LogicalType>> columns;
     std::vector<bool> sniffType;
-    main::ClientContext* context;
-    common::CSVOption csvOptions;
     // if the type isn't declared in the header, sniff it
     SerialCSVReader* reader;
 
-    explicit SniffCSVNameAndTypeDriver(main::ClientContext* context,
-        const common::CSVOption& csvOptions, SerialCSVReader* reader,
+    SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
         const function::ScanTableFuncBindInput* bindInput);
     bool done(uint64_t rowNum) const;
     void addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);

--- a/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
@@ -32,7 +32,7 @@ struct SerialCSVScanSharedState final : public function::ScanFileSharedState {
     uint64_t totalReadSizeByFile;
 
     SerialCSVScanSharedState(common::ReaderConfig readerConfig, uint64_t numRows,
-       main::ClientContext* context, common::CSVOption csvOption, CSVColumnInfo columnInfo)
+        main::ClientContext* context, common::CSVOption csvOption, CSVColumnInfo columnInfo)
         : ScanFileSharedState{std::move(readerConfig), numRows, context},
           csvOption{std::move(csvOption)}, columnInfo{std::move(columnInfo)},
           totalReadSizeByFile{0} {

--- a/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
+++ b/src/include/processor/operator/persistent/reader/csv/serial_csv_reader.h
@@ -11,7 +11,7 @@ namespace processor {
 //! Serial CSV reader is a class that reads values from a stream in a single thread.
 class SerialCSVReader final : public BaseCSVReader {
 public:
-    SerialCSVReader(const std::string& filePath, common::CSVOption option, uint64_t numColumns,
+    SerialCSVReader(const std::string& filePath, common::CSVOption option, CSVColumnInfo columnInfo,
         main::ClientContext* context, const function::ScanTableFuncBindInput* bindInput = nullptr);
 
     //! Sniffs CSV dialect and determines skip rows, header row, column types and column names
@@ -27,14 +27,15 @@ private:
 
 struct SerialCSVScanSharedState final : public function::ScanFileSharedState {
     std::unique_ptr<SerialCSVReader> reader;
-    uint64_t numColumns;
+    common::CSVOption csvOption;
+    CSVColumnInfo columnInfo;
     uint64_t totalReadSizeByFile;
-    common::CSVReaderConfig csvReaderConfig;
 
     SerialCSVScanSharedState(common::ReaderConfig readerConfig, uint64_t numRows,
-        uint64_t numColumns, common::CSVReaderConfig csvReaderConfig, main::ClientContext* context)
-        : ScanFileSharedState{std::move(readerConfig), numRows, context}, numColumns{numColumns},
-          totalReadSizeByFile{0}, csvReaderConfig{std::move(csvReaderConfig)} {
+       main::ClientContext* context, common::CSVOption csvOption, CSVColumnInfo columnInfo)
+        : ScanFileSharedState{std::move(readerConfig), numRows, context},
+          csvOption{std::move(csvOption)}, columnInfo{std::move(columnInfo)},
+          totalReadSizeByFile{0} {
         initReader(context);
     }
 

--- a/src/include/processor/operator/persistent/reader/parquet/column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/column_reader.h
@@ -20,28 +20,28 @@ typedef std::bitset<common::DEFAULT_VECTOR_CAPACITY> parquet_filter_t;
 class ColumnReader {
 public:
     ColumnReader(ParquetReader& reader, common::LogicalType type,
-        const kuzu_parquet::format::SchemaElement& schema, uint64_t fileIdx, uint64_t maxDefinition,
+        const kuzu_parquet::format::SchemaElement& schema, common::idx_t fileIdx, uint64_t maxDefinition,
         uint64_t maxRepeat);
     virtual ~ColumnReader() = default;
-    inline const common::LogicalType& getDataType() const { return type; }
-    inline bool hasDefines() const { return maxDefine > 0; }
-    inline bool hasRepeats() const { return maxRepeat > 0; }
-    virtual inline void skip(uint64_t numValues) { pendingSkips += numValues; }
-    virtual inline void dictionary(const std::shared_ptr<ResizeableBuffer>& /*data*/,
+    const common::LogicalType& getDataType() const { return type; }
+    bool hasDefines() const { return maxDefine > 0; }
+    bool hasRepeats() const { return maxRepeat > 0; }
+    virtual void skip(uint64_t numValues) { pendingSkips += numValues; }
+    virtual void dictionary(const std::shared_ptr<ResizeableBuffer>& /*data*/,
         uint64_t /*num_entries*/) {
         KU_UNREACHABLE;
     }
-    virtual inline void offsets(uint32_t* /*offsets*/, uint8_t* /*defines*/, uint64_t /*numValues*/,
+    virtual void offsets(uint32_t* /*offsets*/, uint8_t* /*defines*/, uint64_t /*numValues*/,
         parquet_filter_t& /*filter*/, uint64_t /*resultOffset*/, common::ValueVector* /*result*/) {
         KU_UNREACHABLE;
     }
-    virtual inline void plain(const std::shared_ptr<ByteBuffer>& /*plainData*/,
+    virtual void plain(const std::shared_ptr<ByteBuffer>& /*plainData*/,
         uint8_t* /*defines*/, uint64_t /*numValues*/, parquet_filter_t& /*filter*/,
         uint64_t /*resultOffset*/, common::ValueVector* /*result*/) {
         KU_UNREACHABLE;
     }
-    virtual inline void resetPage() {}
-    virtual inline uint64_t getGroupRowsAvailable() { return groupRowsAvailable; }
+    virtual void resetPage() {}
+    virtual uint64_t getGroupRowsAvailable() { return groupRowsAvailable; }
     virtual void initializeRead(uint64_t rowGroupIdx,
         const std::vector<kuzu_parquet::format::ColumnChunk>& columns,
         kuzu_apache::thrift::protocol::TProtocol& protocol);

--- a/src/include/processor/operator/persistent/reader/parquet/column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/column_reader.h
@@ -20,8 +20,8 @@ typedef std::bitset<common::DEFAULT_VECTOR_CAPACITY> parquet_filter_t;
 class ColumnReader {
 public:
     ColumnReader(ParquetReader& reader, common::LogicalType type,
-        const kuzu_parquet::format::SchemaElement& schema, common::idx_t fileIdx, uint64_t maxDefinition,
-        uint64_t maxRepeat);
+        const kuzu_parquet::format::SchemaElement& schema, common::idx_t fileIdx,
+        uint64_t maxDefinition, uint64_t maxRepeat);
     virtual ~ColumnReader() = default;
     const common::LogicalType& getDataType() const { return type; }
     bool hasDefines() const { return maxDefine > 0; }
@@ -35,9 +35,9 @@ public:
         parquet_filter_t& /*filter*/, uint64_t /*resultOffset*/, common::ValueVector* /*result*/) {
         KU_UNREACHABLE;
     }
-    virtual void plain(const std::shared_ptr<ByteBuffer>& /*plainData*/,
-        uint8_t* /*defines*/, uint64_t /*numValues*/, parquet_filter_t& /*filter*/,
-        uint64_t /*resultOffset*/, common::ValueVector* /*result*/) {
+    virtual void plain(const std::shared_ptr<ByteBuffer>& /*plainData*/, uint8_t* /*defines*/,
+        uint64_t /*numValues*/, parquet_filter_t& /*filter*/, uint64_t /*resultOffset*/,
+        common::ValueVector* /*result*/) {
         KU_UNREACHABLE;
     }
     virtual void resetPage() {}

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -41,7 +41,8 @@ struct ParquetReaderScanState {
 
 class ParquetReader {
 public:
-    ParquetReader(const std::string& filePath, std::vector<bool> columnSkips, main::ClientContext* context);
+    ParquetReader(const std::string& filePath, std::vector<bool> columnSkips,
+        main::ClientContext* context);
     ~ParquetReader() = default;
 
     void initializeScan(ParquetReaderScanState& state, std::vector<uint64_t> groups_to_read,

--- a/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/parquet_reader.h
@@ -41,29 +41,29 @@ struct ParquetReaderScanState {
 
 class ParquetReader {
 public:
-    ParquetReader(const std::string& filePath, main::ClientContext* context);
+    ParquetReader(const std::string& filePath, std::vector<bool> columnSkips, main::ClientContext* context);
     ~ParquetReader() = default;
 
     void initializeScan(ParquetReaderScanState& state, std::vector<uint64_t> groups_to_read,
         common::VirtualFileSystem* vfs);
     bool scanInternal(ParquetReaderScanState& state, common::DataChunk& result);
     void scan(ParquetReaderScanState& state, common::DataChunk& result);
-    inline uint64_t getNumRowsGroups() { return metadata->row_groups.size(); }
+    uint64_t getNumRowsGroups() { return metadata->row_groups.size(); }
 
-    inline uint32_t getNumColumns() const { return columnNames.size(); }
-    inline std::string getColumnName(uint32_t idx) const { return columnNames[idx]; }
-    inline const common::LogicalType& getColumnType(uint32_t idx) const { return columnTypes[idx]; }
+    uint32_t getNumColumns() const { return columnNames.size(); }
+    std::string getColumnName(uint32_t idx) const { return columnNames[idx]; }
+    const common::LogicalType& getColumnType(uint32_t idx) const { return columnTypes[idx]; }
 
-    inline kuzu_parquet::format::FileMetaData* getMetadata() const { return metadata.get(); }
+    kuzu_parquet::format::FileMetaData* getMetadata() const { return metadata.get(); }
 
 private:
-    inline std::unique_ptr<kuzu_apache::thrift::protocol::TProtocol> createThriftProtocol(
+    std::unique_ptr<kuzu_apache::thrift::protocol::TProtocol> createThriftProtocol(
         common::FileInfo* fileInfo_, bool prefetch_mode) {
         return std::make_unique<
             kuzu_apache::thrift::protocol::TCompactProtocolT<ThriftFileTransport>>(
             std::make_shared<ThriftFileTransport>(fileInfo_, prefetch_mode));
     }
-    inline const kuzu_parquet::format::RowGroup& getGroup(ParquetReaderScanState& state) {
+    const kuzu_parquet::format::RowGroup& getGroup(ParquetReaderScanState& state) {
         KU_ASSERT(
             state.currentGroup >= 0 && (uint64_t)state.currentGroup < state.groupIdxList.size());
         KU_ASSERT(state.groupIdxList[state.currentGroup] < metadata->row_groups.size());
@@ -83,17 +83,20 @@ private:
 
 private:
     const std::string filePath;
+    std::vector<bool> columnSkips;
     std::vector<std::string> columnNames;
     std::vector<common::LogicalType> columnTypes;
+
     std::unique_ptr<kuzu_parquet::format::FileMetaData> metadata;
     main::ClientContext* context;
 };
 
 struct ParquetScanSharedState final : public function::ScanFileSharedState {
     explicit ParquetScanSharedState(const common::ReaderConfig readerConfig, uint64_t numRows,
-        main::ClientContext* context);
+        main::ClientContext* context, std::vector<bool> columnSkips);
 
     std::vector<std::unique_ptr<ParquetReader>> readers;
+    std::vector<bool> columnSkips;
     uint64_t totalRowsGroups;
     uint64_t numBlocksReadByFiles;
 };

--- a/src/optimizer/logical_operator_visitor.cpp
+++ b/src/optimizer/logical_operator_visitor.cpp
@@ -7,8 +7,23 @@ namespace optimizer {
 
 void LogicalOperatorVisitor::visitOperatorSwitch(LogicalOperator* op) {
     switch (op->getOperatorType()) {
-    case LogicalOperatorType::FLATTEN: {
-        visitFlatten(op);
+    case LogicalOperatorType::ACCUMULATE: {
+        visitAccumulate(op);
+    } break;
+    case LogicalOperatorType::AGGREGATE: {
+        visitAggregate(op);
+    } break;
+    case LogicalOperatorType::COPY_FROM: {
+        visitCopyFrom(op);
+    } break;
+    case LogicalOperatorType::COPY_TO: {
+        visitCopyTo(op);
+    } break;
+    case LogicalOperatorType::DELETE: {
+        visitDelete(op);
+    } break;
+    case LogicalOperatorType::DISTINCT: {
+        visitDistinct(op);
     } break;
     case LogicalOperatorType::EMPTY_RESULT: {
         visitEmptyResult(op);
@@ -16,17 +31,17 @@ void LogicalOperatorVisitor::visitOperatorSwitch(LogicalOperator* op) {
     case LogicalOperatorType::EXPRESSIONS_SCAN: {
         visitExpressionsScan(op);
     } break;
-    case LogicalOperatorType::SCAN_NODE_TABLE: {
-        visitScanNodeTable(op);
-    } break;
     case LogicalOperatorType::EXTEND: {
         visitExtend(op);
     } break;
-    case LogicalOperatorType::RECURSIVE_EXTEND: {
-        visitRecursiveExtend(op);
+    case LogicalOperatorType::FILTER: {
+        visitFilter(op);
     } break;
-    case LogicalOperatorType::PATH_PROPERTY_PROBE: {
-        visitPathPropertyProbe(op);
+    case LogicalOperatorType::FLATTEN: {
+        visitFlatten(op);
+    } break;
+    case LogicalOperatorType::GDS_CALL: {
+        visitGDSCall(op);
     } break;
     case LogicalOperatorType::HASH_JOIN: {
         visitHashJoin(op);
@@ -34,53 +49,41 @@ void LogicalOperatorVisitor::visitOperatorSwitch(LogicalOperator* op) {
     case LogicalOperatorType::INTERSECT: {
         visitIntersect(op);
     } break;
-    case LogicalOperatorType::PROJECTION: {
-        visitProjection(op);
-    } break;
-    case LogicalOperatorType::AGGREGATE: {
-        visitAggregate(op);
-    } break;
-    case LogicalOperatorType::ORDER_BY: {
-        visitOrderBy(op);
+    case LogicalOperatorType::INSERT: {
+        visitInsert(op);
     } break;
     case LogicalOperatorType::LIMIT: {
         visitLimit(op);
     } break;
-    case LogicalOperatorType::ACCUMULATE: {
-        visitAccumulate(op);
+    case LogicalOperatorType::MERGE: {
+        visitMerge(op);
     } break;
-    case LogicalOperatorType::DISTINCT: {
-        visitDistinct(op);
+    case LogicalOperatorType::ORDER_BY: {
+        visitOrderBy(op);
     } break;
-    case LogicalOperatorType::UNWIND: {
-        visitUnwind(op);
+    case LogicalOperatorType::PATH_PROPERTY_PROBE: {
+        visitPathPropertyProbe(op);
     } break;
-    case LogicalOperatorType::UNION_ALL: {
-        visitUnion(op);
+    case LogicalOperatorType::PROJECTION: {
+        visitProjection(op);
     } break;
-    case LogicalOperatorType::FILTER: {
-        visitFilter(op);
+    case LogicalOperatorType::RECURSIVE_EXTEND: {
+        visitRecursiveExtend(op);
+    } break;
+    case LogicalOperatorType::SCAN_NODE_TABLE: {
+        visitScanNodeTable(op);
     } break;
     case LogicalOperatorType::SET_PROPERTY: {
         visitSetProperty(op);
     } break;
-    case LogicalOperatorType::DELETE: {
-        visitDelete(op);
+    case LogicalOperatorType::TABLE_FUNCTION_CALL: {
+        visitTableFunctionCall(op);
     } break;
-    case LogicalOperatorType::INSERT: {
-        visitInsert(op);
+    case LogicalOperatorType::UNION_ALL: {
+        visitUnion(op);
     } break;
-    case LogicalOperatorType::MERGE: {
-        visitMerge(op);
-    } break;
-    case LogicalOperatorType::COPY_TO: {
-        visitCopyTo(op);
-    } break;
-    case LogicalOperatorType::COPY_FROM: {
-        visitCopyFrom(op);
-    } break;
-    case LogicalOperatorType::GDS_CALL: {
-        visitGDSCall(op);
+    case LogicalOperatorType::UNWIND: {
+        visitUnwind(op);
     } break;
     default:
         return;
@@ -90,8 +93,23 @@ void LogicalOperatorVisitor::visitOperatorSwitch(LogicalOperator* op) {
 std::shared_ptr<LogicalOperator> LogicalOperatorVisitor::visitOperatorReplaceSwitch(
     std::shared_ptr<LogicalOperator> op) {
     switch (op->getOperatorType()) {
-    case LogicalOperatorType::FLATTEN: {
-        return visitFlattenReplace(op);
+    case LogicalOperatorType::ACCUMULATE: {
+        return visitAccumulateReplace(op);
+    }
+    case LogicalOperatorType::AGGREGATE: {
+        return visitAggregateReplace(op);
+    }
+    case LogicalOperatorType::COPY_FROM: {
+        return visitCopyFromReplace(op);
+    }
+    case LogicalOperatorType::COPY_TO: {
+        return visitCopyToReplace(op);
+    }
+    case LogicalOperatorType::DELETE: {
+        return visitDeleteReplace(op);
+    }
+    case LogicalOperatorType::DISTINCT: {
+        return visitDistinctReplace(op);
     }
     case LogicalOperatorType::EMPTY_RESULT: {
         return visitEmptyResultReplace(op);
@@ -99,17 +117,17 @@ std::shared_ptr<LogicalOperator> LogicalOperatorVisitor::visitOperatorReplaceSwi
     case LogicalOperatorType::EXPRESSIONS_SCAN: {
         return visitExpressionsScanReplace(op);
     }
-    case LogicalOperatorType::SCAN_NODE_TABLE: {
-        return visitScanNodeTableReplace(op);
-    }
     case LogicalOperatorType::EXTEND: {
         return visitExtendReplace(op);
     }
-    case LogicalOperatorType::RECURSIVE_EXTEND: {
-        return visitRecursiveExtendReplace(op);
+    case LogicalOperatorType::FILTER: {
+        return visitFilterReplace(op);
     }
-    case LogicalOperatorType::PATH_PROPERTY_PROBE: {
-        return visitPathPropertyProbeReplace(op);
+    case LogicalOperatorType::FLATTEN: {
+        return visitFlattenReplace(op);
+    }
+    case LogicalOperatorType::GDS_CALL: {
+        return visitGDSCallReplace(op);
     }
     case LogicalOperatorType::HASH_JOIN: {
         return visitHashJoinReplace(op);
@@ -117,53 +135,41 @@ std::shared_ptr<LogicalOperator> LogicalOperatorVisitor::visitOperatorReplaceSwi
     case LogicalOperatorType::INTERSECT: {
         return visitIntersectReplace(op);
     }
-    case LogicalOperatorType::PROJECTION: {
-        return visitProjectionReplace(op);
-    }
-    case LogicalOperatorType::AGGREGATE: {
-        return visitAggregateReplace(op);
-    }
-    case LogicalOperatorType::ORDER_BY: {
-        return visitOrderByReplace(op);
+    case LogicalOperatorType::INSERT: {
+        return visitInsertReplace(op);
     }
     case LogicalOperatorType::LIMIT: {
         return visitLimitReplace(op);
     }
-    case LogicalOperatorType::ACCUMULATE: {
-        return visitAccumulateReplace(op);
+    case LogicalOperatorType::MERGE: {
+        return visitMergeReplace(op);
     }
-    case LogicalOperatorType::DISTINCT: {
-        return visitDistinctReplace(op);
+    case LogicalOperatorType::ORDER_BY: {
+        return visitOrderByReplace(op);
     }
-    case LogicalOperatorType::UNWIND: {
-        return visitUnwindReplace(op);
+    case LogicalOperatorType::PATH_PROPERTY_PROBE: {
+        return visitPathPropertyProbeReplace(op);
     }
-    case LogicalOperatorType::UNION_ALL: {
-        return visitUnionReplace(op);
+    case LogicalOperatorType::PROJECTION: {
+        return visitProjectionReplace(op);
     }
-    case LogicalOperatorType::FILTER: {
-        return visitFilterReplace(op);
+    case LogicalOperatorType::RECURSIVE_EXTEND: {
+        return visitRecursiveExtendReplace(op);
+    }
+    case LogicalOperatorType::SCAN_NODE_TABLE: {
+        return visitScanNodeTableReplace(op);
     }
     case LogicalOperatorType::SET_PROPERTY: {
         return visitSetPropertyReplace(op);
     }
-    case LogicalOperatorType::DELETE: {
-        return visitDeleteReplace(op);
+    case LogicalOperatorType::TABLE_FUNCTION_CALL: {
+        return visitTableFunctionCallReplace(op);
     }
-    case LogicalOperatorType::INSERT: {
-        return visitInsertReplace(op);
+    case LogicalOperatorType::UNION_ALL: {
+        return visitUnionReplace(op);
     }
-    case LogicalOperatorType::MERGE: {
-        return visitMergeReplace(op);
-    }
-    case LogicalOperatorType::COPY_TO: {
-        return visitCopyToReplace(op);
-    }
-    case LogicalOperatorType::COPY_FROM: {
-        return visitCopyFromReplace(op);
-    }
-    case LogicalOperatorType::GDS_CALL: {
-        return visitGDSCallReplace(op);
+    case LogicalOperatorType::UNWIND: {
+        return visitUnwindReplace(op);
     }
     default:
         return op;

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -9,13 +9,13 @@
 #include "planner/operator/logical_intersect.h"
 #include "planner/operator/logical_order_by.h"
 #include "planner/operator/logical_projection.h"
+#include "planner/operator/logical_table_function_call.h"
 #include "planner/operator/logical_unwind.h"
 #include "planner/operator/persistent/logical_copy_from.h"
 #include "planner/operator/persistent/logical_delete.h"
 #include "planner/operator/persistent/logical_insert.h"
 #include "planner/operator/persistent/logical_merge.h"
 #include "planner/operator/persistent/logical_set.h"
-#include "planner/operator/logical_table_function_call.h"
 
 using namespace kuzu::common;
 using namespace kuzu::planner;
@@ -329,8 +329,8 @@ binder::expression_vector ProjectionPushDownOptimizer::pruneExpressions(
     return expression_vector{expressionsAfterPruning.begin(), expressionsAfterPruning.end()};
 }
 
-void ProjectionPushDownOptimizer::preAppendProjection(LogicalOperator* op,
-    idx_t childIdx, binder::expression_vector expressions) {
+void ProjectionPushDownOptimizer::preAppendProjection(LogicalOperator* op, idx_t childIdx,
+    binder::expression_vector expressions) {
     if (expressions.empty()) {
         // We don't have a way to handle
         return;

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -1,7 +1,6 @@
 #include "optimizer/projection_push_down_optimizer.h"
 
 #include "binder/expression_visitor.h"
-#include "common/cast.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/extend/logical_recursive_extend.h"
 #include "planner/operator/logical_accumulate.h"
@@ -16,6 +15,7 @@
 #include "planner/operator/persistent/logical_insert.h"
 #include "planner/operator/persistent/logical_merge.h"
 #include "planner/operator/persistent/logical_set.h"
+#include "planner/operator/logical_table_function_call.h"
 
 using namespace kuzu::common;
 using namespace kuzu::planner;
@@ -24,7 +24,7 @@ using namespace kuzu::binder;
 namespace kuzu {
 namespace optimizer {
 
-void ProjectionPushDownOptimizer::rewrite(planner::LogicalPlan* plan) {
+void ProjectionPushDownOptimizer::rewrite(LogicalPlan* plan) {
     visitOperator(plan->getLastOperator().get());
 }
 
@@ -41,32 +41,32 @@ void ProjectionPushDownOptimizer::visitOperator(LogicalOperator* op) {
     op->computeFlatSchema();
 }
 
-void ProjectionPushDownOptimizer::visitPathPropertyProbe(planner::LogicalOperator* op) {
-    auto pathPropertyProbe = (LogicalPathPropertyProbe*)op;
+void ProjectionPushDownOptimizer::visitPathPropertyProbe(LogicalOperator* op) {
+    auto& pathPropertyProbe = op->cast<LogicalPathPropertyProbe>();
     KU_ASSERT(
-        pathPropertyProbe->getChild(0)->getOperatorType() == LogicalOperatorType::RECURSIVE_EXTEND);
-    auto recursiveExtend = (LogicalRecursiveExtend*)pathPropertyProbe->getChild(0).get();
-    auto boundNodeID = recursiveExtend->getBoundNode()->getInternalID();
+        pathPropertyProbe.getChild(0)->getOperatorType() == LogicalOperatorType::RECURSIVE_EXTEND);
+    auto& recursiveExtend = pathPropertyProbe.getChild(0)->cast<LogicalRecursiveExtend>();
+    auto boundNodeID = recursiveExtend.getBoundNode()->getInternalID();
     collectExpressionsInUse(boundNodeID);
-    auto rel = recursiveExtend->getRel();
-    if (!patternInUse.contains(rel)) {
-        pathPropertyProbe->setJoinType(planner::RecursiveJoinType::TRACK_NONE);
-        recursiveExtend->setJoinType(planner::RecursiveJoinType::TRACK_NONE);
+    auto rel = recursiveExtend.getRel();
+    if (!nodeOrRelInUse.contains(rel)) {
+        pathPropertyProbe.setJoinType(RecursiveJoinType::TRACK_NONE);
+        recursiveExtend.setJoinType(RecursiveJoinType::TRACK_NONE);
     }
 }
 
-void ProjectionPushDownOptimizer::visitExtend(planner::LogicalOperator* op) {
-    auto extend = (LogicalExtend*)op;
-    auto boundNodeID = extend->getBoundNode()->getInternalID();
+void ProjectionPushDownOptimizer::visitExtend(LogicalOperator* op) {
+    auto& extend = op->constCast<LogicalExtend>();
+    auto boundNodeID = extend.getBoundNode()->getInternalID();
     collectExpressionsInUse(boundNodeID);
 }
 
-void ProjectionPushDownOptimizer::visitAccumulate(planner::LogicalOperator* op) {
-    auto accumulate = (LogicalAccumulate*)op;
-    if (accumulate->getAccumulateType() != AccumulateType::REGULAR) {
+void ProjectionPushDownOptimizer::visitAccumulate(LogicalOperator* op) {
+    auto& accumulate = op->constCast<LogicalAccumulate>();
+    if (accumulate.getAccumulateType() != AccumulateType::REGULAR) {
         return;
     }
-    auto expressionsBeforePruning = accumulate->getPayloads();
+    auto expressionsBeforePruning = accumulate.getPayloads();
     auto expressionsAfterPruning = pruneExpressions(expressionsBeforePruning);
     if (expressionsBeforePruning.size() == expressionsAfterPruning.size()) {
         return;
@@ -74,21 +74,21 @@ void ProjectionPushDownOptimizer::visitAccumulate(planner::LogicalOperator* op) 
     preAppendProjection(op, 0, expressionsAfterPruning);
 }
 
-void ProjectionPushDownOptimizer::visitFilter(planner::LogicalOperator* op) {
-    auto filter = (LogicalFilter*)op;
-    collectExpressionsInUse(filter->getPredicate());
+void ProjectionPushDownOptimizer::visitFilter(LogicalOperator* op) {
+    auto& filter = op->constCast<LogicalFilter>();
+    collectExpressionsInUse(filter.getPredicate());
 }
 
-void ProjectionPushDownOptimizer::visitHashJoin(planner::LogicalOperator* op) {
-    auto hashJoin = (LogicalHashJoin*)op;
-    for (auto& [probeJoinKey, buildJoinKey] : hashJoin->getJoinConditions()) {
+void ProjectionPushDownOptimizer::visitHashJoin(LogicalOperator* op) {
+    auto& hashJoin = op->constCast<LogicalHashJoin>();
+    for (auto& [probeJoinKey, buildJoinKey] : hashJoin.getJoinConditions()) {
         collectExpressionsInUse(probeJoinKey);
         collectExpressionsInUse(buildJoinKey);
     }
-    if (hashJoin->getJoinType() == JoinType::MARK) { // no need to perform push down for mark join.
+    if (hashJoin.getJoinType() == JoinType::MARK) { // no need to perform push down for mark join.
         return;
     }
-    auto expressionsBeforePruning = hashJoin->getExpressionsToMaterialize();
+    auto expressionsBeforePruning = hashJoin.getExpressionsToMaterialize();
     auto expressionsAfterPruning = pruneExpressions(expressionsBeforePruning);
     if (expressionsBeforePruning.size() == expressionsAfterPruning.size()) {
         // TODO(Xiyang): replace this with a separate optimizer.
@@ -97,12 +97,12 @@ void ProjectionPushDownOptimizer::visitHashJoin(planner::LogicalOperator* op) {
     preAppendProjection(op, 1, expressionsAfterPruning);
 }
 
-void ProjectionPushDownOptimizer::visitIntersect(planner::LogicalOperator* op) {
-    auto intersect = (LogicalIntersect*)op;
-    collectExpressionsInUse(intersect->getIntersectNodeID());
-    for (auto i = 0u; i < intersect->getNumBuilds(); ++i) {
+void ProjectionPushDownOptimizer::visitIntersect(LogicalOperator* op) {
+    auto& intersect = op->constCast<LogicalIntersect>();
+    collectExpressionsInUse(intersect.getIntersectNodeID());
+    for (auto i = 0u; i < intersect.getNumBuilds(); ++i) {
         auto childIdx = i + 1; // skip probe
-        auto keyNodeID = intersect->getKeyNodeID(i);
+        auto keyNodeID = intersect.getKeyNodeID(i);
         collectExpressionsInUse(keyNodeID);
         // Note: we have a potential bug under intersect.cpp. The following code ensures build key
         // and intersect key always appear as the first and second column. Should be removed once
@@ -110,15 +110,15 @@ void ProjectionPushDownOptimizer::visitIntersect(planner::LogicalOperator* op) {
         expression_vector expressionsBeforePruning;
         expression_vector expressionsAfterPruning;
         for (auto& expression :
-            intersect->getChild(childIdx)->getSchema()->getExpressionsInScope()) {
-            if (expression->getUniqueName() == intersect->getIntersectNodeID()->getUniqueName() ||
+            intersect.getChild(childIdx)->getSchema()->getExpressionsInScope()) {
+            if (expression->getUniqueName() == intersect.getIntersectNodeID()->getUniqueName() ||
                 expression->getUniqueName() == keyNodeID->getUniqueName()) {
                 continue;
             }
             expressionsBeforePruning.push_back(expression);
         }
         expressionsAfterPruning.push_back(keyNodeID);
-        expressionsAfterPruning.push_back(intersect->getIntersectNodeID());
+        expressionsAfterPruning.push_back(intersect.getIntersectNodeID());
         for (auto& expression : pruneExpressions(expressionsBeforePruning)) {
             expressionsAfterPruning.push_back(expression);
         }
@@ -134,19 +134,19 @@ void ProjectionPushDownOptimizer::visitProjection(LogicalOperator* op) {
     // Projection operator defines the start of a projection push down until the next projection
     // operator is seen.
     ProjectionPushDownOptimizer optimizer;
-    auto projection = (LogicalProjection*)op;
-    for (auto& expression : projection->getExpressionsToProject()) {
+    auto& projection = op->constCast<LogicalProjection>();
+    for (auto& expression : projection.getExpressionsToProject()) {
         optimizer.collectExpressionsInUse(expression);
     }
     optimizer.visitOperator(op->getChild(0).get());
 }
 
-void ProjectionPushDownOptimizer::visitOrderBy(planner::LogicalOperator* op) {
-    auto orderBy = (LogicalOrderBy*)op;
-    for (auto& expression : orderBy->getExpressionsToOrderBy()) {
+void ProjectionPushDownOptimizer::visitOrderBy(LogicalOperator* op) {
+    auto& orderBy = op->constCast<LogicalOrderBy>();
+    for (auto& expression : orderBy.getExpressionsToOrderBy()) {
         collectExpressionsInUse(expression);
     }
-    auto expressionsBeforePruning = orderBy->getChild(0)->getSchema()->getExpressionsInScope();
+    auto expressionsBeforePruning = orderBy.getChild(0)->getSchema()->getExpressionsInScope();
     auto expressionsAfterPruning = pruneExpressions(expressionsBeforePruning);
     if (expressionsBeforePruning.size() == expressionsAfterPruning.size()) {
         return;
@@ -154,21 +154,21 @@ void ProjectionPushDownOptimizer::visitOrderBy(planner::LogicalOperator* op) {
     preAppendProjection(op, 0, expressionsAfterPruning);
 }
 
-void ProjectionPushDownOptimizer::visitUnwind(planner::LogicalOperator* op) {
-    auto unwind = (LogicalUnwind*)op;
-    collectExpressionsInUse(unwind->getInExpr());
+void ProjectionPushDownOptimizer::visitUnwind(LogicalOperator* op) {
+    auto& unwind = op->constCast<LogicalUnwind>();
+    collectExpressionsInUse(unwind.getInExpr());
 }
 
-void ProjectionPushDownOptimizer::visitInsert(planner::LogicalOperator* op) {
-    auto insert = (LogicalInsert*)op;
-    for (auto& info : insert->getInfos()) {
+void ProjectionPushDownOptimizer::visitInsert(LogicalOperator* op) {
+    auto& insert = op->constCast<LogicalInsert>();
+    for (auto& info : insert.getInfos()) {
         visitInsertInfo(info);
     }
 }
 
-void ProjectionPushDownOptimizer::visitDelete(planner::LogicalOperator* op) {
-    auto delete_ = op->constPtrCast<LogicalDelete>();
-    auto& infos = delete_->getInfos();
+void ProjectionPushDownOptimizer::visitDelete(LogicalOperator* op) {
+    auto& delete_ = op->constCast<LogicalDelete>();
+    auto& infos = delete_.getInfos();
     KU_ASSERT(!infos.empty());
     switch (infos[0].tableType) {
     case TableType::NODE: {
@@ -193,42 +193,51 @@ void ProjectionPushDownOptimizer::visitDelete(planner::LogicalOperator* op) {
     }
 }
 
-void ProjectionPushDownOptimizer::visitMerge(planner::LogicalOperator* op) {
-    auto merge = op->ptrCast<LogicalMerge>();
-    collectExpressionsInUse(merge->getExistenceMark());
-    for (auto& info : merge->getInsertNodeInfos()) {
+void ProjectionPushDownOptimizer::visitMerge(LogicalOperator* op) {
+    auto& merge = op->constCast<LogicalMerge>();
+    collectExpressionsInUse(merge.getExistenceMark());
+    for (auto& info : merge.getInsertNodeInfos()) {
         visitInsertInfo(info);
     }
-    for (auto& info : merge->getInsertRelInfos()) {
+    for (auto& info : merge.getInsertRelInfos()) {
         visitInsertInfo(info);
     }
-    for (auto& info : merge->getOnCreateSetNodeInfos()) {
+    for (auto& info : merge.getOnCreateSetNodeInfos()) {
         visitSetInfo(info);
     }
-    for (auto& info : merge->getOnMatchSetNodeInfos()) {
+    for (auto& info : merge.getOnMatchSetNodeInfos()) {
         visitSetInfo(info);
     }
-    for (auto& info : merge->getOnCreateSetRelInfos()) {
+    for (auto& info : merge.getOnCreateSetRelInfos()) {
         visitSetInfo(info);
     }
-    for (auto& info : merge->getOnMatchSetRelInfos()) {
+    for (auto& info : merge.getOnMatchSetRelInfos()) {
         visitSetInfo(info);
     }
 }
 
-void ProjectionPushDownOptimizer::visitSetProperty(planner::LogicalOperator* op) {
-    auto set = op->ptrCast<LogicalSetProperty>();
-    for (auto& info : set->getInfos()) {
+void ProjectionPushDownOptimizer::visitSetProperty(LogicalOperator* op) {
+    auto& set = op->constCast<LogicalSetProperty>();
+    for (auto& info : set.getInfos()) {
         visitSetInfo(info);
     }
 }
 
-void ProjectionPushDownOptimizer::visitCopyFrom(planner::LogicalOperator* op) {
-    auto copyFrom = ku_dynamic_cast<LogicalOperator*, LogicalCopyFrom*>(op);
-    for (auto& expr : copyFrom->getInfo()->source->getColumns()) {
+void ProjectionPushDownOptimizer::visitCopyFrom(LogicalOperator* op) {
+    auto& copyFrom = op->constCast<LogicalCopyFrom>();
+    for (auto& expr : copyFrom.getInfo()->source->getColumns()) {
         collectExpressionsInUse(expr);
     }
-    collectExpressionsInUse(copyFrom->getInfo()->offset);
+    collectExpressionsInUse(copyFrom.getInfo()->offset);
+}
+
+void ProjectionPushDownOptimizer::visitTableFunctionCall(LogicalOperator* op) {
+    auto& tableFunctionCall = op->cast<LogicalTableFunctionCall>();
+    std::vector<bool> columnSkips;
+    for (auto& column : tableFunctionCall.getColumns()) {
+        columnSkips.push_back(!variablesInUse.contains(column));
+    }
+    tableFunctionCall.setColumnSkips(std::move(columnSkips));
 }
 
 void ProjectionPushDownOptimizer::visitSetInfo(const binder::BoundSetPropertyInfo& info) {
@@ -252,7 +261,7 @@ void ProjectionPushDownOptimizer::visitSetInfo(const binder::BoundSetPropertyInf
     collectExpressionsInUse(info.columnData);
 }
 
-void ProjectionPushDownOptimizer::visitInsertInfo(const planner::LogicalInsertInfo& info) {
+void ProjectionPushDownOptimizer::visitInsertInfo(const LogicalInsertInfo& info) {
     if (info.tableType == common::TableType::REL) {
         auto& rel = info.pattern->constCast<RelExpression>();
         collectExpressionsInUse(rel.getSrcNode()->getInternalID());
@@ -270,15 +279,26 @@ void ProjectionPushDownOptimizer::visitInsertInfo(const planner::LogicalInsertIn
 // See comments above this class for how to collect expressions in use.
 void ProjectionPushDownOptimizer::collectExpressionsInUse(
     std::shared_ptr<binder::Expression> expression) {
-    if (expression->expressionType == ExpressionType::PROPERTY) {
-        propertiesInUse.insert(std::move(expression));
+    switch (expression->expressionType) {
+    case ExpressionType::PROPERTY: {
+        propertiesInUse.insert(expression);
         return;
     }
-    if (expression->expressionType == ExpressionType::PATTERN) {
-        patternInUse.insert(expression);
+    case ExpressionType::VARIABLE: {
+        variablesInUse.insert(expression);
+        return;
     }
-    for (auto& child : ExpressionChildrenCollector::collectChildren(*expression)) {
-        collectExpressionsInUse(child);
+    case ExpressionType::PATTERN: {
+        nodeOrRelInUse.insert(expression);
+        for (auto& child : ExpressionChildrenCollector::collectChildren(*expression)) {
+            collectExpressionsInUse(child);
+        }
+        return;
+    }
+    default:
+        for (auto& child : ExpressionChildrenCollector::collectChildren(*expression)) {
+            collectExpressionsInUse(child);
+        }
     }
 }
 
@@ -287,13 +307,18 @@ binder::expression_vector ProjectionPushDownOptimizer::pruneExpressions(
     expression_set expressionsAfterPruning;
     for (auto& expression : expressions) {
         switch (expression->expressionType) {
-        case ExpressionType::PATTERN: {
-            if (patternInUse.contains(expression)) {
+        case ExpressionType::PROPERTY: {
+            if (propertiesInUse.contains(expression)) {
                 expressionsAfterPruning.insert(expression);
             }
         } break;
-        case ExpressionType::PROPERTY: {
-            if (propertiesInUse.contains(expression)) {
+        case ExpressionType::VARIABLE: {
+            if (variablesInUse.contains(expression)) {
+                expressionsAfterPruning.insert(expression);
+            }
+        } break;
+        case ExpressionType::PATTERN: {
+            if (nodeOrRelInUse.contains(expression)) {
                 expressionsAfterPruning.insert(expression);
             }
         } break;
@@ -304,8 +329,8 @@ binder::expression_vector ProjectionPushDownOptimizer::pruneExpressions(
     return expression_vector{expressionsAfterPruning.begin(), expressionsAfterPruning.end()};
 }
 
-void ProjectionPushDownOptimizer::preAppendProjection(planner::LogicalOperator* op,
-    uint32_t childIdx, binder::expression_vector expressions) {
+void ProjectionPushDownOptimizer::preAppendProjection(LogicalOperator* op,
+    idx_t childIdx, binder::expression_vector expressions) {
     if (expressions.empty()) {
         // We don't have a way to handle
         return;

--- a/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
@@ -16,9 +16,9 @@ namespace kuzu {
 namespace processor {
 
 BaseCSVReader::BaseCSVReader(const std::string& filePath, common::CSVOption option,
-    uint64_t numColumns, main::ClientContext* context)
-    : option{std::move(option)}, numColumns{numColumns}, buffer{nullptr}, bufferSize{0},
-      position{0}, osFileOffset{0}, rowEmpty{false}, context{context} {
+    CSVColumnInfo columnInfo, main::ClientContext* context)
+    : context{context}, option{std::move(option)}, columnInfo{std::move(columnInfo)}, buffer{nullptr}, bufferSize{0},
+      position{0}, osFileOffset{0}, rowEmpty{false} {
     fileInfo = context->getVFSUnsafe()->openFile(filePath,
         O_RDONLY
 #ifdef _WIN32
@@ -39,7 +39,7 @@ line_start:
     }
 
     // If the number of columns is 1, every line start indicates a row.
-    if (numColumns == 1) {
+    if (columnInfo.numColumns == 1) {
         rows++;
     }
 
@@ -51,7 +51,7 @@ line_start:
         goto line_start;
     } else {
         // If we have more than one column, every non-empty line is a row.
-        if (numColumns != 1) {
+        if (columnInfo.numColumns != 1) {
             rows++;
         }
         goto normal;

--- a/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
@@ -17,8 +17,8 @@ namespace processor {
 
 BaseCSVReader::BaseCSVReader(const std::string& filePath, common::CSVOption option,
     CSVColumnInfo columnInfo, main::ClientContext* context)
-    : context{context}, option{std::move(option)}, columnInfo{std::move(columnInfo)}, buffer{nullptr}, bufferSize{0},
-      position{0}, osFileOffset{0}, rowEmpty{false} {
+    : context{context}, option{std::move(option)}, columnInfo{std::move(columnInfo)},
+      buffer{nullptr}, bufferSize{0}, position{0}, osFileOffset{0}, rowEmpty{false} {
     fileInfo = context->getVFSUnsafe()->openFile(filePath,
         O_RDONLY
 #ifdef _WIN32

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -59,9 +59,9 @@ bool ParsingDriver::addRow(uint64_t /*rowNum*/, common::column_id_t columnCount)
     }
     if (columnCount < reader->getNumColumns()) {
         // Column number mismatch.
-        throw CopyException(
-            stringFormat("Error in file {} on line {}: expected {} values per row, but got {}",
-                reader->fileInfo->path, reader->getLineNumber(), reader->getNumColumns(), columnCount));
+        throw CopyException(stringFormat(
+            "Error in file {} on line {}: expected {} values per row, but got {}",
+            reader->fileInfo->path, reader->getLineNumber(), reader->getNumColumns(), columnCount));
     }
     return true;
 }
@@ -124,8 +124,8 @@ void SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t co
         auto it = value.rfind(':');
         if (it != std::string_view::npos) {
             try {
-                columnType =
-                    LogicalType::convertFromString(std::string(value.substr(it + 1)), reader->getClientContext());
+                columnType = LogicalType::convertFromString(std::string(value.substr(it + 1)),
+                    reader->getClientContext());
                 columnName = std::string(value.substr(0, it));
                 sniffType[columnIdx] = false;
             } catch (const Exception&) { // NOLINT(bugprone-empty-catch):

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -26,14 +26,18 @@ void ParsingDriver::addValue(uint64_t rowNum, common::column_id_t columnIdx,
         rowEmpty = false;
     }
     BaseCSVReader* reader = getReader();
-    if (columnIdx == reader->numColumns && length == 0) {
+
+    if (columnIdx == reader->getNumColumns() && length == 0) {
         // skip a single trailing delimiter in last columnIdx
         return;
     }
-    if (columnIdx >= reader->numColumns) {
+    if (columnIdx >= reader->getNumColumns()) {
         throw CopyException(
             stringFormat("Error in file {}, on line {}: expected {} values per row, but got more.",
-                reader->fileInfo->path, reader->getLineNumber(), reader->numColumns));
+                reader->fileInfo->path, reader->getLineNumber(), reader->getNumColumns()));
+    }
+    if (reader->skipColumn(columnIdx)) {
+        return;
     }
     try {
         function::CastString::copyStringToVector(chunk.getValueVector(columnIdx).get(), rowNum,
@@ -48,16 +52,16 @@ bool ParsingDriver::addRow(uint64_t /*rowNum*/, common::column_id_t columnCount)
     BaseCSVReader* reader = getReader();
     if (rowEmpty) {
         rowEmpty = false;
-        if (reader->numColumns != 1) {
+        if (reader->getNumColumns() != 1) {
             return false;
         }
         // Otherwise, treat it as null.
     }
-    if (columnCount < reader->numColumns) {
+    if (columnCount < reader->getNumColumns()) {
         // Column number mismatch.
         throw CopyException(
             stringFormat("Error in file {} on line {}: expected {} values per row, but got {}",
-                reader->fileInfo->path, reader->getLineNumber(), reader->numColumns, columnCount));
+                reader->fileInfo->path, reader->getLineNumber(), reader->getNumColumns(), columnCount));
     }
     return true;
 }
@@ -83,10 +87,10 @@ bool SerialParsingDriver::doneEarly() {
 BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
-SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(main::ClientContext* context,
-    const common::CSVOption& csvOptions, SerialCSVReader* reader,
+
+SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
     const function::ScanTableFuncBindInput* bindInput)
-    : context{context}, csvOptions{csvOptions}, reader{reader} {
+    : reader{reader} {
     if (bindInput != nullptr) {
         for (auto i = 0u; i < bindInput->expectedColumnNames.size(); i++) {
             columns.push_back(
@@ -97,12 +101,14 @@ SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(main::ClientContext* contex
 }
 
 bool SniffCSVNameAndTypeDriver::done(uint64_t rowNum) const {
-    return (csvOptions.hasHeader ? 1 : 0) + csvOptions.sampleSize <= rowNum;
+    auto& csvOption = reader->getCSVOption();
+    return (csvOption.hasHeader ? 1 : 0) + csvOption.sampleSize <= rowNum;
 }
 
 void SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t columnIdx,
     std::string_view value) {
-    if (columns.size() < columnIdx + 1 && csvOptions.hasHeader && rowNum > 0) {
+    auto& csvOption = reader->getCSVOption();
+    if (columns.size() < columnIdx + 1 && csvOption.hasHeader && rowNum > 0) {
         throw CopyException(
             stringFormat("Error in file {}, on line {}: expected {} values per row, but got more.",
                 reader->fileInfo->path, reader->getLineNumber(), columns.size()));
@@ -111,7 +117,7 @@ void SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t co
         columns.emplace_back(stringFormat("column{}", columns.size()), LogicalType::ANY());
         sniffType.push_back(true);
     }
-    if (rowNum == 0 && csvOptions.hasHeader) {
+    if (rowNum == 0 && csvOption.hasHeader) {
         // reading the header
         std::string columnName(value);
         LogicalType columnType(LogicalTypeID::ANY);
@@ -119,7 +125,7 @@ void SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t co
         if (it != std::string_view::npos) {
             try {
                 columnType =
-                    LogicalType::convertFromString(std::string(value.substr(it + 1)), context);
+                    LogicalType::convertFromString(std::string(value.substr(it + 1)), reader->getClientContext());
                 columnName = std::string(value.substr(0, it));
                 sniffType[columnIdx] = false;
             } catch (const Exception&) { // NOLINT(bugprone-empty-catch):

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -20,8 +20,8 @@ namespace kuzu {
 namespace processor {
 
 ParallelCSVReader::ParallelCSVReader(const std::string& filePath, CSVOption option,
-    uint64_t numColumns, main::ClientContext* context)
-    : BaseCSVReader{filePath, std::move(option), numColumns, context} {}
+    CSVColumnInfo columnInfo, main::ClientContext* context)
+    : BaseCSVReader{filePath, std::move(option), std::move(columnInfo), context} {}
 
 bool ParallelCSVReader::hasMoreToRead() const {
     // If we haven't started the first block yet or are done our block, get the next block.
@@ -117,38 +117,36 @@ void ParallelCSVScanSharedState::setFileComplete(uint64_t completedFileIdx) {
 
 static offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& outputChunk = output.dataChunk;
-    auto parallelCSVLocalState =
-        ku_dynamic_cast<TableFuncLocalState*, ParallelCSVLocalState*>(input.localState);
-    auto parallelCSVSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, ParallelCSVScanSharedState*>(input.sharedState);
+    auto localState = input.localState->ptrCast<ParallelCSVLocalState>();
+    auto sharedState =
+        input.sharedState->ptrCast<ParallelCSVScanSharedState>();
     do {
-        if (parallelCSVLocalState->reader != nullptr &&
-            parallelCSVLocalState->reader->hasMoreToRead()) {
-            auto result = parallelCSVLocalState->reader->continueBlock(outputChunk);
+        if (localState->reader != nullptr &&
+            localState->reader->hasMoreToRead()) {
+            auto result = localState->reader->continueBlock(outputChunk);
             outputChunk.state->getSelVectorUnsafe().setSelSize(result);
             if (result > 0) {
                 return result;
             }
         }
-        auto [fileIdx, blockIdx] = parallelCSVSharedState->getNext();
+        auto [fileIdx, blockIdx] = sharedState->getNext();
         if (fileIdx == UINT64_MAX) {
             return 0;
         }
-        if (fileIdx != parallelCSVLocalState->fileIdx) {
-            parallelCSVLocalState->fileIdx = fileIdx;
-            parallelCSVLocalState->reader = std::make_unique<ParallelCSVReader>(
-                parallelCSVSharedState->readerConfig.filePaths[fileIdx],
-                parallelCSVSharedState->csvReaderConfig.option.copy(),
-                parallelCSVSharedState->numColumns, parallelCSVSharedState->context);
+        if (fileIdx != localState->fileIdx) {
+            localState->fileIdx = fileIdx;
+            localState->reader = std::make_unique<ParallelCSVReader>(
+                sharedState->readerConfig.filePaths[fileIdx], sharedState->csvOption.copy(),
+                sharedState->columnInfo.copy(), sharedState->context);
         }
-        auto numRowsRead = parallelCSVLocalState->reader->parseBlock(blockIdx, outputChunk);
+        auto numRowsRead = localState->reader->parseBlock(blockIdx, outputChunk);
         outputChunk.state->getSelVectorUnsafe().setSelSize(numRowsRead);
         if (numRowsRead > 0) {
             return numRowsRead;
         }
-        if (parallelCSVLocalState->reader->isEOF()) {
-            parallelCSVSharedState->setFileComplete(parallelCSVLocalState->fileIdx);
-            parallelCSVLocalState->reader = nullptr;
+        if (localState->reader->isEOF()) {
+            sharedState->setFileComplete(localState->fileIdx);
+            localState->reader = nullptr;
         }
     } while (true);
 }
@@ -172,15 +170,15 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
 }
 
 static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input) {
-    auto bindData = ku_dynamic_cast<TableFuncBindData*, ScanBindData*>(input.bindData);
-    auto csvConfig = CSVReaderConfig::construct(bindData->config.options);
+    auto bindData = input.bindData->constPtrCast<ScanBindData>();
+    auto csvOption = CSVReaderConfig::construct(bindData->config.options).option;
     row_idx_t numRows = 0;
+    auto columnInfo = CSVColumnInfo(bindData->getNumColumns(), bindData->getColumnSkips());
     auto sharedState = std::make_unique<ParallelCSVScanSharedState>(bindData->config.copy(),
-        numRows, bindData->columnNames.size(), bindData->context, csvConfig.copy());
+        numRows, bindData->context, csvOption.copy(), columnInfo.copy());
     for (auto filePath : sharedState->readerConfig.filePaths) {
         auto reader = std::make_unique<ParallelCSVReader>(filePath,
-            sharedState->csvReaderConfig.option.copy(), sharedState->numColumns,
-            sharedState->context);
+            csvOption.copy(), columnInfo.copy(), bindData->context);
         sharedState->totalSize += reader->getFileSize();
     }
     return sharedState;
@@ -189,15 +187,15 @@ static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitIn
 static std::unique_ptr<TableFuncLocalState> initLocalState(TableFunctionInitInput& /*input*/,
     TableFuncSharedState* state, storage::MemoryManager* /*mm*/) {
     auto localState = std::make_unique<ParallelCSVLocalState>();
-    auto sharedState = ku_dynamic_cast<TableFuncSharedState*, ParallelCSVScanSharedState*>(state);
+    auto sharedState = state->ptrCast<ParallelCSVScanSharedState>();
     localState->reader = std::make_unique<ParallelCSVReader>(sharedState->readerConfig.filePaths[0],
-        sharedState->csvReaderConfig.option.copy(), sharedState->numColumns, sharedState->context);
+        sharedState->csvOption.copy(), sharedState->columnInfo.copy(), sharedState->context);
     localState->fileIdx = 0;
     return localState;
 }
 
 static double progressFunc(TableFuncSharedState* sharedState) {
-    auto state = ku_dynamic_cast<TableFuncSharedState*, ParallelCSVScanSharedState*>(sharedState);
+    auto state = sharedState->ptrCast<ParallelCSVScanSharedState>();
     if (state->fileIdx >= state->readerConfig.getNumFiles()) {
         return 1.0;
     }

--- a/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/parallel_csv_reader.cpp
@@ -118,11 +118,9 @@ void ParallelCSVScanSharedState::setFileComplete(uint64_t completedFileIdx) {
 static offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
     auto& outputChunk = output.dataChunk;
     auto localState = input.localState->ptrCast<ParallelCSVLocalState>();
-    auto sharedState =
-        input.sharedState->ptrCast<ParallelCSVScanSharedState>();
+    auto sharedState = input.sharedState->ptrCast<ParallelCSVScanSharedState>();
     do {
-        if (localState->reader != nullptr &&
-            localState->reader->hasMoreToRead()) {
+        if (localState->reader != nullptr && localState->reader->hasMoreToRead()) {
             auto result = localState->reader->continueBlock(outputChunk);
             outputChunk.state->getSelVectorUnsafe().setSelSize(result);
             if (result > 0) {
@@ -177,8 +175,8 @@ static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitIn
     auto sharedState = std::make_unique<ParallelCSVScanSharedState>(bindData->config.copy(),
         numRows, bindData->context, csvOption.copy(), columnInfo.copy());
     for (auto filePath : sharedState->readerConfig.filePaths) {
-        auto reader = std::make_unique<ParallelCSVReader>(filePath,
-            csvOption.copy(), columnInfo.copy(), bindData->context);
+        auto reader = std::make_unique<ParallelCSVReader>(filePath, csvOption.copy(),
+            columnInfo.copy(), bindData->context);
         sharedState->totalSize += reader->getFileSize();
     }
     return sharedState;

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -12,7 +12,8 @@ namespace processor {
 
 SerialCSVReader::SerialCSVReader(const std::string& filePath, CSVOption option,
     CSVColumnInfo columnInfo, main::ClientContext* context, const ScanTableFuncBindInput* bindInput)
-    : BaseCSVReader{filePath, std::move(option), std::move(columnInfo), context}, bindInput{bindInput} {}
+    : BaseCSVReader{filePath, std::move(option), std::move(columnInfo), context},
+      bindInput{bindInput} {}
 
 std::vector<std::pair<std::string, LogicalType>> SerialCSVReader::sniffCSV() {
     readBOM();
@@ -83,7 +84,7 @@ static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_
     auto csvOption = CSVReaderConfig::construct(bindInput->config.options).option;
     auto columnInfo = CSVColumnInfo(0 /* numColumns */, {} /* columnSkips */);
     auto csvReader = SerialCSVReader(bindInput->config.filePaths[fileIdx], csvOption.copy(),
-       columnInfo.copy(), bindInput->context, bindInput);
+        columnInfo.copy(), bindInput->context, bindInput);
     auto sniffedColumns = csvReader.sniffCSV();
     for (auto& [name, type] : sniffedColumns) {
         columnNames.push_back(name);
@@ -130,7 +131,7 @@ static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitIn
         bindData->context, csvOption.copy(), columnInfo.copy());
     for (auto filePath : sharedState->readerConfig.filePaths) {
         auto reader = std::make_unique<SerialCSVReader>(filePath, csvOption.copy(),
-                columnInfo.copy(), sharedState->context);
+            columnInfo.copy(), sharedState->context);
         sharedState->totalSize += reader->getFileSize();
     }
     return sharedState;

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -10,13 +10,13 @@ using namespace kuzu::function;
 namespace kuzu {
 namespace processor {
 
-SerialCSVReader::SerialCSVReader(const std::string& filePath, CSVOption option, uint64_t numColumns,
-    main::ClientContext* context, const ScanTableFuncBindInput* bindInput)
-    : BaseCSVReader{filePath, std::move(option), numColumns, context}, bindInput{bindInput} {}
+SerialCSVReader::SerialCSVReader(const std::string& filePath, CSVOption option,
+    CSVColumnInfo columnInfo, main::ClientContext* context, const ScanTableFuncBindInput* bindInput)
+    : BaseCSVReader{filePath, std::move(option), std::move(columnInfo), context}, bindInput{bindInput} {}
 
 std::vector<std::pair<std::string, LogicalType>> SerialCSVReader::sniffCSV() {
     readBOM();
-    SniffCSVNameAndTypeDriver driver{context, option, this, bindInput};
+    SniffCSVNameAndTypeDriver driver{this, bindInput};
     parseCSV(driver);
     // finalize the columns; rename duplicate names
     std::map<std::string, int32_t> names;
@@ -67,7 +67,7 @@ void SerialCSVScanSharedState::read(DataChunk& outputChunk) {
 void SerialCSVScanSharedState::initReader(main::ClientContext* context) {
     if (fileIdx < readerConfig.getNumFiles()) {
         reader = std::make_unique<SerialCSVReader>(readerConfig.filePaths[fileIdx],
-            csvReaderConfig.option.copy(), numColumns, context);
+            csvOption.copy(), columnInfo.copy(), context);
     }
 }
 
@@ -80,9 +80,10 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 
 static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_t fileIdx,
     std::vector<std::string>& columnNames, std::vector<LogicalType>& columnTypes) {
-    auto csvConfig = CSVReaderConfig::construct(bindInput->config.options);
-    auto csvReader = SerialCSVReader(bindInput->config.filePaths[fileIdx], csvConfig.option.copy(),
-        0 /* numColumns */, bindInput->context, bindInput);
+    auto csvOption = CSVReaderConfig::construct(bindInput->config.options).option;
+    auto columnInfo = CSVColumnInfo(0 /* numColumns */, {} /* columnSkips */);
+    auto csvReader = SerialCSVReader(bindInput->config.filePaths[fileIdx], csvOption.copy(),
+       columnInfo.copy(), bindInput->context, bindInput);
     auto sniffedColumns = csvReader.sniffCSV();
     for (auto& [name, type] : sniffedColumns) {
         columnNames.push_back(name);
@@ -121,15 +122,15 @@ static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* /*contex
 }
 
 static std::unique_ptr<TableFuncSharedState> initSharedState(TableFunctionInitInput& input) {
-    auto bindData = ku_dynamic_cast<TableFuncBindData*, ScanBindData*>(input.bindData);
-    auto csvConfig = CSVReaderConfig::construct(bindData->config.options);
+    auto bindData = input.bindData->constPtrCast<ScanBindData>();
+    auto csvOption = CSVReaderConfig::construct(bindData->config.options).option;
     row_idx_t numRows = 0;
+    auto columnInfo = CSVColumnInfo(bindData->getNumColumns(), bindData->getColumnSkips());
     auto sharedState = std::make_unique<SerialCSVScanSharedState>(bindData->config.copy(), numRows,
-        bindData->columnNames.size(), csvConfig.copy(), bindData->context);
+        bindData->context, csvOption.copy(), columnInfo.copy());
     for (auto filePath : sharedState->readerConfig.filePaths) {
-        auto reader =
-            std::make_unique<SerialCSVReader>(filePath, sharedState->csvReaderConfig.option.copy(),
-                sharedState->numColumns, sharedState->context);
+        auto reader = std::make_unique<SerialCSVReader>(filePath, csvOption.copy(),
+                columnInfo.copy(), sharedState->context);
         sharedState->totalSize += reader->getFileSize();
     }
     return sharedState;

--- a/src/processor/operator/persistent/reader/parquet/column_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/column_reader.cpp
@@ -19,6 +19,8 @@
 #include "snappy/snappy.h"
 #include "zstd.h"
 
+using namespace kuzu::common;
+
 namespace kuzu {
 namespace processor {
 
@@ -28,8 +30,8 @@ using kuzu_parquet::format::Encoding;
 using kuzu_parquet::format::PageType;
 using kuzu_parquet::format::Type;
 
-ColumnReader::ColumnReader(ParquetReader& reader, common::LogicalType type,
-    const kuzu_parquet::format::SchemaElement& schema, uint64_t fileIdx, uint64_t maxDefinition,
+ColumnReader::ColumnReader(ParquetReader& reader, LogicalType type,
+    const kuzu_parquet::format::SchemaElement& schema, idx_t fileIdx, uint64_t maxDefinition,
     uint64_t maxRepeat)
     : schema{schema}, fileIdx{fileIdx}, maxDefine{maxDefinition}, maxRepeat{maxRepeat},
       reader{reader}, type{std::move(type)}, pageRowsAvailable{0} {}

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -20,7 +20,8 @@ namespace processor {
 using namespace kuzu::function;
 using namespace kuzu::common;
 
-ParquetReader::ParquetReader(const std::string& filePath, std::vector<bool> columnSkips, main::ClientContext* context)
+ParquetReader::ParquetReader(const std::string& filePath, std::vector<bool> columnSkips,
+    main::ClientContext* context)
     : filePath{filePath}, columnSkips(std::move(columnSkips)), context{context} {
     initMetadata();
 }
@@ -583,11 +584,12 @@ uint64_t ParquetReader::getGroupOffset(ParquetReaderScanState& state) {
 ParquetScanSharedState::ParquetScanSharedState(common::ReaderConfig readerConfig, uint64_t numRows,
     main::ClientContext* context, std::vector<bool> columnSkips)
     : ScanFileSharedState{std::move(readerConfig), numRows, context}, columnSkips{columnSkips} {
-    readers.push_back(
-        std::make_unique<ParquetReader>(this->readerConfig.filePaths[fileIdx], columnSkips, context));
+    readers.push_back(std::make_unique<ParquetReader>(this->readerConfig.filePaths[fileIdx],
+        columnSkips, context));
     totalRowsGroups = 0;
     for (auto i = fileIdx; i < this->readerConfig.getNumFiles(); i++) {
-        auto reader = std::make_unique<ParquetReader>(this->readerConfig.filePaths[i], columnSkips, context);
+        auto reader =
+            std::make_unique<ParquetReader>(this->readerConfig.filePaths[i], columnSkips, context);
         totalRowsGroups += reader->getNumRowsGroups();
     }
     numBlocksReadByFiles = 0;
@@ -615,7 +617,8 @@ static bool parquetSharedStateNext(ParquetScanLocalState& localState,
                 return false;
             }
             sharedState.readers.push_back(std::make_unique<ParquetReader>(
-                sharedState.readerConfig.filePaths[sharedState.fileIdx], sharedState.columnSkips, sharedState.context));
+                sharedState.readerConfig.filePaths[sharedState.fileIdx], sharedState.columnSkips,
+                sharedState.context));
             continue;
         }
     }
@@ -689,7 +692,8 @@ static std::unique_ptr<function::TableFuncSharedState> initSharedState(
     auto bindData = input.bindData->constPtrCast<ScanBindData>();
     row_idx_t numRows = 0;
     for (const auto& path : bindData->config.filePaths) {
-        auto reader = std::make_unique<ParquetReader>(path, bindData->getColumnSkips(), bindData->context);
+        auto reader =
+            std::make_unique<ParquetReader>(path, bindData->getColumnSkips(), bindData->context);
         numRows += reader->getMetadata()->num_rows;
     }
     return std::make_unique<ParquetScanSharedState>(bindData->config.copy(), numRows,

--- a/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
+++ b/src/processor/operator/persistent/reader/parquet/parquet_reader.cpp
@@ -20,8 +20,8 @@ namespace processor {
 using namespace kuzu::function;
 using namespace kuzu::common;
 
-ParquetReader::ParquetReader(const std::string& filePath, main::ClientContext* context)
-    : filePath{filePath}, context{context} {
+ParquetReader::ParquetReader(const std::string& filePath, std::vector<bool> columnSkips, main::ClientContext* context)
+    : filePath{filePath}, columnSkips(std::move(columnSkips)), context{context} {
     initMetadata();
 }
 
@@ -143,6 +143,9 @@ bool ParquetReader::scanInternal(ParquetReaderScanState& state, DataChunk& resul
     auto rootReader = ku_dynamic_cast<ColumnReader*, StructColumnReader*>(state.rootReader.get());
 
     for (auto colIdx = 0u; colIdx < result.getNumValueVectors(); colIdx++) {
+        if (!columnSkips.empty() && columnSkips[colIdx]) {
+            continue;
+        }
         auto fileColIdx = colIdx;
         auto resultVector = result.getValueVector(colIdx);
         auto childReader = rootReader->getChildReader(fileColIdx);
@@ -578,13 +581,13 @@ uint64_t ParquetReader::getGroupOffset(ParquetReaderScanState& state) {
 }
 
 ParquetScanSharedState::ParquetScanSharedState(common::ReaderConfig readerConfig, uint64_t numRows,
-    main::ClientContext* context)
-    : ScanFileSharedState{std::move(readerConfig), numRows, context} {
+    main::ClientContext* context, std::vector<bool> columnSkips)
+    : ScanFileSharedState{std::move(readerConfig), numRows, context}, columnSkips{columnSkips} {
     readers.push_back(
-        std::make_unique<ParquetReader>(this->readerConfig.filePaths[fileIdx], context));
+        std::make_unique<ParquetReader>(this->readerConfig.filePaths[fileIdx], columnSkips, context));
     totalRowsGroups = 0;
     for (auto i = fileIdx; i < this->readerConfig.getNumFiles(); i++) {
-        auto reader = std::make_unique<ParquetReader>(this->readerConfig.filePaths[i], context);
+        auto reader = std::make_unique<ParquetReader>(this->readerConfig.filePaths[i], columnSkips, context);
         totalRowsGroups += reader->getNumRowsGroups();
     }
     numBlocksReadByFiles = 0;
@@ -612,7 +615,7 @@ static bool parquetSharedStateNext(ParquetScanLocalState& localState,
                 return false;
             }
             sharedState.readers.push_back(std::make_unique<ParquetReader>(
-                sharedState.readerConfig.filePaths[sharedState.fileIdx], sharedState.context));
+                sharedState.readerConfig.filePaths[sharedState.fileIdx], sharedState.columnSkips, sharedState.context));
             continue;
         }
     }
@@ -640,7 +643,7 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 
 static void bindColumns(const ScanTableFuncBindInput* bindInput, uint32_t fileIdx,
     std::vector<std::string>& columnNames, std::vector<common::LogicalType>& columnTypes) {
-    auto reader = ParquetReader(bindInput->config.filePaths[fileIdx], bindInput->context);
+    auto reader = ParquetReader(bindInput->config.filePaths[fileIdx], {}, bindInput->context);
     auto state = std::make_unique<processor::ParquetReaderScanState>();
     reader.initializeScan(*state, std::vector<uint64_t>{}, bindInput->context->getVFSUnsafe());
     for (auto i = 0u; i < reader.getNumColumns(); ++i) {
@@ -683,30 +686,29 @@ static std::unique_ptr<function::TableFuncBindData> bindFunc(main::ClientContext
 
 static std::unique_ptr<function::TableFuncSharedState> initSharedState(
     TableFunctionInitInput& input) {
-    auto parquetScanBindData = ku_dynamic_cast<TableFuncBindData*, ScanBindData*>(input.bindData);
+    auto bindData = input.bindData->constPtrCast<ScanBindData>();
     row_idx_t numRows = 0;
-    for (const auto& path : parquetScanBindData->config.filePaths) {
-        auto reader = std::make_unique<ParquetReader>(path, parquetScanBindData->context);
+    for (const auto& path : bindData->config.filePaths) {
+        auto reader = std::make_unique<ParquetReader>(path, bindData->getColumnSkips(), bindData->context);
         numRows += reader->getMetadata()->num_rows;
     }
-    return std::make_unique<ParquetScanSharedState>(parquetScanBindData->config.copy(), numRows,
-        parquetScanBindData->context);
+    return std::make_unique<ParquetScanSharedState>(bindData->config.copy(), numRows,
+        bindData->context, bindData->getColumnSkips());
 }
 
 static std::unique_ptr<function::TableFuncLocalState> initLocalState(
     TableFunctionInitInput& /*input*/, TableFuncSharedState* state,
     storage::MemoryManager* /*mm*/) {
-    auto parquetScanSharedState =
-        ku_dynamic_cast<TableFuncSharedState*, ParquetScanSharedState*>(state);
+    auto sharedState = state->ptrCast<ParquetScanSharedState>();
     auto localState = std::make_unique<ParquetScanLocalState>();
-    if (!parquetSharedStateNext(*localState, *parquetScanSharedState)) {
+    if (!parquetSharedStateNext(*localState, *sharedState)) {
         return nullptr;
     }
     return localState;
 }
 
 static double progressFunc(TableFuncSharedState* sharedState) {
-    auto state = ku_dynamic_cast<TableFuncSharedState*, ParquetScanSharedState*>(sharedState);
+    auto state = sharedState->ptrCast<ParquetScanSharedState>();
     if (state->fileIdx >= state->readerConfig.getNumFiles()) {
         return 1.0;
     }


### PR DESCRIPTION
# Description

Add projection push down when we scan from csv and parquet. 

For parquet, the improvement is linear 
```
400 ms when scanning single column & 1.2s when scanning three columns
``` 

For csv, the improvement is less noticeable as we still have to read row by row.

@acquamarin should propagate this to scan relational table.
@mxwli should propagate this to scan python object.

Simply propagate `columnSkips` flag in `TableFuncBindData` to each reader.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).