### PR TITLE
Remove RJOutputType

### DIFF
--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -550,31 +550,27 @@ struct AllSPPathsEdgeCompute : public EdgeCompute {
 class AllSPDestinationsAlgorithm final : public RJAlgorithm {
 public:
     AllSPDestinationsAlgorithm() = default;
-    AllSPDestinationsAlgorithm(const AllSPDestinationsAlgorithm& other)
-        : RJAlgorithm{other} {}
+    AllSPDestinationsAlgorithm(const AllSPDestinationsAlgorithm& other) : RJAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder *) const override {
-        return getNodeIDResultColumns();
-    }
+    expression_vector getResultColumns(Binder*) const override { return getNodeIDResultColumns(); }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
         return std::make_unique<AllSPDestinationsAlgorithm>(*this);
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto output = std::make_unique<AllSPMultiplicitiesOutputs>(
             sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
             clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<AllSPOutputWriterDsts>(clientContext,
-            output.get());
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
-            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto outputWriter = std::make_unique<AllSPOutputWriterDsts>(clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
+            clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<AllSPLengthsEdgeCompute>(frontierPair.get(),
             output->multiplicities.get());
-        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
-            std::move(output), std::move(outputWriter));
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
+            std::move(outputWriter));
     }
 };
 
@@ -583,7 +579,7 @@ public:
     AllSPLengthsAlgorithm() = default;
     AllSPLengthsAlgorithm(const AllSPLengthsAlgorithm& other) : RJAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder *binder) const override {
+    expression_vector getResultColumns(Binder* binder) const override {
         auto columns = getNodeIDResultColumns();
         columns.push_back(getLengthColumn(binder));
         return columns;
@@ -594,19 +590,18 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto output = std::make_unique<AllSPMultiplicitiesOutputs>(
             sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
             clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<AllSPOutputWriterLengths>(
-            clientContext, output.get());
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
-            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto outputWriter = std::make_unique<AllSPOutputWriterLengths>(clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
+            clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<AllSPLengthsEdgeCompute>(frontierPair.get(),
             output->multiplicities.get());
-        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
-            std::move(output), std::move(outputWriter));
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
+            std::move(outputWriter));
     }
 };
 
@@ -615,7 +610,7 @@ public:
     AllSPPathsAlgorithm() = default;
     AllSPPathsAlgorithm(const AllSPPathsAlgorithm& other) : RJAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder *binder) const override {
+    expression_vector getResultColumns(Binder* binder) const override {
         auto columns = getNodeIDResultColumns();
         columns.push_back(getLengthColumn(binder));
         columns.push_back(getPathNodeIDsColumn(binder));
@@ -627,19 +622,19 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto output = std::make_unique<VarLenOrAllSPPathsOutputs>(
             sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
             clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<AllSPOutputWriterPaths>(clientContext,
-            output.get(), bindData->ptrCast<RJBindData>()->upperBound);
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
-            output->pathLengths, clientContext->getMaxNumThreadForExec());
-        auto edgeCompute = std::make_unique<AllSPPathsEdgeCompute>(frontierPair.get(),
-            output->parentPtrs.get());
-        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
-            std::move(output), std::move(outputWriter));
+        auto outputWriter = std::make_unique<AllSPOutputWriterPaths>(clientContext, output.get(),
+            bindData->ptrCast<RJBindData>()->upperBound);
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
+            clientContext->getMaxNumThreadForExec());
+        auto edgeCompute =
+            std::make_unique<AllSPPathsEdgeCompute>(frontierPair.get(), output->parentPtrs.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
+            std::move(outputWriter));
     }
 };
 
@@ -680,7 +675,7 @@ public:
     explicit VarLenJoinsAlgorithm() : RJAlgorithm(RJInputType::HAS_LOWER_BOUND) {}
     VarLenJoinsAlgorithm(const VarLenJoinsAlgorithm& other) : RJAlgorithm(other) {}
 
-    binder::expression_vector getResultColumns(binder::Binder *binder) const override {
+    binder::expression_vector getResultColumns(binder::Binder* binder) const override {
         auto columns = getNodeIDResultColumns();
         columns.push_back(getLengthColumn(binder));
         columns.push_back(getPathNodeIDsColumn(binder));
@@ -696,19 +691,17 @@ private:
         auto clientContext = context->clientContext;
         auto mm = clientContext->getMemoryManager();
         auto nodeTableToNumNodes = sharedState->graph->getNodeTableIDAndNumNodes();
-        auto output = std::make_unique<VarLenOrAllSPPathsOutputs>(
-            nodeTableToNumNodes, sourceNodeID, mm);
+        auto output =
+            std::make_unique<VarLenOrAllSPPathsOutputs>(nodeTableToNumNodes, sourceNodeID, mm);
         auto rjBindData = bindData->ptrCast<RJBindData>();
-        auto outputWriter =
-            std::make_unique<VarLenOutputWriterPaths>(clientContext,
-                output.get(), rjBindData->lowerBound, rjBindData->upperBound);
-        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(
-            nodeTableToNumNodes, clientContext->getMaxNumThreadForExec(), mm);
+        auto outputWriter = std::make_unique<VarLenOutputWriterPaths>(clientContext, output.get(),
+            rjBindData->lowerBound, rjBindData->upperBound);
+        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(nodeTableToNumNodes,
+            clientContext->getMaxNumThreadForExec(), mm);
         auto edgeCompute =
-            std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(),
-                output->parentPtrs.get());
-        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
-            std::move(output), std::move(outputWriter));
+            std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(), output->parentPtrs.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
+            std::move(outputWriter));
     }
 };
 
@@ -720,22 +713,21 @@ function_set VarLenJoinsFunction::getFunctionSet() {
 
 function_set AllSPDestinationsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<AllSPDestinationsAlgorithm>()));
+    result.push_back(
+        std::make_unique<GDSFunction>(name, std::make_unique<AllSPDestinationsAlgorithm>()));
     return result;
 }
 
 function_set AllSPLengthsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<AllSPLengthsAlgorithm>()));
+    result.push_back(
+        std::make_unique<GDSFunction>(name, std::make_unique<AllSPLengthsAlgorithm>()));
     return result;
 }
 
 function_set AllSPPathsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(
-        std::make_unique<GDSFunction>(name, std::make_unique<AllSPPathsAlgorithm>()));
+    result.push_back(std::make_unique<GDSFunction>(name, std::make_unique<AllSPPathsAlgorithm>()));
     return result;
 }
 

--- a/src/function/gds/all_shortest_paths.cpp
+++ b/src/function/gds/all_shortest_paths.cpp
@@ -1,4 +1,3 @@
-#include "common/exception/runtime.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
@@ -547,73 +546,100 @@ struct AllSPPathsEdgeCompute : public EdgeCompute {
  * is returned for each destination. If paths are not returned, multiplicities indicate the number
  * of paths to each destination.
  */
-class AllSPAlgorithm final : public RJAlgorithm {
 
+class AllSPDestinationsAlgorithm final : public RJAlgorithm {
 public:
-    explicit AllSPAlgorithm(RJOutputType outputType) : RJAlgorithm(outputType){};
+    AllSPDestinationsAlgorithm() = default;
+    AllSPDestinationsAlgorithm(const AllSPDestinationsAlgorithm& other)
+        : RJAlgorithm{other} {}
 
-    AllSPAlgorithm(const AllSPAlgorithm& other) : RJAlgorithm(other) {}
-
-    RJCompState getRJCompState(processor::ExecutionContext* executionContext,
-        common::nodeID_t sourceNodeID) override {
-        std::unique_ptr<SPOutputs> spOutputs;
-        std::unique_ptr<RJOutputWriter> outputWriter;
-        switch (outputType) {
-        case RJOutputType::DESTINATION_NODES:
-            spOutputs = std::make_unique<AllSPMultiplicitiesOutputs>(
-                sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
-                executionContext->clientContext->getMemoryManager());
-            outputWriter = std::make_unique<AllSPOutputWriterDsts>(executionContext->clientContext,
-                spOutputs.get());
-            break;
-        case RJOutputType::LENGTHS: {
-            spOutputs = std::make_unique<AllSPMultiplicitiesOutputs>(
-                sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
-                executionContext->clientContext->getMemoryManager());
-            outputWriter = std::make_unique<AllSPOutputWriterLengths>(
-                executionContext->clientContext, spOutputs.get());
-            break;
-        }
-        case RJOutputType::PATHS: {
-            spOutputs = std::make_unique<VarLenOrAllSPPathsOutputs>(
-                sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
-                executionContext->clientContext->getMemoryManager());
-            outputWriter = std::make_unique<AllSPOutputWriterPaths>(executionContext->clientContext,
-                spOutputs.get(), bindData->ptrCast<RJBindData>()->upperBound);
-            break;
-        }
-        default:
-            throw RuntimeException(
-                "Unrecognized RJOutputType in "
-                "AllSPAlgorithm::getRJCompState() setting output and outputWriter: " +
-                std::to_string(static_cast<uint8_t>(outputType)) + ".");
-        }
-        auto pathLengthsFrontiers = std::make_unique<SinglePathLengthsFrontierPair>(
-            spOutputs->pathLengths, executionContext->clientContext->getMaxNumThreadForExec());
-        std::unique_ptr<EdgeCompute> edgeCompute;
-        switch (outputType) {
-        case RJOutputType::DESTINATION_NODES:
-        case RJOutputType::LENGTHS: {
-            edgeCompute = std::make_unique<AllSPLengthsEdgeCompute>(pathLengthsFrontiers.get(),
-                spOutputs->ptrCast<AllSPMultiplicitiesOutputs>()->multiplicities.get());
-            break;
-        }
-        case RJOutputType::PATHS: {
-            edgeCompute = std::make_unique<AllSPPathsEdgeCompute>(pathLengthsFrontiers.get(),
-                spOutputs->ptrCast<VarLenOrAllSPPathsOutputs>()->parentPtrs.get());
-            break;
-        }
-        default:
-            throw RuntimeException("Unrecognized RJOutputType in "
-                                   "AllSPAlgorithm::getRJCompState() setting edgeCompute: " +
-                                   std::to_string(static_cast<uint8_t>(outputType)) + ".");
-        }
-        return RJCompState(std::move(pathLengthsFrontiers), std::move(edgeCompute),
-            std::move(spOutputs), std::move(outputWriter));
+    expression_vector getResultColumns(Binder *) const override {
+        return getNodeIDResultColumns();
     }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
-        return std::make_unique<AllSPAlgorithm>(*this);
+        return std::make_unique<AllSPDestinationsAlgorithm>(*this);
+    }
+
+private:
+    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+        auto clientContext = context->clientContext;
+        auto output = std::make_unique<AllSPMultiplicitiesOutputs>(
+            sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
+            clientContext->getMemoryManager());
+        auto outputWriter = std::make_unique<AllSPOutputWriterDsts>(clientContext,
+            output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
+            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto edgeCompute = std::make_unique<AllSPLengthsEdgeCompute>(frontierPair.get(),
+            output->multiplicities.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
+            std::move(output), std::move(outputWriter));
+    }
+};
+
+class AllSPLengthsAlgorithm final : public RJAlgorithm {
+public:
+    AllSPLengthsAlgorithm() = default;
+    AllSPLengthsAlgorithm(const AllSPLengthsAlgorithm& other) : RJAlgorithm{other} {}
+
+    expression_vector getResultColumns(Binder *binder) const override {
+        auto columns = getNodeIDResultColumns();
+        columns.push_back(getLengthColumn(binder));
+        return columns;
+    }
+
+    std::unique_ptr<GDSAlgorithm> copy() const override {
+        return std::make_unique<AllSPLengthsAlgorithm>(*this);
+    }
+
+private:
+    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+        auto clientContext = context->clientContext;
+        auto output = std::make_unique<AllSPMultiplicitiesOutputs>(
+            sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
+            clientContext->getMemoryManager());
+        auto outputWriter = std::make_unique<AllSPOutputWriterLengths>(
+            clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
+            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto edgeCompute = std::make_unique<AllSPLengthsEdgeCompute>(frontierPair.get(),
+            output->multiplicities.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
+            std::move(output), std::move(outputWriter));
+    }
+};
+
+class AllSPPathsAlgorithm final : public RJAlgorithm {
+public:
+    AllSPPathsAlgorithm() = default;
+    AllSPPathsAlgorithm(const AllSPPathsAlgorithm& other) : RJAlgorithm{other} {}
+
+    expression_vector getResultColumns(Binder *binder) const override {
+        auto columns = getNodeIDResultColumns();
+        columns.push_back(getLengthColumn(binder));
+        columns.push_back(getPathNodeIDsColumn(binder));
+        return columns;
+    }
+
+    std::unique_ptr<GDSAlgorithm> copy() const override {
+        return std::make_unique<AllSPPathsAlgorithm>(*this);
+    }
+
+private:
+    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+        auto clientContext = context->clientContext;
+        auto output = std::make_unique<VarLenOrAllSPPathsOutputs>(
+            sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
+            clientContext->getMemoryManager());
+        auto outputWriter = std::make_unique<AllSPOutputWriterPaths>(clientContext,
+            output.get(), bindData->ptrCast<RJBindData>()->upperBound);
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
+            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto edgeCompute = std::make_unique<AllSPPathsEdgeCompute>(frontierPair.get(),
+            output->parentPtrs.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
+            std::move(output), std::move(outputWriter));
     }
 };
 
@@ -621,7 +647,8 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
     DoublePathLengthsFrontierPair* doublePathLengthsFrontiers;
     ParentPtrsAtomics* parentPtrs;
     ParentPtrsBlock* parentPtrsBlock;
-    explicit VarLenJoinsEdgeCompute(DoublePathLengthsFrontierPair* doublePathLengthsFrontiers,
+
+    VarLenJoinsEdgeCompute(DoublePathLengthsFrontierPair* doublePathLengthsFrontiers,
         ParentPtrsAtomics* parentPtrs)
         : doublePathLengthsFrontiers{doublePathLengthsFrontiers}, parentPtrs{parentPtrs} {
         parentPtrsBlock = parentPtrs->addNewBlock();
@@ -649,34 +676,39 @@ struct VarLenJoinsEdgeCompute : public EdgeCompute {
  * of paths to each destination.
  */
 class VarLenJoinsAlgorithm final : public RJAlgorithm {
-
 public:
-    explicit VarLenJoinsAlgorithm()
-        : RJAlgorithm(RJOutputType::PATHS, RJInputType::HAS_LOWER_BOUND) {}
+    explicit VarLenJoinsAlgorithm() : RJAlgorithm(RJInputType::HAS_LOWER_BOUND) {}
     VarLenJoinsAlgorithm(const VarLenJoinsAlgorithm& other) : RJAlgorithm(other) {}
 
-    RJCompState getRJCompState(processor::ExecutionContext* executionContext,
-        common::nodeID_t sourceNodeID) override {
-        std::unique_ptr<RJOutputs> spOutputs = std::make_unique<VarLenOrAllSPPathsOutputs>(
-            sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
-            executionContext->clientContext->getMemoryManager());
-        std::unique_ptr<RJOutputWriter> outputWriter =
-            std::make_unique<VarLenOutputWriterPaths>(executionContext->clientContext,
-                spOutputs.get(), bindData->ptrCast<RJBindData>()->lowerBound,
-                bindData->ptrCast<RJBindData>()->upperBound);
-        auto doublePathLengthsFrontiers = std::make_unique<DoublePathLengthsFrontierPair>(
-            sharedState->graph->getNodeTableIDAndNumNodes(),
-            executionContext->clientContext->getMaxNumThreadForExec(),
-            executionContext->clientContext->getMemoryManager());
-        auto edgeCompute =
-            std::make_unique<VarLenJoinsEdgeCompute>(doublePathLengthsFrontiers.get(),
-                spOutputs->ptrCast<VarLenOrAllSPPathsOutputs>()->parentPtrs.get());
-        return RJCompState(std::move(doublePathLengthsFrontiers), std::move(edgeCompute),
-            std::move(spOutputs), std::move(outputWriter));
+    binder::expression_vector getResultColumns(binder::Binder *binder) const override {
+        auto columns = getNodeIDResultColumns();
+        columns.push_back(getLengthColumn(binder));
+        columns.push_back(getPathNodeIDsColumn(binder));
+        return columns;
     }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
         return std::make_unique<VarLenJoinsAlgorithm>(*this);
+    }
+
+private:
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
+        auto clientContext = context->clientContext;
+        auto mm = clientContext->getMemoryManager();
+        auto nodeTableToNumNodes = sharedState->graph->getNodeTableIDAndNumNodes();
+        auto output = std::make_unique<VarLenOrAllSPPathsOutputs>(
+            nodeTableToNumNodes, sourceNodeID, mm);
+        auto rjBindData = bindData->ptrCast<RJBindData>();
+        auto outputWriter =
+            std::make_unique<VarLenOutputWriterPaths>(clientContext,
+                output.get(), rjBindData->lowerBound, rjBindData->upperBound);
+        auto frontierPair = std::make_unique<DoublePathLengthsFrontierPair>(
+            nodeTableToNumNodes, clientContext->getMaxNumThreadForExec(), mm);
+        auto edgeCompute =
+            std::make_unique<VarLenJoinsEdgeCompute>(frontierPair.get(),
+                output->parentPtrs.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute),
+            std::move(output), std::move(outputWriter));
     }
 };
 
@@ -689,21 +721,21 @@ function_set VarLenJoinsFunction::getFunctionSet() {
 function_set AllSPDestinationsFunction::getFunctionSet() {
     function_set result;
     result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<AllSPAlgorithm>(RJOutputType::DESTINATION_NODES)));
+        std::make_unique<AllSPDestinationsAlgorithm>()));
     return result;
 }
 
 function_set AllSPLengthsFunction::getFunctionSet() {
     function_set result;
     result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<AllSPAlgorithm>(RJOutputType::LENGTHS)));
+        std::make_unique<AllSPLengthsAlgorithm>()));
     return result;
 }
 
 function_set AllSPPathsFunction::getFunctionSet() {
     function_set result;
     result.push_back(
-        std::make_unique<GDSFunction>(name, std::make_unique<AllSPAlgorithm>(RJOutputType::PATHS)));
+        std::make_unique<GDSFunction>(name, std::make_unique<AllSPPathsAlgorithm>()));
     return result;
 }
 

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -76,20 +76,21 @@ void RJAlgorithm::bind(const binder::expression_vector& params, binder::Binder* 
         std::make_unique<RJBindData>(nodeInput, nodeOutput, outputProperty, lowerBound, upperBound);
 }
 
-binder::expression_vector RJAlgorithm::getResultColumns(Binder* binder) const {
-    binder::expression_vector columns;
+expression_vector RJAlgorithm::getNodeIDResultColumns() const {
+    expression_vector columns;
     auto& inputNode = bindData->getNodeInput()->constCast<NodeExpression>();
     columns.push_back(inputNode.getInternalID());
     auto& outputNode = bindData->getNodeOutput()->constCast<NodeExpression>();
     columns.push_back(outputNode.getInternalID());
-    if (RJOutputType::LENGTHS == outputType || RJOutputType::PATHS == outputType) {
-        columns.push_back(binder->createVariable(LENGTH_COLUMN_NAME, LogicalType::INT64()));
-        if (RJOutputType::PATHS == outputType) {
-            columns.push_back(binder->createVariable(PATH_NODE_IDS_COLUMN_NAME,
-                LogicalType::LIST(LogicalType::INTERNAL_ID())));
-        }
-    }
     return columns;
+}
+
+std::shared_ptr<binder::Expression> RJAlgorithm::getLengthColumn(Binder* binder) const {
+    return binder->createVariable(LENGTH_COLUMN_NAME, LogicalType::INT64());
+}
+
+std::shared_ptr<binder::Expression> RJAlgorithm::getPathNodeIDsColumn(Binder* binder) const {
+    return binder->createVariable(PATH_NODE_IDS_COLUMN_NAME, LogicalType::LIST(LogicalType::INTERNAL_ID()));
 }
 
 class RJOutputWriterVCSharedState {

--- a/src/function/gds/rec_joins.cpp
+++ b/src/function/gds/rec_joins.cpp
@@ -90,7 +90,8 @@ std::shared_ptr<binder::Expression> RJAlgorithm::getLengthColumn(Binder* binder)
 }
 
 std::shared_ptr<binder::Expression> RJAlgorithm::getPathNodeIDsColumn(Binder* binder) const {
-    return binder->createVariable(PATH_NODE_IDS_COLUMN_NAME, LogicalType::LIST(LogicalType::INTERNAL_ID()));
+    return binder->createVariable(PATH_NODE_IDS_COLUMN_NAME,
+        LogicalType::LIST(LogicalType::INTERNAL_ID()));
 }
 
 class RJOutputWriterVCSharedState {

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -29,9 +29,7 @@ public:
         buffer.insert({tableID, mm->allocateBuffer(false, numNodes * elementSize)});
     }
 
-    bool contains(common::table_id_t tableID) {
-        return buffer.contains(tableID);
-    }
+    bool contains(common::table_id_t tableID) { return buffer.contains(tableID); }
 
     std::atomic<uint64_t>* getData(common::table_id_t tableID) {
         KU_ASSERT(contains(tableID));
@@ -233,35 +231,33 @@ public:
     SingleSPDestinationsAlgorithm(const SingleSPDestinationsAlgorithm& other)
         : RJAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder *) const override {
-        return getNodeIDResultColumns();
-    }
+    expression_vector getResultColumns(Binder*) const override { return getNodeIDResultColumns(); }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
         return std::make_unique<SingleSPDestinationsAlgorithm>(*this);
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto output = std::make_unique<SingleSPOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
-            sourceNodeID, clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<SPOutputWriterDsts>(clientContext,
-            output.get());
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
-            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto output =
+            std::make_unique<SingleSPOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
+                sourceNodeID, clientContext->getMemoryManager());
+        auto outputWriter = std::make_unique<SPOutputWriterDsts>(clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
+            clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<SingleSPLengthsEdgeCompute>(frontierPair.get());
-        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output), std::move(outputWriter));
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
+            std::move(outputWriter));
     }
 };
 
 class SingleSPLengthsAlgorithm : public RJAlgorithm {
 public:
     SingleSPLengthsAlgorithm() = default;
-    SingleSPLengthsAlgorithm(const SingleSPLengthsAlgorithm& other)
-        : RJAlgorithm{other} {}
+    SingleSPLengthsAlgorithm(const SingleSPLengthsAlgorithm& other) : RJAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder *binder) const override {
+    expression_vector getResultColumns(Binder* binder) const override {
         auto columns = getNodeIDResultColumns();
         columns.push_back(getLengthColumn(binder));
         return columns;
@@ -272,19 +268,19 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
         auto output =
             std::make_unique<SingleSPOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
                 sourceNodeID, clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<SingleSPOutputWriterLengths>(
-            clientContext, output.get());
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
-            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto outputWriter =
+            std::make_unique<SingleSPOutputWriterLengths>(clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
+            clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<SingleSPLengthsEdgeCompute>(frontierPair.get());
-        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output), std::move(outputWriter));
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
+            std::move(outputWriter));
     }
-
 };
 
 class SingleSPPathsAlgorithm : public RJAlgorithm {
@@ -292,7 +288,7 @@ public:
     SingleSPPathsAlgorithm() = default;
     SingleSPPathsAlgorithm(const SingleSPPathsAlgorithm& other) : RJAlgorithm{other} {}
 
-    expression_vector getResultColumns(Binder *binder) const override {
+    expression_vector getResultColumns(Binder* binder) const override {
         auto columns = getNodeIDResultColumns();
         columns.push_back(getLengthColumn(binder));
         columns.push_back(getPathNodeIDsColumn(binder));
@@ -304,40 +300,40 @@ public:
     }
 
 private:
-    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+    RJCompState getRJCompState(ExecutionContext* context, nodeID_t sourceNodeID) override {
         auto clientContext = context->clientContext;
-        auto output = std::make_unique<SingleSPOutputsPaths>(
-            sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
-            clientContext->getMemoryManager());
-        auto outputWriter = std::make_unique<SingleSPOutputWriterPaths>(
-            clientContext, output.get());
-        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
-            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto output =
+            std::make_unique<SingleSPOutputsPaths>(sharedState->graph->getNodeTableIDAndNumNodes(),
+                sourceNodeID, clientContext->getMemoryManager());
+        auto outputWriter =
+            std::make_unique<SingleSPOutputWriterPaths>(clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(output->pathLengths,
+            clientContext->getMaxNumThreadForExec());
         auto edgeCompute = std::make_unique<SingleSPPathsEdgeCompute>(frontierPair.get(),
             output->singlePaths.get());
-        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output), std::move(outputWriter));
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output),
+            std::move(outputWriter));
     }
-
 };
 
 function_set SingleSPDestinationsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<SingleSPDestinationsAlgorithm>()));
+    result.push_back(
+        std::make_unique<GDSFunction>(name, std::make_unique<SingleSPDestinationsAlgorithm>()));
     return result;
 }
 
 function_set SingleSPLengthsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<SingleSPLengthsAlgorithm>()));
+    result.push_back(
+        std::make_unique<GDSFunction>(name, std::make_unique<SingleSPLengthsAlgorithm>()));
     return result;
 }
 
 function_set SingleSPPathsFunction::getFunctionSet() {
     function_set result;
-    result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<SingleSPPathsAlgorithm>()));
+    result.push_back(
+        std::make_unique<GDSFunction>(name, std::make_unique<SingleSPPathsAlgorithm>()));
     return result;
 }
 

--- a/src/function/gds/single_shortest_paths.cpp
+++ b/src/function/gds/single_shortest_paths.cpp
@@ -1,4 +1,3 @@
-#include "common/exception/runtime.h"
 #include "function/gds/gds_frontier.h"
 #include "function/gds/gds_function_collection.h"
 #include "function/gds/rec_joins.h"
@@ -16,25 +15,46 @@ using namespace kuzu::graph;
 namespace kuzu {
 namespace function {
 
+// TODO(Xiyang): Merge this class with ParentPtrsAtomics & PathMultiplicities
+class ParentEdges {
+public:
+    ParentEdges() = default;
+
+    void allocate(common::table_id_t tableID, common::offset_t numNodes, MemoryManager* mm) {
+        // Note: We should be storing common::nodeID_t atomically but that is not possible
+        // because common::nodeID_t consists of 2 primitive values, an offset and a tableID.
+        // Therefore, we store two atomic<uint64_t> values per nodeID. First is the node offset
+        // and the second is the tableID.
+        auto elementSize = 2 * sizeof(std::atomic<uint64_t>);
+        buffer.insert({tableID, mm->allocateBuffer(false, numNodes * elementSize)});
+    }
+
+    bool contains(common::table_id_t tableID) {
+        return buffer.contains(tableID);
+    }
+
+    std::atomic<uint64_t>* getData(common::table_id_t tableID) {
+        KU_ASSERT(contains(tableID));
+        return reinterpret_cast<std::atomic<uint64_t>*>(buffer.at(tableID)->buffer.data());
+    }
+
+private:
+    common::table_id_map_t<std::unique_ptr<MemoryBuffer>> buffer;
+};
+
 class SinglePaths {
 public:
     explicit SinglePaths(std::unordered_map<common::table_id_t, uint64_t> nodeTableIDAndNumNodes,
         MemoryManager* mm) {
         for (const auto& [tableID, numNodes] : nodeTableIDAndNumNodes) {
-            // Note: We should be storing common::nodeID_t atomically but that is not possible
-            // because common::nodeID_t consists of 2 primitive values, an offset and a tableID.
-            // Therefore we store two atomic<uint64_t> values per nodeID. First is the node offset
-            // and the second is the tableID.
-            parentEdges.insert({tableID,
-                mm->allocateBuffer(false, numNodes * (2 * sizeof(std::atomic<uint64_t>)))});
+            parentEdges.allocate(tableID, numNodes, mm);
         }
     }
 
     common::nodeID_t getParent(common::nodeID_t nodeID) {
         auto offsetPos = nodeID.offset << 1;
         auto tableIDPos = offsetPos + 1;
-        auto bufPtr = reinterpret_cast<std::atomic<uint64_t>*>(
-            parentEdges.at(nodeID.tableID).get()->buffer.data());
+        auto bufPtr = parentEdges.getData(nodeID.tableID);
         return common::nodeID_t(bufPtr[offsetPos].load(std::memory_order_relaxed),
             bufPtr[tableIDPos].load(std::memory_order_relaxed));
     }
@@ -60,15 +80,13 @@ public:
         bufPtr[tableIDPos].store(parentEdge.tableID, std::memory_order_relaxed);
     }
 
-    void fixNodeTable(common::table_id_t tableID) {
+    void pinNodeTable(common::table_id_t tableID) {
         KU_ASSERT(parentEdges.contains(tableID));
-        currentFixedParentEdges.store(
-            reinterpret_cast<std::atomic<uint64_t>*>(parentEdges.at(tableID).get()->buffer.data()),
-            std::memory_order_relaxed);
+        currentFixedParentEdges.store(parentEdges.getData(tableID), std::memory_order_relaxed);
     }
 
 private:
-    common::table_id_map_t<std::unique_ptr<MemoryBuffer>> parentEdges;
+    ParentEdges parentEdges;
     std::atomic<std::atomic<uint64_t>*> currentFixedParentEdges;
 };
 
@@ -97,12 +115,12 @@ struct SingleSPOutputsPaths : public SPOutputs {
     }
 
     void beginFrontierComputeBetweenTables(table_id_t, table_id_t nextFrontierTableID) override {
-        singlePaths->fixNodeTable(nextFrontierTableID);
+        singlePaths->pinNodeTable(nextFrontierTableID);
     };
 
     void beginWritingOutputsForDstNodesInTable(table_id_t tableID) override {
         pathLengths->fixCurFrontierNodeTable(tableID);
-        singlePaths->fixNodeTable(tableID);
+        singlePaths->pinNodeTable(tableID);
     }
 };
 
@@ -181,7 +199,8 @@ struct SingleSPLengthsEdgeCompute : public EdgeCompute {
 
 struct SingleSPPathsEdgeCompute : public SingleSPLengthsEdgeCompute {
     SinglePaths* singlePaths;
-    explicit SingleSPPathsEdgeCompute(SinglePathLengthsFrontierPair* pathLengthsFrontiers,
+
+    SingleSPPathsEdgeCompute(SinglePathLengthsFrontierPair* pathLengthsFrontiers,
         SinglePaths* singlePaths)
         : SingleSPLengthsEdgeCompute(pathLengthsFrontiers), singlePaths{singlePaths} {};
 
@@ -207,93 +226,118 @@ struct SingleSPPathsEdgeCompute : public SingleSPLengthsEdgeCompute {
  * multiplicities of each destination is ignored (e.g., if there are 3 paths to a destination d,
  * d is returned only once).
  */
-class SingleSPAlgorithm final : public RJAlgorithm {
 
+class SingleSPDestinationsAlgorithm : public RJAlgorithm {
 public:
-    explicit SingleSPAlgorithm(RJOutputType outputType) : RJAlgorithm(outputType){};
-    SingleSPAlgorithm(const SingleSPAlgorithm& other) : RJAlgorithm(other) {}
+    SingleSPDestinationsAlgorithm() = default;
+    SingleSPDestinationsAlgorithm(const SingleSPDestinationsAlgorithm& other)
+        : RJAlgorithm{other} {}
+
+    expression_vector getResultColumns(Binder *) const override {
+        return getNodeIDResultColumns();
+    }
 
     std::unique_ptr<GDSAlgorithm> copy() const override {
-        return std::make_unique<SingleSPAlgorithm>(*this);
+        return std::make_unique<SingleSPDestinationsAlgorithm>(*this);
     }
 
-protected:
-    RJCompState getRJCompState(processor::ExecutionContext* executionContext,
-        common::nodeID_t sourceNodeID) override {
-        std::unique_ptr<SPOutputs> spOutputs;
-        std::unique_ptr<RJOutputWriter> outputWriter;
-        switch (outputType) {
-        case RJOutputType::DESTINATION_NODES:
-            spOutputs =
-                std::make_unique<SingleSPOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
-                    sourceNodeID, executionContext->clientContext->getMemoryManager());
-            outputWriter = std::make_unique<SPOutputWriterDsts>(executionContext->clientContext,
-                spOutputs.get());
-            break;
-        case RJOutputType::LENGTHS: {
-            spOutputs =
-                std::make_unique<SingleSPOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
-                    sourceNodeID, executionContext->clientContext->getMemoryManager());
-            outputWriter = std::make_unique<SingleSPOutputWriterLengths>(
-                executionContext->clientContext, spOutputs.get());
-            break;
-        }
-        case RJOutputType::PATHS: {
-            spOutputs = std::make_unique<SingleSPOutputsPaths>(
-                sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
-                executionContext->clientContext->getMemoryManager());
-            outputWriter = std::make_unique<SingleSPOutputWriterPaths>(
-                executionContext->clientContext, spOutputs.get());
-            break;
-        }
-        default:
-            throw RuntimeException(
-                "Unrecognized RJOutputType in "
-                "SingleSPAlgorithm::getRJCompState() setting output and outputWriter: " +
-                std::to_string(static_cast<uint8_t>(outputType)) + ".");
-        }
-        auto pathLengthsFrontiers = std::make_unique<SinglePathLengthsFrontierPair>(
-            spOutputs->pathLengths, executionContext->clientContext->getMaxNumThreadForExec());
-        std::unique_ptr<EdgeCompute> edgeCompute;
-        switch (outputType) {
-        case RJOutputType::DESTINATION_NODES:
-        case RJOutputType::LENGTHS: {
-            edgeCompute = std::make_unique<SingleSPLengthsEdgeCompute>(pathLengthsFrontiers.get());
-            break;
-        }
-        case RJOutputType::PATHS: {
-            edgeCompute = std::make_unique<SingleSPPathsEdgeCompute>(pathLengthsFrontiers.get(),
-                spOutputs->ptrCast<SingleSPOutputsPaths>()->singlePaths.get());
-            break;
-        }
-        default:
-            throw RuntimeException("Unrecognized RJOutputType in "
-                                   "SingleSPAlgorithm::getRJCompState(): " +
-                                   std::to_string(static_cast<uint8_t>(outputType)) + ".");
-        }
-        return RJCompState(std::move(pathLengthsFrontiers), std::move(edgeCompute),
-            std::move(spOutputs), std::move(outputWriter));
+private:
+    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+        auto clientContext = context->clientContext;
+        auto output = std::make_unique<SingleSPOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
+            sourceNodeID, clientContext->getMemoryManager());
+        auto outputWriter = std::make_unique<SPOutputWriterDsts>(clientContext,
+            output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
+            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto edgeCompute = std::make_unique<SingleSPLengthsEdgeCompute>(frontierPair.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output), std::move(outputWriter));
     }
+};
+
+class SingleSPLengthsAlgorithm : public RJAlgorithm {
+public:
+    SingleSPLengthsAlgorithm() = default;
+    SingleSPLengthsAlgorithm(const SingleSPLengthsAlgorithm& other)
+        : RJAlgorithm{other} {}
+
+    expression_vector getResultColumns(Binder *binder) const override {
+        auto columns = getNodeIDResultColumns();
+        columns.push_back(getLengthColumn(binder));
+        return columns;
+    }
+
+    std::unique_ptr<GDSAlgorithm> copy() const override {
+        return std::make_unique<SingleSPLengthsAlgorithm>(*this);
+    }
+
+private:
+    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+        auto clientContext = context->clientContext;
+        auto output =
+            std::make_unique<SingleSPOutputs>(sharedState->graph->getNodeTableIDAndNumNodes(),
+                sourceNodeID, clientContext->getMemoryManager());
+        auto outputWriter = std::make_unique<SingleSPOutputWriterLengths>(
+            clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
+            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto edgeCompute = std::make_unique<SingleSPLengthsEdgeCompute>(frontierPair.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output), std::move(outputWriter));
+    }
+
+};
+
+class SingleSPPathsAlgorithm : public RJAlgorithm {
+public:
+    SingleSPPathsAlgorithm() = default;
+    SingleSPPathsAlgorithm(const SingleSPPathsAlgorithm& other) : RJAlgorithm{other} {}
+
+    expression_vector getResultColumns(Binder *binder) const override {
+        auto columns = getNodeIDResultColumns();
+        columns.push_back(getLengthColumn(binder));
+        columns.push_back(getPathNodeIDsColumn(binder));
+        return columns;
+    }
+
+    std::unique_ptr<GDSAlgorithm> copy() const override {
+        return std::make_unique<SingleSPPathsAlgorithm>(*this);
+    }
+
+private:
+    RJCompState getRJCompState(ExecutionContext *context, nodeID_t sourceNodeID) override {
+        auto clientContext = context->clientContext;
+        auto output = std::make_unique<SingleSPOutputsPaths>(
+            sharedState->graph->getNodeTableIDAndNumNodes(), sourceNodeID,
+            clientContext->getMemoryManager());
+        auto outputWriter = std::make_unique<SingleSPOutputWriterPaths>(
+            clientContext, output.get());
+        auto frontierPair = std::make_unique<SinglePathLengthsFrontierPair>(
+            output->pathLengths, clientContext->getMaxNumThreadForExec());
+        auto edgeCompute = std::make_unique<SingleSPPathsEdgeCompute>(frontierPair.get(),
+            output->singlePaths.get());
+        return RJCompState(std::move(frontierPair), std::move(edgeCompute), std::move(output), std::move(outputWriter));
+    }
+
 };
 
 function_set SingleSPDestinationsFunction::getFunctionSet() {
     function_set result;
     result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<SingleSPAlgorithm>(RJOutputType::DESTINATION_NODES)));
+        std::make_unique<SingleSPDestinationsAlgorithm>()));
     return result;
 }
 
 function_set SingleSPLengthsFunction::getFunctionSet() {
     function_set result;
     result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<SingleSPAlgorithm>(RJOutputType::LENGTHS)));
+        std::make_unique<SingleSPLengthsAlgorithm>()));
     return result;
 }
 
 function_set SingleSPPathsFunction::getFunctionSet() {
     function_set result;
     result.push_back(std::make_unique<GDSFunction>(name,
-        std::make_unique<SingleSPAlgorithm>(RJOutputType::PATHS)));
+        std::make_unique<SingleSPPathsAlgorithm>()));
     return result;
 }
 

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -195,13 +195,6 @@ struct RJBindData final : public function::GDSBindData {
     }
 };
 
-enum class RJOutputType : uint8_t {
-    DESTINATION_NODES = 0,
-    LENGTHS = 1,
-    // PATHS returns only the intermediate nodeIDs in a path, not the source or dst nodeIDs.
-    PATHS = 2,
-};
-
 enum class RJInputType : uint8_t {
     HAS_LOWER_BOUND = 0,
     NO_LOWER_BOUND = 1,
@@ -333,15 +326,15 @@ protected:
 };
 
 class RJAlgorithm : public GDSAlgorithm {
+protected:
     static constexpr char LENGTH_COLUMN_NAME[] = "length";
     static constexpr char PATH_NODE_IDS_COLUMN_NAME[] = "pathNodeIDs";
 
 public:
-    explicit RJAlgorithm(RJOutputType outputType,
-        RJInputType inputType = RJInputType::NO_LOWER_BOUND)
-        : outputType{outputType}, inputType{inputType} {};
+    explicit RJAlgorithm(RJInputType inputType = RJInputType::NO_LOWER_BOUND)
+        : inputType{inputType} {};
     RJAlgorithm(const RJAlgorithm& other)
-        : GDSAlgorithm{other}, outputType{other.outputType}, inputType{other.inputType} {}
+        : GDSAlgorithm{other},inputType{other.inputType} {}
     /*
      * Inputs include the following:
      *
@@ -362,8 +355,6 @@ public:
         }
     }
 
-    binder::expression_vector getResultColumns(binder::Binder* binder) const override;
-
     void bind(const binder::expression_vector& params, binder::Binder* binder,
         graph::GraphEntry& graphEntry) override;
 
@@ -372,7 +363,11 @@ public:
         nodeID_t sourceNodeID) = 0;
 
 protected:
-    RJOutputType outputType;
+    binder::expression_vector getNodeIDResultColumns() const;
+    std::shared_ptr<binder::Expression> getLengthColumn(binder::Binder* binder) const;
+    std::shared_ptr<binder::Expression> getPathNodeIDsColumn(binder::Binder* binder) const;
+
+protected:
     RJInputType inputType;
 };
 } // namespace function

--- a/src/include/function/gds/rec_joins.h
+++ b/src/include/function/gds/rec_joins.h
@@ -333,8 +333,7 @@ protected:
 public:
     explicit RJAlgorithm(RJInputType inputType = RJInputType::NO_LOWER_BOUND)
         : inputType{inputType} {};
-    RJAlgorithm(const RJAlgorithm& other)
-        : GDSAlgorithm{other},inputType{other.inputType} {}
+    RJAlgorithm(const RJAlgorithm& other) : GDSAlgorithm{other}, inputType{other.inputType} {}
     /*
      * Inputs include the following:
      *


### PR DESCRIPTION
# Description

This PR removes `RJOutputType` by having a more fine-grained inheritance for SingleShortestPath and AllShortestPath.

Fixes # (issue)

# Contributor agreement

- [x] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).