### PR TITLE
Enable read only DB tests on windows

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -107,7 +107,8 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, int
                             LOCKFILE_FAIL_IMMEDIATELY | LOCKFILE_EXCLUSIVE_LOCK;
         OVERLAPPED overlapped = {0};
         overlapped.Offset = 0;
-        BOOL rc = LockFileEx(handle, dwFlags, 0, 0, 0, &overlapped);
+        BOOL rc = LockFileEx(handle, dwFlags, 0 /*reserved*/, 1 /*numBytesLow*/, 0 /*numBytesHigh*/,
+            &overlapped);
         if (!rc) {
             throw IOException("Could not set lock on file : " + fullPath);
         }

--- a/test/c_api/database_test.cpp
+++ b/test/c_api/database_test.cpp
@@ -24,10 +24,6 @@ TEST_F(CApiDatabaseTest, CreationAndDestroy) {
 }
 
 TEST_F(CApiDatabaseTest, CreationReadOnly) {
-// TODO: Enable this test on Windows when the read-only mode is implemented.
-#ifdef _WIN32
-    return;
-#endif
     kuzu_database database;
     kuzu_connection connection;
     kuzu_query_result queryResult;

--- a/test/main/CMakeLists.txt
+++ b/test/main/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(MSVC)
     add_kuzu_api_test(main_test
+            system_config_test.cpp
             arrow_test.cpp
             connection_test.cpp
             prepare_test.cpp

--- a/test/main/connection_test.cpp
+++ b/test/main/connection_test.cpp
@@ -150,6 +150,7 @@ TEST_F(ApiTest, Prepare) {
 }
 
 TEST_F(ApiTest, CreateTableAfterClosingDatabase) {
+    database.reset();
     database = std::make_unique<Database>(databasePath, *systemConfig);
     conn = std::make_unique<Connection>(database.get());
 

--- a/test/main/system_config_test.cpp
+++ b/test/main/system_config_test.cpp
@@ -5,7 +5,9 @@ using namespace kuzu::common;
 using namespace kuzu::testing;
 using namespace kuzu::main;
 
-class SystemConfigTest : public ApiTest {};
+class SystemConfigTest : public ApiTest {
+    void SetUp() override { BaseGraphTest::SetUp(); }
+};
 
 void assertQuery(QueryResult& result) {
     auto a = result.toString();

--- a/tools/python_api/test/conftest.py
+++ b/tools/python_api/test/conftest.py
@@ -165,11 +165,7 @@ def conn_db_readonly(tmp_path: Path) -> ConnDB:
     """Return a cached read-only connection and database."""
     global _READONLY_CONN_DB_
     if _READONLY_CONN_DB_ is None:
-        # On Windows, the read-only mode is not implemented yet.
-        # Therefore, we create a writable database on Windows.
-        # However, the caller should ensure that the database is not modified.
-        # TODO: Remove this workaround when the read-only mode is implemented on Windows.
-        _READONLY_CONN_DB_ = create_conn_db(init_db(tmp_path), read_only=sys.platform != "win32")
+        _READONLY_CONN_DB_ = create_conn_db(init_db(tmp_path), read_only=True)
     return _READONLY_CONN_DB_
 
 

--- a/tools/python_api/test/test_database.py
+++ b/tools/python_api/test/test_database.py
@@ -35,13 +35,11 @@ def test_database_close(tmp_path: Path, build_dir: Path) -> None:
     assert db._database is not None
 
     # Open the database on a subprocess. It should raise an exception.
-    # TODO: Enable this test on Windows when the read-only mode is implemented.
-    if sys.platform != "win32":
-        with pytest.raises(
-            RuntimeError,
-            match=r"RuntimeError: IO exception: Could not set lock on file",
-        ):
-            open_database_on_subprocess(db_path, build_dir)
+    with pytest.raises(
+        Exception,
+        match=r"RuntimeError: IO exception: Could not set lock on file",
+    ):
+        open_database_on_subprocess(db_path, build_dir)
 
     db.close()
     assert db.is_closed

--- a/tools/python_api/test/test_exception.py
+++ b/tools/python_api/test/test_exception.py
@@ -25,9 +25,6 @@ def test_db_path_exception() -> None:
 
 
 def test_read_only_exception(conn_db_readonly: ConnDB) -> None:
-    # TODO: Enable this test on Windows when the read-only mode is implemented.
-    if sys.platform == "win32":
-        pytest.skip("Read-only mode has not been implemented on Windows yet")
     _, db = conn_db_readonly
     path = db.database_path
     read_only_db = kuzu.Database(path, read_only=True)


### PR DESCRIPTION
Support for this was implemented a while ago (I don't recall exactly when), but evidently these tests were missed.