### PR TITLE
Make Connection::query in rust call the C++ query function instead of using prepare+execute

### DIFF
--- a/tools/rust_api/include/kuzu_rs.h
+++ b/tools/rust_api/include/kuzu_rs.h
@@ -107,6 +107,10 @@ void database_set_logging_level(kuzu::main::Database& database, const std::strin
 std::unique_ptr<kuzu::main::Connection> database_connect(kuzu::main::Database& database);
 std::unique_ptr<kuzu::main::QueryResult> connection_execute(kuzu::main::Connection& connection,
     kuzu::main::PreparedStatement& query, std::unique_ptr<QueryParams> params);
+inline std::unique_ptr<kuzu::main::QueryResult> connection_query(kuzu::main::Connection& connection,
+    std::string_view query) {
+    return connection.query(query);
+}
 
 /* PreparedStatement */
 rust::String prepared_statement_error_message(const kuzu::main::PreparedStatement& statement);

--- a/tools/rust_api/src/ffi.rs
+++ b/tools/rust_api/src/ffi.rs
@@ -185,6 +185,12 @@ pub(crate) mod ffi {
             params: UniquePtr<QueryParams>,
         ) -> Result<UniquePtr<QueryResult>>;
 
+        #[namespace = "kuzu_rs"]
+        fn connection_query<'a>(
+            connection: Pin<&mut Connection>,
+            query: StringView<'a>,
+        ) -> Result<UniquePtr<QueryResult>>;
+
         fn getMaxNumThreadForExec(self: Pin<&mut Connection>) -> u64;
         fn setMaxNumThreadForExec(self: Pin<&mut Connection>, num_threads: u64);
         fn interrupt(self: Pin<&mut Connection>) -> Result<()>;


### PR DESCRIPTION
Originally just a simplification as the C++ `Connection::query` function was also originally also doing this.

Fixes #4116 