### PR TITLE
Fixing issue 4129: Unexpected error message when copying from csv files with mismatched num of columns

### DIFF
--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -49,9 +49,9 @@ private:
 class SerialCSVReader;
 
 class SerialParsingDriver : public ParsingDriver {
-    SerialCSVReader* reader;
-
+    
 public:
+    SerialCSVReader* reader;
     SerialParsingDriver(common::DataChunk& chunk, SerialCSVReader* reader);
 
     bool doneEarly() override;
@@ -61,19 +61,17 @@ private:
 };
 
 class SniffCSVNameAndTypeDriver : public SerialParsingDriver {
-    SerialCSVReader* reader;
-    // static common::DataChunk dummyChunk;
 
 public:
     SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
         const function::ScanTableFuncBindInput* bindInput);
 
+    bool done(uint64_t rowNum) const;
+    bool addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);
+
     std::vector<std::pair<std::string, common::LogicalType>> columns;
     std::vector<bool> sniffType;
     // if the type isn't declared in the header, sniff it
-
-    bool done(uint64_t rowNum) const;
-    bool addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);
 };
 
 } // namespace processor

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -62,7 +62,7 @@ private:
 
 class SniffCSVNameAndTypeDriver : public SerialParsingDriver {
     SerialCSVReader* reader;
-    static common::DataChunk dummyChunk;
+    //static common::DataChunk dummyChunk;
 
 public:
     SniffCSVNameAndTypeDriver(SerialCSVReader* reader,

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -63,6 +63,7 @@ struct SniffCSVNameAndTypeDriver {
     std::vector<bool> sniffType;
     // if the type isn't declared in the header, sniff it
     SerialCSVReader* reader;
+    bool rowEmpty = false;
 
     SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
         const function::ScanTableFuncBindInput* bindInput);

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -62,7 +62,7 @@ private:
 
 class SniffCSVNameAndTypeDriver : public SerialParsingDriver {
     SerialCSVReader* reader;
-    //static common::DataChunk dummyChunk;
+    // static common::DataChunk dummyChunk;
 
 public:
     SniffCSVNameAndTypeDriver(SerialCSVReader* reader,

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -15,11 +15,6 @@ namespace processor {
 // TODO(Keenan): Split up this file.
 class BaseCSVReader;
 class ParsingDriver {
-    common::DataChunk& chunk;
-
-protected:
-    bool rowEmpty;
-
 public:
     explicit ParsingDriver(common::DataChunk& chunk);
     virtual ~ParsingDriver() = default;
@@ -31,39 +26,43 @@ public:
 private:
     virtual bool doneEarly() = 0;
     virtual BaseCSVReader* getReader() = 0;
+
+protected:
+    bool rowEmpty;
+
+private:
+    common::DataChunk& chunk;
 };
 
 class ParallelCSVReader;
 
 class ParallelParsingDriver : public ParsingDriver {
-    ParallelCSVReader* reader;
-
 public:
     ParallelParsingDriver(common::DataChunk& chunk, ParallelCSVReader* reader);
     bool doneEarly() override;
 
 private:
     BaseCSVReader* getReader() override;
+
+private:
+    ParallelCSVReader* reader;
 };
 
 class SerialCSVReader;
 
 class SerialParsingDriver : public ParsingDriver {
-
-protected:
-    SerialCSVReader* reader;
-
 public:
     SerialParsingDriver(common::DataChunk& chunk, SerialCSVReader* reader);
-
     bool doneEarly() override;
 
 private:
     BaseCSVReader* getReader() override;
+
+protected:
+    SerialCSVReader* reader;
 };
 
 class SniffCSVNameAndTypeDriver : public SerialParsingDriver {
-
 public:
     SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
         const function::ScanTableFuncBindInput* bindInput);
@@ -71,6 +70,7 @@ public:
     bool done(uint64_t rowNum) const;
     bool addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);
 
+private:
     std::vector<std::pair<std::string, common::LogicalType>> columns;
     std::vector<bool> sniffType;
     // if the type isn't declared in the header, sniff it

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -70,7 +70,7 @@ public:
     bool done(uint64_t rowNum) const;
     bool addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);
 
-private:
+public:
     std::vector<std::pair<std::string, common::LogicalType>> columns;
     std::vector<bool> sniffType;
     // if the type isn't declared in the header, sniff it

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -49,11 +49,11 @@ private:
 class SerialCSVReader;
 
 class SerialParsingDriver : public ParsingDriver {
-    
+
 protected:
     SerialCSVReader* reader;
-    
-public:    
+
+public:
     SerialParsingDriver(common::DataChunk& chunk, SerialCSVReader* reader);
 
     bool doneEarly() override;

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -50,8 +50,10 @@ class SerialCSVReader;
 
 class SerialParsingDriver : public ParsingDriver {
     
-public:
+protected:
     SerialCSVReader* reader;
+    
+public:    
     SerialParsingDriver(common::DataChunk& chunk, SerialCSVReader* reader);
 
     bool doneEarly() override;

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -16,6 +16,8 @@ namespace processor {
 class BaseCSVReader;
 class ParsingDriver {
     common::DataChunk& chunk;
+
+protected:
     bool rowEmpty;
 
 public:
@@ -58,18 +60,20 @@ private:
     BaseCSVReader* getReader() override;
 };
 
-struct SniffCSVNameAndTypeDriver {
+class SniffCSVNameAndTypeDriver : public SerialParsingDriver {
+    SerialCSVReader* reader;
+    static common::DataChunk dummyChunk; 
+
+public:
+    SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
+        const function::ScanTableFuncBindInput* bindInput);
+
     std::vector<std::pair<std::string, common::LogicalType>> columns;
     std::vector<bool> sniffType;
     // if the type isn't declared in the header, sniff it
-    SerialCSVReader* reader;
-    bool rowEmpty = false;
 
-    SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
-        const function::ScanTableFuncBindInput* bindInput);
     bool done(uint64_t rowNum) const;
     bool addValue(uint64_t rowNum, common::column_id_t columnIdx, std::string_view value);
-    bool addRow(uint64_t rowNum, common::column_id_t columntCount);
 };
 
 } // namespace processor

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -62,7 +62,7 @@ private:
 
 class SniffCSVNameAndTypeDriver : public SerialParsingDriver {
     SerialCSVReader* reader;
-    static common::DataChunk dummyChunk; 
+    static common::DataChunk dummyChunk;
 
 public:
     SniffCSVNameAndTypeDriver(SerialCSVReader* reader,

--- a/src/include/processor/operator/persistent/reader/csv/driver.h
+++ b/src/include/processor/operator/persistent/reader/csv/driver.h
@@ -27,11 +27,11 @@ private:
     virtual bool doneEarly() = 0;
     virtual BaseCSVReader* getReader() = 0;
 
-protected:
-    bool rowEmpty;
-
 private:
     common::DataChunk& chunk;
+
+protected:
+    bool rowEmpty;
 };
 
 class ParallelCSVReader;

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -89,11 +89,15 @@ BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
 
-common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk();
+//common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk(); 
+common::DataChunk& getDummyDataChunk() {
+    static common::DataChunk dummyChunk; // static ensures it's created only once
+    return dummyChunk;
+}
 
 SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
     const function::ScanTableFuncBindInput* bindInput)
-    : SerialParsingDriver(dummyChunk, reader) {
+    : SerialParsingDriver(getDummyDataChunk(), reader) {
     if (bindInput != nullptr) {
         for (auto i = 0u; i < bindInput->expectedColumnNames.size(); i++) {
             columns.push_back(

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -89,7 +89,7 @@ BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
 
-common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk; 
+common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk;
 
 SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
     const function::ScanTableFuncBindInput* bindInput)

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -91,7 +91,7 @@ BaseCSVReader* SerialParsingDriver::getReader() {
 
 // common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk();
 common::DataChunk& getDummyDataChunk() {
-    static common::DataChunk dummyChunk; // static ensures it's created only once
+    static common::DataChunk dummyChunk = DataChunk(); // static ensures it's created only once
     return dummyChunk;
 }
 

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -89,7 +89,7 @@ BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
 
-//common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk(); 
+// common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk();
 common::DataChunk& getDummyDataChunk() {
     static common::DataChunk dummyChunk; // static ensures it's created only once
     return dummyChunk;

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -89,7 +89,7 @@ BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
 
-common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk;
+common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk(); 
 
 SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
     const function::ScanTableFuncBindInput* bindInput)

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -89,7 +89,6 @@ BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
 
-// common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk();
 common::DataChunk& getDummyDataChunk() {
     static common::DataChunk dummyChunk = DataChunk(); // static ensures it's created only once
     return dummyChunk;

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -4,7 +4,6 @@
 #include "function/cast/functions/cast_from_string_functions.h"
 #include "processor/operator/persistent/reader/csv/parallel_csv_reader.h"
 #include "processor/operator/persistent/reader/csv/serial_csv_reader.h"
-
 using namespace kuzu::common;
 
 namespace kuzu {
@@ -148,7 +147,13 @@ bool SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t co
     return true;
 }
 
-bool SniffCSVNameAndTypeDriver::addRow(uint64_t, common::column_id_t) {
+bool SniffCSVNameAndTypeDriver::addRow(uint64_t, common::column_id_t columnCount) {
+    if (columnCount < reader->getNumColumns()) {
+        // Column number mismatch.
+        reader->handleCopyException(stringFormat("expected {} values per row, but got {}.",
+            reader->getNumColumns(), columnCount));
+        return false;
+    }
     return true;
 }
 

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -89,9 +89,11 @@ BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
 
+common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk; 
+
 SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
     const function::ScanTableFuncBindInput* bindInput)
-    : reader{reader} {
+    : SerialParsingDriver(dummyChunk, reader) {
     if (bindInput != nullptr) {
         for (auto i = 0u; i < bindInput->expectedColumnNames.size(); i++) {
             columns.push_back(
@@ -151,23 +153,6 @@ bool SniffCSVNameAndTypeDriver::addValue(uint64_t rowNum, common::column_id_t co
         }
     }
 
-    return true;
-}
-
-bool SniffCSVNameAndTypeDriver::addRow(uint64_t, common::column_id_t columnCount) {
-    if (rowEmpty) {
-        rowEmpty = false;
-        if (reader->getNumColumns() != 1) {
-            return false;
-        }
-        // Otherwise, treat it as null.
-    }
-    if (columnCount < reader->getNumColumns()) {
-        // Column number mismatch.
-        reader->handleCopyException(stringFormat("expected {} values per row, but got {}.",
-            reader->getNumColumns(), columnCount));
-        return false;
-    }
     return true;
 }
 

--- a/src/processor/operator/persistent/reader/csv/driver.cpp
+++ b/src/processor/operator/persistent/reader/csv/driver.cpp
@@ -89,7 +89,7 @@ BaseCSVReader* SerialParsingDriver::getReader() {
     return reader;
 }
 
-common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk(); 
+common::DataChunk SniffCSVNameAndTypeDriver::dummyChunk = DataChunk();
 
 SniffCSVNameAndTypeDriver::SniffCSVNameAndTypeDriver(SerialCSVReader* reader,
     const function::ScanTableFuncBindInput* bindInput)

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -106,7 +106,8 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_t fileIdx,
     std::vector<std::string>& columnNames, std::vector<LogicalType>& columnTypes) {
     auto csvOption = CSVReaderConfig::construct(bindInput->config.options).option;
-    auto columnInfo = CSVColumnInfo(bindInput->expectedColumnNames.size() /* numColumns */, {} /* columnSkips */);
+    auto columnInfo =
+        CSVColumnInfo(bindInput->expectedColumnNames.size() /* numColumns */, {} /* columnSkips */);
     auto warningCounter = std::make_shared<warning_counter_t>();
     SharedCSVFileErrorHandler errorHandler{bindInput->config.getFilePath(fileIdx), nullptr,
         bindInput->context->getClientConfig()->warningLimit, warningCounter,

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -106,13 +106,15 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_t fileIdx,
     std::vector<std::string>& columnNames, std::vector<LogicalType>& columnTypes) {
     auto csvOption = CSVReaderConfig::construct(bindInput->config.options).option;
-    auto columnInfo = CSVColumnInfo(0 /* numColumns */, {} /* columnSkips */);
+    ////////////////////////////////CHANGED
+    auto columnInfo = CSVColumnInfo(bindInput->expectedColumnNames.size() /* numColumns */, {} /* columnSkips */);
+    ////////////////////////////////
     auto warningCounter = std::make_shared<warning_counter_t>();
     SharedCSVFileErrorHandler errorHandler{bindInput->config.getFilePath(fileIdx), nullptr,
         bindInput->context->getClientConfig()->warningLimit, warningCounter,
         csvOption.ignoreErrors};
     auto csvReader = SerialCSVReader(bindInput->config.filePaths[fileIdx], csvOption.copy(),
-        columnInfo.copy(), bindInput->context, &errorHandler, bindInput);
+        columnInfo.copy(), bindInput->context, &errorHandler, bindInput);  
     auto sniffedColumns = csvReader.sniffCSV();
     for (auto& [name, type] : sniffedColumns) {
         columnNames.push_back(name);

--- a/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
+++ b/src/processor/operator/persistent/reader/csv/serial_csv_reader.cpp
@@ -106,15 +106,13 @@ static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output
 static void bindColumnsFromFile(const ScanTableFuncBindInput* bindInput, uint32_t fileIdx,
     std::vector<std::string>& columnNames, std::vector<LogicalType>& columnTypes) {
     auto csvOption = CSVReaderConfig::construct(bindInput->config.options).option;
-    ////////////////////////////////CHANGED
     auto columnInfo = CSVColumnInfo(bindInput->expectedColumnNames.size() /* numColumns */, {} /* columnSkips */);
-    ////////////////////////////////
     auto warningCounter = std::make_shared<warning_counter_t>();
     SharedCSVFileErrorHandler errorHandler{bindInput->config.getFilePath(fileIdx), nullptr,
         bindInput->context->getClientConfig()->warningLimit, warningCounter,
         csvOption.ignoreErrors};
     auto csvReader = SerialCSVReader(bindInput->config.filePaths[fileIdx], csvOption.copy(),
-        columnInfo.copy(), bindInput->context, &errorHandler, bindInput);  
+        columnInfo.copy(), bindInput->context, &errorHandler, bindInput);
     auto sniffedColumns = csvReader.sniffCSV();
     for (auto& [name, type] : sniffedColumns) {
         columnNames.push_back(name);

--- a/test/test_files/copy/copy_partial_column.test
+++ b/test/test_files/copy/copy_partial_column.test
@@ -162,8 +162,8 @@ Binder exception: Table tableOfTypes7 does not contain column nonexistentColumn.
 ---- ok
 -STATEMENT COPY tableOfTypes8 (id, int64Column, doubleColumn, booleanColumn, dateColumn, timestampColumn, stringColumn,
     listOfInt, extraColumn) FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/csv/types_50k.csv" (HEADER=true);
----- error(regex)
-Copy exception: Error in file \${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/csv/types_50k\.csv on line 8?2: expected 9 values per row, but got 8. Line containing the error: '0,73,3.2585065282054626,true,1829-10-28,1829-10-28 0:21:21,FrPZkcHFuepVxcAiMwyAsRqDlRtQx,"\[99,2,98,100\]"'
+---- error
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/copy-test/node/csv/types_50k.csv on line 1: expected 9 values per row, but got 8. Line containing the error: 'id,column1,column2,column3,column4,column5,column6,"[94,70,35,36,73]"'
 
 -LOG PartialCopyException4
 -STATEMENT CREATE NODE TABLE tableOfTypes9 (id INT64, int64Column INT64, doubleColumn DOUBLE, booleanColumn BOOLEAN,

--- a/test/test_files/exceptions/copy/wrong_header.test
+++ b/test/test_files/exceptions/copy/wrong_header.test
@@ -30,7 +30,7 @@ Binder exception: Number of columns mismatch. Expected 1 but got 2.
        ["${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPerson.csv",
         "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPersonMissingColumn.csv"] (HEADER=true)
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPersonMissingColumn.csv on line 2: expected 2 values per row, but got 1. Line containing the error: '10'
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/vPersonMissingColumn.csv on line 1: expected 2 values per row, but got 1. Line containing the error: 'id'
 -STATEMENT CREATE REL TABLE knows (FROM person TO person, prop1 INTERVAL);
 ---- ok
 -STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/eKnowsWrongColumnName.csv" (HEADER=true)
@@ -105,7 +105,7 @@ Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/tinysnb/vPerson.csv
 ---- ok
 -STATEMENT COPY knows FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/eKnowsMissingColumn.csv" (HEADER=true)
 ---- error
-Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/eKnowsMissingColumn.csv on line 2: expected 4 values per row, but got 3. Line containing the error: '10,24,1'
+Copy exception: Error in file ${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/wrong-header/eKnowsMissingColumn.csv on line 1: expected 4 values per row, but got 3. Line containing the error: 'from,to,prop1'
 
 -CASE NodeUnmatchedNumColumns
 -STATEMENT create node table person (ID1 SERIAL, ID INT64, fName INT64, age INT64, PRIMARY KEY (ID1))


### PR DESCRIPTION
# Description
This PR aims to solve issue [4129](https://github.com/kuzudb/kuzu/issues/4129#issuecomment-2331899406),

The solution is to make use of 
`bool SniffCSVNameAndTypeDriver::addRow(uint64_t, common::column_id_t columnCount)` inside `driver.cpp`, 

it dumbly returns true before, we could add a check of `columnCount` here, similar to what we did in 
`bool ParsingDriver::addRow(uint64_t /*rowNum*/, common::column_id_t columnCount)`. 

And also in `serial_csv_reader.cpp` the `numColumn` of `columnInfo` inside the `Reader` need to be initialized properly as `auto columnInfo = CSVColumnInfo(bindInput->expectedColumnNames.size() /* numColumns */, {} /* columnSkips */);`,before it was simply zero. 

A new field `"rowEmpty"` is introduced in `SniffCSVNameAndTypeDriver`, which is checked by `addRow` function to skip any empty row during the sniffing, similar to what we did in `ParsingDriver`.

After these changes, the mismatched num of columns problem can be detected when sniffing the header, as expected in the BUG description.

Three test cases are revised accordingly, which is `521/1219/1223`, they was expecting exception to be thrown in content before, now they should expect exception to be thrown in header.

Fixes # (4129)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).