### PR TITLE
Refactor Validate Property Name

### DIFF
--- a/src/binder/bind/bind_ddl.cpp
+++ b/src/binder/bind/bind_ddl.cpp
@@ -31,12 +31,16 @@ using namespace kuzu::catalog;
 namespace kuzu {
 namespace binder {
 
-static void validateUniquePropertyName(const std::vector<PropertyDefinition>& definitions) {
+void Binder::validatePropertyName(const std::vector<PropertyDefinition>& definitions) {
     common::case_insensitve_set_t nameSet;
     for (auto& definition : definitions) {
         if (nameSet.contains(definition.getName())) {
             throw BinderException(stringFormat(
                 "Duplicated column name: {}, column name must be unique.", definition.getName()));
+        }
+        if (reservedInColumnName(definition.getName())) {
+            throw BinderException(
+                stringFormat("{} is a reserved property name.", definition.getName()));
         }
         nameSet.insert(definition.getName());
     }
@@ -65,13 +69,7 @@ std::vector<PropertyDefinition> Binder::bindPropertyDefinitions(
         auto columnDefinition = ColumnDefinition(parsedDefinition.getName(), std::move(type));
         definitions.emplace_back(std::move(columnDefinition), std::move(expr));
     }
-    validateUniquePropertyName(definitions);
-    for (auto& definition : definitions) {
-        if (reservedInColumnName(definition.getName())) {
-            throw BinderException(
-                stringFormat("{} is a reserved property name.", definition.getName()));
-        }
-    }
+    validatePropertyName(definitions);
     return definitions;
 }
 

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -121,6 +121,8 @@ public:
         const std::vector<parser::ParsedPropertyDefinition>& parsedDefinitions,
         const std::string& tableName);
 
+    static void validatePropertyName(const std::vector<PropertyDefinition>& definitions);
+    
     /*** bind copy ***/
     std::unique_ptr<BoundStatement> bindCopyFromClause(const parser::Statement& statement);
     std::unique_ptr<BoundStatement> bindCopyNodeFrom(const parser::Statement& statement,

--- a/src/include/binder/binder.h
+++ b/src/include/binder/binder.h
@@ -122,7 +122,7 @@ public:
         const std::string& tableName);
 
     static void validatePropertyName(const std::vector<PropertyDefinition>& definitions);
-    
+
     /*** bind copy ***/
     std::unique_ptr<BoundStatement> bindCopyFromClause(const parser::Statement& statement);
     std::unique_ptr<BoundStatement> bindCopyNodeFrom(const parser::Statement& statement,


### PR DESCRIPTION
# Description

Was looking through `bind_ddl.cpp`, noticed that the checks for unique and reserved can probably both go into the same function/for loop. Just a suggestion :)

# Contributor agreement

- [ ] I have read and agree to the [Contributor Agreement](https://github.com/kuzudb/kuzu/blob/master/CLA.md).