### PR TITLE
Add more explicit comparisons when checking test result output

### DIFF
--- a/test/include/test_runner/test_runner.h
+++ b/test/include/test_runner/test_runner.h
@@ -15,11 +15,11 @@ public:
         main::Connection& conn);
 
 private:
-    static bool testStatement(TestStatement* statement, main::Connection& conn,
+    static void testStatement(TestStatement* statement, main::Connection& conn,
         std::string& databasePath);
-    static bool checkLogicalPlans(std::unique_ptr<main::PreparedStatement>& preparedStatement,
+    static void checkLogicalPlans(std::unique_ptr<main::PreparedStatement>& preparedStatement,
         TestStatement* statement, size_t resultIdx, main::Connection& conn);
-    static bool checkLogicalPlan(std::unique_ptr<main::PreparedStatement>& preparedStatement,
+    static void checkLogicalPlan(std::unique_ptr<main::PreparedStatement>& preparedStatement,
         TestStatement* statement, size_t resultIdx, main::Connection& conn, uint32_t planIdx);
     static bool checkResultNumeric(main::QueryResult& resultTuples, TestStatement* statement,
         size_t resultIdx);
@@ -28,7 +28,7 @@ private:
     static std::string convertResultToMD5Hash(main::QueryResult& queryResult, bool checkOutputOrder,
         bool checkColumnNames); // returns hash and number of values hashed
     static std::string convertResultColumnsToString(main::QueryResult& queryResult);
-    static bool checkPlanResult(std::unique_ptr<main::QueryResult>& result,
+    static void checkPlanResult(std::unique_ptr<main::QueryResult>& result,
         TestStatement* statement, size_t resultIdx, const std::string& planStr, uint32_t planIdx);
 };
 

--- a/test/test_files/dml_node/merge/merge_tinysnb.test
+++ b/test/test_files/dml_node/merge/merge_tinysnb.test
@@ -195,7 +195,7 @@ h
 -STATEMENT CREATE NODE TABLE person1 (id int64, primary key(id))
 ---- ok
 -STATEMENT UNWIND [11,20,20,11,32,41,32] as x merge (a:person {ID: x}), (b:person1 {id: x}) on match set b.id = x + 20, a.ID = x+100;
----- error
+---- ok
 -STATEMENT MATCH (p:person) RETURN p.ID;
 ---- 17
 0

--- a/test/test_files/transaction/create_node/merge_tinysnb_checkpoint.test
+++ b/test/test_files/transaction/create_node/merge_tinysnb_checkpoint.test
@@ -178,7 +178,7 @@ h
 -STATEMENT CREATE NODE TABLE person1 (id int64, primary key(id))
 ---- ok
 -STATEMENT UNWIND [11,20,20,11,32,41,32] as x merge (a:person {ID: x}), (b:person1 {id: x}) on match set b.id = x + 20, a.ID = x+100;
----- error
+---- ok
 -STATEMENT MATCH (p:person) RETURN p.ID;
 ---- 17
 0


### PR DESCRIPTION
Generally what this changes is that instead of just displaying the actual results when they differ from the expected results, it also does a tuple-by-tuple comparison so that it's more clear from the test output alone what the issue is.

If there is a different number of result tuples from what's expected I have it comparing the vectors directly with `ASSERT_EQ`, which shows both in their entirely in the case of an error, but admittedly without any newlines between the results, so I'm not sure it's really ideal. Maybe a better option would be to do a text diff of the results.

I also fixed a minor bug in the test runner which led to expected errors with empty results allowing a result of no error, since the error message field stores an empty string when there is no error (only affected two tests, which were erroneously marked as having an error result).