### PR TITLE
Fix double-initialization of the NullChunkData buffer

### DIFF
--- a/src/storage/store/column_chunk_data.cpp
+++ b/src/storage/store/column_chunk_data.cpp
@@ -106,9 +106,6 @@ void ColumnChunkData::initializeBuffer(common::PhysicalTypeID physicalType) {
     numBytesPerValue = getDataTypeSizeInChunk(physicalType);
     bufferSize = getBufferSize(capacity);
     buffer = std::make_unique<uint8_t[]>(bufferSize);
-    if (nullData) {
-        nullData->initializeBuffer(physicalType);
-    }
 }
 
 void ColumnChunkData::initializeFunction(bool enableCompression) {


### PR DESCRIPTION
The NullChunkData class also calls initializeBuffer in its constructor