### PR TITLE
Fix undefined behaviour in the Buffer Manager after failure

### DIFF
--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -114,7 +114,7 @@ uint8_t* BufferManager::pin(FileHandle& fileHandle, page_idx_t pageIdx,
         case PageState::EVICTED: {
             if (pageState->tryLock(currStateAndVersion)) {
                 if (!claimAFrame(fileHandle, pageIdx, pageReadPolicy)) {
-                    pageState->unlock();
+                    pageState->resetToEvicted();
                     throw BufferManagerException("Failed to claim a frame.");
                 }
                 if (!evictionQueue.insert(fileHandle.getFileIndex(), pageIdx)) {


### PR DESCRIPTION
When multiple threads try to read the same page and run out of memory, the page was being left as unlocked rather than evicted, which let other threads read from the uninitialized data left over from the failed read.

In particular this was manifesting as segfaults (or disk array out of range access with checks enabled) in the Hash index if a slot had no overflow slots, since the slot would be read as having a nextOverflowSlot of 0 (the page should usually be zeroed, unless if was previously used and not reclaimed by the OS) and it would attempt to read that nonexistant slot.