### PR TITLE
Fix rel checkpoint due to incrrect set null and misaligned gaps due to empty src node

### DIFF
--- a/src/include/storage/store/csr_node_group.h
+++ b/src/include/storage/store/csr_node_group.h
@@ -227,8 +227,6 @@ private:
 
     void populateCSRLengthInMemOnly(const common::UniqLock& lock, common::offset_t numNodes,
         const CSRNodeGroupCheckpointState& csrState);
-    void initInMemScanChunkAndScanState(const CSRNodeGroupCheckpointState& csrState,
-        common::DataChunk& dataChunk, TableScanState& scanState) const;
 
     void collectRegionChangesAndUpdateHeaderLength(const common::UniqLock& lock, CSRRegion& region,
         const CSRNodeGroupCheckpointState& csrState);
@@ -245,6 +243,8 @@ private:
     common::row_idx_t getNumDeletionsForNodeInPersistentData(common::offset_t nodeOffset,
         const CSRNodeGroupCheckpointState& csrState) const;
 
+    static void initScanStateFromScanChunk(const CSRNodeGroupCheckpointState& csrState,
+        const common::DataChunk& dataChunk, TableScanState& scanState);
     static void redistributeCSRRegions(const CSRNodeGroupCheckpointState& csrState,
         const std::vector<CSRRegion>& leafRegions);
     static std::vector<CSRRegion> mergeRegionsToCheckpoint(


### PR DESCRIPTION
# Description

Gaps incorrectly set when the node is at the end of a region and `numRows` for the node is `0`.
