### PR TITLE
Fix export-import rel group

### DIFF
--- a/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
+++ b/src/catalog/catalog_entry/rel_group_catalog_entry.cpp
@@ -94,7 +94,7 @@ std::string RelGroupCatalogEntry::toCypher(ClientContext* clientContext) const {
     }
     auto childRelEntry =
         clientContext->getCatalog()->getTableCatalogEntry(clientContext->getTx(), relTableIDs[0]);
-    if (childRelEntry->getNumProperties() > 0) {
+    if (childRelEntry->getNumProperties() > 1) { // skip internal id property.
         auto propertyStr = stringFormat(", {}", childRelEntry->propertiesToCypher());
         propertyStr.resize(propertyStr.size() - 1);
         ss << propertyStr;

--- a/test/test_files/copy/export_import_db.test
+++ b/test/test_files/copy/export_import_db.test
@@ -111,12 +111,20 @@ Binder exception: Directory ${KUZU_EXPORT_DB_DIRECTORY}_case4/demo-db5 does not 
 ---- ok
 -STATEMENT CREATE REL TABLE GROUP REL2(FROM A TO B, FROM B TO End2, num INT64);
 ---- ok
+-STATEMENT CREATE REL TABLE GROUP REL3(FROM A TO B, FROM B TO End2);
+---- ok
 -STATEMENT CREATE (a:A{ID:0})-[:REL2_A_B {num: 1}]->(b:B{ID:1})-[:REL2_B_End2 {num: 2}]->(e:End2{ID:2});
+---- ok
+-STATEMENT MATCH (a:A{ID:0}), (b:B{ID:1}) CREATE (a)-[:REL3_A_B]->(b);
 ---- ok
 -STATEMENT MATCH (a)-[r:REL2_A_B]->(b:B)
            RETURN a.ID;
 ---- 1
 0
+-STATEMENT MATCH (a)-[r:REL3_A_B]->(b:B)
+           RETURN a.ID, b.ID;
+---- 1
+0|1
 -STATEMENT Export Database "${KUZU_EXPORT_DB_DIRECTORY}_case5/demo-db"
 ---- 1
 Exported database successfully.
@@ -124,6 +132,10 @@ Exported database successfully.
 -STATEMENT IMPORT DATABASE "${KUZU_EXPORT_DB_DIRECTORY}_case5/demo-db"
 ---- 1
 Imported database successfully.
+-STATEMENT MATCH (a)-[r:REL3_A_B]->(b:B)
+           RETURN a.ID, b.ID;
+---- 1
+0|1
 -STATEMENT MATCH (u:User) WHERE u.name = "Adam" SET u.age = 50
 ---- ok
 -LOG ReturnAge


### PR DESCRIPTION
# Description

When exporting REL Group, we add a tail `,` even though there is no property.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).