### PR TITLE
list lambda body support use parameter more than once

### DIFF
--- a/extension/json/third_party/yyjson/src/yyjson.c
+++ b/extension/json/third_party/yyjson/src/yyjson.c
@@ -323,31 +323,21 @@ uint32_t yyjson_version(void) {
  *============================================================================*/
 
 /* Macros used for loop unrolling and other purpose. */
-#define repeat2(x)                                                                                 \
-    { x x }
-#define repeat3(x)                                                                                 \
-    { x x x }
-#define repeat4(x)                                                                                 \
-    { x x x x }
-#define repeat8(x)                                                                                 \
-    { x x x x x x x x }
-#define repeat16(x)                                                                                \
-    { x x x x x x x x x x x x x x x x }
+#define repeat2(x) {x x}
+#define repeat3(x) {x x x}
+#define repeat4(x) {x x x x}
+#define repeat8(x) {x x x x x x x x}
+#define repeat16(x) {x x x x x x x x x x x x x x x x}
 
-#define repeat2_incr(x)                                                                            \
-    { x(0) x(1) }
-#define repeat4_incr(x)                                                                            \
-    { x(0) x(1) x(2) x(3) }
-#define repeat8_incr(x)                                                                            \
-    { x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) }
+#define repeat2_incr(x) {x(0) x(1)}
+#define repeat4_incr(x) {x(0) x(1) x(2) x(3)}
+#define repeat8_incr(x) {x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7)}
 #define repeat16_incr(x)                                                                           \
-    { x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15) }
+    {x(0) x(1) x(2) x(3) x(4) x(5) x(6) x(7) x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15)}
 
 #define repeat_in_1_18(x)                                                                          \
-    {                                                                                              \
-        x(1) x(2) x(3) x(4) x(5) x(6) x(7) x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15) x(16)     \
-            x(17) x(18)                                                                            \
-    }
+    {x(1) x(2) x(3) x(4) x(5) x(6) x(7) x(8) x(9) x(10) x(11) x(12) x(13) x(14) x(15) x(16) x(17)  \
+            x(18)}
 
 /* Macros used to provide branch prediction information for compiler. */
 #undef likely

--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -41,8 +41,8 @@ void ListLambdaEvaluator::init(const ResultSet& resultSet, ClientContext* client
     resolveResultVector(resultSet, clientContext->getMemoryManager());
     params.push_back(children[0]->resultVector);
     params.push_back(lambdaRootEvaluator->resultVector);
-    bindData =
-        ListLambdaBindData{lambdaParamEvaluators, varNames, lambdaRootEvaluator.get()};
+    auto indexInVar = getIndexInVars();
+    bindData = ListLambdaBindData{lambdaParamEvaluators, indexInVar, lambdaRootEvaluator.get()};
 }
 
 void ListLambdaEvaluator::evaluate() {

--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -29,7 +29,7 @@ void ListLambdaEvaluator::init(const ResultSet& resultSet, ClientContext* client
         // For list_reduce:
         // We should create two vectors for each lambda variable resultVector since we are going to
         // update the list elements during execution.
-        evaluator->resultVector = evaluators.size() == 1 ?
+        evaluator->resultVector = listLambdaType != ListLambdaType::LIST_REDUCE ?
                                       ListVector::getSharedDataVector(listInputVector) :
                                       std::make_shared<ValueVector>(
                                           ListType::getChildType(listInputVector->dataType).copy(),
@@ -41,7 +41,8 @@ void ListLambdaEvaluator::init(const ResultSet& resultSet, ClientContext* client
     resolveResultVector(resultSet, clientContext->getMemoryManager());
     params.push_back(children[0]->resultVector);
     params.push_back(lambdaRootEvaluator->resultVector);
-    bindData = ListLambdaBindData{lambdaParamEvaluators, lambdaRootEvaluator.get()};
+    bindData =
+        ListLambdaBindData{lambdaParamEvaluators, varNames, lambdaRootEvaluator.get()};
 }
 
 void ListLambdaEvaluator::evaluate() {
@@ -59,6 +60,18 @@ void ListLambdaEvaluator::resolveResultVector(const ResultSet&, MemoryManager* m
         ListVector::setDataVector(resultVector.get(), lambdaRootEvaluator->resultVector);
     }
     isResultFlat_ = children[0]->isResultFlat();
+}
+
+ListLambdaType ListLambdaEvaluator::checkListLambdaTypeWithFunctionName(std::string functionName) {
+    if (0 == functionName.compare(function::ListTransformFunction::name)) {
+        return ListLambdaType::LIST_TRANSFORM;
+    } else if (0 == functionName.compare(function::ListFilterFunction::name)) {
+        return ListLambdaType::LIST_FILTER;
+    } else if (0 == functionName.compare(function::ListReduceFunction::name)) {
+        return ListLambdaType::LIST_REDUCE;
+    } else {
+        return ListLambdaType::DEFAULT;
+    }
 }
 
 } // namespace evaluator

--- a/src/expression_evaluator/lambda_evaluator.cpp
+++ b/src/expression_evaluator/lambda_evaluator.cpp
@@ -41,8 +41,8 @@ void ListLambdaEvaluator::init(const ResultSet& resultSet, ClientContext* client
     resolveResultVector(resultSet, clientContext->getMemoryManager());
     params.push_back(children[0]->resultVector);
     params.push_back(lambdaRootEvaluator->resultVector);
-    auto indexInVar = getIndexInVars();
-    bindData = ListLambdaBindData{lambdaParamEvaluators, indexInVar, lambdaRootEvaluator.get()};
+    auto paramIndices = getParamIndices();
+    bindData = ListLambdaBindData{lambdaParamEvaluators, paramIndices, lambdaRootEvaluator.get()};
 }
 
 void ListLambdaEvaluator::evaluate() {
@@ -61,7 +61,26 @@ void ListLambdaEvaluator::resolveResultVector(const ResultSet&, MemoryManager* m
     }
     isResultFlat_ = children[0]->isResultFlat();
 }
-
+std::vector<common::idx_t> ListLambdaEvaluator::getParamIndices() {
+    const auto& paramNames = getExpression()
+                                 ->getChild(1)
+                                 ->constCast<binder::LambdaExpression>()
+                                 .getParsedLambdaExpr()
+                                 ->constCast<parser::ParsedLambdaExpression>()
+                                 .getVarNames();
+    std::vector<common::idx_t> index(lambdaParamEvaluators.size());
+    for (common::idx_t i = 0; i < lambdaParamEvaluators.size(); i++) {
+        auto paramName = lambdaParamEvaluators[i]->getVarName();
+        auto it = std::find(paramNames.begin(), paramNames.end(), paramName);
+        if (it != paramNames.end()) {
+            index[i] = it - paramNames.begin();
+        } else {
+            throw common::RuntimeException(
+                common::stringFormat("Lambda paramName {} cannot found.", paramName));
+        }
+    }
+    return index;
+}
 ListLambdaType ListLambdaEvaluator::checkListLambdaTypeWithFunctionName(std::string functionName) {
     if (0 == functionName.compare(function::ListTransformFunction::name)) {
         return ListLambdaType::LIST_TRANSFORM;

--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -39,21 +39,20 @@ namespace kuzu {
 namespace function {
 
 #define SCALAR_FUNCTION_BASE(_PARAM, _NAME)                                                        \
-    { _PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _NAME, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 #define SCALAR_FUNCTION(_PARAM) SCALAR_FUNCTION_BASE(_PARAM, _PARAM::name)
 #define SCALAR_FUNCTION_ALIAS(_PARAM) SCALAR_FUNCTION_BASE(_PARAM::alias, _PARAM::name)
 #define REWRITE_FUNCTION(_PARAM)                                                                   \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::REWRITE_FUNCTION_ENTRY}
 #define AGGREGATE_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::AGGREGATE_FUNCTION_ENTRY}
 #define EXPORT_FUNCTION(_PARAM)                                                                    \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::COPY_FUNCTION_ENTRY}
 #define TABLE_FUNCTION(_PARAM)                                                                     \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::TABLE_FUNCTION_ENTRY}
 #define ALGORITHM_FUNCTION(_PARAM)                                                                 \
-    { _PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY }
-#define FINAL_FUNCTION                                                                             \
-    { nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY }
+    {_PARAM::getFunctionSet, _PARAM::name, CatalogEntryType::GDS_FUNCTION_ENTRY}
+#define FINAL_FUNCTION {nullptr, nullptr, CatalogEntryType::SCALAR_FUNCTION_ENTRY}
 
 FunctionCollection* FunctionCollection::getFunctions() {
     static FunctionCollection functions[] = {

--- a/src/function/list/list_filter.cpp
+++ b/src/function/list/list_filter.cpp
@@ -42,9 +42,8 @@ static void execFunc(const std::vector<std::shared_ptr<ValueVector>>& input, Val
     auto listLambdaBindData = reinterpret_cast<evaluator::ListLambdaBindData*>(bindData);
     auto inputVector = input[0].get();
     auto listSize = ListVector::getDataVectorSize(inputVector);
-    if (!listLambdaBindData->lambdaParamEvaluators.empty()) {
-        auto lambdaParamVector = listLambdaBindData->lambdaParamEvaluators[0]->resultVector.get();
-        lambdaParamVector->state->getSelVectorUnsafe().setSelSize(listSize);
+    for (auto& lambdaParam : listLambdaBindData->lambdaParamEvaluators) {
+        lambdaParam->resultVector.get()->state->getSelVectorUnsafe().setSelSize(listSize);
     }
     listLambdaBindData->rootEvaluator->evaluate();
     KU_ASSERT(input.size() == 2);

--- a/src/function/list/list_reduce.cpp
+++ b/src/function/list/list_reduce.cpp
@@ -22,27 +22,15 @@ static std::unique_ptr<FunctionBindData> bindFunc(ScalarBindFuncInput input) {
         ListType::getChildType(input.arguments[0]->getDataType()).copy());
 }
 
-static uint32_t findIndex(const std::vector<std::string>& strings, const std::string& str) {
-    auto it = std::find(strings.begin(), strings.end(), str);
-    if (it != strings.end()) {
-        return it - strings.begin();
-    } else {
-        throw common::RuntimeException{"list_reduce lambda var name cannot found."};
-    }
-}
-
 static void reduceList(const list_entry_t& listEntry, uint64_t pos, common::ValueVector& result,
     common::ValueVector& inputDataVector, const common::ValueVector& tmpResultVector,
     evaluator::ListLambdaBindData& bindData) {
+    const auto& indexInVars = bindData.indexInVars;
     std::vector<ValueVector*> params(bindData.lambdaParamEvaluators.size());
-    std::vector<uint32_t> indexInVars(bindData.lambdaParamEvaluators.size());
-    for (uint32_t i = 0; i < bindData.lambdaParamEvaluators.size(); i++) {
+    for (auto i = 0u; i < bindData.lambdaParamEvaluators.size(); i++) {
         auto param = bindData.lambdaParamEvaluators[i]->resultVector.get();
         params[i] = param;
-        indexInVars[i] =
-            findIndex(bindData.varNames, bindData.lambdaParamEvaluators[i]->getVarName());
     }
-
     auto paramPos = params[0]->state->getSelVector()[0];
     auto tmpResultPos = tmpResultVector.state->getSelVector()[0];
     if (listEntry.size == 0) {

--- a/src/function/list/list_reduce.cpp
+++ b/src/function/list/list_reduce.cpp
@@ -25,7 +25,7 @@ static std::unique_ptr<FunctionBindData> bindFunc(ScalarBindFuncInput input) {
 static void reduceList(const list_entry_t& listEntry, uint64_t pos, common::ValueVector& result,
     common::ValueVector& inputDataVector, const common::ValueVector& tmpResultVector,
     evaluator::ListLambdaBindData& bindData) {
-    const auto& indexInVars = bindData.indexInVars;
+    const auto& paramIndices = bindData.paramIndices;
     std::vector<ValueVector*> params(bindData.lambdaParamEvaluators.size());
     for (auto i = 0u; i < bindData.lambdaParamEvaluators.size(); i++) {
         auto param = bindData.lambdaParamEvaluators[i]->resultVector.get();
@@ -42,11 +42,11 @@ static void reduceList(const list_entry_t& listEntry, uint64_t pos, common::Valu
     } else {
         for (auto j = 0u; j < listEntry.size - 1; j++) {
             for (auto k = 0u; k < params.size(); k++) {
-                if (0u == indexInVars[k] && 0u != j) {
+                if (0u == paramIndices[k] && 0u != j) {
                     params[k]->copyFromVectorData(paramPos, &tmpResultVector, tmpResultPos);
                 } else {
                     params[k]->copyFromVectorData(paramPos, &inputDataVector,
-                        listEntry.offset + j + indexInVars[k]);
+                        listEntry.offset + j + paramIndices[k]);
                 }
                 params[k]->state->getSelVectorUnsafe().setSelSize(1);
             }

--- a/src/function/list/list_transform.cpp
+++ b/src/function/list/list_transform.cpp
@@ -26,9 +26,9 @@ static void execFunc(const std::vector<std::shared_ptr<common::ValueVector>>& in
     auto listLambdaBindData = reinterpret_cast<evaluator::ListLambdaBindData*>(bindData);
     auto inputVector = input[0].get();
     auto listSize = ListVector::getDataVectorSize(inputVector);
-    if (!listLambdaBindData->lambdaParamEvaluators.empty()) {
-        auto lambdaParamVector = listLambdaBindData->lambdaParamEvaluators[0]->resultVector.get();
-        lambdaParamVector->state->getSelVectorUnsafe().setSelSize(listSize);
+    for (auto& lambdaParamEvaluator : listLambdaBindData->lambdaParamEvaluators) {
+        auto param = lambdaParamEvaluator->resultVector.get();
+        param->state->getSelVectorUnsafe().setSelSize(listSize);
     }
     listLambdaBindData->rootEvaluator->evaluate();
     KU_ASSERT(input.size() == 2);

--- a/src/include/common/data_chunk/data_chunk.h
+++ b/src/include/common/data_chunk/data_chunk.h
@@ -21,7 +21,7 @@ class DataChunk {
 public:
     DataChunk() : DataChunk{0} {}
     explicit DataChunk(uint32_t numValueVectors)
-        : DataChunk(numValueVectors, std::make_shared<DataChunkState>()){};
+        : DataChunk(numValueVectors, std::make_shared<DataChunkState>()) {};
 
     DataChunk(uint32_t numValueVectors, const std::shared_ptr<DataChunkState>& state)
         : valueVectors(numValueVectors), state{state} {};

--- a/src/include/common/exception/binder.h
+++ b/src/include/common/exception/binder.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API BinderException : public Exception {
 public:
-    explicit BinderException(const std::string& msg) : Exception("Binder exception: " + msg){};
+    explicit BinderException(const std::string& msg) : Exception("Binder exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/buffer_manager.h
+++ b/src/include/common/exception/buffer_manager.h
@@ -9,7 +9,7 @@ namespace common {
 class KUZU_API BufferManagerException : public Exception {
 public:
     explicit BufferManagerException(const std::string& msg)
-        : Exception("Buffer manager exception: " + msg){};
+        : Exception("Buffer manager exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/catalog.h
+++ b/src/include/common/exception/catalog.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API CatalogException : public Exception {
 public:
-    explicit CatalogException(const std::string& msg) : Exception("Catalog exception: " + msg){};
+    explicit CatalogException(const std::string& msg) : Exception("Catalog exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/connection.h
+++ b/src/include/common/exception/connection.h
@@ -9,7 +9,7 @@ namespace common {
 class KUZU_API ConnectionException : public Exception {
 public:
     explicit ConnectionException(const std::string& msg)
-        : Exception("Connection exception: " + msg){};
+        : Exception("Connection exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/copy.h
+++ b/src/include/common/exception/copy.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API CopyException : public Exception {
 public:
-    explicit CopyException(const std::string& msg) : Exception("Copy exception: " + msg){};
+    explicit CopyException(const std::string& msg) : Exception("Copy exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/internal.h
+++ b/src/include/common/exception/internal.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API InternalException : public Exception {
 public:
-    explicit InternalException(const std::string& msg) : Exception(msg){};
+    explicit InternalException(const std::string& msg) : Exception(msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/interrupt.h
+++ b/src/include/common/exception/interrupt.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API InterruptException : public Exception {
 public:
-    explicit InterruptException() : Exception("Interrupted."){};
+    explicit InterruptException() : Exception("Interrupted.") {};
 };
 
 } // namespace common

--- a/src/include/common/exception/not_implemented.h
+++ b/src/include/common/exception/not_implemented.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API NotImplementedException : public Exception {
 public:
-    explicit NotImplementedException(const std::string& msg) : Exception(msg){};
+    explicit NotImplementedException(const std::string& msg) : Exception(msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/parser.h
+++ b/src/include/common/exception/parser.h
@@ -10,7 +10,7 @@ class KUZU_API ParserException : public Exception {
 public:
     static constexpr const char* ERROR_PREFIX = "Parser exception: ";
 
-    explicit ParserException(const std::string& msg) : Exception(ERROR_PREFIX + msg){};
+    explicit ParserException(const std::string& msg) : Exception(ERROR_PREFIX + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/runtime.h
+++ b/src/include/common/exception/runtime.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API RuntimeException : public Exception {
 public:
-    explicit RuntimeException(const std::string& msg) : Exception("Runtime exception: " + msg){};
+    explicit RuntimeException(const std::string& msg) : Exception("Runtime exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/storage.h
+++ b/src/include/common/exception/storage.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API StorageException : public Exception {
 public:
-    explicit StorageException(const std::string& msg) : Exception("Storage exception: " + msg){};
+    explicit StorageException(const std::string& msg) : Exception("Storage exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/test.h
+++ b/src/include/common/exception/test.h
@@ -7,7 +7,7 @@ namespace common {
 
 class TestException : public Exception {
 public:
-    explicit TestException(const std::string& msg) : Exception("Test exception: " + msg){};
+    explicit TestException(const std::string& msg) : Exception("Test exception: " + msg) {};
 };
 
 } // namespace common

--- a/src/include/common/exception/transaction_manager.h
+++ b/src/include/common/exception/transaction_manager.h
@@ -8,7 +8,7 @@ namespace common {
 
 class KUZU_API TransactionManagerException : public Exception {
 public:
-    explicit TransactionManagerException(const std::string& msg) : Exception(msg){};
+    explicit TransactionManagerException(const std::string& msg) : Exception(msg) {};
 };
 
 } // namespace common

--- a/src/include/common/static_vector.h
+++ b/src/include/common/static_vector.h
@@ -29,7 +29,7 @@ class StaticVector {
     }
 
 public:
-    StaticVector() : len(0){};
+    StaticVector() : len(0) {};
     StaticVector(StaticVector&& other) : len(other.len) {
         std::uninitialized_move(other.begin(), other.end(), begin());
         other.len = 0;

--- a/src/include/expression_evaluator/lambda_evaluator.h
+++ b/src/include/expression_evaluator/lambda_evaluator.h
@@ -38,7 +38,7 @@ protected:
 
 struct ListLambdaBindData {
     std::vector<LambdaParamEvaluator*> lambdaParamEvaluators;
-    std::vector<common::idx_t> indexInVars;
+    std::vector<common::idx_t> paramIndices;
     ExpressionEvaluator* rootEvaluator;
 };
 
@@ -74,26 +74,7 @@ public:
         return result;
     }
 
-    std::vector<common::idx_t> getIndexInVars() {
-        const auto& paramNames = getExpression()
-                                   ->getChild(1)
-                                   ->constCast<binder::LambdaExpression>()
-                                   .getParsedLambdaExpr()
-                                   ->constCast<parser::ParsedLambdaExpression>()
-                                   .getVarNames();
-        std::vector<common::idx_t> index(lambdaParamEvaluators.size());
-        for (common::idx_t i = 0; i < lambdaParamEvaluators.size(); i++) {
-            auto paramName = lambdaParamEvaluators[i]->getVarName();
-            auto it = std::find(paramNames.begin(), paramNames.end(), paramName);
-            if (it != paramNames.end()) {
-                index[i] = it - paramNames.begin();
-            } else {
-                throw common::RuntimeException(
-                    common::stringFormat("Lambda paramName {} cannot found.", paramName));
-            }
-        }
-        return index;
-    }
+    std::vector<common::idx_t> getParamIndices();
 
 protected:
     void resolveResultVector(const processor::ResultSet& resultSet,

--- a/src/include/processor/operator/persistent/reader/parquet/boolean_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/boolean_column_reader.h
@@ -18,7 +18,7 @@ public:
         uint64_t maxRepeat)
         : TemplatedColumnReader<bool, BooleanParquetValueConversion>(reader, std::move(type),
               schema, schemaIdx, maxDefine, maxRepeat),
-          bytePos(0){};
+          bytePos(0) {};
 
     uint8_t bytePos;
 

--- a/src/include/processor/operator/persistent/reader/parquet/interval_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/interval_column_reader.h
@@ -29,7 +29,7 @@ public:
         const kuzu_parquet::format::SchemaElement& schema, uint64_t fileIdx, uint64_t maxDefine,
         uint64_t maxRepeat)
         : TemplatedColumnReader<common::interval_t, IntervalValueConversion>(reader,
-              std::move(type), schema, fileIdx, maxDefine, maxRepeat){};
+              std::move(type), schema, fileIdx, maxDefine, maxRepeat) {};
 
 protected:
     void dictionary(const std::shared_ptr<ResizeableBuffer>& dictionaryData,

--- a/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/templated_column_reader.h
@@ -31,7 +31,7 @@ public:
     TemplatedColumnReader(ParquetReader& reader, common::LogicalType type,
         const kuzu_parquet::format::SchemaElement& schema, uint64_t schemaIdx, uint64_t maxDefine,
         uint64_t maxRepeat)
-        : ColumnReader(reader, std::move(type), schema, schemaIdx, maxDefine, maxRepeat){};
+        : ColumnReader(reader, std::move(type), schema, schemaIdx, maxDefine, maxRepeat) {};
 
     std::shared_ptr<ResizeableBuffer> dict;
 

--- a/src/include/processor/operator/persistent/reader/parquet/thrift_tools.h
+++ b/src/include/processor/operator/persistent/reader/parquet/thrift_tools.h
@@ -12,7 +12,7 @@ namespace processor {
 
 // A ReadHead for prefetching data in a specific range
 struct ReadHead {
-    ReadHead(uint64_t location, uint64_t size) : location(location), size(size){};
+    ReadHead(uint64_t location, uint64_t size) : location(location), size(size) {};
     // Hint info
     uint64_t location;
     uint64_t size;

--- a/src/include/processor/operator/persistent/reader/parquet/uuid_column_reader.h
+++ b/src/include/processor/operator/persistent/reader/parquet/uuid_column_reader.h
@@ -28,7 +28,7 @@ public:
         const kuzu_parquet::format::SchemaElement& schema_p, uint64_t file_idx_p,
         uint64_t maxDefine, uint64_t maxRepeat)
         : TemplatedColumnReader<common::ku_uuid_t, UUIDValueConversion>(reader, std::move(dataType),
-              schema_p, file_idx_p, maxDefine, maxRepeat){};
+              schema_p, file_idx_p, maxDefine, maxRepeat) {};
 
 protected:
     void dictionary(const std::shared_ptr<ResizeableBuffer>& dictionaryData,

--- a/src/main/db_config.cpp
+++ b/src/main/db_config.cpp
@@ -10,7 +10,7 @@ namespace kuzu {
 namespace main {
 
 #define GET_CONFIGURATION(_PARAM)                                                                  \
-    { _PARAM::name, _PARAM::inputType, _PARAM::setContext, _PARAM::getSetting }
+    {_PARAM::name, _PARAM::inputType, _PARAM::setContext, _PARAM::getSetting}
 
 static ConfigurationOption options[] = { // NOLINT(cert-err58-cpp):
     GET_CONFIGURATION(ThreadsSetting), GET_CONFIGURATION(TimeoutSetting),

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -153,9 +153,6 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getFunctionEvaluator(
         auto& lambdaExpr = expression->getChild(1)->constCast<LambdaExpression>();
         result->setLambdaRootEvaluator(
             recursiveExprMapper.getEvaluator(lambdaExpr.getFunctionExpr()));
-        result->setVarNames(lambdaExpr.getParsedLambdaExpr()
-                ->constCast<parser::ParsedLambdaExpression>()
-                .getVarNames());
         return result;
     }
     childrenEvaluators = getEvaluators(expression->getChildren());

--- a/src/processor/map/expression_mapper.cpp
+++ b/src/processor/map/expression_mapper.cpp
@@ -17,6 +17,7 @@
 #include "expression_evaluator/path_evaluator.h"
 #include "expression_evaluator/pattern_evaluator.h"
 #include "expression_evaluator/reference_evaluator.h"
+#include "parser/expression/parsed_lambda_expression.h"
 #include "planner/operator/schema.h"
 
 using namespace kuzu::binder;
@@ -152,6 +153,9 @@ std::unique_ptr<ExpressionEvaluator> ExpressionMapper::getFunctionEvaluator(
         auto& lambdaExpr = expression->getChild(1)->constCast<LambdaExpression>();
         result->setLambdaRootEvaluator(
             recursiveExprMapper.getEvaluator(lambdaExpr.getFunctionExpr()));
+        result->setVarNames(lambdaExpr.getParsedLambdaExpr()
+                ->constCast<parser::ParsedLambdaExpression>()
+                .getVarNames());
         return result;
     }
     childrenEvaluators = getEvaluators(expression->getChildren());

--- a/test/test_files/function/lambda/list_filter.test
+++ b/test/test_files/function/lambda/list_filter.test
@@ -69,3 +69,16 @@ Binder exception: LIST_FILTER requires the result type of lambda expression be B
 [Fesdwe]
 [Grad]
 [Wolfeschlegelstein,Daniel]
+-STATEMENT RETURN LIST_FILTER(['Duckdb', 'Alice', 'kuzu', 'long long string'], x -> size(x) > 4 and size(x) < 6)
+---- 1
+[Alice]
+-STATEMENT MATCH (a:person) RETURN LIST_FILTER(a.workedHours, x->x > 5 and x<=10)
+---- 8
+[10]
+[8]
+[]
+[9]
+[]
+[6,7]
+[]
+[10,6,7]

--- a/test/test_files/function/lambda/list_reduce.test
+++ b/test/test_files/function/lambda/list_reduce.test
@@ -44,3 +44,12 @@ Runtime exception: Cannot execute list_reduce on an empty list.
 -STATEMENT RETURN LIST_REDUCE([null, 52, 223], (x, y) -> x + y)
 ---- 1
 
+-STATEMENT RETURN LIST_REDUCE(['a:', 'b:', 'c:', 'd:'], (x, y) -> y+x)
+---- 1
+d:c:b:a:
+-STATEMENT RETURN LIST_REDUCE(['a:', 'b:', 'c:', 'd:'], (x, y) -> x+y+x)
+---- 1
+a:b:a:c:a:b:a:d:a:b:a:c:a:b:a:
+-STATEMENT RETURN LIST_REDUCE(['a:', 'b:', 'c:', 'd:'], (x, y) -> y+x+y)
+---- 1
+d:c:b:a:b:c:d:

--- a/test/test_files/function/lambda/list_transform.test
+++ b/test/test_files/function/lambda/list_transform.test
@@ -77,3 +77,16 @@ Binder exception: The second argument of LIST_TRANSFORM should be a lambda expre
 [500]
 [500]
 [500]
+-STATEMENT MATCH (a:person) RETURN LIST_TRANSFORM(a.workedHours, x->x+x+2)
+---- 8
+[22,12]
+[26,18]
+[10,12]
+[4,20]
+[6]
+[8,10,12,14,16]
+[4]
+[22,24,26,8,10,12,14,16]
+-STATEMENT RETURN LIST_TRANSFORM(['KUZU', 'DUCKDB', 'NEO4J'], x-> size(x)+size(x))
+---- 1
+[8,12,10]

--- a/tools/shell/include/output.h
+++ b/tools/shell/include/output.h
@@ -91,7 +91,7 @@ struct BaseTableDrawingCharacters : public DrawingCharacters {
     bool Types = true;
 
 protected:
-    explicit BaseTableDrawingCharacters(PrintType pt) : DrawingCharacters(pt){};
+    explicit BaseTableDrawingCharacters(PrintType pt) : DrawingCharacters(pt) {};
 };
 
 struct BoxDrawingCharacters : public BaseTableDrawingCharacters {


### PR DESCRIPTION
# Description

lambda body support use parameter more than once
for list_filter, list_transform:
the lambda only has one parameter name support: x->x+x, x->x>1 and x<5
for list_reduce:
the lambda has two parameters, the parameter on the left indicates the first element in the list or the result of the previous reduce operation, the right one is just the subsequent element in the list.
e.g. RETURN LIST_REDUCE(['a:', 'b:', 'c:', 'd:'], (x, y) -> y+x) 
result is d:c:b:a:

I have read and agree to the terms under [CLA.md](https://github.com/kuzudb/kuzu/blob/master/CLA.md).