### PR TITLE
Fix progress bar threading issue

### DIFF
--- a/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
@@ -139,6 +139,7 @@ bool BaseCSVReader::readBuffer(uint64_t* start) {
     auto readCount = fileInfo->readFile(buffer.get() + remaining, bufferReadSize);
     if (readCount == -1) {
         // LCOV_EXCL_START
+        lineContext.setEndOfLine(getFileOffset());
         handleCopyException(stringFormat("Could not read from file: {}", posixErrMessage()), true);
         // LCOV_EXCL_STOP
     }

--- a/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/base_csv_reader.cpp
@@ -131,7 +131,6 @@ bool BaseCSVReader::readBuffer(uint64_t* start) {
     }
 
     buffer = std::unique_ptr<char[]>(new char[bufferReadSize + remaining + 1]());
-    bufferSize = remaining + bufferReadSize;
     if (remaining > 0) {
         // remaining from last buffer: copy it here
         KU_ASSERT(start != nullptr);


### PR DESCRIPTION
# Description

Fixes https://github.com/kuzudb/kuzu/issues/4128

Ensure that the invariant `osFileOffset >= bufferSize` always holds in the serial CSV reader (even when observed from an external thread) to ensure that the assertion `BaseCSVReader::getFileOffset()` is never triggered even when called by the Serial CSV reader's `progressFunc()`

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).