### PR TITLE
Fix casting assertion errors in `getNodeTableEntries` and `getRelTableEntries`

### DIFF
--- a/src/catalog/catalog_set.cpp
+++ b/src/catalog/catalog_set.cpp
@@ -219,7 +219,7 @@ void CatalogSet::iterateEntriesOfType(const Transaction* transaction, CatalogEnt
         }
         const auto currentEntry =
             traverseVersionChainsForTransactionNoLock(transaction, entry.get());
-        if (currentEntry->isDeleted()) {
+        if (currentEntry->getType() != type || currentEntry->isDeleted()) {
             continue;
         }
         func(currentEntry);


### PR DESCRIPTION
# Description

Fix issue #4101 .
