### PR TITLE
Fix buffer manager failure false positive

### DIFF
--- a/src/include/storage/buffer_manager/buffer_manager.h
+++ b/src/include/storage/buffer_manager/buffer_manager.h
@@ -219,7 +219,6 @@ private:
         PageReadPolicy pageReadPolicy);
     void removePageFromFrame(FileHandle& fileHandle, common::page_idx_t pageIdx, bool shouldFlush);
 
-    uint64_t reserveUsedMemory(uint64_t size) { return usedMemory.fetch_add(size); }
     uint64_t freeUsedMemory(uint64_t size) {
         KU_ASSERT(usedMemory.load() >= size);
         return usedMemory.fetch_sub(size);


### PR DESCRIPTION
I still haven't figured out why we seem to be getting segfaults in the hash index sometimes when the buffer manager runs out of memory, but I did figure out why it's running out of memory in the one test with the larger page size ([E.g.](https://github.com/kuzudb/kuzu/actions/runs/10641076879/job/29517798084)).

We currently reserve memory before evicting, and try to evict enough pages that the amount of used memory is no larger than the buffer pool, but having each thread do that independently means that each thread tries to evict enough memory for the total amount of memory being reserved concurrently. So if enough threads are evicting simultaneously and the number of evictable pages is small, we may evict sufficient memory for all threads, but not sufficient memory to get the free space below the required threshold (which was also higher than necessary since we were taking into account the current size being reserved twice on iterations after the first). If we instead allow a thread to finish reserving when they have evicted enough space for the memory they are trying to reserve regardless of the total used memory, this can be avoided.
There is still a possible race condition if a thread is unable to evict enough and hits the failure check before the other threads which evicted more than enough finish freeing the memory and updating the usedMemory counter, but the likelihood is much smaller and fixing that race condition will probably have a significant performance penalty.

VMCache seems to avoid this issue by ignoring the possibility of of failure entirely. But they also use a `PHYSGB` environment variable to initialize the buffer pool size, so the idea may just be that the you let it use all your free memory and the kernel will handle the failure eventually.