### PR TITLE
Load httpfs and duckdb extension from local

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -398,7 +398,7 @@ jobs:
     strategy:
       matrix:
         page_size_log2: [16, 18]
-    name: clang build & test with page size log2 ${{ matrix.page_size_log2 }}
+    name: clang build & test with page size log2=${{ matrix.page_size_log2 }}
     needs: [clang-build-test]
     runs-on: kuzu-self-hosted-testing
     env:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -152,7 +152,7 @@ jobs:
         working-directory: tools/nodejs_api
       
       - name: Build httpfs
-        run: make extension-httpfs-release
+        run: make extension-for-test
 
       - name: Test
         run: |
@@ -210,7 +210,7 @@ jobs:
         run: sudo apt-get install -y lcov
       
       - name: Build httpfs
-        run: make extension-httpfs-release
+        run: make extension-for-test
 
       - name: Test with coverage
         run: make lcov NUM_THREADS=$(nproc)
@@ -258,7 +258,7 @@ jobs:
 
       - name: Build & Test
         run: |
-          docker exec kuzu-x86 make extension-httpfs-release NUM_THREADS=$(nproc)
+          docker exec kuzu-x86 make extension-for-test NUM_THREADS=$(nproc)
           docker exec --env USE_EXISTING_BINARY_DATASET=1 kuzu-x86 make test NUM_THREADS=$(nproc)
 
       - name: Stop Docker container
@@ -314,7 +314,7 @@ jobs:
         working-directory: tools/nodejs_api
       
       - name: Build httpfs
-        run: make extension-httpfs-release
+        run: make extension-for-test
 
       - name: Test with ASAN
         run: make test ASAN=1
@@ -364,7 +364,7 @@ jobs:
         working-directory: tools/nodejs_api
       
       - name: Build httpfs
-        run: make extension-httpfs-release
+        run: make extension-for-test
 
       - name: Test
         run: |
@@ -433,7 +433,7 @@ jobs:
           make release PAGE_SIZE_LOG2=${{ matrix.page_size_log2 }}
 
       - name: Build httpfs
-        run: make extension-httpfs-release
+        run: make extension-for-test
   
       - name: Generate binary demo
         run: |
@@ -489,7 +489,7 @@ jobs:
           make all GEN="Visual Studio 17 2022"
       
       - name: Build httpfs
-        run: make extension-httpfs-release
+        run: make extension-for-test
 
       - name: Test
         shell: cmd
@@ -729,7 +729,7 @@ jobs:
         working-directory: tools/nodejs_api
       
       - name: Build httpfs
-        run: make extension-httpfs-release
+        run: make extension-for-test
 
       - name: Test
         run: |

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -150,6 +150,9 @@ jobs:
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
+      
+      - name: Build httpfs
+        run: make extension-httpfs-release
 
       - name: Test
         run: |
@@ -205,6 +208,9 @@ jobs:
 
       - name: Install lcov
         run: sudo apt-get install -y lcov
+      
+      - name: Build httpfs
+        run: make extension-httpfs-release
 
       - name: Test with coverage
         run: make lcov NUM_THREADS=$(nproc)
@@ -252,6 +258,7 @@ jobs:
 
       - name: Build & Test
         run: |
+          docker exec kuzu-x86 make extension-httpfs-release NUM_THREADS=$(nproc)
           docker exec --env USE_EXISTING_BINARY_DATASET=1 kuzu-x86 make test NUM_THREADS=$(nproc)
 
       - name: Stop Docker container
@@ -305,6 +312,9 @@ jobs:
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
+      
+      - name: Build httpfs
+        run: make extension-httpfs-release
 
       - name: Test with ASAN
         run: make test ASAN=1
@@ -352,6 +362,9 @@ jobs:
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
+      
+      - name: Build httpfs
+        run: make extension-httpfs-release
 
       - name: Test
         run: |
@@ -381,8 +394,11 @@ jobs:
           KUZU_LIBRARY_DIR: ${{ github.workspace }}/build/release/src
         run: cargo test --profile=relwithdebinfo --locked --features arrow -- --test-threads=12
 
-  clang-build-test-64KB-page-size:
-    name: clang build & test with page size 64KB
+  clang-build-test-various-page-sizes:
+    strategy:
+      matrix:
+        page_size_log2: [16, 18]
+    name: clang build & test with page size log2 ${{ matrix.page_size_log2 }}
     needs: [clang-build-test]
     runs-on: kuzu-self-hosted-testing
     env:
@@ -414,58 +430,18 @@ jobs:
       - name: Build
         run: |
           ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
-          make release PAGE_SIZE_LOG2=16
+          make release PAGE_SIZE_LOG2=${{ matrix.page_size_log2 }}
 
+      - name: Build httpfs
+        run: make extension-httpfs-release
+  
       - name: Generate binary demo
         run: |
           bash scripts/generate_binary_demo.sh
 
       - name: Test
         run: |
-          make test PAGE_SIZE_LOG2=16
-
-  clang-build-test-256KB-page-size:
-    name: clang build & test with page size 256KB
-    needs: [clang-build-test]
-    runs-on: kuzu-self-hosted-testing
-    env:
-      NUM_THREADS: 32
-      CMAKE_BUILD_PARALLEL_LEVEL: 32
-      TEST_JOBS: 16
-      CC: clang
-      CXX: clang++
-      UW_S3_ACCESS_KEY_ID: ${{ secrets.UW_S3_ACCESS_KEY_ID }}
-      UW_S3_SECRET_ACCESS_KEY: ${{ secrets.UW_S3_SECRET_ACCESS_KEY }}
-      AWS_S3_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
-      AWS_S3_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_S3_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_S3_SECRET_ACCESS_KEY }}
-      RUN_ID: "$(hostname)-$(date +%s)"
-      HTTP_CACHE_FILE: TRUE
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Ensure Python dependencies
-        run: |
-          pip install torch~=2.2.0 --break-system-package --extra-index-url https://download.pytorch.org/whl/cpu
-          pip install --break-system-package --user -r tools/python_api/requirements_dev.txt -f https://data.pyg.org/whl/torch-2.2.0+cpu.html
-
-      - name: Ensure Node.js dependencies
-        run: npm install --include=dev
-        working-directory: tools/nodejs_api
-
-      - name: Build
-        run: |
-          ln -s /home/runner/ldbc-1-csv dataset/ldbc-1/csv
-          make release PAGE_SIZE_LOG2=18
-
-      - name: Generate binary demo
-        run: |
-          bash scripts/generate_binary_demo.sh
-
-      - name: Test
-        run: |
-          make test PAGE_SIZE_LOG2=18
+          make test PAGE_SIZE_LOG2=${{ matrix.page_size_log2 }}
 
   msvc-build-test:
     name: msvc build & test
@@ -511,6 +487,9 @@ jobs:
         run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
           make all GEN="Visual Studio 17 2022"
+      
+      - name: Build httpfs
+        run: make extension-httpfs-release
 
       - name: Test
         shell: cmd
@@ -748,6 +727,9 @@ jobs:
       - name: Ensure Node.js dependencies
         run: npm install --include=dev
         working-directory: tools/nodejs_api
+      
+      - name: Build httpfs
+        run: make extension-httpfs-release
 
       - name: Test
         run: |

--- a/Makefile
+++ b/Makefile
@@ -184,8 +184,8 @@ extension-json-test-build:
 		-DENABLE_ADDRESS_SANITIZER=TRUE \
 	)
 
-extension-httpfs-release:
-	$(call run-cmake-release, -DBUILD_EXTENSIONS="httpfs")
+extension-for-test:
+	$(call run-cmake-release, -DBUILD_EXTENSIONS="httpfs;duckdb")
 
 extension-test: extension-test-build
 	ctest --test-dir build/release/extension --output-on-failure -j ${TEST_JOBS}

--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ extension-json-test-build:
 	)
 
 extension-httpfs-release:
-	$(call run-cmake-release, -DBUILD_EXTENSIONS="httpfs" -DBUILD_KUZU=FALSE)
+	$(call run-cmake-release, -DBUILD_EXTENSIONS="httpfs")
 
 extension-test: extension-test-build
 	ctest --test-dir build/release/extension --output-on-failure -j ${TEST_JOBS}

--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,9 @@ extension-json-test-build:
 		-DENABLE_ADDRESS_SANITIZER=TRUE \
 	)
 
+extension-httpfs-release:
+	$(call run-cmake-release, -DBUILD_EXTENSIONS="httpfs" -DBUILD_KUZU=FALSE)
+
 extension-test: extension-test-build
 	ctest --test-dir build/release/extension --output-on-failure -j ${TEST_JOBS}
 	aws s3 rm s3://kuzu-dataset-us/${RUN_ID}/ --recursive

--- a/test/test_files/extension/extension.test
+++ b/test/test_files/extension/extension.test
@@ -9,7 +9,7 @@
 -SKIP_MUSL
 -LOG InstallExtension
 -STATEMENT INSTALL httpfs;
-           LOAD EXTENSION httpfs;
+           LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/httpfs/build/libhttpfs.kuzu_extension";
            LOAD FROM 'http://extension.kuzudb.com/dataset/test/city.csv' return *;
 ---- ok
 ---- ok

--- a/test/test_files/extension/show_attached_databases.test
+++ b/test/test_files/extension/show_attached_databases.test
@@ -7,7 +7,7 @@
 -LOG InstallExtension
 -STATEMENT INSTALL duckdb;
 ---- ok
--STATEMENT LOAD EXTENSION duckdb;
+-STATEMENT LOAD EXTENSION "${KUZU_ROOT_DIRECTORY}/extension/duckdb/build/libduckdb.kuzu_extension";
 ---- ok
 -STATEMENT ATTACH '${KUZU_ROOT_DIRECTORY}/dataset/databases/duckdb_database/tinysnb.db' (dbtype duckdb, skip_unsupported_table = true);
 ---- ok

--- a/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
@@ -1,6 +1,7 @@
 package com.kuzudb.java_test;
 
 import com.kuzudb.*;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -11,7 +12,11 @@ public class ExtensionTest extends TestBase {
         KuzuQueryResult result = conn.query("INSTALL httpfs");
         assertTrue(result.isSuccess());
         result.destroy();
-        result = conn.query("LOAD EXTENSION httpfs");
+        String currentDir = System.getProperty("user.dir");
+        Path path = Path.of(currentDir, "../../extension/httpfs/build/libhttpfs.kuzu_extension");
+        Path absPath = path.normalize().toAbsolutePath();
+        result = conn.query("LOAD EXTENSION " + "\"" + absPath + "\"");
+        
         assertTrue(result.isSuccess());
         result.destroy();
     }

--- a/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
@@ -15,6 +15,8 @@ public class ExtensionTest extends TestBase {
         String currentDir = System.getProperty("user.dir");
         Path path = Path.of(currentDir, "../../extension/httpfs/build/libhttpfs.kuzu_extension");
         Path absPath = path.normalize().toAbsolutePath();
+        String absPathStr = absPath.toString();
+        absPathStr = absPathStr.replace("\\", "/");
         result = conn.query("LOAD EXTENSION " + "\"" + absPath + "\"");
         
         assertTrue(result.isSuccess());

--- a/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
@@ -16,7 +16,7 @@ public class ExtensionTest extends TestBase {
         Path path = Path.of(currentDir, "../../extension/httpfs/build/libhttpfs.kuzu_extension");
         Path absPath = path.normalize().toAbsolutePath();
         String absPathStr = absPath.toString();
-        absPathStr = absPathStr.replace("\\", "/");
+        absPathStr = absPathStr.replaceAll("\\", "/");
         result = conn.query("LOAD EXTENSION " + "\"" + absPath + "\"");
         
         assertTrue(result.isSuccess());

--- a/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
@@ -17,7 +17,7 @@ public class ExtensionTest extends TestBase {
         Path absPath = path.normalize().toAbsolutePath();
         String absPathStr = absPath.toString();
         absPathStr = absPathStr.replace("\\", "/");
-        result = conn.query("LOAD EXTENSION " + "\"" + absPath + "\"");
+        result = conn.query("LOAD EXTENSION " + "\"" + absPathStr + "\"");
         
         assertTrue(result.isSuccess());
         result.destroy();

--- a/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
+++ b/tools/java_api/src/test/java/com/kuzudb/test/ExtensionTest.java
@@ -16,7 +16,7 @@ public class ExtensionTest extends TestBase {
         Path path = Path.of(currentDir, "../../extension/httpfs/build/libhttpfs.kuzu_extension");
         Path absPath = path.normalize().toAbsolutePath();
         String absPathStr = absPath.toString();
-        absPathStr = absPathStr.replaceAll("\\", "/");
+        absPathStr = absPathStr.replace("\\", "/");
         result = conn.query("LOAD EXTENSION " + "\"" + absPath + "\"");
         
         assertTrue(result.isSuccess());

--- a/tools/nodejs_api/test/test_extension.js
+++ b/tools/nodejs_api/test/test_extension.js
@@ -1,9 +1,10 @@
 const path = require("path");
 
 describe("Extension loading", () => {
-  const extensionPath = path.resolve(
+  let extensionPath = path.resolve(
     path.join(__dirname, "..", "..", "..", "extension", "httpfs", "build", "libhttpfs.kuzu_extension")
   );
+  extensionPath.replaceAll("\\", "/");
 
   it("should install and load httpfs extension", async function () {
     this.timeout(10000);

--- a/tools/nodejs_api/test/test_extension.js
+++ b/tools/nodejs_api/test/test_extension.js
@@ -4,7 +4,7 @@ describe("Extension loading", () => {
   let extensionPath = path.resolve(
     path.join(__dirname, "..", "..", "..", "extension", "httpfs", "build", "libhttpfs.kuzu_extension")
   );
-  extensionPath.replaceAll("\\", "/");
+  extensionPath = extensionPath.replaceAll("\\", "/");
 
   it("should install and load httpfs extension", async function () {
     this.timeout(10000);

--- a/tools/nodejs_api/test/test_extension.js
+++ b/tools/nodejs_api/test/test_extension.js
@@ -1,9 +1,13 @@
-const { assert } = require("chai");
+const path = require("path");
 
 describe("Extension loading", () => {
+  const extensionPath = path.resolve(
+    path.join(__dirname, "..", "..", "..", "extension", "httpfs", "build", "libhttpfs.kuzu_extension")
+  );
+
   it("should install and load httpfs extension", async function () {
     this.timeout(10000);
     await conn.query("INSTALL httpfs");
-    await conn.query("LOAD EXTENSION httpfs");
+    await conn.query(`LOAD EXTENSION "${extensionPath}"`);
   });
 });

--- a/tools/python_api/test/test_extension.py
+++ b/tools/python_api/test/test_extension.py
@@ -9,8 +9,7 @@ def test_install_and_load_httpfs(conn_db_readonly: ConnDB) -> None:
     )
     httpfs_path = httpfs_path.resolve()
     httpfs_path_str = str(httpfs_path)
-    # Replace single `\` with double `\\` for Windows
-    httpfs_path_str = httpfs_path_str.replace("\\", "\\\\")
+    httpfs_path_str = httpfs_path_str.replace("\\", "/")
     conn, _ = conn_db_readonly
     conn.execute("INSTALL httpfs")
     conn.execute('LOAD EXTENSION "{}"'.format(httpfs_path_str))

--- a/tools/python_api/test/test_extension.py
+++ b/tools/python_api/test/test_extension.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 from type_aliases import ConnDB
-
+import pathlib
 
 def test_install_and_load_httpfs(conn_db_readonly: ConnDB) -> None:
-    conn, db = conn_db_readonly
+    httpfs_path = (
+        pathlib.Path(__file__).parent.parent.parent.parent / "extension" / "httpfs" /  "build" /  "libhttpfs.kuzu_extension"
+    )
+    httpfs_path = httpfs_path.resolve()
+    httpfs_path_str = str(httpfs_path)
+    conn, _ = conn_db_readonly
     conn.execute("INSTALL httpfs")
-    conn.execute("LOAD EXTENSION httpfs")
+    conn.execute('LOAD EXTENSION "{}"'.format(httpfs_path_str))

--- a/tools/python_api/test/test_extension.py
+++ b/tools/python_api/test/test_extension.py
@@ -9,6 +9,8 @@ def test_install_and_load_httpfs(conn_db_readonly: ConnDB) -> None:
     )
     httpfs_path = httpfs_path.resolve()
     httpfs_path_str = str(httpfs_path)
+    # Replace single `\` with double `\\` for Windows
+    httpfs_path_str = httpfs_path_str.replace("\\", "\\\\")
     conn, _ = conn_db_readonly
     conn.execute("INSTALL httpfs")
     conn.execute('LOAD EXTENSION "{}"'.format(httpfs_path_str))


### PR DESCRIPTION
This PR modifies the workflow to load httpfs and duckdb extensions from locally-compiled binaries instead of the server. This should eliminate the need to rebuild extensions for tests. 