### PR TITLE
Providing better error message in CLI

### DIFF
--- a/src/common/file_system/local_file_system.cpp
+++ b/src/common/file_system/local_file_system.cpp
@@ -116,7 +116,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, int
         overlapped.Offset = 0;
         BOOL rc = LockFileEx(handle, dwFlags, 0, 0, 0, &overlapped);
         if (!rc) {
-            throw IOException("Could not set lock on file : " + fullPath);
+            throw IOException("Could not set lock on file : " + fullPath + "\n" + "See the docs: https://docs.kuzudb.com/concurrency for more information.");
         }
     }
     return std::make_unique<LocalFileInfo>(fullPath, handle, this);
@@ -134,7 +134,7 @@ std::unique_ptr<FileInfo> LocalFileSystem::openFile(const std::string& path, int
         fl.l_len = 0;
         int rc = fcntl(fd, F_SETLK, &fl);
         if (rc == -1) {
-            throw IOException("Could not set lock on file : " + fullPath);
+            throw IOException("Could not set lock on file : " + fullPath + "\n" + "See the docs: https://docs.kuzudb.com/concurrency for more information.");
         }
     }
     return std::make_unique<LocalFileInfo>(fullPath, fd, this);

--- a/tools/shell/shell_runner.cpp
+++ b/tools/shell/shell_runner.cpp
@@ -188,9 +188,9 @@ int main(int argc, char* argv[]) {
         auto shell = EmbeddedShell(database, conn, shellConfig);
         processRunCommands(shell, initFile);
         if (DBConfig::isDBPathInMemory(databasePath)) {
-            std::cout << "Opened the database under in-memory mode." << '\n';
+            std::cout << "Opening the database under in-memory mode." << '\n';
         } else {
-            std::cout << "Opened the database at path: " << databasePath << " in "
+            std::cout << "Opening the database at path: " << databasePath << " in "
                       << (readOnlyMode ? "read-only mode" : "read-write mode") << "." << '\n';
         }
         std::cout << "Enter \":help\" for usage hints." << '\n' << std::flush;

--- a/tools/shell/test/test_shell_flags.py
+++ b/tools/shell/test/test_shell_flags.py
@@ -10,7 +10,7 @@ def test_database_path(temp_db) -> None:
     # no database path
     test = ShellTest()
     result = test.run()
-    result.check_stdout("Opened the database under in-memory mode.")
+    result.check_stdout("Opening the database under in-memory mode.")
 
     # valid database path
     test = ShellTest().add_argument(temp_db).statement('RETURN "databases rule" AS a;')
@@ -57,7 +57,7 @@ def test_default_bp_size(temp_db, flag) -> None:
     # successful flag
     test = ShellTest().add_argument(temp_db).add_argument(flag).add_argument("1000")
     result = test.run()
-    result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
+    result.check_stdout(f"Opening the database at path: {temp_db} in read-write mode.")
 
 
 @pytest.mark.parametrize(
@@ -70,7 +70,7 @@ def test_default_bp_size(temp_db, flag) -> None:
 def test_no_compression(temp_db, flag) -> None:
     test = ShellTest().add_argument(temp_db).add_argument(flag)
     result = test.run()
-    result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
+    result.check_stdout(f"Opening the database at path: {temp_db} in read-write mode.")
 
 
 @pytest.mark.parametrize(
@@ -85,7 +85,7 @@ def test_read_only(temp_db, flag) -> None:
     # cannot open an empty database in read only mode so initialize database
     test = ShellTest().add_argument(temp_db)
     result = test.run()
-    result.check_stdout(f"Opened the database at path: {temp_db} in read-write mode.")
+    result.check_stdout(f"Opening the database at path: {temp_db} in read-write mode.")
 
     # test read only
     test = (
@@ -97,7 +97,7 @@ def test_read_only(temp_db, flag) -> None:
         .statement('RETURN "kuzu is cool" AS b;')
     )
     result = test.run()
-    result.check_stdout(f"Opened the database at path: {temp_db} in read-only mode.")
+    result.check_stdout(f"Opening the database at path: {temp_db} in read-only mode.")
     result.check_stdout("databases rule")
     result.check_stdout(
         "Error: Connection exception: Cannot execute write operations in a read-only database!",


### PR DESCRIPTION
# Description
Changes "Opened" to "Opening" to fit better. 
Added docs links to concurrency information for error returns

Fixes # (issue)
https://github.com/kuzudb/kuzu/issues/3883

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).