### PR TITLE
Remove unncessary scan of nbrNodeID from rel tables

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -26,7 +26,7 @@ static std::unique_ptr<RelTableScanState> getRelScanState(MemoryManager& memoryM
     // TODO(Guodong): FIX-ME.
     auto scanState = std::make_unique<RelTableScanState>(memoryManager, columnIDs, columns, nullptr,
         nullptr, direction);
-    scanState->boundNodeIDVector = srcVector;
+    scanState->nodeIDVector = srcVector;
     scanState->outputVectors.push_back(dstVector);
     return scanState;
 }

--- a/src/include/planner/operator/extend/logical_extend.h
+++ b/src/include/planner/operator/extend/logical_extend.h
@@ -6,7 +6,7 @@
 namespace kuzu {
 namespace planner {
 
-class LogicalExtend : public BaseLogicalExtend {
+class LogicalExtend final : public BaseLogicalExtend {
     static constexpr LogicalOperatorType type_ = LogicalOperatorType::EXTEND;
 
 public:
@@ -16,7 +16,7 @@ public:
         binder::expression_vector properties, std::shared_ptr<LogicalOperator> child)
         : BaseLogicalExtend{type_, std::move(boundNode), std::move(nbrNode), std::move(rel),
               direction, extendFromSource, std::move(child)},
-          properties{std::move(properties)} {}
+          scanNbrID{true}, properties{std::move(properties)} {}
 
     f_group_pos_set getGroupsPosToFlatten() override;
 
@@ -30,10 +30,13 @@ public:
     const std::vector<storage::ColumnPredicateSet>& getPropertyPredicates() const {
         return propertyPredicates;
     }
+    void setScanNbrID(bool scanNbrID_) { scanNbrID = scanNbrID_; }
+    bool shouldScanNbrID() const { return scanNbrID; }
 
     std::unique_ptr<LogicalOperator> copy() override;
 
 private:
+    bool scanNbrID;
     binder::expression_vector properties;
     std::vector<storage::ColumnPredicateSet> propertyPredicates;
 };

--- a/src/include/processor/operator/scan/offset_scan_node_table.h
+++ b/src/include/processor/operator/scan/offset_scan_node_table.h
@@ -31,8 +31,12 @@ public:
     }
 
 private:
+    void initVectors(storage::TableScanState& state, const ResultSet& resultSet) const override;
+
+private:
     common::table_id_map_t<ScanNodeTableInfo> tableIDToNodeInfo;
     bool executed;
+    common::ValueVector* nodeIDVector;
 };
 
 } // namespace processor

--- a/src/include/processor/operator/scan/primary_key_scan_node_table.h
+++ b/src/include/processor/operator/scan/primary_key_scan_node_table.h
@@ -60,6 +60,9 @@ public:
     }
 
 private:
+    void initVectors(storage::TableScanState& state, const ResultSet& resultSet) const override;
+
+private:
     std::vector<ScanNodeTableInfo> nodeInfos;
     std::unique_ptr<evaluator::ExpressionEvaluator> indexEvaluator;
     std::shared_ptr<PrimaryKeyScanSharedState> sharedState;

--- a/src/include/processor/operator/scan/scan_multi_rel_tables.h
+++ b/src/include/processor/operator/scan/scan_multi_rel_tables.h
@@ -34,7 +34,7 @@ public:
         nextTableIdx = 0;
     }
 
-    bool scan(const common::SelectionVector& selVector, transaction::Transaction* transaction);
+    bool scan(transaction::Transaction* transaction);
 
 private:
     RelTableCollectionScanner(const RelTableCollectionScanner& other)
@@ -57,7 +57,7 @@ public:
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : ScanTable{type_, std::move(info), std::move(child), id, std::move(printInfo)},
-          directionInfo{std::move(directionInfo)}, boundNodeIDVector{nullptr},
+          directionInfo{std::move(directionInfo)}, boundNodeIDVector{nullptr}, outState{nullptr},
           scanners{std::move(scanners)}, currentScanner{nullptr} {}
 
     void initLocalStateInternal(ResultSet* resultSet, ExecutionContext* context) override;
@@ -69,10 +69,12 @@ public:
 private:
     void resetState();
     void initCurrentScanner(const common::nodeID_t& nodeID);
+    void initVectors(storage::TableScanState& state, const ResultSet& resultSet) const override;
 
 private:
     DirectionInfo directionInfo;
     common::ValueVector* boundNodeIDVector;
+    common::DataChunkState* outState;
     common::table_id_map_t<RelTableCollectionScanner> scanners;
     RelTableCollectionScanner* currentScanner;
 };

--- a/src/include/processor/operator/scan/scan_node_table.h
+++ b/src/include/processor/operator/scan/scan_node_table.h
@@ -112,6 +112,7 @@ public:
 
 private:
     void initGlobalStateInternal(ExecutionContext* context) override;
+    void initVectors(storage::TableScanState& state, const ResultSet& resultSet) const override;
 
 private:
     common::idx_t currentTableIdx;

--- a/src/include/processor/operator/scan/scan_rel_table.h
+++ b/src/include/processor/operator/scan/scan_rel_table.h
@@ -15,25 +15,24 @@ namespace processor {
 struct ScanRelTableInfo {
     storage::RelTable* table;
     common::RelDataDirection direction;
-    DataPos boundNodeIDPos;
     std::vector<common::column_id_t> columnIDs;
     std::vector<storage::ColumnPredicateSet> columnPredicates;
 
     std::unique_ptr<storage::RelTableScanState> scanState;
 
     ScanRelTableInfo(storage::RelTable* table, common::RelDataDirection direction,
-        DataPos boundNodeIDPos, std::vector<common::column_id_t> columnIDs,
+        std::vector<common::column_id_t> columnIDs,
         std::vector<storage::ColumnPredicateSet> columnPredicates)
-        : table{table}, direction{direction}, boundNodeIDPos{boundNodeIDPos},
-          columnIDs{std::move(columnIDs)}, columnPredicates{std::move(columnPredicates)} {}
+        : table{table}, direction{direction}, columnIDs{std::move(columnIDs)},
+          columnPredicates{std::move(columnPredicates)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ScanRelTableInfo);
 
     void initScanState(storage::MemoryManager& memoryManager);
 
 private:
     ScanRelTableInfo(const ScanRelTableInfo& other)
-        : table{other.table}, direction{other.direction}, boundNodeIDPos{other.boundNodeIDPos},
-          columnIDs{other.columnIDs}, columnPredicates{copyVector(other.columnPredicates)} {}
+        : table{other.table}, direction{other.direction}, columnIDs{other.columnIDs},
+          columnPredicates{copyVector(other.columnPredicates)} {}
 };
 
 struct ScanRelTablePrintInfo final : OPPrintInfo {

--- a/src/include/processor/operator/scan/scan_table.h
+++ b/src/include/processor/operator/scan/scan_table.h
@@ -7,18 +7,18 @@ namespace kuzu {
 namespace processor {
 
 struct ScanTableInfo {
-    // Node/Rel ID vector position.
-    DataPos IDPos;
+    // Node ID vector position.
+    DataPos nodeIDPos;
     // Output vector (properties or CSRs) positions
     std::vector<DataPos> outVectorsPos;
 
     ScanTableInfo(DataPos nodeIDPos, std::vector<DataPos> outVectorsPos)
-        : IDPos{nodeIDPos}, outVectorsPos{std::move(outVectorsPos)} {}
+        : nodeIDPos{nodeIDPos}, outVectorsPos{std::move(outVectorsPos)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ScanTableInfo);
 
 private:
     ScanTableInfo(const ScanTableInfo& other)
-        : IDPos{other.IDPos}, outVectorsPos{other.outVectorsPos} {}
+        : nodeIDPos{other.nodeIDPos}, outVectorsPos{other.outVectorsPos} {}
 };
 
 class ScanTable : public PhysicalOperator {
@@ -27,24 +27,17 @@ public:
         std::unique_ptr<PhysicalOperator> child, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
         : PhysicalOperator{operatorType, std::move(child), id, std::move(printInfo)},
-          info{std::move(info)}, IDVector{nullptr}, outState{nullptr} {}
+          info{std::move(info)} {}
 
     ScanTable(PhysicalOperatorType operatorType, ScanTableInfo info, uint32_t id,
         std::unique_ptr<OPPrintInfo> printInfo)
-        : PhysicalOperator{operatorType, id, std::move(printInfo)}, info{std::move(info)},
-          IDVector{nullptr}, outState{nullptr} {}
+        : PhysicalOperator{operatorType, id, std::move(printInfo)}, info{std::move(info)} {}
 
 protected:
-    void initLocalStateInternal(ResultSet*, ExecutionContext*) override;
-
     virtual void initVectors(storage::TableScanState& state, const ResultSet& resultSet) const;
 
 protected:
     ScanTableInfo info;
-    // Node/Rel id vector.
-    common::ValueVector* IDVector;
-    // All output vectors share the same state.
-    common::DataChunkState* outState;
 };
 
 } // namespace processor

--- a/src/include/storage/store/rel_table.h
+++ b/src/include/storage/store/rel_table.h
@@ -17,7 +17,6 @@ class MemoryManager;
 struct LocalRelTableScanState;
 struct RelTableScanState : TableScanState {
     common::RelDataDirection direction;
-    common::ValueVector* boundNodeIDVector;
     common::offset_t boundNodeOffset;
     Column* csrOffsetColumn;
     Column* csrLengthColumn;
@@ -40,9 +39,8 @@ struct RelTableScanState : TableScanState {
         Column* csrOffsetCol, Column* csrLengthCol, common::RelDataDirection direction,
         std::vector<ColumnPredicateSet> columnPredicateSets)
         : TableScanState{columnIDs, columns, std::move(columnPredicateSets)}, direction{direction},
-          boundNodeIDVector{nullptr}, boundNodeOffset{common::INVALID_OFFSET},
-          csrOffsetColumn{csrOffsetCol}, csrLengthColumn{csrLengthCol},
-          localTableScanState{nullptr} {
+          boundNodeOffset{common::INVALID_OFFSET}, csrOffsetColumn{csrOffsetCol},
+          csrLengthColumn{csrLengthCol}, localTableScanState{nullptr} {
         nodeGroupScanState =
             std::make_unique<CSRNodeGroupScanState>(memoryManager, this->columnIDs.size());
         if (!this->columnPredicateSets.empty()) {
@@ -71,7 +69,7 @@ struct LocalRelTableScanState final : RelTableScanState {
         const std::vector<common::column_id_t>& columnIDs, LocalRelTable* localRelTable)
         : RelTableScanState{memoryManager, columnIDs}, localRelTable{localRelTable} {
         direction = state.direction;
-        boundNodeIDVector = state.boundNodeIDVector;
+        nodeIDVector = state.nodeIDVector;
         outputVectors = state.outputVectors;
         // Setting source to UNCOMMITTED is not necessary but just to keep it semantically
         // consistent.

--- a/src/optimizer/projection_push_down_optimizer.cpp
+++ b/src/optimizer/projection_push_down_optimizer.cpp
@@ -56,9 +56,11 @@ void ProjectionPushDownOptimizer::visitPathPropertyProbe(LogicalOperator* op) {
 }
 
 void ProjectionPushDownOptimizer::visitExtend(LogicalOperator* op) {
-    auto& extend = op->constCast<LogicalExtend>();
-    auto boundNodeID = extend.getBoundNode()->getInternalID();
+    auto& extend = op->cast<LogicalExtend>();
+    const auto boundNodeID = extend.getBoundNode()->getInternalID();
     collectExpressionsInUse(boundNodeID);
+    const auto nbrNodeID = extend.getNbrNode()->getInternalID();
+    extend.setScanNbrID(propertiesInUse.contains(nbrNodeID));
 }
 
 void ProjectionPushDownOptimizer::visitAccumulate(LogicalOperator* op) {

--- a/src/planner/operator/extend/logical_extend.cpp
+++ b/src/planner/operator/extend/logical_extend.cpp
@@ -45,6 +45,7 @@ std::unique_ptr<LogicalOperator> LogicalExtend::copy() {
     auto extend = std::make_unique<LogicalExtend>(boundNode, nbrNode, rel, direction,
         extendFromSource_, properties, children[0]->copy());
     extend->setPropertyPredicates(copyVector(propertyPredicates));
+    extend->scanNbrID = scanNbrID;
     return extend;
 }
 

--- a/src/processor/operator/scan/primary_key_scan_node_table.cpp
+++ b/src/processor/operator/scan/primary_key_scan_node_table.cpp
@@ -27,7 +27,6 @@ idx_t PrimaryKeyScanSharedState::getTableIdx() {
 
 void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
     ExecutionContext* context) {
-    ScanTable::initLocalStateInternal(resultSet, context);
     for (auto& nodeInfo : nodeInfos) {
         std::vector<Column*> columns;
         columns.reserve(nodeInfo.columnIDs.size());
@@ -42,6 +41,12 @@ void PrimaryKeyScanNodeTable::initLocalStateInternal(ResultSet* resultSet,
         initVectors(*nodeInfo.localScanState, *resultSet);
     }
     indexEvaluator->init(*resultSet, context->clientContext);
+}
+
+void PrimaryKeyScanNodeTable::initVectors(TableScanState& state, const ResultSet& resultSet) const {
+    ScanTable::initVectors(state, resultSet);
+    state.rowIdxVector->state = state.nodeIDVector->state;
+    state.outState = state.rowIdxVector->state.get();
 }
 
 bool PrimaryKeyScanNodeTable::getNextTuplesInternal(ExecutionContext* context) {

--- a/src/processor/operator/scan/scan_node_table.cpp
+++ b/src/processor/operator/scan/scan_node_table.cpp
@@ -90,6 +90,12 @@ void ScanNodeTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContex
     }
 }
 
+void ScanNodeTable::initVectors(TableScanState& state, const ResultSet& resultSet) const {
+    ScanTable::initVectors(state, resultSet);
+    state.rowIdxVector->state = state.nodeIDVector->state;
+    state.outState = state.rowIdxVector->state.get();
+}
+
 void ScanNodeTable::initGlobalStateInternal(ExecutionContext* context) {
     KU_ASSERT(sharedStates.size() == nodeInfos.size());
     for (auto i = 0u; i < nodeInfos.size(); i++) {

--- a/src/processor/operator/scan/scan_table.cpp
+++ b/src/processor/operator/scan/scan_table.cpp
@@ -3,21 +3,8 @@
 namespace kuzu {
 namespace processor {
 
-void ScanTable::initLocalStateInternal(ResultSet* resultSet, ExecutionContext*) {
-    IDVector = resultSet->getValueVector(info.IDPos).get();
-    if (info.outVectorsPos.empty()) {
-        outState = IDVector->state.get();
-    } else {
-        outState = resultSet->getValueVector(info.outVectorsPos[0])->state.get();
-    }
-}
-
 void ScanTable::initVectors(storage::TableScanState& state, const ResultSet& resultSet) const {
-    state.nodeIDVector = resultSet.getValueVector(info.IDPos).get();
-    state.rowIdxVector->state = info.outVectorsPos.empty() ?
-                                    state.nodeIDVector->state :
-                                    resultSet.getValueVector(info.outVectorsPos[0])->state;
-    state.outState = outState;
+    state.nodeIDVector = resultSet.getValueVector(info.nodeIDPos).get();
     for (auto& pos : info.outVectorsPos) {
         state.outputVectors.push_back(resultSet.getValueVector(pos).get());
     }

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -54,8 +54,8 @@ void RelTable::initializeScanState(Transaction* transaction, TableScanState& sca
     // Scan always start with committed data first.
     auto& relScanState = scanState.cast<RelTableScanState>();
 
-    relScanState.boundNodeOffset = relScanState.boundNodeIDVector->readNodeOffset(
-        relScanState.boundNodeIDVector->state->getSelVector()[0]);
+    relScanState.boundNodeOffset = relScanState.nodeIDVector->readNodeOffset(
+        relScanState.nodeIDVector->state->getSelVector()[0]);
     if (relScanState.boundNodeOffset >= StorageConstants::MAX_NUM_ROWS_IN_TABLE) {
         relScanState.nodeGroup = nullptr;
     } else {
@@ -212,7 +212,7 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
     const auto relReadState =
         std::make_unique<RelTableScanState>(memoryManager, columnsToScan, tableData->getColumns(),
             tableData->getCSROffsetColumn(), tableData->getCSRLengthColumn(), direction);
-    relReadState->boundNodeIDVector = &deleteState->srcNodeIDVector;
+    relReadState->nodeIDVector = &deleteState->srcNodeIDVector;
     relReadState->outputVectors =
         std::vector<ValueVector*>{&deleteState->dstNodeIDVector, &deleteState->relIDVector};
     relReadState->rowIdxVector->state = relReadState->outputVectors[1]->state;

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -125,7 +125,7 @@ std::pair<CSRNodeGroupScanSource, row_idx_t> RelTableData::findMatchingRow(Trans
     std::vector<Column*> columns{getColumn(REL_ID_COLUMN_ID), nullptr};
     const auto scanState = std::make_unique<RelTableScanState>(*memoryManager, columnIDs, columns,
         csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);
-    scanState->boundNodeIDVector = &boundNodeIDVector;
+    scanState->nodeIDVector = &boundNodeIDVector;
     scanState->outputVectors.push_back(scanChunk.getValueVector(0).get());
     const auto scannedIDVector = scanState->outputVectors[0];
     scanState->outState = scannedIDVector->state.get();
@@ -173,7 +173,7 @@ void RelTableData::checkIfNodeHasRels(Transaction* transaction,
     std::vector<Column*> columns{getColumn(REL_ID_COLUMN_ID)};
     const auto scanState = std::make_unique<RelTableScanState>(*memoryManager, columnIDs, columns,
         csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);
-    scanState->boundNodeIDVector = srcNodeIDVector;
+    scanState->nodeIDVector = srcNodeIDVector;
     scanState->outputVectors.push_back(scanChunk.getValueVector(0).get());
     scanState->outState = scanState->outputVectors[0]->state.get();
     scanState->source = TableScanSource::COMMITTED;


### PR DESCRIPTION
# Description

`nbrNodeID` is always scanned regardless needed or not currently, similar to `relID`.
This PR optimizes the unnecessary scan of `nbrNodeID` away when possible by replacing the `NBR_ID_COLUMN_ID` with `INVALID_COLUMN_ID`.

Also, add more strict checks to optimize away unnecessary rel table scans in multi-label or undirected rel table scans.

Some benchmark numbers here:
LDBC30 dataset on my local Mac mini 2023 (M2 Pro).
```
// Q1: match (a)-[e:likeComment]->(b) return count(*);
|  master  | current |
| -------- | ------- |
| 355.13ms | 18.17ms |

// Q2: match (a)-[e:knows]->(b) return count(*);
|  master | current |
| ------- | ------- |
| 51.12ms | 19.11ms |
```

@andyfengHKU I found that under many cases involving undirected and mutli-labled rel table scans, we apply NodeLabelFilter, which first is invisible in our query plan somehow, second I wonder if we can have more restricted apply of it.