### PR TITLE
Add function call to clear cached warnings

### DIFF
--- a/src/function/function_collection.cpp
+++ b/src/function/function_collection.cpp
@@ -217,9 +217,10 @@ FunctionCollection* FunctionCollection::getFunctions() {
         // Table functions
         TABLE_FUNCTION(CurrentSettingFunction), TABLE_FUNCTION(DBVersionFunction),
         TABLE_FUNCTION(ShowTablesFunction), TABLE_FUNCTION(ShowWarningsFunction),
-        TABLE_FUNCTION(TableInfoFunction), TABLE_FUNCTION(ShowConnectionFunction),
-        TABLE_FUNCTION(StorageInfoFunction), TABLE_FUNCTION(ShowAttachedDatabasesFunction),
-        TABLE_FUNCTION(ShowSequencesFunction), TABLE_FUNCTION(ShowFunctionsFunction),
+        TABLE_FUNCTION(ClearWarningsFunction), TABLE_FUNCTION(TableInfoFunction),
+        TABLE_FUNCTION(ShowConnectionFunction), TABLE_FUNCTION(StorageInfoFunction),
+        TABLE_FUNCTION(ShowAttachedDatabasesFunction), TABLE_FUNCTION(ShowSequencesFunction),
+        TABLE_FUNCTION(ShowFunctionsFunction),
 
         // Scan functions
         TABLE_FUNCTION(ParquetScanFunction), TABLE_FUNCTION(NpyScanFunction),

--- a/src/function/table/call/CMakeLists.txt
+++ b/src/function/table/call/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(kuzu_table_call
         show_attached_databases.cpp
         show_tables.cpp
         show_warnings.cpp
+        clear_warnings.cpp
         storage_info.cpp
         table_info.cpp
         show_sequences.cpp

--- a/src/function/table/call/clear_warnings.cpp
+++ b/src/function/table/call/clear_warnings.cpp
@@ -1,0 +1,44 @@
+#include "function/table/call_functions.h"
+#include "processor/warning_context.h"
+
+using namespace kuzu::common;
+
+namespace kuzu {
+namespace function {
+static constexpr offset_t singleValueReturnOffset = 1;
+
+static common::offset_t tableFunc(TableFuncInput& input, TableFuncOutput& output) {
+    auto& dataChunk = output.dataChunk;
+    auto sharedState = input.sharedState->ptrCast<CallFuncSharedState>();
+    auto morsel = sharedState->getMorsel();
+    if (!morsel.hasMoreToOutput()) {
+        return 0;
+    }
+    // we should only be reporting a single row containing the status code
+    KU_ASSERT(morsel.endOffset - morsel.startOffset == singleValueReturnOffset);
+    static constexpr uint64_t statusCodeColumnIdx = 0;
+    static constexpr uint8_t successStatusCode = 0;
+    dataChunk.getValueVector(statusCodeColumnIdx)->setValue(morsel.startOffset, successStatusCode);
+    return singleValueReturnOffset;
+}
+
+static std::unique_ptr<TableFuncBindData> bindFunc(main::ClientContext* context,
+    ScanTableFuncBindInput*) {
+    context->getWarningContextUnsafe().clearPopulatedWarnings();
+
+    std::vector<std::string> columnNames({"status"});
+    std::vector<LogicalType> columnTypes;
+    columnTypes.push_back(LogicalType::UINT8());
+    return std::make_unique<CallTableFuncBindData>(std::move(columnTypes), std::move(columnNames),
+        singleValueReturnOffset);
+}
+
+function_set ClearWarningsFunction::getFunctionSet() {
+    function_set functionSet;
+    functionSet.push_back(std::make_unique<TableFunction>(name, tableFunc, bindFunc,
+        initSharedState, initEmptyLocalState, std::vector<LogicalTypeID>{}));
+    return functionSet;
+}
+
+} // namespace function
+} // namespace kuzu

--- a/src/include/function/table/call_functions.h
+++ b/src/include/function/table/call_functions.h
@@ -75,6 +75,12 @@ struct ShowWarningsFunction : CallFunction {
     static function_set getFunctionSet();
 };
 
+struct ClearWarningsFunction : CallFunction {
+    static constexpr const char* name = "CLEAR_WARNINGS";
+
+    static function_set getFunctionSet();
+};
+
 struct TableInfoFunction : CallFunction {
     static constexpr const char* name = "TABLE_INFO";
 

--- a/src/include/processor/warning_context.h
+++ b/src/include/processor/warning_context.h
@@ -91,6 +91,7 @@ public:
 
     const std::vector<WarningInfo>& getPopulatedWarnings() const;
     uint64_t getWarningCount(uint64_t queryID);
+    void clearPopulatedWarnings();
 
     main::ClientConfig* getClientConfig();
 

--- a/src/processor/warning_context.cpp
+++ b/src/processor/warning_context.cpp
@@ -76,6 +76,11 @@ void WarningContext::populateWarnings(common::idx_t fileIdx, uint64_t queryID,
     unpopulatedWarnings[fileIdx].warnings.clear();
 }
 
+void WarningContext::clearPopulatedWarnings() {
+    populatedWarnings.clear();
+    numStoredWarnings = 0;
+}
+
 uint64_t WarningContext::getWarningCount(uint64_t) {
     auto ret = queryWarningCount;
     queryWarningCount = 0;

--- a/test/test_files/exceptions/copy/ignore_invalid_row.test
+++ b/test/test_files/exceptions/copy/ignore_invalid_row.test
@@ -97,6 +97,26 @@ neither QUOTE nor ESCAPE is proceeded by ESCAPE.|${KUZU_ROOT_DIRECTORY}/dataset/
 Conversion exception: Cast failed. Could not convert "2147483650" to INT32.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv|2|2,2147483650
 Conversion exception: Cast failed. Could not convert "01abc" to INT32.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv|5|5,01abc
 
+-CASE ParallelSkipInvalidNodeTableRowsClearWarnings
+-STATEMENT CALL warning_limit=2
+---- ok
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv" (IGNORE_ERRORS=true)
+---- ok
+-STATEMENT CALL show_warnings() RETURN message, file_path, line_number, skipped_line
+---- 2
+Conversion exception: Cast failed. Could not convert "2147483650" to INT32.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv|2|2,2147483650
+Conversion exception: Cast failed. Could not convert "01abc" to INT32.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv|5|5,01abc
+-STATEMENT CALL clear_warnings() RETURN status;
+---- ok
+-STATEMENT CALL show_warnings() RETURN *;
+---- 0
+-STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv" (IGNORE_ERRORS=true)
+---- ok
+-STATEMENT CALL show_warnings() RETURN message, file_path, line_number, skipped_line
+---- 2
+Conversion exception: Cast failed. Could not convert "2147483650" to INT32.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv|2|2,2147483650
+Conversion exception: Cast failed. Could not convert "01abc" to INT32.|${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv|5|5,01abc
+
 -CASE ParallelSkipInvalidRelMixed
 -STATEMENT COPY person FROM "${KUZU_ROOT_DIRECTORY}/dataset/copy-fault-tests/invalid-row/vPerson.csv" (IGNORE_ERRORS=true, ESCAPE="~")
 ---- ok


### PR DESCRIPTION
# Description

Fixes #4226

Adds function call `CALL clear_warnings() RETURN status` which clears accumulated warnings in the global `WarningContext`

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).