### PR TITLE
Fixed cli prompt retaining previous highlighting in singleline mode

### DIFF
--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -1738,6 +1738,9 @@ static void refreshSingleLine(struct linenoiseState* l) {
     /* Cursor to left edge */
     snprintf(seq, 64, "\r");
     append_buffer.abAppend(seq);
+
+    append_buffer.abAppend("\033[0m"); // reset all attributes
+
     /* Write the prompt and the current buffer content */
     append_buffer.abAppend(l->prompt);
     if (maskmode == 1) {
@@ -2263,6 +2266,9 @@ static void refreshSearchMultiLine(struct linenoiseState* l, const char* searchP
     /* Cursor to left edge */
     snprintf(seq, 64, "\r");
     append_buffer.abAppend(seq);
+
+    append_buffer.abAppend("\033[0m"); // reset all attributes
+    
     /* Write the prompt and the current buffer content */
     append_buffer.abAppend(l->prompt);
     if (maskmode == 1) {

--- a/tools/shell/linenoise.cpp
+++ b/tools/shell/linenoise.cpp
@@ -2268,7 +2268,7 @@ static void refreshSearchMultiLine(struct linenoiseState* l, const char* searchP
     append_buffer.abAppend(seq);
 
     append_buffer.abAppend("\033[0m"); // reset all attributes
-    
+
     /* Write the prompt and the current buffer content */
     append_buffer.abAppend(l->prompt);
     if (maskmode == 1) {


### PR DESCRIPTION
# Description

Due to clearing lines, the shell `kuzu>` prompt would retain the coloring of the cursor in singleline mode. This issue has now been fixed

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).