### PR TITLE
Http file cache improve

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ add_subdirectory(third_party)
 if(${BUILD_KUZU})
 add_definitions(-DKUZU_ROOT_DIRECTORY="${PROJECT_SOURCE_DIR}")
 add_definitions(-DKUZU_CMAKE_VERSION="${CMAKE_PROJECT_VERSION}")
-add_definitions(-DKUZU_EXTENSION_VERSION="0.5.2.1")
+add_definitions(-DKUZU_EXTENSION_VERSION="0.5.2.2")
 
 include_directories(src/include)
 

--- a/extension/httpfs/src/cached_file_manager.cpp
+++ b/extension/httpfs/src/cached_file_manager.cpp
@@ -47,6 +47,7 @@ std::string CachedFileManager::getCachedDirForTrx(common::transaction_t transact
 }
 
 void CachedFileManager::downloadFile(HTTPFileInfo* fileToDownload, FileInfo* cacheFileInfo) {
+    fileToDownload->initMetadata();
     uint64_t numBytesRead;
     uint64_t offsetToWrite = 0;
     do {

--- a/extension/httpfs/src/httpfs.cpp
+++ b/extension/httpfs/src/httpfs.cpp
@@ -144,6 +144,9 @@ bool HTTPFileSystem::fileOrPathExists(const std::string& path, main::ClientConte
     try {
         auto fileInfo = openFile(path, FileFlags::READ_ONLY, context, FileLockType::READ_LOCK);
         auto httpFileInfo = fileInfo->constPtrCast<HTTPFileInfo>();
+        if (httpFileInfo->cachedFileInfo != nullptr) {
+            return true;
+        }
         if (httpFileInfo->length == 0) {
             return false;
         }

--- a/extension/httpfs/src/httpfs.cpp
+++ b/extension/httpfs/src/httpfs.cpp
@@ -23,9 +23,9 @@ HTTPFileInfo::HTTPFileInfo(std::string path, FileSystem* fileSystem, int flags,
       bufferIdx{0}, fileOffset{0}, bufferStartPos{0}, bufferEndPos{0}, httpConfig{context},
       cachedFileInfo{nullptr} {}
 
-void HTTPFileInfo::initialize(main::ClientContext* context) {
-    initializeClient();
+void HTTPFileInfo::initMetadata() {
     auto hfs = fileSystem->ptrCast<HTTPFileSystem>();
+    initializeClient();
     auto res = hfs->headRequest(this->ptrCast<HTTPFileInfo>(), path, {});
     std::string rangeLength;
     if (res->code != 200) {
@@ -105,10 +105,16 @@ void HTTPFileInfo::initialize(main::ClientContext* context) {
             // LCOV_EXCL_STOP
         }
     }
+}
+
+void HTTPFileInfo::initialize(main::ClientContext* context) {
     if (httpConfig.cacheFile) {
+        auto hfs = fileSystem->ptrCast<HTTPFileSystem>();
         cachedFileInfo =
             hfs->getCachedFileManager().getCachedFileInfo(this, context->getTx()->getID());
+        return;
     }
+    initMetadata();
 }
 
 void HTTPFileInfo::initializeClient() {
@@ -155,7 +161,7 @@ void HTTPFileSystem::cleanUP(main::ClientContext* context) {
 
 void HTTPFileSystem::readFromFile(common::FileInfo& fileInfo, void* buffer, uint64_t numBytes,
     uint64_t position) const {
-    auto& httpFileInfo = ku_dynamic_cast<FileInfo&, HTTPFileInfo&>(fileInfo);
+    auto& httpFileInfo = fileInfo.cast<HTTPFileInfo>();
     auto numBytesToRead = numBytes;
     auto bufferOffset = 0;
     if (httpFileInfo.cachedFileInfo != nullptr) {
@@ -214,7 +220,10 @@ void HTTPFileSystem::readFromFile(common::FileInfo& fileInfo, void* buffer, uint
 }
 
 int64_t HTTPFileSystem::readFile(common::FileInfo& fileInfo, void* buf, size_t numBytes) const {
-    auto& httpFileInfo = ku_dynamic_cast<FileInfo&, HTTPFileInfo&>(fileInfo);
+    auto& httpFileInfo = fileInfo.constCast<HTTPFileInfo>();
+    if (httpFileInfo.cachedFileInfo != nullptr) {
+        return httpFileInfo.cachedFileInfo->readFile(buf, numBytes);
+    }
     auto maxNumBytesToRead = httpFileInfo.length - httpFileInfo.fileOffset;
     numBytes = std::min<uint64_t>(maxNumBytesToRead, numBytes);
     if (httpFileInfo.fileOffset > httpFileInfo.getFileSize()) {
@@ -228,14 +237,21 @@ void HTTPFileSystem::syncFile(const common::FileInfo&) const {
     throw NotImplementedException("syncFile is not supported in HTTPFileSystem");
 }
 
-int64_t HTTPFileSystem::seek(common::FileInfo& fileInfo, uint64_t offset, int /*whence*/) const {
-    auto& httpFileInfo = ku_dynamic_cast<FileInfo&, HTTPFileInfo&>(fileInfo);
+int64_t HTTPFileSystem::seek(common::FileInfo& fileInfo, uint64_t offset, int whence) const {
+    auto& httpFileInfo = fileInfo.cast<HTTPFileInfo>();
+    if (httpFileInfo.cachedFileInfo != nullptr) {
+        httpFileInfo.cachedFileInfo->seek(offset, whence);
+        return offset;
+    }
     httpFileInfo.fileOffset = offset;
     return offset;
 }
 
 uint64_t HTTPFileSystem::getFileSize(const common::FileInfo& fileInfo) const {
-    auto& httpFileInfo = ku_dynamic_cast<const FileInfo&, const HTTPFileInfo&>(fileInfo);
+    auto& httpFileInfo = fileInfo.constCast<HTTPFileInfo>();
+    if (httpFileInfo.cachedFileInfo != nullptr) {
+        return httpFileInfo.cachedFileInfo->getFileSize();
+    }
     return httpFileInfo.length;
 }
 

--- a/extension/httpfs/src/include/httpfs.h
+++ b/extension/httpfs/src/include/httpfs.h
@@ -42,6 +42,8 @@ struct HTTPFileInfo : public common::FileInfo {
 
     virtual void initializeClient();
 
+    void initMetadata();
+
     // We keep a http client stored for connection reuse with keep-alive headers.
     std::unique_ptr<httplib::Client> httpClient;
 

--- a/src/include/common/file_system/file_info.h
+++ b/src/include/common/file_system/file_info.h
@@ -41,6 +41,16 @@ struct KUZU_API FileInfo {
         return common::ku_dynamic_cast<const FileInfo*, const TARGET*>(this);
     }
 
+    template<class TARGET>
+    const TARGET& constCast() const {
+        return common::ku_dynamic_cast<const FileInfo&, const TARGET&>(*this);
+    }
+
+    template<class TARGET>
+    TARGET& cast() {
+        return common::ku_dynamic_cast<FileInfo&, TARGET&>(*this);
+    }
+
     const std::string path;
 
     FileSystem* fileSystem;


### PR DESCRIPTION
# Description

This PR improves the http file cache performance by avoiding retriving the metadata information if the file cache is present.

Solves #4010 

# Performance number:
We run the same query twice in the same transaction:
`load from 's3://kuzu-test/dataset/ldbc10/comment_0_0.csv'(header=true,delim='|') return *;`
LDBC10: 2.1 GB
This branch:
| Run ID | compiling time | execution time | total time |
| -------- | ------- |------- |------- |
| 1 | 27.32s | 0.846s | 28.166 s |
| 2 | < 1ms | 0.812s | 0.812 s |


Master:
| Run ID | compiling time | execution time | total time |
| -------- | ------- |------- |------- |
| 1 | 27.05s | 4.59s | 31.64 s |
| 2 | 0.249s | 4.367s | 5.616 s |