### PR TITLE
Add filter push down to relational table

### DIFF
--- a/extension/duckdb/src/duckdb_scan.cpp
+++ b/extension/duckdb/src/duckdb_scan.cpp
@@ -27,6 +27,7 @@ DuckDBScanBindData::DuckDBScanBindData(std::string query,
     }
 }
 
+<<<<<<< HEAD
 std::unique_ptr<TableFuncBindData> DuckDBScanBindData::copy() const {
     auto result = std::make_unique<DuckDBScanBindData>(query, LogicalType::copy(columnTypes),
         columnNames, connector);
@@ -34,6 +35,8 @@ std::unique_ptr<TableFuncBindData> DuckDBScanBindData::copy() const {
     return result;
 }
 
+=======
+>>>>>>> d60dddffa (Add filter push down to relational table)
 DuckDBScanSharedState::DuckDBScanSharedState(
     std::unique_ptr<duckdb::MaterializedQueryResult> queryResult)
     : BaseScanSharedStateWithNumRows{queryResult->RowCount()}, queryResult{std::move(queryResult)} {

--- a/extension/duckdb/src/include/duckdb_scan.h
+++ b/extension/duckdb/src/include/duckdb_scan.h
@@ -28,9 +28,9 @@ struct DuckDBScanBindData : public function::TableFuncBindData {
 
     DuckDBScanBindData(std::string query, std::vector<common::LogicalType> columnTypes,
         std::vector<std::string> columnNames, const DuckDBConnector& connector);
-    DuckDBScanBindData(const DuckDBScanBindData& other) : function::TableFuncBindData{other},
-          query{other.query}, conversionFunctions{other.conversionFunctions},
-          connector{other.connector}  {}
+    DuckDBScanBindData(const DuckDBScanBindData& other)
+        : function::TableFuncBindData{other}, query{other.query},
+          conversionFunctions{other.conversionFunctions}, connector{other.connector} {}
 
     std::unique_ptr<TableFuncBindData> copy() const override {
         return std::make_unique<DuckDBScanBindData>(*this);

--- a/extension/duckdb/src/include/duckdb_scan.h
+++ b/extension/duckdb/src/include/duckdb_scan.h
@@ -22,14 +22,19 @@ using duckdb_conversion_func_t = std::function<void(duckdb::Vector& duckDBVector
 using init_duckdb_conn_t = std::function<std::pair<duckdb::DuckDB, duckdb::Connection>()>;
 
 struct DuckDBScanBindData : public function::TableFuncBindData {
-    explicit DuckDBScanBindData(std::string query, std::vector<common::LogicalType> columnTypes,
-        std::vector<std::string> columnNames, const DuckDBConnector& connector);
-
-    std::unique_ptr<TableFuncBindData> copy() const override;
-
     std::string query;
     std::vector<duckdb_conversion_func_t> conversionFunctions;
     const DuckDBConnector& connector;
+
+    DuckDBScanBindData(std::string query, std::vector<common::LogicalType> columnTypes,
+        std::vector<std::string> columnNames, const DuckDBConnector& connector);
+    DuckDBScanBindData(const DuckDBScanBindData& other) : function::TableFuncBindData{other},
+          query{other.query}, conversionFunctions{other.conversionFunctions},
+          connector{other.connector}  {}
+
+    std::unique_ptr<TableFuncBindData> copy() const override {
+        return std::make_unique<DuckDBScanBindData>(*this);
+    }
 };
 
 struct DuckDBScanSharedState : public function::BaseScanSharedStateWithNumRows {

--- a/extension/duckdb/test/test_files/duckdb.test
+++ b/extension/duckdb/test/test_files/duckdb.test
@@ -62,6 +62,21 @@ Elizabeth
 Farooq
 Greg
 Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+-STATEMENT LOAD FROM tinysnb.person WHERE ID > 5 RETURN fName;
+---- 4
+Elizabeth
+Farooq
+Greg
+Hubert Blaine Wolfeschlegelsteinhausenbergerdorff
+-STATEMENT LOAD FROM tinysnb.person WHERE ID = 2 RETURN fName;
+---- 1
+Bob
+-STATEMENT LOAD FROM tinysnb.person WHERE ID < 5 AND usedNames = ['Aida'] RETURN fName;
+---- 1
+Alice
+-STATEMENT LOAD FROM tinysnb.person WHERE ID > 4 AND u = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a15' RETURN fName;
+---- 1
+Elizabeth
 -STATEMENT LOAD FROM tinysnb.organisation RETURN *;
 ---- 3
 1|ABFsUni|325|3.700000|-2|10 years 5 months 13 hours 24 us|3 years 5 days|1.000000|{revenue: 138, "location": ['toronto','montr,eal'], stock: {price: [96,56], volume: 1000}}|3.12

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -107,6 +107,26 @@ std::string ExpressionTypeUtil::toString(ExpressionType type) {
     }
     return "";
 }
+
+
+std::string ExpressionTypeUtil::toParsableString(ExpressionType type) {
+    switch (type) {
+    case ExpressionType::EQUALS:
+        return "=";
+    case ExpressionType::NOT_EQUALS:
+        return "<>";
+    case ExpressionType::GREATER_THAN:
+        return ">";
+    case ExpressionType::GREATER_THAN_EQUALS:
+        return ">=";
+    case ExpressionType::LESS_THAN:
+        return "<";
+    case ExpressionType::LESS_THAN_EQUALS:
+        return "<=";
+    default:
+        throw RuntimeException(stringFormat("ExpressionTypeUtil::toParsableString not implemented for {}", toString(type)));
+    }
+}
 // LCOV_EXCL_STOP
 
 } // namespace common

--- a/src/common/expression_type.cpp
+++ b/src/common/expression_type.cpp
@@ -108,7 +108,6 @@ std::string ExpressionTypeUtil::toString(ExpressionType type) {
     return "";
 }
 
-
 std::string ExpressionTypeUtil::toParsableString(ExpressionType type) {
     switch (type) {
     case ExpressionType::EQUALS:
@@ -124,7 +123,8 @@ std::string ExpressionTypeUtil::toParsableString(ExpressionType type) {
     case ExpressionType::LESS_THAN_EQUALS:
         return "<=";
     default:
-        throw RuntimeException(stringFormat("ExpressionTypeUtil::toParsableString not implemented for {}", toString(type)));
+        throw RuntimeException(stringFormat(
+            "ExpressionTypeUtil::toParsableString not implemented for {}", toString(type)));
     }
 }
 // LCOV_EXCL_STOP

--- a/src/include/common/enums/expression_type.h
+++ b/src/include/common/enums/expression_type.h
@@ -64,6 +64,7 @@ struct ExpressionTypeUtil {
     static ExpressionType reverseComparisonDirection(ExpressionType type);
 
     static std::string toString(ExpressionType type);
+    static std::string toParsableString(ExpressionType type);
 };
 
 } // namespace common

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -44,15 +44,5 @@ bool isLittleEndian();
 template<typename T>
 bool integerFitsIn(int64_t val);
 
-template<typename T>
-std::vector<T> copyVector(const std::vector<T>& objects) {
-    std::vector<T> result;
-    result.reserve(objects.size());
-    for (auto& object : objects) {
-        result.push_back(object->copy());
-    }
-    return result;
-}
-
 } // namespace common
 } // namespace kuzu

--- a/src/include/common/utils.h
+++ b/src/include/common/utils.h
@@ -2,7 +2,6 @@
 
 #include <cstdint>
 #include <limits>
-#include <vector>
 
 #include "common/assert.h"
 #include "common/numeric_utils.h"

--- a/src/include/function/table/bind_data.h
+++ b/src/include/function/table/bind_data.h
@@ -3,6 +3,7 @@
 #include "common/copier_config/reader_config.h"
 #include "common/types/types.h"
 #include "main/client_context.h"
+#include "storage/predicate/column_predicate.h"
 
 namespace kuzu {
 namespace common {
@@ -21,12 +22,19 @@ struct TableFuncBindData {
         : columnTypes{std::move(columnTypes)}, columnNames{std::move(columnNames)} {}
     TableFuncBindData(const TableFuncBindData& other)
         : columnTypes{common::LogicalType::copy(other.columnTypes)}, columnNames{other.columnNames},
-          columnSkips{other.columnSkips} {}
+          columnSkips{other.columnSkips}, columnPredicates{copyVector(other.columnPredicates)} {}
     virtual ~TableFuncBindData() = default;
 
     common::idx_t getNumColumns() const { return columnTypes.size(); }
     void setColumnSkips(std::vector<bool> skips) { columnSkips = std::move(skips); }
     KUZU_API std::vector<bool> getColumnSkips() const;
+
+    void setColumnPredicates(std::vector<storage::ColumnPredicateSet> predicates) {
+        columnPredicates = std::move(predicates);
+    }
+    const std::vector<storage::ColumnPredicateSet>& getColumnPredicates() const {
+        return columnPredicates;
+    }
 
     virtual std::unique_ptr<TableFuncBindData> copy() const = 0;
 
@@ -37,6 +45,7 @@ struct TableFuncBindData {
 
 private:
     std::vector<bool> columnSkips;
+    std::vector<storage::ColumnPredicateSet> columnPredicates;
 };
 
 struct ScanBindData : public TableFuncBindData {

--- a/src/include/optimizer/filter_push_down_optimizer.h
+++ b/src/include/optimizer/filter_push_down_optimizer.h
@@ -62,6 +62,9 @@ private:
     // Push Filter into EXTEND.
     std::shared_ptr<planner::LogicalOperator> visitExtendReplace(
         const std::shared_ptr<planner::LogicalOperator>& op);
+    // Push Filter into TABLE_FUNCTION_CALL
+    std::shared_ptr<planner::LogicalOperator> visitTableFunctionCallReplace(
+        const std::shared_ptr<planner::LogicalOperator>& op);
 
     // Finish the current push down optimization by apply remaining predicates as a single filter.
     // And heuristically reorder equality predicates first in the filter.

--- a/src/include/planner/operator/logical_table_function_call.h
+++ b/src/include/planner/operator/logical_table_function_call.h
@@ -19,8 +19,12 @@ public:
 
     const function::TableFunction& getTableFunc() const { return tableFunc; }
     const function::TableFuncBindData* getBindData() const { return bindData.get(); }
+
     void setColumnSkips(std::vector<bool> columnSkips) {
         bindData->setColumnSkips(std::move(columnSkips));
+    }
+    void setColumnPredicates(std::vector<storage::ColumnPredicateSet> predicates) {
+        bindData->setColumnPredicates(std::move(predicates));
     }
 
     void computeFlatSchema() override;

--- a/src/include/storage/predicate/column_predicate.h
+++ b/src/include/storage/predicate/column_predicate.h
@@ -18,11 +18,15 @@ public:
     void addPredicate(std::unique_ptr<ColumnPredicate> predicate) {
         predicates.push_back(std::move(predicate));
     }
+    bool isEmpty() const { return predicates.empty(); }
 
     common::ZoneMapCheckResult checkZoneMap(const CompressionMetadata& metadata);
 
+    std::string toString() const;
+
 private:
-    ColumnPredicateSet(const ColumnPredicateSet& other);
+    ColumnPredicateSet(const ColumnPredicateSet& other)
+        : predicates{copyVector(other.predicates)} {}
 
 private:
     std::vector<std::unique_ptr<ColumnPredicate>> predicates;
@@ -30,9 +34,13 @@ private:
 
 class ColumnPredicate {
 public:
+    explicit ColumnPredicate(std::string columnName) : columnName{std::move(columnName)} {}
+
     virtual ~ColumnPredicate() = default;
 
     virtual common::ZoneMapCheckResult checkZoneMap(const CompressionMetadata& metadata) const = 0;
+
+    virtual std::string toString() = 0;
 
     virtual std::unique_ptr<ColumnPredicate> copy() const = 0;
 
@@ -40,10 +48,13 @@ public:
     const TARGET& constCast() const {
         return common::ku_dynamic_cast<const ColumnPredicate&, const TARGET&>(*this);
     }
+
+protected:
+    std::string columnName;
 };
 
 struct ColumnPredicateUtil {
-    static std::unique_ptr<ColumnPredicate> tryConvert(const binder::Expression& property,
+    static std::unique_ptr<ColumnPredicate> tryConvert(const binder::Expression& column,
         const binder::Expression& predicate);
 };
 

--- a/src/include/storage/predicate/column_predicate.h
+++ b/src/include/storage/predicate/column_predicate.h
@@ -10,7 +10,7 @@ namespace storage {
 struct CompressionMetadata;
 
 class ColumnPredicate;
-class ColumnPredicateSet {
+class KUZU_API ColumnPredicateSet {
 public:
     ColumnPredicateSet() = default;
     EXPLICIT_COPY_DEFAULT_MOVE(ColumnPredicateSet);
@@ -32,7 +32,7 @@ private:
     std::vector<std::unique_ptr<ColumnPredicate>> predicates;
 };
 
-class ColumnPredicate {
+class KUZU_API ColumnPredicate {
 public:
     explicit ColumnPredicate(std::string columnName) : columnName{std::move(columnName)} {}
 

--- a/src/include/storage/predicate/constant_predicate.h
+++ b/src/include/storage/predicate/constant_predicate.h
@@ -9,8 +9,10 @@ namespace storage {
 
 class ColumnConstantPredicate : public ColumnPredicate {
 public:
-    ColumnConstantPredicate(std::string columnName, common::ExpressionType expressionType, common::Value value)
-        : ColumnPredicate{std::move(columnName)}, expressionType{expressionType}, value{std::move(value)} {}
+    ColumnConstantPredicate(std::string columnName, common::ExpressionType expressionType,
+        common::Value value)
+        : ColumnPredicate{std::move(columnName)}, expressionType{expressionType},
+          value{std::move(value)} {}
 
     common::ZoneMapCheckResult checkZoneMap(const CompressionMetadata& metadata) const override;
 

--- a/src/include/storage/predicate/constant_predicate.h
+++ b/src/include/storage/predicate/constant_predicate.h
@@ -9,13 +9,15 @@ namespace storage {
 
 class ColumnConstantPredicate : public ColumnPredicate {
 public:
-    ColumnConstantPredicate(common::ExpressionType expressionType, common::Value value)
-        : expressionType{expressionType}, value{std::move(value)} {}
+    ColumnConstantPredicate(std::string columnName, common::ExpressionType expressionType, common::Value value)
+        : ColumnPredicate{std::move(columnName)}, expressionType{expressionType}, value{std::move(value)} {}
 
     common::ZoneMapCheckResult checkZoneMap(const CompressionMetadata& metadata) const override;
 
+    std::string toString() override;
+
     std::unique_ptr<ColumnPredicate> copy() const override {
-        return std::make_unique<ColumnConstantPredicate>(expressionType, value);
+        return std::make_unique<ColumnConstantPredicate>(columnName, expressionType, value);
     }
 
 private:

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -8,8 +8,8 @@
 #include "planner/operator/logical_empty_result.h"
 #include "planner/operator/logical_filter.h"
 #include "planner/operator/logical_hash_join.h"
-#include "planner/operator/scan/logical_scan_node_table.h"
 #include "planner/operator/logical_table_function_call.h"
+#include "planner/operator/scan/logical_scan_node_table.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -179,7 +179,8 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
     auto nodeID = scan.getNodeID();
     // Apply column predicates.
     if (context->getClientConfig()->enableZoneMap) {
-        scan.setPropertyPredicates(getColumnPredicateSets(scan.getProperties(), predicateSet.getAllPredicates()));
+        scan.setPropertyPredicates(
+            getColumnPredicateSets(scan.getProperties(), predicateSet.getAllPredicates()));
     }
     // Apply index scan
     auto tableIDs = scan.getTableIDs();
@@ -204,8 +205,9 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
 
 std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitTableFunctionCallReplace(
     const std::shared_ptr<LogicalOperator>& op) {
-    auto& tableFunctionCall = op -> cast<LogicalTableFunctionCall>();
-    auto columnPredicates = getColumnPredicateSets(tableFunctionCall.getColumns(), predicateSet.getAllPredicates());
+    auto& tableFunctionCall = op->cast<LogicalTableFunctionCall>();
+    auto columnPredicates =
+        getColumnPredicateSets(tableFunctionCall.getColumns(), predicateSet.getAllPredicates());
     tableFunctionCall.setColumnPredicates(std::move(columnPredicates));
     return finishPushDown(op);
 }
@@ -218,7 +220,8 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitExtendReplace(
     }
     auto& extend = op->cast<LogicalExtend>();
     // Apply column predicates.
-    auto columnPredicates = getColumnPredicateSets(extend.getProperties(), predicateSet.getAllPredicates());
+    auto columnPredicates =
+        getColumnPredicateSets(extend.getProperties(), predicateSet.getAllPredicates());
     extend.setPropertyPredicates(std::move(columnPredicates));
     return finishPushDown(op);
 }

--- a/src/optimizer/filter_push_down_optimizer.cpp
+++ b/src/optimizer/filter_push_down_optimizer.cpp
@@ -9,6 +9,7 @@
 #include "planner/operator/logical_filter.h"
 #include "planner/operator/logical_hash_join.h"
 #include "planner/operator/scan/logical_scan_node_table.h"
+#include "planner/operator/logical_table_function_call.h"
 
 using namespace kuzu::binder;
 using namespace kuzu::common;
@@ -37,6 +38,9 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitOperator(
         //    }
     case LogicalOperatorType::SCAN_NODE_TABLE: {
         return visitScanNodeTableReplace(op);
+    }
+    case LogicalOperatorType::TABLE_FUNCTION_CALL: {
+        return visitTableFunctionCallReplace(op);
     }
     default: { // Stop current push down for unhandled operator.
         for (auto i = 0u; i < op->getNumChildren(); ++i) {
@@ -127,17 +131,26 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitCrossProductRepla
     return appendFilters(predicates, hashJoin);
 }
 
-static ColumnPredicateSet getPropertyPredicateSet(const Expression& property,
+static ColumnPredicateSet getPredicateSet(const Expression& column,
     const binder::expression_vector& predicates) {
-    auto propertyPredicateSet = ColumnPredicateSet();
+    auto predicateSet = ColumnPredicateSet();
     for (auto& predicate : predicates) {
-        auto columnPredicate = ColumnPredicateUtil::tryConvert(property, *predicate);
+        auto columnPredicate = ColumnPredicateUtil::tryConvert(column, *predicate);
         if (columnPredicate == nullptr) {
             continue;
         }
-        propertyPredicateSet.addPredicate(std::move(columnPredicate));
+        predicateSet.addPredicate(std::move(columnPredicate));
     }
-    return propertyPredicateSet;
+    return predicateSet;
+}
+
+static std::vector<ColumnPredicateSet> getColumnPredicateSets(const expression_vector& columns,
+    const expression_vector& predicates) {
+    std::vector<ColumnPredicateSet> predicateSets;
+    for (auto& column : columns) {
+        predicateSets.push_back(getPredicateSet(*column, predicates));
+    }
+    return predicateSets;
 }
 
 static bool isConstantExpression(const std::shared_ptr<Expression> expression) {
@@ -166,14 +179,8 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
     auto nodeID = scan.getNodeID();
     // Apply column predicates.
     if (context->getClientConfig()->enableZoneMap) {
-        std::vector<ColumnPredicateSet> propertyPredicateSets;
-        auto predicates = predicateSet.getAllPredicates();
-        for (auto& property : scan.getProperties()) {
-            propertyPredicateSets.push_back(getPropertyPredicateSet(*property, predicates));
-        }
-        scan.setPropertyPredicates(std::move(propertyPredicateSets));
+        scan.setPropertyPredicates(getColumnPredicateSets(scan.getProperties(), predicateSet.getAllPredicates()));
     }
-
     // Apply index scan
     auto tableIDs = scan.getTableIDs();
     std::shared_ptr<Expression> primaryKeyEqualityComparison = nullptr;
@@ -195,6 +202,14 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitScanNodeTableRepl
     return finishPushDown(op);
 }
 
+std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitTableFunctionCallReplace(
+    const std::shared_ptr<LogicalOperator>& op) {
+    auto& tableFunctionCall = op -> cast<LogicalTableFunctionCall>();
+    auto columnPredicates = getColumnPredicateSets(tableFunctionCall.getColumns(), predicateSet.getAllPredicates());
+    tableFunctionCall.setColumnPredicates(std::move(columnPredicates));
+    return finishPushDown(op);
+}
+
 std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitExtendReplace(
     const std::shared_ptr<LogicalOperator>& op) {
     if (op->ptrCast<BaseLogicalExtend>()->isRecursive() ||
@@ -203,12 +218,8 @@ std::shared_ptr<LogicalOperator> FilterPushDownOptimizer::visitExtendReplace(
     }
     auto& extend = op->cast<LogicalExtend>();
     // Apply column predicates.
-    std::vector<ColumnPredicateSet> propertyPredicateSets;
-    auto predicates = predicateSet.getAllPredicates();
-    for (auto& property : extend.getProperties()) {
-        propertyPredicateSets.push_back(getPropertyPredicateSet(*property, predicates));
-    }
-    extend.setPropertyPredicates(std::move(propertyPredicateSets));
+    auto columnPredicates = getColumnPredicateSets(extend.getProperties(), predicateSet.getAllPredicates());
+    extend.setPropertyPredicates(std::move(columnPredicates));
     return finishPushDown(op);
 }
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -24,7 +24,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
 
     auto removeUnnecessaryJoinOptimizer = RemoveUnnecessaryJoinOptimizer();
     removeUnnecessaryJoinOptimizer.rewrite(plan);
-
+    
     auto filterPushDownOptimizer = FilterPushDownOptimizer(context);
     filterPushDownOptimizer.rewrite(plan);
 

--- a/src/optimizer/optimizer.cpp
+++ b/src/optimizer/optimizer.cpp
@@ -24,7 +24,7 @@ void Optimizer::optimize(planner::LogicalPlan* plan, main::ClientContext* contex
 
     auto removeUnnecessaryJoinOptimizer = RemoveUnnecessaryJoinOptimizer();
     removeUnnecessaryJoinOptimizer.rewrite(plan);
-    
+
     auto filterPushDownOptimizer = FilterPushDownOptimizer(context);
     filterPushDownOptimizer.rewrite(plan);
 

--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -44,7 +44,8 @@ static std::unique_ptr<ColumnPredicate> tryConvertToConstColumnPredicate(const E
             return nullptr;
         }
         auto value = predicate.getChild(1)->constCast<LiteralExpression>().getValue();
-        return std::make_unique<ColumnConstantPredicate>(column.toString(), predicate.expressionType, value);
+        return std::make_unique<ColumnConstantPredicate>(column.toString(),
+            predicate.expressionType, value);
     } else if (isColumnRefConstantPair(*predicate.getChild(1), *predicate.getChild(0))) {
         if (column != *predicate.getChild(1)) {
             return nullptr;

--- a/src/storage/predicate/column_predicate.cpp
+++ b/src/storage/predicate/column_predicate.cpp
@@ -18,33 +18,41 @@ ZoneMapCheckResult ColumnPredicateSet::checkZoneMap(const CompressionMetadata& m
     return ZoneMapCheckResult::ALWAYS_SCAN;
 }
 
-ColumnPredicateSet::ColumnPredicateSet(const ColumnPredicateSet& other) {
-    for (auto& p : other.predicates) {
-        predicates.push_back(p->copy());
+std::string ColumnPredicateSet::toString() const {
+    if (predicates.empty()) {
+        return {};
     }
+    auto result = predicates[0]->toString();
+    for (auto i = 1u; i < predicates.size(); ++i) {
+        result += stringFormat(" AND {}", predicates[i]->toString());
+    }
+    return result;
 }
 
-static bool isPropertyConstantPair(const Expression& left, const Expression& right) {
-    return left.expressionType == ExpressionType::PROPERTY &&
-           right.expressionType == ExpressionType::LITERAL;
+static bool isColumnRef(ExpressionType type) {
+    return type == ExpressionType::PROPERTY || type == ExpressionType::VARIABLE;
 }
 
-static std::unique_ptr<ColumnPredicate> tryConvertToConstColumnPredicate(const Expression& property,
+static bool isColumnRefConstantPair(const Expression& left, const Expression& right) {
+    return isColumnRef(left.expressionType) && right.expressionType == ExpressionType::LITERAL;
+}
+
+static std::unique_ptr<ColumnPredicate> tryConvertToConstColumnPredicate(const Expression& column,
     const Expression& predicate) {
-    if (isPropertyConstantPair(*predicate.getChild(0), *predicate.getChild(1))) {
-        if (property != *predicate.getChild(0)) {
+    if (isColumnRefConstantPair(*predicate.getChild(0), *predicate.getChild(1))) {
+        if (column != *predicate.getChild(0)) {
             return nullptr;
         }
         auto value = predicate.getChild(1)->constCast<LiteralExpression>().getValue();
-        return std::make_unique<ColumnConstantPredicate>(predicate.expressionType, value);
-    } else if (isPropertyConstantPair(*predicate.getChild(1), *predicate.getChild(0))) {
-        if (property != *predicate.getChild(1)) {
+        return std::make_unique<ColumnConstantPredicate>(column.toString(), predicate.expressionType, value);
+    } else if (isColumnRefConstantPair(*predicate.getChild(1), *predicate.getChild(0))) {
+        if (column != *predicate.getChild(1)) {
             return nullptr;
         }
         auto value = predicate.getChild(0)->constCast<LiteralExpression>().getValue();
         auto expressionType =
             ExpressionTypeUtil::reverseComparisonDirection(predicate.expressionType);
-        return std::make_unique<ColumnConstantPredicate>(expressionType, value);
+        return std::make_unique<ColumnConstantPredicate>(column.toString(), expressionType, value);
     }
     // Not a predicate that runs on this property.
     return nullptr;

--- a/src/storage/predicate/constant_predicate.cpp
+++ b/src/storage/predicate/constant_predicate.cpp
@@ -70,5 +70,16 @@ ZoneMapCheckResult ColumnConstantPredicate::checkZoneMap(
         [&](auto) { return ZoneMapCheckResult::ALWAYS_SCAN; });
 }
 
+std::string ColumnConstantPredicate::toString() {
+    std::string valStr;
+    // TODO(Ziyi): test if we need to skip char for other types.
+    if (value.getDataType().getLogicalTypeID() == LogicalTypeID::STRING) {
+        valStr = stringFormat("'{}'", value.toString());
+    } else {
+        valStr = value.toString();
+    }
+    return stringFormat("{} {} {}", columnName, ExpressionTypeUtil::toParsableString(expressionType), valStr);
+}
+
 } // namespace storage
 } // namespace kuzu

--- a/src/storage/predicate/constant_predicate.cpp
+++ b/src/storage/predicate/constant_predicate.cpp
@@ -78,7 +78,8 @@ std::string ColumnConstantPredicate::toString() {
     } else {
         valStr = value.toString();
     }
-    return stringFormat("{} {} {}", columnName, ExpressionTypeUtil::toParsableString(expressionType), valStr);
+    return stringFormat("{} {} {}", columnName,
+        ExpressionTypeUtil::toParsableString(expressionType), valStr);
 }
 
 } // namespace storage

--- a/src/storage/predicate/constant_predicate.cpp
+++ b/src/storage/predicate/constant_predicate.cpp
@@ -72,8 +72,14 @@ ZoneMapCheckResult ColumnConstantPredicate::checkZoneMap(
 
 std::string ColumnConstantPredicate::toString() {
     std::string valStr;
-    // TODO(Ziyi): test if we need to skip char for other types.
-    if (value.getDataType().getLogicalTypeID() == LogicalTypeID::STRING) {
+    if (value.getDataType().getPhysicalType() == PhysicalTypeID::STRING ||
+        value.getDataType().getPhysicalType() == PhysicalTypeID::LIST ||
+        value.getDataType().getPhysicalType() == PhysicalTypeID::ARRAY ||
+        value.getDataType().getPhysicalType() == PhysicalTypeID::STRUCT ||
+        value.getDataType().getLogicalTypeID() == LogicalTypeID::UUID ||
+        value.getDataType().getLogicalTypeID() == LogicalTypeID::TIMESTAMP ||
+        value.getDataType().getLogicalTypeID() == LogicalTypeID::DATE ||
+        value.getDataType().getLogicalTypeID() == LogicalTypeID::INTERVAL) {
         valStr = stringFormat("'{}'", value.toString());
     } else {
         valStr = value.toString();


### PR DESCRIPTION
# Description

Push filter into relational table scanning. We need this optimization to make cypher over pg more performant. I'm having some problem debugging duckdb extension so I'm leaving the rest to @acquamarin 

Fixes # (issue)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).