### PR TITLE
Fix re-opening databases after a copy failure

### DIFF
--- a/src/storage/buffer_manager/buffer_manager.cpp
+++ b/src/storage/buffer_manager/buffer_manager.cpp
@@ -115,7 +115,8 @@ uint8_t* BufferManager::pin(FileHandle& fileHandle, page_idx_t pageIdx,
             if (pageState->tryLock(currStateAndVersion)) {
                 if (!claimAFrame(fileHandle, pageIdx, pageReadPolicy)) {
                     pageState->resetToEvicted();
-                    throw BufferManagerException("Failed to claim a frame.");
+                    throw BufferManagerException("Unable to allocate memory! The buffer pool is "
+                                                 "full and no memory could be freed!");
                 }
                 if (!evictionQueue.insert(fileHandle.getFileIndex(), pageIdx)) {
                     throw BufferManagerException(

--- a/src/storage/store/node_group.cpp
+++ b/src/storage/store/node_group.cpp
@@ -1,8 +1,13 @@
 #include "storage/store/node_group.h"
 
+#include "common/types/types.h"
 #include "main/client_context.h"
 #include "storage/buffer_manager/memory_manager.h"
+#include "storage/enums/residency_state.h"
 #include "storage/storage_utils.h"
+#include "storage/store/chunked_node_group.h"
+#include "storage/store/column_chunk.h"
+#include "storage/store/csr_chunked_node_group.h"
 #include "storage/store/csr_node_group.h"
 #include "storage/store/node_table.h"
 #include "transaction/transaction.h"
@@ -401,19 +406,27 @@ std::unique_ptr<NodeGroup> NodeGroup::deserialize(MemoryManager& memoryManager,
     deSer.deserializeValue<NodeGroupDataFormat>(format);
     deSer.validateDebuggingInfo(key, "has_checkpointed_data");
     deSer.deserializeValue<bool>(hasCheckpointedData);
-    if (!hasCheckpointedData) {
-        return nullptr;
-    }
     deSer.validateDebuggingInfo(key, "checkpointed_data");
     std::unique_ptr<ChunkedNodeGroup> chunkedNodeGroup;
     switch (format) {
     case NodeGroupDataFormat::REGULAR: {
-        chunkedNodeGroup = ChunkedNodeGroup::deserialize(memoryManager, deSer);
+        if (hasCheckpointedData) {
+            chunkedNodeGroup = ChunkedNodeGroup::deserialize(memoryManager, deSer);
+        } else {
+            chunkedNodeGroup =
+                std::make_unique<ChunkedNodeGroup>(std::vector<std::unique_ptr<ColumnChunk>>(), 0);
+        }
         return std::make_unique<NodeGroup>(nodeGroupIdx, enableCompression,
             std::move(chunkedNodeGroup));
     }
     case NodeGroupDataFormat::CSR: {
-        chunkedNodeGroup = ChunkedCSRNodeGroup::deserialize(memoryManager, deSer);
+        if (hasCheckpointedData) {
+            chunkedNodeGroup = ChunkedCSRNodeGroup::deserialize(memoryManager, deSer);
+        } else {
+            std::vector<LogicalType> columnTypes;
+            chunkedNodeGroup = std::make_unique<ChunkedCSRNodeGroup>(memoryManager, columnTypes,
+                true, 0, 0, ResidencyState::IN_MEMORY);
+        }
         return std::make_unique<CSRNodeGroup>(nodeGroupIdx, enableCompression,
             std::move(chunkedNodeGroup));
     }

--- a/test/copy/CMakeLists.txt
+++ b/test/copy/CMakeLists.txt
@@ -1,1 +1,1 @@
-add_kuzu_test(copy_tests multi_copy_test.cpp)
+add_kuzu_test(copy_tests multi_copy_test.cpp copy_test.cpp)

--- a/test/copy/copy_test.cpp
+++ b/test/copy/copy_test.cpp
@@ -1,0 +1,99 @@
+#include "common/string_format.h"
+#include "graph_test/base_graph_test.h"
+#include "graph_test/graph_test.h"
+#include "main/database.h"
+
+namespace kuzu {
+namespace testing {
+
+// TODO: set buffer pool size
+class CopyTest : public BaseGraphTest {
+public:
+    void resetDB(uint64_t bufferPoolSize) {
+        systemConfig->bufferPoolSize = bufferPoolSize;
+        conn.reset();
+        database.reset();
+        createDBAndConn();
+    }
+    std::string getInputDir() override { KU_UNREACHABLE; }
+};
+
+TEST_F(CopyTest, OutOfMemoryRecovery) {
+    if (inMemMode) {
+        GTEST_SKIP();
+    }
+    // Needs to be small enough that we cannot successfully complete the rel table copy
+    resetDB(64 * 1024 * 1024);
+    conn->query("CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID))");
+    conn->query("CREATE REL TABLE follows(FROM account TO account);");
+    {
+        auto result = conn->query(common::stringFormat(
+            "COPY account FROM \"{}/dataset/snap/twitter/csv/twitter-nodes.csv\"",
+            KUZU_ROOT_DIRECTORY));
+        ASSERT_TRUE(result->isSuccess()) << result->toString();
+        result = conn->query(common::stringFormat(
+            "COPY follows FROM '{}/dataset/snap/twitter/csv/twitter-edges.csv' (DELIM=' ')",
+            KUZU_ROOT_DIRECTORY));
+        ASSERT_FALSE(result->isSuccess());
+        ASSERT_EQ(result->getErrorMessage(),
+            "Buffer manager exception: Unable to allocate memory! The buffer pool is full and no "
+            "memory could be freed!");
+    }
+    // Try opening then closing the database
+    resetDB(256 * 1024 * 1024);
+    // Try again with a larger buffer pool size
+    resetDB(256 * 1024 * 1024);
+    {
+        auto result = conn->query(common::stringFormat(
+            "COPY follows FROM '{}/dataset/snap/twitter/csv/twitter-edges.csv' (DELIM=' ')",
+            KUZU_ROOT_DIRECTORY));
+        ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+        // Test that the table copied as expected after the query
+        result = conn->query("MATCH (a:account)-[:follows]->(b:account) RETURN COUNT(*)");
+        ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+        ASSERT_TRUE(result->hasNext());
+        ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 2420766);
+    }
+}
+
+TEST_F(CopyTest, OutOfMemoryRecoveryDropTable) {
+    if (inMemMode) {
+        GTEST_SKIP();
+    }
+    // Needs to be small enough that we cannot successfully complete the rel table copy
+    resetDB(64 * 1024 * 1024);
+    conn->query("CREATE NODE TABLE account(ID INT64, PRIMARY KEY(ID))");
+    conn->query("CREATE REL TABLE follows(FROM account TO account);");
+    {
+        auto result = conn->query(common::stringFormat(
+            "COPY account FROM \"{}/dataset/snap/twitter/csv/twitter-nodes.csv\"",
+            KUZU_ROOT_DIRECTORY));
+        ASSERT_TRUE(result->isSuccess()) << result->toString();
+        result = conn->query(common::stringFormat(
+            "COPY follows FROM '{}/dataset/snap/twitter/csv/twitter-edges.csv' (DELIM=' ')",
+            KUZU_ROOT_DIRECTORY));
+        ASSERT_FALSE(result->isSuccess());
+        ASSERT_EQ(result->getErrorMessage(),
+            "Buffer manager exception: Unable to allocate memory! The buffer pool is full and no "
+            "memory could be freed!");
+    }
+    // Try dropping the table before trying again with a larger buffer pool size
+    resetDB(256 * 1024 * 1024);
+    {
+        auto result = conn->query("DROP TABLE follows;");
+        ASSERT_TRUE(result->isSuccess()) << result->toString();
+        result = conn->query("CREATE REL TABLE follows(FROM account TO account);");
+        ASSERT_TRUE(result->isSuccess()) << result->toString();
+        result = conn->query(common::stringFormat(
+            "COPY follows FROM '{}/dataset/snap/twitter/csv/twitter-edges.csv' (DELIM=' ')",
+            KUZU_ROOT_DIRECTORY));
+        ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+        // Test that the table copied as expected after the query
+        result = conn->query("MATCH (a:account)-[:follows]->(b:account) RETURN COUNT(*)");
+        ASSERT_TRUE(result->isSuccess()) << result->getErrorMessage();
+        ASSERT_TRUE(result->hasNext());
+        ASSERT_EQ(result->getNext()->getValue(0)->getValue<int64_t>(), 2420766);
+    }
+}
+} // namespace testing
+} // namespace kuzu


### PR DESCRIPTION
I'm not sure if there will be consequences to leaving the ChunkedNodeGroup empty and without any type information, but its more robust than leaving a null pointer at the top level.