### PR TITLE
Skip scan of rel id when possible

### DIFF
--- a/src/expression_evaluator/pattern_evaluator.cpp
+++ b/src/expression_evaluator/pattern_evaluator.cpp
@@ -45,6 +45,7 @@ void PatternExpressionEvaluator::initFurther(const ResultSet&) {
     StructPackFunctions::compileFunc(nullptr, parameters, resultVector);
     const auto& dataType = expression->getDataType();
     auto fieldIdx = StructType::getFieldIdx(dataType.copy(), InternalKeyword::ID);
+    KU_ASSERT(fieldIdx != INVALID_STRUCT_FIELD_IDX);
     idVector = StructVector::getFieldVector(resultVector.get(), fieldIdx).get();
 }
 

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -226,21 +226,20 @@ std::vector<nodeID_t> OnDiskGraph::scanBwdRandom(nodeID_t, GraphScanState&) {
     return result;
 }
 
-void OnDiskGraph::scan(nodeID_t nodeID, RelTable* relTable, OnDiskGraphScanStates& scanState,
-    RelTableScanState& relTableScanState, std::vector<nodeID_t>& nbrNodeIDs) {
-    scanState.srcNodeIDVector->setValue<nodeID_t>(0, nodeID);
-    relTableScanState.resetState();
-    relTable->initializeScanState(context->getTx(), relTableScanState);
-    while (relTableScanState.source != TableScanSource::NONE &&
-           relTable->scan(context->getTx(), relTableScanState)) {
-        if (relTableScanState.IDVector->state->getSelVector().getSelSize() > 0) {
-            for (auto i = 0u; i < relTableScanState.IDVector->state->getSelVector().getSelSize();
-                 ++i) {
-                auto nbrID = relTableScanState.IDVector->getValue<nodeID_t>(i);
-                nbrNodeIDs.push_back(nbrID);
-            }
-        }
-    }
+void OnDiskGraph::scan(nodeID_t, RelTable*, OnDiskGraphScanStates&, RelTableScanState&,
+    std::vector<nodeID_t>&) {
+    // scanState.srcNodeIDVector->setValue<nodeID_t>(0, nodeID);
+    // relTableScanState.resetState();
+    // relTable->initializeScanState(context->getTx(), relTableScanState);
+    // while (relTableScanState.source != TableScanSource::NONE &&
+    //        relTable->scan(context->getTx(), relTableScanState)) {
+    //     if (relTableScanState.outState->getSelVector().getSelSize() > 0) {
+    //         for (auto i = 0u; i < relTableScanState.outState->getSelVector().getSelSize(); ++i) {
+    //             auto nbrID = relTableScanState.IDVector->getValue<nodeID_t>(i);
+    //             nbrNodeIDs.push_back(nbrID);
+    //         }
+    //     }
+    // }
 }
 
 } // namespace graph

--- a/src/include/processor/operator/filtering_operator.h
+++ b/src/include/processor/operator/filtering_operator.h
@@ -18,7 +18,7 @@ public:
     virtual ~SelVectorOverWriter() = default;
 
 protected:
-    void restoreSelVector(common::DataChunkState& dataChunkState);
+    void restoreSelVector(common::DataChunkState& dataChunkState) const;
 
     void saveSelVector(common::DataChunkState& dataChunkState);
 

--- a/src/include/processor/operator/flatten.h
+++ b/src/include/processor/operator/flatten.h
@@ -11,14 +11,14 @@ struct FlattenLocalState {
     uint64_t sizeToFlatten = 0;
 };
 
-class Flatten : public PhysicalOperator, SelVectorOverWriter {
+class Flatten final : public PhysicalOperator, SelVectorOverWriter {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::FLATTEN;
 
 public:
     Flatten(data_chunk_pos_t dataChunkToFlattenPos, std::unique_ptr<PhysicalOperator> child,
         uint32_t id, std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{type_, std::move(child), id, std::move(printInfo)},
-          dataChunkToFlattenPos{dataChunkToFlattenPos} {}
+          dataChunkToFlattenPos{dataChunkToFlattenPos}, dataChunkState{nullptr} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 

--- a/src/include/processor/operator/persistent/delete_executor.h
+++ b/src/include/processor/operator/persistent/delete_executor.h
@@ -136,6 +136,10 @@ struct RelDeleteInfo {
     common::ValueVector* dstNodeIDVector = nullptr;
     common::ValueVector* relIDVector = nullptr;
 
+    RelDeleteInfo()
+        : srcNodeIDPos{INVALID_DATA_CHUNK_POS, INVALID_VALUE_VECTOR_POS},
+          dstNodeIDPos{INVALID_DATA_CHUNK_POS, INVALID_VALUE_VECTOR_POS},
+          relIDPos{INVALID_DATA_CHUNK_POS, INVALID_VALUE_VECTOR_POS} {}
     RelDeleteInfo(DataPos srcNodeIDPos, DataPos dstNodeIDPos, DataPos relIDPos)
         : srcNodeIDPos{srcNodeIDPos}, dstNodeIDPos{dstNodeIDPos}, relIDPos{relIDPos} {}
     EXPLICIT_COPY_DEFAULT_MOVE(RelDeleteInfo);
@@ -154,7 +158,7 @@ public:
     RelDeleteExecutor(const RelDeleteExecutor& other) : info{other.info.copy()} {}
     virtual ~RelDeleteExecutor() = default;
 
-    void init(ResultSet* resultSet, ExecutionContext* context);
+    virtual void init(ResultSet* resultSet, ExecutionContext* context);
 
     virtual void delete_(ExecutionContext* context) = 0;
 
@@ -166,8 +170,10 @@ protected:
 
 class EmptyRelDeleteExecutor final : public RelDeleteExecutor {
 public:
-    explicit EmptyRelDeleteExecutor(RelDeleteInfo info) : RelDeleteExecutor{std::move(info)} {}
+    explicit EmptyRelDeleteExecutor() : RelDeleteExecutor{RelDeleteInfo{}} {}
     EmptyRelDeleteExecutor(const EmptyRelDeleteExecutor& other) : RelDeleteExecutor{other} {}
+
+    void init(ResultSet*, ExecutionContext*) override {}
 
     void delete_(ExecutionContext*) override {}
 

--- a/src/include/processor/operator/scan/offset_scan_node_table.h
+++ b/src/include/processor/operator/scan/offset_scan_node_table.h
@@ -7,7 +7,7 @@ namespace processor {
 
 // OffsetScanNodeTable is only used as the source operator for RecursiveJoin and thus cannot be
 // executed in parallel. Therefore, it does not have a shared state.
-class OffsetScanNodeTable : public ScanTable {
+class OffsetScanNodeTable final : public ScanTable {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::OFFSET_SCAN_NODE_TABLE;
 
 public:

--- a/src/include/processor/operator/scan/scan_multi_rel_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_rel_tables.h
@@ -48,7 +48,7 @@ private:
     uint32_t nextTableIdx = 0;
 };
 
-class ScanMultiRelTable : public ScanTable {
+class ScanMultiRelTable final : public ScanTable {
     static constexpr PhysicalOperatorType type_ = PhysicalOperatorType::SCAN_REL_TABLE;
 
 public:
@@ -57,13 +57,14 @@ public:
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : ScanTable{type_, std::move(info), std::move(child), id, std::move(printInfo)},
-          directionInfo{std::move(directionInfo)}, scanners{std::move(scanners)} {}
+          directionInfo{std::move(directionInfo)}, boundNodeIDVector{nullptr},
+          scanners{std::move(scanners)}, currentScanner{nullptr} {}
 
-    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) final;
+    void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
 
-    bool getNextTuplesInternal(ExecutionContext* context) final;
+    bool getNextTuplesInternal(ExecutionContext* context) override;
 
-    std::unique_ptr<PhysicalOperator> clone() final;
+    std::unique_ptr<PhysicalOperator> clone() override;
 
 private:
     void resetState();
@@ -71,9 +72,9 @@ private:
 
 private:
     DirectionInfo directionInfo;
-    common::ValueVector* boundNodeIDVector = nullptr;
+    common::ValueVector* boundNodeIDVector;
     common::table_id_map_t<RelTableCollectionScanner> scanners;
-    RelTableCollectionScanner* currentScanner = nullptr;
+    RelTableCollectionScanner* currentScanner;
 };
 
 } // namespace processor

--- a/src/include/storage/store/node_table.h
+++ b/src/include/storage/store/node_table.h
@@ -28,15 +28,10 @@ struct NodeTableScanState final : TableScanState {
     // Scan state for un-committed data.
     // Ideally we shouldn't need columns to scan un-checkpointed but committed data.
     explicit NodeTableScanState(std::vector<common::column_id_t> columnIDs)
-        : TableScanState{std::move(columnIDs), {}} {
-        nodeGroupScanState = std::make_unique<NodeGroupScanState>(this->columnIDs.size());
-    }
-
+        : NodeTableScanState{std::move(columnIDs), {}} {}
     NodeTableScanState(std::vector<common::column_id_t> columnIDs, std::vector<Column*> columns)
-        : TableScanState{std::move(columnIDs), std::move(columns),
-              std::vector<ColumnPredicateSet>{}} {
-        nodeGroupScanState = std::make_unique<NodeGroupScanState>(this->columnIDs.size());
-    }
+        : NodeTableScanState{std::move(columnIDs), std::move(columns),
+              std::vector<ColumnPredicateSet>{}} {}
     NodeTableScanState(std::vector<common::column_id_t> columnIDs, std::vector<Column*> columns,
         std::vector<ColumnPredicateSet> columnPredicateSets)
         : TableScanState{std::move(columnIDs), std::move(columns), std::move(columnPredicateSets)} {

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -29,18 +29,12 @@ struct RelTableScanState : TableScanState {
         const std::vector<common::column_id_t>& columnIDs)
         : RelTableScanState(memoryManager, columnIDs, {}, nullptr, nullptr,
               common::RelDataDirection::FWD /* This is a dummy direction */,
-              std::vector<ColumnPredicateSet>{}) {
-        nodeGroupScanState =
-            std::make_unique<CSRNodeGroupScanState>(memoryManager, this->columnIDs.size());
-    }
+              std::vector<ColumnPredicateSet>{}) {}
     RelTableScanState(MemoryManager& memoryManager,
         const std::vector<common::column_id_t>& columnIDs, const std::vector<Column*>& columns,
         Column* csrOffsetCol, Column* csrLengthCol, common::RelDataDirection direction)
         : RelTableScanState(memoryManager, columnIDs, columns, csrOffsetCol, csrLengthCol,
-              direction, std::vector<ColumnPredicateSet>{}) {
-        nodeGroupScanState =
-            std::make_unique<CSRNodeGroupScanState>(memoryManager, this->columnIDs.size());
-    }
+              direction, std::vector<ColumnPredicateSet>{}) {}
     RelTableScanState(MemoryManager& memoryManager,
         const std::vector<common::column_id_t>& columnIDs, const std::vector<Column*>& columns,
         Column* csrOffsetCol, Column* csrLengthCol, common::RelDataDirection direction,
@@ -76,7 +70,6 @@ struct LocalRelTableScanState final : RelTableScanState {
     LocalRelTableScanState(MemoryManager& memoryManager, const RelTableScanState& state,
         const std::vector<common::column_id_t>& columnIDs, LocalRelTable* localRelTable)
         : RelTableScanState{memoryManager, columnIDs}, localRelTable{localRelTable} {
-        IDVector = state.IDVector;
         direction = state.direction;
         boundNodeIDVector = state.boundNodeIDVector;
         outputVectors = state.outputVectors;

--- a/src/main/storage_driver.cpp
+++ b/src/main/storage_driver.cpp
@@ -144,7 +144,7 @@ void StorageDriver::scanColumn(storage::Table* table, column_id_t columnID, offs
     idVector->state = vectorState;
     columnVector->state = vectorState;
     scanState->rowIdxVector->state = vectorState;
-    scanState->IDVector = idVector.get();
+    scanState->nodeIDVector = idVector.get();
     scanState->outputVectors.push_back(columnVector.get());
     // Scan
     // TODO: validate not more than 1 level nested

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -185,7 +185,8 @@ void ProjectionPushDownOptimizer::visitDelete(LogicalOperator* op) {
             auto& rel = info.pattern->constCast<RelExpression>();
             collectExpressionsInUse(rel.getSrcNode()->getInternalID());
             collectExpressionsInUse(rel.getDstNode()->getInternalID());
-            if (!rel.isEmpty() && rel.getRelType() == QueryRelType::NON_RECURSIVE) {
+            KU_ASSERT(rel.getRelType() == QueryRelType::NON_RECURSIVE);
+            if (!rel.isEmpty()) {
                 collectExpressionsInUse(rel.getInternalIDProperty());
             }
         }

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -185,7 +185,9 @@ void ProjectionPushDownOptimizer::visitDelete(LogicalOperator* op) {
             auto& rel = info.pattern->constCast<RelExpression>();
             collectExpressionsInUse(rel.getSrcNode()->getInternalID());
             collectExpressionsInUse(rel.getDstNode()->getInternalID());
-            collectExpressionsInUse(rel.getInternalIDProperty());
+            if (!rel.isEmpty() && rel.getRelType() == QueryRelType::NON_RECURSIVE) {
+                collectExpressionsInUse(rel.getInternalIDProperty());
+            }
         }
     } break;
     default:

--- a/src/planner/operator/persistent/logical_delete.cpp
+++ b/src/planner/operator/persistent/logical_delete.cpp
@@ -21,7 +21,7 @@ std::string LogicalDelete::getExpressionsForPrinting() const {
 
 f_group_pos_set LogicalDelete::getGroupsPosToFlatten() const {
     KU_ASSERT(!infos.empty());
-    auto childSchema = children[0]->getSchema();
+    const auto childSchema = children[0]->getSchema();
     f_group_pos_set dependentGroupPos;
     switch (infos[0].tableType) {
     case TableType::NODE: {

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -6,7 +6,6 @@
 #include "catalog/catalog.h"
 #include "catalog/catalog_entry/rel_table_catalog_entry.h"
 #include "common/enums/join_type.h"
-#include "common/exception/runtime.h"
 #include "planner/join_order/cost_model.h"
 #include "planner/operator/extend/logical_extend.h"
 #include "planner/operator/extend/logical_recursive_extend.h"

--- a/src/planner/plan/append_extend.cpp
+++ b/src/planner/plan/append_extend.cpp
@@ -78,27 +78,10 @@ static std::shared_ptr<Expression> getIRIProperty(const expression_vector& prope
     return nullptr;
 }
 
-static void validatePropertiesContainRelID(const RelExpression& rel,
-    const expression_vector& properties) {
-    if (rel.isEmpty()) {
-        return;
-    }
-    for (auto& property : properties) {
-        if (*property == *rel.getInternalIDProperty()) {
-            return;
-        }
-    }
-    // LCOV_EXCL_START
-    throw RuntimeException(stringFormat(
-        "Internal ID of relationship {} is not scanned. This should not happen.", rel.toString()));
-    // LCOV_EXCL_STOP
-}
-
 void Planner::appendNonRecursiveExtend(const std::shared_ptr<NodeExpression>& boundNode,
     const std::shared_ptr<NodeExpression>& nbrNode, const std::shared_ptr<RelExpression>& rel,
     ExtendDirection direction, bool extendFromSource, const expression_vector& properties,
     LogicalPlan& plan) {
-    validatePropertiesContainRelID(*rel, properties);
     // Filter bound node label if we know some incoming nodes won't have any outgoing rel. This
     // cannot be done at binding time because the pruning is affected by extend direction.
     auto boundNodeTableIDSet = getBoundNodeTableIDSet(*rel, direction);

--- a/src/processor/map/map_extend.cpp
+++ b/src/processor/map/map_extend.cpp
@@ -91,13 +91,12 @@ std::unique_ptr<PhysicalOperator> PlanMapper::mapExtend(LogicalOperator* logical
     auto prevOperator = mapOperator(logicalOperator->getChild(0).get());
     auto inNodeIDPos = getDataPos(*boundNode->getInternalID(), *inFSchema);
     auto outNodeIDPos = getDataPos(*nbrNode->getInternalID(), *outFSchema);
-    auto relIDPos = getDataPos(*rel->getInternalIDProperty(), *outFSchema);
     std::vector<DataPos> outVectorsPos;
     outVectorsPos.push_back(outNodeIDPos);
     for (auto& expression : extend->getProperties()) {
         outVectorsPos.push_back(getDataPos(*expression, *outFSchema));
     }
-    auto scanInfo = ScanTableInfo(relIDPos, outVectorsPos);
+    auto scanInfo = ScanTableInfo(inNodeIDPos, outVectorsPos);
     std::vector<std::string> tableNames;
     auto storageManager = clientContext->getStorageManager();
     for (auto entry : rel->getEntries()) {

--- a/src/processor/operator/filtering_operator.cpp
+++ b/src/processor/operator/filtering_operator.cpp
@@ -9,7 +9,7 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace processor {
 
-void SelVectorOverWriter::restoreSelVector(DataChunkState& dataChunkState) {
+void SelVectorOverWriter::restoreSelVector(DataChunkState& dataChunkState) const {
     if (prevSelVector != nullptr) {
         dataChunkState.setSelVector(prevSelVector);
     }

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -68,7 +68,7 @@ bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
         return false;
     }
     auto nodeID = nodeID_t{nodeOffset, nodeInfo.table->getTableID()};
-    nodeInfo.localScanState->IDVector->setValue<nodeID_t>(pos, nodeID);
+    nodeInfo.localScanState->nodeIDVector->setValue<nodeID_t>(pos, nodeID);
     if (nodeOffset >= StorageConstants::MAX_NUM_ROWS_IN_TABLE) {
         nodeInfo.localScanState->source = TableScanSource::UNCOMMITTED;
         nodeInfo.localScanState->nodeGroupIdx =

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -87,7 +87,7 @@ bool ScanMultiRelTable::getNextTuplesInternal(ExecutionContext* context) {
             resetState();
             return false;
         }
-        const auto currentIdx = IDVector->state->getSelVector()[0];
+        const auto currentIdx = boundNodeIDVector->state->getSelVector()[0];
         if (boundNodeIDVector->isNull(currentIdx)) {
             outState->getSelVectorUnsafe().setSelSize(0);
             continue;

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -107,7 +107,7 @@ bool ScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {
         if (!skipScan) {
             while (scanState.source != TableScanSource::NONE &&
                    info.table->scan(transaction, scanState)) {
-                if (scanState.IDVector->state->getSelVector().getSelSize() > 0) {
+                if (scanState.outState->getSelVector().getSelSize() > 0) {
                     return true;
                 }
             }

--- a/src/processor/operator/scan/scan_rel_table.cpp
+++ b/src/processor/operator/scan/scan_rel_table.cpp
@@ -94,7 +94,7 @@ bool ScanRelTable::getNextTuplesInternal(ExecutionContext* context) {
         if (!skipScan) {
             while (scanState.source != TableScanSource::NONE &&
                    relInfo.table->scan(transaction, scanState)) {
-                if (scanState.IDVector->state->getSelVector().getSelSize() > 0) {
+                if (scanState.outState->getSelVector().getSelSize() > 0) {
                     return true;
                 }
             }

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -13,8 +13,11 @@ void ScanTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) 
 }
 
 void ScanTable::initVectors(storage::TableScanState& state, const ResultSet& resultSet) const {
-    state.IDVector = resultSet.getValueVector(info.IDPos).get();
-    state.rowIdxVector->state = IDVector->state;
+    state.nodeIDVector = resultSet.getValueVector(info.IDPos).get();
+    state.rowIdxVector->state = info.outVectorsPos.empty() ?
+                                    state.nodeIDVector->state :
+                                    resultSet.getValueVector(info.outVectorsPos[0])->state;
+    state.outState = outState;
     for (auto& pos : info.outVectorsPos) {
         state.outputVectors.push_back(resultSet.getValueVector(pos).get());
     }

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -218,7 +218,7 @@ row_idx_t LocalRelTable::findMatchingRow(MemoryManager& memoryManager, offset_t 
     std::vector<column_id_t> columnIDs;
     columnIDs.push_back(LOCAL_REL_ID_COLUMN_ID);
     const auto scanState = std::make_unique<RelTableScanState>(memoryManager, columnIDs);
-    scanState->IDVector = scanChunk.getValueVector(0).get();
+    scanState->outState = scanChunk.state.get();
     scanState->rowIdxVector->state = scanChunk.state;
     scanState->outputVectors.push_back(scanChunk.getValueVector(0).get());
     scanChunk.state->getSelVectorUnsafe().setSelSize(intersectRows.size());

--- a/src/storage/store/chunked_node_group.cpp
+++ b/src/storage/store/chunked_node_group.cpp
@@ -204,7 +204,7 @@ void ChunkedNodeGroup::scan(const Transaction* transaction, const TableScanState
             rowIdxInGroup, numRowsToScan);
         hasValuesToScan = selVector->getSelSize() > 0;
     }
-    auto& anchorSelVector = scanState.IDVector->state->getSelVectorUnsafe();
+    auto& anchorSelVector = scanState.outState->getSelVectorUnsafe();
     if (selVector && selVector->getSelSize() != numRowsToScan) {
         std::memcpy(anchorSelVector.getMultableBuffer().data(),
             selVector->getMultableBuffer().data(), selVector->getSelSize() * sizeof(sel_t));

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -147,7 +147,7 @@ NodeGroupScanResult NodeGroup::scan(Transaction* transaction, TableScanState& st
         const auto startNodeOffset = nodeGroupScanState.nextRowToScan +
                                      StorageUtils::getStartOffsetOfNodeGroup(state.nodeGroupIdx);
         if (!state.semiMask->isMasked(startNodeOffset, startNodeOffset + numRowsToScan - 1)) {
-            state.IDVector->state->getSelVectorUnsafe().setSelSize(0);
+            state.outState->getSelVectorUnsafe().setSelSize(0);
             nodeGroupScanState.nextRowToScan += numRowsToScan;
             return NodeGroupScanResult{nodeGroupScanState.nextRowToScan, 0};
         }


### PR DESCRIPTION
# Description

Currently, we all scan `REL_ID` regardless if it's projected or not.
This PR removed the logic of always projecting `REL_ID` property when scan rel tables. This can improve performance of scan rel in some level.

LDBC30 dataset on my local Mac mini 2023 (M2 Pro).
```
// Q1: match (a)-[e:likeComment]->(b) return count(*);
|  master  | current |
| -------- | ------- |
| 696.65ms | 357.96ms |

// Q2: match (a)-[e:knows]->(b) return count(*);
|  master | current |
| ------- | ------- |
| 96.18ms | 51.72ms |
```

Future todo: we don't always need to scan NBR ID from rel tables, which should also be optimized away later.