### PR TITLE
Add Go API installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,13 @@ Kùzu is available under a permissible license. So try it out and help us make i
 
 | Language | Installation                                                           |
 | -------- |------------------------------------------------------------------------|
-| Python | `pip install kuzu`                                                     |
-| NodeJS | `npm install kuzu`                                                     |
-| Rust   | `cargo add kuzu`                                                       |
-| Java   | [jar file](https://github.com/kuzudb/kuzu/releases/latest)             |
-| C/C++  | [precompiled binaries](https://github.com/kuzudb/kuzu/releases/latest) |
-| CLI    | [precompiled binaries](https://github.com/kuzudb/kuzu/releases/latest) |
+| Python   | `pip install kuzu`                                                     |
+| NodeJS   | `npm install kuzu`                                                     |
+| Rust     | `cargo add kuzu`                                                       |
+| Go       | `go get github.com/kuzudb/go-kuzu`                                     |
+| Java     | [jar file](https://github.com/kuzudb/kuzu/releases/latest)             |
+| C/C++    | [precompiled binaries](https://github.com/kuzudb/kuzu/releases/latest) |
+| CLI      | [precompiled binaries](https://github.com/kuzudb/kuzu/releases/latest) |
 
 To learn more about installation, see our [Installation](https://docs.kuzudb.com/installation) page.
 


### PR DESCRIPTION
# Description

Adding a Go installation command to let users know about our new Go client API.

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).