### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Storage
+src/storage @benjaminwinger
+src/include/storage @benjaminwinger
+
+# APIs
+
+## Rust
+tools/rust_api @benjaminwinger
+examples/rust @benjaminwinger


### PR DESCRIPTION
This mainly comes out of my frustration with github's notification settings. Watching the whole repository inundates my inbox with far too many notifications, and just watching mentions and PRs/issues I'm involved in means I sometimes miss some new stuff that I would like to have seen.
But I think this would generally be a useful tool for making sure people see stuff that's relevant to them (we probably want to keep this a little more limited rather than adding people as owners for everything they could possibly want to be notified about though).

See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners for documentation.
By default as far as I can tell the only thing it will do is add people as reviewers on PRs modifying the code they own. You can also make code owner reviews required.
We could also create teams so that multiple people who deal with a part of the code get notified without making it seem like they all should review it.

I've just added myself to the file for now. Others are welcome to add themselves to it as an addition to this PR, or later, assuming we want to use this.