### PR TITLE
Simplify and scan rel operator and rel table scan interface 

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -23,9 +23,8 @@ static std::unique_ptr<RelTableScanState> getRelScanState(MemoryManager& memoryM
     // Empty columnIDs since we do not scan any rel property.
     auto columnIDs = std::vector<column_id_t>{};
     auto columns = std::vector<Column*>{};
-    // TODO(Guodong): FIX-ME.
-    auto scanState = std::make_unique<RelTableScanState>(memoryManager, columnIDs, columns, nullptr,
-        nullptr, direction);
+    auto scanState = std::make_unique<RelTableScanState>(memoryManager, INVALID_TABLE_ID, columnIDs,
+        columns, nullptr, nullptr, direction);
     scanState->nodeIDVector = srcVector;
     scanState->outputVectors.push_back(dstVector);
     return scanState;

--- a/src/include/common/assert.h
+++ b/src/include/common/assert.h
@@ -26,7 +26,8 @@ namespace common {
 #endif
 
 #define KU_UNREACHABLE                                                                             \
-    [[unlikely]] kuzu::common::kuAssertFailureInternal("KU_UNREACHABLE", __FILE__, __LINE__)
+    /* LCOV_EXCL_START */ [[unlikely]] kuzu::common::kuAssertFailureInternal("KU_UNREACHABLE",     \
+        __FILE__, __LINE__) /* LCOV_EXCL_STOP */
 #define KU_UNUSED(expr) (void)(expr)
 
 } // namespace common

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -22,10 +22,10 @@ public:
           numUnCommittedNodeGroups{0}, semiMask{std::move(semiMask)} {};
 
     void initialize(const transaction::Transaction* transaction, storage::NodeTable* table,
-        std::shared_ptr<ScanNodeTableProgressSharedState> progressSharedState);
+        ScanNodeTableProgressSharedState& progressSharedState);
 
     void nextMorsel(storage::NodeTableScanState& scanState,
-        std::shared_ptr<ScanNodeTableProgressSharedState> progressSharedState);
+        ScanNodeTableProgressSharedState& progressSharedState);
 
     common::NodeSemiMask* getSemiMask() const { return semiMask.get(); }
 

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -27,16 +27,20 @@ namespace storage {
 struct NodeTableScanState final : TableScanState {
     // Scan state for un-committed data.
     // Ideally we shouldn't need columns to scan un-checkpointed but committed data.
-    explicit NodeTableScanState(std::vector<common::column_id_t> columnIDs)
-        : NodeTableScanState{std::move(columnIDs), {}} {}
-    NodeTableScanState(std::vector<common::column_id_t> columnIDs, std::vector<Column*> columns)
-        : NodeTableScanState{std::move(columnIDs), std::move(columns),
+    NodeTableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs)
+        : NodeTableScanState{tableID, std::move(columnIDs), {}} {}
+    NodeTableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs,
+        std::vector<Column*> columns)
+        : NodeTableScanState{tableID, std::move(columnIDs), std::move(columns),
               std::vector<ColumnPredicateSet>{}} {}
-    NodeTableScanState(std::vector<common::column_id_t> columnIDs, std::vector<Column*> columns,
-        std::vector<ColumnPredicateSet> columnPredicateSets)
-        : TableScanState{std::move(columnIDs), std::move(columns), std::move(columnPredicateSets)} {
+    NodeTableScanState(common::table_id_t tableID, std::vector<common::column_id_t> columnIDs,
+        std::vector<Column*> columns, std::vector<ColumnPredicateSet> columnPredicateSets)
+        : TableScanState{tableID, std::move(columnIDs), std::move(columns),
+              std::move(columnPredicateSets)} {
         nodeGroupScanState = std::make_unique<NodeGroupScanState>(this->columnIDs.size());
     }
+
+    bool scanNext(transaction::Transaction* transaction) override;
 };
 
 struct NodeTableInsertState final : TableInsertState {
@@ -80,8 +84,9 @@ public:
         return types;
     }
 
-    NodeTable(StorageManager* storageManager, const catalog::NodeTableCatalogEntry* nodeTableEntry,
-        MemoryManager* memoryManager, common::VirtualFileSystem* vfs, main::ClientContext* context,
+    NodeTable(const StorageManager* storageManager,
+        const catalog::NodeTableCatalogEntry* nodeTableEntry, MemoryManager* memoryManager,
+        common::VirtualFileSystem* vfs, main::ClientContext* context,
         common::Deserializer* deSer = nullptr);
 
     static std::unique_ptr<NodeTable> loadTable(common::Deserializer& deSer,
@@ -94,8 +99,7 @@ public:
 
     common::row_idx_t getNumRows() override { return nodeGroups->getNumRows(); }
 
-    void initializeScanState(transaction::Transaction* transaction,
-        TableScanState& scanState) override;
+    void initScanState(transaction::Transaction* transaction, TableScanState& scanState) override;
 
     bool scanInternal(transaction::Transaction* transaction, TableScanState& scanState) override;
     bool lookup(transaction::Transaction* transaction, const TableScanState& scanState) const;

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -133,9 +133,7 @@ void StorageDriver::scanColumn(storage::Table* table, column_id_t columnID, offs
     auto column = &nodeTable->getColumn(columnID);
     std::vector<Column*> columns;
     columns.push_back(column);
-    std::vector<ColumnPredicateSet> emptyPredicateSets;
-    auto scanState =
-        std::make_unique<NodeTableScanState>(columnIDs, columns, std::move(emptyPredicateSets));
+    auto scanState = std::make_unique<NodeTableScanState>(table->getTableID(), columnIDs, columns);
     // Create value vectors
     auto idVector = std::make_unique<ValueVector>(LogicalType::INTERNAL_ID());
     auto columnVector = std::make_unique<ValueVector>(column->getDataType().copy(),

--- a/src/processor/operator/persistent/rel_batch_insert.cpp
+++ b/src/processor/operator/persistent/rel_batch_insert.cpp
@@ -4,7 +4,6 @@
 #include "common/exception/message.h"
 #include "common/string_format.h"
 #include "processor/result/factorized_table_util.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_utils.h"
 #include "storage/store/column_chunk_data.h"
 #include "storage/store/rel_table.h"

--- a/src/processor/operator/scan/offset_scan_node_table.cpp
+++ b/src/processor/operator/scan/offset_scan_node_table.cpp
@@ -42,7 +42,7 @@ bool OffsetScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
         nodeInfo.localScanState->source = TableScanSource::COMMITTED;
         nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeID.offset);
     }
-    nodeInfo.table->initializeScanState(transaction, *nodeInfo.localScanState);
+    nodeInfo.table->initScanState(transaction, *nodeInfo.localScanState);
     if (!nodeInfo.table->lookup(transaction, *nodeInfo.localScanState)) {
         // LCOV_EXCL_START
         throw RuntimeException(stringFormat("Cannot perform lookup on {}. This should not happen.",

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -37,7 +37,8 @@ void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
                 columns.push_back(&nodeInfo.table->getColumn(columnID));
             }
         }
-        nodeInfo.localScanState = std::make_unique<NodeTableScanState>(nodeInfo.columnIDs, columns);
+        nodeInfo.localScanState = std::make_unique<NodeTableScanState>(nodeInfo.table->getTableID(),
+            nodeInfo.columnIDs, columns);
         initVectors(*nodeInfo.localScanState, *resultSet);
     }
     indexEvaluator->init(*resultSet, context->clientContext);
@@ -82,7 +83,7 @@ bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
         nodeInfo.localScanState->source = TableScanSource::COMMITTED;
         nodeInfo.localScanState->nodeGroupIdx = StorageUtils::getNodeGroupIdx(nodeOffset);
     }
-    nodeInfo.table->initializeScanState(transaction, *nodeInfo.localScanState);
+    nodeInfo.table->initScanState(transaction, *nodeInfo.localScanState);
     return nodeInfo.table->lookup(transaction, *nodeInfo.localScanState);
 }
 

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -24,10 +24,7 @@ bool RelTableCollectionScanner::scan(Transaction* transaction) {
     while (true) {
         const auto& relInfo = relInfos[currentTableIdx];
         auto& scanState = *relInfo.scanState;
-        const auto skipScan =
-            transaction->isReadOnly() && scanState.zoneMapResult == ZoneMapCheckResult::SKIP_SCAN;
-        if (!skipScan && scanState.source != TableScanSource::NONE &&
-            relInfo.table->scan(transaction, scanState)) {
+        if (relInfo.table->scan(transaction, scanState)) {
             if (directionVector != nullptr) {
                 for (auto i = 0u; i < scanState.outState->getSelVector().getSelSize(); ++i) {
                     directionVector->setValue<bool>(i, directionValues[currentTableIdx]);
@@ -41,7 +38,7 @@ bool RelTableCollectionScanner::scan(Transaction* transaction) {
             if (currentTableIdx == relInfos.size()) {
                 return false;
             }
-            relInfos[currentTableIdx].table->initializeScanState(transaction,
+            relInfos[currentTableIdx].table->initScanState(transaction,
                 *relInfos[currentTableIdx].scanState);
             nextTableIdx++;
         }

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -26,7 +26,7 @@ std::string ScanNodeTablePrintInfo::toString() const {
 }
 
 void ScanNodeTableSharedState::initialize(const transaction::Transaction* transaction,
-    NodeTable* table, std::shared_ptr<ScanNodeTableProgressSharedState> progressSharedState) {
+    NodeTable* table, ScanNodeTableProgressSharedState& progressSharedState) {
     this->table = table;
     this->currentCommittedGroupIdx = 0;
     this->currentUnCommittedGroupIdx = 0;
@@ -38,15 +38,15 @@ void ScanNodeTableSharedState::initialize(const transaction::Transaction* transa
             this->numUnCommittedNodeGroups = localNodeTable.getNumNodeGroups();
         }
     }
-    progressSharedState->numGroups += numCommittedNodeGroups;
+    progressSharedState.numGroups += numCommittedNodeGroups;
 }
 
 void ScanNodeTableSharedState::nextMorsel(NodeTableScanState& scanState,
-    std::shared_ptr<ScanNodeTableProgressSharedState> progressSharedState) {
+    ScanNodeTableProgressSharedState& progressSharedState) {
     std::unique_lock lck{mtx};
     if (currentCommittedGroupIdx < numCommittedNodeGroups) {
         scanState.nodeGroupIdx = currentCommittedGroupIdx++;
-        progressSharedState->numGroupsScanned++;
+        progressSharedState.numGroupsScanned++;
         scanState.source = TableScanSource::COMMITTED;
         return;
     }
@@ -68,8 +68,8 @@ void ScanNodeTableInfo::initScanState(NodeSemiMask* semiMask) {
             columns.push_back(&table->getColumn(columnID));
         }
     }
-    localScanState =
-        std::make_unique<NodeTableScanState>(columnIDs, columns, copyVector(columnPredicates));
+    localScanState = std::make_unique<NodeTableScanState>(table->getTableID(), columnIDs, columns,
+        copyVector(columnPredicates));
     localScanState->semiMask = semiMask;
 }
 
@@ -100,7 +100,7 @@ void ScanNodeTable::initGlobalStateInternal(ExecutionContext* context) {
     KU_ASSERT(sharedStates.size() == nodeInfos.size());
     for (auto i = 0u; i < nodeInfos.size(); i++) {
         sharedStates[i]->initialize(context->clientContext->getTx(), nodeInfos[i].table,
-            progressSharedState);
+            *progressSharedState);
     }
 }
 
@@ -109,21 +109,16 @@ bool ScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
     while (currentTableIdx < nodeInfos.size()) {
         const auto& info = nodeInfos[currentTableIdx];
         auto& scanState = *info.localScanState;
-        const auto skipScan =
-            transaction->isReadOnly() && scanState.zoneMapResult == ZoneMapCheckResult::SKIP_SCAN;
-        if (!skipScan) {
-            while (scanState.source != TableScanSource::NONE &&
-                   info.table->scan(transaction, scanState)) {
-                if (scanState.outState->getSelVector().getSelSize() > 0) {
-                    return true;
-                }
+        while (info.table->scan(transaction, scanState)) {
+            if (scanState.outState->getSelVector().getSelSize() > 0) {
+                return true;
             }
         }
-        sharedStates[currentTableIdx]->nextMorsel(scanState, progressSharedState);
+        sharedStates[currentTableIdx]->nextMorsel(scanState, *progressSharedState);
         if (scanState.source == TableScanSource::NONE) {
             currentTableIdx++;
         } else {
-            info.table->initializeScanState(transaction, scanState);
+            info.table->initScanState(transaction, scanState);
         }
     }
     return false;

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -29,13 +29,13 @@ std::vector<LogicalType> LocalRelTable::getTypesForLocalRelTable(const RelTable&
 LocalRelTable::LocalRelTable(Table& table) : LocalTable{table} {
     localNodeGroup = std::make_unique<NodeGroup>(0, false,
         getTypesForLocalRelTable(table.cast<RelTable>()), INVALID_ROW_IDX);
-    auto& relTable = table.cast<RelTable>();
+    const auto& relTable = table.cast<RelTable>();
     nodeOffsetColumns[LOCAL_BOUND_NODE_ID_COLUMN_ID] = relTable.getFromNodeTableID();
     nodeOffsetColumns[LOCAL_NBR_NODE_ID_COLUMN_ID] = relTable.getToNodeTableID();
-    auto numColumns = relTable.getNumColumns();
+    const auto numColumns = relTable.getNumColumns();
     // skip NBR_ID and REL_ID, this assumes all INTERNAL_ID are node references
     for (auto i = 2u; i < numColumns; i++) {
-        auto column = relTable.getColumn(i, RelDataDirection::FWD);
+        const auto column = relTable.getColumn(i, RelDataDirection::FWD);
         if (column->getDataType().getPhysicalType() == PhysicalTypeID::INTERNAL_ID) {
             nodeOffsetColumns[i + 1] = column->cast<InternalIDColumn>().getCommonTableID();
         }
@@ -217,7 +217,8 @@ row_idx_t LocalRelTable::findMatchingRow(MemoryManager& memoryManager, offset_t 
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector<column_id_t> columnIDs;
     columnIDs.push_back(LOCAL_REL_ID_COLUMN_ID);
-    const auto scanState = std::make_unique<RelTableScanState>(memoryManager, columnIDs);
+    const auto scanState =
+        std::make_unique<RelTableScanState>(memoryManager, table.getTableID(), columnIDs);
     scanState->outState = scanChunk.state.get();
     scanState->rowIdxVector->state = scanChunk.state;
     scanState->outputVectors.push_back(scanChunk.getValueVector(0).get());

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -196,7 +196,6 @@ void ChunkedNodeGroup::scan(const Transaction* transaction, const TableScanState
     const NodeGroupScanState& nodeGroupScanState, offset_t rowIdxInGroup,
     length_t numRowsToScan) const {
     KU_ASSERT(rowIdxInGroup + numRowsToScan <= numRows);
-    std::unique_ptr<SelectionVector> selVector = nullptr;
     auto& anchorSelVector = scanState.outState->getSelVectorUnsafe();
     if (versionInfo) {
         versionInfo->getSelVectorToScan(transaction->getStartTS(), transaction->getID(),

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -196,16 +196,15 @@ void ChunkedNodeGroup::scan(const Transaction* transaction, const TableScanState
     const NodeGroupScanState& nodeGroupScanState, offset_t rowIdxInGroup,
     length_t numRowsToScan) const {
     KU_ASSERT(rowIdxInGroup + numRowsToScan <= numRows);
-    bool hasValuesToScan = true;
     std::unique_ptr<SelectionVector> selVector = nullptr;
     auto& anchorSelVector = scanState.outState->getSelVectorUnsafe();
-    anchorSelVector.setToUnfiltered(numRowsToScan);
     if (versionInfo) {
         versionInfo->getSelVectorToScan(transaction->getStartTS(), transaction->getID(),
             anchorSelVector, rowIdxInGroup, numRowsToScan);
-        hasValuesToScan = anchorSelVector.getSelSize() > 0;
+    } else {
+        anchorSelVector.setToUnfiltered(numRowsToScan);
     }
-    if (hasValuesToScan) {
+    if (anchorSelVector.getSelSize() > 0) {
         for (auto i = 0u; i < scanState.columnIDs.size(); i++) {
             const auto columnID = scanState.columnIDs[i];
             if (columnID == INVALID_COLUMN_ID) {

--- a/src/storage/store/csr_node_group.cpp
+++ b/src/storage/store/csr_node_group.cpp
@@ -626,7 +626,7 @@ void CSRNodeGroup::checkpointInMemOnly(const UniqLock& lock, NodeGroupCheckpoint
     const auto numColumnsToCheckpoint = csrState.columnIDs.size();
     const auto scanChunkState = std::make_shared<DataChunkState>();
     DataChunk scanChunk(csrState.columnIDs.size(), scanChunkState);
-    const auto scanState = std::make_unique<TableScanState>(csrState.columnIDs);
+    const auto scanState = std::make_unique<TableScanState>(INVALID_TABLE_ID, csrState.columnIDs);
     initInMemScanChunkAndScanState(csrState, scanChunk, *scanState);
 
     // Init data chunks to be appended and flushed.

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -18,7 +18,72 @@ using namespace kuzu::evaluator;
 namespace kuzu {
 namespace storage {
 
-RelTable::RelTable(RelTableCatalogEntry* relTableEntry, StorageManager* storageManager,
+RelTableScanState::RelTableScanState(MemoryManager& memoryManager, table_id_t tableID,
+    const std::vector<column_id_t>& columnIDs, const std::vector<Column*>& columns,
+    Column* csrOffsetCol, Column* csrLengthCol, RelDataDirection direction,
+    std::vector<ColumnPredicateSet> columnPredicateSets)
+    : TableScanState{tableID, columnIDs, columns, std::move(columnPredicateSets)},
+      direction{direction}, boundNodeOffset{INVALID_OFFSET}, csrOffsetColumn{csrOffsetCol},
+      csrLengthColumn{csrLengthCol}, localTableScanState{nullptr} {
+    nodeGroupScanState =
+        std::make_unique<CSRNodeGroupScanState>(memoryManager, this->columnIDs.size());
+    if (!this->columnPredicateSets.empty()) {
+        // Since we insert a nbr column. We need to pad an empty nbr column predicate set.
+        this->columnPredicateSets.insert(this->columnPredicateSets.begin(), ColumnPredicateSet());
+    }
+}
+
+void RelTableScanState::initState(Transaction* transaction, NodeGroup* nodeGroup) {
+    this->nodeGroup = nodeGroup;
+    if (this->nodeGroup) {
+        source = TableScanSource::COMMITTED;
+        this->nodeGroup->initializeScanState(transaction, *this);
+    } else if (localTableScanState) {
+        initLocalState();
+    } else {
+        source = TableScanSource::NONE;
+    }
+}
+
+bool RelTableScanState::scanNext(Transaction* transaction) {
+    switch (source) {
+    case TableScanSource::COMMITTED: {
+        const auto scanResult = nodeGroup->scan(transaction, *this);
+        if (scanResult == NODE_GROUP_SCAN_EMMPTY_RESULT) {
+            if (localTableScanState) {
+                initLocalState();
+            } else {
+                source = TableScanSource::NONE;
+                return false;
+            }
+        }
+        return true;
+    }
+    case TableScanSource::UNCOMMITTED: {
+        KU_ASSERT(localTableScanState && localTableScanState->localRelTable);
+        return localTableScanState->localRelTable->scan(transaction, *this);
+    }
+    case TableScanSource::NONE: {
+        return false;
+    }
+    default: {
+        KU_UNREACHABLE;
+    }
+    }
+}
+
+void RelTableScanState::initLocalState() {
+    KU_ASSERT(localTableScanState);
+    source = TableScanSource::UNCOMMITTED;
+    auto& localScanState = *localTableScanState;
+    KU_ASSERT(localScanState.localRelTable);
+    localScanState.boundNodeOffset = boundNodeOffset;
+    localScanState.rowIdxVector->setState(rowIdxVector->state);
+    localScanState.localRelTable->initializeScan(*localTableScanState);
+    localScanState.nextRowToScan = 0;
+}
+
+RelTable::RelTable(RelTableCatalogEntry* relTableEntry, const StorageManager* storageManager,
     MemoryManager* memoryManager, Deserializer* deSer)
     : Table{relTableEntry, storageManager, memoryManager},
       fromNodeTableID{relTableEntry->getSrcTableID()},
@@ -39,7 +104,7 @@ std::unique_ptr<RelTable> RelTable::loadTable(Deserializer& deSer, const Catalog
     deSer.deserializeValue<table_id_t>(tableID);
     deSer.validateDebuggingInfo(key, "next_rel_offset");
     deSer.deserializeValue<offset_t>(nextRelOffset);
-    auto catalogEntry = catalog.getTableCatalogEntry(&DUMMY_TRANSACTION, tableID);
+    const auto catalogEntry = catalog.getTableCatalogEntry(&DUMMY_TRANSACTION, tableID);
     if (!catalogEntry) {
         throw RuntimeException(
             stringFormat("Load table failed: table {} doesn't exist in catalog.", tableID));
@@ -50,73 +115,31 @@ std::unique_ptr<RelTable> RelTable::loadTable(Deserializer& deSer, const Catalog
     return relTable;
 }
 
-void RelTable::initializeScanState(Transaction* transaction, TableScanState& scanState) {
-    // Scan always start with committed data first.
+void RelTable::initScanState(Transaction* transaction, TableScanState& scanState) {
     auto& relScanState = scanState.cast<RelTableScanState>();
-
     relScanState.boundNodeOffset = relScanState.nodeIDVector->readNodeOffset(
         relScanState.nodeIDVector->state->getSelVector()[0]);
+    NodeGroup* nodeGroup;
     if (relScanState.boundNodeOffset >= StorageConstants::MAX_NUM_ROWS_IN_TABLE) {
-        relScanState.nodeGroup = nullptr;
+        nodeGroup = nullptr;
     } else {
         // Check if the node group idx is same as previous scan.
         const auto nodeGroupIdx = StorageUtils::getNodeGroupIdx(relScanState.boundNodeOffset);
         if (relScanState.nodeGroupIdx != nodeGroupIdx) {
             // We need to re-initialize the node group scan state.
-            relScanState.nodeGroup = relScanState.direction == RelDataDirection::FWD ?
-                                         fwdRelTableData->getNodeGroup(nodeGroupIdx) :
-                                         bwdRelTableData->getNodeGroup(nodeGroupIdx);
+            nodeGroup = relScanState.direction == RelDataDirection::FWD ?
+                            fwdRelTableData->getNodeGroup(nodeGroupIdx) :
+                            bwdRelTableData->getNodeGroup(nodeGroupIdx);
+        } else {
+            nodeGroup = relScanState.nodeGroup;
         }
     }
-    if (relScanState.nodeGroup) {
-        relScanState.source = TableScanSource::COMMITTED;
-        relScanState.nodeGroup->initializeScanState(transaction, scanState);
-    } else if (relScanState.localTableScanState) {
-        initializeLocalRelScanState(relScanState);
-    } else {
-        relScanState.source = TableScanSource::NONE;
-    }
-}
-
-void RelTable::initializeLocalRelScanState(RelTableScanState& relScanState) {
-    relScanState.source = TableScanSource::UNCOMMITTED;
-    KU_ASSERT(relScanState.localTableScanState);
-    auto& localScanState = *relScanState.localTableScanState;
-    KU_ASSERT(localScanState.localRelTable);
-    localScanState.boundNodeOffset = relScanState.boundNodeOffset;
-    localScanState.rowIdxVector->setState(relScanState.rowIdxVector->state);
-    localScanState.localRelTable->initializeScan(*relScanState.localTableScanState);
-    localScanState.nextRowToScan = 0;
+    scanState.initState(transaction, nodeGroup);
 }
 
 bool RelTable::scanInternal(Transaction* transaction, TableScanState& scanState) {
     auto& relScanState = scanState.cast<RelTableScanState>();
-    relScanState.outState->getSelVectorUnsafe().setToUnfiltered();
-    switch (relScanState.source) {
-    case TableScanSource::COMMITTED: {
-        const auto scanResult = relScanState.nodeGroup->scan(transaction, scanState);
-        if (scanResult == NODE_GROUP_SCAN_EMMPTY_RESULT) {
-            if (relScanState.localTableScanState) {
-                initializeLocalRelScanState(relScanState);
-            } else {
-                relScanState.source = TableScanSource::NONE;
-                return false;
-            }
-        }
-        return true;
-    }
-    case TableScanSource::UNCOMMITTED: {
-        const auto localScanState = relScanState.localTableScanState.get();
-        KU_ASSERT(localScanState && localScanState->localRelTable);
-        return localScanState->localRelTable->scan(transaction, scanState);
-    }
-    case TableScanSource::NONE: {
-        return false;
-    }
-    default: {
-        KU_UNREACHABLE;
-    }
-    }
+    return relScanState.scanNext(transaction);
 }
 
 void RelTable::insert(Transaction* transaction, TableInsertState& insertState) {
@@ -128,7 +151,7 @@ void RelTable::insert(Transaction* transaction, TableInsertState& insertState) {
         KU_ASSERT(transaction->isWriteTransaction());
         KU_ASSERT(transaction->getClientContext());
         auto& wal = transaction->getClientContext()->getStorageManager()->getWAL();
-        auto& relInsertState = insertState.cast<RelTableInsertState>();
+        const auto& relInsertState = insertState.cast<RelTableInsertState>();
         std::vector<ValueVector*> vectorsToLog;
         vectorsToLog.push_back(&relInsertState.srcNodeIDVector);
         vectorsToLog.push_back(&relInsertState.dstNodeIDVector);
@@ -209,14 +232,14 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
     const auto reverseTableData =
         direction == RelDataDirection::FWD ? bwdRelTableData.get() : fwdRelTableData.get();
     std::vector<column_id_t> columnsToScan = {NBR_ID_COLUMN_ID, REL_ID_COLUMN_ID};
-    const auto relReadState =
-        std::make_unique<RelTableScanState>(memoryManager, columnsToScan, tableData->getColumns(),
-            tableData->getCSROffsetColumn(), tableData->getCSRLengthColumn(), direction);
+    const auto relReadState = std::make_unique<RelTableScanState>(memoryManager, tableID,
+        columnsToScan, tableData->getColumns(), tableData->getCSROffsetColumn(),
+        tableData->getCSRLengthColumn(), direction);
     relReadState->nodeIDVector = &deleteState->srcNodeIDVector;
     relReadState->outputVectors =
         std::vector<ValueVector*>{&deleteState->dstNodeIDVector, &deleteState->relIDVector};
-    relReadState->rowIdxVector->state = relReadState->outputVectors[1]->state;
-    relReadState->outState = relReadState->rowIdxVector->state.get();
+    relReadState->outState = relReadState->outputVectors[0]->state.get();
+    relReadState->rowIdxVector->state = relReadState->outputVectors[0]->state;
     if (const auto localRelTable = transaction->getLocalStorage()->getLocalTable(tableID,
             LocalStorage::NotExistAction::RETURN_NULL)) {
         auto localTableColumnIDs =
@@ -225,7 +248,7 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
             *relReadState, localTableColumnIDs, localRelTable->ptrCast<LocalRelTable>());
         relReadState->localTableScanState->rowIdxVector->state = relReadState->rowIdxVector->state;
     }
-    initializeScanState(transaction, *relReadState);
+    initScanState(transaction, *relReadState);
     detachDeleteForCSRRels(transaction, tableData, reverseTableData, relReadState.get(),
         deleteState);
     if (transaction->shouldLogToWAL()) {
@@ -249,14 +272,14 @@ void RelTable::checkIfNodeHasRels(Transaction* transaction, RelDataDirection dir
         bwdRelTableData->checkIfNodeHasRels(transaction, srcNodeIDVector);
 }
 
-void RelTable::detachDeleteForCSRRels(Transaction* transaction, RelTableData* tableData,
-    RelTableData* reverseTableData, RelTableScanState* relDataReadState,
+void RelTable::detachDeleteForCSRRels(Transaction* transaction, const RelTableData* tableData,
+    const RelTableData* reverseTableData, RelTableScanState* relDataReadState,
     RelTableDeleteState* deleteState) {
     const auto localTable = transaction->getLocalStorage()->getLocalTable(tableID,
         LocalStorage::NotExistAction::RETURN_NULL);
-    auto tempState = deleteState->dstNodeIDVector.state.get();
+    const auto tempState = deleteState->dstNodeIDVector.state.get();
     while (scan(transaction, *relDataReadState)) {
-        auto numRelsScanned = tempState->getSelVector().getSelSize();
+        const auto numRelsScanned = tempState->getSelVector().getSelSize();
         tempState->getSelVectorUnsafe().setToFiltered(1);
         for (auto i = 0u; i < numRelsScanned; i++) {
             tempState->getSelVectorUnsafe()[0] = i;

--- a/src/storage/store/version_info.cpp
+++ b/src/storage/store/version_info.cpp
@@ -403,8 +403,7 @@ void VersionInfo::getSelVectorToScan(const transaction_t startTS, const transact
     auto [endVectorIdx, endRowIdxInVector] =
         StorageUtils::getQuotientRemainder(startRow + numRows - 1, DEFAULT_VECTOR_CAPACITY);
     auto vectorIdx = startVectorIdx;
-    selVector.setSelSize(0);
-    KU_ASSERT(selVector.isUnfiltered());
+    selVector.setToUnfiltered(0);
     sel_t outputPos = 0u;
     while (vectorIdx <= endVectorIdx) {
         const auto startRowIdx = vectorIdx == startVectorIdx ? startRowIdxInVector : 0;


### PR DESCRIPTION
# Description

- Move the internal scan logic into TableScanState.
- Removed the unnecessary allocation of SelectionVector in `ChunkedNodeGroup::scan`.