### PR TITLE
Nested alias

### DIFF
--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -27,12 +27,14 @@ namespace binder {
 // TODO(Xiyang): the above rewrite is creating problem for alias handling. Consider move this out of
 //  binder.
 
-static void addToProjectionList(std::shared_ptr<Expression> expr, const std::string& alias, expression_vector& exprs, std::vector<std::string>& aliases) {
+static void addToProjectionList(std::shared_ptr<Expression> expr, const std::string& alias,
+    expression_vector& exprs, std::vector<std::string>& aliases) {
     exprs.push_back(expr);
     aliases.push_back(alias);
 }
 
-static void tryAddToProjectionList(expression_set& set, std::shared_ptr<Expression> expr,  const std::string& alias, expression_vector& exprs, std::vector<std::string>& aliases) {
+static void tryAddToProjectionList(expression_set& set, std::shared_ptr<Expression> expr,
+    const std::string& alias, expression_vector& exprs, std::vector<std::string>& aliases) {
     if (set.contains(expr)) {
         return;
     }
@@ -40,7 +42,8 @@ static void tryAddToProjectionList(expression_set& set, std::shared_ptr<Expressi
     addToProjectionList(expr, alias, exprs, aliases);
 }
 
-static std::pair<expression_vector, std::vector<std::string>> rewriteProjectionInWithClause(const expression_vector& expressions, const std::vector<std::string>& aliases) {
+static std::pair<expression_vector, std::vector<std::string>> rewriteProjectionInWithClause(
+    const expression_vector& expressions, const std::vector<std::string>& aliases) {
     expression_vector newExprs;
     std::vector<std::string> newAliases;
     auto set = expression_set{};
@@ -52,8 +55,10 @@ static std::pair<expression_vector, std::vector<std::string>> rewriteProjectionI
             tryAddToProjectionList(set, node.getInternalID(), "", newExprs, newAliases);
         } else if (ExpressionUtil::isRelPattern(*expression)) {
             auto& rel = expression->constCast<RelExpression>();
-            tryAddToProjectionList(set, rel.getSrcNode()->getInternalID(), "", newExprs, newAliases);
-            tryAddToProjectionList(set, rel.getDstNode()->getInternalID(), "", newExprs, newAliases);
+            tryAddToProjectionList(set, rel.getSrcNode()->getInternalID(), "", newExprs,
+                newAliases);
+            tryAddToProjectionList(set, rel.getDstNode()->getInternalID(), "", newExprs,
+                newAliases);
             tryAddToProjectionList(set, rel.getInternalIDProperty(), "", newExprs, newAliases);
             if (rel.hasDirectionExpr()) {
                 tryAddToProjectionList(set, rel.getDirectionExpr(), "", newExprs, newAliases);
@@ -71,8 +76,7 @@ static std::pair<expression_vector, std::vector<std::string>> rewriteProjectionI
 
 BoundWithClause Binder::bindWithClause(const WithClause& withClause) {
     auto projectionBody = withClause.getProjectionBody();
-    auto boundProjectionBody =
-        bindProjectionBody(*projectionBody, true /* isWithClause */);
+    auto boundProjectionBody = bindProjectionBody(*projectionBody, true /* isWithClause */);
     validateOrderByFollowedBySkipOrLimitInWithClause(boundProjectionBody);
     auto boundWithClause = BoundWithClause(std::move(boundProjectionBody));
     if (withClause.hasWhereExpression()) {
@@ -109,7 +113,8 @@ static expression_vector getAggregateExpressions(const std::shared_ptr<Expressio
     return result;
 }
 
-BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& projectionBody, bool isWithClause) {
+BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& projectionBody,
+    bool isWithClause) {
     expression_vector projectionExprs;
     std::vector<std::string> aliases;
     for (auto& parsedExpr : projectionBody.getProjectionExpressions()) {
@@ -172,12 +177,11 @@ BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& pro
         expr->setAlias(aliases[i]);
     }
 
-    for (auto i =0u; i <originProjectionExprs.size(); ++i) {
+    for (auto i = 0u; i < originProjectionExprs.size(); ++i) {
         originProjectionExprs[i]->setAlias(originAliases[i]);
     }
     validateProjectionColumnNamesAreUnique(originProjectionExprs);
-    auto boundProjectionBody =
-        BoundProjectionBody(projectionBody.getIsDistinct());
+    auto boundProjectionBody = BoundProjectionBody(projectionBody.getIsDistinct());
     boundProjectionBody.setProjectionExpressions(projectionExprs);
 
     if (!aggregateExprs.empty()) {

--- a/src/binder/bind/bind_projection_clause.cpp
+++ b/src/binder/bind/bind_projection_clause.cpp
@@ -24,41 +24,56 @@ namespace binder {
 // MATCH (a) WITH a._id RETURN a.age;
 // And then apply WithClauseProjectionRewriter after binding to rewrite as
 // MATCH (a) WITH a._id, a.age RETURN a.age
-static expression_vector rewriteProjectionInWithClause(const expression_vector& expressions) {
-    expression_vector result;
-    for (auto& expression : expressions) {
+// TODO(Xiyang): the above rewrite is creating problem for alias handling. Consider move this out of
+//  binder.
+
+static void addToProjectionList(std::shared_ptr<Expression> expr, const std::string& alias, expression_vector& exprs, std::vector<std::string>& aliases) {
+    exprs.push_back(expr);
+    aliases.push_back(alias);
+}
+
+static void tryAddToProjectionList(expression_set& set, std::shared_ptr<Expression> expr,  const std::string& alias, expression_vector& exprs, std::vector<std::string>& aliases) {
+    if (set.contains(expr)) {
+        return;
+    }
+    set.insert(expr);
+    addToProjectionList(expr, alias, exprs, aliases);
+}
+
+static std::pair<expression_vector, std::vector<std::string>> rewriteProjectionInWithClause(const expression_vector& expressions, const std::vector<std::string>& aliases) {
+    expression_vector newExprs;
+    std::vector<std::string> newAliases;
+    auto set = expression_set{};
+    for (auto i = 0u; i < expressions.size(); ++i) {
+        auto expression = expressions[i];
         if (ExpressionUtil::isNodePattern(*expression)) {
             auto& node = expression->constCast<NodeExpression>();
-            result.push_back(node.getInternalID());
+            auto id = node.getInternalID();
+            tryAddToProjectionList(set, node.getInternalID(), "", newExprs, newAliases);
         } else if (ExpressionUtil::isRelPattern(*expression)) {
             auto& rel = expression->constCast<RelExpression>();
-            result.push_back(rel.getSrcNode()->getInternalID());
-            result.push_back(rel.getDstNode()->getInternalID());
-            result.push_back(rel.getInternalIDProperty());
+            tryAddToProjectionList(set, rel.getSrcNode()->getInternalID(), "", newExprs, newAliases);
+            tryAddToProjectionList(set, rel.getDstNode()->getInternalID(), "", newExprs, newAliases);
+            tryAddToProjectionList(set, rel.getInternalIDProperty(), "", newExprs, newAliases);
             if (rel.hasDirectionExpr()) {
-                result.push_back(rel.getDirectionExpr());
+                tryAddToProjectionList(set, rel.getDirectionExpr(), "", newExprs, newAliases);
             }
         } else if (ExpressionUtil::isRecursiveRelPattern(*expression)) {
             auto& rel = expression->constCast<RelExpression>();
-            result.push_back(expression);
-            result.push_back(rel.getLengthExpression());
+            tryAddToProjectionList(set, expression, "", newExprs, newAliases);
+            tryAddToProjectionList(set, rel.getLengthExpression(), "", newExprs, newAliases);
         } else {
-            result.push_back(expression);
+            addToProjectionList(expression, aliases[i], newExprs, newAliases);
         }
     }
-    return ExpressionUtil::removeDuplication(result);
+    return {newExprs, newAliases};
 }
 
 BoundWithClause Binder::bindWithClause(const WithClause& withClause) {
     auto projectionBody = withClause.getProjectionBody();
-    auto projectionExpressions =
-        bindProjectionExpressions(projectionBody->getProjectionExpressions());
-    validateProjectionColumnsInWithClauseAreAliased(projectionExpressions);
     auto boundProjectionBody =
-        bindProjectionBody(*projectionBody, rewriteProjectionInWithClause(projectionExpressions));
+        bindProjectionBody(*projectionBody, true /* isWithClause */);
     validateOrderByFollowedBySkipOrLimitInWithClause(boundProjectionBody);
-    scope.clear();
-    addExpressionsToScope(projectionExpressions);
     auto boundWithClause = BoundWithClause(std::move(boundProjectionBody));
     if (withClause.hasWhereExpression()) {
         boundWithClause.setWhereExpression(bindWhereExpression(*withClause.getWhereExpression()));
@@ -68,30 +83,12 @@ BoundWithClause Binder::bindWithClause(const WithClause& withClause) {
 
 BoundReturnClause Binder::bindReturnClause(const ReturnClause& returnClause) {
     auto projectionBody = returnClause.getProjectionBody();
-    auto boundProjectionExpressions =
-        bindProjectionExpressions(projectionBody->getProjectionExpressions());
+    auto boundProjectionBody = bindProjectionBody(*projectionBody, false /* isWithClause */);
     auto statementResult = BoundStatementResult();
-    for (auto& expression : boundProjectionExpressions) {
+    for (auto& expression : boundProjectionBody.getProjectionExpressions()) {
         statementResult.addColumn(expression);
     }
-    auto boundProjectionBody = bindProjectionBody(*projectionBody, statementResult.getColumns());
     return BoundReturnClause(std::move(boundProjectionBody), std::move(statementResult));
-}
-
-static bool isAggregateExpression(const std::shared_ptr<Expression>& expression,
-    const BinderScope& scope) {
-    if (expression->hasAlias() && scope.contains(expression->getAlias())) {
-        return false;
-    }
-    if (expression->expressionType == ExpressionType::AGGREGATE_FUNCTION) {
-        return true;
-    }
-    for (auto& child : ExpressionChildrenCollector::collectChildren(*expression)) {
-        if (isAggregateExpression(child, scope)) {
-            return true;
-        }
-    }
-    return false;
 }
 
 static expression_vector getAggregateExpressions(const std::shared_ptr<Expression>& expression,
@@ -112,29 +109,83 @@ static expression_vector getAggregateExpressions(const std::shared_ptr<Expressio
     return result;
 }
 
-BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& projectionBody,
-    const expression_vector& projectionExpressions) {
-    auto boundProjectionBody =
-        BoundProjectionBody(projectionBody.getIsDistinct(), projectionExpressions);
-    // Bind group by & aggregate.
-    expression_vector groupByExpressions;
-    expression_vector aggregateExpressions;
-    for (auto& expression : projectionExpressions) {
-        if (isAggregateExpression(expression, scope)) {
-            for (auto& agg : getAggregateExpressions(expression, scope)) {
-                aggregateExpressions.push_back(agg);
+BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& projectionBody, bool isWithClause) {
+    expression_vector projectionExprs;
+    std::vector<std::string> aliases;
+    for (auto& parsedExpr : projectionBody.getProjectionExpressions()) {
+        if (parsedExpr->getExpressionType() == ExpressionType::STAR) {
+            // Rewrite star expression as all expression in scope.
+            if (scope.empty()) {
+                throw BinderException(
+                    "RETURN or WITH * is not allowed when there are no variables in scope.");
+            }
+            for (auto& expr : scope.getExpressions()) {
+                projectionExprs.push_back(expr);
+                aliases.push_back(expr->getAlias());
+            }
+        } else if (parsedExpr->getExpressionType() == ExpressionType::PROPERTY) {
+            auto& propExpr = parsedExpr->constCast<ParsedPropertyExpression>();
+            if (propExpr.isStar()) {
+                // Rewrite property star expression
+                for (auto& expr : expressionBinder.bindPropertyStarExpression(*parsedExpr)) {
+                    projectionExprs.push_back(expr);
+                    aliases.push_back("");
+                }
+            } else {
+                auto expr = expressionBinder.bindExpression(*parsedExpr);
+                projectionExprs.push_back(expr);
+                aliases.push_back(parsedExpr->getAlias());
             }
         } else {
-            groupByExpressions.push_back(expression);
+            auto expr = expressionBinder.bindExpression(*parsedExpr);
+            projectionExprs.push_back(expr);
+            aliases.push_back(parsedExpr->hasAlias() ? parsedExpr->getAlias() : expr->getAlias());
         }
     }
+    auto originProjectionExprs = projectionExprs;
+    auto originAliases = aliases;
 
-    if (!aggregateExpressions.empty()) {
-        if (!groupByExpressions.empty()) {
+    if (isWithClause) {
+        for (auto& alias : aliases) {
+            if (alias.empty()) {
+                throw BinderException("Expression in WITH must be aliased (use AS).");
+            }
+        }
+        auto [a, b] = rewriteProjectionInWithClause(projectionExprs, aliases);
+        projectionExprs = a;
+        aliases = b;
+    }
+
+    expression_vector groupByExprs;
+    expression_vector aggregateExprs;
+    KU_ASSERT(projectionExprs.size() == aliases.size());
+    for (auto i = 0u; i < projectionExprs.size(); ++i) {
+        auto expr = projectionExprs[i];
+        auto aggExprs = getAggregateExpressions(expr, scope);
+        if (!aggExprs.empty()) {
+            for (auto& agg : aggExprs) {
+                aggregateExprs.push_back(agg);
+            }
+        } else {
+            groupByExprs.push_back(expr);
+        }
+        expr->setAlias(aliases[i]);
+    }
+
+    for (auto i =0u; i <originProjectionExprs.size(); ++i) {
+        originProjectionExprs[i]->setAlias(originAliases[i]);
+    }
+    validateProjectionColumnNamesAreUnique(originProjectionExprs);
+    auto boundProjectionBody =
+        BoundProjectionBody(projectionBody.getIsDistinct());
+    boundProjectionBody.setProjectionExpressions(projectionExprs);
+
+    if (!aggregateExprs.empty()) {
+        if (!groupByExprs.empty()) {
             // TODO(Xiyang): we can remove augment group by. But make sure we test sufficient
             // including edge case and bug before release.
-            expression_vector augmentedGroupByExpressions = groupByExpressions;
-            for (auto& expression : groupByExpressions) {
+            expression_vector augmentedGroupByExpressions = groupByExprs;
+            for (auto& expression : groupByExprs) {
                 if (ExpressionUtil::isNodePattern(*expression)) {
                     auto node = (NodeExpression*)expression.get();
                     augmentedGroupByExpressions.push_back(node->getInternalID());
@@ -145,11 +196,11 @@ BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& pro
             }
             boundProjectionBody.setGroupByExpressions(std::move(augmentedGroupByExpressions));
         }
-        boundProjectionBody.setAggregateExpressions(std::move(aggregateExpressions));
+        boundProjectionBody.setAggregateExpressions(std::move(aggregateExprs));
     }
     // Bind order by
     if (projectionBody.hasOrderByExpressions()) {
-        addExpressionsToScope(projectionExpressions);
+        addExpressionsToScope(projectionExprs);
         auto orderByExpressions = bindOrderByExpressions(projectionBody.getOrderByExpressions());
         // Cypher rule of ORDER BY expression scope: if projection contains aggregation, only
         // expressions in projection are available. Otherwise, expressions before projection are
@@ -159,7 +210,7 @@ BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& pro
             // reference expression to solve this. Our property expression should also be changed to
             // reference expression.
             auto projectionExpressionSet =
-                expression_set{projectionExpressions.begin(), projectionExpressions.end()};
+                expression_set{projectionExprs.begin(), projectionExprs.end()};
             for (auto& orderByExpression : orderByExpressions) {
                 if (!projectionExpressionSet.contains(orderByExpression)) {
                     throw BinderException("Order by expression " + orderByExpression->toString() +
@@ -180,39 +231,12 @@ BoundProjectionBody Binder::bindProjectionBody(const parser::ProjectionBody& pro
         boundProjectionBody.setLimitNumber(
             bindSkipLimitExpression(*projectionBody.getLimitExpression()));
     }
-    return boundProjectionBody;
-}
-
-expression_vector Binder::bindProjectionExpressions(
-    const parsed_expr_vector& projectionExpressions) {
-    expression_vector exprs;
-    // Rewrite star expressions, including RETURN * or RETURN a.*
-    for (auto& e : projectionExpressions) {
-        if (e->getExpressionType() == ExpressionType::STAR) {
-            // Rewrite star expression as all expression in scope.
-            if (scope.empty()) {
-                throw BinderException(
-                    "RETURN or WITH * is not allowed when there are no variables in scope.");
-            }
-            for (auto& expr : scope.getExpressions()) {
-                exprs.push_back(expr);
-            }
-        } else if (e->getExpressionType() == ExpressionType::PROPERTY) {
-            auto& propExpr = e->constCast<ParsedPropertyExpression>();
-            if (propExpr.isStar()) {
-                // Rewrite property star expression
-                for (auto& expr : expressionBinder.bindPropertyStarExpression(*e)) {
-                    exprs.push_back(expr);
-                }
-            } else {
-                exprs.push_back(expressionBinder.bindExpression(*e));
-            }
-        } else {
-            exprs.push_back(expressionBinder.bindExpression(*e));
-        }
+    // Update scope.
+    if (isWithClause) {
+        scope.clear();
+        addExpressionsToScope(originProjectionExprs);
     }
-    validateProjectionColumnNamesAreUnique(exprs);
-    return exprs;
+    return boundProjectionBody;
 }
 
 expression_vector Binder::bindOrderByExpressions(

--- a/src/binder/bind_expression/bind_function_expression.cpp
+++ b/src/binder/bind_expression/bind_function_expression.cpp
@@ -52,7 +52,11 @@ std::shared_ptr<Expression> ExpressionBinder::bindScalarFunctionExpression(
     const ParsedExpression& parsedExpression, const std::string& functionName) {
     expression_vector children;
     for (auto i = 0u; i < parsedExpression.getNumChildren(); ++i) {
-        children.push_back(bindExpression(*parsedExpression.getChild(i)));
+        auto expr = bindExpression(*parsedExpression.getChild(i));
+        if (parsedExpression.getChild(i)->hasAlias()) {
+            expr->setAlias(parsedExpression.getChild(i)->getAlias());
+        }
+        children.push_back(expr);
     }
     return bindScalarFunctionExpression(children, functionName);
 }

--- a/src/binder/binder.cpp
+++ b/src/binder/binder.cpp
@@ -127,14 +127,6 @@ void Binder::validateProjectionColumnNamesAreUnique(const expression_vector& exp
     }
 }
 
-void Binder::validateProjectionColumnsInWithClauseAreAliased(const expression_vector& expressions) {
-    for (auto& expression : expressions) {
-        if (!expression->hasAlias()) {
-            throw BinderException("Expression in WITH must be aliased (use AS).");
-        }
-    }
-}
-
 void Binder::validateOrderByFollowedBySkipOrLimitInWithClause(
     const BoundProjectionBody& boundProjectionBody) {
     auto hasSkipOrLimit = boundProjectionBody.hasSkip() || boundProjectionBody.hasLimit();

--- a/src/binder/expression_binder.cpp
+++ b/src/binder/expression_binder.cpp
@@ -73,9 +73,6 @@ std::shared_ptr<Expression> ExpressionBinder::bindExpression(
         throw NotImplementedException(
             "bindExpression(" + ExpressionTypeUtil::toString(expressionType) + ").");
     }
-    if (parsedExpression.hasAlias()) {
-        expression->setAlias(parsedExpression.getAlias());
-    }
     validateAggregationExpressionIsNotNested(expression);
     if (ConstantExpressionVisitor::needFold(*expression)) {
         return foldExpression(expression);

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -230,7 +230,8 @@ public:
     BoundWithClause bindWithClause(const parser::WithClause& withClause);
     BoundReturnClause bindReturnClause(const parser::ReturnClause& returnClause);
 
-    BoundProjectionBody bindProjectionBody(const parser::ProjectionBody& projectionBody, bool isWithClause);
+    BoundProjectionBody bindProjectionBody(const parser::ProjectionBody& projectionBody,
+        bool isWithClause);
 
     expression_vector bindOrderByExpressions(
         const std::vector<std::unique_ptr<parser::ParsedExpression>>& orderByExpressions);

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -229,11 +229,8 @@ public:
     /*** bind projection clause ***/
     BoundWithClause bindWithClause(const parser::WithClause& withClause);
     BoundReturnClause bindReturnClause(const parser::ReturnClause& returnClause);
-    BoundProjectionBody bindProjectionBody(const parser::ProjectionBody& projectionBody,
-        const expression_vector& projectionExpressions);
 
-    expression_vector bindProjectionExpressions(
-        const parser::parsed_expr_vector& parsedExpressions);
+    BoundProjectionBody bindProjectionBody(const parser::ProjectionBody& projectionBody, bool isWithClause);
 
     expression_vector bindOrderByExpressions(
         const std::vector<std::unique_ptr<parser::ParsedExpression>>& orderByExpressions);
@@ -291,10 +288,6 @@ public:
     /*** validations ***/
     // E.g. ... RETURN a, b AS a
     static void validateProjectionColumnNamesAreUnique(const expression_vector& expressions);
-
-    // E.g. ... WITH COUNT(*) MATCH ...
-    static void validateProjectionColumnsInWithClauseAreAliased(
-        const expression_vector& expressions);
 
     static void validateOrderByFollowedBySkipOrLimitInWithClause(
         const BoundProjectionBody& boundProjectionBody);

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -54,7 +54,7 @@ public:
     DELETE_COPY_DEFAULT_MOVE(Expression);
     virtual ~Expression() = default;
 
-    void setAlias(const std::string& name) { alias = name; }
+
 
     void setUniqueName(const std::string& name) { uniqueName = name; }
     std::string getUniqueName() const {
@@ -63,10 +63,11 @@ public:
     }
 
     virtual void cast(const common::LogicalType& type);
-    // NOTE: Avoid using the following unsafe getter. It is meant for resolving ANY data type only.
-    common::LogicalType& getDataTypeUnsafe() { return dataType; }
     const common::LogicalType& getDataType() const { return dataType; }
 
+    void setAlias(const std::string& newAlias) {
+        alias = newAlias;
+    }
     bool hasAlias() const { return !alias.empty(); }
     std::string getAlias() const { return alias; }
 

--- a/src/include/binder/expression/expression.h
+++ b/src/include/binder/expression/expression.h
@@ -54,8 +54,6 @@ public:
     DELETE_COPY_DEFAULT_MOVE(Expression);
     virtual ~Expression() = default;
 
-
-
     void setUniqueName(const std::string& name) { uniqueName = name; }
     std::string getUniqueName() const {
         KU_ASSERT(!uniqueName.empty());
@@ -65,9 +63,7 @@ public:
     virtual void cast(const common::LogicalType& type);
     const common::LogicalType& getDataType() const { return dataType; }
 
-    void setAlias(const std::string& newAlias) {
-        alias = newAlias;
-    }
+    void setAlias(const std::string& newAlias) { alias = newAlias; }
     bool hasAlias() const { return !alias.empty(); }
     std::string getAlias() const { return alias; }
 

--- a/src/include/binder/query/return_with_clause/bound_projection_body.h
+++ b/src/include/binder/query/return_with_clause/bound_projection_body.h
@@ -9,46 +9,45 @@ class BoundProjectionBody {
     static constexpr uint64_t INVALID_NUMBER = UINT64_MAX;
 
 public:
-    BoundProjectionBody(bool isDistinct, expression_vector projectionExpressions)
-        : isDistinct{isDistinct}, projectionExpressions{std::move(projectionExpressions)},
-          skipNumber{INVALID_NUMBER}, limitNumber{INVALID_NUMBER} {}
+    explicit BoundProjectionBody(bool isDistinct)
+        : isDistinct{isDistinct}, skipNumber{INVALID_NUMBER}, limitNumber{INVALID_NUMBER} {}
     EXPLICIT_COPY_DEFAULT_MOVE(BoundProjectionBody);
 
-    inline bool getIsDistinct() const { return isDistinct; }
+    bool getIsDistinct() const { return isDistinct; }
 
-    inline void setProjectionExpressions(expression_vector expressions) {
+    void setProjectionExpressions(expression_vector expressions) {
         projectionExpressions = std::move(expressions);
     }
-    inline expression_vector getProjectionExpressions() const { return projectionExpressions; }
+    expression_vector getProjectionExpressions() const { return projectionExpressions; }
 
-    inline void setGroupByExpressions(expression_vector expressions) {
+    void setGroupByExpressions(expression_vector expressions) {
         groupByExpressions = std::move(expressions);
     }
-    inline expression_vector getGroupByExpressions() const { return groupByExpressions; }
+    expression_vector getGroupByExpressions() const { return groupByExpressions; }
 
-    inline void setAggregateExpressions(expression_vector expressions) {
+    void setAggregateExpressions(expression_vector expressions) {
         aggregateExpressions = std::move(expressions);
     }
-    inline bool hasAggregateExpressions() const { return !aggregateExpressions.empty(); }
-    inline expression_vector getAggregateExpressions() const { return aggregateExpressions; }
+    bool hasAggregateExpressions() const { return !aggregateExpressions.empty(); }
+    expression_vector getAggregateExpressions() const { return aggregateExpressions; }
 
-    inline void setOrderByExpressions(expression_vector expressions, std::vector<bool> sortOrders) {
+    void setOrderByExpressions(expression_vector expressions, std::vector<bool> sortOrders) {
         orderByExpressions = std::move(expressions);
         isAscOrders = std::move(sortOrders);
     }
-    inline bool hasOrderByExpressions() const { return !orderByExpressions.empty(); }
-    inline const expression_vector& getOrderByExpressions() const { return orderByExpressions; }
-    inline const std::vector<bool>& getSortingOrders() const { return isAscOrders; }
+    bool hasOrderByExpressions() const { return !orderByExpressions.empty(); }
+    const expression_vector& getOrderByExpressions() const { return orderByExpressions; }
+    const std::vector<bool>& getSortingOrders() const { return isAscOrders; }
 
-    inline void setSkipNumber(uint64_t number) { skipNumber = number; }
-    inline bool hasSkip() const { return skipNumber != INVALID_NUMBER; }
-    inline uint64_t getSkipNumber() const { return skipNumber; }
+    void setSkipNumber(uint64_t number) { skipNumber = number; }
+    bool hasSkip() const { return skipNumber != INVALID_NUMBER; }
+    uint64_t getSkipNumber() const { return skipNumber; }
 
-    inline void setLimitNumber(uint64_t number) { limitNumber = number; }
-    inline bool hasLimit() const { return limitNumber != INVALID_NUMBER; }
-    inline uint64_t getLimitNumber() const { return limitNumber; }
+    void setLimitNumber(uint64_t number) { limitNumber = number; }
+    bool hasLimit() const { return limitNumber != INVALID_NUMBER; }
+    uint64_t getLimitNumber() const { return limitNumber; }
 
-    inline bool hasSkipOrLimit() const { return hasSkip() || hasLimit(); }
+    bool hasSkipOrLimit() const { return hasSkip() || hasLimit(); }
 
 private:
     BoundProjectionBody(const BoundProjectionBody& other)

--- a/test/test_files/match/node.test
+++ b/test/test_files/match/node.test
@@ -4,6 +4,10 @@
 
 -CASE MatchNode
 
+-STATEMENT MATCH (a) WITH COUNT(a) AS b RETURN b AS c;
+---- 1
+14
+
 -LOG node1
 -STATEMENT MATCH (a:person /* returns all person */) RETURN COUNT(*)
 ---- 1


### PR DESCRIPTION
# Description

Fix a bug where we cannot handle nested alias properly.

See the following test
```
-STATEMENT MATCH (a) WITH COUNT(a) AS b RETURN b AS c;
---- 1
14
```

Fixes #4132

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).