### PR TITLE
Fix race condition causing an infinite loop in the eviction queue

### DIFF
--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -45,7 +45,7 @@ std::atomic<EvictionCandidate>* EvictionQueue::next() {
         // Since the buffer pool size is a power of two (as is the page size), (UINT64_MAX + 1) %
         // size == 0, which means no entries will be skipped when the cursor overflows
         candidate = &data[evictionCursor.fetch_add(1, std::memory_order_relaxed) % capacity];
-    } while (candidate->load() == EMPTY);
+    } while (candidate->load() == EMPTY && size > 0);
     return candidate;
 }
 


### PR DESCRIPTION
Other threads may evict all remaining items in the eviction queue while looping looking for the next item to evict.

I suspect this fixes the issues described in #3743, and is not related to #3459, but I haven't checked.

I noticed this when investigating the CI failure in the 256KB page pipeline. It doesn't fix that failure, but does make it a little easier to reproduce as it was hanging sometimes when I tried to reproduce it.

*this only actually occurs when the page size and thread count is large enough, and the buffer pool size is small enough, that enough threads try to reserve pages simultaneously and have to evict that the entire eviction queue is cleared; so it would have been extremely rare outside of certain tests*