### PR TITLE
Re-enabling LDBC Shortest Path Queries

### DIFF
--- a/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q37.benchmark
+++ b/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q37.benchmark
@@ -1,5 +1,5 @@
 -NAME q37
 -COMPARE_RESULT 1
--QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..3]->(b:Person) WHERE a.ID = 94 RETURN COUNT(*)
+-QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..10]->(b:Person) WHERE a.ID = 933 RETURN COUNT(*)
 ---- 1
-66396
+356867

--- a/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q37.benchmark
+++ b/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q37.benchmark
@@ -1,0 +1,5 @@
+-NAME q37
+-COMPARE_RESULT 1
+-QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..3]->(b:Person) WHERE a.ID = 94 RETURN COUNT(*)
+---- 1
+66396

--- a/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q37.skip
+++ b/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q37.skip
@@ -1,5 +1,0 @@
--NAME q37
--COMPARE_RESULT 1
--QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..30]->(b:Person) WHERE a.ID = 94 RETURN COUNT(*)
----- 1
-407396

--- a/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q38.benchmark
+++ b/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q38.benchmark
@@ -1,0 +1,5 @@
+-NAME q38
+-COMPARE_RESULT 1
+-QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..2]->(b:Person) WHERE a.ID < 10000 RETURN COUNT(*)
+---- 1
+573677

--- a/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q38.skip
+++ b/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q38.skip
@@ -1,5 +1,0 @@
-#-NAME q38
-#-COMPARE_RESULT 1
-#-QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..30]->(b:Person) WHERE a.ID < 17805 RETURN COUNT(*)
-#---- 1
-#360202025

--- a/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q40.benchmark
+++ b/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q40.benchmark
@@ -1,0 +1,5 @@
+-NAME q40
+-COMPARE_RESULT 1
+-QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..2]->(b:Person) WHERE a.ID < 1000 AND b.ID < 100000 RETURN COUNT(*)
+---- 1
+2609

--- a/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q40.skip
+++ b/benchmark/queries/ldbc-sf100/shortest_path_ldbc100/q40.skip
@@ -1,5 +1,0 @@
-#-NAME q40
-#-COMPARE_RESULT 1
-#-QUERY MATCH (a:Person)-[r:knows* SHORTEST 1..30]->(b:Person) WHERE a.ID < 17805 AND b.ID < 17805 RETURN COUNT(*)
-#---- 1
-#6269


### PR DESCRIPTION
# Description

Re-enabling queries after double checking numbers with neo4j

Fixes:
https://github.com/kuzudb/kuzu/issues/2150#event-14115084744
https://github.com/kuzudb/kuzu/issues/1837#issuecomment-2334644987

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).