### PR TITLE
Avoid unnecessary allocation of CSR header chunks when scanning from local rel tables

### DIFF
--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -6,7 +6,6 @@
 #include "common/vector/value_vector.h"
 #include "graph/graph.h"
 #include "main/client_context.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/storage_manager.h"
 #include "storage/store/rel_table.h"
 
@@ -18,8 +17,8 @@ using namespace kuzu::common;
 namespace kuzu {
 namespace graph {
 
-static std::unique_ptr<RelTableScanState> getRelScanState(MemoryManager& memoryManager,
-    RelDataDirection direction, ValueVector* srcVector, ValueVector* dstVector) {
+static std::unique_ptr<RelTableScanState> getRelScanState(RelDataDirection direction,
+    ValueVector* srcVector, ValueVector* dstVector) {
     // Empty columnIDs since we do not scan any rel property.
     auto columnIDs = std::vector<column_id_t>{};
     auto columns = std::vector<Column*>{};
@@ -30,12 +29,10 @@ static std::unique_ptr<RelTableScanState> getRelScanState(MemoryManager& memoryM
     return scanState;
 }
 
-OnDiskGraphScanState::OnDiskGraphScanState(MemoryManager& memoryManager,
-    ValueVector* srcNodeIDVector, ValueVector* dstNodeIDVector) {
-    fwdScanState =
-        getRelScanState(memoryManager, RelDataDirection::FWD, srcNodeIDVector, dstNodeIDVector);
-    bwdScanState =
-        getRelScanState(memoryManager, RelDataDirection::BWD, srcNodeIDVector, dstNodeIDVector);
+OnDiskGraphScanState::OnDiskGraphScanState(ValueVector* srcNodeIDVector,
+    ValueVector* dstNodeIDVector) {
+    fwdScanState = getRelScanState(RelDataDirection::FWD, srcNodeIDVector, dstNodeIDVector);
+    bwdScanState = getRelScanState(RelDataDirection::BWD, srcNodeIDVector, dstNodeIDVector);
 }
 
 OnDiskGraphScanStates::OnDiskGraphScanStates(std::span<table_id_t> tableIDs, MemoryManager* mm) {
@@ -49,7 +46,7 @@ OnDiskGraphScanStates::OnDiskGraphScanStates(std::span<table_id_t> tableIDs, Mem
 
     for (auto tableID : tableIDs) {
         scanStates.emplace_back(std::make_pair(tableID,
-            OnDiskGraphScanState(*mm, srcNodeIDVector.get(), dstNodeIDVector.get())));
+            OnDiskGraphScanState(srcNodeIDVector.get(), dstNodeIDVector.get())));
     }
 }
 

--- a/src/graph/on_disk_graph.cpp
+++ b/src/graph/on_disk_graph.cpp
@@ -23,8 +23,8 @@ static std::unique_ptr<RelTableScanState> getRelScanState(MemoryManager& memoryM
     // Empty columnIDs since we do not scan any rel property.
     auto columnIDs = std::vector<column_id_t>{};
     auto columns = std::vector<Column*>{};
-    auto scanState = std::make_unique<RelTableScanState>(memoryManager, INVALID_TABLE_ID, columnIDs,
-        columns, nullptr, nullptr, direction);
+    auto scanState = std::make_unique<RelTableScanState>(INVALID_TABLE_ID, columnIDs, columns,
+        nullptr, nullptr, direction);
     scanState->nodeIDVector = srcVector;
     scanState->outputVectors.push_back(dstVector);
     return scanState;

--- a/src/include/graph/on_disk_graph.h
+++ b/src/include/graph/on_disk_graph.h
@@ -16,8 +16,8 @@ struct OnDiskGraphScanState {
     std::unique_ptr<storage::RelTableScanState> fwdScanState;
     std::unique_ptr<storage::RelTableScanState> bwdScanState;
 
-    explicit OnDiskGraphScanState(storage::MemoryManager& memoryManager,
-        common::ValueVector* srcNodeIDVector, common::ValueVector* dstNodeIDVector);
+    explicit OnDiskGraphScanState(common::ValueVector* srcNodeIDVector,
+        common::ValueVector* dstNodeIDVector);
 };
 
 class OnDiskGraphScanStates : public GraphScanState {

--- a/src/include/processor/operator/scan/scan_rel_table.h
+++ b/src/include/processor/operator/scan/scan_rel_table.h
@@ -27,7 +27,7 @@ struct ScanRelTableInfo {
           columnPredicates{std::move(columnPredicates)} {}
     EXPLICIT_COPY_DEFAULT_MOVE(ScanRelTableInfo);
 
-    void initScanState(storage::MemoryManager& memoryManager);
+    void initScanState();
 
 private:
     ScanRelTableInfo(const ScanRelTableInfo& other)

--- a/src/include/storage/local_storage/local_rel_table.h
+++ b/src/include/storage/local_storage/local_rel_table.h
@@ -65,7 +65,7 @@ public:
         common::column_id_t columnID);
 
 private:
-    common::row_idx_t findMatchingRow(MemoryManager& memoryManager, common::offset_t srcNodeOffset,
+    common::row_idx_t findMatchingRow(common::offset_t srcNodeOffset,
         common::offset_t dstNodeOffset, common::offset_t relOffset);
 
 private:

--- a/src/processor/operator/scan/scan_multi_rel_tables.cpp
+++ b/src/processor/operator/scan/scan_multi_rel_tables.cpp
@@ -51,7 +51,7 @@ void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionCo
     outState = resultSet->getValueVector(info.outVectorsPos[0])->state.get();
     for (auto& [_, scanner] : scanners) {
         for (auto& relInfo : scanner.relInfos) {
-            relInfo.initScanState(*context->clientContext->getMemoryManager());
+            relInfo.initScanState();
             initVectors(*relInfo.scanState, *resultSet);
             auto& scanState = relInfo.scanState->cast<RelTableScanState>();
             KU_ASSERT(outState == scanState.outState);
@@ -61,9 +61,9 @@ void ScanMultiRelTable::initLocalStateInternal(ResultSet* resultSet, ExecutionCo
                         relInfo.table->getTableID(), LocalStorage::NotExistAction::RETURN_NULL)) {
                 auto localTableColumnIDs = LocalRelTable::rewriteLocalColumnIDs(relInfo.direction,
                     relInfo.scanState->columnIDs);
-                relInfo.scanState->localTableScanState = std::make_unique<LocalRelTableScanState>(
-                    *context->clientContext->getMemoryManager(), *relInfo.scanState,
-                    localTableColumnIDs, localRelTable->ptrCast<LocalRelTable>());
+                relInfo.scanState->localTableScanState =
+                    std::make_unique<LocalRelTableScanState>(*relInfo.scanState,
+                        localTableColumnIDs, localRelTable->ptrCast<LocalRelTable>());
             }
             if (directionInfo.directionPos.isValid()) {
                 scanner.directionVector =

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -87,8 +87,7 @@ bool LocalRelTable::update(Transaction* transaction, TableUpdateState& state) {
     const auto srcNodeOffset = updateState.srcNodeIDVector.readNodeOffset(srcNodePos);
     const auto dstNodeOffset = updateState.dstNodeIDVector.readNodeOffset(dstNodePos);
     const auto relOffset = updateState.relIDVector.readNodeOffset(relIDPos);
-    const auto matchedRow =
-        findMatchingRow(table.getMemoryManager(), srcNodeOffset, dstNodeOffset, relOffset);
+    const auto matchedRow = findMatchingRow(srcNodeOffset, dstNodeOffset, relOffset);
     if (matchedRow == INVALID_ROW_IDX) {
         return false;
     }
@@ -112,8 +111,7 @@ bool LocalRelTable::delete_(Transaction*, TableDeleteState& state) {
     const auto srcNodeOffset = deleteState.srcNodeIDVector.readNodeOffset(srcNodePos);
     const auto dstNodeOffset = deleteState.dstNodeIDVector.readNodeOffset(dstNodePos);
     const auto relOffset = deleteState.relIDVector.readNodeOffset(relIDPos);
-    const auto matchedRow =
-        findMatchingRow(table.getMemoryManager(), srcNodeOffset, dstNodeOffset, relOffset);
+    const auto matchedRow = findMatchingRow(srcNodeOffset, dstNodeOffset, relOffset);
     if (matchedRow == INVALID_ROW_IDX) {
         return false;
     }
@@ -203,8 +201,8 @@ bool LocalRelTable::scan(Transaction* transaction, TableScanState& state) const 
     return true;
 }
 
-row_idx_t LocalRelTable::findMatchingRow(MemoryManager& memoryManager, offset_t srcNodeOffset,
-    offset_t dstNodeOffset, offset_t relOffset) {
+row_idx_t LocalRelTable::findMatchingRow(offset_t srcNodeOffset, offset_t dstNodeOffset,
+    offset_t relOffset) {
     auto& fwdRows = fwdIndex[srcNodeOffset];
     std::sort(fwdRows.begin(), fwdRows.end());
     auto& bwdRows = bwdIndex[dstNodeOffset];
@@ -217,8 +215,7 @@ row_idx_t LocalRelTable::findMatchingRow(MemoryManager& memoryManager, offset_t 
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector<column_id_t> columnIDs;
     columnIDs.push_back(LOCAL_REL_ID_COLUMN_ID);
-    const auto scanState =
-        std::make_unique<RelTableScanState>(memoryManager, table.getTableID(), columnIDs);
+    const auto scanState = std::make_unique<RelTableScanState>(table.getTableID(), columnIDs);
     scanState->outState = scanChunk.state.get();
     scanState->rowIdxVector->state = scanChunk.state;
     scanState->outputVectors.push_back(scanChunk.getValueVector(0).get());

--- a/src/storage/local_storage/local_rel_table.cpp
+++ b/src/storage/local_storage/local_rel_table.cpp
@@ -5,7 +5,6 @@
 #include "common/enums/rel_direction.h"
 #include "common/exception/message.h"
 #include "common/exception/runtime.h"
-#include "storage/buffer_manager/memory_manager.h"
 #include "storage/store/rel_table.h"
 #include "transaction/transaction.h"
 

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -224,7 +224,6 @@ bool RelTable::delete_(Transaction* transaction, TableDeleteState& deleteState) 
 
 void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction,
     RelTableDeleteState* deleteState) {
-    auto& memoryManager = *transaction->getClientContext()->getMemoryManager();
     KU_ASSERT(deleteState->srcNodeIDVector.state->getSelVector().getSelSize() == 1);
     const auto tableData =
         direction == RelDataDirection::FWD ? fwdRelTableData.get() : bwdRelTableData.get();

--- a/src/storage/store/rel_table.cpp
+++ b/src/storage/store/rel_table.cpp
@@ -18,15 +18,13 @@ using namespace kuzu::evaluator;
 namespace kuzu {
 namespace storage {
 
-RelTableScanState::RelTableScanState(MemoryManager& memoryManager, table_id_t tableID,
-    const std::vector<column_id_t>& columnIDs, const std::vector<Column*>& columns,
-    Column* csrOffsetCol, Column* csrLengthCol, RelDataDirection direction,
-    std::vector<ColumnPredicateSet> columnPredicateSets)
+RelTableScanState::RelTableScanState(table_id_t tableID, const std::vector<column_id_t>& columnIDs,
+    const std::vector<Column*>& columns, Column* csrOffsetCol, Column* csrLengthCol,
+    RelDataDirection direction, std::vector<ColumnPredicateSet> columnPredicateSets)
     : TableScanState{tableID, columnIDs, columns, std::move(columnPredicateSets)},
       direction{direction}, boundNodeOffset{INVALID_OFFSET}, csrOffsetColumn{csrOffsetCol},
       csrLengthColumn{csrLengthCol}, localTableScanState{nullptr} {
-    nodeGroupScanState =
-        std::make_unique<CSRNodeGroupScanState>(memoryManager, this->columnIDs.size());
+    nodeGroupScanState = std::make_unique<CSRNodeGroupScanState>(this->columnIDs.size());
     if (!this->columnPredicateSets.empty()) {
         // Since we insert a nbr column. We need to pad an empty nbr column predicate set.
         this->columnPredicateSets.insert(this->columnPredicateSets.begin(), ColumnPredicateSet());
@@ -39,6 +37,7 @@ void RelTableScanState::initState(Transaction* transaction, NodeGroup* nodeGroup
         source = TableScanSource::COMMITTED;
         this->nodeGroup->initializeScanState(transaction, *this);
     } else if (localTableScanState) {
+        source = TableScanSource::UNCOMMITTED;
         initLocalState();
     } else {
         source = TableScanSource::NONE;
@@ -51,6 +50,7 @@ bool RelTableScanState::scanNext(Transaction* transaction) {
         const auto scanResult = nodeGroup->scan(transaction, *this);
         if (scanResult == NODE_GROUP_SCAN_EMMPTY_RESULT) {
             if (localTableScanState) {
+                source = TableScanSource::UNCOMMITTED;
                 initLocalState();
             } else {
                 source = TableScanSource::NONE;
@@ -72,9 +72,8 @@ bool RelTableScanState::scanNext(Transaction* transaction) {
     }
 }
 
-void RelTableScanState::initLocalState() {
+void RelTableScanState::initLocalState() const {
     KU_ASSERT(localTableScanState);
-    source = TableScanSource::UNCOMMITTED;
     auto& localScanState = *localTableScanState;
     KU_ASSERT(localScanState.localRelTable);
     localScanState.boundNodeOffset = boundNodeOffset;
@@ -232,9 +231,9 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
     const auto reverseTableData =
         direction == RelDataDirection::FWD ? bwdRelTableData.get() : fwdRelTableData.get();
     std::vector<column_id_t> columnsToScan = {NBR_ID_COLUMN_ID, REL_ID_COLUMN_ID};
-    const auto relReadState = std::make_unique<RelTableScanState>(memoryManager, tableID,
-        columnsToScan, tableData->getColumns(), tableData->getCSROffsetColumn(),
-        tableData->getCSRLengthColumn(), direction);
+    const auto relReadState =
+        std::make_unique<RelTableScanState>(tableID, columnsToScan, tableData->getColumns(),
+            tableData->getCSROffsetColumn(), tableData->getCSRLengthColumn(), direction);
     relReadState->nodeIDVector = &deleteState->srcNodeIDVector;
     relReadState->outputVectors =
         std::vector<ValueVector*>{&deleteState->dstNodeIDVector, &deleteState->relIDVector};
@@ -244,8 +243,8 @@ void RelTable::detachDelete(Transaction* transaction, RelDataDirection direction
             LocalStorage::NotExistAction::RETURN_NULL)) {
         auto localTableColumnIDs =
             LocalRelTable::rewriteLocalColumnIDs(direction, relReadState->columnIDs);
-        relReadState->localTableScanState = std::make_unique<LocalRelTableScanState>(memoryManager,
-            *relReadState, localTableColumnIDs, localRelTable->ptrCast<LocalRelTable>());
+        relReadState->localTableScanState = std::make_unique<LocalRelTableScanState>(*relReadState,
+            localTableColumnIDs, localRelTable->ptrCast<LocalRelTable>());
         relReadState->localTableScanState->rowIdxVector->state = relReadState->rowIdxVector->state;
     }
     initScanState(transaction, *relReadState);

--- a/src/storage/store/rel_table_data.cpp
+++ b/src/storage/store/rel_table_data.cpp
@@ -122,8 +122,8 @@ std::pair<CSRNodeGroupScanSource, row_idx_t> RelTableData::findMatchingRow(Trans
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector<column_id_t> columnIDs = {REL_ID_COLUMN_ID, ROW_IDX_COLUMN_ID};
     std::vector<Column*> columns{getColumn(REL_ID_COLUMN_ID), nullptr};
-    const auto scanState = std::make_unique<RelTableScanState>(*memoryManager, tableID, columnIDs,
-        columns, csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);
+    const auto scanState = std::make_unique<RelTableScanState>(tableID, columnIDs, columns,
+        csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);
     scanState->nodeIDVector = &boundNodeIDVector;
     scanState->outputVectors.push_back(scanChunk.getValueVector(0).get());
     const auto scannedIDVector = scanState->outputVectors[0];
@@ -170,8 +170,8 @@ void RelTableData::checkIfNodeHasRels(Transaction* transaction,
     scanChunk.insert(0, std::make_shared<ValueVector>(LogicalType::INTERNAL_ID()));
     std::vector<column_id_t> columnIDs = {REL_ID_COLUMN_ID};
     std::vector<Column*> columns{getColumn(REL_ID_COLUMN_ID)};
-    const auto scanState = std::make_unique<RelTableScanState>(*memoryManager, tableID, columnIDs,
-        columns, csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);
+    const auto scanState = std::make_unique<RelTableScanState>(tableID, columnIDs, columns,
+        csrHeaderColumns.offset.get(), csrHeaderColumns.length.get(), direction);
     scanState->nodeIDVector = srcNodeIDVector;
     scanState->outputVectors.push_back(scanChunk.getValueVector(0).get());
     scanState->outState = scanState->outputVectors[0]->state.get();


### PR DESCRIPTION
# Description

Improved scan from local rel tables by skipping unnecessary allocation of CSR header chunks inside `CSRNodeGroupScanState`.

Did a simple benchmark by looping over each line in ldbc1 knows csv file with 180623 rows, and for each row, perform `match (a:person {id: rows[0]}) match (b:person {id: rows[1]} merge (a)-[e:knows]->(b);` in a single transaction.
The end-to-end execution time improves from 622s to 384s.