### PR TITLE
Fix the number of threads used in the CSV converter tests

### DIFF
--- a/test/test_runner/csv_converter.cpp
+++ b/test/test_runner/csv_converter.cpp
@@ -181,7 +181,9 @@ void CSVConverter::convertCSVDataset() {
     copySchemaFile();
     createCopyFile();
 
-    systemConfig = std::make_unique<main::SystemConfig>(bufferPoolSize);
+    systemConfig = TestHelper::getSystemConfigFromEnv();
+    // FIXME(bmwinger): This ignores the environment variables
+    systemConfig->bufferPoolSize = bufferPoolSize;
     std::string tempDatabasePath = TestHelper::getTempDir("csv_converter");
     tempDb = std::make_unique<main::Database>(tempDatabasePath, *systemConfig);
     tempConn = std::make_unique<main::Connection>(tempDb.get());


### PR DESCRIPTION
More threads than the default 2 were being used for converting parquet files to CSV, leading to higher than normal memory requirements during the copies (not sure why; I didn't think we were using any memory-manager-backed structures during copies; I'd first run into this in #3743).

This should hide the bug casing the bfs_sssp_parquet test to fail in CI with 256KB pages, though it still needs to be investigated.